### PR TITLE
Add not_null overload of dg::lift_flux

### DIFF
--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/LiftFlux.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/LiftFlux.hpp
@@ -13,9 +13,11 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace dg {
+// @{
 /// \ingroup DiscontinuousGalerkinGroup
 /// \brief Lifts the flux contribution from an interface to the volume.
 ///
@@ -36,12 +38,13 @@ namespace dg {
 ///
 /// \note The result is still provided only on the boundary grid.  The
 /// values away from the boundary are zero and are not stored.
-template <typename... FluxTags>
-auto lift_flux(Variables<tmpl::list<FluxTags...>> flux,
-               const size_t extent_perpendicular_to_boundary,
-               Scalar<DataVector> magnitude_of_face_normal) noexcept
-    -> Variables<tmpl::list<db::remove_tag_prefix<FluxTags>...>> {
-  auto lift_factor = std::move(get(magnitude_of_face_normal));
+template <typename... BoundaryCorrectionTags>
+void lift_flux(
+    const gsl::not_null<Variables<tmpl::list<BoundaryCorrectionTags...>>*>
+        boundary_correction_terms,
+    const size_t extent_perpendicular_to_boundary,
+    Scalar<DataVector> magnitude_of_face_normal) noexcept {
+  DataVector lift_factor = std::move(get(magnitude_of_face_normal));
   // For an Nth degree basis (i.e., one with N+1 basis functions), the LGL
   // weights are:
   //   w_i = 2 / ((N + 1) * N * (P_{N}(xi_i))^2)
@@ -56,9 +59,19 @@ auto lift_flux(Variables<tmpl::list<FluxTags...>> flux,
       -0.5 * static_cast<double>((extent_perpendicular_to_boundary *
                                   (extent_perpendicular_to_boundary - 1)));
 
+  *boundary_correction_terms *= lift_factor;
+}
+
+template <typename... FluxTags>
+auto lift_flux(Variables<tmpl::list<FluxTags...>> flux,
+               const size_t extent_perpendicular_to_boundary,
+               Scalar<DataVector> magnitude_of_face_normal) noexcept
+    -> Variables<tmpl::list<db::remove_tag_prefix<FluxTags>...>> {
   Variables<tmpl::list<db::remove_tag_prefix<FluxTags>...>> lifted_data(
       std::move(flux));
-  lifted_data *= lift_factor;
+  lift_flux(make_not_null(&lifted_data), extent_perpendicular_to_boundary,
+            std::move(magnitude_of_face_normal));
   return lifted_data;
 }
+// @}
 }  // namespace dg


### PR DESCRIPTION
## Proposed changes

Add `gsl::not_null` overload of `dg::lift_flux`. I end up using this in the new boundary code because I already have the allocation.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
