### PR TITLE
Add ChangeCenterOfStrahlkorper.

### DIFF
--- a/src/ApparentHorizons/CMakeLists.txt
+++ b/src/ApparentHorizons/CMakeLists.txt
@@ -8,6 +8,7 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  ChangeCenterOfStrahlkorper.cpp
   FastFlow.cpp
   SpherepackIterator.cpp
   Strahlkorper.cpp
@@ -21,6 +22,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  ChangeCenterOfStrahlkorper.hpp
   ComputeItems.hpp
   FastFlow.hpp
   SpherepackIterator.hpp

--- a/src/ApparentHorizons/ChangeCenterOfStrahlkorper.cpp
+++ b/src/ApparentHorizons/ChangeCenterOfStrahlkorper.cpp
@@ -1,0 +1,158 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ApparentHorizons/ChangeCenterOfStrahlkorper.hpp"
+
+#include <cmath>
+
+#include "ApparentHorizons/Strahlkorper.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "NumericalAlgorithms/RootFinding/TOMS748.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace {
+
+// Get the r_hat vector of the Strahlkorper, which defines the
+// collocation points.
+template <typename Frame>
+tnsr::i<DataVector, 3, Frame> get_rhat(
+    const Strahlkorper<Frame>& strahlkorper) noexcept {
+  const auto new_theta_phi = strahlkorper.ylm_spherepack().theta_phi_points();
+  const DataVector sin_theta = sin(new_theta_phi[0]);
+  return tnsr::i<DataVector, 3, Frame>{{sin_theta * cos(new_theta_phi[1]),
+                                        sin_theta * sin(new_theta_phi[1]),
+                                        cos(new_theta_phi[0])}};
+}
+
+// Work function called by the two interface functions.
+template <typename Frame>
+void change_expansion_center(
+    const gsl::not_null<Strahlkorper<Frame>*> strahlkorper,
+    const std::array<double, 3>& new_center,
+    const tnsr::i<DataVector, 3, Frame>& r_hat) noexcept {
+  // Get new_center minus old_center.
+  const auto& old_center = strahlkorper->center();
+  const std::array<double, 3> center_difference{
+      {new_center[0] - old_center[0], new_center[1] - old_center[1],
+       new_center[2] - old_center[2]}};
+
+  // For bracketing the root, get the min and max radius with respect
+  // to the new center.
+  const auto [r_min, r_max] =
+      [&center_difference, &r_hat, &strahlkorper ]() noexcept {
+    const auto radius_old = strahlkorper->ylm_spherepack().spec_to_phys(
+        strahlkorper->coefficients());
+    DataVector radius_new =
+        square(get<0>(r_hat) * radius_old - center_difference[0]);
+    for (size_t d = 1; d < 3; ++d) {  // Start at 1; already did zero.
+      radius_new +=
+          square(r_hat.get(d) * radius_old - gsl::at(center_difference, d));
+    }
+    radius_new = sqrt(radius_new);
+    const auto minmax =
+        std::minmax_element(radius_new.begin(), radius_new.end());
+    return std::make_pair(*(minmax.first), *(minmax.second));
+  }
+  ();
+
+  // Find the coordinate radius of the surface, with respect to the
+  // new center, at each of the angular collocation points of the
+  // surface with respect to the new center. To do so, for each index
+  // 's' (corresponding to an angular collocation point), find the
+  // root 'r_new' that zeroes this lambda function.
+  const auto radius_function = [&center_difference, &r_hat, &strahlkorper ](
+      const double r_new, const size_t s) noexcept {
+    // Get cartesian coordinates of the point with respect to the old
+    // center.
+    const std::array<double, 3> x_old{
+        {r_new * get<0>(r_hat)[s] + center_difference[0],
+         r_new * get<1>(r_hat)[s] + center_difference[1],
+         r_new * get<2>(r_hat)[s] + center_difference[2]}};
+
+    // Find (r, theta, phi) of the same point with respect to the old_center.
+    const double r_old =
+        sqrt(square(x_old[0]) + square(x_old[1]) + square(x_old[2]));
+    const double theta_old = acos(x_old[2] / r_old);
+    const double phi_old = atan2(x_old[1], x_old[0]);
+
+    // Evaluate the radius of the surface on the old strahlkorper
+    // at theta_old, phi_old.
+    const double r_surf_old = strahlkorper->radius(theta_old, phi_old);
+
+    // If r_surf_old is r_old, then 'r_new' is on the surface.
+    return r_surf_old - r_old;
+  };
+
+  // We try to bracket the root between r_min and r_max.
+  // But r_min and r_max are only approximate, and there may be grid points
+  // with radii outside that range. So we pad by 10% to be safe.
+  const double padding = 0.10;
+
+  const auto radius_at_each_angle = RootFinder::toms748(
+      radius_function,
+      make_with_value<DataVector>(get<0>(r_hat), r_min * (1.0 - padding)),
+      make_with_value<DataVector>(get<0>(r_hat), r_max * (1.0 + padding)),
+      std::numeric_limits<double>::epsilon() * (r_min + r_max),
+      2.0 * std::numeric_limits<double>::epsilon());
+
+  // Now reset the radius and center of the new strahlkorper.
+  *strahlkorper =
+      Strahlkorper<Frame>(strahlkorper->l_max(), strahlkorper->m_max(),
+                          radius_at_each_angle, new_center);
+}
+}  // namespace
+
+template <typename Frame>
+void change_expansion_center_of_strahlkorper(
+    const gsl::not_null<Strahlkorper<Frame>*> strahlkorper,
+    const std::array<double, 3>& new_center) noexcept {
+  change_expansion_center(strahlkorper, new_center, get_rhat(*strahlkorper));
+}
+
+template <typename Frame>
+void change_expansion_center_of_strahlkorper_to_physical(
+    const gsl::not_null<Strahlkorper<Frame>*> strahlkorper) noexcept {
+  const auto r_hat = get_rhat(*strahlkorper);
+
+  // Zeroth iteration.
+  change_expansion_center(strahlkorper, strahlkorper->physical_center(), r_hat);
+
+  // In the random number tests, it never needed more than 7
+  // iterations to converge to relative error of roundoff.  Allow 14
+  // iterations to be safe.
+  const size_t maxiter = 14;
+  for (size_t iter = 0; iter < maxiter; ++iter) {
+    const auto phys_center = strahlkorper->physical_center();
+    const auto center = strahlkorper->center();
+    const auto average_radius = strahlkorper->average_radius();
+    const double relative_error = sqrt(square(center[0] - phys_center[0]) +
+                                       square(center[1] - phys_center[1]) +
+                                       square(center[2] - phys_center[2])) /
+                                  average_radius;
+    if (relative_error <= 2.0 * std::numeric_limits<double>::epsilon()) {
+      return;
+    }
+    change_expansion_center(strahlkorper, phys_center, r_hat);
+  }
+  ERROR("Too many iterations in change_expansion_center_of_strahlkorper");
+}
+/// \cond
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                         \
+  template void change_expansion_center_of_strahlkorper(             \
+      const gsl::not_null<Strahlkorper<FRAME(data)>*> strahlkorper,  \
+      const std::array<double, 3>& new_center) noexcept;             \
+  template void change_expansion_center_of_strahlkorper_to_physical( \
+      const gsl::not_null<Strahlkorper<FRAME(data)>*> strahlkorper) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (::Frame::Inertial))
+
+#undef INSTANTIATE
+#undef FRAME
+/// \endcond

