### PR TITLE
Add characteristic helpers for NewtonianEuler limiters

### DIFF
--- a/src/Evolution/Systems/NewtonianEuler/CMakeLists.txt
+++ b/src/Evolution/Systems/NewtonianEuler/CMakeLists.txt
@@ -37,5 +37,6 @@ target_link_libraries(
   INTERFACE Hydro
   )
 
+add_subdirectory(Limiters)
 add_subdirectory(NumericalFluxes)
 add_subdirectory(Sources)

--- a/src/Evolution/Systems/NewtonianEuler/Limiters/CMakeLists.txt
+++ b/src/Evolution/Systems/NewtonianEuler/Limiters/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY NewtonianEulerLimiters)
+
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  CharacteristicHelpers.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  CharacteristicHelpers.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  Boost::boost
+  DataStructures
+  Domain
+  ErrorHandling
+  Limiters
+  NewtonianEuler
+  Utilities
+  )

--- a/src/Evolution/Systems/NewtonianEuler/Limiters/CharacteristicHelpers.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Limiters/CharacteristicHelpers.cpp
@@ -1,0 +1,285 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/NewtonianEuler/Limiters/CharacteristicHelpers.hpp"
+
+#include <array>
+#include <boost/functional/hash.hpp>  // IWYU pragma: keep
+#include <cstddef>
+#include <limits>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/Tags.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/Element.hpp"  // IWYU pragma: keep
+#include "Domain/Tags.hpp"               // IWYU pragma: keep
+#include "ErrorHandling/Assert.hpp"
+#include "Evolution/Systems/NewtonianEuler/Characteristics.hpp"
+#include "Evolution/Systems/NewtonianEuler/SoundSpeedSquared.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace NewtonianEuler::Limiters {
+
+template <size_t VolumeDim, size_t ThermodynamicDim>
+std::pair<Matrix, Matrix> right_and_left_eigenvectors(
+    const Scalar<double>& mean_density,
+    const tnsr::I<double, VolumeDim>& mean_momentum,
+    const Scalar<double>& mean_energy,
+    const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
+        equation_of_state,
+    const tnsr::i<double, VolumeDim>& unit_normal) noexcept {
+  // Compute fluid primitives from mean conserved state
+  const auto velocity = [&mean_density, &mean_momentum]() noexcept {
+    auto result = mean_momentum;
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      result.get(i) /= get(mean_density);
+    }
+    return result;
+  }();
+  const auto specific_internal_energy = [&mean_density, &mean_energy,
+                                         &mean_momentum]() noexcept {
+    auto result = mean_energy;
+    get(result) /= get(mean_density);
+    get(result) -= 0.5 * get(dot_product(mean_momentum, mean_momentum)) /
+                   square(get(mean_density));
+    return result;
+  }();
+
+  Scalar<double> pressure{};
+  Scalar<double> kappa_over_density{};
+  if constexpr (ThermodynamicDim == 1) {
+    pressure = equation_of_state.pressure_from_density(mean_density);
+    get(kappa_over_density) =
+        get(equation_of_state.kappa_times_p_over_rho_squared_from_density(
+            mean_density)) *
+        get(mean_density) / get(pressure);
+  } else if constexpr (ThermodynamicDim == 2) {
+    pressure = equation_of_state.pressure_from_density_and_energy(
+        mean_density, specific_internal_energy);
+    get(kappa_over_density) =
+        get(equation_of_state
+                .kappa_times_p_over_rho_squared_from_density_and_energy(
+                    mean_density, specific_internal_energy)) *
+        get(mean_density) / get(pressure);
+  }
+
+  const Scalar<double> specific_enthalpy{
+      {{(get(mean_energy) + get(pressure)) / get(mean_density)}}};
+  const Scalar<double> sound_speed_squared =
+      NewtonianEuler::sound_speed_squared(
+          mean_density, specific_internal_energy, equation_of_state);
+
+  return std::make_pair(right_eigenvectors<VolumeDim>(
+                            velocity, sound_speed_squared, specific_enthalpy,
+                            kappa_over_density, unit_normal),
+                        left_eigenvectors<VolumeDim>(
+                            velocity, sound_speed_squared, specific_enthalpy,
+                            kappa_over_density, unit_normal));
+}
+
+template <size_t VolumeDim>
+void characteristic_fields(
+    const gsl::not_null<tuples::TaggedTuple<
+        ::Tags::Mean<NewtonianEuler::Tags::VMinus>,
+        ::Tags::Mean<NewtonianEuler::Tags::VMomentum<VolumeDim>>,
+        ::Tags::Mean<NewtonianEuler::Tags::VPlus>>*>
+        char_means,
+    const tuples::TaggedTuple<
+        ::Tags::Mean<NewtonianEuler::Tags::MassDensityCons>,
+        ::Tags::Mean<NewtonianEuler::Tags::MomentumDensity<VolumeDim>>,
+        ::Tags::Mean<NewtonianEuler::Tags::EnergyDensity>>& cons_means,
+    const Matrix& left) noexcept {
+  auto& char_v_minus =
+      get<::Tags::Mean<NewtonianEuler::Tags::VMinus>>(*char_means);
+  auto& char_v_momentum =
+      get<::Tags::Mean<NewtonianEuler::Tags::VMomentum<VolumeDim>>>(
+          *char_means);
+  auto& char_v_plus =
+      get<::Tags::Mean<NewtonianEuler::Tags::VPlus>>(*char_means);
+
+  const auto& cons_mass_density =
+      get<::Tags::Mean<NewtonianEuler::Tags::MassDensityCons>>(cons_means);
+  const auto& cons_momentum_density =
+      get<::Tags::Mean<NewtonianEuler::Tags::MomentumDensity<VolumeDim>>>(
+          cons_means);
+  const auto& cons_energy_density =
+      get<::Tags::Mean<NewtonianEuler::Tags::EnergyDensity>>(cons_means);
+
+  get(char_v_minus) = left(0, 0) * get(cons_mass_density);
+  for (size_t j = 0; j < VolumeDim; ++j) {
+    char_v_momentum.get(j) = left(j + 1, 0) * get(cons_mass_density);
+  }
+  get(char_v_plus) = left(VolumeDim + 1, 0) * get(cons_mass_density);
+
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    get(char_v_minus) += left(0, i + 1) * cons_momentum_density.get(i);
+    for (size_t j = 0; j < VolumeDim; ++j) {
+      char_v_momentum.get(j) +=
+          left(j + 1, i + 1) * cons_momentum_density.get(i);
+    }
+    get(char_v_plus) +=
+        left(VolumeDim + 1, i + 1) * cons_momentum_density.get(i);
+  }
+
+  get(char_v_minus) += left(0, VolumeDim + 1) * get(cons_energy_density);
+  for (size_t j = 0; j < VolumeDim; ++j) {
+    char_v_momentum.get(j) +=
+        left(j + 1, VolumeDim + 1) * get(cons_energy_density);
+  }
+  get(char_v_plus) +=
+      left(VolumeDim + 1, VolumeDim + 1) * get(cons_energy_density);
+}
+
+template <size_t VolumeDim>
+void characteristic_fields(
+    const gsl::not_null<Scalar<DataVector>*> char_v_minus,
+    const gsl::not_null<tnsr::I<DataVector, VolumeDim>*> char_v_momentum,
+    const gsl::not_null<Scalar<DataVector>*> char_v_plus,
+    const Scalar<DataVector>& cons_mass_density,
+    const tnsr::I<DataVector, VolumeDim>& cons_momentum_density,
+    const Scalar<DataVector>& cons_energy_density,
+    const Matrix& left) noexcept {
+  get(*char_v_minus) = left(0, 0) * get(cons_mass_density);
+  for (size_t j = 0; j < VolumeDim; ++j) {
+    char_v_momentum->get(j) = left(j + 1, 0) * get(cons_mass_density);
+  }
+  get(*char_v_plus) = left(VolumeDim + 1, 0) * get(cons_mass_density);
+
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    get(*char_v_minus) += left(0, i + 1) * cons_momentum_density.get(i);
+    for (size_t j = 0; j < VolumeDim; ++j) {
+      char_v_momentum->get(j) +=
+          left(j + 1, i + 1) * cons_momentum_density.get(i);
+    }
+    get(*char_v_plus) +=
+        left(VolumeDim + 1, i + 1) * cons_momentum_density.get(i);
+  }
+
+  get(*char_v_minus) += left(0, VolumeDim + 1) * get(cons_energy_density);
+  for (size_t j = 0; j < VolumeDim; ++j) {
+    char_v_momentum->get(j) +=
+        left(j + 1, VolumeDim + 1) * get(cons_energy_density);
+  }
+  get(*char_v_plus) +=
+      left(VolumeDim + 1, VolumeDim + 1) * get(cons_energy_density);
+}
+
+template <size_t VolumeDim>
+void characteristic_fields(
+    const gsl::not_null<
+        Variables<tmpl::list<NewtonianEuler::Tags::VMinus,
+                             NewtonianEuler::Tags::VMomentum<VolumeDim>,
+                             NewtonianEuler::Tags::VPlus>>*>
+        char_vars,
+    const Variables<tmpl::list<NewtonianEuler::Tags::MassDensityCons,
+                               NewtonianEuler::Tags::MomentumDensity<VolumeDim>,
+                               NewtonianEuler::Tags::EnergyDensity>>& cons_vars,
+    const Matrix& left) noexcept {
+  characteristic_fields(
+      make_not_null(&get<NewtonianEuler::Tags::VMinus>(*char_vars)),
+      make_not_null(
+          &get<NewtonianEuler::Tags::VMomentum<VolumeDim>>(*char_vars)),
+      make_not_null(&get<NewtonianEuler::Tags::VPlus>(*char_vars)),
+      get<NewtonianEuler::Tags::MassDensityCons>(cons_vars),
+      get<NewtonianEuler::Tags::MomentumDensity<VolumeDim>>(cons_vars),
+      get<NewtonianEuler::Tags::EnergyDensity>(cons_vars), left);
+}
+
+template <size_t VolumeDim>
+void conserved_fields_from_characteristic_fields(
+    const gsl::not_null<Scalar<DataVector>*> cons_mass_density,
+    const gsl::not_null<tnsr::I<DataVector, VolumeDim>*> cons_momentum_density,
+    const gsl::not_null<Scalar<DataVector>*> cons_energy_density,
+    const Scalar<DataVector>& char_v_minus,
+    const tnsr::I<DataVector, VolumeDim>& char_v_momentum,
+    const Scalar<DataVector>& char_v_plus, const Matrix& right) noexcept {
+  get(*cons_mass_density) = right(0, 0) * get(char_v_minus);
+  for (size_t j = 0; j < VolumeDim; ++j) {
+    cons_momentum_density->get(j) = right(j + 1, 0) * get(char_v_minus);
+  }
+  get(*cons_energy_density) = right(VolumeDim + 1, 0) * get(char_v_minus);
+
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    get(*cons_mass_density) += right(0, i + 1) * char_v_momentum.get(i);
+    for (size_t j = 0; j < VolumeDim; ++j) {
+      cons_momentum_density->get(j) +=
+          right(j + 1, i + 1) * char_v_momentum.get(i);
+    }
+    get(*cons_energy_density) +=
+        right(VolumeDim + 1, i + 1) * char_v_momentum.get(i);
+  }
+
+  get(*cons_mass_density) += right(0, VolumeDim + 1) * get(char_v_plus);
+  for (size_t j = 0; j < VolumeDim; ++j) {
+    cons_momentum_density->get(j) +=
+        right(j + 1, VolumeDim + 1) * get(char_v_plus);
+  }
+  get(*cons_energy_density) +=
+      right(VolumeDim + 1, VolumeDim + 1) * get(char_v_plus);
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define THERMODIM(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                            \
+  template std::pair<Matrix, Matrix> right_and_left_eigenvectors(       \
+      const Scalar<double>&, const tnsr::I<double, DIM(data)>&,         \
+      const Scalar<double>&,                                            \
+      const EquationsOfState::EquationOfState<false, THERMODIM(data)>&, \
+      const tnsr::i<double, DIM(data)>&) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (1, 2))
+
+#undef THERMODIM
+#undef INSTANTIATE
+
+#define INSTANTIATE(_, data)                                               \
+  template void characteristic_fields(                                     \
+      const gsl::not_null<tuples::TaggedTuple<                             \
+          ::Tags::Mean<NewtonianEuler::Tags::VMinus>,                      \
+          ::Tags::Mean<NewtonianEuler::Tags::VMomentum<DIM(data)>>,        \
+          ::Tags::Mean<NewtonianEuler::Tags::VPlus>>*>,                    \
+      const tuples::TaggedTuple<                                           \
+          ::Tags::Mean<NewtonianEuler::Tags::MassDensityCons>,             \
+          ::Tags::Mean<NewtonianEuler::Tags::MomentumDensity<DIM(data)>>,  \
+          ::Tags::Mean<NewtonianEuler::Tags::EnergyDensity>>&,             \
+      const Matrix&) noexcept;                                             \
+  template void characteristic_fields(                                     \
+      const gsl::not_null<Scalar<DataVector>*>,                            \
+      const gsl::not_null<tnsr::I<DataVector, DIM(data)>*>,                \
+      const gsl::not_null<Scalar<DataVector>*>, const Scalar<DataVector>&, \
+      const tnsr::I<DataVector, DIM(data)>&, const Scalar<DataVector>&,    \
+      const Matrix&) noexcept;                                             \
+  template void characteristic_fields(                                     \
+      const gsl::not_null<                                                 \
+          Variables<tmpl::list<NewtonianEuler::Tags::VMinus,               \
+                               NewtonianEuler::Tags::VMomentum<DIM(data)>, \
+                               NewtonianEuler::Tags::VPlus>>*>,            \
+      const Variables<                                                     \
+          tmpl::list<NewtonianEuler::Tags::MassDensityCons,                \
+                     NewtonianEuler::Tags::MomentumDensity<DIM(data)>,     \
+                     NewtonianEuler::Tags::EnergyDensity>>&,               \
+      const Matrix&) noexcept;                                             \
+  template void conserved_fields_from_characteristic_fields(               \
+      const gsl::not_null<Scalar<DataVector>*>,                            \
+      const gsl::not_null<tnsr::I<DataVector, DIM(data)>*>,                \
+      const gsl::not_null<Scalar<DataVector>*>, const Scalar<DataVector>&, \
+      const tnsr::I<DataVector, DIM(data)>&, const Scalar<DataVector>&,    \
+      const Matrix&) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATE
+
+}  // namespace NewtonianEuler::Limiters

