### PR TITLE
Add ocean clang env (no container)

### DIFF
--- a/support/Environments/ocean_clang.sh
+++ b/support/Environments/ocean_clang.sh
@@ -1,0 +1,81 @@
+#!/bin/env sh
+
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Environment for the ocean cluster, located at Cal State Fullerton.
+#
+# Access ocean via `ssh ocean.fullerton.edu`
+#
+# For questions regarding ocean or to request access, please contact
+# Geoffrey Lovelace by email (glovelace at fullerton dot edu).
+# Access is normally restricted to members of Cal State Fullerton's
+# Gravitational-Wave Physics and Astronomy Center and their collaborators.
+
+spectre_setup_modules() {
+    echo "All modules on ocean are provided by the system"
+}
+
+spectre_unload_modules() {
+    module unload ohpc
+    module unload llvm/10.0.1
+    module unload gnu7/7.3.0
+    module unload openmpi/1.10.7
+    module unload prun/1.2
+    module unload cmake-3.13.1-gcc-7.3.0-r7qr3qo
+    module unload git-2.19.2-gcc-7.3.0-jfnpgdh
+    module unload blaze-3.7-gcc-7.3.0-6o4boto
+    module unload brigand-master-gcc-7.3.0-3m5ibui
+    module unload libsharp-2018-01-17-gcc-7.3.0-4xamgaw
+    module unload catch-2.4.0-gcc-7.3.0-prvl6kv
+    module unload gsl-2.5-gcc-7.3.0-i7icadp
+    module unload jemalloc-4.5.0-gcc-7.3.0-wlf2m7r
+    module unload libxsmm-1.10-gcc-7.3.0-sjh5yzv
+    module unload yaml-cpp-develop-gcc-7.3.0-qcfbbll
+    module unload boost-1.68.0-gcc-7.3.0-vgl6ofr
+    module unload hdf5-1.12.0-gcc-7.3.0-mknp6xv
+    module unload openblas-0.3.4-gcc-7.3.0-tt2coe7
+    module unload python/3.7.0
+    module unload charm-6.10.2
+}
+
+spectre_load_modules() {
+    module load ohpc
+    module load python/3.7.0
+    module load gnu7/7.3.0
+    module load openmpi/1.10.7
+    module load prun/1.2
+    module load llvm/10.0.1
+    source /opt/ohpc/pub/apps/spack/0.12.0/share/spack/setup-env.sh
+    module load cmake-3.13.1-gcc-7.3.0-r7qr3qo
+    module load git-2.19.2-gcc-7.3.0-jfnpgdh
+    module load blaze-3.7-gcc-7.3.0-6o4boto
+    module load brigand-master-gcc-7.3.0-3m5ibui
+    module load libsharp-2018-01-17-gcc-7.3.0-4xamgaw
+    module load catch-2.4.0-gcc-7.3.0-prvl6kv
+    module load gsl-2.5-gcc-7.3.0-i7icadp
+    module load jemalloc-4.5.0-gcc-7.3.0-wlf2m7r
+    module load libxsmm-1.10-gcc-7.3.0-sjh5yzv
+    module load yaml-cpp-develop-gcc-7.3.0-qcfbbll
+    module load boost-1.68.0-gcc-7.3.0-vgl6ofr
+    module load hdf5-1.12.0-gcc-7.3.0-mknp6xv
+    module load openblas-0.3.4-gcc-7.3.0-tt2coe7
+    module load charm-6.10.2
+}
+
+spectre_run_cmake() {
+    if [ -z ${SPECTRE_HOME} ]; then
+        echo "You must set SPECTRE_HOME to the cloned SpECTRE directory"
+        return 1
+    fi
+    spectre_load_modules
+    export GCC_HOME=/opt/ohpc/pub/compiler/gcc/7.3.0/bin
+    cmake -D CHARM_ROOT=$CHARM_ROOT \
+          -D CMAKE_BUILD_TYPE=Release \
+          -D CMAKE_C_COMPILER=clang \
+          -D CMAKE_CXX_COMPILER=clang++ \
+          -D CMAKE_Fortran_COMPILER=${GCC_HOME}/gfortran \
+          -D MEMORY_ALLOCATOR=SYSTEM \
+          "$@" \
+          $SPECTRE_HOME
+}

