### PR TITLE
Add "Auto" value in option parsing

### DIFF
--- a/src/Options/Auto.hpp
+++ b/src/Options/Auto.hpp
@@ -1,0 +1,73 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <optional>
+#include <ostream>
+#include <string>
+#include <utility>
+
+#include "Options/Options.hpp"
+#include "Utilities/GetOutput.hpp"
+
+namespace Options {
+/// \ingroup OptionParsingGroup
+/// \brief A class indicating that a parsed value can be automatically
+/// computed instead of specified.
+///
+/// When an `Auto<T>` is parsed from an input file, the value may be
+/// specified either as "Auto" or as a value of type `T`.  When this
+/// class is passed to the constructor of the class taking it as an
+/// option, it can be implicitly converted to a `std::optional<T>`.
+///
+/// \snippet Test_Auto.cpp example_class
+/// \snippet Test_Auto.cpp example_create
+template <typename T>
+class Auto {
+ public:
+  Auto() = default;
+  explicit Auto(T value) noexcept : value_(std::move(value)) {}
+
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  operator std::optional<T>() && { return std::move(value_); }
+
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  operator const std::optional<T>&() const { return value_; }
+
+ private:
+  std::optional<T> value_{};
+};
+
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const Auto<T>& x) noexcept {
+  const std::optional<T>& value = x;
+  if (value) {
+    return os << get_output(*value);
+  } else {
+    return os << "Auto";
+  }
+}
+
+template <typename T>
+struct create_from_yaml<Auto<T>> {
+  template <typename Metavariables>
+  static Auto<T> create(const Option& options) {
+    try {
+      if (options.parse_as<std::string>() == "Auto") {
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 8 && __GNUC__ < 10
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif  // defined(__GNUC__) && !defined(__clang__) && __GNUC__ => 8 && __GNUC__ < 10
+        return {};
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 8 && __GNUC__ < 10
+#pragma GCC diagnostic pop
+#endif  // defined(__GNUC__) && !defined(__clang__) && __GNUC__ => 8 && __GNUC__ < 10
+      }
+    } catch (...) {
+      // The node failed to parse as a string.  It is not "Auto".
+    }
+    return Auto<T>{options.parse_as<T>()};
+  }
+};
+}  // namespace Options

--- a/src/Options/CMakeLists.txt
+++ b/src/Options/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Auto.hpp
   Factory.hpp
   Options.hpp
   OptionsDetails.hpp

--- a/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <limits>
+#include <optional>
 #include <string>
 
 #include "Evolution/Systems/Cce/Initialize/InitializeJ.hpp"
@@ -59,10 +60,18 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
   CHECK(TestHelpers::test_creation<double, Cce::OptionTags::ExtractionRadius>(
             "100.0") == 100.0);
 
