### PR TITLE
Add overlap helpers for Schwarz solver, fix some slice-related things

### DIFF
--- a/src/DataStructures/SliceIterator.cpp
+++ b/src/DataStructures/SliceIterator.cpp
@@ -43,11 +43,13 @@ void SliceIterator::reset() {
 }
 
 template <size_t VolumeDim>
+// NOLINTNEXTLINE(modernize-avoid-c-arrays)
 std::pair<std::unique_ptr<std::pair<size_t, size_t>[], decltype(&free)>,
           std::array<std::pair<gsl::span<std::pair<size_t, size_t>>,
                                gsl::span<std::pair<size_t, size_t>>>,
                      VolumeDim>>
 volume_and_slice_indices(const Index<VolumeDim>& extents) noexcept {
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays)
   std::unique_ptr<std::pair<size_t, size_t>[], decltype(&free)> indices_buffer(
       nullptr, &free);
   // array over dim, pair over lower/upper, span<pair> over volume/boundary
@@ -66,7 +68,7 @@ volume_and_slice_indices(const Index<VolumeDim>& extents) noexcept {
          "'volume_and_slice_indices' function. Please file an issue describing "
          "the necessary steps to reproduce this error. Thank you!");
   // clang-tidy thinks we make size zero allocations. The ASSERT prevents that.
-  // NOLINTNEXTLINE(clang-analyzer-unix.API)
+  // NOLINTNEXTLINE(clang-analyzer-unix.API, cppcoreguidelines-owning-memory)
   indices_buffer.reset(static_cast<std::pair<size_t, size_t>*>(malloc(
       sizeof(std::pair<size_t, size_t>) * half_number_boundary_points * 2)));
   size_t alloc_offset = 0;

