### PR TITLE
Add OneOverOneFormMagnitudeTag

### DIFF
--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -13,6 +13,7 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataBox/TagName.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"  // IWYU pragma: keep
 #include "Utilities/ForceInline.hpp"
@@ -201,6 +202,28 @@ struct NormalOneForm : db::ComputeTag {
                        const aliases::OneForm<Frame>& dx_radius,
                        const aliases::OneForm<Frame>& r_hat) noexcept;
   using argument_tags = tmpl::list<DxRadius<Frame>, Rhat<Frame>>;
+};
+/// The OneOverOneFormMagnitude is the reciprocal of the magnitude of the
+/// one-form perpendicular to the horizon
+struct OneOverOneFormMagnitude : db::SimpleTag {
+  using type = DataVector;
+};
+/// Computes the reciprocal of the magnitude of the one form perpendicular to
+/// the horizon
+template <size_t Dim, typename Frame, typename DataType>
+struct OneOverOneFormMagnitudeCompute : db::ComputeTag,
+                                        OneOverOneFormMagnitude {
+  using base = OneOverOneFormMagnitude;
+  static void function(
+      const gsl::not_null<DataVector*> one_over_magnitude,
+      const tnsr::II<DataType, Dim, Frame>& inverse_spatial_metric,
+      const tnsr::i<DataType, Dim, Frame>& normal_one_form) noexcept {
+    *one_over_magnitude =
+        1.0 / get(magnitude(normal_one_form, inverse_spatial_metric));
+  }
+  using argument_tags =
+      tmpl::list<gr::Tags::InverseSpatialMetric<Dim, Frame, DataType>,
+                 NormalOneForm<Frame>>;
 };
 
 /// `Tangents(i,j)` is \f$\partial x_{\rm surf}^i/\partial q^j\f$,

--- a/src/ApparentHorizons/TagsDeclarations.hpp
+++ b/src/ApparentHorizons/TagsDeclarations.hpp
@@ -35,6 +35,9 @@ template <typename Frame>
 struct EuclideanAreaElement;
 template <typename IntegrandTag, typename Frame>
 struct EuclideanSurfaceIntegral;
+struct OneOverOneFormMagnitude;
+template <size_t Dim, typename Frame, typename DataType>
+struct OneOverOneFormMagnitudeCompute;
 
 }  // namespace StrahlkorperTags
 
@@ -50,5 +53,6 @@ struct AreaCompute;
 struct IrreducibleMass;
 template <typename Frame>
 struct IrreducibleMassCompute;
+
 }  // namespace Tags
 }  // namespace StrahlkorperGr

--- a/tests/Unit/ApparentHorizons/Test_Tags.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Tags.cpp
@@ -296,6 +296,8 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
   TestHelpers::db::test_simple_tag<StrahlkorperGr::Tags::Area>("Area");
   TestHelpers::db::test_simple_tag<StrahlkorperGr::Tags::IrreducibleMass>(
       "IrreducibleMass");
+  TestHelpers::db::test_simple_tag<StrahlkorperTags::OneOverOneFormMagnitude>(
+      "OneOverOneFormMagnitude");
   TestHelpers::db::test_simple_tag<
       StrahlkorperTags::Strahlkorper<Frame::Inertial>>("Strahlkorper");
   TestHelpers::db::test_compute_tag<
@@ -342,4 +344,16 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
   TestHelpers::db::test_compute_tag<
       StrahlkorperGr::Tags::IrreducibleMassCompute<Frame::Inertial>>(
       "IrreducibleMass");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::OneOverOneFormMagnitudeCompute<1, Frame::Inertial,
+                                                       DataVector>>(
+      "OneOverOneFormMagnitude");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::OneOverOneFormMagnitudeCompute<2, Frame::Inertial,
+                                                       DataVector>>(
+      "OneOverOneFormMagnitude");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::OneOverOneFormMagnitudeCompute<3, Frame::Inertial,
+                                                       DataVector>>(
+      "OneOverOneFormMagnitude");
 }


### PR DESCRIPTION
## Proposed changes

Add OneOverOneFormMagnitudeTag and OneOverOneFormMagnitudeCompute for computing the OneOverOneFormMagnitude normal vector to the horizon.

### Types of changes:

- [ ] Bugfix
- [ x] New feature
- [ ] Refactor

### Component:

- [ x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