--- a/src/Evolution/Systems/NewtonianEuler/Limiters/CharacteristicHelpers.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Limiters/CharacteristicHelpers.hpp
@@ -1,0 +1,109 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/Tags.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/NewtonianEuler/Characteristics.hpp"
+#include "Evolution/Systems/NewtonianEuler/SoundSpeedSquared.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace NewtonianEuler::Limiters {
+
+/*!
+ * \brief Compute the transform matrices between the conserved variables and
+ * the characteristic variables of the NewtonianEuler system.
+ *
+ * Wraps calls to `NewtonianEuler::right_eigenvectors` and
+ * `NewtonianEuler::left_eigenvectors`.
+ */
+template <size_t VolumeDim, size_t ThermodynamicDim>
+std::pair<Matrix, Matrix> right_and_left_eigenvectors(
+    const Scalar<double>& mean_density,
+    const tnsr::I<double, VolumeDim>& mean_momentum,
+    const Scalar<double>& mean_energy,
+    const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
+        equation_of_state,
+    const tnsr::i<double, VolumeDim>& unit_normal) noexcept;
+
+// @{
+/// \brief Compute characteristic fields from conserved fields
+///
+/// Note that these functions apply the same transformation to every grid point
+/// in the element, using the same matrix from `left_eigenvectors`.
+/// This is in contrast to the characteristic transformation used in the
+/// GeneralizedHarmonic upwind flux, which is computed pointwise.
+///
+/// By using a fixed matrix of eigenvectors computed from the cell-averaged
+/// fields, we ensure we can consistently transform back from the characteristic
+/// variables even after applying the limiter (the limiter changes the pointwise
+/// values but preserves the cell averages).
+template <size_t VolumeDim>
+void characteristic_fields(
+    gsl::not_null<tuples::TaggedTuple<
+        ::Tags::Mean<NewtonianEuler::Tags::VMinus>,
+        ::Tags::Mean<NewtonianEuler::Tags::VMomentum<VolumeDim>>,
+        ::Tags::Mean<NewtonianEuler::Tags::VPlus>>*>
+        char_means,
+    const tuples::TaggedTuple<
+        ::Tags::Mean<NewtonianEuler::Tags::MassDensityCons>,
+        ::Tags::Mean<NewtonianEuler::Tags::MomentumDensity<VolumeDim>>,
+        ::Tags::Mean<NewtonianEuler::Tags::EnergyDensity>>& cons_means,
+    const Matrix& left) noexcept;
+
+template <size_t VolumeDim>
+void characteristic_fields(
+    gsl::not_null<Scalar<DataVector>*> char_v_minus,
+    gsl::not_null<tnsr::I<DataVector, VolumeDim>*> char_v_momentum,
+    gsl::not_null<Scalar<DataVector>*> char_v_plus,
+    const Scalar<DataVector>& cons_mass_density,
+    const tnsr::I<DataVector, VolumeDim>& cons_momentum_density,
+    const Scalar<DataVector>& cons_energy_density, const Matrix& left) noexcept;
+
+template <size_t VolumeDim>
+void characteristic_fields(
+    gsl::not_null<
+        Variables<tmpl::list<NewtonianEuler::Tags::VMinus,
+                             NewtonianEuler::Tags::VMomentum<VolumeDim>,
+                             NewtonianEuler::Tags::VPlus>>*>
+        char_vars,
+    const Variables<tmpl::list<NewtonianEuler::Tags::MassDensityCons,
+                               NewtonianEuler::Tags::MomentumDensity<VolumeDim>,
+                               NewtonianEuler::Tags::EnergyDensity>>& cons_vars,
+    const Matrix& left) noexcept;
+// @}
+
+/// \brief Compute conserved fields from characteristic fields
+///
+/// Note that this function applies the same transformation to every grid point
+/// in the element, using the same matrix from `right_eigenvectors`.
+/// This is in contrast to the characteristic transformation used in the
+/// GeneralizedHarmonic upwind flux, which is computed pointwise.
+///
+/// By using a fixed matrix of eigenvectors computed from the cell-averaged
+/// fields, we ensure we can consistently transform back from the characteristic
+/// variables even after applying the limiter (the limiter changes the pointwise
+/// values but preserves the cell averages).
+template <size_t VolumeDim>
+void conserved_fields_from_characteristic_fields(
+    gsl::not_null<Scalar<DataVector>*> cons_mass_density,
+    gsl::not_null<tnsr::I<DataVector, VolumeDim>*> cons_momentum_density,
+    gsl::not_null<Scalar<DataVector>*> cons_energy_density,
+    const Scalar<DataVector>& char_v_minus,
+    const tnsr::I<DataVector, VolumeDim>& char_v_momentum,
+    const Scalar<DataVector>& char_v_plus, const Matrix& right) noexcept;
+
+}  // namespace NewtonianEuler::Limiters

