### PR TITLE
Remove Burgers du_dt function

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Bump.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Bump.cpp
@@ -34,34 +34,10 @@ Scalar<T> Bump::u(const tnsr::I<T, 1>& x, double t) const noexcept {
                    (height_ - center_distance * reduced_peak_distance * denom));
 }
 
-template <typename T>
-Scalar<T> Bump::du_dt(const tnsr::I<T, 1>& x, double t) const noexcept {
-  const T center_distance = get<0>(x) - center_;
-  // Distance from the current peak location divided by the half width
-  // and the time the shock reaches the solution zero.
-  const T reduced_peak_distance =
-      2. * height_ / square(half_width_) * (center_distance - height_ * t);
-
-  const T denom = 1. / (1. + sqrt(1. - 2. * t * reduced_peak_distance));
-
-  return Scalar<T>(4. * square(height_ / half_width_) * square(denom) *
-                   (denom / (1. - denom) *
-                        (center_distance - 2. * height_ * t) *
-                        (1 - 2. / height_ * denom * center_distance *
-                                 reduced_peak_distance) +
-                    center_distance));
-}
-
 tuples::TaggedTuple<Tags::U> Bump::variables(
     const tnsr::I<DataVector, 1>& x, double t,
     tmpl::list<Tags::U> /*meta*/) const noexcept {
   return {u(x, t)};
-}
-
-tuples::TaggedTuple<::Tags::dt<Tags::U>> Bump::variables(
-    const tnsr::I<DataVector, 1>& x, double t,
-    tmpl::list<::Tags::dt<Tags::U>> /*meta*/) const noexcept {
-  return {du_dt(x, t)};
 }
 
 void Bump::pup(PUP::er& p) noexcept {
@@ -77,8 +53,6 @@ void Bump::pup(PUP::er& p) noexcept {
 
 #define INSTANTIATE(_, data)                                      \
   template Scalar<DTYPE(data)> Burgers::Solutions::Bump::u(       \
-      const tnsr::I<DTYPE(data), 1>& x, double t) const noexcept; \
-  template Scalar<DTYPE(data)> Burgers::Solutions::Bump::du_dt(   \
       const tnsr::I<DTYPE(data), 1>& x, double t) const noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Bump.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Bump.cpp
@@ -13,8 +13,7 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-namespace Burgers {
-namespace Solutions {
+namespace Burgers::Solutions {
 
 Bump::Bump(const double half_width, const double height,
            const double center) noexcept
@@ -46,8 +45,7 @@ void Bump::pup(PUP::er& p) noexcept {
   p | center_;
 }
 
-}  // namespace Solutions
-}  // namespace Burgers
+}  // namespace Burgers::Solutions
 
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Bump.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Bump.hpp
@@ -70,16 +70,9 @@ class Bump : public MarkAsAnalyticSolution {
   template <typename T>
   Scalar<T> u(const tnsr::I<T, 1>& x, double t) const noexcept;
 
-  template <typename T>
-  Scalar<T> du_dt(const tnsr::I<T, 1>& x, double t) const noexcept;
-
   tuples::TaggedTuple<Tags::U> variables(
       const tnsr::I<DataVector, 1>& x, double t,
       tmpl::list<Tags::U> /*meta*/) const noexcept;
-
-  tuples::TaggedTuple<::Tags::dt<Burgers::Tags::U>> variables(
-      const tnsr::I<DataVector, 1>& x, double t,
-      tmpl::list<::Tags::dt<Tags::U>> /*meta*/) const noexcept;
 
   // clang-tidy: no pass by reference
   void pup(PUP::er& p) noexcept;  // NOLINT

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Linear.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Linear.cpp
@@ -24,23 +24,10 @@ Scalar<T> Linear::u(const tnsr::I<T, 1>& x, double t) const noexcept {
   return result;
 }
 
-template <typename T>
-Scalar<T> Linear::du_dt(const tnsr::I<T, 1>& x, double t) const noexcept {
-  Scalar<T> result(get<0>(x));
-  get(result) /= -square(t - shock_time_);
-  return result;
-}
-
 tuples::TaggedTuple<Tags::U> Linear::variables(
     const tnsr::I<DataVector, 1>& x, double t,
     tmpl::list<Tags::U> /*meta*/) const noexcept {
   return {u(x, t)};
-}
-
-tuples::TaggedTuple<::Tags::dt<Tags::U>> Linear::variables(
-    const tnsr::I<DataVector, 1>& x, double t,
-    tmpl::list<::Tags::dt<Tags::U>> /*meta*/) const noexcept {
-  return {du_dt(x, t)};
 }
 
 void Linear::pup(PUP::er& p) noexcept { p | shock_time_; }
@@ -52,8 +39,6 @@ void Linear::pup(PUP::er& p) noexcept { p | shock_time_; }
 
 #define INSTANTIATE(_, data)                                      \
   template Scalar<DTYPE(data)> Burgers::Solutions::Linear::u(     \
-      const tnsr::I<DTYPE(data), 1>& x, double t) const noexcept; \
-  template Scalar<DTYPE(data)> Burgers::Solutions::Linear::du_dt( \
       const tnsr::I<DTYPE(data), 1>& x, double t) const noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Linear.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Linear.cpp
@@ -12,8 +12,7 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-namespace Burgers {
-namespace Solutions {
+namespace Burgers::Solutions {
 
 Linear::Linear(const double shock_time) noexcept : shock_time_(shock_time) {}
 
@@ -32,8 +31,7 @@ tuples::TaggedTuple<Tags::U> Linear::variables(
 
 void Linear::pup(PUP::er& p) noexcept { p | shock_time_; }
 
-}  // namespace Solutions
-}  // namespace Burgers
+}  // namespace Burgers::Solutions
 
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Linear.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Linear.hpp
@@ -48,16 +48,9 @@ class Linear : public MarkAsAnalyticSolution {
   template <typename T>
   Scalar<T> u(const tnsr::I<T, 1>& x, double t) const noexcept;
 
-  template <typename T>
-  Scalar<T> du_dt(const tnsr::I<T, 1>& x, double t) const noexcept;
-
   tuples::TaggedTuple<Tags::U> variables(
       const tnsr::I<DataVector, 1>& x, double t,
       tmpl::list<Tags::U> /*meta*/) const noexcept;
-
-  tuples::TaggedTuple<::Tags::dt<Tags::U>> variables(
-      const tnsr::I<DataVector, 1>& x, double t,
-      tmpl::list<::Tags::dt<Tags::U>> /*meta*/) const noexcept;
 
   // clang-tidy: no pass by reference
   void pup(PUP::er& p) noexcept;  // NOLINT

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Step.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Step.cpp
@@ -35,23 +35,11 @@ Scalar<T> Step::u(const tnsr::I<T, 1>& x, const double t) const noexcept {
                        step_function(get<0>(x) - current_shock_position));
 }
 
-template <typename T>
-Scalar<T> Step::du_dt(const tnsr::I<T, 1>& x, const double /*t*/) const
-    noexcept {
-  return make_with_value<Scalar<T>>(x, 0.0);
-}
-
 tuples::TaggedTuple<Tags::U> Step::variables(const tnsr::I<DataVector, 1>& x,
                                              const double t,
                                              tmpl::list<Tags::U> /*meta*/) const
     noexcept {
   return {u(x, t)};
-}
-
-tuples::TaggedTuple<::Tags::dt<Tags::U>> Step::variables(
-    const tnsr::I<DataVector, 1>& x, const double t,
-    tmpl::list<::Tags::dt<Tags::U>> /*meta*/) const noexcept {
-  return {du_dt(x, t)};
 }
 
 void Step::pup(PUP::er& p) noexcept {
@@ -67,8 +55,6 @@ void Step::pup(PUP::er& p) noexcept {
 
 #define INSTANTIATE(_, data)                                      \
   template Scalar<DTYPE(data)> Burgers::Solutions::Step::u(       \
-      const tnsr::I<DTYPE(data), 1>& x, double t) const noexcept; \
-  template Scalar<DTYPE(data)> Burgers::Solutions::Step::du_dt(   \
       const tnsr::I<DTYPE(data), 1>& x, double t) const noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Step.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Step.cpp
@@ -13,8 +13,7 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-namespace Burgers {
-namespace Solutions {
+namespace Burgers::Solutions {
 
 Step::Step(const double left_value, const double right_value,
            const double initial_shock_position, const OptionContext& context)
@@ -48,8 +47,7 @@ void Step::pup(PUP::er& p) noexcept {
   p | initial_shock_position_;
 }
 
-}  // namespace Solutions
-}  // namespace Burgers
+}  // namespace Burgers::Solutions
 
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Step.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Step.hpp
@@ -34,8 +34,6 @@ namespace Solutions {
 ///
 /// \note At the shock, where \f$x = x_0 + vt\f$, we have \f$U(x, t) = U_L\f$.
 /// (This is inherited from the Heaviside implementation `step_function`.)
-/// Additionally, the time derivative \f$\partial_t u0\f$ is zero, rather than
-/// the correct delta function.
 class Step : public MarkAsAnalyticSolution {
  public:
   struct LeftValue {
@@ -71,17 +69,10 @@ class Step : public MarkAsAnalyticSolution {
   template <typename T>
   Scalar<T> u(const tnsr::I<T, 1>& x, double t) const noexcept;
 
-  template <typename T>
-  Scalar<T> du_dt(const tnsr::I<T, 1>& x, double t) const noexcept;
-
   tuples::TaggedTuple<Tags::U> variables(const tnsr::I<DataVector, 1>& x,
                                          double t,
                                          tmpl::list<Tags::U> /*meta*/) const
       noexcept;
-
-  tuples::TaggedTuple<::Tags::dt<Tags::U>> variables(
-      const tnsr::I<DataVector, 1>& x, double t,
-      tmpl::list<::Tags::dt<Tags::U>> /*meta*/) const noexcept;
 
   // clang-tidy: no pass by reference
   void pup(PUP::er& p) noexcept;  // NOLINT

--- a/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/Burgers/CheckBurgersSolution.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/Burgers/CheckBurgersSolution.hpp
@@ -34,41 +34,16 @@ void check_burgers_solution(const Solution& solution,
                             const std::vector<double>& times) noexcept {
   static_assert(evolution::is_analytic_solution_v<Solution>,
                 "Solution was not derived from AnalyticSolution");
-  // Check that different functions are consistent.
+  // Check that DataVector and double functions are consistent.
   const tnsr::I<DataVector, 1> positions_tnsr{{{positions}}};
   for (const double time : times) {
     const auto value = solution.u(positions_tnsr, time);
-    const auto time_deriv = solution.du_dt(positions_tnsr, time);
     CHECK(get<Burgers::Tags::U>(solution.variables(
               positions_tnsr, time, tmpl::list<Burgers::Tags::U>{})) == value);
-    CHECK(get<Tags::dt<Burgers::Tags::U>>(solution.variables(
-              positions_tnsr, time,
-              tmpl::list<Tags::dt<Burgers::Tags::U>>{})) ==
-          time_deriv);
     for (size_t point = 0; point < positions.size(); ++point) {
       const tnsr::I<double, 1> xp{{{positions[point]}}};
       const double up = get(value)[point];
-      const double dtup = get(time_deriv)[point];
       CHECK(get(solution.u(xp, time)) == approx(up));
-      CHECK(get(solution.du_dt(xp, time)) == approx(dtup));
-      // Check that the time derivative is the derivative of the
-      // value.
-      CHECK(numerical_derivative(
-                [&solution, &xp](const std::array<double, 1>& t) noexcept {
-                  return std::array<double, 1>{{get(solution.u(xp, t[0]))}};
-                },
-                std::array<double, 1>{{time}}, 0, 1e-4)[0] ==
-            approx.epsilon(1e-10)(dtup));
-      // Check that the Burgers equation is satisfied.
-      CHECK(numerical_derivative([&solution, &time](
-                                     const std::array<double, 1>& x) noexcept {
-              tnsr::I<DataVector, 1> flux{{{DataVector(1)}}};
-              Burgers::Fluxes::apply(
-                  &flux, solution.u(tnsr::I<DataVector, 1>{{{{x[0]}}}}, time));
-              return std::array<double, 1>{{get<0>(flux)[0]}};
-            },
-                                 std::array<double, 1>{{get<0>(xp)}}, 0,
-                                 1e-4)[0] == approx(-dtup));
     }
   }
 }


### PR DESCRIPTION
## Proposed changes

Removes du_dt from Burgers system, as per #1060

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

