### PR TITLE
Remove many uses of const_item_type

### DIFF
--- a/cmake/SetupClangTidy.cmake
+++ b/cmake/SetupClangTidy.cmake
@@ -32,13 +32,14 @@
 #         public and protected member variables are fine
 # -readability-uppercase-literal-suffix: we're okay with lower case
 # -readability-const-return-type: complains about decltype(auto)
+# -bugprone-infinite-loop:  complains about Catch macros having infinite loops
 #
 # Notes:
 # misc-move-const-arg: we keep this check because even though this gives
 #                      a lot of annoying warnings about moving trivially
 #                      copyable types, it warns about moving const objects,
 #                      which can have severe performance impacts.
-set(CLANG_TIDY_IGNORE_CHECKS "*,-cppcoreguidelines-no-malloc,-llvm-header-guard,-google-runtime-int,-readability-else-after-return,-misc-noexcept-move-constructor,-misc-unconventional-assign-operator,-cppcoreguidelines-c-copy-assignment-signature,-modernize-raw-string-literal,-hicpp-*,-android-*,-cert-err58-cpp,-google-default-arguments,-fuchsia-*,-performance-noexcept-move-constructor,-modernize-use-trailing-return-type,-cert-oop54-cpp,-misc-definitions-in-headers,-cppcoreguidelines-macro-usage,-cppcoreguidelines-avoid-magic-numbers,-modernize-use-nodiscard,-readability-magic-numbers,-bugprone-exception-escape,-cert-msc32-c,-misc-non-private-member-variables-in-classes,-cppcoreguidelines-avoid-c-arrays,-cppcoreguidelines-non-private-member-variables-in-classes,-cert-msc51-cpp,-bugprone-macro-parentheses,-readability-uppercase-literal-suffix,-readability-const-return-type")
+set(CLANG_TIDY_IGNORE_CHECKS "*,-cppcoreguidelines-no-malloc,-llvm-header-guard,-google-runtime-int,-readability-else-after-return,-misc-noexcept-move-constructor,-misc-unconventional-assign-operator,-cppcoreguidelines-c-copy-assignment-signature,-modernize-raw-string-literal,-hicpp-*,-android-*,-cert-err58-cpp,-google-default-arguments,-fuchsia-*,-performance-noexcept-move-constructor,-modernize-use-trailing-return-type,-cert-oop54-cpp,-misc-definitions-in-headers,-cppcoreguidelines-macro-usage,-cppcoreguidelines-avoid-magic-numbers,-modernize-use-nodiscard,-readability-magic-numbers,-bugprone-exception-escape,-cert-msc32-c,-misc-non-private-member-variables-in-classes,-cppcoreguidelines-avoid-c-arrays,-cppcoreguidelines-non-private-member-variables-in-classes,-cert-msc51-cpp,-bugprone-macro-parentheses,-readability-uppercase-literal-suffix,-readability-const-return-type,-bugprone-infinite-loop")
 
 if(NOT CLANG_TIDY_ROOT)
   # Need to set to empty to avoid warnings with --warn-uninitialized

