### PR TITLE
Avoid clang FPE in Test_Gmres.cpp

### DIFF
--- a/src/Utilities/Array.hpp
+++ b/src/Utilities/Array.hpp
@@ -16,8 +16,8 @@
 namespace cpp17 {
 namespace detail {
 template <typename T, size_t Size, size_t... Is>
-// NOLINTNEXTLINE(modernize-avoid-c-arrays)
 constexpr std::array<T, Size> convert_to_array(
+    // NOLINTNEXTLINE(modernize-avoid-c-arrays)
     const T (&t)[Size], std::index_sequence<Is...> /*meta*/) {
   return {{t[Is]...}};
 }

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Test_Gmres.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Test_Gmres.cpp
@@ -223,8 +223,8 @@ SPECTRE_TEST_CASE("Unit.LinearSolver.Serial.Gmres",
       INFO("Diagonal (Jacobi) preconditioner");
       // Use the inverse of the diagonal as preconditioner.
       const auto preconditioner = [](DenseVector<double> arg) noexcept {
-        arg[0] /= 4.;
-        arg[1] /= 3.;
+        arg[0] *= 0.25;
+        arg[1] *= 1. / 3.;
         return arg;
       };
       const auto result =


### PR DESCRIPTION
## Proposed changes

When building in the singularity container with clang-10 in release mode with debug info, Test_Gmres.cpp has a test that fails with an FPE. Changing some /= to *= (which I would have thought they should be anyway, because multiplication is preferred over division when possible for efficiency) avoids the FPE.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
