### PR TITLE
Add inbox utility and use in CCE code, move ConstructionObserver to TestHelpers.hpp

### DIFF
--- a/src/Parallel/Actions/CMakeLists.txt
+++ b/src/Parallel/Actions/CMakeLists.txt
@@ -6,5 +6,6 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Goto.hpp
+  Receive.hpp
   TerminatePhase.hpp
   )

--- a/src/Parallel/Actions/Receive.hpp
+++ b/src/Parallel/Actions/Receive.hpp
@@ -1,0 +1,45 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace Parallel {
+template <typename Metavariables>
+struct GlobalCache;
+}  // namespace Parallel
+/// \endcond
+
+namespace Parallel::Actions {
+
+/*!
+ * \brief Wait for the `InboxTag` to be received at the current temporal ID
+ *
+ * This class does not provide an implementation of `apply`. Instead, actions
+ * can derive from this class to inherit the `is_ready` function and implement
+ * their own `apply` function. The `Parallel::extract_from_inbox` function can
+ * be useful to implement the `apply` function. Here's an example for an action
+ * that derives from this class:
+ *
+ * \snippet Parallel/Actions/Test_Receive.cpp receive_action
+ */
+template <typename InboxTag, typename TemporalIdTag>
+struct Receive {
+  using inbox_tags = tmpl::list<InboxTag>;
+
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex>
+  static bool is_ready(const db::DataBox<DbTags>& box,
+                       const tuples::TaggedTuple<InboxTags...>& inboxes,
+                       const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                       const ArrayIndex& /*array_index*/) noexcept {
+    const auto& inbox = get<InboxTag>(inboxes);
+    return inbox.find(db::get<TemporalIdTag>(box)) != inbox.end();
+  }
+};
+
+}  // namespace Parallel::Actions

