### PR TITLE
Add tag for DG formulation

### DIFF
--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ComputeNonconservativeBoundaryFluxes.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ComputeNonconservativeBoundaryFluxes.hpp
@@ -68,7 +68,8 @@ struct ComputeNonconservativeBoundaryFluxes {
     using variables_tag = typename system::variables_tag;
 
     using interface_normal_dot_fluxes_tag = domain::Tags::Interface<
-        DirectionsTag, db::add_tag_prefix<Tags::NormalDotFlux, variables_tag>>;
+        DirectionsTag,
+        db::add_tag_prefix<::Tags::NormalDotFlux, variables_tag>>;
 
     db::mutate_apply<
         tmpl::list<interface_normal_dot_fluxes_tag>,

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp
@@ -131,7 +131,7 @@ struct ImposeDirichletBoundaryConditions {
                 typename system::variables_tag::type::tags_list{}));
           }
         },
-        make_not_null(&box), db::get<Tags::Time>(box),
+        make_not_null(&box), db::get<::Tags::Time>(box),
         get<typename Metavariables::boundary_condition_tag>(cache),
         db::get<domain::Tags::Interface<
             domain::Tags::BoundaryDirectionsExterior<VolumeDim>,
@@ -195,7 +195,7 @@ struct ImposeDirichletBoundaryConditions {
                 tmpl::list<system>{});
           }
         },
