### PR TITLE
Evaluate TensorExpressions using a storage index get

### DIFF
--- a/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
+++ b/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
@@ -95,6 +95,17 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
     }
   }
 
+  template <typename LhsStructure, typename... LhsIndices>
+  SPECTRE_ALWAYS_INLINE type get(const size_t lhs_storage_index) const {
+    if constexpr (Sign == 1) {
+      return t1_.template get<LhsStructure, LhsIndices...>(lhs_storage_index) +
+             t2_.template get<LhsStructure, LhsIndices...>(lhs_storage_index);
+    } else {
+      return t1_.template get<LhsStructure, LhsIndices...>(lhs_storage_index) -
+             t2_.template get<LhsStructure, LhsIndices...>(lhs_storage_index);
+    }
+  }
+
   SPECTRE_ALWAYS_INLINE typename T1::type operator[](size_t i) const {
     if constexpr (Sign == 1) {
       return t1_[i] + t2_[i];

--- a/src/DataStructures/Tensor/Structure.hpp
+++ b/src/DataStructures/Tensor/Structure.hpp
@@ -487,9 +487,9 @@ struct Structure {
   }
 
   /// Get the array of tensor_index's corresponding to the storage_index's.
-  SPECTRE_ALWAYS_INLINE static constexpr const std::array<
-      std::array<size_t, sizeof...(Indices) == 0 ? 1 : sizeof...(Indices)>,
-      size()>&
+  SPECTRE_ALWAYS_INLINE static constexpr const cpp20::array<
+      cpp20::array<size_t, sizeof...(Indices) == 0 ? 1 : sizeof...(Indices)>,
+      size()>
   storage_to_tensor_index() noexcept {
     constexpr auto storage_to_tensor = storage_to_tensor_;
     return storage_to_tensor;

--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -152,8 +152,8 @@ class Tensor<X, Symm, IndexList<Indices...>> {
         "evaluate<_a_t, _b_t>(G); if G has 2 free indices and you want "
         "the LHS of the equation to be F_{ab} rather than F_{ba}.");
     for (size_t i = 0; i < size(); ++i) {
-      gsl::at(data_, i) = tensor_expression.template get<LhsIndices...>(
-          structure::get_canonical_tensor_index(i));
+      gsl::at(data_, i) =
+          tensor_expression.template get<structure, LhsIndices...>(i);
     }
   }
   /// \endcond

--- a/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
+++ b/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_Expressions")
 
 set(LIBRARY_SOURCES
+  Test_AddSubtract.cpp
   Test_TensorExpressions.cpp
   )
 

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubtract.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubtract.cpp
@@ -1,0 +1,89 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <iterator>
+#include <numeric>
+
+#include "DataStructures/Tensor/Expressions/AddSubtract.hpp"
+#include "DataStructures/Tensor/Expressions/Evaluate.hpp"
+#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+
+SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
+                  "[DataStructures][Unit]") {
+  // Test adding scalars
+  const Tensor<double> scalar_1{{{2.1}}};
+  const Tensor<double> scalar_2{{{-0.8}}};
+  Tensor<double> lhs_scalar =
+      TensorExpressions::evaluate(scalar_1() + scalar_2());
+  CHECK(lhs_scalar.get() == 1.3);
+
+  Tensor<double, Symmetry<1, 1>,
+         index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
+      All{};
+  std::iota(All.begin(), All.end(), 0.0);
+  Tensor<double, Symmetry<2, 1>,
+         index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
+      Hll{};
+  Tensor<double, Symmetry<2, 1>,
+         index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
+      HHll{};
+  std::iota(Hll.begin(), Hll.end(), 0.0);
+  std::iota(HHll.rbegin(), HHll.rend(), -Hll.size());
+  /// [use_tensor_index]
+  auto Gll = TensorExpressions::evaluate<ti_a_t, ti_b_t>(All(ti_a, ti_b) +
+                                                         Hll(ti_a, ti_b));
+  auto Gll2 = TensorExpressions::evaluate<ti_a_t, ti_b_t>(All(ti_a, ti_b) +
+                                                          Hll(ti_b, ti_a));
+  auto Gll3 = TensorExpressions::evaluate<ti_a_t, ti_b_t>(
+      All(ti_a, ti_b) + Hll(ti_b, ti_a) + All(ti_b, ti_a) - Hll(ti_b, ti_a));
+  /// [use_tensor_index]
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      CHECK(Gll.get(i, j) == All.get(i, j) + Hll.get(i, j));
+      CHECK(Gll2.get(i, j) == All.get(i, j) + Hll.get(j, i));
+      CHECK(Gll3.get(i, j) == 2.0 * All.get(i, j));
+    }
+  }
+  // Test 3 indices add subtract
+  Tensor<double, Symmetry<1, 1, 2>,
+         index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
+      Alll{};
+  std::iota(Alll.begin(), Alll.end(), 0.0);
+  Tensor<double, Symmetry<1, 2, 3>,
+         index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
+      Hlll{};
+  Tensor<double, Symmetry<1, 2, 3>,
+         index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
+      HHlll{};
+  std::iota(Hlll.begin(), Hlll.end(), 0.0);
+  std::iota(HHlll.rbegin(), HHlll.rend(), -Hlll.size());
+  auto Glll = TensorExpressions::evaluate<ti_a_t, ti_b_t, ti_c_t>(
+      Alll(ti_a, ti_b, ti_c) + Hlll(ti_a, ti_b, ti_c));
+  auto Glll2 = TensorExpressions::evaluate<ti_a_t, ti_b_t, ti_c_t>(
+      Alll(ti_a, ti_b, ti_c) + Hlll(ti_b, ti_a, ti_c));
+  auto Glll3 = TensorExpressions::evaluate<ti_a_t, ti_b_t, ti_c_t>(
+      Alll(ti_a, ti_b, ti_c) + Hlll(ti_b, ti_a, ti_c) + Alll(ti_b, ti_a, ti_c) -
+      Hlll(ti_b, ti_a, ti_c));
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      for (int k = 0; k < 3; ++k) {
+        CHECK(Glll.get(i, j, k) == Alll.get(i, j, k) + Hlll.get(i, j, k));
+        CHECK(Glll2.get(i, j, k) == Alll.get(i, j, k) + Hlll.get(j, i, k));
+        CHECK(Glll3.get(i, j, k) == 2.0 * Alll.get(i, j, k));
+      }
+    }
+  }
+}

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubtract.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubtract.cpp
@@ -30,12 +30,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
          index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
                     SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
       Hll{};
-  Tensor<double, Symmetry<2, 1>,
-         index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
-      HHll{};
   std::iota(Hll.begin(), Hll.end(), 0.0);
-  std::iota(HHll.rbegin(), HHll.rend(), -Hll.size());
   /// [use_tensor_index]
   auto Gll = TensorExpressions::evaluate<ti_a_t, ti_b_t>(All(ti_a, ti_b) +
                                                          Hll(ti_a, ti_b));
@@ -63,13 +58,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
                     SpatialIndex<3, UpLo::Lo, Frame::Grid>,
                     SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
       Hlll{};
-  Tensor<double, Symmetry<1, 2, 3>,
-         index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpatialIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
-      HHlll{};
   std::iota(Hlll.begin(), Hlll.end(), 0.0);
-  std::iota(HHlll.rbegin(), HHlll.rend(), -Hlll.size());
   auto Glll = TensorExpressions::evaluate<ti_a_t, ti_b_t, ti_c_t>(
       Alll(ti_a, ti_b, ti_c) + Hlll(ti_a, ti_b, ti_c));
   auto Glll2 = TensorExpressions::evaluate<ti_a_t, ti_b_t, ti_c_t>(

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_TensorExpressions.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_TensorExpressions.cpp
@@ -3,15 +3,16 @@
 
 #include "Framework/TestingFramework.hpp"
 
-#include <cstddef>
-#include <iterator>
-#include <numeric>
-
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Expressions/AddSubtract.hpp"
 #include "DataStructures/Tensor/Expressions/Evaluate.hpp"
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/ComputeRhsTensorIndexRank0TestHelpers.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/ComputeRhsTensorIndexRank1TestHelpers.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/ComputeRhsTensorIndexRank2TestHelpers.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/ComputeRhsTensorIndexRank3TestHelpers.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/ComputeRhsTensorIndexRank4TestHelpers.hpp"
 #include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank0TestHelpers.hpp"
 #include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank1TestHelpers.hpp"
 #include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank2TestHelpers.hpp"
@@ -247,78 +248,281 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Evaluate",
                                                             ti_D);
 }
 
-SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
+SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.ComputeRhsTensorIndex",
                   "[DataStructures][Unit]") {
-  // Test adding scalars
-  const Tensor<double> scalar_1{{{2.1}}};
-  const Tensor<double> scalar_2{{{-0.8}}};
-  Tensor<double> lhs_scalar =
-      TensorExpressions::evaluate(scalar_1() + scalar_2());
-  CHECK(lhs_scalar.get() == 1.3);
+  // Rank 0: double
+  TestHelpers::TensorExpressions::test_compute_rhs_tensor_index_rank_0<
+      double>();
 
-  Tensor<double, Symmetry<1, 1>,
-         index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
-      All{};
-  std::iota(All.begin(), All.end(), 0.0);
-  Tensor<double, Symmetry<2, 1>,
-         index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
-      Hll{};
-  Tensor<double, Symmetry<2, 1>,
-         index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
-      HHll{};
-  std::iota(Hll.begin(), Hll.end(), 0.0);
-  std::iota(HHll.rbegin(), HHll.rend(), -Hll.size());
-  /// [use_tensor_index]
-  auto Gll = TensorExpressions::evaluate<ti_a_t, ti_b_t>(All(ti_a, ti_b) +
-                                                         Hll(ti_a, ti_b));
-  auto Gll2 = TensorExpressions::evaluate<ti_a_t, ti_b_t>(All(ti_a, ti_b) +
-                                                          Hll(ti_b, ti_a));
-  auto Gll3 = TensorExpressions::evaluate<ti_a_t, ti_b_t>(
-      All(ti_a, ti_b) + Hll(ti_b, ti_a) + All(ti_b, ti_a) - Hll(ti_b, ti_a));
-  /// [use_tensor_index]
-  for (int i = 0; i < 3; ++i) {
-    for (int j = 0; j < 3; ++j) {
-      CHECK(Gll.get(i, j) == All.get(i, j) + Hll.get(i, j));
-      CHECK(Gll2.get(i, j) == All.get(i, j) + Hll.get(j, i));
-      CHECK(Gll3.get(i, j) == 2.0 * All.get(i, j));
-    }
-  }
-  // Test 3 indices add subtract
-  Tensor<double, Symmetry<1, 1, 2>,
-         index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpatialIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
-      Alll{};
-  std::iota(Alll.begin(), Alll.end(), 0.0);
-  Tensor<double, Symmetry<1, 2, 3>,
-         index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpatialIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
-      Hlll{};
-  Tensor<double, Symmetry<1, 2, 3>,
-         index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpatialIndex<3, UpLo::Lo, Frame::Grid>,
-                    SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
-      HHlll{};
-  std::iota(Hlll.begin(), Hlll.end(), 0.0);
-  std::iota(HHlll.rbegin(), HHlll.rend(), -Hlll.size());
-  auto Glll = TensorExpressions::evaluate<ti_a_t, ti_b_t, ti_c_t>(
-      Alll(ti_a, ti_b, ti_c) + Hlll(ti_a, ti_b, ti_c));
-  auto Glll2 = TensorExpressions::evaluate<ti_a_t, ti_b_t, ti_c_t>(
-      Alll(ti_a, ti_b, ti_c) + Hlll(ti_b, ti_a, ti_c));
-  auto Glll3 = TensorExpressions::evaluate<ti_a_t, ti_b_t, ti_c_t>(
-      Alll(ti_a, ti_b, ti_c) + Hlll(ti_b, ti_a, ti_c) + Alll(ti_b, ti_a, ti_c) -
-      Hlll(ti_b, ti_a, ti_c));
-  for (int i = 0; i < 3; ++i) {
-    for (int j = 0; j < 3; ++j) {
-      for (int k = 0; k < 3; ++k) {
-        CHECK(Glll.get(i, j, k) == Alll.get(i, j, k) + Hlll.get(i, j, k));
-        CHECK(Glll2.get(i, j, k) == Alll.get(i, j, k) + Hlll.get(j, i, k));
-        CHECK(Glll3.get(i, j, k) == 2.0 * Alll.get(i, j, k));
-      }
-    }
-  }
+  // Rank 0: DataVector
+  TestHelpers::TensorExpressions::test_compute_rhs_tensor_index_rank_0<
+      DataVector>();
+
+  // Rank 1: double; spacetime
+  TestHelpers::TensorExpressions::test_compute_rhs_tensor_index_rank_1<
+      double, SpacetimeIndex, UpLo::Lo>(ti_a);
+  TestHelpers::TensorExpressions::test_compute_rhs_tensor_index_rank_1<
+      double, SpacetimeIndex, UpLo::Lo>(ti_b);
+  TestHelpers::TensorExpressions::test_compute_rhs_tensor_index_rank_1<
+      double, SpacetimeIndex, UpLo::Up>(ti_A);
+  TestHelpers::TensorExpressions::test_compute_rhs_tensor_index_rank_1<
+      double, SpacetimeIndex, UpLo::Up>(ti_B);
+
+  // Rank 1: double; spatial
+  TestHelpers::TensorExpressions::test_compute_rhs_tensor_index_rank_1<
+      double, SpatialIndex, UpLo::Lo>(ti_i);
+  TestHelpers::TensorExpressions::test_compute_rhs_tensor_index_rank_1<
+      double, SpatialIndex, UpLo::Lo>(ti_j);
+  TestHelpers::TensorExpressions::test_compute_rhs_tensor_index_rank_1<
+      double, SpatialIndex, UpLo::Up>(ti_I);
+  TestHelpers::TensorExpressions::test_compute_rhs_tensor_index_rank_1<
+      double, SpatialIndex, UpLo::Up>(ti_J);
+
+  // Rank 1: DataVector
+  TestHelpers::TensorExpressions::test_compute_rhs_tensor_index_rank_1<
+      DataVector, SpatialIndex, UpLo::Up>(ti_L);
+
+  // Rank 2: double; nonsymmetric; spacetime only
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_no_symmetry<
+          double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo>(ti_a,
+                                                                      ti_b);
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_no_symmetry<
+          double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Up>(ti_A,
+                                                                      ti_B);
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_no_symmetry<
+          double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo>(ti_d,
+                                                                      ti_c);
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_no_symmetry<
+          double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Up>(ti_D,
+                                                                      ti_C);
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_no_symmetry<
+          double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up>(ti_e,
+                                                                      ti_F);
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_no_symmetry<
+          double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo>(ti_F,
+                                                                      ti_e);
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_no_symmetry<
+          double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up>(ti_g,
+                                                                      ti_B);
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_no_symmetry<
+          double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo>(ti_G,
+                                                                      ti_b);
+
+  // Rank 2: double; nonsymmetric; spatial only
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_no_symmetry<
+          double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Lo>(ti_i, ti_j);
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_no_symmetry<
+          double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Up>(ti_I, ti_J);
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_no_symmetry<
+          double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Lo>(ti_j, ti_i);
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_no_symmetry<
+          double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Up>(ti_J, ti_I);
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_no_symmetry<
+          double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Up>(ti_i, ti_J);
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_no_symmetry<
+          double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Lo>(ti_I, ti_j);
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_no_symmetry<
+          double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Up>(ti_j, ti_I);
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_no_symmetry<
+          double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Lo>(ti_J, ti_i);
+
+  // Rank 2: double; nonsymmetric; spacetime and spatial mixed
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_no_symmetry<
+          double, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Up>(ti_c, ti_I);
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_no_symmetry<
+          double, SpacetimeIndex, SpatialIndex, UpLo::Up, UpLo::Lo>(ti_A, ti_i);
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_no_symmetry<
+          double, SpatialIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo>(ti_J, ti_a);
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_no_symmetry<
+          double, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up>(ti_i, ti_B);
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_no_symmetry<
+          double, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Lo>(ti_e, ti_j);
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_no_symmetry<
+          double, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo>(ti_i, ti_d);
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_no_symmetry<
+          double, SpacetimeIndex, SpatialIndex, UpLo::Up, UpLo::Up>(ti_C, ti_I);
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_no_symmetry<
+          double, SpatialIndex, SpacetimeIndex, UpLo::Up, UpLo::Up>(ti_J, ti_A);
+
+  // Rank 2: double; symmetric; spacetime
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_symmetric<double, SpacetimeIndex,
+                                                     UpLo::Lo>(ti_a, ti_d);
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_symmetric<double, SpacetimeIndex,
+                                                     UpLo::Up>(ti_G, ti_B);
+
+  // Rank 2: double; symmetric; spatial
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_symmetric<double, SpatialIndex,
+                                                     UpLo::Lo>(ti_j, ti_i);
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_symmetric<double, SpatialIndex,
+                                                     UpLo::Up>(ti_I, ti_J);
+
+  // Rank 2: DataVector; nonsymmetric
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_no_symmetry<
+          DataVector, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up>(ti_f,
+                                                                          ti_G);
+
+  // Rank 2: DataVector; symmetric
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_2_symmetric<DataVector, SpatialIndex,
+                                                     UpLo::Lo>(ti_j, ti_i);
+
+  // Rank 3: double; nonsymmetric
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_3_no_symmetry<
+          double, SpacetimeIndex, SpatialIndex, SpacetimeIndex, UpLo::Up,
+          UpLo::Lo, UpLo::Up>(ti_D, ti_j, ti_B);
+
+  // Rank 3: double; first and second indices symmetric
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_3_ab_symmetry<
+          double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up>(
+          ti_b, ti_a, ti_C);
+
+  // Rank 3: double; first and third indices symmetric
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_3_ac_symmetry<
+          double, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo>(ti_i, ti_f,
+                                                                    ti_j);
+
+  // Rank 3: double; second and third indices symmetric
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_3_bc_symmetry<
+          double, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Up>(ti_d, ti_J,
+                                                                    ti_I);
+
+  // Rank 3: double; symmetric
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_3_abc_symmetry<double, SpacetimeIndex,
+                                                        UpLo::Lo>(ti_f, ti_d,
+                                                                  ti_a);
+
+  // Rank 3: DataVector; nonsymmetric
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_3_no_symmetry<
+          DataVector, SpacetimeIndex, SpatialIndex, SpacetimeIndex, UpLo::Up,
+          UpLo::Lo, UpLo::Up>(ti_D, ti_j, ti_B);
+
+  // Rank 3: DataVector; first and second indices symmetric
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_3_ab_symmetry<
+          DataVector, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up>(
+          ti_b, ti_a, ti_C);
+
+  // Rank 3: DataVector; first and third indices symmetric
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_3_ac_symmetry<
+          DataVector, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo>(
+          ti_i, ti_f, ti_j);
+
+  // Rank 3: DataVector; second and third indices symmetric
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_3_bc_symmetry<
+          DataVector, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Up>(
+          ti_d, ti_J, ti_I);
+
+  // Rank 3: DataVector; symmetric
+  TestHelpers::TensorExpressions::
+      test_compute_rhs_tensor_index_rank_3_abc_symmetry<
+          DataVector, SpacetimeIndex, UpLo::Lo>(ti_f, ti_d, ti_a);
+
+  // Rank 4: double; nonsymmetric
+  TestHelpers::TensorExpressions::test_compute_rhs_tensor_index_rank_4<
+      double, Symmetry<4, 3, 2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpatialIndex<2, UpLo::Up, Frame::Grid>,
+                 SpatialIndex<1, UpLo::Lo, Frame::Grid>,
+                 SpacetimeIndex<2, UpLo::Up, Frame::Grid>>>(ti_c, ti_J, ti_i,
+                                                            ti_A);
+
+  // Rank 4: double; second and third indices symmetric
+  TestHelpers::TensorExpressions::test_compute_rhs_tensor_index_rank_4<
+      double, Symmetry<3, 2, 2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpatialIndex<1, UpLo::Lo, Frame::Grid>>>(ti_G, ti_d, ti_a,
+                                                          ti_j);
+
+  // Rank 4: double; first, second, and fourth indices symmetric
+  TestHelpers::TensorExpressions::test_compute_rhs_tensor_index_rank_4<
+      double, Symmetry<2, 2, 1, 2>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>(ti_j, ti_i, ti_k,
+                                                              ti_l);
+
+  // Rank 4: double; symmetric
+  TestHelpers::TensorExpressions::test_compute_rhs_tensor_index_rank_4<
+      double, Symmetry<1, 1, 1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>(ti_F, ti_A, ti_C,
+                                                            ti_D);
+
+  // Rank 4: DataVector; nonsymmetric
+  TestHelpers::TensorExpressions::test_compute_rhs_tensor_index_rank_4<
+      DataVector, Symmetry<4, 3, 2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpatialIndex<1, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Lo, Frame::Inertial>>>(ti_b, ti_A, ti_k,
+                                                              ti_l);
+
+  // Rank 4: DataVector; second and third indices symmetric
+  TestHelpers::TensorExpressions::test_compute_rhs_tensor_index_rank_4<
+      DataVector, Symmetry<3, 2, 2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpatialIndex<1, UpLo::Lo, Frame::Grid>>>(ti_G, ti_d, ti_a,
+                                                          ti_j);
+
+  // Rank 4: DataVector; first, second, and fourth indices symmetric
+  TestHelpers::TensorExpressions::test_compute_rhs_tensor_index_rank_4<
+      DataVector, Symmetry<2, 2, 1, 2>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>(ti_j, ti_i, ti_k,
+                                                              ti_l);
+
+  // Rank 4: DataVector; symmetric
+  TestHelpers::TensorExpressions::test_compute_rhs_tensor_index_rank_4<
+      DataVector, Symmetry<1, 1, 1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>(ti_F, ti_A, ti_C,
+                                                            ti_D);
 }

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/ComputeRhsTensorIndexRank0TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/ComputeRhsTensorIndexRank0TestHelpers.hpp
@@ -1,0 +1,32 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace TestHelpers::TensorExpressions {
+
+/// \ingroup TestingFrameworkGroup
+/// \brief Test that the computed tensor multi-index of a rank 0 RHS Tensor is
+/// equivalent to the given LHS tensor multi-index
+///
+/// \tparam DataType the type of data being stored in the Tensors
+template <typename DataType>
+void test_compute_rhs_tensor_index_rank_0() noexcept {
+  const Tensor<DataType> rhs_tensor{};
+  // Get TensorExpression from RHS tensor
+  const auto R = rhs_tensor();
+
+  const std::array<size_t, 0> index_order = {};
+
+  const std::array<size_t, 0> tensor_multi_index = {};
+  CHECK(R.compute_rhs_tensor_index(index_order, index_order,
+                                   tensor_multi_index) == tensor_multi_index);
+}
+
+}  // namespace TestHelpers::TensorExpressions

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/ComputeRhsTensorIndexRank1TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/ComputeRhsTensorIndexRank1TestHelpers.hpp
@@ -1,0 +1,76 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace TestHelpers::TensorExpressions {
+
+/// \ingroup TestingFrameworkGroup
+/// \brief Test that the computed tensor multi-index of a rank 1 RHS Tensor is
+/// equivalent to the given LHS tensor multi-index
+///
+/// \tparam DataType the type of data being stored in the Tensors
+/// \tparam TensorIndexTypeList the Tensors' typelist containing their
+/// \ref SpacetimeIndex "TensorIndexType"
+/// \param tensorindex the TensorIndex used in the the TensorExpression,
+/// e.g. `ti_a`
+template <typename DataType, typename TensorIndexTypeList, typename TensorIndex>
+void test_compute_rhs_tensor_index_rank_1_impl(
+    const TensorIndex& tensorindex) noexcept {
+  const Tensor<DataType, Symmetry<1>, TensorIndexTypeList> rhs_tensor(5_st);
+  // Get TensorExpression from RHS tensor
+  const auto R_a = rhs_tensor(tensorindex);
+
+  const std::array<size_t, 1> index_order = {TensorIndex::value};
+
+  const size_t dim = tmpl::at_c<TensorIndexTypeList, 0>::dim;
+
+  // For L_a = R_a, check that L_i == R_i
+  for (size_t i = 0; i < dim; i++) {
+    const std::array<size_t, 1> tensor_multi_index = {i};
+    CHECK(R_a.compute_rhs_tensor_index(index_order, index_order,
+                                       tensor_multi_index) ==
+          tensor_multi_index);
+  }
+}
+
+/// \ingroup TestingFrameworkGroup
+/// \brief Iterate testing of computing the RHS tensor multi-index equivalent of
+/// the LHS tensor multi-index with rank 1 Tensors on multiple Frame types and
+/// dimensions
+///
+/// \tparam DataType the type of data being stored in the Tensors
+/// \tparam TensorIndexType the Tensors' \ref SpacetimeIndex "TensorIndexType"
+/// \tparam Valence the valence of the Tensors' index
+/// \param tensorindex the TensorIndex used in the the TensorExpression,
+/// e.g. `ti_a`
+template <typename DataType,
+          template <size_t, UpLo, typename> class TensorIndexType, UpLo Valence,
+          typename TensorIndex>
+void test_compute_rhs_tensor_index_rank_1(
+    const TensorIndex& tensorindex) noexcept {
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define CALL_TEST_COMPUTE_RHS_TENSOR_INDEX_RANK_1_IMPL(_, data)                \
+  test_compute_rhs_tensor_index_rank_1_impl<                                   \
+      DataType, index_list<TensorIndexType<DIM(data), Valence, FRAME(data)>>>( \
+      tensorindex);
+
+  GENERATE_INSTANTIATIONS(CALL_TEST_COMPUTE_RHS_TENSOR_INDEX_RANK_1_IMPL,
+                          (1, 2, 3), (Frame::Grid, Frame::Inertial))
+
+#undef CALL_TEST_COMPUTE_RHS_TENSOR_INDEX_RANK_1_IMPL
+#undef FRAME
+#undef DIM
+}
+
+}  // namespace TestHelpers::TensorExpressions

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/ComputeRhsTensorIndexRank2TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/ComputeRhsTensorIndexRank2TestHelpers.hpp
@@ -1,0 +1,159 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace TestHelpers::TensorExpressions {
+
+/// \ingroup TestingFrameworkGroup
+/// \brief Test that the computed tensor multi-index of a rank 2 RHS Tensor is
+/// equivalent to the given LHS tensor multi-index, according to the order of
+/// their generic indices
+///
+/// \details `TensorIndexA` and `TensorIndexB` can be any type of TensorIndex
+/// and are not necessarily `ti_a_t` and `ti_b_t`. The "A" and "B" suffixes just
+/// denote the ordering of the generic indices of the RHS tensor expression. In
+/// the RHS tensor expression, it means `TensorIndexA` is the first index used
+/// and `TensorIndexB` is the second index used.
+///
+/// If we consider the RHS tensor's generic indices to be (a, b), the possible
+/// orderings of the LHS tensor's generic indices are: (a, b) and (b, a). For
+/// each of these cases, this test checks that for each LHS component's tensor
+/// multi-index, the equivalent RHS tensor multi-index is correctly computed.
+///
+/// \tparam DataType the type of data being stored in the Tensors
+/// \tparam RhsSymmetry the ::Symmetry of the RHS Tensor
+/// \tparam RhsTensorIndexTypeList the RHS Tensor's typelist of
+/// \ref SpacetimeIndex "TensorIndexType"s
+/// \param tensorindex_a the first TensorIndex used on the RHS of the
+/// TensorExpression, e.g. `ti_a`
+/// \param tensorindex_b the second TensorIndex used on the RHS of the
+/// TensorExpression, e.g. `ti_B`
+template <typename DataType, typename RhsSymmetry,
+          typename RhsTensorIndexTypeList, typename TensorIndexA,
+          typename TensorIndexB>
+void test_compute_rhs_tensor_index_rank_2_impl(
+    const TensorIndexA& tensorindex_a,
+    const TensorIndexB& tensorindex_b) noexcept {
+  const Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList> rhs_tensor(5_st);
+  // Get TensorExpression from RHS tensor
+  const auto R_ab = rhs_tensor(tensorindex_a, tensorindex_b);
+
+  const std::array<size_t, 2> index_order_ab = {TensorIndexA::value,
+                                                TensorIndexB::value};
+  const std::array<size_t, 2> index_order_ba = {TensorIndexB::value,
+                                                TensorIndexA::value};
+
+  const size_t dim_a = tmpl::at_c<RhsTensorIndexTypeList, 0>::dim;
+  const size_t dim_b = tmpl::at_c<RhsTensorIndexTypeList, 1>::dim;
+
+  for (size_t i = 0; i < dim_a; i++) {
+    for (size_t j = 0; j < dim_b; j++) {
+      const std::array<size_t, 2> ij = {i, j};
+      const std::array<size_t, 2> ji = {j, i};
+
+      // For L_{ab} = R_{ab}, check that L_{ij} == R_{ij}
+      CHECK(R_ab.compute_rhs_tensor_index(index_order_ab, index_order_ab, ij) ==
+            ij);
+      // For L_{ba} = R_{ab}, check that L_{ij} == R_{ji}
+      CHECK(R_ab.compute_rhs_tensor_index(index_order_ba, index_order_ab, ij) ==
+            ji);
+    }
+  }
+}
+
+/// \ingroup TestingFrameworkGroup
+/// \brief Iterate testing of computing the RHS tensor multi-index equivalent of
+/// the LHS tensor multi-index with rank 2 Tensors on multiple Frame types and
+/// dimension combinations
+///
+/// We test nonsymmetric indices and symmetric indices across two functions to
+/// ensure that the code works correctly with symmetries. This function tests
+/// one of the following symmetries:
+/// - <2, 1> (`test_compute_rhs_tensor_index_rank_2_no_symmetry`)
+/// - <1, 1> (`test_compute_rhs_tensor_index_rank_2_symmetric`)
+///
+/// \details `TensorIndexA` and `TensorIndexB` can be any type of TensorIndex
+/// and are not necessarily `ti_a_t` and `ti_b_t`. The "A" and "B" suffixes just
+/// denote the ordering of the generic indices of the RHS tensor expression. In
+/// the RHS tensor expression, it means `TensorIndexA` is the first index used
+/// and `TensorIndexB` is the second index used.
+///
+/// Note: `test_compute_rhs_tensor_index_rank_2_symmetric` has fewer template
+/// parameters due to the two indices having a shared \ref SpacetimeIndex
+/// "TensorIndexType" and and valence
+///
+/// \tparam DataType the type of data being stored in the Tensors
+/// \tparam TensorIndexTypeA the \ref SpacetimeIndex "TensorIndexType" of the
+/// first index of the RHS Tensor
+/// \tparam TensorIndexTypeB the \ref SpacetimeIndex "TensorIndexType" of the
+/// second index of the RHS Tensor
+/// \tparam ValenceA the valence of the first index used on the RHS of the
+/// TensorExpression
+/// \tparam ValenceB the valence of the second index used on the RHS of the
+/// TensorExpression
+/// \param tensorindex_a the first TensorIndex used on the RHS of the
+/// TensorExpression, e.g. `ti_a`
+/// \param tensorindex_b the second TensorIndex used on the RHS of the
+/// TensorExpression, e.g. `ti_B`
+template <
+    typename DataType, template <size_t, UpLo, typename> class TensorIndexTypeA,
+    template <size_t, UpLo, typename> class TensorIndexTypeB, UpLo ValenceA,
+    UpLo ValenceB, typename TensorIndexA, typename TensorIndexB>
+void test_compute_rhs_tensor_index_rank_2_no_symmetry(
+    const TensorIndexA& tensorindex_a,
+    const TensorIndexB& tensorindex_b) noexcept {
+#define DIM_A(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DIM_B(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define CALL_TEST_COMPUTE_RHS_TENSOR_INDEX_RANK_2_IMPL(_, data)          \
+  test_compute_rhs_tensor_index_rank_2_impl<                             \
+      DataType, Symmetry<2, 1>,                                          \
+      index_list<TensorIndexTypeA<DIM_A(data), ValenceA, FRAME(data)>,   \
+                 TensorIndexTypeB<DIM_B(data), ValenceB, FRAME(data)>>>( \
+      tensorindex_a, tensorindex_b);
+
+  GENERATE_INSTANTIATIONS(CALL_TEST_COMPUTE_RHS_TENSOR_INDEX_RANK_2_IMPL,
+                          (1, 2, 3), (1, 2, 3), (Frame::Grid, Frame::Inertial))
+
+#undef CALL_TEST_COMPUTE_RHS_TENSOR_INDEX_RANK_2_IMPL
+#undef FRAME
+#undef DIM_B
+#undef DIM_A
+}
+
+/// \ingroup TestingFrameworkGroup
+/// \copydoc test_compute_rhs_tensor_index_rank_2_no_symmetry()
+template <
+    typename DataType, template <size_t, UpLo, typename> class TensorIndexType,
+    UpLo Valence, typename TensorIndexA, typename TensorIndexB>
+void test_compute_rhs_tensor_index_rank_2_symmetric(
+    const TensorIndexA& tensorindex_a,
+    const TensorIndexB& tensorindex_b) noexcept {
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define CALL_TEST_COMPUTE_RHS_TENSOR_INDEX_RANK_2_IMPL(_, data)     \
+  test_compute_rhs_tensor_index_rank_2_impl<                        \
+      DataType, Symmetry<1, 1>,                                     \
+      index_list<TensorIndexType<DIM(data), Valence, FRAME(data)>,  \
+                 TensorIndexType<DIM(data), Valence, FRAME(data)>>, \
+      TensorIndexA, TensorIndexB>(tensorindex_a, tensorindex_b);
+
+  GENERATE_INSTANTIATIONS(CALL_TEST_COMPUTE_RHS_TENSOR_INDEX_RANK_2_IMPL,
+                          (1, 2, 3), (Frame::Grid, Frame::Inertial))
+
+#undef CALL_TEST_COMPUTE_RHS_TENSOR_INDEX_RANK_2_IMPL
+#undef FRAME
+#undef DIM
+}
+
+}  // namespace TestHelpers::TensorExpressions

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/ComputeRhsTensorIndexRank3TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/ComputeRhsTensorIndexRank3TestHelpers.hpp
@@ -1,0 +1,300 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace TestHelpers::TensorExpressions {
+
+/// \ingroup TestingFrameworkGroup
+/// \brief Test that the computed tensor multi-index of a rank 3 RHS Tensor is
+/// equivalent to the given LHS tensor multi-index, according to the order of
+/// their generic indices
+///
+/// \details `TensorIndexA`, `TensorIndexB`, and `TensorIndexC` can be any type
+/// of TensorIndex and are not necessarily `ti_a_t`, `ti_b_t`, and `ti_c_t`. The
+/// "A", "B", and "C" suffixes just denote the ordering of the generic indices
+/// of the RHS tensor expression. In the RHS tensor expression, it means
+/// `TensorIndexA` is the first index used, `TensorIndexB` is the second index
+/// used, and `TensorIndexC` is the third index used.
+///
+/// If we consider the RHS tensor's generic indices to be (a, b, c), the
+/// possible orderings of the LHS tensor's generic indices are: (a, b, c),
+/// (a, c, b), (b, a, c), (b, c, a), (c, a, b), and (c, b, a). For each of these
+/// cases, this test checks that for each LHS component's tensor multi-index,
+/// the equivalent RHS tensor multi-index is correctly computed.
+///
+/// \tparam DataType the type of data being stored in the Tensors
+/// \tparam RhsSymmetry the ::Symmetry of the RHS Tensor
+/// \tparam RhsTensorIndexTypeList the RHS Tensor's typelist of
+/// \ref SpacetimeIndex "TensorIndexType"s
+/// \param tensorindex_a the first TensorIndex used on the RHS of the
+/// TensorExpression, e.g. `ti_a`
+/// \param tensorindex_b the second TensorIndex used on the RHS of the
+/// TensorExpression, e.g. `ti_B`
+/// \param tensorindex_c the third TensorIndex used on the RHS of the
+/// TensorExpression, e.g. `ti_c`
+template <typename DataType, typename RhsSymmetry,
+          typename RhsTensorIndexTypeList, typename TensorIndexA,
+          typename TensorIndexB, typename TensorIndexC>
+void test_compute_rhs_tensor_index_rank_3_impl(
+    const TensorIndexA& tensorindex_a, const TensorIndexB& tensorindex_b,
+    const TensorIndexC& tensorindex_c) noexcept {
+  const Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList> rhs_tensor(5_st);
+  // Get TensorExpression from RHS tensor
+  const auto R_abc = rhs_tensor(tensorindex_a, tensorindex_b, tensorindex_c);
+
+  const std::array<size_t, 3> index_order_abc = {
+      TensorIndexA::value, TensorIndexB::value, TensorIndexC::value};
+  const std::array<size_t, 3> index_order_acb = {
+      TensorIndexA::value, TensorIndexC::value, TensorIndexB::value};
+  const std::array<size_t, 3> index_order_bac = {
+      TensorIndexB::value, TensorIndexA::value, TensorIndexC::value};
+  const std::array<size_t, 3> index_order_bca = {
+      TensorIndexB::value, TensorIndexC::value, TensorIndexA::value};
+  const std::array<size_t, 3> index_order_cab = {
+      TensorIndexC::value, TensorIndexA::value, TensorIndexB::value};
+  const std::array<size_t, 3> index_order_cba = {
+      TensorIndexC::value, TensorIndexB::value, TensorIndexA::value};
+
+  const size_t dim_a = tmpl::at_c<RhsTensorIndexTypeList, 0>::dim;
+  const size_t dim_b = tmpl::at_c<RhsTensorIndexTypeList, 1>::dim;
+  const size_t dim_c = tmpl::at_c<RhsTensorIndexTypeList, 2>::dim;
+
+  for (size_t i = 0; i < dim_a; i++) {
+    for (size_t j = 0; j < dim_b; j++) {
+      for (size_t k = 0; k < dim_c; k++) {
+        const std::array<size_t, 3> ijk = {i, j, k};
+        const std::array<size_t, 3> ikj = {i, k, j};
+        const std::array<size_t, 3> jik = {j, i, k};
+        const std::array<size_t, 3> jki = {j, k, i};
+        const std::array<size_t, 3> kij = {k, i, j};
+        const std::array<size_t, 3> kji = {k, j, i};
+
+        // For L_{abc} = R_{abc}, check that L_{ijk} == R_{ijk}
+        CHECK(R_abc.compute_rhs_tensor_index(index_order_abc, index_order_abc,
+                                             ijk) == ijk);
+        // For L_{acb} = R_{abc}, check that L_{ijk} == R_{ikj}
+        CHECK(R_abc.compute_rhs_tensor_index(index_order_acb, index_order_abc,
+                                             ijk) == ikj);
+        // For L_{bac} = R_{abc}, check that L_{ijk} == R_{jik}
+        CHECK(R_abc.compute_rhs_tensor_index(index_order_bac, index_order_abc,
+                                             ijk) == jik);
+        // For L_{bca} = R_{abc}, check that L_{ijk} == R_{kij}
+        CHECK(R_abc.compute_rhs_tensor_index(index_order_bca, index_order_abc,
+                                             ijk) == kij);
+        // For L_{cab} = R_{abc}, check that L_{ijk} == R_{jki}
+        CHECK(R_abc.compute_rhs_tensor_index(index_order_cab, index_order_abc,
+                                             ijk) == jki);
+        // For L_{cba} = R_{abc}, check that L_{ijk} == R_{kji}
+        CHECK(R_abc.compute_rhs_tensor_index(index_order_cba, index_order_abc,
+                                             ijk) == kji);
+      }
+    }
+  }
+}
+
+/// \ingroup TestingFrameworkGroup
+/// \brief Iterate testing of computing the RHS tensor multi-index equivalent of
+/// the LHS tensor multi-index with rank 3 Tensors on multiple Frame types and
+/// dimension combinations for nonsymmetric indices
+///
+/// We test various different symmetries across several functions to ensure that
+/// the code works correctly with symmetries. This function tests one of the
+/// following symmetries:
+/// - <3, 2, 1> (`test_compute_rhs_tensor_index_rank_3_no_symmetry`)
+/// - <2, 2, 1> (`test_compute_rhs_tensor_index_rank_3_ab_symmetry`)
+/// - <2, 1, 2> (`test_compute_rhs_tensor_index_rank_3_ac_symmetry`)
+/// - <2, 1, 1> (`test_compute_rhs_tensor_index_rank_3_bc_symmetry`)
+/// - <1, 1, 1> (`test_compute_rhs_tensor_index_rank_3_abc_symmetry`)
+///
+/// \details `TensorIndexA`, `TensorIndexB`, and `TensorIndexC` can be any type
+/// of TensorIndex and are not necessarily `ti_a_t`, `ti_b_t`, and `ti_c_t`. The
+/// "A", "B", and "C" suffixes just denote the ordering of the generic indices
+/// of the RHS tensor expression. In the RHS tensor expression, it means
+/// `TensorIndexA` is the first index used, `TensorIndexB` is the second index
+/// used, and `TensorIndexC` is the third index used.
+///
+/// Note: the functions dealing with symmetric indices have fewer template
+/// parameters due to the indices having a shared \ref SpacetimeIndex
+/// "TensorIndexType" and valence
+///
+/// \tparam DataType the type of data being stored in the Tensors
+/// \tparam TensorIndexTypeA the \ref SpacetimeIndex "TensorIndexType" of the
+/// first index of the RHS Tensor
+/// \tparam TensorIndexTypeB the \ref SpacetimeIndex "TensorIndexType" of the
+/// second index of the RHS Tensor
+/// \tparam TensorIndexTypeC the \ref SpacetimeIndex "TensorIndexType" of the
+/// third index of the RHS Tensor
+/// \tparam ValenceA the valence of the first index used on the RHS of the
+/// TensorExpression
+/// \tparam ValenceB the valence of the second index used on the RHS of the
+/// TensorExpression
+/// \tparam ValenceC the valence of the third index used on the RHS of the
+/// TensorExpression
+/// \param tensorindex_a the first TensorIndex used on the RHS of the
+/// TensorExpression, e.g. `ti_a`
+/// \param tensorindex_b the second TensorIndex used on the RHS of the
+/// TensorExpression, e.g. `ti_B`
+/// \param tensorindex_c the third TensorIndex used on the RHS of the
+/// TensorExpression, e.g. `ti_c`
+template <typename DataType,
+          template <size_t, UpLo, typename> class TensorIndexTypeA,
+          template <size_t, UpLo, typename> class TensorIndexTypeB,
+          template <size_t, UpLo, typename> class TensorIndexTypeC,
+          UpLo ValenceA, UpLo ValenceB, UpLo ValenceC, typename TensorIndexA,
+          typename TensorIndexB, typename TensorIndexC>
+void test_compute_rhs_tensor_index_rank_3_no_symmetry(
+    const TensorIndexA& tensorindex_a, const TensorIndexB& tensorindex_b,
+    const TensorIndexC& tensorindex_c) noexcept {
+#define DIM_A(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DIM_B(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define DIM_C(data) BOOST_PP_TUPLE_ELEM(2, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(3, data)
+
+#define CALL_TEST_COMPUTE_RHS_TENSOR_INDEX_RANK_3_IMPL(_, data)          \
+  test_compute_rhs_tensor_index_rank_3_impl<                             \
+      DataType, Symmetry<3, 2, 1>,                                       \
+      index_list<TensorIndexTypeA<DIM_A(data), ValenceA, FRAME(data)>,   \
+                 TensorIndexTypeB<DIM_B(data), ValenceB, FRAME(data)>,   \
+                 TensorIndexTypeC<DIM_C(data), ValenceC, FRAME(data)>>>( \
+      tensorindex_a, tensorindex_b, tensorindex_c);
+
+  GENERATE_INSTANTIATIONS(CALL_TEST_COMPUTE_RHS_TENSOR_INDEX_RANK_3_IMPL,
+                          (1, 2, 3), (1, 2, 3), (1, 2, 3),
+                          (Frame::Grid, Frame::Inertial))
+
+#undef CALL_TEST_COMPUTE_RHS_TENSOR_INDEX_RANK_3_IMPL
+#undef FRAME
+#undef DIM_C
+#undef DIM_B
+#undef DIM_A
+}
+
+/// \ingroup TestingFrameworkGroup
+/// \copydoc test_compute_rhs_tensor_index_rank_3_no_symmetry()
+template <typename DataType,
+          template <size_t, UpLo, typename> class TensorIndexTypeAB,
+          template <size_t, UpLo, typename> class TensorIndexTypeC,
+          UpLo ValenceAB, UpLo ValenceC, typename TensorIndexA,
+          typename TensorIndexB, typename TensorIndexC>
+void test_compute_rhs_tensor_index_rank_3_ab_symmetry(
+    const TensorIndexA& tensorindex_a, const TensorIndexB& tensorindex_b,
+    const TensorIndexC& tensorindex_c) noexcept {
+#define DIM_AB(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DIM_C(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define CALL_TEST_COMPUTE_RHS_TENSOR_INDEX_RANK_3_IMPL(_, data)            \
+  test_compute_rhs_tensor_index_rank_3_impl<                               \
+      DataType, Symmetry<2, 2, 1>,                                         \
+      index_list<TensorIndexTypeAB<DIM_AB(data), ValenceAB, FRAME(data)>,  \
+                 TensorIndexTypeAB<DIM_AB(data), ValenceAB, FRAME(data)>,  \
+                 TensorIndexTypeC<DIM_C(data), ValenceC, FRAME(data)>>>(   \
+      tensorindex_a, tensorindex_b, tensorindex_c);
+
+  GENERATE_INSTANTIATIONS(CALL_TEST_COMPUTE_RHS_TENSOR_INDEX_RANK_3_IMPL,
+                          (1, 2, 3), (1, 2, 3), (Frame::Grid, Frame::Inertial))
+
+#undef CALL_TEST_COMPUTE_RHS_TENSOR_INDEX_RANK_3_IMPL
+#undef FRAME
+#undef DIM_C
+#undef DIM_AB
+}
+
+/// \ingroup TestingFrameworkGroup
+/// \copydoc test_compute_rhs_tensor_index_rank_3_no_symmetry()
+template <typename DataType,
+          template <size_t, UpLo, typename> class TensorIndexTypeAC,
+          template <size_t, UpLo, typename> class TensorIndexTypeB,
+          UpLo ValenceAC, UpLo ValenceB, typename TensorIndexA,
+          typename TensorIndexB, typename TensorIndexC>
+void test_compute_rhs_tensor_index_rank_3_ac_symmetry(
+    const TensorIndexA& tensorindex_a, const TensorIndexB& tensorindex_b,
+    const TensorIndexC& tensorindex_c) noexcept {
+#define DIM_AC(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DIM_B(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define CALL_TEST_COMPUTE_RHS_TENSOR_INDEX_RANK_3_IMPL(_, data)             \
+  test_compute_rhs_tensor_index_rank_3_impl<                                \
+      DataType, Symmetry<2, 1, 2>,                                          \
+      index_list<TensorIndexTypeAC<DIM_AC(data), ValenceAC, FRAME(data)>,   \
+                 TensorIndexTypeB<DIM_B(data), ValenceB, FRAME(data)>,      \
+                 TensorIndexTypeAC<DIM_AC(data), ValenceAC, FRAME(data)>>>( \
+      tensorindex_a, tensorindex_b, tensorindex_c);
+
+  GENERATE_INSTANTIATIONS(CALL_TEST_COMPUTE_RHS_TENSOR_INDEX_RANK_3_IMPL,
+                          (1, 2, 3), (1, 2, 3), (Frame::Grid, Frame::Inertial))
+
+#undef CALL_TEST_COMPUTE_RHS_TENSOR_INDEX_RANK_3_IMPL
+#undef FRAME
+#undef DIM_B
+#undef DIM_AC
+}
+
+/// \ingroup TestingFrameworkGroup
+/// \copydoc test_compute_rhs_tensor_index_rank_3_no_symmetry()
+template <typename DataType,
+          template <size_t, UpLo, typename> class TensorIndexTypeA,
+          template <size_t, UpLo, typename> class TensorIndexTypeBC,
+          UpLo ValenceA, UpLo ValenceBC, typename TensorIndexA,
+          typename TensorIndexB, typename TensorIndexC>
+void test_compute_rhs_tensor_index_rank_3_bc_symmetry(
+    const TensorIndexA& tensorindex_a, const TensorIndexB& tensorindex_b,
+    const TensorIndexC& tensorindex_c) noexcept {
+#define DIM_A(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DIM_BC(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define CALL_TEST_COMPUTE_RHS_TENSOR_INDEX_RANK_3_IMPL(_, data)             \
+  test_compute_rhs_tensor_index_rank_3_impl<                                \
+      DataType, Symmetry<2, 1, 1>,                                          \
+      index_list<TensorIndexTypeA<DIM_A(data), ValenceA, FRAME(data)>,      \
+                 TensorIndexTypeBC<DIM_BC(data), ValenceBC, FRAME(data)>,   \
+                 TensorIndexTypeBC<DIM_BC(data), ValenceBC, FRAME(data)>>>( \
+      tensorindex_a, tensorindex_b, tensorindex_c);
+
+  GENERATE_INSTANTIATIONS(CALL_TEST_COMPUTE_RHS_TENSOR_INDEX_RANK_3_IMPL,
+                          (1, 2, 3), (1, 2, 3), (Frame::Grid, Frame::Inertial))
+
+#undef CALL_TEST_COMPUTE_RHS_TENSOR_INDEX_RANK_3_IMPL
+#undef FRAME
+#undef DIM_BC
+#undef DIM_A
+}
+
+/// \ingroup TestingFrameworkGroup
+/// \copydoc test_compute_rhs_tensor_index_rank_3_no_symmetry()
+template <typename DataType,
+          template <size_t, UpLo, typename> class TensorIndexType, UpLo Valence,
+          typename TensorIndexA, typename TensorIndexB, typename TensorIndexC>
+void test_compute_rhs_tensor_index_rank_3_abc_symmetry(
+    const TensorIndexA& tensorindex_a, const TensorIndexB& tensorindex_b,
+    const TensorIndexC& tensorindex_c) noexcept {
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define CALL_TEST_COMPUTE_RHS_TENSOR_INDEX_RANK_3_IMPL(_, data)      \
+  test_compute_rhs_tensor_index_rank_3_impl<                         \
+      DataType, Symmetry<1, 1, 1>,                                   \
+      index_list<TensorIndexType<DIM(data), Valence, FRAME(data)>,   \
+                 TensorIndexType<DIM(data), Valence, FRAME(data)>,   \
+                 TensorIndexType<DIM(data), Valence, FRAME(data)>>>( \
+      tensorindex_a, tensorindex_b, tensorindex_c);
+
+  GENERATE_INSTANTIATIONS(CALL_TEST_COMPUTE_RHS_TENSOR_INDEX_RANK_3_IMPL,
+                          (1, 2, 3), (Frame::Grid, Frame::Inertial))
+
+#undef CALL_TEST_COMPUTE_RHS_TENSOR_INDEX_RANK_3_IMPL
+#undef FRAME
+#undef DIM
+}
+
+}  // namespace TestHelpers::TensorExpressions

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/ComputeRhsTensorIndexRank4TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/ComputeRhsTensorIndexRank4TestHelpers.hpp
@@ -1,0 +1,252 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace TestHelpers::TensorExpressions {
+
+/// \ingroup TestingFrameworkGroup
+/// \brief Test that the computed tensor multi-index of a rank 4 RHS Tensor is
+/// equivalent to the given LHS tensor multi-index, according to the order of
+/// their generic indices
+///
+/// \details `TensorIndexA`, `TensorIndexB`, `TensorIndexC`, and  `TensorIndexD`
+/// can be any type of TensorIndex and are not necessarily `ti_a_t`, `ti_b_t`,
+/// `ti_c_t`, and `ti_d_t`. The "A", "B", "C", and "D" suffixes just denote the
+/// ordering of the generic indices of the RHS tensor expression. In the RHS
+/// tensor expression, it means `TensorIndexA` is the first index used,
+/// `TensorIndexB` is the second index used, `TensorIndexC` is the third index
+/// used, and `TensorIndexD` is the fourth index used.
+///
+/// If we consider the RHS tensor's generic indices to be (a, b, c, d), there
+/// are 24 permutations that are possible orderings of the LHS tensor's generic
+/// indices, such as: (a, b, c, d), e.g. (a, b, d, c), (a, c, b, d), etc. For
+/// each of these cases, this test checks that for each LHS component's tensor
+/// multi-index, the equivalent RHS tensor multi-index is correctly computed.
+///
+/// \tparam DataType the type of data being stored in the Tensors
+/// \tparam RhsSymmetry the ::Symmetry of the RHS Tensor
+/// \tparam RhsTensorIndexTypeList the RHS Tensor's typelist of
+/// \ref SpacetimeIndex "TensorIndexType"s
+/// \param tensorindex_a the first TensorIndex used on the RHS of the
+/// TensorExpression, e.g. `ti_a`
+/// \param tensorindex_b the second TensorIndex used on the RHS of the
+/// TensorExpression, e.g. `ti_B`
+/// \param tensorindex_c the third TensorIndex used on the RHS of the
+/// TensorExpression, e.g. `ti_c`
+/// \param tensorindex_d the fourth TensorIndex used on the RHS of the
+/// TensorExpression, e.g. `ti_D`
+template <typename DataType, typename RhsSymmetry,
+          typename RhsTensorIndexTypeList, typename TensorIndexA,
+          typename TensorIndexB, typename TensorIndexC, typename TensorIndexD>
+void test_compute_rhs_tensor_index_rank_4(
+    const TensorIndexA& tensorindex_a, const TensorIndexB& tensorindex_b,
+    const TensorIndexC& tensorindex_c,
+    const TensorIndexD& tensorindex_d) noexcept {
+  const Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList> rhs_tensor(5_st);
+  // Get TensorExpression from RHS tensor
+  const auto R_abcd =
+      rhs_tensor(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d);
+
+  const std::array<size_t, 4> index_order_abcd = {
+      TensorIndexA::value, TensorIndexB::value, TensorIndexC::value,
+      TensorIndexD::value};
+  const std::array<size_t, 4> index_order_abdc = {
+      TensorIndexA::value, TensorIndexB::value, TensorIndexD::value,
+      TensorIndexC::value};
+  const std::array<size_t, 4> index_order_acbd = {
+      TensorIndexA::value, TensorIndexC::value, TensorIndexB::value,
+      TensorIndexD::value};
+  const std::array<size_t, 4> index_order_acdb = {
+      TensorIndexA::value, TensorIndexC::value, TensorIndexD::value,
+      TensorIndexB::value};
+  const std::array<size_t, 4> index_order_adbc = {
+      TensorIndexA::value, TensorIndexD::value, TensorIndexB::value,
+      TensorIndexC::value};
+  const std::array<size_t, 4> index_order_adcb = {
+      TensorIndexA::value, TensorIndexD::value, TensorIndexC::value,
+      TensorIndexB::value};
+
+  const std::array<size_t, 4> index_order_bacd = {
+      TensorIndexB::value, TensorIndexA::value, TensorIndexC::value,
+      TensorIndexD::value};
+  const std::array<size_t, 4> index_order_badc = {
+      TensorIndexB::value, TensorIndexA::value, TensorIndexD::value,
+      TensorIndexC::value};
+  const std::array<size_t, 4> index_order_bcad = {
+      TensorIndexB::value, TensorIndexC::value, TensorIndexA::value,
+      TensorIndexD::value};
+  const std::array<size_t, 4> index_order_bcda = {
+      TensorIndexB::value, TensorIndexC::value, TensorIndexD::value,
+      TensorIndexA::value};
+  const std::array<size_t, 4> index_order_bdac = {
+      TensorIndexB::value, TensorIndexD::value, TensorIndexA::value,
+      TensorIndexC::value};
+  const std::array<size_t, 4> index_order_bdca = {
+      TensorIndexB::value, TensorIndexD::value, TensorIndexC::value,
+      TensorIndexA::value};
+
+  const std::array<size_t, 4> index_order_cabd = {
+      TensorIndexC::value, TensorIndexA::value, TensorIndexB::value,
+      TensorIndexD::value};
+  const std::array<size_t, 4> index_order_cadb = {
+      TensorIndexC::value, TensorIndexA::value, TensorIndexD::value,
+      TensorIndexB::value};
+  const std::array<size_t, 4> index_order_cbad = {
+      TensorIndexC::value, TensorIndexB::value, TensorIndexA::value,
+      TensorIndexD::value};
+  const std::array<size_t, 4> index_order_cbda = {
+      TensorIndexC::value, TensorIndexB::value, TensorIndexD::value,
+      TensorIndexA::value};
+  const std::array<size_t, 4> index_order_cdab = {
+      TensorIndexC::value, TensorIndexD::value, TensorIndexA::value,
+      TensorIndexB::value};
+  const std::array<size_t, 4> index_order_cdba = {
+      TensorIndexC::value, TensorIndexD::value, TensorIndexB::value,
+      TensorIndexA::value};
+
+  const std::array<size_t, 4> index_order_dabc = {
+      TensorIndexD::value, TensorIndexA::value, TensorIndexB::value,
+      TensorIndexC::value};
+  const std::array<size_t, 4> index_order_dacb = {
+      TensorIndexD::value, TensorIndexA::value, TensorIndexC::value,
+      TensorIndexB::value};
+  const std::array<size_t, 4> index_order_dbac = {
+      TensorIndexD::value, TensorIndexB::value, TensorIndexA::value,
+      TensorIndexC::value};
+  const std::array<size_t, 4> index_order_dbca = {
+      TensorIndexD::value, TensorIndexB::value, TensorIndexC::value,
+      TensorIndexA::value};
+  const std::array<size_t, 4> index_order_dcab = {
+      TensorIndexD::value, TensorIndexC::value, TensorIndexA::value,
+      TensorIndexB::value};
+  const std::array<size_t, 4> index_order_dcba = {
+      TensorIndexD::value, TensorIndexC::value, TensorIndexB::value,
+      TensorIndexA::value};
+
+  const size_t dim_a = tmpl::at_c<RhsTensorIndexTypeList, 0>::dim;
+  const size_t dim_b = tmpl::at_c<RhsTensorIndexTypeList, 1>::dim;
+  const size_t dim_c = tmpl::at_c<RhsTensorIndexTypeList, 2>::dim;
+  const size_t dim_d = tmpl::at_c<RhsTensorIndexTypeList, 3>::dim;
+
+  for (size_t i = 0; i < dim_a; i++) {
+    for (size_t j = 0; j < dim_b; j++) {
+      for (size_t k = 0; k < dim_c; k++) {
+        for (size_t l = 0; l < dim_d; l++) {
+          const std::array<size_t, 4> ijkl = {i, j, k, l};
+          const std::array<size_t, 4> ijlk = {i, j, l, k};
+          const std::array<size_t, 4> ikjl = {i, k, j, l};
+          const std::array<size_t, 4> iklj = {i, k, l, j};
+          const std::array<size_t, 4> iljk = {i, l, j, k};
+          const std::array<size_t, 4> ilkj = {i, l, k, j};
+
+          const std::array<size_t, 4> jikl = {j, i, k, l};
+          const std::array<size_t, 4> jilk = {j, i, l, k};
+          const std::array<size_t, 4> jkil = {j, k, i, l};
+          const std::array<size_t, 4> jkli = {j, k, l, i};
+          const std::array<size_t, 4> jlik = {j, l, i, k};
+          const std::array<size_t, 4> jlki = {j, l, k, i};
+
+          const std::array<size_t, 4> kijl = {k, i, j, l};
+          const std::array<size_t, 4> kilj = {k, i, l, j};
+          const std::array<size_t, 4> kjil = {k, j, i, l};
+          const std::array<size_t, 4> kjli = {k, j, l, i};
+          const std::array<size_t, 4> klij = {k, l, i, j};
+          const std::array<size_t, 4> klji = {k, l, j, i};
+
+          const std::array<size_t, 4> lijk = {l, i, j, k};
+          const std::array<size_t, 4> likj = {l, i, k, j};
+          const std::array<size_t, 4> ljik = {l, j, i, k};
+          const std::array<size_t, 4> ljki = {l, j, k, i};
+          const std::array<size_t, 4> lkij = {l, k, i, j};
+          const std::array<size_t, 4> lkji = {l, k, j, i};
+
+          // For L_{abcd} = R_{abcd}, check that L_{ijkl} == R_{ijkl}
+          CHECK(R_abcd.compute_rhs_tensor_index(
+                    index_order_abcd, index_order_abcd, ijkl) == ijkl);
+          // For L_{abdc} = R_{abcd}, check that L_{ijkl} == R_{ijlk}
+          CHECK(R_abcd.compute_rhs_tensor_index(
+                    index_order_abdc, index_order_abcd, ijkl) == ijlk);
+          // For L_{acbd} = R_{abcd}, check that L_{ijkl} == R_{ikjl}
+          CHECK(R_abcd.compute_rhs_tensor_index(
+                    index_order_acbd, index_order_abcd, ijkl) == ikjl);
+          // For L_{acdb} = R_{abcd}, check that L_{ijkl} == R_{iklj}
+          CHECK(R_abcd.compute_rhs_tensor_index(
+                    index_order_acdb, index_order_abcd, ijkl) == iljk);
+          // For L_{adbc} = R_{abcd}, check that L_{ijkl} == R_{iklj}
+          CHECK(R_abcd.compute_rhs_tensor_index(
+                    index_order_adbc, index_order_abcd, ijkl) == iklj);
+          // For L_{adcb} = R_{abcd}, check that L_{ijkl} == R_{ilkj}
+          CHECK(R_abcd.compute_rhs_tensor_index(
+                    index_order_adcb, index_order_abcd, ijkl) == ilkj);
+
+          // For L_{bacd} = R_{abcd}, check that L_{ijkl} == R_{jikl}
+          CHECK(R_abcd.compute_rhs_tensor_index(
+                    index_order_bacd, index_order_abcd, ijkl) == jikl);
+          // For L_{badc} = R_{abcd}, check that L_{ijkl} == R_{jilk}
+          CHECK(R_abcd.compute_rhs_tensor_index(
+                    index_order_badc, index_order_abcd, ijkl) == jilk);
+          // For L_{bcad} = R_{abcd}, check that L_{ijkl} == R_{kijl}
+          CHECK(R_abcd.compute_rhs_tensor_index(
+                    index_order_bcad, index_order_abcd, ijkl) == kijl);
+          // For L_{bcda} = R_{abcd}, check that L_{ijkl} == R_{lijk}
+          CHECK(R_abcd.compute_rhs_tensor_index(
+                    index_order_bcda, index_order_abcd, ijkl) == lijk);
+          // For L_{bdac} = R_{abcd}, check that L_{ijkl} == R_{kilj}
+          CHECK(R_abcd.compute_rhs_tensor_index(
+                    index_order_bdac, index_order_abcd, ijkl) == kilj);
+          // For L_{bdca} = R_{abcd}, check that L_{ijkl} == R_{likj}
+          CHECK(R_abcd.compute_rhs_tensor_index(
+                    index_order_bdca, index_order_abcd, ijkl) == likj);
+
+          // For L_{cabd} = R_{abcd}, check that L_{ijkl} == R_{jkil}
+          CHECK(R_abcd.compute_rhs_tensor_index(
+                    index_order_cabd, index_order_abcd, ijkl) == jkil);
+          // For L_{cadb} = R_{abcd}, check that L_{ijkl} == R_{jlik}
+          CHECK(R_abcd.compute_rhs_tensor_index(
+                    index_order_cadb, index_order_abcd, ijkl) == jlik);
+          // For L_{cbad} = R_{abcd}, check that L_{ijkl} == R_{kjil}
+          CHECK(R_abcd.compute_rhs_tensor_index(
+                    index_order_cbad, index_order_abcd, ijkl) == kjil);
+          // For L_{cbda} = R_{abcd}, check that L_{ijkl} == R_{ljik}
+          CHECK(R_abcd.compute_rhs_tensor_index(
+                    index_order_cbda, index_order_abcd, ijkl) == ljik);
+          // For L_{cdab} = R_{abcd}, check that L_{ijkl} == R_{klij}
+          CHECK(R_abcd.compute_rhs_tensor_index(
+                    index_order_cdab, index_order_abcd, ijkl) == klij);
+          // For L_{cdba} = R_{abcd}, check that L_{ijkl} == R_{lkij}
+          CHECK(R_abcd.compute_rhs_tensor_index(
+                    index_order_cdba, index_order_abcd, ijkl) == lkij);
+
+          // For L_{dabc} = R_{abcd}, check that L_{ijkl} == R_{jkli}
+          CHECK(R_abcd.compute_rhs_tensor_index(
+                    index_order_dabc, index_order_abcd, ijkl) == jkli);
+          // For L_{dacb} = R_{abcd}, check that L_{ijkl} == R_{jlki}
+          CHECK(R_abcd.compute_rhs_tensor_index(
+                    index_order_dacb, index_order_abcd, ijkl) == jlki);
+          // For L_{dbac} = R_{abcd}, check that L_{ijkl} == R_{kjli}
+          CHECK(R_abcd.compute_rhs_tensor_index(
+                    index_order_dbac, index_order_abcd, ijkl) == kjli);
+          // For L_{dbca} = R_{abcd}, check that L_{ijkl} == R_{ljki}
+          CHECK(R_abcd.compute_rhs_tensor_index(
+                    index_order_dbca, index_order_abcd, ijkl) == ljki);
+          // For L_{dcab} = R_{abcd}, check that L_{ijkl} == R_{klji}
+          CHECK(R_abcd.compute_rhs_tensor_index(
+                    index_order_dcab, index_order_abcd, ijkl) == klji);
+          // For L_{dcba} = R_{abcd}, check that L_{ijkl} == R_{lkji}
+          CHECK(R_abcd.compute_rhs_tensor_index(
+                    index_order_dcba, index_order_abcd, ijkl) == lkji);
+        }
+      }
+    }
+  }
+}
+
+}  // namespace TestHelpers::TensorExpressions


