### PR TITLE
Don't gitignore Tags/ directories on case-insensitive file systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ GRTAGS
 GTAGS
 TAGS
 tags
+# Keep Tags/ directories on case-insensitive file systems
+!Tags/


### PR DESCRIPTION
## Proposed changes

@kidder recently added a `Tags/` directory in `src/DataStructures/`. This PR excludes `Tags/` directories from a rule in our `.gitignore` that is meant to ignore files named `TAGS` or `tags`.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
