### PR TITLE
Add UnitNormalOneFormTag

### DIFF
--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -304,7 +304,28 @@ struct OneOverOneFormMagnitudeCompute : db::ComputeTag,
                  NormalOneForm<Frame>>;
 };
 
+<<<<<<< HEAD
 // @{
+=======
+/// unit one-form is \f$_j\f$,the normalized one-form.
+template <typename Frame>
+struct UnitNormalOneForm : db::SimpleTag {
+  using type = tnsr::i<DataVector, 3, Frame>;
+};
+/// Computes the unit one-form perpendicular to the horizon
+template <typename Frame>
+struct UnitNormalOneFormCompute : UnitNormalOneForm<Frame>, db::ComputeTag {
+    using base = UnitNormalOneForm<Frame>;
+  static constexpr auto function = static_cast<void (*)(
+      const gsl::not_null<tnsr::i<DataVector, 3, Frame>*>,
+      const tnsr::i<DataVector, 3, Frame>&, const DataVector&) noexcept>(
+      &::StrahlkorperGr::unit_normal_one_form<Frame>);
+  using argument_tags = tmpl::list<StrahlkorperTags::NormalOneForm<Frame>,
+                                   OneOverOneFormMagnitude>;
+  using return_type = tnsr::i<DataVector, 3, Frame>;
+};
+
+>>>>>>> 4efd5ec... Add UnitNormalOneFormTag
 /// `Tangents(i,j)` is \f$\partial x_{\rm surf}^i/\partial q^j\f$,
 /// where \f$x_{\rm surf}^i\f$ are the Cartesian coordinates of the
 /// surface (i.e. `CartesianCoords`) and are considered functions of

--- a/src/ApparentHorizons/TagsDeclarations.hpp
+++ b/src/ApparentHorizons/TagsDeclarations.hpp
@@ -38,6 +38,11 @@ struct EuclideanSurfaceIntegral;
 struct OneOverOneFormMagnitude;
 template <size_t Dim, typename Frame, typename DataType>
 struct OneOverOneFormMagnitudeCompute;
+template <typename Frame>
+struct UnitNormalOneForm;
+template <typename Frame>
+struct UnitNormalOneFormCompute;
+
 
 }  // namespace StrahlkorperTags
 

--- a/tests/Unit/ApparentHorizons/Test_Tags.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Tags.cpp
@@ -299,6 +299,9 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
   TestHelpers::db::test_simple_tag<StrahlkorperTags::OneOverOneFormMagnitude>(
       "OneOverOneFormMagnitude");
   TestHelpers::db::test_simple_tag<
+      StrahlkorperTags::UnitNormalOneForm<Frame::Inertial>>(
+      "UnitNormalOneForm");
+  TestHelpers::db::test_simple_tag<
       StrahlkorperTags::Strahlkorper<Frame::Inertial>>("Strahlkorper");
   TestHelpers::db::test_simple_tag<StrahlkorperTags::ThetaPhi<Frame::Inertial>>(
       "ThetaPhi");
@@ -398,4 +401,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
       StrahlkorperTags::OneOverOneFormMagnitudeCompute<3, Frame::Inertial,
                                                        DataVector>>(
       "OneOverOneFormMagnitude");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::UnitNormalOneFormCompute<Frame::Inertial>>(
+      "UnitNormalOneForm");
 }


### PR DESCRIPTION
## Proposed changes

Add UnitNormalOneFormTag and UnitNormalOneFormCompute for computing the unit one form perpendicular to the horizon.

### Types of changes:

- [ ] Bugfix
- [ x] New feature
- [ ] Refactor

### Component:

- [ x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments
