### PR TITLE
Time-dependence in block_logical_coordinates

### DIFF
--- a/src/Domain/BlockLogicalCoordinates.cpp
+++ b/src/Domain/BlockLogicalCoordinates.cpp
@@ -19,16 +19,19 @@ namespace {
 template <size_t Dim>
 using block_logical_coord_holder = boost::optional<
     IdPair<domain::BlockId, tnsr::I<double, Dim, typename ::Frame::Logical>>>;
+using functions_of_time_type = std::unordered_map<
+    std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>;
 }  // namespace
 
-template <size_t Dim>
+template <size_t Dim, typename Frame>
 std::vector<block_logical_coord_holder<Dim>> block_logical_coordinates(
-    const Domain<Dim>& domain,
-    const tnsr::I<DataVector, Dim, Frame::Inertial>& x) noexcept {
+    const Domain<Dim>& domain, const tnsr::I<DataVector, Dim, Frame>& x,
+    const double time,
+    const functions_of_time_type& functions_of_time) noexcept {
   const size_t num_pts = get<0>(x).size();
   std::vector<block_logical_coord_holder<Dim>> block_coord_holders(num_pts);
   for (size_t s = 0; s < num_pts; ++s) {
-    tnsr::I<double, Dim, Frame::Inertial> x_frame(0.0);
+    tnsr::I<double, Dim, Frame> x_frame(0.0);
     for (size_t d = 0; d < Dim; ++d) {
       x_frame.get(d) = x.get(d)[s];
     }
@@ -39,24 +42,69 @@ std::vector<block_logical_coord_holder<Dim>> block_logical_coordinates(
     // the smallest block_id).
     for (const auto& block : domain.blocks()) {
       if (block.is_time_dependent()) {
-        const auto moving_inv =
-            block.moving_mesh_grid_to_inertial_map().inverse(x_frame);
-        if (not moving_inv) {
-          continue;
+        if constexpr (std::is_same_v<Frame, ::Frame::Inertial>) {
+          // Point is in the inertial frame, so we need to map to the grid
+          // frame and then the logical frame.
+          const auto moving_inv =
+              block.moving_mesh_grid_to_inertial_map().inverse(
+                  x_frame, time, functions_of_time);
+          if (not moving_inv) {
+            continue;
+          }
+          // logical to grid map is time-independent.
+          const auto inv =
+              block.moving_mesh_logical_to_grid_map().inverse(moving_inv.get());
+          if (inv) {
+            x_logical = inv.get();
+          } else {
+            continue;  // Not in this block
+          }
+        } else {  // frame is different than ::Frame::Inertial
+          // Currently 'time' is unused in this branch.
+          // To make the compiler happy, need to trick it to think that
+          // 'time' is used.
+          (void) time;
+          // Currently we only support Grid and Inertial frames in the
+          // block, so make sure Frame is ::Frame::Grid. (The
+          // Inertial case was handled above.)
+          static_assert(std::is_same_v<Frame, ::Frame::Grid>,
+                        "Cannot convert from given frame to Grid frame");
+
+          // Point is in the grid frame, just map to logical frame.
+          const auto inv =
+              block.moving_mesh_logical_to_grid_map().inverse(x_frame);
+          if (inv) {
+            x_logical = inv.get();
+          } else {
+            continue;  // Not in this block
+          }
         }
-        const auto inv =
-            block.moving_mesh_logical_to_grid_map().inverse(moving_inv.get());
-        if (inv) {
-          x_logical = inv.get();
+      } else {  // not block.is_time_dependent()
+        if constexpr (std::is_same_v<Frame, ::Frame::Inertial>) {
+          const auto inv = block.stationary_map().inverse(x_frame);
+          if (inv) {
+            x_logical = inv.get();
+          } else {
+            continue;  // Not in this block
+          }
         } else {
-          continue;  // Not in this block
-        }
-      } else {
-        const auto inv = block.stationary_map().inverse(x_frame);
-        if (inv) {
-          x_logical = inv.get();
-        } else {
-          continue;  // Not in this block
+          // If the map is time-independent, then the grid and
+          // inertial frames are the same.  So if we are in the grid frame,
+          // convert to the inertial frame.  Otherwise throw a static_assert.
+          // Once we support more frames (e.g. distorted) this logic will
+          // change.
+          static_assert(std::is_same_v<Frame, ::Frame::Grid>,
+                        "Cannot convert from given frame to Grid frame");
+          tnsr::I<double, Dim, ::Frame::Inertial> x_inertial(0.0);
+          for (size_t d = 0; d < Dim; ++d) {
+            x_inertial.get(d) = x_frame.get(d);
+          }
+          const auto inv = block.stationary_map().inverse(x_inertial);
+          if (inv) {
+            x_logical = inv.get();
+          } else {
+            continue;  // Not in this block
+          }
         }
       }
       bool is_contained = true;
@@ -81,14 +129,19 @@ std::vector<block_logical_coord_holder<Dim>> block_logical_coordinates(
 // Explicit instantiations
 /// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATE(_, data)                                  \
-  template std::vector<block_logical_coord_holder<DIM(data)>> \
-  block_logical_coordinates(const Domain<DIM(data)>& domain,  \
-                            const tnsr::I<DataVector, DIM(data)>& x) noexcept;
+#define INSTANTIATE(_, data)                                                   \
+  template std::vector<block_logical_coord_holder<DIM(data)>>                  \
+  block_logical_coordinates(                                                   \
+      const Domain<DIM(data)>& domain,                                         \
+      const tnsr::I<DataVector, DIM(data), FRAME(data)>& x, const double time, \
+      const functions_of_time_type& functions_of_time) noexcept;
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
+                        (::Frame::Inertial, ::Frame::Grid))
 
+#undef FRAME
 #undef DIM
 #undef INSTANTIATE
 /// \endcond

--- a/src/Domain/BlockLogicalCoordinates.hpp
+++ b/src/Domain/BlockLogicalCoordinates.hpp
@@ -5,9 +5,13 @@
 
 #include <boost/optional.hpp>
 #include <cstddef>
+#include <memory>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 
 /// \cond
 namespace domain {
@@ -22,8 +26,8 @@ class IdPair;
 
 /// \ingroup ComputationalDomainGroup
 ///
-/// Computes the block logical coordinates and the containing `BlockId`
-/// of a set of points, given coordinates in the `Frame::Inertial` frame.
+/// Computes the block logical coordinates and the containing `BlockId` of
+/// a set of points, given coordinates in a particular frame.
 ///
 /// \details Returns a std::vector<boost::optional<IdPair<BlockId,coords>>>,
 /// where the vector runs over the points and is indexed in the same order as
@@ -34,9 +38,15 @@ class IdPair;
 /// If a point is on a shared boundary of two or more `Block`s, it is
 /// returned only once, and is considered to belong to the `Block`
 /// with the smaller `BlockId`.
-template <size_t Dim>
+template <size_t Dim, typename Frame>
 auto block_logical_coordinates(
-    const Domain<Dim>& domain,
-    const tnsr::I<DataVector, Dim, Frame::Inertial>& x) noexcept
+    const Domain<Dim>& domain, const tnsr::I<DataVector, Dim, Frame>& x,
+    double time = std::numeric_limits<double>::signaling_NaN(),
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time = std::unordered_map<
+            std::string,
+            std::unique_ptr<
+                domain::FunctionsOfTime::FunctionOfTime>>{}) noexcept
     -> std::vector<boost::optional<
-        IdPair<domain::BlockId, tnsr::I<double, Dim, Frame::Logical>>>>;
+        IdPair<domain::BlockId, tnsr::I<double, Dim, ::Frame::Logical>>>>;


### PR DESCRIPTION
## Proposed changes

Allow block_logical_coordinates to work with time-dependent maps,
and allow it to work for points in the grid frame, not just the inertial frame.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
