### PR TITLE
Add ElementCenteredSubdomainData for Schwarz solver

### DIFF
--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/CMakeLists.txt
@@ -15,6 +15,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  ElementCenteredSubdomainData.hpp
   OverlapHelpers.hpp
   Schwarz.hpp
   )
@@ -28,4 +29,6 @@ target_link_libraries(
   PRIVATE
   ErrorHandling
   Utilities
+  INTERFACE
+  LinearSolver
   )

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementCenteredSubdomainData.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementCenteredSubdomainData.hpp
@@ -1,0 +1,213 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <ostream>
+#include <pup.h>
+#include <string>
+#include <tuple>
+
+#include "DataStructures/Variables.hpp"
+#include "NumericalAlgorithms/LinearSolver/InnerProduct.hpp"
+#include "ParallelAlgorithms/LinearSolver/Schwarz/OverlapHelpers.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace LinearSolver::Schwarz {
+
+/*!
+ * \brief Data on an element-centered subdomain
+ *
+ * An element-centered subdomain consists of a central element and overlap
+ * regions with all neighboring elements. This class holds data on such a
+ * subdomain. It supports vector space operations (addition and scalar
+ * multiplication) and an inner product, which allows the use of this data type
+ * with linear solvers (see e.g. `LinearSolver::Serial::Gmres`).
+ */
+template <size_t Dim, typename TagsList>
+struct ElementCenteredSubdomainData {
+  static constexpr size_t volume_dim = Dim;
+  using ElementData = Variables<TagsList>;
+  using OverlapData = ElementData;
+
+  ElementCenteredSubdomainData() = default;
+  ElementCenteredSubdomainData(const ElementCenteredSubdomainData&) = default;
+  ElementCenteredSubdomainData& operator=(
+      const ElementCenteredSubdomainData&) noexcept = default;
+  ElementCenteredSubdomainData(ElementCenteredSubdomainData&&) noexcept =
+      default;
+  ElementCenteredSubdomainData& operator=(
+      ElementCenteredSubdomainData&&) noexcept = default;
+  ~ElementCenteredSubdomainData() noexcept = default;
+
+  explicit ElementCenteredSubdomainData(
+      const size_t element_num_points) noexcept
+      : element_data{element_num_points} {}
+
+  ElementCenteredSubdomainData(
+      Variables<TagsList> local_element_data,
+      OverlapMap<Dim, Variables<TagsList>> local_overlap_data) noexcept
+      : element_data{std::move(local_element_data)},
+        overlap_data{std::move(local_overlap_data)} {}
+
+  void pup(PUP::er& p) noexcept {  // NOLINT
+    p | element_data;
+    p | overlap_data;
+  }
+
+  template <typename RhsTagsList>
+  ElementCenteredSubdomainData& operator+=(
+      const ElementCenteredSubdomainData<Dim, RhsTagsList>& rhs) noexcept {
+    element_data += rhs.element_data;
+    for (auto& [overlap_id, data] : overlap_data) {
+      data += rhs.overlap_data.at(overlap_id);
+    }
+    return *this;
+  }
+
+  template <typename RhsTagsList>
+  ElementCenteredSubdomainData& operator-=(
+      const ElementCenteredSubdomainData<Dim, RhsTagsList>& rhs) noexcept {
+    element_data -= rhs.element_data;
+    for (auto& [overlap_id, data] : overlap_data) {
+      data -= rhs.overlap_data.at(overlap_id);
+    }
+    return *this;
+  }
+
+  ElementCenteredSubdomainData& operator*=(const double scalar) noexcept {
+    element_data *= scalar;
+    for (auto& [overlap_id, data] : overlap_data) {
+      data *= scalar;
+      // Silence unused-variable warning on GCC 7
+      (void)overlap_id;
+    }
+    return *this;
+  }
+
+  ElementCenteredSubdomainData& operator/=(const double scalar) noexcept {
+    element_data /= scalar;
+    for (auto& [overlap_id, data] : overlap_data) {
+      data /= scalar;
+      // Silence unused-variable warning on GCC 7
+      (void)overlap_id;
+    }
+    return *this;
+  }
+
+  ElementData element_data{};
+  OverlapMap<Dim, OverlapData> overlap_data{};
+};
+
+template <size_t Dim, typename LhsTagsList, typename RhsTagsList>
+decltype(auto) operator+(
+    ElementCenteredSubdomainData<Dim, LhsTagsList> lhs,
+    const ElementCenteredSubdomainData<Dim, RhsTagsList>& rhs) noexcept {
+  lhs += rhs;
+  return lhs;
+}
+
+template <size_t Dim, typename LhsTagsList, typename RhsTagsList>
+decltype(auto) operator-(
+    ElementCenteredSubdomainData<Dim, LhsTagsList> lhs,
+    const ElementCenteredSubdomainData<Dim, RhsTagsList>& rhs) noexcept {
+  lhs -= rhs;
+  return lhs;
+}
+
+template <size_t Dim, typename TagsList>
+decltype(auto) operator*(
+    const double scalar,
+    ElementCenteredSubdomainData<Dim, TagsList> data) noexcept {
+  data *= scalar;
+  return data;
+}
+
+template <size_t Dim, typename TagsList>
+decltype(auto) operator*(ElementCenteredSubdomainData<Dim, TagsList> data,
+                         const double scalar) noexcept {
+  data *= scalar;
+  return data;
+}
+
+template <size_t Dim, typename TagsList>
+decltype(auto) operator/(ElementCenteredSubdomainData<Dim, TagsList> data,
+                         const double scalar) noexcept {
+  data /= scalar;
+  return data;
+}
+
+template <size_t Dim, typename TagsList>
+std::ostream& operator<<(std::ostream& os,
+                         const ElementCenteredSubdomainData<Dim, TagsList>&
+                             subdomain_data) noexcept {
+  os << "Element data:\n"
+     << subdomain_data.element_data << "\nOverlap data:\n"
+     << subdomain_data.overlap_data;
+  return os;
+}
+
+template <size_t Dim, typename TagsList>
+bool operator==(
+    const ElementCenteredSubdomainData<Dim, TagsList>& lhs,
+    const ElementCenteredSubdomainData<Dim, TagsList>& rhs) noexcept {
+  return lhs.element_data == rhs.element_data and
+         lhs.overlap_data == rhs.overlap_data;
+}
+
+template <size_t Dim, typename TagsList>
+bool operator!=(
+    const ElementCenteredSubdomainData<Dim, TagsList>& lhs,
+    const ElementCenteredSubdomainData<Dim, TagsList>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+}  // namespace LinearSolver::Schwarz
+
+namespace LinearSolver::InnerProductImpls {
+
+template <size_t Dim, typename LhsTagsList, typename RhsTagsList>
+struct InnerProductImpl<
+    Schwarz::ElementCenteredSubdomainData<Dim, LhsTagsList>,
+    Schwarz::ElementCenteredSubdomainData<Dim, RhsTagsList>> {
+  static double apply(
+      const Schwarz::ElementCenteredSubdomainData<Dim, LhsTagsList>& lhs,
+      const Schwarz::ElementCenteredSubdomainData<Dim, RhsTagsList>&
+          rhs) noexcept {
+    double result = inner_product(lhs.element_data, rhs.element_data);
+    for (const auto& [overlap_id, lhs_data] : lhs.overlap_data) {
+      result += inner_product(lhs_data, rhs.overlap_data.at(overlap_id));
+    }
+    return result;
+  }
+};
+
+}  // namespace LinearSolver::InnerProductImpls
+
+namespace MakeWithValueImpls {
+
+template <size_t Dim, typename TagsListOut, typename TagsListIn>
+struct MakeWithValueImpl<
+    LinearSolver::Schwarz::ElementCenteredSubdomainData<Dim, TagsListOut>,
+    LinearSolver::Schwarz::ElementCenteredSubdomainData<Dim, TagsListIn>> {
+  using SubdomainDataIn =
+      LinearSolver::Schwarz::ElementCenteredSubdomainData<Dim, TagsListIn>;
+  using SubdomainDataOut =
+      LinearSolver::Schwarz::ElementCenteredSubdomainData<Dim, TagsListOut>;
+  static SPECTRE_ALWAYS_INLINE SubdomainDataOut
+  apply(const SubdomainDataIn& input, const double value) noexcept {
+    SubdomainDataOut output{};
+    output.element_data =
+        make_with_value<typename SubdomainDataOut::ElementData>(
+            input.element_data, value);
+    for (const auto& [overlap_id, input_data] : input.overlap_data) {
+      output.overlap_data.emplace(
+          overlap_id, make_with_value<typename SubdomainDataOut::OverlapData>(
+                          input_data, value));
+    }
+    return output;
+  }
+};
+
+}  // namespace MakeWithValueImpls

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_ParallelSchwarz")
 
 set(LIBRARY_SOURCES
+  Test_ElementCenteredSubdomainData.cpp
   Test_OverlapHelpers.cpp
   )
 
