### PR TITLE
Support options type alias templated on Metavariables

### DIFF
--- a/tests/Unit/Options/Test_CustomTypeConstruction.cpp
+++ b/tests/Unit/Options/Test_CustomTypeConstruction.cpp
@@ -148,7 +148,7 @@ template <>
 struct create_from_yaml<CreateFromOptionsAnimal> {
   template <typename Metavariables>
   static CreateFromOptionsAnimal create(const Option& options) {
-    const std::string animal = options.parse_as<std::string>();
+    const auto animal = options.parse_as<std::string>();
     if (animal == "Cat") {
       return CreateFromOptionsAnimal::Cat;
     }
@@ -195,7 +195,7 @@ template <>
 CreateFromOptionsExoticAnimal
 create_from_yaml<CreateFromOptionsExoticAnimal>::create<void>(
     const Option& options) {
-  const std::string animal = options.parse_as<std::string>();
+  const auto animal = options.parse_as<std::string>();
   if (animal == "MexicanWalkingFish") {
     return CreateFromOptionsExoticAnimal::MexicanWalkingFish;
   }

--- a/tests/Unit/Options/Test_CustomTypeConstruction.cpp
+++ b/tests/Unit/Options/Test_CustomTypeConstruction.cpp
@@ -24,14 +24,45 @@ struct CFO {
   static constexpr OptionString help = {"help"};
 };
 
+// In order to avoid duplicating too much code we use inheritance to get the
+// `using options` type alias into CreateFromOptions.
+template <typename>
+struct CfoOption {
+  static std::string name() noexcept { return "Option"; }
+  using type = std::string;
+  static constexpr OptionString help = {"Option help text"};
+};
+
+template <>
+struct CfoOption<Metavariables<true>> {
+  static std::string name() noexcept { return "Option"; }
+  using type = std::string;
+  static constexpr OptionString help = {"Option help text"};
+  static type default_value() noexcept { return "fHi"; }
+};
+
+template <>
+struct CfoOption<Metavariables<false>> {
+  static std::string name() noexcept { return "Option"; }
+  using type = std::string;
+  static constexpr OptionString help = {"Option help text"};
+  static type default_value() noexcept { return "fHello"; }
+};
+
+template <typename>
+struct Selector {
+  template <typename Metavariables>
+  using options = tmpl::list<CfoOption<Metavariables>>;
+};
+
+template <>
+struct Selector<int> {
+  using options = tmpl::list<CfoOption<void>>;
+};
+
 template <typename T>
-class CreateFromOptions {
+class CreateFromOptions : public Selector<T> {
  public:
-  struct Option {
-    using type = std::string;
-    static constexpr OptionString help = {"Option help text"};
-  };
-  using options = tmpl::list<Option>;
   static constexpr OptionString help = {"Class help text"};
 
   CreateFromOptions() = default;
@@ -56,14 +87,31 @@ CFO:
   Option: foo
 )";
 /// [class_creation_example]
+
+struct CfoVoid {
+  using type = CreateFromOptions<void>;
+  static constexpr OptionString help = {"help"};
+};
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Options.CustomType", "[Unit][Options]") {
-  Options<tmpl::list<CFO>> opts("");
-  opts.parse(input_file_text);
-  CHECK(opts.get<CFO, Metavariables<true>>().str_ == "foo");
-  CHECK(opts.get<CFO, Metavariables<true>>().valid_);
-  CHECK_FALSE(opts.get<CFO, Metavariables<false>>().valid_);
+  {
+    INFO("Type alias options is not a template");
+    Options<tmpl::list<CFO>> opts("");
+    opts.parse(input_file_text);
+    CHECK(opts.get<CFO, Metavariables<true>>().str_ == "foo");
+    CHECK(opts.get<CFO, Metavariables<true>>().valid_);
+    CHECK_FALSE(opts.get<CFO, Metavariables<false>>().valid_);
+  }
+  {
+    INFO("Type alias options is a template");
+    Options<tmpl::list<CfoVoid>> opts("");
+    opts.parse("CfoVoid:");
+    CHECK(opts.get<CfoVoid, Metavariables<true>>().str_ == "fHi");
+    CHECK(opts.get<CfoVoid, Metavariables<true>>().valid_);
+    CHECK(opts.get<CfoVoid, Metavariables<false>>().str_ == "fHello");
+    CHECK_FALSE(opts.get<CfoVoid, Metavariables<false>>().valid_);
+  }
 }
 
 // [[OutputRegex, In string:.*At line 2 column 3:.Option 'NotOption' is not a


### PR DESCRIPTION
## Proposed changes

We support having the constructor of option creatable classes being templated on the metavariables. In some cases (for me it's boundary conditions in the DomainCreators) it is also necessary to have the `using options` type alias be a template on `Metavariables`. The case I specifically need this for is that the options to the domain creator need to be aware of the system, but the domain creator itself does not need to be. Making the domain creators all be templated on the system would add a lot of unnecessary compilation overhead and so going the route of support `using options` taking the metavariables seemed to me the most consistent and easiest approach.

@wthrowe I think I've mentioned this feature to you several months ago. It was actually a really simple change, which I view as a statement that you designed the options code really well :)

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
