### PR TITLE
Miscellaneous updates related to forthcoming DataBox changes

### DIFF
--- a/src/DataStructures/DataBox/TagTraits.hpp
+++ b/src/DataStructures/DataBox/TagTraits.hpp
@@ -35,6 +35,23 @@ template <typename Tag>
 constexpr bool is_compute_tag_v = is_compute_tag<Tag>::value;
 // @}
 
+/*!
+ * \ingroup DataBoxGroup
+ * \brief Check if `Tag` is a simple tag.
+ */
+template <typename Tag, typename = std::nullptr_t>
+struct is_simple_tag : std::false_type {};
+/// \cond HIDDEN_SYMBOLS
+template <typename Tag>
+struct is_simple_tag<Tag, Requires<std::is_base_of_v<db::SimpleTag, Tag> and
+                                   not is_compute_tag_v<Tag>>>
+    : std::true_type {};
+/// \endcond
+
+template <typename Tag>
+constexpr bool is_simple_tag_v = is_simple_tag<Tag>::value;
+// @}
+
 // @{
 /*!
  * \ingroup DataBoxGroup

--- a/src/Domain/FaceNormal.hpp
+++ b/src/Domain/FaceNormal.hpp
@@ -111,7 +111,6 @@ namespace Tags {
 /// The unnormalized face normal one form
 template <size_t VolumeDim, typename Frame = ::Frame::Inertial>
 struct UnnormalizedFaceNormal : db::SimpleTag {
-  static std::string name() noexcept { return "UnnormalizedFaceNormal"; }
   using type = tnsr::i<DataVector, VolumeDim, Frame>;
 };
 
@@ -169,6 +168,8 @@ struct InterfaceCompute<Tags::BoundaryDirectionsExterior<VolumeDim>,
     : db::ComputeTag,
       Tags::Interface<Tags::BoundaryDirectionsExterior<VolumeDim>,
                       Tags::UnnormalizedFaceNormal<VolumeDim, Frame>> {
+  using base = Tags::Interface<Tags::BoundaryDirectionsExterior<VolumeDim>,
+                               Tags::UnnormalizedFaceNormal<VolumeDim, Frame>>;
   using dirs = BoundaryDirectionsExterior<VolumeDim>;
 
   static std::string name() noexcept {
@@ -202,6 +203,9 @@ struct InterfaceCompute<Tags::BoundaryDirectionsExterior<VolumeDim>,
       Tags::Interface<
           Tags::BoundaryDirectionsExterior<VolumeDim>,
           Tags::UnnormalizedFaceNormal<VolumeDim, Frame::Inertial>> {
+  using base =
+      Tags::Interface<Tags::BoundaryDirectionsExterior<VolumeDim>,
+                      Tags::UnnormalizedFaceNormal<VolumeDim, Frame::Inertial>>;
   using dirs = BoundaryDirectionsExterior<VolumeDim>;
 
   static std::string name() noexcept {

--- a/src/Domain/InterfaceComputeTags.hpp
+++ b/src/Domain/InterfaceComputeTags.hpp
@@ -134,6 +134,7 @@ struct evaluate_compute_item<DirectionsTag, BaseComputeItem,
 /// \tparam Tag the tag labeling the item
 template <typename DirectionsTag, typename Tag>
 struct InterfaceCompute : Interface<DirectionsTag, Tag>, db::ComputeTag {
+  using base = Interface<DirectionsTag, Tag>;
   static_assert(db::is_compute_tag_v<Tag>,
                 "Cannot use a non compute item as an interface compute item.");
   // Defining name here prevents an ambiguous function call when using base
@@ -175,6 +176,7 @@ struct InterfaceCompute : Interface<DirectionsTag, Tag>, db::ComputeTag {
 /// \tparam Tag the tag labeling the item
 template <typename DirectionsTag, typename Tag>
 struct Slice : Interface<DirectionsTag, Tag>, db::ComputeTag {
+  using base = Interface<DirectionsTag, Tag>;
   static constexpr size_t volume_dim = DirectionsTag::volume_dim;
 
   using return_type =
@@ -202,6 +204,7 @@ struct Slice : Interface<DirectionsTag, Tag>, db::ComputeTag {
 template <typename DirectionsTag, size_t VolumeDim>
 struct InterfaceCompute<DirectionsTag, Direction<VolumeDim>>
     : db::ComputeTag, Tags::Interface<DirectionsTag, Direction<VolumeDim>> {
+  using base = Tags::Interface<DirectionsTag, Direction<VolumeDim>>;
   static std::string name() noexcept { return "Interface"; }
   using tag = Direction<VolumeDim>;
   using return_type =

--- a/src/Domain/MinimumGridSpacing.hpp
+++ b/src/Domain/MinimumGridSpacing.hpp
@@ -9,6 +9,7 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Tags.hpp"  // IWYU pragma: keep
+#include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -28,18 +29,27 @@ double minimum_grid_spacing(
 
 namespace domain {
 namespace Tags {
+// @{
 /// \ingroup ComputationalDomainGroup
 /// \ingroup DataBoxTagsGroup
 /// The minimum coordinate distance between grid points.
 template <size_t Dim, typename Frame>
-struct MinimumGridSpacing : db::ComputeTag {
-  static std::string name() noexcept { return "MinimumGridSpacing"; }
-  static auto function(
-      const ::Mesh<Dim>& mesh,
+struct MinimumGridSpacing : db::SimpleTag {
+  using type = double;
+};
+
+template <size_t Dim, typename Frame>
+struct MinimumGridSpacingCompute : MinimumGridSpacing<Dim, Frame>,
+                                   db::ComputeTag {
+  using base = MinimumGridSpacing<Dim, Frame>;
+  using return_type = double;
+  static void function(
+      const gsl::not_null<double*> result, const ::Mesh<Dim>& mesh,
       const tnsr::I<DataVector, Dim, Frame>& coordinates) noexcept {
-    return minimum_grid_spacing(mesh.extents(), coordinates);
+    *result = minimum_grid_spacing(mesh.extents(), coordinates);
   }
   using argument_tags = tmpl::list<Mesh<Dim>, Coordinates<Dim, Frame>>;
 };
+// @}
 }  // namespace Tags
 }  // namespace domain

--- a/src/Domain/Structure/Element.cpp
+++ b/src/Domain/Structure/Element.cpp
@@ -31,6 +31,13 @@ Element<VolumeDim>::Element(ElementId<VolumeDim> id,
           external_boundaries.erase(neighbor_direction.first);
         }
         return external_boundaries;
+      }()),
+      internal_boundaries_([this]() {
+        std::unordered_set<Direction<VolumeDim>> internal_boundaries;
+        for (const auto& direction_neighbors : neighbors_) {
+          internal_boundaries.insert(direction_neighbors.first);
+        }
+        return internal_boundaries;
       }()) {
   // Assuming a maximum 2-to-1 refinement between neighboring elements:
   ASSERT(number_of_neighbors_ <= maximum_number_of_neighbors(VolumeDim),
@@ -44,6 +51,7 @@ void Element<VolumeDim>::pup(PUP::er& p) noexcept {
   p | neighbors_;
   p | number_of_neighbors_;
   p | external_boundaries_;
+  p | internal_boundaries_;
 }
 
 template <size_t VolumeDim>
@@ -51,7 +59,8 @@ bool operator==(const Element<VolumeDim>& lhs,
                 const Element<VolumeDim>& rhs) noexcept {
   return lhs.id() == rhs.id() and lhs.neighbors() == rhs.neighbors() and
          lhs.number_of_neighbors() == rhs.number_of_neighbors() and
-         lhs.external_boundaries() == rhs.external_boundaries();
+         lhs.external_boundaries() == rhs.external_boundaries() and
+         lhs.internal_boundaries() == rhs.internal_boundaries();
 }
 
 template <size_t VolumeDim>

--- a/src/Domain/Structure/Element.hpp
+++ b/src/Domain/Structure/Element.hpp
@@ -53,6 +53,12 @@ class Element {
     return external_boundaries_;
   }
 
+  /// The directions of the faces of the Element that are internal boundaries.
+  const std::unordered_set<Direction<VolumeDim>>& internal_boundaries() const
+      noexcept {
+    return internal_boundaries_;
+  }
+
   /// A unique ID for the Element.
   const ElementId<VolumeDim>& id() const noexcept { return id_; }
 
@@ -70,6 +76,7 @@ class Element {
   Neighbors_t neighbors_{};
   size_t number_of_neighbors_{};
   std::unordered_set<Direction<VolumeDim>> external_boundaries_{};
+  std::unordered_set<Direction<VolumeDim>> internal_boundaries_{};
 };
 
 template <size_t VolumeDim>

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -227,13 +227,21 @@ struct DetInvJacobianCompute : db::ComputeTag,
 /// Base tag for boundary data needed for updating the variables.
 struct VariablesBoundaryData : db::BaseTag {};
 
+// @{
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup
 /// The set of directions to neighboring Elements
 template <size_t VolumeDim>
-struct InternalDirections : db::ComputeTag {
+struct InternalDirections : db::SimpleTag {
   static constexpr size_t volume_dim = VolumeDim;
-  static std::string name() noexcept { return "InternalDirections"; }
+  using type = std::unordered_set<::Direction<VolumeDim>>;
+};
+
+template <size_t VolumeDim>
+struct InternalDirectionsCompute : InternalDirections<VolumeDim>,
+                                   db::ComputeTag {
+  static constexpr size_t volume_dim = VolumeDim;
+  using base = InternalDirections<VolumeDim>;
   using return_type = std::unordered_set<::Direction<VolumeDim>>;
   using argument_tags = tmpl::list<Element<VolumeDim>>;
   static void function(const gsl::not_null<return_type*> directions,
@@ -243,6 +251,7 @@ struct InternalDirections : db::ComputeTag {
     }
   }
 };
+// @}
 
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup
@@ -250,9 +259,17 @@ struct InternalDirections : db::ComputeTag {
 /// Used for representing data on the interior side of the external boundary
 /// faces.
 template <size_t VolumeDim>
-struct BoundaryDirectionsInterior : db::ComputeTag {
+struct BoundaryDirectionsInterior : db::SimpleTag {
   static constexpr size_t volume_dim = VolumeDim;
-  static std::string name() noexcept { return "BoundaryDirectionsInterior"; }
+  using type = std::unordered_set<::Direction<VolumeDim>>;
+};
+
+template <size_t VolumeDim>
+struct BoundaryDirectionsInteriorCompute
+    : BoundaryDirectionsInterior<VolumeDim>,
+      db::ComputeTag {
+  static constexpr size_t volume_dim = VolumeDim;
+  using base = BoundaryDirectionsInterior<VolumeDim>;
   using return_type = std::unordered_set<::Direction<VolumeDim>>;
   using argument_tags = tmpl::list<Element<VolumeDim>>;
   static void function(const gsl::not_null<return_type*> directions,
@@ -260,16 +277,26 @@ struct BoundaryDirectionsInterior : db::ComputeTag {
     *directions = element.external_boundaries();
   }
 };
+// @}
 
+// @{
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup
 /// The set of directions which correspond to external boundaries. To be used
 /// to represent data which exists on the exterior side of the external boundary
 /// faces.
 template <size_t VolumeDim>
-struct BoundaryDirectionsExterior : db::ComputeTag {
+struct BoundaryDirectionsExterior : db::SimpleTag {
   static constexpr size_t volume_dim = VolumeDim;
-  static std::string name() noexcept { return "BoundaryDirectionsExterior"; }
+  using type = std::unordered_set<::Direction<VolumeDim>>;
+};
+
+template <size_t VolumeDim>
+struct BoundaryDirectionsExteriorCompute
+    : BoundaryDirectionsExterior<VolumeDim>,
+      db::ComputeTag {
+  static constexpr size_t volume_dim = VolumeDim;
+  using base = BoundaryDirectionsExterior<VolumeDim>;
   using return_type = std::unordered_set<::Direction<VolumeDim>>;
   using argument_tags = tmpl::list<Element<VolumeDim>>;
   static constexpr auto function(const gsl::not_null<return_type*> directions,
@@ -277,6 +304,7 @@ struct BoundaryDirectionsExterior : db::ComputeTag {
     *directions = element.external_boundaries();
   }
 };
+// @}
 
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -341,7 +341,6 @@ struct Interface : virtual db::SimpleTag,
 /// ::Direction to an interface
 template <size_t VolumeDim>
 struct Direction : db::SimpleTag {
-  static std::string name() noexcept { return "Direction"; }
   using type = ::Direction<VolumeDim>;
 };
 

--- a/src/Domain/TagsCharacteresticSpeeds.hpp
+++ b/src/Domain/TagsCharacteresticSpeeds.hpp
@@ -11,6 +11,7 @@
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"  // For Tags::Normalized
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/InterfaceHelpers.hpp"
 #include "Domain/Tags.hpp"
 #include "Domain/TagsTimeDependent.hpp"
 #include "Utilities/Gsl.hpp"
@@ -24,8 +25,8 @@ namespace Tags {
 /// \note Assumes that `typename CharSpeedsComputeTag::return_type` is a
 /// `std::array<DataVector, NumberOfCharSpeeds>`
 template <typename CharSpeedsComputeTag, size_t Dim>
-struct CharSpeedCompute : CharSpeedsComputeTag {
-  using base = CharSpeedsComputeTag;
+struct CharSpeedCompute : CharSpeedsComputeTag::base, db::ComputeTag {
+  using base = typename CharSpeedsComputeTag::base;
   using return_type = typename CharSpeedsComputeTag::return_type;
 
   template <typename... Ts, typename T, size_t NumberOfCharSpeeds>
@@ -53,6 +54,7 @@ struct CharSpeedCompute : CharSpeedsComputeTag {
       tmpl::push_front<typename CharSpeedsComputeTag::argument_tags,
                        MeshVelocity<Dim, Frame::Inertial>,
                        ::Tags::Normalized<UnnormalizedFaceNormal<Dim>>>;
+  using volume_tags = get_volume_tags<CharSpeedsComputeTag>;
 };
 }  // namespace Tags
 }  // namespace domain

--- a/src/Evolution/Initialization/DgDomain.hpp
+++ b/src/Evolution/Initialization/DgDomain.hpp
@@ -72,7 +72,7 @@ namespace Initialization {
  *   - `domain::Tags::DetInvJacobian<Frame::Logical, Frame::Inertial>`
  *   - `domain::Tags::MeshVelocity<Dim, Frame::Inertial>`
  *   - `domain::Tags::DivMeshVelocity`
- *   - `domain::Tags::MinimumGridSpacing<Dim, Frame::Inertial>>`
+ *   - `domain::Tags::MinimumGridSpacingCompute<Dim, Frame::Inertial>>`
  * - Removes: nothing
  * - Modifies: nothing
  */
