### PR TITLE
Add computation of det Jac times inverse Jacobian

### DIFF
--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   Formulation.cpp
+  MetricIdentityJacobian.cpp
   MortarHelpers.cpp
   )
 
@@ -18,6 +19,7 @@ spectre_target_headers(
   HEADERS
   Formulation.hpp
   LiftFlux.hpp
+  MetricIdentityJacobian.hpp
   MortarHelpers.hpp
   NormalDotFlux.hpp
   Protocols.hpp

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/MetricIdentityJacobian.cpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/MetricIdentityJacobian.cpp
@@ -1,0 +1,225 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/DiscontinuousGalerkin/MetricIdentityJacobian.hpp"
+
+#include <array>
+#include <cstddef>
+#include <functional>
+
+#include "DataStructures/ApplyMatrices.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace dg {
+template <size_t Dim>
+void metric_identity_jacobian(
+    const gsl::not_null<
+        InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>*>
+        det_jac_times_inverse_jacobian,
+    const Mesh<Dim>& mesh,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords,
+    const Jacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>&
+        jacobian) noexcept {
+  destructive_resize_components(det_jac_times_inverse_jacobian,
+                                mesh.number_of_grid_points());
+  if constexpr (Dim == 1) {
+    (void)jacobian;
+    get<0, 0>(*det_jac_times_inverse_jacobian) = 1.0;
+  } else if constexpr (Dim == 2) {
+    (void)jacobian;
+    const Mesh<1>& mesh0 = mesh.slice_through(0);
+    const Mesh<1>& mesh1 = mesh.slice_through(1);
+    const Matrix identity{};
+    auto diff_matrices = make_array<Dim>(std::cref(identity));
+
+    diff_matrices[1] = Spectral::differentiation_matrix(mesh1);
+    apply_matrices(make_not_null(&get<0, 0>(*det_jac_times_inverse_jacobian)),
+                   diff_matrices, get<1>(inertial_coords), mesh.extents());
+
+    apply_matrices(make_not_null(&get<0, 1>(*det_jac_times_inverse_jacobian)),
+                   diff_matrices, get<0>(inertial_coords), mesh.extents());
+    get<0, 1>(*det_jac_times_inverse_jacobian) *= -1.0;
+
+    diff_matrices[1] = std::cref(identity);
+    diff_matrices[0] = Spectral::differentiation_matrix(mesh0);
+    apply_matrices(make_not_null(&get<1, 0>(*det_jac_times_inverse_jacobian)),
+                   diff_matrices, get<1>(inertial_coords), mesh.extents());
+    get<1, 0>(*det_jac_times_inverse_jacobian) *= -1.0;
+
+    apply_matrices(make_not_null(&get<1, 1>(*det_jac_times_inverse_jacobian)),
+                   diff_matrices, get<0>(inertial_coords), mesh.extents());
+  } else {
+    static_assert(Dim == 3,
+                  "The metric identity-satisfying Jacobian is only implemented "
+                  "in 1d, 2d, and 3d.");
+    const Mesh<1>& mesh0 = mesh.slice_through(0);
+    const Mesh<1>& mesh1 = mesh.slice_through(1);
+    const Mesh<1>& mesh2 = mesh.slice_through(2);
+    const Matrix identity{};
+    auto diff_matrices = make_array<Dim>(std::cref(identity));
+
+    DataVector buffer(mesh.number_of_grid_points());
+    DataVector buffer_component(mesh.number_of_grid_points());
+
+    // Note that we will multiply everything by 0.5 once we have all terms
+    // contributing to each component computed.
+
+    // Compute all terms with logical derivatives in xi direction
+    diff_matrices[0] = Spectral::differentiation_matrix(mesh0);
+    buffer = get<2>(inertial_coords) * get<1, 2>(jacobian) -
+             get<1>(inertial_coords) * get<2, 2>(jacobian);
+    apply_matrices(make_not_null(&get<1, 0>(*det_jac_times_inverse_jacobian)),
+                   diff_matrices, buffer, mesh.extents());
+
+    buffer = get<1>(inertial_coords) * get<2, 1>(jacobian) -
+             get<2>(inertial_coords) * get<1, 1>(jacobian);
+    apply_matrices(make_not_null(&get<2, 0>(*det_jac_times_inverse_jacobian)),
+                   diff_matrices, buffer, mesh.extents());
+
+    buffer = get<0>(inertial_coords) * get<2, 2>(jacobian) -
+             get<2>(inertial_coords) * get<0, 2>(jacobian);
+    apply_matrices(make_not_null(&get<1, 1>(*det_jac_times_inverse_jacobian)),
+                   diff_matrices, buffer, mesh.extents());
+
+    buffer = get<2>(inertial_coords) * get<0, 1>(jacobian) -
+             get<0>(inertial_coords) * get<2, 1>(jacobian);
+    apply_matrices(make_not_null(&get<2, 1>(*det_jac_times_inverse_jacobian)),
+                   diff_matrices, buffer, mesh.extents());
+
+    buffer = get<1>(inertial_coords) * get<0, 2>(jacobian) -
+             get<0>(inertial_coords) * get<1, 2>(jacobian);
+    apply_matrices(make_not_null(&get<1, 2>(*det_jac_times_inverse_jacobian)),
+                   diff_matrices, buffer, mesh.extents());
+
+    buffer = get<0>(inertial_coords) * get<1, 1>(jacobian) -
+             get<1>(inertial_coords) * get<0, 1>(jacobian);
+    apply_matrices(make_not_null(&get<2, 2>(*det_jac_times_inverse_jacobian)),
+                   diff_matrices, buffer, mesh.extents());
+
+    // Compute all terms with logical derivatives in eta direction
+    diff_matrices[0] = identity;
+    diff_matrices[1] = Spectral::differentiation_matrix(mesh1);
+
+    // First do terms where the derivative can be directly written into the
+    // output buffer.
+    buffer = get<1>(inertial_coords) * get<2, 2>(jacobian) -
+             get<2>(inertial_coords) * get<1, 2>(jacobian);
+    apply_matrices(make_not_null(&get<0, 0>(*det_jac_times_inverse_jacobian)),
+                   diff_matrices, buffer, mesh.extents());
+
+    buffer = get<2>(inertial_coords) * get<0, 2>(jacobian) -
+             get<0>(inertial_coords) * get<2, 2>(jacobian);
+    apply_matrices(make_not_null(&get<0, 1>(*det_jac_times_inverse_jacobian)),
+                   diff_matrices, buffer, mesh.extents());
+
+    buffer = get<0>(inertial_coords) * get<1, 2>(jacobian) -
+             get<1>(inertial_coords) * get<0, 2>(jacobian);
+    apply_matrices(make_not_null(&get<0, 2>(*det_jac_times_inverse_jacobian)),
+                   diff_matrices, buffer, mesh.extents());
+
+    // Now do terms that need to be added to existing output.
+    // These we can multiply by 0.5
+    buffer = get<2>(inertial_coords) * get<1, 0>(jacobian) -
+             get<1>(inertial_coords) * get<2, 0>(jacobian);
+    apply_matrices(make_not_null(&buffer_component), diff_matrices, buffer,
+                   mesh.extents());
+    get<2, 0>(*det_jac_times_inverse_jacobian) += buffer_component;
+    get<2, 0>(*det_jac_times_inverse_jacobian) *= 0.5;
+
+    buffer = get<0>(inertial_coords) * get<2, 0>(jacobian) -
+             get<2>(inertial_coords) * get<0, 0>(jacobian);
+    apply_matrices(make_not_null(&buffer_component), diff_matrices, buffer,
+                   mesh.extents());
+    get<2, 1>(*det_jac_times_inverse_jacobian) += buffer_component;
+    get<2, 1>(*det_jac_times_inverse_jacobian) *= 0.5;
+
+    buffer = get<1>(inertial_coords) * get<0, 0>(jacobian) -
+             get<0>(inertial_coords) * get<1, 0>(jacobian);
+    apply_matrices(make_not_null(&buffer_component), diff_matrices, buffer,
+                   mesh.extents());
+    get<2, 2>(*det_jac_times_inverse_jacobian) += buffer_component;
+    get<2, 2>(*det_jac_times_inverse_jacobian) *= 0.5;
+
+    // Compute all terms with logical derivatives in eta direction
+    diff_matrices[1] = identity;
+    diff_matrices[2] = Spectral::differentiation_matrix(mesh2);
+
+    // All terms need to be added to existing output.
+    // These we multiply by 0.5
+    buffer = get<2>(inertial_coords) * get<1, 1>(jacobian) -
+             get<1>(inertial_coords) * get<2, 1>(jacobian);
+    apply_matrices(make_not_null(&buffer_component), diff_matrices, buffer,
+                   mesh.extents());
+    get<0, 0>(*det_jac_times_inverse_jacobian) += buffer_component;
+    get<0, 0>(*det_jac_times_inverse_jacobian) *= 0.5;
+
+    buffer = get<1>(inertial_coords) * get<2, 0>(jacobian) -
+             get<2>(inertial_coords) * get<1, 0>(jacobian);
+    apply_matrices(make_not_null(&buffer_component), diff_matrices, buffer,
+                   mesh.extents());
+    get<1, 0>(*det_jac_times_inverse_jacobian) += buffer_component;
+    get<1, 0>(*det_jac_times_inverse_jacobian) *= 0.5;
+
+    buffer = get<0>(inertial_coords) * get<2, 1>(jacobian) -
+             get<2>(inertial_coords) * get<0, 1>(jacobian);
+    apply_matrices(make_not_null(&buffer_component), diff_matrices, buffer,
+                   mesh.extents());
+    get<0, 1>(*det_jac_times_inverse_jacobian) += buffer_component;
+    get<0, 1>(*det_jac_times_inverse_jacobian) *= 0.5;
+
+    buffer = get<2>(inertial_coords) * get<0, 0>(jacobian) -
+             get<0>(inertial_coords) * get<2, 0>(jacobian);
+    apply_matrices(make_not_null(&buffer_component), diff_matrices, buffer,
+                   mesh.extents());
+    get<1, 1>(*det_jac_times_inverse_jacobian) += buffer_component;
+    get<1, 1>(*det_jac_times_inverse_jacobian) *= 0.5;
+
+    buffer = get<1>(inertial_coords) * get<0, 1>(jacobian) -
+             get<0>(inertial_coords) * get<1, 1>(jacobian);
+    apply_matrices(make_not_null(&buffer_component), diff_matrices, buffer,
+                   mesh.extents());
+    get<0, 2>(*det_jac_times_inverse_jacobian) += buffer_component;
+    get<0, 2>(*det_jac_times_inverse_jacobian) *= 0.5;
+
+    buffer = get<0>(inertial_coords) * get<1, 0>(jacobian) -
+             get<1>(inertial_coords) * get<0, 0>(jacobian);
+    apply_matrices(make_not_null(&buffer_component), diff_matrices, buffer,
+                   mesh.extents());
+    get<1, 2>(*det_jac_times_inverse_jacobian) += buffer_component;
+    get<1, 2>(*det_jac_times_inverse_jacobian) *= 0.5;
+  }
+}
+
+template void metric_identity_jacobian(
+    gsl::not_null<
+        InverseJacobian<DataVector, 1, Frame::Logical, Frame::Inertial>*>
+        det_jac_times_inverse_jacobian,
+    const Mesh<1>& mesh,
+    const tnsr::I<DataVector, 1, Frame::Inertial>& inertial_coords,
+    const Jacobian<DataVector, 1, Frame::Logical, Frame::Inertial>&
+        jacobian) noexcept;
+template void metric_identity_jacobian(
+    gsl::not_null<
+        InverseJacobian<DataVector, 2, Frame::Logical, Frame::Inertial>*>
+        det_jac_times_inverse_jacobian,
+    const Mesh<2>& mesh,
+    const tnsr::I<DataVector, 2, Frame::Inertial>& inertial_coords,
+    const Jacobian<DataVector, 2, Frame::Logical, Frame::Inertial>&
+        jacobian) noexcept;
+template void metric_identity_jacobian(
+    gsl::not_null<
+        InverseJacobian<DataVector, 3, Frame::Logical, Frame::Inertial>*>
+        det_jac_times_inverse_jacobian,
+    const Mesh<3>& mesh,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_coords,
+    const Jacobian<DataVector, 3, Frame::Logical, Frame::Inertial>&
+        jacobian) noexcept;
+}  // namespace dg

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/MetricIdentityJacobian.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/MetricIdentityJacobian.hpp
@@ -1,0 +1,186 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+/// \cond
+class DataVector;
+template <size_t Dim>
+class Mesh;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace dg {
+/*!
+ * \ingroup DiscontinuousGalerkinGroup
+ * \brief Compute the Jacobian determinant times the inverse Jacobian so that
+ * the result is divergence-free.
+ *
+ * The metric identities are given by
+ *
+ * \f{align*}{
+ *
+ * \partial_{\hat{\imath}}\left(J\frac{\partial\xi^{\hat{\imath}}}
+ * {\partial x^i}\right)=0.
+ *
+ * \f}
+ *
+ * We want to compute \f$J\partial\xi^{\hat{\imath}}/\partial x^i\f$ in such a
+ * way that the above metric identity is satisfied numerically/discretely. We
+ * refer to the inverse Jacobian computed this way as the "metric
+ * indentity-satisfying inverse Jacobian".
+ *
+ * The discretized form, with the Jacobian determinant \f$J\f$ expanded, is
+ * given by
+ *
+ * \f{align*}{
+ *
+ * 2\left(J\frac{\partial \xi^{\hat{\imath}}}{\partial x^i}\right)_{s}
+ *  &=\epsilon_{ijk}
+ *    \sum_{t_{\hat{1}}} \epsilon^{\hat{\imath}\hat{1}\hat{k}}
+ *    D^{(\hat{1})}_{s t_1}
+ *    \left(x^j\frac{\partial x^k}{\partial \xi^{\hat{k}}}\right)_{t}
+ *    \notag \\
+ *  &+\epsilon_{ijk}
+ *    \sum_{t_{\hat{2}}} \epsilon^{\hat{\imath}\hat{2}\hat{k}}
+ *    D^{(\hat{2})}_{st_2}
+ *    \left(x^j\frac{\partial x^k}{\partial \xi^{\hat{k}}}\right)_{t}
+ *    \notag \\
+ *  &+\epsilon_{ijk}
+ *    \sum_{t_{\hat{3}}}\epsilon^{\hat{\imath}\hat{3}\hat{k}}
+ *    D^{(\hat{3})}_{st_3}
+ *    \left(x^j\frac{\partial x^k}{\partial \xi^{\hat{k}}}\right)_{t}.
+ *
+ * \f}
+ *
+ * where indices \f$s,t,t_1,t_2\f$ and \f$t_3\f$ are over grid points. \f$t_i\f$
+ * are the grid points in the particular logical direction.
+ *
+ * In 1d we have:
+ *
+ * \f{align*}{
+ *
+ * J\frac{\partial \xi^{\hat{\imath}}}{\partial x^i}=
+ * = J\frac{\partial \xi^{\hat{i}}}{\partial x^i} = 1
+ *
+ * \f}
+ *
+ * In 2d we have:
+ *
+ * \f{align*}{
+ *
+ *  J\frac{\partial \xi^{\hat{1}}}{\partial x^1}&=D^{\hat{(2)}}x^2 &
+ *  J\frac{\partial \xi^{\hat{2}}}{\partial x^1}&=-D^{\hat{(1)}}x^2 \\
+ *  J\frac{\partial \xi^{\hat{1}}}{\partial x^2}&=-D^{\hat{(2)}}x^1 &
+ *  J\frac{\partial \xi^{\hat{2}}}{\partial x^2}&=D^{\hat{(1)}}x^1 \\
+ *
+ * \f}
+ *
+ * In 3d we have:
+ *
+ * \f{align*}{
+ *
+ * 2J\frac{\partial \xi^{\hat{1}}}{\partial x^1}&=
+ * D^{(\hat{2})}\left(x^2\frac{\partial x^3}{\partial \xi^{\hat{3}}}\right)
+ * -D^{(\hat{2})}\left(x^3\frac{\partial x^2}{\partial \xi^{\hat{3}}}\right)
+ * +D^{(\hat{3})}\left(x^3\frac{\partial x^2}{\partial \xi^{\hat{2}}}\right)
+ * -D^{(\hat{3})}\left(x^2\frac{\partial x^3}{\partial \xi^{\hat{2}}}\right)\\
+ * 2J\frac{\partial \xi^{\hat{2}}}{\partial x^1}&=
+ * D^{(\hat{1})}\left(x^3\frac{\partial x^2}{\partial\xi^{\hat{3}}}\right)
+ * -D^{(\hat{1})}\left(x^2\frac{\partial x^3}{\partial\xi^{\hat{3}}}\right)
+ * +D^{(\hat{3})}\left(x^2\frac{\partial x^3}{\partial\xi^{\hat{1}}}\right)
+ * -D^{(\hat{3})}\left(x^3\frac{\partial x^2}{\partial\xi^{\hat{1}}}\right) \\
+ * 2J\frac{\partial \xi^{\hat{3}}}{\partial x^1}&=
+ * D^{(\hat{1})}\left(x^2\frac{\partial x^3}{\partial\xi^{\hat{2}}}\right)
+ * -D^{(\hat{1})}\left(x^3\frac{\partial x^2}{\partial\xi^{\hat{2}}}\right)
+ * +D^{(\hat{2})}\left(x^3\frac{\partial x^2}{\partial\xi^{\hat{1}}}\right)
+ * -D^{(\hat{2})}\left(x^2\frac{\partial x^3}{\partial\xi^{\hat{1}}}\right)\\
+ * 2J\frac{\partial \xi^{\hat{1}}}{\partial x^2}&=
+ * D^{(\hat{2})}\left(x^3\frac{\partial x^1}{\partial \xi^{\hat{3}}}\right)
+ * -D^{(\hat{2})}\left(x^1\frac{\partial x^3}{\partial \xi^{\hat{3}}}\right)
+ * +D^{(\hat{3})}\left(x^1\frac{\partial x^3}{\partial \xi^{\hat{2}}}\right)
+ * -D^{(\hat{3})}\left(x^3\frac{\partial x^1}{\partial \xi^{\hat{2}}}\right) \\
+ * 2J\frac{\partial \xi^{\hat{2}}}{\partial x^2}&=
+ * D^{(\hat{1})}\left(x^1\frac{\partial x^3}{\partial \xi^{\hat{3}}}\right)
+ * -D^{(\hat{1})}\left(x^3\frac{\partial x^1}{\partial \xi^{\hat{3}}}\right)
+ * +D^{(\hat{3})}\left(x^3\frac{\partial x^1}{\partial \xi^{\hat{1}}}\right)
+ * -D^{(\hat{3})}\left(x^1\frac{\partial x^3}{\partial \xi^{\hat{1}}}\right)\\
+ * 2J\frac{\partial \xi^{\hat{3}}}{\partial x^2}&=
+ * D^{(\hat{1})}\left(x^3\frac{\partial x^1}{\partial \xi^{\hat{2}}}\right)
+ * -D^{(\hat{1})}\left(x^1\frac{\partial x^3}{\partial \xi^{\hat{2}}}\right)
+ * +D^{(\hat{2})}\left(x^1\frac{\partial x^3}{\partial \xi^{\hat{1}}}\right)
+ * -D^{(\hat{2})}\left(x^3\frac{\partial x^1}{\partial \xi^{\hat{1}}}\right) \\
+ * 2J\frac{\partial \xi^{\hat{1}}}{\partial x^3}&=
+ * D^{(\hat{2})}\left(x^1\frac{\partial x^2}{\partial \xi^{\hat{3}}}\right)
+ * -D^{(\hat{2})}\left(x^2\frac{\partial x^1}{\partial \xi^{\hat{3}}}\right)
+ * +D^{(\hat{3})}\left(x^2\frac{\partial x^1}{\partial \xi^{\hat{2}}}\right)
+ * -D^{(\hat{3})}\left(x^1\frac{\partial x^2}{\partial \xi^{\hat{2}}}\right) \\
+ * 2J\frac{\partial \xi^{\hat{2}}}{\partial x^3}&=
+ * D^{(\hat{1})}\left(x^2\frac{\partial x^1}{\partial \xi^{\hat{3}}}\right)
+ * -D^{(\hat{1})}\left(x^1\frac{\partial x^2}{\partial \xi^{\hat{3}}}\right)
+ * +D^{(\hat{3})}\left(x^1\frac{\partial x^2}{\partial \xi^{\hat{1}}}\right)
+ * -D^{(\hat{3})}\left(x^2\frac{\partial x^1}{\partial \xi^{\hat{1}}}\right) \\
+ * 2J\frac{\partial \xi^{\hat{3}}}{\partial x^3}&=
+ * D^{(\hat{1})}\left(x^1\frac{\partial x^2}{\partial \xi^{\hat{2}}}\right)
+ * -D^{(\hat{1})}\left(x^2\frac{\partial x^1}{\partial \xi^{\hat{2}}}\right)
+ * +D^{(\hat{2})}\left(x^2\frac{\partial x^1}{\partial \xi^{\hat{1}}}\right)
+ * -D^{(\hat{2})}\left(x^1\frac{\partial x^2}{\partial \xi^{\hat{1}}}\right)
+ *
+ * \f}
+ *
+ * Again, this ensures that the metric identities are satisfied discretely. That
+ * is,
+ *
+ * \f{align*}{
+ *
+ * \partial_{\hat{\imath}}\left(J\frac{\partial\xi^{\hat{\imath}}}
+ * {\partial x^i}\right)=0
+ *
+ * \f}
+ *
+ * numerically.
+ *
+ * The reason for calculating \f$J\partial\xi^{\hat{\imath}}/\partial x^i\f$ in
+ * this manner is because in the weak form of DG (and most spectral-type methods
+ * can be recast as DG) we effectively evaluate
+ *
+ * \f{align*}{
+ *
+ * \partial_{\hat{\imath}}\left(J\frac{\partial\xi^{\hat{\imath}}}
+ * {\partial x^i} F^i\right),
+ *
+ * \f}
+ *
+ * which should be identically zero if \f$F^i\f$ is constant. This feature of a
+ * scheme is referred to as free-stream preserving. Note that another way to
+ * achieve free-stream preservation is to subtract off the metric identity
+ * violations. That is,
+ *
+ * \f{align*}{
+ *
+ * \partial_{\hat{\imath}}\left(J\frac{\partial\xi^{\hat{\imath}}}
+ * {\partial x^i} F^i\right) -
+ * F^i \partial_{\hat{\imath}}\left(J\frac{\partial\xi^{\hat{\imath}}}
+ * {\partial x^i}\right).
+ *
+ * \f}
+ *
+ * The subtraction technique is most commonly used in finite difference codes.
+ */
+template <size_t Dim>
+void metric_identity_jacobian(
+    gsl::not_null<
+        InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>*>
+        det_jac_times_inverse_jacobian,
+    const Mesh<Dim>& mesh,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords,
+    const Jacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>&
+        jacobian) noexcept;
+}  // namespace dg

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY "Test_NumericalDiscontinuousGalerkin")
 set(LIBRARY_SOURCES
   Test_Formulation.cpp
   Test_LiftFlux.cpp
+  Test_MetricIdentityJacobian.cpp
   Test_MortarHelpers.cpp
   Test_NormalDotFlux.cpp
   Test_Protocols.cpp

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MetricIdentityJacobian.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MetricIdentityJacobian.cpp
@@ -1,0 +1,160 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <functional>
+#include <random>
+
+#include "DataStructures/ApplyMatrices.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tensor/EagerMath/Determinant.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/CoordinateMaps/Wedge2D.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/MetricIdentityJacobian.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace {
+using Affine = domain::CoordinateMaps::Affine;
+using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+using Affine3D = domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+
+template <size_t VolumeDim>
+auto make_map() noexcept;
+
+template <>
+auto make_map<1>() noexcept {
+  return domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
+      Affine{-1.0, 1.0, -0.3, 0.7});
+}
+
+template <>
+auto make_map<2>() noexcept {
+  return domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
+      Affine2D{{-1.0, 1.0, -1.0, -0.99}, {-1.0, 1.0, -1.0, -0.99}},
+      domain::CoordinateMaps::Wedge2D{1.0, 2.0, 0.0, 1.0, {}, false});
+}
+
+template <>
+auto make_map<3>() noexcept {
+  return domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
+      Affine3D{{-1.0, 1.0, -1.0, -0.99},
+               {-1.0, 1.0, -1.0, -0.99},
+               {-1.0, 1.0, -1.0, 1.0}},
+      domain::CoordinateMaps::ProductOf2Maps<domain::CoordinateMaps::Wedge2D,
+                                             Affine>{
+          {1.0, 2.0, 0.0, 1.0, {}, false}, {0.0, 1.0, 0.0, 1.0}});
+}
+
+
+template <size_t Dim>
+void test(const Mesh<Dim>& mesh) {
+  CAPTURE(Dim);
+  CAPTURE(mesh);
+  std::uniform_real_distribution<double> dist(-1.0, 2.3);
+  MAKE_GENERATOR(gen);
+  tnsr::I<DataVector, Dim, Frame::Inertial> inertial_coords{
+      mesh.number_of_grid_points()};
+  Jacobian<DataVector, Dim, Frame::Logical, Frame::Inertial> jacobian{
+      mesh.number_of_grid_points()};
+
+  fill_with_random_values(make_not_null(&inertial_coords), make_not_null(&gen),
+                          make_not_null(&dist));
+  fill_with_random_values(make_not_null(&jacobian), make_not_null(&gen),
+                          make_not_null(&dist));
+
+  InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial> result{};
+
+  dg::metric_identity_jacobian(make_not_null(&result), mesh, inertial_coords,
+                               jacobian);
+
+  // Check metric identities are satisfied by taking the numerical divergence
+  tnsr::i<DataVector, Dim, Frame::Inertial> divergence_terms{
+      mesh.number_of_grid_points(), 0.0};
+  DataVector buffer(mesh.number_of_grid_points());
+  std::array<Mesh<1>, Dim> meshes_1d{};
+  for (size_t i = 0; i < Dim; ++i) {
+    gsl::at(meshes_1d, i) = mesh.slice_through(i);
+  }
+  const Matrix identity{};
+
+  for (size_t i_hat = 0; i_hat < Dim; ++i_hat) {  // logical index
+    auto diff_matrices = make_array<Dim>(std::cref(identity));
+    gsl::at(diff_matrices, i_hat) =
+        Spectral::differentiation_matrix(gsl::at(meshes_1d, i_hat));
+    for (size_t i = 0; i < Dim; ++i) {  // inertial index
+      apply_matrices(make_not_null(&buffer), diff_matrices,
+                     result.get(i_hat, i), mesh.extents());
+      divergence_terms.get(i) += buffer;
+    }
+  }
+
+  Approx local_approx = Approx::custom().epsilon(1.0e-12).scale(1.);
+  const DataVector expected{mesh.number_of_grid_points(), 0.0};
+  for (size_t i = 0; i < Dim; ++i) {
+    CHECK_ITERABLE_CUSTOM_APPROX(divergence_terms.get(i), expected,
+                                 local_approx);
+  }
+
+  // Now check with a map that the terms of the inverse Jacobian (times the
+  // Jacobian determinent) are computed correctly. This is not expected to be
+  // super accurate unless the maps are very well resolved.
+  auto map = make_map<Dim>();
+  const InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>
+      analytic_inverse_jacobian = map.inv_jacobian(logical_coordinates(mesh));
+  InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>
+      analytic_det_jac_times_inverse_jacobian = analytic_inverse_jacobian;
+  const Scalar<DataVector> analytic_det_jac{
+      1.0 / get(determinant(analytic_inverse_jacobian))};
+  for (auto& t : analytic_det_jac_times_inverse_jacobian) {
+    t *= get(analytic_det_jac);
+  }
+  InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>
+      det_jac_times_inverse_jacobian{};
+
+  dg::metric_identity_jacobian(make_not_null(&det_jac_times_inverse_jacobian),
+                               mesh, map(logical_coordinates(mesh)),
+                               map.jacobian(logical_coordinates(mesh)));
+
+  Approx coarse_local_approx = Approx::custom().epsilon(1.0e-9).scale(1.);
+  for (size_t i = 0; i < Dim; ++i) {
+    CAPTURE(i);
+    for (size_t j = 0; j < Dim; ++j) {
+      CAPTURE(j);
+      CHECK_ITERABLE_CUSTOM_APPROX(
+          det_jac_times_inverse_jacobian.get(i, j),
+          analytic_det_jac_times_inverse_jacobian.get(i, j),
+          coarse_local_approx);
+    }
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DG.MetricIdentityJacobian",
+                  "[Unit][NumericalAlgorithms]") {
+  test(Mesh<1>{5, Spectral::Basis::Legendre,
+               Spectral::Quadrature::GaussLobatto});
+  test(Mesh<1>{5, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss});
+
+  test(Mesh<2>{5, Spectral::Basis::Legendre,
+               Spectral::Quadrature::GaussLobatto});
+  test(Mesh<2>{5, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss});
+
+  test(Mesh<3>{5, Spectral::Basis::Legendre,
+               Spectral::Quadrature::GaussLobatto});
+  test(Mesh<3>{5, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss});
+}


### PR DESCRIPTION
## Proposed changes

Adds a method of computing the determinant of the Jacobian times the inverse
Jacobian in a way that the result satisfies the metric identities discretely.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
