### PR TITLE
Add Burgers Bump, Linear, and Sinusoid targets

### DIFF
--- a/src/Evolution/Executables/Burgers/CMakeLists.txt
+++ b/src/Evolution/Executables/Burgers/CMakeLists.txt
@@ -28,6 +28,21 @@ function(add_burgers_executable INITIAL_DATA_NAME INITIAL_DATA)
 endfunction(add_burgers_executable)
 
 add_burgers_executable(
+  Bump
+  Burgers::Solutions::Bump
+  )
+
+add_burgers_executable(
+  Linear
+  Burgers::Solutions::Linear
+  )
+
+add_burgers_executable(
   Step
   Burgers::Solutions::Step
+  )
+
+add_burgers_executable(
+  Sinusoid
+  Burgers::AnalyticData::Sinusoid
   )


### PR DESCRIPTION
## Proposed changes

Add targets to build executables with the Bump and Linear Burgers solution, and
the sinusoid analytic data.


### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
