### PR TITLE
Fix TensorExpression and AddSub get for scalars

### DIFF
--- a/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
+++ b/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
@@ -78,8 +78,7 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
   using symmetry = tmpl::transform<typename T1::symmetry, typename T2::symmetry,
                                    tmpl::append<tmpl::max<tmpl::_1, tmpl::_2>>>;
   using index_list = typename T1::index_list;
-  static constexpr auto num_tensor_indices =
-      tmpl::size<index_list>::value == 0 ? 1 : tmpl::size<index_list>::value;
+  static constexpr auto num_tensor_indices = tmpl::size<index_list>::value;
   using args_list = tmpl::sort<typename T1::args_list>;
 
   AddSub(T1 t1, T2 t2) : t1_(std::move(t1)), t2_(std::move(t2)) {}

--- a/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
@@ -310,8 +310,7 @@ struct TensorExpression<Derived, DataType, Symm, IndexList, ArgsList<Args...>>
   using type = DataType;
   using symmetry = Symm;
   using index_list = IndexList;
-  static constexpr auto num_tensor_indices =
-      tmpl::size<index_list>::value == 0 ? 1 : tmpl::size<index_list>::value;
+  static constexpr auto num_tensor_indices = tmpl::size<index_list>::value;
   /// Typelist of the tensor indices, e.g. `_a_t` and `_b_t` in `F(_a, _b)`
   using args_list = ArgsList<Args...>;
 

--- a/src/DataStructures/Tensor/Structure.hpp
+++ b/src/DataStructures/Tensor/Structure.hpp
@@ -40,8 +40,8 @@ constexpr size_t number_of_independent_components(
     for (size_t i = 0; i < Size; ++i) {
       // clang-tidy: internal STL and gls::at (don't need it in constexpr)
       assert(symm[i] > 0);  // NOLINT
-      max_element = std::max(static_cast<size_t>(ce_abs(symm[i])),
-                             max_element);  // NOLINT
+      max_element = std::max(static_cast<size_t>(ce_abs(symm[i])),  // NOLINT
+                             max_element);
     }
     assert(max_element > 0);  // NOLINT
     size_t total_independent_components = 1;

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_TensorExpressions.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_TensorExpressions.cpp
@@ -15,6 +15,13 @@
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
                   "[DataStructures][Unit]") {
+  // Test adding scalars
+  const Tensor<double> scalar_1{{{2.1}}};
+  const Tensor<double> scalar_2{{{-0.8}}};
+  Tensor<double> lhs_scalar =
+      TensorExpressions::evaluate(scalar_1() + scalar_2());
+  CHECK(lhs_scalar.get() == 1.3);
+
   Tensor<double, Symmetry<1, 1>,
          index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
                     SpatialIndex<3, UpLo::Lo, Frame::Grid>>>


### PR DESCRIPTION
## Proposed changes

This PR fixes `TensorExpression::get` and `AddSub::get` to handle evaluating scalars and the addition of scalars. The bug that currently exists is a result of the canonical tensor multi-index of a rank 0 `Tensor` being defined as an empty array (representing 0 indices), while the number of indices of a rank 0 tensor represented by a `TensorExpression` or `AddSub` is defined as 1. Specifically, this PR updates the latter to be defined as 0 instead of 1 in order to be consistent with the former.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments
Currently, the following type of evaluation generates a compile error, given that `A` and `B` are each a rank 0 `Tensor` of `double`s:
```
Tensor<double> C = TensorExpressions::evaluate(A() + B());
```
The argument given to `evaluate` in this call is an `AddSub` containing two `TensorExpression`s representing `A` and `B`. Within `evaluate`, a LHS `Tensor` is constructed. This `Tensor` constructor calls `TensorExpression::get` ([see call here](https://github.com/sxs-collaboration/spectre/blob/33f6bc1f9de88e95f4314a1e014f665dd1459299/src/DataStructures/Tensor/Tensor.hpp#L155)), which takes the canonical tensor multi-index of a storage index as an argument ([see definition here](https://github.com/sxs-collaboration/spectre/blob/33f6bc1f9de88e95f4314a1e014f665dd1459299/src/DataStructures/Tensor/Expressions/TensorExpression.hpp#L414)). The argument, `tensor_index`, as defined should be an array with size equal to `num_tensor_indices`, which is defined to be 1 if the `TensorExpression` contains a pointer to a rank 0 tensor ([see definition here](https://github.com/sxs-collaboration/spectre/blob/33f6bc1f9de88e95f4314a1e014f665dd1459299/src/DataStructures/Tensor/Expressions/TensorExpression.hpp#L313)). However, in the call to `TensorExpression::get` within the `Tensor` constructor, the argument passed in is an empty array, since `Structure::get_canonical_tensor_index` will return an empty array for a rank 0 `Tensor` ([see here](https://github.com/sxs-collaboration/spectre/blob/33f6bc1f9de88e95f4314a1e014f665dd1459299/src/DataStructures/Tensor/Structure.hpp#L411)).

Because `TensorExpression::num_tensor_indices` is defined as 1 for rank 0 tensors, but `Structure::get_canonical_tensor_index` returns a size 0 array, the above example evaluation of scalars cannot be performed. This PR updates `num_tensor_indices` to be 0 for rank 0 tensors to resolve this inconsistency and support this type of evaluation. The test added to `Test_TensorExpressions.cpp` demonstrates this functionality working correctly.

#### Relevant aside
Soon, I plan on submitting a PR that adds a `TensorExpression::get` and `AddSub::get` that take storage indices as arguments as opposed to tensor multi-indices as arguments, and will accordingly update `TensorExpressions::evaluate` to use this storage index `TensorExpression::get`, instead of the current multi-index version. With this change, the problem presented here is not encountered. However, regardless of potential plans for `evaluate,` it still remains that the current implementation of this multi-index `TensorExpression::get` and `AddSub::get` don't work with this rank 0 `Tensor` case.