--- a/src/ApparentHorizons/ChangeCenterOfStrahlkorper.hpp
+++ b/src/ApparentHorizons/ChangeCenterOfStrahlkorper.hpp
@@ -1,0 +1,35 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+
+/// \cond
+template <typename Frame>
+class Strahlkorper;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+/// Changes the expansion center of a Strahlkorper, where the
+/// expansion center is defined as the point about which the spectral
+/// basis of the Strahlkorper is expanded, which is the quantity
+/// returned by `Strahlkorper::center()`.
+template <typename Frame>
+void change_expansion_center_of_strahlkorper(
+    gsl::not_null<Strahlkorper<Frame>*> strahlkorper,
+    const std::array<double, 3>& new_center) noexcept;
+
+/// Changes the expansion center of a Strahlkorper to the physical
+/// center.  Because `Strahlkorper::physical_center()` returns only an
+/// approximate quantity,
+/// `change_expansion_center_of_strahlkorper_to_physical` is
+/// iterative, and does not return exactly the same result as passing
+/// `Strahlkorper::physical_center()` to
+/// `change_expansion_center_of_strahlkorper`.
+template <typename Frame>
+void change_expansion_center_of_strahlkorper_to_physical(
+    gsl::not_null<Strahlkorper<Frame>*> strahlkorper) noexcept;

