### PR TITLE
Remove requirement that temporal IDs have a step_prefix

### DIFF
--- a/src/Elliptic/Executables/Elasticity/SolveElasticityProblem.hpp
+++ b/src/Elliptic/Executables/Elasticity/SolveElasticityProblem.hpp
@@ -118,10 +118,11 @@ struct Metavariables {
   // Specify the DG boundary scheme. We use the strong first-order scheme here
   // that only requires us to compute normals dotted into the first-order
   // fluxes.
-  using boundary_scheme =
-      dg::FirstOrderScheme::FirstOrderScheme<volume_dim, linear_operand_tag,
-                                             normal_dot_numerical_flux,
-                                             linear_solver_iteration_id>;
+  using boundary_scheme = dg::FirstOrderScheme::FirstOrderScheme<
+      volume_dim, linear_operand_tag,
+      db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo,
+                         linear_operand_tag>,
+      normal_dot_numerical_flux, linear_solver_iteration_id>;
 
   // Collect events and triggers
   // (public for use by the Charm++ registration code)

--- a/src/Elliptic/Executables/Poisson/SolvePoissonProblem.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoissonProblem.hpp
@@ -113,10 +113,11 @@ struct Metavariables {
   // Specify the DG boundary scheme. We use the strong first-order scheme here
   // that only requires us to compute normals dotted into the first-order
   // fluxes.
-  using boundary_scheme =
-      dg::FirstOrderScheme::FirstOrderScheme<volume_dim, linear_operand_tag,
-                                             normal_dot_numerical_flux,
-                                             linear_solver_iteration_id>;
+  using boundary_scheme = dg::FirstOrderScheme::FirstOrderScheme<
+      volume_dim, linear_operand_tag,
+      db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo,
+                         linear_operand_tag>,
+      normal_dot_numerical_flux, linear_solver_iteration_id>;
 
   // Collect events and triggers
   // (public for use by the Charm++ registration code)

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -138,11 +138,13 @@ struct EvolutionMetavars {
   using boundary_scheme = tmpl::conditional_t<
       local_time_stepping,
       dg::FirstOrderScheme::FirstOrderSchemeLts<
-          volume_dim, typename system::variables_tag, normal_dot_numerical_flux,
-          Tags::TimeStepId, time_stepper_tag>,
+          volume_dim, typename system::variables_tag,
+          db::add_tag_prefix<::Tags::dt, typename system::variables_tag>,
+          normal_dot_numerical_flux, Tags::TimeStepId, time_stepper_tag>,
       dg::FirstOrderScheme::FirstOrderScheme<
-          volume_dim, typename system::variables_tag, normal_dot_numerical_flux,
-          Tags::TimeStepId>>;
+          volume_dim, typename system::variables_tag,
+          db::add_tag_prefix<::Tags::dt, typename system::variables_tag>,
+          normal_dot_numerical_flux, Tags::TimeStepId>>;
 
   // public for use by the Charm++ registration code
   using observe_fields = typename system::variables_tag::tags_list;

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -166,11 +166,13 @@ struct EvolutionMetavars {
   using boundary_scheme = tmpl::conditional_t<
       local_time_stepping,
       dg::FirstOrderScheme::FirstOrderSchemeLts<
-          volume_dim, typename system::variables_tag, normal_dot_numerical_flux,
-          Tags::TimeStepId, time_stepper_tag>,
+          volume_dim, typename system::variables_tag,
+          db::add_tag_prefix<::Tags::dt, typename system::variables_tag>,
+          normal_dot_numerical_flux, Tags::TimeStepId, time_stepper_tag>,
       dg::FirstOrderScheme::FirstOrderScheme<
-          volume_dim, typename system::variables_tag, normal_dot_numerical_flux,
-          Tags::TimeStepId>>;
+          volume_dim, typename system::variables_tag,
+          db::add_tag_prefix<::Tags::dt, typename system::variables_tag>,
+          normal_dot_numerical_flux, Tags::TimeStepId>>;
 
   using analytic_solution_fields = typename system::variables_tag::tags_list;
   using observe_fields = tmpl::append<

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -195,11 +195,13 @@ struct EvolutionMetavars {
   using boundary_scheme = tmpl::conditional_t<
       local_time_stepping,
       dg::FirstOrderScheme::FirstOrderSchemeLts<
-          volume_dim, typename system::variables_tag, normal_dot_numerical_flux,
-          Tags::TimeStepId, time_stepper_tag>,
+          volume_dim, typename system::variables_tag,
+          db::add_tag_prefix<::Tags::dt, typename system::variables_tag>,
+          normal_dot_numerical_flux, Tags::TimeStepId, time_stepper_tag>,
       dg::FirstOrderScheme::FirstOrderScheme<
-          volume_dim, typename system::variables_tag, normal_dot_numerical_flux,
-          Tags::TimeStepId>>;
+          volume_dim, typename system::variables_tag,
+          db::add_tag_prefix<::Tags::dt, typename system::variables_tag>,
+          normal_dot_numerical_flux, Tags::TimeStepId>>;
 
   // public for use by the Charm++ registration code
   using observation_events = tmpl::flatten<tmpl::list<

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -163,11 +163,13 @@ struct EvolutionMetavars {
   using boundary_scheme = tmpl::conditional_t<
       local_time_stepping,
       dg::FirstOrderScheme::FirstOrderSchemeLts<
-          Dim, typename system::variables_tag, normal_dot_numerical_flux,
-          Tags::TimeStepId, time_stepper_tag>,
+          Dim, typename system::variables_tag,
+          db::add_tag_prefix<::Tags::dt, typename system::variables_tag>,
+          normal_dot_numerical_flux, Tags::TimeStepId, time_stepper_tag>,
       dg::FirstOrderScheme::FirstOrderScheme<
-          Dim, typename system::variables_tag, normal_dot_numerical_flux,
-          Tags::TimeStepId>>;
+          Dim, typename system::variables_tag,
+          db::add_tag_prefix<::Tags::dt, typename system::variables_tag>,
+          normal_dot_numerical_flux, Tags::TimeStepId>>;
 
   using events = tmpl::flatten<tmpl::list<
       tmpl::conditional_t<evolution::is_analytic_solution_v<initial_data>,

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -152,11 +152,13 @@ struct EvolutionMetavars {
   using boundary_scheme = tmpl::conditional_t<
       local_time_stepping,
       dg::FirstOrderScheme::FirstOrderSchemeLts<
-          volume_dim, typename system::variables_tag, normal_dot_numerical_flux,
-          Tags::TimeStepId, time_stepper_tag>,
+          volume_dim, typename system::variables_tag,
+          db::add_tag_prefix<::Tags::dt, typename system::variables_tag>,
+          normal_dot_numerical_flux, Tags::TimeStepId, time_stepper_tag>,
       dg::FirstOrderScheme::FirstOrderScheme<
-          volume_dim, typename system::variables_tag, normal_dot_numerical_flux,
-          Tags::TimeStepId>>;
+          volume_dim, typename system::variables_tag,
+          db::add_tag_prefix<::Tags::dt, typename system::variables_tag>,
+          normal_dot_numerical_flux, Tags::TimeStepId>>;
 
   // public for use by the Charm++ registration code
   using events = tmpl::flatten<tmpl::list<

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -164,11 +164,13 @@ struct EvolutionMetavars {
   using boundary_scheme = tmpl::conditional_t<
       local_time_stepping,
       dg::FirstOrderScheme::FirstOrderSchemeLts<
-          Dim, typename system::variables_tag, normal_dot_numerical_flux,
-          Tags::TimeStepId, time_stepper_tag>,
+          Dim, typename system::variables_tag,
+          db::add_tag_prefix<::Tags::dt, typename system::variables_tag>,
+          normal_dot_numerical_flux, Tags::TimeStepId, time_stepper_tag>,
       dg::FirstOrderScheme::FirstOrderScheme<
-          Dim, typename system::variables_tag, normal_dot_numerical_flux,
-          Tags::TimeStepId>>;
+          Dim, typename system::variables_tag,
+          db::add_tag_prefix<::Tags::dt, typename system::variables_tag>,
+          normal_dot_numerical_flux, Tags::TimeStepId>>;
 
   using events = tmpl::list<
       tmpl::conditional_t<evolution::is_analytic_solution_v<initial_data>,

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -117,11 +117,13 @@ struct EvolutionMetavars {
   using boundary_scheme = tmpl::conditional_t<
       local_time_stepping,
       dg::FirstOrderScheme::FirstOrderSchemeLts<
-          Dim, typename system::variables_tag, normal_dot_numerical_flux,
-          Tags::TimeStepId, time_stepper_tag>,
+          Dim, typename system::variables_tag,
+          db::add_tag_prefix<::Tags::dt, typename system::variables_tag>,
+          normal_dot_numerical_flux, Tags::TimeStepId, time_stepper_tag>,
       dg::FirstOrderScheme::FirstOrderScheme<
-          Dim, typename system::variables_tag, normal_dot_numerical_flux,
-          Tags::TimeStepId>>;
+          Dim, typename system::variables_tag,
+          db::add_tag_prefix<::Tags::dt, typename system::variables_tag>,
+          normal_dot_numerical_flux, Tags::TimeStepId>>;
 
   using step_choosers_common =
       tmpl::list<StepChoosers::Registrars::ByBlock<volume_dim>,

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/FirstOrderScheme.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/FirstOrderScheme.hpp
@@ -59,11 +59,11 @@ struct boundary_data_computer_impl {
  *
  * Computes Eq. (2.20) in \cite Teukolsky2015ega and lifts it to the
  * volume (see `dg::lift_flux`) on all mortars that touch an element. The
- * resulting boundary contributions are added to the DG operator data in
- * `db::add_tag_prefix<TemporalIdTag::template step_prefix, VariablesTag>`.
+ * resulting boundary contributions are added to the DG operator data in the
+ * `DtVariablesTag`.
  */
-template <size_t Dim, typename VariablesTag, typename NumericalFluxComputerTag,
-          typename TemporalIdTag>
+template <size_t Dim, typename VariablesTag, typename DtVariablesTag,
+          typename NumericalFluxComputerTag, typename TemporalIdTag>
 struct FirstOrderScheme {
   static constexpr size_t volume_dim = Dim;
   using variables_tag = VariablesTag;
@@ -71,8 +71,7 @@ struct FirstOrderScheme {
   using NumericalFlux = typename NumericalFluxComputerTag::type;
   using temporal_id_tag = TemporalIdTag;
   using receive_temporal_id_tag = temporal_id_tag;
-  using dt_variables_tag =
-      db::add_tag_prefix<TemporalIdTag::template step_prefix, variables_tag>;
+  using dt_variables_tag = DtVariablesTag;
 
   static_assert(
       tt::assert_conforms_to<NumericalFlux, dg::protocols::NumericalFlux>);

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/FirstOrderSchemeLts.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/FirstOrderSchemeLts.hpp
@@ -74,12 +74,13 @@ struct boundary_data_computer_lts_impl<Dim, VariablesTag,
  * - We need to store the face-normal magnitude in the boundary history, as
  * opposed to the non-LTS case where we can retrieve it when needed.
  */
-template <size_t Dim, typename VariablesTag, typename NumericalFluxComputerTag,
-          typename TemporalIdTag, typename TimeStepperTag>
+template <size_t Dim, typename VariablesTag, typename DtVariablesTag,
+          typename NumericalFluxComputerTag, typename TemporalIdTag,
+          typename TimeStepperTag>
 struct FirstOrderSchemeLts {
  private:
-  using base = FirstOrderScheme<Dim, VariablesTag, NumericalFluxComputerTag,
-                                TemporalIdTag>;
+  using base = FirstOrderScheme<Dim, VariablesTag, DtVariablesTag,
+                                NumericalFluxComputerTag, TemporalIdTag>;
 
  public:
   static constexpr size_t volume_dim = Dim;

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ComputeTimeDerivative.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ComputeTimeDerivative.cpp
@@ -292,6 +292,7 @@ struct Metavariables {
   using system = System<Dim, system_type>;
   using boundary_scheme = ::dg::FirstOrderScheme::FirstOrderScheme<
       Dim, typename system::variables_tag,
+      db::add_tag_prefix<::Tags::dt, typename system::variables_tag>,
       Tags::NumericalFlux<BoundaryTerms<Dim>>, Tags::TimeStepId>;
   using normal_dot_numerical_flux = Tags::NumericalFlux<BoundaryTerms<Dim>>;
   using const_global_cache_tags =

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/Test_FirstOrderScheme.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/Test_FirstOrderScheme.cpp
@@ -67,8 +67,6 @@ struct BoundaryContribution : db::SimpleTag, db::PrefixTag {
 
 struct TemporalIdTag : db::SimpleTag {
   using type = int;
-  template <typename Tag>
-  using step_prefix = BoundaryContribution<Tag>;
 };
 
 // Helper function to combine local and remote boundary data to mortar data
@@ -88,9 +86,10 @@ auto make_mortar_data(const dg::MortarId<BoundaryScheme::volume_dim>& mortar_id,
 template <size_t Dim>
 void test_first_order_scheme() {
   CAPTURE(Dim);
-  using boundary_scheme =
-      dg::FirstOrderScheme::FirstOrderScheme<Dim, variables_tag,
-                                             NumericalFluxTag, TemporalIdTag>;
+  using boundary_scheme = dg::FirstOrderScheme::FirstOrderScheme<
+      Dim, variables_tag,
+      db::add_tag_prefix<BoundaryContribution, variables_tag>, NumericalFluxTag,
+      TemporalIdTag>;
 
   using BoundaryData = typename boundary_scheme::BoundaryData;
   using mortar_data_tag = typename boundary_scheme::mortar_data_tag;

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/Test_FirstOrderSchemeLts.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/Test_FirstOrderSchemeLts.cpp
@@ -70,8 +70,6 @@ struct BoundaryContribution : db::SimpleTag, db::PrefixTag {
 
 struct TemporalIdTag : db::SimpleTag {
   using type = int;
-  template <typename Tag>
-  using step_prefix = BoundaryContribution<Tag>;
 };
 
 // Helper function to combine local and remote boundary data to mortar data
@@ -94,8 +92,9 @@ void test_first_order_scheme_lts() {
   CAPTURE(Dim);
   using time_stepper_tag = Tags::TimeStepper<TimeSteppers::AdamsBashforthN>;
   using boundary_scheme = dg::FirstOrderScheme::FirstOrderSchemeLts<
-      Dim, variables_tag, NumericalFluxTag<NumericalFlux>, TemporalIdTag,
-      time_stepper_tag>;
+      Dim, variables_tag,
+      db::add_tag_prefix<BoundaryContribution, variables_tag>,
+      NumericalFluxTag<NumericalFlux>, TemporalIdTag, time_stepper_tag>;
 
   using BoundaryData = typename boundary_scheme::BoundaryData;
   using mortar_data_tag = typename boundary_scheme::mortar_data_tag;
@@ -278,8 +277,9 @@ SPECTRE_TEST_CASE("Unit.DG.FirstOrderScheme.Lts",
 
     using time_stepper_tag = Tags::TimeStepper<TimeSteppers::AdamsBashforthN>;
     using boundary_scheme = dg::FirstOrderScheme::FirstOrderSchemeLts<
-        2, variables_tag, NumericalFluxTag<TestNumericalFlux>, TemporalIdTag,
-        time_stepper_tag>;
+        2, variables_tag,
+        db::add_tag_prefix<BoundaryContribution, variables_tag>,
+        NumericalFluxTag<TestNumericalFlux>, TemporalIdTag, time_stepper_tag>;
 
     using BoundaryData = typename boundary_scheme::BoundaryData;
     using mortar_data_tag = typename boundary_scheme::mortar_data_tag;

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
@@ -144,6 +144,7 @@ struct Metavariables {
   using system = ScalarWave::System<1>;
   using boundary_scheme = dg::FirstOrderScheme::FirstOrderScheme<
       1, typename system::variables_tag,
+      db::add_tag_prefix<::Tags::dt, typename system::variables_tag>,
       Tags::NumericalFlux<ScalarWave::UpwindPenaltyCorrection<1>>,
       Tags::TimeStepId>;
 


### PR DESCRIPTION
## Proposed changes

Coupling the step_prefix to the temporal ID was a bad idea (by me), this commit
instead passes the `DtVariablesTag` to the DG boundary scheme directly.
We are transitioning away from the boundary schemes anyway, and this
commit is a (small) step towards that.

(The reason I'm doing this refactor now is so that I can more easily generalize the iteration ID tag used in the linear solvers for the upcoming nonlinear solver)

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
