### PR TITLE
Add caltech HPC environment file

### DIFF
--- a/cmake/AddInputFileTests.cmake
+++ b/cmake/AddInputFileTests.cmake
@@ -31,7 +31,7 @@ function(add_single_input_file_test INPUT_FILE EXECUTABLE COMMAND_LINE_ARGS
 
   set(
     CTEST_NAME
-    "\"InputFiles.${EXECUTABLE_DIR_NAME}.${INPUT_FILE_NAME}.${CHECK_TYPE}\""
+    "InputFiles.${EXECUTABLE_DIR_NAME}.${INPUT_FILE_NAME}.${CHECK_TYPE}"
     )
   set(
     RUN_DIRECTORY
@@ -39,13 +39,13 @@ function(add_single_input_file_test INPUT_FILE EXECUTABLE COMMAND_LINE_ARGS
     )
   if ("${CHECK_TYPE}" STREQUAL "parse")
     add_test(
-      NAME "${CTEST_NAME}"
+      NAME ${CTEST_NAME}
       COMMAND ${CMAKE_BINARY_DIR}/bin/${EXECUTABLE}
       --check-options --input-file ${INPUT_FILE}
       )
   elseif("${CHECK_TYPE}" STREQUAL "execute")
     add_test(
-      NAME "${CTEST_NAME}"
+      NAME ${CTEST_NAME}
       # This script is written below, and only once
       COMMAND sh ${PROJECT_BINARY_DIR}/tmp/InputFileExecuteAndClean.sh
       ${EXECUTABLE} ${INPUT_FILE} ${COMMAND_LINE_ARGS}
@@ -78,7 +78,7 @@ function(add_single_input_file_test INPUT_FILE EXECUTABLE COMMAND_LINE_ARGS
   endif()
 
   set_tests_properties(
-    "${CTEST_NAME}"
+    ${CTEST_NAME}
     PROPERTIES
     FAIL_REGULAR_EXPRESSION "ERROR"
     TIMEOUT ${TIMEOUT}

--- a/cmake/SpectreAddCatchTests.cmake
+++ b/cmake/SpectreAddCatchTests.cmake
@@ -212,7 +212,7 @@ function(spectre_parse_file SOURCE_FILE TEST_TARGET)
     endif()
 
     # Add the test and set its properties
-    add_test(NAME "\"${CTEST_NAME}\""
+    add_test(NAME ${CTEST_NAME}
       COMMAND $<TARGET_FILE:${TEST_TARGET}>
       \"${NAME}\" --durations yes
       --warn NoAssertions
@@ -226,7 +226,7 @@ function(spectre_parse_file SOURCE_FILE TEST_TARGET)
           "${OUTPUT_REGEX}|### No ASSERT tests in release mode ###")
       endif()
       set_tests_properties(
-        "\"${CTEST_NAME}\"" PROPERTIES
+        ${CTEST_NAME} PROPERTIES
         FAIL_REGULAR_EXPRESSION "No tests ran"
         TIMEOUT ${TIMEOUT}
         PASS_REGULAR_EXPRESSION "${OUTPUT_REGEX}"
@@ -235,7 +235,7 @@ function(spectre_parse_file SOURCE_FILE TEST_TARGET)
       set(FAILURE_TESTS "\"~${CTEST_NAME}\";${FAILURE_TESTS}")
     else ()
       set_tests_properties(
-        "\"${CTEST_NAME}\"" PROPERTIES
+        ${CTEST_NAME} PROPERTIES
         FAIL_REGULAR_EXPRESSION "No tests ran"
         TIMEOUT ${TIMEOUT}
         LABELS "${TAGS}"

--- a/docs/Installation/InstallationOnClusters.md
+++ b/docs/Installation/InstallationOnClusters.md
@@ -75,6 +75,19 @@ you do not need to install any dependencies, so you can skip steps 5 and 6. You
 can optionally compile using LLVM/Clang by sourcing `wheeler_clang.sh` instead
 of `wheeler_gcc.sh`
 
+## CaltechHPC at Caltech
+
+Follow the general instructions, using `caltech_hpc` for `SYSTEM_TO_RUN_ON`.
+When you go to build, you will need to get an interactive node (login nodes
+limit the amount of memory accessible to individual users, to below the amount
+necessary to build SpECTRE).
+To ensure you get an entire node to build on, use the command:
+```
+srun -t 02:00:00 -N 1 -c 32 --mem=192000 -A sxs -D . --pty /bin/bash
+```
+being sure to re-source environment files once you get the interactive node
+shell.
+
 ## Ocean at Fullerton
 
 Follow the general instructions, using `ocean` for `SYSTEM_TO_RUN_ON`,

--- a/support/Environments/caltech_hpc_gcc.sh
+++ b/support/Environments/caltech_hpc_gcc.sh
@@ -1,0 +1,312 @@
+#!/bin/env sh
+
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Load system modules
+spectre_load_sys_modules() {
+    module load gcc/9.2.0
+    module load mkl/18.1
+    module load gsl/2.4
+    module load hdf5/1.10.1
+    module load boost/1_68_0-gcc730
+    module load cmake/3.18.0
+    module load python3/3.8.5
+}
+
+# Unload system modules
+spectre_unload_sys_modules() {
+    module unload boost/1_68_0-gcc730
+    module unload hdf5/1.10.1
+    module unload gsl/2.4
+    module unload mkl/18.1
+    module unload gcc/9.2.0
+    module unload cmake/3.18.0
+    module unload python3/3.8.5
+}
+
+
+spectre_setup_modules() {
+    if [ -z ${SPECTRE_HOME} ]; then
+        echo "You must set SPECTRE_HOME to the cloned SpECTRE directory"
+        return 1
+    fi
+
+    local start_dir=`pwd`
+    dep_dir=`realpath $1`
+    if [ $# != 1 ]; then
+        echo "You must pass one argument to spectre_setup_modules, which"
+        echo "is the directory where you want the dependencies to be built."
+        return 1
+    fi
+    mkdir -p $dep_dir
+    cd $dep_dir
+    mkdir -p $dep_dir/modules
+
+    spectre_load_sys_modules
+
+    if [ -f catch/include/catch.hpp ]; then
+        echo "Catch is already installed"
+    else
+        echo "Installing catch..."
+        mkdir -p $dep_dir/catch/include
+        cd $dep_dir/catch/include
+        wget https://github.com/catchorg/Catch2/releases/download/v2.13.0/catch.hpp -O catch.hpp
+        echo "Installed Catch into $dep_dir/catch"
+cat >$dep_dir/modules/catch <<EOF
+#%Module1.0
+prepend-path CPATH "$dep_dir/catch/include"
+prepend-path CMAKE_PREFIX_PATH "$dep_dir/catch/"
+EOF
+    fi
+    cd $dep_dir
+
+    if [ -f blaze/include/blaze/Blaze.h ]; then
+        echo "Blaze is already installed"
+    else
+        echo "Installing Blaze..."
+        mkdir -p $dep_dir/blaze/
+        cd $dep_dir/blaze/
+        wget https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.8.tar.gz -O blaze.tar.gz
+        tar -xzf blaze.tar.gz
+        mv blaze-* include
+        ln -s include/blaze-3.8/blaze include/blaze
+        echo "Installed Blaze into $dep_dir/blaze"
+        cat >$dep_dir/modules/blaze <<EOF
+#%Module1.0
+prepend-path CPATH "$dep_dir/blaze/include"
+prepend-path CMAKE_PREFIX_PATH "$dep_dir/blaze/"
+EOF
+    fi
+    cd $dep_dir
+
+
+    if [ -f brigand/include/brigand/brigand.hpp ]; then
+        echo "Brigand is already installed"
+    else
+        echo "Installing Brigand..."
+        rm -rf $dep_dir/brigand
+        git clone https://github.com/edouarda/brigand.git
+        echo "Installed Brigand into $dep_dir/brigand"
+        cat >$dep_dir/modules/brigand <<EOF
+#%Module1.0
+prepend-path CPATH "$dep_dir/brigand/include"
+prepend-path CMAKE_PREFIX_PATH "$dep_dir/brigand/"
+EOF
+    fi
+    cd $dep_dir
+
+    if [ -f libxsmm/lib/libxsmm.a ]; then
+        echo "LIBXSMM is already installed"
+    else
+        echo "Installing LIBXSMM..."
+        rm -rf $dep_dir/libxsmm
+        wget https://github.com/hfp/libxsmm/archive/1.16.1.tar.gz -O libxsmm.tar.gz
+        tar -xzf libxsmm.tar.gz
+        mv libxsmm-* libxsmm
+        cd libxsmm
+        make CXX=g++ CC=gcc FC=gfortran -j4
+        cd $dep_dir
+        rm libxsmm.tar.gz
+        echo "Installed LIBXSMM into $dep_dir/libxsmm"
+        cat >$dep_dir/modules/libxsmm <<EOF
+#%Module1.0
+prepend-path LIBRARY_PATH "$dep_dir/libxsmm/lib"
+prepend-path LD_LIBRARY_PATH "$dep_dir/libxsmm/lib"
+prepend-path CPATH "$dep_dir/libxsmm/include"
+prepend-path CMAKE_PREFIX_PATH "$dep_dir/libxsmm/"
+EOF
+    fi
+    cd $dep_dir
+
+    if [ -f $dep_dir/yaml-cpp/lib/libyaml-cpp.a ]; then
+        echo "yaml-cpp is already installed"
+    else
+        echo "Installing yaml-cpp..."
+        wget https://github.com/jbeder/yaml-cpp/archive/yaml-cpp-0.6.2.tar.gz -O yaml-cpp.tar.gz
+        tar -xzf yaml-cpp.tar.gz
+        mv yaml-cpp-* yaml-cpp-build
+        cd $dep_dir/yaml-cpp-build
+        mkdir build
+        cd build
+        cmake -D CMAKE_BUILD_TYPE=Release -D YAML_CPP_BUILD_TESTS=OFF \
+              -D CMAKE_C_COMPILER=gcc -D CMAKE_CXX_COMPILER=g++ \
+              -D YAML_CPP_BUILD_CONTRIB=OFF \
+              -D YAML_CPP_BUILD_TOOLS=ON \
+              -D CMAKE_INSTALL_PREFIX=$dep_dir/yaml-cpp ..
+        make -j4
+        make install
+        cd $dep_dir
+        rm -r yaml-cpp-build
+        rm -r yaml-cpp.tar.gz
+        echo "Installed yaml-cpp into $dep_dir/yaml-cpp"
+        cat >$dep_dir/modules/yaml-cpp <<EOF
+#%Module1.0
+prepend-path LIBRARY_PATH "$dep_dir/yaml-cpp/lib"
+prepend-path LD_LIBRARY_PATH "$dep_dir/yaml-cpp/lib"
+prepend-path CPATH "$dep_dir/yaml-cpp/include"
+prepend-path CMAKE_PREFIX_PATH "$dep_dir/yaml-cpp/"
+EOF
+    fi
+    cd $dep_dir
+
+    if [ -f $dep_dir/libsharp/lib/libsharp.a ]; then
+        echo "libsharp is already installed"
+    else
+        echo "Installing libsharp..."
+        wget https://github.com/Libsharp/libsharp/archive/v1.0.0.tar.gz -O libsharp.tar.gz
+        tar -xzf libsharp.tar.gz
+        mv libsharp-* libsharp_build
+        cd $dep_dir/libsharp_build
+        autoconf
+        ./configure --prefix=$dep_dir/libsharp --disable-openmp
+        make -j4
+        mv ./auto $dep_dir/libsharp
+        cd $dep_dir
+        rm -r libsharp_build
+        rm libsharp.tar.gz
+        echo "Installed libsharp into $dep_dir/libsharp"
+        cat >$dep_dir/modules/libsharp <<EOF
+#%Module1.0
+prepend-path LIBRARY_PATH "$dep_dir/libsharp/lib"
+prepend-path LD_LIBRARY_PATH "$dep_dir/libsharp/lib"
+prepend-path CPATH "$dep_dir/libsharp/include"
+prepend-path CMAKE_PREFIX_PATH "$dep_dir/libsharp/"
+EOF
+    fi
+    cd $dep_dir
+
+    # Set up Charm++ because that can be difficult
+    if [ -f $dep_dir/charm/verbs-linux-x86_64-smp/lib/libck.a ]; then
+        echo "Charm++ is already installed"
+    else
+        echo "Installing Charm++..."
+        wget https://github.com/UIUC-PPL/charm/archive/v6.10.2.tar.gz
+        tar xzf v6.10.2.tar.gz
+        mv charm-6.10.2 charm
+        cd $dep_dir/charm
+        ./build charm++ verbs-linux-x86_64-smp --with-production -j4
+        ./build LIBS verbs-linux-x86_64-smp --with-production -j4
+        cd $dep_dir
+        rm v6.10.2.tar.gz
+        echo "Installed Charm++ into $dep_dir/charm"
+        cat >$dep_dir/modules/charm <<EOF
+#%Module1.0
+prepend-path LIBRARY_PATH "$dep_dir/charm/verbs-linux-x86_64-smp/lib"
+prepend-path LD_LIBRARY_PATH "$dep_dir/charm/verbs-linux-x86_64-smp/lib"
+prepend-path CPATH "$dep_dir/charm/verbs-linux-x86_64-smp/include"
+prepend-path CMAKE_PREFIX_PATH "$dep_dir/charm/verbs-linux-x86_64-smp/"
+prepend-path PATH "$dep_dir/charm/verbs-linux-x86_64-smp/bin"
+setenv CHARM_VERSION 6.10.2
+setenv CHARM_HOME $dep_dir/charm/verbs-linux-x86_64-smp
+setenv CHARM_ROOT $dep_dir/charm/verbs-linux-x86_64-smp
+EOF
+    fi
+    cd $dep_dir
+
+    if [ -f $dep_dir/modules/spectre_boost ]; then
+        echo "Boost is already set up"
+    else
+        cat >$dep_dir/modules/spectre_boost <<EOF
+#%Module1.0
+prepend-path CPATH "$BOOST_HOME/include"
+setenv BOOST_ROOT "$BOOST_HOME"
+EOF
+    fi
+    cd $dep_dir
+
+    if [ -f $dep_dir/modules/spectre_gsl ]; then
+        echo "GSL is already set up"
+    else
+        # This hard-coded gsl path is not easily maintainable, so if and when
+        # Caltech HPC assigns an accessible environment variable for the loaded
+        # GSL module, we should use that in favor of the hard-coded path
+        cat >$dep_dir/modules/spectre_gsl <<EOF
+#%Module1.0
+setenv GSL_HOME "/software/gsl/2.4"
+setenv GSL_ROOT "/software/gsl/2.4"
+EOF
+    fi
+    cd $dep_dir
+
+    if [ -f $dep_dir/jemalloc/lib/libjemalloc.a ]; then
+        echo "jemalloc is already set up"
+    else
+        echo "Installing jemalloc..."
+        wget https://github.com/jemalloc/jemalloc/releases/download/5.2.1/jemalloc-5.2.1.tar.bz2
+        tar -xjf jemalloc-5.2.1.tar.bz2
+        mv jemalloc-5.2.1 jemalloc
+        cd $dep_dir/jemalloc
+        ./autogen.sh
+        make
+        cd $dep_dir
+        rm jemalloc-5.2.1.tar.bz2
+        echo "Installed jemalloc into $dep_dir/jemalloc"
+        cat >$dep_dir/modules/jemalloc <<EOF
+#%Module1.0
+prepend-path LIBRARY_PATH "$dep_dir/jemalloc/lib"
+prepend-path LD_LIBRARY_PATH "$dep_dir/jemalloc/lib"
+prepend-path CPATH "$dep_dir/jemalloc/include"
+prepend-path PATH "$dep_dir/jemalloc/bin"
+prepend-path LD_RUN_PATH "$dep_dir/jemalloc/lib"
+setenv JEMALLOC_HOME $dep_dir/jemalloc/
+prepend-path CMAKE_PREFIX_PATH "$dep_dir/jemalloc/"
+EOF
+    fi
+
+    cd $start_dir
+
+    spectre_unload_sys_modules
+
+    printf "\n\nIMPORTANT!!!\nIn order to be able to use these modules you\n"
+    echo "must run:"
+    echo "  module use $dep_dir/modules"
+    echo "You will need to do this every time you compile SpECTRE, so you may"
+    echo "want to add it to your ~/.bashrc."
+}
+
+spectre_unload_modules() {
+    module unload charm
+    module unload yaml-cpp
+    module unload spectre_boost
+    module unload spectre_gsl
+    module unload jemalloc
+    module unload libxsmm
+    module unload libsharp
+    module unload catch
+    module unload brigand
+    module unload blaze
+
+    spectre_unload_sys_modules
+}
+
+spectre_load_modules() {
+    spectre_load_sys_modules
+
+    module load blaze
+    module load brigand
+    module load catch
+    module load libsharp
+    module load libxsmm
+    module load jemalloc
+    module load spectre_boost
+    module load spectre_gsl
+    module load yaml-cpp
+    module load charm
+}
+
+spectre_run_cmake() {
+    if [ -z ${SPECTRE_HOME} ]; then
+        echo "You must set SPECTRE_HOME to the cloned SpECTRE directory"
+        return 1
+    fi
+    spectre_load_modules
+    cmake -D CHARM_ROOT=$CHARM_ROOT \
+          -D CMAKE_BUILD_TYPE=Release \
+          -D CMAKE_Fortran_COMPILER=gfortran \
+          -D MEMORY_ALLOCATOR=JEMALLOC \
+          -D BUILD_PYTHON_BINDINGS=off \
+          -D PYTHON_EXECUTABLE=`which python3` \
+          "$@" \
+          $SPECTRE_HOME
+}

--- a/support/SubmitScripts/CaltechHpc.sh
+++ b/support/SubmitScripts/CaltechHpc.sh
@@ -1,0 +1,92 @@
+#!/bin/bash -
+#SBATCH -o spectre.stdout
+#SBATCH -e spectre.stderr
+#SBATCH --ntasks-per-node 32
+#SBATCH -J KerrSchild
+#SBATCH --nodes 2
+#SBATCH -p any
+#SBATCH -t 12:00:00
+#SBATCH -D .
+
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# To run a job on Caltech HPC:
+# - Set the -J, --nodes, and -t options above, which correspond to job name,
+#   number of nodes, and wall time limit in HH:MM:SS, respectively.
+# - Set an `#SBATCH -A` argument for the computing account id.
+# - Set the build directory, run directory, executable name,
+#   and input file below.
+#
+# NOTE: The executable will not be copied from the build directory, so if you
+#       update your build directory this file will use the updated executable.
+#
+# Optionally, if you need more control over how SpECTRE is launched on
+# Caltech HPC you can edit the launch command at the end of this file directly.
+#
+# To submit the script to the queue run:
+#   sbatch CaltechHpc.sh
+
+# Replace these paths with the path to your build directory, to the source root
+# directory, and to the directory where you want the output to appear, i.e. the
+# run directory.
+# E.g., if you cloned spectre in your home directory, set
+# SPECTRE_BUILD_DIR to ${HOME}/spectre/build. If you want to run in a
+# directory called "Run" in the current directory, set
+# SPECTRE_RUN_DIR to ${PWD}/Run
+export SPECTRE_BUILD_DIR=${HOME}/Codes/spectre/build_clang/
+export SPECTRE_HOME=${HOME}/Codes/spectre/
+export SPECTRE_RUN_DIR=${PWD}/Run
+
+# Choose the executable and input file to run
+# To use an input file in the current directory, set
+# SPECTRE_INPUT_FILE to ${PWD}/InputFileName.yaml
+export SPECTRE_EXECUTABLE=${SPECTRE_BUILD_DIR}/bin/EvolveGeneralizedHarmonic
+export SPECTRE_INPUT_FILE=${PWD}/KerrSchild.yaml
+
+# These commands load the relevant modules and cd into the run directory,
+# creating it if it doesn't exist
+source ${SPECTRE_HOME}/support/Environments/caltech_hpc_gcc.sh
+spectre_load_modules
+module list
+
+mkdir -p ${SPECTRE_RUN_DIR}
+cd ${SPECTRE_RUN_DIR}
+
+# Copy the input file into the run directory, to preserve it
+cp ${SPECTRE_INPUT_FILE} ${SPECTRE_RUN_DIR}/
+
+# Set desired permissions for files created with this script
+umask 0022
+
+# Set the path to include the build directory's bin directory
+export PATH=${SPECTRE_BUILD_DIR}/bin:$PATH
+
+# Generate the nodefile
+echo "Running on the following nodes:"
+echo ${SLURM_NODELIST}
+touch nodelist.$SLURM_JOBID
+for node in $(echo $SLURM_NODELIST | scontrol show hostnames); do
+  echo "host ${node}" >> nodelist.$SLURM_JOBID
+done
+
+WORKER_THREADS_PER_NODE=$((SLURM_NTASKS_PER_NODE - 1))
+WORKER_THREADS=$((SLURM_NPROCS - SLURM_NNODES))
+SPECTRE_COMMAND="${SPECTRE_EXECUTABLE} ++np ${SLURM_NNODES} \
+++p ${WORKER_THREADS} ++ppn ${WORKER_THREADS_PER_NODE} \
+++nodelist nodelist.${SLURM_JOBID}"
+
+# When invoking through `charmrun`, charm will initiate remote sessions which
+# will wipe out environment settings unless it is forced to re-initialize the
+# spectre environment between the start of the remote session and starting the
+# spectre executable
+echo "#!/bin/sh
+source /home/moxon/spectre/support/Environments/caltech_hpc_gcc.sh
+spectre_load_modules
+\$@
+" > runscript
+
+chmod u+x ./runscript
+
+charmrun ++runscript ./runscript ${SPECTRE_COMMAND} \
+         --input-file ${SPECTRE_INPUT_FILE}

--- a/tests/Unit/CMakeLists.txt
+++ b/tests/Unit/CMakeLists.txt
@@ -64,6 +64,7 @@ target_link_libraries(
   Options
   SystemUtilities
   Utilities
+  util
   )
 
 add_dependencies(

--- a/tests/Unit/IO/Importers/CMakeLists.txt
+++ b/tests/Unit/IO/Importers/CMakeLists.txt
@@ -36,13 +36,13 @@ function(add_algorithm_test TEST_NAME DIM)
   add_dependencies(test-executables ${EXECUTABLE_NAME})
 
   add_test(
-    NAME "\"${TEST_IDENTIFIER}\""
+    NAME ${TEST_IDENTIFIER}
     COMMAND ${CMAKE_BINARY_DIR}/bin/${EXECUTABLE_NAME} --input-file
     ${CMAKE_CURRENT_SOURCE_DIR}/${EXECUTABLE_NAME}.yaml
     )
 
   set_tests_properties(
-    "\"${TEST_IDENTIFIER}\""
+    ${TEST_IDENTIFIER}
     PROPERTIES
     TIMEOUT 5
     LABELS "integration"

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -71,7 +71,7 @@ endif()
 
 function(add_algorithm_test TEST_NAME REGEX_TO_MATCH)
   add_test(
-    NAME "\"Unit.Parallel.${TEST_NAME}\""
+    NAME Unit.Parallel.${TEST_NAME}
     COMMAND
     ${SHELL_EXECUTABLE}
     -c
@@ -80,7 +80,7 @@ function(add_algorithm_test TEST_NAME REGEX_TO_MATCH)
 
   if("${REGEX_TO_MATCH}" STREQUAL "")
     set_tests_properties(
-      "\"Unit.Parallel.${TEST_NAME}\""
+      Unit.Parallel.${TEST_NAME}
       PROPERTIES
       FAIL_REGULAR_EXPRESSION "ERROR"
       TIMEOUT 10
@@ -88,7 +88,7 @@ function(add_algorithm_test TEST_NAME REGEX_TO_MATCH)
       ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
   else()
     set_tests_properties(
-      "\"Unit.Parallel.${TEST_NAME}\""
+      Unit.Parallel.${TEST_NAME}
       PROPERTIES
       PASS_REGULAR_EXPRESSION
       "${REGEX_TO_MATCH}"

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/CMakeLists.txt
@@ -51,13 +51,13 @@ function(add_linear_solver_algorithm_test TEST_NAME)
   add_dependencies(test-executables ${EXECUTABLE_NAME})
 
   add_test(
-    NAME "\"${TEST_IDENTIFIER}\""
+    NAME ${TEST_IDENTIFIER}
     COMMAND ${CMAKE_BINARY_DIR}/bin/${EXECUTABLE_NAME} --input-file
     ${CMAKE_CURRENT_SOURCE_DIR}/${EXECUTABLE_NAME}.yaml
     )
 
   set_tests_properties(
-    "\"${TEST_IDENTIFIER}\""
+    ${TEST_IDENTIFIER}
     PROPERTIES
     TIMEOUT 5
     LABELS "integration"


### PR DESCRIPTION
## Proposed changes

Adds a new environment file for compiling natively on the caltech HPC system with gcc, based heavily on the frontera environment file. This also adds an extra linker flag that fixed a linker error that appeared for that system.


### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
