### PR TITLE
Add aliases for temp tensors Ijj, ijk, and ijaa

### DIFF
--- a/src/DataStructures/Tags/TempTensor.hpp
+++ b/src/DataStructures/Tags/TempTensor.hpp
@@ -97,6 +97,12 @@ template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
 using Tempijj = TempTensor<N, tnsr::ijj<DataType, SpatialDim, Fr>>;
 template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
           typename DataType = DataVector>
+using TempIjj = TempTensor<N, tnsr::Ijj<DataType, SpatialDim, Fr>>;
+template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
+          typename DataType = DataVector>
+using Tempijk = TempTensor<N, tnsr::ijk<DataType, SpatialDim, Fr>>;
+template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
+          typename DataType = DataVector>
 using Tempiaa = TempTensor<N, tnsr::iaa<DataType, SpatialDim, Fr>>;
 template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
           typename DataType = DataVector>
@@ -110,5 +116,10 @@ using Tempabb = TempTensor<N, tnsr::abb<DataType, SpatialDim, Fr>>;
 template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
           typename DataType = DataVector>
 using TempabC = TempTensor<N, tnsr::abC<DataType, SpatialDim, Fr>>;
+
+// Rank 4
+template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
+          typename DataType = DataVector>
+using Tempijaa = TempTensor<N, tnsr::ijaa<DataType, SpatialDim, Fr>>;
 // @}
 }  // namespace Tags


### PR DESCRIPTION
## Proposed changes

Add aliases for temporary tensors `TempIjj`, `Tempijk`, and `Tempijaa` . While useful in general, these are specifically needed in #1558 and #2529 

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
