### PR TITLE
Remove most default options from limiters

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Krivodonova.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Krivodonova.hpp
@@ -444,10 +444,6 @@ class Krivodonova<VolumeDim, tmpl::list<Tags...>> {
         double, Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>;
     static constexpr Options::String help = {
         "The alpha parameters of the Krivodonova limiter"};
-    static type default_value() noexcept {
-      return make_array<
-          Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>(1.0);
-    }
   };
   /*!
    * \brief Turn the limiter off
@@ -557,7 +553,8 @@ class Krivodonova<VolumeDim, tmpl::list<Tags...>> {
   std::array<double,
              Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>
       alphas_ = make_array<
-          Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>(1.0);
+          Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>(
+          std::numeric_limits<double>::signaling_NaN());
   bool disable_for_debugging_{false};
 };
 

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp
@@ -132,6 +132,14 @@ bool minmod_limited_slopes(
 /// between the mean solution values across neighboring cells, but may not
 /// control oscillations within the cells.
 ///
+/// The choice of the TVB constant \f$m\f$ is difficult. Larger values result in
+/// fewer limiter activations, especially near smooth extrema in the solution
+/// --- this can help to avoid incorrectly limiting away these smooth extrema,
+/// but can also result in insufficient limiting of truly spurious oscillations.
+/// The reference uses a value of 50 when presenting the limiter with simple
+/// shock tests, but in general the value \f$m\f$ that optimizes between
+/// robustness and minimal loss of accuracy is problem dependent.
+///
 /// The limiter acts in the `Frame::Logical` coordinates, because in these
 /// coordinates it is straightforward to formulate the algorithm. This means the
 /// limiter can operate on generic deformed grids. However, if the grid is too
@@ -169,10 +177,10 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
   };
   /// \brief The TVB constant
   ///
-  /// See `Limiters::Minmod` documentation for details.
+  /// See `Limiters::Minmod` documentation for details. The optimal value of
+  /// this parameter is unfortunately problem-dependent.
   struct TvbConstant {
     using type = double;
-    static type default_value() noexcept { return 0.0; }
     static type lower_bound() noexcept { return 0.0; }
     static constexpr Options::String help = {"TVB constant 'm'"};
   };
@@ -197,10 +205,9 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
   /// \brief Constuct a Minmod slope limiter
   ///
   /// \param minmod_type The type of Minmod slope limiter.
-  /// \param tvb_constant The value of the TVB constant (default: 0).
-  /// \param disable_for_debugging Switch to turn the limiter off (default:
-  //         false).
-  explicit Minmod(MinmodType minmod_type, double tvb_constant = 0.0,
+  /// \param tvb_constant The value of the TVB constant.
+  /// \param disable_for_debugging Switch to turn the limiter off.
+  explicit Minmod(MinmodType minmod_type, double tvb_constant,
                   bool disable_for_debugging = false) noexcept;
 
   Minmod() noexcept = default;

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
@@ -109,12 +109,12 @@ class Weno<VolumeDim, tmpl::list<Tags...>> {
   /// \brief The linear weight given to each neighbor
   ///
   /// This linear weight gets combined with the oscillation indicator to
-  /// compute the weight for each WENO estimated solution. Larger values are
-  /// better suited for problems with strong shocks, and smaller values are
-  /// better suited to smooth problems.
+  /// compute the weight for each WENO estimated solution. The standard value
+  /// in the literature is 0.001; larger values may be better suited for
+  /// problems with strong shocks, and smaller values may be better suited to
+  /// smooth problems.
   struct NeighborWeight {
     using type = double;
-    static type default_value() noexcept { return 0.001; }
     static type lower_bound() noexcept { return 1e-6; }
     static type upper_bound() noexcept { return 0.1; }
     static constexpr Options::String help = {

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Weno.hpp
@@ -125,7 +125,6 @@ class Weno<VolumeDim, tmpl::list<Tags...>> {
   /// See `Limiters::Minmod` documentation for details.
   struct TvbConstant {
     using type = double;
-    static type default_value() noexcept { return 0.0; }
     static type lower_bound() noexcept { return 0.0; }
     static constexpr Options::String help = {"TVB constant 'm'"};
   };
@@ -143,8 +142,8 @@ class Weno<VolumeDim, tmpl::list<Tags...>> {
       tmpl::list<Type, NeighborWeight, TvbConstant, DisableForDebugging>;
   static constexpr Options::String help = {"A WENO limiter for DG"};
 
-  Weno(WenoType weno_type, double neighbor_linear_weight,
-       double tvb_constant = 0.0, bool disable_for_debugging = false) noexcept;
+  Weno(WenoType weno_type, double neighbor_linear_weight, double tvb_constant,
+       bool disable_for_debugging = false) noexcept;
 
   Weno() noexcept = default;
   Weno(const Weno& /*rhs*/) = default;

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -31,6 +31,9 @@ NumericalFlux:
 Limiter:
   Minmod:
     Type: LambdaPi1
