### PR TITLE
Make conversion from cpp17::array to std::array constexpr

### DIFF
--- a/src/Utilities/Array.hpp
+++ b/src/Utilities/Array.hpp
@@ -17,8 +17,8 @@ namespace cpp17 {
 namespace detail {
 template <typename T, size_t Size, size_t... Is>
 // NOLINTNEXTLINE(modernize-avoid-c-arrays)
-std::array<T, Size> convert_to_array(const T (&t)[Size],
-                                     std::index_sequence<Is...> /*meta*/) {
+constexpr std::array<T, Size> convert_to_array(
+    const T (&t)[Size], std::index_sequence<Is...> /*meta*/) {
   return {{t[Is]...}};
 }
 }  // namespace detail
@@ -36,7 +36,7 @@ struct array {
   using difference_type = std::ptrdiff_t;
 
   // clang-tidy: mark explicit. We want implicit conversion
-  operator std::array<T, Size>() const noexcept {  // NOLINT
+  constexpr operator std::array<T, Size>() const noexcept {  // NOLINT
     return detail::convert_to_array(data_, std::make_index_sequence<Size>{});
   }
 


### PR DESCRIPTION
## Proposed changes

This PR updates the conversion of `cpp17::array`->`std::array` to be `constexpr`. The motivation for this is to be able to perform this conversion within and between `constexpr` functions.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
