### PR TITLE
Simplify Interface tags

### DIFF
--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -323,38 +323,14 @@ struct BoundaryDirectionsExteriorCompute
 /// Interface is desired, then it should be added using `Slice`. In all cases,
 /// the tag can then be retrieved using `Tags::Interface<DirectionsTag, Tag>`.
 ///
-/// If using the base tag mechanism for an interface tag is desired,
-/// then `Tag` can have a `base` type alias pointing to its base
-/// class.  (This requirement is due to the lack of a way to determine
-/// a type's base classes in C++.)
-///
-/// It must be possible to determine the type associated with `Tag`
-/// without reference to a DataBox.
-///
 /// \tparam DirectionsTag the item of directions
 /// \tparam Tag the tag labeling the item
 ///
 /// \see InterfaceCompute, Slice
 template <typename DirectionsTag, typename Tag>
-struct Interface;
-
-namespace Interface_detail {
-template <typename DirectionsTag, typename Tag, typename = std::void_t<>>
-struct GetBaseTagIfPresent {};
-
-template <typename DirectionsTag, typename Tag>
-struct GetBaseTagIfPresent<DirectionsTag, Tag, std::void_t<typename Tag::base>>
-    : Interface<DirectionsTag, typename Tag::base> {
-  static_assert(std::is_base_of_v<typename Tag::base, Tag>,
-                "Tag `base` alias must be a base class of `Tag`.");
-};
-}  // namespace Interface_detail
-
-// Virtual inheritance is used here to prevent a compiler warning: Derived class
-// SimpleTag is inaccessible
-template <typename DirectionsTag, typename Tag>
-struct Interface : virtual db::SimpleTag,
-                   Interface_detail::GetBaseTagIfPresent<DirectionsTag, Tag> {
+struct Interface : db::SimpleTag {
+  static_assert(db::is_simple_tag_v<DirectionsTag>);
+  static_assert(db::is_simple_tag_v<Tag>);
   static std::string name() noexcept {
     return "Interface<" + db::tag_name<DirectionsTag>() + ", " +
            db::tag_name<Tag>() + ">";

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -304,14 +304,14 @@ struct EvolutionMetavars {
           dg::Initialization::slice_tags_to_face<
               typename system::variables_tag,
               gr::Tags::SpatialMetric<volume_dim, frame, DataVector>,
-              gr::Tags::DetAndInverseSpatialMetricCompute<volume_dim, frame,
-                                                          DataVector>,
+              typename gr::Tags::DetAndInverseSpatialMetricCompute<
+                  volume_dim, frame, DataVector>::base,
               gr::Tags::Shift<volume_dim, frame, DataVector>,
               gr::Tags::Lapse<DataVector>>,
           dg::Initialization::slice_tags_to_exterior<
               gr::Tags::SpatialMetric<volume_dim, frame, DataVector>,
-              gr::Tags::DetAndInverseSpatialMetricCompute<volume_dim, frame,
-                                                          DataVector>,
+              typename gr::Tags::DetAndInverseSpatialMetricCompute<
+                  volume_dim, frame, DataVector>::base,
               gr::Tags::Shift<volume_dim, frame, DataVector>,
               gr::Tags::Lapse<DataVector>>,
           dg::Initialization::face_compute_tags<

--- a/tests/Unit/Domain/Test_InterfaceHelpers.cpp
+++ b/tests/Unit/Domain/Test_InterfaceHelpers.cpp
@@ -56,16 +56,16 @@ struct ComputeWithVoidReturnType {
 template <size_t Dim, typename DirectionsTag>
 void test_interface_apply(
     const Element<Dim>& element,
+    const std::unordered_set<Direction<Dim>>& directions,
     const std::unordered_map<Direction<Dim>, double>& number_on_interfaces,
     const std::unordered_map<Direction<Dim>, double>&
         expected_result_on_interfaces) {
   // Construct DataBox that holds the test data
   const auto box =
-      db::create<db::AddSimpleTags<Tags::Element<Dim>,
+      db::create<db::AddSimpleTags<Tags::Element<Dim>, DirectionsTag,
                                    Tags::Interface<DirectionsTag, SomeNumber>,
-                                   SomeVolumeArgument>,
-                 db::AddComputeTags<DirectionsTag>>(element,
-                                                    number_on_interfaces, 1.);
+                                   SomeVolumeArgument>>(
+          element, directions, number_on_interfaces, 1.);
   // Test applying a function to the interface and give an example
   /// [interface_apply_example]
   const auto computed_number_on_interfaces =
@@ -131,22 +131,24 @@ void test_interface_apply(
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.InterfaceHelpers", "[Unit][Domain]") {
-  test_interface_apply<1, Tags::InternalDirectionsCompute<1>>(
+  test_interface_apply<1, Tags::InternalDirections<1>>(
       // Reference element has one internal direction:
       // [ X | ]-> xi
       {{0, {{{1, 0}}}}, {{Direction<1>::upper_xi(), {{{0, {{{1, 1}}}}}, {}}}}},
-      {{Direction<1>::upper_xi(), 2.}}, {{Direction<1>::upper_xi(), 5.}});
-  test_interface_apply<1, Tags::InternalDirectionsCompute<1>>(
+      {Direction<1>::upper_xi()}, {{Direction<1>::upper_xi(), 2.}},
+      {{Direction<1>::upper_xi(), 5.}});
+  test_interface_apply<1, Tags::InternalDirections<1>>(
       // Reference element has no internal directions:
       // [ X ]-> xi
-      {{0, {{{0, 0}}}}, {}}, {}, {});
-  test_interface_apply<1, Tags::BoundaryDirectionsInteriorCompute<1>>(
+      {{0, {{{0, 0}}}}, {}}, {}, {}, {});
+  test_interface_apply<1, Tags::BoundaryDirectionsInterior<1>>(
       // Reference element has two boundary directions:
       // [ X ]-> xi
       {{0, {{{0, 0}}}}, {}},
+      {Direction<1>::lower_xi(), Direction<1>::upper_xi()},
       {{Direction<1>::lower_xi(), 2.}, {Direction<1>::upper_xi(), 3.}},
       {{Direction<1>::lower_xi(), 5.}, {Direction<1>::upper_xi(), 7.}});
-  test_interface_apply<2, Tags::InternalDirectionsCompute<2>>(
+  test_interface_apply<2, Tags::InternalDirections<2>>(
       // Reference element has one internal directions:
       // ^ eta
       // +-+-+
@@ -154,7 +156,8 @@ SPECTRE_TEST_CASE("Unit.Domain.InterfaceHelpers", "[Unit][Domain]") {
       // +-+-+> xi
       {{0, {{{1, 0}, {0, 0}}}},
        {{Direction<2>::upper_xi(), {{{0, {{{1, 1}, {0, 0}}}}}, {}}}}},
-      {{Direction<2>::upper_xi(), 2.}}, {{Direction<2>::upper_xi(), 5.}});
+      {Direction<2>::upper_xi()}, {{Direction<2>::upper_xi(), 2.}},
+      {{Direction<2>::upper_xi(), 5.}});
 }
 }  // namespace
 }  // namespace domain


### PR DESCRIPTION
## Proposed changes

Several simplifications for interface tags that are either enabled by or required for the forthcoming implementation of DataBox (which is the next PR I plan to open).

- `Tags::Interface<DirectionsTag, Tag>` is now just derived from `db::SimpleTag`.
-  For `Tags::Interface`, the template parameters`DirectionsTag` and `Tag` must be simple tags, as if they were compute tags they would bypass the dependency graph of a `DataBox`.
- With the recent changes to compute tags so that they are all mutating, the implementation
of `InterfaceCompute` has been simplified.  
- The `DirectionsTag` template parameter of `Slice` and `InterfaceCompute` are restricted to be simple tags (this is independent of how the`DirectionsTag` is inserted into the `DataBox`, it can still be inserted as a compute tag).
- Tried to clarify some documentation.

There are two things that were used in `Test_InterfaceItems` that are no longer allowed with these changes:
- It was possible to derive one `db::SimpleTag`  from another `db::SimpleTag` (e.g. `SimpleDerived` is derived
from `SimpleBase`) and fetch the `Interface<DirectionsTag, DerivedTag>` using `Interface<DirectionsTag, BaseTag>`.  We do not have any current simple tags deriving from another simple tag and have been actively telling everyone not to do it. (Instead use a `db::BaseTag`).
- Similarly it was possible to fetch `InterfaceCompute<DirectionsTag, ComputeTag>` using `Interface<DirectionsTag, ComputeTag>` or `Interface<DirectionsTag, SimpleTag>` (where `ComputeTag` is derived from `SimpleTag`).  Now only the latter is possible.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
