### PR TITLE
Use verbs charm on ocean

### DIFF
--- a/support/Environments/ocean_clang.sh
+++ b/support/Environments/ocean_clang.sh
@@ -36,7 +36,7 @@ spectre_unload_modules() {
     module unload hdf5-1.12.0-gcc-7.3.0-mknp6xv
     module unload openblas-0.3.4-gcc-7.3.0-tt2coe7
     module unload python/3.7.0
-    module unload charm-6.10.2
+    module unload charm-6.10.2-libs
 }
 
 spectre_load_modules() {
@@ -60,7 +60,7 @@ spectre_load_modules() {
     module load boost-1.68.0-gcc-7.3.0-vgl6ofr
     module load hdf5-1.12.0-gcc-7.3.0-mknp6xv
     module load openblas-0.3.4-gcc-7.3.0-tt2coe7
-    module load charm-6.10.2
+    module load charm-6.10.2-libs
 }
 
 spectre_run_cmake() {
@@ -75,7 +75,6 @@ spectre_run_cmake() {
           -D CMAKE_C_COMPILER=clang \
           -D CMAKE_CXX_COMPILER=clang++ \
           -D CMAKE_Fortran_COMPILER=${GCC_HOME}/gfortran \
-          -D MEMORY_ALLOCATOR=SYSTEM \
           "$@" \
           $SPECTRE_HOME
 }


### PR DESCRIPTION
## Proposed changes

The recent PR updating ocean to build with llvm outside of singularity used an mpi charm build instead of the verbs build of charm that I had intended. My apologies!

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
