### PR TITLE
Add non-rollon damped wave gauge

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
@@ -29,7 +29,11 @@ namespace gauges {
  * \brief Damped harmonic gauge source function and its spacetime derivative.
  *
  * \details The gauge condition has been taken from \cite Szilagyi2009qz and
- * \cite Deppe2018uye.
+ * \cite Deppe2018uye. We provide both a "rollon" version
+ * (`damped_harmonic_rollon`), and a "non-rollon" version (`damped_harmonic`).
+ * In the non-rollon version the rollon function \f$R(t)=1\f$.
+ *
+ * \warning Only the non-rollon version can be used with a moving mesh.
  *
  * The covariant form of the source function \f$H_a\f$ is written as:
  *
@@ -169,14 +173,28 @@ void damped_harmonic_rollon(
     const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
     const tnsr::aa<DataVector, SpatialDim, Frame>& pi,
     const tnsr::iaa<DataVector, SpatialDim, Frame>& phi, double time,
-    const tnsr::I<DataVector, SpatialDim, Frame>& coords,
-    // Scaling coeffs in front of each term
-    double amp_coef_L1, double amp_coef_L2, double amp_coef_S,
-    // exponents
-    int exp_L1, int exp_L2, int exp_S,
-    // roll on function parameters for lapse / shift terms
-    double rollon_start_time, double rollon_width,
-    // weight function
+    const tnsr::I<DataVector, SpatialDim, Frame>& coords, double amp_coef_L1,
+    double amp_coef_L2, double amp_coef_S, int exp_L1, int exp_L2, int exp_S,
+    double rollon_start_time, double rollon_width, double sigma_r) noexcept;
+
+/*!
+ * \copydoc damped_harmonic_rollon()
+ */
+template <size_t SpatialDim, typename Frame>
+void damped_harmonic(
+    gsl::not_null<tnsr::a<DataVector, SpatialDim, Frame>*> gauge_h,
+    gsl::not_null<tnsr::ab<DataVector, SpatialDim, Frame>*> d4_gauge_h,
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, SpatialDim, Frame>& shift,
+    const tnsr::a<DataVector, SpatialDim, Frame>&
+        spacetime_unit_normal_one_form,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const tnsr::II<DataVector, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
+    const tnsr::aa<DataVector, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataVector, SpatialDim, Frame>& phi,
+    const tnsr::I<DataVector, SpatialDim, Frame>& coords, double amp_coef_L1,
+    double amp_coef_L2, double amp_coef_S, int exp_L1, int exp_L2, int exp_S,
     double sigma_r) noexcept;
 }  // namespace gauges
 }  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/InitializeDampedHarmonic.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/InitializeDampedHarmonic.cpp
