### PR TITLE
Add iterators over hypercube vertices and edges

### DIFF
--- a/src/Domain/Structure/CMakeLists.txt
+++ b/src/Domain/Structure/CMakeLists.txt
@@ -13,6 +13,7 @@ spectre_target_sources(
   Direction.cpp
   Element.cpp
   ElementId.cpp
+  Hypercube.cpp
   InitialElementIds.cpp
   Neighbors.cpp
   OrientationMap.cpp
@@ -32,6 +33,7 @@ spectre_target_headers(
   DirectionMap.hpp
   Element.hpp
   ElementId.hpp
+  Hypercube.hpp
   IndexToSliceAt.hpp
   InitialElementIds.hpp
   MaxNumberOfNeighbors.hpp

--- a/src/Domain/Structure/Hypercube.cpp
+++ b/src/Domain/Structure/Hypercube.cpp
@@ -1,0 +1,256 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Structure/Hypercube.hpp"
+
+#include <algorithm>
+#include <array>
+#include <bitset>
+#include <cstddef>
+#include <ostream>
+
+#include "Domain/Structure/Side.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+template <size_t ElementDim, size_t HypercubeDim>
+HypercubeElement<ElementDim, HypercubeDim>::HypercubeElement(
+    std::array<size_t, ElementDim> dimensions_in_parent,
+    std::array<Side, HypercubeDim - ElementDim> index) noexcept
+    : dimensions_in_parent_{std::move(dimensions_in_parent)},
+      index_{std::move(index)} {
+  ASSERT(
+      not std::any_of(
+          dimensions_in_parent_.begin(), dimensions_in_parent_.end(),
+          [](const size_t d) noexcept { return d >= HypercubeDim; }),
+      "Found dimension that exceeds the hypercube dimension in construction of "
+          << HypercubeDim << "D element: " << dimensions_in_parent_);
+  if constexpr (ElementDim > 1) {
+    std::sort(dimensions_in_parent_.begin(), dimensions_in_parent_.end());
+    ASSERT(
+        [this]() noexcept {
+          for (size_t d = 1; d < ElementDim; ++d) {
+            if (gsl::at(dimensions_in_parent_, d) ==
+                gsl::at(dimensions_in_parent_, d - 1)) {
+              return false;
+            }
+          }
+          return true;
+        }(),
+        "Found repeated dimension in construction of hypercube element: "
+            << dimensions_in_parent_ << " (sorted)");
+  }
+}
+
+template <size_t ElementDim, size_t HypercubeDim>
+template <size_t LocalElementDim, Requires<LocalElementDim == 0>>
+HypercubeElement<ElementDim, HypercubeDim>::HypercubeElement(
+    std::array<Side, HypercubeDim> index) noexcept
+    : index_{std::move(index)} {}
+
+template <size_t ElementDim, size_t HypercubeDim>
+template <size_t LocalElementDim, Requires<LocalElementDim == 1>>
+HypercubeElement<ElementDim, HypercubeDim>::HypercubeElement(
+    size_t dim_in_parent, std::array<Side, HypercubeDim - 1> index) noexcept
+    : dimensions_in_parent_{dim_in_parent}, index_{std::move(index)} {
+  ASSERT(dim_in_parent < HypercubeDim,
+         "Dimension " << dim_in_parent << " exceeds hypercube dimension in "
+                      << HypercubeDim << "D");
+}
+
+template <size_t ElementDim, size_t HypercubeDim>
+const std::array<size_t, ElementDim>&
+HypercubeElement<ElementDim, HypercubeDim>::dimensions_in_parent() const
+    noexcept {
+  return dimensions_in_parent_;
+}
+
+template <size_t ElementDim, size_t HypercubeDim>
+template <size_t LocalElementDim, Requires<LocalElementDim == 1>>
+size_t HypercubeElement<ElementDim, HypercubeDim>::dimension_in_parent() const
+    noexcept {
+  return dimensions_in_parent_[0];
+}
+
+template <size_t ElementDim, size_t HypercubeDim>
+const std::array<Side, HypercubeDim - ElementDim>&
+HypercubeElement<ElementDim, HypercubeDim>::index() const noexcept {
+  return index_;
+}
+
+template <size_t ElementDim, size_t HypercubeDim>
+const Side&
+HypercubeElement<ElementDim, HypercubeDim>::side_in_parent_dimension(
+    size_t d) const noexcept {
+  ASSERT(not std::any_of(dimensions_in_parent_.begin(),
+                         dimensions_in_parent_.end(),
+                         [&d](const size_t dim_in_parent) noexcept {
+                           return dim_in_parent == d;
+                         }),
+         "The parent dimension "
+             << d << " is aligned with the hypercube element '" << *this
+             << "', so the element is not located at a particular side in this "
+                "dimension.");
+  for (size_t dim_in_element = ElementDim; dim_in_element > 0;
+       --dim_in_element) {
+    if (gsl::at(dimensions_in_parent_, dim_in_element - 1) <= d) {
+      --d;
+    }
+  }
+  return gsl::at(index_, d);
+}
+
+template <size_t ElementDim, size_t HypercubeDim>
+std::ostream& operator<<(
+    std::ostream& os,
+    const HypercubeElement<ElementDim, HypercubeDim>& element) noexcept {
+  if constexpr (ElementDim == 0) {
+    os << "Vertex";
+  } else if constexpr (ElementDim == 1) {
+    os << "Edge";
+  } else if constexpr (ElementDim == 2) {
+    os << "Face";
+  } else if constexpr (ElementDim == 3) {
+    os << "Cell";
+  } else {
+    os << ElementDim << "-face";
+  }
+  return os << HypercubeDim << "D[" << element.dimensions_in_parent() << ","
+            << element.index() << "]";
+}
+
+template <size_t ElementDim, size_t HypercubeDim>
+HypercubeElementsIterator<ElementDim,
+                          HypercubeDim>::HypercubeElementsIterator() noexcept
+    : index_{0} {
+  if constexpr (ElementDim > 0) {
+    for (size_t d = 0; d < ElementDim; ++d) {
+      gsl::at(dimensions_in_parent_, d) = d;
+    }
+  }
+}
+
+template <size_t ElementDim, size_t HypercubeDim>
+HypercubeElementsIterator<ElementDim, HypercubeDim>
+HypercubeElementsIterator<ElementDim, HypercubeDim>::begin() noexcept {
+  return {};
+}
+
+template <size_t ElementDim, size_t HypercubeDim>
+HypercubeElementsIterator<ElementDim, HypercubeDim>
+HypercubeElementsIterator<ElementDim, HypercubeDim>::end() noexcept {
+  HypercubeElementsIterator end_iterator{};
+  if constexpr (ElementDim > 0) {
+    for (size_t d = 0; d < ElementDim; ++d) {
+      gsl::at(end_iterator.dimensions_in_parent_, d) = num_indices + d + 1;
+    }
+  } else {
+    end_iterator.index_ = two_to_the(num_indices);
+  }
+  return end_iterator;
+}
+
+template <size_t ElementDim, size_t HypercubeDim>
+template <size_t LocalElementDim, Requires<(LocalElementDim > 0)>>
+void HypercubeElementsIterator<ElementDim, HypercubeDim>::
+    increment_dimension_in_parent(const size_t d) noexcept {
+  ++gsl::at(dimensions_in_parent_, d);
+  if (gsl::at(dimensions_in_parent_, d) == num_indices + d + 1 and d > 0) {
+    increment_dimension_in_parent(d - 1);
+    gsl::at(dimensions_in_parent_, d) =
+        gsl::at(dimensions_in_parent_, d - 1) + 1;
+  }
+}
+
+template <size_t ElementDim, size_t HypercubeDim>
+HypercubeElementsIterator<ElementDim, HypercubeDim>&
+HypercubeElementsIterator<ElementDim, HypercubeDim>::operator++() noexcept {
+  ++index_;
+  if constexpr (ElementDim > 0) {
+    if (index_ == two_to_the(num_indices)) {
+      index_ = 0;
+      increment_dimension_in_parent(ElementDim - 1);
+    }
+  }
+  return *this;
+}
+
+template <size_t ElementDim, size_t HypercubeDim>
+// NOLINTNEXTLINE(cert-dcl21-cpp) see declaration
+HypercubeElementsIterator<ElementDim, HypercubeDim>
+HypercubeElementsIterator<ElementDim, HypercubeDim>::operator++(int) noexcept {
+  const auto ret = *this;
+  operator++();
+  return ret;
+}
+
+template <size_t ElementDim, size_t HypercubeDim>
+HypercubeElement<ElementDim, HypercubeDim>
+    HypercubeElementsIterator<ElementDim, HypercubeDim>::operator*() const
+    noexcept {
+  const std::bitset<num_indices> index_bits{index_};
+  std::array<Side, num_indices> sides{};
+  for (size_t d = 0; d < num_indices; ++d) {
+    gsl::at(sides, d) = index_bits[d] ? Side::Upper : Side::Lower;
+  }
+  return HypercubeElement<ElementDim, HypercubeDim>{dimensions_in_parent_,
+                                                    std::move(sides)};
+}
+
+template <size_t ElementDim, size_t HypercubeDim>
+bool operator==(
+    const HypercubeElementsIterator<ElementDim, HypercubeDim>& lhs,
+    const HypercubeElementsIterator<ElementDim, HypercubeDim>& rhs) noexcept {
+  return lhs.dimensions_in_parent_ == rhs.dimensions_in_parent_ and
+         lhs.index_ == rhs.index_;
+}
+
+template <size_t ElementDim, size_t HypercubeDim>
+bool operator!=(
+    const HypercubeElementsIterator<ElementDim, HypercubeDim>& lhs,
+    const HypercubeElementsIterator<ElementDim, HypercubeDim>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+/// \cond
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define INSTANTIATE(ELEMENT_DIM, HYPERCUBE_DIM)                              \
+  template struct HypercubeElement<ELEMENT_DIM, HYPERCUBE_DIM>;              \
+  template std::ostream& operator<<(                                         \
+      std::ostream& os,                                                      \
+      const HypercubeElement<ELEMENT_DIM, HYPERCUBE_DIM>& element) noexcept; \
+  template struct HypercubeElementsIterator<ELEMENT_DIM, HYPERCUBE_DIM>;     \
+  template bool operator==(                                                  \
+      const HypercubeElementsIterator<ELEMENT_DIM, HYPERCUBE_DIM>& lhs,      \
+      const HypercubeElementsIterator<ELEMENT_DIM, HYPERCUBE_DIM>&           \
+          rhs) noexcept;                                                     \
+  template bool operator!=(                                                  \
+      const HypercubeElementsIterator<ELEMENT_DIM, HYPERCUBE_DIM>& lhs,      \
+      const HypercubeElementsIterator<ELEMENT_DIM, HYPERCUBE_DIM>&           \
+          rhs) noexcept;
+#define INSTANTIATE_VERTEX(r, data)                          \
+  INSTANTIATE(0, DIM(data))                                  \
+  template HypercubeElement<0, DIM(data)>::HypercubeElement( \
+      std::array<Side, DIM(data)>);
+#define INSTANTIATE_EDGE(r, data)                                       \
+  INSTANTIATE(1, DIM(data))                                             \
+  template HypercubeElement<1, DIM(data)>::HypercubeElement(            \
+      size_t, std::array<Side, DIM(data) - 1>);                         \
+  template size_t HypercubeElement<1, DIM(data)>::dimension_in_parent() \
+      const noexcept;
+#define INSTANTIATE_FACE(r, data) INSTANTIATE(2, DIM(data))
+#define INSTANTIATE_CELL(r, data) INSTANTIATE(3, DIM(data))
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_VERTEX, (0, 1, 2, 3))
+GENERATE_INSTANTIATIONS(INSTANTIATE_EDGE, (1, 2, 3))
+GENERATE_INSTANTIATIONS(INSTANTIATE_FACE, (2, 3))
+GENERATE_INSTANTIATIONS(INSTANTIATE_CELL, (3))
+
+#undef DIM
+#undef INSTANTIATE
+#undef INSTANTIATE_VERTEX
+#undef INSTANTIATE_EDGE
+#undef INSTANTIATE_FACE
+#undef INSTANTIATE_CELL
+/// \endcond

--- a/src/Domain/Structure/Hypercube.hpp
+++ b/src/Domain/Structure/Hypercube.hpp
@@ -1,0 +1,188 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <ostream>
+
+#include "Domain/Structure/Side.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/StdHelpers.hpp"
+
+/*!
+ * \brief An element of dimension `ElementDim` on the boundary of a hypercube of
+ * dimension `HypercubeDim`
+ *
+ * A hypercube of dimension \f$n\f$ (`HypercubeDim`) is composed of
+ * \f$2^{n-k}\binom{n}{k}\f$ elements of dimension \f$k \leq n\f$
+ * (`ElementDim`). For example, a 3D cube has 8 vertices (\f$k=0\f$), 12 edges
+ * (\f$k=1\f$), 6 faces (\f$k=2\f$) and 1 cell (\f$k=3\f$). Each element is
+ * identified by the \f$k\f$ dimensions it shares with the parent hypercube
+ * and \f$n - k\f$ indices that specify whether it is located on the lower or
+ * upper side of the parent hypercube's remaining dimensions.
+ */
+template <size_t ElementDim, size_t HypercubeDim>
+struct HypercubeElement {
+  static_assert(ElementDim <= HypercubeDim);
+
+  HypercubeElement(std::array<size_t, ElementDim> dimensions_in_parent,
+                   std::array<Side, HypercubeDim - ElementDim> index) noexcept;
+
+  template <size_t NumIndices = HypercubeDim - ElementDim,
+            Requires<NumIndices == 0> = nullptr>
+  HypercubeElement() noexcept {
+    for (size_t d = 0; d < ElementDim; ++d) {
+      gsl::at(dimensions_in_parent_, d) = d;
+    }
+  }
+
+  template <size_t LocalElementDim = ElementDim,
+            Requires<LocalElementDim == 0> = nullptr>
+  explicit HypercubeElement(std::array<Side, HypercubeDim> index) noexcept;
+
+  template <typename... Indices, size_t LocalElementDim = ElementDim,
+            size_t LocalHypercubeDim = HypercubeDim,
+            Requires<(LocalElementDim == 0 and LocalHypercubeDim > 0 and
+                      sizeof...(Indices) == LocalHypercubeDim)> = nullptr>
+  explicit HypercubeElement(Indices... indices) noexcept
+      : index_{{static_cast<Side>(indices)...}} {}
+
+  template <size_t LocalElementDim = ElementDim,
+            Requires<LocalElementDim == 1> = nullptr>
+  HypercubeElement(size_t dim_in_parent,
+                   std::array<Side, HypercubeDim - 1> index) noexcept;
+
+  // @{
+  /// The parent hypercube's dimensions that this element shares
+  const std::array<size_t, ElementDim>& dimensions_in_parent() const noexcept;
+
+  template <size_t LocalElementDim = ElementDim,
+            Requires<LocalElementDim == 1> = nullptr>
+  size_t dimension_in_parent() const noexcept;
+  // @}
+
+  // @{
+  /// Whether this element is located on the lower or upper side in those
+  /// dimensions that it does not share with its parent hypercube
+  const std::array<Side, HypercubeDim - ElementDim>& index() const noexcept;
+
+  const Side& side_in_parent_dimension(size_t d) const noexcept;
+
+  template <size_t NumIndices = HypercubeDim - ElementDim,
+            Requires<NumIndices == 1> = nullptr>
+  const Side& side() const noexcept {
+    return index_[0];
+  }
+  // @}
+
+  bool operator==(const HypercubeElement& rhs) const noexcept {
+    return dimensions_in_parent_ == rhs.dimensions_in_parent_ and
+           index_ == rhs.index_;
+  }
+
+  bool operator!=(const HypercubeElement& rhs) const noexcept {
+    return not(*this == rhs);
+  }
+
+ private:
+  std::array<size_t, ElementDim> dimensions_in_parent_{};
+  std::array<Side, HypercubeDim - ElementDim> index_{};
+};
+
+template <size_t ElementDim, size_t HypercubeDim>
+std::ostream& operator<<(
+    std::ostream& os,
+    const HypercubeElement<ElementDim, HypercubeDim>& element) noexcept;
+
+/// A vertex in a `Dim`-dimensional hypercube
+template <size_t Dim>
+using Vertex = HypercubeElement<0, Dim>;
+
+/// An edge in a `Dim`-dimensional hypercube
+template <size_t Dim>
+using Edge = HypercubeElement<1, Dim>;
+
+/// A face in a `Dim`-dimensional hypercube
+template <size_t Dim>
+using Face = HypercubeElement<2, Dim>;
+
+/// A cell in a `Dim`-dimensional hypercube
+template <size_t Dim>
+using Cell = HypercubeElement<3, Dim>;
+
+/*!
+ * \brief Iterator over all `ElementDim`-dimensional elements on the boundary of
+ * a `HypercubeDim`-dimensional hypercube.
+ *
+ * \see `HypercubeElement`
+ */
+template <size_t ElementDim, size_t HypercubeDim>
+struct HypercubeElementsIterator {
+  static_assert(
+      ElementDim <= HypercubeDim,
+      "Hypercube element dimension must not exceed hypercube dimension.");
+
+ public:
+  static constexpr size_t num_indices = HypercubeDim - ElementDim;
+
+  /// The number of `ElementDim`-dimensional elements on the boundary of a
+  /// `HypercubeDim`-dimensional hypercube.
+  static constexpr size_t size() noexcept {
+    return two_to_the(num_indices) * factorial(HypercubeDim) /
+           factorial(ElementDim) / factorial(num_indices);
+  }
+
+  HypercubeElementsIterator() noexcept;
+
+  static HypercubeElementsIterator begin() noexcept;
+
+  static HypercubeElementsIterator end() noexcept;
+
+  HypercubeElementsIterator& operator++() noexcept;
+
+  // NOLINTNEXTLINE(cert-dcl21-cpp) returned object doesn't need to be const
+  HypercubeElementsIterator operator++(int) noexcept;
+
+  HypercubeElement<ElementDim, HypercubeDim> operator*() const noexcept;
+
+ private:
+  template <size_t LocalElementDim = ElementDim,
+            Requires<(LocalElementDim > 0)> = nullptr>
+  void increment_dimension_in_parent(size_t d) noexcept;
+
+  template <size_t LocalElementDim, size_t LocalHypercubeDim>
+  // NOLINTNEXTLINE(readability-redundant-declaration)
+  friend bool operator==(
+      const HypercubeElementsIterator<LocalElementDim, LocalHypercubeDim>& lhs,
+      const HypercubeElementsIterator<LocalElementDim, LocalHypercubeDim>&
+          rhs) noexcept;
+
+  std::array<size_t, ElementDim> dimensions_in_parent_{};
+  size_t index_ = std::numeric_limits<size_t>::max();
+};
+
+template <size_t ElementDim, size_t HypercubeDim>
+bool operator!=(
+    const HypercubeElementsIterator<ElementDim, HypercubeDim>& lhs,
+    const HypercubeElementsIterator<ElementDim, HypercubeDim>& rhs) noexcept;
+
+/// Iterate over all vertices in a `Dim`-dimensional hypercube
+template <size_t Dim>
+using VertexIterator = HypercubeElementsIterator<0, Dim>;
+
+/// Iterate over all edges in a `Dim`-dimensional hypercube
+template <size_t Dim>
+using EdgeIterator = HypercubeElementsIterator<1, Dim>;
+
+/// Iterate over all faces in a `Dim`-dimensional hypercube
+template <size_t Dim>
+using FaceIterator = HypercubeElementsIterator<2, Dim>;
+
+/// Iterate over all cells in a `Dim`-dimensional hypercube
+template <size_t Dim>
+using CellIterator = HypercubeElementsIterator<3, Dim>;

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory(Python)
 set(LIBRARY "Test_Domain")
 
 set(LIBRARY_SOURCES
+  Structure/Test_Hypercube.cpp
   Test_Block.cpp
   Test_BlockAndElementLogicalCoordinates.cpp
   Test_BlockId.cpp

--- a/tests/Unit/Domain/Structure/Test_Hypercube.cpp
+++ b/tests/Unit/Domain/Structure/Test_Hypercube.cpp
@@ -1,0 +1,224 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <string>
+
+#include "Domain/Structure/Hypercube.hpp"
+#include "Domain/Structure/Side.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/Gsl.hpp"
+
+template <size_t HypercubeDim, size_t ElementDim, size_t ExpectedSize>
+void test_hypercube_iterator(
+    std::array<HypercubeElement<ElementDim, HypercubeDim>, ExpectedSize>
+        expected_elements) {
+  CAPTURE(ElementDim);
+  CAPTURE(HypercubeDim);
+  HypercubeElementsIterator<ElementDim, HypercubeDim> elements_iterator{};
+  static_assert(ExpectedSize > 0);
+  static_assert(elements_iterator.size() == ExpectedSize);
+  CHECK(elements_iterator ==
+        HypercubeElementsIterator<ElementDim, HypercubeDim>::begin());
+  CHECK(*elements_iterator ==
+        *HypercubeElementsIterator<ElementDim, HypercubeDim>::begin());
+  CHECK(elements_iterator !=
+        HypercubeElementsIterator<ElementDim, HypercubeDim>::end());
+  size_t i = 0;
+  for (const auto& element : elements_iterator) {
+    CAPTURE(i);
+    CAPTURE(element);
+    CHECK(element == gsl::at(expected_elements, i));
+    ++i;
+  }
+  CHECK(i == ExpectedSize);
+  // Test postfix operator
+  elements_iterator =
+      HypercubeElementsIterator<ElementDim, HypercubeDim>::begin();
+  const auto previous_iterator = elements_iterator++;
+  CHECK(previous_iterator ==
+        HypercubeElementsIterator<ElementDim, HypercubeDim>::begin());
+  CHECK(elements_iterator ==
+        ++HypercubeElementsIterator<ElementDim, HypercubeDim>::begin());
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.Hypercube", "[Domain][Unit]") {
+  {
+    const Vertex<0> point{};
+    CHECK(get_output(point) == "Vertex0D[(),()]");
+    CHECK(point.dimensions_in_parent() == std::array<size_t, 0>{});
+    CHECK(point.index() == std::array<Side, 0>{});
+    CHECK(point == Vertex<0>{});
+    const Vertex<1> left{Side::Lower};
+    CHECK(get_output(left) == "Vertex1D[(),(Lower)]");
+    CHECK(left.index() == std::array<Side, 1>{{Side::Lower}});
+    CHECK(left.side() == Side::Lower);
+    CHECK(left == Vertex<1>{Side::Lower});
+    CHECK(left != Vertex<1>{Side::Upper});
+    const Vertex<2> lower_right{Side::Lower, Side::Upper};
+    CHECK(get_output(lower_right) == "Vertex2D[(),(Lower,Upper)]");
+    CHECK(lower_right.index() ==
+          std::array<Side, 2>{{Side::Lower, Side::Upper}});
+    CHECK(lower_right == Vertex<2>{{{Side::Lower, Side::Upper}}});
+    CHECK(lower_right != Vertex<2>{{{Side::Upper, Side::Upper}}});
+  }
+  {
+    const Edge<2> south{0, {{Side::Lower}}};
+    CHECK(get_output(south) == "Edge2D[(0),(Lower)]");
+    CHECK(south.dimensions_in_parent() == std::array<size_t, 1>{{0}});
+    CHECK(south.dimension_in_parent() == 0);
+    CHECK(south.index() == std::array<Side, 1>{{Side::Lower}});
+    CHECK(south.side_in_parent_dimension(1) == Side::Lower);
+    CHECK(south.side() == Side::Lower);
+    CHECK(south == Edge<2>{0, {{Side::Lower}}});
+    CHECK(south != Edge<2>{1, {{Side::Lower}}});
+    CHECK(south != Edge<2>{0, {{Side::Upper}}});
+    const Edge<2> north{0, {{Side::Upper}}};
+    CHECK(get_output(north) == "Edge2D[(0),(Upper)]");
+    CHECK(north.dimensions_in_parent() == std::array<size_t, 1>{{0}});
+    CHECK(north.dimension_in_parent() == 0);
+    CHECK(north.index() == std::array<Side, 1>{{Side::Upper}});
+    CHECK(north.side_in_parent_dimension(1) == Side::Upper);
+    CHECK(north.side() == Side::Upper);
+    const Edge<2> west{1, {{Side::Lower}}};
+    CHECK(get_output(west) == "Edge2D[(1),(Lower)]");
+    CHECK(west.dimensions_in_parent() == std::array<size_t, 1>{{1}});
+    CHECK(west.dimension_in_parent() == 1);
+    CHECK(west.index() == std::array<Side, 1>{{Side::Lower}});
+    CHECK(west.side_in_parent_dimension(0) == Side::Lower);
+    const Edge<2> east{1, {{Side::Upper}}};
+    CHECK(get_output(east) == "Edge2D[(1),(Upper)]");
+    CHECK(east.dimensions_in_parent() == std::array<size_t, 1>{{1}});
+    CHECK(east.dimension_in_parent() == 1);
+    CHECK(east.index() == std::array<Side, 1>{{Side::Upper}});
+    CHECK(east.side_in_parent_dimension(0) == Side::Upper);
+    CHECK(east.side() == Side::Upper);
+  }
+  {
+    const Edge<3> top_left{1, {{Side::Lower, Side::Upper}}};
+    CHECK(get_output(top_left) == "Edge3D[(1),(Lower,Upper)]");
+    CHECK(top_left.dimensions_in_parent() == std::array<size_t, 1>{{1}});
+    CHECK(top_left.dimension_in_parent() == 1);
+    CHECK(top_left.index() == std::array<Side, 2>{{Side::Lower, Side::Upper}});
+    CHECK(top_left.side_in_parent_dimension(0) == Side::Lower);
+    CHECK(top_left.side_in_parent_dimension(2) == Side::Upper);
+    CHECK(top_left == Edge<3>{1, {{Side::Lower, Side::Upper}}});
+    CHECK(top_left != Edge<3>{0, {{Side::Lower, Side::Upper}}});
+    CHECK(top_left != Edge<3>{1, {{Side::Lower, Side::Lower}}});
+    const Edge<3> top_front{0, {{Side::Lower, Side::Upper}}};
+    CHECK(get_output(top_front) == "Edge3D[(0),(Lower,Upper)]");
+    CHECK(top_front.dimensions_in_parent() == std::array<size_t, 1>{{0}});
+    CHECK(top_front.dimension_in_parent() == 0);
+    CHECK(top_front.index() == std::array<Side, 2>{{Side::Lower, Side::Upper}});
+    CHECK(top_front.side_in_parent_dimension(1) == Side::Lower);
+    CHECK(top_front.side_in_parent_dimension(2) == Side::Upper);
+    const Edge<3> front_left{2, {{Side::Lower, Side::Upper}}};
+    CHECK(get_output(front_left) == "Edge3D[(2),(Lower,Upper)]");
+    CHECK(front_left.dimensions_in_parent() == std::array<size_t, 1>{{2}});
+    CHECK(front_left.dimension_in_parent() == 2);
+    CHECK(front_left.index() ==
+          std::array<Side, 2>{{Side::Lower, Side::Upper}});
+    CHECK(front_left.side_in_parent_dimension(0) == Side::Lower);
+    CHECK(front_left.side_in_parent_dimension(1) == Side::Upper);
+  }
+  {
+    const Face<3> top{{{0, 1}}, {{Side::Upper}}};
+    CHECK(get_output(top) == "Face3D[(0,1),(Upper)]");
+    CHECK(top.dimensions_in_parent() == std::array<size_t, 2>{{0, 1}});
+    CHECK(top.index() == std::array<Side, 1>{{Side::Upper}});
+    CHECK(top.side_in_parent_dimension(2) == Side::Upper);
+    CHECK(top.side() == Side::Upper);
+    CHECK(top == Face<3>{{{0, 1}}, {{Side::Upper}}});
+    CHECK(top != Face<3>{{{0, 2}}, {{Side::Upper}}});
+    CHECK(top != Face<3>{{{0, 1}}, {{Side::Lower}}});
+    const Face<3> top_rotated{{{1, 0}}, {{Side::Upper}}};
+    CHECK(top_rotated == top);
+    const Face<3> left{{{1, 2}}, {{Side::Lower}}};
+    CHECK(get_output(left) == "Face3D[(1,2),(Lower)]");
+    CHECK(left.dimensions_in_parent() == std::array<size_t, 2>{{1, 2}});
+    CHECK(left.index() == std::array<Side, 1>{{Side::Lower}});
+    CHECK(left.side_in_parent_dimension(0) == Side::Lower);
+    CHECK(left.side() == Side::Lower);
+    const Face<3> left_rotated{{{2, 1}}, {{Side::Lower}}};
+    CHECK(left_rotated == left);
+    const Face<3> front{{{0, 2}}, {{Side::Lower}}};
+    CHECK(get_output(front) == "Face3D[(0,2),(Lower)]");
+    CHECK(front.dimensions_in_parent() == std::array<size_t, 2>{{0, 2}});
+    CHECK(front.index() == std::array<Side, 1>{{Side::Lower}});
+    CHECK(front.side_in_parent_dimension(1) == Side::Lower);
+    CHECK(front.side() == Side::Lower);
+    const Face<3> front_rotated{{{2, 0}}, {{Side::Lower}}};
+    CHECK(front_rotated == front);
+  }
+  {
+    const Cell<3> cube{};
+    CHECK(get_output(cube) == "Cell3D[(0,1,2),()]");
+    CHECK(cube.dimensions_in_parent() == std::array<size_t, 3>{{0, 1, 2}});
+    CHECK(cube.index() == std::array<Side, 0>{});
+    const Cell<3> cube_rotated{{{1, 2, 0}}, {}};
+    CHECK(cube_rotated == cube);
+  }
+  {
+    INFO("Hypercube iterator");
+    // 0D: .
+    // -> 1 vertex
+    test_hypercube_iterator<0, 0, 1>({{Vertex<0>{}}});
+    // 1D: -
+    // -> 2 vertices and 1 edge
+    test_hypercube_iterator<1, 0, 2>(
+        {{Vertex<1>{Side::Lower}, Vertex<1>{Side::Upper}}});
+    test_hypercube_iterator<1, 1, 1>({{Edge<1>{}}});
+    // 2D:
+    // +---+
+    // |   |
+    // +---+
+    // -> 4 vertices, 4 edges and 1 face
+    test_hypercube_iterator<2, 0, 4>({{Vertex<2>{Side::Lower, Side::Lower},
+                                       Vertex<2>{Side::Upper, Side::Lower},
+                                       Vertex<2>{Side::Lower, Side::Upper},
+                                       Vertex<2>{Side::Upper, Side::Upper}}});
+    test_hypercube_iterator<2, 1, 4>(
+        {{Edge<2>{0, {{Side::Lower}}}, Edge<2>{0, {{Side::Upper}}},
+          Edge<2>{1, {{Side::Lower}}}, Edge<2>{1, {{Side::Upper}}}}});
+    test_hypercube_iterator<2, 2, 1>({{Face<2>{}}});
+    // 3D:
+    //    +---+
+    //  /   / |
+    // +---+  +
+    // |   | /
+    // +---+
+    // -> 8 vertices, 12 edges, 6 faces and 1 cell
+    test_hypercube_iterator<3, 0, 8>(
+        {{Vertex<3>{Side::Lower, Side::Lower, Side::Lower},
+          Vertex<3>{Side::Upper, Side::Lower, Side::Lower},
+          Vertex<3>{Side::Lower, Side::Upper, Side::Lower},
+          Vertex<3>{Side::Upper, Side::Upper, Side::Lower},
+          Vertex<3>{Side::Lower, Side::Lower, Side::Upper},
+          Vertex<3>{Side::Upper, Side::Lower, Side::Upper},
+          Vertex<3>{Side::Lower, Side::Upper, Side::Upper},
+          Vertex<3>{Side::Upper, Side::Upper, Side::Upper}}});
+    test_hypercube_iterator<3, 1, 12>(
+        {{Edge<3>{0, {{Side::Lower, Side::Lower}}},
+          Edge<3>{0, {{Side::Upper, Side::Lower}}},
+          Edge<3>{0, {{Side::Lower, Side::Upper}}},
+          Edge<3>{0, {{Side::Upper, Side::Upper}}},
+          Edge<3>{1, {{Side::Lower, Side::Lower}}},
+          Edge<3>{1, {{Side::Upper, Side::Lower}}},
+          Edge<3>{1, {{Side::Lower, Side::Upper}}},
+          Edge<3>{1, {{Side::Upper, Side::Upper}}},
+          Edge<3>{2, {{Side::Lower, Side::Lower}}},
+          Edge<3>{2, {{Side::Upper, Side::Lower}}},
+          Edge<3>{2, {{Side::Lower, Side::Upper}}},
+          Edge<3>{2, {{Side::Upper, Side::Upper}}}}});
+    test_hypercube_iterator<3, 2, 6>({{Face<3>{{{0, 1}}, {{Side::Lower}}},
+                                       Face<3>{{{0, 1}}, {{Side::Upper}}},
+                                       Face<3>{{{0, 2}}, {{Side::Lower}}},
+                                       Face<3>{{{0, 2}}, {{Side::Upper}}},
+                                       Face<3>{{{1, 2}}, {{Side::Lower}}},
+                                       Face<3>{{{1, 2}}, {{Side::Upper}}}}});
+    test_hypercube_iterator<3, 3, 1>({{Cell<3>{}}});
+  }
+}


### PR DESCRIPTION
## Proposed changes

These iterators help looping over all corners and edges of a cube. I'm using them to construct weighting functions for my Schwarz subdomain solver.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