-        make_not_null(&box), db::get<Tags::Time>(box),
+        make_not_null(&box), db::get<::Tags::Time>(box),
         get<typename Metavariables::boundary_condition_tag>(cache),
         db::get<domain::Tags::Interface<
             domain::Tags::BoundaryDirectionsExterior<VolumeDim>,

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/FirstOrderScheme.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/FirstOrderScheme.hpp
@@ -87,8 +87,8 @@ struct FirstOrderScheme {
       detail::boundary_data_computer_impl<Dim, VariablesTag,
                                           NumericalFluxComputerTag>;
 
-  using mortar_data_tag = Tags::SimpleMortarData<typename TemporalIdTag::type,
-                                                 BoundaryData, BoundaryData>;
+  using mortar_data_tag = ::Tags::SimpleMortarData<typename TemporalIdTag::type,
+                                                   BoundaryData, BoundaryData>;
 
   // Only a shortcut
   using magnitude_of_face_normal_tag =

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/FirstOrderSchemeLts.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/FirstOrderSchemeLts.hpp
@@ -100,8 +100,8 @@ struct FirstOrderSchemeLts {
   using boundary_data_computer = detail::boundary_data_computer_lts_impl<
       volume_dim, variables_tag, numerical_flux_computer_tag, BoundaryData>;
 
-  using mortar_data_tag = Tags::BoundaryHistory<BoundaryData, BoundaryData,
-                                                typename variables_tag::type>;
+  using mortar_data_tag = ::Tags::BoundaryHistory<BoundaryData, BoundaryData,
+                                                  typename variables_tag::type>;
 
   using return_tags =
       tmpl::list<variables_tag, ::Tags::Mortars<mortar_data_tag, Dim>>;

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Formulation.cpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Formulation.cpp
@@ -4,8 +4,10 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
 
 #include <ostream>
+#include <string>
 
 #include "ErrorHandling/Error.hpp"
+#include "Options/ParseOptions.hpp"
 
 namespace dg {
 std::ostream& operator<<(std::ostream& os, const Formulation t) noexcept {
@@ -19,3 +21,20 @@ std::ostream& operator<<(std::ostream& os, const Formulation t) noexcept {
   }
 }
 }  // namespace dg
+
+/// \cond
+template <>
+dg::Formulation Options::create_from_yaml<dg::Formulation>::create<void>(
+    const Options::Option& options) {
+  const auto type_read = options.parse_as<std::string>();
+  if ("StrongInertial" == type_read) {
+    return dg::Formulation::StrongInertial;
+  } else if ("WeakInertial" == type_read) {
+    return dg::Formulation::WeakInertial;
+  }
+  PARSE_ERROR(options.context(), "Failed to convert \""
+                                     << type_read
+                                     << "\" to dg::Formulation. Must be one "
+                                        "of StrongInertial or WeakInertial.");
+}
+/// \endcond

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp
@@ -5,6 +5,14 @@
 
 #include <iosfwd>
 
+/// \cond
+namespace Options {
+class Option;
+template <typename T>
+struct create_from_yaml;
+}  // namespace Options
+/// \endcond
+
 namespace dg {
 /*!
  * \ingroup DiscontinuousGalerkinGroup
@@ -27,3 +35,17 @@ enum class Formulation { StrongInertial, WeakInertial };
 
 std::ostream& operator<<(std::ostream& os, Formulation t) noexcept;
 }  // namespace dg
+
+/// \cond
+template <>
+struct Options::create_from_yaml<dg::Formulation> {
+  template <typename Metavariables>
+  static dg::Formulation create(const Options::Option& options) {
+    return create<void>(options);
+  }
+};
+
+template <>
+dg::Formulation Options::create_from_yaml<dg::Formulation>::create<void>(
+    const Options::Option& options);
+/// \endcond

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags/CMakeLists.txt
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags/CMakeLists.txt
@@ -1,9 +1,16 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+spectre_target_sources(
+  DiscontinuousGalerkin
+  PRIVATE
+  Formulation.cpp
+  )
+
 spectre_target_headers(
   DiscontinuousGalerkin
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Formulation.hpp
   OptionsGroup.hpp
   )

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags/Formulation.cpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags/Formulation.cpp
@@ -1,0 +1,13 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags/Formulation.hpp"
+
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+
+namespace dg::Tags {
+dg::Formulation Formulation::create_from_options(
+    const dg::Formulation& formulation) noexcept {
+  return formulation;
+}
+}  // namespace dg::Tags

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags/Formulation.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags/Formulation.hpp
@@ -1,0 +1,36 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags/OptionsGroup.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace dg {
+namespace OptionTags {
+struct Formulation {
+  using type = dg::Formulation;
+  using group = DiscontinuousGalerkinGroup;
+  static constexpr Options::String help =
+      "Discontinuous Galerkin formulation to use, e.g. StrongInertial for the "
+      "strong form.";
+};
+}  // namespace OptionTags
+
+namespace Tags {
+/*!
+ * \brief The DG formulation to use.
+ */
+struct Formulation : db::SimpleTag {
+  using type = dg::Formulation;
+
+  using option_tags = tmpl::list<OptionTags::Formulation>;
+  static constexpr bool pass_metavariables = false;
+  static dg::Formulation create_from_options(
+      const dg::Formulation& formulation) noexcept;
+};
+}  // namespace Tags
+}  // namespace dg

--- a/src/ParallelAlgorithms/DiscontinuousGalerkin/CollectDataForFluxes.hpp
+++ b/src/ParallelAlgorithms/DiscontinuousGalerkin/CollectDataForFluxes.hpp
@@ -100,9 +100,11 @@ struct CollectDataForFluxes<BoundaryScheme, domain::Tags::InternalDirections<
         domain::Tags::Interface<domain::Tags::InternalDirections<volume_dim>,
                                 domain::Tags::Mesh<volume_dim - 1>>>(box);
     const auto& mortar_meshes =
-        get<Tags::Mortars<domain::Tags::Mesh<volume_dim - 1>, volume_dim>>(box);
+        get<::Tags::Mortars<domain::Tags::Mesh<volume_dim - 1>, volume_dim>>(
+            box);
     const auto& mortar_sizes =
-        get<Tags::Mortars<Tags::MortarSize<volume_dim - 1>, volume_dim>>(box);
+        get<::Tags::Mortars<::Tags::MortarSize<volume_dim - 1>, volume_dim>>(
+            box);
     const auto& temporal_id = get<temporal_id_tag>(box);
     for (const auto& direction_and_neighbors : element.neighbors()) {
       const auto& direction = direction_and_neighbors.first;

--- a/src/ParallelAlgorithms/DiscontinuousGalerkin/FluxCommunication.hpp
+++ b/src/ParallelAlgorithms/DiscontinuousGalerkin/FluxCommunication.hpp
@@ -102,9 +102,8 @@ struct SendDataForFluxes {
     const auto& element = db::get<domain::Tags::Element<volume_dim>>(box);
     const auto& temporal_id = db::get<temporal_id_tag>(box);
     const auto& receive_temporal_id = db::get<receive_temporal_id_tag>(box);
-    const auto& mortar_meshes =
-        db::get<Tags::Mortars<domain::Tags::Mesh<volume_dim - 1>, volume_dim>>(
-            box);
+    const auto& mortar_meshes = db::get<
+        ::Tags::Mortars<domain::Tags::Mesh<volume_dim - 1>, volume_dim>>(box);
 
     // Iterate over neighbors
     for (const auto& direction_and_neighbors : element.neighbors()) {
@@ -285,16 +284,15 @@ struct ReceiveDataForFluxes<
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) noexcept {
     db::mutate<all_mortar_data_tag,
-               Tags::Mortars<receive_temporal_id_tag, volume_dim>>(
+               ::Tags::Mortars<receive_temporal_id_tag, volume_dim>>(
         make_not_null(&box),
-        [&inboxes](
-            const gsl::not_null<typename all_mortar_data_tag::type*>
-                mortar_data,
-            const gsl::not_null<typename Tags::Mortars<receive_temporal_id_tag,
-                                                       volume_dim>::type*>
-                neighbor_next_temporal_ids,
-            const typename receive_temporal_id_tag::type&
-                local_next_temporal_id) noexcept {
+        [&inboxes](const gsl::not_null<typename all_mortar_data_tag::type*>
+                       mortar_data,
+                   const gsl::not_null<typename ::Tags::Mortars<
+                       receive_temporal_id_tag, volume_dim>::type*>
+                       neighbor_next_temporal_ids,
+                   const typename receive_temporal_id_tag::type&
+                       local_next_temporal_id) noexcept {
           auto& inbox = tuples::get<fluxes_inbox_tag>(inboxes);
           for (auto received_data = inbox.begin();
                received_data != inbox.end() and
@@ -354,7 +352,7 @@ struct ReceiveDataForFluxes<
     const auto& inbox = tuples::get<fluxes_inbox_tag>(inboxes);
     const auto& local_next_temporal_id = db::get<receive_temporal_id_tag>(box);
     const auto& mortars_next_temporal_id =
-        db::get<Tags::Mortars<receive_temporal_id_tag, volume_dim>>(box);
+        db::get<::Tags::Mortars<receive_temporal_id_tag, volume_dim>>(box);
     for (const auto& mortar_id_next_temporal_id : mortars_next_temporal_id) {
       const auto& mortar_id = mortar_id_next_temporal_id.first;
       // If on an external boundary

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
@@ -4,6 +4,7 @@
 add_subdirectory(Actions)
 add_subdirectory(BoundarySchemes)
 add_subdirectory(NumericalFluxes)
+add_subdirectory(Tags)
 
 set(LIBRARY "Test_NumericalDiscontinuousGalerkin")
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Tags/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Tags/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_NumericalDiscontinuousGalerkinTags")
+
+set(LIBRARY_SOURCES
+  Test_Formulation.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "NumericalAlgorithms/DiscontinuousGalerkin/Tags/"
+  "${LIBRARY_SOURCES}"
+  "DataStructures;Domain;DiscontinuousGalerkin;ErrorHandling;Spectral;Utilities"
+  )

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Tags/Test_Formulation.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Tags/Test_Formulation.cpp
@@ -1,0 +1,22 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "Framework/TestCreation.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags/Formulation.hpp"
+
+SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Tags.Formulation",
+                  "[Unit][Evolution]") {
+  TestHelpers::db::test_simple_tag<dg::Tags::Formulation>("Formulation");
+  CHECK(
+      TestHelpers::test_creation<dg::Formulation, dg::OptionTags::Formulation>(
+          "StrongInertial") == dg::Formulation::StrongInertial);
+  CHECK(
+      TestHelpers::test_creation<dg::Formulation, dg::OptionTags::Formulation>(
+          "WeakInertial") == dg::Formulation::WeakInertial);
+}


### PR DESCRIPTION
## Proposed changes

Add an option tag and tag so we can store the DG formulation in the DataBox.

Note that I add a `dg::Tags` namespace so I have to add `::` in a bunch of places that use `::Tags` but are inside the `dg` namespace.

Depends on:
- [x] #2548 

Only the following commits are new:
- Add tags for dg::Formulation (with 167 additions and 22 deletions.)

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
