### PR TITLE
Serialize algorithm

### DIFF
--- a/cmake/SetupCharm.cmake
+++ b/cmake/SetupCharm.cmake
@@ -28,7 +28,7 @@ endif(NOT TARGET Charmxx)
 #       with GCC
 string(
     REGEX REPLACE "<CMAKE_CXX_COMPILER>"
-    "${CHARM_COMPILER} -pthread -module DistributedLB -no-charmrun"
+    "${CHARM_COMPILER} -pthread -module CommonLBs -no-charmrun"
     CMAKE_CXX_LINK_EXECUTABLE "${CMAKE_CXX_LINK_EXECUTABLE}")
 
 # When building for trace analysis the PAPI counters passed to charmc

--- a/docs/DevGuide/Parallelization.md
+++ b/docs/DevGuide/Parallelization.md
@@ -484,9 +484,7 @@ component. The algorithm can be explicitly evaluated in a new phase by calling
 \snippet Test_AlgorithmCore.cpp start_phase
 
 Alternatively, to evaluate the algorithm without changing phases the
-`perform_algorithm()` method can be used:
-
-\snippet Test_AlgorithmParallel.cpp perform_algorithm
+`perform_algorithm()` method can be used.
 
 By passing `true` to `perform_algorithm` the algorithm will be restarted if it
 was terminated.

--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -180,7 +180,7 @@ class AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>
       tuples::TaggedTuple<InitializationTags...> initialization_items) noexcept;
 
   /// Charm++ migration constructor, used after a chare is migrated
-  constexpr explicit AlgorithmImpl(CkMigrateMessage* /*msg*/) noexcept;
+  explicit AlgorithmImpl(CkMigrateMessage* /*msg*/) noexcept;
 
   /// \cond
   ~AlgorithmImpl() override;
@@ -419,10 +419,19 @@ AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>::
 }
 
 template <typename ParallelComponent, typename... PhaseDepActionListsPack>
-constexpr AlgorithmImpl<ParallelComponent,
-                        tmpl::list<PhaseDepActionListsPack...>>::
-    AlgorithmImpl(CkMigrateMessage* /*msg*/) noexcept
-    : AlgorithmImpl() {}
+AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>::
+    AlgorithmImpl(CkMigrateMessage* msg) noexcept
+    : cbase_type(msg) {
+  if (UNLIKELY(msg == nullptr)) {
+    ERROR(
+        "The AlgorithmImpl has been constructed with a nullptr as a "
+        "CkMigrateMessage* -- most likely this indicates that a constructor "
+        "is being used incorrectly, as the CkMigrateMessage* constructor "
+        "should only be used by the charm framework when migrating. "
+        "Constructing with a nullptr CkMigrateMessage* is dangerous and can "
+        "cause segfaults.");
+  }
+}
 
 template <typename ParallelComponent, typename... PhaseDepActionListsPack>
 AlgorithmImpl<ParallelComponent,

--- a/src/Parallel/ArrayIndex.hpp
+++ b/src/Parallel/ArrayIndex.hpp
@@ -6,6 +6,7 @@
 #include <charm++.h>
 #include <type_traits>
 
