### PR TITLE
Remove extra braces in initializers

### DIFF
--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_CoefficientTransforms.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_CoefficientTransforms.cpp
@@ -102,12 +102,12 @@ void test_1d(const gsl::not_null<Generator*> generator) noexcept {
   CAPTURE(order);
   const Mesh<1> mesh(order + 1, Basis, Quadrature);
   check_transforms<ModalVectorType, NodalVectorType, Basis, Quadrature>(
-      mesh, {{{{order}}}});
+      mesh, {{{order}}});
   check_transforms<ModalVectorType, NodalVectorType, Basis, Quadrature>(
-      mesh, {{{{order}}, {{order / 2}}}});
+      mesh, {{{order}}, {{order / 2}}});
   if (order > 4) {
     check_transforms<ModalVectorType, NodalVectorType, Basis, Quadrature>(
-        mesh, {{{{order}}, {{order / 3}}}});
+        mesh, {{{order}}, {{order / 3}}});
   }
 }
 
@@ -123,17 +123,17 @@ void test_2d(const gsl::not_null<Generator*> generator) noexcept {
   CAPTURE(order);
   const Mesh<2> mesh({{order + 1, order}}, Basis, Quadrature);
   check_transforms<ModalVectorType, NodalVectorType, Basis, Quadrature>(
-      mesh, {{{{order, order - 1}}}});
+      mesh, {{{order, order - 1}}});
   check_transforms<ModalVectorType, NodalVectorType, Basis, Quadrature>(
-      mesh, {{{{order, order - 1}}, {{order / 2, order / 2}}}});
-  check_transforms<ModalVectorType, NodalVectorType, Basis, Quadrature>(
-      Mesh<2>{{{order + 1, order + 1}}, Basis, Quadrature},
-      {{{{order - 1, order}}, {{order / 2, order / 2}}}});
+      mesh, {{{order, order - 1}}, {{order / 2, order / 2}}});
   check_transforms<ModalVectorType, NodalVectorType, Basis, Quadrature>(
       Mesh<2>{{{order + 1, order + 1}}, Basis, Quadrature},
-      {{{{order, order}}, {{order / 2, order / 2}}}});
+      {{{order - 1, order}}, {{order / 2, order / 2}}});
   check_transforms<ModalVectorType, NodalVectorType, Basis, Quadrature>(
-      mesh, {{{{order, order - 1}}, {{order / 3, order / 3}}}});
+      Mesh<2>{{{order + 1, order + 1}}, Basis, Quadrature},
+      {{{order, order}}, {{order / 2, order / 2}}});
+  check_transforms<ModalVectorType, NodalVectorType, Basis, Quadrature>(
+      mesh, {{{order, order - 1}}, {{order / 3, order / 3}}});
 }
 
 template <typename ModalVectorType, typename NodalVectorType,
@@ -149,16 +149,16 @@ void test_3d(const gsl::not_null<Generator*> generator) noexcept {
   CAPTURE(order);
   const Mesh<3> mesh({{order + 1, order, order - 1}}, Basis, Quadrature);
   check_transforms<ModalVectorType, NodalVectorType, Basis, Quadrature>(
-      mesh, {{{{order, order - 1, order - 2}}}});
+      mesh, {{{order, order - 1, order - 2}}});
   check_transforms<ModalVectorType, NodalVectorType, Basis, Quadrature>(
       mesh,
-      {{{{order, order - 1, order - 2}}, {{order / 2, order / 2, order / 2}}}});
+      {{{order, order - 1, order - 2}}, {{order / 2, order / 2, order / 2}}});
   check_transforms<ModalVectorType, NodalVectorType, Basis, Quadrature>(
       Mesh<3>{{{order + 1, order + 1, order + 1}}, Basis, Quadrature},
-      {{{{order, order, order}}}});
+      {{{order, order, order}}});
   check_transforms<ModalVectorType, NodalVectorType, Basis, Quadrature>(
       mesh,
-      {{{{order, order - 1, order - 2}}, {{order / 3, order / 3, order / 3}}}});
+      {{{order, order - 1, order - 2}}, {{order / 3, order / 3, order / 3}}});
 }
 }  // namespace
 

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_FluxCommunication.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_FluxCommunication.cpp
@@ -184,8 +184,7 @@ void test_no_refinement() noexcept {
   using all_mortar_data_tag = ::Tags::Mortars<MortarDataTag<2>, 2>;
   const Mesh<2> mesh{3, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto};
-  const std::vector<std::array<size_t, 2>> initial_extents{
-      {{{3, 3}}, {{3, 3}}}};
+  const std::vector<std::array<size_t, 2>> initial_extents{{{3, 3}}, {{3, 3}}};
 
   //      xi      Block       +- xi
   //      |     0   |   1     |
@@ -347,8 +346,7 @@ void test_no_neighbors() noexcept {
 
   const Mesh<2> mesh{3, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto};
-  const std::vector<std::array<size_t, 2>> initial_extents{
-      {{{3, 3}}, {{3, 3}}}};
+  const std::vector<std::array<size_t, 2>> initial_extents{{{3, 3}}, {{3, 3}}};
   const ElementId<2> self_id(1, {{{1, 0}, {1, 0}}});
   const Element<2> element(self_id, {});
 
@@ -408,7 +406,7 @@ void test_p_refinement() noexcept {
   const Mesh<3> mesh_neighbor({{3, 3, 3}}, Spectral::Basis::Legendre,
                               Spectral::Quadrature::GaussLobatto);
   const std::vector<std::array<size_t, 3>> initial_extents{
-      {{{2, 3, 4}}, {{3, 3, 3}}}};
+      {{2, 3, 4}}, {{3, 3, 3}}};
 
   const auto mortar_id = std::make_pair(Direction<3>::upper_eta(), neighbor_id);
   const Element<3> element(
@@ -518,7 +516,7 @@ void test_h_refinement(const Spectral::MortarSize& mortar_size) {
   const Mesh<2> mesh(2, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto);
   const std::vector<std::array<size_t, 2>> initial_extents{
-      {{{2, 2}}, {{2, 2}}}};
+      {{2, 2}}, {{2, 2}}};
 
   const TemporalId time{1};
 

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_FluxCommunicationLts.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_FluxCommunicationLts.cpp
@@ -199,7 +199,7 @@ void insert_neighbor(
   const Mesh<2> mesh{2, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto};
   const std::vector<std::array<size_t, 2>> initial_extents{
-      {{{2, 2}}, {{2, 2}}, {{2, 2}}}};
+      {{2, 2}}, {{2, 2}}, {{2, 2}}};
 
   ElementMap<2, Frame::Inertial> map(
       element.id(),
@@ -277,7 +277,7 @@ void run_lts_case(const int self_step_end, const std::vector<int>& left_steps,
   const Mesh<2> mesh{2, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto};
   const std::vector<std::array<size_t, 2>> initial_extents{
-      {{{2, 2}}, {{2, 2}}, {{2, 2}}}};
+      {{2, 2}}, {{2, 2}}, {{2, 2}}};
 
   ActionTesting::MockRuntimeSystem<metavariables> runner{{}};
 


### PR DESCRIPTION
This lets the code compile with gcc 10, but there are still runtime
problems.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
