### PR TITLE
Remove cpp17::void_type

### DIFF
--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -532,8 +532,7 @@ class DataBox<tmpl::list<Tags...>>
       tmpl::list<Subtags...> /*meta*/) noexcept;
 
   template <size_t ArgsIndex, typename Tag, typename... Ts>
-  constexpr cpp17::void_type add_item_to_box(
-      std::tuple<Ts...>& tupull) noexcept;
+  constexpr char add_item_to_box(std::tuple<Ts...>& tupull) noexcept;
   // End adding simple items
 
   template <typename FullTagList, typename... Ts, typename... AddItemTags,
@@ -684,7 +683,7 @@ namespace DataBox_detail {
 // This function exists so that the user can look at the template
 // arguments to find out what triggered the static_assert.
 template <typename ComputeItem, typename Argument, typename FullTagList>
-constexpr cpp17::void_type check_compute_item_argument_exists() noexcept {
+constexpr char check_compute_item_argument_exists() noexcept {
   using compute_item_index = tmpl::index_of<FullTagList, ComputeItem>;
   static_assert(
       tmpl::less<tmpl::index_if<FullTagList,
@@ -696,7 +695,7 @@ constexpr cpp17::void_type check_compute_item_argument_exists() noexcept {
       "dependencies arise.  See the first and second template "
       "arguments of the instantiation of this function for the "
       "compute item and missing dependency.");
-  return cpp17::void_type{};
+  return '0';
 }
 }  // namespace DataBox_detail
 
@@ -760,7 +759,7 @@ db::DataBox<tmpl::list<Tags...>>::add_subitem_tags_to_box(
 
 template <typename... Tags>
 template <size_t ArgsIndex, typename Tag, typename... Ts>
-SPECTRE_ALWAYS_INLINE constexpr cpp17::void_type
+SPECTRE_ALWAYS_INLINE constexpr char
 db::DataBox<tmpl::list<Tags...>>::add_item_to_box(
     std::tuple<Ts...>& tupull) noexcept {
   using ArgType = std::tuple_element_t<ArgsIndex, std::tuple<Ts...>>;
@@ -773,7 +772,7 @@ db::DataBox<tmpl::list<Tags...>>::add_item_to_box(
       Deferred<DataBox_detail::storage_type<Tag, tmpl::list<Tags...>>>(
           std::forward<ArgType>(std::get<ArgsIndex>(tupull)));
   add_subitem_tags_to_box<Tag>(typename Subitems<Tag>::type{});
-  return cpp17::void_type{};  // must return in constexpr function
+  return '0';  // must return in constexpr function
 }
 // End adding simple items
 

--- a/src/Parallel/ParallelComponentHelpers.hpp
+++ b/src/Parallel/ParallelComponentHelpers.hpp
@@ -193,7 +193,7 @@ struct get_array_index;
 template <>
 struct get_array_index<Parallel::Algorithms::Singleton> {
   template <class ParallelComponent>
-  using f = cpp17::void_type;
+  using f = char;
 };
 
 template <>

--- a/src/Utilities/TypeTraits.hpp
+++ b/src/Utilities/TypeTraits.hpp
@@ -6,21 +6,6 @@
 #include <type_traits>
 
 /// \ingroup TypeTraitsGroup
-/// C++ STL code present in C++17
-namespace cpp17 {
-
-/*!
- * \ingroup UtilitiesGroup
- * \brief Mark a return type as being "void". In C++17 void is a regular type
- * under certain circumstances, so this can be replaced by `void` then.
- *
- * The proposal is available
- * [here](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0146r1.html)
- */
-struct void_type {};
-}  // namespace cpp17
-
-/// \ingroup TypeTraitsGroup
 /// C++ STL code present in C++20
 namespace cpp20 {
 /// \ingroup TypeTraitsGroup

--- a/tests/Unit/Helpers/Tests/Test_MakeRandomVectorInMagnitudeRange.cpp
+++ b/tests/Unit/Helpers/Tests/Test_MakeRandomVectorInMagnitudeRange.cpp
@@ -32,7 +32,7 @@ void check_random_values(const Variables<tmpl::list<Tags...>>& v,
                          const double bound1, const double bound2) noexcept {
   expand_pack((
       check_random_values<decltype(get<Tags>(v))>(get<Tags>(v), bound1, bound2),
-      cpp17::void_type{})...);
+      '0')...);
 }
 
 // Compute Magnitude

--- a/tests/Unit/Helpers/Tests/Test_MakeWithRandomValues.cpp
+++ b/tests/Unit/Helpers/Tests/Test_MakeWithRandomValues.cpp
@@ -66,7 +66,7 @@ void check_random_values(
     const double upper_bound) noexcept {
   expand_pack((check_random_values<decltype(get<Tags>(v))>(
                    values, counter, get<Tags>(v), lower_bound, upper_bound),
-               cpp17::void_type{})...);
+               '0')...);
 }
 
 template <typename T, typename U>


### PR DESCRIPTION
## Proposed changes

Regular void didn't make it into the C++17 or C++20 standards. So we just replace our `void_type` with `char`.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

