### PR TITLE
Cce analytic test rotating schwarzschild

### DIFF
--- a/src/Evolution/Systems/Cce/AnalyticSolutions/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   BouncingBlackHole.cpp
   LinearizedBondiSachs.cpp
+  RotatingSchwarzschild.cpp
   SphericalMetricData.cpp
   TeukolskyWave.cpp
   WorldtubeData.cpp
@@ -21,6 +22,7 @@ spectre_target_headers(
   HEADERS
   BouncingBlackHole.hpp
   LinearizedBondiSachs.hpp
+  RotatingSchwarzschild.hpp
   SphericalMetricData.hpp
   TeukolskyWave.hpp
   WorldtubeData.hpp

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/RotatingSchwarzschild.cpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/RotatingSchwarzschild.cpp
@@ -1,0 +1,118 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Cce/AnalyticSolutions/RotatingSchwarzschild.hpp"
+
+#include <complex>
+#include <vector>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Tags.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "NumericalAlgorithms/Spectral/SwshInterpolation.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Cce::Solutions {
+
+/// \cond
+RotatingSchwarzschild::RotatingSchwarzschild(const double extraction_radius,
+                                             const double mass,
+                                             const double frequency) noexcept
+    : SphericalMetricData{extraction_radius},
+      frequency_{frequency},
+      mass_{mass} {}
+
+std::unique_ptr<WorldtubeData> RotatingSchwarzschild::get_clone() const
+    noexcept {
+  return std::make_unique<RotatingSchwarzschild>(*this);
+}
+
+void RotatingSchwarzschild::spherical_metric(
+    const gsl::not_null<
+        tnsr::aa<DataVector, 3, ::Frame::Spherical<::Frame::Inertial>>*>
+        spherical_metric,
+    const size_t l_max, double /*time*/) const noexcept {
+  get<0, 1>(*spherical_metric) = 0.0;
+  get<0, 2>(*spherical_metric) = 0.0;
+
+  get<1, 1>(*spherical_metric) = 1.0 / (1.0 - 2.0 * mass_ / extraction_radius_);
+  get<1, 2>(*spherical_metric) = 0.0;
+  get<1, 3>(*spherical_metric) = 0.0;
+
+  get<2, 2>(*spherical_metric) = square(extraction_radius_);
+  get<2, 3>(*spherical_metric) = 0.0;
+
+  // note: omit the sin factors for the phi components due to pfaffian
+  // Jacobian factors
+  get<3, 3>(*spherical_metric) = square(extraction_radius_);
+
+  const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
+      Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
+  for (const auto& collocation_point : collocation) {
+    get<0, 0>(*spherical_metric)[collocation_point.offset] =
+        -(1.0 - 2.0 * mass_ / extraction_radius_ -
+          square(frequency_) * square(extraction_radius_) *
+              square(sin(collocation_point.theta)));
+    get<0, 3>(*spherical_metric)[collocation_point.offset] =
+        square(extraction_radius_) * frequency_ * sin(collocation_point.theta);
+  }
+}
+
+void RotatingSchwarzschild::dr_spherical_metric(
+    const gsl::not_null<
+        tnsr::aa<DataVector, 3, ::Frame::Spherical<::Frame::Inertial>>*>
+        dr_spherical_metric,
+    const size_t l_max, double /*time*/) const noexcept {
+  get<0, 1>(*dr_spherical_metric) = 0.0;
+  get<0, 2>(*dr_spherical_metric) = 0.0;
+
+  get<1, 1>(*dr_spherical_metric) =
+      -2.0 * mass_ / (square(extraction_radius_ - 2.0 * mass_));
+  get<1, 2>(*dr_spherical_metric) = 0.0;
+  get<1, 3>(*dr_spherical_metric) = 0.0;
+
+  get<2, 2>(*dr_spherical_metric) = 2.0 * extraction_radius_;
+  get<2, 3>(*dr_spherical_metric) = 0.0;
+
+  // note: omit the sin factors for the phi components due to pfaffian
+  // Jacobian factors
+  get<3, 3>(*dr_spherical_metric) = 2.0 * extraction_radius_;
+
+  const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
+      Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
+  for (const auto& collocation_point : collocation) {
+    get<0, 0>(*dr_spherical_metric)[collocation_point.offset] =
+        -(2.0 * mass_ / square(extraction_radius_) -
+          2.0 * square(frequency_) * extraction_radius_ *
+              square(sin(collocation_point.theta)));
+    get<0, 3>(*dr_spherical_metric)[collocation_point.offset] =
+        2.0 * extraction_radius_ * frequency_ * sin(collocation_point.theta);
+  }
+}
+
+void RotatingSchwarzschild::dt_spherical_metric(
+    const gsl::not_null<
+        tnsr::aa<DataVector, 3, ::Frame::Spherical<::Frame::Inertial>>*>
+        dt_spherical_metric,
+    size_t /*l_max*/, double /*time*/) const noexcept {
+  for(auto& component : *dt_spherical_metric) {
+    component = 0.0;
+  }
+}
+
+void RotatingSchwarzschild::variables_impl(
+    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, -2>>*> news,
+    size_t /*output_l_max*/, double /*time*/,
+    tmpl::type_<Tags::News> /*meta*/) const noexcept {
+  get(*news).data() = 0.0;
+}
+
+PUP::able::PUP_ID RotatingSchwarzschild::my_PUP_ID = 0;
+/// \endcond
+}  // namespace Cce::Solutions

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/RotatingSchwarzschild.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/RotatingSchwarzschild.hpp
@@ -1,0 +1,144 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <complex>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <vector>
+
+#include "DataStructures/SpinWeighted.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/SphericalMetricData.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+class ComplexDataVector;
+/// \endcond
+
+namespace Cce::Solutions {
+
+/*!
+ * \brief Computes the analytic data for the rotating Schwarzschild solution
+ * described in \cite Barkett2019uae, section VI.C.
+ *
+ * \details This is a comparatively simple test which simply determines the
+ * Schwarzschild metric in transformed coordinates given by \f$\phi\rightarrow
+ * \phi + \omega u\f$, where \f$u\f$ is the retarded time.
+ */
+struct RotatingSchwarzschild : public SphericalMetricData {
+  struct ExtractionRadius {
+    using type = double;
+    static constexpr Options::String help{
+        "The extraction radius of the spherical solution"};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+  struct Mass {
+    using type = double;
+    static constexpr Options::String help{
+        "The mass of the Schwarzschild black hole"};
+    static type lower_bound() noexcept { return 0.0; }
+    static type default_value() noexcept { return 1.0; }
+  };
+  struct Frequency {
+    using type = double;
+    static constexpr Options::String help{
+        "The frequency of the coordinate rotation."};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+
+  using options = tmpl::list<ExtractionRadius, Mass, Frequency>;
+
+  static constexpr Options::String help = {
+      "Analytic solution representing a Schwarzschild black hole in a rotating "
+      "frame"};
+
+  WRAPPED_PUPable_decl_template(RotatingSchwarzschild);  // NOLINT
+
+  explicit RotatingSchwarzschild(CkMigrateMessage* /*unused*/) noexcept {}
+
+  // clang doesn't manage to use = default correctly in this case
+  // NOLINTNEXTLINE(modernize-use-equals-default)
+  RotatingSchwarzschild() noexcept {};
+
+  RotatingSchwarzschild(double extraction_radius, double mass,
+                        double frequency) noexcept;
+
+  std::unique_ptr<WorldtubeData> get_clone() const noexcept override;
+
+ protected:
+  /// A no-op as the rotating Schwarzschild solution does not have substantial
+  /// shared computation to prepare before the separate component calculations.
+  void prepare_solution(const size_t /*output_l_max*/,
+                        const double /*time*/) const noexcept override {}
+
+  /*!
+   * \brief Compute the spherical coordinate metric from the closed-form
+   * rotating Schwarzschild metric.
+   *
+   * \details The rotating Schwarzschild takes the coordinate form
+   * \cite Barkett2019uae,
+   *
+   * \f{align}{
+   * ds^2 = -\left(1 - \frac{2 M}{r} - \omega^2 r^2 \sin^2 \theta\right) dt^2
+   * + \frac{1}{1 - \frac{2 M}{r}} dr^2
+   * + 2 \omega r^2 \sin^2 \theta dt d\phi + r^2 d\Omega^2
+   * \f}
+   */
+  void spherical_metric(
+      gsl::not_null<
+          tnsr::aa<DataVector, 3, ::Frame::Spherical<::Frame::Inertial>>*>
+          spherical_metric,
+      size_t l_max, double time) const noexcept override;
+
+  /*!
+   * \brief Compute the radial derivative of the spherical coordinate metric
+   * from the closed-form rotating Schwarzschild metric.
+   *
+   * \details The rotating Schwarzschild takes the coordinate form
+   * \cite Barkett2019uae,
+   *
+   * \f{align}{
+   * \partial_r g_{a b} dx^a dx^b =& -\left(\frac{2 M}{r^2} - 2 \omega^2 r
+   * \sin^2 \theta\right) dt^2 - \frac{2 M}{(r - 2 M)^2} dr^2
+   * + 4 \omega r \sin^2 \theta dt d\phi + 2 r d\Omega^2
+   * \f}
+   */
+  void dr_spherical_metric(
+      gsl::not_null<
+          tnsr::aa<DataVector, 3, ::Frame::Spherical<::Frame::Inertial>>*>
+          dr_spherical_metric,
+      size_t l_max, double time) const noexcept override;
+
+  /*!
+   * \brief The time derivative of the spherical coordinate metric in the
+   * rotating Schwarzschild metric vanishes.
+   */
+  void dt_spherical_metric(
+      gsl::not_null<
+          tnsr::aa<DataVector, 3, ::Frame::Spherical<::Frame::Inertial>>*>
+          dt_spherical_metric,
+      size_t l_max, double time) const noexcept override;
+
+  using WorldtubeData::variables_impl;
+
+  using SphericalMetricData::variables_impl;
+
+  /// The News vanishes in the rotating Schwarzschild metric
+  void variables_impl(
+      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, -2>>*> news,
+      size_t l_max, double time,
+      tmpl::type_<Tags::News> /*meta*/) const noexcept override;
+
+  double frequency_ = std::numeric_limits<double>::signaling_NaN();
+  double mass_ = std::numeric_limits<double>::signaling_NaN();
+};
+}  // namespace Cce::Solutions

--- a/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_Cce_AnalyticSolutions")
 set(LIBRARY_SOURCES
   Test_BouncingBlackHole.cpp
   Test_LinearizedBondiSachs.cpp
+  Test_RotatingSchwarzschild.cpp
   Test_TeukolskyWave.cpp
   )
 

--- a/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/RotatingSchwarzschild.py
+++ b/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/RotatingSchwarzschild.py
@@ -1,0 +1,28 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def spherical_metric(sin_theta, cos_theta, t, r, m, f):
+    return np.array([[(-(1.0 - 2.0 * m / r - f**2 * r**2 * sin_theta**2)), 0.0,
+                      0.0, r**2 * f * sin_theta],
+                     [0.0, 1.0 / (1.0 - 2.0 * m / r), 0.0, 0.0],
+                     [0.0, 0.0, r**2, 0.0],
+                     [r**2 * f * sin_theta, 0.0, 0.0, r**2]])
+
+
+def dr_spherical_metric(sin_theta, cos_theta, t, r, m, f):
+    return np.array([[(-(2.0 * m / r**2 - 2.0 * f**2 * r * sin_theta**2)), 0.0,
+                      0.0, 2.0 * r * f * sin_theta],
+                     [0.0, -2.0 * m / (r - 2.0 * m)**2, 0.0, 0.0],
+                     [0.0, 0.0, 2.0 * r, 0.0],
+                     [2.0 * r * f * sin_theta, 0.0, 0.0, 2.0 * r]])
+
+
+def dt_spherical_metric(sin_theta, cos_theta, t, r, m, f):
+    return np.zeros((4, 4))
+
+
+def news(sin_theta, t, r, m, f):
+    return complex(0.0, 0.0)

--- a/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/Test_RotatingSchwarzschild.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/Test_RotatingSchwarzschild.cpp
@@ -1,0 +1,37 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <complex>
+#include <cstddef>
+
+#include "Evolution/Systems/Cce/AnalyticSolutions/RotatingSchwarzschild.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/TeukolskyWave.hpp"
+#include "Framework/Pypp.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/Evolution/Systems/Cce/AnalyticSolutions/AnalyticDataHelpers.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+
+namespace Cce::Solutions {
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.RotatingSchwarzschild",
+                  "[Unit][Cce]") {
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<double> radius_dist{5.0, 10.0};
+  UniformCustomDistribution<double> parameter_dist{0.5, 2.0};
+  const double extraction_radius = radius_dist(gen);
+  const size_t l_max = 16;
+  // use a low frequency so that the dimensionless parameter in the metric is ~1
+  const double frequency = parameter_dist(gen) / 30.0;
+  const double mass = parameter_dist(gen);
+  TestHelpers::SphericalSolutionWrapper<RotatingSchwarzschild>
+      boundary_solution{extraction_radius, mass, frequency};
+  const double time = 10.0 * parameter_dist(gen);
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/Cce/AnalyticSolutions/"};
+  boundary_solution.test_spherical_metric("RotatingSchwarzschild", l_max, time,
+                                          extraction_radius, mass, frequency);
+}
+}  // namespace Cce::Solutions

--- a/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/Test_TeukolskyWave.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/Test_TeukolskyWave.cpp
@@ -3,121 +3,18 @@
 
 #include "Framework/TestingFramework.hpp"
 
-#include <cmath>
 #include <complex>
 #include <cstddef>
-#include <limits>
 
-#include "DataStructures/ComplexDataVector.hpp"
-#include "DataStructures/DataBox/Prefixes.hpp"
-#include "DataStructures/DataVector.hpp"
-#include "DataStructures/SpinWeighted.hpp"
-#include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/Systems/Cce/AnalyticSolutions/TeukolskyWave.hpp"
-#include "Evolution/Systems/Cce/BoundaryDataTags.hpp"
-#include "Evolution/Systems/Cce/Tags.hpp"
-#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "Framework/Pypp.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/Evolution/Systems/Cce/AnalyticSolutions/AnalyticDataHelpers.hpp"
-#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
-#include "Utilities/ConstantExpressions.hpp"
-#include "Utilities/Gsl.hpp"
-#include "Utilities/TMPL.hpp"
 
 namespace Cce::Solutions {
-
-namespace {
-
-struct TeukolskyWaveWrapper : public TeukolskyWave {
-  using taglist =
-      tmpl::list<gr::Tags::SpacetimeMetric<
-                     3, ::Frame::Spherical<::Frame::Inertial>, DataVector>,
-                 Tags::Dr<gr::Tags::SpacetimeMetric<
-                     3, ::Frame::Spherical<::Frame::Inertial>, DataVector>>,
-                 ::Tags::dt<gr::Tags::SpacetimeMetric<
-                     3, ::Frame::Spherical<::Frame::Inertial>, DataVector>>,
-                 Tags::News>;
-
-  using TeukolskyWave::TeukolskyWave;
-
-  void test_spherical_metric(const size_t l_max, const double time) noexcept {
-    const size_t size =
-        Spectral::Swsh::number_of_swsh_collocation_points(l_max);
-    Scalar<DataVector> sin_theta{size};
-    Scalar<DataVector> cos_theta{size};
-    const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
-        Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
-    for (const auto& collocation_point : collocation) {
-      get(sin_theta)[collocation_point.offset] = sin(collocation_point.theta);
-      get(cos_theta)[collocation_point.offset] = cos(collocation_point.theta);
-    }
-    tnsr::aa<DataVector, 3, ::Frame::Spherical<::Frame::Inertial>>
-        local_spherical_metric{size};
-    tnsr::aa<DataVector, 3, ::Frame::Spherical<::Frame::Inertial>>
-        local_dr_spherical_metric{size};
-    tnsr::aa<DataVector, 3, ::Frame::Spherical<::Frame::Inertial>>
-        local_dt_spherical_metric{size};
-    Scalar<SpinWeighted<ComplexDataVector, -2>> local_news{size};
-
-    this->spherical_metric(make_not_null(&local_spherical_metric), l_max, time);
-    this->dr_spherical_metric(make_not_null(&local_dr_spherical_metric), l_max,
-                              time);
-    this->dt_spherical_metric(make_not_null(&local_dt_spherical_metric), l_max,
-                              time);
-    this->variables_impl(make_not_null(&local_news), l_max, time,
-                         tmpl::type_<Tags::News>{});
-
-    // Pypp call expects all of the objects to be the same category -- here we
-    // need to use tensors, so we must pack up the `double` arguments into
-    // tensors.
-    Scalar<DataVector> time_vector;
-    get(time_vector) = DataVector{size, time};
-    Scalar<DataVector> radius_vector;
-    get(radius_vector) = DataVector{size, extraction_radius_};
-    Scalar<DataVector> amplitude_vector;
-    get(amplitude_vector) = DataVector{size, amplitude_};
-    Scalar<DataVector> duration_vector;
-    get(duration_vector) = DataVector{size, duration_};
-
-    const auto py_spherical_metric = pypp::call<
-        tnsr::aa<DataVector, 3, ::Frame::Spherical<::Frame::Inertial>>>(
-        "TeukolskyWave", "spherical_metric", sin_theta, cos_theta, time_vector,
-        radius_vector, amplitude_vector, duration_vector);
-    const auto py_dt_spherical_metric = pypp::call<
-        tnsr::aa<DataVector, 3, ::Frame::Spherical<::Frame::Inertial>>>(
-        "TeukolskyWave", "dt_spherical_metric", sin_theta, cos_theta,
-        time_vector, radius_vector, amplitude_vector, duration_vector);
-    const auto py_dr_spherical_metric = pypp::call<
-        tnsr::aa<DataVector, 3, ::Frame::Spherical<::Frame::Inertial>>>(
-        "TeukolskyWave", "dr_spherical_metric", sin_theta, cos_theta,
-        time_vector, radius_vector, amplitude_vector, duration_vector);
-    const auto py_news = pypp::call<Scalar<SpinWeighted<ComplexDataVector, 2>>>(
-        "TeukolskyWave", "news", sin_theta, time_vector, radius_vector,
-        amplitude_vector, duration_vector);
-
-    for (size_t a = 0; a < 4; ++a) {
-      for (size_t b = a; b < 4; ++b) {
-        CAPTURE(a);
-        CAPTURE(b);
-        const auto& lhs = local_spherical_metric.get(a, b);
-        const auto& rhs = py_spherical_metric.get(a, b);
-        CHECK_ITERABLE_APPROX(lhs, rhs);
-        const auto& dr_lhs = local_dr_spherical_metric.get(a, b);
-        const auto& dr_rhs = py_dr_spherical_metric.get(a, b);
-        CHECK_ITERABLE_APPROX(dr_lhs, dr_rhs);
-        const auto& dt_lhs = local_dt_spherical_metric.get(a, b);
-        const auto& dt_rhs = py_dt_spherical_metric.get(a, b);
-        CHECK_ITERABLE_APPROX(dt_lhs, dt_rhs);
-      }
-    }
-  }
-};
-}  // namespace
-
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.TeukolskyWave", "[Unit][Cce]") {
   MAKE_GENERATOR(gen);
   UniformCustomDistribution<double> radius_dist{5.0, 10.0};
@@ -127,11 +24,12 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.TeukolskyWave", "[Unit][Cce]") {
   // use a low frequency so that the dimensionless parameter in the metric is ~1
   const double amplitude = parameter_dist(gen);
   const double duration = 1.0 + parameter_dist(gen);
-  TeukolskyWaveWrapper boundary_solution{extraction_radius, amplitude,
-                                         duration};
+  TestHelpers::SphericalSolutionWrapper<TeukolskyWave> boundary_solution{
+      extraction_radius, amplitude, duration};
   const double time = duration + extraction_radius + parameter_dist(gen);
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/Cce/AnalyticSolutions/"};
-  boundary_solution.test_spherical_metric(l_max, time);
+  boundary_solution.test_spherical_metric(
+      "TeukolskyWave", l_max, time, extraction_radius, amplitude, duration);
 }
 }  // namespace Cce::Solutions

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/AnalyticSolutions/CMakeLists.txt
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/AnalyticSolutions/CMakeLists.txt
@@ -14,5 +14,6 @@ target_link_libraries(
   PUBLIC
   Cce
   DataStructures
+  Framework
   Utilities
   )


### PR DESCRIPTION
## Proposed changes

Adds another analytic test to the CCE analytic test collection. Also refactors one of the CCE test tools to more easily write the pypp tests for this kind of analytic data class.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
