### PR TITLE
Setup databox action

### DIFF
--- a/src/Elliptic/Actions/InitializeAnalyticSolution.hpp
+++ b/src/Elliptic/Actions/InitializeAnalyticSolution.hpp
@@ -15,7 +15,7 @@
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Tags.hpp"
 #include "Parallel/GlobalCache.hpp"
-#include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+#include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -40,10 +40,20 @@ namespace Actions {
  * DataBox:
  * - Adds:
  *   - `db::wrap_tags_in<::Tags::Analytic, AnalyticSolutionFields>`
+ *
+ * \note This action relies on the `SetupDataBox` aggregated initialization
+ * mechanism, so `Actions::SetupDataBox` must be present in the `Initialization`
+ * phase action list prior to this action.
  */
 template <typename AnalyticSolutionTag, typename AnalyticSolutionFields>
 struct InitializeAnalyticSolution {
   using const_global_cache_tags = tmpl::list<AnalyticSolutionTag>;
+  using analytic_fields_tag =
+      db::add_tag_prefix<::Tags::Analytic,
+                          ::Tags::Variables<AnalyticSolutionFields>>;
+
+  using simple_tags = tmpl::list<analytic_fields_tag>;
+  using compute_tags = tmpl::list<>;
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             size_t Dim, typename ActionList, typename ParallelComponent>
@@ -53,20 +63,16 @@ struct InitializeAnalyticSolution {
                     const ElementId<Dim>& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    using analytic_fields_tag =
-        db::add_tag_prefix<::Tags::Analytic,
-                           ::Tags::Variables<AnalyticSolutionFields>>;
 
     const auto& inertial_coords =
         get<domain::Tags::Coordinates<Dim, Frame::Inertial>>(box);
     typename analytic_fields_tag::type analytic_fields{
         variables_from_tagged_tuple(get<AnalyticSolutionTag>(cache).variables(
             inertial_coords, AnalyticSolutionFields{}))};
+    Initialization::mutate_assign<simple_tags>(make_not_null(&box),
+                                               std::move(analytic_fields));
 
-    return std::make_tuple(
-        ::Initialization::merge_into_databox<
-            InitializeAnalyticSolution, db::AddSimpleTags<analytic_fields_tag>>(
-            std::move(box), std::move(analytic_fields)));
+    return std::make_tuple(std::move(box));
   }
 };
 

