### PR TITLE
Cce analytic test gaugewave

### DIFF
--- a/src/Evolution/Systems/Cce/AnalyticSolutions/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   BouncingBlackHole.cpp
   LinearizedBondiSachs.cpp
+  GaugeWave.cpp
   RotatingSchwarzschild.cpp
   SphericalMetricData.cpp
   TeukolskyWave.cpp
@@ -22,6 +23,7 @@ spectre_target_headers(
   HEADERS
   BouncingBlackHole.hpp
   LinearizedBondiSachs.hpp
+  GaugeWave.hpp
   RotatingSchwarzschild.hpp
   SphericalMetricData.hpp
   TeukolskyWave.hpp

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/GaugeWave.cpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/GaugeWave.cpp
@@ -1,0 +1,205 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Cce/AnalyticSolutions/GaugeWave.hpp"
+
+#include <cmath>
+#include <complex>
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Tags.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "NumericalAlgorithms/Spectral/SwshInterpolation.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Cce::Solutions {
+
+/// \cond
+GaugeWave::GaugeWave(const double extraction_radius, const double mass,
+                     const double frequency, const double amplitude,
+                     const double peak_time, const double duration) noexcept
+    : SphericalMetricData{extraction_radius},
+      mass_{mass},
+      frequency_{frequency},
+      amplitude_{amplitude},
+      peak_time_{peak_time},
+      duration_{duration} {}
+
+std::unique_ptr<WorldtubeData> GaugeWave::get_clone() const
+    noexcept {
+  return std::make_unique<GaugeWave>(*this);
+}
+
+double GaugeWave::coordinate_wave_function(const double time) const noexcept {
+  const auto retarded_time = time - extraction_radius_;
+  return amplitude_ * sin(frequency_ * retarded_time) *
+         exp(-square(retarded_time - peak_time_) / square(duration_));
+}
+
+double GaugeWave::du_coordinate_wave_function(const double time) const
+    noexcept {
+  const auto retarded_time = time - extraction_radius_;
+  return amplitude_ *
+         (-2.0 * (retarded_time - peak_time_) / square(duration_) *
+              sin(frequency_ * retarded_time) +
+          frequency_ * cos(frequency_ * retarded_time)) *
+         exp(-square(retarded_time - peak_time_) / square(duration_));
+}
+
+double GaugeWave::du_du_coordinate_wave_function(const double time) const
+    noexcept {
+  const auto retarded_time = time - extraction_radius_;
+  return amplitude_ *
+         (-4.0 * square(duration_) * (retarded_time - peak_time_) * frequency_ *
+              cos(frequency_ * retarded_time) +
+          (-2.0 * square(duration_) + 4.0 * square(retarded_time - peak_time_) -
+           pow<4>(duration_) * square(frequency_)) *
+              sin(frequency_ * retarded_time)) /
+         pow<4>(duration_) *
+         exp(-square(retarded_time - peak_time_) / square(duration_));
+}
+
+void GaugeWave::spherical_metric(
+    const gsl::not_null<
+        tnsr::aa<DataVector, 3, ::Frame::Spherical<::Frame::Inertial>>*>
+        spherical_metric,
+    const size_t /*l_max*/, const double time) const noexcept {
+  const auto wave_f = coordinate_wave_function(time);
+  const auto du_wave_f = du_coordinate_wave_function(time);
+  get<0, 0>(*spherical_metric) = -(extraction_radius_ - 2.0 * mass_) *
+                                 square(extraction_radius_ + du_wave_f) /
+                                 pow<3>(extraction_radius_);
+  get<0, 1>(*spherical_metric) =
+      (extraction_radius_ + du_wave_f) *
+      (2.0 * mass_ * square(extraction_radius_) +
+       (extraction_radius_ - 2.0 * mass_) *
+           (extraction_radius_ * du_wave_f + wave_f)) /
+      pow<4>(extraction_radius_);
+  get<0, 2>(*spherical_metric) = 0.0;
+  get<0, 3>(*spherical_metric) = 0.0;
+
+  get<1, 1>(*spherical_metric) =
+      (square(extraction_radius_) - extraction_radius_ * du_wave_f - wave_f) *
+      (pow<3>(extraction_radius_) + 2.0 * mass_ * square(extraction_radius_) +
+       (extraction_radius_ - 2.0 * mass_) *
+           (extraction_radius_ * du_wave_f + wave_f)) /
+      pow<5>(extraction_radius_);
+  get<1, 2>(*spherical_metric) = 0.0;
+  get<1, 3>(*spherical_metric) = 0.0;
+  get<2, 2>(*spherical_metric) = square(extraction_radius_);
+  get<2, 3>(*spherical_metric) = 0.0;
+  get<3, 3>(*spherical_metric) = square(extraction_radius_);
+}
+
+void GaugeWave::dr_spherical_metric(
+    const gsl::not_null<
+        tnsr::aa<DataVector, 3, ::Frame::Spherical<::Frame::Inertial>>*>
+        dr_spherical_metric,
+    const size_t l_max, const double time) const noexcept {
+  const auto wave_f = coordinate_wave_function(time);
+  const auto du_wave_f = du_coordinate_wave_function(time);
+  // for simpler expressions, we take advantage of the F derivatives evaluated
+  // in the dt function (because the F function depends only on retarded time
+  // t - r)
+  dt_spherical_metric(dr_spherical_metric, l_max, time);
+
+  get<0, 0>(*dr_spherical_metric) =
+      -get<0, 0>(*dr_spherical_metric) +
+      2.0 / pow<4>(extraction_radius_) * (extraction_radius_ + du_wave_f) *
+          (-mass_ * extraction_radius_ +
+           (extraction_radius_ - 3.0 * mass_) * du_wave_f);
+
+  get<0, 1>(*dr_spherical_metric) =
+      -get<0, 1>(*dr_spherical_metric) -
+      (2.0 * mass_ * pow<3>(extraction_radius_) +
+       2.0 * extraction_radius_ * wave_f * (extraction_radius_ - 3.0 * mass_) +
+       du_wave_f * (pow<3>(extraction_radius_) +
+                    wave_f * (3.0 * extraction_radius_ - 8.0 * mass_)) +
+       2.0 * extraction_radius_ * square(du_wave_f) *
+           (extraction_radius_ - 3.0 * mass_)) /
+          pow<5>(extraction_radius_);
+
+  get<0, 2>(*dr_spherical_metric) = 0.0;
+  get<0, 3>(*dr_spherical_metric) = 0.0;
+
+  get<1, 1>(*dr_spherical_metric) =
+      -get<1, 1>(*dr_spherical_metric) +
+      2.0 *
+          (-mass_ * pow<4>(extraction_radius_) +
+           square(wave_f) * (2.0 * extraction_radius_ - 5.0 * mass_) +
+           du_wave_f * square(extraction_radius_) *
+               (4.0 * mass_ * extraction_radius_ +
+                du_wave_f * (extraction_radius_ - 3.0 * mass_)) +
+           wave_f * extraction_radius_ *
+               (6.0 * mass_ * extraction_radius_ +
+                du_wave_f * (3.0 * extraction_radius_ - 8.0 * mass_))) /
+          pow<6>(extraction_radius_);
+
+  get<1, 2>(*dr_spherical_metric) = 0.0;
+  get<1, 3>(*dr_spherical_metric) = 0.0;
+  get<2, 2>(*dr_spherical_metric) = 2.0 * extraction_radius_;
+  get<2, 3>(*dr_spherical_metric) = 0.0;
+  get<3, 3>(*dr_spherical_metric) = 2.0 * extraction_radius_;
+}
+
+void GaugeWave::dt_spherical_metric(
+    const gsl::not_null<
+        tnsr::aa<DataVector, 3, ::Frame::Spherical<::Frame::Inertial>>*>
+        dt_spherical_metric,
+    const size_t /*l_max*/, const double time) const noexcept {
+  const auto wave_f = coordinate_wave_function(time);
+  const auto du_wave_f = du_coordinate_wave_function(time);
+  const auto du_du_wave_f = du_du_coordinate_wave_function(time);
+
+  get<0, 0>(*dt_spherical_metric) =
+      -2.0 * du_du_wave_f / pow<3>(extraction_radius_) *
+      (extraction_radius_ - 2.0 * mass_) * (extraction_radius_ + du_wave_f);
+  get<0, 1>(*dt_spherical_metric) =
+      (du_du_wave_f * (2.0 * mass_ * square(extraction_radius_) +
+                       (extraction_radius_ - 2.0 * mass_) *
+                           (extraction_radius_ * du_wave_f + wave_f)) +
+       (extraction_radius_ + du_wave_f) * (extraction_radius_ - 2.0 * mass_) *
+           (extraction_radius_ * du_du_wave_f + du_wave_f)) /
+      pow<4>(extraction_radius_);
+
+  get<0, 2>(*dt_spherical_metric) = 0.0;
+  get<0, 3>(*dt_spherical_metric) = 0.0;
+
+  get<1, 1>(*dt_spherical_metric) =
+      (-(extraction_radius_ * du_du_wave_f + du_wave_f) *
+           (pow<3>(extraction_radius_) +
+            2.0 * mass_ * square(extraction_radius_) +
+            (extraction_radius_ - 2.0 * mass_) *
+                (extraction_radius_ * du_wave_f + wave_f)) +
+       (square(extraction_radius_) - extraction_radius_ * du_wave_f - wave_f) *
+           (extraction_radius_ - 2.0 * mass_) *
+           (extraction_radius_ * du_du_wave_f + du_wave_f)) /
+      pow<5>(extraction_radius_);
+
+  get<1, 2>(*dt_spherical_metric) = 0.0;
+  get<1, 3>(*dt_spherical_metric) = 0.0;
+  get<2, 2>(*dt_spherical_metric) = 0.0;
+  get<2, 3>(*dt_spherical_metric) = 0.0;
+  get<3, 3>(*dt_spherical_metric) = 0.0;
+}
+
+void GaugeWave::variables_impl(
+    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, -2>>*> news,
+    const size_t /*l_max*/, const double /*time*/,
+    tmpl::type_<Tags::News> /*meta*/) const noexcept {
+  get(*news).data() = 0.0;
+}
+
+PUP::able::PUP_ID GaugeWave::my_PUP_ID = 0;
+/// \endcond
+}  // namespace Cce::Solutions

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/GaugeWave.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/GaugeWave.hpp
@@ -1,0 +1,273 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <complex>
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+#include "DataStructures/SpinWeighted.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/SphericalMetricData.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+class ComplexDataVector;
+/// \endcond
+
+namespace Cce {
+namespace Solutions {
+
+/*!
+ * \brief Computes the analytic data for a gauge wave solution described in
+ * \cite Barkett2019uae.
+ *
+ * \details This test computes an analytic solution of a pure-gauge perturbation
+ * of the Schwarzschild metric. The gauge perturbation is constructed using the
+ * time-dependent coordinate transformation of the ingoing Eddington-Finklestein
+ * coordinate \f$\nu \rightarrow \nu + F(t - r) / r\f$, where
+ *
+ * \f[
+ * F(u) = A \sin(\omega u) e^{- (u - u_0)^2 / k^2}.
+ * \f]
+ *
+ * \note In the paper \cite Barkett2019uae, a translation map was
+ * applied to the solution to make the test more demanding. For simplicity, we
+ * omit that extra map. The behavior of translation-independence is
+ * tested by the `Cce::Solutions::BouncingBlackHole` solution.
+ */
+struct GaugeWave : public SphericalMetricData {
+  struct ExtractionRadius {
+    using type = double;
+    static constexpr Options::String help{
+        "The extraction radius of the spherical solution"};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+  struct Mass {
+    using type = double;
+    static constexpr Options::String help{
+        "The mass of the Schwarzschild solution."};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+  struct Frequency {
+    using type = double;
+    static constexpr Options::String help{
+        "The frequency of the oscillation of the gauge wave."};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+  struct Amplitude {
+    using type = double;
+    static constexpr Options::String help{
+      "The amplitude of the gauge wave."};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+  struct PeakTime {
+    using type = double;
+    static constexpr Options::String help{
+        "The time of the peak of the Gaussian envelope."};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+  struct Duration {
+    using type = double;
+    static constexpr Options::String help{
+        "The characteristic duration of the Gaussian envelope."};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+
+  using options = tmpl::list<ExtractionRadius, Mass, Frequency, Amplitude,
+                             PeakTime, Duration>;
+
+  static constexpr Options::String help = {
+      "Analytic solution representing worldtube data for a pure-gauge "
+      "perturbation near a Schwarzschild metric in spherical coordinates"};
+
+  WRAPPED_PUPable_decl_template(GaugeWave);  // NOLINT
+
+  explicit GaugeWave(CkMigrateMessage* /*unused*/) noexcept {}
+
+  // clang doesn't manage to use = default correctly in this case
+  // NOLINTNEXTLINE(modernize-use-equals-default)
+  GaugeWave() noexcept {}
+
+  GaugeWave(double extraction_radius, double mass, double frequency,
+            double amplitude, double peak_time, double duration) noexcept;
+
+  std::unique_ptr<WorldtubeData> get_clone() const noexcept override;
+ private:
+  double coordinate_wave_function(double time) const noexcept;
+
+  double du_coordinate_wave_function(double time) const noexcept;
+
+  double du_du_coordinate_wave_function(double time) const noexcept;
+
+ protected:
+  /// A no-op as the gauge wave solution does not have substantial
+  /// shared computation to prepare before the separate component calculations.
+  void prepare_solution(const size_t /*output_l_max*/,
+                        const double /*time*/) const noexcept override {}
+
+  /*!
+   * \brief Compute the spherical coordinate metric from the closed-form gauge
+   * wave metric.
+   *
+   * \details The transformation of the ingoing Eddington-Finkelstein coordinate
+   * produces metric components in spherical coordinates (identical up to minor
+   * manipulations of the metric given in Eq. (149) of \cite Barkett2019uae):
+   *
+   * \f{align*}{
+   * g_{tt} &= \frac{-1}{r^3}\left(r - 2 M\right)
+   * \left[r + \partial_u F(u)\right]^2\\
+   * g_{rt} &= \frac{1}{r^4} \left[r + \partial_u F(u)\right]
+   * \left\{2 M r^2 + \left(r - 2 M\right)
+   * \left[r \partial_u F(u) + F(u)\right]\right\} \\
+   * g_{rr} &= \frac{1}{r^5} \left[r^2 - r \partial_u F(u) - F(u)\right]
+   * \left\{r^3 + 2 M r^2 + \left(r - 2 M\right)
+   * \left[r \partial_u F(u) + F(u)\right]\right\} \\
+   * g_{\theta \theta} &= r^2 \\
+   * g_{\phi \phi} &= r^2 \sin^2(\theta),
+   * \f}
+   *
+   * and all other components vanish. Here, \f$F(u)\f$ is defined as
+   *
+   * \f{align*}{
+   * F(u) &= A \sin(\omega u) e^{-(u - u_0)^2 /k^2},\\
+   * \partial_u F(u) &= A \left[-2 \frac{u - u_0}{k^2} \sin(\omega u)
+   * + \omega \cos(\omega u)\right] e^{-(u - u_0)^2 / k^2}.
+   * \f}
+   *
+   * \warning The \f$\phi\f$ components are returned in a form for which the
+   * \f$\sin(\theta)\f$ factors are omitted, assuming that derivatives and
+   * Jacobians will be applied similarly omitting those factors (and therefore
+   * improving precision of the tensor expression). If you require the
+   * \f$\sin(\theta)\f$ factors, be sure to put them in by hand in the calling
+   * code.
+   */
+  void spherical_metric(
+      gsl::not_null<
+          tnsr::aa<DataVector, 3, ::Frame::Spherical<::Frame::Inertial>>*>
+          spherical_metric,
+      size_t l_max, double time) const noexcept override;
+
+  /*!
+   * \brief Compute the radial derivative of the spherical coordinate metric
+   * from the closed-form gauge wave metric.
+   *
+   * \details The transformation of the ingoing Eddington-Finkelstein coordinate
+   * produces the radial derivative of the metric components in spherical
+   * coordinates:
+   *
+   * \f{align*}{
+   * \partial_r g_{tt} + \partial_t g_{tt} =& \frac{2}{r^4}
+   * \left[r + \partial_u F(u)\right]
+   * \left[- M r + (r - 3 M)\partial_u F(u)\right] \\
+   * \partial_r g_{rt} + \partial_t g_{rt} =& - \frac{1}{r^5}
+   * \left\{2 M r^3 + 2 r F(u) (r - 3M) + \partial_u F(u)[r^3 + F(u)(3r - 8 M)]
+   * + 2 r [\partial_u F(u)]^2 (r - 3M)\right\}\\
+   * \partial_r g_{rr} + \partial_t g_{rr} =& \frac{2}{r^6}
+   * \left\{- M r^4 + F(u)^2 (2r - 5M)
+   * + \partial_u F(u) r^2 \left[4 M r + \partial_u F(u) (r - 3 M)\right]
+   * + F(u) r \left[6 M r + \partial_u F(u) (3r - 8 M)\right]\right\} \\
+   * g_{\theta \theta} =& 2 r \\
+   * g_{\phi \phi} =& 2 r \sin^2(\theta),
+   * \f}
+   *
+   * and all other components vanish (these formulae are obtained simply by
+   * applying radial derivatives to those given in
+   * `GaugeWave::spherical_metric()`). Here, \f$F(u)\f$ is defined as
+   *
+   * \f{align*}{
+   * F(u) &= A \sin(\omega u) e^{-(u - u_0)^2 /k^2},\\
+   * \partial_u F(u) &= A \left[-2 \frac{u - u_0}{k^2} \sin(\omega u)
+   * + \omega \cos(\omega u)\right] e^{-(u - u_0)^2 / k^2}.
+   * \f}
+   *
+   * \warning The \f$\phi\f$ components are returned in a form for which the
+   * \f$\sin(\theta)\f$ factors are omitted, assuming that derivatives and
+   * Jacobians will be applied similarly omitting those factors (and therefore
+   * improving precision of the tensor expression). If you require the
+   * \f$\sin(\theta)\f$ factors, be sure to put them in by hand in the calling
+   * code.
+   */
+  void dr_spherical_metric(
+      gsl::not_null<
+          tnsr::aa<DataVector, 3, ::Frame::Spherical<::Frame::Inertial>>*>
+          dr_spherical_metric,
+      size_t l_max, double time) const noexcept override;
+
+  /*!
+   * \brief Compute the spherical coordinate metric from the closed-form gauge
+   * wave metric.
+   *
+   * \details The transformation of the ingoing Eddington-Finkelstein coordinate
+   * produces metric components in spherical coordinates:
+   *
+   * \f{align*}{
+   * \partial_t g_{tt} =& \frac{-2 \partial_u^2 F(u)}{r^3}
+   * \left(r - 2 M\right) \left(r + \partial_u F(u)\right) \\
+   * \partial_t g_{rt} =& \frac{1}{r^4} \Bigg\{\partial_u^2 F(u)
+   * \left[2 M r^2 + \left(r - 2 M\right)
+   * (r \partial_u F(u) + F(u))\right] \\
+   * &+ \left[r + \partial_u F(u)\right]
+   * \left(r - 2M\right) \left[r \partial_u^2 F(u) + \partial_u F(u)
+   * \right]\Bigg\} \\
+   * \partial_t g_{rr} =&
+   * \frac{1}{r^5}\Bigg\{-\left[r \partial_u^2 F(u) + \partial_u F(u)\right]
+   * \left[r^3 + 2 M r^2  + \left(r - 2 M\right)
+   * \left(r \partial_u F(u) + F(u)\right)\right]\\
+   * &+ \left[r^2 - r \partial_u F(u) - F(u)\right]
+   * \left(r - 2 M\right)
+   * \left[r \partial_u^2 F(u) + \partial_u F(u)\right]\Bigg\} \\
+   * \partial_t g_{\theta \theta} =& 0 \\
+   * \partial_t g_{\phi \phi} =& 0,
+   * \f}
+   *
+   * and all other components vanish. Here, \f$F(u)\f$ is defined as
+   *
+   * \f{align*}{
+   * F(u) &= A \sin(\omega u) e^{-(u - u_0)^2 /k^2},\\
+   * \partial_u F(u) &= A \left[-2 \frac{u - u_0}{k^2} \sin(\omega u)
+   * + \omega \cos(\omega u)\right] e^{-(u - u_0)^2 / k^2},\\
+   * \partial^2_u F(u) &= \frac{A}{k^4} \left\{-4 k^2 \omega (u - u_0)
+   * \cos(\omega u) + \left[-2 k^2 + 4 (u - u_0)^2 - k^4 \omega^2\right]
+   * \sin(\omega u)\right\}  e^{-(u - u_0) / k^2}
+   * \f}
+   *
+   * \warning The \f$\phi\f$ components are returned in a form for which the
+   * \f$\sin(\theta)\f$ factors are omitted, assuming that derivatives and
+   * Jacobians will be applied similarly omitting those factors (and therefore
+   * improving precision of the tensor expression). If you require the
+   * \f$\sin(\theta)\f$ factors, be sure to put them in by hand in the calling
+   * code.
+   */
+  void dt_spherical_metric(
+      gsl::not_null<
+          tnsr::aa<DataVector, 3, ::Frame::Spherical<::Frame::Inertial>>*>
+          dt_spherical_metric,
+      size_t l_max, double time) const noexcept override;
+
+  using WorldtubeData::variables_impl;
+
+  using SphericalMetricData::variables_impl;
+
+  /// The News vanishes, because the wave is pure gauge.
+  void variables_impl(
+      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, -2>>*> News,
+      size_t l_max, double time,
+      tmpl::type_<Tags::News> /*meta*/) const noexcept override;
+
+  double mass_ = std::numeric_limits<double>::signaling_NaN();
+  double frequency_ = std::numeric_limits<double>::signaling_NaN();
+  double amplitude_ = std::numeric_limits<double>::signaling_NaN();
+  double peak_time_ = std::numeric_limits<double>::signaling_NaN();
+  double duration_ = std::numeric_limits<double>::signaling_NaN();
+};
+}  // namespace Solutions
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/SphericalMetricData.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/SphericalMetricData.hpp
@@ -197,7 +197,7 @@ struct SphericalMetricData : public WorldtubeData {
    *
    * \details The derived classes provide spherical metric data via the virtual
    * function `SphericalMetricData::spherical_metric()` at a resolution
-   * determined by member variable `l_max_`. This function performs the
+   * determined by the `l_max` argument. This function performs the
    * coordinate transformation using the Jacobian computed from
    * `SphericalMetricData::inverse_jacobian()`.
    */
@@ -214,7 +214,7 @@ struct SphericalMetricData : public WorldtubeData {
    * \details The derived classes provide the time derivative of the spherical
    * metric data via the virtual function
    * `SphericalMetricData::dt_spherical_metric()` at a resolution determined by
-   * member variable `l_max_`. This function performs the coordinate
+   * the `l_max` argument. This function performs the coordinate
    * transformation using the Jacobian computed from
    * `SphericalMetricData::inverse_jacobian()`.
    */
@@ -231,7 +231,7 @@ struct SphericalMetricData : public WorldtubeData {
    * \details The derived classes provide the radial derivative of the spherical
    * metric data via the virtual function
    * `SphericalMetricData::dr_spherical_metric()` at a resolution determined by
-   * member variable `l_max_`. This function performs the additional angular
+   * the `l_max_` argument. This function performs the additional angular
    * derivatives necessary to assemble the full spatial derivative and performs
    * the coordinate transformation to Cartesian coordinates via the Jacobians
    * computed in `SphericalMetricData::inverse_jacobian()` and

--- a/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_Cce_AnalyticSolutions")
 
 set(LIBRARY_SOURCES
   Test_BouncingBlackHole.cpp
+  Test_GaugeWave.cpp
   Test_LinearizedBondiSachs.cpp
   Test_RotatingSchwarzschild.cpp
   Test_TeukolskyWave.cpp

--- a/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/GaugeWave.py
+++ b/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/GaugeWave.py
@@ -1,0 +1,89 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from numpy import array, cos, exp, sin
+
+
+def coordinate_wave_function(t, r, f, a, tpeak, duration):
+    u = t - r
+    return a * sin(f * u) * exp(-(u - tpeak)**2 / duration**2)
+
+
+def du_coordinate_wave_function(t, r, f, a, tpeak, duration):
+    u = t - r
+    return a * (f * cos(f * u) - 2.0 * sin(f * u) *
+                (u - tpeak) / duration**2) * exp(-(u - tpeak)**2 / duration**2)
+
+
+def du_du_coordinate_wave_function(t, r, f, a, tpeak, duration):
+    u = t - r
+    return (-a * f**2 * sin(f * u) - 2.0 * a * f * cos(f * u) *
+            (u - tpeak) / duration**2 - 2.0 * a * sin(f * u) / duration**2 -
+            2.0 * (u - tpeak) / duration**2 *
+            (a * f * cos(f * u) - 2.0 * a * sin(f * u) *
+             (u - tpeak) / duration**2)) * exp(-(u - tpeak)**2 / duration**2)
+
+
+def spherical_metric(sin_theta, cos_theta, t, r, m, f, a, tpeak, duration):
+    wave_func = coordinate_wave_function(t, r, f, a, tpeak, duration)
+    du_wave_func = du_coordinate_wave_function(t, r, f, a, tpeak, duration)
+    g_tt = -(r - 2.0 * m) * (r + du_wave_func)**2 / r**3
+    g_tr = (1 + du_wave_func / r) * (2.0 * m / r + (1.0 - 2.0 * m / r) *
+                                     (du_wave_func / r + wave_func / r**2))
+    g_rr = (1 - du_wave_func / r -
+            wave_func / r**2) * (1.0 + 2.0 * m / r + (1.0 - 2.0 * m / r) *
+                                 (du_wave_func / r + wave_func / r**2))
+    return array([[g_tt, g_tr, 0.0, 0.0], [g_tr, g_rr, 0.0, 0.0],
+                  [0.0, 0.0, r**2, 0.0], [0.0, 0.0, 0.0, r**2]])
+
+
+def dt_spherical_metric(sin_theta, cos_theta, t, r, m, f, a, tpeak, duration):
+    wave_func = coordinate_wave_function(t, r, f, a, tpeak, duration)
+    du_wave_func = du_coordinate_wave_function(t, r, f, a, tpeak, duration)
+    du_du_wave_func = du_du_coordinate_wave_function(t, r, f, a, tpeak,
+                                                     duration)
+    dt_g_tt = (-2.0 * (1.0 - 2.0 * m / r) * (1.0 + du_wave_func / r) *
+               (du_du_wave_func / r))
+    dt_g_tr = ((du_du_wave_func / r) *
+               (2.0 * m / r + (1.0 - 2.0 * m / r) *
+                (du_wave_func / r + wave_func / r**2)) +
+               (1.0 + du_wave_func / r) * (1.0 - 2.0 * m / r) *
+               (du_du_wave_func / r + du_wave_func / r**2))
+    dt_g_rr = ((-du_du_wave_func / r - du_wave_func / r**2) *
+               (1.0 + 2.0 * m / r + (1.0 - 2.0 * m / r) *
+                (du_wave_func / r + wave_func / r**2)) +
+               (1.0 - du_wave_func / r - wave_func / r**2) *
+               (1.0 - 2.0 * m / r) *
+               (du_du_wave_func / r + du_wave_func / r**2))
+    return array([[dt_g_tt, dt_g_tr, 0.0, 0.0], [dt_g_tr, dt_g_rr, 0.0, 0.0],
+                  [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]])
+
+
+def dr_spherical_metric(sin_theta, cos_theta, t, r, m, f, a, tpeak, duration):
+    wave_func = coordinate_wave_function(t, r, f, a, tpeak, duration)
+    du_wave_func = du_coordinate_wave_function(t, r, f, a, tpeak, duration)
+    dt_metric = dt_spherical_metric(sin_theta, cos_theta, t, r, m, f, a, tpeak,
+                                    duration)
+    dr_g_tt = -(2.0 * m / r**2) * (1.0 + du_wave_func / r)**2 + 2.0 * (
+        1.0 - 2.0 * m / r) * (1.0 + du_wave_func / r) * du_wave_func / r**2
+    dr_g_tr = (-du_wave_func / r**2 * (2.0 * m / r + (1.0 - 2.0 * m / r) *
+                                       (du_wave_func / r + wave_func / r**2)) +
+               (1.0 + du_wave_func / r) *
+               (-2.0 * m / r**2 + 2.0 * m / r**2 *
+                (du_wave_func / r + wave_func / r**2) + (1.0 - 2.0 * m / r) *
+                (-du_wave_func / r**2 - 2.0 * wave_func / r**3)))
+    dr_g_rr = ((du_wave_func / r**2 + 2.0 * wave_func / r**3) *
+               (1.0 + 2.0 * m / r + (1.0 - 2.0 * m / r) *
+                (du_wave_func / r + wave_func / r**2)) +
+               (1.0 - du_wave_func / r - wave_func / r**2) *
+               (-2.0 * m / r**2 + 2.0 * m / r**2 *
+                (du_wave_func / r + wave_func / r**2) + (1.0 - 2.0 * m / r) *
+                (-du_wave_func / r**2 - 2.0 * wave_func / r**3)))
+    return array(
+        [[dr_g_tt - dt_metric[0, 0], dr_g_tr - dt_metric[0, 1], 0.0, 0.0],
+         [dr_g_tr - dt_metric[1, 0], dr_g_rr - dt_metric[1, 1], 0.0, 0.0],
+         [0.0, 0.0, 2.0 * r, 0.0], [0.0, 0.0, 0.0, 2.0 * r]])
+
+
+def news(sin_theta, t, r, m, f, a, tpeak, duration):
+    return complex(0.0, 0.0)

--- a/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/Test_GaugeWave.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/Test_GaugeWave.cpp
@@ -6,8 +6,7 @@
 #include <complex>
 #include <cstddef>
 
-#include "Evolution/Systems/Cce/AnalyticSolutions/RotatingSchwarzschild.hpp"
-#include "Evolution/Systems/Cce/AnalyticSolutions/TeukolskyWave.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/GaugeWave.hpp"
 #include "Framework/Pypp.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Framework/TestHelpers.hpp"
@@ -16,23 +15,25 @@
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 
 namespace Cce::Solutions {
-SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.RotatingSchwarzschild",
-                  "[Unit][Cce]") {
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.GaugeWave", "[Unit][Cce]") {
   MAKE_GENERATOR(gen);
   UniformCustomDistribution<double> radius_dist{5.0, 10.0};
   UniformCustomDistribution<double> parameter_dist{0.5, 2.0};
   const double extraction_radius = radius_dist(gen);
   const size_t l_max = 16;
   // use a low frequency so that the dimensionless parameter in the metric is ~1
-  const double frequency = parameter_dist(gen) / 30.0;
+  const double frequency = parameter_dist(gen) / 5.0;
   const double mass = parameter_dist(gen);
-  TestHelpers::SphericalSolutionWrapper<RotatingSchwarzschild>
-      boundary_solution{extraction_radius, mass, frequency};
-  const double time = 10.0 * parameter_dist(gen);
+  const double amplitude = parameter_dist(gen) / 10.0;
+  const double peak_time = parameter_dist(gen);
+  const double duration = parameter_dist(gen);
+  TestHelpers::SphericalSolutionWrapper<GaugeWave> boundary_solution{
+      extraction_radius, mass, frequency, amplitude, peak_time, duration};
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/Cce/AnalyticSolutions/"};
-  boundary_solution.test_spherical_metric("RotatingSchwarzschild", l_max, time,
-                                          approx, extraction_radius, mass,
-                                          frequency);
+  boundary_solution.test_spherical_metric(
+      "GaugeWave", l_max, peak_time - 0.1 * duration,
+      Approx::custom().epsilon(1.e-11).scale(1.0), extraction_radius, mass,
+      frequency, amplitude, peak_time, duration);
 }
 }  // namespace Cce::Solutions

--- a/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/Test_TeukolskyWave.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/Test_TeukolskyWave.cpp
@@ -29,7 +29,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.TeukolskyWave", "[Unit][Cce]") {
   const double time = duration + extraction_radius + parameter_dist(gen);
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/Cce/AnalyticSolutions/"};
-  boundary_solution.test_spherical_metric(
-      "TeukolskyWave", l_max, time, extraction_radius, amplitude, duration);
+  boundary_solution.test_spherical_metric("TeukolskyWave", l_max, time, approx,
+                                          extraction_radius, amplitude,
+                                          duration);
 }
 }  // namespace Cce::Solutions

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/AnalyticSolutions/AnalyticDataHelpers.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/AnalyticSolutions/AnalyticDataHelpers.hpp
@@ -46,7 +46,7 @@ struct SphericalSolutionWrapper : public SphericalSolution {
 
   template <typename... Args>
   void test_spherical_metric(const std::string python_file, const size_t l_max,
-                             const double time,
+                             const double time, Approx custom_approx,
                              const Args... args) const noexcept {
     const size_t size =
         Spectral::Swsh::number_of_swsh_collocation_points(l_max);
@@ -102,13 +102,13 @@ struct SphericalSolutionWrapper : public SphericalSolution {
         CAPTURE(b);
         const auto& lhs = local_spherical_metric.get(a, b);
         const auto& rhs = py_spherical_metric.get(a, b);
-        CHECK_ITERABLE_APPROX(lhs, rhs);
-        const auto& dr_lhs = local_dr_spherical_metric.get(a, b);
-        const auto& dr_rhs = py_dr_spherical_metric.get(a, b);
-        CHECK_ITERABLE_APPROX(dr_lhs, dr_rhs);
+        CHECK_ITERABLE_CUSTOM_APPROX(lhs, rhs, custom_approx);
         const auto& dt_lhs = local_dt_spherical_metric.get(a, b);
         const auto& dt_rhs = py_dt_spherical_metric.get(a, b);
-        CHECK_ITERABLE_APPROX(dt_lhs, dt_rhs);
+        CHECK_ITERABLE_CUSTOM_APPROX(dt_lhs, dt_rhs, custom_approx);
+        const auto& dr_lhs = local_dr_spherical_metric.get(a, b);
+        const auto& dr_rhs = py_dr_spherical_metric.get(a, b);
+        CHECK_ITERABLE_CUSTOM_APPROX(dr_lhs, dr_rhs, custom_approx);
       }
     }
   }


### PR DESCRIPTION
## Proposed changes

Adds the gauge wave CCE analytic worldtube solution.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spec
