### PR TITLE
Allow running the macOS workflow manually on develop

### DIFF
--- a/.github/workflows/MacOs.yaml
+++ b/.github/workflows/MacOs.yaml
@@ -120,7 +120,7 @@ jobs:
           tar -xzf charm-${CHARM_VERSION}.tar.gz
           cd ./charm-v${CHARM_VERSION}
           ./build charm++ multicore-darwin-x86_64 -j4 -O0 $SPECTRE_MIN_MACOS
-         rm ../charm-${CHARM_VERSION}.tar.gz
+          rm ../charm-${CHARM_VERSION}.tar.gz
       # Replace the ccache directory that building the dependencies may have
       # generated with the cached ccache directory.
       - name: Clear ccache from dependencies

--- a/.github/workflows/MacOs.yaml
+++ b/.github/workflows/MacOs.yaml
@@ -17,9 +17,11 @@ jobs:
   # Build all test executables and run unit tests on macOS
   unit_tests_macos:
     name: Unit tests on macOS
-    # Don't run on `develop` since we don't require this check to pass for PR
+    # Don't run on `develop` since we don't require this check to pass for PRs
     # be merged. See `CONTRIBUTING.md` for details.
-    if: github.ref != 'refs/heads/develop'
+    # Note: This is commented out to allow running the workflow manually on
+    # `develop` while the trigger is set to `workflow_dispatch`.
+    # if: github.ref != 'refs/heads/develop'
     runs-on: macos-latest
     env:
       # We install `openblas` instead of using the system version because we


### PR DESCRIPTION
## Proposed changes

Allow running the GitHub macOS workflow manually on `develop` while the trigger is set to `workflow_dispatch`.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
