### PR TITLE
Add note on mortar mesh orientation to docs

### DIFF
--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp
@@ -49,6 +49,11 @@ using MortarMap = std::unordered_map<MortarId<VolumeDim>, ValueType,
 /// \ingroup DiscontinuousGalerkinGroup
 /// Find a mesh for a mortar capable of representing data from either
 /// of two faces.
+///
+/// \warning Make sure the two face meshes are oriented the same, i.e.
+/// their dimensions align. This is facilitated by the `orientation`
+/// passed to `domain::Initialization::create_initial_mesh`, for
+/// example.
 template <size_t Dim>
 Mesh<Dim> mortar_mesh(const Mesh<Dim>& face_mesh1,
                       const Mesh<Dim>& face_mesh2) noexcept;


### PR DESCRIPTION
## Proposed changes

I tracked down how mortar meshes between rotated elements are constructed, to make sure the relative orientation is handled correctly. I found the documentation not quite clear, so here's a small addition.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
