### PR TITLE
Update some compute tags to derive from simple tags

### DIFF
--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -253,15 +253,24 @@ struct InternalDirectionsCompute : InternalDirections<VolumeDim>,
 };
 // @}
 
+// @{
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup
 /// The set of directions which correspond to external boundaries.
 /// Used for representing data on the interior side of the external boundary
 /// faces.
 template <size_t VolumeDim>
-struct BoundaryDirectionsInterior : db::ComputeTag {
+struct BoundaryDirectionsInterior : db::SimpleTag {
   static constexpr size_t volume_dim = VolumeDim;
-  static std::string name() noexcept { return "BoundaryDirectionsInterior"; }
+  using type = std::unordered_set<::Direction<VolumeDim>>;
+};
+
+template <size_t VolumeDim>
+struct BoundaryDirectionsInteriorCompute
+    : BoundaryDirectionsInterior<VolumeDim>,
+      db::ComputeTag {
+  static constexpr size_t volume_dim = VolumeDim;
+  using base = BoundaryDirectionsInterior<VolumeDim>;
   using return_type = std::unordered_set<::Direction<VolumeDim>>;
   using argument_tags = tmpl::list<Element<VolumeDim>>;
   static void function(const gsl::not_null<return_type*> directions,
@@ -269,16 +278,26 @@ struct BoundaryDirectionsInterior : db::ComputeTag {
     *directions = element.external_boundaries();
   }
 };
+// @}
 
+// @{
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup
 /// The set of directions which correspond to external boundaries. To be used
 /// to represent data which exists on the exterior side of the external boundary
 /// faces.
 template <size_t VolumeDim>
-struct BoundaryDirectionsExterior : db::ComputeTag {
+struct BoundaryDirectionsExterior : db::SimpleTag {
   static constexpr size_t volume_dim = VolumeDim;
-  static std::string name() noexcept { return "BoundaryDirectionsExterior"; }
+  using type = std::unordered_set<::Direction<VolumeDim>>;
+};
+
+template <size_t VolumeDim>
+struct BoundaryDirectionsExteriorCompute
+    : BoundaryDirectionsExterior<VolumeDim>,
+      db::ComputeTag {
+  static constexpr size_t volume_dim = VolumeDim;
+  using base = BoundaryDirectionsExterior<VolumeDim>;
   using return_type = std::unordered_set<::Direction<VolumeDim>>;
   using argument_tags = tmpl::list<Element<VolumeDim>>;
   static constexpr auto function(const gsl::not_null<return_type*> directions,
@@ -286,6 +305,7 @@ struct BoundaryDirectionsExterior : db::ComputeTag {
     *directions = element.external_boundaries();
   }
 };
+// @}
 
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup

--- a/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeInterfaces.hpp
+++ b/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeInterfaces.hpp
@@ -174,7 +174,7 @@ struct InitializeInterfaces {
                       make_compute_tag<tmpl::_1, tmpl::pin<Directions>>>>>;
 
   using exterior_face_tags = tmpl::flatten<tmpl::list<
-      domain::Tags::BoundaryDirectionsExterior<dim>,
+      domain::Tags::BoundaryDirectionsExteriorCompute<dim>,
       domain::Tags::InterfaceCompute<
           domain::Tags::BoundaryDirectionsExterior<dim>,
           domain::Tags::Direction<dim>>,
@@ -222,7 +222,7 @@ struct InitializeInterfaces {
                      face_tags<domain::Tags::BoundaryDirectionsInterior<dim>>,
                      exterior_face_tags>,
         domain::Tags::InternalDirectionsCompute<dim>,
-        domain::Tags::BoundaryDirectionsInterior<dim>>;
+        domain::Tags::BoundaryDirectionsInteriorCompute<dim>>;
     return std::make_tuple(
         ::Initialization::merge_into_databox<InitializeInterfaces,
                                              db::AddSimpleTags<>, compute_tags>(

--- a/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeInterfaces.hpp
+++ b/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeInterfaces.hpp
@@ -153,7 +153,6 @@ struct InitializeInterfaces {
   };
   template <typename Directions>
   using face_tags = tmpl::flatten<tmpl::list<
-      Directions,
       domain::Tags::InterfaceCompute<Directions, domain::Tags::Direction<dim>>,
       domain::Tags::InterfaceCompute<Directions,
                                      domain::Tags::InterfaceMesh<dim>>,
@@ -218,10 +217,12 @@ struct InitializeInterfaces {
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/, ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    using compute_tags =
+    using compute_tags = tmpl::push_front<
         tmpl::append<face_tags<domain::Tags::InternalDirections<dim>>,
                      face_tags<domain::Tags::BoundaryDirectionsInterior<dim>>,
-                     exterior_face_tags>;
+                     exterior_face_tags>,
+        domain::Tags::InternalDirectionsCompute<dim>,
+        domain::Tags::BoundaryDirectionsInterior<dim>>;
     return std::make_tuple(
         ::Initialization::merge_into_databox<InitializeInterfaces,
                                              db::AddSimpleTags<>, compute_tags>(

--- a/tests/Unit/Domain/Test_FaceNormal.cpp
+++ b/tests/Unit/Domain/Test_FaceNormal.cpp
@@ -150,7 +150,7 @@ void check_time_dependent(
                                                             Frame::Inertial>,
                         ::Tags::Time, Tags::FunctionsOfTime>,
       db::AddComputeTags<
-          Tags::BoundaryDirectionsExterior<Dim>,
+          Tags::BoundaryDirectionsExteriorCompute<Dim>,
           Tags::InterfaceCompute<Directions<Dim>, Tags::Direction<Dim>>,
           Tags::InterfaceCompute<Directions<Dim>, Tags::InterfaceMesh<Dim>>,
           Tags::InterfaceCompute<Tags::BoundaryDirectionsExterior<Dim>,
@@ -354,7 +354,7 @@ void test_compute_item() {
       db::AddSimpleTags<Tags::Element<2>, Directions<2>, Tags::Mesh<2>,
                         Tags::ElementMap<2>>,
       db::AddComputeTags<
-          Tags::BoundaryDirectionsExterior<2>,
+          Tags::BoundaryDirectionsExteriorCompute<2>,
           Tags::InterfaceCompute<Directions<2>, Tags::Direction<2>>,
           Tags::InterfaceCompute<Directions<2>, Tags::InterfaceMesh<2>>,
           Tags::InterfaceCompute<Tags::BoundaryDirectionsExterior<2>,
@@ -410,8 +410,8 @@ void test_compute_item() {
   const auto box_with_non_affine_map = db::create<
       db::AddSimpleTags<Tags::Element<2>, Tags::Mesh<2>, Tags::ElementMap<2>>,
       db::AddComputeTags<
-          Tags::BoundaryDirectionsExterior<2>,
-          Tags::BoundaryDirectionsInterior<2>,
+          Tags::BoundaryDirectionsExteriorCompute<2>,
+          Tags::BoundaryDirectionsInteriorCompute<2>,
           Tags::InterfaceCompute<Tags::BoundaryDirectionsExterior<2>,
                                  Tags::Direction<2>>,
           Tags::InterfaceCompute<Tags::BoundaryDirectionsExterior<2>,

--- a/tests/Unit/Domain/Test_InterfaceHelpers.cpp
+++ b/tests/Unit/Domain/Test_InterfaceHelpers.cpp
@@ -140,7 +140,7 @@ SPECTRE_TEST_CASE("Unit.Domain.InterfaceHelpers", "[Unit][Domain]") {
       // Reference element has no internal directions:
       // [ X ]-> xi
       {{0, {{{0, 0}}}}, {}}, {}, {});
-  test_interface_apply<1, Tags::BoundaryDirectionsInterior<1>>(
+  test_interface_apply<1, Tags::BoundaryDirectionsInteriorCompute<1>>(
       // Reference element has two boundary directions:
       // [ X ]-> xi
       {{0, {{{0, 0}}}}, {}},

--- a/tests/Unit/Domain/Test_InterfaceHelpers.cpp
+++ b/tests/Unit/Domain/Test_InterfaceHelpers.cpp
@@ -131,12 +131,12 @@ void test_interface_apply(
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.InterfaceHelpers", "[Unit][Domain]") {
-  test_interface_apply<1, Tags::InternalDirections<1>>(
+  test_interface_apply<1, Tags::InternalDirectionsCompute<1>>(
       // Reference element has one internal direction:
       // [ X | ]-> xi
       {{0, {{{1, 0}}}}, {{Direction<1>::upper_xi(), {{{0, {{{1, 1}}}}}, {}}}}},
       {{Direction<1>::upper_xi(), 2.}}, {{Direction<1>::upper_xi(), 5.}});
-  test_interface_apply<1, Tags::InternalDirections<1>>(
+  test_interface_apply<1, Tags::InternalDirectionsCompute<1>>(
       // Reference element has no internal directions:
       // [ X ]-> xi
       {{0, {{{0, 0}}}}, {}}, {}, {});
@@ -146,7 +146,7 @@ SPECTRE_TEST_CASE("Unit.Domain.InterfaceHelpers", "[Unit][Domain]") {
       {{0, {{{0, 0}}}}, {}},
       {{Direction<1>::lower_xi(), 2.}, {Direction<1>::upper_xi(), 3.}},
       {{Direction<1>::lower_xi(), 5.}, {Direction<1>::upper_xi(), 7.}});
-  test_interface_apply<2, Tags::InternalDirections<2>>(
+  test_interface_apply<2, Tags::InternalDirectionsCompute<2>>(
       // Reference element has one internal directions:
       // ^ eta
       // +-+-+

--- a/tests/Unit/Domain/Test_InterfaceItems.cpp
+++ b/tests/Unit/Domain/Test_InterfaceItems.cpp
@@ -201,7 +201,7 @@ void test_interface_items() {
                                  TestTags::NegateCompute<TestTags::Double>>,
           Tags::InterfaceCompute<templated_directions,
                                  TestTags::NegateDoubleAddIntCompute>,
-          boundary_directions_interior,
+          Tags::BoundaryDirectionsInteriorCompute<dim>,
           Tags::InterfaceCompute<boundary_directions_interior,
                                  Tags::Direction<dim>>,
           Tags::InterfaceCompute<boundary_directions_interior,
@@ -212,7 +212,7 @@ void test_interface_items() {
                                  TestTags::NegateDoubleAddIntCompute>,
           Tags::InterfaceCompute<boundary_directions_interior,
                                  TestTags::ComplexItemCompute<dim>>,
-          boundary_directions_exterior>>(
+          Tags::BoundaryDirectionsExteriorCompute<dim>>>(
       std::move(element), 5,
       std::unordered_map<Direction<dim>, double>{
           {Direction<dim>::lower_xi(), 1.5},

--- a/tests/Unit/Domain/Test_InterfaceItems.cpp
+++ b/tests/Unit/Domain/Test_InterfaceItems.cpp
@@ -156,9 +156,11 @@ void test_interface_items() {
   using boundary_directions_exterior = Tags::BoundaryDirectionsExterior<dim>;
   using templated_directions = TestTags::TemplatedDirections<int>;
 
-  CHECK(internal_directions::name() == "InternalDirections");
-  CHECK(boundary_directions_interior::name() == "BoundaryDirectionsInterior");
-  CHECK(boundary_directions_exterior::name() == "BoundaryDirectionsExterior");
+  CHECK(db::tag_name<internal_directions>() == "InternalDirections");
+  CHECK(db::tag_name<boundary_directions_interior>() ==
+        "BoundaryDirectionsInterior");
+  CHECK(db::tag_name<boundary_directions_exterior>() ==
+        "BoundaryDirectionsExterior");
 
   Element<dim> element{ElementId<3>(0),
                        {{Direction<dim>::lower_xi(), {}},
@@ -184,7 +186,7 @@ void test_interface_items() {
           templated_directions,
           Tags::Interface<templated_directions, TestTags::Double>>,
       db::AddComputeTags<
-          internal_directions,
+          Tags::InternalDirectionsCompute<dim>,
           Tags::InterfaceCompute<internal_directions, Tags::Direction<dim>>,
           TestTags::NegateCompute<TestTags::Int>,
           Tags::InterfaceCompute<internal_directions, TestTags::IntCompute>,

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
@@ -112,7 +112,7 @@ struct component {
                         interface_tag<Tags::Variables<tmpl::list<Var, Var2>>>,
                         interface_tag<OtherArg>, n_dot_f_tag>;
   using compute_tags = db::AddComputeTags<
-      domain::Tags::InternalDirections<2>,
+      domain::Tags::InternalDirectionsCompute<2>,
       interface_compute_tag<domain::Tags::Direction<2>>,
       interface_compute_tag<domain::Tags::InterfaceMesh<2>>,
       interface_compute_tag<domain::Tags::UnnormalizedFaceNormalCompute<2>>,

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/Test_FirstOrderScheme.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/Test_FirstOrderScheme.cpp
@@ -121,7 +121,7 @@ void test_first_order_scheme() {
                           domain::Tags::Mesh<Dim>, domain::Tags::Element<Dim>,
                           all_normal_dot_fluxes_tag>,
         db::AddComputeTags<
-            domain::Tags::InternalDirections<Dim>,
+            domain::Tags::InternalDirectionsCompute<Dim>,
             domain::Tags::InterfaceCompute<
                 domain::Tags::InternalDirections<Dim>,
                 domain::Tags::Direction<Dim>>,

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/Test_FirstOrderSchemeLts.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/Test_FirstOrderSchemeLts.cpp
@@ -133,7 +133,7 @@ void test_first_order_scheme_lts() {
                           domain::Tags::Element<Dim>, all_normal_dot_fluxes_tag,
                           all_magnitude_of_face_normals_tag>,
         db::AddComputeTags<
-            domain::Tags::InternalDirections<Dim>,
+            domain::Tags::InternalDirectionsCompute<Dim>,
             domain::Tags::InterfaceCompute<
                 domain::Tags::InternalDirections<Dim>,
                 domain::Tags::Direction<Dim>>,

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_CollectDataForFluxes.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_CollectDataForFluxes.cpp
@@ -94,7 +94,7 @@ struct ElementArray {
                   ::Tags::Next<TemporalIdTag>>>,
               dg::Actions::InitializeDomain<volume_dim>,
               Initialization::Actions::AddComputeTags<tmpl::list<
-                  domain::Tags::InternalDirections<volume_dim>,
+                  domain::Tags::InternalDirectionsCompute<volume_dim>,
                   domain::Tags::BoundaryDirectionsInterior<volume_dim>,
                   domain::Tags::BoundaryDirectionsExterior<volume_dim>,
                   domain::Tags::InterfaceCompute<

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_CollectDataForFluxes.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_CollectDataForFluxes.cpp
@@ -95,8 +95,8 @@ struct ElementArray {
               dg::Actions::InitializeDomain<volume_dim>,
               Initialization::Actions::AddComputeTags<tmpl::list<
                   domain::Tags::InternalDirectionsCompute<volume_dim>,
-                  domain::Tags::BoundaryDirectionsInterior<volume_dim>,
-                  domain::Tags::BoundaryDirectionsExterior<volume_dim>,
+                  domain::Tags::BoundaryDirectionsInteriorCompute<volume_dim>,
+                  domain::Tags::BoundaryDirectionsExteriorCompute<volume_dim>,
                   domain::Tags::InterfaceCompute<
                       domain::Tags::InternalDirections<volume_dim>,
                       domain::Tags::Direction<volume_dim>>,

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_FluxCommunication.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_FluxCommunication.cpp
@@ -130,7 +130,7 @@ struct ElementArray {
                  domain::Tags::ElementMap<Dim>>;
   using compute_tags = tmpl::list<
       domain::Tags::InternalDirectionsCompute<Dim>,
-      domain::Tags::BoundaryDirectionsInterior<Dim>,
+      domain::Tags::BoundaryDirectionsInteriorCompute<Dim>,
       domain::Tags::InterfaceCompute<domain::Tags::InternalDirections<Dim>,
                                      domain::Tags::Direction<Dim>>,
       domain::Tags::InterfaceCompute<

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_FluxCommunication.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_FluxCommunication.cpp
@@ -129,7 +129,7 @@ struct ElementArray {
                  domain::Tags::Mesh<Dim>, domain::Tags::Element<Dim>,
                  domain::Tags::ElementMap<Dim>>;
   using compute_tags = tmpl::list<
-      domain::Tags::InternalDirections<Dim>,
+      domain::Tags::InternalDirectionsCompute<Dim>,
       domain::Tags::BoundaryDirectionsInterior<Dim>,
       domain::Tags::InterfaceCompute<domain::Tags::InternalDirections<Dim>,
                                      domain::Tags::Direction<Dim>>,

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_FluxCommunicationLts.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_FluxCommunicationLts.cpp
@@ -147,7 +147,7 @@ struct lts_component {
                  domain::Tags::Element<Dim>, domain::Tags::ElementMap<Dim>>;
   using compute_tags = tmpl::list<
       domain::Tags::InternalDirectionsCompute<Dim>,
-      domain::Tags::BoundaryDirectionsInterior<Dim>,
+      domain::Tags::BoundaryDirectionsInteriorCompute<Dim>,
       domain::Tags::InterfaceCompute<domain::Tags::InternalDirections<Dim>,
                                      domain::Tags::Direction<Dim>>,
       domain::Tags::InterfaceCompute<

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_FluxCommunicationLts.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_FluxCommunicationLts.cpp
@@ -146,7 +146,7 @@ struct lts_component {
                  ::Tags::Next<TemporalIdTag>, domain::Tags::Mesh<Dim>,
                  domain::Tags::Element<Dim>, domain::Tags::ElementMap<Dim>>;
   using compute_tags = tmpl::list<
-      domain::Tags::InternalDirections<Dim>,
+      domain::Tags::InternalDirectionsCompute<Dim>,
       domain::Tags::BoundaryDirectionsInterior<Dim>,
       domain::Tags::InterfaceCompute<domain::Tags::InternalDirections<Dim>,
                                      domain::Tags::Direction<Dim>>,

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeMortars.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeMortars.cpp
@@ -77,7 +77,7 @@ struct ElementArray {
                                     ::Tags::Next<TemporalIdTag>>>,
                      dg::Actions::InitializeDomain<Dim>,
                      Initialization::Actions::AddComputeTags<tmpl::list<
-                         domain::Tags::InternalDirections<Dim>,
+                         domain::Tags::InternalDirectionsCompute<Dim>,
                          domain::Tags::BoundaryDirectionsInterior<Dim>,
                          domain::Tags::InterfaceCompute<
                              domain::Tags::InternalDirections<Dim>,

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeMortars.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeMortars.cpp
@@ -78,7 +78,7 @@ struct ElementArray {
                      dg::Actions::InitializeDomain<Dim>,
                      Initialization::Actions::AddComputeTags<tmpl::list<
                          domain::Tags::InternalDirectionsCompute<Dim>,
-                         domain::Tags::BoundaryDirectionsInterior<Dim>,
+                         domain::Tags::BoundaryDirectionsInteriorCompute<Dim>,
                          domain::Tags::InterfaceCompute<
                              domain::Tags::InternalDirections<Dim>,
                              domain::Tags::Direction<Dim>>,

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
@@ -106,7 +106,7 @@ struct Component {
       inverse_jacobian,
       Tags::DerivCompute<variables_tag, inverse_jacobian,
                          typename metavariables::system::gradients_tags>,
-      domain::Tags::InternalDirections<1>,
+      domain::Tags::InternalDirectionsCompute<1>,
       domain::Tags::Slice<domain::Tags::InternalDirections<1>,
                           typename metavariables::system::variables_tag>,
       domain::Tags::Slice<domain::Tags::InternalDirections<1>,


### PR DESCRIPTION
## Proposed changes

Derive compute tags InternalDirections, BoundaryDirectionsInterior and BoundaryDirectionsExterior from simple tags by appending Compute to their names for the compute tags and keeping those names for the new simple tags

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
