### PR TITLE
Modernize CMakeLists 7

### DIFF
--- a/src/Elliptic/Actions/CMakeLists.txt
+++ b/src/Elliptic/Actions/CMakeLists.txt
@@ -1,13 +1,10 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-set(LIBRARY Xcts)
-
-add_spectre_library(${LIBRARY} INTERFACE)
-
 spectre_target_headers(
-  ${LIBRARY}
+  Elliptic
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
-  Tags.hpp
+  InitializeAnalyticSolution.hpp
+  InitializeSystem.hpp
   )

--- a/src/Elliptic/CMakeLists.txt
+++ b/src/Elliptic/CMakeLists.txt
@@ -1,5 +1,21 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+set(LIBRARY Elliptic)
+
+add_spectre_library(${LIBRARY} INTERFACE)
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  FirstOrderComputeTags.hpp
+  FirstOrderOperator.hpp
+  Tags.hpp
+  )
+
+add_subdirectory(Actions)
+add_subdirectory(DiscontinuousGalerkin)
 add_subdirectory(Executables)
 add_subdirectory(Systems)
+add_subdirectory(Triggers)

--- a/src/Elliptic/DiscontinuousGalerkin/CMakeLists.txt
+++ b/src/Elliptic/DiscontinuousGalerkin/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  Elliptic
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  DgElementArray.hpp
+  ImposeBoundaryConditions.hpp
+  ImposeInhomogeneousBoundaryConditionsOnSource.hpp
+  InitializeFirstOrderOperator.hpp
+  )
+
+add_subdirectory(NumericalFluxes)

--- a/src/Elliptic/DiscontinuousGalerkin/NumericalFluxes/CMakeLists.txt
+++ b/src/Elliptic/DiscontinuousGalerkin/NumericalFluxes/CMakeLists.txt
@@ -1,13 +1,9 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-set(LIBRARY Xcts)
-
-add_spectre_library(${LIBRARY} INTERFACE)
-
 spectre_target_headers(
-  ${LIBRARY}
+  Elliptic
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
-  Tags.hpp
+  FirstOrderInternalPenalty.hpp
   )

--- a/src/Elliptic/Systems/Elasticity/CMakeLists.txt
+++ b/src/Elliptic/Systems/Elasticity/CMakeLists.txt
@@ -3,11 +3,22 @@
 
 set(LIBRARY Elasticity)
 
-set(LIBRARY_SOURCES
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
   Equations.cpp
   )
 
