### PR TITLE
Fix clang-tidy warning in Test_TensorExpressions.cpp

### DIFF
--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_TensorExpressions.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_TensorExpressions.cpp
@@ -264,7 +264,11 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
   Tensor<double, Symmetry<2, 1>,
          index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
                     SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
-      Hll{}, HHll{};
+      Hll{};
+  Tensor<double, Symmetry<2, 1>,
+         index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
+      HHll{};
   std::iota(Hll.begin(), Hll.end(), 0.0);
   std::iota(HHll.rbegin(), HHll.rend(), -Hll.size());
   /// [use_tensor_index]
@@ -293,7 +297,12 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
          index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
                     SpatialIndex<3, UpLo::Lo, Frame::Grid>,
                     SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
-      Hlll{}, HHlll{};
+      Hlll{};
+  Tensor<double, Symmetry<1, 2, 3>,
+         index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
+      HHlll{};
   std::iota(Hlll.begin(), Hlll.end(), 0.0);
   std::iota(HHlll.rbegin(), HHlll.rend(), -Hlll.size());
   auto Glll = TensorExpressions::evaluate<ti_a_t, ti_b_t, ti_c_t>(


### PR DESCRIPTION
## Proposed changes

- Simple clang tidy fix...

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
