### PR TITLE
CylindricalFlatEndcap map.

### DIFF
--- a/docs/Images/Domain/CoordinateMaps/CylindricalFlatEndcap.svg
+++ b/docs/Images/Domain/CoordinateMaps/CylindricalFlatEndcap.svg
@@ -1,0 +1,290 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="111.49998mm"
+   height="110.26717mm"
+   viewBox="0 0 111.5 110.26717"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="CylindricalFlatEndcap.svg">
+  <defs
+     id="defs2">
+    <marker
+       inkscape:stockid="StopL"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="StopL"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1089"
+         d="M 0,5.65 V -5.65"
+         style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.8)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <linearGradient
+       id="linearGradient6115"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop6113" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4526"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4524" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4196848"
+     inkscape:cx="257.31664"
+     inkscape:cy="120.70752"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:window-width="1648"
+     inkscape:window-height="1089"
+     inkscape:window-x="182"
+     inkscape:window-y="64"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-text-baseline="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3713"
+       originx="-15.742712"
+       originy="-138.57345" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-15.742708,-48.159376)">
+    <circle
+       id="path3717"
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26458332;stroke-opacity:1"
+       cy="85.333336"
+       cx="52.916668"
+       r="37.041668" />
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6040"
+       cx="48.947918"
+       cy="65.489578"
+       rx="1.1926295"
+       ry="1.1425189" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.66500002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.665, 1.995;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 127,148.83333 48.947917,65.489576 42.333333,148.83333"
+       id="path6046"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6040-6"
+       cx="52.916668"
+       cy="85.333336"
+       rx="1.2427398"
+       ry="1.1926293" />
+    <path
+       style="fill:#969696;fill-opacity:1;stroke:#000000;stroke-width:0.1;stroke-miterlimit:4;stroke-dasharray:0.1, 0.1;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 84.958748,103.91801 c -8.172438,14.0902 -24.590452,21.18818 -40.453634,17.48928 l -2.171781,27.42604 H 127 Z"
+       id="path1267"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6040-7"
+       cx="84.666664"
+       cy="148.83333"
+       rx="1.0924084"
+       ry="1.1425189" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="41.049763"
+       y="68.590691"
+       id="text6177"><tspan
+         sodipodi:role="line"
+         id="tspan6175"
+         x="41.049763"
+         y="68.590691"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">P</tspan><tspan
+         sodipodi:role="line"
+         x="41.049763"
+         y="76.528191"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="tspan6179" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="82.371765"
+       y="145.46812"
+       id="text6153-9"><tspan
+         sodipodi:role="line"
+         id="tspan6151-2"
+         x="82.371765"
+         y="145.46812"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">C</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="86.76902"
+       y="142.10687"
+       id="text6157-5"><tspan
+         sodipodi:role="line"
+         x="86.76902"
+         y="142.10687"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="tspan6163-4">i</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="88.324593"
+       y="158.42654"
+       id="text6243"><tspan
+         sodipodi:role="line"
+         id="tspan6241"
+         x="88.324593"
+         y="158.42654"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">1</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="58.306488"
+       y="94.579178"
+       id="text6247"><tspan
+         sodipodi:role="line"
+         id="tspan6245"
+         x="58.306488"
+         y="94.579178"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">2</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="45.419254"
+       y="64.884178"
+       id="text6157-5-0"><tspan
+         sodipodi:role="line"
+         x="45.419254"
+         y="64.884178"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="tspan6163-4-5">i</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="53.899979"
+       y="93.019722"
+       id="text6153-9-9"><tspan
+         sodipodi:role="line"
+         id="tspan6151-2-2"
+         x="53.899979"
+         y="93.019722"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">C</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="58.771519"
+       y="88.78492"
+       id="text6157-5-5"><tspan
+         sodipodi:role="line"
+         x="58.771519"
+         y="88.78492"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="tspan6163-4-4">i</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="83.876656"
+       y="157.1051"
+       id="text6153-9-96"><tspan
+         sodipodi:role="line"
+         id="tspan6151-2-0"
+         x="83.876656"
+         y="157.1051"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">R</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="86.722115"
+       y="146.45134"
+       id="text6243-0"><tspan
+         sodipodi:role="line"
+         id="tspan6241-2"
+         x="86.722115"
+         y="146.45134"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">1</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="80.050232"
+       y="157.15646"
+       id="text6153-9-96-4"><tspan
+         sodipodi:role="line"
+         id="tspan6151-2-0-3"
+         x="80.050232"
+         y="157.15646"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">2</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.1, 0.1;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#StopL);marker-end:url(#StopL)"
+       d="M 42.333331,151.47916 H 127"
+       id="path918"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.1;stroke-miterlimit:4;stroke-dasharray:0.1, 0.1;stroke-dashoffset:0;stroke-opacity:1"
+       id="path1262"
+       sodipodi:type="arc"
+       sodipodi:cx="52.916668"
+       sodipodi:cy="85.333328"
+       sodipodi:rx="37.041668"
+       sodipodi:ry="37.041668"
+       sodipodi:start="0.53531442"
+       sodipodi:end="2.3697242"
+       d="M 84.776513,104.22871 A 37.041668,37.041668 0 0 1 57.287638,122.1162 37.041668,37.041668 0 0 1 26.372286,111.16898"
+       sodipodi:open="true" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 42.333333,148.83333 H 127"
+       id="path1270"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -16,6 +16,7 @@ spectre_target_sources(
   EquatorialCompression.cpp
   Equiangular.cpp
   FocallyLiftedEndcap.cpp
+  FocallyLiftedFlatEndcap.cpp
   FocallyLiftedMap.cpp
   FocallyLiftedMapHelpers.cpp
   FocallyLiftedSide.cpp
@@ -42,6 +43,7 @@ spectre_target_headers(
   EquatorialCompression.hpp
   Equiangular.hpp
   FocallyLiftedEndcap.hpp
+  FocallyLiftedFlatEndcap.hpp
   FocallyLiftedMap.hpp
   FocallyLiftedMapHelpers.hpp
   FocallyLiftedSide.hpp

--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_sources(
   Affine.cpp
   BulgedCube.cpp
   CylindricalEndcap.cpp
+  CylindricalFlatEndcap.cpp
   CylindricalSide.cpp
   DiscreteRotation.cpp
   EquatorialCompression.cpp
@@ -38,6 +39,7 @@ spectre_target_headers(
   CoordinateMap.tpp
   CoordinateMapHelpers.hpp
   CylindricalEndcap.hpp
+  CylindricalFlatEndcap.hpp
   CylindricalSide.hpp
   DiscreteRotation.hpp
   EquatorialCompression.hpp

--- a/src/Domain/CoordinateMaps/CylindricalFlatEndcap.cpp
+++ b/src/Domain/CoordinateMaps/CylindricalFlatEndcap.cpp
@@ -1,0 +1,125 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/CylindricalFlatEndcap.hpp"
+
+#include <pup.h>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/FocallyLiftedFlatEndcap.hpp"
+#include "Domain/CoordinateMaps/FocallyLiftedMap.hpp"
+#include "Parallel/PupStlCpp11.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace domain::CoordinateMaps {
+
+CylindricalFlatEndcap::CylindricalFlatEndcap(
+    const std::array<double, 3>& center_one,
+    const std::array<double, 3>& center_two,
+    const std::array<double, 3>& proj_center, double radius_one,
+    double radius_two) noexcept
+    : impl_(center_two, proj_center, radius_two, false,
+            FocallyLiftedInnerMaps::FlatEndcap(center_one, radius_one)) {
+#ifdef SPECTRE_DEBUG
+  // There are two types of sanity checks here on the map parameters.
+  // 1) ASSERTS that guarantee that the map is invertible.
+  // 2) ASSERTS that guarantee that the map parameters fall within
+  //    the range tested by the unit tests (which is the range in which
+  //    the map is expected to be used).
+  //
+  // There are two reasons why 1) and 2) are not the same:
+  //
+  // a) It is possible to choose parameters such that the map is
+  //    invertible but the resulting geometry has very sharp angles,
+  //    very large or ill-conditioned Jacobians, or both.  We want to
+  //    avoid such cases.
+  // b) We do not want to waste effort testing the map for parameters
+  //    that we don't expect to be used.
+  ASSERT(center_one[2] <= center_two[2] - 1.05 * radius_two and
+             center_one[2] >= center_two[2] - 6.0 * radius_two,
+         "The map has only been tested for the case when the plane containing "
+         "the circle is below the sphere, by an amount at least 5% of the "
+         "sphere radius but not more than 5 times the sphere radius.");
+
+  const double dist_proj = sqrt(square(center_two[0] - proj_center[0]) +
+                                square(center_two[1] - proj_center[1]) +
+                                square(center_two[2] - proj_center[2]));
+  ASSERT(dist_proj <= 0.95 * radius_two,
+         "The map has been tested only for the case "
+         "when proj_center is contained inside the sphere, and no closer than "
+         "95% of the way to the surface of the sphere");
+
+  ASSERT(radius_one / radius_two <= 10.0 and radius_two / radius_one <= 10.0,
+         "The map has been tested only for the case when the ratio of "
+         "radius_one to radius_two is between 10 and 1/10");
+
+  ASSERT(
+      abs(center_one[0] - center_two[0]) <= radius_one + radius_two and
+          abs(center_one[1] - center_two[1]) <= radius_one + radius_two,
+      "The map has been tested only when the center of the sphere and the "
+      "center of the circle are not too far apart in the x and y directions");
+#endif
+}
+
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, 3> CylindricalFlatEndcap::operator()(
+    const std::array<T, 3>& source_coords) const noexcept {
+  return impl_.operator()(source_coords);
+}
+
+std::optional<std::array<double, 3>> CylindricalFlatEndcap::inverse(
+    const std::array<double, 3>& target_coords) const noexcept {
+  return impl_.inverse(target_coords);
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
+CylindricalFlatEndcap::jacobian(const std::array<T, 3>& source_coords) const
+    noexcept {
+  return impl_.jacobian(source_coords);
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
+CylindricalFlatEndcap::inv_jacobian(const std::array<T, 3>& source_coords) const
+    noexcept {
+  return impl_.inv_jacobian(source_coords);
+}
+
+void CylindricalFlatEndcap::pup(PUP::er& p) noexcept { p | impl_; }
+
+bool operator==(const CylindricalFlatEndcap& lhs,
+                const CylindricalFlatEndcap& rhs) noexcept {
+  return lhs.impl_ == rhs.impl_;
+}
+bool operator!=(const CylindricalFlatEndcap& lhs,
+                const CylindricalFlatEndcap& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+// Explicit instantiations
+/// \cond
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                 \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>               \
+  CylindricalFlatEndcap::operator()(                                         \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;       \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame> \
+  CylindricalFlatEndcap::jacobian(                                           \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;       \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame> \
+  CylindricalFlatEndcap::inv_jacobian(                                       \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
+                                      std::reference_wrapper<const double>,
+                                      std::reference_wrapper<const DataVector>))
+
+#undef DTYPE
+#undef INSTANTIATE
+/// \endcond
+
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/CylindricalFlatEndcap.hpp
+++ b/src/Domain/CoordinateMaps/CylindricalFlatEndcap.hpp
@@ -1,0 +1,125 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines the class CylindricalFlatEndcap.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <optional>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/CoordinateMaps/FocallyLiftedFlatEndcap.hpp"
+#include "Domain/CoordinateMaps/FocallyLiftedMap.hpp"
+#include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace domain::CoordinateMaps {
+
+/*!
+ * \ingroup CoordinateMapsGroup
+ *
+ * \brief Map from 3D unit right cylinder to a volume that connects
+ *  a portion of a circle to a portion of a spherical surface.
+ *
+ * \image html CylindricalFlatEndcap.svg "A cylinder maps to the shaded region."
+ *
+ * \details Consider a 2D circle in 3D space that is normal to the
+ * \f$z\f$ axis and has (3D) center \f$C_1\f$ and radius \f$R_1\f$.
+ * Also consider a sphere with center \f$C_2\f$, and radius \f$R_2\f$.
+ * Also let there be a projection point \f$P\f$.
+ *
+ * CylindricalFlatEndcap maps a 3D unit right cylinder (with coordinates
+ * \f$(\bar{x},\bar{y},\bar{z})\f$ such that \f$-1\leq\bar{z}\leq 1\f$
+ * and \f$\bar{x}^2+\bar{y}^2 \leq 1\f$) to the shaded area
+ * in the figure above (with coordinates \f$(x,y,z)\f$).  The "bottom"
+ * of the cylinder \f$\bar{z}=-1\f$ is mapped to the interior of the
+ * circle of radius \f$R_1\f$.  Curves of constant
+ * \f$(\bar{x},\bar{y})\f$ are mapped to portions of lines that pass
+ * through \f$P\f$. Along each of these curves, \f$\bar{z}=-1\f$ is
+ * mapped to a point on the circle and \f$\bar{z}=+1\f$ is mapped to a
+ * point on the sphere.
+ *
+ * CylindricalFlatEndcap is intended to be composed with Wedge2D maps to
+ * construct a portion of a cylindrical domain for a binary system.
+ *
+ * CylindricalFlatEndcap is described briefly in the Appendix of
+ * \cite Buchman:2012dw.
+ * CylindricalFlatEndcap is used to construct the blocks labeled 'MA
+ * wedge' and 'MB wedge' in Figure 20 of that paper.
+ *
+ * CylindricalFlatEndcap is implemented using `FocallyLiftedMap`
+ * and `FocallyLiftedInnerMaps::FlatEndcap`; see those classes for
+ * details.
+ *
+ * ### Restrictions on map parameters.
+ *
+ * The following restrictions are made so that the map is not singular
+ * or close to singular. It is possible to construct a valid map
+ * without these assumptions, but the assumptions simplify the code and
+ * avoid problematic edge cases, and the expected use cases obey
+ * these restrictions.
+ *
+ * We demand that
+ * - The plane containing the circle is below (i.e. at a smaller value
+ *   of \f$z\f$ than) the sphere, by an amount at least 5% of the sphere
+ *   radius \f$R_2\f$ but not more than 5 times the sphere radius \f$R_2\f$.
+ * - \f$P\f$ is inside the sphere but not too close to its surface;
+ *   specifically, we demand that \f$|P-C_2|\leq 0.95 R_2\f$.
+ * - The ratio \f$R_1/R_2\f$ is between 10 and 1/10, inclusive.
+ * - The x and y components of \f$C_2-C_1\f$ both have magnitudes
+ *   smaller than or equal to \f$R_1+R_2\f$.
+ *
+ */
+class CylindricalFlatEndcap {
+ public:
+  static constexpr size_t dim = 3;
+  CylindricalFlatEndcap(const std::array<double, 3>& center_one,
+                        const std::array<double, 3>& center_two,
+                        const std::array<double, 3>& proj_center,
+                        double radius_one, double radius_two) noexcept;
+
+  CylindricalFlatEndcap() = default;
+  ~CylindricalFlatEndcap() = default;
+  CylindricalFlatEndcap(CylindricalFlatEndcap&&) = default;
+  CylindricalFlatEndcap(const CylindricalFlatEndcap&) = default;
+  CylindricalFlatEndcap& operator=(const CylindricalFlatEndcap&) = default;
+  CylindricalFlatEndcap& operator=(CylindricalFlatEndcap&&) = default;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  std::optional<std::array<double, 3>> inverse(
+      const std::array<double, 3>& target_coords) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> jacobian(
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> inv_jacobian(
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  // clang-tidy: google runtime references
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+  static bool is_identity() noexcept { return false; }
+
+ private:
+  friend bool operator==(const CylindricalFlatEndcap& lhs,
+                         const CylindricalFlatEndcap& rhs) noexcept;
+  FocallyLiftedMap<FocallyLiftedInnerMaps::FlatEndcap> impl_;
+};
+bool operator!=(const CylindricalFlatEndcap& lhs,
+                const CylindricalFlatEndcap& rhs) noexcept;
+
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/FocallyLiftedEndcap.cpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedEndcap.cpp
@@ -77,7 +77,7 @@ double one_over_x_d_sin_ax_over_x(const double x, const double a) noexcept {
   // Then the series above can be rewritten
   // 1/x d/dx [ sin(ax)/x ] = a/x^2 [- 2(ax)^2/3! + 4(ax)^4/5! - 6(ax)^6/7!]
   //                        = -a^3/3 [ 1 - 4*3*(ax)^2/5! + 6*3*(ax)^4/7!]
-  const double ax = a*x;
+  const double ax = a * x;
   return pow<8>(ax) < 45360.0 * std::numeric_limits<double>::epsilon()
              ? (-cube(a) / 3.0) *
                    (1.0 + square(ax) * (-0.1 + square(ax) / 280.0))
@@ -104,7 +104,7 @@ Endcap::Endcap(const std::array<double, 3>& center, const double radius,
                "Cannot have zero radius");
         return radius;
       }()),
-      theta_max_([&center,&radius,&z_plane]() noexcept {
+      theta_max_([&center, &radius, &z_plane]() noexcept {
         const double cos_theta_max = (z_plane - center[2]) / radius;
         ASSERT(abs(cos_theta_max) < 1.0,
                "Plane must intersect sphere, and at more than one point");
@@ -113,7 +113,7 @@ Endcap::Endcap(const std::array<double, 3>& center, const double radius,
 
 template <typename T>
 void Endcap::forward_map(
-    const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>&
+    const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
         target_coords,
     const std::array<T, 3>& source_coords) const noexcept {
   using ReturnType = tt::remove_cvref_wrap_t<T>;
@@ -132,10 +132,10 @@ void Endcap::forward_map(
 }
 
 template <typename T>
-void Endcap::jacobian(
-    const gsl::not_null<
-        tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>*>& jacobian_out,
-    const std::array<T, 3>& source_coords) const noexcept {
+void Endcap::jacobian(const gsl::not_null<tnsr::Ij<tt::remove_cvref_wrap_t<T>,
+                                                   3, Frame::NoFrame>*>
+                          jacobian_out,
+                      const std::array<T, 3>& source_coords) const noexcept {
   using ReturnType = tt::remove_cvref_wrap_t<T>;
   const ReturnType& xbar = source_coords[0];
   const ReturnType& ybar = source_coords[1];
@@ -145,7 +145,7 @@ void Endcap::jacobian(
         jacobian_out, static_cast<ReturnType>(source_coords[0]).size());
   }
   // Most of the jacobian components are zero.
-  for(auto& jac_component: *jacobian_out) {
+  for (auto& jac_component : *jacobian_out) {
     jac_component = 0.0;
   }
 
@@ -182,8 +182,9 @@ void Endcap::jacobian(
 
 template <typename T>
 void Endcap::inv_jacobian(
-    const gsl::not_null<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3,
-                                 Frame::NoFrame>*>& inv_jacobian_out,
+    const gsl::not_null<
+        tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>*>
+        inv_jacobian_out,
     const std::array<T, 3>& source_coords) const noexcept {
   using ReturnType = tt::remove_cvref_wrap_t<T>;
   const ReturnType& xbar = source_coords[0];
@@ -194,7 +195,7 @@ void Endcap::inv_jacobian(
         inv_jacobian_out, static_cast<ReturnType>(source_coords[0]).size());
   }
   // Most of the inverse jacobian components are zero.
-  for(auto& jac_component: *inv_jacobian_out) {
+  for (auto& jac_component : *inv_jacobian_out) {
     jac_component = 0.0;
   }
 
@@ -220,20 +221,17 @@ void Endcap::inv_jacobian(
        square(get<1, 0>(*inv_jacobian_out)) * get<1, 1>(*inv_jacobian_out));
 
   // 1/(r q), i.e. first term in Eq. 22.
-  get<0, 0>(*inv_jacobian_out) =
-      1.0 / (get<0, 1>(*inv_jacobian_out) * radius_);
+  get<0, 0>(*inv_jacobian_out) = 1.0 / (get<0, 1>(*inv_jacobian_out) * radius_);
 
   // Right-hand side of Eq. 23, without the factor of
   // xbar ybar or the minus sign.
   get<1, 0>(*inv_jacobian_out) *= get<0, 0>(*inv_jacobian_out);
 
   // dybar/dy
-  get<1, 1>(*inv_jacobian_out) =
-      get<0, 0>(*inv_jacobian_out) -
-      square(ybar) * get<1, 0>(*inv_jacobian_out);
+  get<1, 1>(*inv_jacobian_out) = get<0, 0>(*inv_jacobian_out) -
+                                 square(ybar) * get<1, 0>(*inv_jacobian_out);
   // dxbar/dx
-  get<0, 0>(*inv_jacobian_out) -=
-      square(xbar) * get<1, 0>(*inv_jacobian_out);
+  get<0, 0>(*inv_jacobian_out) -= square(xbar) * get<1, 0>(*inv_jacobian_out);
   // dybar/dx
   get<1, 0>(*inv_jacobian_out) *= -xbar * ybar;
   // dxbar/dy
@@ -283,14 +281,14 @@ std::optional<std::array<double, 3>> Endcap::inverse(
 }
 
 template <typename T>
-void Endcap::sigma(const gsl::not_null<tt::remove_cvref_wrap_t<T>*>& sigma_out,
+void Endcap::sigma(const gsl::not_null<tt::remove_cvref_wrap_t<T>*> sigma_out,
                    const std::array<T, 3>& source_coords) const noexcept {
   *sigma_out = 0.5 * (source_coords[2] + 1.0);
 }
 
 template <typename T>
 void Endcap::deriv_sigma(
-    const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>&
+    const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
         deriv_sigma_out,
     const std::array<T, 3>& source_coords) const noexcept {
   using ReturnType = tt::remove_cvref_wrap_t<T>;
@@ -305,7 +303,7 @@ void Endcap::deriv_sigma(
 
 template <typename T>
 void Endcap::dxbar_dsigma(
-    const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>&
+    const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
         dxbar_dsigma_out,
     const std::array<T, 3>& source_coords) const noexcept {
   using ReturnType = tt::remove_cvref_wrap_t<T>;
@@ -338,7 +336,7 @@ std::optional<double> Endcap::lambda_tilde(
 
 template <typename T>
 void Endcap::deriv_lambda_tilde(
-    const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>&
+    const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
         deriv_lambda_tilde_out,
     const std::array<T, 3>& target_coords, const T& lambda_tilde,
     const std::array<double, 3>& projection_point) const noexcept {
@@ -365,35 +363,41 @@ bool operator!=(const Endcap& lhs, const Endcap& rhs) noexcept {
 /// \cond
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data)                                                 \
-  template void Endcap::forward_map(                                         \
-      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<DTYPE(data)>,   \
-                                     3>*>& target_coords,                    \
-      const std::array<DTYPE(data), 3>& source_coords) const noexcept;       \
-  template void Endcap::jacobian(                                            \
-      const gsl::not_null<tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3,  \
-                                   Frame::NoFrame>*>& jacobian_out,          \
-      const std::array<DTYPE(data), 3>& source_coords) const noexcept;       \
-  template void Endcap::inv_jacobian(                                        \
-      const gsl::not_null<tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3,  \
-                                   Frame::NoFrame>*>& inv_jacobian_out,      \
-      const std::array<DTYPE(data), 3>& source_coords) const noexcept;       \
-  template void Endcap::sigma(                                               \
-      const gsl::not_null<tt::remove_cvref_wrap_t<DTYPE(data)>*>& sigma_out, \
-      const std::array<DTYPE(data), 3>& source_coords) const noexcept;       \
-  template void Endcap::deriv_sigma(                                         \
-      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<DTYPE(data)>,   \
-                                     3>*>& deriv_sigma_out,                  \
-      const std::array<DTYPE(data), 3>& source_coords) const noexcept;       \
-  template void Endcap::dxbar_dsigma(                                        \
-      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<DTYPE(data)>,   \
-                                     3>*>& dxbar_dsigma_out,                 \
-      const std::array<DTYPE(data), 3>& source_coords) const noexcept;       \
-  template void Endcap::deriv_lambda_tilde(                                  \
-      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<DTYPE(data)>,   \
-                                     3>*>& deriv_lambda_tilde_out,           \
-      const std::array<DTYPE(data), 3>& target_coords,                       \
-      const DTYPE(data) & lambda_tilde,                                      \
+#define INSTANTIATE(_, data)                                                  \
+  template void Endcap::forward_map(                                          \
+      const gsl::not_null<                                                    \
+          std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>*>               \
+          target_coords,                                                      \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;        \
+  template void Endcap::jacobian(                                             \
+      const gsl::not_null<                                                    \
+          tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame>*> \
+          jacobian_out,                                                       \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;        \
+  template void Endcap::inv_jacobian(                                         \
+      const gsl::not_null<                                                    \
+          tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame>*> \
+          inv_jacobian_out,                                                   \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;        \
+  template void Endcap::sigma(                                                \
+      const gsl::not_null<tt::remove_cvref_wrap_t<DTYPE(data)>*> sigma_out,   \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;        \
+  template void Endcap::deriv_sigma(                                          \
+      const gsl::not_null<                                                    \
+          std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>*>               \
+          deriv_sigma_out,                                                    \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;        \
+  template void Endcap::dxbar_dsigma(                                         \
+      const gsl::not_null<                                                    \
+          std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>*>               \
+          dxbar_dsigma_out,                                                   \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;        \
+  template void Endcap::deriv_lambda_tilde(                                   \
+      const gsl::not_null<                                                    \
+          std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>*>               \
+          deriv_lambda_tilde_out,                                             \
+      const std::array<DTYPE(data), 3>& target_coords,                        \
+      const DTYPE(data) & lambda_tilde,                                       \
       const std::array<double, 3>& projection_point) const noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,

--- a/src/Domain/CoordinateMaps/FocallyLiftedEndcap.hpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedEndcap.hpp
@@ -385,7 +385,7 @@ class Endcap {
 
   template <typename T>
   void forward_map(
-      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>&
+      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
           target_coords,
       const std::array<T, 3>& source_coords) const noexcept;
 
@@ -398,29 +398,30 @@ class Endcap {
       double sigma_in) const noexcept;
 
   template <typename T>
-  void jacobian(const gsl::not_null<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3,
-                                             Frame::NoFrame>*>& jacobian_out,
+  void jacobian(const gsl::not_null<
+                    tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>*>
+                    jacobian_out,
                 const std::array<T, 3>& source_coords) const noexcept;
 
   template <typename T>
-  void inv_jacobian(
-      const gsl::not_null<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3,
-                                   Frame::NoFrame>*>& inv_jacobian_out,
-      const std::array<T, 3>& source_coords) const noexcept;
+  void inv_jacobian(const gsl::not_null<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3,
+                                                 Frame::NoFrame>*>
+                        inv_jacobian_out,
+                    const std::array<T, 3>& source_coords) const noexcept;
 
   template <typename T>
-  void sigma(const gsl::not_null<tt::remove_cvref_wrap_t<T>*>& sigma_out,
+  void sigma(const gsl::not_null<tt::remove_cvref_wrap_t<T>*> sigma_out,
              const std::array<T, 3>& source_coords) const noexcept;
 
   template <typename T>
   void deriv_sigma(
-      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>&
+      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
           deriv_sigma_out,
       const std::array<T, 3>& source_coords) const noexcept;
 
   template <typename T>
   void dxbar_dsigma(
-      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>&
+      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
           dxbar_dsigma_out,
       const std::array<T, 3>& source_coords) const noexcept;
 
@@ -431,7 +432,7 @@ class Endcap {
 
   template <typename T>
   void deriv_lambda_tilde(
-      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>&
+      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
           deriv_lambda_tilde_out,
       const std::array<T, 3>& target_coords, const T& lambda_tilde,
       const std::array<double, 3>& projection_point) const noexcept;

--- a/src/Domain/CoordinateMaps/FocallyLiftedFlatEndcap.cpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedFlatEndcap.cpp
@@ -1,0 +1,246 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/FocallyLiftedFlatEndcap.hpp"
+
+#include <cmath>
+#include <limits>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Parallel/PupStlCpp11.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace domain::CoordinateMaps::FocallyLiftedInnerMaps {
+
+FlatEndcap::FlatEndcap(const std::array<double, 3>& center,
+                       double radius) noexcept
+    : center_(center), radius_([&radius]() noexcept {
+        ASSERT(
+            not equal_within_roundoff(radius, 0.0),
+            "Cannot have zero radius.  Note that this ASSERT implicitly "
+            "assumes that the radius has a scale of roughly unity.  Therefore, "
+            "this ASSERT may trigger in the case where we intentionally want "
+            "an entire domain that is very small.  If we really want small "
+            "domains, then this ASSERT should be modified.");
+        return radius;
+      }()) {}
+
+template <typename T>
+void FlatEndcap::forward_map(
+    const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
+        target_coords,
+    const std::array<T, 3>& source_coords) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  const ReturnType& xbar = source_coords[0];
+  const ReturnType& ybar = source_coords[1];
+
+  if constexpr (not std::is_same_v<ReturnType, double>) {
+    (*target_coords)[2].destructive_resize(
+        static_cast<ReturnType>(source_coords[0]).size());
+  }
+
+  (*target_coords)[0] = radius_ * xbar + center_[0];
+  (*target_coords)[1] = radius_ * ybar + center_[1];
+  (*target_coords)[2] = center_[2];
+}
+
+template <typename T>
+void FlatEndcap::jacobian(
+    const gsl::not_null<
+        tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>*>
+        jacobian_out,
+    const std::array<T, 3>& source_coords) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+
+  if constexpr (not std::is_same_v<ReturnType, double>) {
+    destructive_resize_components(
+        jacobian_out, static_cast<ReturnType>(source_coords[0]).size());
+  }
+  // Most of the jacobian components are zero.
+  for (auto& jac_component : *jacobian_out) {
+    jac_component = 0.0;
+  }
+
+  // dx/dxbar
+  get<0, 0>(*jacobian_out) = radius_;
+  // dy/dybar
+  get<1, 1>(*jacobian_out) = radius_;
+}
+
+template <typename T>
+void FlatEndcap::inv_jacobian(
+    const gsl::not_null<
+        tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>*>
+        inv_jacobian_out,
+    const std::array<T, 3>& source_coords) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+
+  if constexpr (not std::is_same_v<ReturnType, double>) {
+    destructive_resize_components(
+        inv_jacobian_out, static_cast<ReturnType>(source_coords[0]).size());
+  }
+  // Most of the inverse jacobian components are zero.
+  for (auto& jac_component : *inv_jacobian_out) {
+    jac_component = 0.0;
+  }
+
+  // dxbar/dx
+  get<0, 0>(*inv_jacobian_out) = 1.0 / radius_;
+  // dybar/dy
+  get<1, 1>(*inv_jacobian_out) = 1.0 / radius_;
+}
+
+std::optional<std::array<double, 3>> FlatEndcap::inverse(
+    const std::array<double, 3>& target_coords,
+    const double sigma_in) const noexcept {
+  const double xbar = (target_coords[0] - center_[0]) / radius_;
+  const double ybar = (target_coords[1] - center_[1]) / radius_;
+  const double zbar = 2.0 * sigma_in - 1.0;
+
+  if (abs(zbar) > 1.0 and not equal_within_roundoff(abs(zbar), 1.0)) {
+    return {};
+  }
+  const double rho_squared = square(xbar) + square(ybar);
+  if (rho_squared > 1.0 and not equal_within_roundoff(rho_squared, 1.0)) {
+    return {};
+  }
+
+  return std::array<double, 3>{{xbar, ybar, zbar}};
+}
+
+template <typename T>
+void FlatEndcap::sigma(
+    const gsl::not_null<tt::remove_cvref_wrap_t<T>*> sigma_out,
+    const std::array<T, 3>& source_coords) const noexcept {
+  *sigma_out = 0.5 * (source_coords[2] + 1.0);
+}
+
+template <typename T>
+void FlatEndcap::deriv_sigma(
+    const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
+        deriv_sigma_out,
+    const std::array<T, 3>& source_coords) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  if constexpr (not std::is_same_v<ReturnType, double>) {
+    destructive_resize_components(
+        deriv_sigma_out, static_cast<ReturnType>(source_coords[0]).size());
+  }
+  (*deriv_sigma_out)[0] = 0.0;
+  (*deriv_sigma_out)[1] = 0.0;
+  (*deriv_sigma_out)[2] = 0.5;
+}
+
+template <typename T>
+void FlatEndcap::dxbar_dsigma(
+    const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
+        dxbar_dsigma_out,
+    const std::array<T, 3>& source_coords) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  if constexpr (not std::is_same_v<ReturnType, double>) {
+    destructive_resize_components(
+        dxbar_dsigma_out, static_cast<ReturnType>(source_coords[0]).size());
+  }
+  (*dxbar_dsigma_out)[0] = 0.0;
+  (*dxbar_dsigma_out)[1] = 0.0;
+  (*dxbar_dsigma_out)[2] = 2.0;
+}
+
+std::optional<double> FlatEndcap::lambda_tilde(
+    const std::array<double, 3>& parent_mapped_target_coords,
+    const std::array<double, 3>& projection_point,
+    const bool /*source_is_between_focus_and_target*/) const noexcept {
+  const double result = (center_[2] - projection_point[2]) /
+                        (parent_mapped_target_coords[2] - projection_point[2]);
+  if (result < 1.0) {
+    return {};
+  }
+  return result;
+}
+
+template <typename T>
+void FlatEndcap::deriv_lambda_tilde(
+    const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
+        deriv_lambda_tilde_out,
+    const std::array<T, 3>& target_coords, const T& lambda_tilde,
+    const std::array<double, 3>& projection_point) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+
+  if constexpr (not std::is_same_v<ReturnType, double>) {
+    destructive_resize_components(
+        deriv_lambda_tilde_out,
+        static_cast<ReturnType>(target_coords[0]).size());
+  }
+
+  (*deriv_lambda_tilde_out)[0] = 0.0;
+  (*deriv_lambda_tilde_out)[1] = 0.0;
+  (*deriv_lambda_tilde_out)[2] =
+      -square(lambda_tilde) / (center_[2] - projection_point[2]);
+}
+
+void FlatEndcap::pup(PUP::er& p) noexcept {
+  p | center_;
+  p | radius_;
+}
+
+bool operator==(const FlatEndcap& lhs, const FlatEndcap& rhs) noexcept {
+  return lhs.center_ == rhs.center_ and lhs.radius_ == rhs.radius_;
+}
+
+bool operator!=(const FlatEndcap& lhs, const FlatEndcap& rhs) noexcept {
+  return not(lhs == rhs);
+}
+// Explicit instantiations
+/// \cond
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                  \
+  template void FlatEndcap::forward_map(                                      \
+      const gsl::not_null<                                                    \
+          std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>*>               \
+          target_coords,                                                      \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;        \
+  template void FlatEndcap::jacobian(                                         \
+      const gsl::not_null<                                                    \
+          tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame>*> \
+          jacobian_out,                                                       \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;        \
+  template void FlatEndcap::inv_jacobian(                                     \
+      const gsl::not_null<                                                    \
+          tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame>*> \
+          inv_jacobian_out,                                                   \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;        \
+  template void FlatEndcap::sigma(                                            \
+      const gsl::not_null<tt::remove_cvref_wrap_t<DTYPE(data)>*> sigma_out,   \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;        \
+  template void FlatEndcap::deriv_sigma(                                      \
+      const gsl::not_null<                                                    \
+          std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>*>               \
+          deriv_sigma_out,                                                    \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;        \
+  template void FlatEndcap::dxbar_dsigma(                                     \
+      const gsl::not_null<                                                    \
+          std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>*>               \
+          dxbar_dsigma_out,                                                   \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;        \
+  template void FlatEndcap::deriv_lambda_tilde(                               \
+      const gsl::not_null<                                                    \
+          std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>*>               \
+          deriv_lambda_tilde_out,                                             \
+      const std::array<DTYPE(data), 3>& target_coords,                        \
+      const DTYPE(data) & lambda_tilde,                                       \
+      const std::array<double, 3>& projection_point) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
+                                      std::reference_wrapper<const double>,
+                                      std::reference_wrapper<const DataVector>))
+
+#undef INSTANTIATE
+#undef DTYPE
+/// \endcond
+}  // namespace domain::CoordinateMaps::FocallyLiftedInnerMaps

--- a/src/Domain/CoordinateMaps/FocallyLiftedFlatEndcap.hpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedFlatEndcap.hpp
@@ -1,0 +1,226 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <optional>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+/// Contains FocallyLiftedInnerMaps
+namespace domain::CoordinateMaps::FocallyLiftedInnerMaps {
+/*!
+ * \brief A FocallyLiftedInnerMap that maps a 3D unit right cylinder
+ *  to a volume that connects a portion of a plane and a spherical
+ *  surface.
+ *
+ * \details The domain of the map is a 3D unit right cylinder with
+ * coordinates \f$(\bar{x},\bar{y},\bar{z})\f$ such that
+ * \f$-1\leq\bar{z}\leq 1\f$ and \f$\bar{x}^2+\bar{y}^2 \leq
+ * 1\f$.  The range of the map has coordinates \f$(x,y,z)\f$.
+ *
+ * Consider a 2D circle in 3D space that is normal to the \f$z\f$ axis
+ * and has (3D) center \f$C^i\f$ and radius \f$R\f$.  `FlatEndcap`
+ * provides the following functions:
+ *
+ * ### forward_map()
+ * `forward_map()` maps \f$(\bar{x},\bar{y},\bar{z}=-1)\f$ to the interior
+ * of the circle.  The arguments to `forward_map()`
+ * are \f$(\bar{x},\bar{y},\bar{z})\f$, but \f$\bar{z}\f$ is ignored.
+ * `forward_map()` returns \f$x_0^i\f$,
+ * the 3D coordinates on the circle, which are given by
+ *
+ * \f{align}
+ * x_0^0 &= R \bar{x} + C^0,\\
+ * x_0^1 &= R \bar{y} + C^1,\\
+ * x_0^2 &= C^2.
+ * \f}
+ *
+ * ### sigma
+ *
+ * \f$\sigma\f$ is a function that is zero on the plane
+ * \f$x^i=x_0^i\f$ and unity at \f$\bar{z}=+1\f$ (corresponding to the
+ * upper surface of the FocallyLiftedMap). We define
+ *
+ * \f{align}
+ *  \sigma &= \frac{\bar{z}+1}{2}.
+ * \f}
+ *
+ * ### deriv_sigma
+ *
+ * `deriv_sigma` returns
+ *
+ * \f{align}
+ *  \frac{\partial \sigma}{\partial \bar{x}^j} &= (0,0,1/2).
+ * \f}
+ *
+ * ### jacobian
+ *
+ * `jacobian` returns \f$\partial x_0^k/\partial \bar{x}^j\f$.
+ * The arguments to `jacobian`
+ * are \f$(\bar{x},\bar{y},\bar{z})\f$, but \f$\bar{z}\f$ is ignored.
+ *
+ * Differentiating Eqs.(1--3) above yields
+ *
+ * \f{align*}
+ * \frac{\partial x_0^0}{\partial \bar{x}} &= R,\\
+ * \frac{\partial x_0^1}{\partial \bar{y}} &= R,
+ * \f}
+ * and all other components are zero.
+ *
+ * ### inverse
+ *
+ * `inverse` takes \f$x_0^i\f$ and \f$\sigma\f$ as arguments, and
+ * returns \f$(\bar{x},\bar{y},\bar{z})\f$, or a default-constructed
+ * `std::optional<std::array<double, 3>>` if
+ * \f$x_0^i\f$ or \f$\sigma\f$ are outside the range of the map.
+ * The formula for the inverse is straightforward:
+ *
+ * \f{align}
+ *  \bar{x} &= \frac{x_0^0-C^0}{R},\\
+ *  \bar{y} &= \frac{x_0^1-C^1}{R},\\
+ *  \bar{z} &= 2\sigma - 1.
+ * \f}
+ *
+ * If \f$\bar{z}\f$ is outside the range \f$[-1,1]\f$ or
+ * if \f$\bar{x}^2+\bar{y}^2 > 1\f$ then we return
+ * a default-constructed `std::optional<std::array<double, 3>>`
+ *
+ * ### lambda_tilde
+ *
+ * `lambda_tilde` takes as arguments a point \f$x^i\f$ and a projection point
+ *  \f$P^i\f$, and computes \f$\tilde{\lambda}\f$, the solution to
+ *
+ * \f{align} x_0^i = P^i + (x^i - P^i) \tilde{\lambda}.\f}
+ *
+ * Since \f$x_0^i\f$ must lie on the plane \f$x_0^3=C^3\f$,
+ *
+ * \f{align} \tilde{\lambda} &= \frac{C^3-P^3}{x^3-P^3}.\f}
+ *
+ * For `FocallyLiftedInnerMaps::FlatEndcap`, \f$x^i\f$ is always between
+ * \f$P^i\f$ and \f$x_0^i\f$, so \f$\tilde{\lambda}\ge 1\f$.
+ * Therefore a default-constructed `std::optional<double>` is returned
+ * if \f$\tilde{\lambda}\f$ is less than unity (meaning that \f$x^i\f$
+ * is outside the range of the map).
+ *
+ * ### deriv_lambda_tilde
+ *
+ * `deriv_lambda_tilde` takes as arguments \f$x_0^i\f$, a projection point
+ *  \f$P^i\f$, and \f$\tilde{\lambda}\f$, and
+ *  returns \f$\partial \tilde{\lambda}/\partial x^i\f$. We have
+ *
+ * \f{align}
+ * \frac{\partial\tilde{\lambda}}{\partial x^3} =
+ * -\frac{C^3-P^3}{(x^3-P^3)^2} = -\frac{\tilde{\lambda}^2}{C^3-P^3},
+ * \f}
+ * and other components are zero.
+ *
+ * ### inv_jacobian
+ *
+ * `inv_jacobian` returns \f$\partial \bar{x}^i/\partial x_0^k\f$,
+ *  where \f$\sigma\f$ is held fixed.
+ *  The arguments to `inv_jacobian`
+ *  are \f$(\bar{x},\bar{y},\bar{z})\f$, but \f$\bar{z}\f$ is ignored.
+ *
+ * The nonzero components are
+ * \f{align}
+ * \frac{\partial \bar{x}}{\partial x_0^0} &= \frac{1}{R},\\
+ * \frac{\partial \bar{y}}{\partial x_0^1} &= \frac{1}{R}.
+ * \f}
+ *
+ * ### dxbar_dsigma
+ *
+ * `dxbar_dsigma` returns \f$\partial \bar{x}^i/\partial \sigma\f$,
+ *  where \f$x_0^i\f$ is held fixed.
+ *
+ * From Eq. (6) we have
+ *
+ * \f{align}
+ * \frac{\partial \bar{x}^i}{\partial \sigma} &= (0,0,2).
+ * \f}
+ *
+ */
+class FlatEndcap {
+ public:
+  FlatEndcap(const std::array<double, 3>& center, double radius) noexcept;
+
+  FlatEndcap() = default;
+  ~FlatEndcap() = default;
+  FlatEndcap(FlatEndcap&&) = default;
+  FlatEndcap(const FlatEndcap&) = default;
+  FlatEndcap& operator=(const FlatEndcap&) = default;
+  FlatEndcap& operator=(FlatEndcap&&) = default;
+
+  template <typename T>
+  void forward_map(
+      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
+          target_coords,
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  std::optional<std::array<double, 3>> inverse(
+      const std::array<double, 3>& target_coords,
+      double sigma_in) const noexcept;
+
+  template <typename T>
+  void jacobian(const gsl::not_null<
+                    tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>*>
+                    jacobian_out,
+                const std::array<T, 3>& source_coords) const noexcept;
+
+  template <typename T>
+  void inv_jacobian(const gsl::not_null<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3,
+                                                 Frame::NoFrame>*>
+                        inv_jacobian_out,
+                    const std::array<T, 3>& source_coords) const noexcept;
+
+  template <typename T>
+  void sigma(const gsl::not_null<tt::remove_cvref_wrap_t<T>*> sigma_out,
+             const std::array<T, 3>& source_coords) const noexcept;
+
+  template <typename T>
+  void deriv_sigma(
+      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
+          deriv_sigma_out,
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  template <typename T>
+  void dxbar_dsigma(
+      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
+          dxbar_dsigma_out,
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  std::optional<double> lambda_tilde(
+      const std::array<double, 3>& parent_mapped_target_coords,
+      const std::array<double, 3>& projection_point,
+      bool source_is_between_focus_and_target) const noexcept;
+
+  template <typename T>
+  void deriv_lambda_tilde(
+      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
+          deriv_lambda_tilde_out,
+      const std::array<T, 3>& target_coords, const T& lambda_tilde,
+      const std::array<double, 3>& projection_point) const noexcept;
+
+  // clang-tidy: google runtime references
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+  static bool is_identity() noexcept { return false; }
+
+ private:
+  friend bool operator==(const FlatEndcap& lhs, const FlatEndcap& rhs) noexcept;
+  std::array<double, 3> center_{};
+  double radius_{std::numeric_limits<double>::signaling_NaN()};
+};
+bool operator!=(const FlatEndcap& lhs, const FlatEndcap& rhs) noexcept;
+}  // namespace domain::CoordinateMaps::FocallyLiftedInnerMaps

--- a/src/Domain/CoordinateMaps/FocallyLiftedMap.cpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedMap.cpp
@@ -9,6 +9,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/FocallyLiftedEndcap.hpp"
+#include "Domain/CoordinateMaps/FocallyLiftedFlatEndcap.hpp"
 #include "Domain/CoordinateMaps/FocallyLiftedMapHelpers.hpp"
 #include "Domain/CoordinateMaps/FocallyLiftedSide.hpp"
 #include "Utilities/ConstantExpressions.hpp"
@@ -368,6 +369,7 @@ bool operator==(const FocallyLiftedMap<InnerMap>& lhs,
                            const FocallyLiftedMap<IMAP(data)>& rhs) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (FocallyLiftedInnerMaps::Endcap,
+                                      FocallyLiftedInnerMaps::FlatEndcap,
                                       FocallyLiftedInnerMaps::Side))
 
 #undef INSTANTIATE
@@ -385,10 +387,13 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (FocallyLiftedInnerMaps::Endcap,
   FocallyLiftedMap<IMAP(data)>::inv_jacobian(                                \
       const std::array<DTYPE(data), 3>& source_coords) const noexcept;
 
-GENERATE_INSTANTIATIONS(
-    INSTANTIATE, (FocallyLiftedInnerMaps::Endcap, FocallyLiftedInnerMaps::Side),
-    (double, DataVector, std::reference_wrapper<const double>,
-     std::reference_wrapper<const DataVector>))
+GENERATE_INSTANTIATIONS(INSTANTIATE,
+                        (FocallyLiftedInnerMaps::Endcap,
+                         FocallyLiftedInnerMaps::FlatEndcap,
+                         FocallyLiftedInnerMaps::Side),
+                        (double, DataVector,
+                         std::reference_wrapper<const double>,
+                         std::reference_wrapper<const DataVector>))
 
 #undef INSTANTIATE
 #undef DTYPE

--- a/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_BulgedCube.cpp
   Test_CoordinateMap.cpp
   Test_CylindricalEndcap.cpp
+  Test_CylindricalFlatEndcap.cpp
   Test_CylindricalSide.cpp
   Test_DiscreteRotation.cpp
   Test_EquatorialCompression.cpp

--- a/tests/Unit/Domain/CoordinateMaps/Test_CylindricalFlatEndcap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CylindricalFlatEndcap.cpp
@@ -1,0 +1,76 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <gsl/gsl_poly.h>
+#include <random>
+
+#include "Domain/CoordinateMaps/CylindricalFlatEndcap.hpp"
+#include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
+#include "NumericalAlgorithms/RootFinding/QuadraticEquation.hpp"
+
+namespace domain {
+namespace {
+void test_cylindrical_flat_endcap() {
+  INFO("CylindricalFlatEndcap");
+  // Set up random number generator
+  MAKE_GENERATOR(gen);
+
+  std::uniform_real_distribution<> unit_dis(0.0, 1.0);
+  std::uniform_real_distribution<> interval_dis(-1.0, 1.0);
+  std::uniform_real_distribution<> angle_dis(0.0, 2.0 * M_PI);
+
+  // Choose random radii for sphere_two and circle_one, and ensure
+  // that the two radii don't have a ratio of more than 10:1.
+  const double radius_two = 0.1 + 0.9 * unit_dis(gen);
+  CAPTURE(radius_two);
+  const double radius_one = 0.1 + 0.9 * unit_dis(gen);
+  CAPTURE(radius_one);
+
+  // Choose a random center for sphere_two.
+  const std::array<double, 3> center_two = {
+      interval_dis(gen), interval_dis(gen), interval_dis(gen)};
+  CAPTURE(center_two);
+
+  // Choose a random center for the circle, making sure the z-coordinate
+  // is outside sphere_two and below it by at least 5% of radius_two
+  // and at most 5 times radius_two.
+  // For the x and y coordinates, make sure that they are not displaced by
+  // more than radius_one + radius_two with respect to sphere_two.
+  const std::array<double, 3> center_one = {
+      center_two[0] + (radius_one + radius_two) * interval_dis(gen),
+      center_two[1] + (radius_one + radius_two) * interval_dis(gen),
+      center_two[2] - radius_two -
+          5.0 * radius_two * (0.01 + 0.99 * unit_dis(gen))};
+  CAPTURE(center_one);
+
+  // Pick proj_center inside sphere_two, but less than 95% from the
+  // surface.
+  const std::array<double, 3> proj_center = [&center_two, &radius_two, &gen,
+                                             &unit_dis, &interval_dis,
+                                             &angle_dis]() noexcept {
+    const double phi = angle_dis(gen);
+    const double cos_theta = interval_dis(gen);
+    const double sin_theta = sqrt(1.0 - square(cos_theta));
+    const double r = radius_two * 0.95 * unit_dis(gen);
+    return std::array<double, 3>{center_two[0] + r * sin_theta * cos(phi),
+                                 center_two[1] + r * sin_theta * sin(phi),
+                                 center_two[2] + r * cos_theta};
+  }();
+  CAPTURE(proj_center);
+
+  const CoordinateMaps::CylindricalFlatEndcap map(
+      center_one, center_two, proj_center, radius_one, radius_two);
+  test_suite_for_map_on_cylinder(map, 0.0, 1.0);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.CylindricalFlatEndcap",
+                  "[Domain][Unit]") {
+  test_cylindrical_flat_endcap();
+  CHECK(not CoordinateMaps::CylindricalFlatEndcap{}.is_identity());
+}
+}  // namespace domain


### PR DESCRIPTION
## Proposed changes

This adds a map to be used for blocks of a cylindrical binary domain: the blocks that are between the two excised regions.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
