### PR TITLE
Two minor DataBox improvements

### DIFF
--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -379,7 +379,7 @@ class DataBox<tmpl::list<Tags...>>
 
   /// A list of all the compute item tags, excluding their subitems
   using compute_item_tags =
-      tmpl::filter<tags_list, db::is_compute_item<tmpl::_1>>;
+      tmpl::filter<tags_list, db::is_compute_tag<tmpl::_1>>;
 
   /// A list of all the compute items, including subitems from the compute items
   using compute_with_subitems_tags =
@@ -580,12 +580,12 @@ class DataBox<tmpl::list<Tags...>>
       tmpl::list<Subtags...> /*meta*/) noexcept;
 
   template <typename ComputeItem,
-            Requires<not db::is_compute_item_v<ComputeItem>> = nullptr>
+            Requires<not db::is_compute_tag_v<ComputeItem>> = nullptr>
   constexpr void add_reset_compute_item_to_box(tmpl::list<> /*meta*/) noexcept {
   }
 
   template <typename ComputeItem, typename... ComputeItemArgumentsTags,
-            Requires<db::is_compute_item_v<ComputeItem>> = nullptr>
+            Requires<db::is_compute_tag_v<ComputeItem>> = nullptr>
   constexpr void add_reset_compute_item_to_box(
       tmpl::list<ComputeItemArgumentsTags...> /*meta*/) noexcept;
 
@@ -656,7 +656,7 @@ struct get_argument_list_impl<true> {
 /// then it returns tmpl::list<>
 template <class Tag>
 using get_argument_list = typename get_argument_list_impl<
-    ::db::is_compute_item_v<Tag>>::template f<Tag>;
+    ::db::is_compute_tag_v<Tag>>::template f<Tag>;
 }  // namespace DataBox_detail
 
 template <typename... Tags>
@@ -946,7 +946,7 @@ void DataBox<tmpl::list<Tags...>>::pup_impl(
 // Classes and functions necessary for db::mutate to work
 template <typename... Tags>
 template <typename ComputeItem, typename... ComputeItemArgumentsTags,
-          Requires<db::is_compute_item_v<ComputeItem>>>
+          Requires<db::is_compute_tag_v<ComputeItem>>>
 SPECTRE_ALWAYS_INLINE constexpr void
 DataBox<tmpl::list<Tags...>>::add_reset_compute_item_to_box(
     tmpl::list<ComputeItemArgumentsTags...> /*meta*/) noexcept {
@@ -991,7 +991,7 @@ db::DataBox<tmpl::list<Tags...>>::mutate_subitem_tags_in_box(
           make_not_null(&get_deferred<tag>().mutate()));
     });
 
-  EXPAND_PACK_LEFT_TO_RIGHT(helper(Subtags{}, is_compute_item<ParentTag>{}));
+  EXPAND_PACK_LEFT_TO_RIGHT(helper(Subtags{}, is_compute_tag<ParentTag>{}));
 }
 
 /*!
@@ -1199,11 +1199,11 @@ SPECTRE_ALWAYS_INLINE constexpr auto create(Args&&... args) {
   static_assert(tt::is_a_v<tmpl::list, AddSimpleTags>,
                 "AddSimpleTags must be a tmpl::list");
   static_assert(
-      not tmpl::any<AddSimpleTags, is_compute_item<tmpl::_1>>::value,
+      not tmpl::any<AddSimpleTags, is_compute_tag<tmpl::_1>>::value,
       "Cannot add any ComputeTags in the AddSimpleTags list, must use the "
       "AddComputeTags list.");
   static_assert(
-      tmpl::all<AddComputeTags, is_compute_item<tmpl::_1>>::value,
+      tmpl::all<AddComputeTags, is_compute_tag<tmpl::_1>>::value,
       "Cannot add any SimpleTags in the AddComputeTags list, must use the "
       "AddSimpleTags list.");
 
@@ -1241,7 +1241,7 @@ SPECTRE_ALWAYS_INLINE constexpr auto create_from(Box&& box,
 
   // 2. Expand simple remove tags and compute remove tags
   using compute_tags_to_remove =
-      tmpl::filter<remove_tags, db::is_compute_item<tmpl::_1>>;
+      tmpl::filter<remove_tags, db::is_compute_tag<tmpl::_1>>;
   using compute_tags_to_remove_with_subitems =
       DataBox_detail::expand_subitems_from_list<old_box_tags,
                                                 compute_tags_to_remove>;
@@ -1742,7 +1742,7 @@ SPECTRE_ALWAYS_INLINE constexpr auto mutate_apply(
  * \brief Get all the Tags that are compute items from the `TagList`
  */
 template <class TagList>