+#include "ErrorHandling/Assert.hpp"
 #include "Utilities/TypeTraits/IsA.hpp"
 
 namespace Parallel {

--- a/src/Parallel/GlobalCache.hpp
+++ b/src/Parallel/GlobalCache.hpp
@@ -103,13 +103,25 @@ class MutableGlobalCache : public CBase_MutableGlobalCache<Metavariables> {
   explicit MutableGlobalCache(tuples::tagged_tuple_from_typelist<
                               get_mutable_global_cache_tags<Metavariables>>
                                   mutable_global_cache) noexcept;
-  explicit MutableGlobalCache(CkMigrateMessage* /*msg*/) {}
+  explicit MutableGlobalCache(CkMigrateMessage* msg)
+      : CBase_MutableGlobalCache<Metavariables>(msg) {
+    if (UNLIKELY(msg == nullptr)) {
+      ERROR(
+          "The MutableGlobalCache has been constructed with a nullptr as a "
+          "CkMigrateMessage* -- most likely this indicates that a constructor "
+          "is being used incorrectly, as the CkMigrateMessage* constructor "
+          "should only be used by the charm framework when migrating. "
+          "Constructing with a nullptr CkMigrateMessage* is dangerous and can "
+          "cause segfaults.");
+    }
+  }
   ~MutableGlobalCache() noexcept override {
     (void)Parallel::charmxx::RegisterChare<
         MutableGlobalCache<Metavariables>,
         CkIndex_MutableGlobalCache<Metavariables>>::registrar;
   }
   /// \cond
+  MutableGlobalCache() = default;
   MutableGlobalCache(const MutableGlobalCache&) = default;
   MutableGlobalCache& operator=(const MutableGlobalCache&) = default;
   MutableGlobalCache(MutableGlobalCache&&) = default;
@@ -296,13 +308,25 @@ class GlobalCache : public CBase_GlobalCache<Metavariables> {
               CProxy_MutableGlobalCache<Metavariables>
                   mutable_global_cache_proxy) noexcept;
 
-  explicit GlobalCache(CkMigrateMessage* /*msg*/) {}
+  explicit GlobalCache(CkMigrateMessage* msg)
+      : CBase_GlobalCache<Metavariables>(msg) {
+    if (UNLIKELY(msg == nullptr)) {
+      ERROR(
+          "The GlobalCache has been constructed with a nullptr as a "
+          "CkMigrateMessage* -- most likely this indicates that a constructor "
+          "is being used incorrectly, as the CkMigrateMessage* constructor "
+          "should only be used by the charm framework when migrating. "
+          "Constructing with a nullptr CkMigrateMessage* is dangerous and can "
+          "cause segfaults.");
+    }
+  }
   ~GlobalCache() noexcept override {
     (void)Parallel::charmxx::RegisterChare<
         GlobalCache<Metavariables>,
         CkIndex_GlobalCache<Metavariables>>::registrar;
   }
   /// \cond
+  GlobalCache() = default;
   GlobalCache(const GlobalCache&) = default;
   GlobalCache& operator=(const GlobalCache&) = default;
   GlobalCache(GlobalCache&&) = default;

--- a/tests/Unit/DataStructures/Test_LeviCivitaIterator.cpp
+++ b/tests/Unit/DataStructures/Test_LeviCivitaIterator.cpp
@@ -8,6 +8,7 @@
 
 #include "DataStructures/LeviCivitaIterator.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/StdHelpers.hpp"
 
 SPECTRE_TEST_CASE("Unit.DataStructures.LeviCivitaIterator",
                   "[DataStructures][Unit]") {

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -108,6 +108,43 @@ function(add_algorithm_test_with_input_file TEST_NAME INPUT_FILE_DIR)
     ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
 endfunction()
 
+# Note that we have a 'balance' here that happens 2.5e4 of times per second just
+# to be completely certain that the desired number of migrations occur during
+# the test (5). This tends to have a lot of fluctuation depending on how quickly
+# the machine manages to execute this fairly short test, and the current balance
+# frequency has been roughly tuned to a) very consistently get at least 5
+# balances (usually gets several dozen), and b) complete the test in a
+# reasonable duration. Balancing too frequently can mean the test time explodes
+# due to balancing so much that the test computation doesn't get much of a
+# chance to execute.
+function(add_algorithm_test_with_balancing TEST_NAME EXECUTABLE_NAME REGEX_TO_MATCH)
+  add_test(
+    NAME "\"Integration.Parallel.${TEST_NAME}\""
+    COMMAND
+    ${SHELL_EXECUTABLE}
+    -c "${CMAKE_BINARY_DIR}/bin/Test_${EXECUTABLE_NAME} +p2 +balancer \
+     RotateLB +LBPeriod 4.0e-5 +LBDebug 3 2>&1"
+    )
+
+  if("${REGEX_TO_MATCH}" STREQUAL "")
+    set_tests_properties(
+      "\"Integration.Parallel.${TEST_NAME}\""
+      PROPERTIES
+      TIMEOUT 10
+      LABELS "integration"
+      ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
+  else()
+    set_tests_properties(
+      "\"Integration.Parallel.${TEST_NAME}\""
+      PROPERTIES
+      PASS_REGULAR_EXPRESSION
+      "${REGEX_TO_MATCH}"
+      TIMEOUT 10
+      LABELS "integration"
+      ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
+  endif()
+endfunction()
+
 add_algorithm_test("AlgorithmCore" "")
 add_algorithm_test(
   "AlgorithmBadBoxApply"
@@ -127,6 +164,8 @@ add_algorithm_test("AlgorithmParallel" "")
 add_algorithm_test("AlgorithmReduction" "")
 add_algorithm_test("AlgorithmNodelock" "")
 add_algorithm_test("GlobalCache" "")
+add_algorithm_test_with_balancing("AlgorithmParallelWithBalancing"
+  "AlgorithmParallel" "Objects migrating: 14")
 
 add_algorithm_test_with_input_file("AlgorithmGlobalCache" "Unit/Parallel")
 

--- a/tests/Unit/Parallel/Test_AlgorithmCore.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmCore.cpp
@@ -742,4 +742,16 @@ static const std::vector<void (*)()> charm_init_proc_funcs{
 using charmxx_main_component = Parallel::Main<TestMetavariables>;
 /// [charm_main_example]
 
+// [[OutputRegex, AlgorithmImpl has been constructed with a nullptr]]
+SPECTRE_TEST_CASE("Unit.Parallel.Algorithm.NullptrConstructError",
+                  "[Parallel][Unit]") {
+  ERROR_TEST();
+  Parallel::AlgorithmImpl < NoOpsComponent<TestMetavariables>,
+      tmpl::list<
+          Parallel::PhaseActions<typename TestMetavariables::Phase,
+                                 TestMetavariables::Phase::Initialization,
+                                 tmpl::list<add_remove_test::initialize>>>>{
+          nullptr};
+}
+
 #include "Parallel/CharmMain.tpp"  // IWYU pragma: keep

--- a/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
@@ -243,12 +243,9 @@ struct AddIntValue10 {
         [](const gsl::not_null<int*> count_actions_called) {
           ++*count_actions_called;
         });
-    const bool terminate_algorithm =
-        db::get<Tags::CountActionsCalled>(box) >= 15;
     return std::make_tuple(
         db::create_from<tmpl::list<>, tmpl::list<Tags::Int0>>(std::move(box),
-                                                              10),
-        terminate_algorithm);
+                                                              10));
   }
 };
 
@@ -322,8 +319,11 @@ struct RemoveInt0 {
         [](const gsl::not_null<int*> count_actions_called) {
           ++*count_actions_called;
         });
+    const bool terminate_algorithm =
+        db::get<Tags::CountActionsCalled>(box) >= 15;
     return std::make_tuple(
-        db::create_from<tmpl::list<Tags::Int0>>(std::move(box)));
+        db::create_from<tmpl::list<Tags::Int0>>(std::move(box)),
+        terminate_algorithm);
   }
 };
 