+    # The optimal value of the TVB constant is problem-dependent.
+    # This test uses 0 to favor robustness over accuracy.
+    TvbConstant: 0.0
 
 EventsAndTriggers:
   ? Always

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/CylindricalBlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/CylindricalBlastWave.yaml
@@ -38,7 +38,9 @@ EvolutionSystem:
 Limiter:
   Minmod:
     Type: Muscl
-    TvbConstant: 0
+    # The optimal value of the TVB constant is problem-dependent.
+    # This test uses 0 to favor robustness over accuracy.
+    TvbConstant: 0.0
 
 VariableFixing:
   FixConservatives:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -50,8 +50,9 @@ Limiter:
     # Uncomment line below to turn off the limiter:
     # DisableForDebugging: True
     Type: LambdaPiN
-    # Recommended value from minmod papers:
-    TvbConstant: 50.0
+    # The optimal value of the TVB constant is problem-dependent.
+    # This test uses 0 to favor robustness over accuracy.
+    TvbConstant: 0.0
 
 VariableFixing:
   FixConservatives:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -47,8 +47,6 @@ EvolutionSystem:
 
 Limiter:
   Minmod:
-    # Uncomment line below to turn off the limiter:
-    # DisableForDebugging: True
     Type: LambdaPiN
     # The optimal value of the TVB constant is problem-dependent.
     # This test uses 0 to favor robustness over accuracy.

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
@@ -34,8 +34,6 @@ NumericalFlux:
 
 Limiter:
   Minmod:
-    # Uncomment line below to turn off the limiter:
-    # DisableForDebugging: True
     Type: LambdaPiN
     # The optimal value of the TVB constant is problem-dependent.
     # This test uses 0 to favor robustness over accuracy.

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
@@ -37,8 +37,9 @@ Limiter:
     # Uncomment line below to turn off the limiter:
     # DisableForDebugging: True
     Type: LambdaPiN
-    # Recommended value from minmod papers:
-    TvbConstant: 50.0
+    # The optimal value of the TVB constant is problem-dependent.
+    # This test uses 0 to favor robustness over accuracy.
+    TvbConstant: 0.0
 
 EventsAndTriggers:
   # ? EveryNSlabs:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
@@ -34,8 +34,6 @@ NumericalFlux:
 
 Limiter:
   Minmod:
-    # Uncomment line below to turn off the limiter:
-    # DisableForDebugging: True
     Type: LambdaPiN
     # The optimal value of the TVB constant is problem-dependent.
     # This test uses 0 to favor robustness over accuracy.

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
@@ -37,8 +37,9 @@ Limiter:
     # Uncomment line below to turn off the limiter:
     # DisableForDebugging: True
     Type: LambdaPiN
-    # Recommended value from minmod papers:
-    TvbConstant: 50.0
+    # The optimal value of the TVB constant is problem-dependent.
+    # This test uses 0 to favor robustness over accuracy.
+    TvbConstant: 0.0
 
 EventsAndTriggers:
   # ? EveryNSlabs:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
@@ -34,8 +34,6 @@ NumericalFlux:
 
 Limiter:
   Minmod:
-    # Uncomment line below to turn off the limiter:
-    # DisableForDebugging: True
     Type: LambdaPiN
     # The optimal value of the TVB constant is problem-dependent.
     # This test uses 0 to favor robustness over accuracy.

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
@@ -37,8 +37,9 @@ Limiter:
     # Uncomment line below to turn off the limiter:
     # DisableForDebugging: True
     Type: LambdaPiN
-    # Recommended value from minmod papers:
-    TvbConstant: 50.0
+    # The optimal value of the TVB constant is problem-dependent.
+    # This test uses 0 to favor robustness over accuracy.
+    TvbConstant: 0.0
 
 EventsAndTriggers:
   # ? EveryNSlabs:

--- a/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
+++ b/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
@@ -31,8 +31,6 @@ NumericalFlux:
 
 Limiter:
   Minmod:
-    # Uncomment line below to turn off the limiter:
-    # DisableForDebugging: True
     Type: LambdaPiN
     # The optimal value of the TVB constant is problem-dependent.
     # This test uses 0 to favor robustness over accuracy.

--- a/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
+++ b/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
@@ -34,8 +34,9 @@ Limiter:
     # Uncomment line below to turn off the limiter:
     # DisableForDebugging: True
     Type: LambdaPiN
