### PR TITLE
Add Schwarzschild solution to XCTS system in isotropic coords

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -110,6 +110,16 @@
   SLACcitation   = "%%CITATION = GR-QC/0610120;%%"
 }
 
+@book{BaumgarteShapiro,
+  author    = {Baumgarte, Thomas W. and Shapiro, Stuart L.},
+  title     = {Numerical Relativity: Solving {Einstein's} Equations on the
+               Computer},
+  year      = {2010},
+  url       = {https://doi.org/10.1017/CBO9781139193344},
+  doi       = {10.1017/CBO9781139193344},
+  publisher = {Cambridge University Press}
+}
+
 @article{Beckwith2011iy,
   author         = "Beckwith, Kris and Stone, James M.",
   title          = "A Second-order {Godunov} Method for Multi-dimensional

--- a/src/Elliptic/Systems/Xcts/Tags.hpp
+++ b/src/Elliptic/Systems/Xcts/Tags.hpp
@@ -7,6 +7,7 @@
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 
 /*!
  * \ingroup EllipticSystemsGroup
@@ -14,15 +15,110 @@
  * equations.
  */
 namespace Xcts {
+/// Tags related to the XCTS equations
 namespace Tags {
 
 /*!
  * \brief The conformal factor \f$\psi(x)\f$ that rescales the spatial metric
- * \f$\gamma_{ij}=\psi^4\overline{\gamma}_{ij}\f$.
+ * \f$\gamma_{ij}=\psi^4\bar{\gamma}_{ij}\f$.
  */
 template <typename DataType>
 struct ConformalFactor : db::SimpleTag {
   using type = Scalar<DataType>;
+};
+
+/*!
+ * \brief The quantity `Tag` scaled by the `Xcts::Tags::ConformalFactor` to the
+ * given `Power`
+ */
+template <typename Tag, int Power>
+struct Conformal : db::PrefixTag, db::SimpleTag {
+  using type = typename Tag::type;
+  using tag = Tag;
+  static constexpr int conformal_factor_power = Power;
+};
+
+/*!
+ * \brief The conformally scaled spatial metric
+ * \f$\bar{\gamma}_{ij}=\psi^{-4}\gamma_{ij}\f$, where \f$\psi\f$ is the
+ * `Xcts::Tags::ConformalFactor` and \f$gamma_{ij}\f$ is the
+ * `gr::Tags::SpatialMetric`
+ */
+template <typename DataType, size_t Dim, typename Frame>
+using ConformalMetric =
+    Conformal<gr::Tags::SpatialMetric<Dim, Frame, DataType>, -4>;
+
+/*!
+ * \brief The product of lapse \f$\alpha(x)\f$ and conformal factor
+ * \f$\psi(x)\f$
+ *
+ * This quantity is commonly used in formulations of the XCTS equations.
+ */
+template <typename DataType>
+struct LapseTimesConformalFactor : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+/*!
+ * \brief The constant part \f$\beta^i_\mathrm{background}\f$ of the shift
+ * \f$\beta^i=\beta^i_\mathrm{background} + \beta^i_\mathrm{excess}\f$
+ *
+ * \see `Xcts::Tags::ShiftExcess`
+ */
+template <typename DataType, size_t Dim, typename Frame>
+struct ShiftBackground : db::SimpleTag {
+  using type = tnsr::I<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief The dynamic part \f$\beta^i_\mathrm{excess}\f$ of the shift
+ * \f$\beta^i=\beta^i_\mathrm{background} + \beta^i_\mathrm{excess}\f$
+ *
+ * We commonly split off the part of the shift that diverges at large coordinate
+ * distances (the "background" shift \f$\beta^i_\mathrm{background}\f$) and
+ * solve only for the remainder (the "excess" shift
+ * \f$\beta^i_\mathrm{excess}\f$). For example, the background shift might be a
+ * uniform rotation \f$\beta^i_\mathrm{background}=(-\Omega y, \Omega x, 0)\f$
+ * with angular velocity \f$\Omega\f$ around the z-axis, given here in Cartesian
+ * coordinates.
+ *
+ * \see `Xcts::Tags::Background`
+ */
+template <typename DataType, size_t Dim, typename Frame>
+struct ShiftExcess : db::SimpleTag {
+  using type = tnsr::I<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief The symmetric "strain" of the shift vector
+ * \f$B_{ij} = \bar{\nabla}_{(i}\bar{\gamma}_{j)k}\beta^k =
+ * \left(\partial_{(i}\bar{\gamma}_{j)k} - \bar{\Gamma}_{kij}\right)\beta^k\f$
+ *
+ * This quantity is used in our formulations of the XCTS equations.
+ *
+ * Note that the shift is not a conformal quantity, so its index is generally
+ * raised and lowered with the spatial metric, not with the conformal metric.
+ * However, to compute this "strain" we use the conformal metric as defined
+ * above. The conformal longitudinal shift in terms of this quantity is then:
+ *
+ * \f{equation}
+ * (\bar{L}\beta)^{ij} = 2\left(\bar{\gamma}^{ik}\bar{\gamma}^{jl}
+ * - \frac{1}{3}\bar{\gamma}^{ij}\bar{\gamma}^{kl}\right) B_{kl}
+ * \f}
+ *
+ * Note that the conformal longitudinal shift is (minus) the "stress" quantity
+ * of a linear elasticity system in which the shift takes the role of the
+ * displacement vector and the definition of its "strain" remains the same. This
+ * auxiliary elasticity system is formulated on an isotropic constitutive
+ * relation based on the conformal metric with vanishing bulk modulus \f$K=0\f$
+ * (not to be confused with the extrinsic curvature trace \f$K\f$ in this
+ * context) and unit shear modulus \f$\mu=1\f$. See the
+ * `Elasticity::FirstOrderSystem` and the
+ * `Elasticity::ConstitutiveRelations::IsotropicHomogeneous` for details.
+ */
+template <typename DataType, size_t Dim, typename Frame>
+struct ShiftStrain : db::SimpleTag {
+  using type = tnsr::ii<DataType, Dim, Frame>;
 };
 
 }  // namespace Tags

--- a/src/Elliptic/Systems/Xcts/Tags.hpp
+++ b/src/Elliptic/Systems/Xcts/Tags.hpp
@@ -25,16 +25,5 @@ struct ConformalFactor : db::SimpleTag {
   using type = Scalar<DataType>;
 };
 
-/*!
- * \brief The gradient of the conformal factor \f$\psi(x)\f$
- *
- * \details This quantity can be used as an auxiliary variable in a first-order
- * formulation of the XCTS equations.
- */
-template <size_t Dim, typename Frame, typename DataType>
-struct ConformalFactorGradient : db::SimpleTag {
-  using type = tnsr::I<DataType, Dim, Frame>;
-};
-
 }  // namespace Tags
 }  // namespace Xcts

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
@@ -16,6 +16,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ConstantDensityStar.hpp
+  Solutions.hpp
   )
 
 target_link_libraries(

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   ConstantDensityStar.cpp
+  Schwarzschild.cpp
   )
 
 spectre_target_headers(
@@ -16,6 +17,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ConstantDensityStar.hpp
+  Schwarzschild.hpp
   Solutions.hpp
   )
 
@@ -24,6 +26,8 @@ target_link_libraries(
   PUBLIC
   DataStructures
   ErrorHandling
+  GeneralRelativity
   Options
   Utilities
+  Xcts
   )

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/ConstantDensityStar.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/ConstantDensityStar.cpp
@@ -13,6 +13,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/Tensor.hpp"               // IWYU pragma: keep
+#include "Elliptic/Systems/Xcts/Tags.hpp"
 #include "NumericalAlgorithms/RootFinding/NewtonRaphson.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/ConstantExpressions.hpp"
@@ -66,8 +67,7 @@ Scalar<DataVector> compute_piecewise(const Scalar<DataVector>& r,
 }  // namespace
 
 /// \cond
-namespace Xcts {
-namespace Solutions {
+namespace Xcts::Solutions {
 
 ConstantDensityStar::ConstantDensityStar(const double density,
                                          const double radius,
@@ -126,13 +126,14 @@ ConstantDensityStar::variables(
 }
 
 template <typename DataType>
-tuples::TaggedTuple<::Tags::Initial<
-    Xcts::Tags::ConformalFactorGradient<3, Frame::Inertial, DataType>>>
+tuples::TaggedTuple<::Tags::Initial<::Tags::deriv<
+    Xcts::Tags::ConformalFactor<DataType>, tmpl::size_t<3>, Frame::Inertial>>>
 ConstantDensityStar::variables(
     const tnsr::I<DataType, 3, Frame::Inertial>& x,
-    tmpl::list<::Tags::Initial<Xcts::Tags::ConformalFactorGradient<
-        3, Frame::Inertial, DataType>>> /*meta*/) const noexcept {
-  return {make_with_value<tnsr::I<DataType, 3, Frame::Inertial>>(x, 0.)};
+    tmpl::list<::Tags::Initial<
+        ::Tags::deriv<Xcts::Tags::ConformalFactor<DataType>, tmpl::size_t<3>,
+                      Frame::Inertial>>> /*meta*/) const noexcept {
+  return {make_with_value<tnsr::i<DataType, 3, Frame::Inertial>>(x, 0.)};
 }
 
 template <typename DataType>
@@ -165,33 +166,35 @@ bool operator!=(const ConstantDensityStar& lhs,
 
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data)                                                 \
-  template tuples::TaggedTuple<Xcts::Tags::ConformalFactor<DTYPE(data)>>     \
-  ConstantDensityStar::variables(                                            \
-      const tnsr::I<DTYPE(data), 3, Frame::Inertial>&,                       \
-      tmpl::list<Xcts::Tags::ConformalFactor<DTYPE(data)>>) const noexcept;  \
-  template tuples::TaggedTuple<                                              \
-      ::Tags::Initial<Xcts::Tags::ConformalFactor<DTYPE(data)>>>             \
-  ConstantDensityStar::variables(                                            \
-      const tnsr::I<DTYPE(data), 3, Frame::Inertial>&,                       \
-      tmpl::list<::Tags::Initial<Xcts::Tags::ConformalFactor<DTYPE(data)>>>) \
-      const noexcept;                                                        \
-  template tuples::TaggedTuple<::Tags::Initial<                              \
-      Xcts::Tags::ConformalFactorGradient<3, Frame::Inertial, DTYPE(data)>>> \
-  ConstantDensityStar::variables(                                            \
-      const tnsr::I<DTYPE(data), 3, Frame::Inertial>&,                       \
-      tmpl::list<::Tags::Initial<Xcts::Tags::ConformalFactorGradient<        \
-          3, Frame::Inertial, DTYPE(data)>>>) const noexcept;                \
-  template tuples::TaggedTuple<                                              \
-      ::Tags::FixedSource<Xcts::Tags::ConformalFactor<DTYPE(data)>>>         \
-  ConstantDensityStar::variables(                                            \
-      const tnsr::I<DTYPE(data), 3, Frame::Inertial>&,                       \
-      tmpl::list<                                                            \
-          ::Tags::FixedSource<Xcts::Tags::ConformalFactor<DTYPE(data)>>>)    \
-      const noexcept;                                                        \
-  template tuples::TaggedTuple<gr::Tags::EnergyDensity<DTYPE(data)>>         \
-  ConstantDensityStar::variables(                                            \
-      const tnsr::I<DTYPE(data), 3, Frame::Inertial>&,                       \
+#define INSTANTIATE(_, data)                                                  \
+  template tuples::TaggedTuple<Xcts::Tags::ConformalFactor<DTYPE(data)>>      \
+  ConstantDensityStar::variables(                                             \
+      const tnsr::I<DTYPE(data), 3, Frame::Inertial>&,                        \
+      tmpl::list<Xcts::Tags::ConformalFactor<DTYPE(data)>>) const noexcept;   \
+  template tuples::TaggedTuple<                                               \
+      ::Tags::Initial<Xcts::Tags::ConformalFactor<DTYPE(data)>>>              \
+  ConstantDensityStar::variables(                                             \
+      const tnsr::I<DTYPE(data), 3, Frame::Inertial>&,                        \
+      tmpl::list<::Tags::Initial<Xcts::Tags::ConformalFactor<DTYPE(data)>>>)  \
+      const noexcept;                                                         \
+  template tuples::TaggedTuple<                                               \
+      ::Tags::Initial<::Tags::deriv<Xcts::Tags::ConformalFactor<DTYPE(data)>, \
+                                    tmpl::size_t<3>, Frame::Inertial>>>       \
+  ConstantDensityStar::variables(                                             \
+      const tnsr::I<DTYPE(data), 3, Frame::Inertial>&,                        \
+      tmpl::list<::Tags::Initial<                                             \
+          ::Tags::deriv<Xcts::Tags::ConformalFactor<DTYPE(data)>,             \
+                        tmpl::size_t<3>, Frame::Inertial>>>) const noexcept;  \
+  template tuples::TaggedTuple<                                               \
+      ::Tags::FixedSource<Xcts::Tags::ConformalFactor<DTYPE(data)>>>          \
+  ConstantDensityStar::variables(                                             \
+      const tnsr::I<DTYPE(data), 3, Frame::Inertial>&,                        \
+      tmpl::list<                                                             \
+          ::Tags::FixedSource<Xcts::Tags::ConformalFactor<DTYPE(data)>>>)     \
+      const noexcept;                                                         \
+  template tuples::TaggedTuple<gr::Tags::EnergyDensity<DTYPE(data)>>          \
+  ConstantDensityStar::variables(                                             \
+      const tnsr::I<DTYPE(data), 3, Frame::Inertial>&,                        \
       tmpl::list<gr::Tags::EnergyDensity<DTYPE(data)>>) const noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
@@ -199,6 +202,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
 #undef DTYPE
 #undef INSTANTIATE
 
-}  // namespace Solutions
-}  // namespace Xcts
+}  // namespace Xcts::Solutions
 /// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/ConstantDensityStar.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/ConstantDensityStar.hpp
@@ -8,6 +8,7 @@
 #include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/Tensor.hpp"     // IWYU pragma: keep
 #include "Elliptic/Systems/Xcts/Tags.hpp"       // IWYU pragma: keep
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "Options/Options.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/TMPL.hpp"
@@ -21,8 +22,7 @@ class er;
 }  // namespace PUP
 /// \endcond
 
-namespace Xcts {
-namespace Solutions {
+namespace Xcts::Solutions {
 
 /*!
  * \brief A constant density star in general relativity
@@ -136,10 +136,12 @@ class ConstantDensityStar {
 
   template <typename DataType>
   auto variables(const tnsr::I<DataType, 3, Frame::Inertial>& x,
-                 tmpl::list<::Tags::Initial<Xcts::Tags::ConformalFactorGradient<
-                     3, Frame::Inertial, DataType>>> /*meta*/) const noexcept
-      -> tuples::TaggedTuple<::Tags::Initial<
-          Xcts::Tags::ConformalFactorGradient<3, Frame::Inertial, DataType>>>;
+                 tmpl::list<::Tags::Initial<
+                     ::Tags::deriv<Xcts::Tags::ConformalFactor<DataType>,
+                                   tmpl::size_t<3>, Frame::Inertial>>> /*meta*/)
+      const noexcept -> tuples::TaggedTuple<
+          ::Tags::Initial<::Tags::deriv<Xcts::Tags::ConformalFactor<DataType>,
+                                        tmpl::size_t<3>, Frame::Inertial>>>;
 
   template <typename DataType>
   auto variables(const tnsr::I<DataType, 3, Frame::Inertial>& x,
@@ -180,5 +182,4 @@ bool operator==(const ConstantDensityStar& /*lhs*/,
 bool operator!=(const ConstantDensityStar& lhs,
                 const ConstantDensityStar& rhs) noexcept;
 
-}  // namespace Solutions
-}  // namespace Xcts
+}  // namespace Xcts::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.cpp
@@ -1,0 +1,375 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.hpp"
+
+#include <ostream>
+#include <utility>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Elliptic/Systems/Xcts/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+/// \cond
+namespace Xcts::Solutions {
+
+std::ostream& operator<<(std::ostream& os,
+                         const SchwarzschildCoordinates coords) noexcept {
+  switch (coords) {
+    case SchwarzschildCoordinates::Isotropic:
+      return os << "Isotropic";
+    default:
+      ERROR("Unknown SchwarzschildCoordinates");
+  }
+}
+
+template <SchwarzschildCoordinates Coords>
+Schwarzschild<Coords>::Schwarzschild(const double mass) noexcept
+    : mass_(mass) {}
+
+template <SchwarzschildCoordinates Coords>
+double Schwarzschild<Coords>::mass() const noexcept {
+  return mass_;
+}
+
+template <>
+double Schwarzschild<SchwarzschildCoordinates::Isotropic>::radius_at_horizon()
+    const noexcept {
+  return 0.5 * mass_;
+}
+
+// Conformal metric
+
+template <SchwarzschildCoordinates Coords>
+template <typename DataType>
+tuples::TaggedTuple<Xcts::Tags::ConformalMetric<DataType, 3, Frame::Inertial>>
+Schwarzschild<Coords>::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<Xcts::Tags::ConformalMetric<DataType, 3,
+                                           Frame::Inertial>> /*meta*/) const
+    noexcept {
+  auto conformal_metric =
+      make_with_value<tnsr::ii<DataType, 3, Frame::Inertial>>(x, 0.);
+  get<0, 0>(conformal_metric) = 1.;
+  get<1, 1>(conformal_metric) = 1.;
+  get<2, 2>(conformal_metric) = 1.;
+  return {std::move(conformal_metric)};
+}
+
+// Extrinsic curvature trace
+
+template <>
+template <typename DataType>
+tuples::TaggedTuple<gr::Tags::TraceExtrinsicCurvature<DataType>>
+Schwarzschild<SchwarzschildCoordinates::Isotropic>::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<gr::Tags::TraceExtrinsicCurvature<DataType>> /*meta*/) const
+    noexcept {
+  return {make_with_value<Scalar<DataType>>(x, 0.)};
+}
+
+// Extrinsic curvature trace gradient
+
+template <>
+template <typename DataType>
+tuples::TaggedTuple<::Tags::deriv<gr::Tags::TraceExtrinsicCurvature<DataType>,
+                                  tmpl::size_t<3>, Frame::Inertial>>
+Schwarzschild<SchwarzschildCoordinates::Isotropic>::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<::Tags::deriv<gr::Tags::TraceExtrinsicCurvature<DataType>,
+                             tmpl::size_t<3>, Frame::Inertial>> /*meta*/) const
+    noexcept {
+  return {make_with_value<tnsr::i<DataType, 3, Frame::Inertial>>(x, 0.)};
+}
+
+// Conformal factor
+
+template <>
+template <typename DataType>
+tuples::TaggedTuple<Xcts::Tags::ConformalFactor<DataType>>
+Schwarzschild<SchwarzschildCoordinates::Isotropic>::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<Xcts::Tags::ConformalFactor<DataType>> /*meta*/) const noexcept {
+  return {Scalar<DataType>{1. + 0.5 * mass_ / get(magnitude(x))}};
+}
+
+// Conformal factor gradient
+
+template <>
+template <typename DataType>
+tuples::TaggedTuple<::Tags::deriv<Xcts::Tags::ConformalFactor<DataType>,
+                                  tmpl::size_t<3>, Frame::Inertial>>
+Schwarzschild<SchwarzschildCoordinates::Isotropic>::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<::Tags::deriv<Xcts::Tags::ConformalFactor<DataType>,
+                             tmpl::size_t<3>, Frame::Inertial>> /*meta*/) const
+    noexcept {
+  const DataType isotropic_prefactor = -0.5 * mass_ / cube(get(magnitude(x)));
+  auto conformal_factor_gradient =
+      make_with_value<tnsr::i<DataType, 3, Frame::Inertial>>(x, 0.);
+  get<0>(conformal_factor_gradient) = isotropic_prefactor * get<0>(x);
+  get<1>(conformal_factor_gradient) = isotropic_prefactor * get<1>(x);
+  get<2>(conformal_factor_gradient) = isotropic_prefactor * get<2>(x);
+  return {std::move(conformal_factor_gradient)};
+}
+
+// Lapse (times conformal factor)
+
+template <>
+template <typename DataType>
+tuples::TaggedTuple<Xcts::Tags::LapseTimesConformalFactor<DataType>>
+Schwarzschild<SchwarzschildCoordinates::Isotropic>::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<Xcts::Tags::LapseTimesConformalFactor<DataType>> /*meta*/) const
+    noexcept {
+  return {Scalar<DataType>{1. - 0.5 * mass_ / get(magnitude(x))}};
+}
+
+// Lapse (times conformal factor) gradient
+
+template <>
+template <typename DataType>
+tuples::TaggedTuple<
+    ::Tags::deriv<Xcts::Tags::LapseTimesConformalFactor<DataType>,
+                  tmpl::size_t<3>, Frame::Inertial>>
+Schwarzschild<SchwarzschildCoordinates::Isotropic>::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<::Tags::deriv<Xcts::Tags::LapseTimesConformalFactor<DataType>,
+                             tmpl::size_t<3>, Frame::Inertial>> /*meta*/) const
+    noexcept {
+  auto lapse_times_conformal_factor_gradient = get<::Tags::deriv<
+      Xcts::Tags::ConformalFactor<DataType>, tmpl::size_t<3>, Frame::Inertial>>(
+      variables(x,
+                tmpl::list<::Tags::deriv<Xcts::Tags::ConformalFactor<DataType>,
+                                         tmpl::size_t<3>, Frame::Inertial>>{}));
+  get<0>(lapse_times_conformal_factor_gradient) *= -1.;
+  get<1>(lapse_times_conformal_factor_gradient) *= -1.;
+  get<2>(lapse_times_conformal_factor_gradient) *= -1.;
+  return {std::move(lapse_times_conformal_factor_gradient)};
+}
+
+// Shift
+
+template <SchwarzschildCoordinates Coords>
+template <typename DataType>
+tuples::TaggedTuple<Xcts::Tags::ShiftBackground<DataType, 3, Frame::Inertial>>
+Schwarzschild<Coords>::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<Xcts::Tags::ShiftBackground<DataType, 3,
+                                           Frame::Inertial>> /*meta*/) const
+    noexcept {
+  return {make_with_value<tnsr::I<DataType, 3, Frame::Inertial>>(x, 0.)};
+}
+
+template <>
+template <typename DataType>
+tuples::TaggedTuple<Xcts::Tags::ShiftExcess<DataType, 3, Frame::Inertial>>
+Schwarzschild<SchwarzschildCoordinates::Isotropic>::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<Xcts::Tags::ShiftExcess<DataType, 3, Frame::Inertial>> /*meta*/)
+    const noexcept {
+  return {make_with_value<tnsr::I<DataType, 3, Frame::Inertial>>(x, 0.)};
+}
+
+// Shift strain
+
+template <>
+template <typename DataType>
+tuples::TaggedTuple<Xcts::Tags::ShiftStrain<DataType, 3, Frame::Inertial>>
+Schwarzschild<SchwarzschildCoordinates::Isotropic>::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<Xcts::Tags::ShiftStrain<DataType, 3, Frame::Inertial>> /*meta*/)
+    const noexcept {
+  return {make_with_value<tnsr::ii<DataType, 3, Frame::Inertial>>(x, 0.)};
+}
+
+// Fixed sources (all zero)
+
+template <SchwarzschildCoordinates Coords>
+template <typename DataType>
+tuples::TaggedTuple<::Tags::FixedSource<Xcts::Tags::ConformalFactor<DataType>>>
+Schwarzschild<Coords>::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<
+        ::Tags::FixedSource<Xcts::Tags::ConformalFactor<DataType>>> /*meta*/)
+    const noexcept {
+  return {make_with_value<Scalar<DataType>>(x, 0.)};
+}
+
+template <SchwarzschildCoordinates Coords>
+template <typename DataType>
+tuples::TaggedTuple<
+    ::Tags::FixedSource<Xcts::Tags::LapseTimesConformalFactor<DataType>>>
+Schwarzschild<Coords>::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<::Tags::FixedSource<
+        Xcts::Tags::LapseTimesConformalFactor<DataType>>> /*meta*/) const
+    noexcept {
+  return {make_with_value<Scalar<DataType>>(x, 0.)};
+}
+
+template <SchwarzschildCoordinates Coords>
+template <typename DataType>
+tuples::TaggedTuple<
+    ::Tags::FixedSource<Xcts::Tags::ShiftExcess<DataType, 3, Frame::Inertial>>>
+Schwarzschild<Coords>::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<::Tags::FixedSource<
+        Xcts::Tags::ShiftExcess<DataType, 3, Frame::Inertial>>> /*meta*/) const
+    noexcept {
+  return {make_with_value<tnsr::I<DataType, 3, Frame::Inertial>>(x, 0.)};
+}
+
+// Matter sources (all zero)
+
+template <SchwarzschildCoordinates Coords>
+template <typename DataType>
+tuples::TaggedTuple<gr::Tags::EnergyDensity<DataType>>
+Schwarzschild<Coords>::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<gr::Tags::EnergyDensity<DataType>> /*meta*/) const noexcept {
+  return {make_with_value<Scalar<DataType>>(x, 0.)};
+}
+
+template <SchwarzschildCoordinates Coords>
+template <typename DataType>
+tuples::TaggedTuple<gr::Tags::StressTrace<DataType>>
+Schwarzschild<Coords>::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<gr::Tags::StressTrace<DataType>> /*meta*/) const noexcept {
+  return {make_with_value<Scalar<DataType>>(x, 0.)};
+}
+
+template <SchwarzschildCoordinates Coords>
+template <typename DataType>
+tuples::TaggedTuple<gr::Tags::MomentumDensity<3, Frame::Inertial, DataType>>
+Schwarzschild<Coords>::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<
+        gr::Tags::MomentumDensity<3, Frame::Inertial, DataType>> /*meta*/) const
+    noexcept {
+  return {make_with_value<tnsr::I<DataType, 3, Frame::Inertial>>(x, 0.)};
+}
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define COORDS(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                                   \
+  template tuples::TaggedTuple<                                                \
+      Xcts::Tags::ConformalMetric<DTYPE(data), 3, Frame::Inertial>>            \
+  Schwarzschild<COORDS(data)>::variables(                                      \
+      const tnsr::I<DTYPE(data), 3, Frame::Inertial>&,                         \
+      tmpl::list<                                                              \
+          Xcts::Tags::ConformalMetric<DTYPE(data), 3, Frame::Inertial>>)       \
+      const noexcept;                                                          \
+  template tuples::TaggedTuple<gr::Tags::TraceExtrinsicCurvature<DTYPE(data)>> \
+  Schwarzschild<COORDS(data)>::variables(                                      \
+      const tnsr::I<DTYPE(data), 3, Frame::Inertial>&,                         \
+      tmpl::list<gr::Tags::TraceExtrinsicCurvature<DTYPE(data)>>)              \
+      const noexcept;                                                          \
+  template tuples::TaggedTuple<                                                \
+      ::Tags::deriv<gr::Tags::TraceExtrinsicCurvature<DTYPE(data)>,            \
+                    tmpl::size_t<3>, Frame::Inertial>>                         \
+  Schwarzschild<COORDS(data)>::variables(                                      \
+      const tnsr::I<DTYPE(data), 3, Frame::Inertial>&,                         \
+      tmpl::list<::Tags::deriv<gr::Tags::TraceExtrinsicCurvature<DTYPE(data)>, \
+                               tmpl::size_t<3>, Frame::Inertial>>)             \
+      const noexcept;                                                          \
+  template tuples::TaggedTuple<Xcts::Tags::ConformalFactor<DTYPE(data)>>       \
+  Schwarzschild<COORDS(data)>::variables(                                      \
+      const tnsr::I<DTYPE(data), 3, Frame::Inertial>&,                         \
+      tmpl::list<Xcts::Tags::ConformalFactor<DTYPE(data)>>) const noexcept;    \
+  template tuples::TaggedTuple<                                                \
+      ::Tags::deriv<Xcts::Tags::ConformalFactor<DTYPE(data)>, tmpl::size_t<3>, \
+                    Frame::Inertial>>                                          \
+  Schwarzschild<COORDS(data)>::variables(                                      \
+      const tnsr::I<DTYPE(data), 3, Frame::Inertial>&,                         \
+      tmpl::list<::Tags::deriv<Xcts::Tags::ConformalFactor<DTYPE(data)>,       \
+                               tmpl::size_t<3>, Frame::Inertial>>)             \
+      const noexcept;                                                          \
+  template tuples::TaggedTuple<                                                \
+      Xcts::Tags::LapseTimesConformalFactor<DTYPE(data)>>                      \
+  Schwarzschild<COORDS(data)>::variables(                                      \
+      const tnsr::I<DTYPE(data), 3, Frame::Inertial>&,                         \
+      tmpl::list<Xcts::Tags::LapseTimesConformalFactor<DTYPE(data)>>)          \
+      const noexcept;                                                          \
+  template tuples::TaggedTuple<                                                \
+      ::Tags::deriv<Xcts::Tags::LapseTimesConformalFactor<DTYPE(data)>,        \
+                    tmpl::size_t<3>, Frame::Inertial>>                         \
+  Schwarzschild<COORDS(data)>::variables(                                      \
+      const tnsr::I<DTYPE(data), 3, Frame::Inertial>&,                         \
+      tmpl::list<                                                              \
+          ::Tags::deriv<Xcts::Tags::LapseTimesConformalFactor<DTYPE(data)>,    \
+                        tmpl::size_t<3>, Frame::Inertial>>) const noexcept;    \
+  template tuples::TaggedTuple<                                                \
+      Xcts::Tags::ShiftBackground<DTYPE(data), 3, Frame::Inertial>>            \
+  Schwarzschild<COORDS(data)>::variables(                                      \
+      const tnsr::I<DTYPE(data), 3, Frame::Inertial>&,                         \
+      tmpl::list<                                                              \
+          Xcts::Tags::ShiftBackground<DTYPE(data), 3, Frame::Inertial>>)       \
+      const noexcept;                                                          \
+  template tuples::TaggedTuple<                                                \
+      Xcts::Tags::ShiftExcess<DTYPE(data), 3, Frame::Inertial>>                \
+  Schwarzschild<COORDS(data)>::variables(                                      \
+      const tnsr::I<DTYPE(data), 3, Frame::Inertial>&,                         \
+      tmpl::list<Xcts::Tags::ShiftExcess<DTYPE(data), 3, Frame::Inertial>>)    \
+      const noexcept;                                                          \
+  template tuples::TaggedTuple<                                                \
+      Xcts::Tags::ShiftStrain<DTYPE(data), 3, Frame::Inertial>>                \
+  Schwarzschild<COORDS(data)>::variables(                                      \
+      const tnsr::I<DTYPE(data), 3, Frame::Inertial>&,                         \
+      tmpl::list<Xcts::Tags::ShiftStrain<DTYPE(data), 3, Frame::Inertial>>)    \
+      const noexcept;                                                          \
+  template tuples::TaggedTuple<                                                \
+      ::Tags::FixedSource<Xcts::Tags::ConformalFactor<DTYPE(data)>>>           \
+  Schwarzschild<COORDS(data)>::variables(                                      \
+      const tnsr::I<DTYPE(data), 3, Frame::Inertial>&,                         \
+      tmpl::list<                                                              \
+          ::Tags::FixedSource<Xcts::Tags::ConformalFactor<DTYPE(data)>>>)      \
+      const noexcept;                                                          \
+  template tuples::TaggedTuple<                                                \
+      ::Tags::FixedSource<Xcts::Tags::LapseTimesConformalFactor<DTYPE(data)>>> \
+  Schwarzschild<COORDS(data)>::variables(                                      \
+      const tnsr::I<DTYPE(data), 3, Frame::Inertial>&,                         \
+      tmpl::list<::Tags::FixedSource<                                          \
+          Xcts::Tags::LapseTimesConformalFactor<DTYPE(data)>>>)                \
+      const noexcept;                                                          \
+  template tuples::TaggedTuple<::Tags::FixedSource<                            \
+      Xcts::Tags::ShiftExcess<DTYPE(data), 3, Frame::Inertial>>>               \
+  Schwarzschild<COORDS(data)>::variables(                                      \
+      const tnsr::I<DTYPE(data), 3, Frame::Inertial>&,                         \
+      tmpl::list<::Tags::FixedSource<                                          \
+          Xcts::Tags::ShiftExcess<DTYPE(data), 3, Frame::Inertial>>>)          \
+      const noexcept;                                                          \
+  template tuples::TaggedTuple<gr::Tags::EnergyDensity<DTYPE(data)>>           \
+  Schwarzschild<COORDS(data)>::variables(                                      \
+      const tnsr::I<DTYPE(data), 3, Frame::Inertial>&,                         \
+      tmpl::list<gr::Tags::EnergyDensity<DTYPE(data)>>) const noexcept;        \
+  template tuples::TaggedTuple<gr::Tags::StressTrace<DTYPE(data)>>             \
+  Schwarzschild<COORDS(data)>::variables(                                      \
+      const tnsr::I<DTYPE(data), 3, Frame::Inertial>&,                         \
+      tmpl::list<gr::Tags::StressTrace<DTYPE(data)>>) const noexcept;          \
+  template tuples::TaggedTuple<                                                \
+      gr::Tags::MomentumDensity<3, Frame::Inertial, DTYPE(data)>>              \
+  Schwarzschild<COORDS(data)>::variables(                                      \
+      const tnsr::I<DTYPE(data), 3, Frame::Inertial>&,                         \
+      tmpl::list<gr::Tags::MomentumDensity<3, Frame::Inertial, DTYPE(data)>>)  \
+      const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector),
+                        (SchwarzschildCoordinates::Isotropic))
+
+template class Schwarzschild<SchwarzschildCoordinates::Isotropic>;
+
+#undef DTYPE
+#undef INSTANTIATE
+
+}  // namespace Xcts::Solutions
+/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.hpp
@@ -1,0 +1,251 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <ostream>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Elliptic/Systems/Xcts/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace Xcts::Solutions {
+
+/// Various coordinate systems in which to express the Schwarzschild solution
+enum class SchwarzschildCoordinates {
+  /*!
+   * \brief Isotropic Schwarzschild coordinates
+   *
+   * These arise from the canonical Schwarzschild coordinates by the radial
+   * transformation
+   *
+   * \f{equation}
+   * r = \bar{r}\left(1+\frac{M}{2\bar{r}}\right)^2
+   * \f}
+   *
+   * (Eq. (1.61) in \cite BaumgarteShapiro) where \f$r\f$ is the canonical
+   * Schwarzschild radius, also referred to as "areal" radius because it is
+   * defined such that spheres with constant \f$r\f$ have the area \f$4\pi
+   * r^2\f$, and \f$\bar{r}\f$ is the "isotropic" radius. In the isotropic
+   * radius the Schwarzschild spatial metric is conformally flat:
+   *
+   * \f{equation}
+   * \gamma_{ij}=\psi^4\eta_{ij} \quad \text{with conformal factor} \quad
+   * \psi=1+\frac{M}{2\bar{r}}
+   * \f}
+   *
+   * (Table 2.1 in \cite BaumgarteShapiro). Its lapse transforms to
+   *
+   * \f{equation}
+   * \alpha=\frac{1-M/(2\bar{r})}{1+M/(2\bar{r})}
+   * \f}
+   *
+   * and the shift vanishes (\f$\beta^i=0\f$) as it does in areal Schwarzschild
+   * coordinates. The solution also remains maximally sliced, i.e. \f$K=0\f$.
+   *
+   * The Schwarzschild horizon in these coordinates is at
+   * \f$\bar{r}=\frac{M}{2}\f$ due to the radial transformation from \f$r=2M\f$.
+   */
+  Isotropic,
+};
+
+std::ostream& operator<<(std::ostream& os,
+                         SchwarzschildCoordinates coords) noexcept;
+
+/*!
+ * \brief Schwarzschild spacetime in general relativity
+ *
+ * This class implements the Schwarzschild solution with mass parameter
+ * \f$M\f$ in various coordinate systems. See the entries of the
+ * `Xcts::Solutions::SchwarzschildCoordinates` enum for the available coordinate
+ * systems and for the solution variables in the respective coordinates.
+ */
+template <SchwarzschildCoordinates Coords>
+class Schwarzschild {
+ private:
+  struct Mass {
+    using type = double;
+    static constexpr Options::String help = "Mass parameter M";
+  };
+
+ public:
+  using options = tmpl::list<Mass>;
+  static constexpr Options::String help{
+      "Schwarzschild spacetime in general relativity"};
+
+  Schwarzschild() = default;
+  Schwarzschild(const Schwarzschild&) noexcept = delete;
+  Schwarzschild& operator=(const Schwarzschild&) noexcept = delete;
+  Schwarzschild(Schwarzschild&&) noexcept = default;
+  Schwarzschild& operator=(Schwarzschild&&) noexcept = default;
+  ~Schwarzschild() noexcept = default;
+
+  explicit Schwarzschild(double mass) noexcept;
+
+  /// The mass parameter \f$M\f$.
+  double mass() const noexcept;
+
+  /// The radius of the Schwarzschild horizon in the given coordinates.
+  double radius_at_horizon() const noexcept;
+
+  // @{
+  /// Retrieve variable at coordinates `x`
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, 3, Frame::Inertial>& x,
+                 tmpl::list<Xcts::Tags::ConformalMetric<
+                     DataType, 3, Frame::Inertial>> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<
+          Xcts::Tags::ConformalMetric<DataType, 3, Frame::Inertial>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, 3, Frame::Inertial>& x,
+      tmpl::list<gr::Tags::TraceExtrinsicCurvature<DataType>> /*meta*/) const
+      noexcept
+      -> tuples::TaggedTuple<gr::Tags::TraceExtrinsicCurvature<DataType>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, 3, Frame::Inertial>& x,
+      tmpl::list<::Tags::deriv<gr::Tags::TraceExtrinsicCurvature<DataType>,
+                               tmpl::size_t<3>, Frame::Inertial>> /*meta*/)
+      const noexcept -> tuples::TaggedTuple<
+          ::Tags::deriv<gr::Tags::TraceExtrinsicCurvature<DataType>,
+                        tmpl::size_t<3>, Frame::Inertial>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, 3, Frame::Inertial>& x,
+      tmpl::list<Xcts::Tags::ConformalFactor<DataType>> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<Xcts::Tags::ConformalFactor<DataType>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, 3, Frame::Inertial>& x,
+      tmpl::list<::Tags::deriv<Xcts::Tags::ConformalFactor<DataType>,
+                               tmpl::size_t<3>, Frame::Inertial>> /*meta*/)
+      const noexcept -> tuples::TaggedTuple<
+          ::Tags::deriv<Xcts::Tags::ConformalFactor<DataType>, tmpl::size_t<3>,
+                        Frame::Inertial>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, 3, Frame::Inertial>& x,
+      tmpl::list<Xcts::Tags::LapseTimesConformalFactor<DataType>> /*meta*/)
+      const noexcept
+      -> tuples::TaggedTuple<Xcts::Tags::LapseTimesConformalFactor<DataType>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, 3, Frame::Inertial>& x,
+      tmpl::list<::Tags::deriv<Xcts::Tags::LapseTimesConformalFactor<DataType>,
+                               tmpl::size_t<3>, Frame::Inertial>> /*meta*/)
+      const noexcept -> tuples::TaggedTuple<
+          ::Tags::deriv<Xcts::Tags::LapseTimesConformalFactor<DataType>,
+                        tmpl::size_t<3>, Frame::Inertial>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, 3, Frame::Inertial>& x,
+                 tmpl::list<Xcts::Tags::ShiftBackground<
+                     DataType, 3, Frame::Inertial>> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<
+          Xcts::Tags::ShiftBackground<DataType, 3, Frame::Inertial>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, 3, Frame::Inertial>& x,
+      tmpl::list<
+          Xcts::Tags::ShiftExcess<DataType, 3, Frame::Inertial>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<
+          Xcts::Tags::ShiftExcess<DataType, 3, Frame::Inertial>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, 3, Frame::Inertial>& x,
+      tmpl::list<
+          Xcts::Tags::ShiftStrain<DataType, 3, Frame::Inertial>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<
+          Xcts::Tags::ShiftStrain<DataType, 3, Frame::Inertial>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, 3, Frame::Inertial>& x,
+                 tmpl::list<::Tags::FixedSource<
+                     Xcts::Tags::ConformalFactor<DataType>>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<
+          ::Tags::FixedSource<Xcts::Tags::ConformalFactor<DataType>>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, 3, Frame::Inertial>& x,
+                 tmpl::list<::Tags::FixedSource<
+                     Xcts::Tags::LapseTimesConformalFactor<DataType>>> /*meta*/)
+      const noexcept -> tuples::TaggedTuple<
+          ::Tags::FixedSource<Xcts::Tags::LapseTimesConformalFactor<DataType>>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, 3, Frame::Inertial>& x,
+                 tmpl::list<::Tags::FixedSource<Xcts::Tags::ShiftExcess<
+                     DataType, 3, Frame::Inertial>>> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<::Tags::FixedSource<
+          Xcts::Tags::ShiftExcess<DataType, 3, Frame::Inertial>>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, 3, Frame::Inertial>& x,
+                 tmpl::list<gr::Tags::EnergyDensity<DataType>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<gr::Tags::EnergyDensity<DataType>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, 3, Frame::Inertial>& x,
+                 tmpl::list<gr::Tags::StressTrace<DataType>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<gr::Tags::StressTrace<DataType>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, 3, Frame::Inertial>& x,
+                 tmpl::list<gr::Tags::MomentumDensity<3, Frame::Inertial,
+                                                      DataType>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<
+          gr::Tags::MomentumDensity<3, Frame::Inertial, DataType>>;
+  // @}
+
+  /// Retrieve a collection of variables at coordinates `x`
+  template <typename DataType, typename... Tags>
+  tuples::TaggedTuple<Tags...> variables(
+      const tnsr::I<DataType, 3, Frame::Inertial>& x,
+      tmpl::list<Tags...> /*meta*/) const noexcept {
+    static_assert(sizeof...(Tags) > 1, "The requested tag is not implemented.");
+    return {tuples::get<Tags>(variables(x, tmpl::list<Tags>{}))...};
+  }
+
+  void pup(PUP::er& p) noexcept {  // NOLINT
+    p | mass_;
+  }
+
+ private:
+  double mass_;
+};
+
+template <SchwarzschildCoordinates Coords>
+SPECTRE_ALWAYS_INLINE bool operator==(
+    const Schwarzschild<Coords>& lhs,
+    const Schwarzschild<Coords>& rhs) noexcept {
+  return lhs.mass() == rhs.mass();
+}
+
+template <SchwarzschildCoordinates Coords>
+SPECTRE_ALWAYS_INLINE bool operator!=(
+    const Schwarzschild<Coords>& lhs,
+    const Schwarzschild<Coords>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+}  // namespace Xcts::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Solutions.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Solutions.hpp
@@ -1,0 +1,15 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines Xcts::Solutions namespace
+
+#pragma once
+
+namespace Xcts {
+/*!
+ * \ingroup AnalyticSolutionsGroup
+ * \brief Analytic solutions to the \ref Xcts "XCTS" equations
+ */
+namespace Solutions {}
+}  // namespace Xcts

