### PR TITLE
Run clang-tidy on CI relative to nearest common ancestor

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -75,8 +75,8 @@ jobs:
           cd $GITHUB_WORKSPACE
           ./tools/CheckFiles.sh
 
-  # Lint with clang-tidy. We check only code that changed relative to
-  # `sxs-collaboration/spectre/develop`.
+  # Lint with clang-tidy. We check only code that changed relative to the
+  # nearest common ancestor commit with `sxs-collaboration/spectre/develop`.
   clang_tidy:
     name: Clang-tidy
     if: >
@@ -93,6 +93,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Fetch sxs-collaboration/spectre/develop
         run: >
           cd $GITHUB_WORKSPACE
@@ -121,8 +123,13 @@ jobs:
           $GITHUB_WORKSPACE
       - name: Check clang-tidy
         working-directory: /work/build
-        run: |
-          make clang-tidy-hash HASH=upstream/develop
+        run: >
+          UPSTREAM_HASH=$(
+            cd $GITHUB_WORKSPACE && git merge-base HEAD upstream/develop)
+
+          echo "Running clang-tidy relative to: $UPSTREAM_HASH\n"
+
+          make clang-tidy-hash HASH=$UPSTREAM_HASH
 
   # Build the documentation and check for problems, then upload as a workflow
   # artifact.


### PR DESCRIPTION
## Proposed changes

With this change, pushes to forks should trigger clang-tidy checks only on changes relative to the nearest common ancestor commit with sxs-collaboration/spectre/develop.

To test this, I based this PR's branch on an older commit in the history of sxs-collaboration/spectre/develop. Here's the CI build on my fork: https://github.com/nilsleiffischer/spectre/runs/810430760?check_suite_focus=true. Note that it runs clang-tidy only on the files changes in the PR, not the files changed on sxs-collaboration/spectre/develop that are not in the PR's history.

Once reviewed I'll drop 63d2a26 and rebase on `develop` of course.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
