### PR TITLE
Small improvements to AH treatment.

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -222,7 +222,7 @@ struct EvolutionMetavars {
     using compute_target_points =
         intrp::TargetPoints::ApparentHorizon<AhA, ::Frame::Inertial>;
     using post_interpolation_callback =
-        intrp::callbacks::FindApparentHorizon<AhA>;
+        intrp::callbacks::FindApparentHorizon<AhA, ::Frame::Inertial>;
     using post_horizon_find_callback =
         intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, AhA, AhA>;
   };

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.cpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.cpp
@@ -13,8 +13,7 @@ struct Inertial;
 }  // namespace Frame
 /// \endcond
 
-namespace intrp {
-namespace OptionHolders {
+namespace intrp::OptionHolders {
 template <typename Frame>
 ApparentHorizon<Frame>::ApparentHorizon(Strahlkorper<Frame> initial_guess_in,
                                         ::FastFlow fast_flow_in,
@@ -59,5 +58,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (::Frame::Inertial))
 #undef FRAME
 #undef INSTANTIATE
 /// \endcond
-}  // namespace OptionHolders
-}  // namespace intrp
+}  // namespace intrp::OptionHolders

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.cpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.cpp
@@ -5,6 +5,8 @@
 
 #include <algorithm>
 
+#include "Utilities/GenerateInstantiations.hpp"
+
 /// \cond
 namespace Frame {
 struct Inertial;
@@ -42,14 +44,20 @@ bool operator!=(const ApparentHorizon<Frame>& lhs,
   return not(lhs == rhs);
 }
 
-// So far instantiate for only one frame. But once we
-// have control systems working, we will need this for at
-// least two frames.
-template struct ApparentHorizon<Frame::Inertial>;
-template bool operator==(const ApparentHorizon<Frame::Inertial>& lhs,
-                         const ApparentHorizon<Frame::Inertial>& rhs) noexcept;
-template bool operator!=(const ApparentHorizon<Frame::Inertial>& lhs,
-                         const ApparentHorizon<Frame::Inertial>& rhs) noexcept;
+// Explicit instantiations
+/// \cond
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
 
+#define INSTANTIATE(_, data)                                                  \
+  template struct ApparentHorizon<FRAME(data)>;                               \
+  template bool operator==(const ApparentHorizon<FRAME(data)>& lhs,           \
+                           const ApparentHorizon<FRAME(data)>& rhs) noexcept; \
+  template bool operator!=(const ApparentHorizon<FRAME(data)>& lhs,           \
+                           const ApparentHorizon<FRAME(data)>& rhs) noexcept;
+GENERATE_INSTANTIATIONS(INSTANTIATE, (::Frame::Inertial))
+
+#undef FRAME
+#undef INSTANTIATE
+/// \endcond
 }  // namespace OptionHolders
 }  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
@@ -196,10 +196,6 @@ struct ApparentHorizon {
         make_not_null(&prolonged_coords), prolonged_strahlkorper, radius,
         r_hat);
 
-    // In the future, when we add support for multiple Frames,
-    // the code that transforms coordinates from the Strahlkorper Frame
-    // to Frame::Inertial will go here.  That transformation
-    // may depend on `temporal_id`.
     return prolonged_coords;
   }
 };

--- a/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
@@ -204,7 +204,7 @@ struct MockMetavariables {
     using compute_target_points =
         intrp::TargetPoints::ApparentHorizon<AhA, ::Frame::Inertial>;
     using post_interpolation_callback =
-        intrp::callbacks::FindApparentHorizon<AhA>;
+        intrp::callbacks::FindApparentHorizon<AhA, ::Frame::Inertial>;
     using post_horizon_find_callback = PostHorizonFindCallback;
   };
   using interpolator_source_vars =


### PR DESCRIPTION
## Proposed changes

This is a small PR that generalizes the instantiations of InterpolationTargetApparentHorizon, and templates FindApparentHorizon on Frame.  This is working toward finding AHs in multiple frames.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
