### PR TITLE
Add thermal noise executable with analytic solution

### DIFF
--- a/src/Elliptic/Executables/Elasticity/CMakeLists.txt
+++ b/src/Elliptic/Executables/Elasticity/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBS_TO_LINK
   DiscontinuousGalerkin
   DomainCreators
   Elasticity
+  ElasticPotentialEnergy
   Informer
   IO
   LinearOperators

--- a/src/Elliptic/Executables/Elasticity/CMakeLists.txt
+++ b/src/Elliptic/Executables/Elasticity/CMakeLists.txt
@@ -39,3 +39,16 @@ target_link_libraries(
   PRIVATE
   ElasticitySolutions
   )
+
+# Elasticity system with half-space mirror solution
+add_elasticity_executable(
+  HalfSpaceMirror
+  "Elasticity::FirstOrderSystem<3>"
+  Elasticity::Solutions::HalfSpaceMirror
+  Elasticity::Solutions::HalfSpaceMirror
+  )
+target_link_libraries(
+  SolveElasticHalfSpaceMirror
+  PRIVATE
+  ElasticitySolutions
+  )

--- a/src/Elliptic/Executables/Elasticity/SolveElasticityProblem.hpp
+++ b/src/Elliptic/Executables/Elasticity/SolveElasticityProblem.hpp
@@ -49,6 +49,7 @@
 #include "ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "PointwiseFunctions/Elasticity/PotentialEnergy.hpp"
 #include "Utilities/Blas.hpp"

--- a/src/Elliptic/Executables/Elasticity/SolveElasticityProblem.hpp
+++ b/src/Elliptic/Executables/Elasticity/SolveElasticityProblem.hpp
@@ -17,6 +17,7 @@
 #include "Elliptic/DiscontinuousGalerkin/NumericalFluxes/FirstOrderInternalPenalty.hpp"
 #include "Elliptic/FirstOrderOperator.hpp"
 #include "Elliptic/Systems/Elasticity/FirstOrderSystem.hpp"
+#include "Elliptic/Systems/Elasticity/Tags.hpp"
 #include "Elliptic/Tags.hpp"
 #include "Elliptic/Triggers/EveryNIterations.hpp"
 #include "ErrorHandling/FloatingPointExceptions.hpp"
@@ -40,13 +41,16 @@
 #include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeMortars.hpp"
 #include "ParallelAlgorithms/Events/ObserveErrorNorms.hpp"
 #include "ParallelAlgorithms/Events/ObserveFields.hpp"
+#include "ParallelAlgorithms/Events/ObserveVolumeIntegrals.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp"
+#include "ParallelAlgorithms/Initialization/Actions/AddComputeTags.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
 #include "ParallelAlgorithms/LinearSolver/Actions/TerminateIfConverged.hpp"
 #include "ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/Elasticity/PotentialEnergy.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/Functional.hpp"
 #include "Utilities/TMPL.hpp"
@@ -127,12 +131,15 @@ struct Metavariables {
   // (public for use by the Charm++ registration code)
   using observe_fields = typename system::fields_tag::tags_list;
   using analytic_solution_fields = observe_fields;
-  using events =
-      tmpl::list<dg::Events::Registrars::ObserveFields<
-                     volume_dim, linear_solver_iteration_id, observe_fields,
-                     analytic_solution_fields>,
-                 dg::Events::Registrars::ObserveErrorNorms<
-                     linear_solver_iteration_id, analytic_solution_fields>>;
+  using events = tmpl::list<
+      dg::Events::Registrars::ObserveFields<
+          volume_dim, linear_solver_iteration_id, observe_fields,
+          analytic_solution_fields>,
+      dg::Events::Registrars::ObserveErrorNorms<linear_solver_iteration_id,
+                                                analytic_solution_fields>,
+      dg::Events::Registrars::ObserveVolumeIntegrals<
+          volume_dim, linear_solver_iteration_id,
+          tmpl::list<Elasticity::Tags::PotentialEnergyDensity<volume_dim>>>>;
   using triggers = tmpl::list<elliptic::Triggers::Registrars::EveryNIterations<
       linear_solver_iteration_id>>;
 
@@ -160,6 +167,8 @@ struct Metavariables {
           dg::Initialization::exterior_compute_tags<>, false, false>,
       typename linear_solver::initialize_element,
       elliptic::Actions::InitializeSystem,
+      Initialization::Actions::AddComputeTags<tmpl::list<
+          Elasticity::Tags::PotentialEnergyDensityCompute<volume_dim>>>,
       elliptic::Actions::InitializeAnalyticSolution<analytic_solution_tag,
                                                     analytic_solution_fields>,
       elliptic::dg::Actions::ImposeInhomogeneousBoundaryConditionsOnSource<

--- a/src/Elliptic/Executables/Elasticity/SolveElasticityProblemFwd.hpp
+++ b/src/Elliptic/Executables/Elasticity/SolveElasticityProblemFwd.hpp
@@ -11,6 +11,7 @@ template <size_t Dim>
 struct FirstOrderSystem;
 namespace Solutions {
 struct BentBeam;
+struct HalfSpaceMirror;
 }  // namespace Solutions
 }  // namespace Elasticity
 

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -1,0 +1,55 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: SolveElasticHalfSpaceMirror
+# Check: parse;execute
+# ExpectedOutput:
+#   ElasticHalfSpaceMirrorReductions.h5
+#   ElasticHalfSpaceMirrorVolume0.h5
+
+AnalyticSolution:
+  HalfSpaceMirror:
+    BeamWidth: 0.177
+    Material:
+      # Fused Silica
+      BulkModulus: 36.36363636363637
+      ShearModulus: 30.76923076923077
+
+DomainCreator:
+  Cylinder:
+    InnerRadius: 0.08
+    OuterRadius: 0.6
+    LowerBound: 0
+    UpperBound: 0.3
+    IsPeriodicInZ: False
+    InitialRefinement: 0
+    InitialGridPoints: [3, 3, 4]
+    UseEquiangularMap: True
+
+NumericalFlux:
+  InternalPenalty:
+    PenaltyParameter: 1
+
+Observers:
+  VolumeFileName: "ElasticHalfSpaceMirrorVolume"
+  ReductionFileName: "ElasticHalfSpaceMirrorReductions"
+
+LinearSolver:
+  GMRES:
+    ConvergenceCriteria:
+      MaxIterations: 1
+      RelativeResidual: 1e-8
+      AbsoluteResidual: 1e-12
+    Verbosity: Verbose
+
+EventsAndTriggers:
+  ? EveryNIterations:
+      N: 1
+  : - ObserveErrorNorms:
+        SubfileName: ErrorNorms
+    - ObserveVolumeIntegrals:
+        SubfileName: VolumeIntegrals
+  ? EveryNIterations:
+      N: 10
+  : - ObserveFields:
+        SubfileName: VolumeData


### PR DESCRIPTION
## Proposed changes

Adds the first thermal noise executable, which solves a linear elasticity system for the `HalfSpaceMirror` analytic solution.

To try running the solve, set the `LinearSolver.GMRES.ConvergenceCriteria.MaxIterations` option in the input file to ~1000 and note that this solve is unpreconditioned and thus extremely inefficient. On my branch that adds the Multigrid-Schwarz preconditioner to the executable ([this one](https://github.com/nilsleiffischer/spectre/commits/elasticity_multigrid)), the solve needs only 5 iterations.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
