### PR TITLE
Add GH constraint damping functions with options

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -42,3 +42,4 @@ target_link_libraries(
   )
 
 add_subdirectory(GaugeSourceFunctions)
+add_subdirectory(ConstraintDamping)

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY GhConstraintDamping)
+
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  GaussianPlusConstant.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  GaussianPlusConstant.hpp
+  DampingFunction.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  DataStructures
+  ErrorHandling
+  Options
+  )

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/DampingFunction.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/DampingFunction.hpp
@@ -1,0 +1,57 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Parallel/CharmPupable.hpp"
+
+/// \cond
+class DataVector;
+/// \endcond
+
+/// Holds classes implementing DampingFunction (functions \f$R^n \to R\f$).
+namespace GeneralizedHarmonic::ConstraintDamping {
+/// \cond
+template <size_t VolumeDim, typename Fr>
+class GaussianPlusConstant;
+/// \endcond
+
+/*!
+ * \brief Base class defining interface for constraint damping functions.
+ *
+ * Encodes a function \f$R^n \to R\f$ where n is `VolumeDim` that represents
+ * a generalized-harmonic constraint-damping parameter (i.e., Gamma0,
+ * Gamma1, or Gamma2).
+ */
+template <size_t VolumeDim, typename Fr>
+class DampingFunction : public PUP::able {
+ public:
+  using creatable_classes =
+      tmpl::list<GeneralizedHarmonic::ConstraintDamping::GaussianPlusConstant<
+          VolumeDim, Fr>>;
+  constexpr static size_t volume_dim = VolumeDim;
+  using frame = Fr;
+
+  WRAPPED_PUPable_abstract(DampingFunction);  // NOLINT
+
+  DampingFunction() = default;
+  DampingFunction(const DampingFunction& /*rhs*/) = delete;
+  DampingFunction& operator=(const DampingFunction& /*rhs*/) = delete;
+  DampingFunction(DampingFunction&& /*rhs*/) noexcept = default;
+  DampingFunction& operator=(DampingFunction&& /*rhs*/) noexcept = default;
+  ~DampingFunction() override = default;
+
+  //@{
+  /// Returns the value of the function at the coordinate 'x'.
+  virtual Scalar<double> operator()(
+      const tnsr::I<double, VolumeDim, Fr>& x) const noexcept = 0;
+  virtual Scalar<DataVector> operator()(
+      const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept = 0;
+  //@}
+};
+}  // namespace GeneralizedHarmonic::ConstraintDamping
+
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/GaussianPlusConstant.hpp"

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/GaussianPlusConstant.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/GaussianPlusConstant.cpp
@@ -1,0 +1,105 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/GaussianPlusConstant.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <pup.h>
+#include <pup_stl.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace GeneralizedHarmonic::ConstraintDamping {
+
+template <size_t VolumeDim, typename Fr>
+GaussianPlusConstant<VolumeDim, Fr>::GaussianPlusConstant(
+    const double constant, const double amplitude, const double width,
+    const std::array<double, VolumeDim>& center) noexcept
+    : constant_(constant),
+      amplitude_(amplitude),
+      inverse_width_(1.0 / width),
+      center_(center) {}
+
+template <size_t VolumeDim, typename Fr>
+template <typename T>
+tnsr::I<T, VolumeDim, Fr>
+GaussianPlusConstant<VolumeDim, Fr>::centered_coordinates(
+    const tnsr::I<T, VolumeDim, Fr>& x) const noexcept {
+  tnsr::I<T, VolumeDim, Fr> centered_coords = x;
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    centered_coords.get(i) -= gsl::at(center_, i);
+  }
+  return centered_coords;
+}
+
+template <size_t VolumeDim, typename Fr>
+template <typename T>
+Scalar<T> GaussianPlusConstant<VolumeDim, Fr>::apply_call_operator(
+    const tnsr::I<T, VolumeDim, Fr>& centered_coords) const noexcept {
+  Scalar<T> result = dot_product(centered_coords, centered_coords);
+  get(result) =
+      constant_ + amplitude_ * exp(-get(result) * square(inverse_width_));
+  return result;
+}
+
+template <size_t VolumeDim, typename Fr>
+Scalar<double> GaussianPlusConstant<VolumeDim, Fr>::operator()(
+    const tnsr::I<double, VolumeDim, Fr>& x) const noexcept {
+  return apply_call_operator(centered_coordinates(x));
+}
+template <size_t VolumeDim, typename Fr>
+Scalar<DataVector> GaussianPlusConstant<VolumeDim, Fr>::operator()(
+    const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept {
+  return apply_call_operator(centered_coordinates(x));
+}
+
+template <size_t VolumeDim, typename Fr>
+void GaussianPlusConstant<VolumeDim, Fr>::pup(PUP::er& p) {
+  DampingFunction<VolumeDim, Fr>::pup(p);
+  p | constant_;
+  p | amplitude_;
+  p | inverse_width_;
+  p | center_;
+}
+}  // namespace GeneralizedHarmonic::ConstraintDamping
+
+/// \cond
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define INSTANTIATE(_, data)                                                  \
+  template GeneralizedHarmonic::ConstraintDamping::                           \
+      GaussianPlusConstant<DIM(data), FRAME(data)>::GaussianPlusConstant(     \
+          const double constant, const double amplitude, const double width,  \
+          const std::array<double, DIM(data)>& center) noexcept;              \
+  template void GeneralizedHarmonic::ConstraintDamping::GaussianPlusConstant< \
+      DIM(data), FRAME(data)>::pup(PUP::er& p);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial))
+#undef DIM
+#undef FRAME
+#undef INSTANTIATE
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                            \
+  template Scalar<DTYPE(data)> GeneralizedHarmonic::ConstraintDamping:: \
+      GaussianPlusConstant<DIM(data), FRAME(data)>::operator()(         \
+          const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& x)        \
+          const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial),
+                        (double, DataVector))
+#undef FRAME
+#undef DIM
+#undef DTYPE
+#undef INSTANTIATE
+
+/// \endcond

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/GaussianPlusConstant.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/GaussianPlusConstant.hpp
@@ -1,0 +1,122 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/DampingFunction.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace GeneralizedHarmonic::ConstraintDamping {
+/*!
+ * \brief A Gaussian plus a constant: \f$f = C + A
+ * \exp\left(-\frac{(x-x_0)^2}{w^2}\right)\f$
+ *
+ * \details Input file options are: `Constant` \f$C\f$, `Amplitude` \f$A\f$,
+ * `Width` \f$w\f$, and `Center`\f$x_0\f$. The function takes input coordinates
+ * of type `tnsr::I<T, VolumeDim, Fr>`, where `T` is e.g. `double` or
+ * `DataVector`, `Fr` is a frame (e.g. `Frame::Inertial`), and `VolumeDim` is
+ * the dimension of the spatial volume.
+ */
+template <size_t VolumeDim, typename Fr>
+class GaussianPlusConstant : public DampingFunction<VolumeDim, Fr> {
+ public:
+  struct Constant {
+    using type = double;
+    static constexpr Options::String help = {"The constant."};
+  };
+
+  struct Amplitude {
+    using type = double;
+    static constexpr Options::String help = {"The amplitude of the Gaussian."};
+  };
+
+  struct Width {
+    using type = double;
+    static constexpr Options::String help = {"The width of the Gaussian."};
+    static type lower_bound() noexcept { return 0.; }
+  };
+
+  struct Center {
+    using type = std::array<double, VolumeDim>;
+    static constexpr Options::String help = {"The center of the Gaussian."};
+  };
+  using options = tmpl::list<Constant, Amplitude, Width, Center>;
+
+  static constexpr Options::String help = {
+      "Computes a Gaussian plus a constant about an arbitrary coordinate "
+      "center with given width and amplitude"};
+
+  /// \cond
+  WRAPPED_PUPable_decl_base_template(SINGLE_ARG(DampingFunction<VolumeDim, Fr>),
+                                     GaussianPlusConstant);  // NOLINT
+
+  explicit GaussianPlusConstant(CkMigrateMessage* /*unused*/) noexcept {}
+  /// \endcond
+
+  GaussianPlusConstant(double constant, double amplitude, double width,
+                       const std::array<double, VolumeDim>& center) noexcept;
+
+  GaussianPlusConstant() = default;
+  ~GaussianPlusConstant() override = default;
+  GaussianPlusConstant(const GaussianPlusConstant& /*rhs*/) = delete;
+  GaussianPlusConstant& operator=(const GaussianPlusConstant& /*rhs*/) = delete;
+  GaussianPlusConstant(GaussianPlusConstant&& /*rhs*/) noexcept = default;
+  GaussianPlusConstant& operator=(GaussianPlusConstant&& /*rhs*/) noexcept =
+      default;
+
+  Scalar<double> operator()(
+      const tnsr::I<double, VolumeDim, Fr>& x) const noexcept override;
+  Scalar<DataVector> operator()(
+      const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept override;
+
+  // clang-tidy: google-runtime-references
+  void pup(PUP::er& p) override;  // NOLINT
+
+ private:
+  friend bool operator==(const GaussianPlusConstant& lhs,
+                         const GaussianPlusConstant& rhs) noexcept {
+    return lhs.constant_ == rhs.constant_ and
+           lhs.amplitude_ == rhs.amplitude_ and
+           lhs.inverse_width_ == rhs.inverse_width_ and
+           lhs.center_ == rhs.center_;
+  }
+
+  double constant_ = std::numeric_limits<double>::signaling_NaN();
+  double amplitude_ = std::numeric_limits<double>::signaling_NaN();
+  double inverse_width_ = std::numeric_limits<double>::signaling_NaN();
+  std::array<double, VolumeDim> center_{};
+
+  template <typename T>
+  tnsr::I<T, VolumeDim, Fr> centered_coordinates(
+      const tnsr::I<T, VolumeDim, Fr>& x) const noexcept;
+  template <typename T>
+  Scalar<T> apply_call_operator(
+      const tnsr::I<T, VolumeDim, Fr>& centered_coords) const noexcept;
+};
+
+template <size_t VolumeDim, typename Fr>
+bool operator!=(const GaussianPlusConstant<VolumeDim, Fr>& lhs,
+                const GaussianPlusConstant<VolumeDim, Fr>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+}  // namespace GeneralizedHarmonic::ConstraintDamping
+
+/// \cond
+template <size_t VolumeDim, typename Fr>
+PUP::able::PUP_ID GeneralizedHarmonic::ConstraintDamping::GaussianPlusConstant<
+    VolumeDim, Fr>::my_PUP_ID = 0;  // NOLINT
+/// \endcond

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -2,6 +2,7 @@
 # See LICENSE.txt for details.
 
 add_subdirectory(GaugeSourceFunctions)
+add_subdirectory(ConstraintDamping)
 
 set(LIBRARY "Test_GeneralizedHarmonic")
 

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_GhConstraintDamping")
+
+set(LIBRARY_SOURCES
+  Test_GaussianPlusConstant.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/"
+  "${LIBRARY_SOURCES}"
+  "GhConstraintDamping;Utilities"
+  )

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Python/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Python/TestFunctions.py
@@ -1,0 +1,21 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def centered_coordinates(coords, center):
+    return coords - center
+
+
+def squared_distance_from_center(centered_coords, center):
+    return np.einsum("i,i", centered_coords, centered_coords)
+
+
+def gaussian_plus_constant_call_operator(coords, constant, amplitude, width,
+                                         center):
+    one_over_width = 1.0 / width
+    distance = squared_distance_from_center(
+        centered_coordinates(coords, center), center)
+    return amplitude * np.exp(
+        -1.0 * distance * np.square(one_over_width)) + constant

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Test_GaussianPlusConstant.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Test_GaussianPlusConstant.cpp
@@ -1,0 +1,109 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/DampingFunction.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/GaussianPlusConstant.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TestHelpers.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+template <size_t VolumeDim, typename DataType, typename Fr>
+void test_gaussian_plus_constant_random(
+    const DataType& used_for_size) noexcept {
+  Parallel::register_derived_classes_with_charm<
+      GeneralizedHarmonic::ConstraintDamping::GaussianPlusConstant<VolumeDim,
+                                                                   Fr>>();
+
+  // Generate the amplitude and width
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> real_dis(-1, 1);
+  std::uniform_real_distribution<> positive_dis(0, 1);
+
+  const double constant = real_dis(gen);
+  const double amplitude = positive_dis(gen);
+  // If the width is too small then the terms in the second derivative
+  // can become very large and fail the test due to rounding errors.
+  const double width = positive_dis(gen) + 0.5;
+
+  // Generate the center
+  std::array<double, VolumeDim> center{};
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    gsl::at(center, i) = real_dis(gen);
+  }
+
+  GeneralizedHarmonic::ConstraintDamping::GaussianPlusConstant<VolumeDim, Fr>
+      gauss_plus_const{constant, amplitude, width, center};
+
+  TestHelpers::GeneralizedHarmonic::ConstraintDamping::check(
+      std::move(gauss_plus_const), "gaussian_plus_constant", used_for_size,
+      {{{-1.0, 1.0}}}, constant, amplitude, width, center);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.GeneralizedHarmonic.ConstraintDamp.GaussPlusConst",
+    "[PointwiseFunctions][Unit]") {
+  const DataVector dv{5};
+
+  pypp::SetupLocalPythonEnvironment{
+      "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Python"};
+
+  using VolumeDims = tmpl::integral_list<size_t, 1, 2, 3>;
+  using Frames = tmpl::list<Frame::Grid, Frame::Inertial>;
+
+  tmpl::for_each<VolumeDims>([&dv](auto dim_v) {
+    using VolumeDim = typename decltype(dim_v)::type;
+    tmpl::for_each<Frames>([&dv](auto frame_v) {
+      using Fr = typename decltype(frame_v)::type;
+      test_gaussian_plus_constant_random<VolumeDim::value, DataVector, Fr>(dv);
+      test_gaussian_plus_constant_random<VolumeDim::value, double, Fr>(
+          std::numeric_limits<double>::signaling_NaN());
+    });
+  });
+
+  TestHelpers::test_factory_creation<GeneralizedHarmonic::ConstraintDamping::
+                                         DampingFunction<1, Frame::Inertial>>(
+      "GaussianPlusConstant:\n"
+      "  Constant: 4.0\n"
+      "  Amplitude: 3.0\n"
+      "  Width: 2.0\n"
+      "  Center: [-9.0]");
+
+  const double constant_3d{5.0};
+  const double amplitude_3d{4.0};
+  const double width_3d{1.5};
+  const std::array<double, 3> center_3d{{1.1, -2.2, 3.3}};
+  const GeneralizedHarmonic::ConstraintDamping::GaussianPlusConstant<
+      3, Frame::Inertial>
+      gauss_plus_const_3d{constant_3d, amplitude_3d, width_3d, center_3d};
+  const auto created_gauss_plus_const =
+      TestHelpers::test_creation<GeneralizedHarmonic::ConstraintDamping::
+                                     GaussianPlusConstant<3, Frame::Inertial>>(
+          "Constant: 5.0\n"
+          "Amplitude: 4.0\n"
+          "Width: 1.5\n"
+          "Center: [1.1, -2.2, 3.3]");
+  CHECK(created_gauss_plus_const == gauss_plus_const_3d);
+  const auto created_gauss_gh_damping_function =
+      TestHelpers::test_factory_creation<
+          GeneralizedHarmonic::ConstraintDamping::DampingFunction<
+              3, Frame::Inertial>>(
+          "GaussianPlusConstant:\n"
+          "  Constant: 5.0\n"
+          "  Amplitude: 4.0\n"
+          "  Width: 1.5\n"
+          "  Center: [1.1, -2.2, 3.3]");
+
+  test_serialization(gauss_plus_const_3d);
+}

--- a/tests/Unit/Helpers/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TestHelpers.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TestHelpers.hpp
@@ -1,0 +1,109 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Framework/TestingFramework.hpp"
+
+#include <memory>
+#include <pup.h>
+#include <string>
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/DampingFunction.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Parallel/PupStlCpp11.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/Overloader.hpp"
+
+namespace TestHelpers::GeneralizedHarmonic::ConstraintDamping {
+namespace detail {
+template <size_t VolumeDim, typename Fr, class... MemberArgs, class T>
+void check_impl(
+    const std::unique_ptr<
+        ::GeneralizedHarmonic::ConstraintDamping::DampingFunction<
+            VolumeDim, Fr>>& in_gh_damping_function,
+    const std::string& python_function_prefix, const T& used_for_size,
+    const std::array<std::pair<double, double>, 1> random_value_bounds,
+    const MemberArgs&... member_args) noexcept {
+  using GhDampingFunc =
+      ::GeneralizedHarmonic::ConstraintDamping::DampingFunction<VolumeDim,
+                                                                  Fr>;
+  using CallOperatorFunction =
+      Scalar<T> (GhDampingFunc::*)(const tnsr::I<T, VolumeDim, Fr>&)
+          const noexcept;
+
+  const auto member_args_tuple = std::make_tuple(member_args...);
+  const auto helper =
+      [&python_function_prefix, &random_value_bounds, &member_args_tuple,
+       &used_for_size](
+          const std::unique_ptr<GhDampingFunc>& gh_damping_function) noexcept {
+        INFO("Testing call operator...")
+        pypp::check_with_random_values<1>(
+            static_cast<CallOperatorFunction>(&GhDampingFunc::operator()),
+            *gh_damping_function, "TestFunctions",
+            python_function_prefix + "_call_operator", random_value_bounds,
+            member_args_tuple, used_for_size);
+        INFO("Done testing call operator...")
+        INFO("Done\n\n")
+      };
+  helper(in_gh_damping_function);
+  helper(serialize_and_deserialize(in_gh_damping_function));
+}
+}  // namespace detail
+// @{
+/*!
+ * \ingroup TestingFrameworkGroup
+ * \brief Test a DampingFunction by comparing to python functions
+ *
+ * The python functions must be added to TestFunctions.py in
+ * tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Python.
+ * Each python function for a corresponding DampingFunction should begin
+ * with a prefix `python_function_prefix`. The prefix for each class of
+ * DampingFunction is arbitrary, but should generally be descriptive (e.g.
+ * 'gaussian_plus_constant') of the DampingFunction.
+ *
+ * If a DampingFunction class has member variables set by its constructor, then
+ * these member variables must be passed in as the last arguments to the `check`
+ * function`. Each python function must take these same arguments as the
+ * trailing arguments.
+ */
+template <class DampingFunctionType, class T, class... MemberArgs>
+void check(std::unique_ptr<DampingFunctionType> in_gh_damping_function,
+           const std::string& python_function_prefix, const T& used_for_size,
+           const std::array<std::pair<double, double>, 1> random_value_bounds,
+           const MemberArgs&... member_args) noexcept {
+  detail::check_impl(
+      std::unique_ptr<
+          ::GeneralizedHarmonic::ConstraintDamping::DampingFunction<
+              DampingFunctionType::volume_dim,
+              typename DampingFunctionType::frame>>(
+          std::move(in_gh_damping_function)),
+      python_function_prefix, used_for_size, random_value_bounds,
+      member_args...);
+}
+
+template <class DampingFunctionType, class T, class... MemberArgs>
+void check(DampingFunctionType in_gh_damping_function,
+           const std::string& python_function_prefix, const T& used_for_size,
+           const std::array<std::pair<double, double>, 1> random_value_bounds,
+           const MemberArgs&... member_args) noexcept {
+  detail::check_impl(
+      std::unique_ptr<
+          ::GeneralizedHarmonic::ConstraintDamping::DampingFunction<
+              DampingFunctionType::volume_dim,
+              typename DampingFunctionType::frame>>(
+          std::make_unique<DampingFunctionType>(
+              std::move(in_gh_damping_function))),
+      python_function_prefix, used_for_size, random_value_bounds,
+      member_args...);
+}
+// @}
+}  // namespace TestHelpers::GeneralizedHarmonic::ConstraintDamping


### PR DESCRIPTION
## Proposed changes

This is the first PR of a series to change the GH constraint damping parameters from completely hard-coded functions (which must be changed any time you change the data you're evolving) to a set of functions that take input-file options. This will ultimately allow you to change options (such as the center of a gaussian) without editing the parameters by hand in the code and then recompiling.

The new set of functions are similar to PointwiseFunctions/MathFunctions, but unlike MathFunctions, they i) don't compute derivatives, ii) don't support a special interface for 1 spatial dimension, and iii) will (through a future PR) support dependence on time and on FunctionsOfTime.

The plan I'd like to suggest to implement this is the following:

1. (this PR) PR for GH damping function base class, and a gaussian + constant as an example (no time dependence yet)
2. PR updating the compute tags for GH gammas to use the damping functions from pr 1, reproducing current behavior for EvolveKerrSchild. (This would also support EvolveGaugeWave with only input-file changes, unlike now, when you would have to change the hard-coded damping parameters and recompile).
3. PR adding time dependence support, so gammas can depend on time and FunctionsOfTime, testing with a Gaussian moving at a constant velocity (e.g., for a boosted black hole)
4. PR adding triple gaussian + constant that scales Gaussian widths by the expansion factor (i.e., the damping parameters used in BBH evolutions)

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [x] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
