### PR TITLE
Add CylindricalEndcap map.

### DIFF
--- a/docs/Images/Domain/CoordinateMaps/CylindricalEndcap.svg
+++ b/docs/Images/Domain/CoordinateMaps/CylindricalEndcap.svg
@@ -1,0 +1,301 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="127.26459mm"
+   height="160.11301mm"
+   viewBox="0 0 127.26459 160.11301"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="CylindricalEndcap.svg">
+  <defs
+     id="defs2">
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Lend"
+       style="overflow:visible;"
+       inkscape:isstock="true">
+      <path
+         id="path4686"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) rotate(180) translate(12.5,0)" />
+    </marker>
+    <linearGradient
+       id="linearGradient6115"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop6113" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4526"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4524" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.93338095"
+     inkscape:cx="211.35181"
+     inkscape:cy="287.53122"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:window-width="1267"
+     inkscape:window-height="913"
+     inkscape:window-x="95"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3713"
+       originx="-5.1593686"
+       originy="-136.3005" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-5.1593686,-0.58648957)">
+    <circle
+       id="path3717"
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26458332;stroke-opacity:1"
+       cy="85.333336"
+       cx="52.916668"
+       r="37.041668" />
+    <circle
+       id="path3717-3"
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26458332;stroke-opacity:1"
+       cy="74.75"
+       cx="68.791664"
+       r="63.500004" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 79.775883,0.58648957 c 0,153.45834043 0,153.45834043 0,153.45834043"
+       id="path6030"
+       inkscape:connector-curvature="0" />
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6040"
+       cx="47.625"
+       cy="64.166664"
+       rx="1.1926295"
+       ry="1.1425189" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.66500002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.665, 1.33;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 79.47522,59.376106 47.624999,64.166667"
+       id="path6042"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 79.575441,59.376106 128.20265,51.899621"
+       id="path6044"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.66500002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.665, 1.995;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 47.304293,64.086488 78.974116,110.58902"
+       id="path6046"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 79.375,110.58901 15.073232,21.96844"
+       id="path6048"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6040-6"
+       cx="52.916668"
+       cy="85.333336"
+       rx="1.2427398"
+       ry="1.1926293" />
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6040-7"
+       cx="68.791664"
+       cy="74.75"
+       rx="1.0924084"
+       ry="1.1425189" />
+    <path
+       style="fill:#969696;fill-opacity:1;stroke:#000000;stroke-width:1.54204726;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 330.20722,459.84881 -27.62827,-40.337 4.77565,-5.43916 c 14.439,-16.44511 26.01836,-40.16867 30.70342,-62.90452 2.82815,-13.72457 3.25714,-40.63286 0.85866,-53.85964 -3.871,-21.3473 -14.1331,-44.09123 -27.97825,-62.00833 -4.73338,-6.12551 -10.66338,-10.9541 -10.4,-11.19318 0.26339,-0.23907 43.21095,-6.56797 92.66126,-13.60124 l 89.90964,-12.78777 1.48983,3.90519 c 17.2719,45.27368 18.16422,106.25515 2.26499,154.7912 -5.13982,15.69047 -17.05815,41.24815 -24.94936,53.50142 -14.8589,23.07252 -38.27408,48.22626 -60.02923,64.48638 -10.49872,7.8469 -38.70633,24.50037 -45.25929,26.84528 -1.63403,0.58473 -6.55511,-12.39748 -26.41905,-41.39863 z"
+       id="path6071"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="scsssscscsssscs"
+       transform="scale(0.26458333)" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;"
+       x="41.892361"
+       y="62.482944"
+       id="text6177"><tspan
+         sodipodi:role="line"
+         id="tspan6175"
+         x="41.892361"
+         y="62.482944"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr;text-anchor:start;stroke-width:0.26458332;">P</tspan><tspan
+         sodipodi:role="line"
+         x="41.892361"
+         y="69.097527"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr;text-anchor:start;stroke-width:0.26458332;"
+         id="tspan6179" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;"
+       x="70.257866"
+       y="73.250671"
+       id="text6153-9"><tspan
+         sodipodi:role="line"
+         id="tspan6151-2"
+         x="70.257866"
+         y="73.250671"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr;text-anchor:start;stroke-width:0.26458332;">C</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="75.586967"
+       y="68.771202"
+       id="text6157-5"><tspan
+         sodipodi:role="line"
+         x="75.586967"
+         y="68.771202"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="tspan6163-4">i</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="80.622108"
+       y="155.39073"
+       id="text6223"><tspan
+         sodipodi:role="line"
+         id="tspan6221"
+         x="80.622108"
+         y="155.39073"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">z</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="84.343307"
+       y="157.29788"
+       id="text6227"><tspan
+         sodipodi:role="line"
+         id="tspan6225"
+         x="84.343307"
+         y="157.29788"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">P</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="48.907825"
+       y="89.843269"
+       id="text6243"><tspan
+         sodipodi:role="line"
+         id="tspan6241"
+         x="48.907825"
+         y="89.843269"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">1</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="75.265945"
+       y="75.010567"
+       id="text6247"><tspan
+         sodipodi:role="line"
+         id="tspan6245"
+         x="75.265945"
+         y="75.010567"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">2</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="45.620899"
+       y="58.749088"
+       id="text6157-5-0"><tspan
+         sodipodi:role="line"
+         x="45.620899"
+         y="58.749088"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="tspan6163-4-5">i</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="44.581596"
+       y="87.80143"
+       id="text6153-9-9"><tspan
+         sodipodi:role="line"
+         id="tspan6151-2-2"
+         x="44.581596"
+         y="87.80143"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">C</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="49.266769"
+       y="83.566628"
+       id="text6157-5-5"><tspan
+         sodipodi:role="line"
+         x="49.266769"
+         y="83.566628"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="tspan6163-4-4">i</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;marker-end:url(#Arrow1Lend)"
+       d="M 92.467412,146.24264 H 121.94805"
+       id="path3876"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="113.76174"
+       y="144.2939"
+       id="text6223-7"><tspan
+         sodipodi:role="line"
+         id="tspan6221-0"
+         x="113.76174"
+         y="144.2939"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">z</tspan></text>
+  </g>
+</svg>

--- a/docs/Images/Domain/CoordinateMaps/CylindricalEndcap_Allowed.svg
+++ b/docs/Images/Domain/CoordinateMaps/CylindricalEndcap_Allowed.svg
@@ -1,0 +1,341 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="365.3898mm"
+   height="169.59834mm"
+   viewBox="0 0 365.3898 169.59834"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="CylindricalEndcap_Allowed.svg">
+  <defs
+     id="defs2">
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Mstart"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4588"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6362"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6360"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Mstart"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4606"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(0.6)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lstart"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path4582"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.8,0,0,0.8,10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.49497475"
+     inkscape:cx="343.31422"
+     inkscape:cy="152.77746"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:snap-global="true"
+     inkscape:snap-text-baseline="true"
+     inkscape:window-width="1385"
+     inkscape:window-height="773"
+     inkscape:window-x="535"
+     inkscape:window-y="132"
+     inkscape:window-maximized="0"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3713"
+       originx="0.132501"
+       originy="-58.075763" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0.13250054,-69.325819)">
+    <circle
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.40799999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path3715"
+       cy="154.125"
+       cx="95.25"
+       r="52.916668" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 111.125,93.270831 V 214.97917"
+       id="path4522"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4524"
+       sodipodi:type="arc"
+       sodipodi:cx="95.25"
+       sodipodi:cy="154.125"
+       sodipodi:rx="1.0583333"
+       sodipodi:ry="1.0583333"
+       sodipodi:start="0"
+       sodipodi:end="6.26554"
+       d="m 96.308333,154.125 a 1.0583333,1.0583333 0 0 1 -1.053664,1.05832 1.0583333,1.0583333 0 0 1 -1.062961,-1.04898 1.0583333,1.0583333 0 0 1 1.044286,-1.06758 1.0583333,1.0583333 0 0 1 1.072175,1.03957 L 95.25,154.125 Z" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.26499999, 0.52999997;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 111.125,103.85417 95.25,154.125 l 15.875,50.27083"
+       id="path4528"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.26458332, 0.79374995;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow1Lstart)"
+       d="m 206.37501,154.125 h 52.91666"
+       id="path4530"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.52916663, 0.52916663;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 10.583333,69.458333 259.29167,154.125 10.583333,238.79167"
+       id="path4532"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:0.52999997, 0.52999997;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4534"
+       sodipodi:type="arc"
+       sodipodi:cx="10.583333"
+       sodipodi:cy="154.125"
+       sodipodi:rx="10.583333"
+       sodipodi:ry="84.666664"
+       sodipodi:start="0"
+       sodipodi:end="6.2788558"
+       d="M 21.166666,154.125 A 10.583333,84.666664 0 0 1 10.594788,238.79161 10.583333,84.666664 0 0 1 2.4797576e-5,154.30828 10.583333,84.666664 0 0 1 10.548968,69.458782 10.583333,84.666664 0 0 1 21.166567,153.75844"
+       sodipodi:open="true" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79374995, 0.79374995;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 359.83333,122.375 -100.54166,31.75 100.54166,31.75"
+       id="path4536"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26458332;stroke-miterlimit:4;stroke-dasharray:0.79374994, 0.79374994;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4538"
+       sodipodi:type="arc"
+       sodipodi:cx="359.83334"
+       sodipodi:cy="154.125"
+       sodipodi:rx="5.2916665"
+       sodipodi:ry="31.75"
+       sodipodi:start="0"
+       sodipodi:end="6.2788569"
+       sodipodi:open="true"
+       d="m 365.12501,154.125 a 5.2916665,31.75 0 0 1 -5.28594,31.74998 5.2916665,31.75 0 0 1 -5.29738,-31.68127 5.2916665,31.75 0 0 1 5.27448,-31.81854 5.2916665,31.75 0 0 1 5.30879,31.6124" />
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4524-0"
+       sodipodi:type="arc"
+       sodipodi:cx="259.29166"
+       sodipodi:cy="154.125"
+       sodipodi:rx="1.0583333"
+       sodipodi:ry="1.0583333"
+       sodipodi:start="0"
+       sodipodi:end="6.26554"
+       d="m 260.34999,154.125 a 1.0583333,1.0583333 0 0 1 -1.05366,1.05832 1.0583333,1.0583333 0 0 1 -1.06297,-1.04898 1.0583333,1.0583333 0 0 1 1.04429,-1.06758 1.0583333,1.0583333 0 0 1 1.07218,1.03957 l -1.05817,0.0187 z" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 109.80208,107.82292 5.48066,2.26785 1.60639,-4.2679"
+       id="path4563"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 109.63602,199.26744 5.46051,-2.00174 1.69418,5.15247"
+       id="path4565"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.26458332, 0.79374996;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker6362)"
+       d="M 95.250007,154.125 H 132.29167"
+       id="path4530-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:0.795, 0.795;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow2Mstart)"
+       id="path5412"
+       sodipodi:type="arc"
+       sodipodi:cx="252.3839"
+       sodipodi:cy="157.3031"
+       sodipodi:rx="22.489584"
+       sodipodi:ry="22.489584"
+       sodipodi:start="3.3511363"
+       sodipodi:end="3.6585709"
+       d="m 230.38625,152.62496 a 22.489584,22.489584 0 0 1 2.44708,-6.43746"
+       sodipodi:open="true" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:0.79499999, 0.79499999;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow1Mstart)"
+       id="path6428"
+       sodipodi:type="arc"
+       sodipodi:cx="95.25"
+       sodipodi:cy="154.125"
+       sodipodi:rx="10.583339"
+       sodipodi:ry="10.583339"
+       sodipodi:start="5.1628641"
+       sodipodi:end="6.1468576"
+       d="m 99.857915,144.59745 a 10.583339,10.583339 0 0 1 5.877225,8.08921"
+       sodipodi:open="true" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="105.83334"
+       y="148.83333"
+       id="text6536"><tspan
+         sodipodi:role="line"
+         id="tspan6534"
+         x="105.83334"
+         y="148.83333"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">θ</tspan></text>
+    <flowRoot
+       xml:space="preserve"
+       id="flowRoot6538"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       transform="scale(0.26458333)"><flowRegion
+         id="flowRegion6540"><rect
+           id="rect6542"
+           width="110"
+           height="120"
+           x="1540"
+           y="342.51968" /></flowRegion><flowPara
+         id="flowPara6544" /></flowRoot>    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="216.95833"
+       y="151.47917"
+       id="text6548"><tspan
+         sodipodi:role="line"
+         id="tspan6546"
+         x="216.95833"
+         y="151.47917"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">π-θ</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="87.3125"
+       y="159.41667"
+       id="text6552"><tspan
+         sodipodi:role="line"
+         id="tspan6550"
+         x="87.3125"
+         y="159.41667"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">C</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.29166651px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="92.604164"
+       y="162.0625"
+       id="text6560"><tspan
+         sodipodi:role="line"
+         id="tspan6558"
+         x="92.604164"
+         y="162.0625"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.29166651px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">1</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="113.77084"
+       y="217.625"
+       id="text6564"><tspan
+         sodipodi:role="line"
+         id="tspan6562"
+         x="113.77084"
+         y="217.625"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">Z</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.29166651px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="119.0625"
+       y="220.27083"
+       id="text6568"><tspan
+         sodipodi:role="line"
+         id="tspan6566"
+         x="119.0625"
+         y="220.27083"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.29166651px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">P</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="256.64584"
+       y="164.70833"
+       id="text6572"><tspan
+         sodipodi:role="line"
+         id="tspan6570"
+         x="256.64584"
+         y="164.70833"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">S</tspan></text>
+  </g>
+</svg>

