### PR TITLE
Serialize std::optional and std::variant

### DIFF
--- a/src/Parallel/CMakeLists.txt
+++ b/src/Parallel/CMakeLists.txt
@@ -38,6 +38,7 @@ spectre_target_headers(
   PhaseDependentActionList.hpp
   Printf.hpp
   PupStlCpp11.hpp
+  PupStlCpp17.hpp
   Reduction.hpp
   RegisterDerivedClassesWithCharm.hpp
   Serialize.hpp

--- a/src/Parallel/PupStlCpp17.hpp
+++ b/src/Parallel/PupStlCpp17.hpp
@@ -6,6 +6,10 @@
 #include <optional>
 #include <pup_stl.h>
 #include <utility>
+#include <variant>
+
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace PUP {
 /// \ingroup ParallelGroup
@@ -35,6 +39,42 @@ void pup(er& p, std::optional<T>& t) noexcept {  // NOLINT
 /// Serialization of std::optional for Charm++
 template <typename T>
 void operator|(er& p, std::optional<T>& t) noexcept {  // NOLINT
+  pup(p, t);
+}
+
+/// \ingroup ParallelGroup
+/// Serialization of std::variant for Charm++
+template <typename... Ts>
+void pup(er& p, std::variant<Ts...>& t) noexcept {  // NOLINT
+  // clang tidy: complains about pointer decay, I don't understand the error
+  // since nothing here is doing anything with pointers.
+  assert(not t.valueless_by_exception());  // NOLINT
+
+  size_t current_index = 0;
+  size_t send_index = t.index();
+  p | send_index;
+
+  const auto pup_helper = [&current_index, &p, send_index,
+                           &t](auto type_v) noexcept {
+    using type = tmpl::type_from<decltype(type_v)>;
+    if (UNLIKELY(current_index == send_index)) {
+      if (p.isUnpacking()) {
+        type temp{};
+        p | temp;
+        t = std::move(temp);
+      } else {
+        p | std::get<type>(t);
+      }
+    }
+    ++current_index;
+  };
+  EXPAND_PACK_LEFT_TO_RIGHT(pup_helper(tmpl::type_<Ts>{}));
+}
+
+/// \ingroup ParallelGroup
+/// Serialization of std::variant for Charm++
+template <typename... Ts>
+void operator|(er& p, std::variant<Ts...>& t) noexcept {  // NOLINT
   pup(p, t);
 }
 }  // namespace PUP

--- a/src/Parallel/PupStlCpp17.hpp
+++ b/src/Parallel/PupStlCpp17.hpp
@@ -1,0 +1,40 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <optional>
+#include <pup_stl.h>
+#include <utility>
+
+namespace PUP {
+/// \ingroup ParallelGroup
+/// Serialization of std::optional for Charm++
+template <typename T>
+void pup(er& p, std::optional<T>& t) noexcept {  // NOLINT
+  bool valid = false;
+  if (p.isUnpacking()) {
+    p | valid;
+    if (valid) {
+      T value{};
+      p | value;
+      t = std::move(value);
+    } else {
+      t.reset();
+    }
+  } else {
+    valid = t.has_value();
+    p | valid;
+    if (valid) {
+      p | *t;
+    }
+  }
+}
+
+/// \ingroup ParallelGroup
+/// Serialization of std::optional for Charm++
+template <typename T>
+void operator|(er& p, std::optional<T>& t) noexcept {  // NOLINT
+  pup(p, t);
+}
+}  // namespace PUP

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -136,6 +136,7 @@ set(LIBRARY_SOURCES
   Test_Parallel.cpp
   Test_ParallelComponentHelpers.cpp
   Test_PupStlCpp11.cpp
+  Test_PupStlCpp17.cpp
   Test_TypeTraits.cpp
   )
 

--- a/tests/Unit/Parallel/Test_PupStlCpp17.cpp
+++ b/tests/Unit/Parallel/Test_PupStlCpp17.cpp
@@ -3,7 +3,9 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <cstddef>
 #include <optional>
+#include <variant>
 
 #include "Framework/TestHelpers.hpp"
 #include "Parallel/PupStlCpp17.hpp"
@@ -21,5 +23,16 @@ SPECTRE_TEST_CASE("Unit.Serialization.PupStlCpp17", "[Serialization][Unit]") {
     const auto t_set_deserialized = serialize_and_deserialize(t_set);
     REQUIRE(t_set_deserialized.value());
     CHECK(*t_set_deserialized == 10);
+  }
+  {
+    INFO("Variant");
+    std::variant<int, char, size_t> t{-1};
+    CHECK(std::get<int>(serialize_and_deserialize(t)) == -1);
+    t = 'a';
+    CHECK(std::get<char>(serialize_and_deserialize(t)) == 'a');
+    t = 10;
+    CHECK(std::get<int>(serialize_and_deserialize(t)) == 10);
+    t = static_cast<size_t>(100);
+    CHECK(std::get<size_t>(serialize_and_deserialize(t)) == 100);
   }
 }

--- a/tests/Unit/Parallel/Test_PupStlCpp17.cpp
+++ b/tests/Unit/Parallel/Test_PupStlCpp17.cpp
@@ -1,0 +1,25 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <optional>
+
+#include "Framework/TestHelpers.hpp"
+#include "Parallel/PupStlCpp17.hpp"
+
+SPECTRE_TEST_CASE("Unit.Serialization.PupStlCpp17", "[Serialization][Unit]") {
+  {
+    INFO("Optional");
+    const std::optional<int> t_not_set{};
+    CHECK_FALSE(t_not_set.has_value());
+    const auto t_not_set_deserialized = serialize_and_deserialize(t_not_set);
+    CHECK_FALSE(t_not_set_deserialized.has_value());
+
+    const std::optional<int> t_set{10};
+    REQUIRE(t_set.value());
+    const auto t_set_deserialized = serialize_and_deserialize(t_set);
+    REQUIRE(t_set_deserialized.value());
+    CHECK(*t_set_deserialized == 10);
+  }
+}


### PR DESCRIPTION
## Proposed changes

Add serialization for std::optional and std::variant

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
