### PR TITLE
Avoid relative path bug using `realpath`

### DIFF
--- a/support/Environments/frontera_gcc.sh
+++ b/support/Environments/frontera_gcc.sh
@@ -30,7 +30,7 @@ spectre_setup_modules() {
     fi
 
     local start_dir=`pwd`
-    dep_dir=$1
+    dep_dir=`realpath $1`
     if [ $# != 1 ]; then
         echo "You must pass one argument to spectre_setup_modules, which"
         echo "is the directory where you want the dependencies to be built."


### PR DESCRIPTION
## Proposed changes

Ran into a trouble when working with the frontera env file that relative paths cause scary behavior. I suggest this simple fix to transform an input relative path to the absolute path.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