--- a/tests/Unit/Elliptic/Systems/Xcts/Test_Tags.cpp
+++ b/tests/Unit/Elliptic/Systems/Xcts/Test_Tags.cpp
@@ -7,6 +7,7 @@
 
 #include "Elliptic/Systems/Xcts/Tags.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 
 struct DataVector;
 namespace Frame {
@@ -16,4 +17,15 @@ struct Inertial;
 SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Xcts.Tags", "[Unit][Elliptic]") {
   TestHelpers::db::test_simple_tag<Xcts::Tags::ConformalFactor<DataVector>>(
       "ConformalFactor");
+  TestHelpers::db::test_simple_tag<
+      Xcts::Tags::LapseTimesConformalFactor<DataVector>>(
+      "LapseTimesConformalFactor");
+  TestHelpers::db::test_simple_tag<
+      Xcts::Tags::ShiftStrain<DataVector, 3, Frame::Inertial>>("ShiftStrain");
+  TestHelpers::db::test_prefix_tag<
+      Xcts::Tags::Conformal<gr::Tags::EnergyDensity<DataVector>, 2>>(
+      "Conformal(EnergyDensity)");
+  TestHelpers::db::test_simple_tag<
+      Xcts::Tags::ConformalMetric<DataVector, 3, Frame::Inertial>>(
+      "Conformal(SpatialMetric)");
 }

