### PR TITLE
Threaded spec piecewise polynomial reader

### DIFF
--- a/src/IO/Importers/ReadSpecThirdOrderPiecewisePolynomial.hpp
+++ b/src/IO/Importers/ReadSpecThirdOrderPiecewisePolynomial.hpp
@@ -184,15 +184,13 @@ struct ReadSpecThirdOrderPiecewisePolynomial {
             std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
             spec_functions_of_time_for_tuple;
         for (const auto& key_and_poly : spec_functions_of_time) {
-          spec_functions_of_time_for_tuple[key_and_poly.first] = static_cast<
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>(
+          spec_functions_of_time_for_tuple[key_and_poly.first] =
               std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<3>>(
-                  key_and_poly.second));
+                  key_and_poly.second);
         }
 
         // Package the domain::Tags::FunctionsOfTime in a TaggedTuple
-        tuples::tagged_tuple_from_typelist<
-            tmpl::list<::domain::Tags::FunctionsOfTime>>
+        tuples::TaggedTuple<::domain::Tags::FunctionsOfTime>
             imported_functions_of_time{};
         get<domain::Tags::FunctionsOfTime>(imported_functions_of_time) =
             std::move(spec_functions_of_time_for_tuple);

--- a/src/IO/Importers/ReadSpecThirdOrderPiecewisePolynomial.hpp
+++ b/src/IO/Importers/ReadSpecThirdOrderPiecewisePolynomial.hpp
@@ -22,7 +22,11 @@
 #include "IO/H5/Dat.hpp"
 #include "IO/H5/File.hpp"
 #include "IO/Importers/Tags.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "Parallel/ArrayIndex.hpp"
 #include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/NodeLock.hpp"
 #include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Requires.hpp"
