### PR TITLE
Remove unused observation types

### DIFF
--- a/src/Elliptic/Executables/Elasticity/SolveElasticityProblem.hpp
+++ b/src/Elliptic/Executables/Elasticity/SolveElasticityProblem.hpp
@@ -143,7 +143,6 @@ struct Metavariables {
       Tags::EventsAndTriggers<events, triggers>>;
 
   // Collect all reduction tags for observers
-  struct element_observation_type {};
   using observed_reduction_data_tags =
       observers::collect_reduction_data_tags<tmpl::flatten<tmpl::list<
           typename Event<events>::creatable_classes, linear_solver>>>;

--- a/src/Elliptic/Executables/Poisson/SolvePoissonProblem.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoissonProblem.hpp
@@ -137,7 +137,6 @@ struct Metavariables {
                  Tags::EventsAndTriggers<events, triggers>>;
 
   // Collect all reduction tags for observers
-  struct element_observation_type {};
   using observed_reduction_data_tags =
       observers::collect_reduction_data_tags<tmpl::flatten<tmpl::list<
           typename Event<events>::creatable_classes, linear_solver>>>;

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -163,9 +163,6 @@ struct EvolutionMetavars {
       tmpl::list<initial_data_tag, normal_dot_numerical_flux, time_stepper_tag,
                  Tags::EventsAndTriggers<events, triggers>>;
 
-  struct ObservationType {};
-  using element_observation_type = ObservationType;
-
   using observed_reduction_data_tags = observers::collect_reduction_data_tags<
       typename Event<events>::creatable_classes>;
 

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -245,9 +245,6 @@ struct EvolutionMetavars {
       tmpl::list<analytic_solution_tag, normal_dot_numerical_flux,
                  time_stepper_tag, Tags::EventsAndTriggers<events, triggers>>;
 
-  struct ObservationType {};
-  using element_observation_type = ObservationType;
-
   using observed_reduction_data_tags = observers::collect_reduction_data_tags<
       tmpl::push_back<typename Event<observation_events>::creatable_classes,
                       typename AhA::post_horizon_find_callback>>;

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -223,9 +223,6 @@ struct EvolutionMetavars {
       grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin,
       grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::PalenzuelaEtAl>;
 
-  struct ObservationType {};
-  using element_observation_type = ObservationType;
-
   using interpolation_target_tags = tmpl::list<InterpolationTargetTags...>;
 
   using observed_reduction_data_tags =

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -185,9 +185,6 @@ struct EvolutionMetavars {
       Events::Registrars::ChangeSlabSize<slab_choosers>>>;
   using triggers = Triggers::time_triggers;
 
-  struct ObservationType {};
-  using element_observation_type = ObservationType;
-
   using observed_reduction_data_tags = observers::collect_reduction_data_tags<
       typename Event<events>::creatable_classes>;
 

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -171,9 +171,6 @@ struct EvolutionMetavars {
       Events::Registrars::ChangeSlabSize<slab_choosers>>>;
   using triggers = Triggers::time_triggers;
 
-  struct ObservationType {};
-  using element_observation_type = ObservationType;
-
   using observed_reduction_data_tags = observers::collect_reduction_data_tags<
       typename Event<events>::creatable_classes>;
 

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -182,9 +182,6 @@ struct EvolutionMetavars {
       Events::Registrars::ChangeSlabSize<slab_choosers>>;
   using triggers = Triggers::time_triggers;
 
-  struct ObservationType {};
-  using element_observation_type = ObservationType;
-
   using observed_reduction_data_tags = observers::collect_reduction_data_tags<
       typename Event<events>::creatable_classes>;
 

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -155,9 +155,6 @@ struct EvolutionMetavars {
       tmpl::list<initial_data_tag, normal_dot_numerical_flux, time_stepper_tag,
                  Tags::EventsAndTriggers<events, triggers>>;
 
-  struct ObservationType {};
-  using element_observation_type = ObservationType;
-
   using observed_reduction_data_tags = observers::collect_reduction_data_tags<
       typename Event<events>::creatable_classes>;
 

--- a/src/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/ElementActions.hpp
@@ -51,9 +51,6 @@ using reduction_data = Parallel::ReductionData<
     // Residual
     Parallel::ReductionDatum<double, funcl::Plus<>, funcl::Sqrt<>>>;
 
-template <typename OptionsGroup>
-struct ElementObservationType {};
-
 template <typename FieldsTag, typename OptionsGroup, typename ParallelComponent,
           typename DbTagsList, typename Metavariables, typename ArrayIndex>
 void contribute_to_residual_observation(
@@ -75,9 +72,8 @@ void contribute_to_residual_observation(
            .ckLocalBranch();
   Parallel::simple_action<observers::Actions::ContributeReductionData>(
       local_observer,
-      observers::ObservationId(
-          iteration_id,
-          pretty_type::get_name<ElementObservationType<OptionsGroup>>()),
+      observers::ObservationId(iteration_id,
+                               pretty_type::get_name<OptionsGroup>()),
       observers::ArrayComponentId{
           std::add_pointer_t<ParallelComponent>{nullptr},
           Parallel::ArrayIndex<ArrayIndex>(array_index)},
@@ -155,8 +151,7 @@ struct RegisterObservers {
   register_info(const db::DataBox<DbTagsList>& /*box*/,
                 const ArrayIndex& /*array_index*/) noexcept {
     return {observers::TypeOfObservation::Reduction,
-            observers::ObservationKey{
-                pretty_type::get_name<ElementObservationType<OptionsGroup>>()}};
+            observers::ObservationKey{pretty_type::get_name<OptionsGroup>()}};
   }
 };
 

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp
@@ -48,7 +48,7 @@ struct ResidualMonitor {
           typename Metavariables::Phase,
           Metavariables::Phase::RegisterWithObserver,
           tmpl::list<observers::Actions::RegisterSingletonWithObserverWriter<
-              LinearSolver::observe_detail::Registration>>>>;
+              LinearSolver::observe_detail::Registration<OptionsGroup>>>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
@@ -49,7 +49,7 @@ struct ResidualMonitor {
           typename Metavariables::Phase,
           Metavariables::Phase::RegisterWithObserver,
           tmpl::list<observers::Actions::RegisterSingletonWithObserverWriter<
-              LinearSolver::observe_detail::Registration>>>>;
+              LinearSolver::observe_detail::Registration<OptionsGroup>>>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 

--- a/src/ParallelAlgorithms/LinearSolver/Observe.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Observe.hpp
@@ -14,6 +14,7 @@
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Reduction.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
+#include "Utilities/PrettyType.hpp"
 
 namespace LinearSolver {
 namespace observe_detail {
@@ -24,8 +25,7 @@ using reduction_data = Parallel::ReductionData<
     // Residual
     Parallel::ReductionDatum<double, funcl::AssertEqual<>>>;
 
-struct ObservationType {};
-
+template <typename OptionsGroup>
 struct Registration {
   template <typename ParallelComponent, typename DbTagsList,
             typename ArrayIndex>
@@ -33,8 +33,7 @@ struct Registration {
   register_info(const db::DataBox<DbTagsList>& /*box*/,
                 const ArrayIndex& /*array_index*/) noexcept {
     return {observers::TypeOfObservation::Reduction,
-            observers::ObservationKey{
-                "LinearSolver::observe_detail::ObservationType"}};
+            observers::ObservationKey{pretty_type::get_name<OptionsGroup>()}};
   }
 };
 
@@ -64,7 +63,7 @@ void contribute_to_reduction_observer(
 
   const auto observation_id = observers::ObservationId(
       get<LinearSolver::Tags::IterationId<OptionsGroup>>(box),
-      "LinearSolver::observe_detail::ObservationType");
+      pretty_type::get_name<OptionsGroup>());
   auto& reduction_writer = Parallel::get_parallel_component<
       observers::ObserverWriter<Metavariables>>(cache);
   Parallel::threaded_action<observers::ThreadedActions::WriteReductionData>(

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveErrorNorms.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveErrorNorms.cpp
@@ -137,9 +137,6 @@ struct Metavariables {
   using const_global_cache_tags =
       tmpl::list<Tags::AnalyticSolution<typename System::solution_for_test>>;
   enum class Phase { Initialization, Testing, Exit };
-
-  struct ObservationType {};
-  using element_observation_type = ObservationType;
 };
 
 // Test systems

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
@@ -144,9 +144,6 @@ struct Metavariables {
   using const_global_cache_tags =
       tmpl::list<Tags::AnalyticSolution<typename System::solution_for_test>>;
   enum class Phase { Initialization, Testing, Exit };
-
-  struct ObservationType {};
-  using element_observation_type = ObservationType;
 };
 
 // Test systems

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
@@ -126,9 +126,6 @@ struct Metavariables {
                                     MockObserverComponent<Metavariables>>;
   using const_global_cache_tags = tmpl::list<>;  //  unused
   enum class Phase { Initialization, Testing, Exit };
-
-  struct ObservationType {};
-  using element_observation_type = ObservationType;
 };
 
 struct ScalarVar : db::SimpleTag {

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ResidualMonitorActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ResidualMonitorActions.cpp
@@ -239,9 +239,9 @@ SPECTRE_TEST_CASE(
     // Test element state
     CHECK_FALSE(get_element_tag(CheckConvergedTag{}));
     // Test observer writer state
-    CHECK(get_observer_writer_tag(helpers::CheckObservationIdTag{}) ==
-          observers::ObservationId{
-              0, "LinearSolver::observe_detail::ObservationType"});
+    CHECK(
+        get_observer_writer_tag(helpers::CheckObservationIdTag{}) ==
+        observers::ObservationId{0, "(anonymous namespace)::TestLinearSolver"});
     CHECK(get_observer_writer_tag(helpers::CheckSubfileNameTag{}) ==
           "/TestLinearSolverResiduals");
     CHECK(get_observer_writer_tag(helpers::CheckReductionNamesTag{}) ==
@@ -321,9 +321,9 @@ SPECTRE_TEST_CASE(
           get_residual_monitor_tag(
               LinearSolver::Tags::HasConverged<TestLinearSolver>{}));
     // Test observer writer state
-    CHECK(get_observer_writer_tag(helpers::CheckObservationIdTag{}) ==
-          observers::ObservationId{
-              1, "LinearSolver::observe_detail::ObservationType"});
+    CHECK(
+        get_observer_writer_tag(helpers::CheckObservationIdTag{}) ==
+        observers::ObservationId{1, "(anonymous namespace)::TestLinearSolver"});
     CHECK(get_observer_writer_tag(helpers::CheckSubfileNameTag{}) ==
           "/TestLinearSolverResiduals");
     CHECK(get_observer_writer_tag(helpers::CheckReductionNamesTag{}) ==

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ResidualMonitorActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ResidualMonitorActions.cpp
@@ -267,9 +267,9 @@ SPECTRE_TEST_CASE(
           get_residual_monitor_tag(
               LinearSolver::Tags::HasConverged<TestLinearSolver>{}));
     // Test observer writer state
-    CHECK(get_observer_writer_tag(helpers::CheckObservationIdTag{}) ==
-          observers::ObservationId{
-              0, "LinearSolver::observe_detail::ObservationType"});
+    CHECK(
+        get_observer_writer_tag(helpers::CheckObservationIdTag{}) ==
+        observers::ObservationId{0, "(anonymous namespace)::TestLinearSolver"});
     CHECK(get_observer_writer_tag(helpers::CheckSubfileNameTag{}) ==
           "/TestLinearSolverResiduals");
     CHECK(get_observer_writer_tag(helpers::CheckReductionNamesTag{}) ==
@@ -387,9 +387,9 @@ SPECTRE_TEST_CASE(
               LinearSolver::Tags::HasConverged<TestLinearSolver>{}));
     CHECK(get_element_tag(CheckValueTag{}) == approx(2.));
     // Test observer writer state
-    CHECK(get_observer_writer_tag(helpers::CheckObservationIdTag{}) ==
-          observers::ObservationId{
-              1, "LinearSolver::observe_detail::ObservationType"});
+    CHECK(
+        get_observer_writer_tag(helpers::CheckObservationIdTag{}) ==
+        observers::ObservationId{1, "(anonymous namespace)::TestLinearSolver"});
     CHECK(get_observer_writer_tag(helpers::CheckSubfileNameTag{}) ==
           "/TestLinearSolverResiduals");
     CHECK(get_observer_writer_tag(helpers::CheckReductionNamesTag{}) ==


### PR DESCRIPTION
## Proposed changes

The "observation types" we had to identify observations are not needed anymore as of #2436. I came across these types when cleaning up the linear solver code, and removed them throughout the codebase.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
