### PR TITLE
Docs fix: // \cond -> /// \cond in ParseOptions

### DIFF
--- a/src/Options/ParseOptions.hpp
+++ b/src/Options/ParseOptions.hpp
@@ -419,7 +419,7 @@ struct apply_helper<tmpl::list<Tags...>> {
 };
 }  // namespace Options_detail
 
-// \cond
+/// \cond
 // Doxygen is confused by decltype(auto)
 template <typename OptionList, typename Group>
 template <typename TagList, typename Metavariables, typename F>
@@ -427,7 +427,7 @@ decltype(auto) Parser<OptionList, Group>::apply(F&& func) const {
   return Options_detail::apply_helper<TagList>::template apply<Metavariables>(
       *this, std::forward<F>(func));
 }
-// \endcond
+/// \endcond
 
 template <typename OptionList, typename Group>
 std::string Parser<OptionList, Group>::help() const noexcept {


### PR DESCRIPTION
## Proposed changes

Really quick PR that fixes a mistake I found, where someone used // \cond instead of /// \cond

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
