### PR TITLE
Fix SetupBlas for cmake<3.12

### DIFF
--- a/cmake/SetupBlas.cmake
+++ b/cmake/SetupBlas.cmake
@@ -39,7 +39,7 @@ ${CHECK_DISABLE_OPENBLAS_MULTITHREADING_SOURCE}' -o /dev/null"
   )
 if(${CHECK_DISABLE_OPENBLAS_MULTITHREADING_RESULT} EQUAL 0)
   set(DISABLE_OPENBLAS_MULTITHREADING ON)
-  add_compile_definitions(DISABLE_OPENBLAS_MULTITHREADING)
+  add_definitions(-DDISABLE_OPENBLAS_MULTITHREADING)
   message(STATUS "Disabled OpenBLAS multithreading")
 else()
   message(STATUS "BLAS vendor is probably not OpenBLAS. Make sure it doesn't "


### PR DESCRIPTION
## Proposed changes

#2463 used `add_compiler_definitions`, which is only available in cmake v6.12+. This PR replaces it with `add_definitions`.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
