### PR TITLE
Add Jacobian simple and compute tags

### DIFF
--- a/src/ApparentHorizons/Tags.cpp
+++ b/src/ApparentHorizons/Tags.cpp
@@ -13,6 +13,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
+/// \cond
 namespace StrahlkorperTags {
 
 template <typename Frame>
@@ -271,3 +272,4 @@ template struct LaplacianRadiusCompute<Frame::Inertial>;
 template struct NormalOneFormCompute<Frame::Inertial>;
 template struct TangentsCompute<Frame::Inertial>;
 }  // namespace StrahlkorperTags
+/// \endcond

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -194,6 +194,22 @@ struct InverseJacobianCompute
 
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup
+/// \brief The Jacobian from the source frame to the target frame.
+///
+/// Specifically, \f$\partial x^{i} / \partial \xi^{\bar{i}}\f$, where
+/// \f$\xi^\bar{i}\f$ denotes the source frame and \f$x^i\f$ denotes the target
+/// frame.
+template <size_t Dim, typename SourceFrame, typename TargetFrame>
+struct Jacobian : db::SimpleTag {
+  static std::string name() noexcept {
+    return "Jacobian(" + get_output(SourceFrame{}) + "," +
+           get_output(TargetFrame{}) + ")";
+  }
+  using type = ::Jacobian<DataVector, Dim, SourceFrame, TargetFrame>;
+};
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ComputationalDomainGroup
 /// \brief The determinant of the inverse Jacobian from the source frame to the
 /// target frame.
 template <typename SourceFrame, typename TargetFrame>

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -19,6 +19,7 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataBox/TagName.hpp"
 #include "DataStructures/Tensor/EagerMath/Determinant.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/OptionTags.hpp"
@@ -206,6 +207,24 @@ struct Jacobian : db::SimpleTag {
            get_output(TargetFrame{}) + ")";
   }
   using type = ::Jacobian<DataVector, Dim, SourceFrame, TargetFrame>;
+};
+
+/// \ingroup ComputationalDomainGroup
+/// Computes the Jacobian of the map from the `InverseJacobian<Dim, SourceFrame,
+/// TargetFrame>` tag.
+template <size_t Dim, typename SourceFrame, typename TargetFrame>
+struct JacobianCompute : Jacobian<Dim, SourceFrame, TargetFrame>,
+                         db::ComputeTag {
+  using base = Jacobian<Dim, SourceFrame, TargetFrame>;
+  using return_type = typename base::type;
+  using argument_tags =
+      tmpl::list<InverseJacobian<Dim, SourceFrame, TargetFrame>>;
+  static constexpr auto function(
+      const gsl::not_null<return_type*> jacobian,
+      const ::InverseJacobian<DataVector, Dim, SourceFrame, TargetFrame>&
+          inv_jac) noexcept {
+    *jacobian = determinant_and_inverse(inv_jac).second;
+  }
 };
 
 /// \ingroup DataBoxTagsGroup

--- a/tests/Unit/Domain/Test_Tags.cpp
+++ b/tests/Unit/Domain/Test_Tags.cpp
@@ -119,11 +119,15 @@ void test_compute_tags() noexcept {
   TestHelpers::db::test_compute_tag<Tags::MappedCoordinates<
       Tags::ElementMap<Dim>, Tags::Coordinates<Dim, Frame::Logical>>>(
       "InertialCoordinates");
+  TestHelpers::db::test_compute_tag<
+      Tags::JacobianCompute<Dim, Frame::Logical, Frame::Inertial>>(
+      "Jacobian(Logical,Inertial)");
 
   auto map = element_map<Dim>();
   const tnsr::I<DataVector, Dim, Frame::Logical> logical_coords(
       make_array<Dim>(DataVector{-1.0, -0.5, 0.0, 0.5, 1.0}));
   const auto expected_inv_jacobian = map.inv_jacobian(logical_coords);
+  const auto expected_jacobian = map.jacobian(logical_coords);
 
   const auto box = db::create<
       tmpl::list<Tags::ElementMap<Dim, Frame::Grid>,
@@ -131,7 +135,8 @@ void test_compute_tags() noexcept {
       db::AddComputeTags<
           Tags::InverseJacobianCompute<Tags::ElementMap<Dim, Frame::Grid>,
                                        Tags::Coordinates<Dim, Frame::Logical>>,
-          Tags::DetInvJacobianCompute<Dim, Frame::Logical, Frame::Grid>>>(
+          Tags::DetInvJacobianCompute<Dim, Frame::Logical, Frame::Grid>,
+          Tags::JacobianCompute<Dim, Frame::Logical, Frame::Grid>>>(
       std::move(map), logical_coords);
   CHECK_ITERABLE_APPROX(
       (db::get<Tags::InverseJacobian<Dim, Frame::Logical, Frame::Grid>>(box)),
@@ -139,6 +144,9 @@ void test_compute_tags() noexcept {
   CHECK_ITERABLE_APPROX(
       (db::get<Tags::DetInvJacobian<Frame::Logical, Frame::Grid>>(box)),
       determinant(expected_inv_jacobian));
+  CHECK_ITERABLE_APPROX(
+      (db::get<Tags::Jacobian<Dim, Frame::Logical, Frame::Grid>>(box)),
+      expected_jacobian);
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.Tags", "[Unit][Domain]") {

--- a/tests/Unit/Domain/Test_Tags.cpp
+++ b/tests/Unit/Domain/Test_Tags.cpp
@@ -54,6 +54,9 @@ void test_simple_tags() noexcept {
   TestHelpers::db::test_simple_tag<Tags::BoundaryDirectionsExterior<Dim>>(
       "BoundaryDirectionsExterior");
   TestHelpers::db::test_simple_tag<Tags::Direction<Dim>>("Direction");
+  TestHelpers::db::test_simple_tag<
+      Tags::Jacobian<Dim, Frame::Logical, Frame::Inertial>>(
+      "Jacobian(Logical,Inertial)");
 }
 
 template <size_t Dim>


### PR DESCRIPTION
## Proposed changes

Note that the compute tag are not optimized for moving mesh (could eliminate the Jacobian calculate there completely)

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
