### PR TITLE
Mutable GlobalCache

### DIFF
--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -688,7 +688,7 @@ AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>::
                         Algorithm_detail::is_is_ready_callable_t<
                             local_this_action, this_databox,
                             tuples::tagged_tuple_from_typelist<inbox_tags_list>,
-                            Parallel::GlobalCache<metavariables>,
+                            Parallel::GlobalCache<metavariables>&,
                             array_index>{},
                         local_this_action{}, box)) {
                   take_next_action = false;
@@ -712,7 +712,7 @@ AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>::
                         Algorithm_detail::is_is_ready_callable_t<
                             local_this_action, this_databox,
                             tuples::tagged_tuple_from_typelist<inbox_tags_list>,
-                            Parallel::GlobalCache<metavariables>,
+                            Parallel::GlobalCache<metavariables>&,
                             array_index>{},
                         local_this_action{}, box)) {
                   take_next_action = false;
@@ -753,7 +753,7 @@ AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>::
                         Algorithm_detail::is_is_ready_callable_t<
                             local_this_action, this_databox,
                             tuples::tagged_tuple_from_typelist<inbox_tags_list>,
-                            Parallel::GlobalCache<metavariables>,
+                            Parallel::GlobalCache<metavariables>&,
                             array_index>{},
                         local_this_action{}, box)) {
                   take_next_action = false;

--- a/src/Parallel/GlobalCache.ci
+++ b/src/Parallel/GlobalCache.ci
@@ -7,10 +7,20 @@ module GlobalCache {
   namespace Parallel {
 
   template <typename Metavariables>
+  group[migratable] MutableGlobalCache {
+    entry MutableGlobalCache(
+        tuples::tagged_tuple_from_typelist<
+            get_mutable_global_cache_tags<Metavariables>>&);
+    template <typename GlobalCacheTag, typename Function, typename... Args>
+    entry void mutate(std::tuple<Args...> & args);
+  }
+
+  template <typename Metavariables>
   nodegroup[migratable] GlobalCache {
     entry GlobalCache(
         tuples::tagged_tuple_from_typelist<
-            get_const_global_cache_tags<Metavariables>>&);
+            get_const_global_cache_tags<Metavariables>>&,
+            CProxy_MutableGlobalCache<Metavariables>&);
     entry void set_parallel_components(
         tuples::tagged_tuple_from_typelist<tmpl::transform<
             typename Metavariables::component_list,
@@ -18,6 +28,8 @@ module GlobalCache {
                        tmpl::bind<Parallel::proxy_from_parallel_component,
                                   tmpl::_1>>>>,
         const CkCallback&);
+    template <typename GlobalCacheTag, typename Function, typename... Args>
+    entry void mutate(std::tuple<Args...> & args);
   }
   }
 }

--- a/src/Parallel/GlobalCache.hpp
+++ b/src/Parallel/GlobalCache.hpp
@@ -6,12 +6,17 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
+#include <tuple>
+#include <vector>
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "ErrorHandling/Assert.hpp"
+#include "ErrorHandling/Error.hpp"
 #include "Parallel/CharmRegistration.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
@@ -23,43 +28,16 @@
 namespace Parallel {
 
 namespace GlobalCache_detail {
-template <typename T>
-struct type_for_get_helper {
-  using type = T;
-};
 
-template <typename T, typename D>
-struct type_for_get_helper<std::unique_ptr<T, D>> {
-  using type = T;
-};
-
-// This struct provides a better error message if
-// an unknown tag is requested from the GlobalCache.
-template <typename GlobalCacheTag, typename ListOfPossibleTags>
-struct list_of_matching_tags_helper {
-  using type = tmpl::filter<ListOfPossibleTags,
-               std::is_base_of<tmpl::pin<GlobalCacheTag>, tmpl::_1>>;
-  static_assert(not std::is_same_v<type, tmpl::list<>>,
-                "Trying to get a nonexistent tag from the GlobalCache. "
-                "To diagnose the problem, search for "
-                "'list_of_matching_tags_helper' in the error message. "
-                "The first template parameter of "
-                "'list_of_matching_tags_helper' is the requested tag, and "
-                "the second template parameter is a tmpl::list of all the "
-                "tags in the GlobalCache.  One possible bug that may "
-                "lead to this error message is a missing or misspelled "
-                "const_global_cache_tags type alias.");
-};
-
-// Note: Returned list does not need to be size 1
 template <class GlobalCacheTag, class Metavariables>
-using get_list_of_matching_tags = typename list_of_matching_tags_helper<
-    GlobalCacheTag, get_const_global_cache_tags<Metavariables>>::type;
+using get_matching_tag = typename matching_tag_helper<
+    GlobalCacheTag,
+    tmpl::append<get_const_global_cache_tags<Metavariables>,
+                 get_mutable_global_cache_tags<Metavariables>>>::type;
 
 template <class GlobalCacheTag, class Metavariables>
 using type_for_get = typename type_for_get_helper<
-    typename tmpl::front<GlobalCache_detail::get_list_of_matching_tags<
-        GlobalCacheTag, Metavariables>>::type>::type;
+    typename get_matching_tag<GlobalCacheTag, Metavariables>::type>::type;
 
 template <class T, class = std::void_t<>>
 struct has_component_being_mocked_alias : std::false_type {};
@@ -85,10 +63,17 @@ struct get_component_if_mocked_helper {
                             ComponentToFind>;
 };
 
+template <typename... Tags>
+auto make_mutable_cache_tag_storage(
+    tuples::TaggedTuple<Tags...>&& input) noexcept {
+  return tuples::TaggedTuple<MutableCacheTag<Tags>...>(std::make_tuple(
+      std::move(tuples::get<Tags>(input)), std::vector<CkCallback>{})...);
+}
+
 /// In order to be able to use a mock action testing framework we need to be
 /// able to get the correct parallel component from the global cache even when
-/// the correct component is a mock. We do this by having the mocked components
-/// have a member type alias `component_being_mocked`, and having
+/// the correct component is a mock. We do this by having the mocked
+/// components have a member type alias `component_being_mocked`, and having
 /// `Parallel::get_component` check if the component to be retrieved is in the
 /// `metavariables::component_list`. If it is not in the `component_list` then
 /// we search for a mock component that is mocking the component we are trying
@@ -103,14 +88,148 @@ using get_component_if_mocked = tmpl::front<tmpl::type_from<tmpl::conditional_t<
 }  // namespace GlobalCache_detail
 
 /// \ingroup ParallelGroup
-/// A Charm++ chare that caches constant data once per Charm++ node.
+/// A Charm++ chare that caches mutable data once per Charm++ core.
+///
+/// `MutableGlobalCache` is not intended to be visible to the end user; its
+/// interface is via the `GlobalCache` member functions
+/// `mutable_cache_item_is_ready`, `mutate`, and `get`.
+/// Accordingly, most documentation of `MutableGlobalCache` is provided
+/// in the relevant `GlobalCache` member functions.
+template <typename Metavariables>
+class MutableGlobalCache : public CBase_MutableGlobalCache<Metavariables> {
+ public:
+  explicit MutableGlobalCache(tuples::tagged_tuple_from_typelist<
+                              get_mutable_global_cache_tags<Metavariables>>
+                                  mutable_global_cache) noexcept;
+  explicit MutableGlobalCache(CkMigrateMessage* /*msg*/) {}
+  ~MutableGlobalCache() noexcept override {
+    (void)Parallel::charmxx::RegisterChare<
+        MutableGlobalCache<Metavariables>,
+        CkIndex_MutableGlobalCache<Metavariables>>::registrar;
+  }
+  /// \cond
+  MutableGlobalCache(const MutableGlobalCache&) = default;
+  MutableGlobalCache& operator=(const MutableGlobalCache&) = default;
+  MutableGlobalCache(MutableGlobalCache&&) = default;
+  MutableGlobalCache& operator=(MutableGlobalCache&&) = default;
+  /// \endcond
+
+  template <typename GlobalCacheTag>
+  auto get() const noexcept
+      -> const GlobalCache_detail::type_for_get<GlobalCacheTag, Metavariables>&;
+
+  // Entry method to mutate the object indentified by `GlobalCacheTag`.
+  // Internally calls Function::apply(), where
+  // Function is a struct, and Function::apply is a user-defined
+  // static function that mutates the object.  Function::apply() takes
+  // as its first argument a gsl::not_null pointer to the object named
+  // by the GlobalCacheTag, and then the contents of 'args' as
+  // subsequent arguments.  Called via `GlobalCache::mutate`.
+  template <typename GlobalCacheTag, typename Function, typename... Args>
+  void mutate(const std::tuple<Args...>& args) noexcept;
+
+  // Not an entry method, and intended to be called only from
+  // `GlobalCache` via the free function
+  // `Parallel::mutable_cache_item_is_ready`.  See the free function
+  // `Parallel::mutable_cache_item_is_ready` for documentation.
+  template <typename GlobalCacheTag, typename Function>
+  bool mutable_cache_item_is_ready(const Function& function) noexcept;
+
+ private:
+  tuples::tagged_tuple_from_typelist<
+      get_mutable_global_cache_tag_storage<Metavariables>>
+      mutable_global_cache_{};
+};
+
+template <typename Metavariables>
+MutableGlobalCache<Metavariables>::MutableGlobalCache(
+    tuples::tagged_tuple_from_typelist<
+        get_mutable_global_cache_tags<Metavariables>>
+        mutable_global_cache) noexcept
+    : mutable_global_cache_(GlobalCache_detail::make_mutable_cache_tag_storage(
+          std::move(mutable_global_cache))) {}
+
+template <typename Metavariables>
+template <typename GlobalCacheTag>
+auto MutableGlobalCache<Metavariables>::get() const noexcept
+    -> const GlobalCache_detail::type_for_get<GlobalCacheTag, Metavariables>& {
+  using tag = MutableCacheTag<
+      GlobalCache_detail::get_matching_tag<GlobalCacheTag, Metavariables>>;
+  if constexpr (tt::is_a_v<std::unique_ptr, typename tag::tag::type>) {
+    return *(std::get<0>(tuples::get<tag>(mutable_global_cache_)));
+  } else {
+    return std::get<0>(tuples::get<tag>(mutable_global_cache_));
+  }
+}
+
+template <typename Metavariables>
+template <typename GlobalCacheTag, typename Function>
+bool MutableGlobalCache<Metavariables>::mutable_cache_item_is_ready(
+    const Function& function) noexcept {
+  using tag = MutableCacheTag<GlobalCache_detail::get_matching_mutable_tag<
+      GlobalCacheTag, Metavariables>>;
+  std::optional<CkCallback> optional_callback{};
+  if constexpr (tt::is_a_v<std::unique_ptr, typename tag::tag::type>) {
+    optional_callback =
+        function(*(std::get<0>(tuples::get<tag>(mutable_global_cache_))));
+  } else {
+    optional_callback =
+        function(std::get<0>(tuples::get<tag>(mutable_global_cache_)));
+  }
+  if (optional_callback) {
+    std::get<1>(tuples::get<tag>(mutable_global_cache_))
+        .push_back(std::move(*optional_callback));
+    if (std::get<1>(tuples::get<tag>(mutable_global_cache_)).size() > 20000) {
+      ERROR("The number of callbacks in MutableGlobalCache for tag "
+            << pretty_type::short_name<GlobalCacheTag>()
+            << " has gotten too large, and may be growing without bound");
+    }
+    return false;
+  } else {
+    // The user-defined `function` didn't specify a callback, which
+    // means that the item is ready.
+    return true;
+  }
+}
+
+template <typename Metavariables>
+template <typename GlobalCacheTag, typename Function, typename... Args>
+void MutableGlobalCache<Metavariables>::mutate(
+    const std::tuple<Args...>& args) noexcept {
+  (void)Parallel::charmxx::RegisterMutableGlobalCacheMutate<
+      Metavariables, GlobalCacheTag, Function, Args...>::registrar;
+  using tag = MutableCacheTag<GlobalCache_detail::get_matching_mutable_tag<
+      GlobalCacheTag, Metavariables>>;
+
+  // Do the mutate.
+  std::apply(
+      [this](const auto&... local_args) noexcept {
+        Function::apply(make_not_null(&std::get<0>(
+                            tuples::get<tag>(mutable_global_cache_))),
+                        local_args...);
+      },
+      args);
+
+  // Call the callbacks and clear the list of callbacks.
+  for (auto& callback : std::get<1>(tuples::get<tag>(mutable_global_cache_))) {
+    callback.send(nullptr);
+  }
+  std::get<1>(tuples::get<tag>(mutable_global_cache_)).clear();
+  std::get<1>(tuples::get<tag>(mutable_global_cache_)).shrink_to_fit();
+}
+
+/// \ingroup ParallelGroup
+/// A Charm++ chare that caches constant data once per Charm++ node or
+/// non-constant data once per Charm++ core.
 ///
 /// `Metavariables` must define the following metavariables:
 ///   - `component_list`   typelist of ParallelComponents
 ///   - `const_global_cache_tags`   (possibly empty) typelist of tags of
 ///     constant data
+///   - `mutable_global_cache_tags` (possibly empty) typelist of tags of
+///     non-constant data
 ///
-/// The tag list for the items added to the GlobalCache is created by
+/// The tag lists for the const items added to the GlobalCache is created by
 /// combining the following tag lists:
 ///   - `Metavariables::const_global_cache_tags` which should contain only those
 ///     tags that cannot be added from the other tag lists below.
@@ -124,14 +243,21 @@ using get_component_if_mocked = tmpl::front<tmpl::type_from<tmpl::conditional_t<
 ///     `Metavariables::component_list` which should contain the tags needed by
 ///     that  Action.  The type alias may be omitted for an empty list.
 ///
-/// The tags in the `const_global_cache_tags` type lists are db::SimpleTag%s
-/// that have a `using option_tags` type alias and a static function
-/// `create_from_options` that are used to create the constant data from input
-/// file options.
+/// The tag lists for the non-const items added to the GlobalCache is created
+/// by combining exactly the same tag lists as for the const items, except with
+/// `const_global_cache_tags` replaced by `mutable_global_cache_tags`.
 ///
-/// References to items in the GlobalCache are also added to the
-/// db::DataBox of each `Component` in the `Metavariables::component_list` with
-/// the same tag with which they were inserted into the GlobalCache.
+/// The tags in the `const_global_cache_tags` and
+/// `mutable_global_cache_tags` type lists are db::SimpleTag%s that
+/// have a `using option_tags` type alias and a static function
+/// `create_from_options` that are used to create the constant data
+/// from input file options.
+///
+/// References to const items in the GlobalCache are also added to the
+/// db::DataBox of each `Component` in the
+/// `Metavariables::component_list` with the same tag with which they
+/// were inserted into the GlobalCache.  References to non-const items
+/// in the GlobalCache are not added to the db::DataBox.
 template <typename Metavariables>
 class GlobalCache : public CBase_GlobalCache<Metavariables> {
   using parallel_component_tag_list = tmpl::transform<
@@ -146,10 +272,20 @@ class GlobalCache : public CBase_GlobalCache<Metavariables> {
   /// Typelist of the ParallelComponents stored in the GlobalCache
   using component_list = typename Metavariables::component_list;
 
-  explicit GlobalCache(tuples::tagged_tuple_from_typelist<
-                            get_const_global_cache_tags<Metavariables>>
-                                global_cache) noexcept
-      : global_cache_(std::move(global_cache)) {}
+  /// Constructor used only by the ActionTesting framework and other
+  /// non-charm++ tests that don't know about proxies.
+  GlobalCache(tuples::tagged_tuple_from_typelist<
+                  get_const_global_cache_tags<Metavariables>>
+                  const_global_cache,
+              MutableGlobalCache<Metavariables>* mutable_global_cache) noexcept;
+
+  /// Constructor used by Main and anything else that is charm++ aware.
+  GlobalCache(tuples::tagged_tuple_from_typelist<
+                  get_const_global_cache_tags<Metavariables>>
+                  const_global_cache,
+              CProxy_MutableGlobalCache<Metavariables>
+                  mutable_global_cache_proxy) noexcept;
+
   explicit GlobalCache(CkMigrateMessage* /*msg*/) {}
   ~GlobalCache() noexcept override {
     (void)Parallel::charmxx::RegisterChare<
@@ -168,6 +304,34 @@ class GlobalCache : public CBase_GlobalCache<Metavariables> {
       tuples::tagged_tuple_from_typelist<parallel_component_tag_list>&&
           parallel_components,
       const CkCallback& callback) noexcept;
+
+  /// Returns whether the object referred to by `GlobalCacheTag`
+  /// (which must be a mutable cache tag) is ready to be accessed by a
+  /// `get` call.
+  ///
+  /// `function` is a user-defined invokable that:
+  /// - takes one argument: a const reference to the object referred to by the
+  ///   `GlobalCacheTag`.
+  /// - if the data is ready, returns a default constructed
+  ///   `std::optional<CkCallBack>`
+  /// - if the data is not ready, returns a `std::optional<CkCallBack>`,
+  ///   where the `CkCallback` will re-invoke the current action on the
+  ///   current parallel component.
+  template <typename GlobalCacheTag, typename Function>
+  bool mutable_cache_item_is_ready(const Function& function) noexcept;
+
+  /// Mutates the non-const object identified by GlobalCacheTag.
+  /// \requires `GlobalCacheTag` is a tag in `mutable_global_cache_tags`
+  /// defined by the Metavariables and in Actions.
+  ///
+  /// Internally calls `Function::apply()`, where `Function` is a
+  /// user-defined struct and `Function::apply()` is a user-defined
+  /// static function that mutates the object.  `Function::apply()`
+  /// takes as its first argument a `gsl::not_null` pointer to the
+  /// object named by the GlobalCacheTag, and takes the contents of
+  /// `args` as subsequent arguments.
+  template <typename GlobalCacheTag, typename Function, typename... Args>
+  void mutate(const std::tuple<Args...>& args) noexcept;
 
  private:
   // clang-tidy: false positive, redundant declaration
@@ -193,11 +357,46 @@ class GlobalCache : public CBase_GlobalCache<Metavariables> {
               ParallelComponentTag>>&;  // NOLINT
 
   tuples::tagged_tuple_from_typelist<get_const_global_cache_tags<Metavariables>>
-      global_cache_{};
+      const_global_cache_{};
   tuples::tagged_tuple_from_typelist<parallel_component_tag_list>
       parallel_components_{};
+  // We store both a pointer and a proxy to the MutableGlobalCache.
+  // There is both a pointer and a proxy because we want to use
+  // MutableGlobalCache in production (where it must be charm-aware)
+  // and for simple testing (which we want to do in a non-charm-aware
+  // context for simplicity).  If the charm-aware constructor is
+  // used, then the pointer is set to nullptr and the proxy is set.
+  // If the non-charm-aware constructor is used, the the pointer is
+  // set and the proxy is ignored.  The member functions that need the
+  // MutableGlobalCache should use the pointer if it is not nullptr,
+  // otherwise use the proxy.
+  MutableGlobalCache<Metavariables>* mutable_global_cache_{nullptr};
+  CProxy_MutableGlobalCache<Metavariables> mutable_global_cache_proxy_{};
   bool parallel_components_have_been_set_{false};
 };
+
+template <typename Metavariables>
+GlobalCache<Metavariables>::GlobalCache(
+    tuples::tagged_tuple_from_typelist<
+        get_const_global_cache_tags<Metavariables>>
+        const_global_cache,
+    MutableGlobalCache<Metavariables>* mutable_global_cache) noexcept
+    : const_global_cache_(std::move(const_global_cache)),
+      mutable_global_cache_(mutable_global_cache) {
+  ASSERT(mutable_global_cache_ != nullptr,
+         "GlobalCache: Do not construct with a nullptr!");
+}
+
+template <typename Metavariables>
+GlobalCache<Metavariables>::GlobalCache(
+    tuples::tagged_tuple_from_typelist<
+        get_const_global_cache_tags<Metavariables>>
+        const_global_cache,
+    CProxy_MutableGlobalCache<Metavariables>
+        mutable_global_cache_proxy) noexcept
+    : const_global_cache_(std::move(const_global_cache)),
+      mutable_global_cache_(nullptr),
+      mutable_global_cache_proxy_(std::move(mutable_global_cache_proxy)) {}
 
 template <typename Metavariables>
 void GlobalCache<Metavariables>::set_parallel_components(
@@ -209,6 +408,38 @@ void GlobalCache<Metavariables>::set_parallel_components(
   parallel_components_ = std::move(parallel_components);
   parallel_components_have_been_set_ = true;
   this->contribute(callback);
+}
+
+template <typename Metavariables>
+template <typename GlobalCacheTag, typename Function>
+bool GlobalCache<Metavariables>::mutable_cache_item_is_ready(
+    const Function& function) noexcept {
+  if (mutable_global_cache_ == nullptr) {
+    return mutable_global_cache_proxy_.ckLocalBranch()
+        ->template mutable_cache_item_is_ready<GlobalCacheTag>(function);
+  } else {
+    return mutable_global_cache_
+        ->template mutable_cache_item_is_ready<GlobalCacheTag>(function);
+  }
+}
+
+template <typename Metavariables>
+template <typename GlobalCacheTag, typename Function, typename... Args>
+void GlobalCache<Metavariables>::mutate(
+    const std::tuple<Args...>& args) noexcept {
+  (void)Parallel::charmxx::RegisterGlobalCacheMutate<
+      Metavariables, GlobalCacheTag, Function, Args...>::registrar;
+  if (mutable_global_cache_ == nullptr) {
+    // charm-aware version: Mutate the variable on all PEs on this node.
+    for (auto pe = CkNodeFirst(CkMyNode());
+         pe < CkNodeFirst(CkMyNode()) + CkNodeSize(CkMyNode()); ++pe) {
+      mutable_global_cache_proxy_[pe].template mutate<GlobalCacheTag, Function>(
+          args);
+    }
+  } else {
+    // version that bypasses proxies.  Just call the function.
+    mutable_global_cache_->template mutate<GlobalCacheTag, Function>(args);
+  }
 }
 
 // @{
@@ -231,8 +462,7 @@ auto get_parallel_component(GlobalCache<Metavariables>& cache) noexcept
 }
 
 template <typename ParallelComponentTag, typename Metavariables>
-auto get_parallel_component(
-    const GlobalCache<Metavariables>& cache) noexcept
+auto get_parallel_component(const GlobalCache<Metavariables>& cache) noexcept
     -> const Parallel::proxy_from_parallel_component<
         GlobalCache_detail::get_component_if_mocked<
             typename Metavariables::component_list, ParallelComponentTag>>& {
@@ -247,32 +477,102 @@ auto get_parallel_component(
 /// \ingroup ParallelGroup
 /// \brief Access data in the cache
 ///
-/// \requires GlobalCacheTag is a tag in tag_list
+/// \requires GlobalCacheTag is a tag in the `mutable_global_cache_tags`
+/// or `const_global_cache_tags` defined by the Metavariables and in Actions.
 ///
 /// \returns a constant reference to an object in the cache
 template <typename GlobalCacheTag, typename Metavariables>
-auto get(const GlobalCache<Metavariables>& cache) noexcept -> const
-    GlobalCache_detail::type_for_get<GlobalCacheTag, Metavariables>& {
+auto get(const GlobalCache<Metavariables>& cache) noexcept
+    -> const GlobalCache_detail::type_for_get<GlobalCacheTag, Metavariables>& {
   // We check if the tag is to be retrieved directly or via a base class
-  using tag = tmpl::front<GlobalCache_detail::get_list_of_matching_tags<
-      GlobalCacheTag, Metavariables>>;
-  static_assert(tmpl::size<GlobalCache_detail::get_list_of_matching_tags<
-                        GlobalCacheTag, Metavariables>>::value == 1,
-                "Found more than one tag matching the GlobalCacheTag "
-                "requesting to be retrieved.");
-  return make_overloader(
-      [](std::true_type /*is_unique_ptr*/, auto&& local_cache)
-          -> decltype(
-              *(tuples::get<tag>(local_cache.global_cache_).get())) {
-        return *(
-            tuples::get<tag>(local_cache.global_cache_)
-                .get());
-      },
-      [](std::false_type /*is_unique_ptr*/, auto&& local_cache)
-          -> decltype(tuples::get<tag>(local_cache.global_cache_)) {
-        return tuples::get<tag>(
-            local_cache.global_cache_);
-      })(typename tt::is_a<std::unique_ptr, typename tag::type>::type{}, cache);
+  using tag =
+      GlobalCache_detail::get_matching_tag<GlobalCacheTag, Metavariables>;
+  using tag_is_not_in_const_tags = std::is_same<
+      tmpl::filter<get_const_global_cache_tags<Metavariables>,
+                   std::is_base_of<tmpl::pin<GlobalCacheTag>, tmpl::_1>>,
+      tmpl::list<>>;
+  if constexpr (tag_is_not_in_const_tags::value) {
+    // Tag is not in the const tags, so use MutableGlobalCache
+    if (cache.mutable_global_cache_ == nullptr) {
+      const auto& local_mutable_cache =
+          *cache.mutable_global_cache_proxy_.ckLocalBranch();
+      return local_mutable_cache.template get<GlobalCacheTag>();
+    } else {
+      return cache.mutable_global_cache_->template get<GlobalCacheTag>();
+    }
+  } else {
+    // Tag is in the const tags, so use const_global_cache_
+    if constexpr (tt::is_a_v<std::unique_ptr, typename tag::type>) {
+      return *(tuples::get<tag>(cache.const_global_cache_));
+    } else {
+      return tuples::get<tag>(cache.const_global_cache_);
+    }
+  }
+}
+
+/// \ingroup ParallelGroup
+/// \brief Returns whether the object identified by `GlobalCacheTag`
+/// is ready to be accessed by `get`.
+///
+/// \requires `GlobalCacheTag` is a tag in `mutable_global_cache_tags`
+/// defined by the Metavariables and in Actions.
+///
+/// \requires `function` is a user-defined invokable that takes one argument:
+/// a const reference to the object referred to by the
+/// `GlobalCacheTag`.  `function` returns a
+/// `std::optional<CkCallBack>` that determines the readiness. To
+/// indicate that the item is ready, the `std::optional` returned
+/// by `function` must be invalid; in this case
+/// `mutable_cache_item_is_ready` returns true. To indicate that the
+/// item is not ready, the `std::optional` returned by `function`
+/// must be valid; in this case, `mutable_cache_item_is_ready`
+/// appends the `std::optional`'s wrapped `CkCallback` to an
+/// internal list of callbacks to be called on `mutate`, and then
+/// returns false.
+template <typename GlobalCacheTag, typename Function, typename Metavariables>
+bool mutable_cache_item_is_ready(GlobalCache<Metavariables>& cache,
+                                 const Function& function) noexcept {
+  return cache.template mutable_cache_item_is_ready<GlobalCacheTag>(function);
+}
+
+/// \ingroup ParallelGroup
+/// \brief Mutates non-const data in the cache, by calling `Function::apply()`
+///
+/// \requires `GlobalCacheTag` is a tag in the `mutable_global_cache_tags`
+/// defined by the Metavariables and in Actions.
+/// \requires `Function` is a struct with a static void `apply()`
+/// function that mutates the object. `Function::apply()` takes as its
+/// first argument a `gsl::not_null` pointer to the object named by
+/// the `GlobalCacheTag`, and takes `args` as
+/// subsequent arguments.
+///
+/// This is the version that takes a GlobalCache<Metavariables>. Used only
+/// for tests.
+template <typename GlobalCacheTag, typename Function, typename Metavariables,
+          typename... Args>
+void mutate(GlobalCache<Metavariables>& cache, Args&&... args) noexcept {
+  cache.template mutate<GlobalCacheTag, Function>(
+      std::make_tuple<Args...>(std::forward<Args>(args)...));
+}
+
+/// \ingroup ParallelGroup
+///
+/// \brief Mutates non-const data in the cache, by calling `Function::apply()`
+///
+/// \requires `GlobalCacheTag` is a tag in tag_list.
+/// \requires `Function` is a struct with a static void `apply()`
+/// function that mutates the object. `Function::apply()` takes as its
+/// first argument a `gsl::not_null` pointer to the object named by
+/// the `GlobalCacheTag`, and takes `args` as
+/// subsequent arguments.
+///
+/// This is the version that takes a charm++ proxy to the GlobalCache.
+template <typename GlobalCacheTag, typename Function, typename Metavariables,
+          typename... Args>
+void mutate(CProxy_GlobalCache<Metavariables>& cache_proxy,
+            Args&&... args) noexcept {
+  cache_proxy.template mutate<GlobalCacheTag, Function>(
+      std::make_tuple<Args...>(std::forward<Args>(args)...));
 }
 
 namespace Tags {

--- a/tests/Unit/Framework/ActionTesting.hpp
+++ b/tests/Unit/Framework/ActionTesting.hpp
@@ -1649,7 +1649,8 @@ class MockRuntimeSystem {
 
   /// Construct from the tuple of GlobalCache objects.
   explicit MockRuntimeSystem(CacheTuple cache_contents)
-      : cache_(std::move(cache_contents)) {
+      : mutable_cache_(tuples::TaggedTuple<>{}),
+        cache_(std::move(cache_contents), &mutable_cache_) {
     tmpl::for_each<typename Metavariables::component_list>([this](
                                                                auto component) {
       using Component = tmpl::type_from<decltype(component)>;
@@ -1911,6 +1912,7 @@ class MockRuntimeSystem {
   }
 
  private:
+  Parallel::MutableGlobalCache<Metavariables> mutable_cache_{};
   GlobalCache cache_{};
   Inboxes inboxes_{};
   TupleOfMockDistributedObjects local_algorithms_{};

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -33,6 +33,7 @@ endfunction()
 
 add_algorithm_test(Test_AlgorithmCore)
 add_algorithm_test(Test_AlgorithmBadBoxApply)
+add_algorithm_test(Test_AlgorithmGlobalCache)
 add_algorithm_test(Test_AlgorithmNestedApply1)
 add_algorithm_test(Test_AlgorithmNestedApply2)
 add_algorithm_test(Test_AlgorithmParallel)
@@ -92,6 +93,23 @@ function(add_algorithm_test TEST_NAME REGEX_TO_MATCH)
   endif()
 endfunction()
 
+function(add_algorithm_test_with_input_file TEST_NAME INPUT_FILE_DIR)
+  add_test(
+    NAME "\"Integration.Parallel.${TEST_NAME}\""
+    COMMAND
+    ${SHELL_EXECUTABLE}
+    -c
+    "${CMAKE_BINARY_DIR}/bin/Test_${TEST_NAME} --input-file \
+     ${CMAKE_SOURCE_DIR}/tests/${INPUT_FILE_DIR}/Test_${TEST_NAME}.yaml 2>&1"
+    )
+    set_tests_properties(
+      "\"Integration.Parallel.${TEST_NAME}\""
+      PROPERTIES
+      TIMEOUT 10
+      LABELS "integration"
+      ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
+endfunction()
+
 add_algorithm_test("AlgorithmCore" "")
 add_algorithm_test(
   "AlgorithmBadBoxApply"
@@ -111,6 +129,8 @@ add_algorithm_test("AlgorithmParallel" "")
 add_algorithm_test("AlgorithmReduction" "")
 add_algorithm_test("AlgorithmNodelock" "")
 add_algorithm_test("GlobalCache" "")
+
+add_algorithm_test_with_input_file("AlgorithmGlobalCache" "Unit/Parallel")
 
 # Tests that do not require their own Chare setup and can work with the
 # unit tests

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -38,6 +38,7 @@ add_algorithm_test(Test_AlgorithmNestedApply2)
 add_algorithm_test(Test_AlgorithmParallel)
 add_algorithm_test(Test_AlgorithmNodelock)
 add_algorithm_test(Test_AlgorithmReduction)
+add_algorithm_test(Test_GlobalCache)
 
 # Test GlobalCache
 add_charm_module(Test_GlobalCache)
@@ -47,27 +48,12 @@ add_dependencies(
   module_GlobalCache
   )
 
-add_spectre_executable(
-  Test_GlobalCache
-  Test_GlobalCache.cpp
-  )
-
 add_dependencies(
   Test_GlobalCache
   module_Test_GlobalCache
   )
 
-target_link_libraries(
-  Test_GlobalCache
-  PRIVATE
-  ErrorHandling
-  Informer
-  Parallel
-  )
-
 add_dependencies(test-executables Test_GlobalCache)
-
-spectre_add_catch_tests(Test_GlobalCache "")
 
 # Add integration tests. For tests that result in a failure it is necessary to
 # redirect output from stderr to stdout. However, it was necessary at least on
@@ -124,6 +110,7 @@ function is not invoked via a proxy, which we do not allow.")
 add_algorithm_test("AlgorithmParallel" "")
 add_algorithm_test("AlgorithmReduction" "")
 add_algorithm_test("AlgorithmNodelock" "")
+add_algorithm_test("GlobalCache" "")
 
 # Tests that do not require their own Chare setup and can work with the
 # unit tests

--- a/tests/Unit/Parallel/Test_AlgorithmGlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmGlobalCache.cpp
@@ -1,0 +1,273 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+// Need CATCH_CONFIG_RUNNER to avoid linking errors with Catch2
+#define CATCH_CONFIG_RUNNER
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "AlgorithmSingleton.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Main.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+template <class Metavariables>
+struct MutateCacheComponent;
+template <class Metavariables>
+struct UseMutatedCacheComponent;
+
+namespace mutate_cache {
+
+// An option tag is needed for every type the GlobalCache contains.
+namespace OptionTags {
+struct VectorOfDoubles {
+  static std::string name() noexcept { return "VectorOfDoubles"; }
+  static constexpr Options::String help = "Options for vector of doubles";
+  using type = std::vector<double>;
+};
+}  // namespace OptionTags
+
+// Tag to label the quantity in the GlobalCache.
+namespace Tags {
+struct VectorOfDoubles : db::SimpleTag {
+  using type = typename OptionTags::VectorOfDoubles::type;
+  using option_tags = tmpl::list<OptionTags::VectorOfDoubles>;
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& input_type) noexcept {
+    return input_type;
+  }
+};
+}  // namespace Tags
+
+// Functions to be passed into GlobalCache::mutate
+/// [mutate_global_cache_item_mutator]
+namespace MutationFunctions {
+struct add_stored_double {
+  static void apply(const gsl::not_null<std::vector<double>*> data,
+                    const double new_value) noexcept {
+    data->emplace_back(new_value);
+  }
+};
+}  // namespace MutationFunctions
+/// [mutate_global_cache_item_mutator]
+
+namespace Actions {
+struct initialize {
+  template <typename... DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<tmpl::list<DbTags...>>& box,
+                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+                    const ParallelComponent* const  // NOLINT const
+                    /*meta*/) noexcept {
+    return std::make_tuple(
+        db::create_from<db::RemoveTags<>, db::AddSimpleTags<>>(std::move(box)),
+        true);
+  }
+};
+
+struct add_new_stored_double {
+  template <typename ParallelComponent, typename... DbTags,
+            typename Metavariables, typename ArrayIndex>
+  static void apply(db::DataBox<tmpl::list<DbTags...>>& /*box*/,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/) noexcept {
+    /// [mutate_global_cache_item]
+    Parallel::mutate<Tags::VectorOfDoubles,
+                     MutationFunctions::add_stored_double>(cache.thisProxy,
+                                                           42.0);
+    /// [mutate_global_cache_item]
+  }
+};
+
+// Global variables to make sure that certain functions have been called.
+size_t number_of_calls_to_use_stored_double_is_ready = 0;
+size_t number_of_calls_to_use_stored_double_apply = 0;
+
+struct finalize {
+  template <typename ParallelComponent, typename... DbTags,
+            typename Metavariables, typename ArrayIndex>
+  static void apply(db::DataBox<tmpl::list<DbTags...>>& /*box*/,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/) noexcept {
+    const std::vector<double> expected_result{42.0};
+    SPECTRE_PARALLEL_REQUIRE(Parallel::get<Tags::VectorOfDoubles>(cache) ==
+                             expected_result);
+    SPECTRE_PARALLEL_REQUIRE(number_of_calls_to_use_stored_double_is_ready ==
+                             2);
+    SPECTRE_PARALLEL_REQUIRE(number_of_calls_to_use_stored_double_apply == 1);
+  }
+};
+
+struct use_stored_double {
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTags>& box,
+                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    ++number_of_calls_to_use_stored_double_apply;
+    const std::vector<double> expected_result{42.0};
+    /// [retrieve_mutable_cache_item]
+    SPECTRE_PARALLEL_REQUIRE(Parallel::get<Tags::VectorOfDoubles>(cache) ==
+                             expected_result);
+    /// [retrieve_mutable_cache_item]
+    return std::tuple<db::DataBox<DbTags>&&, bool>(std::move(box), true);
+  }
+
+  /// [check_mutable_cache_item_is_ready]
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex>
+  static bool is_ready(const db::DataBox<DbTags>& /*box*/,
+                       const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                       Parallel::GlobalCache<Metavariables>& cache,
+                       const ArrayIndex& /*array_index*/) noexcept {
+    ++number_of_calls_to_use_stored_double_is_ready;
+    auto& this_proxy = Parallel::get_parallel_component<
+        UseMutatedCacheComponent<Metavariables>>(cache);
+    auto callback = CkCallback(
+        Parallel::index_from_parallel_component<
+            UseMutatedCacheComponent<Metavariables>>::perform_algorithm(),
+        this_proxy);
+    return ::Parallel::mutable_cache_item_is_ready<Tags::VectorOfDoubles>(
+        cache,
+        [&callback](const std::vector<double>& VectorOfDoubles)
+            -> std::optional<CkCallback> {
+          return VectorOfDoubles.empty() ? std::optional<CkCallback>(callback)
+                                         : std::optional<CkCallback>{};
+        });
+  }
+  /// [check_mutable_cache_item_is_ready]
+};
+}  // namespace Actions
+
+}  // namespace mutate_cache
+
+// We have two ParallelComponents:
+//
+// 1) MutateCacheComponent mutates the value in the GlobalCache using
+//    simple_actions, and then tests that the value in the GlobalCache
+//    is correct, using simple_actions.
+//
+// 2) UseMutatedCacheComponent has a single iterable_action whose
+//    is_ready function checks the size of the value in the
+//    GlobalCache.  If the size is correct, then its apply function
+//    verifies that the value is correct.
+template <class Metavariables>
+struct MutateCacheComponent {
+  using chare_type = Parallel::Algorithms::Singleton;
+  using metavariables = Metavariables;
+  using mutable_global_cache_tags =
+      tmpl::list<mutate_cache::Tags::VectorOfDoubles>;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      tmpl::list<mutate_cache::Actions::initialize>>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+
+  static void execute_next_phase(
+      const typename Metavariables::Phase next_phase,
+      const Parallel::CProxy_GlobalCache<Metavariables>& global_cache) {
+    auto& local_cache = *(global_cache.ckLocalBranch());
+    Parallel::get_parallel_component<MutateCacheComponent>(local_cache)
+        .start_phase(next_phase);
+    if (next_phase == Metavariables::Phase::MutableCacheStart) {
+      Parallel::simple_action<mutate_cache::Actions::add_new_stored_double>(
+          Parallel::get_parallel_component<MutateCacheComponent>(local_cache));
+    } else if (next_phase == Metavariables::Phase::MutableCacheFinish) {
+      Parallel::simple_action<mutate_cache::Actions::finalize>(
+          Parallel::get_parallel_component<MutateCacheComponent>(local_cache));
+    }
+  }
+};
+
+template <class Metavariables>
+struct UseMutatedCacheComponent {
+  using chare_type = Parallel::Algorithms::Singleton;
+  using metavariables = Metavariables;
+  using mutable_global_cache_tags =
+      tmpl::list<mutate_cache::Tags::VectorOfDoubles>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Initialization,
+                             tmpl::list<mutate_cache::Actions::initialize>>,
+      Parallel::PhaseActions<
+          typename Metavariables::Phase,
+          Metavariables::Phase::MutableCacheStart,
+          tmpl::list<mutate_cache::Actions::use_stored_double>>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+
+  static void execute_next_phase(
+      const typename Metavariables::Phase next_phase,
+      const Parallel::CProxy_GlobalCache<Metavariables>& global_cache) {
+    auto& local_cache = *(global_cache.ckLocalBranch());
+    Parallel::get_parallel_component<UseMutatedCacheComponent>(local_cache)
+        .start_phase(next_phase);
+  }
+};
+
+struct TestMetavariables {
+  using component_list =
+      tmpl::list<MutateCacheComponent<TestMetavariables>,
+                 UseMutatedCacheComponent<TestMetavariables>>;
+
+  static constexpr Options::String help =
+      "An executable for testing mutable items in the GlobalCache.";
+
+  enum class Phase {
+    Initialization,
+    MutableCacheStart,
+    MutableCacheFinish,
+    Exit
+  };
+
+  static Phase determine_next_phase(
+      const Phase& current_phase,
+      const Parallel::CProxy_GlobalCache<
+          TestMetavariables>& /*cache_proxy*/) noexcept {
+    switch (current_phase) {
+      case Phase::Initialization:
+        return Phase::MutableCacheStart;
+      case Phase::MutableCacheStart:
+        return Phase::MutableCacheFinish;
+      case Phase::MutableCacheFinish:
+        [[fallthrough]];
+      case Phase::Exit:
+        return Phase::Exit;
+      default:
+        ERROR("Unknown Phase...");
+    }
+
+    return Phase::Exit;
+  }
+};
+
+static const std::vector<void (*)()> charm_init_node_funcs{
+    &setup_error_handling};
+static const std::vector<void (*)()> charm_init_proc_funcs{
+    &enable_floating_point_exceptions};
+
+using charmxx_main_component = Parallel::Main<TestMetavariables>;
+
+#include "Parallel/CharmMain.tpp"  // IWYU pragma: keep

--- a/tests/Unit/Parallel/Test_AlgorithmGlobalCache.yaml
+++ b/tests/Unit/Parallel/Test_AlgorithmGlobalCache.yaml
@@ -1,0 +1,5 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Initialize to empty vector.
+VectorOfDoubles: []

--- a/tests/Unit/Parallel/Test_GlobalCache.ci
+++ b/tests/Unit/Parallel/Test_GlobalCache.ci
@@ -2,32 +2,21 @@
 // See LICENSE.txt for details.
 
 mainmodule Test_GlobalCache {
-
-  initnode void register_pupables();
-
-  extern module GlobalCache;
-
-  namespace Parallel {
-  nodegroup GlobalCache<TestMetavariables>;
-  }
-
-  mainchare Test_GlobalCache {
-    entry Test_GlobalCache(CkArgMsg * msg);
+  template <typename Metavariables>
+  mainchare [migratable] Test_GlobalCache {
+    entry Test_GlobalCache(CkArgMsg* msg);
+    entry void exit_if_done(int index);
   };
 
+  template <typename Metavariables>
   array [1D] TestArrayChare {
-    entry TestArrayChare();
+    entry TestArrayChare(
+        CProxy_Test_GlobalCache<Metavariables> & main_proxy,
+        Parallel::CProxy_GlobalCache<Metavariables> & global_cache_proxy);
+    entry void run_test_one();
+    entry void run_test_two();
+    entry void run_test_three();
+    entry void run_test_four();
+    entry void run_test_five();
   };
-
-  chare ParallelComponent {
-    entry ParallelComponent(int);
-  };
-
-  group TestGroupChare {
-    entry TestGroupChare();
-  };
-
-  nodegroup TestNodeGroupChare {
-    entry TestNodeGroupChare();
-  };
-};
+}

--- a/tests/Unit/Parallel/Test_GlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_GlobalCache.cpp
@@ -1,41 +1,37 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+// Need CATCH_CONFIG_RUNNER to avoid linking errors with Catch2
 #define CATCH_CONFIG_RUNNER
 
 #include "Framework/TestingFramework.hpp"
 
-void register_pupables();
-
 #include "Parallel/Test_GlobalCache.hpp"
 
-#include <algorithm>
 #include <charm++.h>
 #include <cstddef>
-#include <exception>
-#include <memory>
+#include <functional>
+#include <optional>
+#include <pup.h>
 #include <string>
+#include <tuple>
 
 #include "AlgorithmArray.hpp"
 #include "AlgorithmGroup.hpp"
 #include "AlgorithmNodegroup.hpp"
 #include "AlgorithmSingleton.hpp"
 #include "ErrorHandling/FloatingPointExceptions.hpp"
-#include "Informer/InfoFromBuild.hpp"
-#include "Parallel/Abort.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "Parallel/Exit.hpp"
 #include "Parallel/GlobalCache.hpp"
+#include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
-#include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
-#include "Parallel/Printf.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "Utilities/TypeTraits.hpp"
-
-namespace Parallel::charmxx {
-struct RegistrationHelper;
-}  // namespace Parallel::charmxx
 
 namespace {
 
@@ -49,6 +45,14 @@ struct age {
 
 struct height {
   using type = double;
+};
+
+struct weight {
+  using type = double;
+};
+
+struct email {
+  using type = std::string;
 };
 
 #pragma GCC diagnostic push
@@ -82,6 +86,37 @@ class Square : public Shape {
                                      Square);
   void pup(PUP::er& p) override { Shape::pup(p); }
 };
+
+class Animal : public PUP::able {
+ public:
+  Animal() = default;
+  virtual size_t number_of_legs() const = 0;
+  virtual void set_number_of_legs(size_t) = 0;
+  // clang-tidy: internal charm++ warnings
+  WRAPPED_PUPable_abstract(Animal);  // NOLINT
+};
+
+class Arthropod : public Animal {
+ public:
+  Arthropod() = default;
+  explicit Arthropod(const size_t num_legs) : number_of_legs_(num_legs){};
+  explicit Arthropod(CkMigrateMessage* /*m*/) {}
+  size_t number_of_legs() const noexcept final { return number_of_legs_; }
+  void set_number_of_legs(const size_t num_legs) noexcept final {
+    number_of_legs_ = num_legs;
+  }
+  // clang-tidy: internal charm++ warnings
+  WRAPPED_PUPable_decl_base_template(Animal,  // NOLINT
+                                     Arthropod);
+
+  void pup(PUP::er& p) override {
+    Animal::pup(p);
+    p | number_of_legs_;
+  }
+
+ private:
+  size_t number_of_legs_{0};
+};
 #pragma GCC diagnostic pop
 
 struct shape_of_nametag_base {};
@@ -90,10 +125,32 @@ struct shape_of_nametag : shape_of_nametag_base {
   using type = std::unique_ptr<Shape>;
 };
 
+struct animal_base {};
+
+struct animal : animal_base {
+  using type = std::unique_ptr<Animal>;
+};
+
+template <typename T>
+struct modify_value {
+  static void apply(const gsl::not_null<T*> value,
+                    const T& new_value) noexcept {
+    *value = new_value;
+  }
+};
+
+struct modify_number_of_legs {
+  static void apply(const gsl::not_null<std::unique_ptr<Animal>*> animal_local,
+                    const size_t num_legs) noexcept {
+    (*animal_local)->set_number_of_legs(num_legs);
+  }
+};
+
 template <class Metavariables>
 struct SingletonParallelComponent {
   using chare_type = Parallel::Algorithms::Singleton;
   using const_global_cache_tags = tmpl::list<name, age, height>;
+  using mutable_global_cache_tags = tmpl::list<weight, animal>;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<typename Metavariables::Phase,
@@ -106,6 +163,7 @@ template <class Metavariables>
 struct ArrayParallelComponent {
   using chare_type = Parallel::Algorithms::Array;
   using const_global_cache_tags = tmpl::list<height, shape_of_nametag>;
+  using mutable_global_cache_tags = tmpl::list<email, weight>;
   using array_index = int;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
@@ -119,6 +177,7 @@ template <class Metavariables>
 struct GroupParallelComponent {
   using chare_type = Parallel::Algorithms::Group;
   using const_global_cache_tags = tmpl::list<name>;
+  using mutable_global_cache_tags = tmpl::list<email>;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<typename Metavariables::Phase,
@@ -131,6 +190,7 @@ template <class Metavariables>
 struct NodegroupParallelComponent {
   using chare_type = Parallel::Algorithms::Nodegroup;
   using const_global_cache_tags = tmpl::list<height>;
+  using mutable_global_cache_tags = tmpl::list<animal>;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<typename Metavariables::Phase,
@@ -150,83 +210,259 @@ struct TestMetavariables {
 
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Parallel.GlobalCache", "[Unit][Parallel]") {
-  {
-    using tag_list =
-        typename Parallel::get_const_global_cache_tags<TestMetavariables>;
-    static_assert(
-        std::is_same_v<tag_list,
-                       tmpl::list<name, age, height, shape_of_nametag>>,
-        "Wrong tag_list in GlobalCache test");
+template <typename Metavariables>
+void TestArrayChare<Metavariables>::run_test_one() noexcept {
+  // Test that the values are what we think they should be.
+  auto& local_cache = *global_cache_proxy_.ckLocalBranch();
+  SPECTRE_PARALLEL_REQUIRE("Nobody" == Parallel::get<name>(local_cache));
+  SPECTRE_PARALLEL_REQUIRE(178 == Parallel::get<age>(local_cache));
+  SPECTRE_PARALLEL_REQUIRE(2.2 == Parallel::get<height>(local_cache));
+  SPECTRE_PARALLEL_REQUIRE(
+      4 == Parallel::get<shape_of_nametag>(local_cache).number_of_sides());
+  SPECTRE_PARALLEL_REQUIRE(
+      4 == Parallel::get<shape_of_nametag_base>(local_cache).number_of_sides());
+  SPECTRE_PARALLEL_REQUIRE(160 == Parallel::get<weight>(local_cache));
+  SPECTRE_PARALLEL_REQUIRE("joe@somewhere.com" ==
+                           Parallel::get<email>(local_cache));
+  SPECTRE_PARALLEL_REQUIRE(6 ==
+                           Parallel::get<animal>(local_cache).number_of_legs());
+  SPECTRE_PARALLEL_REQUIRE(
+      6 == Parallel::get<animal_base>(local_cache).number_of_legs());
 
-    tuples::tagged_tuple_from_typelist<tag_list> const_data_to_be_cached(
-        "Nobody", 178, 2.2, std::make_unique<Square>());
-    Parallel::GlobalCache<TestMetavariables> cache(
-        std::move(const_data_to_be_cached));
-    CHECK("Nobody" == Parallel::get<name>(cache));
-    CHECK(178 == Parallel::get<age>(cache));
-    CHECK(2.2 == Parallel::get<height>(cache));
-    CHECK(4 == Parallel::get<shape_of_nametag>(cache).number_of_sides());
-    CHECK(4 == Parallel::get<shape_of_nametag_base>(cache).number_of_sides());
-  }
+  // Mutate the weight to 150.
+  Parallel::mutate<weight, modify_value<double>>(global_cache_proxy_, 150.0);
+  run_test_two();
+}
 
-  {
-    using tag_list =
-        typename Parallel::get_const_global_cache_tags<TestMetavariables>;
-    static_assert(
-        std::is_same_v<tag_list,
-                       tmpl::list<name, age, height, shape_of_nametag>>,
-        "Wrong tag_list in GlobalCache test");
+template <typename Metavariables>
+void TestArrayChare<Metavariables>::run_test_two() noexcept {
+  // Move on when the weight is 150.
+  auto callback =
+      CkCallback(CkIndex_TestArrayChare<Metavariables>::run_test_two(),
+                 this->thisProxy[this->thisIndex]);
+  if (Parallel::mutable_cache_item_is_ready<weight>(
+          *global_cache_proxy_.ckLocalBranch(),
+          [&callback](const double& weight_l) -> std::optional<CkCallback> {
+            return weight_l == 150 ? std::optional<CkCallback>{}
+                                   : std::optional<CkCallback>(callback);
+          })) {
+    auto& local_cache = *global_cache_proxy_.ckLocalBranch();
+    SPECTRE_PARALLEL_REQUIRE(150 == Parallel::get<weight>(local_cache));
 
-    tuples::tagged_tuple_from_typelist<tag_list> const_data_to_be_cached(
-        "Nobody", 178, 2.2, std::make_unique<Square>());
-
-    Parallel::CProxy_GlobalCache<TestMetavariables>
-        global_cache_proxy =
-            Parallel::CProxy_GlobalCache<TestMetavariables>::ckNew(
-                const_data_to_be_cached);
-    const auto& local_cache = *global_cache_proxy.ckLocalBranch();
-    CHECK("Nobody" == Parallel::get<name>(local_cache));
-    CHECK(178 == Parallel::get<age>(local_cache));
-    CHECK(2.2 == Parallel::get<height>(local_cache));
-    CHECK(4 == Parallel::get<shape_of_nametag>(local_cache).number_of_sides());
-    CHECK(4 ==
-          Parallel::get<shape_of_nametag_base>(local_cache).number_of_sides());
+    // Now the weight is 150, so mutate the email.
+    Parallel::mutate<email, modify_value<std::string>>(
+        global_cache_proxy_, std::string("albert@einstein.de"));
+    // ... and make the arthropod into a lobster.
+    Parallel::mutate<animal, modify_number_of_legs>(global_cache_proxy_, 10_st);
+    run_test_three();
   }
 }
 
-Test_GlobalCache::Test_GlobalCache(CkArgMsg* msg) {
-  std::set_terminate(
-      []() { Parallel::abort("Called terminate. Aborting..."); });
-  Parallel::printf("%s", info_from_build().c_str());
-  enable_floating_point_exceptions();
-  int result = Catch::Session().run(msg->argc, msg->argv);
-  if (0 == result) {
+template <typename Metavariables>
+void TestArrayChare<Metavariables>::run_test_three() noexcept {
+  // Move on when the email is Albert's.
+  auto callback =
+      CkCallback(CkIndex_TestArrayChare<Metavariables>::run_test_three(),
+                 this->thisProxy[this->thisIndex]);
+  if (Parallel::mutable_cache_item_is_ready<email>(
+          *global_cache_proxy_.ckLocalBranch(),
+          [&callback](const std::string& email_l) -> std::optional<CkCallback> {
+            return email_l == "albert@einstein.de"
+                       ? std::optional<CkCallback>{}
+                       : std::optional<CkCallback>(callback);
+          })) {
+    auto& local_cache = *global_cache_proxy_.ckLocalBranch();
+    SPECTRE_PARALLEL_REQUIRE("albert@einstein.de" ==
+                             Parallel::get<email>(local_cache));
+
+    // Now make the arthropod into a spider.
+    Parallel::mutate<animal, modify_number_of_legs>(global_cache_proxy_, 8_st);
+    run_test_four();
+  }
+}
+
+template <typename Metavariables>
+void TestArrayChare<Metavariables>::run_test_four() noexcept {
+  // Move on when the animal has 8 legs.
+  auto callback =
+      CkCallback(CkIndex_TestArrayChare<Metavariables>::run_test_four(),
+                 this->thisProxy[this->thisIndex]);
+  if (Parallel::mutable_cache_item_is_ready<animal>(
+          *global_cache_proxy_.ckLocalBranch(),
+          [&callback](const Animal& animal_l) -> std::optional<CkCallback> {
+            return animal_l.number_of_legs() == 8
+                       ? std::optional<CkCallback>{}
+                       : std::optional<CkCallback>(callback);
+          })) {
+    auto& local_cache = *global_cache_proxy_.ckLocalBranch();
+    SPECTRE_PARALLEL_REQUIRE(
+        8 == Parallel::get<animal>(local_cache).number_of_legs());
+
+    // Make the arthropod into a Scutigera coleoptrata.
+    Parallel::mutate<animal_base, modify_number_of_legs>(global_cache_proxy_,
+                                                         30_st);
+
+    run_test_five();
+  }
+}
+
+template <typename Metavariables>
+void TestArrayChare<Metavariables>::run_test_five() noexcept {
+  // Move on when the animal has 30 legs.
+  auto callback =
+      CkCallback(CkIndex_TestArrayChare<Metavariables>::run_test_five(),
+                 this->thisProxy[this->thisIndex]);
+  if (Parallel::mutable_cache_item_is_ready<animal_base>(
+          *global_cache_proxy_.ckLocalBranch(),
+          [&callback](const Animal& animal_l) -> std::optional<CkCallback> {
+            return animal_l.number_of_legs() == 30
+                       ? std::optional<CkCallback>{}
+                       : std::optional<CkCallback>(callback);
+          })) {
+    auto& local_cache = *global_cache_proxy_.ckLocalBranch();
+    SPECTRE_PARALLEL_REQUIRE(
+        30 == Parallel::get<animal_base>(local_cache).number_of_legs());
+    main_proxy_.exit_if_done(this->thisIndex);
+  }
+}
+
+// run_single_core_test constructs and tests GlobalCache without
+// using proxies or parallelism.  run_single_core_test tests constructors
+// and member functions that are used in the action testing framework.
+template <typename Metavariables>
+void Test_GlobalCache<Metavariables>::run_single_core_test() noexcept {
+  using const_tag_list =
+      typename Parallel::get_const_global_cache_tags<TestMetavariables>;
+  static_assert(std::is_same_v<const_tag_list,
+                               tmpl::list<name, age, height, shape_of_nametag>>,
+                "Wrong const_tag_list in GlobalCache test");
+
+  using mutable_tag_list =
+      typename Parallel::get_mutable_global_cache_tags<TestMetavariables>;
+  static_assert(
+      std::is_same_v<mutable_tag_list, tmpl::list<weight, animal, email>>,
+      "Wrong mutable_tag_list in GlobalCache test");
+
+  tuples::tagged_tuple_from_typelist<const_tag_list> const_data_to_be_cached(
+      "Nobody", 178, 2.2, std::make_unique<Square>());
+  tuples::tagged_tuple_from_typelist<mutable_tag_list>
+      mutable_data_to_be_cached(160, std::make_unique<Arthropod>(6),
+                                "joe@somewhere.com");
+
+  Parallel::MutableGlobalCache<TestMetavariables> mutable_cache(
+      std::move(mutable_data_to_be_cached));
+  Parallel::GlobalCache<TestMetavariables> cache(
+      std::move(const_data_to_be_cached), &mutable_cache);
+  SPECTRE_PARALLEL_REQUIRE("Nobody" == Parallel::get<name>(cache));
+  SPECTRE_PARALLEL_REQUIRE(178 == Parallel::get<age>(cache));
+  SPECTRE_PARALLEL_REQUIRE(2.2 == Parallel::get<height>(cache));
+  SPECTRE_PARALLEL_REQUIRE(
+      4 == Parallel::get<shape_of_nametag>(cache).number_of_sides());
+  SPECTRE_PARALLEL_REQUIRE(
+      4 == Parallel::get<shape_of_nametag_base>(cache).number_of_sides());
+  SPECTRE_PARALLEL_REQUIRE(160 == Parallel::get<weight>(cache));
+  SPECTRE_PARALLEL_REQUIRE("joe@somewhere.com" == Parallel::get<email>(cache));
+  SPECTRE_PARALLEL_REQUIRE(6 == Parallel::get<animal>(cache).number_of_legs());
+  SPECTRE_PARALLEL_REQUIRE(6 ==
+                           Parallel::get<animal_base>(cache).number_of_legs());
+
+  // Check that we can modify the non-const items.
+  Parallel::mutate<weight, modify_value<double>>(cache, 150.0);
+  Parallel::mutate<email, modify_value<std::string>>(
+      cache, std::string("nobody@nowhere.com"));
+  SPECTRE_PARALLEL_REQUIRE(150 == Parallel::get<weight>(cache));
+  SPECTRE_PARALLEL_REQUIRE("nobody@nowhere.com" == Parallel::get<email>(cache));
+  Parallel::mutate<email, modify_value<std::string>>(
+      cache, std::string("isaac@newton.com"));
+  SPECTRE_PARALLEL_REQUIRE("isaac@newton.com" == Parallel::get<email>(cache));
+  // Make the arthropod into a spider.
+  Parallel::mutate<animal, modify_number_of_legs>(cache, 8_st);
+  SPECTRE_PARALLEL_REQUIRE(8 == Parallel::get<animal>(cache).number_of_legs());
+  SPECTRE_PARALLEL_REQUIRE(8 ==
+                           Parallel::get<animal_base>(cache).number_of_legs());
+  // Make the arthropod into a Scutigera coleoptrata.
+  Parallel::mutate<animal_base, modify_number_of_legs>(cache, 30_st);
+  SPECTRE_PARALLEL_REQUIRE(30 == Parallel::get<animal>(cache).number_of_legs());
+  SPECTRE_PARALLEL_REQUIRE(30 ==
+                           Parallel::get<animal_base>(cache).number_of_legs());
+}
+
+template <typename Metavariables>
+Test_GlobalCache<Metavariables>::Test_GlobalCache(CkArgMsg*
+                                                  /*msg*/) noexcept {
+  // Register the pup functions.
+  Parallel::register_classes_in_list<tmpl::list<Triangle, Square, Arthropod>>();
+
+  // Call the single core test before doing anything else.
+  run_single_core_test();
+
+  // Initialize number of elements
+  num_elements_ = 4;
+
+  // Create GlobalCache proxies.
+  using mutable_tag_list =
+      typename Parallel::get_mutable_global_cache_tags<TestMetavariables>;
+  static_assert(
+      std::is_same_v<mutable_tag_list, tmpl::list<weight, animal, email>>,
+      "Wrong mutable_tag_list in GlobalCache test");
+  // Arthropod begins as an insect.
+  tuples::tagged_tuple_from_typelist<mutable_tag_list>
+      mutable_data_to_be_cached(160, std::make_unique<Arthropod>(6),
+                                "joe@somewhere.com");
+  mutable_global_cache_proxy_ =
+      Parallel::CProxy_MutableGlobalCache<TestMetavariables>::ckNew(
+          mutable_data_to_be_cached);
+
+  // global_cache_proxy_ depends on mutable_global_cache_proxy_.
+  CkEntryOptions mutable_global_cache_dependency;
+  mutable_global_cache_dependency.setGroupDepID(
+      mutable_global_cache_proxy_.ckGetGroupID());
+
+  using const_tag_list =
+      typename Parallel::get_const_global_cache_tags<TestMetavariables>;
+  static_assert(std::is_same_v<const_tag_list,
+                               tmpl::list<name, age, height, shape_of_nametag>>,
+                "Wrong const_tag_list in GlobalCache test");
+  tuples::tagged_tuple_from_typelist<const_tag_list> const_data_to_be_cached(
+      "Nobody", 178, 2.2, std::make_unique<Square>());
+  global_cache_proxy_ = Parallel::CProxy_GlobalCache<TestMetavariables>::ckNew(
+      const_data_to_be_cached, mutable_global_cache_proxy_,
+      &mutable_global_cache_dependency);
+
+  CkEntryOptions global_cache_dependency;
+  global_cache_dependency.setGroupDepID(global_cache_proxy_.ckGetGroupID());
+
+  // Create array
+  CProxy_TestArrayChare<Metavariables> array_proxy =
+      CProxy_TestArrayChare<Metavariables>::ckNew(
+          this->thisProxy, global_cache_proxy_, num_elements_);
+
+  array_proxy.run_test_one();
+}
+
+template <typename Metavariables>
+void Test_GlobalCache<Metavariables>::exit_if_done(int index) noexcept {
+  elements_that_are_finished_.insert(index);
+  if (elements_that_are_finished_.size() >= num_elements_) {
     Parallel::exit();
   }
-  Parallel::abort("A catch test has failed.");
 }
 
-void register_pupables() {
-  PUPable_reg(Triangle);
-  PUPable_reg(Square);
-}
+// --------- registration stuff below -------
 
 /// \cond
 // clang-tidy: possibly throwing constructor static storage
 // clang-tidy: false positive: redundant declaration
-PUP::able::PUP_ID Triangle::my_PUP_ID = 0;  // NOLINT
-PUP::able::PUP_ID Square::my_PUP_ID = 0;    // NOLINT
+PUP::able::PUP_ID Triangle::my_PUP_ID = 0;   // NOLINT
+PUP::able::PUP_ID Square::my_PUP_ID = 0;     // NOLINT
+PUP::able::PUP_ID Arthropod::my_PUP_ID = 0;  // NOLINT
 /// \endcond
 
-#include "src/Parallel/GlobalCache.def.h"  // IWYU pragma: keep
+static const std::vector<void (*)()> charm_init_node_funcs{
+    &setup_error_handling};
+static const std::vector<void (*)()> charm_init_proc_funcs{
+    &enable_floating_point_exceptions};
 
-#include "tests/Unit/Parallel/Test_GlobalCache.def.h"  // IWYU pragma: keep
+using charmxx_main_component = Test_GlobalCache<TestMetavariables>;
 
-namespace Parallel::charmxx {
-/// \cond
-std::unique_ptr<RegistrationHelper>* charm_register_list = nullptr;
-size_t charm_register_list_capacity = 0;
-size_t charm_register_list_size = 0;
-/// \endcond
-}  // namespace Parallel::charmxx
+#include "Parallel/CharmMain.tpp"  // IWYU pragma: keep

--- a/tests/Unit/Parallel/Test_GlobalCache.hpp
+++ b/tests/Unit/Parallel/Test_GlobalCache.hpp
@@ -3,49 +3,79 @@
 
 #pragma once
 
-#include <limits>
-#include <pup.h>
+#include <charm++.h>
+#include <set>
 
-#include "Parallel/Info.hpp"
+#include "Parallel/CharmRegistration.hpp"
+#include "Parallel/GlobalCache.hpp"
+
 #include "tests/Unit/Parallel/Test_GlobalCache.decl.h"
 
-/// \cond
-class CkArgMsg;
-/// \endcond
-
-class TestArrayChare : public CBase_TestArrayChare {
+template <typename Metavariables>
+class Test_GlobalCache : public CBase_Test_GlobalCache<Metavariables> {
  public:
-  TestArrayChare() = default;
-  explicit TestArrayChare(CkMigrateMessage* /*unused*/) {}
-  int my_index() const noexcept { return thisIndex; }
-};
+  /// \cond HIDDEN_SYMBOLS
+  /// The constructor used to register the class
+  explicit Test_GlobalCache(const
+  Parallel::charmxx::MainChareRegistrationConstructor& /*used 4 registration*/)
+    noexcept {
+  }
+  ~Test_GlobalCache() noexcept override {
+    (void)Parallel::charmxx::RegisterChare<
+        Test_GlobalCache<Metavariables>,
+        CkIndex_Test_GlobalCache<Metavariables>>::registrar;
+  }
+  Test_GlobalCache(const Test_GlobalCache&) = default;
+  Test_GlobalCache& operator=(const Test_GlobalCache&) = default;
+  Test_GlobalCache(Test_GlobalCache&&) = default;
+  Test_GlobalCache& operator=(Test_GlobalCache&&) = default;
+  /// \endcond
 
-class ParallelComponent : public CBase_ParallelComponent {
- public:
-  explicit ParallelComponent(int id) noexcept : id_(id) {}
-  explicit ParallelComponent(CkMigrateMessage* /*unused*/) {}
-  int my_id() const noexcept { return id_; }
+  explicit Test_GlobalCache(CkArgMsg* msg) noexcept;
+  explicit Test_GlobalCache(CkMigrateMessage* /*msg*/) {}
+
+  void exit_if_done(int index) noexcept;
+
+  void run_single_core_test() noexcept;
 
  private:
-  int id_{std::numeric_limits<int>::max()};
+  Parallel::CProxy_MutableGlobalCache<Metavariables>
+      mutable_global_cache_proxy_{};
+  Parallel::CProxy_GlobalCache<Metavariables> global_cache_proxy_{};
+  size_t num_elements_{4};
+  std::set<int> elements_that_are_finished_{};
 };
 
-class TestGroupChare : public CBase_TestGroupChare {
+template <typename Metavariables>
+class TestArrayChare : public CBase_TestArrayChare<Metavariables> {
  public:
-  TestGroupChare() = default;
-  explicit TestGroupChare(CkMigrateMessage* /*unused*/) {}
-  static int my_proc() noexcept { return Parallel::my_proc(); }
+  explicit TestArrayChare(
+      CProxy_Test_GlobalCache<Metavariables> main_proxy,
+      Parallel::CProxy_GlobalCache<Metavariables> global_cache_proxy)
+      : main_proxy_(std::move(main_proxy)),
+        global_cache_proxy_(std::move(global_cache_proxy)) {}
+  explicit TestArrayChare(CkMigrateMessage* /*msg*/) {}
+  ~TestArrayChare() noexcept override {
+    (void)Parallel::charmxx::RegisterChare<
+        TestArrayChare<Metavariables>,
+        CkIndex_TestArrayChare<Metavariables>>::registrar;
+  }
+  TestArrayChare(const TestArrayChare&) = default;
+  TestArrayChare& operator=(const TestArrayChare&) = default;
+  TestArrayChare(TestArrayChare&&) = default;
+  TestArrayChare& operator=(TestArrayChare&&) = default;
+
+  void run_test_one() noexcept;
+  void run_test_two() noexcept;
+  void run_test_three() noexcept;
+  void run_test_four() noexcept;
+  void run_test_five() noexcept;
+
+ private:
+  CProxy_Test_GlobalCache<Metavariables> main_proxy_;
+  Parallel::CProxy_GlobalCache<Metavariables> global_cache_proxy_;
 };
 
-class TestNodeGroupChare : public CBase_TestNodeGroupChare {
- public:
-  TestNodeGroupChare() = default;
-  explicit TestNodeGroupChare(CkMigrateMessage* /*unused*/) {}
-  static int my_node() noexcept { return Parallel::my_node(); }
-};
-
-/// Main executable for running the unit tests.
-class Test_GlobalCache : public CBase_Test_GlobalCache {
- public:
-  [[noreturn]] explicit Test_GlobalCache(CkArgMsg* msg);
-};
+#define CK_TEMPLATES_ONLY
+#include "tests/Unit/Parallel/Test_GlobalCache.def.h"
+#undef CK_TEMPLATES_ONLY

--- a/tests/Unit/Parallel/Test_GlobalCacheDataBox.cpp
+++ b/tests/Unit/Parallel/Test_GlobalCacheDataBox.cpp
@@ -42,7 +42,8 @@ SPECTRE_TEST_CASE("Unit.Parallel.GlobalCacheDataBox", "[Unit][Parallel]") {
   tuples::get<Tags::IntegerList>(tuple) = std::array<int, 3>{{-1, 3, 7}};
   tuples::get<Tags::UniquePtrIntegerList>(tuple) =
       std::make_unique<std::array<int, 3>>(std::array<int, 3>{{1, 5, -8}});
-  GlobalCache<Metavars> cache{std::move(tuple)};
+  MutableGlobalCache<Metavars> mutable_cache{tuples::TaggedTuple<>{}};
+  GlobalCache<Metavars> cache{std::move(tuple), &mutable_cache};
   auto box =
       db::create<db::AddSimpleTags<Tags::GlobalCacheImpl<Metavars>>,
                  db::AddComputeTags<
@@ -62,7 +63,8 @@ SPECTRE_TEST_CASE("Unit.Parallel.GlobalCacheDataBox", "[Unit][Parallel]") {
   tuples::get<Tags::IntegerList>(tuple2) = std::array<int, 3>{{10, -3, 700}};
   tuples::get<Tags::UniquePtrIntegerList>(tuple2) =
       std::make_unique<std::array<int, 3>>(std::array<int, 3>{{100, -7, -300}});
-  GlobalCache<Metavars> cache2{std::move(tuple2)};
+  MutableGlobalCache<Metavars> mutable_cache2{tuples::TaggedTuple<>{}};
+  GlobalCache<Metavars> cache2{std::move(tuple2), &mutable_cache2};
   db::mutate<Tags::GlobalCache>(
       make_not_null(&box),
       [&cache2](


### PR DESCRIPTION
## Proposed changes

Allows mutable objects in the GlobalCache.
Adds tests and documentation for mutable objects in the GlobalCache.
Rewrites Test_GlobalCache to use automatic charm++ registration framework.
Does only minimal modification to mock testing framework.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
