### PR TITLE
Add DG time derivative action, use in some systems as an example

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
@@ -1,0 +1,589 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <tuple>
+#include <type_traits>
+#include <unordered_set>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/InterfaceHelpers.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/TagsTimeDependent.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Projection.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace tuples {
+template <typename...>
+class TaggedTuple;
+}  // namespace tuples
+
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
+/// \endcond
+
+namespace evolution::dg::Actions {
+/*!
+ * \brief Computes the time derivative for a DG time step.
+ *
+ * Computes the volume fluxes, the divergence of the fluxes and all additional
+ * interior contributions to the time derivatives (both nonconservative products
+ * and source terms). The internal mortar data is also computed.
+ *
+ * The general first-order hyperbolic evolution equation solved for conservative
+ * systems is:
+ *
+ * \f{align*}{
+ * \frac{\partial u_\alpha}{\partial \hat{t}}
+ *  + \partial_{i}
+ *   \left(F^i_\alpha - v^i_g u_\alpha\right)
+ *   = S_\alpha-u_\alpha\partial_i v^i_g,
+ * \f}
+ *
+ * where \f$F^i_{\alpha}\f$ are the fluxes when the mesh isn't moving,
+ * \f$v^i_g\f$ is the velocity of the mesh, \f$u_{\alpha}\f$ are the evolved
+ * variables, \f$S_{\alpha}\f$ are the source terms, and \f$\hat{t}\f$ is the
+ * time in the logical frame. For evolution equations that do not have any
+ * fluxes and only nonconservative products we evolve:
+ *
+ * \f{align*}{
+ * \frac{\partial u_\alpha}{\partial \hat{t}}
+ *   +\left(B^i_{\alpha\beta}-v^i_g \delta_{\alpha\beta}
+ *   \right)\partial_{i}u_\beta = S_\alpha.
+ * \f}
+ *
+ * Finally, for equations with both conservative terms and nonconservative
+ * products we use:
+ *
+ * \f{align*}{
+ * \frac{\partial u_\alpha}{\partial \hat{t}}
+ *   + \partial_{i}
+ *   \left(F^i_\alpha - v^i_g u_\alpha\right)
+ *   +B^i_{\alpha\beta}\partial_{i}u_\beta
+ *   = S_\alpha-u_\alpha\partial_i v^i_g,
+ * \f}
+ *
+ * where \f$B^i_{\alpha\beta}\f$ is the matrix for the nonconservative products.
+ *
+ * The mesh velocity is added to the flux automatically if the mesh is moving.
+ * That is,
+ *
+ * \f{align*}{
+ *  F^i_{\alpha}\to F^i_{\alpha}-v^i_{g} u_{\alpha}
+ * \f}
+ *
+ * The source terms are also altered automatically by adding:
+ *
+ * \f{align*}{
+ *  -u_\alpha \partial_i v^i_g,
+ * \f}
+ *
+ * For systems with equations that only contain nonconservative products, the
+ * following mesh velocity is automatically added to the time derivative:
+ *
+ * \f{align*}{
+ *  v^i_g \partial_i u_\alpha,
+ * \f}
+ *
+ * Uses:
+ * - System:
+ *   - `variables_tag`
+ *   - `flux_variables`
+ *   - `gradient_variables`
+ *   - `compute_volume_time_derivative`
+ *
+ * - DataBox:
+ *   - Items in `system::compute_volume_time_derivative::argument_tags`
+ *   - `domain::Tags::MeshVelocity<Metavariables::volume_dim>`
+ *   - `Metavariables::system::variables_tag`
+ *   - `Metavariables::system::flux_variables`
+ *   - `Metavariables::system::gradient_variables`
+ *   - `domain::Tags::DivMeshVelocity`
+ *   - `DirectionsTag`,
+ *   - Required interface items for `Metavariables::system::normal_dot_fluxes`
+ *
+ * DataBox changes:
+ * - Adds: nothing
+ * - Removes: nothing
+ * - Modifies:
+ *   - db::add_tag_prefix<Tags::Flux, variables_tag,
+ *                        tmpl::size_t<system::volume_dim>, Frame::Inertial>
+ *   - `Tags::dt<system::variable_tags>`
+ *   - Tags::Interface<
+ *     DirectionsTag, db::add_tag_prefix<Tags::NormalDotFlux, variables_tag>>
+ *   - `Tags::Mortars<typename BoundaryScheme::mortar_data_tag, VolumeDim>`
+ */
+template <typename Metavariables>
+struct ComputeTimeDerivative {
+ public:
+  template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
+            typename ActionList, typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&> apply(
+      db::DataBox<DbTagsList>& box,
+      tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+      const ParallelComponent* /*meta*/) noexcept;  // NOLINT const
+
+ private:
+  /*
+   * Computes the volume terms for a discontinuous Galerkin scheme.
+   *
+   * The function does the following (in order):
+   *
+   * 1. Compute the partial derivatives of the `System::gradient_variables`.
+   *
+   *    The partial derivatives are needed in the nonconservative product terms
+   *    of the evolution equations. Any variable whose evolution equation does
+   *    not contain a flux must contain a nonconservative product and the
+   *    variable must be listed in the `System::gradient_variables` type alias.
+   *    The partial derivatives are also needed for adding the moving mesh terms
+   *    to the equations that do not have a flux term.
+   *
+   * 2. The volume time derivatives are calculated from
+   *    `System::compute_volume_time_derivative`
+   *
+   *    The source terms and nonconservative products are contributed directly
+   *    to the `dt_vars` arguments passed to the time derivative function, while
+   *    the volume fluxes are computed into the `volume_fluxes` arguments. The
+   *    divergence of the volume fluxes will be computed and added to the time
+   *    derivatives later in the function.
+   *
+   * 3. If the mesh is moving the appropriate mesh velocity terms are added to
+   *    the equations.
+   *
+   *    For equations with fluxes this means that \f$-v^i_g u_\alpha\f$ is
+   *    added to the fluxes and \f$-u_\alpha \partial_i v^i_g\f$ is added
+   *    to the time derivatives. For equations without fluxes
+   *    \f$v^i\partial_i u_\alpha\f$ is added to the time derivatives.
+   *
+   * 4. Compute flux divergence contribution and add it to the time derivatives.
+   *
+   *    Either the weak or strong form can be used. Currently only the strong
+   *    form is coded, but adding the weak form is quite easy.
+   *
+   *    Note that the computation of the flux divergence and adding that to the
+   *    time derivative must be done *after* the mesh velocity is subtracted
+   *    from the fluxes.
+   */
+  template <size_t Dim, typename ComputeVolumeTimeDerivatives,
+            typename DbTagsList, typename... VariablesTags,
+            typename... TimeDerivativeArgumentTags,
+            typename... PartialDerivTags, typename... FluxVariablesTags,
+            typename... TemporaryTags>
+  static void volume_terms(
+      gsl::not_null<db::DataBox<DbTagsList>*> box,
+      gsl::not_null<Variables<tmpl::list<FluxVariablesTags...>>*> volume_fluxes,
+      gsl::not_null<Variables<tmpl::list<PartialDerivTags...>>*> partial_derivs,
+      gsl::not_null<Variables<tmpl::list<TemporaryTags...>>*> temporaries,
+      ::dg::Formulation dg_formulation,
+      tmpl::list<VariablesTags...> /*variables_tags*/,
+      tmpl::list<TimeDerivativeArgumentTags...> /*meta*/) noexcept;
+
+  template <typename... NormalDotFluxTags, typename... Args>
+  static void apply_flux(
+      gsl::not_null<Variables<tmpl::list<NormalDotFluxTags...>>*> boundary_flux,
+      const Args&... boundary_variables) noexcept {
+    Metavariables::system::normal_dot_fluxes::apply(
+        make_not_null(&get<NormalDotFluxTags>(*boundary_flux))...,
+        boundary_variables...);
+  }
+
+  template <typename DbTagsList>
+  static void boundary_terms_nonconservative_products(
+      gsl::not_null<db::DataBox<DbTagsList>*> box) noexcept;
+
+  template <size_t VolumeDim, typename BoundaryScheme, typename DbTagsList>
+  static void fill_mortar_data_for_internal_boundaries(
+      gsl::not_null<db::DataBox<DbTagsList>*> box) noexcept;
+};
+
+template <typename Metavariables>
+template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
+          typename ActionList, typename ParallelComponent>
+std::tuple<db::DataBox<DbTagsList>&&>
+ComputeTimeDerivative<Metavariables>::apply(
+    db::DataBox<DbTagsList>& box,
+    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+    const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+    const ParallelComponent* const /*meta*/) noexcept {  // NOLINT const
+  static constexpr size_t volume_dim = Metavariables::volume_dim;
+  using system = typename Metavariables::system;
+  using variables_tags = typename system::variables_tag::tags_list;
+  using partial_derivative_tags = typename system::gradient_variables;
+  using flux_variables = typename system::flux_variables;
+  using compute_volume_time_derivative =
+      typename system::compute_volume_time_derivative;
+
+  const Mesh<volume_dim>& mesh = db::get<::domain::Tags::Mesh<volume_dim>>(box);
+  // Allocate the Variables classes needed for the time derivative
+  // computation.
+  //
+  // This is factored out so that we will be able to do ADER-DG/CG where a
+  // spacetime polynomial is constructed by solving implicit equations in time
+  // using a Picard iteration. A high-order initial guess is needed to
+  // efficiently construct the ADER spacetime solution. This initial guess is
+  // obtained using continuous RK methods, and so we will want to reuse
+  // buffers. Thus, the volume_terms function returns by reference rather than
+  // by value.
+  Variables<typename compute_volume_time_derivative::temporary_tags>
+      temporaries{mesh.number_of_grid_points()};
+  Variables<db::wrap_tags_in<::Tags::Flux, flux_variables,
+                             tmpl::size_t<volume_dim>, Frame::Inertial>>
+      volume_fluxes{mesh.number_of_grid_points()};
+  Variables<db::wrap_tags_in<::Tags::deriv, partial_derivative_tags,
+                             tmpl::size_t<volume_dim>, Frame::Inertial>>
+      partial_derivs{mesh.number_of_grid_points()};
+
+  volume_terms<volume_dim, compute_volume_time_derivative>(
+      make_not_null(&box), make_not_null(&volume_fluxes),
+      make_not_null(&partial_derivs), make_not_null(&temporaries),
+      Metavariables::dg_formulation, variables_tags{},
+      typename compute_volume_time_derivative::argument_tags{});
+
+  // The below if-else and fill_mortar_data_for_internal_boundaries are for
+  // compatibility with the current boundary schemes. Once the current
+  // boundary schemes are removed the code will be refactored to reflect that
+  // change.
+  if constexpr (not std::is_same_v<tmpl::list<>, flux_variables>) {
+    using flux_variables_tag = ::Tags::Variables<flux_variables>;
+    using fluxes_tag =
+        db::add_tag_prefix<::Tags::Flux, flux_variables_tag,
+                           tmpl::size_t<Metavariables::volume_dim>,
+                           Frame::Inertial>;
+
+    // We currently set the fluxes in the DataBox to interface with the
+    // boundary correction communication code.
+    db::mutate<fluxes_tag>(make_not_null(&box),
+                           [&volume_fluxes](const auto fluxes_ptr) noexcept {
+                             *fluxes_ptr = volume_fluxes;
+                           });
+  } else {
+    boundary_terms_nonconservative_products(make_not_null(&box));
+  }
+
+  // Compute internal boundary quantities
+  fill_mortar_data_for_internal_boundaries<
+      volume_dim, typename Metavariables::boundary_scheme>(make_not_null(&box));
+  return {std::move(box)};
+}
+
+template <typename Metavariables>
+template <size_t Dim, typename ComputeVolumeTimeDerivatives,
+          typename DbTagsList, typename... VariablesTags,
+          typename... TimeDerivativeArgumentTags, typename... PartialDerivTags,
+          typename... FluxVariablesTags, typename... TemporaryTags>
+void ComputeTimeDerivative<Metavariables>::volume_terms(
+    const gsl::not_null<db::DataBox<DbTagsList>*> box,
+    const gsl::not_null<Variables<tmpl::list<FluxVariablesTags...>>*>
+        volume_fluxes,
+    const gsl::not_null<Variables<tmpl::list<PartialDerivTags...>>*>
+        partial_derivs,
+    const gsl::not_null<Variables<tmpl::list<TemporaryTags...>>*> temporaries,
+    const ::dg::Formulation dg_formulation,
+
+    tmpl::list<VariablesTags...> /*variables_tags*/,
+    tmpl::list<TimeDerivativeArgumentTags...> /*meta*/) noexcept {
+  static constexpr bool has_partial_derivs = sizeof...(PartialDerivTags) != 0;
+  static constexpr bool has_fluxes = sizeof...(FluxVariablesTags) != 0;
+  static_assert(
+      has_fluxes or has_partial_derivs,
+      "Must have either fluxes or partial derivatives in a "
+      "DG evolution scheme. This means the evolution system struct (usually in "
+      "Evolution/Systems/YourSystem/System.hpp) being used does not specify "
+      "any flux_variables or gradient_variables. Make sure the type aliases "
+      "are defined, and that at least one of them is a non-empty list of "
+      "tags.");
+
+  using system = typename Metavariables::system;
+  using variables_tag = typename system::variables_tag;
+  using variables_tags = typename variables_tag::tags_list;
+  using partial_derivative_tags = typename system::gradient_variables;
+  using flux_variables = typename system::flux_variables;
+
+  const Mesh<Dim>& mesh = db::get<::domain::Tags::Mesh<Dim>>(*box);
+  const auto& logical_to_inertial_inverse_jacobian = db::get<
+      ::domain::Tags::InverseJacobian<Dim, Frame::Logical, Frame::Inertial>>(
+      *box);
+  const auto& evolved_vars = db::get<variables_tag>(*box);
+
+  // Compute d_i u_\alpha for nonconservative products
+  if constexpr (has_partial_derivs) {
+    partial_derivatives<partial_derivative_tags>(
+        partial_derivs, evolved_vars, mesh,
+        logical_to_inertial_inverse_jacobian);
+  }
+
+  // Compute volume du/dt and fluxes
+
+  // Compute volume terms that are unrelated to moving meshes
+  db::mutate<db::add_tag_prefix<::Tags::dt, variables_tag>>(
+      box,
+      [&mesh, &partial_derivs, &temporaries, &volume_fluxes](
+          const gsl::not_null<Variables<
+              db::wrap_tags_in<::Tags::dt, typename variables_tag::tags_list>>*>
+              dt_vars_ptr,
+          const auto&... args) noexcept {
+        // Silence compiler warnings since we genuinely don't always need all
+        // the vars but sometimes do. This warning shows up with empty parameter
+        // packs, which means the packs aren't "used" below in the
+        // ComputeVolumeTimeDerivatives::apply call.
+        (void)partial_derivs;
+        (void)volume_fluxes;
+        (void)temporaries;
+
+        // For now just zero dt_vars. If this is a performance bottle neck we
+        // can re-evaluate in the future.
+        dt_vars_ptr->initialize(mesh.number_of_grid_points(), 0.0);
+
+        ComputeVolumeTimeDerivatives::apply(
+            make_not_null(&get<::Tags::dt<VariablesTags>>(*dt_vars_ptr))...,
+            make_not_null(&get<FluxVariablesTags>(*volume_fluxes))...,
+            make_not_null(&get<TemporaryTags>(*temporaries))...,
+            get<PartialDerivTags>(*partial_derivs)..., args...);
+      },
+      db::get<TimeDerivativeArgumentTags>(*box)...);
+
+  // Add volume terms for moving meshes
+  if (const auto& mesh_velocity =
+          db::get<::domain::Tags::MeshVelocity<Dim>>(*box);
+      static_cast<bool>(mesh_velocity)) {
+    db::mutate<db::add_tag_prefix<::Tags::dt, variables_tag>>(
+        box,
+        [&evolved_vars, &mesh_velocity, &volume_fluxes](
+            const gsl::not_null<Variables<db::wrap_tags_in<
+                ::Tags::dt, typename variables_tag::tags_list>>*>
+                dt_vars_ptr,
+            const boost::optional<Scalar<DataVector>>&
+                div_mesh_velocity) noexcept {
+          tmpl::for_each<flux_variables>([&div_mesh_velocity, &dt_vars_ptr,
+                                          &evolved_vars, &mesh_velocity,
+                                          &volume_fluxes](auto tag_v) noexcept {
+            // Modify fluxes for moving mesh
+            using var_tag = typename decltype(tag_v)::type;
+            using flux_var_tag =
+                db::add_tag_prefix<::Tags::Flux, var_tag, tmpl::size_t<Dim>,
+                                   Frame::Inertial>;
+            auto& flux_var = get<flux_var_tag>(*volume_fluxes);
+            // Loop over all independent components of flux_var
+            for (size_t flux_var_storage_index = 0;
+                 flux_var_storage_index < flux_var.size();
+                 ++flux_var_storage_index) {
+              // Get the flux variable's tensor index, e.g. (i,j) for a F^i of
+              // the spatial velocity (or some other spatial tensor).
+              const auto flux_var_tensor_index =
+                  flux_var.get_tensor_index(flux_var_storage_index);
+              // Remove the first index from the flux tensor index, gets back
+              // (j)
+              const auto var_tensor_index =
+                  all_but_specified_element_of(flux_var_tensor_index, 0);
+              // Set flux_index to (i)
+              const size_t flux_index = gsl::at(flux_var_tensor_index, 0);
+
+              // We now need to index flux(i,j) -= u(j) * v_g(i)
+              flux_var[flux_var_storage_index] -=
+                  get<var_tag>(evolved_vars).get(var_tensor_index) *
+                  mesh_velocity->get(flux_index);
+            }
+
+            // Modify time derivative (i.e. source terms) for moving mesh
+            auto& dt_var = get<::Tags::dt<var_tag>>(*dt_vars_ptr);
+            for (size_t dt_var_storage_index = 0;
+                 dt_var_storage_index < dt_var.size(); ++dt_var_storage_index) {
+              // This is S -> S - u d_i v^i_g
+              dt_var[dt_var_storage_index] -=
+                  get<var_tag>(evolved_vars)[dt_var_storage_index] *
+                  get(*div_mesh_velocity);
+            }
+          });
+        },
+        db::get<::domain::Tags::DivMeshVelocity>(*box));
+
+    // We add the mesh velocity to all equations that don't have flux terms.
+    // This doesn't need to be equal to the equations that have partial
+    // derivatives. For example, the scalar field evolution equation in
+    // first-order form does not have any partial derivatives but still needs
+    // the velocity term added. This is because the velocity term arises from
+    // transforming the time derivative.
+    using non_flux_tags = tmpl::list_difference<variables_tags, flux_variables>;
+
+    db::mutate<db::add_tag_prefix<::Tags::dt, variables_tag>>(
+        box, [&mesh_velocity, &partial_derivs](
+                 const gsl::not_null<Variables<db::wrap_tags_in<
+                     ::Tags::dt, typename variables_tag::tags_list>>*>
+                     dt_vars) noexcept {
+          tmpl::for_each<non_flux_tags>(
+              [&dt_vars, &mesh_velocity,
+               &partial_derivs](auto var_tag_v) noexcept {
+                using var_tag = typename decltype(var_tag_v)::type;
+                using dt_var_tag = ::Tags::dt<var_tag>;
+                using deriv_var_tag =
+                    ::Tags::deriv<var_tag, tmpl::size_t<Dim>, Frame::Inertial>;
+
+                const auto& deriv_var = get<deriv_var_tag>(*partial_derivs);
+                auto& dt_var = get<dt_var_tag>(*dt_vars);
+
+                // Loop over all independent components of the derivative of the
+                // variable.
+                for (size_t deriv_var_storage_index = 0;
+                     deriv_var_storage_index < deriv_var.size();
+                     ++deriv_var_storage_index) {
+                  // We grab the `deriv_tensor_index`, which would be e.g.
+                  // `(i, a, b)`, so `(0, 2, 3)`
+                  const auto deriv_var_tensor_index =
+                      deriv_var.get_tensor_index(deriv_var_storage_index);
+                  // Then we drop the derivative index (the first entry) to get
+                  // `(a, b)` (or `(2, 3)`)
+                  const auto dt_var_tensor_index =
+                      all_but_specified_element_of(deriv_var_tensor_index, 0);
+                  // Set `deriv_index` to `i` (or `0` in the example)
+                  const size_t deriv_index = gsl::at(deriv_var_tensor_index, 0);
+                  dt_var.get(dt_var_tensor_index) +=
+                      mesh_velocity->get(deriv_index) *
+                      deriv_var[deriv_var_storage_index];
+                }
+              });
+        });
+  }
+
+  // Add the flux divergence term to du_\alpha/dt, which must be done
+  // after the corrections for the moving mesh are made.
+  if constexpr (has_fluxes) {
+    db::mutate<db::add_tag_prefix<::Tags::dt, variables_tag>>(
+        box,
+        [dg_formulation, &logical_to_inertial_inverse_jacobian, &mesh,
+         &volume_fluxes](const gsl::not_null<Variables<db::wrap_tags_in<
+                             ::Tags::dt, typename variables_tag::tags_list>>*>
+                             dt_vars_ptr) noexcept {
+          if (dg_formulation == ::dg::Formulation::StrongInertial) {
+            const Variables<tmpl::list<::Tags::div<FluxVariablesTags>...>>
+                div_fluxes = divergence(*volume_fluxes, mesh,
+                                        logical_to_inertial_inverse_jacobian);
+            tmpl::for_each<flux_variables>([&dt_vars_ptr, &div_fluxes](
+                                               auto var_tag_v) noexcept {
+              using var_tag = typename decltype(var_tag_v)::type;
+              auto& dt_var = get<::Tags::dt<var_tag>>(*dt_vars_ptr);
+              const auto& div_flux_var = get<::Tags::div<
+                  ::Tags::Flux<var_tag, tmpl::size_t<Dim>, Frame::Inertial>>>(
+                  div_fluxes);
+              for (size_t storage_index = 0; storage_index < dt_var.size();
+                   ++storage_index) {
+                dt_var[storage_index] -= div_flux_var[storage_index];
+              }
+            });
+          } else if (dg_formulation == ::dg::Formulation::WeakInertial) {
+            ERROR("Weak inertial DG formulation not yet implemented");
+          } else {
+            ERROR("Unsupported DG formulation: " << dg_formulation);
+          }
+        });
+  } else {
+    (void)dg_formulation;
+  }
+}
+
+template <typename Metavariables>
+template <typename DbTagsList>
+void ComputeTimeDerivative<Metavariables>::
+    boundary_terms_nonconservative_products(
+        const gsl::not_null<db::DataBox<DbTagsList>*> box) noexcept {
+  using system = typename Metavariables::system;
+  using variables_tag = typename system::variables_tag;
+  using DirectionsTag =
+      domain::Tags::InternalDirections<Metavariables::volume_dim>;
+
+  using interface_normal_dot_fluxes_tag = domain::Tags::Interface<
+      DirectionsTag, db::add_tag_prefix<::Tags::NormalDotFlux, variables_tag>>;
+
+  using interface_compute_item_argument_tags = tmpl::transform<
+      typename Metavariables::system::normal_dot_fluxes::argument_tags,
+      tmpl::bind<domain::Tags::Interface, DirectionsTag, tmpl::_1>>;
+
+  db::mutate_apply<
+      tmpl::list<interface_normal_dot_fluxes_tag>,
+      tmpl::push_front<interface_compute_item_argument_tags, DirectionsTag>>(
+      [](const auto boundary_fluxes_ptr,
+         const std::unordered_set<Direction<Metavariables::volume_dim>>&
+             internal_directions,
+         const auto&... tensors) noexcept {
+        for (const auto& direction : internal_directions) {
+          apply_flux(make_not_null(&boundary_fluxes_ptr->at(direction)),
+                     tensors.at(direction)...);
+        }
+      },
+      box);
+}
+
+template <typename Metavariables>
+template <size_t VolumeDim, typename BoundaryScheme, typename DbTagsList>
+void ComputeTimeDerivative<Metavariables>::
+    fill_mortar_data_for_internal_boundaries(
+        const gsl::not_null<db::DataBox<DbTagsList>*> box) noexcept {
+  using temporal_id_tag = typename BoundaryScheme::temporal_id_tag;
+  using all_mortar_data_tag =
+      ::Tags::Mortars<typename BoundaryScheme::mortar_data_tag, VolumeDim>;
+  using boundary_data_computer =
+      typename BoundaryScheme::boundary_data_computer;
+
+  // Collect data on element interfaces
+  auto boundary_data_on_interfaces =
+      interface_apply<domain::Tags::InternalDirections<VolumeDim>,
+                      boundary_data_computer>(*box);
+
+  // Project collected data to all internal mortars and store in DataBox
+  const auto& element = db::get<domain::Tags::Element<VolumeDim>>(*box);
+  const auto& face_meshes =
+      get<domain::Tags::Interface<domain::Tags::InternalDirections<VolumeDim>,
+                                  domain::Tags::Mesh<VolumeDim - 1>>>(*box);
+  const auto& mortar_meshes =
+      get<::Tags::Mortars<domain::Tags::Mesh<VolumeDim - 1>, VolumeDim>>(*box);
+  const auto& mortar_sizes =
+      get<::Tags::Mortars<::Tags::MortarSize<VolumeDim - 1>, VolumeDim>>(*box);
+  const auto& temporal_id = get<temporal_id_tag>(*box);
+  for (const auto& [direction, neighbors] : element.neighbors()) {
+    const auto& face_mesh = face_meshes.at(direction);
+    for (const auto& neighbor : neighbors) {
+      const auto mortar_id = std::make_pair(direction, neighbor);
+      const auto& mortar_mesh = mortar_meshes.at(mortar_id);
+      const auto& mortar_size = mortar_sizes.at(mortar_id);
+
+      // Project the data from the face to the mortar.
+      // Where no projection is necessary we `std::move` the data directly to
+      // avoid a copy. We can't move the data or modify it in-place when
+      // projecting, because in that case the face may touch two mortars so we
+      // need to keep the data around.
+      auto boundary_data_on_mortar =
+          ::dg::needs_projection(face_mesh, mortar_mesh, mortar_size)
+              ? boundary_data_on_interfaces.at(direction).project_to_mortar(
+                    face_mesh, mortar_mesh, mortar_size)
+              : std::move(boundary_data_on_interfaces.at(direction));
+
+      // Store the boundary data on this side of the mortar
+      db::mutate<all_mortar_data_tag>(
+          box, [&mortar_id, &temporal_id, &boundary_data_on_mortar](
+                   const gsl::not_null<db::item_type<all_mortar_data_tag>*>
+                       all_mortar_data) noexcept {
+            all_mortar_data->at(mortar_id).local_insert(
+                temporal_id, std::move(boundary_data_on_mortar));
+          });
+    }
+  }
+}
+}  // namespace evolution::dg::Actions

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -11,10 +11,8 @@
 #include "Domain/Tags.hpp"
 #include "ErrorHandling/FloatingPointExceptions.hpp"
 #include "Evolution/Actions/AddMeshVelocitySourceTerms.hpp"
