### PR TITLE
Housekeeping in limiter code

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Limiters/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/CMakeLists.txt
@@ -3,7 +3,11 @@
 
 set(LIBRARY Limiters)
 
-set(LIBRARY_SOURCES
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
   HwenoImpl.cpp
   Minmod.cpp
   MinmodHelpers.cpp
@@ -15,7 +19,28 @@ set(LIBRARY_SOURCES
   WenoType.cpp
   )
 
-add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  HwenoImpl.hpp
+  Krivodonova.hpp
+  LimiterActions.hpp
+  Limiters.hpp
+  Minmod.hpp
+  Minmod.tpp
+  MinmodHelpers.hpp
+  MinmodTci.hpp
+  MinmodType.hpp
+  SimpleWenoImpl.hpp
+  Tags.hpp
+  Tci.hpp
+  Weno.hpp
+  WenoGridHelpers.hpp
+  WenoHelpers.hpp
+  WenoOscillationIndicator.hpp
+  WenoType.hpp
+  )
 
 target_link_libraries(
   ${LIBRARY}
@@ -23,7 +48,7 @@ target_link_libraries(
   Boost::boost
   DataStructures
   Domain
-  Interpolation  # for WENO
+  Interpolation
   LinearOperators
   Options
   )

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/HwenoImpl.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/HwenoImpl.cpp
@@ -108,8 +108,7 @@ Matrix volume_interpolation_matrix(
 
 }  // namespace
 
-namespace Limiters {
-namespace Weno_detail {
+namespace Limiters::Weno_detail {
 
 template <size_t VolumeDim>
 Matrix inverse_a_matrix(
@@ -342,5 +341,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 #undef DIM
 #undef INSTANTIATE
 
-}  // namespace Weno_detail
-}  // namespace Limiters
+}  // namespace Limiters::Weno_detail

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/HwenoImpl.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/HwenoImpl.cpp
@@ -81,7 +81,8 @@ Matrix volume_interpolation_matrix(
   // direction is identity). This function undoes the optimization by returning
   // elements of an identity matrix if an empty matrix is found.
   const auto matrix_element = [&interpolation_matrices_1d](
-      const size_t dim, const size_t r, const size_t s) noexcept {
+                                  const size_t dim, const size_t r,
+                                  const size_t s) noexcept {
     const auto& matrix = gsl::at(interpolation_matrices_1d, dim);
     if (matrix.rows() * matrix.columns() == 0) {
       return (r == s) ? 1. : 0.;
@@ -125,15 +126,14 @@ Matrix inverse_a_matrix(
   Matrix a(number_of_grid_points, number_of_grid_points, 0.);
 
   // Loop only over directions where there is a neighbor
-  const std::vector<Direction<VolumeDim>>
-      directions_with_neighbors = [&element]() noexcept {
-    std::vector<Direction<VolumeDim>> result;
-    for (const auto& dir_and_neighbors : element.neighbors()) {
-      result.push_back(dir_and_neighbors.first);
-    }
-    return result;
-  }
-  ();
+  const std::vector<Direction<VolumeDim>> directions_with_neighbors =
+      [&element]() noexcept {
+        std::vector<Direction<VolumeDim>> result;
+        for (const auto& dir_and_neighbors : element.neighbors()) {
+          result.push_back(dir_and_neighbors.first);
+        }
+        return result;
+      }();
 
   // Sanity check that directions_to_exclude is consistent with the element
   ASSERT(
@@ -189,15 +189,14 @@ ConstrainedFitCache<VolumeDim>::ConstrainedFitCache(
     const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh) noexcept
     : quadrature_weights(volume_quadrature_weights(mesh)) {
   // Cache will only store quantities for directions that have neighbors.
-  const std::vector<Direction<VolumeDim>>
-      directions_with_neighbors = [&element]() noexcept {
-    std::vector<Direction<VolumeDim>> result;
-    for (const auto& dir_and_neighbors : element.neighbors()) {
-      result.push_back(dir_and_neighbors.first);
-    }
-    return result;
-  }
-  ();
+  const std::vector<Direction<VolumeDim>> directions_with_neighbors =
+      [&element]() noexcept {
+        std::vector<Direction<VolumeDim>> result;
+        for (const auto& dir_and_neighbors : element.neighbors()) {
+          result.push_back(dir_and_neighbors.first);
+        }
+        return result;
+      }();
 
   for (const auto& dir : directions_with_neighbors) {
     interpolation_matrices[dir] =
@@ -307,8 +306,7 @@ const ConstrainedFitCache<VolumeDim>& constrained_fit_cache(
       }
     }
     return static_cast<size_t>(bits.to_ulong());
-  }
-  ();
+  }();
   ASSERT(index_from_boundary_types >= 0 and
              index_from_boundary_types < sizeof...(Is),
          "Got index_from_boundary_types = "

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/HwenoImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/HwenoImpl.hpp
@@ -39,8 +39,7 @@ template <size_t>
 class Mesh;
 /// \endcond
 
-namespace Limiters {
-namespace Weno_detail {
+namespace Limiters::Weno_detail {
 
 // Caching class that holds various precomputed terms used in the constrained-
 // fit algebra on each element.
@@ -578,5 +577,4 @@ void hweno_impl(
   }
 }
 
-}  // namespace Weno_detail
-}  // namespace Limiters
+}  // namespace Limiters::Weno_detail

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/HwenoImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/HwenoImpl.hpp
@@ -160,13 +160,14 @@ secondary_neighbors_to_exclude_from_fit(
   }
 
   // Identify element with maximum mean difference
-  const auto mean_difference = [&tensor_index, &local_mean ](
-      const std::pair<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>,
-                      Package>& neighbor_and_data) noexcept {
-    return fabs(
-        get<::Tags::Mean<Tag>>(neighbor_and_data.second.means)[tensor_index] -
-        local_mean);
-  };
+  const auto mean_difference =
+      [&tensor_index, &local_mean](
+          const std::pair<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>,
+                          Package>& neighbor_and_data) noexcept {
+        return fabs(get<::Tags::Mean<Tag>>(
+                        neighbor_and_data.second.means)[tensor_index] -
+                    local_mean);
+      };
 
   double max_difference = std::numeric_limits<double>::lowest();
   std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>
@@ -269,8 +270,7 @@ DataVector b_vector(
               neighbor_tensor_component[r] * neighbor_quadrature_weights[r];
         }
         return result;
-      }
-      ();
+      }();
       b += quadrature_weights_dot_u *
            quadrature_weights_dot_interpolation_matrix;
     }
@@ -308,15 +308,14 @@ void solve_constrained_fit(
   // Because we don't support h-refinement, the direction is the only piece
   // of the neighbor information that we actually need.
   const Direction<VolumeDim> primary_direction = primary_neighbor.first;
-  const std::vector<Direction<VolumeDim>>
-      directions_to_exclude = [&neighbors_to_exclude]() noexcept {
-    std::vector<Direction<VolumeDim>> result(neighbors_to_exclude.size());
-    for (size_t i = 0; i < result.size(); ++i) {
-      result[i] = neighbors_to_exclude[i].first;
-    }
-    return result;
-  }
-  ();
+  const std::vector<Direction<VolumeDim>> directions_to_exclude =
+      [&neighbors_to_exclude]() noexcept {
+        std::vector<Direction<VolumeDim>> result(neighbors_to_exclude.size());
+        for (size_t i = 0; i < result.size(); ++i) {
+          result[i] = neighbors_to_exclude[i].first;
+        }
+        return result;
+      }();
 
   const DataVector& w = cache.quadrature_weights;
   const DirectionMap<VolumeDim, Matrix>& interp_matrices =
@@ -348,9 +347,9 @@ void solve_constrained_fit(
   // Compute Lagrange multiplier:
   // Note: we take w as an argument (instead of as a lambda capture), because
   //       some versions of Clang incorrectly warn about capturing w.
-  const double lagrange_multiplier =
-      [&number_of_points, &inverse_a_times_b, &inverse_a_times_w, &
-       u ](const DataVector& local_w) noexcept {
+  const double lagrange_multiplier = [&number_of_points, &inverse_a_times_b,
+                                      &inverse_a_times_w,
+                                      &u](const DataVector& local_w) noexcept {
     double numerator = 0.;
     double denominator = 0.;
     for (size_t s = 0; s < number_of_points; ++s) {
@@ -358,8 +357,7 @@ void solve_constrained_fit(
       denominator += local_w[s] * inverse_a_times_w[s];
     }
     return -numerator / denominator;
-  }
-  (w);
+  }(w);
 
   // Compute solution:
   *constrained_fit_result =
@@ -539,21 +537,22 @@ void hweno_impl(
         std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, PackagedData,
         boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
         neighbor_data) noexcept {
-  ASSERT(modified_neighbor_solution_buffer->size() == neighbor_data.size(),
-         "modified_neighbor_solution_buffer->size() = "
-         << modified_neighbor_solution_buffer->size()
-         << "\nneighbor_data.size() = " << neighbor_data.size()
-         << "\nmodified_neighbor_solution_buffer was incorrectly initialized "
-            "before calling hweno_impl.");
+  ASSERT(
+      modified_neighbor_solution_buffer->size() == neighbor_data.size(),
+      "modified_neighbor_solution_buffer->size() = "
+          << modified_neighbor_solution_buffer->size()
+          << "\nneighbor_data.size() = " << neighbor_data.size()
+          << "\nmodified_neighbor_solution_buffer was incorrectly initialized "
+             "before calling hweno_impl.");
 
-  alg::for_each(neighbor_data, [&element, &
-                                mesh ](const auto& neighbor_and_data) noexcept {
-    ASSERT(Weno_detail::check_element_has_one_similar_neighbor_in_direction(
-               element, neighbor_and_data.first.first),
-           "Found some amount of h-refinement; this is not supported");
-    ASSERT(neighbor_and_data.second.mesh == mesh,
-           "Found some amount of p-refinement; this is not supported");
-  });
+  alg::for_each(
+      neighbor_data, [&element, &mesh](const auto& neighbor_and_data) noexcept {
+        ASSERT(Weno_detail::check_element_has_one_similar_neighbor_in_direction(
+                   element, neighbor_and_data.first.first),
+               "Found some amount of h-refinement; this is not supported");
+        ASSERT(neighbor_and_data.second.mesh == mesh,
+               "Found some amount of p-refinement; this is not supported");
+      });
 
   for (size_t tensor_index = 0; tensor_index < tensor->size(); ++tensor_index) {
     const auto& tensor_component = (*tensor)[tensor_index];

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Krivodonova.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Krivodonova.hpp
@@ -650,16 +650,16 @@ bool Krivodonova<VolumeDim, tmpl::list<Tags...>>::operator()(
 
   // transform back to nodal coefficients
   const auto wrap_copy_nodal_coeffs =
-      [&mesh, &coeffs_self ](auto tag, const auto tensor) noexcept {
-    auto& coeffs_tensor = get<decltype(tag)>(coeffs_self);
-    auto tensor_it = tensor->begin();
-    for (auto coeffs_it = coeffs_tensor.begin();
-         coeffs_it != coeffs_tensor.end();
-         (void)++coeffs_it, (void)++tensor_it) {
-      to_nodal_coefficients(make_not_null(&*tensor_it), *coeffs_it, mesh);
-    }
-    return '0';
-  };
+      [&mesh, &coeffs_self](auto tag, const auto tensor) noexcept {
+        auto& coeffs_tensor = get<decltype(tag)>(coeffs_self);
+        auto tensor_it = tensor->begin();
+        for (auto coeffs_it = coeffs_tensor.begin();
+             coeffs_it != coeffs_tensor.end();
+             (void)++coeffs_it, (void)++tensor_it) {
+          to_nodal_coefficients(make_not_null(&*tensor_it), *coeffs_it, mesh);
+        }
+        return '0';
+      };
   expand_pack(wrap_copy_nodal_coeffs(::Tags::Modal<Tags>{}, tensors)...);
 
   return limited_any_component;
@@ -721,9 +721,9 @@ char Krivodonova<VolumeDim, tmpl::list<Tags...>>::limit_one_tensor(
         boost::hash<std::pair<Direction<2>, ElementId<2>>>>& neighbor_data)
     const noexcept {
   using tensor_type = typename Tag::type;
-  const auto minmod = [&coeffs_self, &mesh, &neighbor_data, this ](
-      const size_t local_i, const size_t local_j,
-      const size_t local_tensor_storage_index) noexcept {
+  const auto minmod = [&coeffs_self, &mesh, &neighbor_data, this](
+                          const size_t local_i, const size_t local_j,
+                          const size_t local_tensor_storage_index) noexcept {
     const auto& self_coeffs =
         get<Tag>(*coeffs_self)[local_tensor_storage_index];
     double min_abs_coeff = std::abs(
@@ -809,9 +809,10 @@ char Krivodonova<VolumeDim, tmpl::list<Tags...>>::limit_one_tensor(
         boost::hash<std::pair<Direction<3>, ElementId<3>>>>& neighbor_data)
     const noexcept {
   using tensor_type = typename Tag::type;
-  const auto minmod = [&coeffs_self, &mesh, &neighbor_data, this ](
-      const size_t local_i, const size_t local_j, const size_t local_k,
-      const size_t local_tensor_storage_index) noexcept {
+  const auto minmod = [&coeffs_self, &mesh, &neighbor_data, this](
+                          const size_t local_i, const size_t local_j,
+                          const size_t local_k,
+                          const size_t local_tensor_storage_index) noexcept {
     const auto& self_coeffs =
         get<Tag>(*coeffs_self)[local_tensor_storage_index];
     double min_abs_coeff = std::abs(self_coeffs[mesh.storage_index(

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Krivodonova.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Krivodonova.hpp
@@ -483,7 +483,7 @@ class Krivodonova<VolumeDim, tmpl::list<Tags...>> {
   Krivodonova& operator=(Krivodonova&&) = default;
   ~Krivodonova() = default;
 
-  // NOLINTNEXTLINE(google-runtime-reference)
+  // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) noexcept;
 
   bool operator==(const Krivodonova& rhs) const noexcept;

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.cpp
@@ -33,12 +33,11 @@ bool minmod_limited_slopes(
     const std::array<double, VolumeDim>& element_size,
     const DirectionMap<VolumeDim, double>& effective_neighbor_means,
     const DirectionMap<VolumeDim, double>& effective_neighbor_sizes) noexcept {
-  const double tvb_scale = [&tvb_constant, &element_size ]() noexcept {
+  const double tvb_scale = [&tvb_constant, &element_size]() noexcept {
     const double max_h =
         *std::max_element(element_size.begin(), element_size.end());
     return tvb_constant * square(max_h);
-  }
-  ();
+  }();
 
   // Results from SpECTRE paper (https://arxiv.org/abs/1609.00098) used a
   // max_slope_factor a factor of 2.0 too small, so that LambdaPi1 behaved
@@ -48,14 +47,13 @@ bool minmod_limited_slopes(
 
   *u_mean = mean_value(u, mesh);
 
-  const auto difference_to_neighbor = [
-    &u_mean, &element, &element_size, &effective_neighbor_means, &
-    effective_neighbor_sizes
-  ](const size_t dim, const Side& side) noexcept {
-    return effective_difference_to_neighbor(*u_mean, element, element_size, dim,
-                                            side, effective_neighbor_means,
-                                            effective_neighbor_sizes);
-  };
+  const auto difference_to_neighbor =
+      [&u_mean, &element, &element_size, &effective_neighbor_means,
+       &effective_neighbor_sizes](const size_t dim, const Side& side) noexcept {
+        return effective_difference_to_neighbor(
+            *u_mean, element, element_size, dim, side, effective_neighbor_means,
+            effective_neighbor_sizes);
+      };
 
   // The LambdaPiN limiter calls a simple troubled-cell indicator to avoid
   // limiting solutions that appear smooth:

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.cpp
@@ -18,8 +18,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
 
-namespace Limiters {
-namespace Minmod_detail {
+namespace Limiters::Minmod_detail {
 
 template <size_t VolumeDim>
 bool minmod_limited_slopes(
@@ -144,5 +143,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 #undef DIM
 #undef INSTANTIATE
 
-}  // namespace Minmod_detail
-}  // namespace Limiters
+}  // namespace Limiters::Minmod_detail

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp
@@ -54,8 +54,7 @@ class BufferWrapper;
 }  // namespace Minmod_detail
 }  // namespace Limiters
 
-namespace domain {
-namespace Tags {
+namespace domain::Tags {
 template <size_t Dim, typename Frame>
 struct Coordinates;
 template <size_t VolumeDim>
@@ -64,8 +63,7 @@ template <size_t VolumeDim>
 struct Mesh;
 template <size_t VolumeDim>
 struct SizeOfElement;
-}  // namespace Tags
-}  // namespace domain
+}  // namespace domain::Tags
 /// \endcond
 
 namespace Limiters {

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.tpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.tpp
@@ -126,8 +126,8 @@ void Minmod<VolumeDim, tmpl::list<Tags...>>::package_data(
     return;
   }
 
-  const auto wrap_compute_means =
-      [&mesh, &packaged_data ](auto tag, const auto tensor) noexcept {
+  const auto wrap_compute_means = [&mesh, &packaged_data](
+                                      auto tag, const auto tensor) noexcept {
     for (size_t i = 0; i < tensor.size(); ++i) {
       // Compute the mean using the local orientation of the tensor and mesh:
       // this avoids the work of reorienting the tensor while giving the same
@@ -161,10 +161,10 @@ bool Minmod<VolumeDim, tmpl::list<Tags...>>::operator()(
   Minmod_detail::BufferWrapper<VolumeDim> buffer(mesh);
 
   bool limiter_activated = false;
-  const auto wrap_limit_one_tensor = [
-    this, &limiter_activated, &element, &mesh, &logical_coords, &element_size,
-    &neighbor_data, &u_lin_buffer, &buffer
-  ](auto tag, const auto tensor) noexcept {
+  const auto wrap_limit_one_tensor = [this, &limiter_activated, &element, &mesh,
+                                      &logical_coords, &element_size,
+                                      &neighbor_data, &u_lin_buffer, &buffer](
+                                         auto tag, const auto tensor) noexcept {
     limiter_activated =
         Minmod_detail::limit_one_tensor<VolumeDim, decltype(tag)>(
             &u_lin_buffer, &buffer, tensor, minmod_type_, tvb_constant_, mesh,

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.tpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.tpp
@@ -9,6 +9,7 @@
 #include <boost/functional/hash.hpp>
 #include <cstdlib>
 #include <iterator>
+#include <limits>
 #include <memory>
 #include <pup.h>
 #include <type_traits>
@@ -76,7 +77,7 @@ bool limit_one_tensor(
         compute_effective_neighbor_means<Tag>(i, element, neighbor_data);
 
     DataVector& u = (*tensor)[i];
-    double u_mean;
+    double u_mean = std::numeric_limits<double>::signaling_NaN();
     std::array<double, VolumeDim> u_limited_slopes{};
     const bool reduce_slopes = minmod_limited_slopes(
         u_lin_buffer, buffer, make_not_null(&u_mean),

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.cpp
@@ -17,8 +17,7 @@
 #include "Utilities/Literals.hpp"
 #include "Utilities/Numeric.hpp"
 
-namespace Limiters {
-namespace Minmod_detail {
+namespace Limiters::Minmod_detail {
 
 MinmodResult tvb_corrected_minmod(const double a, const double b,
                                   const double c,
@@ -104,5 +103,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 #undef DIM
 #undef INSTANTIATE
 
-}  // namespace Minmod_detail
-}  // namespace Limiters
+}  // namespace Limiters::Minmod_detail

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.cpp
@@ -49,8 +49,8 @@ BufferWrapper<VolumeDim>::BufferWrapper(const Mesh<VolumeDim>& mesh) noexcept
           ::volume_and_slice_indices(mesh.extents())),
       volume_and_slice_indices(volume_and_slice_buffer_and_indices_.second) {
   const size_t half_number_boundary_points = alg::accumulate(
-      alg::iota(std::array<size_t, VolumeDim>{{}}, 0_st),
-      0_st, [&mesh](const size_t state, const size_t d) noexcept {
+      alg::iota(std::array<size_t, VolumeDim>{{}}, 0_st), 0_st,
+      [&mesh](const size_t state, const size_t d) noexcept {
         return state + mesh.slice_away(d).number_of_grid_points();
       });
   contiguous_boundary_buffer_.reset(static_cast<double*>(

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.cpp
@@ -53,8 +53,8 @@ BufferWrapper<VolumeDim>::BufferWrapper(const Mesh<VolumeDim>& mesh) noexcept
         return state + mesh.slice_away(d).number_of_grid_points();
       });
   contiguous_boundary_buffer_.reset(static_cast<double*>(
-      // clang-tidy incorrectly thinks this is a 0-byte malloc
-      // NOLINTNEXTLINE(clang-analyzer-unix.API)
+      // clang-tidy fails to see we are assigning to an owning unique_ptr
+      // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
       malloc(sizeof(double) * half_number_boundary_points)));
   size_t alloc_offset = 0;
   for (size_t d = 0; d < VolumeDim; ++d) {

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.hpp
@@ -31,8 +31,7 @@ struct hash;
 }  // namespace boost
 /// \endcond
 
-namespace Limiters {
-namespace Minmod_detail {
+namespace Limiters::Minmod_detail {
 
 // Encodes the return status of the tvb_corrected_minmod function.
 struct MinmodResult {
@@ -158,5 +157,4 @@ double effective_difference_to_neighbor(
     const DirectionMap<VolumeDim, double>& effective_neighbor_means,
     const DirectionMap<VolumeDim, double>& effective_neighbor_sizes) noexcept;
 
-}  // namespace Minmod_detail
-}  // namespace Limiters
+}  // namespace Limiters::Minmod_detail

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.hpp
@@ -53,7 +53,9 @@ class BufferWrapper {
   explicit BufferWrapper(const Mesh<VolumeDim>& mesh) noexcept;
 
  private:
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays)
   std::unique_ptr<double[], decltype(&free)> contiguous_boundary_buffer_;
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays)
   const std::pair<std::unique_ptr<std::pair<size_t, size_t>[], decltype(&free)>,
                   std::array<std::pair<gsl::span<std::pair<size_t, size_t>>,
                                        gsl::span<std::pair<size_t, size_t>>>,

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.hpp
@@ -86,8 +86,8 @@ DirectionMap<VolumeDim, double> compute_effective_neighbor_sizes(
     const auto& externals = element.external_boundaries();
     const bool neighbors_in_this_dir = (externals.find(dir) == externals.end());
     if (neighbors_in_this_dir) {
-      const double effective_neighbor_size =
-          [&dir, &element, &neighbor_data ]() noexcept {
+      const double effective_neighbor_size = [&dir, &element,
+                                              &neighbor_data]() noexcept {
         const size_t dim = dir.dimension();
         const auto& neighbor_ids = element.neighbors().at(dir).ids();
         double size_accumulate = 0.;
@@ -96,8 +96,7 @@ DirectionMap<VolumeDim, double> compute_effective_neighbor_sizes(
               neighbor_data.at(std::make_pair(dir, id)).element_size, dim);
         }
         return size_accumulate / neighbor_ids.size();
-      }
-      ();
+      }();
       result.insert(std::make_pair(dir, effective_neighbor_size));
     }
   }
@@ -124,17 +123,16 @@ DirectionMap<VolumeDim, double> compute_effective_neighbor_means(
     const bool neighbors_in_this_dir = (externals.find(dir) == externals.end());
     if (neighbors_in_this_dir) {
       const double effective_neighbor_mean =
-          [&dir, &element, &neighbor_data, &tensor_storage_index ]() noexcept {
-        const auto& neighbor_ids = element.neighbors().at(dir).ids();
-        double mean_accumulate = 0.0;
-        for (const auto& id : neighbor_ids) {
-          mean_accumulate += tuples::get<::Tags::Mean<Tag>>(
-              neighbor_data.at(std::make_pair(dir, id))
-                  .means)[tensor_storage_index];
-        }
-        return mean_accumulate / neighbor_ids.size();
-      }
-      ();
+          [&dir, &element, &neighbor_data, &tensor_storage_index]() noexcept {
+            const auto& neighbor_ids = element.neighbors().at(dir).ids();
+            double mean_accumulate = 0.0;
+            for (const auto& id : neighbor_ids) {
+              mean_accumulate += tuples::get<::Tags::Mean<Tag>>(
+                  neighbor_data.at(std::make_pair(dir, id))
+                      .means)[tensor_storage_index];
+            }
+            return mean_accumulate / neighbor_ids.size();
+          }();
       result.insert(std::make_pair(dir, effective_neighbor_mean));
     }
   }

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.cpp
@@ -25,22 +25,20 @@ bool tvb_minmod_indicator(
     const std::array<double, VolumeDim>& element_size,
     const DirectionMap<VolumeDim, double>& effective_neighbor_means,
     const DirectionMap<VolumeDim, double>& effective_neighbor_sizes) noexcept {
-  const double tvb_scale = [&tvb_constant, &element_size ]() noexcept {
+  const double tvb_scale = [&tvb_constant, &element_size]() noexcept {
     const double max_h =
         *std::max_element(element_size.begin(), element_size.end());
     return tvb_constant * square(max_h);
-  }
-  ();
+  }();
   const double u_mean = mean_value(u, mesh);
 
-  const auto difference_to_neighbor = [
-    &u_mean, &element, &element_size, &effective_neighbor_means, &
-    effective_neighbor_sizes
-  ](const size_t dim, const Side& side) noexcept {
-    return Minmod_detail::effective_difference_to_neighbor(
-        u_mean, element, element_size, dim, side, effective_neighbor_means,
-        effective_neighbor_sizes);
-  };
+  const auto difference_to_neighbor =
+      [&u_mean, &element, &element_size, &effective_neighbor_means,
+       &effective_neighbor_sizes](const size_t dim, const Side& side) noexcept {
+        return Minmod_detail::effective_difference_to_neighbor(
+            u_mean, element, element_size, dim, side, effective_neighbor_means,
+            effective_neighbor_sizes);
+      };
 
   for (size_t d = 0; d < VolumeDim; ++d) {
     auto& boundary_buffers_d = gsl::at(buffer->boundary_buffers, d);

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.cpp
@@ -14,8 +14,7 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-namespace Limiters {
-namespace Tci {
+namespace Limiters::Tci {
 
 template <size_t VolumeDim>
 bool tvb_minmod_indicator(
@@ -88,5 +87,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 #undef DIM
 #undef INSTANTIATE
 
-}  // namespace Tci
-}  // namespace Limiters
+}  // namespace Limiters::Tci

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.hpp
@@ -32,8 +32,7 @@ struct hash;
 }  // namespace boost
 /// \endcond
 
-namespace Limiters {
-namespace Tci {
+namespace Limiters::Tci {
 
 // Implements the TVB troubled-cell indicator from Cockburn1999.
 template <size_t VolumeDim>
@@ -99,5 +98,4 @@ bool tvb_minmod_indicator(
   return some_component_needs_limiting;
 }
 
-}  // namespace Tci
-}  // namespace Limiters
+}  // namespace Limiters::Tci

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/SimpleWenoImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/SimpleWenoImpl.hpp
@@ -26,8 +26,7 @@
 #include "NumericalAlgorithms/LinearOperators/MeanValue.hpp"
 #include "Utilities/Gsl.hpp"
 
-namespace Limiters {
-namespace Weno_detail {
+namespace Limiters::Weno_detail {
 
 // Compute the Simple WENO solution for one tensor component
 //
@@ -139,5 +138,4 @@ void simple_weno_impl(
   }
 }
 
-}  // namespace Weno_detail
-}  // namespace Limiters
+}  // namespace Limiters::Weno_detail

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/SimpleWenoImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/SimpleWenoImpl.hpp
@@ -57,12 +57,13 @@ void simple_weno_impl(
         std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, PackagedData,
         boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
         neighbor_data) noexcept {
-  ASSERT(modified_neighbor_solution_buffer->size() == neighbor_data.size(),
-         "modified_neighbor_solution_buffer->size() = "
-         << modified_neighbor_solution_buffer->size()
-         << "\nneighbor_data.size() = " << neighbor_data.size()
-         << "\nmodified_neighbor_solution_buffer was incorrectly initialized "
-            "before calling simple_weno_impl.");
+  ASSERT(
+      modified_neighbor_solution_buffer->size() == neighbor_data.size(),
+      "modified_neighbor_solution_buffer->size() = "
+          << modified_neighbor_solution_buffer->size()
+          << "\nneighbor_data.size() = " << neighbor_data.size()
+          << "\nmodified_neighbor_solution_buffer was incorrectly initialized "
+             "before calling simple_weno_impl.");
 
   // Compute the modified neighbor solutions.
   // First extrapolate neighbor data onto local grid points, then shift the

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/WenoGridHelpers.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/WenoGridHelpers.cpp
@@ -13,8 +13,7 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-namespace Limiters {
-namespace Weno_detail {
+namespace Limiters::Weno_detail {
 
 template <size_t VolumeDim>
 bool check_element_has_one_similar_neighbor_in_direction(
@@ -119,5 +118,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 #undef DIM
 #undef INSTANTIATE
 
-}  // namespace Weno_detail
-}  // namespace Limiters
+}  // namespace Limiters::Weno_detail

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/WenoGridHelpers.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/WenoGridHelpers.hpp
@@ -16,8 +16,7 @@ template <size_t>
 class Mesh;
 /// \endcond
 
-namespace Limiters {
-namespace Weno_detail {
+namespace Limiters::Weno_detail {
 
 // Check that an element has just one neighbor in a particular direction, and
 // that this neighbor has the same refinement level as the element.
@@ -61,5 +60,4 @@ std::array<DataVector, VolumeDim> local_grid_points_in_neighbor_logical_coords(
     const Element<VolumeDim>& element,
     const Direction<VolumeDim>& direction_to_neighbor) noexcept;
 
-}  // namespace Weno_detail
-}  // namespace Limiters
+}  // namespace Limiters::Weno_detail

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/WenoHelpers.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/WenoHelpers.cpp
@@ -31,8 +31,7 @@ inline double unnormalized_nonlinear_weight(
 
 }  // namespace
 
-namespace Limiters {
-namespace Weno_detail {
+namespace Limiters::Weno_detail {
 
 template <size_t VolumeDim>
 void reconstruct_from_weighted_sum(
@@ -122,5 +121,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 #undef DIM
 #undef INSTANTIATE
 
-}  // namespace Weno_detail
-}  // namespace Limiters
+}  // namespace Limiters::Weno_detail

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/WenoHelpers.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/WenoHelpers.hpp
@@ -23,8 +23,7 @@ struct hash;
 }  // namespace boost
 /// \endcond
 
-namespace Limiters {
-namespace Weno_detail {
+namespace Limiters::Weno_detail {
 
 // Compute the WENO weighted reconstruction of a DataVector, see e.g.,
 // Eq. 4.3 of Zhu2016. This is fairly standard, though different references can
@@ -46,5 +45,4 @@ void reconstruct_from_weighted_sum(
         boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
         neighbor_polynomials) noexcept;
 
-}  // namespace Weno_detail
-}  // namespace Limiters
+}  // namespace Limiters::Weno_detail

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.cpp
@@ -108,22 +108,22 @@ Matrix compute_indicator_matrix(
   const std::array<
       double, Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>
       weights_for_derivatives = [&derivative_weight]() noexcept {
-    auto weights = make_array<
-        Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>(1.);
-    if (derivative_weight ==
-        Limiters::Weno_detail::DerivativeWeight::PowTwoEll) {
-      for (size_t l = 0; l < weights.size(); ++l) {
-        gsl::at(weights, l) = pow(2., 2. * l - 1.);
-      }
-    } else if (derivative_weight == Limiters::Weno_detail::DerivativeWeight::
-                                        PowTwoEllOverEllFactorial) {
-      for (size_t l = 0; l < weights.size(); ++l) {
-        gsl::at(weights, l) = 0.5 * square(pow(2., l) / factorial(l));
-      }
-    }
-    return weights;
-  }
-  ();
+        auto weights = make_array<
+            Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>(1.);
+        if (derivative_weight ==
+            Limiters::Weno_detail::DerivativeWeight::PowTwoEll) {
+          for (size_t l = 0; l < weights.size(); ++l) {
+            gsl::at(weights, l) = pow(2., 2. * l - 1.);
+          }
+        } else if (derivative_weight ==
+                   Limiters::Weno_detail::DerivativeWeight::
+                       PowTwoEllOverEllFactorial) {
+          for (size_t l = 0; l < weights.size(); ++l) {
+            gsl::at(weights, l) = 0.5 * square(pow(2., l) / factorial(l));
+          }
+        }
+        return weights;
+      }();
 
   for (IndexIterator<VolumeDim> m(mesh.extents()); m; ++m) {
     if (m.collapsed_index() == 0) {
@@ -195,7 +195,7 @@ double oscillation_indicator(const DerivativeWeight derivative_weight,
   const auto cache = make_static_cache<CacheEnumeration<
       DerivativeWeight, DerivativeWeight::Unity, DerivativeWeight::PowTwoEll,
       DerivativeWeight::PowTwoEllOverEllFactorial>>(
-      [&mesh](const DerivativeWeight dw) noexcept->Matrix {
+      [&mesh](const DerivativeWeight dw) noexcept -> Matrix {
         return compute_indicator_matrix(dw, mesh);
       });
   const Matrix indicator_matrix = cache(derivative_weight);

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.cpp
@@ -165,8 +165,7 @@ Matrix compute_indicator_matrix(
 
 }  // namespace
 
-namespace Limiters {
-namespace Weno_detail {
+namespace Limiters::Weno_detail {
 
 std::ostream& operator<<(std::ostream& os,
                          DerivativeWeight derivative_weight) noexcept {
@@ -241,5 +240,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 #undef DIM
 #undef INSTANTIATE
 
-}  // namespace Weno_detail
-}  // namespace Limiters
+}  // namespace Limiters::Weno_detail

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.hpp
@@ -12,8 +12,7 @@ template <size_t>
 class Mesh;
 /// \endcond
 
-namespace Limiters {
-namespace Weno_detail {
+namespace Limiters::Weno_detail {
 
 // Denote different schemes for computing related oscillation indicators by
 // changing the relative weight given to each derivative of the input data.
@@ -44,5 +43,4 @@ double oscillation_indicator(DerivativeWeight derivative_weight,
                              const DataVector& data,
                              const Mesh<VolumeDim>& mesh) noexcept;
 
-}  // namespace Weno_detail
-}  // namespace Limiters
+}  // namespace Limiters::Weno_detail

--- a/src/Utilities/StaticCache.hpp
+++ b/src/Utilities/StaticCache.hpp
@@ -70,7 +70,7 @@ template <typename Generator, typename T, typename... Ranges>
 class StaticCache {
  public:
   template <typename Gen>
-  // NOLINTNEXTLINE(misc-forwarding-reference-overload)
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   explicit StaticCache(Gen&& generator) noexcept
       : generator_{std::forward<Gen>(generator)} {}
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_HwenoImpl.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_HwenoImpl.cpp
@@ -75,29 +75,32 @@ void test_secondary_neighbors_to_exclude_from_fit() noexcept {
   get(get<::Tags::Mean<ScalarTag>>(dummy_neighbor_data[lower_eta].means)) = 3.;
   get(get<::Tags::Mean<ScalarTag>>(dummy_neighbor_data[upper_eta].means)) = 3.;
 
-  const auto check_excluded_neighbors = [&dummy_neighbor_data](
-      const double mean,
-      const std::pair<Direction<2>, ElementId<2>>& primary_neighbor,
-      const std::unordered_set<
-          std::pair<Direction<2>, ElementId<2>>,
-          boost::hash<std::pair<Direction<2>, ElementId<2>>>>&
-          expected_excluded_neighbors) noexcept {
-    const size_t tensor_index = 0;
-    const auto excluded_neighbors_vector =
-        Limiters::Weno_detail::secondary_neighbors_to_exclude_from_fit<
-            ScalarTag>(mean, tensor_index, dummy_neighbor_data,
-                       primary_neighbor);
-    // The elements of `excluded_neighbors_vector` are ordered in an undefined
-    // way, because they are filled by looping over the unordered_map of
-    // neighbor data. To provide meaningful test comparisons, we move the data
-    // into an unordered_set. (A sort would also work here, if the Direction and
-    // ElementId classes were sortable, which they aren't.)
-    const std::unordered_set<std::pair<Direction<2>, ElementId<2>>,
-                             boost::hash<std::pair<Direction<2>, ElementId<2>>>>
-        excluded_neighbors(excluded_neighbors_vector.begin(),
-                           excluded_neighbors_vector.end());
-    CHECK(excluded_neighbors == expected_excluded_neighbors);
-  };
+  const auto check_excluded_neighbors =
+      [&dummy_neighbor_data](
+          const double mean,
+          const std::pair<Direction<2>, ElementId<2>>& primary_neighbor,
+          const std::unordered_set<
+              std::pair<Direction<2>, ElementId<2>>,
+              boost::hash<std::pair<Direction<2>, ElementId<2>>>>&
+              expected_excluded_neighbors) noexcept {
+        const size_t tensor_index = 0;
+        const auto excluded_neighbors_vector =
+            Limiters::Weno_detail::secondary_neighbors_to_exclude_from_fit<
+                ScalarTag>(mean, tensor_index, dummy_neighbor_data,
+                           primary_neighbor);
+        // The elements of `excluded_neighbors_vector` are ordered in an
+        // undefined way, because they are filled by looping over the
+        // unordered_map of neighbor data. To provide meaningful test
+        // comparisons, we move the data into an unordered_set. (A sort would
+        // also work here, if the Direction and ElementId classes were sortable,
+        // which they aren't.)
+        const std::unordered_set<
+            std::pair<Direction<2>, ElementId<2>>,
+            boost::hash<std::pair<Direction<2>, ElementId<2>>>>
+            excluded_neighbors(excluded_neighbors_vector.begin(),
+                               excluded_neighbors_vector.end());
+        CHECK(excluded_neighbors == expected_excluded_neighbors);
+      };
 
   check_excluded_neighbors(0., lower_xi, {{lower_eta, upper_eta}});
   check_excluded_neighbors(0., upper_xi, {{lower_eta, upper_eta}});
@@ -129,30 +132,27 @@ void test_constrained_fit_1d() noexcept {
   const auto local_data = [&logical_coords]() noexcept {
     const auto& x = get<0>(logical_coords);
     return DataVector{1. - 0.2 * x + 0.4 * square(x)};
-  }
-  ();
+  }();
 
-  const auto lower_xi_vars = [&mesh, &logical_coords ]() noexcept {
+  const auto lower_xi_vars = [&mesh, &logical_coords]() noexcept {
     Variables<TagsList> result(mesh.number_of_grid_points());
     const auto x = get<0>(logical_coords) - 2.;
     get(get<ScalarTag>(result)) = 4. - 0.5 * x - 0.1 * square(x);
     return result;
-  }
-  ();
+  }();
 
-  const auto upper_xi_vars = [&mesh, &logical_coords ]() noexcept {
+  const auto upper_xi_vars = [&mesh, &logical_coords]() noexcept {
     Variables<TagsList> result(mesh.number_of_grid_points());
     const auto x = get<0>(logical_coords) + 2.;
     get(get<ScalarTag>(result)) = 1. - 0.2 * x + 0.1 * square(x);
     return result;
-  }
-  ();
+  }();
 
-  const auto make_tuple_of_means = [&mesh](
-      const Variables<TagsList>& vars) noexcept {
-    return tuples::TaggedTuple<::Tags::Mean<ScalarTag>>(
-        mean_value(get(get<ScalarTag>(vars)), mesh));
-  };
+  const auto make_tuple_of_means =
+      [&mesh](const Variables<TagsList>& vars) noexcept {
+        return tuples::TaggedTuple<::Tags::Mean<ScalarTag>>(
+            mean_value(get(get<ScalarTag>(vars)), mesh));
+      };
 
   struct PackagedData {
     tuples::TaggedTuple<::Tags::Mean<ScalarTag>> means;
@@ -201,8 +201,7 @@ void test_constrained_fit_1d() noexcept {
       const auto& x = get<0>(logical_coords);
       constexpr std::array<double, 3> c{{41. / 30., -31. / 10., -7. / 10.}};
       return DataVector{c[0] + c[1] * x + c[2] * square(x)};
-    }
-    ();
+    }();
 
     // Fit procedure has somewhat larger error scale than default
     Approx local_approx = Approx::custom().epsilon(1e-11).scale(1.);
@@ -242,8 +241,7 @@ void test_constrained_fit_1d() noexcept {
       constexpr std::array<double, 3> c{
           {929. / 850., -124. / 425., 103. / 850.}};
       return DataVector{c[0] + c[1] * x + c[2] * square(x)};
-    }
-    ();
+    }();
 
     Approx local_approx = Approx::custom().epsilon(1e-11).scale(1.);
     CHECK_ITERABLE_CUSTOM_APPROX(constrained_fit, expected, local_approx);
@@ -321,20 +319,18 @@ void test_constrained_fit_2d_vector() noexcept {
     return VectorTag<2>::type{{{DataVector{1. + 0.1 * x + 0.2 * y +
                                            0.1 * x * y + 0.1 * x * square(y)},
                                 DataVector(x.size(), 2.)}}};
-  }
-  ();
+  }();
 
-  const auto lower_xi_vars = [&mesh, &logical_coords ]() noexcept {
+  const auto lower_xi_vars = [&mesh, &logical_coords]() noexcept {
     Variables<TagsList> result(mesh.number_of_grid_points());
     const auto x = get<0>(logical_coords) - 2.;
     const auto& y = get<1>(logical_coords);
     get<0>(get<VectorTag<2>>(result)) = 2. + 0.2 * x - 0.1 * y;
     get<1>(get<VectorTag<2>>(result)) = 1.;
     return result;
-  }
-  ();
+  }();
 
-  const auto upper_xi_vars = [&mesh, &logical_coords ]() noexcept {
+  const auto upper_xi_vars = [&mesh, &logical_coords]() noexcept {
     Variables<TagsList> result(mesh.number_of_grid_points());
     const auto x = get<0>(logical_coords) + 2.;
     const auto& y = get<1>(logical_coords);
@@ -342,10 +338,9 @@ void test_constrained_fit_2d_vector() noexcept {
         1. + 1. / 3. * x + 0.25 * y - 0.05 * square(x);
     get<1>(get<VectorTag<2>>(result)) = -0.5;
     return result;
-  }
-  ();
+  }();
 
-  const auto lower_eta_vars = [&mesh, &logical_coords ]() noexcept {
+  const auto lower_eta_vars = [&mesh, &logical_coords]() noexcept {
     Variables<TagsList> result(mesh.number_of_grid_points());
     const auto& x = get<0>(logical_coords);
     const auto y = get<1>(logical_coords) - 2.;
@@ -354,25 +349,24 @@ void test_constrained_fit_2d_vector() noexcept {
     get<1>(get<VectorTag<2>>(result)) =
         1.2 + 0.5 * x - 0.1 * square(x) - 0.2 * y + 0.1 * square(x) * square(y);
     return result;
-  }
-  ();
+  }();
 
-  const auto upper_eta_vars = [&mesh, &logical_coords ]() noexcept {
+  const auto upper_eta_vars = [&mesh, &logical_coords]() noexcept {
     Variables<TagsList> result(mesh.number_of_grid_points());
     const auto& x = get<0>(logical_coords);
     const auto y = get<1>(logical_coords) + 2.;
     get<0>(get<VectorTag<2>>(result)) = 1. + 1. / 3. * x + 0.2 * y;
     get<1>(get<VectorTag<2>>(result)) = 0.1;
     return result;
-  }
-  ();
+  }();
 
-  const auto make_tuple_of_means = [&mesh](
-      const Variables<TagsList>& vars) noexcept {
-    return tuples::TaggedTuple<::Tags::Mean<VectorTag<2>>>(tnsr::I<double, 2>{
-        {{mean_value(get<0>(get<VectorTag<2>>(vars)), mesh),
-          mean_value(get<1>(get<VectorTag<2>>(vars)), mesh)}}});
-  };
+  const auto make_tuple_of_means =
+      [&mesh](const Variables<TagsList>& vars) noexcept {
+        return tuples::TaggedTuple<::Tags::Mean<VectorTag<2>>>(
+            tnsr::I<double, 2>{
+                {{mean_value(get<0>(get<VectorTag<2>>(vars)), mesh),
+                  mean_value(get<1>(get<VectorTag<2>>(vars)), mesh)}}});
+      };
 
   struct PackagedData {
     tuples::TaggedTuple<::Tags::Mean<VectorTag<2>>> means;
@@ -475,8 +469,7 @@ void test_constrained_fit_2d_vector() noexcept {
                 y * (d[4] + d[5] * x + d[6] * square(x) + d[7] * cube(x)) +
                 square(y) *
                     (d[8] + d[9] * x + d[10] * square(x) + d[11] * cube(x))}}}};
-    }
-    ();
+    }();
 
     // Fit procedure has somewhat larger error scale than default
     Approx local_approx = Approx::custom().epsilon(1e-10).scale(1.);
@@ -540,8 +533,7 @@ void test_constrained_fit_2d_vector() noexcept {
                 y * (d[4] + d[5] * x + d[6] * square(x) + d[7] * cube(x)) +
                 square(y) *
                     (d[8] + d[9] * x + d[10] * square(x) + d[11] * cube(x))}}}};
-    }
-    ();
+    }();
 
     // Fit procedure has somewhat larger error scale than default
     Approx local_approx = Approx::custom().epsilon(1e-10).scale(1.);
@@ -587,45 +579,39 @@ void test_constrained_fit_3d() noexcept {
     const auto& y = get<1>(logical_coords);
     const auto& z = get<2>(logical_coords);
     return DataVector{0.5 + 0.2 * x + 0.1 * square(y) * z};
-  }
-  ();
+  }();
 
   const auto lower_xi_vars = [&mesh]() noexcept {
     Variables<TagsList> result(mesh.number_of_grid_points());
     get(get<ScalarTag>(result)) = 1.2;
     return result;
-  }
-  ();
+  }();
 
   const auto upper_xi_vars = [&mesh]() noexcept {
     Variables<TagsList> result(mesh.number_of_grid_points());
     get(get<ScalarTag>(result)) = 4.;
     return result;
-  }
-  ();
+  }();
 
   const auto lower_eta_vars = [&mesh]() noexcept {
     Variables<TagsList> result(mesh.number_of_grid_points());
     get(get<ScalarTag>(result)) = 3.;
     return result;
-  }
-  ();
+  }();
 
   const auto upper_eta_vars = [&mesh]() noexcept {
     Variables<TagsList> result(mesh.number_of_grid_points());
     get(get<ScalarTag>(result)) = 2.5;
     return result;
-  }
-  ();
+  }();
 
   const auto lower_zeta_vars = [&mesh]() noexcept {
     Variables<TagsList> result(mesh.number_of_grid_points());
     get(get<ScalarTag>(result)) = 2.;
     return result;
-  }
-  ();
+  }();
 
-  const auto upper_zeta_vars = [&mesh, &logical_coords ]() noexcept {
+  const auto upper_zeta_vars = [&mesh, &logical_coords]() noexcept {
     Variables<TagsList> result(mesh.number_of_grid_points());
     const auto& x = get<0>(logical_coords);
     const auto& y = get<1>(logical_coords);
@@ -633,14 +619,13 @@ void test_constrained_fit_3d() noexcept {
     get(get<ScalarTag>(result)) =
         1. + 0.25 * x + 0.1 * y * z + 0.5 * x * square(y) * z + 0.1 * cube(z);
     return result;
-  }
-  ();
+  }();
 
-  const auto make_tuple_of_means = [&mesh](
-      const Variables<TagsList>& vars) noexcept {
-    return tuples::TaggedTuple<::Tags::Mean<ScalarTag>>(
-        mean_value(get(get<ScalarTag>(vars)), mesh));
-  };
+  const auto make_tuple_of_means =
+      [&mesh](const Variables<TagsList>& vars) noexcept {
+        return tuples::TaggedTuple<::Tags::Mean<ScalarTag>>(
+            mean_value(get(get<ScalarTag>(vars)), mesh));
+      };
 
   std::unordered_map<std::pair<Direction<3>, ElementId<3>>, PackagedData,
                      boost::hash<std::pair<Direction<3>, ElementId<3>>>>
@@ -814,8 +799,7 @@ void test_constrained_fit_3d() noexcept {
           square(y) * (c[33] + c[34] * x + c[35] * square(x));
       return DataVector{term_z0 + term_z1 * z + term_z2 * square(z) +
                         term_z3 * cube(z)};
-    }
-    ();
+    }();
 
     // Fit procedure has somewhat larger error scale than default
     Approx local_approx = Approx::custom().epsilon(1e-8).scale(1.);
@@ -894,8 +878,7 @@ void test_constrained_fit_3d() noexcept {
           square(y) * (c[33] + c[34] * x + c[35] * square(x));
       return DataVector{term_z0 + term_z1 * z + term_z2 * square(z) +
                         term_z3 * cube(z)};
-    }
-    ();
+    }();
 
     // Fit procedure has somewhat larger error scale than default
     Approx local_approx = Approx::custom().epsilon(1e-8).scale(1.);
@@ -929,16 +912,17 @@ void test_hweno_work(
     Mesh<VolumeDim> mesh;
   };
 
-  const auto make_tuple_of_means = [&mesh](
-      const Variables<tmpl::list<VectorTag<VolumeDim>>>& vars) noexcept {
-    tuples::TaggedTuple<::Tags::Mean<VectorTag<VolumeDim>>> result(
-        tnsr::I<double, VolumeDim>{});
-    for (size_t i = 0; i < VolumeDim; ++i) {
-      get<::Tags::Mean<VectorTag<VolumeDim>>>(result).get(i) =
-          mean_value(get<VectorTag<VolumeDim>>(vars).get(i), mesh);
-    }
-    return result;
-  };
+  const auto make_tuple_of_means =
+      [&mesh](
+          const Variables<tmpl::list<VectorTag<VolumeDim>>>& vars) noexcept {
+        tuples::TaggedTuple<::Tags::Mean<VectorTag<VolumeDim>>> result(
+            tnsr::I<double, VolumeDim>{});
+        for (size_t i = 0; i < VolumeDim; ++i) {
+          get<::Tags::Mean<VectorTag<VolumeDim>>>(result).get(i) =
+              mean_value(get<VectorTag<VolumeDim>>(vars).get(i), mesh);
+        }
+        return result;
+      };
 
   std::unordered_map<
       std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, PackagedData,
@@ -1020,24 +1004,21 @@ void test_hweno_impl_1d() noexcept {
   const auto local_tensor = [&logical_coords]() noexcept {
     const auto& x = get<0>(logical_coords);
     return VectorTag<1>::type{{{DataVector{1. + 2.1 * x + 0.3 * square(x)}}}};
-  }
-  ();
+  }();
 
-  const auto lower_xi_vars = [&mesh, &logical_coords ]() noexcept {
+  const auto lower_xi_vars = [&mesh, &logical_coords]() noexcept {
     Variables<TagsList> result(mesh.number_of_grid_points());
     const auto x = get<0>(logical_coords) - 2.;
     get<0>(get<VectorTag<1>>(result)) = 4. - 0.5 * x - 0.1 * square(x);
     return result;
-  }
-  ();
+  }();
 
-  const auto upper_xi_vars = [&mesh, &logical_coords ]() noexcept {
+  const auto upper_xi_vars = [&mesh, &logical_coords]() noexcept {
     Variables<TagsList> result(mesh.number_of_grid_points());
     const auto x = get<0>(logical_coords) + 2.;
     get<0>(get<VectorTag<1>>(result)) = 1. - 0.2 * x + 0.1 * square(x);
     return result;
-  }
-  ();
+  }();
 
   Approx local_approx = Approx::custom().epsilon(1e-11).scale(1.);
   test_hweno_work<1>(
@@ -1078,20 +1059,18 @@ void test_hweno_impl_2d() noexcept {
     return VectorTag<2>::type{{{DataVector{1. + 0.1 * x + 0.2 * y +
                                            0.1 * x * y + 0.1 * x * square(y)},
                                 DataVector(x.size(), 2.)}}};
-  }
-  ();
+  }();
 
-  const auto lower_xi_vars = [&mesh, &logical_coords ]() noexcept {
+  const auto lower_xi_vars = [&mesh, &logical_coords]() noexcept {
     Variables<TagsList> result(mesh.number_of_grid_points());
     const auto x = get<0>(logical_coords) - 2.;
     const auto& y = get<1>(logical_coords);
     get<0>(get<VectorTag<2>>(result)) = 2. + 0.2 * x - 0.1 * y;
     get<1>(get<VectorTag<2>>(result)) = 1.;
     return result;
-  }
-  ();
+  }();
 
-  const auto upper_xi_vars = [&mesh, &logical_coords ]() noexcept {
+  const auto upper_xi_vars = [&mesh, &logical_coords]() noexcept {
     Variables<TagsList> result(mesh.number_of_grid_points());
     const auto x = get<0>(logical_coords) + 2.;
     const auto& y = get<1>(logical_coords);
@@ -1099,10 +1078,9 @@ void test_hweno_impl_2d() noexcept {
         1. + 1. / 3. * x + 0.25 * y - 0.05 * square(x);
     get<1>(get<VectorTag<2>>(result)) = -0.5;
     return result;
-  }
-  ();
+  }();
 
-  const auto lower_eta_vars = [&mesh, &logical_coords ]() noexcept {
+  const auto lower_eta_vars = [&mesh, &logical_coords]() noexcept {
     Variables<TagsList> result(mesh.number_of_grid_points());
     const auto& x = get<0>(logical_coords);
     const auto y = get<1>(logical_coords) - 2.;
@@ -1111,18 +1089,16 @@ void test_hweno_impl_2d() noexcept {
     get<1>(get<VectorTag<2>>(result)) =
         1.2 + 0.5 * x - 0.1 * square(x) - 0.2 * y + 0.1 * square(x) * square(y);
     return result;
-  }
-  ();
+  }();
 
-  const auto upper_eta_vars = [&mesh, &logical_coords ]() noexcept {
+  const auto upper_eta_vars = [&mesh, &logical_coords]() noexcept {
     Variables<TagsList> result(mesh.number_of_grid_points());
     const auto& x = get<0>(logical_coords);
     const auto y = get<1>(logical_coords) + 2.;
     get<0>(get<VectorTag<2>>(result)) = 1. + 1. / 3. * x + 0.2 * y;
     get<1>(get<VectorTag<2>>(result)) = 0.1;
     return result;
-  }
-  ();
+  }();
 
   using DirKey = std::pair<Direction<2>, ElementId<2>>;
   Approx local_approx = Approx::custom().epsilon(1e-11).scale(1.);
@@ -1180,8 +1156,7 @@ void test_hweno_impl_3d() noexcept {
     return VectorTag<3>::type{{{DataVector{-2. + 0.2 * y * square(z)},
                                 DataVector{0.8 - 0.1 * square(x) * z},
                                 DataVector{5. + 0.5 * x * y * z}}}};
-  }
-  ();
+  }();
 
   const auto lower_xi_vars = [&mesh]() noexcept {
     Variables<TagsList> result(mesh.number_of_grid_points());
@@ -1189,8 +1164,7 @@ void test_hweno_impl_3d() noexcept {
     get<1>(get<VectorTag<3>>(result)) = 1.;
     get<2>(get<VectorTag<3>>(result)) = 1.;
     return result;
-  }
-  ();
+  }();
 
   const auto upper_xi_vars = [&mesh]() noexcept {
     Variables<TagsList> result(mesh.number_of_grid_points());
@@ -1198,8 +1172,7 @@ void test_hweno_impl_3d() noexcept {
     get<1>(get<VectorTag<3>>(result)) = -1.5;
     get<2>(get<VectorTag<3>>(result)) = 2.5;
     return result;
-  }
-  ();
+  }();
 
   const auto lower_eta_vars = [&mesh]() noexcept {
     Variables<TagsList> result(mesh.number_of_grid_points());
@@ -1207,8 +1180,7 @@ void test_hweno_impl_3d() noexcept {
     get<1>(get<VectorTag<3>>(result)) = 0.1;
     get<2>(get<VectorTag<3>>(result)) = 10.3;
     return result;
-  }
-  ();
+  }();
 
   const auto upper_eta_vars = [&mesh]() noexcept {
     Variables<TagsList> result(mesh.number_of_grid_points());
@@ -1216,8 +1188,7 @@ void test_hweno_impl_3d() noexcept {
     get<1>(get<VectorTag<3>>(result)) = 1.2;
     get<2>(get<VectorTag<3>>(result)) = -0.3;
     return result;
-  }
-  ();
+  }();
 
   const auto lower_zeta_vars = [&mesh]() noexcept {
     Variables<TagsList> result(mesh.number_of_grid_points());
@@ -1225,8 +1196,7 @@ void test_hweno_impl_3d() noexcept {
     get<1>(get<VectorTag<3>>(result)) = 0.1;
     get<2>(get<VectorTag<3>>(result)) = 4.2;
     return result;
-  }
-  ();
+  }();
 
   const auto upper_zeta_vars = [&mesh]() noexcept {
     Variables<TagsList> result(mesh.number_of_grid_points());
@@ -1234,8 +1204,7 @@ void test_hweno_impl_3d() noexcept {
     get<1>(get<VectorTag<3>>(result)) = -0.9;
     get<2>(get<VectorTag<3>>(result)) = 1.1;
     return result;
-  }
-  ();
+  }();
 
   using DirKey = std::pair<Direction<3>, ElementId<3>>;
   Approx local_approx = Approx::custom().epsilon(1e-11).scale(1.);

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Krivodonova.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Krivodonova.cpp
@@ -141,37 +141,36 @@ void test_limiting_two_neighbors() noexcept {
   tnsr::I<DataVector, dim> nodal_vector_data_to_limit(num_pts, 0.0);
   DataVector expected(num_pts);
   const auto helper =
-      [
-        &element, &expected, &krivodonova, &mesh, &neighbor_data,
-        &package_data_lower, &package_data_upper, &nodal_scalar_data_to_limit, &
-        nodal_vector_data_to_limit
-      ](const ModalVector& upper_coeffs, const ModalVector& initial_coeffs,
-        const ModalVector& lower_coeffs,
-        const ModalVector& expected_coeffs) noexcept {
-    to_nodal_coefficients(&get(nodal_scalar_data_to_limit), initial_coeffs,
-                          mesh);
-    get(get<::Tags::Modal<ScalarTag<0>>>(
-        package_data_upper.modal_volume_data)) = upper_coeffs;
-    get(get<::Tags::Modal<ScalarTag<0>>>(
-        package_data_lower.modal_volume_data)) = lower_coeffs;
-    for (size_t i = 0; i < dim; ++i) {
-      to_nodal_coefficients(&nodal_vector_data_to_limit.get(i), initial_coeffs,
-                            mesh);
-      get<::Tags::Modal<VectorTag<dim, 0>>>(
-          package_data_upper.modal_volume_data)
-          .get(i) = upper_coeffs;
-      get<::Tags::Modal<VectorTag<dim, 0>>>(
-          package_data_lower.modal_volume_data)
-          .get(i) = lower_coeffs;
-    }
-    krivodonova(&nodal_scalar_data_to_limit, &nodal_vector_data_to_limit,
-                element, mesh, neighbor_data);
-    to_nodal_coefficients(&expected, expected_coeffs, mesh);
-    CHECK_ITERABLE_APPROX(get(nodal_scalar_data_to_limit), expected);
-    for (size_t i = 0; i < dim; ++i) {
-      CHECK_ITERABLE_APPROX(nodal_vector_data_to_limit.get(i), expected);
-    }
-  };
+      [&element, &expected, &krivodonova, &mesh, &neighbor_data,
+       &package_data_lower, &package_data_upper, &nodal_scalar_data_to_limit,
+       &nodal_vector_data_to_limit](
+          const ModalVector& upper_coeffs, const ModalVector& initial_coeffs,
+          const ModalVector& lower_coeffs,
+          const ModalVector& expected_coeffs) noexcept {
+        to_nodal_coefficients(&get(nodal_scalar_data_to_limit), initial_coeffs,
+                              mesh);
+        get(get<::Tags::Modal<ScalarTag<0>>>(
+            package_data_upper.modal_volume_data)) = upper_coeffs;
+        get(get<::Tags::Modal<ScalarTag<0>>>(
+            package_data_lower.modal_volume_data)) = lower_coeffs;
+        for (size_t i = 0; i < dim; ++i) {
+          to_nodal_coefficients(&nodal_vector_data_to_limit.get(i),
+                                initial_coeffs, mesh);
+          get<::Tags::Modal<VectorTag<dim, 0>>>(
+              package_data_upper.modal_volume_data)
+              .get(i) = upper_coeffs;
+          get<::Tags::Modal<VectorTag<dim, 0>>>(
+              package_data_lower.modal_volume_data)
+              .get(i) = lower_coeffs;
+        }
+        krivodonova(&nodal_scalar_data_to_limit, &nodal_vector_data_to_limit,
+                    element, mesh, neighbor_data);
+        to_nodal_coefficients(&expected, expected_coeffs, mesh);
+        CHECK_ITERABLE_APPROX(get(nodal_scalar_data_to_limit), expected);
+        for (size_t i = 0; i < dim; ++i) {
+          CHECK_ITERABLE_APPROX(nodal_vector_data_to_limit.get(i), expected);
+        }
+      };
 
   // Note: Throughout the tests 1.0e-18 is used anywhere that we need a positive
   // but zero coefficient, because it is below machine precision for O(1)
@@ -948,28 +947,27 @@ void run() noexcept {
   Scalar<DataVector> nodal_scalar_data_to_limit(num_pts, 0.0);
   DataVector expected(num_pts);
   const auto helper =
-      [
-        &element, &expected, &krivodonova, &mesh, &neighbor_data,
-        &package_data_lo_xi, &package_data_up_xi, &package_data_lo_eta,
-        &package_data_up_eta, &nodal_scalar_data_to_limit
-      ](const ModalVector& up_xi_coeffs, const ModalVector& up_eta_coeffs,
-        const ModalVector& initial_coeffs, const ModalVector& lo_xi_coeffs,
-        const ModalVector& lo_eta_coeffs,
-        const ModalVector& expected_coeffs) noexcept {
-    to_nodal_coefficients(&get(nodal_scalar_data_to_limit), initial_coeffs,
-                          mesh);
-    get(get<::Tags::Modal<ScalarTag<0>>>(
-        package_data_up_xi.modal_volume_data)) = up_xi_coeffs;
-    get(get<::Tags::Modal<ScalarTag<0>>>(
-        package_data_lo_xi.modal_volume_data)) = lo_xi_coeffs;
-    get(get<::Tags::Modal<ScalarTag<0>>>(
-        package_data_up_eta.modal_volume_data)) = up_eta_coeffs;
-    get(get<::Tags::Modal<ScalarTag<0>>>(
-        package_data_lo_eta.modal_volume_data)) = lo_eta_coeffs;
-    krivodonova(&nodal_scalar_data_to_limit, element, mesh, neighbor_data);
-    to_nodal_coefficients(&expected, expected_coeffs, mesh);
-    CHECK_ITERABLE_APPROX(get(nodal_scalar_data_to_limit), expected);
-  };
+      [&element, &expected, &krivodonova, &mesh, &neighbor_data,
+       &package_data_lo_xi, &package_data_up_xi, &package_data_lo_eta,
+       &package_data_up_eta, &nodal_scalar_data_to_limit](
+          const ModalVector& up_xi_coeffs, const ModalVector& up_eta_coeffs,
+          const ModalVector& initial_coeffs, const ModalVector& lo_xi_coeffs,
+          const ModalVector& lo_eta_coeffs,
+          const ModalVector& expected_coeffs) noexcept {
+        to_nodal_coefficients(&get(nodal_scalar_data_to_limit), initial_coeffs,
+                              mesh);
+        get(get<::Tags::Modal<ScalarTag<0>>>(
+            package_data_up_xi.modal_volume_data)) = up_xi_coeffs;
+        get(get<::Tags::Modal<ScalarTag<0>>>(
+            package_data_lo_xi.modal_volume_data)) = lo_xi_coeffs;
+        get(get<::Tags::Modal<ScalarTag<0>>>(
+            package_data_up_eta.modal_volume_data)) = up_eta_coeffs;
+        get(get<::Tags::Modal<ScalarTag<0>>>(
+            package_data_lo_eta.modal_volume_data)) = lo_eta_coeffs;
+        krivodonova(&nodal_scalar_data_to_limit, element, mesh, neighbor_data);
+        to_nodal_coefficients(&expected, expected_coeffs, mesh);
+        CHECK_ITERABLE_APPROX(get(nodal_scalar_data_to_limit), expected);
+      };
 
   // Map between 2D and 1D coefficients:
   // [(0,0), (1,0), (2,0), (0,1), (1,1), (2,1), (0,2), (1,2), (2,2)]
@@ -2815,62 +2813,61 @@ void run() noexcept {
   tnsr::I<DataVector, dim> nodal_vector_data_to_limit(num_pts, 0.0);
   DataVector expected(num_pts);
   const auto helper =
-      [
-        &element, &expected, &krivodonova, &mesh, &neighbor_data,
-        &package_data_lo_xi, &package_data_up_xi, &package_data_lo_eta,
-        &package_data_up_eta, &package_data_lo_zeta, &package_data_up_zeta,
-        &nodal_scalar_data_to_limit, &nodal_vector_data_to_limit
-      ](const ModalVector& up_xi_coeffs, const ModalVector& up_eta_coeffs,
-        const ModalVector& up_zeta_coeffs, const ModalVector& initial_coeffs,
-        const ModalVector& lo_xi_coeffs, const ModalVector& lo_eta_coeffs,
-        const ModalVector& lo_zeta_coeffs,
-        const ModalVector& expected_coeffs) noexcept {
-    to_nodal_coefficients(&get(nodal_scalar_data_to_limit), initial_coeffs,
-                          mesh);
-    get(get<::Tags::Modal<ScalarTag<0>>>(
-        package_data_up_xi.modal_volume_data)) = up_xi_coeffs;
-    get(get<::Tags::Modal<ScalarTag<0>>>(
-        package_data_lo_xi.modal_volume_data)) = lo_xi_coeffs;
-    get(get<::Tags::Modal<ScalarTag<0>>>(
-        package_data_up_eta.modal_volume_data)) = up_eta_coeffs;
-    get(get<::Tags::Modal<ScalarTag<0>>>(
-        package_data_lo_eta.modal_volume_data)) = lo_eta_coeffs;
-    get(get<::Tags::Modal<ScalarTag<0>>>(
-        package_data_up_zeta.modal_volume_data)) = up_zeta_coeffs;
-    get(get<::Tags::Modal<ScalarTag<0>>>(
-        package_data_lo_zeta.modal_volume_data)) = lo_zeta_coeffs;
+      [&element, &expected, &krivodonova, &mesh, &neighbor_data,
+       &package_data_lo_xi, &package_data_up_xi, &package_data_lo_eta,
+       &package_data_up_eta, &package_data_lo_zeta, &package_data_up_zeta,
+       &nodal_scalar_data_to_limit, &nodal_vector_data_to_limit](
+          const ModalVector& up_xi_coeffs, const ModalVector& up_eta_coeffs,
+          const ModalVector& up_zeta_coeffs, const ModalVector& initial_coeffs,
+          const ModalVector& lo_xi_coeffs, const ModalVector& lo_eta_coeffs,
+          const ModalVector& lo_zeta_coeffs,
+          const ModalVector& expected_coeffs) noexcept {
+        to_nodal_coefficients(&get(nodal_scalar_data_to_limit), initial_coeffs,
+                              mesh);
+        get(get<::Tags::Modal<ScalarTag<0>>>(
+            package_data_up_xi.modal_volume_data)) = up_xi_coeffs;
+        get(get<::Tags::Modal<ScalarTag<0>>>(
+            package_data_lo_xi.modal_volume_data)) = lo_xi_coeffs;
+        get(get<::Tags::Modal<ScalarTag<0>>>(
+            package_data_up_eta.modal_volume_data)) = up_eta_coeffs;
+        get(get<::Tags::Modal<ScalarTag<0>>>(
+            package_data_lo_eta.modal_volume_data)) = lo_eta_coeffs;
+        get(get<::Tags::Modal<ScalarTag<0>>>(
+            package_data_up_zeta.modal_volume_data)) = up_zeta_coeffs;
+        get(get<::Tags::Modal<ScalarTag<0>>>(
+            package_data_lo_zeta.modal_volume_data)) = lo_zeta_coeffs;
 
-    for (size_t i = 0; i < dim; ++i) {
-      to_nodal_coefficients(&nodal_vector_data_to_limit.get(i), initial_coeffs,
-                            mesh);
-      get<::Tags::Modal<VectorTag<dim, 0>>>(
-          package_data_up_xi.modal_volume_data)
-          .get(i) = up_xi_coeffs;
-      get<::Tags::Modal<VectorTag<dim, 0>>>(
-          package_data_lo_xi.modal_volume_data)
-          .get(i) = lo_xi_coeffs;
-      get<::Tags::Modal<VectorTag<dim, 0>>>(
-          package_data_up_eta.modal_volume_data)
-          .get(i) = up_eta_coeffs;
-      get<::Tags::Modal<VectorTag<dim, 0>>>(
-          package_data_lo_eta.modal_volume_data)
-          .get(i) = lo_eta_coeffs;
-      get<::Tags::Modal<VectorTag<dim, 0>>>(
-          package_data_up_zeta.modal_volume_data)
-          .get(i) = up_zeta_coeffs;
-      get<::Tags::Modal<VectorTag<dim, 0>>>(
-          package_data_lo_zeta.modal_volume_data)
-          .get(i) = lo_zeta_coeffs;
-    }
+        for (size_t i = 0; i < dim; ++i) {
+          to_nodal_coefficients(&nodal_vector_data_to_limit.get(i),
+                                initial_coeffs, mesh);
+          get<::Tags::Modal<VectorTag<dim, 0>>>(
+              package_data_up_xi.modal_volume_data)
+              .get(i) = up_xi_coeffs;
+          get<::Tags::Modal<VectorTag<dim, 0>>>(
+              package_data_lo_xi.modal_volume_data)
+              .get(i) = lo_xi_coeffs;
+          get<::Tags::Modal<VectorTag<dim, 0>>>(
+              package_data_up_eta.modal_volume_data)
+              .get(i) = up_eta_coeffs;
+          get<::Tags::Modal<VectorTag<dim, 0>>>(
+              package_data_lo_eta.modal_volume_data)
+              .get(i) = lo_eta_coeffs;
+          get<::Tags::Modal<VectorTag<dim, 0>>>(
+              package_data_up_zeta.modal_volume_data)
+              .get(i) = up_zeta_coeffs;
+          get<::Tags::Modal<VectorTag<dim, 0>>>(
+              package_data_lo_zeta.modal_volume_data)
+              .get(i) = lo_zeta_coeffs;
+        }
 
-    krivodonova(&nodal_scalar_data_to_limit, &nodal_vector_data_to_limit,
-                element, mesh, neighbor_data);
-    to_nodal_coefficients(&expected, expected_coeffs, mesh);
-    CHECK_ITERABLE_APPROX(get(nodal_scalar_data_to_limit), expected);
-    for (size_t i = 0; i < dim; ++i) {
-      CHECK_ITERABLE_APPROX(nodal_vector_data_to_limit.get(i), expected);
-    }
-  };
+        krivodonova(&nodal_scalar_data_to_limit, &nodal_vector_data_to_limit,
+                    element, mesh, neighbor_data);
+        to_nodal_coefficients(&expected, expected_coeffs, mesh);
+        CHECK_ITERABLE_APPROX(get(nodal_scalar_data_to_limit), expected);
+        for (size_t i = 0; i < dim; ++i) {
+          CHECK_ITERABLE_APPROX(nodal_vector_data_to_limit.get(i), expected);
+        }
+      };
 
   // Map between 3D and 1D coefficients:
   // [(0,0,0), (1,0,0), (2,0,0), (0,1,0), (1,1,0), (2,1,0), (0,2,0), (1,2,0),

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActions.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActions.cpp
@@ -199,10 +199,11 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.LimiterActions.Generic",
          Scalar<DataVector>(mesh.number_of_grid_points(), 1234.)});
   }
 
-  const auto emplace_neighbor = [&mesh, &self_id, &coordmap, &runner ](
-      const ElementId<2>& id, const Direction<2>& direction,
-      const OrientationMap<2>& orientation,
-      const Scalar<DataVector>& var) noexcept {
+  const auto emplace_neighbor = [&mesh, &self_id, &coordmap, &runner](
+                                    const ElementId<2>& id,
+                                    const Direction<2>& direction,
+                                    const OrientationMap<2>& orientation,
+                                    const Scalar<DataVector>& var) noexcept {
     const Element<2> element(id, {{direction, {{self_id}, orientation}}});
     auto map = ElementMap<2, Frame::Inertial>(id, coordmap->get_clone());
     ActionTesting::emplace_component_and_initialize<my_component>(
@@ -228,8 +229,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.LimiterActions.Generic",
   {
     CHECK(runner.nonempty_inboxes<my_component, limiter_comm_tag>() ==
           std::unordered_set<ElementId<2>>{west_id, east_id, south_id});
-    const auto check_sent_data = [&runner, &self_id ](
-        const ElementId<2>& id, const Direction<2>& direction) noexcept {
+    const auto check_sent_data = [&runner, &self_id](
+                                     const ElementId<2>& id,
+                                     const Direction<2>& direction) noexcept {
       const auto& inboxes = runner.inboxes<my_component>();
       const auto& inbox = tuples::get<limiter_comm_tag>(inboxes.at(id));
       CHECK(inbox.size() == 1);
@@ -255,10 +257,11 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.LimiterActions.Generic",
   // ApplyLimiter::is_ready reports true, so here we check that the inbox is
   // correctly filled with information from neighbors.
   {
-    const auto check_inbox = [&runner, &self_id ](
-        const ElementId<2>& id, const Direction<2>& direction,
-        const double expected_mean_data,
-        const Mesh<2>& expected_mesh) noexcept {
+    const auto check_inbox = [&runner, &self_id](
+                                 const ElementId<2>& id,
+                                 const Direction<2>& direction,
+                                 const double expected_mean_data,
+                                 const Mesh<2>& expected_mesh) noexcept {
       const auto received_package =
           tuples::get<limiter_comm_tag>(
               runner.inboxes<my_component>().at(self_id))

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActions.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActions.cpp
@@ -69,6 +69,10 @@ class DummyLimiterForTest {
     Mesh<2> mesh_;
   };
   using package_argument_tags = tmpl::list<Var, domain::Tags::Mesh<2>>;
+  // We ignore clang-tidy and instead match the interface of the "real"
+  // limiter implementations, where the package_data function will generally
+  // not be static.
+  // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
   void package_data(const gsl::not_null<PackagedData*> packaged_data,
                     const Scalar<DataVector>& var, const Mesh<2>& mesh,
                     const OrientationMap<2>& orientation_map) const noexcept {

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Minmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Minmod.cpp
@@ -286,25 +286,26 @@ void test_minmod_slopes_on_linear_function(
   const auto element = TestHelpers::Limiters::make_element<1>();
   const auto element_size = make_array<1>(2.0);
 
-  const auto test_activates =
-      [&minmod_type, &tvb_constant, &mesh, &element, &element_size ](
-          const DataVector& local_input, const double left, const double right,
-          const double expected_slope) noexcept {
+  const auto test_activates = [&minmod_type, &tvb_constant, &mesh, &element,
+                               &element_size](
+                                  const DataVector& local_input,
+                                  const double left, const double right,
+                                  const double expected_slope) noexcept {
     const auto expected_slopes = make_array<1>(expected_slope);
     test_minmod_activates(minmod_type, tvb_constant, local_input, mesh, element,
                           element_size, make_two_neighbors(left, right),
                           make_two_neighbors(2.0, 2.0), expected_slopes);
   };
   const auto test_does_not_activate =
-      [&minmod_type, &tvb_constant, &mesh, &element, &element_size ](
+      [&minmod_type, &tvb_constant, &mesh, &element, &element_size](
           const DataVector& local_input, const double left, const double right,
           const double original_slope) noexcept {
-    const auto original_slopes = make_array<1>(original_slope);
-    test_minmod_does_not_activate(
-        minmod_type, tvb_constant, local_input, mesh, element, element_size,
-        make_two_neighbors(left, right), make_two_neighbors(2.0, 2.0),
-        original_slopes);
-  };
+        const auto original_slopes = make_array<1>(original_slope);
+        test_minmod_does_not_activate(
+            minmod_type, tvb_constant, local_input, mesh, element, element_size,
+            make_two_neighbors(left, right), make_two_neighbors(2.0, 2.0),
+            original_slopes);
+      };
 
   // With a MUSCL limiter, the largest allowed slope is half as big as for a
   // LambdaPi1 or LambdaPiN limiter. We can re-use the same test cases by
@@ -315,11 +316,10 @@ void test_minmod_slopes_on_linear_function(
 
   // Test a positive-slope function
   {
-    const auto input = [&muscl_slope_factor, &mesh ]() noexcept {
+    const auto input = [&muscl_slope_factor, &mesh]() noexcept {
       const auto coords = logical_coordinates(mesh);
       return DataVector{3.6 + 1.2 * muscl_slope_factor * get<0>(coords)};
-    }
-    ();
+    }();
 
     // Steepness test
     // Limiter does not reduce slope if (difference of means) > (local slope),
@@ -343,11 +343,10 @@ void test_minmod_slopes_on_linear_function(
 
   // Test a negative-slope function
   {
-    const auto input = [&muscl_slope_factor, &mesh ]() noexcept {
+    const auto input = [&muscl_slope_factor, &mesh]() noexcept {
       const auto coords = logical_coordinates(mesh);
       return DataVector{-0.4 - 0.8 * muscl_slope_factor * get<0>(coords)};
-    }
-    ();
+    }();
 
     // Steepness test
     test_does_not_activate(input, 0.9, -2.3, -0.8 * muscl_slope_factor);
@@ -378,37 +377,37 @@ void test_minmod_slopes_on_quadratic_function(
   const auto element = TestHelpers::Limiters::make_element<1>();
   const auto element_size = make_array<1>(2.0);
 
-  const auto test_activates =
-      [&minmod_type, &tvb_constant, &mesh, &element, &element_size ](
-          const DataVector& local_input, const double left, const double right,
-          const double expected_slope) noexcept {
+  const auto test_activates = [&minmod_type, &tvb_constant, &mesh, &element,
+                               &element_size](
+                                  const DataVector& local_input,
+                                  const double left, const double right,
+                                  const double expected_slope) noexcept {
     const auto expected_slopes = make_array<1>(expected_slope);
     test_minmod_activates(minmod_type, tvb_constant, local_input, mesh, element,
                           element_size, make_two_neighbors(left, right),
                           make_two_neighbors(2.0, 2.0), expected_slopes);
   };
   const auto test_does_not_activate =
-      [&minmod_type, &tvb_constant, &mesh, &element, &element_size ](
+      [&minmod_type, &tvb_constant, &mesh, &element, &element_size](
           const DataVector& local_input, const double left, const double right,
           const double original_slope) noexcept {
-    const auto original_slopes = make_array<1>(original_slope);
-    test_minmod_does_not_activate(
-        minmod_type, tvb_constant, local_input, mesh, element, element_size,
-        make_two_neighbors(left, right), make_two_neighbors(2.0, 2.0),
-        original_slopes);
-  };
+        const auto original_slopes = make_array<1>(original_slope);
+        test_minmod_does_not_activate(
+            minmod_type, tvb_constant, local_input, mesh, element, element_size,
+            make_two_neighbors(left, right), make_two_neighbors(2.0, 2.0),
+            original_slopes);
+      };
 
   const double muscl_slope_factor =
       (minmod_type == Limiters::MinmodType::Muscl) ? 0.5 : 1.0;
 
-  const auto input = [&muscl_slope_factor, &mesh ]() noexcept {
+  const auto input = [&muscl_slope_factor, &mesh]() noexcept {
     const auto coords = logical_coordinates(mesh);
     const auto& x = get<0>(coords);
     // For easier testing, center the quadratic term on the grid: otherwise this
     // term will affect the average slope on the element.
     return DataVector{13.0 + 4.0 * muscl_slope_factor * x + 2.5 * square(x)};
-  }
-  ();
+  }();
   const double mean = mean_value(input, mesh);
 
   // Steepness test
@@ -440,26 +439,27 @@ void test_minmod_slopes_with_tvb_correction(
   const auto element = TestHelpers::Limiters::make_element<1>();
   const auto element_size = make_array<1>(2.0);
 
-  const auto test_activates = [&minmod_type, &mesh, &element, &element_size ](
-      const double tvb_constant, const DataVector& local_input,
-      const double left, const double right,
-      const double expected_slope) noexcept {
+  const auto test_activates = [&minmod_type, &mesh, &element, &element_size](
+                                  const double tvb_constant,
+                                  const DataVector& local_input,
+                                  const double left, const double right,
+                                  const double expected_slope) noexcept {
     const auto expected_slopes = make_array<1>(expected_slope);
     test_minmod_activates(minmod_type, tvb_constant, local_input, mesh, element,
                           element_size, make_two_neighbors(left, right),
                           make_two_neighbors(2.0, 2.0), expected_slopes);
   };
   const auto test_does_not_activate =
-      [&minmod_type, &mesh, &element, &
-       element_size ](const double tvb_constant, const DataVector& local_input,
-                      const double left, const double right,
-                      const double original_slope) noexcept {
-    const auto original_slopes = make_array<1>(original_slope);
-    test_minmod_does_not_activate(
-        minmod_type, tvb_constant, local_input, mesh, element, element_size,
-        make_two_neighbors(left, right), make_two_neighbors(2.0, 2.0),
-        original_slopes);
-  };
+      [&minmod_type, &mesh, &element, &element_size](
+          const double tvb_constant, const DataVector& local_input,
+          const double left, const double right,
+          const double original_slope) noexcept {
+        const auto original_slopes = make_array<1>(original_slope);
+        test_minmod_does_not_activate(
+            minmod_type, tvb_constant, local_input, mesh, element, element_size,
+            make_two_neighbors(left, right), make_two_neighbors(2.0, 2.0),
+            original_slopes);
+      };
 
   // Slopes will be compared to m * h^2, where here h = 2
   const double tvb_m0 = 0.0;
@@ -469,8 +469,7 @@ void test_minmod_slopes_with_tvb_correction(
   const auto input = [&mesh]() noexcept {
     const auto coords = logical_coordinates(mesh);
     return DataVector{21.6 + 7.2 * get<0>(coords)};
-  }
-  ();
+  }();
 
   // The TVB constant sets a threshold slope, below which the solution will not
   // be limited. We test this by increasing the TVB constant until the limiter
@@ -495,28 +494,30 @@ void test_lambda_pin_troubled_cell_tvb_correction(
   const auto logical_coords = logical_coordinates(mesh);
   const auto element_size = make_array<1>(2.0);
 
-  const auto test_activates = [&mesh, &element, &element_size ](
-      const double tvb_constant, const DataVector& local_input,
-      const double left, const double right,
-      const double expected_slope) noexcept {
+  const auto test_activates = [&mesh, &element, &element_size](
+                                  const double tvb_constant,
+                                  const DataVector& local_input,
+                                  const double left, const double right,
+                                  const double expected_slope) noexcept {
     const auto expected_slopes = make_array<1>(expected_slope);
     test_minmod_activates(Limiters::MinmodType::LambdaPiN, tvb_constant,
                           local_input, mesh, element, element_size,
                           make_two_neighbors(left, right),
                           make_two_neighbors(2.0, 2.0), expected_slopes);
   };
-  const auto test_does_not_activate = [&mesh, &element, &element_size ](
-      const double tvb_constant, const DataVector& local_input,
-      const double left, const double right) noexcept {
-    // Because in this test the limiter is LambdaPiN, no slopes are returned,
-    // and no comparison is made. So set these to NaN
-    const auto original_slopes =
-        make_array<1>(std::numeric_limits<double>::signaling_NaN());
-    test_minmod_does_not_activate(
-        Limiters::MinmodType::LambdaPiN, tvb_constant, local_input, mesh,
-        element, element_size, make_two_neighbors(left, right),
-        make_two_neighbors(2.0, 2.0), original_slopes);
-  };
+  const auto test_does_not_activate =
+      [&mesh, &element, &element_size](
+          const double tvb_constant, const DataVector& local_input,
+          const double left, const double right) noexcept {
+        // Because in this test the limiter is LambdaPiN, no slopes are
+        // returned, and no comparison is made. So set these to NaN
+        const auto original_slopes =
+            make_array<1>(std::numeric_limits<double>::signaling_NaN());
+        test_minmod_does_not_activate(
+            Limiters::MinmodType::LambdaPiN, tvb_constant, local_input, mesh,
+            element, element_size, make_two_neighbors(left, right),
+            make_two_neighbors(2.0, 2.0), original_slopes);
+      };
 
   const double m0 = 0.0;
   const double m1 = 1.0;
@@ -525,8 +526,7 @@ void test_lambda_pin_troubled_cell_tvb_correction(
   const auto input = [&mesh]() noexcept {
     const auto coords = logical_coordinates(mesh);
     return DataVector{10.0 * step_function(get<0>(coords))};
-  }
-  ();
+  }();
 
   // Establish baseline m = 0 case; LambdaPiN normally avoids limiting when
   // max(edge - mean) <= min(neighbor - mean)
@@ -567,11 +567,10 @@ void test_minmod_slopes_at_boundary(
 
   const double muscl_slope_factor =
       (minmod_type == Limiters::MinmodType::Muscl) ? 0.5 : 1.0;
-  const auto input = [&muscl_slope_factor, &mesh ]() noexcept {
+  const auto input = [&muscl_slope_factor, &mesh]() noexcept {
     const auto coords = logical_coordinates(mesh);
     return DataVector{1.2 * muscl_slope_factor * get<0>(coords)};
-  }
-  ();
+  }();
 
   // Test with element that has external lower-xi boundary
   const auto element_at_lower_xi_boundary =
@@ -610,37 +609,36 @@ void test_minmod_slopes_with_different_size_neighbor(
   const auto element_size = make_array<1>(dx);
 
   const auto test_activates =
-      [&minmod_type, &tvb_constant, &mesh, &element, &element_size ](
+      [&minmod_type, &tvb_constant, &mesh, &element, &element_size](
           const DataVector& local_input, const double left, const double right,
           const double left_size, const double right_size,
           const double expected_slope) noexcept {
-    const auto expected_slopes = make_array<1>(expected_slope);
-    test_minmod_activates(minmod_type, tvb_constant, local_input, mesh, element,
-                          element_size, make_two_neighbors(left, right),
-                          make_two_neighbors(left_size, right_size),
-                          expected_slopes);
-  };
+        const auto expected_slopes = make_array<1>(expected_slope);
+        test_minmod_activates(
+            minmod_type, tvb_constant, local_input, mesh, element, element_size,
+            make_two_neighbors(left, right),
+            make_two_neighbors(left_size, right_size), expected_slopes);
+      };
   const auto test_does_not_activate =
-      [&minmod_type, &tvb_constant, &mesh, &element, &element_size ](
+      [&minmod_type, &tvb_constant, &mesh, &element, &element_size](
           const DataVector& local_input, const double left, const double right,
           const double left_size, const double right_size,
           const double original_slope) noexcept {
-    const auto original_slopes = make_array<1>(original_slope);
-    test_minmod_does_not_activate(
-        minmod_type, tvb_constant, local_input, mesh, element, element_size,
-        make_two_neighbors(left, right),
-        make_two_neighbors(left_size, right_size), original_slopes);
-  };
+        const auto original_slopes = make_array<1>(original_slope);
+        test_minmod_does_not_activate(
+            minmod_type, tvb_constant, local_input, mesh, element, element_size,
+            make_two_neighbors(left, right),
+            make_two_neighbors(left_size, right_size), original_slopes);
+      };
 
   const double muscl_slope_factor =
       (minmod_type == Limiters::MinmodType::Muscl) ? 0.5 : 1.0;
   const double eps = 100.0 * std::numeric_limits<double>::epsilon();
 
-  const auto input = [&muscl_slope_factor, &mesh ]() noexcept {
+  const auto input = [&muscl_slope_factor, &mesh]() noexcept {
     const auto coords = logical_coordinates(mesh);
     return DataVector{2.0 + 1.2 * muscl_slope_factor * get<0>(coords)};
-  }
-  ();
+  }();
 
   // Establish baseline using evenly-sized elements
   test_does_not_activate(input, 0.8 - eps, 3.2 + eps, dx, dx,
@@ -705,33 +703,32 @@ void test_minmod_limited_slopes_2d() noexcept {
   const auto element_size = make_array<2>(2.0);
 
   const auto test_activates =
-      [&minmod_type, &tvb_constant, &mesh, &element, &
-       element_size ](const DataVector& local_input,
-                      const std::array<double, 4>& neighbor_means,
-                      const std::array<double, 2>& expected_slopes) noexcept {
-    test_minmod_activates(minmod_type, tvb_constant, local_input, mesh, element,
-                          element_size, make_four_neighbors(neighbor_means),
-                          make_four_neighbors(make_array<4>(2.0)),
-                          expected_slopes);
-  };
+      [&minmod_type, &tvb_constant, &mesh, &element, &element_size](
+          const DataVector& local_input,
+          const std::array<double, 4>& neighbor_means,
+          const std::array<double, 2>& expected_slopes) noexcept {
+        test_minmod_activates(
+            minmod_type, tvb_constant, local_input, mesh, element, element_size,
+            make_four_neighbors(neighbor_means),
+            make_four_neighbors(make_array<4>(2.0)), expected_slopes);
+      };
   const auto test_does_not_activate =
-      [&minmod_type, &tvb_constant, &mesh, &element, &
-       element_size ](const DataVector& local_input,
-                      const std::array<double, 4>& neighbor_means,
-                      const std::array<double, 2>& original_slopes) noexcept {
-    test_minmod_does_not_activate(
-        minmod_type, tvb_constant, local_input, mesh, element, element_size,
-        make_four_neighbors(neighbor_means),
-        make_four_neighbors(make_array<4>(2.0)), original_slopes);
-  };
+      [&minmod_type, &tvb_constant, &mesh, &element, &element_size](
+          const DataVector& local_input,
+          const std::array<double, 4>& neighbor_means,
+          const std::array<double, 2>& original_slopes) noexcept {
+        test_minmod_does_not_activate(
+            minmod_type, tvb_constant, local_input, mesh, element, element_size,
+            make_four_neighbors(neighbor_means),
+            make_four_neighbors(make_array<4>(2.0)), original_slopes);
+      };
 
   const auto input = [&mesh]() noexcept {
     const auto coords = logical_coordinates(mesh);
     const auto& x = get<0>(coords);
     const auto& y = get<1>(coords);
     return DataVector{3.0 + x + 2.0 * y + 0.1 * x * y};
-  }
-  ();
+  }();
 
   // Case with no activation
   test_does_not_activate(input, {{1.9, 4.2, -0.5, 5.6}}, {{1.0, 2.0}});
@@ -760,25 +757,25 @@ void test_minmod_limited_slopes_3d() noexcept {
   const auto element_size = make_array<3>(2.0);
 
   const auto test_activates =
-      [&minmod_type, &tvb_constant, &mesh, &element, &
-       element_size ](const DataVector& local_input,
-                      const std::array<double, 6>& neighbor_means,
-                      const std::array<double, 3>& expected_slopes) noexcept {
-    test_minmod_activates(minmod_type, tvb_constant, local_input, mesh, element,
-                          element_size, make_six_neighbors(neighbor_means),
-                          make_six_neighbors(make_array<6>(2.0)),
-                          expected_slopes);
-  };
+      [&minmod_type, &tvb_constant, &mesh, &element, &element_size](
+          const DataVector& local_input,
+          const std::array<double, 6>& neighbor_means,
+          const std::array<double, 3>& expected_slopes) noexcept {
+        test_minmod_activates(
+            minmod_type, tvb_constant, local_input, mesh, element, element_size,
+            make_six_neighbors(neighbor_means),
+            make_six_neighbors(make_array<6>(2.0)), expected_slopes);
+      };
   const auto test_does_not_activate =
-      [&minmod_type, &tvb_constant, &mesh, &element, &
-       element_size ](const DataVector& local_input,
-                      const std::array<double, 6>& neighbor_means,
-                      const std::array<double, 3>& original_slopes) noexcept {
-    test_minmod_does_not_activate(
-        minmod_type, tvb_constant, local_input, mesh, element, element_size,
-        make_six_neighbors(neighbor_means),
-        make_six_neighbors(make_array<6>(2.0)), original_slopes);
-  };
+      [&minmod_type, &tvb_constant, &mesh, &element, &element_size](
+          const DataVector& local_input,
+          const std::array<double, 6>& neighbor_means,
+          const std::array<double, 3>& original_slopes) noexcept {
+        test_minmod_does_not_activate(
+            minmod_type, tvb_constant, local_input, mesh, element, element_size,
+            make_six_neighbors(neighbor_means),
+            make_six_neighbors(make_array<6>(2.0)), original_slopes);
+      };
 
   const auto input = [&mesh]() noexcept {
     const auto coords = logical_coordinates(mesh);
@@ -787,8 +784,7 @@ void test_minmod_limited_slopes_3d() noexcept {
     const auto& z = get<2>(coords);
     return DataVector{2.0 - 1.6 * x + 0.4 * y + 0.4 * z + 0.1 * x * y -
                       0.1 * x * z - 0.2 * y * z};
-  }
-  ();
+  }();
 
   // Case with no activation
   test_does_not_activate(input, {{3.8, -0.1, 1.5, 2.7, 1.2, 2.5}},
@@ -834,14 +830,13 @@ void test_limiter_work(
 
   // Minmod should preserve the mean, so expected = initial
   const double expected_scalar_mean = mean_value(get(scalar_to_limit), mesh);
-  const auto expected_vector_means = [&vector_to_limit, &mesh ]() noexcept {
+  const auto expected_vector_means = [&vector_to_limit, &mesh]() noexcept {
     std::array<double, VolumeDim> means{};
     for (size_t d = 0; d < VolumeDim; ++d) {
       gsl::at(means, d) = mean_value(vector_to_limit.get(d), mesh);
     }
     return means;
-  }
-  ();
+  }();
 
   const auto element = TestHelpers::Limiters::make_element<VolumeDim>();
   const Limiters::Minmod<VolumeDim, tmpl::list<ScalarTag, VectorTag<VolumeDim>>>
@@ -858,15 +853,17 @@ void test_limiter_work(
           approx(gsl::at(expected_vector_means, d)));
   }
 
-  const auto expected_limiter_output = [&logical_coords, &mesh ](
-      const DataVector& input,
-      const std::array<double, VolumeDim> expected_slope) noexcept {
-    auto result = make_with_value<DataVector>(input, mean_value(input, mesh));
-    for (size_t d = 0; d < VolumeDim; ++d) {
-      result += logical_coords.get(d) * gsl::at(expected_slope, d);
-    }
-    return result;
-  };
+  const auto expected_limiter_output =
+      [&logical_coords, &mesh](
+          const DataVector& input,
+          const std::array<double, VolumeDim> expected_slope) noexcept {
+        auto result =
+            make_with_value<DataVector>(input, mean_value(input, mesh));
+        for (size_t d = 0; d < VolumeDim; ++d) {
+          result += logical_coords.get(d) * gsl::at(expected_slope, d);
+        }
+        return result;
+      };
 
   CHECK_ITERABLE_APPROX(
       get(scalar_to_limit),
@@ -890,11 +887,12 @@ void test_minmod_limiter_1d() noexcept {
   const auto logical_coords = logical_coordinates(mesh);
   const auto element_size = make_array<1>(0.5);
   const auto true_slope = std::array<double, 1>{{2.0}};
-  const auto func = [&true_slope](
-      const tnsr::I<DataVector, 1, Frame::Logical>& coords) noexcept {
-    const auto& x = get<0>(coords);
-    return 1.0 + true_slope[0] * x + 3.3 * square(x);
-  };
+  const auto func =
+      [&true_slope](
+          const tnsr::I<DataVector, 1, Frame::Logical>& coords) noexcept {
+        const auto& x = get<0>(coords);
+        return 1.0 + true_slope[0] * x + 3.3 * square(x);
+      };
   const auto data = DataVector{func(logical_coords)};
   const double mean = mean_value(data, mesh);
   const auto input_scalar = ScalarTag::type{data};
@@ -946,13 +944,14 @@ void test_minmod_limiter_2d() noexcept {
   const auto logical_coords = logical_coordinates(mesh);
   const auto element_size = make_array(0.5, 1.0);
   const auto true_slope = std::array<double, 2>{{2.0, -3.0}};
-  const auto& func = [&true_slope](
-      const tnsr::I<DataVector, 2, Frame::Logical>& coords) noexcept {
-    const auto& x = get<0>(coords);
-    const auto& y = get<1>(coords);
-    return 1.0 + true_slope[0] * x + 3.3 * square(x) + true_slope[1] * y +
-           square(y);
-  };
+  const auto& func =
+      [&true_slope](
+          const tnsr::I<DataVector, 2, Frame::Logical>& coords) noexcept {
+        const auto& x = get<0>(coords);
+        const auto& y = get<1>(coords);
+        return 1.0 + true_slope[0] * x + 3.3 * square(x) + true_slope[1] * y +
+               square(y);
+      };
   const auto data = DataVector{func(logical_coords)};
   const double mean = mean_value(data, mesh);
   const auto input_scalar = ScalarTag::type{data};
@@ -1036,14 +1035,15 @@ void test_minmod_limiter_3d() noexcept {
   const auto logical_coords = logical_coordinates(mesh);
   const auto element_size = make_array(0.5, 1.0, 0.8);
   const auto true_slope = std::array<double, 3>{{2.0, -3.0, 1.0}};
-  const auto func = [&true_slope](
-      const tnsr::I<DataVector, 3, Frame::Logical>& coords) noexcept {
-    const auto& x = get<0>(coords);
-    const auto& y = get<1>(coords);
-    const auto& z = get<2>(coords);
-    return 1.0 + true_slope[0] * x + 3.3 * square(x) + true_slope[1] * y +
-           square(y) + true_slope[2] * z - square(z);
-  };
+  const auto func =
+      [&true_slope](
+          const tnsr::I<DataVector, 3, Frame::Logical>& coords) noexcept {
+        const auto& x = get<0>(coords);
+        const auto& y = get<1>(coords);
+        const auto& z = get<2>(coords);
+        return 1.0 + true_slope[0] * x + 3.3 * square(x) + true_slope[1] * y +
+               square(y) + true_slope[2] * z - square(z);
+      };
   const auto data = DataVector{func(logical_coords)};
   const double mean = mean_value(data, mesh);
   const auto input_scalar = ScalarTag::type{data};
@@ -1160,12 +1160,12 @@ void test_limiter_activates_work(
       minmod(make_not_null(&input_to_limit), mesh, element, logical_coords,
              element_size, neighbor_data);
   CHECK(limiter_activated);
-  const ScalarTag::type expected_output = [&logical_coords, &mesh ](
-      const ScalarTag::type& in, const double slope) noexcept {
+  const ScalarTag::type expected_output = [&logical_coords, &mesh](
+                                              const ScalarTag::type& in,
+                                              const double slope) noexcept {
     const double mean = mean_value(get(in), mesh);
     return ScalarTag::type(mean + get<0>(logical_coords) * slope);
-  }
-  (input, expected_slope);
+  }(input, expected_slope);
   CHECK_ITERABLE_APPROX(input_to_limit, expected_output);
 }
 
@@ -1188,10 +1188,10 @@ void test_minmod_limiter_two_lower_xi_neighbors() noexcept {
   const auto element_size = make_array<2>(dx);
 
   const auto mean = 2.0;
-  const auto func = [&mean](
-      const tnsr::I<DataVector, 2, Frame::Logical>& coords) noexcept {
-    return mean + 1.2 * get<0>(coords);
-  };
+  const auto func =
+      [&mean](const tnsr::I<DataVector, 2, Frame::Logical>& coords) noexcept {
+        return mean + 1.2 * get<0>(coords);
+      };
   const auto input = ScalarTag::type(func(logical_coords));
 
   const auto make_neighbors = [&dx](const double left1, const double left2,
@@ -1253,38 +1253,38 @@ void test_minmod_limiter_four_upper_xi_neighbors() noexcept {
   const auto element_size = make_array<3>(dx);
 
   const auto mean = 2.0;
-  const auto func = [&mean](
-      const tnsr::I<DataVector, 3, Frame::Logical>& coords) noexcept {
-    return mean + 1.2 * get<0>(coords);
-  };
+  const auto func =
+      [&mean](const tnsr::I<DataVector, 3, Frame::Logical>& coords) noexcept {
+        return mean + 1.2 * get<0>(coords);
+      };
   const auto input = ScalarTag::type(func(logical_coords));
 
-  const auto make_neighbors = [&dx](
-      const double left, const double right1, const double right2,
-      const double right3, const double right4, const double right1_size,
-      const double right2_size, const double right3_size,
-      const double right4_size) noexcept {
-    using Pack = Limiters::Minmod<3, tmpl::list<ScalarTag>>::PackagedData;
-    return std::unordered_map<
-        std::pair<Direction<3>, ElementId<3>>, Pack,
-        boost::hash<std::pair<Direction<3>, ElementId<3>>>>{
-        std::make_pair(
-            std::make_pair(Direction<3>::lower_xi(), ElementId<3>(1)),
-            Pack{Scalar<double>(left), make_array<3>(dx)}),
-        std::make_pair(
-            std::make_pair(Direction<3>::upper_xi(), ElementId<3>(2)),
-            Pack{Scalar<double>(right1), make_array(right1_size, dx, dx)}),
-        std::make_pair(
-            std::make_pair(Direction<3>::upper_xi(), ElementId<3>(7)),
-            Pack{Scalar<double>(right2), make_array(right2_size, dx, dx)}),
-        std::make_pair(
-            std::make_pair(Direction<3>::upper_xi(), ElementId<3>(8)),
-            Pack{Scalar<double>(right3), make_array(right3_size, dx, dx)}),
-        std::make_pair(
-            std::make_pair(Direction<3>::upper_xi(), ElementId<3>(9)),
-            Pack{Scalar<double>(right4), make_array(right4_size, dx, dx)}),
-    };
-  };
+  const auto make_neighbors =
+      [&dx](const double left, const double right1, const double right2,
+            const double right3, const double right4, const double right1_size,
+            const double right2_size, const double right3_size,
+            const double right4_size) noexcept {
+        using Pack = Limiters::Minmod<3, tmpl::list<ScalarTag>>::PackagedData;
+        return std::unordered_map<
+            std::pair<Direction<3>, ElementId<3>>, Pack,
+            boost::hash<std::pair<Direction<3>, ElementId<3>>>>{
+            std::make_pair(
+                std::make_pair(Direction<3>::lower_xi(), ElementId<3>(1)),
+                Pack{Scalar<double>(left), make_array<3>(dx)}),
+            std::make_pair(
+                std::make_pair(Direction<3>::upper_xi(), ElementId<3>(2)),
+                Pack{Scalar<double>(right1), make_array(right1_size, dx, dx)}),
+            std::make_pair(
+                std::make_pair(Direction<3>::upper_xi(), ElementId<3>(7)),
+                Pack{Scalar<double>(right2), make_array(right2_size, dx, dx)}),
+            std::make_pair(
+                std::make_pair(Direction<3>::upper_xi(), ElementId<3>(8)),
+                Pack{Scalar<double>(right3), make_array(right3_size, dx, dx)}),
+            std::make_pair(
+                std::make_pair(Direction<3>::upper_xi(), ElementId<3>(9)),
+                Pack{Scalar<double>(right4), make_array(right4_size, dx, dx)}),
+        };
+      };
 
   const Limiters::Minmod<3, tmpl::list<ScalarTag>> minmod(
       Limiters::MinmodType::LambdaPi1);

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_MinmodTci.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_MinmodTci.cpp
@@ -86,9 +86,10 @@ void test_tci_on_linear_function(const size_t number_of_grid_points) noexcept {
 
   // Lambda takes tvb_scale = tvb_constant * h^2, to facilitate specifying
   // critical threshold values for testing
-  const auto test_tci = [&mesh, &element ](
-      const bool expected, const DataVector& input, const double left_mean,
-      const double right_mean, const double tvb_scale) noexcept {
+  const auto test_tci = [&mesh, &element](
+                            const bool expected, const DataVector& input,
+                            const double left_mean, const double right_mean,
+                            const double tvb_scale) noexcept {
     const double h = 1.2;
     const double tvb_constant = tvb_scale / square(h);
     const auto element_size = make_array<1>(h);
@@ -102,8 +103,7 @@ void test_tci_on_linear_function(const size_t number_of_grid_points) noexcept {
   const DataVector input = [&mesh]() noexcept {
     const auto x = get<0>(logical_coordinates(mesh));
     return DataVector{1.6 + 0.2 * x};
-  }
-  ();
+  }();
 
   // Test trigger due to left, right neighbors
   test_tci(false, input, 1.35, 1.85, 0.0);
@@ -134,9 +134,10 @@ void test_tci_on_quadratic_function(
 
   // Lambda takes tvb_scale = tvb_constant * h^2, to facilitate specifying
   // critical threshold values for testing
-  const auto test_tci = [&mesh, &element ](
-      const bool expected, const DataVector& input, const double left_mean,
-      const double right_mean, const double tvb_scale) noexcept {
+  const auto test_tci = [&mesh, &element](
+                            const bool expected, const DataVector& input,
+                            const double left_mean, const double right_mean,
+                            const double tvb_scale) noexcept {
     const double h = 1.2;
     const double tvb_constant = tvb_scale / square(h);
     const auto element_size = make_array<1>(h);
@@ -151,8 +152,7 @@ void test_tci_on_quadratic_function(
   const DataVector input = [&mesh]() noexcept {
     const auto x = get<0>(logical_coordinates(mesh));
     return DataVector{1.45 + 0.2 * x + 0.15 * square(x)};
-  }
-  ();
+  }();
 
   // Test trigger due to left, right neighbors
   test_tci(false, input, 1.15, 1.85, 0.0);
@@ -171,8 +171,7 @@ void test_tci_on_quadratic_function(
   const DataVector input2 = [&mesh]() noexcept {
     const auto x = get<0>(logical_coordinates(mesh));
     return DataVector{1.4 + 0.1 * x + 0.3 * square(x)};
-  }
-  ();
+  }();
 
   // Because left-to-mean and mean-to-right slopes have different signs,
   // any TCI call with TVB=0 should trigger
@@ -207,8 +206,7 @@ void test_tci_at_boundary(const size_t number_of_grid_points) noexcept {
   const auto input = [&mesh]() noexcept {
     const auto coords = logical_coordinates(mesh);
     return DataVector{1.2 * get<0>(coords)};
-  }
-  ();
+  }();
 
   // Test with element that has external lower-xi boundary
   const auto element_at_lower_xi_boundary =
@@ -242,10 +240,11 @@ void test_tci_with_different_size_neighbor(
   const double dx = 1.0;
   const auto element_size = make_array<1>(dx);
 
-  const auto test_tci = [&tvb_constant, &element, &mesh, &element_size ](
-      const bool expected_detection, const DataVector& local_input,
-      const double left, const double right, const double left_size,
-      const double right_size) noexcept {
+  const auto test_tci = [&tvb_constant, &element, &mesh, &element_size](
+                            const bool expected_detection,
+                            const DataVector& local_input, const double left,
+                            const double right, const double left_size,
+                            const double right_size) noexcept {
     test_tci_detection(expected_detection, tvb_constant, local_input, mesh,
                        element, element_size, make_two_neighbors(left, right),
                        make_two_neighbors(left_size, right_size));
@@ -256,8 +255,7 @@ void test_tci_with_different_size_neighbor(
   const auto input = [&mesh]() noexcept {
     const auto coords = logical_coordinates(mesh);
     return DataVector{2.0 + 1.2 * get<0>(coords)};
-  }
-  ();
+  }();
 
   // Establish baseline using evenly-sized elements
   test_tci(false, input, 0.8 - eps, 3.2 + eps, dx, dx);
@@ -306,22 +304,22 @@ void test_tvb_minmod_tci_2d() noexcept {
                      Spectral::Quadrature::GaussLobatto);
   const auto element_size = make_array<2>(2.0);
 
-  const auto test_tci = [&tvb_constant, &element, &mesh, &element_size ](
-      const bool expected_detection, const DataVector& local_input,
-      const std::array<double, 4>& neighbor_means) noexcept {
-    test_tci_detection(expected_detection, tvb_constant, local_input, mesh,
-                       element, element_size,
-                       make_four_neighbors(neighbor_means),
-                       make_four_neighbors(make_array<4>(2.0)));
-  };
+  const auto test_tci =
+      [&tvb_constant, &element, &mesh, &element_size](
+          const bool expected_detection, const DataVector& local_input,
+          const std::array<double, 4>& neighbor_means) noexcept {
+        test_tci_detection(expected_detection, tvb_constant, local_input, mesh,
+                           element, element_size,
+                           make_four_neighbors(neighbor_means),
+                           make_four_neighbors(make_array<4>(2.0)));
+      };
 
   const auto input = [&mesh]() noexcept {
     const auto coords = logical_coordinates(mesh);
     const auto& x = get<0>(coords);
     const auto& y = get<1>(coords);
     return DataVector{3.0 + x + 2.0 * y + 0.1 * x * y};
-  }
-  ();
+  }();
 
   // Case with no activation
   test_tci(false, input, {{1.9, 4.2, -0.5, 5.6}});
@@ -349,14 +347,15 @@ void test_tvb_minmod_tci_3d() noexcept {
                      Spectral::Quadrature::GaussLobatto);
   const auto element_size = make_array<3>(2.0);
 
-  const auto test_tci = [&tvb_constant, &element, &mesh, &element_size ](
-      const bool expected_detection, const DataVector& local_input,
-      const std::array<double, 6>& neighbor_means) noexcept {
-    test_tci_detection(expected_detection, tvb_constant, local_input, mesh,
-                       element, element_size,
-                       make_six_neighbors(neighbor_means),
-                       make_six_neighbors(make_array<6>(2.0)));
-  };
+  const auto test_tci =
+      [&tvb_constant, &element, &mesh, &element_size](
+          const bool expected_detection, const DataVector& local_input,
+          const std::array<double, 6>& neighbor_means) noexcept {
+        test_tci_detection(expected_detection, tvb_constant, local_input, mesh,
+                           element, element_size,
+                           make_six_neighbors(neighbor_means),
+                           make_six_neighbors(make_array<6>(2.0)));
+      };
 
   const auto input = [&mesh]() noexcept {
     const auto coords = logical_coordinates(mesh);
@@ -365,8 +364,7 @@ void test_tvb_minmod_tci_3d() noexcept {
     const auto& z = get<2>(coords);
     return DataVector{2.0 - 1.6 * x + 0.4 * y + 0.4 * z + 0.1 * x * y -
                       0.1 * x * z - 0.2 * y * z};
-  }
-  ();
+  }();
 
   // Case with no activation
   test_tci(false, input, {{3.8, -0.1, 1.5, 2.7, 1.2, 2.5}});

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Weno.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Weno.cpp
@@ -160,14 +160,13 @@ void test_package_data_work(
   weno.package_data(make_not_null(&packaged_data), input_scalar, input_vector,
                     mesh, element_size, orientation_map);
 
-  const Variables<TagList> oriented_vars =
-      [&mesh, &input_scalar, &input_vector, &orientation_map ]() noexcept {
+  const Variables<TagList> oriented_vars = [&mesh, &input_scalar, &input_vector,
+                                            &orientation_map]() noexcept {
     Variables<TagList> input_vars(mesh.number_of_grid_points());
     get<ScalarTag>(input_vars) = input_scalar;
     get<VectorTag<VolumeDim>>(input_vars) = input_vector;
     return orient_variables(input_vars, mesh.extents(), orientation_map);
-  }
-  ();
+  }();
   CHECK(packaged_data.volume_data == oriented_vars);
   CHECK(packaged_data.mesh == orientation_map(mesh));
   CHECK(packaged_data.element_size ==
@@ -285,20 +284,20 @@ make_neighbor_data_from_neighbor_vars(
     const Mesh<VolumeDim>& mesh, const Element<VolumeDim>& element,
     const std::array<double, VolumeDim>& element_size,
     const VariablesMap<VolumeDim>& neighbor_vars) noexcept {
-  const auto make_tuple_of_means = [&mesh](
-      const Variables<tmpl::list<ScalarTag, VectorTag<VolumeDim>>>&
-          vars_to_average) noexcept {
-    tuples::TaggedTuple<::Tags::Mean<ScalarTag>,
-                        ::Tags::Mean<VectorTag<VolumeDim>>>
-        result;
-    get(get<::Tags::Mean<ScalarTag>>(result)) =
-        mean_value(get(get<ScalarTag>(vars_to_average)), mesh);
-    for (size_t d = 0; d < VolumeDim; ++d) {
-      get<::Tags::Mean<VectorTag<VolumeDim>>>(result).get(d) =
-          mean_value(get<VectorTag<VolumeDim>>(vars_to_average).get(d), mesh);
-    }
-    return result;
-  };
+  const auto make_tuple_of_means =
+      [&mesh](const Variables<tmpl::list<ScalarTag, VectorTag<VolumeDim>>>&
+                  vars_to_average) noexcept {
+        tuples::TaggedTuple<::Tags::Mean<ScalarTag>,
+                            ::Tags::Mean<VectorTag<VolumeDim>>>
+            result;
+        get(get<::Tags::Mean<ScalarTag>>(result)) =
+            mean_value(get(get<ScalarTag>(vars_to_average)), mesh);
+        for (size_t d = 0; d < VolumeDim; ++d) {
+          get<::Tags::Mean<VectorTag<VolumeDim>>>(result).get(d) = mean_value(
+              get<VectorTag<VolumeDim>>(vars_to_average).get(d), mesh);
+        }
+        return result;
+      };
 
   std::unordered_map<
       std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>,

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoGridHelpers.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoGridHelpers.cpp
@@ -71,30 +71,31 @@ template <size_t VolumeDim>
 void check_grid_point_transform_no_href(
     const Mesh<VolumeDim>& local_mesh, const Mesh<VolumeDim>& neighbor_mesh,
     const Element<VolumeDim>& element) noexcept {
-  const auto check = [&local_mesh, &neighbor_mesh ](
-      const std::array<DataVector, VolumeDim>& transformed_coords,
-      const bool local_mesh_provides_grid_points, const size_t dim,
-      const double offset) noexcept {
-    const Mesh<VolumeDim>& source_mesh =
-        (local_mesh_provides_grid_points ? local_mesh : neighbor_mesh);
-    for (size_t i = 0; i < VolumeDim; ++i) {
-      const DataVector source_coords =
-          get<0>(logical_coordinates(source_mesh.slice_through(i)));
-      if (i == dim) {
-        // Coordinates normal to the interface
-        const DataVector expected_coords = source_coords + offset;
-        CHECK(gsl::at(transformed_coords, i) == expected_coords);
-      } else {
-        // Coordinates parallel to the interface
-        if (neighbor_mesh.slice_through(i) == local_mesh.slice_through(i)) {
-          CHECK(gsl::at(transformed_coords, i).size() == 0);
-        } else {
-          const DataVector& expected_coords = source_coords;
-          CHECK(gsl::at(transformed_coords, i) == expected_coords);
+  const auto check =
+      [&local_mesh, &neighbor_mesh](
+          const std::array<DataVector, VolumeDim>& transformed_coords,
+          const bool local_mesh_provides_grid_points, const size_t dim,
+          const double offset) noexcept {
+        const Mesh<VolumeDim>& source_mesh =
+            (local_mesh_provides_grid_points ? local_mesh : neighbor_mesh);
+        for (size_t i = 0; i < VolumeDim; ++i) {
+          const DataVector source_coords =
+              get<0>(logical_coordinates(source_mesh.slice_through(i)));
+          if (i == dim) {
+            // Coordinates normal to the interface
+            const DataVector expected_coords = source_coords + offset;
+            CHECK(gsl::at(transformed_coords, i) == expected_coords);
+          } else {
+            // Coordinates parallel to the interface
+            if (neighbor_mesh.slice_through(i) == local_mesh.slice_through(i)) {
+              CHECK(gsl::at(transformed_coords, i).size() == 0);
+            } else {
+              const DataVector& expected_coords = source_coords;
+              CHECK(gsl::at(transformed_coords, i) == expected_coords);
+            }
+          }
         }
-      }
-    }
-  };
+      };
 
   for (size_t dim = 0; dim < VolumeDim; ++dim) {
     const auto from_lower =

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoHelpers.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoHelpers.cpp
@@ -29,22 +29,22 @@ void test_reconstruction_1d() noexcept {
                      Spectral::Quadrature::GaussLobatto);
   const auto coords = logical_coordinates(mesh);
 
-  const auto evaluate_polynomial = [&coords](
-      const std::array<double, 5>& coeffs) noexcept {
-    const auto& x = get<0>(coords);
-    return DataVector{coeffs[0] + coeffs[1] * x + coeffs[2] * square(x) +
-                      coeffs[3] * cube(x) + coeffs[4] * pow<4>(x)};
-  };
+  const auto evaluate_polynomial =
+      [&coords](const std::array<double, 5>& coeffs) noexcept {
+        const auto& x = get<0>(coords);
+        return DataVector{coeffs[0] + coeffs[1] * x + coeffs[2] * square(x) +
+                          coeffs[3] * cube(x) + coeffs[4] * pow<4>(x)};
+      };
 
   DataVector local_data = evaluate_polynomial({{1., 2., 0., 0.5, 0.1}});
   // WENO reconstruction should preserve the mean, so expected = initial
   const double expected_local_mean = mean_value(local_data, mesh);
 
   const auto shift_data_to_local_mean =
-      [&mesh, &expected_local_mean ](const DataVector& neighbor_data) noexcept {
-    return neighbor_data + expected_local_mean -
-           mean_value(neighbor_data, mesh);
-  };
+      [&mesh, &expected_local_mean](const DataVector& neighbor_data) noexcept {
+        return neighbor_data + expected_local_mean -
+               mean_value(neighbor_data, mesh);
+      };
 
   std::unordered_map<std::pair<Direction<1>, ElementId<1>>, DataVector,
                      boost::hash<std::pair<Direction<1>, ElementId<1>>>>
@@ -73,15 +73,15 @@ void test_reconstruction_2d() noexcept {
                      Spectral::Quadrature::GaussLobatto);
   const auto coords = logical_coordinates(mesh);
 
-  const auto evaluate_polynomial = [&coords](
-      const std::array<double, 9>& coeffs) noexcept {
-    const auto& x = get<0>(coords);
-    const auto& y = get<1>(coords);
-    return DataVector{coeffs[0] + coeffs[1] * x + coeffs[2] * square(x) +
-                      y * (coeffs[3] + coeffs[4] * x + coeffs[5] * square(x)) +
-                      square(y) *
-                          (coeffs[6] + coeffs[7] * x + coeffs[8] * square(x))};
-  };
+  const auto evaluate_polynomial =
+      [&coords](const std::array<double, 9>& coeffs) noexcept {
+        const auto& x = get<0>(coords);
+        const auto& y = get<1>(coords);
+        return DataVector{
+            coeffs[0] + coeffs[1] * x + coeffs[2] * square(x) +
+            y * (coeffs[3] + coeffs[4] * x + coeffs[5] * square(x)) +
+            square(y) * (coeffs[6] + coeffs[7] * x + coeffs[8] * square(x))};
+      };
 
   DataVector local_data =
       evaluate_polynomial({{2., 1., 0., 1.5, 1., 0., 1., 0., 0.}});
@@ -89,10 +89,10 @@ void test_reconstruction_2d() noexcept {
   const double expected_local_mean = mean_value(local_data, mesh);
 
   const auto shift_data_to_local_mean =
-      [&mesh, &expected_local_mean ](const DataVector& neighbor_data) noexcept {
-    return neighbor_data + expected_local_mean -
-           mean_value(neighbor_data, mesh);
-  };
+      [&mesh, &expected_local_mean](const DataVector& neighbor_data) noexcept {
+        return neighbor_data + expected_local_mean -
+               mean_value(neighbor_data, mesh);
+      };
 
   std::unordered_map<std::pair<Direction<2>, ElementId<2>>, DataVector,
                      boost::hash<std::pair<Direction<2>, ElementId<2>>>>
@@ -132,25 +132,25 @@ void test_reconstruction_3d() noexcept {
 
   // 3D case has so many modes... so we simplify by only setting 6 of them, the
   // choice of modes to use here is arbitrary.
-  const auto evaluate_polynomial = [&coords](
-      const std::array<double, 6>& coeffs) noexcept {
-    const auto& x = get<0>(coords);
-    const auto& y = get<1>(coords);
-    const auto& z = get<2>(coords);
-    return DataVector{coeffs[0] + coeffs[1] * y + coeffs[2] * x * z +
-                      coeffs[3] * x * y * z + coeffs[4] * square(y) * z +
-                      coeffs[5] * square(x) * y * square(z)};
-  };
+  const auto evaluate_polynomial =
+      [&coords](const std::array<double, 6>& coeffs) noexcept {
+        const auto& x = get<0>(coords);
+        const auto& y = get<1>(coords);
+        const auto& z = get<2>(coords);
+        return DataVector{coeffs[0] + coeffs[1] * y + coeffs[2] * x * z +
+                          coeffs[3] * x * y * z + coeffs[4] * square(y) * z +
+                          coeffs[5] * square(x) * y * square(z)};
+      };
 
   DataVector local_data = evaluate_polynomial({{1., 0.5, 0.5, 0.2, 0.2, 0.1}});
   // WENO reconstruction should preserve the mean, so expected = initial
   const double expected_local_mean = mean_value(local_data, mesh);
 
   const auto shift_data_to_local_mean =
-      [&mesh, &expected_local_mean ](const DataVector& neighbor_data) noexcept {
-    return neighbor_data + expected_local_mean -
-           mean_value(neighbor_data, mesh);
-  };
+      [&mesh, &expected_local_mean](const DataVector& neighbor_data) noexcept {
+        return neighbor_data + expected_local_mean -
+               mean_value(neighbor_data, mesh);
+      };
 
   // We skip one neighbor, lower_eta, to simulate an external boundary
   std::unordered_map<std::pair<Direction<3>, ElementId<3>>, DataVector,


### PR DESCRIPTION
## Proposed changes

- updates CMakeLists.txt for new design
- applies recent clang-format, mostly affecting lambda formatting
- applies recent clang-tidy

The newer clang-tidy finds some issues that I fixed and/or NOLINTed, but also raises a lot of complaints from statements like `CHECK(some_bool)`, e.g.,
```
tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Minmod.cpp:249:3: error: this loop is infinite; none of its condition variables (reduce_slopes) are updated in the loop body [bugprone-infinite-loop,-warnings-as-errors]
  CHECK(reduce_slopes);
  ^
```

These are not fixed.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
