### PR TITLE
CylindricalEndcap Map (general version)

### DIFF
--- a/docs/Images/Domain/CoordinateMaps/CylindricalEndcap.svg
+++ b/docs/Images/Domain/CoordinateMaps/CylindricalEndcap.svg
@@ -1,0 +1,301 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="127.26459mm"
+   height="160.11301mm"
+   viewBox="0 0 127.26459 160.11301"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="CylindricalEndcap.svg">
+  <defs
+     id="defs2">
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Lend"
+       style="overflow:visible;"
+       inkscape:isstock="true">
+      <path
+         id="path4686"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) rotate(180) translate(12.5,0)" />
+    </marker>
+    <linearGradient
+       id="linearGradient6115"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop6113" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4526"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4524" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.93338095"
+     inkscape:cx="211.35181"
+     inkscape:cy="287.53122"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:window-width="1267"
+     inkscape:window-height="913"
+     inkscape:window-x="95"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3713"
+       originx="-5.1593686"
+       originy="-136.3005" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-5.1593686,-0.58648957)">
+    <circle
+       id="path3717"
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26458332;stroke-opacity:1"
+       cy="85.333336"
+       cx="52.916668"
+       r="37.041668" />
+    <circle
+       id="path3717-3"
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26458332;stroke-opacity:1"
+       cy="74.75"
+       cx="68.791664"
+       r="63.500004" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 79.775883,0.58648957 c 0,153.45834043 0,153.45834043 0,153.45834043"
+       id="path6030"
+       inkscape:connector-curvature="0" />
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6040"
+       cx="47.625"
+       cy="64.166664"
+       rx="1.1926295"
+       ry="1.1425189" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.66500002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.665, 1.33;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 79.47522,59.376106 47.624999,64.166667"
+       id="path6042"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 79.575441,59.376106 128.20265,51.899621"
+       id="path6044"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.66500002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.665, 1.995;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 47.304293,64.086488 78.974116,110.58902"
+       id="path6046"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 79.375,110.58901 15.073232,21.96844"
+       id="path6048"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6040-6"
+       cx="52.916668"
+       cy="85.333336"
+       rx="1.2427398"
+       ry="1.1926293" />
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6040-7"
+       cx="68.791664"
+       cy="74.75"
+       rx="1.0924084"
+       ry="1.1425189" />
+    <path
+       style="fill:#969696;fill-opacity:1;stroke:#000000;stroke-width:1.54204726;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 330.20722,459.84881 -27.62827,-40.337 4.77565,-5.43916 c 14.439,-16.44511 26.01836,-40.16867 30.70342,-62.90452 2.82815,-13.72457 3.25714,-40.63286 0.85866,-53.85964 -3.871,-21.3473 -14.1331,-44.09123 -27.97825,-62.00833 -4.73338,-6.12551 -10.66338,-10.9541 -10.4,-11.19318 0.26339,-0.23907 43.21095,-6.56797 92.66126,-13.60124 l 89.90964,-12.78777 1.48983,3.90519 c 17.2719,45.27368 18.16422,106.25515 2.26499,154.7912 -5.13982,15.69047 -17.05815,41.24815 -24.94936,53.50142 -14.8589,23.07252 -38.27408,48.22626 -60.02923,64.48638 -10.49872,7.8469 -38.70633,24.50037 -45.25929,26.84528 -1.63403,0.58473 -6.55511,-12.39748 -26.41905,-41.39863 z"
+       id="path6071"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="scsssscscsssscs"
+       transform="scale(0.26458333)" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;"
+       x="41.892361"
+       y="62.482944"
+       id="text6177"><tspan
+         sodipodi:role="line"
+         id="tspan6175"
+         x="41.892361"
+         y="62.482944"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr;text-anchor:start;stroke-width:0.26458332;">P</tspan><tspan
+         sodipodi:role="line"
+         x="41.892361"
+         y="69.097527"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr;text-anchor:start;stroke-width:0.26458332;"
+         id="tspan6179" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;"
+       x="70.257866"
+       y="73.250671"
+       id="text6153-9"><tspan
+         sodipodi:role="line"
+         id="tspan6151-2"
+         x="70.257866"
+         y="73.250671"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr;text-anchor:start;stroke-width:0.26458332;">C</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="75.586967"
+       y="68.771202"
+       id="text6157-5"><tspan
+         sodipodi:role="line"
+         x="75.586967"
+         y="68.771202"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="tspan6163-4">i</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="80.622108"
+       y="155.39073"
+       id="text6223"><tspan
+         sodipodi:role="line"
+         id="tspan6221"
+         x="80.622108"
+         y="155.39073"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">z</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="84.343307"
+       y="157.29788"
+       id="text6227"><tspan
+         sodipodi:role="line"
+         id="tspan6225"
+         x="84.343307"
+         y="157.29788"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">P</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="48.907825"
+       y="89.843269"
+       id="text6243"><tspan
+         sodipodi:role="line"
+         id="tspan6241"
+         x="48.907825"
+         y="89.843269"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">1</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="75.265945"
+       y="75.010567"
+       id="text6247"><tspan
+         sodipodi:role="line"
+         id="tspan6245"
+         x="75.265945"
+         y="75.010567"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">2</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="45.620899"
+       y="58.749088"
+       id="text6157-5-0"><tspan
+         sodipodi:role="line"
+         x="45.620899"
+         y="58.749088"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="tspan6163-4-5">i</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="44.581596"
+       y="87.80143"
+       id="text6153-9-9"><tspan
+         sodipodi:role="line"
+         id="tspan6151-2-2"
+         x="44.581596"
+         y="87.80143"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">C</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="49.266769"
+       y="83.566628"
+       id="text6157-5-5"><tspan
+         sodipodi:role="line"
+         x="49.266769"
+         y="83.566628"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="tspan6163-4-4">i</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;marker-end:url(#Arrow1Lend)"
+       d="M 92.467412,146.24264 H 121.94805"
+       id="path3876"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="113.76174"
+       y="144.2939"
+       id="text6223-7"><tspan
+         sodipodi:role="line"
+         id="tspan6221-0"
+         x="113.76174"
+         y="144.2939"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">z</tspan></text>
+  </g>
+</svg>

--- a/docs/Images/Domain/CoordinateMaps/CylindricalEndcap_Allowed.svg
+++ b/docs/Images/Domain/CoordinateMaps/CylindricalEndcap_Allowed.svg
@@ -1,0 +1,508 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="365.3898mm"
+   height="169.59834mm"
+   viewBox="0 0 365.3898 169.59834"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="CylindricalEndcap_Allowed.svg">
+  <defs
+     id="defs2">
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1483"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1481"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1015"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1013" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker951"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lstart">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(0.8,0,0,0.8,10,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path949" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker899"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path897" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Mstart"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path4588"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6362"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path6360"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Mstart"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4606"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(0.6)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lstart"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path4582"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.8,0,0,0.8,10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.70710678"
+     inkscape:cx="1110.5277"
+     inkscape:cy="123.06463"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:snap-global="true"
+     inkscape:snap-text-baseline="false"
+     inkscape:window-width="1997"
+     inkscape:window-height="1118"
+     inkscape:window-x="352"
+     inkscape:window-y="84"
+     inkscape:window-maximized="0"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3713"
+       originx="0.132501"
+       originy="-58.075763" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0.13250054,-69.325819)">
+    <circle
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.40799999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path3715"
+       cy="154.125"
+       cx="95.25"
+       r="52.916668" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 111.125,93.270831 V 214.97917"
+       id="path4522"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4524"
+       sodipodi:type="arc"
+       sodipodi:cx="95.25"
+       sodipodi:cy="154.125"
+       sodipodi:rx="1.0583333"
+       sodipodi:ry="1.0583333"
+       sodipodi:start="0"
+       sodipodi:end="6.26554"
+       d="m 96.308333,154.125 a 1.0583333,1.0583333 0 0 1 -1.053664,1.05832 1.0583333,1.0583333 0 0 1 -1.062961,-1.04898 1.0583333,1.0583333 0 0 1 1.044286,-1.06758 1.0583333,1.0583333 0 0 1 1.072175,1.03957 L 95.25,154.125 Z" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.26499999, 0.52999997;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 111.125,103.85417 95.25,154.125 l 15.875,50.27083"
+       id="path4528"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.26458332, 0.79374995;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow1Lstart)"
+       d="m 206.37501,154.125 h 52.91666"
+       id="path4530"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.52916663, 0.52916663;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 10.583333,69.458333 259.29167,154.125 10.583333,238.79167"
+       id="path4532"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:0.52999997, 0.52999997;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4534"
+       sodipodi:type="arc"
+       sodipodi:cx="10.583333"
+       sodipodi:cy="154.125"
+       sodipodi:rx="10.583333"
+       sodipodi:ry="84.666664"
+       sodipodi:start="0"
+       sodipodi:end="6.2788558"
+       d="M 21.166666,154.125 A 10.583333,84.666664 0 0 1 10.594788,238.79161 10.583333,84.666664 0 0 1 2.4797576e-5,154.30828 10.583333,84.666664 0 0 1 10.548968,69.458782 10.583333,84.666664 0 0 1 21.166567,153.75844"
+       sodipodi:open="true" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79374995, 0.79374995;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 359.83333,122.375 -100.54166,31.75 100.54166,31.75"
+       id="path4536"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26458332;stroke-miterlimit:4;stroke-dasharray:0.79374994, 0.79374994;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4538"
+       sodipodi:type="arc"
+       sodipodi:cx="359.83334"
+       sodipodi:cy="154.125"
+       sodipodi:rx="5.2916665"
+       sodipodi:ry="31.75"
+       sodipodi:start="0"
+       sodipodi:end="6.2788569"
+       sodipodi:open="true"
+       d="m 365.12501,154.125 a 5.2916665,31.75 0 0 1 -5.28594,31.74998 5.2916665,31.75 0 0 1 -5.29738,-31.68127 5.2916665,31.75 0 0 1 5.27448,-31.81854 5.2916665,31.75 0 0 1 5.30879,31.6124" />
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4524-0"
+       sodipodi:type="arc"
+       sodipodi:cx="259.29166"
+       sodipodi:cy="154.125"
+       sodipodi:rx="1.0583333"
+       sodipodi:ry="1.0583333"
+       sodipodi:start="0"
+       sodipodi:end="6.26554"
+       d="m 260.34999,154.125 a 1.0583333,1.0583333 0 0 1 -1.05366,1.05832 1.0583333,1.0583333 0 0 1 -1.06297,-1.04898 1.0583333,1.0583333 0 0 1 1.04429,-1.06758 1.0583333,1.0583333 0 0 1 1.07218,1.03957 l -1.05817,0.0187 z" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 109.80208,107.82292 5.48066,2.26785 1.60639,-4.2679"
+       id="path4563"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 109.63602,199.26744 5.46051,-2.00174 1.69418,5.15247"
+       id="path4565"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.26458332, 0.79374996;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker6362)"
+       d="M 95.250007,154.125 H 132.29167"
+       id="path4530-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:0.795, 0.795;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow2Mstart)"
+       id="path5412"
+       sodipodi:type="arc"
+       sodipodi:cx="252.3839"
+       sodipodi:cy="157.3031"
+       sodipodi:rx="22.489584"
+       sodipodi:ry="22.489584"
+       sodipodi:start="3.3511363"
+       sodipodi:end="3.6585709"
+       d="m 230.38625,152.62496 a 22.489584,22.489584 0 0 1 2.44708,-6.43746"
+       sodipodi:open="true" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:0.79499999, 0.79499999;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow1Mstart)"
+       id="path6428"
+       sodipodi:type="arc"
+       sodipodi:cx="95.25"
+       sodipodi:cy="154.125"
+       sodipodi:rx="10.583339"
+       sodipodi:ry="10.583339"
+       sodipodi:start="5.1628641"
+       sodipodi:end="6.1468576"
+       d="m 99.857915,144.59745 a 10.583339,10.583339 0 0 1 5.877225,8.08921"
+       sodipodi:open="true" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="105.83334"
+       y="148.83333"
+       id="text6536"><tspan
+         sodipodi:role="line"
+         id="tspan6534"
+         x="105.83334"
+         y="148.83333"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">θ</tspan></text>
+    <flowRoot
+       xml:space="preserve"
+       id="flowRoot6538"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       transform="scale(0.26458333)"><flowRegion
+         id="flowRegion6540"><rect
+           id="rect6542"
+           width="110"
+           height="120"
+           x="1540"
+           y="342.51968" /></flowRegion><flowPara
+         id="flowPara6544" /></flowRoot>    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="87.3125"
+       y="159.41667"
+       id="text6552"><tspan
+         sodipodi:role="line"
+         id="tspan6550"
+         x="87.3125"
+         y="159.41667"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">C</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.29166651px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="92.604164"
+       y="162.0625"
+       id="text6560"><tspan
+         sodipodi:role="line"
+         id="tspan6558"
+         x="92.604164"
+         y="162.0625"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.29166651px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">1</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="113.77084"
+       y="217.625"
+       id="text6564"><tspan
+         sodipodi:role="line"
+         id="tspan6562"
+         x="113.77084"
+         y="217.625"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">Z</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.29166651px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="119.0625"
+       y="220.27083"
+       id="text6568"><tspan
+         sodipodi:role="line"
+         id="tspan6566"
+         x="119.0625"
+         y="220.27083"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.29166651px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">P</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="256.64584"
+       y="164.70833"
+       id="text6572"><tspan
+         sodipodi:role="line"
+         id="tspan6570"
+         x="256.64584"
+         y="164.70833"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">S</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="227.54167"
+       y="191.16658"
+       id="text3754"><tspan
+         sodipodi:role="line"
+         id="tspan3752"
+         x="227.54167"
+         y="200.53035"
+         style="stroke-width:0.26458332" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="223.57292"
+       y="177.93742"
+       id="text3758"><tspan
+         sodipodi:role="line"
+         id="tspan3756"
+         x="223.57292"
+         y="187.30119"
+         style="stroke-width:0.26458332" /></text>
+    <g
+       id="g3814"
+       transform="translate(3.6482291,0.74835468)">
+      <text
+         id="text3770"
+         y="152.46629"
+         x="211.67996"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="152.46629"
+           x="211.67996"
+           id="tspan3768"
+           sodipodi:role="line">2</tspan></text>
+      <text
+         id="text3774"
+         y="148.47095"
+         x="217.11789"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="148.47095"
+           x="217.11789"
+           id="tspan3772"
+           sodipodi:role="line">-θ</tspan></text>
+      <text
+         id="text3778"
+         y="145.38353"
+         x="211.9326"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           id="tspan3780"
+           style="stroke-width:0.26458332"
+           y="145.38353"
+           x="211.9326"
+           sodipodi:role="line">π</tspan></text>
+      <text
+         id="text3786"
+         y="144.80849"
+         x="212.25453"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="144.80849"
+           x="212.25453"
+           id="tspan3784"
+           sodipodi:role="line">_</tspan></text>
+    </g>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker951);marker-end:url(#marker1015)"
+       d="m 301.625,201.74992 0,31.75 h 31.75"
+       id="path889"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1483)"
+       d="M 301.625,233.49992 317.5,212.33326"
+       id="path1473"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="337.80048"
+       y="234.73836"
+       id="text6564-2"><tspan
+         sodipodi:role="line"
+         id="tspan6562-9"
+         x="337.80048"
+         y="234.73836"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">z</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="318.66428"
+       y="210.791"
+       id="text6564-9"><tspan
+         sodipodi:role="line"
+         id="tspan6562-0"
+         x="318.66428"
+         y="210.791"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">x</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="299.58121"
+       y="196.94644"
+       id="text6564-8"><tspan
+         sodipodi:role="line"
+         id="tspan6562-1"
+         x="299.58121"
+         y="196.94644"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">y</tspan></text>
+  </g>
+</svg>