-#include "Evolution/Actions/ComputeTimeDerivative.hpp"  // IWYU pragma: keep
-#include "Evolution/Actions/ComputeVolumeFluxes.hpp"    // IWYU pragma: keep
 #include "Evolution/ComputeTags.hpp"
-#include "Evolution/Conservative/ConservativeDuDt.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp"
 #include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"  // IWYU pragma: keep
 #include "Evolution/DiscontinuousGalerkin/Limiters/LimiterActions.hpp"
 #include "Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp"
@@ -167,13 +165,8 @@ struct EvolutionMetavars {
       typename Event<events>::creatable_classes>;
 
   using step_actions = tmpl::flatten<tmpl::list<
-      Actions::ComputeVolumeFluxes,
-      dg::Actions::CollectDataForFluxes<
-          boundary_scheme, domain::Tags::InternalDirections<volume_dim>>,
+      evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
       dg::Actions::SendDataForFluxes<boundary_scheme>,
-      Actions::ComputeTimeDerivative<
-          evolution::dg::ConservativeDuDt<Burgers::System, dg_formulation>>,
-      evolution::Actions::AddMeshVelocitySourceTerms,
       tmpl::conditional_t<
           evolution::is_analytic_solution_v<initial_data>,
           dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -11,13 +11,9 @@
 #include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
 #include "Domain/Tags.hpp"
 #include "ErrorHandling/FloatingPointExceptions.hpp"
-#include "Evolution/Actions/AddMeshVelocitySourceTerms.hpp"
-#include "Evolution/Actions/ComputeTimeDerivative.hpp"
-#include "Evolution/Actions/ComputeVolumeFluxes.hpp"
-#include "Evolution/Actions/ComputeVolumeSources.hpp"
 #include "Evolution/ComputeTags.hpp"
-#include "Evolution/Conservative/ConservativeDuDt.hpp"
 #include "Evolution/Conservative/UpdateConservatives.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp"
 #include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"
 #include "Evolution/DiscontinuousGalerkin/Limiters/LimiterActions.hpp"
 #include "Evolution/DiscontinuousGalerkin/Limiters/Minmod.tpp"
@@ -189,15 +185,8 @@ struct EvolutionMetavars {
       typename Event<events>::creatable_classes>;
 
   using step_actions = tmpl::flatten<tmpl::list<
-      Actions::ComputeVolumeFluxes,
-      dg::Actions::CollectDataForFluxes<
-          boundary_scheme, domain::Tags::InternalDirections<volume_dim>>,
+      evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
       dg::Actions::SendDataForFluxes<boundary_scheme>,
-      tmpl::conditional_t<has_source_terms, Actions::ComputeVolumeSources,
-                          tmpl::list<>>,
-      Actions::ComputeTimeDerivative<
-          evolution::dg::ConservativeDuDt<system, dg_formulation>>,
-      evolution::Actions::AddMeshVelocitySourceTerms,
       tmpl::conditional_t<
           evolution::is_analytic_solution_v<initial_data>,
           dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,

--- a/src/Evolution/Systems/Burgers/CMakeLists.txt
+++ b/src/Evolution/Systems/Burgers/CMakeLists.txt
@@ -12,6 +12,7 @@ spectre_target_sources(
   Divergence.cpp
   Fluxes.cpp
   Minmod.cpp
+  TimeDerivative.cpp
   )
 
 spectre_target_headers(
@@ -22,6 +23,7 @@ spectre_target_headers(
   Fluxes.hpp
   System.hpp
   Tags.hpp
+  TimeDerivative.hpp
   )
 
 target_link_libraries(

--- a/src/Evolution/Systems/Burgers/System.hpp
+++ b/src/Evolution/Systems/Burgers/System.hpp
@@ -10,6 +10,7 @@
 #include "Evolution/Systems/Burgers/Characteristics.hpp"
 #include "Evolution/Systems/Burgers/Fluxes.hpp"
 #include "Evolution/Systems/Burgers/Tags.hpp"  // IWYU pragma: keep
+#include "Evolution/Systems/Burgers/TimeDerivative.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \ingroup EvolutionSystemsGroup
@@ -25,9 +26,13 @@ struct System {
   static constexpr size_t volume_dim = 1;
 
   using variables_tag = ::Tags::Variables<tmpl::list<Tags::U>>;
+  using flux_variables = tmpl::list<Tags::U>;
+  using gradient_variables = tmpl::list<>;
   using sourced_variables = tmpl::list<>;
 
+  using compute_volume_time_derivative = TimeDerivative;
   using volume_fluxes = Fluxes;
+
   using compute_largest_characteristic_speed =
       ComputeLargestCharacteristicSpeed;
 

--- a/src/Evolution/Systems/Burgers/TimeDerivative.cpp
+++ b/src/Evolution/Systems/Burgers/TimeDerivative.cpp
@@ -1,0 +1,19 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Burgers/TimeDerivative.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+namespace Burgers {
+void TimeDerivative::apply(
+    const gsl::not_null<Scalar<DataVector>*> /*dt_vars*/,
+    const gsl::not_null<tnsr::I<DataVector, 1, Frame::Inertial>*> flux_u,
+    const Scalar<DataVector>& u) noexcept {
+  get<0>(*flux_u) = 0.5 * square(get(u));
+}
+}  // namespace Burgers
+/// \endcond

--- a/src/Evolution/Systems/Burgers/TimeDerivative.hpp
+++ b/src/Evolution/Systems/Burgers/TimeDerivative.hpp
@@ -1,0 +1,46 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+// IWYU pragma: no_forward_declare Tensor
+namespace Burgers {
+namespace Tags {
+struct U;
+}  // namespace Tags
+}  // namespace Burgers
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+
+class DataVector;
+/// \endcond
+
+namespace Burgers {
+/// Computes the time derivative terms needed for the Burgers system, which are
+/// just the fluxes.
+struct TimeDerivative {
+  using temporary_tags = tmpl::list<>;
+  using argument_tags = tmpl::list<Tags::U>;
+
+  static void apply(
+      // Time derivatives returned by reference. No source terms or
+      // nonconservative products, so not used. All the tags in the
+      // variables_tag in the system struct.
+      gsl::not_null<Scalar<DataVector>*> /*dt_vars*/,
+
+      // Fluxes returned by reference. Listed in the system struct as
+      // flux_variables.
+      gsl::not_null<tnsr::I<DataVector, 1, Frame::Inertial>*> flux_u,
+
+      // Arguments listed in argument_tags above
+      const Scalar<DataVector>& u) noexcept;
+};
+}  // namespace Burgers

--- a/src/Evolution/Systems/NewtonianEuler/CMakeLists.txt
+++ b/src/Evolution/Systems/NewtonianEuler/CMakeLists.txt
@@ -28,6 +28,7 @@ spectre_target_headers(
   System.hpp
   Tags.hpp
   TagsDeclarations.hpp
+  TimeDerivative.hpp
   )
 
 target_link_libraries(

--- a/src/Evolution/Systems/NewtonianEuler/Fluxes.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Fluxes.cpp
@@ -14,6 +14,30 @@
 
 /// \cond
 namespace NewtonianEuler {
+namespace detail {
+template <size_t Dim>
+void fluxes_impl(
+    const gsl::not_null<tnsr::I<DataVector, Dim>*> mass_density_cons_flux,
+    const gsl::not_null<tnsr::IJ<DataVector, Dim>*> momentum_density_flux,
+    const gsl::not_null<tnsr::I<DataVector, Dim>*> energy_density_flux,
+    const gsl::not_null<Scalar<DataVector>*> enthalpy_density,
+    const tnsr::I<DataVector, Dim>& momentum_density,
+    const Scalar<DataVector>& energy_density,
+    const tnsr::I<DataVector, Dim>& velocity,
+    const Scalar<DataVector>& pressure) noexcept {
+  get(*enthalpy_density) = get(energy_density) + get(pressure);
+
+  for (size_t i = 0; i < Dim; ++i) {
+    mass_density_cons_flux->get(i) = momentum_density.get(i);
+    for (size_t j = 0; j < Dim; ++j) {
+      momentum_density_flux->get(i, j) =
+          momentum_density.get(i) * velocity.get(j);
+    }
+    momentum_density_flux->get(i, i) += get(pressure);
+    energy_density_flux->get(i) = get(*enthalpy_density) * velocity.get(i);
+  }
+}
+}  // namespace detail
 
 template <size_t Dim>
 void ComputeFluxes<Dim>::apply(
@@ -24,24 +48,26 @@ void ComputeFluxes<Dim>::apply(
     const Scalar<DataVector>& energy_density,
     const tnsr::I<DataVector, Dim>& velocity,
     const Scalar<DataVector>& pressure) noexcept {
-  const DataVector enthalpy_density = get(energy_density) + get(pressure);
-
-  for (size_t i = 0; i < Dim; ++i) {
-    mass_density_cons_flux->get(i) = momentum_density.get(i);
-    for (size_t j = 0; j < Dim; ++j) {
-      momentum_density_flux->get(i, j) =
-          momentum_density.get(i) * velocity.get(j);
-    }
-    momentum_density_flux->get(i, i) += get(pressure);
-    energy_density_flux->get(i) = enthalpy_density * velocity.get(i);
-  }
+  Scalar<DataVector> enthalpy_density{get<0>(momentum_density).size()};
+  detail::fluxes_impl(mass_density_cons_flux, momentum_density_flux,
+                      energy_density_flux, make_not_null(&enthalpy_density),
+                      momentum_density, energy_density, velocity, pressure);
 }
 
 }  // namespace NewtonianEuler
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data) \
+#define INSTANTIATE(_, data)                                                 \
+  template void NewtonianEuler::detail::fluxes_impl<DIM(data)>(              \
+      gsl::not_null<tnsr::I<DataVector, DIM(data)>*> mass_density_cons_flux, \
+      gsl::not_null<tnsr::IJ<DataVector, DIM(data)>*> momentum_density_flux, \
+      gsl::not_null<tnsr::I<DataVector, DIM(data)>*> energy_density_flux,    \
+      gsl::not_null<Scalar<DataVector>*> enthalpy_density,                   \
+      const tnsr::I<DataVector, DIM(data)>& momentum_density,                \
+      const Scalar<DataVector>& energy_density,                              \
+      const tnsr::I<DataVector, DIM(data)>& velocity,                        \
+      const Scalar<DataVector>& pressure) noexcept;                          \
   template class NewtonianEuler::ComputeFluxes<DIM(data)>;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))

--- a/src/Evolution/Systems/NewtonianEuler/Sources/NoSource.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Sources/NoSource.hpp
@@ -20,7 +20,7 @@ namespace Sources {
  */
 struct NoSource {
   using sourced_variables = tmpl::list<>;
-
+  using argument_tags = tmpl::list<>;
   // clang-tidy: google-runtime-references
   void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
 };

--- a/src/Evolution/Systems/NewtonianEuler/System.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/System.hpp
@@ -13,6 +13,7 @@
 #include "Evolution/Systems/NewtonianEuler/PrimitiveFromConservative.hpp"
 #include "Evolution/Systems/NewtonianEuler/Sources.hpp"
 #include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "Evolution/Systems/NewtonianEuler/TimeDerivative.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -28,33 +29,36 @@ struct System {
   static constexpr size_t thermodynamic_dim =
       EquationOfStateType::thermodynamic_dim;
 
+  using variables_tag = ::Tags::Variables<tmpl::list<
+      Tags::MassDensityCons, Tags::MomentumDensity<Dim>, Tags::EnergyDensity>>;
+  using flux_variables =
+      tmpl::list<Tags::MassDensityCons, Tags::MomentumDensity<Dim>,
+                 Tags::EnergyDensity>;
+  using gradient_variables = tmpl::list<>;
+  using sourced_variables =
+      typename InitialDataType::source_term_type::sourced_variables;
   // Compute item for pressure not currently implemented in SpECTRE,
   // so its simple tag is passed along with the primitive variables.
   using primitive_variables_tag = ::Tags::Variables<tmpl::list<
       Tags::MassDensity<DataVector>, Tags::Velocity<DataVector, Dim>,
       Tags::SpecificInternalEnergy<DataVector>, Tags::Pressure<DataVector>>>;
 
-  using variables_tag = ::Tags::Variables<tmpl::list<
-      Tags::MassDensityCons, Tags::MomentumDensity<Dim>, Tags::EnergyDensity>>;
+  using compute_volume_time_derivative = TimeDerivative<Dim, InitialDataType>;
+  using volume_fluxes = ComputeFluxes<Dim>;
+  using volume_sources = ComputeSources<InitialDataType>;
 
-  template <typename Tag>
-  using magnitude_tag = ::Tags::EuclideanMagnitude<Tag>;
+
+  using conservative_from_primitive = ConservativeFromPrimitive<Dim>;
+  using primitive_from_conservative =
+      PrimitiveFromConservative<Dim, thermodynamic_dim>;
 
   using char_speeds_compute_tag = Tags::CharacteristicSpeedsCompute<Dim>;
   using char_speeds_tag = Tags::CharacteristicSpeeds<Dim>;
   using compute_largest_characteristic_speed =
       ComputeLargestCharacteristicSpeed<Dim>;
 
-  using conservative_from_primitive = ConservativeFromPrimitive<Dim>;
-  using primitive_from_conservative =
-      PrimitiveFromConservative<Dim, thermodynamic_dim>;
-
-  using volume_fluxes = ComputeFluxes<Dim>;
-
-  using volume_sources = ComputeSources<InitialDataType>;
-
-  using sourced_variables =
-      typename InitialDataType::source_term_type::sourced_variables;
+  template <typename Tag>
+  using magnitude_tag = ::Tags::EuclideanMagnitude<Tag>;
 };
 
 }  // namespace NewtonianEuler

--- a/src/Evolution/Systems/NewtonianEuler/TimeDerivative.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/TimeDerivative.hpp
@@ -1,0 +1,149 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/NewtonianEuler/TagsDeclarations.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+
+class DataVector;
+/// \endcond
+
+namespace NewtonianEuler {
+/// \cond
+namespace Sources {
+struct NoSource;
+}  // namespace Sources
+/// \endcond
+
+namespace detail {
+template <size_t Dim>
+void fluxes_impl(
+    gsl::not_null<tnsr::I<DataVector, Dim>*> mass_density_cons_flux,
+    gsl::not_null<tnsr::IJ<DataVector, Dim>*> momentum_density_flux,
+    gsl::not_null<tnsr::I<DataVector, Dim>*> energy_density_flux,
+    gsl::not_null<Scalar<DataVector>*> enthalpy_density,
+    const tnsr::I<DataVector, Dim>& momentum_density,
+    const Scalar<DataVector>& energy_density,
+    const tnsr::I<DataVector, Dim>& velocity,
+    const Scalar<DataVector>& pressure) noexcept;
+}  // namespace detail
+
+/*!
+ * \brief Compute the time derivative of the conserved variables for the
+ * Newtonian Euler system
+ */
+template <size_t Dim, typename InitialDataType>
+struct TimeDerivative {
+ private:
+  struct EnthalpyDensity : db::SimpleTag {
+    using type = Scalar<DataVector>;
+  };
+
+  using SourceTerm = typename InitialDataType::source_term_type;
+  using argument_tags_flux =
+      tmpl::list<Tags::MomentumDensity<Dim>, Tags::EnergyDensity,
+                 Tags::Velocity<DataVector, Dim>, Tags::Pressure<DataVector>>;
+
+ public:
+  using temporary_tags = tmpl::list<EnthalpyDensity>;
+  using argument_tags = tmpl::append<
+      argument_tags_flux,
+      tmpl::conditional_t<std::is_same_v<SourceTerm, Sources::NoSource>,
+                          tmpl::list<>,
+                          tmpl::push_front<typename SourceTerm::argument_tags,
+                                           Tags::SourceTerm<InitialDataType>>>>;
+
+  template <typename... SourceTermArgs>
+  static void apply(
+      // Time derivatives returned by reference. All the tags in the
+      // variables_tag in the system struct.
+      const gsl::not_null<Scalar<DataVector>*> dt_mass_density,
+      const gsl::not_null<tnsr::I<DataVector, Dim>*> dt_momentum_density,
+      const gsl::not_null<Scalar<DataVector>*> dt_energy_density,
+
+      // Fluxes returned by reference. Listed in the system struct as
+      // flux_variables.
+      const gsl::not_null<tnsr::I<DataVector, Dim>*> mass_density_cons_flux,
+      const gsl::not_null<tnsr::IJ<DataVector, Dim>*> momentum_density_flux,
+      const gsl::not_null<tnsr::I<DataVector, Dim>*> energy_density_flux,
+
+      // Temporaries returned by reference. Listed in temporary_tags above.
+      const gsl::not_null<Scalar<DataVector>*> enthalpy_density,
+
+      // Arguments listed in argument_tags above
+      const tnsr::I<DataVector, Dim>& momentum_density,
+      const Scalar<DataVector>& energy_density,
+      const tnsr::I<DataVector, Dim>& velocity,
+      const Scalar<DataVector>& pressure, const SourceTerm& source,
+      const SourceTermArgs&... source_term_args) noexcept {
+    detail::fluxes_impl(mass_density_cons_flux, momentum_density_flux,
+                        energy_density_flux, enthalpy_density, momentum_density,
+                        energy_density, velocity, pressure);
+    if constexpr (not std::is_same_v<SourceTerm, Sources::NoSource>) {
+      sources_impl(
+          std::make_tuple(dt_mass_density, dt_momentum_density,
+                          dt_energy_density),
+          typename InitialDataType::source_term_type::sourced_variables{},
+          source, source_term_args...);
+    }
+  }
+
+  static void apply(
+      // Time derivatives returned by reference. No source terms or
+      // nonconservative products, so not used. All the tags in the
+      // variables_tag in the system struct.
+      const gsl::not_null<Scalar<DataVector>*> /*dt_mass_density*/,
+      const gsl::not_null<tnsr::I<DataVector, Dim>*> /*dt_momentum_density*/,
+      const gsl::not_null<Scalar<DataVector>*> /*dt_energy_density*/,
+
+      // Fluxes returned by reference. Listed in the system struct as
+      // flux_variables.
+      const gsl::not_null<tnsr::I<DataVector, Dim>*> mass_density_cons_flux,
+      const gsl::not_null<tnsr::IJ<DataVector, Dim>*> momentum_density_flux,
+      const gsl::not_null<tnsr::I<DataVector, Dim>*> energy_density_flux,
+
+      // Temporaries returned by reference. Listed in temporary_tags above.
+      const gsl::not_null<Scalar<DataVector>*> enthalpy_density,
+
+      // Arguments listed in argument_tags above
+      const tnsr::I<DataVector, Dim>& momentum_density,
+      const Scalar<DataVector>& energy_density,
+      const tnsr::I<DataVector, Dim>& velocity,
+      const Scalar<DataVector>& pressure) noexcept {
+    detail::fluxes_impl(mass_density_cons_flux, momentum_density_flux,
+                        energy_density_flux, enthalpy_density, momentum_density,
+                        energy_density, velocity, pressure);
+  }
+
+ private:
+  using dt_vars_list =
+      tmpl::list<Tags::MassDensityCons, Tags::MomentumDensity<Dim>,
+                 Tags::EnergyDensity>;
+
+  template <typename... SourceTermArgs, typename... SourcedVars>
+  static void sources_impl(std::tuple<gsl::not_null<Scalar<DataVector>*>,
+                                      gsl::not_null<tnsr::I<DataVector, Dim>*>,
+                                      gsl::not_null<Scalar<DataVector>*>>
+                               dt_vars,
+                           tmpl::list<SourcedVars...> /*meta*/,
+                           const SourceTerm& source,
+                           const SourceTermArgs&... source_term_args) noexcept {
+    source.apply(
+        std::get<tmpl::index_of<dt_vars_list, SourcedVars>::value>(dt_vars)...,
+        source_term_args...);
+  }
+};
+
+}  // namespace NewtonianEuler

--- a/src/Evolution/Systems/ScalarWave/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarWave/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_sources(
   Characteristics.cpp
   Constraints.cpp
   Equations.cpp
+  TimeDerivative.cpp
   UpwindPenaltyCorrection.cpp
   )
 
@@ -25,6 +26,7 @@ spectre_target_headers(
   System.hpp
   Tags.hpp
   TagsDeclarations.hpp
+  TimeDerivative.hpp
   UpwindPenaltyCorrection.hpp
   )
 

--- a/src/Evolution/Systems/ScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.hpp
@@ -4,90 +4,24 @@
 #pragma once
 
 #include <cstddef>
-#include <string>
 
-#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
-#include "Domain/FaceNormal.hpp"
 #include "Evolution/Systems/ScalarWave/Tags.hpp"
-#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
-#include "Options/Options.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-template <typename>
-class Variables;
-
 class DataVector;
 
 namespace gsl {
 template <typename T>
 class not_null;
 }  // namespace gsl
-
-namespace Tags {
-template <typename>
-struct NormalDotFlux;
-template <typename>
-struct Normalized;
-}  // namespace Tags
-
-namespace ScalarWave {
-struct Psi;
-struct Pi;
-template <size_t Dim>
-struct Phi;
-}  // namespace ScalarWave
-
-namespace PUP {
-class er;
-}  // namespace PUP
 /// \endcond
 
 // IWYU pragma: no_forward_declare Tensor
 
 namespace ScalarWave {
-/*!
- * \brief Compute the time derivative of the evolved variables of the
- * first-order scalar wave system.
- *
- * The evolution equations for the first-order scalar wave system are given by:
- * \f{align}
- * \partial_t\Psi = & -\Pi \\
- * \partial_t\Phi_i = & -\partial_i \Pi +
- *                       \gamma_2 (\partial_i\Psi - \Phi_i) \\
- * \partial_t\Pi = & - \delta^{ij}\partial_i\Phi_j
- * \f}
- *
- * where \f$\Psi\f$ is the scalar field, \f$\Pi=-\partial_t\Psi\f$ is the
- * conjugate momentum to \f$\Psi\f$, \f$\Phi_i=\partial_i\Psi\f$ is an
- * auxiliary variable, and \f$\gamma_2\f$ is the constraint damping parameter.
- */
-template <size_t Dim>
-struct ComputeDuDt {
-  template <template <class> class StepPrefix>
-  using return_tags =
-      tmpl::list<StepPrefix<Pi>, StepPrefix<Phi<Dim>>, StepPrefix<Psi>>;
-
-  using argument_tags =
-      tmpl::list<::Tags::deriv<Psi, tmpl::size_t<Dim>, Frame::Inertial>, Pi,
-                 ::Tags::deriv<Pi, tmpl::size_t<Dim>, Frame::Inertial>,
-                 Phi<Dim>,
-                 ::Tags::deriv<Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>,
-                 Tags::ConstraintGamma2>;
-  static void apply(
-      gsl::not_null<Scalar<DataVector>*> dt_pi,
-      gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> dt_phi,
-      gsl::not_null<Scalar<DataVector>*> dt_psi,
-      const tnsr::i<DataVector, Dim, Frame::Inertial>& d_psi,
-      const Scalar<DataVector>& pi,
-      const tnsr::i<DataVector, Dim, Frame::Inertial>& d_pi,
-      const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
-      const tnsr::ij<DataVector, Dim, Frame::Inertial>& d_phi,
-      const Scalar<DataVector>& gamma2) noexcept;
-};
-
 /*!
  * \brief A relic of an old incorrect way of handling boundaries for
  * non-conservative systems.

--- a/src/Evolution/Systems/ScalarWave/System.hpp
+++ b/src/Evolution/Systems/ScalarWave/System.hpp
@@ -13,6 +13,7 @@
 #include "Evolution/Systems/ScalarWave/Characteristics.hpp"
 #include "Evolution/Systems/ScalarWave/Equations.hpp"
 #include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "Evolution/Systems/ScalarWave/TimeDerivative.hpp"
 #include "Utilities/TMPL.hpp"
 
 /*!
@@ -41,10 +42,12 @@ struct System {
   static constexpr size_t volume_dim = Dim;
 
   using variables_tag = ::Tags::Variables<tmpl::list<Pi, Phi<Dim>, Psi>>;
-  // Typelist of which subset of the variables to take the gradient of.
-  using gradients_tags = tmpl::list<Pi, Phi<Dim>, Psi>;
+  using flux_variables = tmpl::list<>;
+  using gradient_variables = tmpl::list<Pi, Phi<Dim>, Psi>;
 
+  using compute_volume_time_derivative = TimeDerivative<Dim>;
   using normal_dot_fluxes = ComputeNormalDotFluxes<Dim>;
+
   using compute_largest_characteristic_speed =
       ComputeLargestCharacteristicSpeed;
 
@@ -53,5 +56,9 @@ struct System {
 
   template <typename Tag>
   using magnitude_tag = ::Tags::EuclideanMagnitude<Tag>;
+
+  // Remove gradients_tags once GH is converted over to the new
+  // dg::ComputeTimeDerivative action.
+  using gradients_tags = gradient_variables;
 };
 }  // namespace ScalarWave

--- a/src/Evolution/Systems/ScalarWave/TimeDerivative.cpp
+++ b/src/Evolution/Systems/ScalarWave/TimeDerivative.cpp
@@ -1,0 +1,40 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarWave/TimeDerivative.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace ScalarWave {
+/// \cond
+template <size_t Dim>
+void TimeDerivative<Dim>::apply(
+    const gsl::not_null<Scalar<DataVector>*> dt_pi,
+    const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> dt_phi,
+    const gsl::not_null<Scalar<DataVector>*> dt_psi,
+
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& d_pi,
+    const tnsr::ij<DataVector, Dim, Frame::Inertial>& d_phi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& d_psi,
+    const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
+    const Scalar<DataVector>& gamma2) noexcept {
+  get(*dt_psi) = -get(pi);
+  get(*dt_pi) = -get<0, 0>(d_phi);
+  for (size_t d = 1; d < Dim; ++d) {
+    get(*dt_pi) -= d_phi.get(d, d);
+  }
+  for (size_t d = 0; d < Dim; ++d) {
+    dt_phi->get(d) = -d_pi.get(d) + get(gamma2) * (d_psi.get(d) - phi.get(d));
+  }
+}
+
+template class TimeDerivative<1>;
+template class TimeDerivative<2>;
+template class TimeDerivative<3>;
+/// \endcond
+}  // namespace ScalarWave

--- a/src/Evolution/Systems/ScalarWave/TimeDerivative.hpp
+++ b/src/Evolution/Systems/ScalarWave/TimeDerivative.hpp
@@ -1,0 +1,48 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+
+class DataVector;
+/// \endcond
+
+namespace ScalarWave {
+/*!
+ * \brief Compute the time derivatives for scalar wave system
+ */
+template <size_t Dim>
+struct TimeDerivative {
+  using temporary_tags = tmpl::list<>;
+  using argument_tags = tmpl::list<Pi, Phi<Dim>, Tags::ConstraintGamma2>;
+
+  static void apply(
+      // Time derivatives returned by reference. All the tags in the
+      // variables_tag in the system struct.
+      gsl::not_null<Scalar<DataVector>*> dt_pi,
+      gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> dt_phi,
+      gsl::not_null<Scalar<DataVector>*> dt_psi,
+
+      // Partial derivative arguments. Listed in the system struct as
+      // gradient_variables.
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& d_pi,
+      const tnsr::ij<DataVector, Dim, Frame::Inertial>& d_phi,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& d_psi,
+
+      // Terms list in argument_tags above
+      const Scalar<DataVector>& pi,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
+      const Scalar<DataVector>& gamma2) noexcept;
+};
+}  // namespace ScalarWave

--- a/tests/Unit/Evolution/Actions/CMakeLists.txt
+++ b/tests/Unit/Evolution/Actions/CMakeLists.txt
@@ -15,7 +15,7 @@ add_test_library(
   ${LIBRARY}
   "Evolution/Actions/"
   "${LIBRARY_SOURCES}"
-  "Boost::boost;DataStructures;Domain;ErrorHandling"
+  "Boost::boost;DataStructures;DiscontinuousGalerkin;Domain;ErrorHandling"
   )
 
 add_dependencies(

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ComputeTimeDerivative.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ComputeTimeDerivative.cpp
@@ -1,0 +1,566 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/TagsTimeDependent.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/FirstOrderScheme.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "NumericalAlgorithms/LinearOperators/Divergence.tpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeMortars.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+enum SystemType { Conservative, Nonconservative };
+
+struct Var1 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct Var2 : db::SimpleTag {
+  using type = tnsr::I<DataVector, Dim, Frame::Inertial>;
+};
+
+// Var3 is used as an extra quantity in the DataBox that the time derivative
+// computation depends on. It could be loosely interpreted as a "primitive"
+// variable, or a compute tag retrieved for the time derivative computation.
+struct Var3 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+struct PackagedVar1 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct PackagedVar2 : db::SimpleTag {
+  using type = tnsr::I<DataVector, Dim, Frame::Inertial>;
+};
+
+template <size_t Dim, SystemType system_type>
+struct TimeDerivative {
+  struct Var3Squared : db::SimpleTag {
+    using type = Scalar<DataVector>;
+  };
+  using temporary_tags = tmpl::list<Var3Squared>;
+  using argument_tags = tmpl::list<Var1, Var2<Dim>, Var3>;
+
+  // Conservative system
+  static void apply(
+      // Time derivatives returned by reference. All the tags in the
+      // variables_tag in the system struct.
+      const gsl::not_null<Scalar<DataVector>*> dt_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> dt_var2,
+
+      // Fluxes returned by reference. Listed in the system struct as
+      // flux_variables.
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> flux_var1,
+      const gsl::not_null<tnsr::IJ<DataVector, Dim, Frame::Inertial>*>
+          flux_var2,
+
+      // Temporaries returned by reference. Listed in temporary_tags above.
+      const gsl::not_null<Scalar<DataVector>*> square_var3,
+
+      // Arguments listed in argument_tags above
+      const Scalar<DataVector>& var1,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& var2,
+      const Scalar<DataVector>& var3) noexcept {
+    get(*square_var3) = square(get(var3));
+
+    // Set source terms
+    get(*dt_var1) = get(*square_var3);
+    for (size_t d = 0; d < Dim; ++d) {
+      dt_var2->get(d) = get(var3) * d;
+    }
+
+    // Set fluxes
+    for (size_t i = 0; i < Dim; ++i) {
+      flux_var1->get(i) = square(get(var1)) * var2.get(i);
+      for (size_t j = 0; j < Dim; ++j) {
+        flux_var2->get(i, j) = var2.get(i) * var2.get(j) * get(var1);
+        if (i == j) {
+          flux_var2->get(i, j) += cube(get(var1));
+        }
+      }
+    }
+  }
+
+  // Nonconservative system
+  static void apply(
+      // Time derivatives returned by reference. All the tags in the
+      // variables_tag in the system struct.
+      const gsl::not_null<Scalar<DataVector>*> dt_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> dt_var2,
+
+      // Temporaries returned by reference. Listed in temporary_tags above.
+      const gsl::not_null<Scalar<DataVector>*> square_var3,
+
+      // Partial derivative arguments. Listed in the system struct as
+      // gradient_variables.
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& d_var1,
+      const tnsr::iJ<DataVector, Dim, Frame::Inertial>& d_var2,
+
+      // Arguments listed in argument_tags above
+      const Scalar<DataVector>& var1,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& var2,
+      const Scalar<DataVector>& var3) noexcept {
+    get(*square_var3) = square(get(var3));
+
+    // Set source terms and nonconservative products
+    get(*dt_var1) = get(*square_var3);
+    for (size_t d = 0; d < Dim; ++d) {
+      get(*dt_var1) -= var2.get(d) * d_var1.get(d);
+      dt_var2->get(d) = get(var3) * d;
+      for (size_t i = 0; i < Dim; ++i) {
+        dt_var2->get(d) -= get(var1) * var2.get(i) * d_var2.get(i, d);
+      }
+    }
+  }
+};
+
+template <size_t Dim>
+struct NonconservativeNormalDotFlux {
+  using argument_tags = tmpl::list<>;
+  static void apply(
+      const gsl::not_null<Scalar<DataVector>*> var1_normal_dot_flux,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+          var2_normal_dot_flux) noexcept {
+    get(*var1_normal_dot_flux) = 1.1;
+    for (size_t i = 0; i < Dim; ++i) {
+      var2_normal_dot_flux->get(i) = 1.3 + i;
+    }
+  }
+};
+
+template <size_t Dim>
+struct BoundaryTerms : tt::ConformsTo<dg::protocols::NumericalFlux> {
+  struct MaxAbsCharSpeed : db::SimpleTag {
+    using type = Scalar<DataVector>;
+  };
+
+  using variables_tags = tmpl::list<Var1, Var2<Dim>>;
+  using variables_tag = Tags::Variables<variables_tags>;
+
+  using package_field_tags =
+      tmpl::push_back<tmpl::append<db::split_tag<db::add_tag_prefix<
+                                       ::Tags::NormalDotFlux, variables_tag>>,
+                                   variables_tags>,
+                      MaxAbsCharSpeed>;
+  using package_extra_tags = tmpl::list<>;
+
+  using argument_tags = tmpl::push_back<tmpl::append<
+      db::wrap_tags_in<::Tags::NormalDotFlux, variables_tags>, variables_tags>>;
+
+  void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
+
+  void package_data(
+      const gsl::not_null<Scalar<DataVector>*> out_normal_dot_flux_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+          out_normal_dot_flux_var2,
+      const gsl::not_null<Scalar<DataVector>*> out_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var2,
+      const gsl::not_null<Scalar<DataVector>*> max_abs_char_speed,
+      const Scalar<DataVector>& normal_dot_flux_var1,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& normal_dot_flux_var2,
+      const Scalar<DataVector>& var1,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& var2) const noexcept {
+    *out_normal_dot_flux_var1 = normal_dot_flux_var1;
+    *out_normal_dot_flux_var2 = normal_dot_flux_var2;
+    *out_var1 = var1;
+    *out_var2 = var2;
+    get(*max_abs_char_speed) = 2.0 * max(get(var1));
+  }
+};
+
+template <size_t Dim, SystemType system_type>
+struct System {
+  static constexpr bool has_primitive_and_conservative_vars = true;
+  static constexpr size_t volume_dim = Dim;
+
+  using variables_tag = Tags::Variables<tmpl::list<Var1, Var2<Dim>>>;
+  using flux_variables =
+      tmpl::conditional_t<system_type == SystemType::Conservative,
+                          tmpl::list<Var1, Var2<Dim>>, tmpl::list<>>;
+  using gradient_variables =
+      tmpl::conditional_t<system_type == SystemType::Conservative, tmpl::list<>,
+                          tmpl::list<Var1, Var2<Dim>>>;
+
+  using compute_volume_time_derivative = TimeDerivative<Dim, system_type>;
+
+  using normal_dot_fluxes = NonconservativeNormalDotFlux<Dim>;
+};
+
+template <typename Metavariables>
+struct component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementId<Metavariables::volume_dim>;
+
+  using internal_directions =
+      domain::Tags::InternalDirections<Metavariables::volume_dim>;
+  using boundary_directions_interior =
+      domain::Tags::BoundaryDirectionsInterior<Metavariables::volume_dim>;
+
+  using common_simple_tags = tmpl::list<
+      ::Tags::TimeStepId, typename Metavariables::system::variables_tag,
+      db::add_tag_prefix<::Tags::dt,
+                         typename Metavariables::system::variables_tag>,
+      Var3, domain::Tags::Mesh<Metavariables::volume_dim>,
+      domain::Tags::Interface<
+          internal_directions,
+          db::add_tag_prefix<
+              ::Tags::NormalDotFlux,
+              typename metavariables::boundary_scheme::variables_tag>>,
+      domain::Tags::Element<Metavariables::volume_dim>,
+      domain::Tags::InverseJacobian<Metavariables::volume_dim, Frame::Logical,
+                                    Frame::Inertial>,
+      domain::Tags::MeshVelocity<Metavariables::volume_dim>,
+      domain::Tags::DivMeshVelocity>;
+  using simple_tags = tmpl::conditional_t<
+      Metavariables::system_type == SystemType::Conservative,
+      tmpl::push_back<
+          common_simple_tags,
+          db::add_tag_prefix<
+              ::Tags::Flux, typename Metavariables::system::variables_tag,
+              tmpl::size_t<Metavariables::volume_dim>, Frame::Inertial>>,
+      common_simple_tags>;
+  using compute_tags = tmpl::list<
+      domain::Tags::InternalDirectionsCompute<Metavariables::volume_dim>,
+      domain::Tags::InterfaceCompute<
+          internal_directions,
+          domain::Tags::Direction<Metavariables::volume_dim>>,
+      domain::Tags::InterfaceCompute<
+          internal_directions,
+          domain::Tags::InterfaceMesh<Metavariables::volume_dim>>,
+      domain::Tags::BoundaryDirectionsInteriorCompute<
+          Metavariables::volume_dim>,
+      domain::Tags::InterfaceCompute<
+          boundary_directions_interior,
+          domain::Tags::Direction<Metavariables::volume_dim>>,
+      domain::Tags::InterfaceCompute<
+          boundary_directions_interior,
+          domain::Tags::InterfaceMesh<Metavariables::volume_dim>>,
+      domain::Tags::Slice<internal_directions, Var1>,
+      domain::Tags::Slice<internal_directions,
+                          Var2<Metavariables::volume_dim>>>;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          tmpl::list<
+              ActionTesting::InitializeDataBox<simple_tags, compute_tags>,
+              dg::Actions::InitializeMortars<
+                  typename Metavariables::boundary_scheme>>>,
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          tmpl::list<
+              evolution::dg::Actions::ComputeTimeDerivative<Metavariables>>>>;
+};
+
+template <size_t Dim, SystemType SystemTypeIn>
+struct Metavariables {
+  static constexpr dg::Formulation dg_formulation =
+      dg::Formulation::StrongInertial;
+  static constexpr size_t volume_dim = Dim;
+  static constexpr SystemType system_type = SystemTypeIn;
+  using system = System<Dim, system_type>;
+  using boundary_scheme = ::dg::FirstOrderScheme::FirstOrderScheme<
+      Dim, typename system::variables_tag,
+      Tags::NumericalFlux<BoundaryTerms<Dim>>, Tags::TimeStepId>;
+  using normal_dot_numerical_flux = Tags::NumericalFlux<BoundaryTerms<Dim>>;
+  using const_global_cache_tags =
+      tmpl::list<domain::Tags::InitialExtents<Dim>, normal_dot_numerical_flux>;
+
+  using component_list = tmpl::list<component<Metavariables>>;
+  enum class Phase { Initialization, Testing, Exit };
+};
+
+template <bool UseMovingMesh, size_t Dim, SystemType system_type>
+void test_impl() noexcept {
+  using metavars = Metavariables<Dim, system_type>;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
+  // The reference element in 2d denoted by X below:
+  // ^ eta
+  // +-+-+> xi
+  // |X| |
+  // +-+-+
+  // | | |
+  // +-+-+
+  //
+  // The "self_id" for the element that we are considering is marked by an X in
+  // the diagram. We consider a configuration with one neighbor in the +xi
+  // direction (east_id), and (in 2d and 3d) one in the -eta (south_id)
+  // direction.
+  //
+  // In 1d there aren't any projections to test, and in 3d we only have 1
+  // element in the z-direction.
+  DirectionMap<Dim, Neighbors<Dim>> neighbors{};
+  ElementId<Dim> self_id{};
+  ElementId<Dim> east_id{};
+  ElementId<Dim> south_id{};  // not used in 1d
+
+  if constexpr (Dim == 1) {
+    self_id = ElementId<Dim>{0, {{{1, 0}}}};
+    east_id = ElementId<Dim>{0, {{{1, 1}}}};
+    neighbors[Direction<Dim>::upper_xi()] = Neighbors<Dim>{{east_id}, {}};
+  } else if constexpr (Dim == 2) {
+    self_id = ElementId<Dim>{0, {{{1, 0}, {0, 0}}}};
+    east_id = ElementId<Dim>{0, {{{1, 1}, {0, 0}}}};
+    south_id = ElementId<Dim>{1, {{{1, 0}, {0, 0}}}};
+    neighbors[Direction<Dim>::upper_xi()] = Neighbors<Dim>{{east_id}, {}};
+    neighbors[Direction<Dim>::lower_eta()] = Neighbors<Dim>{{south_id}, {}};
+  } else {
+    static_assert(Dim == 3, "Only implemented tests in 1, 2, and 3d");
+    self_id = ElementId<Dim>{0, {{{1, 0}, {0, 0}, {0, 0}}}};
+    east_id = ElementId<Dim>{0, {{{1, 1}, {0, 0}, {0, 0}}}};
+    south_id = ElementId<Dim>{1, {{{1, 0}, {0, 0}, {0, 0}}}};
+    neighbors[Direction<Dim>::upper_xi()] = Neighbors<Dim>{{east_id}, {}};
+    neighbors[Direction<Dim>::lower_eta()] = Neighbors<Dim>{{south_id}, {}};
+  }
+  const Element<Dim> element{self_id, neighbors};
+  MockRuntimeSystem runner{
+      {std::vector<std::array<size_t, Dim>>{make_array<Dim>(2_st),
+                                            make_array<Dim>(3_st)},
+       typename metavars::normal_dot_numerical_flux::type{}}};
+
+  const Mesh<Dim> mesh{2, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+
+  ::InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial> inv_jac{
+      mesh.number_of_grid_points(), 0.0};
+  for (size_t i = 0; i < Dim; ++i) {
+    inv_jac.get(i, i) = 1.0;
+  }
+
+  boost::optional<tnsr::I<DataVector, Dim, Frame::Inertial>> mesh_velocity{};
+  boost::optional<Scalar<DataVector>> div_mesh_velocity{};
+  if (UseMovingMesh) {
+    const std::array<double, 3> velocities = {{1.2, -1.4, 0.3}};
+    mesh_velocity =
+        tnsr::I<DataVector, Dim, Frame::Inertial>{mesh.number_of_grid_points()};
+    for (size_t i = 0; i < Dim; ++i) {
+      mesh_velocity->get(i) = gsl::at(velocities, i);
+    }
+    div_mesh_velocity = Scalar<DataVector>{mesh.number_of_grid_points(), 1.5};
+  }
+
+  Variables<tmpl::list<Var1, Var2<Dim>>> evolved_vars{
+      mesh.number_of_grid_points()};
+  Scalar<DataVector> var3{mesh.number_of_grid_points()};
+  // Set the variables so they are constant in y & z
+  for (size_t i = 0; i < mesh.number_of_grid_points(); i += 2) {
+    get(get<Var1>(evolved_vars))[i] = 3.0;
+    get(get<Var1>(evolved_vars))[i + 1] = 2.0;
+    for (size_t j = 0; j < Dim; ++j) {
+      get<Var2<Dim>>(evolved_vars).get(j)[i] = j + 1.0;
+      get<Var2<Dim>>(evolved_vars).get(j)[i + 1] = j + 3.0;
+    }
+    get(var3)[i] = 5.0;
+    get(var3)[i + 1] = 6.0;
+  }
+  Variables<tmpl::list<::Tags::dt<Var1>, ::Tags::dt<Var2<Dim>>>>
+      dt_evolved_vars{mesh.number_of_grid_points()};
+
+  using flux_tags =
+      tmpl::conditional_t<system_type == SystemType::Nonconservative,
+                          tmpl::list<>, tmpl::list<Var1, Var2<Dim>>>;
+
+  std::unordered_map<::Direction<Dim>,
+                     Variables<tmpl::list<::Tags::NormalDotFlux<Var1>,
+                                          ::Tags::NormalDotFlux<Var2<Dim>>>>>
+      normal_dot_fluxes_interface{};
+  const size_t interface_grid_points =
+      mesh.slice_away(0).number_of_grid_points();
+  for (const auto& [direction, nhbrs] : element.neighbors()) {
+    (void)nhbrs;
+    normal_dot_fluxes_interface[direction].initialize(interface_grid_points,
+                                                      0.0);
+  }
+
+  const TimeStepId time_step_id{true, 3, Time{Slab{0.2, 3.4}, {3, 100}}};
+  if constexpr (not std::is_same_v<tmpl::list<>, flux_tags>) {
+    ActionTesting::emplace_component_and_initialize<component<metavars>>(
+        &runner, self_id,
+        {time_step_id, evolved_vars, dt_evolved_vars, var3, mesh,
+         normal_dot_fluxes_interface, element, inv_jac, mesh_velocity,
+         div_mesh_velocity,
+         Variables<db::wrap_tags_in<::Tags::Flux, flux_tags, tmpl::size_t<Dim>,
+                                    Frame::Inertial>>{2, -100.0}});
+  } else {
+    ActionTesting::emplace_component_and_initialize<component<metavars>>(
+        &runner, self_id,
+        {time_step_id, evolved_vars, dt_evolved_vars, var3, mesh,
+         normal_dot_fluxes_interface, element, inv_jac, mesh_velocity,
+         div_mesh_velocity});
+  }
+  // Initialize the mortars
+  ActionTesting::next_action<component<metavars>>(make_not_null(&runner),
+                                                  self_id);
+  // Start testing the actual dg::ComputeTimeDerivative action
+  ActionTesting::set_phase(make_not_null(&runner), metavars::Phase::Testing);
+  ActionTesting::next_action<component<metavars>>(make_not_null(&runner),
+                                                  self_id);
+
+  Variables<tmpl::list<::Tags::dt<Var1>, ::Tags::dt<Var2<Dim>>>>
+      expected_dt_evolved_vars{mesh.number_of_grid_points()};
+  if constexpr (system_type == SystemType::Nonconservative) {
+    for (size_t i = 0; i < mesh.number_of_grid_points(); i += 2) {
+      get(get<::Tags::dt<Var1>>(expected_dt_evolved_vars))[i] = 25.5;
+      get(get<::Tags::dt<Var1>>(expected_dt_evolved_vars))[i + 1] = 37.5;
+      for (size_t j = 0; j < Dim; ++j) {
+        get<::Tags::dt<Var2<Dim>>>(expected_dt_evolved_vars).get(j)[i] = -3.0;
+        get<::Tags::dt<Var2<Dim>>>(expected_dt_evolved_vars).get(j)[i + 1] =
+            -6.0;
+      }
+    }
+    for (size_t j = 0; j < Dim; ++j) {
+      get<::Tags::dt<Var2<Dim>>>(expected_dt_evolved_vars).get(j) +=
+          j * get(var3);
+    }
+    if (UseMovingMesh) {
+      get(get<::Tags::dt<Var1>>(expected_dt_evolved_vars)) +=
+          -0.5 * get<0>(*mesh_velocity);
+      for (size_t j = 0; j < Dim; ++j) {
+        get<::Tags::dt<Var2<Dim>>>(expected_dt_evolved_vars).get(j) +=
+            get<0>(*mesh_velocity);
+      }
+    }
+  } else if constexpr (system_type == SystemType::Conservative) {
+    // Deal with source terms:
+    get(get<::Tags::dt<Var1>>(expected_dt_evolved_vars)) = square(get(var3));
+    for (size_t j = 0; j < Dim; ++j) {
+      get<::Tags::dt<Var2<Dim>>>(expected_dt_evolved_vars).get(j) =
+          j * get(var3);
+    }
+    // Deal with volume flux divergence
+    get(get<::Tags::dt<Var1>>(expected_dt_evolved_vars)) -= 1.5;
+    get<0>(get<::Tags::dt<Var2<Dim>>>(expected_dt_evolved_vars)) += 2.0;
+    if constexpr (Dim > 1) {
+      get<1>(get<::Tags::dt<Var2<Dim>>>(expected_dt_evolved_vars)) -= 9.0;
+    }
+    if constexpr (Dim > 2) {
+      get<2>(get<::Tags::dt<Var2<Dim>>>(expected_dt_evolved_vars)) -= 10.5;
+    }
+    if constexpr (UseMovingMesh) {
+      get(get<::Tags::dt<Var1>>(expected_dt_evolved_vars)) -=
+          1.5 * get(get<Var1>(evolved_vars)) - mesh_velocity->get(0) * -0.5;
+      for (size_t j = 0; j < Dim; ++j) {
+        get<::Tags::dt<Var2<Dim>>>(expected_dt_evolved_vars).get(j) -=
+            1.5 * get<Var2<Dim>>(evolved_vars).get(j) -
+            mesh_velocity->get(0) * 1.0;
+      }
+    }
+  }
+
+  CHECK(ActionTesting::get_databox_tag<
+            component<metavars>,
+            db::add_tag_prefix<::Tags::dt,
+                               typename metavars::system::variables_tag>>(
+            runner, self_id) == expected_dt_evolved_vars);
+
+  const auto get_tag = [&runner, &self_id](auto tag_v) -> decltype(auto) {
+    using tag = std::decay_t<decltype(tag_v)>;
+    return ActionTesting::get_databox_tag<component<metavars>, tag>(runner,
+                                                                    self_id);
+  };
+
+  const auto check_mortar =
+      [&get_tag, &time_step_id](
+          const std::pair<Direction<Dim>, ElementId<Dim>>& mortar_id,
+          const size_t num_points) noexcept {
+        CAPTURE(mortar_id);
+        CAPTURE(Dim);
+        const auto& all_mortar_data = get_tag(
+            ::Tags::Mortars<typename metavars::boundary_scheme::mortar_data_tag,
+                            Dim>{});
+        const dg::SimpleBoundaryData<
+            typename BoundaryTerms<Dim>::package_field_tags>& boundary_data =
+            all_mortar_data.at(mortar_id).local_data(time_step_id);
+        CHECK(boundary_data.field_data.number_of_grid_points() == num_points);
+        // Actually checking all the fields is a total nightmare because the
+        // whole boundary scheme code is a complete disaster. The checks will be
+        // added once the boundary scheme code is cleaned up.
+        if constexpr (system_type == SystemType::Conservative) {
+          const Scalar<DataVector> expected_var1_normal_dot_flux(num_points,
+                                                                 0.0);
+          CHECK(get<::Tags::NormalDotFlux<Var1>>(boundary_data.field_data) ==
+                expected_var1_normal_dot_flux);
+        }
+      };
+
+  const auto mortar_id_east =
+      std::make_pair(Direction<Dim>::upper_xi(), east_id);
+  check_mortar(mortar_id_east, Dim == 1 ? 1 : Dim == 2 ? 2 : 4);
+  if constexpr (Dim > 1) {
+    const auto mortar_id_south =
+        std::make_pair(Direction<Dim>::lower_eta(), south_id);
+    // The number of points on the mortar should be 3 in 2d and 9 and 3d because
+    // we do projection to the southern neighbor, which has 3 points per
+    // dimension.
+    check_mortar(mortar_id_south, Dim == 2 ? 3 : 9);
+  }
+}
+
+template <SystemType system_type>
+void test() noexcept {
+  test_impl<false, 1, system_type>();
+  test_impl<true, 1, system_type>();
+  test_impl<false, 2, system_type>();
+  test_impl<true, 2, system_type>();
+  test_impl<false, 3, system_type>();
+  test_impl<true, 3, system_type>();
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.DG.ComputeTimeDerivative",
+                  "[Unit][Evolution][Actions]") {
+  // The test is designed to test the `ComputeTimeDerivative` action for DG.
+  // This action does a lot:
+  //
+  // - compute partial derivatives as needed
+  // - compute the time derivative from
+  //   `System::compute_volume_time_derivative`. This includes fluxes, sources,
+  //   and nonconservative products.
+  // - adds moving mesh terms as needed.
+  // - compute flux divergence and add to the time derivative.
+  // - compute mortar data for internal boundaries.
+  //
+  // The action supports conservative systems, and nonconservative systems
+  // (mixed conservative-nonconservative systems will be added in the future).
+  //
+  // To test the action thoroughly we need to test a lot of different
+  // combinations:
+  //
+  // - system type (conservative/nonconservative), using the enum SystemType
+  // - 1d, 2d, 3d
+  // - whether the mesh is moving or not
+
+  test<SystemType::Nonconservative>();
+  test<SystemType::Conservative>();
+}

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -2,3 +2,21 @@
 # See LICENSE.txt for details.
 
 add_subdirectory(Limiters)
+
+set(LIBRARY "Test_EvolutionDg")
+
+set(LIBRARY_SOURCES
+  Actions/Test_ComputeTimeDerivative.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "Evolution/DiscontinuousGalerkin/"
+  "${LIBRARY_SOURCES}"
+  "Boost::boost;Evolution"
+  )
+
+add_dependencies(
+  ${LIBRARY}
+  module_GlobalCache
+  )

--- a/tests/Unit/Evolution/Systems/Burgers/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Burgers/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_Characteristics.cpp
   Test_Fluxes.cpp
   Test_Tags.cpp
+  Test_TimeDerivative.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Evolution/Systems/Burgers/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/Test_TimeDerivative.cpp
@@ -1,0 +1,42 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Evolution/Systems/Burgers/System.hpp"
+#include "Evolution/Systems/Burgers/Tags.hpp"
+#include "Evolution/Systems/Burgers/TimeDerivative.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+SPECTRE_TEST_CASE("Unit.Burgers.TimeDerivative", "[Unit][Burgers]") {
+  constexpr size_t num_points = 10;
+  const Mesh<1> mesh(num_points, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto);
+  const auto coords = get<0>(logical_coordinates(mesh));
+
+  // Arbitrary polynomial whose square is exactly representable.
+  const Scalar<DataVector> burgers_u{DataVector{
+      pow<num_points / 2 - 1>(coords) + pow<num_points / 4>(coords) + 5.0}};
+
+  tnsr::I<DataVector, 1, Frame::Inertial> flux(num_points);
+  Scalar<DataVector> dudt{num_points, 0.0};
+  Burgers::TimeDerivative::apply(&dudt, &flux, burgers_u);
+
+  // dudt should be zero since we have no source terms
+  const Scalar<DataVector> dudt_expected{num_points, 0.0};
+  const tnsr::I<DataVector, 1, Frame::Inertial> flux_expected{
+      DataVector{0.5 * square(get(burgers_u))}};
+
+  CHECK_ITERABLE_APPROX(dudt, dudt_expected);
+  CHECK_ITERABLE_APPROX(flux, flux_expected);
+}

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBRARY_SOURCES
   Test_SoundSpeedSquared.cpp
   Test_Sources.cpp
   Test_Tags.cpp
+  Test_TimeDerivative.cpp
   )
 
 add_subdirectory(Limiters)

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/TestFunctions.py
@@ -34,26 +34,6 @@ def energy_density(mass_density, velocity, specific_internal_energy):
 # End functions for testing ConservativeFromPrimitive.cpp
 
 
-# Functions for testing Fluxes.cpp
-def mass_density_cons_flux(momentum_density, energy_density, velocity,
-                           pressure):
-    return momentum_density
-
-
-def momentum_density_flux(momentum_density, energy_density, velocity,
-                          pressure):
-    result = np.outer(momentum_density, velocity)
-    result += pressure * np.identity(velocity.size)
-    return result
-
-
-def energy_density_flux(momentum_density, energy_density, velocity, pressure):
-    return (energy_density + pressure) * velocity
-
-
-# End functions for testing Fluxes.cpp
-
-
 # Functions for testing PrimitiveFromConservative.cpp
 def mass_density(mass_density_cons, momentum_density, energy_density):
     return mass_density_cons
@@ -81,19 +61,3 @@ def pressure_2d(mass_density_cons, momentum_density, energy_density):
 
 
 # End functions for testing PrimitiveFromConservative.cpp
-
-
-# Functions for testing Sources.cpp
-def source_mass_density_cons(first_arg, second_arg, third_arg, fourth_arg):
-    return np.exp(first_arg)
-
-
-def source_momentum_density(first_arg, second_arg, third_arg, fourth_arg):
-    return (first_arg - 1.5 * third_arg) * second_arg
-
-
-def source_energy_density(first_arg, second_arg, third_arg, fourth_arg):
-    return np.dot(second_arg, fourth_arg) + 3.0 * third_arg
-
-
-# End functions for testing Sources.cpp

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Fluxes.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Fluxes.cpp
@@ -14,11 +14,11 @@ namespace {
 
 template <size_t Dim>
 void test_fluxes(const DataVector& used_for_size) {
-  pypp::check_with_random_values<4>(
-      &NewtonianEuler::ComputeFluxes<Dim>::apply, "TestFunctions",
-      {"mass_density_cons_flux", "momentum_density_flux",
-       "energy_density_flux"},
-      {{{-1.0, 1.0}, {-1.0, 1.0}, {-1.0, 1.0}, {-1.0, 1.0}}}, used_for_size);
+  pypp::check_with_random_values<1>(
+      &NewtonianEuler::ComputeFluxes<Dim>::apply, "TimeDerivative",
+      {"mass_density_cons_flux_impl", "momentum_density_flux_impl",
+       "energy_density_flux_impl"},
+      {{{-1.0, 1.0}}}, used_for_size);
 }
 
 }  // namespace

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Test_TimeDerivative.cpp
@@ -10,8 +10,8 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Evolution/Systems/NewtonianEuler/Sources.hpp"
 #include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "Evolution/Systems/NewtonianEuler/TimeDerivative.hpp"
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Helpers/Evolution/Systems/NewtonianEuler/TimeDerivative.hpp"
@@ -22,57 +22,67 @@ namespace {
 // We need a wrapper around the time derivative call because pypp cannot forward
 // the source terms, only Tensor<DataVector>s and doubles.
 template <typename InitialDataType, size_t Dim = InitialDataType::volume_dim>
-void wrap_sources(
-    const gsl::not_null<Scalar<DataVector>*> source_mass_density_cons,
-    const gsl::not_null<tnsr::I<DataVector, Dim>*> source_momentum_density,
-    const gsl::not_null<Scalar<DataVector>*> source_energy_density,
+void wrap_time_derivative(
+    const gsl::not_null<Scalar<DataVector>*> dt_mass_density_cons,
+    const gsl::not_null<tnsr::I<DataVector, Dim>*> dt_momentum_density,
+    const gsl::not_null<Scalar<DataVector>*> dt_energy_density,
+
+    const gsl::not_null<tnsr::I<DataVector, Dim>*> mass_density_cons_flux,
+    const gsl::not_null<tnsr::IJ<DataVector, Dim>*> momentum_density_flux,
+    const gsl::not_null<tnsr::I<DataVector, Dim>*> energy_density_flux,
+
+    const tnsr::I<DataVector, Dim>& momentum_density,
+    const Scalar<DataVector>& energy_density,
+    const tnsr::I<DataVector, Dim>& velocity,
+    const Scalar<DataVector>& pressure,
 
     const Scalar<DataVector>& first_arg,
     const tnsr::I<DataVector, Dim>& second_arg,
     const Scalar<DataVector>& third_arg,
     const tnsr::i<DataVector, Dim>& fourth_arg) noexcept {
   typename InitialDataType::source_term_type source_computer;
+  Scalar<DataVector> enthalpy_density{get(energy_density).size()};
   if constexpr (std::is_same_v<
                     TestHelpers::NewtonianEuler::TestInitialData<
                         TestHelpers::NewtonianEuler::SomeOtherSourceType<Dim>>,
                     InitialDataType>) {
-    get(*source_mass_density_cons) = -1.0;
-    NewtonianEuler::ComputeSources<InitialDataType>::apply(
-        source_momentum_density, source_energy_density, source_computer,
-        first_arg, second_arg, third_arg, fourth_arg);
-  } else {
-    NewtonianEuler::ComputeSources<InitialDataType>::apply(
-        source_mass_density_cons, source_momentum_density,
-        source_energy_density, source_computer, first_arg, second_arg,
-        third_arg, fourth_arg);
+    get(*dt_mass_density_cons) = -1.0;
   }
+  NewtonianEuler::TimeDerivative<Dim, InitialDataType>::apply(
+      dt_mass_density_cons, dt_momentum_density, dt_energy_density,
+      mass_density_cons_flux, momentum_density_flux, energy_density_flux,
+      make_not_null(&enthalpy_density), momentum_density, energy_density,
+      velocity, pressure, source_computer, first_arg, second_arg, third_arg,
+      fourth_arg);
 }
 
 template <size_t Dim>
-void test_sources(const DataVector& used_for_size) {
+void test_time_derivative(const DataVector& used_for_size) {
   pypp::check_with_random_values<1>(
-      &wrap_sources<TestHelpers::NewtonianEuler::TestInitialData<
+      &wrap_time_derivative<TestHelpers::NewtonianEuler::TestInitialData<
           TestHelpers::NewtonianEuler::SomeSourceType<Dim>>>,
       "TimeDerivative",
-      {"source_mass_density_cons_impl", "source_momentum_density_impl",
-       "source_energy_density_impl"},
+      {"source_mass_density_cons", "source_momentum_density",
+       "source_energy_density", "mass_density_cons_flux",
+       "momentum_density_flux", "energy_density_flux"},
       {{{-1.0, 1.0}}}, used_for_size);
   pypp::check_with_random_values<1>(
-      &wrap_sources<TestHelpers::NewtonianEuler::TestInitialData<
+      &wrap_time_derivative<TestHelpers::NewtonianEuler::TestInitialData<
           TestHelpers::NewtonianEuler::SomeOtherSourceType<Dim>>>,
       "TimeDerivative",
-      {"minus_one_mass_density_impl", "source_momentum_density_impl",
-       "source_energy_density_impl"},
+      {"minus_one_mass_density", "source_momentum_density",
+       "source_energy_density", "mass_density_cons_flux",
+       "momentum_density_flux", "energy_density_flux"},
       {{{-1.0, 1.0}}}, used_for_size);
 }
 
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Evolution.Systems.NewtonianEuler.Sources",
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.NewtonianEuler.TimeDerivative",
                   "[Unit][Evolution]") {
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/NewtonianEuler"};
 
   GENERATE_UNINITIALIZED_DATAVECTOR;
-  CHECK_FOR_DATAVECTORS(test_sources, (1, 2, 3))
+  CHECK_FOR_DATAVECTORS(test_time_derivative, (1, 2, 3))
 }

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/TimeDerivative.py
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/TimeDerivative.py
@@ -1,0 +1,84 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def mass_density_cons_flux_impl(momentum_density, energy_density, velocity,
+                                pressure):
+    return momentum_density
+
+
+def momentum_density_flux_impl(momentum_density, energy_density, velocity,
+                               pressure):
+    result = np.outer(momentum_density, velocity)
+    result += pressure * np.identity(velocity.size)
+    return result
+
+
+def energy_density_flux_impl(momentum_density, energy_density, velocity,
+                             pressure):
+    return (energy_density + pressure) * velocity
+
+
+def mass_density_cons_flux(momentum_density, energy_density, velocity,
+                           pressure, first_arg, second_arg, third_arg,
+                           fourth_arg):
+    return mass_density_cons_flux_impl(momentum_density, energy_density,
+                                       velocity, pressure)
+
+
+def momentum_density_flux(momentum_density, energy_density, velocity, pressure,
+                          first_arg, second_arg, third_arg, fourth_arg):
+    return momentum_density_flux_impl(momentum_density, energy_density,
+                                      velocity, pressure)
+
+
+def energy_density_flux(momentum_density, energy_density, velocity, pressure,
+                        first_arg, second_arg, third_arg, fourth_arg):
+    return energy_density_flux_impl(momentum_density, energy_density, velocity,
+                                    pressure)
+
+
+def source_mass_density_cons_impl(first_arg, second_arg, third_arg,
+                                  fourth_arg):
+    return np.exp(first_arg)
+
+
+def source_momentum_density_impl(first_arg, second_arg, third_arg, fourth_arg):
+    return (first_arg - 1.5 * third_arg) * second_arg
+
+
+def source_energy_density_impl(first_arg, second_arg, third_arg, fourth_arg):
+    return np.dot(second_arg, fourth_arg) + 3.0 * third_arg
+
+
+def minus_one_mass_density_impl(first_arg, second_arg, third_arg, fourth_arg):
+    return 0.0 * first_arg - 1.0
+
+
+def source_mass_density_cons(momentum_density, energy_density, velocity,
+                             pressure, first_arg, second_arg, third_arg,
+                             fourth_arg):
+    return source_mass_density_cons_impl(first_arg, second_arg, third_arg,
+                                         fourth_arg)
+
+
+def source_momentum_density(momentum_density, energy_density, velocity,
+                            pressure, first_arg, second_arg, third_arg,
+                            fourth_arg):
+    return source_momentum_density_impl(first_arg, second_arg, third_arg,
+                                        fourth_arg)
+
+
+def source_energy_density(momentum_density, energy_density, velocity, pressure,
+                          first_arg, second_arg, third_arg, fourth_arg):
+    return source_energy_density_impl(first_arg, second_arg, third_arg,
+                                      fourth_arg)
+
+
+def minus_one_mass_density(momentum_density, energy_density, velocity,
+                           pressure, first_arg, second_arg, third_arg,
+                           fourth_arg):
+    return minus_one_mass_density_impl(first_arg, second_arg, third_arg,
+                                       fourth_arg)

--- a/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_Characteristics.cpp
   Test_Constraints.cpp
   Test_Equations.cpp
+  Test_TimeDerivative.cpp
   Test_UpwindPenaltyCorrection.cpp
   )
 

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Equations.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Equations.cpp
@@ -35,108 +35,6 @@
 
 namespace {
 template <size_t Dim>
-auto add_scalar_to_tensor_components(
-    const tnsr::i<DataVector, Dim, Frame::Inertial>& input,
-    double constant) noexcept {
-  tnsr::i<DataVector, Dim, Frame::Inertial> copy_of_input =
-      [&input, &constant]() noexcept {
-        auto local_copy_of_input = input;
-        for (size_t i = 0; i < Dim; ++i) {
-          local_copy_of_input.get(i) += constant;
-        }
-        return local_copy_of_input;
-      }();
-  return copy_of_input;
-}
-template <size_t Dim>
-void check_du_dt(const size_t npts, const double time) {
-  ScalarWave::Solutions::PlaneWave<Dim> solution(
-      make_array<Dim>(0.1), make_array<Dim>(0.0),
-      std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(1.0, 1.0,
-                                                                    0.0));
-
-  tnsr::I<DataVector, Dim> x = [npts]() {
-    auto logical_coords = logical_coordinates(Mesh<Dim>{
-        3, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto});
-    tnsr::I<DataVector, Dim> coords{pow<Dim>(npts)};
-    for (size_t i = 0; i < Dim; ++i) {
-      coords.get(i) = std::move(logical_coords.get(i));
-    }
-    return coords;
-  }();
-
-  auto local_check_du_dt = [&npts, &time, &solution, &x](
-                               const double gamma2,
-                               const double constraint) {
-    auto box = db::create<db::AddSimpleTags<
-        ScalarWave::Tags::ConstraintGamma2, Tags::dt<ScalarWave::Pi>,
-        Tags::dt<ScalarWave::Phi<Dim>>, Tags::dt<ScalarWave::Psi>,
-        ScalarWave::Pi, ScalarWave::Phi<Dim>,
-        Tags::deriv<ScalarWave::Pi, tmpl::size_t<Dim>, Frame::Inertial>,
-        Tags::deriv<ScalarWave::Psi, tmpl::size_t<Dim>, Frame::Inertial>,
-        Tags::deriv<ScalarWave::Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>>>(
-        Scalar<DataVector>(pow<Dim>(npts), gamma2),
-        Scalar<DataVector>(pow<Dim>(npts), 0.0),
-        tnsr::i<DataVector, Dim, Frame::Inertial>(pow<Dim>(npts), 0.0),
-        Scalar<DataVector>(pow<Dim>(npts), 0.0),
-        Scalar<DataVector>(-1.0 * solution.dpsi_dt(x, time).get()),
-        add_scalar_to_tensor_components(solution.dpsi_dx(x, time),
-                                        constraint),
-        [&x, &time, &solution ]() noexcept {
-          auto dpi_dx = solution.d2psi_dtdx(x, time);
-          for (size_t i = 0; i < Dim; ++i) {
-            dpi_dx.get(i) *= -1.0;
-          }
-          return dpi_dx;
-        }(),
-        solution.dpsi_dx(x, time), [&npts, &x, &time, &solution ]() noexcept {
-          tnsr::ij<DataVector, Dim, Frame::Inertial> d2psi_dxdx{pow<Dim>(npts),
-                                                                0.0};
-          const tnsr::ii<DataVector, Dim, Frame::Inertial> ddpsi_soln =
-              solution.d2psi_dxdx(x, time);
-          for (size_t i = 0; i < Dim; ++i) {
-            for (size_t j = 0; j < Dim; ++j) {
-              d2psi_dxdx.get(i, j) = ddpsi_soln.get(i, j);
-            }
-          }
-          return d2psi_dxdx;
-        }());
-
-    db::mutate_apply<
-        tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
-                   Tags::dt<ScalarWave::Psi>>,
-        typename ScalarWave::ComputeDuDt<Dim>::argument_tags>(
-        ScalarWave::ComputeDuDt<Dim>{}, make_not_null(&box));
-
-    CHECK_ITERABLE_APPROX(
-        db::get<Tags::dt<ScalarWave::Pi>>(box),
-        Scalar<DataVector>(-1.0 * solution.d2psi_dt2(x, time).get()));
-    CHECK_ITERABLE_APPROX(
-        db::get<Tags::dt<ScalarWave::Phi<Dim>>>(box),
-        add_scalar_to_tensor_components(solution.d2psi_dtdx(x, time),
-                                        -gamma2 * constraint));
-    CHECK_ITERABLE_APPROX(db::get<Tags::dt<ScalarWave::Psi>>(box),
-                          solution.dpsi_dt(x, time));
-  };
-
-  // Test with constraint damping parameter set to zero
-  local_check_du_dt(0.0, 0.0);
-  local_check_du_dt(0.0, 100.0);
-  local_check_du_dt(0.0, -998.0);
-
-  // Test with constraint satisfied but nonzero constraint damping parameter
-  local_check_du_dt(10.0, 0.0);
-  local_check_du_dt(-4.3, 0.0);
-
-  // Test with one-index constraint NOT satisfied and nonzero constraint
-  // damping parameter
-  local_check_du_dt(10.0, 10.9);
-  local_check_du_dt(1.2, -77.0);
-  local_check_du_dt(-10.9, 43.0);
-  local_check_du_dt(-90.0, -56.0);
-}
-
-template <size_t Dim>
 void check_normal_dot_fluxes(const size_t npts, const double t) {
   const ScalarWave::Solutions::PlaneWave<Dim> solution(
       make_array<Dim>(0.1), make_array<Dim>(0.0),
@@ -183,21 +81,13 @@ void check_normal_dot_fluxes(const size_t npts, const double t) {
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave", "[Unit][Evolution]") {
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave.NormalDotFluxes",
+                  "[Unit][Evolution]") {
   constexpr double time = 0.7;
-  {
-    INFO("Check ComputeDuDt");
-    check_du_dt<1>(3, time);
-    check_du_dt<2>(3, time);
-    check_du_dt<3>(3, time);
-  }
-
-  {
-    INFO("Check NormalDotFluxes");
-    check_normal_dot_fluxes<1>(3, time);
-    check_normal_dot_fluxes<2>(3, time);
-    check_normal_dot_fluxes<3>(3, time);
-  }
+  INFO("Check NormalDotFluxes");
+  check_normal_dot_fluxes<1>(3, time);
+  check_normal_dot_fluxes<2>(3, time);
+  check_normal_dot_fluxes<3>(3, time);
 }
 
 static_assert(1.0 == ScalarWave::ComputeLargestCharacteristicSpeed::apply(),

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_TimeDerivative.cpp
@@ -1,0 +1,147 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <memory>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "Evolution/Systems/ScalarWave/TimeDerivative.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"
+#include "PointwiseFunctions/MathFunctions/Gaussian.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+template <size_t Dim>
+auto add_scalar_to_tensor_components(
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& input,
+    double constant) noexcept {
+  tnsr::i<DataVector, Dim, Frame::Inertial> copy_of_input =
+      [&input, &constant]() noexcept {
+        auto local_copy_of_input = input;
+        for (size_t i = 0; i < Dim; ++i) {
+          local_copy_of_input.get(i) += constant;
+        }
+        return local_copy_of_input;
+      }();
+  return copy_of_input;
+}
+template <size_t Dim>
+void check_du_dt(const size_t npts, const double time) {
+  ScalarWave::Solutions::PlaneWave<Dim> solution(
+      make_array<Dim>(0.1), make_array<Dim>(0.0),
+      std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(1.0, 1.0,
+                                                                    0.0));
+
+  tnsr::I<DataVector, Dim> x = [npts]() {
+    auto logical_coords = logical_coordinates(Mesh<Dim>{
+        3, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto});
+    tnsr::I<DataVector, Dim> coords{pow<Dim>(npts)};
+    for (size_t i = 0; i < Dim; ++i) {
+      coords.get(i) = std::move(logical_coords.get(i));
+    }
+    return coords;
+  }();
+
+  auto local_check_du_dt = [&npts, &time, &solution, &x](
+                               const double gamma2, const double constraint) {
+    auto box = db::create<db::AddSimpleTags<
+        ScalarWave::Tags::ConstraintGamma2, Tags::dt<ScalarWave::Pi>,
+        Tags::dt<ScalarWave::Phi<Dim>>, Tags::dt<ScalarWave::Psi>,
+        ScalarWave::Pi, ScalarWave::Phi<Dim>,
+        Tags::deriv<ScalarWave::Pi, tmpl::size_t<Dim>, Frame::Inertial>,
+        Tags::deriv<ScalarWave::Psi, tmpl::size_t<Dim>, Frame::Inertial>,
+        Tags::deriv<ScalarWave::Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>>>(
+        Scalar<DataVector>(pow<Dim>(npts), gamma2),
+        Scalar<DataVector>(pow<Dim>(npts), 0.0),
+        tnsr::i<DataVector, Dim, Frame::Inertial>(pow<Dim>(npts), 0.0),
+        Scalar<DataVector>(pow<Dim>(npts), 0.0),
+        Scalar<DataVector>(-1.0 * solution.dpsi_dt(x, time).get()),
+        add_scalar_to_tensor_components(solution.dpsi_dx(x, time), constraint),
+        [&x, &time, &solution]() noexcept {
+          auto dpi_dx = solution.d2psi_dtdx(x, time);
+          for (size_t i = 0; i < Dim; ++i) {
+            dpi_dx.get(i) *= -1.0;
+          }
+          return dpi_dx;
+        }(),
+        solution.dpsi_dx(x, time),
+        [&npts, &x, &time, &solution]() noexcept {
+          tnsr::ij<DataVector, Dim, Frame::Inertial> d2psi_dxdx{pow<Dim>(npts),
+                                                                0.0};
+          const tnsr::ii<DataVector, Dim, Frame::Inertial> ddpsi_soln =
+              solution.d2psi_dxdx(x, time);
+          for (size_t i = 0; i < Dim; ++i) {
+            for (size_t j = 0; j < Dim; ++j) {
+              d2psi_dxdx.get(i, j) = ddpsi_soln.get(i, j);
+            }
+          }
+          return d2psi_dxdx;
+        }());
+
+    db::mutate_apply<
+        tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
+                   Tags::dt<ScalarWave::Psi>>,
+        tmpl::push_front<
+            typename ScalarWave::TimeDerivative<Dim>::argument_tags,
+            Tags::deriv<ScalarWave::Pi, tmpl::size_t<Dim>, Frame::Inertial>,
+            Tags::deriv<ScalarWave::Phi<Dim>, tmpl::size_t<Dim>,
+                        Frame::Inertial>,
+            Tags::deriv<ScalarWave::Psi, tmpl::size_t<Dim>, Frame::Inertial>>>(
+        ScalarWave::TimeDerivative<Dim>{}, make_not_null(&box));
+
+    CHECK_ITERABLE_APPROX(
+        db::get<Tags::dt<ScalarWave::Pi>>(box),
+        Scalar<DataVector>(-1.0 * solution.d2psi_dt2(x, time).get()));
+    CHECK_ITERABLE_APPROX(
+        db::get<Tags::dt<ScalarWave::Phi<Dim>>>(box),
+        add_scalar_to_tensor_components(solution.d2psi_dtdx(x, time),
+                                        -gamma2 * constraint));
+    CHECK_ITERABLE_APPROX(db::get<Tags::dt<ScalarWave::Psi>>(box),
+                          solution.dpsi_dt(x, time));
+  };
+
+  // Test with constraint damping parameter set to zero
+  local_check_du_dt(0.0, 0.0);
+  local_check_du_dt(0.0, 100.0);
+  local_check_du_dt(0.0, -998.0);
+
+  // Test with constraint satisfied but nonzero constraint damping parameter
+  local_check_du_dt(10.0, 0.0);
+  local_check_du_dt(-4.3, 0.0);
+
+  // Test with one-index constraint NOT satisfied and nonzero constraint
+  // damping parameter
+  local_check_du_dt(10.0, 10.9);
+  local_check_du_dt(1.2, -77.0);
+  local_check_du_dt(-10.9, 43.0);
+  local_check_du_dt(-90.0, -56.0);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave.TimeDerivative",
+                  "[Unit][Evolution]") {
+  constexpr double time = 0.7;
+  check_du_dt<1>(3, time);
+  check_du_dt<2>(3, time);
+  check_du_dt<3>(3, time);
+}

--- a/tests/Unit/Helpers/Evolution/Systems/NewtonianEuler/TimeDerivative.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/NewtonianEuler/TimeDerivative.hpp
@@ -1,0 +1,97 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace TestHelpers::NewtonianEuler {
+struct FirstArg : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct SecondArg : db::SimpleTag {
+  using type = tnsr::I<DataVector, Dim>;
+};
+
+struct ThirdArg : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct FourthArg : db::SimpleTag {
+  using type = tnsr::i<DataVector, Dim>;
+};
+
+// Some source term where all three conservative quantities are sourced.
+template <size_t Dim>
+struct SomeSourceType {
+  static constexpr size_t volume_dim = Dim;
+  using sourced_variables =
+      tmpl::list<::NewtonianEuler::Tags::MassDensityCons,
+                 ::NewtonianEuler::Tags::MomentumDensity<Dim>,
+                 ::NewtonianEuler::Tags::EnergyDensity>;
+
+  using argument_tags =
+      tmpl::list<FirstArg, SecondArg<Dim>, ThirdArg, FourthArg<Dim>>;
+
+  void apply(
+      const gsl::not_null<Scalar<DataVector>*> source_mass_density_cons,
+      const gsl::not_null<tnsr::I<DataVector, Dim>*> source_momentum_density,
+      const gsl::not_null<Scalar<DataVector>*> source_energy_density,
+      const Scalar<DataVector>& first_arg,
+      const tnsr::I<DataVector, Dim>& second_arg,
+      const Scalar<DataVector>& third_arg,
+      const tnsr::i<DataVector, Dim>& fourth_arg) const noexcept {
+    get(*source_mass_density_cons) = exp(get(first_arg));
+    for (size_t i = 0; i < Dim; ++i) {
+      source_momentum_density->get(i) =
+          (get(first_arg) - 1.5 * get(third_arg)) * second_arg.get(i);
+    }
+    get(*source_energy_density) =
+        get(dot_product(second_arg, fourth_arg)) + 3.0 * get(third_arg);
+  }
+};
+
+// Some other source term where the mass density is not sourced (this is by
+// far the most common type of non-trivial source term for NewtonianEuler.)
+template <size_t Dim>
+struct SomeOtherSourceType {
+  static constexpr size_t volume_dim = Dim;
+  using sourced_variables =
+      tmpl::list<::NewtonianEuler::Tags::MomentumDensity<Dim>,
+                 ::NewtonianEuler::Tags::EnergyDensity>;
+
+  using argument_tags =
+      tmpl::list<FirstArg, SecondArg<Dim>, ThirdArg, FourthArg<Dim>>;
+
+  void apply(
+      const gsl::not_null<tnsr::I<DataVector, Dim>*> source_momentum_density,
+      const gsl::not_null<Scalar<DataVector>*> source_energy_density,
+      const Scalar<DataVector>& first_arg,
+      const tnsr::I<DataVector, Dim>& second_arg,
+      const Scalar<DataVector>& third_arg,
+      const tnsr::i<DataVector, Dim>& fourth_arg) const noexcept {
+    for (size_t i = 0; i < Dim; ++i) {
+      source_momentum_density->get(i) =
+          (get(first_arg) - 1.5 * get(third_arg)) * second_arg.get(i);
+    }
+    get(*source_energy_density) =
+        get(dot_product(second_arg, fourth_arg)) + 3.0 * get(third_arg);
+  }
+};
+
+template <typename SourceTermType>
+struct TestInitialData {
+  static constexpr size_t volume_dim = SourceTermType::volume_dim;
+  using source_term_type = SourceTermType;
+};
+}  // namespace TestHelpers::NewtonianEuler


### PR DESCRIPTION
## Proposed changes

- Support base tags for internal directions. This is also added in #474 but I'm not sure what that's waiting on.
- Add new DG time derivative action that combines `ComputeVolumeFluxes`, `ComputeVolumeSources`, `ComputeTimeDerivative`, `AddMeshVelocitySourceTerms`, `AddMeshVelocityNonconservative`, `ComputeNonconservativeBoundaryFluxes` (partly), and `CollectDataForFluxes` (partly). The switching between what to do is handled locally inside the action, temporaries are computed inside the time derivative action which means in the future we can eliminate basically all compute tags, and the divergence of the fluxes is also computed inside the action (used to be done as compute tags). This is the first major step towards having:
  - Correct boundary conditions
  - Bjorhus boundary conditions
  - Specifying the boundary condition in the input file
  - Supporting both the weak and strong form
  - Supporting both Gauss and Gauss-Lobatto points
  - Support ADER-DG
- Convert Burgers to the new time derivative action
- Convert Newtonian Euler to the new time derivative action
- Convert Scalar Wave to the new time derivative action

I have the rest of the evolution systems also converted, but I figured a 2500 line diff is better than a 5k line diff :) Once this is reviewed and merged I'll rebase and update the other changes with whatever feedback I get here and submit them as a followup PR.

Some notes of possible interest:
- I do not remove the `ComputeVolumeFluxes` and `ComputeVolumeSources` actions since I'm hoping these could be reused or adjusted for finite difference where the fluxes and source terms are genuinely on different grids
- Having fewer to no compute items means DG-subcell will be significantly easier to implement (and more efficient)
- DG-subcell is also much easier to deal with when using ADER time stepping since there isn't a huge history like there is with RK or AB time steppers.
- I currently error in weak form and gauss points since I wanted to keep this PR "small"

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
