### PR TITLE
Allow Gauss points on mortars

### DIFF
--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.cpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.cpp
@@ -22,14 +22,23 @@ Mesh<Dim> mortar_mesh(const Mesh<Dim>& face_mesh1,
   for (size_t i = 0; i < Dim; ++i) {
     ASSERT(
         face_mesh1.basis(i) == Spectral::Basis::Legendre and
-            face_mesh2.basis(i) == Spectral::Basis::Legendre and
-            face_mesh1.quadrature(i) == Spectral::Quadrature::GaussLobatto and
-            face_mesh2.quadrature(i) == Spectral::Quadrature::GaussLobatto,
-        "Only LGL meshes are supported for element faces so far.");
+            face_mesh2.basis(i) == Spectral::Basis::Legendre,
+        "Only Legendre basis meshes are supported for element faces so far.");
+    ASSERT(face_mesh1.quadrature(i) == face_mesh2.quadrature(i),
+           "The quadrature on face_mesh1 and face_mesh2 must be equal in "
+           "direction "
+               << i << " but face_mesh1 is " << face_mesh1.quadrature(i)
+               << " while face_mesh2 is " << face_mesh2.quadrature(i));
+    ASSERT(face_mesh1.quadrature(i) == Spectral::Quadrature::Gauss or
+               face_mesh1.quadrature(i) == Spectral::Quadrature::GaussLobatto,
+           "The quadrature on the faces must be Gauss or GaussLobatto, not "
+               << face_mesh1.quadrature(i) << ". The direction is " << i);
     mortar_extents[i] = std::max(face_mesh1.extents(i), face_mesh2.extents(i));
   }
-  return {mortar_extents.indices(), Spectral::Basis::Legendre,
-          Spectral::Quadrature::GaussLobatto};
+  // In 0-d we don't care about basis or quadrature so just specify GaussLobatto
+  return {
+      mortar_extents.indices(), Spectral::Basis::Legendre,
+      Dim != 0 ? face_mesh1.quadrature(0) : Spectral::Quadrature::GaussLobatto};
 }
 
 template <size_t Dim>


### PR DESCRIPTION
## Proposed changes

In the evolution code we will start supporting Gauss points soon (I have this working on a branch). It's not at all clear to me why this `ASSERT` is in the `mortar_mesh` function since that code fully supports Gauss points, it's other functions that don't.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