--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   Affine.cpp
   BulgedCube.cpp
+  CylindricalEndcap.cpp
   DiscreteRotation.cpp
   EquatorialCompression.cpp
   Equiangular.cpp
@@ -30,6 +31,7 @@ spectre_target_headers(
   CoordinateMap.hpp
   CoordinateMap.tpp
   CoordinateMapHelpers.hpp
+  CylindricalEndcap.hpp
   DiscreteRotation.hpp
   EquatorialCompression.hpp
   Equiangular.hpp
@@ -55,6 +57,8 @@ target_link_libraries(
   DomainStructure
   ErrorHandling
   FunctionsOfTime
+  GSL::gsl
+  RootFinding
   )
 
 add_subdirectory(TimeDependent)

--- a/src/Domain/CoordinateMaps/CylindricalEndcap.cpp
+++ b/src/Domain/CoordinateMaps/CylindricalEndcap.cpp
@@ -1,0 +1,902 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/CylindricalEndcap.hpp"
+
+#include <boost/none.hpp>
+#include <cmath>
+#include <gsl/gsl_poly.h>
+#include <limits>
+#include <pup.h>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/RootFinding/QuadraticEquation.hpp"
+#include "Parallel/PupStlCpp11.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace domain::CoordinateMaps {
+
+namespace CylindricalEndcap_detail {
+
+// Maps a unit disk to the z>z_plane portion of a sphere
+// with a given center and radius.
+// The source coordinates are Cartesian xbar,ybar,zbar.
+// This is a 2D map, but has the interface of a 3D map.
+// The map is independent of zbar=source_coords[2], and
+// the 3 coordinates returned by operator() obey a constraint
+// (namely that they lie on a 2-sphere).
+class InnerSphereMap {
+ public:
+  InnerSphereMap(const std::array<double, 3>& center, double radius,
+                 double z_plane) noexcept;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
+      const std::array<T, 3>& source_coords) const noexcept;
+  boost::optional<std::array<double, 3>> inverse(
+      const std::array<double, 3>& target_coords) const noexcept;
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> jacobian(
+      const std::array<T, 3>& source_coords) const noexcept;
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> inv_jacobian(
+      const std::array<T, 3>& source_coords) const noexcept;
+
+ private:
+  // Compute sin(ax)/x.
+  // For small x, use sin(ax)/x = a(1 - a^2 x^2 / 6 + ...) to evaluate.
+  // x is considered small if the first-ignored term in the series is roundoff.
+  static double sin_ax_over_x(double x, double ax, double a) noexcept;
+  static double sin_ax_over_x(double x, double a) noexcept {
+    return sin_ax_over_x(x, a * x, a);
+  }
+  static DataVector sin_ax_over_x(const DataVector& x, double a) noexcept;
+
+  // Compute 1/x d/dx [sin(ax)/x].
+  // For small x, use sin(ax)/x = a(1 - a^2 x^2 / 6 + a^4 x^4 / 5! ...).
+  // x is considered small if the first-ignored term in the series is roundoff.
+  static double dlogx_sin_ax_over_x(double x, double ax, double a) noexcept;
+  static double dlogx_sin_ax_over_x(double x, double a) noexcept {
+    return dlogx_sin_ax_over_x(x, a * x, a);
+  }
+  static DataVector dlogx_sin_ax_over_x(const DataVector& x, double a) noexcept;
+
+  const std::array<double, 3> center_;
+  const double radius_;
+  const double theta_;
+};
+
+InnerSphereMap::InnerSphereMap(const std::array<double, 3>& center,
+                               double radius, double z_plane) noexcept
+    : center_(center),
+      radius_([&]() noexcept {
+        // The equal_within_roundoff below has an implicit scale of 1,
+        // so the ASSERT may trigger in the case where we really
+        // want an entire domain that is very small.
+        ASSERT(not equal_within_roundoff(radius, 0.0),
+               "Cannot have zero radius");
+        return radius;
+      }()),
+      theta_(acos((z_plane - center_[2]) / radius_)) {
+  ASSERT(z_plane != center[2],
+         "Plane must intersect sphere at more than one point");
+}
+
+double InnerSphereMap::sin_ax_over_x(double x, double ax, double a) noexcept {
+  return square(ax) < 6.0 * std::numeric_limits<double>::epsilon()
+             ? a
+             : sin(ax) / x;
+}
+DataVector InnerSphereMap::sin_ax_over_x(const DataVector& x,
+                                         double a) noexcept {
+  DataVector result(x);
+  for (size_t i = 0; i < x.size(); ++i) {
+    result[i] = sin_ax_over_x(x[i], a * x[i], a);
+  }
+  return result;
+}
+
+double InnerSphereMap::dlogx_sin_ax_over_x(double x, double ax,
+                                           double a) noexcept {
+  return square(ax) < 10.0 * std::numeric_limits<double>::epsilon()
+             ? -cube(a) / 3.0
+             : (a * cos(ax) - sin(ax) / x) / square(x);
+}
+DataVector InnerSphereMap::dlogx_sin_ax_over_x(const DataVector& x,
+                                               double a) noexcept {
+  DataVector result(x);
+  for (size_t i = 0; i < x.size(); ++i) {
+    result[i] = dlogx_sin_ax_over_x(x[i], a * x[i], a);
+  }
+  return result;
+}
+
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, 3> InnerSphereMap::operator()(
+    const std::array<T, 3>& source_coords) const noexcept {
+  using return_type = tt::remove_cvref_wrap_t<T>;
+  const return_type& xbar = source_coords[0];
+  const return_type& ybar = source_coords[1];
+  const return_type rho = sqrt(square(xbar) + square(ybar));
+  const return_type sin_factor = radius_ * sin_ax_over_x(rho, theta_);
+  const return_type z = radius_ * cos(rho * theta_) + center_[2];
+  const return_type x = sin_factor * xbar + center_[0];
+  const return_type y = sin_factor * ybar + center_[1];
+  return std::array<return_type, 3>{{std::move(x), std::move(y), std::move(z)}};
+}
+
+boost::optional<std::array<double, 3>> InnerSphereMap::inverse(
+    const std::array<double, 3>& target_coords) const noexcept {
+  const double x = target_coords[0] - center_[0];
+  const double y = target_coords[1] - center_[1];
+  const double z = target_coords[2] - center_[2];
+  const double r = sqrt(square(x) + square(y) + square(z));
+  // The equal_within_roundoff below has an implicit scale of 1,
+  // so the inverse may fail if radius_ is very small on purpose,
+  // e.g. if we really want a tiny tiny domain for some reason.
+  if (not equal_within_roundoff(r, radius_)) {
+    return boost::none;
+  }
+
+  // Compute sin^2(rho theta).
+  const double sin_squared_rho_theta = (square(x) + square(y)) / square(r);
+  // Compute sin(rho theta)/rho.
+  // If sin^2(rho theta) is small,
+  // use arcsin(q) = q(1 + q^2/6 + 3 q^4/40 + ...)
+  // for q = sin(rho theta).
+  double sin_rho_theta_over_rho = 0.0;
+  if (square(sin_squared_rho_theta) <
+      (40.0 / 3.0) * std::numeric_limits<double>::epsilon()) {
+    sin_rho_theta_over_rho = theta_ * (1.0 - sin_squared_rho_theta / 6.0);
+  } else {
+    const double rho = asin(sqrt(sin_squared_rho_theta)) / theta_;
+    sin_rho_theta_over_rho = sqrt(sin_squared_rho_theta) / rho;
+  }
+
+  // Note about the division in the next line: The above check of r
+  // versus radius_ means that r cannot be zero unless the radius of
+  // the sphere (a map parameter) is chosen to be zero, which would
+  // make the map singular.  Also sin_rho_theta_over_rho cannot be
+  // zero unless theta_ (a map parameter) is chosen to be zero, which
+  // also would make the map singular.
+  const double xbar = x / (r * sin_rho_theta_over_rho);
+  const double ybar = y / (r * sin_rho_theta_over_rho);
+  const double rho_squared = square(xbar) + square(ybar);
+  if (rho_squared > 1.0 and not equal_within_roundoff(rho_squared, 1.0)) {
+    return boost::none;
+  }
+
+  return std::array<double, 3>{{xbar, ybar, -1.0}};
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
+InnerSphereMap::jacobian(const std::array<T, 3>& source_coords) const noexcept {
+  using return_type = tt::remove_cvref_wrap_t<T>;
+  const return_type& xbar = source_coords[0];
+  const return_type& ybar = source_coords[1];
+  const return_type rho = sqrt(square(xbar) + square(ybar));
+  const return_type sin_factor = radius_ * sin_ax_over_x(rho, theta_);
+  const return_type d_sin_factor = radius_ * dlogx_sin_ax_over_x(rho, theta_);
+
+  auto jacobian_matrix =
+      make_with_value<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>>(
+          dereference_wrapper(source_coords[0]), 0.0);
+
+  // dz/dxbar
+  get<2, 0>(jacobian_matrix) = -sin_factor * theta_ * xbar;
+  // dz/dybar
+  get<2, 1>(jacobian_matrix) = -sin_factor * theta_ * ybar;
+  // dx/dxbar
+  get<0, 0>(jacobian_matrix) = d_sin_factor * square(xbar) + sin_factor;
+  // dx/dybar
+  get<0, 1>(jacobian_matrix) = d_sin_factor * xbar * ybar;
+  // dy/dxbar
+  get<1, 0>(jacobian_matrix) = d_sin_factor * ybar * xbar;
+  // dy/dybar
+  get<1, 1>(jacobian_matrix) = d_sin_factor * square(ybar) + sin_factor;
+
+  return jacobian_matrix;
+}
+
+// This is really a 2-dimensional inverse jacobian because zbar = -1
+// and xbar,ybar depend only on y,z (given y,z we know x since
+// x,y,z must be on the sphere).
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
+InnerSphereMap::inv_jacobian(const std::array<T, 3>& source_coords) const
+    noexcept {
+  using return_type = tt::remove_cvref_wrap_t<T>;
+  const return_type& xbar = source_coords[0];
+  const return_type& ybar = source_coords[1];
+  const return_type rho = sqrt(square(xbar) + square(ybar));
+  // Let q = sin(rho theta)/rho
+  const return_type q = sin_ax_over_x(rho, theta_);
+  const return_type dlogrho_q = dlogx_sin_ax_over_x(rho, theta_);
+  const return_type one_over_r_q = 1.0 / (q * radius_);
+  const return_type tmp =
+      one_over_r_q * dlogrho_q / (q + square(rho) * dlogrho_q);
+
+  auto inv_jacobian_matrix =
+      make_with_value<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>>(
+          dereference_wrapper(source_coords[0]), 0.0);
+
+  // dxbar/dx
+  get<0, 0>(inv_jacobian_matrix) = one_over_r_q - square(xbar) * tmp;
+  // dxbar/dy
+  get<0, 1>(inv_jacobian_matrix) = -xbar * ybar * tmp;
+  // dybar/dx
+  get<1, 0>(inv_jacobian_matrix) = get<0, 1>(inv_jacobian_matrix);
+  // dybar/dy
+  get<1, 1>(inv_jacobian_matrix) = one_over_r_q - square(ybar) * tmp;
+
+  return inv_jacobian_matrix;
+}
+
+// Consider a sphere with center 'sphere_center' and radius 'radius',
+// and let 'proj_center' and 'src_point' be two arbitrary points.
+//
+// Consider the line passing through 'proj_center' and 'src_point'.
+// This ray intersects the sphere at either zero, one, or two points.
+// If there are zero such points, then 'scale_factor' is undefined.
+// If there is at least one intersection point, then
+// 'scale_factor' is a scalar defined by the relation
+// intersection_point - proj_center = scale_factor * (src_point - proj_center).
+// See below for what happens when there are two intersection points.
+//
+// More detail:
+//
+// Let x = 'src_point', p = 'proj_center', c = 'sphere_center',
+// and r = 'radius'.
+//
+// then if y = 'intersection_point' and lambda = 'scale_factor', then
+//  y = p + (x-p) \lambda
+//
+// To solve for 'scale_factor', we note that y is on the surface of
+// the sphere, so
+//   | y - c |^2 = r^2
+// or
+//   | p-c + (x-p)\lambda |^2 = r^2.
+//
+// This is a quadratic equation for \lambda in terms of x, p, c, and r.
+//
+// For the forward map, we want a positive root \lambda that is
+// greater than or equal to unity.  If there are two such roots (this
+// occurs if all of sphere_2 is closer to src_point than to
+// proj_center) we take the smaller one. The function scale_factor
+// returns the desired root, and ASSERTS if there are not two real
+// roots or if there is no positive root \lambda >= 1.
+//
+// For the inverse map, we provide a function called try_scale_factor
+// that has additional options as to which root to choose.
+// try_scale_factor returns boost::none if the roots are not as
+// expected (i.e. if the inverse map was called for a point not in the
+// range of the map).
+template <typename T>
+tt::remove_cvref_wrap_t<T> scale_factor(
+    const std::array<tt::remove_cvref_wrap_t<T>, 3>& src_point,
+    const std::array<double, 3>& proj_center,
+    const std::array<double, 3>& sphere_center, double radius) noexcept {
+  using return_type = tt::remove_cvref_wrap_t<T>;
+  // quadratic equation is
+  // a x^2 + b x + c = 0
+  const return_type a = square(src_point[0] - proj_center[0]) +
+                        square(src_point[1] - proj_center[1]) +
+                        square(src_point[2] - proj_center[2]);
+  const return_type b =
+      2.0 *
+      ((src_point[0] - proj_center[0]) * (proj_center[0] - sphere_center[0]) +
+       (src_point[1] - proj_center[1]) * (proj_center[1] - sphere_center[1]) +
+       (src_point[2] - proj_center[2]) * (proj_center[2] - sphere_center[2]));
+  const double c = square(sphere_center[0] - proj_center[0]) +
+                   square(sphere_center[1] - proj_center[1]) +
+                   square(sphere_center[2] - proj_center[2]) - square(radius);
+  return smallest_root_greater_than_value_within_roundoff(
+      a, b, make_with_value<return_type>(a, c), 1.0);
+}
+
+boost::optional<double> try_scale_factor(
+    const std::array<double, 3>& src_point,
+    const std::array<double, 3>& proj_center,
+    const std::array<double, 3>& sphere_center, double radius,
+    const bool pick_larger_root,
+    const bool pick_root_greater_than_one) noexcept {
+  // We solve the quadratic for (scale_factor-1) instead of scale_factor to
+  // avoid roundoff problems when scale_factor is very nearly equal to unity.
+  // Note that scale_factor==1 will occur when src_point is on the sphere, which
+  // happens when inverse-mapping the boundaries.
+
+  // quadratic equation is
+  // a x^2 + b x + c = 0
+  const double a = square(src_point[0] - proj_center[0]) +
+                   square(src_point[1] - proj_center[1]) +
+                   square(src_point[2] - proj_center[2]);
+  const double b =
+      2.0 *
+      ((src_point[0] - proj_center[0]) * (src_point[0] - sphere_center[0]) +
+       (src_point[1] - proj_center[1]) * (src_point[1] - sphere_center[1]) +
+       (src_point[2] - proj_center[2]) * (src_point[2] - sphere_center[2]));
+  const double c = square(sphere_center[0] - src_point[0]) +
+                   square(sphere_center[1] - src_point[1]) +
+                   square(sphere_center[2] - src_point[2]) - square(radius);
+
+  double x0 = std::numeric_limits<double>::signaling_NaN();
+  double x1 = std::numeric_limits<double>::signaling_NaN();
+  const int num_real_roots = gsl_poly_solve_quadratic(a, b, c, &x0, &x1);
+  if (num_real_roots == 2) {
+    // We solved for scale_factor-1 above, so add 1 to get scale_factor.
+    x0 += 1.0;
+    x1 += 1.0;
+    if (equal_within_roundoff(x0, 1.0)) {
+      x0 = 1.0;
+    }
+    if (equal_within_roundoff(x1, 1.0)) {
+      x1 = 1.0;
+    }
+    if (pick_root_greater_than_one) {
+      // For the inverse map, we want the a scale_factor s such that
+      // s >= 1. Note that gsl_poly_solve_quadratic returns x0 < x1.
+      // have three cases:
+      //  a) x0 < x1 < 1         ->   error
+      //  b) x0 < 1 <= x1        ->   Choose x1
+      //  c) 1 <= x0 < x1        ->   choose based on pick_larger_root
+      if (x0 >= 1.0 and not pick_larger_root) {
+        return x0;
+      } else if (x1 >= 1.0) {
+        return x1;
+      } else {
+        return boost::none;
+      }
+    } else {
+      // For the inverse map, we want a scale_factor s such that 0 < s <= 1.
+      // Note that gsl_poly_solve_quadratic returns x0 < x1.
+      // So we have six cases:
+      //  a) x0 < x1 <= 0        ->   error
+      //  b) x0 <= 0 < x1 <= 1   ->   Choose x1
+      //  c) x0 <= 0 and x1 > 1  ->   error
+      //  d) 0 < x0 < x1 <= 1      ->   Choose according to pick_larger_root
+      //  e) 0 < x0 <= 1 < x1      ->   Choose x0
+      //  f) 1 < x0 < x1           ->   error
+      if (x0 <= 0.0) {
+        if (x1 > 0.0 and x1 <= 1.0) {
+          return x1; // b)
+        } else {
+          return boost::none;  // a) and c)
+        }
+      } else if (x0 <= 1.0) {
+        if (x1 > 1.0) {
+          return x0;  // e)
+        } else {
+          return pick_larger_root ? x1 : x0;  // d)
+        }
+      } else {
+        return boost::none;  // f)
+      }
+    }
+  } else if (num_real_roots == 1) {
+    // We solved for scale_factor-1 above, so add 1 to get scale_factor.
+    x0 += 1.0;
+    if (equal_within_roundoff(x0, 1.0)) {
+      x0 = 1.0;
+    }
+    if (pick_root_greater_than_one) {
+      if (x0 < 1.0) {
+        return boost::none;
+      } else {
+        return x0;
+      }
+    } else {
+      if (x0 <= 0.0 or x0 > 1.0) {
+        return boost::none;
+      } else {
+        return x0;
+      }
+    }
+  } else {
+    return boost::none;
+  }
+}
+
+// Let xbar^i be 'src_point' and lambda be 'scale_factor' as computed by
+// the function scale_factor, and let 'intersection_point' be the computed
+// intersection point derived from lambda and xbar^i.
+//
+// d_scale_factor_d_src_point computes partial lambda/partial xbar^i for
+// all i.
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, 3> d_scale_factor_d_src_point(
+    const std::array<tt::remove_cvref_wrap_t<T>, 3>& intersection_point,
+    const std::array<double, 3>& proj_center,
+    const std::array<double, 3>& sphere_center,
+    const tt::remove_cvref_wrap_t<T>& lambda) noexcept {
+  using return_type = tt::remove_cvref_wrap_t<T>;
+  const return_type lambda_over_denominator =
+      square(lambda) / (square(intersection_point[0] - proj_center[0]) +
+                        square(intersection_point[1] - proj_center[1]) +
+                        square(intersection_point[2] - proj_center[2]) +
+                        ((intersection_point[0] - proj_center[0]) *
+                             (proj_center[0] - sphere_center[0]) +
+                         (intersection_point[1] - proj_center[1]) *
+                             (proj_center[1] - sphere_center[1]) +
+                         (intersection_point[2] - proj_center[2]) *
+                             (proj_center[2] - sphere_center[2])));
+  auto result =
+      make_with_value<std::array<return_type, 3>>(lambda_over_denominator, 0.0);
+  for (size_t i = 0; i < 3; ++i) {
+    gsl::at(result, i) =
+        lambda_over_denominator *
+        (gsl::at(sphere_center, i) - gsl::at(intersection_point, i));
+  }
+  return result;
+}
+}  // namespace CylindricalEndcap_detail
+
+CylindricalEndcap::CylindricalEndcap(const std::array<double, 3>& center_one,
+                                     const std::array<double, 3>& center_two,
+                                     const std::array<double, 3>& proj_center,
+                                     double radius_one, double radius_two,
+                                     double z_plane) noexcept
+    : center_one_(center_one),
+      center_two_(center_two),
+      proj_center_(proj_center),
+      radius_one_(radius_one),
+      radius_two_(radius_two),
+      z_plane_(z_plane) {
+
+#ifdef SPECTRE_DEBUG
+  // There are two types of sanity checks here on the map parameters.
+  // 1) ASSERTS that guarantee that the map is invertible.
+  // 2) ASSERTS that guarantee that the map parameters fall within
+  //    the range tested by the unit tests (which is the range in which
+  //    the map is expected to be used).
+  //
+  // There are two reasons why 1) and 2) are not the same:
+  //
+  // a) It is possible to choose parameters such that the map is
+  //    invertible but the resulting geometry has very sharp angles,
+  //    very large or ill-conditioned Jacobians, or both.  We want to
+  //    avoid such cases.
+  // b) We do not want to waste effort testing the map for parameters
+  //    that we don't expect to be used.  For example, we demand
+  //    here that proj_center and sphere_one are contained within
+  //    sphere_two, but the map should still be valid for some choices
+  //    of parameters where sphere_one and sphere_two are disjoint;
+  //    allowing those parameter choices would involve much more
+  //    complicated logic to determine whether the map produces shapes
+  //    with sharp angles or large jacobians, and it would involve more
+  //    complicated unit tests to cover those possibilities.
+
+  // First test for invertibility.
+
+  // Consider the intersection of sphere_one and the plane formed by
+  // z_plane.  Call it circle_one.  Consider the cone with apex
+  // center_one that intersects sphere_one on circle_one. This cone
+  // has an opening angle 2*theta.  Call the cone 'cone_one'.
+  const double cos_theta = (z_plane - center_one_[2]) / radius_one_;
+
+  // Now consider a different cone, cone_new, constructed so that
+  // cone_new and cone_one intersect each other on circle_one at right
+  // angles.  The apex of cone_new is cone_new_apex, defined as
+  // follows:
+  const std::array<double, 3> cone_new_apex = {
+      center_one_[0], center_one_[1], center_one_[2] + radius_one_ / cos_theta};
+  // Cone_new opens in the -z direction with opening angle 2*(pi/2-theta).
+
+  // A necessary condition for invertibility is that proj_center lies
+  // either inside of cone_new or inside of the reflection of cone_new
+  // (a cone with apex cone_new_apex but opening in the +x direction
+  // with opening angle 2*(pi/2-theta)).
+
+  // Determine the angle of proj_center relative to cone_new_apex. Call this
+  // angle alpha.
+  const double dist_cone_proj =
+      sqrt(square(cone_new_apex[0] - proj_center_[0]) +
+           square(cone_new_apex[1] - proj_center_[1]) +
+           square(cone_new_apex[2] - proj_center_[2]));
+  const double cos_alpha = (cone_new_apex[2] - proj_center[2]) / dist_cone_proj;
+
+  // Now make sure that alpha < pi/2-theta.
+  // The cone on either side of cone_new_apex is ok, so we use abs below.
+  ASSERT(acos(abs(cos_alpha)) < abs(asin(cos_theta)),
+         "The arguments passed into the CylindricalEndcap constructor "
+         "yield a noninvertible map.");
+
+  // Another necessary condition for invertibility is that proj_center
+  // cannot lie between sphere_one and cone_new_apex.
+  const double proj_radius_one = sqrt(square(center_one_[0] - proj_center_[0]) +
+                                      square(center_one_[1] - proj_center_[1]) +
+                                      square(center_one_[2] - proj_center_[2]));
+  ASSERT(proj_center_[2] > cone_new_apex[2] or proj_center_[2] < z_plane_ or
+             proj_radius_one < radius_one_,
+         "The arguments passed into the CylindricalEndcap constructor "
+         "yield a noninvertible map.");
+
+  // Other sanity checks that may be relaxed if there is more logic
+  // added and more unit tests to test these cases.
+
+  ASSERT(proj_center_[2] < z_plane_,
+         "CylindricalEndcap: The map hasn't been tested for this "
+         "configuration. The map may still be invertible, but further "
+         "testing would be needed to ensure that jacobians are not "
+         "ill-conditioned.");
+
+  ASSERT(abs(cos_theta) <= 0.9,
+         "CylindricalEndcap: z_plane is too far from the center of sphere_one. "
+             << "cos_theta = " << cos_theta
+             << ". If |cos_theta| > 1 the map is singular.  If 0.9 < "
+                "|cos_theta| < 1 then the map is not singular, but the "
+                "jacobians are likely to be large and the map has not been "
+                "tested for these parameters.");
+  ASSERT(
+      abs(cos_theta) >= 0.1,
+      "CylindricalEndcap: z_plane is too close to the center of sphere_one. "
+          << "cos_theta = " << cos_theta
+          << ". The map is not singular, but the jacobians are likely to be "
+             "large "
+             "and the map has not been tested for this choice of parameters.");
+
+  const double dist_spheres = sqrt(square(center_one_[0] - center_two_[0]) +
+                                   square(center_one_[1] - center_two_[1]) +
+                                   square(center_one_[2] - center_two_[2]));
+  ASSERT(dist_spheres + radius_one < radius_two,
+         "CylindricalEndcap: The map has been tested only for the case when "
+         "sphere_one is contained inside sphere_two");
+
+  const double proj_radius_two = sqrt(square(center_two_[0] - proj_center_[0]) +
+                                      square(center_two_[1] - proj_center_[1]) +
+                                      square(center_two_[2] - proj_center_[2]));
+  ASSERT(proj_radius_two < radius_two_,
+         "CylindricalEndcap: The map has been tested only for the case when "
+         "proj_center is contained inside sphere_two");
+
+  // Check if we are too close to singular.
+  ASSERT(acos(abs(cos_alpha)) < abs(0.95 * asin(cos_theta)),
+         "CylindricalEndcap: Parameters are close to where the map becomes "
+         "non-invertible.  The map has not been tested for this case.");
+
+  // Check if opening angle is small enough.
+  const double max_opening_angle = M_PI / 3.0;
+  const double max_proj_center_z =
+      z_plane_ -
+      radius_one_ * sqrt(1.0 - square(cos_theta)) / tan(max_opening_angle);
+  ASSERT(proj_center_[2] < max_proj_center_z,
+         "CylindricalEndcap: proj_center is too close to z_plane. The "
+         "map has not been tested for this case.");
+  const double tan_beta = sqrt(square(center_one_[0] - proj_center_[0]) +
+                               square(center_one_[1] - proj_center_[1])) /
+                          (max_proj_center_z - proj_center_[2]);
+  ASSERT(tan_beta < tan(max_opening_angle),
+         "CylindricalEndcap: opening angle is too large. The map has not "
+         "been tested for this case.");
+#endif
+}
+
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, 3> CylindricalEndcap::operator()(
+    const std::array<T, 3>& source_coords) const noexcept {
+  using return_type = tt::remove_cvref_wrap_t<T>;
+  CylindricalEndcap_detail::InnerSphereMap inner_map(center_one_, radius_one_,
+                                                     z_plane_);
+
+  // lower_coords are the mapped coords on the surface of sphere 1.
+  const std::array<return_type, 3> lower_coords = inner_map(source_coords);
+
+  // upper_coords are the mapped coords on the surface of sphere 2.
+  const auto lambda = CylindricalEndcap_detail::scale_factor<return_type>(
+      lower_coords, proj_center_, center_two_, radius_two_);
+
+  std::array<return_type, 3> upper_coords = lower_coords;
+  for (size_t i = 0; i < 3; ++i) {
+    gsl::at(upper_coords, i) =
+        gsl::at(proj_center_, i) +
+        (gsl::at(lower_coords, i) - gsl::at(proj_center_, i)) * lambda;
+  }
+
+  // mapped_coords goes linearly from lower_coords to upper_coords
+  // as zbar goes from -1 to 1.
+  const return_type& zbar = source_coords[2];
+  auto mapped_coords = make_with_value<std::array<return_type, 3>>(zbar, 0.0);
+  for (size_t i = 0; i < 3; ++i) {
+    gsl::at(mapped_coords, i) =
+        gsl::at(lower_coords, i) +
+        (gsl::at(upper_coords, i) - gsl::at(lower_coords, i)) * 0.5 *
+            (zbar + 1.0);
+  }
+  return mapped_coords;
+}
+
+boost::optional<std::array<double, 3>> CylindricalEndcap::inverse(
+    const std::array<double, 3>& target_coords) const noexcept {
+  // If target_coords are outside of sphere_two then the point
+  // is out of range.
+  const double radius_squared = square(target_coords[0] - center_two_[0]) +
+                                square(target_coords[1] - center_two_[1]) +
+                                square(target_coords[2] - center_two_[2]);
+  // The equal_within_roundoff below has an implicit scale of 1,
+  // so the inverse may fail if radius_two_ is intentionally very
+  // small, e.g. if we really want a tiny tiny domain.
+  if (radius_squared > square(radius_two_) and
+      not equal_within_roundoff(radius_squared, square(radius_two_))) {
+    return boost::none;
+  }
+
+  // Try to find lambda_tilde going from target_coords to *sphere 1*.
+  // This lambda_tilde should be positive and less than or equal to unity.
+  // If there are two such roots, we choose based on where the points are.
+  const bool choose_larger_root = target_coords[2] > proj_center_[2];
+  const auto lambda_tilde = CylindricalEndcap_detail::try_scale_factor(
+      target_coords, proj_center_, center_one_, radius_one_, choose_larger_root,
+      false);
+
+  // Cannot find scale factor, so we are out of range of the map.
+  if (not lambda_tilde) {
+    return boost::none;
+  }
+
+  // If lambda_tilde is negative, then we are on the wrong side of
+  // the sphere.  If lambda_tilde is larger than unity, then we are
+  // outside the sphere.
+  if (lambda_tilde.get() <= 0.0 or
+      (lambda_tilde.get() > 1.0 and
+       not equal_within_roundoff(lambda_tilde.get(), 1.0))) {
+    return boost::none;
+  }
+
+  // Try to find lambda_bar going from target_coords to *sphere 2*.
+  // This lambda_bar should be positive and greater than or equal to unity.
+  const auto lambda_bar = CylindricalEndcap_detail::try_scale_factor(
+      target_coords, proj_center_, center_two_, radius_two_, false, true);
+
+  // Cannot find scale factor, so we are out of range of the map.
+  if (not lambda_bar) {
+    return boost::none;
+  }
+
+  // Compute zbar in a roundoff-friendly way that should get the
+  // correct values at zbar=1 and zbar=-1.
+  double zbar = 0.0;
+  if (equal_within_roundoff(lambda_tilde.get(), 1.0, 1.e-5)) {
+    // Get zbar correct for zbar near -1
+    zbar = 2.0 * (lambda_tilde.get() - 1.0) /
+               (lambda_tilde.get() - lambda_bar.get()) -
+           1.0;
+  } else {
+    // Get zbar correct for zbar near +1
+    zbar = 2.0 * (lambda_bar.get() - 1.0) /
+               (lambda_tilde.get() - lambda_bar.get()) +
+           1.0;
+  }
+
+  std::array<double, 3> lower_coords = target_coords;
+  for (size_t i = 0; i < 3; ++i) {
+    gsl::at(lower_coords, i) =
+        gsl::at(proj_center_, i) +
+        (gsl::at(target_coords, i) - gsl::at(proj_center_, i)) *
+            lambda_tilde.get();
+  }
+
+  // Map lower_coords back to (xbar,ybar,zbar)
+  // Here zbar will be -1.
+  CylindricalEndcap_detail::InnerSphereMap inner_map(center_one_, radius_one_,
+                                                     z_plane_);
+  boost::optional<std::array<double, 3>> orig_coords =
+      inner_map.inverse(lower_coords);
+
+  if (orig_coords) {
+    orig_coords.get()[2] = zbar;
+  }
+
+  // Root polishing.
+  // Here we do a single Newton iteration to get the
+  // inverse to agree with the forward map to the level of machine
+  // roundoff that is required by the unit tests.
+  // Without the root polishing, the unit tests occasionally fail
+  // the 'inverse(map(x))=x' test at a level slightly above roundoff.
+  if (orig_coords) {
+    const auto inv_jac = inv_jacobian(orig_coords.get());
+    const auto mapped_coords = operator()(orig_coords.get());
+    for (size_t i = 0; i < 3; ++i) {
+      for (size_t j = 0; j < 3; ++j) {
+        gsl::at(orig_coords.get(), i) +=
+            (gsl::at(target_coords, j) - gsl::at(mapped_coords, j)) *
+            inv_jac.get(i, j);
+      }
+    }
+  }
+
+  return orig_coords;
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
+CylindricalEndcap::jacobian(const std::array<T, 3>& source_coords) const
+    noexcept {
+  using return_type = tt::remove_cvref_wrap_t<T>;
+  CylindricalEndcap_detail::InnerSphereMap inner_map(center_one_, radius_one_,
+                                                     z_plane_);
+
+  // lower_coords are the mapped coords on the surface of sphere 1.
+  const std::array<return_type, 3> lower_coords = inner_map(source_coords);
+  const auto lambda = CylindricalEndcap_detail::scale_factor<return_type>(
+      lower_coords, proj_center_, center_two_, radius_two_);
+
+  // upper_coords are the mapped coords on the surface of sphere 2.
+  std::array<return_type, 3> upper_coords = lower_coords;
+  for (size_t i = 0; i < 3; ++i) {
+    gsl::at(upper_coords, i) =
+        gsl::at(proj_center_, i) +
+        (gsl::at(lower_coords, i) - gsl::at(proj_center_, i)) * lambda;
+  }
+
+  const return_type& zbar = source_coords[2];
+
+  auto jacobian_matrix =
+      make_with_value<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>>(
+          dereference_wrapper(source_coords[0]), 0.0);
+
+  // dx^i/dzbar is easy, do it first.
+  for (size_t i = 0; i < 3; ++i) {
+    jacobian_matrix.get(i, 2) =
+        0.5 * (gsl::at(upper_coords, i) - gsl::at(lower_coords, i));
+  }
+
+  // Do the easiest of the terms involving the inner map.
+  const auto d_inner = inner_map.jacobian(source_coords);
+  const return_type lambda_factor = 0.5 * (1.0 - zbar + lambda * (1.0 + zbar));
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      jacobian_matrix.get(i, j) += lambda_factor * d_inner.get(i, j);
+    }
+  }
+
+  // Do lambda term, which is the most complicated one.
+  const auto d_lambda_d_lower_coords =
+      CylindricalEndcap_detail::d_scale_factor_d_src_point<return_type>(
+          upper_coords, proj_center_, center_two_, lambda);
+  const return_type z_factor = 0.5 * (1.0 + zbar);
+  for (size_t j = 0; j < 3; ++j) {
+    auto temp = make_with_value<return_type>(z_factor, 0.0);
+    for (size_t k = 0; k < 3; ++k) {
+      temp += gsl::at(d_lambda_d_lower_coords, k) * d_inner.get(k, j);
+    }
+    temp *= z_factor;
+    for (size_t i = 0; i < 3; ++i) {
+      jacobian_matrix.get(i, j) +=
+          temp * (gsl::at(lower_coords, i) - gsl::at(proj_center_, i));
+    }
+  }
+
+  return jacobian_matrix;
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
+CylindricalEndcap::inv_jacobian(const std::array<T, 3>& source_coords) const
+    noexcept {
+  using return_type = tt::remove_cvref_wrap_t<T>;
+  CylindricalEndcap_detail::InnerSphereMap inner_map(center_one_, radius_one_,
+                                                     z_plane_);
+
+  // lower_coords are the mapped coords on the surface of sphere 1.
+  const std::array<return_type, 3> lower_coords = inner_map(source_coords);
+
+  // Lambda is the scale factor between lower coords and upper coords.
+  const auto lambda = CylindricalEndcap_detail::scale_factor<return_type>(
+      lower_coords, proj_center_, center_two_, radius_two_);
+
+  // upper_coords are the mapped coords on the surface of sphere 2.
+  std::array<return_type, 3> upper_coords = lower_coords;
+  for (size_t i = 0; i < 3; ++i) {
+    gsl::at(upper_coords, i) =
+        gsl::at(proj_center_, i) +
+        (gsl::at(lower_coords, i) - gsl::at(proj_center_, i)) * lambda;
+  }
+
+  // Derivative of lambda
+  const auto d_lambda_d_lower_coords =
+      CylindricalEndcap_detail::d_scale_factor_d_src_point<return_type>(
+          upper_coords, proj_center_, center_two_, lambda);
+
+  // Lambda_tilde is the scale factor between mapped coords and lower coords.
+  // We can compute it with a shortcut because there is a relationship
+  // between lambda, lambda_tilde, and zbar.
+  const return_type& zbar = source_coords[2];
+  const return_type lambda_tilde =
+      1.0 / (1.0 - 0.5 * (1.0 - lambda) * (1.0 + zbar));
+
+  // Derivative of lambda_tilde
+  const auto d_lambda_tilde_d_mapped_coords =
+      CylindricalEndcap_detail::d_scale_factor_d_src_point<return_type>(
+          lower_coords, proj_center_, center_one_, lambda_tilde);
+
+  // Derivatives of zbar with respect to lambda and lambda_tilde
+  const return_type dzbar_dlambda = (1.0 + zbar) / (1.0 - lambda);
+  const return_type dzbar_dlambdatilde =
+      2.0 / square(lambda_tilde) / (1.0 - lambda);
+
+  auto inv_jacobian_matrix =
+      make_with_value<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>>(
+          dereference_wrapper(source_coords[0]), 0.0);
+
+  // dzbar/dx^i
+  for (size_t i = 0; i < 3; ++i) {
+    auto tmp = make_with_value<return_type>(lambda, 0.0);
+    for (size_t j = 0; j < 3; ++j) {
+      tmp += gsl::at(d_lambda_d_lower_coords, j) *
+             (gsl::at(lower_coords, j) - gsl::at(proj_center_, j));
+    }
+    inv_jacobian_matrix.get(2, i) =
+        gsl::at(d_lambda_d_lower_coords, i) * dzbar_dlambda * lambda_tilde +
+        gsl::at(d_lambda_tilde_d_mapped_coords, i) *
+            (dzbar_dlambdatilde + tmp * dzbar_dlambda / lambda_tilde);
+  }
+
+  // dxbar/dx^i and dybar/dx^i
+  const auto dxbar_dx_inner = inner_map.inv_jacobian(source_coords);
+
+  for (size_t i = 0; i < 2; ++i) {  // Loop up to 2; we already did zbar
+    auto tmp = make_with_value<return_type>(lambda, 0.0);
+    for (size_t k = 0; k < 3; ++k) {
+      tmp += (gsl::at(lower_coords, k) - gsl::at(proj_center_, k)) *
+             dxbar_dx_inner.get(i, k);
+    }
+    for (size_t j = 0; j < 3; ++j) {
+      inv_jacobian_matrix.get(i, j) =
+          tmp * (gsl::at(d_lambda_tilde_d_mapped_coords, j) / lambda_tilde) +
+          lambda_tilde * dxbar_dx_inner.get(i, j);
+    }
+  }
+  return inv_jacobian_matrix;
+}
+
+void CylindricalEndcap::pup(PUP::er& p) noexcept {
+  p | center_one_;
+  p | center_two_;
+  p | proj_center_;
+  p | radius_one_;
+  p | radius_two_;
+  p | z_plane_;
+}
+
+bool operator==(const CylindricalEndcap& lhs,
+                const CylindricalEndcap& rhs) noexcept {
+  return lhs.center_one_ == rhs.center_one_ and
+         lhs.center_two_ == rhs.center_two_ and
+         lhs.proj_center_ == rhs.proj_center_ and
+         lhs.radius_one_ == rhs.radius_one_ and
+         lhs.radius_two_ == rhs.radius_two_ and lhs.z_plane_ == rhs.z_plane_;
+}
+
+bool operator!=(const CylindricalEndcap& lhs,
+                const CylindricalEndcap& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+// Explicit instantiations
+/// \cond
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                   \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>                 \
+  CylindricalEndcap::operator()(                                               \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;         \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame>   \
+  CylindricalEndcap::jacobian(const std::array<DTYPE(data), 3>& source_coords) \
+      const noexcept;                                                          \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame>   \
+  CylindricalEndcap::inv_jacobian(                                             \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
+                                      std::reference_wrapper<const double>,
+                                      std::reference_wrapper<const DataVector>))
+
+#undef DTYPE
+#undef INSTANTIATE
+/// \endcond
+
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/CylindricalEndcap.hpp
+++ b/src/Domain/CoordinateMaps/CylindricalEndcap.hpp
@@ -1,0 +1,487 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines the class CylindricalEndcap.
+
+#pragma once
+
+#include <array>
+#include <boost/optional.hpp>
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace domain::CoordinateMaps {
+
+/*!
+ * \ingroup CoordinateMapsGroup
+ *
+ * \brief Map from 3D unit right cylinder to a volume that connects
+ *  portions of two spherical surfaces.
+ *
+ * \image html CylindricalEndcap.svg "A cylinder maps to the shaded region."
+ *
+ * \details Consider two spheres with centers \f$C_1\f$ and \f$C_2\f$,
+ * and radii \f$R_1\f$ and \f$R_2\f$. Let sphere 1 be intersected by a
+ * plane normal to the \f$z\f$ axis and located at \f$z = z_\mathrm{P}\f$.
+ * Also let there be a projection point \f$P\f$.
+ *
+ * CylindricalEndcap maps a 3D unit right cylinder (with coordinates
+ * \f$(\bar{x},\bar{y},\bar{z})\f$ such that \f$-1\leq\bar{z}\leq 1\f$
+ * and \f$\bar{x}^2+\bar{y}^2+\bar{z}^2 \leq 1\f$) to the shaded area
+ * in the figure above (with coordinates \f$(x,y,z)\f$).  The "bottom"
+ * of the cylinder \f$\bar{z}=-1\f$ is mapped to the portion of sphere
+ * 1 that has \f$z \geq z_\mathrm{P}\f$.  Curves of constant
+ * \f$(\bar{x},\bar{y})\f$ are mapped to portions of lines that pass
+ * through \f$P\f$. Along each of these curves, \f$\bar{z}=-1\f$ is
+ * mapped to a point on sphere 1 and \f$\bar{z}=+1\f$ is mapped to a
+ * point on sphere 2.
+ *
+ * CylindricalEndcap is intended to be composed with Wedge2D maps to
+ * construct a portion of a cylindrical domain for a binary system.
+ *
+ * CylindricalEndcap is described briefly in the Appendix of
+ * Phys. Rev. D 86, 084033 (2012), https://arxiv.org/abs/1206.3015.
+ * CylindricalEndcap is used to construct the blocks labeled 'CA
+ * wedge', 'EA wedge', 'CB wedge', 'EE wedge', and 'EB wedge' in
+ * Figure 20 of that paper.
+ *
+ * ### More detail on how the map is constructed:
+ *
+ * Let \f$x_0^i\f$ be the coordinates \f$x^i\f$ that lie on
+ * the two-dimensional image of \f$(\bar{x},\bar{y},\bar{z}=-1)\f$.
+ * Thus \f$x_0^i\f$ lies on sphere 1 and has \f$x_0^2 \geq x_{\mathrm P}\f$.
+ * \f$x_0^i\f$ is determined by
+ *
+ * \f{align}
+ * x_0^0 &= R_1 \frac{\sin(\bar{\rho} \theta_\mathrm{max})
+ *              \bar{x}}{\bar{\rho}} + C_1^0\\
+ * x_0^1 &= R_1 \frac{\sin(\bar{\rho} \theta_\mathrm{max})
+ *              \bar{y}}{\bar{\rho}} + C_1^1\\
+ * x_0^2 &= R_1 \cos(\bar{\rho} \theta_\mathrm{max}) + C_1^2
+ * \f}
+ *
+ * where \f$\bar{\rho}^2 \equiv \bar{x}^2+\bar{y}^2\f$, and where
+ * \f$\theta_\mathrm{max}\f$ is defined by
+ * \f$\cos(\theta_\mathrm{max}) = (z_\mathrm{P}-C_1^2)/R_1\f$.
+ * Note that care must be taken to evaluate
+ * \f$\sin(\bar{\rho}\theta_\mathrm{max})/\bar{\rho}\f$
+ * near \f$\bar{\rho}=0\f$.
+ *
+ * Now let \f$x_1^i\f$ be the image of \f$(\bar{x},\bar{y},\bar{z}=+1)\f$.
+ * This point lies on sphere 2, and is constructed so that \f$P\f$,
+ * \f$x_0^i\f$, and \f$x_1^i\f$ are co-linear.  In particular, \f$x_1^i\f$
+ * is determined by the equation
+ *
+ * \f{align} x_1^i = P^i + (x_0^i - P^i) \lambda,\f}
+ *
+ * where \f$\lambda\f$ is a scalar factor that depends on \f$x_0^i\f$ and
+ * that can be computed by solving a quadratic equation.  This quadratic
+ * equation is derived by demanding that \f$x_1^i\f$ lies on sphere2:
+ *
+ * \f{align}
+ * |P^i + (x_0^i - P^i) \lambda - C_2^i |^2 - R_2^2 = 0.
+ * \f}
+ *
+ * Finally, once \f$\lambda\f$ has been computed and \f$x_1^i\f$ has
+ * been determined, the result of the CylindricalEndcap map is given
+ * by mapping linearly in \f$\bar{z}\f$ between \f$x_0^i\f$ and
+ * \f$x_1^i\f$ as follows:
+ *
+ * \f[x^i = x_0^i + (x_1^i - x_0^i) \frac{\bar{z}+1}{2}\f]
+ *
+ * ### Jacobian
+ *
+ * Because \f$x_0^i\f$ and \f$x_1^i\f$ are independent of \f$\bar{z}\f$,
+ * a few of the Jacobian components are easy:
+ *
+ * \f[
+ * \frac{\partial x^i}{\partial \bar{z}} = \frac{1}{2}(x_1^i - x_0^i).
+ * \f]
+ *
+ * The other components of the Jacobian require more effort.
+ *
+ * Differentiating Eqs.(1--3) above yields
+ *
+ * \f{align*}
+ * \frac{\partial x_0^2}{\partial \bar{x}} &=
+ * - R_1 \theta_\mathrm{max}
+ * \frac{\sin(\bar{\rho}\theta_\mathrm{max})}{\bar{\rho}}\bar{x}\\
+ * \frac{\partial x_0^2}{\partial \bar{y}} &=
+ * - R_1 \theta_\mathrm{max}
+ * \frac{\sin(\bar{\rho}\theta_\mathrm{max})}{\bar{\rho}}\bar{y}\\
+ * \frac{\partial x_0^0}{\partial \bar{x}} &=
+ * R_1 \frac{\sin(\bar{\rho}\theta_\mathrm{max})}{\bar{\rho}} +
+ * R_1 \frac{1}{\bar{\rho}}\frac{d}{d\bar{\rho}}
+ * \left(\frac{\sin(\bar{\rho}\theta_\mathrm{max})}{\bar{\rho}}\right)
+ * \bar{x}^2\\
+ * \frac{\partial x_0^0}{\partial \bar{y}} &=
+ * R_1 \frac{1}{\bar{\rho}}\frac{d}{d\bar{\rho}}
+ * \left(\frac{\sin(\bar{\rho}\theta_\mathrm{max})}{\bar{\rho}}\right)
+ * \bar{x}\bar{y}\\
+ * \frac{\partial x_0^1}{\partial \bar{x}} &=
+ * R_1 \frac{1}{\bar{\rho}}\frac{d}{d\bar{\rho}}
+ * \left(\frac{\sin(\bar{\rho}\theta_\mathrm{max})}{\bar{\rho}}\right)
+ * \bar{x}\bar{y}\\
+ * \frac{\partial x_0^1}{\partial \bar{y}} &=
+ * R_1 \frac{\sin(\bar{\rho}\theta_\mathrm{max})}{\bar{\rho}} +
+ * R_1 \frac{1}{\bar{\rho}}\frac{d}{d\bar{\rho}}
+ * \left(\frac{\sin(\bar{\rho}\theta_\mathrm{max})}{\bar{\rho}}\right)
+ * \bar{y}^2,
+ * \f}
+ * where care must be taken to evaluate
+ * \f$\sin(\bar{\rho}\theta_\mathrm{max})/\bar{\rho}\f$
+ * and its derivatives near \f$\bar{\rho}=0\f$.
+ *
+ * Differentiating Eq.(5) above yields
+ *
+ * \f{align}
+ * \frac{\partial\lambda}{\partial x_0^j} &=
+ * \lambda^2 \frac{C_2^j - x_1^j}{|x_1^i - P^i|^2
+ * + (x_1^i - P^i)(P_i - C_{2i})},
+ * \f}
+ *
+ * and differentiating Eq.(4) above yields
+ *
+ * \f[
+ * \frac{\partial x_1^i}{\partial x_0^j} = \lambda +
+ *  (x_0^i - P^i) \frac{\partial \lambda}{\partial x_0^j}.
+ * \f]
+ *
+ * Combining the above results, for \f$\bar{x}^j\f$ not equal to
+ * \f$\bar{z}\f$ the Jacobian is evaluated via
+ *
+ * \f[
+ * \frac{\partial x^i}{\partial \bar{x}^j} =
+ * \frac{1+\bar{z}}{2} \frac{\partial x_1^i}{\partial x_0^k}
+ * \frac{\partial x_0^k}{\partial \bar{x}^j} +
+ * \frac{1-\bar{z}}{2}\frac{\partial x_0^i}{\partial \bar{x}^j}.
+ * \f]
+ *
+ * ### Inverse map
+ *
+ * Given \f$x^i\f$, we wish to compute \f$\bar{x}\f$,
+ * \f$\bar{y}\f$, and \f$\bar{z}\f$.
+ *
+ * We first find the coordinates \f$x_0^i\f$ that lie on sphere 1
+ * and are defined such that \f$P\f$, \f$x_0^i\f$, and \f$x^i\f$ are co-linear.
+ * \f$x_0^i\f$ is determined by the equation
+ *
+ * \f{align} x_0^i = P^i + (x^i - P^i) \tilde{\lambda},\f}
+ *
+ * where \f$\tilde{\lambda}\f$ is a scalar factor that depends on \f$x^i\f$ and
+ * that can be computed by solving a quadratic equation.  This quadratic
+ * equation is derived by demanding that \f$x_0^i\f$ lies on sphere 1:
+ *
+ * \f{align}
+ * |P^i + (x^i - P^i) \tilde{\lambda} - C_1^i |^2 - R_1^2 = 0.
+ * \f}
+ *
+ * Note that Eqs. (7) and (8) are similar to Eqs. (4) and (5) above.
+ * In solving the quadratic, we choose the larger root if
+ * \f$x^2>z_\mathrm{P}\f$ and the smaller root otherwise. We demand that
+ * the root is greater than unity.  If there is no such root, this means
+ * that the point \f$x^i\f$ is not in the range of the map and the
+ * inverse function returns boost::none.
+ * Also, if the point \f$x_0^i\f$ computed by Eq. (7) does not lie
+ * on sphere 1, then likewise the point \f$x^i\f$ is not in the range
+ * of the map and the inverse function returns boost::none.
+ *
+ * Now consider the coordinates \f$x_1^i\f$ that lie on sphere 2
+ * and are defined such that \f$P\f$, \f$x_1^i\f$, and \f$x^i\f$ are co-linear.
+ * \f$x_1^i\f$ is determined by the equation
+ *
+ * \f{align} x_1^i = P^i + (x^i - P^i) \bar{\lambda},\f}
+ *
+ * where \f$\bar{\lambda}\f$ is a scalar factor that depends on \f$x^i\f$ and
+ * is the solution of a quadratic
+ * that is derived by demanding that \f$x_1^i\f$ lies on sphere 2:
+ *
+ * \f{align}
+ * |P^i + (x^i - P^i) \bar{\lambda} - C_2^i |^2 - R_2^2 = 0.
+ * \f}
+ *
+ * Once we have found \f$\bar{\lambda}\f$, we don't actually need to compute
+ * \f$x_1^i\f$. Instead, we use \f$\bar{\lambda}\f$ and \f$\tilde{\lambda}\f$
+ * to determine \f$\bar{z}\f$ by the equation
+ *
+ * \f{align}
+ * \bar{z} &= 2 \frac{\tilde{\lambda}-1}{\tilde{\lambda}-\bar{\lambda}} - 1,
+ * \f}
+ *
+ * or by the equivalent equation
+ *
+ * \f{align}
+ * \bar{z} &= 2 \frac{\bar{\lambda}-1}{\tilde{\lambda}-\bar{\lambda}} + 1,
+ * \f}
+ *
+ * where to minimize roundoff error we choose the first
+ * equation if \f$\tilde{\lambda}\sim 1\f$ and the second equation otherwise.
+ *
+ * We now have \f$\bar{z}\f$. To get \f$\bar{x}\f$ and \f$\bar{y}\f$,
+ * we use our computed values of \f$x_0^i\f$ above and invert
+ * Eqs (1--3).  Note that we have already demanded that
+ * \f$x_0^i\f$ lies on sphere 1, so therefore the inverse of Eqs. (1--3)
+ * depends on \f$x_0^0\f$ and \f$x_0^1\f$ but not on \f$x_0^2\f$.
+ * To compute the inverse, we start by finding
+ *
+ * \f{align}
+ * \sigma \equiv \sin(\bar{\rho}\theta_\mathrm{max})
+ *        &= \sqrt{\frac{(x_0^0-C_1^0)^2+(x_0^1-C_1^1)^2}{R^2_1}}.
+ * \f}
+ *
+ * Then we determine \f$\sin(\bar{\rho}\theta_\mathrm{max})/\bar{\rho}\f$
+ * from
+ *
+ * \f{align*}
+ * \frac{1}{\bar{\rho}}\sin(\bar{\rho}\theta_\mathrm{max})
+ * &= \frac{\theta_\mathrm{max}\sigma}{\arcsin(\sigma)}\\
+ * &\sim \theta_\mathrm{max}\left(1-\frac{\sigma^2}{6}\right)
+ * \qquad \hbox{(for small $\bar{\rho}$)},
+ * \f}
+ *
+ * where we use the Taylor approximation only for small \f$\bar{\rho}\f$.
+ * Finally, we have
+ *
+ * \f{align}
+ * \bar{x} &= \frac{x_0^0-C_1^0}{R_1}\left(\frac{1}{\bar{\rho}}
+              \sin(\bar{\rho}\theta_\mathrm{max})\right)^{-1}\\
+ * \bar{y} &= \frac{x_0^1-C_1^1}{R_1}\left(\frac{1}{\bar{\rho}}
+              \sin(\bar{\rho}\theta_\mathrm{max})\right)^{-1}.
+ * \f}
+ *
+ * Note that if \f$\bar{x}^2+\bar{y}^2 > 1\f$, the original point is outside
+ * the range of the map so we return boost::none.
+ *
+ * #### Root polishing
+ *
+ * The inverse function described above will sometimes have errors that
+ * are noticeably larger than roundoff.  Therefore we apply a single
+ * Newton-Raphson iteration to refine the result of the inverse map:
+ * Suppose we are given \f$x^i\f$, and we have computed \f$\bar{x}^i\f$
+ * by the above procedure.  We then correct \f$\bar{x}^i\f$ by adding
+ *
+ * \f[
+ * \delta \bar{x}^i = \left(x^j - x^j(\bar{x})\right)
+ * \frac{\partial \bar{x}^i}{\partial x^j},
+ * \f]
+ *
+ * where \f$x^j(\bar{x})\f$ is the result of applying the forward map
+ * to \f$\bar{x}^i\f$ and \f$\partial \bar{x}^i/\partial x^j\f$ is the
+ * inverse jacobian.
+ *
+ * ### Inverse jacobian
+ *
+ * We first consider components \f$\partial\bar{z}/\partial x^i\f$; we
+ * will separately treat the other components below.
+ * We note that \f$\bar{\lambda}=\tilde{\lambda}\lambda\f$,
+ * so Eq. (11) and (12) are equivalent to
+ *
+ * \f{align}
+ * \bar{z} &=
+ * 2 \frac{\tilde{\lambda}-1}{\tilde{\lambda}-\lambda\tilde{\lambda}} - 1.
+ * \f}
+ *
+ * Differentiating this expression yields
+ *
+ * \f{align}
+ * \frac{\partial \bar{z}}{\partial x^i} &=
+ * \frac{\partial \bar{z}}{\partial \lambda}
+ * \frac{\partial \lambda}{\partial x_0^j}
+ * \frac{\partial x_0^j}{\partial x^i}
+ * + \frac{\partial \bar{z}}{\partial \tilde\lambda}
+ *   \frac{\partial \tilde\lambda}{\partial x^i}.
+ * \f}
+ *
+ * We now compute the factors on the right-hand side of Eq. (17).
+ * By differentiating Eq. (8), we find that
+ *
+ * \f{align}
+ * \frac{\partial\tilde{\lambda}}{\partial x^j} &=
+ * \lambda^2 \frac{C_1^j - x_0^j}{|x_0^i - P^i|^2
+ * + (x_0^i - P^i)(P_i - C_{1i})}.
+ * \f}
+ *
+ * Differentiating Eq. (7) yields
+ *
+ * \f{align}
+ * \frac{\partial x_0^j}{\partial x^i} &= \tilde{\lambda} \delta_i^j
+ * + \frac{x_0^i-P^i}{\tilde{\lambda}}
+ *   \frac{\partial\tilde{\lambda}}{\partial x^j}.
+ * \f}
+ *
+ * We can now evaluate Eq. (17) using Eqs. (6), (16), (18), and (19).
+ *
+ * Now we turn to \f$\partial \bar{x}/\partial x^i\f$ and
+ * \f$\partial \bar{y}/\partial x^i\f$.  We write
+ *
+ * \f{align}
+ * \frac{\partial \bar{x}^i}{\partial x^j} =
+ * \frac{\partial x_0^k}{\partial x^j}
+ * \frac{\partial \bar{x}^i}{\partial x_0^k}
+ * \qquad (i\neq 2),
+ * \f}
+ *
+ * The first factor on the right-hand side can be evaluated using
+ * Eq. (19).  Now we turn to the second factor
+ * \f$\partial \bar{x}^i/\partial x_0^k\f$.  Note that
+ * \f$\bar{x}\f$ and \f$\bar{y}\f$ can be considered to depend only on
+ * \f$x_0^0\f$ and \f$x_0^1\f$ but not on \f$x_0^2\f$, because the
+ * point \f$x_0^i\f$ is constrained to lie on a sphere of radius \f$R_1\f$.
+ * We will compute \f$\partial \bar{x}^i/\partial x_0^k\f$ by differentiating
+ * Eqs. (14) and (15), but those equations involve \f$\bar{\rho}\f$, so
+ * first we establish some relations involving \f$\bar{\rho}\f$.  For
+ * ease of notation, we define
+ *
+ * \f[
+ * q \equiv \frac{\sin(\bar{\rho}\theta_\mathrm{max})}{\bar{\rho}}.
+ * \f]
+ *
+ * First observe that
+ * \f[
+ * \frac{dq}{d\sigma}
+ * = \frac{dq}{d\bar{\rho}}
+ * \left(\bar{\rho} \frac{dq}{d\bar{\rho}} + q\right)^{-1},
+ * \f]
+ *
+ * where \f$\sigma\f$ is the quantity defined by Eq. (13).  Therefore
+ *
+ * \f{align}
+ * \frac{\partial q}{\partial x_0^0} &=
+ * \frac{\bar{x}}{\bar{\rho}}\frac{dq}{d\bar{\rho}}
+ * \left(\bar{\rho} \frac{dq}{d\bar{\rho}} + q\right)^{-1},\\
+ * \frac{\partial q}{\partial x_0^1} &=
+ * \frac{\bar{y}}{\bar{\rho}}\frac{dq}{d\bar{\rho}}
+ * \left(\bar{\rho} \frac{dq}{d\bar{\rho}} + q\right)^{-1},
+ * \f}
+ *
+ * where we have differentiated Eq. (13), and where we have
+ * used Eqs. (14) and (15) to eliminate \f$x_0^0\f$ and
+ * \f$x_0^1\f$ in favor of \f$\bar{x}\f$ and
+ * \f$\bar{y}\f$ in the final result.
+ *
+ * By differentiating Eqs. (14) and (15), and using Eqs. (21) and (22), we
+ * find
+ *
+ * \f{align}
+ * \frac{\partial \bar{x}}{\partial x_0^2} &= 0,\\
+ * \frac{\partial \bar{x}}{\partial x_0^0} &=
+ * \frac{1}{R_1 q}
+ * - \frac{\bar{x}^2}{R_1 q \bar{\rho}} \frac{dq}{d\bar{\rho}}
+ * \left(\bar{\rho} \frac{dq}{d\bar{\rho}} + q\right)^{-1},\\
+ * \frac{\partial \bar{x}}{\partial x_0^1} &=
+ * - \frac{\bar{x}\bar{y}}{R_1 q \bar{\rho}} \frac{dq}{d\bar{\rho}}
+ * \left(\bar{\rho} \frac{dq}{d\bar{\rho}} + q\right)^{-1},\\
+ * \frac{\partial \bar{y}}{\partial x_0^2} &= 0,\\
+ * \frac{\partial \bar{y}}{\partial x_0^0} &=
+ * \frac{\partial \bar{x}}{\partial x_0^1},\\
+ * \frac{\partial \bar{y}}{\partial x_0^1} &=
+ * \frac{1}{R_1 q}
+ * - \frac{\bar{y}^2}{R_1 q \bar{\rho}} \frac{dq}{d\bar{\rho}}
+ * \left(\bar{\rho} \frac{dq}{d\bar{\rho}} + q\right)^{-1}.
+ * \f}
+ * Note that care must be taken to evaluate
+ * \f$q = \sin(\bar{\rho}\theta_\mathrm{max})/\bar{\rho}\f$ and its
+ * derivative near \f$\bar{\rho}=0\f$.
+ *
+ * Now we can evaluate Eq. (20) using Eq. (19) and
+ * Eqs. (23--28).
+ *
+ * ### Restrictions on map parameters.
+ *
+ * We demand that Sphere 1 is fully contained inside Sphere 2. It is
+ * possible to construct a valid map without this assumption, but the
+ * assumption simplifies the code, and the expected use cases obey
+ * this restriction.
+ *
+ * We also demand that \f$z_\mathrm{P} > C_1^2\f$, that is, the plane
+ * in the above and below figures lies to the right of \f$C_1^2\f$.
+ * This restriction not strictly necessary but is made for simplicity.
+ *
+ * The map is invertible only for some choices of the projection point
+ * \f$P\f$.  Given the above restrictions, the allowed values of
+ * \f$P\f$ are illustrated by the following diagram:
+ *
+ * \image html CylindricalEndcap_Allowed.svg "Allowed region for P." width=75%
+ *
+ * The plane \f$z=z_\mathrm{P}\f$ intersects sphere 1 on a circle. The
+ * cone with apex \f$C_1\f$ that intersects that circle has opening
+ * angle \f$2\theta\f$ as shown in the above figure. Construct another
+ * cone, the "invertibility cone", with apex \f$S\f$ chosen such that
+ * the two cones intersect at right angles on the circle; thus the
+ * opening angle of the invertibility cone is \f$2(\pi-\theta)\f$.  A
+ * necessary condition for invertibility is that the projection point
+ * \f$P\f$ lies inside the invertibility cone, but not between \f$S\f$
+ * and sphere 1.  Placing the projection point \f$P\f$ to the right of
+ * \f$S\f$ (but inside the invertibility cone) is ok for
+ * invertibility.
+ *
+ * In addition to invertibility and the two additional restrictions
+ * already mentioned above, we demand a few more restrictions on the
+ * map parameters to simplify the logic for the expected use cases, and
+ * to ensure that jacobians do not get too large. We demand:
+ *
+ * - \f$P\f$ is not too close to the edge of the invertibility cone.
+ * - \f$P\f$ is contained in sphere 2.
+ * - \f$P\f$ is to the left of \f$z_\mathrm{P}\f$.
+ * - \f$z_\mathrm{P}\f$ is not too close to the center or the edge of sphere 1.
+ * - If a line segment is drawn between \f$P\f$ and any point on the
+ *   intersection circle, the angle between the line segment and
+ *   the x-axis is smaller than \f$\pi/3\f$.
+ *
+ */
+class CylindricalEndcap {
+ public:
+  static constexpr size_t dim = 3;
+  CylindricalEndcap(const std::array<double, 3>& center_one,
+                    const std::array<double, 3>& center_two,
+                    const std::array<double, 3>& proj_center, double radius_one,
+                    double radius_two, double z_plane) noexcept;
+
+  CylindricalEndcap() = default;
+  ~CylindricalEndcap() = default;
+  CylindricalEndcap(CylindricalEndcap&&) = default;
+  CylindricalEndcap(const CylindricalEndcap&) = default;
+  CylindricalEndcap& operator=(const CylindricalEndcap&) = default;
+  CylindricalEndcap& operator=(CylindricalEndcap&&) = default;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  boost::optional<std::array<double, 3>> inverse(
+      const std::array<double, 3>& target_coords) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> jacobian(
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> inv_jacobian(
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  // clang-tidy: google runtime references
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+  static bool is_identity() noexcept { return false; }
+
+ private:
+  friend bool operator==(const CylindricalEndcap& lhs,
+                         const CylindricalEndcap& rhs) noexcept;
+  std::array<double, 3> center_one_{}, center_two_{}, proj_center_{};
+  double radius_one_{std::numeric_limits<double>::signaling_NaN()};
+  double radius_two_{std::numeric_limits<double>::signaling_NaN()};
+  double z_plane_{std::numeric_limits<double>::signaling_NaN()};
+};
+bool operator!=(const CylindricalEndcap& lhs,
+                const CylindricalEndcap& rhs) noexcept;
+}  // namespace domain::CoordinateMaps

--- a/src/NumericalAlgorithms/RootFinding/QuadraticEquation.cpp
+++ b/src/NumericalAlgorithms/RootFinding/QuadraticEquation.cpp
@@ -6,7 +6,10 @@
 #include <gsl/gsl_poly.h>
 #include <limits>
 
+#include "DataStructures/DataVector.hpp"
 #include "ErrorHandling/Assert.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
 
 double positive_root(const double a, const double b, const double c) noexcept {
   const auto roots = real_roots(a, b, c);
@@ -28,3 +31,64 @@ std::array<double, 2> real_roots(const double a, const double b,
          << " b=" << b << " c=" << c);
   return {{x0, x1}};
 }
+
+template <typename T>
+struct smallest_root_greater_than_value_within_roundoff_impl;
+
+template <typename T>
+T smallest_root_greater_than_value_within_roundoff(const T& a, const T& b,
+                                                   const T& c,
+                                                   double value) noexcept {
+  return smallest_root_greater_than_value_within_roundoff_impl<T>::f(a, b, c,
+                                                                     value);
+}
+
+template <>
+struct smallest_root_greater_than_value_within_roundoff_impl<double> {
+  static double f(const double a, const double b, const double c,
+                  const double value) noexcept {
+    const auto roots = real_roots(a, b, c);
+    // Roots are returned in increasing order.
+
+    if (roots[0] >= value or equal_within_roundoff(roots[0], value)) {
+      return roots[0];
+    }
+    ASSERT(roots[1] >= value or equal_within_roundoff(roots[1], value),
+           "No root >=1.  Roots are " << roots[0] << " and " << roots[1]
+                                      << ", with a=" << a << " b=" << b
+                                      << " c=" << c);
+    return roots[1];
+  }
+};
+
+template <>
+struct smallest_root_greater_than_value_within_roundoff_impl<DataVector> {
+  static DataVector f(const DataVector& a, const DataVector& b,
+                      const DataVector& c, const double value) noexcept {
+    ASSERT(a.size() == b.size(),
+           "Size mismatch a vs b: " << a.size() << " " << b.size());
+    ASSERT(a.size() == c.size(),
+           "Size mismatch a vs c: " << a.size() << " " << c.size());
+    DataVector result(a.size());
+    for (size_t i = 0; i < a.size(); ++i) {
+      result[i] = smallest_root_greater_than_value_within_roundoff(a[i], b[i],
+                                                                   c[i], value);
+    }
+    return result;
+  }
+};
+
+// Explicit instantiations
+/// \cond
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                               \
+  template DTYPE(data) smallest_root_greater_than_value_within_roundoff(   \
+      const DTYPE(data) & a, const DTYPE(data) & b, const DTYPE(data) & c, \
+      double value) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
+
+#undef DTYPE
+#undef INSTANTIATE
+/// \endcond

--- a/src/NumericalAlgorithms/RootFinding/QuadraticEquation.hpp
+++ b/src/NumericalAlgorithms/RootFinding/QuadraticEquation.hpp
@@ -19,6 +19,17 @@ double positive_root(double a, double b, double c) noexcept;
 
 /*!
  * \ingroup NumericalAlgorithmsGroup
+ * \brief Returns the smallest root of a quadratic equation \f$ax^2 +
+ * bx + c = 0\f$ that is greater than the given value, within roundoff.
+ * \returns A root of a quadratic equation.
+ * \requires That there are two real roots.
+ */
+template <typename T>
+T smallest_root_greater_than_value_within_roundoff(const T& a, const T& b,
+                                                   const T& c,
+                                                   double value) noexcept;
+/*!
+ * \ingroup NumericalAlgorithmsGroup
  * \brief Returns the two real roots of a quadratic equation \f$ax^2 +
  * bx + c = 0\f$ with the root closer to \f$-\infty\f$ first.
  * \returns An array of the roots of a quadratic equation

--- a/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_Affine.cpp
   Test_BulgedCube.cpp
   Test_CoordinateMap.cpp
+  Test_CylindricalEndcap.cpp
   Test_DiscreteRotation.cpp
   Test_EquatorialCompression.cpp
   Test_Equiangular.cpp

--- a/tests/Unit/Domain/CoordinateMaps/Test_CylindricalEndcap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CylindricalEndcap.cpp
@@ -1,0 +1,218 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <boost/optional.hpp>
+#include <cmath>
+#include <gsl/gsl_poly.h>
+#include <random>
+
+#include "Domain/CoordinateMaps/CylindricalEndcap.hpp"
+#include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
+#include "NumericalAlgorithms/RootFinding/QuadraticEquation.hpp"
+
+namespace domain {
+namespace {
+void test_cylindrical_endcap() {
+  INFO("CylindricalEndcap");
+  // Set up random number generator
+  MAKE_GENERATOR(gen);
+
+  std::uniform_real_distribution<> unit_dis(0.0, 1.0);
+  std::uniform_real_distribution<> interval_dis(-1.0, 1.0);
+  std::uniform_real_distribution<> angle_dis(0.0, 2.0 * M_PI);
+
+  // Choose some random centers for sphere_one and sphere_two
+  const std::array<double, 3> center_one = {
+      interval_dis(gen), interval_dis(gen), interval_dis(gen)};
+  CAPTURE_PRECISE(center_one);
+  const std::array<double, 3> center_two = {
+      interval_dis(gen), interval_dis(gen), interval_dis(gen)};
+  CAPTURE_PRECISE(center_two);
+  const double dist_between_spheres =
+      sqrt(square(center_two[0] - center_one[0]) +
+           square(center_two[1] - center_one[1]) +
+           square(center_two[2] - center_one[2]));
+
+  // Pick radius of sphere_one not too small compared to the distance
+  // between the centers.
+  const double radius_one = 0.3 * dist_between_spheres + unit_dis(gen);
+  CAPTURE_PRECISE(radius_one);
+
+  // Make sure z_plane intersects sphere_one on the +z side of the
+  // center. We don't allow the plane to be displaced by less than 10%
+  // or more than 90% of the radius.
+  const double z_plane =
+      center_one[2] + (0.1 + 0.8 * unit_dis(gen)) * radius_one;
+  CAPTURE_PRECISE(z_plane);
+
+  // Now construct sphere_two which we make sure encloses sphere_one,
+  // but doesn't have too large of a radius.
+  const double radius_two =
+      (unit_dis(gen) + 1.0) * (radius_one + dist_between_spheres);
+  CAPTURE_PRECISE(radius_two);
+
+  const std::array<double, 3> proj_center = [
+    &z_plane, &center_one, &radius_one, &center_two, &radius_two, &gen,
+    &unit_dis, &angle_dis
+  ]() noexcept {
+    // Consider a cone formed by taking the intersection of z_plane and
+    // sphere_one (this is a circle called circle_one) and connecting it to
+    // center_one. Compute theta, where 2*theta is the opening angle of this
+    // cone. Call this cone 'cone_one'.
+    const double cos_theta = (z_plane - center_one[2]) / radius_one;
+
+    // We will construct two new cones. The first we will call
+    // cone_regular. It is constructed so that cone_regular and
+    // cone_one intersect each other on circle_one at right angles.
+    // Cone_regular opens in the -z direction with opening angle 2*(pi/2-theta).
+    // The apex of cone_regular is cone_regular_apex, defined as follows:
+    const std::array<double, 3> cone_regular_apex = {
+        center_one[0], center_one[1], center_one[2] + radius_one / cos_theta};
+    // A necessary condition for the map being
+    // invertible is that proj_center must lie either inside
+    // cone_regular (which opens in the -z direction and intersects
+    // cone_one), or proj_center must lie inside the reflection of
+    // cone_regular (which opens in the +z direction).  If proj_center
+    // is inside cone_regular (i.e. the one that opens in the -z
+    // direction), an additional condition for the map being
+    // invertible is that proj_center cannot lie between sphere_one
+    // and the center of cone_regular.
+
+    // The second cone we will construct we will call cone_opening.
+    // It will have some maximum opening angle that we choose freely.
+    const double max_opening_angle = M_PI / 3.0;
+    // max_opening_angle determines the maximum possible x-coordinate
+    // of proj_center.
+    const double max_proj_center_z =
+        z_plane -
+        radius_one * sqrt(1.0 - square(cos_theta)) / tan(max_opening_angle);
+    // Cone_opening has apex
+    // (center_one[0], center_one[1], max_proj_center_z). Note that if
+    // max_opening_angle > pi/4 and if z_plane > center_one[2] then
+    // the apex of cone_opening is inside sphere_one.
+
+    // Now that we have two cones, cone_regular and cone_opening.  We
+    // will choose proj_center so that it lies inside of both cones,
+    // and that it lies inside of sphere_two.
+    const double cone_regular_opening_angle = asin(cos_theta);
+
+    if (max_opening_angle < cone_regular_opening_angle) {
+      // The easier case.  We need to worry only about max_opening_angle.
+
+      // Choose some smaller cone inside of cone_opening.
+      // We will place proj_center on this smaller cone.
+      const double beta = unit_dis(gen) * max_opening_angle;
+
+      // Choose an azimuthal coordinate for the point on the cone.
+      const double phi = angle_dis(gen);
+
+      // Choose a radius for the point on the cone that will be
+      // proj_center. The point should be inside sphere_two.  So
+      // determine the radius at which the point intersects
+      // sphere_two. This radius is the solution of a quadratic equation
+      // ax^2 + bx + c = 0
+      const double a = 1.0;
+      const double b =
+          2.0 * (-(max_proj_center_z - center_two[2]) * cos(beta) +
+                 (center_one[0] - center_two[0]) * sin(beta) * cos(phi) +
+                 (center_one[1] - center_two[1]) * sin(beta) * sin(phi));
+      const double c = square(max_proj_center_z - center_two[2]) +
+                       square(center_one[0] - center_two[0]) +
+                       square(center_one[1] - center_two[1]) -
+                       square(radius_two);
+      ASSERT(c < 0.0,
+             "max_proj_center_z is too negative. The apex "
+             "is not inside sphere_two");
+      // Should be two real roots. Choose the positive one.
+      const double r_max = positive_root(a, b, c);
+
+      const double proj_radius = unit_dis(gen) * r_max;
+      return std::array<double, 3>{
+          center_one[0] + proj_radius * sin(beta) * cos(phi),
+          center_one[1] + proj_radius * sin(beta) * sin(phi),
+          max_proj_center_z - proj_radius * cos(beta)};
+    } else {
+      // The more difficult case.
+
+      // We may need to try several values of alpha.
+      // When one works, exit.
+      while (true) {
+        // Choose some smaller cone inside of cone_regular.
+        // We will place proj_center on this smaller cone.
+        // We do not allow the smaller cone to go all the way to
+        // cone_regular_opening_angle.
+        const double alpha = unit_dis(gen) * 0.95 * cone_regular_opening_angle;
+
+        // Consider the circle at which the smaller cone intersects
+        // cone_opening, and find the distance from cone_regular_apex to
+        // this circle.
+        const double radius_coord_circle =
+            (cone_regular_apex[2] - max_proj_center_z) *
+            tan(max_opening_angle) / (tan(max_opening_angle) - tan(alpha)) /
+            cos(alpha);
+
+        // Choose an azimuthal coordinate for the point on the cone.
+        const double phi = angle_dis(gen);
+
+        // Choose a radius for the point on the cone that will be
+        // proj_center. The point should be inside sphere_two.  So
+        // determine the radius at which the point intersects
+        // sphere_two. This radius is the solution of a quadratic equation
+        // ax^2 + bx + c = 0
+        const double a = 1.0;
+        const double b =
+            2.0 * (-(cone_regular_apex[2] - center_two[2]) * cos(alpha) +
+                   (center_one[0] - center_two[0]) * sin(alpha) * cos(phi) +
+                   (center_one[1] - center_two[1]) * sin(alpha) * sin(phi));
+        const double c = square(cone_regular_apex[2] - center_two[2]) +
+                         square(center_one[0] - center_two[0]) +
+                         square(center_one[1] - center_two[1]) -
+                         square(radius_two);
+
+        double x0 = std::numeric_limits<double>::signaling_NaN();
+        double x1 = std::numeric_limits<double>::signaling_NaN();
+        const int num_real_roots = gsl_poly_solve_quadratic(a, b, c, &x0, &x1);
+        double r_max = 0.0;
+        if (num_real_roots == 2) {
+          // Take the largest root.  The smallest one is negative if
+          // cone_regular_apex[0] is inside sphere_two, positive if
+          // cone_regular_apex[0] is outside sphere_two.
+          r_max = std::max(x0, x1);
+        } else if (num_real_roots == 1) {
+          r_max = x0;
+        } else {
+          ASSERT(false, "No roots were found. Something is horribly wrong.");
+        }
+
+        if (r_max <= radius_coord_circle) {
+          // We cannot satisfy all the conditions because sphere_two is
+          // too small. So try again with a different alpha.
+          continue;
+        }
+        const double proj_radius =
+            radius_coord_circle + unit_dis(gen) * (r_max - radius_coord_circle);
+        return std::array<double, 3>{
+            center_one[0] + proj_radius * sin(alpha) * cos(phi),
+            center_one[1] + proj_radius * sin(alpha) * sin(phi),
+            cone_regular_apex[2] - proj_radius * cos(alpha)};
+      }
+    }
+  }
+  ();
+  CAPTURE_PRECISE(proj_center);
+
+  const CoordinateMaps::CylindricalEndcap map(
+      center_one, center_two, proj_center, radius_one, radius_two, z_plane);
+  test_suite_for_map_on_cylinder(map);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.CylindricalEndcap",
+                  "[Domain][Unit]") {
+  test_cylindrical_endcap();
+  CHECK(not CoordinateMaps::CylindricalEndcap{}.is_identity());
+}
+}  // namespace domain

--- a/tests/Unit/NumericalAlgorithms/RootFinding/Test_QuadraticEquation.cpp
+++ b/tests/Unit/NumericalAlgorithms/RootFinding/Test_QuadraticEquation.cpp
@@ -6,8 +6,10 @@
 #include <algorithm>
 #include <array>
 
+#include "DataStructures/DataVector.hpp"
 #include "ErrorHandling/Error.hpp"
 #include "NumericalAlgorithms/RootFinding/QuadraticEquation.hpp"
+#include "Utilities/MakeWithValue.hpp"
 
 // [[OutputRegex, There are only 0 real roots]]
 [[noreturn]] SPECTRE_TEST_CASE(
@@ -42,6 +44,25 @@
 #endif
 }
 
+namespace {
+  template <typename T>
+  void test_smallest_root_greater_than_value_within_roundoff(
+      const T& used_for_size) noexcept {
+    const auto a = make_with_value<T>(used_for_size, 2.0);
+    const auto b = make_with_value<T>(used_for_size, -11.0);
+    const auto c = make_with_value<T>(used_for_size, 5.0);
+    const auto expected_root_1 = make_with_value<T>(used_for_size, 0.5);
+    const auto expected_root_2 = make_with_value<T>(used_for_size, 5.0);
+
+    auto root = smallest_root_greater_than_value_within_roundoff(a, b, c, 0.3);
+    CHECK_ITERABLE_APPROX(expected_root_1, root);
+    root = smallest_root_greater_than_value_within_roundoff(a, b, c, 0.5);
+    CHECK_ITERABLE_APPROX(expected_root_1, root);
+    root = smallest_root_greater_than_value_within_roundoff(a, b, c, 0.6);
+    CHECK_ITERABLE_APPROX(expected_root_2, root);
+  }
+}  // namespace
+
 SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.QuadraticEquation",
                   "[NumericalAlgorithms][RootFinding][Unit]") {
   // Positive root
@@ -60,4 +81,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.QuadraticEquation",
   const auto small_negative = real_roots(1e-8, -(1.0 - 1e-16), -1e-8);
   CHECK(approx(-1e-8) == small_negative[0]);
   CHECK(approx(1e8) == small_negative[1]);
+
+  test_smallest_root_greater_than_value_within_roundoff<double>(1.0);
+  test_smallest_root_greater_than_value_within_roundoff(DataVector(2));
 }


### PR DESCRIPTION
Adds a map from a 3D unit right cylinder to a volume that connects portions of two spherical surfaces.

CylindricalEndcap is intended to be composed with Wedge2D maps to
construct the "endcap" portion of a cylindrical domain for a binary system.

## Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