-    # Recommended value from minmod papers:
-    TvbConstant: 50.0
+    # The optimal value of the TVB constant is problem-dependent.
+    # This test uses 0 to favor robustness over accuracy.
+    TvbConstant: 0.0
 
 EventsAndTriggers:
   ? EveryNSlabs:

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow1D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow1D.yaml
@@ -31,8 +31,6 @@ NumericalFlux:
 
 Limiter:
   Minmod:
-    # Uncomment line below to turn off the limiter:
-    # DisableForDebugging: True
     Type: LambdaPiN
     # The optimal value of the TVB constant is problem-dependent.
     # This test uses 100 to favor accuracy in the smooth flow.

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow1D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow1D.yaml
@@ -34,8 +34,9 @@ Limiter:
     # Uncomment line below to turn off the limiter:
     # DisableForDebugging: True
     Type: LambdaPiN
-    # Recommended value from minmod papers:
-    TvbConstant: 50.0
+    # The optimal value of the TVB constant is problem-dependent.
+    # This test uses 100 to favor accuracy in the smooth flow.
+    TvbConstant: 100.0
 
 VariableFixing:
   FixConservatives:

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow2D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow2D.yaml
@@ -31,8 +31,6 @@ NumericalFlux:
 
 Limiter:
   Minmod:
-    # Uncomment line below to turn off the limiter:
-    # DisableForDebugging: True
     Type: LambdaPiN
     # The optimal value of the TVB constant is problem-dependent.
     # This test uses 100 to favor accuracy in the smooth flow.

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow2D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow2D.yaml
@@ -34,7 +34,8 @@ Limiter:
     # Uncomment line below to turn off the limiter:
     # DisableForDebugging: True
     Type: LambdaPiN
-    # Recommended value from minmod papers:
+    # The optimal value of the TVB constant is problem-dependent.
+    # This test uses 100 to favor accuracy in the smooth flow.
     TvbConstant: 100.0
 
 VariableFixing:

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow3D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow3D.yaml
@@ -31,8 +31,6 @@ NumericalFlux:
 
 Limiter:
   Minmod:
-    # Uncomment line below to turn off the limiter:
-    # DisableForDebugging: True
     Type: LambdaPiN
     # The optimal value of the TVB constant is problem-dependent.
     # This test uses 100 to favor accuracy in the smooth flow.

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow3D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow3D.yaml
@@ -34,7 +34,8 @@ Limiter:
     # Uncomment line below to turn off the limiter:
     # DisableForDebugging: True
     Type: LambdaPiN
