### PR TITLE
Replace make_overloader as wrapper for EquationOfState

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.cpp
@@ -83,8 +83,7 @@ void compute_characteristic_speeds(
 }
 }  // namespace
 
-namespace grmhd {
-namespace ValenciaDivClean {
+namespace grmhd::ValenciaDivClean {
 template <size_t ThermodynamicDim>
 void characteristic_speeds(
     const gsl::not_null<std::array<DataVector, 9>*> char_speeds,
@@ -240,6 +239,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
 
 #undef GET_DIM
 #undef INSTANTIATION
-}  // namespace ValenciaDivClean
-}  // namespace grmhd
+}  // namespace grmhd::ValenciaDivClean
 /// \endcond

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.cpp
@@ -18,9 +18,7 @@
 // IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
 
 /// \cond
-namespace grmhd {
-namespace ValenciaDivClean {
-namespace PrimitiveRecoverySchemes {
+namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes {
 
 template <size_t ThermodynamicDim>
 boost::optional<PrimitiveRecoveryData> NewmanHamlin::apply(
@@ -172,9 +170,7 @@ boost::optional<PrimitiveRecoveryData> NewmanHamlin::apply(
                 relative_tolerance_ * (current_pressure + previous_pressure);
   }  // while loop
 }
-}  // namespace PrimitiveRecoverySchemes
-}  // namespace ValenciaDivClean
-}  // namespace grmhd
+}  // namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes
 
 #define THERMODIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define INSTANTIATION(_, data)                                                 \

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.cpp
@@ -6,6 +6,7 @@
 #include <boost/none.hpp>
 #include <cmath>
 #include <exception>
+#include <limits>
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveRecoveryData.hpp"
@@ -16,9 +17,7 @@
 // IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
 
 /// \cond
-namespace grmhd {
-namespace ValenciaDivClean {
-namespace PrimitiveRecoverySchemes {
+namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes {
 
 namespace {
 
@@ -117,7 +116,8 @@ boost::optional<PrimitiveRecoveryData> PalenzuelaEtAl::apply(
                                     magnetic_field_squared,
                                     rest_mass_density_times_lorentz_factor,
                                     equation_of_state};
-  double specific_enthalpy_times_lorentz_factor;
+  double specific_enthalpy_times_lorentz_factor =
+      std::numeric_limits<double>::signaling_NaN();
   try {
     specific_enthalpy_times_lorentz_factor =
         // NOLINTNEXTLINE(clang-analyzer-core)
@@ -147,9 +147,7 @@ boost::optional<PrimitiveRecoveryData> PalenzuelaEtAl::apply(
                                specific_enthalpy_times_lorentz_factor *
                                    rest_mass_density_times_lorentz_factor};
 }
-}  // namespace PrimitiveRecoverySchemes
-}  // namespace ValenciaDivClean
-}  // namespace grmhd
+}  // namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes
 
 #define THERMODIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define INSTANTIATION(_, data)                                                 \

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
@@ -33,8 +33,7 @@
 // IWYU pragma: no_forward_declare Tensor
 
 /// \cond
-namespace grmhd {
-namespace ValenciaDivClean {
+namespace grmhd::ValenciaDivClean {
 
 template <typename OrderedListOfPrimitiveRecoverySchemes,
           size_t ThermodynamicDim>
@@ -173,8 +172,7 @@ void PrimitiveFromConservative<OrderedListOfPrimitiveRecoverySchemes,
   *specific_enthalpy = hydro::relativistic_specific_enthalpy(
       *rest_mass_density, *specific_internal_energy, *pressure);
 }
-}  // namespace ValenciaDivClean
-}  // namespace grmhd
+}  // namespace grmhd::ValenciaDivClean
 
 #define RECOVERY(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define THERMODIM(data) BOOST_PP_TUPLE_ELEM(1, data)

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
@@ -25,7 +25,6 @@
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
-#include "Utilities/Overloader.hpp"
 #include "Utilities/TMPL.hpp"
 
 // IWYU pragma: no_include <array>
@@ -162,19 +161,15 @@ void PrimitiveFromConservative<OrderedListOfPrimitiveRecoverySchemes,
             << "previous_lorentz_factor = " << get(*lorentz_factor)[s] << "\n");
     }
   }
