### PR TITLE
Add subfile name option to GenerateXdmf

### DIFF
--- a/src/Visualization/Python/GenerateXdmf.py
+++ b/src/Visualization/Python/GenerateXdmf.py
@@ -10,8 +10,8 @@ import numpy as np
 import sys
 
 
-def generate_xdmf(file_prefix, output, start_time, stop_time, stride,
-                  coordinates):
+def generate_xdmf(file_prefix, output, subfile_name, start_time, stop_time,
+                  stride, coordinates):
     """
     Generate one XDMF file that ParaView and VisIt can use to load the data
     out of the HDF5 files.
@@ -27,7 +27,7 @@ def generate_xdmf(file_prefix, output, start_time, stop_time, stride,
     assert len(h5files) > 0, "No H5 files with prefix '{}' found.".format(
         file_prefix)
 
-    element_data = h5files[0][0].get('element_data.vol')
+    element_data = h5files[0][0].get(subfile_name + '.vol')
     temporal_ids_and_values = [(x,
                                 element_data.get(x).attrs['observation_value'])
                                for x in element_data.keys()]
@@ -57,7 +57,8 @@ def generate_xdmf(file_prefix, output, start_time, stop_time, stride,
         xdmf_output += "    <Time Value=\"%1.14e\"/>\n" % (id_and_value[1])
         # loop over each h5 file
         for h5file in h5files:
-            h5temporal = h5file[0].get('element_data.vol').get(id_and_value[0])
+            h5temporal = h5file[0].get(subfile_name + '.vol').get(
+                id_and_value[0])
             # Make sure the coordinates are found in the file. We assume there
             # should always be an x-coordinate.
             assert coordinates + '_x' in h5temporal, (
@@ -130,8 +131,8 @@ def generate_xdmf(file_prefix, output, start_time, stop_time, stride,
                                  (numpoints))
 
             # Configure grid location
-            Grid_path = "          %s:/element_data.vol/%s" % (h5file[1],
-                                                               id_and_value[0])
+            Grid_path = ("          {}:/".format(h5file[1]) + subfile_name +
+                         ".vol/{}".format(id_and_value[0]))
             xdmf_output += ("    <Grid Name=\"%s\" GridType=\"Uniform\">\n" %
                             (h5file[1]))
             # Write topology information. In 3d we write a hexahedral topology
@@ -250,6 +251,11 @@ def parse_args():
         '-o',
         required=True,
         help="Output file name, an xmf extension will be added")
+    parser.add_argument(
+        '--subfile-name',
+        '-d',
+        help="Name of the volume data subfile in the H5 files, excluding the "
+        "'.vol' extension")
     parser.add_argument("--stride",
                         default=1,
                         type=int,

--- a/src/Visualization/Python/GenerateXdmf.py
+++ b/src/Visualization/Python/GenerateXdmf.py
@@ -10,7 +10,7 @@ import numpy as np
 import sys
 
 
-def generate_xdmf(file_prefix, output_filename, start_time, stop_time, stride,
+def generate_xdmf(file_prefix, output, start_time, stop_time, stride,
                   coordinates):
     """
     Generate one XDMF file that ParaView and VisIt can use to load the data
@@ -227,7 +227,7 @@ def generate_xdmf(file_prefix, output_filename, start_time, stop_time, stride,
     for h5file in h5files:
         h5file[0].close()
 
-    with open(output_filename + ".xmf", "w") as xmf_file:
+    with open(output + ".xmf", "w") as xmf_file:
         xmf_file.write(xdmf_output)
 
 
@@ -247,6 +247,7 @@ def parse_args():
         help="The common prefix of the H5 volume files to load")
     parser.add_argument(
         '--output',
+        '-o',
         required=True,
         help="Output file name, an xmf extension will be added")
     parser.add_argument("--stride",
@@ -274,6 +275,4 @@ def parse_args():
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     input_args = parse_args()
-    generate_xdmf(input_args.file_prefix, input_args.output,
-                  input_args.start_time, input_args.stop_time,
-                  input_args.stride, input_args.coordinates)
+    generate_xdmf(**vars(input_args))

--- a/tests/Unit/Visualization/Python/Test_GenerateXdmf.py
+++ b/tests/Unit/Visualization/Python/Test_GenerateXdmf.py
@@ -17,7 +17,7 @@ class TestGenerateXdmf(unittest.TestCase):
             os.remove(output_filename + '.xmf')
 
         generate_xdmf(file_prefix=data_file_prefix,
-                      output_filename=output_filename,
+                      output=output_filename,
                       start_time=0.,
                       stop_time=1.,
                       stride=1,

--- a/tests/Unit/Visualization/Python/Test_GenerateXdmf.py
+++ b/tests/Unit/Visualization/Python/Test_GenerateXdmf.py
@@ -18,6 +18,7 @@ class TestGenerateXdmf(unittest.TestCase):
 
         generate_xdmf(file_prefix=data_file_prefix,
                       output=output_filename,
+                      subfile_name="element_data",
                       start_time=0.,
                       stop_time=1.,
                       stride=1,


### PR DESCRIPTION
## Proposed changes

With the recent observer changes (#2436) the volume data subfile in the H5 files can be arbitrarily named, so this PR updates  the `GenerateXdmf` script to support that. 

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