-using get_compute_items = tmpl::filter<TagList, db::is_compute_item<tmpl::_1>>;
+using get_compute_items = tmpl::filter<TagList, db::is_compute_tag<tmpl::_1>>;
 
 /*!
  * \ingroup DataBoxGroup
@@ -1750,8 +1750,7 @@ using get_compute_items = tmpl::filter<TagList, db::is_compute_item<tmpl::_1>>;
  */
 template <class TagList>
 using get_items =
-    tmpl::filter<TagList,
-                 tmpl::not_<tmpl::bind<db::is_compute_item, tmpl::_1>>>;
+    tmpl::filter<TagList, tmpl::not_<tmpl::bind<db::is_compute_tag, tmpl::_1>>>;
 
 namespace DataBox_detail {
 template <class ItemsList, class ComputeItemsList>

--- a/src/DataStructures/DataBox/DataBoxTag.hpp
+++ b/src/DataStructures/DataBox/DataBoxTag.hpp
@@ -142,12 +142,12 @@ struct storage_type_impl {
   using type = typename dispatch_storage_type<
       is_base_tag_v<Tag>
           ? 4
-          : (is_compute_item_v<Tag>and has_return_type_member_v<Tag>)
+          : (is_compute_tag_v<Tag>and has_return_type_member_v<Tag>)
                 ? 3
-                : is_compute_item_v<Tag> ? 2
-                                         : std::is_base_of_v<db::SimpleTag, Tag>
-                                               ? 1
-                                               : 0>::template f<TagList, Tag>;
+                : is_compute_tag_v<Tag> ? 2
+                                        : std::is_base_of_v<db::SimpleTag, Tag>
+                                              ? 1
+                                              : 0>::template f<TagList, Tag>;
 };
 
 template <>
@@ -220,7 +220,7 @@ using storage_type = typename storage_type_impl<TagList, Tag>::type;
 
 template <typename TagList, typename Tag>
 struct item_type_impl {
-  static_assert(not is_compute_item_v<Tag>,
+  static_assert(not is_compute_tag_v<Tag>,
                 "Can't call item_type on a compute item because compute items "
                 "cannot be modified.  You probably wanted const_item_type.");
   using type = DataBox_detail::storage_type<Tag, TagList>;

--- a/src/DataStructures/DataBox/TagName.hpp
+++ b/src/DataStructures/DataBox/TagName.hpp
@@ -26,19 +26,19 @@ struct tag_name_impl;
 
 template <typename Tag, typename = std::nullptr_t, typename = std::void_t<>>
 struct tag_name_impl2 {
-  static_assert(not is_compute_item_v<Tag>,
+  static_assert(not is_compute_tag_v<Tag>,
                 "Compute tags must have a name function or a base alias.");
   static std::string name() noexcept { return pretty_type::short_name<Tag>(); }
 };
 
 template <typename Tag>
-struct tag_name_impl2<Tag, Requires<is_compute_item_v<Tag>>,
+struct tag_name_impl2<Tag, Requires<is_compute_tag_v<Tag>>,
                       std::void_t<typename Tag::base>>
     : tag_name_impl<typename Tag::base> {};
 
 template <typename Tag>
 struct tag_name_impl2<Tag, Requires<std::is_base_of_v<db::PrefixTag, Tag> and
-                                    not is_compute_item_v<Tag>>> {
+                                    not is_compute_tag_v<Tag>>> {
   static std::string name() noexcept {
     return pretty_type::short_name<Tag>() + "(" +
            tag_name_impl<typename Tag::tag>::name() + ")";

--- a/src/DataStructures/DataBox/TagName.hpp
+++ b/src/DataStructures/DataBox/TagName.hpp
@@ -11,6 +11,8 @@
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TypeTraits.hpp"
+#include "Utilities/TypeTraits/CreateHasTypeAlias.hpp"
+#include "Utilities/TypeTraits/CreateIsCallable.hpp"
 
 /// \cond
 namespace db {
@@ -20,37 +22,12 @@ struct PrefixTag;
 
 namespace db {
 
-namespace DataBox_detail {
-template <typename Tag, typename = std::void_t<>>
-struct tag_name_impl;
-
-template <typename Tag, typename = std::nullptr_t, typename = std::void_t<>>
-struct tag_name_impl2 {
-  static_assert(not is_compute_tag_v<Tag>,
-                "Compute tags must have a name function or a base alias.");
-  static std::string name() noexcept { return pretty_type::short_name<Tag>(); }
-};
-
-template <typename Tag>
-struct tag_name_impl2<Tag, Requires<is_compute_tag_v<Tag>>,
-                      std::void_t<typename Tag::base>>
-    : tag_name_impl<typename Tag::base> {};
-
-template <typename Tag>
-struct tag_name_impl2<Tag, Requires<std::is_base_of_v<db::PrefixTag, Tag> and
-                                    not is_compute_tag_v<Tag>>> {
-  static std::string name() noexcept {
-    return pretty_type::short_name<Tag>() + "(" +
-           tag_name_impl<typename Tag::tag>::name() + ")";
-  }
-};
-
-template <typename Tag, typename>
-struct tag_name_impl : tag_name_impl2<Tag> {};
-
-template <typename Tag>
-struct tag_name_impl<Tag, std::void_t<decltype(Tag::name())>> : public Tag {};
-}  // namespace DataBox_detail
+namespace detail {
+CREATE_IS_CALLABLE(name)
+CREATE_IS_CALLABLE_V(name)
+CREATE_HAS_TYPE_ALIAS(base)
+CREATE_HAS_TYPE_ALIAS_V(base)
+}  // namespace detail
 
 /*!
  * \ingroup DataBoxGroup
@@ -65,7 +42,17 @@ struct tag_name_impl<Tag, std::void_t<decltype(Tag::name())>> : public Tag {};
  */
 template <typename Tag>
 std::string tag_name() noexcept {
-  return DataBox_detail::tag_name_impl<Tag>::name();
+  if constexpr (detail::is_name_callable_v<Tag>) {
+    return Tag::name();
+  } else if constexpr (db::is_compute_tag_v<Tag>) {
+    static_assert(detail::has_base_v<Tag>,
+                  "Compute tags must have a name function or a base alias");
+    return tag_name<typename Tag::base>();
+  } else if constexpr (std::is_base_of_v<db::PrefixTag, Tag>) {
+    return pretty_type::short_name<Tag>() + "(" +
+           tag_name<typename Tag::tag>() + ")";
+  } else {
+    return pretty_type::short_name<Tag>();
+  }
 }
-
 }  // namespace db

--- a/src/DataStructures/DataBox/TagTraits.hpp
+++ b/src/DataStructures/DataBox/TagTraits.hpp
@@ -24,15 +24,15 @@ namespace db {
  * \brief Check if `Tag` derives off of db::ComputeTag
  */
 template <typename Tag, typename = std::nullptr_t>
-struct is_compute_item : std::false_type {};
+struct is_compute_tag : std::false_type {};
 /// \cond HIDDEN_SYMBOLS
 template <typename Tag>
-struct is_compute_item<Tag, Requires<std::is_base_of_v<db::ComputeTag, Tag>>>
+struct is_compute_tag<Tag, Requires<std::is_base_of_v<db::ComputeTag, Tag>>>
     : std::true_type {};
 /// \endcond
 
 template <typename Tag>
-constexpr bool is_compute_item_v = is_compute_item<Tag>::value;
+constexpr bool is_compute_tag_v = is_compute_tag<Tag>::value;
 // @}
 
 // @{
@@ -84,7 +84,7 @@ struct is_base_tag : std::false_type {};
 template <typename Tag>
 struct is_base_tag<Tag, Requires<std::is_base_of_v<db::BaseTag, Tag> and
                                  not std::is_base_of_v<db::SimpleTag, Tag> and
-                                 not is_compute_item_v<Tag>>> : std::true_type {
+                                 not is_compute_tag_v<Tag>>> : std::true_type {
 };
 /// \endcond
 

--- a/src/Domain/InterfaceComputeTags.hpp
+++ b/src/Domain/InterfaceComputeTags.hpp
@@ -134,7 +134,7 @@ template <typename DirectionsTag, typename Tag>
 struct InterfaceCompute : Interface<DirectionsTag, Tag>,
                           db::ComputeTag,
                           virtual db::PrefixTag {
-  static_assert(db::is_compute_item_v<Tag>,
+  static_assert(db::is_compute_tag_v<Tag>,
                 "Cannot use a non compute item as an interface compute item.");
   // Defining name here prevents an ambiguous function call when using base
   // tags; Both Interface<Dirs, Tag> and Interface<Dirs, Tag::base> will have a

--- a/tests/Unit/DataStructures/DataBox/Test_TagTraits.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_TagTraits.cpp
@@ -4,34 +4,34 @@
 #include "DataStructures/DataBox/TagTraits.hpp"
 #include "Helpers/DataStructures/DataBox/TestTags.hpp"
 
-static_assert(not db::is_compute_item_v<TestHelpers::db::Tags::Bad>,
-              "Failed testing is_compute_item");
-static_assert(not db::is_compute_item_v<TestHelpers::db::Tags::Simple>,
-              "Failed testing is_compute_item");
-static_assert(not db::is_compute_item_v<TestHelpers::db::Tags::Base>,
-              "Failed testing is_compute_item");
-static_assert(not db::is_compute_item_v<TestHelpers::db::Tags::SimpleWithBase>,
-              "Failed testing is_compute_item");
-static_assert(db::is_compute_item_v<TestHelpers::db::Tags::Compute>,
-              "Failed testing is_compute_item");
-static_assert(db::is_compute_item_v<TestHelpers::db::Tags::SimpleCompute>,
-              "Failed testing is_compute_item");
-static_assert(db::is_compute_item_v<TestHelpers::db::Tags::BaseCompute>,
-              "Failed testing is_compute_item");
+static_assert(not db::is_compute_tag_v<TestHelpers::db::Tags::Bad>,
+              "Failed testing is_compute_tag");
+static_assert(not db::is_compute_tag_v<TestHelpers::db::Tags::Simple>,
+              "Failed testing is_compute_tag");
+static_assert(not db::is_compute_tag_v<TestHelpers::db::Tags::Base>,
+              "Failed testing is_compute_tag");
+static_assert(not db::is_compute_tag_v<TestHelpers::db::Tags::SimpleWithBase>,
+              "Failed testing is_compute_tag");
+static_assert(db::is_compute_tag_v<TestHelpers::db::Tags::Compute>,
+              "Failed testing is_compute_tag");
+static_assert(db::is_compute_tag_v<TestHelpers::db::Tags::SimpleCompute>,
+              "Failed testing is_compute_tag");
+static_assert(db::is_compute_tag_v<TestHelpers::db::Tags::BaseCompute>,
+              "Failed testing is_compute_tag");
 static_assert(
-    db::is_compute_item_v<TestHelpers::db::Tags::SimpleWithBaseCompute>,
-    "Failed testing is_compute_item");
-static_assert(not db::is_compute_item_v<
+    db::is_compute_tag_v<TestHelpers::db::Tags::SimpleWithBaseCompute>,
+    "Failed testing is_compute_tag");
+static_assert(not db::is_compute_tag_v<
                   TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>,
-              "Failed testing is_compute_item");
+              "Failed testing is_compute_tag");
 static_assert(
-    db::is_compute_item_v<
+    db::is_compute_tag_v<
         TestHelpers::db::Tags::Operator<TestHelpers::db::Tags::Simple>>,
-    "Failed testing is_compute_item");
+    "Failed testing is_compute_tag");
 static_assert(
-    db::is_compute_item_v<
+    db::is_compute_tag_v<
         TestHelpers::db::Tags::LabelCompute<TestHelpers::db::Tags::Simple>>,
-    "Failed testing is_compute_item");
+    "Failed testing is_compute_tag");
 
 static_assert(not db::is_non_base_tag_v<TestHelpers::db::Tags::Bad>,
               "Failed testing is_non_base_tag");

--- a/tests/Unit/Helpers/DataStructures/DataBox/TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/DataBox/TestHelpers.hpp
@@ -24,7 +24,7 @@ CREATE_IS_CALLABLE_V(name)
 template <typename Tag>
 void check_tag_name(const std::string& expected_name) {
   CHECK(::db::tag_name<Tag>() == expected_name);
-  if (is_name_callable_v<Tag> and not ::db::is_compute_item_v<Tag>) {
+  if (is_name_callable_v<Tag> and not ::db::is_compute_tag_v<Tag>) {
     INFO("Do not define name for Tag '" << ::db::tag_name<Tag>() << "',");
     INFO("as it will automatically be generated with that name.");
     CHECK(::db::tag_name<Tag>() != pretty_type::short_name<Tag>());
@@ -42,7 +42,7 @@ void test_base_tag(const std::string& expected_name) {
 
 template <typename Tag>
 void test_compute_tag(const std::string& expected_name) {
-  static_assert(::db::is_compute_item_v<Tag>,
+  static_assert(::db::is_compute_tag_v<Tag>,
                 "A compute tag must be derived from db::ComputeTag");
   detail::check_tag_name<Tag>(expected_name);
 }


### PR DESCRIPTION
## Proposed changes

- Rename is_compute_item to is_compute_tag
- Rewrite tag_name using if constexpr

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