--- a/tests/Unit/Elliptic/Systems/Xcts/Test_Tags.cpp
+++ b/tests/Unit/Elliptic/Systems/Xcts/Test_Tags.cpp
@@ -16,7 +16,4 @@ struct Inertial;
 SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Xcts.Tags", "[Unit][Elliptic]") {
   TestHelpers::db::test_simple_tag<Xcts::Tags::ConformalFactor<DataVector>>(
       "ConformalFactor");
-  TestHelpers::db::test_simple_tag<
-      Xcts::Tags::ConformalFactorGradient<3, Frame::Inertial, DataVector>>(
-      "ConformalFactorGradient");
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
@@ -5,11 +5,12 @@ set(LIBRARY "Test_XctsSolutions")
 
 set(LIBRARY_SOURCES
   Test_ConstantDensityStar.cpp
+  Test_Schwarzschild.cpp
   )
 
 add_test_library(
   ${LIBRARY}
   "PointwiseFunctions/AnalyticSolutions/Xcts/"
   "${LIBRARY_SOURCES}"
-  "XctsSolutions;Utilities"
+  "DataStructures;Utilities;Xcts;XctsSolutions"
   )

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.py
@@ -1,0 +1,82 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+from numpy import sqrt, exp
+from scipy.optimize import newton
+
+# Isotropic Schwarzschild coordinates
+
+
+def conformal_spatial_metric_isotropic(x, mass):
+    return np.identity(3)
+
+
+def extrinsic_curvature_trace_isotropic(x, mass):
+    return 0.
+
+
+def extrinsic_curvature_trace_gradient_isotropic(x, mass):
+    return np.zeros(3)
+
+
+def conformal_factor_isotropic(x, mass):
+    r = np.linalg.norm(x)
+    return 1. + 0.5 * mass / r
+
+
+def conformal_factor_gradient_isotropic(x, mass):
+    r = np.linalg.norm(x)
+    return -0.5 * mass * x / r**3
+
+
+def lapse_times_conformal_factor_isotropic(x, mass):
+    r = np.linalg.norm(x)
+    return 1. - 0.5 * mass / r
+
+
+def lapse_times_conformal_factor_gradient_isotropic(x, mass):
+    r = np.linalg.norm(x)
+    return 0.5 * mass * x / r**3
+
+
+def shift_background(x, mass):
+    return np.zeros(3)
+
+
+def shift_isotropic(x, mass):
+    return np.zeros(3)
+
+
+def shift_strain_isotropic(x, mass):
+    return np.zeros((3, 3))
+
+
+# Matter sources
+
+
+def energy_density(x, mass):
+    return 0.
+
+
+def stress_trace(x, mass):
+    return 0.
+
+
+def momentum_density(x, mass):
+    return np.zeros(3)
+
+
+# Fixed sources
+
+
+def conformal_factor_fixed_source(x, mass):
+    return 0.
+
+
+def lapse_times_conformal_factor_fixed_source(x, mass):
+    return 0.
+
+
+def shift_fixed_source(x, mass):
+    return np.zeros(3)

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_ConstantDensityStar.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_ConstantDensityStar.cpp
@@ -15,6 +15,7 @@
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/ConstantDensityStar.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
@@ -25,8 +26,9 @@
 namespace {
 
 using field_tags = tmpl::list<Xcts::Tags::ConformalFactor<DataVector>>;
-using auxiliary_field_tags = tmpl::list<
-    Xcts::Tags::ConformalFactorGradient<3, Frame::Inertial, DataVector>>;
+using auxiliary_field_tags =
+    tmpl::list<::Tags::deriv<Xcts::Tags::ConformalFactor<DataVector>,
+                             tmpl::size_t<3>, Frame::Inertial>>;
 using initial_tags =
     db::wrap_tags_in<Tags::Initial,
                      tmpl::append<field_tags, auxiliary_field_tags>>;
@@ -78,7 +80,7 @@ void test_solution(const double density, const double radius,
       get<Xcts::Tags::ConformalFactor<DataVector>>(far_away_solution),
       make_with_value<Scalar<DataVector>>(far_away_coords, 1.));
 
-  Xcts::Solutions::ConstantDensityStar created_solution =
+  const auto created_solution =
       TestHelpers::test_creation<Xcts::Solutions::ConstantDensityStar>(options);
   CHECK(created_solution == solution);
   test_serialization(solution);

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_Schwarzschild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_Schwarzschild.cpp
@@ -1,0 +1,133 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+#include <tuple>
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Elliptic/Systems/Xcts/Tags.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+
+using field_tags =
+    tmpl::list<Xcts::Tags::ConformalFactor<DataVector>,
+               Xcts::Tags::LapseTimesConformalFactor<DataVector>,
+               Xcts::Tags::ShiftExcess<DataVector, 3, Frame::Inertial>>;
+using auxiliary_field_tags =
+    tmpl::list<::Tags::deriv<Xcts::Tags::ConformalFactor<DataVector>,
+                             tmpl::size_t<3>, Frame::Inertial>,
+               ::Tags::deriv<Xcts::Tags::LapseTimesConformalFactor<DataVector>,
+                             tmpl::size_t<3>, Frame::Inertial>,
+               Xcts::Tags::ShiftStrain<DataVector, 3, Frame::Inertial>>;
+using background_tags =
+    tmpl::list<Xcts::Tags::ConformalMetric<DataVector, 3, Frame::Inertial>,
+               gr::Tags::TraceExtrinsicCurvature<DataVector>,
+               ::Tags::deriv<gr::Tags::TraceExtrinsicCurvature<DataVector>,
+                             tmpl::size_t<3>, Frame::Inertial>,
+               Xcts::Tags::ShiftBackground<DataVector, 3, Frame::Inertial>>;
+using matter_source_tags =
+    tmpl::list<gr::Tags::EnergyDensity<DataVector>,
+               gr::Tags::StressTrace<DataVector>,
+               gr::Tags::MomentumDensity<3, Frame::Inertial, DataVector>>;
+using fixed_source_tags = db::wrap_tags_in<Tags::FixedSource, field_tags>;
+
+template <Xcts::Solutions::SchwarzschildCoordinates Coords>
+struct SchwarzschildProxy : Xcts::Solutions::Schwarzschild<Coords> {
+  using Xcts::Solutions::Schwarzschild<Coords>::Schwarzschild;
+  tuples::tagged_tuple_from_typelist<
+      tmpl::append<field_tags, auxiliary_field_tags>>
+  field_variables(const tnsr::I<DataVector, 3, Frame::Inertial>& x) const
+      noexcept {
+    return Xcts::Solutions::Schwarzschild<Coords>::variables(
+        x, tmpl::append<field_tags, auxiliary_field_tags>{});
+  }
+  tuples::tagged_tuple_from_typelist<background_tags> background_variables(
+      const tnsr::I<DataVector, 3, Frame::Inertial>& x) const noexcept {
+    return Xcts::Solutions::Schwarzschild<Coords>::variables(x,
+                                                             background_tags{});
+  }
+  tuples::tagged_tuple_from_typelist<matter_source_tags>
+  matter_source_variables(
+      const tnsr::I<DataVector, 3, Frame::Inertial>& x) const noexcept {
+    return Xcts::Solutions::Schwarzschild<Coords>::variables(
+        x, matter_source_tags{});
+  }
+  tuples::tagged_tuple_from_typelist<fixed_source_tags> fixed_source_variables(
+      const tnsr::I<DataVector, 3, Frame::Inertial>& x) const noexcept {
+    return Xcts::Solutions::Schwarzschild<Coords>::variables(
+        x, fixed_source_tags{});
+  }
+};
+
+template <Xcts::Solutions::SchwarzschildCoordinates Coords>
+void test_solution(const double mass, const double expected_radius_at_horizon,
+                   const std::string& py_functions_suffix,
+                   const std::string& options_string) {
+  CAPTURE(Coords);
+  CAPTURE(mass);
+  const SchwarzschildProxy<Coords> solution{mass};
+  CHECK(solution.mass() == mass);
+  REQUIRE(solution.radius_at_horizon() == approx(expected_radius_at_horizon));
+  const double inner_radius = 0.5 * expected_radius_at_horizon;
+  const double outer_radius = 2. * expected_radius_at_horizon;
+  pypp::check_with_random_values<
+      1, tmpl::append<field_tags, auxiliary_field_tags>>(
+      &SchwarzschildProxy<Coords>::field_variables, solution, "Schwarzschild",
+      {"conformal_factor_" + py_functions_suffix,
+       "lapse_times_conformal_factor_" + py_functions_suffix,
+       "shift_" + py_functions_suffix,
+       "conformal_factor_gradient_" + py_functions_suffix,
+       "lapse_times_conformal_factor_gradient_" + py_functions_suffix,
+       "shift_strain_" + py_functions_suffix},
+      {{{inner_radius, outer_radius}}}, std::make_tuple(mass), DataVector(5));
+  pypp::check_with_random_values<1, background_tags>(
+      &SchwarzschildProxy<Coords>::background_variables, solution,
+      "Schwarzschild",
+      {"conformal_spatial_metric_" + py_functions_suffix,
+       "extrinsic_curvature_trace_" + py_functions_suffix,
+       "extrinsic_curvature_trace_gradient_" + py_functions_suffix,
+       "shift_background"},
+      {{{inner_radius, outer_radius}}}, std::make_tuple(mass), DataVector(5));
+  pypp::check_with_random_values<1, matter_source_tags>(
+      &SchwarzschildProxy<Coords>::matter_source_variables, solution,
+      "Schwarzschild", {"energy_density", "stress_trace", "momentum_density"},
+      {{{inner_radius, outer_radius}}}, std::make_tuple(mass), DataVector(5));
+  pypp::check_with_random_values<1, fixed_source_tags>(
+      &SchwarzschildProxy<Coords>::fixed_source_variables, solution,
+      "Schwarzschild",
+      {"conformal_factor_fixed_source",
+       "lapse_times_conformal_factor_fixed_source", "shift_fixed_source"},
+      {{{inner_radius, outer_radius}}}, std::make_tuple(mass), DataVector(5));
+
+  const auto created_solution =
+      TestHelpers::test_creation<Xcts::Solutions::Schwarzschild<Coords>>(
+          options_string);
+  CHECK(created_solution == solution);
+  test_serialization(solution);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticSolutions.Xcts.Schwarzschild",
+    "[PointwiseFunctions][Unit]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/AnalyticSolutions/Xcts"};
+  test_solution<Xcts::Solutions::SchwarzschildCoordinates::Isotropic>(
+      1., 0.5, "isotropic", "Mass: 1.");
+  test_solution<Xcts::Solutions::SchwarzschildCoordinates::Isotropic>(
+      0.8, 0.4, "isotropic", "Mass: 0.8");
+}


### PR DESCRIPTION
## Proposed changes

Add Schwarzschild solution to XCTS system. This PR adds it in isotropic coordinates, i.e. where the radial coordinate is transformed such that the metric is conformally flat. Upcoming PRs will add the solution also in Painleve-Gullstrand and isotropic Kerr-Schild coordinates. These solutions will then be used to test the XCTS system equations.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