@@ -30,7 +34,7 @@
 #include "Utilities/TaggedTuple.hpp"
 
 namespace importers {
-namespace Actions {
+namespace ThreadedActions {
 /// \brief Import SpEC `FunctionOfTime` data from an H5 file.
 ///
 /// Uses:
@@ -59,147 +63,153 @@ namespace Actions {
 /// the first component and its derivatives, columns 9-12 give the second
 /// component and its derivatives, etc.
 ///
+template <typename CallbackAction, typename CallbackComponent>
 struct ReadSpecThirdOrderPiecewisePolynomial {
   using const_global_cache_tags =
-       tmpl::list<importers::Tags::FunctionOfTimeFile,
-                  importers::Tags::FunctionOfTimeNameMap>;
-  template <
-      typename DbTagsList, typename... InboxTags, typename Metavariables,
-      typename ArrayIndex, typename ActionList, typename ParallelComponent,
-      Requires<db::tag_is_retrievable_v<importers::Tags::FunctionOfTimeFile,
-                                        db::DataBox<DbTagsList>> and
-               db::tag_is_retrievable_v<importers::Tags::FunctionOfTimeNameMap,
-                                        db::DataBox<DbTagsList>> and
-               db::tag_is_retrievable_v<::domain::Tags::FunctionsOfTime,
-                                        db::DataBox<DbTagsList>>> = nullptr>
-  static auto apply(db::DataBox<DbTagsList>& box,
-                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
-                    const ArrayIndex& /*array_index*/,
-                    const ActionList /*meta*/,
-                    const ParallelComponent* const /*meta*/) noexcept {
-    const std::string& file_name{
-        db::get<importers::Tags::FunctionOfTimeFile>(box)};
+      tmpl::list<importers::Tags::FunctionOfTimeFile,
+                 importers::Tags::FunctionOfTimeNameMap>;
+  template <typename ParallelComponent, typename DataBox,
+            typename Metavariables, typename ArrayIndex,
+            Requires<db::tag_is_retrievable_v<Tags::RegisteredElements,
+                                              DataBox>> = nullptr>
+  static auto apply(
+      DataBox& box, Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/,
+      const gsl::not_null<Parallel::NodeLock*> node_lock) noexcept {
+    node_lock->lock();
+    {
+      // The scoping is to close the file before unlocking
+      const std::string& file_name{
+          db::get<importers::Tags::FunctionOfTimeFile>(box)};
 
-    // Get the map of SpEC -> SpECTRE FunctionofTime names
-    const std::map<std::string, std::string>& dataset_name_map{
-        db::get<importers::Tags::FunctionOfTimeNameMap>(box)};
+      // Get the map of SpEC -> SpECTRE FunctionofTime names
+      const std::map<std::string, std::string>& dataset_name_map{
+          db::get<importers::Tags::FunctionOfTimeNameMap>(box)};
 
-    // Currently, only support order 3 piecewise polynomials.
-    // This could be generalized later, but the SpEC functions of time
-    // that we will read in with this action will always be 3rd-order
-    // piecewise polynomials
-    constexpr size_t max_deriv{3};
+      // Currently, only support order 3 piecewise polynomials.
+      // This could be generalized later, but the SpEC functions of time
+      // that we will read in with this action will always be 3rd-order
+      // piecewise polynomials
+      constexpr size_t max_deriv{3};
 
-    std::unordered_map<std::string,
-                       domain::FunctionsOfTime::PiecewisePolynomial<max_deriv>>
-        spec_functions_of_time;
+      std::unordered_map<std::string,
+                         domain::FunctionsOfTime::PiecewisePolynomial<3>>
+          spec_functions_of_time;
 
-    std::unique_ptr<h5::H5File<h5::AccessType::ReadOnly>> file =
-        std::make_unique<h5::H5File<h5::AccessType::ReadOnly>>(file_name);
-    for (const auto& spec_and_spectre_names : dataset_name_map) {
-      const std::string& spec_name = std::get<0>(spec_and_spectre_names);
-      const std::string& spectre_name = std::get<1>(spec_and_spectre_names);
-      // clang-tidy: use auto when initializing with a template cast to avoid
-      // duplicating the type name
-      const h5::Dat& dat_file = file->get<h5::Dat>("/" + spec_name);  // NOLINT
-      const Matrix& dat_data = dat_file.get_data();
+      std::unique_ptr<h5::H5File<h5::AccessType::ReadOnly>> file =
+          std::make_unique<h5::H5File<h5::AccessType::ReadOnly>>(file_name);
+      for (const auto& spec_and_spectre_names : dataset_name_map) {
+        const std::string& spec_name = std::get<0>(spec_and_spectre_names);
+        const std::string& spectre_name = std::get<1>(spec_and_spectre_names);
+        // clang-tidy: use auto when initializing with a template cast to avoid
+        // duplicating the type name
+        const auto& dat_file = file->get<h5::Dat>("/" + spec_name);  // NOLINT
+        const Matrix& dat_data = dat_file.get_data();
 
-      // Check that the data in the file uses deriv order 3
-      // Column 3 of the file contains the derivative order
-      const size_t dat_max_deriv = dat_data(0, 3);
-      if (dat_max_deriv != max_deriv) {
-        file.reset();
-        ERROR("Deriv order in " << file_name << " should be " << max_deriv
-                                << ", not " << dat_max_deriv);
-      }
-
-      // Get the initial time ('time of last update') from the file
-      // and the values of the function and its derivatives at that time
-      const double start_time = dat_data(0, 1);
-
-      // Currently, assume the same number of components are used
-      // at each time. This could be generalized if needed
-      const size_t number_of_components = dat_data(0, 2);
-
-      std::array<DataVector, max_deriv + 1> initial_coefficients;
-      for (size_t deriv_order = 0; deriv_order < max_deriv + 1; ++deriv_order) {
-        gsl::at(initial_coefficients, deriv_order) =
-            DataVector(number_of_components);
-        for (size_t component = 0; component < number_of_components;
-             ++component) {
-          gsl::at(initial_coefficients, deriv_order)[component] =
-              dat_data(0, 5 + (max_deriv + 1) * component + deriv_order);
-        }
-      }
-      spec_functions_of_time[spectre_name] =
-          domain::FunctionsOfTime::PiecewisePolynomial<3>(start_time,
-                                                          initial_coefficients);
-
-      // Loop over the remaining times, updating the function of time
-      DataVector highest_derivative(number_of_components);
-      double time_last_updated = start_time;
-      for (size_t row = 1; row < dat_data.rows(); ++row) {
-        // If time of last update has changed, then update the FunctionOfTime
-        // The time of last update is stored in column 1 in the dat file
-        if (dat_data(row, 1) > time_last_updated) {
-          time_last_updated = dat_data(row, 1);
-          for (size_t a = 0; a < number_of_components; ++a) {
-            highest_derivative[a] =
-                dat_data(row, 5 + (max_deriv + 1) * a + max_deriv);
-          }
-          spec_functions_of_time[spectre_name].update(time_last_updated,
-                                                      highest_derivative);
-        } else {
+        // Check that the data in the file uses deriv order 3
+        // Column 3 of the file contains the derivative order
+        const size_t dat_max_deriv = dat_data(0, 3);
+        if (dat_max_deriv != max_deriv) {
           file.reset();
-          ERROR("Non-monotonic time found in FunctionOfTime data. "
-                << "Time " << dat_data(row, 1) << " follows time "
-                << time_last_updated << " while reading " << spectre_name
-                << "\n");
+          ERROR("Deriv order in " << file_name << " should be " << max_deriv
+                                  << ", not " << dat_max_deriv);
         }
+
+        // Get the initial time ('time of last update') from the file
+        // and the values of the function and its derivatives at that time
+        const double start_time = dat_data(0, 1);
+
+        // Currently, assume the same number of components are used
+        // at each time. This could be generalized if needed
+        const size_t number_of_components = dat_data(0, 2);
+
+        std::array<DataVector, max_deriv + 1> initial_coefficients;
+        for (size_t deriv_order = 0; deriv_order < max_deriv + 1;
+             ++deriv_order) {
+          gsl::at(initial_coefficients, deriv_order) =
+              DataVector(number_of_components);
+          for (size_t component = 0; component < number_of_components;
+               ++component) {
+            gsl::at(initial_coefficients, deriv_order)[component] =
+                dat_data(0, 5 + (max_deriv + 1) * component + deriv_order);
+          }
+        }
+        domain::FunctionsOfTime::PiecewisePolynomial<3> piecewise_polynomial{
+            start_time, initial_coefficients};
+
+        // Loop over the remaining times, updating the function of time
+        DataVector highest_derivative(number_of_components);
+        double time_last_updated = start_time;
+        for (size_t row = 1; row < dat_data.rows(); ++row) {
+          // If time of last update has changed, then update the FunctionOfTime
+          // The time of last update is stored in column 1 in the dat file
+          if (dat_data(row, 1) > time_last_updated) {
+            time_last_updated = dat_data(row, 1);
+            for (size_t a = 0; a < number_of_components; ++a) {
+              highest_derivative[a] =
+                  dat_data(row, 5 + (max_deriv + 1) * a + max_deriv);
+            }
+            piecewise_polynomial.update(time_last_updated, highest_derivative);
+          } else {
+            file.reset();
+            ERROR("Non-monotonic time found in FunctionOfTime data. "
+                  << "Time " << dat_data(row, 1) << " follows time "
+                  << time_last_updated << " while reading " << spectre_name
+                  << "\n");
+          }
+        }
+        spec_functions_of_time[spectre_name] = piecewise_polynomial;
+      }
+
+      // Loop over elements, and broadcast the functions of time to each
+      // element's DataBox
+      for (auto& element_and_name : get<Tags::RegisteredElements>(box)) {
+        const CkArrayIndex& raw_element_index =
+            element_and_name.first.array_index();
+        // Check if the parallel component of the registered element matches the
+        // callback, because it's possible that elements from other components
+        // with the same index are also registered.
+        // Since the way the component is encoded in `ArrayComponentId` is
+        // private to that class, we construct one and compare.
+        if (element_and_name.first !=
+            observers::ArrayComponentId(
+                std::add_pointer_t<CallbackComponent>{nullptr},
+                raw_element_index)) {
+          continue;
+        }
+
+        // Make an object to hold domain::Tags::FunctionsOfTime data
+        std::unordered_map<
+            std::string,
+            std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+            spec_functions_of_time_for_tuple;
+        for (const auto& key_and_poly : spec_functions_of_time) {
+          spec_functions_of_time_for_tuple[key_and_poly.first] = static_cast<
+              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>(
+              std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<3>>(
+                  key_and_poly.second));
+        }
+
+        // Package the domain::Tags::FunctionsOfTime in a TaggedTuple
+        tuples::tagged_tuple_from_typelist<
+            tmpl::list<::domain::Tags::FunctionsOfTime>>
+            imported_functions_of_time{};
+        get<domain::Tags::FunctionsOfTime>(imported_functions_of_time) =
+            std::move(spec_functions_of_time_for_tuple);
+
+        // Pass the TaggedTuple to the element in a simple action
+        const auto element_index =
+            Parallel::ArrayIndex<typename CallbackComponent::array_index>(
+                raw_element_index)
+                .get_index();
+        Parallel::simple_action<CallbackAction>(
+            Parallel::get_parallel_component<CallbackComponent>(
+                cache)[element_index],
+            std::move(imported_functions_of_time));
       }
     }
-
-    // Mutate ::domain::Tags::FunctionsOfTime, adding the imported
-    // FunctionsOfTime to it
-    db::mutate<::domain::Tags::FunctionsOfTime>(
-        make_not_null(&box),
-        [&dataset_name_map, &spec_functions_of_time,
-         &file](const gsl::not_null<std::unordered_map<
-                    std::string,
-                    std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>*>
-                    functions_of_time) {
-          for (auto spec_and_spectre_names : dataset_name_map) {
-            const std::string& spectre_name =
-                std::get<1>(spec_and_spectre_names);
-
-            // The FunctionsOfTime we are mutating must already have
-            // an element with key==spectre_name; this action only
-            // mutates the value associated with that key
-            if ((*functions_of_time).count(spectre_name) == 0) {
-              file.reset();
-              ERROR("Trying to import data for key "
-                    << spectre_name
-                    << "in FunctionsOfTime, but FunctionsOfTime does not "
-                       "contain that key.\n");
-            }
-            auto* piecewise_polynomial = dynamic_cast<
-                domain::FunctionsOfTime::PiecewisePolynomial<max_deriv>*>(
-                (*functions_of_time)[spectre_name].get());
-            if (piecewise_polynomial == nullptr) {
-              file.reset();
-              ERROR(
-                  "The function of time with name spectre_name is not a "
-                  "PiecewisePolynomial<"
-                  << max_deriv
-                  << "> and so cannot be set using "
-                     "ReadSpecThirdOrderPiecewisePolynomial\n");
-            }
-            *piecewise_polynomial = spec_functions_of_time[spectre_name];
-          }
-        });
-    return std::forward_as_tuple(std::move(box));
+    node_lock->unlock();
   }
 };
-}  // namespace Actions
+}  // namespace ThreadedActions
 }  // namespace importers

--- a/support/Environments/ocean_clang.sh
+++ b/support/Environments/ocean_clang.sh
@@ -36,7 +36,7 @@ spectre_unload_modules() {
     module unload hdf5-1.12.0-gcc-7.3.0-mknp6xv
     module unload openblas-0.3.4-gcc-7.3.0-tt2coe7
     module unload python/3.7.0
-    module unload charm-6.10.2
+    module unload charm-6.10.2-libs
 }
 
 spectre_load_modules() {
@@ -60,7 +60,7 @@ spectre_load_modules() {
     module load boost-1.68.0-gcc-7.3.0-vgl6ofr
     module load hdf5-1.12.0-gcc-7.3.0-mknp6xv
     module load openblas-0.3.4-gcc-7.3.0-tt2coe7
-    module load charm-6.10.2
+    module load charm-6.10.2-libs
 }
 
 spectre_run_cmake() {
@@ -75,7 +75,6 @@ spectre_run_cmake() {
           -D CMAKE_C_COMPILER=clang \
           -D CMAKE_CXX_COMPILER=clang++ \
           -D CMAKE_Fortran_COMPILER=${GCC_HOME}/gfortran \
-          -D MEMORY_ALLOCATOR=SYSTEM \
           "$@" \
           $SPECTRE_HOME
 }

--- a/tests/Unit/IO/Importers/Test_ReadSpecThirdOrderPiecewisePolynomial.cpp
+++ b/tests/Unit/IO/Importers/Test_ReadSpecThirdOrderPiecewisePolynomial.cpp
@@ -279,13 +279,11 @@ void test_reader() noexcept {
                        std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
         expected_functions_of_time;
     expected_functions_of_time["ExpansionFactor"] =
-        static_cast<std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>(
-            std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<3>>(
-                expansion));
+        std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<3>>(
+            expansion);
     expected_functions_of_time["RotationAngle"] =
-        static_cast<std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>(
-            std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<3>>(
-                rotation));
+        std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<3>>(
+            rotation);
 
     // Initialize the FunctionsOfTime on each element
     ActionTesting::emplace_component_and_initialize<element_array>(

--- a/tests/Unit/IO/Importers/Test_ReadSpecThirdOrderPiecewisePolynomial.cpp
+++ b/tests/Unit/IO/Importers/Test_ReadSpecThirdOrderPiecewisePolynomial.cpp
@@ -24,8 +24,11 @@
 #include "IO/H5/AccessType.hpp"
 #include "IO/H5/Dat.hpp"
 #include "IO/H5/File.hpp"
+#include "IO/Importers/ElementActions.hpp"
 #include "IO/Importers/ReadSpecThirdOrderPiecewisePolynomial.hpp"
 #include "IO/Importers/Tags.hpp"
+#include "IO/Importers/VolumeDataReader.hpp"
+#include "IO/Importers/VolumeDataReaderActions.hpp"
 #include "Informer/InfoFromBuild.hpp"
 #include "Options/Options.hpp"
 #include "Options/ParseOptions.hpp"
@@ -35,25 +38,39 @@
 #include "Utilities/TMPL.hpp"
 
 namespace {
+using ElementIdType = ElementId<2>;
+
 template <typename Metavariables>
-struct component {
+struct MockElementArray {
+  using component_being_mocked = void;  // Not needed
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementIdType;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<
+                     tmpl::list<domain::Tags::FunctionsOfTime>>,
+                 importers::Actions::RegisterWithVolumeDataReader>>>;
+};
+
+template <typename Metavariables>
+struct MockVolumeDataReader {
+  using component_being_mocked = importers::VolumeDataReader<Metavariables>;
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using simple_tags = tmpl::list<::domain::Tags::FunctionsOfTime>;
-  using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
-      Parallel::PhaseActions<
-          typename Metavariables::Phase, Metavariables::Phase::Testing,
-          tmpl::list<
-              importers::Actions::ReadSpecThirdOrderPiecewisePolynomial>>>;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      tmpl::list<importers::detail::InitializeVolumeDataReader>>>;
 };
 
 struct Metavariables {
-  using component_list = tmpl::list<component<Metavariables>>;
-  enum class Phase { Initialization, Testing, Exit };
+  using component_list = tmpl::list<MockElementArray<Metavariables>,
+                                    MockVolumeDataReader<Metavariables>>;
+  using const_global_cache_tags =
+      tmpl::list<importers::Tags::FunctionOfTimeFile,
+                 importers::Tags::FunctionOfTimeNameMap>;
+  enum class Phase { Initialization, Testing };
 };
 
 void test_options() noexcept {
@@ -78,30 +95,64 @@ void test_options() noexcept {
       {"Set1", "Name1"}, {"Set2", "Name2"}};
   CHECK(set_names == expected_set_names);
 }
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.IO.ReadSpecThirdOrderPiecewisePolynomial",
-                  "[Unit][Evolution][Actions]") {
-  domain::FunctionsOfTime::register_derived_with_charm();
+struct TestCallback {
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables, typename DataBox = db::DataBox<DbTagsList>,
+            Requires<db::tag_is_retrievable_v<domain::Tags::FunctionsOfTime,
+                                              DataBox>> = nullptr>
+  static void apply(db::DataBox<DbTagsList>& box,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ElementIdType& /*array_index*/,
+                    tuples::tagged_tuple_from_typelist<
+                        tmpl::list<domain::Tags::FunctionsOfTime>>
+                        functions_of_time_data) noexcept {
+    // Get the expected FunctionsOfTime from the DataBox.
+    const auto& expected_functions_of_time =
+        get<domain::Tags::FunctionsOfTime>(box);
 
-  test_options();
+    const std::array<std::string, 2> expected_names{
+        {"ExpansionFactor", "RotationAngle"}};
+    constexpr size_t number_of_times = 3;
+    const std::array<double, number_of_times> expected_times{{0.0, 0.1, 0.2}};
 
-  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
+    // The callback action receives the imported functions of time as a
+    // TaggedTuple.
+    const auto& functions_of_time =
+        get<domain::Tags::FunctionsOfTime>(functions_of_time_data);
 
-  const size_t self_id{1};
+    REQUIRE(expected_functions_of_time.size() == functions_of_time.size());
+    REQUIRE(functions_of_time.size() == expected_names.size());
 
-  // Create a temporary file with test data to read in
-  // First, check if the file exists, and delete it if so
-  const std::string test_filename{"TestSpecFuncOfTimeData.h5"};
-  constexpr uint32_t version_number = 4;
-  if (file_system::check_if_file_exists(test_filename)) {
-    file_system::rm(test_filename, true);
+    // Check that the imported and expected FunctionsOfTime match
+    for (const auto& function_of_time : functions_of_time) {
+      const auto& f = function_of_time.second;
+      const auto& name = function_of_time.first;
+      // Check if the name is one of the expected names
+      CHECK(std::find(expected_names.begin(), expected_names.end(), name) !=
+            expected_names.end());
+
+      for (size_t i = 0; i < number_of_times; ++i) {
+        const auto time = gsl::at(expected_times, i);
+        const auto f_and_derivs = f->func_and_2_derivs(time);
+        const auto expected_f_and_derivs =
+            expected_functions_of_time.at(name)->func_and_2_derivs(time);
+        for (size_t j = 0; j < 3; ++j) {
+          CHECK(gsl::at(expected_f_and_derivs, j)[0] ==
+                approx(gsl::at(f_and_derivs, j)[0]));
+        }
+      }
+    }
   }
+};
 
-  h5::H5File<h5::AccessType::ReadWrite> test_file(test_filename);
-
+template <bool TestNonmonotonic>
+void test_reader() noexcept {
   constexpr size_t number_of_times = 3;
   const std::array<double, number_of_times> expected_times{{0.0, 0.1, 0.2}};
+  const std::array<double, number_of_times> output_times =
+      TestNonmonotonic ? std::array<double, number_of_times>{{0.0, -0.1, 0.2}}
+                       : expected_times;
   const std::array<std::string, 2> expected_names{
       {"ExpansionFactor", "RotationAngle"}};
 
@@ -132,15 +183,15 @@ SPECTRE_TEST_CASE("Unit.IO.ReadSpecThirdOrderPiecewisePolynomial",
            rotation.func_and_2_derivs(expected_times[2])}};
 
   const std::vector<std::vector<double>> test_expansion{
-      {expected_times[0], expected_times[0], 1.0, 3.0, 1.0,
-       initial_expansion[0][0], initial_expansion[1][0],
-       initial_expansion[2][0], initial_expansion[3][0]},
-      {expected_times[1], expected_times[1], 1.0, 3.0, 1.0,
+      {output_times[0], output_times[0], 1.0, 3.0, 1.0, initial_expansion[0][0],
+       initial_expansion[1][0], initial_expansion[2][0],
+       initial_expansion[3][0]},
+      {output_times[1], output_times[1], 1.0, 3.0, 1.0,
        expansion_func_and_2_derivs_next[0][0][0],
        expansion_func_and_2_derivs_next[0][1][0],
        expansion_func_and_2_derivs_next[0][2][0],
        next_expansion_third_deriv[0][0]},
-      {expected_times[2], expected_times[2], 1.0, 3.0, 1.0,
+      {output_times[2], output_times[2], 1.0, 3.0, 1.0,
        expansion_func_and_2_derivs_next[1][0][0],
        expansion_func_and_2_derivs_next[1][1][0],
        expansion_func_and_2_derivs_next[1][2][0],
@@ -148,20 +199,16 @@ SPECTRE_TEST_CASE("Unit.IO.ReadSpecThirdOrderPiecewisePolynomial",
   const std::vector<std::string> expansion_legend{
       "Time", "TLastUpdate", "Nc",  "DerivOrder", "Version",
       "a",    "da",          "d2a", "d3a"};
-  auto& expansion_file = test_file.insert<h5::Dat>(
-      "/" + expected_names[0], expansion_legend, version_number);
-  expansion_file.append(test_expansion);
 
   const std::vector<std::vector<double>> test_rotation{
-      {expected_times[0], expected_times[0], 1.0, 3.0, 1.0,
-       initial_rotation[0][0], initial_rotation[1][0], initial_rotation[2][0],
-       initial_rotation[3][0]},
-      {expected_times[1], expected_times[1], 1.0, 3.0, 1.0,
+      {output_times[0], output_times[0], 1.0, 3.0, 1.0, initial_rotation[0][0],
+       initial_rotation[1][0], initial_rotation[2][0], initial_rotation[3][0]},
+      {output_times[1], output_times[1], 1.0, 3.0, 1.0,
        rotation_func_and_2_derivs_next[0][0][0],
        rotation_func_and_2_derivs_next[0][1][0],
        rotation_func_and_2_derivs_next[0][2][0],
        next_rotation_third_deriv[0][0]},
-      {expected_times[2], expected_times[2], 1.0, 3.0, 1.0,
+      {output_times[2], output_times[2], 1.0, 3.0, 1.0,
        rotation_func_and_2_derivs_next[1][0][0],
        rotation_func_and_2_derivs_next[1][1][0],
        rotation_func_and_2_derivs_next[1][2][0],
@@ -169,42 +216,29 @@ SPECTRE_TEST_CASE("Unit.IO.ReadSpecThirdOrderPiecewisePolynomial",
   const std::vector<std::string> rotation_legend{
       "Time", "TLastUpdate", "Nc",    "DerivOrder", "Version",
       "Phi",  "dPhi",        "d2Phi", "d3Phi"};
-  auto& rotation_file = test_file.insert<h5::Dat>(
-      "/" + expected_names[1], rotation_legend, version_number);
-  rotation_file.append(test_rotation);
 
-  MockRuntimeSystem runner{
-      {std::string{test_filename}, std::map<std::string, std::string>{
-                                       {"ExpansionFactor", "ExpansionFactor"},
-                                       {"RotationAngle", "RotationAngle"}}}};
-  std::unordered_map<std::string,
-                     std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>
-      initial_functions_of_time{};
+  std::string test_filename{"TestSpecFuncOfTime.h5"};
+  if (TestNonmonotonic) {
+    test_filename = std::string{"TestSpecFuncOfTimeDataNonmonotonic.h5"};
+  }
+  constexpr uint32_t version_number = 4;
+  {
+    // Create a temporary file with test data to read in
+    // First, check if the file exists, and delete it if so
+    if (file_system::check_if_file_exists(test_filename)) {
+      file_system::rm(test_filename, true);
+    }
 
-  const std::array<DataVector, 4> initial_coefficients{
-      {{0.0}, {0.0}, {0.0}, {0.0}}};
-  initial_functions_of_time["ExpansionFactor"] =
-      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<3>>(
-          0.0, initial_coefficients);
-  initial_functions_of_time["RotationAngle"] =
-      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<3>>(
-          0.0, initial_coefficients);
+    h5::H5File<h5::AccessType::ReadWrite> test_file(test_filename);
+    auto& expansion_file = test_file.insert<h5::Dat>(
+        "/" + expected_names[0], expansion_legend, version_number);
+    expansion_file.append(test_expansion);
+    auto& rotation_file = test_file.insert<h5::Dat>(
+        "/" + expected_names[1], rotation_legend, version_number);
+    rotation_file.append(test_rotation);
+  }
 
-  ActionTesting::emplace_component_and_initialize<component<Metavariables>>(
-      &runner, self_id, {std::move(initial_functions_of_time)});
-
-  ActionTesting::set_phase(make_not_null(&runner),
-                           Metavariables::Phase::Testing);
-  ActionTesting::next_action<component<Metavariables>>(make_not_null(&runner),
-                                                       self_id);
-
-  const auto& functions_of_time =
-      ActionTesting::get_databox_tag<component<Metavariables>,
-                                     domain::Tags::FunctionsOfTime>(runner,
-                                                                    self_id);
-
-  // Check that the FunctionOfTime and its derivatives have the expected
-  // values
+  // Create the expected function_vs_time, for comparing to the imported data
   const std::array<std::array<double, 3>, number_of_times> expected_expansion{
       {{{test_expansion[0][5], test_expansion[0][6], test_expansion[0][7]}},
        {{test_expansion[1][5], test_expansion[1][6], test_expansion[1][7]}},
@@ -219,27 +253,80 @@ SPECTRE_TEST_CASE("Unit.IO.ReadSpecThirdOrderPiecewisePolynomial",
   expected_functions[expected_names[0]] = expected_expansion;
   expected_functions[expected_names[1]] = expected_rotation;
 
-  REQUIRE(functions_of_time.size() == expected_names.size());
+  // Set up the MockRuntimeSystem runner
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
+  MockRuntimeSystem runner{
+      {std::string{test_filename}, std::map<std::string, std::string>{
+                                       {"ExpansionFactor", "ExpansionFactor"},
+                                       {"RotationAngle", "RotationAngle"}}}};
+  // Setup mock data file reader
+  using reader_component = MockVolumeDataReader<Metavariables>;
+  using element_array = MockElementArray<Metavariables>;
+  ActionTesting::emplace_component<reader_component>(make_not_null(&runner), 0);
+  ActionTesting::next_action<reader_component>(make_not_null(&runner), 0);
 
-  for (const auto& function_of_time : functions_of_time) {
-    const auto& f = function_of_time.second;
-    const auto& name = function_of_time.first;
-    // Check if the name is one of the expected names
-    CHECK(std::find(expected_names.begin(), expected_names.end(), name) !=
-          expected_names.end());
+  // Create a few elements with sample data
+  // Specific IDs have no significance, just need different IDs.
+  const std::vector<ElementId<2>> element_ids{{1, {{{1, 0}, {1, 0}}}},
+                                              {1, {{{1, 1}, {1, 0}}}},
+                                              {1, {{{1, 0}, {2, 3}}}},
+                                              {1, {{{1, 0}, {5, 4}}}},
+                                              {0, {{{1, 0}, {1, 0}}}}};
 
-    for (size_t i = 0; i < number_of_times; ++i) {
-      const auto time = gsl::at(expected_times, i);
-      const auto f_and_derivs = f->func_and_2_derivs(time);
-      for (size_t j = 0; j < 3; ++j) {
-        CHECK(gsl::at(gsl::at(expected_functions[name], i), j) ==
-              approx(gsl::at(f_and_derivs, j)[0]));
-      }
-    }
+  for (const auto& id : element_ids) {
+    // Create a FunctionsOfTime storing the expected piecewise polynomials
+    std::unordered_map<std::string,
+                       std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+        expected_functions_of_time;
+    expected_functions_of_time["ExpansionFactor"] =
+        static_cast<std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>(
+            std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<3>>(
+                expansion));
+    expected_functions_of_time["RotationAngle"] =
+        static_cast<std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>(
+            std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<3>>(
+                rotation));
+
+    // Initialize the FunctionsOfTime on each element
+    ActionTesting::emplace_component_and_initialize<element_array>(
+        make_not_null(&runner), ElementIdType{id},
+        {std::move(expected_functions_of_time)});
+
+    // Register each element
+    ActionTesting::next_action<element_array>(make_not_null(&runner), id);
+
+    // Invoke the simple_action RegisterElementWithSelf that was called on the
+    // reader component by the RegisterWithVolumeDataReader action.
+    runner.invoke_queued_simple_action<reader_component>(0);
+  }
+
+  ActionTesting::set_phase(make_not_null(&runner),
+                           Metavariables::Phase::Testing);
+
+  // Have the importer read the file and pass it to the callback
+  runner.algorithms<reader_component>()
+      .at(0)
+      .template threaded_action<
+          importers::ThreadedActions::ReadSpecThirdOrderPiecewisePolynomial<
+              TestCallback, element_array>>();
+  runner.invoke_queued_threaded_action<reader_component>(0);
+
+  // Invoke the queued callbacks on the elements that test if the data is
+  // correct
+  for (const auto& id : element_ids) {
+    runner.invoke_queued_simple_action<element_array>(id);
   }
 
   // Delete the temporary file created for this test
   file_system::rm(test_filename, true);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.IO.ReadSpecThirdOrderPiecewisePolynomial",
+                  "[Unit][Evolution][Actions]") {
+  domain::FunctionsOfTime::register_derived_with_charm();
+  test_options();
+  test_reader<false>();
 }
 
 // [[OutputRegex, Non-monotonic time found]]
@@ -247,48 +334,5 @@ SPECTRE_TEST_CASE("Unit.IO.ReadSpecThirdOrderPiecewisePolynomialNonmonotonic",
                   "[Unit][Evolution][Actions]") {
   ERROR_TEST();
   domain::FunctionsOfTime::register_derived_with_charm();
-
-  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
-
-  const size_t self_id{1};
-
-  // Create a temporary file with test data to read in
-  // First, check if the file exists, and delete it if so
-  const std::string test_filename{"TestSpecFuncOfTimeDataNonmonotonic.h5"};
-  constexpr uint32_t version_number = 4;
-  if (file_system::check_if_file_exists(test_filename)) {
-    file_system::rm(test_filename, true);
-  }
-
-  h5::H5File<h5::AccessType::ReadWrite> test_file(test_filename);
-
-  const std::vector<std::vector<double>> test_rotation{
-      {0.0, 0.0, 1.0, 3.0, 1.0, 0.0, 1.3472907726000001e-02, 0.0, 0.0},
-      {-1.0, -1.0, 1.0, 3.0, 1.0, 8.0837442877282155e-05,
-       1.3472907726000001e-02, 0.0, 1.4799266358888008e-04}};
-  const std::vector<std::string> rotation_legend{
-      "Time", "TLastUpdate", "Nc",    "DerivOrder", "Version",
-      "Phi",  "dPhi",        "d2Phi", "d3Phi"};
-  auto& rotation_file = test_file.insert<h5::Dat>(
-      "/RotationAngle", rotation_legend, version_number);
-  rotation_file.append(test_rotation);
-
-  MockRuntimeSystem runner{
-      {std::string{test_filename},
-       std::map<std::string, std::string>{{"RotationAngle", "RotationAngle"}}}};
-  std::unordered_map<std::string,
-                     std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>
-      initial_functions_of_time{};
-
-  const std::array<DataVector, 4> initial_coefficients{
-      {{0.0}, {0.0}, {0.0}, {0.0}}};
-  initial_functions_of_time["RotationAngle"] =
-      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<3>>(
-          0.0, initial_coefficients);
-
-  ActionTesting::emplace_component_and_initialize<component<Metavariables>>(
-      &runner, self_id, {std::move(initial_functions_of_time)});
-
-  runner.set_phase(Metavariables::Phase::Testing);
-  runner.next_action<component<Metavariables>>(self_id);
+  test_reader<true>();
 }


### PR DESCRIPTION
## Proposed changes

Rewrites the ReadSpecThirdOrderPiecewisePolynomial action as a threaded action, so it reads the H5 file once / node, instead of once / element. Specifically, this PR introduces a new ThreadedAction that can be used similarly to the volume data reader's threaded action. Aside from the action, this scheme reuses everything (the VolumeDataReader parallel component and the SetData callback) already implemented for the VolumeDataReader.

The motivation is that this eliminates segfaults in the HDF5 library when reading in the spec function of time data in release mode.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
