### PR TITLE
Make size_of_element easier to use without moving mesh

### DIFF
--- a/src/Domain/SizeOfElement.cpp
+++ b/src/Domain/SizeOfElement.cpp
@@ -17,8 +17,7 @@
 #include "Utilities/StdArrayHelpers.hpp"  // IWYU pragma: keep
 
 template <size_t VolumeDim>
-void size_of_element(
-    const gsl::not_null<std::array<double, VolumeDim>*> result,
+std::array<double, VolumeDim> size_of_element(
     const ElementMap<VolumeDim, Frame::Grid>& logical_to_grid_map,
     const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, VolumeDim>&
         grid_to_inertial_map,
@@ -26,7 +25,7 @@ void size_of_element(
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) noexcept {
-  *result = make_array<VolumeDim>(0.0);
+  auto result = make_array<VolumeDim>(0.0);
   for (size_t logical_dim = 0; logical_dim < VolumeDim; ++logical_dim) {
     const auto face_center = [&functions_of_time, &grid_to_inertial_map,
                               &logical_dim, &logical_to_grid_map,
@@ -48,16 +47,16 @@ void size_of_element(
           upper_center.get(inertial_dim) - lower_center.get(inertial_dim);
     }
 
-    result->at(logical_dim) = magnitude(center_to_center);
+    result.at(logical_dim) = magnitude(center_to_center);
   }
+  return result;
 }
 
 // Explicit instantiations
 #define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATION(r, data)                                              \
-  template void size_of_element(                                            \
-      gsl::not_null<std::array<double, GET_DIM(data)>*> result,             \
+  template std::array<double, GET_DIM(data)> size_of_element(               \
       const ElementMap<GET_DIM(data), Frame::Grid>& logical_to_grid_map,    \
       const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial,         \
                                       GET_DIM(data)>& grid_to_inertial_map, \

--- a/src/Domain/SizeOfElement.cpp
+++ b/src/Domain/SizeOfElement.cpp
@@ -16,6 +16,49 @@
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/StdArrayHelpers.hpp"  // IWYU pragma: keep
 
+namespace {
+// The face-center coordinates for the unit cube's face in direction `dir`, so,
+// * in 1D, returns (-1), (1)
+// * in 2D, returns (-1, 0), (1, 0), (0, -1), (0, 1)
+// * in 3D, returns (-1, 0, 0), ..., (0, 0, 1)
+template <size_t VolumeDim>
+inline tnsr::I<double, VolumeDim, Frame::Logical> logical_face_center(
+    const Direction<VolumeDim>& dir) noexcept {
+  tnsr::I<double, VolumeDim, Frame::Logical> result{{{0.0}}};
+  result.get(dir.dimension()) = (dir.side() == Side::Lower ? -1.0 : 1.0);
+  return result;
+}
+
+template <size_t VolumeDim>
+inline double distance_between_face_centers(
+    const tnsr::I<double, VolumeDim, Frame::Inertial>& lower_center,
+    const tnsr::I<double, VolumeDim, Frame::Inertial>& upper_center) noexcept {
+  auto center_to_center = make_array<VolumeDim>(0.0);
+  alg::transform(upper_center, lower_center, center_to_center.begin(),
+                 std::minus<>{});
+  return magnitude(center_to_center);
+}
+}  // namespace
+
+template <size_t VolumeDim>
+std::array<double, VolumeDim> size_of_element(
+    const ElementMap<VolumeDim, Frame::Inertial>&
+        logical_to_inertial_map) noexcept {
+  auto result = make_array<VolumeDim>(0.0);
+  for (size_t logical_index = 0; logical_index < VolumeDim; ++logical_index) {
+    const auto inertial_face_center =
+        [&logical_index, &logical_to_inertial_map](const Side& side) noexcept {
+          const Direction<VolumeDim> dir(logical_index, side);
+          return logical_to_inertial_map(logical_face_center(dir));
+        };
+    const auto lower_center = inertial_face_center(Side::Lower);
+    const auto upper_center = inertial_face_center(Side::Upper);
+    result.at(logical_index) =
+        distance_between_face_centers(lower_center, upper_center);
+  }
+  return result;
+}
+
 template <size_t VolumeDim>
 std::array<double, VolumeDim> size_of_element(
     const ElementMap<VolumeDim, Frame::Grid>& logical_to_grid_map,
@@ -26,28 +69,19 @@ std::array<double, VolumeDim> size_of_element(
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) noexcept {
   auto result = make_array<VolumeDim>(0.0);
-  for (size_t logical_dim = 0; logical_dim < VolumeDim; ++logical_dim) {
-    const auto face_center = [&functions_of_time, &grid_to_inertial_map,
-                              &logical_dim, &logical_to_grid_map,
-                              time](const Side& side) noexcept {
-      tnsr::I<double, VolumeDim, Frame::Logical> logical_center{{{0.0}}};
-      logical_center.get(logical_dim) = (side == Side::Lower ? -1.0 : 1.0);
-      const tnsr::I<double, VolumeDim, Frame::Inertial> inertial_center =
-          grid_to_inertial_map(logical_to_grid_map(logical_center), time,
-                               functions_of_time);
-      return inertial_center;
+  for (size_t logical_index = 0; logical_index < VolumeDim; ++logical_index) {
+    const auto inertial_face_center = [&functions_of_time,
+                                       &grid_to_inertial_map, &logical_index,
+                                       &logical_to_grid_map,
+                                       time](const Side& side) noexcept {
+      const Direction<VolumeDim> dir(logical_index, side);
+      return grid_to_inertial_map(logical_to_grid_map(logical_face_center(dir)),
+                                  time, functions_of_time);
     };
-    const auto lower_center = face_center(Side::Lower);
-    const auto upper_center = face_center(Side::Upper);
-
-    // inertial-coord distance from lower face center to upper face center
-    auto center_to_center = make_array<VolumeDim>(0.0);
-    for (size_t inertial_dim = 0; inertial_dim < VolumeDim; ++inertial_dim) {
-      center_to_center.at(inertial_dim) =
-          upper_center.get(inertial_dim) - lower_center.get(inertial_dim);
-    }
-
-    result.at(logical_dim) = magnitude(center_to_center);
+    const auto lower_center = inertial_face_center(Side::Lower);
+    const auto upper_center = inertial_face_center(Side::Upper);
+    result.at(logical_index) =
+        distance_between_face_centers(lower_center, upper_center);
   }
   return result;
 }
@@ -56,6 +90,9 @@ std::array<double, VolumeDim> size_of_element(
 #define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATION(r, data)                                              \
+  template std::array<double, GET_DIM(data)> size_of_element(               \
+      const ElementMap<GET_DIM(data), Frame::Inertial>&                     \
+          logical_to_inertial_map) noexcept;                                \
   template std::array<double, GET_DIM(data)> size_of_element(               \
       const ElementMap<GET_DIM(data), Frame::Grid>& logical_to_grid_map,    \
       const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial,         \

--- a/src/Domain/SizeOfElement.hpp
+++ b/src/Domain/SizeOfElement.hpp
@@ -52,8 +52,7 @@ struct ElementMap;
  * not well represented by a `Tensor`, so we use a `std::array`.
  */
 template <size_t VolumeDim>
-void size_of_element(
-    gsl::not_null<std::array<double, VolumeDim>*> result,
+std::array<double, VolumeDim> size_of_element(
     const ElementMap<VolumeDim, Frame::Grid>& logical_to_grid_map,
     const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, VolumeDim>&
         grid_to_inertial_map,
@@ -84,15 +83,19 @@ struct SizeOfElementCompute : db::ComputeTag, SizeOfElement<VolumeDim> {
                  ::Tags::Time, domain::Tags::FunctionsOfTime>;
   using return_type = typename base::type;
 
-  static constexpr void (*function)(
+  static constexpr void function(
       gsl::not_null<std::array<double, VolumeDim>*> result,
-      const ::ElementMap<VolumeDim, Frame::Grid>&,
-      const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, VolumeDim>&,
-      const double,
+      const ::ElementMap<VolumeDim, Frame::Grid>& logical_to_grid_map,
+      const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, VolumeDim>&
+          grid_to_inertial_map,
+      const double time,
       const std::unordered_map<
           std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&) =
-      size_of_element<VolumeDim>;
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) noexcept {
+    *result = size_of_element(logical_to_grid_map, grid_to_inertial_map, time,
+                              functions_of_time);
+  }
 };
 }  // namespace Tags
 }  // namespace domain

--- a/src/Domain/SizeOfElement.hpp
+++ b/src/Domain/SizeOfElement.hpp
@@ -53,6 +53,11 @@ struct ElementMap;
  */
 template <size_t VolumeDim>
 std::array<double, VolumeDim> size_of_element(
+    const ElementMap<VolumeDim, Frame::Inertial>&
+        logical_to_inertial_map) noexcept;
+
+template <size_t VolumeDim>
+std::array<double, VolumeDim> size_of_element(
     const ElementMap<VolumeDim, Frame::Grid>& logical_to_grid_map,
     const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, VolumeDim>&
         grid_to_inertial_map,

--- a/tests/Unit/Domain/Test_SizeOfElement.cpp
+++ b/tests/Unit/Domain/Test_SizeOfElement.cpp
@@ -63,20 +63,19 @@ void test_1d(const std::array<double, 4>& times_to_check) noexcept {
       std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
       functions_of_time = make_single_expansion_functions_of_time();
 
-  const auto check_helper =
-      [&functions_of_time, &logical_to_grid_map,
-       &times_to_check](const auto& grid_to_inertial_map) noexcept {
-        std::array<double, 1> element_size{};
-        for (const double time : times_to_check) {
-          size_of_element(make_not_null(&element_size), logical_to_grid_map,
-                          grid_to_inertial_map, time, functions_of_time);
-          // for this affine map, expected size = width of block / number of
-          // elements
-          const auto expected_size_of_element =
-              make_array<1>(0.225 * (UseMovingMesh ? time : 1.0));
-          CHECK_ITERABLE_APPROX(element_size, expected_size_of_element);
-        }
-      };
+  const auto check_helper = [&functions_of_time, &logical_to_grid_map,
+                             &times_to_check](
+                                const auto& grid_to_inertial_map) noexcept {
+    for (const double time : times_to_check) {
+      const auto element_size = size_of_element(
+          logical_to_grid_map, grid_to_inertial_map, time, functions_of_time);
+      // for this affine map, expected size = width of block / number of
+      // elements
+      const auto expected_size_of_element =
+          make_array<1>(0.225 * (UseMovingMesh ? time : 1.0));
+      CHECK_ITERABLE_APPROX(element_size, expected_size_of_element);
+    }
+  };
 
   if (UseMovingMesh) {
     check_helper(domain::make_coordinate_map<Frame::Grid, Frame::Inertial>(
@@ -106,18 +105,17 @@ void test_2d(const std::array<double, 4>& times_to_check) noexcept {
       std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
       functions_of_time = make_single_expansion_functions_of_time();
 
-  const auto check_helper =
-      [&functions_of_time, &logical_to_grid_map,
-       &times_to_check](const auto& grid_to_inertial_map) noexcept {
-        std::array<double, 2> element_size{};
-        for (const double time : times_to_check) {
-          size_of_element(make_not_null(&element_size), logical_to_grid_map,
-                          grid_to_inertial_map, time, functions_of_time);
-          const auto expected_size_of_element =
-              make_array(0.05, 0.425) * (UseMovingMesh ? time : 1.0);
-          CHECK_ITERABLE_APPROX(element_size, expected_size_of_element);
-        }
-      };
+  const auto check_helper = [&functions_of_time, &logical_to_grid_map,
+                             &times_to_check](
+                                const auto& grid_to_inertial_map) noexcept {
+    for (const double time : times_to_check) {
+      const auto element_size = size_of_element(
+          logical_to_grid_map, grid_to_inertial_map, time, functions_of_time);
+      const auto expected_size_of_element =
+          make_array(0.05, 0.425) * (UseMovingMesh ? time : 1.0);
+      CHECK_ITERABLE_APPROX(element_size, expected_size_of_element);
+    }
+  };
 
   if (UseMovingMesh) {
     check_helper(domain::make_coordinate_map<Frame::Grid, Frame::Inertial>(
@@ -148,18 +146,17 @@ void test_3d(const std::array<double, 4>& times_to_check) noexcept {
       std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
       functions_of_time = make_single_expansion_functions_of_time();
 
-  const auto check_helper =
-      [&functions_of_time, &logical_to_grid_map,
-       &times_to_check](const auto& grid_to_inertial_map) noexcept {
-        std::array<double, 3> element_size{};
-        for (const double time : times_to_check) {
-          size_of_element(make_not_null(&element_size), logical_to_grid_map,
-                          grid_to_inertial_map, time, functions_of_time);
-          const auto expected_size_of_element =
-              make_array(0.0125, 0.85, 0.125) * (UseMovingMesh ? time : 1.0);
-          CHECK_ITERABLE_APPROX(element_size, expected_size_of_element);
-        }
-      };
+  const auto check_helper = [&functions_of_time, &logical_to_grid_map,
+                             &times_to_check](
+                                const auto& grid_to_inertial_map) noexcept {
+    for (const double time : times_to_check) {
+      const auto element_size = size_of_element(
+          logical_to_grid_map, grid_to_inertial_map, time, functions_of_time);
+      const auto expected_size_of_element =
+          make_array(0.0125, 0.85, 0.125) * (UseMovingMesh ? time : 1.0);
+      CHECK_ITERABLE_APPROX(element_size, expected_size_of_element);
+    }
+  };
 
   if (UseMovingMesh) {
     check_helper(domain::make_coordinate_map<Frame::Grid, Frame::Inertial>(

--- a/tests/Unit/Domain/Test_SizeOfElement.cpp
+++ b/tests/Unit/Domain/Test_SizeOfElement.cpp
@@ -33,6 +33,50 @@
 #include "Utilities/TMPL.hpp"
 
 namespace {
+void test_1d() noexcept {
+  INFO("1d");
+  auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      domain::CoordinateMaps::Affine(-1.0, 1.0, 0.3, 1.2));
+  const ElementId<1> element_id(0, {{{2, 3}}});
+  const ElementMap<1, Frame::Inertial> element_map(element_id, std::move(map));
+  const auto size = size_of_element(element_map);
+  // for this affine map, expected size = width of block / number of elements
+  const auto size_expected = make_array<1>(0.225);
+  CHECK_ITERABLE_APPROX(size, size_expected);
+}
+
+void test_2d() noexcept {
+  INFO("2d");
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+  auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      Affine2D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.2)},
+      domain::CoordinateMaps::DiscreteRotation<2>(
+          OrientationMap<2>{std::array<Direction<2>, 2>{
+              {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}}));
+  const ElementId<2> element_id(0, {{{1, 1}, {2, 0}}});
+  const ElementMap<2, Frame::Inertial> element_map(element_id, std::move(map));
+  const auto size = size_of_element(element_map);
+  const auto size_expected = make_array(0.05, 0.425);
+  CHECK_ITERABLE_APPROX(size, size_expected);
+}
+
+void test_3d() noexcept {
+  INFO("3d");
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine3D =
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+      Affine3D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.2),
+               Affine(-1.0, 1.0, 12.0, 12.5)},
+      domain::CoordinateMaps::Rotation<3>(0.7, 2.3, -0.4));
+  const ElementId<3> element_id(0, {{{3, 5}, {1, 0}, {2, 3}}});
+  const ElementMap<3, Frame::Inertial> element_map(element_id, std::move(map));
+  const auto size = size_of_element(element_map);
+  const auto size_expected = make_array(0.0125, 0.85, 0.125);
+  CHECK_ITERABLE_APPROX(size, size_expected);
+}
+
 template <size_t Dim>
 using CubicScale = domain::CoordinateMaps::TimeDependent::CubicScale<Dim>;
 
@@ -50,46 +94,32 @@ make_single_expansion_functions_of_time() noexcept {
   return functions_of_time;
 }
 
-template <bool UseMovingMesh>
-void test_1d(const std::array<double, 4>& times_to_check) noexcept {
-  INFO("1d");
+void test_1d_moving_mesh(const std::array<double, 4>& times_to_check) noexcept {
+  INFO("1d with moving mesh");
   auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
       domain::CoordinateMaps::Affine(-1.0, 1.0, 0.3, 1.2));
-  const ElementId<1> element_id(0,
-                                std::array<SegmentId, 1>({{SegmentId(2, 3)}}));
+  const ElementId<1> element_id(0, {{{2, 3}}});
   const ElementMap<1, Frame::Grid> logical_to_grid_map(element_id,
                                                        std::move(map));
+  const auto grid_to_inertial_map =
+      domain::make_coordinate_map<Frame::Grid, Frame::Inertial>(
+          CubicScale<1>{10.0, "Expansion", "Expansion"});
   const std::unordered_map<
       std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
       functions_of_time = make_single_expansion_functions_of_time();
 
-  const auto check_helper = [&functions_of_time, &logical_to_grid_map,
-                             &times_to_check](
-                                const auto& grid_to_inertial_map) noexcept {
-    for (const double time : times_to_check) {
-      const auto element_size = size_of_element(
-          logical_to_grid_map, grid_to_inertial_map, time, functions_of_time);
-      // for this affine map, expected size = width of block / number of
-      // elements
-      const auto expected_size_of_element =
-          make_array<1>(0.225 * (UseMovingMesh ? time : 1.0));
-      CHECK_ITERABLE_APPROX(element_size, expected_size_of_element);
-    }
-  };
-
-  if (UseMovingMesh) {
-    check_helper(domain::make_coordinate_map<Frame::Grid, Frame::Inertial>(
-        CubicScale<1>{10.0, "Expansion", "Expansion"}));
-
-  } else {
-    check_helper(domain::make_coordinate_map<Frame::Grid, Frame::Inertial>(
-        domain::CoordinateMaps::Identity<1>{}));
+  for (const double time : times_to_check) {
+    const auto element_size = size_of_element(
+        logical_to_grid_map, grid_to_inertial_map, time, functions_of_time);
+    // for this affine map, expected size = width of block / number of
+    // elements
+    const auto expected_size_of_element = make_array<1>(0.225 * time);
+    CHECK_ITERABLE_APPROX(element_size, expected_size_of_element);
   }
 }
 
-template <bool UseMovingMesh>
-void test_2d(const std::array<double, 4>& times_to_check) noexcept {
-  INFO("2d");
+void test_2d_moving_mesh(const std::array<double, 4>& times_to_check) noexcept {
+  INFO("2d with moving mesh");
   using Affine = domain::CoordinateMaps::Affine;
   using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
   auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
@@ -97,39 +127,26 @@ void test_2d(const std::array<double, 4>& times_to_check) noexcept {
       domain::CoordinateMaps::DiscreteRotation<2>(
           OrientationMap<2>{std::array<Direction<2>, 2>{
               {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}}));
-  const ElementId<2> element_id(
-      0, std::array<SegmentId, 2>({{SegmentId(1, 1), SegmentId(2, 0)}}));
+  const ElementId<2> element_id(0, {{{1, 1}, {2, 0}}});
   const ElementMap<2, Frame::Grid> logical_to_grid_map(element_id,
                                                        std::move(map));
+  const auto grid_to_inertial_map =
+      domain::make_coordinate_map<Frame::Grid, Frame::Inertial>(
+          CubicScale<2>{10.0, "Expansion", "Expansion"});
   const std::unordered_map<
       std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
       functions_of_time = make_single_expansion_functions_of_time();
 
-  const auto check_helper = [&functions_of_time, &logical_to_grid_map,
-                             &times_to_check](
-                                const auto& grid_to_inertial_map) noexcept {
-    for (const double time : times_to_check) {
-      const auto element_size = size_of_element(
-          logical_to_grid_map, grid_to_inertial_map, time, functions_of_time);
-      const auto expected_size_of_element =
-          make_array(0.05, 0.425) * (UseMovingMesh ? time : 1.0);
-      CHECK_ITERABLE_APPROX(element_size, expected_size_of_element);
-    }
-  };
-
-  if (UseMovingMesh) {
-    check_helper(domain::make_coordinate_map<Frame::Grid, Frame::Inertial>(
-        CubicScale<2>{10.0, "Expansion", "Expansion"}));
-
-  } else {
-    check_helper(domain::make_coordinate_map<Frame::Grid, Frame::Inertial>(
-        domain::CoordinateMaps::Identity<2>{}));
+  for (const double time : times_to_check) {
+    const auto element_size = size_of_element(
+        logical_to_grid_map, grid_to_inertial_map, time, functions_of_time);
+    const auto expected_size_of_element = make_array(0.05, 0.425) * time;
+    CHECK_ITERABLE_APPROX(element_size, expected_size_of_element);
   }
 }
 
-template <bool UseMovingMesh>
-void test_3d(const std::array<double, 4>& times_to_check) noexcept {
-  INFO("3d");
+void test_3d_moving_mesh(const std::array<double, 4>& times_to_check) noexcept {
+  INFO("3d with moving mesh");
   using Affine = domain::CoordinateMaps::Affine;
   using Affine3D =
       domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
@@ -137,40 +154,27 @@ void test_3d(const std::array<double, 4>& times_to_check) noexcept {
       Affine3D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.2),
                Affine(-1.0, 1.0, 12.0, 12.5)},
       domain::CoordinateMaps::Rotation<3>(0.7, 2.3, -0.4));
-  const ElementId<3> element_id(
-      0, std::array<SegmentId, 3>(
-             {{SegmentId(3, 5), SegmentId(1, 0), SegmentId(2, 3)}}));
+  const ElementId<3> element_id(0, {{{3, 5}, {1, 0}, {2, 3}}});
   const ElementMap<3, Frame::Grid> logical_to_grid_map(element_id,
                                                        std::move(map));
+  const auto grid_to_inertial_map =
+      domain::make_coordinate_map<Frame::Grid, Frame::Inertial>(
+          CubicScale<3>{10.0, "Expansion", "Expansion"});
   const std::unordered_map<
       std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
       functions_of_time = make_single_expansion_functions_of_time();
 
-  const auto check_helper = [&functions_of_time, &logical_to_grid_map,
-                             &times_to_check](
-                                const auto& grid_to_inertial_map) noexcept {
-    for (const double time : times_to_check) {
-      const auto element_size = size_of_element(
-          logical_to_grid_map, grid_to_inertial_map, time, functions_of_time);
-      const auto expected_size_of_element =
-          make_array(0.0125, 0.85, 0.125) * (UseMovingMesh ? time : 1.0);
-      CHECK_ITERABLE_APPROX(element_size, expected_size_of_element);
-    }
-  };
-
-  if (UseMovingMesh) {
-    check_helper(domain::make_coordinate_map<Frame::Grid, Frame::Inertial>(
-        CubicScale<3>{10.0, "Expansion", "Expansion"}));
-
-  } else {
-    check_helper(domain::make_coordinate_map<Frame::Grid, Frame::Inertial>(
-        domain::CoordinateMaps::Identity<3>{}));
+  for (const double time : times_to_check) {
+    const auto element_size = size_of_element(
+        logical_to_grid_map, grid_to_inertial_map, time, functions_of_time);
+    const auto expected_size_of_element =
+        make_array(0.0125, 0.85, 0.125) * time;
+    CHECK_ITERABLE_APPROX(element_size, expected_size_of_element);
   }
 }
 
-template <bool UseMovingMesh>
 void test_compute_tag(const std::array<double, 4>& times_to_check) noexcept {
-  INFO("compute tag");
+  INFO("compute tag in 2d, with moving mesh");
   using Affine = domain::CoordinateMaps::Affine;
   using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
   auto map = domain::make_coordinate_map_base<Frame::Logical, Frame::Grid>(
@@ -178,21 +182,11 @@ void test_compute_tag(const std::array<double, 4>& times_to_check) noexcept {
       domain::CoordinateMaps::DiscreteRotation<2>(
           OrientationMap<2>{std::array<Direction<2>, 2>{
               {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}}));
-  const ElementId<2> element_id(
-      0, std::array<SegmentId, 2>({{SegmentId(1, 1), SegmentId(2, 0)}}));
+  const ElementId<2> element_id(0, {{{1, 1}, {2, 0}}});
   ElementMap<2, Frame::Grid> logical_to_grid_map(element_id, std::move(map));
-  std::unique_ptr<domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, 2>>
-      grid_to_inertial_map = nullptr;
-  if (UseMovingMesh) {
-    grid_to_inertial_map =
-        domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
-            CubicScale<2>{10.0, "Expansion", "Expansion"});
-  } else {
-    grid_to_inertial_map =
-        domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
-            domain::CoordinateMaps::Identity<2>{});
-  }
-
+  auto grid_to_inertial_map =
+      domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+          CubicScale<2>{10.0, "Expansion", "Expansion"});
   std::unordered_map<std::string,
                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
       functions_of_time = make_single_expansion_functions_of_time();
@@ -212,8 +206,7 @@ void test_compute_tag(const std::array<double, 4>& times_to_check) noexcept {
         [time](const gsl::not_null<double*> time_ptr) noexcept {
           *time_ptr = time;
         });
-    const auto expected_size_of_element =
-        make_array(0.05, 0.425) * (UseMovingMesh ? time : 1.0);
+    const auto expected_size_of_element = make_array(0.05, 0.425) * time;
     CHECK_ITERABLE_APPROX(db::get<domain::Tags::SizeOfElement<2>>(box),
                           expected_size_of_element);
   }
@@ -221,15 +214,13 @@ void test_compute_tag(const std::array<double, 4>& times_to_check) noexcept {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.SizeOfElement", "[Domain][Unit]") {
+  test_1d();
+  test_2d();
+  test_3d();
+
   const std::array<double, 4> times_to_check{{0.0, 0.3, 1.1, 7.8}};
-
-  test_1d<false>(times_to_check);
-  test_2d<false>(times_to_check);
-  test_3d<false>(times_to_check);
-  test_compute_tag<false>(times_to_check);
-
-  test_1d<true>(times_to_check);
-  test_2d<true>(times_to_check);
-  test_3d<true>(times_to_check);
-  test_compute_tag<true>(times_to_check);
+  test_1d_moving_mesh(times_to_check);
+  test_2d_moving_mesh(times_to_check);
+  test_3d_moving_mesh(times_to_check);
+  test_compute_tag(times_to_check);
 }


### PR DESCRIPTION
## Proposed changes

- Fixes a clang-tidy complaint in tensor structure
- Makes `size_of_element` easier to use without moving mesh, by reintroducing an overload with a simple interface. The tests are also simplified.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
