### PR TITLE
Use tex-chtml-full.js because that seems to render

### DIFF
--- a/docs/config/MathJax.js
+++ b/docs/config/MathJax.js
@@ -16,7 +16,11 @@ window.MathJax = {
 
 (function () {
   var script = document.createElement('script');
-  script.src = 'https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js';
+  script.src = 'https://cdn.jsdelivr.net/npm/mathjax@3.1.0/es5/tex-chtml-full.js';
+  // cryptographic hashes can be found here:
+  // https://www.jsdelivr.com/package/npm/mathjax?path=es5
+  script.integrity = 'sha256-HJUiQvFxmEVWZ3D0qyz7Bg0JyJ2bkriI/WHQYo1ch5Y=';
+  script.crossOrigin = 'anonymous';
   script.async = true;
   document.head.appendChild(script);
 })();


### PR DESCRIPTION
## Proposed changes

Mathjax seems to be broken on some systems. This tries to fix mathjax by grabbing a different script from npm. I think we should have at least two other people verify that a) they can reproduce the error when rendering the dox on their own system and b) this fixes the problem (or they can't reproduce the original problem and this PR at least doesn't break anything). I've verified this does the trick for my linux system.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

