### PR TITLE
CylindricalFlatSide map.

### DIFF
--- a/docs/Images/Domain/CoordinateMaps/CylindricalFlatSide.svg
+++ b/docs/Images/Domain/CoordinateMaps/CylindricalFlatSide.svg
@@ -1,0 +1,330 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="111.56284mm"
+   height="109.86378mm"
+   viewBox="0 0 111.56286 109.86378"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="CylindricalFlatSide.svg">
+  <defs
+     id="defs2">
+    <marker
+       inkscape:stockid="StopL"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="StopL"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1089"
+         d="M 0,5.65 V -5.65"
+         style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.8)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <linearGradient
+       id="linearGradient6115"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop6113" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4526"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4524" />
+    </linearGradient>
+    <marker
+       inkscape:stockid="StopL"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="StopL-0"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1089-8"
+         d="M 0,5.65 V -5.65"
+         style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.8)"
+         inkscape:connector-curvature="0" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.4761299"
+     inkscape:cx="247.80044"
+     inkscape:cy="155.55128"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:window-width="1648"
+     inkscape:window-height="1089"
+     inkscape:window-x="156"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-text-baseline="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3713"
+       originx="-15.742714"
+       originy="-138.97684" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-15.742708,-48.159376)">
+    <circle
+       id="path3717"
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26458332;stroke-opacity:1"
+       cy="85.333336"
+       cx="52.916668"
+       r="37.041668" />
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6040"
+       cx="48.947918"
+       cy="65.489578"
+       rx="1.1926295"
+       ry="1.1425189" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.66500002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.665, 1.995;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 127,148.83333 48.947917,65.489576 42.333333,148.83333"
+       id="path6046"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6040-6"
+       cx="52.916668"
+       cy="85.333336"
+       rx="1.2427398"
+       ry="1.1926293" />
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6040-7"
+       cx="84.666664"
+       cy="148.83333"
+       rx="1.0924084"
+       ry="1.1425189" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="41.049763"
+       y="68.590691"
+       id="text6177"><tspan
+         sodipodi:role="line"
+         id="tspan6175"
+         x="41.049763"
+         y="68.590691"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">P</tspan><tspan
+         sodipodi:role="line"
+         x="41.049763"
+         y="76.528191"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="tspan6179" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="82.371765"
+       y="145.46812"
+       id="text6153-9"><tspan
+         sodipodi:role="line"
+         id="tspan6151-2"
+         x="82.371765"
+         y="145.46812"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">C</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="86.76902"
+       y="142.10687"
+       id="text6157-5"><tspan
+         sodipodi:role="line"
+         x="86.76902"
+         y="142.10687"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="tspan6163-4">i</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="105.85379"
+       y="157.97321"
+       id="text6243"><tspan
+         sodipodi:role="line"
+         id="tspan6241"
+         x="105.85379"
+         y="157.97321"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">out</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="58.306488"
+       y="94.579178"
+       id="text6247"><tspan
+         sodipodi:role="line"
+         id="tspan6245"
+         x="58.306488"
+         y="94.579178"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">2</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="45.419254"
+       y="64.884178"
+       id="text6157-5-0"><tspan
+         sodipodi:role="line"
+         x="45.419254"
+         y="64.884178"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="tspan6163-4-5">i</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="53.899979"
+       y="93.019722"
+       id="text6153-9-9"><tspan
+         sodipodi:role="line"
+         id="tspan6151-2-2"
+         x="53.899979"
+         y="93.019722"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">C</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="58.771519"
+       y="88.78492"
+       id="text6157-5-5"><tspan
+         sodipodi:role="line"
+         x="58.771519"
+         y="88.78492"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         id="tspan6163-4-4">i</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="101.40585"
+       y="156.95399"
+       id="text6153-9-96"><tspan
+         sodipodi:role="line"
+         id="tspan6151-2-0"
+         x="101.40585"
+         y="156.95399"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">R</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="86.722115"
+       y="146.45134"
+       id="text6243-0"><tspan
+         sodipodi:role="line"
+         id="tspan6241-2"
+         x="86.722115"
+         y="146.45134"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">1</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.1, 0.1;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#StopL);marker-end:url(#StopL)"
+       d="M 84.666663,151.47917 127,151.47916"
+       id="path918"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.1;stroke-miterlimit:4;stroke-dasharray:0.1, 0.1;stroke-dashoffset:0;stroke-opacity:1"
+       id="path1262"
+       sodipodi:type="arc"
+       sodipodi:cx="52.916668"
+       sodipodi:cy="85.333328"
+       sodipodi:rx="37.041668"
+       sodipodi:ry="37.041668"
+       sodipodi:start="0.53531442"
+       sodipodi:end="2.3697242"
+       d="M 84.776513,104.22871 A 37.041668,37.041668 0 0 1 57.287638,122.1162 37.041668,37.041668 0 0 1 26.372286,111.16898"
+       sodipodi:open="true" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.1, 0.1;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#StopL-0);marker-end:url(#StopL-0)"
+       d="m 68.791663,155.44792 h 15.875"
+       id="path918-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="71.278313"
+       y="154.11055"
+       id="text6153-9-96-0"><tspan
+         sodipodi:role="line"
+         id="tspan6151-2-0-6"
+         x="71.278313"
+         y="154.11055"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">R</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="75.801804"
+       y="154.90175"
+       id="text6243-4"><tspan
+         sodipodi:role="line"
+         id="tspan6241-6"
+         x="75.801804"
+         y="154.90175"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">in</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.66500002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.66500005, 2.66000019;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 68.791663,148.83333 48.947913,65.489583 100.54166,148.83333"
+       id="path10224"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:#969696;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 62.254123,121.1788 c -5.810287,1.51353 -11.901408,1.59197 -17.748743,0.22856 l -2.172047,27.42597 h 26.45833 z"
+       id="path10226"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:#969696;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 84.956208,103.92239 c -1.860295,3.20635 -4.191348,6.11529 -6.915246,8.62959 l 22.500698,36.28135 H 127 Z"
+       id="path10229"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+  </g>
+</svg>

