### PR TITLE
Make TensorExpression inherit from Expression

### DIFF
--- a/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
+++ b/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
@@ -60,8 +60,7 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
           typename T1::type,
           tmpl::transform<typename T1::symmetry, typename T2::symmetry,
                           tmpl::append<tmpl::max<tmpl::_1, tmpl::_2>>>,
-          typename T1::index_list, tmpl::sort<typename T1::args_list>>,
-      public Expression {
+          typename T1::index_list, tmpl::sort<typename T1::args_list>> {
   static_assert(std::is_same<typename T1::type, typename T2::type>::value,
                 "Cannot add or subtract Tensors holding different data types.");
   static_assert(

--- a/src/DataStructures/Tensor/Expressions/Contract.hpp
+++ b/src/DataStructures/Tensor/Expressions/Contract.hpp
@@ -81,8 +81,7 @@ struct TensorContract
           typename detail::ComputeContractedType<
               Index1, Index2, T, X, Symm, IndexList, ArgsList>::index_list,
           typename detail::ComputeContractedType<
-              Index1, Index2, T, X, Symm, IndexList, ArgsList>::args_list>,
-      public Expression {
+              Index1, Index2, T, X, Symm, IndexList, ArgsList>::args_list> {
   using CI1 = tmpl::at<IndexList, Index1>;
   using CI2 = tmpl::at<IndexList, Index2>;
   static_assert(tmpl::size<Symm>::value > 1 and

--- a/src/DataStructures/Tensor/Expressions/Product.hpp
+++ b/src/DataStructures/Tensor/Expressions/Product.hpp
@@ -30,8 +30,7 @@ struct Product<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>>
           typename T1::type, double,
           tmpl::append<typename T1::index_list, typename T2::index_list>,
           tmpl::sort<
-              tmpl::append<typename T1::args_list, typename T2::args_list>>>,
-      public Expression {
+              tmpl::append<typename T1::args_list, typename T2::args_list>>> {
   static_assert(std::is_same<typename T1::type, typename T2::type>::value,
                 "Cannot product Tensors holding different data types.");
   using max_symm2 = tmpl::fold<typename T2::symmetry, tmpl::uint32_t<0>,

--- a/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
@@ -293,7 +293,8 @@ struct TensorExpression;
 template <typename Derived, typename DataType, typename Symm,
           typename IndexList, template <typename...> class ArgsList,
           typename... Args>
-struct TensorExpression<Derived, DataType, Symm, IndexList, ArgsList<Args...>> {
+struct TensorExpression<Derived, DataType, Symm, IndexList, ArgsList<Args...>>
+    : public Expression {
   static_assert(sizeof...(Args) == 0 or
                     sizeof...(Args) == tmpl::size<IndexList>::value,
                 "the number of Tensor indices must match the number of "


### PR DESCRIPTION
## Proposed changes

Currently, children of the `TensorExpression` struct (`AddSub`, `TensorContract`, and `Product`) not only directly inherit from `TensorExpression` but also from an empty base struct, `Expression`. Having the empty base struct provides convenience for type checking. However, `TensorExpression` does not inherit from `Expression`, even though its children do. Current inheritance:  

&nbsp;&nbsp;&nbsp;&nbsp;`TensorExpression`     `Expression`  
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\ &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/  
     [`AddSub`, `TensorContract`, `Product`]                 

This PR changes the inheritance relationship so that the current children of `TensorExpression` only directly inherit from `TensorExpression` (not also directly from `Expression`), and that instead `TensorExpression` directly inherits from the empty base struct, `Expression`. Proposed inheritance:  

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`Expression`  
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|  
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`TensorExpression`  
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|  
[`AddSub`, `TensorContract`, `Product`]  
  
The motivation for this is so that when type checking is done, a `TensorExpression` is considered to be an `Expression`. An example can be found [here](https://github.com/sxs-collaboration/spectre/blob/6296d0fea286f9e97dce8c2ce142cc7202bad559/src/DataStructures/Tensor/Expressions/Evaluate.hpp#L25), in the case when a `TensorExpression` is passed to `evaluate`, instead of one of its children types. With the proposed change to the inheritance, `Expression` will be recognized as a base class of `TensorExpression`, which would now meet the template requirement and allow `evaluate` to be given a `TensorExpression` as an argument.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
