### PR TITLE
Add Gauss lifting

### DIFF
--- a/src/NumericalAlgorithms/Spectral/Spectral.hpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.hpp
@@ -419,6 +419,50 @@ template <typename T>
 Matrix interpolation_matrix(const Mesh<1>& mesh,
                             const T& target_points) noexcept;
 
+// @{
+/*!
+ * \brief Matrices that interpolate to the lower and upper boundaries of the
+ * element.
+ *
+ * Assumes that the logical coordinates are \f$[-1, 1]\f$. The first element of
+ * the pair interpolates to \f$\xi=-1\f$ and the second to \f$\xi=1\f$. These
+ * are just the Lagrange interpolating polynomials evaluated at \f$\xi=\pm1\f$.
+ * For Gauss-Lobatto points the only non-zero element is at the boundaries
+ * and is one and so is not implemented.
+ *
+ * \warning This can only be called with Gauss points.
+ */
+const std::pair<Matrix, Matrix>& boundary_interpolation_matrices(
+    const Mesh<1>& mesh) noexcept;
+
+template <Basis BasisType, Quadrature QuadratureType>
+const std::pair<Matrix, Matrix>& boundary_interpolation_matrices(
+    size_t num_points) noexcept;
+// @}
+
+// @{
+/*!
+ * \brief Terms used during the lifting portion of a discontinuous Galerkin
+ * scheme when using Gauss points.
+ *
+ * Assumes that the logical coordinates are \f$[-1, 1]\f$. The first element of
+ * the pair is the Lagrange polyonmials evaluated at \f$\xi=-1\f$ divided by the
+ * weights and the second at \f$\xi=1\f$. Specifically,
+ *
+ * \f{align*}{
+ * \frac{\ell_j(\xi=\pm1)}{w_j}
+ * \f}
+ *
+ * \warning This can only be called with Gauss points.
+ */
+const std::pair<DataVector, DataVector>& boundary_lifting_term(
+    const Mesh<1>& mesh) noexcept;
+
+template <Basis BasisType, Quadrature QuadratureType>
+const std::pair<DataVector, DataVector>& boundary_lifting_term(
+    size_t num_points) noexcept;
+// @}
+
 /*!
  * \brief %Matrix used to transform from the spectral coefficients (modes) of a
  * function to its nodal coefficients. Also referred to as the _Vandermonde

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
@@ -19,15 +19,13 @@
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/Math.hpp"
 
-SPECTRE_TEST_CASE("Unit.Numerical.Spectral.streaming",
-                  "[NumericalAlgorithms][Spectral][Unit]") {
+namespace {
+void test_streaming() {
   CHECK(get_output(Spectral::Basis::Legendre) == "Legendre");
 
   CHECK(get_output(Spectral::Quadrature::Gauss) == "Gauss");
   CHECK(get_output(Spectral::Quadrature::GaussLobatto) == "GaussLobatto");
 }
-
-namespace {
 
 DataVector unit_polynomial(const size_t deg, const DataVector& x) {
   // Choose all polynomial coefficients to be one
@@ -53,7 +51,7 @@ double unit_polynomial_integral(const size_t deg) {
 
 template <Spectral::Basis BasisType, Spectral::Quadrature QuadratureType,
           typename Function>
-void test_exact_differentiation(const Function& max_poly_deg) {
+void test_exact_differentiation_impl(const Function& max_poly_deg) {
   INFO("Test exact differentiation.");
   CAPTURE(BasisType);
   CAPTURE(QuadratureType);
@@ -130,19 +128,18 @@ void test_weak_differentiation() {
   }
 }
 
-}  // namespace
-
-SPECTRE_TEST_CASE("Unit.Numerical.Spectral.ExactDifferentiation",
-                  "[NumericalAlgorithms][Spectral][Unit]") {
+void test_exact_differentiation_matrices() {
   const auto minus_one = [](const size_t n) noexcept { return n - 1; };
-  test_exact_differentiation<Spectral::Basis::Legendre,
-                             Spectral::Quadrature::Gauss>(minus_one);
-  test_exact_differentiation<Spectral::Basis::Legendre,
-                             Spectral::Quadrature::GaussLobatto>(minus_one);
-  test_exact_differentiation<Spectral::Basis::Chebyshev,
-                             Spectral::Quadrature::Gauss>(minus_one);
-  test_exact_differentiation<Spectral::Basis::Chebyshev,
-                             Spectral::Quadrature::GaussLobatto>(minus_one);
+  test_exact_differentiation_impl<Spectral::Basis::Legendre,
+                                  Spectral::Quadrature::Gauss>(minus_one);
+  test_exact_differentiation_impl<Spectral::Basis::Legendre,
+                                  Spectral::Quadrature::GaussLobatto>(
+      minus_one);
+  test_exact_differentiation_impl<Spectral::Basis::Chebyshev,
+                                  Spectral::Quadrature::Gauss>(minus_one);
+  test_exact_differentiation_impl<Spectral::Basis::Chebyshev,
+                                  Spectral::Quadrature::GaussLobatto>(
+      minus_one);
 
   test_weak_differentiation<Spectral::Basis::Legendre,
                             Spectral::Quadrature::Gauss>();
@@ -150,10 +147,8 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.ExactDifferentiation",
                             Spectral::Quadrature::GaussLobatto>();
 }
 
-namespace {
-
 template <Spectral::Basis BasisType, Spectral::Quadrature QuadratureType>
-void test_linear_filter() {
+void test_linear_filter_impl() {
   for (size_t n = Spectral::minimum_number_of_points<BasisType, QuadratureType>;
        n <= Spectral::maximum_number_of_points<BasisType>; n++) {
     const auto& filter_matrix =
@@ -176,29 +171,28 @@ void test_linear_filter() {
   }
 }
 
-}  // namespace
-
-SPECTRE_TEST_CASE("Unit.Numerical.Spectral.LinearFilter",
-                  "[NumericalAlgorithms][Spectral][Unit]") {
-  SECTION("Legendre-Gauss") {
-    test_linear_filter<Spectral::Basis::Legendre,
-                       Spectral::Quadrature::Gauss>();
+void test_linear_filter() {
+  {
+    INFO("Legendre-Gauss");
+    test_linear_filter_impl<Spectral::Basis::Legendre,
+                            Spectral::Quadrature::Gauss>();
   }
-  SECTION("Legendre-Gauss-Lobatto") {
-    test_linear_filter<Spectral::Basis::Legendre,
-                       Spectral::Quadrature::GaussLobatto>();
+  {
+    INFO("Legendre-Gauss-Lobatto");
+    test_linear_filter_impl<Spectral::Basis::Legendre,
+                            Spectral::Quadrature::GaussLobatto>();
   }
-  SECTION("Chebyshev-Gauss") {
-    test_linear_filter<Spectral::Basis::Chebyshev,
-                       Spectral::Quadrature::Gauss>();
+  {
+    INFO("Chebyshev-Gauss");
+    test_linear_filter_impl<Spectral::Basis::Chebyshev,
+                            Spectral::Quadrature::Gauss>();
   }
-  SECTION("Chebyshev-Gauss-Lobatto") {
-    test_linear_filter<Spectral::Basis::Chebyshev,
-                       Spectral::Quadrature::GaussLobatto>();
+  {
+    INFO("Chebyshev-Gauss-Lobatto");
+    test_linear_filter_impl<Spectral::Basis::Chebyshev,
+                            Spectral::Quadrature::GaussLobatto>();
   }
 }
-
-namespace {
 
 // By default, uses the default tolerance for floating-point comparisons. When
 // a non-zero eps is passed in as last argument, uses that tolerance instead.
@@ -235,7 +229,7 @@ void test_interpolation_matrix(const DataVector& target_points,
 
 template <Spectral::Basis BasisType, Spectral::Quadrature QuadratureType,
           typename Function>
-void test_exact_interpolation(const Function& max_poly_deg) noexcept {
+void test_exact_interpolation_impl(const Function& max_poly_deg) noexcept {
   const DataVector target_points{-0.5, -0.4837, 0.5, 0.9378, 1.};
   test_interpolation_matrix<BasisType, QuadratureType>(target_points,
                                                        max_poly_deg);
@@ -243,7 +237,7 @@ void test_exact_interpolation(const Function& max_poly_deg) noexcept {
 
 template <Spectral::Basis BasisType, Spectral::Quadrature QuadratureType,
           typename Function>
-void test_exact_extrapolation(const Function& max_poly_deg) {
+void test_exact_extrapolation_impl(const Function& max_poly_deg) {
   const DataVector target_points{-1.66, 1., 1.5, 1.98, 2.};
   // Errors are larger when extrapolating outside of the original grid:
   const double eps = 1.e-9;
@@ -251,46 +245,49 @@ void test_exact_extrapolation(const Function& max_poly_deg) {
                                                        max_poly_deg, eps);
 }
 
-}  // namespace
-
-SPECTRE_TEST_CASE("Unit.Numerical.Spectral.ExactInterpolation",
-                  "[NumericalAlgorithms][Spectral][Unit]") {
+void test_exact_extrapolation() {
   const auto minus_one = [](const size_t n) noexcept { return n - 1; };
-  SECTION(
-      "Legendre-Gauss interpolation is exact to polynomial order "
-      "num_points-1") {
-    test_exact_interpolation<Spectral::Basis::Legendre,
-                             Spectral::Quadrature::Gauss>(minus_one);
-    test_exact_extrapolation<Spectral::Basis::Legendre,
-                             Spectral::Quadrature::Gauss>(minus_one);
+  {
+    INFO(
+        "Legendre-Gauss interpolation is exact to polynomial order "
+        "num_points-1");
+    test_exact_interpolation_impl<Spectral::Basis::Legendre,
+                                  Spectral::Quadrature::Gauss>(minus_one);
+    test_exact_extrapolation_impl<Spectral::Basis::Legendre,
+                                  Spectral::Quadrature::Gauss>(minus_one);
   }
-  SECTION(
-      "Legendre-Gauss-Lobatto interpolation is exact to polynomial "
-      "order num_points-1") {
-    test_exact_interpolation<Spectral::Basis::Legendre,
-                             Spectral::Quadrature::GaussLobatto>(minus_one);
-    test_exact_extrapolation<Spectral::Basis::Legendre,
-                             Spectral::Quadrature::GaussLobatto>(minus_one);
+  {
+    INFO(
+        "Legendre-Gauss-Lobatto interpolation is exact to polynomial "
+        "order num_points-1");
+    test_exact_interpolation_impl<Spectral::Basis::Legendre,
+                                  Spectral::Quadrature::GaussLobatto>(
+        minus_one);
+    test_exact_extrapolation_impl<Spectral::Basis::Legendre,
+                                  Spectral::Quadrature::GaussLobatto>(
+        minus_one);
   }
-  SECTION(
-      "Chebyshev-Gauss interpolation is exact to polynomial "
-      "order num_points-1") {
-    test_exact_interpolation<Spectral::Basis::Chebyshev,
-                             Spectral::Quadrature::Gauss>(minus_one);
-    test_exact_extrapolation<Spectral::Basis::Chebyshev,
-                             Spectral::Quadrature::Gauss>(minus_one);
+  {
+    INFO(
+        "Chebyshev-Gauss interpolation is exact to polynomial "
+        "order num_points-1");
+    test_exact_interpolation_impl<Spectral::Basis::Chebyshev,
+                                  Spectral::Quadrature::Gauss>(minus_one);
+    test_exact_extrapolation_impl<Spectral::Basis::Chebyshev,
+                                  Spectral::Quadrature::Gauss>(minus_one);
   }
-  SECTION(
-      "Chebyshev-Gauss-Lobatto interpolation is exact to polynomial "
-      "order num_points-1") {
-    test_exact_interpolation<Spectral::Basis::Chebyshev,
-                             Spectral::Quadrature::GaussLobatto>(minus_one);
-    test_exact_extrapolation<Spectral::Basis::Chebyshev,
-                             Spectral::Quadrature::GaussLobatto>(minus_one);
+  {
+    INFO(
+        "Chebyshev-Gauss-Lobatto interpolation is exact to polynomial "
+        "order num_points-1");
+    test_exact_interpolation_impl<Spectral::Basis::Chebyshev,
+                                  Spectral::Quadrature::GaussLobatto>(
+        minus_one);
+    test_exact_extrapolation_impl<Spectral::Basis::Chebyshev,
+                                  Spectral::Quadrature::GaussLobatto>(
+        minus_one);
   }
 }
-
-namespace {
 
 template <Spectral::Basis BasisType, Spectral::Quadrature QuadratureType>
 void test_exact_quadrature(const size_t n, const size_t p,
@@ -321,19 +318,19 @@ void test_exact_unit_weight_quadrature(const Function& max_poly_deg) {
   }
 }
 
-}  // namespace
-
-SPECTRE_TEST_CASE("Unit.Numerical.Spectral.ExactQuadrature",
-                  "[NumericalAlgorithms][Spectral][Unit]") {
-  SECTION(
-      "Legendre-Gauss quadrature is exact to polynomial order 2*num_points-1") {
+void test_exact_quadrature() {
+  {
+    INFO(
+        "Legendre-Gauss quadrature is exact to polynomial order "
+        "2*num_points-1");
     test_exact_unit_weight_quadrature<Spectral::Basis::Legendre,
                                       Spectral::Quadrature::Gauss>(
         [](const size_t n) { return 2 * n - 1; });
   }
-  SECTION(
-      "Legendre-Gauss-Lobatto quadrature is exact to polynomial order "
-      "2*num_points-3") {
+  {
+    INFO(
+        "Legendre-Gauss-Lobatto quadrature is exact to polynomial order "
+        "2*num_points-3");
     test_exact_unit_weight_quadrature<Spectral::Basis::Legendre,
                                       Spectral::Quadrature::GaussLobatto>(
         [](const size_t n) { return 2 * n - 3; });
@@ -342,9 +339,10 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.ExactQuadrature",
   // \f$\int_{-1}^{1}f(x)w(x)\mathrm{d}x\f$ where \f$w(x)=1/sqrt(1-x^2)\f$ is
   // the Chebyshev weight. We test this here for polynomials with unit
   // coefficients \f$f(x)=1+x+x^2+\ldots\f$.
-  SECTION(
-      "Chebyshev-Gauss quadrature is exact to polynomial order "
-      "2*num_points-1") {
+  {
+    INFO(
+        "Chebyshev-Gauss quadrature is exact to polynomial order "
+        "2*num_points-1");
     test_exact_quadrature<Spectral::Basis::Chebyshev,
                           Spectral::Quadrature::Gauss>(1, 1, M_PI);
     test_exact_quadrature<Spectral::Basis::Chebyshev,
@@ -360,9 +358,10 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.ExactQuadrature",
                           Spectral::Quadrature::Gauss>(6, 11,
                                                        693. * M_PI / 256.);
   }
-  SECTION(
-      "Chebyshev-Gauss-Lobatto quadrature is exact to polynomial order "
-      "2*num_points-3") {
+  {
+    INFO(
+        "Chebyshev-Gauss-Lobatto quadrature is exact to polynomial order "
+        "2*num_points-3");
     test_exact_quadrature<Spectral::Basis::Chebyshev,
                           Spectral::Quadrature::GaussLobatto>(2, 1, M_PI);
     test_exact_quadrature<Spectral::Basis::Chebyshev,
@@ -380,10 +379,8 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.ExactQuadrature",
   }
 }
 
-namespace {
-
 template <Spectral::Basis BasisType, Spectral::Quadrature QuadratureType>
-void test_quadrature_weights() {
+void test_quadrature_weights_impl() {
   for (size_t n = Spectral::minimum_number_of_points<BasisType, QuadratureType>;
        n <= Spectral::maximum_number_of_points<BasisType>; n++) {
     const auto& weights =
@@ -401,26 +398,21 @@ void test_quadrature_weights() {
   }
 }
 
-}  // namespace
-
-SPECTRE_TEST_CASE("Unit.Numerical.Spectral.QuadratureWeights",
-                  "[NumericalAlgorithms][Spectral][Unit]") {
+void test_quadrature_weights() {
   // Test that the Spectral::quadrature_weights are those used to compute
   // definite integrals, as opposed to the weighted inner product.
-  test_quadrature_weights<Spectral::Basis::Legendre,
-                          Spectral::Quadrature::Gauss>();
-  test_quadrature_weights<Spectral::Basis::Legendre,
-                          Spectral::Quadrature::GaussLobatto>();
-  test_quadrature_weights<Spectral::Basis::Chebyshev,
-                          Spectral::Quadrature::Gauss>();
-  test_quadrature_weights<Spectral::Basis::Chebyshev,
-                          Spectral::Quadrature::GaussLobatto>();
+  test_quadrature_weights_impl<Spectral::Basis::Legendre,
+                               Spectral::Quadrature::Gauss>();
+  test_quadrature_weights_impl<Spectral::Basis::Legendre,
+                               Spectral::Quadrature::GaussLobatto>();
+  test_quadrature_weights_impl<Spectral::Basis::Chebyshev,
+                               Spectral::Quadrature::Gauss>();
+  test_quadrature_weights_impl<Spectral::Basis::Chebyshev,
+                               Spectral::Quadrature::GaussLobatto>();
 }
 
-namespace {
-
 template <Spectral::Basis BasisType, Spectral::Quadrature QuadratureType>
-void test_spectral_quantities_for_mesh(const Mesh<1>& slice) {
+void test_spectral_quantities_for_mesh_impl(const Mesh<1>& slice) {
   const auto num_points = slice.extents(0);
   const auto& expected_points =
       Spectral::collocation_points<BasisType, QuadratureType>(num_points);
@@ -448,10 +440,7 @@ void test_spectral_quantities_for_mesh(const Mesh<1>& slice) {
   CHECK(Spectral::linear_filter_matrix(slice) == expected_lin_matrix);
 }
 
-}  // namespace
-
-SPECTRE_TEST_CASE("Unit.Numerical.Spectral.Mesh",
-                  "[NumericalAlgorithms][Spectral][Unit]") {
+void test_spectral_quantities_for_mesh() {
   /// [get_points_for_mesh]
   const Mesh<2> mesh2d{
       {{3, 4}},
@@ -460,10 +449,22 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.Mesh",
   const auto collocation_points_in_first_dim =
       Spectral::collocation_points(mesh2d.slice_through(0));
   /// [get_points_for_mesh]
-  test_spectral_quantities_for_mesh<Spectral::Basis::Legendre,
-                                    Spectral::Quadrature::Gauss>(
+  test_spectral_quantities_for_mesh_impl<Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::Gauss>(
       mesh2d.slice_through(0));
-  test_spectral_quantities_for_mesh<Spectral::Basis::Legendre,
-                                    Spectral::Quadrature::GaussLobatto>(
+  test_spectral_quantities_for_mesh_impl<Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::GaussLobatto>(
       mesh2d.slice_through(1));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Numerical.Spectral",
+                  "[NumericalAlgorithms][Spectral][Unit]") {
+  test_streaming();
+  test_exact_differentiation_matrices();
+  test_linear_filter();
+  test_exact_extrapolation();
+  test_exact_quadrature();
+  test_quadrature_weights();
+  test_spectral_quantities_for_mesh();
 }

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
@@ -149,6 +149,8 @@ void test_exact_differentiation_matrices() {
 
 template <Spectral::Basis BasisType, Spectral::Quadrature QuadratureType>
 void test_linear_filter_impl() {
+  CAPTURE(BasisType);
+  CAPTURE(QuadratureType);
   for (size_t n = Spectral::minimum_number_of_points<BasisType, QuadratureType>;
        n <= Spectral::maximum_number_of_points<BasisType>; n++) {
     const auto& filter_matrix =
@@ -172,26 +174,14 @@ void test_linear_filter_impl() {
 }
 
 void test_linear_filter() {
-  {
-    INFO("Legendre-Gauss");
-    test_linear_filter_impl<Spectral::Basis::Legendre,
-                            Spectral::Quadrature::Gauss>();
-  }
-  {
-    INFO("Legendre-Gauss-Lobatto");
-    test_linear_filter_impl<Spectral::Basis::Legendre,
-                            Spectral::Quadrature::GaussLobatto>();
-  }
-  {
-    INFO("Chebyshev-Gauss");
-    test_linear_filter_impl<Spectral::Basis::Chebyshev,
-                            Spectral::Quadrature::Gauss>();
-  }
-  {
-    INFO("Chebyshev-Gauss-Lobatto");
-    test_linear_filter_impl<Spectral::Basis::Chebyshev,
-                            Spectral::Quadrature::GaussLobatto>();
-  }
+  test_linear_filter_impl<Spectral::Basis::Legendre,
+                          Spectral::Quadrature::Gauss>();
+  test_linear_filter_impl<Spectral::Basis::Legendre,
+                          Spectral::Quadrature::GaussLobatto>();
+  test_linear_filter_impl<Spectral::Basis::Chebyshev,
+                          Spectral::Quadrature::Gauss>();
+  test_linear_filter_impl<Spectral::Basis::Chebyshev,
+                          Spectral::Quadrature::GaussLobatto>();
 }
 
 // By default, uses the default tolerance for floating-point comparisons. When


### PR DESCRIPTION
## Proposed changes

- Combine test cases in `Test_Spectral.cpp`
- Add interpolation matrices and lifting weights for Gauss-Legendre points

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
