### PR TITLE
Add function to lift from interface when using Gauss points

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -7,9 +7,16 @@ spectre_target_headers(
   HEADERS
   DgElementArray.hpp
   InboxTags.hpp
+  LiftFromBoundary.hpp
   MortarData.hpp
   MortarTags.hpp
   ProjectToBoundary.hpp
+  )
+
+spectre_target_sources(
+  Evolution
+  PRIVATE
+  LiftFromBoundary.cpp
   )
 
 spectre_target_sources(

--- a/src/Evolution/DiscontinuousGalerkin/LiftFromBoundary.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/LiftFromBoundary.cpp
@@ -1,0 +1,243 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/DiscontinuousGalerkin/LiftFromBoundary.hpp"
+
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/StripeIterator.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace evolution::dg::detail {
+// We use a separate function in the  xi direction to avoid the expensive
+// SliceIterator
+void lift_boundary_terms_gauss_points_impl_xi_dir(
+    const gsl::not_null<double*> volume_dt_vars,
+    const size_t num_independent_components, const size_t num_volume_pts,
+    const Scalar<DataVector>& volume_det_inv_jacobian,
+    const size_t num_boundary_pts,
+    const gsl::span<const double>& boundary_corrections,
+    const DataVector& boundary_lifting_term,
+    const Scalar<DataVector>& magnitude_of_face_normal,
+    const Scalar<DataVector>& face_det_jacobian) noexcept {
+  DataVector volume_dt_vars_view{};
+  DataVector volume_inv_det_jacobian_view{};
+  for (size_t component_index = 0; component_index < num_independent_components;
+       ++component_index) {
+    const size_t stripe_size = num_volume_pts / num_boundary_pts;
+    for (size_t boundary_index = 0; boundary_index < num_boundary_pts;
+         ++boundary_index) {
+      volume_dt_vars_view.set_data_ref(volume_dt_vars.get() +
+                                           component_index * num_volume_pts +
+                                           boundary_index * stripe_size,
+                                       stripe_size);
+      // safe const_cast since used as a view
+      volume_inv_det_jacobian_view.set_data_ref(
+          // NOLINTNEXTLINE
+          const_cast<double*>(get(volume_det_inv_jacobian).data()) +
+              boundary_index * stripe_size,
+          stripe_size);
+      // Minus sign because we brought this from the LHS to the RHS.
+      volume_dt_vars_view -=
+          volume_inv_det_jacobian_view * boundary_lifting_term *
+          get(face_det_jacobian)[boundary_index] *
+          get(magnitude_of_face_normal)[boundary_index] *
+          boundary_corrections[component_index * num_boundary_pts +
+                               boundary_index];
+    }
+  }
+}
+
+// We use a separate function in the  xi direction to avoid the expensive
+// SliceIterator
+void lift_boundary_terms_gauss_points_impl_xi_dir(
+    const gsl::not_null<double*> volume_dt_vars,
+    const size_t num_independent_components, const size_t num_volume_pts,
+    const Scalar<DataVector>& volume_det_inv_jacobian,
+    const size_t num_boundary_pts,
+    const gsl::span<const double>& upper_boundary_corrections,
+    const DataVector& upper_boundary_lifting_term,
+    const Scalar<DataVector>& upper_magnitude_of_face_normal,
+    const Scalar<DataVector>& upper_face_det_jacobian,
+    const gsl::span<const double>& lower_boundary_corrections,
+    const DataVector& lower_boundary_lifting_term,
+    const Scalar<DataVector>& lower_magnitude_of_face_normal,
+    const Scalar<DataVector>& lower_face_det_jacobian) noexcept {
+  DataVector volume_dt_vars_view{};
+  DataVector volume_inv_det_jacobian_view{};
+  for (size_t component_index = 0; component_index < num_independent_components;
+       ++component_index) {
+    const size_t stripe_size = num_volume_pts / num_boundary_pts;
+    for (size_t boundary_index = 0; boundary_index < num_boundary_pts;
+         ++boundary_index) {
+      volume_dt_vars_view.set_data_ref(volume_dt_vars.get() +
+                                           component_index * num_volume_pts +
+                                           boundary_index * stripe_size,
+                                       stripe_size);
+      // safe const_cast since used as a view
+      volume_inv_det_jacobian_view.set_data_ref(
+          // NOLINTNEXTLINE
+          const_cast<double*>(get(volume_det_inv_jacobian).data()) +
+              boundary_index * stripe_size,
+          stripe_size);
+      // Minus sign because we brought this from the LHS to the RHS.
+      volume_dt_vars_view -=
+          volume_inv_det_jacobian_view *
+          (upper_boundary_lifting_term *
+               get(upper_face_det_jacobian)[boundary_index] *
+               get(upper_magnitude_of_face_normal)[boundary_index] *
+               upper_boundary_corrections[component_index * num_boundary_pts +
+                                          boundary_index] +
+           lower_boundary_lifting_term *
+               get(lower_face_det_jacobian)[boundary_index] *
+               get(lower_magnitude_of_face_normal)[boundary_index] *
+               lower_boundary_corrections[component_index * num_boundary_pts +
+                                          boundary_index]);
+    }
+  }
+}
+
+template <size_t Dim>
+void lift_boundary_terms_gauss_points_impl(
+    const gsl::not_null<double*> volume_dt_vars,
+    const size_t num_independent_components, const Mesh<Dim>& volume_mesh,
+    const size_t dimension, const Scalar<DataVector>& volume_det_inv_jacobian,
+    const size_t num_boundary_pts,
+    const gsl::span<const double>& boundary_corrections,
+    const DataVector& boundary_lifting_term,
+    const Scalar<DataVector>& magnitude_of_face_normal,
+    const Scalar<DataVector>& face_det_jacobian) noexcept {
+  const size_t num_volume_pts = volume_mesh.number_of_grid_points();
+  if (dimension == 0) {
+    lift_boundary_terms_gauss_points_impl_xi_dir(
+        volume_dt_vars, num_independent_components, num_volume_pts,
+        volume_det_inv_jacobian, num_boundary_pts, boundary_corrections,
+        boundary_lifting_term, magnitude_of_face_normal, face_det_jacobian);
+    return;
+  }
+
+  // Developer note: A potential optimization is to re-order (not transpose!)
+  // the volume time derivative for all variables before lifting, so that the
+  // lifting can be done using vectorized math and DataVectors as views. It
+  // would need to be tested whether that actually increases performance.
+  // Another alternative would be to use a SIMD library, such as nsimd or xsimd.
+
+  const size_t stripe_size = volume_mesh.extents(dimension);
+  size_t boundary_index = 0;
+  for (StripeIterator si{volume_mesh.extents(), dimension}; si;
+       (void)++si, (void)++boundary_index) {
+    // Loop over each stripe in this logical direction. This is effectively
+    // looping over each boundary grid point.
+    for (size_t component_index = 0;
+         component_index < num_independent_components; ++component_index) {
+      for (size_t index_on_stripe = 0; index_on_stripe < stripe_size;
+           ++index_on_stripe) {
+        const size_t volume_index = si.offset() + si.stride() * index_on_stripe;
+        volume_dt_vars.get()[component_index * num_volume_pts + volume_index] -=
+            get(volume_det_inv_jacobian)[volume_index] *
+            boundary_lifting_term[index_on_stripe] *
+            get(face_det_jacobian)[boundary_index] *
+            get(magnitude_of_face_normal)[boundary_index] *
+            boundary_corrections[component_index * num_boundary_pts +
+                                 boundary_index];
+      }
+    }
+  }
+}
+
+template <size_t Dim>
+void lift_boundary_terms_gauss_points_impl(
+    const gsl::not_null<double*> volume_dt_vars,
+    const size_t num_independent_components, const Mesh<Dim>& volume_mesh,
+    const size_t dimension, const Scalar<DataVector>& volume_det_inv_jacobian,
+    const size_t num_boundary_pts,
+    const gsl::span<const double>& upper_boundary_corrections,
+    const DataVector& upper_boundary_lifting_term,
+    const Scalar<DataVector>& upper_magnitude_of_face_normal,
+    const Scalar<DataVector>& upper_face_det_jacobian,
+    const gsl::span<const double>& lower_boundary_corrections,
+    const DataVector& lower_boundary_lifting_term,
+    const Scalar<DataVector>& lower_magnitude_of_face_normal,
+    const Scalar<DataVector>& lower_face_det_jacobian) noexcept {
+  const size_t num_volume_pts = volume_mesh.number_of_grid_points();
+  if (dimension == 0) {
+    lift_boundary_terms_gauss_points_impl_xi_dir(
+        volume_dt_vars, num_independent_components, num_volume_pts,
+        volume_det_inv_jacobian, num_boundary_pts, upper_boundary_corrections,
+        upper_boundary_lifting_term, upper_magnitude_of_face_normal,
+        upper_face_det_jacobian, lower_boundary_corrections,
+        lower_boundary_lifting_term, lower_magnitude_of_face_normal,
+        lower_face_det_jacobian);
+    return;
+  }
+  // Developer note: A potential optimization is to re-order (not transpose!)
+  // the volume time derivative for all variables before lifting, so that the
+  // lifting can be done using vectorized math and DataVectors as views. It
+  // would need to be tested whether that actually increases performance.
+  // Another alternative would be to use a SIMD library, such as nsimd or xsimd.
+
+  const size_t stripe_size = volume_mesh.extents(dimension);
+  size_t boundary_index = 0;
+  for (StripeIterator si{volume_mesh.extents(), dimension}; si;
+       (void)++si, (void)++boundary_index) {
+    // Loop over each stripe in this logical direction. This is effectively
+    // looping over each boundary grid point.
+    for (size_t component_index = 0;
+         component_index < num_independent_components; ++component_index) {
+      for (size_t index_on_stripe = 0; index_on_stripe < stripe_size;
+           ++index_on_stripe) {
+        const size_t volume_index = si.offset() + si.stride() * index_on_stripe;
+        volume_dt_vars.get()[component_index * num_volume_pts + volume_index] -=
+            get(volume_det_inv_jacobian)[volume_index] *
+            (upper_boundary_lifting_term[index_on_stripe] *
+                 get(upper_face_det_jacobian)[boundary_index] *
+                 get(upper_magnitude_of_face_normal)[boundary_index] *
+                 upper_boundary_corrections[component_index * num_boundary_pts +
+                                            boundary_index] +
+             lower_boundary_lifting_term[index_on_stripe] *
+                 get(lower_face_det_jacobian)[boundary_index] *
+                 get(lower_magnitude_of_face_normal)[boundary_index] *
+                 lower_boundary_corrections[component_index * num_boundary_pts +
+                                            boundary_index]);
+      }
+    }
+  }
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(r, data)                                                 \
+  template void lift_boundary_terms_gauss_points_impl(                       \
+      gsl::not_null<double*> volume_dt_vars,                                 \
+      size_t num_independent_components, const Mesh<DIM(data)>& volume_mesh, \
+      size_t dimension, const Scalar<DataVector>& volume_det_inv_jacobian,   \
+      size_t num_boundary_pts,                                               \
+      const gsl::span<const double>& boundary_corrections,                   \
+      const DataVector& boundary_lifting_term,                               \
+      const Scalar<DataVector>& magnitude_of_face_normal,                    \
+      const Scalar<DataVector>& face_det_jacobian) noexcept;                 \
+  template void lift_boundary_terms_gauss_points_impl(                       \
+      gsl::not_null<double*> volume_dt_vars,                                 \
+      size_t num_independent_components, const Mesh<DIM(data)>& volume_mesh, \
+      size_t dimension, const Scalar<DataVector>& volume_det_inv_jacobian,   \
+      size_t num_boundary_pts,                                               \
+      const gsl::span<const double>& upper_boundary_corrections,             \
+      const DataVector& upper_boundary_lifting_term,                         \
+      const Scalar<DataVector>& upper_magnitude_of_face_normal,              \
+      const Scalar<DataVector>& upper_face_det_jacobian,                     \
+      const gsl::span<const double>& lower_boundary_corrections,             \
+      const DataVector& lower_boundary_lifting_term,                         \
+      const Scalar<DataVector>& lower_magnitude_of_face_normal,              \
+      const Scalar<DataVector>& lower_face_det_jacobian) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+#undef DIM
+}  // namespace evolution::dg::detail

--- a/src/Evolution/DiscontinuousGalerkin/LiftFromBoundary.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/LiftFromBoundary.hpp
@@ -1,0 +1,175 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Side.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace evolution::dg {
+namespace detail {
+template <size_t Dim>
+void lift_boundary_terms_gauss_points_impl(
+    gsl::not_null<double*> volume_dt_vars, size_t num_independent_components,
+    const Mesh<Dim>& volume_mesh, size_t dimension,
+    const Scalar<DataVector>& volume_det_inv_jacobian, size_t num_boundary_pts,
+    const gsl::span<const double>& boundary_corrections,
+    const DataVector& boundary_lifting_term,
+    const Scalar<DataVector>& magnitude_of_face_normal,
+    const Scalar<DataVector>& face_det_jacobian) noexcept;
+
+template <size_t Dim>
+void lift_boundary_terms_gauss_points_impl(
+    gsl::not_null<double*> volume_dt_vars, size_t num_independent_components,
+    const Mesh<Dim>& volume_mesh, size_t dimension,
+    const Scalar<DataVector>& volume_det_inv_jacobian, size_t num_boundary_pts,
+    const gsl::span<const double>& upper_boundary_corrections,
+    const DataVector& upper_boundary_lifting_term,
+    const Scalar<DataVector>& upper_magnitude_of_face_normal,
+    const Scalar<DataVector>& upper_face_det_jacobian,
+    const gsl::span<const double>& lower_boundary_corrections,
+    const DataVector& lower_boundary_lifting_term,
+    const Scalar<DataVector>& lower_magnitude_of_face_normal,
+    const Scalar<DataVector>& lower_face_det_jacobian) noexcept;
+}  // namespace detail
+
+/*!
+ * \brief Lift the boundary corrections to the volume time derivatives in the
+ * specified direction.
+ *
+ * The general lifting term (for the \f$\xi\f$-dimension) is:
+ *
+ * \f{align*}{
+ * \partial_t u_{\alpha\breve{\imath}\breve{\jmath}\breve{k}}=\cdots
+ * -\frac{\ell_{\breve{\imath}}\left(\xi=1\right)}
+ *   {w_{\breve{\imath}}J_{\breve{\imath}\breve{\jmath}\breve{k}}}
+ *   \left[J\sqrt{
+ *   \frac{\partial\xi}{\partial x^i} \gamma^{ij}
+ *   \frac{\partial\xi}{\partial x^j}}
+ *   \left(G_{\alpha} + D_{\alpha}\right)
+ *   \right]_{\breve{\jmath}\breve{k}}\left(\xi=1\right),
+ * \f}
+ *
+ * where \f$\breve{\imath}\f$, \f$\breve{\jmath}\f$, and \f$\breve{k}\f$ are
+ * indices in the logical \f$\xi\f$, \f$\eta\f$, and \f$\zeta\f$ dimensions.
+ * The \f$G+D\f$ terms correspond to the `boundary_corrections` function
+ * argument, and the function Spectral::boundary_lifting_term() is used to
+ * compute and cache the terms from the lifting terms
+ * \f$\ell_{\breve{\imath}}(\xi=\pm1)/w_{\breve{\imath}}\f$.
+ *
+ * \note that normal vectors are pointing out of the element.
+ */
+template <size_t Dim, typename DtTagsList, typename BoundaryCorrectionTagsList>
+void lift_boundary_terms_gauss_points(
+    const gsl::not_null<Variables<DtTagsList>*> dt_vars,
+    const Scalar<DataVector>& volume_det_inv_jacobian,
+    const Mesh<Dim>& volume_mesh, const Direction<Dim>& direction,
+    const Variables<BoundaryCorrectionTagsList>& boundary_corrections,
+    const Scalar<DataVector>& magnitude_of_face_normal,
+    const Scalar<DataVector>& face_det_jacobian) noexcept {
+  ASSERT(std::all_of(volume_mesh.quadrature().begin(),
+                     volume_mesh.quadrature().end(),
+                     [](const Spectral::Quadrature quadrature) noexcept {
+                       return quadrature == Spectral::Quadrature::Gauss;
+                     }),
+         "Must use Gauss points in all directions but got the mesh: "
+             << volume_mesh);
+  const Mesh<Dim - 1> boundary_mesh =
+      volume_mesh.slice_away(direction.dimension());
+  const Mesh<1> volume_stripe_mesh =
+      volume_mesh.slice_through(direction.dimension());
+  const size_t num_boundary_grid_points = boundary_mesh.number_of_grid_points();
+  detail::lift_boundary_terms_gauss_points_impl(
+      make_not_null(dt_vars->data()), dt_vars->number_of_independent_components,
+      volume_mesh, direction.dimension(), volume_det_inv_jacobian,
+      num_boundary_grid_points,
+      gsl::make_span(boundary_corrections.data(), boundary_corrections.size()),
+      direction.side() == Side::Upper
+          ? Spectral::boundary_lifting_term(volume_stripe_mesh).second
+          : Spectral::boundary_lifting_term(volume_stripe_mesh).first,
+      magnitude_of_face_normal, face_det_jacobian);
+}
+
+/*!
+ * \brief Lift both the upper and lower (in logical coordinates) boundary
+ * corrections to the volume time derivatives in the specified logical
+ * dimension.
+ *
+ * The upper and lower boundary corrections in the logical `dimension` are
+ * lifted together in order to reduce the amount of striding through data that
+ * is needed and to improve cache-friendliness.
+ *
+ * The general lifting term (for the \f$\xi\f$-dimension) is:
+ *
+ * \f{align*}{
+ * \partial_t u_{\alpha\breve{\imath}\breve{\jmath}\breve{k}}=\cdots
+ * -\frac{\ell_{\breve{\imath}}\left(\xi=1\right)}
+ *   {w_{\breve{\imath}}J_{\breve{\imath}\breve{\jmath}\breve{k}}}
+ *   \left[J\sqrt{
+ *   \frac{\partial\xi}{\partial x^i} \gamma^{ij}
+ *   \frac{\partial\xi}{\partial x^j}}
+ *   \left(G_{\alpha} + D_{\alpha}\right)
+ *   \right]_{\breve{\jmath}\breve{k}}\left(\xi=1\right)
+ * - \frac{\ell_{\breve{\imath}}\left(\xi=-1\right)}
+ *   {w_{\breve{\imath}}J_{\breve{\imath}\breve{\jmath}\breve{k}}}
+ *   \left[J\sqrt{
+ *   \frac{\partial\xi}{\partial x^i} \gamma^{ij}
+ *   \frac{\partial\xi}{\partial x^j}}
+ *   \left(G_{\alpha} + D_{\alpha}\right)
+ *   \right]_{\breve{\jmath}\breve{k}}\left(\xi=-1\right),
+ * \f}
+ *
+ * where \f$\breve{\imath}\f$, \f$\breve{\jmath}\f$, and \f$\breve{k}\f$ are
+ * indices in the logical \f$\xi\f$, \f$\eta\f$, and \f$\zeta\f$ dimensions.
+ * The \f$G+D\f$ terms correspond to the `upper_boundary_corrections` and
+ * `lower_boundary_corrections` function arguments, and the function
+ * Spectral::boundary_lifting_term() is used to compute and cache the terms
+ * from the lifting terms
+ * \f$\ell_{\breve{\imath}}(\xi=\pm1)/w_{\breve{\imath}}\f$.
+ *
+ * \note that normal vectors are pointing out of the element and therefore both
+ * terms have the same sign.
+ */
+template <size_t Dim, typename DtTagsList, typename BoundaryCorrectionTagsList>
+void lift_boundary_terms_gauss_points(
+    const gsl::not_null<Variables<DtTagsList>*> dt_vars,
+    const Scalar<DataVector>& volume_det_inv_jacobian,
+    const Mesh<Dim>& volume_mesh, const size_t dimension,
+    const Variables<BoundaryCorrectionTagsList>& upper_boundary_corrections,
+    const Scalar<DataVector>& upper_magnitude_of_face_normal,
+    const Scalar<DataVector>& upper_face_det_jacobian,
+    const Variables<BoundaryCorrectionTagsList>& lower_boundary_corrections,
+    const Scalar<DataVector>& lower_magnitude_of_face_normal,
+    const Scalar<DataVector>& lower_face_det_jacobian) noexcept {
+  ASSERT(std::all_of(volume_mesh.quadrature().begin(),
+                     volume_mesh.quadrature().end(),
+                     [](const Spectral::Quadrature quadrature) noexcept {
+                       return quadrature == Spectral::Quadrature::Gauss;
+                     }),
+         "Must use Gauss points in all directions but got the mesh: "
+             << volume_mesh);
+  const Mesh<Dim - 1> boundary_mesh = volume_mesh.slice_away(dimension);
+  const Mesh<1> volume_stripe_mesh = volume_mesh.slice_through(dimension);
+  const size_t num_boundary_grid_points = boundary_mesh.number_of_grid_points();
+  detail::lift_boundary_terms_gauss_points_impl(
+      make_not_null(dt_vars->data()), dt_vars->number_of_independent_components,
+      volume_mesh, dimension, volume_det_inv_jacobian, num_boundary_grid_points,
+      gsl::make_span(upper_boundary_corrections.data(),
+                     upper_boundary_corrections.size()),
+      Spectral::boundary_lifting_term(volume_stripe_mesh).second,
+      upper_magnitude_of_face_normal, upper_face_det_jacobian,
+      gsl::make_span(lower_boundary_corrections.data(),
+                     lower_boundary_corrections.size()),
+      Spectral::boundary_lifting_term(volume_stripe_mesh).first,
+      lower_magnitude_of_face_normal, lower_face_det_jacobian);
+}
+}  // namespace evolution::dg

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
@@ -32,7 +32,7 @@ namespace Solutions {
  * \brief Fluid disk orbiting a Kerr black hole
  *
  * The Fishbone-Moncrief solution to the 3D relativistic Euler system
- * \cite fishbone1976apj, representing the isentropic flow of a thick fluid disk
+ * \cite Fishbone1976apj, representing the isentropic flow of a thick fluid disk
  * orbiting a Kerr black hole. In Boyer-Lindquist coordinates
  * \f$(t, r, \theta, \phi)\f$, the flow is assumed to be purely toroidal,
  *

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
   Initialization/Test_Mortars.cpp
   Initialization/Test_QuadratureTag.cpp
   Test_InboxTags.cpp
+  Test_LiftFromBoundary.cpp
   Test_MortarData.cpp
   Test_MortarTags.cpp
   Test_ProjectToBoundary.cpp

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_LiftFromBoundary.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_LiftFromBoundary.cpp
@@ -1,0 +1,260 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <type_traits>
+#include <vector>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/CoordinateMaps/Wedge2D.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Evolution/DiscontinuousGalerkin/LiftFromBoundary.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/MetricIdentityJacobian.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp"
+#include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
+#include "NumericalAlgorithms/LinearOperators/Divergence.tpp"
+#include "NumericalAlgorithms/LinearOperators/WeakDivergence.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct Var1 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct Var2 : db::SimpleTag {
+  using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
+};
+
+template <typename TagsList, size_t Dim>
+auto polynomial_volume_fluxes(
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& coords,
+    const Index<Dim>& powers) noexcept {
+  Variables<db::wrap_tags_in<Tags::Flux, TagsList, tmpl::size_t<Dim>,
+                             Frame::Inertial>>
+      result(get<0>(coords).size(), 1.0);
+
+  if constexpr (tmpl::list_contains_v<TagsList, Var1>) {
+    for (size_t i = 1; i < Dim; ++i) {
+      get<Tags::Flux<Var1, tmpl::size_t<Dim>, Frame::Inertial>>(result).get(i) =
+          0.0;
+    }
+  }
+
+  for (size_t power_index = 0; power_index < Dim; ++power_index) {
+    if constexpr (tmpl::list_contains_v<TagsList, Var1>) {
+      get<0>(get<Tags::Flux<Var1, tmpl::size_t<Dim>, Frame::Inertial>>(
+          result)) *= (1.0) * pow(coords.get(power_index), powers[power_index]);
+    }
+    if constexpr (tmpl::list_contains_v<TagsList, Var2<Dim>>) {
+      for (size_t i = 0; i < Dim; ++i) {
+        for (size_t j = 0; j < Dim; ++j) {
+          get<Tags::Flux<Var2<Dim>, tmpl::size_t<Dim>, Frame::Inertial>>(result)
+              .get(i, j) *= (i + 2.0) * (j + 3.0) *
+                            pow(coords.get(power_index), powers[power_index]);
+        }
+      }
+    }
+  }
+  return result;
+}
+
+using Affine = domain::CoordinateMaps::Affine;
+using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+using Affine3D = domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+
+template <size_t VolumeDim>
+auto make_map() noexcept;
+
+template <>
+auto make_map<1>() noexcept {
+  return domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
+      Affine{-1.0, 1.0, -0.3, 0.7});
+}
+
+template <>
+auto make_map<2>() noexcept {
+  return domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
+      Affine2D{{-1.0, 1.0, -1.0, -0.9}, {-1.0, 1.0, -1.0, -0.9}},
+      domain::CoordinateMaps::Wedge2D{1.0, 2.0, 0.0, 1.0, {}, false});
+}
+
+template <>
+auto make_map<3>() noexcept {
+  return domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
+      Affine3D{{-1.0, 1.0, -1.0, -0.9},
+               {-1.0, 1.0, -1.0, -0.9},
+               {-1.0, 1.0, -1.0, 1.0}},
+      domain::CoordinateMaps::ProductOf2Maps<domain::CoordinateMaps::Wedge2D,
+                                             Affine>{
+          {1.0, 2.0, 0.0, 1.0, {}, false}, {0.0, 1.0, 0.0, 1.0}});
+}
+
+template <size_t Dim>
+void test(const double eps) {
+  // Allow specifying either Var1 or Var2 so that debugging is easier. This test
+  // will be useful when trying to better understand preserving the metric
+  // identities numerically.
+  //
+  // Currently the weak form with the lifting test as coded here does not
+  // satisfy the metric identities on curved meshes. This is likely because the
+  // boundary term does not have the metric identity satisfying normal and
+  // Jacobian terms.
+  using tags = tmpl::list<Var1, Var2<Dim>>;
+  Mesh<Dim> volume_mesh{8, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::Gauss};
+  CAPTURE(Dim);
+  CAPTURE(volume_mesh);
+
+  Index<Dim> powers{};
+  for (size_t i = 0; i < Dim; ++i) {
+    powers[i] = volume_mesh.extents(i) - 4 - i;
+  }
+
+  const auto map = make_map<Dim>();
+  const auto logical_coords = logical_coordinates(volume_mesh);
+  const auto inertial_coords = map(logical_coords);
+  const auto volume_inv_jacobian = map.inv_jacobian(logical_coords);
+  const auto [volume_det_inv_jacobian, volume_jacobian] =
+      determinant_and_inverse(volume_inv_jacobian);
+
+  auto volume_fluxes = polynomial_volume_fluxes<tags>(inertial_coords, powers);
+
+  InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>
+      det_jac_times_inverse_jacobian{volume_mesh.number_of_grid_points()};
+  dg::metric_identity_jacobian(make_not_null(&det_jac_times_inverse_jacobian),
+                               volume_mesh, inertial_coords, volume_jacobian);
+
+  Variables<db::wrap_tags_in<
+      Tags::div, typename std::decay_t<decltype(volume_fluxes)>::tags_list>>
+      weak_div_fluxes{volume_mesh.number_of_grid_points()};
+  weak_divergence(make_not_null(&weak_div_fluxes), volume_fluxes, volume_mesh,
+                  det_jac_times_inverse_jacobian);
+
+  Variables<db::wrap_tags_in<Tags::dt, tags>> dt_vars_lifted_one_at_a_time{
+      volume_mesh.number_of_grid_points(), 0.0};
+  Variables<db::wrap_tags_in<Tags::dt, tags>> dt_vars_lifted_two_at_a_time{
+      volume_mesh.number_of_grid_points()};
+  std::copy(weak_div_fluxes.data(),
+            weak_div_fluxes.data() + weak_div_fluxes.size(),
+            dt_vars_lifted_one_at_a_time.data());
+  std::copy(weak_div_fluxes.data(),
+            weak_div_fluxes.data() + weak_div_fluxes.size(),
+            dt_vars_lifted_two_at_a_time.data());
+
+  dt_vars_lifted_one_at_a_time *= get(volume_det_inv_jacobian);
+  dt_vars_lifted_two_at_a_time *= get(volume_det_inv_jacobian);
+
+  for (const auto& direction : Direction<Dim>::all_directions()) {
+    // compute geometric terms
+    const auto face_mesh = volume_mesh.slice_away(direction.dimension());
+    const auto face_logical_coords =
+        interface_logical_coordinates(face_mesh, direction);
+    const auto face_inertial_coords = map(face_logical_coords);
+    const auto face_det_jacobian =
+        determinant(map.jacobian(face_logical_coords));
+    const auto face_normal =
+        unnormalized_face_normal(face_mesh, map, direction);
+    const auto face_normal_magnitude = magnitude(face_normal);
+    auto unit_face_normal = face_normal;
+    for (auto& t : unit_face_normal) {
+      t /= get(face_normal_magnitude);
+    }
+
+    const auto boundary_corrections = normal_dot_flux<tags>(
+        unit_face_normal,
+        polynomial_volume_fluxes<tags>(face_inertial_coords, powers));
+
+    // Now perform lifting
+    evolution::dg::lift_boundary_terms_gauss_points(
+        make_not_null(&dt_vars_lifted_one_at_a_time), volume_det_inv_jacobian,
+        volume_mesh, direction, boundary_corrections, face_normal_magnitude,
+        face_det_jacobian);
+
+    if (direction.side() == Side::Upper) {
+      // Test lifting both upper and lower correction at the same time
+      const auto lower_direction = direction.opposite();
+      const auto lower_face_mesh =
+          volume_mesh.slice_away(lower_direction.dimension());
+      const auto lower_face_logical_coords =
+          interface_logical_coordinates(lower_face_mesh, lower_direction);
+      const auto lower_face_inertial_coords = map(lower_face_logical_coords);
+      const auto lower_face_det_jacobian =
+          determinant(map.jacobian(lower_face_logical_coords));
+      const auto lower_face_normal =
+          unnormalized_face_normal(lower_face_mesh, map, lower_direction);
+      const auto lower_face_normal_magnitude = magnitude(lower_face_normal);
+      auto lower_unit_face_normal = lower_face_normal;
+      for (auto& t : lower_unit_face_normal) {
+        t /= get(lower_face_normal_magnitude);
+      }
+
+      const auto lower_boundary_corrections = normal_dot_flux<tags>(
+          lower_unit_face_normal,
+          polynomial_volume_fluxes<tags>(lower_face_inertial_coords, powers));
+
+      // Now perform lifting
+      evolution::dg::lift_boundary_terms_gauss_points(
+          make_not_null(&dt_vars_lifted_two_at_a_time), volume_det_inv_jacobian,
+          volume_mesh, direction.dimension(), boundary_corrections,
+          face_normal_magnitude, face_det_jacobian, lower_boundary_corrections,
+          lower_face_normal_magnitude, lower_face_det_jacobian);
+    }
+  }
+
+  Variables<db::wrap_tags_in<
+      Tags::div, typename std::decay_t<decltype(volume_fluxes)>::tags_list>>
+      div_fluxes{volume_mesh.number_of_grid_points()};
+  divergence(make_not_null(&div_fluxes), volume_fluxes, volume_mesh,
+             volume_inv_jacobian);
+  Variables<db::wrap_tags_in<Tags::dt, tags>> expected_dt_vars{
+      volume_mesh.number_of_grid_points()};
+  std::copy(div_fluxes.data(), div_fluxes.data() + div_fluxes.size(),
+            expected_dt_vars.data());
+  expected_dt_vars *= -1.0;
+
+  Approx local_approx = Approx::custom().epsilon(eps).scale(1.0);
+  tmpl::for_each<typename decltype(expected_dt_vars)::tags_list>(
+      [&dt_vars_lifted_one_at_a_time, &dt_vars_lifted_two_at_a_time,
+       &expected_dt_vars, &local_approx](auto tag_v) noexcept {
+        using tag = tmpl::type_from<decltype(tag_v)>;
+        CHECK_ITERABLE_CUSTOM_APPROX(get<tag>(dt_vars_lifted_one_at_a_time),
+                                     get<tag>(expected_dt_vars), local_approx);
+        CHECK_ITERABLE_CUSTOM_APPROX(get<tag>(dt_vars_lifted_two_at_a_time),
+                                     get<tag>(expected_dt_vars), local_approx);
+      });
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.DG.LiftFromBoundary", "[Unit][Evolution]") {
+  // We test the lifting procedure (and at the same time the weak divergence
+  // more thoroughly) by checking the
+  //    weak divergence + lifting boundary terms == strong divergence
+  //
+  // Currently the weak form with the lifting test as coded here does not
+  // satisfy the metric identities on curved meshes. This is likely because the
+  // boundary term does not have the metric identity satisfying normal and
+  // Jacobian terms.
+  test<1>(1.0e-12);
+  test<2>(1.0e-8);
+  test<3>(1.0e-8);
+}


### PR DESCRIPTION
## Proposed changes

Add function to lift from interface when using Gauss points

Depends on:
- [x] #2539 

Only the following commits are new:
- Add code to lift from Gauss points

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
