### PR TITLE
Revert blaze 3.8

### DIFF
--- a/cmake/SetupBlaze.cmake
+++ b/cmake/SetupBlaze.cmake
@@ -1,10 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-# Every time we've upgraded blaze compatibility in the past, we've had to change
-# vector code, so we should expect to need changes again on each subsequent
-# release, so we specify an exact version requirement.
-find_package(Blaze 3.8 EXACT REQUIRED)
+find_package(Blaze 3.5 REQUIRED)
 
 message(STATUS "Blaze incl: ${BLAZE_INCLUDE_DIR}")
 message(STATUS "Blaze vers: ${BLAZE_VERSION}")

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -116,7 +116,7 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.18.2/cmake-3.18.2
 # Build with GCC7 when easily possible to maximize ABI compatibility.
 #
 # Install blaze, brigand, catch2, libsharp, libxsmm, yaml-cpp in /usr/local
-RUN wget https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.8.tar.gz -O blaze.tar.gz \
+RUN wget https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.7.tar.gz -O blaze.tar.gz \
     && tar -xzf blaze.tar.gz \
     && mv blaze-* blaze \
     && mv blaze/blaze /usr/local/include \

--- a/docs/DevGuide/ImplementingVectors.md
+++ b/docs/DevGuide/ImplementingVectors.md
@@ -45,26 +45,14 @@ DataVector>`. This template pattern is known as the
 ["Curiously Recurring Template Pattern"]
 (https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern) (CRTP).
 
-For the Blaze system to use the CRTP inheritance appropriately, it requires the
-specification of separate type traits in the `blaze` namespace.
-These traits can usually be declared in a standard form, so are abstracted in a
-macro. For any new vector `MyNewVector`, the pattern that must appear at the
-beginning of the file (i.e. before the class definition) is:
-```
-/// \cond
-class MyNewVector;
-/// \endcond
-namespace blaze {
-DECLARE_GENERAL_VECTOR_BLAZE_TRAITS(MyNewVector);
-}
-```
 The class template `VectorImpl` defines various constructors, assignment
 operators, and iterator generation members. Most of these are inherited from
 Blaze types, but in addition, the methods `set_data_ref`, and `pup` are defined
 for use in SpECTRE. All except for the assignment operators and constructors
 will be implicitly inherited from `VectorImpl`. The assignment and constructors
 may be inherited calling the following alias code in the vector class
- definition:
+definition:
+
 ```
 using VectorImpl<T,VectorType>::operator=;
 using VectorImpl<T,VectorType>::VectorImpl;
