### PR TITLE
Add UnitNormalVectorTag

### DIFF
--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -322,6 +322,28 @@ struct UnitNormalOneFormCompute : UnitNormalOneForm<Frame>, db::ComputeTag {
   using return_type = tnsr::i<DataVector, 3, Frame>;
 };
 
+/// UnitNormalVector is defined as \f$S^i = \gamma^{ij} S_j\f$,
+/// where \f$S_j\f$ is the unit normal one form
+/// and \f$\gamma^{ij}\f$ is the inverse spatial metric.
+template <typename Frame>
+struct UnitNormalVector : db::SimpleTag {
+  using type = tnsr::I<DataVector, 3, Frame>;
+};
+/// Computes the UnitNormalVector perpendicular to the horizon.
+template <typename Frame>
+struct UnitNormalVectorCompute : UnitNormalVector<Frame>, db::ComputeTag {
+  using base = UnitNormalVector<Frame>;
+  static void function(gsl::not_null<tnsr::I<DataVector, 3, Frame>*> result,
+      const tnsr::II<DataVector, 3, Frame>& inverse_spatial_metric,
+      const tnsr::i<DataVector, 3, Frame>& unit_normal_one_form) noexcept {
+    raise_or_lower_index(result, unit_normal_one_form, inverse_spatial_metric);
+  }
+  using argument_tags =
+      tmpl::list<gr::Tags::InverseSpatialMetric<3, Frame, DataVector>,
+                 UnitNormalOneForm<Frame>>;
+  using return_type = tnsr::I<DataVector, 3, Frame>;
+};
+
 // @{
 /// `Tangents(i,j)` is \f$\partial x_{\rm surf}^i/\partial q^j\f$,
 /// where \f$x_{\rm surf}^i\f$ are the Cartesian coordinates of the

--- a/src/ApparentHorizons/TagsDeclarations.hpp
+++ b/src/ApparentHorizons/TagsDeclarations.hpp
@@ -42,6 +42,10 @@ template <typename Frame>
 struct UnitNormalOneForm;
 template <typename Frame>
 struct UnitNormalOneFormCompute;
+template <typename Frame>
+struct UnitNormalVector;
+template <typename Frame>
+struct UnitNormalVectorCompute;
 
 }  // namespace StrahlkorperTags
 

--- a/tests/Unit/ApparentHorizons/Test_Tags.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Tags.cpp
@@ -302,6 +302,8 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
       StrahlkorperTags::UnitNormalOneForm<Frame::Inertial>>(
       "UnitNormalOneForm");
   TestHelpers::db::test_simple_tag<
+      StrahlkorperTags::UnitNormalVector<Frame::Inertial>>("UnitNormalVector");
+  TestHelpers::db::test_simple_tag<
       StrahlkorperTags::Strahlkorper<Frame::Inertial>>("Strahlkorper");
   TestHelpers::db::test_simple_tag<StrahlkorperTags::ThetaPhi<Frame::Inertial>>(
       "ThetaPhi");
@@ -404,4 +406,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
   TestHelpers::db::test_compute_tag<
       StrahlkorperTags::UnitNormalOneFormCompute<Frame::Inertial>>(
       "UnitNormalOneForm");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::UnitNormalVectorCompute<Frame::Inertial>>(
+      "UnitNormalVector");
 }


### PR DESCRIPTION
## Proposed changes

Add UnitNormalVectorTag and UnitNormalVectorCompute for computing the unit normal vector perpendicular to the horizon.

### Types of changes:

- [ ] Bugfix
- [ x] New feature
- [ ] Refactor

### Component:

- [ x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments


