### PR TITLE
Fix a bug in FixedHashMap equality operator

### DIFF
--- a/src/DataStructures/FixedHashMap.hpp
+++ b/src/DataStructures/FixedHashMap.hpp
@@ -575,7 +575,16 @@ template <size_t MaxSize, class Key, class ValueType, class Hash,
 bool operator==(
     const FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>& a,
     const FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>& b) noexcept {
-  return a.size_ == b.size_ and a.data_ == b.data_;
+  if (a.size_ != b.size_) {
+    return false;
+  }
+  for (const auto& key_and_value : a) {
+    const auto found_in_b = b.find(key_and_value.first);
+    if (found_in_b == b.end() or found_in_b->second != key_and_value.second) {
+      return false;
+    }
+  }
+  return true;
 }
 
 template <size_t MaxSize, class Key, class ValueType, class Hash,

--- a/src/DataStructures/FixedHashMap.hpp
+++ b/src/DataStructures/FixedHashMap.hpp
@@ -204,7 +204,11 @@ class FixedHashMap {
   using storage_type = std::array<boost::optional<value_type>, MaxSize>;
 
   SPECTRE_ALWAYS_INLINE size_type hash(const key_type& key) const noexcept {
-    return hash_is_perfect ? Hash{}(key) : Hash{}(key) % MaxSize;
+    if constexpr (hash_is_perfect) {
+      return Hash{}(key);
+    } else {
+      return Hash{}(key) % MaxSize;
+    }
   }
 
   template <bool IsInserting>
@@ -540,7 +544,7 @@ auto FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>::get_data_entry(
     const Key& key) noexcept -> typename storage_type::iterator {
   const auto hashed_key = hash(key);
   auto it = data_.begin() + hashed_key;
-  if (not hash_is_perfect) {
+  if constexpr (not hash_is_perfect) {
     // First search for an existing key.
     while (not is_set(*it) or (**it).first != key) {
       if (++it == data_.end()) {

--- a/tests/Unit/DataStructures/Test_FixedHashMap.cpp
+++ b/tests/Unit/DataStructures/Test_FixedHashMap.cpp
@@ -303,7 +303,7 @@ struct RepeatedHash {
 };
 
 template <typename KeyType>
-// NOLINTNEXTLINE(google-readability-function-size)
+// NOLINTNEXTLINE(google-readability-function-size, readability-function-size)
 void test_repeated_key() {
   using CopyableKeyMapType = FixedHashMap<6, size_t, size_t, RepeatedHash>;
   using NonCopyableKeyMapType =
@@ -556,10 +556,28 @@ void test_repeated_key() {
       make_not_null(&map));
 }
 
+void test_equality() {
+  {
+    INFO("Equality should not depend on insertion order");
+    // Using a hash that is not ordered
+    using Map = FixedHashMap<2, Direction<1>, double, std::hash<Direction<1>>>;
+    const auto dir1 = Direction<1>::lower_xi();
+    const auto dir2 = Direction<1>::upper_xi();
+    Map map{};
+    map.emplace(dir1, 1.);
+    map.emplace(dir2, 2.);
+    Map same_map{};
+    same_map.emplace(dir2, 2.);
+    same_map.emplace(dir1, 1.);
+    CHECK(map == same_map);
+  }
+}
+
 SPECTRE_TEST_CASE("Unit.DataStructures.FixedHashMap",
                   "[DataStructures][Unit]") {
   test_direction_key<4>();
   test_repeated_key<size_t>();
   test_repeated_key<NonCopyableSizeT>();
+  test_equality();
 }
 }  // namespace


### PR DESCRIPTION
## Proposed changes

The `FixedHashMap` equality operator was sometimes sensitive to the ordering of insertions. The added test fails in the container with clang-9. I fixed the issue using `std::is_permutation`, but there may be a more efficient way that uses the `FixedHashMap` internals.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