### PR DESCRIPTION
## Proposed changes

This PR adds a `get` function to the `TensorExpression` and `AddSub` structs that takes the storage index of a LHS tensor component, as opposed to the structs' existing `get` functions that take a LHS tensor component's multi-index. In addition, the `Tensor` constructor called by `TensorExpressions::evaluate` is updated to use this new storage index `get` instead of the existing `get` that takes a tensor multi-index. The motivation for adding this feature is to provide a faster lookup of tensor components when evaluating `TensorExpression`s.

The unit test added tests a helper function used by this `get` and follows the same testing pattern used for [this existing unit test](https://github.com/sxs-collaboration/spectre/blob/bcfdc07b657ee4c7d4861060178c0bb69056aa07/tests/Unit/DataStructures/Tensor/Expressions/Test_TensorExpressions.cpp#L21) for `TensorExpressions::evaluate`.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

**On the new `get`**
Evaluating `TensorExpression`s currently relies on the existing `get` functions that take a LHS tensor multi-index to access and manipulate components. To do this, when a LHS tensor multi-index of a component is provided, the equivalent RHS multi-index is needed. While a mapping between the two is computed at compile time, at runtime: (i) the equivalent RHS multi-index is generated from the mapping, (ii) the storage index of this RHS multi-index is computed, and (iii) the component is then accessed using this storage index. This new storage index `get` instead computes a mapping between the LHS and RHS components' storage indices at compile time. With this storage index mapping pre-computed, `get`ting the RHS component that corresponds to the input LHS storage index is done with a simple array lookup using the map. In effect, this replaces steps (i) and (ii) with an array lookup.

**On the unit test**
The added unit test tests the new `TensorExpression` function, `compute_rhs_tensor_index`, which is helper function used by the new storage index `get` to help generate the storage index mapping. A new unit test was not added for the new `TensorExpression` and `AddSub` struct `get` functions because the update that changes the `Tensor` constructor called by `TensorExpressions::evaluate` to use this storage index `get` means that these two new `get` functions are now indirectly tested through the calls to `TensorExpressions::evaluate` in the existing unit tests for `TensorExpressions::evaluate` and `AddSub`, found [here](https://github.com/sxs-collaboration/spectre/blob/bcfdc07b657ee4c7d4861060178c0bb69056aa07/tests/Unit/DataStructures/Tensor/Expressions/Test_TensorExpressions.cpp#L21) and [here](https://github.com/sxs-collaboration/spectre/blob/bcfdc07b657ee4c7d4861060178c0bb69056aa07/tests/Unit/DataStructures/Tensor/Expressions/Test_TensorExpressions.cpp#L250), respectively. Note that the latter was moved to its own file in this PR (`Test_AddSubtract.cpp`) to separate general `TensorExpression` testing from the testing of its derived types. Because this will mean that the tensor-index `get` functions are no longer being called and indirectly tested, this might mean that unit tests should now be added to directly test them. They currently are indirectly tested through the existing calls to `TensorExpressions::evaluate` in the two tests mentioned above, since the `Tensor` constructor called by `TensorExpressions::evaluate` currently uses the multi-index `get`.