### PR TITLE
Add KXRCF TCI for NewtonianEuler limiting

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -565,6 +565,22 @@
   pages    = "209--220",
 }
 
+@article{Krivodonova2004,
+  author   = "L. Krivodonova and J. Xin and J.-F. Remacle and N. Chevaugeon
+              and J.E. Flaherty",
+  title    = "Shock detection and limiting with discontinuous {Galerkin} methods
+              for hyperbolic conservation laws",
+  journal  = "Applied Numerical Mathematics",
+  volume   = "48",
+  number   = "3",
+  pages    = "323 - 338",
+  year     = "2004",
+  note     = "Workshop on Innovative Time Integrators for PDEs",
+  issn     = "0168-9274",
+  doi      = "https://doi.org/10.1016/j.apnum.2003.11.002",
+  url      = "http://www.sciencedirect.com/science/article/pii/S0168927403001831",
+}
+
 @article{Krivodonova2007,
   title    = "Limiters for high-order discontinuous {Galerkin} methods",
   journal  = "Journal of Computational Physics",

--- a/src/Evolution/Systems/NewtonianEuler/Limiters/CMakeLists.txt
+++ b/src/Evolution/Systems/NewtonianEuler/Limiters/CMakeLists.txt
@@ -18,6 +18,7 @@ spectre_target_headers(
   HEADERS
   CharacteristicHelpers.hpp
   Flattener.hpp
+  KxrcfTci.hpp
   )
 
 target_link_libraries(

--- a/src/Evolution/Systems/NewtonianEuler/Limiters/KxrcfTci.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Limiters/KxrcfTci.hpp
@@ -1,0 +1,218 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <boost/functional/hash.hpp>
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/SliceVariables.hpp"
+#include "DataStructures/Tags.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Slice.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/SizeOfElement.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Tags.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp"
+#include "NumericalAlgorithms/LinearOperators/MeanValue.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+
+/// \cond
+template <size_t VolumeDim>
+class ElementId;
+/// \endcond
+
+namespace NewtonianEuler {
+namespace Limiters {
+namespace Tci {
+
+/// \ingroup LimitersGroup
+/// \brief Implements the troubled-cell indicator from Krivodonova et al, 2004.
+///
+/// The KXRCF (these are the author initials) TCI is described in
+/// \cite Krivodonova2004.
+///
+/// In summary, this TCI uses the size of discontinuities between neighboring DG
+/// elements to determine the smoothness of the solution. This works because the
+/// discontinuities converge rapidly for smooth solutions, therefore a large
+/// discontinuity suggests a lack of smoothness and the need to apply a limiter.
+///
+/// The reference sets the constant we call `kxrcf_constant` to 1. This should
+/// generally be a good threshold to use, though it might not be the optimal
+/// value (in balancing robustness vs accuracy) for any particular problem.
+///
+/// This implementation
+/// - does not support h- or p-refinement; this is checked by assertion.
+/// - chooses not to check external boundaries, because this adds complexity.
+///   However, by not checking external boundaries, the implementation may not
+///   be robust for problems that feed in shocks through boundary conditions.
+template <size_t VolumeDim, typename PackagedData>
+bool kxrcf_indicator(
+    const double kxrcf_constant, const Scalar<DataVector>& cons_mass_density,
+    const tnsr::I<DataVector, VolumeDim>& cons_momentum_density,
+    const Scalar<DataVector>& cons_energy_density, const Mesh<VolumeDim>& mesh,
+    const Element<VolumeDim>& element,
+    const std::array<double, VolumeDim>& element_size,
+    const Scalar<DataVector>& det_logical_to_inertial_jacobian,
+    const std::unordered_map<Direction<VolumeDim>,
+                             tnsr::i<DataVector, VolumeDim>>&
+        unnormalized_normals,
+    const std::unordered_map<
+        std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, PackagedData,
+        boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
+        neighbor_data) noexcept {
+  // Enforce restrictions on h-refinement, p-refinement
+  if (UNLIKELY(alg::any_of(element.neighbors(),
+                           [](const auto& direction_neighbors) noexcept {
+                             return direction_neighbors.second.size() != 1;
+                           }))) {
+    ERROR("The Kxrcf TCI does not yet support h-refinement");
+    // Removing this limitation will require adapting the surface integrals to
+    // correctly acount for,
+    // - multiple (smaller) neighbors contributing to the integral
+    // - only a portion of a (larger) neighbor contributing to the integral
+  }
+  alg::for_each(neighbor_data, [&mesh](const auto& neighbor_and_data) noexcept {
+    if (UNLIKELY(neighbor_and_data.second.mesh != mesh)) {
+      ERROR("The Kxrcf TCI does not yet support p-refinement");
+      // Removing this limitation will require generalizing the surface
+      // integrals to make sure the meshes are consistent.
+    }
+  });
+  // Check the mesh matches expectations:
+  // - the extents must be uniform, because the TCI expects a unique "order" for
+  //   the DG scheme. This shows up when computing the threshold parameter,
+  //   h^(degree+1)/2
+  // - the quadrature must be GL, because the current implementation doesn't
+  //   handle extrapolation to the boundary, though this could be changed.
+  // - the basis in principle could be changed, but until we need to change it
+  //   we just check it's the expected Legendre for simplicity
+  ASSERT(mesh == Mesh<VolumeDim>(mesh.extents(0), Spectral::Basis::Legendre,
+                                 Spectral::Quadrature::GaussLobatto),
+         "The Kxrcf TCI expects a uniform LGL mesh, but got mesh = " << mesh);
+
+  bool inflow_boundaries_present = false;
+  double inflow_area = 0.;
+  double inflow_delta_density = 0.;
+  double inflow_delta_energy = 0.;
+
+  for (const auto& [neighbor, data] : neighbor_data) {
+    // Skip computations on boundary if the boundary is external. This choice
+    // might be problematic for evolutions (likely only simple test cases) that
+    // feed in shocks through the boundary condition: the limiter might fail to
+    // activate in the cell that touches the boundary.
+    //
+    // Note that to do this properly we would need the limiter to know about the
+    // boundary condition in general, which may be difficult. Furthermore, such
+    // a change may also require changing the tags at the call site to ensure
+    // that ALL face normals are grabbed from the databox (and not only the
+    // internal face normals, as occurs when grabbing
+    // `Tags::Interface<Tags::InternalDirections, ...>`).
+    const auto& dir = neighbor.first;
+    if (unnormalized_normals.find(dir) == unnormalized_normals.end()) {
+      continue;
+    }
+
+    const size_t sliced_dim = dir.dimension();
+    const size_t index_of_slice =
+        (dir.side() == Side::Lower ? 0 : mesh.extents()[sliced_dim] - 1);
+    const auto momentum_on_slice = data_on_slice(
+        cons_momentum_density, mesh.extents(), sliced_dim, index_of_slice);
+    const auto momentum_dot_normal =
+        dot_product(momentum_on_slice, unnormalized_normals.at(dir));
+
+    // Skip boundaries with no significant inflow
+    // Note: the cutoff value here is small but arbitrarily chosen.
+    if (min(get(momentum_dot_normal)) > -1e-12) {
+      continue;
+    }
+    inflow_boundaries_present = true;
+
+    // This mask has value 1. for momentum_dot_normal < 0.
+    //                     0. for momentum_dot_normal >= 0.
+    const DataVector inflow_mask = 1. - step_function(get(momentum_dot_normal));
+    // Mask is then weighted pointwise by the Jacobian determinant giving
+    // surface integrals in inertial coordinates. This Jacobian determinant is
+    // given by the product of the volume Jacobian determinant with the norm of
+    // the unnormalized face normals.
+    const DataVector weighted_inflow_mask =
+        inflow_mask *
+        get(data_on_slice(det_logical_to_inertial_jacobian, mesh.extents(),
+                          sliced_dim, index_of_slice)) *
+        get(magnitude(unnormalized_normals.at(dir)));
+
+    inflow_area +=
+        definite_integral(weighted_inflow_mask, mesh.slice_away(sliced_dim));
+
+    // This is the step that is incompatible with h/p refinement. For use with
+    // h/p refinement, would need to correctly obtain the neighbor solution on
+    // the local grid points.
+    const auto neighbor_vars_on_slice = data_on_slice(
+        data.volume_data, mesh.extents(), sliced_dim, index_of_slice);
+
+    const auto density_on_slice = data_on_slice(
+        cons_mass_density, mesh.extents(), sliced_dim, index_of_slice);
+    const auto& neighbor_density_on_slice =
+        get<NewtonianEuler::Tags::MassDensityCons>(neighbor_vars_on_slice);
+    inflow_delta_density += definite_integral(
+        (get(density_on_slice) - get(neighbor_density_on_slice)) *
+            weighted_inflow_mask,
+        mesh.slice_away(sliced_dim));
+
+    const auto energy_on_slice = data_on_slice(
+        cons_energy_density, mesh.extents(), sliced_dim, index_of_slice);
+    const auto& neighbor_energy_on_slice =
+        get<NewtonianEuler::Tags::EnergyDensity>(neighbor_vars_on_slice);
+    inflow_delta_energy += definite_integral(
+        (get(energy_on_slice) - get(neighbor_energy_on_slice)) *
+            weighted_inflow_mask,
+        mesh.slice_away(sliced_dim));
+  }
+
+  if (not inflow_boundaries_present) {
+    // No boundaries had inflow, so not a troubled cell
+    return false;
+  }
+
+  // KXRCF take h to be the radius of the circumscribed circle
+  const double h = 0.5 * magnitude(element_size);
+  const double h_pow = pow(h, 0.5 * mesh.extents(0));
+
+  ASSERT(inflow_area > 0.,
+         "Sanity check failed: negative area of inflow boundaries");
+
+  const double norm_squared_density = mean_value(
+      get(det_logical_to_inertial_jacobian) * square(get(cons_mass_density)),
+      mesh);
+  ASSERT(norm_squared_density > 0.,
+         "Sanity check failed: negative density norm over element");
+  const double norm_density = sqrt(norm_squared_density);
+  const double ratio_for_density =
+      abs(inflow_delta_density) / (h_pow * inflow_area * norm_density);
+
+  const double norm_squared_energy = mean_value(
+      get(det_logical_to_inertial_jacobian) * square(get(cons_energy_density)),
+      mesh);
+  ASSERT(norm_squared_energy > 0.,
+         "Sanity check failed: negative energy norm over element");
+  const double norm_energy = sqrt(norm_squared_energy);
+  const double ratio_for_energy =
+      abs(inflow_delta_energy) / (h_pow * inflow_area * norm_energy);
+
+  return (ratio_for_density > kxrcf_constant or
+          ratio_for_energy > kxrcf_constant);
+}
+
+}  // namespace Tci
+}  // namespace Limiters
+}  // namespace NewtonianEuler

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_NewtonianEulerLimiters")
 set(LIBRARY_SOURCES
   Test_CharacteristicHelpers.cpp
   Test_Flattener.cpp
+  Test_KxrcfTci.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/Test_KxrcfTci.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/Test_KxrcfTci.cpp
@@ -1,0 +1,423 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Determinant.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/SizeOfElement.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Evolution/Systems/NewtonianEuler/Limiters/KxrcfTci.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/Limiters/TestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+
+template <size_t VolumeDim>
+struct TestPackagedData {
+  Variables<tmpl::list<NewtonianEuler::Tags::MassDensityCons,
+                       NewtonianEuler::Tags::MomentumDensity<VolumeDim>,
+                       NewtonianEuler::Tags::EnergyDensity>>
+      volume_data;
+  Mesh<VolumeDim> mesh;
+};
+
+template <size_t VolumeDim>
+DirectionMap<VolumeDim, DataVector> make_dirmap_of_datavectors_from_value(
+    const size_t size, const double value) noexcept {
+  DirectionMap<VolumeDim, DataVector> result{};
+  for (const auto& dir : Direction<VolumeDim>::all_directions()) {
+    result[dir] = DataVector(size, value);
+  }
+  return result;
+}
+
+template <size_t VolumeDim>
+void test_kxrcf_work(
+    const bool expected_detection, const double kxrcf_constant,
+    const Scalar<DataVector>& cons_density,
+    const tnsr::I<DataVector, VolumeDim>& cons_momentum,
+    const Scalar<DataVector>& cons_energy, const Mesh<VolumeDim>& mesh,
+    const Element<VolumeDim>& element,
+    const ElementMap<VolumeDim, Frame::Inertial>& element_map,
+    const DirectionMap<VolumeDim, DataVector>& neighbor_densities,
+    const DirectionMap<VolumeDim, DataVector>& neighbor_energies) noexcept {
+  // Check that this help function is called correctly
+  ASSERT(element.neighbors().size() == neighbor_densities.size(),
+         "The test helper was passed inconsistent data.");
+  ASSERT(element.neighbors().size() == neighbor_energies.size(),
+         "The test helper was passed inconsistent data.");
+  for (const auto& dir : Direction<VolumeDim>::all_directions()) {
+    const auto& ids = element.neighbors().at(dir).ids();
+    ASSERT(ids.size() == 1,
+           "The test helper test_kxrcf_work isn't set up for h-refinement.");
+  }
+
+  // Create and fill neighbor data
+  std::unordered_map<
+      std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>,
+      TestPackagedData<VolumeDim>,
+      boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>
+      neighbor_data{};
+  for (const auto& dir : Direction<VolumeDim>::all_directions()) {
+    const auto& id = *(element.neighbors().at(dir).ids().begin());
+    TestPackagedData<VolumeDim>& neighbor =
+        neighbor_data[std::make_pair(dir, id)];
+    neighbor.mesh = mesh;
+    neighbor.volume_data.initialize(mesh.number_of_grid_points(), 0.);
+    get(get<NewtonianEuler::Tags::MassDensityCons>(neighbor.volume_data)) =
+        neighbor_densities.at(dir);
+    get(get<NewtonianEuler::Tags::EnergyDensity>(neighbor.volume_data)) =
+        neighbor_energies.at(dir);
+  }
+
+  const auto element_size = size_of_element(element_map);
+  const Scalar<DataVector> det_jacobian{
+      {1. /
+       get(determinant(element_map.inv_jacobian(logical_coordinates(mesh))))}};
+
+  // Create and fill unit normals
+  std::unordered_map<Direction<VolumeDim>, tnsr::i<DataVector, VolumeDim>>
+      unnormalized_normals{};
+  for (const auto& dir : Direction<VolumeDim>::all_directions()) {
+    unnormalized_face_normal(make_not_null(&(unnormalized_normals[dir])),
+                             mesh.slice_away(dir.dimension()), element_map,
+                             dir);
+  }
+
+  const bool tci_detection = NewtonianEuler::Limiters::Tci::kxrcf_indicator(
+      kxrcf_constant, cons_density, cons_momentum, cons_energy, mesh, element,
+      element_size, det_jacobian, unnormalized_normals, neighbor_data);
+  CHECK(tci_detection == expected_detection);
+}
+
+void test_kxrcf_1d() noexcept {
+  const auto element = TestHelpers::Limiters::make_element<1>();
+  const Mesh<1> mesh(3, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto);
+  using Affine = domain::CoordinateMaps::Affine;
+  const Affine xi_map{-1., 1., 3., 4.2};
+  const auto coordmap =
+      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(xi_map);
+  const ElementMap<1, Frame::Inertial> element_map(element.id(),
+                                                   coordmap->get_clone());
+
+  Scalar<DataVector> cons_density{DataVector{{0.4, 0.2, 0.}}};
+  tnsr::I<DataVector, 1> cons_momentum{DataVector{{0.2, 0.1, 0.05}}};
+  Scalar<DataVector> cons_energy{DataVector{{0., 1.3, 0.}}};
+
+  const auto neighbor_densities = make_dirmap_of_datavectors_from_value<1>(
+      mesh.number_of_grid_points(), 0.);
+  const auto neighbor_energies = make_dirmap_of_datavectors_from_value<1>(
+      mesh.number_of_grid_points(), 0.);
+
+  // In realistic uses of the TCI, the kxrcf_constant would be set to a finite
+  // value, perhaps 1, and different solutions may or may not trigger limiting.
+  // For ease of testing, we do the opposite: we fix the solution and vary the
+  // threshold.
+
+  // trigger: density inflow at lower xi boundary
+  double kxrcf_constant = 0.;
+  test_kxrcf_work(true, kxrcf_constant, cons_density, cons_momentum,
+                  cons_energy, mesh, element, element_map, neighbor_densities,
+                  neighbor_energies);
+
+  // trigger: threshold is just met
+  kxrcf_constant = 4.81;
+  test_kxrcf_work(true, kxrcf_constant, cons_density, cons_momentum,
+                  cons_energy, mesh, element, element_map, neighbor_densities,
+                  neighbor_energies);
+
+  // no trigger: threshold is not met
+  kxrcf_constant = 4.82;
+  test_kxrcf_work(false, kxrcf_constant, cons_density, cons_momentum,
+                  cons_energy, mesh, element, element_map, neighbor_densities,
+                  neighbor_energies);
+
+  // no trigger: density has no jump at lower xi boundary
+  kxrcf_constant = 0.;
+  get(cons_density)[0] = 0.;
+  test_kxrcf_work(false, kxrcf_constant, cons_density, cons_momentum,
+                  cons_energy, mesh, element, element_map, neighbor_densities,
+                  neighbor_energies);
+
+  // trigger: energy inflow at upper xi boundary
+  cons_density = Scalar<DataVector>{DataVector{{0., 0.3, 0.}}};
+  cons_momentum = tnsr::I<DataVector, 1>{DataVector{{-0.2, 0.1, -0.05}}};
+  cons_energy = Scalar<DataVector>{DataVector{{0., 1.3, 1.7}}};
+  test_kxrcf_work(true, kxrcf_constant, cons_density, cons_momentum,
+                  cons_energy, mesh, element, element_map, neighbor_densities,
+                  neighbor_energies);
+
+  // no trigger: energy has no jump at upper xi boundary
+  get(cons_energy)[mesh.number_of_grid_points() - 1] = 0.;
+  test_kxrcf_work(false, kxrcf_constant, cons_density, cons_momentum,
+                  cons_energy, mesh, element, element_map, neighbor_densities,
+                  neighbor_energies);
+
+  // no trigger: all boundaries are outflow
+  cons_density = Scalar<DataVector>{DataVector{{0.4, 0.3, 0.2}}};
+  cons_momentum = tnsr::I<DataVector, 1>{DataVector{{-0.2, 0.1, 0.05}}};
+  cons_energy = Scalar<DataVector>{DataVector{{1.4, 1.3, 1.7}}};
+  test_kxrcf_work(false, kxrcf_constant, cons_density, cons_momentum,
+                  cons_energy, mesh, element, element_map, neighbor_densities,
+                  neighbor_energies);
+}
+
+void test_kxrcf_2d() noexcept {
+  const auto element = TestHelpers::Limiters::make_element<2>();
+  const Mesh<2> mesh(3, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto);
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+  const Affine xi_map{-1., 1., 3., 4.2};
+  const Affine eta_map{-1., 1., 3., 7.};
+  const auto coordmap =
+      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          Affine2D(xi_map, eta_map));
+  const ElementMap<2, Frame::Inertial> element_map(element.id(),
+                                                   coordmap->get_clone());
+
+  const DataVector zero(mesh.number_of_grid_points(), 0.);
+
+  Scalar<DataVector> cons_density{
+      DataVector{{0.4, 0.3, 0.2, 0., 0., 0., 0., 0., 0.}}};
+  tnsr::I<DataVector, 2> cons_momentum{};
+  get<0>(cons_momentum) = zero;
+  get<1>(cons_momentum) = DataVector{{0.2, 0.1, 0.05, 0., 0., 0., 0., 0., 0.}};
+  Scalar<DataVector> cons_energy{
+      DataVector{{0., 0., 0., 0., 0., 0., 0.3, 0.2, 0.1}}};
+
+  const auto neighbor_densities = make_dirmap_of_datavectors_from_value<2>(
+      mesh.number_of_grid_points(), 0.);
+  const auto neighbor_energies = make_dirmap_of_datavectors_from_value<2>(
+      mesh.number_of_grid_points(), 0.);
+
+  // In realistic uses of the TCI, the kxrcf_constant would be set to a finite
+  // value, perhaps 1, and different solutions may or may not trigger limiting.
+  // For ease of testing, we do the opposite: we fix the solution and vary the
+  // threshold.
+
+  // trigger: density inflow at lower eta boundary
+  double kxrcf_constant = 0.;
+  test_kxrcf_work(true, kxrcf_constant, cons_density, cons_momentum,
+                  cons_energy, mesh, element, element_map, neighbor_densities,
+                  neighbor_energies);
+
+  // trigger: density inflow on subset of lower eta boundary
+  get<1>(cons_momentum) = DataVector{{0.2, 0.1, -0.05, 0., 0., 0., 0., 0., 0.}};
+  test_kxrcf_work(true, kxrcf_constant, cons_density, cons_momentum,
+                  cons_energy, mesh, element, element_map, neighbor_densities,
+                  neighbor_energies);
+
+  // trigger: threshold is just met
+  kxrcf_constant = 0.776;
+  test_kxrcf_work(true, kxrcf_constant, cons_density, cons_momentum,
+                  cons_energy, mesh, element, element_map, neighbor_densities,
+                  neighbor_energies);
+
+  // no trigger: threshold is not met
+  kxrcf_constant = 0.777;
+  test_kxrcf_work(false, kxrcf_constant, cons_density, cons_momentum,
+                  cons_energy, mesh, element, element_map, neighbor_densities,
+                  neighbor_energies);
+
+  // trigger: same threshold, but now upper xi boundary also contributes
+  get(cons_density) = DataVector{{0.4, 0.3, 0.2, 0., 0., 0., 0., 0., 0.8}};
+  get<0>(cons_momentum) = DataVector{{0., 0., 0., 0., 0., 0., 0., 0., -1.4}};
+  test_kxrcf_work(true, kxrcf_constant, cons_density, cons_momentum,
+                  cons_energy, mesh, element, element_map, neighbor_densities,
+                  neighbor_energies);
+
+  // trigger: energy inflow at upper eta boundary
+  kxrcf_constant = 0.;
+  get(cons_density) = DataVector{{0.4, 0.3, 0.2, 0., 0., 0., 0., 0., 0.}};
+  get<0>(cons_momentum) = zero;
+  get<1>(cons_momentum) =
+      DataVector{{0., 0., 0., 0., 0., 0., -0.8, -1.3, -1.2}};
+  test_kxrcf_work(true, kxrcf_constant, cons_density, cons_momentum,
+                  cons_energy, mesh, element, element_map, neighbor_densities,
+                  neighbor_energies);
+
+  // no trigger: all boundaries are outflow
+  get<0>(cons_momentum) =
+      DataVector{{-0.2, 0., 0.05, -1.2, 0., 0.3, -0.9, 0., 0.4}};
+  get<1>(cons_momentum) =
+      DataVector{{-0.2, -0.1, -0.05, 0., 0., 0., 0.3, 1.2, 2.3}};
+  test_kxrcf_work(false, kxrcf_constant, cons_density, cons_momentum,
+                  cons_energy, mesh, element, element_map, neighbor_densities,
+                  neighbor_energies);
+}
+
+void test_kxrcf_3d() noexcept {
+  const auto element = TestHelpers::Limiters::make_element<3>();
+  const Mesh<3> mesh(3, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto);
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine3D =
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  const Affine xi_map{-1., 1., 3., 4.2};
+  const Affine eta_map{-1., 1., -3., -2.4};
+  const Affine zeta_map{-1., 1., 3., 7.};
+  const auto coordmap =
+      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          Affine3D(xi_map, eta_map, zeta_map));
+  const ElementMap<3, Frame::Inertial> element_map(element.id(),
+                                                   coordmap->get_clone());
+
+  const DataVector zero(mesh.number_of_grid_points(), 0.);
+
+  Scalar<DataVector> cons_density{
+      // clang-format off
+      DataVector{{0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                  0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                  0.4, 0.3, 0.2, 0.3, 0.2, 0.2, 0.2, 0.2, 0.1}}};
+  // clang-format on
+  tnsr::I<DataVector, 3> cons_momentum{};
+  get<0>(cons_momentum) = zero;
+  get<1>(cons_momentum) = zero;
+  get<2>(cons_momentum) =
+      // clang-format off
+      DataVector{{0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                  0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                  -0.1, -0.4, -0.2, -0.8, -0.3, -0.6, -1.2, -1.8, -0.9}};
+  // clang-format on
+  Scalar<DataVector> cons_energy{
+      // clang-format off
+      DataVector{{1.1, 1.3, 0.8, 1.3, 0.7, 0.6, 0.9, 1.2, 1.1,
+                  0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                  0., 0., 0., 0., 0., 0., 0., 0., 0.}}};
+  // clang-format on
+
+  const auto neighbor_densities = make_dirmap_of_datavectors_from_value<3>(
+      mesh.number_of_grid_points(), 0.);
+  const auto neighbor_energies = make_dirmap_of_datavectors_from_value<3>(
+      mesh.number_of_grid_points(), 0.);
+
+  // In realistic uses of the TCI, the kxrcf_constant would be set to a finite
+  // value, perhaps 1, and different solutions may or may not trigger limiting.
+  // For ease of testing, we do the opposite: we fix the solution and vary the
+  // threshold.
+
+  // trigger: density inflow at upper zeta boundary
+  double kxrcf_constant = 0.;
+  test_kxrcf_work(true, kxrcf_constant, cons_density, cons_momentum,
+                  cons_energy, mesh, element, element_map, neighbor_densities,
+                  neighbor_energies);
+
+  // trigger: density inflow on subset of upper zeta boundary
+  get<2>(cons_momentum) =
+      // clang-format off
+      DataVector{{0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                  0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                  0.8, -0.4, -0.2, 0.1, 0.3, -0.6, -1.2, -1.8, -0.9}};
+  // clang-format on
+  test_kxrcf_work(true, kxrcf_constant, cons_density, cons_momentum,
+                  cons_energy, mesh, element, element_map, neighbor_densities,
+                  neighbor_energies);
+
+  // trigger: threshold is just met
+  kxrcf_constant = 1.26;
+  test_kxrcf_work(true, kxrcf_constant, cons_density, cons_momentum,
+                  cons_energy, mesh, element, element_map, neighbor_densities,
+                  neighbor_energies);
+
+  // no trigger: threshold is not met
+  kxrcf_constant = 1.27;
+  test_kxrcf_work(false, kxrcf_constant, cons_density, cons_momentum,
+                  cons_energy, mesh, element, element_map, neighbor_densities,
+                  neighbor_energies);
+
+  // trigger: same threshold, but now lower eta boundary also contributes
+  get(cons_density) =
+      // clang-format off
+      DataVector{{0., 0.2, 0.2, 0., 0., 0., 0., 0., 0.,
+                  0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                  0.4, 0.3, 0.2, 0.3, 0.2, 0.2, 0.2, 0.2, 0.1}};
+  // clang-format on
+  get<1>(cons_momentum) =
+      // clang-format off
+      DataVector{{0., 0.2, 0.2, 0., 0., 0., 0., 0., 0.,
+                  0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                  0.1, 0.4, 0.2, 0., 0., 0., 0., 0., 0.}};
+  // clang-format on
+  test_kxrcf_work(true, kxrcf_constant, cons_density, cons_momentum,
+                  cons_energy, mesh, element, element_map, neighbor_densities,
+                  neighbor_energies);
+
+  // trigger: energy inflow at lower zeta boundary
+  kxrcf_constant = 0.;
+  get(cons_density) =
+      // clang-format off
+      DataVector{{0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                  0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                  0.4, 0.3, 0.2, 0.3, 0.2, 0.2, 0.2, 0.2, 0.1}};
+  // clang-format on
+  get<1>(cons_momentum) = zero;
+  get<2>(cons_momentum) =
+      // clang-format off
+      DataVector{{0.3, 0.1, 0.2, 0.4, 0.2, 0.3, 0.6, 0.4, 0.7,
+                  0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                  0., 0., 0., 0., 0., 0., 0., 0., 0.}};
+  // clang-format on
+  test_kxrcf_work(true, kxrcf_constant, cons_density, cons_momentum,
+                  cons_energy, mesh, element, element_map, neighbor_densities,
+                  neighbor_energies);
+
+  // no trigger: all boundaries are outflow
+  get<0>(cons_momentum) =
+      // clang-format off
+      DataVector{{-0.2, 0., 0.05, -0.2, 0., 0.3, -0.8, 0., 0.2,
+                  -0.4, 0., 0.07, -0.9, 0., 0.7, -0.3, 0., 0.8,
+                  -0.7, 0., 0.1, -1.3, 0., 0.8, -0.2, 0., 0.7}};
+  // clang-format on
+  get<1>(cons_momentum) =
+      // clang-format off
+      DataVector{{-0.2, -0.1, -0.05, 0., 0., 0., 0.3, 1.2, 2.3,
+                  -0.4, -0.1, -0.1, 0., 0., 0., 0.3, 0.8, 1.6,
+                  -0.7, -0.2, -0.1, 0., 0., 0., 0.2, 0.2, 0.7}};
+  // clang-format on
+  get<2>(cons_momentum) =
+      // clang-format off
+      DataVector{{-0.2, -0.1, -0.05, -0.1, -0.1, -0.4, -0.3, -1.2, -2.3,
+                  0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                  0.7, 1.3, 1.1, 0.5, 1., 0.2, 0.2, 0.3, 0.3}};
+  // clang-format on
+  test_kxrcf_work(false, kxrcf_constant, cons_density, cons_momentum,
+                  cons_energy, mesh, element, element_map, neighbor_densities,
+                  neighbor_energies);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.NewtonianEuler.Limiters.KxrcfTci",
+                  "[Unit][Evolution]") {
+  test_kxrcf_1d();
+  test_kxrcf_2d();
+  test_kxrcf_3d();
+}


### PR DESCRIPTION
## Proposed changes

Add a new troubled-cell indicator for the NewtonianEuler system.

Depends on #2456 for convenience of testing. Only the last commit is new.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

