### PR TITLE
Modernize CMakeLists 1

### DIFF
--- a/src/DataStructures/Tensor/CMakeLists.txt
+++ b/src/DataStructures/Tensor/CMakeLists.txt
@@ -22,6 +22,5 @@ spectre_target_headers(
   TypeAliases.hpp
   )
 
-
 add_subdirectory(EagerMath)
 add_subdirectory(Expressions)

--- a/src/ErrorHandling/CMakeLists.txt
+++ b/src/ErrorHandling/CMakeLists.txt
@@ -3,11 +3,14 @@
 
 set(LIBRARY ErrorHandling)
 
-set(LIBRARY_SOURCES
-    AbortWithErrorMessage.cpp
-    FloatingPointExceptions.cpp)
+add_spectre_library(${LIBRARY})
 
-add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  AbortWithErrorMessage.cpp
+  FloatingPointExceptions.cpp
+  )
 
 spectre_target_headers(
   ${LIBRARY}

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -3,7 +3,11 @@
 
 set(LIBRARY Utilities)
 
-set(LIBRARY_SOURCES
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
   FileSystem.cpp
   Formaline.cpp
   OptimizerHacks.cpp
@@ -12,21 +16,9 @@ set(LIBRARY_SOURCES
   WrapText.cpp
   )
 
-add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
-
-target_link_libraries(
-  ${LIBRARY}
-  PUBLIC
-  Blaze
-  Boost::boost
-  Brigand
-  ErrorHandling
-  Libxsmm
-  )
-
 spectre_target_headers(
   ${LIBRARY}
-  INCLUDE_DIRECTORY "${CMAKE_SOURCE_DIR}/src"
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Algorithm.hpp
   Array.hpp
@@ -79,6 +71,16 @@ spectre_target_headers(
   TypeTraits.hpp
   VectorAlgebra.hpp
   WrapText.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  Blaze
+  Boost::boost
+  Brigand
+  ErrorHandling
+  Libxsmm
   )
 
 add_subdirectory(TypeTraits)

--- a/src/Utilities/TypeTraits/CMakeLists.txt
+++ b/src/Utilities/TypeTraits/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 spectre_target_headers(
   Utilities
-  INCLUDE_DIRECTORY "${CMAKE_SOURCE_DIR}/src"
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ArraySize.hpp
   CanBeCopyConstructed.hpp


### PR DESCRIPTION
## Proposed changes

The first of a series of PRs that updates how we specify source/header files in our CMakeLists.txt. Eventually, this change (combined with previous CMake code already merged) will enable better dependency-checking.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

