### PR TITLE
Move Domain/Structure tests

### DIFF
--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_DataStructures")
 
 set(LIBRARY_SOURCES
+  Test_ApplyMatrices.cpp
   Test_CachedTempBuffer.cpp
   Test_ComplexDataVector.cpp
   Test_ComplexDataVectorBinaryOperations.cpp
@@ -32,6 +33,7 @@ set(LIBRARY_SOURCES
   Test_StripeIterator.cpp
   Test_Tags.cpp
   Test_TempBuffer.cpp
+  Test_Transpose.cpp
   Test_Variables.cpp
   Test_VectorImpl.cpp
   Test_VectorImplTestHelper.cpp

--- a/tests/Unit/DataStructures/Test_ApplyMatrices.cpp
+++ b/tests/Unit/DataStructures/Test_ApplyMatrices.cpp
@@ -170,8 +170,8 @@ void test_interpolation() noexcept {
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.ApplyMatrices",
-                  "[NumericalAlgorithms][LinearOperators][Unit]") {
+SPECTRE_TEST_CASE("Unit.DataStructures.ApplyMatrices",
+                  "[DataStructures][Unit]") {
   {
     INFO("DataVector test");
     test_interpolation<ScalarTag, TensorTag, 1>();

--- a/tests/Unit/DataStructures/Test_Transpose.cpp
+++ b/tests/Unit/DataStructures/Test_Transpose.cpp
@@ -34,8 +34,7 @@ template <size_t Dim>
 using one_var = tmpl::list<Var1<Dim>>;
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.Transpose",
-                  "[NumericalAlgorithms][LinearOperators][Unit]") {
+SPECTRE_TEST_CASE("Unit.DataStructures.Transpose", "[DataStructures][Unit]") {
   // clang-format off
   /// [transpose_matrix]
   const DataVector matrix{ 1.,  2.,  3.,
@@ -113,7 +112,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.Transpose",
   Variables<one_var<2>> partial_vars(n_grid_pts, 0.);
   get<Var1<2>>(partial_vars) = get<Var1<2>>(variables);
   Variables<one_var<2>> partial_transpose(n_grid_pts, 0.);
-  const size_t partial_number_of_chunks = 2*number_of_chunks_vars / 3;
+  const size_t partial_number_of_chunks = 2 * number_of_chunks_vars / 3;
   transpose(make_not_null(&partial_transpose), variables, chunk_size_vars,
             partial_number_of_chunks);
   for (size_t i = 0; i < chunk_size_vars; ++i) {

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -27,7 +27,6 @@ set(LIBRARY_SOURCES
   Test_InterfaceHelpers.cpp
   Test_InterfaceItems.cpp
   Test_LogicalCoordinates.cpp
-  Test_Mesh.cpp
   Test_MinimumGridSpacing.cpp
   Test_Neighbors.cpp
   Test_OrientationMap.cpp

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -7,7 +7,6 @@ add_subdirectory(Python)
 set(LIBRARY "Test_Domain")
 
 set(LIBRARY_SOURCES
-  Structure/Test_Hypercube.cpp
   Test_Block.cpp
   Test_BlockAndElementLogicalCoordinates.cpp
   Test_BlockId.cpp
@@ -44,6 +43,7 @@ set(LIBRARY_SOURCES
 add_subdirectory(Amr)
 add_subdirectory(CoordinateMaps)
 add_subdirectory(Creators)
+add_subdirectory(Structure)
 
 add_test_library(
   ${LIBRARY}

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -9,30 +9,17 @@ set(LIBRARY "Test_Domain")
 set(LIBRARY_SOURCES
   Test_Block.cpp
   Test_BlockAndElementLogicalCoordinates.cpp
-  Test_BlockId.cpp
-  Test_BlockNeighbor.cpp
   Test_CoordinatesTag.cpp
   Test_CreateInitialElement.cpp
-  Test_CreateInitialMesh.cpp
-  Test_Direction.cpp
   Test_Domain.cpp
   Test_DomainHelpers.cpp
   Test_DomainTestHelpers.cpp
-  Test_Element.cpp
-  Test_ElementId.cpp
   Test_ElementMap.cpp
   Test_FaceNormal.cpp
-  Test_IndexToSliceAt.cpp
-  Test_InitialElementIds.cpp
   Test_InterfaceHelpers.cpp
   Test_InterfaceItems.cpp
   Test_LogicalCoordinates.cpp
   Test_MinimumGridSpacing.cpp
-  Test_Neighbors.cpp
-  Test_OrientationMap.cpp
-  Test_OrientationMapHelpers.cpp
-  Test_SegmentId.cpp
-  Test_Side.cpp
   Test_SizeOfElement.cpp
   Test_Tags.cpp
   Test_TagsCharacteristicSpeeds.cpp

--- a/tests/Unit/Domain/Structure/CMakeLists.txt
+++ b/tests/Unit/Domain/Structure/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_DomainStructure")
+
+set(LIBRARY_SOURCES
+  Test_Hypercube.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "Domain/Structure"
+  "${LIBRARY_SOURCES}"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DomainHelpers
+  DomainStructure
+  Utilities
+  )

--- a/tests/Unit/Domain/Structure/CMakeLists.txt
+++ b/tests/Unit/Domain/Structure/CMakeLists.txt
@@ -4,7 +4,20 @@
 set(LIBRARY "Test_DomainStructure")
 
 set(LIBRARY_SOURCES
+  Test_BlockId.cpp
+  Test_BlockNeighbor.cpp
+  Test_CreateInitialMesh.cpp
+  Test_Direction.cpp
+  Test_Element.cpp
+  Test_ElementId.cpp
   Test_Hypercube.cpp
+  Test_IndexToSliceAt.cpp
+  Test_InitialElementIds.cpp
+  Test_Neighbors.cpp
+  Test_OrientationMap.cpp
+  Test_OrientationMapHelpers.cpp
+  Test_SegmentId.cpp
+  Test_Side.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Domain/Structure/Test_BlockId.cpp
+++ b/tests/Unit/Domain/Structure/Test_BlockId.cpp
@@ -9,7 +9,7 @@
 #include "Framework/TestHelpers.hpp"
 #include "Utilities/GetOutput.hpp"
 
-SPECTRE_TEST_CASE("Unit.Domain.BlockId", "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.Structure.BlockId", "[Domain][Unit]") {
   domain::BlockId id{10};
   CHECK(id.get_index() == 10);
   CHECK(id == domain::BlockId{10});

--- a/tests/Unit/Domain/Structure/Test_BlockNeighbor.cpp
+++ b/tests/Unit/Domain/Structure/Test_BlockNeighbor.cpp
@@ -15,7 +15,7 @@
 #include "Framework/TestHelpers.hpp"
 #include "Utilities/GetOutput.hpp"
 
-SPECTRE_TEST_CASE("Unit.Domain.BlockNeighbor", "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.Structure.BlockNeighbor", "[Domain][Unit]") {
   // Test default constructor, only used for Charm++ serialization so no CHECK
   // calls:
   BlockNeighbor<3> test_block_neighbor;

--- a/tests/Unit/Domain/Structure/Test_CreateInitialMesh.cpp
+++ b/tests/Unit/Domain/Structure/Test_CreateInitialMesh.cpp
@@ -14,7 +14,7 @@
 
 namespace domain::Initialization {
 
-SPECTRE_TEST_CASE("Unit.Domain.CreateInitialMesh", "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.Structure.CreateInitialMesh", "[Domain][Unit]") {
   {
     INFO("Single element");
     CHECK(create_initial_mesh({{{3}}}, ElementId<1>{0}) ==

--- a/tests/Unit/Domain/Structure/Test_Direction.cpp
+++ b/tests/Unit/Domain/Structure/Test_Direction.cpp
@@ -210,7 +210,7 @@ void test_output() {
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.Direction", "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.Structure.Direction", "[Domain][Unit]") {
   test_construction_1d();
   test_construction_2d();
   test_construction_3d();
@@ -221,7 +221,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Direction", "[Domain][Unit]") {
 }
 
 // [[OutputRegex, dim = 1, for Direction<1> only dim = 0 is allowed.]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Direction.FirstDimension",
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Structure.Direction.FirstDimension",
                                "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
@@ -234,8 +234,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Direction", "[Domain][Unit]") {
 
 // [[OutputRegex, dim = 2, for Direction<2> only dim = 0 or dim = 1 are
 // allowed.]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Direction.SecondDimension",
-                               "[Domain][Unit]") {
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Domain.Structure.Direction.SecondDimension", "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   auto failed_direction = Direction<2>(2, Side::Upper);
@@ -247,7 +247,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Direction", "[Domain][Unit]") {
 
 // [[OutputRegex, dim = 3, for Direction<3> only dim = 0, dim = 1, or dim = 2
 // are allowed.]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Direction.ThirdDimension",
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Structure.Direction.ThirdDimension",
                                "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG

--- a/tests/Unit/Domain/Structure/Test_Element.cpp
+++ b/tests/Unit/Domain/Structure/Test_Element.cpp
@@ -100,7 +100,7 @@ void check_element_3d() {
 
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.Element", "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.Structure.Element", "[Domain][Unit]") {
   check_element_1d();
   check_element_2d();
   check_element_3d();

--- a/tests/Unit/Domain/Structure/Test_ElementId.cpp
+++ b/tests/Unit/Domain/Structure/Test_ElementId.cpp
@@ -152,7 +152,7 @@ void test_serialization() noexcept {
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.ElementId", "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.Structure.ElementId", "[Domain][Unit]") {
   test_element_id();
   test_placement_new_and_hashing();
   test_serialization<1>();
@@ -161,7 +161,7 @@ SPECTRE_TEST_CASE("Unit.Domain.ElementId", "[Domain][Unit]") {
 }
 
 // [[OutputRegex, Block id out of bounds]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.ElementId.BadBlockId",
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Structure.ElementId.BadBlockId",
                                "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG

--- a/tests/Unit/Domain/Structure/Test_Hypercube.cpp
+++ b/tests/Unit/Domain/Structure/Test_Hypercube.cpp
@@ -45,7 +45,7 @@ void test_hypercube_iterator(
         ++HypercubeElementsIterator<ElementDim, HypercubeDim>::begin());
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Hypercube", "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.Structure.Hypercube", "[Domain][Unit]") {
   {
     const Vertex<0> point{};
     CHECK(get_output(point) == "Vertex0D[(),()]");

--- a/tests/Unit/Domain/Structure/Test_IndexToSliceAt.cpp
+++ b/tests/Unit/Domain/Structure/Test_IndexToSliceAt.cpp
@@ -7,7 +7,7 @@
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/IndexToSliceAt.hpp"
 
-SPECTRE_TEST_CASE("Unit.Domain.IndexToSliceAt", "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.Structure.IndexToSliceAt", "[Domain][Unit]") {
   const Index<2> extents{{{2, 5}}};
   CHECK(index_to_slice_at(extents, Direction<2>::lower_xi()) == 0);
   CHECK(index_to_slice_at(extents, Direction<2>::upper_xi()) == 1);

--- a/tests/Unit/Domain/Structure/Test_InitialElementIds.cpp
+++ b/tests/Unit/Domain/Structure/Test_InitialElementIds.cpp
@@ -41,7 +41,7 @@ void test_initial_element_ids(
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.InitialElementIds", "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.Structure.InitialElementIds", "[Domain][Unit]") {
   const std::vector<std::array<size_t, 1>> initial_refinement_levels_1d{{{2}},
                                                                         {{3}}};
   const auto element_ids_1d = initial_element_ids(initial_refinement_levels_1d);

--- a/tests/Unit/Domain/Structure/Test_Neighbors.cpp
+++ b/tests/Unit/Domain/Structure/Test_Neighbors.cpp
@@ -17,7 +17,7 @@
 #include "Framework/TestHelpers.hpp"
 #include "Utilities/GetOutput.hpp"
 
-SPECTRE_TEST_CASE("Unit.Domain.Neighbors.1d", "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.Structure.Neighbors.1d", "[Domain][Unit]") {
   // Test default constructor, only used for Charm++ serialization so no CHECK
   // calls:
   Neighbors<1> test_neighbors;
@@ -57,7 +57,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Neighbors.1d", "[Domain][Unit]") {
   test_iterators(custom_neighbors);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Neighbors.2d", "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.Structure.Neighbors.2d", "[Domain][Unit]") {
   // Test default constructor, only used for Charm++ serialization so no CHECK
   // calls:
   Neighbors<2> test_neighbors;
@@ -99,7 +99,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Neighbors.2d", "[Domain][Unit]") {
   test_move_semantics(std::move(custom_neighbors), custom_copy);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Neighbors.3d", "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.Structure.Neighbors.3d", "[Domain][Unit]") {
   // Test default constructor, only used for Charm++ serialization so no CHECK
   // calls:
   Neighbors<3> test_neighbors;

--- a/tests/Unit/Domain/Structure/Test_OrientationMap.cpp
+++ b/tests/Unit/Domain/Structure/Test_OrientationMap.cpp
@@ -314,14 +314,14 @@ void test_3d() {
 
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.OrientationMap", "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.Structure.OrientationMap", "[Domain][Unit]") {
   test_1d();
   test_2d();
   test_3d();
 }
 
 // [[OutputRegex, This OrientationMap fails to map Directions one-to-one.]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.OrientationMap.Bijective",
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Structure.OrientationMap.Bijective",
                                "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
@@ -334,8 +334,8 @@ SPECTRE_TEST_CASE("Unit.Domain.OrientationMap", "[Domain][Unit]") {
 }
 
 // [[OutputRegex, This OrientationMap fails to map Directions one-to-one.]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.OrientationMap.BijectiveHost",
-                               "[Domain][Unit]") {
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Domain.Structure.OrientationMap.BijectiveHost", "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   auto failed_orientationmap = OrientationMap<2>{
@@ -351,8 +351,9 @@ SPECTRE_TEST_CASE("Unit.Domain.OrientationMap", "[Domain][Unit]") {
 }
 
 // [[OutputRegex, This OrientationMap fails to map Directions one-to-one.]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.OrientationMap.BijectiveNeighbor",
-                               "[Domain][Unit]") {
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Domain.Structure.OrientationMap.BijectiveNeighbor",
+    "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   auto failed_orientationmap = OrientationMap<3>{
@@ -369,7 +370,7 @@ SPECTRE_TEST_CASE("Unit.Domain.OrientationMap", "[Domain][Unit]") {
 #endif
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.DiscreteRotation.AllOrientations",
+SPECTRE_TEST_CASE("Unit.Domain.Structure.DiscreteRotation.AllOrientations",
                   "[Domain][Unit]") {
   for (OrientationMapIterator<2> map_i{}; map_i; ++map_i) {
     const std::array<double, 2> original_point{{0.5, -2.0}};
@@ -395,7 +396,8 @@ SPECTRE_TEST_CASE("Unit.Domain.DiscreteRotation.AllOrientations",
   }
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.DiscreteRotation.Rotation", "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.Structure.DiscreteRotation.Rotation",
+                  "[Domain][Unit]") {
   const OrientationMap<1> rotation1(
       std::array<Direction<1>, 1>{{Direction<1>::lower_xi()}});
   const std::array<DataVector, 1> test_points1{
@@ -430,7 +432,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DiscreteRotation.Rotation", "[Domain][Unit]") {
         std::array<double, 3>{{0.5, -1.0, 1.0}});
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.DiscreteRotation.ReferenceWrapper",
+SPECTRE_TEST_CASE("Unit.Domain.Structure.DiscreteRotation.ReferenceWrapper",
                   "[Domain][Unit]") {
   const OrientationMap<3> rotation(std::array<Direction<3>, 3>{
       {Direction<3>::upper_eta(), Direction<3>::lower_zeta(),

--- a/tests/Unit/Domain/Structure/Test_OrientationMapHelpers.cpp
+++ b/tests/Unit/Domain/Structure/Test_OrientationMapHelpers.cpp
@@ -429,7 +429,8 @@ void test_2d_orient_variables_on_slice() noexcept {
 
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.OrientationMapHelpers", "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.Structure.OrientationMapHelpers",
+                  "[Domain][Unit]") {
   SECTION("Testing orient_variables") {
     test_1d_orient_variables();
     test_2d_orient_variables();

--- a/tests/Unit/Domain/Structure/Test_SegmentId.cpp
+++ b/tests/Unit/Domain/Structure/Test_SegmentId.cpp
@@ -14,7 +14,7 @@
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/GetOutput.hpp"
 
-SPECTRE_TEST_CASE("Unit.Domain.SegmentId", "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.Structure.SegmentId", "[Domain][Unit]") {
   // Test equality operator:
   SegmentId segment_one(4, 3);
   SegmentId segment_two(4, 3);
@@ -75,7 +75,7 @@ SPECTRE_TEST_CASE("Unit.Domain.SegmentId", "[Domain][Unit]") {
 }
 
 // [[OutputRegex, index = 8, refinement_level = 3]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.SegmentId.BadIndex",
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Structure.SegmentId.BadIndex",
                                "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
@@ -86,7 +86,7 @@ SPECTRE_TEST_CASE("Unit.Domain.SegmentId", "[Domain][Unit]") {
 }
 
 // [[OutputRegex, on root refinement level!]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.SegmentId.NoParent",
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Structure.SegmentId.NoParent",
                                "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
@@ -97,7 +97,7 @@ SPECTRE_TEST_CASE("Unit.Domain.SegmentId", "[Domain][Unit]") {
 }
 
 // [[OutputRegex, The segment on the root refinement level has no sibling]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.SegmentId.NoSibling",
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Structure.SegmentId.NoSibling",
                                "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
@@ -109,7 +109,7 @@ SPECTRE_TEST_CASE("Unit.Domain.SegmentId", "[Domain][Unit]") {
 
 // [[OutputRegex, The segment on the root refinement level has no abutting
 // nibling]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.SegmentId.NoNibling",
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Structure.SegmentId.NoNibling",
                                "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
@@ -120,7 +120,7 @@ SPECTRE_TEST_CASE("Unit.Domain.SegmentId", "[Domain][Unit]") {
 }
 
 // [[OutputRegex, The segment on the root refinement level has no sibling]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.SegmentId.NoSibling2",
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Structure.SegmentId.NoSibling2",
                                "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG

--- a/tests/Unit/Domain/Structure/Test_Side.cpp
+++ b/tests/Unit/Domain/Structure/Test_Side.cpp
@@ -8,7 +8,7 @@
 #include "Domain/Structure/Side.hpp"
 #include "Utilities/GetOutput.hpp"
 
-SPECTRE_TEST_CASE("Unit.Domain.Side", "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.Structure.Side", "[Domain][Unit]") {
   Side side_lower = Side::Lower;
   CHECK(opposite(side_lower) == Side::Upper);
   CHECK(opposite(opposite(side_lower)) == Side::Lower);

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/CMakeLists.txt
@@ -4,7 +4,6 @@
 set(LIBRARY "Test_LinearOperators")
 
 set(LIBRARY_SOURCES
-  Test_ApplyMatrices.cpp
   Test_CoefficientTransforms.cpp
   Test_DefiniteIntegral.cpp
   Test_Divergence.cpp
@@ -13,7 +12,6 @@ set(LIBRARY_SOURCES
   Test_Linearize.cpp
   Test_MeanValue.cpp
   Test_PartialDerivatives.cpp
-  Test_Transpose.cpp
   )
 
 add_test_library(

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBRARY_SOURCES
   Test_IndefiniteIntegral.cpp
   Test_LegendreGauss.cpp
   Test_LegendreGaussLobatto.cpp
+  Test_Mesh.cpp
   Test_Projection.cpp
   Test_Spectral.cpp
   Test_SwshCoefficients.cpp

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Mesh.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Mesh.cpp
@@ -241,7 +241,8 @@ void test_serialization() noexcept {
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.Mesh", "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.Mesh",
+                  "[NumericalAlgorithms][Spectral][Unit]") {
   test_uniform_lgl_mesh();
   test_explicit_choices_per_dimension();
   test_equality();
@@ -250,7 +251,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Mesh", "[Domain][Unit]") {
 
 // [[OutputRegex, Tried to slice through non-existing dimension]]
 [[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Domain.Mesh.SliceThroughNonExistingDimension", "[Domain][Unit]") {
+    "Unit.NumericalAlgorithms.Spectral.Mesh.SliceThroughNonExistingDimension",
+    "[NumericalAlgorithms][Spectral][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   const Mesh<1> mesh1d{2, Spectral::Basis::Legendre,
@@ -261,8 +263,9 @@ SPECTRE_TEST_CASE("Unit.Domain.Mesh", "[Domain][Unit]") {
 }
 
 // [[OutputRegex, Tried to slice away non-existing dimension]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Mesh.SliceAwayNonExistingDimension",
-                               "[Domain][Unit]") {
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.NumericalAlgorithms.Spectral.Mesh.SliceAwayNonExistingDimension",
+    "[NumericalAlgorithms][Spectral][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   const Mesh<1> mesh1d{2, Spectral::Basis::Legendre,
@@ -274,7 +277,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Mesh", "[Domain][Unit]") {
 
 // [[OutputRegex, Dimensions to slice through contain duplicates]]
 [[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Domain.Mesh.SliceThroughDuplicateDimensions", "[Domain][Unit]") {
+    "Unit.NumericalAlgorithms.Spectral.Mesh.SliceThroughDuplicateDimensions",
+    "[NumericalAlgorithms][Spectral][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   const Mesh<3> mesh3d{2, Spectral::Basis::Legendre,


### PR DESCRIPTION
## Proposed changes

PR #2382 moved code in `src` without making the same moves in `tests`. This PR fixes that.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