--- a/tests/Unit/ApparentHorizons/CMakeLists.txt
+++ b/tests/Unit/ApparentHorizons/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_ApparentHorizons")
 
 set(LIBRARY_SOURCES
   Test_ApparentHorizonFinder.cpp
+  Test_ChangeCenterOfStrahlkorper.cpp
   Test_ComputeItems.cpp
   Test_FastFlow.cpp
   Test_SpherepackIterator.cpp

--- a/tests/Unit/ApparentHorizons/Test_ChangeCenterOfStrahlkorper.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ChangeCenterOfStrahlkorper.cpp
@@ -1,0 +1,106 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <random>
+
+#include "ApparentHorizons/ChangeCenterOfStrahlkorper.hpp"
+#include "ApparentHorizons/SpherepackIterator.hpp"
+#include "ApparentHorizons/Strahlkorper.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
+/// \endcond
+
+namespace {
+
+Strahlkorper<Frame::Inertial> make_strahlkorper() noexcept {
+  const std::array<double, 3> center{{0.1, 0.2, 0.3}};
+  const size_t l_max = 18;
+  const double avg_radius = 2.0;
+  const double delta_radius = 0.1;
+
+  std::uniform_real_distribution<double> interval_dis(-1.0, 1.0);
+  MAKE_GENERATOR(gen);
+
+  // First make a sphere.
+  Strahlkorper<Frame::Inertial> sk(l_max, l_max, avg_radius, center);
+  // Now adjust the coefficients randomly, but in a manner so that
+  // coefficients decay like exp(-l).
+  auto coefs = sk.coefficients();
+  for (SpherepackIterator it(l_max, l_max); it; ++it) {
+    coefs[it()] +=
+        interval_dis(gen) * delta_radius * exp(-static_cast<double>(it.l()));
+  }
+  return Strahlkorper<Frame::Inertial>(coefs, sk);
+}
+
+void test_change_center_of_strahlkorper() noexcept {
+  auto strahlkorper = make_strahlkorper();
+  const auto original_strahlkorper = strahlkorper;
+  const auto original_physical_center = strahlkorper.physical_center();
+
+  const std::array<double, 3> new_center{{0.12, 0.21, 0.33}};
+  change_expansion_center_of_strahlkorper(make_not_null(&strahlkorper),
+                                          new_center);
+
+  // Center should have changed
+  for (size_t i = 0; i < 3; ++i) {
+    CHECK(gsl::at(new_center, i) == gsl::at(strahlkorper.center(), i));
+  }
+
+  // Physical center should not change (to lowest order only, since physical
+  // center is only computed to l=1.  Therefore we use a custom approx here.)
+  const auto new_physical_center = strahlkorper.physical_center();
+  Approx custom_approx_three = Approx::custom().epsilon(1.e-3).scale(1.);
+  for (size_t i = 0; i < 3; ++i) {
+    CHECK(custom_approx_three(gsl::at(original_physical_center, i)) ==
+          gsl::at(new_physical_center, i));
+  }
+
+  // Now transform back
+  change_expansion_center_of_strahlkorper(make_not_null(&strahlkorper),
+                                          original_strahlkorper.center());
+
+  // The original center and radii should have been restored.
+  for (size_t i = 0; i < 3; ++i) {
+    CHECK(gsl::at(original_strahlkorper.center(), i) ==
+          gsl::at(strahlkorper.center(), i));
+  }
+  // Radii are not the same to machine precision, but only to the
+  // specified l_max.  If l_max is changed at the top of this file, then the
+  // approx below may need to change.
+  Approx custom_approx_nine = Approx::custom().epsilon(1.e-9).scale(1.);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      strahlkorper.ylm_spherepack().spec_to_phys(strahlkorper.coefficients()),
+      original_strahlkorper.ylm_spherepack().spec_to_phys(
+          original_strahlkorper.coefficients()),
+      custom_approx_nine);
+}
+
+void test_change_center_of_strahlkorper_to_physical() {
+  auto strahlkorper = make_strahlkorper();
+
+  change_expansion_center_of_strahlkorper_to_physical(
+      make_not_null(&strahlkorper));
+
+  const auto new_physical_center = strahlkorper.physical_center();
+  const auto new_center = strahlkorper.center();
+  for (size_t i = 0; i < 3; ++i) {
+    CHECK(approx(gsl::at(new_physical_center, i)) == gsl::at(new_center, i));
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizons.Strahlkorper.ChangeCenter",
+                  "[ApparentHorizons][Unit]") {
+  test_change_center_of_strahlkorper();
+  test_change_center_of_strahlkorper_to_physical();
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

Adds functions for changing the expansion center of a Strahlkorper.

This is used mostly when changing Strahlkorpers from one frame to another, in which case
one often wants to reset the expansion center so that it is near the physical center.

This will also be useful for the plunge->ringdown transition of a BBH where one wishes to center a new AH on a new grid with a single excision region.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
