### PR TITLE
Fix ObservationId serialization

### DIFF
--- a/src/IO/CMakeLists.txt
+++ b/src/IO/CMakeLists.txt
@@ -21,7 +21,7 @@ spectre_target_headers(
 target_link_libraries(
   ${LIBRARY}
   PUBLIC
-  Boost::boost # PUBLIC because of the actions
+  Boost::boost
   DataStructures
   ErrorHandling
   Hdf5

--- a/src/IO/Observer/ObservationId.cpp
+++ b/src/IO/Observer/ObservationId.cpp
@@ -3,14 +3,22 @@
 
 #include "IO/Observer/ObservationId.hpp"
 
+#include <boost/functional/hash.hpp>
+#include <cstddef>
 #include <ostream>
 #include <pup.h>
+#include <pup_stl.h>
+#include <string>
+#include <utility>
 
 namespace observers {
 ObservationKey::ObservationKey(std::string tag) noexcept
     : key_(std::hash<std::string>{}(tag)), tag_(std::move(tag)) {}
 
-void ObservationKey::pup(PUP::er& p) noexcept { p | key_; }
+void ObservationKey::pup(PUP::er& p) noexcept {
+  p | key_;
+  p | tag_;
+}
 
 const std::string& ObservationKey::tag() const noexcept { return tag_; }
 

--- a/tests/Unit/IO/Observers/Test_ObservationId.cpp
+++ b/tests/Unit/IO/Observers/Test_ObservationId.cpp
@@ -53,5 +53,6 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.ObservationId", "[Unit][Observers]") {
   CHECK(key0 != key1);
   CHECK(key0 == id0.observation_key());
   CHECK(get_output(key0) == "(" + get_output(key0.tag()) + ")");
+  test_serialization(key0);
 }
 }  // namespace observers


### PR DESCRIPTION
## Proposed changes

This PR fixes a bug where the observer diagnostics didn't output the observation key when it was sent through Charm++.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