--- a/support/SubmitScripts/OceanClang.sh
+++ b/support/SubmitScripts/OceanClang.sh
@@ -1,0 +1,87 @@
+#!/bin/bash -
+#SBATCH -o spectre.stdout
+#SBATCH -e spectre.stderr
+#SBATCH --ntasks-per-node 20
+#SBATCH -J KerrSchild
+#SBATCH --nodes 2
+#SBATCH -p orca-1
+#SBATCH -t 12:00:00
+#SBATCH -D .
+
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# To run a job on Ocean:
+# - Set the -J, --nodes, and -t options above, which correspond to job name,
+#   number of nodes, and wall time limit in HH:MM:SS, respectively.
+# - Set the build directory, run directory, executable name,
+#   and input file below.
+# - Add a file ${HOME}/.charmrunrc that does the following (replace
+#   ${SPECTRE_BUILD_DIR}/../ with the path to your spectre checkout):
+#    source ${SPECTRE_BUILD_DIR}/../support/Environments/ocean_clang_lb.sh
+#    spectre_load_modules
+#
+# NOTE: The executable will not be copied from the build directory, so if you
+#       update your build directory this file will use the updated executable.
+#
+# Optionally, if you need more control over how SpECTRE is launched on
+# Ocean you can edit the launch command at the end of this file directly.
+#
+# To submit the script to the queue run:
+#   sbatch Ocean.sh
+
+# Replace these paths with the path to your build directory and to the
+# directory where you want the output to appear, i.e. the run directory
+# E.g., if you cloned spectre in your home directory, set
+# SPECTRE_BUILD_DIR to ${HOME}/spectre/build. If you want to run in a
+# directory called "Run" in the current directory, set
+# SPECTRE_RUN_DIR to ${PWD}/Run
+export SPECTRE_BUILD_DIR=${HOME}/Codes/spectre/spectre/build_clang
+export SPECTRE_RUN_DIR=${PWD}/Run
+
+# Choose the executable and input file to run
+# To use an input file in the current directory, set
+# SPECTRE_INPUT_FILE to ${PWD}/InputFileName.yaml
+export SPECTRE_EXECUTABLE=${SPECTRE_BUILD_DIR}/bin/EvolveKerrSchild
+export SPECTRE_INPUT_FILE=${PWD}/KerrSchild.yaml
+
+# These commands load the relevant modules and cd into the run directory,
+# creating it if it doesn't exist
+module load ohpc
+source ${SPECTRE_BUILD_DIR}/../support/Environments/ocean_clang.sh
+spectre_load_modules
+module list
+
+mkdir -p ${SPECTRE_RUN_DIR}
+cd ${SPECTRE_RUN_DIR}
+
+# Copy the input file into the run directory, to preserve it
+cp ${SPECTRE_INPUT_FILE} ${SPECTRE_RUN_DIR}/
+
+# Set desired permissions for files created with this script
+umask 0022
+
+# Set the path to include the build directory's bin directory
+export PATH=${SPECTRE_BUILD_DIR}/bin:$PATH
+
+# Flag to stop blas in CCE from parallelizing without charm++
+export OPENBLAS_NUM_THREADS=1
+
+# Generate the nodefile
+echo "Running on the following nodes:"
+echo ${SLURM_NODELIST}
+touch nodelist.$SLURM_JOBID
+for node in $(echo $SLURM_NODELIST | scontrol show hostnames); do
+  echo "host ${node}" >> nodelist.$SLURM_JOBID
+done
+
+# The 19 is there because Charm++ uses one thread per node for communication
+# Here, -np should take the number of nodes (must be the same as --nodes
+# in the #SBATCH options above).
+WORKER_THREADS_PER_NODE=$((SLURM_NTASKS_PER_NODE - 1))
+WORKER_THREADS=$((SLURM_NPROCS - SLURM_NNODES))
+SPECTRE_COMMAND="${SPECTRE_EXECUTABLE} ++np ${SLURM_NNODES} \
+++p ${WORKER_THREADS} ++ppn ${WORKER_THREADS_PER_NODE} \
+++nodelist nodelist.${SLURM_JOBID}"
+
+charmrun ${SPECTRE_COMMAND} --input-file ${SPECTRE_INPUT_FILE}


### PR DESCRIPTION
## Proposed changes

Support building on ocean using clang but not the singularity container.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
