### PR TITLE
Fix bugs in CMake dependency checking

### DIFF
--- a/cmake/SpectreCheckDependencies.cmake
+++ b/cmake/SpectreCheckDependencies.cmake
@@ -21,6 +21,7 @@ function(check_spectre_libs_dependencies)
       ${SPECTRE_TPLS}
       ${SPECTRE_LIBS}
       ALLOWED_EXTRA_TARGETS
+      SpectreAllocator
       SpectreFlags
       ERROR_ON_FAILURE
       )

--- a/cmake/SpectreCheckTargetDependencies.cmake
+++ b/cmake/SpectreCheckTargetDependencies.cmake
@@ -407,6 +407,12 @@ function(_check_and_print_dependencies
     TARGET ${TARGET_NAME}
     PROPERTY INTERFACE_LINK_LIBRARIES
     )
+  # The property INTERFACE_LINK_LIBRARIES contains generator expressions for
+  # private link-time dependencies. We will be handling these private
+  # dependencies explicitly below, so here we want to remove them from the list
+  # of interface dependencies. The generators have format "$<LINK_ONLY:dep>"
+  list(FILTER _INTERFACE_LIBS EXCLUDE REGEX "\\$<LINK_ONLY:.+>")
+
   unset(_MISSING_INTERFACE_LIBS)
   foreach(_INTERFACE_DEP ${TARGET_INTERFACE_DEPS})
     if(NOT ${_INTERFACE_DEP} IN_LIST _INTERFACE_LIBS)

--- a/src/Domain/ElementLogicalCoordinates.cpp
+++ b/src/Domain/ElementLogicalCoordinates.cpp
@@ -1,7 +1,7 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include "ElementLogicalCoordinates.hpp"
+#include "Domain/ElementLogicalCoordinates.hpp"
 
 #include <array>
 #include <memory>


### PR DESCRIPTION
## Proposed changes

Fix some bugs revealed while testing out the dependency checking

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
