### PR TITLE
Add ninja to the Docker container.

### DIFF
--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -35,7 +35,7 @@ RUN apt-get update -y \
                           gcc-8 g++-8 gfortran-8 \
                           gcc-9 g++-9 gfortran-9 \
                           gcc-10 g++-10 gfortran-10 \
-                          gdb git cmake autoconf automake \
+                          gdb git ninja-build autoconf automake \
                           libopenblas-dev liblapack-dev \
                           libhdf5-dev hdf5-tools \
                           libgsl0-dev \
@@ -96,6 +96,17 @@ RUN apt-get update -y \
     && apt-get install -y bash-completion \
     && printf "if [ -f /etc/bash_completion ] && ! shopt -oq posix; then\n\
     . /etc/bash_completion\nfi\n\n" >> /root/.bashrc
+
+
+# Install cmake.  We need version 3.18.2 so that fortran builds work
+# with ninja.
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.18.2/cmake-3.18.2.tar.gz \
+    && tar -xzf cmake-3.18.2.tar.gz \
+    && cd cmake-3.18.2 \
+    && ./bootstrap --prefix=/usr/local \
+    && make \
+    && make install \
+    && rm -rf cmake*
 
 # We install dependencies not available through apt manually rather than using
 # Spack since Spack ends up building a lot of dependencies from scratch


### PR DESCRIPTION
Adds ninja to the Docker container, for faster compilation.

Also compiles newer version of cmake as required for fortran compilation with ninja.

Currently this is pushed to DockerHub as spectrebuildenv_experimental, which can be eventually removed.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
