### PR TITLE
Add k, K, l, and L TensorIndex types

### DIFF
--- a/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
@@ -75,6 +75,10 @@ static TensorIndex<8> ti_i{};
 static TensorIndex<8> ti_I{};
 static TensorIndex<9> ti_j{};
 static TensorIndex<9> ti_J{};
+static TensorIndex<10> ti_k{};
+static TensorIndex<10> ti_K{};
+static TensorIndex<11> ti_l{};
+static TensorIndex<11> ti_L{};
 
 using ti_a_t = decltype(ti_a);
 using ti_A_t = decltype(ti_A);
@@ -96,6 +100,10 @@ using ti_i_t = decltype(ti_i);
 using ti_I_t = decltype(ti_I);
 using ti_j_t = decltype(ti_j);
 using ti_J_t = decltype(ti_J);
+using ti_k_t = decltype(ti_k);
+using ti_K_t = decltype(ti_K);
+using ti_l_t = decltype(ti_l);
+using ti_L_t = decltype(ti_L);
 // @}
 
 /// \cond HIDDEN_SYMBOLS


### PR DESCRIPTION
## Proposed changes

SpECTRE uses generic indices a/A, b/B, c/C, and d/D to refer to spacetime indices, and generic indices i/I, j/J, k/K, and l/L to refer to spatial indices, as noted [here](https://github.com/sxs-collaboration/spectre/blob/11b5bef1bad1db883fc0a0330384557437e24cb3/src/DataStructures/Tensor/TypeAliases.hpp#L27).  Currently, `TensorExpression`s only have two spatial indices to work with, based on this convention: i/I and j/J. This PR adds two additional `TensorIndex` types to get two more spatial indices with `TensorExpressions`: k/K and l/L.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
