### PR TITLE
Pass fluxes to elliptic source computers

### DIFF
--- a/src/Elliptic/DiscontinuousGalerkin/InitializeFirstOrderOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/InitializeFirstOrderOperator.hpp
@@ -71,7 +71,7 @@ struct InitializeFirstOrderOperator {
                                               vars_tag, PrimalVariables,
                                               AuxiliaryVariables>;
   using sources_compute_tag = elliptic::Tags::FirstOrderSourcesCompute<
-      SourcesComputer, vars_tag, PrimalVariables, AuxiliaryVariables>;
+      Dim, SourcesComputer, vars_tag, PrimalVariables, AuxiliaryVariables>;
 
   using exterior_tags = tmpl::list<
       // On exterior (ghost) boundary faces we compute the fluxes from the

--- a/src/Elliptic/FirstOrderOperator.hpp
+++ b/src/Elliptic/FirstOrderOperator.hpp
@@ -43,13 +43,13 @@ struct FirstOrderFluxesImpl<Dim, tmpl::list<PrimalFields...>,
   }
 };
 
-template <typename PrimalFields, typename AuxiliaryFields,
+template <size_t Dim, typename PrimalFields, typename AuxiliaryFields,
           typename SourcesComputer>
 struct FirstOrderSourcesImpl;
 
-template <typename... PrimalFields, typename... AuxiliaryFields,
+template <size_t Dim, typename... PrimalFields, typename... AuxiliaryFields,
           typename SourcesComputer>
