### PR TITLE
Add smoothstep function

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.cpp
@@ -15,8 +15,7 @@
 #include "Utilities/Math.hpp"
 // IWYU pragma: no_forward_declare Tensor
 
-namespace Poisson {
-namespace Solutions {
+namespace Poisson::Solutions {
 
 /// \cond
 template <size_t Dim>
@@ -44,7 +43,8 @@ Moustache<1>::variables(
                              Frame::Inertial>> /*meta*/) const noexcept {
   const auto& x_d = get<0>(x);
   tnsr::i<DataVector, 1> field_gradient{
-      abs(x_d - 0.5) * evaluate_polynomial<double>({0.25, -3., 7.5, -5.}, x_d)};
+      abs(x_d - 0.5) *
+      evaluate_polynomial(std::array<double, 4>{{0.25, -3., 7.5, -5.}}, x_d)};
   return {std::move(field_gradient)};
 }
 
@@ -62,9 +62,10 @@ Moustache<2>::variables(
     const auto& x_p = x.get((d + 1) % 2);
     field_gradient.get(d) =
         sqrt(norm_square) * x_p * (1. - x_p) *
-        (evaluate_polynomial<double>({0.25, -3.5, 7.5, -5.}, x_d) +
-         evaluate_polynomial<double>({0.25, -1., 1.}, x_p) + 2. * x_d * x_p -
-         2. * x_d * square(x_p));
+        (evaluate_polynomial(std::array<double, 4>{{0.25, -3.5, 7.5, -5.}},
+                             x_d) +
+         evaluate_polynomial(std::array<double, 3>{{0.25, -1., 1.}}, x_p) +
+         2. * x_d * x_p - 2. * x_d * square(x_p));
   }
   return {std::move(field_gradient)};
 }
@@ -101,8 +102,7 @@ tuples::TaggedTuple<::Tags::FixedSource<Tags::Field>> Moustache<2>::variables(
 template <size_t Dim>
 void Moustache<Dim>::pup(PUP::er& /*p*/) noexcept {}
 
-}  // namespace Solutions
-}  // namespace Poisson
+}  // namespace Poisson::Solutions
 
 template class Poisson::Solutions::Moustache<1>;
 template class Poisson::Solutions::Moustache<2>;

--- a/src/Utilities/Math.hpp
+++ b/src/Utilities/Math.hpp
@@ -41,19 +41,23 @@ SPECTRE_ALWAYS_INLINE T number_of_digits(const T number) {
  * largest power
  * \param x The polynomial variable \f$x\f$
  *
- * \tparam U The type of the polynomial coefficients \p coeffs. Can be `double`,
- * which means the coefficients are constant for all values in \p x. Can also be
- * a vector type of typically the same size as `T`, which means the coefficients
- * vary with the elements in \p x.
- * \tparam T The type of the polynomial variable \p x. Must support
- * `make_with_value<T, T>`, as well as (elementwise) addition with `U` and
- * multiplication with `T`.
+ * \tparam CoeffsIterable The type of the polynomial coefficients \p coeffs. Can
+ * be a `std::vector<double>` or `std::array<double>`, which means the
+ * coefficients are constant for all values in \p x. Each coefficient can also
+ * be a vector type of typically the same size as \p x, which means the
+ * coefficients vary with the elements in \p x.
+ * \tparam DataType The type of the polynomial variable \p x. Must support
+ * `make_with_value<DataType, DataType>`, as well as (elementwise) addition with
+ * `CoeffsIterable::value_type` and multiplication with `DataType`.
  */
-template <typename U, typename T>
-T evaluate_polynomial(const std::vector<U>& coeffs, const T& x) noexcept {
+template <typename CoeffsIterable, typename DataType>
+DataType evaluate_polynomial(const CoeffsIterable& coeffs,
+                             const DataType& x) noexcept {
   return std::accumulate(
-      coeffs.rbegin(), coeffs.rend(), make_with_value<T>(x, 0.),
-      [&x](const T& state, const U& element) { return state * x + element; });
+      coeffs.rbegin(), coeffs.rend(), make_with_value<DataType>(x, 0.),
+      [&x](const DataType& state, const auto& element) noexcept {
+        return state * x + element;
+      });
 }
 
 /// \ingroup UtilitiesGroup

--- a/tests/Unit/Utilities/Test_Math.cpp
+++ b/tests/Unit/Utilities/Test_Math.cpp
@@ -10,6 +10,22 @@
 #include "Utilities/Math.hpp"
 #include "Utilities/TypeTraits.hpp"
 
+namespace {
+template <size_t N>
+void test_smoothstep() {
+  CAPTURE(N);
+  CHECK(smoothstep<N>(0., 1., 0.) == approx(0.));
+  CHECK(smoothstep<N>(0., 1., 0.5) == approx(0.5));
+  CHECK(smoothstep<N>(0., 1., 1.) == approx(1.));
+  CHECK_ITERABLE_APPROX(
+      smoothstep<N>(0., 1., DataVector({-1., 0., 0.5, 1., 2.})),
+      DataVector({0., 0., 0.5, 1., 1.}));
+  CHECK_ITERABLE_APPROX(
+      smoothstep<N>(-1., 1., DataVector({-2., -1., 0., 1., 2.})),
+      DataVector({0., 0., 0.5, 1., 1.}));
+}
+}  // namespace
+
 SPECTRE_TEST_CASE("Unit.Utilities.Math", "[Unit][Utilities]") {
   {
     INFO("Test number_of_digits");
@@ -36,6 +52,14 @@ SPECTRE_TEST_CASE("Unit.Utilities.Math", "[Unit][Utilities]") {
     CHECK_ITERABLE_APPROX(
         evaluate_polynomial(poly_variable_coeffs, DataVector({0., 0.5, 1.})),
         DataVector({1., 1., 3.}));
+  }
+
+  {
+    INFO("Test smoothstep");
+    test_smoothstep<0>();
+    test_smoothstep<1>();
+    test_smoothstep<2>();
+    test_smoothstep<3>();
   }
 
   {

--- a/tests/Unit/Utilities/Test_Math.cpp
+++ b/tests/Unit/Utilities/Test_Math.cpp
@@ -25,6 +25,9 @@ SPECTRE_TEST_CASE("Unit.Utilities.Math", "[Unit][Utilities]") {
     const std::vector<double> poly_coeffs{1., 2.5, 0.3, 1.5};
     CHECK_ITERABLE_APPROX(evaluate_polynomial(poly_coeffs, 0.5), 2.5125);
     CHECK_ITERABLE_APPROX(
+        evaluate_polynomial(std::array<double, 4>{1., 2.5, 0.3, 1.5}, 0.5),
+        2.5125);
+    CHECK_ITERABLE_APPROX(
         evaluate_polynomial(poly_coeffs,
                             DataVector({-0.5, -0.1, 0., 0.8, 1., 12.})),
         DataVector({-0.3625, 0.7515, 1., 3.96, 5.3, 2666.2}));


### PR DESCRIPTION
## Proposed changes

Add `smoothstep` to `Utilities/Math.hpp`. I'll need it to define a weighting function for the Schwarz subdomain solver and thought it might be useful for others to have in `Utilities`.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