@@ -124,7 +124,7 @@ struct Domain {
         ::domain::Tags::InertialMeshVelocityCompute<Dim>,
         evolution::domain::Tags::DivMeshVelocityCompute<Dim>,
         // Compute tags for other mesh quantities
-        ::domain::Tags::MinimumGridSpacing<Dim, Frame::Inertial>>;
+        ::domain::Tags::MinimumGridSpacingCompute<Dim, Frame::Inertial>>;
 
     const auto& initial_extents =
         db::get<::domain::Tags::InitialExtents<Dim>>(box);

--- a/src/Evolution/Initialization/DiscontinuousGalerkin.hpp
+++ b/src/Evolution/Initialization/DiscontinuousGalerkin.hpp
@@ -105,9 +105,8 @@ struct DiscontinuousGalerkin {
     using boundary_exterior_compute_tag = domain::Tags::InterfaceCompute<
         domain::Tags::BoundaryDirectionsExterior<dim>, Tag>;
 
-    using char_speed_tag =
-        domain::Tags::CharSpeedCompute<typename LocalSystem::char_speeds_tag,
-                                       dim>;
+    using char_speed_tag = domain::Tags::CharSpeedCompute<
+        typename LocalSystem::char_speeds_compute_tag, dim>;
 
     using compute_tags = db::AddComputeTags<
         domain::Tags::Slice<domain::Tags::InternalDirections<dim>,
@@ -178,9 +177,8 @@ struct DiscontinuousGalerkin {
     using boundary_exterior_compute_tag = domain::Tags::InterfaceCompute<
         domain::Tags::BoundaryDirectionsExterior<dim>, Tag>;
 
-    using char_speed_tag =
-        domain::Tags::CharSpeedCompute<typename LocalSystem::char_speeds_tag,
-                                       dim>;
+    using char_speed_tag = domain::Tags::CharSpeedCompute<
+        typename LocalSystem::char_speeds_compute_tag, dim>;
 
     using compute_tags = db::AddComputeTags<
         domain::Tags::Slice<

--- a/src/Evolution/Systems/Burgers/System.hpp
+++ b/src/Evolution/Systems/Burgers/System.hpp
@@ -31,7 +31,8 @@ struct System {
   using compute_largest_characteristic_speed =
       ComputeLargestCharacteristicSpeed;
 
-  using char_speeds_tag = Tags::CharacteristicSpeedsCompute;
+  using char_speeds_compute_tag = Tags::CharacteristicSpeedsCompute;
+  using char_speeds_tag = Tags::CharacteristicSpeeds;
 
   template <typename Tag>
   using magnitude_tag = ::Tags::EuclideanMagnitude<Tag>;

--- a/src/Evolution/Systems/Cce/BoundaryDataTags.hpp
+++ b/src/Evolution/Systems/Cce/BoundaryDataTags.hpp
@@ -6,6 +6,13 @@
 #include <cstddef>
 
 #include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class ComplexDataVector;
+class DataVector;
+/// \endcond
 
 namespace Cce {
 namespace Frame {

--- a/src/Evolution/Systems/Cce/ScriPlusInterpolationManager.hpp
+++ b/src/Evolution/Systems/Cce/ScriPlusInterpolationManager.hpp
@@ -44,6 +44,8 @@ namespace Cce {
 template <typename VectorTypeToInterpolate, typename Tag>
 struct ScriPlusInterpolationManager {
  public:
+  ScriPlusInterpolationManager() = default;
+
   ScriPlusInterpolationManager(
       const size_t target_number_of_points, const size_t vector_size,
       std::unique_ptr<intrp::SpanInterpolator> interpolator) noexcept
@@ -312,6 +314,7 @@ template <typename VectorTypeToInterpolate, typename MultipliesLhs,
 struct ScriPlusInterpolationManager<
     VectorTypeToInterpolate, ::Tags::Multiplies<MultipliesLhs, MultipliesRhs>> {
  public:
+  ScriPlusInterpolationManager() = default;
   ScriPlusInterpolationManager(
       const size_t target_number_of_points, const size_t vector_size,
       std::unique_ptr<intrp::SpanInterpolator> interpolator) noexcept
@@ -452,6 +455,7 @@ struct ScriPlusInterpolationManager<
 template <typename VectorTypeToInterpolate, typename Tag>
 struct ScriPlusInterpolationManager<VectorTypeToInterpolate, Tags::Du<Tag>> {
  public:
+  ScriPlusInterpolationManager() = default;
   ScriPlusInterpolationManager(
       const size_t target_number_of_points, const size_t vector_size,
       std::unique_ptr<intrp::SpanInterpolator> interpolator) noexcept

--- a/src/Evolution/Systems/CurvedScalarWave/Constraints.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Constraints.hpp
@@ -14,41 +14,9 @@
 #include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "Utilities/Gsl.hpp"
-#include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace CurvedScalarWave {
-namespace Tags {
-/*!
- * \brief Compute items to compute constraint damping parameters.
- *
- * \details For the evolution system with constraint damping parameters
- * to be symmetric-hyperbolic, we need \f$\gamma_1 \gamma_2 = 0\f$. When
- * \f$\gamma_1 = 0\f$, Ref. \cite Holst2004wt shows that the one-index
- * constraint decays exponentially on a time-scale \f$ 1/\gamma_2\f$.
- * Conversely, they also show that using \f$\gamma_2 > 0\f$ leads to
- * exponential suppression of constraint violations.
- *
- * Can be retrieved using `CurvedScalarWave::Tags::ConstraintGamma1`
- * and `CurvedScalarWave::Tags::ConstraintGamma2`.
- */
-struct ConstraintGamma1Compute : ConstraintGamma1, db::ComputeTag {
-  using argument_tags = tmpl::list<Psi>;
-  static auto function(const Scalar<DataVector>& used_for_size) noexcept {
-    return make_with_value<type>(used_for_size, 0.);
-  }
-  using base = ConstraintGamma1;
-};
-/// \copydoc ConstraintGamma1Compute
-struct ConstraintGamma2Compute : ConstraintGamma2, db::ComputeTag {
-  using argument_tags = tmpl::list<Psi>;
-  static auto function(const Scalar<DataVector>& used_for_size) noexcept {
-    return make_with_value<type>(used_for_size, 1.);
-  }
-  using base = ConstraintGamma2;
-};
-}  // namespace Tags
-
 // @{
 /*!
  * \brief Computes the scalar-wave one-index constraint.

--- a/src/Evolution/Systems/GeneralizedHarmonic/System.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/System.hpp
@@ -34,7 +34,9 @@ struct System {
                  Tags::Phi<Dim, Frame::Inertial>>;
 
   using normal_dot_fluxes = ComputeNormalDotFluxes<Dim>;
-  using char_speeds_tag = CharacteristicSpeedsCompute<Dim, Frame::Inertial>;
+  using char_speeds_compute_tag =
+      CharacteristicSpeedsCompute<Dim, Frame::Inertial>;
+  using char_speeds_tag = Tags::CharacteristicSpeeds<Dim, Frame::Inertial>;
   using compute_largest_characteristic_speed =
       ComputeLargestCharacteristicSpeed<Dim, Frame::Inertial>;
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp
@@ -53,8 +53,9 @@ struct System {
   using magnitude_tag = ::Tags::NonEuclideanMagnitude<
       Tag, gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>>;
 
-  using char_speeds_tag =
+  using char_speeds_compute_tag =
       Tags::CharacteristicSpeedsCompute<EquationOfStateType>;
+  using char_speeds_tag = Tags::CharacteristicSpeeds;
   using compute_largest_characteristic_speed =
       ComputeLargestCharacteristicSpeed;
 

--- a/src/Evolution/Systems/NewtonianEuler/NumericalFluxes/Hllc.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/NumericalFluxes/Hllc.hpp
@@ -119,7 +119,7 @@ namespace NumericalFluxes {
  */
 template <size_t Dim, typename Frame>
 struct Hllc : tt::ConformsTo<dg::protocols::NumericalFlux> {
-  using char_speeds_tag = Tags::CharacteristicSpeedsCompute<Dim>;
+  using char_speeds_tag = Tags::CharacteristicSpeeds<Dim>;
 
   /// Estimate for one of the signal speeds
   struct LargestIngoingSpeed : db::SimpleTag {

--- a/src/Evolution/Systems/NewtonianEuler/System.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/System.hpp
@@ -40,7 +40,8 @@ struct System {
   template <typename Tag>
   using magnitude_tag = ::Tags::EuclideanMagnitude<Tag>;
 
-  using char_speeds_tag = Tags::CharacteristicSpeedsCompute<Dim>;
+  using char_speeds_compute_tag = Tags::CharacteristicSpeedsCompute<Dim>;
+  using char_speeds_tag = Tags::CharacteristicSpeeds<Dim>;
   using compute_largest_characteristic_speed =
       ComputeLargestCharacteristicSpeed<Dim>;
 

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/System.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/System.hpp
@@ -78,7 +78,8 @@ struct System<tmpl::list<NeutrinoSpecies...>> {
   using magnitude_tag = ::Tags::NonEuclideanMagnitude<
       Tag, gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>>;
 
-  using char_speeds_tag = Tags::CharacteristicSpeedsCompute;
+  using char_speeds_compute_tag = Tags::CharacteristicSpeedsCompute;
+  using char_speeds_tag = Tags::CharacteristicSpeeds;
 
   using volume_fluxes = ComputeFluxes<NeutrinoSpecies...>;
 

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/System.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/System.hpp
@@ -54,7 +54,8 @@ struct System {
   using magnitude_tag = ::Tags::NonEuclideanMagnitude<
       Tag, gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>>;
 
-  using char_speeds_tag = Tags::CharacteristicSpeedsCompute<Dim>;
+  using char_speeds_compute_tag = Tags::CharacteristicSpeedsCompute<Dim>;
+  using char_speeds_tag = Tags::CharacteristicSpeeds<Dim>;
 
   using volume_fluxes = ComputeFluxes<Dim>;
 

--- a/src/Evolution/Systems/ScalarWave/System.hpp
+++ b/src/Evolution/Systems/ScalarWave/System.hpp
@@ -48,7 +48,8 @@ struct System {
   using compute_largest_characteristic_speed =
       ComputeLargestCharacteristicSpeed;
 
-  using char_speeds_tag = Tags::CharacteristicSpeedsCompute<Dim>;
+  using char_speeds_compute_tag = Tags::CharacteristicSpeedsCompute<Dim>;
+  using char_speeds_tag = Tags::CharacteristicSpeeds<Dim>;
 
   template <typename Tag>
   using magnitude_tag = ::Tags::EuclideanMagnitude<Tag>;

--- a/src/Evolution/VariableFixing/Tags.hpp
+++ b/src/Evolution/VariableFixing/Tags.hpp
@@ -40,7 +40,6 @@ namespace Tags {
  */
 template <typename VariableFixerType>
 struct VariableFixer : db::SimpleTag {
-  static std::string name() noexcept { return "VariableFixer"; }
   using type = VariableFixerType;
   using option_tags =
       tmpl::list<::OptionTags::VariableFixer<VariableFixerType>>;

--- a/src/IO/Importers/Tags.hpp
+++ b/src/IO/Importers/Tags.hpp
@@ -175,7 +175,6 @@ struct RegisteredElements : db::SimpleTag {
  * \brief Path to an H5 file containing SpEC `FunctionOfTime` data to read.
  */
 struct FunctionOfTimeFile : db::SimpleTag {
-  static std::string name() noexcept { return "FunctionOfTimeFile"; }
   using type = std::string;
   using option_tags = tmpl::list<::importers::OptionTags::FunctionOfTimeFile>;
   static constexpr bool pass_metavariables = false;
@@ -195,7 +194,6 @@ struct FunctionOfTimeFile : db::SimpleTag {
  * `std::unordered_map` after reading it.
  */
 struct FunctionOfTimeNameMap : db::SimpleTag {
-  static std::string name() noexcept { return "FunctionOfTimeNameMap"; }
   using type = std::map<std::string, std::string>;
   using option_tags =
       tmpl::list<::importers::OptionTags::FunctionOfTimeNameMap>;

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp
@@ -79,6 +79,7 @@ template <typename Tag, size_t VolumeDim, typename Fr>
 struct NormalDotFluxCompute : db::add_tag_prefix<NormalDotFlux, Tag>,
                               db::ComputeTag {
   using base = db::add_tag_prefix<NormalDotFlux, Tag>;
+  using return_type = typename base::type;
 
  private:
   using flux_tag = db::add_tag_prefix<Flux, Tag, tmpl::size_t<VolumeDim>, Fr>;
@@ -86,10 +87,11 @@ struct NormalDotFluxCompute : db::add_tag_prefix<NormalDotFlux, Tag>,
       Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<VolumeDim, Fr>>;
 
  public:
-  static auto function(
+  static void function(
+      const gsl::not_null<return_type*> result,
       const typename flux_tag::type& flux,
       const tnsr::i<DataVector, VolumeDim, Fr>& normal) noexcept {
-    return normal_dot_flux<typename Tag::tags_list>(normal, flux);
+    *result = normal_dot_flux<typename Tag::tags_list>(normal, flux);
   }
   using argument_tags = tmpl::list<flux_tag, normal_tag>;
 };

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/LocalLaxFriedrichs.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/LocalLaxFriedrichs.hpp
@@ -54,7 +54,6 @@ struct LocalLaxFriedrichs : tt::ConformsTo<dg::protocols::NumericalFlux> {
   /// The maximum characteristic speed modulus on one side of the interface.
   struct MaxAbsCharSpeed : db::SimpleTag {
     using type = Scalar<DataVector>;
-    static std::string name() noexcept { return "MaxAbsCharSpeed"; }
   };
 
   using variables_tags = typename System::variables_tag::tags_list;

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
@@ -261,7 +261,9 @@ struct WedgeSectionTorus {
 
     // Take tensor product to get full 3D r/theta/phi points
     const size_t num_total = num_radial * num_theta * num_phi;
-    DataVector radii(num_total), thetas(num_total), phis(num_total);
+    DataVector radii(num_total);
+    DataVector thetas(num_total);
+    DataVector phis(num_total);
     for (size_t phi = 0; phi < num_phi; ++phi) {
       for (size_t theta = 0; theta < num_theta; ++theta) {
         for (size_t r = 0; r < num_radial; ++r) {

--- a/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp
+++ b/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp
@@ -56,7 +56,7 @@ namespace Actions {
  *   - `Tags::InverseJacobianCompute<
  *   Tags::ElementMap<Dim>, Tags::Coordinates<Dim, Frame::Logical>>`
  *   - `Tags::DetInvJacobianCompute<Dim, Frame::Logical, Frame::Inertial>`
- *   - `Tags::MinimumGridSpacing<Dim, Frame::Inertial>>`
+ *   - `Tags::MinimumGridSpacingCompute<Dim, Frame::Inertial>>`
  * - Removes: nothing
  * - Modifies: nothing
  */
@@ -91,7 +91,7 @@ struct InitializeDomain {
             domain::Tags::Coordinates<Dim, Frame::Logical>>,
         domain::Tags::DetInvJacobianCompute<Dim, Frame::Logical,
                                             Frame::Inertial>,
-        domain::Tags::MinimumGridSpacing<Dim, Frame::Inertial>>>;
+        domain::Tags::MinimumGridSpacingCompute<Dim, Frame::Inertial>>>;
 
     const auto& initial_extents =
         db::get<domain::Tags::InitialExtents<Dim>>(box);

--- a/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeInterfaces.hpp
+++ b/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeInterfaces.hpp
@@ -119,7 +119,6 @@ struct InitializeInterfaces {
 
   template <typename Directions>
   using face_tags = tmpl::flatten<tmpl::list<
-      Directions,
       domain::Tags::InterfaceCompute<Directions, domain::Tags::Direction<dim>>,
       domain::Tags::InterfaceCompute<Directions,
                                      domain::Tags::InterfaceMesh<dim>>,
@@ -141,7 +140,7 @@ struct InitializeInterfaces {
                       make_compute_tag<tmpl::_1, tmpl::pin<Directions>>>>>;
 
   using exterior_face_tags = tmpl::flatten<tmpl::list<
-      domain::Tags::BoundaryDirectionsExterior<dim>,
+      domain::Tags::BoundaryDirectionsExteriorCompute<dim>,
       domain::Tags::InterfaceCompute<
           domain::Tags::BoundaryDirectionsExterior<dim>,
           domain::Tags::Direction<dim>>,
@@ -184,10 +183,12 @@ struct InitializeInterfaces {
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/, ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    using compute_tags =
+    using compute_tags = tmpl::push_front<
         tmpl::append<face_tags<domain::Tags::InternalDirections<dim>>,
                      face_tags<domain::Tags::BoundaryDirectionsInterior<dim>>,
-                     exterior_face_tags>;
+                     exterior_face_tags>,
+        domain::Tags::InternalDirectionsCompute<dim>,
+        domain::Tags::BoundaryDirectionsInteriorCompute<dim>>;
 
     if constexpr (AddExteriorVariables) {
       using system = typename Metavariables::system;

--- a/tests/Unit/DataStructures/DataBox/Test_TagTraits.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_TagTraits.cpp
@@ -21,6 +21,23 @@ static_assert(not db::is_compute_tag_v<
                   TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>,
               "Failed testing is_compute_tag");
 
+static_assert(not db::is_simple_tag_v<TestHelpers::db::Tags::Bad>,
+              "Failed testing is_simple_tag");
+static_assert(db::is_simple_tag_v<TestHelpers::db::Tags::Simple>,
+              "Failed testing is_simple_tag");
+static_assert(not db::is_simple_tag_v<TestHelpers::db::Tags::Base>,
+              "Failed testing is_simple_tag");
+static_assert(db::is_simple_tag_v<TestHelpers::db::Tags::SimpleWithBase>,
+              "Failed testing is_simple_tag");
+static_assert(not db::is_simple_tag_v<TestHelpers::db::Tags::SimpleCompute>,
+              "Failed testing is_simple_tag");
+static_assert(
+    not db::is_simple_tag_v<TestHelpers::db::Tags::SimpleWithBaseCompute>,
+    "Failed testing is_simple_tag");
+static_assert(db::is_simple_tag_v<
+                  TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>,
+              "Failed testing is_simple_tag");
+
 static_assert(not db::is_non_base_tag_v<TestHelpers::db::Tags::Bad>,
               "Failed testing is_non_base_tag");
 static_assert(db::is_non_base_tag_v<TestHelpers::db::Tags::Simple>,

--- a/tests/Unit/DataStructures/Tensor/EagerMath/Test_Magnitude.cpp
+++ b/tests/Unit/DataStructures/Tensor/EagerMath/Test_Magnitude.cpp
@@ -256,7 +256,7 @@ void test_root_tags() {
   CHECK(get(db::get<Tags::Sqrt<MyScalar>>(box)) == DataVector{npts, sqrt(3.0)});
 
   using Tag = MyScalar;
-  TestHelpers::db::test_simple_tag<Tags::Sqrt<Tag>>("Sqrt(MyScalar)");
+  TestHelpers::db::test_prefix_tag<Tags::Sqrt<Tag>>("Sqrt(MyScalar)");
   TestHelpers::db::test_compute_tag<Tags::SqrtCompute<Tag>>("Sqrt(MyScalar)");
 }
 }  // namespace

--- a/tests/Unit/Domain/Structure/Test_Element.cpp
+++ b/tests/Unit/Domain/Structure/Test_Element.cpp
@@ -33,7 +33,15 @@ void check_element_work(const typename Element<VolumeDim>::Neighbors_t&
     // The highest spatial dimension has neighbors; else, external boundary.
     CHECK((direction.dimension() == VolumeDim - 1) !=
           (element.external_boundaries().count(direction) == 1));
+    CHECK((direction.dimension() != VolumeDim - 1) !=
+          (element.internal_boundaries().count(direction) == 1));
+    CHECK((direction.dimension() != VolumeDim - 1) !=
+          (element.neighbors().count(direction) == 1));
   }
+  CHECK(element.neighbors().size() == element.internal_boundaries().size());
+  CHECK(element.internal_boundaries().size() +
+            element.external_boundaries().size() ==
+        2 * VolumeDim);
   CHECK(element == element);
   CHECK_FALSE(element != element);
 

--- a/tests/Unit/Domain/Test_FaceNormal.cpp
+++ b/tests/Unit/Domain/Test_FaceNormal.cpp
@@ -151,7 +151,7 @@ void check_time_dependent(
                                                             Frame::Inertial>,
                         ::Tags::Time, Tags::FunctionsOfTime>,
       db::AddComputeTags<
-          Tags::BoundaryDirectionsExterior<Dim>,
+          Tags::BoundaryDirectionsExteriorCompute<Dim>,
           Tags::InterfaceCompute<Directions<Dim>, Tags::Direction<Dim>>,
           Tags::InterfaceCompute<Directions<Dim>, Tags::InterfaceMesh<Dim>>,
           Tags::InterfaceCompute<Tags::BoundaryDirectionsExterior<Dim>,
@@ -360,7 +360,7 @@ void test_compute_item() {
       db::AddSimpleTags<Tags::Element<2>, Directions<2>, Tags::Mesh<2>,
                         Tags::ElementMap<2>>,
       db::AddComputeTags<
-          Tags::BoundaryDirectionsExterior<2>,
+          Tags::BoundaryDirectionsExteriorCompute<2>,
           Tags::InterfaceCompute<Directions<2>, Tags::Direction<2>>,
           Tags::InterfaceCompute<Directions<2>, Tags::InterfaceMesh<2>>,
           Tags::InterfaceCompute<Tags::BoundaryDirectionsExterior<2>,
@@ -416,8 +416,8 @@ void test_compute_item() {
   const auto box_with_non_affine_map = db::create<
       db::AddSimpleTags<Tags::Element<2>, Tags::Mesh<2>, Tags::ElementMap<2>>,
       db::AddComputeTags<
-          Tags::BoundaryDirectionsExterior<2>,
-          Tags::BoundaryDirectionsInterior<2>,
+          Tags::BoundaryDirectionsExteriorCompute<2>,
+          Tags::BoundaryDirectionsInteriorCompute<2>,
           Tags::InterfaceCompute<Tags::BoundaryDirectionsExterior<2>,
                                  Tags::Direction<2>>,
           Tags::InterfaceCompute<Tags::BoundaryDirectionsExterior<2>,

--- a/tests/Unit/Domain/Test_InterfaceHelpers.cpp
+++ b/tests/Unit/Domain/Test_InterfaceHelpers.cpp
@@ -131,22 +131,22 @@ void test_interface_apply(
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.InterfaceHelpers", "[Unit][Domain]") {
-  test_interface_apply<1, Tags::InternalDirections<1>>(
+  test_interface_apply<1, Tags::InternalDirectionsCompute<1>>(
       // Reference element has one internal direction:
       // [ X | ]-> xi
       {{0, {{{1, 0}}}}, {{Direction<1>::upper_xi(), {{{0, {{{1, 1}}}}}, {}}}}},
       {{Direction<1>::upper_xi(), 2.}}, {{Direction<1>::upper_xi(), 5.}});
-  test_interface_apply<1, Tags::InternalDirections<1>>(
+  test_interface_apply<1, Tags::InternalDirectionsCompute<1>>(
       // Reference element has no internal directions:
       // [ X ]-> xi
       {{0, {{{0, 0}}}}, {}}, {}, {});
-  test_interface_apply<1, Tags::BoundaryDirectionsInterior<1>>(
+  test_interface_apply<1, Tags::BoundaryDirectionsInteriorCompute<1>>(
       // Reference element has two boundary directions:
       // [ X ]-> xi
       {{0, {{{0, 0}}}}, {}},
       {{Direction<1>::lower_xi(), 2.}, {Direction<1>::upper_xi(), 3.}},
       {{Direction<1>::lower_xi(), 5.}, {Direction<1>::upper_xi(), 7.}});
-  test_interface_apply<2, Tags::InternalDirections<2>>(
+  test_interface_apply<2, Tags::InternalDirectionsCompute<2>>(
       // Reference element has one internal directions:
       // ^ eta
       // +-+-+

--- a/tests/Unit/Domain/Test_LogicalCoordinates.cpp
+++ b/tests/Unit/Domain/Test_LogicalCoordinates.cpp
@@ -18,6 +18,7 @@
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Tags.hpp"  // IWYU pragma: keep
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 
@@ -77,9 +78,12 @@ SPECTRE_TEST_CASE("Unit.Domain.LogicalCoordinates", "[Domain][Unit]") {
   CHECK(x_3d[2][0] == -32.0);
   CHECK(x_3d[2][15] == 74.0);
 
-  CHECK(Tags::LogicalCoordinates<1>::name() == "LogicalCoordinates");
-  CHECK(Tags::LogicalCoordinates<2>::name() == "LogicalCoordinates");
-  CHECK(Tags::LogicalCoordinates<3>::name() == "LogicalCoordinates");
+  TestHelpers::db::test_compute_tag<Tags::LogicalCoordinates<1>>(
+      "LogicalCoordinates");
+  TestHelpers::db::test_compute_tag<Tags::LogicalCoordinates<2>>(
+      "LogicalCoordinates");
+  TestHelpers::db::test_compute_tag<Tags::LogicalCoordinates<3>>(
+      "LogicalCoordinates");
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.InterfaceLogicalCoordinates", "[Domain][Unit]") {

--- a/tests/Unit/Domain/Test_MinimumGridSpacing.cpp
+++ b/tests/Unit/Domain/Test_MinimumGridSpacing.cpp
@@ -12,6 +12,7 @@
 #include "DataStructures/Matrix.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/MinimumGridSpacing.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 
 // IWYU pragma: no_include "Utilities/Array.hpp"
 
@@ -95,6 +96,12 @@ void check_frame() noexcept {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.MinimumGridSpacing", "[Domain][Unit]") {
+  TestHelpers::db::test_simple_tag<
+      domain::Tags::MinimumGridSpacing<3, Frame::Inertial>>(
+      "MinimumGridSpacing");
+  TestHelpers::db::test_compute_tag<
+      domain::Tags::MinimumGridSpacingCompute<3, Frame::Inertial>>(
+      "MinimumGridSpacing");
   check_frame<Frame::Grid>();
   check_frame<Frame::Inertial>();
 }

--- a/tests/Unit/Domain/Test_SizeOfElement.cpp
+++ b/tests/Unit/Domain/Test_SizeOfElement.cpp
@@ -28,6 +28,7 @@
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Domain/Structure/SegmentId.hpp"
 #include "Domain/Tags.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "Time/Tags.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
@@ -211,6 +212,14 @@ void test_compute_tag(const std::array<double, 4>& times_to_check) noexcept {
                           expected_size_of_element);
   }
 }
+
+template <size_t Dim>
+void test_tags() {
+  TestHelpers::db::test_simple_tag<domain::Tags::SizeOfElement<Dim>>(
+      "SizeOfElement");
+  TestHelpers::db::test_compute_tag<domain::Tags::SizeOfElementCompute<Dim>>(
+      "SizeOfElement");
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.SizeOfElement", "[Domain][Unit]") {
@@ -223,4 +232,8 @@ SPECTRE_TEST_CASE("Unit.Domain.SizeOfElement", "[Domain][Unit]") {
   test_2d_moving_mesh(times_to_check);
   test_3d_moving_mesh(times_to_check);
   test_compute_tag(times_to_check);
+
+  test_tags<1>();
+  test_tags<2>();
+  test_tags<3>();
 }

--- a/tests/Unit/Domain/Test_Tags.cpp
+++ b/tests/Unit/Domain/Test_Tags.cpp
@@ -47,6 +47,13 @@ void test_simple_tags() noexcept {
   TestHelpers::db::test_simple_tag<
       Tags::DetInvJacobian<Frame::Logical, Frame::Inertial>>(
       "DetInvJacobian(Logical,Inertial)");
+  TestHelpers::db::test_simple_tag<Tags::InternalDirections<Dim>>(
+      "InternalDirections");
+  TestHelpers::db::test_simple_tag<Tags::BoundaryDirectionsInterior<Dim>>(
+      "BoundaryDirectionsInterior");
+  TestHelpers::db::test_simple_tag<Tags::BoundaryDirectionsExterior<Dim>>(
+      "BoundaryDirectionsExterior");
+  TestHelpers::db::test_simple_tag<Tags::Direction<Dim>>("Direction");
 }
 
 template <size_t Dim>
@@ -98,6 +105,17 @@ void test_compute_tags() noexcept {
   TestHelpers::db::test_compute_tag<
       Tags::DetInvJacobianCompute<Dim, Frame::Logical, Frame::Inertial>>(
       "DetInvJacobian(Logical,Inertial)");
+  TestHelpers::db::test_compute_tag<Tags::InternalDirectionsCompute<Dim>>(
+      "InternalDirections");
+  TestHelpers::db::test_compute_tag<
+      Tags::BoundaryDirectionsInteriorCompute<Dim>>(
+      "BoundaryDirectionsInterior");
+  TestHelpers::db::test_compute_tag<
+      Tags::BoundaryDirectionsExteriorCompute<Dim>>(
+      "BoundaryDirectionsExterior");
+  TestHelpers::db::test_compute_tag<Tags::MappedCoordinates<
+      Tags::ElementMap<Dim>, Tags::Coordinates<Dim, Frame::Logical>>>(
+      "InertialCoordinates");
 
   auto map = element_map<Dim>();
   const tnsr::I<DataVector, Dim, Frame::Logical> logical_coords(

--- a/tests/Unit/Domain/Test_TagsTimeDependent.cpp
+++ b/tests/Unit/Domain/Test_TagsTimeDependent.cpp
@@ -54,6 +54,9 @@ void test_tags() noexcept {
   TestHelpers::db::test_compute_tag<
       domain::Tags::InertialFromGridCoordinatesCompute<Dim>>(
       "InertialCoordinates");
+  TestHelpers::db::test_compute_tag<
+      domain::Tags::ElementToInertialInverseJacobian<Dim>>(
+      "InverseJacobian(Logical,Inertial)");
   TestHelpers::db::test_simple_tag<domain::Tags::MeshVelocity<Dim>>(
       "MeshVelocity");
   TestHelpers::db::test_compute_tag<

--- a/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBRARY_SOURCES
   InterfaceManagers/Test_GhLockstep.cpp
   Test_AnalyticBoundaryDataManager.cpp
   Test_BoundaryData.cpp
+  Test_BoundaryDataTags.cpp
   Test_Equations.cpp
   Test_GaugeTransformBoundaryData.cpp
   Test_InitializeCce.cpp

--- a/tests/Unit/Evolution/Systems/Cce/Test_BoundaryDataTags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_BoundaryDataTags.cpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Evolution/Systems/Cce/BoundaryDataTags.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.BoundaryDataTags",
+                  "[Unit][Cce]") {
+  TestHelpers::db::test_simple_tag<Cce::Tags::detail::CosPhi>("CosPhi");
+  TestHelpers::db::test_simple_tag<Cce::Tags::detail::CosTheta>("CosTheta");
+  TestHelpers::db::test_simple_tag<Cce::Tags::detail::SinPhi>("SinPhi");
+  TestHelpers::db::test_simple_tag<Cce::Tags::detail::SinTheta>("SinTheta");
+  TestHelpers::db::test_simple_tag<Cce::Tags::detail::CartesianCoordinates>(
+      "CartesianCoordinates");
+  TestHelpers::db::test_simple_tag<
+      Cce::Tags::detail::CartesianToSphericalJacobian>(
+      "CartesianToSphericalJacobian");
+  TestHelpers::db::test_simple_tag<
+      Cce::Tags::detail::InverseCartesianToSphericalJacobian>(
+      "InverseCartesianToSphericalJacobian");
+  TestHelpers::db::test_simple_tag<Cce::Tags::detail::WorldtubeNormal>(
+      "WorldtubeNormal");
+  TestHelpers::db::test_simple_tag<Cce::Tags::detail::UpDyad>("UpDyad");
+  TestHelpers::db::test_simple_tag<Cce::Tags::detail::DownDyad>("DownDyad");
+  TestHelpers::db::test_simple_tag<Cce::Tags::detail::RealBondiR>("RealBondiR");
+  TestHelpers::db::test_simple_tag<Cce::Tags::detail::AngularDNullL>(
+      "AngularDNullL");
+  TestHelpers::db::test_simple_tag<Cce::Tags::detail::NullL>("NullL");
+  TestHelpers::db::test_simple_tag<
+      Cce::Tags::detail::DLambda<Cce::Tags::detail::RealBondiR>>("DLambda");
+}

--- a/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
@@ -29,9 +29,24 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
   TestHelpers::db::test_simple_tag<
       Cce::InitializationTags::ScriInterpolationOrder>(
       "ScriInterpolationOrder");
+  TestHelpers::db::test_simple_tag<Cce::InitializationTags::TargetStepSize>(
+      "TargetStepSize");
+  TestHelpers::db::test_simple_tag<Cce::InitializationTags::ExtractionRadius>(
+      "ExtractionRadius");
   TestHelpers::db::test_simple_tag<Cce::InitializationTags::ScriOutputDensity>(
       "ScriOutputDensity");
-
+  TestHelpers::db::test_simple_tag<Cce::Tags::H5WorldtubeBoundaryDataManager>(
+      "H5WorldtubeBoundaryDataManager");
+  TestHelpers::db::test_simple_tag<Cce::Tags::LMax>("LMax");
+  TestHelpers::db::test_simple_tag<Cce::Tags::NumberOfRadialPoints>(
+      "NumberOfRadialPoints");
+  TestHelpers::db::test_simple_tag<Cce::Tags::ObservationLMax>(
+      "ObservationLMax");
+  TestHelpers::db::test_simple_tag<Cce::Tags::FilterLMax>("FilterLMax");
+  TestHelpers::db::test_simple_tag<Cce::Tags::RadialFilterAlpha>(
+      "RadialFilterAlpha");
+  TestHelpers::db::test_simple_tag<Cce::Tags::RadialFilterHalfPower>(
+      "RadialFilterHalfPower");
   TestHelpers::db::test_simple_tag<Cce::Tags::StartTimeFromFile>(
       "StartTimeFromFile");
   TestHelpers::db::test_simple_tag<Cce::Tags::EndTimeFromFile>(
@@ -41,6 +56,11 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
       "SpecifiedStartTime");
   TestHelpers::db::test_simple_tag<Cce::Tags::SpecifiedEndTime>(
       "SpecifiedEndTime");
+  TestHelpers::db::test_simple_tag<Cce::Tags::GhInterfaceManager>(
+      "GhInterfaceManager");
+  TestHelpers::db::test_simple_tag<
+      Cce::Tags::InterfaceManagerInterpolationStrategy>(
+      "InterfaceManagerInterpolationStrategy");
   TestHelpers::db::test_simple_tag<Cce::Tags::InitializeJ>("InitializeJ");
 
   CHECK(TestHelpers::test_creation<size_t, Cce::OptionTags::LMax>("8") == 8_st);

--- a/tests/Unit/Evolution/Systems/Cce/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_Tags.cpp
@@ -21,6 +21,8 @@ struct SomeTag {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Tags", "[Unit][Cce]") {
+  TestHelpers::db::test_base_tag<Cce::Tags::EndTime>("EndTime");
+  TestHelpers::db::test_base_tag<Cce::Tags::StartTime>("StartTime");
   TestHelpers::db::test_simple_tag<Cce::Tags::BondiBeta>("BondiBeta");
   TestHelpers::db::test_simple_tag<Cce::Tags::BondiH>("H");
   TestHelpers::db::test_simple_tag<Cce::Tags::BondiJ>("J");
@@ -67,7 +69,11 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Tags", "[Unit][Cce]") {
   TestHelpers::db::test_simple_tag<Cce::Tags::Psi3>("Psi3");
   TestHelpers::db::test_simple_tag<Cce::Tags::Psi4>("Psi4");
   TestHelpers::db::test_simple_tag<Cce::Tags::Strain>("Strain");
+  TestHelpers::db::test_simple_tag<
+      Cce::Tags::InterpolationManager<ComplexDataVector, SomeTag>>(
+      "InterpolationManager(SomeTag)");
 
+  TestHelpers::db::test_prefix_tag<::Tags::dt<Cce::Tags::BondiJ>>("H");
   TestHelpers::db::test_prefix_tag<Cce::Tags::Dy<SomeTag>>("Dy(SomeTag)");
   TestHelpers::db::test_prefix_tag<Cce::Tags::Du<SomeTag>>("Du(SomeTag)");
   TestHelpers::db::test_prefix_tag<Cce::Tags::Dr<SomeTag>>("Dr(SomeTag)");

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_InitializeDampedHarmonic.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_InitializeDampedHarmonic.cpp
@@ -25,6 +25,7 @@
 #include "Evolution/Systems/GeneralizedHarmonic/Initialize.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Test_Tags.cpp
@@ -50,6 +50,26 @@ SPECTRE_TEST_CASE("Evolution.Systems.RadiationTransport.M1Grey.Tags",
           Frame::Grid, neutrinos::ElectronNeutrinos<1>>>(
       "Grid_TildeHSpatial_ElectronNeutrinos1");
   TestHelpers::db::test_simple_tag<
+      RadiationTransport::M1Grey::Tags::GreyEmissivity<
+          neutrinos::ElectronNeutrinos<1>>>(
+      "GreyEmissivity_ElectronNeutrinos1");
+  TestHelpers::db::test_simple_tag<
+      RadiationTransport::M1Grey::Tags::GreyAbsorptionOpacity<
+          neutrinos::ElectronNeutrinos<1>>>(
+      "GreyAbsorptionOpacity_ElectronNeutrinos1");
+  TestHelpers::db::test_simple_tag<
+      RadiationTransport::M1Grey::Tags::GreyScatteringOpacity<
+          neutrinos::ElectronNeutrinos<1>>>(
+      "GreyScatteringOpacity_ElectronNeutrinos1");
+  TestHelpers::db::test_simple_tag<
+      RadiationTransport::M1Grey::Tags::M1HydroCouplingNormal<
+          neutrinos::ElectronNeutrinos<1>>>(
+      "M1HydroCouplingNormal_ElectronNeutrinos1");
+  TestHelpers::db::test_simple_tag<
+      RadiationTransport::M1Grey::Tags::M1HydroCouplingSpatial<
+          Frame::Grid, neutrinos::ElectronNeutrinos<1>>>(
+      "Grid_M1HydroCouplingSpatial_ElectronNeutrinos1");
+  TestHelpers::db::test_simple_tag<
       RadiationTransport::M1Grey::Tags::CharacteristicSpeeds>(
       "CharacteristicSpeeds");
   TestHelpers::db::test_compute_tag<

--- a/tests/Unit/Evolution/Test_ComputeTags.cpp
+++ b/tests/Unit/Evolution/Test_ComputeTags.cpp
@@ -99,4 +99,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.ComputeTags.Errors",
       CHECK_ITERABLE_APPROX(diff[i], -1.0 * get<tensor_tag>(analytic)[i] + 5.0);
     }
   });
+
+  TestHelpers::db::test_compute_tag<evolution::Tags::ErrorsCompute<
+      1, AnalyticSolutionTag, tmpl::list<FieldTag>>>(
+      "Variables(Error(FieldTag))");
 }

--- a/tests/Unit/Evolution/VariableFixing/Test_Actions.cpp
+++ b/tests/Unit/Evolution/VariableFixing/Test_Actions.cpp
@@ -12,7 +12,9 @@
 #include "Domain/Tags.hpp"  // IWYU pragma: keep
 #include "Evolution/VariableFixing/Actions.hpp"
 #include "Evolution/VariableFixing/RadiallyFallingFloor.hpp"
+#include "Evolution/VariableFixing/Tags.hpp"
 #include "Framework/ActionTesting.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/Hydro/Tags.hpp"      // IWYU pragma: keep
@@ -48,10 +50,15 @@ struct Metavariables {
   using component_list = tmpl::list<mock_component<Metavariables>>;
   enum class Phase { Initialization, Testing, Exit };
 };
+
+struct SomeType {};
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.VariableFixing.Actions",
                   "[Unit][Evolution][VariableFixing]") {
+  TestHelpers::db::test_simple_tag<Tags::VariableFixer<SomeType>>(
+      "VariableFixer");
+
   using component = mock_component<Metavariables>;
   const DataVector x{-2.0, -1.0, 0.0, 1.0, 2.0};
   const DataVector y{-2.0, -1.0, 0.0, 1.0, 2.0};

--- a/tests/Unit/Framework/Tests/Test_ActionTesting.cpp
+++ b/tests/Unit/Framework/Tests/Test_ActionTesting.cpp
@@ -186,7 +186,7 @@ struct SimpleActionMockMetavariables {
 
 struct MockMetavariablesWithGlobalCacheTags {
   using component_list = tmpl::list<
-      component_for_simple_action_mock<SimpleActionMockMetavariables>>;
+      component_for_simple_action_mock<MockMetavariablesWithGlobalCacheTags>>;
   /// [const global cache metavars]
   using const_global_cache_tags = tmpl::list<ValueTag, PassedToB>;
   /// [const global cache metavars]

--- a/tests/Unit/Helpers/DataStructures/DataBox/TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/DataBox/TestHelpers.hpp
@@ -17,16 +17,16 @@
 
 namespace TestHelpers {
 
-CREATE_HAS_TYPE_ALIAS(base)
-CREATE_HAS_TYPE_ALIAS_V(base)
-CREATE_HAS_TYPE_ALIAS(argument_tags)
-CREATE_HAS_TYPE_ALIAS_V(argument_tags)
-CREATE_HAS_TYPE_ALIAS(return_type)
-CREATE_HAS_TYPE_ALIAS_V(return_type)
-
 namespace db {
 
 namespace detail {
+CREATE_HAS_TYPE_ALIAS(argument_tags)
+CREATE_HAS_TYPE_ALIAS_V(argument_tags)
+CREATE_HAS_TYPE_ALIAS(base)
+CREATE_HAS_TYPE_ALIAS_V(base)
+CREATE_HAS_TYPE_ALIAS(return_type)
+CREATE_HAS_TYPE_ALIAS_V(return_type)
+
 CREATE_IS_CALLABLE(name)
 CREATE_IS_CALLABLE_V(name)
 
@@ -53,9 +53,9 @@ template <typename Tag>
 void test_compute_tag(const std::string& expected_name) {
   static_assert(::db::is_compute_tag_v<Tag>,
                 "A compute tag must be derived from db::ComputeTag");
-  static_assert(has_return_type_v<Tag>);
-  static_assert(has_argument_tags_v<Tag>);
-  static_assert(has_base_v<Tag>);
+  static_assert(detail::has_return_type_v<Tag>);
+  static_assert(detail::has_argument_tags_v<Tag>);
+  static_assert(detail::has_base_v<Tag>);
   static_assert(std::is_same_v<typename Tag::return_type, typename Tag::type>);
   detail::check_tag_name<Tag>(expected_name);
 }

--- a/tests/Unit/Helpers/DataStructures/DataBox/TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/DataBox/TestHelpers.hpp
@@ -26,6 +26,10 @@ CREATE_HAS_TYPE_ALIAS(base)
 CREATE_HAS_TYPE_ALIAS_V(base)
 CREATE_HAS_TYPE_ALIAS(return_type)
 CREATE_HAS_TYPE_ALIAS_V(return_type)
+CREATE_HAS_TYPE_ALIAS(tag)
+CREATE_HAS_TYPE_ALIAS_V(tag)
+CREATE_HAS_TYPE_ALIAS(type)
+CREATE_HAS_TYPE_ALIAS_V(type)
 
 CREATE_IS_CALLABLE(name)
 CREATE_IS_CALLABLE_V(name)
@@ -46,6 +50,10 @@ void test_base_tag(const std::string& expected_name) {
   static_assert(::db::is_base_tag_v<Tag>,
                 "A base tag must be derived from db::BaseTag, but "
                 "not from db::SimpleTag nor db::ComputeTag");
+  static_assert(
+      not detail::has_type_v<Tag>,
+      "The only reason to use a base tag is fetch an item without knowing the "
+      "type.  Since the type is known, make it a simple tag.");
   detail::check_tag_name<Tag>(expected_name);
 }
 
@@ -56,6 +64,8 @@ void test_compute_tag(const std::string& expected_name) {
   static_assert(detail::has_return_type_v<Tag>);
   static_assert(detail::has_argument_tags_v<Tag>);
   static_assert(detail::has_base_v<Tag>);
+  static_assert(::db::is_simple_tag_v<typename Tag::base>,
+                "The base type alias of a compute tag must be a simple tag.");
   static_assert(std::is_same_v<typename Tag::return_type, typename Tag::type>);
   detail::check_tag_name<Tag>(expected_name);
 }
@@ -64,15 +74,23 @@ template <typename Tag>
 void test_prefix_tag(const std::string& expected_name) {
   static_assert(std::is_base_of_v<::db::PrefixTag, Tag>,
                 "A prefix tag must be derived from db::PrefixTag");
+  static_assert(::db::is_simple_tag_v<Tag>,
+                "A prefix tag should also be a simple tag");
+  static_assert(detail::has_type_v<Tag>);
+  static_assert(detail::has_tag_v<Tag>);
   detail::check_tag_name<Tag>(expected_name);
 }
 
 template <typename Tag>
 void test_simple_tag(const std::string& expected_name) {
-  static_assert(std::is_base_of_v<::db::SimpleTag, Tag> and
-                    not std::is_base_of_v<::db::ComputeTag, Tag>,
-                "A simple tag must be derived from "
-                "db::SimpleTag, but not db::ComputeTag");
+  static_assert(::db::is_simple_tag_v<Tag>,
+                "A simple tag must be derived from db::SimpleTag, but not "
+                "db::ComputeTag");
+  static_assert(detail::has_type_v<Tag>);
+  if constexpr (detail::has_base_v<Tag>) {
+    static_assert(::db::is_base_tag_v<Tag::base>,
+                  "The base type alias of a simple tag must be a base tag.");
+  }
   static_assert(not std::is_same_v<Tag, typename Tag::type>,
                 "A type cannot be its own tag.");
   detail::check_tag_name<Tag>(expected_name);

--- a/tests/Unit/Helpers/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/TestHelpers.hpp
+++ b/tests/Unit/Helpers/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/TestHelpers.hpp
@@ -30,27 +30,27 @@ namespace TestHelpers {
 namespace NumericalFluxes {
 
 namespace Tags {
-struct Variable1 : db::SimpleTag {
+struct Variable1 : ::db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 
 template <size_t Dim>
-struct Variable2 : db::SimpleTag {
+struct Variable2 : ::db::SimpleTag {
   using type = tnsr::I<DataVector, Dim>;
 };
 
 template <size_t Dim>
-struct Variable3 : db::SimpleTag {
+struct Variable3 : ::db::SimpleTag {
   using type = tnsr::i<DataVector, Dim>;
 };
 
 template <size_t Dim>
-struct Variable4 : db::SimpleTag {
+struct Variable4 : ::db::SimpleTag {
   using type = tnsr::Ij<DataVector, Dim>;
 };
 
 template <size_t Dim>
-struct CharacteristicSpeeds : db::SimpleTag {
+struct CharacteristicSpeeds : ::db::SimpleTag {
   using type = std::array<DataVector, (Dim + 1) * (Dim + 1)>;
 };
 

--- a/tests/Unit/IO/Importers/Test_Tags.cpp
+++ b/tests/Unit/IO/Importers/Test_Tags.cpp
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "DataStructures/DataBox/TagName.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "IO/Importers/Tags.hpp"
 #include "Options/Options.hpp"
 #include "Options/ParseOptions.hpp"
@@ -18,14 +19,21 @@ struct ExampleVolumeData {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.IO.Importers.Tags", "[Unit][IO]") {
-  CHECK(db::tag_name<importers::Tags::RegisteredElements>() ==
-        "RegisteredElements");
-  CHECK(db::tag_name<importers::Tags::FileName<ExampleVolumeData>>() ==
-        "FileName(ExampleVolumeData)");
-  CHECK(db::tag_name<importers::Tags::Subgroup<ExampleVolumeData>>() ==
-        "Subgroup(ExampleVolumeData)");
-  CHECK(db::tag_name<importers::Tags::ObservationValue<ExampleVolumeData>>() ==
-        "ObservationValue(ExampleVolumeData)");
+  TestHelpers::db::test_simple_tag<importers::Tags::RegisteredElements>(
+      "RegisteredElements");
+  TestHelpers::db::test_simple_tag<
+      importers::Tags::FileName<ExampleVolumeData>>(
+      "FileName(ExampleVolumeData)");
+  TestHelpers::db::test_simple_tag<
+      importers::Tags::Subgroup<ExampleVolumeData>>(
+      "Subgroup(ExampleVolumeData)");
+  TestHelpers::db::test_simple_tag<
+      importers::Tags::ObservationValue<ExampleVolumeData>>(
+      "ObservationValue(ExampleVolumeData)");
+  TestHelpers::db::test_simple_tag<importers::Tags::FunctionOfTimeFile>(
+      "FunctionOfTimeFile");
+  TestHelpers::db::test_simple_tag<importers::Tags::FunctionOfTimeNameMap>(
+      "FunctionOfTimeNameMap");
 
   Options::Parser<
       tmpl::list<importers::OptionTags::FileName<ExampleVolumeData>,

--- a/tests/Unit/IO/Observers/Test_Tags.cpp
+++ b/tests/Unit/IO/Observers/Test_Tags.cpp
@@ -19,8 +19,10 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.Tags", "[Unit][Observers]") {
       "NodesThatContributedReductions");
   TestHelpers::db::test_simple_tag<NodesExpectedToContributeReductions>(
       "NodesExpectedToContributeReductions");
+  TestHelpers::db::test_simple_tag<ReductionDataLock>("ReductionDataLock");
   TestHelpers::db::test_simple_tag<ContributorsOfTensorData>(
       "ContributorsOfTensorData");
+  TestHelpers::db::test_simple_tag<VolumeDataLock>("VolumeDataLock");
   TestHelpers::db::test_simple_tag<TensorData>("TensorData");
   TestHelpers::db::test_simple_tag<ReductionData<double>>("ReductionData");
   TestHelpers::db::test_simple_tag<ReductionDataNames<double>>(
@@ -28,8 +30,6 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.Tags", "[Unit][Observers]") {
   TestHelpers::db::test_simple_tag<H5FileLock>("H5FileLock");
   TestHelpers::db::test_simple_tag<VolumeFileName>("VolumeFileName");
   TestHelpers::db::test_simple_tag<ReductionFileName>("ReductionFileName");
-  TestHelpers::db::test_simple_tag<NodesExpectedToContributeReductions>(
-      "NodesExpectedToContributeReductions");
   static_assert(
       std::is_same_v<typename ReductionData<double, int, char>::names_tag,
                      ReductionDataNames<double, int, char>>,

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
@@ -112,7 +112,7 @@ struct component {
                         interface_tag<Tags::Variables<tmpl::list<Var, Var2>>>,
                         interface_tag<OtherArg>, n_dot_f_tag>;
   using compute_tags = db::AddComputeTags<
-      domain::Tags::InternalDirections<2>,
+      domain::Tags::InternalDirectionsCompute<2>,
       interface_compute_tag<domain::Tags::Direction<2>>,
       interface_compute_tag<domain::Tags::InterfaceMesh<2>>,
       interface_compute_tag<domain::Tags::UnnormalizedFaceNormalCompute<2>>,

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/Test_FirstOrderScheme.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/Test_FirstOrderScheme.cpp
@@ -121,7 +121,7 @@ void test_first_order_scheme() {
                           domain::Tags::Mesh<Dim>, domain::Tags::Element<Dim>,
                           all_normal_dot_fluxes_tag>,
         db::AddComputeTags<
-            domain::Tags::InternalDirections<Dim>,
+            domain::Tags::InternalDirectionsCompute<Dim>,
             domain::Tags::InterfaceCompute<
                 domain::Tags::InternalDirections<Dim>,
                 domain::Tags::Direction<Dim>>,

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/Test_FirstOrderSchemeLts.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/Test_FirstOrderSchemeLts.cpp
@@ -133,7 +133,7 @@ void test_first_order_scheme_lts() {
                           domain::Tags::Element<Dim>, all_normal_dot_fluxes_tag,
                           all_magnitude_of_face_normals_tag>,
         db::AddComputeTags<
-            domain::Tags::InternalDirections<Dim>,
+            domain::Tags::InternalDirectionsCompute<Dim>,
             domain::Tags::InterfaceCompute<
                 domain::Tags::InternalDirections<Dim>,
                 domain::Tags::Direction<Dim>>,

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/Test_Hll.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/Test_Hll.cpp
@@ -13,6 +13,7 @@
 #include "DataStructures/Variables.hpp"  // IWYU pragma: keep
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "Helpers/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/TestHelpers.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/Hll.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Protocols.hpp"
@@ -28,6 +29,10 @@ template <size_t Dim>
 void test_hll_flux_tags() noexcept {
   using system = TestHelpers::NumericalFluxes::System<Dim>;
   using hll_flux = dg::NumericalFluxes::Hll<system>;
+  TestHelpers::db::test_simple_tag<typename hll_flux::LargestIngoingSpeed>(
+      "LargestIngoingSpeed");
+  TestHelpers::db::test_simple_tag<typename hll_flux::LargestOutgoingSpeed>(
+      "LargestOutgoingSpeed");
 
   using expected_type_argument_tags = tmpl::list<
       Tags::NormalDotFlux<TestHelpers::NumericalFluxes::Tags::Variable1>,

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/Test_LocalLaxFriedrichs.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/Test_LocalLaxFriedrichs.cpp
@@ -13,6 +13,7 @@
 #include "DataStructures/Variables.hpp"  // IWYU pragma: keep
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "Helpers/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/TestHelpers.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/LocalLaxFriedrichs.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Protocols.hpp"
@@ -28,6 +29,8 @@ template <size_t Dim>
 void test_llf_flux_tags() noexcept {
   using system = TestHelpers::NumericalFluxes::System<Dim>;
   using llf_flux = dg::NumericalFluxes::LocalLaxFriedrichs<system>;
+  TestHelpers::db::test_simple_tag<typename llf_flux::MaxAbsCharSpeed>(
+      "MaxAbsCharSpeed");
 
   using expected_type_argument_tags = tmpl::list<
       Tags::NormalDotFlux<TestHelpers::NumericalFluxes::Tags::Variable1>,

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_NormalDotFlux.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_NormalDotFlux.cpp
@@ -20,6 +20,7 @@
 #include "Domain/FaceNormal.hpp"
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
@@ -196,6 +197,9 @@ void check_compute_item() {
                         flux_tag<Dim, Frame>>,
       db::AddComputeTags<magnitude_normal_tag, normalized_normal_tag,
                          compute_n_dot_f>>(normal, fluxes);
+  TestHelpers::db::test_compute_tag<compute_n_dot_f>(
+      "Variables(NormalDotFlux(Var1),NormalDotFlux(Var2))");
+
   static_assert(
       std::is_same_v<typename compute_n_dot_f::argument_tags,
                      tmpl::list<flux_tag<Dim, Frame>,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
@@ -17,6 +17,7 @@
 #include "Domain/Creators/Shell.hpp"
 #include "Domain/Domain.hpp"
 #include "Framework/TestCreation.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "Helpers/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp"
 #include "Informer/Tags.hpp"  // IWYU pragma: keep
 #include "Informer/Verbosity.hpp"
@@ -116,6 +117,10 @@ SPECTRE_TEST_CASE(
     return block_logical_coordinates(domain_creator.create_domain(), points);
   }
   ();
+
+  TestHelpers::db::test_simple_tag<intrp::Tags::ApparentHorizon<
+      MockMetavariables::InterpolationTargetA, Frame::Inertial>>(
+      "ApparentHorizon");
 
   InterpTargetTestHelpers::test_interpolation_target<
       MockMetavariables,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
@@ -15,6 +15,7 @@
 #include "Domain/Creators/Shell.hpp"
 #include "Domain/Domain.hpp"
 #include "Framework/TestCreation.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "Helpers/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp"
 #include "NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
@@ -142,6 +143,10 @@ void test_interpolation_target_kerr_horizon(
     }
     return block_logical_coordinates(domain_creator.create_domain(), points);
   }();
+
+  TestHelpers::db::test_simple_tag<
+      intrp::Tags::KerrHorizon<MockMetavariables::InterpolationTargetA>>(
+      "KerrHorizon");
 
   InterpTargetTestHelpers::test_interpolation_target<
       MockMetavariables,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
@@ -14,6 +14,7 @@
 #include "Domain/Creators/Shell.hpp"
 #include "Domain/Domain.hpp"
 #include "Framework/TestCreation.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "Helpers/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp"
 #include "NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
@@ -70,6 +71,10 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.LineSegment",
     return block_logical_coordinates(domain_creator.create_domain(), points);
   }
   ();
+
+  TestHelpers::db::test_simple_tag<
+      intrp::Tags::LineSegment<MockMetavariables::InterpolationTargetA, 3>>(
+      "LineSegment");
 
   InterpTargetTestHelpers::test_interpolation_target<
       MockMetavariables,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
@@ -15,6 +15,7 @@
 #include "Domain/Creators/Shell.hpp"
 #include "Domain/Domain.hpp"
 #include "Framework/TestCreation.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "Helpers/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp"
 #include "NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
@@ -122,6 +123,10 @@ void test_r_theta_uniform() noexcept {
     }
     return block_logical_coordinates(domain_creator.create_domain(), points);
   }();
+
+  TestHelpers::db::test_simple_tag<
+      intrp::Tags::WedgeSectionTorus<MockMetavariables::InterpolationTargetA>>(
+      "WedgeSectionTorus");
 
   InterpTargetTestHelpers::test_interpolation_target<
       MockMetavariables,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
@@ -75,7 +75,7 @@ void test_r_theta_lgl() noexcept {
                                      num_theta)[t]);
         for (size_t p = 0; p < num_phi; ++p) {
           const double phi = 2.0 * M_PI * p / num_phi;
-          const double i = r + t * num_radial + p * num_theta * num_radial;
+          const size_t i = r + t * num_radial + p * num_theta * num_radial;
           get<0>(points)[i] = radius * sin(theta) * cos(phi);
           get<1>(points)[i] = radius * sin(theta) * sin(phi);
           get<2>(points)[i] = radius * cos(theta);
@@ -114,7 +114,7 @@ void test_r_theta_uniform() noexcept {
         const double theta = M_PI * (0.25 + 0.5 * t / (num_theta - 1.0));
         for (size_t p = 0; p < num_phi; ++p) {
           const double phi = 2.0 * M_PI * p / num_phi;
-          const double i = r + t * num_radial + p * num_theta * num_radial;
+          const size_t i = r + t * num_radial + p * num_theta * num_radial;
           get<0>(points)[i] = radius * sin(theta) * cos(phi);
           get<1>(points)[i] = radius * sin(theta) * sin(phi);
           get<2>(points)[i] = radius * cos(theta);

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_Tags.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_Tags.cpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "NumericalAlgorithms/Interpolation/PointInfoTag.hpp"
 #include "NumericalAlgorithms/Interpolation/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -45,4 +46,6 @@ SPECTRE_TEST_CASE("Unit.Interpolation.Tags", "[Unit][NumericalAlgorithms]") {
       "InterpolatedVarsHolders");
   TestHelpers::db::test_simple_tag<intrp::Tags::NumberOfElements>(
       "NumberOfElements");
+  TestHelpers::db::test_simple_tag<intrp::Tags::InterpPointInfo<Metavars>>(
+      "InterpPointInfo");
 }

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTags.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTags.cpp
@@ -119,6 +119,9 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.Tags",
   TestHelpers::db::test_simple_tag<LMax>("LMax");
   TestHelpers::db::test_simple_tag<NumberOfRadialPoints>(
       "NumberOfRadialPoints");
+  TestHelpers::db::test_base_tag<LMaxBase>("LMaxBase");
+  TestHelpers::db::test_base_tag<NumberOfRadialPointsBase>(
+      "NumberOfRadialPointsBase");
 }
 }  // namespace
 }  // namespace Tags

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTags.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTags.cpp
@@ -22,9 +22,7 @@ class ComplexDataVector;
 class ComplexModalVector;
 /// \endcond
 
-namespace Spectral {
-namespace Swsh {
-namespace Tags {
+namespace Spectral::Swsh::Tags {
 namespace {
 
 struct UnweightedTestTag : db::SimpleTag {
@@ -124,6 +122,4 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.Tags",
       "NumberOfRadialPointsBase");
 }
 }  // namespace
-}  // namespace Tags
-}  // namespace Swsh
-}  // namespace Spectral
+}  // namespace Spectral::Swsh::Tags

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_CollectDataForFluxes.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_CollectDataForFluxes.cpp
@@ -94,9 +94,9 @@ struct ElementArray {
                   ::Tags::Next<TemporalIdTag>>>,
               dg::Actions::InitializeDomain<volume_dim>,
               Initialization::Actions::AddComputeTags<tmpl::list<
-                  domain::Tags::InternalDirections<volume_dim>,
-                  domain::Tags::BoundaryDirectionsInterior<volume_dim>,
-                  domain::Tags::BoundaryDirectionsExterior<volume_dim>,
+                  domain::Tags::InternalDirectionsCompute<volume_dim>,
+                  domain::Tags::BoundaryDirectionsInteriorCompute<volume_dim>,
+                  domain::Tags::BoundaryDirectionsExteriorCompute<volume_dim>,
                   domain::Tags::InterfaceCompute<
                       domain::Tags::InternalDirections<volume_dim>,
                       domain::Tags::Direction<volume_dim>>,

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_FluxCommunication.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_FluxCommunication.cpp
@@ -129,8 +129,8 @@ struct ElementArray {
                  domain::Tags::Mesh<Dim>, domain::Tags::Element<Dim>,
                  domain::Tags::ElementMap<Dim>>;
   using compute_tags = tmpl::list<
-      domain::Tags::InternalDirections<Dim>,
-      domain::Tags::BoundaryDirectionsInterior<Dim>,
+      domain::Tags::InternalDirectionsCompute<Dim>,
+      domain::Tags::BoundaryDirectionsInteriorCompute<Dim>,
       domain::Tags::InterfaceCompute<domain::Tags::InternalDirections<Dim>,
                                      domain::Tags::Direction<Dim>>,
       domain::Tags::InterfaceCompute<

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_FluxCommunicationLts.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_FluxCommunicationLts.cpp
@@ -146,8 +146,8 @@ struct lts_component {
                  ::Tags::Next<TemporalIdTag>, domain::Tags::Mesh<Dim>,
                  domain::Tags::Element<Dim>, domain::Tags::ElementMap<Dim>>;
   using compute_tags = tmpl::list<
-      domain::Tags::InternalDirections<Dim>,
-      domain::Tags::BoundaryDirectionsInterior<Dim>,
+      domain::Tags::InternalDirectionsCompute<Dim>,
+      domain::Tags::BoundaryDirectionsInteriorCompute<Dim>,
       domain::Tags::InterfaceCompute<domain::Tags::InternalDirections<Dim>,
                                      domain::Tags::Direction<Dim>>,
       domain::Tags::InterfaceCompute<

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeMortars.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeMortars.cpp
@@ -77,8 +77,8 @@ struct ElementArray {
                                     ::Tags::Next<TemporalIdTag>>>,
                      dg::Actions::InitializeDomain<Dim>,
                      Initialization::Actions::AddComputeTags<tmpl::list<
-                         domain::Tags::InternalDirections<Dim>,
-                         domain::Tags::BoundaryDirectionsInterior<Dim>,
+                         domain::Tags::InternalDirectionsCompute<Dim>,
+                         domain::Tags::BoundaryDirectionsInteriorCompute<Dim>,
                          domain::Tags::InterfaceCompute<
                              domain::Tags::InternalDirections<Dim>,
                              domain::Tags::Direction<Dim>>,

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Test_Tags.cpp
@@ -107,6 +107,9 @@ SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.LinearSolver.Tags",
 
   {
     INFO("HasConvergedByIterationsCompute - not converged");
+    TestHelpers::db::test_compute_tag<
+        LinearSolver::Tags::HasConvergedByIterationsCompute<TestOptionsGroup>>(
+        "HasConverged(TestLinearSolver)");
     const auto box = db::create<
         db::AddSimpleTags<LinearSolver::Tags::Iterations<TestOptionsGroup>,
                           LinearSolver::Tags::IterationId<TestOptionsGroup>>,

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Test_Tags.cpp
@@ -29,4 +29,5 @@ SPECTRE_TEST_CASE("Unit.AnalyticSolutions.Tags", "[Unit][PointwiseFunctions]") {
   TestHelpers::db::test_prefix_tag<Tags::Analytic<DummyTag>>(
       "Analytic(DummyTag)");
   /// [analytic_name]
+  TestHelpers::db::test_prefix_tag<Tags::Error<DummyTag>>("Error(DummyTag)");
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
@@ -106,7 +106,7 @@ struct Component {
       inverse_jacobian,
       Tags::DerivCompute<variables_tag, inverse_jacobian,
                          typename metavariables::system::gradients_tags>,
-      domain::Tags::InternalDirections<1>,
+      domain::Tags::InternalDirectionsCompute<1>,
       domain::Tags::Slice<domain::Tags::InternalDirections<1>,
                           typename metavariables::system::variables_tag>,
       domain::Tags::Slice<domain::Tags::InternalDirections<1>,

--- a/tests/Unit/PointwiseFunctions/Elasticity/Test_PotentialEnergy.cpp
+++ b/tests/Unit/PointwiseFunctions/Elasticity/Test_PotentialEnergy.cpp
@@ -14,6 +14,7 @@
 #include "Elliptic/Systems/Elasticity/Tags.hpp"
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp"
 #include "PointwiseFunctions/Elasticity/ConstitutiveRelations/Tags.hpp"
@@ -54,6 +55,8 @@ void test_compute_tags(const DataVector& used_for_size) noexcept {
   using constitutive_relation_tag = Elasticity::Tags::ConstitutiveRelation<
       Elasticity::ConstitutiveRelations::IsotropicHomogeneous<Dim>>;
   using coordinates_tag = domain::Tags::Coordinates<Dim, Frame::Inertial>;
+  TestHelpers::db::test_compute_tag<energy_compute_tag>(
+      "PotentialEnergyDensity");
   const size_t num_points = used_for_size.size();
   {
     INFO("Energy");

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
@@ -36,6 +36,7 @@
 #include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
 #include "PointwiseFunctions/GeneralRelativity/DerivativesOfSpacetimeMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/ExtrinsicCurvature.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ConstraintGammas.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/DerivSpatialMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ExtrinsicCurvature.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/GaugeSource.hpp"
@@ -732,6 +733,22 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.GhQuantities",
   TestHelpers::db::test_compute_tag<
       GeneralizedHarmonic::Tags::TraceExtrinsicCurvatureCompute<
           3, Frame::Inertial>>("TraceExtrinsicCurvature");
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::Tags::ConstraintGamma0Compute<3, Frame::Inertial>>(
+      "ConstraintGamma0");
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::Tags::ConstraintGamma1Compute<3, Frame::Inertial>>(
+      "ConstraintGamma1");
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::Tags::ConstraintGamma2Compute<3, Frame::Inertial>>(
+      "ConstraintGamma2");
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::Tags::SpacetimeDerivGaugeHCompute<3,
+                                                             Frame::Inertial>>(
+      "SpacetimeDerivGaugeH");
+  TestHelpers::db::test_compute_tag<
+      GeneralizedHarmonic::Tags::GaugeHImplicitFrom3p1QuantitiesCompute<
+          3, Frame::Inertial>>("GaugeH");
 
   // Check that the compute items return the correct values
   MAKE_GENERATOR(generator);

--- a/tests/Unit/Time/StepChoosers/Test_Cfl.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_Cfl.cpp
@@ -61,7 +61,7 @@ double get_suggestion(const size_t stepper_order, const double safety_factor,
       db::AddSimpleTags<
           CharacteristicSpeed, domain::Tags::Coordinates<dim, frame>,
           domain::Tags::Mesh<dim>, Tags::TimeStepper<TimeStepper>>,
-      db::AddComputeTags<domain::Tags::MinimumGridSpacing<dim, frame>>>(
+      db::AddComputeTags<domain::Tags::MinimumGridSpacingCompute<dim, frame>>>(
       characteristic_speed, tnsr::I<DataVector, dim, frame>{{{coordinates}}},
       Mesh<dim>(coordinates.size(), Spectral::Basis::Legendre,
                 Spectral::Quadrature::GaussLobatto),


### PR DESCRIPTION
## Proposed changes

Various changes needed for forthcoming changes to DataBox:

- Refactor Actions::InitializeInterfaces to use `if constexpr`. 
- Add a trait to test if a tag is a simple tag
- Add convenience function to `Element` to obtain the directions to internal boundaries
- Update various compute tags so they inherit from a simple tag and have a function that mutates instead of returning a value
- Remove unnecessary name functions
- Remove unused compute tags in CurvedScalarWave
- Test untested tags
- Add default constructor for `ScriPlusInterpolationManager`


### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
