### PR TITLE
Add Pybinding for `h5::offset_and_length_for_grid`

### DIFF
--- a/src/IO/H5/Python/VolumeData.cpp
+++ b/src/IO/H5/Python/VolumeData.cpp
@@ -28,5 +28,8 @@ void bind_h5vol(py::module& m) {  // NOLINT
            py::arg("observation_id"), py::arg("tensor_component"))
       .def("get_extents", &h5::VolumeData::get_extents,
            py::arg("observation_id"));
+  m.def("offset_and_length_for_grid", &h5::offset_and_length_for_grid,
+        py::arg("grid_name"), py::arg("all_grid_names"),
+        py::arg("all_extents"));
 }
 }  // namespace py_bindings

--- a/tests/Unit/IO/Test_VolumeData.py
+++ b/tests/Unit/IO/Test_VolumeData.py
@@ -151,6 +151,21 @@ class TestIOH5VolumeData(unittest.TestCase):
                                       expected_zcoord_tensor_data)
         h5_file.close()
 
+    def test_offset_and_length_for_grid(self):
+        h5_file = spectre_h5.H5File(file_name=self.file_name_r,
+                                    append_to_file=True)
+        vol_file = h5_file.get_vol(path="/element_data")
+        obs_id = vol_file.list_observation_ids()[0]
+        all_grid_names = vol_file.get_grid_names(observation_id=obs_id)
+        all_extents = vol_file.get_extents(observation_id=obs_id)
+        h5_file.close()
+
+        self.assertEqual(
+            spectre_h5.offset_and_length_for_grid(
+                grid_name='[B0,(L0I0,L0I0,L0I0)]',
+                all_grid_names=all_grid_names,
+                all_extents=all_extents), (0, 8))
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes

Adds a missing pybinding to work with H5 volume data

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
