### PR TITLE
Use C++17 features in option parsing code

### DIFF
--- a/src/Options/OptionsDetails.hpp
+++ b/src/Options/OptionsDetails.hpp
@@ -382,9 +382,10 @@ struct wrap_create_types_impl<std::map<K, V>> {
     using UnwrappedK = decltype(unwrap_create_types<K>(std::declval<K>()));
     using UnwrappedV = decltype(unwrap_create_types<V>(std::declval<V>()));
     std::map<UnwrappedK, UnwrappedV> result;
-    for (auto& w : wrapped) {
-      result.emplace(unwrap_create_types<K>(std::move(w.first)),
-                     unwrap_create_types<V>(std::move(w.second)));
+    for (auto it = wrapped.begin(); it != wrapped.end();) {
+      auto node = wrapped.extract(it++);
+      result.emplace(unwrap_create_types<K>(std::move(node.key())),
+                     unwrap_create_types<V>(std::move(node.mapped())));
     }
     return result;
   }

--- a/tests/Unit/Options/Test_Options.cpp
+++ b/tests/Unit/Options/Test_Options.cpp
@@ -766,6 +766,21 @@ struct FormatUnorderedMap {
   static constexpr const char* const expected = "{[int x0]: [double x0]}";
 };
 
+struct ScalarWithLimits {
+  using type = int;
+  static constexpr OptionString help = "ScalarHelp";
+  static type default_value() noexcept { return 7; }
+  static type lower_bound() noexcept { return 2; }
+  static type upper_bound() noexcept { return 8; }
+};
+
+struct VectorWithLimits {
+  using type = std::vector<int>;
+  static constexpr OptionString help = "VectorHelp";
+  static size_t lower_bound_on_size() noexcept { return 5; }
+  static size_t upper_bound_on_size() noexcept { return 9; }
+};
+
 void test_options_format() {
   const auto check = [](auto opt) noexcept {
     using Opt = decltype(opt);
@@ -783,6 +798,32 @@ void test_options_format() {
   check(FormatArray{});
   check(FormatPair{});
   check(FormatUnorderedMap{});
+
+  CHECK(Options<tmpl::list<ScalarWithLimits>>("").help() == R"(
+==== Description of expected options:
+
+
+Options:
+  ScalarWithLimits:
+    type=int
+    default=7
+    min=2
+    max=8
+    ScalarHelp
+
+)");
+  CHECK(Options<tmpl::list<VectorWithLimits>>("").help() == R"(
+==== Description of expected options:
+
+
+Options:
+  VectorWithLimits:
+    type=[int, ...]
+    min size=5
+    max size=9
+    VectorHelp
+
+)");
 }
 
 // [[OutputRegex, Failed to convert value to type

--- a/tests/Unit/Options/Test_Options.cpp
+++ b/tests/Unit/Options/Test_Options.cpp
@@ -714,7 +714,7 @@ void test_options_apply() {
       "Apply3: [1, 2, 3]");
   // We do the checks outside the lambda to make sure it actually gets called.
   std::vector<int> arg1;
-  int arg2;
+  int arg2 = 0;
   opts.apply<tmpl::list<Apply3, Apply1>>([&](const auto& a, auto b) {
     arg1 = a;
     arg2 = b;


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