-  *specific_internal_energy = make_overloader(
-      [&rest_mass_density](const EquationsOfState::EquationOfState<true, 1>&
-                               the_equation_of_state) noexcept {
-        return the_equation_of_state.specific_internal_energy_from_density(
+  if constexpr (ThermodynamicDim == 1) {
+    *specific_internal_energy =
+        equation_of_state.specific_internal_energy_from_density(
             *rest_mass_density);
-      },
-      [&rest_mass_density,
-       &pressure ](const EquationsOfState::EquationOfState<true, 2>&
-                       the_equation_of_state) noexcept {
-        return the_equation_of_state
-            .specific_internal_energy_from_density_and_pressure(
-                *rest_mass_density, *pressure);
-      })(equation_of_state);
+  } else if constexpr (ThermodynamicDim == 2) {
+    *specific_internal_energy =
+        equation_of_state.specific_internal_energy_from_density_and_pressure(
+            *rest_mass_density, *pressure);
+  }
   *specific_enthalpy = hydro::relativistic_specific_enthalpy(
       *rest_mass_density, *specific_internal_energy, *pressure);
 }

--- a/src/Evolution/Systems/NewtonianEuler/SoundSpeedSquared.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/SoundSpeedSquared.cpp
@@ -11,7 +11,6 @@
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
-#include "Utilities/Overloader.hpp"
 
 // IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
 
@@ -26,25 +25,19 @@ void sound_speed_squared(
     const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
         equation_of_state) noexcept {
   destructive_resize_components(result, get_size(get(mass_density)));
-  make_overloader(
-      [&mass_density,
-       &result ](const EquationsOfState::EquationOfState<false, 1>&
-                     the_equation_of_state) noexcept {
-        get(*result) =
-            get(the_equation_of_state.chi_from_density(mass_density)) +
-            get(the_equation_of_state
-                    .kappa_times_p_over_rho_squared_from_density(mass_density));
-      },
-      [&mass_density, &specific_internal_energy,
-       &result ](const EquationsOfState::EquationOfState<false, 2>&
-                     the_equation_of_state) noexcept {
-        get(*result) =
-            get(the_equation_of_state.chi_from_density_and_energy(
-                mass_density, specific_internal_energy)) +
-            get(the_equation_of_state
-                    .kappa_times_p_over_rho_squared_from_density_and_energy(
-                        mass_density, specific_internal_energy));
-      })(equation_of_state);
+  if constexpr (ThermodynamicDim == 1) {
+    get(*result) =
+        get(equation_of_state.chi_from_density(mass_density)) +
+        get(equation_of_state.kappa_times_p_over_rho_squared_from_density(
+            mass_density));
+  } else if constexpr (ThermodynamicDim == 2) {
+    get(*result) =
+        get(equation_of_state.chi_from_density_and_energy(
+            mass_density, specific_internal_energy)) +
+        get(equation_of_state
+                .kappa_times_p_over_rho_squared_from_density_and_energy(
+                    mass_density, specific_internal_energy));
+  }
 }
 
 template <typename DataType, size_t ThermodynamicDim>

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/Characteristics.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/Characteristics.cpp
@@ -13,7 +13,6 @@
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
-#include "Utilities/Overloader.hpp"
 #include "Utilities/TMPL.hpp"
 
 // IWYU pragma: no_forward_declare Tensor
@@ -170,7 +169,7 @@ Matrix right_eigenvectors(const Scalar<double>& rest_mass_density,
   }
 
   // if Dim > 1 set degenerate eigenvectors