@@ -502,10 +502,8 @@ struct SingletonParallelComponent {
           global_cache) noexcept {
     if (next_phase == Metavariables::Phase::PerformSingletonAlgorithm) {
       auto& local_cache = *(global_cache.ckLocalBranch());
-      /// [perform_algorithm]
       Parallel::get_parallel_component<SingletonParallelComponent>(local_cache)
-          .perform_algorithm();
-      /// [perform_algorithm]
+          .start_phase(next_phase);
       return;
     }
   }
@@ -557,7 +555,7 @@ struct ArrayParallelComponent {
     if (next_phase == Metavariables::Phase::PerformArrayAlgorithm or
         next_phase == Metavariables::Phase::FinalizeArray) {
       Parallel::get_parallel_component<ArrayParallelComponent>(local_cache)
-          .perform_algorithm();
+          .start_phase(next_phase);
     }
   }
 };

--- a/tests/Unit/Parallel/Test_GlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_GlobalCache.cpp
@@ -248,9 +248,8 @@ void TestArrayChare<Metavariables>::run_test_one() noexcept {
                                     serialized_and_deserialized_local_cache)
                                     .number_of_sides());
 
-  CkMigrateMessage empty_message{};
   Parallel::GlobalCache<TestMetavariables>
-      serialized_and_deserialized_global_cache{&empty_message};
+      serialized_and_deserialized_global_cache{};
   serialize_and_deserialize(
       make_not_null(&serialized_and_deserialized_global_cache), local_cache);
   SPECTRE_PARALLEL_REQUIRE(
@@ -422,9 +421,8 @@ void Test_GlobalCache<Metavariables>::run_single_core_test() noexcept {
                            Parallel::get<animal_base>(cache).number_of_legs());
 
   // Check the serialization of the mutable global cache
-  CkMigrateMessage empty_message{};
   Parallel::MutableGlobalCache<TestMetavariables>
-      serialized_and_deserialized_mutable_cache{&empty_message};
+      serialized_and_deserialized_mutable_cache{};
   serialize_and_deserialize(
       make_not_null(&serialized_and_deserialized_mutable_cache), mutable_cache);
 
@@ -504,6 +502,20 @@ void Test_GlobalCache<Metavariables>::exit_if_done(int index) noexcept {
   if (elements_that_are_finished_.size() >= num_elements_) {
     Parallel::exit();
   }
+}
+
+// [[OutputRegex, MutableGlobalCache has been constructed with a nullptr]]
+SPECTRE_TEST_CASE("Unit.Parallel.GlobalCache.NullptrConstructError",
+                  "[Parallel][Unit]") {
+  ERROR_TEST();
+  Parallel::GlobalCache<TestMetavariables>{nullptr};
+}
+
+// [[OutputRegex, MutableGlobalCache has been constructed with a nullptr]]
+SPECTRE_TEST_CASE("Unit.Parallel.MutableGlobalCache.NullptrConstructError",
+                  "[Parallel][Unit]") {
+  ERROR_TEST();
+  Parallel::MutableGlobalCache<TestMetavariables>{nullptr};
 }
 
 // --------- registration stuff below -------

--- a/tests/Unit/Time/StepChoosers/Test_ByBlock.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_ByBlock.cpp
@@ -41,7 +41,7 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ByBlock", "[Unit][Time]") {
       std::make_unique<ByBlock>(by_block);
 
   const double current_step = std::numeric_limits<double>::infinity();
-  const Parallel::GlobalCache<Metavariables> cache{{}};
+  const Parallel::GlobalCache<Metavariables> cache{};
   for (size_t block = 0; block < 3; ++block) {
     const Element<volume_dim> element(ElementId<volume_dim>(block), {});
     const auto box =

--- a/tests/Unit/Time/StepChoosers/Test_Cfl.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_Cfl.cpp
@@ -55,7 +55,7 @@ struct Metavariables {
 double get_suggestion(const size_t stepper_order, const double safety_factor,
                       const double characteristic_speed,
                       const DataVector& coordinates) noexcept {
-  const Parallel::GlobalCache<Metavariables> cache{{}};
+  const Parallel::GlobalCache<Metavariables> cache{};
   const auto box = db::create<
       db::AddSimpleTags<
           CharacteristicSpeed, domain::Tags::Coordinates<dim, frame>,

--- a/tests/Unit/Time/StepChoosers/Test_Constant.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_Constant.cpp
@@ -30,7 +30,7 @@ using Constant = StepChoosers::Constant<>;
 SPECTRE_TEST_CASE("Unit.Time.StepChoosers.Constant", "[Unit][Time]") {
   Parallel::register_derived_classes_with_charm<StepChooserType>();
 
-  const Parallel::GlobalCache<Metavariables> cache{{}};
+  const Parallel::GlobalCache<Metavariables> cache{};
   const auto box = db::create<db::AddSimpleTags<>>();
 
   const Constant constant{5.4};

--- a/tests/Unit/Time/StepChoosers/Test_Increase.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_Increase.cpp
@@ -32,7 +32,7 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.Increase", "[Unit][Time]") {
 
   Parallel::register_derived_classes_with_charm<StepChooserType>();
 
-  const Parallel::GlobalCache<Metavariables> cache{{}};
+  const Parallel::GlobalCache<Metavariables> cache{};
   const auto box = db::create<db::AddSimpleTags<>>();
   const auto check =
       [&box, &cache](const double step, const double expected) noexcept {

--- a/tests/Unit/Time/StepChoosers/Test_PreventRapidIncrease.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_PreventRapidIncrease.cpp
@@ -50,7 +50,7 @@ void check_case(const Frac& expected_frac,
   const std::unique_ptr<StepChooserType> relax_base =
       std::make_unique<PreventRapidIncrease>(relax);
 
-  const Parallel::GlobalCache<Metavariables> cache{{}};
+  const Parallel::GlobalCache<Metavariables> cache{};
 
   const Slab slab(0.25, 1.5);
   const double expected = expected_frac == -1

--- a/tests/Unit/Time/StepChoosers/Test_StepToTimes.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_StepToTimes.cpp
@@ -54,7 +54,7 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.StepToTimes", "[Unit][Time]") {
           std::make_unique<StepToTimes>(
               std::make_unique<Specified>(impl_times));
 
-      const Parallel::GlobalCache<Metavariables> cache{{}};
+      const Parallel::GlobalCache<Metavariables> cache{};
       const auto box = db::create<db::AddSimpleTags<Tags::TimeStepId>>(now_id);
 
       const double answer = step_to_times(now_id, step, cache);


### PR DESCRIPTION
## Proposed changes

Adds the ability to serialize the `AlgorithmImpl`, which represents the charm++ 'chare' associated with all of our parallel components.
This also enables the ability to load-balance any of our existing executables.

There are a few parts of this serialization that I was entirely unsure how to test, in particular the serialization of the AlgorithmImpl, the ConstGlobalCache, and the CmiNodeLock, as they seem irreducibly associated with a true charm++ runtime, rather than the action-testing framework. I've added a test yaml that ensures load-balancing is performed successfully in the Burgers executable, but I'd welcome suggestions for good ways of unit testing these serializations more directly.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Dependencies

- [x] #2324
- [x] #2368
- [x] #2413
- [x] #2555
- [x] #2612
- [x] #2613
- [x] #2616