--- a/docs/Images/Domain/CoordinateMaps/FocallyLifted.svg
+++ b/docs/Images/Domain/CoordinateMaps/FocallyLifted.svg
@@ -1,0 +1,697 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="180.01971mm"
+   height="79.620331mm"
+   viewBox="0 0 180.01974 79.620333"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="FocallyLifted.svg">
+  <defs
+     id="defs2">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6059">
+      <stop
+         style="stop-color:#1e82e8;stop-opacity:1;"
+         offset="0"
+         id="stop6055" />
+      <stop
+         style="stop-color:#1e82e8;stop-opacity:0;"
+         offset="1"
+         id="stop6057" />
+    </linearGradient>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5055"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5053"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path4754"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="StopL"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="StopL"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1089"
+         d="M 0,5.65 V -5.65"
+         style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.8)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <linearGradient
+       id="linearGradient6115"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop6113" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4526"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4524" />
+    </linearGradient>
+    <marker
+       inkscape:stockid="StopL"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="StopL-0"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1089-8"
+         d="M 0,5.65 V -5.65"
+         style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.8)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6059"
+       id="radialGradient6063"
+       cx="102.93344"
+       cy="-3.6646354"
+       fx="102.93344"
+       fy="-3.6646354"
+       r="5.382401"
+       gradientTransform="matrix(1,0,0,0.37159071,0,-2.302891)"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.7508882"
+     inkscape:cx="338.30906"
+     inkscape:cy="87.442016"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:window-width="1648"
+     inkscape:window-height="1117"
+     inkscape:window-x="912"
+     inkscape:window-y="667"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-text-baseline="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3713"
+       originx="-7.9667581"
+       originy="-256.65245" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer 2">
+    <path
+       style="fill:#c8c8c8;fill-opacity:1;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 161.1823,29.356172 c -3.90291,-0.661244 -13.22916,3.96875 -19.84374,3.96875 -6.61458,0 -11.90625,-9.260416 -21.16667,0 l -8.9261,-11.68748 c 6.39567,-10.238195 17.3791,-16.7176171 29.43347,-17.3636071 12.05438,-0.64599 23.66737,4.622489 31.1206,14.1185241 z"
+       id="path6087-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccscc" />
+  </g>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-7.9667509,39.27279)">
+    <rect
+       style="fill:#c8c8c8;stroke:#000000;stroke-width:0.26458332;stroke-opacity:1;fill-opacity:1"
+       id="rect4574"
+       width="54.239582"
+       height="62.177082"
+       x="15.874994"
+       y="-28.437506" />
+    <g
+       id="g4641">
+      <text
+         id="text6177-6"
+         y="40.347542"
+         x="17.578501"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="40.347542"
+           x="17.578501"
+           id="tspan6175-7"
+           sodipodi:role="line">x</tspan><tspan
+           id="tspan6179-5"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="48.285042"
+           x="17.578501"
+           sodipodi:role="line" /></text>
+      <text
+         id="text4614"
+         y="38.502483"
+         x="18.203733"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="38.502483"
+           x="18.203733"
+           id="tspan4612"
+           sodipodi:role="line">-</tspan></text>
+      <text
+         id="text6157-5-0-2"
+         y="37.39798"
+         x="22.001791"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           id="tspan6163-4-5-9"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="37.39798"
+           x="22.001791"
+           sodipodi:role="line">0</tspan></text>
+    </g>
+    <g
+       id="g6496">
+      <text
+         id="text6177-6-8"
+         y="30.548027"
+         x="7.7838163"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="30.548027"
+           x="7.7838163"
+           id="tspan6175-7-8"
+           sodipodi:role="line">x</tspan><tspan
+           id="tspan6179-5-5"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="38.485527"
+           x="7.7838163"
+           sodipodi:role="line" /></text>
+      <text
+         id="text4614-0"
+         y="28.702969"
+         x="8.409049"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="28.702969"
+           x="8.409049"
+           id="tspan4612-9"
+           sodipodi:role="line">-</tspan></text>
+      <text
+         id="text6157-5-0-2-6"
+         y="27.598465"
+         x="12.207107"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           id="tspan6163-4-5-9-3"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="27.598465"
+           x="12.207107"
+           sodipodi:role="line">1</tspan></text>
+    </g>
+    <g
+       id="g4740"
+       transform="translate(-25.858565,38.146726)"
+       style="fill:#1e82e8;fill-opacity:1;stroke:#1e82e8;stroke-opacity:1">
+      <text
+         id="text4688"
+         y="-1.9384993"
+         x="97.371895"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.64444447px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.64444447px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+           y="-1.9384993"
+           x="97.371895"
+           id="tspan4686"
+           sodipodi:role="line">σ</tspan></text>
+      <text
+         id="text4692-6"
+         y="-1.8668123"
+         x="101.231"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888903px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+           y="-1.8668123"
+           x="101.231"
+           id="tspan4690-2"
+           sodipodi:role="line">=0</tspan><tspan
+           id="tspan4694-9"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888903px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+           y="4.3067989"
+           x="101.231"
+           sodipodi:role="line" /></text>
+    </g>
+    <g
+       id="g4747"
+       transform="translate(-16.13489,-42.420869)"
+       style="fill:#ef1218;fill-opacity:1;stroke:#ef1218;stroke-opacity:1">
+      <text
+         id="text4692"
+         y="15.218743"
+         x="91.281242"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ef1218;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888903px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ef1218;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+           y="15.218743"
+           x="91.281242"
+           id="tspan4690"
+           sodipodi:role="line">=1</tspan><tspan
+           id="tspan4694"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888903px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ef1218;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+           y="21.392355"
+           x="91.281242"
+           sodipodi:role="line" /></text>
+      <text
+         id="text4688-9"
+         y="15.229761"
+         x="87.635094"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.64444447px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ef1218;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.64444447px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ef1218;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+           y="15.229761"
+           x="87.635094"
+           id="tspan4686-0"
+           sodipodi:role="line">σ</tspan></text>
+    </g>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend)"
+       d="M 26.46568,38.502076 H 39.694847"
+       id="path4749"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker5055)"
+       d="M 10.318744,23.156243 V 8.60416"
+       id="path5045"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#1e82e8;stroke-width:0.76499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 15.874994,33.739577 H 70.114577"
+       id="path6053"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#ef1218;stroke-width:0.76499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 15.874994,-28.437506 H 70.114577"
+       id="path6079"
+       inkscape:connector-curvature="0" />
+    <g
+       id="g6487"
+       transform="translate(-4.630206)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6081"
+         d="m 92.60416,-3.3020896 h 14.55208"
+         style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path6083"
+         d="m 92.60416,-0.65625632 h 14.55208"
+         style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path6085"
+         d="m 104.51041,-5.9479234 3.96875,3.9687499 -3.96875,3.96875"
+         style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+    <g
+       id="g4740-1"
+       transform="translate(69.541142,-1.7892703)"
+       style="fill:#1e82e8;fill-opacity:1;stroke:#1e82e8;stroke-opacity:1">
+      <text
+         id="text4688-3"
+         y="-1.9384993"
+         x="97.371895"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.64444447px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.64444447px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+           y="-1.9384993"
+           x="97.371895"
+           id="tspan4686-1"
+           sodipodi:role="line">σ</tspan></text>
+      <text
+         id="text4692-6-1"
+         y="-1.8668123"
+         x="101.231"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888903px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+           y="-1.8668123"
+           x="101.231"
+           id="tspan4690-2-0"
+           sodipodi:role="line">=0</tspan><tspan
+           id="tspan4694-9-3"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888903px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+           y="4.3067989"
+           x="101.231"
+           sodipodi:role="line" /></text>
+    </g>
+    <g
+       id="g4747-4"
+       transform="translate(74.965706,-50.063314)"
+       style="fill:#ef1218;fill-opacity:1;stroke:#ef1218;stroke-opacity:1">
+      <text
+         id="text4692-0"
+         y="15.218743"
+         x="91.281242"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ef1218;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888903px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ef1218;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+           y="15.218743"
+           x="91.281242"
+           id="tspan4690-3"
+           sodipodi:role="line">=1</tspan><tspan
+           id="tspan4694-91"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888903px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ef1218;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+           y="21.392355"
+           x="91.281242"
+           sodipodi:role="line" /></text>
+      <text
+         id="text4688-9-9"
+         y="15.229761"
+         x="87.635094"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.64444447px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ef1218;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.64444447px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ef1218;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+           y="15.229761"
+           x="87.635094"
+           id="tspan4686-0-6"
+           sodipodi:role="line">σ</tspan></text>
+    </g>
+    <circle
+       id="path3717-9"
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26458332;stroke-opacity:1"
+       cy="1.9895765"
+       cx="150.8125"
+       r="37.041668" />
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6040-6-6"
+       cx="144.19791"
+       cy="15.218743"
+       rx="1.2427398"
+       ry="1.1926293" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:0.26458332,1.05833327;stroke-dashoffset:0"
+       d="m 119.49816,-17.800747 24.69975,33.01949 35.71875,-35.983333"
+       id="path6209"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#1e82e8;stroke-width:0.76499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 128.32291,-5.9479235 c 9.26042,-9.2604165 14.55209,0 21.16667,0 6.61458,0 15.94083,-4.6299945 19.84375,-3.9687504"
+       id="path6087"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       id="path3717-9-0"
+       style="fill:none;fill-opacity:1;stroke:#ef1218;stroke-width:0.76499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       sodipodi:type="arc"
+       sodipodi:cx="150.8125"
+       sodipodi:cy="1.9895765"
+       sodipodi:rx="37.041672"
+       sodipodi:ry="37.041668"
+       sodipodi:start="3.6999671"
+       sodipodi:end="5.6177336"
+       d="m 119.39681,-17.635404 a 37.041672,37.041668 0 0 1 29.43348,-17.363612 37.041672,37.041668 0 0 1 31.1206,14.118529"
+       sodipodi:open="true" />
+    <g
+       transform="translate(97.618665,-44.973657)"
+       id="g6251-0">
+      <text
+         id="text6177-4"
+         y="68.590691"
+         x="41.049763"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="68.590691"
+           x="41.049763"
+           id="tspan6175-6"
+           sodipodi:role="line">P</tspan><tspan
+           id="tspan6179-2"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="76.528191"
+           x="41.049763"
+           sodipodi:role="line" /></text>
+      <text
+         id="text6157-5-0-6"
+         y="64.884178"
+         x="45.419254"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           id="tspan6163-4-5-7"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="64.884178"
+           x="45.419254"
+           sodipodi:role="line">i</tspan></text>
+    </g>
+    <g
+       id="g6351"
+       transform="translate(-10.227028,-2.7268785)"
+       inkscape:transform-center-x="1.6622518"
+       inkscape:transform-center-y="-3.6267342">
+      <text
+         id="text6177-6-6"
+         y="1.3121818"
+         x="142.57787"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+           y="1.3121818"
+           x="142.57787"
+           id="tspan6175-7-9"
+           sodipodi:role="line">x</tspan><tspan
+           id="tspan6179-5-8"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+           y="9.2496815"
+           x="142.57787"
+           sodipodi:role="line" /></text>
+      <text
+         id="text6157-5-0-2-8"
+         y="2.896033"
+         x="146.3967"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           id="tspan6163-4-5-9-2"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke-width:0.26458332"
+           y="2.896033"
+           x="146.3967"
+           sodipodi:role="line">0</tspan></text>
+      <text
+         id="text6157-5-0-2-8-9"
+         y="-2.0960903"
+         x="147.57292"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           id="tspan6163-4-5-9-2-9"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke-width:0.26458332"
+           y="-2.0960903"
+           x="147.57292"
+           sodipodi:role="line">i</tspan></text>
+    </g>
+    <g
+       id="g6426"
+       transform="translate(-2.778193,1.0685358)">
+      <text
+         id="text6177-6-6-0"
+         y="-34.252769"
+         x="128.90784"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ef1218;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ef1218;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+           y="-34.252769"
+           x="128.90784"
+           id="tspan6175-7-9-2"
+           sodipodi:role="line">x</tspan><tspan
+           id="tspan6179-5-8-7"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ef1218;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+           y="-26.315269"
+           x="128.90784"
+           sodipodi:role="line" /></text>
+      <text
+         id="text6157-5-0-2-8-6"
+         y="-32.668919"
+         x="132.72667"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ef1218;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           id="tspan6163-4-5-9-2-1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ef1218;fill-opacity:1;stroke-width:0.26458332"
+           y="-32.668919"
+           x="132.72667"
+           sodipodi:role="line">1</tspan></text>
+      <text
+         id="text6157-5-0-2-8-9-3"
+         y="-37.661041"
+         x="133.90289"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ef1218;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           id="tspan6163-4-5-9-2-9-2"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ef1218;fill-opacity:1;stroke-width:0.26458332"
+           y="-37.661041"
+           x="133.90289"
+           sodipodi:role="line">i</tspan></text>
+    </g>
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6040-7-1"
+       cx="133.61458"
+       cy="-31.08334"
+       rx="1.0924085"
+       ry="1.1425189" />
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6040-7-5"
+       cx="138.37708"
+       cy="-9.9166737"
+       rx="1.0924085"
+       ry="1.1425189" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:0.26499999,1.05999995;stroke-dashoffset:0"
+       d="M 144.19791,15.218743 133.61458,-31.08334"
+       id="path6417"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6040-7-9"
+       cx="136.26041"
+       cy="-19.17709"
+       rx="1.0924085"
+       ry="1.1425189" />
+    <text
+       xml:space="preserve"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+       x="128.20059"
+       y="-17.773655"
+       id="text6177-6-6-1"><tspan
+         sodipodi:role="line"
+         id="tspan6175-7-9-4"
+         x="128.20059"
+         y="-17.773655"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1">x</tspan><tspan
+         sodipodi:role="line"
+         x="128.20059"
+         y="-9.8361549"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+         id="tspan6179-5-8-9" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+       x="133.19565"
+       y="-21.181927"
+       id="text6157-5-0-2-8-9-7"><tspan
+         sodipodi:role="line"
+         x="133.19565"
+         y="-21.181927"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+         id="tspan6163-4-5-9-2-9-5">i</tspan></text>
+    <g
+       id="g6548"
+       transform="translate(-12.822429,-0.32056073)">
+      <text
+         id="text6177-6-8-7"
+         y="14.058769"
+         x="46.022228"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="14.058769"
+           x="46.022228"
+           id="tspan6175-7-8-0"
+           sodipodi:role="line">x</tspan><tspan
+           id="tspan6179-5-5-4"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="21.996269"
+           x="46.022228"
+           sodipodi:role="line" /></text>
+      <text
+         id="text4614-0-8"
+         y="12.213711"
+         x="46.647461"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="12.213711"
+           x="46.647461"
+           id="tspan4612-9-0"
+           sodipodi:role="line">-</tspan></text>
+      <text
+         id="text6157-5-0-2-6-4"
+         y="11.109207"
+         x="50.445518"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           id="tspan6163-4-5-9-3-2"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="11.109207"
+           x="50.445518"
+           sodipodi:role="line">i</tspan></text>
+    </g>
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6040-7-9-9"
+       cx="30.427078"
+       cy="13.895826"
+       rx="1.0924085"
+       ry="1.1425189" />
+  </g>
+</svg>

--- a/docs/Images/Domain/CoordinateMaps/FocallyLiftedEndcap.svg
+++ b/docs/Images/Domain/CoordinateMaps/FocallyLiftedEndcap.svg
@@ -1,0 +1,690 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="186.90083mm"
+   height="74.595894mm"
+   viewBox="0 0 186.90086 74.595899"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="FocallyLiftedEndcap.svg">
+  <defs
+     id="defs2">
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4874"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4872"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4004"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4002"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6059">
+      <stop
+         style="stop-color:#1e82e8;stop-opacity:1;"
+         offset="0"
+         id="stop6055" />
+      <stop
+         style="stop-color:#1e82e8;stop-opacity:0;"
+         offset="1"
+         id="stop6057" />
+    </linearGradient>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5055"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#000000;fill-opacity:0.91764706;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:0.91764706"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5053"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path4754"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="StopL"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="StopL"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1089"
+         d="M 0,5.65 V -5.65"
+         style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.8)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <linearGradient
+       id="linearGradient6115"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop6113" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4526"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4524" />
+    </linearGradient>
+    <marker
+       inkscape:stockid="StopL"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="StopL-0"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1089-8"
+         d="M 0,5.65 V -5.65"
+         style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.8)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6059"
+       id="radialGradient6063"
+       cx="102.93344"
+       cy="-3.6646354"
+       fx="102.93344"
+       fy="-3.6646354"
+       r="5.382401"
+       gradientTransform="matrix(1,0,0,0.37159071,0,-2.302891)"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.7508882"
+     inkscape:cx="428.33293"
+     inkscape:cy="233.77105"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:window-width="1648"
+     inkscape:window-height="1117"
+     inkscape:window-x="376"
+     inkscape:window-y="30"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-text-baseline="false"
+     inkscape:snap-bbox="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3713"
+       originx="4.3383411"
+       originy="-190.36775" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer 2"
+     transform="translate(12.305098,-71.309175)" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(4.3383471,-32.036385)">
+    <g
+       id="g6487"
+       transform="translate(-17.859373,70.114618)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6081"
+         d="m 92.60416,-3.3020896 h 14.55208"
+         style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path6083"
+         d="m 92.60416,-0.65625632 h 14.55208"
+         style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path6085"
+         d="m 104.51041,-5.9479234 3.96875,3.9687499 -3.96875,3.96875"
+         style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.26458332, 1.05833327;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 113.77083,42.999991 26.45833,26.458333 26.45833,-26.458333"
+       id="path6209"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <g
+       id="g6351"
+       transform="translate(-13.704488,39.427891)"
+       inkscape:transform-center-x="1.6622518"
+       inkscape:transform-center-y="-3.6267342">
+      <text
+         id="text6177-6-6"
+         y="1.3121818"
+         x="142.57787"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+           y="1.3121818"
+           x="142.57787"
+           id="tspan6175-7-9"
+           sodipodi:role="line">x</tspan><tspan
+           id="tspan6179-5-8"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+           y="9.2496815"
+           x="142.57787"
+           sodipodi:role="line" /></text>
+      <text
+         id="text6157-5-0-2-8"
+         y="2.896033"
+         x="146.3967"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           id="tspan6163-4-5-9-2"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke-width:0.26458332"
+           y="2.896033"
+           x="146.3967"
+           sodipodi:role="line">0</tspan></text>
+      <text
+         id="text6157-5-0-2-8-9"
+         y="-2.0960903"
+         x="147.57292"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           id="tspan6163-4-5-9-2-9"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke-width:0.26458332"
+           y="-2.0960903"
+           x="147.57292"
+           sodipodi:role="line">i</tspan></text>
+    </g>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.26499999, 1.05999995;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 140.16457,68.782104 0.0646,-36.365447"
+       id="path6417"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path1335"
+       sodipodi:type="arc"
+       sodipodi:cx="103.18748"
+       sodipodi:cy="61.520821"
+       sodipodi:rx="19.84375"
+       sodipodi:ry="9.260417"
+       sodipodi:start="3.3894385"
+       sodipodi:end="3.4031651"
+       sodipodi:open="true"
+       d="m 83.95009,59.24909 a 19.84375,9.260417 0 0 1 0.06863,-0.123012" />
+    <ellipse
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path1345-0"
+       ry="5.291667"
+       rx="27.78125"
+       cy="45.645824"
+       cx="29.10416" />
+    <ellipse
+       style="fill:#1e82e8;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path1345-0-9"
+       ry="5.2916684"
+       rx="27.78125"
+       cy="90.624992"
+       cx="29.10416" />
+    <g
+       id="g1393"
+       transform="translate(22.281981,53.82212)">
+      <text
+         id="text6177-6"
+         y="40.347542"
+         x="17.578501"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="40.347542"
+           x="17.578501"
+           id="tspan6175-7"
+           sodipodi:role="line">x</tspan><tspan
+           id="tspan6179-5"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="48.285042"
+           x="17.578501"
+           sodipodi:role="line" /></text>
+      <text
+         id="text4614"
+         y="38.502483"
+         x="18.203733"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="38.502483"
+           x="18.203733"
+           id="tspan4612"
+           sodipodi:role="line">-</tspan></text>
+    </g>
+    <g
+       id="g3411"
+       transform="translate(-12.395015,53.213082)">
+      <text
+         id="text6177-6-8"
+         y="30.548027"
+         x="7.7838163"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="30.548027"
+           x="7.7838163"
+           id="tspan6175-7-8"
+           sodipodi:role="line">z</tspan><tspan
+           id="tspan6179-5-5"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="38.485527"
+           x="7.7838163"
+           sodipodi:role="line" /></text>
+      <text
+         id="text4614-0"
+         y="28.702969"
+         x="8.409049"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="28.702969"
+           x="8.409049"
+           id="tspan4612-9"
+           sodipodi:role="line">-</tspan></text>
+    </g>
+    <g
+       id="g4740"
+       transform="translate(-38.574141,94.244855)"
+       style="fill:#1e82e8;fill-opacity:1;stroke:#1e82e8;stroke-opacity:1">
+      <text
+         id="text4688"
+         y="-1.9384993"
+         x="97.371895"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.64444447px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.64444447px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+           y="-1.9384993"
+           x="97.371895"
+           id="tspan4686"
+           sodipodi:role="line">σ</tspan></text>
+      <text
+         id="text4692-6"
+         y="-1.8668123"
+         x="101.231"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888903px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+           y="-1.8668123"
+           x="101.231"
+           id="tspan4690-2"
+           sodipodi:role="line">=0</tspan><tspan
+           id="tspan4694-9"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888903px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+           y="4.3067989"
+           x="101.231"
+           sodipodi:role="line" /></text>
+    </g>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend)"
+       d="m 27.781243,91.154157 13.129718,4.091979"
+       id="path4749"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker5055)"
+       d="M -2.6458405,75.668275 V 61.116192"
+       id="path5045"
+       inkscape:connector-curvature="0" />
+    <g
+       id="g6548"
+       transform="translate(-38.615796,79.098338)">
+      <text
+         id="text6177-6-8-7"
+         y="14.058769"
+         x="46.022228"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="14.058769"
+           x="46.022228"
+           id="tspan6175-7-8-0"
+           sodipodi:role="line">x</tspan><tspan
+           id="tspan6179-5-5-4"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="21.996269"
+           x="46.022228"
+           sodipodi:role="line" /></text>
+      <text
+         id="text4614-0-8"
+         y="12.213711"
+         x="46.647461"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="12.213711"
+           x="46.647461"
+           id="tspan4612-9-0"
+           sodipodi:role="line">-</tspan></text>
+      <text
+         id="text6157-5-0-2-6-4"
+         y="11.109207"
+         x="50.445518"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           id="tspan6163-4-5-9-3-2"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="11.109207"
+           x="50.445518"
+           sodipodi:role="line">i</tspan></text>
+    </g>
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6040-7-9-9"
+       cx="14.552076"
+       cy="90.624992"
+       rx="1.0924085"
+       ry="1.1425189" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 1.3229095,90.624989 V 45.645824"
+       id="path1383"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 56.885409,90.624989 V 45.645824"
+       id="path1385"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <circle
+       id="path3717-9"
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26458332;stroke-opacity:1"
+       cy="69.458321"
+       cx="140.22916"
+       r="37.041668" />
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6040-7-9-9-6"
+       cx="140.22916"
+       cy="69.458321"
+       rx="1.0924085"
+       ry="1.1425189" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#1e82e8;stroke-width:0.76499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path3806"
+       sodipodi:type="arc"
+       sodipodi:cx="140.22916"
+       sodipodi:cy="69.458321"
+       sodipodi:rx="37.041668"
+       sodipodi:ry="37.041668"
+       sodipodi:start="3.9341107"
+       sodipodi:end="5.4835909"
+       sodipodi:open="true"
+       d="m 114.22389,43.080085 a 37.041668,37.041668 0 0 1 51.82322,-0.183361" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 103.18749,42.999989 h 79.375"
+       id="path3913"
+       inkscape:connector-curvature="0" />
+    <g
+       id="g3955"
+       transform="translate(-25.571526,-84.982116)">
+      <text
+         id="text6177-4-8"
+         y="129.51512"
+         x="109.04856"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="129.51512"
+           x="109.04856"
+           id="tspan6175-6-5"
+           sodipodi:role="line">z = z</tspan><tspan
+           id="tspan6179-2-6"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="137.45262"
+           x="109.04856"
+           sodipodi:role="line" /></text>
+      <text
+         id="text6157-5-0-6-1"
+         y="131.15129"
+         x="125.2788"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           id="tspan6163-4-5-7-1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="131.15129"
+           x="125.2788"
+           sodipodi:role="line">P</tspan></text>
+    </g>
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6040-7-5"
+       cx="126.99999"
+       cy="35.062492"
+       rx="1.0924085"
+       ry="1.1425189" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="143.37407"
+       y="58.859402"
+       id="text6177-4-9"><tspan
+         sodipodi:role="line"
+         id="tspan6175-6-8"
+         x="143.37407"
+         y="58.859402"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">θ</tspan><tspan
+         sodipodi:role="line"
+         x="143.37407"
+         y="66.796898"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="tspan6179-2-4" /></text>
+    <path
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.91764706;marker-end:url(#marker4004)"
+       id="path3994"
+       sodipodi:type="arc"
+       sodipodi:cx="140.22916"
+       sodipodi:cy="69.458321"
+       sodipodi:rx="21.166662"
+       sodipodi:ry="21.166662"
+       sodipodi:start="4.7145202"
+       sodipodi:end="5.3945086"
+       d="m 140.27427,48.291706 a 21.166662,21.166662 0 0 1 13.29919,4.736243"
+       sodipodi:open="true" />
+    <g
+       id="g1400"
+       transform="translate(-0.6770013,50.554705)">
+      <text
+         id="text6177-6-4"
+         y="40.394913"
+         x="25.539686"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="40.394913"
+           x="25.539686"
+           id="tspan6175-7-81"
+           sodipodi:role="line">y</tspan><tspan
+           id="tspan6179-5-2"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="48.332413"
+           x="25.539686"
+           sodipodi:role="line" /></text>
+      <text
+         id="text4614-9"
+         y="38.549854"
+         x="26.164919"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="38.549854"
+           x="26.164919"
+           id="tspan4612-3"
+           sodipodi:role="line">-</tspan></text>
+    </g>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4874)"
+       d="m 27.781243,91.154157 7.408333,-5.291666"
+       id="path4864"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <g
+       id="g4740-3"
+       transform="translate(65.671948,39.986007)"
+       style="fill:#1e82e8;fill-opacity:1;stroke:#1e82e8;stroke-opacity:1">
+      <text
+         id="text4688-0"
+         y="-1.9384993"
+         x="97.371895"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.64444447px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.64444447px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+           y="-1.9384993"
+           x="97.371895"
+           id="tspan4686-4"
+           sodipodi:role="line">σ</tspan></text>
+      <text
+         id="text4692-6-4"
+         y="-1.8668123"
+         x="101.231"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888903px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+           y="-1.8668123"
+           x="101.231"
+           id="tspan4690-2-4"
+           sodipodi:role="line">=0</tspan><tspan
+           id="tspan4694-9-4"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888903px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#1e82e8;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+           y="4.3067989"
+           x="101.231"
+           sodipodi:role="line" /></text>
+    </g>
+    <g
+       id="g7052"
+       transform="translate(12.089103,-4.2311859)">
+      <text
+         id="text6177-4-8-6"
+         y="80.285233"
+         x="128.09396"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="80.285233"
+           x="128.09396"
+           id="tspan6175-6-5-3"
+           sodipodi:role="line">C</tspan><tspan
+           id="tspan6179-2-6-1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="88.222733"
+           x="128.09396"
+           sodipodi:role="line" /></text>
+      <text
+         id="text6157-5-0-6-1-7"
+         y="77.085762"
+         x="134.19958"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           id="tspan6163-4-5-7-1-5"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="77.085762"
+           x="134.19958"
+           sodipodi:role="line">i</tspan></text>
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="125.08685"
+       y="64.939995"
+       id="text6177-4-8-6-6"><tspan
+         sodipodi:role="line"
+         id="tspan6175-6-5-3-2"
+         x="125.08685"
+         y="64.939995"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">R</tspan><tspan
+         sodipodi:role="line"
+         x="125.08685"
+         y="72.877495"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="tspan6179-2-6-1-1" /></text>
+  </g>
+</svg>

--- a/docs/References.bib
+++ b/docs/References.bib
@@ -214,6 +214,21 @@
   primaryClass   = "math",
 }
 