--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -18,6 +18,7 @@ spectre_target_sources(
   Equiangular.cpp
   FocallyLiftedEndcap.cpp
   FocallyLiftedFlatEndcap.cpp
+  FocallyLiftedFlatSide.cpp
   FocallyLiftedMap.cpp
   FocallyLiftedMapHelpers.cpp
   FocallyLiftedSide.cpp
@@ -46,6 +47,7 @@ spectre_target_headers(
   Equiangular.hpp
   FocallyLiftedEndcap.hpp
   FocallyLiftedFlatEndcap.hpp
+  FocallyLiftedFlatSide.hpp
   FocallyLiftedMap.hpp
   FocallyLiftedMapHelpers.hpp
   FocallyLiftedSide.hpp

--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -12,6 +12,7 @@ spectre_target_sources(
   BulgedCube.cpp
   CylindricalEndcap.cpp
   CylindricalFlatEndcap.cpp
+  CylindricalFlatSide.cpp
   CylindricalSide.cpp
   DiscreteRotation.cpp
   EquatorialCompression.cpp
@@ -41,6 +42,7 @@ spectre_target_headers(
   CoordinateMapHelpers.hpp
   CylindricalEndcap.hpp
   CylindricalFlatEndcap.hpp
+  CylindricalFlatSide.hpp
   CylindricalSide.hpp
   DiscreteRotation.hpp
   EquatorialCompression.hpp

--- a/src/Domain/CoordinateMaps/CylindricalFlatSide.cpp
+++ b/src/Domain/CoordinateMaps/CylindricalFlatSide.cpp
@@ -1,0 +1,136 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/CylindricalFlatSide.hpp"
+
+#include <optional>
+#include <pup.h>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/FocallyLiftedFlatSide.hpp"
+#include "Domain/CoordinateMaps/FocallyLiftedMap.hpp"
+#include "Parallel/PupStlCpp11.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace domain::CoordinateMaps {
+
+CylindricalFlatSide::CylindricalFlatSide(
+    const std::array<double, 3>& center_one,
+    const std::array<double, 3>& center_two,
+    const std::array<double, 3>& proj_center, const double inner_radius,
+    const double outer_radius, const double radius_two) noexcept
+    : impl_(center_two, proj_center, radius_two, false,
+            FocallyLiftedInnerMaps::FlatSide(center_one, inner_radius,
+                                             outer_radius)) {
+#ifdef SPECTRE_DEBUG
+  // There are two types of sanity checks here on the map parameters.
+  // 1) ASSERTS that guarantee that the map is invertible.
+  // 2) ASSERTS that guarantee that the map parameters fall within
+  //    the range tested by the unit tests (which is the range in which
+  //    the map is expected to be used).
+  //
+  // There are two reasons why 1) and 2) are not the same:
+  //
+  // a) It is possible to choose parameters such that the map is
+  //    invertible but the resulting geometry has very sharp angles,
+  //    very large or ill-conditioned Jacobians, or both.  We want to
+  //    avoid such cases.
+  // b) We do not want to waste effort testing the map for parameters
+  //    that we don't expect to be used.
+  ASSERT(center_one[2] < center_two[2] - radius_two * 1.05,
+         "CylindricalFlatSide: The map has only been tested for the case "
+         "when the sphere is contained at larger z-coordinate than the "
+         "plane that contains the annulus, and the sphere is not too "
+         "close to the annulus.");
+  const double dist_proj = sqrt(square(center_two[0] - proj_center[0]) +
+                                square(center_two[1] - proj_center[1]) +
+                                square(center_two[2] - proj_center[2]));
+  ASSERT(dist_proj < 0.95 * radius_two,
+         "CylindricalFlatSide: The map has been tested only for the case when "
+         "proj_center is contained inside the sphere and not too close to the "
+         "surface of the sphere");
+  const double dist_xy_annulus = sqrt(square(center_two[0] - center_one[0]) +
+                                      square(center_two[1] - center_one[1]));
+  ASSERT(dist_xy_annulus < radius_two,
+         "CylindricalFlatSide: The map has been tested only for the case when "
+         "the center of the annulus is contained in the projection of the "
+         "sphere onto the z-axis");
+  const double dist_annulus_proj = sqrt(square(center_one[0] - proj_center[0]) +
+                                        square(center_one[1] - proj_center[1]) +
+                                        square(center_one[2] - proj_center[2]));
+  ASSERT(outer_radius > 0.05 * dist_annulus_proj,
+         "CylindricalFlatSide: The map has been tested only for the case when "
+         "the annulus is not too small");
+  ASSERT(inner_radius < 0.95 * outer_radius,
+         "CylindricalFlatSide: The map has been tested only for the case when "
+         "the annulus is not too thin");
+  const double min_inner_radius_fac =
+      std::max(0.05, dist_annulus_proj * 0.01 / outer_radius);
+  ASSERT(inner_radius > min_inner_radius_fac * outer_radius,
+         "CylindricalFlatSide: The map has been tested only for the case when "
+         "the inner radius is not too small");
+#endif
+}
+
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, 3> CylindricalFlatSide::operator()(
+    const std::array<T, 3>& source_coords) const noexcept {
+  return impl_.operator()(source_coords);
+}
+
+std::optional<std::array<double, 3>> CylindricalFlatSide::inverse(
+    const std::array<double, 3>& target_coords) const noexcept {
+  return impl_.inverse(target_coords);
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
+CylindricalFlatSide::jacobian(
+    const std::array<T, 3>& source_coords) const noexcept {
+  return impl_.jacobian(source_coords);
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
+CylindricalFlatSide::inv_jacobian(
+    const std::array<T, 3>& source_coords) const noexcept {
+  return impl_.inv_jacobian(source_coords);
+}
+
+void CylindricalFlatSide::pup(PUP::er& p) noexcept { p | impl_; }
+
+bool operator==(const CylindricalFlatSide& lhs,
+                const CylindricalFlatSide& rhs) noexcept {
+  return lhs.impl_ == rhs.impl_;
+}
+bool operator!=(const CylindricalFlatSide& lhs,
+                const CylindricalFlatSide& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+// Explicit instantiations
+/// \cond
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                 \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>               \
+  CylindricalFlatSide::operator()(                                           \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;       \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame> \
+  CylindricalFlatSide::jacobian(                                             \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;       \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame> \
+  CylindricalFlatSide::inv_jacobian(                                         \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
+                                      std::reference_wrapper<const double>,
+                                      std::reference_wrapper<const DataVector>))
+
+#undef DTYPE
+#undef INSTANTIATE
+/// \endcond
+
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/CylindricalFlatSide.hpp
+++ b/src/Domain/CoordinateMaps/CylindricalFlatSide.hpp
@@ -1,0 +1,133 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines the class CylindricalFlatSide.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <optional>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/CoordinateMaps/FocallyLiftedFlatSide.hpp"
+#include "Domain/CoordinateMaps/FocallyLiftedMap.hpp"
+#include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace domain::CoordinateMaps {
+
+/*!
+ * \ingroup CoordinateMapsGroup
+ *
+ * \brief Map from 3D unit right cylindrical shell to a volume that connects
+ *  a portion of an annulus to a portion of a spherical surface.
+ *
+ * \image html CylindricalFlatSide.svg "A cylinder maps to the shaded region."
+ *
+ * \details Consider a 2D annulus in 3D space that is normal to the
+ * \f$z\f$ axis and has (3D) center \f$C_1\f$, inner radius
+ * \f$R_\mathrm{in}\f$ and outer radius \f$R_\mathrm{out}\f$
+ * Also consider a sphere with center \f$C_2\f$, and radius \f$R_2\f$.
+ * Also let there be a projection point \f$P\f$.
+ *
+ * CylindricalFlatSide maps a 3D unit right cylindrical shell (with
+ * coordinates \f$(\bar{x},\bar{y},\bar{z})\f$ such that
+ * \f$-1\leq\bar{z}\leq 1\f$ and \f$1 \leq \bar{x}^2+\bar{y}^2 \leq
+ * 4\f$) to the shaded area in the figure above (with coordinates
+ * \f$(x,y,z)\f$).  The "bottom" of the cylinder \f$\bar{z}=-1\f$ is
+ * mapped to the interior of the annulus with radii
+ * \f$R_\mathrm{in}\f$ and \f$R_\mathrm{out}\f$.  Curves of constant
+ * \f$(\bar{x},\bar{y})\f$ are mapped to portions of lines that pass
+ * through \f$P\f$. Along each of these curves, \f$\bar{z}=-1\f$ is
+ * mapped to a point inside the annulus and \f$\bar{z}=+1\f$ is mapped to a
+ * point on the sphere.
+ *
+ * CylindricalFlatSide is intended to be composed with Wedge2D maps to
+ * construct a portion of a cylindrical domain for a binary system.
+ *
+ * CylindricalFlatSide is described briefly in the Appendix of
+ * \cite Buchman:2012dw.
+ * CylindricalFlatSide is used to construct the blocks labeled 'ME
+ * cylinder' in Figure 20 of that paper.
+ *
+ * CylindricalFlatSide is implemented using `FocallyLiftedMap`
+ * and `FocallyLiftedInnerMaps::FlatSide`; see those classes for
+ * details.
+ *
+ * ### Restrictions on map parameters.
+ *
+ * We demand that:
+ * - The sphere is at a larger value of \f$z\f$ (plus 5
+ *   percent of the sphere radius) than the plane containing the
+ *   annulus.
+ * - The projection point \f$z_\mathrm{P}\f$ is
+ *   inside the sphere and more than 5 percent away from the boundary
+ *   of the sphere.
+ * - The center of the annulus is contained in the circle that results from
+ *   projecting the sphere into the \f$xy\f$ plane.
+ * - The outer radius of the annulus is larger than 5 percent of the distance
+ *   between the center of the annulus and the projection point.
+ * - The inner radius of the annulus is less than 95 percent of the outer
+ *   radius, larger than 5 percent of the outer radius, and larger than one
+ *   percent of the distance between the center of the annulus and the
+ *   projection point.  The last condition means that the angle subtended by
+ *   the inner radius with respect to the projection point is not too small.
+ *
+ * It is possible to construct a valid map without these assumptions,
+ * but some of these assumptions simplify the code and others eliminate
+ * edge cases where Jacobians become large or small.
+ *
+ */
+class CylindricalFlatSide {
+ public:
+  static constexpr size_t dim = 3;
+  CylindricalFlatSide(const std::array<double, 3>& center_one,
+                      const std::array<double, 3>& center_two,
+                      const std::array<double, 3>& proj_center,
+                      const double inner_radius, const double outer_radius,
+                      const double radius_two) noexcept;
+
+  CylindricalFlatSide() = default;
+  ~CylindricalFlatSide() = default;
+  CylindricalFlatSide(CylindricalFlatSide&&) = default;
+  CylindricalFlatSide(const CylindricalFlatSide&) = default;
+  CylindricalFlatSide& operator=(const CylindricalFlatSide&) = default;
+  CylindricalFlatSide& operator=(CylindricalFlatSide&&) = default;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  std::optional<std::array<double, 3>> inverse(
+      const std::array<double, 3>& target_coords) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> jacobian(
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> inv_jacobian(
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  // clang-tidy: google runtime references
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+  static bool is_identity() noexcept { return false; }
+
+ private:
+  friend bool operator==(const CylindricalFlatSide& lhs,
+                         const CylindricalFlatSide& rhs) noexcept;
+  FocallyLiftedMap<FocallyLiftedInnerMaps::FlatSide> impl_;
+};
+bool operator!=(const CylindricalFlatSide& lhs,
+                const CylindricalFlatSide& rhs) noexcept;
+
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/FocallyLiftedFlatSide.cpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedFlatSide.cpp
@@ -1,0 +1,305 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/FocallyLiftedFlatSide.hpp"
+
+#include <array>
+#include <cmath>
+#include <limits>
+#include <optional>
+#include <pup.h>
+#include <type_traits>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Parallel/PupStlCpp11.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
+
+namespace domain::CoordinateMaps::FocallyLiftedInnerMaps {
+
+FlatSide::FlatSide(const std::array<double, 3>& center,
+                   const double inner_radius,
+                   const double outer_radius) noexcept
+    : center_(center),
+      inner_radius_(inner_radius),
+      outer_radius_(outer_radius) {
+  ASSERT(not equal_within_roundoff(inner_radius, 0.0),
+         "Cannot have zero radius.  Note that this ASSERT implicitly "
+         "assumes that the radius has a scale of roughly unity.  Therefore, "
+         "this ASSERT may trigger in the case where we intentionally want "
+         "an entire domain that is very small.  If we really want small "
+         "domains, then this ASSERT should be modified.");
+  ASSERT(outer_radius > inner_radius,
+         "Outer radius should be larger than inner radius. Inner radius: "
+             << inner_radius << " outer radius: " << outer_radius);
+}
+
+template <typename T>
+void FlatSide::forward_map(
+    const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
+        target_coords,
+    const std::array<T, 3>& source_coords) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  const ReturnType& xbar = source_coords[0];
+  const ReturnType& ybar = source_coords[1];
+  ReturnType& x = (*target_coords)[0];
+  ReturnType& y = (*target_coords)[1];
+  ReturnType& z = (*target_coords)[2];
+
+  // Use z and y as temporary storage to avoid allocations,
+  // before setting them to their actual values.
+  z = sqrt(square(xbar) + square(ybar));
+  y = (inner_radius_ + (outer_radius_ - inner_radius_) * (z - 1.0)) / z;
+
+  x = y * xbar + center_[0];
+  y = y * ybar + center_[1];
+  z = center_[2];
+}
+
+template <typename T>
+void FlatSide::jacobian(const gsl::not_null<tnsr::Ij<tt::remove_cvref_wrap_t<T>,
+                                                     3, Frame::NoFrame>*>
+                            jacobian_out,
+                        const std::array<T, 3>& source_coords) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  const ReturnType& xbar = source_coords[0];
+  const ReturnType& ybar = source_coords[1];
+
+  if constexpr (not std::is_same_v<ReturnType, double>) {
+    destructive_resize_components(
+        jacobian_out, static_cast<ReturnType>(source_coords[0]).size());
+  }
+
+  // Use part of Jacobian as temp storage to reduce allocations.
+  get<1, 1>(*jacobian_out) = 1.0 / cube(sqrt(square(xbar) + square(ybar)));
+
+  // dx/dxbar
+  get<0, 0>(*jacobian_out) = (2.0 * inner_radius_ - outer_radius_) *
+                                 square(ybar) * get<1, 1>(*jacobian_out) +
+                             (outer_radius_ - inner_radius_);
+  // dx/dybar
+  get<0, 1>(*jacobian_out) = (outer_radius_ - 2.0 * inner_radius_) * xbar *
+                             ybar * get<1, 1>(*jacobian_out);
+  // dy/dxbar
+  get<1, 0>(*jacobian_out) = get<0, 1>(*jacobian_out);
+  // dy/dybar
+  get<1, 1>(*jacobian_out) = (2.0 * inner_radius_ - outer_radius_) *
+                                 square(xbar) * get<1, 1>(*jacobian_out) +
+                             (outer_radius_ - inner_radius_);
+
+  // Set remaining components to zero
+  for (size_t i = 0; i < 3; ++i) {
+    jacobian_out->get(i, 2) = 0.0;
+  }
+  for (size_t i = 0; i < 2; ++i) {
+    jacobian_out->get(2, i) = 0.0;
+  }
+}
+
+template <typename T>
+void FlatSide::inv_jacobian(
+    const gsl::not_null<
+        tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>*>
+        inv_jacobian_out,
+    const std::array<T, 3>& source_coords) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  const ReturnType& xbar = source_coords[0];
+  const ReturnType& ybar = source_coords[1];
+
+  if constexpr (not std::is_same<ReturnType, double>::value) {
+    destructive_resize_components(
+        inv_jacobian_out, static_cast<ReturnType>(source_coords[0]).size());
+  }
+
+  // Use part of inverse Jacobian for temp storage to avoid allocations.
+  const double tmp =
+      (2.0 * inner_radius_ - outer_radius_) / (outer_radius_ - inner_radius_);
+  // Denominator in the next line is guaranteed to be nonzero.
+  get<0, 1>(*inv_jacobian_out) = 1.0 / sqrt(square(xbar) + square(ybar));
+  get<0, 1>(*inv_jacobian_out) =
+      cube(get<0, 1>(*inv_jacobian_out)) * tmp /
+      ((outer_radius_ - inner_radius_) +
+       (2.0 * inner_radius_ - outer_radius_) * get<0, 1>(*inv_jacobian_out));
+
+  // dxbar/dx
+  get<0, 0>(*inv_jacobian_out) = -square(ybar) * get<0, 1>(*inv_jacobian_out) +
+                                 1.0 / (outer_radius_ - inner_radius_);
+  // dybar/dy
+  get<1, 1>(*inv_jacobian_out) = -square(xbar) * get<0, 1>(*inv_jacobian_out) +
+                                 1.0 / (outer_radius_ - inner_radius_);
+  // dxbar/dy
+  get<0, 1>(*inv_jacobian_out) *= xbar * ybar;
+  // dybar/dx
+  get<1, 0>(*inv_jacobian_out) = get<0, 1>(*inv_jacobian_out);
+
+  // Set remaining components to zero
+  for (size_t i = 0; i < 3; ++i) {
+    inv_jacobian_out->get(i, 2) = 0.0;
+  }
+  for (size_t i = 0; i < 2; ++i) {
+    inv_jacobian_out->get(2, i) = 0.0;
+  }
+}
+
+std::optional<std::array<double, 3>> FlatSide::inverse(
+    const std::array<double, 3>& target_coords,
+    const double sigma_in) const noexcept {
+  const double x = (target_coords[0] - center_[0]);
+  const double y = (target_coords[1] - center_[1]);
+  const double rho = sqrt(square(x) + square(y));
+  const double rhobar =
+      (rho - inner_radius_) / (outer_radius_ - inner_radius_) + 1.0;
+  if (rhobar < 1.0 and not equal_within_roundoff(rhobar, 1.0)) {
+    return {};
+  }
+  if (rhobar > 2.0 and not equal_within_roundoff(rhobar, 2.0)) {
+    return {};
+  }
+  const double xbar = rhobar * x / rho;
+  const double ybar = rhobar * y / rho;
+  const double zbar = 2.0 * sigma_in - 1.0;
+
+  if (abs(zbar) > 1.0 and not equal_within_roundoff(abs(zbar), 1.0)) {
+    return {};
+  }
+
+  return std::array<double, 3>{{xbar, ybar, zbar}};
+}
+
+template <typename T>
+void FlatSide::sigma(const gsl::not_null<tt::remove_cvref_wrap_t<T>*> sigma_out,
+                     const std::array<T, 3>& source_coords) const noexcept {
+  *sigma_out = 0.5 * (source_coords[2] + 1.0);
+}
+
+template <typename T>
+void FlatSide::deriv_sigma(
+    const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
+        deriv_sigma_out,
+    const std::array<T, 3>& source_coords) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  if constexpr (not std::is_same<ReturnType, double>::value) {
+    destructive_resize_components(
+        deriv_sigma_out, static_cast<ReturnType>(source_coords[0]).size());
+  }
+  (*deriv_sigma_out)[0] = 0.0;
+  (*deriv_sigma_out)[1] = 0.0;
+  (*deriv_sigma_out)[2] = 0.5;
+}
+
+template <typename T>
+void FlatSide::dxbar_dsigma(
+    const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
+        dxbar_dsigma_out,
+    const std::array<T, 3>& source_coords) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  if constexpr (not std::is_same<ReturnType, double>::value) {
+    destructive_resize_components(
+        dxbar_dsigma_out, static_cast<ReturnType>(source_coords[0]).size());
+  }
+  (*dxbar_dsigma_out)[0] = 0.0;
+  (*dxbar_dsigma_out)[1] = 0.0;
+  (*dxbar_dsigma_out)[2] = 2.0;
+}
+
+std::optional<double> FlatSide::lambda_tilde(
+    const std::array<double, 3>& parent_mapped_target_coords,
+    const std::array<double, 3>& projection_point,
+    const bool /*source_is_between_focus_and_target*/) const noexcept {
+  const double result = (center_[2] - projection_point[2]) /
+                        (parent_mapped_target_coords[2] - projection_point[2]);
+  if (result < 1.0) {
+    return {};
+  }
+  return result;
+}
+
+template <typename T>
+void FlatSide::deriv_lambda_tilde(
+    const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
+        deriv_lambda_tilde_out,
+    const std::array<T, 3>& target_coords, const T& lambda_tilde,
+    const std::array<double, 3>& projection_point) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  if constexpr (not std::is_same<ReturnType, double>::value) {
+    destructive_resize_components(
+        deriv_lambda_tilde_out,
+        static_cast<ReturnType>(target_coords[0]).size());
+  }
+  (*deriv_lambda_tilde_out)[0] = 0.0;
+  (*deriv_lambda_tilde_out)[1] = 0.0;
+  (*deriv_lambda_tilde_out)[2] =
+      -square(lambda_tilde) / (center_[2] - projection_point[2]);
+}
+
+void FlatSide::pup(PUP::er& p) noexcept {
+  p | center_;
+  p | inner_radius_;
+  p | outer_radius_;
+}
+
+bool operator==(const FlatSide& lhs, const FlatSide& rhs) noexcept {
+  return lhs.center_ == rhs.center_ and
+         lhs.inner_radius_ == rhs.inner_radius_ and
+         lhs.outer_radius_ == rhs.outer_radius_;
+}
+
+bool operator!=(const FlatSide& lhs, const FlatSide& rhs) noexcept {
+  return not(lhs == rhs);
+}
+// Explicit instantiations
+/// \cond
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                  \
+  template void FlatSide::forward_map(                                        \
+      const gsl::not_null<                                                    \
+          std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>*>               \
+          target_coords,                                                      \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;        \
+  template void FlatSide::jacobian(                                           \
+      const gsl::not_null<                                                    \
+          tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame>*> \
+          jacobian_out,                                                       \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;        \
+  template void FlatSide::inv_jacobian(                                       \
+      const gsl::not_null<                                                    \
+          tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame>*> \
+          inv_jacobian_out,                                                   \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;        \
+  template void FlatSide::sigma(                                              \
+      const gsl::not_null<tt::remove_cvref_wrap_t<DTYPE(data)>*> sigma_out,   \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;        \
+  template void FlatSide::deriv_sigma(                                        \
+      const gsl::not_null<                                                    \
+          std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>*>               \
+          deriv_sigma_out,                                                    \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;        \
+  template void FlatSide::dxbar_dsigma(                                       \
+      const gsl::not_null<                                                    \
+          std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>*>               \
+          dxbar_dsigma_out,                                                   \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;        \
+  template void FlatSide::deriv_lambda_tilde(                                 \
+      const gsl::not_null<                                                    \
+          std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>*>               \
+          deriv_lambda_tilde_out,                                             \
+      const std::array<DTYPE(data), 3>& target_coords,                        \
+      const DTYPE(data) & lambda_tilde,                                       \
+      const std::array<double, 3>& projection_point) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
+                                      std::reference_wrapper<const double>,
+                                      std::reference_wrapper<const DataVector>))
+
+#undef INSTANTIATE
+#undef DTYPE
+/// \endcond
+}  // namespace domain::CoordinateMaps::FocallyLiftedInnerMaps

--- a/src/Domain/CoordinateMaps/FocallyLiftedFlatSide.hpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedFlatSide.hpp
@@ -1,0 +1,276 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <optional>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+/// Contains FocallyLiftedInnerMaps
+namespace domain::CoordinateMaps::FocallyLiftedInnerMaps {
+/*!
+ * \brief A FocallyLiftedInnerMap that maps a 3D unit right cylinder
+ *  to a volume that connects a 2D annulus to a spherical
+ *  surface.
+ *
+ * \details The domain of the map is a 3D unit right cylinder with
+ * coordinates \f$(\bar{x},\bar{y},\bar{z})\f$ such that
+ * \f$-1\leq\bar{z}\leq 1\f$ and \f$1\leq \bar{x}^2+\bar{y}^2 \leq
+ * 4\f$.  The range of the map has coordinates \f$(x,y,z)\f$.
+ *
+ * Consider a 2D annulus in 3D space
+ * oriented normal to the \f$z\f$ axis.  The inner and outer radii
+ * of the annulus are \f$R_\mathrm{in}\f$ and \f$R_\mathrm{out}\f$, and the
+ * (3D) center of the annulus is \f$C^i\f$.
+ * `FlatSide` provides the following functions:
+ *
+ * ### forward_map()
+ * `forward_map()` maps \f$(\bar{x},\bar{y},\bar{z}=-1)\f$ to the interior
+ * of the annulus.  The arguments to `forward_map()`
+ * are \f$(\bar{x},\bar{y},\bar{z})\f$, but \f$\bar{z}\f$ is ignored.
+ * `forward_map()` returns \f$x_0^i\f$,
+ * the 3D coordinates on the annulus, which are given by
+ *
+ * \f{align}
+ * x_0^0 &= \left(R_\mathrm{in}+(R_\mathrm{out}-R_\mathrm{in})
+ *    (\bar{\rho}-1)\right)
+ *    \frac{\bar{x}}{\bar{\rho}} + C^0, \label{eq:forward_map_x}\\
+ * x_0^1 &= \left(R_\mathrm{in}+(R_\mathrm{out}-R_\mathrm{in})
+ *    (\bar{\rho}-1)\right)
+ *    \frac{\bar{y}}{\bar{\rho}} + C^1,\\
+ * x_0^2 &= C^2 \label{eq:forward_map_z},
+ * \f}
+ *
+ * where
+ *
+ * \f{align} \bar{\rho} = \sqrt{\bar{x}^2+\bar{y}^2}.\label{eq:rhobar}\f}
+ *
+ * ### sigma
+ *
+ * \f$\sigma\f$ is a function that is zero on the sphere
+ * \f$x^i=x_0^i\f$ and unity at \f$\bar{z}=+1\f$ (corresponding to the
+ * upper surface of the FocallyLiftedMap). We define
+ *
+ * \f{align}
+ *  \sigma &= \frac{\bar{z}+1}{2}.
+ * \f}
+ *
+ * ### deriv_sigma
+ *
+ * `deriv_sigma` returns
+ *
+ * \f{align}
+ *  \frac{\partial \sigma}{\partial \bar{x}^j} &= (0,0,1/2).
+ *  \label{eq:deriv_sigma}
+ * \f}
+ *
+ * ### jacobian
+ *
+ * `jacobian` returns \f$\partial x_0^k/\partial \bar{x}^j\f$.
+ * The arguments to `jacobian`
+ * are \f$(\bar{x},\bar{y},\bar{z})\f$, but \f$\bar{z}\f$ is ignored.
+ *
+ * Differentiating
+ * Eqs. (\f$\ref{eq:forward_map_x}\f$--\f$\ref{eq:forward_map_z}\f$)
+ * above yields
+ *
+ * \f{align*}
+ * \frac{\partial x_0^0}{\partial \bar{x}} &=
+ * R_\mathrm{out}-R_\mathrm{in} + (2 R_\mathrm{in}-R_\mathrm{out})
+ * \frac{\bar{y}^2}{\bar{\rho}^3},\\
+ * \frac{\partial x_0^0}{\partial \bar{y}} &=
+ * -(2 R_\mathrm{in}-R_\mathrm{out})
+ * \frac{\bar{x}\bar{y}}{\bar{\rho}^3},\\
+ * \frac{\partial x_0^1}{\partial \bar{x}} &=
+ * -(2 R_\mathrm{in}-R_\mathrm{out})
+ * \frac{\bar{x}\bar{y}}{\bar{\rho}^3},\\
+ * \frac{\partial x_0^1}{\partial \bar{y}} &=
+ * R_\mathrm{out}-R_\mathrm{in} + (2 R_\mathrm{in}-R_\mathrm{out})
+ * \frac{\bar{x}^2}{\bar{\rho}^3},\\
+ * \f}
+ * and all other components are zero.
+ *
+ * ### inverse
+ *
+ * `inverse` takes \f$x_0^i\f$ and \f$\sigma\f$ as arguments, and
+ * returns \f$(\bar{x},\bar{y},\bar{z})\f$, or a default-constructed
+ * `std::optional<std::array<double, 3>>` if
+ * \f$x_0^i\f$ or \f$\sigma\f$ are outside the range of the map.
+ *
+ * Let
+ * \f{align}
+ *  \rho = \sqrt{(x_0^0-C^0)^2+(x_0^1-C^1)^2}.
+ *  \label{eq:rho}
+ * \f}
+ *
+ * Then
+ * \f{align}
+ *  \bar{x} &= \frac{x_0^0-C^0}{\rho}
+ *  \frac{\rho+R_\mathrm{out}-2 R_\mathrm{in}}{R_\mathrm{out}-R_\mathrm{in}},\\
+ *  \bar{y} &= \frac{x_0^1-C^1}{\rho}
+ *  \frac{\rho+R_\mathrm{out}-2 R_\mathrm{in}}{R_\mathrm{out}-R_\mathrm{in}},\\
+ *  \bar{z} &= 2\sigma - 1.
+ * \f}
+ *
+ * Note that \f$\rho\f$ in Eq. (\f$\ref{eq:rho}\f$) can be written
+ * \f{align}
+ * \rho = R_\mathrm{in}+(R_\mathrm{out}-R_\mathrm{in})(\bar{\rho}-1),
+ * \label{eq:rho_from_rhobar}
+ * \f}
+ * where \f$\bar{\rho}\f$ is given by Eq. (\f$\ref{eq:rhobar}\f$).
+ *
+ * If \f$\bar{z}\f$ is outside the range \f$[-1,1]\f$ or
+ * if \f$\bar{x}^2+\bar{y}^2\f$ is less than 1 or greater than 4
+ * then we return a default-constructed
+ * `std::optional<std::array<double, 3>>`.
+ *
+ * ### lambda_tilde
+ *
+ * `lambda_tilde` takes as arguments a point \f$x^i\f$ and a projection point
+ *  \f$P^i\f$, and computes \f$\tilde{\lambda}\f$, the solution to
+ *
+ * \f{align} x_0^i = P^i + (x^i - P^i) \tilde{\lambda}.\f}
+ *
+ * Since \f$x_0^i\f$ must lie on the plane \f$x_0^3=C^3\f$,
+ *
+ * \f{align} \tilde{\lambda} &= \frac{C^3-P^3}{x^3-P^3}.\f}
+ *
+ * If \f$\tilde{\lambda}\f$ is less than unity (indicating that the
+ * supplied point is outside the range of the map), then a
+ * default-constructed `std::optional<double>` is returned.
+ *
+ * ### deriv_lambda_tilde
+ *
+ * `deriv_lambda_tilde` takes as arguments \f$x_0^i\f$, a projection point
+ *  \f$P^i\f$, and \f$\tilde{\lambda}\f$, and
+ *  returns \f$\partial \tilde{\lambda}/\partial x^i\f$. We have
+ *
+ * \f{align}
+ * \frac{\partial\tilde{\lambda}}{\partial x^3} =
+ * -\frac{C^3-P^3}{(x^3-P^3)^2} = -\frac{\tilde{\lambda}^2}{C^3-P^3},
+ * \f}
+ * and other components are zero.
+ *
+ * ### inv_jacobian
+ *
+ * `inv_jacobian` returns \f$\partial \bar{x}^i/\partial x_0^k\f$,
+ *  where \f$\sigma\f$ is held fixed.
+ *  The arguments to `inv_jacobian`
+ *  are \f$(\bar{x},\bar{y},\bar{z})\f$, but \f$\bar{z}\f$ is ignored.
+ *
+ * The nonzero components are
+ * \f{align}
+ * \frac{\partial \bar{x}}{\partial x_0^0} &=
+ *  \frac{1}{R_\mathrm{out}-R_\mathrm{in}} + \frac{\bar{y}^2}{\bar{\rho}^2\rho}
+ *  \frac{R_\mathrm{out}-2 R_\mathrm{in}}{R_\mathrm{out}-R_\mathrm{in}},\\
+ * \frac{\partial \bar{x}}{\partial x_0^1} &=
+ *  - \frac{\bar{x}\bar{y}}{\bar{\rho}^2\rho}
+ *  \frac{R_\mathrm{out}-2 R_\mathrm{in}}{R_\mathrm{out}-R_\mathrm{in}},\\
+ * \frac{\partial \bar{y}}{\partial x_0^1} &=
+ *  \frac{1}{R_\mathrm{out}-R_\mathrm{in}} + \frac{\bar{x}^2}{\bar{\rho}^2\rho}
+ *  \frac{R_\mathrm{out}-2 R_\mathrm{in}}{R_\mathrm{out}-R_\mathrm{in}},\\
+ * \frac{\partial \bar{y}}{\partial x_0^0} &=
+ *  - \frac{\bar{x}\bar{y}}{\bar{\rho}^2\rho}
+ *  \frac{R_\mathrm{out}-2 R_\mathrm{in}}{R_\mathrm{out}-R_\mathrm{in}},
+ * \f}
+ * where \f$\rho\f$ is computed from Eq. (\f$\ref{eq:rho_from_rhobar}\f$).
+ *
+ * ### dxbar_dsigma
+ *
+ * `dxbar_dsigma` returns \f$\partial \bar{x}^i/\partial \sigma\f$,
+ *  where \f$x_0^i\f$ is held fixed.
+ *
+ * From Eq. (\f$\ref{eq:deriv_sigma}\f$) we have
+ *
+ * \f{align}
+ * \frac{\partial \bar{x}^i}{\partial \sigma} &= (0,0,2).
+ * \f}
+ *
+ */
+class FlatSide {
+ public:
+  FlatSide(const std::array<double, 3>& center, const double inner_radius,
+           const double outer_radius) noexcept;
+
+  FlatSide() = default;
+  ~FlatSide() = default;
+  FlatSide(FlatSide&&) = default;
+  FlatSide(const FlatSide&) = default;
+  FlatSide& operator=(const FlatSide&) = default;
+  FlatSide& operator=(FlatSide&&) = default;
+
+  template <typename T>
+  void forward_map(
+      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
+          target_coords,
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  std::optional<std::array<double, 3>> inverse(
+      const std::array<double, 3>& target_coords,
+      double sigma_in) const noexcept;
+
+  template <typename T>
+  void jacobian(const gsl::not_null<
+                    tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>*>
+                    jacobian_out,
+                const std::array<T, 3>& source_coords) const noexcept;
+
+  template <typename T>
+  void inv_jacobian(const gsl::not_null<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3,
+                                                 Frame::NoFrame>*>
+                        inv_jacobian_out,
+                    const std::array<T, 3>& source_coords) const noexcept;
+
+  template <typename T>
+  void sigma(const gsl::not_null<tt::remove_cvref_wrap_t<T>*> sigma_out,
+             const std::array<T, 3>& source_coords) const noexcept;
+
+  template <typename T>
+  void deriv_sigma(
+      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
+          deriv_sigma_out,
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  template <typename T>
+  void dxbar_dsigma(
+      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
+          dxbar_dsigma_out,
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  std::optional<double> lambda_tilde(
+      const std::array<double, 3>& parent_mapped_target_coords,
+      const std::array<double, 3>& projection_point,
+      bool source_is_between_focus_and_target) const noexcept;
+
+  template <typename T>
+  void deriv_lambda_tilde(
+      const gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*>
+          deriv_lambda_tilde_out,
+      const std::array<T, 3>& target_coords, const T& lambda_tilde,
+      const std::array<double, 3>& projection_point) const noexcept;
+
+  // clang-tidy: google runtime references
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+  static bool is_identity() noexcept { return false; }
+
+ private:
+  friend bool operator==(const FlatSide& lhs, const FlatSide& rhs) noexcept;
+  std::array<double, 3> center_{};
+  double inner_radius_{std::numeric_limits<double>::signaling_NaN()};
+  double outer_radius_{std::numeric_limits<double>::signaling_NaN()};
+};
+bool operator!=(const FlatSide& lhs, const FlatSide& rhs) noexcept;
+}  // namespace domain::CoordinateMaps::FocallyLiftedInnerMaps

--- a/src/Domain/CoordinateMaps/FocallyLiftedMap.cpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedMap.cpp
@@ -10,6 +10,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/FocallyLiftedEndcap.hpp"
 #include "Domain/CoordinateMaps/FocallyLiftedFlatEndcap.hpp"
+#include "Domain/CoordinateMaps/FocallyLiftedFlatSide.hpp"
 #include "Domain/CoordinateMaps/FocallyLiftedMapHelpers.hpp"
 #include "Domain/CoordinateMaps/FocallyLiftedSide.hpp"
 #include "Utilities/ConstantExpressions.hpp"
@@ -370,6 +371,7 @@ bool operator==(const FocallyLiftedMap<InnerMap>& lhs,
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (FocallyLiftedInnerMaps::Endcap,
                                       FocallyLiftedInnerMaps::FlatEndcap,
+                                      FocallyLiftedInnerMaps::FlatSide,
                                       FocallyLiftedInnerMaps::Side))
 
 #undef INSTANTIATE
@@ -390,6 +392,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (FocallyLiftedInnerMaps::Endcap,
 GENERATE_INSTANTIATIONS(INSTANTIATE,
                         (FocallyLiftedInnerMaps::Endcap,
                          FocallyLiftedInnerMaps::FlatEndcap,
+                         FocallyLiftedInnerMaps::FlatSide,
                          FocallyLiftedInnerMaps::Side),
                         (double, DataVector,
                          std::reference_wrapper<const double>,

--- a/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   Test_CoordinateMap.cpp
   Test_CylindricalEndcap.cpp
   Test_CylindricalFlatEndcap.cpp
+  Test_CylindricalFlatSide.cpp
   Test_CylindricalSide.cpp
   Test_DiscreteRotation.cpp
   Test_EquatorialCompression.cpp

--- a/tests/Unit/Domain/CoordinateMaps/Test_CylindricalFlatSide.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CylindricalFlatSide.cpp
@@ -1,0 +1,96 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <gsl/gsl_poly.h>
+#include <random>
+
+#include "Domain/CoordinateMaps/CylindricalFlatSide.hpp"
+#include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
+#include "NumericalAlgorithms/RootFinding/QuadraticEquation.hpp"
+
+namespace domain {
+namespace {
+void test_cylindrical_flat_side() {
+  INFO("CylindricalFlatSide");
+  // Set up random number generator
+  MAKE_GENERATOR(gen);
+
+  std::uniform_real_distribution<> unit_dis(0.0, 1.0);
+  std::uniform_real_distribution<> interval_dis(-1.0, 1.0);
+  std::uniform_real_distribution<> angle_dis(0.0, 2.0 * M_PI);
+
+  // Choose a random center and radius for sphere_two
+  const std::array<double, 3> center_two = {
+      interval_dis(gen), interval_dis(gen), interval_dis(gen)};
+  CAPTURE(center_two);
+  const double radius_two = 0.3 + unit_dis(gen);
+  CAPTURE(radius_two);
+
+  // Choose a random center for the annulus, making sure the
+  // z-coordinate is outside sphere_two and at least 5 percent below
+  // it.  Also make sure that the center of the annulus is not offset
+  // in x-y farther than the radius of sphere_two.
+  const std::array<double, 3> center_one = [&radius_two, &center_two, &unit_dis,
+                                            &angle_dis, &gen]() noexcept {
+    const double rho = unit_dis(gen) * radius_two;
+    const double phi = angle_dis(gen);
+    const double x = center_two[0] + rho * cos(phi);
+    const double y = center_two[1] + rho * sin(phi);
+    const double z = center_two[2] - radius_two * (1.05 + unit_dis(gen));
+    return std::array<double, 3>{{x, y, z}};
+  }();
+  CAPTURE(center_one);
+
+  // Pick proj_center inside sphere_two.
+  // Don't let proj_center be too close to the edge of the sphere.
+  const std::array<double, 3> proj_center = [&center_two, &radius_two, &gen,
+                                             &unit_dis, &interval_dis,
+                                             &angle_dis]() noexcept {
+    const double phi = angle_dis(gen);
+    const double cos_theta = interval_dis(gen);
+    const double sin_theta = sqrt(1.0 - square(cos_theta));
+    const double r = radius_two * 0.95 * unit_dis(gen);
+    return std::array<double, 3>{center_two[0] + r * sin_theta * cos(phi),
+                                 center_two[1] + r * sin_theta * sin(phi),
+                                 center_two[2] + r * cos_theta};
+  }();
+  CAPTURE(proj_center);
+
+  const double dist_annulus_proj = sqrt(square(center_one[0] - proj_center[0]) +
+                                        square(center_one[1] - proj_center[1]) +
+                                        square(center_one[2] - proj_center[2]));
+
+  // Pick outer radius of annulus, but not too small.
+  // Smallness is decided by making sure angle subtended by annulus with
+  // respect to projection center is greater than 0.05 radians.
+  const double outer_radius = dist_annulus_proj * 0.05 + unit_dis(gen);
+  CAPTURE(outer_radius);
+
+  // Pick inner radius of annulus.
+  // Don't make the annulus too thin,
+  // and don't make the inner radius too small.
+  const double min_inner_radius_fac =
+      std::max(0.05, dist_annulus_proj * 0.01 / outer_radius);
+  const double max_inner_radius_fac = 0.95 - min_inner_radius_fac;
+  const double inner_radius =
+      outer_radius *
+      (min_inner_radius_fac + max_inner_radius_fac * unit_dis(gen));
+  CAPTURE(inner_radius);
+
+  const CoordinateMaps::CylindricalFlatSide map(center_one, center_two,
+                                                proj_center, inner_radius,
+                                                outer_radius, radius_two);
+  test_suite_for_map_on_cylinder(map, 1.0, 2.0);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.CylindricalFlatSide",
+                  "[Domain][Unit]") {
+  test_cylindrical_flat_side();
+  CHECK(not CoordinateMaps::CylindricalFlatSide{}.is_identity());
+}
+}  // namespace domain


### PR DESCRIPTION
## Proposed changes

This adds a map to be used for blocks of a cylindrical binary domain: one of the blocks between the excised regions.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
