### PR TITLE
Add more tests of compute tags and fix non-conforming compute tags

### DIFF
--- a/src/ApparentHorizons/Tags.cpp
+++ b/src/ApparentHorizons/Tags.cpp
@@ -16,7 +16,7 @@
 namespace StrahlkorperTags {
 
 template <typename Frame>
-void ThetaPhi<Frame>::function(
+void ThetaPhiCompute<Frame>::function(
     const gsl::not_null<aliases::ThetaPhi<Frame>*> theta_phi,
     const ::Strahlkorper<Frame>& strahlkorper) noexcept {
   auto temp = strahlkorper.ylm_spherepack().theta_phi_points();
@@ -26,8 +26,9 @@ void ThetaPhi<Frame>::function(
 }
 
 template <typename Frame>
-void Rhat<Frame>::function(const gsl::not_null<aliases::OneForm<Frame>*> r_hat,
-                           const aliases::ThetaPhi<Frame>& theta_phi) noexcept {
+void RhatCompute<Frame>::function(
+    const gsl::not_null<aliases::OneForm<Frame>*> r_hat,
+    const aliases::ThetaPhi<Frame>& theta_phi) noexcept {
   const auto& theta = get<0>(theta_phi);
   const auto& phi = get<1>(theta_phi);
 
@@ -39,7 +40,7 @@ void Rhat<Frame>::function(const gsl::not_null<aliases::OneForm<Frame>*> r_hat,
 }
 
 template <typename Frame>
-void Jacobian<Frame>::function(
+void JacobianCompute<Frame>::function(
     const gsl::not_null<aliases::Jacobian<Frame>*> jac,
     const aliases::ThetaPhi<Frame>& theta_phi) noexcept {
   const auto& theta = get<0>(theta_phi);
@@ -58,7 +59,7 @@ void Jacobian<Frame>::function(
 }
 
 template <typename Frame>
-void InvJacobian<Frame>::function(
+void InvJacobianCompute<Frame>::function(
     const gsl::not_null<aliases::InvJacobian<Frame>*> inv_jac,
     const aliases::ThetaPhi<Frame>& theta_phi) noexcept {
   const auto& theta = get<0>(theta_phi);
@@ -77,7 +78,7 @@ void InvJacobian<Frame>::function(
 }
 
 template <typename Frame>
-void InvHessian<Frame>::function(
+void InvHessianCompute<Frame>::function(
     const gsl::not_null<aliases::InvHessian<Frame>*> inv_hess,
     const aliases::ThetaPhi<Frame>& theta_phi) noexcept {
   const auto& theta = get<0>(theta_phi);
@@ -139,7 +140,7 @@ void InvHessian<Frame>::function(
 }
 
 template <typename Frame>
-void Radius<Frame>::function(
+void RadiusCompute<Frame>::function(
     const gsl::not_null<DataVector*> radius,
     const ::Strahlkorper<Frame>& strahlkorper) noexcept {
   radius->destructive_resize(strahlkorper.ylm_spherepack().physical_size());
@@ -148,7 +149,7 @@ void Radius<Frame>::function(
 }
 
 template <typename Frame>
-void CartesianCoords<Frame>::function(
+void CartesianCoordsCompute<Frame>::function(
     const gsl::not_null<aliases::Vector<Frame>*> coords,
     const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
     const aliases::OneForm<Frame>& r_hat) noexcept {
@@ -159,7 +160,7 @@ void CartesianCoords<Frame>::function(
 }
 
 template <typename Frame>
-void DxRadius<Frame>::function(
+void DxRadiusCompute<Frame>::function(
     const gsl::not_null<aliases::OneForm<Frame>*> dx_radius,
     const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
     const aliases::InvJacobian<Frame>& inv_jac) noexcept {
@@ -176,7 +177,7 @@ void DxRadius<Frame>::function(
 }
 
 template <typename Frame>
-void D2xRadius<Frame>::function(
+void D2xRadiusCompute<Frame>::function(
     const gsl::not_null<aliases::SecondDeriv<Frame>*> d2x_radius,
     const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
     const aliases::InvJacobian<Frame>& inv_jac,
@@ -217,7 +218,7 @@ void D2xRadius<Frame>::function(
 }
 
 template <typename Frame>
-void LaplacianRadius<Frame>::function(
+void LaplacianRadiusCompute<Frame>::function(
     const gsl::not_null<DataVector*> lap_radius,
     const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
     const aliases::ThetaPhi<Frame>& theta_phi) noexcept {
@@ -229,7 +230,7 @@ void LaplacianRadius<Frame>::function(
 }
 
 template <typename Frame>
-void NormalOneForm<Frame>::function(
+void NormalOneFormCompute<Frame>::function(
     const gsl::not_null<aliases::OneForm<Frame>*> one_form,
     const aliases::OneForm<Frame>& dx_radius,
     const aliases::OneForm<Frame>& r_hat) noexcept {
@@ -240,7 +241,7 @@ void NormalOneForm<Frame>::function(
 }
 
 template <typename Frame>
-void Tangents<Frame>::function(
+void TangentsCompute<Frame>::function(
     const gsl::not_null<aliases::Jacobian<Frame>*> tangents,
     const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
     const aliases::OneForm<Frame>& r_hat,
@@ -257,22 +258,16 @@ void Tangents<Frame>::function(
 }  // namespace StrahlkorperTags
 
 namespace StrahlkorperTags {
-template struct ThetaPhi<Frame::Inertial>;
-template struct Rhat<Frame::Inertial>;
-template struct Jacobian<Frame::Inertial>;
-template struct InvJacobian<Frame::Inertial>;
-template struct InvHessian<Frame::Inertial>;
-template struct Radius<Frame::Inertial>;
-template struct CartesianCoords<Frame::Inertial>;
-template struct DxRadius<Frame::Inertial>;
-template struct D2xRadius<Frame::Inertial>;
-template struct LaplacianRadius<Frame::Inertial>;
-template struct NormalOneForm<Frame::Inertial>;
-template struct Tangents<Frame::Inertial>;
+template struct ThetaPhiCompute<Frame::Inertial>;
+template struct RhatCompute<Frame::Inertial>;
+template struct JacobianCompute<Frame::Inertial>;
+template struct InvJacobianCompute<Frame::Inertial>;
+template struct InvHessianCompute<Frame::Inertial>;
+template struct RadiusCompute<Frame::Inertial>;
+template struct CartesianCoordsCompute<Frame::Inertial>;
+template struct DxRadiusCompute<Frame::Inertial>;
+template struct D2xRadiusCompute<Frame::Inertial>;
+template struct LaplacianRadiusCompute<Frame::Inertial>;
+template struct NormalOneFormCompute<Frame::Inertial>;
+template struct TangentsCompute<Frame::Inertial>;
 }  // namespace StrahlkorperTags
-
-namespace StrahlkorperGr {
-namespace Tags {
-template struct AreaElement<Frame::Inertial>;
-}  // namespace Tags
-}  // namespace StrahlkorperGr

--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -26,13 +26,11 @@ class DataVector;
 class FastFlow;
 /// \endcond
 
-namespace ah {
-namespace Tags {
+namespace ah::Tags {
 struct FastFlow : db::SimpleTag {
   using type = ::FastFlow;
 };
-}  // namespace Tags
-}  // namespace ah
+}  // namespace ah::Tags
 
 /// \ingroup SurfacesGroup
 /// Holds tags and ComputeItems associated with a `::Strahlkorper`.
@@ -44,85 +42,133 @@ struct Strahlkorper : db::SimpleTag {
   using type = ::Strahlkorper<Frame>;
 };
 
+// @{
 /// \f$(\theta,\phi)\f$ on the grid.
 /// Doesn't depend on the shape of the surface.
 template <typename Frame>
-struct ThetaPhi : db::ComputeTag {
-  static std::string name() noexcept { return "ThetaPhi"; }
+struct ThetaPhi : db::SimpleTag {
+  using type = aliases::ThetaPhi<Frame>;
+};
+
+template <typename Frame>
+struct ThetaPhiCompute : ThetaPhi<Frame>, db::ComputeTag {
+  using base = ThetaPhi<Frame>;
   using return_type = aliases::ThetaPhi<Frame>;
   static void function(gsl::not_null<aliases::ThetaPhi<Frame>*> theta_phi,
                        const ::Strahlkorper<Frame>& strahlkorper) noexcept;
   using argument_tags = tmpl::list<Strahlkorper<Frame>>;
 };
+// }@
 
+// @{
 /// `Rhat(i)` is \f$\hat{r}^i = x_i/\sqrt{x^2+y^2+z^2}\f$ on the grid.
 /// Doesn't depend on the shape of the surface.
 template <typename Frame>
-struct Rhat : db::ComputeTag {
-  static std::string name() noexcept { return "Rhat"; }
+struct Rhat : db::SimpleTag {
+  using type = aliases::OneForm<Frame>;
+};
+
+template <typename Frame>
+struct RhatCompute : Rhat<Frame>, db::ComputeTag {
+  using base = Rhat<Frame>;
   using return_type = aliases::OneForm<Frame>;
   static void function(gsl::not_null<aliases::OneForm<Frame>*> r_hat,
                        const aliases::ThetaPhi<Frame>& theta_phi) noexcept;
   using argument_tags = tmpl::list<ThetaPhi<Frame>>;
 };
+// }@
 
+// @{
 /// `Jacobian(i,0)` is \f$\frac{1}{r}\partial x^i/\partial\theta\f$,
 /// and `Jacobian(i,1)`
 /// is \f$\frac{1}{r\sin\theta}\partial x^i/\partial\phi\f$.
 /// Here \f$r\f$ means \f$\sqrt{x^2+y^2+z^2}\f$.
 /// `Jacobian` doesn't depend on the shape of the surface.
 template <typename Frame>
-struct Jacobian : db::ComputeTag {
-  static std::string name() noexcept { return "Jacobian"; }
+struct Jacobian : db::SimpleTag {
+  using type = aliases::Jacobian<Frame>;
+};
+
+template <typename Frame>
+struct JacobianCompute : Jacobian<Frame>, db::ComputeTag {
+  using base = Jacobian<Frame>;
   using return_type = aliases::Jacobian<Frame>;
   static void function(gsl::not_null<aliases::Jacobian<Frame>*> jac,
                        const aliases::ThetaPhi<Frame>& theta_phi) noexcept;
   using argument_tags = tmpl::list<ThetaPhi<Frame>>;
 };
+// }@
 
+// @{
 /// `InvJacobian(0,i)` is \f$r\partial\theta/\partial x^i\f$,
 /// and `InvJacobian(1,i)` is \f$r\sin\theta\partial\phi/\partial x^i\f$.
 /// Here \f$r\f$ means \f$\sqrt{x^2+y^2+z^2}\f$.
 /// `InvJacobian` doesn't depend on the shape of the surface.
 template <typename Frame>
-struct InvJacobian : db::ComputeTag {
-  static std::string name() noexcept { return "InvJacobian"; }
+struct InvJacobian : db::SimpleTag {
+  using type = aliases::InvJacobian<Frame>;
+};
+
+template <typename Frame>
+struct InvJacobianCompute : InvJacobian<Frame>, db::ComputeTag {
+  using base = InvJacobian<Frame>;
   using return_type = aliases::InvJacobian<Frame>;
   static void function(gsl::not_null<aliases::InvJacobian<Frame>*> inv_jac,
                        const aliases::ThetaPhi<Frame>& theta_phi) noexcept;
   using argument_tags = tmpl::list<ThetaPhi<Frame>>;
 };
+// }@
 
+// @{
 /// `InvHessian(k,i,j)` is \f$\partial (J^{-1}){}^k_j/\partial x^i\f$,
 /// where \f$(J^{-1}){}^k_j\f$ is the inverse Jacobian.
 /// `InvHessian` is not symmetric because the Jacobians are Pfaffian.
 /// `InvHessian` doesn't depend on the shape of the surface.
 template <typename Frame>
-struct InvHessian : db::ComputeTag {
-  static std::string name() noexcept { return "InvHessian"; }
+struct InvHessian : db::SimpleTag {
+  using type = aliases::InvHessian<Frame>;
+};
+
+template <typename Frame>
+struct InvHessianCompute : InvHessian<Frame>, db::ComputeTag {
+  using base = InvHessian<Frame>;
   using return_type = aliases::InvHessian<Frame>;
   static void function(gsl::not_null<aliases::InvHessian<Frame>*> inv_hess,
                        const aliases::ThetaPhi<Frame>& theta_phi) noexcept;
   using argument_tags = tmpl::list<ThetaPhi<Frame>>;
 };
+// }@
 
+// @{
 /// (Euclidean) distance \f$r_{\rm surf}(\theta,\phi)\f$ from the center to each
 /// point of the surface.
 template <typename Frame>
-struct Radius : db::ComputeTag {
-  static std::string name() noexcept { return "Radius"; }
+struct Radius : db::SimpleTag {
+  using type = DataVector;
+};
+
+template <typename Frame>
+struct RadiusCompute : Radius<Frame>, db::ComputeTag {
+  using base = Radius<Frame>;
   using return_type = DataVector;
   static void function(gsl::not_null<DataVector*> radius,
                        const ::Strahlkorper<Frame>& strahlkorper) noexcept;
   using argument_tags = tmpl::list<Strahlkorper<Frame>>;
 };
+// }@
 
+// @{
 /// `CartesianCoords(i)` is \f$x_{\rm surf}^i\f$,
 /// the vector of \f$(x,y,z)\f$ coordinates of each point
 /// on the surface.
 template <typename Frame>
-struct CartesianCoords : db::ComputeTag {
-  static std::string name() noexcept { return "CartesianCoords"; }
+struct CartesianCoords : db::SimpleTag {
+  using type = aliases::Vector<Frame>;
+};
+
+template <typename Frame>
+struct CartesianCoordsCompute : CartesianCoords<Frame>, db::ComputeTag {
+  using base = CartesianCoords<Frame>;
   using return_type = aliases::Vector<Frame>;
   static void function(gsl::not_null<aliases::Vector<Frame>*> coords,
                        const ::Strahlkorper<Frame>& strahlkorper,
@@ -131,7 +177,9 @@ struct CartesianCoords : db::ComputeTag {
   using argument_tags =
       tmpl::list<Strahlkorper<Frame>, Radius<Frame>, Rhat<Frame>>;
 };
+// }@
 
+// @{
 /// `DxRadius(i)` is \f$\partial r_{\rm surf}/\partial x^i\f$.  Here
 /// \f$r_{\rm surf}=r_{\rm surf}(\theta,\phi)\f$ is the function
 /// describing the surface, which is considered a function of
@@ -139,8 +187,13 @@ struct CartesianCoords : db::ComputeTag {
 /// \f$r_{\rm surf}=r_{\rm surf}(\theta(x,y,z),\phi(x,y,z))\f$
 /// for this operation.
 template <typename Frame>
-struct DxRadius : db::ComputeTag {
-  static std::string name() noexcept { return "DxRadius"; }
+struct DxRadius : db::SimpleTag {
+  using type = aliases::OneForm<Frame>;
+};
+
+template <typename Frame>
+struct DxRadiusCompute : DxRadius<Frame>, db::ComputeTag {
+  using base = DxRadius<Frame>;
   using return_type = aliases::OneForm<Frame>;
   static void function(gsl::not_null<aliases::OneForm<Frame>*> dx_radius,
                        const ::Strahlkorper<Frame>& strahlkorper,
@@ -149,7 +202,9 @@ struct DxRadius : db::ComputeTag {
   using argument_tags =
       tmpl::list<Strahlkorper<Frame>, Radius<Frame>, InvJacobian<Frame>>;
 };
+// }@
 
+// @{
 /// `D2xRadius(i,j)` is
 /// \f$\partial^2 r_{\rm surf}/\partial x^i\partial x^j\f$. Here
 /// \f$r_{\rm surf}=r_{\rm surf}(\theta,\phi)\f$ is the function
@@ -158,8 +213,13 @@ struct DxRadius : db::ComputeTag {
 /// \f$r_{\rm surf}=r_{\rm surf}(\theta(x,y,z),\phi(x,y,z))\f$
 /// for this operation.
 template <typename Frame>
-struct D2xRadius : db::ComputeTag {
-  static std::string name() noexcept { return "D2xRadius"; }
+struct D2xRadius : db::SimpleTag {
+  using type = aliases::SecondDeriv<Frame>;
+};
+
+template <typename Frame>
+struct D2xRadiusCompute : D2xRadius<Frame>, db::ComputeTag {
+  using base = D2xRadius<Frame>;
   using return_type = aliases::SecondDeriv<Frame>;
   static void function(gsl::not_null<aliases::SecondDeriv<Frame>*> d2x_radius,
                        const ::Strahlkorper<Frame>& strahlkorper,
@@ -169,13 +229,20 @@ struct D2xRadius : db::ComputeTag {
   using argument_tags = tmpl::list<Strahlkorper<Frame>, Radius<Frame>,
                                    InvJacobian<Frame>, InvHessian<Frame>>;
 };
+// }@
 
+// @{
 /// \f$\nabla^2 r_{\rm surf}\f$, the flat Laplacian of the surface.
 /// This is \f$\eta^{ij}\partial^2 r_{\rm surf}/\partial x^i\partial x^j\f$,
 /// where \f$r_{\rm surf}=r_{\rm surf}(\theta(x,y,z),\phi(x,y,z))\f$.
 template <typename Frame>
-struct LaplacianRadius : db::ComputeTag {
-  static std::string name() noexcept { return "LaplacianRadius"; }
+struct LaplacianRadius : db::SimpleTag {
+  using type = DataVector;
+};
+
+template <typename Frame>
+struct LaplacianRadiusCompute : LaplacianRadius<Frame>, db::ComputeTag {
+  using base = LaplacianRadius<Frame>;
   using return_type = DataVector;
   static void function(gsl::not_null<DataVector*> lap_radius,
                        const ::Strahlkorper<Frame>& strahlkorper,
@@ -184,7 +251,9 @@ struct LaplacianRadius : db::ComputeTag {
   using argument_tags =
       tmpl::list<Strahlkorper<Frame>, Radius<Frame>, ThetaPhi<Frame>>;
 };
+// }@
 
+// @{
 /// `NormalOneForm(i)` is \f$s_i\f$, the (unnormalized) normal one-form
 /// to the surface, expressed in Cartesian components.
 /// This is computed by \f$x_i/r-\partial r_{\rm surf}/\partial x^i\f$,
@@ -195,25 +264,34 @@ struct LaplacianRadius : db::ComputeTag {
 /// (it is "normal" to the surface), but it does not have unit length
 /// (it is not "normalized"; normalization requires a metric).
 template <typename Frame>
-struct NormalOneForm : db::ComputeTag {
-  static std::string name() noexcept { return "NormalOneForm"; }
+struct NormalOneForm : db::SimpleTag {
+  using type = aliases::OneForm<Frame>;
+};
+
+template <typename Frame>
+struct NormalOneFormCompute : NormalOneForm<Frame>, db::ComputeTag {
+  using base = NormalOneForm<Frame>;
   using return_type = aliases::OneForm<Frame>;
   static void function(gsl::not_null<aliases::OneForm<Frame>*> one_form,
                        const aliases::OneForm<Frame>& dx_radius,
                        const aliases::OneForm<Frame>& r_hat) noexcept;
   using argument_tags = tmpl::list<DxRadius<Frame>, Rhat<Frame>>;
 };
+// }@
+
 /// The OneOverOneFormMagnitude is the reciprocal of the magnitude of the
 /// one-form perpendicular to the horizon
 struct OneOverOneFormMagnitude : db::SimpleTag {
   using type = DataVector;
 };
+
 /// Computes the reciprocal of the magnitude of the one form perpendicular to
 /// the horizon
 template <size_t Dim, typename Frame, typename DataType>
 struct OneOverOneFormMagnitudeCompute : db::ComputeTag,
                                         OneOverOneFormMagnitude {
   using base = OneOverOneFormMagnitude;
+  using return_type = DataVector;
   static void function(
       const gsl::not_null<DataVector*> one_over_magnitude,
       const tnsr::II<DataType, Dim, Frame>& inverse_spatial_metric,
@@ -226,6 +304,7 @@ struct OneOverOneFormMagnitudeCompute : db::ComputeTag,
                  NormalOneForm<Frame>>;
 };
 
+// @{
 /// `Tangents(i,j)` is \f$\partial x_{\rm surf}^i/\partial q^j\f$,
 /// where \f$x_{\rm surf}^i\f$ are the Cartesian coordinates of the
 /// surface (i.e. `CartesianCoords`) and are considered functions of
@@ -242,8 +321,13 @@ struct OneOverOneFormMagnitudeCompute : db::ComputeTag,
 /// since orthogonality between 2 vectors (as opposed to a vector and
 /// a one-form) is metric-dependent.
 template <typename Frame>
-struct Tangents : db::ComputeTag {
-  static std::string name() noexcept { return "Tangents"; }
+struct Tangents : db::SimpleTag {
+  using type = aliases::Jacobian<Frame>;
+};
+
+template <typename Frame>
+struct TangentsCompute : Tangents<Frame>, db::ComputeTag {
+  using base = Tangents<Frame>;
   using return_type = aliases::Jacobian<Frame>;
   static void function(gsl::not_null<aliases::Jacobian<Frame>*> tangents,
                        const ::Strahlkorper<Frame>& strahlkorper,
@@ -253,12 +337,20 @@ struct Tangents : db::ComputeTag {
   using argument_tags = tmpl::list<Strahlkorper<Frame>, Radius<Frame>,
                                    Rhat<Frame>, Jacobian<Frame>>;
 };
+// }@
 
+// @{
 /// Computes the Euclidean area element on a Strahlkorper.
 /// Useful for flat space integrals.
 template <typename Frame>
-struct EuclideanAreaElement : db::ComputeTag {
-  static std::string name() noexcept { return "EuclideanAreaElement"; }
+struct EuclideanAreaElement : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+template <typename Frame>
+struct EuclideanAreaElementCompute : EuclideanAreaElement<Frame>,
+                                     db::ComputeTag {
+  using base = EuclideanAreaElement<Frame>;
   using return_type = Scalar<DataVector>;
   static constexpr auto function = static_cast<void (*)(
       gsl::not_null<Scalar<DataVector>*>,
@@ -270,13 +362,23 @@ struct EuclideanAreaElement : db::ComputeTag {
       StrahlkorperTags::Jacobian<Frame>, StrahlkorperTags::NormalOneForm<Frame>,
       StrahlkorperTags::Radius<Frame>, StrahlkorperTags::Rhat<Frame>>;
 };
+// }@
 
+// @{
 /// Computes the flat-space integral of a scalar over a Strahlkorper.
 template <typename IntegrandTag, typename Frame>
-struct EuclideanSurfaceIntegral : db::ComputeTag {
+struct EuclideanSurfaceIntegral : db::SimpleTag {
   static std::string name() noexcept {
     return "EuclideanSurfaceIntegral(" + db::tag_name<IntegrandTag>() + ")";
   }
+  using type = double;
+};
+
+template <typename IntegrandTag, typename Frame>
+struct EuclideanSurfaceIntegralCompute
+    : EuclideanSurfaceIntegral<IntegrandTag, Frame>,
+      db::ComputeTag {
+  using base = EuclideanSurfaceIntegral<IntegrandTag, Frame>;
   using return_type = double;
   static void function(const gsl::not_null<double*> surface_integral,
                        const Scalar<DataVector>& euclidean_area_element,
@@ -288,7 +390,9 @@ struct EuclideanSurfaceIntegral : db::ComputeTag {
   using argument_tags = tmpl::list<EuclideanAreaElement<Frame>, IntegrandTag,
                                    StrahlkorperTags::Strahlkorper<Frame>>;
 };
+// }@
 
+// @{
 /// Computes the Euclidean-space integral of a vector over a
 /// Strahlkorper, \f$\oint V^i s_i (s_j s_k \delta^{jk})^{-1/2} d^2 S\f$,
 /// where \f$s_i\f$ is the Strahlkorper surface unit normal and
@@ -296,11 +400,19 @@ struct EuclideanSurfaceIntegral : db::ComputeTag {
 /// not assumed to be normalized; the denominator of the integrand
 /// effectively normalizes it using the Euclidean metric.
 template <typename IntegrandTag, typename Frame>
-struct EuclideanSurfaceIntegralVector : db::ComputeTag {
+struct EuclideanSurfaceIntegralVector : db::SimpleTag {
   static std::string name() noexcept {
     return "EuclideanSurfaceIntegralVector(" + db::tag_name<IntegrandTag>() +
            ")";
   }
+  using type = double;
+};
+
+template <typename IntegrandTag, typename Frame>
+struct EuclideanSurfaceIntegralVectorCompute
+    : EuclideanSurfaceIntegralVector<IntegrandTag, Frame>,
+      db::ComputeTag {
+  using base = EuclideanSurfaceIntegralVector<IntegrandTag, Frame>;
   using return_type = double;
   static void function(const gsl::not_null<double*> surface_integral,
                        const Scalar<DataVector>& euclidean_area_element,
@@ -315,16 +427,19 @@ struct EuclideanSurfaceIntegralVector : db::ComputeTag {
                                    StrahlkorperTags::NormalOneForm<Frame>,
                                    StrahlkorperTags::Strahlkorper<Frame>>;
 };
+// }@
 
 template <typename Frame>
 using items_tags = tmpl::list<Strahlkorper<Frame>>;
 
 template <typename Frame>
 using compute_items_tags =
-    tmpl::list<ThetaPhi<Frame>, Rhat<Frame>, Jacobian<Frame>,
-               InvJacobian<Frame>, InvHessian<Frame>, Radius<Frame>,
-               CartesianCoords<Frame>, DxRadius<Frame>, D2xRadius<Frame>,
-               LaplacianRadius<Frame>, NormalOneForm<Frame>, Tangents<Frame>>;
+    tmpl::list<ThetaPhiCompute<Frame>, RhatCompute<Frame>,
+               JacobianCompute<Frame>, InvJacobianCompute<Frame>,
+               InvHessianCompute<Frame>, RadiusCompute<Frame>,
+               CartesianCoordsCompute<Frame>, DxRadiusCompute<Frame>,
+               D2xRadiusCompute<Frame>, LaplacianRadiusCompute<Frame>,
+               NormalOneFormCompute<Frame>, TangentsCompute<Frame>>;
 
 }  // namespace StrahlkorperTags
 
@@ -334,10 +449,16 @@ namespace StrahlkorperGr {
 /// also need a metric.
 namespace Tags {
 
+// @{
 /// Computes the area element on a Strahlkorper. Useful for integrals.
 template <typename Frame>
-struct AreaElement : db::ComputeTag {
-  static std::string name() noexcept { return "AreaElement"; }
+struct AreaElement : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+template <typename Frame>
+struct AreaElementCompute : AreaElement<Frame>, db::ComputeTag {
+  using base = AreaElement<Frame>;
   using return_type = Scalar<DataVector>;
   static constexpr auto function = static_cast<void (*)(
       gsl::not_null<Scalar<DataVector>*>, const tnsr::ii<DataVector, 3, Frame>&,
@@ -349,13 +470,22 @@ struct AreaElement : db::ComputeTag {
       StrahlkorperTags::NormalOneForm<Frame>, StrahlkorperTags::Radius<Frame>,
       StrahlkorperTags::Rhat<Frame>>;
 };
+// }@
 
+// @{
 /// Computes the integral of a scalar over a Strahlkorper.
 template <typename IntegrandTag, typename Frame>
-struct SurfaceIntegral : db::ComputeTag {
+struct SurfaceIntegral : db::SimpleTag {
   static std::string name() noexcept {
     return "SurfaceIntegral(" + db::tag_name<IntegrandTag>() + ")";
   }
+  using type = double;
+};
+
+template <typename IntegrandTag, typename Frame>
+struct SurfaceIntegralCompute : SurfaceIntegral<IntegrandTag, Frame>,
+                                db::ComputeTag {
+  using base = SurfaceIntegral<IntegrandTag, Frame>;
   using return_type = double;
   static void function(const gsl::not_null<double*> surface_integral,
                        const Scalar<DataVector>& area_element,
@@ -367,15 +497,19 @@ struct SurfaceIntegral : db::ComputeTag {
   using argument_tags = tmpl::list<AreaElement<Frame>, IntegrandTag,
                                    StrahlkorperTags::Strahlkorper<Frame>>;
 };
+// }@
+
 /// Tag representing the surface area of a Strahlkorper
 struct Area : db::SimpleTag {
   using type = double;
 };
+
 /// Computes the surface area of a Strahlkorer, \f$A = \oint_S dA\f$ given an
 /// AreaElement \f$dA\f$ and a Strahlkorper \f$S\f$.
 template <typename Frame>
 struct AreaCompute : Area, db::ComputeTag {
   using base = Area;
+  using return_type = double;
   static double function(const Strahlkorper<Frame>& strahlkorper,
                          const Scalar<DataVector>& area_element) noexcept {
     return strahlkorper.ylm_spherepack().definite_integral(
@@ -384,10 +518,12 @@ struct AreaCompute : Area, db::ComputeTag {
   using argument_tags =
       tmpl::list<StrahlkorperTags::Strahlkorper<Frame>, AreaElement<Frame>>;
 };
+
 /// The Irreducible (areal) mass of an apparent horizon
 struct IrreducibleMass : db::SimpleTag {
   using type = double;
 };
+
 /// Computes the Irreducible mass of an apparent horizon from its area
 template <typename Frame>
 struct IrreducibleMassCompute : IrreducibleMass, db::ComputeTag {

--- a/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
@@ -95,13 +95,8 @@ namespace Tags {
 /// \ingroup DataBoxTagsGroup
 /// \ingroup DataStructuresGroup
 /// The magnitude of a (co)vector
-///
-/// \snippet Test_Magnitude.cpp magnitude_name
 template <typename Tag>
 struct Magnitude : db::PrefixTag, db::SimpleTag {
-  static std::string name() noexcept {
-    return "Magnitude(" + db::tag_name<Tag>() + ")";
-  }
   using tag = Tag;
   using type = Scalar<DataVector>;
 };
@@ -139,13 +134,8 @@ struct NonEuclideanMagnitude : Magnitude<Tag>, db::ComputeTag {
 /// \ingroup DataBoxTagsGroup
 /// \ingroup DataStructuresGroup
 /// The normalized (co)vector represented by Tag
-///
-/// \snippet Test_Magnitude.cpp normalized_name
 template <typename Tag>
 struct Normalized : db::PrefixTag, db::SimpleTag {
-  static std::string name() noexcept {
-    return "Normalized(" + db::tag_name<Tag>() + ")";
-  }
   using tag = Tag;
   using type = typename Tag::type;
 };
@@ -175,13 +165,20 @@ struct NormalizedCompute : Normalized<Tag>, db::ComputeTag {
 /// \ingroup DataBoxTagsGroup
 /// \ingroup DataStructuresGroup
 /// The square root of a scalar
-///
-/// \snippet Test_Magnitude.cpp sqrt_name
 template <typename Tag>
-struct Sqrt : db::ComputeTag {
-  static std::string name() noexcept {
-    return "Sqrt(" + db::tag_name<Tag>() + ")";
-  }
+struct Sqrt : db::PrefixTag, db::SimpleTag {
+  using tag = Tag;
+  using type = Scalar<DataVector>;
+};
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup DataStructuresGroup
+/// The square root of a scalar
+///
+/// This tag inherits from `Tags::Sqrt<Tag>`
+template <typename Tag>
+struct SqrtCompute : Sqrt<Tag>, db::ComputeTag {
+  using base = Sqrt<Tag>;
   using return_type = Scalar<DataVector>;
   static constexpr auto function = static_cast<void (*)(
       const gsl::not_null<return_type*>, const typename Tag::type&) noexcept>(

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -201,7 +201,7 @@ struct EvolutionMetavars {
 
   struct AhA {
     using tags_to_observe =
-        tmpl::list<StrahlkorperGr::Tags::SurfaceIntegral<Unity, frame>>;
+        tmpl::list<StrahlkorperGr::Tags::SurfaceIntegralCompute<Unity, frame>>;
     using compute_items_on_source = tmpl::list<
         gr::Tags::SpatialMetricCompute<volume_dim, frame, DataVector>,
         ah::Tags::InverseSpatialMetricCompute<volume_dim, frame>,
@@ -213,7 +213,7 @@ struct EvolutionMetavars {
                    gr::Tags::ExtrinsicCurvature<volume_dim, frame>,
                    gr::Tags::SpatialChristoffelSecondKind<volume_dim, frame>>;
     using compute_items_on_target = tmpl::append<
-        tmpl::list<StrahlkorperGr::Tags::AreaElement<frame>, Unity>,
+        tmpl::list<StrahlkorperGr::Tags::AreaElementCompute<frame>, Unity>,
         tags_to_observe>;
     using compute_target_points =
         intrp::TargetPoints::ApparentHorizon<AhA, ::Frame::Inertial>;

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -133,7 +133,7 @@ class CProxy_ConstGlobalCache;
 
 struct KerrHorizon {
   using tags_to_observe =
-      tmpl::list<StrahlkorperTags::EuclideanSurfaceIntegralVector<
+      tmpl::list<StrahlkorperTags::EuclideanSurfaceIntegralVectorCompute<
           hydro::Tags::MassFlux<DataVector, 3>, ::Frame::Inertial>>;
   using compute_items_on_source = tmpl::list<>;
   using vars_to_interpolate_to_target =
@@ -145,7 +145,7 @@ struct KerrHorizon {
                  gr::Tags::SqrtDetSpatialMetric<DataVector>>;
   using compute_items_on_target = tmpl::push_front<
       tags_to_observe,
-      StrahlkorperTags::EuclideanAreaElement<::Frame::Inertial>,
+      StrahlkorperTags::EuclideanAreaElementCompute<::Frame::Inertial>,
       hydro::Tags::MassFluxCompute<DataVector, 3, ::Frame::Inertial>>;
   using compute_target_points =
       intrp::TargetPoints::KerrHorizon<KerrHorizon, ::Frame::Inertial>;

--- a/src/Evolution/Systems/Burgers/Characteristics.hpp
+++ b/src/Evolution/Systems/Burgers/Characteristics.hpp
@@ -27,11 +27,9 @@ namespace Burgers {
 namespace Tags {
 /// Computes the characteristic speeds
 struct CharacteristicSpeedsCompute : CharacteristicSpeeds, db::ComputeTag {
-  static std::string name() noexcept { return "CharacteristicSpeeds"; }
-
+  using base = CharacteristicSpeeds;
   using argument_tags =
       tmpl::list<Tags::U, domain::Tags::UnnormalizedFaceNormal<1>>;
-
   using return_type = std::array<DataVector, 1>;
   static void function(gsl::not_null<return_type*> result,
                        const Scalar<DataVector>& u,

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
@@ -183,14 +183,15 @@ struct ApparentHorizon {
         get<::Tags::Tempi<0, 2, ::Frame::Spherical<Frame>>>(temp_buffer);
     auto& r_hat = get<::Tags::Tempi<1, 3, Frame>>(temp_buffer);
     auto& radius = get(get<::Tags::TempScalar<2>>(temp_buffer));
-    StrahlkorperTags::ThetaPhi<Frame>::function(make_not_null(&theta_phi),
-                                                prolonged_strahlkorper);
-    StrahlkorperTags::Rhat<Frame>::function(make_not_null(&r_hat), theta_phi);
-    StrahlkorperTags::Radius<Frame>::function(make_not_null(&radius),
-                                              prolonged_strahlkorper);
+    StrahlkorperTags::ThetaPhiCompute<Frame>::function(
+        make_not_null(&theta_phi), prolonged_strahlkorper);
+    StrahlkorperTags::RhatCompute<Frame>::function(make_not_null(&r_hat),
+                                                   theta_phi);
+    StrahlkorperTags::RadiusCompute<Frame>::function(make_not_null(&radius),
+                                                     prolonged_strahlkorper);
 
     tnsr::I<DataVector, 3, Frame> prolonged_coords{};
-    StrahlkorperTags::CartesianCoords<Frame>::function(
+    StrahlkorperTags::CartesianCoordsCompute<Frame>::function(
         make_not_null(&prolonged_coords), prolonged_strahlkorper, radius,
         r_hat);
 

--- a/tests/Unit/ApparentHorizons/Test_Tags.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Tags.cpp
@@ -300,44 +300,86 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
       "OneOverOneFormMagnitude");
   TestHelpers::db::test_simple_tag<
       StrahlkorperTags::Strahlkorper<Frame::Inertial>>("Strahlkorper");
-  TestHelpers::db::test_compute_tag<
-      StrahlkorperTags::ThetaPhi<Frame::Inertial>>("ThetaPhi");
-  TestHelpers::db::test_compute_tag<StrahlkorperTags::Rhat<Frame::Inertial>>(
+  TestHelpers::db::test_simple_tag<StrahlkorperTags::ThetaPhi<Frame::Inertial>>(
+      "ThetaPhi");
+  TestHelpers::db::test_simple_tag<StrahlkorperTags::Rhat<Frame::Inertial>>(
       "Rhat");
-  TestHelpers::db::test_compute_tag<
-      StrahlkorperTags::Jacobian<Frame::Inertial>>("Jacobian");
-  TestHelpers::db::test_compute_tag<
+  TestHelpers::db::test_simple_tag<StrahlkorperTags::Jacobian<Frame::Inertial>>(
+      "Jacobian");
+  TestHelpers::db::test_simple_tag<
       StrahlkorperTags::InvJacobian<Frame::Inertial>>("InvJacobian");
-  TestHelpers::db::test_compute_tag<
+  TestHelpers::db::test_simple_tag<
       StrahlkorperTags::InvHessian<Frame::Inertial>>("InvHessian");
-  TestHelpers::db::test_compute_tag<StrahlkorperTags::Radius<Frame::Inertial>>(
+  TestHelpers::db::test_simple_tag<StrahlkorperTags::Radius<Frame::Inertial>>(
       "Radius");
-  TestHelpers::db::test_compute_tag<
+  TestHelpers::db::test_simple_tag<
       StrahlkorperTags::CartesianCoords<Frame::Inertial>>("CartesianCoords");
-  TestHelpers::db::test_compute_tag<
-      StrahlkorperTags::DxRadius<Frame::Inertial>>("DxRadius");
-  TestHelpers::db::test_compute_tag<
+  TestHelpers::db::test_simple_tag<StrahlkorperTags::DxRadius<Frame::Inertial>>(
+      "DxRadius");
+  TestHelpers::db::test_simple_tag<
       StrahlkorperTags::D2xRadius<Frame::Inertial>>("D2xRadius");
-  TestHelpers::db::test_compute_tag<
+  TestHelpers::db::test_simple_tag<
       StrahlkorperTags::LaplacianRadius<Frame::Inertial>>("LaplacianRadius");
-  TestHelpers::db::test_compute_tag<
+  TestHelpers::db::test_simple_tag<
       StrahlkorperTags::NormalOneForm<Frame::Inertial>>("NormalOneForm");
-  TestHelpers::db::test_compute_tag<
-      StrahlkorperTags::Tangents<Frame::Inertial>>("Tangents");
-  TestHelpers::db::test_compute_tag<
+  TestHelpers::db::test_simple_tag<StrahlkorperTags::Tangents<Frame::Inertial>>(
+      "Tangents");
+  TestHelpers::db::test_simple_tag<
       StrahlkorperTags::EuclideanAreaElement<Frame::Inertial>>(
       "EuclideanAreaElement");
-  TestHelpers::db::test_compute_tag<
+  TestHelpers::db::test_simple_tag<
       StrahlkorperTags::EuclideanSurfaceIntegral<SomeTag, Frame::Inertial>>(
       "EuclideanSurfaceIntegral(SomeTag)");
-  TestHelpers::db::test_compute_tag<
+  TestHelpers::db::test_simple_tag<
       StrahlkorperTags::EuclideanSurfaceIntegralVector<SomeTag,
                                                        Frame::Inertial>>(
       "EuclideanSurfaceIntegralVector(SomeTag)");
-  TestHelpers::db::test_compute_tag<
+  TestHelpers::db::test_simple_tag<
       StrahlkorperGr::Tags::AreaElement<Frame::Inertial>>("AreaElement");
-  TestHelpers::db::test_compute_tag<
+  TestHelpers::db::test_simple_tag<
       StrahlkorperGr::Tags::SurfaceIntegral<SomeTag, Frame::Inertial>>(
+      "SurfaceIntegral(SomeTag)");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::ThetaPhiCompute<Frame::Inertial>>("ThetaPhi");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::RhatCompute<Frame::Inertial>>("Rhat");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::JacobianCompute<Frame::Inertial>>("Jacobian");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::InvJacobianCompute<Frame::Inertial>>("InvJacobian");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::InvHessianCompute<Frame::Inertial>>("InvHessian");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::RadiusCompute<Frame::Inertial>>("Radius");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::CartesianCoordsCompute<Frame::Inertial>>(
+      "CartesianCoords");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::DxRadiusCompute<Frame::Inertial>>("DxRadius");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::D2xRadiusCompute<Frame::Inertial>>("D2xRadius");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::LaplacianRadiusCompute<Frame::Inertial>>(
+      "LaplacianRadius");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::NormalOneFormCompute<Frame::Inertial>>("NormalOneForm");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::TangentsCompute<Frame::Inertial>>("Tangents");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::EuclideanAreaElementCompute<Frame::Inertial>>(
+      "EuclideanAreaElement");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::EuclideanSurfaceIntegralCompute<SomeTag,
+                                                        Frame::Inertial>>(
+      "EuclideanSurfaceIntegral(SomeTag)");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::EuclideanSurfaceIntegralVectorCompute<SomeTag,
+                                                              Frame::Inertial>>(
+      "EuclideanSurfaceIntegralVector(SomeTag)");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperGr::Tags::AreaElementCompute<Frame::Inertial>>("AreaElement");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperGr::Tags::SurfaceIntegralCompute<SomeTag, Frame::Inertial>>(
       "SurfaceIntegral(SomeTag)");
   TestHelpers::db::test_compute_tag<
       StrahlkorperGr::Tags::AreaCompute<Frame::Inertial>>("Area");

--- a/tests/Unit/DataStructures/DataBox/Test_DataBoxDocumentation.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBoxDocumentation.cpp
@@ -309,21 +309,22 @@ const double volume = db::get<Volume>(refined_databox);
 return density * volume *  velocity * velocity / radius;
 }
 
-double mass_from_density_and_volume(
+void mass_from_density_and_volume(const gsl::not_null<double*> result,
   const double density, const double volume) noexcept {
-  return density * volume;
+  *result = density * volume;
 }
 /// [compute_tags]
 struct MassCompute : db::ComputeTag, Mass {
-  static std::string name() noexcept { return "MassCompute"; }
+  using base = Mass;
+  using return_type = double;
   static constexpr auto function = &mass_from_density_and_volume;
   using argument_tags = tmpl::list<Density, Volume>;
 };
 /// [compute_tags]
 
-double acceleration_from_velocity_and_radius(
+void acceleration_from_velocity_and_radius(const gsl::not_null<double*> result,
   const double velocity, const double radius) noexcept {
-  return velocity * velocity / radius;
+  *result = velocity * velocity / radius;
 }
 
 struct Acceleration : db::SimpleTag {
@@ -331,7 +332,8 @@ struct Acceleration : db::SimpleTag {
 };
 
 struct AccelerationCompute : db::ComputeTag, Acceleration {
-  static std::string name() noexcept { return "AccelerationCompute"; }
+  using base = Acceleration;
+  using return_type = double;
   static constexpr auto function = &acceleration_from_velocity_and_radius;
   using argument_tags = tmpl::list<Velocity, Radius>;
 };
@@ -342,10 +344,11 @@ struct Force : db::SimpleTag {
 };
 
 struct ForceCompute : db::ComputeTag, Force {
-  static std::string name() noexcept { return "ForceCompute"; }
-  static constexpr auto function(
+  using base = Force;
+  using return_type = double;
+  static constexpr void function(const gsl::not_null<double*> result,
     const double mass, const double acceleration) noexcept {
-    return mass * acceleration; }
+    *result = mass * acceleration; }
   using argument_tags = tmpl::list<Mass, Acceleration>;
 };
 /// [compute_tags_force_compute]

--- a/tests/Unit/DataStructures/DataBox/Test_TagName.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_TagName.cpp
@@ -40,18 +40,6 @@ struct NamedSimpleCompute : NamedSimple, db::ComputeTag {
   using base = NamedSimple;
 };
 
-struct BaseNamedCompute : TestHelpers::db::Tags::Base, db::ComputeTag {
-  static std::string name() noexcept { return "NameOfBaseCompute"; }
-};
-
-struct NamedBaseNamedCompute : NamedBase, db::ComputeTag {
-  static std::string name() noexcept { return "NameOfNamedBaseCompute"; }
-};
-
-struct NamedBaseCompute : NamedBase, db::ComputeTag {
-  using base = NamedBase;
-};
-
 struct SimpleWithBaseNamedCompute : TestHelpers::db::Tags::SimpleWithBase,
                                     db::ComputeTag {
   static std::string name() noexcept { return "NameOfSimpleWithBaseCompute"; }
@@ -127,9 +115,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.TagName",
   CHECK(db::tag_name<TestHelpers::db::Tags::Simple>() == "Simple");
   CHECK(db::tag_name<TestHelpers::db::Tags::SimpleWithBase>() ==
         "SimpleWithBase");
-  CHECK(db::tag_name<TestHelpers::db::Tags::Compute>() == "Compute");
   CHECK(db::tag_name<TestHelpers::db::Tags::SimpleCompute>() == "Simple");
-  CHECK(db::tag_name<TestHelpers::db::Tags::BaseCompute>() == "Base");
   CHECK(db::tag_name<TestHelpers::db::Tags::SimpleWithBaseCompute>() ==
         "SimpleWithBase");
   CHECK(db::tag_name<NamedSimple>() == "NameOfSimple");
@@ -141,9 +127,6 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.TagName",
   CHECK(db::tag_name<SimpleNamedCompute>() == "NameOfSimpleCompute");
   CHECK(db::tag_name<NamedSimpleNamedCompute>() == "NameOfNamedSimpleCompute");
   CHECK(db::tag_name<NamedSimpleCompute>() == "NameOfSimple");
-  CHECK(db::tag_name<BaseNamedCompute>() == "NameOfBaseCompute");
-  CHECK(db::tag_name<NamedBaseNamedCompute>() == "NameOfNamedBaseCompute");
-  CHECK(db::tag_name<NamedBaseCompute>() == "NameOfBase");
   CHECK(db::tag_name<SimpleWithBaseNamedCompute>() ==
         "NameOfSimpleWithBaseCompute");
   CHECK(db::tag_name<NamedSimpleWithBaseNamedCompute>() ==
@@ -166,15 +149,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.TagName",
   CHECK(db::tag_name<TestHelpers::db::Tags::Label<
             TestHelpers::db::Tags::SimpleWithBase>>() ==
         "Label(SimpleWithBase)");
-  CHECK(db::tag_name<
-            TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Compute>>() ==
-        "Label(Compute)");
   CHECK(db::tag_name<TestHelpers::db::Tags::Label<
             TestHelpers::db::Tags::SimpleCompute>>() == "Label(Simple)");
-  CHECK(
-      db::tag_name<
-          TestHelpers::db::Tags::Label<TestHelpers::db::Tags::BaseCompute>>() ==
-      "Label(Base)");
   CHECK(db::tag_name<TestHelpers::db::Tags::Label<
             TestHelpers::db::Tags::SimpleWithBaseCompute>>() ==
         "Label(SimpleWithBase)");
@@ -195,12 +171,6 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.TagName",
         "Label(NameOfNamedSimpleCompute)");
   CHECK(db::tag_name<TestHelpers::db::Tags::Label<NamedSimpleCompute>>() ==
         "Label(NameOfSimple)");
-  CHECK(db::tag_name<TestHelpers::db::Tags::Label<BaseNamedCompute>>() ==
-        "Label(NameOfBaseCompute)");
-  CHECK(db::tag_name<TestHelpers::db::Tags::Label<NamedBaseNamedCompute>>() ==
-        "Label(NameOfNamedBaseCompute)");
-  CHECK(db::tag_name<TestHelpers::db::Tags::Label<NamedBaseCompute>>() ==
-        "Label(NameOfBase)");
   CHECK(db::tag_name<
             TestHelpers::db::Tags::Label<SimpleWithBaseNamedCompute>>() ==
         "Label(NameOfSimpleWithBaseCompute)");
@@ -223,11 +193,6 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.TagName",
             TestHelpers::db::Tags::Label<NamedSimpleWithNamedBaseCompute>>() ==
         "Label(NameOfSimpleWithNamedBase)");
 
-  CHECK(db::tag_name<
-            TestHelpers::db::Tags::Operator<TestHelpers::db::Tags::Simple>>() ==
-        "Operator(Simple)");
-  CHECK(db::tag_name<TestHelpers::db::Tags::LabelCompute<
-            TestHelpers::db::Tags::Simple>>() == "Label(Simple)");
   CHECK(db::tag_name<NamedLabel<TestHelpers::db::Tags::Simple>>() ==
         "NameOfLabel(Simple)");
   CHECK(db::tag_name<LabelNamedCompute<TestHelpers::db::Tags::Simple>>() ==
@@ -237,10 +202,6 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.TagName",
   CHECK(db::tag_name<NamedLabelNamedCompute<TestHelpers::db::Tags::Simple>>() ==
         "NameOfNamedLabelCompute(Simple)");
 
-  CHECK(db::tag_name<TestHelpers::db::Tags::Operator<NamedSimple>>() ==
-        "Operator(NameOfSimple)");
-  CHECK(db::tag_name<TestHelpers::db::Tags::LabelCompute<NamedSimple>>() ==
-        "Label(NameOfSimple)");
   CHECK(db::tag_name<NamedLabel<NamedSimple>>() == "NameOfLabel(NameOfSimple)");
   CHECK(db::tag_name<LabelNamedCompute<NamedSimple>>() ==
         "NameOfLabelCompute(NameOfSimple)");
@@ -248,19 +209,4 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.TagName",
         "NameOfLabel(NameOfSimple)");
   CHECK(db::tag_name<NamedLabelNamedCompute<NamedSimple>>() ==
         "NameOfNamedLabelCompute(NameOfSimple)");
-
-  CHECK(db::tag_name<TestHelpers::db::Tags::Operator<
-            TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>>() ==
-        "Operator(Label(Simple))");
-  CHECK(db::tag_name<TestHelpers::db::Tags::Operator<
-            NamedLabel<TestHelpers::db::Tags::Simple>>>() ==
-        "Operator(NameOfLabel(Simple))");
-  CHECK(
-      db::tag_name<TestHelpers::db::Tags::Label<
-          TestHelpers::db::Tags::Operator<TestHelpers::db::Tags::Simple>>>() ==
-      "Label(Operator(Simple))");
-  CHECK(
-      db::tag_name<NamedLabel<
-          TestHelpers::db::Tags::Operator<TestHelpers::db::Tags::Simple>>>() ==
-      "NameOfLabel(Operator(Simple))");
 }

--- a/tests/Unit/DataStructures/DataBox/Test_TagTraits.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_TagTraits.cpp
@@ -12,11 +12,7 @@ static_assert(not db::is_compute_tag_v<TestHelpers::db::Tags::Base>,
               "Failed testing is_compute_tag");
 static_assert(not db::is_compute_tag_v<TestHelpers::db::Tags::SimpleWithBase>,
               "Failed testing is_compute_tag");
-static_assert(db::is_compute_tag_v<TestHelpers::db::Tags::Compute>,
-              "Failed testing is_compute_tag");
 static_assert(db::is_compute_tag_v<TestHelpers::db::Tags::SimpleCompute>,
-              "Failed testing is_compute_tag");
-static_assert(db::is_compute_tag_v<TestHelpers::db::Tags::BaseCompute>,
               "Failed testing is_compute_tag");
 static_assert(
     db::is_compute_tag_v<TestHelpers::db::Tags::SimpleWithBaseCompute>,
@@ -24,14 +20,6 @@ static_assert(
 static_assert(not db::is_compute_tag_v<
                   TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>,
               "Failed testing is_compute_tag");
-static_assert(
-    db::is_compute_tag_v<
-        TestHelpers::db::Tags::Operator<TestHelpers::db::Tags::Simple>>,
-    "Failed testing is_compute_tag");
-static_assert(
-    db::is_compute_tag_v<
-        TestHelpers::db::Tags::LabelCompute<TestHelpers::db::Tags::Simple>>,
-    "Failed testing is_compute_tag");
 
 static_assert(not db::is_non_base_tag_v<TestHelpers::db::Tags::Bad>,
               "Failed testing is_non_base_tag");
@@ -41,11 +29,7 @@ static_assert(not db::is_non_base_tag_v<TestHelpers::db::Tags::Base>,
               "Failed testing is_non_base_tag");
 static_assert(db::is_non_base_tag_v<TestHelpers::db::Tags::SimpleWithBase>,
               "Failed testing is_non_base_tag");
-static_assert(db::is_non_base_tag_v<TestHelpers::db::Tags::Compute>,
-              "Failed testing is_non_base_tag");
 static_assert(db::is_non_base_tag_v<TestHelpers::db::Tags::SimpleCompute>,
-              "Failed testing is_non_base_tag");
-static_assert(db::is_non_base_tag_v<TestHelpers::db::Tags::BaseCompute>,
               "Failed testing is_non_base_tag");
 static_assert(
     db::is_non_base_tag_v<TestHelpers::db::Tags::SimpleWithBaseCompute>,
@@ -53,14 +37,6 @@ static_assert(
 static_assert(db::is_non_base_tag_v<
                   TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>,
               "Failed testing is_non_base_tag");
-static_assert(
-    db::is_non_base_tag_v<
-        TestHelpers::db::Tags::Operator<TestHelpers::db::Tags::Simple>>,
-    "Failed testing is_non_base_tag");
-static_assert(
-    db::is_non_base_tag_v<
-        TestHelpers::db::Tags::LabelCompute<TestHelpers::db::Tags::Simple>>,
-    "Failed testing is_non_base_tag");
 
 static_assert(not db::is_tag_v<TestHelpers::db::Tags::Bad>,
               "Failed testing is_tag");
@@ -70,24 +46,12 @@ static_assert(db::is_tag_v<TestHelpers::db::Tags::Base>,
               "Failed testing is_tag");
 static_assert(db::is_tag_v<TestHelpers::db::Tags::SimpleWithBase>,
               "Failed testing is_tag");
-static_assert(db::is_tag_v<TestHelpers::db::Tags::Compute>,
-              "Failed testing is_tag");
 static_assert(db::is_tag_v<TestHelpers::db::Tags::SimpleCompute>,
-              "Failed testing is_tag");
-static_assert(db::is_tag_v<TestHelpers::db::Tags::BaseCompute>,
               "Failed testing is_tag");
 static_assert(db::is_tag_v<TestHelpers::db::Tags::SimpleWithBaseCompute>,
               "Failed testing is_tag");
 static_assert(
     db::is_tag_v<TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>,
-    "Failed testing is_tag");
-static_assert(
-    db::is_tag_v<
-        TestHelpers::db::Tags::Operator<TestHelpers::db::Tags::Simple>>,
-    "Failed testing is_tag");
-static_assert(
-    db::is_tag_v<
-        TestHelpers::db::Tags::LabelCompute<TestHelpers::db::Tags::Simple>>,
     "Failed testing is_tag");
 
 static_assert(not db::is_base_tag_v<TestHelpers::db::Tags::Bad>,
@@ -98,11 +62,7 @@ static_assert(db::is_base_tag_v<TestHelpers::db::Tags::Base>,
               "Failed testing is_base_tag");
 static_assert(not db::is_base_tag_v<TestHelpers::db::Tags::SimpleWithBase>,
               "Failed testing is_base_tag");
-static_assert(not db::is_base_tag_v<TestHelpers::db::Tags::Compute>,
-              "Failed testing is_base_tag");
 static_assert(not db::is_base_tag_v<TestHelpers::db::Tags::SimpleCompute>,
-              "Failed testing is_base_tag");
-static_assert(not db::is_base_tag_v<TestHelpers::db::Tags::BaseCompute>,
               "Failed testing is_base_tag");
 static_assert(
     not db::is_base_tag_v<TestHelpers::db::Tags::SimpleWithBaseCompute>,
@@ -110,11 +70,3 @@ static_assert(
 static_assert(not db::is_base_tag_v<
                   TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>,
               "Failed testing is_base_tag");
-static_assert(
-    not db::is_base_tag_v<
-        TestHelpers::db::Tags::Operator<TestHelpers::db::Tags::Simple>>,
-    "Failed testing is_base_tag");
-static_assert(
-    not db::is_base_tag_v<
-        TestHelpers::db::Tags::LabelCompute<TestHelpers::db::Tags::Simple>>,
-    "Failed testing is_base_tag");

--- a/tests/Unit/DataStructures/Tensor/EagerMath/Test_Magnitude.cpp
+++ b/tests/Unit/DataStructures/Tensor/EagerMath/Test_Magnitude.cpp
@@ -170,12 +170,8 @@ void test_magnitude_tags() {
             {{{3. / 5., 5. / 13.}, {4. / 5., 12. / 13.}}}));
 
   using Tag = Vector;
-  /// [magnitude_name]
   TestHelpers::db::test_prefix_tag<Tags::Magnitude<Tag>>("Magnitude(Vector)");
-  /// [magnitude_name]
-  /// [normalized_name]
   TestHelpers::db::test_prefix_tag<Tags::Normalized<Tag>>("Normalized(Vector)");
-  /// [normalized_name]
   TestHelpers::db::test_compute_tag<Tags::EuclideanMagnitude<Tag>>(
       "Magnitude(Vector)");
   TestHelpers::db::test_compute_tag<Tags::NormalizedCompute<Tag>>(
@@ -255,14 +251,13 @@ void test_root_tags() {
 
   const auto box =
       db::create<db::AddSimpleTags<MyScalar>,
-                 db::AddComputeTags<Tags::Sqrt<MyScalar>>>(my_scalar);
+                 db::AddComputeTags<Tags::SqrtCompute<MyScalar>>>(my_scalar);
 
   CHECK(get(db::get<Tags::Sqrt<MyScalar>>(box)) == DataVector{npts, sqrt(3.0)});
 
   using Tag = MyScalar;
-  /// [sqrt_name]
-  TestHelpers::db::test_compute_tag<Tags::Sqrt<Tag>>("Sqrt(MyScalar)");
-  /// [sqrt_name]
+  TestHelpers::db::test_simple_tag<Tags::Sqrt<Tag>>("Sqrt(MyScalar)");
+  TestHelpers::db::test_compute_tag<Tags::SqrtCompute<Tag>>("Sqrt(MyScalar)");
 }
 }  // namespace
 

--- a/tests/Unit/Helpers/DataStructures/DataBox/TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/DataBox/TestHelpers.hpp
@@ -11,9 +11,18 @@
 #include "DataStructures/DataBox/TagName.hpp"
 #include "DataStructures/DataBox/TagTraits.hpp"
 #include "Utilities/TypeTraits.hpp"
+#include "Utilities/TypeTraits/CreateHasStaticMemberVariable.hpp"
+#include "Utilities/TypeTraits/CreateHasTypeAlias.hpp"
 #include "Utilities/TypeTraits/CreateIsCallable.hpp"
 
 namespace TestHelpers {
+
+CREATE_HAS_TYPE_ALIAS(base)
+CREATE_HAS_TYPE_ALIAS_V(base)
+CREATE_HAS_TYPE_ALIAS(argument_tags)
+CREATE_HAS_TYPE_ALIAS_V(argument_tags)
+CREATE_HAS_TYPE_ALIAS(return_type)
+CREATE_HAS_TYPE_ALIAS_V(return_type)
 
 namespace db {
 
@@ -44,6 +53,10 @@ template <typename Tag>
 void test_compute_tag(const std::string& expected_name) {
   static_assert(::db::is_compute_tag_v<Tag>,
                 "A compute tag must be derived from db::ComputeTag");
+  static_assert(has_return_type_v<Tag>);
+  static_assert(has_argument_tags_v<Tag>);
+  static_assert(has_base_v<Tag>);
+  static_assert(std::is_same_v<typename Tag::return_type, typename Tag::type>);
   detail::check_tag_name<Tag>(expected_name);
 }
 

--- a/tests/Unit/Helpers/DataStructures/DataBox/TestTags.hpp
+++ b/tests/Unit/Helpers/DataStructures/DataBox/TestTags.hpp
@@ -7,13 +7,14 @@
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataBox/TagName.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace TestHelpers {
 
 struct SomeType;
 
-SomeType do_something();
+void do_something(gsl::not_null<SomeType*> /* return_value */);
 
 namespace db {
 namespace Tags {
@@ -30,27 +31,17 @@ struct SimpleWithBase : Base, ::db::SimpleTag {
   using type = SomeType;
 };
 
-struct Compute : ::db::ComputeTag {
-  using argument_list = tmpl::list<>;
-  static constexpr auto function = do_something;
-  static std::string name() noexcept { return "Compute"; }
-};
-
 struct SimpleCompute : Simple, ::db::ComputeTag {
   using base = Simple;
-  using argument_list = tmpl::list<>;
-  static constexpr auto function = do_something;
-};
-
-struct BaseCompute : Base, ::db::ComputeTag {
-  using base = Base;
-  using argument_list = tmpl::list<>;
+  using return_type = SomeType;
+  using argument_tags = tmpl::list<>;
   static constexpr auto function = do_something;
 };
 
 struct SimpleWithBaseCompute : SimpleWithBase, ::db::ComputeTag {
   using base = SimpleWithBase;
-  using argument_list = tmpl::list<>;
+  using return_type = SomeType;
+  using argument_tags = tmpl::list<>;
   static constexpr auto function = do_something;
 };
 
@@ -60,24 +51,6 @@ struct Label : ::db::PrefixTag, ::db::SimpleTag {
   using type = SomeType;
 };
 
-template <typename Tag>
-struct Operator : ::db::PrefixTag, ::db::ComputeTag {
-  using tag = Tag;
-  using argument_list = tmpl::list<>;
-
-  static std::string name() noexcept {
-    return "Operator(" + ::db::tag_name<Tag>() + ")";
-  }
-  static constexpr auto function = do_something;
-};
-
-template <typename Tag>
-struct LabelCompute : Label<Tag>, ::db::ComputeTag {
-  using base = Label<Tag>;
-  using tag = Tag;
-  using argument_list = tmpl::list<>;
-  static constexpr auto function = do_something;
-};
 
 }  // namespace Tags
 }  // namespace db

--- a/tests/Unit/Helpers/NumericalAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp
+++ b/tests/Unit/Helpers/NumericalAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp
@@ -30,6 +30,8 @@
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
 #include "Time/TimeStepId.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
 
 /// Holds code that is shared between multiple tests. Currently used by
 /// - Test_InterpolateToTarget
@@ -45,16 +47,16 @@ struct TestSolution : db::SimpleTag {
 struct TestTargetPoints : db::SimpleTag {
   using type = tnsr::I<DataVector, 3, Frame::Inertial>;
 };
-// ComputeItem for test.
 struct MultiplyByTwo : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
-struct MultiplyByTwoComputeItem : MultiplyByTwo, db::ComputeTag {
-  static Scalar<DataVector> function(const Scalar<DataVector>& x) noexcept {
-    auto result = make_with_value<Scalar<DataVector>>(x, 0.0);
-    get<>(result) = get<>(x) * 2.0;
-    return result;
+// Compute tag for test.
+struct MultiplyByTwoCompute : MultiplyByTwo, db::ComputeTag {
+  static void function(const gsl::not_null<Scalar<DataVector>*> result,
+                       const Scalar<DataVector>& x) noexcept {
+    get<>(*result) = get<>(x) * 2.0;
   }
+  using return_type = Scalar<DataVector>;
   using argument_tags = tmpl::list<TestSolution>;
   using base = MultiplyByTwo;
 };

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateToTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateToTarget.cpp
@@ -34,8 +34,7 @@ struct mock_element {
                  intrp::Tags::InterpPointInfo<Metavariables>>;
   using compute_tags = tmpl::conditional_t<
       AddComputeItemToBox,
-      tmpl::list<
-          InterpolateOnElementTestHelpers::Tags::MultiplyByTwoComputeItem>,
+      tmpl::list<InterpolateOnElementTestHelpers::Tags::MultiplyByTwoCompute>,
       tmpl::list<>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
@@ -92,8 +91,7 @@ struct MockMetavariables {
         InterpolateOnElementTestHelpers::Tags::TestSolution>>;
     using compute_items_on_source = tmpl::conditional_t<
         HaveComputeItemsOnSource,
-        tmpl::list<
-            InterpolateOnElementTestHelpers::Tags::MultiplyByTwoComputeItem>,
+        tmpl::list<InterpolateOnElementTestHelpers::Tags::MultiplyByTwoCompute>,
         tmpl::list<>>;
   };
   using temporal_id = ::Tags::TimeStepId;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateWithoutInterpComponent.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateWithoutInterpComponent.cpp
@@ -93,8 +93,7 @@ struct MockMetavariables {
         InterpolateOnElementTestHelpers::Tags::TestSolution>>;
     using compute_items_on_source = tmpl::conditional_t<
         HaveComputeItemsOnSource,
-        tmpl::list<
-            InterpolateOnElementTestHelpers::Tags::MultiplyByTwoComputeItem>,
+        tmpl::list<InterpolateOnElementTestHelpers::Tags::MultiplyByTwoCompute>,
         tmpl::list<>>;
   };
   using temporal_id = ::Tags::TimeStepId;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
@@ -42,12 +42,10 @@
 // IWYU pragma: no_forward_declare ActionTesting::InitializeDataBox
 // IWYU pragma: no_forward_declare Tensor
 // IWYU pragma: no_forward_declare Variables
-namespace intrp {
-namespace Actions {
+namespace intrp::Actions {
 template <typename InterpolationTargetTag>
 struct CleanUpInterpolator;
-}  // namespace Actions
-}  // namespace intrp
+}  // namespace intrp::Actions
 namespace Parallel {
 template <typename Metavariables>
 class ConstGlobalCache;
@@ -56,8 +54,7 @@ namespace db {
 template <typename TagsList>
 class DataBox;
 }  // namespace db
-namespace intrp {
-namespace Tags {
+namespace intrp::Tags {
 template <typename Metavariables>
 struct IndicesOfFilledInterpPoints;
 struct NumberOfElements;
@@ -65,8 +62,7 @@ template <typename TemporalId>
 struct TemporalIds;
 template <typename TemporalId>
 struct CompletedTemporalIds;
-}  // namespace Tags
-}  // namespace intrp
+}  // namespace intrp::Tags
 /// \endcond
 
 namespace {
@@ -167,14 +163,14 @@ namespace Tags {
 struct Square : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
-struct SquareComputeItem : Square, db::ComputeTag {
-  static Scalar<DataVector> function(const Scalar<DataVector>& x) noexcept {
-    auto result = make_with_value<Scalar<DataVector>>(x, 0.0);
-    get<>(result) = square(get<>(x));
-    return result;
+struct SquareCompute : Square, db::ComputeTag {
+  static void function(gsl::not_null<Scalar<DataVector>*> result,
+                       const Scalar<DataVector>& x) noexcept {
+    get(*result) = square(get(x));
   }
   using argument_tags = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using base = Square;
+  using return_type = Scalar<DataVector>;
 };
 }  // namespace Tags
 
@@ -269,7 +265,7 @@ struct MockMetavariables {
         tmpl::list<gr::Tags::Lapse<DataVector>>;
     using compute_target_points = MockComputeTargetPoints;
     using post_interpolation_callback = MockCallBackType;
-    using compute_items_on_target = tmpl::list<Tags::SquareComputeItem>;
+    using compute_items_on_target = tmpl::list<Tags::SquareCompute>;
   };
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetVarsFromElement.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetVarsFromElement.cpp
@@ -41,14 +41,14 @@ struct TestSolution : db::SimpleTag {
 struct Square : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
-struct SquareComputeItem : Square, db::ComputeTag {
-  static Scalar<DataVector> function(const Scalar<DataVector>& x) noexcept {
-    auto result = make_with_value<Scalar<DataVector>>(x, 0.0);
-    get<>(result) = square(get<>(x));
-    return result;
+struct SquareCompute : Square, db::ComputeTag {
+  static void function(gsl::not_null<Scalar<DataVector>*> result,
+                       const Scalar<DataVector>& x) noexcept {
+    get(*result) = square(get(x));
   }
-  using argument_tags = tmpl::list<Tags::TestSolution>;
+  using argument_tags = tmpl::list<TestSolution>;
   using base = Square;
+  using return_type = Scalar<DataVector>;
 };
 }  // namespace Tags
 
@@ -119,7 +119,7 @@ struct mock_interpolation_target {
 struct MockMetavariables {
   struct InterpolationTargetA {
     using vars_to_interpolate_to_target = tmpl::list<Tags::TestSolution>;
-    using compute_items_on_target = tmpl::list<Tags::SquareComputeItem>;
+    using compute_items_on_target = tmpl::list<Tags::SquareCompute>;
     using compute_target_points = MockComputeTargetPoints;
     using post_interpolation_callback = MockPostInterpolationCallback;
   };

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
@@ -90,14 +90,14 @@ namespace Tags {
 struct Square : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
-struct SquareComputeItem : Square, db::ComputeTag {
-  static Scalar<DataVector> function(const Scalar<DataVector>& x) noexcept {
-    auto result = make_with_value<Scalar<DataVector>>(x, 0.0);
-    get<>(result) = square(get<>(x));
-    return result;
+struct SquareCompute : Square, db::ComputeTag {
+  static void function(gsl::not_null<Scalar<DataVector>*> result,
+                       const Scalar<DataVector>& x) noexcept {
+    get(*result) = square(get(x));
   }
   using argument_tags = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using base = Square;
+  using return_type = Scalar<DataVector>;
 };
 }  // namespace Tags
 
@@ -205,7 +205,7 @@ struct mock_interpolator {
 struct MockMetavariables {
   struct InterpolationTargetA {
     using vars_to_interpolate_to_target = tmpl::list<Tags::Square>;
-    using compute_items_on_source = tmpl::list<Tags::SquareComputeItem>;
+    using compute_items_on_source = tmpl::list<Tags::SquareCompute>;
     using compute_items_on_target = tmpl::list<>;
   };
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
@@ -89,25 +89,25 @@ struct Square : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 struct SquareCompute : Square, db::ComputeTag {
-  static Scalar<DataVector> function(const Scalar<DataVector>& x) noexcept {
-    auto result = make_with_value<Scalar<DataVector>>(x, 0.0);
-    get(result) = square(get(x));
-    return result;
+  static void function(gsl::not_null<Scalar<DataVector>*> result,
+                       const Scalar<DataVector>& x) noexcept {
+    get(*result) = square(get(x));
   }
   using argument_tags = tmpl::list<TestSolution>;
   using base = Square;
+  using return_type = Scalar<DataVector>;
 };
 struct Negate : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 struct NegateCompute : Negate, db::ComputeTag {
-  static Scalar<DataVector> function(const Scalar<DataVector>& x) noexcept {
-    auto result = make_with_value<Scalar<DataVector>>(x, 0.0);
-    get(result) = -get(x);
-    return result;
+  static void function(gsl::not_null<Scalar<DataVector>*> result,
+                       const Scalar<DataVector>& x) noexcept {
+    get(*result) = -get(x);
   }
   using argument_tags = tmpl::list<Square>;
   using base = Negate;
+  using return_type = Scalar<DataVector>;
 };
 }  // namespace Tags
 
@@ -199,10 +199,11 @@ struct MockMetavariables {
     using vars_to_interpolate_to_target =
         tmpl::list<Tags::TestSolution,
                    gr::Tags::SpatialMetric<3, Frame::Inertial>>;
-    using compute_items_on_target = tmpl::list<
-        Tags::SquareCompute,
-        StrahlkorperGr::Tags::AreaElement<Frame::Inertial>,
-        StrahlkorperGr::Tags::SurfaceIntegral<Tags::Square, ::Frame::Inertial>>;
+    using compute_items_on_target =
+        tmpl::list<Tags::SquareCompute,
+                   StrahlkorperGr::Tags::AreaElementCompute<Frame::Inertial>,
+                   StrahlkorperGr::Tags::SurfaceIntegralCompute<
+                       Tags::Square, ::Frame::Inertial>>;
     using compute_target_points =
         intrp::TargetPoints::KerrHorizon<SurfaceA, ::Frame::Inertial>;
     using post_interpolation_callback =
@@ -216,11 +217,13 @@ struct MockMetavariables {
     using vars_to_interpolate_to_target =
         tmpl::list<Tags::TestSolution,
                    gr::Tags::SpatialMetric<3, Frame::Inertial>>;
-    using compute_items_on_target = tmpl::list<
-        Tags::SquareCompute, Tags::NegateCompute,
-        StrahlkorperGr::Tags::AreaElement<Frame::Inertial>,
-        StrahlkorperGr::Tags::SurfaceIntegral<Tags::Square, Frame::Inertial>,
-        StrahlkorperGr::Tags::SurfaceIntegral<Tags::Negate, Frame::Inertial>>;
+    using compute_items_on_target =
+        tmpl::list<Tags::SquareCompute, Tags::NegateCompute,
+                   StrahlkorperGr::Tags::AreaElementCompute<Frame::Inertial>,
+                   StrahlkorperGr::Tags::SurfaceIntegralCompute<
+                       Tags::Square, Frame::Inertial>,
+                   StrahlkorperGr::Tags::SurfaceIntegralCompute<
+                       Tags::Negate, Frame::Inertial>>;
     using compute_target_points =
         intrp::TargetPoints::KerrHorizon<SurfaceB, ::Frame::Inertial>;
     using post_interpolation_callback =
@@ -236,10 +239,11 @@ struct MockMetavariables {
     using vars_to_interpolate_to_target =
         tmpl::list<Tags::TestSolution,
                    gr::Tags::SpatialMetric<3, Frame::Inertial>>;
-    using compute_items_on_target = tmpl::list<
-        Tags::SquareCompute, Tags::NegateCompute,
-        StrahlkorperGr::Tags::AreaElement<Frame::Inertial>,
-        StrahlkorperGr::Tags::SurfaceIntegral<Tags::Negate, ::Frame::Inertial>>;
+    using compute_items_on_target =
+        tmpl::list<Tags::SquareCompute, Tags::NegateCompute,
+                   StrahlkorperGr::Tags::AreaElementCompute<Frame::Inertial>,
+                   StrahlkorperGr::Tags::SurfaceIntegralCompute<
+                       Tags::Negate, ::Frame::Inertial>>;
     using compute_target_points =
         intrp::TargetPoints::KerrHorizon<SurfaceC, ::Frame::Inertial>;
     using post_interpolation_callback =

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
@@ -78,25 +78,25 @@ struct Square : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 struct SquareCompute : Square, db::ComputeTag {
-  static Scalar<DataVector> function(const Scalar<DataVector>& x) noexcept {
-    auto result = make_with_value<Scalar<DataVector>>(x, 0.0);
-    get(result) = square(get(x));
-    return result;
+  static void function(gsl::not_null<Scalar<DataVector>*> result,
+                       const Scalar<DataVector>& x) noexcept {
+    get(*result) = square(get(x));
   }
   using argument_tags = tmpl::list<TestSolution>;
   using base = Square;
+  using return_type = Scalar<DataVector>;
 };
 struct Negate : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 struct NegateCompute : Negate, db::ComputeTag {
-  static Scalar<DataVector> function(const Scalar<DataVector>& x) noexcept {
-    auto result = make_with_value<Scalar<DataVector>>(x, 0.0);
-    get(result) = -get(x);
-    return result;
+  static void function(gsl::not_null<Scalar<DataVector>*> result,
+                       const Scalar<DataVector>& x) noexcept {
+    get(*result) = -get(x);
   }
   using argument_tags = tmpl::list<Square>;
   using base = Negate;
+  using return_type = Scalar<DataVector>;
 };
 }  // namespace Tags
 

--- a/tests/Unit/Parallel/Test_ConstGlobalCacheDataBox.cpp
+++ b/tests/Unit/Parallel/Test_ConstGlobalCacheDataBox.cpp
@@ -82,11 +82,13 @@ SPECTRE_TEST_CASE("Unit.Parallel.ConstGlobalCacheDataBox", "[Unit][Parallel]") {
   TestHelpers::db::test_base_tag<Tags::ConstGlobalCache>("ConstGlobalCache");
   TestHelpers::db::test_simple_tag<Tags::ConstGlobalCacheImpl<Metavars>>(
       "ConstGlobalCache");
-  TestHelpers::db::test_compute_tag<
-      Tags::FromConstGlobalCache<Tags::IntegerList>>(
-      "FromConstGlobalCache(IntegerList)");
-  TestHelpers::db::test_compute_tag<
-      Tags::FromConstGlobalCache<Tags::UniquePtrIntegerList>>(
-      "FromConstGlobalCache(UniquePtrIntegerList)");
+  // In a near-future PR this tag will be converted to a new type of tag called
+  // a db::ReferenceTag as it can not be a mutating compute tag.
+  // TestHelpers::db::test_compute_tag<
+  //     Tags::FromConstGlobalCache<Tags::IntegerList>>(
+  //     "FromConstGlobalCache(IntegerList)");
+  // TestHelpers::db::test_compute_tag<
+  //     Tags::FromConstGlobalCache<Tags::UniquePtrIntegerList>>(
+  //     "FromConstGlobalCache(UniquePtrIntegerList)");
 }
 }  // namespace Parallel

--- a/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_AddComputeTags.cpp
+++ b/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_AddComputeTags.cpp
@@ -12,6 +12,7 @@
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/AddComputeTags.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -25,10 +26,13 @@ struct SquareNumber : db::SimpleTag {
 };
 
 struct SquareNumberCompute : SquareNumber, db::ComputeTag {
-  static double function(const double some_number) noexcept {
-    return square(some_number);
+  static void function(const gsl::not_null<double*> result,
+                       const double some_number) noexcept {
+    *result = square(some_number);
   }
   using argument_tags = tmpl::list<SomeNumber>;
+  using base = SquareNumber;
+  using return_type = double;
 };
 
 template <typename Metavariables>

--- a/tests/Unit/ParallelAlgorithms/Initialization/Test_MergeIntoDataBox.cpp
+++ b/tests/Unit/ParallelAlgorithms/Initialization/Test_MergeIntoDataBox.cpp
@@ -9,6 +9,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -17,99 +18,112 @@ struct NoEquivalence {
   int value = 0;
 };
 
-struct TagInt : db::SimpleTag {
-  static std::string name() noexcept { return "Int"; }
+namespace Tags {
+struct Int : db::SimpleTag {
   using type = int;
 };
 
-struct TagNoEquivalence : db::SimpleTag {
-  static std::string name() noexcept { return "NoEquivalence"; }
-  using type = NoEquivalence;
+struct NoEquivalence : db::SimpleTag {
+  using type = TestAddToBox_detail::NoEquivalence;
 };
 
 template <typename Tag>
-struct TagMultiplyByTwo : db::ComputeTag {
-  static std::string name() noexcept { return "MultiplyByTwo"; }
-  static int function(const int& t) noexcept { return t * 2; }
-  static int function(const NoEquivalence& t) noexcept { return t.value * 2; }
-  using argument_tags = tmpl::list<Tag>;
+struct MultiplyByTwo : db::SimpleTag {
+  using type = int;
 };
+
+template <typename Tag>
+struct MultiplyByTwoCompute : MultiplyByTwo<Tag>, db::ComputeTag {
+  static void function(const gsl::not_null<int*> result,
+                       const int& t) noexcept {
+    *result = t * 2;
+  }
+  static void function(const gsl::not_null<int*> result,
+                       const TestAddToBox_detail::NoEquivalence& t) noexcept {
+    *result = t.value * 2;
+  }
+  using argument_tags = tmpl::list<Tag>;
+  using return_type = int;
+  using base = MultiplyByTwo<Tag>;
+};
+}  // namespace Tags
 
 struct FakeAction {};
 
 void test() {
-  auto box0 =
-      Initialization::merge_into_databox<FakeAction, db::AddSimpleTags<TagInt>>(
-          db::create<db::AddSimpleTags<>>(), 2);
-  CHECK(db::get<TagInt>(box0) == 2);
-  auto box1 =
-      Initialization::merge_into_databox<FakeAction, db::AddSimpleTags<TagInt>>(
-          std::move(box0), 2);
-  CHECK(db::get<TagInt>(box1) == 2);
-  auto box2 =
-      Initialization::merge_into_databox<FakeAction,
-                                         db::AddSimpleTags<TagNoEquivalence>>(
-          std::move(box1), NoEquivalence{5});
-  CHECK(db::get<TagNoEquivalence>(box2).value == 5);
+  auto box0 = Initialization::merge_into_databox<FakeAction,
+                                                 db::AddSimpleTags<Tags::Int>>(
+      db::create<db::AddSimpleTags<>>(), 2);
+  CHECK(db::get<Tags::Int>(box0) == 2);
+  auto box1 = Initialization::merge_into_databox<FakeAction,
+                                                 db::AddSimpleTags<Tags::Int>>(
+      std::move(box0), 2);
+  CHECK(db::get<Tags::Int>(box1) == 2);
+  auto box2 = Initialization::merge_into_databox<
+      FakeAction, db::AddSimpleTags<Tags::NoEquivalence>>(std::move(box1),
+                                                          NoEquivalence{5});
+  CHECK(db::get<Tags::NoEquivalence>(box2).value == 5);
 
   // Make sure that for tags that don't have an equivalence operator we don't
   // overwrite the value.
   auto box3 = Initialization::merge_into_databox<
-      FakeAction, db::AddSimpleTags<TagNoEquivalence>, db::AddComputeTags<>,
+      FakeAction, db::AddSimpleTags<Tags::NoEquivalence>, db::AddComputeTags<>,
       Initialization::MergePolicy::IgnoreIncomparable>(std::move(box2),
                                                        NoEquivalence{7});
-  CHECK(db::get<TagNoEquivalence>(box3).value == 5);
+  CHECK(db::get<Tags::NoEquivalence>(box3).value == 5);
 
   // Check that we can overwrite tags that have an equivalence operator
   auto box4 = Initialization::merge_into_databox<
-      FakeAction, db::AddSimpleTags<TagInt>, db::AddComputeTags<>,
+      FakeAction, db::AddSimpleTags<Tags::Int>, db::AddComputeTags<>,
       Initialization::MergePolicy::Overwrite>(std::move(box3), 4);
-  CHECK(db::get<TagInt>(box4) == 4);
+  CHECK(db::get<Tags::Int>(box4) == 4);
 
   auto box5 = Initialization::merge_into_databox<
-      FakeAction, db::AddSimpleTags<TagNoEquivalence>, db::AddComputeTags<>,
-      Initialization::MergePolicy::Overwrite>(std::move(box4),
-                                              NoEquivalence{7});
-  CHECK(db::get<TagNoEquivalence>(box5).value == 7);
+      FakeAction, db::AddSimpleTags<Tags::NoEquivalence>, db::AddComputeTags<>,
+      Initialization::MergePolicy::Overwrite>(
+      std::move(box4), TestAddToBox_detail::NoEquivalence{7});
+  CHECK(db::get<Tags::NoEquivalence>(box5).value == 7);
 
   // Check that adding nothing works
   auto box6 =
       Initialization::merge_into_databox<FakeAction, db::AddSimpleTags<>>(
           std::move(box5));
-  CHECK(db::get<TagInt>(box6) == 4);
-  CHECK(db::get<TagNoEquivalence>(box6).value == 7);
+  CHECK(db::get<Tags::Int>(box6) == 4);
+  CHECK(db::get<Tags::NoEquivalence>(box6).value == 7);
 
   // Now test that compute items are not re-added, and that they are properly
   // reset if a simple tag is mutated.
   auto box7 = Initialization::merge_into_databox<
       FakeAction, db::AddSimpleTags<>,
-      db::AddComputeTags<TagMultiplyByTwo<TagInt>>>(std::move(box6));
-  CHECK(db::get<TagMultiplyByTwo<TagInt>>(box7) == 8);
+      db::AddComputeTags<Tags::MultiplyByTwoCompute<Tags::Int>>>(
+      std::move(box6));
+  CHECK(db::get<Tags::MultiplyByTwo<Tags::Int>>(box7) == 8);
 
   auto box8 = Initialization::merge_into_databox<
       FakeAction, db::AddSimpleTags<>,
-      db::AddComputeTags<TagMultiplyByTwo<TagInt>,
-                         TagMultiplyByTwo<TagNoEquivalence>>>(std::move(box7));
-  CHECK(db::get<TagMultiplyByTwo<TagNoEquivalence>>(box8) == 14);
+      db::AddComputeTags<Tags::MultiplyByTwoCompute<Tags::Int>,
+                         Tags::MultiplyByTwoCompute<Tags::NoEquivalence>>>(
+      std::move(box7));
+  CHECK(db::get<Tags::MultiplyByTwo<Tags::NoEquivalence>>(box8) == 14);
 
-  // Now swap out the value of TagInt
+  // Now swap out the value of Tags::Int
   auto box9 = Initialization::merge_into_databox<
-      FakeAction, db::AddSimpleTags<TagInt>,
-      db::AddComputeTags<TagMultiplyByTwo<TagInt>,
-                         TagMultiplyByTwo<TagNoEquivalence>>,
+      FakeAction, db::AddSimpleTags<Tags::Int>,
+      db::AddComputeTags<Tags::MultiplyByTwoCompute<Tags::Int>,
+                         Tags::MultiplyByTwoCompute<Tags::NoEquivalence>>,
       Initialization::MergePolicy::Overwrite>(std::move(box8), 10);
-  CHECK(db::get<TagMultiplyByTwo<TagInt>>(box9) == 20);
+  CHECK(db::get<Tags::MultiplyByTwo<Tags::Int>>(box9) == 20);
 }
 
 void test_failure_value() {
-  auto box0 =
-      Initialization::merge_into_databox<FakeAction, db::AddSimpleTags<TagInt>>(
-          db::create<db::AddSimpleTags<>>(), 2);
-  CHECK(db::get<TagInt>(box0) == 2);
+  auto box0 = Initialization::merge_into_databox<FakeAction,
+                                                 db::AddSimpleTags<Tags::Int>>(
+      db::create<db::AddSimpleTags<>>(), 2);
+  CHECK(db::get<Tags::Int>(box0) == 2);
   // This merge should give an error since they're different values
-  auto box1 =
-      Initialization::merge_into_databox<FakeAction, db::AddSimpleTags<TagInt>>(
-          std::move(box0), 3);
+  auto box1 = Initialization::merge_into_databox<FakeAction,
+                                                 db::AddSimpleTags<Tags::Int>>(
+      std::move(box0), 3);
 }
 }  // namespace TestAddToBox_detail
 


### PR DESCRIPTION
Compute tags are now required to have type aliases base, argument_tags, and
return_type, and their function must return void and take as first argument
a gsl::not_null<return_type*>.

Also remove some unnecessary name functions.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