-struct FirstOrderSourcesImpl<tmpl::list<PrimalFields...>,
+struct FirstOrderSourcesImpl<Dim, tmpl::list<PrimalFields...>,
                              tmpl::list<AuxiliaryFields...>, SourcesComputer> {
   template <typename VarsTags, typename... SourcesArgs>
   static constexpr void apply(
@@ -57,20 +57,30 @@ struct FirstOrderSourcesImpl<tmpl::list<PrimalFields...>,
           Variables<db::wrap_tags_in<::Tags::Source, VarsTags>>*>
           sources,
       const Variables<VarsTags>& vars,
+      const Variables<db::wrap_tags_in<
+          ::Tags::Flux, VarsTags, tmpl::size_t<Dim>, Frame::Inertial>>& fluxes,
       const SourcesArgs&... sources_args) noexcept {
-    // Compute sources for primal fields
-    SourcesComputer::apply(
-        make_not_null(&get<::Tags::Source<PrimalFields>>(*sources))...,
-        sources_args..., get<PrimalFields>(vars)...);
-    // Compute sources for auxiliary fields. They are just the auxiliary field
-    // values.
+    // Set auxiliary field sources to the auxiliary field values to begin with.
+    // This is the standard choice, since the auxiliary equations define the
+    // auxiliary variables. Source computers can adjust or add to these sources.
     tmpl::for_each<tmpl::list<AuxiliaryFields...>>(
-        [&sources, &vars ](const auto auxiliary_field_tag_v) noexcept {
+        [&sources, &vars](const auto auxiliary_field_tag_v) noexcept {
           using auxiliary_field_tag =
               tmpl::type_from<decltype(auxiliary_field_tag_v)>;
           get<::Tags::Source<auxiliary_field_tag>>(*sources) =
               get<auxiliary_field_tag>(vars);
         });
+    // Call into the sources computer to set primal field sources and possibly
+    // adjust auxiliary field sources. The sources depend on the primal and the
+    // auxiliary variables. However, we pass the volume fluxes instead of the
+    // auxiliary variables to the source computer as an optimization so they
+    // don't have to be re-computed.
+    SourcesComputer::apply(
+        make_not_null(&get<::Tags::Source<PrimalFields>>(*sources))...,
+        make_not_null(&get<::Tags::Source<AuxiliaryFields>>(*sources))...,
+        sources_args..., get<PrimalFields>(vars)...,
+        get<::Tags::Flux<PrimalFields, tmpl::size_t<Dim>, Frame::Inertial>>(
+            fluxes)...);
   }
 };
 
@@ -118,30 +128,41 @@ auto first_order_fluxes(const Variables<VarsTags>& vars,
  * \brief Compute the sources \f$S(u)\f$ for the first-order formulation of
  * elliptic systems.
  *
+ * This function takes the `fluxes` as an argument in addition to the variables
+ * as an optimization. The fluxes will generally be computed before the sources
+ * anyway, so we pass them to the source computers to avoid having to re-compute
+ * them for source-terms that have the same form as the fluxes.
+ *
  * \see `elliptic::first_order_operator`
  */
-template <typename PrimalFields, typename AuxiliaryFields,
+template <size_t Dim, typename PrimalFields, typename AuxiliaryFields,
           typename SourcesComputer, typename VarsTags, typename... SourcesArgs>
 void first_order_sources(
     gsl::not_null<Variables<db::wrap_tags_in<::Tags::Source, VarsTags>>*>
         sources,
     const Variables<VarsTags>& vars,
+    const Variables<db::wrap_tags_in<::Tags::Flux, VarsTags, tmpl::size_t<Dim>,
+                                     Frame::Inertial>>& fluxes,
     const SourcesArgs&... sources_args) noexcept {
   first_order_operator_detail::FirstOrderSourcesImpl<
-      PrimalFields, AuxiliaryFields, SourcesComputer>::apply(std::move(sources),
-                                                             vars,
-                                                             sources_args...);
+      Dim, PrimalFields, AuxiliaryFields,
+      SourcesComputer>::apply(std::move(sources), vars, fluxes,
+                              sources_args...);
 }
 
-template <typename PrimalFields, typename AuxiliaryFields,
+template <size_t Dim, typename PrimalFields, typename AuxiliaryFields,
           typename SourcesComputer, typename VarsTags, typename... SourcesArgs>
-auto first_order_sources(const Variables<VarsTags>& vars,
-                         const SourcesArgs&... sources_args) noexcept {
+auto first_order_sources(
+    const Variables<VarsTags>& vars,
+    const Variables<db::wrap_tags_in<::Tags::Flux, VarsTags, tmpl::size_t<Dim>,
+                                     Frame::Inertial>>& fluxes,
+    const SourcesArgs&... sources_args) noexcept {
   Variables<db::wrap_tags_in<::Tags::Source, VarsTags>> sources{
       vars.number_of_grid_points()};
   first_order_operator_detail::FirstOrderSourcesImpl<
-      PrimalFields, AuxiliaryFields,
-      SourcesComputer>::apply(make_not_null(&sources), vars, sources_args...);
+      Dim, PrimalFields, AuxiliaryFields,
+      SourcesComputer>::apply(make_not_null(&sources), vars, fluxes,
+                              sources_args...);
   return sources;
 }
 // @}

--- a/src/Elliptic/Systems/Elasticity/Equations.hpp
+++ b/src/Elliptic/Systems/Elasticity/Equations.hpp
@@ -94,7 +94,9 @@ struct Sources {
   using argument_tags = tmpl::list<>;
   static void apply(
       const gsl::not_null<tnsr::I<DataVector, Dim>*> source_for_displacement,
-      const tnsr::I<DataVector, Dim>& /*displacement*/) noexcept {
+      const gsl::not_null<tnsr::ii<DataVector, Dim>*> /*source_for_strain*/,
+      const tnsr::I<DataVector, Dim>& /*displacement*/,
+      const tnsr::IJ<DataVector, Dim>& /*stress*/) noexcept {
     for (size_t d = 0; d < Dim; d++) {
       source_for_displacement->get(d) = 0.;
     }

--- a/src/Elliptic/Systems/Poisson/Equations.cpp
+++ b/src/Elliptic/Systems/Poisson/Equations.cpp
@@ -16,9 +16,8 @@ namespace Poisson {
 
 template <size_t Dim>
 void euclidean_fluxes(
-    const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
-        flux_for_field,
-    const tnsr::i<DataVector, Dim, Frame::Inertial>& field_gradient) noexcept {
+    const gsl::not_null<tnsr::I<DataVector, Dim>*> flux_for_field,
+    const tnsr::i<DataVector, Dim>& field_gradient) noexcept {
   for (size_t d = 0; d < Dim; d++) {
     flux_for_field->get(d) = field_gradient.get(d);
   }
@@ -26,11 +25,10 @@ void euclidean_fluxes(
 
 template <size_t Dim>
 void non_euclidean_fluxes(
-    const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
-        flux_for_field,
-    const tnsr::II<DataVector, Dim, Frame::Inertial>& inv_spatial_metric,
+    const gsl::not_null<tnsr::I<DataVector, Dim>*> flux_for_field,
+    const tnsr::II<DataVector, Dim>& inv_spatial_metric,
     const Scalar<DataVector>& det_spatial_metric,
-    const tnsr::i<DataVector, Dim, Frame::Inertial>& field_gradient) noexcept {
+    const tnsr::i<DataVector, Dim>& field_gradient) noexcept {
   raise_or_lower_index(flux_for_field, field_gradient, inv_spatial_metric);
   for (size_t i = 0; i < Dim; i++) {
     flux_for_field->get(i) *= sqrt(get(det_spatial_metric));
@@ -38,9 +36,9 @@ void non_euclidean_fluxes(
 }
 
 template <size_t Dim>
-void auxiliary_fluxes(gsl::not_null<tnsr::Ij<DataVector, Dim, Frame::Inertial>*>
-                          flux_for_gradient,
-                      const Scalar<DataVector>& field) noexcept {
+void auxiliary_fluxes(
+    gsl::not_null<tnsr::Ij<DataVector, Dim>*> flux_for_gradient,
+    const Scalar<DataVector>& field) noexcept {
   std::fill(flux_for_gradient->begin(), flux_for_gradient->end(), 0.);
   for (size_t d = 0; d < Dim; d++) {
     flux_for_gradient->get(d, d) = get(field);
@@ -51,17 +49,16 @@ void auxiliary_fluxes(gsl::not_null<tnsr::Ij<DataVector, Dim, Frame::Inertial>*>
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data)                                                 \
-  template void Poisson::euclidean_fluxes<DIM(data)>(                        \
-      const gsl::not_null<tnsr::I<DataVector, DIM(data), Frame::Inertial>*>, \
-      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&) noexcept;      \
-  template void Poisson::non_euclidean_fluxes<DIM(data)>(                    \
-      const gsl::not_null<tnsr::I<DataVector, DIM(data), Frame::Inertial>*>, \
-      const tnsr::II<DataVector, DIM(data), Frame::Inertial>&,               \
-      const Scalar<DataVector>&,                                             \
-      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&) noexcept;      \
-  template void Poisson::auxiliary_fluxes<DIM(data)>(                        \
-      gsl::not_null<tnsr::Ij<DataVector, DIM(data), Frame::Inertial>*>,      \
+#define INSTANTIATE(_, data)                                             \
+  template void Poisson::euclidean_fluxes<DIM(data)>(                    \
+      const gsl::not_null<tnsr::I<DataVector, DIM(data)>*>,              \
+      const tnsr::i<DataVector, DIM(data)>&) noexcept;                   \
+  template void Poisson::non_euclidean_fluxes<DIM(data)>(                \
+      const gsl::not_null<tnsr::I<DataVector, DIM(data)>*>,              \
+      const tnsr::II<DataVector, DIM(data)>&, const Scalar<DataVector>&, \
+      const tnsr::i<DataVector, DIM(data)>&) noexcept;                   \
+  template void Poisson::auxiliary_fluxes<DIM(data)>(                    \
+      gsl::not_null<tnsr::Ij<DataVector, DIM(data)>*>,                   \
       const Scalar<DataVector>&) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))

--- a/src/Elliptic/Systems/Poisson/Equations.hpp
+++ b/src/Elliptic/Systems/Poisson/Equations.hpp
@@ -25,9 +25,8 @@ namespace Poisson {
  * equation on a flat spatial metric in Cartesian coordinates.
  */
 template <size_t Dim>
-void euclidean_fluxes(
-    gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> flux_for_field,
-    const tnsr::i<DataVector, Dim, Frame::Inertial>& field_gradient) noexcept;
+void euclidean_fluxes(gsl::not_null<tnsr::I<DataVector, Dim>*> flux_for_field,
+                      const tnsr::i<DataVector, Dim>& field_gradient) noexcept;
 
 /*!
  * \brief Compute the fluxes \f$F^i=\sqrt{\gamma}\gamma^{ij}\partial_j u(x)\f$
@@ -35,10 +34,10 @@ void euclidean_fluxes(
  */
 template <size_t Dim>
 void non_euclidean_fluxes(
-    gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> flux_for_field,
-    const tnsr::II<DataVector, Dim, Frame::Inertial>& inv_spatial_metric,
+    gsl::not_null<tnsr::I<DataVector, Dim>*> flux_for_field,
+    const tnsr::II<DataVector, Dim>& inv_spatial_metric,
     const Scalar<DataVector>& det_spatial_metric,
-    const tnsr::i<DataVector, Dim, Frame::Inertial>& field_gradient) noexcept;
+    const tnsr::i<DataVector, Dim>& field_gradient) noexcept;
 
 /*!
  * \brief Compute the fluxes \f$F^i_j=\delta^i_j u(x)\f$ for the auxiliary
@@ -47,9 +46,9 @@ void non_euclidean_fluxes(
  * \see Poisson::FirstOrderSystem
  */
 template <size_t Dim>
-void auxiliary_fluxes(gsl::not_null<tnsr::Ij<DataVector, Dim, Frame::Inertial>*>
-                          flux_for_gradient,
-                      const Scalar<DataVector>& field) noexcept;
+void auxiliary_fluxes(
+    gsl::not_null<tnsr::Ij<DataVector, Dim>*> flux_for_gradient,
+    const Scalar<DataVector>& field) noexcept;
 
 /*!
  * \brief Compute the fluxes \f$F^i_A\f$ for the Poisson equation on a flat
@@ -61,15 +60,12 @@ template <size_t Dim>
 struct EuclideanFluxes {
   using argument_tags = tmpl::list<>;
   static void apply(
-      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
-          flux_for_field,
-      const tnsr::i<DataVector, Dim, Frame::Inertial>&
-          field_gradient) noexcept {
+      const gsl::not_null<tnsr::I<DataVector, Dim>*> flux_for_field,
+      const tnsr::i<DataVector, Dim>& field_gradient) noexcept {
     euclidean_fluxes(flux_for_field, field_gradient);
   }
   static void apply(
-      const gsl::not_null<tnsr::Ij<DataVector, Dim, Frame::Inertial>*>
-          flux_for_gradient,
+      const gsl::not_null<tnsr::Ij<DataVector, Dim>*> flux_for_gradient,
       const Scalar<DataVector>& field) noexcept {
     auxiliary_fluxes(flux_for_gradient, field);
   }
@@ -89,19 +85,16 @@ struct NonEuclideanFluxes {
       gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>,
       gr::Tags::DetSpatialMetric<DataVector>>;
   static void apply(
-      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
-          flux_for_field,
-      const tnsr::II<DataVector, Dim, Frame::Inertial>& inv_spatial_metric,
+      const gsl::not_null<tnsr::I<DataVector, Dim>*> flux_for_field,
+      const tnsr::II<DataVector, Dim>& inv_spatial_metric,
       const Scalar<DataVector>& det_spatial_metric,
-      const tnsr::i<DataVector, Dim, Frame::Inertial>&
-          field_gradient) noexcept {
+      const tnsr::i<DataVector, Dim>& field_gradient) noexcept {
     non_euclidean_fluxes(flux_for_field, inv_spatial_metric, det_spatial_metric,
                          field_gradient);
   }
   static void apply(
-      const gsl::not_null<tnsr::Ij<DataVector, Dim, Frame::Inertial>*>
-          flux_for_gradient,
-      const tnsr::II<DataVector, Dim, Frame::Inertial>& /*inv_spatial_metric*/,
+      const gsl::not_null<tnsr::Ij<DataVector, Dim>*> flux_for_gradient,
+      const tnsr::II<DataVector, Dim>& /*inv_spatial_metric*/,
       const Scalar<DataVector>& /*det_spatial_metric*/,
       const Scalar<DataVector>& field) noexcept {
     auxiliary_fluxes(flux_for_gradient, field);

--- a/src/Elliptic/Systems/Poisson/Equations.hpp
+++ b/src/Elliptic/Systems/Poisson/Equations.hpp
@@ -110,8 +110,13 @@ struct NonEuclideanFluxes {
  */
 struct Sources {
   using argument_tags = tmpl::list<>;
-  static void apply(const gsl::not_null<Scalar<DataVector>*> source_for_field,
-                    const Scalar<DataVector>& /*field*/) noexcept {
+  template <size_t Dim>
+  static void apply(
+      const gsl::not_null<Scalar<DataVector>*> source_for_field,
+      const gsl::not_null<
+          tnsr::i<DataVector, Dim>*> /*source_for_field_gradient*/,
+      const Scalar<DataVector>& /*field*/,
+      const tnsr::I<DataVector, Dim>& /*field_flux*/) noexcept {
     get(*source_for_field) = 0.;
   }
 };

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFirstOrderOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFirstOrderOperator.cpp
@@ -86,8 +86,12 @@ struct Fluxes {
 
 struct Sources {
   using argument_tags = tmpl::list<>;
-  static void apply(const gsl::not_null<Scalar<DataVector>*> source_for_field,
-                    const Scalar<DataVector>& field) {
+  template <size_t Dim>
+  static void apply(
+      const gsl::not_null<Scalar<DataVector>*> source_for_field,
+      const gsl::not_null<tnsr::i<DataVector, Dim>*> /*source_for_aux_field*/,
+      const Scalar<DataVector>& field,
+      const tnsr::I<DataVector, Dim>& /*field_flux*/) {
     get(*source_for_field) = get(field);
   }
 };

--- a/tests/Unit/Elliptic/Systems/Poisson/Test_Equations.cpp
+++ b/tests/Unit/Elliptic/Systems/Poisson/Test_Equations.cpp
@@ -51,6 +51,7 @@ void test_computers(const DataVector& used_for_size) {
   using auxiliary_flux_tag =
       ::Tags::Flux<auxiliary_field_tag, tmpl::size_t<Dim>, Frame::Inertial>;
   using field_source_tag = ::Tags::Source<field_tag>;
+  using auxiliary_source_tag = ::Tags::Source<auxiliary_field_tag>;
 
   const size_t num_points = used_for_size.size();
   {
@@ -133,14 +134,23 @@ void test_computers(const DataVector& used_for_size) {
   }
   {
     INFO("Sources" << Dim << "D");
-    auto box = db::create<db::AddSimpleTags<field_tag, field_source_tag>>(
-        Scalar<DataVector>{num_points, 2.}, Scalar<DataVector>{num_points, 0.});
+    auto box =
+        db::create<db::AddSimpleTags<field_source_tag, auxiliary_source_tag>>(
+            Scalar<DataVector>{num_points,
+                               std::numeric_limits<double>::signaling_NaN()},
+            tnsr::i<DataVector, Dim>{
+                num_points, std::numeric_limits<double>::signaling_NaN()});
 
     const Poisson::Sources sources_computer{};
     using argument_tags = typename Poisson::Sources::argument_tags;
 
-    db::mutate_apply<tmpl::list<field_source_tag>, argument_tags>(
-        sources_computer, make_not_null(&box), get<field_tag>(box));
+    db::mutate_apply<tmpl::list<field_source_tag, auxiliary_source_tag>,
+                     argument_tags>(
+        sources_computer, make_not_null(&box),
+        Scalar<DataVector>{num_points,
+                           std::numeric_limits<double>::signaling_NaN()},
+        tnsr::I<DataVector, Dim>{num_points,
+                                 std::numeric_limits<double>::signaling_NaN()});
     auto expected_field_source = Scalar<DataVector>{num_points, 0.};
     CHECK(get<field_source_tag>(box) == expected_field_source);
   }

--- a/tests/Unit/Elliptic/Test_FirstOrderComputeTags.cpp
+++ b/tests/Unit/Elliptic/Test_FirstOrderComputeTags.cpp
@@ -63,9 +63,13 @@ struct Fluxes {
 
 struct Sources {
   using argument_tags = tmpl::list<AnArgument, BaseArgumentTag>;
-  static void apply(const gsl::not_null<Scalar<DataVector>*> source_for_field,
-                    const double an_argument, const double base_tag_argument,
-                    const Scalar<DataVector>& field) {
+  template <size_t Dim>
+  static void apply(
+      const gsl::not_null<Scalar<DataVector>*> source_for_field,
+      const gsl::not_null<tnsr::i<DataVector, Dim>*> /*source_for_aux_field*/,
+      const double an_argument, const double base_tag_argument,
+      const Scalar<DataVector>& field,
+      const tnsr::I<DataVector, Dim>& /*field_flux*/) {
     get(*source_for_field) =
         get(field) * square(an_argument) + base_tag_argument;
   }
@@ -82,8 +86,8 @@ void test_first_order_compute_tags() {
       elliptic::Tags::FirstOrderFluxesCompute<Dim, Fluxes<Dim>, vars_tag,
                                               primal_vars, auxiliary_vars>;
   using first_order_sources_compute_tag =
-      elliptic::Tags::FirstOrderSourcesCompute<Sources, vars_tag, primal_vars,
-                                               auxiliary_vars>;
+      elliptic::Tags::FirstOrderSourcesCompute<Dim, Sources, vars_tag,
+                                               primal_vars, auxiliary_vars>;
 
   TestHelpers::db::test_compute_tag<first_order_fluxes_compute_tag>(
       "Variables(Flux(FieldTag),Flux(AuxiliaryFieldTag))");


### PR DESCRIPTION
## Proposed changes

More involved systems such as XCTS need all variables to compute source terms.

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->
- The signature of functions in `Elliptic/FirstOrderOperator.hpp` have changed.
<!-- UPGRADE INSTRUCTIONS -->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