@@ -11,5 +12,5 @@ add_test_library(
   ${LIBRARY}
   "ParallelAlgorithms/LinearSolver/Schwarz"
   "${LIBRARY_SOURCES}"
-  "DataStructures;DomainStructure;ParallelSchwarz"
+  "DataStructures;DomainStructure;LinearSolver;ParallelSchwarz"
   )

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_ElementCenteredSubdomainData.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_ElementCenteredSubdomainData.cpp
@@ -1,0 +1,91 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/LinearSolver/InnerProduct.hpp"
+#include "ParallelAlgorithms/LinearSolver/Schwarz/ElementCenteredSubdomainData.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace LinearSolver::Schwarz {
+
+namespace {
+struct ScalarField : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ParallelSchwarz.ElementCenteredSubdomainData",
+                  "[Unit][ParallelAlgorithms][LinearSolver]") {
+  const auto west_id =
+      std::make_pair(Direction<1>::lower_xi(), ElementId<1>{0, {{{2, 0}}}});
+  const auto east_id =
+      std::make_pair(Direction<1>::upper_xi(), ElementId<1>{0, {{{2, 2}}}});
+  const auto make_subdomain_data = [&west_id, &east_id](
+                                       DataVector element_data,
+                                       DataVector east_overlap_data,
+                                       DataVector west_overlap_data) noexcept {
+    ElementCenteredSubdomainData<1, tmpl::list<ScalarField>> subdomain_data{
+        element_data.size()};
+    get(get<ScalarField>(subdomain_data.element_data)) =
+        std::move(element_data);
+    subdomain_data.overlap_data.emplace(west_id, west_overlap_data.size());
+    get(get<ScalarField>(subdomain_data.overlap_data.at(west_id))) =
+        std::move(west_overlap_data);
+    subdomain_data.overlap_data.emplace(east_id, east_overlap_data.size());
+    get(get<ScalarField>(subdomain_data.overlap_data.at(east_id))) =
+        std::move(east_overlap_data);
+    return subdomain_data;
+  };
+  auto subdomain_data1 = make_subdomain_data({1., 2., 3.}, {4., 5.}, {6.});
+  const auto subdomain_data2 =
+      make_subdomain_data({2., 1., 0.}, {1., 2.}, {3.});
+  SECTION("Addition") {
+    const auto subdomain_data_sum =
+        make_subdomain_data({3., 3., 3.}, {5., 7.}, {9.});
+    CHECK(subdomain_data1 + subdomain_data2 == subdomain_data_sum);
+    subdomain_data1 += subdomain_data2;
+    CHECK(subdomain_data1 == subdomain_data_sum);
+  }
+  SECTION("Subtraction") {
+    const auto subdomain_data_diff =
+        make_subdomain_data({-1., 1., 3.}, {3., 3.}, {3.});
+    CHECK(subdomain_data1 - subdomain_data2 == subdomain_data_diff);
+    subdomain_data1 -= subdomain_data2;
+    CHECK(subdomain_data1 == subdomain_data_diff);
+  }
+  SECTION("Scalar multiplication") {
+    const auto subdomain_data_double =
+        make_subdomain_data({2., 4., 6.}, {8., 10.}, {12.});
+    CHECK(2. * subdomain_data1 == subdomain_data_double);
+    CHECK(subdomain_data1 * 2. == subdomain_data_double);
+    subdomain_data1 *= 2.;
+    CHECK(subdomain_data1 == subdomain_data_double);
+  }
+  SECTION("Scalar division") {
+    const auto subdomain_data_half =
+        make_subdomain_data({0.5, 1., 1.5}, {2., 2.5}, {3.});
+    CHECK(subdomain_data1 / 2. == subdomain_data_half);
+    subdomain_data1 /= 2.;
+    CHECK(subdomain_data1 == subdomain_data_half);
+  }
+  SECTION("Remaining tests") {
+    test_serialization(subdomain_data1);
+    test_copy_semantics(subdomain_data1);
+    auto copied_subdomain_data = subdomain_data1;
+    test_move_semantics(std::move(copied_subdomain_data), subdomain_data1);
+    CHECK(inner_product(subdomain_data1, subdomain_data2) == 36.);
+    CHECK(make_with_value<
+              ElementCenteredSubdomainData<1, tmpl::list<ScalarField>>>(
+              subdomain_data1, 1.) ==
+          make_subdomain_data({1., 1., 1.}, {1., 1.}, {1.}));
+  }
+}
+
+}  // namespace LinearSolver::Schwarz


### PR DESCRIPTION
## Proposed changes

An element-centered subdomain consists of a central element and overlap
regions with all neighboring elements. This class holds data on such a
subdomain. It supports vector space operations (addition and scalar
multiplication) and an inner product, which allow to use this data type with
linear solvers (e.g. `LinearSolver::Serial::Gmres`).

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
