### PR TITLE
Fix TensorExpressions::evaluate to use LHS index order for LHS Tensor

### DIFF
--- a/src/DataStructures/Tensor/Expressions/Evaluate.hpp
+++ b/src/DataStructures/Tensor/Expressions/Evaluate.hpp
@@ -8,35 +8,116 @@
 
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/Algorithm.hpp"
 #include "Utilities/Requires.hpp"
 
 namespace TensorExpressions {
+/*!
+ * \ingroup TensorExpressionsGroup
+ * \brief Determines and stores a LHS tensor's symmetry and index list from a
+ * RHS tensor expression and desired LHS index order
+ *
+ * \details Given the generic index order of a RHS TensorExpression and the
+ * generic index order of the desired LHS Tensor, this creates a mapping between
+ * the two that is used to determine the (potentially reordered) ordering of the
+ * elements of the desired LHS Tensor`s ::Symmetry and typelist of
+ * \ref SpacetimeIndex "TensorIndexType"s.
+ *
+ * @tparam RhsTensorIndexList the typelist of TensorIndex of the RHS
+ * TensorExpression, e.g. `ti_a_t`, `ti_b_t`, `ti_c_t`
+ * @tparam LhsTensorIndexList the typelist of TensorIndexs of the desired LHS
+ * tensor, e.g. `ti_b_t`, `ti_c_t`, `ti_a_t`
+ * @tparam RhsSymmetry the ::Symmetry of the RHS indices
+ * @tparam RhsTensorIndexTypeList the RHS TensorExpression's typelist of
+ * \ref SpacetimeIndex "TensorIndexType"s
+ */
+template <typename RhsTensorIndexList, typename LhsTensorIndexList,
+          typename RhsSymmetry, typename RhsTensorIndexTypeList,
+          size_t NumIndices = tmpl::size<RhsSymmetry>::value,
+          typename IndexSequence = std::make_index_sequence<NumIndices>>
+struct LhsTensorSymmAndIndices;
+
+template <typename RhsTensorIndexList, typename... LhsTensorIndices,
+          typename RhsSymmetry, typename RhsTensorIndexTypeList,
+          size_t NumIndices, size_t... Ints>
+struct LhsTensorSymmAndIndices<
+    RhsTensorIndexList, tmpl::list<LhsTensorIndices...>, RhsSymmetry,
+    RhsTensorIndexTypeList, NumIndices, std::index_sequence<Ints...>> {
+  static constexpr std::array<size_t, NumIndices> lhs_tensorindex_values = {
+      {LhsTensorIndices::value...}};
+  static constexpr std::array<size_t, NumIndices> rhs_tensorindex_values = {
+      {tmpl::at_c<RhsTensorIndexList, Ints>::value...}};
+  static constexpr std::array<size_t, NumIndices> lhs_to_rhs_map = {
+      {std::distance(
+          rhs_tensorindex_values.begin(),
+          alg::find(rhs_tensorindex_values, lhs_tensorindex_values[Ints]))...}};
+
+  // Desired LHS Tensor's Symmetry and typelist of TensorIndexTypes
+  using symmetry =
+      Symmetry<tmpl::at_c<RhsSymmetry, lhs_to_rhs_map[Ints]>::value...>;
+  using tensorindextype_list =
+      tmpl::list<tmpl::at_c<RhsTensorIndexTypeList, lhs_to_rhs_map[Ints]>...>;
+};
 
 /*!
  * \ingroup TensorExpressionsGroup
- * \brief Evaluate a Tensor Expression with LHS indices set in the template
- * parameters
+ * \brief Evaluate a RHS tensor expression to a tensor with the LHS index order
+ * set in the template parameters
  *
- * @tparam LhsIndices the indices on the left hand side of the tensor expression
- * @return Tensor<typename T::type, typename T::symmetry, typename
- * T::index_list>
+ * \details Uses the right hand side (RHS) TensorExpression's index ordering
+ * (`T::args_list`) and the desired left hand side (LHS) tensor's index ordering
+ * (`LhsTensorIndices`) to construct a LHS Tensor with that LHS index ordering.
+ * This can carry out the evaluation of a RHS tensor expression to a LHS tensor
+ * with the same index ordering, such as \f$L_{ab} = R_{ab}\f$, or different
+ * ordering, such as \f$L_{ba} = R_{ab}\f$.
+ *
+ * ### Example usage
+ * Given two rank 2 Tensors `R` and `S` with index order (a, b), add them
+ * together and generate the resultant LHS Tensor `L` with index order (b, a):
+ * \code{.cpp}
+ * auto L = TensorExpressions::evaluate<ti_b_t, ti_a_t>(
+ *     R(ti_a, ti_b) + S(ti_a, ti_b));
+ * \endcode
+ * \metareturns Tensor
+ *
+ * This represents evaluating: \f$L_{ba} = \R_{ab} + S_{ab}\f$
+ *
+ * @tparam LhsTensorIndices the TensorIndex of the Tensor on the LHS of the
+ * tensor expression, e.g. `ti_a_t`, `ti_b_t`, `ti_c_t`
+ * @tparam T the type of the RHS TensorExpression
+ * @param rhs_te the RHS TensorExpression to be evaluated
+ * @return the LHS Tensor with index order specified by LhsTensorIndices
  */
-template <typename... LhsIndices, typename T,
+template <typename... LhsTensorIndices, typename T,
           Requires<std::is_base_of<Expression, T>::value> = nullptr>
-auto evaluate(const T& te) {
+auto evaluate(const T& rhs_te) {
   static_assert(
-      sizeof...(LhsIndices) == tmpl::size<typename T::args_list>::value,
+      sizeof...(LhsTensorIndices) == tmpl::size<typename T::args_list>::value,
       "Must have the same number of indices on the LHS and RHS of a tensor "
       "equation.");
   using rhs = tmpl::transform<tmpl::remove_duplicates<typename T::args_list>,
                               std::decay<tmpl::_1>>;
   static_assert(
-      tmpl::equal_members<tmpl::list<std::decay_t<LhsIndices>...>, rhs>::value,
+      tmpl::equal_members<tmpl::list<std::decay_t<LhsTensorIndices>...>,
+                          rhs>::value,
       "All indices on the LHS of a Tensor Expression (that is, those specified "
       "in evaluate<Indices::...>) must be present on the RHS of the expression "
       "as well.");
-  return Tensor<typename T::type, typename T::symmetry, typename T::index_list>(
-      te, tmpl::list<LhsIndices...>{});
-}
 
+  using rhs_tensorindex_list = typename T::args_list;
+  using lhs_tensorindex_list = tmpl::list<LhsTensorIndices...>;
+  using rhs_symmetry = typename T::symmetry;
+  using rhs_tensorindextype_list = typename T::index_list;
+
+  // Stores (potentially reordered) symmetry and indices needed for constructing
+  // the LHS tensor with index order specified by LhsTensorIndices
+  using lhs_tensor =
+      LhsTensorSymmAndIndices<rhs_tensorindex_list, lhs_tensorindex_list,
+                              rhs_symmetry, rhs_tensorindextype_list>;
+
+  // Construct and return LHS tensor
+  return Tensor<typename T::type, typename lhs_tensor::symmetry,
+                typename lhs_tensor::tensorindextype_list>(
+      rhs_te, tmpl::list<LhsTensorIndices...>{});
+}
 }  // namespace TensorExpressions

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_TensorExpressions.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_TensorExpressions.cpp
@@ -7,11 +7,245 @@
 #include <iterator>
 #include <numeric>
 
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Expressions/AddSubtract.hpp"
 #include "DataStructures/Tensor/Expressions/Evaluate.hpp"
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Utilities/TMPL.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank0TestHelpers.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank1TestHelpers.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank2TestHelpers.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank3TestHelpers.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank4TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Evaluate",
+                  "[DataStructures][Unit]") {
+  // Rank 0: double
+  TestHelpers::TensorExpressions::test_evaluate_rank_0<double>(-7.31);
+
+  // Rank 0: DataVector
+  TestHelpers::TensorExpressions::test_evaluate_rank_0<DataVector>(
+      DataVector{-3.1, 9.4, 0.0, -3.1, 2.4, 9.8});
+
+  // Rank 1: double; spacetime
+  TestHelpers::TensorExpressions::test_evaluate_rank_1<double, SpacetimeIndex,
+                                                       UpLo::Lo>(ti_a);
+  TestHelpers::TensorExpressions::test_evaluate_rank_1<double, SpacetimeIndex,
+                                                       UpLo::Lo>(ti_b);
+  TestHelpers::TensorExpressions::test_evaluate_rank_1<double, SpacetimeIndex,
+                                                       UpLo::Up>(ti_A);
+  TestHelpers::TensorExpressions::test_evaluate_rank_1<double, SpacetimeIndex,
+                                                       UpLo::Up>(ti_B);
+
+  // Rank 1: double; spatial
+  TestHelpers::TensorExpressions::test_evaluate_rank_1<double, SpatialIndex,
+                                                       UpLo::Lo>(ti_i);
+  TestHelpers::TensorExpressions::test_evaluate_rank_1<double, SpatialIndex,
+                                                       UpLo::Lo>(ti_j);
+  TestHelpers::TensorExpressions::test_evaluate_rank_1<double, SpatialIndex,
+                                                       UpLo::Up>(ti_I);
+  TestHelpers::TensorExpressions::test_evaluate_rank_1<double, SpatialIndex,
+                                                       UpLo::Up>(ti_J);
+
+  // Rank 1: DataVector
+  TestHelpers::TensorExpressions::test_evaluate_rank_1<DataVector, SpatialIndex,
+                                                       UpLo::Up>(ti_L);
+
+  // Rank 2: double; nonsymmetric; spacetime only
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo>(ti_a, ti_b);
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+      double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Up>(ti_A, ti_B);
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo>(ti_d, ti_c);
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+      double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Up>(ti_D, ti_C);
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up>(ti_e, ti_F);
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+      double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo>(ti_F, ti_e);
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up>(ti_g, ti_B);
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+      double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo>(ti_G, ti_b);
+
+  // Rank 2: double; nonsymmetric; spatial only
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+      double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Lo>(ti_i, ti_j);
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+      double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Up>(ti_I, ti_J);
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+      double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Lo>(ti_j, ti_i);
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+      double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Up>(ti_J, ti_I);
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+      double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Up>(ti_i, ti_J);
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+      double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Lo>(ti_I, ti_j);
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+      double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Up>(ti_j, ti_I);
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+      double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Lo>(ti_J, ti_i);
+
+  // Rank 2: double; nonsymmetric; spacetime and spatial mixed
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+      double, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Up>(ti_c, ti_I);
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+      double, SpacetimeIndex, SpatialIndex, UpLo::Up, UpLo::Lo>(ti_A, ti_i);
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+      double, SpatialIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo>(ti_J, ti_a);
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+      double, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up>(ti_i, ti_B);
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+      double, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Lo>(ti_e, ti_j);
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+      double, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo>(ti_i, ti_d);
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+      double, SpacetimeIndex, SpatialIndex, UpLo::Up, UpLo::Up>(ti_C, ti_I);
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+      double, SpatialIndex, SpacetimeIndex, UpLo::Up, UpLo::Up>(ti_J, ti_A);
+
+  // Rank 2: double; symmetric; spacetime
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_symmetric<
+      double, SpacetimeIndex, UpLo::Lo>(ti_a, ti_d);
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_symmetric<
+      double, SpacetimeIndex, UpLo::Up>(ti_G, ti_B);
+
+  // Rank 2: double; symmetric; spatial
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_symmetric<
+      double, SpatialIndex, UpLo::Lo>(ti_j, ti_i);
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_symmetric<
+      double, SpatialIndex, UpLo::Up>(ti_I, ti_J);
+
+  // Rank 2: DataVector; nonsymmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
+      DataVector, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up>(ti_f,
+                                                                      ti_G);
+
+  // Rank 2: DataVector; symmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_2_symmetric<
+      DataVector, SpatialIndex, UpLo::Lo>(ti_j, ti_i);
+
+  // Rank 3: double; nonsymmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_3_no_symmetry<
+      double, SpacetimeIndex, SpatialIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo,
+      UpLo::Up>(ti_D, ti_j, ti_B);
+
+  // Rank 3: double; first and second indices symmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_3_ab_symmetry<
+      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up>(ti_b, ti_a,
+                                                                  ti_C);
+
+  // Rank 3: double; first and third indices symmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_3_ac_symmetry<
+      double, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo>(ti_i, ti_f,
+                                                                ti_j);
+
+  // Rank 3: double; second and third indices symmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_3_bc_symmetry<
+      double, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Up>(ti_d, ti_J,
+                                                                ti_I);
+
+  // Rank 3: double; symmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_3_abc_symmetry<
+      double, SpacetimeIndex, UpLo::Lo>(ti_f, ti_d, ti_a);
+
+  // Rank 3: DataVector; nonsymmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_3_no_symmetry<
+      DataVector, SpacetimeIndex, SpatialIndex, SpacetimeIndex, UpLo::Up,
+      UpLo::Lo, UpLo::Up>(ti_D, ti_j, ti_B);
+
+  // Rank 3: DataVector; first and second indices symmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_3_ab_symmetry<
+      DataVector, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up>(
+      ti_b, ti_a, ti_C);
+
+  // Rank 3: DataVector; first and third indices symmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_3_ac_symmetry<
+      DataVector, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo>(ti_i, ti_f,
+                                                                    ti_j);
+
+  // Rank 3: DataVector; second and third indices symmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_3_bc_symmetry<
+      DataVector, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Up>(ti_d, ti_J,
+                                                                    ti_I);
+
+  // Rank 3: DataVector; symmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_3_abc_symmetry<
+      DataVector, SpacetimeIndex, UpLo::Lo>(ti_f, ti_d, ti_a);
+
+  // Rank 4: double; nonsymmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_4<
+      double, Symmetry<4, 3, 2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpatialIndex<1, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Lo, Frame::Inertial>>>(ti_b, ti_A, ti_k,
+                                                              ti_l);
+
+  // Rank 4: double; second and third indices symmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_4<
+      double, Symmetry<3, 2, 2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpatialIndex<1, UpLo::Lo, Frame::Grid>>>(ti_G, ti_d, ti_a,
+                                                          ti_j);
+
+  // Rank 4: double; first, second, and fourth indices symmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_4<
+      double, Symmetry<2, 2, 1, 2>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>(ti_j, ti_i, ti_k,
+                                                              ti_l);
+
+  // Rank 4: double; symmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_4<
+      double, Symmetry<1, 1, 1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>(ti_F, ti_A, ti_C,
+                                                            ti_D);
+
+  // Rank 4: DataVector; nonsymmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_4<
+      DataVector, Symmetry<4, 3, 2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpatialIndex<1, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Lo, Frame::Inertial>>>(ti_b, ti_A, ti_k,
+                                                              ti_l);
+
+  // Rank 4: DataVector; second and third indices symmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_4<
+      DataVector, Symmetry<3, 2, 2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpatialIndex<1, UpLo::Lo, Frame::Grid>>>(ti_G, ti_d, ti_a,
+                                                          ti_j);
+
+  // Rank 4: DataVector; first, second, and fourth indices symmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_4<
+      DataVector, Symmetry<2, 2, 1, 2>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>(ti_j, ti_i, ti_k,
+                                                              ti_l);
+
+  // Rank 4: DataVector; symmetric
+  TestHelpers::TensorExpressions::test_evaluate_rank_4<
+      DataVector, Symmetry<1, 1, 1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>(ti_F, ti_A, ti_C,
+                                                            ti_D);
+}
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
                   "[DataStructures][Unit]") {

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank0TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank0TestHelpers.hpp
@@ -1,0 +1,29 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/Tensor/Expressions/Evaluate.hpp"
+#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+
+namespace TestHelpers::TensorExpressions {
+
+/// \ingroup TestingFrameworkGroup
+/// \brief Test that evaluating a right hand side tensor expression containing a
+/// single rank 0 tensor correctly assigns the data to the evaluated left hand
+/// side tensor
+///
+/// \param data the data being stored in the Tensors
+template <typename DataType>
+void test_evaluate_rank_0(const DataType& data) noexcept {
+  const Tensor<DataType> R{{{data}}};
+
+  // Use explicit type (vs auto) so the compiler checks the return type of
+  // `evaluate`
+  const Tensor<DataType> L = ::TensorExpressions::evaluate(R());
+
+  CHECK(L.get() == data);
+}
+
+}  // namespace TestHelpers::TensorExpressions

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank1TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank1TestHelpers.hpp
@@ -1,0 +1,76 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <iterator>
+#include <numeric>
+
+#include "DataStructures/Tensor/Expressions/Evaluate.hpp"
+#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace TestHelpers::TensorExpressions {
+
+/// \ingroup TestingFrameworkGroup
+/// \brief Test that evaluating a right hand side tensor expression containing a
+/// single rank 1 tensor correctly assigns the data to the evaluated left hand
+/// side tensor
+///
+/// \tparam DataType the type of data being stored in the Tensors
+/// \tparam TensorIndexTypeList the Tensors' typelist containing their
+/// \ref SpacetimeIndex "TensorIndexType"
+/// \param tensorindex the TensorIndex used in the the TensorExpression,
+/// e.g. `ti_a`
+template <typename DataType, typename TensorIndexTypeList, typename TensorIndex>
+void test_evaluate_rank_1_impl(const TensorIndex& tensorindex) noexcept {
+  Tensor<DataType, Symmetry<1>, TensorIndexTypeList> R_a(5_st);
+  std::iota(R_a.begin(), R_a.end(), 0.0);
+
+  // L_a = R_a
+  // Use explicit type (vs auto) so the compiler checks return type of
+  // `evaluate`
+  const Tensor<DataType, Symmetry<1>, TensorIndexTypeList> L_a =
+      ::TensorExpressions::evaluate<TensorIndex>(R_a(tensorindex));
+
+  const size_t dim = tmpl::at_c<TensorIndexTypeList, 0>::dim;
+
+  // For L_a = R_a, check that L_i == R_i
+  for (size_t i = 0; i < dim; ++i) {
+    CHECK(L_a.get(i) == R_a.get(i));
+  }
+}
+
+/// \ingroup TestingFrameworkGroup
+/// \brief Iterate testing of evaluating single rank 1 Tensors on multiple Frame
+/// types and dimensions
+///
+/// \tparam DataType the type of data being stored in the Tensors
+/// \tparam TensorIndexType the Tensors' \ref SpacetimeIndex "TensorIndexType"
+/// \tparam Valence the valence of the Tensors' index
+/// \param tensorindex the TensorIndex used in the the TensorExpression,
+/// e.g. `ti_a`
+template <typename DataType,
+          template <size_t, UpLo, typename> class TensorIndexType, UpLo Valence,
+          typename TensorIndex>
+void test_evaluate_rank_1(const TensorIndex& tensorindex) noexcept {
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define CALL_TEST_EVALUATE_RANK_1_IMPL(_, data)                                \
+  test_evaluate_rank_1_impl<                                                   \
+      DataType, index_list<TensorIndexType<DIM(data), Valence, FRAME(data)>>>( \
+      tensorindex);
+
+  GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_1_IMPL, (1, 2, 3),
+                          (Frame::Grid, Frame::Inertial))
+
+#undef CALL_TEST_EVALUATE_RANK_1_IMPL
+#undef FRAME
+#undef DIM
+}
+
+}  // namespace TestHelpers::TensorExpressions

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank2TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank2TestHelpers.hpp
@@ -1,0 +1,165 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <iterator>
+#include <numeric>
+
+#include "DataStructures/Tensor/Expressions/Evaluate.hpp"
+#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace TestHelpers::TensorExpressions {
+
+/// \ingroup TestingFrameworkGroup
+/// \brief Test that evaluating a right hand side tensor expression containing a
+/// single rank 2 tensor correctly assigns the data to the evaluated left hand
+/// side tensor
+///
+/// \details `TensorIndexA` and `TensorIndexB` can be any type of TensorIndex
+/// and are not necessarily `ti_a_t` and `ti_b_t`. The "A" and "B" suffixes just
+/// denote the ordering of the generic indices of the RHS tensor expression. In
+/// the RHS tensor expression, it means `TensorIndexA` is the first index used
+/// and `TensorIndexB` is the second index used.
+///
+/// If we consider the RHS tensor's generic indices to be (a, b), then this test
+/// checks that the data in the evaluated LHS tensor is correct according to the
+/// index orders of the LHS and RHS. The two possible cases that are checked are
+/// when the LHS tensor is evaluated with index order (a, b) and when it is
+/// evaluated with the index order (b, a).
+///
+/// \tparam DataType the type of data being stored in the Tensors
+/// \tparam RhsSymmetry the ::Symmetry of the RHS Tensor
+/// \tparam RhsTensorIndexTypeList the RHS Tensor's typelist of
+/// \ref SpacetimeIndex "TensorIndexType"s
+/// \param tensorindex_a the first TensorIndex used on the RHS of the
+/// TensorExpression, e.g. `ti_a`
+/// \param tensorindex_b the second TensorIndex used on the RHS of the
+/// TensorExpression, e.g. `ti_B`
+template <typename DataType, typename RhsSymmetry,
+          typename RhsTensorIndexTypeList, typename TensorIndexA,
+          typename TensorIndexB>
+void test_evaluate_rank_2_impl(const TensorIndexA& tensorindex_a,
+                               const TensorIndexB& tensorindex_b) noexcept {
+  Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList> R_ab(5_st);
+  std::iota(R_ab.begin(), R_ab.end(), 0.0);
+
+  // L_{ab} = R_{ab}
+  // Use explicit type (vs auto) so the compiler checks the return type of
+  // `evaluate`
+  const Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList> L_ab =
+      ::TensorExpressions::evaluate<TensorIndexA, TensorIndexB>(
+          R_ab(tensorindex_a, tensorindex_b));
+
+  // L_{ba} = R_{ab}
+  using L_ba_tensorindextype_list =
+      tmpl::list<tmpl::at_c<RhsTensorIndexTypeList, 1>,
+                 tmpl::at_c<RhsTensorIndexTypeList, 0>>;
+  const Tensor<DataType, RhsSymmetry, L_ba_tensorindextype_list> L_ba =
+      ::TensorExpressions::evaluate<TensorIndexB, TensorIndexA>(
+          R_ab(tensorindex_a, tensorindex_b));
+
+  const size_t dim_a = tmpl::at_c<RhsTensorIndexTypeList, 0>::dim;
+  const size_t dim_b = tmpl::at_c<RhsTensorIndexTypeList, 1>::dim;
+
+  for (size_t i = 0; i < dim_a; ++i) {
+    for (size_t j = 0; j < dim_b; ++j) {
+      // For L_{ab} = R_{ab}, check that L_{ij} == R_{ij}
+      CHECK(L_ab.get(i, j) == R_ab.get(i, j));
+      // For L_{ba} = R_{ab}, check that L_{ji} == R_{ij}
+      CHECK(L_ba.get(j, i) == R_ab.get(i, j));
+    }
+  }
+}
+
+/// \ingroup TestingFrameworkGroup
+/// \brief Iterate testing of evaluating single rank 2 Tensors on multiple Frame
+/// types and dimension combinations
+///
+/// We test nonsymmetric indices and symmetric indices across two functions to
+/// ensure that the code works correctly with symmetries. This function tests
+/// one of the following symmetries:
+/// - <2, 1> (`test_evaluate_rank_2_no_symmetry`)
+/// - <1, 1> (`test_evaluate_rank_2_symmetric`)
+///
+/// \details `TensorIndexA` and `TensorIndexB` can be any type of TensorIndex
+/// and are not necessarily `ti_a_t` and `ti_b_t`. The "A" and "B" suffixes just
+/// denote the ordering of the generic indices of the RHS tensor expression. In
+/// the RHS tensor expression, it means `TensorIndexA` is the first index used
+/// and `TensorIndexB` is the second index used.
+///
+/// Note: `test_evaluate_rank_2_symmetric` has fewer template parameters due to
+/// the two indices having a shared \ref SpacetimeIndex "TensorIndexType" and
+/// and valence
+///
+/// \tparam DataType the type of data being stored in the Tensors
+/// \tparam TensorIndexTypeA the \ref SpacetimeIndex "TensorIndexType" of the
+/// first index of the RHS Tensor
+/// \tparam TensorIndexTypeB the \ref SpacetimeIndex "TensorIndexType" of the
+/// second index of the RHS Tensor
+/// \tparam ValenceA the valence of the first index used on the RHS of the
+/// TensorExpression
+/// \tparam ValenceB the valence of the second index used on the RHS of the
+/// TensorExpression
+/// \param tensorindex_a the first TensorIndex used on the RHS of the
+/// TensorExpression, e.g. `ti_a`
+/// \param tensorindex_b the second TensorIndex used on the RHS of the
+/// TensorExpression, e.g. `ti_B`
+template <
+    typename DataType, template <size_t, UpLo, typename> class TensorIndexTypeA,
+    template <size_t, UpLo, typename> class TensorIndexTypeB, UpLo ValenceA,
+    UpLo ValenceB, typename TensorIndexA, typename TensorIndexB>
+void test_evaluate_rank_2_no_symmetry(
+    const TensorIndexA& tensorindex_a,
+    const TensorIndexB& tensorindex_b) noexcept {
+#define DIM_A(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DIM_B(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define CALL_TEST_EVALUATE_RANK_2_IMPL(_, data)                          \
+  test_evaluate_rank_2_impl<                                             \
+      DataType, Symmetry<2, 1>,                                          \
+      index_list<TensorIndexTypeA<DIM_A(data), ValenceA, FRAME(data)>,   \
+                 TensorIndexTypeB<DIM_B(data), ValenceB, FRAME(data)>>>( \
+      tensorindex_a, tensorindex_b);
+
+  GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_2_IMPL, (1, 2, 3), (1, 2, 3),
+                          (Frame::Grid, Frame::Inertial))
+
+#undef CALL_TEST_EVALUATE_RANK_2_IMPL
+#undef FRAME
+#undef DIM_B
+#undef DIM_A
+}
+
+/// \ingroup TestingFrameworkGroup
+/// \copydoc test_evaluate_rank_2_no_symmetry()
+template <
+    typename DataType, template <size_t, UpLo, typename> class TensorIndexType,
+    UpLo Valence, typename TensorIndexA, typename TensorIndexB>
+void test_evaluate_rank_2_symmetric(
+    const TensorIndexA& tensorindex_a,
+    const TensorIndexB& tensorindex_b) noexcept {
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define CALL_TEST_EVALUATE_RANK_2_IMPL(_, data)                     \
+  test_evaluate_rank_2_impl<                                        \
+      DataType, Symmetry<1, 1>,                                     \
+      index_list<TensorIndexType<DIM(data), Valence, FRAME(data)>,  \
+                 TensorIndexType<DIM(data), Valence, FRAME(data)>>, \
+      TensorIndexA, TensorIndexB>(tensorindex_a, tensorindex_b);
+
+  GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_2_IMPL, (1, 2, 3),
+                          (Frame::Grid, Frame::Inertial))
+
+#undef CALL_TEST_EVALUATE_RANK_2_IMPL
+#undef FRAME
+#undef DIM
+}
+
+}  // namespace TestHelpers::TensorExpressions

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank3TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank3TestHelpers.hpp
@@ -1,0 +1,346 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <iterator>
+#include <numeric>
+
+#include "DataStructures/Tensor/Expressions/Evaluate.hpp"
+#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace TestHelpers::TensorExpressions {
+
+/// \ingroup TestingFrameworkGroup
+/// \brief Test that evaluating a right hand side tensor expression containing a
+/// single rank 3 tensor correctly assigns the data to the evaluated left hand
+/// side tensor
+///
+/// \details `TensorIndexA`, `TensorIndexB`, and `TensorIndexC` can be any type
+/// of TensorIndex and are not necessarily `ti_a_t`, `ti_b_t`, and `ti_c_t`. The
+/// "A", "B", and "C" suffixes just denote the ordering of the generic indices
+/// of the RHS tensor expression. In the RHS tensor expression, it means
+/// `TensorIndexA` is the first index used, `TensorIndexB` is the second index
+/// used, and `TensorIndexC` is the third index used.
+///
+/// If we consider the RHS tensor's generic indices to be (a, b, c), then this
+/// test checks that the data in the evaluated LHS tensor is correct according
+/// to the index orders of the LHS and RHS. The possible cases that are checked
+/// are when the LHS tensor is evaluated with index orders: (a, b, c),
+/// (a, c, b), (b, a, c), (b, c, a), (c, a, b), and (c, b, a).
+///
+/// \tparam DataType the type of data being stored in the Tensors
+/// \tparam RhsSymmetry the ::Symmetry of the RHS Tensor
+/// \tparam RhsTensorIndexTypeList the RHS Tensor's typelist of
+/// \ref SpacetimeIndex "TensorIndexType"s
+/// \param tensorindex_a the first TensorIndex used on the RHS of the
+/// TensorExpression, e.g. `ti_a`
+/// \param tensorindex_b the second TensorIndex used on the RHS of the
+/// TensorExpression, e.g. `ti_B`
+/// \param tensorindex_c the third TensorIndex used on the RHS of the
+/// TensorExpression, e.g. `ti_c`
+template <typename DataType, typename RhsSymmetry,
+          typename RhsTensorIndexTypeList, typename TensorIndexA,
+          typename TensorIndexB, typename TensorIndexC>
+void test_evaluate_rank_3_impl(const TensorIndexA& tensorindex_a,
+                               const TensorIndexB& tensorindex_b,
+                               const TensorIndexC& tensorindex_c) noexcept {
+  Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList> R_abc(5_st);
+  std::iota(R_abc.begin(), R_abc.end(), 0.0);
+
+  // Used for enforcing the ordering of the symmetry and TensorIndexTypes of the
+  // LHS Tensor returned by `evaluate`
+  const std::int32_t rhs_symmetry_element_a = tmpl::at_c<RhsSymmetry, 0>::value;
+  const std::int32_t rhs_symmetry_element_b = tmpl::at_c<RhsSymmetry, 1>::value;
+  const std::int32_t rhs_symmetry_element_c = tmpl::at_c<RhsSymmetry, 2>::value;
+  using rhs_tensorindextype_a = tmpl::at_c<RhsTensorIndexTypeList, 0>;
+  using rhs_tensorindextype_b = tmpl::at_c<RhsTensorIndexTypeList, 1>;
+  using rhs_tensorindextype_c = tmpl::at_c<RhsTensorIndexTypeList, 2>;
+
+  // L_{abc} = R_{abc}
+  // Use explicit type (vs auto) so the compiler checks the return type of
+  // `evaluate`
+  const Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList> L_abc =
+      ::TensorExpressions::evaluate<TensorIndexA, TensorIndexB, TensorIndexC>(
+          R_abc(tensorindex_a, tensorindex_b, tensorindex_c));
+
+  // L_{acb} = R_{abc}
+  using L_acb_symmetry =
+      Symmetry<rhs_symmetry_element_a, rhs_symmetry_element_c,
+               rhs_symmetry_element_b>;
+  using L_acb_tensorindextype_list =
+      tmpl::list<rhs_tensorindextype_a, rhs_tensorindextype_c,
+                 rhs_tensorindextype_b>;
+  const Tensor<DataType, L_acb_symmetry, L_acb_tensorindextype_list> L_acb =
+      ::TensorExpressions::evaluate<TensorIndexA, TensorIndexC, TensorIndexB>(
+          R_abc(tensorindex_a, tensorindex_b, tensorindex_c));
+
+  // L_{bac} = R_{abc}
+  using L_bac_symmetry =
+      Symmetry<rhs_symmetry_element_b, rhs_symmetry_element_a,
+               rhs_symmetry_element_c>;
+  using L_bac_tensorindextype_list =
+      tmpl::list<rhs_tensorindextype_b, rhs_tensorindextype_a,
+                 rhs_tensorindextype_c>;
+  const Tensor<DataType, L_bac_symmetry, L_bac_tensorindextype_list> L_bac =
+      ::TensorExpressions::evaluate<TensorIndexB, TensorIndexA, TensorIndexC>(
+          R_abc(tensorindex_a, tensorindex_b, tensorindex_c));
+
+  // L_{bca} = R_{abc}
+  using L_bca_symmetry =
+      Symmetry<rhs_symmetry_element_b, rhs_symmetry_element_c,
+               rhs_symmetry_element_a>;
+  using L_bca_tensorindextype_list =
+      tmpl::list<rhs_tensorindextype_b, rhs_tensorindextype_c,
+                 rhs_tensorindextype_a>;
+  const Tensor<DataType, L_bca_symmetry, L_bca_tensorindextype_list> L_bca =
+      ::TensorExpressions::evaluate<TensorIndexB, TensorIndexC, TensorIndexA>(
+          R_abc(tensorindex_a, tensorindex_b, tensorindex_c));
+
+  // L_{cab} = R_{abc}
+  using L_cab_symmetry =
+      Symmetry<rhs_symmetry_element_c, rhs_symmetry_element_a,
+               rhs_symmetry_element_b>;
+  using L_cab_tensorindextype_list =
+      tmpl::list<rhs_tensorindextype_c, rhs_tensorindextype_a,
+                 rhs_tensorindextype_b>;
+  const Tensor<DataType, L_cab_symmetry, L_cab_tensorindextype_list> L_cab =
+      ::TensorExpressions::evaluate<TensorIndexC, TensorIndexA, TensorIndexB>(
+          R_abc(tensorindex_a, tensorindex_b, tensorindex_c));
+
+  // L_{cba} = R_{abc}
+  using L_cba_symmetry =
+      Symmetry<rhs_symmetry_element_c, rhs_symmetry_element_b,
+               rhs_symmetry_element_a>;
+  using L_cba_tensorindextype_list =
+      tmpl::list<rhs_tensorindextype_c, rhs_tensorindextype_b,
+                 rhs_tensorindextype_a>;
+  const Tensor<DataType, L_cba_symmetry, L_cba_tensorindextype_list> L_cba =
+      ::TensorExpressions::evaluate<TensorIndexC, TensorIndexB, TensorIndexA>(
+          R_abc(tensorindex_a, tensorindex_b, tensorindex_c));
+
+  const size_t dim_a = tmpl::at_c<RhsTensorIndexTypeList, 0>::dim;
+  const size_t dim_b = tmpl::at_c<RhsTensorIndexTypeList, 1>::dim;
+  const size_t dim_c = tmpl::at_c<RhsTensorIndexTypeList, 2>::dim;
+
+  for (size_t i = 0; i < dim_a; ++i) {
+    for (size_t j = 0; j < dim_b; ++j) {
+      for (size_t k = 0; k < dim_c; ++k) {
+        // For L_{abc} = R_{abc}, check that L_{ijk} == R_{ijk}
+        CHECK(L_abc.get(i, j, k) == R_abc.get(i, j, k));
+        // For L_{acb} = R_{abc}, check that L_{ikj} == R_{ijk}
+        CHECK(L_acb.get(i, k, j) == R_abc.get(i, j, k));
+        // For L_{bac} = R_{abc}, check that L_{jik} == R_{ijk}
+        CHECK(L_bac.get(j, i, k) == R_abc.get(i, j, k));
+        // For L_{bca} = R_{abc}, check that L_{jki} == R_{ijk}
+        CHECK(L_bca.get(j, k, i) == R_abc.get(i, j, k));
+        // For L_{cab} = R_{abc}, check that L_{kij} == R_{ijk}
+        CHECK(L_cab.get(k, i, j) == R_abc.get(i, j, k));
+        // For L_{cba} = R_{abc}, check that L_{kji} == R_{ijk}
+        CHECK(L_cba.get(k, j, i) == R_abc.get(i, j, k));
+      }
+    }
+  }
+}
+
+/// \ingroup TestingFrameworkGroup
+/// \brief Iterate testing of evaluating single rank 3 Tensors on multiple Frame
+/// types and dimension combinations
+///
+/// We test various different symmetries across several functions to ensure that
+/// the code works correctly with symmetries. This function tests one of the
+/// following symmetries:
+/// - <3, 2, 1> (`test_evaluate_rank_3_no_symmetry`)
+/// - <2, 2, 1> (`test_evaluate_rank_3_ab_symmetry`)
+/// - <2, 1, 2> (`test_evaluate_rank_3_ac_symmetry`)
+/// - <2, 1, 1> (`test_evaluate_rank_3_bc_symmetry`)
+/// - <1, 1, 1> (`test_evaluate_rank_3_abc_symmetry`)
+///
+/// \details `TensorIndexA`, `TensorIndexB`, and `TensorIndexC` can be any type
+/// of TensorIndex and are not necessarily `ti_a_t`, `ti_b_t`, and `ti_c_t`. The
+/// "A", "B", and "C" suffixes just denote the ordering of the generic indices
+/// of the RHS tensor expression. In the RHS tensor expression, it means
+/// `TensorIndexA` is the first index used, `TensorIndexB` is the second index
+/// used, and `TensorIndexC` is the third index used.
+///
+/// Note: the functions dealing with symmetric indices have fewer template
+/// parameters due to the indices having a shared \ref SpacetimeIndex
+/// "TensorIndexType" and valence
+///
+/// \tparam DataType the type of data being stored in the Tensors
+/// \tparam TensorIndexTypeA the \ref SpacetimeIndex "TensorIndexType" of the
+/// first index of the RHS Tensor
+/// \tparam TensorIndexTypeB the \ref SpacetimeIndex "TensorIndexType" of the
+/// second index of the RHS Tensor
+/// \tparam TensorIndexTypeC the \ref SpacetimeIndex "TensorIndexType" of the
+/// third index of the RHS Tensor
+/// \tparam ValenceA the valence of the first index used on the RHS of the
+/// TensorExpression
+/// \tparam ValenceB the valence of the second index used on the RHS of the
+/// TensorExpression
+/// \tparam ValenceC the valence of the third index used on the RHS of the
+/// TensorExpression
+/// \param tensorindex_a the first TensorIndex used on the RHS of the
+/// TensorExpression, e.g. `ti_a`
+/// \param tensorindex_b the second TensorIndex used on the RHS of the
+/// TensorExpression, e.g. `ti_B`
+/// \param tensorindex_c the third TensorIndex used on the RHS of the
+/// TensorExpression, e.g. `ti_c`
+template <typename DataType,
+          template <size_t, UpLo, typename> class TensorIndexTypeA,
+          template <size_t, UpLo, typename> class TensorIndexTypeB,
+          template <size_t, UpLo, typename> class TensorIndexTypeC,
+          UpLo ValenceA, UpLo ValenceB, UpLo ValenceC, typename TensorIndexA,
+          typename TensorIndexB, typename TensorIndexC>
+void test_evaluate_rank_3_no_symmetry(
+    const TensorIndexA& tensorindex_a, const TensorIndexB& tensorindex_b,
+    const TensorIndexC& tensorindex_c) noexcept {
+#define DIM_A(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DIM_B(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define DIM_C(data) BOOST_PP_TUPLE_ELEM(2, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(3, data)
+
+#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                          \
+  test_evaluate_rank_3_impl<                                             \
+      DataType, Symmetry<3, 2, 1>,                                       \
+      index_list<TensorIndexTypeA<DIM_A(data), ValenceA, FRAME(data)>,   \
+                 TensorIndexTypeB<DIM_B(data), ValenceB, FRAME(data)>,   \
+                 TensorIndexTypeC<DIM_C(data), ValenceC, FRAME(data)>>>( \
+      tensorindex_a, tensorindex_b, tensorindex_c);
+
+  GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3), (1, 2, 3),
+                          (1, 2, 3), (Frame::Grid, Frame::Inertial))
+
+#undef CALL_TEST_EVALUATE_RANK_3_IMPL
+#undef FRAME
+#undef DIM_C
+#undef DIM_B
+#undef DIM_A
+}
+
+/// \ingroup TestingFrameworkGroup
+/// \copydoc test_evaluate_rank_3_no_symmetry()
+template <typename DataType,
+          template <size_t, UpLo, typename> class TensorIndexTypeAB,
+          template <size_t, UpLo, typename> class TensorIndexTypeC,
+          UpLo ValenceAB, UpLo ValenceC, typename TensorIndexA,
+          typename TensorIndexB, typename TensorIndexC>
+void test_evaluate_rank_3_ab_symmetry(
+    const TensorIndexA& tensorindex_a, const TensorIndexB& tensorindex_b,
+    const TensorIndexC& tensorindex_c) noexcept {
+#define DIM_AB(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DIM_C(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                            \
+  test_evaluate_rank_3_impl<                                               \
+      DataType, Symmetry<2, 2, 1>,                                         \
+      index_list<TensorIndexTypeAB<DIM_AB(data), ValenceAB, FRAME(data)>,  \
+                 TensorIndexTypeAB<DIM_AB(data), ValenceAB, FRAME(data)>,  \
+                 TensorIndexTypeC<DIM_C(data), ValenceC, FRAME(data)>>>(   \
+      tensorindex_a, tensorindex_b, tensorindex_c);
+
+  GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3), (1, 2, 3),
+                          (Frame::Grid, Frame::Inertial))
+
+#undef CALL_TEST_EVALUATE_RANK_3_IMPL
+#undef FRAME
+#undef DIM_C
+#undef DIM_AB
+}
+
+/// \ingroup TestingFrameworkGroup
+/// \copydoc test_evaluate_rank_3_no_symmetry()
+template <typename DataType,
+          template <size_t, UpLo, typename> class TensorIndexTypeAC,
+          template <size_t, UpLo, typename> class TensorIndexTypeB,
+          UpLo ValenceAC, UpLo ValenceB, typename TensorIndexA,
+          typename TensorIndexB, typename TensorIndexC>
+void test_evaluate_rank_3_ac_symmetry(
+    const TensorIndexA& tensorindex_a, const TensorIndexB& tensorindex_b,
+    const TensorIndexC& tensorindex_c) noexcept {
+#define DIM_AC(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DIM_B(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                             \
+  test_evaluate_rank_3_impl<                                                \
+      DataType, Symmetry<2, 1, 2>,                                          \
+      index_list<TensorIndexTypeAC<DIM_AC(data), ValenceAC, FRAME(data)>,   \
+                 TensorIndexTypeB<DIM_B(data), ValenceB, FRAME(data)>,      \
+                 TensorIndexTypeAC<DIM_AC(data), ValenceAC, FRAME(data)>>>( \
+      tensorindex_a, tensorindex_b, tensorindex_c);
+
+  GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3), (1, 2, 3),
+                          (Frame::Grid, Frame::Inertial))
+
+#undef CALL_TEST_EVALUATE_RANK_3_IMPL
+#undef FRAME
+#undef DIM_B
+#undef DIM_AC
+}
+
+/// \ingroup TestingFrameworkGroup
+/// \copydoc test_evaluate_rank_3_no_symmetry()
+template <typename DataType,
+          template <size_t, UpLo, typename> class TensorIndexTypeA,
+          template <size_t, UpLo, typename> class TensorIndexTypeBC,
+          UpLo ValenceA, UpLo ValenceBC, typename TensorIndexA,
+          typename TensorIndexB, typename TensorIndexC>
+void test_evaluate_rank_3_bc_symmetry(
+    const TensorIndexA& tensorindex_a, const TensorIndexB& tensorindex_b,
+    const TensorIndexC& tensorindex_c) noexcept {
+#define DIM_A(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DIM_BC(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                             \
+  test_evaluate_rank_3_impl<                                                \
+      DataType, Symmetry<2, 1, 1>,                                          \
+      index_list<TensorIndexTypeA<DIM_A(data), ValenceA, FRAME(data)>,      \
+                 TensorIndexTypeBC<DIM_BC(data), ValenceBC, FRAME(data)>,   \
+                 TensorIndexTypeBC<DIM_BC(data), ValenceBC, FRAME(data)>>>( \
+      tensorindex_a, tensorindex_b, tensorindex_c);
+
+  GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3), (1, 2, 3),
+                          (Frame::Grid, Frame::Inertial))
+
+#undef CALL_TEST_EVALUATE_RANK_3_IMPL
+#undef FRAME
+#undef DIM_BC
+#undef DIM_A
+}
+
+/// \ingroup TestingFrameworkGroup
+/// \copydoc test_evaluate_rank_3_no_symmetry()
+template <typename DataType,
+          template <size_t, UpLo, typename> class TensorIndexType, UpLo Valence,
+          typename TensorIndexA, typename TensorIndexB, typename TensorIndexC>
+void test_evaluate_rank_3_abc_symmetry(
+    const TensorIndexA& tensorindex_a, const TensorIndexB& tensorindex_b,
+    const TensorIndexC& tensorindex_c) noexcept {
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                      \
+  test_evaluate_rank_3_impl<                                         \
+      DataType, Symmetry<1, 1, 1>,                                   \
+      index_list<TensorIndexType<DIM(data), Valence, FRAME(data)>,   \
+                 TensorIndexType<DIM(data), Valence, FRAME(data)>,   \
+                 TensorIndexType<DIM(data), Valence, FRAME(data)>>>( \
+      tensorindex_a, tensorindex_b, tensorindex_c);
+
+  GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3),
+                          (Frame::Grid, Frame::Inertial))
+
+#undef CALL_TEST_EVALUATE_RANK_3_IMPL
+#undef FRAME
+#undef DIM
+}
+
+}  // namespace TestHelpers::TensorExpressions

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank4TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank4TestHelpers.hpp
@@ -1,0 +1,416 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <iterator>
+#include <numeric>
+
+#include "DataStructures/Tensor/Expressions/Evaluate.hpp"
+#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace TestHelpers::TensorExpressions {
+
+/// \ingroup TestingFrameworkGroup
+/// \brief Test that evaluating a right hand side tensor expression containing a
+/// single rank 4 tensor correctly assigns the data to the evaluated left hand
+/// side tensor
+///
+/// \details `TensorIndexA`, `TensorIndexB`, `TensorIndexC`, and  `TensorIndexD`
+/// can be any type of TensorIndex and are not necessarily `ti_a_t`, `ti_b_t`,
+/// `ti_c_t`, and `ti_d_t`. The "A", "B", "C", and "D" suffixes just denote the
+/// ordering of the generic indices of the RHS tensor expression. In the RHS
+/// tensor expression, it means `TensorIndexA` is the first index used,
+/// `TensorIndexB` is the second index used, `TensorIndexC` is the third index
+/// used, and `TensorIndexD` is the fourth index used.
+///
+/// If we consider the RHS tensor's generic indices to be (a, b, c, d), then
+/// this test checks that the data in the evaluated LHS tensor is correct
+/// according to the index orders of the LHS and RHS. The possible cases that
+/// are checked are when the LHS tensor is evaluated with index orders of all 24
+/// permutations of (a, b, c, d), e.g. (a, b, d, c), (a, c, b, d), ...
+///
+/// \tparam DataType the type of data being stored in the Tensors
+/// \tparam RhsSymmetry the ::Symmetry of the RHS Tensor
+/// \tparam RhsTensorIndexTypeList the RHS Tensor's typelist of
+/// \ref SpacetimeIndex "TensorIndexType"s
+/// \param tensorindex_a the first TensorIndex used on the RHS of the
+/// TensorExpression, e.g. `ti_a`
+/// \param tensorindex_b the second TensorIndex used on the RHS of the
+/// TensorExpression, e.g. `ti_B`
+/// \param tensorindex_c the third TensorIndex used on the RHS of the
+/// TensorExpression, e.g. `ti_c`
+/// \param tensorindex_d the fourth TensorIndex used on the RHS of the
+/// TensorExpression, e.g. `ti_D`
+template <typename DataType, typename RhsSymmetry,
+          typename RhsTensorIndexTypeList, typename TensorIndexA,
+          typename TensorIndexB, typename TensorIndexC, typename TensorIndexD>
+void test_evaluate_rank_4(const TensorIndexA& tensorindex_a,
+                          const TensorIndexB& tensorindex_b,
+                          const TensorIndexC& tensorindex_c,
+                          const TensorIndexD& tensorindex_d) noexcept {
+  Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList> R_abcd(5_st);
+  std::iota(R_abcd.begin(), R_abcd.end(), 0.0);
+
+  // Used for enforcing the ordering of the symmetry and TensorIndexTypes of the
+  // LHS Tensor returned by `evaluate`
+  const std::int32_t rhs_symmetry_element_a = tmpl::at_c<RhsSymmetry, 0>::value;
+  const std::int32_t rhs_symmetry_element_b = tmpl::at_c<RhsSymmetry, 1>::value;
+  const std::int32_t rhs_symmetry_element_c = tmpl::at_c<RhsSymmetry, 2>::value;
+  const std::int32_t rhs_symmetry_element_d = tmpl::at_c<RhsSymmetry, 3>::value;
+  using rhs_tensorindextype_a = tmpl::at_c<RhsTensorIndexTypeList, 0>;
+  using rhs_tensorindextype_b = tmpl::at_c<RhsTensorIndexTypeList, 1>;
+  using rhs_tensorindextype_c = tmpl::at_c<RhsTensorIndexTypeList, 2>;
+  using rhs_tensorindextype_d = tmpl::at_c<RhsTensorIndexTypeList, 3>;
+
+  // L_{abcd} = R_{abcd}
+  // Use explicit type (vs auto) so the compiler checks the return type of
+  // `evaluate`
+  const Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList> L_abcd =
+      ::TensorExpressions::evaluate<TensorIndexA, TensorIndexB, TensorIndexC,
+                                    TensorIndexD>(
+          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+
+  // L_{abdc} = R_{abcd}
+  using L_abdc_symmetry =
+      Symmetry<rhs_symmetry_element_a, rhs_symmetry_element_b,
+               rhs_symmetry_element_d, rhs_symmetry_element_c>;
+  using L_abdc_tensorindextype_list =
+      tmpl::list<rhs_tensorindextype_a, rhs_tensorindextype_b,
+                 rhs_tensorindextype_d, rhs_tensorindextype_c>;
+  const Tensor<DataType, L_abdc_symmetry, L_abdc_tensorindextype_list> L_abdc =
+      ::TensorExpressions::evaluate<TensorIndexA, TensorIndexB, TensorIndexD,
+                                    TensorIndexC>(
+          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+
+  // L_{acbd} = R_{abcd}
+  using L_acbd_symmetry =
+      Symmetry<rhs_symmetry_element_a, rhs_symmetry_element_c,
+               rhs_symmetry_element_b, rhs_symmetry_element_d>;
+  using L_acbd_tensorindextype_list =
+      tmpl::list<rhs_tensorindextype_a, rhs_tensorindextype_c,
+                 rhs_tensorindextype_b, rhs_tensorindextype_d>;
+  const Tensor<DataType, L_acbd_symmetry, L_acbd_tensorindextype_list> L_acbd =
+      ::TensorExpressions::evaluate<TensorIndexA, TensorIndexC, TensorIndexB,
+                                    TensorIndexD>(
+          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+
+  // L_{acdb} = R_{abcd}
+  using L_acdb_symmetry =
+      Symmetry<rhs_symmetry_element_a, rhs_symmetry_element_c,
+               rhs_symmetry_element_d, rhs_symmetry_element_b>;
+  using L_acdb_tensorindextype_list =
+      tmpl::list<rhs_tensorindextype_a, rhs_tensorindextype_c,
+                 rhs_tensorindextype_d, rhs_tensorindextype_b>;
+  const Tensor<DataType, L_acdb_symmetry, L_acdb_tensorindextype_list> L_acdb =
+      ::TensorExpressions::evaluate<TensorIndexA, TensorIndexC, TensorIndexD,
+                                    TensorIndexB>(
+          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+
+  // L_{adbc} = R_{abcd}
+  using L_adbc_symmetry =
+      Symmetry<rhs_symmetry_element_a, rhs_symmetry_element_d,
+               rhs_symmetry_element_b, rhs_symmetry_element_c>;
+  using L_adbc_tensorindextype_list =
+      tmpl::list<rhs_tensorindextype_a, rhs_tensorindextype_d,
+                 rhs_tensorindextype_b, rhs_tensorindextype_c>;
+  const Tensor<DataType, L_adbc_symmetry, L_adbc_tensorindextype_list> L_adbc =
+      ::TensorExpressions::evaluate<TensorIndexA, TensorIndexD, TensorIndexB,
+                                    TensorIndexC>(
+          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+
+  // L_{adcb} = R_{abcd}
+  using L_adcb_symmetry =
+      Symmetry<rhs_symmetry_element_a, rhs_symmetry_element_d,
+               rhs_symmetry_element_c, rhs_symmetry_element_b>;
+  using L_adcb_tensorindextype_list =
+      tmpl::list<rhs_tensorindextype_a, rhs_tensorindextype_d,
+                 rhs_tensorindextype_c, rhs_tensorindextype_b>;
+  const Tensor<DataType, L_adcb_symmetry, L_adcb_tensorindextype_list> L_adcb =
+      ::TensorExpressions::evaluate<TensorIndexA, TensorIndexD, TensorIndexC,
+                                    TensorIndexB>(
+          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+
+  // L_{bacd} = R_{abcd}
+  using L_bacd_symmetry =
+      Symmetry<rhs_symmetry_element_b, rhs_symmetry_element_a,
+               rhs_symmetry_element_c, rhs_symmetry_element_d>;
+  using L_bacd_tensorindextype_list =
+      tmpl::list<rhs_tensorindextype_b, rhs_tensorindextype_a,
+                 rhs_tensorindextype_c, rhs_tensorindextype_d>;
+  const Tensor<DataType, L_bacd_symmetry, L_bacd_tensorindextype_list> L_bacd =
+      ::TensorExpressions::evaluate<TensorIndexB, TensorIndexA, TensorIndexC,
+                                    TensorIndexD>(
+          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+
+  // L_{badc} = R_{abcd}
+  using L_badc_symmetry =
+      Symmetry<rhs_symmetry_element_b, rhs_symmetry_element_a,
+               rhs_symmetry_element_d, rhs_symmetry_element_c>;
+  using L_badc_tensorindextype_list =
+      tmpl::list<rhs_tensorindextype_b, rhs_tensorindextype_a,
+                 rhs_tensorindextype_d, rhs_tensorindextype_c>;
+  const Tensor<DataType, L_badc_symmetry, L_badc_tensorindextype_list> L_badc =
+      ::TensorExpressions::evaluate<TensorIndexB, TensorIndexA, TensorIndexD,
+                                    TensorIndexC>(
+          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+
+  // L_{bcad} = R_{abcd}
+  using L_bcad_symmetry =
+      Symmetry<rhs_symmetry_element_b, rhs_symmetry_element_c,
+               rhs_symmetry_element_a, rhs_symmetry_element_d>;
+  using L_bcad_tensorindextype_list =
+      tmpl::list<rhs_tensorindextype_b, rhs_tensorindextype_c,
+                 rhs_tensorindextype_a, rhs_tensorindextype_d>;
+  const Tensor<DataType, L_bcad_symmetry, L_bcad_tensorindextype_list> L_bcad =
+      ::TensorExpressions::evaluate<TensorIndexB, TensorIndexC, TensorIndexA,
+                                    TensorIndexD>(
+          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+
+  // L_{bcda} = R_{abcd}
+  using L_bcda_symmetry =
+      Symmetry<rhs_symmetry_element_b, rhs_symmetry_element_c,
+               rhs_symmetry_element_d, rhs_symmetry_element_a>;
+  using L_bcda_tensorindextype_list =
+      tmpl::list<rhs_tensorindextype_b, rhs_tensorindextype_c,
+                 rhs_tensorindextype_d, rhs_tensorindextype_a>;
+  const Tensor<DataType, L_bcda_symmetry, L_bcda_tensorindextype_list> L_bcda =
+      ::TensorExpressions::evaluate<TensorIndexB, TensorIndexC, TensorIndexD,
+                                    TensorIndexA>(
+          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+
+  // L_{bdac} = R_{abcd}
+  using L_bdac_symmetry =
+      Symmetry<rhs_symmetry_element_b, rhs_symmetry_element_d,
+               rhs_symmetry_element_a, rhs_symmetry_element_c>;
+  using L_bdac_tensorindextype_list =
+      tmpl::list<rhs_tensorindextype_b, rhs_tensorindextype_d,
+                 rhs_tensorindextype_a, rhs_tensorindextype_c>;
+  const Tensor<DataType, L_bdac_symmetry, L_bdac_tensorindextype_list> L_bdac =
+      ::TensorExpressions::evaluate<TensorIndexB, TensorIndexD, TensorIndexA,
+                                    TensorIndexC>(
+          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+
+  // L_{bdca} = R_{abcd}
+  using L_bdca_symmetry =
+      Symmetry<rhs_symmetry_element_b, rhs_symmetry_element_d,
+               rhs_symmetry_element_c, rhs_symmetry_element_a>;
+  using L_bdca_tensorindextype_list =
+      tmpl::list<rhs_tensorindextype_b, rhs_tensorindextype_d,
+                 rhs_tensorindextype_c, rhs_tensorindextype_a>;
+  const Tensor<DataType, L_bdca_symmetry, L_bdca_tensorindextype_list> L_bdca =
+      ::TensorExpressions::evaluate<TensorIndexB, TensorIndexD, TensorIndexC,
+                                    TensorIndexA>(
+          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+
+  // L_{cabd} = R_{abcd}
+  using L_cabd_symmetry =
+      Symmetry<rhs_symmetry_element_c, rhs_symmetry_element_a,
+               rhs_symmetry_element_b, rhs_symmetry_element_d>;
+  using L_cabd_tensorindextype_list =
+      tmpl::list<rhs_tensorindextype_c, rhs_tensorindextype_a,
+                 rhs_tensorindextype_b, rhs_tensorindextype_d>;
+  const Tensor<DataType, L_cabd_symmetry, L_cabd_tensorindextype_list> L_cabd =
+      ::TensorExpressions::evaluate<TensorIndexC, TensorIndexA, TensorIndexB,
+                                    TensorIndexD>(
+          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+
+  // L_{cadb} = R_{abcd}
+  using L_cadb_symmetry =
+      Symmetry<rhs_symmetry_element_c, rhs_symmetry_element_a,
+               rhs_symmetry_element_d, rhs_symmetry_element_b>;
+  using L_cadb_tensorindextype_list =
+      tmpl::list<rhs_tensorindextype_c, rhs_tensorindextype_a,
+                 rhs_tensorindextype_d, rhs_tensorindextype_b>;
+  const Tensor<DataType, L_cadb_symmetry, L_cadb_tensorindextype_list> L_cadb =
+      ::TensorExpressions::evaluate<TensorIndexC, TensorIndexA, TensorIndexD,
+                                    TensorIndexB>(
+          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+
+  // L_{cbad} = R_{abcd}
+  using L_cbad_symmetry =
+      Symmetry<rhs_symmetry_element_c, rhs_symmetry_element_b,
+               rhs_symmetry_element_a, rhs_symmetry_element_d>;
+  using L_cbad_tensorindextype_list =
+      tmpl::list<rhs_tensorindextype_c, rhs_tensorindextype_b,
+                 rhs_tensorindextype_a, rhs_tensorindextype_d>;
+  const Tensor<DataType, L_cbad_symmetry, L_cbad_tensorindextype_list> L_cbad =
+      ::TensorExpressions::evaluate<TensorIndexC, TensorIndexB, TensorIndexA,
+                                    TensorIndexD>(
+          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+
+  // L_{cbda} = R_{abcd}
+  using L_cbda_symmetry =
+      Symmetry<rhs_symmetry_element_c, rhs_symmetry_element_b,
+               rhs_symmetry_element_d, rhs_symmetry_element_a>;
+  using L_cbda_tensorindextype_list =
+      tmpl::list<rhs_tensorindextype_c, rhs_tensorindextype_b,
+                 rhs_tensorindextype_d, rhs_tensorindextype_a>;
+  const Tensor<DataType, L_cbda_symmetry, L_cbda_tensorindextype_list> L_cbda =
+      ::TensorExpressions::evaluate<TensorIndexC, TensorIndexB, TensorIndexD,
+                                    TensorIndexA>(
+          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+
+  // L_{cdab} = R_{abcd}
+  using L_cdab_symmetry =
+      Symmetry<rhs_symmetry_element_c, rhs_symmetry_element_d,
+               rhs_symmetry_element_a, rhs_symmetry_element_b>;
+  using L_cdab_tensorindextype_list =
+      tmpl::list<rhs_tensorindextype_c, rhs_tensorindextype_d,
+                 rhs_tensorindextype_a, rhs_tensorindextype_b>;
+  const Tensor<DataType, L_cdab_symmetry, L_cdab_tensorindextype_list> L_cdab =
+      ::TensorExpressions::evaluate<TensorIndexC, TensorIndexD, TensorIndexA,
+                                    TensorIndexB>(
+          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+
+  // L_{cdba} = R_{abcd}
+  using L_cdba_symmetry =
+      Symmetry<rhs_symmetry_element_c, rhs_symmetry_element_d,
+               rhs_symmetry_element_b, rhs_symmetry_element_a>;
+  using L_cdba_tensorindextype_list =
+      tmpl::list<rhs_tensorindextype_c, rhs_tensorindextype_d,
+                 rhs_tensorindextype_b, rhs_tensorindextype_a>;
+  const Tensor<DataType, L_cdba_symmetry, L_cdba_tensorindextype_list> L_cdba =
+      ::TensorExpressions::evaluate<TensorIndexC, TensorIndexD, TensorIndexB,
+                                    TensorIndexA>(
+          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+
+  // L_{dabc} = R_{abcd}
+  using L_dabc_symmetry =
+      Symmetry<rhs_symmetry_element_d, rhs_symmetry_element_a,
+               rhs_symmetry_element_b, rhs_symmetry_element_c>;
+  using L_dabc_tensorindextype_list =
+      tmpl::list<rhs_tensorindextype_d, rhs_tensorindextype_a,
+                 rhs_tensorindextype_b, rhs_tensorindextype_c>;
+  const Tensor<DataType, L_dabc_symmetry, L_dabc_tensorindextype_list> L_dabc =
+      ::TensorExpressions::evaluate<TensorIndexD, TensorIndexA, TensorIndexB,
+                                    TensorIndexC>(
+          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+
+  // L_{dacb} = R_{abcd}
+  using L_dacb_symmetry =
+      Symmetry<rhs_symmetry_element_d, rhs_symmetry_element_a,
+               rhs_symmetry_element_c, rhs_symmetry_element_b>;
+  using L_dacb_tensorindextype_list =
+      tmpl::list<rhs_tensorindextype_d, rhs_tensorindextype_a,
+                 rhs_tensorindextype_c, rhs_tensorindextype_b>;
+  const Tensor<DataType, L_dacb_symmetry, L_dacb_tensorindextype_list> L_dacb =
+      ::TensorExpressions::evaluate<TensorIndexD, TensorIndexA, TensorIndexC,
+                                    TensorIndexB>(
+          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+
+  // L_{dbac} = R_{abcd}
+  using L_dbac_symmetry =
+      Symmetry<rhs_symmetry_element_d, rhs_symmetry_element_b,
+               rhs_symmetry_element_a, rhs_symmetry_element_c>;
+  using L_dbac_tensorindextype_list =
+      tmpl::list<rhs_tensorindextype_d, rhs_tensorindextype_b,
+                 rhs_tensorindextype_a, rhs_tensorindextype_c>;
+  const Tensor<DataType, L_dbac_symmetry, L_dbac_tensorindextype_list> L_dbac =
+      ::TensorExpressions::evaluate<TensorIndexD, TensorIndexB, TensorIndexA,
+                                    TensorIndexC>(
+          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+
+  // L_{dbca} = R_{abcd}
+  using L_dbca_symmetry =
+      Symmetry<rhs_symmetry_element_d, rhs_symmetry_element_b,
+               rhs_symmetry_element_c, rhs_symmetry_element_a>;
+  using L_dbca_tensorindextype_list =
+      tmpl::list<rhs_tensorindextype_d, rhs_tensorindextype_b,
+                 rhs_tensorindextype_c, rhs_tensorindextype_a>;
+  const Tensor<DataType, L_dbca_symmetry, L_dbca_tensorindextype_list> L_dbca =
+      ::TensorExpressions::evaluate<TensorIndexD, TensorIndexB, TensorIndexC,
+                                    TensorIndexA>(
+          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+
+  // L_{dcab} = R_{abcd}
+  using L_dcab_symmetry =
+      Symmetry<rhs_symmetry_element_d, rhs_symmetry_element_c,
+               rhs_symmetry_element_a, rhs_symmetry_element_b>;
+  using L_dcab_tensorindextype_list =
+      tmpl::list<rhs_tensorindextype_d, rhs_tensorindextype_c,
+                 rhs_tensorindextype_a, rhs_tensorindextype_b>;
+  const Tensor<DataType, L_dcab_symmetry, L_dcab_tensorindextype_list> L_dcab =
+      ::TensorExpressions::evaluate<TensorIndexD, TensorIndexC, TensorIndexA,
+                                    TensorIndexB>(
+          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+
+  // L_{dcba} = R_{abcd}
+  using L_dcba_symmetry =
+      Symmetry<rhs_symmetry_element_d, rhs_symmetry_element_c,
+               rhs_symmetry_element_b, rhs_symmetry_element_a>;
+  using L_dcba_tensorindextype_list =
+      tmpl::list<rhs_tensorindextype_d, rhs_tensorindextype_c,
+                 rhs_tensorindextype_b, rhs_tensorindextype_a>;
+  const Tensor<DataType, L_dcba_symmetry, L_dcba_tensorindextype_list> L_dcba =
+      ::TensorExpressions::evaluate<TensorIndexD, TensorIndexC, TensorIndexB,
+                                    TensorIndexA>(
+          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+
+  const size_t dim_a = tmpl::at_c<RhsTensorIndexTypeList, 0>::dim;
+  const size_t dim_b = tmpl::at_c<RhsTensorIndexTypeList, 1>::dim;
+  const size_t dim_c = tmpl::at_c<RhsTensorIndexTypeList, 2>::dim;
+  const size_t dim_d = tmpl::at_c<RhsTensorIndexTypeList, 3>::dim;
+
+  for (size_t i = 0; i < dim_a; ++i) {
+    for (size_t j = 0; j < dim_b; ++j) {
+      for (size_t k = 0; k < dim_c; ++k) {
+          for (size_t l = 0; l < dim_d; ++l) {
+            // For L_{abcd} = R_{abcd}, check that L_{ijkl} == R_{ijkl}
+            CHECK(L_abcd.get(i, j, k, l) == R_abcd.get(i, j, k, l));
+            // For L_{abdc} = R_{abcd}, check that L_{ijlk} == R_{ijkl}
+            CHECK(L_abdc.get(i, j, l, k) == R_abcd.get(i, j, k, l));
+            // For L_{acbd} = R_{abcd}, check that L_{ikjl} == R_{ijkl}
+            CHECK(L_acbd.get(i, k, j, l) == R_abcd.get(i, j, k, l));
+            // For L_{acdb} = R_{abcd}, check that L_{iklj} == R_{ijkl}
+            CHECK(L_acdb.get(i, k, l, j) == R_abcd.get(i, j, k, l));
+            // For L_{adbc} = R_{abcd}, check that L_{iljk} == R_{ijkl}
+            CHECK(L_adbc.get(i, l, j, k) == R_abcd.get(i, j, k, l));
+            // For L_{adcb} = R_{abcd}, check that L_{ilkj} == R_{ijkl}
+            CHECK(L_adcb.get(i, l, k, j) == R_abcd.get(i, j, k, l));
+            // For L_{bacd} = R_{abcd}, check that L_{jikl} == R_{ijkl}
+            CHECK(L_bacd.get(j, i, k, l) == R_abcd.get(i, j, k, l));
+            // For L_{badc} = R_{abcd}, check that L_{jilk} == R_{ijkl}
+            CHECK(L_badc.get(j, i, l, k) == R_abcd.get(i, j, k, l));
+            // For L_{bcad} = R_{abcd}, check that L_{jkil} == R_{ijkl}
+            CHECK(L_bcad.get(j, k, i, l) == R_abcd.get(i, j, k, l));
+            // For L_{bcda} = R_{abcd}, check that L_{jkli} == R_{ijkl}
+            CHECK(L_bcda.get(j, k, l, i) == R_abcd.get(i, j, k, l));
+            // For L_{bdac} = R_{abcd}, check that L_{jlik} == R_{ijkl}
+            CHECK(L_bdac.get(j, l, i, k) == R_abcd.get(i, j, k, l));
+            // For L_{bdca} = R_{abcd}, check that L_{jlki} == R_{ijkl}
+            CHECK(L_bdca.get(j, l, k, i) == R_abcd.get(i, j, k, l));
+            // For L_{cabd} = R_{abcd}, check that L_{kijl} == R_{ijkl}
+            CHECK(L_cabd.get(k, i, j, l) == R_abcd.get(i, j, k, l));
+            // For L_{cadb} = R_{abcd}, check that L_{kilj} == R_{ijkl}
+            CHECK(L_cadb.get(k, i, l, j) == R_abcd.get(i, j, k, l));
+            // For L_{cbad} = R_{abcd}, check that L_{kjil} == R_{ijkl}
+            CHECK(L_cbad.get(k, j, i, l) == R_abcd.get(i, j, k, l));
+            // For L_{cbda} = R_{abcd}, check that L_{kjli} == R_{ijkl}
+            CHECK(L_cbda.get(k, j, l, i) == R_abcd.get(i, j, k, l));
+            // For L_{cdab} = R_{abcd}, check that L_{klij} == R_{ijkl}
+            CHECK(L_cdab.get(k, l, i, j) == R_abcd.get(i, j, k, l));
+            // For L_{cdba} = R_{abcd}, check that L_{klji} == R_{ijkl}
+            CHECK(L_cdba.get(k, l, j, i) == R_abcd.get(i, j, k, l));
+            // For L_{dabc} = R_{abcd}, check that L_{lijk} == R_{ijkl}
+            CHECK(L_dabc.get(l, i, j, k) == R_abcd.get(i, j, k, l));
+            // For L_{dacb} = R_{abcd}, check that L_{likj} == R_{ijkl}
+            CHECK(L_dacb.get(l, i, k, j) == R_abcd.get(i, j, k, l));
+            // For L_{dbac} = R_{abcd}, check that L_{ljik} == R_{ijkl}
+            CHECK(L_dbac.get(l, j, i, k) == R_abcd.get(i, j, k, l));
+            // For L_{dbca} = R_{abcd}, check that L_{ljki} == R_{ijkl}
+            CHECK(L_dbca.get(l, j, k, i) == R_abcd.get(i, j, k, l));
+            // For L_{dcab} = R_{abcd}, check that L_{lkij} == R_{ijkl}
+            CHECK(L_dcab.get(l, k, i, j) == R_abcd.get(i, j, k, l));
+            // For L_{dcba} = R_{abcd}, check that L_{lkji} == R_{ijkl}
+            CHECK(L_dcba.get(l, k, j, i) == R_abcd.get(i, j, k, l));
+        }
+      }
+    }
+  }
+}
+
+}  // namespace TestHelpers::TensorExpressions


### PR DESCRIPTION
## Proposed changes

Given a right hand side (RHS) tensor, its generic index order, and a left hand side (LHS) generic index order, `TensorExpressions::evaluate` constructs a left hand side (LHS) tensor with the desired LHS generic index order. Currently, `TensorExpressions::evaluate` constructs this LHS tensor using the RHS symmetry and list of indices, but it should be constructed using the (potentially reordered) LHS symmetry and list of indices, based on the desired LHS generic index order. This PR fixes this by determining the (potentially reordered) LHS symmetry and list of indices and constructing the LHS tensor using them. In addition, a unit test for `TensorExpressions::evaluate` was added.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

If we have a `Tensor` named `R` and a `TensorExpression` named `R_abc`:
```
  Tensor<double, Symmetry<2, 1, 2>,
         index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                    SpacetimeIndex<4, UpLo::Lo, Frame::Grid>,
                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
      R{};
  auto R_abc = R(ti_a, ti_b, ti_c);
```
and then evaluate the RHS `TensorExpression` to a LHS `Tensor` named `L_bac`, where the first two indices switched:
```
  auto L_bac = TensorExpressions::evaluate<ti_b_t, ti_a_t, ti_c_t>(R_abc);
```
`L_bac`'s symmetry should be reordered according to swapping the first two indices. The RHS's symmetry is `Symmetry<2, 1, 2>`. If we reordered `<2, 1, 2>` to match this swap, then the reordered LHS symmetry should be `Symmetry<1, 2, 2>`. Likewise, the indices in the `index_list` of the LHS `Tensor` should also be reordered according to swapping the first two indices. In order words, the LHS `index_list` should be:
```
index_list<SpacetimeIndex<4, UpLo::Lo, Frame::Grid>,
           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>
```
Currently, `evaluate` uses the RHS symmetry's ordering and index list ordering for constructing the LHS `Tensor`. This PR fixes is it to use the LHS symmetry and index list ordering, as described above.

In the new unit test, `TensorExpressions::evaluate` is tested using rank 0 through rank 4 `TensorExpression`s as the argument. The test checks that evaluating a RHS `TensorExpression` to a LHS `Tensor` with some RHS generic index order and desired LHS generic index order yields a LHS `Tensor` whose indices and components have been properly ordered (potentially reordered). This test iterates over RHS `Tensor`s with different index dimensions, index types (`SpatialIndex`, `SpacetimeIndex`), frame types (`Grid`, `Inertial`), and symmetries using different RHS and LHS generic index orders.