-add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Equations.hpp
+  FirstOrderSystem.hpp
+  Tags.hpp
+  )
 
 target_link_libraries(
   ${LIBRARY}

--- a/src/Elliptic/Systems/Poisson/CMakeLists.txt
+++ b/src/Elliptic/Systems/Poisson/CMakeLists.txt
@@ -3,11 +3,23 @@
 
 set(LIBRARY Poisson)
 
-set(LIBRARY_SOURCES
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
   Equations.cpp
   )
 
-add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Equations.hpp
+  FirstOrderSystem.hpp
+  Geometry.hpp
+  Tags.hpp
+  )
 
 target_link_libraries(
   ${LIBRARY}

--- a/src/Elliptic/Triggers/CMakeLists.txt
+++ b/src/Elliptic/Triggers/CMakeLists.txt
@@ -1,13 +1,9 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-set(LIBRARY Xcts)
-
-add_spectre_library(${LIBRARY} INTERFACE)
-
 spectre_target_headers(
-  ${LIBRARY}
+  Elliptic
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
-  Tags.hpp
+  EveryNIterations.hpp
   )

--- a/src/Evolution/Actions/CMakeLists.txt
+++ b/src/Evolution/Actions/CMakeLists.txt
@@ -5,7 +5,9 @@ spectre_target_headers(
   Evolution
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
-  DgElementArray.hpp
+  AddMeshVelocityNonconservative.hpp
+  AddMeshVelocitySourceTerms.hpp
+  ComputeTimeDerivative.hpp
+  ComputeVolumeFluxes.hpp
+  ComputeVolumeSources.hpp
   )
-
-add_subdirectory(Limiters)

--- a/src/Evolution/CMakeLists.txt
+++ b/src/Evolution/CMakeLists.txt
@@ -3,12 +3,26 @@
 
 set(LIBRARY Evolution)
 
-set(LIBRARY_SOURCES
-  Initialization/DgDomain.cpp
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
   TagsDomain.cpp
   )
 
-add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  ComputeTags.hpp
+  Evolution.hpp
+  NumericInitialData.hpp
+  Protocols.hpp
+  Tags.hpp
+  TagsDomain.hpp
+  TypeTraits.hpp
+  )
 
 target_link_libraries(
   ${LIBRARY}
@@ -18,7 +32,6 @@ target_link_libraries(
   DataStructures
   Options
   Utilities
-
   PRIVATE
   LinearOperators
   )
@@ -28,7 +41,10 @@ add_dependencies(
   module_ConstGlobalCache
   )
 
+add_subdirectory(Actions)
+add_subdirectory(Conservative)
 add_subdirectory(DiscontinuousGalerkin)
 add_subdirectory(Executables)
+add_subdirectory(Initialization)
 add_subdirectory(Systems)
 add_subdirectory(VariableFixing)

--- a/src/Evolution/Conservative/CMakeLists.txt
+++ b/src/Evolution/Conservative/CMakeLists.txt
@@ -5,7 +5,7 @@ spectre_target_headers(
   Evolution
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
-  DgElementArray.hpp
+  ConservativeDuDt.hpp
+  UpdateConservatives.hpp
+  UpdatePrimitives.hpp
   )
-
-add_subdirectory(Limiters)

--- a/src/Evolution/Initialization/CMakeLists.txt
+++ b/src/Evolution/Initialization/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_sources(
+  Evolution
+  PRIVATE
+  DgDomain.cpp
+  )
+
+spectre_target_headers(
+  Evolution
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  ConservativeSystem.hpp
+  DgDomain.hpp
+  DiscontinuousGalerkin.hpp
+  Evolution.hpp
+  GrTagsForHydro.hpp
+  InitialData.hpp
+  Limiter.hpp
+  NonconservativeSystem.hpp
+  SetVariables.hpp
+  Tags.hpp
+  )

--- a/src/Evolution/Systems/Burgers/CMakeLists.txt
+++ b/src/Evolution/Systems/Burgers/CMakeLists.txt
@@ -3,14 +3,26 @@
 
 set(LIBRARY Burgers)
 
-set(LIBRARY_SOURCES
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
   Characteristics.cpp
   Divergence.cpp
   Fluxes.cpp
   Minmod.cpp
   )
 
-add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Characteristics.hpp
+  Fluxes.hpp
+  System.hpp
+  Tags.hpp
+  )
 
 target_link_libraries(
   ${LIBRARY}

--- a/src/Evolution/Systems/Cce/Actions/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/Actions/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  Cce
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  BoundaryComputeAndSendToEvolution.hpp
+  CalculateScriInputs.hpp
+  CharacteristicEvolutionBondiCalculations.hpp
+  FilterSwshVolumeQuantity.hpp
+  InitializeCharacteristicEvolutionScri.hpp
+  InitializeCharacteristicEvolutionTime.hpp
+  InitializeCharacteristicEvolutionVariables.hpp
+  InitializeFirstHypersurface.hpp
+  InitializeWorldtubeBoundary.hpp
+  InsertInterpolationScriData.hpp
+  ReceiveGhWorldtubeData.hpp
+  ReceiveWorldtubeData.hpp
+  RequestBoundaryData.hpp
+  ScriObserveInterpolated.hpp
+  TimeManagement.hpp
+  UpdateGauge.hpp
+  )

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/CMakeLists.txt
@@ -3,14 +3,26 @@
 
 set(LIBRARY CceAnalyticSolutions)
 
-set(LIBRARY_SOURCES
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
   BouncingBlackHole.cpp
   LinearizedBondiSachs.cpp
   SphericalMetricData.cpp
   WorldtubeData.cpp
   )
 
