### PR TITLE
Simplify input arguments for the two-index and F-constraints

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/Constraints.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Constraints.hpp
@@ -123,7 +123,7 @@ void gauge_constraint(
  */
 template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::ia<DataType, SpatialDim, Frame> two_index_constraint(
-    const tnsr::ia<DataType, SpatialDim, Frame>& d_gauge_function,
+    const tnsr::ab<DataType, SpatialDim, Frame>& spacetime_d_gauge_function,
     const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
     const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
     const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
@@ -139,7 +139,7 @@ tnsr::ia<DataType, SpatialDim, Frame> two_index_constraint(
 template <size_t SpatialDim, typename Frame, typename DataType>
 void two_index_constraint(
     gsl::not_null<tnsr::ia<DataType, SpatialDim, Frame>*> constraint,
-    const tnsr::ia<DataType, SpatialDim, Frame>& d_gauge_function,
+    const tnsr::ab<DataType, SpatialDim, Frame>& spacetime_d_gauge_function,
     const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
     const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
     const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
@@ -246,7 +246,7 @@ void four_index_constraint(
 template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::a<DataType, SpatialDim, Frame> f_constraint(
     const tnsr::a<DataType, SpatialDim, Frame>& gauge_function,
-    const tnsr::ia<DataType, SpatialDim, Frame>& d_gauge_function,
+    const tnsr::ab<DataType, SpatialDim, Frame>& spacetime_d_gauge_function,
     const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
     const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
     const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
@@ -263,7 +263,7 @@ template <size_t SpatialDim, typename Frame, typename DataType>
 void f_constraint(
     gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
     const tnsr::a<DataType, SpatialDim, Frame>& gauge_function,
-    const tnsr::ia<DataType, SpatialDim, Frame>& d_gauge_function,
+    const tnsr::ab<DataType, SpatialDim, Frame>& spacetime_d_gauge_function,
     const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
     const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
     const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
@@ -539,8 +539,7 @@ struct GaugeConstraintCompute : GaugeConstraint<SpatialDim, Frame>,
 template <size_t SpatialDim, typename Frame>
 struct FConstraintCompute : FConstraint<SpatialDim, Frame>, db::ComputeTag {
   using argument_tags = tmpl::list<
-      GaugeH<SpatialDim, Frame>,
-      ::Tags::deriv<GaugeH<SpatialDim, Frame>, tmpl::size_t<SpatialDim>, Frame>,
+      GaugeH<SpatialDim, Frame>, SpacetimeDerivGaugeH<SpatialDim, Frame>,
       gr::Tags::SpacetimeNormalOneForm<SpatialDim, Frame, DataVector>,
       gr::Tags::SpacetimeNormalVector<SpatialDim, Frame, DataVector>,
       gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataVector>,
@@ -556,7 +555,7 @@ struct FConstraintCompute : FConstraint<SpatialDim, Frame>, db::ComputeTag {
   static constexpr auto function = static_cast<void (*)(
       gsl::not_null<tnsr::a<DataVector, SpatialDim, Frame>*>,
       const tnsr::a<DataVector, SpatialDim, Frame>&,
-      const tnsr::ia<DataVector, SpatialDim, Frame>&,
+      const tnsr::ab<DataVector, SpatialDim, Frame>&,
       const tnsr::a<DataVector, SpatialDim, Frame>&,
       const tnsr::A<DataVector, SpatialDim, Frame>&,
       const tnsr::II<DataVector, SpatialDim, Frame>&,
@@ -583,7 +582,7 @@ template <size_t SpatialDim, typename Frame>
 struct TwoIndexConstraintCompute : TwoIndexConstraint<SpatialDim, Frame>,
                                    db::ComputeTag {
   using argument_tags = tmpl::list<
-      ::Tags::deriv<GaugeH<SpatialDim, Frame>, tmpl::size_t<SpatialDim>, Frame>,
+      SpacetimeDerivGaugeH<SpatialDim, Frame>,
       gr::Tags::SpacetimeNormalOneForm<SpatialDim, Frame, DataVector>,
       gr::Tags::SpacetimeNormalVector<SpatialDim, Frame, DataVector>,
       gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataVector>,
@@ -598,7 +597,7 @@ struct TwoIndexConstraintCompute : TwoIndexConstraint<SpatialDim, Frame>,
 
   static constexpr auto function = static_cast<void (*)(
       gsl::not_null<tnsr::ia<DataVector, SpatialDim, Frame>*>,
-      const tnsr::ia<DataVector, SpatialDim, Frame>&,
+      const tnsr::ab<DataVector, SpatialDim, Frame>&,
       const tnsr::a<DataVector, SpatialDim, Frame>&,
       const tnsr::A<DataVector, SpatialDim, Frame>&,
       const tnsr::II<DataVector, SpatialDim, Frame>&,

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/TestFunctions.py
@@ -58,7 +58,7 @@ def two_index_constraint_term_4_of_11(spacetime_normal_one_form,
 
 
 def two_index_constraint_term_5_of_11(d_gauge_function):
-    return d_gauge_function
+    return d_gauge_function[1:, :]
 
 
 def two_index_constraint_term_6_of_11(spacetime_normal_vector,
@@ -287,7 +287,7 @@ def f_constraint_term_4_of_25(spacetime_normal_one_form,
 
 def f_constraint_term_5_of_25(spacetime_normal_one_form,
                               inverse_spatial_metric, d_gauge_function):
-    d_gauge_function_ij = d_gauge_function[:, 1:]
+    d_gauge_function_ij = d_gauge_function[1:, 1:]
     return np.einsum("a,ij,ij", spacetime_normal_one_form,
                      inverse_spatial_metric, d_gauge_function_ij)
 
@@ -324,14 +324,12 @@ def f_constraint_term_7_of_25(spacetime_normal_one_form,
 
 def f_constraint_term_8_of_25(spacetime_normal_one_form,
                               spacetime_normal_vector, d_gauge_function):
-    d_gauge_function_ab = np.pad(d_gauge_function, ((1, 0), (0, 0)),
-                                 'constant')
+    d_gauge_function[0, :] = 0
     spacetime_normal_vector_I = spacetime_normal_vector[1:]
-    term = -1.0 * np.einsum("b,ab", spacetime_normal_vector,
-                            d_gauge_function_ab)
+    term = -1.0 * np.einsum("b,ab", spacetime_normal_vector, d_gauge_function)
     return term - np.einsum("a,i,b,ib", spacetime_normal_one_form,
                             spacetime_normal_vector_I, spacetime_normal_vector,
-                            d_gauge_function)
+                            d_gauge_function[1:, :])
 
 
 def f_constraint_term_9_of_25(inverse_spatial_metric, phi,

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
@@ -1293,6 +1293,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.FConstraint",
       std::numeric_limits<double>::signaling_NaN());
 }
 
+// This is the most expensive test as it requires the computation of
+// all constraints. It randomly times out with clang-8.
+// [[TimeOut, 11]
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.ConstraintEnergy",
                   "[Unit][Evolution]") {
   pypp::SetupLocalPythonEnvironment local_python_env{

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
@@ -172,7 +172,7 @@ template <size_t SpatialDim, typename Frame, typename DataType>
 void test_two_index_constraint_random(const DataType& used_for_size) noexcept {
   pypp::check_with_random_values<1>(
       static_cast<tnsr::ia<DataType, SpatialDim, Frame> (*)(
-          const tnsr::ia<DataType, SpatialDim, Frame>&,
+          const tnsr::ab<DataType, SpatialDim, Frame>&,
           const tnsr::a<DataType, SpatialDim, Frame>&,
           const tnsr::A<DataType, SpatialDim, Frame>&,
           const tnsr::II<DataType, SpatialDim, Frame>&,
@@ -287,6 +287,21 @@ void test_two_index_constraint_analytic(
   const auto& d_gauge_function =
       get<Tags::deriv<GaugeH, tmpl::size_t<3>, Frame::Inertial>>(gh_derivs);
 
+  // Populate spacetime derivative of gauge function
+  const auto d4_gauge_function = [&x, &d_gauge_function]() {
+    auto tmp =
+        make_with_value<tnsr::ab<DataVector, 3, Frame::Inertial>>(x, 0.0);
+    for (size_t a = 0; a < 4; ++a) {
+      for (size_t i = 0; i < 3; ++i) {
+        tmp.get(i + 1, a) = d_gauge_function.get(i, a);
+      }
+      // Populate the time derivative with NaN as a check that those are not
+      // being used in calculating constraints
+      tmp.get(0, a) = std::numeric_limits<double>::signaling_NaN();
+    }
+    return tmp;
+  }();
+
   // Compute the three-index constraint
   const auto three_index_constraint =
       GeneralizedHarmonic::three_index_constraint(d_spacetime_metric, phi);
@@ -296,7 +311,7 @@ void test_two_index_constraint_analytic(
       make_with_value<tnsr::ia<DataVector, 3, Frame::Inertial>>(
           x, std::numeric_limits<double>::signaling_NaN());
   GeneralizedHarmonic::two_index_constraint(
-      make_not_null(&two_index_constraint), d_gauge_function, normal_one_form,
+      make_not_null(&two_index_constraint), d4_gauge_function, normal_one_form,
       normal_vector, inverse_spatial_metric, inverse_spacetime_metric, pi, phi,
       d_pi, d_phi, gamma2, three_index_constraint);
 
@@ -399,7 +414,7 @@ void test_f_constraint_random(const DataType& used_for_size) noexcept {
   pypp::check_with_random_values<1>(
       static_cast<tnsr::a<DataType, SpatialDim, Frame> (*)(
           const tnsr::a<DataType, SpatialDim, Frame>&,
-          const tnsr::ia<DataType, SpatialDim, Frame>&,
+          const tnsr::ab<DataType, SpatialDim, Frame>&,
           const tnsr::a<DataType, SpatialDim, Frame>&,
           const tnsr::A<DataType, SpatialDim, Frame>&,
           const tnsr::II<DataType, SpatialDim, Frame>&,
@@ -513,6 +528,21 @@ void test_f_constraint_analytic(const Solution& solution,
   const auto& d_gauge_function =
       get<Tags::deriv<GaugeH, tmpl::size_t<3>, Frame::Inertial>>(gh_derivs);
 
+  // Populate spacetime derivative of gauge function
+  const auto d4_gauge_function = [&x, &d_gauge_function]() {
+    auto tmp =
+        make_with_value<tnsr::ab<DataVector, 3, Frame::Inertial>>(x, 0.0);
+    for (size_t a = 0; a < 4; ++a) {
+      for (size_t i = 0; i < 3; ++i) {
+        tmp.get(i + 1, a) = d_gauge_function.get(i, a);
+      }
+      // Populate the time derivative with NaN as a check that those are not
+      // being used in calculating constraints
+      tmp.get(0, a) = std::numeric_limits<double>::signaling_NaN();
+    }
+    return tmp;
+  }();
+
   // Compute the three-index constraint
   const auto three_index_constraint =
       GeneralizedHarmonic::three_index_constraint(d_spacetime_metric, phi);
@@ -521,7 +551,7 @@ void test_f_constraint_analytic(const Solution& solution,
   auto f_constraint = make_with_value<tnsr::a<DataVector, 3, Frame::Inertial>>(
       x, std::numeric_limits<double>::signaling_NaN());
   GeneralizedHarmonic::f_constraint(
-      make_not_null(&f_constraint), gauge_function, d_gauge_function,
+      make_not_null(&f_constraint), gauge_function, d4_gauge_function,
       normal_one_form, normal_vector, inverse_spatial_metric,
       inverse_spacetime_metric, pi, phi, d_pi, d_phi, gamma2,
       three_index_constraint);
@@ -648,6 +678,21 @@ void test_constraint_energy_analytic(const Solution& solution,
   const auto& d_gauge_function =
       get<Tags::deriv<GaugeH, tmpl::size_t<3>, Frame::Inertial>>(gh_derivs);
 
+  // Populate spacetime derivative of gauge function
+  const auto d4_gauge_function = [&x, &d_gauge_function]() {
+    auto tmp =
+        make_with_value<tnsr::ab<DataVector, 3, Frame::Inertial>>(x, 0.0);
+    for (size_t a = 0; a < 4; ++a) {
+      for (size_t i = 0; i < 3; ++i) {
+        tmp.get(i + 1, a) = d_gauge_function.get(i, a);
+      }
+      // Populate the time derivative with NaN as a check that those are not
+      // being used in calculating constraints
+      tmp.get(0, a) = std::numeric_limits<double>::signaling_NaN();
+    }
+    return tmp;
+  }();
+
   // Arbitrary choice for gamma2
   const auto gamma2 = make_with_value<Scalar<DataVector>>(x, 4.0);
 
@@ -660,11 +705,11 @@ void test_constraint_energy_analytic(const Solution& solution,
   const auto four_index_constraint =
       GeneralizedHarmonic::four_index_constraint(d_phi);
   const auto two_index_constraint = GeneralizedHarmonic::two_index_constraint(
-      d_gauge_function, normal_one_form, normal_vector, inverse_spatial_metric,
+      d4_gauge_function, normal_one_form, normal_vector, inverse_spatial_metric,
       inverse_spacetime_metric, pi, phi, d_pi, d_phi, gamma2,
       three_index_constraint);
   const auto f_constraint = GeneralizedHarmonic::f_constraint(
-      gauge_function, d_gauge_function, normal_one_form, normal_vector,
+      gauge_function, d4_gauge_function, normal_one_form, normal_vector,
       inverse_spatial_metric, inverse_spacetime_metric, pi, phi, d_pi, d_phi,
       gamma2, three_index_constraint);
 
@@ -837,11 +882,10 @@ void test_constraint_compute_items(
   get<2>(time_deriv_gauge_source) = 0.07;
   get<3>(time_deriv_gauge_source) = -0.05;
 
-  tnsr::ab<DataVector, 3, Frame::Inertial> derivatives_of_gauge_source{};
-  GeneralizedHarmonic::Tags::SpacetimeDerivGaugeHCompute<
-      3, Frame::Inertial>::function(make_not_null(&derivatives_of_gauge_source),
-                                    time_deriv_gauge_source,
-                                    deriv_gauge_source);
+  tnsr::ab<DataVector, 3, Frame::Inertial> spacetime_deriv_gauge_source{};
+  GeneralizedHarmonic::Tags::SpacetimeDerivGaugeHCompute<3, Frame::Inertial>::
+      function(make_not_null(&spacetime_deriv_gauge_source),
+               time_deriv_gauge_source, deriv_gauge_source);
 
   // Make DampingFunctions for the constraint damping parameters
   // Note: these parameters are taken from SpEC single-black-hole simulations
@@ -989,14 +1033,14 @@ void test_constraint_compute_items(
   const auto three_index_constraint =
       GeneralizedHarmonic::three_index_constraint(deriv_spacetime_metric, phi);
   const auto two_index_constraint = GeneralizedHarmonic::two_index_constraint(
-      deriv_gauge_source, spacetime_normal_one_form, spacetime_normal_vector,
-      inverse_spatial_metric, inverse_spacetime_metric, pi, phi, deriv_pi,
-      deriv_phi, gamma2, three_index_constraint);
+      spacetime_deriv_gauge_source, spacetime_normal_one_form,
+      spacetime_normal_vector, inverse_spatial_metric, inverse_spacetime_metric,
+      pi, phi, deriv_pi, deriv_phi, gamma2, three_index_constraint);
   const auto gauge_constraint = GeneralizedHarmonic::gauge_constraint(
       gauge_source, spacetime_normal_one_form, spacetime_normal_vector,
       inverse_spatial_metric, inverse_spacetime_metric, pi, phi);
   const auto f_constraint = GeneralizedHarmonic::f_constraint(
-      gauge_source, deriv_gauge_source, spacetime_normal_one_form,
+      gauge_source, spacetime_deriv_gauge_source, spacetime_normal_one_form,
       spacetime_normal_vector, inverse_spatial_metric, inverse_spacetime_metric,
       pi, phi, deriv_pi, deriv_phi, gamma2, three_index_constraint);
   const auto constraint_energy = GeneralizedHarmonic::constraint_energy(
@@ -1016,7 +1060,7 @@ void test_constraint_compute_items(
   CHECK(
       db::get<
           GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<3, Frame::Inertial>>(
-          box) == derivatives_of_gauge_source);
+          box) == spacetime_deriv_gauge_source);
   CHECK(db::get<
             GeneralizedHarmonic::Tags::FourIndexConstraint<3, Frame::Inertial>>(
             box) == four_index_constraint);


### PR DESCRIPTION
## Proposed changes

The `TwoIndexConstraint` and the `FConstraint` require the spatial derivative of the gauge source function H. As the spacetime derivative of H is almost always added to the evolution databox anyway, it is simpler for these constraints' computing methods and compute tags to directly accept the spacetime derivative of H as input and extract the spatial derivative internally. This commit makes this simplification.

This PR is needed by #1558 


### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
