### PR TITLE
Factor MakeWithValue into size and creation parts

### DIFF
--- a/src/DataStructures/DenseVector.hpp
+++ b/src/DataStructures/DenseVector.hpp
@@ -59,13 +59,21 @@ class DenseVector : public blaze::DynamicVector<T, TF> {
 };
 
 namespace MakeWithValueImpls {
-template <bool TFOut, typename TIn, bool TFIn>
-struct MakeWithValueImpl<DenseVector<double, TFOut>, DenseVector<TIn, TFIn>> {
-  /// \brief Returns a `DenseVector` the same size as `input`, with each element
+template <bool TF>
+struct NumberOfPoints<DenseVector<double, TF>> {
+  static SPECTRE_ALWAYS_INLINE size_t
+  apply(const DenseVector<double, TF>& input) noexcept {
+    return input.size();
+  }
+};
+
+template <bool TF>
+struct MakeWithSize<DenseVector<double, TF>> {
+  /// \brief Returns a `DenseVector` with the given size, with each element
   /// equal to `value`.
-  static SPECTRE_ALWAYS_INLINE DenseVector<double, TFOut> apply(
-      const DenseVector<TIn, TFIn>& input, const double value) noexcept {
-    return DenseVector<double, TFOut>(input.size(), value);
+  static SPECTRE_ALWAYS_INLINE DenseVector<double, TF> apply(
+      const size_t size, const double value) noexcept {
+    return DenseVector<double, TF>(size, value);
   }
 };
 }  // namespace MakeWithValueImpls

--- a/src/DataStructures/SpinWeighted.hpp
+++ b/src/DataStructures/SpinWeighted.hpp
@@ -560,26 +560,21 @@ std::ostream& operator<<(std::ostream& os,
 }
 
 namespace MakeWithValueImpls {
-template <int Spin1, int Spin2, typename SpinWeightedType1,
-          typename SpinWeightedType2>
-struct MakeWithValueImpl<SpinWeighted<SpinWeightedType1, Spin1>,
-                         SpinWeighted<SpinWeightedType2, Spin2>> {
-  template <typename ValueType>
-  static SPECTRE_ALWAYS_INLINE SpinWeighted<SpinWeightedType1, Spin1> apply(
-      const SpinWeighted<SpinWeightedType2, Spin2>& input,
-      const ValueType value) noexcept {
-    return SpinWeighted<SpinWeightedType1, Spin1>{
-        make_with_value<SpinWeightedType1>(input.data(), value)};
+template <int Spin, typename SpinWeightedType>
+struct NumberOfPoints<SpinWeighted<SpinWeightedType, Spin>> {
+  static SPECTRE_ALWAYS_INLINE size_t
+  apply(const SpinWeighted<SpinWeightedType, Spin>& input) noexcept {
+    return number_of_points(input.data());
   }
 };
 
-template <int Spin, typename SpinWeightedType, typename MakeWithType>
-struct MakeWithValueImpl<SpinWeighted<SpinWeightedType, Spin>, MakeWithType> {
+template <int Spin, typename SpinWeightedType>
+struct MakeWithSize<SpinWeighted<SpinWeightedType, Spin>> {
   template <typename ValueType>
   static SPECTRE_ALWAYS_INLINE SpinWeighted<SpinWeightedType, Spin> apply(
-      const MakeWithType& input, const ValueType value) noexcept {
+      const size_t size, const ValueType value) noexcept {
     return SpinWeighted<SpinWeightedType, Spin>{
-        make_with_value<SpinWeightedType>(input, value)};
+        make_with_value<SpinWeightedType>(size, value)};
   }
 };
 }  // namespace MakeWithValueImpls

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -896,39 +896,19 @@ Variables<tmpl::list<Tags...>> variables_from_tagged_tuple(
 
 namespace MakeWithValueImpls {
 template <typename TagList>
-struct MakeWithValueImpl<Variables<TagList>,
-                         typename Variables<TagList>::vector_type> {
-  /// \brief Returns a Variables whose vectors are the same size as `input`,
-  /// with each element equal to `value`.
+struct MakeWithSize<Variables<TagList>> {
   static SPECTRE_ALWAYS_INLINE Variables<TagList> apply(
-      const typename Variables<TagList>::vector_type& input,
+      const size_t size,
       const typename Variables<TagList>::value_type value) noexcept {
-    return Variables<TagList>(input.size(), value);
+    return Variables<TagList>(size, value);
   }
 };
 
-template <typename TagList, typename... Structure>
-struct MakeWithValueImpl<
-    Variables<TagList>,
-    Tensor<typename Variables<TagList>::vector_type, Structure...>> {
-  /// \brief Returns a Variables whose DataVectors are the same size as `input`,
-  /// with each element equal to `value`.
-  static SPECTRE_ALWAYS_INLINE Variables<TagList> apply(
-      const Tensor<typename Variables<TagList>::vector_type, Structure...>&
-          input,
-      const typename Variables<TagList>::value_type value) noexcept {
-    return Variables<TagList>(input.begin()->size(), value);
-  }
-};
-
-template <typename TagListOut, typename TagListIn>
-struct MakeWithValueImpl<Variables<TagListOut>, Variables<TagListIn>> {
-  /// \brief Returns a Variables whose DataVectors are the same size as `input`,
-  /// with each element equal to `value`.
-  static SPECTRE_ALWAYS_INLINE Variables<TagListOut> apply(
-      const Variables<TagListIn>& input,
-      const typename Variables<TagListIn>::value_type value) noexcept {
-    return Variables<TagListOut>(input.number_of_grid_points(), value);
+template <typename TagList>
+struct NumberOfPoints<Variables<TagList>> {
+  static SPECTRE_ALWAYS_INLINE size_t
+  apply(const Variables<TagList>& input) noexcept {
+    return input.number_of_grid_points();
   }
 };
 }  // namespace MakeWithValueImpls

--- a/src/DataStructures/VectorImpl.hpp
+++ b/src/DataStructures/VectorImpl.hpp
@@ -522,15 +522,14 @@ std::ostream& operator<<(std::ostream& os,
 #define MAKE_WITH_VALUE_IMPL_DEFINITION_FOR(VECTOR_TYPE)                     \
   namespace MakeWithValueImpls {                                             \
   template <>                                                                \
-  struct MakeWithValueImpl<VECTOR_TYPE, VECTOR_TYPE> {                       \
-    static SPECTRE_ALWAYS_INLINE VECTOR_TYPE                                 \
-    apply(const VECTOR_TYPE& input,                                          \
-          const VECTOR_TYPE::value_type value) noexcept {                    \
-      return VECTOR_TYPE(input.size(), value);                               \
+  struct NumberOfPoints<VECTOR_TYPE> {                                       \
+    static SPECTRE_ALWAYS_INLINE size_t                                      \
+    apply(const VECTOR_TYPE& input) noexcept {                               \
+      return input.size();                                                   \
     }                                                                        \
   };                                                                         \
   template <>                                                                \
-  struct MakeWithValueImpl<VECTOR_TYPE, size_t> {                            \
+  struct MakeWithSize<VECTOR_TYPE> {                                         \
     static SPECTRE_ALWAYS_INLINE VECTOR_TYPE                                 \
     apply(const size_t size, const VECTOR_TYPE::value_type value) noexcept { \
       return VECTOR_TYPE(size, value);                                       \


### PR DESCRIPTION
The number of specializations of MakeWithValueImpl was becoming
unwieldy as the number of creatable types and types usable for size
increased.  The new default implementation splits the size
determination and the creation so separate specializations are not
needed for every pair of types.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
