### PR TITLE
Remove redundant blaze overloads

### DIFF
--- a/src/DataStructures/ComplexDataVector.hpp
+++ b/src/DataStructures/ComplexDataVector.hpp
@@ -56,8 +56,6 @@ class ComplexDataVector
 
   using VectorImpl<std::complex<double>, ComplexDataVector>::operator=;
   using VectorImpl<std::complex<double>, ComplexDataVector>::VectorImpl;
-
-  MAKE_MATH_ASSIGN_EXPRESSION_ARITHMETIC(ComplexDataVector)
 };
 
 namespace blaze {

--- a/src/DataStructures/ComplexModalVector.hpp
+++ b/src/DataStructures/ComplexModalVector.hpp
@@ -48,9 +48,6 @@ class ComplexModalVector
 
   using VectorImpl<std::complex<double>, ComplexModalVector>::operator=;
   using VectorImpl<std::complex<double>, ComplexModalVector>::VectorImpl;
-
-  MAKE_MATH_ASSIGN_EXPRESSION_POINTERVECTOR(+=, ComplexModalVector)
-  MAKE_MATH_ASSIGN_EXPRESSION_POINTERVECTOR(-=, ComplexModalVector)
 };
 
 namespace blaze {

--- a/src/DataStructures/DataVector.hpp
+++ b/src/DataStructures/DataVector.hpp
@@ -50,8 +50,6 @@ class DataVector : public VectorImpl<double, DataVector> {
 
   using VectorImpl<double, DataVector>::operator=;
   using VectorImpl<double, DataVector>::VectorImpl;
-
-  MAKE_MATH_ASSIGN_EXPRESSION_ARITHMETIC(DataVector)
 };
 
 // Specialize the Blaze type traits to correctly handle DataVector

--- a/src/DataStructures/DiagonalModalOperator.hpp
+++ b/src/DataStructures/DiagonalModalOperator.hpp
@@ -47,8 +47,6 @@ class DiagonalModalOperator : public VectorImpl<double, DiagonalModalOperator> {
 
   using VectorImpl<double, DiagonalModalOperator>::operator=;
   using VectorImpl<double, DiagonalModalOperator>::VectorImpl;
-
-  MAKE_MATH_ASSIGN_EXPRESSION_ARITHMETIC(DiagonalModalOperator)
 };
 
 namespace blaze {

--- a/src/DataStructures/ModalVector.hpp
+++ b/src/DataStructures/ModalVector.hpp
@@ -38,9 +38,6 @@ class ModalVector : public VectorImpl<double, ModalVector> {
 
   using VectorImpl<double, ModalVector>::operator=;
   using VectorImpl<double, ModalVector>::VectorImpl;
-
-  MAKE_MATH_ASSIGN_EXPRESSION_POINTERVECTOR(+=, ModalVector)
-  MAKE_MATH_ASSIGN_EXPRESSION_POINTERVECTOR(-=, ModalVector)
 };
 
 namespace blaze {

--- a/src/DataStructures/VectorImpl.hpp
+++ b/src/DataStructures/VectorImpl.hpp
@@ -510,19 +510,6 @@ std::ostream& operator<<(std::ostream& os,
 
 /*!
  * \ingroup DataStructuresGroup
- * \brief Defines `MAKE_MATH_ASSIGN_EXPRESSION_POINTERVECTOR` with all
- * assignment arithmetic operations
- *
- * \param VECTOR_TYPE The vector type (e.g. `DataVector`)
- */
-#define MAKE_MATH_ASSIGN_EXPRESSION_ARITHMETIC(VECTOR_TYPE)  \
-  MAKE_MATH_ASSIGN_EXPRESSION_POINTERVECTOR(+=, VECTOR_TYPE) \
-  MAKE_MATH_ASSIGN_EXPRESSION_POINTERVECTOR(-=, VECTOR_TYPE) \
-  MAKE_MATH_ASSIGN_EXPRESSION_POINTERVECTOR(*=, VECTOR_TYPE) \
-  MAKE_MATH_ASSIGN_EXPRESSION_POINTERVECTOR(/=, VECTOR_TYPE)
-
-/*!
- * \ingroup DataStructuresGroup
  * \brief Defines the `MakeWithValueImpl` `apply` specialization
  *
  * \details The `MakeWithValueImpl<VECTOR_TYPE, VECTOR_TYPE>` member

--- a/src/Utilities/PointerVector.hpp
+++ b/src/Utilities/PointerVector.hpp
@@ -1330,35 +1330,3 @@ decltype(auto) pow(const PointerVector<Type, AF, PF, TF, ExprResultType>& t,
   return ReturnType(t, BlazePow<double>{static_cast<double>(exponent)});
 #endif
 }
-
-/*!
- * \brief Generates the `OP` assignment operator for the type `TYPE`
- *
- * For example, if `OP` is `+=` and `TYPE` is `DataVector` then this will add
- * `+=` for `DataVector` on the RHS, `blaze::DenseVector` on the RHS, and
- * `ElementType` (`double` for `DataVector`) on the RHS. This macro is used in
- * the cases where the new vector type inherits from `PointerVector` with a
- * custom `ExprResultType`.
- */
-#if ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION >= 6))
-#define MAKE_MATH_ASSIGN_EXPRESSION_POINTERVECTOR(OP, TYPE)
-#else
-#define MAKE_MATH_ASSIGN_EXPRESSION_POINTERVECTOR(OP, TYPE)             \
-  TYPE& operator OP(const TYPE& rhs) noexcept {                         \
-    /* clang-tidy: parens around OP */                                  \
-    ~*this OP ~rhs; /* NOLINT */                                        \
-    return *this;                                                       \
-  }                                                                     \
-  /* clang-tidy: parens around TYPE */                                  \
-  template <typename VT, bool VF>                                       \
-  TYPE& operator OP(const blaze::DenseVector<VT, VF>& rhs) /* NOLINT */ \
-      noexcept {                                                        \
-    ~*this OP rhs;                                                      \
-    return *this;                                                       \
-  }                                                                     \
-  /* clang-tidy: parens around TYPE */                                  \
-  TYPE& operator OP(const ElementType& rhs) noexcept { /* NOLINT */     \
-    ~*this OP rhs;                                                      \
-    return *this;                                                       \
-  }
-#endif

--- a/support/Environments/wheeler_gcc.sh
+++ b/support/Environments/wheeler_gcc.sh
@@ -9,7 +9,7 @@ spectre_setup_modules() {
 
 spectre_unload_modules() {
     module unload gcc/7.3.0
-    module unload blaze/3.5
+    module unload blaze/3.7
     module unload boost/1.65.0-gcc-6.4.0
     module unload brigand/master
     module unload catch/2.1.2
@@ -31,7 +31,7 @@ spectre_unload_modules() {
 
 spectre_load_modules() {
     module load gcc/7.3.0
-    module load blaze/3.5
+    module load blaze/3.7
     module load boost/1.65.0-gcc-6.4.0
     module load brigand/master
     module load catch/2.1.2


### PR DESCRIPTION
## Proposed changes

Removes overloads of inplace operators present in Blaze 3.5 and overlooked in the previous blaze upgrade PR. Given that they are removed for 3.5, we can then remove the macros altogether in several places, simplifying our Blaze wrapper.

Also updates the wheeler gcc environment to use the Blaze 3.7 module.

I've tested on the Blaze 3.5 wheeler environment, but perhaps it would be good to double-check with someone else's Blaze 3.5 environment?

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
