### PR TITLE
Symlink Python executables on configure

### DIFF
--- a/cmake/SpectreSetupPythonPackage.cmake
+++ b/cmake/SpectreSetupPythonPackage.cmake
@@ -285,8 +285,6 @@ function (spectre_python_add_dependencies LIBRARY_NAME)
     )
 endfunction()
 
-add_custom_target(python-executables)
-
 # Register a Python file as an executable. It will be symlinked to bin/.
 # - EXECUTABLE_NAME   The name of the executable in bin/
 #
@@ -296,11 +294,10 @@ add_custom_target(python-executables)
 #                     configured by calling `spectre_python_add_module`, _not_
 #                     the path to the Python file in `src/`.
 function (spectre_python_add_executable EXECUTABLE_NAME EXECUTABLE_PATH)
-  add_custom_target(${EXECUTABLE_NAME} ALL
+  execute_process(
     COMMAND ${CMAKE_COMMAND} -E create_symlink
     "${SPECTRE_PYTHON_PREFIX}/${EXECUTABLE_PATH}"
     "${CMAKE_BINARY_DIR}/bin/${EXECUTABLE_NAME}")
-  add_dependencies(python-executables ${EXECUTABLE_NAME})
 endfunction()
 
 # Register a python test file with ctest.


### PR DESCRIPTION
## Proposed changes

Create the symlinks directly when running cmake, instead of having to `make` them.

Fixes #1928.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
