### PR TITLE
Remove position_of_first

### DIFF
--- a/src/NumericalAlgorithms/Spectral/SwshDerivatives.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshDerivatives.hpp
@@ -111,11 +111,7 @@ void compute_coefficients_of_derivative(
 // `pre_derivative_mode_tuple`, and calls `compute_coefficients_of_derivative`,
 // deriving the coefficients for `DerivativeTag` and returning by pointer.
 template <typename DerivativeTag, typename PreDerivativeTagList>
-struct dispatch_to_compute_coefficients_of_derivative;
-
-template <typename DerivativeTag, typename... PreDerivativeTags>
-struct dispatch_to_compute_coefficients_of_derivative<
-    DerivativeTag, tmpl::list<PreDerivativeTags...>> {
+struct dispatch_to_compute_coefficients_of_derivative {
   template <int Spin, typename... ModalTypes>
   static void apply(const gsl::not_null<SpinWeighted<ComplexModalVector, Spin>*>
                         derivative_modes,
@@ -124,7 +120,7 @@ struct dispatch_to_compute_coefficients_of_derivative<
                     const size_t number_of_radial_points) noexcept {
     compute_coefficients_of_derivative<typename DerivativeTag::derivative_kind>(
         derivative_modes,
-        get<tmpl::index_of<tmpl::list<PreDerivativeTags...>,
+        get<tmpl::index_of<PreDerivativeTagList,
                            typename DerivativeTag::derivative_of>::value>(
             pre_derivative_mode_tuple),
         l_max, number_of_radial_points);
@@ -150,10 +146,9 @@ template <typename Transform, typename TagList>
 struct dispatch_to_transform;
 
 template <ComplexRepresentation Representation, typename... TransformTags,
-          typename... Tags>
+          typename TagList>
 struct dispatch_to_transform<
-    SwshTransform<tmpl::list<TransformTags...>, Representation>,
-    tmpl::list<Tags...>> {
+    SwshTransform<tmpl::list<TransformTags...>, Representation>, TagList> {
   template <typename... ModalTypes, typename... NodalTypes>
   static void apply(const gsl::not_null<std::tuple<ModalTypes...>*> modal_tuple,
                     const std::tuple<NodalTypes...>& nodal_tuple,
@@ -161,19 +156,17 @@ struct dispatch_to_transform<
                     const size_t number_of_radial_points) noexcept {
     SwshTransform<tmpl::list<TransformTags...>, Representation>::
         apply_to_vectors(
-            get<tmpl::index_of<tmpl::list<Tags...>, TransformTags>::value>(
-                *modal_tuple)...,
-            get<tmpl::index_of<tmpl::list<Tags...>, TransformTags>::value>(
-                nodal_tuple)...,
+            get<tmpl::index_of<TagList, TransformTags>::value>(*modal_tuple)...,
+            get<tmpl::index_of<TagList, TransformTags>::value>(nodal_tuple)...,
             l_max, number_of_radial_points);
   }
 };
 
 template <ComplexRepresentation Representation, typename... TransformTags,
-          typename... Tags>
+          typename TagList>
 struct dispatch_to_transform<
     InverseSwshTransform<tmpl::list<TransformTags...>, Representation>,
-    tmpl::list<Tags...>> {
+    TagList> {
   template <typename... NodalTypes, typename... ModalTypes>
   static void apply(const gsl::not_null<std::tuple<NodalTypes...>*> nodal_tuple,
                     const std::tuple<ModalTypes...>& modal_tuple,
@@ -181,10 +174,8 @@ struct dispatch_to_transform<
                     const size_t number_of_radial_points) noexcept {
     InverseSwshTransform<tmpl::list<TransformTags...>, Representation>::
         apply_to_vectors(
-            get<tmpl::index_of<tmpl::list<Tags...>, TransformTags>::value>(
-                *nodal_tuple)...,
-            *get<tmpl::index_of<tmpl::list<Tags...>, TransformTags>::value>(
-                modal_tuple)...,
+            get<tmpl::index_of<TagList, TransformTags>::value>(*nodal_tuple)...,
+            *get<tmpl::index_of<TagList, TransformTags>::value>(modal_tuple)...,
             l_max, number_of_radial_points);
   }
 };

--- a/src/NumericalAlgorithms/Spectral/SwshDerivatives.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshDerivatives.hpp
@@ -124,8 +124,8 @@ struct dispatch_to_compute_coefficients_of_derivative<
                     const size_t number_of_radial_points) noexcept {
     compute_coefficients_of_derivative<typename DerivativeTag::derivative_kind>(
         derivative_modes,
-        get<tmpl::position_of_first_v<tmpl::list<PreDerivativeTags...>,
-                                      typename DerivativeTag::derivative_of>>(
+        get<tmpl::index_of<tmpl::list<PreDerivativeTags...>,
+                           typename DerivativeTag::derivative_of>::value>(
             pre_derivative_mode_tuple),
         l_max, number_of_radial_points);
   }
@@ -161,9 +161,9 @@ struct dispatch_to_transform<
                     const size_t number_of_radial_points) noexcept {
     SwshTransform<tmpl::list<TransformTags...>, Representation>::
         apply_to_vectors(
-            get<tmpl::position_of_first_v<tmpl::list<Tags...>, TransformTags>>(
+            get<tmpl::index_of<tmpl::list<Tags...>, TransformTags>::value>(
                 *modal_tuple)...,
-            get<tmpl::position_of_first_v<tmpl::list<Tags...>, TransformTags>>(
+            get<tmpl::index_of<tmpl::list<Tags...>, TransformTags>::value>(
                 nodal_tuple)...,
             l_max, number_of_radial_points);
   }
@@ -181,9 +181,9 @@ struct dispatch_to_transform<
                     const size_t number_of_radial_points) noexcept {
     InverseSwshTransform<tmpl::list<TransformTags...>, Representation>::
         apply_to_vectors(
-            get<tmpl::position_of_first_v<tmpl::list<Tags...>, TransformTags>>(
+            get<tmpl::index_of<tmpl::list<Tags...>, TransformTags>::value>(
                 *nodal_tuple)...,
-            *get<tmpl::position_of_first_v<tmpl::list<Tags...>, TransformTags>>(
+            *get<tmpl::index_of<tmpl::list<Tags...>, TransformTags>::value>(
                 modal_tuple)...,
             l_max, number_of_radial_points);
   }

--- a/src/Utilities/TMPL.hpp
+++ b/src/Utilities/TMPL.hpp
@@ -585,19 +585,4 @@ constexpr const bool list_contains_v = list_contains<Sequence, Item>::value;
 template <typename Sequence1, typename Sequence2>
 using list_difference =
     fold<Sequence2, Sequence1, lazy::remove<_state, _element>>;
-
-// @{
-/// The index in `Sequence` of the first item with type `Element`. If `Element`
-/// is not in `Sequence`, takes the value of the size of `Sequence`
-template <typename Sequence, typename Element>
-using position_of_first = tmpl::integral_constant<
-    std::size_t,
-    tmpl::size<Sequence>::value -
-        tmpl::size<
-            find<Sequence, std::is_same<_1, tmpl::pin<Element>>>>::value>;
-
-template <typename Sequence, typename Element>
-constexpr std::size_t position_of_first_v =
-    position_of_first<Sequence, Element>::value;
-// @}
 }  // namespace brigand

--- a/tests/Unit/Utilities/Test_TMPL.cpp
+++ b/tests/Unit/Utilities/Test_TMPL.cpp
@@ -69,18 +69,6 @@ static_assert(
         tmpl::list<>>,
     "Failed testing list_difference");
 
-static_assert(tmpl::position_of_first_v<
-                  tmpl::list<char, int, double, char, float>, char> == 0,
-              "Failed testing `tmpl::position_of_first`");
-
-static_assert(tmpl::position_of_first_v<
-                  tmpl::list<char, int, double, char, float>, double> == 2,
-              "Failed testing `tmpl::position_of_first`");
-
-static_assert(tmpl::position_of_first_v<
-                  tmpl::list<char, int, double, char, float>, size_t> == 5,
-              "Failed testing `tmpl::position_of_first`");
-
 SPECTRE_TEST_CASE("Unit.Utilities.get_first_argument", "[Unit][Utilities]") {
   const long a0 = 5;
   const long a1 = 6;


### PR DESCRIPTION
It's basically the same as index_of.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