@@ -74,6 +62,12 @@ Only the mathematical operations supported on the base Blaze types are supported
 by default. Those operations are determined by the storage type `T` and by the
 Blaze library. See [blaze-wiki/Vector_Operations]
 (https://bitbucket.org/blaze-lib/blaze/wiki/Vector%20Operations).
+
+Other math operations may be defined either in the class definition or
+outside. For ease in defining some of these math operations, `PointerVector.hpp`
+defines the macro `MAKE_EXPRESSION_MATH_ASSIGN(OP, TYPE)`, which can be used to
+define math assignment operations such as `+=` provided the underlying operation
+(e.g. `+`) is defined on the Blaze type.
 
 # Allowed operator specification {#blaze_definitions}
 
@@ -306,9 +300,9 @@ More use cases of this functionality can be found in `Test_DataVector.cpp`.
 # Vector storage nuts and bolts {#Vector_storage}
 
 Internally, all vector classes inherit from the templated `VectorImpl`, which
-inherits from a `blaze::CustomVector`. Most of the mathematical operations are
-supported through the Blaze inheritance, which ensures that the math operations
-execute the optimized forms in Blaze.
+inherits from `PointerVector`, which inherits from a `blaze::DenseVector`. Most
+of the mathematical operations are supported through the Blaze inheritance,
+which ensures that the math operations execute the optimized forms in Blaze.
 
 SpECTRE vectors can be either "owning" or "non-owning". If a vector is owning,
 it allocates and controls the data it has access to, and is responsible for
@@ -318,16 +312,27 @@ memory. Non-owning vectors do not manage memory, nor can they change size. The
 two cases of data ownership cause the underlying data to be handled fairly
 differently, so we will discuss each in turn.
 
+In both cases of ownership, the base `PointerVector` contains a pointer to the
+allocated contiguous block of memory via a raw pointer `v_` (accessible via
+`PointerVector.data()` and the extent of that memory `size_` (accessible via
+`PointerVector.size()`). The raw pointer in `PointerVector` then gives access to
+the memory block to the base Blaze types, which perform the work of the actual
+math operations. `PointerVector` is closely patterned off of Blaze internal
+functionality (`CustomVector`), and we stress that direct alteration of
+`PointerVector` should be avoided unless completely necessary. The discussion in
+this section is intended to provide a better understanding of how the interface
+is used for the SpECTRE vector types so that future customization of derived
+classes of `VectorImpl` is as easy as possible.
+
 When a SpECTRE vector is constructed as owning, or becomes owning, it allocates
 its own block of memory of appropriate size, and stores a pointer to that memory
 in a `std::unique_ptr` named `owned_data_`. The `std::unique_ptr` ensures that
 the SpECTRE vector needs to perform no further direct memory management, and
-that the memory will be appropriately managed whenever the
-`std::unique_ptr owned_data_` member is deleted or moved. The base
-`blaze::CustomVector` must also be told about the pointer, which is always
-accomplished by calling the protected function
-`VectorImpl.reset_pointer_vector(const size_t set_size)`, which sets the
-`blaze::CustomVector` internal pointer to the pointer obtained by
+that the memory will be appropriately managed whenever the `std::unique_ptr
+owned_data_` member is deleted or moved. The base `PointerVector` must also be
+told about the pointer, which is always accomplished by calling the protected
+function `VectorImpl.reset_pointer_vector(const size_t set_size)`, which sets
+the `PointerVector` internal pointer to the pointer obtained by
 `std::unique_pointer.get()`.
 
 When a SpECTRE vector is constructed as non-owning by the `VectorImpl(ValueType*
@@ -337,6 +342,6 @@ longer points to the data represented by the vector and can be thought of as
 "inactive" for the purposes of computation and memory management. This behavior
 is desirable, because otherwise the `std::unique_ptr` would attempt to free
 memory that is presumed to be also used elsewhere, causing difficult to diagnose
-memory errors. The non-owning SpECTRE vector updates the base
-`blaze::CustomVector` pointer directly by calling `blaze::CustomVector.reset`
-from the derived class (on itself).
+memory errors. The non-owning SpECTRE vector updates the base `PointerVector`
+pointer directly by calling `PointerVector.reset` from the derived class (on
+itself).

--- a/docs/DevGuide/ImplementingVectors.md
+++ b/docs/DevGuide/ImplementingVectors.md
@@ -64,7 +64,7 @@ Blaze types, but in addition, the methods `set_data_ref`, and `pup` are defined
 for use in SpECTRE. All except for the assignment operators and constructors
 will be implicitly inherited from `VectorImpl`. The assignment and constructors
 may be inherited calling the following alias code in the vector class
-definition:
+ definition:
 ```
 using VectorImpl<T,VectorType>::operator=;
 using VectorImpl<T,VectorType>::VectorImpl;

--- a/src/DataStructures/ComplexDataVector.hpp
+++ b/src/DataStructures/ComplexDataVector.hpp
@@ -14,13 +14,7 @@
 #include "Utilities/Requires.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 
-/// \cond
-class ComplexDataVector;
-/// \endcond
-
-namespace blaze {
-DECLARE_GENERAL_VECTOR_BLAZE_TRAITS(ComplexDataVector);
-}  // namespace blaze
+// IWYU pragma: no_forward_declare ConstantExpressions_detail::pow
 
 /*!
  * \ingroup DataStructuresGroup
@@ -160,11 +154,9 @@ namespace blaze {
 // ComplexDataVector. This does *not* prevent taking the norm of the square (or
 // some other math expression) of a ComplexDataVector.
 template <typename Abs, typename Power>
-struct DVecNormHelper<
-    blaze::CustomVector<std::complex<double>, blaze_unaligned, blaze_unpadded,
-                        blaze::defaultTransposeFlag, blaze::GroupTag<0>,
-                        ComplexDataVector>,
-    Abs, Power> {};
+struct DVecNormHelper<PointerVector<std::complex<double>, blaze_unaligned,
+                                    blaze_unpadded, false, ComplexDataVector>,
+                      Abs, Power> {};
 }  // namespace blaze
 /// \endcond
 

--- a/src/DataStructures/ComplexModalVector.hpp
+++ b/src/DataStructures/ComplexModalVector.hpp
@@ -4,16 +4,15 @@
 #pragma once
 
 #include "DataStructures/VectorImpl.hpp"
+#include "Utilities/PointerVector.hpp"  // IWYU pragma: keep
 #include "Utilities/TMPL.hpp"
+
+// IWYU pragma: no_include <blaze/math/expressions/DVecMapExpr.h>
+// IWYU pragma: no_include <blaze/math/typetraits/IsVector.h>
 
 /// \cond
 class ModalVector;
-class ComplexModalVector;
 /// \endcond
-
-namespace blaze {
-DECLARE_GENERAL_VECTOR_BLAZE_TRAITS(ComplexModalVector);
-}  // namespace blaze
 
 /*!
  * \ingroup DataStructuresGroup
@@ -53,6 +52,8 @@ class ComplexModalVector
 
 namespace blaze {
 template <>
+struct IsVector<ComplexModalVector> : std::true_type {};
+template <>
 struct TransposeFlag<ComplexModalVector>
     : BoolConstant<ComplexModalVector::transpose_flag> {};
 template <>
@@ -84,24 +85,23 @@ struct DivTrait<ComplexModalVector, double> {
   using Type = ComplexModalVector;
 };
 
+#if ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION < 6))
 template <typename Operator>
 struct MapTrait<ComplexModalVector, Operator> {
   // Selectively allow unary operations for spectral coefficients
-  static_assert(tmpl::list_contains_v<
-                    tmpl::list<blaze::Conj,
-                               // Following 3 reqd. by operator(+,+=), (-,-=),
-                               // (-) w/doubles
-                               blaze::Bind1st<blaze::Add, std::complex<double>>,
-                               blaze::Bind2nd<blaze::Add, std::complex<double>>,
-                               blaze::Bind1st<blaze::Sub, std::complex<double>>,
-                               blaze::Bind2nd<blaze::Sub, std::complex<double>>,
-                               blaze::Bind1st<blaze::Add, double>,
-                               blaze::Bind2nd<blaze::Add, double>,
-                               blaze::Bind1st<blaze::Sub, double>,
-                               blaze::Bind2nd<blaze::Sub, double>>,
-                    Operator>,
-                "Only unary operations permitted on a ComplexModalVector are:"
-                " conj, imag, and real");
+  static_assert(
+      tmpl::list_contains_v<
+          tmpl::list<blaze::Conj,
+                     // Following 3 reqd. by operator(+,+=), (-,-=),
+                     // (-) w/doubles
+                     blaze::AddScalar<ComplexModalVector::ElementType>,
+                     blaze::SubScalarRhs<ComplexModalVector::ElementType>,
+                     blaze::SubScalarLhs<ComplexModalVector::ElementType>,
+                     blaze::AddScalar<double>, blaze::SubScalarRhs<double>,
+                     blaze::SubScalarLhs<double>>,
+          Operator>,
+      "Only unary operations permitted on a ComplexModalVector are:"
+      " conj, imag, and real");
   using Type = ComplexModalVector;
 };
 template <>
@@ -131,6 +131,61 @@ struct MapTrait<ComplexModalVector, ComplexModalVector, Operator> {
       "This binary operation is not permitted on a ComplexModalVector.");
   using Type = ComplexModalVector;
 };
+#else
+template <typename Operator>
+struct MapTrait<ComplexModalVector, Operator> {
+  // Selectively allow unary operations for spectral coefficients
+  static_assert(
+      tmpl::list_contains_v<
+          tmpl::list<blaze::Conj,
+                     // Following 3 reqd. by operator(+,+=), (-,-=),
+                     // (-) w/doubles
+                     blaze::AddScalar<ComplexModalVector::ElementType>,
+                     blaze::SubScalarRhs<ComplexModalVector::ElementType>,
+                     blaze::SubScalarLhs<ComplexModalVector::ElementType>,
+                     blaze::AddScalar<double>, blaze::SubScalarRhs<double>,
+                     blaze::SubScalarLhs<double>,
+                     blaze::Bind1st<blaze::Add, std::complex<double>>,
+                     blaze::Bind2nd<blaze::Add, std::complex<double>>,
+                     blaze::Bind1st<blaze::Sub, std::complex<double>>,
+                     blaze::Bind2nd<blaze::Sub, std::complex<double>>,
+                     blaze::Bind1st<blaze::Add, double>,
+                     blaze::Bind2nd<blaze::Add, double>,
+                     blaze::Bind1st<blaze::Sub, double>,
+                     blaze::Bind2nd<blaze::Sub, double>>,
+          Operator>,
+      "Only unary operations permitted on a ComplexModalVector are:"
+      " conj, imag, and real");
+  using Type = ComplexModalVector;
+};
+template <>
+struct MapTrait<ComplexModalVector, blaze::Imag> {
+  using Type = ModalVector;
+};
+template <>
+struct MapTrait<ComplexModalVector, blaze::Real> {
+  using Type = ModalVector;
+};
+template <>
+struct MapTrait<ModalVector, blaze::Imag> {
+  using Type = ModalVector;
+};
+template <>
+struct MapTrait<ModalVector, blaze::Real> {
+  using Type = ModalVector;
+};
+
+template <typename Operator>
+struct MapTrait<ComplexModalVector, ComplexModalVector, Operator> {
+  // Forbid math operations in this specialization of BinaryMap traits for
+  // ComplexModalVector that are unlikely to be used on spectral coefficients.
+  // Currently no non-arithmetic binary operations are supported.
+  static_assert(
+      tmpl::list_contains_v<tmpl::list<>, Operator>,
+      "This binary operation is not permitted on a ComplexModalVector.");
+  using Type = ComplexModalVector;
+};
+#endif  // ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 3))
 }  // namespace blaze
 
 /// \cond
@@ -148,11 +203,9 @@ namespace blaze {
 // ComplexModalVector. This does *not* prevent taking the norm of the square (or
 // some other math expression) of a ComplexModalVector.
 template <typename Abs, typename Power>
-struct DVecNormHelper<
-    blaze::CustomVector<std::complex<double>, blaze_unaligned, blaze_unpadded,
-                        blaze::defaultTransposeFlag, blaze::GroupTag<0>,
-                        ComplexModalVector>,
-    Abs, Power> {};
+struct DVecNormHelper<PointerVector<std::complex<double>, blaze_unaligned,
+                                    blaze_unpadded, false, ComplexModalVector>,
+                      Abs, Power> {};
 }  // namespace blaze
 /// \endcond
 MAKE_WITH_VALUE_IMPL_DEFINITION_FOR(ComplexModalVector)

--- a/src/DataStructures/DataVector.hpp
+++ b/src/DataStructures/DataVector.hpp
@@ -7,14 +7,10 @@
 
 #include "DataStructures/VectorImpl.hpp"
 #include "Utilities/ForceInline.hpp"
+#include "Utilities/PointerVector.hpp"
 
-/// \cond
-class DataVector;
-/// \endcond
-
-namespace blaze {
-DECLARE_GENERAL_VECTOR_BLAZE_TRAITS(DataVector);
-}  // namespace blaze
+// IWYU pragma: no_include <blaze/math/expressions/DVecMapExpr.h>
+// IWYU pragma: no_include <blaze/math/typetraits/IsVector.h>
 
 /*!
  * \ingroup DataStructuresGroup
@@ -63,7 +59,7 @@ VECTOR_BLAZE_TRAIT_SPECIALIZE_ALL_MAP_TRAITS(DataVector);
 }  // namespace blaze
 
 SPECTRE_ALWAYS_INLINE auto fabs(const DataVector& t) noexcept {
-  return abs(*t);
+  return abs(~t);
 }
 
 MAKE_STD_ARRAY_VECTOR_BINOPS(DataVector)

--- a/src/DataStructures/DiagonalModalOperator.hpp
+++ b/src/DataStructures/DiagonalModalOperator.hpp
@@ -5,16 +5,15 @@
 
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "DataStructures/VectorImpl.hpp"
+#include "Utilities/PointerVector.hpp"  // IWYU pragma: keep
 #include "Utilities/TMPL.hpp"
 
 /// \cond
 class ModalVector;
-class DiagonalModalOperator;
 /// \endcond
 
-namespace blaze {
-DECLARE_GENERAL_VECTOR_BLAZE_TRAITS(DiagonalModalOperator);
-}  // namespace blaze
+// IWYU pragma: no_include <blaze/math/expressions/DVecMapExpr.h>
+// IWYU pragma: no_include <blaze/math/typetraits/IsVector.h>
 
 /*!
  * \ingroup DataStructuresGroup
@@ -56,23 +55,27 @@ BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ModalVector,
                                                DiagonalModalOperator,
                                                MultTrait, ModalVector);
 
+#if ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION < 6))
 template <typename Operator>
 struct MapTrait<DiagonalModalOperator, Operator> {
   // Selectively allow unary operations for spectral coefficient operators
   static_assert(
       tmpl::list_contains_v<
-          tmpl::list<blaze::Bind1st<blaze::Add, double>,
-                     blaze::Bind2nd<blaze::Add, double>,
-                     blaze::Bind1st<blaze::Div, double>,
-                     blaze::Bind2nd<blaze::Div, double>,
-                     blaze::Bind1st<blaze::Sub, double>,
-                     blaze::Bind2nd<blaze::Sub, double>,
-                     blaze::Bind1st<blaze::Add, std::complex<double>>,
-                     blaze::Bind2nd<blaze::Add, std::complex<double>>,
-                     blaze::Bind1st<blaze::Div, std::complex<double>>,
-                     blaze::Bind2nd<blaze::Div, std::complex<double>>,
-                     blaze::Bind1st<blaze::Sub, std::complex<double>>,
-                     blaze::Bind2nd<blaze::Sub, std::complex<double>>>,
+          tmpl::list<
+              // these traits are required for operators acting with doubles
+              blaze::AddScalar<DiagonalModalOperator::ElementType>,
+              blaze::SubScalarRhs<DiagonalModalOperator::ElementType>,
+              blaze::SubScalarLhs<DiagonalModalOperator::ElementType>,
+              blaze::DivideScalarByVector<DiagonalModalOperator::ElementType>,
+              // With these and the blaze traits in
+              // `ComplexDiagonalModalOperator.hpp`, the `DiagonalModalOperator`
+              // can be operated with a `std::complex<double>` to produce a
+              // `ComplexDiagonalModalOperator`, analogous to implicit casting
+              // in the standard library
+              blaze::AddScalar<std::complex<double>>,
+              blaze::SubScalarRhs<std::complex<double>>,
+              blaze::SubScalarLhs<std::complex<double>>,
+              blaze::DivideScalarByVector<std::complex<double>>>,
           Operator>,
       "This unary operation is not permitted on a DiagonalModalOperator");
   using Type = DiagonalModalOperator;
@@ -88,6 +91,55 @@ struct MapTrait<DiagonalModalOperator, DiagonalModalOperator, Operator> {
       "This binary operation is not permitted on a DiagonalModalOperator.");
   using Type = DiagonalModalOperator;
 };
+#else
+template <typename Operator>
+struct MapTrait<DiagonalModalOperator, Operator> {
+  // Selectively allow unary operations for spectral coefficient operators
+  static_assert(
+      tmpl::list_contains_v<
+          tmpl::list<
+              // these traits are required for operators acting with doubles
+              blaze::AddScalar<DiagonalModalOperator::ElementType>,
+              blaze::SubScalarRhs<DiagonalModalOperator::ElementType>,
+              blaze::SubScalarLhs<DiagonalModalOperator::ElementType>,
+              blaze::DivideScalarByVector<DiagonalModalOperator::ElementType>,
+              // With these and the blaze traits in
+              // `ComplexDiagonalModalOperator.hpp`, the `DiagonalModalOperator`
+              // can be operated with a `std::complex<double>` to produce a
+              // `ComplexDiagonalModalOperator`, analogous to implicit casting
+              // in the standard library
+              blaze::AddScalar<std::complex<double>>,
+              blaze::SubScalarRhs<std::complex<double>>,
+              blaze::SubScalarLhs<std::complex<double>>,
+              blaze::DivideScalarByVector<std::complex<double>>,
+              blaze::Bind1st<blaze::Add, double>,
+              blaze::Bind2nd<blaze::Add, double>,
+              blaze::Bind1st<blaze::Div, double>,
+              blaze::Bind2nd<blaze::Div, double>,
+              blaze::Bind1st<blaze::Sub, double>,
+              blaze::Bind2nd<blaze::Sub, double>,
+              blaze::Bind1st<blaze::Add, std::complex<double>>,
+              blaze::Bind2nd<blaze::Add, std::complex<double>>,
+              blaze::Bind1st<blaze::Div, std::complex<double>>,
+              blaze::Bind2nd<blaze::Div, std::complex<double>>,
+              blaze::Bind1st<blaze::Sub, std::complex<double>>,
+              blaze::Bind2nd<blaze::Sub, std::complex<double>>>,
+          Operator>,
+      "This unary operation is not permitted on a DiagonalModalOperator");
+  using Type = DiagonalModalOperator;
+};
+
+template <typename Operator>
+struct MapTrait<DiagonalModalOperator, DiagonalModalOperator, Operator> {
+  // Forbid math operations in this specialization of BinaryMap traits for
+  // DiagonalModalOperator that are unlikely to be used on spectral
+  // coefficients. Currently no non-arithmetic binary operations are supported.
+  static_assert(
+      tmpl::list_contains_v<tmpl::list<>, Operator>,
+      "This binary operation is not permitted on a DiagonalModalOperator.");
+  using Type = DiagonalModalOperator;
+};
+#endif  // ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION < 6))
 }  // namespace blaze
 
 MAKE_STD_ARRAY_VECTOR_BINOPS(DiagonalModalOperator)

--- a/src/DataStructures/ModalVector.hpp
+++ b/src/DataStructures/ModalVector.hpp
@@ -4,15 +4,11 @@
 #pragma once
 
 #include "DataStructures/VectorImpl.hpp"
+#include "Utilities/PointerVector.hpp"  // IWYU pragma: keep
 #include "Utilities/TMPL.hpp"
 
-/// \cond
-class ModalVector;
-/// \endcond
-
-namespace blaze {
-DECLARE_GENERAL_VECTOR_BLAZE_TRAITS(ModalVector);
-}  // namespace blaze
+// IWYU pragma: no_include <blaze/math/expressions/DVecMapExpr.h>
+// IWYU pragma: no_include <blaze/math/typetraits/IsVector.h>
 
 /*!
  * \ingroup DataStructuresGroup
@@ -46,6 +42,8 @@ class ModalVector : public VectorImpl<double, ModalVector> {
 
 namespace blaze {
 template <>
+struct IsVector<ModalVector> : std::true_type {};
+template <>
 struct TransposeFlag<ModalVector> : BoolConstant<ModalVector::transpose_flag> {
 };
 template <>
@@ -63,12 +61,61 @@ struct DivTrait<ModalVector, double> {
   using Type = ModalVector;
 };
 
+#if ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION < 6))
+template <typename Operator>
+struct MapTrait<ModalVector, Operator> {
+  // Selectively allow unary operations for spectral coefficients
+  static_assert(tmpl::list_contains_v<
+                    tmpl::list<blaze::Abs,
+                               // Following 3 reqd. by operator(+,+=), (-,-=),
+                               // (-) w/doubles
+                               blaze::AddScalar<ModalVector::ElementType>,
+                               blaze::SubScalarRhs<ModalVector::ElementType>,
+                               blaze::SubScalarLhs<ModalVector::ElementType>,
+                               // With these and the blaze traits in
+                               // `ComplexModalVector.hpp`, the `ModalVector`
+                               // can be operated with a `std::complex<double>`
+                               // to produce a `ComplexModalVector`, analogous
+                               // to implicit casting in the standard library
+                               blaze::AddScalar<std::complex<double>>,
+                               blaze::SubScalarRhs<std::complex<double>>,
+                               blaze::SubScalarLhs<std::complex<double>>>,
+                    Operator>,
+                "The only unary operation permitted on a ModalVector is:"
+                " abs.");
+  using Type = ModalVector;
+};
+
+template <typename Operator>
+struct MapTrait<ModalVector, ModalVector, Operator> {
+  // Forbid math operations in this specialization of BinaryMap traits for
+  // ModalVector that are unlikely to be used on spectral coefficients.
+  // Currently no non-arithmetic binary operations are supported.
+  static_assert(tmpl::list_contains_v<tmpl::list<>, Operator>,
+                "This binary operation is not permitted on a ModalVector.");
+  using Type = ModalVector;
+};
+#else
 template <typename Operator>
 struct MapTrait<ModalVector, Operator> {
   // Selectively allow unary operations for spectral coefficients
   static_assert(
       tmpl::list_contains_v<
-          tmpl::list<blaze::Abs, blaze::Bind1st<blaze::Add, double>,
+          tmpl::list<blaze::Abs,
+                     // Following 3 reqd. by operator(+,+=), (-,-=),
+                     // (-) w/doubles
+                     blaze::AddScalar<ModalVector::ElementType>,
+                     blaze::SubScalarRhs<ModalVector::ElementType>,
+                     blaze::SubScalarLhs<ModalVector::ElementType>,
+                     // With these and the blaze traits in
+                     // `ComplexModalVector.hpp`, the `ModalVector`
+                     // can be operated with a `std::complex<double>`
+                     // to produce a `ComplexModalVector`, analogous
+                     // to implicit casting in the standard library
+                     blaze::AddScalar<std::complex<double>>,
+                     blaze::SubScalarRhs<std::complex<double>>,
+                     blaze::SubScalarLhs<std::complex<double>>,
+                     blaze::Bind1st<blaze::Add, double>,
                      blaze::Bind2nd<blaze::Add, double>,
                      blaze::Bind1st<blaze::Sub, double>,
                      blaze::Bind2nd<blaze::Sub, double>,
@@ -91,6 +138,7 @@ struct MapTrait<ModalVector, ModalVector, Operator> {
                 "This binary operation is not permitted on a ModalVector.");
   using Type = ModalVector;
 };
+#endif  // ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION < 6))
 }  // namespace blaze
 
 /// \cond

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -108,8 +108,8 @@ class Variables<tmpl::list<Tags...>> {
   using const_pointer = const value_type*;
   using allocator_type = std::allocator<value_type>;
   using pointer_type =
-      blaze::CustomVector<value_type, blaze_unaligned, blaze_unpadded,
-                          transpose_flag, blaze::GroupTag<0>, vector_type>;
+      PointerVector<value_type, blaze_unaligned, blaze_unpadded, transpose_flag,
+                    blaze::DynamicVector<value_type, transpose_flag>>;
 
   static_assert(
       std::is_fundamental_v<value_type> or tt::is_a_v<std::complex, value_type>,
@@ -256,10 +256,10 @@ class Variables<tmpl::list<Tags...>> {
   /// Converting constructor for an expression to a Variables class
   // clang-tidy: mark as explicit (we want conversion to Variables)
   template <typename VT, bool VF>
-  Variables(const blaze::DenseVector<VT, VF>& expression) noexcept;  // NOLINT
+  Variables(const blaze::Vector<VT, VF>& expression) noexcept;  // NOLINT
 
   template <typename VT, bool VF>
-  Variables& operator=(const blaze::DenseVector<VT, VF>& expression) noexcept;
+  Variables& operator=(const blaze::Vector<VT, VF>& expression) noexcept;
 
   template <typename... WrappedTags,
             Requires<tmpl2::flat_all<std::is_same_v<
@@ -326,13 +326,13 @@ class Variables<tmpl::list<Tags...>> {
   }
   template <typename VT, bool VF>
   friend SPECTRE_ALWAYS_INLINE decltype(auto) operator+(
-      const blaze::DenseVector<VT, VF>& lhs, const Variables& rhs) noexcept {
-    return *lhs + rhs.variable_data_;
+      const blaze::Vector<VT, VF>& lhs, const Variables& rhs) noexcept {
+    return ~lhs + rhs.variable_data_;
   }
   template <typename VT, bool VF>
   friend SPECTRE_ALWAYS_INLINE decltype(auto) operator+(
-      const Variables& lhs, const blaze::DenseVector<VT, VF>& rhs) noexcept {
-    return lhs.variable_data_ + *rhs;
+      const Variables& lhs, const blaze::Vector<VT, VF>& rhs) noexcept {
+    return lhs.variable_data_ + ~rhs;
   }
 
   template <typename... WrappedTags,
@@ -350,13 +350,13 @@ class Variables<tmpl::list<Tags...>> {
   }
   template <typename VT, bool VF>
   friend SPECTRE_ALWAYS_INLINE decltype(auto) operator-(
-      const blaze::DenseVector<VT, VF>& lhs, const Variables& rhs) noexcept {
-    return *lhs - rhs.variable_data_;
+      const blaze::Vector<VT, VF>& lhs, const Variables& rhs) noexcept {
+    return ~lhs - rhs.variable_data_;
   }
   template <typename VT, bool VF>
   friend SPECTRE_ALWAYS_INLINE decltype(auto) operator-(
-      const Variables& lhs, const blaze::DenseVector<VT, VF>& rhs) noexcept {
-    return lhs.variable_data_ - *rhs;
+      const Variables& lhs, const blaze::Vector<VT, VF>& rhs) noexcept {
+    return lhs.variable_data_ - ~rhs;
   }
 
   friend SPECTRE_ALWAYS_INLINE decltype(auto) operator*(
@@ -408,18 +408,6 @@ class Variables<tmpl::list<Tags...>> {
 
   friend bool operator==(const Variables& lhs, const Variables& rhs) noexcept {
     return lhs.variable_data_ == rhs.variable_data_;
-  }
-
-  template <typename VT, bool TF>
-  friend bool operator==(const Variables& lhs,
-                         const blaze::DenseVector<VT, TF>& rhs) noexcept {
-    return lhs.variable_data_ == *rhs;
-  }
-
-  template <typename VT, bool TF>
-  friend bool operator==(const blaze::DenseVector<VT, TF>& lhs,
-                         const Variables& rhs) noexcept {
-    return *lhs == rhs.variable_data_;
   }
 
   template <class FriendTags>
@@ -605,14 +593,11 @@ Variables<tmpl::list<Tags...>>::Variables(
     : variable_data_impl_(std::move(rhs.variable_data_impl_)),
       size_(rhs.size()),
       number_of_grid_points_(rhs.number_of_grid_points()),
+      variable_data_(variable_data_impl_.get(), size_),
       reference_variable_data_(std::move(rhs.reference_variable_data_)) {
   static_assert(
       (std::is_same_v<typename Tags::type, typename WrappedTags::type> and ...),
       "Tensor types do not match!");
-  if (size_ == 0) {
-    return;
-  }
-  variable_data_.reset(variable_data_impl_.get(), size_);
 }
 
 template <typename... Tags>
@@ -673,8 +658,8 @@ constexpr const typename Tag::type& get(const Variables<TagList>& v) noexcept {
 template <typename... Tags>
 template <typename VT, bool VF>
 Variables<tmpl::list<Tags...>>::Variables(
-    const blaze::DenseVector<VT, VF>& expression) noexcept {
-  initialize((*expression).size() / number_of_independent_components);
+    const blaze::Vector<VT, VF>& expression) noexcept {
+  initialize((~expression).size() / number_of_independent_components);
   variable_data_ = expression;
 }
 
@@ -682,8 +667,8 @@ Variables<tmpl::list<Tags...>>::Variables(
 template <typename... Tags>
 template <typename VT, bool VF>
 Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
-    const blaze::DenseVector<VT, VF>& expression) noexcept {
-  initialize((*expression).size() / number_of_independent_components);
+    const blaze::Vector<VT, VF>& expression) noexcept {
+  initialize((~expression).size() / number_of_independent_components);
   variable_data_ = expression;
   return *this;
 }

--- a/src/DataStructures/VectorImpl.hpp
+++ b/src/DataStructures/VectorImpl.hpp
@@ -41,8 +41,8 @@
  * derived classes supporting a chosen set of mathematical operations.
  *
  * In addition, the equivalence operator `==` is inherited from the underlying
- * `blaze::CustomVector` type, and returns true if and only if the size and
- * contents of the two compared vectors are equivalent.
+ * `PointerVector` type, and returns true if and only if the size and contents
+ * of the two compared vectors are equivalent.
  *
  * Template parameters:
  * - `T` is the underlying stored type, e.g. `double`, `std::complex<double>`,
@@ -354,9 +354,9 @@ VectorImpl<T, VectorType>& VectorImpl<T, VectorType>::operator=(
 /// \endcond
 
 // The case of assigning a type apart from the same VectorImpl or a
-// `blaze::DenseVector` forwards the assignment to the `blaze::CustomVector`
-// base type. In the case of a single compatible value, this fills the vector
-// with that value.
+// `blaze::DenseVector` forwards the assignment to the `PointerVector` base
+// type. In the case of a single compatible value, this fills the vector with
+// that value.
 template <typename T, typename VectorType>
 VectorImpl<T, VectorType>& VectorImpl<T, VectorType>::operator=(
     const T& rhs) noexcept {

--- a/src/DataStructures/VectorImpl.hpp
+++ b/src/DataStructures/VectorImpl.hpp
@@ -5,7 +5,6 @@
 
 #include <algorithm>  // IWYU pragma: keep  // for std::fill
 #include <array>
-#include <blaze/math/CustomVector.h>
 #include <cstddef>
 #include <cstdlib>
 #include <cstring>
@@ -18,10 +17,10 @@
 #include <type_traits>
 
 #include "ErrorHandling/Assert.hpp"
-#include "Utilities/Blaze.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"  // IWYU pragma: keep
+#include "Utilities/PointerVector.hpp"  // IWYU pragma: keep
 #include "Utilities/PrintHelpers.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
@@ -70,16 +69,14 @@
  */
 template <typename T, typename VectorType>
 class VectorImpl
-    : public blaze::CustomVector<T, blaze_unaligned, blaze_unpadded,
-                                 blaze::defaultTransposeFlag,
-                                 blaze::GroupTag<0>, VectorType> {
+    : public PointerVector<T, blaze_unaligned, blaze_unpadded,
+                           blaze::defaultTransposeFlag, VectorType> {
  public:
   using value_type = T;
   using size_type = size_t;
   using difference_type = std::ptrdiff_t;
-  using BaseType = blaze::CustomVector<T, blaze_unaligned, blaze_unpadded,
-                                       blaze::defaultTransposeFlag,
-                                       blaze::GroupTag<0>, VectorType>;
+  using BaseType = PointerVector<T, blaze::unaligned, blaze::unpadded,
+                                 blaze::defaultTransposeFlag, VectorType>;
   static constexpr bool transpose_flag = blaze::defaultTransposeFlag;
 
   using ElementType = T;
@@ -101,10 +98,10 @@ class VectorImpl
   /// \attention
   /// upcast should only be used when implementing a derived vector type, not in
   /// calling code
-  const BaseType& operator*() const noexcept {
+  const BaseType& operator~() const noexcept {
     return static_cast<const BaseType&>(*this);
   }
-  BaseType& operator*() noexcept { return static_cast<BaseType&>(*this); }
+  BaseType& operator~() noexcept { return static_cast<BaseType&>(*this); }
   // @}
 
   /// Create with the given size. In debug mode, the vector is initialized to
@@ -185,11 +182,7 @@ class VectorImpl
 
   void set_data_ref(T* const start, const size_t set_size) noexcept {
     owned_data_.reset();
-    if(start == nullptr) {
-      (**this).reset();
-    } else {
-      (**this).reset(start, set_size);
-    }
+    (~*this).reset(start, set_size);
     owning_ = false;
   }
   // @}
@@ -236,14 +229,6 @@ class VectorImpl
 
   SPECTRE_ALWAYS_INLINE void reset_pointer_vector(
       const size_t set_size) noexcept {
-    if(set_size == 0) {
-      return;
-    }
-    if (owned_data_ == nullptr) {
-      ERROR(
-          "VectorImpl::reset_pointer_vector cannot be called when owned_data_ "
-          "is nullptr.");
-    }
     this->reset(owned_data_.get(), set_size);
   }
 };
@@ -284,7 +269,7 @@ template <typename T, typename VectorType>
 VectorImpl<T, VectorType>::VectorImpl(
     VectorImpl<T, VectorType>&& rhs) noexcept {
   owned_data_ = std::move(rhs.owned_data_);
-  **this = std::move(*rhs);
+  ~*this = ~rhs;  // PointerVector is trivially copyable
   owning_ = rhs.owning_;
   rhs.owning_ = true;
   rhs.reset();
@@ -296,7 +281,7 @@ VectorImpl<T, VectorType>& VectorImpl<T, VectorType>::operator=(
   if (this != &rhs) {
     if (owning_) {
       owned_data_ = std::move(rhs.owned_data_);
-      **this = std::move(*rhs);
+      ~*this = ~rhs; /* PointerVector is trivially copyable */
       owning_ = rhs.owning_;
     } else {
       ASSERT(rhs.size() == size(), "Must copy into same size, not "
@@ -320,14 +305,14 @@ VectorImpl<T, VectorType>::VectorImpl(
     const blaze::DenseVector<VT, VF>& expression)  // NOLINT
     noexcept
     : owned_data_(static_cast<value_type*>(
-                      malloc((*expression).size() * sizeof(value_type))),
+                      malloc((~expression).size() * sizeof(value_type))),
                   &free) {
   static_assert(std::is_same_v<typename VT::ResultType, VectorType>,
                 "You are attempting to assign the result of an expression "
                 "that is not consistent with the VectorImpl type you are "
                 "assigning to.");
-  reset_pointer_vector((*expression).size());
-  **this = expression;
+  reset_pointer_vector((~expression).size());
+  ~*this = expression;
 }
 
 template <typename T, typename VectorType>
@@ -338,17 +323,17 @@ VectorImpl<T, VectorType>& VectorImpl<T, VectorType>::operator=(
                 "You are attempting to assign the result of an expression "
                 "that is not consistent with the VectorImpl type you are "
                 "assigning to.");
-  if (owning_ and (*expression).size() != size()) {
+  if (owning_ and (~expression).size() != size()) {
     owned_data_.reset(static_cast<value_type*>(
         // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
-        malloc((*expression).size() * sizeof(value_type))));
-    reset_pointer_vector((*expression).size());
+        malloc((~expression).size() * sizeof(value_type))));
+    reset_pointer_vector((~expression).size());
   } else if (not owning_) {
-    ASSERT((*expression).size() == size(), "Must copy into same size, not "
-                                               << (*expression).size()
+    ASSERT((~expression).size() == size(), "Must copy into same size, not "
+                                               << (~expression).size()
                                                << " into " << size());
   }
-  **this = expression;
+  ~*this = expression;
   return *this;
 }
 /// \endcond
@@ -360,7 +345,7 @@ VectorImpl<T, VectorType>& VectorImpl<T, VectorType>::operator=(
 template <typename T, typename VectorType>
 VectorImpl<T, VectorType>& VectorImpl<T, VectorType>::operator=(
     const T& rhs) noexcept {
-  **this = rhs;
+  ~*this = rhs;
   return *this;
 }
 
@@ -387,18 +372,6 @@ std::ostream& operator<<(std::ostream& os,
   sequence_print_helper(os, d.begin(), d.end());
   return os;
 }
-
-#define DECLARE_GENERAL_VECTOR_BLAZE_TRAITS(VECTOR_TYPE)         \
-  template <>                                                    \
-  struct IsDenseVector<VECTOR_TYPE> : public blaze::TrueType {}; \
-                                                                 \
-  template <>                                                    \
-  struct IsVector<VECTOR_TYPE> : public blaze::TrueType {};      \
-                                                                 \
-  template <>                                                    \
-  struct CustomTransposeType<VECTOR_TYPE> {                      \
-    using Type = VECTOR_TYPE;                                    \
-  }
 
 /*!
  * \ingroup DataStructuresGroup
@@ -470,6 +443,8 @@ std::ostream& operator<<(std::ostream& os,
  * the type of the operation result (e.g. `DataVector`)
  */
 #define VECTOR_BLAZE_TRAIT_SPECIALIZE_ARITHMETIC_TRAITS(VECTOR_TYPE) \
+  template <>                                                        \
+  struct IsVector<VECTOR_TYPE> : std::true_type {};                  \
   template <>                                                        \
   struct TransposeFlag<VECTOR_TYPE>                                  \
       : BoolConstant<VECTOR_TYPE::transpose_flag> {};                \

--- a/src/Utilities/Blaze.hpp
+++ b/src/Utilities/Blaze.hpp
@@ -4,9 +4,6 @@
 /// \file
 /// Includes Blaze library with specific configs
 
-#include <blaze/math/CustomVector.h>
-#include <blaze/system/Optimizations.h>
-
 #pragma once
 
 #ifdef __GNUC__
@@ -21,9 +18,15 @@
 
 // Override padding, streaming and kernel options
 #define _BLAZE_SYSTEM_OPTIMIZATIONS_H_
+namespace blaze {
+constexpr bool usePadding = false;
+constexpr bool useStreaming = true;
+constexpr bool useOptimizedKernels = true;
+}
 
-const blaze::AlignmentFlag blaze_unaligned = blaze::AlignmentFlag::unaligned;
-const blaze::PaddingFlag blaze_unpadded = blaze::PaddingFlag::unpadded;
+namespace blaze {
+constexpr bool useDefaultInitialization = false;
+}
 
 // Override SMP configurations
 #define _BLAZE_SYSTEM_SMP_H_
@@ -38,75 +41,4 @@ const blaze::PaddingFlag blaze_unpadded = blaze::PaddingFlag::unpadded;
 
 // Disable HPX parallelization
 #define BLAZE_HPX_PARALLEL_MODE 0
-
-// Disable all padding
-#define BLAZE_USE_PADDING 0
-
-#define BLAZE_USE_STREAMING 1
-#define BLAZE_USE_OPTIMIZED_KERNELS 1
-#define BLAZE_USE_DEFAULT_INITIALIZATON 0
 /// \endcond
-
-namespace blaze {
-template <typename T>
-BLAZE_ALWAYS_INLINE SIMDdouble step_function(const SIMDf64<T>& v) noexcept
-#if BLAZE_AVX512F_MODE || BLAZE_MIC_MODE
-{
-  return _mm512_set_pd((*v).eval().value[7] < 0.0 ? 0.0 : 1.0,
-                       (*v).eval().value[6] < 0.0 ? 0.0 : 1.0,
-                       (*v).eval().value[5] < 0.0 ? 0.0 : 1.0,
-                       (*v).eval().value[4] < 0.0 ? 0.0 : 1.0,
-                       (*v).eval().value[3] < 0.0 ? 0.0 : 1.0,
-                       (*v).eval().value[2] < 0.0 ? 0.0 : 1.0,
-                       (*v).eval().value[1] < 0.0 ? 0.0 : 1.0,
-                       (*v).eval().value[0] < 0.0 ? 0.0 : 1.0);
-}
-#elif BLAZE_AVX_MODE
-{
-  return _mm256_set_pd((*v).eval().value[3] < 0.0 ? 0.0 : 1.0,
-                       (*v).eval().value[2] < 0.0 ? 0.0 : 1.0,
-                       (*v).eval().value[1] < 0.0 ? 0.0 : 1.0,
-                       (*v).eval().value[0] < 0.0 ? 0.0 : 1.0);
-}
-#elif BLAZE_SSE2_MODE
-{
-  return _mm_set_pd((*v).eval().value[1] < 0.0 ? 0.0 : 1.0,
-                    (*v).eval().value[0] < 0.0 ? 0.0 : 1.0);
-}
-#else
-{
-  return SIMDdouble{(*v).value < 0.0 ? 0.0 : 1.0};
-}
-#endif
-
-BLAZE_ALWAYS_INLINE double step_function(const double v) noexcept {
-  return v < 0.0 ? 0.0 : 1.0;
-}
-
-struct StepFunction {
-  explicit inline StepFunction() = default;
-
-  template <typename T>
-  BLAZE_ALWAYS_INLINE decltype(auto) operator()(const T& a) const noexcept {
-    return step_function(a);
-  }
-
-  template <typename T>
-  BLAZE_ALWAYS_INLINE decltype(auto) load(const T& a) const noexcept {
-    BLAZE_CONSTRAINT_MUST_BE_SIMD_PACK(T);
-    return step_function(a);
-  }
-};
-}  // namespace blaze
-
-template <typename VT, bool TF>
-BLAZE_ALWAYS_INLINE decltype(auto) step_function(
-    const blaze::DenseVector<VT, TF>& vec) noexcept {
-  return map(*vec, blaze::StepFunction{});
-}
-
-template <typename VT, bool TF>
-BLAZE_ALWAYS_INLINE decltype(auto) StepFunction(
-    const blaze::DenseVector<VT, TF>& vec) noexcept {
-  return map(*vec, blaze::StepFunction{});
-}

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -52,6 +52,7 @@ spectre_target_headers(
   Numeric.hpp
   OptimizerHacks.hpp
   Overloader.hpp
+  PointerVector.hpp
   PrettyType.hpp
   PrintHelpers.hpp
   ProtocolHelpers.hpp

--- a/src/Utilities/DereferenceWrapper.hpp
+++ b/src/Utilities/DereferenceWrapper.hpp
@@ -45,7 +45,7 @@ T&& dereference_wrapper(std::reference_wrapper<T>&& t) {
 /// \cond
 // Add overloads of math functions for reference_wrapper.
 // This is necessary because if a class, say DataVector, inherits from
-// blaze vector types and does not specify the math operators specifically for
+// PointerVector and does not specify the math operators specifically for
 // DataVector then the implicit cast from reference_wrapper<DataVector> to
 // DataVector does not result in finding the math operators.
 //

--- a/src/Utilities/PointerVector.hpp
+++ b/src/Utilities/PointerVector.hpp
@@ -1,0 +1,1337 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines class PointerVector
+
+#pragma once
+
+#include <cmath>
+#include <functional>
+
+// The Utilities/Blaze.hpp configures Blaze
+#include "ErrorHandling/Assert.hpp"
+#include "Utilities/Blaze.hpp"
+
+#include <blaze/math/CustomVector.h>
+#include <blaze/system/Optimizations.h>
+#include <blaze/system/Version.h>
+#include <blaze/util/typetraits/RemoveConst.h>
+
+// clang-tidy: do not use pointer arithmetic
+#define SPECTRE_BLAZE_ALLOCATOR(_TYPE_T, _SIZE_V) \
+  new _TYPE_T[_SIZE_V]  // NOLINT
+#define SPECTRE_BLAZE_DEALLOCATOR blaze::ArrayDelete()
+
+// Blaze version compatibility definitions:
+// between Blaze 3.2 and 3.4, there have been several minor changes to type
+// definitions. Here, we define the aliases to the appropriate tokens for the
+// respective versions.
+#if ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION < 6))
+const bool blaze_unaligned = blaze::unaligned != 0;
+const bool blaze_unpadded = blaze::unpadded != 0;
+using AlignmentFlag_t = bool;
+using PaddingFlag_t = bool;
+template <typename T>
+using BlazePow = blaze::UnaryPow<T>;
+#elif ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION == 6))
+const blaze::AlignmentFlag blaze_unaligned = blaze::AlignmentFlag::unaligned;
+const bool blaze_unpadded = blaze::unpadded;
+#define BLAZE_TEMPLATE template
+using AlignmentFlag_t = blaze::AlignmentFlag;
+using PaddingFlag_t = bool;
+template <typename T>
+using BlazePow = blaze::Bind2nd<blaze::Pow, T>;
+#elif ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION >= 7))
+const blaze::AlignmentFlag blaze_unaligned = blaze::AlignmentFlag::unaligned;
+const blaze::PaddingFlag blaze_unpadded = blaze::PaddingFlag::unpadded;
+#define BLAZE_TEMPLATE template
+using AlignmentFlag_t = blaze::AlignmentFlag;
+using PaddingFlag_t = blaze::PaddingFlag;
+template <typename T>
+using BlazePow = blaze::Bind2nd<blaze::Pow, T>;
+#endif
+
+template <bool B>
+using blaze_enable_if_t = blaze::EnableIf_t<B>;
+template <typename T>
+using blaze_remove_const_t = blaze::RemoveConst_t<T>;
+template <typename T>
+using blaze_simd_trait_t = blaze::SIMDTrait_t<T>;
+template <typename T>
+using blaze_element_type_t = blaze::ElementType_t<T>;
+template <typename T>
+using blaze_result_type_t = blaze::ResultType_t<T>;
+template <typename T1, typename T2>
+using blaze_mult_trait_t = blaze::MultTrait_t<T1, T2>;
+template <typename T1, typename T2>
+using blaze_div_trait_t = blaze::DivTrait_t<T1, T2>;
+template <typename T1, typename T2>
+using blaze_cross_trait_t = blaze::CrossTrait_t<T1, T2>;
+template <typename T>
+using blaze_const_iterator_t = blaze::ConstIterator_t<T>;
+template <typename T>
+const bool blaze_is_numeric = blaze::IsNumeric_v<T>;
+template <typename T>
+const bool blaze_is_numeric_v = blaze_is_numeric<T>;
+
+namespace blaze {
+template <typename T>
+BLAZE_ALWAYS_INLINE SIMDdouble step_function(const SIMDf64<T>& v) noexcept
+#if BLAZE_AVX512F_MODE || BLAZE_MIC_MODE
+{
+  return _mm512_set_pd((~v).eval().value[7] < 0.0 ? 0.0 : 1.0,
+                       (~v).eval().value[6] < 0.0 ? 0.0 : 1.0,
+                       (~v).eval().value[5] < 0.0 ? 0.0 : 1.0,
+                       (~v).eval().value[4] < 0.0 ? 0.0 : 1.0,
+                       (~v).eval().value[3] < 0.0 ? 0.0 : 1.0,
+                       (~v).eval().value[2] < 0.0 ? 0.0 : 1.0,
+                       (~v).eval().value[1] < 0.0 ? 0.0 : 1.0,
+                       (~v).eval().value[0] < 0.0 ? 0.0 : 1.0);
+}
+#elif BLAZE_AVX_MODE
+{
+  return _mm256_set_pd((~v).eval().value[3] < 0.0 ? 0.0 : 1.0,
+                       (~v).eval().value[2] < 0.0 ? 0.0 : 1.0,
+                       (~v).eval().value[1] < 0.0 ? 0.0 : 1.0,
+                       (~v).eval().value[0] < 0.0 ? 0.0 : 1.0);
+}
+#elif BLAZE_SSE2_MODE
+{
+  return _mm_set_pd((~v).eval().value[1] < 0.0 ? 0.0 : 1.0,
+                    (~v).eval().value[0] < 0.0 ? 0.0 : 1.0);
+}
+#else
+{
+  return SIMDdouble{(~v).value < 0.0 ? 0.0 : 1.0};
+}
+#endif
+
+BLAZE_ALWAYS_INLINE double step_function(const double v) noexcept {
+  return v < 0.0 ? 0.0 : 1.0;
+}
+
+struct StepFunction {
+  explicit inline StepFunction() = default;
+
+  template <typename T>
+  BLAZE_ALWAYS_INLINE decltype(auto) operator()(const T& a) const noexcept {
+    return step_function(a);
+  }
+
+  template <typename T>
+  BLAZE_ALWAYS_INLINE decltype(auto) load(const T& a) const noexcept {
+    BLAZE_CONSTRAINT_MUST_BE_SIMD_PACK(T);
+    return step_function(a);
+  }
+};
+}  // namespace blaze
+
+template <typename VT, bool TF>
+// NOLINTNEXTLINE(readability-const-return-type)
+BLAZE_ALWAYS_INLINE decltype(auto) step_function(
+    const blaze::DenseVector<VT, TF>& vec) noexcept {
+  return map(~vec, blaze::StepFunction{});
+}
+
+template <typename VT, bool TF>
+BLAZE_ALWAYS_INLINE decltype(auto) StepFunction(
+    const blaze::DenseVector<VT, TF>& vec) noexcept {
+  return map(~vec, blaze::StepFunction{});
+}
+
+namespace blaze {
+template <typename ST>
+struct DivideScalarByVector {
+ public:
+  explicit inline DivideScalarByVector(ST scalar) : scalar_(scalar) {}
+
+  template <typename T>
+  BLAZE_ALWAYS_INLINE decltype(auto) operator()(const T& a) const {
+    return scalar_ / a;
+  }
+
+  template <typename T>
+  static constexpr bool simdEnabled() {
+    return blaze::HasSIMDDiv<T, ST>::value;
+  }
+
+  template <typename T>
+  BLAZE_ALWAYS_INLINE decltype(auto) load(const T& a) const {
+    BLAZE_CONSTRAINT_MUST_BE_SIMD_PACK(T);
+    return set(scalar_) / a;
+  }
+
+ private:
+  ST scalar_;
+};
+
+#if ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION < 6))
+template <typename Scalar, typename VT, bool TF,
+          typename = blaze_enable_if_t<blaze_is_numeric<Scalar>>>
+BLAZE_ALWAYS_INLINE decltype(auto) operator/(
+    Scalar scalar, const blaze::DenseVector<VT, TF>& vec) {
+  return forEach(~vec, DivideScalarByVector<Scalar>(scalar));
+}
+#endif
+
+template <typename ST>
+struct AddScalar {
+ public:
+  explicit inline AddScalar(ST scalar) : scalar_(scalar) {}
+
+  template <typename T>
+  BLAZE_ALWAYS_INLINE decltype(auto) operator()(const T& a) const {
+    return a + scalar_;
+  }
+
+  template <typename T>
+  static constexpr bool simdEnabled() {
+    return blaze::HasSIMDAdd<T, ST>::value;
+  }
+
+  template <typename T>
+  BLAZE_ALWAYS_INLINE decltype(auto) load(const T& a) const {
+    BLAZE_CONSTRAINT_MUST_BE_SIMD_PACK(T);
+    return a + set(scalar_);
+  }
+
+ private:
+  ST scalar_;
+};
+
+#if ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION < 6))
+template <typename VT, bool TF, typename Scalar,
+          typename = blaze_enable_if_t<blaze_is_numeric<Scalar>>>
+decltype(auto) operator+(const blaze::DenseVector<VT, TF>& vec, Scalar scalar) {
+  return forEach(~vec, AddScalar<Scalar>(scalar));
+}
+
+template <typename Scalar, typename VT, bool TF,
+          typename = blaze_enable_if_t<blaze_is_numeric<Scalar>>>
+decltype(auto) operator+(Scalar scalar, const blaze::DenseVector<VT, TF>& vec) {
+  return forEach(~vec, AddScalar<Scalar>(scalar));
+}
+
+template <typename VT, bool TF, typename Scalar,
+          typename = blaze_enable_if_t<blaze_is_numeric<Scalar>>>
+VT& operator+=(blaze::DenseVector<VT, TF>& vec, Scalar scalar) {
+  (~vec) = (~vec) + scalar;
+  return ~vec;
+}
+#endif
+
+template <typename ST>
+struct SubScalarRhs {
+ public:
+  explicit inline SubScalarRhs(ST scalar) : scalar_(scalar) {}
+
+  template <typename T>
+  BLAZE_ALWAYS_INLINE decltype(auto) operator()(const T& a) const {
+    return a - scalar_;
+  }
+
+  template <typename T>
+  static constexpr bool simdEnabled() {
+    return blaze::HasSIMDSub<T, ST>::value;
+  }
+
+  template <typename T>
+  BLAZE_ALWAYS_INLINE decltype(auto) load(const T& a) const {
+    BLAZE_CONSTRAINT_MUST_BE_SIMD_PACK(T);
+    return a - set(scalar_);
+  }
+
+ private:
+  ST scalar_;
+};
+
+template <typename ST>
+struct SubScalarLhs {
+ public:
+  explicit inline SubScalarLhs(ST scalar) : scalar_(scalar) {}
+
+  template <typename T>
+  BLAZE_ALWAYS_INLINE decltype(auto) operator()(const T& a) const {
+    return scalar_ - a;
+  }
+
+  template <typename T>
+  static constexpr bool simdEnabled() {
+    return blaze::HasSIMDSub<T, ST>::value;
+  }
+
+  template <typename T>
+  BLAZE_ALWAYS_INLINE decltype(auto) load(const T& a) const {
+    BLAZE_CONSTRAINT_MUST_BE_SIMD_PACK(T);
+    return set(scalar_) - a;
+  }
+
+ private:
+  ST scalar_;
+};
+
+#if ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION < 6))
+template <typename VT, bool TF, typename Scalar,
+          typename = blaze_enable_if_t<blaze_is_numeric<Scalar>>>
+decltype(auto) operator-(const blaze::DenseVector<VT, TF>& vec, Scalar scalar) {
+  return forEach(~vec, SubScalarRhs<Scalar>(scalar));
+}
+
+template <typename VT, bool TF, typename Scalar,
+          typename = blaze_enable_if_t<blaze_is_numeric<Scalar>>>
+decltype(auto) operator-(Scalar scalar, const blaze::DenseVector<VT, TF>& vec) {
+  return forEach(~vec, SubScalarLhs<Scalar>(scalar));
+}
+
+template <typename VT, bool TF, typename Scalar,
+          typename = blaze_enable_if_t<blaze_is_numeric<Scalar>>>
+VT& operator-=(blaze::DenseVector<VT, TF>& vec, Scalar scalar) {
+  (~vec) = (~vec) - scalar;
+  return ~vec;
+}
+#endif
+}  // namespace blaze
+
+namespace blaze {
+// Enable support for reference wrappers with Blaze
+template <typename T>
+struct UnderlyingElement<std::reference_wrapper<T>> {
+  using Type = typename UnderlyingElement<std::decay_t<T>>::Type;
+};
+}  // namespace blaze
+
+/*!
+ * \ingroup UtilitiesGroup
+ * \brief A raw pointer endowed with expression template support via the Blaze
+ * library
+ *
+ * PointerVector can be used instead of a raw pointer to pass around size
+ * information and to be able to have the pointer array support expression
+ * templates. The primary use case for PointerVector is inside the Data class
+ * so that Data has support for expression templates but not incurring any
+ * overhead for them.
+ *
+ * See the Blaze documentation for CustomVector for details on the template
+ * parameters to PointerVector since CustomVector is what PointerVector is
+ * modeled after.
+ *
+ * One additional feature that Blaze's CustomVector (currently) does not support
+ * is the ability to change the result type so that CustomVector can be used for
+ * the expression template backend for different vector types. PointerVector
+ * allows this by passing the `ExprResultType` template parameter. For example,
+ * `DataVector` sets `ExprResultType = DataVector`.
+ */
+template <typename Type, AlignmentFlag_t AF = blaze_unaligned,
+          PaddingFlag_t PF = blaze_unpadded,
+          bool TF = blaze::defaultTransposeFlag,
+          typename ExprResultType =
+              blaze::DynamicVector<blaze_remove_const_t<Type>, TF>>
+struct PointerVector
+    : public blaze::DenseVector<PointerVector<Type, AF, PF, TF, ExprResultType>,
+                                TF> {
+  /// \cond
+ public:
+  using This = PointerVector<Type, AF, PF, TF, ExprResultType>;
+  using BaseType = blaze::DenseVector<This, TF>;
+  using ResultType = ExprResultType;
+  using TransposeType = PointerVector<Type, AF, PF, !TF, ExprResultType>;
+  using ElementType = Type;
+  using SIMDType = blaze_simd_trait_t<ElementType>;
+  using ReturnType = const Type&;
+  using CompositeType = const PointerVector&;
+
+  using Reference = Type&;
+  using ConstReference = const Type&;
+  using Pointer = Type*;
+  using ConstPointer = const Type*;
+
+#if ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 6))
+  using Iterator = blaze::DenseIterator<Type, AF != blaze_unaligned>;
+  using ConstIterator = blaze::DenseIterator<const Type, AF != blaze_unaligned>;
+#else
+  using Iterator = blaze::DenseIterator<Type, AF>;
+  using ConstIterator = blaze::DenseIterator<const Type, AF>;
+#endif
+  enum : bool { simdEnabled = blaze::IsVectorizable<Type>::value };
+  enum : bool { smpAssignable = !blaze::IsSMPAssignable<Type>::value };
+
+  PointerVector() = default;
+  PointerVector(Type* ptr, size_t size) : v_(ptr), size_(size) {}
+  PointerVector(const PointerVector& /*rhs*/) = default;
+  PointerVector& operator=(const PointerVector& /*rhs*/) = default;
+  PointerVector(PointerVector&& /*rhs*/) = default;
+  PointerVector& operator=(PointerVector&& /*rhs*/) = default;
+  ~PointerVector() = default;
+
+  /*!\name Data access functions */
+  //@{
+  Type& operator[](const size_t i) noexcept {
+    ASSERT(i < size(), "i = " << i << ", size = " << size());
+    // clang-tidy: do not use pointer arithmetic
+    return v_[i];  // NOLINT
+  }
+  const Type& operator[](const size_t i) const noexcept {
+    ASSERT(i < size(), "i = " << i << ", size = " << size());
+    // clang-tidy: do not use pointer arithmetic
+    return v_[i];  // NOLINT
+  }
+  Reference at(size_t index);
+  ConstReference at(size_t index) const;
+  Pointer data() noexcept { return v_; }
+  ConstPointer data() const noexcept { return v_; }
+  Iterator begin() noexcept { return Iterator(v_); }
+  ConstIterator begin() const noexcept { return ConstIterator(v_); }
+  ConstIterator cbegin() const noexcept { return ConstIterator(v_); }
+  Iterator end() noexcept {
+    // clang-tidy: do not use pointer arithmetic
+    return Iterator(v_ + size_);  // NOLINT
+  }
+  ConstIterator end() const noexcept {
+    // clang-tidy: do not use pointer arithmetic
+    return ConstIterator(v_ + size_);  // NOLINT
+  }
+  ConstIterator cend() const noexcept { return ConstIterator(v_ + size_); }
+  //@}
+
+  /*!\name Assignment operators */
+  //@{
+  PointerVector& operator=(const Type& rhs);
+  PointerVector& operator=(std::initializer_list<Type> list);
+
+  template <typename Other, size_t N>
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays)
+  PointerVector& operator=(const Other (&array)[N]);
+
+  template <typename VT>
+  PointerVector& operator=(const blaze::Vector<VT, TF>& rhs);
+  template <typename VT>
+  PointerVector& operator+=(const blaze::Vector<VT, TF>& rhs);
+  template <typename VT>
+  PointerVector& operator-=(const blaze::Vector<VT, TF>& rhs);
+  template <typename VT>
+  PointerVector& operator*=(const blaze::Vector<VT, TF>& rhs);
+  template <typename VT>
+  PointerVector& operator/=(const blaze::Vector<VT, TF>& rhs);
+  template <typename VT>
+  PointerVector& operator%=(const blaze::Vector<VT, TF>& rhs);
+
+  template <typename Other>
+  std::enable_if_t<blaze_is_numeric_v<Other>, This>& operator*=(Other rhs);
+
+  template <typename Other>
+  std::enable_if_t<blaze_is_numeric_v<Other>, This>& operator/=(Other rhs);
+  //@}
+
+  /*!\name Utility functions */
+  //@{
+  void clear() noexcept {
+    size_ = 0;
+    v_ = nullptr;
+  }
+
+  size_t spacing() const noexcept { return size_; }
+
+  size_t size() const noexcept { return size_; }
+  //@}
+
+  /*!\name Resource management functions */
+  //@{
+  void reset() { clear(); }
+
+  void reset(Type* ptr, size_t n) noexcept {
+    v_ = ptr;
+    size_ = n;
+  }
+  //@}
+
+ private:
+  template <typename VT>
+  using VectorizedAssign = std::integral_constant<
+      bool, blaze::useOptimizedKernels && simdEnabled && VT::simdEnabled &&
+                blaze::IsSIMDCombinable<Type, blaze_element_type_t<VT>>::value>;
+
+  template <typename VT>
+  using VectorizedAddAssign = std::integral_constant<
+      bool,
+      blaze::useOptimizedKernels && simdEnabled && VT::simdEnabled &&
+          blaze::IsSIMDCombinable<Type, blaze_element_type_t<VT>>::value &&
+          blaze::HasSIMDAdd<Type, blaze_element_type_t<VT>>::value>;
+
+  template <typename VT>
+  using VectorizedSubAssign = std::integral_constant<
+      bool,
+      blaze::useOptimizedKernels && simdEnabled && VT::simdEnabled &&
+          blaze::IsSIMDCombinable<Type, blaze_element_type_t<VT>>::value &&
+          blaze::HasSIMDSub<Type, blaze_element_type_t<VT>>::value>;
+
+  template <typename VT>
+  using VectorizedMultAssign = std::integral_constant<
+      bool,
+      blaze::useOptimizedKernels && simdEnabled && VT::simdEnabled &&
+          blaze::IsSIMDCombinable<Type, blaze_element_type_t<VT>>::value &&
+          blaze::HasSIMDMult<Type, blaze_element_type_t<VT>>::value>;
+
+  template <typename VT>
+  using VectorizedDivAssign = std::integral_constant<
+      bool,
+      blaze::useOptimizedKernels && simdEnabled && VT::simdEnabled &&
+          blaze::IsSIMDCombinable<Type, blaze_element_type_t<VT>>::value &&
+          blaze::HasSIMDDiv<Type, blaze_element_type_t<VT>>::value>;
+
+  //! The number of elements packed within a single SIMD element.
+  enum : size_t { SIMDSIZE = blaze::SIMDTrait<ElementType>::size };
+
+ public:
+  /*!\name Expression template evaluation functions */
+  //@{
+  template <typename Other>
+  bool canAlias(const Other* alias) const noexcept;
+  template <typename Other>
+  bool isAliased(const Other* alias) const noexcept;
+
+  bool isAligned() const noexcept;
+  bool canSMPAssign() const noexcept;
+
+  BLAZE_ALWAYS_INLINE SIMDType load(size_t index) const noexcept;
+  BLAZE_ALWAYS_INLINE SIMDType loada(size_t index) const noexcept;
+  BLAZE_ALWAYS_INLINE SIMDType loadu(size_t index) const noexcept;
+
+  BLAZE_ALWAYS_INLINE void store(size_t index, const SIMDType& value) noexcept;
+  BLAZE_ALWAYS_INLINE void storea(size_t index, const SIMDType& value) noexcept;
+  BLAZE_ALWAYS_INLINE void storeu(size_t index, const SIMDType& value) noexcept;
+  BLAZE_ALWAYS_INLINE void stream(size_t index, const SIMDType& value) noexcept;
+
+  template <typename VT>
+  std::enable_if_t<not(This::template VectorizedAssign<VT>::value)> assign(
+      const blaze::DenseVector<VT, TF>& rhs);
+
+  template <typename VT>
+  std::enable_if_t<(VectorizedAssign<VT>::value)> assign(
+      const blaze::DenseVector<VT, TF>& rhs);
+
+  template <typename VT>
+  std::enable_if_t<not(This::template VectorizedAddAssign<VT>::value)>
+  addAssign(const blaze::DenseVector<VT, TF>& rhs);
+
+  template <typename VT>
+  std::enable_if_t<(VectorizedAddAssign<VT>::value)> addAssign(
+      const blaze::DenseVector<VT, TF>& rhs);
+
+  template <typename VT>
+  void addAssign(const blaze::SparseVector<VT, TF>& rhs);
+
+  template <typename VT>
+  std::enable_if_t<not(This::template VectorizedSubAssign<VT>::value)>
+  subAssign(const blaze::DenseVector<VT, TF>& rhs);
+
+  template <typename VT>
+  std::enable_if_t<(VectorizedSubAssign<VT>::value)> subAssign(
+      const blaze::DenseVector<VT, TF>& rhs);
+
+  template <typename VT>
+  void subAssign(const blaze::SparseVector<VT, TF>& rhs);
+
+  template <typename VT>
+  std::enable_if_t<not(PointerVector<Type, AF, PF, TF, ResultType>::
+                           template VectorizedMultAssign<VT>::value)>
+  multAssign(const blaze::DenseVector<VT, TF>& rhs);
+
+  template <typename VT>
+  std::enable_if_t<(VectorizedMultAssign<VT>::value)> multAssign(
+      const blaze::DenseVector<VT, TF>& rhs);
+
+  template <typename VT>
+  void multAssign(const blaze::SparseVector<VT, TF>& rhs);
+
+  template <typename VT>
+  std::enable_if_t<not(This::template VectorizedDivAssign<VT>::value)>
+  divAssign(const blaze::DenseVector<VT, TF>& rhs);
+
+  template <typename VT>
+  std::enable_if_t<(VectorizedDivAssign<VT>::value)> divAssign(
+      const blaze::DenseVector<VT, TF>& rhs);
+  //@}
+
+ private:
+  Type* v_ = nullptr;
+  size_t size_ = 0;
+  /// \endcond
+};
+
+/// \cond
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+inline typename PointerVector<Type, AF, PF, TF, ExprResultType>::Reference
+PointerVector<Type, AF, PF, TF, ExprResultType>::at(size_t index) {
+  if (index >= size_) {
+    BLAZE_THROW_OUT_OF_RANGE("Invalid vector access index");
+  }
+  return (*this)[index];
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+inline typename PointerVector<Type, AF, PF, TF, ExprResultType>::ConstReference
+PointerVector<Type, AF, PF, TF, ExprResultType>::at(size_t index) const {
+  if (index >= size_) {
+    BLAZE_THROW_OUT_OF_RANGE("Invalid vector access index");
+  }
+  return (*this)[index];
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+inline PointerVector<Type, AF, PF, TF, ExprResultType>&
+PointerVector<Type, AF, PF, TF, ExprResultType>::operator=(const Type& rhs) {
+  for (size_t i = 0; i < size_; ++i) {
+    // clang-tidy: do not use pointer arithmetic
+    v_[i] = rhs;  // NOLINT
+  }
+  return *this;
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+inline PointerVector<Type, AF, PF, TF, ExprResultType>&
+PointerVector<Type, AF, PF, TF, ExprResultType>::operator=(
+    std::initializer_list<Type> list) {
+  ASSERT(list.size() <= size_, "Invalid assignment to custom vector");
+  std::fill(std::copy(list.begin(), list.end(), v_), v_ + size_, Type());
+  return *this;
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+template <typename Other, size_t N>
+inline PointerVector<Type, AF, PF, TF, ExprResultType>&
+PointerVector<Type, AF, PF, TF, ExprResultType>::operator=(
+    // NOLINTNEXTLINE(modernize-avoid-c-arrays)
+    const Other (&array)[N]) {
+  ASSERT(size_ == N, "Invalid array size");
+  for (size_t i = 0UL; i < N; ++i) {
+    // clang-tidy: do not use pointer arithmetic
+    v_[i] = array[i];  // NOLINT
+  }
+  return *this;
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+template <typename VT>
+inline PointerVector<Type, AF, PF, TF, ExprResultType>&
+PointerVector<Type, AF, PF, TF, ExprResultType>::operator=(
+    const blaze::Vector<VT, TF>& rhs) {
+  ASSERT((~rhs).size() == size_,
+         "Vector sizes do not match: " << size_ << " and " << (~rhs).size());
+  blaze::smpAssign(*this, ~rhs);
+  return *this;
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+template <typename VT>
+inline PointerVector<Type, AF, PF, TF, ExprResultType>&
+PointerVector<Type, AF, PF, TF, ExprResultType>::operator+=(
+    const blaze::Vector<VT, TF>& rhs) {
+  ASSERT((~rhs).size() == size_,
+         "Vector sizes do not match: " << size_ << " and " << (~rhs).size());
+  blaze::smpAddAssign(*this, ~rhs);
+  return *this;
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+template <typename VT>
+inline PointerVector<Type, AF, PF, TF, ExprResultType>&
+PointerVector<Type, AF, PF, TF, ExprResultType>::operator-=(
+    const blaze::Vector<VT, TF>& rhs) {
+  ASSERT((~rhs).size() == size_,
+         "Vector sizes do not match: " << size_ << " and " << (~rhs).size());
+  blaze::smpSubAssign(*this, ~rhs);
+  return *this;
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+template <typename VT>
+inline PointerVector<Type, AF, PF, TF, ExprResultType>&
+PointerVector<Type, AF, PF, TF, ExprResultType>::operator*=(
+    const blaze::Vector<VT, TF>& rhs) {
+  BLAZE_CONSTRAINT_MUST_BE_VECTOR_WITH_TRANSPOSE_FLAG(VT, TF);
+  BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION(blaze_result_type_t<VT>);
+
+  using MultType = blaze_mult_trait_t<ResultType, blaze_result_type_t<VT>>;
+
+  BLAZE_CONSTRAINT_MUST_BE_VECTOR_WITH_TRANSPOSE_FLAG(MultType, TF);
+  BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION(MultType);
+
+  ASSERT((~rhs).size() == size_,
+         "Vector sizes do not match: " << size_ << " and " << (~rhs).size());
+  blaze::smpMultAssign(*this, ~rhs);
+  return *this;
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+template <typename VT>
+inline PointerVector<Type, AF, PF, TF, ExprResultType>&
+PointerVector<Type, AF, PF, TF, ExprResultType>::operator/=(
+    const blaze::Vector<VT, TF>& rhs) {
+  BLAZE_CONSTRAINT_MUST_BE_VECTOR_WITH_TRANSPOSE_FLAG(VT, TF);
+  BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION(blaze_result_type_t<VT>);
+
+  using DivType = blaze_div_trait_t<ResultType, blaze_result_type_t<VT>>;
+
+  BLAZE_CONSTRAINT_MUST_BE_VECTOR_WITH_TRANSPOSE_FLAG(DivType, TF);
+  BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION(DivType);
+
+  ASSERT((~rhs).size() == size_,
+         "Vector sizes do not match: " << size_ << " and " << (~rhs).size());
+  blaze::smpDivAssign(*this, ~rhs);
+  return *this;
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+template <typename VT>
+inline PointerVector<Type, AF, PF, TF, ExprResultType>&
+PointerVector<Type, AF, PF, TF, ExprResultType>::operator%=(
+    const blaze::Vector<VT, TF>& rhs) {
+  using blaze::assign;
+
+  BLAZE_CONSTRAINT_MUST_BE_VECTOR_WITH_TRANSPOSE_FLAG(VT, TF);
+  BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION(blaze_result_type_t<VT>);
+
+  using CrossType = blaze_cross_trait_t<ResultType, blaze_result_type_t<VT>>;
+
+  BLAZE_CONSTRAINT_MUST_BE_DENSE_VECTOR_TYPE(CrossType);
+  BLAZE_CONSTRAINT_MUST_BE_VECTOR_WITH_TRANSPOSE_FLAG(CrossType, TF);
+  BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION(CrossType);
+
+  if (size_ != 3UL || (~rhs).size() != 3UL) {
+    BLAZE_THROW_INVALID_ARGUMENT("Invalid vector size for cross product");
+  }
+
+  const CrossType tmp(*this % (~rhs));
+  assign(*this, tmp);
+
+  return *this;
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+template <typename Other>
+inline std::enable_if_t<blaze_is_numeric_v<Other>,
+                        PointerVector<Type, AF, PF, TF, ExprResultType>>&
+PointerVector<Type, AF, PF, TF, ExprResultType>::operator*=(Other rhs) {
+  blaze::smpAssign(*this, (*this) * rhs);
+  return *this;
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+template <typename Other>
+inline std::enable_if_t<blaze_is_numeric_v<Other>,
+                        PointerVector<Type, AF, PF, TF, ExprResultType>>&
+PointerVector<Type, AF, PF, TF, ExprResultType>::operator/=(Other rhs) {
+  BLAZE_USER_ASSERT(rhs != Other(0), "Division by zero detected");
+  blaze::smpAssign(*this, (*this) / rhs);
+  return *this;
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+template <typename Other>
+inline bool PointerVector<Type, AF, PF, TF, ExprResultType>::canAlias(
+    const Other* alias) const noexcept {
+  return static_cast<const void*>(this) == static_cast<const void*>(alias);
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+template <typename Other>
+inline bool PointerVector<Type, AF, PF, TF, ExprResultType>::isAliased(
+    const Other* alias) const noexcept {
+  return static_cast<const void*>(this) == static_cast<const void*>(alias);
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+inline bool PointerVector<Type, AF, PF, TF, ExprResultType>::isAligned() const
+    noexcept {
+  return (AF || checkAlignment(v_));
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+inline bool PointerVector<Type, AF, PF, TF, ExprResultType>::canSMPAssign()
+    const noexcept {
+  return (size() > blaze::SMP_DVECASSIGN_THRESHOLD);
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+BLAZE_ALWAYS_INLINE
+    typename PointerVector<Type, AF, PF, TF, ExprResultType>::SIMDType
+    PointerVector<Type, AF, PF, TF, ExprResultType>::load(size_t index) const
+    noexcept {
+  if (AF != blaze_unaligned) {
+    return loada(index);
+  }
+  return loadu(index);
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+BLAZE_ALWAYS_INLINE
+    typename PointerVector<Type, AF, PF, TF, ExprResultType>::SIMDType
+    PointerVector<Type, AF, PF, TF, ExprResultType>::loada(size_t index) const
+    noexcept {
+  using blaze::loada;
+
+  BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE(Type);
+
+  BLAZE_INTERNAL_ASSERT(index < size_, "Invalid vector access index");
+  BLAZE_INTERNAL_ASSERT(index + SIMDSIZE <= size_,
+                        "Invalid vector access index");
+  BLAZE_INTERNAL_ASSERT(!AF || index % SIMDSIZE == 0UL,
+                        "Invalid vector access index");
+  BLAZE_INTERNAL_ASSERT(checkAlignment(v_ + index),
+                        "Invalid vector access index");
+  // clang-tidy: do not use pointer arithmetic
+  return loada(v_ + index);  // NOLINT
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+BLAZE_ALWAYS_INLINE
+    typename PointerVector<Type, AF, PF, TF, ExprResultType>::SIMDType
+    PointerVector<Type, AF, PF, TF, ExprResultType>::loadu(size_t index) const
+    noexcept {
+  using blaze::loadu;
+
+  BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE(Type);
+
+  BLAZE_INTERNAL_ASSERT(index < size_, "Invalid vector access index");
+  BLAZE_INTERNAL_ASSERT(index + SIMDSIZE <= size_,
+                        "Invalid vector access index");
+  // clang-tidy: do not use pointer arithmetic
+  return loadu(v_ + index);  // NOLINT
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+BLAZE_ALWAYS_INLINE void PointerVector<Type, AF, PF, TF, ExprResultType>::store(
+    size_t index, const SIMDType& value) noexcept {
+  if (AF != blaze_unaligned) {
+    storea(index, value);
+  } else {
+    storeu(index, value);
+  }
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+BLAZE_ALWAYS_INLINE void
+PointerVector<Type, AF, PF, TF, ExprResultType>::storea(
+    size_t index, const SIMDType& value) noexcept {
+  using blaze::storea;
+
+  BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE(Type);
+
+  BLAZE_INTERNAL_ASSERT(index < size_, "Invalid vector access index");
+  BLAZE_INTERNAL_ASSERT(index + SIMDSIZE <= size_,
+                        "Invalid vector access index");
+  BLAZE_INTERNAL_ASSERT(!AF || index % SIMDSIZE == 0UL,
+                        "Invalid vector access index");
+  BLAZE_INTERNAL_ASSERT(checkAlignment(v_ + index),
+                        "Invalid vector access index");
+  // clang-tidy: do not use pointer arithmetic
+  storea(v_ + index, value);  // NOLINT
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+BLAZE_ALWAYS_INLINE void
+PointerVector<Type, AF, PF, TF, ExprResultType>::storeu(
+    size_t index, const SIMDType& value) noexcept {
+  using blaze::storeu;
+
+  BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE(Type);
+
+  BLAZE_INTERNAL_ASSERT(index < size_, "Invalid vector access index");
+  BLAZE_INTERNAL_ASSERT(index + SIMDSIZE <= size_,
+                        "Invalid vector access index");
+  // clang-tidy: do not use pointer arithmetic
+  storeu(v_ + index, value);  // NOLINT
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+BLAZE_ALWAYS_INLINE void
+PointerVector<Type, AF, PF, TF, ExprResultType>::stream(
+    size_t index, const SIMDType& value) noexcept {
+  using blaze::stream;
+
+  BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE(Type);
+
+  BLAZE_INTERNAL_ASSERT(index < size_, "Invalid vector access index");
+  BLAZE_INTERNAL_ASSERT(index + SIMDSIZE <= size_,
+                        "Invalid vector access index");
+  BLAZE_INTERNAL_ASSERT(!AF || index % SIMDSIZE == 0UL,
+                        "Invalid vector access index");
+  BLAZE_INTERNAL_ASSERT(checkAlignment(v_ + index),
+                        "Invalid vector access index");
+  // clang-tidy: do not use pointer arithmetic
+  stream(v_ + index, value);  // NOLINT
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+template <typename VT>
+inline std::enable_if_t<not(PointerVector<Type, AF, PF, TF, ExprResultType>::
+                                BLAZE_TEMPLATE VectorizedAssign<VT>::value)>
+PointerVector<Type, AF, PF, TF, ExprResultType>::assign(
+    const blaze::DenseVector<VT, TF>& rhs) {
+  BLAZE_INTERNAL_ASSERT(size_ == (~rhs).size(), "Invalid vector sizes");
+
+  const size_t ipos(size_ & size_t(-2));
+  BLAZE_INTERNAL_ASSERT((size_ - (size_ % 2UL)) == ipos,
+                        "Invalid end calculation");
+
+  for (size_t i = 0UL; i < ipos; i += 2UL) {
+    // clang-tidy: do not use pointer arithmetic
+    v_[i] = (~rhs)[i];              // NOLINT
+    v_[i + 1UL] = (~rhs)[i + 1UL];  // NOLINT
+  }
+  if (ipos < (~rhs).size()) {
+    // clang-tidy: do not use pointer arithmetic
+    v_[ipos] = (~rhs)[ipos];  // NOLINT
+  }
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+template <typename VT>
+inline std::enable_if_t<(PointerVector<Type, AF, PF, TF, ExprResultType>::
+                             BLAZE_TEMPLATE VectorizedAssign<VT>::value)>
+PointerVector<Type, AF, PF, TF, ExprResultType>::assign(
+    const blaze::DenseVector<VT, TF>& rhs) {
+  BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE(Type);
+
+  BLAZE_INTERNAL_ASSERT(size_ == (~rhs).size(), "Invalid vector sizes");
+
+  const size_t ipos(size_ & size_t(-SIMDSIZE));
+  BLAZE_INTERNAL_ASSERT((size_ - (size_ % SIMDSIZE)) == ipos,
+                        "Invalid end calculation");
+
+  if (AF && blaze::useStreaming &&
+      size_ > (blaze::cacheSize / (sizeof(Type) * 3UL)) &&
+      !(~rhs).isAliased(this)) {
+    size_t i(0UL);
+
+    for (; i < ipos; i += SIMDSIZE) {
+      stream(i, (~rhs).load(i));
+    }
+    for (; i < size_; ++i) {
+      // clang-tidy: do not use pointer arithmetic
+      v_[i] = (~rhs)[i];  // NOLINT
+    }
+  } else {
+    const size_t i4way(size_ & size_t(-SIMDSIZE * 4));
+    BLAZE_INTERNAL_ASSERT((size_ - (size_ % (SIMDSIZE * 4UL))) == i4way,
+                          "Invalid end calculation");
+    BLAZE_INTERNAL_ASSERT(i4way <= ipos, "Invalid end calculation");
+
+    size_t i(0UL);
+    blaze_const_iterator_t<VT> it((~rhs).begin());
+
+    for (; i < i4way; i += SIMDSIZE * 4UL) {
+      store(i, it.load());
+      it += SIMDSIZE;
+      store(i + SIMDSIZE, it.load());
+      it += SIMDSIZE;
+      store(i + SIMDSIZE * 2UL, it.load());
+      it += SIMDSIZE;
+      store(i + SIMDSIZE * 3UL, it.load());
+      it += SIMDSIZE;
+    }
+    for (; i < ipos; i += SIMDSIZE, it += SIMDSIZE) {
+      store(i, it.load());
+    }
+    for (; i < size_; ++i, ++it) {
+      // clang-tidy: do not use pointer arithmetic
+      v_[i] = *it;  // NOLINT
+    }
+  }
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+template <typename VT>
+inline std::enable_if_t<not(PointerVector<Type, AF, PF, TF, ExprResultType>::
+                                BLAZE_TEMPLATE VectorizedAddAssign<VT>::value)>
+PointerVector<Type, AF, PF, TF, ExprResultType>::addAssign(
+    const blaze::DenseVector<VT, TF>& rhs) {
+  BLAZE_INTERNAL_ASSERT(size_ == (~rhs).size(), "Invalid vector sizes");
+
+  const size_t ipos(size_ & size_t(-2));
+  BLAZE_INTERNAL_ASSERT((size_ - (size_ % 2UL)) == ipos,
+                        "Invalid end calculation");
+
+  for (size_t i = 0UL; i < ipos; i += 2UL) {
+    // clang-tidy: do not use pointer arithmetic
+    v_[i] += (~rhs)[i];              // NOLINT
+    v_[i + 1UL] += (~rhs)[i + 1UL];  // NOLINT
+  }
+  if (ipos < (~rhs).size()) {
+    // clang-tidy: do not use pointer arithmetic
+    v_[ipos] += (~rhs)[ipos];  // NOLINT
+  }
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+template <typename VT>
+inline std::enable_if_t<(PointerVector<Type, AF, PF, TF, ExprResultType>::
+                             BLAZE_TEMPLATE VectorizedAddAssign<VT>::value)>
+PointerVector<Type, AF, PF, TF, ExprResultType>::addAssign(
+    const blaze::DenseVector<VT, TF>& rhs) {
+  BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE(Type);
+
+  BLAZE_INTERNAL_ASSERT(size_ == (~rhs).size(), "Invalid vector sizes");
+
+  const size_t ipos(size_ & size_t(-SIMDSIZE));
+  BLAZE_INTERNAL_ASSERT((size_ - (size_ % SIMDSIZE)) == ipos,
+                        "Invalid end calculation");
+
+  const size_t i4way(size_ & size_t(-SIMDSIZE * 4));
+  BLAZE_INTERNAL_ASSERT((size_ - (size_ % (SIMDSIZE * 4UL))) == i4way,
+                        "Invalid end calculation");
+  BLAZE_INTERNAL_ASSERT(i4way <= ipos, "Invalid end calculation");
+
+  size_t i(0UL);
+  blaze_const_iterator_t<VT> it((~rhs).begin());
+
+  for (; i < i4way; i += SIMDSIZE * 4UL) {
+    store(i, load(i) + it.load());
+    it += SIMDSIZE;
+    store(i + SIMDSIZE, load(i + SIMDSIZE) + it.load());
+    it += SIMDSIZE;
+    store(i + SIMDSIZE * 2UL, load(i + SIMDSIZE * 2UL) + it.load());
+    it += SIMDSIZE;
+    store(i + SIMDSIZE * 3UL, load(i + SIMDSIZE * 3UL) + it.load());
+    it += SIMDSIZE;
+  }
+  for (; i < ipos; i += SIMDSIZE, it += SIMDSIZE) {
+    store(i, load(i) + it.load());
+  }
+  for (; i < size_; ++i, ++it) {
+    // clang-tidy: do not use pointer arithmetic
+    v_[i] += *it;  // NOLINT
+  }
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+template <typename VT>
+inline void PointerVector<Type, AF, PF, TF, ExprResultType>::addAssign(
+    const blaze::SparseVector<VT, TF>& rhs) {
+  BLAZE_INTERNAL_ASSERT(size_ == (~rhs).size(), "Invalid vector sizes");
+
+  for (blaze_const_iterator_t<VT> element = (~rhs).begin();
+       element != (~rhs).end(); ++element) {
+    v_[element->index()] += element->value();
+  }
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+template <typename VT>
+inline std::enable_if_t<not(PointerVector<Type, AF, PF, TF, ExprResultType>::
+                                BLAZE_TEMPLATE VectorizedSubAssign<VT>::value)>
+PointerVector<Type, AF, PF, TF, ExprResultType>::subAssign(
+    const blaze::DenseVector<VT, TF>& rhs) {
+  BLAZE_INTERNAL_ASSERT(size_ == (~rhs).size(), "Invalid vector sizes");
+
+  const size_t ipos(size_ & size_t(-2));
+  BLAZE_INTERNAL_ASSERT((size_ - (size_ % 2UL)) == ipos,
+                        "Invalid end calculation");
+
+  for (size_t i = 0UL; i < ipos; i += 2UL) {
+    // clang-tidy: do not use pointer arithmetic
+    v_[i] -= (~rhs)[i];              // NOLINT
+    v_[i + 1UL] -= (~rhs)[i + 1UL];  // NOLINT
+  }
+  if (ipos < (~rhs).size()) {
+    // clang-tidy: do not use pointer arithmetic
+    v_[ipos] -= (~rhs)[ipos];  // NOLINT
+  }
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+template <typename VT>
+inline std::enable_if_t<(PointerVector<Type, AF, PF, TF, ExprResultType>::
+                             BLAZE_TEMPLATE VectorizedSubAssign<VT>::value)>
+PointerVector<Type, AF, PF, TF, ExprResultType>::subAssign(
+    const blaze::DenseVector<VT, TF>& rhs) {
+  BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE(Type);
+
+  BLAZE_INTERNAL_ASSERT(size_ == (~rhs).size(), "Invalid vector sizes");
+
+  const size_t ipos(size_ & size_t(-SIMDSIZE));
+  BLAZE_INTERNAL_ASSERT((size_ - (size_ % SIMDSIZE)) == ipos,
+                        "Invalid end calculation");
+
+  const size_t i4way(size_ & size_t(-SIMDSIZE * 4));
+  BLAZE_INTERNAL_ASSERT((size_ - (size_ % (SIMDSIZE * 4UL))) == i4way,
+                        "Invalid end calculation");
+  BLAZE_INTERNAL_ASSERT(i4way <= ipos, "Invalid end calculation");
+
+  size_t i(0UL);
+  blaze_const_iterator_t<VT> it((~rhs).begin());
+
+  for (; i < i4way; i += SIMDSIZE * 4UL) {
+    store(i, load(i) - it.load());
+    it += SIMDSIZE;
+    store(i + SIMDSIZE, load(i + SIMDSIZE) - it.load());
+    it += SIMDSIZE;
+    store(i + SIMDSIZE * 2UL, load(i + SIMDSIZE * 2UL) - it.load());
+    it += SIMDSIZE;
+    store(i + SIMDSIZE * 3UL, load(i + SIMDSIZE * 3UL) - it.load());
+    it += SIMDSIZE;
+  }
+  for (; i < ipos; i += SIMDSIZE, it += SIMDSIZE) {
+    store(i, load(i) - it.load());
+  }
+  for (; i < size_; ++i, ++it) {
+    // clang-tidy: do not use pointer arithmetic
+    v_[i] -= *it;  // NOLINT
+  }
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+template <typename VT>
+inline void PointerVector<Type, AF, PF, TF, ExprResultType>::subAssign(
+    const blaze::SparseVector<VT, TF>& rhs) {
+  BLAZE_INTERNAL_ASSERT(size_ == (~rhs).size(), "Invalid vector sizes");
+
+  for (blaze_const_iterator_t<VT> element = (~rhs).begin();
+       element != (~rhs).end(); ++element) {
+    v_[element->index()] -= element->value();
+  }
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+template <typename VT>
+inline std::enable_if_t<not(PointerVector<Type, AF, PF, TF, ExprResultType>::
+                                BLAZE_TEMPLATE VectorizedMultAssign<VT>::value)>
+PointerVector<Type, AF, PF, TF, ExprResultType>::multAssign(
+    const blaze::DenseVector<VT, TF>& rhs) {
+  BLAZE_INTERNAL_ASSERT(size_ == (~rhs).size(), "Invalid vector sizes");
+
+  const size_t ipos(size_ & size_t(-2));
+  BLAZE_INTERNAL_ASSERT((size_ - (size_ % 2UL)) == ipos,
+                        "Invalid end calculation");
+
+  for (size_t i = 0UL; i < ipos; i += 2UL) {
+    // clang-tidy: do not use pointer arithmetic
+    v_[i] *= (~rhs)[i];              // NOLINT
+    v_[i + 1UL] *= (~rhs)[i + 1UL];  // NOLINT
+  }
+  if (ipos < (~rhs).size()) {
+    // clang-tidy: do not use pointer arithmetic
+    v_[ipos] *= (~rhs)[ipos];  // NOLINT
+  }
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+template <typename VT>
+inline std::enable_if_t<(PointerVector<Type, AF, PF, TF, ExprResultType>::
+                             BLAZE_TEMPLATE VectorizedMultAssign<VT>::value)>
+PointerVector<Type, AF, PF, TF, ExprResultType>::multAssign(
+    const blaze::DenseVector<VT, TF>& rhs) {
+  BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE(Type);
+
+  BLAZE_INTERNAL_ASSERT(size_ == (~rhs).size(), "Invalid vector sizes");
+
+  const size_t ipos(size_ & size_t(-SIMDSIZE));
+  BLAZE_INTERNAL_ASSERT((size_ - (size_ % SIMDSIZE)) == ipos,
+                        "Invalid end calculation");
+
+  const size_t i4way(size_ & size_t(-SIMDSIZE * 4));
+  BLAZE_INTERNAL_ASSERT((size_ - (size_ % (SIMDSIZE * 4UL))) == i4way,
+                        "Invalid end calculation");
+  BLAZE_INTERNAL_ASSERT(i4way <= ipos, "Invalid end calculation");
+
+  size_t i(0UL);
+  blaze_const_iterator_t<VT> it((~rhs).begin());
+
+  for (; i < i4way; i += SIMDSIZE * 4UL) {
+    store(i, load(i) * it.load());
+    it += SIMDSIZE;
+    store(i + SIMDSIZE, load(i + SIMDSIZE) * it.load());
+    it += SIMDSIZE;
+    store(i + SIMDSIZE * 2UL, load(i + SIMDSIZE * 2UL) * it.load());
+    it += SIMDSIZE;
+    store(i + SIMDSIZE * 3UL, load(i + SIMDSIZE * 3UL) * it.load());
+    it += SIMDSIZE;
+  }
+  for (; i < ipos; i += SIMDSIZE, it += SIMDSIZE) {
+    store(i, load(i) * it.load());  // LCOV_EXCL_LINE
+  }
+  for (; i < size_; ++i, ++it) {
+    // clang-tidy: do not use pointer arithmetic
+    v_[i] *= *it;  // NOLINT
+  }
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+template <typename VT>
+inline void PointerVector<Type, AF, PF, TF, ExprResultType>::multAssign(
+    const blaze::SparseVector<VT, TF>& rhs) {
+  BLAZE_INTERNAL_ASSERT(size_ == (~rhs).size(), "Invalid vector sizes");
+
+  const blaze::DynamicVector<Type, TF> tmp(serial(*this));
+  reset();
+  for (blaze_const_iterator_t<VT> element = (~rhs).begin();
+       element != (~rhs).end(); ++element) {
+    v_[element->index()] = tmp[element->index()] * element->value();
+  }
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+template <typename VT>
+inline std::enable_if_t<not(PointerVector<Type, AF, PF, TF, ExprResultType>::
+                                BLAZE_TEMPLATE VectorizedDivAssign<VT>::value)>
+PointerVector<Type, AF, PF, TF, ExprResultType>::divAssign(
+    const blaze::DenseVector<VT, TF>& rhs) {
+  BLAZE_INTERNAL_ASSERT(size_ == (~rhs).size(), "Invalid vector sizes");
+
+  const size_t ipos(size_ & size_t(-2));
+  BLAZE_INTERNAL_ASSERT((size_ - (size_ % 2UL)) == ipos,
+                        "Invalid end calculation");
+
+  for (size_t i = 0UL; i < ipos; i += 2UL) {
+    // clang-tidy: do not use pointer arithmetic
+    v_[i] /= (~rhs)[i];              // NOLINT
+    v_[i + 1UL] /= (~rhs)[i + 1UL];  // NOLINT
+  }
+  if (ipos < (~rhs).size()) {
+    // clang-tidy: do not use pointer arithmetic
+    v_[ipos] /= (~rhs)[ipos];  // NOLINT
+  }
+}
+
+template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+          typename ExprResultType>
+template <typename VT>
+inline std::enable_if_t<(PointerVector<Type, AF, PF, TF, ExprResultType>::
+                             BLAZE_TEMPLATE VectorizedDivAssign<VT>::value)>
+PointerVector<Type, AF, PF, TF, ExprResultType>::divAssign(
+    const blaze::DenseVector<VT, TF>& rhs) {
+  BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE(Type);
+
+  BLAZE_INTERNAL_ASSERT(size_ == (~rhs).size(), "Invalid vector sizes");
+
+  const size_t ipos(size_ & size_t(-SIMDSIZE));
+  BLAZE_INTERNAL_ASSERT((size_ - (size_ % SIMDSIZE)) == ipos,
+                        "Invalid end calculation");
+
+  const size_t i4way(size_ & size_t(-SIMDSIZE * 4));
+  BLAZE_INTERNAL_ASSERT((size_ - (size_ % (SIMDSIZE * 4UL))) == i4way,
+                        "Invalid end calculation");
+  BLAZE_INTERNAL_ASSERT(i4way <= ipos, "Invalid end calculation");
+
+  size_t i(0UL);
+  blaze_const_iterator_t<VT> it((~rhs).begin());
+
+  for (; i < i4way; i += SIMDSIZE * 4UL) {
+    store(i, load(i) / it.load());
+    it += SIMDSIZE;
+    store(i + SIMDSIZE, load(i + SIMDSIZE) / it.load());
+    it += SIMDSIZE;
+    store(i + SIMDSIZE * 2UL, load(i + SIMDSIZE * 2UL) / it.load());
+    it += SIMDSIZE;
+    store(i + SIMDSIZE * 3UL, load(i + SIMDSIZE * 3UL) / it.load());
+    it += SIMDSIZE;
+  }
+  for (; i < ipos; i += SIMDSIZE, it += SIMDSIZE) {
+    store(i, load(i) / it.load());  // LCOV_EXCL_LINE
+  }
+  for (; i < size_; ++i, ++it) {
+    // clang-tidy: do not use pointer arithmetic
+    v_[i] /= *it;  // NOLINT
+  }
+}
+/// \endcond
+
+#define CHECK_FOR_SIZE_ZERO(SCALAR_TYPE)                                    \
+  template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,   \
+            typename ExprResultType>                                        \
+  inline bool operator==(                                                   \
+      const PointerVector<Type, AF, PF, TF, ExprResultType>& a,             \
+      const SCALAR_TYPE& b) noexcept {                                      \
+    ASSERT(a.size() != 0,                                                   \
+           "Comparing an empty vector to a value usually indicates a bug, " \
+           "and so is disallowed.");                                        \
+    return static_cast<const typename PointerVector<                        \
+               Type, AF, PF, TF, ExprResultType>::BaseType&>(a) == b;       \
+  }                                                                         \
+                                                                            \
+  template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,   \
+            typename ExprResultType>                                        \
+  inline bool operator==(                                                   \
+      const SCALAR_TYPE& a,                                                 \
+      const PointerVector<Type, AF, PF, TF, ExprResultType>& b) noexcept {  \
+    return b == a;                                                          \
+  }                                                                         \
+                                                                            \
+  template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,   \
+            typename ExprResultType>                                        \
+  inline bool operator!=(                                                   \
+      const PointerVector<Type, AF, PF, TF, ExprResultType>& a,             \
+      const SCALAR_TYPE& b) noexcept {                                      \
+    return not(a == b);                                                     \
+  }                                                                         \
+                                                                            \
+  template <typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,   \
+            typename ExprResultType>                                        \
+  inline bool operator!=(                                                   \
+      const SCALAR_TYPE& a,                                                 \
+      const PointerVector<Type, AF, PF, TF, ExprResultType>& b) noexcept {  \
+    return not(a == b);                                                     \
+  }
+
+CHECK_FOR_SIZE_ZERO(double)
+CHECK_FOR_SIZE_ZERO(std::complex<double>)
+#undef CHECK_FOR_SIZE_ZERO
+
+// There is a bug either in Blaze or in vector intrinsics implementation in GCC
+// that results in _mm_set1_epi64 not being callable with an `unsigned long`.
+// The way to work around this is to use a forwarding reference (which is super
+// aggressive and matches everything), convert the exponent to a double, and
+// then call the double pow.
+template <
+    typename Type, AlignmentFlag_t AF, PaddingFlag_t PF, bool TF,
+    typename ExprResultType, typename T,
+    typename = std::enable_if_t<std::is_fundamental<std::decay_t<T>>::value>>
+decltype(auto) pow(const PointerVector<Type, AF, PF, TF, ExprResultType>& t,
+                   T&& exponent) noexcept {
+  using ReturnType =
+      const blaze::DVecMapExpr<PointerVector<Type, AF, PF, TF, ExprResultType>,
+                               BlazePow<double>, TF>;
+#if ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION >= 6))
+  return ReturnType(
+      t, BlazePow<double>{blaze::Pow{}, static_cast<double>(exponent)});
+#else
+  return ReturnType(t, BlazePow<double>{static_cast<double>(exponent)});
+#endif
+}

--- a/src/Utilities/VectorAlgebra.hpp
+++ b/src/Utilities/VectorAlgebra.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include "Utilities/Blaze.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/PointerVector.hpp"  // For blaze::MultTrait
 
 // @{
 /// \ingroup UtilitiesGroup

--- a/support/Environments/frontera_gcc.sh
+++ b/support/Environments/frontera_gcc.sh
@@ -64,7 +64,7 @@ EOF
         echo "Installing Blaze..."
         mkdir -p $dep_dir/blaze/
         cd $dep_dir/blaze/
-        wget https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.8.tar.gz -O blaze.tar.gz
+        wget https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.7.tar.gz -O blaze.tar.gz
         tar -xzf blaze.tar.gz
         mv blaze-* include
         echo "Installed Blaze into $dep_dir/blaze"

--- a/support/Environments/wheeler_clang.sh
+++ b/support/Environments/wheeler_clang.sh
@@ -9,7 +9,7 @@ spectre_setup_modules() {
 
 spectre_unload_modules() {
     module unload gcc/7.3.0
-    module unload blaze/3.8
+    module unload blaze/3.7
     module unload boost/1.65.0-gcc-6.4.0
     module unload brigand/master
     module unload catch/2.1.2
@@ -31,7 +31,7 @@ spectre_unload_modules() {
 
 spectre_load_modules() {
     module load gcc/7.3.0
-    module load blaze/3.8
+    module load blaze/3.7
     module load boost/1.65.0-gcc-6.4.0
     module load brigand/master
     module load catch/2.1.2

--- a/support/Environments/wheeler_gcc.sh
+++ b/support/Environments/wheeler_gcc.sh
@@ -9,7 +9,7 @@ spectre_setup_modules() {
 
 spectre_unload_modules() {
     module unload gcc/7.3.0
-    module unload blaze/3.8
+    module unload blaze/3.7
     module unload boost/1.65.0-gcc-6.4.0
     module unload brigand/master
     module unload catch/2.1.2
@@ -31,7 +31,7 @@ spectre_unload_modules() {
 
 spectre_load_modules() {
     module load gcc/7.3.0
-    module load blaze/3.8
+    module load blaze/3.7
     module load boost/1.65.0-gcc-6.4.0
     module load brigand/master
     module load catch/2.1.2

--- a/tests/Unit/DataStructures/Test_VectorImpl.cpp
+++ b/tests/Unit/DataStructures/Test_VectorImpl.cpp
@@ -37,3 +37,24 @@ static_assert(not is_derived_of_vector_impl_v<std::complex<double>>,
 static_assert(not is_derived_of_vector_impl_v<std::vector<int>>,
               "Failed testing type trait is_derived_of_vector_impl");
 
+// [[OutputRegex, Comparing an empty vector to a value]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.DataStructures.VectorImpl.empty_equals_double",
+    "[DataStructures][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  (void)(DataVector{} == 1.0);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Comparing an empty vector to a value]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.DataStructures.VectorImpl.empty_equals_complex",
+    "[DataStructures][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  (void)(ComplexDataVector{} != std::complex<double>{});
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -434,6 +434,7 @@ enable_if() {
         whitelist "$1" \
                   'src/DataStructures/Tensor/Structure.hpp$' \
                   'src/IO/H5/File.hpp$' \
+                  'src/Utilities/PointerVector.hpp$' \
                   'src/Utilities/Requires.hpp$' \
                   'src/Utilities/TMPL.hpp$' \
                   'src/Utilities/TaggedTuple.hpp$' \

--- a/tools/Iwyu/iwyu.imp
+++ b/tools/Iwyu/iwyu.imp
@@ -13,6 +13,8 @@
               "\"DataStructures/DenseMatrix.hpp\"", public]},
   { include: ["@<blaze/.*>", private,
               "\"DataStructures/DenseVector.hpp\"", public]},
+  { include: ["@<blaze/.*>", private,
+              "\"Utilities/PointerVector.hpp\"", private]},
 
   { include: ["<ckmessage.h>", private,
               "<charm++.h>", public]},
@@ -96,4 +98,7 @@
               "\"AlgorithmSingleton.hpp\"", public]},
   { include: ["\"ParallelInfo.decl.h\"", private,
               "\"Executables/ParallelInfo/ParallelInfo.decl.h\"", public]},
+
+  { include: ["\"Utilities/PointerVector.hpp\"", private,
+              "\"DataStructures/DataVector.hpp\"", public]},
 ]

--- a/tools/SpectrePch.hpp
+++ b/tools/SpectrePch.hpp
@@ -14,7 +14,8 @@
 #include <utility>
 #include <vector>
 
-#include <Utilities/Blaze.hpp>
+// Include PointerVector.hpp since this is what we use to wrap Blaze
+#include <Utilities/PointerVector.hpp>
 #include <blaze/math/typetraits/IsVector.h>
 
 // Include Brigand related headers

--- a/tools/SpectrePch.hpp
+++ b/tools/SpectrePch.hpp
@@ -14,13 +14,8 @@
 #include <utility>
 #include <vector>
 
-#include <ErrorHandling/Assert.hpp>
 #include <Utilities/Blaze.hpp>
-#include <blaze/math/CustomVector.h>
 #include <blaze/math/typetraits/IsVector.h>
-#include <blaze/system/Optimizations.h>
-#include <blaze/system/Version.h>
-#include <blaze/util/typetraits/RemoveConst.h>
 
 // Include Brigand related headers
 #include <Utilities/TMPL.hpp>


### PR DESCRIPTION
## Proposed changes

Blaze 3.8 won't build with AVX/AVX2 intrinsics, which is basically all recent (year or two) CPUs.

I've filed an issue upstream asking for guidance on the matter: https://bitbucket.org/blaze-lib/blaze/issues/377/build-failure-with-avx-and-clang-10 but until that's resolved I'd like to be able to compile the code. I've already downgraded the container.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
