### PR TITLE
Fix ParaView crash when loading generated XMF files

### DIFF
--- a/src/Visualization/Python/GenerateXdmf.py
+++ b/src/Visualization/Python/GenerateXdmf.py
@@ -183,6 +183,8 @@ def generate_xdmf(file_prefix, output_filename, start_time, stop_time, stride,
             components.remove('connectivity')
             components.remove('total_extents')
             components.remove('grid_names')
+            components.remove('bases')
+            components.remove('quadratures')
 
             # Write the tensors that are to be visualized.
             for component in components:


### PR DESCRIPTION
## Proposed changes

Fixes #2464 

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
