### PR TITLE
Read correct deriv from spec piecewise polynomial

### DIFF
--- a/src/IO/Importers/ReadSpecThirdOrderPiecewisePolynomial.hpp
+++ b/src/IO/Importers/ReadSpecThirdOrderPiecewisePolynomial.hpp
@@ -146,7 +146,7 @@ struct ReadSpecThirdOrderPiecewisePolynomial {
           time_last_updated = dat_data(row, 1);
           for (size_t a = 0; a < number_of_components; ++a) {
             highest_derivative[a] =
-                dat_data(row, 4 + (max_deriv + 1) * a + max_deriv);
+                dat_data(row, 5 + (max_deriv + 1) * a + max_deriv);
           }
           spec_functions_of_time[spectre_name].update(time_last_updated,
                                                       highest_derivative);


### PR DESCRIPTION
## Proposed changes

The importer that reads spec third order piecewise polynomials reads the wrong column for the third derivative: it reads the second derivative instead of the third derivative from the spec history file. 

The test didn't catch this because it only checked reading functions of time with data for two times, and you need at least 3 to catch this.

This update fixes the importer to read the correct column from the spec history file and also fixes the test so that it catches this.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