-  CHECK(TestHelpers::test_creation<double, Cce::OptionTags::EndTime>("4.0") ==
-        4.0);
-  CHECK(TestHelpers::test_creation<double, Cce::OptionTags::StartTime>("2.0") ==
-        2.0);
+  CHECK(TestHelpers::test_creation<std::optional<double>,
+                                   Cce::OptionTags::EndTime>("4.0") ==
+        std::optional<double>{4.0});
+  CHECK(TestHelpers::test_creation<std::optional<double>,
+                                   Cce::OptionTags::EndTime>("Auto") ==
+        std::optional<double>{});
+  CHECK(TestHelpers::test_creation<std::optional<double>,
+                                   Cce::OptionTags::StartTime>("2.0") ==
+        std::optional<double>{2.0});
+  CHECK(TestHelpers::test_creation<std::optional<double>,
+                                   Cce::OptionTags::StartTime>("Auto") ==
+        std::optional<double>{});
   CHECK(TestHelpers::test_creation<double, Cce::OptionTags::TargetStepSize>(
             "0.5") == 0.5);
   CHECK(TestHelpers::test_creation<std::string,
@@ -106,16 +115,18 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
   CHECK(Cce::Tags::NumberOfRadialPoints::create_from_options(6u) == 6u);
 
   CHECK(Cce::Tags::StartTimeFromFile::create_from_options(
-            -std::numeric_limits<double>::infinity(),
-            "OptionTagsTestCceR0100.h5", false) == 2.5);
+            std::optional<double>{}, "OptionTagsTestCceR0100.h5", false) ==
+        2.5);
   CHECK(Cce::Tags::StartTimeFromFile::create_from_options(
-            3.3, "OptionTagsTestCceR0100.h5", false) == 3.3);
+            std::optional<double>{3.3}, "OptionTagsTestCceR0100.h5", false) ==
+        3.3);
 
   CHECK(Cce::Tags::EndTimeFromFile::create_from_options(
-            std::numeric_limits<double>::infinity(),
-            "OptionTagsTestCceR0100.h5", false) == 5.4);
+            std::optional<double>{}, "OptionTagsTestCceR0100.h5", false) ==
+        5.4);
   CHECK(Cce::Tags::EndTimeFromFile::create_from_options(
-            2.2, "OptionTagsTestCceR0100.h5", false) == 2.2);
+            std::optional<double>{2.2}, "OptionTagsTestCceR0100.h5", false) ==
+        2.2);
 
   CHECK(Cce::Tags::ObservationLMax::create_from_options(5_st) == 5_st);
   CHECK(Cce::InitializationTags::TargetStepSize::create_from_options(0.2) ==

--- a/tests/Unit/Options/CMakeLists.txt
+++ b/tests/Unit/Options/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_Options")
 
 set(LIBRARY_SOURCES
+  Test_Auto.cpp
   Test_CustomTypeConstruction.cpp
   Test_Factory.cpp
   Test_Options.cpp

--- a/tests/Unit/Options/Test_Auto.cpp
+++ b/tests/Unit/Options/Test_Auto.cpp
@@ -1,0 +1,153 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "Framework/TestCreation.hpp"
+#include "Options/Auto.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+template <typename T>
+void test_instance(Options::Auto<T> value,
+                   const std::optional<T> expected) noexcept {
+  CHECK(static_cast<const std::optional<T>&>(value) == expected);
+  CHECK(static_cast<std::optional<T>>(std::move(value)) == expected);
+}
+
+void test_class() noexcept {
+  test_instance(Options::Auto<int>{}, std::optional<int>{});
+  test_instance(Options::Auto<int>{3}, std::optional<int>{3});
+  test_instance(Options::Auto<std::unique_ptr<int>>{},
+                std::optional<std::unique_ptr<int>>{});
+  {
+    Options::Auto<std::unique_ptr<int>> value{std::make_unique<int>(3)};
+    const std::optional<std::unique_ptr<int>>& contained = value;
+    CHECK((contained and *contained and **contained == 3));
+    const std::optional<std::unique_ptr<int>> extracted = std::move(value);
+    CHECK((extracted and *extracted and **extracted == 3));
+  }
+
+  CHECK(get_output(Options::Auto<int>{}) == "Auto");
+  CHECK(get_output(Options::Auto<int>{3}) == "3");
+  CHECK(get_output(Options::Auto<std::vector<int>>{{1, 2}}) ==
+        get_output(std::vector<int>{1, 2}));
+}
+
+struct Derived;
+
+struct Base {
+  Base() = default;
+  Base(const Base&) = default;
+  Base& operator=(Base&&) = default;
+  Base(Base&&) = default;
+  Base& operator=(const Base&) = default;
+  virtual ~Base() = default;
+  using creatable_classes = tmpl::list<Derived>;
+};
+
+struct Derived : Base {
+  using options = tmpl::list<>;
+  static constexpr Options::String help = "halp";
+};
+
+template <typename T>
+void check_create(const std::string& creation_string,
+                  const std::optional<T>& expected) noexcept {
+  CAPTURE(creation_string);
+  CHECK(static_cast<std::optional<T>>(
+            TestHelpers::test_creation<Options::Auto<T>>(creation_string)) ==
+        expected);
+}
+
+void test_parsing() noexcept {
+  check_create<int>("3", 3);
+  check_create<int>("Auto", {});
+
+  check_create<std::string>("Auto", {});
+  check_create<std::string>("Not Auto", "Not Auto");
+
+  check_create<std::unique_ptr<Base>>("Auto", {});
+  {
+    const std::optional<std::unique_ptr<Base>> created =
+        TestHelpers::test_creation<Options::Auto<std::unique_ptr<Base>>>(
+            "Derived");
+    CHECK(created);
+    CHECK(*created);
+  }
+
+  check_create<std::vector<int>>("Auto", {});
+  check_create<std::vector<int>>("", std::vector<int>{});
+  check_create<std::vector<int>>("[1, 2, 3]", std::vector<int>{1, 2, 3});
+}
+
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 8 && __GNUC__ < 11
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif  // defined(__GNUC__) && !defined(__clang__) && __GNUC__ => 8 && __GNUC__ < 11
+/// [example_class]
+class ExampleClass {
+ public:
+  ExampleClass() = default;
+
+  struct AutoArg {
+    using type = Options::Auto<int>;
+    static type default_value() noexcept { return {}; }
+    static constexpr Options::String help =
+        "Integer that can be automatically chosen";
+  };
+
+  static constexpr Options::String help =
+      "A class that can automatically choose an argument";
+  using options = tmpl::list<AutoArg>;
+
+  explicit ExampleClass(std::optional<int> auto_arg) noexcept
+      : value(auto_arg ? *auto_arg : -12) {}
+
+  int value{};
+};
+/// [example_class]
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 8 && __GNUC__ < 11
+#pragma GCC diagnostic pop
+#endif  // defined(__GNUC__) && !defined(__clang__) && __GNUC__ => 8 && __GNUC__ < 11
+
+class NonCopyableArgument {
+ public:
+  NonCopyableArgument() = default;
+
+  struct AutoArg {
+    using type = Options::Auto<std::unique_ptr<Base>>;
+    static constexpr Options::String help = "halp";
+  };
+
+  static constexpr Options::String help = "halp";
+  using options = tmpl::list<AutoArg>;
+
+  explicit NonCopyableArgument(
+      std::optional<std::unique_ptr<Base>> /*auto_arg*/) noexcept {}
+};
+
+void test_use_as_option() noexcept {
+  /// [example_create]
+  CHECK(TestHelpers::test_creation<ExampleClass>("AutoArg: 7").value == 7);
+  CHECK(TestHelpers::test_creation<ExampleClass>("AutoArg: Auto").value == -12);
+  /// [example_create]
+
+  // Make sure this compiles.
+  TestHelpers::test_creation<NonCopyableArgument>("AutoArg: Auto");
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Options.Auto", "[Unit][Options]") {
+  test_class();
+  test_parsing();
+  test_use_as_option();
+}


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