--- a/src/ApparentHorizons/FastFlow.cpp
+++ b/src/ApparentHorizons/FastFlow.cpp
@@ -63,8 +63,7 @@ namespace {
 template <typename Frame>
 DataVector fast_flow_weight(
     const Scalar<DataVector>& one_form_magnitude,
-    const db::const_item_type<StrahlkorperTags::Rhat<Frame>>& r_hat,
-    const db::const_item_type<StrahlkorperTags::Radius<Frame>>& radius,
+    const tnsr::i<DataVector, 3, Frame>& r_hat, const DataVector& radius,
     const tnsr::II<DataVector, 3, Frame>& inverse_surface_metric) noexcept {
   // Form Euclidean surface metric
   auto flat_metric =
@@ -258,7 +257,9 @@ FastFlow::iterate_horizon_finder(
   for (auto cit = SpherepackIterator(current_strahlkorper->l_max(),
                                      current_strahlkorper->l_max());
        cit; ++cit) {
-    coefs[cit()] -= flow_A / (1.0 + flow_B * cit.l() * (cit.l() + 1)) *
+    coefs[cit()] -= flow_A /
+                    (1.0 + flow_B * static_cast<double>(cit.l()) *
+                               (static_cast<double>(cit.l()) + 1)) *
                     residual_on_surface[cit()];
   }
   *current_strahlkorper = Strahlkorper<Frame>(coefs, *current_strahlkorper);
@@ -341,7 +342,7 @@ bool operator==(const FastFlow& lhs, const FastFlow& rhs) noexcept {
 template <>
 FastFlow::FlowType create_from_yaml<FastFlow::FlowType>::create<void>(
     const Option& options) {
-  const std::string flow_type_read = options.parse_as<std::string>();
+  const auto flow_type_read = options.parse_as<std::string>();
   if ("Jacobi" == flow_type_read) {
     return FastFlow::FlowType::Jacobi;
   } else if ("Curvature" == flow_type_read) {

--- a/src/DataStructures/CachedTempBuffer.hpp
+++ b/src/DataStructures/CachedTempBuffer.hpp
@@ -6,7 +6,6 @@
 #include <cstddef>
 #include <utility>  // IWYU pragma: keep  // for std::move
 
-#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/TempBuffer.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -36,7 +35,7 @@ class CachedTempBuffer {
 
   /// Obtain a value from the buffer, computing it if necessary.
   template <typename Tag>
-  const db::const_item_type<Tag>& get_var(Tag /*meta*/) noexcept {
+  const typename Tag::type& get_var(Tag /*meta*/) noexcept {
     // This function can't be called "get" because that interferes
     // with the ADL needed to access data_.
     if (not get<Computed<Tag>>(computed_flags_)) {

--- a/src/DataStructures/DataBox/Prefixes.hpp
+++ b/src/DataStructures/DataBox/Prefixes.hpp
@@ -7,11 +7,8 @@
 #pragma once
 
 #include <cstddef>
-#include <string>
 
-#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
-#include "DataStructures/DataBox/TagName.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Metafunctions.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -30,10 +27,7 @@ namespace Tags {
 /// \snippet Test_DataBoxPrefixes.cpp dt_name
 template <typename Tag>
 struct dt : db::PrefixTag, db::SimpleTag {
-  static std::string name() noexcept {
-    return "dt(" + db::tag_name<Tag>() + ")";
-  }
-  using type = db::const_item_type<Tag>;
+  using type = typename Tag::type;
   using tag = Tag;
 };
 
@@ -48,25 +42,19 @@ struct Flux;
 /// \cond
 template <typename Tag, typename VolumeDim, typename Fr>
 struct Flux<Tag, VolumeDim, Fr,
-            Requires<tt::is_a_v<Tensor, db::const_item_type<Tag>>>>
-    : db::PrefixTag, db::SimpleTag {
+            Requires<tt::is_a_v<Tensor, typename Tag::type>>> : db::PrefixTag,
+                                                                db::SimpleTag {
   using type = TensorMetafunctions::prepend_spatial_index<
-      db::const_item_type<Tag>, VolumeDim::value, UpLo::Up, Fr>;
+      typename Tag::type, VolumeDim::value, UpLo::Up, Fr>;
   using tag = Tag;
-  static std::string name() noexcept {
-    return "Flux(" + db::tag_name<Tag>() + ")";
-  }
 };
 
 template <typename Tag, typename VolumeDim, typename Fr>
 struct Flux<Tag, VolumeDim, Fr,
-            Requires<tt::is_a_v<::Variables, db::const_item_type<Tag>>>>
+            Requires<tt::is_a_v<::Variables, typename Tag::type>>>
     : db::PrefixTag, db::SimpleTag {
-  using type = db::const_item_type<Tag>;
+  using type = typename Tag::type;
   using tag = Tag;
-  static std::string name() noexcept {
-    return "Flux(" + db::tag_name<Tag>() + ")";
-  }
 };
 /// \endcond
 
@@ -76,11 +64,8 @@ struct Flux<Tag, VolumeDim, Fr,
 /// \snippet Test_DataBoxPrefixes.cpp source_name
 template <typename Tag>
 struct Source : db::PrefixTag, db::SimpleTag {
-  using type = db::const_item_type<Tag>;
+  using type = typename Tag::type;
   using tag = Tag;
-  static std::string name() noexcept {
-    return "Source(" + db::tag_name<Tag>() + ")";
-  }
 };
 
 /// \ingroup DataBoxTagsGroup
@@ -88,7 +73,7 @@ struct Source : db::PrefixTag, db::SimpleTag {
 /// variables
 template <typename Tag>
 struct FixedSource : db::PrefixTag, db::SimpleTag {
-  using type = db::const_item_type<Tag>;
+  using type = typename Tag::type;
   using tag = Tag;
 };
 
@@ -98,11 +83,8 @@ struct FixedSource : db::PrefixTag, db::SimpleTag {
 /// \snippet Test_DataBoxPrefixes.cpp initial_name
 template <typename Tag>
 struct Initial : db::PrefixTag, db::SimpleTag {
-  using type = db::const_item_type<Tag>;
+  using type = typename Tag::type;
   using tag = Tag;
-  static std::string name() noexcept {
-    return "Initial(" + db::tag_name<Tag>() + ")";
-  }
 };
 
 /// \ingroup DataBoxTagsGroup
@@ -112,11 +94,8 @@ struct Initial : db::PrefixTag, db::SimpleTag {
 /// \snippet Test_DataBoxPrefixes.cpp normal_dot_flux_name
 template <typename Tag>
 struct NormalDotFlux : db::PrefixTag, db::SimpleTag {
-  using type = db::const_item_type<Tag>;
+  using type = typename Tag::type;
   using tag = Tag;
-  static std::string name() noexcept {
-    return "NormalDotFlux(" + db::tag_name<Tag>() + ")";
-  }
 };
 
 /// \ingroup DataBoxTagsGroup
@@ -126,11 +105,8 @@ struct NormalDotFlux : db::PrefixTag, db::SimpleTag {
 /// \snippet Test_DataBoxPrefixes.cpp normal_dot_numerical_flux_name
 template <typename Tag>
 struct NormalDotNumericalFlux : db::PrefixTag, db::SimpleTag {
-  using type = db::const_item_type<Tag>;
+  using type = typename Tag::type;
   using tag = Tag;
-  static std::string name() noexcept {
-    return "NormalDotNumericalFlux(" + db::tag_name<Tag>() + ")";
-  }
 };
 
 /// \ingroup DataBoxTagsGroup
@@ -140,11 +116,8 @@ struct NormalDotNumericalFlux : db::PrefixTag, db::SimpleTag {
 /// \snippet Test_DataBoxPrefixes.cpp next_name
 template <typename Tag>
 struct Next : db::PrefixTag, db::SimpleTag {
-  using type = db::const_item_type<Tag>;
+  using type = typename Tag::type;
   using tag = Tag;
-  static std::string name() noexcept {
-    return "Next(" + db::tag_name<Tag>() + ")";
-  }
 };
 
 /// \ingroup DataBoxTagsGroup

--- a/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
@@ -147,7 +147,7 @@ struct Normalized : db::PrefixTag, db::SimpleTag {
     return "Normalized(" + db::tag_name<Tag>() + ")";
   }
   using tag = Tag;
-  using type = db::const_item_type<Tag>;
+  using type = typename Tag::type;
 };
 
 /// \ingroup DataBoxTagsGroup

--- a/src/Domain/FaceNormal.hpp
+++ b/src/Domain/FaceNormal.hpp
@@ -177,12 +177,10 @@ struct InterfaceCompute<Tags::BoundaryDirectionsExterior<VolumeDim>,
   }
   using return_type = std::unordered_map<::Direction<VolumeDim>,
                                          tnsr::i<DataVector, VolumeDim, Frame>>;
-  static void function(
-      const gsl::not_null<return_type*> normals,
-      const db::const_item_type<Tags::Interface<dirs, Mesh<VolumeDim - 1>>>&
-          meshes,
-      const db::const_item_type<Tags::ElementMap<VolumeDim, Frame>>&
-          map) noexcept {
+  static void function(const gsl::not_null<return_type*> normals,
+                       const std::unordered_map<::Direction<VolumeDim>,
+                                                ::Mesh<VolumeDim - 1>>& meshes,
+                       const ::ElementMap<VolumeDim, Frame>& map) noexcept {
     for (const auto& direction_and_mesh : meshes) {
       const auto& direction = direction_and_mesh.first;
       const auto& mesh = direction_and_mesh.second;
@@ -216,7 +214,7 @@ struct InterfaceCompute<Tags::BoundaryDirectionsExterior<VolumeDim>,
                          tnsr::i<DataVector, VolumeDim, Frame::Inertial>>;
   static void function(
       const gsl::not_null<return_type*> normals,
-      const db::const_item_type<Tags::Interface<dirs, Mesh<VolumeDim - 1>>>&
+      const std::unordered_map<::Direction<VolumeDim>, ::Mesh<VolumeDim - 1>>&
           meshes,
       const ::ElementMap<VolumeDim, Frame::Grid>& logical_to_grid_map,
       const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, VolumeDim>&

--- a/src/Elliptic/DiscontinuousGalerkin/ImposeBoundaryConditions.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/ImposeBoundaryConditions.hpp
@@ -101,12 +101,8 @@ struct ImposeHomogeneousDirichletBoundaryConditions {
     db::mutate<domain::Tags::Interface<
         domain::Tags::BoundaryDirectionsExterior<Dim>, VariablesTag>>(
         make_not_null(&box),
-        [](const gsl::not_null<db::item_type<domain::Tags::Interface<
-               domain::Tags::BoundaryDirectionsExterior<Dim>, VariablesTag>>*>
-               exterior_boundary_vars,
-           const db::const_item_type<domain::Tags::Interface<
-               domain::Tags::BoundaryDirectionsInterior<Dim>, VariablesTag>>&
-               interior_vars) noexcept {
+        [](const auto exterior_boundary_vars,
+           const auto& interior_vars) noexcept {
           for (auto& exterior_direction_and_vars : *exterior_boundary_vars) {
             auto& direction = exterior_direction_and_vars.first;
             homogeneous_dirichlet_boundary_conditions<DirichletTags>(

--- a/src/Elliptic/DiscontinuousGalerkin/NumericalFluxes/FirstOrderInternalPenalty.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/NumericalFluxes/FirstOrderInternalPenalty.hpp
@@ -143,7 +143,7 @@ struct FirstOrderInternalPenalty<Dim, FluxesComputerTag,
     : tt::ConformsTo<::dg::protocols::NumericalFlux> {
  private:
   using fluxes_computer_tag = FluxesComputerTag;
-  using FluxesComputer = db::const_item_type<fluxes_computer_tag>;
+  using FluxesComputer = typename fluxes_computer_tag::type;
 
   template <typename Tag>
   struct NormalDotDivFlux : db::PrefixTag, db::SimpleTag {
@@ -215,9 +215,9 @@ struct FirstOrderInternalPenalty<Dim, FluxesComputerTag,
           AuxiliaryFieldTags>>*>... packaged_n_dot_principal_n_dot_aux_fluxes,
       const db::item_type<::Tags::NormalDotFlux<
           AuxiliaryFieldTags>>&... normal_dot_auxiliary_field_fluxes,
-      const db::const_item_type<::Tags::div<
+      const typename ::Tags::div<
           ::Tags::Flux<AuxiliaryFieldTags, tmpl::size_t<Dim>,
-                       Frame::Inertial>>>&... div_auxiliary_field_fluxes,
+                       Frame::Inertial>>::type&... div_auxiliary_field_fluxes,
       const tnsr::i<DataVector, Dim, Frame::Inertial>& interface_unit_normal,
       const FluxesComputer& fluxes_computer,
       const FluxesArgs&... fluxes_args) const noexcept {
@@ -339,7 +339,7 @@ struct FirstOrderInternalPenalty<Dim, FluxesComputerTag,
           FieldTags>>*>... numerical_flux_for_fields,
       const gsl::not_null<db::item_type<::Tags::NormalDotNumericalFlux<
           AuxiliaryFieldTags>>*>... numerical_flux_for_auxiliary_fields,
-      const db::const_item_type<FieldTags>&... dirichlet_fields,
+      const typename FieldTags::type&... dirichlet_fields,
       const tnsr::i<DataVector, Dim, Frame::Inertial>& interface_unit_normal,
       const FluxesComputer& fluxes_computer,
       const FluxesArgs&... fluxes_args) const noexcept {

--- a/src/Elliptic/FirstOrderComputeTags.hpp
+++ b/src/Elliptic/FirstOrderComputeTags.hpp
@@ -37,7 +37,7 @@ struct FirstOrderFluxesCompute
   using return_type = db::item_type<base>;
   template <typename... FluxesArgs>
   static void function(const gsl::not_null<return_type*> fluxes,
-                       const db::const_item_type<VariablesTag>& vars,
+                       const typename VariablesTag::type& vars,
                        const FluxesComputer& fluxes_computer,
                        const FluxesArgs&... fluxes_args) noexcept {
     *fluxes = return_type{vars.number_of_grid_points()};
@@ -58,7 +58,7 @@ struct FirstOrderSourcesCompute
   using return_type = db::item_type<base>;
   template <typename... SourcesArgs>
   static void function(const gsl::not_null<return_type*> sources,
-                       const db::const_item_type<VariablesTag>& vars,
+                       const typename VariablesTag::type& vars,
                        const SourcesArgs&... sources_args) noexcept {
     *sources = return_type{vars.number_of_grid_points()};
     elliptic::first_order_sources<PrimalVariables, AuxiliaryVariables,

--- a/src/Elliptic/Triggers/EveryNIterations.hpp
+++ b/src/Elliptic/Triggers/EveryNIterations.hpp
@@ -60,7 +60,7 @@ class EveryNIterations : public Trigger<TriggerRegistrars> {
 
   using argument_tags = tmpl::list<IterationId>;
 
-  bool operator()(const db::const_item_type<IterationId>& iteration_id) const
+  bool operator()(const typename IterationId::type& iteration_id) const
       noexcept {
     const auto step_number = static_cast<uint64_t>(iteration_id);
     return step_number >= offset_ and (step_number - offset_) % interval_ == 0;

--- a/src/Evolution/ComputeTags.hpp
+++ b/src/Evolution/ComputeTags.hpp
@@ -33,8 +33,7 @@ struct AnalyticCompute
                  domain::Tags::Coordinates<Dim, Frame::Inertial>, ::Tags::Time>;
   static void function(
       const gsl::not_null<return_type*> analytic_solution,
-      const db::const_item_type<AnalyticSolutionTag>&
-          analytic_solution_computer,
+      const typename AnalyticSolutionTag::type& analytic_solution_computer,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords,
       const double time) noexcept {
     *analytic_solution =

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Krivodonova.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Krivodonova.hpp
@@ -504,7 +504,7 @@ class Krivodonova<VolumeDim, tmpl::list<Tags...>> {
 
   /// \brief Package data for sending to neighbor elements.
   void package_data(gsl::not_null<PackagedData*> packaged_data,
-                    const db::const_item_type<Tags>&... tensors,
+                    const typename Tags::type&... tensors,
                     const Mesh<VolumeDim>& mesh,
                     const OrientationMap<VolumeDim>& orientation_map) const
       noexcept;
@@ -551,7 +551,7 @@ class Krivodonova<VolumeDim, tmpl::list<Tags...>> {
   char fill_variables_tag_with_spectral_coeffs(
       gsl::not_null<Variables<tmpl::list<::Tags::Modal<Tags>...>>*>
           modal_coeffs,
-      const db::const_item_type<Tag>& nodal_tensor, const Mesh<Dim>& mesh) const
+      const typename Tag::type& nodal_tensor, const Mesh<Dim>& mesh) const
       noexcept;
 
   std::array<double,
@@ -582,7 +582,7 @@ Krivodonova<VolumeDim, tmpl::list<Tags...>>::Krivodonova(
 template <size_t VolumeDim, typename... Tags>
 void Krivodonova<VolumeDim, tmpl::list<Tags...>>::package_data(
     const gsl::not_null<PackagedData*> packaged_data,
-    const db::const_item_type<Tags>&... tensors, const Mesh<VolumeDim>& mesh,
+    const typename Tags::type&... tensors, const Mesh<VolumeDim>& mesh,
     const OrientationMap<VolumeDim>& orientation_map) const noexcept {
   if (UNLIKELY(disable_for_debugging_)) {
     // Do not initialize packaged_data
@@ -966,8 +966,8 @@ char Krivodonova<VolumeDim, tmpl::list<Tags...>>::
     fill_variables_tag_with_spectral_coeffs(
         const gsl::not_null<Variables<tmpl::list<::Tags::Modal<Tags>...>>*>
             modal_coeffs,
-        const db::const_item_type<Tag>& nodal_tensor,
-        const Mesh<Dim>& mesh) const noexcept {
+        const typename Tag::type& nodal_tensor, const Mesh<Dim>& mesh) const
+    noexcept {
   auto& coeffs_tensor = get<::Tags::Modal<Tag>>(*modal_coeffs);
   auto tensor_it = nodal_tensor.begin();
   for (auto coeffs_it = coeffs_tensor.begin(); coeffs_it != coeffs_tensor.end();

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/LimiterActions.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/LimiterActions.hpp
@@ -30,7 +30,7 @@ struct LimiterCommunicationTag : public Parallel::InboxInserters::Map<
                                      LimiterCommunicationTag<Metavariables>> {
   static constexpr size_t volume_dim = Metavariables::system::volume_dim;
   using packaged_data_t = typename Metavariables::limiter::type::PackagedData;
-  using temporal_id = db::const_item_type<typename Metavariables::temporal_id>;
+  using temporal_id = typename Metavariables::temporal_id::type;
   using type =
       std::map<temporal_id,
                std::unordered_map<

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp
@@ -249,7 +249,7 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
   ///        each dimension of logical coordinates.
   /// \param orientation_map The orientation of the neighbor
   void package_data(gsl::not_null<PackagedData*> packaged_data,
-                    const db::const_item_type<Tags>&... tensors,
+                    const typename Tags::type&... tensors,
                     const Mesh<VolumeDim>& mesh,
                     const std::array<double, VolumeDim>& element_size,
                     const OrientationMap<VolumeDim>& orientation_map) const

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.tpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.tpp
@@ -119,7 +119,7 @@ void Minmod<VolumeDim, tmpl::list<Tags...>>::pup(PUP::er& p) noexcept {
 template <size_t VolumeDim, typename... Tags>
 void Minmod<VolumeDim, tmpl::list<Tags...>>::package_data(
     const gsl::not_null<PackagedData*> packaged_data,
-    const db::const_item_type<Tags>&... tensors, const Mesh<VolumeDim>& mesh,
+    const typename Tags::type&... tensors, const Mesh<VolumeDim>& mesh,
     const std::array<double, VolumeDim>& element_size,
     const OrientationMap<VolumeDim>& orientation_map) const noexcept {
   if (UNLIKELY(disable_for_debugging_)) {

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.hpp
@@ -52,7 +52,7 @@ bool tvb_minmod_indicator(
 // - a variable `element_size` that is a `std::array<double, VolumeDim>`
 template <size_t VolumeDim, typename PackagedData, typename... Tags>
 bool tvb_minmod_indicator(
-    const double tvb_constant, const db::const_item_type<Tags>&... tensors,
+    const double tvb_constant, const typename Tags::type&... tensors,
     const Mesh<VolumeDim>& mesh, const Element<VolumeDim>& element,
     const std::array<double, VolumeDim>& element_size,
     const std::unordered_map<

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
@@ -179,7 +179,7 @@ class Weno<VolumeDim, tmpl::list<Tags...>> {
 
   /// \brief Package data for sending to neighbor elements
   void package_data(gsl::not_null<PackagedData*> packaged_data,
-                    const db::const_item_type<Tags>&... tensors,
+                    const typename Tags::type&... tensors,
                     const Mesh<VolumeDim>& mesh,
                     const std::array<double, VolumeDim>& element_size,
                     const OrientationMap<VolumeDim>& orientation_map) const
@@ -234,7 +234,7 @@ void Weno<VolumeDim, tmpl::list<Tags...>>::pup(PUP::er& p) noexcept {
 template <size_t VolumeDim, typename... Tags>
 void Weno<VolumeDim, tmpl::list<Tags...>>::package_data(
     const gsl::not_null<PackagedData*> packaged_data,
-    const db::const_item_type<Tags>&... tensors, const Mesh<VolumeDim>& mesh,
+    const typename Tags::type&... tensors, const Mesh<VolumeDim>& mesh,
     const std::array<double, VolumeDim>& element_size,
     const OrientationMap<VolumeDim>& orientation_map) const noexcept {
   // By always initializing the PackagedData Variables member, we avoid an

--- a/src/Evolution/Systems/Burgers/Characteristics.hpp
+++ b/src/Evolution/Systems/Burgers/Characteristics.hpp
@@ -9,6 +9,7 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/FaceNormal.hpp"
+#include "Evolution/Systems/Burgers/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -25,7 +26,7 @@ struct U;
 namespace Burgers {
 namespace Tags {
 /// Computes the characteristic speeds
-struct CharacteristicSpeedsCompute : db::ComputeTag {
+struct CharacteristicSpeedsCompute : CharacteristicSpeeds, db::ComputeTag {
   static std::string name() noexcept { return "CharacteristicSpeeds"; }
 
   using argument_tags =

--- a/src/Evolution/Systems/Burgers/Tags.hpp
+++ b/src/Evolution/Systems/Burgers/Tags.hpp
@@ -14,5 +14,10 @@ namespace Tags {
 struct U : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
+
+/// The characteristic speeds
+struct CharacteristicSpeeds : db::SimpleTag {
+  using type = std::array<DataVector, 1>;
+};
 }  // namespace Tags
 }  // namespace Burgers

--- a/src/Evolution/Systems/CurvedScalarWave/Equations.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Equations.cpp
@@ -20,13 +20,13 @@ class Tensor;
 namespace CurvedScalarWave {
 namespace CurvedScalarWave_detail {
 template <typename FieldTag>
-db::const_item_type<FieldTag> weight_char_field(
-    const db::const_item_type<FieldTag>& char_field_int,
+typename FieldTag::type weight_char_field(
+    const typename FieldTag::type& char_field_int,
     const DataVector& char_speed_int,
-    const db::const_item_type<FieldTag>& char_field_ext,
+    const typename FieldTag::type& char_field_ext,
     const DataVector& char_speed_ext) noexcept {
   const DataVector& char_speed_avg{0.5 * (char_speed_int + char_speed_ext)};
-  db::const_item_type<FieldTag> weighted_char_field = char_field_int;
+  auto weighted_char_field = char_field_int;
   auto weighted_char_field_it = weighted_char_field.begin();
   for (auto int_it = char_field_int.begin(), ext_it = char_field_ext.begin();
        int_it != char_field_int.end();
@@ -40,12 +40,15 @@ db::const_item_type<FieldTag> weight_char_field(
 }
 
 template <size_t Dim>
-db::const_item_type<Tags::CharacteristicFields<Dim>> weight_char_fields(
-    const db::const_item_type<Tags::CharacteristicFields<Dim>>& char_fields_int,
-    const db::const_item_type<Tags::CharacteristicSpeeds<Dim>>& char_speeds_int,
-    const db::const_item_type<Tags::CharacteristicFields<Dim>>& char_fields_ext,
-    const db::const_item_type<Tags::CharacteristicSpeeds<Dim>>&
-        char_speeds_ext) noexcept {
+using char_field_tags =
+    tmpl::list<Tags::VPsi, Tags::VZero<Dim>, Tags::VPlus, Tags::VMinus>;
+
+template <size_t Dim>
+Variables<char_field_tags<Dim>> weight_char_fields(
+    const Variables<char_field_tags<Dim>>& char_fields_int,
+    const std::array<DataVector, 4>& char_speeds_int,
+    const Variables<char_field_tags<Dim>>& char_fields_ext,
+    const std::array<DataVector, 4>& char_speeds_ext) noexcept {
   const auto& v_psi_int = get<Tags::VPsi>(char_fields_int);
   const auto& v_zero_int = get<Tags::VZero<Dim>>(char_fields_int);
   const auto& v_plus_int = get<Tags::VPlus>(char_fields_int);
@@ -66,9 +69,8 @@ db::const_item_type<Tags::CharacteristicFields<Dim>> weight_char_fields(
   const DataVector& char_speed_v_plus_ext{char_speeds_ext[2]};
   const DataVector& char_speed_v_minus_ext{char_speeds_ext[3]};
 
-  auto weighted_char_fields =
-      make_with_value<db::const_item_type<Tags::CharacteristicFields<Dim>>>(
-          char_speed_v_psi_int, 0.);
+  Variables<char_field_tags<Dim>> weighted_char_fields{
+      char_speeds_int[0].size()};
 
   get<Tags::VPsi>(weighted_char_fields) = weight_char_field<Tags::VPsi>(
       v_psi_int, char_speed_v_psi_int, v_psi_ext, char_speed_v_psi_ext);

--- a/src/Evolution/Systems/NewtonianEuler/NumericalFluxes/Hllc.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/NumericalFluxes/Hllc.cpp
@@ -22,8 +22,7 @@
 #include "Utilities/MakeWithValue.hpp"
 
 /// \cond
-namespace NewtonianEuler {
-namespace NumericalFluxes {
+namespace NewtonianEuler::NumericalFluxes {
 
 template <size_t Dim, typename Frame>
 void Hllc<Dim, Frame>::package_data(
@@ -48,7 +47,7 @@ void Hllc<Dim, Frame>::package_data(
     const Scalar<DataVector>& energy_density,
     const tnsr::I<DataVector, Dim, Frame>& velocity,
     const Scalar<DataVector>& pressure,
-    const db::const_item_type<char_speeds_tag>& characteristic_speeds,
+    const typename char_speeds_tag::type& characteristic_speeds,
     const tnsr::i<DataVector, Dim, Frame>& interface_unit_normal) const
     noexcept {
   *packaged_n_dot_f_mass_density = normal_dot_flux_mass_density;
@@ -218,6 +217,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Inertial))
 #undef DIM
 #undef FRAME
 #undef INSTANTIATE
-}  // namespace NumericalFluxes
-}  // namespace NewtonianEuler
+}  // namespace NewtonianEuler::NumericalFluxes
 /// \endcond

--- a/src/Evolution/Systems/NewtonianEuler/NumericalFluxes/Hllc.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/NumericalFluxes/Hllc.hpp
@@ -187,7 +187,7 @@ struct Hllc : tt::ConformsTo<dg::protocols::NumericalFlux> {
       const Scalar<DataVector>& energy_density,
       const tnsr::I<DataVector, Dim, Frame>& velocity,
       const Scalar<DataVector>& pressure,
-      const db::const_item_type<char_speeds_tag>& characteristic_speeds,
+      const typename char_speeds_tag::type& characteristic_speeds,
       const tnsr::i<DataVector, Dim, Frame>& interface_unit_normal) const
       noexcept;
 

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/Fluxes.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/Fluxes.hpp
@@ -73,18 +73,18 @@ struct ComputeFluxes {
                  gr::Tags::SpatialMetric<3>, gr::Tags::InverseSpatialMetric<3>>;
 
   static void apply(
-      const gsl::not_null<db::const_item_type<
-          ::Tags::Flux<Tags::TildeE<Frame::Inertial, NeutrinoSpecies>,
-                       tmpl::size_t<3>, Frame::Inertial>>*>... tilde_e_flux,
-      const gsl::not_null<db::const_item_type<
-          ::Tags::Flux<Tags::TildeS<Frame::Inertial, NeutrinoSpecies>,
-                       tmpl::size_t<3>, Frame::Inertial>>*>... tilde_s_flux,
-      const db::const_item_type<
-          Tags::TildeE<Frame::Inertial, NeutrinoSpecies>>&... tilde_e,
-      const db::const_item_type<
-          Tags::TildeS<Frame::Inertial, NeutrinoSpecies>>&... tilde_s,
-      const db::const_item_type<
-          Tags::TildeP<Frame::Inertial, NeutrinoSpecies>>&... tilde_p,
+      const gsl::not_null<typename ::Tags::Flux<
+          Tags::TildeE<Frame::Inertial, NeutrinoSpecies>, tmpl::size_t<3>,
+          Frame::Inertial>::type*>... tilde_e_flux,
+      const gsl::not_null<typename ::Tags::Flux<
+          Tags::TildeS<Frame::Inertial, NeutrinoSpecies>, tmpl::size_t<3>,
+          Frame::Inertial>::type*>... tilde_s_flux,
+      const typename Tags::TildeE<Frame::Inertial,
+                                  NeutrinoSpecies>::type&... tilde_e,
+      const typename Tags::TildeS<Frame::Inertial,
+                                  NeutrinoSpecies>::type&... tilde_s,
+      const typename Tags::TildeP<Frame::Inertial,
+                                  NeutrinoSpecies>::type&... tilde_p,
       const Scalar<DataVector>& lapse,
       const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
       const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/M1Closure.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/M1Closure.hpp
@@ -130,27 +130,24 @@ struct ComputeM1Closure<tmpl::list<NeutrinoSpecies...>> {
                  gr::Tags::SpatialMetric<3>, gr::Tags::InverseSpatialMetric<3>>;
 
   static void apply(
-      const gsl::not_null<db::const_item_type<
-          Tags::ClosureFactor<NeutrinoSpecies>>*>... closure_factor,
-      const gsl::not_null<db::const_item_type<
-          Tags::TildeP<Frame::Inertial, NeutrinoSpecies>>*>... tilde_p,
+      const gsl::not_null<typename Tags::ClosureFactor<
+          NeutrinoSpecies>::type*>... closure_factor,
+      const gsl::not_null<typename Tags::TildeP<
+          Frame::Inertial, NeutrinoSpecies>::type*>... tilde_p,
       const gsl::not_null<
-          db::const_item_type<Tags::TildeJ<NeutrinoSpecies>>*>... tilde_j,
-      const gsl::not_null<db::const_item_type<
-          Tags::TildeHNormal<NeutrinoSpecies>>*>... tilde_hn,
-      const gsl::not_null<db::const_item_type<
-          Tags::TildeHSpatial<Frame::Inertial, NeutrinoSpecies>>*>... tilde_hi,
-      const db::const_item_type<
-          Tags::TildeE<Frame::Inertial, NeutrinoSpecies>>&... tilde_e,
-      const db::const_item_type<
-          Tags::TildeS<Frame::Inertial, NeutrinoSpecies>>&... tilde_s,
-      const db::const_item_type<hydro::Tags::SpatialVelocity<DataVector, 3>>&
-          spatial_velocity,
-      const db::const_item_type<hydro::Tags::LorentzFactor<DataVector>>&
-          lorentz_factor,
-      const db::const_item_type<gr::Tags::SpatialMetric<3>>& spatial_metric,
-      const db::const_item_type<gr::Tags::InverseSpatialMetric<3>>&
-          inv_spatial_metric) noexcept {
+          typename Tags::TildeJ<NeutrinoSpecies>::type*>... tilde_j,
+      const gsl::not_null<
+          typename Tags::TildeHNormal<NeutrinoSpecies>::type*>... tilde_hn,
+      const gsl::not_null<typename Tags::TildeHSpatial<
+          Frame::Inertial, NeutrinoSpecies>::type*>... tilde_hi,
+      const typename Tags::TildeE<Frame::Inertial,
+                                  NeutrinoSpecies>::type&... tilde_e,
+      const typename Tags::TildeS<Frame::Inertial,
+                                  NeutrinoSpecies>::type&... tilde_s,
+      const tnsr::I<DataVector, 3>& spatial_velocity,
+      const Scalar<DataVector>& lorentz_factor,
+      const tnsr::ii<DataVector, 3>& spatial_metric,
+      const tnsr::II<DataVector, 3>& inv_spatial_metric) noexcept {
     EXPAND_PACK_LEFT_TO_RIGHT(detail::compute_closure_impl(
         closure_factor, tilde_p, tilde_j, tilde_hn, tilde_hi, tilde_e, tilde_s,
         spatial_velocity, lorentz_factor, spatial_metric, inv_spatial_metric));

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/M1HydroCoupling.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/M1HydroCoupling.hpp
@@ -96,29 +96,23 @@ struct ComputeM1HydroCoupling<tmpl::list<NeutrinoSpecies...>> {
                  gr::Tags::SpatialMetric<3>, gr::Tags::SqrtDetSpatialMetric<>>;
 
   static void apply(
-      const gsl::not_null<db::const_item_type<
-          Tags::M1HydroCouplingNormal<NeutrinoSpecies>>*>... source_n,
-      const gsl::not_null<db::const_item_type<Tags::M1HydroCouplingSpatial<
-          Frame::Inertial, NeutrinoSpecies>>*>... source_i,
-      const db::const_item_type<
-          Tags::GreyEmissivity<NeutrinoSpecies>>&... emissivity,
-      const db::const_item_type<
-          Tags::GreyAbsorptionOpacity<NeutrinoSpecies>>&... absorption_opacity,
-      const db::const_item_type<
-          Tags::GreyScatteringOpacity<NeutrinoSpecies>>&... scattering_opacity,
-      const db::const_item_type<Tags::TildeJ<NeutrinoSpecies>>&... tilde_j,
-      const db::const_item_type<
-          Tags::TildeHNormal<NeutrinoSpecies>>&... tilde_hn,
-      const db::const_item_type<
-          Tags::TildeHSpatial<Frame::Inertial, NeutrinoSpecies>>&... tilde_hi,
-      const db::const_item_type<hydro::Tags::SpatialVelocity<DataVector, 3>>&
-          spatial_velocity,
-      const db::const_item_type<hydro::Tags::LorentzFactor<DataVector>>&
-          lorentz_factor,
-      const db::const_item_type<gr::Tags::Lapse<>>& lapse,
+      const gsl::not_null<typename Tags::M1HydroCouplingNormal<
+          NeutrinoSpecies>::type*>... source_n,
+      const gsl::not_null<typename Tags::M1HydroCouplingSpatial<
+          Frame::Inertial, NeutrinoSpecies>::type*>... source_i,
+      const typename Tags::GreyEmissivity<NeutrinoSpecies>::type&... emissivity,
+      const typename Tags::GreyAbsorptionOpacity<
+          NeutrinoSpecies>::type&... absorption_opacity,
+      const typename Tags::GreyScatteringOpacity<
+          NeutrinoSpecies>::type&... scattering_opacity,
+      const typename Tags::TildeJ<NeutrinoSpecies>::type&... tilde_j,
+      const typename Tags::TildeHNormal<NeutrinoSpecies>::type&... tilde_hn,
+      const typename Tags::TildeHSpatial<Frame::Inertial,
+                                         NeutrinoSpecies>::type&... tilde_hi,
+      const tnsr::I<DataVector, 3>& spatial_velocity,
+      const Scalar<DataVector>& lorentz_factor, const Scalar<DataVector>& lapse,
       const tnsr::ii<DataVector, 3>& spatial_metric,
-      const db::const_item_type<gr::Tags::SqrtDetSpatialMetric<>>&
-          sqrt_det_spatial_metric) noexcept {
+      const Scalar<DataVector>& sqrt_det_spatial_metric) noexcept {
     EXPAND_PACK_LEFT_TO_RIGHT(detail::compute_m1_hydro_coupling_impl(
         source_n, source_i, emissivity, absorption_opacity, scattering_opacity,
         tilde_j, tilde_hn, tilde_hi, spatial_velocity, lorentz_factor, lapse,

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/Sources.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/Sources.hpp
@@ -92,20 +92,20 @@ struct ComputeSources {
       gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>>;
 
   static void apply(
-      const gsl::not_null<db::const_item_type<
-          Tags::TildeE<Frame::Inertial, NeutrinoSpecies>>*>... sources_tilde_e,
-      const gsl::not_null<db::const_item_type<
-          Tags::TildeS<Frame::Inertial, NeutrinoSpecies>>*>... sources_tilde_s,
-      const db::const_item_type<
-          Tags::TildeE<Frame::Inertial, NeutrinoSpecies>>&... tilde_e,
-      const db::const_item_type<
-          Tags::TildeS<Frame::Inertial, NeutrinoSpecies>>&... tilde_s,
-      const db::const_item_type<
-          Tags::TildeP<Frame::Inertial, NeutrinoSpecies>>&... tilde_p,
-      const db::const_item_type<
-          Tags::M1HydroCouplingNormal<NeutrinoSpecies>>&... source_n,
-      const db::const_item_type<Tags::M1HydroCouplingSpatial<
-          Frame::Inertial, NeutrinoSpecies>>&... source_i,
+      const gsl::not_null<typename Tags::TildeE<
+          Frame::Inertial, NeutrinoSpecies>::type*>... sources_tilde_e,
+      const gsl::not_null<typename Tags::TildeS<
+          Frame::Inertial, NeutrinoSpecies>::type*>... sources_tilde_s,
+      const typename Tags::TildeE<Frame::Inertial,
+                                  NeutrinoSpecies>::type&... tilde_e,
+      const typename Tags::TildeS<Frame::Inertial,
+                                  NeutrinoSpecies>::type&... tilde_s,
+      const typename Tags::TildeP<Frame::Inertial,
+                                  NeutrinoSpecies>::type&... tilde_p,
+      const typename Tags::M1HydroCouplingNormal<
+          NeutrinoSpecies>::type&... source_n,
+      const typename Tags::M1HydroCouplingSpatial<
+          Frame::Inertial, NeutrinoSpecies>::type&... source_i,
       const Scalar<DataVector>& lapse, const tnsr::i<DataVector, 3>& d_lapse,
       const tnsr::iJ<DataVector, 3>& d_shift,
       const tnsr::ijj<DataVector, 3>& d_spatial_metric,

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ComputeNonconservativeBoundaryFluxes.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ComputeNonconservativeBoundaryFluxes.hpp
@@ -79,7 +79,8 @@ struct ComputeNonconservativeBoundaryFluxes {
                          DirectionsTag>>(
         [](const gsl::not_null<db::item_type<interface_normal_dot_fluxes_tag>*>
                boundary_fluxes,
-           const db::const_item_type<DirectionsTag>& internal_directions,
+           const std::unordered_set<Direction<Metavariables::volume_dim>>&
+               internal_directions,
            const auto&... tensors) noexcept {
           for (const auto& direction : internal_directions) {
             // Prepending the type name works around an issue with gcc-6

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp
@@ -51,9 +51,9 @@ struct FluxCommunicationTypes {
 
   /// The type of the local data stored on the mortar.  Contains the
   /// packaged data and the local flux.
-  using LocalMortarData = Variables<tmpl::remove_duplicates<tmpl::append<
-      typename db::const_item_type<normal_dot_fluxes_tag>::tags_list,
-      typename PackagedData::tags_list>>>;
+  using LocalMortarData = Variables<tmpl::remove_duplicates<
+      tmpl::append<typename normal_dot_fluxes_tag::type::tags_list,
+                   typename PackagedData::tags_list>>>;
 
   /// The type of the data needed for the local part of the flux
   /// numerical flux computations.  Contains the PackagedData, the
@@ -78,26 +78,23 @@ struct FluxCommunicationTypes {
  public:
   /// The DataBox tag for the data stored on the mortars for global
   /// stepping.
-  using simple_mortar_data_tag =
-      BasedMortars<domain::Tags::VariablesBoundaryData,
-                   Tags::SimpleMortarData<
-                       db::const_item_type<typename Metavariables::temporal_id>,
-                       LocalData, PackagedData>,
-                   volume_dim>;
+  using simple_mortar_data_tag = BasedMortars<
+      domain::Tags::VariablesBoundaryData,
+      Tags::SimpleMortarData<typename Metavariables::temporal_id::type,
+                             LocalData, PackagedData>,
+      volume_dim>;
 
   /// The DataBox tag for the data stored on the mortars for local
   /// stepping.
   using local_time_stepping_mortar_data_tag =
       BasedMortars<domain::Tags::VariablesBoundaryData,
-                   Tags::BoundaryHistory<
-                       LocalData, PackagedData,
-                       db::const_item_type<typename system::variables_tag>>,
+                   Tags::BoundaryHistory<LocalData, PackagedData,
+                                         typename system::variables_tag::type>,
                    volume_dim>;
 
   /// The inbox tag for flux communication.
   struct FluxesTag : public Parallel::InboxInserters::Map<FluxesTag> {
-    using temporal_id =
-        db::const_item_type<typename Metavariables::temporal_id>;
+    using temporal_id = typename Metavariables::temporal_id::type;
     using type = std::map<
         temporal_id,
         FixedHashMap<maximum_number_of_neighbors(volume_dim),

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp
@@ -173,16 +173,15 @@ auto compute_boundary_flux_contribution(
     const typename FluxCommTypes::PackagedData& remote_data,
     const Mesh<Dim>& face_mesh, const Mesh<Dim>& mortar_mesh,
     const size_t extent_perpendicular_to_boundary,
-    const MortarSize<Dim>& mortar_size) noexcept
-    -> db::const_item_type<
-        db::remove_tag_prefix<typename FluxCommTypes::normal_dot_fluxes_tag>> {
+    const MortarSize<Dim>& mortar_size) noexcept ->
+    typename db::remove_tag_prefix<
+        typename FluxCommTypes::normal_dot_fluxes_tag>::type {
   static_assert(std::is_same_v<std::decay_t<LocalData>,
                                typename FluxCommTypes::LocalData>,
                 "Second argument must be a FluxCommTypes::LocalData");
   using variables_tag =
       db::remove_tag_prefix<typename FluxCommTypes::normal_dot_fluxes_tag>;
-  db::const_item_type<db::add_tag_prefix<Tags::NormalDotNumericalFlux,
-                                         variables_tag>>
+  typename db::add_tag_prefix<Tags::NormalDotNumericalFlux, variables_tag>::type
       normal_dot_numerical_fluxes(mortar_mesh.number_of_grid_points(), 0.0);
   MortarHelpers_detail::apply_normal_dot_numerical_flux(
       make_not_null(&normal_dot_numerical_fluxes),

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp
@@ -86,9 +86,10 @@ struct NormalDotFluxCompute : db::add_tag_prefix<NormalDotFlux, Tag>,
       Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<VolumeDim, Fr>>;
 
  public:
-  static auto function(const db::const_item_type<flux_tag>& flux,
-                       const db::const_item_type<normal_tag>& normal) noexcept {
-    using tags_list = typename db::const_item_type<Tag>::tags_list;
+  static auto function(
+      const typename flux_tag::type& flux,
+      const tnsr::i<DataVector, VolumeDim, Fr>& normal) noexcept {
+    using tags_list = typename Tag::type::tags_list;
     return normal_dot_flux<tags_list>(normal, flux);
   }
   using argument_tags = tmpl::list<flux_tag, normal_tag>;

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/Hll.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/Hll.hpp
@@ -101,10 +101,9 @@ struct Hll : tt::ConformsTo<dg::protocols::NumericalFlux> {
         const gsl::not_null<Scalar<DataVector>*> packaged_largest_ingoing_speed,
         const gsl::not_null<Scalar<DataVector>*>
             packaged_largest_outgoing_speed,
-        const db::const_item_type<NormalDotFluxTags>&... n_dot_f_to_package,
-        const db::const_item_type<VariablesTags>&... u_to_package,
-        const db::const_item_type<char_speeds_tag>&
-            characteristic_speeds) noexcept {
+        const typename NormalDotFluxTags::type&... n_dot_f_to_package,
+        const typename VariablesTags::type&... u_to_package,
+        const typename char_speeds_tag::type& characteristic_speeds) noexcept {
       expand_pack((*packaged_u = u_to_package)...);
       expand_pack((*packaged_n_dot_f = n_dot_f_to_package)...);
 
@@ -147,27 +146,22 @@ struct Hll : tt::ConformsTo<dg::protocols::NumericalFlux> {
     static void function(
         const gsl::not_null<
             db::item_type<NormalDotNumericalFluxTags>*>... n_dot_numerical_f,
-        const db::const_item_type<NormalDotFluxTags>&... n_dot_f_interior,
-        const db::const_item_type<VariablesTags>&... u_interior,
-        const db::const_item_type<LargestIngoingSpeed>&
-            largest_ingoing_speed_interior,
-        const db::const_item_type<LargestOutgoingSpeed>&
+        const typename NormalDotFluxTags::type&... n_dot_f_interior,
+        const typename VariablesTags::type&... u_interior,
+        const Scalar<DataVector>& largest_ingoing_speed_interior,
+        const typename LargestOutgoingSpeed::type&
             largest_outgoing_speed_interior,
-        const db::const_item_type<NormalDotFluxTags>&... minus_n_dot_f_exterior,
-        const db::const_item_type<VariablesTags>&... u_exterior,
+        const typename NormalDotFluxTags::type&... minus_n_dot_f_exterior,
+        const typename VariablesTags::type&... u_exterior,
         // names are inverted w.r.t. interior data. See package_data()
-        const db::const_item_type<LargestIngoingSpeed>&
+        const typename LargestIngoingSpeed::type&
             minus_largest_outgoing_speed_exterior,
-        const db::const_item_type<LargestOutgoingSpeed>&
+        const typename LargestOutgoingSpeed::type&
             minus_largest_ingoing_speed_exterior) noexcept {
-      auto largest_ingoing_speed =
-          make_with_value<db::const_item_type<LargestIngoingSpeed>>(
-              largest_ingoing_speed_interior,
-              std::numeric_limits<double>::signaling_NaN());
-      auto largest_outgoing_speed =
-          make_with_value<db::const_item_type<LargestOutgoingSpeed>>(
-              largest_outgoing_speed_interior,
-              std::numeric_limits<double>::signaling_NaN());
+      const auto number_of_grid_points =
+          get(largest_ingoing_speed_interior).size();
+      auto largest_ingoing_speed = Scalar<DataVector>{number_of_grid_points};
+      auto largest_outgoing_speed = Scalar<DataVector>{number_of_grid_points};
       for (size_t s = 0; s < largest_ingoing_speed.begin()->size(); ++s) {
         get(largest_ingoing_speed)[s] =
             std::min({get(largest_ingoing_speed_interior)[s],

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/LocalLaxFriedrichs.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/LocalLaxFriedrichs.hpp
@@ -85,10 +85,9 @@ struct LocalLaxFriedrichs : tt::ConformsTo<dg::protocols::NumericalFlux> {
             db::item_type<NormalDotFluxTags>*>... packaged_n_dot_f,
         const gsl::not_null<db::item_type<VariablesTags>*>... packaged_u,
         const gsl::not_null<Scalar<DataVector>*> packaged_max_char_speed,
-        const db::const_item_type<NormalDotFluxTags>&... n_dot_f_to_package,
-        const db::const_item_type<VariablesTags>&... u_to_package,
-        const db::const_item_type<char_speeds_tag>&
-            characteristic_speeds) noexcept {
+        const typename NormalDotFluxTags::type&... n_dot_f_to_package,
+        const typename VariablesTags::type&... u_to_package,
+        const typename char_speeds_tag::type& characteristic_speeds) noexcept {
       ASSERT(get(*packaged_max_char_speed).size() ==
                  characteristic_speeds[0].size(),
              "Size of packaged data ("
@@ -121,13 +120,12 @@ struct LocalLaxFriedrichs : tt::ConformsTo<dg::protocols::NumericalFlux> {
     static void apply(
         const gsl::not_null<
             db::item_type<NormalDotNumericalFluxTags>*>... n_dot_numerical_f,
-        const db::const_item_type<NormalDotFluxTags>&... n_dot_f_interior,
-        const db::const_item_type<VariablesTags>&... u_interior,
-        const db::const_item_type<MaxAbsCharSpeed>& max_abs_speed_interior,
-        const db::const_item_type<NormalDotFluxTags>&... minus_n_dot_f_exterior,
-        const db::const_item_type<VariablesTags>&... u_exterior,
-        const db::const_item_type<MaxAbsCharSpeed>&
-            max_abs_speed_exterior) noexcept {
+        const typename NormalDotFluxTags::type&... n_dot_f_interior,
+        const typename VariablesTags::type&... u_interior,
+        const Scalar<DataVector>& max_abs_speed_interior,
+        const typename NormalDotFluxTags::type&... minus_n_dot_f_exterior,
+        const typename VariablesTags::type&... u_exterior,
+        const Scalar<DataVector>& max_abs_speed_exterior) noexcept {
       const Scalar<DataVector> max_abs_speed(DataVector(
           max(get(max_abs_speed_interior), get(max_abs_speed_exterior))));
       const auto assemble_numerical_flux = [&max_abs_speed](

--- a/src/NumericalAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp
@@ -106,8 +106,7 @@ class InterpolateWithoutInterpComponent<VolumeDim, InterpolationTargetTag,
   void operator()(
       const TimeStepId& time_id,
       const db::item_type<Tags::InterpPointInfo<Metavariables>>& point_infos,
-      const Mesh<VolumeDim>& mesh,
-      const db::const_item_type<Tensors>&... tensors,
+      const Mesh<VolumeDim>& mesh, const typename Tensors::type&... tensors,
       Parallel::ConstGlobalCache<Metavariables>& cache,
       const ElementId<VolumeDim>& array_index,
       const ParallelComponent* const /*meta*/) const noexcept {

--- a/src/NumericalAlgorithms/Interpolation/Interpolate.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Interpolate.hpp
@@ -93,7 +93,7 @@ class Interpolate<VolumeDim, InterpolationTargetTag, tmpl::list<Tensors...>,
 
   template <typename Metavariables, typename ParallelComponent>
   void operator()(const TimeStepId& time_id, const Mesh<VolumeDim>& mesh,
-                  const db::const_item_type<Tensors>&... tensors,
+                  const typename Tensors::type&... tensors,
                   Parallel::ConstGlobalCache<Metavariables>& cache,
                   const ElementId<VolumeDim>& array_index,
                   const ParallelComponent* const /*meta*/) const noexcept {

--- a/src/NumericalAlgorithms/Interpolation/TryToInterpolate.hpp
+++ b/src/NumericalAlgorithms/Interpolation/TryToInterpolate.hpp
@@ -44,7 +44,7 @@ void interpolate_data(
           const gsl::not_null<
               db::item_type<Tags::InterpolatedVarsHolders<Metavariables>>*>
               holders,
-          const db::const_item_type<Tags::VolumeVarsInfo<Metavariables>>&
+          const typename Tags::VolumeVarsInfo<Metavariables>::type&
               volume_vars_info) noexcept {
         auto& interp_info =
             get<Vars::HolderTag<InterpolationTargetTag, Metavariables>>(

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
@@ -47,24 +47,23 @@ struct div;
 
 /// \cond
 template <typename Tag>
-struct div<Tag, Requires<tt::is_a_v<Tensor, db::const_item_type<Tag>>>>
+struct div<Tag, Requires<tt::is_a_v<Tensor, typename Tag::type>>>
     : db::PrefixTag, db::SimpleTag {
   static std::string name() noexcept {
     return "div(" + db::tag_name<Tag>() + ")";
   }
   using tag = Tag;
-  using type =
-      TensorMetafunctions::remove_first_index<db::const_item_type<Tag>>;
+  using type = TensorMetafunctions::remove_first_index<typename Tag::type>;
 };
 
 template <typename Tag>
-struct div<Tag, Requires<tt::is_a_v<::Variables, db::const_item_type<Tag>>>>
+struct div<Tag, Requires<tt::is_a_v<::Variables, typename Tag::type>>>
     : db::PrefixTag, db::SimpleTag {
   static std::string name() noexcept {
     return "div(" + db::tag_name<Tag>() + ")";
   }
   using tag = Tag;
-  using type = db::const_item_type<Tag>;
+  using type = typename Tag::type;
 };
 /// \endcond
 }  // namespace Tags
@@ -134,8 +133,7 @@ namespace Tags {
 template <typename Tag, typename InverseJacobianTag>
 struct DivVariablesCompute : db::add_tag_prefix<div, Tag>, db::ComputeTag {
  private:
-  using inv_jac_indices =
-      typename db::const_item_type<InverseJacobianTag>::index_list;
+  using inv_jac_indices = typename InverseJacobianTag::type::index_list;
   static constexpr auto dim = tmpl::back<inv_jac_indices>::dim;
   static_assert(std::is_same_v<typename tmpl::front<inv_jac_indices>::Frame,
                                Frame::Logical>,
@@ -147,7 +145,7 @@ struct DivVariablesCompute : db::add_tag_prefix<div, Tag>, db::ComputeTag {
   static constexpr void (*function)(const gsl::not_null<return_type*>,
                                     const typename Tag::type&, const Mesh<dim>&,
                                     const typename InverseJacobianTag::type&) =
-      divergence<typename db::const_item_type<Tag>::tags_list, dim,
+      divergence<typename Tag::type::tags_list, dim,
                  typename tmpl::back<inv_jac_indices>::Frame>;
   using argument_tags =
       tmpl::list<Tag, domain::Tags::Mesh<dim>, InverseJacobianTag>;
@@ -160,8 +158,7 @@ struct DivVariablesCompute : db::add_tag_prefix<div, Tag>, db::ComputeTag {
 template <typename Tag, typename InverseJacobianTag>
 struct DivVectorCompute : db::add_tag_prefix<div, Tag>, db::ComputeTag {
  private:
-  using inv_jac_indices =
-      typename db::const_item_type<InverseJacobianTag>::index_list;
+  using inv_jac_indices = typename InverseJacobianTag::type::index_list;
   static constexpr auto dim = tmpl::back<inv_jac_indices>::dim;
   static_assert(std::is_same_v<typename tmpl::front<inv_jac_indices>::Frame,
                                Frame::Logical>,

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.tpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.tpp
@@ -44,7 +44,7 @@ void divergence(
     using DivFluxTag = Tags::div<FluxTag>;
 
     using first_index =
-        tmpl::front<typename db::const_item_type<FluxTag>::index_list>;
+        tmpl::front<typename FluxTag::type::index_list>;
     static_assert(
         std::is_same_v<typename first_index::Frame, DerivativeFrame> and
             first_index::ul == UpLo::Up,

--- a/src/NumericalAlgorithms/Spectral/SwshDerivatives.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshDerivatives.hpp
@@ -214,7 +214,7 @@ struct AngularDerivativesImpl<tmpl::list<DerivativeTags...>,
           DerivativeTags>>*>... transform_of_derivative_scalars,
       const gsl::not_null<db::item_type<Tags::SwshTransform<
           UniqueDifferentiatedFromTags>>*>... transform_of_input_scalars,
-      const db::const_item_type<UniqueDifferentiatedFromTags>&... input_scalars,
+      const typename UniqueDifferentiatedFromTags::type&... input_scalars,
       const size_t l_max, const size_t number_of_radial_points) noexcept {
     apply_to_vectors(make_not_null(&get(*transform_of_derivative_scalars))...,
                      make_not_null(&get(*transform_of_input_scalars))...,
@@ -239,10 +239,8 @@ struct AngularDerivativesImpl<tmpl::list<DerivativeTags...>,
           DerivativeTags>>::type*>... transform_of_derivatives,
       const gsl::not_null<typename db::item_type<Tags::SwshTransform<
           UniqueDifferentiatedFromTags>>::type*>... transform_of_inputs,
-      const gsl::not_null<
-          typename db::const_item_type<DerivativeTags>::type*>... derivatives,
-      const typename db::const_item_type<
-          UniqueDifferentiatedFromTags>::type&... inputs,
+      const gsl::not_null<typename DerivativeTags::type::type*>... derivatives,
+      const typename UniqueDifferentiatedFromTags::type::type&... inputs,
       const size_t l_max, const size_t number_of_radial_points) noexcept {
     // perform the forward transform on the minimal set of input nodal
     // quantities to obtain all of the requested derivatives

--- a/src/NumericalAlgorithms/Spectral/SwshTransform.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshTransform.hpp
@@ -422,11 +422,10 @@ struct SwshTransform;
 /// \cond
 template <typename... TransformTags, ComplexRepresentation Representation>
 struct SwshTransform<tmpl::list<TransformTags...>, Representation> {
-  static constexpr int spin = db::const_item_type<
-      tmpl::front<tmpl::list<TransformTags...>>>::type::spin;
+  static constexpr int spin =
+      tmpl::front<tmpl::list<TransformTags...>>::type::type::spin;
 
-  static_assert(tmpl2::flat_all_v<
-                    db::const_item_type<TransformTags>::type::spin == spin...>,
+  static_assert(tmpl2::flat_all_v<TransformTags::type::type::spin == spin...>,
                 "All Tags in TagList submitted to SwshTransform must have the "
                 "same spin weight.");
 
@@ -437,8 +436,8 @@ struct SwshTransform<tmpl::list<TransformTags...>, Representation> {
   static void apply(
       const gsl::not_null<
           db::item_type<Tags::SwshTransform<TransformTags>>*>... coefficients,
-      const db::const_item_type<TransformTags>&... collocations,
-      const size_t l_max, const size_t number_of_radial_points) noexcept {
+      const typename TransformTags::type&... collocations, const size_t l_max,
+      const size_t number_of_radial_points) noexcept {
     // forward to the version which takes parameter packs of vectors
     apply_to_vectors(make_not_null(&get(*coefficients))...,
                      get(collocations)..., l_max, number_of_radial_points);
@@ -464,8 +463,8 @@ struct SwshTransform<tmpl::list<TransformTags...>, Representation> {
   static void apply_to_vectors(
       const gsl::not_null<typename db::item_type<
           Tags::SwshTransform<TransformTags>>::type*>... coefficients,
-      const typename db::const_item_type<TransformTags>::type&... collocations,
-      size_t l_max, size_t number_of_radial_points) noexcept;
+      const typename TransformTags::type::type&... collocations, size_t l_max,
+      size_t number_of_radial_points) noexcept;
 };
 /// \endcond
 
@@ -506,12 +505,11 @@ struct InverseSwshTransform;
 /// \cond
 template <typename... TransformTags, ComplexRepresentation Representation>
 struct InverseSwshTransform<tmpl::list<TransformTags...>, Representation> {
-  static constexpr int spin = db::const_item_type<
-      tmpl::front<tmpl::list<TransformTags...>>>::type::spin;
+  static constexpr int spin =
+      tmpl::front<tmpl::list<TransformTags...>>::type::type::spin;
 
   static_assert(
-      tmpl2::flat_all_v<db::const_item_type<TransformTags>::type::spin ==
-                        spin...>,
+      tmpl2::flat_all_v<TransformTags ::type::type::spin == spin...>,
       "All Tags in TagList submitted to InverseSwshTransform must have the "
       "same spin weight.");
 
@@ -522,8 +520,7 @@ struct InverseSwshTransform<tmpl::list<TransformTags...>, Representation> {
 
   static void apply(
       const gsl::not_null<db::item_type<TransformTags>*>... collocations,
-      const db::const_item_type<
-          Tags::SwshTransform<TransformTags>>&... coefficients,
+      const typename Tags::SwshTransform<TransformTags>::type&... coefficients,
       const size_t l_max, const size_t number_of_radial_points) noexcept {
     // forward to the version which takes parameter packs of vectors
     apply_to_vectors(make_not_null(&get(*collocations))...,
@@ -550,8 +547,8 @@ struct InverseSwshTransform<tmpl::list<TransformTags...>, Representation> {
   static void apply_to_vectors(
       const gsl::not_null<
           typename db::item_type<TransformTags>::type*>... collocations,
-      const typename db::const_item_type<
-          Tags::SwshTransform<TransformTags>>::type&... coefficients,
+      const typename Tags::SwshTransform<
+          TransformTags>::type::type&... coefficients,
       size_t l_max, size_t number_of_radial_points) noexcept;
 };
 
@@ -560,8 +557,7 @@ void SwshTransform<tmpl::list<TransformTags...>, Representation>::
     apply_to_vectors(
         const gsl::not_null<typename db::item_type<
             Tags::SwshTransform<TransformTags>>::type*>... coefficients,
-        const typename db::const_item_type<
-            TransformTags>::type&... collocations,
+        const typename TransformTags::type::type&... collocations,
         const size_t l_max, const size_t number_of_radial_points) noexcept {
   EXPAND_PACK_LEFT_TO_RIGHT(coefficients->destructive_resize(
       size_of_libsharp_coefficient_vector(l_max) * number_of_radial_points));
@@ -614,8 +610,8 @@ void InverseSwshTransform<tmpl::list<TransformTags...>, Representation>::
     apply_to_vectors(
         const gsl::not_null<
             typename db::item_type<TransformTags>::type*>... collocations,
-        const typename db::const_item_type<
-            Tags::SwshTransform<TransformTags>>::type&... coefficients,
+        const typename Tags::SwshTransform<
+            TransformTags>::type::type&... coefficients,
         const size_t l_max, const size_t number_of_radial_points) noexcept {
   EXPAND_PACK_LEFT_TO_RIGHT(collocations->destructive_resize(
       number_of_swsh_collocation_points(l_max) * number_of_radial_points));

--- a/src/ParallelAlgorithms/DiscontinuousGalerkin/FluxCommunication.hpp
+++ b/src/ParallelAlgorithms/DiscontinuousGalerkin/FluxCommunication.hpp
@@ -292,7 +292,7 @@ struct ReceiveDataForFluxes<
                    const gsl::not_null<db::item_type<
                        Tags::Mortars<receive_temporal_id_tag, volume_dim>>*>
                        neighbor_next_temporal_ids,
-                   const db::const_item_type<receive_temporal_id_tag>&
+                   const typename receive_temporal_id_tag::type&
                        local_next_temporal_id) noexcept {
           auto& inbox = tuples::get<fluxes_inbox_tag>(inboxes);
           for (auto received_data = inbox.begin();

--- a/src/ParallelAlgorithms/Events/ObserveErrorNorms.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveErrorNorms.hpp
@@ -9,7 +9,6 @@
 #include <utility>
 #include <vector>
 
-#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataBox/TagName.hpp"
 #include "Domain/Tags.hpp"
@@ -123,9 +122,9 @@ class ObserveErrorNorms<ObservationValueTag, tmpl::list<Tensors...>,
   template <typename Metavariables, typename ArrayIndex,
             typename ParallelComponent>
   void operator()(
-      const db::const_item_type<ObservationValueTag>& observation_value,
-      const db::const_item_type<Tensors>&... tensors,
-      const db::const_item_type<::Tags::Analytic<Tensors>>&... analytic_tensors,
+      const typename ObservationValueTag::type& observation_value,
+      const typename Tensors::type&... tensors,
+      const typename ::Tags::Analytic<Tensors>::type&... analytic_tensors,
       Parallel::ConstGlobalCache<Metavariables>& cache,
       const ArrayIndex& /*array_index*/,
       const ParallelComponent* const /*meta*/) const noexcept {

--- a/src/ParallelAlgorithms/Events/ObserveFields.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveFields.hpp
@@ -12,7 +12,6 @@
 #include <utility>
 #include <vector>
 
-#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataBox/TagName.hpp"
 #include "DataStructures/DataVector.hpp"
@@ -164,15 +163,15 @@ class ObserveFields<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
 
   template <typename Metavariables, typename ParallelComponent>
   void operator()(
-      const db::const_item_type<ObservationValueTag>& observation_value,
+      const typename ObservationValueTag::type& observation_value,
       const Mesh<VolumeDim>& mesh,
       const tnsr::I<DataVector, VolumeDim, Frame::Inertial>&
           inertial_coordinates,
-      const db::const_item_type<
-          AnalyticSolutionTensors>&... analytic_solution_tensors,
-      const db::const_item_type<
-          ::Tags::Analytic<AnalyticSolutionTensors>>&... analytic_solutions,
-      const db::const_item_type<NonSolutionTensors>&... non_solution_tensors,
+      const typename AnalyticSolutionTensors::
+          type&... analytic_solution_tensors,
+      const typename ::Tags::Analytic<
+          AnalyticSolutionTensors>::type&... analytic_solutions,
+      const typename NonSolutionTensors::type&... non_solution_tensors,
       Parallel::ConstGlobalCache<Metavariables>& cache,
       const ElementId<VolumeDim>& array_index,
       const ParallelComponent* const /*meta*/) const noexcept {
@@ -187,8 +186,8 @@ class ObserveFields<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
     components.reserve(alg::accumulate(
         std::initializer_list<size_t>{
             inertial_coordinates.size(),
-            2 * db::const_item_type<AnalyticSolutionTensors>::size()...,
-            db::const_item_type<NonSolutionTensors>::size()...},
+            2 * AnalyticSolutionTensors::type::size()...,
+            NonSolutionTensors::type::size()...},
         0_st));
 
     const auto record_tensor_components = [ this, &components, &element_name ](

--- a/src/ParallelAlgorithms/Events/ObserveVolumeIntegrals.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveVolumeIntegrals.hpp
@@ -9,7 +9,6 @@
 #include <utility>
 #include <vector>
 
-#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "Domain/Tags.hpp"
@@ -118,13 +117,13 @@ class ObserveVolumeIntegrals<VolumeDim, ObservationValueTag,
 
   template <typename Metavariables, typename ArrayIndex,
             typename ParallelComponent>
-  void operator()(
-      const db::const_item_type<ObservationValueTag>& observation_value,
-      const Mesh<VolumeDim>& mesh, const Scalar<DataVector>& det_inv_jacobian,
-      const db::const_item_type<Tensors>&... tensors,
-      Parallel::ConstGlobalCache<Metavariables>& cache,
-      const ArrayIndex& /*array_index*/,
-      const ParallelComponent* const /*meta*/) const noexcept {
+  void operator()(const typename ObservationValueTag::type& observation_value,
+                  const Mesh<VolumeDim>& mesh,
+                  const Scalar<DataVector>& det_inv_jacobian,
+                  const typename Tensors::type&... tensors,
+                  Parallel::ConstGlobalCache<Metavariables>& cache,
+                  const ArrayIndex& /*array_index*/,
+                  const ParallelComponent* const /*meta*/) const noexcept {
     // Determinant of Jacobian is needed because integral is performed in
     // logical coords.
     const DataVector det_jacobian = 1.0 / get(det_inv_jacobian);

--- a/src/ParallelAlgorithms/LinearSolver/Tags.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Tags.hpp
@@ -115,7 +115,7 @@ struct ResidualCompute : db::add_tag_prefix<Residual, FieldsTag>,
   using return_type = typename base::type;
   static void function(
       const gsl::not_null<return_type*> residual,
-      const db::const_item_type<SourceTag>& source,
+      const typename SourceTag::type& source,
       const db::item_type<db::add_tag_prefix<OperatorAppliedTo, FieldsTag>>&
           operator_applied_to_fields) noexcept {
     *residual = source - operator_applied_to_fields;
@@ -214,8 +214,7 @@ struct OrthogonalizationHistory : db::PrefixTag, db::SimpleTag {
  * `db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo,
  * db::add_tag_prefix<LinearSolver::Tags::Operand, Tag>>` and
  * `db::add_tag_prefix<::Tags::FixedSource, Tag>`, respectively. Therefore, each
- * basis vector is of the type `db::const_item_type<db::add_tag_prefix<Operand,
- * Tag>>`.
+ * basis vector is of the type db::add_tag_prefix<Operand, Tag>::type.
  */
 template <typename Tag>
 struct KrylovSubspaceBasis : db::PrefixTag, db::SimpleTag {
@@ -224,7 +223,7 @@ struct KrylovSubspaceBasis : db::PrefixTag, db::SimpleTag {
     // operator
     return "KrylovSubspaceBasis(" + db::tag_name<Tag>() + ")";
   }
-  using type = std::vector<db::const_item_type<Tag>>;
+  using type = std::vector<typename Tag::type>;
   using tag = Tag;
 };
 

--- a/src/Time/Actions/RecordTimeStepperData.hpp
+++ b/src/Time/Actions/RecordTimeStepperData.hpp
@@ -67,8 +67,8 @@ struct RecordTimeStepperData {
         make_not_null(&box),
         [](const gsl::not_null<db::item_type<history_tag>*> history,
            const TimeStepId& time_step_id,
-           const db::const_item_type<variables_tag>& vars,
-           const db::const_item_type<dt_variables_tag>& dt_vars) noexcept {
+           const typename variables_tag::type& vars,
+           const typename dt_variables_tag::type& dt_vars) noexcept {
           history->insert(time_step_id, vars, dt_vars);
         },
         db::get<Tags::TimeStepId>(box), db::get<variables_tag>(box),

--- a/src/Time/Actions/UpdateU.hpp
+++ b/src/Time/Actions/UpdateU.hpp
@@ -66,9 +66,7 @@ struct UpdateU {
         make_not_null(&box),
         [](const gsl::not_null<db::item_type<variables_tag>*> vars,
            const gsl::not_null<db::item_type<history_tag>*> history,
-           const db::const_item_type<Tags::TimeStep>& time_step,
-           const db::const_item_type<Tags::TimeStepper<>, DbTags>&
-               time_stepper) noexcept {
+           const ::TimeDelta& time_step, const auto& time_stepper) noexcept {
           time_stepper.update_u(vars, history, time_step);
         },
         db::get<Tags::TimeStep>(box), db::get<Tags::TimeStepper<>>(box));

--- a/src/Time/StepChoosers/Cfl.hpp
+++ b/src/Time/StepChoosers/Cfl.hpp
@@ -8,7 +8,6 @@
 #include <pup.h>
 
 #include "DataStructures/DataBox/DataBox.hpp"
-#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"  // IWYU pragma: keep
@@ -74,7 +73,8 @@ class Cfl : public StepChooser<StepChooserRegistrars> {
   template <typename Metavariables, typename DbTags>
   double operator()(
       const double minimum_grid_spacing, const db::DataBox<DbTags>& box,
-      const db::const_item_type<Tags::TimeStepper<>, DbTags>& time_stepper,
+      const typename Metavariables::time_stepper_tag::type::element_type&
+          time_stepper,
       const double /*last_step_magnitude*/,
       const Parallel::ConstGlobalCache<Metavariables>& /*cache*/) const
       noexcept {

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -91,9 +91,9 @@ struct HistoryEvolvedVariables<> : db::BaseTag {};
 
 template <typename Tag>
 struct HistoryEvolvedVariables : HistoryEvolvedVariables<>, db::SimpleTag {
-  using type = TimeSteppers::History<
-      db::const_item_type<Tag>,
-      db::const_item_type<db::add_tag_prefix<Tags::dt, Tag>>>;
+  using type =
+      TimeSteppers::History<typename Tag::type,
+                            typename db::add_tag_prefix<Tags::dt, Tag>::type>;
 };
 /// \endcond
 

--- a/tests/Unit/ApparentHorizons/Test_Tags.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Tags.cpp
@@ -13,7 +13,6 @@
 #include "ApparentHorizons/Tags.hpp"  // IWYU pragma: keep
 #include "ApparentHorizons/YlmSpherepack.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
-#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
@@ -84,8 +83,7 @@ void test_radius_and_derivs() {
   CHECK_ITERABLE_APPROX(strahlkorper_radius, expected_radius);
 
   // Test derivative of radius
-  db::const_item_type<StrahlkorperTags::DxRadius<Frame::Inertial>>
-      expected_dx_radius(n_pts);
+  tnsr::i<DataVector, 3> expected_dx_radius(n_pts);
   for (size_t s = 0; s < n_pts; ++s) {
     // Analytic solution Mark Scheel computed in Mathematica
     const double theta = theta_phi[0][s];
@@ -111,8 +109,7 @@ void test_radius_and_derivs() {
   CHECK_ITERABLE_APPROX(strahlkorper_dx_radius, expected_dx_radius);
 
   // Test second derivatives.
-  db::const_item_type<StrahlkorperTags::D2xRadius<Frame::Inertial>>
-      expected_d2x_radius(n_pts);
+  tnsr::ii<DataVector, 3> expected_d2x_radius(n_pts);
   for (size_t s = 0; s < n_pts; ++s) {
     // Messy analytic solution Mark Scheel computed in Mathematica
     const double theta = theta_phi[0][s];
@@ -177,7 +174,7 @@ void test_normals() {
 
   // Test surface_tangents
 
-  db::const_item_type<StrahlkorperTags::Tangents<Frame::Inertial>>
+  StrahlkorperTags::aliases ::Jacobian<Frame::Inertial>
       expected_surface_tangents(n_pts);
   const double amp = -sqrt(3.0 / 8.0 / M_PI) * y11_amplitude;
 
@@ -212,8 +209,7 @@ void test_normals() {
   CHECK_ITERABLE_APPROX(surface_tangents, expected_surface_tangents);
 
   // Test surface_cartesian_coordinates
-  db::const_item_type<StrahlkorperTags::CartesianCoords<Frame::Inertial>>
-      expected_cart_coords(n_pts);
+  tnsr::I<DataVector, 3> expected_cart_coords(n_pts);
 
   {
     const DataVector temp = radius + amp * sin_phi * sin_theta;
@@ -226,8 +222,7 @@ void test_normals() {
   CHECK_ITERABLE_APPROX(expected_cart_coords, cart_coords);
 
   // Test surface_normal_one_form
-  db::const_item_type<StrahlkorperTags::NormalOneForm<Frame::Inertial>>
-      expected_normal_one_form(n_pts);
+  tnsr::i<DataVector, 3> expected_normal_one_form(n_pts);
   {
     const auto& r = db::get<StrahlkorperTags::Radius<Frame::Inertial>>(box);
     const DataVector one_over_r = 1.0 / r;

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_UpwindFlux.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_UpwindFlux.cpp
@@ -35,12 +35,15 @@
 
 namespace CurvedScalarWave::CurvedScalarWave_detail {
 template <size_t Dim>
-db::const_item_type<Tags::CharacteristicFields<Dim>> weight_char_fields(
-    const db::const_item_type<Tags::CharacteristicFields<Dim>>& char_fields_int,
-    const db::const_item_type<Tags::CharacteristicSpeeds<Dim>>& char_speeds_int,
-    const db::const_item_type<Tags::CharacteristicFields<Dim>>& char_fields_ext,
-    const db::const_item_type<Tags::CharacteristicSpeeds<Dim>>&
-        char_speeds_ext) noexcept;
+using char_field_tags =
+    tmpl::list<Tags::VPsi, Tags::VZero<Dim>, Tags::VPlus, Tags::VMinus>;
+
+template <size_t Dim>
+Variables<char_field_tags<Dim>> weight_char_fields(
+    const Variables<char_field_tags<Dim>>& char_fields_int,
+    const std::array<DataVector, 4>& char_speeds_int,
+    const Variables<char_field_tags<Dim>>& char_fields_ext,
+    const std::array<DataVector, 4>& char_speeds_ext) noexcept;
 }  // namespace CurvedScalarWave::CurvedScalarWave_detail
 
 namespace {

--- a/tests/Unit/Helpers/DataStructures/TestTags.hpp
+++ b/tests/Unit/Helpers/DataStructures/TestTags.hpp
@@ -26,26 +26,26 @@ struct scalar2 : db::SimpleTag {
 /// [prefix_variables_tag]
 template <class Tag>
 struct Prefix0 : db::PrefixTag, db::SimpleTag {
-  using type = db::const_item_type<Tag>;
+  using type = typename Tag::type;
   using tag = Tag;
 };
 /// [prefix_variables_tag]
 
 template <class Tag>
 struct Prefix1 : db::PrefixTag, db::SimpleTag {
-  using type = db::const_item_type<Tag>;
+  using type = typename Tag::type;
   using tag = Tag;
 };
 
 template <class Tag>
 struct Prefix2 : db::PrefixTag, db::SimpleTag {
-  using type = db::const_item_type<Tag>;
+  using type = typename Tag::type;
   using tag = Tag;
 };
 
 template <class Tag>
 struct Prefix3 : db::PrefixTag, db::SimpleTag {
-  using type = db::const_item_type<Tag>;
+  using type = typename Tag::type;
   using tag = Tag;
 };
 }  // namespace VariablesTestTags_detail

--- a/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp
@@ -258,11 +258,9 @@ template <typename Tag>
 using deriv = Tags::deriv<Tag, tmpl::size_t<3>, Frame::Inertial>;
 
 template <typename Tag, typename Solution>
-db::const_item_type<Tag> time_derivative(const Solution& solution,
-                                         const tnsr::I<double, 3>& x,
-                                         const double time,
-                                         const double dt) noexcept {
-  db::const_item_type<Tag> result{};
+auto time_derivative(const Solution& solution, const tnsr::I<double, 3>& x,
+                     const double time, const double dt) noexcept {
+  typename Tag::type result{};
   for (auto it = result.begin(); it != result.end(); ++it) {
     const auto index = result.get_tensor_index(it);
     *it = numerical_derivative(
@@ -277,11 +275,9 @@ db::const_item_type<Tag> time_derivative(const Solution& solution,
 }
 
 template <typename Tag, typename Solution>
-db::const_item_type<deriv<Tag>> space_derivative(const Solution& solution,
-                                                 const tnsr::I<double, 3>& x,
-                                                 const double time,
-                                                 const double dx) noexcept {
-  db::const_item_type<deriv<Tag>> result{};
+auto space_derivative(const Solution& solution, const tnsr::I<double, 3>& x,
+                      const double time, const double dx) noexcept {
+  typename deriv<Tag>::type result{};
   for (auto it = result.begin(); it != result.end(); ++it) {
     const auto index = result.get_tensor_index(it);
     *it = numerical_derivative(

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
@@ -134,6 +134,7 @@ struct component {
 };
 
 struct Metavariables {
+  static constexpr size_t volume_dim = 2;
   using system = System;
   using component_list = tmpl::list<component<Metavariables>>;
   enum class Phase { Initialization, Testing, Exit };

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateEvent.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateEvent.cpp
@@ -45,11 +45,9 @@ namespace db {
 template <typename TagsList>
 class DataBox;
 }  // namespace db
-namespace intrp {
-namespace Actions {
+namespace intrp::Actions {
 struct InterpolatorReceiveVolumeData;
-}  // namespace Actions
-}  // namespace intrp
+}  // namespace intrp::Actions
 /// \endcond
 
 namespace {
@@ -75,9 +73,7 @@ struct MockInterpolatorReceiveVolumeData {
   static void apply(
       db::DataBox<DbTags>& /*box*/,
       Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
-      const ArrayIndex& /*array_index*/,
-      const db::const_item_type<typename Metavariables::temporal_id>&
-          temporal_id,
+      const ArrayIndex& /*array_index*/, const ::TimeStepId& temporal_id,
       const ElementId<VolumeDim>& element_id, const ::Mesh<VolumeDim>& mesh,
       Variables<typename Metavariables::interpolator_source_vars>&&
           vars) noexcept {

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeInterfaces.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeInterfaces.cpp
@@ -49,7 +49,7 @@ struct OtherDataTag : db::SimpleTag {
 template <typename VarsTag>
 struct SomeComputeTag : db::ComputeTag {
   static std::string name() noexcept { return "SomeComputeTag"; }
-  static size_t function(const db::const_item_type<VarsTag>& vars) {
+  static size_t function(const typename VarsTag::type& vars) {
     return vars.number_of_grid_points();
   }
   using argument_tags = tmpl::list<VarsTag>;

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
@@ -140,6 +140,7 @@ struct Component {
 };
 
 struct Metavariables {
+  static constexpr size_t volume_dim = 1;
   using system = ScalarWave::System<1>;
   using component_list = tmpl::list<Component<Metavariables>>;
   using temporal_id = Tags::TimeStepId;
@@ -217,10 +218,10 @@ std::pair<tnsr::I<DataVector, 1>, EvolvedVariables> evaluate_rhs(
             make_not_null(&runner), id);
         db::mutate<system::variables_tag>(
             make_not_null(&box),
-            [&solution, &time](
-                const gsl::not_null<EvolvedVariables*> vars,
-                const db::const_item_type<domain::Tags::Coordinates<
-                    1, Frame::Inertial>>& coords) noexcept {
+            [
+              &solution, &time
+            ](const gsl::not_null<EvolvedVariables*> vars,
+              const tnsr::I<DataVector, 1, Frame::Inertial>& coords) noexcept {
               vars->assign_subset(solution.variables(
                   coords, time, system::variables_tag::tags_list{}));
             },
@@ -252,7 +253,7 @@ std::pair<tnsr::I<DataVector, 1>, EvolvedVariables> evaluate_rhs(
       ActionTesting::get_databox_tag<
           component, domain::Tags::Coordinates<1, Frame::Inertial>>(runner,
                                                                     self_id),
-      db::const_item_type<system::variables_tag>(
+      EvolvedVariables(
           ActionTesting::get_databox_tag<
               component, db::add_tag_prefix<Tags::dt, system::variables_tag>>(
               runner, self_id))};

--- a/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
+++ b/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
@@ -114,7 +114,7 @@ struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
   using ordered_list_of_primitive_recovery_schemes = tmpl::list<>;
   using temporal_id = TemporalId;
-
+  using time_stepper_tag = Tags::TimeStepper<TimeStepper>;
   enum class Phase { Initialization, Testing, Exit };
 };
 
@@ -218,7 +218,7 @@ template <typename Stop, typename Whitelist, bool HasPrimitives>
 bool run_past(
     const gsl::not_null<MockRuntimeSystem<HasPrimitives>*> runner) noexcept {
   for (;;) {
-    bool done;
+    bool done = false;
     const size_t current_action = ActionTesting::get_next_action_index<
         Component<Metavariables<HasPrimitives>>>(*runner, 0);
     size_t action_to_check = current_action;

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -93,6 +93,7 @@ struct ComponentWithTemplateSpecifiedVariables {
 
 struct Metavariables {
   using system = System;
+  using time_stepper_tag = Tags::TimeStepper<TimeStepper>;
   using component_list =
       tmpl::list<Component<Metavariables>,
                  ComponentWithTemplateSpecifiedVariables<Metavariables>>;
@@ -162,7 +163,8 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.UpdateU", "[Unit][Time][Actions]") {
 
     runner.next_action<component>(0);
     runner.next_action<component_with_template_specified_variables>(0);
-    auto& box = ActionTesting::get_databox<component, simple_tags>(runner, 0);
+    const auto& box =
+        ActionTesting::get_databox<component, simple_tags>(runner, 0);
     auto& alternative_box = ActionTesting::get_databox<
         component_with_template_specified_variables,
         typename component_with_template_specified_variables::simple_tags>(

--- a/tests/Unit/Time/StepChoosers/Test_Cfl.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_Cfl.cpp
@@ -46,6 +46,7 @@ struct CharacteristicSpeed : db::SimpleTag {
 struct Metavariables {
   using component_list = tmpl::list<>;
   using const_global_cache_tags = tmpl::list<>;
+  using time_stepper_tag = Tags::TimeStepper<TimeStepper>;
   struct system {
     struct compute_largest_characteristic_speed {
       using argument_tags = tmpl::list<CharacteristicSpeed>;

--- a/tests/Unit/Time/Test_Tags.cpp
+++ b/tests/Unit/Time/Test_Tags.cpp
@@ -28,7 +28,7 @@ SPECTRE_TEST_CASE("Unit.Time.Tags", "[Unit][Time]") {
   TestHelpers::db::test_simple_tag<Tags::TimeStep>("TimeStep");
   TestHelpers::db::test_simple_tag<Tags::SubstepTime>("SubstepTime");
   TestHelpers::db::test_simple_tag<Tags::Time>("Time");
-  TestHelpers::db::test_simple_tag<Tags::HistoryEvolvedVariables<DummyType>>(
+  TestHelpers::db::test_simple_tag<Tags::HistoryEvolvedVariables<DummyTag>>(
       "HistoryEvolvedVariables");
   TestHelpers::db::test_simple_tag<
       Tags::BoundaryHistory<DummyType, DummyType, DummyType>>(


### PR DESCRIPTION
## Proposed changes

This is part of the clean up and simplification of DataBox.  
`const_item_type` should only be used when absolutely necessary; my goal is to eliminate it or use it only in a detail namespace.

In some cases replace with the explicit type.
In most cases replace with typename T::type.
If T was a unique_ptr, replace with typename T::type::element_type

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
