### PR TITLE
Check CMakeLists.txt in CI

### DIFF
--- a/docs/DevGuide/Travis.md
+++ b/docs/DevGuide/Travis.md
@@ -72,6 +72,9 @@ if any of the following are true:
   - A `c++` test,
     * uses `TEST_CASE` (use `SPECTRE_TEST_CASE` instead)
     * uses `Approx` (use `approx` instead)
+  - A `CMakeLists.txt` file in `src`, but not in an Executables or
+    Python-binding directory,
+    * does not list a `C++` file that is present in the directory
   - A python file is not formatted according to the `.style.yapf` file in the
     root of the repository.
 * RUN_CLANG_TIDY runs the script `.travis/RunClangTidy.sh` which runs

--- a/docs/DevGuide/Travis.md
+++ b/docs/DevGuide/Travis.md
@@ -75,6 +75,7 @@ if any of the following are true:
   - A `CMakeLists.txt` file in `src`, but not in an Executables or
     Python-binding directory,
     * does not list a `C++` file that is present in the directory
+    * lists a `C++` file that is not present in the directory
   - A python file is not formatted according to the `.style.yapf` file in the
     root of the repository.
 * RUN_CLANG_TIDY runs the script `.travis/RunClangTidy.sh` which runs

--- a/src/Evolution/Systems/Cce/Actions/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/Actions/CMakeLists.txt
@@ -1,6 +1,12 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+spectre_target_sources(
+  Cce
+  PRIVATE
+  ScriObserveInterpolated.cpp
+  )
+
 spectre_target_headers(
   Cce
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/CMakeLists.txt
@@ -22,6 +22,7 @@ spectre_target_headers(
   BouncingBlackHole.hpp
   LinearizedBondiSachs.hpp
   SphericalMetricData.hpp
+  TeukolskyWave.hpp
   WorldtubeData.hpp
   )
 

--- a/src/Evolution/Systems/Cce/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/CMakeLists.txt
@@ -8,7 +8,6 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
-  Actions/ScriObserveInterpolated.cpp
   AnalyticBoundaryDataManager.cpp
   BoundaryData.cpp
   Equations.cpp

--- a/src/Informer/CMakeLists.txt
+++ b/src/Informer/CMakeLists.txt
@@ -9,7 +9,7 @@ add_spectre_library(${LIBRARY})
 # InfoAtLink.cpp. These files contain placeholder strings that CMake fills in
 # (in copies of the files in the build directory) when configuring the build.
 #
-# We track the *generated* IntoAtCompile.cpp as a library source. This means
+# We track the *generated* InfoAtCompile.cpp as a library source. This means
 # that CMake must have been configured *before* checking library dependencies
 # via the CMake function check_spectre_libs_dependencies.
 #

--- a/tools/CheckFiles.sh
+++ b/tools/CheckFiles.sh
@@ -98,6 +98,52 @@ check_cmakelists_for_missing_cpp_test() {
 }
 ci_checks+=(check_cmakelists_for_missing_cpp)
 
+# Check CMakeLists.txt contain no spurious C++ files
+# (Checked in CI because this involves comparisons between files and may
+#  be too slow for a fluid git-hook user experience)
+#
+# Check for CMakeLists lines that are [two spaces][anything][.?pp]
+# Then we check that the filename has no slashes (this would indicate a file
+# in a subdirectory), and that the corresponding file exists.
+check_cmakelists_for_extra_cpp() {
+    local dir match matches
+    dir=$(dirname $1)
+    if [[ $1 =~ CMakeLists\.txt$ ]] && whitelist "$dir" 'docs' \
+                                                        'tests' \
+                                                        'tools' \
+                                                        'Executables' \
+                                                        'Python'; then
+        matches=$(grep -E "^  .*\.[cht]pp" $1)
+        for match in $matches; do
+            # Special case: the Informer CMakeLists includes a special C++ file
+            [[ $match == '${CMAKE_BINARY_DIR}/Informer/InfoAtCompile.cpp' ]] \
+              && continue
+            [[ $match =~ '/' ]] || [[ ! -f "${dir}/$match" ]] && return 0
+        done
+    fi
+    return 1
+}
+check_cmakelists_for_extra_cpp_report() {
+    local file dir match matches
+    echo "Found spurious C++ files in CMakeLists.txt:"
+    for file in "$@"; do
+        dir=$(dirname $file)
+        matches=$(grep -E "^  .*\.[cht]pp" $file)
+        for match in $matches; do
+            [[ $match == '${CMAKE_BINARY_DIR}/Informer/InfoAtCompile.cpp' ]] \
+              && continue
+            [[ $match =~ '/' ]] || [[ ! -f "${dir}/$match" ]] \
+              && echo "$match should be removed from $file"
+        done
+    done
+}
+check_cmakelists_for_extra_cpp_test() {
+    # This check relies on comparisons between different files, which makes
+    # it cumbersome to test. We omit the test.
+    :
+}
+ci_checks+=(check_cmakelists_for_extra_cpp)
+
 if [ "$1" = --test ] ; then
     run_tests "${ci_checks[@]}"
     exit 0


### PR DESCRIPTION
## Proposed changes

Adds new CI checks that the C++ files in a directory match what is given in the `CMakeLists.txt` file.

The new checks are not tested (in the sense of `CheckFiles.sh --test`) because I couldn't figure out a simple way to write tests for these multiple-file comparison checks.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