--- a/src/DataStructures/SliceIterator.cpp
+++ b/src/DataStructures/SliceIterator.cpp
@@ -39,6 +39,7 @@ SliceIterator& SliceIterator::operator++() {
 void SliceIterator::reset() {
   volume_offset_ = initial_offset_;
   slice_offset_ = 0;
+  stride_count_ = 0;
 }
 
 template <size_t VolumeDim>

--- a/src/DataStructures/SliceIterator.cpp
+++ b/src/DataStructures/SliceIterator.cpp
@@ -116,5 +116,5 @@ volume_and_slice_indices(const Index<VolumeDim>& extents) noexcept {
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef DIM
-#undef INSTANTIATE
+#undef INSTANTIATION
 /// \endcond

--- a/src/DataStructures/SliceVariables.hpp
+++ b/src/DataStructures/SliceVariables.hpp
@@ -78,13 +78,21 @@ Variables<TagsList> data_on_slice(const Variables<TagsList>& vars,
  *
  * \see data_on_slice
  */
-template <std::size_t VolumeDim, typename TagsList>
-void add_slice_to_data(const gsl::not_null<Variables<TagsList>*> volume_vars,
-                       const Variables<TagsList>& vars_on_slice,
-                       const Index<VolumeDim>& extents, const size_t sliced_dim,
-                       const size_t fixed_index) noexcept {
+template <std::size_t VolumeDim, typename... VolumeTags, typename... SliceTags>
+void add_slice_to_data(
+    const gsl::not_null<Variables<tmpl::list<VolumeTags...>>*> volume_vars,
+    const Variables<tmpl::list<SliceTags...>>& vars_on_slice,
+    const Index<VolumeDim>& extents, const size_t sliced_dim,
+    const size_t fixed_index) noexcept {
+  static_assert((std::is_same_v<db::remove_all_prefixes<VolumeTags>,
+                                db::remove_all_prefixes<SliceTags>> and
+                 ...));
+  static_assert(
+      (std::is_same_v<typename VolumeTags::type, typename SliceTags::type> and
+       ...),
+      "Tensor types do not match.");
   constexpr const size_t number_of_independent_components =
-      Variables<TagsList>::number_of_independent_components;
+      Variables<tmpl::list<VolumeTags...>>::number_of_independent_components;
   const size_t volume_grid_points = extents.product();
   const size_t slice_grid_points = extents.slice_away(sliced_dim).product();
   ASSERT(volume_vars->number_of_grid_points() == volume_grid_points,
@@ -95,7 +103,7 @@ void add_slice_to_data(const gsl::not_null<Variables<TagsList>*> volume_vars,
          "vars_on_slice has wrong number of grid points.  Expected "
              << slice_grid_points << ", got "
              << vars_on_slice.number_of_grid_points());
-  using value_type = typename Variables<TagsList>::value_type;
+  using value_type = typename Variables<tmpl::list<VolumeTags...>>::value_type;
   value_type* const volume_data = volume_vars->data();
   const value_type* const slice_data = vars_on_slice.data();
   for (SliceIterator si(extents, sliced_dim, fixed_index); si; ++si) {

--- a/src/Domain/Structure/IndexToSliceAt.hpp
+++ b/src/Domain/Structure/IndexToSliceAt.hpp
@@ -10,10 +10,15 @@
 #include "Domain/Structure/Side.hpp"
 
 /// \ingroup ComputationalDomainGroup
-/// Finds the index in the perpendicular dimension of an element boundary
+/// \brief Finds the index in the perpendicular dimension of an element boundary
+///
+/// Optionally provide an `offset` to find an index offset from the element
+/// boundary.
 template <size_t Dim>
 size_t index_to_slice_at(const Index<Dim>& extents,
-                         const Direction<Dim>& direction) noexcept {
-  return direction.side() == Side::Lower ? 0
-                                         : extents[direction.dimension()] - 1;
+                         const Direction<Dim>& direction,
+                         const size_t offset = 0) noexcept {
+  return direction.side() == Side::Lower
+             ? offset
+             : extents[direction.dimension()] - 1 - offset;
 }

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/OverlapHelpers.cpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/OverlapHelpers.cpp
@@ -5,9 +5,13 @@
 
 #include <cmath>
 #include <cstddef>
+#include <numeric>  // std::accumulate
 #include <string>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Side.hpp"
 #include "ErrorHandling/Assert.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
@@ -61,10 +65,119 @@ double overlap_width(const size_t overlap_extent,
   return collocation_points[overlap_extent] - collocation_points[0];
 }
 
+template <size_t Dim>
+OverlapIterator::OverlapIterator(const Index<Dim>& volume_extents,
+                                 const size_t overlap_extent,
+                                 const Direction<Dim>& direction) noexcept
+    : size_{overlap_num_points(volume_extents, overlap_extent,
+                               direction.dimension())},
+      num_slices_{overlap_extent},
+      stride_{std::accumulate(volume_extents.begin(),
+                              volume_extents.begin() + direction.dimension(),
+                              1_st, std::multiplies<size_t>())},
+      stride_count_{0},
+      jump_{(volume_extents[direction.dimension()] - num_slices_) * stride_},
+      initial_offset_{stride_ * (direction.side() == Side::Lower
+                                     ? 0
+                                     : (volume_extents[direction.dimension()] -
+                                        num_slices_))},
+      volume_offset_{initial_offset_},
+      overlap_offset_{0} {
+  assert_overlap_extent(volume_extents, overlap_extent, direction.dimension());
+}
+
+OverlapIterator::operator bool() const noexcept {
+  return overlap_offset_ < size_;
+}
+
+OverlapIterator& OverlapIterator::operator++() {
+  ++volume_offset_;
+  ++overlap_offset_;
+  ++stride_count_;
+  if (stride_count_ == stride_ * num_slices_) {
+    volume_offset_ += jump_;
+    stride_count_ = 0;
+  }
+  return *this;
+}
+
+size_t OverlapIterator::volume_offset() const noexcept {
+  return volume_offset_;
+}
+
+size_t OverlapIterator::overlap_offset() const noexcept {
+  return overlap_offset_;
+}
+
+void OverlapIterator::reset() noexcept {
+  volume_offset_ = initial_offset_;
+  overlap_offset_ = 0;
+  stride_count_ = 0;
+}
+
+namespace detail {
+
+template <size_t Dim>
+void data_on_overlap_impl(double* overlap_data, const double* volume_data,
+                          const size_t num_components,
+                          const Index<Dim>& volume_extents,
+                          const size_t overlap_extent,
+                          const Direction<Dim>& direction) noexcept {
+  const size_t volume_num_points = volume_extents.product();
+  const size_t overlap_num_points = LinearSolver::Schwarz::overlap_num_points(
+      volume_extents, overlap_extent, direction.dimension());
+  for (OverlapIterator overlap_iterator{volume_extents, overlap_extent,
+                                        direction};
+       overlap_iterator; ++overlap_iterator) {
+    for (size_t j = 0; j < num_components; ++j) {
+      const size_t volume_data_index =
+          overlap_iterator.volume_offset() + j * volume_num_points;
+      const size_t overlap_data_index =
+          overlap_iterator.overlap_offset() + j * overlap_num_points;
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      overlap_data[overlap_data_index] = volume_data[volume_data_index];
+    }
+  }
+}
+
+template <size_t Dim>
+void add_overlap_data_impl(double* volume_data, const double* overlap_data,
+                           const size_t num_components,
+                           const Index<Dim>& volume_extents,
+                           const size_t overlap_extent,
+                           const Direction<Dim>& direction) noexcept {
+  const size_t volume_num_points = volume_extents.product();
+  const size_t overlap_num_points = LinearSolver::Schwarz::overlap_num_points(
+      volume_extents, overlap_extent, direction.dimension());
+  for (OverlapIterator overlap_iterator{volume_extents, overlap_extent,
+                                        direction};
+       overlap_iterator; ++overlap_iterator) {
+    for (size_t j = 0; j < num_components; ++j) {
+      const size_t volume_data_index =
+          overlap_iterator.volume_offset() + j * volume_num_points;
+      const size_t overlap_data_index =
+          overlap_iterator.overlap_offset() + j * overlap_num_points;
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      volume_data[volume_data_index] += overlap_data[overlap_data_index];
+    }
+  }
+}
+
+}  // namespace detail
+
 /// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
-#define INSTANTIATE(r, data) \
-  template size_t overlap_num_points(const Index<DIM(data)>&, size_t, size_t);
+#define INSTANTIATE(r, data)                                                  \
+  template size_t overlap_num_points(const Index<DIM(data)>&, size_t,         \
+                                     size_t) noexcept;                        \
+  template OverlapIterator::OverlapIterator(                                  \
+      const Index<DIM(data)>&, size_t, const Direction<DIM(data)>&) noexcept; \
+  template void detail::add_overlap_data_impl(                                \
+      double*, const double*, size_t, const Index<DIM(data)>&, size_t,        \
+      const Direction<DIM(data)>&) noexcept;                                  \
+  template void detail::data_on_overlap_impl(                                 \
+      double*, const double*, size_t, const Index<DIM(data)>&, size_t,        \
+      const Direction<DIM(data)>&) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/OverlapHelpers.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/OverlapHelpers.hpp
@@ -4,14 +4,20 @@
 #pragma once
 
 #include <boost/functional/hash.hpp>
+#include <cstddef>
+#include <limits>
 #include <tuple>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/FixedHashMap.hpp"
 #include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/MaxNumberOfNeighbors.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Utilities/ContainerHelpers.hpp"
 
 namespace LinearSolver::Schwarz {
 
@@ -89,5 +95,180 @@ size_t overlap_num_points(const Index<Dim>& volume_extents,
  */
 double overlap_width(size_t overlap_extent,
                      const DataVector& collocation_points) noexcept;
+
+/*!
+ * \brief Iterate over grid points in a region that extends partially into the
+ * volume
+ *
+ * Here's an example how to use this iterator:
+ *
+ * \snippet Test_OverlapHelpers.cpp overlap_iterator
+ */
+class OverlapIterator {
+ public:
+  template <size_t Dim>
+  OverlapIterator(const Index<Dim>& volume_extents, size_t overlap_extent,
+                  const Direction<Dim>& direction) noexcept;
+
+  explicit operator bool() const noexcept;
+
+  OverlapIterator& operator++();
+
+  /// Offset into a DataVector that holds full volume data
+  size_t volume_offset() const noexcept;
+
+  /// Offset into a DataVector that holds data only on the overlap region
+  size_t overlap_offset() const noexcept;
+
+  void reset() noexcept;
+
+ private:
+  size_t size_ = std::numeric_limits<size_t>::max();
+  size_t num_slices_ = std::numeric_limits<size_t>::max();
+  size_t stride_ = std::numeric_limits<size_t>::max();
+  size_t stride_count_ = std::numeric_limits<size_t>::max();
+  size_t jump_ = std::numeric_limits<size_t>::max();
+  size_t initial_offset_ = std::numeric_limits<size_t>::max();
+  size_t volume_offset_ = std::numeric_limits<size_t>::max();
+  size_t overlap_offset_ = std::numeric_limits<size_t>::max();
+};
+
+// @{
+/// The part of the tensor data that lies within the overlap region
+template <size_t Dim, typename DataType, typename... TensorStructure>
+void data_on_overlap(const gsl::not_null<Tensor<DataType, TensorStructure...>*>
+                         restricted_tensor,
+                     const Tensor<DataType, TensorStructure...>& tensor,
+                     const Index<Dim>& volume_extents,
+                     const size_t overlap_extent,
+                     const Direction<Dim>& direction) noexcept {
+  for (OverlapIterator overlap_iterator{volume_extents, overlap_extent,
+                                        direction};
+       overlap_iterator; ++overlap_iterator) {
+    for (size_t tensor_component = 0; tensor_component < tensor.size();
+         ++tensor_component) {
+      (*restricted_tensor)[tensor_component][overlap_iterator
+                                                 .overlap_offset()] =
+          tensor[tensor_component][overlap_iterator.volume_offset()];
+    }
+  }
+}
+
+template <size_t Dim, typename DataType, typename... TensorStructure>
+Tensor<DataType, TensorStructure...> data_on_overlap(
+    const Tensor<DataType, TensorStructure...>& tensor,
+    const Index<Dim>& volume_extents, const size_t overlap_extent,
+    const Direction<Dim>& direction) noexcept {
+  Tensor<DataType, TensorStructure...> restricted_tensor{overlap_num_points(
+      volume_extents, overlap_extent, direction.dimension())};
+  data_on_overlap(make_not_null(&restricted_tensor), tensor, volume_extents,
+                  overlap_extent, direction);
+  return restricted_tensor;
+}
+
+namespace detail {
+template <size_t Dim>
+void data_on_overlap_impl(double* overlap_data, const double* volume_data,
+                          size_t num_components,
+                          const Index<Dim>& volume_extents,
+                          size_t overlap_extent,
+                          const Direction<Dim>& direction) noexcept;
+}  // namespace detail
+
+template <size_t Dim, typename OverlapTagsList, typename VolumeTagsList>
+void data_on_overlap(
+    const gsl::not_null<Variables<OverlapTagsList>*> overlap_data,
+    const Variables<VolumeTagsList>& volume_data,
+    const Index<Dim>& volume_extents, const size_t overlap_extent,
+    const Direction<Dim>& direction) noexcept {
+  constexpr size_t num_components =
+      Variables<VolumeTagsList>::number_of_independent_components;
+  ASSERT(volume_data.number_of_grid_points() == volume_extents.product(),
+         "volume_data has wrong number of grid points.  Expected "
+             << volume_extents.product() << ", got "
+             << volume_data.number_of_grid_points());
+  ASSERT(overlap_data->number_of_grid_points() ==
+             overlap_num_points(volume_extents, overlap_extent,
+                                direction.dimension()),
+         "overlap_data has wrong number of grid points.  Expected "
+             << overlap_num_points(volume_extents, overlap_extent,
+                                   direction.dimension())
+             << ", got " << overlap_data->number_of_grid_points());
+  detail::data_on_overlap_impl(overlap_data->data(), volume_data.data(),
+                               num_components, volume_extents, overlap_extent,
+                               direction);
+}
+
+template <size_t Dim, typename TagsList>
+Variables<TagsList> data_on_overlap(const Variables<TagsList>& volume_data,
+                                    const Index<Dim>& volume_extents,
+                                    const size_t overlap_extent,
+                                    const Direction<Dim>& direction) noexcept {
+  Variables<TagsList> overlap_data{overlap_num_points(
+      volume_extents, overlap_extent, direction.dimension())};
+  data_on_overlap(make_not_null(&overlap_data), volume_data, volume_extents,
+                  overlap_extent, direction);
+  return overlap_data;
+}
+// @}
+
+namespace detail {
+template <size_t Dim>
+void add_overlap_data_impl(double* volume_data, const double* overlap_data,
+                           size_t num_components,
+                           const Index<Dim>& volume_extents,
+                           size_t overlap_extent,
+                           const Direction<Dim>& direction) noexcept;
+}  // namespace detail
+
+/// Add the `overlap_data` to the `volume_data`
+template <size_t Dim, typename VolumeTagsList, typename OverlapTagsList>
+void add_overlap_data(
+    const gsl::not_null<Variables<VolumeTagsList>*> volume_data,
+    const Variables<OverlapTagsList>& overlap_data,
+    const Index<Dim>& volume_extents, const size_t overlap_extent,
+    const Direction<Dim>& direction) noexcept {
+  constexpr size_t num_components =
+      Variables<VolumeTagsList>::number_of_independent_components;
+  ASSERT(volume_data->number_of_grid_points() == volume_extents.product(),
+         "volume_data has wrong number of grid points.  Expected "
+             << volume_extents.product() << ", got "
+             << volume_data->number_of_grid_points());
+  ASSERT(overlap_data.number_of_grid_points() ==
+             overlap_num_points(volume_extents, overlap_extent,
+                                direction.dimension()),
+         "overlap_data has wrong number of grid points.  Expected "
+             << overlap_num_points(volume_extents, overlap_extent,
+                                   direction.dimension())
+             << ", got " << overlap_data.number_of_grid_points());
+  detail::add_overlap_data_impl(volume_data->data(), overlap_data.data(),
+                                num_components, volume_extents, overlap_extent,
+                                direction);
+}
+
+// @{
+/// Extend the overlap data to the full mesh by filling it with zeros outside
+/// the overlap region
+template <size_t Dim, typename ExtendedTagsList, typename OverlapTagsList>
+void extended_overlap_data(
+    const gsl::not_null<Variables<ExtendedTagsList>*> extended_data,
+    const Variables<OverlapTagsList>& overlap_data,
+    const Index<Dim>& volume_extents, const size_t overlap_extent,
+    const Direction<Dim>& direction) noexcept {
+  *extended_data = Variables<ExtendedTagsList>{volume_extents.product(), 0.};
+  add_overlap_data(extended_data, overlap_data, volume_extents, overlap_extent,
+                   direction);
+}
+
+template <size_t Dim, typename TagsList>
+Variables<TagsList> extended_overlap_data(
+    const Variables<TagsList>& overlap_data, const Index<Dim>& volume_extents,
+    const size_t overlap_extent, const Direction<Dim>& direction) noexcept {
+  Variables<TagsList> extended_data{volume_extents.product()};
+  extended_overlap_data(make_not_null(&extended_data), overlap_data,
+                        volume_extents, overlap_extent, direction);
+  return extended_data;
+}
+// @}
 
 }  // namespace LinearSolver::Schwarz

--- a/tests/Unit/DataStructures/Test_SliceIterator.cpp
+++ b/tests/Unit/DataStructures/Test_SliceIterator.cpp
@@ -66,6 +66,10 @@ SPECTRE_TEST_CASE("Unit.DataStructures.SliceIterator",
     check_slice_iterator_helper(slice_iter);
     slice_iter.reset();
     check_slice_iterator_helper(slice_iter);
+    // Run the iterator only partially, then reset
+    ++slice_iter;
+    slice_iter.reset();
+    check_slice_iterator_helper(slice_iter);
   }
   SECTION("volume_and_slice_indices function") {
     check_slice_and_volume_indices(Index<1>{2});

--- a/tests/Unit/DataStructures/Test_SliceVariables.cpp
+++ b/tests/Unit/DataStructures/Test_SliceVariables.cpp
@@ -130,34 +130,45 @@ void test_variables_add_slice_to_data() noexcept {
     add_slice_to_data(make_not_null(&vars), slice, extents, 1, 1);
   }
 
-  // The slice0_vals should have been added to the second half of each of the
-  // three vectors in the tensor. The slice1_vals should have been added to
+  {
+    // Test using add_slice_to_data with prefixed Variables
+    const auto slice_extents = extents.slice_away(0);
+    Variables<tmpl::list<
+        TestHelpers::Tags::Prefix0<TestHelpers::Tags::Vector<VectorType>>>>
+        slice(slice_extents.product(), 0.);
+    get<TestHelpers::Tags::Prefix0<TestHelpers::Tags::Vector<VectorType>>>(
+        slice) = Tensor{{{slice1_vals[0], slice1_vals[1], slice1_vals[2]}}};
+    add_slice_to_data(make_not_null(&vars), slice, extents, 0, 2);
+  }
+
+  // The slice0_vals should have been added twice to the second half of each of
+  // the three vectors in the tensor. The slice1_vals should have been added to
   // entries 2 and 6 in each vector.
   // clang-format off
   const Tensor expected{
       {{{orig_vals[0].at(0),
          orig_vals[0].at(1),
-         orig_vals[0].at(2) + slice1_vals[0].at(0),
+         orig_vals[0].at(2) + 2. * slice1_vals[0].at(0),
          orig_vals[0].at(3),
          orig_vals[0].at(4) + slice0_vals[0].at(0),
          orig_vals[0].at(5) + slice0_vals[0].at(1),
-         orig_vals[0].at(6) + slice0_vals[0].at(2) + slice1_vals[0].at(1),
+         orig_vals[0].at(6) + slice0_vals[0].at(2) + 2. * slice1_vals[0].at(1),
          orig_vals[0].at(7) + slice0_vals[0].at(3)},
         {orig_vals[1].at(0),
          orig_vals[1].at(1),
-         orig_vals[1].at(2) + slice1_vals[1].at(0),
+         orig_vals[1].at(2) + 2. * slice1_vals[1].at(0),
          orig_vals[1].at(3),
          orig_vals[1].at(4) + slice0_vals[1].at(0),
          orig_vals[1].at(5) + slice0_vals[1].at(1),
-         orig_vals[1].at(6) + slice0_vals[1].at(2) + slice1_vals[1].at(1),
+         orig_vals[1].at(6) + slice0_vals[1].at(2) + 2. * slice1_vals[1].at(1),
          orig_vals[1].at(7) + slice0_vals[1].at(3)},
         {orig_vals[2].at(0),
          orig_vals[2].at(1),
-         orig_vals[2].at(2) + slice1_vals[2].at(0),
+         orig_vals[2].at(2) + 2. * slice1_vals[2].at(0),
          orig_vals[2].at(3),
          orig_vals[2].at(4) + slice0_vals[2].at(0),
          orig_vals[2].at(5) + slice0_vals[2].at(1),
-         orig_vals[2].at(6) + slice0_vals[2].at(2) + slice1_vals[2].at(1),
+         orig_vals[2].at(6) + slice0_vals[2].at(2) + 2. * slice1_vals[2].at(1),
          orig_vals[2].at(7) + slice0_vals[2].at(3)}}}};
   // clang-format on
 

--- a/tests/Unit/Domain/Structure/Test_IndexToSliceAt.cpp
+++ b/tests/Unit/Domain/Structure/Test_IndexToSliceAt.cpp
@@ -10,7 +10,11 @@
 SPECTRE_TEST_CASE("Unit.Domain.Structure.IndexToSliceAt", "[Domain][Unit]") {
   const Index<2> extents{{{2, 5}}};
   CHECK(index_to_slice_at(extents, Direction<2>::lower_xi()) == 0);
+  CHECK(index_to_slice_at(extents, Direction<2>::lower_xi(), 1) == 1);
   CHECK(index_to_slice_at(extents, Direction<2>::upper_xi()) == 1);
+  CHECK(index_to_slice_at(extents, Direction<2>::upper_xi(), 1) == 0);
   CHECK(index_to_slice_at(extents, Direction<2>::lower_eta()) == 0);
+  CHECK(index_to_slice_at(extents, Direction<2>::lower_eta(), 1) == 1);
   CHECK(index_to_slice_at(extents, Direction<2>::upper_eta()) == 4);
+  CHECK(index_to_slice_at(extents, Direction<2>::upper_eta(), 1) == 3);
 }

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_OverlapHelpers.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_OverlapHelpers.cpp
@@ -5,10 +5,133 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Index.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/Direction.hpp"
 #include "ErrorHandling/Error.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "ParallelAlgorithms/LinearSolver/Schwarz/OverlapHelpers.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace LinearSolver::Schwarz {
+
+template <size_t Dim>
+void test_data_on_overlap_consistency(const Index<Dim>& volume_extents,
+                                      const size_t overlap_extent,
+                                      const Direction<Dim>& direction) {
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> dist(-1., 1.);
+  const DataVector used_for_size{volume_extents.product()};
+  using tags_list = tmpl::list<::Tags::TempScalar<0>, ::Tags::TempI<1, Dim>,
+                               ::Tags::Tempijj<2, Dim>>;
+  const auto vars = make_with_random_values<Variables<tags_list>>(
+      make_not_null(&generator), make_not_null(&dist), used_for_size);
+  CAPTURE(vars);
+
+  const Variables<tags_list> vars_on_overlap =
+      data_on_overlap(vars, volume_extents, overlap_extent, direction);
+  CAPTURE(vars_on_overlap);
+
+  {
+    INFO("Test Variables and Tensor data on overlap is consistent");
+    tmpl::for_each<tags_list>([&](auto tag_v) {
+      using tag = tmpl::type_from<decltype(tag_v)>;
+      CAPTURE(db::tag_name<tag>());
+      const auto tensor_on_overlap = data_on_overlap(
+          get<tag>(vars), volume_extents, overlap_extent, direction);
+      for (size_t i = 0; i < tensor_on_overlap.size(); i++) {
+        CAPTURE(i);
+        CHECK_ITERABLE_APPROX(tensor_on_overlap[i],
+                              get<tag>(vars_on_overlap)[i]);
+      }
+    });
+  }
+  {
+    INFO("Test extended_overlap_data and add_overlap_data are consistent");
+    Variables<tags_list> extended_vars{used_for_size.size(), 0.};
+    add_overlap_data(make_not_null(&extended_vars), vars_on_overlap,
+                     volume_extents, overlap_extent, direction);
+    CHECK_VARIABLES_APPROX(
+        extended_vars, extended_overlap_data(vars_on_overlap, volume_extents,
+                                             overlap_extent, direction));
+  }
+}
+
+template <size_t Dim>
+void test_data_on_overlap(const DataVector& scalar_volume_data,
+                          const Index<Dim>& volume_extents,
+                          const size_t overlap_extent,
+                          const Direction<Dim>& direction,
+                          const DataVector& expected_overlap_data,
+                          const DataVector& expected_extended_data) {
+  CAPTURE(volume_extents);
+  CAPTURE(overlap_extent);
+  CAPTURE(direction);
+  {
+    INFO("Tensor data on overlap");
+    const Scalar<DataVector> scalar{scalar_volume_data};
+    CHECK_ITERABLE_APPROX(
+        get(data_on_overlap(scalar, volume_extents, overlap_extent, direction)),
+        expected_overlap_data);
+  }
+  Variables<tmpl::list<::Tags::TempScalar<0>>> vars{scalar_volume_data.size()};
+  get(get<::Tags::TempScalar<0>>(vars)) = scalar_volume_data;
+  const auto vars_on_overlap =
+      data_on_overlap(vars, volume_extents, overlap_extent, direction);
+  {
+    INFO("Variables data on overlap");
+    CHECK_ITERABLE_APPROX(get(get<::Tags::TempScalar<0>>(vars_on_overlap)),
+                          expected_overlap_data);
+  }
+  Variables<tmpl::list<::Tags::TempScalar<0>>> extended_vars{
+      scalar_volume_data.size(), 0.};
+  add_overlap_data(make_not_null(&extended_vars), vars_on_overlap,
+                   volume_extents, overlap_extent, direction);
+  {
+    INFO("Add overlap data");
+    CHECK_ITERABLE_APPROX(get(get<::Tags::TempScalar<0>>(extended_vars)),
+                          expected_extended_data);
+  }
+  {
+    INFO("Extended overlap data");
+    CHECK_VARIABLES_APPROX(
+        extended_overlap_data(vars_on_overlap, volume_extents, overlap_extent,
+                              direction),
+        extended_vars);
+  }
+  {
+    INFO("Test consistency with non-scalars");
+    test_data_on_overlap_consistency(volume_extents, overlap_extent, direction);
+  }
+}
+
+template <size_t Dim>
+void test_overlap_iterator(const Index<Dim>& volume_extents,
+                           const size_t overlap_extent,
+                           const Direction<Dim>& direction,
+                           const std::vector<size_t>& expected_volume_offsets) {
+  CAPTURE(Dim);
+  CAPTURE(volume_extents);
+  CAPTURE(overlap_extent);
+  CAPTURE(direction);
+  ASSERT(std::is_sorted(expected_volume_offsets.begin(),
+                        expected_volume_offsets.end()),
+         "Volume indices must be sorted to optimize array access performance.");
+
+  OverlapIterator overlap_iterator{volume_extents, overlap_extent, direction};
+  // Reset the iterator once to test resetting works
+  ++overlap_iterator;
+  overlap_iterator.reset();
+  for (size_t i = 0; i < expected_volume_offsets.size(); ++i) {
+    CHECK(overlap_iterator);
+    CHECK(overlap_iterator.volume_offset() == expected_volume_offsets[i]);
+    CHECK(overlap_iterator.overlap_offset() == i);
+    ++overlap_iterator;
+  }
+  CHECK_FALSE(overlap_iterator);
+}
 
 SPECTRE_TEST_CASE("Unit.ParallelSchwarz.OverlapHelpers",
                   "[Unit][ParallelAlgorithms][LinearSolver]") {
@@ -55,6 +178,182 @@ SPECTRE_TEST_CASE("Unit.ParallelSchwarz.OverlapHelpers",
     CHECK(overlap_width(2, coords) == approx(1.));
     CHECK(overlap_width(3, coords) == approx(1.8));
     CHECK(overlap_width(4, coords) == approx(2.));
+  }
+  {
+    INFO("Overlap iterator");
+    {
+      // Give an example to include in the docs
+      /// [overlap_iterator]
+      // Overlap region:
+      // + - - - + -xi->
+      // | X X O |
+      // | X X O |
+      // + - - - +
+      // v eta
+      const Index<2> volume_extents{{{3, 2}}};
+      const size_t overlap_extent = 2;
+      const auto direction = Direction<2>::lower_xi();
+      const std::array<size_t, 4> expected_volume_offsets{{0, 1, 3, 4}};
+      size_t i = 0;
+      for (OverlapIterator overlap_iterator{volume_extents, overlap_extent,
+                                            direction};
+           overlap_iterator; ++overlap_iterator) {
+        CHECK(overlap_iterator.volume_offset() ==
+              gsl::at(expected_volume_offsets, i));
+        CHECK(overlap_iterator.overlap_offset() == i);
+        ++i;
+      }
+      CHECK(i == expected_volume_offsets.size());
+      /// [overlap_iterator]
+    }
+    // Overlap region: [X X O] -xi->
+    test_overlap_iterator(Index<1>{3}, 2, Direction<1>::lower_xi(), {{0, 1}});
+    // Overlap region: [O X X] -xi->
+    test_overlap_iterator(Index<1>{3}, 2, Direction<1>::upper_xi(), {{1, 2}});
+    // Overlap region:
+    // + - - - + -xi->
+    // | X X O |
+    // | X X O |
+    // + - - - +
+    // v eta
+    test_overlap_iterator(Index<2>{{{3, 2}}}, 2, Direction<2>::lower_xi(),
+                          {{0, 1, 3, 4}});
+    // Overlap region:
+    // + - - - + -xi->
+    // | O X X |
+    // | O X X |
+    // + - - - +
+    // v eta
+    test_overlap_iterator(Index<2>{{{3, 2}}}, 2, Direction<2>::upper_xi(),
+                          {{1, 2, 4, 5}});
+    // Overlap region:
+    // + - - - - + -xi->
+    // | X X X X |
+    // | X X X X |
+    // | O O O O |
+    // + - - - - +
+    // v eta
+    test_overlap_iterator(Index<2>{{{4, 3}}}, 2, Direction<2>::lower_eta(),
+                          {{0, 1, 2, 3, 4, 5, 6, 7}});
+    // Overlap region:
+    // + - - + -xi->
+    // | O O |
+    // | X X |
+    // | X X |
+    // + - - +
+    // v eta
+    test_overlap_iterator(Index<2>{{{2, 3}}}, 2, Direction<2>::upper_eta(),
+                          {{2, 3, 4, 5}});
+    test_overlap_iterator(Index<3>{{{3, 3, 2}}}, 2, Direction<3>::lower_xi(),
+                          {{0, 1, 3, 4, 6, 7, 9, 10, 12, 13, 15, 16}});
+    test_overlap_iterator(Index<3>{{{3, 3, 2}}}, 2, Direction<3>::upper_xi(),
+                          {{1, 2, 4, 5, 7, 8, 10, 11, 13, 14, 16, 17}});
+    test_overlap_iterator(Index<3>{{{3, 3, 2}}}, 2, Direction<3>::lower_eta(),
+                          {{0, 1, 2, 3, 4, 5, 9, 10, 11, 12, 13, 14}});
+    test_overlap_iterator(Index<3>{{{3, 3, 2}}}, 2, Direction<3>::upper_eta(),
+                          {{3, 4, 5, 6, 7, 8, 12, 13, 14, 15, 16, 17}});
+    test_overlap_iterator(Index<3>{{{3, 2, 3}}}, 2, Direction<3>::lower_zeta(),
+                          {{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}});
+    test_overlap_iterator(Index<3>{{{3, 2, 3}}}, 2, Direction<3>::upper_zeta(),
+                          {{6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17}});
+  }
+  {
+    INFO("Data on overlap");
+    {
+      INFO("1D");
+      const Index<1> volume_extents{3};
+      const size_t overlap_extent = 2;
+      DataVector scalar{1., 2., 3.};
+      // Overlap region: [X X O] -xi->
+      test_data_on_overlap(scalar, volume_extents, overlap_extent,
+                           Direction<1>::lower_xi(), {1., 2.}, {1., 2., 0.});
+      // Overlap region: [O X X] -xi->
+      test_data_on_overlap(scalar, volume_extents, overlap_extent,
+                           Direction<1>::upper_xi(), {2., 3.}, {0., 2., 3.});
+    }
+    {
+      INFO("2D");
+      const Index<2> volume_extents{{{3, 2}}};
+      const size_t overlap_extent_xi = 2;
+      const size_t overlap_extent_eta = 1;
+      DataVector scalar{1., 2., 3., 4., 5., 6.};
+      // Overlap region:
+      // + - - - + -xi->
+      // | X X O |
+      // | X X O |
+      // + - - - +
+      // v eta
+      test_data_on_overlap(scalar, volume_extents, overlap_extent_xi,
+                           Direction<2>::lower_xi(), {1., 2., 4., 5.},
+                           {1., 2., 0., 4., 5., 0.});
+      // Overlap region:
+      // + - - - + -xi->
+      // | O X X |
+      // | O X X |
+      // + - - - +
+      // v eta
+      test_data_on_overlap(scalar, volume_extents, overlap_extent_xi,
+                           Direction<2>::upper_xi(), {2., 3., 5., 6.},
+                           {0., 2., 3., 0., 5., 6.});
+      // Overlap region:
+      // + - - - + -xi->
+      // | X X X |
+      // | O O O |
+      // + - - - +
+      // v eta
+      test_data_on_overlap(scalar, volume_extents, overlap_extent_eta,
+                           Direction<2>::lower_eta(), {1., 2., 3.},
+                           {1., 2., 3., 0., 0., 0.});
+      // Overlap region:
+      // + - - - + -xi->
+      // | O O O |
+      // | X X X |
+      // + - - - +
+      // v eta
+      test_data_on_overlap(scalar, volume_extents, overlap_extent_eta,
+                           Direction<2>::upper_eta(), {4., 5., 6.},
+                           {0., 0., 0., 4., 5., 6.});
+    }
+    {
+      INFO("3D");
+      const Index<3> volume_extents{{{3, 2, 3}}};
+      const size_t overlap_extent_xi = 2;
+      const size_t overlap_extent_eta = 1;
+      const size_t overlap_extent_zeta = 2;
+      DataVector scalar{1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9.,
+                        10., 11., 12., 13., 14., 15., 16., 17., 18.};
+      test_data_on_overlap(
+          scalar, volume_extents, overlap_extent_xi, Direction<3>::lower_xi(),
+          {1., 2., 4., 5., 7., 8., 10., 11., 13., 14., 16., 17.},
+          {1., 2., 0., 4., 5., 0., 7., 8., 0., 10., 11., 0., 13., 14., 0., 16.,
+           17., 0.});
+      test_data_on_overlap(
+          scalar, volume_extents, overlap_extent_xi, Direction<3>::upper_xi(),
+          {2., 3., 5., 6., 8., 9., 11., 12., 14., 15., 17., 18.},
+          {0., 2., 3., 0., 5., 6., 0., 8., 9., 0., 11., 12., 0., 14., 15., 0.,
+           17., 18.});
+      test_data_on_overlap(scalar, volume_extents, overlap_extent_eta,
+                           Direction<3>::lower_eta(),
+                           {1., 2., 3., 7., 8., 9., 13., 14., 15.},
+                           {1., 2., 3., 0., 0., 0., 7., 8., 9., 0., 0., 0., 13.,
+                            14., 15., 0., 0., 0.});
+      test_data_on_overlap(scalar, volume_extents, overlap_extent_eta,
+                           Direction<3>::upper_eta(),
+                           {4., 5., 6., 10., 11., 12., 16., 17., 18.},
+                           {0., 0., 0., 4., 5., 6., 0., 0., 0., 10., 11., 12.,
+                            0., 0., 0., 16., 17., 18.});
+      test_data_on_overlap(scalar, volume_extents, overlap_extent_zeta,
+                           Direction<3>::lower_zeta(),
+                           {1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12.},
+                           {1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12.,
+                            0., 0., 0., 0., 0., 0.});
+      test_data_on_overlap(
+          scalar, volume_extents, overlap_extent_zeta,
+          Direction<3>::upper_zeta(),
+          {7., 8., 9., 10., 11., 12., 13., 14., 15., 16., 17., 18.},
+          {0., 0., 0., 0., 0., 0., 7., 8., 9., 10., 11., 12., 13., 14., 15.,
+           16., 17., 18.});
+    }
   }
 }
 


### PR DESCRIPTION
## Proposed changes

- Add functions to deal with data on a region that extends only partially into an element (an "overlap region").
- While implementing this I also fixed a few things in SliceIterator, made `add_slice_to_data` work with prefixed variables and added an optional offset to `index_to_slice_at`.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