-add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  BouncingBlackHole.hpp
+  LinearizedBondiSachs.hpp
+  SphericalMetricData.hpp
+  WorldtubeData.hpp
+  )
 
 target_link_libraries(
   ${LIBRARY}

--- a/src/Evolution/Systems/Cce/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/CMakeLists.txt
@@ -1,38 +1,58 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-add_subdirectory(AnalyticSolutions)
-
 set(LIBRARY Cce)
 
-set(LIBRARY_SOURCES
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
   AnalyticBoundaryDataManager.cpp
   BoundaryData.cpp
   Equations.cpp
   GaugeTransformBoundaryData.cpp
-  Initialize/InitializeJ.cpp
-  Initialize/InverseCubic.cpp
-  Initialize/NoIncomingRadiation.cpp
-  Initialize/ZeroNonSmooth.cpp
-  InterfaceManagers/GhLocalTimeStepping.cpp
-  InterfaceManagers/GhLockstep.cpp
   LinearOperators.cpp
   LinearSolve.cpp
   NewmanPenrose.cpp
   PrecomputeCceDependencies.cpp
   ReadBoundaryDataH5.cpp
   ReducedWorldtubeModeRecorder.cpp
-  SpecBoundaryData.cpp
   ScriPlusValues.cpp
+  SpecBoundaryData.cpp
   )
 
-add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  AnalyticBoundaryDataManager.hpp
+  BoundaryData.hpp
+  BoundaryDataTags.hpp
+  Equations.hpp
+  GaugeTransformBoundaryData.hpp
+  IntegrandInputSteps.hpp
+  LinearOperators.hpp
+  LinearSolve.hpp
+  NewmanPenrose.hpp
+  OptionTags.hpp
+  PreSwshDerivatives.hpp
+  PrecomputeCceDependencies.hpp
+  ReadBoundaryDataH5.hpp
+  ReceiveTags.hpp
+  ReducedWorldtubeModeRecorder.hpp
+  ScriPlusInterpolationManager.hpp
+  ScriPlusValues.hpp
+  SpecBoundaryData.hpp
+  SwshDerivatives.hpp
+  System.hpp
+  Tags.hpp
+  )
 
 target_link_libraries(
   ${LIBRARY}
   PRIVATE
   LinearSolver
-
   PUBLIC
   Boost::boost
   DataStructures
@@ -44,3 +64,9 @@ target_link_libraries(
   Spectral
   Utilities
   )
+
+add_subdirectory(Actions)
+add_subdirectory(AnalyticSolutions)
+add_subdirectory(Components)
+add_subdirectory(Initialize)
+add_subdirectory(InterfaceManagers)

--- a/src/Evolution/Systems/Cce/Components/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/Components/CMakeLists.txt
@@ -1,15 +1,10 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-set(LIBRARY RadiationTransport)
-
-add_spectre_library(${LIBRARY} INTERFACE)
-
 spectre_target_headers(
-  ${LIBRARY}
+  Cce
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
-  Tags.hpp
+  CharacteristicEvolution.hpp
+  WorldtubeBoundary.hpp
   )
-
-add_subdirectory(M1Grey)

--- a/src/Evolution/Systems/Cce/Initialize/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/Initialize/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_sources(
+  Cce
+  PRIVATE
+  InitializeJ.cpp
+  InverseCubic.cpp
+  NoIncomingRadiation.cpp
+  ZeroNonSmooth.cpp
+  )
+
+spectre_target_headers(
+  Cce
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  InitializeJ.hpp
+  InverseCubic.hpp
+  NoIncomingRadiation.hpp
+  ZeroNonSmooth.hpp
+  )

--- a/src/Evolution/Systems/Cce/InterfaceManagers/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/InterfaceManagers/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_sources(
+  Cce
+  PRIVATE
+  GhLocalTimeStepping.cpp
+  GhLockstep.cpp
+  )
+
+spectre_target_headers(
+  Cce
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  GhInterfaceManager.hpp
+  GhLocalTimeStepping.hpp
+  GhLockstep.hpp
+  )

--- a/src/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/src/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -3,13 +3,27 @@
 
 set(LIBRARY CurvedScalarWave)
 
-set(LIBRARY_SOURCES
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
   Characteristics.cpp
   Constraints.cpp
   Equations.cpp
   )
 
-add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Characteristics.hpp
+  Constraints.hpp
+  Equations.hpp
+  System.hpp
+  Tags.hpp
+  TagsDeclarations.hpp
+  )
 
 target_link_libraries(
   ${LIBRARY}

--- a/src/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -1,18 +1,33 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-add_subdirectory(GaugeSourceFunctions)
-
 set(LIBRARY GeneralizedHarmonic)
 
-set(LIBRARY_SOURCES
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
   Characteristics.cpp
   Constraints.cpp
   Equations.cpp
   UpwindPenaltyCorrection.cpp
   )
 
-add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Characteristics.hpp
+  Constraints.hpp
+  DuDtTempTags.hpp
+  Equations.hpp
+  Initialize.hpp
+  System.hpp
+  Tags.hpp
+  TagsDeclarations.hpp
+  UpwindPenaltyCorrection.hpp
+  )
 
 target_link_libraries(
   ${LIBRARY}
@@ -22,3 +37,5 @@ target_link_libraries(
   GeneralRelativity
   Options
   )
+
+add_subdirectory(GaugeSourceFunctions)

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/CMakeLists.txt
@@ -3,13 +3,26 @@
 
 set(LIBRARY GeneralizedHarmonicGaugeSourceFunctions)
 
-set(LIBRARY_SOURCES
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
   DampedHarmonic.cpp
   DampedWaveHelpers.cpp
   InitializeDampedHarmonic.cpp
   )
 
-add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  DampedHarmonic.hpp
+  DampedWaveHelpers.hpp
+  Gauges.hpp
+  InitializeDampedHarmonic.hpp
+  OptionTags.hpp
+  )
 
 target_link_libraries(
   ${LIBRARY}

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -3,7 +3,11 @@
 
 set(LIBRARY ValenciaDivClean)
 
-set(LIBRARY_SOURCES
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
   Characteristics.cpp
   ConservativeFromPrimitive.cpp
   FixConservatives.cpp
@@ -15,7 +19,23 @@ set(LIBRARY_SOURCES
   Sources.cpp
   )
 
-add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Characteristics.hpp
+  ConservativeFromPrimitive.hpp
+  FixConservatives.hpp
+  Fluxes.hpp
+  NewmanHamlin.hpp
+  PalenzuelaEtAl.hpp
+  PrimitiveFromConservative.hpp
+  PrimitiveRecoveryData.hpp
+  Sources.hpp
+  System.hpp
+  Tags.hpp
+  TagsDeclarations.hpp
+  )
 
 target_link_libraries(
   ${LIBRARY}

--- a/src/Evolution/Systems/NewtonianEuler/CMakeLists.txt
+++ b/src/Evolution/Systems/NewtonianEuler/CMakeLists.txt
@@ -3,7 +3,11 @@
 
 set(LIBRARY NewtonianEuler)
 
-set(LIBRARY_SOURCES
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
   Characteristics.cpp
   ConservativeFromPrimitive.cpp
   Fluxes.cpp
@@ -11,7 +15,20 @@ set(LIBRARY_SOURCES
   SoundSpeedSquared.cpp
   )
 
-add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Characteristics.hpp
+  ConservativeFromPrimitive.hpp
+  Fluxes.hpp
+  PrimitiveFromConservative.hpp
+  SoundSpeedSquared.hpp
+  Sources.hpp
+  System.hpp
+  Tags.hpp
+  TagsDeclarations.hpp
+  )
 
 target_link_libraries(
   ${LIBRARY}

--- a/src/Evolution/Systems/NewtonianEuler/NumericalFluxes/CMakeLists.txt
+++ b/src/Evolution/Systems/NewtonianEuler/NumericalFluxes/CMakeLists.txt
@@ -3,18 +3,26 @@
 
 set(LIBRARY NewtonianEulerNumericalFluxes)
 
-set(LIBRARY_SOURCES
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
   Hllc.cpp
   )
 
-add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Hllc.hpp
+  )
 
 target_link_libraries(
   ${LIBRARY}
   PUBLIC
   DataStructures
   Options
-
   PRIVATE
   ErrorHandling
   )

--- a/src/Evolution/Systems/NewtonianEuler/Sources/CMakeLists.txt
+++ b/src/Evolution/Systems/NewtonianEuler/Sources/CMakeLists.txt
@@ -3,13 +3,26 @@
 
 set(LIBRARY NewtonianEulerSources)
 
-set(LIBRARY_SOURCES
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
   LaneEmdenGravitationalField.cpp
   UniformAcceleration.cpp
   VortexPerturbation.cpp
   )
 
-add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  LaneEmdenGravitationalField.hpp
+  NoSource.hpp
+  Source.hpp
+  UniformAcceleration.hpp
+  VortexPerturbation.hpp
+  )
 
 target_link_libraries(
   ${LIBRARY}

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/CMakeLists.txt
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/CMakeLists.txt
@@ -3,7 +3,11 @@
 
 set(LIBRARY M1Grey)
 
-set(LIBRARY_SOURCES
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
   Characteristics.cpp
   Fluxes.cpp
   M1Closure.cpp
@@ -11,7 +15,19 @@ set(LIBRARY_SOURCES
   Sources.cpp
   )
 
-add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Characteristics.hpp
+  Fluxes.hpp
+  Initialize.hpp
+  M1Closure.hpp
+  M1HydroCoupling.hpp
+  Sources.hpp
+  System.hpp
+  Tags.hpp
+  )
 
 target_link_libraries(
   ${LIBRARY}

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/CMakeLists.txt
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/CMakeLists.txt
@@ -3,7 +3,11 @@
 
 set(LIBRARY Valencia)
 
-set(LIBRARY_SOURCES
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
   Characteristics.cpp
   ConservativeFromPrimitive.cpp
   FixConservatives.cpp
@@ -12,7 +16,20 @@ set(LIBRARY_SOURCES
   Sources.cpp
   )
 
-add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Characteristics.hpp
+  ConservativeFromPrimitive.hpp
+  FixConservatives.hpp
+  Fluxes.hpp
+  PrimitiveFromConservative.hpp
+  Sources.hpp
+  System.hpp
+  Tags.hpp
+  TagsDeclarations.hpp
+  )
 
 target_link_libraries(
   ${LIBRARY}

--- a/src/Evolution/Systems/ScalarWave/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarWave/CMakeLists.txt
@@ -3,14 +3,30 @@
 
 set(LIBRARY ScalarWave)
 
-set(LIBRARY_SOURCES
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
   Characteristics.cpp
   Constraints.cpp
   Equations.cpp
   UpwindPenaltyCorrection.cpp
   )
 
-add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Characteristics.hpp
+  Constraints.hpp
+  Equations.hpp
+  Initialize.hpp
+  System.hpp
+  Tags.hpp
+  TagsDeclarations.hpp
+  UpwindPenaltyCorrection.hpp
+  )
 
 target_link_libraries(
   ${LIBRARY}

--- a/src/Evolution/VariableFixing/CMakeLists.txt
+++ b/src/Evolution/VariableFixing/CMakeLists.txt
@@ -3,13 +3,26 @@
 
 set(LIBRARY VariableFixing)
 
-set(LIBRARY_SOURCES
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
   FixToAtmosphere.cpp
   LimitLorentzFactor.cpp
   RadiallyFallingFloor.cpp
   )
 
-add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+spectre_target_headers(
+  Evolution
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Actions.hpp
+  FixToAtmosphere.hpp
+  LimitLorentzFactor.hpp
+  RadiallyFallingFloor.hpp
+  Tags.hpp
+  )
 
 target_link_libraries(
   ${LIBRARY}


### PR DESCRIPTION
## Proposed changes

Modernize the CMakeLists.txt files in `Elliptic` and `Evolution`. This wraps up the ongoing effort to update our (non Python-binding) `src` CMakeLists.txt files to specify the sources and headers for each library.

This PR's a bit bigger, but I'm impatient to get this done 😛 

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
