### PR TITLE
Specify yaml-cpp version in instructions

### DIFF
--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -30,9 +30,8 @@ installation_on_clusters "Installation on clusters" page.
   support disabled for openmp and mpi, as we want all of our parallelism to
   be accomplished via Charm++.
 * [LIBXSMM](https://github.com/hfp/libxsmm)
-* [yaml-cpp](https://github.com/jbeder/yaml-cpp) built from a commit more
-  recent than November 2016 (versions newer than 0.5.3 should work once any
-  are released)
+* [yaml-cpp](https://github.com/jbeder/yaml-cpp) version 0.6.3 is
+  recommended. Building with shared library support is also recommended.
 * [Python](https://www.python.org/) 2.7, or 3.5 or later
 * [NumPy](http://www.numpy.org/) 1.10 or later
 * [SciPy](https://www.scipy.org)


### PR DESCRIPTION
## Proposed changes

Newer code on develop of yaml-cpp seems to behave differently causing the test
Unit.Options.bad_colon to fail.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