-  if (Dim > 1) {
+  if constexpr (Dim > 1) {
     const double two_h_w_minus_one =
         h_w_minus_one + specific_enthalpy_times_lorentz_factor;
     const auto unit_tangent_oneform =
@@ -196,26 +195,12 @@ Matrix right_eigenvectors(const Scalar<double>& rest_mass_density,
     };
     set_degenerate_eigenvector(1, unit_tangent_oneform);
 
-    if (Dim > 2) {
+    if constexpr (Dim > 2) {
       // orthonormal_oneform for two forms is defined for 3-d only
-      // so it needs to be called from a make_overloader.
-      make_overloader([](std::integral_constant<size_t, 1> /*dim*/,
-                         const auto&...) noexcept {},
-                      [](std::integral_constant<size_t, 2> /*dim*/,
-                         const auto&...) noexcept {},
-                      [&set_degenerate_eigenvector](
-                          std::integral_constant<size_t, 3> /*dim*/,
-                          const auto& the_unit_normal,
-                          const auto& the_unit_tangent_oneform,
-                          const auto& the_spatial_metric,
-                          const auto& the_det_spatial_metric) noexcept {
-                        set_degenerate_eigenvector(
-                            2, orthonormal_oneform<double, Frame::Inertial>(
-                                   the_unit_normal, the_unit_tangent_oneform,
-                                   the_spatial_metric, the_det_spatial_metric));
-                      })(std::integral_constant<size_t, Dim>{}, unit_normal,
-                         unit_tangent_oneform, spatial_metric,
-                         det_spatial_metric);
+      set_degenerate_eigenvector(
+          2, orthonormal_oneform<double, Frame::Inertial>(
+                 unit_normal, unit_tangent_oneform, spatial_metric,
+                 det_spatial_metric));
     }
   }
 
@@ -323,7 +308,7 @@ Matrix left_eigenvectors(const Scalar<double>& rest_mass_density,
   result(eigenvector_id, 1) *= -1.0;
 
   // if Dim > 1 set degenerate eigenvectors
-  if (Dim > 1) {
+  if constexpr (Dim > 1) {
     const double prefactor = -inv_specific_enthalpy / one_minus_vn_squared;
     const auto unit_tangent_oneform =
         orthonormal_oneform(unit_normal, inv_spatial_metric);
@@ -346,26 +331,12 @@ Matrix left_eigenvectors(const Scalar<double>& rest_mass_density,
     };
     set_degenerate_eigenvector(1, unit_tangent_oneform);
 
-    if (Dim > 2) {
+    if constexpr (Dim > 2) {
       // orthonormal_oneform for two forms is defined for 3-d only
-      // so it needs to be called from a make_overloader.
-      make_overloader([](std::integral_constant<size_t, 1> /*dim*/,
-                         const auto&...) noexcept {},
-                      [](std::integral_constant<size_t, 2> /*dim*/,
-                         const auto&...) noexcept {},
-                      [&set_degenerate_eigenvector](
-                          std::integral_constant<size_t, 3> /*dim*/,
-                          const auto& the_unit_normal,
-                          const auto& the_unit_tangent_oneform,
-                          const auto& the_spatial_metric,
-                          const auto& the_det_spatial_metric) noexcept {
-                        set_degenerate_eigenvector(
-                            2, orthonormal_oneform<double, Frame::Inertial>(
-                                   the_unit_normal, the_unit_tangent_oneform,
-                                   the_spatial_metric, the_det_spatial_metric));
-                      })(std::integral_constant<size_t, Dim>{}, unit_normal,
-                         unit_tangent_oneform, spatial_metric,
-                         det_spatial_metric);
+      set_degenerate_eigenvector(
+          2, orthonormal_oneform<double, Frame::Inertial>(
+                 unit_normal, unit_tangent_oneform, spatial_metric,
+                 det_spatial_metric));
     }
   }
 

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/Characteristics.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/Characteristics.cpp
@@ -18,8 +18,7 @@
 // IWYU pragma: no_forward_declare Tensor
 
 /// \cond
-namespace RelativisticEuler {
-namespace Valencia {
+namespace RelativisticEuler::Valencia {
 
 template <size_t Dim>
 void characteristic_speeds(
@@ -343,8 +342,7 @@ Matrix left_eigenvectors(const Scalar<double>& rest_mass_density,
   return result;
 }
 
-}  // namespace Valencia
-}  // namespace RelativisticEuler
+}  // namespace RelativisticEuler::Valencia
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/PrimitiveFromConservative.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/PrimitiveFromConservative.cpp
@@ -19,8 +19,7 @@
 // IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
 
 /// \cond
-namespace RelativisticEuler {
-namespace Valencia {
+namespace RelativisticEuler::Valencia {
 
 namespace {
 
@@ -154,6 +153,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
 #undef INSTANTIATION
 #undef THERMODIM
 #undef DIM
-}  // namespace Valencia
-}  // namespace RelativisticEuler
+}  // namespace RelativisticEuler::Valencia
 /// \endcond

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/PrimitiveFromConservative.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/PrimitiveFromConservative.cpp
@@ -15,7 +15,6 @@
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
-#include "Utilities/Overloader.hpp"
 
 // IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
 
@@ -53,19 +52,14 @@ class FunctionOfZ {
     const double epsilon = W * q - z * r + square(z) / (1.0 + W);
     const double e = rho * (1.0 + epsilon);
 
-    const double pressure =
-        make_overloader(
-            [&rho](const EquationsOfState::EquationOfState<true, 1>&
-                       equation_of_state) noexcept {
-              return equation_of_state.pressure_from_density(
-                  Scalar<double>(rho));
-            },
-            [&rho, &epsilon ](const EquationsOfState::EquationOfState<true, 2>&
-                                  equation_of_state) noexcept {
-              return equation_of_state.pressure_from_density_and_energy(
-                  Scalar<double>(rho), Scalar<double>(epsilon));
-            })(equation_of_state_)
-            .get();
+    double pressure = std::numeric_limits<double>::signaling_NaN();
+    if constexpr (ThermodynamicDim == 1) {
+      pressure =
+          get(equation_of_state_.pressure_from_density(Scalar<double>(rho)));
+    } else if constexpr (ThermodynamicDim == 2) {
+      pressure = get(equation_of_state_.pressure_from_density_and_energy(
+          Scalar<double>(rho), Scalar<double>(epsilon)));
+    }
 
     const double a = pressure / e;
     const double h = (1.0 + epsilon) * (1.0 + a);
@@ -131,17 +125,12 @@ void PrimitiveFromConservative<ThermodynamicDim, Dim>::apply(
           get(tilde_d) +
       square(z) / (1.0 + get(*lorentz_factor));
 
-  *pressure = make_overloader(
-      [&rest_mass_density](const EquationsOfState::EquationOfState<true, 1>&
-                               the_equation_of_state) noexcept {
-        return the_equation_of_state.pressure_from_density(*rest_mass_density);
-      },
-      [&rest_mass_density, &specific_internal_energy ](
-          const EquationsOfState::EquationOfState<true, 2>&
-              the_equation_of_state) noexcept {
-        return the_equation_of_state.pressure_from_density_and_energy(
-            *rest_mass_density, *specific_internal_energy);
-      })(equation_of_state);
+  if constexpr (ThermodynamicDim == 1) {
+    *pressure = equation_of_state.pressure_from_density(*rest_mass_density);
+  } else if constexpr (ThermodynamicDim == 2) {
+    *pressure = equation_of_state.pressure_from_density_and_energy(
+        *rest_mass_density, *specific_internal_energy);
+  }
 
   get(*specific_enthalpy) = 1.0 + get(*specific_internal_energy) +
                             get(*pressure) / get(*rest_mass_density);

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_PrimitiveFromConservative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_PrimitiveFromConservative.cpp
@@ -27,14 +27,10 @@
 // IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
 // IWYU pragma: no_forward_declare Tensor
 
-namespace grmhd {
-namespace ValenciaDivClean {
-namespace PrimitiveRecoverySchemes {
+namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes {
 class NewmanHamlin;
 class PalenzuelaEtAl;
-}  // namespace PrimitiveRecoverySchemes
-}  // namespace ValenciaDivClean
-}  // namespace grmhd
+}  // namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes
 
 namespace {
 

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_PrimitiveFromConservative.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_PrimitiveFromConservative.cpp
@@ -22,7 +22,6 @@
 #include "PointwiseFunctions/Hydro/SpecificEnthalpy.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
-#include "Utilities/Overloader.hpp"
 
 // IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
 
@@ -42,33 +41,22 @@ void test_primitive_from_conservative(
       TestHelpers::gr::random_spatial_metric<Dim>(generator, used_for_size);
   const auto expected_spatial_velocity = TestHelpers::hydro::random_velocity(
       generator, expected_lorentz_factor, spatial_metric);
-  const auto expected_specific_internal_energy = make_overloader(
-      [&expected_rest_mass_density](
-          const EquationsOfState::EquationOfState<true, 1>&
-              the_equation_of_state) noexcept {
-        return the_equation_of_state.specific_internal_energy_from_density(
+  Scalar<DataVector> expected_specific_internal_energy{};
+  Scalar<DataVector> expected_pressure{};
+  if constexpr (ThermodynamicDim == 1) {
+    expected_specific_internal_energy =
+        equation_of_state.specific_internal_energy_from_density(
             expected_rest_mass_density);
-      },
-      [&generator,
-       &used_for_size ](const EquationsOfState::EquationOfState<true, 2>&
-                        /*the_equation_of_state*/) noexcept {
-        // note this call assumes an ideal fluid
-        return TestHelpers::hydro::random_specific_internal_energy(
-            generator, used_for_size);
-      })(equation_of_state);
-  const auto expected_pressure = make_overloader(
-      [&expected_rest_mass_density](
-          const EquationsOfState::EquationOfState<true, 1>&
-              the_equation_of_state) noexcept {
-        return the_equation_of_state.pressure_from_density(
-            expected_rest_mass_density);
-      },
-      [&expected_rest_mass_density, &expected_specific_internal_energy ](
-          const EquationsOfState::EquationOfState<true, 2>&
-              the_equation_of_state) noexcept {
-        return the_equation_of_state.pressure_from_density_and_energy(
-            expected_rest_mass_density, expected_specific_internal_energy);
-      })(equation_of_state);
+    expected_pressure =
+        equation_of_state.pressure_from_density(expected_rest_mass_density);
+  } else if constexpr (ThermodynamicDim == 2) {
+    // note this call assumes an ideal fluid
+    expected_specific_internal_energy =
+        TestHelpers::hydro::random_specific_internal_energy(generator,
+                                                            used_for_size);
+    expected_pressure = equation_of_state.pressure_from_density_and_energy(
+        expected_rest_mass_density, expected_specific_internal_energy);
+  }
 
   const auto expected_specific_enthalpy = hydro::relativistic_specific_enthalpy(
       expected_rest_mass_density, expected_specific_internal_energy,


### PR DESCRIPTION
## Proposed changes

EquationOfState calls use a different interface based on the ThermodynamicDim of the equation of state. Previously, switching between different interfaces was done by wrapping the calls inside lambdas inside `make_overloader`. Now we have access to c++17 and `if constexpr`, so this PR updates the equation of state call wrappers to `if constexpr`.

This is usually a very simple change, except in the (non-MHD) Valencia characteristic test, where I had to change a lambda to a function to expose the ThermodynamicDim template parameter.

Also fix a few clang-tidy complaints... but I still expect this PR to fail clang-tidy due to the usual boost rootfinder false-positives.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