+@article{Buchman:2012dw,
+    author = "Buchman, Luisa T. and Pfeiffer, Harald P. and Scheel, Mark A.
+             and Szilagyi, Bela",
+    title = "{Simulations of non-equal mass black hole binaries with
+              spectral methods}",
+    eprint = "1206.3015",
+    archivePrefix = "arXiv",
+    primaryClass = "gr-qc",
+    doi = "10.1103/PhysRevD.86.084033",
+    journal = "Phys. Rev. D",
+    volume = "86",
+    pages = "084033",
+    year = "2012"
+}
+
 @book{Chandrasekhar1939,
   author = "Chandrasekhar, Subrahmanyan",
   title  = "An introduction to the study of stellar structure",

--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   Affine.cpp
   BulgedCube.cpp
+  CylindricalEndcap.cpp
   DiscreteRotation.cpp
   EquatorialCompression.cpp
   Equiangular.cpp
@@ -33,6 +34,7 @@ spectre_target_headers(
   CoordinateMap.hpp
   CoordinateMap.tpp
   CoordinateMapHelpers.hpp
+  CylindricalEndcap.hpp
   DiscreteRotation.hpp
   EquatorialCompression.hpp
   Equiangular.hpp
@@ -61,6 +63,8 @@ target_link_libraries(
   DomainStructure
   ErrorHandling
   FunctionsOfTime
+  GSL::gsl
+  RootFinding
   )
 
 add_subdirectory(TimeDependent)

--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -13,6 +13,7 @@ spectre_target_sources(
   DiscreteRotation.cpp
   EquatorialCompression.cpp
   Equiangular.cpp
+  FocallyLiftedMapHelpers.cpp
   Frustum.cpp
   Identity.cpp
   Rotation.cpp
@@ -33,6 +34,7 @@ spectre_target_headers(
   DiscreteRotation.hpp
   EquatorialCompression.hpp
   Equiangular.hpp
+  FocallyLiftedMapHelpers.hpp
   Frustum.hpp
   Identity.hpp
   MapInstantiationMacros.hpp

--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -13,6 +13,7 @@ spectre_target_sources(
   DiscreteRotation.cpp
   EquatorialCompression.cpp
   Equiangular.cpp
+  FocallyLiftedMap.cpp
   FocallyLiftedMapHelpers.cpp
   Frustum.cpp
   Identity.cpp
@@ -34,6 +35,7 @@ spectre_target_headers(
   DiscreteRotation.hpp
   EquatorialCompression.hpp
   Equiangular.hpp
+  FocallyLiftedMap.hpp
   FocallyLiftedMapHelpers.hpp
   Frustum.hpp
   Identity.hpp

--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -13,6 +13,7 @@ spectre_target_sources(
   DiscreteRotation.cpp
   EquatorialCompression.cpp
   Equiangular.cpp
+  FocallyLiftedEndcap.cpp
   FocallyLiftedMap.cpp
   FocallyLiftedMapHelpers.cpp
   Frustum.cpp
@@ -35,6 +36,7 @@ spectre_target_headers(
   DiscreteRotation.hpp
   EquatorialCompression.hpp
   Equiangular.hpp
+  FocallyLiftedEndcap.hpp
   FocallyLiftedMap.hpp
   FocallyLiftedMapHelpers.hpp
   Frustum.hpp

--- a/src/Domain/CoordinateMaps/CylindricalEndcap.cpp
+++ b/src/Domain/CoordinateMaps/CylindricalEndcap.cpp
@@ -1,0 +1,234 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/CylindricalEndcap.hpp"
+
+#include <optional>
+#include <pup.h>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/FocallyLiftedEndcap.hpp"
+#include "Domain/CoordinateMaps/FocallyLiftedMap.hpp"
+#include "Parallel/PupStlCpp11.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace domain::CoordinateMaps {
+
+CylindricalEndcap::CylindricalEndcap(const std::array<double, 3>& center_one,
+                                     const std::array<double, 3>& center_two,
+                                     const std::array<double, 3>& proj_center,
+                                     double radius_one, double radius_two,
+                                     double z_plane) noexcept
+    : impl_(center_two, proj_center, radius_two,
+            FocallyLiftedInnerMaps::Endcap(center_one, radius_one, z_plane)) {
+#ifdef SPECTRE_DEBUG
+  // There are two types of sanity checks here on the map parameters.
+  // 1) ASSERTS that guarantee that the map is invertible.
+  // 2) ASSERTS that guarantee that the map parameters fall within
+  //    the range tested by the unit tests (which is the range in which
+  //    the map is expected to be used).
+  //
+  // There are two reasons why 1) and 2) are not the same:
+  //
+  // a) It is possible to choose parameters such that the map is
+  //    invertible but the resulting geometry has very sharp angles,
+  //    very large or ill-conditioned Jacobians, or both.  We want to
+  //    avoid such cases.
+  // b) We do not want to waste effort testing the map for parameters
+  //    that we don't expect to be used.  For example, we demand
+  //    here that proj_center and sphere_one are contained within
+  //    sphere_two, but the map should still be valid for some choices
+  //    of parameters where sphere_one and sphere_two are disjoint;
+  //    allowing those parameter choices would involve much more
+  //    complicated logic to determine whether the map produces shapes
+  //    with sharp angles or large jacobians, and it would involve more
+  //    complicated unit tests to cover those possibilities.
+
+  // First test for invertibility.
+
+  // Consider the intersection of sphere_one and the plane formed by
+  // z_plane.  Call it circle_one.  Consider the cone with apex
+  // center_one that intersects sphere_one on circle_one. This cone
+  // has an opening angle 2*theta.  Call the cone 'cone_one'.
+  const double cos_theta = (z_plane - center_one[2]) / radius_one;
+
+  // Now consider a different cone, called 'invertibility_cone', constructed so
+  // that invertibility_cone and cone_one intersect each other on circle_one at
+  // right angles.  The apex of invertibility_cone is invertibility_cone_apex,
+  // defined as follows:
+  const std::array<double, 3> invertibility_cone_apex = {
+      center_one[0], center_one[1], center_one[2] + radius_one / cos_theta};
+  // invertibility_cone opens in the -z direction with opening angle
+  // 2*(pi/2-theta). invertibility_cone_apex is labeled 'S' in the 'Allowed
+  // Region' figure in CylindricalEndcap.hpp
+
+  // A necessary condition for invertibility is that proj_center lies
+  // either inside of invertibility_cone or inside of the reflection of
+  // invertibility_cone (a cone with apex invertibility_cone_apex but opening in
+  // the +x direction with opening angle 2*(pi/2-theta)).
+
+  // Determine the angle of proj_center relative to invertibility_cone_apex.
+  // Call this angle alpha.
+  const double dist_cone_proj =
+      sqrt(square(invertibility_cone_apex[0] - proj_center[0]) +
+           square(invertibility_cone_apex[1] - proj_center[1]) +
+           square(invertibility_cone_apex[2] - proj_center[2]));
+  const double cos_alpha =
+      (invertibility_cone_apex[2] - proj_center[2]) / dist_cone_proj;
+
+  // Now make sure that alpha < pi/2-theta.
+  // The cone on either side of invertibility_cone_apex is ok, so we use abs
+  // below.
+  ASSERT(acos(abs(cos_alpha)) < abs(asin(cos_theta)),
+         "The arguments passed into the CylindricalEndcap constructor "
+         "yield a noninvertible map.");
+
+  // Another necessary condition for invertibility is that proj_center
+  // cannot lie between sphere_one and invertibility_cone_apex.
+  const double proj_radius_one_squared =
+      square(center_one[0] - proj_center[0]) +
+      square(center_one[1] - proj_center[1]) +
+      square(center_one[2] - proj_center[2]);
+  ASSERT(proj_center[2] > invertibility_cone_apex[2] or
+             proj_center[2] < z_plane or
+             proj_radius_one_squared < square(radius_one),
+         "The arguments passed into the CylindricalEndcap constructor "
+         "yield a noninvertible map.");
+
+  // Other sanity checks that may be relaxed if there is more logic
+  // added and more unit tests to test these cases.
+  // We put these sanity checks in a separate place precisely because
+  // they may be relaxed in the future, whereas the above sanity checks
+  // are hard limits that shouldn't be touched.
+
+  ASSERT(proj_center[2] < z_plane,
+         "The map hasn't been tested for the "
+         "case where proj_center is at larger z than the z_plane. "
+         "The map may still be invertible, but further "
+         "testing would be needed to ensure that jacobians are not "
+         "ill-conditioned.");
+
+  ASSERT(abs(cos_theta) <= 0.9,
+         "z_plane is too far from the center of sphere_one. "
+             << "cos_theta = " << cos_theta
+             << ". If |cos_theta| > 1 the map is singular.  If 0.9 < "
+                "|cos_theta| < 1 then the map is not singular, but the "
+                "jacobians are likely to be large and the map has not been "
+                "tested for these parameters.");
+  ASSERT(abs(cos_theta) >= 0.1,
+         "z_plane is too close to the center of sphere_one. "
+             << "cos_theta = " << cos_theta
+             << ". The map is not singular, but the jacobians are likely to be "
+                "large and the map has not been tested for this choice of "
+                "parameters.");
+
+  const double dist_spheres = sqrt(square(center_one[0] - center_two[0]) +
+                                   square(center_one[1] - center_two[1]) +
+                                   square(center_one[2] - center_two[2]));
+  ASSERT(dist_spheres + radius_one < radius_two,
+         "The map has been tested only for the case when "
+         "sphere_one is contained inside sphere_two");
+
+  const double proj_radius_two_squared =
+      square(center_two[0] - proj_center[0]) +
+      square(center_two[1] - proj_center[1]) +
+      square(center_two[2] - proj_center[2]);
+  ASSERT(proj_radius_two_squared < square(radius_two),
+         "The map has been tested only for the case when "
+         "proj_center is contained inside sphere_two");
+
+  // Check if we are too close to singular.  We do this check
+  // separately from the earlier similar check because this check may
+  // be changed in the future based on further testing and further
+  // logic that may be added (for example we may want to change the
+  // 0.95 to some other number), but the previous check (without the
+  // 0.95) is a hard limit that should always be obeyed.
+  ASSERT(acos(abs(cos_alpha)) < abs(0.95 * asin(cos_theta)),
+         "Parameters are close to where the map becomes "
+         "non-invertible.  The map has not been tested for this case.");
+
+  // Check if opening angle is small enough.
+  const double max_opening_angle = M_PI / 3.0;
+  const double max_proj_center_z = z_plane - radius_one *
+                                                 sqrt(1.0 - square(cos_theta)) /
+                                                 tan(max_opening_angle);
+  ASSERT(proj_center[2] < max_proj_center_z,
+         "proj_center is too close to z_plane. The "
+         "map has not been tested for this case.");
+  // Let a line segment be drawn between the projection point and any
+  // point on the intersection circle (the circle where sphere 1
+  // intersects z_plane). Consider the angle between that line segment
+  // and the z axis, and let beta be the maximum of that angle (over all points
+  // on the intersection circle).  We demand that beta is less than a certain
+  // maximum opening angle.
+  const double tan_beta = sqrt(square(center_one[0] - proj_center[0]) +
+                               square(center_one[1] - proj_center[1])) /
+                          (max_proj_center_z - proj_center[2]);
+  ASSERT(tan_beta < tan(max_opening_angle),
+         "Opening angle is too large. The map has not "
+         "been tested for this case.");
+#endif
+}
+
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, 3> CylindricalEndcap::operator()(
+    const std::array<T, 3>& source_coords) const noexcept {
+  return impl_.operator()(source_coords);
+}
+
+std::optional<std::array<double, 3>> CylindricalEndcap::inverse(
+    const std::array<double, 3>& target_coords) const noexcept {
+  return impl_.inverse(target_coords);
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
+CylindricalEndcap::jacobian(const std::array<T, 3>& source_coords) const
+    noexcept {
+  return impl_.jacobian(source_coords);
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
+CylindricalEndcap::inv_jacobian(const std::array<T, 3>& source_coords) const
+    noexcept {
+  return impl_.inv_jacobian(source_coords);
+}
+
+void CylindricalEndcap::pup(PUP::er& p) noexcept { p | impl_; }
+
+bool operator==(const CylindricalEndcap& lhs,
+                const CylindricalEndcap& rhs) noexcept {
+  return lhs.impl_ == rhs.impl_;
+}
+bool operator!=(const CylindricalEndcap& lhs,
+                const CylindricalEndcap& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+// Explicit instantiations
+/// \cond
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                   \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>                 \
+  CylindricalEndcap::operator()(                                               \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;         \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame>   \
+  CylindricalEndcap::jacobian(const std::array<DTYPE(data), 3>& source_coords) \
+      const noexcept;                                                          \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame>   \
+  CylindricalEndcap::inv_jacobian(                                             \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
+                                      std::reference_wrapper<const double>,
+                                      std::reference_wrapper<const DataVector>))
+
+#undef DTYPE
+#undef INSTANTIATE
+/// \endcond
+
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/CylindricalEndcap.hpp
+++ b/src/Domain/CoordinateMaps/CylindricalEndcap.hpp
@@ -1,0 +1,162 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines the class CylindricalEndcap.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <optional>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/CoordinateMaps/FocallyLiftedEndcap.hpp"
+#include "Domain/CoordinateMaps/FocallyLiftedMap.hpp"
+#include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace domain::CoordinateMaps {
+
+/*!
+ * \ingroup CoordinateMapsGroup
+ *
+ * \brief Map from 3D unit right cylinder to a volume that connects
+ *  portions of two spherical surfaces.
+ *
+ * \image html CylindricalEndcap.svg "A cylinder maps to the shaded region."
+ *
+ * \details Consider two spheres with centers \f$C_1\f$ and \f$C_2\f$,
+ * and radii \f$R_1\f$ and \f$R_2\f$. Let sphere 1 be intersected by a
+ * plane normal to the \f$z\f$ axis and located at \f$z = z_\mathrm{P}\f$.
+ * Also let there be a projection point \f$P\f$.
+ *
+ * CylindricalEndcap maps a 3D unit right cylinder (with coordinates
+ * \f$(\bar{x},\bar{y},\bar{z})\f$ such that \f$-1\leq\bar{z}\leq 1\f$
+ * and \f$\bar{x}^2+\bar{y}^2 \leq 1\f$) to the shaded area
+ * in the figure above (with coordinates \f$(x,y,z)\f$).  The "bottom"
+ * of the cylinder \f$\bar{z}=-1\f$ is mapped to the portion of sphere
+ * 1 that has \f$z \geq z_\mathrm{P}\f$.  Curves of constant
+ * \f$(\bar{x},\bar{y})\f$ are mapped to portions of lines that pass
+ * through \f$P\f$. Along each of these curves, \f$\bar{z}=-1\f$ is
+ * mapped to a point on sphere 1 and \f$\bar{z}=+1\f$ is mapped to a
+ * point on sphere 2.
+ *
+ * CylindricalEndcap is intended to be composed with Wedge2D maps to
+ * construct a portion of a cylindrical domain for a binary system.
+ *
+ * CylindricalEndcap is described briefly in the Appendix of
+ * \cite Buchman:2012dw.
+ * CylindricalEndcap is used to construct the blocks labeled 'CA
+ * wedge', 'EA wedge', 'CB wedge', 'EE wedge', and 'EB wedge' in
+ * Figure 20 of that paper.
+ *
+ * CylindricalEndcap is implemented using `FocallyLiftedMap`
+ * and `FocallyLiftedInnerMaps::Endcap`; see those classes for details.
+ *
+ * ### Restrictions on map parameters.
+ *
+ * We demand that Sphere 1 is fully contained inside Sphere 2. It is
+ * possible to construct a valid map without this assumption, but the
+ * assumption simplifies the code, and the expected use cases obey
+ * this restriction.
+ *
+ * We also demand that \f$z_\mathrm{P} > C_1^2\f$, that is, the plane
+ * in the above and below figures lies to the right of \f$C_1^2\f$.
+ * This restriction not strictly necessary but is made for simplicity.
+ *
+ * The map is invertible only for some choices of the projection point
+ * \f$P\f$.  Given the above restrictions, the allowed values of
+ * \f$P\f$ are illustrated by the following diagram:
+ *
+ * \image html CylindricalEndcap_Allowed.svg "Allowed region for P." width=75%
+ *
+ * The plane \f$z=z_\mathrm{P}\f$ intersects sphere 1 on a circle. The
+ * cone with apex \f$C_1\f$ that intersects that circle has opening
+ * angle \f$2\theta\f$ as shown in the above figure. Construct another
+ * cone, the "invertibility cone", with apex \f$S\f$ chosen such that
+ * the two cones intersect at right angles on the circle; thus the
+ * opening angle of the invertibility cone is \f$\pi-2\theta\f$.  A
+ * necessary condition for invertibility is that the projection point
+ * \f$P\f$ lies inside the invertibility cone, but not between \f$S\f$
+ * and sphere 1.  (If \f$P\f$ does not obey this condition, then from the
+ * diagram one can find at least one line through \f$P\f$
+ * that twice intersects the surface of sphere 1 with \f$z>z_\mathrm{P}\f$;
+ * the inverse map is thus double-valued at those intersection points.)
+ * Placing the projection point \f$P\f$ to the
+ * right of \f$S\f$ (but inside the invertibility cone) is ok for
+ * invertibility.
+ *
+ * In addition to invertibility and the two additional restrictions
+ * already mentioned above, we demand a few more restrictions on the
+ * map parameters to simplify the logic for the expected use cases and
+ * to ensure that jacobians do not get too large. We demand:
+ *
+ * - \f$P\f$ is not too close to the edge of the invertibility cone.
+ *   Here we demand that the angle between \f$P\f$ and \f$S\f$
+ *   is less than \f$0.95 (\pi/2-\theta)\f$ (note that if this
+ *   angle is exactly \f$\pi/2-\theta\f$ it is exactly on the
+ *   invertibility cone); The 0.95 was chosen empirically based on
+ *   unit tests.
+ * - \f$P\f$ is contained in sphere 2.
+ * - \f$P\f$ is to the left of \f$z_\mathrm{P}\f$.
+ * - \f$z_\mathrm{P}\f$ is not too close to the center or the edge of sphere 1.
+ *   Here we demand that \f$0.1 \leq \cos(\theta) \leq 0.9\f$, where
+ *   the values 0.1 and 0.9 were chosen empirically based on unit tests.
+ * - If a line segment is drawn between \f$P\f$ and any point on the
+ *   intersection circle (the circle where sphere 1 intersects the
+ *   plane \f$z=z_\mathrm{P}\f$), the angle between the line segment and
+ *   the z-axis is smaller than \f$\pi/3\f$.
+ *
+ */
+class CylindricalEndcap {
+ public:
+  static constexpr size_t dim = 3;
+  CylindricalEndcap(const std::array<double, 3>& center_one,
+                       const std::array<double, 3>& center_two,
+                       const std::array<double, 3>& proj_center,
+                       double radius_one, double radius_two,
+                       double z_plane) noexcept;
+
+  CylindricalEndcap() = default;
+  ~CylindricalEndcap() = default;
+  CylindricalEndcap(CylindricalEndcap&&) = default;
+  CylindricalEndcap(const CylindricalEndcap&) = default;
+  CylindricalEndcap& operator=(const CylindricalEndcap&) = default;
+  CylindricalEndcap& operator=(CylindricalEndcap&&) = default;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  std::optional<std::array<double, 3>> inverse(
+      const std::array<double, 3>& target_coords) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> jacobian(
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> inv_jacobian(
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  // clang-tidy: google runtime references
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+  static bool is_identity() noexcept { return false; }
+
+ private:
+  friend bool operator==(const CylindricalEndcap& lhs,
+                         const CylindricalEndcap& rhs) noexcept;
+  FocallyLiftedMap<FocallyLiftedInnerMaps::Endcap> impl_;
+};
+bool operator!=(const CylindricalEndcap& lhs,
+                const CylindricalEndcap& rhs) noexcept;
+
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/FocallyLiftedEndcap.cpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedEndcap.cpp
@@ -1,0 +1,402 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/FocallyLiftedEndcap.hpp"
+
+#include <cmath>
+#include <limits>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/FocallyLiftedMapHelpers.hpp"
+#include "Parallel/PupStlCpp11.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace domain::CoordinateMaps::FocallyLiftedInnerMaps {
+
+namespace Endcap_detail {
+double sin_ax_over_x(const double x, const double a) noexcept {
+  // sin(ax)/x returns the right thing except if x is zero, so
+  // we need to treat only that case as special.
+  return x == 0.0 ? a : sin(a * x) / x;
+}
+DataVector sin_ax_over_x(const DataVector& x, const double a) noexcept {
+  DataVector result(x);
+  for (size_t i = 0; i < x.size(); ++i) {
+    result[i] = sin_ax_over_x(x[i], a);
+  }
+  return result;
+}
+double one_over_x_d_sin_ax_over_x(const double x, const double a) noexcept {
+  // Evaluates (1/x) d/dx [ sin(ax)/x ], which is the quantity that
+  // approaches a finite limit as x approaches zero.
+  //
+  // Here we need to worry about roundoff. Note that we can expand
+  // (1/x) d/dx [ sin(ax)/x ] =
+  // a/x^2 [ 1 - 1 - 2(ax)^2/3! + 4(ax)^4/5! - 6(ax)^6/7! + ...],
+  // where I kept the "1 - 1" above as a reminder that when evaluating
+  // this function directly as (a * cos(ax) - sin(ax) / x) / square(x)
+  // there can be significant roundoff because of the "1" in each of the
+  // two terms that are subtracted.
+  //
+  // The relative error in the above expression, if evaluated directly,
+  // is 3*eps/(ax)^2 where eps is machine epsilon.  (That expression comes
+  // from replacing "1 - 1" with eps and noting that the correct answer
+  // is the 2(ax)^2/3! term and eps is an error contribution).
+  // This means the error is 100% if (ax)^2 is 3*eps.
+  //
+  // The solution is to evaluate the series if (ax) is small enough.
+  // Suppose we keep up to and including the (ax)^(2n) term in the
+  // series.  Then the series is accurate if the (ax)^{2n+2} term (the
+  // next term in the series) is small, i.e. if
+  // (2n+2)(ax)^{2n+2}/(2n+3)! < eps.
+  //
+  // For the worst case of (2n+2)(ax)^{2n+2}/(2n+3)! == eps, the direct
+  // evaluation still has a relative error of 3*eps/(ax)^2, which evaluates to
+  // error = 3*eps* eps^{-1/(n+1)} * ((2n+2)/(2n+3)!)^{1/(n+1)}.
+  // This can be rewritten as
+  // error = 3 * [eps^n*((2n+2)/(2n+3)!)]^{1/(n+1)}.
+  //
+  // For certain values of n:
+  // n=1    error=3*sqrt(eps/30)               ~ 5e-9
+  // n=2    error=3*(eps^2/840)^(1/3)          ~ 7e-12
+  // n=3    error=3*(eps^3/45360)^(1/4)        ~ 2e-13
+  // n=4    error=3*(eps^4/3991680)^(1/5)      ~ 2e-14
+  // n=5    error=3*(eps^5/518918400)^(1/6)    ~ 5e-15
+  // n=6    error=3*(eps^6/93405312000)^(1/7)  ~ 1e-15
+  //
+  // We gain less and less with each order.
+  //
+  // So here we choose n=3.
+  // Then the series above can be rewritten
+  // 1/x d/dx [ sin(ax)/x ] = a/x^2 [- 2(ax)^2/3! + 4(ax)^4/5! - 6(ax)^6/7!]
+  //                        = -a^3/3 [ 1 - 4*3*(ax)^2/5! + 6*3*(ax)^4/7!]
+  const double ax = a*x;
+  return pow<8>(ax) < 45360.0 * std::numeric_limits<double>::epsilon()
+             ? (-cube(a) / 3.0) *
+                   (1.0 + square(ax) * (-0.1 + square(ax) / 280.0))
+             : (a * cos(ax) - sin(ax) / x) / square(x);
+}
+DataVector one_over_x_d_sin_ax_over_x(const DataVector& x,
+                                      const double a) noexcept {
+  DataVector result(x);
+  for (size_t i = 0; i < x.size(); ++i) {
+    result[i] = one_over_x_d_sin_ax_over_x(x[i], a);
+  }
+  return result;
+}
+}  // namespace Endcap_detail
+
+Endcap::Endcap(const std::array<double, 3>& center, const double radius,
+               const double z_plane) noexcept
+    : center_(center),
+      radius_([&radius]() noexcept {
+        // The equal_within_roundoff below has an implicit scale of 1,
+        // so the ASSERT may trigger in the case where we really
+        // want an entire domain that is very small.
+        ASSERT(not equal_within_roundoff(radius, 0.0),
+               "Cannot have zero radius");
+        return radius;
+      }()),
+      theta_max_([&center,&radius,&z_plane]() noexcept {
+        const double cos_theta_max = (z_plane - center[2]) / radius;
+        ASSERT(abs(cos_theta_max) < 1.0,
+               "Plane must intersect sphere, and at more than one point");
+        return acos(cos_theta_max);
+      }()) {}
+
+template <typename T>
+void Endcap::forward_map(
+    const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>&
+        target_coords,
+    const std::array<T, 3>& source_coords) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  const ReturnType& xbar = source_coords[0];
+  const ReturnType& ybar = source_coords[1];
+  ReturnType& x = (*target_coords)[0];
+  ReturnType& y = (*target_coords)[1];
+  ReturnType& z = (*target_coords)[2];
+  // Use z and y as temporary storage to avoid allocations,
+  // before setting them to their actual values.
+  z = sqrt(square(xbar) + square(ybar));
+  y = Endcap_detail::sin_ax_over_x(z, theta_max_) * radius_;
+  x = y * xbar + center_[0];
+  y = y * ybar + center_[1];
+  z = radius_ * cos(z * theta_max_) + center_[2];
+}
+
+template <typename T>
+void Endcap::jacobian(
+    const gsl::not_null<
+        tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>*>& jacobian_out,
+    const std::array<T, 3>& source_coords) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  const ReturnType& xbar = source_coords[0];
+  const ReturnType& ybar = source_coords[1];
+
+  if constexpr (not std::is_same<ReturnType, double>::value) {
+    destructive_resize_components(
+        jacobian_out, static_cast<ReturnType>(source_coords[0]).size());
+  }
+  // Most of the jacobian components are zero.
+  for(auto& jac_component: *jacobian_out) {
+    jac_component = 0.0;
+  }
+
+  // Use parts of Jacobian as temp storage to reduce allocations.
+  get<1, 1>(*jacobian_out) = sqrt(square(xbar) + square(ybar));
+  get<1, 0>(*jacobian_out) =
+      radius_ *
+      Endcap_detail::sin_ax_over_x(get<1, 1>(*jacobian_out), theta_max_);
+  // 1/rhobar d/d(rhobar) [(sin (rhobar theta_max)/rhobar)]
+  get<0, 1>(*jacobian_out) =
+      radius_ * Endcap_detail::one_over_x_d_sin_ax_over_x(
+                    get<1, 1>(*jacobian_out), theta_max_);
+
+  // dy/dybar
+  get<1, 1>(*jacobian_out) =
+      get<0, 1>(*jacobian_out) * square(ybar) + get<1, 0>(*jacobian_out);
+  // dx/dxbar
+  get<0, 0>(*jacobian_out) =
+      get<0, 1>(*jacobian_out) * square(xbar) + get<1, 0>(*jacobian_out);
+
+  // Still a temporary variable here.
+  get<1, 0>(*jacobian_out) *= -theta_max_;
+
+  // dz/dxbar
+  get<2, 0>(*jacobian_out) = get<1, 0>(*jacobian_out) * xbar;
+  // dz/dybar
+  get<2, 1>(*jacobian_out) = get<1, 0>(*jacobian_out) * ybar;
+
+  // dx/dybar
+  get<0, 1>(*jacobian_out) *= xbar * ybar;
+  // dy/dxbar
+  get<1, 0>(*jacobian_out) = get<0, 1>(*jacobian_out);
+}
+
+template <typename T>
+void Endcap::inv_jacobian(
+    const gsl::not_null<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3,
+                                 Frame::NoFrame>*>& inv_jacobian_out,
+    const std::array<T, 3>& source_coords) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  const ReturnType& xbar = source_coords[0];
+  const ReturnType& ybar = source_coords[1];
+
+  if constexpr (not std::is_same<ReturnType, double>::value) {
+    destructive_resize_components(
+        inv_jacobian_out, static_cast<ReturnType>(source_coords[0]).size());
+  }
+  // Most of the inverse jacobian components are zero.
+  for(auto& jac_component: *inv_jacobian_out) {
+    jac_component = 0.0;
+  }
+
+  // Use parts of Jacobian as temp storage to reduce allocations.
+  // We comment temporary quantities to make the code more understandable.
+
+  // rhobar, Eq. 7 in the documentation.
+  get<1, 0>(*inv_jacobian_out) = sqrt(square(xbar) + square(ybar));
+
+  // q = sin(rhobar theta)/rhobar as defined in the documentation, Eq. 17.
+  get<0, 1>(*inv_jacobian_out) =
+      Endcap_detail::sin_ax_over_x(get<1, 0>(*inv_jacobian_out), theta_max_);
+
+  // 1/rhobar dq/d(rhobar)
+  get<1, 1>(*inv_jacobian_out) = Endcap_detail::one_over_x_d_sin_ax_over_x(
+      get<1, 0>(*inv_jacobian_out), theta_max_);
+
+  // Right-hand side of Eq. 23, without the factor of
+  // xbar ybar/rq or the minus sign.
+  get<1, 0>(*inv_jacobian_out) =
+      get<1, 1>(*inv_jacobian_out) /
+      (get<0, 1>(*inv_jacobian_out) +
+       square(get<1, 0>(*inv_jacobian_out)) * get<1, 1>(*inv_jacobian_out));
+
+  // 1/(r q), i.e. first term in Eq. 22.
+  get<0, 0>(*inv_jacobian_out) =
+      1.0 / (get<0, 1>(*inv_jacobian_out) * radius_);
+
+  // Right-hand side of Eq. 23, without the factor of
+  // xbar ybar or the minus sign.
+  get<1, 0>(*inv_jacobian_out) *= get<0, 0>(*inv_jacobian_out);
+
+  // dybar/dy
+  get<1, 1>(*inv_jacobian_out) =
+      get<0, 0>(*inv_jacobian_out) -
+      square(ybar) * get<1, 0>(*inv_jacobian_out);
+  // dxbar/dx
+  get<0, 0>(*inv_jacobian_out) -=
+      square(xbar) * get<1, 0>(*inv_jacobian_out);
+  // dybar/dx
+  get<1, 0>(*inv_jacobian_out) *= -xbar * ybar;
+  // dxbar/dy
+  get<0, 1>(*inv_jacobian_out) = get<1, 0>(*inv_jacobian_out);
+}
+
+std::optional<std::array<double, 3>> Endcap::inverse(
+    const std::array<double, 3>& target_coords,
+    const double sigma_in) const noexcept {
+  const double x = target_coords[0] - center_[0];
+  const double y = target_coords[1] - center_[1];
+  const double z = target_coords[2] - center_[2];
+
+  // Are we in the range of the map?
+  // The equal_within_roundoff below has an implicit scale of 1,
+  // so the inverse may fail if radius_ is very small on purpose,
+  // e.g. if we really want a tiny tiny domain for some reason.
+  const double r = sqrt(square(x) + square(y) + square(z));
+  if (not equal_within_roundoff(r, radius_)) {
+    return std::optional<std::array<double, 3>>{};
+  }
+
+  // Compute zbar and check if we are in the range of the map.
+  const double zbar = 2.0 * sigma_in - 1.0;
+  if (abs(zbar) > 1.0 and not equal_within_roundoff(abs(zbar), 1.0)) {
+    return std::optional<std::array<double, 3>>{};
+  }
+
+  const double rho = sqrt(square(x) + square(y));
+  if (UNLIKELY(rho == 0.0)) {
+    // If x and y are zero, so are xbar and ybar,
+    // so we are done.
+    return std::array<double, 3>{{0.0, 0.0, zbar}};
+  }
+
+  // Note: theta_max_ cannot be zero for a nonsingular map.
+  const double rhobar = atan2(rho, z) / theta_max_;
+
+  // Check if we are outside the range of the map.
+  if (rhobar > 1.0 and not equal_within_roundoff(rhobar, 1.0)) {
+    return std::optional<std::array<double, 3>>{};
+  }
+
+  const double xbar = x * rhobar / rho;
+  const double ybar = y * rhobar / rho;
+  return std::array<double, 3>{{xbar, ybar, zbar}};
+}
+
+template <typename T>
+void Endcap::sigma(const gsl::not_null<tt::remove_cvref_wrap_t<T>*>& sigma_out,
+                   const std::array<T, 3>& source_coords) const noexcept {
+  *sigma_out = 0.5 * (source_coords[2] + 1.0);
+}
+
+template <typename T>
+void Endcap::deriv_sigma(
+    const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>&
+        deriv_sigma_out,
+    const std::array<T, 3>& source_coords) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  if constexpr (not std::is_same<ReturnType, double>::value) {
+    destructive_resize_components(
+        deriv_sigma_out, static_cast<ReturnType>(source_coords[0]).size());
+  }
+  (*deriv_sigma_out)[0] = 0.0;
+  (*deriv_sigma_out)[1] = 0.0;
+  (*deriv_sigma_out)[2] = 0.5;
+}
+
+template <typename T>
+void Endcap::dxbar_dsigma(
+    const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>&
+        dxbar_dsigma_out,
+    const std::array<T, 3>& source_coords) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  if constexpr (not std::is_same<ReturnType, double>::value) {
+    destructive_resize_components(
+        dxbar_dsigma_out, static_cast<ReturnType>(source_coords[0]).size());
+  }
+  (*dxbar_dsigma_out)[0] = 0.0;
+  (*dxbar_dsigma_out)[1] = 0.0;
+  (*dxbar_dsigma_out)[2] = 2.0;
+}
+
+std::optional<double> Endcap::lambda_tilde(
+    const std::array<double, 3>& parent_mapped_target_coords,
+    const std::array<double, 3>& projection_point) const noexcept {
+  // Try to find lambda_tilde going from target_coords to sphere.
+  // This lambda_tilde should be positive and less than or equal to unity.
+  // If there are two such roots, we choose based on where the points are.
+  const bool choose_larger_root =
+      parent_mapped_target_coords[2] > projection_point[2];
+  return FocallyLiftedMapHelpers::try_scale_factor(
+      parent_mapped_target_coords, projection_point, center_, radius_,
+      choose_larger_root, false);
+}
+
+template <typename T>
+void Endcap::deriv_lambda_tilde(
+    const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>&
+        deriv_lambda_tilde_out,
+    const std::array<T, 3>& target_coords, const T& lambda_tilde,
+    const std::array<double, 3>& projection_point) const noexcept {
+  FocallyLiftedMapHelpers::d_scale_factor_d_src_point(
+      deriv_lambda_tilde_out, target_coords, projection_point, center_,
+      lambda_tilde);
+}
+
+void Endcap::pup(PUP::er& p) noexcept {
+  p | center_;
+  p | radius_;
+  p | theta_max_;
+}
+
+bool operator==(const Endcap& lhs, const Endcap& rhs) noexcept {
+  return lhs.center_ == rhs.center_ and lhs.radius_ == rhs.radius_ and
+         lhs.theta_max_ == rhs.theta_max_;
+}
+
+bool operator!=(const Endcap& lhs, const Endcap& rhs) noexcept {
+  return not(lhs == rhs);
+}
+// Explicit instantiations
+/// \cond
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                 \
+  template void Endcap::forward_map(                                         \
+      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<DTYPE(data)>,   \
+                                     3>*>& target_coords,                    \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;       \
+  template void Endcap::jacobian(                                            \
+      const gsl::not_null<tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3,  \
+                                   Frame::NoFrame>*>& jacobian_out,          \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;       \
+  template void Endcap::inv_jacobian(                                        \
+      const gsl::not_null<tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3,  \
+                                   Frame::NoFrame>*>& inv_jacobian_out,      \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;       \
+  template void Endcap::sigma(                                               \
+      const gsl::not_null<tt::remove_cvref_wrap_t<DTYPE(data)>*>& sigma_out, \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;       \
+  template void Endcap::deriv_sigma(                                         \
+      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<DTYPE(data)>,   \
+                                     3>*>& deriv_sigma_out,                  \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;       \
+  template void Endcap::dxbar_dsigma(                                        \
+      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<DTYPE(data)>,   \
+                                     3>*>& dxbar_dsigma_out,                 \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;       \
+  template void Endcap::deriv_lambda_tilde(                                  \
+      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<DTYPE(data)>,   \
+                                     3>*>& deriv_lambda_tilde_out,           \
+      const std::array<DTYPE(data), 3>& target_coords,                       \
+      const DTYPE(data) & lambda_tilde,                                      \
+      const std::array<double, 3>& projection_point) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
+                                      std::reference_wrapper<const double>,
+                                      std::reference_wrapper<const DataVector>))
+
+#undef INSTANTIATE
+#undef DTYPE
+/// \endcond
+
+}  // namespace domain::CoordinateMaps::FocallyLiftedInnerMaps

--- a/src/Domain/CoordinateMaps/FocallyLiftedEndcap.hpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedEndcap.hpp
@@ -1,0 +1,450 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <optional>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+/// Contains FocallyLiftedInnerMaps
+namespace domain::CoordinateMaps::FocallyLiftedInnerMaps {
+/*!
+ * \brief A FocallyLiftedInnerMap that maps a 3D unit right cylinder
+ *  to a volume that connects portions of two spherical surfaces.
+ *
+ * Because FocallyLiftedEndcap is a FocallyLiftedInnerMap, it is meant
+ * to be a template parameter of FocallyLiftedMap, and its member functions
+ * are meant to be used by FocallyLiftedMap. See FocallyLiftedMap for further
+ * documentation.
+ *
+ * \image html FocallyLiftedEndcap.svg "Focally Lifted Endcap."
+ *
+ * \details The domain of the map is a 3D unit right cylinder with
+ * coordinates \f$(\bar{x},\bar{y},\bar{z})\f$ such that
+ * \f$-1\leq\bar{z}\leq 1\f$ and \f$\bar{x}^2+\bar{y}^2 \leq
+ * 1\f$.  The range of the map has coordinates \f$(x,y,z)\f$.
+ *
+ * Consider a sphere with center \f$C^i\f$ and radius \f$R\f$ that is
+ * intersected by a plane normal to the \f$z\f$ axis and located at
+ * \f$z = z_\mathrm{P}\f$.  In the figure above, every point
+ * \f$\bar{x}^i\f$ in the blue region \f$\sigma=0\f$ maps to a point
+ * \f$x_0^i\f$ on a portion of the surface of the sphere.
+ *
+ * `Endcap` provides the following functions:
+ *
+ * ### forward_map
+ * `forward_map` maps \f$(\bar{x},\bar{y},\bar{z}=-1)\f$ to the portion of
+ * the sphere with \f$z \geq z_\mathrm{P}\f$.  The arguments to `forward_map`
+ * are \f$(\bar{x},\bar{y},\bar{z})\f$, but \f$\bar{z}\f$ is ignored.
+ * `forward_map` returns \f$x_0^i\f$,
+ * the 3D coordinates on that sphere, which are given by
+ *
+ * \f{align}
+ * x_0^0 &= R \frac{\sin(\bar{\rho} \theta_\mathrm{max})
+ *              \bar{x}}{\bar{\rho}} + C^0,\\
+ * x_0^1 &= R \frac{\sin(\bar{\rho} \theta_\mathrm{max})
+ *              \bar{y}}{\bar{\rho}} + C^1,\\
+ * x_0^2 &= R \cos(\bar{\rho} \theta_\mathrm{max}) + C^2.
+ * \f}
+ *
+ * Here \f$\bar{\rho}^2 \equiv (\bar{x}^2+\bar{y}^2)/\bar{R}^2\f$, where
+ * \f$\bar{R}\f$ is the radius of the cylinder in barred coordinates,
+ * which is always unity,
+ * and where
+ * \f$\theta_\mathrm{max}\f$ is defined by
+ * \f$\cos(\theta_\mathrm{max}) = (z_\mathrm{P}-C^2)/R\f$.
+ * Note that when \f$\bar{\rho}=0\f$, we must evaluate
+ * \f$\sin(\bar{\rho}\theta_\mathrm{max})/\bar{\rho}\f$
+ * as \f$\theta_\mathrm{max}\f$.
+ *
+ * ### sigma
+ *
+ * \f$\sigma\f$ is a function that is zero at \f$\bar{z}=-1\f$
+ * (which maps onto the sphere \f$x^i=x_0^i\f$) and
+ * unity at \f$\bar{z}=+1\f$ (corresponding to the
+ * upper surface of the FocallyLiftedMap). We define
+ *
+ * \f{align}
+ *  \sigma &= \frac{\bar{z}+1}{2}.
+ * \f}
+ *
+ * ### deriv_sigma
+ *
+ * `deriv_sigma` returns
+ *
+ * \f{align}
+ *  \frac{\partial \sigma}{\partial \bar{x}^j} &= (0,0,1/2).
+ * \f}
+ *
+ * ### jacobian
+ *
+ * `jacobian` returns \f$\partial x_0^k/\partial \bar{x}^j\f$.
+ * The arguments to `jacobian`
+ * are \f$(\bar{x},\bar{y},\bar{z})\f$, but \f$\bar{z}\f$ is ignored.
+ *
+ * Differentiating Eqs.(1--3) above yields
+ *
+ * \f{align*}
+ * \frac{\partial x_0^2}{\partial \bar{x}} &=
+ * - R \theta_\mathrm{max}
+ * \frac{\sin(\bar{\rho}\theta_\mathrm{max})}{\bar{\rho}}\bar{x}\\
+ * \frac{\partial x_0^2}{\partial \bar{y}} &=
+ * - R \theta_\mathrm{max}
+ * \frac{\sin(\bar{\rho}\theta_\mathrm{max})}{\bar{\rho}}\bar{y}\\
+ * \frac{\partial x_0^0}{\partial \bar{x}} &=
+ * R \frac{\sin(\bar{\rho}\theta_\mathrm{max})}{\bar{\rho}} +
+ * R \frac{1}{\bar{\rho}}\frac{d}{d\bar{\rho}}
+ * \left(\frac{\sin(\bar{\rho}\theta_\mathrm{max})}{\bar{\rho}}\right)
+ * \bar{x}^2\\
+ * \frac{\partial x_0^0}{\partial \bar{y}} &=
+ * R \frac{1}{\bar{\rho}}\frac{d}{d\bar{\rho}}
+ * \left(\frac{\sin(\bar{\rho}\theta_\mathrm{max})}{\bar{\rho}}\right)
+ * \bar{x}\bar{y}\\
+ * \frac{\partial x_0^1}{\partial \bar{x}} &=
+ * R \frac{1}{\bar{\rho}}\frac{d}{d\bar{\rho}}
+ * \left(\frac{\sin(\bar{\rho}\theta_\mathrm{max})}{\bar{\rho}}\right)
+ * \bar{x}\bar{y}\\
+ * \frac{\partial x_0^1}{\partial \bar{y}} &=
+ * R \frac{\sin(\bar{\rho}\theta_\mathrm{max})}{\bar{\rho}} +
+ * R \frac{1}{\bar{\rho}}\frac{d}{d\bar{\rho}}
+ * \left(\frac{\sin(\bar{\rho}\theta_\mathrm{max})}{\bar{\rho}}\right)
+ * \bar{y}^2\\
+ * \frac{\partial x_0^i}{\partial \bar{z}} &=0.
+ * \f}
+ *
+ * ### Evaluating sinc functions
+ *
+ * Note that \f$\sin(\bar{\rho}\theta_\mathrm{max})/\bar{\rho}\f$ and
+ * its derivative appear in the above equations.  We evaluate
+ * \f$\sin(ax)/x\f$ in a straightforward way, except we are careful
+ * to evaluate \f$\sin(ax)/x = a\f$ for the special case \f$x=0\f$.
+ *
+ * The derivative of the sync function is more complicated to evaluate
+ * because of roundoff. Note that we can expand
+ *
+ * \f{align*}
+ *  \frac{1}{x}\frac{d}{dx}\left(\frac{\sin(ax)}{x}\right) &=
+ *  \frac{a}{x^2}\left(1 - 1 - \frac{2 (ax)^2}{3!} +
+ *  \frac{4(ax)^4}{5!} - \frac{5(ax)^6}{7!} + \cdots \right),
+ * \f}
+ *
+ * where we kept the "1 - 1" above as a reminder that when evaluating
+ * this function directly as \f$(a \cos(ax)/x^2 - \sin(ax)/x^3)\f$, there
+ * can be significant roundoff because of the "1" in each of the two
+ * terms that are subtracted. The relative error in direct evaluation is
+ * \f$3\epsilon/(ax)^2\f$, where \f$\epsilon\f$ is machine precision
+ * (This expression comes from replacing "1 - 1" with \f$\epsilon\f$
+ * and comparing the lowest-order contribution to the correct answer, i.e.
+ * the \f$2(ax)^2/3!\f$ term, with \f$\epsilon\f$, the error contribution).
+ * This means the error is 100% if \f$(ax)^2=3\epsilon\f$.
+ *
+ * To avoid roundoff, we evaluate the series if \f$ax\f$ is small
+ * enough.  Suppose we keep terms up to and including the \f$(ax)^{2n}\f$
+ * term in the series.  Then we evaluate the series if the
+ * next term, the \f$(ax)^{2n+2}\f$ term, is roundoff,
+ * i.e. if \f$(2n+2)(ax)^{2n+2}/(2n+3)! < \epsilon\f$.  In this case,
+ * the direct evaluation has the maximum error if
+ * \f$(2n+2)(ax)^{2n+2}/(2n+3)! = \epsilon\f$.  We showed above that the
+ * relative error in direct evaluation is \f$3\epsilon/(ax)^2\f$,
+ * which evaluates to \f$(\epsilon^n (2n+2)/(2n+3)!)^{1/(n+1)}\f$.
+ *
+ * \f{align*}
+ *   n=1 \qquad& \mathrm{error}=3(\epsilon/30)^{1/2} &\qquad
+ *               \sim \mathrm{5e-09}\\
+ *   n=2 \qquad& \mathrm{error}=3(\epsilon^2/840)^{1/3} &\qquad
+ *               \sim \mathrm{7e-12}\\
+ *   n=3 \qquad& \mathrm{error}=3(\epsilon^3/45360)^{1/4} &\qquad
+ *               \sim \mathrm{2e-13}\\
+ *   n=4 \qquad& \mathrm{error}=3(\epsilon^4/3991680)^{1/5} &\qquad
+ *               \sim \mathrm{2e-14}\\
+ *   n=5 \qquad& \mathrm{error}=3(\epsilon^5/518918400)^{1/6} &\qquad
+ *               \sim \mathrm{5e-15}\\
+ *   n=6 \qquad& \mathrm{error}=3(\epsilon^6/93405312000)^{1/7} &\qquad
+ *               \sim \mathrm{1e-15}
+ * \f}
+ * We gain less and less with each order, so we choose \f$n=3\f$.
+ * Then the series above can be rewritten to this order in the form
+ * \f{align*}
+ *  \frac{1}{x}\frac{d}{dx}\left(\frac{\sin(ax)}{x}\right) &=
+ *  -\frac{a^3}{3}\left(1 - \frac{3\cdot 4 (ax)^2}{5!} +
+ *  \frac{3 \cdot 6(ax)^4}{7!}\right).
+ * \f}
+ *
+ * ### inverse
+ *
+ * `inverse` takes \f$x_0^i\f$ and \f$\sigma\f$ as arguments, and
+ * returns \f$(\bar{x},\bar{y},\bar{z})\f$, or boost::none if
+ * \f$x_0^i\f$ or \f$\sigma\f$ are outside the range of the map.
+ * For example, if \f$x_0^i\f$ does not lie on the sphere,
+ * we return boost::none.
+ *
+ * The easiest to compute is \f$\bar{z}\f$, which is given by inverting
+ * Eq. (4):
+ *
+ * \f{align}
+ *  \bar{z} &= 2\sigma - 1.
+ * \f}
+ *
+ * If \f$\bar{z}\f$ is outside the range \f$[-1,1]\f$ then we return
+ * boost::none.
+ *
+ * To get \f$\bar{x}\f$ and \f$\bar{y}\f$,
+ * we invert
+ * Eqs (1--3).  If \f$x_0^0=x_0^1=0\f$, then \f$\bar{x}=\bar{y}=0\f$.
+ * Otherwise, we compute
+ *
+ * \f{align}
+ *   \bar{\rho} = \theta_\mathrm{max}^{-1}
+ *   \tan^{-1}\left(\frac{\rho}{x_0^2-C^2}\right),
+ * \f}
+ *
+ * where \f$\rho^2 = (x_0^0-C^0)^2+(x_0^1-C^1)^2\f$. Then
+ *
+ * \f{align}
+ * \bar{x} &= (x_0^0-C^0)\frac{\bar{\rho}}{\rho},\\
+ * \bar{y} &= (x_0^1-C^1)\frac{\bar{\rho}}{\rho}.
+ * \f}
+ *
+ * Note that if \f$\bar{x}^2+\bar{y}^2 > 1\f$, the original point is outside
+ * the range of the map so we return boost::none.
+ *
+ * ### lambda_tilde
+ *
+ * `lambda_tilde` takes as arguments a point \f$x^i\f$ and a projection point
+ *  \f$P^i\f$, and computes \f$\tilde{\lambda}\f$, the solution to
+ *
+ * \f{align} x_0^i = P^i + (x^i - P^i) \tilde{\lambda}.\f}
+ *
+ * Since \f$x_0^i\f$ must lie on the sphere, \f$\tilde{\lambda}\f$ is the
+ * solution of the quadratic equation
+ *
+ * \f{align}
+ * |P^i + (x^i - P^i) \tilde{\lambda} - C^i |^2 - R^2 = 0.
+ * \f}
+ *
+ * In solving the quadratic, we demand a root that is positive and
+ * less than or equal to unity, since \f$x_0^i\f$ is always between
+ * the projection point and \f$x^i\f$. If there are two suitable
+ * roots, this means that the entire sphere lies between \f$P^i\f$ and
+ * \f$x^i\f$; in this case if \f$x^2 \geq z_\mathrm{P}\f$ we choose the
+ * larger root, otherwise we choose the smaller one: this gives
+ * us the root with \f$x_0^2 \geq z_\mathrm{P}\f$, the portion of the sphere
+ * that is the range of `Endcap`. If there is no suitable root,
+ * this means that the point \f$x^i\f$ is not in the range of the map
+ * so we return a default-constructed std::optional.
+ *
+ * ### deriv_lambda_tilde
+ *
+ * `deriv_lambda_tilde` takes as arguments \f$x_0^i\f$, a projection point
+ *  \f$P^i\f$, and \f$\tilde{\lambda}\f$, and
+ *  returns \f$\partial \tilde{\lambda}/\partial x^i\f$.
+ * By differentiating Eq. (11), we find
+ *
+ * \f{align}
+ * \frac{\partial\tilde{\lambda}}{\partial x^j} &=
+ * \tilde{\lambda}^2 \frac{C^j - x_0^j}{|x_0^i - P^i|^2
+ * + (x_0^i - P^i)(P_i - C_{i})}.
+ * \f}
+ *
+ * ### inv_jacobian
+ *
+ * `inv_jacobian` returns \f$\partial \bar{x}^i/\partial x_0^k\f$,
+ *  where \f$\sigma\f$ is held fixed.
+ *  The arguments to `inv_jacobian`
+ *  are \f$(\bar{x},\bar{y},\bar{z})\f$, but \f$\bar{z}\f$ is ignored.
+ *
+ * Note that \f$\bar{x}\f$ and \f$\bar{y}\f$ can be considered to
+ * depend only on \f$x_0^0\f$ and \f$x_0^1\f$ but not on \f$x_0^2\f$,
+ * because the point \f$x_0^i\f$ is constrained to lie on a sphere of
+ * radius \f$R\f$.  Note that there is an alternative way to compute
+ * Eqs. (8) and (9) using only \f$x_0^0\f$ and \f$x_0^1\f$. To do
+ * this, define
+ *
+ * \f{align}
+ * \upsilon \equiv \sin(\bar{\rho}\theta_\mathrm{max})
+ *        &= \sqrt{\frac{(x_0^0-C^0)^2+(x_0^1-C^1)^2}{R^2}}.
+ * \f}
+ *
+ * Then we can write
+ *
+ * \f{align}
+ * \frac{1}{\bar{\rho}}\sin(\bar{\rho}\theta_\mathrm{max})
+ * &= \frac{\theta_\mathrm{max}\upsilon}{\arcsin(\upsilon)},
+ * \f}
+ *
+ * so that
+ *
+ * \f{align}
+ * \bar{x} &= \frac{x_0^0-C^0}{R}\left(\frac{1}{\bar{\rho}}
+ *             \sin(\bar{\rho}\theta_\mathrm{max})\right)^{-1} \\
+ * \bar{y} &= \frac{x_0^1-C^1}{R}\left(\frac{1}{\bar{\rho}}
+ *             \sin(\bar{\rho}\theta_\mathrm{max})\right)^{-1}.
+ * \f}
+ *
+ * We will compute \f$\partial \bar{x}^i/\partial
+ * x_0^k\f$ by differentiating Eqs. (15) and (16).  Because those equations
+ * involve \f$\bar{\rho}\f$, we first establish some relations
+ * involving derivatives of \f$\bar{\rho}\f$.  For ease of notation, we define
+ *
+ * \f{align}
+ * q \equiv \frac{\sin(\bar{\rho}\theta_\mathrm{max})}{\bar{\rho}}.
+ * \f}
+ *
+ * First observe that
+ * \f{align}
+ * \frac{dq}{d\upsilon}
+ * = \frac{dq}{d\bar{\rho}}
+ * \left(\bar{\rho} \frac{dq}{d\bar{\rho}} + q\right)^{-1},
+ * \f}
+ *
+ * where \f$\upsilon\f$ is the quantity defined by Eq. (13).  Therefore
+ *
+ * \f{align}
+ * \frac{\partial q}{\partial x_0^0} &=
+ * \frac{\bar{x}}{\bar{\rho}R}\frac{dq}{d\bar{\rho}}
+ * \left(\bar{\rho} \frac{dq}{d\bar{\rho}} + q\right)^{-1},\\
+ * \frac{\partial q}{\partial x_0^1} &=
+ * \frac{\bar{y}}{\bar{\rho}R}\frac{dq}{d\bar{\rho}}
+ * \left(\bar{\rho} \frac{dq}{d\bar{\rho}} + q\right)^{-1},
+ * \f}
+ *
+ * where we have differentiated Eq. (13), and where we have
+ * used Eqs. (15) and (16) to eliminate \f$x_0^0\f$ and
+ * \f$x_0^1\f$ in favor of \f$\bar{x}\f$ and
+ * \f$\bar{y}\f$ in the final result.
+ *
+ * Let
+ * \f{align}
+ * \Sigma \equiv \frac{1}{\bar\rho} \frac{dq}{d\bar{\rho}},
+ * \f}
+ * since that combination will appear frequently in formulas below. Note that
+ * \f$\Sigma\f$ has a finite limit as \f$\bar{\rho}\to 0\f$, and it is evaluated
+ * according to the section on evaluating sinc functions above.
+ *
+ * By differentiating Eqs. (15) and (16), and using Eqs. (19) and (20), we
+ * find
+ *
+ * \f{align}
+ * \frac{\partial \bar{x}}{\partial x_0^0} &=
+ * \frac{1}{R q}
+ * - \frac{\bar{x}^2 \Sigma}{R q}
+ * \left(\bar{\rho}^2 \Sigma + q\right)^{-1},\\
+ * \frac{\partial \bar{x}}{\partial x_0^1} &=
+ * - \frac{\bar{x}\bar{y} \Sigma}{R q}
+ * \left(\bar{\rho}^2 \Sigma + q\right)^{-1},\\
+ * \frac{\partial \bar{x}}{\partial x_0^2} &= 0,\\
+ * \frac{\partial \bar{y}}{\partial x_0^0} &=
+ * \frac{\partial \bar{x}}{\partial x_0^1},\\
+ * \frac{\partial \bar{y}}{\partial x_0^1} &=
+ * \frac{1}{R q}
+ * - \frac{\bar{y}^2 \Sigma}{R q}
+ * \left(\bar{\rho}^2 \Sigma + q\right)^{-1},\\
+ * \frac{\partial \bar{y}}{\partial x_0^2} &= 0,\\
+ * \frac{\partial \bar{z}}{\partial x_0^i} &= 0.
+ * \f}
+ * Note that care must be taken to evaluate
+ * \f$q = \sin(\bar{\rho}\theta_\mathrm{max})/\bar{\rho}\f$ and its
+ * derivative \f$\Sigma\f$ near \f$\bar{\rho}=0\f$; see the discussion above on
+ * evaluating sinc functions.
+ *
+ * ### dxbar_dsigma
+ *
+ * `dxbar_dsigma` returns \f$\partial \bar{x}^i/\partial \sigma\f$,
+ *  where \f$x_0^i\f$ is held fixed.
+ *
+ * From Eq. (6) we have
+ *
+ * \f{align}
+ * \frac{\partial \bar{x}^i}{\partial \sigma} &= (0,0,2).
+ * \f}
+ *
+ */
+class Endcap {
+ public:
+  Endcap(const std::array<double, 3>& center, double radius,
+         double z_plane) noexcept;
+
+  Endcap() = default;
+  ~Endcap() = default;
+  Endcap(Endcap&&) = default;
+  Endcap(const Endcap&) = default;
+  Endcap& operator=(const Endcap&) = default;
+  Endcap& operator=(Endcap&&) = default;
+
+  template <typename T>
+  void forward_map(
+      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>&
+          target_coords,
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  std::optional<std::array<double, 3>> inverse(
+      const std::array<double, 3>& target_coords,
+      double sigma_in) const noexcept;
+
+  template <typename T>
+  void jacobian(const gsl::not_null<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3,
+                                             Frame::NoFrame>*>& jacobian_out,
+                const std::array<T, 3>& source_coords) const noexcept;
+
+  template <typename T>
+  void inv_jacobian(
+      const gsl::not_null<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3,
+                                   Frame::NoFrame>*>& inv_jacobian_out,
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  template <typename T>
+  void sigma(const gsl::not_null<tt::remove_cvref_wrap_t<T>*>& sigma_out,
+             const std::array<T, 3>& source_coords) const noexcept;
+
+  template <typename T>
+  void deriv_sigma(
+      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>&
+          deriv_sigma_out,
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  template <typename T>
+  void dxbar_dsigma(
+      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>&
+          dxbar_dsigma_out,
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  std::optional<double> lambda_tilde(
+      const std::array<double, 3>& parent_mapped_target_coords,
+      const std::array<double, 3>& projection_point) const noexcept;
+
+  template <typename T>
+  void deriv_lambda_tilde(
+      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>&
+          deriv_lambda_tilde_out,
+      const std::array<T, 3>& target_coords, const T& lambda_tilde,
+      const std::array<double, 3>& projection_point) const noexcept;
+
+  // clang-tidy: google runtime references
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+  static bool is_identity() noexcept { return false; }
+
+  static bool projection_source_is_between_focus_and_target() noexcept {
+    return true;
+  }
+
+ private:
+  friend bool operator==(const Endcap& lhs, const Endcap& rhs) noexcept;
+  std::array<double, 3> center_{};
+  double radius_{std::numeric_limits<double>::signaling_NaN()};
+  double theta_max_{std::numeric_limits<double>::signaling_NaN()};
+};
+bool operator!=(const Endcap& lhs, const Endcap& rhs) noexcept;
+}  // namespace domain::CoordinateMaps::FocallyLiftedInnerMaps

--- a/src/Domain/CoordinateMaps/FocallyLiftedMap.cpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedMap.cpp
@@ -1,0 +1,391 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/FocallyLiftedMap.hpp"
+
+#include <cmath>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/FocallyLiftedEndcap.hpp"
+#include "Domain/CoordinateMaps/FocallyLiftedMapHelpers.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace domain::CoordinateMaps {
+
+template <typename InnerMap>
+FocallyLiftedMap<InnerMap>::FocallyLiftedMap(
+    const std::array<double, 3>& center,
+    const std::array<double, 3>& proj_center, double radius,
+    InnerMap inner_map) noexcept
+    : center_(center),
+      proj_center_(proj_center),
+      radius_(radius),
+      inner_map_(std::move(inner_map)) {}
+
+template <typename InnerMap>
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, 3> FocallyLiftedMap<InnerMap>::
+operator()(const std::array<T, 3>& source_coords) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+
+  // Temporary variable that will be re-used to avoid extra
+  // allocations.
+  ReturnType temp_scalar{};
+
+  // lower_coords are the mapped coords on the surface.
+  std::array<ReturnType, 3> lower_coords{};
+  inner_map_.forward_map(&lower_coords, source_coords);
+
+  // upper_coords are the mapped coords on the surface of the sphere.
+  ReturnType& lambda = temp_scalar;
+  FocallyLiftedMapHelpers::scale_factor(
+      &lambda, lower_coords, proj_center_, center_, radius_,
+      InnerMap::projection_source_is_between_focus_and_target());
+
+  std::array<ReturnType, 3> upper_coords{};
+  for (size_t i = 0; i < 3; ++i) {
+    gsl::at(upper_coords, i) =
+        gsl::at(proj_center_, i) +
+        (gsl::at(lower_coords, i) - gsl::at(proj_center_, i)) * lambda;
+  }
+
+  // mapped_coords goes linearly from lower_coords to upper_coords
+  // as sigma goes from 0 to 1.
+  ReturnType& sigma = temp_scalar; // sigma shares memory with lambda.
+  inner_map_.sigma(&sigma, source_coords);
+
+  // Use upper_coords to store result, so as to save an allocation.
+  for (size_t i = 0; i < 3; ++i) {
+    gsl::at(upper_coords, i) =
+        gsl::at(lower_coords, i) +
+        (gsl::at(upper_coords, i) - gsl::at(lower_coords, i)) * sigma;
+  }
+  return upper_coords;
+}
+
+template <typename InnerMap>
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
+FocallyLiftedMap<InnerMap>::jacobian(
+    const std::array<T, 3>& source_coords) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+
+  // Use these variables to reduce allocations.
+  std::array<ReturnType, 3> temp_vector_one{};
+  std::array<ReturnType, 3> temp_vector_two{};
+
+  auto jacobian_matrix =
+      make_with_value<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>>(
+          dereference_wrapper(source_coords[0]), 0.0);
+
+  // lower_coords are the mapped coords on the surface.
+  std::array<ReturnType, 3> lower_coords{};
+  inner_map_.forward_map(&lower_coords, source_coords);
+
+  ReturnType lambda{};
+  FocallyLiftedMapHelpers::scale_factor(
+      &lambda, lower_coords, proj_center_, center_, radius_,
+      InnerMap::projection_source_is_between_focus_and_target());
+
+  // upper_coords are the mapped coords on the surface of the sphere.
+  std::array<ReturnType, 3>& upper_coords = temp_vector_one;
+  for (size_t i = 0; i < 3; ++i) {
+    gsl::at(upper_coords, i) =
+        gsl::at(proj_center_, i) +
+        (gsl::at(lower_coords, i) - gsl::at(proj_center_, i)) * lambda;
+  }
+
+  std::array<ReturnType, 3>& d_lambda_d_lower_coords = temp_vector_two;
+  FocallyLiftedMapHelpers::d_scale_factor_d_src_point<ReturnType>(
+      &d_lambda_d_lower_coords, upper_coords, proj_center_, center_, lambda);
+
+  // Put the inner map's jacobian temporarily into jacobian_matrix.
+  // This saves an allocation.
+  inner_map_.jacobian(&jacobian_matrix, source_coords);
+
+  // Re-use memory of upper_coords in computing sigma_d_lambda_d_xbar.
+  // Don't multiply by sigma yet because we don't know it.
+  std::array<ReturnType, 3>& sigma_d_lambda_d_xbar = temp_vector_one;
+  for (size_t j = 0; j < 3; ++j) {
+    gsl::at(sigma_d_lambda_d_xbar, j) =
+        d_lambda_d_lower_coords[0] * jacobian_matrix.get(0, j);
+    for (size_t k = 1; k < 3; ++k) {  // First iteration split out above.
+      gsl::at(sigma_d_lambda_d_xbar, j) +=
+          gsl::at(d_lambda_d_lower_coords, k) * jacobian_matrix.get(k, j);
+    }
+  }
+
+  // temp_vector_two isn't used anymore, so use its memory for sigma.
+  ReturnType& sigma = temp_vector_two[0];
+  inner_map_.sigma(&sigma, source_coords);
+
+  // Now complete computation of sigma_d_lambda_d_xbar.
+  for (size_t j = 0; j < 3; ++j) {
+    gsl::at(sigma_d_lambda_d_xbar, j) *= sigma;
+  }
+
+  // Do the easiest of the terms involving the inner map,
+  // i.e. the first term in Eq. (6) in the documentation.
+  ReturnType& lambda_factor = temp_vector_two[1];
+  lambda_factor = 1.0 - sigma + lambda * sigma;
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      jacobian_matrix.get(i, j) *= lambda_factor;
+    }
+  }
+
+  // Do the deriv sigma term, the third term in Eq. (6) in the
+  // documentation.
+  // Note that we explicitly substitute for upper_coords below
+  // because we have re-used its memory.
+  std::array<ReturnType, 3>& d_sigma = temp_vector_two;
+  inner_map_.deriv_sigma(&d_sigma, source_coords);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      jacobian_matrix.get(i, j) +=
+          gsl::at(d_sigma, j) *
+          (gsl::at(proj_center_, i) +
+           (gsl::at(lower_coords, i) - gsl::at(proj_center_, i)) * lambda -
+           gsl::at(lower_coords, i));
+    }
+  }
+
+  // Do the second term in Eq. (6) in the documentation.
+  for (size_t j = 0; j < 3; ++j) {
+    for (size_t i = 0; i < 3; ++i) {
+      jacobian_matrix.get(i, j) +=
+          gsl::at(sigma_d_lambda_d_xbar, j) *
+          (gsl::at(lower_coords, i) - gsl::at(proj_center_, i));
+    }
+  }
+
+  return jacobian_matrix;
+}
+
+template <typename InnerMap>
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
+FocallyLiftedMap<InnerMap>::inv_jacobian(
+    const std::array<T, 3>& source_coords) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+
+  // lower_coords are the mapped coords on the surface.
+  std::array<ReturnType, 3> lower_coords{};
+  inner_map_.forward_map(&lower_coords, source_coords);
+
+  ReturnType lambda{};
+  FocallyLiftedMapHelpers::scale_factor(
+      &lambda, lower_coords, proj_center_, center_, radius_,
+      InnerMap::projection_source_is_between_focus_and_target());
+
+  // upper_coords are the mapped coords on the surface of the sphere.
+  std::array<ReturnType, 3> upper_coords{};
+  for (size_t i = 0; i < 3; ++i) {
+    gsl::at(upper_coords, i) =
+        gsl::at(proj_center_, i) +
+        (gsl::at(lower_coords, i) - gsl::at(proj_center_, i)) * lambda;
+  }
+
+  // Derivative of lambda
+  std::array<ReturnType, 3> d_lambda_d_lower_coords{};
+  FocallyLiftedMapHelpers::d_scale_factor_d_src_point<ReturnType>(
+      &d_lambda_d_lower_coords, upper_coords, proj_center_, center_, lambda);
+
+  // Lambda_tilde is the scale factor between mapped coords and lower coords.
+  // We can compute it with a shortcut because there is a relationship
+  // between lambda, lambda_tilde, and sigma.
+  ReturnType sigma {};
+  inner_map_.sigma(&sigma, source_coords);
+  const ReturnType lambda_tilde = 1.0 / (1.0 - sigma * (1.0 - lambda));
+
+  // Derivative of lambda_tilde
+  std::array<ReturnType, 3> d_lambda_tilde_d_mapped_coords{};
+  inner_map_.deriv_lambda_tilde(&d_lambda_tilde_d_mapped_coords, lower_coords,
+                                lambda_tilde, proj_center_);
+
+  // Deriv of x_0 with respect to x
+  auto dx_inner_dx =
+      make_with_value<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>>(
+          dereference_wrapper(source_coords[0]), 0.0);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      dx_inner_dx.get(i, j) = gsl::at(d_lambda_tilde_d_mapped_coords, j) *
+                         (gsl::at(lower_coords, i) - gsl::at(proj_center_, i)) /
+                         lambda_tilde;
+    }
+    dx_inner_dx.get(i, i) += lambda_tilde;
+  }
+
+  // Deriv of sigma with respect to x,y,z
+  auto d_sigma_d_mapped_coords =
+      make_with_value<tnsr::i<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>>(
+          sigma, 0.0);
+  ReturnType tmp{};
+  for (size_t i = 0; i < 3; ++i) {
+    tmp = d_lambda_d_lower_coords[0] * dx_inner_dx.get(0, i);
+    for (size_t j = 1; j < 3; ++j) {  // first iteration factored out above.
+      tmp += gsl::at(d_lambda_d_lower_coords, j) * dx_inner_dx.get(j, i);
+    }
+    d_sigma_d_mapped_coords.get(i) =
+        (sigma * tmp +
+         gsl::at(d_lambda_tilde_d_mapped_coords, i) / square(lambda_tilde)) /
+        (1.0 - lambda);
+  }
+
+  tnsr::Ij<ReturnType, 3, Frame::NoFrame> dxbar_dx_inner{};
+  inner_map_.inv_jacobian(&dxbar_dx_inner, source_coords);
+  std::array<tt::remove_cvref_wrap_t<T>, 3> dxbar_dsigma{};
+  inner_map_.dxbar_dsigma(&dxbar_dsigma, source_coords);
+
+  auto inv_jacobian_matrix =
+      make_with_value<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>>(
+          dereference_wrapper(source_coords[0]), 0.0);
+
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      for (size_t k = 0; k < 3; ++k) {
+        inv_jacobian_matrix.get(i, j) +=
+            dxbar_dx_inner.get(i, k) * dx_inner_dx.get(k, j);
+      }
+      inv_jacobian_matrix.get(i, j) +=
+          gsl::at(dxbar_dsigma, i) * d_sigma_d_mapped_coords.get(j);
+    }
+  }
+
+  return inv_jacobian_matrix;
+}
+
+template <typename InnerMap>
+std::optional<std::array<double, 3>> FocallyLiftedMap<InnerMap>::inverse(
+    const std::array<double, 3>& target_coords) const noexcept {
+  // Scale factor taking target_coords to lower_coords.
+  const auto lambda_tilde =
+      inner_map_.lambda_tilde(target_coords, proj_center_);
+
+  // Cannot find scale factor, so we are out of range of the map.
+  if (not lambda_tilde) {
+    return std::optional<std::array<double, 3>>{};
+  }
+
+  // Try to find lambda_bar going from target_coords to sphere.
+  const auto lambda_bar = FocallyLiftedMapHelpers::try_scale_factor(
+      target_coords, proj_center_, center_, radius_,
+      not InnerMap::projection_source_is_between_focus_and_target(),
+      InnerMap::projection_source_is_between_focus_and_target());
+
+  // Cannot find scale factor, so we are out of range of the map.
+  if (not lambda_bar) {
+    return std::optional<std::array<double, 3>>{};
+  }
+
+  // compute sigma in a roundoff-friendly way.
+  double sigma = 0.0;
+  if (equal_within_roundoff(*lambda_tilde, 1.0, 1.e-5)) {
+    // Get sigma correct for sigma near 0
+    sigma =
+        (*lambda_tilde - 1.0) / (*lambda_tilde - *lambda_bar);
+  } else {
+    // Get sigma correct for sigma near 1
+    sigma = (*lambda_bar - 1.0) / (*lambda_tilde - *lambda_bar) +
+            1.0;
+  }
+
+  std::array<double, 3> lower_coords{};
+  for (size_t i = 0; i < 3; ++i) {
+    gsl::at(lower_coords, i) =
+        gsl::at(proj_center_, i) +
+        (gsl::at(target_coords, i) - gsl::at(proj_center_, i)) *
+            lambda_tilde.value();
+  }
+
+  std::optional<std::array<double, 3>> orig_coords =
+      inner_map_.inverse(lower_coords, sigma);
+
+  // Root polishing.
+  // Here we do a single Newton iteration to get the
+  // inverse to agree with the forward map to the level of machine
+  // roundoff that is required by the unit tests.
+  // Without the root polishing, the unit tests occasionally fail
+  // the 'inverse(map(x))=x' test at a level slightly above roundoff.
+  if (orig_coords) {
+    const auto inv_jac = inv_jacobian(*orig_coords);
+    const auto mapped_coords = operator()(*orig_coords);
+    for (size_t i = 0; i < 3; ++i) {
+      for (size_t j = 0; j < 3; ++j) {
+        gsl::at(*orig_coords, i) +=
+            (gsl::at(target_coords, j) - gsl::at(mapped_coords, j)) *
+            inv_jac.get(i, j);
+      }
+    }
+  }
+
+  return orig_coords;
+}
+
+template <typename InnerMap>
+void FocallyLiftedMap<InnerMap>::pup(PUP::er& p) noexcept {
+  p | center_;
+  p | proj_center_;
+  p | radius_;
+  p | inner_map_;
+}
+
+template <typename InnerMap>
+bool operator!=(const FocallyLiftedMap<InnerMap>& lhs,
+                const FocallyLiftedMap<InnerMap>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+template <typename InnerMap>
+bool operator==(const FocallyLiftedMap<InnerMap>& lhs,
+                const FocallyLiftedMap<InnerMap>& rhs) noexcept {
+  return lhs.center_ == rhs.center_ and lhs.proj_center_ == rhs.proj_center_ and
+         lhs.radius_ == rhs.radius_ and lhs.inner_map_ == rhs.inner_map_;
+}
+
+// Explicit instantiations
+/// \cond
+#define IMAP(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                  \
+  template class FocallyLiftedMap<IMAP(data)>;                                \
+  template bool operator==(const FocallyLiftedMap<IMAP(data)>& lhs,           \
+                           const FocallyLiftedMap<IMAP(data)>& rhs) noexcept; \
+  template bool operator!=(const FocallyLiftedMap<IMAP(data)>& lhs,           \
+                           const FocallyLiftedMap<IMAP(data)>& rhs) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (FocallyLiftedInnerMaps::Endcap))
+
+#undef INSTANTIATE
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                                 \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>               \
+  FocallyLiftedMap<IMAP(data)>::operator()(                                  \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;       \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame> \
+  FocallyLiftedMap<IMAP(data)>::jacobian(                                    \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;       \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame> \
+  FocallyLiftedMap<IMAP(data)>::inv_jacobian(                                \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (FocallyLiftedInnerMaps::Endcap),
+                        (double, DataVector,
+                         std::reference_wrapper<const double>,
+                         std::reference_wrapper<const DataVector>))
+
+#undef INSTANTIATE
+#undef DTYPE
+#undef IMAP
+/// \endcond
+
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/FocallyLiftedMap.hpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedMap.hpp
@@ -1,0 +1,347 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <optional>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace domain::CoordinateMaps {
+
+template <typename InnerMap>
+class FocallyLiftedMap;
+
+template <typename InnerMap>
+bool operator==(const FocallyLiftedMap<InnerMap>& lhs,
+                const FocallyLiftedMap<InnerMap>& rhs) noexcept;
+
+/*!
+ * \ingroup CoordinateMapsGroup
+ *
+ * \brief Map from \f$(\bar{x},\bar{y},\bar{z})\f$ to the volume
+ * contained between a 2D surface and the surface of a 2-sphere.
+ *
+ *
+ * \image html FocallyLifted.svg "2D representation of focally lifted map."
+ *
+ * \details We are given the radius \f$R\f$ and
+ * center \f$C^i\f$ of a sphere, and a projection point \f$P^i\f$.  Also,
+ * through the class defined by the `InnerMap` template parameter,
+ * we are given the functions
+ * \f$f^i(\bar{x},\bar{y},\bar{z})\f$ and
+ * \f$\sigma(\bar{x},\bar{y},\bar{z})\f$ defined below; these
+ * functions define the mapping from \f$(\bar{x},\bar{y},\bar{z})\f$
+ * to the 2D surface.
+ *
+ * The above figure is a 2D representation of the focally lifted map,
+ * where the shaded region in \f$\bar{x}^i\f$ coordinates on the left
+ * is mapped to the shaded region in the \f$x^i\f$ coordinates on the
+ * right.  Shown is an arbitrary point \f$\bar{x}^i\f$ that is mapped
+ * to \f$x^i\f$; for that point, the corresponding \f$x_0^i\f$ and
+ * \f$x_1^i\f$ (defined below) are shown on the right, as is the
+ * projection point \f$P^i\f$.  Also shown are the level surfaces
+ * \f$\sigma=0\f$ and \f$\sigma=1\f$.
+ *
+ * The input coordinates are labeled \f$(\bar{x},\bar{y},\bar{z})\f$.
+ * Let \f$x_0^i = f^i(\bar{x},\bar{y},\bar{z})\f$ be the three coordinates
+ * of the 2D surface in 3D space.
+ *
+ * Now let \f$x_1^i\f$ be a point on the surface of the sphere,
+ * constructed so that \f$P^i\f$, \f$x_0^i\f$, and \f$x_1^i\f$ are
+ * co-linear.  In particular, \f$x_1^i\f$ is determined by the
+ * equation
+ *
+ * \f{align} x_1^i = P^i + (x_0^i - P^i) \lambda,\f}
+ *
+ * where \f$\lambda\f$ is a scalar factor that depends on \f$x_0^i\f$ and
+ * that can be computed by solving a quadratic equation.  This quadratic
+ * equation is derived by demanding that \f$x_1^i\f$ lies on the sphere:
+ *
+ * \f{align}
+ * |P^i + (x_0^i - P^i) \lambda - C^i |^2 - R^2 = 0,
+ * \f}
+ *
+ * where \f$|A^i|^2\f$ means \f$\delta_{ij} A^i A^j\f$.
+ *
+ * The quadratic equation, Eq. (2),
+ * takes the usual form \f$a\lambda^2+b\lambda+c=0\f$,
+ * with
+ *
+ * \f{align*}
+ *  a &= |x_0^i-P^i|^2,\\
+ *  b &= 2(x_0^i-P^i)(P^j-C^j)\delta_{ij},\\
+ *  c &= |P^i-C^i|^2 - R^2.
+ * \f}
+ *
+ * Now assume that \f$x_0^i\f$ lies on a level surface defined
+ * by some scalar function \f$\sigma(\bar{x}^i)=0\f$,
+ * where \f$\sigma\f$ is normalized so that \f$\sigma=1\f$ on the sphere.
+ * Then, once \f$\lambda\f$ has been computed and \f$x_1^i\f$ has
+ * been determined, the map is given by
+ *
+ * \f{align}x^i = x_0^i + (x_1^i - x_0^i) \sigma(\bar{x}^i).\f}
+ *
+ * Note that classes using FocallyLiftedMap will place restrictions on
+ * \f$P^i\f$, \f$C^i\f$, \f$x_0^i\f$, and \f$R\f$.  For example, we
+ * demand that \f$P^i\f$ does not lie on either the \f$\sigma=0\f$ or
+ * \f$\sigma=1\f$ surfaces depicted in the right panel of the figure,
+ * and we demand that the \f$\sigma=0\f$ and \f$\sigma=1\f$ surfaces do
+ * not intersect; otherwise the map is singular.
+ *
+ * ### Jacobian
+ *
+ * Differentiating Eq. (1) above yields
+ *
+ * \f{align}
+ * \frac{\partial x_1^i}{\partial x_0^j} = \lambda \delta^i_j +
+ *  (x_0^i - P^i) \frac{\partial \lambda}{\partial x_0^j}.
+ * \f}
+ *
+ * and differentiating Eq. (2) and then inserting Eq. (1) yields
+ *
+ * \f{align}
+ * \frac{\partial\lambda}{\partial x_0^j} &=
+ * \lambda^2 \frac{C_j - x_1^j}{|x_1^i - P^i|^2
+ * + (x_1^i - P^i)(P_i - C_{i})}.
+ * \f}
+ *
+ * The Jacobian can be found by differentiating Eq. (3) above and using the
+ * chain rule, recognizing that \f$x_1^i\f$ depends on \f$\bar{x}^i\f$ only
+ * through its dependence on \f$x_0^i\f$; this is because there is no explicit
+ * dependence on \f$\bar{x}^i\f$ in Eq. (1) (which determines \f$x_1^i\f$)
+ * or Eq. (2) (which determines \f$\lambda\f$).
+ *
+ * \f{align}
+ * \frac{\partial x^i}{\partial \bar{x}^j} &=
+ * \sigma \frac{\partial x_1^i}{\partial x_0^k}
+ * \frac{\partial x_0^k}{\partial \bar{x}^j} +
+ * (1-\sigma)\frac{\partial x_0^i}{\partial \bar{x}^j}
+ * + \frac{\partial \sigma}{\partial \bar{x}^j} (x_1^i - x_0^i),
+ * \nonumber \\
+ * &= (1-\sigma+\lambda\sigma) \frac{\partial x_0^i}{\partial \bar{x}^j} +
+ * \sigma (x_0^i - P^i) \frac{\partial \lambda}{\partial x_0^k}
+ * \frac{\partial x_0^k}{\partial \bar{x}^j}
+ * + \frac{\partial \sigma}{\partial \bar{x}^j} (x_1^i - x_0^i),
+ * \f}
+ * where in the last line we have substituted Eq. (4).
+ *
+ * The class defined by the `InnerMap` template parameter
+ * provides the function `deriv_sigma`, which returns
+ * \f$\partial \sigma/\partial \bar{x}^j\f$, and the function `jacobian`,
+ * which returns \f$\partial x_0^k/\partial \bar{x}^j\f$.
+ *
+ * ### Inverse map.
+ *
+ * Given \f$x^i\f$, we wish to compute \f$\bar{x}^i\f$.
+ *
+ * We first find the coordinates \f$x_0^i\f$ that lie on the 2-surface
+ * and are defined such that \f$P^i\f$, \f$x_0^i\f$,
+ * and \f$x^i\f$ are co-linear.
+ * See the right panel of the above figure.
+ * \f$x_0^i\f$ is determined by the equation
+ *
+ * \f{align} x_0^i = P^i + (x^i - P^i) \tilde{\lambda},\f}
+ *
+ * where \f$\tilde{\lambda}\f$ is a scalar factor that depends on
+ * \f$x^i\f$ and is determined by the class defined by the `InnerMap` template
+ * parameter.  `InnerMap`
+ * provides a function `lambda_tilde` that takes \f$x^i\f$ and
+ * \f$P^i\f$ as arguments and returns \f$\tilde{\lambda}\f$ (or
+ * a default-constructed `std::optional` if the appropriate
+ * \f$\tilde{\lambda}\f$ cannot be
+ * found; this default-constructed value indicates that the point \f$x^i\f$ is
+ * outside the range of the map).
+ *
+ * Now consider the coordinates \f$x_1^i\f$ that lie on the sphere and
+ * are defined such that \f$P^i\f$, \f$x_1^i\f$, and \f$x^i\f$ are
+ * co-linear.  See the right panel of the figure.
+ * \f$x_1^i\f$ is determined by the equation
+ *
+ * \f{align} x_1^i = P^i + (x^i - P^i) \bar{\lambda},\f}
+ *
+ * where \f$\bar{\lambda}\f$ is a scalar factor that depends on \f$x^i\f$ and
+ * is the solution of a quadratic
+ * that is derived by demanding that \f$x_1^i\f$ lies on the sphere:
+ *
+ * \f{align}
+ * |P^i + (x^i - P^i) \bar{\lambda} - C^i |^2 - R^2 = 0.
+ * \f}
+ *
+ * Eq. (9) is a quadratic equation that
+ * takes the usual form \f$a\bar{\lambda}^2+b\bar{\lambda}+c=0\f$,
+ * with
+ *
+ * \f{align*}
+ *  a &= |x^i-P^i|^2,\\
+ *  b &= 2(x^i-P^i)(P^j-C^j)\delta_{ij},\\
+ *  c &= |P^i-C^i|^2 - R^2.
+ * \f}
+ *
+ * Note that we don't actually need to compute \f$x_1^i\f$. Instead, we
+ * can determine \f$\sigma\f$ by the relation (obtained by solving Eq. (3)
+ * for \f$\sigma\f$ and then inserting Eqs. (7) and (8) to eliminate
+ * \f$x_1^i\f$ and \f$x_0^i\f$)
+ *
+ * \f{align}
+ * \sigma = \frac{\tilde{\lambda}-1}{\tilde{\lambda}-\bar{\lambda}}.
+ * \f}
+ *
+ * The denominator of Eq. (10) is nonzero for nonsingular maps:
+ * From Eqs. (7) and (8), \f$\bar{\lambda}=\tilde{\lambda}\f$ means
+ * that \f$x_1^i=x_0^i\f$, which means that
+ * the \f$\sigma=0\f$ and \f$\sigma=1\f$ surfaces intersect, i.e.
+ * the map is singular.
+ *
+ * Once we have \f$x_0^i\f$ and \f$\sigma\f$, the point
+ * \f$(\bar{x},\bar{y},\bar{z})\f$ is uniquely determined by `InnerMap`.
+ * The `inverse` function of `InnerMap` takes \f$x_0^i\f$ and \f$\sigma\f$
+ * as arguments, and returns
+ * \f$(\bar{x},\bar{y},\bar{z})\f$, or a default-constructed `std::optional`
+ * if \f$x_0^i\f$ or
+ * \f$\sigma\f$ are outside the range of the map.
+ *
+ * #### Root polishing
+ *
+ * The inverse function described above will sometimes have errors that
+ * are noticeably larger than roundoff.  Therefore we apply a single
+ * Newton-Raphson iteration to refine the result of the inverse map:
+ * Suppose we are given \f$x^i\f$, and we have computed \f$\bar{x}^i\f$
+ * by the above procedure.  We then correct \f$\bar{x}^i\f$ by adding
+ *
+ * \f{align}
+ * \delta \bar{x}^i = \left(x^j - x^j(\bar{x})\right)
+ * \frac{\partial \bar{x}^i}{\partial x^j},
+ * \f}
+ *
+ * where \f$x^j(\bar{x})\f$ is the result of applying the forward map
+ * to \f$\bar{x}^i\f$ and \f$\partial \bar{x}^i/\partial x^j\f$ is the
+ * inverse jacobian.
+ *
+ * ### Inverse jacobian
+ *
+ * We write the inverse Jacobian as
+ *
+ * \f{align}
+ * \frac{\partial \bar{x}^i}{\partial x^j} =
+ * \frac{\partial \bar{x}^i}{\partial x_0^k}
+ * \frac{\partial x_0^k}{\partial x^j}
+ * + \frac{\partial \bar{x}^i}{\partial \sigma}
+ *   \frac{\partial \sigma}{\partial x^j},
+ * \f}
+ *
+ * where we have recognized that \f$\bar{x}^i\f$ depends both on
+ * \f$x_0^k\f$ (the corresponding point on the 2-surface) and on
+ * \f$\sigma\f$ (encoding the distance away from the 2-surface).
+ *
+ * We now evaluate Eq. (12). The `InnerMap` class provides a function
+ * `inv_jacobian` that returns \f$\partial \bar{x}^i/\partial x_0^k\f$
+ * (where \f$\sigma\f$ is held fixed), and a function `dxbar_dsigma`
+ * that returns \f$\partial \bar{x}^i/\partial \sigma\f$ (where
+ * \f$x_0^i\f$ is held fixed).  The factor \f$\partial x_0^j/\partial
+ * x^i\f$ can be computed by differentiating Eq. (7), which yields
+ *
+ * \f{align}
+ * \frac{\partial x_0^j}{\partial x^i} &= \tilde{\lambda} \delta_i^j
+ * + \frac{x_0^j-P^j}{\tilde{\lambda}}
+ *   \frac{\partial\tilde{\lambda}}{\partial x^i},
+ * \f}
+ *
+ * where \f$\partial \tilde{\lambda}/\partial x^i\f$ is provided by
+ * the `deriv_lambda_tilde` function of `InnerMap`.  Note that for
+ * nonsingular maps there is no worry that \f$\tilde{\lambda}\f$ is
+ * zero in the denominator of the second term of Eq. (13); if
+ * \f$\tilde{\lambda}=0\f$ then \f$x_0^i=P^i\f$ by Eq. (7), and therefore
+ * the map is singular.
+ *
+ * To evaluate the remaining unknown factor in Eq. (12),
+ * \f$\partial \sigma/\partial x^j\f$,
+ * note that [combining Eqs. (1), (7), and (8)]
+ * \f$\bar{\lambda}=\tilde{\lambda}\lambda\f$.
+ * Therefore Eq. (10) is equivalent to
+ *
+ * \f{align}
+ * \sigma &= \frac{\tilde{\lambda}-1}{\tilde{\lambda}(1-\lambda)}.
+ * \f}
+ *
+ * Differentiating this expression yields
+ *
+ * \f{align}
+ * \frac{\partial \sigma}{\partial x^i} &=
+ * \frac{\partial \sigma}{\partial \lambda}
+ * \frac{\partial \lambda}{\partial x_0^j}
+ * \frac{\partial x_0^j}{\partial x^i}
+ * + \frac{\partial \sigma}{\partial \tilde\lambda}
+ *   \frac{\partial \tilde\lambda}{\partial x^i}\\
+ * &=
+ * \frac{\sigma}{1-\lambda}
+ * \frac{\partial \lambda}{\partial x_0^j}
+ * \frac{\partial x_0^j}{\partial x^i}
+ * +
+ * \frac{1}{\tilde{\lambda}^2(1-\lambda)}
+ * \frac{\partial \tilde\lambda}{\partial x^i},
+ * \f}
+ *
+ * where the second factor in the first term can be evaluated using
+ * Eq. (5), the third factor in the first term can be evaluated using
+ * Eq. (13), and the second factor in the second term is provided by
+ * `InnerMap`s function `deriv_lambda_tilde`.
+ *
+ */
+template <typename InnerMap>
+class FocallyLiftedMap {
+ public:
+  static constexpr size_t dim = 3;
+  FocallyLiftedMap(const std::array<double, 3>& center,
+                   const std::array<double, 3>& proj_center, double radius,
+                   InnerMap inner_map) noexcept;
+
+  FocallyLiftedMap() = default;
+  ~FocallyLiftedMap() = default;
+  FocallyLiftedMap(FocallyLiftedMap&&) = default;
+  FocallyLiftedMap(const FocallyLiftedMap&) = default;
+  FocallyLiftedMap& operator=(const FocallyLiftedMap&) = default;
+  FocallyLiftedMap& operator=(FocallyLiftedMap&&) = default;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  std::optional<std::array<double, 3>> inverse(
+      const std::array<double, 3>& target_coords) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> jacobian(
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> inv_jacobian(
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  // clang-tidy: google runtime references
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+  static bool is_identity() noexcept { return false; }
+
+ private:
+  friend bool operator==
+      <InnerMap>(const FocallyLiftedMap<InnerMap>& lhs,
+                 const FocallyLiftedMap<InnerMap>& rhs) noexcept;
+  std::array<double, 3> center_{}, proj_center_{};
+  double radius_{std::numeric_limits<double>::signaling_NaN()};
+  InnerMap inner_map_;
+};
+template <typename InnerMap>
+bool operator!=(const FocallyLiftedMap<InnerMap>& lhs,
+                const FocallyLiftedMap<InnerMap>& rhs) noexcept;
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/FocallyLiftedMapHelpers.cpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedMapHelpers.cpp
@@ -1,0 +1,259 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/FocallyLiftedMapHelpers.hpp"
+
+#include <cmath>
+#include <gsl/gsl_poly.h>
+#include <limits>
+
+#include "DataStructures/DataVector.hpp"
+#include "NumericalAlgorithms/RootFinding/QuadraticEquation.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace domain::CoordinateMaps::FocallyLiftedMapHelpers {
+
+template <typename T>
+void scale_factor(const gsl::not_null<tt::remove_cvref_wrap_t<T>*>& result,
+                  const std::array<T, 3>& src_point,
+                  const std::array<double, 3>& proj_center,
+                  const std::array<double, 3>& sphere_center, double radius,
+                  const bool src_is_between_proj_and_target) noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  // quadratic equation is
+  // a scale_factor^2 + b scale_factor + c = 0
+  //
+  // For this case
+  // a = |x_0^i-P^i|^2
+  // b = 2(x_0^i-P^i)(P^j-C^j)\delta_{ij}
+  // c = |P^i-C^i|^2 - R^2
+  //
+  const ReturnType a = square(src_point[0] - proj_center[0]) +
+                       square(src_point[1] - proj_center[1]) +
+                       square(src_point[2] - proj_center[2]);
+  const ReturnType b =
+      2.0 *
+      ((src_point[0] - proj_center[0]) * (proj_center[0] - sphere_center[0]) +
+       (src_point[1] - proj_center[1]) * (proj_center[1] - sphere_center[1]) +
+       (src_point[2] - proj_center[2]) * (proj_center[2] - sphere_center[2]));
+  const double c = square(sphere_center[0] - proj_center[0]) +
+                   square(sphere_center[1] - proj_center[1]) +
+                   square(sphere_center[2] - proj_center[2]) - square(radius);
+  if (src_is_between_proj_and_target) {
+    // Here we assume that src_point is between proj_center and
+    // target_point.  There are three cases: 1) src and proj are both
+    // inside the sphere, 2) src and proj are both outside the sphere,
+    // and 3) proj is outside the sphere and src is inside the sphere.
+    // Note that a root of zero corresponds to target_point = proj_center,
+    // and a root of unity corresponds to target_point = src_point.
+    // To cover all 3 cases, we choose the smallest root that is
+    // greater than or equal to unity. This means for case 2) we are
+    // choosing the point closest to src.
+    *result = smallest_root_greater_than_value_within_roundoff(
+        a, b, make_with_value<ReturnType>(a, c), 1.0);
+  } else {
+    // Here we assume that target_point is between proj_center and
+    // src_point. There are three cases: 1) proj is inside the sphere
+    // and src is outside the sphere 2) src is inside the sphere and proj
+    // is outside the sphere, and 3) the sphere is between src and proj.
+    // Note that a root of zero corresponds to target_point = proj_center,
+    // and a root of unity corresponds to target_point = src_point.
+    // To cover all 3 cases, we choose the largest root that is less than
+    // or equal to unity, and we require that this root is positive.
+    // This means that for 3) we are choosing the point closest to src.
+    *result = largest_root_between_values_within_roundoff(
+        a, b, make_with_value<ReturnType>(a, c), 0.0, 1.0);
+  }
+}
+
+std::optional<double> try_scale_factor(
+    const std::array<double, 3>& src_point,
+    const std::array<double, 3>& proj_center,
+    const std::array<double, 3>& sphere_center, double radius,
+    const bool pick_larger_root,
+    const bool pick_root_greater_than_one) noexcept {
+  // We solve the quadratic for (scale_factor-1) instead of
+  // scale_factor to avoid roundoff problems when scale_factor is very
+  // nearly equal to unity.  Note that scale_factor==1 will occur in
+  // the inverse map when src_point (which is x^i) is
+  // on the sphere.
+  //
+  // Roundoff is not a problem when forward-mapping and solving only
+  // for lambda.
+
+  // If the original quadratic equation is
+  //
+  // A scale_factor^2 + B scale_factor + C = 0,
+  //
+  // and if x = scale_factor-1, then the quadratic equation for x is
+  //
+  // a x^2 + b x + c = 0
+  //
+  // where
+  //
+  // a = A
+  // b = 2A + B
+  // c = A + B + C
+  //
+  // For this case
+  // A = |x_0^i-P^i|^2
+  // B = 2(x_0^i-P^i)(P^j-C^j)\delta_{ij}
+  // C = |P^i-C^i|^2 - R^2
+  //
+  // Note that A + B + C is |x_0^i-P^i+P^i-C^i|^2 - R^2
+  // and 2A+B is 2(x_0^i-P^i)(x_0^j-P^j+P^j-C^j), so
+  //
+  // a = |x_0^i-P^i|^2
+  // b = 2(x_0^i-P^i)(x_0^j-C^j)\delta_{ij}
+  // c = |x_0^i-C^i|^2 - R^2
+
+  const double a = square(src_point[0] - proj_center[0]) +
+                   square(src_point[1] - proj_center[1]) +
+                   square(src_point[2] - proj_center[2]);
+  const double b =
+      2.0 *
+      ((src_point[0] - proj_center[0]) * (src_point[0] - sphere_center[0]) +
+       (src_point[1] - proj_center[1]) * (src_point[1] - sphere_center[1]) +
+       (src_point[2] - proj_center[2]) * (src_point[2] - sphere_center[2]));
+  const double c = square(sphere_center[0] - src_point[0]) +
+                   square(sphere_center[1] - src_point[1]) +
+                   square(sphere_center[2] - src_point[2]) - square(radius);
+
+  double x0 = std::numeric_limits<double>::signaling_NaN();
+  double x1 = std::numeric_limits<double>::signaling_NaN();
+  const int num_real_roots = gsl_poly_solve_quadratic(a, b, c, &x0, &x1);
+  if (num_real_roots == 2) {
+    // We solved for scale_factor-1 above, so add 1 to get scale_factor.
+    x0 += 1.0;
+    x1 += 1.0;
+    if (UNLIKELY(equal_within_roundoff(x0, 1.0))) {
+      x0 = 1.0;
+    }
+    if (UNLIKELY(equal_within_roundoff(x1, 1.0))) {
+      x1 = 1.0;
+    }
+    if (pick_root_greater_than_one) {
+      // For the inverse map, we want the a scale_factor s such that
+      // s >= 1. Note that gsl_poly_solve_quadratic returns x0 < x1.
+      // have three cases:
+      //  a) x0 < x1 < 1         ->   no root
+      //  b) x0 < 1 <= x1        ->   Choose x1
+      //  c) 1 <= x0 < x1        ->   choose based on pick_larger_root
+      if (x0 >= 1.0 and not pick_larger_root) {
+        return x0;
+      } else if (x1 >= 1.0) {
+        return x1;
+      } else {
+        return std::optional<double>{};
+      }
+    } else {
+      // For the inverse map, we want a scale_factor s such that 0 < s <= 1.
+      // Note that gsl_poly_solve_quadratic returns x0 < x1.
+      // So we have six cases:
+      //  a) x0 < x1 <= 0        ->   no root
+      //  b) x0 <= 0 < x1 <= 1   ->   Choose x1
+      //  c) x0 <= 0 and x1 > 1  ->   no root
+      //  d) 0 < x0 < x1 <= 1      ->   Choose according to pick_larger_root
+      //  e) 0 < x0 <= 1 < x1      ->   Choose x0
+      //  f) 1 < x0 < x1           ->   no root
+      if (x0 <= 0.0) {
+        if (x1 > 0.0 and x1 <= 1.0) {
+          return x1;  // b)
+        } else {
+          return std::optional<double>{};  // a) and c)
+        }
+      } else if (x0 <= 1.0) {
+        if (x1 > 1.0) {
+          return x0;  // e)
+        } else {
+          return pick_larger_root ? x1 : x0;  // d)
+        }
+      } else {
+        return std::optional<double>{};  // f)
+      }
+    }
+  } else if (num_real_roots == 1) {
+    // We solved for scale_factor-1 above, so add 1 to get scale_factor.
+    x0 += 1.0;
+    if (equal_within_roundoff(x0, 1.0)) {
+      x0 = 1.0;
+    }
+    if (pick_root_greater_than_one) {
+      if (x0 < 1.0) {
+        return std::optional<double>{};
+      } else {
+        return x0;
+      }
+    } else {
+      if (x0 <= 0.0 or x0 > 1.0) {
+        return std::optional<double>{};
+      } else {
+        return x0;
+      }
+    }
+  } else {
+    return std::optional<double>{};
+  }
+}
+
+template <typename T>
+void d_scale_factor_d_src_point(
+    const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>& result,
+    const std::array<T, 3>& intersection_point,
+    const std::array<double, 3>& proj_center,
+    const std::array<double, 3>& sphere_center, const T& lambda) noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  ASSERT(not(intersection_point[0] == proj_center[0] and
+             intersection_point[1] == proj_center[1] and
+             intersection_point[2] == proj_center[2]),
+         "d_scale_factor_d_src_point: trying to divide by zero.  If this"
+         "happens, then the map is singular.");
+  const ReturnType lambda_squared_over_denominator =
+      square(lambda) / (square(intersection_point[0] - proj_center[0]) +
+                        square(intersection_point[1] - proj_center[1]) +
+                        square(intersection_point[2] - proj_center[2]) +
+                        ((intersection_point[0] - proj_center[0]) *
+                             (proj_center[0] - sphere_center[0]) +
+                         (intersection_point[1] - proj_center[1]) *
+                             (proj_center[1] - sphere_center[1]) +
+                         (intersection_point[2] - proj_center[2]) *
+                             (proj_center[2] - sphere_center[2])));
+  for (size_t i = 0; i < 3; ++i) {
+    gsl::at(*result, i) =
+        lambda_squared_over_denominator *
+        (gsl::at(sphere_center, i) - gsl::at(intersection_point, i));
+  }
+}
+
+// Explicit instantiations
+/// \cond
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                              \
+  template void scale_factor<DTYPE(data)>(                                \
+      const gsl::not_null<tt::remove_cvref_wrap_t<DTYPE(data)>*>& result, \
+      const std::array<DTYPE(data), 3>& src_point,                        \
+      const std::array<double, 3>& proj_center,                           \
+      const std::array<double, 3>& sphere_center, double radius,          \
+      bool src_is_between_proj_and_target) noexcept;                      \
+  template void d_scale_factor_d_src_point<DTYPE(data)>(                  \
+      const gsl::not_null<                                                \
+          std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>*>& result,  \
+      const std::array<DTYPE(data), 3>& intersection_point,               \
+      const std::array<double, 3>& proj_center,                           \
+      const std::array<double, 3>& sphere_center,                         \
+      const DTYPE(data) & lambda) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
+                                      std::reference_wrapper<const double>,
+                                      std::reference_wrapper<const DataVector>))
+#undef INSTANTIATE
+#undef DTYPE
+/// \endcond
+
+}  // namespace domain::CoordinateMaps::FocallyLiftedMapHelpers

--- a/src/Domain/CoordinateMaps/FocallyLiftedMapHelpers.hpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedMapHelpers.hpp
@@ -1,0 +1,156 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <optional>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
+
+/// Holds helper functions for use with
+/// domain::CoordinateMaps::FocallyLiftedMap.
+namespace domain::CoordinateMaps::FocallyLiftedMapHelpers {
+
+/*!
+ * \brief Finds how long to extend a line segment to have it intersect
+ * a point on a 2-sphere.
+ *
+ * \details Consider a 2-sphere with center \f$C^i\f$ and radius \f$R\f$, and
+ * and let \f$P^i\f$ and \f$x_0^i\f$ be two arbitrary 3D points.
+ *
+ * Consider the line passing through \f$P^i\f$ and \f$x_0^i\f$.
+ * If this line intersects the sphere at a point \f$x_1^i\f$, then we can write
+ *
+ * \f[
+ *  x_1^i = P^i + (x_0^i-P^i) \lambda,
+ * \f]
+ *
+ * where \f$\lambda\f$ is a scale factor.
+ *
+ * `scale_factor` computes and returns \f$\lambda\f$.
+ *
+ * ### Even more detail:
+ *
+ * To solve for \f$\lambda\f$, we note that \f$x_1^i\f$ is on the surface of
+ * the sphere, so
+ *
+ * \f[
+ *  |x_1^i-C^i|^2 = R^2,
+ * \f]
+ *
+ * (where \f$|A^i|^2\f$ means \f$\delta_{ij} A^i A^j\f$),
+ *
+ *  or equivalently
+ *
+ * \f[
+ *  | P^i-C^i + (x_0^i-P^i)\lambda |^2 = R^2.
+ * \f]
+ *
+ * This is a quadratic equation for \f$\lambda\f$
+ * and it generally has more than one real root.
+ * It takes the usual form \f$a\lambda^2+b\lambda+c=0\f$,
+ * with
+ *
+ * \f{align*}
+ *  a &= |x_0^i-P^i|^2,\\
+ *  b &= 2(x_0^i-P^i)(P^j-C^j)\delta_{ij},\\
+ *  c &= |P^i-C^i|^2 - R^2,
+ * \f}
+ *
+ * So how do we choose between multiple roots?  Some of the maps that
+ * use `scale_factor` assume that *for all points*, \f$x_0^i\f$ is
+ * between \f$P^i\f$ and \f$x_1^i\f$.  Those maps should set the parameter
+ * `src_is_between_proj_and_target` to true. Other maps assume that
+ * *for all points*, \f$x^i\f$ is always between \f$x_0^i\f$
+ * and \f$P^i\f$. Those maps should set the parameter
+ * `src_is_between_proj_and_target` to false.
+ *
+ * \warning If we ever add maps where
+ * `src_is_between_proj_and_target` can change from point to point,
+ * the logic of `scale_factor` needs to be changed.
+ *
+ * In the arguments to the function below, `src_point` is  \f$x_0^i\f$,
+ * `proj_center` is \f$P^i\f$, `sphere_center` is \f$C^i\f$, and
+ * `radius` is \f$R\f$.
+ *
+ */
+template <typename T>
+void scale_factor(const gsl::not_null<tt::remove_cvref_wrap_t<T>*>& result,
+                  const std::array<T, 3>& src_point,
+                  const std::array<double, 3>& proj_center,
+                  const std::array<double, 3>& sphere_center, double radius,
+                  bool src_is_between_proj_and_target) noexcept;
+
+/*!
+ *  Solves a problem of the same form as `scale_factor`, but is used
+ *  only by the inverse function to compute \f$\tilde{\lambda}\f$ and
+ *  \f$\bar{\lambda}\f$. `try_scale_factor` is used in two contexts:
+ *
+ *  `try_scale_factor` is used to determine \f$\bar{\lambda}\f$
+ *  given \f$x^i\f$. \f$\bar{\lambda}\f$ is defined by
+ *  \f{align*} x_1^i = P^i + (x^i - P^i) \bar{\lambda}.\f}
+ *
+ *  `try_scale_factor` is used by the `lambda_tilde` functions of some
+ *  of the `InnerMap` classes (namely those `InnerMap` classes where
+ *  \f$x_0^i\f$ is a spherical surface) to solve for
+ *  \f$\tilde{\lambda}\f$ given\f$x^i\f$.  \f$\tilde{\lambda}\f$
+ *  is defined by
+ *  \f{align*} x_0^i = P^i + (x^i - P^i) \tilde{\lambda}.\f}
+ *
+ *  In both of these contexts, the input parameter `src_point` is
+ *  \f$x^i\f$, a point that is supposed to be in the range of the
+ *  `FocallyLiftedMap`. Because the inverse function can be and is
+ *  called for an arbitrary \f$x^i\f$ that might not be in the range
+ *  of the `FocallyLiftedMap`, `try_scale_factor` returns a
+ *  std::optional, with a default-constructed std::optional if the roots it
+ *  finds are not as expected (i.e. if the inverse map was called for
+ *  a point not in the range of the map).
+ *
+ *  Because `try_scale_factor` can be called in different situations,
+ *  it has additional boolean arguments `pick_larger_root` and
+ *  `pick_root_greater_than_one` that allow the caller to choose which
+ *  root to return.
+ *
+ * `try_scale_factor` is not templated
+ *  on type because it is used only by the inverse function, which
+ *  works only on doubles.
+ *
+ */
+std::optional<double> try_scale_factor(
+    const std::array<double, 3>& src_point,
+    const std::array<double, 3>& proj_center,
+    const std::array<double, 3>& sphere_center, double radius,
+    bool pick_larger_root, bool pick_root_greater_than_one) noexcept;
+
+/*!
+ * Computes \f$\partial \lambda/\partial x_0^i\f$, where \f$\lambda\f$
+ * is the quantity returned by `scale_factor` and `x_0` is `src_point` in
+ * the `scale_factor` function.
+ *
+ * The formula (see `FocallyLiftedMap`) is
+ * \f{align*}
+ * \frac{\partial\lambda}{\partial x_0^j} &=
+ * \lambda^2 \frac{C_j - x_1^j}{|x_1^i - P^i|^2
+ * + (x_1^i - P^i)(P_i - C_i)}.
+ * \f}
+ *
+ * Note that it takes `intersection_point` and not `src_point` as a
+ * parameter.
+ *
+ * In the arguments to the function below, `intersection_point` is \f$x_1\f$,
+ * `proj_center` is \f$P^i\f$, `sphere_center` is \f$C^i\f$, and
+ * `radius` is \f$R\f$.
+ */
+template <typename T>
+void d_scale_factor_d_src_point(
+    const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>& result,
+    const std::array<T, 3>& intersection_point,
+    const std::array<double, 3>& proj_center,
+    const std::array<double, 3>& sphere_center, const T& lambda) noexcept;
+
+}  // namespace domain::CoordinateMaps::FocallyLiftedMapHelpers

--- a/src/NumericalAlgorithms/RootFinding/QuadraticEquation.cpp
+++ b/src/NumericalAlgorithms/RootFinding/QuadraticEquation.cpp
@@ -6,7 +6,11 @@
 #include <gsl/gsl_poly.h>
 #include <limits>
 
+#include "DataStructures/DataVector.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
 
 double positive_root(const double a, const double b, const double c) noexcept {
   const auto roots = real_roots(a, b, c);
@@ -28,3 +32,131 @@ std::array<double, 2> real_roots(const double a, const double b,
          << " b=" << b << " c=" << c);
   return {{x0, x1}};
 }
+
+namespace detail {
+template <typename T>
+struct root_between_values_impl;
+enum class RootToChoose { min, max };
+}  // namespace detail
+
+template <typename T>
+T smallest_root_greater_than_value_within_roundoff(
+    const T& a, const T& b, const T& c, const double value) noexcept {
+  return detail::root_between_values_impl<T>::function(
+      a, b, c, value, std::numeric_limits<double>::max(),
+      detail::RootToChoose::min);
+}
+
+template <typename T>
+T largest_root_between_values_within_roundoff(const T& a, const T& b,
+                                              const T& c,
+                                              const double min_value,
+                                              const double max_value) noexcept {
+  return detail::root_between_values_impl<T>::function(
+      a, b, c, min_value, max_value, detail::RootToChoose::max);
+}
+
+namespace detail {
+template <>
+struct root_between_values_impl<double> {
+  static double function(const double a, const double b, const double c,
+                         const double min_value, const double max_value,
+                         const RootToChoose min_or_max) noexcept {
+    // Roots are returned in increasing order.
+    const auto roots = real_roots(a, b, c);
+
+    const std::array<bool, 2> roots_out_of_bounds_low{
+        {roots[0] < min_value and
+             not equal_within_roundoff(roots[0], min_value),
+         roots[1] < min_value and
+             not equal_within_roundoff(roots[1], min_value)}};
+    const std::array<bool, 2> roots_out_of_bounds_high{
+        {roots[0] > max_value and
+             not equal_within_roundoff(roots[0], max_value),
+         roots[1] > max_value and
+             not equal_within_roundoff(roots[1], max_value)}};
+
+    double return_value = std::numeric_limits<double>::signaling_NaN();
+    const auto error_message = [&a, &b, &c,
+                                &roots](const std::string& message) noexcept {
+      ERROR(message << " Roots are " << roots[0] << " and " << roots[1]
+                    << ", with a=" << a << " b=" << b << " c=" << c);
+    };
+
+    if (min_or_max == RootToChoose::min) {
+      // Check roots[0] first because it is the smallest
+      if (roots_out_of_bounds_low[0]) {
+        if (roots_out_of_bounds_low[1]) {
+          error_message("No root >= (within roundoff) min_value.");
+        }
+        if (roots_out_of_bounds_high[1]) {
+          error_message(
+              "No root between min_value and max_value (within roundoff).");
+        }
+        return_value = roots[1];
+      } else {
+        if (roots_out_of_bounds_high[0]) {
+          error_message("No root <= (within roundoff) max_value.");
+        }
+        return_value = roots[0];
+      }
+    } else {
+      // Check roots[1] first because it is the largest
+      if (roots_out_of_bounds_high[1]) {
+        if (roots_out_of_bounds_high[0]) {
+          error_message("No root <= (within roundoff) max_value.");
+        }
+        if (roots_out_of_bounds_low[0]) {
+          error_message(
+              "No root between min_value and max_value (within "
+              "roundoff).");
+        }
+        return_value = roots[0];
+      } else {
+        if (roots_out_of_bounds_low[1]) {
+          error_message("No root >= (within roundoff) min_value.");
+        }
+        return_value = roots[1];
+      }
+    }
+    return return_value;
+  }
+};
+
+template <>
+struct root_between_values_impl<DataVector> {
+  static DataVector function(const DataVector& a, const DataVector& b,
+                             const DataVector& c, const double min_value,
+                             const double max_value,
+                             const RootToChoose min_or_max) noexcept {
+    ASSERT(a.size() == b.size(),
+           "Size mismatch a vs b: " << a.size() << " " << b.size());
+    ASSERT(a.size() == c.size(),
+           "Size mismatch a vs c: " << a.size() << " " << c.size());
+    DataVector result(a.size());
+    for (size_t i = 0; i < a.size(); ++i) {
+      result[i] = root_between_values_impl<double>::function(
+          a[i], b[i], c[i], min_value, max_value, min_or_max);
+    }
+    return result;
+  }
+};
+}  // namespace detail
+
+// Explicit instantiations
+/// \cond
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                               \
+  template DTYPE(data) smallest_root_greater_than_value_within_roundoff(   \
+      const DTYPE(data) & a, const DTYPE(data) & b, const DTYPE(data) & c, \
+      double value) noexcept;                                              \
+  template DTYPE(data) largest_root_between_values_within_roundoff(        \
+      const DTYPE(data) & a, const DTYPE(data) & b, const DTYPE(data) & c, \
+      double min_value, double max_value) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
+
+#undef DTYPE
+#undef INSTANTIATE
+/// \endcond

--- a/src/NumericalAlgorithms/RootFinding/QuadraticEquation.hpp
+++ b/src/NumericalAlgorithms/RootFinding/QuadraticEquation.hpp
@@ -19,6 +19,31 @@ double positive_root(double a, double b, double c) noexcept;
 
 /*!
  * \ingroup NumericalAlgorithmsGroup
+ * \brief Returns the smallest root of a quadratic equation \f$ax^2 +
+ * bx + c = 0\f$ that is greater than the given value, within roundoff.
+ * \returns A root of a quadratic equation.
+ * \requires That there are two real roots.
+ * \requires At least one root is greater than the given value, to roundoff.
+ */
+template <typename T>
+T smallest_root_greater_than_value_within_roundoff(const T& a, const T& b,
+                                                   const T& c,
+                                                   double value) noexcept;
+/*!
+ * \ingroup NumericalAlgorithmsGroup
+ * \brief Returns the largest root of a quadratic equation
+ * \f$ax^2 + bx + c = 0\f$ that is between min_value and max_value,
+ * within roundoff.
+ * \returns A root of a quadratic equation.
+ * \requires That there are two real roots.
+ * \requires At least one root is between min_value and max_value, to roundoff.
+ */
+template <typename T>
+T largest_root_between_values_within_roundoff(const T& a, const T& b,
+                                              const T& c, double min_value,
+                                              double max_value) noexcept;
+/*!
+ * \ingroup NumericalAlgorithmsGroup
  * \brief Returns the two real roots of a quadratic equation \f$ax^2 +
  * bx + c = 0\f$ with the root closer to \f$-\infty\f$ first.
  * \returns An array of the roots of a quadratic equation

--- a/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_Affine.cpp
   Test_BulgedCube.cpp
   Test_CoordinateMap.cpp
+  Test_CylindricalEndcap.cpp
   Test_DiscreteRotation.cpp
   Test_EquatorialCompression.cpp
   Test_Equiangular.cpp

--- a/tests/Unit/Domain/CoordinateMaps/Test_CylindricalEndcap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CylindricalEndcap.cpp
@@ -1,0 +1,227 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <gsl/gsl_poly.h>
+#include <optional>
+#include <random>
+
+#include "Domain/CoordinateMaps/CylindricalEndcap.hpp"
+#include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
+#include "NumericalAlgorithms/RootFinding/QuadraticEquation.hpp"
+
+namespace domain {
+namespace {
+void test_cylindrical_endcap() {
+  INFO("CylindricalEndcap");
+  // Set up random number generator
+  MAKE_GENERATOR(gen);
+
+  std::uniform_real_distribution<> unit_dis(0.0, 1.0);
+  std::uniform_real_distribution<> interval_dis(-1.0, 1.0);
+  std::uniform_real_distribution<> angle_dis(0.0, 2.0 * M_PI);
+
+  // Choose some random centers for sphere_one and sphere_two
+  const std::array<double, 3> center_one = {
+      interval_dis(gen), interval_dis(gen), interval_dis(gen)};
+  CAPTURE(center_one);
+  const std::array<double, 3> center_two = {
+      interval_dis(gen), interval_dis(gen), interval_dis(gen)};
+  CAPTURE(center_two);
+  const double dist_between_spheres =
+      sqrt(square(center_two[0] - center_one[0]) +
+           square(center_two[1] - center_one[1]) +
+           square(center_two[2] - center_one[2]));
+
+  // Pick radius of sphere_one not too small compared to the distance
+  // between the centers.  We choose 0.3*dist_between_spheres so that
+  // we don't have a microscopic sphere (without that term the radius could be
+  // arbitrarily small), but still allow the radius to be smaller than
+  // the distance between the centers.
+  const double radius_one = 0.3 * dist_between_spheres + unit_dis(gen);
+  CAPTURE(radius_one);
+
+  // Make sure z_plane intersects sphere_one on the +z side of the
+  // center. We don't allow the plane to be displaced by less than 10%
+  // or more than 90% of the radius.
+  const double z_plane =
+      center_one[2] + (0.1 + 0.8 * unit_dis(gen)) * radius_one;
+  CAPTURE(z_plane);
+
+  // Now construct sphere_two which we make sure encloses sphere_one,
+  // but doesn't have too large of a radius.
+  const double radius_two =
+      (unit_dis(gen) + 1.0) * (radius_one + dist_between_spheres);
+  CAPTURE(radius_two);
+
+  const std::array<double, 3> proj_center = [&z_plane, &center_one, &radius_one,
+                                             &center_two, &radius_two, &gen,
+                                             &unit_dis, &angle_dis]() noexcept {
+    // Consider a cone formed by taking the intersection of z_plane and
+    // sphere_one (this is a circle called circle_one) and connecting it to
+    // center_one. Compute theta, where 2*theta is the opening angle of this
+    // cone. Call this cone 'cone_one'.
+    // cone_one is the cone centered at C_1 in the "Allowed region for P"
+    // figure in the doxygen documentation for ClyndricalEndcap.hpp.
+    const double cos_theta = (z_plane - center_one[2]) / radius_one;
+
+    // We will construct two new cones. The first we will call
+    // cone_regular. It is constructed so that cone_regular and
+    // cone_one intersect each other on circle_one at right angles.
+    // Cone_regular opens in the -z direction with opening angle 2*(pi/2-theta).
+    // cone_regular is the cone centered at S in the "Allowed region for P"
+    // figure in the doxygen documentation for ClyndricalEndcap.hpp.
+    // The apex of cone_regular is cone_regular_apex, defined as follows:
+    const std::array<double, 3> cone_regular_apex = {
+        center_one[0], center_one[1], center_one[2] + radius_one / cos_theta};
+    // A necessary condition for the map being
+    // invertible is that proj_center must lie either inside
+    // cone_regular (which opens in the -z direction and intersects
+    // cone_one), or proj_center must lie inside the reflection of
+    // cone_regular (which opens in the +z direction).  If proj_center
+    // is inside cone_regular (i.e. the one that opens in the -z
+    // direction), an additional condition for the map being
+    // invertible is that proj_center cannot lie between sphere_one
+    // and the center of cone_regular.
+
+    // The second cone we will construct we will call cone_opening.
+    // It will have some maximum opening angle that we choose freely.
+    const double max_opening_angle = M_PI / 3.0;
+    // max_opening_angle determines the maximum possible x-coordinate
+    // of proj_center.
+    const double max_proj_center_z =
+        z_plane -
+        radius_one * sqrt(1.0 - square(cos_theta)) / tan(max_opening_angle);
+    // Cone_opening has apex
+    // (center_one[0], center_one[1], max_proj_center_z). Note that if
+    // max_opening_angle > pi/4 and if z_plane > center_one[2] then
+    // the apex of cone_opening is inside sphere_one.
+
+    // Now that we have two cones, cone_regular and cone_opening.  We
+    // will choose proj_center so that it lies inside of both cones,
+    // and that it lies inside of sphere_two.
+    const double cone_regular_opening_angle = asin(cos_theta);
+
+    if (max_opening_angle < cone_regular_opening_angle) {
+      // The easier case.  We need to worry only about max_opening_angle.
+
+      // Choose some smaller cone inside of cone_opening.
+      // We will place proj_center on this smaller cone.
+      const double beta = unit_dis(gen) * max_opening_angle;
+
+      // Choose an azimuthal coordinate for the point on the cone.
+      const double phi = angle_dis(gen);
+
+      // Choose a radius for the point on the cone that will be
+      // proj_center. The point should be inside sphere_two.  So
+      // determine the radius at which the point intersects
+      // sphere_two. This radius is the solution of a quadratic equation
+      // ax^2 + bx + c = 0
+      const double a = 1.0;
+      const double b =
+          2.0 * (-(max_proj_center_z - center_two[2]) * cos(beta) +
+                 (center_one[0] - center_two[0]) * sin(beta) * cos(phi) +
+                 (center_one[1] - center_two[1]) * sin(beta) * sin(phi));
+      const double c = square(max_proj_center_z - center_two[2]) +
+                       square(center_one[0] - center_two[0]) +
+                       square(center_one[1] - center_two[1]) -
+                       square(radius_two);
+      ASSERT(c < 0.0,
+             "max_proj_center_z is too negative. The apex "
+             "is not inside sphere_two");
+      // Should be two real roots. Choose the positive one.
+      const double r_max = positive_root(a, b, c);
+
+      const double proj_radius = unit_dis(gen) * r_max;
+      return std::array<double, 3>{
+          center_one[0] + proj_radius * sin(beta) * cos(phi),
+          center_one[1] + proj_radius * sin(beta) * sin(phi),
+          max_proj_center_z - proj_radius * cos(beta)};
+    } else {
+      // The more difficult case.
+
+      // We may need to try several values of alpha.
+      // When one works, exit.
+      // Failure is rare; most of the time it should succeed on the first try.
+      while (true) {
+        // Choose some smaller cone inside of cone_regular.
+        // We will place proj_center on this smaller cone.
+        // We do not allow the smaller cone to go all the way to
+        // cone_regular_opening_angle.
+        const double alpha = unit_dis(gen) * 0.95 * cone_regular_opening_angle;
+
+        // Consider the circle at which the smaller cone intersects
+        // cone_opening, and find the distance from cone_regular_apex to
+        // this circle.
+        const double radius_coord_circle =
+            (cone_regular_apex[2] - max_proj_center_z) *
+            tan(max_opening_angle) / (tan(max_opening_angle) - tan(alpha)) /
+            cos(alpha);
+
+        // Choose an azimuthal coordinate for the point on the cone.
+        const double phi = angle_dis(gen);
+
+        // Choose a radius for the point on the cone that will be
+        // proj_center. The point should be inside sphere_two.  So
+        // determine the radius at which the point intersects
+        // sphere_two. This radius is the solution of a quadratic equation
+        // ax^2 + bx + c = 0
+        const double a = 1.0;
+        const double b =
+            2.0 * (-(cone_regular_apex[2] - center_two[2]) * cos(alpha) +
+                   (center_one[0] - center_two[0]) * sin(alpha) * cos(phi) +
+                   (center_one[1] - center_two[1]) * sin(alpha) * sin(phi));
+        const double c = square(cone_regular_apex[2] - center_two[2]) +
+                         square(center_one[0] - center_two[0]) +
+                         square(center_one[1] - center_two[1]) -
+                         square(radius_two);
+
+        double x0 = std::numeric_limits<double>::signaling_NaN();
+        double x1 = std::numeric_limits<double>::signaling_NaN();
+        const int num_real_roots = gsl_poly_solve_quadratic(a, b, c, &x0, &x1);
+        double r_max = 0.0;
+        if (num_real_roots == 2) {
+          // Take the largest root.  The smallest one is negative if
+          // cone_regular_apex[0] is inside sphere_two, positive if
+          // cone_regular_apex[0] is outside sphere_two.
+          r_max = std::max(x0, x1);
+        } else if (num_real_roots == 1) {
+          r_max = x0;
+        } else {
+          ASSERT(false,
+                 "No roots were found. This means that the cone does not "
+                 "intersect sphere_two, which should not happen based on the "
+                 "construction above.");
+        }
+
+        if (r_max <= radius_coord_circle) {
+          // We cannot satisfy all the conditions because sphere_two is
+          // too small. So try again with a different alpha.
+          continue;
+        }
+        const double proj_radius =
+            radius_coord_circle + unit_dis(gen) * (r_max - radius_coord_circle);
+        return std::array<double, 3>{
+            center_one[0] + proj_radius * sin(alpha) * cos(phi),
+            center_one[1] + proj_radius * sin(alpha) * sin(phi),
+            cone_regular_apex[2] - proj_radius * cos(alpha)};
+      }
+    }
+  }();
+  CAPTURE(proj_center);
+
+  const CoordinateMaps::CylindricalEndcap map(
+      center_one, center_two, proj_center, radius_one, radius_two, z_plane);
+  test_suite_for_map_on_cylinder(map, 0.0, 1.0);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.CylindricalEndcap",
+                  "[Domain][Unit]") {
+  test_cylindrical_endcap();
+  CHECK(not CoordinateMaps::CylindricalEndcap{}.is_identity());
+}
+}  // namespace domain

--- a/tests/Unit/NumericalAlgorithms/RootFinding/Test_QuadraticEquation.cpp
+++ b/tests/Unit/NumericalAlgorithms/RootFinding/Test_QuadraticEquation.cpp
@@ -5,9 +5,12 @@
 
 #include <algorithm>
 #include <array>
+#include <limits>
 
+#include "DataStructures/DataVector.hpp"
 #include "NumericalAlgorithms/RootFinding/QuadraticEquation.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/MakeWithValue.hpp"
 
 // [[OutputRegex, There are only 0 real roots]]
 [[noreturn]] SPECTRE_TEST_CASE(
@@ -42,6 +45,71 @@
 #endif
 }
 
+namespace {
+  template <typename T>
+  void test_smallest_root_greater_than_value_within_roundoff(
+      const T& used_for_size) noexcept {
+    const auto a = make_with_value<T>(used_for_size, 2.0);
+    const auto b = make_with_value<T>(used_for_size, -11.0);
+    const auto c = make_with_value<T>(used_for_size, 5.0);
+    const auto expected_root_1 = make_with_value<T>(used_for_size, 0.5);
+    const auto expected_root_2 = make_with_value<T>(used_for_size, 5.0);
+
+    auto root = smallest_root_greater_than_value_within_roundoff(a, b, c, 0.3);
+    CHECK_ITERABLE_APPROX(expected_root_1, root);
+    root = smallest_root_greater_than_value_within_roundoff(a, b, c, 0.5);
+    CHECK_ITERABLE_APPROX(expected_root_1, root);
+    root = smallest_root_greater_than_value_within_roundoff(a, b, c, 0.6);
+    CHECK_ITERABLE_APPROX(expected_root_2, root);
+
+    // Note that 'within roundoff' is defined as 100*epsilon,
+    // so adding 10*epsilon should still be within roundoff.
+    root = smallest_root_greater_than_value_within_roundoff(
+        a, b, c, 0.5 * (1.0 + std::numeric_limits<double>::epsilon() * 10.0));
+    CHECK_ITERABLE_APPROX(expected_root_1, root);
+  }
+
+  template <typename T>
+  void test_largest_root_between_values_within_roundoff(
+      const T& used_for_size) noexcept {
+    const auto a = make_with_value<T>(used_for_size, 2.0);
+    const auto b = make_with_value<T>(used_for_size, -11.0);
+    const auto c = make_with_value<T>(used_for_size, 5.0);
+    const auto expected_root_1 = make_with_value<T>(used_for_size, 0.5);
+    const auto expected_root_2 = make_with_value<T>(used_for_size, 5.0);
+
+    auto root = largest_root_between_values_within_roundoff(a, b, c, 0.3, 0.6);
+    CHECK_ITERABLE_APPROX(expected_root_1, root);
+    root = largest_root_between_values_within_roundoff(a, b, c, 0.3, 0.5);
+    CHECK_ITERABLE_APPROX(expected_root_1, root);
+    root = largest_root_between_values_within_roundoff(a, b, c, 0.3, 6.0);
+    CHECK_ITERABLE_APPROX(expected_root_2, root);
+    root = largest_root_between_values_within_roundoff(a, b, c, 0.5, 6.0);
+    CHECK_ITERABLE_APPROX(expected_root_2, root);
+    root = largest_root_between_values_within_roundoff(a, b, c, 0.6, 6.0);
+    CHECK_ITERABLE_APPROX(expected_root_2, root);
+    root = largest_root_between_values_within_roundoff(a, b, c, 0.6, 5.0);
+    CHECK_ITERABLE_APPROX(expected_root_2, root);
+    root = largest_root_between_values_within_roundoff(a, b, c, 0.3, 5.0);
+    CHECK_ITERABLE_APPROX(expected_root_2, root);
+
+    // Note that 'within roundoff' is defined as 100*epsilon,
+    // so adding/subtracting 10*epsilon should still be within roundoff.
+    root = largest_root_between_values_within_roundoff(
+        a, b, c, 0.3,
+        0.5 * (1.0 - std::numeric_limits<double>::epsilon() * 10.0));
+    CHECK_ITERABLE_APPROX(expected_root_1, root);
+    root = largest_root_between_values_within_roundoff(
+        a, b, c, 0.5 * (1.0 - std::numeric_limits<double>::epsilon() * 10.0),
+        4.0);
+    CHECK_ITERABLE_APPROX(expected_root_1, root);
+    root = largest_root_between_values_within_roundoff(
+        a, b, c, 0.5,
+        6.0 * (1.0 - std::numeric_limits<double>::epsilon() * 10.0));
+    CHECK_ITERABLE_APPROX(expected_root_2, root);
+}
+}  // namespace
+
 SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.QuadraticEquation",
                   "[NumericalAlgorithms][RootFinding][Unit]") {
   // Positive root
@@ -60,4 +128,9 @@ SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.QuadraticEquation",
   const auto small_negative = real_roots(1e-8, -(1.0 - 1e-16), -1e-8);
   CHECK(approx(-1e-8) == small_negative[0]);
   CHECK(approx(1e8) == small_negative[1]);
+
+  test_smallest_root_greater_than_value_within_roundoff<double>(1.0);
+  test_smallest_root_greater_than_value_within_roundoff(DataVector(5));
+  test_largest_root_between_values_within_roundoff<double>(1.0);
+  test_largest_root_between_values_within_roundoff(DataVector(5));
 }


### PR DESCRIPTION
## Proposed changes

Adds a map from a 3D unit right cylinder to a volume that connects portions of two spherical surfaces.

CylindricalEndcap is intended to be composed with Wedge2D maps to
construct the "endcap" portion of a cylindrical domain for a binary system.

This is a version of #2329 (now closed) that is more general and written in a way that is easier to add similar maps.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
