### PR TITLE
Simplify Subitems

### DIFF
--- a/src/DataStructures/DataBox/CMakeLists.txt
+++ b/src/DataStructures/DataBox/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_headers(
   Deferred.hpp
   PrefixHelpers.hpp
   Prefixes.hpp
+  Subitems.hpp
   Tag.hpp
   TagName.hpp
   TagTraits.hpp

--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -122,8 +122,7 @@ class DataBoxLeaf {
 
 template <typename Element>
 struct extract_expand_simple_subitems {
-  using type =
-      tmpl::push_front<typename Subitems<NoSuchType, Element>::type, Element>;
+  using type = tmpl::push_front<typename Subitems<Element>::type, Element>;
 };
 
 // Given a typelist of items List, returns a new typelist containing
@@ -145,14 +144,14 @@ constexpr int select_expand_subitems_impl(const size_t pack_size) noexcept {
 template <int FastTrackSelector, template <typename...> class F>
 struct expand_subitems_impl;
 
-template <typename FulltagList, typename TagList, typename Element>
-using expand_subitems_impl_helper = tmpl::append<
-    tmpl::push_back<TagList, Element>,
-    typename Subitems<tmpl::push_back<TagList, Element>, Element>::type>;
+template <typename TagList, typename Element>
+using expand_subitems_impl_helper =
+    tmpl::append<tmpl::push_back<TagList, Element>,
+                 typename Subitems<Element>::type>;
 
 template <template <typename...> class F>
 struct expand_subitems_impl<0, F> {
-  template <typename FullTagList, typename TagList>
+  template <typename TagList>
   using f = TagList;
 };
 
@@ -161,39 +160,29 @@ struct expand_subitems_impl<1, F> {
   // The compile time here could be improved by having Subitems have a nested
   // type alias that generates the list currently retrieved by `::type` on to
   // the next call of `expand_subitems_impl`
-  template <typename FullTagList, typename TagList, typename Element,
-            typename... Rest>
+  template <typename TagList, typename Element, typename... Rest>
   using f = typename expand_subitems_impl<
       select_expand_subitems_impl(sizeof...(Rest)),
-      F>::template f<FullTagList, F<FullTagList, TagList, Element>, Rest...>;
+      F>::template f<F<TagList, Element>, Rest...>;
 };
 
 template <template <typename...> class F>
 struct expand_subitems_impl<2, F> {
-  template <typename FullTagList, typename TagList, typename Element0,
-            typename Element1, typename... Rest>
+  template <typename TagList, typename Element0, typename Element1,
+            typename... Rest>
   using f = typename expand_subitems_impl<
-      select_expand_subitems_impl(sizeof...(Rest)), F>::
-      template f<FullTagList,
-                 F<FullTagList, F<FullTagList, TagList, Element0>, Element1>,
-                 Rest...>;
+      select_expand_subitems_impl(sizeof...(Rest)),
+      F>::template f<F<F<TagList, Element0>, Element1>, Rest...>;
 };
 
 template <template <typename...> class F>
 struct expand_subitems_impl<3, F> {
-  template <typename FullTagList, typename TagList, typename Element0,
-            typename Element1, typename Element2, typename Element3,
-            typename... Rest>
+  template <typename TagList, typename Element0, typename Element1,
+            typename Element2, typename Element3, typename... Rest>
   using f = typename expand_subitems_impl<
       select_expand_subitems_impl(sizeof...(Rest)), F>::
-      template f<
-          FullTagList,
-          F<FullTagList,
-            F<FullTagList,
-              F<FullTagList, F<FullTagList, TagList, Element0>, Element1>,
-              Element2>,
-            Element3>,
-          Rest...>;
+      template f<F<F<F<F<TagList, Element0>, Element1>, Element2>, Element3>,
+                 Rest...>;
 };
 
 /*!
@@ -217,8 +206,7 @@ struct expand_subitems<tmpl::list<ComputeTags...>, true> {
   using f = typename detail::expand_subitems_impl<select_expand_subitems_impl(
                                                       sizeof...(ComputeTags)),
                                                   expand_subitems_impl_helper>::
-      template f<tmpl::list<>, expand_simple_subitems<SimpleTagsList>,
-                 ComputeTags...>;
+      template f<expand_simple_subitems<SimpleTagsList>, ComputeTags...>;
 };
 
 template <class... ComputeTags>
@@ -226,17 +214,16 @@ struct expand_subitems<tmpl::list<ComputeTags...>, false> {
   template <typename SimpleTagsList>
   using f = typename detail::expand_subitems_impl<
       select_expand_subitems_impl(sizeof...(ComputeTags)),
-      expand_subitems_impl_helper>::template f<tmpl::list<>, SimpleTagsList,
-                                               ComputeTags...>;
+      expand_subitems_impl_helper>::template f<SimpleTagsList, ComputeTags...>;
 };
 
 // The compile time here could be improved by having Subitems have a nested
 // type alias that generates the list currently retrieved by `::type` on to
 // the next call of `expand_subitems_from_list_impl`
-template <typename FullTagList, typename BuildingTagList, typename Element>
+template <typename BuildingTagList, typename Element>
 using expand_subitems_from_list_impl_helper =
     tmpl::append<tmpl::push_back<BuildingTagList, Element>,
-                 typename Subitems<FullTagList, Element>::type>;
+                 typename Subitems<Element>::type>;
 
 template <typename ComputeTagsList>
 struct expanded_list_from_full_list_impl;
@@ -244,11 +231,10 @@ struct expanded_list_from_full_list_impl;
 template <typename... ComputeTags>
 struct expanded_list_from_full_list_impl<tmpl::list<ComputeTags...>> {
   template <typename FullTagList>
-  using f =
-      typename expand_subitems_impl<select_expand_subitems_impl(
-                                        sizeof...(ComputeTags)),
-                                    expand_subitems_from_list_impl_helper>::
-          template f<FullTagList, tmpl::list<>, ComputeTags...>;
+  using f = typename expand_subitems_impl<
+      select_expand_subitems_impl(sizeof...(ComputeTags)),
+      expand_subitems_from_list_impl_helper>::template f<tmpl::list<>,
+                                                         ComputeTags...>;
 };
 
 template <>
@@ -284,9 +270,9 @@ template <typename SimpleTagsList, typename ComputeTagsList,
 using expand_subitems = typename detail::expand_subitems<
     ComputeTagsList, ExpandSimpleTags>::template f<SimpleTagsList>;
 
-template <typename TagList, typename Tag>
-using has_subitems = tmpl::not_<
-    std::is_same<typename Subitems<TagList, Tag>::type, tmpl::list<>>>;
+template <typename Tag>
+using has_subitems =
+    tmpl::not_<std::is_same<typename Subitems<Tag>::type, tmpl::list<>>>;
 
 template <typename ComputeTag, typename ArgumentTag,
           typename FoundComputeItemInBox>
@@ -325,7 +311,7 @@ struct create_dependency_graph {
   // These edges record that the values of the subitems of a compute
   // item depend on the value of the compute item itself.
   using subitem_reverse_edges =
-      tmpl::transform<typename Subitems<TagList, ComputeTag>::type,
+      tmpl::transform<typename Subitems<ComputeTag>::type,
                       tmpl::bind<tmpl::edge, tmpl::pin<ComputeTag>, tmpl::_1>>;
 
   using type = tmpl::append<compute_tag_argument_edges, subitem_reverse_edges>;
@@ -393,17 +379,17 @@ class DataBox<tmpl::list<Tags...>>
 
   /// A list of the simple items that have subitems, without expanding the
   /// subitems out
-  using simple_subitems_tags = tmpl::filter<
-      simple_item_tags,
-      tmpl::bind<DataBox_detail::has_subitems, tmpl::pin<tags_list>, tmpl::_1>>;
+  using simple_subitems_tags =
+      tmpl::filter<simple_item_tags,
+                   tmpl::bind<DataBox_detail::has_subitems, tmpl::_1>>;
 
   /// A list of the expanded simple subitems, not including the main Subitem
   /// tags themselves.
   ///
   /// Specifically, if there is a `Variables<Tag0, Tag1>`, then this list would
   /// contain `Tag0, Tag1`.
-  using simple_only_expanded_subitems_tags = tmpl::flatten<tmpl::transform<
-      simple_subitems_tags, db::Subitems<tmpl::pin<tags_list>, tmpl::_1>>>;
+  using simple_only_expanded_subitems_tags = tmpl::flatten<
+      tmpl::transform<simple_subitems_tags, db::Subitems<tmpl::_1>>>;
 
   /// \cond HIDDEN_SYMBOLS
   /*!
@@ -668,8 +654,8 @@ DataBox<tmpl::list<Tags...>>::add_sub_compute_item_tags_to_box(
     std::false_type /*has_return_type_member*/) noexcept {
   const auto helper = [lazy_function = get_deferred<ParentTag>()](
                           auto tag) noexcept->decltype(auto) {
-    return Subitems<tmpl::list<Tags...>, ParentTag>::
-        template create_compute_item<decltype(tag)>(lazy_function.get());
+    return Subitems<ParentTag>::template create_compute_item<decltype(tag)>(
+        lazy_function.get());
   };
   EXPAND_PACK_LEFT_TO_RIGHT(
       (get_deferred<Subtags>() =
@@ -685,8 +671,8 @@ DataBox<tmpl::list<Tags...>>::add_sub_compute_item_tags_to_box(
     std::true_type /*has_return_type_member*/) noexcept {
   const auto helper = [lazy_function = get_deferred<ParentTag>()](
       const auto result, auto tag) noexcept {
-    Subitems<tmpl::list<Tags...>, ParentTag>::template create_compute_item<
-        decltype(tag)>(result, lazy_function.get());
+    Subitems<ParentTag>::template create_compute_item<decltype(tag)>(
+        result, lazy_function.get());
   };
   EXPAND_PACK_LEFT_TO_RIGHT(
       (get_deferred<Subtags>() = make_deferred_for_subitem<
@@ -748,9 +734,8 @@ db::DataBox<tmpl::list<Tags...>>::add_compute_item_to_box() noexcept {
                       tmpl::bind<DataBox_detail::first_matching_tag,
                                  tmpl::pin<tmpl::list<Tags...>>, tmpl::_1>>{});
   add_sub_compute_item_tags_to_box<Tag>(
-      typename Subitems<tmpl::list<Tags...>, Tag>::type{},
-      typename has_return_type_member<
-          Subitems<tmpl::list<Tags...>, Tag>>::type{});
+      typename Subitems<Tag>::type{},
+      typename has_return_type_member<Subitems<Tag>>::type{});
 }
 // End adding compute items
 
@@ -765,7 +750,7 @@ db::DataBox<tmpl::list<Tags...>>::add_subitem_tags_to_box(
     using tag = decltype(tag_v);
     using ItemType = DataBox_detail::storage_type<tag, tmpl::list<Tags...>>;
     get_deferred<tag>() = Deferred<ItemType>(ItemType{});
-    Subitems<tmpl::list<Tags...>, ParentTag>::template create_item<tag>(
+    Subitems<ParentTag>::template create_item<tag>(
         make_not_null(&get_deferred<ParentTag>().mutate()),
         make_not_null(&get_deferred<tag>().mutate()));
   };
@@ -787,8 +772,7 @@ db::DataBox<tmpl::list<Tags...>>::add_item_to_box(
   get_deferred<Tag>() =
       Deferred<DataBox_detail::storage_type<Tag, tmpl::list<Tags...>>>(
           std::forward<ArgType>(std::get<ArgsIndex>(tupull)));
-  add_subitem_tags_to_box<Tag>(
-      typename Subitems<tmpl::list<Tags...>, Tag>::type{});
+  add_subitem_tags_to_box<Tag>(typename Subitems<Tag>::type{});
   return cpp17::void_type{};  // must return in constexpr function
 }
 // End adding simple items
@@ -921,8 +905,7 @@ void DataBox<tmpl::list<Tags...>>::pup_impl(
       get_deferred<tag>() =
           Deferred<DataBox_detail::storage_type<tag, tmpl::list<Tags...>>>(
               std::move(t));
-      add_subitem_tags_to_box<tag>(
-          typename Subitems<tmpl::list<Tags...>, tag>::type{});
+      add_subitem_tags_to_box<tag>(typename Subitems<tag>::type{});
     } else {
       p | get_deferred<tag>().mutate();
     }
@@ -953,7 +936,7 @@ DataBox<tmpl::list<Tags...>>::add_reset_compute_item_to_box(
     tmpl::list<ComputeItemArgumentsTags...> /*meta*/) noexcept {
   get_deferred<ComputeItem>().reset();
   mutate_subitem_tags_in_box<ComputeItem>(
-      typename Subitems<tmpl::list<Tags...>, ComputeItem>::type{});
+      typename Subitems<ComputeItem>::type{});
 }
 
 template <typename... Tags>
@@ -987,7 +970,7 @@ db::DataBox<tmpl::list<Tags...>>::mutate_subitem_tags_in_box(
     [this](auto tag_v, std::false_type /*is_compute_tag*/) noexcept {
       (void)this;  // Compiler bug warns about unused this capture
       using tag = decltype(tag_v);
-      Subitems<tmpl::list<Tags...>, ParentTag>::template create_item<tag>(
+      Subitems<ParentTag>::template create_item<tag>(
           make_not_null(&get_deferred<ParentTag>().mutate()),
           make_not_null(&get_deferred<tag>().mutate()));
     });
@@ -1050,12 +1033,11 @@ void mutate(const gsl::not_null<DataBox<TagList>*> box, Invokable&& invokable,
   // being mutated. Then, remove any tags that would be passed
   // multiple times.
   using extra_mutated_tags = tmpl::list_difference<
-      tmpl::filter<
-          TagList,
-          tmpl::bind<
-              tmpl::found, Subitems<tmpl::pin<TagList>, tmpl::_1>,
-              tmpl::pin<tmpl::bind<tmpl::list_contains,
-                                   tmpl::pin<mutate_tags_list>, tmpl::_1>>>>,
+      tmpl::filter<TagList,
+                   tmpl::bind<tmpl::found, Subitems<tmpl::_1>,
+                              tmpl::pin<tmpl::bind<tmpl::list_contains,
+                                                   tmpl::pin<mutate_tags_list>,
+                                                   tmpl::_1>>>>,
       mutate_tags_list>;
   // Extract the subtags inside the MutateTags and reset compute items
   // depending on those too.
@@ -1072,7 +1054,7 @@ void mutate(const gsl::not_null<DataBox<TagList>*> box, Invokable&& invokable,
 
   EXPAND_PACK_LEFT_TO_RIGHT(
       box->template mutate_subitem_tags_in_box<MutateTags>(
-          typename Subitems<TagList, MutateTags>::type{}));
+          typename Subitems<MutateTags>::type{}));
   box->template reset_compute_items_after_mutate(
       first_compute_items_to_reset{});
 
@@ -1288,11 +1270,10 @@ SPECTRE_ALWAYS_INLINE constexpr auto create_from(Box&& box,
   // Check that we're not removing a subitem itself, should remove the parent.
   using compute_subitems_tags =
       tmpl::filter<typename std::decay_t<Box>::compute_item_tags,
-                   tmpl::bind<DataBox_detail::has_subitems,
-                              tmpl::pin<old_box_tags>, tmpl::_1>>;
+                   tmpl::bind<DataBox_detail::has_subitems, tmpl::_1>>;
 
-  using compute_only_expand_subitems_tags = tmpl::flatten<tmpl::transform<
-      compute_subitems_tags, db::Subitems<tmpl::pin<old_box_tags>, tmpl::_1>>>;
+  using compute_only_expand_subitems_tags = tmpl::flatten<
+      tmpl::transform<compute_subitems_tags, db::Subitems<tmpl::_1>>>;
   using all_only_subitems_tags = tmpl::append<
       typename std::decay_t<Box>::simple_only_expanded_subitems_tags,
       compute_only_expand_subitems_tags>;

--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -17,6 +17,7 @@
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/Deferred.hpp"
+#include "DataStructures/DataBox/Subitems.hpp"
 #include "DataStructures/DataBox/TagName.hpp"
 #include "DataStructures/DataBox/TagTraits.hpp"
 #include "ErrorHandling/Error.hpp"

--- a/src/DataStructures/DataBox/DataBoxTag.hpp
+++ b/src/DataStructures/DataBox/DataBoxTag.hpp
@@ -11,6 +11,7 @@
 #include <ostream>
 #include <string>
 
+#include "DataStructures/DataBox/Subitems.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataBox/TagTraits.hpp"
 #include "DataStructures/VariablesTag.hpp"
@@ -277,31 +278,6 @@ struct compute_item_type<tmpl::list<Args...>> {
       Tag::function(std::declval<const_item_type<Args, TagList>>()...));
 };
 }  // namespace DataBox_detail
-
-/// \ingroup DataBoxGroup
-/// Struct that can be specialized to allow DataBox items to have
-/// subitems.  Specializations must define:
-/// * `using type = tmpl::list<...>` listing the subtags of `Tag`
-/// * A static member function to initialize a subitem of a simple
-///   item:
-///   ```
-///   template <typename Subtag>
-///   static void create_item(
-///       const gsl::not_null<item_type<Tag>*> parent_value,
-///       const gsl::not_null<item_type<Subtag>*> sub_value) noexcept;
-///   ```
-///   Mutating the subitems must also modify the main item.
-/// * A static member function evaluating a subitem of a compute
-///   item:
-///   ```
-///   template <typename Subtag>
-///   static item_type<Subtag> create_compute_item(
-///       const item_type<Tag>& parent_value) noexcept;
-///   ```
-template <typename TagList, typename Tag, typename = std::nullptr_t>
-struct Subitems {
-  using type = tmpl::list<>;
-};
 
 /// \ingroup DataBoxGroup
 /// Split a tag into its subitems.  `Tag` cannot be a base tag.

--- a/src/DataStructures/DataBox/DataBoxTag.hpp
+++ b/src/DataStructures/DataBox/DataBoxTag.hpp
@@ -281,10 +281,10 @@ struct compute_item_type<tmpl::list<Args...>> {
 
 /// \ingroup DataBoxGroup
 /// Split a tag into its subitems.  `Tag` cannot be a base tag.
-template <typename Tag, typename TagList = NoSuchType>
-using split_tag = tmpl::conditional_t<
-    tmpl::size<typename Subitems<TagList, Tag>::type>::value == 0,
-    tmpl::list<Tag>, typename Subitems<TagList, Tag>::type>;
+template <typename Tag>
+using split_tag =
+    tmpl::conditional_t<tmpl::size<typename Subitems<Tag>::type>::value == 0,
+                        tmpl::list<Tag>, typename Subitems<Tag>::type>;
 
 /// \ingroup DataBoxTagsGroup
 /// \brief `true_type` if the prefix tag wraps the specified tag, `false_type`

--- a/src/DataStructures/DataBox/Subitems.hpp
+++ b/src/DataStructures/DataBox/Subitems.hpp
@@ -1,0 +1,35 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "Utilities/TMPL.hpp"
+
+namespace db {
+/// \ingroup DataBoxGroup
+/// Struct that can be specialized to allow DataBox items to have
+/// subitems.  Specializations must define:
+/// * `using type = tmpl::list<...>` listing the subtags of `Tag`
+/// * A static member function to initialize a subitem of a simple
+///   item:
+///   ```
+///   template <typename Subtag>
+///   static void create_item(
+///       const gsl::not_null<item_type<Tag>*> parent_value,
+///       const gsl::not_null<item_type<Subtag>*> sub_value) noexcept;
+///   ```
+///   Mutating the subitems must also modify the main item.
+/// * A static member function evaluating a subitem of a compute
+///   item:
+///   ```
+///   template <typename Subtag>
+///   static item_type<Subtag> create_compute_item(
+///       const item_type<Tag>& parent_value) noexcept;
+///   ```
+template <typename TagList, typename Tag, typename = std::nullptr_t>
+struct Subitems {
+  using type = tmpl::list<>;
+};
+}  // namespace db

--- a/src/DataStructures/DataBox/Subitems.hpp
+++ b/src/DataStructures/DataBox/Subitems.hpp
@@ -28,7 +28,7 @@ namespace db {
 ///   static item_type<Subtag> create_compute_item(
 ///       const item_type<Tag>& parent_value) noexcept;
 ///   ```
-template <typename TagList, typename Tag, typename = std::nullptr_t>
+template <typename Tag, typename = std::nullptr_t>
 struct Subitems {
   using type = tmpl::list<>;
 };

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -934,10 +934,8 @@ struct MakeWithValueImpl<Variables<TagListOut>, Variables<TagListIn>> {
 }  // namespace MakeWithValueImpls
 
 namespace db {
-template <typename TagList, typename Tag>
-struct Subitems<
-    TagList, Tag,
-    Requires<tt::is_a_v<Variables, const_item_type<Tag, TagList>>>> {
+template <typename Tag>
+struct Subitems<Tag, Requires<tt::is_a_v<Variables, typename Tag::type>>> {
   using type = typename const_item_type<Tag>::tags_list;
 
   template <typename Subtag, typename LocalTag = Tag>

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -16,6 +16,7 @@
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Subitems.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataBox/TagName.hpp"
 #include "DataStructures/DataVector.hpp"

--- a/src/Domain/InterfaceComputeTags.hpp
+++ b/src/Domain/InterfaceComputeTags.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Subitems.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataBox/TagName.hpp"
 #include "DataStructures/DataBox/TagTraits.hpp"

--- a/src/Domain/InterfaceComputeTags.hpp
+++ b/src/Domain/InterfaceComputeTags.hpp
@@ -298,15 +298,13 @@ struct BoundaryCoordinates : db::ComputeTag,
 }  // namespace domain
 
 namespace db {
-template <typename TagList, typename DirectionsTag, typename VariablesTag>
-struct Subitems<
-    TagList, domain::Tags::InterfaceCompute<DirectionsTag, VariablesTag>,
-    Requires<tt::is_a_v<Variables, const_item_type<VariablesTag, TagList>>>>
-    : detail::InterfaceSubitemsImpl<TagList, DirectionsTag, VariablesTag> {};
+template <typename DirectionsTag, typename VariablesTag>
+struct Subitems<domain::Tags::InterfaceCompute<DirectionsTag, VariablesTag>,
+                Requires<tt::is_a_v<Variables, typename VariablesTag::type>>>
+    : detail::InterfaceSubitemsImpl<DirectionsTag, VariablesTag> {};
 
-template <typename TagList, typename DirectionsTag, typename VariablesTag>
-struct Subitems<
-    TagList, domain::Tags::Slice<DirectionsTag, VariablesTag>,
-    Requires<tt::is_a_v<Variables, const_item_type<VariablesTag, TagList>>>>
-    : detail::InterfaceSubitemsImpl<TagList, DirectionsTag, VariablesTag> {};
+template <typename DirectionsTag, typename VariablesTag>
+struct Subitems<domain::Tags::Slice<DirectionsTag, VariablesTag>,
+                Requires<tt::is_a_v<Variables, typename VariablesTag::type>>>
+    : detail::InterfaceSubitemsImpl<DirectionsTag, VariablesTag> {};
 }  // namespace db

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -353,7 +353,7 @@ struct Direction : db::SimpleTag {
 
 namespace db {
 namespace detail {
-template <typename TagList, typename DirectionsTag, typename VariablesTag>
+template <typename DirectionsTag, typename VariablesTag>
 struct InterfaceSubitemsImpl {
   using type = tmpl::transform<
       typename const_item_type<VariablesTag>::tags_list,
@@ -409,10 +409,9 @@ struct InterfaceSubitemsImpl {
 };
 }  // namespace detail
 
-template <typename TagList, typename DirectionsTag, typename VariablesTag>
-struct Subitems<
-    TagList, domain::Tags::Interface<DirectionsTag, VariablesTag>,
-    Requires<tt::is_a_v<Variables, item_type<VariablesTag, TagList>>>>
-    : detail::InterfaceSubitemsImpl<TagList, DirectionsTag, VariablesTag> {};
+template <typename DirectionsTag, typename VariablesTag>
+struct Subitems<domain::Tags::Interface<DirectionsTag, VariablesTag>,
+                Requires<tt::is_a_v<Variables, typename VariablesTag::type>>>
+    : detail::InterfaceSubitemsImpl<DirectionsTag, VariablesTag> {};
 
 }  // namespace db

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Subitems.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataBox/TagName.hpp"
 #include "DataStructures/Tensor/EagerMath/Determinant.hpp"

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/InitializeDampedHarmonic.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/InitializeDampedHarmonic.hpp
@@ -9,6 +9,7 @@
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/VariablesTag.hpp"
 #include "Domain/CoordinateMaps/Tags.hpp"
 #include "Domain/FunctionsOfTime/Tags.hpp"
 #include "Domain/Tags.hpp"
@@ -154,7 +155,13 @@ struct InitializeDampedHarmonic {
   };
 
   template <typename Frame>
-  struct DampedHarmonicRollonCompute : db::ComputeTag {
+  struct DampedHarmonicRollonCompute
+      : db::ComputeTag,
+        ::Tags::Variables<tmpl::list<Tags::GaugeH<Dim, Frame>,
+                                     Tags::SpacetimeDerivGaugeH<Dim, Frame>>> {
+    using base =
+        ::Tags::Variables<tmpl::list<Tags::GaugeH<Dim, Frame>,
+                                     Tags::SpacetimeDerivGaugeH<Dim, Frame>>>;
     static std::string name() noexcept { return "DampedHarmonicRollonCompute"; }
     using argument_tags =
         tmpl::list<Tags::InitialGaugeH<Dim, Frame>,
@@ -191,7 +198,13 @@ struct InitializeDampedHarmonic {
   };
 
   template <typename Frame>
-  struct DampedHarmonicCompute : db::ComputeTag {
+  struct DampedHarmonicCompute
+      : db::ComputeTag,
+        ::Tags::Variables<tmpl::list<Tags::GaugeH<Dim, Frame>,
+                                     Tags::SpacetimeDerivGaugeH<Dim, Frame>>> {
+    using base =
+        ::Tags::Variables<tmpl::list<Tags::GaugeH<Dim, Frame>,
+                                     Tags::SpacetimeDerivGaugeH<Dim, Frame>>>;
     static std::string name() noexcept { return "DampedHarmonicCompute"; }
     using argument_tags =
         tmpl::list<::gr::Tags::Lapse<DataVector>,

--- a/tests/Unit/DataStructures/DataBox/Test_BaseTags.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_BaseTags.cpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Subitems.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"

--- a/tests/Unit/DataStructures/DataBox/Test_BaseTags.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_BaseTags.cpp
@@ -287,8 +287,8 @@ struct MultiplyByTwoCompute : MultiplyByTwo<N0, N1>, db::ComputeTag {
 }  // namespace
 
 namespace db {
-template <typename TagList, size_t N>
-struct Subitems<TagList, TestTags::Parent<N>> {
+template <size_t N>
+struct Subitems<TestTags::Parent<N>> {
   using type = tmpl::list<TestTags::First<N>, TestTags::Second<N>>;
   using tag = TestTags::Parent<N>;
 
@@ -311,12 +311,12 @@ struct Subitems<TagList, TestTags::Parent<N>> {
     // DataBox will only allow access to a const version of the result
     // and we ensure in the definition of Boxed that that will not
     // allow modification of the original item.
-    return const_cast<item_type<Subtag, TagList>&>(  // NOLINT
+    return const_cast<typename Subtag::type&>(  // NOLINT
         std::get<Subtag::index>(parent_value));
   }
 };
-template <typename TagList, size_t N>
-struct Subitems<TagList, TestTags::ParentCompute<N>> {
+template <size_t N>
+struct Subitems<TestTags::ParentCompute<N>> {
   using type = tmpl::list<TestTags::First<N>, TestTags::Second<N>>;
   using tag = TestTags::ParentCompute<N>;
 
@@ -339,7 +339,7 @@ struct Subitems<TagList, TestTags::ParentCompute<N>> {
     // DataBox will only allow access to a const version of the result
     // and we ensure in the definition of Boxed that that will not
     // allow modification of the original item.
-    return const_cast<item_type<Subtag, TagList>&>(  // NOLINT
+    return const_cast<typename Subtag::type&>(  // NOLINT
         std::get<Subtag::index>(parent_value));
   }
 };

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -16,6 +16,7 @@
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/DataOnSlice.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Subitems.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataBox/TagName.hpp"
 #include "DataStructures/DataVector.hpp"

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -1883,8 +1883,8 @@ struct Second : db::SimpleTag {
 }  // namespace
 
 namespace db {
-template <typename TagList, size_t N>
-struct Subitems<TagList, Parent<N>> {
+template <size_t N>
+struct Subitems<Parent<N>> {
   using type = tmpl::list<First<N>, Second<N>>;
   using tag = Parent<N>;
 
@@ -1909,8 +1909,8 @@ struct Subitems<TagList, Parent<N>> {
         std::get<Subtag::index>(parent_value));
   }
 };
-template <typename TagList, size_t N>
-struct Subitems<TagList, ParentCompute<N>> {
+template <size_t N>
+struct Subitems<ParentCompute<N>> {
   using type = tmpl::list<First<N>, Second<N>>;
   using tag = ParentCompute<N>;
 

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -74,8 +74,8 @@ void test_connectivity() {
   constexpr double radius_enveloping_sphere = 32.4;
 
   // Misc.:
-  constexpr size_t refinement = 2;
-  constexpr size_t grid_points = 6;
+  constexpr size_t refinement = 1;
+  constexpr size_t grid_points = 3;
   constexpr bool use_projective_map = true;
 
   // Options for outer sphere
@@ -149,8 +149,8 @@ void test_bbh_time_dependent_factory() {
           "    ExciseInteriorB: true\n"
           "    RadiusOuterCube: 22.0\n"
           "    RadiusOuterSphere: 25.0\n"
-          "    InitialRefinement: 2\n"
-          "    InitialGridPoints: 6\n"
+          "    InitialRefinement: 1\n"
+          "    InitialGridPoints: 3\n"
           "    UseEquiangularMap: true\n"
           "    TimeDependence:\n"
           "      UniformTranslation:\n"
@@ -221,8 +221,8 @@ void test_bbh_equiangular_factory() {
           "    ExciseInteriorB: true\n"
           "    RadiusOuterCube: 22.0\n"
           "    RadiusOuterSphere: 25.0\n"
-          "    InitialRefinement: 2\n"
-          "    InitialGridPoints: 6\n"
+          "    InitialRefinement: 1\n"
+          "    InitialGridPoints: 3\n"
           "    UseEquiangularMap: true\n");
   test_binary_compact_object_construction(
       dynamic_cast<const domain::creators::BinaryCompactObject&>(
@@ -243,8 +243,8 @@ void test_bbh_2_outer_radial_refinements_linear_map_factory() {
           "    ExciseInteriorB: true\n"
           "    RadiusOuterCube: 22.0\n"
           "    RadiusOuterSphere: 25.0\n"
-          "    InitialRefinement: 2\n"
-          "    InitialGridPoints: 6\n"
+          "    InitialRefinement: 1\n"
+          "    InitialGridPoints: 3\n"
           "    AdditionToObjectBRadialRefinementLevel: 2\n"
           "    UseEquiangularMap: true\n"
           "    AdditionToOuterLayerRadialRefinementLevel: 2\n");
@@ -267,8 +267,8 @@ void test_bbh_3_outer_radial_refinements_log_map_factory() {
           "    ExciseInteriorB: true\n"
           "    RadiusOuterCube: 22.0\n"
           "    RadiusOuterSphere: 25.0\n"
-          "    InitialRefinement: 2\n"
-          "    InitialGridPoints: 6\n"
+          "    InitialRefinement: 1\n"
+          "    InitialGridPoints: 3\n"
           "    UseEquiangularMap: true\n"
           "    UseLogarithmicMapObjectA: true\n"
           "    AdditionToObjectARadialRefinementLevel: 3\n"
@@ -293,8 +293,8 @@ void test_bbh_equidistant_factory() {
           "    ExciseInteriorB: true\n"
           "    RadiusOuterCube: 22.0\n"
           "    RadiusOuterSphere: 25.0\n"
-          "    InitialRefinement: 2\n"
-          "    InitialGridPoints: 6\n"
+          "    InitialRefinement: 1\n"
+          "    InitialGridPoints: 3\n"
           "    UseEquiangularMap: false\n");
   test_binary_compact_object_construction(
       dynamic_cast<const domain::creators::BinaryCompactObject&>(
@@ -315,8 +315,8 @@ void test_bns_equiangular_factory() {
           "    ExciseInteriorB: false\n"
           "    RadiusOuterCube: 22.0\n"
           "    RadiusOuterSphere: 25.0\n"
-          "    InitialRefinement: 2\n"
-          "    InitialGridPoints: 6\n"
+          "    InitialRefinement: 1\n"
+          "    InitialGridPoints: 3\n"
           "    UseEquiangularMap: true\n");
   test_binary_compact_object_construction(
       dynamic_cast<const domain::creators::BinaryCompactObject&>(
@@ -337,8 +337,8 @@ void test_bns_equidistant_factory() {
           "    ExciseInteriorB: false\n"
           "    RadiusOuterCube: 22.0\n"
           "    RadiusOuterSphere: 25.0\n"
-          "    InitialRefinement: 2\n"
-          "    InitialGridPoints: 6\n"
+          "    InitialRefinement: 1\n"
+          "    InitialGridPoints: 3\n"
           "    UseEquiangularMap: false\n");
   test_binary_compact_object_construction(
       dynamic_cast<const domain::creators::BinaryCompactObject&>(
@@ -359,8 +359,8 @@ void test_bhns_equiangular_factory() {
           "    ExciseInteriorB: false\n"
           "    RadiusOuterCube: 22.0\n"
           "    RadiusOuterSphere: 25.0\n"
-          "    InitialRefinement: 2\n"
-          "    InitialGridPoints: 6\n"
+          "    InitialRefinement: 1\n"
+          "    InitialGridPoints: 3\n"
           "    UseEquiangularMap: true\n");
   test_binary_compact_object_construction(
       dynamic_cast<const domain::creators::BinaryCompactObject&>(
@@ -381,8 +381,8 @@ void test_bhns_equidistant_factory() {
           "    ExciseInteriorB: false\n"
           "    RadiusOuterCube: 22.0\n"
           "    RadiusOuterSphere: 25.0\n"
-          "    InitialRefinement: 2\n"
-          "    InitialGridPoints: 6\n"
+          "    InitialRefinement: 1\n"
+          "    InitialGridPoints: 3\n"
           "    UseEquiangularMap: false\n");
   test_binary_compact_object_construction(
       dynamic_cast<const domain::creators::BinaryCompactObject&>(
@@ -403,8 +403,8 @@ void test_nsbh_equiangular_factory() {
           "    ExciseInteriorB: true\n"
           "    RadiusOuterCube: 22.0\n"
           "    RadiusOuterSphere: 25.0\n"
-          "    InitialRefinement: 2\n"
-          "    InitialGridPoints: 6\n"
+          "    InitialRefinement: 1\n"
+          "    InitialGridPoints: 3\n"
           "    UseEquiangularMap: true\n");
   test_binary_compact_object_construction(
       dynamic_cast<const domain::creators::BinaryCompactObject&>(
@@ -425,8 +425,8 @@ void test_nsbh_equidistant_factory() {
           "    ExciseInteriorB: true\n"
           "    RadiusOuterCube: 22.0\n"
           "    RadiusOuterSphere: 25.0\n"
-          "    InitialRefinement: 2\n"
-          "    InitialGridPoints: 6\n"
+          "    InitialRefinement: 1\n"
+          "    InitialGridPoints: 3\n"
           "    UseEquiangularMap: false\n");
   test_binary_compact_object_construction(
       dynamic_cast<const domain::creators::BinaryCompactObject&>(
@@ -434,8 +434,6 @@ void test_nsbh_equidistant_factory() {
 }
 }  // namespace
 
-// Test times out sometimes, increase timeout to make it pass reliably.
-// [[TimeOut, 20]]
 SPECTRE_TEST_CASE("Unit.Domain.Creators.BinaryCompactObject.FactoryTests",
                   "[Domain][Unit]") {
   test_connectivity();


### PR DESCRIPTION
## Proposed changes

- Move Subitems to its own file which should eventually reduce coupling through includes
- Remove template parameter `TagsList` from Subitems as it is not needed
- Derived DampedHarmonic compute tags from `::Tags::Variables` as compute tags need to be derived from a simple tag
- Speed up Unit.Domain.Creators.BinaryCompactObject.FactoryTests which times out occasionally.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
