### PR TITLE
Switch linear solvers to iterable actions and remove unnecessary compute tags

### DIFF
--- a/src/Elliptic/Executables/Elasticity/SolveElasticityProblem.hpp
+++ b/src/Elliptic/Executables/Elasticity/SolveElasticityProblem.hpp
@@ -187,18 +187,12 @@ struct Metavariables {
 
   using register_actions =
       tmpl::list<observers::Actions::RegisterEventsWithObservers,
-                 // We prepare the linear solve here to avoid adding an extra
-                 // phase. We can't do that before registration because the
-                 // `prepare_solve` action may contribute to observers.
-                 typename linear_solver::prepare_solve,
                  Parallel::Actions::TerminatePhase>;
 
-  using solve_actions = tmpl::list<Actions::RunEventsAndTriggers,
-                                   LinearSolver::Actions::TerminateIfConverged<
-                                       typename linear_solver::options_group>,
-                                   typename linear_solver::prepare_step,
-                                   build_linear_operator_actions,
-                                   typename linear_solver::perform_step>;
+  using solve_actions = tmpl::list<
+      typename linear_solver::template solve<tmpl::list<
+          Actions::RunEventsAndTriggers, build_linear_operator_actions>>,
+      Actions::RunEventsAndTriggers, Parallel::Actions::TerminatePhase>;
 
   using dg_element_array = elliptic::DgElementArray<
       Metavariables,

--- a/src/Elliptic/Executables/Poisson/SolvePoissonProblem.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoissonProblem.hpp
@@ -181,18 +181,12 @@ struct Metavariables {
 
   using register_actions =
       tmpl::list<observers::Actions::RegisterEventsWithObservers,
-                 // We prepare the linear solve here to avoid adding an extra
-                 // phase. We can't do that before registration because the
-                 // `prepare_solve` action may contribute to observers.
-                 typename linear_solver::prepare_solve,
                  Parallel::Actions::TerminatePhase>;
 
-  using solve_actions = tmpl::list<Actions::RunEventsAndTriggers,
-                                   LinearSolver::Actions::TerminateIfConverged<
-                                       typename linear_solver::options_group>,
-                                   typename linear_solver::prepare_step,
-                                   build_linear_operator_actions,
-                                   typename linear_solver::perform_step>;
+  using solve_actions = tmpl::list<
+      typename linear_solver::template solve<tmpl::list<
+          Actions::RunEventsAndTriggers, build_linear_operator_actions>>,
+      Actions::RunEventsAndTriggers, Parallel::Actions::TerminatePhase>;
 
   using dg_element_array = elliptic::DgElementArray<
       Metavariables,

--- a/src/NumericalAlgorithms/Convergence/HasConverged.cpp
+++ b/src/NumericalAlgorithms/Convergence/HasConverged.cpp
@@ -39,6 +39,12 @@ HasConverged::HasConverged(const Criteria& criteria, const size_t iteration_id,
       residual_magnitude_(residual_magnitude),
       initial_residual_magnitude_(initial_residual_magnitude) {}
 
+HasConverged::HasConverged(const size_t num_iterations,
+                           const size_t iteration_id) noexcept
+    : HasConverged(Criteria{num_iterations, 0., 0.}, iteration_id,
+                   std::numeric_limits<double>::max(),
+                   std::numeric_limits<double>::max()) {}
+
 Reason HasConverged::reason() const noexcept {
   ASSERT(reason_,
          "Tried to retrieve the convergence reason, but has not yet converged. "

--- a/src/NumericalAlgorithms/Convergence/HasConverged.hpp
+++ b/src/NumericalAlgorithms/Convergence/HasConverged.hpp
@@ -67,6 +67,10 @@ struct HasConverged {
                double residual_magnitude,
                double initial_residual_magnitude) noexcept;
 
+  /// Construct at a state where `iteration_id` iterations of a total of
+  /// `num_iterations` have completed.
+  HasConverged(size_t num_iterations, size_t iteration_id) noexcept;
+
   explicit operator bool() const noexcept { return static_cast<bool>(reason_); }
 
   /*!

--- a/src/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/ElementActions.hpp
@@ -58,21 +58,12 @@ using reduction_data = Parallel::ReductionData<
     // Residual
     Parallel::ReductionDatum<double, funcl::Plus<>, funcl::Sqrt<>>>;
 
-template <typename FieldsTag, typename OptionsGroup, typename ParallelComponent,
-          typename DbTagsList, typename Metavariables, typename ArrayIndex>
+template <typename OptionsGroup, typename ParallelComponent,
+          typename Metavariables, typename ArrayIndex>
 void contribute_to_residual_observation(
-    const db::DataBox<DbTagsList>& box,
+    const size_t iteration_id, const double residual_magnitude_square,
     Parallel::GlobalCache<Metavariables>& cache,
     const ArrayIndex& array_index) noexcept {
-  using residual_tag =
-      db::add_tag_prefix<LinearSolver::Tags::Residual, FieldsTag>;
-  using residual_magnitude_square_tag =
-      LinearSolver::Tags::MagnitudeSquare<residual_tag>;
-
-  const size_t iteration_id =
-      get<LinearSolver::Tags::IterationId<OptionsGroup>>(box);
-  const double residual_magnitude_square =
-      get<residual_magnitude_square_tag>(box);
   auto& local_observer =
       *Parallel::get_parallel_component<observers::Observer<Metavariables>>(
            cache)
@@ -135,18 +126,15 @@ struct InitializeElement {
         ::Initialization::merge_into_databox<
             InitializeElement,
             db::AddSimpleTags<LinearSolver::Tags::IterationId<OptionsGroup>,
-                              residual_magnitude_square_tag,
+                              LinearSolver::Tags::HasConverged<OptionsGroup>,
                               operator_applied_to_fields_tag>,
             db::AddComputeTags<
-                LinearSolver::Tags::ResidualCompute<fields_tag, source_tag>,
-                LinearSolver::Tags::HasConvergedByIterationsCompute<
-                    OptionsGroup>>>(
+                LinearSolver::Tags::ResidualCompute<fields_tag, source_tag>>>(
             std::move(box),
             // The `PrepareSolve` action populates these tags with initial
             // values, except for `operator_applied_to_fields_tag` which is
             // expected to be updated in every iteration of the algorithm
-            std::numeric_limits<size_t>::max(),
-            std::numeric_limits<double>::signaling_NaN(),
+            std::numeric_limits<size_t>::max(), Convergence::HasConverged{},
             typename operator_applied_to_fields_tag::type{}));
   }
 };
@@ -174,8 +162,6 @@ struct PrepareSolve {
   using fields_tag = FieldsTag;
   using residual_tag =
       db::add_tag_prefix<LinearSolver::Tags::Residual, FieldsTag>;
-  using residual_magnitude_square_tag =
-      LinearSolver::Tags::MagnitudeSquare<residual_tag>;
 
  public:
   using const_global_cache_tags =
@@ -190,20 +176,26 @@ struct PrepareSolve {
       Parallel::GlobalCache<Metavariables>& cache,
       const ArrayIndex& array_index, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) noexcept {
+    constexpr size_t iteration_id = 0;
+
     db::mutate<LinearSolver::Tags::IterationId<OptionsGroup>,
-               residual_magnitude_square_tag>(
+               LinearSolver::Tags::HasConverged<OptionsGroup>>(
         make_not_null(&box),
-        [](const gsl::not_null<size_t*> iteration_id,
-           const gsl::not_null<double*> residual_magnitude_square,
-           const auto& residual) noexcept {
-          *iteration_id = 0;
-          *residual_magnitude_square = inner_product(residual, residual);
+        [](const gsl::not_null<size_t*> local_iteration_id,
+           const gsl::not_null<Convergence::HasConverged*> has_converged,
+           const size_t num_iterations) noexcept {
+          *local_iteration_id = iteration_id;
+          *has_converged =
+              Convergence::HasConverged{num_iterations, iteration_id};
         },
-        get<residual_tag>(box));
+        get<LinearSolver::Tags::Iterations<OptionsGroup>>(box));
+
     // Observe the initial residual even if no steps are going to be performed
-    contribute_to_residual_observation<FieldsTag, OptionsGroup,
-                                       ParallelComponent>(box, cache,
-                                                          array_index);
+    const auto& residual = get<residual_tag>(box);
+    const double residual_magnitude_square = inner_product(residual, residual);
+    contribute_to_residual_observation<OptionsGroup, ParallelComponent>(
+        iteration_id, residual_magnitude_square, cache, array_index);
+
     // Skip steps entirely if the solve has already converged
     constexpr size_t step_end_index =
         tmpl::index_of<ActionList, CompleteStep<FieldsTag, OptionsGroup,
@@ -224,8 +216,6 @@ struct CompleteStep {
   using fields_tag = FieldsTag;
   using residual_tag =
       db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>;
-  using residual_magnitude_square_tag =
-      LinearSolver::Tags::MagnitudeSquare<residual_tag>;
 
  public:
   using const_global_cache_tags =
@@ -240,20 +230,27 @@ struct CompleteStep {
       Parallel::GlobalCache<Metavariables>& cache,
       const ArrayIndex& array_index, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) noexcept {
-    // Update and observe element-local residual magnitude
-    db::mutate<residual_magnitude_square_tag,
-               LinearSolver::Tags::IterationId<OptionsGroup>>(
+    // Prepare for next iteration
+    db::mutate<LinearSolver::Tags::IterationId<OptionsGroup>,
+               LinearSolver::Tags::HasConverged<OptionsGroup>>(
         make_not_null(&box),
-        [](const gsl::not_null<double*> residual_magnitude_square,
-           const gsl::not_null<size_t*> iteration_id,
-           const auto& residual) noexcept {
-          *residual_magnitude_square = inner_product(residual, residual);
+        [](const gsl::not_null<size_t*> iteration_id,
+           const gsl::not_null<Convergence::HasConverged*> has_converged,
+           const size_t num_iterations) noexcept {
           ++(*iteration_id);
+          *has_converged =
+              Convergence::HasConverged{num_iterations, *iteration_id};
         },
-        get<residual_tag>(box));
-    contribute_to_residual_observation<FieldsTag, OptionsGroup,
-                                       ParallelComponent>(box, cache,
-                                                          array_index);
+        get<LinearSolver::Tags::Iterations<OptionsGroup>>(box));
+
+    // Observe element-local residual magnitude
+    const size_t completed_iterations =
+        get<LinearSolver::Tags::IterationId<OptionsGroup>>(box);
+    const auto& residual = get<residual_tag>(box);
+    const double residual_magnitude_square = inner_product(residual, residual);
+    contribute_to_residual_observation<OptionsGroup, ParallelComponent>(
+        completed_iterations, residual_magnitude_square, cache, array_index);
+
     // Repeat steps until the solve has converged
     constexpr size_t step_begin_index =
         tmpl::index_of<ActionList, PrepareSolve<FieldsTag, OptionsGroup,

--- a/src/ParallelAlgorithms/LinearSolver/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/CMakeLists.txt
@@ -20,8 +20,11 @@ target_link_libraries(
   INTERFACE
   Convergence
   DataStructures
-  LinearSolver
+  Informer
+  Initialization
   IO
+  LinearSolver
+  Parallel
   Utilities
   )
 

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/CMakeLists.txt
@@ -12,3 +12,4 @@ spectre_target_headers(
   ResidualMonitorActions.hpp
   )
 
+add_subdirectory(Tags)

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ElementActions.hpp
@@ -5,20 +5,22 @@
 
 #include <cstddef>
 #include <tuple>
+#include <utility>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "NumericalAlgorithms/LinearSolver/InnerProduct.hpp"
 #include "Parallel/GlobalCache.hpp"
-#include "Parallel/Info.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Reduction.hpp"
 #include "ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp"
+#include "ParallelAlgorithms/LinearSolver/ConjugateGradient/Tags/InboxTags.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 #include "Utilities/Functional.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
 
 /// \cond
 namespace Convergence {
@@ -31,12 +33,14 @@ class TaggedTuple;
 namespace LinearSolver::cg::detail {
 template <typename Metavariables, typename FieldsTag, typename OptionsGroup>
 struct ResidualMonitor;
+template <typename FieldsTag, typename OptionsGroup, typename Label>
+struct UpdateOperand;
 }  // namespace LinearSolver::cg::detail
 /// \endcond
 
 namespace LinearSolver::cg::detail {
 
-template <typename FieldsTag, typename OptionsGroup>
+template <typename FieldsTag, typename OptionsGroup, typename Label>
 struct PrepareSolve {
  private:
   using fields_tag = FieldsTag;
@@ -52,7 +56,7 @@ struct PrepareSolve {
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>
-  static std::tuple<db::DataBox<DbTagsList>&&, bool> apply(
+  static std::tuple<db::DataBox<DbTagsList>&&> apply(
       db::DataBox<DbTagsList>& box,
       const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
       Parallel::GlobalCache<Metavariables>& cache,
@@ -82,68 +86,67 @@ struct PrepareSolve {
         Parallel::get_parallel_component<
             ResidualMonitor<Metavariables, FieldsTag, OptionsGroup>>(cache));
 
-    return {
-        std::move(box),
-        // Terminate algorithm for now. The `ResidualMonitor` will receive the
-        // reduction that is performed above and then broadcast to the following
-        // action, which is responsible for restarting the algorithm.
-        true};
+    return {std::move(box)};
   }
 };
 
-template <typename FieldsTag, typename OptionsGroup>
+template <typename FieldsTag, typename OptionsGroup, typename Label>
 struct InitializeHasConverged {
-  template <
-      typename ParallelComponent, typename DbTagsList, typename Metavariables,
-      typename ArrayIndex, typename DataBox = db::DataBox<DbTagsList>,
-      Requires<db::tag_is_retrievable_v<
-          LinearSolver::Tags::HasConverged<OptionsGroup>, DataBox>> = nullptr>
-  static void apply(db::DataBox<DbTagsList>& box,
-                    Parallel::GlobalCache<Metavariables>& cache,
-                    const ArrayIndex& array_index,
-                    const Convergence::HasConverged& has_converged) noexcept {
+  using inbox_tags = tmpl::list<Tags::InitialHasConverged<OptionsGroup>>;
+
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex>
+  static bool is_ready(const db::DataBox<DbTags>& box,
+                       const tuples::TaggedTuple<InboxTags...>& inboxes,
+                       const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                       const ArrayIndex& /*array_index*/) noexcept {
+    const auto& inbox = get<Tags::InitialHasConverged<OptionsGroup>>(inboxes);
+    return inbox.find(db::get<LinearSolver::Tags::IterationId<OptionsGroup>>(
+               box)) != inbox.end();
+  }
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&, bool, size_t> apply(
+      db::DataBox<DbTagsList>& box, tuples::TaggedTuple<InboxTags...>& inboxes,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    auto has_converged = std::move(
+        tuples::get<Tags::InitialHasConverged<OptionsGroup>>(inboxes)
+            .extract(
+                db::get<LinearSolver::Tags::IterationId<OptionsGroup>>(box))
+            .mapped());
+
     db::mutate<LinearSolver::Tags::HasConverged<OptionsGroup>>(
         make_not_null(&box),
         [&has_converged](const gsl::not_null<Convergence::HasConverged*>
                              local_has_converged) noexcept {
-          *local_has_converged = has_converged;
+          *local_has_converged = std::move(has_converged);
         });
 
-    // Proceed with algorithm
-    Parallel::get_parallel_component<ParallelComponent>(cache)[array_index]
-        .perform_algorithm(true);
+    // Skip steps entirely if the solve has already converged
+    constexpr size_t step_end_index =
+        tmpl::index_of<ActionList,
+                       UpdateOperand<FieldsTag, OptionsGroup, Label>>::value;
+    constexpr size_t this_action_index =
+        tmpl::index_of<ActionList, InitializeHasConverged>::value;
+    return {std::move(box), false,
+            has_converged ? (step_end_index + 1) : (this_action_index + 1)};
   }
 };
 
-template <typename FieldsTag, typename OptionsGroup>
-struct PrepareStep {
+template <typename FieldsTag, typename OptionsGroup, typename Label>
+struct PerformStep {
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>
   static std::tuple<db::DataBox<DbTagsList>&&> apply(
       db::DataBox<DbTagsList>& box,
       const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-      const Parallel::GlobalCache<Metavariables>& /*cache*/,
-      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
-      const ParallelComponent* const /*meta*/) noexcept {
-    // Nothing to do before applying the linear operator to the operand
-    return {std::move(box)};
-  }
-};
-
-template <typename FieldsTag, typename OptionsGroup>
-struct PerformStep {
-  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
-            typename ArrayIndex, typename ActionList,
-            typename ParallelComponent>
-  static std::tuple<db::DataBox<DbTagsList>&&, bool> apply(
-      db::DataBox<DbTagsList>& box,
-      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
       Parallel::GlobalCache<Metavariables>& cache,
-      const ArrayIndex& array_index,
-      // NOLINTNEXTLINE(readability-avoid-const-params-in-decls)
-      const ActionList /*meta*/,
-      // NOLINTNEXTLINE(readability-avoid-const-params-in-decls)
+      const ArrayIndex& array_index, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) noexcept {
     using fields_tag = FieldsTag;
     using operand_tag =
@@ -166,14 +169,11 @@ struct PerformStep {
         Parallel::get_parallel_component<
             ResidualMonitor<Metavariables, FieldsTag, OptionsGroup>>(cache));
 
-    // Terminate algorithm for now. The `ResidualMonitor` will receive the
-    // reduction that is performed above and then broadcast to the following
-    // action, which is responsible for restarting the algorithm.
-    return {std::move(box), true};
+    return {std::move(box)};
   }
 };
 
-template <typename FieldsTag, typename OptionsGroup>
+template <typename FieldsTag, typename OptionsGroup, typename Label>
 struct UpdateFieldValues {
  private:
   using fields_tag = FieldsTag;
@@ -185,18 +185,33 @@ struct UpdateFieldValues {
       db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>;
 
  public:
-  template <typename ParallelComponent, typename DbTagsList,
-            typename Metavariables, typename ArrayIndex,
-            typename DataBox = db::DataBox<DbTagsList>,
-            Requires<db::tag_is_retrievable_v<residual_tag, DataBox> and
-                     db::tag_is_retrievable_v<fields_tag, DataBox> and
-                     db::tag_is_retrievable_v<operand_tag, DataBox> and
-                     db::tag_is_retrievable_v<operator_tag, DataBox>> = nullptr>
-  static auto apply(db::DataBox<DbTagsList>& box,
-                    Parallel::GlobalCache<Metavariables>& cache,
-                    const ArrayIndex& array_index,
-                    const double alpha) noexcept {
-    // Received global reduction result, proceed with conjugate gradient.
+  using inbox_tags = tmpl::list<Tags::Alpha<OptionsGroup>>;
+
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex>
+  static bool is_ready(const db::DataBox<DbTags>& box,
+                       const tuples::TaggedTuple<InboxTags...>& inboxes,
+                       const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                       const ArrayIndex& /*array_index*/) noexcept {
+    const auto& inbox = get<Tags::Alpha<OptionsGroup>>(inboxes);
+    return inbox.find(db::get<LinearSolver::Tags::IterationId<OptionsGroup>>(
+               box)) != inbox.end();
+  }
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&> apply(
+      db::DataBox<DbTagsList>& box, tuples::TaggedTuple<InboxTags...>& inboxes,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    const double alpha = std::move(
+        tuples::get<Tags::Alpha<OptionsGroup>>(inboxes)
+            .extract(
+                db::get<LinearSolver::Tags::IterationId<OptionsGroup>>(box))
+            .mapped());
+
     db::mutate<residual_tag, fields_tag>(
         make_not_null(&box),
         [alpha](const auto residual, const auto fields, const auto& operand,
@@ -219,10 +234,12 @@ struct UpdateFieldValues {
         Parallel::get_parallel_component<ParallelComponent>(cache)[array_index],
         Parallel::get_parallel_component<
             ResidualMonitor<Metavariables, FieldsTag, OptionsGroup>>(cache));
+
+    return {std::move(box)};
   }
 };
 
-template <typename FieldsTag, typename OptionsGroup>
+template <typename FieldsTag, typename OptionsGroup, typename Label>
 struct UpdateOperand {
  private:
   using fields_tag = FieldsTag;
@@ -232,19 +249,37 @@ struct UpdateOperand {
       db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>;
 
  public:
-  template <
-      typename ParallelComponent, typename DbTagsList, typename Metavariables,
-      typename ArrayIndex, typename DataBox = db::DataBox<DbTagsList>,
-      Requires<db::tag_is_retrievable_v<fields_tag, DataBox> and
-               db::tag_is_retrievable_v<
-                   LinearSolver::Tags::HasConverged<OptionsGroup>, DataBox> and
-               db::tag_is_retrievable_v<
-                   LinearSolver::Tags::IterationId<OptionsGroup>, DataBox> and
-               db::tag_is_retrievable_v<residual_tag, DataBox>> = nullptr>
-  static auto apply(db::DataBox<DbTagsList>& box,
-                    Parallel::GlobalCache<Metavariables>& cache,
-                    const ArrayIndex& array_index, const double res_ratio,
-                    const Convergence::HasConverged& has_converged) noexcept {
+  using inbox_tags =
+      tmpl::list<Tags::ResidualRatioAndHasConverged<OptionsGroup>>;
+
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex>
+  static bool is_ready(const db::DataBox<DbTags>& box,
+                       const tuples::TaggedTuple<InboxTags...>& inboxes,
+                       const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                       const ArrayIndex& /*array_index*/) noexcept {
+    const auto& inbox =
+        get<Tags::ResidualRatioAndHasConverged<OptionsGroup>>(inboxes);
+    return inbox.find(db::get<LinearSolver::Tags::IterationId<OptionsGroup>>(
+               box)) != inbox.end();
+  }
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&, bool, size_t> apply(
+      db::DataBox<DbTagsList>& box, tuples::TaggedTuple<InboxTags...>& inboxes,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    auto received_data = std::move(
+        tuples::get<Tags::ResidualRatioAndHasConverged<OptionsGroup>>(inboxes)
+            .extract(
+                db::get<LinearSolver::Tags::IterationId<OptionsGroup>>(box))
+            .mapped());
+    const double res_ratio = get<0>(received_data);
+    auto& has_converged = get<1>(received_data);
+
     db::mutate<operand_tag, LinearSolver::Tags::IterationId<OptionsGroup>,
                LinearSolver::Tags::HasConverged<OptionsGroup>>(
         make_not_null(&box),
@@ -254,13 +289,21 @@ struct UpdateOperand {
             const auto& residual) noexcept {
           *operand = residual + res_ratio * *operand;
           ++(*iteration_id);
-          *local_has_converged = has_converged;
+          *local_has_converged = std::move(has_converged);
         },
         get<residual_tag>(box));
 
-    // Proceed with algorithm
-    Parallel::get_parallel_component<ParallelComponent>(cache)[array_index]
-        .perform_algorithm(true);
+    // Repeat steps until the solve has converged
+    constexpr size_t this_action_index =
+        tmpl::index_of<ActionList, UpdateOperand>::value;
+    constexpr size_t prepare_step_index =
+        tmpl::index_of<ActionList, InitializeHasConverged<
+                                       FieldsTag, OptionsGroup, Label>>::value +
+        1;
+    return {std::move(box), false,
+            get<LinearSolver::Tags::HasConverged<OptionsGroup>>(box)
+                ? (this_action_index + 1)
+                : prepare_step_index};
   }
 };
 

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ElementActions.hpp
@@ -163,7 +163,9 @@ struct PerformStep {
     Parallel::contribute_to_reduction<
         ComputeAlpha<FieldsTag, OptionsGroup, ParallelComponent>>(
         Parallel::ReductionData<
+            Parallel::ReductionDatum<size_t, funcl::AssertEqual<>>,
             Parallel::ReductionDatum<double, funcl::Plus<>>>{
+            get<LinearSolver::Tags::IterationId<OptionsGroup>>(box),
             local_conj_grad_inner_product},
         Parallel::get_parallel_component<ParallelComponent>(cache)[array_index],
         Parallel::get_parallel_component<
@@ -229,7 +231,9 @@ struct UpdateFieldValues {
     Parallel::contribute_to_reduction<
         UpdateResidual<FieldsTag, OptionsGroup, ParallelComponent>>(
         Parallel::ReductionData<
+            Parallel::ReductionDatum<size_t, funcl::AssertEqual<>>,
             Parallel::ReductionDatum<double, funcl::Plus<>>>{
+            get<LinearSolver::Tags::IterationId<OptionsGroup>>(box),
             local_residual_magnitude_square},
         Parallel::get_parallel_component<ParallelComponent>(cache)[array_index],
         Parallel::get_parallel_component<

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/InitializeElement.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/InitializeElement.hpp
@@ -5,16 +5,20 @@
 
 #include <cstddef>
 #include <limits>
+#include <tuple>
+#include <utility>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
-#include "DataStructures/DataBox/Prefixes.hpp"
 #include "NumericalAlgorithms/Convergence/HasConverged.hpp"
-#include "Parallel/GlobalCache.hpp"
 #include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 
 /// \cond
+namespace Parallel {
+template <typename Metavariables>
+struct GlobalCache;
+}  // namespace Parallel
 namespace tuples {
 template <typename...>
 class TaggedTuple;
@@ -42,7 +46,7 @@ struct InitializeElement {
             typename ParallelComponent>
   static auto apply(db::DataBox<DbTagsList>& box,
                     const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-                    Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp
@@ -4,14 +4,14 @@
 #pragma once
 
 #include <cstddef>
+#include <limits>
+#include <tuple>
+#include <utility>
 
 #include "AlgorithmSingleton.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
-#include "DataStructures/DataBox/Prefixes.hpp"
 #include "IO/Observer/Actions/RegisterSingleton.hpp"
-#include "Informer/Tags.hpp"
-#include "Informer/Verbosity.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
@@ -40,6 +40,10 @@ struct ResidualMonitor {
       tmpl::list<LinearSolver::Tags::Verbosity<OptionsGroup>,
                  LinearSolver::Tags::ConvergenceCriteria<OptionsGroup>>;
   using metavariables = Metavariables;
+  // The actions in `ResidualMonitorActions.hpp` are invoked as simple actions
+  // on this component as the result of reductions from the actions in
+  // `ElementActions.hpp`. See `LinearSolver::cg::ConjugateGradient` for
+  // details.
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp
@@ -85,21 +85,16 @@ struct InitializeResidualMonitor {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    using compute_tags = db::AddComputeTags<
-        LinearSolver::Tags::MagnitudeCompute<residual_square_tag>,
-        LinearSolver::Tags::HasConvergedCompute<fields_tag, OptionsGroup>>;
     return std::make_tuple(
         ::Initialization::merge_into_databox<
             InitializeResidualMonitor,
-            db::AddSimpleTags<LinearSolver::Tags::IterationId<OptionsGroup>,
-                              residual_square_tag,
-                              initial_residual_magnitude_tag>,
-            compute_tags>(std::move(box),
-                          // The `InitializeResidual` action populates these
-                          // tags with initial values
-                          std::numeric_limits<size_t>::max(),
-                          std::numeric_limits<double>::signaling_NaN(),
-                          std::numeric_limits<double>::signaling_NaN()),
+            db::AddSimpleTags<residual_square_tag,
+                              initial_residual_magnitude_tag>>(
+            std::move(box),
+            // The `InitializeResidual` action populates these tags with initial
+            // values
+            std::numeric_limits<double>::signaling_NaN(),
+            std::numeric_limits<double>::signaling_NaN()),
         true);
   }
 };

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/Tags/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/Tags/CMakeLists.txt
@@ -5,11 +5,5 @@ spectre_target_headers(
   ParallelLinearSolver
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
-  ElementActions.hpp
-  Gmres.hpp
-  InitializeElement.hpp
-  ResidualMonitor.hpp
-  ResidualMonitorActions.hpp
+  InboxTags.hpp
   )
-
-add_subdirectory(Tags)

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/Tags/InboxTags.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/Tags/InboxTags.hpp
@@ -1,0 +1,38 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <map>
+#include <tuple>
+
+#include "NumericalAlgorithms/Convergence/HasConverged.hpp"
+#include "Parallel/InboxInserters.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace LinearSolver::cg::detail::Tags {
+
+template <typename OptionsGroup>
+struct InitialHasConverged
+    : Parallel::InboxInserters::Value<InitialHasConverged<OptionsGroup>> {
+  using temporal_id = size_t;
+  using type = std::map<temporal_id, Convergence::HasConverged>;
+};
+
+template <typename OptionsGroup>
+struct Alpha : Parallel::InboxInserters::Value<Alpha<OptionsGroup>> {
+  using temporal_id = size_t;
+  using type = std::map<temporal_id, double>;
+};
+
+template <typename OptionsGroup>
+struct ResidualRatioAndHasConverged
+    : Parallel::InboxInserters::Value<
+          ResidualRatioAndHasConverged<OptionsGroup>> {
+  using temporal_id = size_t;
+  using type =
+      std::map<temporal_id, std::tuple<double, Convergence::HasConverged>>;
+};
+
+}  // namespace LinearSolver::cg::detail::Tags

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/ElementActions.hpp
@@ -266,8 +266,13 @@ struct PerformStep {
     Parallel::contribute_to_reduction<
         StoreOrthogonalization<FieldsTag, OptionsGroup, ParallelComponent>>(
         Parallel::ReductionData<
-            Parallel::ReductionDatum<double, funcl::Plus<>>>{inner_product(
-            get<basis_history_tag>(box)[0], get<operand_tag>(box))},
+            Parallel::ReductionDatum<size_t, funcl::AssertEqual<>>,
+            Parallel::ReductionDatum<size_t, funcl::AssertEqual<>>,
+            Parallel::ReductionDatum<double, funcl::Plus<>>>{
+            get<LinearSolver::Tags::IterationId<OptionsGroup>>(box),
+            get<orthogonalization_iteration_id_tag>(box),
+            inner_product(get<basis_history_tag>(box)[0],
+                          get<operand_tag>(box))},
         Parallel::get_parallel_component<ParallelComponent>(cache)[array_index],
         Parallel::get_parallel_component<
             ResidualMonitor<Metavariables, FieldsTag, OptionsGroup>>(cache));
@@ -345,7 +350,10 @@ struct OrthogonalizeOperand {
     Parallel::contribute_to_reduction<
         StoreOrthogonalization<FieldsTag, OptionsGroup, ParallelComponent>>(
         Parallel::ReductionData<
+            Parallel::ReductionDatum<size_t, funcl::AssertEqual<>>,
+            Parallel::ReductionDatum<size_t, funcl::AssertEqual<>>,
             Parallel::ReductionDatum<double, funcl::Plus<>>>{
+            iteration_id, next_orthogonalization_iteration_id,
             local_orthogonalization},
         Parallel::get_parallel_component<ParallelComponent>(cache)[array_index],
         Parallel::get_parallel_component<

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp
@@ -3,12 +3,13 @@
 
 #pragma once
 
-#include "IO/Observer/Actions/RegisterWithObservers.hpp"
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "IO/Observer/Helpers.hpp"
-#include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
 #include "ParallelAlgorithms/LinearSolver/Gmres/ElementActions.hpp"
 #include "ParallelAlgorithms/LinearSolver/Gmres/InitializeElement.hpp"
 #include "ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp"
+#include "ParallelAlgorithms/LinearSolver/Observe.hpp"
+#include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// Items related to the GMRES linear solver
@@ -22,20 +23,24 @@ namespace LinearSolver::gmres {
  * \f$Ax=b\f$.
  *
  * \details The only operation we need to supply to the algorithm is the
- * result of the operation \f$A(p)\f$ (see \ref LinearSolverGroup). Each
- * invocation of the `perform_step` action expects that \f$A(q)\f$ has been
- * computed in a preceding action and stored in the DataBox as
- * `db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, operand_tag>`.
+ * result of the operation \f$A(p)\f$ (see \ref LinearSolverGroup). Each step of
+ * the algorithm expects that \f$A(q)\f$ is computed and stored in the DataBox
+ * as `db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, operand_tag>`.
+ * To perform a solve, add the `solve` action list to an array parallel
+ * component. Pass the actions that compute \f$A(q)\f$, as well as any further
+ * actions you wish to run in each step of the algorithm, as the first template
+ * parameter to `solve`. If you add the `solve` action list multiple times, use
+ * the second template parameter to label each solve with a different type.
  *
  * This linear solver supports preconditioning. Enable preconditioning by
  * setting the `Preconditioned` template parameter to `true`. If you do, run a
- * preconditioner (e.g. another parallel linear solver) in each step before
- * invoking `perform_step`. The preconditioner should approximately solve the
- * linear problem \f$A(q)=b\f$ where \f$q\f$ is the `operand_tag` and \f$b\f$ is
- * the `preconditioner_source_tag`. Make sure the tag
+ * preconditioner (e.g. another parallel linear solver) in each step. The
+ * preconditioner should approximately solve the linear problem \f$A(q)=b\f$
+ * where \f$q\f$ is the `operand_tag` and \f$b\f$ is the
+ * `preconditioner_source_tag`. Make sure the tag
  * `db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, operand_tag>`
- * is up-to-date with the preconditioned result before invoking `perform_step`,
- * i.e. that it is \f$A(q)\f$ where \f$q\f$ is the preconditioner's approximate
+ * is updated with the preconditioned result in each step of the algorithm, i.e.
+ * that it is \f$A(q)\f$ where \f$q\f$ is the preconditioner's approximate
  * solution to \f$A(q)=b\f$.
  *
  * Note that the operand \f$q\f$ for which \f$A(q)\f$ needs to be computed is
@@ -44,17 +49,16 @@ namespace LinearSolver::gmres {
  * initially set to the residual \f$q_0 = b - A(x_0)\f$ where \f$x_0\f$ is the
  * initial value of the `FieldsTag`.
  *
- * When the `perform_step` action is invoked after the operator action
- * \f$A(q)\f$ has been computed and stored in the DataBox, the GMRES algorithm
- * implemented here will converge the field \f$x\f$ towards the solution and
- * update the operand \f$q\f$ in the process. This requires reductions over
- * all elements that are received by a `ResidualMonitor` singleton parallel
- * component, processed, and then broadcast back to all elements. Since the
- * reductions are performed to find a vector that is orthogonal to those used in
- * previous steps, the number of reductions increases linearly with iterations.
- * No restarting mechanism is currently implemented. The actions are implemented
- * in the `gmres::detail` namespace and constitute the full algorithm in the
- * following order:
+ * When the algorithm step is performed after the operator action \f$A(q)\f$ has
+ * been computed and stored in the DataBox, the GMRES algorithm implemented here
+ * will converge the field \f$x\f$ towards the solution and update the operand
+ * \f$q\f$ in the process. This requires reductions over all elements that are
+ * received by a `ResidualMonitor` singleton parallel component, processed, and
+ * then broadcast back to all elements. Since the reductions are performed to
+ * find a vector that is orthogonal to those used in previous steps, the number
+ * of reductions increases linearly with iterations. No restarting mechanism is
+ * currently implemented. The actions are implemented in the `gmres::detail`
+ * namespace and constitute the full algorithm in the following order:
  * 1. `PerformStep` (on elements): Start an Arnoldi orthogonalization by
  * computing the inner product between \f$A(q)\f$ and the first of the
  * previously determined set of orthogonal vectors.
@@ -64,7 +68,7 @@ namespace LinearSolver::gmres {
  * orthogonalization by computing inner products and reducing to
  * `StoreOrthogonalization` on the `ResidualMonitor` until the new orthogonal
  * vector is constructed. Then compute its magnitude and reduce.
- * 4. `StoreFinalOrthogonalization` (on `ResidualMonitor`): Perform a QR
+ * 4. `StoreOrthogonalization` (on `ResidualMonitor`): Perform a QR
  * decomposition of the Hessenberg matrix to produce a residual vector.
  * Broadcast to `NormalizeOperandAndUpdateField` along with a termination
  * flag if the `LinearSolver::Tags::ConvergenceCriteria` are met.
@@ -101,131 +105,26 @@ struct Gmres {
   using component_list = tmpl::list<
       detail::ResidualMonitor<Metavariables, FieldsTag, OptionsGroup>>;
 
-  /*!
-   * \brief Initialize the tags used by the GMRES linear solver.
-   *
-   * Since we have not started iterating yet, we initialize the state _before_
-   * the first iteration. So `LinearSolver::Tags::IterationId` is undefined at
-   * this point and `Tags::Next<LinearSolver::Tags::IterationId>` is the initial
-   * step number. Invoke `prepare_step` to advance the state to the first
-   * iteration.
-   *
-   * \warning This action involves a blocking reduction, so it is a global
-   * synchronization point.
-   *
-   * With:
-   * - `initial_fields_tag` =
-   * `db::add_tag_prefix<LinearSolver::Tags::Initial, FieldsTag>`
-   * - `operand_tag` =
-   * `db::add_tag_prefix<LinearSolver::Tags::Operand, FieldsTag>`
-   * - `operator_tag` =
-   * `db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, operand_tag>`
-   * - `orthogonalization_iteration_id_tag` =
-   * `LinearSolver::Tags::Orthogonalization<LinearSolver::Tags::IterationId>`
-   * - `basis_history_tag` =
-   * `LinearSolver::Tags::KrylovSubspaceBasis<FieldsTag>`
-   *
-   * DataBox changes:
-   * - Adds:
-   *   * `LinearSolver::Tags::IterationId`
-   *   * `Tags::Next<LinearSolver::Tags::IterationId>`
-   *   * `initial_fields_tag`
-   *   * `orthogonalization_iteration_id_tag`
-   *   * `basis_history_tag`
-   *   * `LinearSolver::Tags::HasConverged`
-   * - Removes: nothing
-   * - Modifies:
-   *   * `operand_tag`
-   *
-   * \note The `operand_tag` must already be present in the DataBox and is set
-   * to its initial value here. It is typically added to the DataBox by the
-   * system, which uses it to compute the `operator_tag` in each step. Also the
-   * `operator_tag` is typically added to the DataBox by the system, but does
-   * not need to be initialized until it is computed for the first time in the
-   * first step of the algorithm.
-   */
   using initialize_element =
       detail::InitializeElement<FieldsTag, OptionsGroup, Preconditioned>;
 
   using register_element = tmpl::list<>;
 
-  /*!
-   * \brief Reset the linear solver to its initial state.
-   *
-   * Uses:
-   * - System:
-   *   * `fields_tag`
-   *
-   * With:
-   * - `initial_fields_tag` =
-   * `db::add_tag_prefix<LinearSolver::Tags::Initial, fields_tag>`
-   * - `operand_tag` =
-   * `db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>`
-   * - `orthogonalization_iteration_id_tag` =
-   * `LinearSolver::Tags::Orthogonalization<LinearSolver::Tags::IterationId>`
-   * - `basis_history_tag` =
-   * `LinearSolver::Tags::KrylovSubspaceBasis<fields_tag>`
-   *
-   * DataBox changes:
-   * - Adds: nothing
-   * - Removes: nothing
-   * - Modifies:
-   *   * `LinearSolver::Tags::IterationId`
-   *   * `initial_fields_tag`
-   *   * `orthogonalization_iteration_id_tag`
-   *   * `basis_history_tag`
-   *   * `LinearSolver::Tags::HasConverged`
-   *   * `operand_tag`
-   *
-   * \see `initialize_element`
-   */
-  using prepare_solve =
-      detail::PrepareSolve<FieldsTag, OptionsGroup, Preconditioned>;
-
-  // Compile-time interface for observers
   using observed_reduction_data_tags = observers::make_reduction_data_tags<
       tmpl::list<observe_detail::reduction_data>>;
 
-  /*!
-   * \brief Advance the linear solver to the next iteration.
-   *
-   * DataBox changes:
-   * - Adds: nothing
-   * - Removes: nothing
-   * - Modifies:
-   *   * `LinearSolver::Tags::IterationId`
-   *   * `Tags::Next<LinearSolver::Tags::IterationId>`
-   *   * `orthogonalization_iteration_id_tag`
-   */
-  using prepare_step =
-      detail::PrepareStep<FieldsTag, OptionsGroup, Preconditioned>;
-
-  /*!
-   * \brief Perform an iteration of the GMRES linear solver.
-   *
-   * \warning This action involves a blocking reduction, so it is a global
-   * synchronization point.
-   *
-   * With:
-   * - `operand_tag` =
-   * `db::add_tag_prefix<LinearSolver::Tags::Operand, FieldsTag>`
-   * - `orthogonalization_iteration_id_tag` =
-   * LinearSolver::Tags::Orthogonalization<LinearSolver::Tags::IterationId>`
-   * - `basis_history_tag` =
-   * `LinearSolver::Tags::KrylovSubspaceBasis<FieldsTag>`
-   *
-   * DataBox changes:
-   * - Adds: nothing
-   * - Removes: nothing
-   * - Modifies:
-   *   * `FieldsTag`
-   *   * `operand_tag`
-   *   * `orthogonalization_iteration_id_tag`
-   *   * `basis_history_tag`
-   *   * `LinearSolver::Tags::HasConverged`
-   */
-  using perform_step =
-      detail::PerformStep<FieldsTag, OptionsGroup, Preconditioned>;
+  template <typename ApplyOperatorActions, typename Label = OptionsGroup>
+  using solve = tmpl::list<
+      detail::PrepareSolve<FieldsTag, OptionsGroup, Preconditioned, Label>,
+      detail::NormalizeInitialOperand<FieldsTag, OptionsGroup, Preconditioned,
+                                      Label>,
+      detail::PrepareStep<FieldsTag, OptionsGroup, Preconditioned, Label>,
+      ApplyOperatorActions,
+      detail::PerformStep<FieldsTag, OptionsGroup, Preconditioned, Label>,
+      detail::OrthogonalizeOperand<FieldsTag, OptionsGroup, Preconditioned,
+                                   Label>,
+      detail::NormalizeOperandAndUpdateField<FieldsTag, OptionsGroup,
+                                             Preconditioned, Label>>;
 };
 
 }  // namespace LinearSolver::gmres

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/InitializeElement.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/InitializeElement.hpp
@@ -5,10 +5,13 @@
 
 #include <cstddef>
 #include <limits>
+#include <tuple>
+#include <type_traits>
+#include <utility>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
-#include "DataStructures/DataBox/Prefixes.hpp"
+#include "NumericalAlgorithms/Convergence/HasConverged.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
@@ -68,10 +68,9 @@ template <typename FieldsTag, typename OptionsGroup>
 struct InitializeResidualMonitor {
  private:
   using fields_tag = FieldsTag;
-  using residual_magnitude_tag = LinearSolver::Tags::Magnitude<
-      db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>>;
   using initial_residual_magnitude_tag =
-      LinearSolver::Tags::Initial<residual_magnitude_tag>;
+      LinearSolver::Tags::Initial<LinearSolver::Tags::Magnitude<
+          db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>>>;
   using orthogonalization_iteration_id_tag =
       LinearSolver::Tags::Orthogonalization<
           LinearSolver::Tags::IterationId<OptionsGroup>>;
@@ -88,24 +87,16 @@ struct InitializeResidualMonitor {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    using compute_tags = db::AddComputeTags<
-        LinearSolver::Tags::HasConvergedCompute<fields_tag, OptionsGroup>>;
     return std::make_tuple(
         ::Initialization::merge_into_databox<
             InitializeResidualMonitor,
-            db::AddSimpleTags<residual_magnitude_tag,
-                              initial_residual_magnitude_tag,
-                              LinearSolver::Tags::IterationId<OptionsGroup>,
-                              orthogonalization_iteration_id_tag,
-                              orthogonalization_history_tag>,
-            compute_tags>(std::move(box),
-                          // The `InitializeResidualMagnitude` action populates
-                          // these tags with initial values
-                          std::numeric_limits<double>::signaling_NaN(),
-                          std::numeric_limits<double>::signaling_NaN(),
-                          std::numeric_limits<size_t>::max(),
-                          std::numeric_limits<size_t>::max(),
-                          DenseMatrix<double>{}),
+            db::AddSimpleTags<initial_residual_magnitude_tag,
+                              orthogonalization_history_tag>>(
+            std::move(box),
+            // The `InitializeResidualMagnitude` action populates these tags
+            // with initial values
+            std::numeric_limits<double>::signaling_NaN(),
+            DenseMatrix<double>{}),
         true);
   }
 };

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
@@ -3,13 +3,15 @@
 
 #pragma once
 
+#include <cstddef>
+#include <limits>
+#include <utility>
+
 #include "AlgorithmSingleton.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
-#include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DenseMatrix.hpp"
 #include "IO/Observer/Actions/RegisterSingleton.hpp"
-#include "Informer/Tags.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
@@ -27,9 +29,6 @@ namespace LinearSolver::gmres::detail {
 template <typename FieldsTag, typename OptionsGroup>
 struct InitializeResidualMonitor;
 }  // namespace LinearSolver::gmres::detail
-namespace Convergence {
-struct Criteria;
-}  // namespace Convergence
 /// \endcond
 
 namespace LinearSolver::gmres::detail {
@@ -41,6 +40,9 @@ struct ResidualMonitor {
       tmpl::list<LinearSolver::Tags::Verbosity<OptionsGroup>,
                  LinearSolver::Tags::ConvergenceCriteria<OptionsGroup>>;
   using metavariables = Metavariables;
+  // The actions in `ResidualMonitorActions.hpp` are invoked as simple actions
+  // on this component as the result of reductions from the actions in
+  // `ElementActions.hpp`. See `LinearSolver::gmres::Gmres` for details.
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/Tags/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/Tags/CMakeLists.txt
@@ -5,11 +5,5 @@ spectre_target_headers(
   ParallelLinearSolver
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
-  ElementActions.hpp
-  Gmres.hpp
-  InitializeElement.hpp
-  ResidualMonitor.hpp
-  ResidualMonitorActions.hpp
+  InboxTags.hpp
   )
-
-add_subdirectory(Tags)

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/Tags/InboxTags.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/Tags/InboxTags.hpp
@@ -1,0 +1,40 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <map>
+#include <tuple>
+
+#include "DataStructures/DenseVector.hpp"
+#include "NumericalAlgorithms/Convergence/HasConverged.hpp"
+#include "Parallel/InboxInserters.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace LinearSolver::gmres::detail::Tags {
+
+template <typename OptionsGroup>
+struct InitialOrthogonalization
+    : Parallel::InboxInserters::Value<InitialOrthogonalization<OptionsGroup>> {
+  using temporal_id = size_t;
+  using type =
+      std::map<temporal_id, std::tuple<double, Convergence::HasConverged>>;
+};
+
+template <typename OptionsGroup>
+struct Orthogonalization
+    : Parallel::InboxInserters::Value<Orthogonalization<OptionsGroup>> {
+  using temporal_id = size_t;
+  using type = std::map<temporal_id, double>;
+};
+
+template <typename OptionsGroup>
+struct FinalOrthogonalization
+    : Parallel::InboxInserters::Value<FinalOrthogonalization<OptionsGroup>> {
+  using temporal_id = size_t;
+  using type = std::map<temporal_id, std::tuple<double, DenseVector<double>,
+                                                Convergence::HasConverged>>;
+};
+
+}  // namespace LinearSolver::gmres::detail::Tags

--- a/src/ParallelAlgorithms/LinearSolver/Observe.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Observe.hpp
@@ -3,6 +3,11 @@
 
 #pragma once
 
+#include <cstddef>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "IO/Observer/ObservationId.hpp"
@@ -14,6 +19,7 @@
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Reduction.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
+#include "Utilities/Functional.hpp"
 #include "Utilities/PrettyType.hpp"
 
 namespace LinearSolver {

--- a/src/ParallelAlgorithms/LinearSolver/Richardson/Richardson.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Richardson/Richardson.hpp
@@ -3,9 +3,14 @@
 
 #pragma once
 
+#include <cstddef>
+#include <tuple>
+#include <utility>
+
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
-#include "Options/Options.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "IO/Observer/Helpers.hpp"
 #include "ParallelAlgorithms/LinearSolver/AsynchronousSolvers/ElementActions.hpp"
 #include "ParallelAlgorithms/LinearSolver/Richardson/Tags.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
@@ -109,10 +114,11 @@ struct Richardson {
       async_solvers::InitializeElement<FieldsTag, OptionsGroup, SourceTag>;
   using register_element =
       async_solvers::RegisterElement<FieldsTag, OptionsGroup, SourceTag>;
-  using prepare_solve =
-      async_solvers::PrepareSolve<FieldsTag, OptionsGroup, SourceTag>;
-  using prepare_step = detail::UpdateFields<FieldsTag, OptionsGroup, SourceTag>;
-  using perform_step =
-      async_solvers::CompleteStep<FieldsTag, OptionsGroup, SourceTag>;
+  template <typename ApplyOperatorActions, typename Label = OptionsGroup>
+  using solve = tmpl::list<
+      async_solvers::PrepareSolve<FieldsTag, OptionsGroup, SourceTag, Label>,
+      detail::UpdateFields<FieldsTag, OptionsGroup, SourceTag>,
+      ApplyOperatorActions,
+      async_solvers::CompleteStep<FieldsTag, OptionsGroup, SourceTag, Label>>;
 };
 }  // namespace LinearSolver::Richardson

--- a/src/ParallelAlgorithms/LinearSolver/Tags.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Tags.hpp
@@ -174,7 +174,7 @@ struct MagnitudeCompute : Magnitude<typename MagnitudeSquareTag::tag>,
 };
 
 /*!
- * \brief The prefix for tags related to an orthogonalization procedurce
+ * \brief The prefix for tags related to an orthogonalization procedure
  */
 template <typename Tag>
 struct Orthogonalization : db::PrefixTag, db::SimpleTag {

--- a/src/ParallelAlgorithms/LinearSolver/Tags.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Tags.hpp
@@ -21,19 +21,6 @@
 #include "NumericalAlgorithms/Convergence/Criteria.hpp"
 #include "NumericalAlgorithms/Convergence/HasConverged.hpp"
 #include "Utilities/Gsl.hpp"
-#include "Utilities/Requires.hpp"
-#include "Utilities/TypeTraits/IsA.hpp"
-
-/// \cond
-namespace LinearSolver {
-namespace Tags {
-template <typename OptionsGroup>
-struct ConvergenceCriteria;
-template <typename OptionsGroup>
-struct Iterations;
-}  // namespace Tags
-}  // namespace LinearSolver
-/// \endcond
 
 /*!
  * \ingroup LinearSolverGroup
@@ -157,23 +144,6 @@ struct Magnitude : db::PrefixTag, db::SimpleTag {
 };
 
 /*!
- * \brief Compute the `LinearSolver::Magnitude` of a tag from its
- * `LinearSolver::MagnitudeSquare`.
- */
-template <typename MagnitudeSquareTag,
-          Requires<tt::is_a_v<MagnitudeSquare, MagnitudeSquareTag>> = nullptr>
-struct MagnitudeCompute : Magnitude<typename MagnitudeSquareTag::tag>,
-                          db::ComputeTag {
-  using base = Magnitude<typename MagnitudeSquareTag::tag>;
-  using return_type = double;
-  static void function(const gsl::not_null<double*> magnitude,
-                       const double magnitude_square) noexcept {
-    *magnitude = sqrt(magnitude_square);
-  }
-  using argument_tags = tmpl::list<MagnitudeSquareTag>;
-};
-
-/*!
  * \brief The prefix for tags related to an orthogonalization procedure
  */
 template <typename Tag>
@@ -236,54 +206,6 @@ struct HasConverged : db::SimpleTag {
     return "HasConverged(" + Options::name<OptionsGroup>() + ")";
   }
   using type = Convergence::HasConverged;
-};
-
-/*!
- * \brief Employs the `LinearSolver::Tags::ConvergenceCriteria` to
- * determine the linear solver has converged.
- */
-template <typename FieldsTag, typename OptionsGroup>
-struct HasConvergedCompute : LinearSolver::Tags::HasConverged<OptionsGroup>,
-                             db::ComputeTag {
- private:
-  using residual_magnitude_tag = LinearSolver::Tags::Magnitude<
-      db::add_tag_prefix<LinearSolver::Tags::Residual, FieldsTag>>;
-  using initial_residual_magnitude_tag =
-      LinearSolver::Tags::Initial<residual_magnitude_tag>;
-
- public:
-  using base = LinearSolver::Tags::HasConverged<OptionsGroup>;
-  using return_type = typename base::type;
-  using argument_tags =
-      tmpl::list<LinearSolver::Tags::ConvergenceCriteria<OptionsGroup>,
-                 LinearSolver::Tags::IterationId<OptionsGroup>,
-                 residual_magnitude_tag, initial_residual_magnitude_tag>;
-  static void function(const gsl::not_null<return_type*> has_converged,
-                       const Convergence::Criteria& convergence_criteria,
-                       const size_t iteration_id,
-                       const double residual_magnitude,
-                       const double initial_residual_magnitude) noexcept {
-    *has_converged = {convergence_criteria, iteration_id, residual_magnitude,
-                      initial_residual_magnitude};
-  }
-};
-
-/// Employs the `LinearSolver::Tags::Iterations` to determine the linear solver
-/// has converged once it has completed a fixed number of iterations.
-template <typename OptionsGroup>
-struct HasConvergedByIterationsCompute
-    : LinearSolver::Tags::HasConverged<OptionsGroup>,
-      db::ComputeTag {
-  using base = LinearSolver::Tags::HasConverged<OptionsGroup>;
-  using return_type = typename base::type;
-  using argument_tags =
-      tmpl::list<LinearSolver::Tags::Iterations<OptionsGroup>,
-                 LinearSolver::Tags::IterationId<OptionsGroup>>;
-  static void function(const gsl::not_null<return_type*> has_converged,
-                       const size_t iterations,
-                       const size_t iteration_id) noexcept {
-    *has_converged = {{iterations, 0., 0.}, iteration_id, 1., 1.};
-  }
 };
 
 }  // namespace Tags
@@ -390,20 +312,3 @@ struct Verbosity : db::SimpleTag {
 };
 }  // namespace Tags
 }  // namespace LinearSolver
-
-namespace Tags {
-
-template <typename OptionsGroup>
-struct NextCompute<LinearSolver::Tags::IterationId<OptionsGroup>>
-    : Next<LinearSolver::Tags::IterationId<OptionsGroup>>, db::ComputeTag {
-  using base = Next<LinearSolver::Tags::IterationId<OptionsGroup>>;
-  using return_type = typename base::type;
-  using argument_tags =
-      tmpl::list<LinearSolver::Tags::IterationId<OptionsGroup>>;
-  static void function(const gsl::not_null<return_type*> next_iteration_id,
-                       const size_t iteration_id) noexcept {
-    *next_iteration_id = iteration_id + 1;
-  }
-};
-
-}  // namespace Tags

--- a/tests/Unit/Framework/ActionTesting.hpp
+++ b/tests/Unit/Framework/ActionTesting.hpp
@@ -660,7 +660,8 @@ class MockDistributedObject {
 
   using metavariables = typename Component::metavariables;
 
-  using inbox_tags_list = Parallel::get_inbox_tags<all_actions_list>;
+  using inbox_tags_list =
+      Parallel::get_inbox_tags<tmpl::push_front<all_actions_list, Component>>;
 
   using array_index = typename Parallel::get_array_index<
       typename Component::chare_type>::template f<Component>;
@@ -1857,16 +1858,16 @@ class MockRuntimeSystem {
   template <typename Component>
   auto inboxes() noexcept -> std::unordered_map<
       typename Component::array_index,
-      tuples::tagged_tuple_from_typelist<Parallel::get_inbox_tags<
-          typename MockDistributedObject<Component>::all_actions_list>>>& {
+      tuples::tagged_tuple_from_typelist<
+          typename MockDistributedObject<Component>::inbox_tags_list>>& {
     return tuples::get<InboxesTag<Component>>(inboxes_);
   }
 
   template <typename Component>
   auto inboxes() const noexcept -> const std::unordered_map<
       typename Component::array_index,
-      tuples::tagged_tuple_from_typelist<Parallel::get_inbox_tags<
-          typename MockDistributedObject<Component>::all_actions_list>>>& {
+      tuples::tagged_tuple_from_typelist<
+          typename MockDistributedObject<Component>::inbox_tags_list>>& {
     return tuples::get<InboxesTag<Component>>(inboxes_);
   }
   // @}

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
@@ -219,7 +219,7 @@ struct CollectOperatorAction {
               Ap_local.begin());
     db::mutate<local_operator_applied_to_operand_tag>(
         make_not_null(&box),
-        [&Ap_local, &number_of_grid_points ](auto Ap) noexcept {
+        [&Ap_local, &number_of_grid_points](auto Ap) noexcept {
           *Ap = typename local_operator_applied_to_operand_tag::type{
               number_of_grid_points};
           get(get<LinearSolver::Tags::OperatorAppliedTo<ScalarFieldOperandTag>>(
@@ -252,8 +252,8 @@ struct TestResult {
     const auto& has_converged =
         get<LinearSolver::Tags::HasConverged<OptionsGroup>>(box);
     SPECTRE_PARALLEL_REQUIRE(has_converged);
-    SPECTRE_PARALLEL_REQUIRE(
-        has_converged.reason() == get<helpers::ExpectedConvergenceReason>(box));
+    SPECTRE_PARALLEL_REQUIRE(has_converged.reason() ==
+                             get<helpers::ExpectedConvergenceReason>(box));
     const auto& expected_result =
         gsl::at(get<ExpectedResult>(box), array_index);
     const auto& result = get<ScalarFieldTag>(box).get();

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
@@ -240,14 +240,8 @@ template <typename Preconditioner>
 struct run_preconditioner_impl {
   using type =
       tmpl::list<ComputeOperatorAction<typename Preconditioner::fields_tag>,
-                 typename Preconditioner::prepare_solve,
-                 ::Actions::RepeatUntil<
-                     LinearSolver::Tags::HasConverged<
-                         typename Preconditioner::options_group>,
-                     tmpl::list<typename Preconditioner::prepare_step,
-                                ComputeOperatorAction<
-                                    typename Preconditioner::operand_tag>,
-                                typename Preconditioner::perform_step>>>;
+                 typename Preconditioner::template solve<ComputeOperatorAction<
+                     typename Preconditioner::operand_tag>>>;
 };
 
 template <>
@@ -286,18 +280,15 @@ struct ElementArray {
           Metavariables::Phase::RegisterWithObserver,
           tmpl::list<typename linear_solver::register_element,
                      detail::register_preconditioner<preconditioner>,
-                     typename linear_solver::prepare_solve,
                      Parallel::Actions::TerminatePhase>>,
       Parallel::PhaseActions<
           typename Metavariables::Phase,
           Metavariables::Phase::PerformLinearSolve,
-          tmpl::list<LinearSolver::Actions::TerminateIfConverged<
-                         typename linear_solver::options_group>,
-                     typename linear_solver::prepare_step,
-                     detail::run_preconditioner<preconditioner>,
-                     ComputeOperatorAction<typename linear_solver::operand_tag>,
-                     typename linear_solver::perform_step>>,
-
+          tmpl::list<
+              typename linear_solver::template solve<tmpl::list<
+                  detail::run_preconditioner<preconditioner>,
+                  ComputeOperatorAction<typename linear_solver::operand_tag>>>,
+              Parallel::Actions::TerminatePhase>>,
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::TestResult,
           tmpl::list<TestResult<typename linear_solver::options_group>>>>;

--- a/tests/Unit/NumericalAlgorithms/Convergence/Test_HasConverged.cpp
+++ b/tests/Unit/NumericalAlgorithms/Convergence/Test_HasConverged.cpp
@@ -83,6 +83,23 @@ SPECTRE_TEST_CASE("Unit.Numerical.Convergence.HasConverged",
     test_serialization(has_converged);
     test_copy_semantics(has_converged);
   }
+
+  {
+    INFO("HasConverged - fixed number of iterations incomplete")
+    const Convergence::HasConverged has_converged{1, 0};
+    CHECK_FALSE(has_converged);
+    test_serialization(has_converged);
+    test_copy_semantics(has_converged);
+  }
+
+  {
+    INFO("HasConverged - fixed number of iterations complete")
+    const Convergence::HasConverged has_converged{1, 1};
+    CHECK(has_converged);
+    CHECK(has_converged.reason() == Convergence::Reason::MaxIterations);
+    test_serialization(has_converged);
+    test_copy_semantics(has_converged);
+  }
 }
 
 // [[OutputRegex, Tried to retrieve the convergence reason, but has not yet

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/Test_ElementActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/Test_ElementActions.cpp
@@ -59,9 +59,9 @@ struct ElementArray {
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Test,
           tmpl::list<LinearSolver::async_solvers::PrepareSolve<
-                         fields_tag, TestSolver, source_tag>,
+                         fields_tag, TestSolver, source_tag, TestSolver>,
                      LinearSolver::async_solvers::CompleteStep<
-                         fields_tag, TestSolver, source_tag>>>>;
+                         fields_tag, TestSolver, source_tag, TestSolver>>>>;
 };
 
 struct Metavariables {

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/Test_ElementActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/Test_ElementActions.cpp
@@ -163,7 +163,6 @@ SPECTRE_TEST_CASE("Unit.ParallelLinearSolver.Asynchronous.ElementActions",
     ActionTesting::next_action<element_array>(make_not_null(&runner),
                                               element_id);
     CHECK(get_tag(LinearSolver::Tags::IterationId<TestSolver>{}) == 0);
-    CHECK(get_tag(residual_magnitude_square_tag{}) == 27.);
     CHECK_FALSE(get_tag(LinearSolver::Tags::HasConverged<TestSolver>{}));
     ActionTesting::invoke_queued_simple_action<obs_component>(
         make_not_null(&runner), 0);
@@ -178,7 +177,6 @@ SPECTRE_TEST_CASE("Unit.ParallelLinearSolver.Asynchronous.ElementActions",
     ActionTesting::next_action<element_array>(make_not_null(&runner),
                                               element_id);
     CHECK(get_tag(LinearSolver::Tags::IterationId<TestSolver>{}) == 1);
-    CHECK(get_tag(residual_magnitude_square_tag{}) == 243.);
     CHECK(get_tag(LinearSolver::Tags::HasConverged<TestSolver>{}));
     ActionTesting::invoke_queued_simple_action<obs_component>(
         make_not_null(&runner), 0);

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ResidualMonitorActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ResidualMonitorActions.cpp
@@ -13,7 +13,6 @@
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
-#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DenseVector.hpp"
 #include "Framework/ActionTesting.hpp"
@@ -24,7 +23,7 @@
 #include "NumericalAlgorithms/Convergence/HasConverged.hpp"
 #include "NumericalAlgorithms/Convergence/Reason.hpp"
 #include "ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp"
-#include "ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp"  // IWYU pragma: keep
+#include "ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp"
 #include "ParallelAlgorithms/LinearSolver/Observe.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 #include "Utilities/Gsl.hpp"
@@ -32,20 +31,10 @@
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
-// IWYU pragma: no_forward_declare db::DataBox
-
 namespace Parallel {
 template <typename Metavariables>
 class GlobalCache;
 }  // namespace Parallel
-namespace LinearSolver::cg::detail {
-template <typename FieldsTag, typename OptionsGroup>
-struct InitializeHasConverged;
-template <typename FieldsTag, typename OptionsGroup>
-struct UpdateFieldValues;
-template <typename FieldsTag, typename OptionsGroup>
-struct UpdateOperand;
-}  // namespace LinearSolver::cg::detail
 
 namespace helpers = ResidualMonitorActionsTestHelpers;
 
@@ -62,14 +51,6 @@ using residual_square_tag = LinearSolver::Tags::MagnitudeSquare<
     LinearSolver::Tags::Residual<fields_tag>>;
 using initial_residual_magnitude_tag = LinearSolver::Tags::Initial<
     LinearSolver::Tags::Magnitude<LinearSolver::Tags::Residual<fields_tag>>>;
-
-struct CheckValueTag : db::SimpleTag {
-  using type = double;
-};
-
-using CheckConvergedTag = LinearSolver::Tags::HasConverged<TestLinearSolver>;
-
-using check_tags = tmpl::list<CheckValueTag, CheckConvergedTag>;
 
 template <typename Metavariables>
 struct MockResidualMonitor {
@@ -90,61 +71,6 @@ struct MockResidualMonitor {
           fields_tag, TestLinearSolver>>>>;
 };
 
-struct MockInitializeHasConverged {
-  template <
-      typename ParallelComponent, typename DbTagsList, typename Metavariables,
-      typename ArrayIndex,
-      Requires<tmpl::list_contains_v<DbTagsList, CheckConvergedTag>> = nullptr>
-  static void apply(db::DataBox<DbTagsList>& box,  // NOLINT
-                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
-                    const ArrayIndex& /*array_index*/,
-                    const Convergence::HasConverged& has_converged) noexcept {
-    db::mutate<CheckConvergedTag>(
-        make_not_null(&box),
-        [&has_converged](const gsl::not_null<Convergence::HasConverged*>
-                             check_converged) noexcept {
-          *check_converged = has_converged;
-        });
-  }
-};
-
-struct MockUpdateFieldValues {
-  template <
-      typename ParallelComponent, typename DbTagsList, typename Metavariables,
-      typename ArrayIndex,
-      Requires<tmpl::list_contains_v<DbTagsList, CheckValueTag>> = nullptr>
-  static void apply(db::DataBox<DbTagsList>& box,  // NOLINT
-                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
-                    const ArrayIndex& /*array_index*/,
-                    const double alpha) noexcept {
-    db::mutate<CheckValueTag>(
-        make_not_null(&box),
-        [alpha](const gsl::not_null<double*> check_value) noexcept {
-          *check_value = alpha;
-        });
-  }
-};
-
-struct MockUpdateOperand {
-  template <
-      typename ParallelComponent, typename DbTagsList, typename Metavariables,
-      typename ArrayIndex,
-      Requires<tmpl::list_contains_v<DbTagsList, CheckValueTag>> = nullptr>
-  static void apply(db::DataBox<DbTagsList>& box,  // NOLINT
-                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
-                    const ArrayIndex& /*array_index*/, const double res_ratio,
-                    const Convergence::HasConverged& has_converged) noexcept {
-    db::mutate<CheckValueTag, CheckConvergedTag>(
-        make_not_null(&box), [res_ratio, &has_converged](
-                                 const gsl::not_null<double*> check_value,
-                                 const gsl::not_null<Convergence::HasConverged*>
-                                     check_converged) noexcept {
-          *check_value = res_ratio;
-          *check_converged = has_converged;
-        });
-  }
-};
-
 // This is used to receive action calls from the residual monitor
 template <typename Metavariables>
 struct MockElementArray {
@@ -152,18 +78,15 @@ struct MockElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      typename Metavariables::Phase, Metavariables::Phase::Initialization,
-      tmpl::list<ActionTesting::InitializeDataBox<check_tags>>>>;
-
-  using replace_these_simple_actions = tmpl::list<
-      LinearSolver::cg::detail::InitializeHasConverged<fields_tag,
-                                                       TestLinearSolver>,
-      LinearSolver::cg::detail::UpdateFieldValues<fields_tag, TestLinearSolver>,
-      LinearSolver::cg::detail::UpdateOperand<fields_tag, TestLinearSolver>>;
-  using with_these_simple_actions =
-      tmpl::list<MockInitializeHasConverged, MockUpdateFieldValues,
-                 MockUpdateOperand>;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Initialization,
+                                        tmpl::list<>>>;
+  using inbox_tags = tmpl::list<
+      LinearSolver::cg::detail::Tags::InitialHasConverged<TestLinearSolver>,
+      LinearSolver::cg::detail::Tags::Alpha<TestLinearSolver>,
+      LinearSolver::cg::detail::Tags::ResidualRatioAndHasConverged<
+          TestLinearSolver>>;
 };
 
 struct Metavariables {
@@ -190,10 +113,7 @@ SPECTRE_TEST_CASE(
   ActionTesting::next_action<residual_monitor>(make_not_null(&runner), 0);
 
   // Setup mock element array
-  ActionTesting::emplace_component_and_initialize<element_array>(
-      &runner, 0,
-      {std::numeric_limits<double>::signaling_NaN(),
-       Convergence::HasConverged{}});
+  ActionTesting::emplace_component<element_array>(&runner, 0);
 
   // Setup mock observer writer
   ActionTesting::emplace_component_and_initialize<observer_writer>(
@@ -208,9 +128,9 @@ SPECTRE_TEST_CASE(
     using tag = std::decay_t<decltype(tag_v)>;
     return ActionTesting::get_databox_tag<residual_monitor, tag>(runner, 0);
   };
-  const auto get_element_tag = [&runner](auto tag_v) -> decltype(auto) {
+  const auto get_element_inbox_tag = [&runner](auto tag_v) -> decltype(auto) {
     using tag = std::decay_t<decltype(tag_v)>;
-    return ActionTesting::get_databox_tag<element_array, tag>(runner, 0);
+    return ActionTesting::get_inbox_tag<element_array, tag>(runner, 0);
   };
   const auto get_observer_writer_tag = [&runner](auto tag_v) -> decltype(auto) {
     using tag = std::decay_t<decltype(tag_v)>;
@@ -227,17 +147,19 @@ SPECTRE_TEST_CASE(
         make_not_null(&runner), 0, 4.);
     ActionTesting::invoke_queued_threaded_action<observer_writer>(
         make_not_null(&runner), 0);
-    ActionTesting::invoke_queued_simple_action<element_array>(
-        make_not_null(&runner), 0);
     // Test residual monitor state
     CHECK(get_residual_monitor_tag(residual_square_tag{}) == 4.);
     CHECK(get_residual_monitor_tag(initial_residual_magnitude_tag{}) == 2.);
     CHECK(get_residual_monitor_tag(
               LinearSolver::Tags::IterationId<TestLinearSolver>{}) == 0);
-    CHECK_FALSE(get_residual_monitor_tag(
-        LinearSolver::Tags::HasConverged<TestLinearSolver>{}));
+    const auto& has_converged = get_residual_monitor_tag(
+        LinearSolver::Tags::HasConverged<TestLinearSolver>{});
+    CHECK_FALSE(has_converged);
     // Test element state
-    CHECK_FALSE(get_element_tag(CheckConvergedTag{}));
+    CHECK(get_element_inbox_tag(
+              LinearSolver::cg::detail::Tags::InitialHasConverged<
+                  TestLinearSolver>{})
+              .at(0) == has_converged);
     // Test observer writer state
     CHECK(
         get_observer_writer_tag(helpers::CheckObservationIdTag{}) ==
@@ -257,17 +179,19 @@ SPECTRE_TEST_CASE(
         residual_monitor, LinearSolver::cg::detail::InitializeResidual<
                               fields_tag, TestLinearSolver, element_array>>(
         make_not_null(&runner), 0, 0.);
-    ActionTesting::invoke_queued_simple_action<element_array>(
-        make_not_null(&runner), 0);
     // Test residual monitor state
     CHECK(get_residual_monitor_tag(residual_square_tag{}) == 0.);
     CHECK(get_residual_monitor_tag(initial_residual_magnitude_tag{}) == 0.);
     CHECK(get_residual_monitor_tag(
               LinearSolver::Tags::IterationId<TestLinearSolver>{}) == 0);
-    CHECK(get_residual_monitor_tag(
-        LinearSolver::Tags::HasConverged<TestLinearSolver>{}));
+    const auto& has_converged = get_residual_monitor_tag(
+        LinearSolver::Tags::HasConverged<TestLinearSolver>{});
+    CHECK(has_converged);
     // Test element state
-    CHECK(get_element_tag(CheckConvergedTag{}));
+    CHECK(get_element_inbox_tag(
+              LinearSolver::cg::detail::Tags::InitialHasConverged<
+                  TestLinearSolver>{})
+              .at(0) == has_converged);
   }
 
   SECTION("ComputeAlpha") {
@@ -275,20 +199,18 @@ SPECTRE_TEST_CASE(
         residual_monitor, LinearSolver::cg::detail::InitializeResidual<
                               fields_tag, TestLinearSolver, element_array>>(
         make_not_null(&runner), 0, 1.);
-    ActionTesting::invoke_queued_simple_action<element_array>(
-        make_not_null(&runner), 0);
     ActionTesting::simple_action<
         residual_monitor, LinearSolver::cg::detail::ComputeAlpha<
                               fields_tag, TestLinearSolver, element_array>>(
         make_not_null(&runner), 0, 2.);
-    ActionTesting::invoke_queued_simple_action<element_array>(
-        make_not_null(&runner), 0);
     // Test residual monitor state
     CHECK(get_residual_monitor_tag(residual_square_tag{}) == 1.);
     CHECK(get_residual_monitor_tag(
               LinearSolver::Tags::IterationId<TestLinearSolver>{}) == 0);
     // Test element state
-    CHECK(get_element_tag(CheckValueTag{}) == 0.5);
+    CHECK(get_element_inbox_tag(
+              LinearSolver::cg::detail::Tags::Alpha<TestLinearSolver>{})
+              .at(0) == 0.5);
   }
 
   SECTION("UpdateResidual") {
@@ -298,14 +220,10 @@ SPECTRE_TEST_CASE(
         make_not_null(&runner), 0, 9.);
     ActionTesting::invoke_queued_threaded_action<observer_writer>(
         make_not_null(&runner), 0);
-    ActionTesting::invoke_queued_simple_action<element_array>(
-        make_not_null(&runner), 0);
     ActionTesting::simple_action<
         residual_monitor, LinearSolver::cg::detail::UpdateResidual<
                               fields_tag, TestLinearSolver, element_array>>(
         make_not_null(&runner), 0, 4.);
-    ActionTesting::invoke_queued_simple_action<element_array>(
-        make_not_null(&runner), 0);
     ActionTesting::invoke_queued_threaded_action<observer_writer>(
         make_not_null(&runner), 0);
     // Test residual monitor state
@@ -313,13 +231,17 @@ SPECTRE_TEST_CASE(
     CHECK(get_residual_monitor_tag(initial_residual_magnitude_tag{}) == 3.);
     CHECK(get_residual_monitor_tag(
               LinearSolver::Tags::IterationId<TestLinearSolver>{}) == 1);
-    CHECK_FALSE(get_residual_monitor_tag(
-        LinearSolver::Tags::HasConverged<TestLinearSolver>{}));
+    const auto& has_converged = get_residual_monitor_tag(
+        LinearSolver::Tags::HasConverged<TestLinearSolver>{});
+    CHECK_FALSE(has_converged);
     // Test element state
-    CHECK(get_element_tag(CheckValueTag{}) == approx(4. / 9.));
-    CHECK(get_element_tag(CheckConvergedTag{}) ==
-          get_residual_monitor_tag(
-              LinearSolver::Tags::HasConverged<TestLinearSolver>{}));
+    const auto& element_inbox =
+        get_element_inbox_tag(
+            LinearSolver::cg::detail::Tags::ResidualRatioAndHasConverged<
+                TestLinearSolver>{})
+            .at(0);
+    CHECK(get<0>(element_inbox) == approx(4. / 9.));
+    CHECK(get<1>(element_inbox) == has_converged);
     // Test observer writer state
     CHECK(
         get_observer_writer_tag(helpers::CheckObservationIdTag{}) ==
@@ -339,29 +261,27 @@ SPECTRE_TEST_CASE(
         residual_monitor, LinearSolver::cg::detail::InitializeResidual<
                               fields_tag, TestLinearSolver, element_array>>(
         make_not_null(&runner), 0, 1.);
-    ActionTesting::invoke_queued_simple_action<element_array>(
-        make_not_null(&runner), 0);
     ActionTesting::simple_action<
         residual_monitor, LinearSolver::cg::detail::UpdateResidual<
                               fields_tag, TestLinearSolver, element_array>>(
         make_not_null(&runner), 0, 0.);
-    ActionTesting::invoke_queued_simple_action<element_array>(
-        make_not_null(&runner), 0);
     // Test residual monitor state
     CHECK(get_residual_monitor_tag(residual_square_tag{}) == 0.);
     CHECK(get_residual_monitor_tag(initial_residual_magnitude_tag{}) == 1.);
     CHECK(get_residual_monitor_tag(
               LinearSolver::Tags::IterationId<TestLinearSolver>{}) == 1);
-    CHECK(get_residual_monitor_tag(
-        LinearSolver::Tags::HasConverged<TestLinearSolver>{}));
-    CHECK(get_residual_monitor_tag(
-              LinearSolver::Tags::HasConverged<TestLinearSolver>{})
-              .reason() == Convergence::Reason::AbsoluteResidual);
+    const auto& has_converged = get_residual_monitor_tag(
+        LinearSolver::Tags::HasConverged<TestLinearSolver>{});
+    REQUIRE(has_converged);
+    CHECK(has_converged.reason() == Convergence::Reason::AbsoluteResidual);
     // Test element state
-    CHECK(get_element_tag(CheckValueTag{}) == 0.);
-    CHECK(get_element_tag(CheckConvergedTag{}) ==
-          get_residual_monitor_tag(
-              LinearSolver::Tags::HasConverged<TestLinearSolver>{}));
+    const auto& element_inbox =
+        get_element_inbox_tag(
+            LinearSolver::cg::detail::Tags::ResidualRatioAndHasConverged<
+                TestLinearSolver>{})
+            .at(0);
+    CHECK(get<0>(element_inbox) == 0.);
+    CHECK(get<1>(element_inbox) == has_converged);
   }
 
   SECTION("ConvergeByMaxIterations") {
@@ -369,36 +289,32 @@ SPECTRE_TEST_CASE(
         residual_monitor, LinearSolver::cg::detail::InitializeResidual<
                               fields_tag, TestLinearSolver, element_array>>(
         make_not_null(&runner), 0, 1.);
-    ActionTesting::invoke_queued_simple_action<element_array>(
-        make_not_null(&runner), 0);
     // Perform 2 mock iterations
     ActionTesting::simple_action<
         residual_monitor, LinearSolver::cg::detail::UpdateResidual<
                               fields_tag, TestLinearSolver, element_array>>(
         make_not_null(&runner), 0, 1.);
-    ActionTesting::invoke_queued_simple_action<element_array>(
-        make_not_null(&runner), 0);
     ActionTesting::simple_action<
         residual_monitor, LinearSolver::cg::detail::UpdateResidual<
                               fields_tag, TestLinearSolver, element_array>>(
         make_not_null(&runner), 0, 1.);
-    ActionTesting::invoke_queued_simple_action<element_array>(
-        make_not_null(&runner), 0);
     // Test residual monitor state
     CHECK(get_residual_monitor_tag(residual_square_tag{}) == 1.);
     CHECK(get_residual_monitor_tag(initial_residual_magnitude_tag{}) == 1.);
     CHECK(get_residual_monitor_tag(
               LinearSolver::Tags::IterationId<TestLinearSolver>{}) == 2);
-    CHECK(get_residual_monitor_tag(
-        LinearSolver::Tags::HasConverged<TestLinearSolver>{}));
-    CHECK(get_residual_monitor_tag(
-              LinearSolver::Tags::HasConverged<TestLinearSolver>{})
-              .reason() == Convergence::Reason::MaxIterations);
+    const auto& has_converged = get_residual_monitor_tag(
+        LinearSolver::Tags::HasConverged<TestLinearSolver>{});
+    REQUIRE(has_converged);
+    CHECK(has_converged.reason() == Convergence::Reason::MaxIterations);
     // Test element state
-    CHECK(get_element_tag(CheckValueTag{}) == 1.);
-    CHECK(get_element_tag(CheckConvergedTag{}) ==
-          get_residual_monitor_tag(
-              LinearSolver::Tags::HasConverged<TestLinearSolver>{}));
+    const auto& element_inbox =
+        get_element_inbox_tag(
+            LinearSolver::cg::detail::Tags::ResidualRatioAndHasConverged<
+                TestLinearSolver>{})
+            .at(1);
+    CHECK(get<0>(element_inbox) == 1.);
+    CHECK(get<1>(element_inbox) == has_converged);
   }
 
   SECTION("ConvergeByRelativeResidual") {
@@ -406,28 +322,26 @@ SPECTRE_TEST_CASE(
         residual_monitor, LinearSolver::cg::detail::InitializeResidual<
                               fields_tag, TestLinearSolver, element_array>>(
         make_not_null(&runner), 0, 1.);
-    ActionTesting::invoke_queued_simple_action<element_array>(
-        make_not_null(&runner), 0);
     ActionTesting::simple_action<
         residual_monitor, LinearSolver::cg::detail::UpdateResidual<
                               fields_tag, TestLinearSolver, element_array>>(
         make_not_null(&runner), 0, 0.25);
-    ActionTesting::invoke_queued_simple_action<element_array>(
-        make_not_null(&runner), 0);
     // Test residual monitor state
     CHECK(get_residual_monitor_tag(residual_square_tag{}) == 0.25);
     CHECK(get_residual_monitor_tag(initial_residual_magnitude_tag{}) == 1.);
     CHECK(get_residual_monitor_tag(
               LinearSolver::Tags::IterationId<TestLinearSolver>{}) == 1);
-    CHECK(get_residual_monitor_tag(
-        LinearSolver::Tags::HasConverged<TestLinearSolver>{}));
-    CHECK(get_residual_monitor_tag(
-              LinearSolver::Tags::HasConverged<TestLinearSolver>{})
-              .reason() == Convergence::Reason::RelativeResidual);
+    const auto& has_converged = get_residual_monitor_tag(
+        LinearSolver::Tags::HasConverged<TestLinearSolver>{});
+    REQUIRE(has_converged);
+    CHECK(has_converged.reason() == Convergence::Reason::RelativeResidual);
     // Test element state
-    CHECK(get_element_tag(CheckValueTag{}) == 0.25);
-    CHECK(get_element_tag(CheckConvergedTag{}) ==
-          get_residual_monitor_tag(
-              LinearSolver::Tags::HasConverged<TestLinearSolver>{}));
+    const auto& element_inbox =
+        get_element_inbox_tag(
+            LinearSolver::cg::detail::Tags::ResidualRatioAndHasConverged<
+                TestLinearSolver>{})
+            .at(0);
+    CHECK(get<0>(element_inbox) == 0.25);
+    CHECK(get<1>(element_inbox) == has_converged);
   }
 }

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Test_Tags.cpp
@@ -9,11 +9,7 @@
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
-#include "NumericalAlgorithms/Convergence/Criteria.hpp"
-#include "NumericalAlgorithms/Convergence/HasConverged.hpp"
-#include "NumericalAlgorithms/Convergence/Reason.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
-#include "Utilities/Literals.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace {
@@ -23,12 +19,6 @@ struct Tag : db::SimpleTag {
 struct TestOptionsGroup {
   static std::string name() noexcept { return "TestLinearSolver"; }
 };
-using magnitude_square_tag = LinearSolver::Tags::MagnitudeSquare<Tag>;
-using magnitude_tag = LinearSolver::Tags::Magnitude<Tag>;
-using residual_magnitude_tag =
-    LinearSolver::Tags::Magnitude<LinearSolver::Tags::Residual<Tag>>;
-using initial_residual_magnitude_tag =
-    LinearSolver::Tags::Initial<residual_magnitude_tag>;
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.LinearSolver.Tags",
@@ -71,67 +61,6 @@ SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.LinearSolver.Tags",
       "Verbosity(TestLinearSolver)");
 
   {
-    INFO("HasConvergedCompute");
-    TestHelpers::db::test_compute_tag<
-        LinearSolver::Tags::HasConvergedCompute<Tag, TestOptionsGroup>>(
-        "HasConverged(TestLinearSolver)");
-    const auto box = db::create<
-        db::AddSimpleTags<
-            LinearSolver::Tags::ConvergenceCriteria<TestOptionsGroup>,
-            LinearSolver::Tags::IterationId<TestOptionsGroup>,
-            residual_magnitude_tag, initial_residual_magnitude_tag>,
-        db::AddComputeTags<
-            LinearSolver::Tags::HasConvergedCompute<Tag, TestOptionsGroup>>>(
-        Convergence::Criteria{2, 0., 0.5}, 2_st, 1., 1.);
-    CHECK(db::get<LinearSolver::Tags::HasConverged<TestOptionsGroup>>(box));
-    CHECK(db::get<LinearSolver::Tags::HasConverged<TestOptionsGroup>>(box)
-              .reason() == Convergence::Reason::MaxIterations);
-  }
-
-  {
-    INFO("HasConvergedCompute - Zero initial residual");
-    // A vanishing initial residual should work because the absolute residual
-    // condition takes precedence so that no FPE occurs
-    const auto box = db::create<
-        db::AddSimpleTags<
-            LinearSolver::Tags::ConvergenceCriteria<TestOptionsGroup>,
-            LinearSolver::Tags::IterationId<TestOptionsGroup>,
-            residual_magnitude_tag, initial_residual_magnitude_tag>,
-        db::AddComputeTags<
-            LinearSolver::Tags::HasConvergedCompute<Tag, TestOptionsGroup>>>(
-        Convergence::Criteria{2, 0., 0.5}, 1_st, 0., 0.);
-    CHECK(db::get<LinearSolver::Tags::HasConverged<TestOptionsGroup>>(box));
-    CHECK(db::get<LinearSolver::Tags::HasConverged<TestOptionsGroup>>(box)
-              .reason() == Convergence::Reason::AbsoluteResidual);
-  }
-
-  {
-    INFO("HasConvergedByIterationsCompute - not converged");
-    TestHelpers::db::test_compute_tag<
-        LinearSolver::Tags::HasConvergedByIterationsCompute<TestOptionsGroup>>(
-        "HasConverged(TestLinearSolver)");
-    const auto box = db::create<
-        db::AddSimpleTags<LinearSolver::Tags::Iterations<TestOptionsGroup>,
-                          LinearSolver::Tags::IterationId<TestOptionsGroup>>,
-        db::AddComputeTags<LinearSolver::Tags::HasConvergedByIterationsCompute<
-            TestOptionsGroup>>>(2_st, 1_st);
-    CHECK_FALSE(
-        db::get<LinearSolver::Tags::HasConverged<TestOptionsGroup>>(box));
-  }
-
-  {
-    INFO("HasConvergedByIterationsCompute - has converged");
-    const auto box = db::create<
-        db::AddSimpleTags<LinearSolver::Tags::Iterations<TestOptionsGroup>,
-                          LinearSolver::Tags::IterationId<TestOptionsGroup>>,
-        db::AddComputeTags<LinearSolver::Tags::HasConvergedByIterationsCompute<
-            TestOptionsGroup>>>(2_st, 2_st);
-    CHECK(db::get<LinearSolver::Tags::HasConverged<TestOptionsGroup>>(box));
-    CHECK(db::get<LinearSolver::Tags::HasConverged<TestOptionsGroup>>(box)
-              .reason() == Convergence::Reason::MaxIterations);
-  }
-
-  {
     INFO("ResidualCompute");
     TestHelpers::db::test_compute_tag<
         LinearSolver::Tags::ResidualCompute<Tag, ::Tags::Source<Tag>>>(
@@ -144,20 +73,4 @@ SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.LinearSolver.Tags",
                                                                             2);
     CHECK(db::get<LinearSolver::Tags::Residual<Tag>>(box) == 1);
   }
-
-  {
-    INFO("MagnitudeCompute");
-    TestHelpers::db::test_compute_tag<
-        LinearSolver::Tags::MagnitudeCompute<magnitude_square_tag>>(
-        "LinearMagnitude(Tag)");
-    const auto box =
-        db::create<db::AddSimpleTags<magnitude_square_tag>,
-                   db::AddComputeTags<LinearSolver::Tags::MagnitudeCompute<
-                       magnitude_square_tag>>>(4.);
-    CHECK(db::get<magnitude_tag>(box) == approx(2.));
-  }
-
-  TestHelpers::db::test_compute_tag<
-      Tags::NextCompute<LinearSolver::Tags::IterationId<TestOptionsGroup>>>(
-      "Next(IterationId(TestLinearSolver))");
 }


### PR DESCRIPTION
## Proposed changes

This is a housekeeping PR to address #2425, #2186 (at least partially) and reduce the number of compute tags in the linear solver code. These changes reduce the complexity of the code significantly and make it (hopefully) easier to understand. Here's the changes:

- Use `receive_data` and iterable actions for the parallel linear solvers instead of terminating the algorithm and restarting it with simple actions (came up in a review by @moxcodes and more recently by @nilsdeppe, discussed in #2186 and #2425).

  Note that this applies to the element array. Reductions still invoke simple actions on the residual monitor singletons, since synchronizing actions lists and their phases between components is currently quite painful (e.g. we have many components that hard-code the init and registration phase names because of this).
- The change in architecture now allows to loop the parallel linear solver algorithm directly in the iterable actions, instead of relying on `RepeatUntil`. So parallel linear solvers now just expose a single action list that does the solve. The looping actions are nicely indented in the action list because they are template parameters (see e.g. `SolvePoissonProblem.hpp`), which addresses my concern in #2356 that loops should be visible in the PDALs.
- Fix includes (closes #2425) and linking.

The last commit also removes a bunch of unnecessary compute tags from linear solvers, which reduces the complexity of the  code significantly. I could factor that commit into an extra PR if reviewers prefer.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
