### PR TITLE
Add flattener post-processor for NewtonianEuler limiting

### DIFF
--- a/src/Evolution/Systems/NewtonianEuler/Limiters/CMakeLists.txt
+++ b/src/Evolution/Systems/NewtonianEuler/Limiters/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   CharacteristicHelpers.cpp
+  Flattener.cpp
   )
 
 spectre_target_headers(
@@ -16,6 +17,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   CharacteristicHelpers.hpp
+  Flattener.hpp
   )
 
 target_link_libraries(

--- a/src/Evolution/Systems/NewtonianEuler/Limiters/Flattener.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Limiters/Flattener.cpp
@@ -1,0 +1,156 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/NewtonianEuler/Limiters/Flattener.hpp"
+
+#include <array>
+#include <limits>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace NewtonianEuler::Limiters {
+
+template <size_t VolumeDim, size_t ThermodynamicDim>
+FlattenerAction flatten_solution(
+    const gsl::not_null<Scalar<DataVector>*> mass_density_cons,
+    const gsl::not_null<tnsr::I<DataVector, VolumeDim>*> momentum_density,
+    const gsl::not_null<Scalar<DataVector>*> energy_density,
+    const Mesh<VolumeDim>& mesh,
+    const Scalar<DataVector>& det_logical_to_inertial_jacobian,
+    const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
+        equation_of_state) noexcept {
+  // A note on the design behind the handling of the cell-averaged fields:
+  //
+  // The cell averages are needed for
+  // - sanity-checking the inputs for validity
+  // - flattening in case of negative density
+  // - flattening in case of negative pressure
+  //
+  // In addition, we have the following optimization goals:
+  // - cell averages are only computed once
+  // - cell averages are only computed when needed
+  //
+  // To meet these goals, we create a temporary variable for each field's cell
+  // average. These temporaries live on the stack and should have minimal cost.
+  double mean_density = std::numeric_limits<double>::signaling_NaN();
+  auto mean_momentum =
+      make_array<VolumeDim>(std::numeric_limits<double>::signaling_NaN());
+  double mean_energy = std::numeric_limits<double>::signaling_NaN();
+
+  const auto compute_means = [&mean_density, &mean_momentum, &mean_energy,
+                              &mass_density_cons, &momentum_density,
+                              &energy_density, &mesh,
+                              &det_logical_to_inertial_jacobian]() noexcept {
+    // Compute the means w.r.t. the inertial coords
+    // (Note that several other parts of the limiter code take means w.r.t. the
+    // logical coords, and therefore might not be conservative on curved grids)
+    const double volume_of_cell =
+        definite_integral(get(det_logical_to_inertial_jacobian), mesh);
+    const auto inertial_coord_mean =
+        [&mesh, &det_logical_to_inertial_jacobian,
+         &volume_of_cell](const DataVector& u) noexcept {
+          // Note that the term `det_jac * u` below results in an allocation.
+          // If this function needs to be optimized, a buffer for the product
+          // could be allocated outside the lambda, and updated in the lambda.
+          return definite_integral(get(det_logical_to_inertial_jacobian) * u,
+                                   mesh) /
+                 volume_of_cell;
+        };
+    mean_density = inertial_coord_mean(get(*mass_density_cons));
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      gsl::at(mean_momentum, i) = inertial_coord_mean(momentum_density->get(i));
+    }
+    mean_energy = inertial_coord_mean(get(*energy_density));
+
+    // sanity check the means
+    ASSERT(mean_density > 0., "Invalid mass density input to flattener");
+    if constexpr (ThermodynamicDim == 2) {
+      ASSERT(mean_energy > 0., "Invalid energy density input to flattener");
+    }
+  };
+
+  FlattenerAction flattener_action = FlattenerAction::NoOp;
+
+  // If min(density) is negative, then flatten.
+  const double min_density = min(get(*mass_density_cons));
+  if (min_density < 0.) {
+    compute_means();
+
+    // Note: the current algorithm flattens all fields by the same factor,
+    // though in principle a different factor could be applied to each field.
+    constexpr double safety = 0.95;
+    const double factor = safety * mean_density / (mean_density - min_density);
+
+    get(*mass_density_cons) =
+        mean_density + factor * (get(*mass_density_cons) - mean_density);
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      momentum_density->get(i) =
+          gsl::at(mean_momentum, i) +
+          factor * (momentum_density->get(i) - gsl::at(mean_momentum, i));
+    }
+    get(*energy_density) =
+        mean_energy + factor * (get(*energy_density) - mean_energy);
+
+    flattener_action = FlattenerAction::ScaledSolution;
+  }
+
+  // Check for negative pressures
+  if constexpr (ThermodynamicDim == 2) {
+    const auto specific_internal_energy = Scalar<DataVector>{
+        get(*energy_density) / get(*mass_density_cons) -
+        0.5 * get(dot_product(*momentum_density, *momentum_density)) /
+            square(get(*mass_density_cons))};
+    const auto pressure = equation_of_state.pressure_from_density_and_energy(
+        *mass_density_cons, specific_internal_energy);
+
+    // If min(pressure) is negative, set solution to cell averages
+    const double min_pressure = min(get(pressure));
+    if (min_pressure < 0.) {
+      if (flattener_action == FlattenerAction::NoOp) {
+        // We didn't previously correct for negative densities, therefore the
+        // means have not yet been computed
+        compute_means();
+      }
+
+      get(*mass_density_cons) = mean_density;
+      for (size_t i = 0; i < VolumeDim; ++i) {
+        momentum_density->get(i) = gsl::at(mean_momentum, i);
+      }
+      get(*energy_density) = mean_energy;
+
+      flattener_action = FlattenerAction::SetSolutionToMean;
+    }
+  }
+
+  return flattener_action;
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define THERMODIM(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                      \
+  template FlattenerAction flatten_solution(                      \
+      gsl::not_null<Scalar<DataVector>*>,                         \
+      gsl::not_null<tnsr::I<DataVector, DIM(data)>*>,             \
+      gsl::not_null<Scalar<DataVector>*>, const Mesh<DIM(data)>&, \
+      const Scalar<DataVector>&,                                  \
+      const EquationsOfState::EquationOfState<false,              \
+                                              THERMODIM(data)>&) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (1, 2))
+
+#undef INSTANTIATE
+#undef THERMODIM
+#undef DIM
+
+}  // namespace NewtonianEuler::Limiters

--- a/src/Evolution/Systems/NewtonianEuler/Limiters/Flattener.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Limiters/Flattener.hpp
@@ -1,0 +1,66 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+class DataVector;
+template <size_t>
+class Mesh;
+
+namespace EquationsOfState {
+template <bool, size_t>
+class EquationOfState;
+}  // namespace EquationsOfState
+/// \endcond
+
+namespace NewtonianEuler::Limiters {
+
+/// \ingroup LimitersGroup
+/// \brief Encodes the action taken by `flatten_solution`
+enum class FlattenerAction {
+  NoOp = 0,
+  ScaledSolution = 1,
+  SetSolutionToMean = 2,
+};
+
+/// \ingroup LimitersGroup
+/// \brief Scale a NewtonianEuler solution around its mean to remove pointwise
+/// positivity violations.
+///
+/// If the solution has points with negative density, scales the solution
+/// to make these points positive again. For each component \f$u\f$ of the
+/// solution, the scaling takes the form
+/// \f$u \to \bar{u} + \theta (u - \bar{u})\f$,
+/// where \f$\bar{u}\f$ is the cell-average value of \f$u\f$, and \f$\theta\f$
+/// is a factor less than 1, chosen to restore positive density.
+/// The cell averages in this implementation are computed in inertial
+/// coordinates, so the flattener is conservative even on deformed grids.
+///
+/// A scaling of this form used to restore positivity is usually called a
+/// flattener (we use this name) or a bounds-preserving filter. Note that the
+/// scaling approach only works if the cell-averaged solution is itself
+/// physical, in other words, if the cell-averaged density is positive.
+///
+/// After checking for (and correcting) negative densities, if the equation of
+/// state is two-dimensional, then the pressure is also checked for positivity.
+/// If negative pressures are found, each solution component is set to its mean
+/// (this is equivalent to \f$\theta = 0\f$ in the scaling form above).
+/// In principle, a less aggressive scaling could be used, but solving for the
+/// correct \f$\theta\f$ in this case is more involved.
+template <size_t VolumeDim, size_t ThermodynamicDim>
+FlattenerAction flatten_solution(
+    gsl::not_null<Scalar<DataVector>*> mass_density_cons,
+    gsl::not_null<tnsr::I<DataVector, VolumeDim>*> momentum_density,
+    gsl::not_null<Scalar<DataVector>*> energy_density,
+    const Mesh<VolumeDim>& mesh,
+    const Scalar<DataVector>& det_logical_to_inertial_jacobian,
+    const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
+        equation_of_state) noexcept;
+
+}  // namespace NewtonianEuler::Limiters

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_NewtonianEulerLimiters")
 
 set(LIBRARY_SOURCES
   Test_CharacteristicHelpers.cpp
+  Test_Flattener.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/Test_Flattener.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/Test_Flattener.cpp
@@ -1,0 +1,379 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/NewtonianEuler/Limiters/Flattener.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace {
+
+void test_flattener_1d() noexcept {
+  INFO("Testing flatten_solution in 1D");
+  const Mesh<1> mesh(4, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto);
+  const EquationsOfState::IdealFluid<false> equation_of_state{5. / 3.};
+  const Scalar<DataVector> det_logical_to_inertial_jacobian(
+      DataVector{{2., 2., 2., 2.}});
+
+  {
+    INFO("Case: NoOp");
+    Scalar<DataVector> mass_density_cons(DataVector{{0.8, 1.6, 2.2, 1.2}});
+    tnsr::I<DataVector, 1> momentum_density(DataVector{{-1., 0., 0., -2.}});
+    Scalar<DataVector> energy_density(DataVector{{1., 1.6, 1.9, 1.9}});
+
+    const auto expected_mass_density_cons = mass_density_cons;
+    const auto expected_momentum_density = momentum_density;
+    const auto expected_energy_density = energy_density;
+
+    const auto flattener_action = NewtonianEuler::Limiters::flatten_solution(
+        make_not_null(&mass_density_cons), make_not_null(&momentum_density),
+        make_not_null(&energy_density), mesh, det_logical_to_inertial_jacobian,
+        equation_of_state);
+
+    CHECK(flattener_action == NewtonianEuler::Limiters::FlattenerAction::NoOp);
+    CHECK_ITERABLE_APPROX(mass_density_cons, expected_mass_density_cons);
+    CHECK_ITERABLE_APPROX(momentum_density, expected_momentum_density);
+    CHECK_ITERABLE_APPROX(energy_density, expected_energy_density);
+  }
+
+  {
+    INFO("Case: ScaledSolution because of negative density");
+    Scalar<DataVector> mass_density_cons(DataVector{{0.8, -0.25, 2.25, 1.2}});
+    tnsr::I<DataVector, 1> momentum_density(DataVector{{-1., 0., 0., -2.}});
+    Scalar<DataVector> energy_density(DataVector{{1., 1.6, 1.9, 1.9}});
+
+    // Expect flattening factor (about mean) of 0.8 times the 0.95 safety = 0.76
+    // density mean = 1.
+    // momentum mean = -0.25
+    // energy mean = 1.7
+    const Scalar<DataVector> expected_mass_density_cons(
+        DataVector{{0.848, 0.05, 1.95, 1.152}});
+    const tnsr::I<DataVector, 1> expected_momentum_density(
+        DataVector{{-0.82, -0.06, -0.06, -1.58}});
+    const Scalar<DataVector> expected_energy_density(
+        DataVector{{1.168, 1.624, 1.852, 1.852}});
+
+    const auto flattener_action = NewtonianEuler::Limiters::flatten_solution(
+        make_not_null(&mass_density_cons), make_not_null(&momentum_density),
+        make_not_null(&energy_density), mesh, det_logical_to_inertial_jacobian,
+        equation_of_state);
+
+    CHECK(flattener_action ==
+          NewtonianEuler::Limiters::FlattenerAction::ScaledSolution);
+    CHECK_ITERABLE_APPROX(mass_density_cons, expected_mass_density_cons);
+    CHECK_ITERABLE_APPROX(momentum_density, expected_momentum_density);
+    CHECK_ITERABLE_APPROX(energy_density, expected_energy_density);
+  }
+
+  {
+    INFO("Case: SetSolutionToMean because of negative pressure");
+    Scalar<DataVector> mass_density_cons(DataVector{{0.8, -0.25, 2.25, 1.2}});
+    tnsr::I<DataVector, 1> momentum_density(DataVector{{-1., 0., 0., -2.}});
+    Scalar<DataVector> energy_density(DataVector{{1., 1.6, 1.9, 0.7}});
+
+    // density mean = 1.
+    // momentum mean = -0.25
+    // energy mean = 1.6
+    const auto expected_mass_density_cons =
+        make_with_value<Scalar<DataVector>>(mass_density_cons, 1.);
+    const auto expected_momentum_density =
+        make_with_value<tnsr::I<DataVector, 1>>(momentum_density, -0.25);
+    const auto expected_energy_density =
+        make_with_value<Scalar<DataVector>>(energy_density, 1.6);
+
+    const auto flattener_action = NewtonianEuler::Limiters::flatten_solution(
+        make_not_null(&mass_density_cons), make_not_null(&momentum_density),
+        make_not_null(&energy_density), mesh, det_logical_to_inertial_jacobian,
+        equation_of_state);
+
+    CHECK(flattener_action ==
+          NewtonianEuler::Limiters::FlattenerAction::SetSolutionToMean);
+    CHECK_ITERABLE_APPROX(mass_density_cons, expected_mass_density_cons);
+    CHECK_ITERABLE_APPROX(momentum_density, expected_momentum_density);
+    CHECK_ITERABLE_APPROX(energy_density, expected_energy_density);
+  }
+
+  {
+    INFO("Case: ScaledSolution again, now with non-constant jacobian");
+    const Scalar<DataVector> det_curved_jacobian(
+        DataVector{{1., 1.1, 1.2, 1.3}});
+    Scalar<DataVector> mass_density_cons(DataVector{{0.8, -0.25, 2.25, 1.2}});
+    tnsr::I<DataVector, 1> momentum_density(DataVector{{-1., 0., 0., -2.}});
+    Scalar<DataVector> energy_density(DataVector{{1., 1.6, 1.9, 1.9}});
+
+    // With this jacobian, the means are (from Mathematica)
+    // density mean = 2897 / 2769
+    // momentum mean = -3 / 23
+    // energy mean = 789 / 460
+    // And the scaling factor (before 0.95 safety) is 2897 / 3587
+    // Again from Mathematica, we get the expected results post-flattening...
+    const Scalar<DataVector> expected_mass_density_cons(
+        DataVector{{0.8581014826082916, 0.05248188405797101, 1.970623785368258,
+                    1.165004186817938}});
+    const tnsr::I<DataVector, 1> expected_momentum_density(
+        DataVector{{-0.8279723882134762, -0.06071562768936134,
+                    -0.06071562768936134, -1.595229148737591}});
+    const Scalar<DataVector> expected_energy_density(
+        DataVector{{1.166462012581666, 1.626816068896135, 1.856993097053369,
+                    1.856993097053369}});
+
+    const auto flattener_action = NewtonianEuler::Limiters::flatten_solution(
+        make_not_null(&mass_density_cons), make_not_null(&momentum_density),
+        make_not_null(&energy_density), mesh, det_curved_jacobian,
+        equation_of_state);
+
+    CHECK(flattener_action ==
+          NewtonianEuler::Limiters::FlattenerAction::ScaledSolution);
+    CHECK_ITERABLE_APPROX(mass_density_cons, expected_mass_density_cons);
+    CHECK_ITERABLE_APPROX(momentum_density, expected_momentum_density);
+    CHECK_ITERABLE_APPROX(energy_density, expected_energy_density);
+  }
+}
+
+void test_flattener_2d() noexcept {
+  INFO("Testing flatten_solution in 2D");
+  const Mesh<2> mesh({{2, 3}}, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto);
+  const EquationsOfState::IdealFluid<false> equation_of_state{5. / 3.};
+  const Scalar<DataVector> det_logical_to_inertial_jacobian(
+      DataVector{{2., 2.1, 2.1, 2.2, 2.2, 2.3}});
+
+  {
+    INFO("Case: NoOp");
+    Scalar<DataVector> mass_density_cons(
+        DataVector{{0.8, 1., 0.6, 1.3, 1.1, 1.6}});
+    tnsr::I<DataVector, 2> momentum_density;
+    get<0>(momentum_density) = DataVector{{-0.2, 0.1, 0.2, -0.1, 0.1, -0.2}};
+    get<1>(momentum_density) = DataVector{{0.4, 0.3, 0.2, 0.3, 0.4, 0.7}};
+    Scalar<DataVector> energy_density(DataVector{{1., 1.6, 1.4, 2., 1.8, 1.9}});
+
+    const auto expected_mass_density_cons = mass_density_cons;
+    const auto expected_momentum_density = momentum_density;
+    const auto expected_energy_density = energy_density;
+
+    const auto flattener_action = NewtonianEuler::Limiters::flatten_solution(
+        make_not_null(&mass_density_cons), make_not_null(&momentum_density),
+        make_not_null(&energy_density), mesh, det_logical_to_inertial_jacobian,
+        equation_of_state);
+
+    CHECK(flattener_action == NewtonianEuler::Limiters::FlattenerAction::NoOp);
+    CHECK_ITERABLE_APPROX(mass_density_cons, expected_mass_density_cons);
+    CHECK_ITERABLE_APPROX(momentum_density, expected_momentum_density);
+    CHECK_ITERABLE_APPROX(energy_density, expected_energy_density);
+  }
+
+  {
+    INFO("Case: ScaledSolution because of negative density");
+    Scalar<DataVector> mass_density_cons(
+        DataVector{{0.8, 1., -0.2, 1.3, 1.1, 1.6}});
+    tnsr::I<DataVector, 2> momentum_density;
+    get<0>(momentum_density) = DataVector{{-0.2, 0.1, 0.2, -0.1, 0.1, -0.2}};
+    get<1>(momentum_density) = DataVector{{0.4, 0.3, 0.2, 0.3, 0.4, 0.7}};
+    Scalar<DataVector> energy_density(DataVector{{1., 1.6, 1.4, 2., 1.8, 1.9}});
+
+    const auto original_mass_density_cons = mass_density_cons;
+    const auto original_momentum_density = momentum_density;
+    const auto original_energy_density = energy_density;
+
+    const auto flattener_action = NewtonianEuler::Limiters::flatten_solution(
+        make_not_null(&mass_density_cons), make_not_null(&momentum_density),
+        make_not_null(&energy_density), mesh, det_logical_to_inertial_jacobian,
+        equation_of_state);
+
+    // check 1) action, 2) positive density, 3) all fields changed
+    CHECK(flattener_action ==
+          NewtonianEuler::Limiters::FlattenerAction::ScaledSolution);
+    CHECK(min(get(mass_density_cons)) > 0.);
+    CHECK_FALSE(mass_density_cons == original_mass_density_cons);
+    CHECK_FALSE(momentum_density == original_momentum_density);
+    CHECK_FALSE(energy_density == original_energy_density);
+  }
+
+  {
+    INFO("Case: SetSolutionToMean because of negative pressure");
+    Scalar<DataVector> mass_density_cons(
+        DataVector{{0.8, 1., 0.6, 1.3, 1.1, 1.6}});
+    tnsr::I<DataVector, 2> momentum_density;
+    get<0>(momentum_density) = DataVector{{-2.3, 1.9, 2.1, -3.2, 2.7, -3.2}};
+    get<1>(momentum_density) = DataVector{{0.4, 0.3, 0.2, 0.3, 0.4, 0.7}};
+    Scalar<DataVector> energy_density(DataVector{{1., 1.6, 1.4, 2., 1.8, 1.9}});
+
+    // make sure initial pressure is in fact negative, because if not this isn't
+    // testing the right thing
+    const auto specific_internal_energy_before = Scalar<DataVector>{
+        get(energy_density) / get(mass_density_cons) -
+        0.5 * get(dot_product(momentum_density, momentum_density)) /
+            square(get(mass_density_cons))};
+    const auto pressure_before =
+        equation_of_state.pressure_from_density_and_energy(
+            mass_density_cons, specific_internal_energy_before);
+    CHECK(min(get(pressure_before)) < 0.);
+
+    const auto flattener_action = NewtonianEuler::Limiters::flatten_solution(
+        make_not_null(&mass_density_cons), make_not_null(&momentum_density),
+        make_not_null(&energy_density), mesh, det_logical_to_inertial_jacobian,
+        equation_of_state);
+
+    // check 1) action, 2) positive pressure, 3) all fields set to constant
+    CHECK(flattener_action ==
+          NewtonianEuler::Limiters::FlattenerAction::SetSolutionToMean);
+    const auto specific_internal_energy = Scalar<DataVector>{
+        get(energy_density) / get(mass_density_cons) -
+        0.5 * get(dot_product(momentum_density, momentum_density)) /
+            square(get(mass_density_cons))};
+    const auto pressure = equation_of_state.pressure_from_density_and_energy(
+        mass_density_cons, specific_internal_energy);
+    CHECK(min(get(pressure)) > 0.);
+    CHECK_ITERABLE_APPROX(mass_density_cons,
+                          make_with_value<Scalar<DataVector>>(
+                              get(pressure), get(mass_density_cons)[0]));
+    CHECK_ITERABLE_APPROX(
+        get<0>(momentum_density),
+        DataVector(mesh.number_of_grid_points(), get<0>(momentum_density)[0]));
+    CHECK_ITERABLE_APPROX(
+        get<1>(momentum_density),
+        DataVector(mesh.number_of_grid_points(), get<1>(momentum_density)[0]));
+    CHECK_ITERABLE_APPROX(energy_density,
+                          make_with_value<Scalar<DataVector>>(
+                              get(pressure), get(energy_density)[0]));
+  }
+}
+
+void test_flattener_3d() noexcept {
+  INFO("Testing flatten_solution in 3D");
+  const Mesh<3> mesh(2, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto);
+  const EquationsOfState::IdealFluid<false> equation_of_state{5. / 3.};
+  const Scalar<DataVector> det_logical_to_inertial_jacobian(
+      DataVector{{0.2, 0.1, 0.3, 0.2, 0.5, 0.6, 0.4, 0.5}});
+
+  {
+    INFO("Case: NoOp");
+    Scalar<DataVector> mass_density_cons(
+        DataVector{{1.4, 1.3, 1.2, 1.6, 1.8, 1.7, 1.3, 1.4}});
+    tnsr::I<DataVector, 3> momentum_density;
+    get<0>(momentum_density) = DataVector(8, 0.);
+    get<1>(momentum_density) = DataVector(8, 0.);
+    get<2>(momentum_density) =
+        DataVector{{-0.3, -0.2, -0.4, -0.3, -0.8, -0.2, -0.3, -0.1}};
+    Scalar<DataVector> energy_density(
+        DataVector{{2.1, 2.3, 4.3, 3.5, 2.9, 1.8, 2.6, 2.9}});
+
+    const auto expected_mass_density_cons = mass_density_cons;
+    const auto expected_momentum_density = momentum_density;
+    const auto expected_energy_density = energy_density;
+
+    const auto flattener_action = NewtonianEuler::Limiters::flatten_solution(
+        make_not_null(&mass_density_cons), make_not_null(&momentum_density),
+        make_not_null(&energy_density), mesh, det_logical_to_inertial_jacobian,
+        equation_of_state);
+
+    CHECK(flattener_action == NewtonianEuler::Limiters::FlattenerAction::NoOp);
+    CHECK_ITERABLE_APPROX(mass_density_cons, expected_mass_density_cons);
+    CHECK_ITERABLE_APPROX(momentum_density, expected_momentum_density);
+    CHECK_ITERABLE_APPROX(energy_density, expected_energy_density);
+  }
+
+  {
+    INFO("Case: ScaledSolution because of negative density");
+    Scalar<DataVector> mass_density_cons(
+        DataVector{{1.4, 1.3, 1.2, 1.6, -1.6, 1.7, 1.3, 1.4}});
+    tnsr::I<DataVector, 3> momentum_density;
+    get<0>(momentum_density) = DataVector(8, 0.);
+    get<1>(momentum_density) = DataVector(8, 0.);
+    get<2>(momentum_density) =
+        DataVector{{-0.3, -0.2, -0.4, -0.3, -0.8, -0.2, -0.3, -0.1}};
+    Scalar<DataVector> energy_density(
+        DataVector{{2.1, 2.3, 4.3, 3.5, 2.9, 1.8, 2.6, 2.9}});
+
+    const auto original_mass_density_cons = mass_density_cons;
+    const auto original_momentum_density = momentum_density;
+    const auto original_energy_density = energy_density;
+
+    const auto flattener_action = NewtonianEuler::Limiters::flatten_solution(
+        make_not_null(&mass_density_cons), make_not_null(&momentum_density),
+        make_not_null(&energy_density), mesh, det_logical_to_inertial_jacobian,
+        equation_of_state);
+
+    // check 1) action, 2) positive density, 3) all fields changed
+    CHECK(flattener_action ==
+          NewtonianEuler::Limiters::FlattenerAction::ScaledSolution);
+    CHECK(min(get(mass_density_cons)) > 0.);
+    CHECK_FALSE(mass_density_cons == original_mass_density_cons);
+    CHECK_FALSE(momentum_density == original_momentum_density);
+    CHECK_FALSE(energy_density == original_energy_density);
+  }
+
+  {
+    INFO("Case: SetSolutionToMean because of negative pressure");
+    Scalar<DataVector> mass_density_cons(
+        DataVector{{1.4, 1.3, 1.2, 1.6, 1.8, 1.7, 1.3, 1.4}});
+    tnsr::I<DataVector, 3> momentum_density;
+    get<0>(momentum_density) = DataVector(8, -2.3);
+    get<1>(momentum_density) = DataVector(8, 0.8);
+    get<2>(momentum_density) =
+        DataVector{{-0.3, -0.2, -0.4, -0.3, -0.8, -0.2, -0.3, -0.1}};
+    Scalar<DataVector> energy_density(
+        DataVector{{2.1, 2.3, 4.3, 3.5, 2.9, 1.8, 2.6, 2.9}});
+
+    // make sure initial pressure is in fact negative, because if not this isn't
+    // testing the right thing
+    const auto specific_internal_energy_before = Scalar<DataVector>{
+        get(energy_density) / get(mass_density_cons) -
+        0.5 * get(dot_product(momentum_density, momentum_density)) /
+            square(get(mass_density_cons))};
+    const auto pressure_before =
+        equation_of_state.pressure_from_density_and_energy(
+            mass_density_cons, specific_internal_energy_before);
+    CHECK(min(get(pressure_before)) < 0.);
+
+    const auto flattener_action = NewtonianEuler::Limiters::flatten_solution(
+        make_not_null(&mass_density_cons), make_not_null(&momentum_density),
+        make_not_null(&energy_density), mesh, det_logical_to_inertial_jacobian,
+        equation_of_state);
+
+    // check 1) action, 2) positive pressure, 3) all fields set to constant
+    CHECK(flattener_action ==
+          NewtonianEuler::Limiters::FlattenerAction::SetSolutionToMean);
+    const auto specific_internal_energy = Scalar<DataVector>{
+        get(energy_density) / get(mass_density_cons) -
+        0.5 * get(dot_product(momentum_density, momentum_density)) /
+            square(get(mass_density_cons))};
+    const auto pressure = equation_of_state.pressure_from_density_and_energy(
+        mass_density_cons, specific_internal_energy);
+    CHECK(min(get(pressure)) > 0.);
+    CHECK_ITERABLE_APPROX(mass_density_cons,
+                          make_with_value<Scalar<DataVector>>(
+                              get(pressure), get(mass_density_cons)[0]));
+    CHECK_ITERABLE_APPROX(
+        get<0>(momentum_density),
+        DataVector(mesh.number_of_grid_points(), get<0>(momentum_density)[0]));
+    CHECK_ITERABLE_APPROX(
+        get<1>(momentum_density),
+        DataVector(mesh.number_of_grid_points(), get<1>(momentum_density)[0]));
+    CHECK_ITERABLE_APPROX(energy_density,
+                          make_with_value<Scalar<DataVector>>(
+                              get(pressure), get(energy_density)[0]));
+  }
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.NewtonianEuler.Limiters.Flattener",
+                  "[Unit][Evolution]") {
+  test_flattener_1d();
+  test_flattener_2d();
+  test_flattener_3d();
+}


### PR DESCRIPTION
## Proposed changes

Limiters try to fix oscillations that produce unphysical solution values like negative densities or pressures. But sometimes the algorithms fail to do so, and a further correction step is needed.

This PR adds a "flattener" or "bound-preserving filter" that scales the solution about its mean (u -> ubar + alpha * (u - ubar) for some alpha < 1). This brings every value closer to the mean, and can be used to remove points with negative densities and pressures.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