--- a/src/Evolution/Systems/NewtonianEuler/Tags.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Tags.hpp
@@ -21,12 +21,6 @@ namespace NewtonianEuler {
 /// %Tags for the conservative formulation of the Newtonian Euler system
 namespace Tags {
 
-/// The characteristic speeds.
-template <size_t Dim>
-struct CharacteristicSpeeds : db::SimpleTag {
-  using type = std::array<DataVector, Dim + 2>;
-};
-
 /// The mass density of the fluid.
 template <typename DataType>
 struct MassDensity : db::SimpleTag {
@@ -84,6 +78,26 @@ template <typename DataType>
 struct SoundSpeedSquared : db::SimpleTag {
   using type = Scalar<DataType>;
 };
+
+/// The characteristic speeds.
+template <size_t Dim>
+struct CharacteristicSpeeds : db::SimpleTag {
+  using type = std::array<DataVector, Dim + 2>;
+};
+
+// @{
+/// The characteristic fields of the NewtonianEuler system.
+struct VMinus : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+template <size_t Dim>
+struct VMomentum : db::SimpleTag {
+  using type = tnsr::I<DataVector, Dim>;
+};
+struct VPlus : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+// @}
 
 /// Base tag for the source term
 struct SourceTermBase : db::BaseTag {};

--- a/src/Evolution/Systems/NewtonianEuler/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/TagsDeclarations.hpp
@@ -10,8 +10,7 @@
 /// \cond
 namespace NewtonianEuler {
 namespace Tags {
-template <size_t Dim>
-struct CharacteristicSpeeds;
+
 template <typename DataType>
 struct MassDensity;
 struct MassDensityCons;
@@ -29,9 +28,17 @@ struct SoundSpeed;
 template <typename DataType>
 struct SoundSpeedSquared;
 
+template <size_t Dim>
+struct CharacteristicSpeeds;
+struct VMinus;
+template <size_t Dim>
+struct VMomentum;
+struct VPlus;
+
 struct SourceTermBase;
 template <typename InitialDataType>
 struct SourceTerm;
+
 }  // namespace Tags
 }  // namespace NewtonianEuler
 /// \endcond

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
+add_subdirectory(Limiters)
 add_subdirectory(NumericalFluxes)
 add_subdirectory(Sources)
 

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_NewtonianEulerLimiters")
+
+set(LIBRARY_SOURCES
+  Test_CharacteristicHelpers.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "Evolution/Systems/NewtonianEuler/Limiters"
+  "${LIBRARY_SOURCES}"
+  "NewtonianEulerLimiters"
+  )

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/Test_CharacteristicHelpers.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/Test_CharacteristicHelpers.cpp
@@ -1,0 +1,163 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/NewtonianEuler/Limiters/CharacteristicHelpers.hpp"
+#include "Evolution/Systems/NewtonianEuler/SoundSpeedSquared.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/Limiters/TestHelpers.hpp"
+#include "NumericalAlgorithms/LinearOperators/MeanValue.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
+
+namespace {
+
+template <size_t Dim>
+void test_characteristic_helpers() noexcept {
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> distribution(-1., 1.);
+  std::uniform_real_distribution<> distribution_positive(1e-3, 1.);
+
+  const auto nn_generator = make_not_null(&generator);
+  const auto nn_distribution = make_not_null(&distribution);
+  const auto nn_distribution_positive = make_not_null(&distribution_positive);
+
+  // This computes a unit normal. It is NOT uniformly distributed in angle,
+  // but for this test the angular distribution is not important.
+  const auto unit_normal = [&nn_generator, &nn_distribution]() noexcept {
+    const double double_used_for_size = 0.;
+    auto result = make_with_random_values<tnsr::i<double, Dim>>(
+        nn_generator, nn_distribution, double_used_for_size);
+    double normal_magnitude = get(magnitude(result));
+    // Though highly unlikely, the normal could have length nearly 0. If this
+    // happens, we edit the normal to make it non-zero.
+    if (normal_magnitude < 1e-3) {
+      get<0>(result) += 0.9;
+      normal_magnitude = get(magnitude(result));
+    }
+    for (auto& n_i : result) {
+      n_i /= normal_magnitude;
+    }
+    return result;
+  }();
+
+  const Mesh<Dim> mesh(3, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto);
+  const DataVector used_for_size(pow<Dim>(3), 0.);
+
+  // Derive all fluid quantities from the primitive variables
+  const auto density = make_with_random_values<Scalar<DataVector>>(
+      nn_generator, nn_distribution_positive, used_for_size);
+  const auto velocity = make_with_random_values<tnsr::I<DataVector, Dim>>(
+      nn_generator, nn_distribution, used_for_size);
+  const auto specific_internal_energy =
+      make_with_random_values<Scalar<DataVector>>(
+          nn_generator, nn_distribution_positive, used_for_size);
+
+  const EquationsOfState::IdealFluid<false> equation_of_state{5. / 3.};
+  const auto pressure = equation_of_state.pressure_from_density_and_energy(
+      density, specific_internal_energy);
+
+  const Scalar<DataVector>& mass_density = density;
+  const tnsr::I<DataVector, Dim> momentum_density = [&density,
+                                                     &velocity]() noexcept {
+    auto result = velocity;
+    for (size_t i = 0; i < Dim; ++i) {
+      result.get(i) *= get(density);
+    }
+    return result;
+  }();
+  const Scalar<DataVector> energy_density{
+      get(density) * (get(specific_internal_energy) +
+                      0.5 * get(dot_product(velocity, velocity)))};
+
+  const Scalar<double> mean_mass_density{mean_value(get(mass_density), mesh)};
+  const tnsr::I<double, Dim> mean_momentum_density = [&momentum_density,
+                                                      &mesh]() noexcept {
+    tnsr::I<double, Dim> result{};
+    for (size_t i = 0; i < Dim; ++i) {
+      result.get(i) = mean_value(momentum_density.get(i), mesh);
+    }
+    return result;
+  }();
+  const Scalar<double> mean_energy_density{
+      mean_value(get(energy_density), mesh)};
+
+  const auto right_and_left =
+      NewtonianEuler::Limiters::right_and_left_eigenvectors<Dim>(
+          mean_mass_density, mean_momentum_density, mean_energy_density,
+          equation_of_state, unit_normal);
+  const auto& right = right_and_left.first;
+  const auto& left = right_and_left.second;
+
+  // First test that the tensor-transform helpers are inverses of each
+  // other. This is a sanity check of the two tensor-transform helpers and
+  // of right_and_left_eigenvectors.
+  Scalar<DataVector> v_minus{};
+  tnsr::I<DataVector, Dim> v_momentum{};
+  Scalar<DataVector> v_plus{};
+  NewtonianEuler::Limiters::characteristic_fields(
+      make_not_null(&v_minus), make_not_null(&v_momentum),
+      make_not_null(&v_plus), mass_density, momentum_density, energy_density,
+      left);
+  Scalar<DataVector> recovered_mass_density{};
+  tnsr::I<DataVector, Dim> recovered_momentum_density{};
+  Scalar<DataVector> recovered_energy_density{};
+  NewtonianEuler::Limiters::conserved_fields_from_characteristic_fields(
+      make_not_null(&recovered_mass_density),
+      make_not_null(&recovered_momentum_density),
+      make_not_null(&recovered_energy_density), v_minus, v_momentum, v_plus,
+      right);
+  CHECK_ITERABLE_APPROX(mass_density, recovered_mass_density);
+  CHECK_ITERABLE_APPROX(momentum_density, recovered_momentum_density);
+  CHECK_ITERABLE_APPROX(energy_density, recovered_energy_density);
+
+  // Test that the cell-average helper matches the tensor helper
+  tuples::TaggedTuple<Tags::Mean<NewtonianEuler::Tags::VMinus>,
+                      Tags::Mean<NewtonianEuler::Tags::VMomentum<Dim>>,
+                      Tags::Mean<NewtonianEuler::Tags::VPlus>>
+      mean_char_vars;
+  NewtonianEuler::Limiters::characteristic_fields(
+      make_not_null(&mean_char_vars),
+      {mean_mass_density, mean_momentum_density, mean_energy_density}, left);
+  CHECK(get(get<Tags::Mean<NewtonianEuler::Tags::VMinus>>(mean_char_vars)) ==
+        approx(mean_value(get(v_minus), mesh)));
+  for (size_t i = 0; i < Dim; ++i) {
+    CHECK(get<Tags::Mean<NewtonianEuler::Tags::VMomentum<Dim>>>(mean_char_vars)
+              .get(i) == approx(mean_value(v_momentum.get(i), mesh)));
+  }
+  CHECK(get(get<Tags::Mean<NewtonianEuler::Tags::VPlus>>(mean_char_vars)) ==
+        approx(mean_value(get(v_plus), mesh)));
+
+  // Test that the Variables helper matches the tensor helper
+  Variables<tmpl::list<NewtonianEuler::Tags::VMinus,
+                       NewtonianEuler::Tags::VMomentum<Dim>,
+                       NewtonianEuler::Tags::VPlus>>
+      char_vars(mesh.number_of_grid_points());
+  Variables<tmpl::list<NewtonianEuler::Tags::MassDensityCons,
+                       NewtonianEuler::Tags::MomentumDensity<Dim>,
+                       NewtonianEuler::Tags::EnergyDensity>>
+      cons_vars(mesh.number_of_grid_points());
+  get<NewtonianEuler::Tags::MassDensityCons>(cons_vars) = mass_density;
+  get<NewtonianEuler::Tags::MomentumDensity<Dim>>(cons_vars) = momentum_density;
+  get<NewtonianEuler::Tags::EnergyDensity>(cons_vars) = energy_density;
+  NewtonianEuler::Limiters::characteristic_fields(make_not_null(&char_vars),
+                                                  cons_vars, left);
+  CHECK_ITERABLE_APPROX(get<NewtonianEuler::Tags::VMinus>(char_vars), v_minus);
+  CHECK_ITERABLE_APPROX(get<NewtonianEuler::Tags::VMomentum<Dim>>(char_vars),
+                        v_momentum);
+  CHECK_ITERABLE_APPROX(get<NewtonianEuler::Tags::VPlus>(char_vars), v_plus);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.NewtonianEuler.Limiters.CharacteristicHelpers",
+    "[Unit][Evolution]") {
+  test_characteristic_helpers<1>();
+  test_characteristic_helpers<2>();
+  test_characteristic_helpers<3>();
+}

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Tags.cpp
@@ -19,8 +19,6 @@ struct SomeInitialDataType {
 namespace {
 template <size_t Dim>
 void test_tags() noexcept {
-  TestHelpers::db::test_simple_tag<
-      NewtonianEuler::Tags::CharacteristicSpeeds<Dim>>("CharacteristicSpeeds");
   TestHelpers::db::test_simple_tag<NewtonianEuler::Tags::MassDensityCons>(
       "MassDensityCons");
   TestHelpers::db::test_simple_tag<
@@ -42,6 +40,12 @@ void test_tags() noexcept {
       NewtonianEuler::Tags::SoundSpeed<DataVector>>("SoundSpeed");
   TestHelpers::db::test_simple_tag<
       NewtonianEuler::Tags::SoundSpeedSquared<DataVector>>("SoundSpeedSquared");
+  TestHelpers::db::test_simple_tag<
+      NewtonianEuler::Tags::CharacteristicSpeeds<Dim>>("CharacteristicSpeeds");
+  TestHelpers::db::test_simple_tag<NewtonianEuler::Tags::VMinus>("VMinus");
+  TestHelpers::db::test_simple_tag<NewtonianEuler::Tags::VMomentum<Dim>>(
+      "VMomentum");
+  TestHelpers::db::test_simple_tag<NewtonianEuler::Tags::VPlus>("VPlus");
   TestHelpers::db::test_base_tag<NewtonianEuler::Tags::SourceTermBase>(
       "SourceTermBase");
   TestHelpers::db::test_simple_tag<


### PR DESCRIPTION
## Proposed changes

Adds helper functions to transform between conserved and characteristic variables as will be needed in the limiter code.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