-    # Recommended value from minmod papers:
+    # The optimal value of the TVB constant is problem-dependent.
+    # This test uses 100 to favor accuracy in the smooth flow.
     TvbConstant: 100.0
 
 VariableFixing:

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Krivodonova.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Krivodonova.cpp
@@ -117,8 +117,8 @@ void test_limiting_two_neighbors() noexcept {
   const size_t num_pts = mesh.number_of_grid_points();
 
   using Limiter = Krivodonova<dim, tmpl::list<ScalarTag<0>, VectorTag<dim, 0>>>;
-  // Use non-unity (because that's the default) but close alpha values to make
-  // the math easier but still test thoroughly.
+  // Use non-unity but close alpha values to make the math easier but still
+  // test thoroughly.
   Limiter krivodonova{
       make_array<Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>(
           0.99)};
@@ -255,8 +255,8 @@ void test_limiting_different_values_different_tensors() noexcept {
                        Spectral::Quadrature::GaussLobatto);
   const size_t num_pts = mesh.number_of_grid_points();
   using Limiter = Krivodonova<dim, tmpl::list<ScalarTag<0>, VectorTag<dim, 0>>>;
-  // Use non-unity (because that's the default) but close alpha values to make
-  // the math easier but still test thoroughly.
+  // Use non-unity but close alpha values to make the math easier but still
+  // test thoroughly.
   Limiter krivodonova{
       make_array<Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>(
           0.99)};
@@ -812,8 +812,8 @@ void test_limiting_different_values_different_tensors() noexcept {
                        Spectral::Quadrature::GaussLobatto);
   const size_t num_pts = mesh.number_of_grid_points();
   using Limiter = Krivodonova<dim, tmpl::list<ScalarTag<0>, VectorTag<dim, 0>>>;
-  // Use non-unity (because that's the default) but close alpha values to make
-  // the math easier but still test thoroughly.
+  // Use non-unity but close alpha values to make the math easier but still
+  // test thoroughly.
   Limiter krivodonova{
       make_array<Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>(
           0.99)};
@@ -916,8 +916,8 @@ void run() noexcept {
                        Spectral::Quadrature::GaussLobatto);
   const size_t num_pts = mesh.number_of_grid_points();
   using Limiter = Krivodonova<dim, tmpl::list<ScalarTag<0>>>;
-  // Use non-unity (because that's the default) but close alpha values to make
-  // the math easier but still test thoroughly.
+  // Use non-unity but close alpha values to make the math easier but still
+  // test thoroughly.
   Limiter krivodonova{
       make_array<Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>(
           0.99)};
@@ -2542,8 +2542,8 @@ void test_limiting_different_values_different_tensors() noexcept {
   const size_t num_pts = mesh.number_of_grid_points();
   const auto x = logical_coordinates(mesh);
   using Limiter = Krivodonova<dim, tmpl::list<ScalarTag<0>, VectorTag<dim, 0>>>;
-  // Use non-unity (because that's the default) but close alpha values to make
-  // the math easier but still test thoroughly.
+  // Use non-unity but close alpha values to make the math easier but still
+  // test thoroughly.
   Limiter krivodonova{
       make_array<Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>(
           0.99)};
@@ -2773,8 +2773,8 @@ void run() noexcept {
                        Spectral::Quadrature::GaussLobatto);
   const size_t num_pts = mesh.number_of_grid_points();
   using Limiter = Krivodonova<dim, tmpl::list<ScalarTag<0>, VectorTag<dim, 0>>>;
-  // Use non-unity (because that's the default) but close alpha values to make
-  // the math easier but still test thoroughly.
+  // Use non-unity but close alpha values to make the math easier but still
+  // test thoroughly.
   Limiter krivodonova{
       make_array<Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>(
           0.99)};

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActionsWithMinmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActionsWithMinmod.cpp
@@ -148,8 +148,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.LimiterActions.Minmod",
 
   auto var = Scalar<DataVector>(mesh.number_of_grid_points(), 1234.);
 
+  const double tvb_constant = 0.0;
   ActionTesting::MockRuntimeSystem<metavariables> runner{
-      Limiters::Minmod<2, tmpl::list<Var>>(Limiters::MinmodType::LambdaPi1)};
+      Limiters::Minmod<2, tmpl::list<Var>>(Limiters::MinmodType::LambdaPi1,
+                                           tvb_constant)};
   ActionTesting::emplace_component_and_initialize<my_component>(
       &runner, self_id,
       {0, mesh, element, std::move(logical_to_grid_map),

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Weno.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Weno.cpp
@@ -67,10 +67,6 @@ void test_weno_option_parsing() noexcept {
   const auto hweno_1d =
       TestHelpers::test_creation<Limiters::Weno<1, tmpl::list<ScalarTag>>>(
           "Type: Hweno\n"
-          "TvbConstant: 0.0");
-  const auto hweno_1d_default_weight =
-      TestHelpers::test_creation<Limiters::Weno<1, tmpl::list<ScalarTag>>>(
-          "Type: Hweno\n"
           "NeighborWeight: 0.001\n"
           "TvbConstant: 0.0");
   const auto hweno_1d_larger_weight =
@@ -81,19 +77,22 @@ void test_weno_option_parsing() noexcept {
   const auto hweno_1d_tvb =
       TestHelpers::test_creation<Limiters::Weno<1, tmpl::list<ScalarTag>>>(
           "Type: Hweno\n"
+          "NeighborWeight: 0.001\n"
           "TvbConstant: 1.0");
   const auto hweno_1d_disabled =
       TestHelpers::test_creation<Limiters::Weno<1, tmpl::list<ScalarTag>>>(
           "Type: Hweno\n"
+          "NeighborWeight: 0.001\n"
           "TvbConstant: 0.0\n"
           "DisableForDebugging: True");
   const auto simple_weno_1d =
       TestHelpers::test_creation<Limiters::Weno<1, tmpl::list<ScalarTag>>>(
           "Type: SimpleWeno\n"
+          "NeighborWeight: 0.001\n"
           "TvbConstant: 0.0");
 
   // Check operators == and !=
-  CHECK(hweno_1d == hweno_1d_default_weight);
+  CHECK(hweno_1d == hweno_1d);
   CHECK(hweno_1d != hweno_1d_larger_weight);
   CHECK(hweno_1d != hweno_1d_tvb);
   CHECK(hweno_1d != hweno_1d_disabled);
@@ -102,6 +101,7 @@ void test_weno_option_parsing() noexcept {
   const auto hweno_2d =
       TestHelpers::test_creation<Limiters::Weno<2, tmpl::list<ScalarTag>>>(
           "Type: Hweno\n"
+          "NeighborWeight: 0.001\n"
           "TvbConstant: 0.0");
   const auto hweno_3d_larger_weight = TestHelpers::test_creation<
       Limiters::Weno<3, tmpl::list<ScalarTag, VectorTag<3>>>>(


### PR DESCRIPTION
## Proposed changes

Most limiter options don't have a clear "best" value. This PR removes defaults for these options.

Also cleans up one of the Minmod tests (creation from options) to be more thorough.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

