### PR TITLE
Creates new write path unit_test_build_path pointing to tests/unit in build directory

### DIFF
--- a/src/Informer/InfoAtCompile.cpp
+++ b/src/Informer/InfoAtCompile.cpp
@@ -5,6 +5,10 @@
 
 std::string spectre_version() { return std::string("@SPECTRE_VERSION@"); }
 
-std::string unit_test_path() noexcept {
+std::string unit_test_build_path() noexcept {
+  return "@CMAKE_BINARY_DIR@/tests/Unit/";
+}
+
+std::string unit_test_src_path() noexcept {
   return "@CMAKE_SOURCE_DIR@/tests/Unit/";
 }

--- a/src/Informer/InfoFromBuild.hpp
+++ b/src/Informer/InfoFromBuild.hpp
@@ -41,4 +41,10 @@ std::string spectre_version();
  * \ingroup LoggingGroup
  * \brief Returns the path to the Unit test directory.
  */
-std::string unit_test_path() noexcept;
+std::string unit_test_src_path() noexcept;
+
+/*!
+ * \ingroup LoggingGroup
+ * \brief Returns the path to the Unit test directory in the build directory.
+ */
+std::string unit_test_build_path() noexcept;

--- a/src/Informer/Python/InfoAtCompile.cpp
+++ b/src/Informer/Python/InfoAtCompile.cpp
@@ -12,6 +12,7 @@ namespace py_bindings {
 void bind_info_at_compile(py::module& m) {  // NOLINT
   // Wrapper to make Build Info available from python
   m.def("spectre_version", &spectre_version);
-  m.def("unit_test_path", &unit_test_path);
+  m.def("unit_test_src_path", &unit_test_src_path);
+  m.def("unit_test_build_path", &unit_test_build_path);
 }
 }  // namespace py_bindings

--- a/tests/Unit/Framework/SetupLocalPythonEnvironment.cpp
+++ b/tests/Unit/Framework/SetupLocalPythonEnvironment.cpp
@@ -46,7 +46,8 @@ SetupLocalPythonEnvironment::SetupLocalPythonEnvironment(
       PySys_GetObject(const_cast<char *>("path"));  // NOLINT
   const auto old_paths =
       pypp::from_py_object<std::vector<std::string>>(pyob_old_paths);
-  std::string new_path = unit_test_path() + cur_dir_relative_to_unit_test_path;
+  std::string new_path =
+      unit_test_src_path()+cur_dir_relative_to_unit_test_path;
   for (const auto &p : old_paths) {
     new_path += ":";
     new_path += p;

--- a/tests/Unit/IO/Test_StellarCollapseEos.cpp
+++ b/tests/Unit/IO/Test_StellarCollapseEos.cpp
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 
-#include "DataStructures/BoostMultiArray.hpp" // IWYU pragma: keep
+#include "DataStructures/BoostMultiArray.hpp"  // IWYU pragma: keep
 #include "IO/H5/AccessType.hpp"
 #include "IO/H5/File.hpp"
 #include "IO/H5/Header.hpp"  // IWYU pragma: keep
@@ -37,7 +37,7 @@ void test_tabulated(const std::string& file_path,
   // The group /sample_data has the additional dataset "test_data" which
   // is read to verify that we are not in "/"
   if (subgroup_path != "/") {
-     CHECK(sample_data.get_scalar_dataset<double>("test_data") == 317);
+    CHECK(sample_data.get_scalar_dataset<double>("test_data") == 317);
   }
 
   CHECK(sample_data.get_scalar_dataset<double>("energy_shift") == 317);
@@ -347,8 +347,9 @@ void test_tabulated(const std::string& file_path,
 }
 
 SPECTRE_TEST_CASE("Unit.IO.H5.StellarCollapseEos", "[Unit][IO][H5]") {
-  test_tabulated(unit_test_path() + "/IO/StellarCollapse2017Sample.h5", "/");
-  test_tabulated(unit_test_path() + "/IO/StellarCollapse2017Sample.h5",
+  test_tabulated(unit_test_src_path() + "/IO/StellarCollapse2017Sample.h5",
+                 "/");
+  test_tabulated(unit_test_src_path() + "/IO/StellarCollapse2017Sample.h5",
                  "/sample_data");
 }
 }  // namespace

--- a/tests/Unit/IO/Test_VolumeData.py
+++ b/tests/Unit/IO/Test_VolumeData.py
@@ -16,7 +16,7 @@ class TestVolumeDataWriting(unittest.TestCase):
     def setUp(self):
         # The tests in this class involve inserting vol files, the h5 file
         # will be deleted and recreated for each test
-        self.file_name = os.path.join(Informer.unit_test_path(),
+        self.file_name = os.path.join(Informer.unit_test_build_path(),
                                       "IO/TestVolumeDataWriting.h5")
         if os.path.isfile(self.file_name):
             os.remove(self.file_name)
@@ -46,7 +46,7 @@ class TestVolumeData(unittest.TestCase):
     def setUp(self):
         # The tests in this class use a volume data file written using
         # the write_volume_data() function
-        self.file_name = os.path.join(Informer.unit_test_path(),
+        self.file_name = os.path.join(Informer.unit_test_build_path(),
                                       "IO/TestVolumeData.h5")
 
         if os.path.isfile(self.file_name):

--- a/tests/Unit/Informer/Test_InfoAtCompile.py
+++ b/tests/Unit/Informer/Test_InfoAtCompile.py
@@ -15,10 +15,13 @@ class TestInformer(unittest.TestCase):
     def test_spectre_version(self):
         self.assertRegex(Informer.spectre_version(), VERSION_PATTERN)
 
-    # The unit test path is unpredictable, but the last 12 characters must be
-    # '/tests/Unit/'
-    def test_unit_test_path(self):
-        self.assertEqual(Informer.unit_test_path()[-12:], '/tests/Unit/')
+    # The unit test src path and unit test build path are unpredictable,
+    # but the last 12 characters must be '/tests/Unit/'
+    def test_unit_test_src_path(self):
+        self.assertEqual(Informer.unit_test_src_path()[-12:], '/tests/Unit/')
+
+    def test_unit_test_build_path(self):
+        self.assertEqual(Informer.unit_test_build_path()[-12:], '/tests/Unit/')
 
 
 if __name__ == '__main__':

--- a/tests/Unit/Visualization/Python/Test_GenerateXdmf.py
+++ b/tests/Unit/Visualization/Python/Test_GenerateXdmf.py
@@ -16,9 +16,12 @@ except AttributeError:
 
 class TestGenerateXdmf(unittest.TestCase):
     def test_generate_xdmf(self):
-        data_file_prefix = os.path.join(spectre_informer.unit_test_path(),
+        data_file_prefix = os.path.join(spectre_informer.unit_test_src_path(),
                                         'Visualization/Python', 'VolTestData')
-        output_filename = 'Test_GenerateXdmf_output'
+        #write output file to same relative path in build directory
+        output_filename = os.path.join(spectre_informer.unit_test_build_path(),
+                                       'Visualization/Python',
+                                       'Test_GenerateXdmf_output')
         if os.path.isfile(output_filename + '.xmf'):
             os.remove(output_filename + '.xmf')
 
@@ -37,7 +40,7 @@ class TestGenerateXdmf(unittest.TestCase):
         os.remove(output_filename + '.xmf')
 
     def test_subfile_not_found(self):
-        data_file_prefix = os.path.join(spectre_informer.unit_test_path(),
+        data_file_prefix = os.path.join(spectre_informer.unit_test_src_path(),
                                         'Visualization/Python', 'VolTestData')
         output_filename = 'Test_GenerateXdmf_subfile_not_found'
         if os.path.isfile(output_filename + '.xmf'):


### PR DESCRIPTION
## Proposed changes

<!--
Addressing issue #1957, unit tests write to build/tests/unit (unit_test_build_path) and previous unit_test_path -> unit_test_src_path
-->

### Types of changes:

- [ x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
