### PR TITLE
Add Schwarz weighting functions

### DIFF
--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   OverlapHelpers.cpp
+  Weighting.cpp
   )
 
 spectre_target_headers(
@@ -18,6 +19,7 @@ spectre_target_headers(
   ElementCenteredSubdomainData.hpp
   OverlapHelpers.hpp
   Schwarz.hpp
+  Weighting.hpp
   )
 
 target_link_libraries(
@@ -26,7 +28,6 @@ target_link_libraries(
   Boost::boost
   DataStructures
   DomainStructure
-  PRIVATE
   ErrorHandling
   Utilities
   INTERFACE

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/Weighting.cpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/Weighting.cpp
@@ -1,0 +1,224 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/LinearSolver/Schwarz/Weighting.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <string>
+#include <unordered_set>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Hypercube.hpp"
+#include "Domain/Structure/Side.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Math.hpp"
+
+namespace LinearSolver::Schwarz {
+
+DataVector extruding_weight(const DataVector& logical_coords,
+                            const double width, const Side& side) noexcept {
+  const double sign = side == Side::Lower ? -1. : 1.;
+  return 0.5 + 0.5 * sign -
+         sign * smoothstep<2>(sign - width, sign + width, logical_coords);
+}
+
+namespace {
+void apply_element_weight(const gsl::not_null<Scalar<DataVector>*> weight,
+                          const DataVector& logical_coords, const double width,
+                          const bool has_overlap_lower,
+                          const bool has_overlap_upper) noexcept {
+  if (has_overlap_lower and has_overlap_upper) {
+    get(*weight) *= extruding_weight(logical_coords, width, Side::Lower) +
+                    extruding_weight(logical_coords, width, Side::Upper) - 1.;
+  } else if (has_overlap_lower) {
+    get(*weight) *= extruding_weight(logical_coords, width, Side::Lower);
+  } else if (has_overlap_upper) {
+    get(*weight) *= extruding_weight(logical_coords, width, Side::Upper);
+  }
+}
+}  // namespace
+
+template <size_t Dim>
+void element_weight(
+    const gsl::not_null<Scalar<DataVector>*> weight,
+    const tnsr::I<DataVector, Dim, Frame::Logical>& logical_coords,
+    const std::array<double, Dim>& overlap_widths,
+    const std::unordered_set<Direction<Dim>>& external_boundaries) noexcept {
+  destructive_resize_components(weight, logical_coords.begin()->size());
+  get(*weight) = 1.;
+  for (size_t d = 0; d < Dim; ++d) {
+    ASSERT(gsl::at(overlap_widths, d) > 0,
+           "Don't try to apply weighting when the overlap has zero width.");
+    apply_element_weight(
+        weight, logical_coords.get(d), gsl::at(overlap_widths, d),
+        external_boundaries.find(Direction<Dim>{d, Side::Lower}) ==
+            external_boundaries.end(),
+        external_boundaries.find(Direction<Dim>{d, Side::Upper}) ==
+            external_boundaries.end());
+  }
+}
+
+template <size_t Dim>
+Scalar<DataVector> element_weight(
+    const tnsr::I<DataVector, Dim, Frame::Logical>& logical_coords,
+    const std::array<double, Dim>& overlap_widths,
+    const std::unordered_set<Direction<Dim>>& external_boundaries) noexcept {
+  Scalar<DataVector> weight{logical_coords.begin()->size()};
+  element_weight(make_not_null(&weight), logical_coords, overlap_widths,
+                 external_boundaries);
+  return weight;
+}
+
+DataVector intruding_weight(const DataVector& logical_coords,
+                            const double width, const Side& side) noexcept {
+  const double sign = side == Side::Lower ? -1. : 1.;
+  return extruding_weight(logical_coords - sign * 2., width, opposite(side));
+}
+
+namespace {
+size_t dim_in_volume(const size_t dim_in_slice,
+                     const size_t sliced_dim) noexcept {
+  return dim_in_slice >= sliced_dim ? (dim_in_slice + 1) : dim_in_slice;
+}
+}  // namespace
+
+template <size_t Dim>
+void intruding_weight(
+    const gsl::not_null<Scalar<DataVector>*> weight,
+    const tnsr::I<DataVector, Dim, Frame::Logical>& logical_coords,
+    const Direction<Dim>& direction,
+    const std::array<double, Dim>& overlap_widths,
+    const size_t num_intruding_overlaps,
+    const std::unordered_set<Direction<Dim>>& external_boundaries) noexcept {
+  static_assert(Dim > 0 and Dim <= 3,
+                "This function supports one, two and three dimensions.");
+  ASSERT(gsl::at(overlap_widths, direction.dimension()) > 0,
+         "Don't try to apply weighting when the overlap has zero width.");
+  if constexpr (Dim == 1) {
+    get(*weight) =
+        intruding_weight(logical_coords.get(direction.dimension()),
+                         gsl::at(overlap_widths, direction.dimension()),
+                         direction.side()) /
+        num_intruding_overlaps;
+  } else {
+    const size_t num_points = logical_coords.begin()->size();
+    destructive_resize_components(weight, num_points);
+    get(*weight) = 1.;
+    const auto has_overlap = [&external_boundaries](const size_t dimension,
+                                                    const Side side) noexcept {
+      return external_boundaries.find(Direction<Dim>{dimension, side}) ==
+             external_boundaries.end();
+    };
+    // Apply weighting perpendicular to the overlap direction
+    for (size_t d = 0; (d == direction.dimension() ? ++d : d) < Dim; ++d) {
+      ASSERT(gsl::at(overlap_widths, d) > 0,
+             "Don't try to apply weighting when the overlap has zero width.");
+      apply_element_weight(
+          weight, logical_coords.get(d), gsl::at(overlap_widths, d),
+          has_overlap(d, Side::Lower), has_overlap(d, Side::Upper));
+    }
+    // Add contributions from the corners and edges of the subdomain
+    // These contributions account for the corner- and edge-neighbors not being
+    // part of the subdomain, and thus not contributing weights. To retain
+    // conservation, we add the missing weights to the intruding overlaps here.
+    // See the function documentation for details.
+    const auto skip_corner =
+        [&direction, &has_overlap](const Vertex<Dim - 1>& corner) noexcept {
+          // Skip corners to external boundaries
+          for (size_t d = 0; d < Dim - 1; ++d) {
+            if (not has_overlap(dim_in_volume(d, direction.dimension()),
+                                corner.side_in_parent_dimension(d))) {
+              return true;
+            }
+          }
+          return false;
+        };
+    Scalar<DataVector> corner_weight{num_points};
+    for (const auto& corner : VertexIterator<Dim - 1>{}) {
+      if (skip_corner(corner)) {
+        continue;
+      }
+      get(corner_weight) = 1.;
+      for (size_t d = 0; d < Dim - 1; ++d) {
+        const size_t d_vol = dim_in_volume(d, direction.dimension());
+        get(corner_weight) *= intruding_weight(
+            logical_coords.get(d_vol), gsl::at(overlap_widths, d_vol),
+            corner.side_in_parent_dimension(d));
+      }
+      // Divide equally between all face-neighbors that share this corner
+      get(*weight) += get(corner_weight) / Dim;
+    }
+    if constexpr (Dim == 3) {
+      Scalar<DataVector> edge_weight{num_points};
+      for (const auto& edge : EdgeIterator<Dim - 1>{}) {
+        const size_t d_perp =
+            dim_in_volume(dim_in_volume(0, edge.dimension_in_parent()),
+                          direction.dimension());
+        // Skip edges to external boundaries
+        if (not has_overlap(d_perp, edge.side())) {
+          continue;
+        }
+        get(edge_weight) = 1.;
+        const size_t d_edge =
+            dim_in_volume(edge.dimension_in_parent(), direction.dimension());
+        apply_element_weight(
+            make_not_null(&edge_weight), logical_coords.get(d_edge),
+            gsl::at(overlap_widths, d_edge), has_overlap(d_edge, Side::Lower),
+            has_overlap(d_edge, Side::Upper));
+        get(edge_weight) *=
+            intruding_weight(logical_coords.get(d_perp),
+                             gsl::at(overlap_widths, d_perp), edge.side());
+        // Divide equally between all face-neighbors that share this edge
+        get(*weight) += get(edge_weight) / (Dim - 1);
+      }
+    }
+    // Apply weighting along the overlap direction
+    get(*weight) *=
+        intruding_weight(logical_coords.get(direction.dimension()),
+                         gsl::at(overlap_widths, direction.dimension()),
+                         direction.side()) /
+        num_intruding_overlaps;
+  }
+}
+
+template <size_t Dim>
+Scalar<DataVector> intruding_weight(
+    const tnsr::I<DataVector, Dim, Frame::Logical>& logical_coords,
+    const Direction<Dim>& direction,
+    const std::array<double, Dim>& overlap_widths,
+    const size_t num_intruding_overlaps,
+    const std::unordered_set<Direction<Dim>>& external_boundaries) noexcept {
+  Scalar<DataVector> weight{logical_coords.begin()->size()};
+  intruding_weight(make_not_null(&weight), logical_coords, direction,
+                   overlap_widths, num_intruding_overlaps, external_boundaries);
+  return weight;
+}
+
+/// \cond
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define INSTANTIATE(r, data)                                                \
+  template Scalar<DataVector> element_weight(                               \
+      const tnsr::I<DataVector, DIM(data), Frame::Logical>& logical_coords, \
+      const std::array<double, DIM(data)>& overlap_widths,                  \
+      const std::unordered_set<Direction<DIM(data)>>& external_boundaries); \
+  template Scalar<DataVector> intruding_weight(                             \
+      const tnsr::I<DataVector, DIM(data), Frame::Logical>& logical_coords, \
+      const Direction<DIM(data)>& direction,                                \
+      const std::array<double, DIM(data)>& overlap_widths,                  \
+      size_t num_intruding_overlaps,                                        \
+      const std::unordered_set<Direction<DIM(data)>>& external_boundaries);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATE
+/// \endcond
+
+}  // namespace LinearSolver::Schwarz

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/Weighting.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/Weighting.hpp
@@ -1,0 +1,131 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <unordered_set>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace LinearSolver::Schwarz {
+
+/*!
+ * \brief Weights for the solution on an element-centered subdomain, decreasing
+ * from 1 to 0.5 towards the `side` over the logical distance `width`, and
+ * further to 0 over the same distance outside the element.
+ *
+ * The weighting function over a full element-centered subdomain is
+ *
+ * \f{equation}
+ * w(\xi) = \frac{1}{2}\left( \phi\left( \frac{\xi + 1}{\delta} \right) -
+ * \phi\left( \frac{\xi - 1}{\delta} \right) \right) \f}
+ *
+ * where \f$\phi(\xi)\f$ is a second-order `::smoothstep`, i.e. the quintic
+ * polynomial
+ *
+ * \f{align*}
+ * \phi(\xi) = \begin{cases} \mathrm{sign}(\xi) \quad \text{for}
+ * \quad |\xi| > 1 \\
+ * \frac{1}{8}\left(15\xi - 10\xi^3 + 3\xi^5\right) \end{cases}
+ * \f}
+ *
+ * (see Eq. (39) in \cite Vincent2019qpd).
+ *
+ * The `LinearSolver::Schwarz::extruding_weight` and
+ * `LinearSolver::Schwarz::intruding_weight` functions each compute one of the
+ * two terms in \f$w(\xi)\f$. For example, consider an element-centered
+ * subdomain `A` that overlaps with a neighboring element-centered subdomain
+ * `B`. To combine solutions on `A` and `B` to a weighted solution on `A`,
+ * multiply the solution on `A` with the `extruding_weight` and the solution on
+ * `B` with the `intruding_weight`, both evaluated at the logical coordinates in
+ * `A` and at the `side` of `A` that faces `B`.
+ */
+DataVector extruding_weight(const DataVector& logical_coords, double width,
+                            const Side& side) noexcept;
+
+// @{
+/*!
+ * \brief Weights for data on the central element of an element-centered
+ * subdomain
+ *
+ * Constructs the weighting field
+ *
+ * \f{equation}
+ * W(\boldsymbol{\xi}) = \prod^d_{i=0} w(\xi^i)
+ * \f}
+ *
+ * where \f$w(\xi^i)\f$ is the one-dimensional weighting function described in
+ * `LinearSolver::Schwarz::extruding_weight` and \f$\xi^i\f$ are the
+ * element-logical coordinates (see Eq. (41) in \cite Vincent2019qpd).
+ */
+template <size_t Dim>
+void element_weight(
+    gsl::not_null<Scalar<DataVector>*> element_weight,
+    const tnsr::I<DataVector, Dim, Frame::Logical>& logical_coords,
+    const std::array<double, Dim>& overlap_widths,
+    const std::unordered_set<Direction<Dim>>& external_boundaries) noexcept;
+
+template <size_t Dim>
+Scalar<DataVector> element_weight(
+    const tnsr::I<DataVector, Dim, Frame::Logical>& logical_coords,
+    const std::array<double, Dim>& overlap_widths,
+    const std::unordered_set<Direction<Dim>>& external_boundaries) noexcept;
+// @}
+
+/*!
+ * \brief Weights for the intruding solution of a neighboring element-centered
+ * subdomain, increasing from 0 to 0.5 towards the `side` over the logical
+ * distance `width`, and further to 1 over the same distance outside the
+ * element.
+ *
+ * \see `LinearSolver::Schwarz::extruding_weight`
+ */
+DataVector intruding_weight(const DataVector& logical_coords, double width,
+                            const Side& side) noexcept;
+
+// @{
+/*!
+ * \brief Weights for data on overlap regions intruding into an element-centered
+ * subdomain
+ *
+ * Constructs the weighting field \f$W(\xi)\f$ as described in
+ * `LinearSolver::Schwarz::element_weight` for the data that overlaps with the
+ * central element of an element-centered subdomain. The weights are constructed
+ * in such a way that all weights at a grid point sum to one, i.e. the weight is
+ * conserved. The `logical_coords` are the element-logical coordinates of the
+ * central element.
+ *
+ * This function assumes that corner- and edge-neighbors of the central element
+ * are not part of the subdomain, which means that no contributions from those
+ * neighbors are expected although the weighting field is non-zero in overlap
+ * regions with those neighbors. Therefore, to retain conservation we must
+ * account for this missing weight by adding it to the central element, to the
+ * intruding overlaps from face-neighbors, or split it between the two. We
+ * choose to add the weight to the intruding overlaps, since that's where
+ * information from the corner- and edge-regions propagates through in a DG
+ * context.
+ */
+template <size_t Dim>
+void intruding_weight(
+    gsl::not_null<Scalar<DataVector>*> weight,
+    const tnsr::I<DataVector, Dim, Frame::Logical>& logical_coords,
+    const Direction<Dim>& direction,
+    const std::array<double, Dim>& overlap_widths,
+    size_t num_intruding_overlaps,
+    const std::unordered_set<Direction<Dim>>& external_boundaries) noexcept;
+
+template <size_t Dim>
+Scalar<DataVector> intruding_weight(
+    const tnsr::I<DataVector, Dim, Frame::Logical>& logical_coords,
+    const Direction<Dim>& direction,
+    const std::array<double, Dim>& overlap_widths,
+    size_t num_intruding_overlaps,
+    const std::unordered_set<Direction<Dim>>& external_boundaries) noexcept;
+// @}
+
+}  // namespace LinearSolver::Schwarz

--- a/src/Utilities/Math.hpp
+++ b/src/Utilities/Math.hpp
@@ -121,8 +121,9 @@ DataType smoothstep(const double lower_edge, const double upper_edge,
           return {0., 0., 0., 0., 35., -84., 70., -20.};
         }
       }(),
-      static_cast<DataType>(
-          clamp((arg - lower_edge) / (upper_edge - lower_edge), 0., 1.)));
+      static_cast<DataType>(clamp(
+          static_cast<DataType>((arg - lower_edge) / (upper_edge - lower_edge)),
+          0., 1.)));
 }
 
 /// \ingroup UtilitiesGroup

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/CMakeLists.txt
@@ -6,11 +6,12 @@ set(LIBRARY "Test_ParallelSchwarz")
 set(LIBRARY_SOURCES
   Test_ElementCenteredSubdomainData.cpp
   Test_OverlapHelpers.cpp
+  Test_Weighting.cpp
   )
 
 add_test_library(
   ${LIBRARY}
   "ParallelAlgorithms/LinearSolver/Schwarz"
   "${LIBRARY_SOURCES}"
-  "DataStructures;DomainStructure;LinearSolver;ParallelSchwarz"
+  "DataStructures;Domain;DomainStructure;LinearSolver;ParallelSchwarz;Spectral"
   )

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_Weighting.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_Weighting.cpp
@@ -1,0 +1,199 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Structure/Side.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "ParallelAlgorithms/LinearSolver/Schwarz/OverlapHelpers.hpp"
+#include "ParallelAlgorithms/LinearSolver/Schwarz/Weighting.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace LinearSolver::Schwarz {
+
+namespace {
+
+// This function explicitly implements Eqn. (41) in
+// https://arxiv.org/abs/1907.01572
+template <size_t Dim>
+void test_element_weight() {
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> dist_coords(-2., 2.);
+  std::uniform_real_distribution<> dist_widths(0.1, 2.);
+  const auto logical_coords =
+      make_with_random_values<tnsr::I<DataVector, Dim, Frame::Logical>>(
+          make_not_null(&generator), make_not_null(&dist_coords), size_t{5});
+  const auto widths = make_with_random_values<std::array<double, Dim>>(
+      make_not_null(&generator), make_not_null(&dist_widths));
+  CAPTURE(Dim);
+  CAPTURE(logical_coords);
+  CAPTURE(widths);
+  const auto phi = [](const DataVector& xi) {
+    DataVector result{xi.size()};
+    for (size_t i = 0; i < xi.size(); ++i) {
+      if (xi[i] < -1.) {
+        result[i] = -1.;
+      } else if (xi[i] > 1.) {
+        result[i] = 1.;
+      } else {
+        result[i] =
+            0.125 * (15. * xi[i] - 10. * cube(xi[i]) + 3. * pow<5>(xi[i]));
+      }
+    }
+    return result;
+  };
+  Scalar<DataVector> reference_element_weight{logical_coords.begin()->size(),
+                                              1.};
+  for (size_t d = 0; d < Dim; ++d) {
+    get(reference_element_weight) *=
+        0.5 * (phi((logical_coords.get(d) + 1.) / gsl::at(widths, d)) -
+               phi((logical_coords.get(d) - 1.) / gsl::at(widths, d)));
+  }
+  CHECK_ITERABLE_APPROX(
+      get(LinearSolver::Schwarz::element_weight(logical_coords, widths, {})),
+      get(reference_element_weight));
+}
+
+template <size_t Dim>
+void test_weights_conservation(const Element<Dim>& element,
+                               const Mesh<Dim>& mesh,
+                               const size_t max_overlap) noexcept {
+  INFO("Weight conservation");
+  CAPTURE(Dim);
+  CAPTURE(element);
+  CAPTURE(mesh);
+  CAPTURE(max_overlap);
+  const auto logical_coords = logical_coordinates(mesh);
+  CAPTURE(logical_coords);
+  const size_t num_points = mesh.number_of_grid_points();
+  std::array<double, Dim> overlap_widths{};
+  for (size_t d = 0; d < Dim; ++d) {
+    const auto overlap_extent =
+        LinearSolver::Schwarz::overlap_extent(mesh.extents(d), max_overlap);
+    const auto collocation_points =
+        Spectral::collocation_points(mesh.slice_through(d));
+    gsl::at(overlap_widths, d) = LinearSolver::Schwarz::overlap_width(
+        overlap_extent, collocation_points);
+  }
+  CAPTURE(overlap_widths);
+  // The weights for the element data and those for data on intruding overlaps
+  // should sum to one.
+  const auto element_weights = LinearSolver::Schwarz::element_weight(
+      logical_coords, overlap_widths, element.external_boundaries());
+  CAPTURE(element_weights);
+  auto summed_weights = element_weights;
+  for (const auto& direction_and_neighbors : element.neighbors()) {
+    const auto& direction = direction_and_neighbors.first;
+    const size_t num_neighbors = direction_and_neighbors.second.size();
+    get(summed_weights) +=
+        num_neighbors * get(LinearSolver::Schwarz::intruding_weight(
+                            logical_coords, direction, overlap_widths,
+                            num_neighbors, element.external_boundaries()));
+  }
+  CHECK_ITERABLE_APPROX(get(summed_weights), DataVector(num_points, 1.));
+}
+
+template <size_t Dim>
+void test_weights(const Mesh<Dim>& mesh, const size_t max_overlap) noexcept {
+  typename Element<Dim>::Neighbors_t neighbors{};
+  for (size_t d = 0; d < Dim; ++d) {
+    for (const auto& side : std::array<Side, 2>{{Side::Lower, Side::Upper}}) {
+      auto& direction_neighbors =
+          neighbors.emplace(Direction<Dim>{d, side}, Neighbors<Dim>{})
+              .first->second;
+      for (size_t i = 0; i < two_to_the(Dim - 1); ++i) {
+        direction_neighbors.add_ids({ElementId<Dim>{i + 1}});
+        const Element<Dim> element{ElementId<Dim>{0}, neighbors};
+        for (size_t max_overlap_i = 1; max_overlap_i <= max_overlap;
+             ++max_overlap_i) {
+          test_weights_conservation(element, mesh, max_overlap_i);
+        }
+      }
+    }
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ParallelSchwarz.Weighting",
+                  "[Unit][ParallelAlgorithms][LinearSolver]") {
+  {
+    INFO("Weighting function");
+    // Extruding weight on upper side:
+    // ___
+    //    \       (disabling backslash line continuation)
+    //     --
+    // ---+--> xi
+    //    1.
+    CHECK_ITERABLE_APPROX(
+        extruding_weight(DataVector({-1., 0., 1., 2., 3.}), 1., Side::Upper),
+        DataVector({1., 1., 0.5, 0., 0.}));
+    // Intruding weight on upper side:
+    //      __
+    //    /
+    // ---
+    // ---+---> xi
+    //    1.
+    CHECK_ITERABLE_APPROX(
+        intruding_weight(DataVector({-1., 0., 1., 2., 3.}), 1., Side::Upper),
+        DataVector({0., 0., 0.5, 1., 1.}));
+    // Extruding weight on lower side:
+    //     ___
+    //   /
+    // --
+    // --+----> xi
+    //  -1.
+    CHECK_ITERABLE_APPROX(
+        extruding_weight(DataVector({-3., -2., -1., 0., 1.}), 1., Side::Lower),
+        DataVector({0., 0., 0.5, 1., 1.}));
+    // Intruding weight on lower side:
+    // __
+    //   \        (disabling backslash line continuation)
+    //    ---
+    // --+---> xi
+    //  -1.
+    CHECK_ITERABLE_APPROX(
+        intruding_weight(DataVector({-3., -2., -1., 0., 1.}), 1., Side::Lower),
+        DataVector({1., 1., 0.5, 0., 0.}));
+  }
+  {
+    const auto element_weight = LinearSolver::Schwarz::element_weight(
+        tnsr::I<DataVector, 1, Frame::Logical>{
+            {{{-2., -1.5, -1., -0.5, -0.25, 0., 0.25, 0.5, 1., 1.5, 2.}}}},
+        {{1.}}, {});
+    CHECK_ITERABLE_APPROX(
+        get(element_weight),
+        DataVector({0., 0.103515625, 0.5, 0.896484375, 0.98394775390625, 1.,
+                    0.98394775390625, 0.896484375, 0.5, 0.103515625, 0.}));
+  }
+  // Test against an explicit reference implementation
+  {
+    test_element_weight<1>();
+    test_element_weight<2>();
+    test_element_weight<3>();
+  }
+  // Test weights conservation on all possible element-neighbor configurations
+  {
+    test_weights(Mesh<1>{3, Spectral::Basis::Legendre,
+                         Spectral::Quadrature::GaussLobatto},
+                 4);
+    test_weights(Mesh<2>{{3, 4},
+                         Spectral::Basis::Legendre,
+                         Spectral::Quadrature::GaussLobatto},
+                 4);
+    test_weights(Mesh<3>{{2, 3, 4},
+                         Spectral::Basis::Legendre,
+                         Spectral::Quadrature::GaussLobatto},
+                 4);
+  }
+}
+
+}  // namespace LinearSolver::Schwarz

--- a/tests/Unit/Utilities/Test_Math.cpp
+++ b/tests/Unit/Utilities/Test_Math.cpp
@@ -60,6 +60,13 @@ SPECTRE_TEST_CASE("Unit.Utilities.Math", "[Unit][Utilities]") {
     test_smoothstep<1>();
     test_smoothstep<2>();
     test_smoothstep<3>();
+    // Test a case that failed in Release builds when a static_cast was missing
+    CHECK_ITERABLE_APPROX(
+        smoothstep<2>(0., 2.,
+                      DataVector({-2., -1.5, -1., -0.5, -0.25, 0., 0.25, 0.5,
+                                  1., 1.5, 2.})),
+        DataVector({0., 0., 0., 0., 0., 0., 1.605224609375e-02, 1.03515625e-01,
+                    0.5, 8.96484375e-01, 1.}));
   }
 
   {


### PR DESCRIPTION
## Proposed changes

Weighting functions for the additive Schwarz solver, used to combine solutions of overlapping element-centered subdomains.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
