### PR TITLE
Modernize CMakeLists 5

### DIFF
--- a/src/Parallel/Actions/CMakeLists.txt
+++ b/src/Parallel/Actions/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  Parallel
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Goto.hpp
+  TerminatePhase.hpp
+  )

--- a/src/Parallel/CMakeLists.txt
+++ b/src/Parallel/CMakeLists.txt
@@ -8,6 +8,37 @@ set(LIBRARY Parallel)
 
 add_spectre_library(${LIBRARY} INTERFACE)
 
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Abort.hpp
+  Algorithm.hpp
+  AlgorithmMetafunctions.hpp
+  ArrayIndex.hpp
+  CharmMain.tpp
+  CharmPupable.hpp
+  CharmRegistration.hpp
+  ConstGlobalCache.hpp
+  CreateFromOptions.hpp
+  Exit.hpp
+  InboxInserters.hpp
+  Info.hpp
+  InitializationFunctions.hpp
+  Invoke.hpp
+  Main.hpp
+  NodeLock.hpp
+  ParallelComponentHelpers.hpp
+  PhaseDependentActionList.hpp
+  Printf.hpp
+  PupStlCpp11.hpp
+  Reduction.hpp
+  RegisterDerivedClassesWithCharm.hpp
+  Serialize.hpp
+  SimpleActionVisitation.hpp
+  TypeTraits.hpp
+  )
+
 target_link_libraries(
   ${LIBRARY}
   INTERFACE
@@ -18,3 +49,5 @@ target_link_libraries(
   Options
   Utilities
   )
+
+add_subdirectory(Actions)

--- a/src/ParallelAlgorithms/Actions/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Actions/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY Actions)
+
+add_spectre_library(${LIBRARY} INTERFACE)
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  MutateApply.hpp
+  SetData.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE
+  DataStructures
+  Domain
+  ErrorHandling
+  Utilities
+  )

--- a/src/ParallelAlgorithms/CMakeLists.txt
+++ b/src/ParallelAlgorithms/CMakeLists.txt
@@ -1,4 +1,9 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+add_subdirectory(Actions)
+add_subdirectory(DiscontinuousGalerkin)
+add_subdirectory(Events)
+add_subdirectory(EventsAndTriggers)
+add_subdirectory(Initialization)
 add_subdirectory(LinearSolver)

--- a/src/ParallelAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
+++ b/src/ParallelAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY ParallelDg)
+
+add_spectre_library(${LIBRARY} INTERFACE)
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  CollectDataForFluxes.hpp
+  FluxCommunication.hpp
+  HasReceivedFromAllMortars.hpp
+  InitializeDomain.hpp
+  InitializeInterfaces.hpp
+  InitializeMortars.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE
+  DataStructures
+  Domain
+  ErrorHandling
+  Utilities
+  )

--- a/src/ParallelAlgorithms/Events/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Events/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY Events)
+
+add_spectre_library(${LIBRARY} INTERFACE)
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  ObserveErrorNorms.hpp
+  ObserveFields.hpp
+  ObserveVolumeIntegrals.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE
+  DataStructures
+  Domain
+  ErrorHandling
+  Utilities
+  )

--- a/src/ParallelAlgorithms/EventsAndTriggers/Actions/CMakeLists.txt
+++ b/src/ParallelAlgorithms/EventsAndTriggers/Actions/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  EventsAndTriggers
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  RunEventsAndTriggers.hpp
+  )

--- a/src/ParallelAlgorithms/EventsAndTriggers/CMakeLists.txt
+++ b/src/ParallelAlgorithms/EventsAndTriggers/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY EventsAndTriggers)
+
+add_spectre_library(${LIBRARY} INTERFACE)
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Completion.hpp
+  Event.hpp
+  EventsAndTriggers.hpp
+  LogicalTriggers.hpp
+  Tags.hpp
+  Trigger.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE
+  DataStructures
+  Domain
+  ErrorHandling
+  Utilities
+  )
+
+add_subdirectory(Actions)

--- a/src/ParallelAlgorithms/Initialization/Actions/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Initialization/Actions/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  Initialization
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  AddComputeTags.hpp
+  RemoveOptionsAndTerminatePhase.hpp
+  )

--- a/src/ParallelAlgorithms/Initialization/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Initialization/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY Initialization)
+
+add_spectre_library(${LIBRARY} INTERFACE)
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  MergeIntoDataBox.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE
+  DataStructures
+  Domain
+  ErrorHandling
+  Utilities
+  )
+
+add_subdirectory(Actions)

--- a/src/ParallelAlgorithms/LinearSolver/Actions/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/Actions/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ParallelLinearSolver
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  TerminateIfConverged.hpp
+  )
+

--- a/src/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ParallelLinearSolver
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  ElementActions.hpp
+  )
+

--- a/src/ParallelAlgorithms/LinearSolver/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/CMakeLists.txt
@@ -5,6 +5,14 @@ set(LIBRARY ParallelLinearSolver)
 
 add_spectre_library(${LIBRARY} INTERFACE)
 
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Observe.hpp
+  Tags.hpp
+  )
+
 target_link_libraries(
   ${LIBRARY}
   INTERFACE
@@ -14,3 +22,9 @@ target_link_libraries(
   IO
   Utilities
   )
+
+add_subdirectory(Actions)
+add_subdirectory(AsynchronousSolvers)
+add_subdirectory(ConjugateGradient)
+add_subdirectory(Gmres)
+add_subdirectory(Richardson)

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ParallelLinearSolver
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  ConjugateGradient.hpp
+  ElementActions.hpp
+  InitializeElement.hpp
+  ResidualMonitor.hpp
+  ResidualMonitorActions.hpp
+  )
+

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ParallelLinearSolver
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  ElementActions.hpp
+  Gmres.hpp
+  InitializeElement.hpp
+  ResidualMonitor.hpp
+  ResidualMonitorActions.hpp
+  )
+

--- a/src/ParallelAlgorithms/LinearSolver/Richardson/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/Richardson/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ParallelLinearSolver
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Richardson.hpp
+  Tags.hpp
+  )
+


### PR DESCRIPTION
## Proposed changes

Update more CMakeLists.txt

To verify in particular in code review:
- In `src/Parallel`, there are two `.ci` files (`ConstGlobalCache.ci` and `Main.ci`). If I correctly understand things, there is no need for these (or the resulting generated code) to be part of the library targets because we wrap the generated code in via our `ConstGlobalCache.hpp` and `Main.hpp` headers. Is this correct?
- In `src/ParallelAlgorithms`, I've added a new library `ParallelAlgorithms` to contain everything except the `LinearSolver` headers, which already had their own library. Is this a reasonable choice?


### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