--- a/src/Parallel/CMakeLists.txt
+++ b/src/Parallel/CMakeLists.txt
@@ -27,6 +27,7 @@ spectre_target_headers(
   CharmRegistration.hpp
   CreateFromOptions.hpp
   Exit.hpp
+  ExtractFromInbox.hpp
   GlobalCache.hpp
   InboxInserters.hpp
   Info.hpp

--- a/src/Parallel/ExtractFromInbox.hpp
+++ b/src/Parallel/ExtractFromInbox.hpp
@@ -1,0 +1,21 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace Parallel {
+/// Extract the `InboxTag` from the `inboxes` at the current temporal ID. The
+/// value is returned and erased from the inbox.
+template <typename InboxTag, typename TemporalIdTag, typename DbTagsList,
+          typename... InboxTags>
+typename InboxTag::type::mapped_type extract_from_inbox(
+    tuples::TaggedTuple<InboxTags...>& inboxes,
+    const db::DataBox<DbTagsList>& box) noexcept {
+  return std::move(tuples::get<InboxTag>(inboxes)
+                       .extract(db::get<TemporalIdTag>(box))
+                       .mapped());
+}
+}  // namespace Parallel

--- a/tests/Unit/Framework/TestHelpers.hpp
+++ b/tests/Unit/Framework/TestHelpers.hpp
@@ -231,6 +231,30 @@ void test_reverse_iterators(Container& c) {
 
 /*!
  * \ingroup TestingFrameworkGroup
+ * \brief Class to observe which constructors are used
+ */
+struct ConstructionObserver {
+  ConstructionObserver() = default;
+  ConstructionObserver(const ConstructionObserver& /*rhs*/) noexcept {
+    status = "copy-constructed";
+  }
+  ConstructionObserver& operator=(const ConstructionObserver&) = delete;
+  ConstructionObserver(ConstructionObserver&& rhs) noexcept {
+    status = "move-constructed";
+    rhs.status = "move-constructed-away";
+  }
+  ConstructionObserver& operator=(ConstructionObserver&& rhs) noexcept {
+    status = "moved";
+    rhs.status = "moved-away";
+    return *this;
+  };
+  ~ConstructionObserver() = default;
+
+  std::string status = "initial";
+};
+
+/*!
+ * \ingroup TestingFrameworkGroup
  * \brief Function to test comparison operators.  Pass values with
  * less < greater.
  */

--- a/tests/Unit/Parallel/Actions/CMakeLists.txt
+++ b/tests/Unit/Parallel/Actions/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_ParallelActions")
 
 set(LIBRARY_SOURCES
   Test_Goto.cpp
+  Test_Receive.cpp
   Test_TerminatePhase.cpp
   )
 

--- a/tests/Unit/Parallel/Actions/Test_Receive.cpp
+++ b/tests/Unit/Parallel/Actions/Test_Receive.cpp
@@ -1,0 +1,91 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <map>
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Parallel/Actions/Receive.hpp"
+#include "Parallel/ExtractFromInbox.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/InboxInserters.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+
+/// [receive_action]
+struct TemporalIdTag : db::SimpleTag {
+  using type = size_t;
+};
+
+struct SampleDataTag : Parallel::InboxInserters::Value<SampleDataTag> {
+  using temporal_id = size_t;
+  using type = std::map<temporal_id, int>;
+};
+
+struct ReceiveSampleData
+    : Parallel::Actions::Receive<SampleDataTag, TemporalIdTag> {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&> apply(
+      db::DataBox<DbTagsList>& box, tuples::TaggedTuple<InboxTags...>& inboxes,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    const int received_data =
+        Parallel::extract_from_inbox<SampleDataTag, TemporalIdTag>(inboxes,
+                                                                   box);
+    CHECK(received_data == 1);
+    return {std::move(box)};
+  }
+};
+/// [receive_action]
+
+template <typename Metavariables>
+struct Component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Initialization,
+                             tmpl::list<ActionTesting::InitializeDataBox<
+                                 db::AddSimpleTags<TemporalIdTag>>>>,
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Testing,
+                             tmpl::list<ReceiveSampleData>>>;
+};
+
+struct Metavariables {
+  using component_list = tmpl::list<Component<Metavariables>>;
+  enum class Phase { Initialization, Testing, Exit };
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Parallel.Actions.ReceiveSampleData",
+                  "[Unit][Parallel][Actions]") {
+  using component = Component<Metavariables>;
+
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{{}};
+  const size_t temporal_id = 0;
+  ActionTesting::emplace_component_and_initialize<component>(&runner, 0,
+                                                             {temporal_id});
+
+  ActionTesting::set_phase(make_not_null(&runner),
+                           Metavariables::Phase::Testing);
+
+  CHECK_FALSE(ActionTesting::is_ready<component>(runner, 0));
+  ActionTesting::get_inbox_tag<component, SampleDataTag, Metavariables>(
+      make_not_null(&runner), 0)
+      .emplace(temporal_id, 1);
+  CHECK(ActionTesting::is_ready<component>(runner, 0));
+  ActionTesting::next_action<component>(make_not_null(&runner), 0);
+}

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -130,6 +130,7 @@ add_algorithm_test("AlgorithmNodelock" "")
 set(LIBRARY "Test_Parallel")
 
 set(LIBRARY_SOURCES
+  Test_ExtractFromInbox.cpp
   Test_GlobalCacheDataBox.cpp
   Test_InboxInserters.cpp
   Test_NodeLock.cpp

--- a/tests/Unit/Parallel/Test_ExtractFromInbox.cpp
+++ b/tests/Unit/Parallel/Test_ExtractFromInbox.cpp
@@ -1,0 +1,50 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <map>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Parallel/ExtractFromInbox.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+struct TemporalIdTag : db::SimpleTag {
+  using type = size_t;
+};
+
+struct SampleDataTag {
+  using type = std::map<size_t, int>;
+};
+
+struct ConstructionObserverTag {
+  using type = std::map<size_t, ConstructionObserver>;
+};
+
+SPECTRE_TEST_CASE("Unit.Parallel.ExtractFromInbox", "[Parallel][Unit]") {
+  const size_t temporal_id = 0;
+  const auto box = db::create<db::AddSimpleTags<TemporalIdTag>>(temporal_id);
+  tuples::TaggedTuple<SampleDataTag, ConstructionObserverTag> inboxes{};
+
+  tuples::get<SampleDataTag>(inboxes).emplace(temporal_id, 1);
+  CHECK(Parallel::extract_from_inbox<SampleDataTag, TemporalIdTag>(inboxes,
+                                                                   box) == 1);
+  CHECK(tuples::get<SampleDataTag>(inboxes).empty());
+
+  // Make sure no data gets copied it is extracted
+  tuples::get<ConstructionObserverTag>(inboxes).emplace(
+      std::piecewise_construct, std::make_tuple(temporal_id),
+      std::make_tuple());
+  CHECK(tuples::get<ConstructionObserverTag>(inboxes).at(temporal_id).status ==
+        "initial");
+  const auto extracted_observer =
+      Parallel::extract_from_inbox<ConstructionObserverTag, TemporalIdTag>(
+          inboxes, box);
+  CHECK(extracted_observer.status == "move-constructed");
+  CHECK(tuples::get<ConstructionObserverTag>(inboxes).empty());
+}
+}  // namespace

--- a/tests/Unit/Utilities/Test_TupleSlice.cpp
+++ b/tests/Unit/Utilities/Test_TupleSlice.cpp
@@ -6,31 +6,8 @@
 #include <string>
 #include <tuple>
 
+#include "Framework/TestHelpers.hpp"
 #include "Utilities/TupleSlice.hpp"
-
-namespace {
-
-struct ConstructionObserver {
-  ConstructionObserver() = default;
-  ConstructionObserver(const ConstructionObserver& /*rhs*/) noexcept {
-    status = "copy-constructed";
-  }
-  ConstructionObserver& operator=(const ConstructionObserver&) = delete;
-  ConstructionObserver(ConstructionObserver&& rhs) noexcept {
-    status = "move-constructed";
-    rhs.status = "move-constructed-away";
-  }
-  ConstructionObserver& operator=(ConstructionObserver&& rhs) noexcept {
-    status = "moved";
-    rhs.status = "moved-away";
-    return *this;
-  };
-  ~ConstructionObserver() = default;
-
-  std::string status = "initial";
-};
-
-}  // namespace
 
 SPECTRE_TEST_CASE("Unit.Utilities.TupleSlice", "[Utilities][Unit]") {
   CHECK(tuple_slice<1, 3>(std::tuple<int, float, double, std::string>{


### PR DESCRIPTION
## Proposed changes

Waiting for data to be received and then extracting it from the inbox is a common pattern. This PR adds some utility code that makes this pattern easier to implement, and that avoids copy-pasting this code:

- The function `Parallel::extract_from_index` retrieves an inbox tag at the current temporal ID, then erases it from the inbox.
- The class `Parallel::Receive` implements a simple `is_ready` function that actions can inherit.

I put these to use to simplify the `Cce::Actions::ReceiveWorldtubeData`, and I'll use them to address #2186.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
