### PR TITLE
Add CylindricalSide Map

### DIFF
--- a/docs/Images/Domain/CoordinateMaps/CylindricalSide.svg
+++ b/docs/Images/Domain/CoordinateMaps/CylindricalSide.svg
@@ -1,0 +1,587 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="338.08936mm"
+   height="136.5334mm"
+   viewBox="0 0 338.08937 136.5334"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="CylindricalSide.svg">
+  <defs
+     id="defs2">
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4686"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <linearGradient
+       id="linearGradient6115"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop6113" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4526"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4524" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.1511328"
+     inkscape:cx="324.33962"
+     inkscape:cy="201.18105"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:window-width="1648"
+     inkscape:window-height="1089"
+     inkscape:window-x="149"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-text-baseline="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3713"
+       originx="1.3229168"
+       originy="-158.6177" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer 2"
+     transform="translate(6.7e-6,9.2688117)">
+    <path
+       transform="translate(1.3229167,-11.117705)"
+       style="fill:#969696;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+       d="m 277.03733,105.647 c 10.49189,-15.998319 7.07405,-37.354625 -7.88665,-49.279535 l 47.95061,-13.069121 c 16.642,29.188806 7.66541,66.289626 -20.47931,84.642216 z"
+       id="path4827"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:#969696;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
+       d="M 208.44375,31.579477 C 191.56678,60.44243 199.96219,97.447773 227.6421,116.2021 l 2.5779,-9.16219 c -11.59314,-6.06262 -19.12842,-17.791034 -19.82388,-30.855205 -0.69546,-13.06417 5.55207,-25.526298 16.43604,-32.785458 z"
+       id="path4847"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccscc" />
+  </g>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(1.3229167,-1.8488933)"
+     style="display:inline">
+    <g
+       id="g92">
+      <circle
+         r="37.041668"
+         cx="52.916668"
+         cy="85.333336"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26458332;stroke-opacity:1"
+         id="path3717" />
+      <circle
+         r="63.500004"
+         cx="68.791664"
+         cy="74.75"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26458332;stroke-opacity:1"
+         id="path3717-3" />
+      <ellipse
+         ry="1.1425189"
+         rx="1.1926295"
+         cy="64.166664"
+         cx="47.625"
+         id="path6040"
+         style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path6042"
+         d="M 79.47522,59.376106 47.624999,64.166667"
+         style="fill:none;stroke:#000000;stroke-width:0.66500002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.665, 1.33;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path6044"
+         d="M 79.575441,59.376106 128.20265,51.899621"
+         style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path6046"
+         d="M 78.974116,110.58902 47.304293,64.086488 22.754167,118.67083"
+         style="fill:none;stroke:#000000;stroke-width:0.66500002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.665, 1.995;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path6048"
+         d="m 79.375,110.58901 15.073232,21.96844"
+         style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <ellipse
+         ry="1.1926293"
+         rx="1.2427398"
+         cy="85.333336"
+         cx="52.916668"
+         id="path6040-6"
+         style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <ellipse
+         ry="1.1425189"
+         rx="1.0924084"
+         cy="74.75"
+         cx="68.791664"
+         id="path6040-7"
+         style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         transform="scale(0.26458333)"
+         sodipodi:nodetypes="scsssscscsssscs"
+         inkscape:connector-curvature="0"
+         id="path6071"
+         d="m 330.20722,459.84881 -27.62827,-40.337 4.77565,-5.43916 c 14.439,-16.44511 26.01836,-40.16867 30.70342,-62.90452 2.82815,-13.72457 3.25714,-40.63286 0.85866,-53.85964 -3.871,-21.3473 -14.1331,-44.09123 -27.97825,-62.00833 -4.73338,-6.12551 -10.66338,-10.9541 -10.4,-11.19318 0.26339,-0.23907 43.21095,-6.56797 92.66126,-13.60124 l 89.90964,-12.78777 1.48983,3.90519 c 17.2719,45.27368 18.16422,106.25515 2.26499,154.7912 -5.13982,15.69047 -17.05815,41.24815 -24.94936,53.50142 -14.8589,23.07252 -38.27408,48.22626 -60.02923,64.48638 -10.49872,7.8469 -38.70633,24.50037 -45.25929,26.84528 -1.63403,0.58473 -6.55511,-12.39748 -26.41905,-41.39863 z"
+         style="fill:#969696;fill-opacity:1;stroke:#000000;stroke-width:1.54204726;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <text
+         id="text6177"
+         y="72.346474"
+         x="38.150562"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="72.346474"
+           x="38.150562"
+           id="tspan6175"
+           sodipodi:role="line">P</tspan><tspan
+           id="tspan6179"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="80.283974"
+           x="38.150562"
+           sodipodi:role="line" /></text>
+      <text
+         id="text6153-9"
+         y="73.250671"
+         x="70.257866"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="73.250671"
+           x="70.257866"
+           id="tspan6151-2"
+           sodipodi:role="line">C</tspan></text>
+      <text
+         id="text6157-5"
+         y="68.771202"
+         x="75.586967"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           id="tspan6163-4"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="68.771202"
+           x="75.586967"
+           sodipodi:role="line">i</tspan></text>
+      <text
+         id="text6223"
+         y="55.4077"
+         x="137.85378"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="55.4077"
+           x="137.85378"
+           id="tspan6221"
+           sodipodi:role="line">z</tspan></text>
+      <text
+         id="text6227"
+         y="57.085003"
+         x="141.34514"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="57.085003"
+           x="141.34514"
+           id="tspan6225"
+           sodipodi:role="line">U</tspan></text>
+      <text
+         id="text6243"
+         y="89.843269"
+         x="48.907825"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="89.843269"
+           x="48.907825"
+           id="tspan6241"
+           sodipodi:role="line">1</tspan></text>
+      <text
+         id="text6247"
+         y="75.010567"
+         x="75.265945"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="75.010567"
+           x="75.265945"
+           id="tspan6245"
+           sodipodi:role="line">2</tspan></text>
+      <text
+         id="text6157-5-0"
+         y="68.244614"
+         x="41.795254"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           id="tspan6163-4-5"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="68.244614"
+           x="41.795254"
+           sodipodi:role="line">i</tspan></text>
+      <text
+         id="text6153-9-9"
+         y="87.80143"
+         x="44.581596"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="87.80143"
+           x="44.581596"
+           id="tspan6151-2-2"
+           sodipodi:role="line">C</tspan></text>
+      <text
+         id="text6157-5-5"
+         y="83.566628"
+         x="49.266769"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           id="tspan6163-4-4"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="83.566628"
+           x="49.266769"
+           sodipodi:role="line">i</tspan></text>
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path4581"
+         d="M 22.754167,118.40625 C 6.802203,101.55639 1.3462306,77.254359 8.4666667,55.170829 L 26.458333,59.404163 C 12.274111,73.575359 12.428623,96.41929 26.19375,110.99791 Z"
+         style="fill:#969696;fill-opacity:1;stroke:#000000;stroke-width:0.40799999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path3752"
+         d="M -1.2952283,59.299442 144.17023,59.508884"
+         style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3754"
+         d="M -1.3229167,110.99791 H 144.1979"
+         style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4571"
+         d="M 47.624998,64.166663 8.4666667,55.170829"
+         style="fill:none;stroke:#000000;stroke-width:0.66500002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.665, 1.995;stroke-dashoffset:0;stroke-opacity:1" />
+      <text
+         id="text6223-77"
+         y="107.20413"
+         x="138.53883"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="107.20413"
+           x="138.53883"
+           id="tspan6221-6"
+           sodipodi:role="line">z</tspan></text>
+      <text
+         id="text6227-4"
+         y="108.1919"
+         x="142.25482"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="108.1919"
+           x="142.25482"
+           id="tspan6225-3"
+           sodipodi:role="line">L</tspan></text>
+    </g>
+    <circle
+       id="path3717-4"
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26458332;stroke-opacity:1"
+       cy="85.333328"
+       cx="246.0625"
+       r="37.041668" />
+    <circle
+       id="path3717-3-7"
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26458332;stroke-opacity:1"
+       cy="74.749992"
+       cx="261.9375"
+       r="63.500004" />
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6040-2"
+       cx="240.77083"
+       cy="64.166656"
+       rx="1.1926295"
+       ry="1.1425189" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.66500002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.665, 1.33;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 316.97083,42.999992 -76.2,21.166665"
+       id="path6042-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.66500002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.665, 1.995;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 297.12708,127.66666 240.45012,64.086478 226.74792,127.66666"
+       id="path6046-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6040-6-9"
+       cx="246.0625"
+       cy="85.333328"
+       rx="1.2427398"
+       ry="1.1926293" />
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6040-7-9"
+       cx="261.9375"
+       cy="74.749992"
+       rx="1.0924084"
+       ry="1.1425189" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="231.29639"
+       y="72.346466"
+       id="text6177-8"><tspan
+         sodipodi:role="line"
+         id="tspan6175-1"
+         x="231.29639"
+         y="72.346466"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">P</tspan><tspan
+         sodipodi:role="line"
+         x="231.29639"
+         y="80.283966"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="tspan6179-3" /></text>
+    <g
+       id="g295"
+       transform="translate(0,-16.089224)">
+      <text
+         id="text6223-3"
+         y="55.407688"
+         x="330.9996"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="55.407688"
+           x="330.9996"
+           id="tspan6221-9"
+           sodipodi:role="line">z</tspan></text>
+      <text
+         id="text6227-1"
+         y="57.084991"
+         x="334.49097"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="57.084991"
+           x="334.49097"
+           id="tspan6225-9"
+           sodipodi:role="line">U</tspan></text>
+    </g>
+    <g
+       id="g289"
+       transform="translate(-26.662143,14.020609)">
+      <text
+         id="text6153-9-1"
+         y="73.250664"
+         x="263.40369"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="73.250664"
+           x="263.40369"
+           id="tspan6151-2-1"
+           sodipodi:role="line">C</tspan></text>
+      <text
+         id="text6157-5-03"
+         y="68.771194"
+         x="268.73279"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           id="tspan6163-4-40"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="68.771194"
+           x="268.73279"
+           sodipodi:role="line">i</tspan></text>
+      <text
+         id="text6247-3"
+         y="75.010559"
+         x="268.41177"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="75.010559"
+           x="268.41177"
+           id="tspan6245-3"
+           sodipodi:role="line">2</tspan></text>
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="234.94109"
+       y="68.244606"
+       id="text6157-5-0-8"><tspan
+         sodipodi:role="line"
+         x="234.94109"
+         y="68.244606"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="tspan6163-4-5-0">i</tspan></text>
+    <g
+       id="g281"
+       transform="translate(26.20245,-13.790763)">
+      <text
+         id="text6243-6"
+         y="89.843262"
+         x="242.05365"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="89.843262"
+           x="242.05365"
+           id="tspan6241-9"
+           sodipodi:role="line">1</tspan></text>
+      <text
+         id="text6153-9-9-5"
+         y="87.801422"
+         x="237.72743"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="87.801422"
+           x="237.72743"
+           id="tspan6151-2-2-6"
+           sodipodi:role="line">C</tspan></text>
+      <text
+         id="text6157-5-5-6"
+         y="83.56662"
+         x="242.4126"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           id="tspan6163-4-4-4"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="83.56662"
+           x="242.4126"
+           sodipodi:role="line">i</tspan></text>
+    </g>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 190.55537,42.79055 145.46546,0.209442"
+       id="path3752-0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 190.50001,127.66666 H 336.02083"
+       id="path3754-4"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.66500002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.665, 1.995;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 240.77083,64.166653 206.90417,42.735409"
+       id="path4571-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <g
+       id="g301"
+       transform="translate(-1.1492303,16.778762)">
+      <text
+         id="text6223-77-2"
+         y="107.20412"
+         x="331.68466"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="107.20412"
+           x="331.68466"
+           id="tspan6221-6-6"
+           sodipodi:role="line">z</tspan></text>
+      <text
+         id="text6227-4-7"
+         y="108.19189"
+         x="335.40067"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           y="108.19189"
+           x="335.40067"
+           id="tspan6225-3-5"
+           sodipodi:role="line">L</tspan></text>
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="22.40962"
+       y="7.2637801"
+       id="text4853"><tspan
+         sodipodi:role="line"
+         id="tspan4851"
+         x="22.40962"
+         y="7.2637801"
+         style="stroke-width:0.26458332">Sphere 2 contains Sphere 1</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="212.8501"
+       y="7.2094617"
+       id="text4857"><tspan
+         sodipodi:role="line"
+         id="tspan4855"
+         x="212.8501"
+         y="7.2094617"
+         style="stroke-width:0.26458332">Sphere 1 contains Sphere 2</tspan></text>
+  </g>
+</svg>

