### PR TITLE
Add matplotlib to container, remove Charm 6.8 from container

### DIFF
--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -194,7 +194,6 @@ RUN wget https://github.com/include-what-you-use/include-what-you-use/archive/cl
 # We build both Clang and GCC versions of Charm++ so that all our tests can
 # use the same build environment.
 WORKDIR /work
-ARG CHARM_GIT_TAG=v6.8.0
 # Charm doesn't support compiling with clang without symbolic links
 RUN ln -s $(which clang++-10) /usr/local/bin/clang++ \
     && ln -s $(which clang-10) /usr/local/bin/clang \
@@ -211,17 +210,8 @@ RUN ln -s $(which clang++-10) /usr/local/bin/clang++ \
 # building with Charm++ in the `tmp` directories.
 #
 # We do not build  with debug symbols and build with O2 to reduce build size.
-RUN git clone --single-branch --branch ${CHARM_GIT_TAG} --depth 1 \
-      https://github.com/UIUC-PPL/charm \
-    && cd /work/charm \
-    && git checkout ${CHARM_GIT_TAG} \
-    && ./build charm++ multicore-linux64 gcc ${PARALLEL_MAKE_ARG} -g0 -O2  \
-    && ./build charm++ multicore-linux64 clang ${PARALLEL_MAKE_ARG} -g0 -O2 \
-    && wget https://raw.githubusercontent.com/sxs-collaboration/spectre/develop/support/Charm/v6.8.patch \
-    && git apply /work/charm/v6.8.patch \
-    && rm /work/charm/v6.8.patch \
-    && rm -r /work/charm/doc /work/charm/examples
-RUN git clone https://github.com/UIUC-PPL/charm charm_6_10_2 \
+RUN git clone --single-branch --branch v6.10.2 --depth 1 \
+        https://github.com/UIUC-PPL/charm charm_6_10_2 \
     && cd /work/charm_6_10_2 \
     && git checkout v6.10.2 \
     && ./build charm++ multicore-linux-x86_64 gcc ${PARALLEL_MAKE_ARG} -g -O0 \

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -79,8 +79,8 @@ RUN add-apt-repository universe \
     && curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py \
     && python2 get-pip.py \
     && apt-get install -y python3-pip python-is-python3 \
-    && pip2 --no-cache-dir install numpy scipy h5py \
-    && pip3 --no-cache-dir install numpy scipy h5py \
+    && pip2 --no-cache-dir install numpy scipy h5py matplotlib \
+    && pip3 --no-cache-dir install numpy scipy h5py matplotlib \
     && pip2 --no-cache-dir install coverxygen beautifulsoup4 pybtex \
     && pip3 --no-cache-dir install coverxygen beautifulsoup4 pybtex \
     && pip2 --no-cache-dir install yapf==0.29.0 futures \


### PR DESCRIPTION
## Proposed changes

- Add matplotlib to container (needed for tests in #1578)
- Remove Charm 6.8 from the container since we don't support it anymore.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