--- a/src/Elliptic/Executables/Elasticity/SolveElasticityProblem.hpp
+++ b/src/Elliptic/Executables/Elasticity/SolveElasticityProblem.hpp
@@ -28,6 +28,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/FirstOrderScheme.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/InitializationFunctions.hpp"
@@ -160,7 +161,7 @@ struct Metavariables {
   enum class Phase { Initialization, RegisterWithObserver, Solve, Exit };
 
   using initialization_actions = tmpl::list<
-      dg::Actions::InitializeDomain<volume_dim>,
+      Actions::SetupDataBox, dg::Actions::InitializeDomain<volume_dim>,
       dg::Actions::InitializeInterfaces<
           system, dg::Initialization::slice_tags_to_face<>,
           dg::Initialization::slice_tags_to_exterior<>,
@@ -168,7 +169,7 @@ struct Metavariables {
               domain::Tags::BoundaryCoordinates<volume_dim>>,
           dg::Initialization::exterior_compute_tags<>, false, false>,
       typename linear_solver::initialize_element,
-      elliptic::Actions::InitializeSystem,
+      elliptic::Actions::InitializeSystem<system>,
       Initialization::Actions::AddComputeTags<tmpl::list<
           Elasticity::Tags::PotentialEnergyDensityCompute<volume_dim>>>,
       elliptic::Actions::InitializeAnalyticSolution<analytic_solution_tag,

--- a/src/Elliptic/Executables/Poisson/SolvePoissonProblem.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoissonProblem.hpp
@@ -27,6 +27,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/FirstOrderScheme.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/InitializationFunctions.hpp"
@@ -147,14 +148,14 @@ struct Metavariables {
   enum class Phase { Initialization, RegisterWithObserver, Solve, Exit };
 
   using initialization_actions = tmpl::list<
-      dg::Actions::InitializeDomain<volume_dim>,
+      Actions::SetupDataBox, dg::Actions::InitializeDomain<volume_dim>,
       dg::Actions::InitializeInterfaces<
           system, dg::Initialization::slice_tags_to_face<>,
           dg::Initialization::slice_tags_to_exterior<>,
           dg::Initialization::face_compute_tags<>,
           dg::Initialization::exterior_compute_tags<>, false, false>,
       typename linear_solver::initialize_element,
-      elliptic::Actions::InitializeSystem,
+      elliptic::Actions::InitializeSystem<system>,
       elliptic::Actions::InitializeAnalyticSolution<analytic_solution_tag,
                                                     analytic_solution_fields>,
       elliptic::dg::Actions::ImposeInhomogeneousBoundaryConditionsOnSource<

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -198,9 +198,10 @@ struct EvolutionMetavars {
   };
 
   using initialization_actions = tmpl::list<
+      Actions::SetupDataBox,
       Initialization::Actions::TimeAndTimeStep<EvolutionMetavars>,
       evolution::dg::Initialization::Domain<1>,
-      Initialization::Actions::ConservativeSystem,
+      Initialization::Actions::ConservativeSystem<system>,
       evolution::Initialization::Actions::SetVariables<
           domain::Tags::Coordinates<1, Frame::Logical>>,
       Initialization::Actions::TimeStepperHistory<EvolutionMetavars>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -69,6 +69,7 @@
 #include "NumericalAlgorithms/Interpolation/Tags.hpp"
 #include "NumericalAlgorithms/Interpolation/TryToInterpolate.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
@@ -285,9 +286,10 @@ struct EvolutionMetavars {
   };
 
   using initialization_actions = tmpl::list<
+      Actions::SetupDataBox,
       Initialization::Actions::TimeAndTimeStep<EvolutionMetavars>,
       evolution::dg::Initialization::Domain<volume_dim>,
-      Initialization::Actions::NonconservativeSystem,
+      Initialization::Actions::NonconservativeSystem<system>,
       tmpl::conditional_t<
           evolution::is_numeric_initial_data_v<initial_data>, tmpl::list<>,
           evolution::Initialization::Actions::SetVariables<
@@ -331,6 +333,7 @@ struct EvolutionMetavars {
       Initialization::Actions::RemoveOptionsAndTerminatePhase>;
 
   using initialize_initial_data_dependent_quantities_actions = tmpl::list<
+      Actions::SetupDataBox,
       GeneralizedHarmonic::gauges::Actions::InitializeDampedHarmonic<
           volume_dim, use_damped_harmonic_rollon>,
       GeneralizedHarmonic::Actions::InitializeConstraints<volume_dim>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -64,6 +64,7 @@
 #include "NumericalAlgorithms/Interpolation/Tags.hpp"
 #include "NumericalAlgorithms/Interpolation/TryToInterpolate.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
@@ -264,10 +265,12 @@ struct EvolutionMetavars {
   };
 
   using initialization_actions = tmpl::list<
+      Actions::SetupDataBox,
       Initialization::Actions::TimeAndTimeStep<EvolutionMetavars>,
       evolution::dg::Initialization::Domain<3>,
-      Initialization::Actions::GrTagsForHydro,
-      Initialization::Actions::ConservativeSystem,
+      Initialization::Actions::GrTagsForHydro<system>,
+      Initialization::Actions::ConservativeSystem<system,
+                                                  equation_of_state_tag>,
       evolution::Initialization::Actions::SetVariables<
           domain::Tags::Coordinates<3, Frame::Logical>>,
       Initialization::Actions::TimeStepperHistory<EvolutionMetavars>,
@@ -294,7 +297,8 @@ struct EvolutionMetavars {
       dg::Actions::InitializeMortars<boundary_scheme>,
       Initialization::Actions::DiscontinuousGalerkin<EvolutionMetavars>,
       Initialization::Actions::Minmod<3>,
-      intrp::Actions::ElementInitInterpPoints,
+      intrp::Actions::ElementInitInterpPoints<
+          intrp::Tags::InterpPointInfo<EvolutionMetavars>>,
       Initialization::Actions::RemoveOptionsAndTerminatePhase>;
 
   using dg_element_array_component = DgElementArray<

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -39,6 +39,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/Hll.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
@@ -221,9 +222,11 @@ struct EvolutionMetavars {
   };
 
   using initialization_actions = tmpl::list<
+      Actions::SetupDataBox,
       Initialization::Actions::TimeAndTimeStep<EvolutionMetavars>,
       evolution::dg::Initialization::Domain<Dim>,
-      Initialization::Actions::ConservativeSystem,
+      Initialization::Actions::ConservativeSystem<system,
+                                                  equation_of_state_tag>,
       evolution::Initialization::Actions::SetVariables<
           domain::Tags::Coordinates<Dim, Frame::Logical>>,
       Initialization::Actions::TimeStepperHistory<EvolutionMetavars>,

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -42,6 +42,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/LocalLaxFriedrichs.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
@@ -209,14 +210,15 @@ struct EvolutionMetavars {
   };
 
   using initialization_actions = tmpl::list<
+      Actions::SetupDataBox,
       Initialization::Actions::TimeAndTimeStep<EvolutionMetavars>,
       evolution::dg::Initialization::Domain<volume_dim>,
-      Initialization::Actions::GrTagsForHydro,
-      Initialization::Actions::ConservativeSystem,
+      Initialization::Actions::GrTagsForHydro<system>,
+      Initialization::Actions::ConservativeSystem<system>,
       evolution::Initialization::Actions::SetVariables<
           domain::Tags::Coordinates<volume_dim, Frame::Logical>>,
       Initialization::Actions::TimeStepperHistory<EvolutionMetavars>,
-      RadiationTransport::M1Grey::Actions::InitializeM1Tags,
+      RadiationTransport::M1Grey::Actions::InitializeM1Tags<system>,
       Actions::MutateApply<typename RadiationTransport::M1Grey::
                                ComputeM1Closure<neutrino_species>>,
       Actions::MutateApply<typename RadiationTransport::M1Grey::

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -42,6 +42,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/LocalLaxFriedrichs.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
@@ -220,10 +221,12 @@ struct EvolutionMetavars {
   };
 
   using initialization_actions = tmpl::list<
+      Actions::SetupDataBox,
       Initialization::Actions::TimeAndTimeStep<EvolutionMetavars>,
       evolution::dg::Initialization::Domain<Dim>,
-      Initialization::Actions::GrTagsForHydro,
-      Initialization::Actions::ConservativeSystem,
+      Initialization::Actions::GrTagsForHydro<system>,
+      Initialization::Actions::ConservativeSystem<system,
+                                                  equation_of_state_tag>,
       evolution::Initialization::Actions::SetVariables<
           domain::Tags::Coordinates<Dim, Frame::Logical>>,
       Initialization::Actions::TimeStepperHistory<EvolutionMetavars>,

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -38,6 +38,7 @@
 #include "NumericalAlgorithms/LinearOperators/ExponentialFilter.hpp"
 #include "NumericalAlgorithms/LinearOperators/FilterAction.hpp"  // IWYU pragma: keep
 #include "Options/Options.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
@@ -204,9 +205,10 @@ struct EvolutionMetavars {
   };
 
   using initialization_actions = tmpl::list<
+      Actions::SetupDataBox,
       Initialization::Actions::TimeAndTimeStep<EvolutionMetavars>,
       evolution::dg::Initialization::Domain<volume_dim>,
-      Initialization::Actions::NonconservativeSystem,
+      Initialization::Actions::NonconservativeSystem<system>,
       evolution::Initialization::Actions::SetVariables<
           domain::Tags::Coordinates<Dim, Frame::Logical>>,
       Initialization::Actions::TimeStepperHistory<EvolutionMetavars>,

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -17,7 +17,7 @@
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Parallel/GlobalCache.hpp"
-#include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+#include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "Time/Slab.hpp"
 #include "Time/StepControllers/StepController.hpp"
 #include "Time/Tags.hpp"
@@ -72,11 +72,20 @@ namespace Actions {
 /// - Modifies: nothing
 ///
 /// \note HistoryEvolvedVariables is allocated, but needs to be initialized
+///
+/// \note This action relies on the `SetupDataBox` aggregated initialization
+/// mechanism, so `Actions::SetupDataBox` must be present in the
+/// `Initialization` phase action list prior to this action.
 template <typename Metavariables>
 struct TimeAndTimeStep {
   using initialization_tags =
       tmpl::list<Tags::InitialTime, Tags::InitialTimeDelta,
                  Tags::InitialSlabSize<Metavariables::local_time_stepping>>;
+
+  using simple_tags =
+      tmpl::list<::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>,
+                 ::Tags::Time, ::Tags::TimeStep>;
+  using compute_tags = tmpl::list<::Tags::SubstepTimeCompute>;
 
   template <
       typename DbTagsList, typename... InboxTags, typename ArrayIndex,
@@ -124,19 +133,12 @@ struct TimeAndTimeStep {
         -static_cast<int64_t>(time_stepper.number_of_past_steps()),
         initial_time);
 
-    using compute_tags = db::AddComputeTags<::Tags::SubstepTimeCompute>;
-
-    return std::make_tuple(
-        merge_into_databox<TimeAndTimeStep,
-                           db::AddSimpleTags<::Tags::TimeStepId,
-                                             ::Tags::Next<::Tags::TimeStepId>,
-                                             ::Tags::Time, ::Tags::TimeStep>,
-                           compute_tags>(
-            std::move(box),
-            // At this point we have not started evolution yet, so the current
-            // time is undefined and _next_ is the initial time.
-            TimeStepId{}, time_id, std::numeric_limits<double>::signaling_NaN(),
-            initial_dt));
+    Initialization::mutate_assign<
+        tmpl::list<::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>,
+                   ::Tags::Time, ::Tags::TimeStep>>(
+        make_not_null(&box), TimeStepId{}, time_id,
+        std::numeric_limits<double>::signaling_NaN(), initial_dt);
+    return std::make_tuple(std::move(box));
   }
 
   template <
@@ -182,6 +184,10 @@ struct TimeAndTimeStep {
 /// - Modifies: nothing
 ///
 /// \note HistoryEvolvedVariables is allocated, but needs to be initialized
+///
+/// \note This action relies on the `SetupDataBox` aggregated initialization
+/// mechanism, so `Actions::SetupDataBox` must be present in the
+/// `Initialization` phase action list prior to this action.
 template <typename Metavariables>
 struct TimeStepperHistory {
   using initialization_tags = tmpl::list<>;
@@ -203,6 +209,13 @@ struct TimeStepperHistory {
   struct ComputeTags<System, true> {
     using type = db::AddComputeTags<>;
   };
+
+  using simple_tags =
+      tmpl::list<dt_variables_tag,
+                 ::Tags::HistoryEvolvedVariables<variables_tag>>;
+
+  using compute_tags =
+      typename ComputeTags<typename Metavariables::system>::type;
 
   template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
             typename ActionList, typename ParallelComponent,
@@ -227,15 +240,10 @@ struct TimeStepperHistory {
     DtVars dt_vars{num_grid_points};
     typename ::Tags::HistoryEvolvedVariables<variables_tag>::type history;
 
-    using compute_tags =
-        typename ComputeTags<typename Metavariables::system>::type;
-    return std::make_tuple(
-        merge_into_databox<
-            TimeStepperHistory,
-            db::AddSimpleTags<dt_variables_tag,
-                              ::Tags::HistoryEvolvedVariables<variables_tag>>,
-            compute_tags>(std::move(box), std::move(dt_vars),
-                          std::move(history)));
+    Initialization::mutate_assign<simple_tags>(
+        make_not_null(&box), std::move(dt_vars), std::move(history));
+
+    return std::make_tuple(std::move(box));
   }
 
   template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,

--- a/src/Evolution/Initialization/Limiter.hpp
+++ b/src/Evolution/Initialization/Limiter.hpp
@@ -30,6 +30,10 @@ namespace Actions {
 ///
 /// - Removes: nothing
 /// - Modifies: nothing
+///
+/// \note This action relies on the `SetupDataBox` aggregated initialization
+/// mechanism, so `Actions::SetupDataBox` must be present in the
+/// `Initialization` phase action list prior to this action.
 template <size_t Dim>
 struct Minmod {
   using simple_tags = db::AddSimpleTags<>;
@@ -43,9 +47,7 @@ struct Minmod {
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/, ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    return std::make_tuple(
-        merge_into_databox<Minmod, db::AddSimpleTags<>, compute_tags>(
-            std::move(box)));
+    return std::make_tuple(std::move(box));
   }
 };
 }  // namespace Actions

--- a/src/Evolution/Initialization/NonconservativeSystem.hpp
+++ b/src/Evolution/Initialization/NonconservativeSystem.hpp
@@ -10,7 +10,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "Evolution/Initialization/InitialData.hpp"
 #include "Parallel/GlobalCache.hpp"
-#include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+#include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -39,7 +39,19 @@ namespace Actions {
 ///
 /// - Removes: nothing
 /// - Modifies: nothing
+///
+/// \note This action relies on the `SetupDataBox` aggregated initialization
+/// mechanism, so `Actions::SetupDataBox` must be present in the
+/// `Initialization` phase action list prior to this action.
+template <typename System>
 struct NonconservativeSystem {
+  static_assert(not System::is_in_flux_conservative_form,
+                "System is in flux conservative form");
+  static constexpr size_t dim = System::volume_dim;
+  using variables_tag = typename System::variables_tag;
+  using simple_tags = db::AddSimpleTags<variables_tag>;
+  using compute_tags = db::AddComputeTags<>;
+
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>
@@ -48,19 +60,12 @@ struct NonconservativeSystem {
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/, ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    using system = typename Metavariables::system;
-    static_assert(not system::is_in_flux_conservative_form,
-                  "System is in flux conservative form");
-    static constexpr size_t dim = system::volume_dim;
-    using variables_tag = typename system::variables_tag;
-    using simple_tags = db::AddSimpleTags<variables_tag>;
-    using compute_tags = db::AddComputeTags<>;
     using Vars = typename variables_tag::type;
+    Initialization::mutate_assign<simple_tags>(
+        make_not_null(&box),
+        Vars{db::get<domain::Tags::Mesh<dim>>(box).number_of_grid_points()});
 
-    return std::make_tuple(
-        merge_into_databox<NonconservativeSystem, simple_tags, compute_tags>(
-            std::move(box), Vars{db::get<domain::Tags::Mesh<dim>>(box)
-                                     .number_of_grid_points()}));
+    return std::make_tuple(std::move(box));
   }
 };
 }  // namespace Actions

--- a/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionScri.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionScri.hpp
@@ -11,7 +11,7 @@
 #include "Evolution/Systems/Cce/OptionTags.hpp"
 #include "Evolution/Systems/Cce/ScriPlusInterpolationManager.hpp"
 #include "Parallel/GlobalCache.hpp"
-#include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+#include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "Utilities/Rational.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
@@ -34,65 +34,57 @@ namespace Actions {
  *  - `Cce::Tags::InterpolationManager<ComplexDataVector, Tag>` for each `Tag`
  * in `scri_values_to_observe`
  * - Removes: nothing
+ *
+ * \note This action relies on the `SetupDataBox` aggregated initialization
+ * mechanism, so `Actions::SetupDataBox` must be present in the `Initialization`
+ * phase action list prior to this action.
  */
+template <typename ScriValuesToObserve>
 struct InitializeCharacteristicEvolutionScri {
   using initialization_tags =
       tmpl::list<InitializationTags::ScriInterpolationOrder>;
   using const_global_cache_tags =
       tmpl::list<Tags::LMax, Tags::NumberOfRadialPoints>;
 
-  template <
-      typename DbTags, typename... InboxTags, typename Metavariables,
-      typename ArrayIndex, typename ActionList, typename ParallelComponent,
-      Requires<tmpl::list_contains_v<
-          DbTags, InitializationTags::ScriInterpolationOrder>> = nullptr>
+  using simple_tags =
+      tmpl::transform<ScriValuesToObserve,
+                      tmpl::bind<Tags::InterpolationManager,
+                                 tmpl::pin<ComplexDataVector>, tmpl::_1>>;
+
+  using compute_tags = tmpl::list<>;
+
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
   static auto apply(db::DataBox<DbTags>& box,
                     const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    return std::make_tuple(initialize_impl(
-        std::move(box), typename Metavariables::scri_values_to_observe{}));
+    initialize_impl(make_not_null(&box),
+                    typename Metavariables::scri_values_to_observe{});
+    return std::make_tuple(std::move(box));
   }
 
   template <typename TagList, typename... TagPack>
-  static auto initialize_impl(db::DataBox<TagList>&& box,
+  static void initialize_impl(const gsl::not_null<db::DataBox<TagList>*> box,
                               tmpl::list<TagPack...> /*meta*/) noexcept {
     const size_t target_number_of_points =
-        db::get<InitializationTags::ScriInterpolationOrder>(box);
+        db::get<InitializationTags::ScriInterpolationOrder>(*box);
     const size_t vector_size =
         Spectral::Swsh::number_of_swsh_collocation_points(
-            db::get<Spectral::Swsh::Tags::LMaxBase>(box));
+            db::get<Spectral::Swsh::Tags::LMaxBase>(*box));
     // silence compiler warnings when pack is empty
     (void)vector_size;
-    return Initialization::merge_into_databox<
-        InitializeCharacteristicEvolutionScri,
-        db::AddSimpleTags<
-            Tags::InterpolationManager<ComplexDataVector, TagPack>...>,
-        db::AddComputeTags<>, Initialization::MergePolicy::Overwrite>(
-        std::move(box),
-        ScriPlusInterpolationManager<ComplexDataVector, TagPack>{
-            target_number_of_points, vector_size,
-            std::make_unique<intrp::BarycentricRationalSpanInterpolator>(
-                2 * target_number_of_points - 1,
-                2 * target_number_of_points + 2)}...);
-  }
-
-  template <typename DbTags, typename... InboxTags, typename Metavariables,
-            typename ArrayIndex, typename ActionList,
-            typename ParallelComponent,
-            Requires<not tmpl::list_contains_v<
-                DbTags, InitializationTags::ScriInterpolationOrder>> = nullptr>
-  static std::tuple<db::DataBox<DbTags>&&> apply(
-      const db::DataBox<DbTags>& /*box*/,
-      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-      const Parallel::GlobalCache<Metavariables>& /*cache*/,
-      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
-      const ParallelComponent* const /*meta*/) noexcept {
-    ERROR(
-        "The DataBox is missing required dependency "
-        "`Cce::InitializationTags::ScriPlusInterpolationOrder.`");
+    if constexpr (sizeof...(TagPack) > 0) {
+      Initialization::mutate_assign<simple_tags>(
+          box, ScriPlusInterpolationManager<ComplexDataVector, TagPack>{
+                   target_number_of_points, vector_size,
+                   std::make_unique<intrp::BarycentricRationalSpanInterpolator>(
+                       2 * target_number_of_points - 1,
+                       2 * target_number_of_points + 2)}...);
+    }
   }
 };
 }  // namespace Actions

--- a/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionVariables.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionVariables.hpp
@@ -14,7 +14,7 @@
 #include "Evolution/Systems/Cce/OptionTags.hpp"
 #include "NumericalAlgorithms/Spectral/SwshInterpolation.hpp"
 #include "Parallel/GlobalCache.hpp"
-#include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+#include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -56,23 +56,16 @@ namespace Actions {
  *  - `Tags::Variables<metavariables::cce_swsh_derivative_tags>`
  *  - `Spectral::Swsh::Tags::SwshInterpolator< Tags::CauchyAngularCoords>`
  * - Removes: nothing
+ *
+ * \note This action relies on the `SetupDataBox` aggregated initialization
+ * mechanism, so `Actions::SetupDataBox` must be present in the `Initialization`
+ * phase action list prior to this action.
  */
+template <typename Metavariables>
 struct InitializeCharacteristicEvolutionVariables {
   using const_global_cache_tags =
       tmpl::list<Tags::LMax, Tags::NumberOfRadialPoints>;
 
-  template <
-      typename DbTags, typename... InboxTags, typename Metavariables,
-      typename ArrayIndex, typename ActionList, typename ParallelComponent,
-      Requires<not tmpl::list_contains_v<
-          DbTags, ::Tags::Variables<tmpl::list<
-                      typename Metavariables::evolved_swsh_tag>>>> = nullptr>
-  static auto apply(db::DataBox<DbTags>& box,
-                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
-                    const ArrayIndex& /*array_index*/,
-                    const ActionList /*meta*/,
-                    const ParallelComponent* const /*meta*/) noexcept {
     using boundary_value_variables_tag = ::Tags::Variables<
         tmpl::append<typename Metavariables::cce_boundary_communication_tags,
                      typename Metavariables::cce_gauge_boundary_tags>>;
@@ -99,6 +92,27 @@ struct InitializeCharacteristicEvolutionVariables {
     using evolved_swsh_dt_variables_tag =
         db::add_tag_prefix<::Tags::dt, evolved_swsh_variables_tag>;
 
+  using simple_tags = tmpl::list<
+      boundary_value_variables_tag, coordinate_variables_tag,
+      dt_coordinate_variables_tag, evolved_swsh_variables_tag,
+      evolved_swsh_dt_variables_tag, angular_coordinates_variables_tag,
+      scri_variables_tag, volume_variables_tag,
+      pre_swsh_derivatives_variables_tag, transform_buffer_variables_tag,
+      swsh_derivative_variables_tag,
+      Spectral::Swsh::Tags::SwshInterpolator<Tags::CauchyAngularCoords>>;
+
+  using compute_tags = tmpl::list<>;
+
+  template <
+      typename DbTags, typename... InboxTags, typename ArrayIndex,
+      typename ActionList, typename ParallelComponent>
+  static auto apply(db::DataBox<DbTags>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+
     const size_t l_max = db::get<Spectral::Swsh::Tags::LMaxBase>(box);
     const size_t number_of_radial_points =
         db::get<Spectral::Swsh::Tags::NumberOfRadialPointsBase>(box);
@@ -108,50 +122,23 @@ struct InitializeCharacteristicEvolutionVariables {
     const size_t transform_buffer_size =
         number_of_radial_points *
         Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max);
-    return std::make_tuple(
-        Initialization::merge_into_databox<
-            InitializeCharacteristicEvolutionVariables,
-            db::AddSimpleTags<
-                boundary_value_variables_tag, coordinate_variables_tag,
-                dt_coordinate_variables_tag, evolved_swsh_variables_tag,
-                evolved_swsh_dt_variables_tag,
-                angular_coordinates_variables_tag, scri_variables_tag,
-                volume_variables_tag, pre_swsh_derivatives_variables_tag,
-                transform_buffer_variables_tag, swsh_derivative_variables_tag,
-                Spectral::Swsh::Tags::SwshInterpolator<
-                    Tags::CauchyAngularCoords>>,
-            db::AddComputeTags<>, Initialization::MergePolicy::Overwrite>(
-            std::move(box),
-            typename boundary_value_variables_tag::type{boundary_size},
-            typename coordinate_variables_tag::type{boundary_size},
-            typename dt_coordinate_variables_tag::type{boundary_size},
-            typename evolved_swsh_variables_tag::type{volume_size},
-            typename evolved_swsh_dt_variables_tag::type{volume_size},
-            typename angular_coordinates_variables_tag::type{boundary_size},
-            typename scri_variables_tag::type{boundary_size},
-            typename volume_variables_tag::type{volume_size},
-            typename pre_swsh_derivatives_variables_tag::type{volume_size, 0.0},
-            typename transform_buffer_variables_tag::type{transform_buffer_size,
-                                                          0.0},
-            typename swsh_derivative_variables_tag::type{volume_size, 0.0},
-            Spectral::Swsh::SwshInterpolator{}));
-  }
+    Initialization::mutate_assign<simple_tags>(
+        make_not_null(&box),
+        typename boundary_value_variables_tag::type{boundary_size},
+        typename coordinate_variables_tag::type{boundary_size},
+        typename dt_coordinate_variables_tag::type{boundary_size},
+        typename evolved_swsh_variables_tag::type{volume_size},
+        typename evolved_swsh_dt_variables_tag::type{volume_size},
+        typename angular_coordinates_variables_tag::type{boundary_size},
+        typename scri_variables_tag::type{boundary_size},
+        typename volume_variables_tag::type{volume_size},
+        typename pre_swsh_derivatives_variables_tag::type{volume_size, 0.0},
+        typename transform_buffer_variables_tag::type{transform_buffer_size,
+                                                      0.0},
+        typename swsh_derivative_variables_tag::type{volume_size, 0.0},
+        Spectral::Swsh::SwshInterpolator{});
 
-  template <
-      typename DbTags, typename... InboxTags, typename Metavariables,
-      typename ArrayIndex, typename ActionList, typename ParallelComponent,
-      Requires<tmpl::list_contains_v<
-          DbTags, ::Tags::Variables<tmpl::list<
-                      typename Metavariables::evolved_swsh_tag>>>> = nullptr>
-  static std::tuple<db::DataBox<DbTags>&&> apply(
-      const db::DataBox<DbTags>& /*box*/,
-      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-      const Parallel::GlobalCache<Metavariables>& /*cache*/,
-      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
-      const ParallelComponent* const /*meta*/) noexcept {
-    ERROR(
-        "The DataBox has already been initialized with Cce characteristic "
-        "evolution variables. Only initialize the Cce databox once.");
+    return std::make_tuple(std::move(box));
   }
 };
 

--- a/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
@@ -25,6 +25,7 @@
 #include "Evolution/Systems/Cce/ScriPlusValues.hpp"
 #include "Evolution/Systems/Cce/SwshDerivatives.hpp"
 #include "IO/Observer/ObserverComponent.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
@@ -92,16 +93,20 @@ struct CharacteristicEvolution {
   using chare_type = Parallel::Algorithms::Singleton;
   using metavariables = Metavariables;
 
-  using initialize_action_list =
-      tmpl::list<Actions::InitializeCharacteristicEvolutionVariables,
-                 Actions::InitializeCharacteristicEvolutionTime,
-                 Actions::InitializeCharacteristicEvolutionScri,
-                 Actions::RequestBoundaryData<
-                     typename Metavariables::cce_boundary_component,
-                     CharacteristicEvolution<Metavariables>>,
-                 Actions::ReceiveWorldtubeData<Metavariables>,
-                 Actions::InitializeFirstHypersurface,
-                 Initialization::Actions::RemoveOptionsAndTerminatePhase>;
+  using initialize_action_list = tmpl::list<
+      ::Actions::SetupDataBox,
+      Actions::InitializeCharacteristicEvolutionVariables<Metavariables>,
+      Actions::InitializeCharacteristicEvolutionTime<
+          typename Metavariables::evolved_coordinates_variables_tag,
+          typename Metavariables::evolved_swsh_tag>,
+      Actions::InitializeCharacteristicEvolutionScri<
+          typename Metavariables::scri_values_to_observe>,
+      Actions::RequestBoundaryData<
+          typename Metavariables::cce_boundary_component,
+          CharacteristicEvolution<Metavariables>>,
+      Actions::ReceiveWorldtubeData<Metavariables>,
+      Actions::InitializeFirstHypersurface,
+      Initialization::Actions::RemoveOptionsAndTerminatePhase>;
 
   using initialization_tags =
       Parallel::get_initialization_tags<initialize_action_list>;

--- a/src/Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp
+++ b/src/Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp
@@ -5,6 +5,7 @@
 
 #include "Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp"
 #include "Evolution/Systems/Cce/BoundaryData.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Info.hpp"
@@ -41,7 +42,9 @@ struct H5WorldtubeBoundary {
   using chare_type = Parallel::Algorithms::Singleton;
   using metavariables = Metavariables;
   using initialize_action_list =
-      tmpl::list<Actions::InitializeH5WorldtubeBoundary,
+      tmpl::list<::Actions::SetupDataBox,
+                 Actions::InitializeH5WorldtubeBoundary<
+                     typename Metavariables::cce_boundary_communication_tags>,
                  Initialization::Actions::RemoveOptionsAndTerminatePhase>;
   using initialization_tags =
       Parallel::get_initialization_tags<initialize_action_list>;
@@ -108,7 +111,9 @@ struct GhWorldtubeBoundary {
   using chare_type = Parallel::Algorithms::Singleton;
   using metavariables = Metavariables;
   using initialize_action_list =
-      tmpl::list<Actions::InitializeGhWorldtubeBoundary,
+      tmpl::list<::Actions::SetupDataBox,
+                 Actions::InitializeGhWorldtubeBoundary<
+                     typename Metavariables::cce_boundary_communication_tags>,
                  Initialization::Actions::RemoveOptionsAndTerminatePhase>;
   using initialization_tags =
       Parallel::get_initialization_tags<initialize_action_list>;

--- a/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
@@ -59,6 +59,22 @@ template <size_t Dim>
 struct InitializeConstraints {
   using frame = Frame::Inertial;
 
+  using compute_tags = tmpl::flatten<db::AddComputeTags<
+      GeneralizedHarmonic::Tags::GaugeConstraintCompute<Dim, frame>,
+      // following tags added to observe constraints
+      ::Tags::PointwiseL2NormCompute<
+          GeneralizedHarmonic::Tags::GaugeConstraint<Dim, frame>>,
+      ::Tags::PointwiseL2NormCompute<
+          GeneralizedHarmonic::Tags::ThreeIndexConstraint<Dim, frame>>,
+      // The 4-index constraint is only implemented in 3d
+      tmpl::conditional_t<
+          Dim == 3,
+          tmpl::list<
+              GeneralizedHarmonic::Tags::FourIndexConstraintCompute<Dim, frame>,
+              ::Tags::PointwiseL2NormCompute<
+                  GeneralizedHarmonic::Tags::FourIndexConstraint<Dim, frame>>>,
+          tmpl::list<>>>>;
+
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>
@@ -68,33 +84,26 @@ struct InitializeConstraints {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    using compute_tags = tmpl::flatten<db::AddComputeTags<
-        GeneralizedHarmonic::Tags::GaugeConstraintCompute<Dim, frame>,
-        // following tags added to observe constraints
-        ::Tags::PointwiseL2NormCompute<
-            GeneralizedHarmonic::Tags::GaugeConstraint<Dim, frame>>,
-        ::Tags::PointwiseL2NormCompute<
-            GeneralizedHarmonic::Tags::ThreeIndexConstraint<Dim, frame>>,
-        // The 4-index constraint is only implemented in 3d
-        tmpl::conditional_t<
-            Dim == 3,
-            tmpl::list<GeneralizedHarmonic::Tags::FourIndexConstraintCompute<
-                           Dim, frame>,
-                       ::Tags::PointwiseL2NormCompute<
-                           GeneralizedHarmonic::Tags::FourIndexConstraint<
-                               Dim, frame>>>,
-            tmpl::list<>>>>;
-
-    return std::make_tuple(
-        Initialization::merge_into_databox<InitializeConstraints,
-                                           db::AddSimpleTags<>, compute_tags>(
-            std::move(box)));
+    return std::make_tuple(std::move(box));
   }
 };
 
 template <size_t Dim>
 struct InitializeGhAnd3Plus1Variables {
   using frame = Frame::Inertial;
+  using compute_tags = db::AddComputeTags<
+      gr::Tags::SpatialMetricCompute<Dim, frame, DataVector>,
+      gr::Tags::DetAndInverseSpatialMetricCompute<Dim, frame, DataVector>,
+      gr::Tags::ShiftCompute<Dim, frame, DataVector>,
+      gr::Tags::LapseCompute<Dim, frame, DataVector>,
+      gr::Tags::SqrtDetSpatialMetricCompute<Dim, frame, DataVector>,
+      gr::Tags::SpacetimeNormalOneFormCompute<Dim, frame, DataVector>,
+      gr::Tags::SpacetimeNormalVectorCompute<Dim, frame, DataVector>,
+      gr::Tags::InverseSpacetimeMetricCompute<Dim, frame, DataVector>,
+      GeneralizedHarmonic::Tags::ThreeIndexConstraintCompute<Dim, frame>,
+      ConstraintDamping::Tags::ConstraintGamma0Compute<Dim, frame>,
+      ConstraintDamping::Tags::ConstraintGamma1Compute<Dim, frame>,
+      ConstraintDamping::Tags::ConstraintGamma2Compute<Dim, frame>>;
 
   using const_global_cache_tags = tmpl::list<
       GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma0<
@@ -113,27 +122,7 @@ struct InitializeGhAnd3Plus1Variables {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    using compute_tags = db::AddComputeTags<
-        gr::Tags::SpatialMetricCompute<Dim, frame, DataVector>,
-        gr::Tags::DetAndInverseSpatialMetricCompute<Dim, frame, DataVector>,
-        gr::Tags::ShiftCompute<Dim, frame, DataVector>,
-        gr::Tags::LapseCompute<Dim, frame, DataVector>,
-        gr::Tags::SqrtDetSpatialMetricCompute<Dim, frame, DataVector>,
-        gr::Tags::SpacetimeNormalOneFormCompute<Dim, frame, DataVector>,
-        gr::Tags::SpacetimeNormalVectorCompute<Dim, frame, DataVector>,
-        gr::Tags::InverseSpacetimeMetricCompute<Dim, frame, DataVector>,
-        GeneralizedHarmonic::Tags::ThreeIndexConstraintCompute<Dim, frame>,
-        GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma0Compute<
-            Dim, frame>,
-        GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1Compute<
-            Dim, frame>,
-        GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2Compute<
-            Dim, frame>>;
-
-    return std::make_tuple(
-        Initialization::merge_into_databox<InitializeGhAnd3Plus1Variables,
-                                           db::AddSimpleTags<>, compute_tags>(
-            std::move(box)));
+    return std::make_tuple(std::move(box));
   }
 };
 

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -26,6 +26,7 @@
 #include "IO/Observer/ObserverComponent.hpp"
 #include "IO/Observer/VolumeActions.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Info.hpp"
@@ -205,6 +206,7 @@ struct Metavariables {
                   typename Metavariables::Phase,
                   Metavariables::Phase::Initialization,
                   tmpl::list<
+                      Actions::SetupDataBox,
                       Initialization::Actions::TimeAndTimeStep<Metavariables>,
                       evolution::dg::Initialization::Domain<Dim>,
                       Initialization::Actions::AddComputeTags<

--- a/src/IO/Observer/Initialize.hpp
+++ b/src/IO/Observer/Initialize.hpp
@@ -24,18 +24,22 @@ using reduction_data_to_reduction_names = typename Tag::names_tag;
  * Uses:
  * - Metavariables:
  *   - `observed_reduction_data_tags` (see ContributeReductionData)
+ *
+ * \note This action relies on the `SetupDataBox` aggregated initialization
+ * mechanism, so `Actions::SetupDataBox` must be present in the `Initialization`
+ * phase action list prior to this action.
  */
 template <class Metavariables>
 struct Initialize {
   using simple_tags = tmpl::append<
-      db::AddSimpleTags<Tags::ExpectedContributorsForObservations,
-                        Tags::ContributorsOfReductionData,
-                        Tags::ContributorsOfTensorData, Tags::TensorData>,
+      tmpl::list<Tags::ExpectedContributorsForObservations,
+                 Tags::ContributorsOfReductionData,
+                 Tags::ContributorsOfTensorData, Tags::TensorData>,
       typename Metavariables::observed_reduction_data_tags,
       tmpl::transform<
           typename Metavariables::observed_reduction_data_tags,
           tmpl::bind<detail::reduction_data_to_reduction_names, tmpl::_1>>>;
-  using compute_tags = db::AddComputeTags<>;
+  using compute_tags = tmpl::list<>;
 
   using return_tag_list = tmpl::append<simple_tags, compute_tags>;
 
@@ -47,32 +51,7 @@ struct Initialize {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    if constexpr (not tmpl::list_contains_v<DbTagsList, Tags::TensorData>) {
-      return helper(typename Metavariables::observed_reduction_data_tags{});
-    } else {
-      ERROR("You appear to be initializing the Observer twice.");
-      return std::make_tuple(std::move(box));
-    }
-  }
-
- private:
-  template <typename... ReductionTags>
-  static auto helper(tmpl::list<ReductionTags...> /*meta*/) noexcept {
-    return std::make_tuple(
-        db::create<simple_tags>(
-            std::unordered_map<ObservationKey,
-                               std::unordered_set<ArrayComponentId>>{},
-            std::unordered_map<ObservationId,
-                               std::unordered_set<ArrayComponentId>>{},
-            std::unordered_map<ObservationId,
-                               std::unordered_set<ArrayComponentId>>{},
-            std::unordered_map<observers::ObservationId,
-                               std::unordered_map<observers::ArrayComponentId,
-                                                  ElementVolumeData>>{},
-            typename ReductionTags::type{}...,
-            typename detail::reduction_data_to_reduction_names<
-                ReductionTags>::type{}...),
-        true);
+    return std::make_tuple(std::move(box));
   }
 };
 
@@ -83,21 +62,24 @@ struct Initialize {
  * Uses:
  * - Metavariables:
  *   - `observed_reduction_data_tags` (see ContributeReductionData)
+ *
+ * \note This action relies on the `SetupDataBox` aggregated initialization
+ * mechanism, so `Actions::SetupDataBox` must be present in the `Initialization`
+ * phase action list prior to this action.
  */
 template <class Metavariables>
 struct InitializeWriter {
   using simple_tags = tmpl::append<
-      db::AddSimpleTags<Tags::ExpectedContributorsForObservations,
-                        Tags::ContributorsOfReductionData,
-                        Tags::ReductionDataLock, Tags::ContributorsOfTensorData,
-                        Tags::VolumeDataLock, Tags::TensorData,
-                        Tags::NodesExpectedToContributeReductions,
-                        Tags::NodesThatContributedReductions, Tags::H5FileLock>,
+      tmpl::list<Tags::ExpectedContributorsForObservations,
+                 Tags::ContributorsOfReductionData, Tags::ReductionDataLock,
+                 Tags::ContributorsOfTensorData, Tags::VolumeDataLock,
+                 Tags::TensorData, Tags::NodesExpectedToContributeReductions,
+                 Tags::NodesThatContributedReductions, Tags::H5FileLock>,
       typename Metavariables::observed_reduction_data_tags,
       tmpl::transform<
           typename Metavariables::observed_reduction_data_tags,
           tmpl::bind<detail::reduction_data_to_reduction_names, tmpl::_1>>>;
-  using compute_tags = db::AddComputeTags<>;
+  using compute_tags = tmpl::list<>;
 
   using return_tag_list = tmpl::append<simple_tags, compute_tags>;
 
@@ -109,36 +91,7 @@ struct InitializeWriter {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    if constexpr (not tmpl::list_contains_v<DbTagsList, Tags::TensorData>) {
-      return helper(typename Metavariables::observed_reduction_data_tags{});
-    } else {
-      ERROR("You appear to be initializing the ObserverWriter twice.");
-      return std::make_tuple(std::move(box));
-    }
-  }
-
- private:
-  template <typename... ReductionTags>
-  static auto helper(tmpl::list<ReductionTags...> /*meta*/) noexcept {
-    return std::make_tuple(
-        db::create<simple_tags>(
-            std::unordered_map<ObservationKey,
-                               std::unordered_set<ArrayComponentId>>{},
-            std::unordered_map<ObservationId,
-                               std::unordered_set<ArrayComponentId>>{},
-            Parallel::NodeLock{},
-            std::unordered_map<ObservationId,
-                               std::unordered_set<ArrayComponentId>>{},
-            Parallel::NodeLock{},
-            std::unordered_map<observers::ObservationId,
-                               std::unordered_map<observers::ArrayComponentId,
-                                                  ElementVolumeData>>{},
-            std::unordered_map<ObservationKey, std::set<size_t>>{},
-            std::unordered_map<ObservationId, std::unordered_set<size_t>>{},
-            Parallel::NodeLock{}, typename ReductionTags::type{}...,
-            typename detail::reduction_data_to_reduction_names<
-                ReductionTags>::type{}...),
-        true);
+    return std::make_tuple(std::move(box));
   }
 };
 }  // namespace Actions

--- a/src/IO/Observer/ObserverComponent.hpp
+++ b/src/IO/Observer/ObserverComponent.hpp
@@ -8,9 +8,11 @@
 #include "IO/Observer/ArrayComponentId.hpp"
 #include "IO/Observer/Initialize.hpp"
 #include "IO/Observer/Tags.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
+#include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace observers {
@@ -29,7 +31,8 @@ struct Observer {
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename metavariables::Phase, metavariables::Phase::Initialization,
-      tmpl::list<Actions::Initialize<Metavariables>>>>;
+      tmpl::list<::Actions::SetupDataBox, Actions::Initialize<Metavariables>,
+                 Initialization::Actions::RemoveOptionsAndTerminatePhase>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 
@@ -52,7 +55,9 @@ struct ObserverWriter {
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename metavariables::Phase, metavariables::Phase::Initialization,
-      tmpl::list<Actions::InitializeWriter<Metavariables>>>>;
+      tmpl::list<::Actions::SetupDataBox,
+                 Actions::InitializeWriter<Metavariables>,
+                 Initialization::Actions::RemoveOptionsAndTerminatePhase>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
 

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTarget.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTarget.hpp
@@ -11,6 +11,7 @@
 #include "IO/Observer/ObservationId.hpp"
 #include "IO/Observer/TypeOfObservation.hpp"
 #include "NumericalAlgorithms/Interpolation/Actions/InterpolationTargetSendPoints.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
@@ -53,12 +54,14 @@ namespace intrp {
 ///      takes a `temporal_id` as an extra argument. `compute_target_points`
 ///      can (optionally) have an additional function
 ///```
-///   static auto initialize(db::DataBox<DbTags>&&,
+///   static auto initialize(const gsl::not_null<db::DataBox<DbTags>*>,
 ///                          const Parallel::GlobalCache<Metavariables>&)
 ///                          noexcept;
 ///```
-///      that adds arbitrary tags to the `DataBox` when the
-///      `InterpolationTarget` is initialized.  If `compute_target_points` has
+///      that mutates arbitrary tags in the `DataBox` when the
+///      `InterpolationTarget` is initialized. Additional simple tags to
+///      include should be put in the typelist `simple_tags` and additional
+///      compute tags in `compute_tags`.  If `compute_target_points` has
 ///      an `initialize` function, it must also have a type alias
 ///      `initialization_tags` which is a `tmpl::list` of the tags that are
 ///      added by `initialize`.
@@ -141,7 +144,8 @@ struct InterpolationTarget {
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<intrp::Actions::InitializeInterpolationTarget<
+          tmpl::list<::Actions::SetupDataBox,
+                     intrp::Actions::InitializeInterpolationTarget<
                          Metavariables, InterpolationTargetTag>,
                      Parallel::Actions::TerminatePhase>>,
       Parallel::PhaseActions<

--- a/src/NumericalAlgorithms/Interpolation/Interpolator.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Interpolator.hpp
@@ -6,6 +6,7 @@
 #include "AlgorithmGroup.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "NumericalAlgorithms/Interpolation/InitializeInterpolator.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
@@ -24,7 +25,10 @@ struct Interpolator {
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename metavariables::Phase, metavariables::Phase::Initialization,
-      tmpl::list<Actions::InitializeInterpolator,
+      tmpl::list<::Actions::SetupDataBox,
+                 Actions::InitializeInterpolator<
+                     Tags::VolumeVarsInfo<Metavariables>,
+                     Tags::InterpolatedVarsHolders<Metavariables>>,
                  Parallel::Actions::TerminatePhase>>>;
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;

--- a/src/Parallel/Actions/CMakeLists.txt
+++ b/src/Parallel/Actions/CMakeLists.txt
@@ -6,5 +6,6 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Goto.hpp
+  SetupDataBox.hpp
   TerminatePhase.hpp
   )

--- a/src/Parallel/Actions/SetupDataBox.hpp
+++ b/src/Parallel/Actions/SetupDataBox.hpp
@@ -1,0 +1,106 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <tuple>
+#include <type_traits>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace Actions {
+/// \cond
+struct SetupDataBox;
+/// \endcond
+
+namespace detail {
+template <typename Action, typename enable = std::void_t<>>
+struct optional_simple_tags {
+  using type = tmpl::list<>;
+};
+
+template <typename Action>
+struct optional_simple_tags<Action, std::void_t<typename Action::simple_tags>> {
+  using type = typename Action::simple_tags;
+};
+
+template <typename Action, typename enable = std::void_t<>>
+struct optional_compute_tags {
+  using type = tmpl::list<>;
+};
+
+template <typename Action>
+struct optional_compute_tags<Action,
+                             std::void_t<typename Action::compute_tags>> {
+  using type = typename Action::compute_tags;
+};
+
+template <typename ActionList>
+using get_action_list_simple_tags = tmpl::remove_duplicates<
+    tmpl::flatten<tmpl::transform<ActionList, optional_simple_tags<tmpl::_1>>>>;
+
+template <typename ActionList>
+using get_action_list_compute_tags = tmpl::remove_duplicates<tmpl::flatten<
+    tmpl::transform<ActionList, optional_compute_tags<tmpl::_1>>>>;
+
+template <typename DbTags, typename... SimpleTags, typename... ComputeTags>
+auto merge_into_databox_helper(db::DataBox<DbTags>&& box,
+                               tmpl::list<SimpleTags...> /*meta*/,
+                               tmpl::list<ComputeTags...> /*meta*/) noexcept {
+  return db::create_from<db::RemoveTags<>, db::AddSimpleTags<SimpleTags...>,
+                         db::AddComputeTags<ComputeTags...>>(
+      std::move(box), typename SimpleTags::type{}...);
+}
+}  // namespace detail
+
+/*!
+ * \brief Add into the \ref DataBoxGroup "DataBox" default constructed items for
+ * the collection of tags requested by any of the actions in the current phase.
+ *
+ * \details This action adds all of the simple tags given in the `simple_tags`
+ * type lists in each of the other actions in the current phase, and all of the
+ * compute tags given in the `compute_tags` type lists. If an action does not
+ * give either of the type lists, it is treated as an empty type list.
+ *
+ * To prevent the proliferation of many \ref DataBoxGroup "DataBox" types, which
+ * can drastically slow compile times, it is preferable to use only this action
+ * to add tags to the \ref DataBoxGroup "DataBox", and place this action at the
+ * start of the `Initialization` phase action list. The rest of the
+ * initialization actions should specify `simple_tags` and `compute_tags`, and
+ * assign initial values to those tags, but not add those tags into the \ref
+ * DataBoxGroup "DataBox".
+ *
+ * An example initialization action:
+ * \snippet Test_SetupDataBox.cpp initialization_action
+ */
+struct SetupDataBox {
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTags>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    using action_list_simple_tags =
+        typename detail::get_action_list_simple_tags<ActionList>;
+    using action_list_compute_tags =
+        typename detail::get_action_list_compute_tags<ActionList>;
+    // grab the simple_tags, compute_tags, mutate the databox, creating
+    // default-constructed objects.
+    return std::make_tuple(detail::merge_into_databox_helper(
+        std::move(box),
+        tmpl::list_difference<action_list_simple_tags,
+                              typename db::DataBox<DbTags>::simple_item_tags>{},
+        tmpl::list_difference<
+            action_list_compute_tags,
+            typename db::DataBox<DbTags>::compute_item_tags>{}));
+  }
+};
+}  // namespace Actions

--- a/src/ParallelAlgorithms/Initialization/Actions/AddComputeTags.hpp
+++ b/src/ParallelAlgorithms/Initialization/Actions/AddComputeTags.hpp
@@ -33,9 +33,15 @@ namespace Actions {
  *   - nothing
  * - Modifies:
  *   - nothing
+ *
+ * \note This action relies on the `SetupDataBox` aggregated initialization
+ * mechanism, so `Actions::SetupDataBox` must be present in the `Initialization`
+ * phase action list prior to this action.
  */
 template <typename ComputeTagsList>
 struct AddComputeTags {
+  using compute_tags = ComputeTagsList;
+
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>
@@ -44,10 +50,7 @@ struct AddComputeTags {
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/, ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    return std::make_tuple(
-        merge_into_databox<AddComputeTags, db::AddSimpleTags<>,
-                           db::AddComputeTags<ComputeTagsList>>(
-            std::move(box)));
+    return std::make_tuple(std::move(box));
   }
 };
 }  // namespace Actions

--- a/src/ParallelAlgorithms/Initialization/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Initialization/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   MergeIntoDataBox.hpp
+  MutateAssign.hpp
   )
 
 target_link_libraries(

--- a/src/ParallelAlgorithms/Initialization/MutateAssign.hpp
+++ b/src/ParallelAlgorithms/Initialization/MutateAssign.hpp
@@ -1,0 +1,49 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Initialization {
+namespace detail {
+template <typename... MutateTags, typename BoxTags, typename... Args>
+SPECTRE_ALWAYS_INLINE constexpr void mutate_assign_impl(
+    // NOLINTNEXTLINE(readability-avoid-const-params-in-decls)
+    const gsl::not_null<db::DataBox<BoxTags>*> box,
+    tmpl::list<MutateTags...> /*meta*/, Args&&... args) noexcept {
+  static_assert(sizeof...(MutateTags) == sizeof...(args),
+                "The number of arguments passed to `mutate_assign` must be "
+                "equal to the number of tags passed.");
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays)
+  db::mutate<MutateTags...>(box, [&args...](const auto... box_args) noexcept {
+    // silence unused capture warnings when there are zero args.
+    // This function still gets instantiated despite the `static_assert` in the
+    // parent function.
+    EXPAND_PACK_LEFT_TO_RIGHT((void)args);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+    EXPAND_PACK_LEFT_TO_RIGHT((*box_args = std::forward<Args>(args)));
+  });
+}
+}  // namespace detail
+
+/*!
+ * \ingroup DataBoxGroup
+ * \brief Perform a mutation to the \ref DataBoxGroup `box`, assigning the
+ * `args` to the tags in `MutateTagList` in order.
+ */
+template <typename MutateTagList, typename BoxTags, typename... Args>
+SPECTRE_ALWAYS_INLINE constexpr void mutate_assign(
+    // NOLINTNEXTLINE(readability-avoid-const-params-in-decls)
+    const gsl::not_null<db::DataBox<BoxTags>*> box, Args&&... args) noexcept {
+  static_assert(
+      tmpl::size<MutateTagList>::value > 0,
+      "At least one tag must be passed to `Initialization::mutate_assign`, but "
+      "received 0 tags to mutate.");
+  detail::mutate_assign_impl(box, MutateTagList{}, std::forward<Args>(args)...);
+}
+}  // namespace Initialization

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/InitializeElement.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/InitializeElement.hpp
@@ -12,7 +12,7 @@
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "NumericalAlgorithms/Convergence/HasConverged.hpp"
 #include "NumericalAlgorithms/Convergence/Tags.hpp"
-#include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+#include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 
 /// \cond
@@ -42,6 +42,13 @@ struct InitializeElement {
       db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>;
 
  public:
+  using simple_tags =
+      tmpl::list<Convergence::Tags::IterationId<OptionsGroup>,
+                 operator_applied_to_fields_tag, operand_tag,
+                 operator_applied_to_operand_tag, residual_tag,
+                 Convergence::Tags::HasConverged<OptionsGroup>>;
+  using compute_tags = tmpl::list<>;
+
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>
@@ -51,24 +58,15 @@ struct InitializeElement {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    return std::make_tuple(
-        ::Initialization::merge_into_databox<
-            InitializeElement,
-            db::AddSimpleTags<Convergence::Tags::IterationId<OptionsGroup>,
-                              operator_applied_to_fields_tag, operand_tag,
-                              operator_applied_to_operand_tag, residual_tag,
-                              Convergence::Tags::HasConverged<OptionsGroup>>>(
-            std::move(box),
-            // The `PrepareSolve` action populates these tags with initial
-            // values, except for `operator_applied_to_fields_tag` which is
-            // expected to be filled at that point and
-            // `operator_applied_to_operand_tag` which is expected to be updated
-            // in every iteration of the algorithm.
-            std::numeric_limits<size_t>::max(),
-            typename operator_applied_to_fields_tag::type{},
-            typename operand_tag::type{},
-            typename operator_applied_to_operand_tag::type{},
-            typename residual_tag::type{}, Convergence::HasConverged{}));
+    // The `PrepareSolve` action populates these tags with initial
+    // values, except for `operator_applied_to_fields_tag` which is
+    // expected to be filled at that point and
+    // `operator_applied_to_operand_tag` which is expected to be updated
+    // in every iteration of the algorithm.
+    Initialization::mutate_assign<
+        tmpl::list<Convergence::Tags::IterationId<OptionsGroup>>>(
+        make_not_null(&box), std::numeric_limits<size_t>::max());
+    return std::make_tuple(std::move(box));
   }
 };
 

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/InitializeElement.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/InitializeElement.hpp
@@ -14,7 +14,7 @@
 #include "NumericalAlgorithms/Convergence/HasConverged.hpp"
 #include "NumericalAlgorithms/Convergence/Tags.hpp"
 #include "Parallel/GlobalCache.hpp"
-#include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+#include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 
 /// \cond
@@ -46,8 +46,22 @@ struct InitializeElement {
           Convergence::Tags::IterationId<OptionsGroup>>;
   using basis_history_tag =
       LinearSolver::Tags::KrylovSubspaceBasis<operand_tag>;
+  using preconditioned_basis_history_tag =
+      LinearSolver::Tags::KrylovSubspaceBasis<preconditioned_operand_tag>;
 
  public:
+  using simple_tags = tmpl::append<
+      tmpl::list<Convergence::Tags::IterationId<OptionsGroup>,
+                 initial_fields_tag, operator_applied_to_fields_tag,
+                 operand_tag, operator_applied_to_operand_tag,
+                 orthogonalization_iteration_id_tag, basis_history_tag,
+                 Convergence::Tags::HasConverged<OptionsGroup>>,
+      tmpl::conditional_t<Preconditioned,
+                          tmpl::list<preconditioned_basis_history_tag,
+                                     preconditioned_operand_tag>,
+                          tmpl::list<>>>;
+  using compute_tags = tmpl::list<>;
+
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>
@@ -57,39 +71,12 @@ struct InitializeElement {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    auto initial_box = ::Initialization::merge_into_databox<
-        InitializeElement,
-        db::AddSimpleTags<Convergence::Tags::IterationId<OptionsGroup>,
-                          initial_fields_tag, operator_applied_to_fields_tag,
-                          operand_tag, operator_applied_to_operand_tag,
-                          orthogonalization_iteration_id_tag, basis_history_tag,
-                          Convergence::Tags::HasConverged<OptionsGroup>>>(
-        std::move(box),
-        // The `PrepareSolve` action populates these tags with initial values,
-        // except for `operator_applied_to_fields_tag` which is expected to be
-        // filled at that point and `operator_applied_to_operand_tag` which is
-        // expected to be updated in every iteration of the algorithm.
-        std::numeric_limits<size_t>::max(), typename initial_fields_tag::type{},
-        typename operator_applied_to_fields_tag::type{},
-        typename operand_tag::type{},
-        typename operator_applied_to_operand_tag::type{},
-        std::numeric_limits<size_t>::max(), typename basis_history_tag::type{},
-        Convergence::HasConverged{});
-
-    if constexpr (not Preconditioned) {
-      return std::make_tuple(std::move(initial_box));
-    } else {
-      using preconditioned_basis_history_tag =
-          LinearSolver::Tags::KrylovSubspaceBasis<preconditioned_operand_tag>;
-
-      return std::make_tuple(::Initialization::merge_into_databox<
-                             InitializeElement,
-                             db::AddSimpleTags<preconditioned_basis_history_tag,
-                                               preconditioned_operand_tag>>(
-          std::move(initial_box),
-          typename preconditioned_basis_history_tag::type{},
-          typename preconditioned_operand_tag::type{}));
-    }
+    Initialization::mutate_assign<
+        tmpl::list<Convergence::Tags::IterationId<OptionsGroup>,
+                   orthogonalization_iteration_id_tag>>(
+        make_not_null(&box), std::numeric_limits<size_t>::max(),
+        std::numeric_limits<size_t>::max());
+    return std::make_tuple(std::move(box));
   }
 };
 

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
@@ -14,10 +14,11 @@
 #include "IO/Observer/Actions/RegisterSingleton.hpp"
 #include "Informer/Tags.hpp"
 #include "NumericalAlgorithms/Convergence/Tags.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
-#include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+#include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "ParallelAlgorithms/LinearSolver/Observe.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 #include "Utilities/TMPL.hpp"
@@ -48,7 +49,8 @@ struct ResidualMonitor {
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<InitializeResidualMonitor<FieldsTag, OptionsGroup>>>,
+          tmpl::list<::Actions::SetupDataBox,
+                     InitializeResidualMonitor<FieldsTag, OptionsGroup>>>,
       Parallel::PhaseActions<
           typename Metavariables::Phase,
           Metavariables::Phase::RegisterWithObserver,
@@ -77,6 +79,10 @@ struct InitializeResidualMonitor {
       LinearSolver::Tags::OrthogonalizationHistory<fields_tag>;
 
  public:
+  using simple_tags =
+      tmpl::list<initial_residual_magnitude_tag, orthogonalization_history_tag>;
+  using compute_tags = tmpl::list<>;
+
   template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
             typename Metavariables, typename ActionList,
             typename ParallelComponent>
@@ -86,17 +92,11 @@ struct InitializeResidualMonitor {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    return std::make_tuple(
-        ::Initialization::merge_into_databox<
-            InitializeResidualMonitor,
-            db::AddSimpleTags<initial_residual_magnitude_tag,
-                              orthogonalization_history_tag>>(
-            std::move(box),
-            // The `InitializeResidualMagnitude` action populates these tags
-            // with initial values
-            std::numeric_limits<double>::signaling_NaN(),
-            DenseMatrix<double>{}),
-        true);
+    // The `InitializeResidualMagnitude` action populates these tags
+    // with initial values
+    Initialization::mutate_assign<tmpl::list<initial_residual_magnitude_tag>>(
+        make_not_null(&box), std::numeric_limits<double>::signaling_NaN());
+    return std::make_tuple(std::move(box), true);
   }
 };
 

--- a/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
@@ -45,6 +45,7 @@
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.hpp"
@@ -169,8 +170,9 @@ struct mock_interpolation_target {
           typename InterpolationTargetTag::post_interpolation_callback>>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
-      tmpl::list<intrp::Actions::InitializeInterpolationTarget<
-          Metavariables, InterpolationTargetTag>>>>;
+      tmpl::list<Actions::SetupDataBox,
+                 intrp::Actions::InitializeInterpolationTarget<
+                     Metavariables, InterpolationTargetTag>>>>;
 
   using component_being_mocked =
       intrp::InterpolationTarget<Metavariables, InterpolationTargetTag>;
@@ -183,7 +185,10 @@ struct mock_interpolator {
   using array_index = size_t;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
-      tmpl::list<intrp::Actions::InitializeInterpolator>>>;
+      tmpl::list<Actions::SetupDataBox,
+                 intrp::Actions::InitializeInterpolator<
+                     intrp::Tags::VolumeVarsInfo<Metavariables>,
+                     intrp::Tags::InterpolatedVarsHolders<Metavariables>>>>>;
 
   using component_being_mocked = intrp::Interpolator<Metavariables>;
 };
@@ -263,9 +268,13 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
   ActionTesting::set_phase(make_not_null(&runner),
                            metavars::Phase::Initialization);
   ActionTesting::emplace_component<interp_component>(&runner, 0);
-  ActionTesting::next_action<interp_component>(make_not_null(&runner), 0);
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::next_action<interp_component>(make_not_null(&runner), 0);
+  }
   ActionTesting::emplace_component<target_component>(&runner, 0);
-  ActionTesting::next_action<target_component>(make_not_null(&runner), 0);
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::next_action<target_component>(make_not_null(&runner), 0);
+  }
   ActionTesting::set_phase(make_not_null(&runner),
                            metavars::Phase::Registration);
 

--- a/tests/Unit/Elliptic/Actions/Test_InitializeAnalyticSolution.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeAnalyticSolution.cpp
@@ -13,6 +13,7 @@
 #include "Domain/Tags.hpp"
 #include "Elliptic/Actions/InitializeAnalyticSolution.hpp"
 #include "Framework/ActionTesting.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "Utilities/TMPL.hpp"
@@ -57,8 +58,10 @@ struct ElementArray {
 
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Testing,
-          tmpl::list<elliptic::Actions::InitializeAnalyticSolution<
-              AnalyticSolutionTag<Dim>, tmpl::list<ScalarFieldTag>>>>>;
+          tmpl::list<
+              Actions::SetupDataBox,
+              elliptic::Actions::InitializeAnalyticSolution<
+                  AnalyticSolutionTag<Dim>, tmpl::list<ScalarFieldTag>>>>>;
 };
 
 template <size_t Dim>
@@ -81,7 +84,10 @@ void test_initialize_analytic_solution(
       &runner, element_id, {inertial_coords});
   ActionTesting::set_phase(make_not_null(&runner),
                            metavariables::Phase::Testing);
-  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::next_action<element_array>(make_not_null(&runner),
+                                              element_id);
+  }
   CHECK_ITERABLE_APPROX(
       get(ActionTesting::get_databox_tag<element_array,
                                          ::Tags::Analytic<ScalarFieldTag>>(

--- a/tests/Unit/Elliptic/Actions/Test_InitializeSystem.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeSystem.cpp
@@ -26,6 +26,7 @@
 #include "Domain/Tags.hpp"
 #include "Elliptic/Actions/InitializeSystem.hpp"
 #include "Framework/ActionTesting.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
@@ -80,15 +81,18 @@ struct ElementArray {
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<ActionTesting::InitializeDataBox<tmpl::list<
-                         domain::Tags::InitialRefinementLevels<Dim>,
-                         domain::Tags::InitialExtents<Dim>,
-                         linear_operator_applied_to_fields_tag<Dim>>>,
-                     dg::Actions::InitializeDomain<Dim>>>,
+          tmpl::list<
+              ActionTesting::InitializeDataBox<
+                  tmpl::list<domain::Tags::InitialRefinementLevels<Dim>,
+                             domain::Tags::InitialExtents<Dim>,
+                             linear_operator_applied_to_fields_tag<Dim>>>,
+              Actions::SetupDataBox, dg::Actions::InitializeDomain<Dim>>>,
 
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Testing,
-                             tmpl::list<elliptic::Actions::InitializeSystem>>>;
+                             tmpl::list<Actions::SetupDataBox,
+                                        elliptic::Actions::InitializeSystem<
+                                            typename Metavariables::system>>>>;
 };
 
 template <size_t Dim>
@@ -121,12 +125,16 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeSystem",
         {domain_creator.initial_refinement_levels(),
          domain_creator.initial_extents(),
          typename linear_operator_applied_to_fields_tag<1>::type{4}});
-    ActionTesting::next_action<element_array>(make_not_null(&runner),
-                                              element_id);
+    for (size_t i = 0; i < 2; ++i) {
+      ActionTesting::next_action<element_array>(make_not_null(&runner),
+                                                element_id);
+    }
     ActionTesting::set_phase(make_not_null(&runner),
                              metavariables::Phase::Testing);
-    ActionTesting::next_action<element_array>(make_not_null(&runner),
-                                              element_id);
+    for (size_t i = 0; i < 2; ++i) {
+      ActionTesting::next_action<element_array>(make_not_null(&runner),
+                                                element_id);
+    }
     const auto get_tag = [&runner, &element_id](auto tag_v) -> decltype(auto) {
       using tag = std::decay_t<decltype(tag_v)>;
       return ActionTesting::get_databox_tag<element_array, tag>(runner,
@@ -161,12 +169,16 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeSystem",
         {domain_creator.initial_refinement_levels(),
          domain_creator.initial_extents(),
          typename linear_operator_applied_to_fields_tag<2>::type{12}});
-    ActionTesting::next_action<element_array>(make_not_null(&runner),
-                                              element_id);
+    for (size_t i = 0; i < 2; ++i) {
+      ActionTesting::next_action<element_array>(make_not_null(&runner),
+                                                element_id);
+    }
     ActionTesting::set_phase(make_not_null(&runner),
                              metavariables::Phase::Testing);
-    ActionTesting::next_action<element_array>(make_not_null(&runner),
-                                              element_id);
+    for (size_t i = 0; i < 2; ++i) {
+      ActionTesting::next_action<element_array>(make_not_null(&runner),
+                                                element_id);
+    }
     const auto get_tag = [&runner, &element_id](auto tag_v) -> decltype(auto) {
       using tag = std::decay_t<decltype(tag_v)>;
       return ActionTesting::get_databox_tag<element_array, tag>(runner,
@@ -205,12 +217,16 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeSystem",
         {domain_creator.initial_refinement_levels(),
          domain_creator.initial_extents(),
          typename linear_operator_applied_to_fields_tag<3>::type{24}});
-    ActionTesting::next_action<element_array>(make_not_null(&runner),
-                                              element_id);
+    for (size_t i = 0; i < 2; ++i) {
+      ActionTesting::next_action<element_array>(make_not_null(&runner),
+                                                element_id);
+    }
     ActionTesting::set_phase(make_not_null(&runner),
                              metavariables::Phase::Testing);
-    ActionTesting::next_action<element_array>(make_not_null(&runner),
-                                              element_id);
+    for (size_t i = 0; i < 2; ++i) {
+      ActionTesting::next_action<element_array>(make_not_null(&runner),
+                                                element_id);
+    }
     const auto get_tag = [&runner, &element_id](auto tag_v) -> decltype(auto) {
       using tag = std::decay_t<decltype(tag_v)>;
       return ActionTesting::get_databox_tag<element_array, tag>(runner,

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeInhomogeneousBoundaryConditionsOnSource.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeInhomogeneousBoundaryConditionsOnSource.cpp
@@ -33,6 +33,7 @@
 #include "Elliptic/Tags.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp"
 #include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeInterfaces.hpp"
@@ -116,7 +117,7 @@ struct ElementArray {
                          db::add_tag_prefix<
                              ::Tags::FixedSource,
                              typename Metavariables::system::fields_tag>>>,
-                     dg::Actions::InitializeDomain<Dim>,
+                     Actions::SetupDataBox, dg::Actions::InitializeDomain<Dim>,
                      dg::Actions::InitializeInterfaces<
                          typename Metavariables::system,
                          dg::Initialization::slice_tags_to_face<>,
@@ -162,8 +163,10 @@ void test_impose_inhomogeneous_boundary_conditions_on_source(
       {domain_creator.create_domain(),
        domain_creator.initial_refinement_levels(),
        domain_creator.initial_extents(), std::move(source_vars)});
-  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
-  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
+  for (size_t i = 0; i < 3; ++i) {
+    ActionTesting::next_action<element_array>(make_not_null(&runner),
+                                              element_id);
+  }
   ActionTesting::set_phase(make_not_null(&runner),
                            metavariables::Phase::Testing);
   ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFirstOrderOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFirstOrderOperator.cpp
@@ -27,6 +27,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "NumericalAlgorithms/LinearOperators/Divergence.tpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp"
 #include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeInterfaces.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/AddComputeTags.hpp"
@@ -107,7 +108,7 @@ struct ElementArray {
           tmpl::list<ActionTesting::InitializeDataBox<tmpl::list<
                          domain::Tags::InitialRefinementLevels<Dim>,
                          domain::Tags::InitialExtents<Dim>, vars_tag<Dim>>>,
-                     dg::Actions::InitializeDomain<Dim>,
+                     Actions::SetupDataBox, dg::Actions::InitializeDomain<Dim>,
                      dg::Actions::InitializeInterfaces<
                          typename Metavariables::system,
                          dg::Initialization::slice_tags_to_face<>,
@@ -117,10 +118,11 @@ struct ElementArray {
 
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Testing,
-          tmpl::list<elliptic::dg::Actions::InitializeFirstOrderOperator<
-              Dim, Fluxes<Dim>, Sources, vars_tag<Dim>,
-              tmpl::list<ScalarFieldTag>,
-              tmpl::list<AuxiliaryFieldTag<Dim>>>>>>;
+          tmpl::list<Actions::SetupDataBox,
+                     elliptic::dg::Actions::InitializeFirstOrderOperator<
+                         Dim, Fluxes<Dim>, Sources, vars_tag<Dim>,
+                         tmpl::list<ScalarFieldTag>,
+                         tmpl::list<AuxiliaryFieldTag<Dim>>>>>>;
 };
 
 template <size_t Dim>
@@ -195,12 +197,16 @@ void test_initialize_fluxes(const DomainCreator<Dim>& domain_creator,
       &runner, element_id,
       {domain_creator.initial_refinement_levels(), std::move(initial_extents),
        std::move(vars)});
-  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
-  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
+  for (size_t i = 0; i < 3; ++i) {
+    ActionTesting::next_action<element_array>(make_not_null(&runner),
+                                              element_id);
+  }
   ActionTesting::set_phase(make_not_null(&runner),
                            metavariables::Phase::Testing);
-  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
-
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::next_action<element_array>(make_not_null(&runner),
+                                              element_id);
+  }
   check_compute_items(runner, element_id);
 
   // Check the variables on exterior boundaries exist (for imposing boundary

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ComputeTimeDerivative.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ComputeTimeDerivative.cpp
@@ -27,6 +27,7 @@
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeMortars.hpp"
 #include "Time/Tags.hpp"
@@ -275,6 +276,7 @@ struct component {
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
           tmpl::list<
               ActionTesting::InitializeDataBox<simple_tags, compute_tags>,
+              Actions::SetupDataBox,
               dg::Actions::InitializeMortars<
                   typename Metavariables::boundary_scheme>>>,
       Parallel::PhaseActions<
@@ -420,6 +422,9 @@ void test_impl() noexcept {
          normal_dot_fluxes_interface, element, inv_jac, mesh_velocity,
          div_mesh_velocity});
   }
+  // Setup the DataBox
+  ActionTesting::next_action<component<metavars>>(make_not_null(&runner),
+                                                  self_id);
   // Initialize the mortars
   ActionTesting::next_action<component<metavars>>(make_not_null(&runner),
                                                   self_id);

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_Mortars.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_Mortars.cpp
@@ -26,6 +26,7 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace evolution::dg {
@@ -70,8 +71,9 @@ struct component {
               ActionTesting::InitializeDataBox<simple_tags, compute_tags>>>,
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Testing,
-                             tmpl::list<evolution::dg::Initialization::Mortars<
-                                 Metavariables::volume_dim>>>>;
+                             tmpl::list<Actions::SetupDataBox,
+                                        evolution::dg::Initialization::Mortars<
+                                            Metavariables::volume_dim>>>>;
 };
 
 template <size_t Dim>
@@ -105,6 +107,9 @@ void test_impl(const std::vector<std::array<size_t, Dim>>& initial_extents,
 
   ActionTesting::set_phase(make_not_null(&runner), metavars::Phase::Testing);
 
+  // Run the SetupDataBox action
+  ActionTesting::next_action<component<metavars>>(make_not_null(&runner),
+                                                  element.id());
   // Run the Mortars initialization action
   ActionTesting::next_action<component<metavars>>(make_not_null(&runner),
                                                   element.id());

--- a/tests/Unit/Evolution/Initialization/Test_ConservativeSystem.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_ConservativeSystem.cpp
@@ -17,6 +17,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "PointwiseFunctions/AnalyticData/Tags.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
@@ -63,7 +64,10 @@ struct component {
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<initial_tags>,
-                 Initialization::Actions::ConservativeSystem>>>;
+                 Actions::SetupDataBox,
+                 Initialization::Actions::ConservativeSystem<
+                     typename Metavariables::system,
+                     typename Metavariables::equation_of_state_tag>>>>;
 };
 
 template <size_t Dim, bool HasPrimitives>
@@ -106,7 +110,9 @@ void test() noexcept {
                  Spectral::Quadrature::GaussLobatto};
   ActionTesting::emplace_component_and_initialize<comp>(&runner, 0, {mesh});
   // Invoke the ConservativeSystem action on the runner
-  ActionTesting::next_action<comp>(make_not_null(&runner), 0);
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::next_action<comp>(make_not_null(&runner), 0);
+  }
   using vars_tag = Tags::Variables<tmpl::list<Var>>;
   using fluxes_tag = db::add_tag_prefix<::Tags::Flux, vars_tag,
                                         tmpl::size_t<Dim>, Frame::Inertial>;

--- a/tests/Unit/Evolution/Initialization/Test_DgDomain.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_DgDomain.cpp
@@ -31,6 +31,7 @@
 #include "Domain/TagsTimeDependent.hpp"
 #include "Evolution/Initialization/DgDomain.hpp"
 #include "Framework/ActionTesting.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Utilities/CloneUniquePtrs.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
@@ -164,7 +165,8 @@ struct Component {
 
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Testing,
-          tmpl::list<evolution::dg::Initialization::Domain<dim>,
+        tmpl::list<::Actions::SetupDataBox,
+                     evolution::dg::Initialization::Domain<dim>,
                      Actions::IncrementTime, Actions::IncrementTime>>>;
 };
 
@@ -228,7 +230,9 @@ void test() noexcept {
        std::move(clone_unique_ptrs(functions_of_time)), initial_time});
   runner.set_phase(metavars::Phase::Testing);
   CHECK(ActionTesting::get_next_action_index<component>(runner, self_id) == 0);
-  ActionTesting::next_action<component>(make_not_null(&runner), self_id);
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::next_action<component>(make_not_null(&runner), self_id);
+  }
 
   // Set up data to be used for checking correctness
   const auto logical_to_grid_map = create_affine_map<Dim, Frame::Grid>();

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
@@ -34,6 +34,7 @@
 #include "NumericalAlgorithms/Spectral/SwshCoefficients.hpp"
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
 #include "NumericalAlgorithms/Spectral/SwshTags.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"
@@ -51,7 +52,9 @@ struct mock_h5_worldtube_boundary {
   using with_these_simple_actions = tmpl::list<>;
 
   using initialize_action_list =
-      tmpl::list<Actions::InitializeH5WorldtubeBoundary>;
+      tmpl::list<::Actions::SetupDataBox,
+                 Actions::InitializeH5WorldtubeBoundary<
+                     typename Metavariables::cce_boundary_communication_tags>>;
   using initialization_tags =
       Parallel::get_initialization_tags<initialize_action_list>;
 
@@ -77,10 +80,13 @@ struct mock_characteristic_evolution {
   using replace_these_simple_actions = tmpl::list<>;
   using with_these_simple_actions = tmpl::list<>;
 
-  using initialize_action_list =
-      tmpl::list<Actions::InitializeCharacteristicEvolutionVariables,
-                 Actions::InitializeCharacteristicEvolutionTime,
-                 Initialization::Actions::RemoveOptionsAndTerminatePhase>;
+  using initialize_action_list = tmpl::list<
+      ::Actions::SetupDataBox,
+      Actions::InitializeCharacteristicEvolutionVariables<Metavariables>,
+      Actions::InitializeCharacteristicEvolutionTime<
+          typename Metavariables::evolved_coordinates_variables_tag,
+          typename Metavariables::evolved_swsh_tag>,
+      Initialization::Actions::RemoveOptionsAndTerminatePhase>;
   using initialization_tags =
       Parallel::get_initialization_tags<initialize_action_list>;
 
@@ -210,10 +216,12 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.H5BoundaryCommunication",
           false, false));
 
   // this should run the initializations
-  ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
-  ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
-  ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
-  ActionTesting::next_action<worldtube_component>(make_not_null(&runner), 0);
+  for (size_t i = 0; i < 4; ++i) {
+    ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
+  }
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::next_action<worldtube_component>(make_not_null(&runner), 0);
+  }
   ActionTesting::set_phase(make_not_null(&runner),
                            test_metavariables::Phase::Evolve);
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
@@ -26,6 +26,7 @@
 #include "NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.hpp"
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
 #include "NumericalAlgorithms/Spectral/SwshTags.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/Tags.hpp"
@@ -43,11 +44,15 @@ struct mock_characteristic_evolution {
   using replace_these_simple_actions = tmpl::list<>;
   using with_these_simple_actions = tmpl::list<>;
 
-  using initialize_action_list =
-      tmpl::list<Actions::InitializeCharacteristicEvolutionVariables,
-                 Actions::InitializeCharacteristicEvolutionTime,
-                 Actions::InitializeCharacteristicEvolutionScri,
-                 Initialization::Actions::RemoveOptionsAndTerminatePhase>;
+  using initialize_action_list = tmpl::list<
+      ::Actions::SetupDataBox,
+      Actions::InitializeCharacteristicEvolutionVariables<Metavariables>,
+      Actions::InitializeCharacteristicEvolutionTime<
+          typename Metavariables::evolved_coordinates_variables_tag,
+          typename Metavariables::evolved_swsh_tag>,
+      Actions::InitializeCharacteristicEvolutionScri<
+          typename Metavariables::scri_values_to_observe>,
+      Initialization::Actions::RemoveOptionsAndTerminatePhase>;
   using initialization_tags =
       Parallel::get_initialization_tags<initialize_action_list>;
 
@@ -162,10 +167,9 @@ SPECTRE_TEST_CASE(
                                               scri_plus_interpolation_order);
 
   // this should run the initialization
-  ActionTesting::next_action<component>(make_not_null(&runner), 0);
-  ActionTesting::next_action<component>(make_not_null(&runner), 0);
-  ActionTesting::next_action<component>(make_not_null(&runner), 0);
-  ActionTesting::next_action<component>(make_not_null(&runner), 0);
+  for(size_t i = 0; i < 5; ++i) {
+    ActionTesting::next_action<component>(make_not_null(&runner), 0);
+  }
   ActionTesting::set_phase(make_not_null(&runner),
                            metavariables::Phase::Evolve);
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
@@ -89,8 +89,9 @@ void test_h5_initialization(const gsl::not_null<Generator*> gen) noexcept {
           false, false));
 
   // this should run the initialization
-  ActionTesting::next_action<component>(make_not_null(&runner), 0);
-  ActionTesting::next_action<component>(make_not_null(&runner), 0);
+  for (size_t i = 0; i < 3; ++i) {
+    ActionTesting::next_action<component>(make_not_null(&runner), 0);
+  }
   ActionTesting::set_phase(make_not_null(&runner),
                            H5Metavariables::Phase::Evolve);
   // check that the h5 data manager copied out of the databox has the correct
@@ -137,8 +138,9 @@ void test_gh_initialization() noexcept {
           std::make_unique<InterfaceManagers::GhLockstep>()));
 
   // this should run the initialization
-  ActionTesting::next_action<component>(make_not_null(&runner), 0);
-  ActionTesting::next_action<component>(make_not_null(&runner), 0);
+  for (size_t i = 0; i < 3; ++i) {
+    ActionTesting::next_action<component>(make_not_null(&runner), 0);
+  }
   runner.set_phase(GhMetavariables::Phase::Evolve);
   // check that the GH data manager copied out of the databox has the correct
   // properties that we can examine without running the other actions

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
@@ -22,6 +22,7 @@
 #include "Helpers/Evolution/Systems/Cce/Actions/WorldtubeBoundaryMocking.hpp"
 #include "Helpers/Evolution/Systems/Cce/BoundaryTestHelpers.hpp"
 #include "NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"
@@ -60,10 +61,13 @@ struct mock_characteristic_evolution {
   using replace_these_simple_actions = tmpl::list<>;
   using with_these_simple_actions = tmpl::list<>;
 
-  using initialize_action_list =
-      tmpl::list<Actions::InitializeCharacteristicEvolutionVariables,
-                 Actions::InitializeCharacteristicEvolutionTime,
-                 Initialization::Actions::RemoveOptionsAndTerminatePhase>;
+  using initialize_action_list = tmpl::list<
+      ::Actions::SetupDataBox,
+      Actions::InitializeCharacteristicEvolutionVariables<Metavariables>,
+      Actions::InitializeCharacteristicEvolutionTime<
+          typename Metavariables::evolved_coordinates_variables_tag,
+          typename Metavariables::evolved_swsh_tag>,
+      Initialization::Actions::RemoveOptionsAndTerminatePhase>;
   using initialization_tags =
       Parallel::get_initialization_tags<initialize_action_list>;
 
@@ -193,11 +197,12 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.RequestBoundaryData",
           false, false));
 
   // this should run the initializations
-  ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
-  ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
-  ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
-  ActionTesting::next_action<worldtube_component>(make_not_null(&runner), 0);
-  ActionTesting::next_action<worldtube_component>(make_not_null(&runner), 0);
+  for (size_t i = 0; i < 4; ++i) {
+    ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
+  }
+  for(size_t i = 0; i < 3; ++i) {
+    ActionTesting::next_action<worldtube_component>(make_not_null(&runner), 0);
+  }
   ActionTesting::set_phase(make_not_null(&runner),
                            test_metavariables::Phase::Evolve);
 

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_InitializeDampedHarmonic.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_InitializeDampedHarmonic.cpp
@@ -38,6 +38,7 @@
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Options/Options.hpp"
 #include "Options/ParseOptions.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "PointwiseFunctions/GeneralRelativity/SpacetimeMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Time/Tags.hpp"
@@ -81,6 +82,7 @@ struct component {
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
       tmpl::list<
           ActionTesting::InitializeDataBox<initial_tags, initial_compute_tags>,
+          Actions::SetupDataBox,
           GeneralizedHarmonic::Actions::InitializeGhAnd3Plus1Variables<Dim>,
           GeneralizedHarmonic::gauges::Actions::InitializeDampedHarmonic<
               Dim, metavariables::use_rollon>>>>;
@@ -250,6 +252,8 @@ void test(const gsl::not_null<std::mt19937*> generator) noexcept {
          inv_jac, evolved_vars});
   }
 
+  // Invoke the SetupDataBox action
+  ActionTesting::next_action<comp>(make_not_null(&runner), 0);
   // Invoke the InitializeGhAnd3Plus1Variables action
   ActionTesting::next_action<comp>(make_not_null(&runner), 0);
   // Invoke the InitializeDampedHarmonic action

--- a/tests/Unit/Framework/ActionTesting.hpp
+++ b/tests/Unit/Framework/ActionTesting.hpp
@@ -471,8 +471,10 @@ using item_type_if_contained_t =
 // `emplace_component_and_initialize` function.
 template <typename... SimpleTags, typename ComputeTagsList>
 struct InitializeDataBox<tmpl::list<SimpleTags...>, ComputeTagsList> {
-  using simple_tags = tmpl::list<SimpleTags...>;
-  using compute_tags = ComputeTagsList;
+  // these type aliases must be different from those used by `SetupDataBox` to
+  // avoid a clash.
+  using action_testing_simple_tags = tmpl::list<SimpleTags...>;
+  using action_testing_compute_tags = ComputeTagsList;
   using InitialValues = tuples::TaggedTuple<SimpleTags...>;
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/Actions/WorldtubeBoundaryMocking.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/Actions/WorldtubeBoundaryMocking.hpp
@@ -12,6 +12,7 @@
 #include "Evolution/Systems/Cce/Tags.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "NumericalAlgorithms/Spectral/SwshTags.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -43,7 +44,9 @@ struct mock_h5_worldtube_boundary {
           mock_characteristic_evolution<test_metavariables>>>;
 
   using initialize_action_list =
-      tmpl::list<Actions::InitializeH5WorldtubeBoundary,
+      tmpl::list<::Actions::SetupDataBox,
+                 Actions::InitializeH5WorldtubeBoundary<
+                     typename Metavariables::cce_boundary_communication_tags>,
                  Initialization::Actions::RemoveOptionsAndTerminatePhase>;
   using initialization_tags =
       Parallel::get_initialization_tags<initialize_action_list>;
@@ -74,7 +77,9 @@ struct mock_gh_worldtube_boundary {
           mock_characteristic_evolution<test_metavariables>>>;
 
   using initialize_action_list =
-      tmpl::list<Actions::InitializeGhWorldtubeBoundary,
+      tmpl::list<::Actions::SetupDataBox,
+                 Actions::InitializeGhWorldtubeBoundary<
+                     typename Metavariables::cce_boundary_communication_tags>,
                  Initialization::Actions::RemoveOptionsAndTerminatePhase>;
   using initialization_tags =
       Parallel::get_initialization_tags<initialize_action_list>;

--- a/tests/Unit/Helpers/IO/Observers/ObserverHelpers.hpp
+++ b/tests/Unit/Helpers/IO/Observers/ObserverHelpers.hpp
@@ -13,6 +13,7 @@
 #include "IO/Observer/ObserverComponent.hpp"  // IWYU pragma: keep
 #include "IO/Observer/Tags.hpp"
 #include "IO/Observer/TypeOfObservation.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/ArrayIndex.hpp"
 #include "Utilities/Functional.hpp"
@@ -66,7 +67,8 @@ struct observer_component {
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
-      tmpl::list<observers::Actions::Initialize<Metavariables>>>>;
+      tmpl::list<Actions::SetupDataBox,
+                 observers::Actions::Initialize<Metavariables>>>>;
 };
 
 template <typename Metavariables>
@@ -85,7 +87,8 @@ struct observer_writer_component {
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
-      tmpl::list<observers::Actions::InitializeWriter<Metavariables>>>>;
+      tmpl::list<Actions::SetupDataBox,
+                 observers::Actions::InitializeWriter<Metavariables>>>>;
 };
 
 using l2_error_datum = Parallel::ReductionDatum<double, funcl::Plus<>,

--- a/tests/Unit/Helpers/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
+++ b/tests/Unit/Helpers/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
@@ -19,6 +19,7 @@
 #include "NumericalAlgorithms/Interpolation/InitializeInterpolator.hpp"
 #include "NumericalAlgorithms/Interpolation/InterpolatedVars.hpp"
 #include "NumericalAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Time.hpp"
@@ -74,8 +75,9 @@ struct mock_interpolation_target {
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<intrp::Actions::InitializeInterpolationTarget<
-              Metavariables, InterpolationTargetTag>>>,
+          tmpl::list<Actions::SetupDataBox,
+                     intrp::Actions::InitializeInterpolationTarget<
+                         Metavariables, InterpolationTargetTag>>>,
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Testing, tmpl::list<>>>;
 };
@@ -126,7 +128,10 @@ struct mock_interpolator {
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<intrp::Actions::InitializeInterpolator>>,
+          tmpl::list<Actions::SetupDataBox,
+                     intrp::Actions::InitializeInterpolator<
+                         intrp::Tags::VolumeVarsInfo<Metavariables>,
+                         intrp::Tags::InterpolatedVarsHolders<Metavariables>>>>,
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Testing, tmpl::list<>>>;
 
@@ -158,9 +163,13 @@ void test_interpolation_target(
   ActionTesting::set_phase(make_not_null(&runner),
                            metavars::Phase::Initialization);
   ActionTesting::emplace_component<interp_component>(&runner, 0);
-  ActionTesting::next_action<interp_component>(make_not_null(&runner), 0);
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::next_action<interp_component>(make_not_null(&runner), 0);
+  }
   ActionTesting::emplace_component<target_component>(&runner, 0);
-  ActionTesting::next_action<target_component>(make_not_null(&runner), 0);
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::next_action<target_component>(make_not_null(&runner), 0);
+  }
   ActionTesting::set_phase(make_not_null(&runner), metavars::Phase::Testing);
 
   Slab slab(0.0, 1.0);

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderActions.cpp
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderActions.cpp
@@ -28,6 +28,7 @@
 #include "IO/Importers/Tags.hpp"
 #include "IO/Observer/ArrayComponentId.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/ArrayIndex.hpp"
 #include "Utilities/FileSystem.hpp"
 #include "Utilities/MakeString.hpp"
@@ -80,7 +81,9 @@ struct MockVolumeDataReader {
   using array_index = size_t;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
-      tmpl::list<importers::detail::InitializeElementDataReader>>>;
+
+      tmpl::list<Actions::SetupDataBox,
+                 importers::detail::InitializeElementDataReader>>>;
 };
 
 struct Metavariables {
@@ -100,7 +103,9 @@ SPECTRE_TEST_CASE("Unit.IO.Importers.VolumeDataReaderActions", "[Unit][IO]") {
 
   // Setup mock data file reader
   ActionTesting::emplace_component<reader_component>(make_not_null(&runner), 0);
-  ActionTesting::next_action<reader_component>(make_not_null(&runner), 0);
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::next_action<reader_component>(make_not_null(&runner), 0);
+  }
 
   // Create a few elements with sample data
   // Specific IDs have no significance, just need different IDs.

--- a/tests/Unit/IO/Observers/Test_Initialize.cpp
+++ b/tests/Unit/IO/Observers/Test_Initialize.cpp
@@ -11,6 +11,7 @@
 #include "IO/Observer/ArrayComponentId.hpp"  // IWYU pragma: keep
 #include "IO/Observer/Initialize.hpp"
 #include "IO/Observer/Tags.hpp"                   // IWYU pragma: keep
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -31,7 +32,8 @@ struct observer_component {
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
-      tmpl::list<observers::Actions::Initialize<Metavariables>>>>;
+      tmpl::list<Actions::SetupDataBox,
+                 observers::Actions::Initialize<Metavariables>>>>;
 };
 
 struct Metavariables {
@@ -46,7 +48,9 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.Initialize", "[Unit][Observers]") {
 
   ActionTesting::MockRuntimeSystem<Metavariables> runner{{}};
   ActionTesting::emplace_component<obs_component>(&runner, 0);
-  runner.next_action<obs_component>(0);
+  for (size_t i = 0; i < 2; ++i) {
+    runner.next_action<obs_component>(0);
+  }
 
   CHECK(
       ActionTesting::get_databox_tag<

--- a/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
@@ -57,10 +57,13 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.ReductionObserver", "[Unit][Observers]") {
           "./Unit.IO.Observers.ReductionObserver";
   ActionTesting::MockRuntimeSystem<metavariables> runner{cache_data};
   ActionTesting::emplace_component<obs_component>(&runner, 0);
-  ActionTesting::next_action<obs_component>(make_not_null(&runner), 0);
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::next_action<obs_component>(make_not_null(&runner), 0);
+  }
   ActionTesting::emplace_component<obs_writer>(&runner, 0);
-  ActionTesting::next_action<obs_writer>(make_not_null(&runner), 0);
-
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::next_action<obs_writer>(make_not_null(&runner), 0);
+  }
   // Specific IDs have no significance, just need different IDs.
   const std::vector<ElementId<2>> element_ids{{1, {{{1, 0}, {1, 0}}}},
                                               {1, {{{1, 1}, {1, 0}}}},

--- a/tests/Unit/IO/Observers/Test_RegisterElements.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterElements.cpp
@@ -41,10 +41,13 @@ void check_observer_registration() {
 
   ActionTesting::MockRuntimeSystem<metavariables> runner{{}};
   ActionTesting::emplace_component<obs_component>(&runner, 0);
-  ActionTesting::next_action<obs_component>(make_not_null(&runner), 0);
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::next_action<obs_component>(make_not_null(&runner), 0);
+  }
   ActionTesting::emplace_component<obs_writer>(&runner, 0);
-  ActionTesting::next_action<obs_writer>(make_not_null(&runner), 0);
-
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::next_action<obs_writer>(make_not_null(&runner), 0);
+  }
   // Specific IDs have no significance, just need different IDs.
   const std::vector<ElementId<2>> element_ids{{1, {{{1, 0}, {1, 0}}}},
                                               {1, {{{1, 1}, {1, 0}}}},

--- a/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
@@ -65,10 +65,13 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.VolumeObserver", "[Unit][Observers]") {
           "./Unit.IO.Observers.VolumeObserver";
   ActionTesting::MockRuntimeSystem<metavariables> runner{cache_data};
   ActionTesting::emplace_component<obs_component>(&runner, 0);
-  ActionTesting::next_action<obs_component>(make_not_null(&runner), 0);
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::next_action<obs_component>(make_not_null(&runner), 0);
+  }
   ActionTesting::emplace_component<obs_writer>(&runner, 0);
-  ActionTesting::next_action<obs_writer>(make_not_null(&runner), 0);
-
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::next_action<obs_writer>(make_not_null(&runner), 0);
+  }
   // Specific IDs have no significance, just need different IDs.
   const std::vector<ElementId<2>> element_ids{{1, {{{1, 0}, {1, 0}}}},
                                               {1, {{{1, 1}, {1, 0}}}},

--- a/tests/Unit/IO/Observers/Test_WriteSimpleData.cpp
+++ b/tests/Unit/IO/Observers/Test_WriteSimpleData.cpp
@@ -60,8 +60,9 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.WriteSimpleData", "[Unit][Observers]") {
       tuples::get<observers::Tags::VolumeFileName>(cache_data);
   ActionTesting::MockRuntimeSystem<test_metavariables> runner{cache_data};
   ActionTesting::emplace_component<obs_writer>(&runner, 0);
-  ActionTesting::next_action<obs_writer>(make_not_null(&runner), 0);
-
+  for(size_t i = 0; i < 2; ++i) {
+    ActionTesting::next_action<obs_writer>(make_not_null(&runner), 0);
+  }
   runner.set_phase(test_metavariables::Phase::Testing);
 
   const std::string h5_file_name = output_file_prefix + "0.h5";

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_CleanUpInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_CleanUpInterpolator.cpp
@@ -44,8 +44,11 @@ struct mock_interpolator {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using simple_tags = db::get_items<
-      intrp::Actions::InitializeInterpolator::return_tag_list<Metavariables>>;
+  using simple_tags =
+      db::get_items<typename intrp::Actions::InitializeInterpolator<
+          intrp::Tags::VolumeVarsInfo<Metavariables>,
+          intrp::Tags::InterpolatedVarsHolders<Metavariables>>::
+                        return_tag_list>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
@@ -18,6 +18,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp"
 #include "NumericalAlgorithms/Interpolation/Tags.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Time/Tags.hpp"
@@ -38,8 +39,9 @@ struct mock_interpolation_target {
   using const_global_cache_tags = tmpl::list<domain::Tags::Domain<3>>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
-      tmpl::list<intrp::Actions::InitializeInterpolationTarget<
-          Metavariables, InterpolationTargetTag>>>>;
+      tmpl::list<Actions::SetupDataBox,
+                 intrp::Actions::InitializeInterpolationTarget<
+                     Metavariables, InterpolationTargetTag>>>>;
 };
 
 struct Metavariables {
@@ -70,7 +72,9 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.Initialize",
   ActionTesting::set_phase(make_not_null(&runner),
                            Metavariables::Phase::Initialization);
   ActionTesting::emplace_component<component>(&runner, 0);
-  ActionTesting::next_action<component>(make_not_null(&runner), 0);
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::next_action<component>(make_not_null(&runner), 0);
+  }
   ActionTesting::set_phase(make_not_null(&runner),
                            Metavariables::Phase::Testing);
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateEvent.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateEvent.cpp
@@ -22,6 +22,7 @@
 #include "NumericalAlgorithms/Interpolation/InterpolatorRegisterElement.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
@@ -116,10 +117,15 @@ struct mock_interpolator {
   using array_index = size_t;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
-      tmpl::list<intrp::Actions::InitializeInterpolator>>>;
+      tmpl::list<Actions::SetupDataBox,
+                 ::intrp::Actions::InitializeInterpolator<
+                     intrp::Tags::VolumeVarsInfo<Metavariables>,
+                     intrp::Tags::InterpolatedVarsHolders<Metavariables>>>>>;
   using initial_databox = db::compute_databox_type<
-      typename ::intrp::Actions::InitializeInterpolator::
-          template return_tag_list<Metavariables>>;
+      typename ::intrp::Actions::InitializeInterpolator<
+          intrp::Tags::VolumeVarsInfo<Metavariables>,
+          intrp::Tags::InterpolatedVarsHolders<Metavariables>>::
+          return_tag_list>;
 };
 
 template <typename Metavariables, typename InterpolationTargetTag>

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
@@ -22,6 +22,7 @@
 #include "NumericalAlgorithms/Interpolation/InitializeInterpolator.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/Interpolation/InterpolatedVars.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/Interpolation/InterpolationTargetReceiveVars.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Time/Slab.hpp"
@@ -244,7 +245,10 @@ struct mock_interpolator {
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<intrp::Actions::InitializeInterpolator>>,
+          tmpl::list<Actions::SetupDataBox,
+                     intrp::Actions::InitializeInterpolator<
+                         intrp::Tags::VolumeVarsInfo<Metavariables>,
+                         intrp::Tags::InterpolatedVarsHolders<Metavariables>>>>,
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Testing, tmpl::list<>>>;
 
@@ -308,7 +312,9 @@ void test_interpolation_target_receive_vars() noexcept {
   ActionTesting::MockRuntimeSystem<metavars> runner{
       {domain_creator.create_domain()}};
   ActionTesting::emplace_component<interp_component>(&runner, 0);
-  ActionTesting::next_action<interp_component>(make_not_null(&runner), 0);
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::next_action<interp_component>(make_not_null(&runner), 0);
+  }
   ActionTesting::emplace_component_and_initialize<target_component>(
       &runner, 0,
       {std::unordered_map<temporal_id_type, std::unordered_set<size_t>>{},

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
@@ -40,6 +40,7 @@
 #include "NumericalAlgorithms/Interpolation/TryToInterpolate.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Time/Slab.hpp"
@@ -167,8 +168,9 @@ struct mock_interpolation_target {
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
-          tmpl::list<intrp::Actions::InitializeInterpolationTarget<
-              Metavariables, InterpolationTargetTag>>>,
+          tmpl::list<Actions::SetupDataBox,
+                     intrp::Actions::InitializeInterpolationTarget<
+                         Metavariables, InterpolationTargetTag>>>,
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Registration, tmpl::list<>>,
       Parallel::PhaseActions<typename Metavariables::Phase,
@@ -187,8 +189,11 @@ struct mock_interpolator {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using simple_tags = db::get_items<
-      intrp::Actions::InitializeInterpolator::return_tag_list<Metavariables>>;
+  using simple_tags =
+      db::get_items<typename intrp::Actions::InitializeInterpolator<
+          intrp::Tags::VolumeVarsInfo<Metavariables>,
+          intrp::Tags::InterpolatedVarsHolders<Metavariables>>::
+                        return_tag_list>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -261,7 +266,9 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ReceiveVolumeData",
        typename intrp::Tags::InterpolatedVarsHolders<metavars>::type{
            vars_holders}});
   ActionTesting::emplace_component<target_component>(&runner, 0);
-  ActionTesting::next_action<target_component>(make_not_null(&runner), 0);
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::next_action<target_component>(make_not_null(&runner), 0);
+  }
   ActionTesting::set_phase(make_not_null(&runner),
                            metavars::Phase::Registration);
 

--- a/tests/Unit/Parallel/Actions/CMakeLists.txt
+++ b/tests/Unit/Parallel/Actions/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_ParallelActions")
 
 set(LIBRARY_SOURCES
   Test_Goto.cpp
+  Test_SetupDataBox.cpp
   Test_TerminatePhase.cpp
   )
 

--- a/tests/Unit/Parallel/Actions/Test_SetupDataBox.cpp
+++ b/tests/Unit/Parallel/Actions/Test_SetupDataBox.cpp
@@ -1,0 +1,131 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"  // IWYU pragma: keep
+#include "Parallel/Actions/TerminatePhase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
+#include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct Label1;
+struct Label2;
+
+struct CounterTag : db::SimpleTag {
+  using type = size_t;
+};
+
+struct VectorTag : db::SimpleTag {
+  using type = DataVector;
+};
+
+struct SquareVectorTag : db::SimpleTag {
+  using type = DataVector;
+};
+
+struct SquareVectorCompute : SquareVectorTag, db::ComputeTag {
+  using argument_tags = tmpl::list<VectorTag>;
+  static void function(const gsl::not_null<DataVector*> result,
+                       const DataVector& vector) noexcept {
+    *result = square(vector);
+  }
+  using return_type = DataVector;
+  using base = SquareVectorTag;
+};
+
+/// [initialization_action]
+struct InitializationAction {
+  using simple_tags = tmpl::list<CounterTag, VectorTag>;
+  using compute_tags = tmpl::list<SquareVectorCompute>;
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    Initialization::mutate_assign<tmpl::list<VectorTag>>(make_not_null(&box),
+                                                         DataVector{1.2, 3.0});
+    return {std::move(box)};
+  }
+};
+/// [initialization_action]
+
+struct MutateAction {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    db::mutate<CounterTag>(
+        make_not_null(&box),
+        [](const gsl::not_null<size_t*> counter) noexcept { *counter = 3_st; });
+    return {std::move(box)};
+  }
+};
+
+template <typename Metavariables>
+struct Component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      tmpl::list<Actions::SetupDataBox, InitializationAction, MutateAction>>>;
+};
+
+struct Metavariables {
+  using component_list = tmpl::list<Component<Metavariables>>;
+
+  enum class Phase { Initialization, Exit };
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Parallel.SetupDataBox", "[Unit][Parallel][Actions]") {
+  using component = Component<Metavariables>;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
+  MockRuntimeSystem runner{{}};
+  ActionTesting::emplace_component<component>(&runner, 0);
+
+  // Actions::SetupDataBox
+  runner.next_action<component>(0);
+  // check that all of the DataBox contents have been default-constructed
+  CHECK(ActionTesting::get_databox_tag<component, CounterTag>(runner, 0_st) ==
+        0_st);
+  CHECK(ActionTesting::get_databox_tag<component, VectorTag>(runner, 0_st)
+            .size() == 0_st);
+  CHECK(ActionTesting::get_databox_tag<component, SquareVectorTag>(runner, 0_st)
+            .size() == 0_st);
+  // InitializationAction
+  runner.next_action<component>(0);
+  CHECK(ActionTesting::get_databox_tag<component, CounterTag>(runner, 0_st) ==
+        0_st);
+  CHECK(ActionTesting::get_databox_tag<component, VectorTag>(runner, 0_st) ==
+        DataVector{1.2, 3.0});
+  CHECK(ActionTesting::get_databox_tag<component, SquareVectorTag>(
+            runner, 0_st) == DataVector{1.44, 9.0});
+  // MutateAction
+  runner.next_action<component>(0);
+  CHECK(ActionTesting::get_databox_tag<component, CounterTag>(runner, 0_st) ==
+        3_st);
+  CHECK(ActionTesting::get_databox_tag<component, VectorTag>(runner, 0_st) ==
+        DataVector{1.2, 3.0});
+  CHECK(ActionTesting::get_databox_tag<component, SquareVectorTag>(
+            runner, 0_st) == DataVector{1.44, 9.0});
+}

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_CollectDataForFluxes.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_CollectDataForFluxes.cpp
@@ -22,6 +22,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleMortarData.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Projection.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/DiscontinuousGalerkin/CollectDataForFluxes.hpp"
 #include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp"
@@ -90,7 +91,7 @@ struct ElementArray {
                   domain::Tags::InitialRefinementLevels<volume_dim>,
                   domain::Tags::InitialExtents<volume_dim>, TemporalIdTag,
                   ::Tags::Next<TemporalIdTag>>>,
-              dg::Actions::InitializeDomain<volume_dim>,
+              Actions::SetupDataBox, dg::Actions::InitializeDomain<volume_dim>,
               Initialization::Actions::AddComputeTags<tmpl::list<
                   domain::Tags::InternalDirectionsCompute<volume_dim>,
                   domain::Tags::BoundaryDirectionsInteriorCompute<volume_dim>,
@@ -187,9 +188,9 @@ SPECTRE_TEST_CASE("Unit.DG.Actions.CollectDataForFluxes",
       &runner, self_id,
       {std::move(initial_refinement_levels), std::move(initial_extents), time,
        time + 1});
-  ActionTesting::next_action<element_array>(make_not_null(&runner), self_id);
-  ActionTesting::next_action<element_array>(make_not_null(&runner), self_id);
-  ActionTesting::next_action<element_array>(make_not_null(&runner), self_id);
+  for (size_t i = 0; i < 4; ++i) {
+    ActionTesting::next_action<element_array>(make_not_null(&runner), self_id);
+  }
   runner.set_phase(Metavariables::Phase::Testing);
   const auto get_tag = [&runner, &self_id](auto tag_v) -> decltype(auto) {
     using tag = std::decay_t<decltype(tag_v)>;

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeDomain.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeDomain.cpp
@@ -26,6 +26,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
 #include "Utilities/TMPL.hpp"
@@ -47,7 +48,7 @@ struct ElementArray {
 
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Testing,
-          tmpl::list<dg::Actions::InitializeDomain<Dim>,
+          tmpl::list<Actions::SetupDataBox, dg::Actions::InitializeDomain<Dim>,
                      // Remove options so that dependencies for
                      // `InitializeDomain` are no longer fulfilled in following
                      // iterations of the action list. Else `merge_into_databox`
@@ -106,8 +107,10 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeDomain", "[Unit][Actions]") {
                               domain_creator.initial_extents()});
     ActionTesting::set_phase(make_not_null(&runner),
                              metavariables::Phase::Testing);
-    ActionTesting::next_action<element_array>(make_not_null(&runner),
-                                              element_id);
+    for (size_t i = 0; i < 2; ++i) {
+      ActionTesting::next_action<element_array>(make_not_null(&runner),
+                                                element_id);
+    }
     const auto get_tag = [&runner, &element_id](auto tag_v) -> decltype(auto) {
       using tag = std::decay_t<decltype(tag_v)>;
       return ActionTesting::get_databox_tag<element_array, tag>(runner,
@@ -175,8 +178,10 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeDomain", "[Unit][Actions]") {
                               domain_creator.initial_extents()});
     ActionTesting::set_phase(make_not_null(&runner),
                              metavariables::Phase::Testing);
-    ActionTesting::next_action<element_array>(make_not_null(&runner),
-                                              element_id);
+    for (size_t i = 0; i < 2; ++i) {
+      ActionTesting::next_action<element_array>(make_not_null(&runner),
+                                                element_id);
+    }
     const auto get_tag = [&runner, &element_id](auto tag_v) -> decltype(auto) {
       using tag = std::decay_t<decltype(tag_v)>;
       return ActionTesting::get_databox_tag<element_array, tag>(runner,
@@ -247,8 +252,10 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeDomain", "[Unit][Actions]") {
                               domain_creator.initial_extents()});
     ActionTesting::set_phase(make_not_null(&runner),
                              metavariables::Phase::Testing);
-    ActionTesting::next_action<element_array>(make_not_null(&runner),
-                                              element_id);
+    for (size_t i = 0; i < 2; ++i) {
+      ActionTesting::next_action<element_array>(make_not_null(&runner),
+                                                element_id);
+    }
     const auto get_tag = [&runner, &element_id](auto tag_v) -> decltype(auto) {
       using tag = std::decay_t<decltype(tag_v)>;
       return ActionTesting::get_databox_tag<element_array, tag>(runner,

--- a/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_AddComputeTags.cpp
+++ b/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_AddComputeTags.cpp
@@ -9,6 +9,7 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "Framework/ActionTesting.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/AddComputeTags.hpp"
@@ -49,6 +50,7 @@ struct Component {
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Testing,
           tmpl::list<
+              Actions::SetupDataBox,
               Initialization::Actions::AddComputeTags<SquareNumberCompute>>>>;
 };
 
@@ -69,7 +71,9 @@ SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.Initialization.AddComputeTags",
 
   ActionTesting::set_phase(make_not_null(&runner),
                            Metavariables::Phase::Testing);
-  runner.template next_action<component>(0);
+  for (size_t i = 0; i < 2; ++i) {
+    runner.template next_action<component>(0);
+  }
 
   CHECK(ActionTesting::tag_is_retrievable<component, SquareNumber>(runner, 0));
 }

--- a/tests/Unit/ParallelAlgorithms/Initialization/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Initialization/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_Initialization")
 
 set(LIBRARY_SOURCES
   Test_MergeIntoDataBox.cpp
+  Test_MutateAssign.cpp
   )
 
 add_subdirectory(Actions)

--- a/tests/Unit/ParallelAlgorithms/Initialization/Test_MutateAssign.cpp
+++ b/tests/Unit/ParallelAlgorithms/Initialization/Test_MutateAssign.cpp
@@ -1,0 +1,46 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct Tag0 : db::SimpleTag {
+  using type = double;
+};
+
+struct Tag1 : db::SimpleTag {
+  using type = std::vector<double>;
+};
+
+struct Tag2Base : db::BaseTag {};
+
+struct Tag2 : db::SimpleTag, Tag2Base {
+  using type = std::string;
+};
+
+SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.Initialization.MutateAssign",
+                  "[Unit][ParallelAlgorithms]") {
+  auto box = db::create<db::AddSimpleTags<Tag0, Tag1, Tag2>>(
+      0.5, std::vector<double>{1.0, 2.0}, std::string("original string value"));
+  Initialization::mutate_assign<tmpl::list<Tag0>>(make_not_null(&box), 1.2);
+  CHECK(db::get<Tag0>(box) == 1.2);
+  CHECK(db::get<Tag1>(box) == std::vector<double>{1.0, 2.0});
+  Initialization::mutate_assign<tmpl::list<Tag0, Tag1>>(
+      make_not_null(&box), 1.5, std::vector<double>{1.6, 2.5, 3.0});
+  CHECK(db::get<Tag0>(box) == 1.5);
+  CHECK(db::get<Tag1>(box) == std::vector<double>{1.6, 2.5, 3.0});
+  Initialization::mutate_assign<tmpl::list<Tag2Base>>(make_not_null(&box),
+                                                      "new string value");
+  CHECK(db::get<Tag2>(box) == "new string value");
+  CHECK(db::get<Tag2Base>(box) == "new string value");
+}
+}  // namespace

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ResidualMonitorActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ResidualMonitorActions.cpp
@@ -21,6 +21,7 @@
 #include "NumericalAlgorithms/Convergence/Criteria.hpp"
 #include "NumericalAlgorithms/Convergence/HasConverged.hpp"
 #include "NumericalAlgorithms/Convergence/Reason.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp"
 #include "ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp"
 #include "ParallelAlgorithms/LinearSolver/Observe.hpp"
@@ -66,8 +67,9 @@ struct MockResidualMonitor {
           Metavariables, fields_tag, TestLinearSolver>::const_global_cache_tags;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
-      tmpl::list<LinearSolver::cg::detail::InitializeResidualMonitor<
-          fields_tag, TestLinearSolver>>>>;
+      tmpl::list<Actions::SetupDataBox,
+                 LinearSolver::cg::detail::InitializeResidualMonitor<
+                     fields_tag, TestLinearSolver>>>>;
 };
 
 // This is used to receive action calls from the residual monitor
@@ -109,7 +111,9 @@ SPECTRE_TEST_CASE(
 
   // Setup mock residual monitor
   ActionTesting::emplace_component<residual_monitor>(&runner, 0);
-  ActionTesting::next_action<residual_monitor>(make_not_null(&runner), 0);
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::next_action<residual_monitor>(make_not_null(&runner), 0);
+  }
 
   // Setup mock element array
   ActionTesting::emplace_component<element_array>(&runner, 0);

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ElementActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ElementActions.cpp
@@ -14,7 +14,7 @@
 #include "DataStructures/DenseVector.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "NumericalAlgorithms/Convergence/HasConverged.hpp"
-#include "NumericalAlgorithms/Convergence/Tags.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "ParallelAlgorithms/Actions/SetData.hpp"
 #include "ParallelAlgorithms/LinearSolver/Gmres/ElementActions.hpp"
@@ -60,6 +60,7 @@ struct ElementArray {
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<tmpl::list<VectorTag>>,
+                     Actions::SetupDataBox,
                      LinearSolver::gmres::detail::InitializeElement<
                          fields_tag, DummyOptionsGroup, Preconditioned>>>,
       Parallel::PhaseActions<
@@ -95,7 +96,9 @@ void test_element_actions() {
   // Setup mock element array
   ActionTesting::emplace_component_and_initialize<element_array>(
       make_not_null(&runner), 0, {DenseVector<double>(3, 0.)});
-  ActionTesting::next_action<element_array>(make_not_null(&runner), 0);
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::next_action<element_array>(make_not_null(&runner), 0);
+  }
 
   // DataBox shortcuts
   const auto get_tag = [&runner](auto tag_v) -> decltype(auto) {

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ResidualMonitorActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ResidualMonitorActions.cpp
@@ -22,6 +22,7 @@
 #include "NumericalAlgorithms/Convergence/Criteria.hpp"
 #include "NumericalAlgorithms/Convergence/HasConverged.hpp"
 #include "NumericalAlgorithms/Convergence/Reason.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
 #include "ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp"
 #include "ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitorActions.hpp"
 #include "ParallelAlgorithms/LinearSolver/Observe.hpp"
@@ -67,8 +68,9 @@ struct MockResidualMonitor {
           Metavariables, fields_tag, TestLinearSolver>::const_global_cache_tags;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
-      tmpl::list<LinearSolver::gmres::detail::InitializeResidualMonitor<
-          fields_tag, TestLinearSolver>>>>;
+      tmpl::list<Actions::SetupDataBox,
+                 LinearSolver::gmres::detail::InitializeResidualMonitor<
+                     fields_tag, TestLinearSolver>>>>;
 };
 
 // This is used to receive action calls from the residual monitor
@@ -112,7 +114,9 @@ SPECTRE_TEST_CASE(
 
   // Setup mock residual monitor
   ActionTesting::emplace_component<residual_monitor>(make_not_null(&runner), 0);
-  ActionTesting::next_action<residual_monitor>(make_not_null(&runner), 0);
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::next_action<residual_monitor>(make_not_null(&runner), 0);
+  }
 
   // Setup mock element array
   ActionTesting::emplace_component<element_array>(make_not_null(&runner), 0);


### PR DESCRIPTION
## Proposed changes

This implements a simple optimization to the construction of the `DataBox` in `Initialization` phases, so that (to the extent possible) tags are added to the `DataBox` in as few places as possible. This limits the number of different databox types that need to be instantiated, and, depending on the compiler, can significantly reduce RAM and compile-time for heavier executables.

Below is the summary of some quick tests that I ran. The take-aways are that maximum RAM usage reduced to ~75% of original for clang-6.0, ~80% for clang-10, and to ~50% of original for GCC-7. Compile times are also improved: ~90% of original compile time for clang, ~35% of original for GCC-7. Clang still outperforms gcc, but by a less dramatic margin. Importantly, I think this will qualitatively improve the system resources requirements for the CI builds.
```
Before:
  Clang-6:
    EvolveValenciaDivCleanAlfvenWave:
      Command being timed: "make -j6 EvolveValenciaDivCleanAlfvenWave"
	   Percent of CPU this job got: 329%
	   Elapsed (wall clock) time (h:mm:ss or m:ss): 3:32.34
	   Maximum resident set size (kbytes): 11164788
    EvolveGhKerrSchild:
      Command being timed: "make -j6 EvolveGhKerrSchild"
	   Percent of CPU this job got: 329%
	   Elapsed (wall clock) time (h:mm:ss or m:ss): 3:05.29
	   Maximum resident set size (kbytes): 8170388
  Clang-10:
    EvolveValenciaDivCleanAlfvenWave:
      Command being timed: "make -j6 EvolveValenciaDivCleanAlfvenWave"
	   Percent of CPU this job got: 348%
	   Elapsed (wall clock) time (h:mm:ss or m:ss): 3:33.99
	   Maximum resident set size (kbytes): 9580212
    EvolveGhKerrSchild:
      Command being timed: "make -j6 EvolveGhKerrSchild"
	   Percent of CPU this job got: 349%
	   Elapsed (wall clock) time (h:mm:ss or m:ss): 3:05.56
	   Maximum resident set size (kbytes): 7223804
  GCC-7:
    EvolveValenciaDivCleanAlfvenWave:
      Command being timed: "make -j6 EvolveValenciaDivCleanAlfvenWave"
	   Percent of CPU this job got: 126%
	   Elapsed (wall clock) time (h:mm:ss or m:ss): 32:49.62
	   Maximum resident set size (kbytes): 27467120
    EvolveGhKerrSchild:
      Command being timed: "make -j6 EvolveGhKerrSchild"
	   Percent of CPU this job got: 135%
	   Elapsed (wall clock) time (h:mm:ss or m:ss): 22:20.10
	   Maximum resident set size (kbytes): 19597960

After:
  Clang-6:
    EvolveValenciaDivCleanAlfvenWave:
      Command being timed: "make -j6 EvolveValenciaDivCleanAlfvenWave"
	   Percent of CPU this job got: 347%
	   Elapsed (wall clock) time (h:mm:ss or m:ss): 3:18.24
	   Maximum resident set size (kbytes): 7761604
    EvolveGhKerrSchild:
      Command being timed: "make -j6 EvolveGhKerrSchild"
	   Percent of CPU this job got: 341%
	   Elapsed (wall clock) time (h:mm:ss or m:ss): 2:59.63
	   Maximum resident set size (kbytes): 6329492
  Clang-10:
    EvolveValenciaDivCleanAlfvenWave:
      Command being timed: "make -j6 EvolveValenciaDivCleanAlfvenWave"
	   Percent of CPU this job got: 362%
	   Elapsed (wall clock) time (h:mm:ss or m:ss): 3:15.83
	   Maximum resident set size (kbytes): 7240564
    EvolveGhKerrSchild:
      Command being timed: "make -j6 EvolveGhKerrSchild"
	   Percent of CPU this job got: 360%
	   Elapsed (wall clock) time (h:mm:ss or m:ss): 2:53.72
	   Maximum resident set size (kbytes): 6008284
  GCC-7:
    EvolveValenciaDivCleanAlfvenWave:
      Command being timed: "make -j6 EvolveValenciaDivCleanAlfvenWave"
	   Percent of CPU this job got: 200%
	   Elapsed (wall clock) time (h:mm:ss or m:ss): 8:46.20
	   Maximum resident set size (kbytes): 12538676
    EvolveGhKerrSchild:
      Command being timed: "make -j6 EvolveGhKerrSchild"
	   Percent of CPU this job got: 198%
	   Elapsed (wall clock) time (h:mm:ss or m:ss): 7:55.48
	   Maximum resident set size (kbytes): 10248700
```

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).