--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -17,6 +17,7 @@ spectre_target_sources(
   FocallyLiftedEndcap.cpp
   FocallyLiftedMap.cpp
   FocallyLiftedMapHelpers.cpp
+  FocallyLiftedSide.cpp
   Frustum.cpp
   Identity.cpp
   Rotation.cpp

--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_sources(
   Affine.cpp
   BulgedCube.cpp
   CylindricalEndcap.cpp
+  CylindricalSide.cpp
   DiscreteRotation.cpp
   EquatorialCompression.cpp
   Equiangular.cpp
@@ -36,12 +37,14 @@ spectre_target_headers(
   CoordinateMap.tpp
   CoordinateMapHelpers.hpp
   CylindricalEndcap.hpp
+  CylindricalSide.hpp
   DiscreteRotation.hpp
   EquatorialCompression.hpp
   Equiangular.hpp
   FocallyLiftedEndcap.hpp
   FocallyLiftedMap.hpp
   FocallyLiftedMapHelpers.hpp
+  FocallyLiftedSide.hpp
   Frustum.hpp
   Identity.hpp
   MapInstantiationMacros.hpp

--- a/src/Domain/CoordinateMaps/CylindricalSide.cpp
+++ b/src/Domain/CoordinateMaps/CylindricalSide.cpp
@@ -1,0 +1,166 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/CylindricalSide.hpp"
+
+#include <pup.h>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/FocallyLiftedMap.hpp"
+#include "Domain/CoordinateMaps/FocallyLiftedSide.hpp"
+#include "Parallel/PupStlCpp11.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace domain::CoordinateMaps {
+
+CylindricalSide::CylindricalSide(const std::array<double, 3>& center_one,
+                                 const std::array<double, 3>& center_two,
+                                 const std::array<double, 3>& proj_center,
+                                 const double radius_one,
+                                 const double radius_two, const double z_lower,
+                                 const double z_upper) noexcept
+    : impl_(
+          center_two, proj_center, radius_two,
+          [&center_one, &center_two, &radius_one, &radius_two]() noexcept {
+            const double dist_spheres =
+                sqrt(square(center_one[0] - center_two[0]) +
+                     square(center_one[1] - center_two[1]) +
+                     square(center_one[2] - center_two[2]));
+            // If sphere 1 is contained in sphere 2, then the source (sphere 1)
+            // is always between the projection point and the target (sphere 2).
+            // Otherwise, if sphere 2 is contained in sphere 1, then the source
+            // (sphere 1) is not between the projection point and the target
+            // (sphere 2).
+            //
+            // Note that below we ASSERT that sphere 1 is contained in sphere 2
+            // or vice versa.
+            return dist_spheres + radius_one < radius_two;
+          }(),
+          FocallyLiftedInnerMaps::Side(center_one, radius_one, z_lower,
+                                       z_upper)) {
+#ifdef SPECTRE_DEBUG
+  // There are two types of sanity checks here on the map parameters.
+  // 1) ASSERTS that guarantee that the map is invertible.
+  // 2) ASSERTS that guarantee that the map parameters fall within
+  //    the range tested by the unit tests (which is the range in which
+  //    the map is expected to be used).
+  //
+  // There are two reasons why 1) and 2) are not the same:
+  //
+  // a) It is possible to choose parameters such that the map is
+  //    invertible but the resulting geometry has very sharp angles,
+  //    very large or ill-conditioned Jacobians, or both.  We want to
+  //    avoid such cases.
+  // b) We do not want to waste effort testing the map for parameters
+  //    that we don't expect to be used.  For example, we demand
+  //    here that proj_center and sphere_one are contained within
+  //    sphere_two, but the map should still be valid for some choices
+  //    of parameters where sphere_one and sphere_two are disjoint;
+  //    allowing those parameter choices would involve much more
+  //    complicated logic to determine whether the map produces shapes
+  //    with sharp angles or large jacobians, and it would involve more
+  //    complicated unit tests to cover those possibilities.
+
+  const double dist_spheres = sqrt(square(center_one[0] - center_two[0]) +
+                                   square(center_one[1] - center_two[1]) +
+                                   square(center_one[2] - center_two[2]));
+  ASSERT(dist_spheres + radius_one < radius_two or
+             dist_spheres + radius_two < radius_one,
+         "CylindricalSide: The map has been tested only for the case when "
+         "sphere_one is contained inside sphere_two or vice versa.");
+
+  const double dist_proj_one = sqrt(square(center_one[0] - proj_center[0]) +
+                                    square(center_one[1] - proj_center[1]) +
+                                    square(center_one[2] - proj_center[2]));
+  ASSERT(dist_proj_one < radius_one,
+         "CylindricalSide: The map has been tested only for the case when "
+         "proj_center is contained inside sphere_one");
+
+  const double dist_proj_two = sqrt(square(center_two[0] - proj_center[0]) +
+                                    square(center_two[1] - proj_center[1]) +
+                                    square(center_two[2] - proj_center[2]));
+  ASSERT(dist_proj_two < radius_two,
+         "CylindricalSide: The map has been tested only for the case when "
+         "proj_center is contained inside sphere_two. dist_proj_two="
+         << dist_proj_two << ", radius_two=" << radius_two);
+
+  ASSERT(proj_center[2] >= z_lower and proj_center[2] <= z_upper,
+         "CylindricalSide: The map has been tested only for the case when "
+         "proj_center is contained inside z_lower and z_upper: "
+             << z_lower << " " << proj_center[2] << " " << z_upper);
+
+  ASSERT(center_one[2] - z_lower <= 0.95 * radius_one and
+             z_upper - center_one[2] <= 0.95 * radius_one,
+         "CylindricalSide: The map has been tested only when z_lower and "
+         "z_upper are sufficently far from the edge of sphere_one");
+
+  if (dist_spheres + radius_two < radius_one) {
+    ASSERT(center_one[2] - z_lower >= 0.2 * radius_one and
+               z_upper - center_one[2] >= 0.2 * radius_one,
+           "CylindricalSide: The map has been tested only when z_lower and "
+           "z_upper are sufficently far from the center of sphere_one");
+  }
+#endif
+}
+
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, 3> CylindricalSide::operator()(
+    const std::array<T, 3>& source_coords) const noexcept {
+  return impl_.operator()(source_coords);
+}
+
+std::optional<std::array<double, 3>> CylindricalSide::inverse(
+    const std::array<double, 3>& target_coords) const noexcept {
+  return impl_.inverse(target_coords);
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
+CylindricalSide::jacobian(const std::array<T, 3>& source_coords) const
+    noexcept {
+  return impl_.jacobian(source_coords);
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
+CylindricalSide::inv_jacobian(const std::array<T, 3>& source_coords) const
+    noexcept {
+  return impl_.inv_jacobian(source_coords);
+}
+
+void CylindricalSide::pup(PUP::er& p) noexcept { p | impl_; }
+
+bool operator==(const CylindricalSide& lhs,
+                const CylindricalSide& rhs) noexcept {
+  return lhs.impl_ == rhs.impl_;
+}
+bool operator!=(const CylindricalSide& lhs,
+                const CylindricalSide& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+// Explicit instantiations
+/// \cond
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                   \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>                 \
+  CylindricalSide::operator()(const std::array<DTYPE(data), 3>& source_coords) \
+      const noexcept;                                                          \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame>   \
+  CylindricalSide::jacobian(const std::array<DTYPE(data), 3>& source_coords)   \
+      const noexcept;                                                          \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame>   \
+  CylindricalSide::inv_jacobian(                                               \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
+                                      std::reference_wrapper<const double>,
+                                      std::reference_wrapper<const DataVector>))
+
+#undef DTYPE
+#undef INSTANTIATE
+/// \endcond
+
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/CylindricalSide.hpp
+++ b/src/Domain/CoordinateMaps/CylindricalSide.hpp
@@ -1,0 +1,134 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines the class CylindricalSide.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <optional>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/CoordinateMaps/FocallyLiftedMap.hpp"
+#include "Domain/CoordinateMaps/FocallyLiftedSide.hpp"
+#include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace domain::CoordinateMaps {
+
+/*!
+ * \ingroup CoordinateMapsGroup
+ *
+ * \brief Map from a 3D unit right cylindrical shell to a volume that connects
+ *  portions of two spherical surfaces.
+ *
+ * \image html CylindricalSide.svg "2D slice showing mapped (shaded) region."
+ *
+ * \details Consider two spheres with centers \f$C_1\f$ and \f$C_2\f$,
+ * and radii \f$R_1\f$ and \f$R_2\f$. Let sphere 1 be intersected by two
+ * planes normal to the \f$z\f$ axis and located at \f$z = z_\mathrm{L}\f$
+ * and \f$z = z_\mathrm{U}\f$, with \f$z_\mathrm{L} < z_\mathrm{U}\f$.
+ * Also let there be a projection point \f$P\f$.
+ *
+ * Note that Sphere 1 and Sphere 2 are not equivalent, because the
+ * mapped portion of Sphere 1 is bounded by planes of constant
+ * \f$z\f$ but the mapped portion of Sphere 2 is not (except for
+ * special choices of \f$C_1\f$, \f$C_2\f$, and \f$P\f$).
+ *
+ * CylindricalSide maps a 3D unit right cylindrical shell (with
+ * coordinates \f$(\bar{x},\bar{y},\bar{z})\f$ such that
+ * \f$-1\leq\bar{z}\leq 1\f$ and \f$1 \leq \bar{x}^2+\bar{y}^2 \leq
+ * 4\f$) to the shaded area in each panel of the figure above (with
+ * coordinates \f$(x,y,z)\f$).  The figure shows two different allowed
+ * possibilities: \f$R_1 > R_2\f$ and \f$R_2 > R_1\f$. Note that the
+ * two portions of the shaded region in each panel of the figure
+ * represent different portions of the same block; each panel of the
+ * figure is to be understood as rotated around the \f$z\f$ axis. The
+ * inner boundary of the cylindrical shell \f$\bar{x}^2+\bar{y}^2=1\f$
+ * is mapped to the portion of sphere 1 that has \f$z_\mathrm{L} \leq
+ * z \leq z_\mathrm{U}\f$.  Curves of constant \f$(\bar{z})\f$ along
+ * the vector \f$(\bar{x},\bar{y})\f$ are mapped to portions of lines
+ * that pass through \f$P\f$. Along each of these curves,
+ * \f$\bar{x}^2+\bar{y}^2=1\f$ is mapped to a point on sphere 1 and
+ * \f$\bar{x}^2+\bar{y}^2=4\f$ is mapped to a point on sphere 2.
+ *
+ * CylindricalSide is described briefly in the Appendix of
+ * \cite Buchman:2012dw.  CylindricalSide is used to construct the blocks
+ * labeled 'CA cylinder', 'EA cylinder', 'CB cylinder', 'EE cylinder',
+ * and 'EB cylinder' in Figure 20 of that paper.  Note that 'CA
+ * cylinder', 'CB cylinder', and 'EE cylinder' have Sphere 1 contained
+ * in Sphere2, and 'EA cylinder' and 'EB cylinder' have Sphere 2
+ * contained in Sphere 1.
+ *
+ * CylindricalSide is implemented using `FocallyLiftedMap`
+ * and `FocallyLiftedInnerMaps::Side`; see those classes for
+ * details.
+ *
+ * ### Restrictions on map parameters.
+ *
+ * We demand that:
+ * - Either Sphere 1 is fully contained inside Sphere 2, or
+ *   Sphere 2 is fully contained inside Sphere 1.
+ * - \f$P\f$ is contained inside the smaller sphere, and
+ *   between (or on) the planes defined by \f$z_\mathrm{L}\f$ and
+ *   \f$z_\mathrm{U}\f$.
+ * - If sphere 1 is contained in sphere 2:
+ *   - \f$C_1^z - 0.95 R_1 \leq z_\mathrm{L}\f$
+ *   - \f$z_\mathrm{U} \leq C_1^z + 0.95 R_1\f$
+ * - If sphere 2 is contained in sphere 1:
+ *   - \f$C_1^z - 0.95 R_1 \leq z_\mathrm{L} \leq C_1^z - 0.2 R_1\f$
+ *   - \f$C_1^z + 0.2 R_1 \leq z_\mathrm{U} \leq C_1^z + 0.95 R_1\f$
+ *
+ */
+class CylindricalSide {
+ public:
+  static constexpr size_t dim = 3;
+  CylindricalSide(const std::array<double, 3>& center_one,
+                  const std::array<double, 3>& center_two,
+                  const std::array<double, 3>& proj_center, double radius_one,
+                  double radius_two, double z_lower, double z_upper) noexcept;
+
+  CylindricalSide() = default;
+  ~CylindricalSide() = default;
+  CylindricalSide(CylindricalSide&&) = default;
+  CylindricalSide(const CylindricalSide&) = default;
+  CylindricalSide& operator=(const CylindricalSide&) = default;
+  CylindricalSide& operator=(CylindricalSide&&) = default;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  std::optional<std::array<double, 3>> inverse(
+      const std::array<double, 3>& target_coords) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> jacobian(
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> inv_jacobian(
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  // clang-tidy: google runtime references
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+  static bool is_identity() noexcept { return false; }
+
+ private:
+  friend bool operator==(const CylindricalSide& lhs,
+                         const CylindricalSide& rhs) noexcept;
+  FocallyLiftedMap<FocallyLiftedInnerMaps::Side> impl_;
+};
+bool operator!=(const CylindricalSide& lhs,
+                const CylindricalSide& rhs) noexcept;
+
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/FocallyLiftedMap.cpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedMap.cpp
@@ -10,6 +10,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/FocallyLiftedEndcap.hpp"
 #include "Domain/CoordinateMaps/FocallyLiftedMapHelpers.hpp"
+#include "Domain/CoordinateMaps/FocallyLiftedSide.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
@@ -366,7 +367,8 @@ bool operator==(const FocallyLiftedMap<InnerMap>& lhs,
   template bool operator!=(const FocallyLiftedMap<IMAP(data)>& lhs,           \
                            const FocallyLiftedMap<IMAP(data)>& rhs) noexcept;
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (FocallyLiftedInnerMaps::Endcap))
+GENERATE_INSTANTIATIONS(INSTANTIATE, (FocallyLiftedInnerMaps::Endcap,
+                                      FocallyLiftedInnerMaps::Side))
 
 #undef INSTANTIATE
 
@@ -383,10 +385,10 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (FocallyLiftedInnerMaps::Endcap))
   FocallyLiftedMap<IMAP(data)>::inv_jacobian(                                \
       const std::array<DTYPE(data), 3>& source_coords) const noexcept;
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (FocallyLiftedInnerMaps::Endcap),
-                        (double, DataVector,
-                         std::reference_wrapper<const double>,
-                         std::reference_wrapper<const DataVector>))
+GENERATE_INSTANTIATIONS(
+    INSTANTIATE, (FocallyLiftedInnerMaps::Endcap, FocallyLiftedInnerMaps::Side),
+    (double, DataVector, std::reference_wrapper<const double>,
+     std::reference_wrapper<const DataVector>))
 
 #undef INSTANTIATE
 #undef DTYPE

--- a/src/Domain/CoordinateMaps/FocallyLiftedSide.cpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedSide.cpp
@@ -1,0 +1,313 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/FocallyLiftedSide.hpp"
+
+#include <cmath>
+#include <limits>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/FocallyLiftedMapHelpers.hpp"
+#include "Parallel/PupStlCpp11.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace domain::CoordinateMaps::FocallyLiftedInnerMaps {
+
+Side::Side(const std::array<double, 3>& center, const double radius,
+           const double z_lower, const double z_upper) noexcept
+    : center_(center),
+      radius_([&radius]() noexcept {
+        ASSERT(
+            not equal_within_roundoff(radius, 0.0),
+            "Cannot have zero radius.  Note that this ASSERT implicitly "
+            "assumes that the radius has a scale of roughly unity.  Therefore, "
+            "this ASSERT may trigger in the case where we intentionally want "
+            "an entire domain that is very small.  If we really want small "
+            "domains, then this ASSERT should be modified.");
+        return radius;
+      }()),
+      theta_min_([&z_upper, &center, &radius]() noexcept {
+        ASSERT(abs(z_upper - center[2]) < radius,
+               "Upper plane must intersect sphere, and it must do "
+               "so at more than one point.");
+        return acos((z_upper - center[2]) / radius);
+      }()),
+      theta_max_([&z_lower, &center, &radius]() noexcept {
+        ASSERT(abs(z_lower - center[2]) < radius,
+               "Lower plane must intersect sphere, and it must do "
+               "so at more than one point.");
+        return acos((z_lower - center[2]) / radius);
+      }()) {
+  // Note that theta decreases with increasing z, which is why
+  // theta_min_ above uses z_upper and theta_max_ uses z_lower.
+  ASSERT(z_lower < z_upper, "Lower plane must be below upper plane");
+}
+
+template <typename T>
+void Side::forward_map(
+    const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
+        target_coords,
+    const std::array<T, 3>& source_coords) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  const ReturnType& xbar = source_coords[0];
+  const ReturnType& ybar = source_coords[1];
+  const ReturnType& zbar = source_coords[2];
+  ReturnType& x = (*target_coords)[0];
+  ReturnType& y = (*target_coords)[1];
+  ReturnType& z = (*target_coords)[2];
+  // Use z and y as temporary storage to avoid allocations,
+  // before setting them to their actual values.
+  z = theta_max_ + 0.5 * (theta_min_ - theta_max_) * (1.0 + zbar);
+  // Note: denominator of the next line is guaranteed != 0 because for
+  // this map xbar and ybar are coordinates of points on the *sides*
+  // of a right cylinder, i.e. away from the zbar-axis.
+  y = radius_ * sin(z) / sqrt(square(xbar) + square(ybar));
+  x = y * xbar + center_[0];
+  y = y * ybar + center_[1];
+  z = radius_ * cos(z) + center_[2];
+}
+
+template <typename T>
+void Side::jacobian(const gsl::not_null<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3,
+                                                 Frame::NoFrame>*>
+                        jacobian_out,
+                    const std::array<T, 3>& source_coords) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  const ReturnType& xbar = source_coords[0];
+  const ReturnType& ybar = source_coords[1];
+  const ReturnType& zbar = source_coords[2];
+
+  if constexpr (not std::is_same_v<ReturnType, double>) {
+    destructive_resize_components(
+        jacobian_out, static_cast<ReturnType>(source_coords[0]).size());
+  }
+
+  // Use (1,1) (2,2), and (1,2) parts of Jacobian as temp storage to
+  // reduce allocations.
+  get<1, 1>(*jacobian_out) =
+      theta_max_ + 0.5 * (theta_min_ - theta_max_) * (1.0 + zbar);
+  get<2, 2>(*jacobian_out) = radius_ * sin(get<1, 1>(*jacobian_out));
+  get<1, 2>(*jacobian_out) =
+      radius_ * 0.5 * (theta_min_ - theta_max_) * cos(get<1, 1>(*jacobian_out));
+  // Denominator of next line is guaranteed to not be zero.
+  get<1, 1>(*jacobian_out) = 1.0 / sqrt(square(xbar) + square(ybar));
+  get<1, 2>(*jacobian_out) *= get<1, 1>(*jacobian_out);
+  get<1, 1>(*jacobian_out) =
+      get<2, 2>(*jacobian_out) * cube(get<1, 1>(*jacobian_out));
+
+  // dx/dxbar
+  get<0, 0>(*jacobian_out) = get<1, 1>(*jacobian_out) * square(ybar);
+  // dx/dybar
+  get<0, 1>(*jacobian_out) = -get<1, 1>(*jacobian_out) * xbar * ybar;
+  // dx/dzbar
+  get<0, 2>(*jacobian_out) = get<1, 2>(*jacobian_out) * xbar;
+  // dy/dxbar
+  get<1, 0>(*jacobian_out) = -get<1, 1>(*jacobian_out) * xbar * ybar;
+  // dy/dybar
+  get<1, 1>(*jacobian_out) *= square(xbar);
+  // dy/dzbar
+  get<1, 2>(*jacobian_out) *= ybar;
+  // dz/dzbar
+  get<2, 2>(*jacobian_out) *= -0.5 * (theta_min_ - theta_max_);
+
+  // The rest of the components are zero
+  get<2, 0>(*jacobian_out) = 0.0;
+  get<2, 1>(*jacobian_out) = 0.0;
+}
+
+template <typename T>
+void Side::inv_jacobian(const gsl::not_null<tnsr::Ij<tt::remove_cvref_wrap_t<T>,
+                                                     3, Frame::NoFrame>*>
+                            inv_jacobian_out,
+                        const std::array<T, 3>& source_coords) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  const ReturnType& xbar = source_coords[0];
+  const ReturnType& ybar = source_coords[1];
+  const ReturnType& zbar = source_coords[2];
+
+  if constexpr (not std::is_same<ReturnType, double>::value) {
+    destructive_resize_components(
+        inv_jacobian_out, static_cast<ReturnType>(source_coords[0]).size());
+  }
+
+  // Use parts of inverse Jacobian as temp storage to reduce allocations.
+  const double theta_factor = 0.5 * (theta_min_ - theta_max_);
+  get<2, 2>(*inv_jacobian_out) =
+      1.0 / (radius_ * sin(theta_max_ + theta_factor * (1.0 + zbar)));
+  // Denominator of next line is guaranteed to be nonzero.
+  get<1, 1>(*inv_jacobian_out) =
+      get<2, 2>(*inv_jacobian_out) / sqrt(square(xbar) + square(ybar));
+
+  // dxbar/dx
+  get<0, 0>(*inv_jacobian_out) = square(ybar) * get<1, 1>(*inv_jacobian_out);
+  // dxbar/dy
+  get<0, 1>(*inv_jacobian_out) = -xbar * ybar * get<1, 1>(*inv_jacobian_out);
+  // dybar/dx
+  get<1, 0>(*inv_jacobian_out) = get<0, 1>(*inv_jacobian_out);
+  // dybar/dy
+  get<1, 1>(*inv_jacobian_out) *= square(xbar);
+  // dzbar/dz
+  get<2, 2>(*inv_jacobian_out) /= -theta_factor;
+
+  // The rest of the components are zero
+  get<0, 2>(*inv_jacobian_out) = 0.0;
+  get<1, 2>(*inv_jacobian_out) = 0.0;
+  get<2, 0>(*inv_jacobian_out) = 0.0;
+  get<2, 1>(*inv_jacobian_out) = 0.0;
+}
+
+std::optional<std::array<double, 3>> Side::inverse(
+    const std::array<double, 3>& target_coords,
+    const double sigma_in) const noexcept {
+  if ((sigma_in < 0.0 and not equal_within_roundoff(sigma_in, 0.0)) or
+      (sigma_in > 1.0 and not equal_within_roundoff(sigma_in, 1.0))) {
+    return {};
+  }
+
+  const double x = target_coords[0] - center_[0];
+  const double y = target_coords[1] - center_[1];
+  const double z = target_coords[2] - center_[2];
+  const double rho = sqrt(square(x) + square(y));
+
+  const double zbar =
+      2.0 * ((acos(z / radius_) - theta_max_) / (theta_min_ - theta_max_)) -
+      1.0;
+  if ((zbar < -1.0 and not equal_within_roundoff(zbar, -1.0)) or
+      (zbar > 1.0 and not equal_within_roundoff(zbar, 1.0))) {
+    return {};
+  }
+
+  const double xbar = (1.0 + sigma_in) * x / rho;
+  const double ybar = (1.0 + sigma_in) * y / rho;
+  return std::array<double, 3>{{xbar, ybar, zbar}};
+}
+
+template <typename T>
+void Side::sigma(const gsl::not_null<tt::remove_cvref_wrap_t<T>*> sigma_out,
+                 const std::array<T, 3>& source_coords) const noexcept {
+  *sigma_out = sqrt(square(source_coords[0]) + square(source_coords[1])) - 1.0;
+}
+
+template <typename T>
+void Side::deriv_sigma(
+    const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
+        deriv_sigma_out,
+    const std::array<T, 3>& source_coords) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  const ReturnType& xbar = source_coords[0];
+  const ReturnType& ybar = source_coords[1];
+  if constexpr (not std::is_same<ReturnType, double>::value) {
+    destructive_resize_components(
+        deriv_sigma_out, static_cast<ReturnType>(source_coords[0]).size());
+  }
+
+  // Use as temp storage to reduce allocations.
+  // Note that denominator is guaranteed to be nonzero.
+  (*deriv_sigma_out)[1] = 1.0 / sqrt(square(xbar) + square(ybar));
+
+  (*deriv_sigma_out)[0] = xbar * (*deriv_sigma_out)[1];
+  (*deriv_sigma_out)[1] *= ybar;
+  (*deriv_sigma_out)[2] = 0.0;
+}
+
+template <typename T>
+void Side::dxbar_dsigma(
+    const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
+        dxbar_dsigma_out,
+    const std::array<T, 3>& source_coords) const noexcept {
+  deriv_sigma(dxbar_dsigma_out, source_coords);
+}
+
+std::optional<double> Side::lambda_tilde(
+    const std::array<double, 3>& parent_mapped_target_coords,
+    const std::array<double, 3>& projection_point,
+    const bool source_is_between_focus_and_target) const noexcept {
+  return FocallyLiftedMapHelpers::try_scale_factor(
+      parent_mapped_target_coords, projection_point, center_, radius_,
+      source_is_between_focus_and_target,
+      not source_is_between_focus_and_target);
+}
+
+template <typename T>
+void Side::deriv_lambda_tilde(
+    const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
+        deriv_lambda_tilde_out,
+    const std::array<T, 3>& target_coords, const T& lambda_tilde,
+    const std::array<double, 3>& projection_point) const noexcept {
+  FocallyLiftedMapHelpers::d_scale_factor_d_src_point(
+      deriv_lambda_tilde_out, target_coords, projection_point, center_,
+      lambda_tilde);
+}
+
+void Side::pup(PUP::er& p) noexcept {
+  p | center_;
+  p | radius_;
+  p | theta_min_;
+  p | theta_max_;
+}
+
+bool operator==(const Side& lhs, const Side& rhs) noexcept {
+  return lhs.center_ == rhs.center_ and lhs.radius_ == rhs.radius_ and
+         lhs.theta_min_ == rhs.theta_min_ and lhs.theta_max_ == rhs.theta_max_;
+}
+
+bool operator!=(const Side& lhs, const Side& rhs) noexcept {
+  return not(lhs == rhs);
+}
+// Explicit instantiations
+/// \cond
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                  \
+  template void Side::forward_map(                                            \
+      const gsl::not_null<                                                    \
+          std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>*>               \
+          target_coords,                                                      \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;        \
+  template void Side::jacobian(                                               \
+      const gsl::not_null<                                                    \
+          tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame>*> \
+          jacobian_out,                                                       \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;        \
+  template void Side::inv_jacobian(                                           \
+      const gsl::not_null<                                                    \
+          tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame>*> \
+          inv_jacobian_out,                                                   \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;        \
+  template void Side::sigma(                                                  \
+      const gsl::not_null<tt::remove_cvref_wrap_t<DTYPE(data)>*> sigma_out,   \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;        \
+  template void Side::deriv_sigma(                                            \
+      const gsl::not_null<                                                    \
+          std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>*>               \
+          deriv_sigma_out,                                                    \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;        \
+  template void Side::dxbar_dsigma(                                           \
+      const gsl::not_null<                                                    \
+          std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>*>               \
+          dxbar_dsigma_out,                                                   \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;        \
+  template void Side::deriv_lambda_tilde(                                     \
+      const gsl::not_null<                                                    \
+          std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>*>               \
+          deriv_lambda_tilde_out,                                             \
+      const std::array<DTYPE(data), 3>& target_coords,                        \
+      const DTYPE(data) & lambda_tilde,                                       \
+      const std::array<double, 3>& projection_point) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
+                                      std::reference_wrapper<const double>,
+                                      std::reference_wrapper<const DataVector>))
+
+#undef INSTANTIATE
+#undef DTYPE
+/// \endcond
+
+}  // namespace domain::CoordinateMaps::FocallyLiftedInnerMaps

--- a/src/Domain/CoordinateMaps/FocallyLiftedSide.hpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedSide.hpp
@@ -1,0 +1,314 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <optional>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace domain::CoordinateMaps::FocallyLiftedInnerMaps {
+/*!
+ * \brief A FocallyLiftedInnerMap that maps a 3D unit right cylindrical shell
+ *  to a volume that connects portions of two spherical surfaces.
+ *
+ * \details The domain of the map is a 3D unit right cylinder with
+ * coordinates \f$(\bar{x},\bar{y},\bar{z})\f$ such that
+ * \f$-1\leq\bar{z}\leq 1\f$ and \f$1\leq \bar{x}^2+\bar{y}^2 \leq
+ * 4\f$.  The range of the map has coordinates \f$(x,y,z)\f$.
+ *
+ * Consider a sphere with center \f$C^i\f$ and radius \f$R\f$ that is
+ * intersected by two planes normal to the \f$z\f$ axis located at
+ * \f$z = z_\mathrm{L}\f$ and \f$z = z_\mathrm{U}\f$, with
+ * \f$z_\mathrm{L} < z_\mathrm{U}\f$.
+ * `Side` provides the following functions:
+ *
+ * ### forward_map()
+ * `forward_map()` maps \f$(\bar{x},\bar{y},\bar{z})\f$ to a point on the inner
+ * surface
+ * \f$\bar{x}^2+\bar{y}^2=1\f$ by dividing \f$\bar{x}\f$ and \f$\bar{y}\f$
+ * by \f$(1+\sigma)\f$, where \f$\sigma\f$ is the function given by Eq. (7)
+ * below.
+ * Then it maps that point to a point on the portion of the sphere with
+ * \f$z_\mathrm{L} \leq z \leq z_\mathrm{U}\f$.
+ * `forward_map()` returns
+ * \f$x_0^i\f$, the 3D coordinates on that sphere, which are given by
+ *
+ * \f{align}
+ * x_0^0 &= R \sin\theta \frac{\bar{x}}{1+\sigma} + C^0,\\
+ * x_0^1 &= R \sin\theta \frac{\bar{y}}{1+\sigma} + C^1,\\
+ * x_0^2 &= R \cos\theta + C^2.\\
+ * \f}
+ *
+ * Here
+ * \f{align}
+ * \theta = \theta_\mathrm{max} +
+ * (\theta_\mathrm{min}-\theta_\mathrm{max}) \frac{\bar{z}+1}{2},
+ * \f}
+ *
+ * where
+ * \f{align}
+ * \cos(\theta_\mathrm{max}) &= (z_\mathrm{L}-C^2)/R,\\
+ * \cos(\theta_\mathrm{min}) &= (z_\mathrm{U}-C^2)/R.
+ * \f}
+ *
+ * Note that \f$\theta\f$ decreases with increasing \f$\bar{z}\f$,
+ * which is the usual convention for a polar angle but might otherwise
+ * cause confusion.
+ *
+ * ### sigma
+ *
+ * \f$\sigma\f$ is a function that is zero on the sphere
+ * \f$x^i=x_0^i\f$ and unity at \f$\bar{x}^2+\bar{y}^2=4\f$
+ * (corresponding to the upper surface of the FocallyLiftedMap). We define
+ *
+ * \f{align}
+ *  \sigma &= \sqrt{\bar{x}^2+\bar{y}^2}-1.
+ * \f}
+ *
+ * ### deriv_sigma
+ *
+ * `deriv_sigma` returns
+ *
+ * \f{align}
+ *  \frac{\partial \sigma}{\partial \bar{x}^j} &=
+ * \left(\frac{\bar{x}}{1+\sigma},
+ *       \frac{\bar{y}}{1+\sigma},0\right).
+ * \f}
+ *
+ * ### jacobian
+ *
+ * `jacobian` returns \f$\partial x_0^k/\partial \bar{x}^j\f$.
+ * The arguments to `jacobian` are \f$(\bar{x},\bar{y},\bar{z})\f$.
+ * Differentiating Eqs.(1--4) above yields
+ *
+ * \f{align*}
+ * \frac{\partial x_0^0}{\partial \bar{x}} &= R \sin\theta
+ * \frac{\bar{y}^2}{(1+\sigma)^3}, \\
+ * \frac{\partial x_0^0}{\partial \bar{y}} &= -R \sin\theta
+ * \frac{\bar{x}\bar{y}}{(1+\sigma)^3}, \\
+ * \frac{\partial x_0^0}{\partial \bar{z}} &=
+ * R \cos\theta \frac{\theta_\mathrm{min}-\theta_\mathrm{max}}{2(1+\sigma)}
+ *   \bar{x},\\
+ * \frac{\partial x_0^1}{\partial \bar{x}} &= -R \sin\theta
+ * \frac{\bar{x}\bar{y}}{(1+\sigma)^3}, \\
+ * \frac{\partial x_0^1}{\partial \bar{y}} &= R \sin\theta
+ * \frac{\bar{x}^2}{(1+\sigma)^3}, \\
+ * \frac{\partial x_0^1}{\partial \bar{z}} &=
+ * R \cos\theta \frac{\theta_\mathrm{min}-\theta_\mathrm{max}}{2(1+\sigma)}
+ *   \bar{y},\\
+ * \frac{\partial x_0^2}{\partial \bar{x}} &= 0,\\
+ * \frac{\partial x_0^2}{\partial \bar{y}} &= 0,\\
+ * \frac{\partial x_0^2}{\partial \bar{z}} &=
+ * - R \sin\theta \frac{\theta_\mathrm{min}-\theta_\mathrm{max}}{2}.
+ * \f}
+ *
+ * ### inverse
+ *
+ * `inverse` takes \f$x_0^i\f$ and \f$\sigma\f$ as arguments, and
+ * returns \f$(\bar{x},\bar{y},\bar{z})\f$, or a default-constructed
+ * `std::optional<std::array<double, 3>>` if \f$x_0^i\f$ or \f$\sigma\f$ are
+ * outside the range of the map.
+ *
+ * If \f$\sigma\f$ is outside the range \f$[0,1]\f$ then we return
+ * a default-constructed `std::optional<std::array<double, 3>>`.
+ *
+ * To get \f$\bar{z}\f$ we invert Eq. (4):
+ * \f{align}
+ * \bar{z} &= 2\frac{\acos\left((x_0^2-C^2)/R\right)-\theta_\mathrm{max}}
+ *            {\theta_\mathrm{min}-\theta_\mathrm{max}} - 1.
+ * \f}
+ *
+ * If \f$\bar{z}\f$ is outside the range \f$[-1,1]\f$ then we return
+ * a default-constructed `std::optional<std::array<double, 3>>`.
+ *
+ * To compute \f$\bar{x}\f$ and \f$\bar{y}\f$, we invert Eqs. (1--3) and
+ * use \f$\sigma\f$:
+ *
+ * \f{align}
+ *  \bar{x} &= \frac{(x_0^0-C^0) (1+\sigma)}{\rho},\\
+ *  \bar{y} &= \frac{(x_0^1-C^1) (1+\sigma)}{\rho},
+ * \f}
+ *
+ * where
+ *
+ * \f{align}
+ * \rho = \sqrt{(x_0^0-C^0)^2+(x_0^1-C^1)^2}.
+ * \f}
+ *
+ * ### lambda_tilde
+ *
+ * `lambda_tilde` takes as arguments a point \f$x^i\f$ and a projection point
+ *  \f$P^i\f$, and computes \f$\tilde{\lambda}\f$, the solution to
+ *
+ * \f{align} x_0^i = P^i + (x^i - P^i) \tilde{\lambda}.\f}
+ *
+ * Since \f$x_0^i\f$ must lie on the sphere, \f$\tilde{\lambda}\f$ is the
+ * solution of the quadratic equation
+ *
+ * \f{align}
+ * |P^i + (x^i - P^i) \tilde{\lambda} - C^i |^2 - R^2 = 0.
+ * \f}
+ *
+ * In solving the quadratic, we choose the larger root if
+ * \f$x^2>z_\mathrm{P}\f$ and the smaller root otherwise. We demand
+ * that the root is greater than unity.  If there is no such root,
+ * this means that the point \f$x^i\f$ is not in the range of the map
+ * so we return a default-constructed `std::optional<double>`.
+ *
+ * ### deriv_lambda_tilde
+ *
+ * `deriv_lambda_tilde` takes as arguments \f$x_0^i\f$, a projection point
+ *  \f$P^i\f$, and \f$\tilde{\lambda}\f$, and
+ *  returns \f$\partial \tilde{\lambda}/\partial x^i\f$.
+ * By differentiating Eq. (14), we find
+ *
+ * \f{align}
+ * \frac{\partial\tilde{\lambda}}{\partial x^j} &=
+ * \tilde{\lambda}^2 \frac{C^j - x_0^j}{
+ * (x_0^i - P^i)(x_{0i} - C_{i})} \nonumber \\
+ * &= \tilde{\lambda}^2 \frac{C^j - x_0^j}{|x_0^i - P^i|^2
+ * + (x_0^i - P^i)(P_i - C_{i})}.
+ * \f}
+ *
+ * ### inv_jacobian
+ *
+ * `inv_jacobian` returns \f$\partial \bar{x}^i/\partial x_0^k\f$,
+ *  where \f$\sigma\f$ is held fixed.
+ * The arguments to `inv_jacobian` are \f$(\bar{x},\bar{y},\bar{z})\f$.
+ *
+ * Note from Eqs. (9--12) that \f$\bar{x}\f$ and \f$\bar{y}\f$
+ * depend only on \f$x_0^0\f$ and \f$x_0^1\f$ but not on \f$x_0^2\f$.
+ *
+ * By differentiating Eqs. (9--12), we find
+ *
+ * \f{align*}
+ * \frac{\partial \bar{x}}{\partial x_0^0} &=
+ * \frac{\bar{y}^2}{(1+\sigma)\rho},\\
+ * \frac{\partial \bar{x}}{\partial x_0^1} &=
+ * - \frac{\bar{x}\bar{y}}{(1+\sigma)\rho},\\
+ * \frac{\partial \bar{x}}{\partial x_0^2} &= 0,\\
+ * \frac{\partial \bar{y}}{\partial x_0^0} &=
+ * - \frac{\bar{x}\bar{y}}{(1+\sigma)\rho},\\
+ * \frac{\partial \bar{y}}{\partial x_0^1} &=
+ * \frac{\bar{x}^2}{(1+\sigma)\rho},\\
+ * \frac{\partial \bar{y}}{\partial x_0^2} &= 0,\\
+ * \frac{\partial \bar{z}}{\partial x_0^0} &= 0,\\
+ * \frac{\partial \bar{z}}{\partial x_0^1} &= 0,\\
+ * \frac{\partial \bar{z}}{\partial x_0^2} &=
+ * -\frac{2}{\rho(\theta_\mathrm{min}-\theta_\mathrm{max})},
+ * \f}
+ *
+ * where
+ *
+ * \f[
+ *   \rho = R \sin\theta = R\sin\left(\theta_\mathrm{max} +
+ * (\theta_\mathrm{min}-\theta_\mathrm{max}) \frac{\bar{z}+1}{2}\right),
+ * \f]
+ *
+ * which is also equal to the quantity in Eq. (12).
+ *
+ * ### dxbar_dsigma
+ *
+ * `dxbar_dsigma` returns \f$\partial \bar{x}^i/\partial \sigma\f$,
+ *  where \f$x_0^i\f$ is held fixed.
+ *
+ * From Eqs. (10) and (11) we have
+ *
+ * \f{align}
+ * \frac{\partial \bar{x}^i}{\partial \sigma} &=
+ * \left(\frac{\bar{x}}{\sqrt{\bar{x}^2+\bar{y}^2}},
+ *       \frac{\bar{y}}{\sqrt{\bar{x}^2+\bar{y}^2}},0\right).
+ * \f}
+ *
+ */
+class Side {
+ public:
+  static constexpr size_t dim = 3;
+  Side(const std::array<double, 3>& center, const double radius,
+       const double z_lower, const double z_upper) noexcept;
+
+  Side() = default;
+  ~Side() = default;
+  Side(Side&&) = default;
+  Side(const Side&) = default;
+  Side& operator=(const Side&) = default;
+  Side& operator=(Side&&) = default;
+
+  template <typename T>
+  void forward_map(
+      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
+          target_coords,
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  std::optional<std::array<double, 3>> inverse(
+      const std::array<double, 3>& target_coords,
+      double sigma_in) const noexcept;
+
+  template <typename T>
+  void jacobian(const gsl::not_null<
+                    tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>*>
+                    jacobian_out,
+                const std::array<T, 3>& source_coords) const noexcept;
+
+  template <typename T>
+  void inv_jacobian(const gsl::not_null<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3,
+                                                 Frame::NoFrame>*>
+                        inv_jacobian_out,
+                    const std::array<T, 3>& source_coords) const noexcept;
+
+  template <typename T>
+  void sigma(const gsl::not_null<tt::remove_cvref_wrap_t<T>*> sigma_out,
+             const std::array<T, 3>& source_coords) const noexcept;
+
+  template <typename T>
+  void deriv_sigma(
+      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
+          deriv_sigma_out,
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  template <typename T>
+  void dxbar_dsigma(
+      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
+          dxbar_dsigma_out,
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  std::optional<double> lambda_tilde(
+      const std::array<double, 3>& parent_mapped_target_coords,
+      const std::array<double, 3>& projection_point,
+      bool source_is_between_focus_and_target) const noexcept;
+
+  template <typename T>
+  void deriv_lambda_tilde(
+      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
+          deriv_lambda_tilde_out,
+      const std::array<T, 3>& target_coords, const T& lambda_tilde,
+      const std::array<double, 3>& projection_point) const noexcept;
+
+  // clang-tidy: google runtime references
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+  static bool is_identity() noexcept { return false; }
+
+ private:
+  friend bool operator==(const Side& lhs, const Side& rhs) noexcept;
+  std::array<double, 3> center_{
+      make_array<3>(std::numeric_limits<double>::signaling_NaN())};
+  double radius_{std::numeric_limits<double>::signaling_NaN()};
+  double theta_min_{std::numeric_limits<double>::signaling_NaN()};
+  double theta_max_{std::numeric_limits<double>::signaling_NaN()};
+};
+bool operator!=(const Side& lhs, const Side& rhs) noexcept;
+}  // namespace domain::CoordinateMaps::FocallyLiftedInnerMaps

--- a/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_BulgedCube.cpp
   Test_CoordinateMap.cpp
   Test_CylindricalEndcap.cpp
+  Test_CylindricalSide.cpp
   Test_DiscreteRotation.cpp
   Test_EquatorialCompression.cpp
   Test_Equiangular.cpp

--- a/tests/Unit/Domain/CoordinateMaps/Test_CylindricalSide.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CylindricalSide.cpp
@@ -1,0 +1,174 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <gsl/gsl_poly.h>
+#include <random>
+
+#include "Domain/CoordinateMaps/CylindricalSide.hpp"
+#include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
+#include "NumericalAlgorithms/RootFinding/QuadraticEquation.hpp"
+
+namespace domain {
+namespace {
+void test_cylindrical_side_sphere_two_encloses_sphere_one() {
+  INFO("CylindricalSideSphereTwoEnclosesSphereOne");
+  // Set up random number generator
+  MAKE_GENERATOR(gen);
+
+  std::uniform_real_distribution<> unit_dis(0.0, 1.0);
+  std::uniform_real_distribution<> interval_dis(-1.0, 1.0);
+  std::uniform_real_distribution<> angle_dis(0.0, 2.0 * M_PI);
+
+  // Choose some random centers for sphere_one and sphere_two
+  const std::array<double, 3> center_one = {
+      interval_dis(gen), interval_dis(gen), interval_dis(gen)};
+  CAPTURE(center_one);
+  const std::array<double, 3> center_two = {
+      interval_dis(gen), interval_dis(gen), interval_dis(gen)};
+  CAPTURE(center_two);
+  const double dist_between_spheres =
+      sqrt(square(center_two[0] - center_one[0]) +
+           square(center_two[1] - center_one[1]) +
+           square(center_two[2] - center_one[2]));
+
+  // Pick radius of sphere_one not too small compared to the distance
+  // between the centers.
+  const double radius_one = 0.3 * dist_between_spheres + unit_dis(gen);
+  CAPTURE(radius_one);
+
+  // Now construct sphere_two which we make sure encloses sphere_one,
+  // but doesn't have too large of a radius.
+  const double radius_two =
+      (unit_dis(gen) + 1.0) * (radius_one + dist_between_spheres);
+  CAPTURE(radius_two);
+
+  const std::array<double, 2> z_planes =
+      [&gen, &unit_dis, &center_one, &radius_one ]() noexcept {
+    // Make sure each z_plane intersects sphere_one in two locations;
+    // to do this, ensure that each plane is no closer than 5% of the
+    // radius to the min/max z-extents of sphere_one.
+    const double z_plane_1 =
+        center_one[2] - (0.95 * unit_dis(gen)) * radius_one;
+    const double z_plane_2 =
+        center_one[2] + (0.95 * unit_dis(gen)) * radius_one;
+    return std::array<double, 2>{z_plane_1, z_plane_2};
+  }
+  ();
+  CAPTURE(z_planes);
+
+  // Keep proj_center inside sphere_1 and between (or on) the z_planes.
+  const std::array<double, 3> proj_center = [
+    &z_planes, &center_one, &radius_one, &gen, &unit_dis, &angle_dis
+  ]() noexcept {
+    // Need proj_center between or on the z_planes.
+    const double z = z_planes[0] + (z_planes[1] - z_planes[0]) * unit_dis(gen);
+    // choose 0.95 so that proj_center is not on edge of sphere_one.
+    const double rho_max = 0.95 * radius_one *
+                           sqrt(1.0 - square((z - center_one[2]) / radius_one));
+    const double rho = unit_dis(gen) * rho_max;
+    const double phi = angle_dis(gen);
+    return std::array<double, 3>{center_one[0] + rho * cos(phi),
+                                 center_one[1] + rho * sin(phi), z};
+  }
+  ();
+  CAPTURE(proj_center);
+
+  const CoordinateMaps::CylindricalSide map(center_one, center_two, proj_center,
+                                            radius_one, radius_two, z_planes[0],
+                                            z_planes[1]);
+  test_suite_for_map_on_cylinder(map, 1.0, 2.0);
+}
+
+void test_cylindrical_side_sphere_one_encloses_sphere_two() {
+  INFO("CylindricalSideSphereOneEnclosesSphereTwo");
+  // Set up random number generator
+  MAKE_GENERATOR(gen);
+
+  std::uniform_real_distribution<> unit_dis(0.0, 1.0);
+  std::uniform_real_distribution<> interval_dis(-1.0, 1.0);
+  std::uniform_real_distribution<> angle_dis(0.0, 2.0 * M_PI);
+
+  // Choose some random center for sphere_one
+  const std::array<double, 3> center_one = {
+      interval_dis(gen), interval_dis(gen), interval_dis(gen)};
+  CAPTURE(center_one);
+
+  // Pick radius of sphere_one
+  const double radius_one = 1.5 * (1.0 + unit_dis(gen));
+  CAPTURE(radius_one);
+
+  // Make sure each z_plane intersects sphere_one in two locations;
+  // to do this, ensure that each plane is no closer than 5% of the
+  // radius to the min/max z-extents of sphere_one.
+  // Also make sure that each z_plane is not more than 20% away from
+  // the center of sphere_one (because we need to fit sphere_two between
+  // the planes).
+  const std::array<double, 2> z_planes =
+      [&gen, &unit_dis, &center_one, &radius_one ]() noexcept {
+    const double z_plane_1 =
+        center_one[2] - (0.2 + 0.75 * unit_dis(gen)) * radius_one;
+    const double z_plane_2 =
+        center_one[2] + (0.2 + 0.75 * unit_dis(gen)) * radius_one;
+    return std::array<double, 2>{z_plane_1, z_plane_2};
+  }
+  ();
+  CAPTURE(z_planes);
+
+  // Choose sphere_two to be fully contained inside the z_planes,
+  // and not too small.
+  const double radius_two =
+      (z_planes[1] - z_planes[0]) * 0.25 * (1.0 + unit_dis(gen));
+  CAPTURE(radius_two);
+
+  // Choose center_two so that sphere_two is contained inside sphere_one
+  // and inside the z_planes.
+  const std::array<double, 3> center_two = [&z_planes, &radius_one, &radius_two,
+                                            &center_one, &angle_dis, &unit_dis,
+                                            &gen]() noexcept {
+    const double center_two_z_min = z_planes[0] + radius_two;
+    const double center_two_z_max = z_planes[1] - radius_two;
+    const double center_two_z =
+        center_two_z_min +
+        (center_two_z_max - center_two_z_min) * unit_dis(gen);
+    // Choose 0.95 so that there is some space between sphere_one and
+    // sphere_two.
+    const double rho = 0.95 * unit_dis(gen) *
+                       sqrt(square(radius_one - radius_two) -
+                            square(center_one[2] - center_two_z));
+    const double phi = angle_dis(gen);
+    return std::array<double, 3>{center_one[0] + rho * cos(phi),
+                                 center_one[1] + rho * sin(phi), center_two_z};
+  }();
+  CAPTURE(center_two);
+
+  // Keep proj_center inside sphere_two.
+  const std::array<double, 3> proj_center = [&center_two, &radius_two, &gen,
+                                             &unit_dis, &angle_dis]() noexcept {
+    // choose 0.95 so that proj_center is not on edge of sphere_two.
+    const double r = 0.95 * radius_two * unit_dis(gen);
+    const double theta = 2.0 * angle_dis(gen);
+    const double phi = angle_dis(gen);
+    return std::array<double, 3>{center_two[0] + r * sin(theta) * cos(phi),
+                                 center_two[1] + r * sin(theta) * sin(phi),
+                                 center_two[2] + r * cos(theta)};
+  }();
+  CAPTURE(proj_center);
+
+  const CoordinateMaps::CylindricalSide map(center_one, center_two, proj_center,
+                                            radius_one, radius_two, z_planes[0],
+                                            z_planes[1]);
+  test_suite_for_map_on_cylinder(map, 1.0, 2.0);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.CylindricalSide",
+                  "[Domain][Unit]") {
+  test_cylindrical_side_sphere_two_encloses_sphere_one();
+  test_cylindrical_side_sphere_one_encloses_sphere_two();
+  CHECK(not CoordinateMaps::CylindricalSide{}.is_identity());
+}
+}  // namespace domain


### PR DESCRIPTION
## Proposed changes

This adds a map to be used for several blocks of a cylindrical binary domain: the blocks that form the sides of the cyinders.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