@@ -32,7 +32,7 @@ namespace GeneralizedHarmonic::gauges::Actions {
 template <size_t Dim>
 std::tuple<tnsr::a<DataVector, Dim, Frame::Inertial>,
            tnsr::ab<DataVector, Dim, Frame::Inertial>>
-InitializeDampedHarmonic<Dim>::impl(
+InitializeDampedHarmonic<Dim>::impl_rollon(
     const tnsr::aa<DataVector, Dim, Frame::Inertial>& spacetime_metric,
     const tnsr::aa<DataVector, Dim, Frame::Inertial>& pi,
     const tnsr::iaa<DataVector, Dim, Frame::Inertial>& phi,

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/InitializeDampedHarmonic.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/InitializeDampedHarmonic.hpp
@@ -164,7 +164,7 @@ struct InitializeDampedHarmonic {
     const auto& inverse_jacobian =
         db::get<domain::Tags::InverseJacobian<Dim, Frame::Logical, frame>>(box);
 
-    auto [initial_gauge_h, initial_d4_gauge_h] = impl(
+    auto [initial_gauge_h, initial_d4_gauge_h] = impl_rollon(
         db::get<gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>>(
             box),
         db::get<GeneralizedHarmonic::Tags::Pi<Dim, Frame::Inertial>>(box),
@@ -189,11 +189,12 @@ struct InitializeDampedHarmonic {
  private:
   static std::tuple<tnsr::a<DataVector, Dim, Frame::Inertial>,
                     tnsr::ab<DataVector, Dim, Frame::Inertial>>
-  impl(const tnsr::aa<DataVector, Dim, Frame::Inertial>& spacetime_metric,
-       const tnsr::aa<DataVector, Dim, Frame::Inertial>& pi,
-       const tnsr::iaa<DataVector, Dim, Frame::Inertial>& phi,
-       const Mesh<Dim>& mesh,
-       const InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>&
-           inverse_jacobian) noexcept;
+  impl_rollon(
+      const tnsr::aa<DataVector, Dim, Frame::Inertial>& spacetime_metric,
+      const tnsr::aa<DataVector, Dim, Frame::Inertial>& pi,
+      const tnsr::iaa<DataVector, Dim, Frame::Inertial>& phi,
+      const Mesh<Dim>& mesh,
+      const InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>&
+          inverse_jacobian) noexcept;
 };
 }  // namespace GeneralizedHarmonic::gauges::Actions

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonic.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonic.cpp
@@ -113,6 +113,28 @@ void wrap_damped_harmonic_rollon(
       rollon_width, sigma_r);
 }
 
+template <size_t SpatialDim, typename Frame>
+void wrap_damped_harmonic(
+    const gsl::not_null<tnsr::a<DataVector, SpatialDim, Frame>*> gauge_h,
+    const gsl::not_null<tnsr::ab<DataVector, SpatialDim, Frame>*> d4_gauge_h,
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, SpatialDim, Frame>& shift,
+    const tnsr::a<DataVector, SpatialDim, Frame>&
+        spacetime_unit_normal_one_form,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const tnsr::II<DataVector, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
+    const tnsr::aa<DataVector, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataVector, SpatialDim, Frame>& phi,
+    const tnsr::I<DataVector, SpatialDim, Frame>& coords,
+    const double amp_coef_L1, const double amp_coef_L2, const double amp_coef_S,
+    const double sigma_r) noexcept {
+  GeneralizedHarmonic::gauges::damped_harmonic(
+      gauge_h, d4_gauge_h, lapse, shift, spacetime_unit_normal_one_form,
+      sqrt_det_spatial_metric, inverse_spatial_metric, spacetime_metric, pi,
+      phi, coords, amp_coef_L1, amp_coef_L2, amp_coef_S, 4, 4, 4, sigma_r);
+}
+
 // Compare with Python implementation
 template <size_t SpatialDim, typename Frame>
 void test_with_python(const DataVector& used_for_size) noexcept {
@@ -121,6 +143,14 @@ void test_with_python(const DataVector& used_for_size) noexcept {
   CAPTURE(Frame{});
   pypp::check_with_random_values<1>(
       &wrap_damped_harmonic_rollon<SpatialDim, Frame>,
+      "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
+      "DampedHarmonic",
+      {"damped_harmonic_gauge_source_function_rollon",
+       "spacetime_deriv_damped_harmonic_gauge_source_function_rollon"},
+      {{{0.1, 10.}}}, used_for_size);
+
+  pypp::check_with_random_values<1>(
+      &wrap_damped_harmonic<SpatialDim, Frame>,
       "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
       "DampedHarmonic",
       {"damped_harmonic_gauge_source_function",
@@ -133,7 +163,7 @@ SPECTRE_TEST_CASE(
     "Unit.Evolution.Systems.GeneralizedHarmonic.Gauge.DampedHarmonic",
     "[Unit][Evolution]") {
   pypp::SetupLocalPythonEnvironment local_python_env{""};
-  const DataVector used_for_size(4);
+  const DataVector used_for_size(5);
 
   test_rollon_function<1, Frame::Inertial>(used_for_size);
   test_rollon_function<2, Frame::Inertial>(used_for_size);


### PR DESCRIPTION
## Proposed changes

- Add the implementation for the non-rollon damped wave gauge
- Rename the impl in `InitializeDampedHarmonic` to `rollon_impl`

I will add the initialization action changes in a separate PR in an effort to keep these small.

Including this PR, I have 3 more left, just as an FYI.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
