### PR TITLE
Fix missed Tag::name usage

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "DataStructures/DataBox/TagName.hpp"
 #include "IO/Observer/Helpers.hpp"
 #include "IO/Observer/ObservationId.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
@@ -58,7 +59,7 @@ struct reduction_data_type<tmpl::list<Ts...>> {
 
 template <typename... Ts>
 auto make_legend(tmpl::list<Ts...> /* meta */) {
-  return std::vector<std::string>{"Time", Ts::name()...};
+  return std::vector<std::string>{"Time", db::tag_name<Ts>()...};
 }
 
 template <typename DbTags, typename... Ts>


### PR DESCRIPTION
#  Proposed changes

This enables using compute tags in the interpolator again.


Fixes a bug @MarloMo encountered and needs resolved in order to continue work more easily.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
