### PR TITLE
Fix error when compiling with charm MPI backend

### DIFF
--- a/src/IO/Observer/VolumeActions.hpp
+++ b/src/IO/Observer/VolumeActions.hpp
@@ -207,7 +207,9 @@ struct WriteVolumeData {
     Parallel::lock(node_lock);
     std::unordered_map<observers::ArrayComponentId, ExtentsAndTensorVolumeData>
         volume_data{};
-    CmiNodeLock file_lock = nullptr;
+    // Clang-tidy: CmiNodeLock changes type depending on the Charm++ build and
+    // sometimes clang-tidy doesn't like the way it is constructed
+    CmiNodeLock file_lock{};  // NOLINT
     db::mutate<Tags::H5FileLock, Tags::TensorData>(
         make_not_null(&box),
         [&observation_id, &file_lock, &volume_data ](

--- a/src/IO/Observer/WriteSimpleData.hpp
+++ b/src/IO/Observer/WriteSimpleData.hpp
@@ -42,7 +42,9 @@ struct WriteSimpleData {
                     const std::vector<double>& data_row,
                     const std::string& subfile_name) noexcept {
     Parallel::lock(node_lock);
-    CmiNodeLock file_lock = nullptr;
+    // Clang-tidy: CmiNodeLock changes type depending on the Charm++ build and
+    // sometimes clang-tidy doesn't like the way it is constructed
+    CmiNodeLock file_lock{};  // NOLINT
     db::mutate<Tags::H5FileLock>(
         make_not_null(&box), [&file_lock](const gsl::not_null<CmiNodeLock*>
                                               in_file_lock) noexcept {


### PR DESCRIPTION
## Proposed changes

This was recently changed to appease clang-tidy, but it broke my build on Minerva that uses an MPI backend instead of the container's multicore backend. The reason is that `CmiNodeLock` is a different typedef depending on the backend. If anyone has a better solution to handle this, please feel free to suggest.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
