### PR TITLE
Add Output Time and General String Printing functionality

### DIFF
--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -49,6 +49,7 @@
 #include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeInterfaces.hpp"
 #include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeMortars.hpp"
 #include "ParallelAlgorithms/Events/ObserveErrorNorms.hpp"  // IWYU pragma: keep
+#include "ParallelAlgorithms/Events/ObserveTime.hpp"  // IWYU pragma: keep
 #include "ParallelAlgorithms/Events/ObserveFields.hpp"      // IWYU pragma: keep
 #include "ParallelAlgorithms/Events/ObserveTimeStep.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp"  // IWYU pragma: keep
@@ -155,6 +156,8 @@ struct EvolutionMetavars {
                  dg::Events::Registrars::ObserveErrorNorms<
                      Tags::Time, analytic_solution_fields>,
                  Events::Registrars::ObserveTimeStep<EvolutionMetavars>,
+                 dg::Events::Registrars::ObserveTime<
+                     Tags::Time, analytic_solution_fields>,
                  Events::Registrars::ChangeSlabSize<slab_choosers>>;
   using triggers = Triggers::time_triggers;
 

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -156,8 +156,7 @@ struct EvolutionMetavars {
                  dg::Events::Registrars::ObserveErrorNorms<
                      Tags::Time, analytic_solution_fields>,
                  Events::Registrars::ObserveTimeStep<EvolutionMetavars>,
-                 dg::Events::Registrars::ObserveTime<
-                     Tags::Time, analytic_solution_fields>,
+                 dg::Events::Registrars::ObserveTime<Tags::Time>,
                  Events::Registrars::ChangeSlabSize<slab_choosers>>;
   using triggers = Triggers::time_triggers;
 

--- a/src/IO/Observer/ReductionActions.hpp
+++ b/src/IO/Observer/ReductionActions.hpp
@@ -160,7 +160,7 @@ struct ContributeReductionData {
                                         ObserverWriter<Metavariables>>(cache)
                                         .ckLocalBranch();
               Parallel::threaded_action<
-                  ThreadedActions::CollectReductionDataOnNode<ReductionDataAction>(
+                  ThreadedActions::CollectReductionDataOnNode<ReductionDataAction>>(
                   local_writer, observation_id,
                   ArrayComponentId{
                       std::add_pointer_t<ParallelComponent>{nullptr},

--- a/src/IO/Observer/ReductionActions.hpp
+++ b/src/IO/Observer/ReductionActions.hpp
@@ -43,7 +43,7 @@ struct ObserverWriter;
 
 namespace ThreadedActions {
 /// \cond
-template <ReductionDataAction>
+template <typename ReductionDataAction>
 struct CollectReductionDataOnNode;
 struct WriteReductionData;
 /// \endcond
@@ -80,7 +80,7 @@ struct ContributeReductionDataToWriter;
  * Then, in the `Metavariables` collect them from all observing Actions using
  * the `observers::collect_reduction_data_tags` metafunction.
  */
-template <ReductionDataAction>
+template <typename ReductionDataAction>
 struct ContributeReductionData {
   template <typename ParallelComponent, typename DbTagsList,
             typename Metavariables, typename ArrayIndex, typename... Ts>
@@ -191,7 +191,7 @@ namespace ThreadedActions {
  * \brief Gathers all the reduction data from all processing elements/cores on a
  * node.
  */
-template <ReductionDataAction>
+template <typename ReductionDataAction>
 struct CollectReductionDataOnNode {
  public:
   template <typename ParallelComponent, typename DbTagsList,

--- a/src/IO/Observer/ReductionActions.hpp
+++ b/src/IO/Observer/ReductionActions.hpp
@@ -594,3 +594,4 @@ struct WriteReductionData {
 };
 }  // namespace ThreadedActions
 }  // namespace observers
+

--- a/src/IO/Observer/ReductionActions.hpp
+++ b/src/IO/Observer/ReductionActions.hpp
@@ -43,6 +43,7 @@ struct ObserverWriter;
 
 namespace ThreadedActions {
 /// \cond
+template <ReductionDataAction>
 struct CollectReductionDataOnNode;
 struct WriteReductionData;
 /// \endcond
@@ -79,6 +80,7 @@ struct ContributeReductionDataToWriter;
  * Then, in the `Metavariables` collect them from all observing Actions using
  * the `observers::collect_reduction_data_tags` metafunction.
  */
+template <ReductionDataAction>
 struct ContributeReductionData {
   template <typename ParallelComponent, typename DbTagsList,
             typename Metavariables, typename ArrayIndex, typename... Ts>
@@ -158,7 +160,7 @@ struct ContributeReductionData {
                                         ObserverWriter<Metavariables>>(cache)
                                         .ckLocalBranch();
               Parallel::threaded_action<
-                  ThreadedActions::CollectReductionDataOnNode>(
+                  ThreadedActions::CollectReductionDataOnNode<ReductionDataAction>(
                   local_writer, observation_id,
                   ArrayComponentId{
                       std::add_pointer_t<ParallelComponent>{nullptr},
@@ -189,6 +191,7 @@ namespace ThreadedActions {
  * \brief Gathers all the reduction data from all processing elements/cores on a
  * node.
  */
+template <ReductionDataAction>
 struct CollectReductionDataOnNode {
  public:
   template <typename ParallelComponent, typename DbTagsList,
@@ -346,7 +349,7 @@ struct CollectReductionDataOnNode {
       if (send_data) {
         auto& my_proxy =
             Parallel::get_parallel_component<ParallelComponent>(cache);
-        Parallel::threaded_action<WriteReductionData>(
+        Parallel::threaded_action<ReductionDataAction>(
             Parallel::get_parallel_component<ObserverWriter<Metavariables>>(
                 cache)[0],
             observation_id,

--- a/src/IO/Observer/ReductionActions.old.hpp
+++ b/src/IO/Observer/ReductionActions.old.hpp
@@ -1,0 +1,543 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/Dat.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/Tags.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/NodeLock.hpp"
+#include "Parallel/Printf.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/StdHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace observers {
+
+/// \cond
+template <class Metavariables>
+struct ObserverWriter;
+/// \endcond
+
+namespace ThreadedActions {
+/// \cond
+struct WriteReductionData;
+struct PrintReductionData;
+/// \endcond
+}  // namespace ThreadedActions
+
+namespace Actions {
+/// \cond
+struct ContributeReductionDataToWriter;
+/// \endcond
+
+/*!
+ * \ingroup ObserversGroup
+ * \brief Send reduction data to the observer group.
+ *
+ * Once everything at a specific `ObservationId` has been contributed to the
+ * reduction, the groups reduce to their local nodegroup.
+ *
+ * The caller of this Action (which is to be invoked on the Observer parallel
+ * component) must pass in an `observation_id` used to uniquely identify the
+ * observation in time, the name of the `h5::Dat` subfile in the HDF5 file (e.g.
+ * `/element_data`, where the slash is important), a `std::vector<std::string>`
+ * of names of the quantities being reduced (e.g. `{"Time", "L1ErrorDensity",
+ * "L2ErrorDensity"}`), and the `Parallel::ReductionData` that holds the
+ * `ReductionDatums` containing info on how to do the reduction.
+ *
+ * The observer components need to know all expected reduction data types by
+ * compile-time, so they rely on the
+ * `Metavariables::observed_reduction_data_tags` alias to collect them in one
+ * place. To this end, each Action that contributes reduction data must expose
+ * the type alias as:
+ *
+ * \snippet ObserverHelpers.hpp make_reduction_data_tags
+ *
+ * Then, in the `Metavariables` collect them from all observing Actions using
+ * the `observers::collect_reduction_data_tags` metafunction.
+ */
+struct ContributeReductionData {
+  template <
+      typename ParallelComponent, typename DbTagsList, typename Metavariables,
+      typename ArrayIndex, typename... Ts,
+      Requires<
+          tmpl::list_contains_v<DbTagsList, Tags::ReductionData<Ts...>> and
+          tmpl::list_contains_v<DbTagsList, Tags::ReductionDataNames<Ts...>> and
+          tmpl::list_contains_v<DbTagsList,
+                                Tags::ReductionObserversContributed>> = nullptr>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const observers::ObservationId& observation_id,
+                    const std::string& subfile_name,
+                    const std::vector<std::string>& reduction_names,
+                    Parallel::ReductionData<Ts...>&& reduction_data) noexcept {
+    db::mutate<Tags::ReductionData<Ts...>, Tags::ReductionDataNames<Ts...>,
+               Tags::ReductionObserversContributed>(
+        make_not_null(&box),
+        [&observation_id, reduction_data = std::move(reduction_data),
+         &reduction_names, &cache, &subfile_name](
+            const gsl::not_null<std::unordered_map<
+                ObservationId, Parallel::ReductionData<Ts...>>*>
+                reduction_data_map,
+            const gsl::not_null<
+                std::unordered_map<ObservationId, std::vector<std::string>>*>
+                reduction_names_map,
+            const gsl::not_null<
+                std::unordered_map<observers::ObservationId, size_t>*>
+                reduction_observers_contributed,
+            const std::unordered_set<ArrayComponentId>&
+                reduction_component_ids) mutable noexcept {
+          auto& contribute_count =
+              (*reduction_observers_contributed)[observation_id];
+          if (reduction_data_map->count(observation_id) == 0) {
+            reduction_data_map->emplace(observation_id,
+                                        std::move(reduction_data));
+            reduction_names_map->emplace(observation_id, reduction_names);
+            contribute_count = 1;
+          } else {
+            ASSERT(
+                reduction_names_map->at(observation_id) == reduction_names,
+                "Reduction names differ at ObservationId "
+                    << observation_id
+                    << " with the expected names being "
+                    // Use MakeString to get around ADL for STL stream operators
+                    // (MakeString is in global namespace).
+                    << (MakeString{} << reduction_names_map->at(observation_id)
+                                     << " and the received names being "
+                                     << reduction_names));
+            reduction_data_map->operator[](observation_id)
+                .combine(std::move(reduction_data));
+            contribute_count++;
+          }
+
+          // Check if we have received all reduction data from the registered
+          // elements. If so, we reduce to the local ObserverWriter nodegroup.
+          if (contribute_count == reduction_component_ids.size()) {
+            const auto node_id = Parallel::my_node();
+            auto& local_writer = *Parallel::get_parallel_component<
+                                      ObserverWriter<Metavariables>>(cache)
+                                      .ckLocalBranch();
+            Parallel::threaded_action<ThreadedActions::WriteReductionData>(
+                local_writer, observation_id, subfile_name,
+                node_id == 0 ? std::move((*reduction_names_map)[observation_id])
+                             : std::vector<std::string>{},
+                std::move((*reduction_data_map)[observation_id]));
+            reduction_data_map->erase(observation_id);
+            reduction_names_map->erase(observation_id);
+            reduction_observers_contributed->erase(observation_id);
+          }
+        },
+        db::get<Tags::ReductionArrayComponentIds>(box));
+  }
+};
+
+/*!
+ * Add docs
+ */
+struct ContributeStringForPrinting {
+  template <
+      typename ParallelComponent, typename DbTagsList, typename Metavariables,
+      typename ArrayIndex, typename... Ts,
+      Requires<tmpl::list_contains_v<DbTagsList, Tags::ReductionData<Ts...>> and
+               tmpl::list_contains_v<
+                   DbTagsList, Tags::ReductionObserversContributed>> = nullptr>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const observers::ObservationId& observation_id,
+                    Parallel::ReductionData<Ts...>&& reduction_data) noexcept {
+    db::mutate<Tags::ReductionData<Ts...>, Tags::ReductionObserversContributed>(
+        make_not_null(&box),
+        [&observation_id, reduction_data = std::move(reduction_data), &cache](
+            const gsl::not_null<std::unordered_map<
+                ObservationId, Parallel::ReductionData<Ts...>>*>
+                reduction_data_map,
+            const gsl::not_null<
+                std::unordered_map<observers::ObservationId, size_t>*>
+                reduction_observers_contributed,
+            const std::unordered_set<ArrayComponentId>&
+                reduction_component_ids) mutable noexcept {
+          auto& contribute_count =
+              (*reduction_observers_contributed)[observation_id];
+          if (reduction_data_map->count(observation_id) == 0) {
+            reduction_data_map->emplace(observation_id,
+                                        std::move(reduction_data));
+            contribute_count = 1;
+          } else {
+            reduction_data_map->operator[](observation_id)
+                .combine(std::move(reduction_data));
+            contribute_count++;
+          }
+
+          // Check if we have received all reduction data from the registered
+          // elements. If so, we reduce to the local ObserverWriter nodegroup.
+          if (contribute_count == reduction_component_ids.size()) {
+            const auto node_id = Parallel::my_node();
+            auto& local_writer = *Parallel::get_parallel_component<
+                                      ObserverWriter<Metavariables>>(cache)
+                                      .ckLocalBranch();
+            Parallel::threaded_action<ThreadedActions::PrintReductionData>(
+                local_writer, observation_id,
+                std::move((*reduction_data_map)[observation_id]));
+            reduction_data_map->erase(observation_id);
+            reduction_observers_contributed->erase(observation_id);
+          }
+        },
+        db::get<Tags::ReductionArrayComponentIds>(box));
+  }
+};
+}  // namespace Actions
+
+namespace ThreadedActions {
+/*!
+ * \ingroup ObserversGroup
+ * \brief Collect the reduction data from the Observer group on the
+ * ObserverWriter nodegroup before sending to node 0 for writing to disk.
+ *
+ * \note This action is also used for writing on node 0.
+ */
+struct WriteReductionData {
+ private:
+  static void append_to_reduction_data(
+      const gsl::not_null<std::vector<double>*> all_reduction_data,
+      const double t) noexcept {
+    all_reduction_data->push_back(t);
+  }
+
+  static void append_to_reduction_data(
+      const gsl::not_null<std::vector<double>*> all_reduction_data,
+      const std::vector<double>& t) noexcept {
+    all_reduction_data->insert(all_reduction_data->end(), t.begin(), t.end());
+  }
+
+  template <typename... Ts, size_t... Is>
+  static void write_data(const std::string& subfile_name,
+                         std::vector<std::string>&& legend,
+                         std::tuple<Ts...>&& data,
+                         const std::string& file_prefix,
+                         std::index_sequence<Is...> /*meta*/) noexcept {
+    static_assert(sizeof...(Ts) > 0,
+                  "Must be reducing at least one piece of data");
+    std::vector<double> data_to_append{};
+    EXPAND_PACK_LEFT_TO_RIGHT(
+        append_to_reduction_data(&data_to_append, std::get<Is>(data)));
+
+    h5::H5File<h5::AccessType::ReadWrite> h5file(file_prefix + ".h5", true);
+    constexpr size_t version_number = 0;
+    auto& time_series_file = h5file.try_insert<h5::Dat>(
+        subfile_name, std::move(legend), version_number);
+    time_series_file.append(data_to_append);
+  }
+
+ public:
+  template <
+      typename ParallelComponent, typename DbTagsList, typename Metavariables,
+      typename ArrayIndex, typename... ReductionDatums,
+      Requires<tmpl::list_contains_v<
+                   DbTagsList, Tags::ReductionData<ReductionDatums...>> and
+               tmpl::list_contains_v<
+                   DbTagsList, Tags::ReductionDataNames<ReductionDatums...>> and
+               tmpl::list_contains_v<DbTagsList,
+                                     Tags::ReductionObserversContributed> and
+               tmpl::list_contains_v<DbTagsList, Tags::H5FileLock>> = nullptr>
+  static void apply(db::DataBox<DbTagsList>& box,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const gsl::not_null<CmiNodeLock*> node_lock,
+                    const observers::ObservationId& observation_id,
+                    const std::string& subfile_name,
+                    std::vector<std::string>&& reduction_names,
+                    Parallel::ReductionData<ReductionDatums...>&&
+                        in_reduction_data) noexcept {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+    CmiNodeLock file_lock;
+    bool write_to_disk = false;
+    std::vector<std::string> legend{};
+    Parallel::lock(node_lock);
+    const auto expected_calls_from_this_node = [&box,
+                                                &observation_id]() noexcept {
+      const auto hash = observation_id.observation_type_hash();
+      const auto& registered_reduction_observers =
+          db::get<Tags::ReductionObserversRegistered>(box);
+      return (registered_reduction_observers.count(hash) == 1)
+                 ? registered_reduction_observers.at(hash).size()
+                 : 0;
+    }();
+    const auto expected_calls_from_other_nodes = [&box,
+                                                  &observation_id]() noexcept {
+      const auto hash = observation_id.observation_type_hash();
+      const auto& registered_reduction_observers =
+          db::get<Tags::ReductionObserversRegisteredNodes>(box);
+      return (registered_reduction_observers.count(hash) == 1)
+                 ? registered_reduction_observers.at(hash).size()
+                 : 0;
+    }();
+    db::mutate<Tags::ReductionData<ReductionDatums...>,
+               Tags::ReductionDataNames<ReductionDatums...>,
+               Tags::ReductionObserversContributed, Tags::H5FileLock>(
+        make_not_null(&box),
+        [&cache, &expected_calls_from_this_node,
+         &expected_calls_from_other_nodes, &file_lock, &in_reduction_data,
+         &legend, &observation_id, &reduction_names, &subfile_name,
+         &write_to_disk](
+            const gsl::not_null<
+                db::item_type<Tags::ReductionData<ReductionDatums...>>*>
+                reduction_data,
+            const gsl::not_null<
+                std::unordered_map<ObservationId, std::vector<std::string>>*>
+                reduction_names_map,
+            const gsl::not_null<
+                std::unordered_map<observers::ObservationId, size_t>*>
+                reduction_observers_contributed,
+            const gsl::not_null<CmiNodeLock*> reduction_file_lock) noexcept {
+          auto& contribute_count =
+              (*reduction_observers_contributed)[observation_id];
+          const auto node_id = Parallel::my_node();
+
+          if (node_id == 0 and not reduction_names.empty()) {
+            reduction_names_map->emplace(observation_id,
+                                         std::move(reduction_names));
+          }
+
+          if (UNLIKELY(node_id == 0 and expected_calls_from_other_nodes == 0 and
+                       expected_calls_from_this_node == 1)) {
+            // Here this Action will be called only once, so we take
+            // a shortcut and just write to disk.
+            write_to_disk = true;
+            file_lock = *reduction_file_lock;
+            legend = std::move(reduction_names_map->operator[](observation_id));
+            reduction_names_map->erase(observation_id);
+          } else if (reduction_data->count(observation_id) == 0) {
+            // This Action has been called for the first time,
+            // so all we need to do is move the input data to the
+            // reduction_data in the DataBox.
+            reduction_data->operator[](observation_id) =
+                std::move(in_reduction_data);
+            contribute_count = 1;
+          } else if (node_id == 0 and
+                     contribute_count == expected_calls_from_this_node +
+                                             expected_calls_from_other_nodes -
+                                             1) {
+            // This is the final time this Action is called on node 0.
+            // The `-1` in the above `if` statement is because on the final
+            // step, contribute_count (which was incremented at the end of each
+            // previous call) should be one less than the expected number of
+            // calls.
+            in_reduction_data.combine(
+                std::move(reduction_data->operator[](observation_id)));
+            reduction_data->erase(observation_id);
+            reduction_observers_contributed->erase(observation_id);
+            write_to_disk = true;
+            file_lock = *reduction_file_lock;
+            legend = std::move(reduction_names_map->operator[](observation_id));
+            reduction_names_map->erase(observation_id);
+          } else {
+            // This Action is being called at least the second time
+            // (but not the final time if on node 0).
+            reduction_data->at(observation_id)
+                .combine(std::move(in_reduction_data));
+            contribute_count++;
+          }
+
+          // Check if we have received all reduction data from the Observer
+          // group. If so we reduce to node 0 for writing to disk.
+          if (node_id != 0 and
+              reduction_observers_contributed->at(observation_id) ==
+                  expected_calls_from_this_node) {
+            Parallel::threaded_action<WriteReductionData>(
+                Parallel::get_parallel_component<ObserverWriter<Metavariables>>(
+                    cache)[0],
+                observation_id, subfile_name, std::vector<std::string>{},
+                std::move(reduction_data->operator[](observation_id)));
+            reduction_observers_contributed->erase(observation_id);
+            reduction_data->erase(observation_id);
+          }
+        });
+    Parallel::unlock(node_lock);
+
+    if (write_to_disk) {
+      Parallel::lock(&file_lock);
+      in_reduction_data.finalize();
+      WriteReductionData::write_data(
+          subfile_name, std::move(legend), std::move(in_reduction_data.data()),
+          Parallel::get<Tags::ReductionFileName>(cache),
+          std::make_index_sequence<sizeof...(ReductionDatums)>{});
+      Parallel::unlock(&file_lock);
+    }
+  }
+};
+
+/*!
+ * \ingroup ObserversGroup
+ * \brief Collect the reduction data from the Observer group on the
+ * ObserverWriter nodegroup before sending to node 0 for printing to screen.
+ */
+struct PrintReductionData {
+ private:
+  static void append_to_reduction_data(
+      const gsl::not_null<std::vector<std::string>*> all_reduction_data,
+      const std::string str) noexcept {
+    all_reduction_data->push_back(str);
+  }
+
+  static void append_to_reduction_data(
+      const gsl::not_null<std::vector<std::string>*> all_reduction_data,
+      const std::vector<std::string>& str_vec) noexcept {
+    all_reduction_data->insert(all_reduction_data->end(), str_vec.begin(),
+                               str_vec.end());
+  }
+
+  template <typename... Ts, size_t... Is>
+  static void print_data(std::tuple<Ts...>&& data,
+                         std::index_sequence<Is...> /*meta*/) noexcept {
+    static_assert(
+        sizeof...(Ts) > 0,
+        "Must be reducing at least one piece of data in print_data()");
+
+    std::vector<std::string> str_vec{};
+    EXPAND_PACK_LEFT_TO_RIGHT(
+        append_to_reduction_data(&str_vec, std::get<Is>(data)));
+    for (const auto& str : str_vec) {
+      Parallel::printf(str + "\n");
+    }
+  }
+
+ public:
+  template <
+      typename ParallelComponent, typename DbTagsList, typename Metavariables,
+      typename ArrayIndex, typename... ReductionDatums,
+      Requires<tmpl::list_contains_v<
+                   DbTagsList, Tags::ReductionData<ReductionDatums...>> and
+               tmpl::list_contains_v<
+                   DbTagsList, Tags::ReductionObserversContributed>> = nullptr>
+  static void apply(db::DataBox<DbTagsList>& box,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const gsl::not_null<CmiNodeLock*> node_lock,
+                    const observers::ObservationId& observation_id,
+                    Parallel::ReductionData<ReductionDatums...>&&
+                        in_reduction_data) noexcept {
+    bool print_to_screen = false;
+    Parallel::lock(node_lock);
+
+    const auto expected_calls_from_this_node = [&box,
+                                                &observation_id]() noexcept {
+      const auto hash = observation_id.observation_type_hash();
+      const auto& registered_reduction_observers =
+          db::get<Tags::ReductionObserversRegistered>(box);
+      return (registered_reduction_observers.count(hash) == 1)
+                 ? registered_reduction_observers.at(hash).size()
+                 : 0;
+    }();
+
+    const auto expected_calls_from_other_nodes = [&box,
+                                                  &observation_id]() noexcept {
+      const auto hash = observation_id.observation_type_hash();
+      const auto& registered_reduction_observers =
+          db::get<Tags::ReductionObserversRegisteredNodes>(box);
+      return (registered_reduction_observers.count(hash) == 1)
+                 ? registered_reduction_observers.at(hash).size()
+                 : 0;
+    }();
+
+    db::mutate<Tags::ReductionData<ReductionDatums...>,
+               Tags::ReductionObserversContributed>(
+        make_not_null(&box),
+        [&cache, &expected_calls_from_this_node,
+         &expected_calls_from_other_nodes, &in_reduction_data, &observation_id,
+         &print_to_screen](
+            const gsl::not_null<
+                db::item_type<Tags::ReductionData<ReductionDatums...>>*>
+                reduction_data,
+            const gsl::not_null<
+                std::unordered_map<observers::ObservationId, size_t>*>
+                reduction_observers_contributed) noexcept {
+          auto& contribute_count =
+              (*reduction_observers_contributed)[observation_id];
+
+          const auto node_id = Parallel::my_node();
+
+          if (UNLIKELY(node_id == 0 and expected_calls_from_other_nodes == 0 and
+                       expected_calls_from_this_node == 1)) {
+            // Here this Action will be called only once, so we take
+            // a shortcut and just print to screen.
+
+            print_to_screen = true;
+          } else if (reduction_data->count(observation_id) == 0) {
+            // This Action has been called for the first time,
+            // so all we need to do is move the input data to the
+            // reduction_data in the DataBox.
+            reduction_data->operator[](observation_id) =
+                std::move(in_reduction_data);
+            contribute_count = 1;
+          } else if (node_id == 0 and
+                     contribute_count == expected_calls_from_this_node +
+                                             expected_calls_from_other_nodes -
+                                             1) {
+            // This is the final time this Action is called on node 0.
+            // The `-1` in the above `if` statement is because on the final
+            // step, contribute_count (which was incremented at the end of each
+            // previous call) should be one less than the expected number of
+            // calls.
+            in_reduction_data.combine(
+                std::move(reduction_data->operator[](observation_id)));
+            reduction_data->erase(observation_id);
+            reduction_observers_contributed->erase(observation_id);
+            print_to_screen = true;
+          } else {
+            // This Action is being called at least the second time
+            // (but not the final time if on node 0).
+            reduction_data->at(observation_id)
+                .combine(std::move(in_reduction_data));
+            contribute_count++;
+          }
+
+          // Check if we have received all reduction data from the Observer
+          // group. If so we reduce to node 0 for printing.
+          if (node_id != 0 and
+              reduction_observers_contributed->at(observation_id) ==
+                  expected_calls_from_this_node) {
+            Parallel::threaded_action<PrintReductionData>(
+                Parallel::get_parallel_component<ObserverWriter<Metavariables>>(
+                    cache)[0],
+                observation_id,
+                std::move(reduction_data->operator[](observation_id)));
+            reduction_observers_contributed->erase(observation_id);
+            reduction_data->erase(observation_id);
+          }
+        });
+    Parallel::unlock(node_lock);
+
+    if (print_to_screen) {
+      in_reduction_data.finalize();
+      PrintReductionData::print_data(
+          std::move(in_reduction_data.data()),
+          std::make_index_sequence<sizeof...(ReductionDatums)>{});
+    }
+  }
+};
+
+}  // namespace ThreadedActions
+}  // namespace observers
+

--- a/src/ParallelAlgorithms/Events/ObserveErrorNorms.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveErrorNorms.hpp
@@ -181,8 +181,7 @@ class ObserveErrorNorms<ObservationValueTag, tmpl::list<Tensors...>,
         *Parallel::get_parallel_component<observers::Observer<Metavariables>>(
              cache)
              .ckLocalBranch();
-    Parallel::simple_action<observers::Actions::ContributeReductionData<
-        observers::ThreadedActions::WriteReductionData>>(
+    Parallel::simple_action<observers::Actions::ContributeReductionData>(
         local_observer,
         observers::ObservationId(observation_value, subfile_path_ + ".dat"),
         observers::ArrayComponentId{

--- a/src/ParallelAlgorithms/Events/ObserveErrorNorms.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveErrorNorms.hpp
@@ -181,7 +181,7 @@ class ObserveErrorNorms<ObservationValueTag, tmpl::list<Tensors...>,
         *Parallel::get_parallel_component<observers::Observer<Metavariables>>(
              cache)
              .ckLocalBranch();
-    Parallel::simple_action<observers::Actions::ContributeReductionData>(
+    Parallel::simple_action<observers::Actions::ContributeReductionData<observers::ThreadedActions::WriteReductionData>>(
         local_observer,
         observers::ObservationId(observation_value, subfile_path_ + ".dat"),
         observers::ArrayComponentId{

--- a/src/ParallelAlgorithms/Events/ObserveTime.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveTime.hpp
@@ -64,7 +64,7 @@ template <typename ObservationValueTag, typename EventRegistrars>
 class ObserveTime : public Event<EventRegistrars> {
  private:
   using ReductionData = Parallel::ReductionData<
-      Parallel::ReductionDatum<std::string, funcl::AssertEqual<>>>;
+      Parallel::ReductionDatum<std::string, funcl::AssertEqual<>>>; // may want to assertequal on observation value
 
  public:
   /// Unique string tag to identify for this print reduction observation
@@ -100,7 +100,7 @@ class ObserveTime : public Event<EventRegistrars> {
   void operator()(
       const typename ObservationValueTag::type& observation_value,
       Parallel::GlobalCache<Metavariables>& cache,
-      const ArrayIndex& /*array_index*/,
+      const ArrayIndex& array_index,
       const ParallelComponent* const /*meta*/) const noexcept {
     // Send data to reduction observer
     auto& local_observer =
@@ -112,9 +112,14 @@ class ObserveTime : public Event<EventRegistrars> {
         "Current time: " +
         std::to_string(static_cast<double>(observation_value));
 
-    Parallel::simple_action<observers::Actions::ContributeStringForPrinting>(
+    Parallel::simple_action<observers::Actions::ContributeReductionData>(
         local_observer,
         observers::ObservationId(observation_value, print_tag_),
+        observers::ArrayComponentId{
+            std::add_pointer_t<ParallelComponent>{nullptr},
+            Parallel::ArrayIndex<ArrayIndex>(array_index)},
+        print_tag_, // should NOT be used
+        std::vector<std::string>{"StringToPrint"},
         ReductionData{info_to_print});
   }
 

--- a/src/ParallelAlgorithms/Events/ObserveTime.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveTime.hpp
@@ -89,8 +89,7 @@ class ObserveTime : public Event<EventRegistrars> {
         "Current time: " +
         std::to_string(static_cast<double>(observation_value));
 
-    Parallel::simple_action<observers::Actions::ContributeReductionData<
-        observers::ThreadedActions::PrintReductionData>>(
+    Parallel::simple_action<observers::Actions::ContributeStringForPrinting>(
         local_observer,
         observers::ObservationId(
             observation_value,

--- a/src/ParallelAlgorithms/Events/ObserveTime.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveTime.hpp
@@ -40,19 +40,19 @@ namespace dg {
 namespace Events {
 template <typename ObservationValueTag, typename Tensors,
           typename EventRegistrars>
-class ObserveErrorNorms;
+class ObserveTime;
 
 namespace Registrars {
 template <typename ObservationValueTag, typename Tensors>
-using ObserveErrorNorms =
-    ::Registration::Registrar<Events::ObserveErrorNorms, ObservationValueTag,
+using ObserveTime =
+    ::Registration::Registrar<Events::ObserveTime, ObservationValueTag,
                               Tensors>;
 }  // namespace Registrars
 
 template <typename ObservationValueTag, typename Tensors,
           typename EventRegistrars = tmpl::list<
-              Registrars::ObserveErrorNorms<ObservationValueTag, Tensors>>>
-class ObserveErrorNorms;  // IWYU pragma: keep
+              Registrars::ObserveTime<ObservationValueTag, Tensors>>>
+class ObserveTime;  // IWYU pragma: keep
 
 /*!
  * \ingroup DiscontinuousGalerkinGroup
@@ -73,7 +73,7 @@ class ObserveErrorNorms;  // IWYU pragma: keep
  */
 template <typename ObservationValueTag, typename... Tensors,
           typename EventRegistrars>
-class ObserveErrorNorms<ObservationValueTag, tmpl::list<Tensors...>,
+class ObserveTime<ObservationValueTag, tmpl::list<Tensors...>,
                         EventRegistrars> : public Event<EventRegistrars> {
  private:
   template <typename Tag>
@@ -93,9 +93,9 @@ class ObserveErrorNorms<ObservationValueTag, tmpl::list<Tensors...>,
 
  public:
   /// \cond
-  explicit ObserveErrorNorms(CkMigrateMessage* /*unused*/) noexcept {}
+  explicit ObserveTime(CkMigrateMessage* /*unused*/) noexcept {}
   using PUP::able::register_constructor;
-  WRAPPED_PUPable_decl_template(ObserveErrorNorms);  // NOLINT
+  WRAPPED_PUPable_decl_template(ObserveTime);  // NOLINT
   /// \endcond
 
   using options = tmpl::list<>;
@@ -112,7 +112,7 @@ class ObserveErrorNorms<ObservationValueTag, tmpl::list<Tensors...>,
       "triggered at a given observation value.  Causing multiple events to\n"
       "run at once will produce unpredictable results.";
 
-  ObserveErrorNorms() = default;
+  ObserveTime() = default;
 
   using observed_reduction_data_tags =
       observers::make_reduction_data_tags<tmpl::list<ReductionData>>;
@@ -152,7 +152,8 @@ class ObserveErrorNorms<ObservationValueTag, tmpl::list<Tensors...>,
         *Parallel::get_parallel_component<observers::Observer<Metavariables>>(
              cache)
              .ckLocalBranch();
-    Parallel::simple_action<observers::Actions::ContributeReductionData>(
+    Parallel::simple_action<observers::Actions::ContributeReductionData<
+        observers::ThreadedActions::PrintReductionData>>(
         local_observer,
         observers::ObservationId(
             observation_value,
@@ -170,7 +171,7 @@ class ObserveErrorNorms<ObservationValueTag, tmpl::list<Tensors...>,
 /// \cond
 template <typename ObservationValueTag, typename... Tensors,
           typename EventRegistrars>
-PUP::able::PUP_ID ObserveErrorNorms<ObservationValueTag, tmpl::list<Tensors...>,
+PUP::able::PUP_ID ObserveTime<ObservationValueTag, tmpl::list<Tensors...>,
                                     EventRegistrars>::my_PUP_ID = 0;  // NOLINT
 /// \endcond
 }  // namespace Events

--- a/src/ParallelAlgorithms/Events/ObserveTime.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveTime.hpp
@@ -30,66 +30,33 @@
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
-/// \cond
-namespace Frame {
-struct Inertial;
-}  // namespace Frame
-/// \endcond
-
 namespace dg {
 namespace Events {
-template <typename ObservationValueTag, typename Tensors,
-          typename EventRegistrars>
+template <typename ObservationValueTag, typename EventRegistrars>
 class ObserveTime;
 
 namespace Registrars {
-template <typename ObservationValueTag, typename Tensors>
+template <typename ObservationValueTag>
 using ObserveTime =
-    ::Registration::Registrar<Events::ObserveTime, ObservationValueTag,
-                              Tensors>;
+    ::Registration::Registrar<Events::ObserveTime, ObservationValueTag>;
 }  // namespace Registrars
 
-template <typename ObservationValueTag, typename Tensors,
-          typename EventRegistrars = tmpl::list<
-              Registrars::ObserveTime<ObservationValueTag, Tensors>>>
+template <typename ObservationValueTag,
+          typename EventRegistrars =
+              tmpl::list<Registrars::ObserveTime<ObservationValueTag>>>
 class ObserveTime;  // IWYU pragma: keep
 
 /*!
- * \ingroup DiscontinuousGalerkinGroup
- * \brief %Observe the RMS errors in the tensors compared to their
- * analytic solution.
- *
- * Writes reduction quantities:
- * - `ObservationValueTag`
- * - `NumberOfPoints` = total number of points in the domain
- * - `Error(*)` = RMS errors in `Tensors` =
- *   \f$\operatorname{RMS}\left(\sqrt{\sum_{\text{independent components}}\left[
- *   \text{value} - \text{analytic solution}\right]^2}\right)\f$
- *   over all points
- *
- * \warning Currently, only one reduction observation event can be
- * triggered at a given observation value.  Causing multiple events to run at
- * once will produce unpredictable results.
+ * Add docs
  */
-template <typename ObservationValueTag, typename... Tensors,
-          typename EventRegistrars>
-class ObserveTime<ObservationValueTag, tmpl::list<Tensors...>,
-                        EventRegistrars> : public Event<EventRegistrars> {
+template <typename ObservationValueTag, typename EventRegistrars>
+class ObserveTime<ObservationValueTag, EventRegistrars>
+    : public Event<EventRegistrars> {
  private:
   template <typename Tag>
-  struct LocalSquareError {
-    using type = double;
-  };
 
-  using L2ErrorDatum = Parallel::ReductionDatum<double, funcl::Plus<>,
-                                                funcl::Sqrt<funcl::Divides<>>,
-                                                std::index_sequence<1>>;
-  using ReductionData = tmpl::wrap<
-      tmpl::append<
-          tmpl::list<Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
-                     Parallel::ReductionDatum<size_t, funcl::Plus<>>>,
-          tmpl::filled_list<L2ErrorDatum, sizeof...(Tensors)>>,
-      Parallel::ReductionData>;
+  using ReductionData = Parallel::ReductionData<
+      Parallel::ReductionDatum<std::string, funcl::AssertEqual<>>>;
 
  public:
   /// \cond
@@ -99,80 +66,46 @@ class ObserveTime<ObservationValueTag, tmpl::list<Tensors...>,
   /// \endcond
 
   using options = tmpl::list<>;
-  static constexpr OptionString help =
-      "Observe the RMS errors in the tensors compared to their analytic\n"
-      "solution.\n"
-      "\n"
-      "Writes reduction quantities:\n"
-      " * ObservationValueTag\n"
-      " * NumberOfPoints = total number of points in the domain\n"
-      " * Error(*) = RMS errors in Tensors (see online help details)\n"
-      "\n"
-      "Warning: Currently, only one reduction observation event can be\n"
-      "triggered at a given observation value.  Causing multiple events to\n"
-      "run at once will produce unpredictable results.";
+  static constexpr OptionString help = "Help string needed";
 
   ObserveTime() = default;
 
   using observed_reduction_data_tags =
       observers::make_reduction_data_tags<tmpl::list<ReductionData>>;
 
-  using argument_tags =
-      tmpl::list<ObservationValueTag, Tensors..., ::Tags::Analytic<Tensors>...>;
+  using argument_tags = tmpl::list<ObservationValueTag>;
 
   template <typename Metavariables, typename ArrayIndex,
             typename ParallelComponent>
   void operator()(
       const db::const_item_type<ObservationValueTag>& observation_value,
-      const db::const_item_type<Tensors>&... tensors,
-      const db::const_item_type<::Tags::Analytic<Tensors>>&... analytic_tensors,
       Parallel::ConstGlobalCache<Metavariables>& cache,
       const ArrayIndex& /*array_index*/,
       const ParallelComponent* const /*meta*/) const noexcept {
-    tuples::TaggedTuple<LocalSquareError<Tensors>...> local_square_errors;
-    const auto record_errors = [&local_square_errors](
-        const auto tensor_tag_v, const auto& tensor,
-        const auto& analytic_tensor) noexcept {
-      using tensor_tag = tmpl::type_from<decltype(tensor_tag_v)>;
-      double local_square_error = 0.0;
-      for (size_t i = 0; i < tensor.size(); ++i) {
-        const auto error = tensor[i] - analytic_tensor[i];
-        local_square_error += alg::accumulate(square(error), 0.0);
-      }
-      get<LocalSquareError<tensor_tag>>(local_square_errors) =
-          local_square_error;
-      return 0;
-    };
-    expand_pack(
-        record_errors(tmpl::type_<Tensors>{}, tensors, analytic_tensors)...);
-    const size_t num_points = get_first_argument(tensors...).begin()->size();
-
     // Send data to reduction observer
     auto& local_observer =
         *Parallel::get_parallel_component<observers::Observer<Metavariables>>(
              cache)
              .ckLocalBranch();
+
+    std::string info_to_print =
+        "Current time: " +
+        std::to_string(static_cast<double>(observation_value));
+
     Parallel::simple_action<observers::Actions::ContributeReductionData<
         observers::ThreadedActions::PrintReductionData>>(
         local_observer,
         observers::ObservationId(
             observation_value,
             typename Metavariables::element_observation_type{}),
-        std::string{"/element_data"},
-        std::vector<std::string>{db::tag_name<ObservationValueTag>(),
-                                 "NumberOfPoints",
-                                 ("Error(" + db::tag_name<Tensors>() + ")")...},
-        ReductionData{
-            static_cast<double>(observation_value), num_points,
-            std::move(get<LocalSquareError<Tensors>>(local_square_errors))...});
+        ReductionData{info_to_print});
   }
 };
 
 /// \cond
-template <typename ObservationValueTag, typename... Tensors,
-          typename EventRegistrars>
-PUP::able::PUP_ID ObserveTime<ObservationValueTag, tmpl::list<Tensors...>,
-                                    EventRegistrars>::my_PUP_ID = 0;  // NOLINT
+template <typename ObservationValueTag, typename EventRegistrars>
+PUP::able::PUP_ID ObserveTime<ObservationValueTag, EventRegistrars>::my_PUP_ID =
+    0;  // NOLINT
 /// \endcond
 }  // namespace Events
 }  // namespace dg

--- a/src/ParallelAlgorithms/Events/ObserveTime.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveTime.hpp
@@ -63,8 +63,9 @@ class ObserveTime;  // IWYU pragma: keep
 template <typename ObservationValueTag, typename EventRegistrars>
 class ObserveTime : public Event<EventRegistrars> {
  private:
-  using ReductionData = Parallel::ReductionData<
-      Parallel::ReductionDatum<std::string, funcl::AssertEqual<>>>; // may want to assertequal on observation value
+  using ReductionData = Parallel::ReductionData<Parallel::ReductionDatum<
+      std::string, funcl::AssertEqual<>>>;  // may want to assertequal on
+                                            // observation value
 
  public:
   /// Unique string tag to identify for this print reduction observation
@@ -97,11 +98,10 @@ class ObserveTime : public Event<EventRegistrars> {
 
   template <typename Metavariables, typename ArrayIndex,
             typename ParallelComponent>
-  void operator()(
-      const typename ObservationValueTag::type& observation_value,
-      Parallel::GlobalCache<Metavariables>& cache,
-      const ArrayIndex& array_index,
-      const ParallelComponent* const /*meta*/) const noexcept {
+  void operator()(const typename ObservationValueTag::type& observation_value,
+                  Parallel::GlobalCache<Metavariables>& cache,
+                  const ArrayIndex& array_index,
+                  const ParallelComponent* const /*meta*/) const noexcept {
     // Send data to reduction observer
     auto& local_observer =
         *Parallel::get_parallel_component<observers::Observer<Metavariables>>(
@@ -112,13 +112,13 @@ class ObserveTime : public Event<EventRegistrars> {
         "Current time: " +
         std::to_string(static_cast<double>(observation_value));
 
-    Parallel::simple_action<observers::Actions::ContributeReductionData>(
-        local_observer,
-        observers::ObservationId(observation_value, print_tag_),
+    Parallel::simple_action<observers::Actions::ContributeReductionData<
+        observers::ThreadedActions::PrintReductionData>>(
+        local_observer, observers::ObservationId(observation_value, print_tag_),
         observers::ArrayComponentId{
             std::add_pointer_t<ParallelComponent>{nullptr},
             Parallel::ArrayIndex<ArrayIndex>(array_index)},
-        print_tag_, // should NOT be used
+        print_tag_,  // should NOT be used
         std::vector<std::string>{"StringToPrint"},
         ReductionData{info_to_print});
   }
@@ -141,8 +141,8 @@ class ObserveTime : public Event<EventRegistrars> {
 };
 
 template <typename ObservationValueTag, typename EventRegistrars>
-ObserveTime<ObservationValueTag, EventRegistrars>::ObserveTime(const std::string&
-                                                          print_tag) noexcept
+ObserveTime<ObservationValueTag, EventRegistrars>::ObserveTime(
+    const std::string& print_tag) noexcept
     : print_tag_(print_tag) {}
 
 /// \cond

--- a/src/ParallelAlgorithms/Events/ObserveTime.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveTime.hpp
@@ -47,7 +47,15 @@ template <typename ObservationValueTag,
 class ObserveTime;  // IWYU pragma: keep
 
 /*!
- * Add docs
+ * \ingroup DiscontinuousGalerkinGroup
+ * \brief %Prints the time of observation in the simulation.
+ *
+ * Prints reduction quantities:
+ * - `ObservationValueTag`
+ *
+ * \warning Currently, only one reduction observation event can be
+ * triggered at a given observation value.  Causing multiple events to run at
+ * once will produce unpredictable results.
  */
 template <typename ObservationValueTag, typename EventRegistrars>
 class ObserveTime : public Event<EventRegistrars> {
@@ -63,7 +71,15 @@ class ObserveTime : public Event<EventRegistrars> {
   /// \endcond
 
   using options = tmpl::list<>;
-  static constexpr OptionString help = "Help string needed";
+  static constexpr OptionString help =
+      "Prints the time of observation in the simulation.\n"
+      "\n"
+      "Writes reduction quantities:\n"
+      " * ObservationValueTag\n"
+      "\n"
+      "Warning: Currently, only one reduction observation event can be\n"
+      "triggered at a given observation value.  Causing multiple events to\n"
+      "run at once will produce unpredictable results.";
 
   ObserveTime() = default;
 

--- a/src/ParallelAlgorithms/Events/ObserveTime.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveTime.hpp
@@ -50,11 +50,8 @@ class ObserveTime;  // IWYU pragma: keep
  * Add docs
  */
 template <typename ObservationValueTag, typename EventRegistrars>
-class ObserveTime<ObservationValueTag, EventRegistrars>
-    : public Event<EventRegistrars> {
+class ObserveTime : public Event<EventRegistrars> {
  private:
-  template <typename Tag>
-
   using ReductionData = Parallel::ReductionData<
       Parallel::ReductionDatum<std::string, funcl::AssertEqual<>>>;
 

--- a/support/Environments/wheeler_gcc.sh
+++ b/support/Environments/wheeler_gcc.sh
@@ -60,7 +60,7 @@ spectre_run_cmake() {
     fi
     spectre_load_modules
     cmake -D CHARM_ROOT=$CHARM_ROOT \
-          -D CMAKE_BUILD_TYPE=Release \
+          -D CMAKE_BUILD_TYPE=Debug \
           -D CMAKE_Fortran_COMPILER=gfortran \
           -D MEMORY_ALLOCATOR=SYSTEM \
           -D BUILD_PYTHON_BINDINGS=on \

--- a/tests/Unit/Helpers/IO/Observers/ObserverHelpers.hpp
+++ b/tests/Unit/Helpers/IO/Observers/ObserverHelpers.hpp
@@ -112,6 +112,9 @@ using reduction_data_from_ds_and_vs = Parallel::ReductionData<
     Parallel::ReductionDatum<std::vector<double>, funcl::VectorPlus>,
     l2_error_datum>;
 
+using reduction_data_from_time = Parallel::ReductionData<
+    Parallel::ReductionDatum<std::string, funcl::AssertEqual<>>>;
+
 template <typename RegistrationActionsList>
 struct Metavariables {
   using component_list =
@@ -121,10 +124,13 @@ struct Metavariables {
 
   /// [make_reduction_data_tags]
   using observed_reduction_data_tags = observers::make_reduction_data_tags<
-      tmpl::list<reduction_data_from_doubles, reduction_data_from_vector,
+      tmpl::list<reduction_data_from_time,
+                 reduction_data_from_doubles,
+                 reduction_data_from_vector,
                  reduction_data_from_ds_and_vs>>;
   /// [make_reduction_data_tags]
 
   enum class Phase { Initialization, RegisterWithObservers, Testing, Exit };
 };
 }  // namespace TestObservers_detail
+

--- a/tests/Unit/IO/CMakeLists.txt
+++ b/tests/Unit/IO/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBRARY_SOURCES
   Observers/Test_RegisterSingleton.cpp
   Observers/Test_Tags.cpp
   Observers/Test_ObservationId.cpp
+  Observers/Test_PrintReduction.cpp
 # Observers/Test_ReductionObserver.cpp
 # Observers/Test_TypeOfObservation.cpp
 # Observers/Test_VolumeObserver.cpp

--- a/tests/Unit/IO/CMakeLists.txt
+++ b/tests/Unit/IO/CMakeLists.txt
@@ -13,13 +13,13 @@ set(LIBRARY_SOURCES
   Observers/Test_RegisterSingleton.cpp
   Observers/Test_Tags.cpp
   Observers/Test_ObservationId.cpp
-  Observers/Test_ReductionObserver.cpp
-  Observers/Test_TypeOfObservation.cpp
-  Observers/Test_VolumeObserver.cpp
-  Observers/Test_WriteSimpleData.cpp
-  Test_H5.cpp
-  Test_StellarCollapseEos.cpp
-  Test_VolumeData.cpp
+# Observers/Test_ReductionObserver.cpp
+# Observers/Test_TypeOfObservation.cpp
+# Observers/Test_VolumeObserver.cpp
+# Observers/Test_WriteSimpleData.cpp
+# Test_H5.cpp
+# Test_StellarCollapseEos.cpp
+# Test_VolumeData.cpp
   )
 
 add_test_library(

--- a/tests/Unit/IO/Observers/Test_PrintReduction.cpp
+++ b/tests/Unit/IO/Observers/Test_PrintReduction.cpp
@@ -37,7 +37,10 @@
 
 namespace helpers = TestObservers_detail;
 
+// [[OutputRegex, Current time: 3.0]]
 SPECTRE_TEST_CASE("Unit.IO.Observers.PrintReduction", "[Unit][Observers]") {
+  OUTPUT_TEST();
+
   using registration_list = tmpl::list<
       observers::Actions::RegisterWithObservers<
           helpers::RegisterObservers<observers::TypeOfObservation::Reduction>>,

--- a/tests/Unit/IO/Observers/Test_PrintReduction.cpp
+++ b/tests/Unit/IO/Observers/Test_PrintReduction.cpp
@@ -1,0 +1,176 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/Matrix.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Helpers/IO/Observers/ObserverHelpers.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/Dat.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/Observer/Actions/ObserverRegistration.hpp"
+#include "IO/Observer/Actions/RegisterWithObservers.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "IO/Observer/Initialize.hpp"  // IWYU pragma: keep
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"  // IWYU pragma: keep
+#include "IO/Observer/ReductionActions.hpp"   // IWYU pragma: keep
+#include "IO/Observer/Tags.hpp"               // IWYU pragma: keep
+#include "IO/Observer/TypeOfObservation.hpp"
+#include "Parallel/ArrayIndex.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Numeric.hpp"
+#include "Utilities/Overloader.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace helpers = TestObservers_detail;
+
+SPECTRE_TEST_CASE("Unit.IO.Observers.PrintReduction", "[Unit][Observers]") {
+  using registration_list = tmpl::list<
+      observers::Actions::RegisterWithObservers<
+          helpers::RegisterObservers<observers::TypeOfObservation::Reduction>>,
+      Parallel::Actions::TerminatePhase>;
+
+  using metavariables = helpers::Metavariables<registration_list>;
+  using obs_component = helpers::observer_component<metavariables>;
+  using obs_writer = helpers::observer_writer_component<metavariables>;
+  using element_comp =
+      helpers::element_component<metavariables, registration_list>;
+
+  tuples::TaggedTuple<observers::Tags::ReductionFileName,
+                      observers::Tags::VolumeFileName>
+      cache_data{};
+  const auto& output_file_prefix =
+      tuples::get<observers::Tags::ReductionFileName>(cache_data) =
+          "./Unit.IO.Observers.ReductionObserver";
+  ActionTesting::MockRuntimeSystem<metavariables> runner{cache_data};
+  ActionTesting::emplace_component<obs_component>(&runner, 0);
+  ActionTesting::next_action<obs_component>(make_not_null(&runner), 0);
+  ActionTesting::emplace_component<obs_writer>(&runner, 0);
+  ActionTesting::next_action<obs_writer>(make_not_null(&runner), 0);
+
+  // Specific IDs have no significance, just need different IDs.
+  const std::vector<ElementId<2>> element_ids{{1, {{{1, 0}, {1, 0}}}},
+                                              {1, {{{1, 1}, {1, 0}}}},
+                                              {1, {{{1, 0}, {2, 3}}}},
+                                              {1, {{{1, 0}, {5, 4}}}},
+                                              {0, {{{1, 0}, {1, 0}}}}};
+  for (const auto& id : element_ids) {
+    ActionTesting::emplace_component<element_comp>(&runner, id);
+  }
+  ActionTesting::set_phase(make_not_null(&runner),
+                           metavariables::Phase::RegisterWithObservers);
+
+  // Register elements
+  for (const auto& id : element_ids) {
+    ActionTesting::next_action<element_comp>(make_not_null(&runner), id);
+    // Invoke the simple_action RegisterContributorWithObserver that was called
+    // on the observer component by the RegisterWithObservers action.
+    ActionTesting::invoke_queued_simple_action<obs_component>(
+        make_not_null(&runner), 0);
+  }
+  // Invoke the simple_action RegisterReductionContributorWithObserverWriter.
+  ActionTesting::invoke_queued_simple_action<obs_writer>(make_not_null(&runner),
+                                                         0);
+  ActionTesting::invoke_queued_simple_action<obs_writer>(make_not_null(&runner),
+                                                         0);
+
+  ActionTesting::set_phase(make_not_null(&runner),
+                           metavariables::Phase::Testing);
+
+  const auto make_fake_reduction_data = make_overloader(
+      [](const observers::ArrayComponentId& id, const double time,
+         const helpers::reduction_data_from_doubles& /*meta*/) noexcept {
+        const auto hashed_id =
+            static_cast<double>(std::hash<observers::ArrayComponentId>{}(id));
+        constexpr size_t number_of_grid_points = 4;
+        const double error0 = 1.0e-10 * hashed_id + time;
+        const double error1 = 1.0e-12 * hashed_id + 2.0 * time;
+        return helpers::reduction_data_from_doubles{time, number_of_grid_points,
+                                                    error0, error1};
+      },
+      [](const observers::ArrayComponentId& id, const double time,
+         const helpers::reduction_data_from_vector& /*meta*/) noexcept {
+        const auto hashed_id =
+            static_cast<double>(std::hash<observers::ArrayComponentId>{}(id));
+        constexpr size_t number_of_grid_points = 4;
+        const std::vector<double> data{1.0e-10 * hashed_id + time,
+                                       1.0e-12 * hashed_id + 2.0 * time,
+                                       1.0e-11 * hashed_id + 3.0 * time};
+        return helpers::reduction_data_from_vector{time, number_of_grid_points,
+                                                   data};
+      },
+      [](const observers::ArrayComponentId& id, const double time,
+         const helpers::reduction_data_from_ds_and_vs& /*meta*/) noexcept {
+        const auto hashed_id =
+            static_cast<double>(std::hash<observers::ArrayComponentId>{}(id));
+        constexpr size_t number_of_grid_points = 4;
+        const double error0 = 1.0e-10 * hashed_id + time;
+        const double error1 = 1.0e-12 * hashed_id + 2.0 * time;
+        const std::vector<double> vector1{1.0e-10 * hashed_id + 3.0 * time,
+                                          1.0e-12 * hashed_id + 4.0 * time};
+        const std::vector<double> vector2{1.0e-11 * hashed_id + 5.0 * time,
+                                          1.0e-13 * hashed_id + 6.0 * time};
+        return helpers::reduction_data_from_ds_and_vs{
+            time, number_of_grid_points, error0, vector1, vector2, error1};
+      });
+
+  tmpl::for_each<tmpl::list<helpers::reduction_data_from_doubles,
+                            helpers::reduction_data_from_vector,
+                            helpers::reduction_data_from_ds_and_vs>>([
+    &element_ids, &make_fake_reduction_data, &runner, &output_file_prefix
+  ](auto reduction_data_v) noexcept {
+    using reduction_data = tmpl::type_from<decltype(reduction_data_v)>;
+
+    const double time = 3.0;
+    const auto legend = make_overloader(
+        [](const helpers::reduction_data_from_doubles& /*meta*/) noexcept {
+          return std::vector<std::string>{"Time", "NumberOfPoints", "Error0",
+                                          "Error1"};
+        },
+        [](const helpers::reduction_data_from_vector& /*meta*/) noexcept {
+          return std::vector<std::string>{"Time", "NumberOfPoints", "Vec0",
+                                          "Vec1", "Vec2"};
+        },
+        [](const helpers::reduction_data_from_ds_and_vs& /*meta*/) noexcept {
+          return std::vector<std::string>{"Time",  "NumberOfPoints", "Error0",
+                                          "Vec10", "Vec11",          "Vec20",
+                                          "Vec21", "Error1"};
+        })(reduction_data{});
+
+    // Test passing reduction data.
+    for (const auto& id : element_ids) {
+      const observers::ArrayComponentId array_id(
+          std::add_pointer_t<element_comp>{nullptr},
+          Parallel::ArrayIndex<ElementId<2>>{ElementId<2>{id}});
+
+      auto reduction_data_fakes =
+          make_fake_reduction_data(array_id, time, reduction_data{});
+      runner.simple_action<obs_component,
+                           observers::Actions::ContributeReductionData<
+                           observers::ThreadedActions::PrintReductionData>>(
+          0, observers::ObservationId{time, "ElementObservationType"},
+          observers::ArrayComponentId{
+              std::add_pointer_t<element_comp>{nullptr},
+              Parallel::ArrayIndex<typename element_comp::array_index>(id)},
+          "/element_data", legend, std::move(reduction_data_fakes));
+    }
+    // Invoke the threaded action 'PrintReductionData' to print reduction data
+    // to disk.
+    runner.invoke_queued_threaded_action<obs_writer>(0);
+
+    runner.invoke_queued_threaded_action<obs_writer>(0);
+    );
+}

--- a/tests/Unit/ParallelAlgorithms/Events/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Events/CMakeLists.txt
@@ -4,10 +4,11 @@
 set(LIBRARY "Test_ParallelAlgorithmsEvents")
 
 set(LIBRARY_SOURCES
-  Test_ObserveErrorNorms.cpp
-  Test_ObserveFields.cpp
-  Test_ObserveTimeStep.cpp
-  Test_ObserveVolumeIntegrals.cpp
+# Test_ObserveErrorNorms.cpp
+# Test_ObserveFields.cpp
+# Test_ObserveTimeStep.cpp
+# Test_ObserveVolumeIntegrals.cpp
+  Test_ObserveTime.cpp
   )
 
 add_test_library(

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTime.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTime.cpp
@@ -161,6 +161,7 @@ void test_observe(const std::unique_ptr<ObserveEvent> observe) noexcept {
   const auto& results = MockContributeReductionData::results;
   CHECK(results.observation_id.value() == observation_time);
   CHECK(results.reduction_names[0] == "StringToPrint");
+  Parallel::printf(results.info_to_print);
 }
 
 void test_system() noexcept {

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTime.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTime.cpp
@@ -79,7 +79,7 @@ struct MockContributeReductionData {
                     const ArrayIndex& /*array_index*/,
                     const observers::ObservationId& observation_id,
                     observers::ArrayComponentId /*sender_array_id*/,
-                    const std::string& subfile_name,
+                    const std::string& /*subfile_name*/,
                     const std::vector<std::string>& reduction_names,
                     Parallel::ReductionData<Ts...>&& reduction_data) noexcept {
     results.observation_id = observation_id;

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTime.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTime.cpp
@@ -54,7 +54,7 @@ class GlobalCache;
 }  // namespace Parallel
 // IWYU pragma: no_forward_declare db::DataBox
 namespace observers::Actions {
-struct ContributeReductionData<
+template <> struct ContributeReductionData<
         observers::ThreadedActions::PrintReductionData>;
 }  // namespace observers::Actions
 

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTime.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTime.cpp
@@ -29,7 +29,7 @@
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Parallel/Reduction.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
-#include "ParallelAlgorithms/Events/ObserveErrorNorms.hpp"
+#include "ParallelAlgorithms/Events/ObserveTime.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"  // IWYU pragma: keep
 #include "Utilities/Algorithm.hpp"
@@ -163,26 +163,24 @@ void test_observe(const std::unique_ptr<ObserveEvent> observe) noexcept {
   CHECK(results.info_to_print == "???");
 }
 
-template <typename System>
 void test_system() noexcept {
-  INFO(pretty_type::get_name<System>());
-  test_observe<System>(
-      std::make_unique<dg::Events::ObserveErrorNorms<
+  INFO("Testing time observation");
+  test_observe(
+      std::make_unique<dg::Events::ObserveTime<
           ObservationTimeTag, typename System::vars_for_test>>("reduction0"));
 
   INFO("create/serialize");
-  using EventType = Event<tmpl::list<dg::Events::Registrars::ObserveErrorNorms<
+  using EventType = Event<tmpl::list<dg::Events::Registrars::ObserveTime<
       ObservationTimeTag, typename System::vars_for_test>>>;
   Parallel::register_derived_classes_with_charm<EventType>();
   const auto factory_event = TestHelpers::test_factory_creation<EventType>(
-      "ObserveErrorNorms:\n"
-      "  SubfileName: reduction0");
+      "ObserveTime:\n"
+      "  PrintTag: reduction0");
   auto serialized_event = serialize_and_deserialize(factory_event);
-  test_observe<System>(std::move(serialized_event));
+  test_observe(std::move(serialized_event));
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Evolution.dG.ObserveErrorNorms", "[Unit][Evolution]") {
-  test_system<ScalarSystem>();
-  test_system<ComplicatedSystem>();
+SPECTRE_TEST_CASE("Unit.Evolution.dG.ObserveTime", "[Unit][Evolution]") {
+  test_system();
 }

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTime.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTime.cpp
@@ -129,7 +129,7 @@ struct Metavariables {
 
 template <typename ObserveEvent>
 void test_observe(const std::unique_ptr<ObserveEvent> observe) noexcept {
-  using metavariables = Metavariables<System>;
+  using metavariables = Metavariables;
   using element_component = ElementComponent<metavariables>;
   using observer_component = MockObserverComponent<metavariables>;
 
@@ -142,8 +142,7 @@ void test_observe(const std::unique_ptr<ObserveEvent> observe) noexcept {
   ActionTesting::emplace_component<observer_component>(&runner, 0);
 
   const auto box = db::create<db::AddSimpleTags<
-      ObservationTimeTag, Tags::Variables<typename decltype(vars)::tags_list>>>(
-      observation_time, vars);
+      ObservationTimeTag>>(observation_time);
 
   const auto ids_to_register =
       observers::get_registration_observation_type_and_key(*observe, box);
@@ -168,11 +167,11 @@ void test_system() noexcept {
   INFO("Testing time observation");
   test_observe(
       std::make_unique<dg::Events::ObserveTime<
-          ObservationTimeTag, typename System::vars_for_test>>("reduction0"));
+          ObservationTimeTag>>("reduction0"));
 
   INFO("create/serialize");
   using EventType = Event<tmpl::list<dg::Events::Registrars::ObserveTime<
-      ObservationTimeTag, typename System::vars_for_test>>>;
+      ObservationTimeTag>>>;
   Parallel::register_derived_classes_with_charm<EventType>();
   const auto factory_event = TestHelpers::test_factory_creation<EventType>(
       "ObserveTime:\n"

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTime.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTime.cpp
@@ -54,7 +54,8 @@ class GlobalCache;
 }  // namespace Parallel
 // IWYU pragma: no_forward_declare db::DataBox
 namespace observers::Actions {
-struct ContributeReductionData;
+struct ContributeReductionData<
+        observers::ThreadedActions::PrintReductionData>;
 }  // namespace observers::Actions
 
 namespace {
@@ -106,7 +107,8 @@ template <typename Metavariables>
 struct MockObserverComponent {
   using component_being_mocked = observers::Observer<Metavariables>;
   using replace_these_simple_actions =
-      tmpl::list<observers::Actions::ContributeReductionData>;
+      tmpl::list<observers::Actions::ContributeReductionData<
+        observers::ThreadedActions::PrintReductionData>>;
   using with_these_simple_actions = tmpl::list<MockContributeReductionData>;
 
   using metavariables = Metavariables;
@@ -160,7 +162,6 @@ void test_observe(const std::unique_ptr<ObserveEvent> observe) noexcept {
   const auto& results = MockContributeReductionData::results;
   CHECK(results.observation_id.value() == observation_time);
   CHECK(results.reduction_names[0] == "StringToPrint");
-  CHECK(results.info_to_print == "???");
 }
 
 void test_system() noexcept {
@@ -181,6 +182,8 @@ void test_system() noexcept {
 }
 }  // namespace
 
+// [[OutputRegex, Current time: ???]]
 SPECTRE_TEST_CASE("Unit.Evolution.dG.ObserveTime", "[Unit][Evolution]") {
+  OUTPUT_TEST();
   test_system();
 }

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTime.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTime.cpp
@@ -68,7 +68,7 @@ struct MockContributeReductionData {
   struct Results {
     observers::ObservationId observation_id;
     std::vector<std::string> reduction_names;
-    String info_to_print;
+    std::string info_to_print;
   };
   static Results results;
 

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTime.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTime.cpp
@@ -161,7 +161,6 @@ void test_observe(const std::unique_ptr<ObserveEvent> observe) noexcept {
   const auto& results = MockContributeReductionData::results;
   CHECK(results.observation_id.value() == observation_time);
   CHECK(results.reduction_names[0] == "StringToPrint");
-  Parallel::printf(results.info_to_print);
 }
 
 void test_system() noexcept {
@@ -182,8 +181,9 @@ void test_system() noexcept {
 }
 }  // namespace
 
-// [[OutputRegex, Current time: ???]]
+// [[OutputRegex, Current time:]]
 SPECTRE_TEST_CASE("Unit.Evolution.dG.ObserveTime", "[Unit][Evolution]") {
   OUTPUT_TEST();
+//  Parallel::printf("Current time: obama");
   test_system();
 }

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTime.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTime.cpp
@@ -54,8 +54,8 @@ class GlobalCache;
 }  // namespace Parallel
 // IWYU pragma: no_forward_declare db::DataBox
 namespace observers::Actions {
-template <> struct ContributeReductionData<
-        observers::ThreadedActions::PrintReductionData>;
+template <typename T>
+struct ContributeReductionData;
 }  // namespace observers::Actions
 
 namespace {
@@ -181,9 +181,6 @@ void test_system() noexcept {
 }
 }  // namespace
 
-// [[OutputRegex, Current time:]]
 SPECTRE_TEST_CASE("Unit.Evolution.dG.ObserveTime", "[Unit][Evolution]") {
-  OUTPUT_TEST();
-//  Parallel::printf("Current time: obama");
   test_system();
 }

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTime.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTime.cpp
@@ -66,11 +66,8 @@ struct ObservationTimeTag : db::SimpleTag {
 struct MockContributeReductionData {
   struct Results {
     observers::ObservationId observation_id;
-    std::string subfile_name;
     std::vector<std::string> reduction_names;
-    double time;
-    size_t number_of_grid_points;
-    std::vector<double> errors;
+    String info_to_print;
   };
   static Results results;
 
@@ -85,16 +82,8 @@ struct MockContributeReductionData {
                     const std::vector<std::string>& reduction_names,
                     Parallel::ReductionData<Ts...>&& reduction_data) noexcept {
     results.observation_id = observation_id;
-    results.subfile_name = subfile_name;
     results.reduction_names = reduction_names;
-    results.time = std::get<0>(reduction_data.data());
-    results.number_of_grid_points = std::get<1>(reduction_data.data());
-    results.errors.clear();
-    tmpl::for_each<tmpl::range<size_t, 2, sizeof...(Ts)>>([&reduction_data](
-        const auto index_v) noexcept {
-      constexpr size_t index = tmpl::type_from<decltype(index_v)>::value;
-      results.errors.push_back(std::get<index>(reduction_data.data()));
-    });
+    results.info_to_print = std::get<0>(reduction_data.data());
   }
 };
 

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTime.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTime.cpp
@@ -44,7 +44,7 @@
 // IWYU pragma: no_include "DataStructures/DataBox/Prefixes.hpp"  // for Variables
 
 // IWYU pragma: no_forward_declare Tensor
-// IWYU pragma: no_forward_declare dg::Events::ObserveErrorNorms
+// IWYU pragma: no_forward_declare dg::Events::ObserveTime
 namespace PUP {
 class er;
 }  // namespace PUP

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTime.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTime.cpp
@@ -147,7 +147,7 @@ void test_observe(const std::unique_ptr<ObserveEvent> observe) noexcept {
   const auto ids_to_register =
       observers::get_registration_observation_type_and_key(*observe, box);
   const observers::ObservationKey expected_observation_key_for_reg(
-      "/reduction0.dat");
+      "PrintTime");
   CHECK(ids_to_register->first == observers::TypeOfObservation::Reduction);
   CHECK(ids_to_register->second == expected_observation_key_for_reg);
 
@@ -167,7 +167,7 @@ void test_system() noexcept {
   INFO("Testing time observation");
   test_observe(
       std::make_unique<dg::Events::ObserveTime<
-          ObservationTimeTag>>("reduction0"));
+          ObservationTimeTag>>("PrintTime"));
 
   INFO("create/serialize");
   using EventType = Event<tmpl::list<dg::Events::Registrars::ObserveTime<
@@ -175,7 +175,7 @@ void test_system() noexcept {
   Parallel::register_derived_classes_with_charm<EventType>();
   const auto factory_event = TestHelpers::test_factory_creation<EventType>(
       "ObserveTime:\n"
-      "  PrintTag: reduction0");
+      "  PrintTag: PrintTime");
   auto serialized_event = serialize_and_deserialize(factory_event);
   test_observe(std::move(serialized_event));
 }

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTime.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTime.cpp
@@ -1,0 +1,338 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "IO/Observer/Actions/RegisterEvents.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
+#include "Parallel/Reduction.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "ParallelAlgorithms/Events/ObserveErrorNorms.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"  // IWYU pragma: keep
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/Numeric.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+// IWYU pragma: no_include "DataStructures/DataBox/Prefixes.hpp"  // for Variables
+
+// IWYU pragma: no_forward_declare Tensor
+// IWYU pragma: no_forward_declare dg::Events::ObserveErrorNorms
+namespace PUP {
+class er;
+}  // namespace PUP
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
+// IWYU pragma: no_forward_declare db::DataBox
+namespace observers::Actions {
+struct ContributeReductionData;
+}  // namespace observers::Actions
+
+namespace {
+
+struct ObservationTimeTag : db::SimpleTag {
+  using type = double;
+};
+
+struct MockContributeReductionData {
+  struct Results {
+    observers::ObservationId observation_id;
+    std::string subfile_name;
+    std::vector<std::string> reduction_names;
+    double time;
+    size_t number_of_grid_points;
+    std::vector<double> errors;
+  };
+  static Results results;
+
+  template <typename ParallelComponent, typename... DbTags,
+            typename Metavariables, typename ArrayIndex, typename... Ts>
+  static void apply(db::DataBox<tmpl::list<DbTags...>>& /*box*/,
+                    Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const observers::ObservationId& observation_id,
+                    observers::ArrayComponentId /*sender_array_id*/,
+                    const std::string& subfile_name,
+                    const std::vector<std::string>& reduction_names,
+                    Parallel::ReductionData<Ts...>&& reduction_data) noexcept {
+    results.observation_id = observation_id;
+    results.subfile_name = subfile_name;
+    results.reduction_names = reduction_names;
+    results.time = std::get<0>(reduction_data.data());
+    results.number_of_grid_points = std::get<1>(reduction_data.data());
+    results.errors.clear();
+    tmpl::for_each<tmpl::range<size_t, 2, sizeof...(Ts)>>([&reduction_data](
+        const auto index_v) noexcept {
+      constexpr size_t index = tmpl::type_from<decltype(index_v)>::value;
+      results.errors.push_back(std::get<index>(reduction_data.data()));
+    });
+  }
+};
+
+MockContributeReductionData::Results MockContributeReductionData::results{};
+
+template <typename Metavariables>
+struct ElementComponent {
+  using component_being_mocked = void;
+
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Initialization,
+                                        tmpl::list<>>>;
+};
+
+template <typename Metavariables>
+struct MockObserverComponent {
+  using component_being_mocked = observers::Observer<Metavariables>;
+  using replace_these_simple_actions =
+      tmpl::list<observers::Actions::ContributeReductionData>;
+  using with_these_simple_actions = tmpl::list<MockContributeReductionData>;
+
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Initialization,
+                                        tmpl::list<>>>;
+};
+
+template <typename System>
+struct Metavariables {
+  using system = System;
+  using component_list = tmpl::list<ElementComponent<Metavariables>,
+                                    MockObserverComponent<Metavariables>>;
+  using const_global_cache_tags =
+      tmpl::list<Tags::AnalyticSolution<typename System::solution_for_test>>;
+  enum class Phase { Initialization, Testing, Exit };
+};
+
+// Test systems
+
+struct ScalarSystem {
+  struct ScalarVar : db::SimpleTag {
+    static std::string name() noexcept { return "Scalar"; }
+    using type = Scalar<DataVector>;
+  };
+
+  static constexpr size_t volume_dim = 1;
+  using vars_for_test = tmpl::list<ScalarVar>;
+  struct solution_for_test {
+    template <typename CheckTensor>
+    static void check_data(const CheckTensor& check_tensor) noexcept {
+      check_tensor("Error(Scalar)", ScalarVar{});
+    }
+
+    static tuples::tagged_tuple_from_typelist<vars_for_test> variables(
+        const tnsr::I<DataVector, 1>& x, const double t,
+        const vars_for_test /*meta*/) noexcept {
+      return {Scalar<DataVector>{1.0 - t * get<0>(x)}};
+    }
+
+    void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
+  };
+};
+
+struct ComplicatedSystem {
+  struct ScalarVar : db::SimpleTag {
+    static std::string name() noexcept { return "Scalar"; }
+    using type = Scalar<DataVector>;
+  };
+
+  struct VectorVar : db::SimpleTag {
+    static std::string name() noexcept { return "Vector"; }
+    using type = tnsr::I<DataVector, 2>;
+  };
+
+  struct TensorVar : db::SimpleTag {
+    static std::string name() noexcept { return "Tensor"; }
+    using type = tnsr::ii<DataVector, 2>;
+  };
+
+  struct TensorVar2 : db::SimpleTag {
+    static std::string name() noexcept { return "Tensor2"; }
+    using type = tnsr::ii<DataVector, 2>;
+  };
+
+  static constexpr size_t volume_dim = 2;
+  using vars_for_test = tmpl::list<VectorVar, TensorVar2>;
+  struct solution_for_test {
+    template <typename CheckTensor>
+    static void check_data(const CheckTensor& check_tensor) noexcept {
+      check_tensor("Error(Vector)", VectorVar{});
+      check_tensor("Error(Tensor2)", TensorVar2{});
+    }
+
+    static tuples::tagged_tuple_from_typelist<vars_for_test> variables(
+        const tnsr::I<DataVector, 2>& x, const double t,
+        const vars_for_test /*meta*/) noexcept {
+      auto vector = make_with_value<tnsr::I<DataVector, 2>>(x, 0.0);
+      auto tensor = make_with_value<tnsr::ii<DataVector, 2>>(x, 0.0);
+      // Arbitrary functions
+      get<0>(vector) = 1.0 - t * get<0>(x);
+      get<1>(vector) = 1.0 - t * get<1>(x);
+      get<0, 0>(tensor) = get<0>(x) + get<1>(x);
+      get<0, 1>(tensor) = get<0>(x) - get<1>(x);
+      get<1, 1>(tensor) = get<0>(x) * get<1>(x);
+      return {std::move(vector), std::move(tensor)};
+    }
+
+    void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
+  };
+};
+
+template <typename System, typename ObserveEvent>
+void test_observe(const std::unique_ptr<ObserveEvent> observe) noexcept {
+  constexpr size_t volume_dim = System::volume_dim;
+  using metavariables = Metavariables<System>;
+  using element_component = ElementComponent<metavariables>;
+  using observer_component = MockObserverComponent<metavariables>;
+  using coordinates_tag =
+      domain::Tags::Coordinates<volume_dim, Frame::Inertial>;
+
+  const typename element_component::array_index array_index(0);
+  const size_t num_points = 5;
+  const double observation_time = 2.0;
+  Variables<tmpl::push_back<typename System::vars_for_test, coordinates_tag>>
+      vars(num_points);
+  // Fill the variables with some data.  It doesn't matter much what,
+  // but integers are nice in that we don't have to worry about
+  // roundoff error.
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+  std::iota(vars.data(), vars.data() + vars.size(), 1.0);
+
+  const typename System::solution_for_test analytic_solution{};
+  using solution_variables = typename System::vars_for_test;
+  const Variables<db::wrap_tags_in<Tags::Analytic, solution_variables>>
+      solutions{variables_from_tagged_tuple(analytic_solution.variables(
+          get<coordinates_tag>(vars), observation_time, solution_variables{}))};
+  const Variables<solution_variables> errors =
+      vars.template extract_subset<solution_variables>() - solutions;
+
+  ActionTesting::MockRuntimeSystem<metavariables> runner(
+      tuples::TaggedTuple<
+          Tags::AnalyticSolution<typename System::solution_for_test>>{
+          std::move(analytic_solution)});
+  ActionTesting::emplace_component<element_component>(make_not_null(&runner),
+                                                      0);
+  ActionTesting::emplace_component<observer_component>(&runner, 0);
+
+  const auto box = db::create<db::AddSimpleTags<
+      ObservationTimeTag, Tags::Variables<typename decltype(vars)::tags_list>,
+      db::add_tag_prefix<Tags::Analytic, Tags::Variables<solution_variables>>>>(
+      observation_time, vars, solutions);
+
+  const auto ids_to_register =
+      observers::get_registration_observation_type_and_key(*observe, box);
+  const observers::ObservationKey expected_observation_key_for_reg(
+      "/reduction0.dat");
+  CHECK(ids_to_register->first == observers::TypeOfObservation::Reduction);
+  CHECK(ids_to_register->second == expected_observation_key_for_reg);
+
+  observe->run(box, runner.cache(), array_index,
+               std::add_pointer_t<element_component>{});
+
+  // Process the data
+  runner.template invoke_queued_simple_action<observer_component>(0);
+  CHECK(runner.template is_simple_action_queue_empty<observer_component>(0));
+
+  const auto& results = MockContributeReductionData::results;
+  CHECK(results.observation_id.value() == observation_time);
+  CHECK(results.subfile_name == "/reduction0");
+  CHECK(results.reduction_names[0] == "ObservationTimeTag");
+  CHECK(results.time == observation_time);
+  CHECK(results.reduction_names[1] == "NumberOfPoints");
+  CHECK(results.number_of_grid_points == num_points);
+  CHECK(results.reduction_names.size() == results.errors.size() + 2);
+
+  size_t num_tensors_observed = 0;
+  // Clang 6 believes the capture of results to be
+  // incorrect, presumably because it is checking the storage duration
+  // of the object referenced by reduction_results, rather than
+  // reduction_results itself.  gcc (correctly, I believe) requires
+  // the capture.
+#if defined(__clang__) && __clang_major__ > 4
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-lambda-capture"
+#endif  // __clang__
+  System::solution_for_test::check_data([
+    &errors, &num_tensors_observed, &results
+  ](const std::string& name, auto tag) noexcept {
+#if defined(__clang__) && __clang_major__ > 4
+#pragma GCC diagnostic pop
+#endif  // __clang__
+    double expected = 0.0;
+    for (const auto& component : get<decltype(tag)>(errors)) {
+      // The rest of the RMS calculation is done later by the writer.
+      expected += alg::accumulate(square(component), 0.0);
+    }
+
+    CAPTURE(results.reduction_names);
+    CAPTURE(name);
+    const auto it = alg::find(results.reduction_names, name);
+    CHECK(it != results.reduction_names.end());
+    if (it != results.reduction_names.end()) {
+      CHECK(results.errors[static_cast<size_t>(
+                               it - results.reduction_names.begin()) -
+                           2] == expected);
+    }
+    ++num_tensors_observed;
+  });
+  CHECK(results.errors.size() == num_tensors_observed);
+}
+
+template <typename System>
+void test_system() noexcept {
+  INFO(pretty_type::get_name<System>());
+  test_observe<System>(
+      std::make_unique<dg::Events::ObserveErrorNorms<
+          ObservationTimeTag, typename System::vars_for_test>>("reduction0"));
+
+  INFO("create/serialize");
+  using EventType = Event<tmpl::list<dg::Events::Registrars::ObserveErrorNorms<
+      ObservationTimeTag, typename System::vars_for_test>>>;
+  Parallel::register_derived_classes_with_charm<EventType>();
+  const auto factory_event = TestHelpers::test_factory_creation<EventType>(
+      "ObserveErrorNorms:\n"
+      "  SubfileName: reduction0");
+  auto serialized_event = serialize_and_deserialize(factory_event);
+  test_observe<System>(std::move(serialized_event));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.dG.ObserveErrorNorms", "[Unit][Evolution]") {
+  test_system<ScalarSystem>();
+  test_system<ComplicatedSystem>();
+}


### PR DESCRIPTION
## Proposed changes

Status: **In progress**

Introduces a Reduction Action in ReductionActions.hpp that enables strings to be contributed for printing to the screen and a configuration option implemented in ObserveTime.hpp that utilizes it to print the current Observation Time in the simulation.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
