### PR TITLE
TOMS748: Add version where the user supplies function values.

### DIFF
--- a/src/NumericalAlgorithms/RootFinding/TOMS748.hpp
+++ b/src/NumericalAlgorithms/RootFinding/TOMS748.hpp
@@ -28,6 +28,12 @@ namespace RootFinder {
  * `upper_bound`], and will throw if this interval does not bracket a root,
  * i.e. if `f(lower_bound) * f(upper_bound) > 0`.
  *
+ * The arguments `f_at_lower_bound` and `f_at_upper_bound` are optional, and
+ * are the function values at `lower_bound` and `upper_bound`. These function
+ * values are often known because the user typically checks if a root is
+ * bracketed before calling `toms748`; passing the function values here saves
+ * two function evaluations.
+ *
  * See the [Boost](http://www.boost.org/) documentation for more details.
  *
  * \requires Function `f` is invokable with a `double`
@@ -38,7 +44,8 @@ namespace RootFinder {
  */
 template <typename Function>
 double toms748(const Function& f, const double lower_bound,
-               const double upper_bound, const double absolute_tolerance,
+               const double upper_bound, const double f_at_lower_bound,
+               const double f_at_upper_bound, const double absolute_tolerance,
                const double relative_tolerance,
                const size_t max_iterations = 100) {
   ASSERT(relative_tolerance > std::numeric_limits<double>::epsilon(),
@@ -56,13 +63,78 @@ double toms748(const Function& f, const double lower_bound,
   };
   // clang-tidy: internal boost warning, can't fix it.
   auto result = boost::math::tools::toms748_solve(  // NOLINT
-      f, lower_bound, upper_bound, tol, max_iters);
+      f, lower_bound, upper_bound, f_at_lower_bound, f_at_upper_bound, tol,
+      max_iters);
   if (max_iters >= max_iterations) {
     throw convergence_error(
         "toms748 reached max iterations without converging");
   }
   return result.first + 0.5 * (result.second - result.first);
 }
+
+/*!
+ * \ingroup NumericalAlgorithmsGroup
+ * \brief Finds the root of the function `f` with the TOMS_748 method,
+ * where function values are not supplied at the lower and upper
+ * bounds.
+ */
+template <typename Function>
+double toms748(const Function& f, const double lower_bound,
+               const double upper_bound, const double absolute_tolerance,
+               const double relative_tolerance,
+               const size_t max_iterations = 100) {
+  return toms748(f, lower_bound, upper_bound, f(lower_bound), f(upper_bound),
+                 absolute_tolerance, relative_tolerance, max_iterations);
+}
+
+namespace detail {
+template <typename Function>
+DataVector toms748_impl(const Function& f, const DataVector& lower_bound,
+                        const DataVector& upper_bound,
+                        const DataVector& f_at_lower_bound,
+                        const DataVector& f_at_upper_bound,
+                        const double absolute_tolerance,
+                        const double relative_tolerance,
+                        const size_t max_iterations,
+                        const bool function_values_are_supplied) {
+  ASSERT(relative_tolerance > std::numeric_limits<double>::epsilon(),
+         "The relative tolerance is too small.");
+  // This solver requires tol to be passed as a termination condition. This
+  // termination condition is equivalent to the convergence criteria used by the
+  // GSL
+  auto tol = [absolute_tolerance, relative_tolerance](const double lhs,
+                                                      const double rhs) {
+    return (fabs(lhs - rhs) <=
+            absolute_tolerance +
+                relative_tolerance * fmin(fabs(lhs), fabs(rhs)));
+  };
+  DataVector result_vector{lower_bound.size()};
+  for (size_t i = 0; i < result_vector.size(); ++i) {
+    // toms748_solver modifies the max_iters after the root is found to the
+    // number of iterations that it took to find the root, so we reset it to
+    // max_iterations after each root find.
+    boost::uintmax_t max_iters = max_iterations;
+    auto result = function_values_are_supplied
+                      ?
+                      // clang-tidy: internal boost warning, can't fix it.
+                      boost::math::tools::toms748_solve(  // NOLINT
+                          [&f, i](double x) { return f(x, i); }, lower_bound[i],
+                          upper_bound[i], f_at_lower_bound[i],
+                          f_at_upper_bound[i], tol, max_iters)
+                      :
+                      // clang-tidy: internal boost warning, can't fix it.
+                      boost::math::tools::toms748_solve(  // NOLINT
+                          [&f, i](double x) { return f(x, i); }, lower_bound[i],
+                          upper_bound[i], tol, max_iters);
+    if (max_iters >= max_iterations) {
+      throw convergence_error(
+          "toms748 reached max iterations without converging");
+    }
+    result_vector[i] = result.first + 0.5 * (result.second - result.first);
+  }
+  return result_vector;
+}
+}  // namespace detail
 
 /*!
  * \ingroup NumericalAlgorithmsGroup
@@ -97,34 +169,32 @@ DataVector toms748(const Function& f, const DataVector& lower_bound,
                    const double absolute_tolerance,
                    const double relative_tolerance,
                    const size_t max_iterations = 100) {
-  ASSERT(relative_tolerance > std::numeric_limits<double>::epsilon(),
-         "The relative tolerance is too small.");
-  // This solver requires tol to be passed as a termination condition. This
-  // termination condition is equivalent to the convergence criteria used by the
-  // GSL
-  auto tol = [absolute_tolerance, relative_tolerance](const double lhs,
-                                                      const double rhs) {
-    return (fabs(lhs - rhs) <=
-            absolute_tolerance +
-                relative_tolerance * fmin(fabs(lhs), fabs(rhs)));
-  };
-  DataVector result_vector{lower_bound.size()};
-  for (size_t i = 0; i < result_vector.size(); ++i) {
-    // toms748_solver modifies the max_iters after the root is found to the
-    // number of iterations that it took to find the root, so we reset it to
-    // max_iterations after each root find.
-    boost::uintmax_t max_iters = max_iterations;
-    // clang-tidy: internal boost warning, can't fix it.
-    auto result = boost::math::tools::toms748_solve(  // NOLINT
-        [&f, i](double x) { return f(x, i); }, lower_bound[i], upper_bound[i],
-        tol, max_iters);
-    if (max_iters >= max_iterations) {
-      throw convergence_error(
-          "toms748 reached max iterations without converging");
-    }
-    result_vector[i] = result.first + 0.5 * (result.second - result.first);
-  }
-  return result_vector;
+  return detail::toms748_impl(f, lower_bound, upper_bound, DataVector{},
+                              DataVector{}, absolute_tolerance,
+                              relative_tolerance, max_iterations, false);
+}
+
+/*!
+ * \ingroup NumericalAlgorithmsGroup
+ * \brief Finds the root of the function `f` with the TOMS_748 method on each
+ * element in a `DataVector`, where function values are supplied at the lower
+ * and upper bounds.
+ *
+ * Supplying function values is an optimization that saves two
+ * function calls per point.  The function values are often available
+ * because one often checks if the root is bracketed before calling `toms748`.
+ */
+template <typename Function>
+DataVector toms748(const Function& f, const DataVector& lower_bound,
+                   const DataVector& upper_bound,
+                   const DataVector& f_at_lower_bound,
+                   const DataVector& f_at_upper_bound,
+                   const double absolute_tolerance,
+                   const double relative_tolerance,
+                   const size_t max_iterations = 100) {
+  return detail::toms748_impl(f, lower_bound, upper_bound, f_at_lower_bound,
+                              f_at_upper_bound, absolute_tolerance,
+                              relative_tolerance, max_iterations, true);
 }
 
 }  // namespace RootFinder


### PR DESCRIPTION
## Proposed changes

Adds a TOMS748 function where the user supplies function values.

Function values are often available anyway because the user will
often try to bracket the root before calling TOMS748, and supplying
these function values saves two function evaluations from being
repeated.

This is purely an optimization, since TOMS748 without function values
can be called even if you do have function values.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
