### PR TITLE
Fix singleton registration with observers on multiple nodes

### DIFF
--- a/src/IO/Observer/Actions/RegisterSingleton.hpp
+++ b/src/IO/Observer/Actions/RegisterSingleton.hpp
@@ -14,6 +14,7 @@
 #include "IO/Observer/ObserverComponent.hpp"
 #include "IO/Observer/TypeOfObservation.hpp"
 #include "Parallel/GlobalCache.hpp"
+#include "Parallel/Info.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -52,17 +53,12 @@ struct RegisterSingletonWithObserverWriter {
             "'Reduction' for singleton.");
     };
 
-    // The actual value of the processing element doesn't matter
-    // here; it is used only to give an ObserverWriter a count of how many
-    // times it will be called.
-    constexpr size_t fake_processing_element = 0;
-
     // We call only on node 0; the observation call will occur only
     // on node 0.
     Parallel::simple_action<Actions::RegisterReductionNodeWithWritingNode>(
         Parallel::get_parallel_component<
             observers::ObserverWriter<Metavariables>>(cache)[0],
-        observation_key, fake_processing_element);
+        observation_key, static_cast<size_t>(Parallel::my_node()));
     return {std::move(box), true};
   }
 };


### PR DESCRIPTION
## Proposed changes

When running on multiple nodes I encountered this issue with the singleton registration. We always write reductions on node 0, but the singleton can be on any node, so either it registers with the node it is on or we always pass 0 to `WriteReductionData` instead of its actual node.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
