### PR TITLE
Pypp revamp

### DIFF
--- a/docs/DevGuide/WritingTests.md
+++ b/docs/DevGuide/WritingTests.md
@@ -170,7 +170,7 @@ supplied for each `gsl::not_null` argument to the C++. To perform the test the
 `pypp::check_with_random_values()` function must be called. For example, the
 following checks various C++ functions by calling into `pypp`:
 
-\snippet Test_Pypp.cpp cxx_two_not_null
+\snippet Test_PyppRandomValues.cpp cxx_two_not_null
 
 The corresponding Python functions are:
 

--- a/tests/Unit/Framework/CheckWithRandomValues.hpp
+++ b/tests/Unit/Framework/CheckWithRandomValues.hpp
@@ -38,7 +38,6 @@
 #include <boost/vmd/is_empty.hpp>
 // IWYU pragma: end_exports
 
-#include <initializer_list>
 #include <limits>
 #include <random>
 #include <string>
@@ -152,14 +151,9 @@ void check_with_random_values_impl(
   // Note: generator and distributions cannot be const.
   std::tuple<ArgumentTypes...> args{
       make_with_value<ArgumentTypes>(used_for_size, 0.0)...};
-  // We fill with random values after initialization because the order of
-  // evaluation is not guaranteed for a constructor call and so then knowing
-  // the seed would not lead to reproducible results.
-  (void)std::initializer_list<char>{(
-      (void)fill_with_random_values(
-          make_not_null(&std::get<ArgumentIs>(args)), make_not_null(&generator),
-          make_not_null(&(distributions[ArgumentIs]))),
-      '0')...};
+  EXPAND_PACK_LEFT_TO_RIGHT(fill_with_random_values(
+      make_not_null(&std::get<ArgumentIs>(args)), make_not_null(&generator),
+      make_not_null(&(distributions[ArgumentIs]))));
 
   size_t count = 0;
   tmpl::for_each<TagsList>([&f, &klass, &args, &used_for_size, &member_args,
@@ -204,14 +198,9 @@ void check_with_random_values_impl(
   using ResultType = typename f_info::return_type;
   std::tuple<ArgumentTypes...> args{
       make_with_value<ArgumentTypes>(used_for_size, 0.0)...};
-  // We fill with random values after initialization because the order of
-  // evaluation is not guaranteed for a constructor call and so then knowing the
-  // seed would not lead to reproducible results.
-  (void)std::initializer_list<char>{(
-      (void)fill_with_random_values(
-          make_not_null(&std::get<ArgumentIs>(args)), make_not_null(&generator),
-          make_not_null(&(distributions[ArgumentIs]))),
-      '0')...};
+  EXPAND_PACK_LEFT_TO_RIGHT(fill_with_random_values(
+      make_not_null(&std::get<ArgumentIs>(args)), make_not_null(&generator),
+      make_not_null(&(distributions[ArgumentIs]))));
   const auto result = make_overloader(
       [&](std::true_type /*is_class*/, auto&& local_f) {
         return (klass.*local_f)(std::get<ArgumentIs>(args)...);
@@ -257,22 +246,12 @@ void check_with_random_values_impl(
       make_with_value<ReturnTypes>(used_for_size, 0.0)...};
   std::tuple<ArgumentTypes...> args{
       make_with_value<ArgumentTypes>(used_for_size, 0.0)...};
-  // We fill with random values after initialization because the order of
-  // evaluation is not guaranteed for a constructor call and so then knowing the
-  // seed would not lead to reproducible results.
-  (void)std::initializer_list<char>{(
-      (void)fill_with_random_values(
-          make_not_null(&std::get<ArgumentIs>(args)), make_not_null(&generator),
-          make_not_null(&(distributions[ArgumentIs]))),
-      '0')...};
-  // We intentionally do not set the return value to signaling NaN so that not
-  // all of our functions need to be able to handle the cases where they
-  // receive a NaN. Instead, we fill the return value with random numbers.
-  (void)std::initializer_list<char>{(
-      (void)fill_with_random_values(make_not_null(&std::get<ResultIs>(results)),
-                                    make_not_null(&generator),
-                                    make_not_null(&(distributions[0]))),
-      '0')...};
+  EXPAND_PACK_LEFT_TO_RIGHT(fill_with_random_values(
+      make_not_null(&std::get<ArgumentIs>(args)), make_not_null(&generator),
+      make_not_null(&(distributions[ArgumentIs]))));
+  EXPAND_PACK_LEFT_TO_RIGHT(fill_with_random_values(
+      make_not_null(&std::get<ResultIs>(results)), make_not_null(&generator),
+      make_not_null(&(distributions[0]))));
   make_overloader(
       [&](std::true_type /*is_class*/, auto&& local_f) {
         (klass.*local_f)(make_not_null(&std::get<ResultIs>(results))...,
@@ -304,10 +283,8 @@ void check_with_random_values_impl(
       INFO("Python call failed: " << e.what());
       CHECK(false);
     }
-    return '0';
   };
-  (void)std::initializer_list<char>{
-      helper(std::integral_constant<size_t, ResultIs>{})...};
+  EXPAND_PACK_LEFT_TO_RIGHT(helper(std::integral_constant<size_t, ResultIs>{}));
 }
 }  // namespace TestHelpers_detail
 

--- a/tests/Unit/Framework/Pypp.hpp
+++ b/tests/Unit/Framework/Pypp.hpp
@@ -11,6 +11,7 @@
 #include <boost/optional.hpp>
 #include <boost/range/combine.hpp>
 #include <cstddef>
+#include <optional>
 #include <stdexcept>
 #include <string>
 
@@ -250,6 +251,48 @@ struct ContainerPackAndUnpack<boost::optional<T>, std::nullptr_t> {
              ComplexDataVector>)and UNLIKELY(not static_cast<bool>(unpacked))) {
       throw std::runtime_error(
           "Returned type is None in one element of the boost::optional's "
+          "packed type (DataVector or ComplexDataVector). We can't support "
+          "this because we can't just make one element of the packed type be "
+          "an invalid optional.");
+    }
+    ContainerPackAndUnpack<T>::pack(make_not_null(&*packed), unpacked,
+                                    grid_point_index);
+  }
+
+  static inline size_t get_size(const packed_container& packed) noexcept {
+    if (static_cast<bool>(packed)) {
+      return ContainerPackAndUnpack<T>::get_size(*packed);
+    }
+    return 1;
+  }
+};
+
+template <typename T>
+struct ContainerPackAndUnpack<std::optional<T>, std::nullptr_t> {
+  using unpacked_container =
+      std::optional<typename ContainerPackAndUnpack<T>::unpacked_container>;
+  using packed_container =
+      std::optional<typename ContainerPackAndUnpack<T>::packed_container>;
+  using packed_type = typename ContainerPackAndUnpack<T>::packed_type;
+
+  static inline unpacked_container unpack(
+      const packed_container& packed, const size_t grid_point_index) noexcept {
+    if (static_cast<bool>(packed)) {
+      return unpacked_container{
+          ContainerPackAndUnpack<T>::unpack(*packed, grid_point_index)};
+    }
+    return unpacked_container{std::nullopt};
+  }
+
+  static inline void pack(const gsl::not_null<packed_container*> packed,
+                          const unpacked_container& unpacked,
+                          const size_t grid_point_index) {
+    if ((std::is_same_v<packed_type, DataVector> or
+         std::is_same_v<
+             packed_type,
+             ComplexDataVector>)and UNLIKELY(not static_cast<bool>(unpacked))) {
+      throw std::runtime_error(
+          "Returned type is None in one element of the std::optional's "
           "packed type (DataVector or ComplexDataVector). We can't support "
           "this because we can't just make one element of the packed type be "
           "an invalid optional.");

--- a/tests/Unit/Framework/Pypp.hpp
+++ b/tests/Unit/Framework/Pypp.hpp
@@ -26,10 +26,318 @@
 #include "Utilities/TypeTraits/IsA.hpp"
 #include "Utilities/TypeTraits/IsStdArray.hpp"
 
-/// \ingroup TestingFrameworkGroup
-/// Contains all functions for calling python from C++
+/*!
+ * \ingroup TestingFrameworkGroup
+ * \brief Contains all functions for calling python from C++
+ */
 namespace pypp {
 namespace detail {
+template <typename T, typename ConversionClass>
+struct PackedTypeMatches
+    : std::is_same<typename ConversionClass::packed_container, T> {};
+
+template <typename T, typename ConversionClassList, typename = std::nullptr_t>
+struct ContainerPackAndUnpack;
+
+template <typename T, typename ConversionClassList>
+struct ContainerPackAndUnpack<
+    T, ConversionClassList,
+    Requires<tmpl::found<ConversionClassList,
+                         PackedTypeMatches<tmpl::pin<T>, tmpl::_1>>::value>>
+    : tmpl::front<tmpl::find<ConversionClassList,
+                             PackedTypeMatches<tmpl::pin<T>, tmpl::_1>>> {
+  static_assert(
+      tmpl::count_if<ConversionClassList,
+                     PackedTypeMatches<tmpl::pin<T>, tmpl::_1>>::value == 1,
+      "Found more than one conversion class for the type. See the first "
+      "template parameter of ContainerPackAndUnpack for the type being "
+      "converted, and the second template parameter for a list of all the "
+      "additional conversion classes.");
+};
+
+template <typename ConversionClassList>
+struct ContainerPackAndUnpack<DataVector, ConversionClassList, std::nullptr_t> {
+  using unpacked_container = double;
+  using packed_container = DataVector;
+  using packed_type = packed_container;
+
+  static inline unpacked_container unpack(
+      const packed_container& packed, const size_t grid_point_index) noexcept {
+    ASSERT(grid_point_index < packed.size(),
+           "Trying to slice DataVector of size " << packed.size()
+                                                 << " with grid_point_index "
+                                                 << grid_point_index);
+    return packed[grid_point_index];
+  }
+
+  static inline void pack(const gsl::not_null<packed_container*> packed,
+                          const unpacked_container& unpacked,
+                          const size_t grid_point_index) {
+    (*packed)[grid_point_index] = unpacked;
+  }
+
+  static inline size_t get_size(const packed_container& packed) noexcept {
+    return packed.size();
+  }
+};
+
+template <typename ConversionClassList>
+struct ContainerPackAndUnpack<ComplexDataVector, ConversionClassList,
+                              std::nullptr_t> {
+  using unpacked_container = std::complex<double>;
+  using packed_container = ComplexDataVector;
+  using packed_type = packed_container;
+
+  static inline unpacked_container unpack(
+      const packed_type& packed, const size_t grid_point_index) noexcept {
+    ASSERT(grid_point_index < packed.size(),
+           "Trying to slice ComplexDataVector of size "
+               << packed.size() << " with grid_point_index "
+               << grid_point_index);
+    return packed[grid_point_index];
+  }
+
+  static inline void pack(const gsl::not_null<packed_container*> packed,
+                          const unpacked_container& unpacked,
+                          const size_t grid_point_index) {
+    (*packed)[grid_point_index] = unpacked;
+  }
+
+  static inline size_t get_size(const packed_container& packed) noexcept {
+    return packed.size();
+  }
+};
+
+template <typename T, typename... Ts, typename ConversionClassList>
+struct ContainerPackAndUnpack<Tensor<T, Ts...>, ConversionClassList,
+                              std::nullptr_t> {
+  using unpacked_container =
+      Tensor<typename ContainerPackAndUnpack<
+                 T, ConversionClassList>::unpacked_container,
+             Ts...>;
+  using packed_container = Tensor<
+      typename ContainerPackAndUnpack<T, ConversionClassList>::packed_container,
+      Ts...>;
+  using packed_type =
+      typename ContainerPackAndUnpack<T, ConversionClassList>::packed_type;
+
+  static inline unpacked_container unpack(
+      const packed_container& packed, const size_t grid_point_index) noexcept {
+    unpacked_container unpacked{};
+    for (size_t storage_index = 0; storage_index < unpacked.size();
+         ++storage_index) {
+      unpacked[storage_index] =
+          ContainerPackAndUnpack<T, ConversionClassList>::unpack(
+              packed[storage_index], grid_point_index);
+    }
+    return unpacked;
+  }
+
+  static inline void pack(const gsl::not_null<packed_container*> packed,
+                          const unpacked_container& unpacked,
+                          const size_t grid_point_index) {
+    for (size_t storage_index = 0; storage_index < unpacked.size();
+         ++storage_index) {
+      ContainerPackAndUnpack<T, ConversionClassList>::pack(
+          make_not_null(&(*packed)[storage_index]), unpacked[storage_index],
+          grid_point_index);
+    }
+  }
+
+  static inline size_t get_size(const packed_container& packed) noexcept {
+    return ContainerPackAndUnpack<T, ConversionClassList>::get_size(packed[0]);
+  }
+};
+
+template <typename T, size_t Size, typename ConversionClassList>
+struct ContainerPackAndUnpack<std::array<T, Size>, ConversionClassList,
+                              std::nullptr_t> {
+  using unpacked_container =
+      std::array<typename ContainerPackAndUnpack<
+                     T, ConversionClassList>::unpacked_container,
+                 Size>;
+  using packed_container = std::array<
+      typename ContainerPackAndUnpack<T, ConversionClassList>::packed_container,
+      Size>;
+  using packed_type =
+      typename ContainerPackAndUnpack<T, ConversionClassList>::packed_type;
+
+  static inline unpacked_container unpack(
+      const packed_container& packed, const size_t grid_point_index) noexcept {
+    unpacked_container unpacked{};
+    for (size_t i = 0; i < Size; ++i) {
+      gsl::at(unpacked, i) =
+          ContainerPackAndUnpack<T, ConversionClassList>::unpack(
+              gsl::at(packed, i), grid_point_index);
+    }
+    return unpacked;
+  }
+
+  static inline void pack(const gsl::not_null<packed_container*> packed,
+                          const unpacked_container& unpacked,
+                          const size_t grid_point_index) {
+    for (size_t i = 0; i < unpacked.size(); ++i) {
+      ContainerPackAndUnpack<T, ConversionClassList>::pack(
+          make_not_null(&gsl::at(*packed, i)), gsl::at(unpacked, i),
+          grid_point_index);
+    }
+  }
+
+  static inline size_t get_size(const packed_container& packed) noexcept {
+    return ContainerPackAndUnpack<T, ConversionClassList>::get_size(packed[0]);
+  }
+};
+
+// scalars are the only sort of spin-weighted type we support.
+template <typename ValueType, int Spin, typename ConversionClassList>
+struct ContainerPackAndUnpack<Scalar<SpinWeighted<ValueType, Spin>>,
+                              ConversionClassList, std::nullptr_t> {
+  using unpacked_container = Scalar<typename ContainerPackAndUnpack<
+      ValueType, ConversionClassList>::unpacked_container>;
+  using packed_container =
+      Scalar<SpinWeighted<typename ContainerPackAndUnpack<
+                              ValueType, ConversionClassList>::packed_container,
+                          Spin>>;
+  using packed_type =
+      typename ContainerPackAndUnpack<ValueType,
+                                      ConversionClassList>::packed_type;
+
+  static inline unpacked_container unpack(
+      const packed_container& packed, const size_t grid_point_index) noexcept {
+    unpacked_container unpacked{};
+    get(unpacked) =
+        ContainerPackAndUnpack<ValueType, ConversionClassList>::unpack(
+            get(packed).data(), grid_point_index);
+    return unpacked;
+  }
+
+  static inline void pack(const gsl::not_null<packed_container*> packed,
+                          const unpacked_container& unpacked,
+                          const size_t grid_point_index) {
+    ContainerPackAndUnpack<ValueType, ConversionClassList>::pack(
+        make_not_null(&(get(*packed).data())), get(unpacked), grid_point_index);
+  }
+
+  static inline size_t get_size(const packed_container& packed) noexcept {
+    return ContainerPackAndUnpack<ValueType, ConversionClassList>::get_size(
+        packed[0].data());
+  }
+};
+
+template <typename T, typename ConversionClassList>
+struct ContainerPackAndUnpack<boost::optional<T>, ConversionClassList,
+                              std::nullptr_t> {
+  using unpacked_container = boost::optional<typename ContainerPackAndUnpack<
+      T, ConversionClassList>::unpacked_container>;
+  using packed_container = boost::optional<typename ContainerPackAndUnpack<
+      T, ConversionClassList>::packed_container>;
+  using packed_type =
+      typename ContainerPackAndUnpack<T, ConversionClassList>::packed_type;
+
+  static inline unpacked_container unpack(
+      const packed_container& packed, const size_t grid_point_index) noexcept {
+    if (static_cast<bool>(packed)) {
+      return unpacked_container{
+          ContainerPackAndUnpack<T, ConversionClassList>::unpack(
+              *packed, grid_point_index)};
+    }
+    return unpacked_container{};
+  }
+
+  static inline void pack(const gsl::not_null<packed_container*> packed,
+                          const unpacked_container& unpacked,
+                          const size_t grid_point_index) {
+    if ((std::is_same_v<packed_type, DataVector> or
+         std::is_same_v<
+             packed_type,
+             ComplexDataVector>)and UNLIKELY(not static_cast<bool>(unpacked))) {
+      throw std::runtime_error(
+          "Returned type is None in one element of the boost::optional's "
+          "packed type (DataVector or ComplexDataVector). We can't support "
+          "this because we can't just make one element of the packed type be "
+          "an invalid optional.");
+    }
+    ContainerPackAndUnpack<T, ConversionClassList>::pack(
+        make_not_null(&*packed), unpacked, grid_point_index);
+  }
+
+  static inline size_t get_size(const packed_container& packed) noexcept {
+    if (static_cast<bool>(packed)) {
+      return ContainerPackAndUnpack<T, ConversionClassList>::get_size(*packed);
+    }
+    return 1;
+  }
+};
+
+template <typename T, typename ConversionClassList>
+struct ContainerPackAndUnpack<std::optional<T>, ConversionClassList,
+                              std::nullptr_t> {
+  using unpacked_container = std::optional<typename ContainerPackAndUnpack<
+      T, ConversionClassList>::unpacked_container>;
+  using packed_container = std::optional<typename ContainerPackAndUnpack<
+      T, ConversionClassList>::packed_container>;
+  using packed_type =
+      typename ContainerPackAndUnpack<T, ConversionClassList>::packed_type;
+
+  static inline unpacked_container unpack(
+      const packed_container& packed, const size_t grid_point_index) noexcept {
+    if (static_cast<bool>(packed)) {
+      return unpacked_container{
+          ContainerPackAndUnpack<T, ConversionClassList>::unpack(
+              *packed, grid_point_index)};
+    }
+    return unpacked_container{std::nullopt};
+  }
+
+  static inline void pack(const gsl::not_null<packed_container*> packed,
+                          const unpacked_container& unpacked,
+                          const size_t grid_point_index) {
+    if ((std::is_same_v<packed_type, DataVector> or
+         std::is_same_v<
+             packed_type,
+             ComplexDataVector>)and UNLIKELY(not static_cast<bool>(unpacked))) {
+      throw std::runtime_error(
+          "Returned type is None in one element of the std::optional's "
+          "packed type (DataVector or ComplexDataVector). We can't support "
+          "this because we can't just make one element of the packed type be "
+          "an invalid optional.");
+    }
+    ContainerPackAndUnpack<T, ConversionClassList>::pack(
+        make_not_null(&*packed), unpacked, grid_point_index);
+  }
+
+  static inline size_t get_size(const packed_container& packed) noexcept {
+    if (static_cast<bool>(packed)) {
+      return ContainerPackAndUnpack<T, ConversionClassList>::get_size(*packed);
+    }
+    return 1;
+  }
+};
+
+template <typename T, typename ConversionClassList>
+struct ContainerPackAndUnpack<
+    T, ConversionClassList,
+    Requires<std::is_floating_point_v<T> or std::is_integral_v<T>>> {
+  using unpacked_container = T;
+  using packed_container = T;
+  using packed_type = packed_container;
+
+  static inline unpacked_container unpack(
+      const packed_container t, const size_t /*grid_point_index*/) noexcept {
+    return t;
+  }
+
+  static inline void pack(const gsl::not_null<packed_container*> packed,
+                          const unpacked_container unpacked,
+                          const size_t /*grid_point_index*/) {
+    *packed = unpacked;
+  }
+
+  static inline size_t get_size(const packed_container& /*packed*/) noexcept {
+    return 1;
+  }
+};
+
 template <typename R>
 R call_work(PyObject* python_module, PyObject* func, PyObject* args) {
   PyObject* value = PyObject_CallObject(func, args);
@@ -46,7 +354,7 @@ R call_work(PyObject* python_module, PyObject* func, PyObject* args) {
   return ret;
 }
 
-template <typename R, typename = std::nullptr_t>
+template <typename R, typename ConversionClassList, typename = std::nullptr_t>
 struct CallImpl {
   template <typename... Args>
   static R call(const std::string& module_name,
@@ -73,272 +381,15 @@ struct CallImpl {
   }
 };
 
-template <typename T, typename = std::nullptr_t>
-struct ContainerPackAndUnpack;
-
-template <>
-struct ContainerPackAndUnpack<DataVector, std::nullptr_t> {
-  using unpacked_container = double;
-  using packed_container = DataVector;
-  using packed_type = packed_container;
-
-  static inline unpacked_container unpack(
-      const packed_container& packed, const size_t grid_point_index) noexcept {
-    ASSERT(grid_point_index < packed.size(),
-           "Trying to slice DataVector of size " << packed.size()
-                                                 << " with grid_point_index "
-                                                 << grid_point_index);
-    return packed[grid_point_index];
-  }
-
-  static inline void pack(const gsl::not_null<packed_container*> packed,
-                          const unpacked_container& unpacked,
-                          const size_t grid_point_index) {
-    (*packed)[grid_point_index] = unpacked;
-  }
-
-  static inline size_t get_size(const packed_container& packed) noexcept {
-    return packed.size();
-  }
-};
-
-template <>
-struct ContainerPackAndUnpack<ComplexDataVector, std::nullptr_t> {
-  using unpacked_container = std::complex<double>;
-  using packed_container = ComplexDataVector;
-  using packed_type = packed_container;
-
-  static inline unpacked_container unpack(
-      const packed_type& packed, const size_t grid_point_index) noexcept {
-    ASSERT(grid_point_index < packed.size(),
-           "Trying to slice ComplexDataVector of size "
-               << packed.size() << " with grid_point_index "
-               << grid_point_index);
-    return packed[grid_point_index];
-  }
-
-  static inline void pack(const gsl::not_null<packed_container*> packed,
-                          const unpacked_container& unpacked,
-                          const size_t grid_point_index) {
-    (*packed)[grid_point_index] = unpacked;
-  }
-
-  static inline size_t get_size(const packed_container& packed) noexcept {
-    return packed.size();
-  }
-};
-
-template <typename T, typename... Ts>
-struct ContainerPackAndUnpack<Tensor<T, Ts...>, std::nullptr_t> {
-  using unpacked_container =
-      Tensor<typename ContainerPackAndUnpack<T>::unpacked_container, Ts...>;
-  using packed_container =
-      Tensor<typename ContainerPackAndUnpack<T>::packed_container, Ts...>;
-  using packed_type = typename ContainerPackAndUnpack<T>::packed_type;
-
-  static inline unpacked_container unpack(
-      const packed_container& packed, const size_t grid_point_index) noexcept {
-    unpacked_container unpacked{};
-    for (size_t storage_index = 0; storage_index < unpacked.size();
-         ++storage_index) {
-      unpacked[storage_index] = ContainerPackAndUnpack<T>::unpack(
-          packed[storage_index], grid_point_index);
-    }
-    return unpacked;
-  }
-
-  static inline void pack(const gsl::not_null<packed_container*> packed,
-                          const unpacked_container& unpacked,
-                          const size_t grid_point_index) {
-    for (size_t storage_index = 0; storage_index < unpacked.size();
-         ++storage_index) {
-      ContainerPackAndUnpack<T>::pack(make_not_null(&(*packed)[storage_index]),
-                                      unpacked[storage_index],
-                                      grid_point_index);
-    }
-  }
-
-  static inline size_t get_size(const packed_container& packed) noexcept {
-    return ContainerPackAndUnpack<T>::get_size(packed[0]);
-  }
-};
-
-template <typename T, size_t Size>
-struct ContainerPackAndUnpack<std::array<T, Size>, std::nullptr_t> {
-  using unpacked_container =
-      std::array<typename ContainerPackAndUnpack<T>::unpacked_container, Size>;
-  using packed_container =
-      std::array<typename ContainerPackAndUnpack<T>::packed_container, Size>;
-  using packed_type = typename ContainerPackAndUnpack<T>::packed_type;
-
-  static inline unpacked_container unpack(
-      const packed_container& packed, const size_t grid_point_index) noexcept {
-    unpacked_container unpacked{};
-    for (size_t i = 0; i < Size; ++i) {
-      gsl::at(unpacked, i) = ContainerPackAndUnpack<T>::unpack(
-          gsl::at(packed, i), grid_point_index);
-    }
-    return unpacked;
-  }
-
-  static inline void pack(const gsl::not_null<packed_container*> packed,
-                          const unpacked_container& unpacked,
-                          const size_t grid_point_index) {
-    for (size_t i = 0; i < unpacked.size(); ++i) {
-      ContainerPackAndUnpack<T>::pack(make_not_null(&gsl::at(*packed, i)),
-                                      gsl::at(unpacked, i), grid_point_index);
-    }
-  }
-
-  static inline size_t get_size(const packed_container& packed) noexcept {
-    return ContainerPackAndUnpack<T>::get_size(packed[0]);
-  }
-};
-
-// scalars are the only sort of spin-weighted type we support.
-template <typename ValueType, int Spin>
-struct ContainerPackAndUnpack<Scalar<SpinWeighted<ValueType, Spin>>,
-                              std::nullptr_t> {
-  using unpacked_container =
-      Scalar<typename ContainerPackAndUnpack<ValueType>::unpacked_container>;
-  using packed_container = Scalar<SpinWeighted<
-      typename ContainerPackAndUnpack<ValueType>::packed_container, Spin>>;
-  using packed_type = typename ContainerPackAndUnpack<ValueType>::packed_type;
-
-  static inline unpacked_container unpack(
-      const packed_container& packed, const size_t grid_point_index) noexcept {
-    unpacked_container unpacked{};
-    get(unpacked) = ContainerPackAndUnpack<ValueType>::unpack(
-        get(packed).data(), grid_point_index);
-    return unpacked;
-  }
-
-  static inline void pack(const gsl::not_null<packed_container*> packed,
-                          const unpacked_container& unpacked,
-                          const size_t grid_point_index) {
-    ContainerPackAndUnpack<ValueType>::pack(
-        make_not_null(&(get(*packed).data())), get(unpacked), grid_point_index);
-  }
-
-  static inline size_t get_size(const packed_container& packed) noexcept {
-    return ContainerPackAndUnpack<ValueType>::get_size(packed[0].data());
-  }
-};
-
-template <typename T>
-struct ContainerPackAndUnpack<boost::optional<T>, std::nullptr_t> {
-  using unpacked_container =
-      boost::optional<typename ContainerPackAndUnpack<T>::unpacked_container>;
-  using packed_container =
-      boost::optional<typename ContainerPackAndUnpack<T>::packed_container>;
-  using packed_type = typename ContainerPackAndUnpack<T>::packed_type;
-
-  static inline unpacked_container unpack(
-      const packed_container& packed, const size_t grid_point_index) noexcept {
-    if (static_cast<bool>(packed)) {
-      return unpacked_container{
-          ContainerPackAndUnpack<T>::unpack(*packed, grid_point_index)};
-    }
-    return unpacked_container{};
-  }
-
-  static inline void pack(const gsl::not_null<packed_container*> packed,
-                          const unpacked_container& unpacked,
-                          const size_t grid_point_index) {
-    if ((std::is_same_v<packed_type, DataVector> or
-         std::is_same_v<
-             packed_type,
-             ComplexDataVector>)and UNLIKELY(not static_cast<bool>(unpacked))) {
-      throw std::runtime_error(
-          "Returned type is None in one element of the boost::optional's "
-          "packed type (DataVector or ComplexDataVector). We can't support "
-          "this because we can't just make one element of the packed type be "
-          "an invalid optional.");
-    }
-    ContainerPackAndUnpack<T>::pack(make_not_null(&*packed), unpacked,
-                                    grid_point_index);
-  }
-
-  static inline size_t get_size(const packed_container& packed) noexcept {
-    if (static_cast<bool>(packed)) {
-      return ContainerPackAndUnpack<T>::get_size(*packed);
-    }
-    return 1;
-  }
-};
-
-template <typename T>
-struct ContainerPackAndUnpack<std::optional<T>, std::nullptr_t> {
-  using unpacked_container =
-      std::optional<typename ContainerPackAndUnpack<T>::unpacked_container>;
-  using packed_container =
-      std::optional<typename ContainerPackAndUnpack<T>::packed_container>;
-  using packed_type = typename ContainerPackAndUnpack<T>::packed_type;
-
-  static inline unpacked_container unpack(
-      const packed_container& packed, const size_t grid_point_index) noexcept {
-    if (static_cast<bool>(packed)) {
-      return unpacked_container{
-          ContainerPackAndUnpack<T>::unpack(*packed, grid_point_index)};
-    }
-    return unpacked_container{std::nullopt};
-  }
-
-  static inline void pack(const gsl::not_null<packed_container*> packed,
-                          const unpacked_container& unpacked,
-                          const size_t grid_point_index) {
-    if ((std::is_same_v<packed_type, DataVector> or
-         std::is_same_v<
-             packed_type,
-             ComplexDataVector>)and UNLIKELY(not static_cast<bool>(unpacked))) {
-      throw std::runtime_error(
-          "Returned type is None in one element of the std::optional's "
-          "packed type (DataVector or ComplexDataVector). We can't support "
-          "this because we can't just make one element of the packed type be "
-          "an invalid optional.");
-    }
-    ContainerPackAndUnpack<T>::pack(make_not_null(&*packed), unpacked,
-                                    grid_point_index);
-  }
-
-  static inline size_t get_size(const packed_container& packed) noexcept {
-    if (static_cast<bool>(packed)) {
-      return ContainerPackAndUnpack<T>::get_size(*packed);
-    }
-    return 1;
-  }
-};
-
-template <typename T>
-struct ContainerPackAndUnpack<
-    T, Requires<std::is_floating_point_v<T> or std::is_integral_v<T>>> {
-  using unpacked_container = T;
-  using packed_container = T;
-  using packed_type = packed_container;
-
-  static inline unpacked_container unpack(
-      const packed_container t, const size_t /*grid_point_index*/) noexcept {
-    return t;
-  }
-
-  static inline void pack(const gsl::not_null<packed_container*> packed,
-                          const unpacked_container unpacked,
-                          const size_t /*grid_point_index*/) {
-    *packed = unpacked;
-  }
-
-  static inline size_t get_size(const packed_container& /*packed*/) noexcept {
-    return 1;
-  }
-};
-
-template <typename R>
-struct CallImpl<
-    R, Requires<(tt::is_a_v<Tensor, R> or tt::is_std_array_v<R>)and(
-           std::is_same_v<typename ContainerPackAndUnpack<R>::packed_type,
-                          DataVector> or
-           std::is_same_v<typename ContainerPackAndUnpack<R>::packed_type,
-                          ComplexDataVector>)>> {
+template <typename R, typename ConversionClassList>
+struct CallImpl<R, ConversionClassList,
+                Requires<(tt::is_a_v<Tensor, R> or tt::is_std_array_v<R>)and(
+                    std::is_same_v<typename ContainerPackAndUnpack<
+                                       R, ConversionClassList>::packed_type,
+                                   DataVector> or
+                    std::is_same_v<typename ContainerPackAndUnpack<
+                                       R, ConversionClassList>::packed_type,
+                                   ComplexDataVector>)>> {
   template <typename... Args>
   static R call(const std::string& module_name,
                 const std::string& function_name, const Args&... t) {
@@ -362,28 +413,28 @@ struct CallImpl<
     }
 
     const std::array<size_t, sizeof...(Args)> arg_sizes{
-        {ContainerPackAndUnpack<Args>::get_size(t)...}};
+        {ContainerPackAndUnpack<Args, ConversionClassList>::get_size(t)...}};
     const size_t npts = *std::max_element(arg_sizes.begin(), arg_sizes.end());
     for (size_t i = 0; i < arg_sizes.size(); ++i) {
-      if (arg_sizes[i] != 1 and arg_sizes[i] != npts) {
+      if (gsl::at(arg_sizes, i) != 1 and gsl::at(arg_sizes, i) != npts) {
         ERROR(
             "Each argument must return size 1 or "
             << npts
             << " (the number of points in the DataVector), but argument number "
-            << i << " has size " << arg_sizes[i]);
+            << i << " has size " << gsl::at(arg_sizes, i));
       }
     }
-    auto return_container =
-        make_with_value<typename ContainerPackAndUnpack<R>::packed_container>(
-            npts, 0.0);
+    auto return_container = make_with_value<typename ContainerPackAndUnpack<
+        R, ConversionClassList>::packed_container>(npts, 0.0);
 
     for (size_t s = 0; s < npts; ++s) {
-      PyObject* args =
-          pypp::make_py_tuple(ContainerPackAndUnpack<Args>::unpack(t, s)...);
-      auto ret =
-          call_work<typename ContainerPackAndUnpack<R>::unpacked_container>(
-              python_module, func, args);
-      ContainerPackAndUnpack<R>::pack(make_not_null(&return_container), ret, s);
+      PyObject* args = pypp::make_py_tuple(
+          ContainerPackAndUnpack<Args, ConversionClassList>::unpack(t, s)...);
+      auto ret = call_work<typename ContainerPackAndUnpack<
+          R, ConversionClassList>::unpacked_container>(python_module, func,
+                                                       args);
+      ContainerPackAndUnpack<R, ConversionClassList>::pack(
+          make_not_null(&return_container), ret, s);
     }
     Py_DECREF(func);           // NOLINT
     Py_DECREF(python_module);  // NOLINT
@@ -399,10 +450,48 @@ struct CallImpl<
 /// \param t the arguments to be passed to the Python function
 /// \return the object returned by the Python function converted to a C++ type
 ///
-/// Custom classes can be converted between Python and C++ by overloading the
-/// `pypp::ToPythonObject<T>` and `pypp::FromPythonObject<T>` structs for your
-/// own types. This tells C++ how to deconstruct the Python object into
-/// fundamental types and reconstruct the C++ object and vice-versa.
+/// Custom conversion from containers to basic types that can be converted to
+/// python objects via the `pypp::ToPyObject` class can be added by passing a
+/// typelist of conversion class as the second template parameter to
+/// `pypp::call`. This is generally used for converting classes like
+/// `Tensor<DataVector, ...>` to a `Tensor<double, ...>` to support using
+/// `numpy.einsum` in the python code. However, this can also be used to convert
+/// a complicated class such as an equation of state to a bunch of numbers that
+/// the python code for the particular test can use to compute the required data
+/// without having to fully implement python bindings. The conversion classes
+/// must have the following:
+/// - a type alias `unpacked_container` that is the type at a single grid point.
+/// - a type alias `packed_container` the type used when converting the result
+///   from the python call back into the C++ code.
+/// - a type alias `packed_type` which corresponds to the packed type that the
+///   high-level container holds. For example, a `Scalar<DataVector>` would have
+///   `packed_type` being `DataVector`, a `std::vector<Scalar<DataVector>>`
+///   would have `packed_type` being `DataVector`, and a
+///   `std::vector<Scalar<double>>` would have `packed_type` being `double`.
+/// - an `unpack` function that takes as its arguments the `packed_container`
+///   and the `grid_point_index`, and returns an `unpacked_container` object
+/// - a `pack` function that takes as its arguments a
+///   `gsl::not_null<packed_container*>`, an `const unpacked_container&`, and a
+///   `size_t` corresponding to which grid point to pack
+/// - a `get_size` function that takes as its only argument an object of
+///   `packed_container` and returns the number of elements in the
+///   `packed_type`
+///
+/// Examples of conversion classes can be found in the specializations of
+/// `ContainerPackAndUnpack` in the `Pypp.hpp` file. Below is an example of a
+/// conversion class that takes a class (`ClassForConversionTest`) and returns
+/// the `a_` member variable.
+///
+/// \snippet Test_Pypp.cpp convert_arbitrary_a
+///
+/// Here is the call to `pypp::call`:
+///
+/// \snippet Test_Pypp.cpp convert_arbitrary_a_call
+///
+/// A conversion class for retrieving the member variables `b_` can also be
+/// written as follows:
+///
+/// \snippet Test_Pypp.cpp convert_arbitrary_b
 ///
 /// \note In order to setup the python interpreter and add the local directories
 /// to the path, a SetupLocalPythonEnvironment object needs to be constructed
@@ -442,9 +531,11 @@ struct CallImpl<
 /// `Tensor<DataVector...>` from `pypp::call`, at least one
 /// `Tensor<DataVector...>` must be taken as an argument, as the size of the
 /// returned tensor needs to be deduced.
-template <typename R, typename... Args>
+template <typename R, typename ConversionClassList = tmpl::list<>,
+          typename... Args>
 R call(const std::string& module_name, const std::string& function_name,
        const Args&... t) {
-  return detail::CallImpl<R>::call(module_name, function_name, t...);
+  return detail::CallImpl<R, ConversionClassList>::call(module_name,
+                                                        function_name, t...);
 }
 }  // namespace pypp

--- a/tests/Unit/Framework/PyppFundamentals.hpp
+++ b/tests/Unit/Framework/PyppFundamentals.hpp
@@ -512,8 +512,11 @@ T tensor_conversion_impl(PyObject* p) {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     if (npy_array_dims[i] != static_cast<long>(gsl::at(t_array_dims, i))) {
       throw std::runtime_error{
-          "Mismatch between number of components of ndarray and Tensor in " +
-          std::to_string(i) + "\'th dim"};
+          "Mismatch between number of components of ndarray (" +
+          std::to_string(npy_array_dims[i])  // NOLINT
+          + ") and Tensor of rank " + std::to_string(T::rank()) + " in " +
+          std::to_string(i) + "\'th index with dimension " +
+          std::to_string(static_cast<long>(gsl::at(t_array_dims, i)))};
     }
   }
   auto t = make_with_value<T>(

--- a/tests/Unit/Framework/PyppFundamentals.hpp
+++ b/tests/Unit/Framework/PyppFundamentals.hpp
@@ -8,6 +8,7 @@
 
 #include <Python.h>
 #include <array>
+#include <boost/optional.hpp>
 #include <cstddef>
 #include <initializer_list>
 #include <stdexcept>
@@ -628,6 +629,26 @@ template <typename T>
 struct ToPyObject<Scalar<T>, Requires<is_any_spin_weighted_v<T>>> {
   static PyObject* convert(const Scalar<T>& t) {
     return ToPyObject<typename T::value_type>::convert(get(t).data());
+  }
+};
+
+template <typename T>
+struct FromPyObject<boost::optional<T>> {
+  static boost::optional<T> convert(PyObject* p) {
+    if (p == Py_None) {
+      return boost::optional<T>{};
+    }
+    return FromPyObject<T>::convert(p);
+  }
+};
+
+template <typename T>
+struct ToPyObject<boost::optional<T>> {
+  static PyObject* convert(const boost::optional<T>& t) {
+    if (static_cast<bool>(t)) {
+      return to_py_object(*t);
+    }
+    return Py_None;
   }
 };
 

--- a/tests/Unit/Framework/PyppFundamentals.hpp
+++ b/tests/Unit/Framework/PyppFundamentals.hpp
@@ -11,6 +11,7 @@
 #include <boost/optional.hpp>
 #include <cstddef>
 #include <initializer_list>
+#include <optional>
 #include <stdexcept>
 #include <type_traits>
 #include <vector>
@@ -645,6 +646,26 @@ struct FromPyObject<boost::optional<T>> {
 template <typename T>
 struct ToPyObject<boost::optional<T>> {
   static PyObject* convert(const boost::optional<T>& t) {
+    if (static_cast<bool>(t)) {
+      return to_py_object(*t);
+    }
+    return Py_None;
+  }
+};
+
+template <typename T>
+struct FromPyObject<std::optional<T>> {
+  static std::optional<T> convert(PyObject* p) {
+    if (p == Py_None) {
+      return std::optional<T>{};
+    }
+    return FromPyObject<T>::convert(p);
+  }
+};
+
+template <typename T>
+struct ToPyObject<std::optional<T>> {
+  static PyObject* convert(const std::optional<T>& t) {
     if (static_cast<bool>(t)) {
       return to_py_object(*t);
     }

--- a/tests/Unit/Framework/Tests/CMakeLists.txt
+++ b/tests/Unit/Framework/Tests/CMakeLists.txt
@@ -6,6 +6,8 @@ set(LIBRARY "Test_Framework")
 set(LIBRARY_SOURCES
   Test_ActionTesting.cpp
   Test_Pypp.cpp
+  Test_PyppAnalyticSolution.cpp
+  Test_PyppRandomValues.cpp
   Test_TestCreation.cpp
   Test_TestHelpers.cpp
   Test_TestingFramework.cpp

--- a/tests/Unit/Framework/Tests/PyppPyTests.py
+++ b/tests/Unit/Framework/Tests/PyppPyTests.py
@@ -261,3 +261,7 @@ def add_scalars(a, b):
     if b is None:
         return a
     return a + b
+
+
+def custom_conversion(t, a):
+    return t * a

--- a/tests/Unit/Framework/Tests/PyppPyTests.py
+++ b/tests/Unit/Framework/Tests/PyppPyTests.py
@@ -253,3 +253,11 @@ def mixed_complex_real_function_2(spin_weighted, complex_tensor, real_tensor):
         np.real(spin_weighted * complex_tensor[0] * real_tensor[1]),
         np.imag(complex_tensor[1] * real_tensor[0] / spin_weighted)
     ])
+
+
+def add_scalars(a, b):
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return a + b

--- a/tests/Unit/Framework/Tests/Test_Pypp.cpp
+++ b/tests/Unit/Framework/Tests/Test_Pypp.cpp
@@ -29,15 +29,14 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-SPECTRE_TEST_CASE("Unit.Pypp.none", "[Pypp][Unit]") {
-  pypp::SetupLocalPythonEnvironment local_python_env{"Framework/Tests/"};
+namespace {
+void test_none() {
   pypp::call<pypp::None>("PyppPyTests", "test_none");
   CHECK_THROWS(pypp::call<pypp::None>("PyppPyTests", "test_numeric", 1, 2));
   CHECK_THROWS(pypp::call<std::string>("PyppPyTests", "test_none"));
 }
 
-SPECTRE_TEST_CASE("Unit.Pypp.std::string", "[Pypp][Unit]") {
-  pypp::SetupLocalPythonEnvironment local_python_env{"Framework/Tests/"};
+void test_std_string() {
   const auto ret = pypp::call<std::string>("PyppPyTests", "test_string",
                                            std::string("test string"));
   CHECK(ret == std::string("back test string"));
@@ -47,9 +46,8 @@ SPECTRE_TEST_CASE("Unit.Pypp.std::string", "[Pypp][Unit]") {
                                   std::string("test string")));
 }
 
-SPECTRE_TEST_CASE("Unit.Pypp.int", "[Pypp][Unit]") {
+void test_int() {
   /// [pypp_int_test]
-  pypp::SetupLocalPythonEnvironment local_python_env{"Framework/Tests/"};
   const auto ret = pypp::call<long>("PyppPyTests", "test_numeric", 3, 4);
   CHECK(ret == 3 * 4);
   /// [pypp_int_test]
@@ -58,16 +56,14 @@ SPECTRE_TEST_CASE("Unit.Pypp.int", "[Pypp][Unit]") {
   CHECK_THROWS(pypp::call<long>("PyppPyTests", "test_none"));
 }
 
-SPECTRE_TEST_CASE("Unit.Pypp.long", "[Pypp][Unit]") {
-  pypp::SetupLocalPythonEnvironment local_python_env{"Framework/Tests/"};
+void test_long() {
   const auto ret = pypp::call<long>("PyppPyTests", "test_numeric", 3l, 4l);
   CHECK(ret == 3l * 4l);
   CHECK_THROWS(pypp::call<double>("PyppPyTests", "test_numeric", 3l, 4l));
   CHECK_THROWS(pypp::call<long>("PyppPyTests", "test_numeric", 3.0, 3.74));
 }
 
-SPECTRE_TEST_CASE("Unit.Pypp.unsigned_long", "[Pypp][Unit]") {
-  pypp::SetupLocalPythonEnvironment local_python_env{"Framework/Tests/"};
+void test_unsigned_long() {
   const auto ret =
       pypp::call<unsigned long>("PyppPyTests", "test_numeric", 3ul, 4ul);
   CHECK(ret == 3ul * 4ul);
@@ -76,8 +72,7 @@ SPECTRE_TEST_CASE("Unit.Pypp.unsigned_long", "[Pypp][Unit]") {
       pypp::call<unsigned long>("PyppPyTests", "test_numeric", 3.0, 3.74));
 }
 
-SPECTRE_TEST_CASE("Unit.Pypp.double", "[Pypp][Unit]") {
-  pypp::SetupLocalPythonEnvironment local_python_env{"Framework/Tests/"};
+void test_double() {
   const auto ret =
       pypp::call<double>("PyppPyTests", "test_numeric", 3.49582, 3);
   CHECK(ret == 3.0 * 3.49582);
@@ -85,9 +80,8 @@ SPECTRE_TEST_CASE("Unit.Pypp.double", "[Pypp][Unit]") {
   CHECK_THROWS(pypp::call<double>("PyppPyTests", "test_numeric", 3ul, 3ul));
 }
 
-SPECTRE_TEST_CASE("Unit.Pypp.std::vector", "[Pypp][Unit]") {
+void test_std_vector() {
   /// [pypp_vector_test]
-  pypp::SetupLocalPythonEnvironment local_python_env{"Framework/Tests/"};
   const auto ret = pypp::call<std::vector<double>>(
       "PyppPyTests", "test_vector", std::vector<double>{1.3, 4.9},
       std::vector<double>{4.2, 6.8});
@@ -99,8 +93,7 @@ SPECTRE_TEST_CASE("Unit.Pypp.std::vector", "[Pypp][Unit]") {
                                        std::vector<double>{4.2, 6.8}));
 }
 
-SPECTRE_TEST_CASE("Unit.Pypp.std::array", "[Pypp][Unit]") {
-  pypp::SetupLocalPythonEnvironment local_python_env{"Framework/Tests/"};
+void test_std_array() {
   // std::arrays and std::vectors should both convert to lists in python so this
   // test calls the same python function as the vector test
   const auto ret = pypp::call<std::array<double, 2>>(
@@ -128,8 +121,7 @@ SPECTRE_TEST_CASE("Unit.Pypp.std::array", "[Pypp][Unit]") {
                 {DataVector{2, 1.}, DataVector{2, 2.}, DataVector{2, 3.}}})));
 }
 
-SPECTRE_TEST_CASE("Unit.Pypp.DataVector", "[Pypp][Unit]") {
-  pypp::SetupLocalPythonEnvironment local_python_env{"Framework/Tests/"};
+void test_datavector() {
   const auto ret = pypp::call<DataVector>(
       "numpy", "multiply", DataVector{1.3, 4.9}, DataVector{4.2, 6.8});
   CHECK(approx(ret[0]) == 1.3 * 4.2);
@@ -140,8 +132,7 @@ SPECTRE_TEST_CASE("Unit.Pypp.DataVector", "[Pypp][Unit]") {
   CHECK_THROWS(pypp::call<DataVector>("PyppPyTests", "ndarray_of_floats"));
 }
 
-SPECTRE_TEST_CASE("Unit.Pypp.ComplexDataVector", "[Pypp][Unit]") {
-  pypp::SetupLocalPythonEnvironment local_python_env{"Framework/Tests/"};
+void test_complex_datavector() {
   const std::complex<double> test_value_0{1.3, 2.2};
   const std::complex<double> test_value_1{4.0, 3.1};
   const std::complex<double> test_value_2{4.2, 5.7};
@@ -189,9 +180,7 @@ SPECTRE_TEST_CASE("Unit.Pypp.ComplexDataVector", "[Pypp][Unit]") {
         approx(imag(test_value_3 * 1.2 / test_value_1)));
 }
 
-SPECTRE_TEST_CASE("Unit.Pypp.Tensor.Double", "[Pypp][Unit]") {
-  pypp::SetupLocalPythonEnvironment local_python_env{"Framework/Tests/"};
-
+void test_tensor_double() {
   const Scalar<double> scalar{0.8};
   const tnsr::A<double, 3> vector{{{3., 4., 5., 6.}}};
   const auto tnsr_ia = []() {
@@ -287,8 +276,7 @@ SPECTRE_TEST_CASE("Unit.Pypp.Tensor.Double", "[Pypp][Unit]") {
   CHECK_THROWS((pypp::call<tnsr::iaa<double, 3>>("PyppPyTests", "tnsr_aia")));
 }
 
-SPECTRE_TEST_CASE("Unit.Pypp.Tensor.DataVector", "[Pypp][Unit]") {
-  pypp::SetupLocalPythonEnvironment local_python_env{"Framework/Tests/"};
+void test_tensor_datavector() {
   const size_t npts = 5;
   const Scalar<DataVector> scalar{DataVector(npts, 0.8)};
 
@@ -368,7 +356,6 @@ SPECTRE_TEST_CASE("Unit.Pypp.Tensor.DataVector", "[Pypp][Unit]") {
                          "PyppPyTests", "identity", tnsr_aBcc)));
 }
 
-namespace {
 template <typename T>
 void test_einsum(const T& used_for_size) {
   MAKE_GENERATOR(generator);
@@ -408,16 +395,8 @@ void test_einsum(const T& used_for_size) {
   CHECK_ITERABLE_CUSTOM_APPROX(expected, tensor_from_python,
                                approx.epsilon(2.0e-13));
 }
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Pypp.EinSum", "[Pypp][Unit]") {
-  pypp::SetupLocalPythonEnvironment local_python_env{"Framework/Tests/"};
-  test_einsum<double>(0.);
-  test_einsum<DataVector>(DataVector(5));
-}
-
-SPECTRE_TEST_CASE("Unit.Pypp.FunctionsOfTime", "[Pypp][Unit]") {
-  pypp::SetupLocalPythonEnvironment local_python_env{"Framework/Tests/"};
+void test_function_of_time() {
   const tnsr::i<double, 3> x_d{{{3.4, 4.2, 5.8}}};
   const tnsr::i<DataVector, 3> x_dv{
       {{DataVector(8, 3.4), DataVector(8, 4.2), DataVector(8, 5.8)}}};
@@ -431,869 +410,28 @@ SPECTRE_TEST_CASE("Unit.Pypp.FunctionsOfTime", "[Pypp][Unit]") {
   check(x_d, t);
   check(x_dv, t);
 }
-
-namespace {
-template <typename T>
-void check_single_not_null0(const gsl::not_null<T*> result,
-                            const T& t0) noexcept {
-  *result = t0 + 5.0;
-}
-
-template <typename T>
-void check_single_not_null0_scalar(const gsl::not_null<T*> result,
-                                   const T& t0) noexcept {
-  get(*result) = get(t0) + 5.0;
-}
-
-template <typename T>
-void check_single_not_null1(const gsl::not_null<T*> result, const T& t0,
-                            const T& t1) noexcept {
-  *result = t0 + t1;
-}
-
-template <typename T>
-void check_single_not_null2(const gsl::not_null<T*> result, const T& t0,
-                            const T& t1) noexcept {
-  *result = sqrt(t0) + 1.0 / sqrt(-t1);
-}
-
-template <typename T>
-void check_single_not_null1_scalar(const gsl::not_null<T*> result, const T& t0,
-                                   const T& t1) noexcept {
-  get(*result) = get(t0) + get(t1);
-}
-
-template <typename T>
-void check_single_not_null2_scalar(const gsl::not_null<T*> result, const T& t0,
-                                   const T& t1) noexcept {
-  get(*result) = sqrt(get(t0)) + 1.0 / sqrt(-get(t1));
-}
-
-template <typename T>
-void check_double_not_null0(const gsl::not_null<T*> result0,
-                            const gsl::not_null<T*> result1,
-                            const T& t0) noexcept {
-  *result0 = t0 + 5.0;
-  *result1 = 2.0 * t0 + 5.0;
-}
-
-template <typename T>
-void check_double_not_null0_scalar(const gsl::not_null<T*> result0,
-                                   const gsl::not_null<T*> result1,
-                                   const T& t0) noexcept {
-  get(*result0) = get(t0) + 5.0;
-  get(*result1) = 2.0 * get(t0) + 5.0;
-}
-
-template <typename T>
-void check_double_not_null1(const gsl::not_null<T*> result0,
-                            const gsl::not_null<T*> result1, const T& t0,
-                            const T& t1) noexcept {
-  *result0 = t0 + t1;
-  *result1 = 2.0 * t0 + t1;
-}
-
-template <typename T>
-void check_double_not_null1_scalar(const gsl::not_null<T*> result0,
-                                   const gsl::not_null<T*> result1, const T& t0,
-                                   const T& t1) noexcept {
-  get(*result0) = get(t0) + get(t1);
-  get(*result1) = 2.0 * get(t0) + get(t1);
-}
-
-template <typename T>
-void check_double_not_null2(const gsl::not_null<T*> result0,
-                            const gsl::not_null<T*> result1, const T& t0,
-                            const T& t1) noexcept {
-  *result0 = sqrt(t0) + 1.0 / sqrt(-t1);
-  *result1 = 2.0 * t0 + t1;
-}
-
-template <typename T>
-void check_double_not_null2_scalar(const gsl::not_null<T*> result0,
-                                   const gsl::not_null<T*> result1, const T& t0,
-                                   const T& t1) noexcept {
-  get(*result0) = sqrt(get(t0)) + 1.0 / sqrt(-get(t1));
-  get(*result1) = 2.0 * get(t0) + get(t1);
-}
-
-template <typename T>
-T check_by_value0(const T& t0) noexcept {
-  return t0 + 5.0;
-}
-
-template <typename T>
-T check_by_value0_scalar(const T& t0) noexcept {
-  return T{get(t0) + 5.0};
-}
-
-template <typename T>
-T check_by_value1(const T& t0, const T& t1) noexcept {
-  return t0 + t1;
-}
-
-template <typename T>
-T check_by_value1_scalar(const T& t0, const T& t1) noexcept {
-  return T{get(t0) + get(t1)};
-}
-
-template <typename T>
-T check_by_value2(const T& t0, const T& t1) noexcept {
-  return sqrt(t0) + 1.0 / sqrt(-t1);
-}
-
-template <typename T>
-T check_by_value2_scalar(const T& t0, const T& t1) noexcept {
-  return T{sqrt(get(t0)) + 1.0 / sqrt(-get(t1))};
-}
-
-class RandomValuesTests {
- public:
-  RandomValuesTests(const double a, const double b,
-                    const std::array<double, 3>& c) noexcept
-      : a_(a), b_(b), c_(c) {}
-
-  // by value, single argument
-  template <typename T>
-  T check_by_value0(const T& t0) const noexcept {
-    return t0 + 5.0;
-  }
-
-  template <typename T>
-  T check_by_value1(const T& t0) const noexcept {
-    return t0 + 5.0 * a_;
-  }
-
-  template <typename T>
-  T check_by_value2(const T& t0) const noexcept {
-    return t0 + 5.0 * a_ + b_;
-  }
-
-  template <typename T>
-  T check_by_value3(const T& t0) const noexcept {
-    return t0 + 5.0 * a_ + b_ + c_[0] - 2.0 * c_[1] - c_[2];
-  }
-
-  template <typename T>
-  T check_by_value0_scalar(const T& t0) const noexcept {
-    return T{get(t0) + 5.0};
-  }
-
-  template <typename T>
-  T check_by_value1_scalar(const T& t0) const noexcept {
-    return T{get(t0) + 5.0 * a_};
-  }
-
-  template <typename T>
-  T check_by_value2_scalar(const T& t0) const noexcept {
-    return T{get(t0) + 5.0 * a_ + b_};
-  }
-
-  template <typename T>
-  T check_by_value3_scalar(const T& t0) const noexcept {
-    return T{get(t0) + 5.0 * a_ + b_ + c_[0] - 2.0 * c_[1] - c_[2]};
-  }
-
-  // by value, two arguments
-  template <typename T>
-  T check2_by_value0(const T& t0, const T& t1) const noexcept {
-    return t0 + t1;
-  }
-
-  template <typename T>
-  T check2_by_value1(const T& t0, const T& t1) const noexcept {
-    return t0 + t1 + 5.0 * a_;
-  }
-
-  template <typename T>
-  T check2_by_value2(const T& t0, const T& t1) const noexcept {
-    return t0 + 5.0 * a_ + t1 * b_;
-  }
-
-  template <typename T>
-  T check2_by_value3(const T& t0, const T& t1) const noexcept {
-    return t0 * c_[0] + 5.0 * a_ + t1 * b_ + c_[1] - c_[2];
-  }
-
-  template <typename T>
-  T check2_by_value0_scalar(const T& t0, const T& t1) const noexcept {
-    return T{get(t0) + get(t1)};
-  }
-
-  template <typename T>
-  T check2_by_value1_scalar(const T& t0, const T& t1) const noexcept {
-    return T{get(t0) + get(t1) + 5.0 * a_};
-  }
-
-  template <typename T>
-  T check2_by_value2_scalar(const T& t0, const T& t1) const noexcept {
-    return T{get(t0) + 5.0 * a_ + b_ * get(t1)};
-  }
-
-  template <typename T>
-  T check2_by_value3_scalar(const T& t0, const T& t1) const noexcept {
-    return T{get(t0) * c_[0] + 5.0 * a_ + b_ * get(t1) + c_[1] - c_[2]};
-  }
-
-  // single not_null, single argument
-  template <typename T>
-  void check_by_not_null0(const gsl::not_null<T*> result0, const T& t0) const
-      noexcept {
-    *result0 = t0 + 5.0;
-  }
-
-  template <typename T>
-  void check_by_not_null1(const gsl::not_null<T*> result0, const T& t0) const
-      noexcept {
-    *result0 = t0 + 5.0 * a_;
-  }
-
-  template <typename T>
-  void check_by_not_null2(const gsl::not_null<T*> result0, const T& t0) const
-      noexcept {
-    *result0 = t0 + 5.0 * a_ + b_;
-  }
-
-  template <typename T>
-  void check_by_not_null3(const gsl::not_null<T*> result0, const T& t0) const
-      noexcept {
-    *result0 = t0 + 5.0 * a_ + b_ + c_[0] - 2.0 * c_[1] - c_[2];
-  }
-
-  template <typename T>
-  void check_by_not_null0_scalar(const gsl::not_null<T*> result0,
-                                 const T& t0) const noexcept {
-    get(*result0) = get(t0) + 5.0;
-  }
-
-  template <typename T>
-  void check_by_not_null1_scalar(const gsl::not_null<T*> result0,
-                                 const T& t0) const noexcept {
-    get(*result0) = get(t0) + 5.0 * a_;
-  }
-
-  template <typename T>
-  void check_by_not_null2_scalar(const gsl::not_null<T*> result0,
-                                 const T& t0) const noexcept {
-    get(*result0) = get(t0) + 5.0 * a_ + b_;
-  }
-
-  template <typename T>
-  void check_by_not_null3_scalar(const gsl::not_null<T*> result0,
-                                 const T& t0) const noexcept {
-    get(*result0) = get(t0) + 5.0 * a_ + b_ + c_[0] - 2.0 * c_[1] - c_[2];
-  }
-
-  // by value, two arguments
-  template <typename T>
-  void check2_by_not_null0(const gsl::not_null<T*> result0, const T& t0,
-                           const T& t1) const noexcept {
-    *result0 = t0 + t1;
-  }
-
-  template <typename T>
-  void check2_by_not_null1(const gsl::not_null<T*> result0, const T& t0,
-                           const T& t1) const noexcept {
-    *result0 = t0 + t1 + 5.0 * a_;
-  }
-
-  template <typename T>
-  void check2_by_not_null2(const gsl::not_null<T*> result0, const T& t0,
-                           const T& t1) const noexcept {
-    *result0 = t0 + 5.0 * a_ + t1 * b_;
-  }
-
-  template <typename T>
-  void check2_by_not_null3(const gsl::not_null<T*> result0, const T& t0,
-                           const T& t1) const noexcept {
-    *result0 = t0 * c_[0] + 5.0 * a_ + t1 * b_ + c_[1] - c_[2];
-  }
-
-  template <typename T>
-  void check2_by_not_null0_scalar(const gsl::not_null<T*> result0, const T& t0,
-                                  const T& t1) const noexcept {
-    *result0 = T{get(t0) + get(t1)};
-  }
-
-  template <typename T>
-  void check2_by_not_null1_scalar(const gsl::not_null<T*> result0, const T& t0,
-                                  const T& t1) const noexcept {
-    *result0 = T{get(t0) + get(t1) + 5.0 * a_};
-  }
-
-  template <typename T>
-  void check2_by_not_null2_scalar(const gsl::not_null<T*> result0, const T& t0,
-                                  const T& t1) const noexcept {
-    *result0 = T{get(t0) + 5.0 * a_ + b_ * get(t1)};
-  }
-
-  template <typename T>
-  void check2_by_not_null3_scalar(const gsl::not_null<T*> result0, const T& t0,
-                                  const T& t1) const noexcept {
-    *result0 = T{get(t0) * c_[0] + 5.0 * a_ + b_ * get(t1) + c_[1] - c_[2]};
-  }
-
-  // by value, two arguments
-  template <typename T>
-  void check3_by_not_null0(const gsl::not_null<T*> result0,
-                           const gsl::not_null<T*> result1, const T& t0,
-                           const T& t1) const noexcept {
-    *result0 = t0 + t1;
-    *result1 = 2.0 * t0 + t1;
-  }
-
-  template <typename T>
-  void check3_by_not_null1(const gsl::not_null<T*> result0,
-                           const gsl::not_null<T*> result1, const T& t0,
-                           const T& t1) const noexcept {
-    *result0 = t0 + t1 + 5.0 * a_;
-    *result1 = 2.0 * t0 + t1 + 5.0 * a_;
-  }
-
-  template <typename T>
-  void check3_by_not_null2(const gsl::not_null<T*> result0,
-                           const gsl::not_null<T*> result1, const T& t0,
-                           const T& t1) const noexcept {
-    *result0 = t0 + 5.0 * a_ + t1 * b_;
-    *result1 = 2.0 * t0 + 5.0 * a_ + t1 * b_;
-  }
-
-  template <typename T>
-  void check3_by_not_null0_scalar(const gsl::not_null<T*> result0,
-                                  const gsl::not_null<T*> result1, const T& t0,
-                                  const T& t1) const noexcept {
-    *result0 = T{get(t0) + get(t1)};
-    *result1 = T{2.0 * get(t0) + get(t1)};
-  }
-
-  template <typename T>
-  void check3_by_not_null1_scalar(const gsl::not_null<T*> result0,
-                                  const gsl::not_null<T*> result1, const T& t0,
-                                  const T& t1) const noexcept {
-    *result0 = T{get(t0) + get(t1) + 5.0 * a_};
-    *result1 = T{2.0 * get(t0) + get(t1) + 5.0 * a_};
-  }
-
-  template <typename T>
-  void check3_by_not_null2_scalar(const gsl::not_null<T*> result0,
-                                  const gsl::not_null<T*> result1, const T& t0,
-                                  const T& t1) const noexcept {
-    *result0 = T{get(t0) + 5.0 * a_ + b_ * get(t1)};
-    *result1 = T{2.0 * get(t0) + 5.0 * a_ + b_ * get(t1)};
-  }
-
- private:
-  double a_ = 0;
-  double b_ = 0;
-  std::array<double, 3> c_{};
-};
-
-struct AnalyticSolutionTest {
-  template <typename T>
-  struct Var1 {
-    using type = Scalar<T>;
-  };
-  template <typename T>
-  struct Var2 {
-    using type = tnsr::I<T, 3>;
-  };
-
-  AnalyticSolutionTest(const double a, const std::array<double, 3>& b)
-      : a_(a), b_(b) {}
-
-  template <typename T>
-  tuples::TaggedTuple<Var1<T>, Var2<T>> solution(const tnsr::i<T, 3>& x,
-                                                 const double t) const
-      noexcept {
-    auto sol =
-        make_with_value<tuples::TaggedTuple<Var1<T>, Var2<T>>>(x.get(0), 0.);
-    auto& scalar = tuples::get<Var1<T>>(sol);
-    auto& vector = tuples::get<Var2<T>>(sol);
-
-    for (size_t i = 0; i < 3; ++i) {
-      scalar.get() += x.get(i) * gsl::at(b_, i);
-      vector.get(i) = a_ * x.get(i) - gsl::at(b_, i) * t;
-    }
-    scalar.get() += a_ - t;
-    return sol;
-  }
-
- private:
-  double a_;
-  std::array<double, 3> b_;
-};
-
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Pypp.CheckWithPython", "[Pypp][Unit]") {
+SPECTRE_TEST_CASE("Unit.Pypp", "[Pypp][Unit]") {
   pypp::SetupLocalPythonEnvironment local_python_env{"Framework/Tests/"};
-  constexpr size_t size = 5;
-  const DataVector dv(size);
-  const double doub(0.);
-  const Scalar<double> scalar_double{5.0};
-  const Scalar<DataVector> scalar_dv{size};
-  pypp::check_with_random_values<1>(&check_single_not_null0<double>,
-                                    "PyppPyTests", {"check_single_not_null0"},
-                                    {{{-10.0, 10.0}}}, doub);
-  pypp::check_with_random_values<1>(&check_single_not_null0<DataVector>,
-                                    "PyppPyTests", {"check_single_not_null0"},
-                                    {{{-10.0, 10.0}}}, dv);
-  pypp::check_with_random_values<1>(&check_single_not_null1<double>,
-                                    "PyppPyTests", {"check_single_not_null1"},
-                                    {{{-10.0, 10.0}}}, doub);
-  pypp::check_with_random_values<1>(&check_single_not_null1<DataVector>,
-                                    "PyppPyTests", {"check_single_not_null1"},
-                                    {{{-10.0, 10.0}}}, dv);
-  pypp::check_with_random_values<2>(&check_single_not_null2<double>,
-                                    "PyppPyTests", {"check_single_not_null2"},
-                                    {{{0.0, 10.0}, {-10.0, 0.0}}}, doub);
-  pypp::check_with_random_values<2>(&check_single_not_null2<DataVector>,
-                                    "PyppPyTests", {"check_single_not_null2"},
-                                    {{{0.0, 10.0}, {-10.0, 0.0}}}, dv);
-  pypp::check_with_random_values<1>(
-      &check_single_not_null0_scalar<Scalar<double>>, "PyppPyTests",
-      {"check_single_not_null0"}, {{{-10.0, 10.0}}}, scalar_double);
-  pypp::check_with_random_values<1>(
-      &check_single_not_null0_scalar<Scalar<DataVector>>, "PyppPyTests",
-      {"check_single_not_null0"}, {{{-10.0, 10.0}}}, scalar_dv);
-  pypp::check_with_random_values<1>(
-      &check_single_not_null1_scalar<Scalar<double>>, "PyppPyTests",
-      {"check_single_not_null1"}, {{{-10.0, 10.0}}}, scalar_double);
-  pypp::check_with_random_values<1>(
-      &check_single_not_null1_scalar<Scalar<DataVector>>, "PyppPyTests",
-      {"check_single_not_null1"}, {{{-10.0, 10.0}}}, scalar_dv);
-  pypp::check_with_random_values<2>(
-      &check_single_not_null2_scalar<Scalar<double>>, "PyppPyTests",
-      {"check_single_not_null2"}, {{{0.0, 10.0}, {-10.0, 0.0}}}, scalar_double);
-  pypp::check_with_random_values<2>(
-      &check_single_not_null2_scalar<Scalar<DataVector>>, "PyppPyTests",
-      {"check_single_not_null2"}, {{{0.0, 10.0}, {-10.0, 0.0}}}, scalar_dv);
+  {
+    INFO("Testing scipy support");
+    CHECK((pypp::call<size_t>("scipy", "ndim", tnsr::abcc<double, 3>{})) == 4);
+  }
 
-  pypp::check_with_random_values<1>(
-      &check_double_not_null0<double>, "PyppPyTests",
-      {"check_double_not_null0_result0", "check_double_not_null0_result1"},
-      {{{-10.0, 10.0}}}, doub);
-  pypp::check_with_random_values<1>(
-      &check_double_not_null0<DataVector>, "PyppPyTests",
-      {"check_double_not_null0_result0", "check_double_not_null0_result1"},
-      {{{-10.0, 10.0}}}, dv);
-  pypp::check_with_random_values<1>(
-      &check_double_not_null1<double>, "PyppPyTests",
-      {"check_double_not_null1_result0", "check_double_not_null1_result1"},
-      {{{-10.0, 10.0}}}, doub);
-  pypp::check_with_random_values<1>(
-      &check_double_not_null1<DataVector>, "PyppPyTests",
-      {"check_double_not_null1_result0", "check_double_not_null1_result1"},
-      {{{-10.0, 10.0}}}, dv);
-  pypp::check_with_random_values<2>(
-      &check_double_not_null2<double>, "PyppPyTests",
-      {"check_double_not_null2_result0", "check_double_not_null2_result1"},
-      {{{0.0, 10.0}, {-10.0, 0.0}}}, doub);
-  pypp::check_with_random_values<2>(
-      &check_double_not_null2<DataVector>, "PyppPyTests",
-      {"check_double_not_null2_result0", "check_double_not_null2_result1"},
-      {{{0.0, 10.0}, {-10.0, 0.0}}}, dv);
-  pypp::check_with_random_values<1>(
-      &check_double_not_null0_scalar<Scalar<double>>, "PyppPyTests",
-      {"check_double_not_null0_result0", "check_double_not_null0_result1"},
-      {{{-10.0, 10.0}}}, scalar_double);
-  pypp::check_with_random_values<1>(
-      &check_double_not_null0_scalar<Scalar<DataVector>>, "PyppPyTests",
-      {"check_double_not_null0_result0", "check_double_not_null0_result1"},
-      {{{-10.0, 10.0}}}, scalar_dv);
-  pypp::check_with_random_values<1>(
-      &check_double_not_null1_scalar<Scalar<double>>, "PyppPyTests",
-      {"check_double_not_null1_result0", "check_double_not_null1_result1"},
-      {{{-10.0, 10.0}}}, scalar_double);
-  pypp::check_with_random_values<1>(
-      &check_double_not_null1_scalar<Scalar<DataVector>>, "PyppPyTests",
-      {"check_double_not_null1_result0", "check_double_not_null1_result1"},
-      {{{-10.0, 10.0}}}, scalar_dv);
-  pypp::check_with_random_values<2>(
-      &check_double_not_null2_scalar<Scalar<double>>, "PyppPyTests",
-      {"check_double_not_null2_result0", "check_double_not_null2_result1"},
-      {{{0.0, 10.0}, {-10.0, 0.0}}}, scalar_double);
-  /// [cxx_two_not_null]
-  pypp::check_with_random_values<2>(
-      &check_double_not_null2_scalar<Scalar<DataVector>>, "PyppPyTests",
-      {"check_double_not_null2_result0", "check_double_not_null2_result1"},
-      {{{0.0, 10.0}, {-10.0, 0.0}}}, scalar_dv);
-  /// [cxx_two_not_null]
-
-  pypp::check_with_random_values<1>(&check_by_value0<double>, "PyppPyTests",
-                                    "check_by_value0", {{{-10.0, 10.0}}}, doub);
-  pypp::check_with_random_values<1>(&check_by_value0<DataVector>, "PyppPyTests",
-                                    "check_by_value0", {{{-10.0, 10.0}}}, dv);
-  pypp::check_with_random_values<1>(&check_by_value1<double>, "PyppPyTests",
-                                    "check_by_value1", {{{-10.0, 10.0}}}, doub);
-  pypp::check_with_random_values<1>(&check_by_value1<DataVector>, "PyppPyTests",
-                                    "check_by_value1", {{{-10.0, 10.0}}}, dv);
-  pypp::check_with_random_values<2>(&check_by_value2<double>, "PyppPyTests",
-                                    "check_by_value2",
-                                    {{{0.0, 10.0}, {-10.0, 0.0}}}, doub);
-  pypp::check_with_random_values<2>(&check_by_value2<DataVector>, "PyppPyTests",
-                                    "check_by_value2",
-                                    {{{0.0, 10.0}, {-10.0, 0.0}}}, dv);
-  pypp::check_with_random_values<1>(&check_by_value0_scalar<Scalar<double>>,
-                                    "PyppPyTests", "check_by_value0",
-                                    {{{-10.0, 10.0}}}, scalar_double);
-  pypp::check_with_random_values<1>(&check_by_value0_scalar<Scalar<DataVector>>,
-                                    "PyppPyTests", "check_by_value0",
-                                    {{{-10.0, 10.0}}}, scalar_dv);
-  pypp::check_with_random_values<1>(&check_by_value1_scalar<Scalar<double>>,
-                                    "PyppPyTests", "check_by_value1",
-                                    {{{-10.0, 10.0}}}, scalar_double);
-  pypp::check_with_random_values<1>(&check_by_value1_scalar<Scalar<DataVector>>,
-                                    "PyppPyTests", "check_by_value1",
-                                    {{{-10.0, 10.0}}}, scalar_dv);
-  pypp::check_with_random_values<2>(
-      &check_by_value2_scalar<Scalar<double>>, "PyppPyTests", "check_by_value2",
-      {{{0.0, 10.0}, {-10.0, 0.0}}}, scalar_double);
-  pypp::check_with_random_values<2>(&check_by_value2_scalar<Scalar<DataVector>>,
-                                    "PyppPyTests", "check_by_value2",
-                                    {{{0.0, 10.0}, {-10.0, 0.0}}}, scalar_dv);
-
-  // Test member functions
-  const double a = 3.1, b = 7.24;
-  const std::array<double, 3> c{{4.23, -8.3, 5.4}};
-  const RandomValuesTests test_class{a, b, c};
-  // by value, single argument
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value0<double>, test_class, "PyppPyTests",
-      "check_by_value0", {{{-10.0, 10.0}}}, std::make_tuple(), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value0<DataVector>, test_class,
-      "PyppPyTests", "check_by_value0", {{{-10.0, 10.0}}}, std::make_tuple(),
-      dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value0_scalar<Scalar<double>>, test_class,
-      "PyppPyTests", "check_by_value0", {{{-10.0, 10.0}}}, std::make_tuple(),
-      scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value0_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests", "check_by_value0", {{{-10.0, 10.0}}},
-      std::make_tuple(), scalar_dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value1<double>, test_class, "PyppPyTests",
-      "check_by_value1_class", {{{-10.0, 10.0}}}, std::make_tuple(a), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value1<DataVector>, test_class,
-      "PyppPyTests", "check_by_value1_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value1_scalar<Scalar<double>>, test_class,
-      "PyppPyTests", "check_by_value1_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value1_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests", "check_by_value1_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a), scalar_dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value2<double>, test_class, "PyppPyTests",
-      "check_by_value2_class", {{{-10.0, 10.0}}}, std::make_tuple(a, b), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value2<DataVector>, test_class,
-      "PyppPyTests", "check_by_value2_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value2_scalar<Scalar<double>>, test_class,
-      "PyppPyTests", "check_by_value2_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value2_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests", "check_by_value2_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), scalar_dv);
-  pypp::check_with_random_values<1>(&RandomValuesTests::check_by_value3<double>,
-                                    test_class, "PyppPyTests",
-                                    "check_by_value3_class", {{{-10.0, 10.0}}},
-                                    std::make_tuple(a, b, c), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value3<DataVector>, test_class,
-      "PyppPyTests", "check_by_value3_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a, b, c), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value3_scalar<Scalar<double>>, test_class,
-      "PyppPyTests", "check_by_value3_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a, b, c), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value3_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests", "check_by_value3_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a, b, c), scalar_dv);
-
-  // by value, two arguments
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value0<double>, test_class, "PyppPyTests",
-      "check_by_value1", {{{-10.0, 10.0}}}, std::make_tuple(), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value0<DataVector>, test_class,
-      "PyppPyTests", "check_by_value1", {{{-10.0, 10.0}}}, std::make_tuple(),
-      dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value0_scalar<Scalar<double>>, test_class,
-      "PyppPyTests", "check_by_value1", {{{-10.0, 10.0}}}, std::make_tuple(),
-      scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value0_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests", "check_by_value1", {{{-10.0, 10.0}}},
-      std::make_tuple(), scalar_dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value1<double>, test_class, "PyppPyTests",
-      "check2_by_value1_class", {{{-10.0, 10.0}}}, std::make_tuple(a), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value1<DataVector>, test_class,
-      "PyppPyTests", "check2_by_value1_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value1_scalar<Scalar<double>>, test_class,
-      "PyppPyTests", "check2_by_value1_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value1_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests", "check2_by_value1_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a), scalar_dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value2<double>, test_class, "PyppPyTests",
-      "check2_by_value2_class", {{{-10.0, 10.0}}}, std::make_tuple(a, b), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value2<DataVector>, test_class,
-      "PyppPyTests", "check2_by_value2_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value2_scalar<Scalar<double>>, test_class,
-      "PyppPyTests", "check2_by_value2_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value2_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests", "check2_by_value2_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), scalar_dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value3<double>, test_class, "PyppPyTests",
-      "check2_by_value3_class", {{{-10.0, 10.0}}}, std::make_tuple(a, b, c),
-      doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value3<DataVector>, test_class,
-      "PyppPyTests", "check2_by_value3_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a, b, c), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value3_scalar<Scalar<double>>, test_class,
-      "PyppPyTests", "check2_by_value3_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a, b, c), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value3_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests", "check2_by_value3_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a, b, c), scalar_dv);
-
-  // Single not_null, single argument
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null0<double>, test_class,
-      "PyppPyTests"s, {"check_by_value0"s}, {{{-10.0, 10.0}}},
-      std::make_tuple(), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null0<DataVector>, test_class,
-      "PyppPyTests", {"check_by_value0"}, {{{-10.0, 10.0}}}, std::make_tuple(),
-      dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null0_scalar<Scalar<double>>, test_class,
-      "PyppPyTests", {"check_by_value0"}, {{{-10.0, 10.0}}}, std::make_tuple(),
-      scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null0_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests", {"check_by_value0"}, {{{-10.0, 10.0}}},
-      std::make_tuple(), scalar_dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null1<double>, test_class, "PyppPyTests",
-      {"check_by_value1_class"}, {{{-10.0, 10.0}}}, std::make_tuple(a), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null1<DataVector>, test_class,
-      "PyppPyTests", {"check_by_value1_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null1_scalar<Scalar<double>>, test_class,
-      "PyppPyTests", {"check_by_value1_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null1_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests", {"check_by_value1_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a), scalar_dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null2<double>, test_class, "PyppPyTests",
-      {"check_by_value2_class"}, {{{-10.0, 10.0}}}, std::make_tuple(a, b),
-      doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null2<DataVector>, test_class,
-      "PyppPyTests", {"check_by_value2_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null2_scalar<Scalar<double>>, test_class,
-      "PyppPyTests", {"check_by_value2_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null2_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests", {"check_by_value2_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), scalar_dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null3<double>, test_class, "PyppPyTests",
-      {"check_by_value3_class"}, {{{-10.0, 10.0}}}, std::make_tuple(a, b, c),
-      doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null3<DataVector>, test_class,
-      "PyppPyTests", {"check_by_value3_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b, c), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null3_scalar<Scalar<double>>, test_class,
-      "PyppPyTests", {"check_by_value3_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b, c), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null3_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests", {"check_by_value3_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b, c), scalar_dv);
-
-  // Single not_null, two arguments
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null0<double>, test_class,
-      "PyppPyTests", {"check_by_value1"}, {{{-10.0, 10.0}}}, std::make_tuple(),
-      doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null0<DataVector>, test_class,
-      {"PyppPyTests"}, {"check_by_value1"}, {{{-10.0, 10.0}}},
-      std::make_tuple(), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null0_scalar<Scalar<double>>,
-      test_class, {"PyppPyTests"}, {"check_by_value1"}, {{{-10.0, 10.0}}},
-      std::make_tuple(), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null0_scalar<Scalar<DataVector>>,
-      test_class, {"PyppPyTests"}, {"check_by_value1"}, {{{-10.0, 10.0}}},
-      std::make_tuple(), scalar_dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null1<double>, test_class,
-      {"PyppPyTests"}, {"check2_by_value1_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null1<DataVector>, test_class,
-      {"PyppPyTests"}, {"check2_by_value1_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null1_scalar<Scalar<double>>,
-      test_class, {"PyppPyTests"}, {"check2_by_value1_class"},
-      {{{-10.0, 10.0}}}, std::make_tuple(a), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null1_scalar<Scalar<DataVector>>,
-      test_class, {"PyppPyTests"}, {"check2_by_value1_class"},
-      {{{-10.0, 10.0}}}, std::make_tuple(a), scalar_dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null2<double>, test_class,
-      {"PyppPyTests"}, {"check2_by_value2_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null2<DataVector>, test_class,
-      {"PyppPyTests"}, {"check2_by_value2_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null2_scalar<Scalar<double>>,
-      test_class, {"PyppPyTests"}, {"check2_by_value2_class"},
-      {{{-10.0, 10.0}}}, std::make_tuple(a, b), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null2_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests", {"check2_by_value2_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), scalar_dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null3<double>, test_class,
-      {"PyppPyTests"}, {"check2_by_value3_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b, c), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null3<DataVector>, test_class,
-      {"PyppPyTests"}, {"check2_by_value3_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b, c), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null3_scalar<Scalar<double>>,
-      test_class, {"PyppPyTests"}, {"check2_by_value3_class"},
-      {{{-10.0, 10.0}}}, std::make_tuple(a, b, c), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null3_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests", {"check2_by_value3_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b, c), scalar_dv);
-
-  // Double not_null, two arguments
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null0<double>, test_class,
-      "PyppPyTests",
-      {"check_double_not_null1_result0", "check_double_not_null1_result1"},
-      {{{-10.0, 10.0}}}, std::make_tuple(), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null0<DataVector>, test_class,
-      {"PyppPyTests"},
-      {"check_double_not_null1_result0", "check_double_not_null1_result1"},
-      {{{-10.0, 10.0}}}, std::make_tuple(), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null0_scalar<Scalar<double>>,
-      test_class, {"PyppPyTests"},
-      {"check_double_not_null1_result0", "check_double_not_null1_result1"},
-      {{{-10.0, 10.0}}}, std::make_tuple(), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null0_scalar<Scalar<DataVector>>,
-      test_class, {"PyppPyTests"},
-      {"check_double_not_null1_result0", "check_double_not_null1_result1"},
-      {{{-10.0, 10.0}}}, std::make_tuple(), scalar_dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null1<double>, test_class,
-      {"PyppPyTests"}, {"check2_by_value1_class", "check2_by_value1_class1"},
-      {{{-10.0, 10.0}}}, std::make_tuple(a), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null1<DataVector>, test_class,
-      {"PyppPyTests"}, {"check2_by_value1_class", "check2_by_value1_class1"},
-      {{{-10.0, 10.0}}}, std::make_tuple(a), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null1_scalar<Scalar<double>>,
-      test_class, {"PyppPyTests"},
-      {"check2_by_value1_class", "check2_by_value1_class1"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null1_scalar<Scalar<DataVector>>,
-      test_class, {"PyppPyTests"},
-      {"check2_by_value1_class", "check2_by_value1_class1"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a), scalar_dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null2<double>, test_class,
-      {"PyppPyTests"}, {"check2_by_value2_class", "check2_by_value2_class1"},
-      {{{-10.0, 10.0}}}, std::make_tuple(a, b), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null2<DataVector>, test_class,
-      {"PyppPyTests"}, {"check2_by_value2_class", "check2_by_value2_class1"},
-      {{{-10.0, 10.0}}}, std::make_tuple(a, b), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null2_scalar<Scalar<double>>,
-      test_class, {"PyppPyTests"},
-      {"check2_by_value2_class", "check2_by_value2_class1"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null2_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests",
-      {"check2_by_value2_class", "check2_by_value2_class1"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), scalar_dv);
-}
-
-SPECTRE_TEST_CASE("Unit.Pypp.AnalyticSolution", "[Pypp][Unit]") {
-  pypp::SetupLocalPythonEnvironment local_python_env{"Framework/Tests/"};
-  const double a = 4.3;
-  const std::array<double, 3> b{{-1.3, 5.6, -0.2}};
-  AnalyticSolutionTest solution{a, b};
-  const DataVector used_for_size(5);
-  pypp::check_with_random_values<
-      1, tmpl::list<AnalyticSolutionTest::Var1<double>,
-                    AnalyticSolutionTest::Var2<double>>>(
-      &AnalyticSolutionTest::solution<double>, solution, "PyppPyTests",
-      {"check_solution_scalar", "check_solution_vector"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), a);
-  pypp::check_with_random_values<
-      1, tmpl::list<AnalyticSolutionTest::Var1<DataVector>,
-                    AnalyticSolutionTest::Var2<DataVector>>>(
-      &AnalyticSolutionTest::solution<DataVector>, solution, "PyppPyTests",
-      {"check_solution_scalar", "check_solution_vector"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), used_for_size);
-}
-
-SPECTRE_TEST_CASE("Unit.Pypp.SciPy", "[Pypp][Unit]") {
-  pypp::SetupLocalPythonEnvironment local_python_env{"Framework/Tests/"};
-  CHECK((pypp::call<size_t>("scipy", "ndim", tnsr::abcc<double, 3>{})) == 4);
+  test_none();
+  test_std_string();
+  test_int();
+  test_long();
+  test_unsigned_long();
+  test_double();
+  test_std_vector();
+  test_std_array();
+  test_datavector();
+  test_complex_datavector();
+  test_tensor_double();
+  test_tensor_datavector();
+  test_einsum<double>(0.);
+  test_einsum<DataVector>(DataVector(5));
+  test_function_of_time();
 }

--- a/tests/Unit/Framework/Tests/Test_Pypp.cpp
+++ b/tests/Unit/Framework/Tests/Test_Pypp.cpp
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <complex>
 #include <cstddef>
+#include <optional>
 #include <random>
 #include <string>
 #include <tuple>
@@ -466,4 +467,5 @@ SPECTRE_TEST_CASE("Unit.Pypp", "[Pypp][Unit]") {
   test_einsum<DataVector>(DataVector(5));
   test_function_of_time();
   test_optional<boost::optional>();
+  test_optional<std::optional>();
 }

--- a/tests/Unit/Framework/Tests/Test_Pypp.cpp
+++ b/tests/Unit/Framework/Tests/Test_Pypp.cpp
@@ -57,9 +57,9 @@ void test_int() {
 }
 
 void test_long() {
-  const auto ret = pypp::call<long>("PyppPyTests", "test_numeric", 3l, 4l);
-  CHECK(ret == 3l * 4l);
-  CHECK_THROWS(pypp::call<double>("PyppPyTests", "test_numeric", 3l, 4l));
+  const auto ret = pypp::call<long>("PyppPyTests", "test_numeric", 3L, 4L);
+  CHECK(ret == 3L * 4L);
+  CHECK_THROWS(pypp::call<double>("PyppPyTests", "test_numeric", 3L, 4L));
   CHECK_THROWS(pypp::call<long>("PyppPyTests", "test_numeric", 3.0, 3.74));
 }
 
@@ -196,7 +196,7 @@ void test_tensor_double() {
     tnsr::AA<double, 3> tnsr{};
     for (size_t i = 0; i < 4; ++i) {
       for (size_t j = 0; j < 4; ++j) {
-        tnsr.get(i, j) = i + j + 1.;
+        tnsr.get(i, j) = static_cast<double>(i) + j + 1.;
       }
     }
     return tnsr;
@@ -206,7 +206,7 @@ void test_tensor_double() {
     for (size_t i = 0; i < 3; ++i) {
       for (size_t j = 0; j < 4; ++j) {
         for (size_t k = 0; k < 4; ++k) {
-          tnsr.get(i, j, k) = 2. * (k + 1) * (j + 1) + i + 1.;
+          tnsr.get(i, j, k) = 2. * (k + 1.) * (j + 1.) + i + 1.;
         }
       }
     }
@@ -217,7 +217,7 @@ void test_tensor_double() {
     for (size_t i = 0; i < 4; ++i) {
       for (size_t j = 0; j < 3; ++j) {
         for (size_t k = 0; k < 4; ++k) {
-          tnsr.get(i, j, k) = 2. * (k + 1) * (i + 1) + j + 1.5;
+          tnsr.get(i, j, k) = 2. * (k + 1.) * (i + 1.) + j + 1.5;
         }
       }
     }
@@ -229,7 +229,7 @@ void test_tensor_double() {
       for (size_t j = 0; j < 4; ++j) {
         for (size_t k = 0; k < 4; ++k) {
           for (size_t l = 0; l < 4; ++l) {
-            tnsr.get(i, j, k, l) = 3. * i + j + (k + 1) * (l + 1) + 1.;
+            tnsr.get(i, j, k, l) = 3. * i + j + (k + 1.) * (l + 1.) + 1.;
           }
         }
       }
@@ -297,7 +297,7 @@ void test_tensor_datavector() {
     tnsr::AA<DataVector, 3> tnsr{};
     for (size_t i = 0; i < 4; ++i) {
       for (size_t j = 0; j < 4; ++j) {
-        tnsr.get(i, j) = DataVector(npts, i + j + 1.);
+        tnsr.get(i, j) = DataVector(npts, static_cast<double>(i) + j + 1.);
       }
     }
     return tnsr;
@@ -307,7 +307,8 @@ void test_tensor_datavector() {
     for (size_t i = 0; i < 3; ++i) {
       for (size_t j = 0; j < 4; ++j) {
         for (size_t k = 0; k < 4; ++k) {
-          tnsr.get(i, j, k) = DataVector(npts, 2. * (k + 1) * (j + 1) + i + 1.);
+          tnsr.get(i, j, k) =
+              DataVector(npts, 2. * (k + 1.) * (j + 1.) + i + 1.);
         }
       }
     }
@@ -319,7 +320,7 @@ void test_tensor_datavector() {
       for (size_t j = 0; j < 3; ++j) {
         for (size_t k = 0; k < 4; ++k) {
           tnsr.get(i, j, k) =
-              DataVector(npts, 2. * (k + 1) * (i + 1) + j + 1.5);
+              DataVector(npts, 2. * (k + 1.) * (i + 1.) + j + 1.5);
         }
       }
     }
@@ -332,7 +333,7 @@ void test_tensor_datavector() {
         for (size_t k = 0; k < 4; ++k) {
           for (size_t l = 0; l < 4; ++l) {
             tnsr.get(i, j, k, l) =
-                DataVector(npts, 3. * i + j + (k + 1) * (l + 1) + 1.);
+                DataVector(npts, 3. * i + j + (k + 1.) * (l + 1.) + 1.);
           }
         }
       }

--- a/tests/Unit/Framework/Tests/Test_PyppAnalyticSolution.cpp
+++ b/tests/Unit/Framework/Tests/Test_PyppAnalyticSolution.cpp
@@ -1,0 +1,79 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for detai
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <random>
+#include <tuple>
+#include <type_traits>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/Pypp.hpp"
+#include "Framework/PyppFundamentals.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+struct AnalyticSolutionTest {
+  template <typename T>
+  struct Var1 {
+    using type = Scalar<T>;
+  };
+  template <typename T>
+  struct Var2 {
+    using type = tnsr::I<T, 3>;
+  };
+
+  AnalyticSolutionTest(const double a, const std::array<double, 3>& b)
+      : a_(a), b_(b) {}
+
+  template <typename T>
+  tuples::TaggedTuple<Var1<T>, Var2<T>> solution(
+      const tnsr::i<T, 3>& x, const double t) const noexcept {
+    auto sol =
+        make_with_value<tuples::TaggedTuple<Var1<T>, Var2<T>>>(x.get(0), 0.);
+    auto& scalar = tuples::get<Var1<T>>(sol);
+    auto& vector = tuples::get<Var2<T>>(sol);
+
+    for (size_t i = 0; i < 3; ++i) {
+      scalar.get() += x.get(i) * gsl::at(b_, i);
+      vector.get(i) = a_ * x.get(i) - gsl::at(b_, i) * t;
+    }
+    scalar.get() += a_ - t;
+    return sol;
+  }
+
+ private:
+  double a_;
+  std::array<double, 3> b_;
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Pypp.AnalyticSolution", "[Pypp][Unit]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{"Framework/Tests/"};
+  const double a = 4.3;
+  const std::array<double, 3> b{{-1.3, 5.6, -0.2}};
+  AnalyticSolutionTest solution{a, b};
+  const DataVector used_for_size(5);
+  pypp::check_with_random_values<
+      1, tmpl::list<AnalyticSolutionTest::Var1<double>,
+                    AnalyticSolutionTest::Var2<double>>>(
+      &AnalyticSolutionTest::solution<double>, solution, "PyppPyTests",
+      {"check_solution_scalar", "check_solution_vector"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a, b), a);
+  pypp::check_with_random_values<
+      1, tmpl::list<AnalyticSolutionTest::Var1<DataVector>,
+                    AnalyticSolutionTest::Var2<DataVector>>>(
+      &AnalyticSolutionTest::solution<DataVector>, solution, "PyppPyTests",
+      {"check_solution_scalar", "check_solution_vector"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a, b), used_for_size);
+}

--- a/tests/Unit/Framework/Tests/Test_PyppAnalyticSolution.cpp
+++ b/tests/Unit/Framework/Tests/Test_PyppAnalyticSolution.cpp
@@ -64,15 +64,11 @@ SPECTRE_TEST_CASE("Unit.Pypp.AnalyticSolution", "[Pypp][Unit]") {
   const std::array<double, 3> b{{-1.3, 5.6, -0.2}};
   AnalyticSolutionTest solution{a, b};
   const DataVector used_for_size(5);
-  pypp::check_with_random_values<
-      1, tmpl::list<AnalyticSolutionTest::Var1<double>,
-                    AnalyticSolutionTest::Var2<double>>>(
+  pypp::check_with_random_values<1>(
       &AnalyticSolutionTest::solution<double>, solution, "PyppPyTests",
       {"check_solution_scalar", "check_solution_vector"}, {{{-10.0, 10.0}}},
       std::make_tuple(a, b), a);
-  pypp::check_with_random_values<
-      1, tmpl::list<AnalyticSolutionTest::Var1<DataVector>,
-                    AnalyticSolutionTest::Var2<DataVector>>>(
+  pypp::check_with_random_values<1>(
       &AnalyticSolutionTest::solution<DataVector>, solution, "PyppPyTests",
       {"check_solution_scalar", "check_solution_vector"}, {{{-10.0, 10.0}}},
       std::make_tuple(a, b), used_for_size);

--- a/tests/Unit/Framework/Tests/Test_PyppRandomValues.cpp
+++ b/tests/Unit/Framework/Tests/Test_PyppRandomValues.cpp
@@ -1,0 +1,827 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for detai
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <random>
+#include <string>
+#include <tuple>
+#include <type_traits>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/Pypp.hpp"
+#include "Framework/PyppFundamentals.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+template <typename T>
+void check_single_not_null0(const gsl::not_null<T*> result,
+                            const T& t0) noexcept {
+  *result = t0 + 5.0;
+}
+
+template <typename T>
+void check_single_not_null0_scalar(const gsl::not_null<T*> result,
+                                   const T& t0) noexcept {
+  get(*result) = get(t0) + 5.0;
+}
+
+template <typename T>
+void check_single_not_null1(const gsl::not_null<T*> result, const T& t0,
+                            const T& t1) noexcept {
+  *result = t0 + t1;
+}
+
+template <typename T>
+void check_single_not_null2(const gsl::not_null<T*> result, const T& t0,
+                            const T& t1) noexcept {
+  *result = sqrt(t0) + 1.0 / sqrt(-t1);
+}
+
+template <typename T>
+void check_single_not_null1_scalar(const gsl::not_null<T*> result, const T& t0,
+                                   const T& t1) noexcept {
+  get(*result) = get(t0) + get(t1);
+}
+
+template <typename T>
+void check_single_not_null2_scalar(const gsl::not_null<T*> result, const T& t0,
+                                   const T& t1) noexcept {
+  get(*result) = sqrt(get(t0)) + 1.0 / sqrt(-get(t1));
+}
+
+template <typename T>
+void check_double_not_null0(const gsl::not_null<T*> result0,
+                            const gsl::not_null<T*> result1,
+                            const T& t0) noexcept {
+  *result0 = t0 + 5.0;
+  *result1 = 2.0 * t0 + 5.0;
+}
+
+template <typename T>
+void check_double_not_null0_scalar(const gsl::not_null<T*> result0,
+                                   const gsl::not_null<T*> result1,
+                                   const T& t0) noexcept {
+  get(*result0) = get(t0) + 5.0;
+  get(*result1) = 2.0 * get(t0) + 5.0;
+}
+
+template <typename T>
+void check_double_not_null1(const gsl::not_null<T*> result0,
+                            const gsl::not_null<T*> result1, const T& t0,
+                            const T& t1) noexcept {
+  *result0 = t0 + t1;
+  *result1 = 2.0 * t0 + t1;
+}
+
+template <typename T>
+void check_double_not_null1_scalar(const gsl::not_null<T*> result0,
+                                   const gsl::not_null<T*> result1, const T& t0,
+                                   const T& t1) noexcept {
+  get(*result0) = get(t0) + get(t1);
+  get(*result1) = 2.0 * get(t0) + get(t1);
+}
+
+template <typename T>
+void check_double_not_null2(const gsl::not_null<T*> result0,
+                            const gsl::not_null<T*> result1, const T& t0,
+                            const T& t1) noexcept {
+  *result0 = sqrt(t0) + 1.0 / sqrt(-t1);
+  *result1 = 2.0 * t0 + t1;
+}
+
+template <typename T>
+void check_double_not_null2_scalar(const gsl::not_null<T*> result0,
+                                   const gsl::not_null<T*> result1, const T& t0,
+                                   const T& t1) noexcept {
+  get(*result0) = sqrt(get(t0)) + 1.0 / sqrt(-get(t1));
+  get(*result1) = 2.0 * get(t0) + get(t1);
+}
+
+template <typename T>
+T check_by_value0(const T& t0) noexcept {
+  return t0 + 5.0;
+}
+
+template <typename T>
+T check_by_value0_scalar(const T& t0) noexcept {
+  return T{get(t0) + 5.0};
+}
+
+template <typename T>
+T check_by_value1(const T& t0, const T& t1) noexcept {
+  return t0 + t1;
+}
+
+template <typename T>
+T check_by_value1_scalar(const T& t0, const T& t1) noexcept {
+  return T{get(t0) + get(t1)};
+}
+
+template <typename T>
+T check_by_value2(const T& t0, const T& t1) noexcept {
+  return sqrt(t0) + 1.0 / sqrt(-t1);
+}
+
+template <typename T>
+T check_by_value2_scalar(const T& t0, const T& t1) noexcept {
+  return T{sqrt(get(t0)) + 1.0 / sqrt(-get(t1))};
+}
+
+class RandomValuesTests {
+ public:
+  RandomValuesTests(const double a, const double b,
+                    const std::array<double, 3>& c) noexcept
+      : a_(a), b_(b), c_(c) {}
+
+  // by value, single argument
+  template <typename T>
+  T check_by_value0(const T& t0) const noexcept {
+    return t0 + 5.0;
+  }
+
+  template <typename T>
+  T check_by_value1(const T& t0) const noexcept {
+    return t0 + 5.0 * a_;
+  }
+
+  template <typename T>
+  T check_by_value2(const T& t0) const noexcept {
+    return t0 + 5.0 * a_ + b_;
+  }
+
+  template <typename T>
+  T check_by_value3(const T& t0) const noexcept {
+    return t0 + 5.0 * a_ + b_ + c_[0] - 2.0 * c_[1] - c_[2];
+  }
+
+  template <typename T>
+  T check_by_value0_scalar(const T& t0) const noexcept {
+    return T{get(t0) + 5.0};
+  }
+
+  template <typename T>
+  T check_by_value1_scalar(const T& t0) const noexcept {
+    return T{get(t0) + 5.0 * a_};
+  }
+
+  template <typename T>
+  T check_by_value2_scalar(const T& t0) const noexcept {
+    return T{get(t0) + 5.0 * a_ + b_};
+  }
+
+  template <typename T>
+  T check_by_value3_scalar(const T& t0) const noexcept {
+    return T{get(t0) + 5.0 * a_ + b_ + c_[0] - 2.0 * c_[1] - c_[2]};
+  }
+
+  // by value, two arguments
+  template <typename T>
+  T check2_by_value0(const T& t0, const T& t1) const noexcept {
+    return t0 + t1;
+  }
+
+  template <typename T>
+  T check2_by_value1(const T& t0, const T& t1) const noexcept {
+    return t0 + t1 + 5.0 * a_;
+  }
+
+  template <typename T>
+  T check2_by_value2(const T& t0, const T& t1) const noexcept {
+    return t0 + 5.0 * a_ + t1 * b_;
+  }
+
+  template <typename T>
+  T check2_by_value3(const T& t0, const T& t1) const noexcept {
+    return t0 * c_[0] + 5.0 * a_ + t1 * b_ + c_[1] - c_[2];
+  }
+
+  template <typename T>
+  T check2_by_value0_scalar(const T& t0, const T& t1) const noexcept {
+    return T{get(t0) + get(t1)};
+  }
+
+  template <typename T>
+  T check2_by_value1_scalar(const T& t0, const T& t1) const noexcept {
+    return T{get(t0) + get(t1) + 5.0 * a_};
+  }
+
+  template <typename T>
+  T check2_by_value2_scalar(const T& t0, const T& t1) const noexcept {
+    return T{get(t0) + 5.0 * a_ + b_ * get(t1)};
+  }
+
+  template <typename T>
+  T check2_by_value3_scalar(const T& t0, const T& t1) const noexcept {
+    return T{get(t0) * c_[0] + 5.0 * a_ + b_ * get(t1) + c_[1] - c_[2]};
+  }
+
+  // single not_null, single argument
+  template <typename T>
+  void check_by_not_null0(const gsl::not_null<T*> result0,
+                          const T& t0) const noexcept {
+    *result0 = t0 + 5.0;
+  }
+
+  template <typename T>
+  void check_by_not_null1(const gsl::not_null<T*> result0,
+                          const T& t0) const noexcept {
+    *result0 = t0 + 5.0 * a_;
+  }
+
+  template <typename T>
+  void check_by_not_null2(const gsl::not_null<T*> result0,
+                          const T& t0) const noexcept {
+    *result0 = t0 + 5.0 * a_ + b_;
+  }
+
+  template <typename T>
+  void check_by_not_null3(const gsl::not_null<T*> result0,
+                          const T& t0) const noexcept {
+    *result0 = t0 + 5.0 * a_ + b_ + c_[0] - 2.0 * c_[1] - c_[2];
+  }
+
+  template <typename T>
+  void check_by_not_null0_scalar(const gsl::not_null<T*> result0,
+                                 const T& t0) const noexcept {
+    get(*result0) = get(t0) + 5.0;
+  }
+
+  template <typename T>
+  void check_by_not_null1_scalar(const gsl::not_null<T*> result0,
+                                 const T& t0) const noexcept {
+    get(*result0) = get(t0) + 5.0 * a_;
+  }
+
+  template <typename T>
+  void check_by_not_null2_scalar(const gsl::not_null<T*> result0,
+                                 const T& t0) const noexcept {
+    get(*result0) = get(t0) + 5.0 * a_ + b_;
+  }
+
+  template <typename T>
+  void check_by_not_null3_scalar(const gsl::not_null<T*> result0,
+                                 const T& t0) const noexcept {
+    get(*result0) = get(t0) + 5.0 * a_ + b_ + c_[0] - 2.0 * c_[1] - c_[2];
+  }
+
+  // by value, two arguments
+  template <typename T>
+  void check2_by_not_null0(const gsl::not_null<T*> result0, const T& t0,
+                           const T& t1) const noexcept {
+    *result0 = t0 + t1;
+  }
+
+  template <typename T>
+  void check2_by_not_null1(const gsl::not_null<T*> result0, const T& t0,
+                           const T& t1) const noexcept {
+    *result0 = t0 + t1 + 5.0 * a_;
+  }
+
+  template <typename T>
+  void check2_by_not_null2(const gsl::not_null<T*> result0, const T& t0,
+                           const T& t1) const noexcept {
+    *result0 = t0 + 5.0 * a_ + t1 * b_;
+  }
+
+  template <typename T>
+  void check2_by_not_null3(const gsl::not_null<T*> result0, const T& t0,
+                           const T& t1) const noexcept {
+    *result0 = t0 * c_[0] + 5.0 * a_ + t1 * b_ + c_[1] - c_[2];
+  }
+
+  template <typename T>
+  void check2_by_not_null0_scalar(const gsl::not_null<T*> result0, const T& t0,
+                                  const T& t1) const noexcept {
+    *result0 = T{get(t0) + get(t1)};
+  }
+
+  template <typename T>
+  void check2_by_not_null1_scalar(const gsl::not_null<T*> result0, const T& t0,
+                                  const T& t1) const noexcept {
+    *result0 = T{get(t0) + get(t1) + 5.0 * a_};
+  }
+
+  template <typename T>
+  void check2_by_not_null2_scalar(const gsl::not_null<T*> result0, const T& t0,
+                                  const T& t1) const noexcept {
+    *result0 = T{get(t0) + 5.0 * a_ + b_ * get(t1)};
+  }
+
+  template <typename T>
+  void check2_by_not_null3_scalar(const gsl::not_null<T*> result0, const T& t0,
+                                  const T& t1) const noexcept {
+    *result0 = T{get(t0) * c_[0] + 5.0 * a_ + b_ * get(t1) + c_[1] - c_[2]};
+  }
+
+  // by value, two arguments
+  template <typename T>
+  void check3_by_not_null0(const gsl::not_null<T*> result0,
+                           const gsl::not_null<T*> result1, const T& t0,
+                           const T& t1) const noexcept {
+    *result0 = t0 + t1;
+    *result1 = 2.0 * t0 + t1;
+  }
+
+  template <typename T>
+  void check3_by_not_null1(const gsl::not_null<T*> result0,
+                           const gsl::not_null<T*> result1, const T& t0,
+                           const T& t1) const noexcept {
+    *result0 = t0 + t1 + 5.0 * a_;
+    *result1 = 2.0 * t0 + t1 + 5.0 * a_;
+  }
+
+  template <typename T>
+  void check3_by_not_null2(const gsl::not_null<T*> result0,
+                           const gsl::not_null<T*> result1, const T& t0,
+                           const T& t1) const noexcept {
+    *result0 = t0 + 5.0 * a_ + t1 * b_;
+    *result1 = 2.0 * t0 + 5.0 * a_ + t1 * b_;
+  }
+
+  template <typename T>
+  void check3_by_not_null0_scalar(const gsl::not_null<T*> result0,
+                                  const gsl::not_null<T*> result1, const T& t0,
+                                  const T& t1) const noexcept {
+    *result0 = T{get(t0) + get(t1)};
+    *result1 = T{2.0 * get(t0) + get(t1)};
+  }
+
+  template <typename T>
+  void check3_by_not_null1_scalar(const gsl::not_null<T*> result0,
+                                  const gsl::not_null<T*> result1, const T& t0,
+                                  const T& t1) const noexcept {
+    *result0 = T{get(t0) + get(t1) + 5.0 * a_};
+    *result1 = T{2.0 * get(t0) + get(t1) + 5.0 * a_};
+  }
+
+  template <typename T>
+  void check3_by_not_null2_scalar(const gsl::not_null<T*> result0,
+                                  const gsl::not_null<T*> result1, const T& t0,
+                                  const T& t1) const noexcept {
+    *result0 = T{get(t0) + 5.0 * a_ + b_ * get(t1)};
+    *result1 = T{2.0 * get(t0) + 5.0 * a_ + b_ * get(t1)};
+  }
+
+ private:
+  double a_ = 0;
+  double b_ = 0;
+  std::array<double, 3> c_{};
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Pypp.CheckRandomValues", "[Pypp][Unit]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{"Framework/Tests/"};
+  constexpr size_t size = 5;
+  const DataVector dv(size);
+  const double doub(0.);
+  const Scalar<double> scalar_double{5.0};
+  const Scalar<DataVector> scalar_dv{size};
+  pypp::check_with_random_values<1>(&check_single_not_null0<double>,
+                                    "PyppPyTests", {"check_single_not_null0"},
+                                    {{{-10.0, 10.0}}}, doub);
+  pypp::check_with_random_values<1>(&check_single_not_null0<DataVector>,
+                                    "PyppPyTests", {"check_single_not_null0"},
+                                    {{{-10.0, 10.0}}}, dv);
+  pypp::check_with_random_values<1>(&check_single_not_null1<double>,
+                                    "PyppPyTests", {"check_single_not_null1"},
+                                    {{{-10.0, 10.0}}}, doub);
+  pypp::check_with_random_values<1>(&check_single_not_null1<DataVector>,
+                                    "PyppPyTests", {"check_single_not_null1"},
+                                    {{{-10.0, 10.0}}}, dv);
+  pypp::check_with_random_values<2>(&check_single_not_null2<double>,
+                                    "PyppPyTests", {"check_single_not_null2"},
+                                    {{{0.0, 10.0}, {-10.0, 0.0}}}, doub);
+  pypp::check_with_random_values<2>(&check_single_not_null2<DataVector>,
+                                    "PyppPyTests", {"check_single_not_null2"},
+                                    {{{0.0, 10.0}, {-10.0, 0.0}}}, dv);
+  pypp::check_with_random_values<1>(
+      &check_single_not_null0_scalar<Scalar<double>>, "PyppPyTests",
+      {"check_single_not_null0"}, {{{-10.0, 10.0}}}, scalar_double);
+  pypp::check_with_random_values<1>(
+      &check_single_not_null0_scalar<Scalar<DataVector>>, "PyppPyTests",
+      {"check_single_not_null0"}, {{{-10.0, 10.0}}}, scalar_dv);
+  pypp::check_with_random_values<1>(
+      &check_single_not_null1_scalar<Scalar<double>>, "PyppPyTests",
+      {"check_single_not_null1"}, {{{-10.0, 10.0}}}, scalar_double);
+  pypp::check_with_random_values<1>(
+      &check_single_not_null1_scalar<Scalar<DataVector>>, "PyppPyTests",
+      {"check_single_not_null1"}, {{{-10.0, 10.0}}}, scalar_dv);
+  pypp::check_with_random_values<2>(
+      &check_single_not_null2_scalar<Scalar<double>>, "PyppPyTests",
+      {"check_single_not_null2"}, {{{0.0, 10.0}, {-10.0, 0.0}}}, scalar_double);
+  pypp::check_with_random_values<2>(
+      &check_single_not_null2_scalar<Scalar<DataVector>>, "PyppPyTests",
+      {"check_single_not_null2"}, {{{0.0, 10.0}, {-10.0, 0.0}}}, scalar_dv);
+
+  pypp::check_with_random_values<1>(
+      &check_double_not_null0<double>, "PyppPyTests",
+      {"check_double_not_null0_result0", "check_double_not_null0_result1"},
+      {{{-10.0, 10.0}}}, doub);
+  pypp::check_with_random_values<1>(
+      &check_double_not_null0<DataVector>, "PyppPyTests",
+      {"check_double_not_null0_result0", "check_double_not_null0_result1"},
+      {{{-10.0, 10.0}}}, dv);
+  pypp::check_with_random_values<1>(
+      &check_double_not_null1<double>, "PyppPyTests",
+      {"check_double_not_null1_result0", "check_double_not_null1_result1"},
+      {{{-10.0, 10.0}}}, doub);
+  pypp::check_with_random_values<1>(
+      &check_double_not_null1<DataVector>, "PyppPyTests",
+      {"check_double_not_null1_result0", "check_double_not_null1_result1"},
+      {{{-10.0, 10.0}}}, dv);
+  pypp::check_with_random_values<2>(
+      &check_double_not_null2<double>, "PyppPyTests",
+      {"check_double_not_null2_result0", "check_double_not_null2_result1"},
+      {{{0.0, 10.0}, {-10.0, 0.0}}}, doub);
+  pypp::check_with_random_values<2>(
+      &check_double_not_null2<DataVector>, "PyppPyTests",
+      {"check_double_not_null2_result0", "check_double_not_null2_result1"},
+      {{{0.0, 10.0}, {-10.0, 0.0}}}, dv);
+  pypp::check_with_random_values<1>(
+      &check_double_not_null0_scalar<Scalar<double>>, "PyppPyTests",
+      {"check_double_not_null0_result0", "check_double_not_null0_result1"},
+      {{{-10.0, 10.0}}}, scalar_double);
+  pypp::check_with_random_values<1>(
+      &check_double_not_null0_scalar<Scalar<DataVector>>, "PyppPyTests",
+      {"check_double_not_null0_result0", "check_double_not_null0_result1"},
+      {{{-10.0, 10.0}}}, scalar_dv);
+  pypp::check_with_random_values<1>(
+      &check_double_not_null1_scalar<Scalar<double>>, "PyppPyTests",
+      {"check_double_not_null1_result0", "check_double_not_null1_result1"},
+      {{{-10.0, 10.0}}}, scalar_double);
+  pypp::check_with_random_values<1>(
+      &check_double_not_null1_scalar<Scalar<DataVector>>, "PyppPyTests",
+      {"check_double_not_null1_result0", "check_double_not_null1_result1"},
+      {{{-10.0, 10.0}}}, scalar_dv);
+  pypp::check_with_random_values<2>(
+      &check_double_not_null2_scalar<Scalar<double>>, "PyppPyTests",
+      {"check_double_not_null2_result0", "check_double_not_null2_result1"},
+      {{{0.0, 10.0}, {-10.0, 0.0}}}, scalar_double);
+  /// [cxx_two_not_null]
+  pypp::check_with_random_values<2>(
+      &check_double_not_null2_scalar<Scalar<DataVector>>, "PyppPyTests",
+      {"check_double_not_null2_result0", "check_double_not_null2_result1"},
+      {{{0.0, 10.0}, {-10.0, 0.0}}}, scalar_dv);
+  /// [cxx_two_not_null]
+
+  pypp::check_with_random_values<1>(&check_by_value0<double>, "PyppPyTests",
+                                    "check_by_value0", {{{-10.0, 10.0}}}, doub);
+  pypp::check_with_random_values<1>(&check_by_value0<DataVector>, "PyppPyTests",
+                                    "check_by_value0", {{{-10.0, 10.0}}}, dv);
+  pypp::check_with_random_values<1>(&check_by_value1<double>, "PyppPyTests",
+                                    "check_by_value1", {{{-10.0, 10.0}}}, doub);
+  pypp::check_with_random_values<1>(&check_by_value1<DataVector>, "PyppPyTests",
+                                    "check_by_value1", {{{-10.0, 10.0}}}, dv);
+  pypp::check_with_random_values<2>(&check_by_value2<double>, "PyppPyTests",
+                                    "check_by_value2",
+                                    {{{0.0, 10.0}, {-10.0, 0.0}}}, doub);
+  pypp::check_with_random_values<2>(&check_by_value2<DataVector>, "PyppPyTests",
+                                    "check_by_value2",
+                                    {{{0.0, 10.0}, {-10.0, 0.0}}}, dv);
+  pypp::check_with_random_values<1>(&check_by_value0_scalar<Scalar<double>>,
+                                    "PyppPyTests", "check_by_value0",
+                                    {{{-10.0, 10.0}}}, scalar_double);
+  pypp::check_with_random_values<1>(&check_by_value0_scalar<Scalar<DataVector>>,
+                                    "PyppPyTests", "check_by_value0",
+                                    {{{-10.0, 10.0}}}, scalar_dv);
+  pypp::check_with_random_values<1>(&check_by_value1_scalar<Scalar<double>>,
+                                    "PyppPyTests", "check_by_value1",
+                                    {{{-10.0, 10.0}}}, scalar_double);
+  pypp::check_with_random_values<1>(&check_by_value1_scalar<Scalar<DataVector>>,
+                                    "PyppPyTests", "check_by_value1",
+                                    {{{-10.0, 10.0}}}, scalar_dv);
+  pypp::check_with_random_values<2>(
+      &check_by_value2_scalar<Scalar<double>>, "PyppPyTests", "check_by_value2",
+      {{{0.0, 10.0}, {-10.0, 0.0}}}, scalar_double);
+  pypp::check_with_random_values<2>(&check_by_value2_scalar<Scalar<DataVector>>,
+                                    "PyppPyTests", "check_by_value2",
+                                    {{{0.0, 10.0}, {-10.0, 0.0}}}, scalar_dv);
+
+  // Test member functions
+  const double a = 3.1;
+  const double b = 7.24;
+  const std::array<double, 3> c{{4.23, -8.3, 5.4}};
+  const RandomValuesTests test_class{a, b, c};
+  // by value, single argument
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_value0<double>, test_class, "PyppPyTests",
+      "check_by_value0", {{{-10.0, 10.0}}}, std::make_tuple(), doub);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_value0<DataVector>, test_class,
+      "PyppPyTests", "check_by_value0", {{{-10.0, 10.0}}}, std::make_tuple(),
+      dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_value0_scalar<Scalar<double>>, test_class,
+      "PyppPyTests", "check_by_value0", {{{-10.0, 10.0}}}, std::make_tuple(),
+      scalar_double);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_value0_scalar<Scalar<DataVector>>,
+      test_class, "PyppPyTests", "check_by_value0", {{{-10.0, 10.0}}},
+      std::make_tuple(), scalar_dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_value1<double>, test_class, "PyppPyTests",
+      "check_by_value1_class", {{{-10.0, 10.0}}}, std::make_tuple(a), doub);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_value1<DataVector>, test_class,
+      "PyppPyTests", "check_by_value1_class", {{{-10.0, 10.0}}},
+      std::make_tuple(a), dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_value1_scalar<Scalar<double>>, test_class,
+      "PyppPyTests", "check_by_value1_class", {{{-10.0, 10.0}}},
+      std::make_tuple(a), scalar_double);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_value1_scalar<Scalar<DataVector>>,
+      test_class, "PyppPyTests", "check_by_value1_class", {{{-10.0, 10.0}}},
+      std::make_tuple(a), scalar_dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_value2<double>, test_class, "PyppPyTests",
+      "check_by_value2_class", {{{-10.0, 10.0}}}, std::make_tuple(a, b), doub);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_value2<DataVector>, test_class,
+      "PyppPyTests", "check_by_value2_class", {{{-10.0, 10.0}}},
+      std::make_tuple(a, b), dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_value2_scalar<Scalar<double>>, test_class,
+      "PyppPyTests", "check_by_value2_class", {{{-10.0, 10.0}}},
+      std::make_tuple(a, b), scalar_double);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_value2_scalar<Scalar<DataVector>>,
+      test_class, "PyppPyTests", "check_by_value2_class", {{{-10.0, 10.0}}},
+      std::make_tuple(a, b), scalar_dv);
+  pypp::check_with_random_values<1>(&RandomValuesTests::check_by_value3<double>,
+                                    test_class, "PyppPyTests",
+                                    "check_by_value3_class", {{{-10.0, 10.0}}},
+                                    std::make_tuple(a, b, c), doub);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_value3<DataVector>, test_class,
+      "PyppPyTests", "check_by_value3_class", {{{-10.0, 10.0}}},
+      std::make_tuple(a, b, c), dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_value3_scalar<Scalar<double>>, test_class,
+      "PyppPyTests", "check_by_value3_class", {{{-10.0, 10.0}}},
+      std::make_tuple(a, b, c), scalar_double);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_value3_scalar<Scalar<DataVector>>,
+      test_class, "PyppPyTests", "check_by_value3_class", {{{-10.0, 10.0}}},
+      std::make_tuple(a, b, c), scalar_dv);
+
+  // by value, two arguments
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_value0<double>, test_class, "PyppPyTests",
+      "check_by_value1", {{{-10.0, 10.0}}}, std::make_tuple(), doub);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_value0<DataVector>, test_class,
+      "PyppPyTests", "check_by_value1", {{{-10.0, 10.0}}}, std::make_tuple(),
+      dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_value0_scalar<Scalar<double>>, test_class,
+      "PyppPyTests", "check_by_value1", {{{-10.0, 10.0}}}, std::make_tuple(),
+      scalar_double);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_value0_scalar<Scalar<DataVector>>,
+      test_class, "PyppPyTests", "check_by_value1", {{{-10.0, 10.0}}},
+      std::make_tuple(), scalar_dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_value1<double>, test_class, "PyppPyTests",
+      "check2_by_value1_class", {{{-10.0, 10.0}}}, std::make_tuple(a), doub);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_value1<DataVector>, test_class,
+      "PyppPyTests", "check2_by_value1_class", {{{-10.0, 10.0}}},
+      std::make_tuple(a), dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_value1_scalar<Scalar<double>>, test_class,
+      "PyppPyTests", "check2_by_value1_class", {{{-10.0, 10.0}}},
+      std::make_tuple(a), scalar_double);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_value1_scalar<Scalar<DataVector>>,
+      test_class, "PyppPyTests", "check2_by_value1_class", {{{-10.0, 10.0}}},
+      std::make_tuple(a), scalar_dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_value2<double>, test_class, "PyppPyTests",
+      "check2_by_value2_class", {{{-10.0, 10.0}}}, std::make_tuple(a, b), doub);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_value2<DataVector>, test_class,
+      "PyppPyTests", "check2_by_value2_class", {{{-10.0, 10.0}}},
+      std::make_tuple(a, b), dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_value2_scalar<Scalar<double>>, test_class,
+      "PyppPyTests", "check2_by_value2_class", {{{-10.0, 10.0}}},
+      std::make_tuple(a, b), scalar_double);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_value2_scalar<Scalar<DataVector>>,
+      test_class, "PyppPyTests", "check2_by_value2_class", {{{-10.0, 10.0}}},
+      std::make_tuple(a, b), scalar_dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_value3<double>, test_class, "PyppPyTests",
+      "check2_by_value3_class", {{{-10.0, 10.0}}}, std::make_tuple(a, b, c),
+      doub);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_value3<DataVector>, test_class,
+      "PyppPyTests", "check2_by_value3_class", {{{-10.0, 10.0}}},
+      std::make_tuple(a, b, c), dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_value3_scalar<Scalar<double>>, test_class,
+      "PyppPyTests", "check2_by_value3_class", {{{-10.0, 10.0}}},
+      std::make_tuple(a, b, c), scalar_double);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_value3_scalar<Scalar<DataVector>>,
+      test_class, "PyppPyTests", "check2_by_value3_class", {{{-10.0, 10.0}}},
+      std::make_tuple(a, b, c), scalar_dv);
+
+  // Single not_null, single argument
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_not_null0<double>, test_class,
+      "PyppPyTests"s, {"check_by_value0"s}, {{{-10.0, 10.0}}},
+      std::make_tuple(), doub);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_not_null0<DataVector>, test_class,
+      "PyppPyTests", {"check_by_value0"}, {{{-10.0, 10.0}}}, std::make_tuple(),
+      dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_not_null0_scalar<Scalar<double>>, test_class,
+      "PyppPyTests", {"check_by_value0"}, {{{-10.0, 10.0}}}, std::make_tuple(),
+      scalar_double);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_not_null0_scalar<Scalar<DataVector>>,
+      test_class, "PyppPyTests", {"check_by_value0"}, {{{-10.0, 10.0}}},
+      std::make_tuple(), scalar_dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_not_null1<double>, test_class, "PyppPyTests",
+      {"check_by_value1_class"}, {{{-10.0, 10.0}}}, std::make_tuple(a), doub);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_not_null1<DataVector>, test_class,
+      "PyppPyTests", {"check_by_value1_class"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a), dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_not_null1_scalar<Scalar<double>>, test_class,
+      "PyppPyTests", {"check_by_value1_class"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a), scalar_double);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_not_null1_scalar<Scalar<DataVector>>,
+      test_class, "PyppPyTests", {"check_by_value1_class"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a), scalar_dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_not_null2<double>, test_class, "PyppPyTests",
+      {"check_by_value2_class"}, {{{-10.0, 10.0}}}, std::make_tuple(a, b),
+      doub);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_not_null2<DataVector>, test_class,
+      "PyppPyTests", {"check_by_value2_class"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a, b), dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_not_null2_scalar<Scalar<double>>, test_class,
+      "PyppPyTests", {"check_by_value2_class"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a, b), scalar_double);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_not_null2_scalar<Scalar<DataVector>>,
+      test_class, "PyppPyTests", {"check_by_value2_class"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a, b), scalar_dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_not_null3<double>, test_class, "PyppPyTests",
+      {"check_by_value3_class"}, {{{-10.0, 10.0}}}, std::make_tuple(a, b, c),
+      doub);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_not_null3<DataVector>, test_class,
+      "PyppPyTests", {"check_by_value3_class"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a, b, c), dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_not_null3_scalar<Scalar<double>>, test_class,
+      "PyppPyTests", {"check_by_value3_class"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a, b, c), scalar_double);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_not_null3_scalar<Scalar<DataVector>>,
+      test_class, "PyppPyTests", {"check_by_value3_class"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a, b, c), scalar_dv);
+
+  // Single not_null, two arguments
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_not_null0<double>, test_class,
+      "PyppPyTests", {"check_by_value1"}, {{{-10.0, 10.0}}}, std::make_tuple(),
+      doub);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_not_null0<DataVector>, test_class,
+      {"PyppPyTests"}, {"check_by_value1"}, {{{-10.0, 10.0}}},
+      std::make_tuple(), dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_not_null0_scalar<Scalar<double>>,
+      test_class, {"PyppPyTests"}, {"check_by_value1"}, {{{-10.0, 10.0}}},
+      std::make_tuple(), scalar_double);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_not_null0_scalar<Scalar<DataVector>>,
+      test_class, {"PyppPyTests"}, {"check_by_value1"}, {{{-10.0, 10.0}}},
+      std::make_tuple(), scalar_dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_not_null1<double>, test_class,
+      {"PyppPyTests"}, {"check2_by_value1_class"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a), doub);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_not_null1<DataVector>, test_class,
+      {"PyppPyTests"}, {"check2_by_value1_class"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a), dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_not_null1_scalar<Scalar<double>>,
+      test_class, {"PyppPyTests"}, {"check2_by_value1_class"},
+      {{{-10.0, 10.0}}}, std::make_tuple(a), scalar_double);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_not_null1_scalar<Scalar<DataVector>>,
+      test_class, {"PyppPyTests"}, {"check2_by_value1_class"},
+      {{{-10.0, 10.0}}}, std::make_tuple(a), scalar_dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_not_null2<double>, test_class,
+      {"PyppPyTests"}, {"check2_by_value2_class"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a, b), doub);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_not_null2<DataVector>, test_class,
+      {"PyppPyTests"}, {"check2_by_value2_class"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a, b), dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_not_null2_scalar<Scalar<double>>,
+      test_class, {"PyppPyTests"}, {"check2_by_value2_class"},
+      {{{-10.0, 10.0}}}, std::make_tuple(a, b), scalar_double);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_not_null2_scalar<Scalar<DataVector>>,
+      test_class, "PyppPyTests", {"check2_by_value2_class"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a, b), scalar_dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_not_null3<double>, test_class,
+      {"PyppPyTests"}, {"check2_by_value3_class"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a, b, c), doub);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_not_null3<DataVector>, test_class,
+      {"PyppPyTests"}, {"check2_by_value3_class"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a, b, c), dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_not_null3_scalar<Scalar<double>>,
+      test_class, {"PyppPyTests"}, {"check2_by_value3_class"},
+      {{{-10.0, 10.0}}}, std::make_tuple(a, b, c), scalar_double);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_not_null3_scalar<Scalar<DataVector>>,
+      test_class, "PyppPyTests", {"check2_by_value3_class"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a, b, c), scalar_dv);
+
+  // Double not_null, two arguments
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check3_by_not_null0<double>, test_class,
+      "PyppPyTests",
+      {"check_double_not_null1_result0", "check_double_not_null1_result1"},
+      {{{-10.0, 10.0}}}, std::make_tuple(), doub);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check3_by_not_null0<DataVector>, test_class,
+      {"PyppPyTests"},
+      {"check_double_not_null1_result0", "check_double_not_null1_result1"},
+      {{{-10.0, 10.0}}}, std::make_tuple(), dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check3_by_not_null0_scalar<Scalar<double>>,
+      test_class, {"PyppPyTests"},
+      {"check_double_not_null1_result0", "check_double_not_null1_result1"},
+      {{{-10.0, 10.0}}}, std::make_tuple(), scalar_double);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check3_by_not_null0_scalar<Scalar<DataVector>>,
+      test_class, {"PyppPyTests"},
+      {"check_double_not_null1_result0", "check_double_not_null1_result1"},
+      {{{-10.0, 10.0}}}, std::make_tuple(), scalar_dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check3_by_not_null1<double>, test_class,
+      {"PyppPyTests"}, {"check2_by_value1_class", "check2_by_value1_class1"},
+      {{{-10.0, 10.0}}}, std::make_tuple(a), doub);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check3_by_not_null1<DataVector>, test_class,
+      {"PyppPyTests"}, {"check2_by_value1_class", "check2_by_value1_class1"},
+      {{{-10.0, 10.0}}}, std::make_tuple(a), dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check3_by_not_null1_scalar<Scalar<double>>,
+      test_class, {"PyppPyTests"},
+      {"check2_by_value1_class", "check2_by_value1_class1"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a), scalar_double);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check3_by_not_null1_scalar<Scalar<DataVector>>,
+      test_class, {"PyppPyTests"},
+      {"check2_by_value1_class", "check2_by_value1_class1"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a), scalar_dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check3_by_not_null2<double>, test_class,
+      {"PyppPyTests"}, {"check2_by_value2_class", "check2_by_value2_class1"},
+      {{{-10.0, 10.0}}}, std::make_tuple(a, b), doub);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check3_by_not_null2<DataVector>, test_class,
+      {"PyppPyTests"}, {"check2_by_value2_class", "check2_by_value2_class1"},
+      {{{-10.0, 10.0}}}, std::make_tuple(a, b), dv);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check3_by_not_null2_scalar<Scalar<double>>,
+      test_class, {"PyppPyTests"},
+      {"check2_by_value2_class", "check2_by_value2_class1"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a, b), scalar_double);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check3_by_not_null2_scalar<Scalar<DataVector>>,
+      test_class, "PyppPyTests",
+      {"check2_by_value2_class", "check2_by_value2_class1"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a, b), scalar_dv);
+}

--- a/tests/Unit/Framework/Tests/Test_PyppRandomValues.cpp
+++ b/tests/Unit/Framework/Tests/Test_PyppRandomValues.cpp
@@ -19,120 +19,103 @@
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/TypeTraits/IsA.hpp"
 
 namespace {
 template <typename T>
 void check_single_not_null0(const gsl::not_null<T*> result,
                             const T& t0) noexcept {
-  *result = t0 + 5.0;
-}
-
-template <typename T>
-void check_single_not_null0_scalar(const gsl::not_null<T*> result,
-                                   const T& t0) noexcept {
-  get(*result) = get(t0) + 5.0;
+  if constexpr (tt::is_a_v<Tensor, T>) {
+    get(*result) = get(t0) + 5.0;
+  } else {
+    *result = t0 + 5.0;
+  }
 }
 
 template <typename T>
 void check_single_not_null1(const gsl::not_null<T*> result, const T& t0,
                             const T& t1) noexcept {
-  *result = t0 + t1;
+  if constexpr (tt::is_a_v<Tensor, T>) {
+    get(*result) = get(t0) + get(t1);
+  } else {
+    *result = t0 + t1;
+  }
 }
 
 template <typename T>
 void check_single_not_null2(const gsl::not_null<T*> result, const T& t0,
                             const T& t1) noexcept {
-  *result = sqrt(t0) + 1.0 / sqrt(-t1);
-}
-
-template <typename T>
-void check_single_not_null1_scalar(const gsl::not_null<T*> result, const T& t0,
-                                   const T& t1) noexcept {
-  get(*result) = get(t0) + get(t1);
-}
-
-template <typename T>
-void check_single_not_null2_scalar(const gsl::not_null<T*> result, const T& t0,
-                                   const T& t1) noexcept {
-  get(*result) = sqrt(get(t0)) + 1.0 / sqrt(-get(t1));
+  if constexpr (tt::is_a_v<Tensor, T>) {
+    get(*result) = sqrt(get(t0)) + 1.0 / sqrt(-get(t1));
+  } else {
+    *result = sqrt(t0) + 1.0 / sqrt(-t1);
+  }
 }
 
 template <typename T>
 void check_double_not_null0(const gsl::not_null<T*> result0,
                             const gsl::not_null<T*> result1,
                             const T& t0) noexcept {
-  *result0 = t0 + 5.0;
-  *result1 = 2.0 * t0 + 5.0;
-}
-
-template <typename T>
-void check_double_not_null0_scalar(const gsl::not_null<T*> result0,
-                                   const gsl::not_null<T*> result1,
-                                   const T& t0) noexcept {
-  get(*result0) = get(t0) + 5.0;
-  get(*result1) = 2.0 * get(t0) + 5.0;
+  if constexpr (tt::is_a_v<Tensor, T>) {
+    get(*result0) = get(t0) + 5.0;
+    get(*result1) = 2.0 * get(t0) + 5.0;
+  } else {
+    *result0 = t0 + 5.0;
+    *result1 = 2.0 * t0 + 5.0;
+  }
 }
 
 template <typename T>
 void check_double_not_null1(const gsl::not_null<T*> result0,
                             const gsl::not_null<T*> result1, const T& t0,
                             const T& t1) noexcept {
-  *result0 = t0 + t1;
-  *result1 = 2.0 * t0 + t1;
-}
-
-template <typename T>
-void check_double_not_null1_scalar(const gsl::not_null<T*> result0,
-                                   const gsl::not_null<T*> result1, const T& t0,
-                                   const T& t1) noexcept {
-  get(*result0) = get(t0) + get(t1);
-  get(*result1) = 2.0 * get(t0) + get(t1);
+  if constexpr (tt::is_a_v<Tensor, T>) {
+    get(*result0) = get(t0) + get(t1);
+    get(*result1) = 2.0 * get(t0) + get(t1);
+  } else {
+    *result0 = t0 + t1;
+    *result1 = 2.0 * t0 + t1;
+  }
 }
 
 template <typename T>
 void check_double_not_null2(const gsl::not_null<T*> result0,
                             const gsl::not_null<T*> result1, const T& t0,
                             const T& t1) noexcept {
-  *result0 = sqrt(t0) + 1.0 / sqrt(-t1);
-  *result1 = 2.0 * t0 + t1;
-}
-
-template <typename T>
-void check_double_not_null2_scalar(const gsl::not_null<T*> result0,
-                                   const gsl::not_null<T*> result1, const T& t0,
-                                   const T& t1) noexcept {
-  get(*result0) = sqrt(get(t0)) + 1.0 / sqrt(-get(t1));
-  get(*result1) = 2.0 * get(t0) + get(t1);
+  if constexpr (tt::is_a_v<Tensor, T>) {
+    get(*result0) = sqrt(get(t0)) + 1.0 / sqrt(-get(t1));
+    get(*result1) = 2.0 * get(t0) + get(t1);
+  } else {
+    *result0 = sqrt(t0) + 1.0 / sqrt(-t1);
+    *result1 = 2.0 * t0 + t1;
+  }
 }
 
 template <typename T>
 T check_by_value0(const T& t0) noexcept {
-  return t0 + 5.0;
-}
-
-template <typename T>
-T check_by_value0_scalar(const T& t0) noexcept {
-  return T{get(t0) + 5.0};
+  if constexpr (tt::is_a_v<Tensor, T>) {
+    return T{get(t0) + 5.0};
+  } else {
+    return t0 + 5.0;
+  }
 }
 
 template <typename T>
 T check_by_value1(const T& t0, const T& t1) noexcept {
-  return t0 + t1;
-}
-
-template <typename T>
-T check_by_value1_scalar(const T& t0, const T& t1) noexcept {
-  return T{get(t0) + get(t1)};
+  if constexpr (tt::is_a_v<Tensor, T>) {
+    return T{get(t0) + get(t1)};
+  } else {
+    return t0 + t1;
+  }
 }
 
 template <typename T>
 T check_by_value2(const T& t0, const T& t1) noexcept {
-  return sqrt(t0) + 1.0 / sqrt(-t1);
-}
-
-template <typename T>
-T check_by_value2_scalar(const T& t0, const T& t1) noexcept {
-  return T{sqrt(get(t0)) + 1.0 / sqrt(-get(t1))};
+  if constexpr (tt::is_a_v<Tensor, T>) {
+    return T{sqrt(get(t0)) + 1.0 / sqrt(-get(t1))};
+  } else {
+    return sqrt(t0) + 1.0 / sqrt(-t1);
+  }
 }
 
 class RandomValuesTests {
@@ -144,181 +127,157 @@ class RandomValuesTests {
   // by value, single argument
   template <typename T>
   T check_by_value0(const T& t0) const noexcept {
-    return t0 + 5.0;
+    if constexpr (tt::is_a_v<Tensor, T>) {
+      return T{get(t0) + 5.0};
+    } else {
+      return t0 + 5.0;
+    }
   }
 
   template <typename T>
   T check_by_value1(const T& t0) const noexcept {
-    return t0 + 5.0 * a_;
+    if constexpr (tt::is_a_v<Tensor, T>) {
+      return T{get(t0) + 5.0 * a_};
+    } else {
+      return t0 + 5.0 * a_;
+    }
   }
 
   template <typename T>
   T check_by_value2(const T& t0) const noexcept {
-    return t0 + 5.0 * a_ + b_;
+    if constexpr (tt::is_a_v<Tensor, T>) {
+      return T{get(t0) + 5.0 * a_ + b_};
+    } else {
+      return t0 + 5.0 * a_ + b_;
+    }
   }
 
   template <typename T>
   T check_by_value3(const T& t0) const noexcept {
-    return t0 + 5.0 * a_ + b_ + c_[0] - 2.0 * c_[1] - c_[2];
-  }
-
-  template <typename T>
-  T check_by_value0_scalar(const T& t0) const noexcept {
-    return T{get(t0) + 5.0};
-  }
-
-  template <typename T>
-  T check_by_value1_scalar(const T& t0) const noexcept {
-    return T{get(t0) + 5.0 * a_};
-  }
-
-  template <typename T>
-  T check_by_value2_scalar(const T& t0) const noexcept {
-    return T{get(t0) + 5.0 * a_ + b_};
-  }
-
-  template <typename T>
-  T check_by_value3_scalar(const T& t0) const noexcept {
-    return T{get(t0) + 5.0 * a_ + b_ + c_[0] - 2.0 * c_[1] - c_[2]};
+    if constexpr (tt::is_a_v<Tensor, T>) {
+      return T{get(t0) + 5.0 * a_ + b_ + c_[0] - 2.0 * c_[1] - c_[2]};
+    } else {
+      return t0 + 5.0 * a_ + b_ + c_[0] - 2.0 * c_[1] - c_[2];
+    }
   }
 
   // by value, two arguments
   template <typename T>
   T check2_by_value0(const T& t0, const T& t1) const noexcept {
-    return t0 + t1;
+    if constexpr (tt::is_a_v<Tensor, T>) {
+      return T{get(t0) + get(t1)};
+    } else {
+      return t0 + t1;
+    }
   }
 
   template <typename T>
   T check2_by_value1(const T& t0, const T& t1) const noexcept {
-    return t0 + t1 + 5.0 * a_;
+    if constexpr (tt::is_a_v<Tensor, T>) {
+      return T{get(t0) + get(t1) + 5.0 * a_};
+    } else {
+      return t0 + t1 + 5.0 * a_;
+    }
   }
 
   template <typename T>
   T check2_by_value2(const T& t0, const T& t1) const noexcept {
-    return t0 + 5.0 * a_ + t1 * b_;
+    if constexpr (tt::is_a_v<Tensor, T>) {
+      return T{get(t0) + 5.0 * a_ + b_ * get(t1)};
+    } else {
+      return t0 + 5.0 * a_ + t1 * b_;
+    }
   }
 
   template <typename T>
   T check2_by_value3(const T& t0, const T& t1) const noexcept {
-    return t0 * c_[0] + 5.0 * a_ + t1 * b_ + c_[1] - c_[2];
-  }
-
-  template <typename T>
-  T check2_by_value0_scalar(const T& t0, const T& t1) const noexcept {
-    return T{get(t0) + get(t1)};
-  }
-
-  template <typename T>
-  T check2_by_value1_scalar(const T& t0, const T& t1) const noexcept {
-    return T{get(t0) + get(t1) + 5.0 * a_};
-  }
-
-  template <typename T>
-  T check2_by_value2_scalar(const T& t0, const T& t1) const noexcept {
-    return T{get(t0) + 5.0 * a_ + b_ * get(t1)};
-  }
-
-  template <typename T>
-  T check2_by_value3_scalar(const T& t0, const T& t1) const noexcept {
-    return T{get(t0) * c_[0] + 5.0 * a_ + b_ * get(t1) + c_[1] - c_[2]};
+    if constexpr (tt::is_a_v<Tensor, T>) {
+      return T{get(t0) * c_[0] + 5.0 * a_ + b_ * get(t1) + c_[1] - c_[2]};
+    } else {
+      return t0 * c_[0] + 5.0 * a_ + t1 * b_ + c_[1] - c_[2];
+    }
   }
 
   // single not_null, single argument
   template <typename T>
   void check_by_not_null0(const gsl::not_null<T*> result0,
                           const T& t0) const noexcept {
-    *result0 = t0 + 5.0;
+    if constexpr (tt::is_a_v<Tensor, T>) {
+      get(*result0) = get(t0) + 5.0;
+    } else {
+      *result0 = t0 + 5.0;
+    }
   }
 
   template <typename T>
   void check_by_not_null1(const gsl::not_null<T*> result0,
                           const T& t0) const noexcept {
-    *result0 = t0 + 5.0 * a_;
+    if constexpr (tt::is_a_v<Tensor, T>) {
+      get(*result0) = get(t0) + 5.0 * a_;
+    } else {
+      *result0 = t0 + 5.0 * a_;
+    }
   }
 
   template <typename T>
   void check_by_not_null2(const gsl::not_null<T*> result0,
                           const T& t0) const noexcept {
-    *result0 = t0 + 5.0 * a_ + b_;
+    if constexpr (tt::is_a_v<Tensor, T>) {
+      get(*result0) = get(t0) + 5.0 * a_ + b_;
+    } else {
+      *result0 = t0 + 5.0 * a_ + b_;
+    }
   }
 
   template <typename T>
   void check_by_not_null3(const gsl::not_null<T*> result0,
                           const T& t0) const noexcept {
-    *result0 = t0 + 5.0 * a_ + b_ + c_[0] - 2.0 * c_[1] - c_[2];
-  }
-
-  template <typename T>
-  void check_by_not_null0_scalar(const gsl::not_null<T*> result0,
-                                 const T& t0) const noexcept {
-    get(*result0) = get(t0) + 5.0;
-  }
-
-  template <typename T>
-  void check_by_not_null1_scalar(const gsl::not_null<T*> result0,
-                                 const T& t0) const noexcept {
-    get(*result0) = get(t0) + 5.0 * a_;
-  }
-
-  template <typename T>
-  void check_by_not_null2_scalar(const gsl::not_null<T*> result0,
-                                 const T& t0) const noexcept {
-    get(*result0) = get(t0) + 5.0 * a_ + b_;
-  }
-
-  template <typename T>
-  void check_by_not_null3_scalar(const gsl::not_null<T*> result0,
-                                 const T& t0) const noexcept {
-    get(*result0) = get(t0) + 5.0 * a_ + b_ + c_[0] - 2.0 * c_[1] - c_[2];
+    if constexpr (tt::is_a_v<Tensor, T>) {
+      get(*result0) = get(t0) + 5.0 * a_ + b_ + c_[0] - 2.0 * c_[1] - c_[2];
+    } else {
+      *result0 = t0 + 5.0 * a_ + b_ + c_[0] - 2.0 * c_[1] - c_[2];
+    }
   }
 
   // by value, two arguments
   template <typename T>
   void check2_by_not_null0(const gsl::not_null<T*> result0, const T& t0,
                            const T& t1) const noexcept {
-    *result0 = t0 + t1;
+    if constexpr (tt::is_a_v<Tensor, T>) {
+      *result0 = T{get(t0) + get(t1)};
+    } else {
+      *result0 = t0 + t1;
+    }
   }
 
   template <typename T>
   void check2_by_not_null1(const gsl::not_null<T*> result0, const T& t0,
                            const T& t1) const noexcept {
-    *result0 = t0 + t1 + 5.0 * a_;
+    if constexpr (tt::is_a_v<Tensor, T>) {
+      *result0 = T{get(t0) + get(t1) + 5.0 * a_};
+    } else {
+      *result0 = t0 + t1 + 5.0 * a_;
+    }
   }
 
   template <typename T>
   void check2_by_not_null2(const gsl::not_null<T*> result0, const T& t0,
                            const T& t1) const noexcept {
-    *result0 = t0 + 5.0 * a_ + t1 * b_;
+    if constexpr (tt::is_a_v<Tensor, T>) {
+      *result0 = T{get(t0) + 5.0 * a_ + b_ * get(t1)};
+    } else {
+      *result0 = t0 + 5.0 * a_ + t1 * b_;
+    }
   }
 
   template <typename T>
   void check2_by_not_null3(const gsl::not_null<T*> result0, const T& t0,
                            const T& t1) const noexcept {
-    *result0 = t0 * c_[0] + 5.0 * a_ + t1 * b_ + c_[1] - c_[2];
-  }
-
-  template <typename T>
-  void check2_by_not_null0_scalar(const gsl::not_null<T*> result0, const T& t0,
-                                  const T& t1) const noexcept {
-    *result0 = T{get(t0) + get(t1)};
-  }
-
-  template <typename T>
-  void check2_by_not_null1_scalar(const gsl::not_null<T*> result0, const T& t0,
-                                  const T& t1) const noexcept {
-    *result0 = T{get(t0) + get(t1) + 5.0 * a_};
-  }
-
-  template <typename T>
-  void check2_by_not_null2_scalar(const gsl::not_null<T*> result0, const T& t0,
-                                  const T& t1) const noexcept {
-    *result0 = T{get(t0) + 5.0 * a_ + b_ * get(t1)};
-  }
-
-  template <typename T>
-  void check2_by_not_null3_scalar(const gsl::not_null<T*> result0, const T& t0,
-                                  const T& t1) const noexcept {
-    *result0 = T{get(t0) * c_[0] + 5.0 * a_ + b_ * get(t1) + c_[1] - c_[2]};
+    if constexpr (tt::is_a_v<Tensor, T>) {
+      *result0 = T{get(t0) * c_[0] + 5.0 * a_ + b_ * get(t1) + c_[1] - c_[2]};
+    } else {
+      *result0 = t0 * c_[0] + 5.0 * a_ + t1 * b_ + c_[1] - c_[2];
+    }
   }
 
   // by value, two arguments
@@ -326,48 +285,39 @@ class RandomValuesTests {
   void check3_by_not_null0(const gsl::not_null<T*> result0,
                            const gsl::not_null<T*> result1, const T& t0,
                            const T& t1) const noexcept {
-    *result0 = t0 + t1;
-    *result1 = 2.0 * t0 + t1;
+    if constexpr (tt::is_a_v<Tensor, T>) {
+      *result0 = T{get(t0) + get(t1)};
+      *result1 = T{2.0 * get(t0) + get(t1)};
+    } else {
+      *result0 = t0 + t1;
+      *result1 = 2.0 * t0 + t1;
+    }
   }
 
   template <typename T>
   void check3_by_not_null1(const gsl::not_null<T*> result0,
                            const gsl::not_null<T*> result1, const T& t0,
                            const T& t1) const noexcept {
-    *result0 = t0 + t1 + 5.0 * a_;
-    *result1 = 2.0 * t0 + t1 + 5.0 * a_;
+    if constexpr (tt::is_a_v<Tensor, T>) {
+      *result0 = T{get(t0) + get(t1) + 5.0 * a_};
+      *result1 = T{2.0 * get(t0) + get(t1) + 5.0 * a_};
+    } else {
+      *result0 = t0 + t1 + 5.0 * a_;
+      *result1 = 2.0 * t0 + t1 + 5.0 * a_;
+    }
   }
 
   template <typename T>
   void check3_by_not_null2(const gsl::not_null<T*> result0,
                            const gsl::not_null<T*> result1, const T& t0,
                            const T& t1) const noexcept {
-    *result0 = t0 + 5.0 * a_ + t1 * b_;
-    *result1 = 2.0 * t0 + 5.0 * a_ + t1 * b_;
-  }
-
-  template <typename T>
-  void check3_by_not_null0_scalar(const gsl::not_null<T*> result0,
-                                  const gsl::not_null<T*> result1, const T& t0,
-                                  const T& t1) const noexcept {
-    *result0 = T{get(t0) + get(t1)};
-    *result1 = T{2.0 * get(t0) + get(t1)};
-  }
-
-  template <typename T>
-  void check3_by_not_null1_scalar(const gsl::not_null<T*> result0,
-                                  const gsl::not_null<T*> result1, const T& t0,
-                                  const T& t1) const noexcept {
-    *result0 = T{get(t0) + get(t1) + 5.0 * a_};
-    *result1 = T{2.0 * get(t0) + get(t1) + 5.0 * a_};
-  }
-
-  template <typename T>
-  void check3_by_not_null2_scalar(const gsl::not_null<T*> result0,
-                                  const gsl::not_null<T*> result1, const T& t0,
-                                  const T& t1) const noexcept {
-    *result0 = T{get(t0) + 5.0 * a_ + b_ * get(t1)};
-    *result1 = T{2.0 * get(t0) + 5.0 * a_ + b_ * get(t1)};
+    if constexpr (tt::is_a_v<Tensor, T>) {
+      *result0 = T{get(t0) + 5.0 * a_ + b_ * get(t1)};
+      *result1 = T{2.0 * get(t0) + 5.0 * a_ + b_ * get(t1)};
+    } else {
+      *result0 = t0 + 5.0 * a_ + t1 * b_;
+      *result1 = 2.0 * t0 + 5.0 * a_ + t1 * b_;
+    }
   }
 
  private:
@@ -402,24 +352,24 @@ SPECTRE_TEST_CASE("Unit.Pypp.CheckRandomValues", "[Pypp][Unit]") {
   pypp::check_with_random_values<2>(&check_single_not_null2<DataVector>,
                                     "PyppPyTests", {"check_single_not_null2"},
                                     {{{0.0, 10.0}, {-10.0, 0.0}}}, dv);
-  pypp::check_with_random_values<1>(
-      &check_single_not_null0_scalar<Scalar<double>>, "PyppPyTests",
-      {"check_single_not_null0"}, {{{-10.0, 10.0}}}, scalar_double);
-  pypp::check_with_random_values<1>(
-      &check_single_not_null0_scalar<Scalar<DataVector>>, "PyppPyTests",
-      {"check_single_not_null0"}, {{{-10.0, 10.0}}}, scalar_dv);
-  pypp::check_with_random_values<1>(
-      &check_single_not_null1_scalar<Scalar<double>>, "PyppPyTests",
-      {"check_single_not_null1"}, {{{-10.0, 10.0}}}, scalar_double);
-  pypp::check_with_random_values<1>(
-      &check_single_not_null1_scalar<Scalar<DataVector>>, "PyppPyTests",
-      {"check_single_not_null1"}, {{{-10.0, 10.0}}}, scalar_dv);
+  pypp::check_with_random_values<1>(&check_single_not_null0<Scalar<double>>,
+                                    "PyppPyTests", {"check_single_not_null0"},
+                                    {{{-10.0, 10.0}}}, scalar_double);
+  pypp::check_with_random_values<1>(&check_single_not_null0<Scalar<DataVector>>,
+                                    "PyppPyTests", {"check_single_not_null0"},
+                                    {{{-10.0, 10.0}}}, scalar_dv);
+  pypp::check_with_random_values<1>(&check_single_not_null1<Scalar<double>>,
+                                    "PyppPyTests", {"check_single_not_null1"},
+                                    {{{-10.0, 10.0}}}, scalar_double);
+  pypp::check_with_random_values<1>(&check_single_not_null1<Scalar<DataVector>>,
+                                    "PyppPyTests", {"check_single_not_null1"},
+                                    {{{-10.0, 10.0}}}, scalar_dv);
   pypp::check_with_random_values<2>(
-      &check_single_not_null2_scalar<Scalar<double>>, "PyppPyTests",
+      &check_single_not_null2<Scalar<double>>, "PyppPyTests",
       {"check_single_not_null2"}, {{{0.0, 10.0}, {-10.0, 0.0}}}, scalar_double);
-  pypp::check_with_random_values<2>(
-      &check_single_not_null2_scalar<Scalar<DataVector>>, "PyppPyTests",
-      {"check_single_not_null2"}, {{{0.0, 10.0}, {-10.0, 0.0}}}, scalar_dv);
+  pypp::check_with_random_values<2>(&check_single_not_null2<Scalar<DataVector>>,
+                                    "PyppPyTests", {"check_single_not_null2"},
+                                    {{{0.0, 10.0}, {-10.0, 0.0}}}, scalar_dv);
 
   pypp::check_with_random_values<1>(
       &check_double_not_null0<double>, "PyppPyTests",
@@ -446,28 +396,28 @@ SPECTRE_TEST_CASE("Unit.Pypp.CheckRandomValues", "[Pypp][Unit]") {
       {"check_double_not_null2_result0", "check_double_not_null2_result1"},
       {{{0.0, 10.0}, {-10.0, 0.0}}}, dv);
   pypp::check_with_random_values<1>(
-      &check_double_not_null0_scalar<Scalar<double>>, "PyppPyTests",
+      &check_double_not_null0<Scalar<double>>, "PyppPyTests",
       {"check_double_not_null0_result0", "check_double_not_null0_result1"},
       {{{-10.0, 10.0}}}, scalar_double);
   pypp::check_with_random_values<1>(
-      &check_double_not_null0_scalar<Scalar<DataVector>>, "PyppPyTests",
+      &check_double_not_null0<Scalar<DataVector>>, "PyppPyTests",
       {"check_double_not_null0_result0", "check_double_not_null0_result1"},
       {{{-10.0, 10.0}}}, scalar_dv);
   pypp::check_with_random_values<1>(
-      &check_double_not_null1_scalar<Scalar<double>>, "PyppPyTests",
+      &check_double_not_null1<Scalar<double>>, "PyppPyTests",
       {"check_double_not_null1_result0", "check_double_not_null1_result1"},
       {{{-10.0, 10.0}}}, scalar_double);
   pypp::check_with_random_values<1>(
-      &check_double_not_null1_scalar<Scalar<DataVector>>, "PyppPyTests",
+      &check_double_not_null1<Scalar<DataVector>>, "PyppPyTests",
       {"check_double_not_null1_result0", "check_double_not_null1_result1"},
       {{{-10.0, 10.0}}}, scalar_dv);
   pypp::check_with_random_values<2>(
-      &check_double_not_null2_scalar<Scalar<double>>, "PyppPyTests",
+      &check_double_not_null2<Scalar<double>>, "PyppPyTests",
       {"check_double_not_null2_result0", "check_double_not_null2_result1"},
       {{{0.0, 10.0}, {-10.0, 0.0}}}, scalar_double);
   /// [cxx_two_not_null]
   pypp::check_with_random_values<2>(
-      &check_double_not_null2_scalar<Scalar<DataVector>>, "PyppPyTests",
+      &check_double_not_null2<Scalar<DataVector>>, "PyppPyTests",
       {"check_double_not_null2_result0", "check_double_not_null2_result1"},
       {{{0.0, 10.0}, {-10.0, 0.0}}}, scalar_dv);
   /// [cxx_two_not_null]
@@ -486,22 +436,22 @@ SPECTRE_TEST_CASE("Unit.Pypp.CheckRandomValues", "[Pypp][Unit]") {
   pypp::check_with_random_values<2>(&check_by_value2<DataVector>, "PyppPyTests",
                                     "check_by_value2",
                                     {{{0.0, 10.0}, {-10.0, 0.0}}}, dv);
-  pypp::check_with_random_values<1>(&check_by_value0_scalar<Scalar<double>>,
+  pypp::check_with_random_values<1>(&check_by_value0<Scalar<double>>,
                                     "PyppPyTests", "check_by_value0",
                                     {{{-10.0, 10.0}}}, scalar_double);
-  pypp::check_with_random_values<1>(&check_by_value0_scalar<Scalar<DataVector>>,
+  pypp::check_with_random_values<1>(&check_by_value0<Scalar<DataVector>>,
                                     "PyppPyTests", "check_by_value0",
                                     {{{-10.0, 10.0}}}, scalar_dv);
-  pypp::check_with_random_values<1>(&check_by_value1_scalar<Scalar<double>>,
+  pypp::check_with_random_values<1>(&check_by_value1<Scalar<double>>,
                                     "PyppPyTests", "check_by_value1",
                                     {{{-10.0, 10.0}}}, scalar_double);
-  pypp::check_with_random_values<1>(&check_by_value1_scalar<Scalar<DataVector>>,
+  pypp::check_with_random_values<1>(&check_by_value1<Scalar<DataVector>>,
                                     "PyppPyTests", "check_by_value1",
                                     {{{-10.0, 10.0}}}, scalar_dv);
   pypp::check_with_random_values<2>(
-      &check_by_value2_scalar<Scalar<double>>, "PyppPyTests", "check_by_value2",
+      &check_by_value2<Scalar<double>>, "PyppPyTests", "check_by_value2",
       {{{0.0, 10.0}, {-10.0, 0.0}}}, scalar_double);
-  pypp::check_with_random_values<2>(&check_by_value2_scalar<Scalar<DataVector>>,
+  pypp::check_with_random_values<2>(&check_by_value2<Scalar<DataVector>>,
                                     "PyppPyTests", "check_by_value2",
                                     {{{0.0, 10.0}, {-10.0, 0.0}}}, scalar_dv);
 
@@ -519,13 +469,13 @@ SPECTRE_TEST_CASE("Unit.Pypp.CheckRandomValues", "[Pypp][Unit]") {
       "PyppPyTests", "check_by_value0", {{{-10.0, 10.0}}}, std::make_tuple(),
       dv);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value0_scalar<Scalar<double>>, test_class,
+      &RandomValuesTests::check_by_value0<Scalar<double>>, test_class,
       "PyppPyTests", "check_by_value0", {{{-10.0, 10.0}}}, std::make_tuple(),
       scalar_double);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value0_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests", "check_by_value0", {{{-10.0, 10.0}}},
-      std::make_tuple(), scalar_dv);
+      &RandomValuesTests::check_by_value0<Scalar<DataVector>>, test_class,
+      "PyppPyTests", "check_by_value0", {{{-10.0, 10.0}}}, std::make_tuple(),
+      scalar_dv);
   pypp::check_with_random_values<1>(
       &RandomValuesTests::check_by_value1<double>, test_class, "PyppPyTests",
       "check_by_value1_class", {{{-10.0, 10.0}}}, std::make_tuple(a), doub);
@@ -534,12 +484,12 @@ SPECTRE_TEST_CASE("Unit.Pypp.CheckRandomValues", "[Pypp][Unit]") {
       "PyppPyTests", "check_by_value1_class", {{{-10.0, 10.0}}},
       std::make_tuple(a), dv);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value1_scalar<Scalar<double>>, test_class,
+      &RandomValuesTests::check_by_value1<Scalar<double>>, test_class,
       "PyppPyTests", "check_by_value1_class", {{{-10.0, 10.0}}},
       std::make_tuple(a), scalar_double);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value1_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests", "check_by_value1_class", {{{-10.0, 10.0}}},
+      &RandomValuesTests::check_by_value1<Scalar<DataVector>>, test_class,
+      "PyppPyTests", "check_by_value1_class", {{{-10.0, 10.0}}},
       std::make_tuple(a), scalar_dv);
   pypp::check_with_random_values<1>(
       &RandomValuesTests::check_by_value2<double>, test_class, "PyppPyTests",
@@ -549,12 +499,12 @@ SPECTRE_TEST_CASE("Unit.Pypp.CheckRandomValues", "[Pypp][Unit]") {
       "PyppPyTests", "check_by_value2_class", {{{-10.0, 10.0}}},
       std::make_tuple(a, b), dv);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value2_scalar<Scalar<double>>, test_class,
+      &RandomValuesTests::check_by_value2<Scalar<double>>, test_class,
       "PyppPyTests", "check_by_value2_class", {{{-10.0, 10.0}}},
       std::make_tuple(a, b), scalar_double);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value2_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests", "check_by_value2_class", {{{-10.0, 10.0}}},
+      &RandomValuesTests::check_by_value2<Scalar<DataVector>>, test_class,
+      "PyppPyTests", "check_by_value2_class", {{{-10.0, 10.0}}},
       std::make_tuple(a, b), scalar_dv);
   pypp::check_with_random_values<1>(&RandomValuesTests::check_by_value3<double>,
                                     test_class, "PyppPyTests",
@@ -565,12 +515,12 @@ SPECTRE_TEST_CASE("Unit.Pypp.CheckRandomValues", "[Pypp][Unit]") {
       "PyppPyTests", "check_by_value3_class", {{{-10.0, 10.0}}},
       std::make_tuple(a, b, c), dv);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value3_scalar<Scalar<double>>, test_class,
+      &RandomValuesTests::check_by_value3<Scalar<double>>, test_class,
       "PyppPyTests", "check_by_value3_class", {{{-10.0, 10.0}}},
       std::make_tuple(a, b, c), scalar_double);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value3_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests", "check_by_value3_class", {{{-10.0, 10.0}}},
+      &RandomValuesTests::check_by_value3<Scalar<DataVector>>, test_class,
+      "PyppPyTests", "check_by_value3_class", {{{-10.0, 10.0}}},
       std::make_tuple(a, b, c), scalar_dv);
 
   // by value, two arguments
@@ -582,13 +532,13 @@ SPECTRE_TEST_CASE("Unit.Pypp.CheckRandomValues", "[Pypp][Unit]") {
       "PyppPyTests", "check_by_value1", {{{-10.0, 10.0}}}, std::make_tuple(),
       dv);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value0_scalar<Scalar<double>>, test_class,
+      &RandomValuesTests::check2_by_value0<Scalar<double>>, test_class,
       "PyppPyTests", "check_by_value1", {{{-10.0, 10.0}}}, std::make_tuple(),
       scalar_double);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value0_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests", "check_by_value1", {{{-10.0, 10.0}}},
-      std::make_tuple(), scalar_dv);
+      &RandomValuesTests::check2_by_value0<Scalar<DataVector>>, test_class,
+      "PyppPyTests", "check_by_value1", {{{-10.0, 10.0}}}, std::make_tuple(),
+      scalar_dv);
   pypp::check_with_random_values<1>(
       &RandomValuesTests::check2_by_value1<double>, test_class, "PyppPyTests",
       "check2_by_value1_class", {{{-10.0, 10.0}}}, std::make_tuple(a), doub);
@@ -597,12 +547,12 @@ SPECTRE_TEST_CASE("Unit.Pypp.CheckRandomValues", "[Pypp][Unit]") {
       "PyppPyTests", "check2_by_value1_class", {{{-10.0, 10.0}}},
       std::make_tuple(a), dv);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value1_scalar<Scalar<double>>, test_class,
+      &RandomValuesTests::check2_by_value1<Scalar<double>>, test_class,
       "PyppPyTests", "check2_by_value1_class", {{{-10.0, 10.0}}},
       std::make_tuple(a), scalar_double);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value1_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests", "check2_by_value1_class", {{{-10.0, 10.0}}},
+      &RandomValuesTests::check2_by_value1<Scalar<DataVector>>, test_class,
+      "PyppPyTests", "check2_by_value1_class", {{{-10.0, 10.0}}},
       std::make_tuple(a), scalar_dv);
   pypp::check_with_random_values<1>(
       &RandomValuesTests::check2_by_value2<double>, test_class, "PyppPyTests",
@@ -612,12 +562,12 @@ SPECTRE_TEST_CASE("Unit.Pypp.CheckRandomValues", "[Pypp][Unit]") {
       "PyppPyTests", "check2_by_value2_class", {{{-10.0, 10.0}}},
       std::make_tuple(a, b), dv);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value2_scalar<Scalar<double>>, test_class,
+      &RandomValuesTests::check2_by_value2<Scalar<double>>, test_class,
       "PyppPyTests", "check2_by_value2_class", {{{-10.0, 10.0}}},
       std::make_tuple(a, b), scalar_double);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value2_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests", "check2_by_value2_class", {{{-10.0, 10.0}}},
+      &RandomValuesTests::check2_by_value2<Scalar<DataVector>>, test_class,
+      "PyppPyTests", "check2_by_value2_class", {{{-10.0, 10.0}}},
       std::make_tuple(a, b), scalar_dv);
   pypp::check_with_random_values<1>(
       &RandomValuesTests::check2_by_value3<double>, test_class, "PyppPyTests",
@@ -628,12 +578,12 @@ SPECTRE_TEST_CASE("Unit.Pypp.CheckRandomValues", "[Pypp][Unit]") {
       "PyppPyTests", "check2_by_value3_class", {{{-10.0, 10.0}}},
       std::make_tuple(a, b, c), dv);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value3_scalar<Scalar<double>>, test_class,
+      &RandomValuesTests::check2_by_value3<Scalar<double>>, test_class,
       "PyppPyTests", "check2_by_value3_class", {{{-10.0, 10.0}}},
       std::make_tuple(a, b, c), scalar_double);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value3_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests", "check2_by_value3_class", {{{-10.0, 10.0}}},
+      &RandomValuesTests::check2_by_value3<Scalar<DataVector>>, test_class,
+      "PyppPyTests", "check2_by_value3_class", {{{-10.0, 10.0}}},
       std::make_tuple(a, b, c), scalar_dv);
 
   // Single not_null, single argument
@@ -646,13 +596,13 @@ SPECTRE_TEST_CASE("Unit.Pypp.CheckRandomValues", "[Pypp][Unit]") {
       "PyppPyTests", {"check_by_value0"}, {{{-10.0, 10.0}}}, std::make_tuple(),
       dv);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null0_scalar<Scalar<double>>, test_class,
+      &RandomValuesTests::check_by_not_null0<Scalar<double>>, test_class,
       "PyppPyTests", {"check_by_value0"}, {{{-10.0, 10.0}}}, std::make_tuple(),
       scalar_double);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null0_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests", {"check_by_value0"}, {{{-10.0, 10.0}}},
-      std::make_tuple(), scalar_dv);
+      &RandomValuesTests::check_by_not_null0<Scalar<DataVector>>, test_class,
+      "PyppPyTests", {"check_by_value0"}, {{{-10.0, 10.0}}}, std::make_tuple(),
+      scalar_dv);
   pypp::check_with_random_values<1>(
       &RandomValuesTests::check_by_not_null1<double>, test_class, "PyppPyTests",
       {"check_by_value1_class"}, {{{-10.0, 10.0}}}, std::make_tuple(a), doub);
@@ -661,12 +611,12 @@ SPECTRE_TEST_CASE("Unit.Pypp.CheckRandomValues", "[Pypp][Unit]") {
       "PyppPyTests", {"check_by_value1_class"}, {{{-10.0, 10.0}}},
       std::make_tuple(a), dv);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null1_scalar<Scalar<double>>, test_class,
+      &RandomValuesTests::check_by_not_null1<Scalar<double>>, test_class,
       "PyppPyTests", {"check_by_value1_class"}, {{{-10.0, 10.0}}},
       std::make_tuple(a), scalar_double);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null1_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests", {"check_by_value1_class"}, {{{-10.0, 10.0}}},
+      &RandomValuesTests::check_by_not_null1<Scalar<DataVector>>, test_class,
+      "PyppPyTests", {"check_by_value1_class"}, {{{-10.0, 10.0}}},
       std::make_tuple(a), scalar_dv);
   pypp::check_with_random_values<1>(
       &RandomValuesTests::check_by_not_null2<double>, test_class, "PyppPyTests",
@@ -677,12 +627,12 @@ SPECTRE_TEST_CASE("Unit.Pypp.CheckRandomValues", "[Pypp][Unit]") {
       "PyppPyTests", {"check_by_value2_class"}, {{{-10.0, 10.0}}},
       std::make_tuple(a, b), dv);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null2_scalar<Scalar<double>>, test_class,
+      &RandomValuesTests::check_by_not_null2<Scalar<double>>, test_class,
       "PyppPyTests", {"check_by_value2_class"}, {{{-10.0, 10.0}}},
       std::make_tuple(a, b), scalar_double);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null2_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests", {"check_by_value2_class"}, {{{-10.0, 10.0}}},
+      &RandomValuesTests::check_by_not_null2<Scalar<DataVector>>, test_class,
+      "PyppPyTests", {"check_by_value2_class"}, {{{-10.0, 10.0}}},
       std::make_tuple(a, b), scalar_dv);
   pypp::check_with_random_values<1>(
       &RandomValuesTests::check_by_not_null3<double>, test_class, "PyppPyTests",
@@ -693,12 +643,12 @@ SPECTRE_TEST_CASE("Unit.Pypp.CheckRandomValues", "[Pypp][Unit]") {
       "PyppPyTests", {"check_by_value3_class"}, {{{-10.0, 10.0}}},
       std::make_tuple(a, b, c), dv);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null3_scalar<Scalar<double>>, test_class,
+      &RandomValuesTests::check_by_not_null3<Scalar<double>>, test_class,
       "PyppPyTests", {"check_by_value3_class"}, {{{-10.0, 10.0}}},
       std::make_tuple(a, b, c), scalar_double);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null3_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests", {"check_by_value3_class"}, {{{-10.0, 10.0}}},
+      &RandomValuesTests::check_by_not_null3<Scalar<DataVector>>, test_class,
+      "PyppPyTests", {"check_by_value3_class"}, {{{-10.0, 10.0}}},
       std::make_tuple(a, b, c), scalar_dv);
 
   // Single not_null, two arguments
@@ -711,12 +661,12 @@ SPECTRE_TEST_CASE("Unit.Pypp.CheckRandomValues", "[Pypp][Unit]") {
       {"PyppPyTests"}, {"check_by_value1"}, {{{-10.0, 10.0}}},
       std::make_tuple(), dv);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null0_scalar<Scalar<double>>,
-      test_class, {"PyppPyTests"}, {"check_by_value1"}, {{{-10.0, 10.0}}},
+      &RandomValuesTests::check2_by_not_null0<Scalar<double>>, test_class,
+      {"PyppPyTests"}, {"check_by_value1"}, {{{-10.0, 10.0}}},
       std::make_tuple(), scalar_double);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null0_scalar<Scalar<DataVector>>,
-      test_class, {"PyppPyTests"}, {"check_by_value1"}, {{{-10.0, 10.0}}},
+      &RandomValuesTests::check2_by_not_null0<Scalar<DataVector>>, test_class,
+      {"PyppPyTests"}, {"check_by_value1"}, {{{-10.0, 10.0}}},
       std::make_tuple(), scalar_dv);
   pypp::check_with_random_values<1>(
       &RandomValuesTests::check2_by_not_null1<double>, test_class,
@@ -727,13 +677,13 @@ SPECTRE_TEST_CASE("Unit.Pypp.CheckRandomValues", "[Pypp][Unit]") {
       {"PyppPyTests"}, {"check2_by_value1_class"}, {{{-10.0, 10.0}}},
       std::make_tuple(a), dv);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null1_scalar<Scalar<double>>,
-      test_class, {"PyppPyTests"}, {"check2_by_value1_class"},
-      {{{-10.0, 10.0}}}, std::make_tuple(a), scalar_double);
+      &RandomValuesTests::check2_by_not_null1<Scalar<double>>, test_class,
+      {"PyppPyTests"}, {"check2_by_value1_class"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a), scalar_double);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null1_scalar<Scalar<DataVector>>,
-      test_class, {"PyppPyTests"}, {"check2_by_value1_class"},
-      {{{-10.0, 10.0}}}, std::make_tuple(a), scalar_dv);
+      &RandomValuesTests::check2_by_not_null1<Scalar<DataVector>>, test_class,
+      {"PyppPyTests"}, {"check2_by_value1_class"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a), scalar_dv);
   pypp::check_with_random_values<1>(
       &RandomValuesTests::check2_by_not_null2<double>, test_class,
       {"PyppPyTests"}, {"check2_by_value2_class"}, {{{-10.0, 10.0}}},
@@ -743,12 +693,12 @@ SPECTRE_TEST_CASE("Unit.Pypp.CheckRandomValues", "[Pypp][Unit]") {
       {"PyppPyTests"}, {"check2_by_value2_class"}, {{{-10.0, 10.0}}},
       std::make_tuple(a, b), dv);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null2_scalar<Scalar<double>>,
-      test_class, {"PyppPyTests"}, {"check2_by_value2_class"},
-      {{{-10.0, 10.0}}}, std::make_tuple(a, b), scalar_double);
+      &RandomValuesTests::check2_by_not_null2<Scalar<double>>, test_class,
+      {"PyppPyTests"}, {"check2_by_value2_class"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a, b), scalar_double);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null2_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests", {"check2_by_value2_class"}, {{{-10.0, 10.0}}},
+      &RandomValuesTests::check2_by_not_null2<Scalar<DataVector>>, test_class,
+      "PyppPyTests", {"check2_by_value2_class"}, {{{-10.0, 10.0}}},
       std::make_tuple(a, b), scalar_dv);
   pypp::check_with_random_values<1>(
       &RandomValuesTests::check2_by_not_null3<double>, test_class,
@@ -759,12 +709,12 @@ SPECTRE_TEST_CASE("Unit.Pypp.CheckRandomValues", "[Pypp][Unit]") {
       {"PyppPyTests"}, {"check2_by_value3_class"}, {{{-10.0, 10.0}}},
       std::make_tuple(a, b, c), dv);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null3_scalar<Scalar<double>>,
-      test_class, {"PyppPyTests"}, {"check2_by_value3_class"},
-      {{{-10.0, 10.0}}}, std::make_tuple(a, b, c), scalar_double);
+      &RandomValuesTests::check2_by_not_null3<Scalar<double>>, test_class,
+      {"PyppPyTests"}, {"check2_by_value3_class"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a, b, c), scalar_double);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null3_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests", {"check2_by_value3_class"}, {{{-10.0, 10.0}}},
+      &RandomValuesTests::check2_by_not_null3<Scalar<DataVector>>, test_class,
+      "PyppPyTests", {"check2_by_value3_class"}, {{{-10.0, 10.0}}},
       std::make_tuple(a, b, c), scalar_dv);
 
   // Double not_null, two arguments
@@ -779,13 +729,13 @@ SPECTRE_TEST_CASE("Unit.Pypp.CheckRandomValues", "[Pypp][Unit]") {
       {"check_double_not_null1_result0", "check_double_not_null1_result1"},
       {{{-10.0, 10.0}}}, std::make_tuple(), dv);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null0_scalar<Scalar<double>>,
-      test_class, {"PyppPyTests"},
+      &RandomValuesTests::check3_by_not_null0<Scalar<double>>, test_class,
+      {"PyppPyTests"},
       {"check_double_not_null1_result0", "check_double_not_null1_result1"},
       {{{-10.0, 10.0}}}, std::make_tuple(), scalar_double);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null0_scalar<Scalar<DataVector>>,
-      test_class, {"PyppPyTests"},
+      &RandomValuesTests::check3_by_not_null0<Scalar<DataVector>>, test_class,
+      {"PyppPyTests"},
       {"check_double_not_null1_result0", "check_double_not_null1_result1"},
       {{{-10.0, 10.0}}}, std::make_tuple(), scalar_dv);
   pypp::check_with_random_values<1>(
@@ -797,15 +747,13 @@ SPECTRE_TEST_CASE("Unit.Pypp.CheckRandomValues", "[Pypp][Unit]") {
       {"PyppPyTests"}, {"check2_by_value1_class", "check2_by_value1_class1"},
       {{{-10.0, 10.0}}}, std::make_tuple(a), dv);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null1_scalar<Scalar<double>>,
-      test_class, {"PyppPyTests"},
-      {"check2_by_value1_class", "check2_by_value1_class1"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a), scalar_double);
+      &RandomValuesTests::check3_by_not_null1<Scalar<double>>, test_class,
+      {"PyppPyTests"}, {"check2_by_value1_class", "check2_by_value1_class1"},
+      {{{-10.0, 10.0}}}, std::make_tuple(a), scalar_double);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null1_scalar<Scalar<DataVector>>,
-      test_class, {"PyppPyTests"},
-      {"check2_by_value1_class", "check2_by_value1_class1"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a), scalar_dv);
+      &RandomValuesTests::check3_by_not_null1<Scalar<DataVector>>, test_class,
+      {"PyppPyTests"}, {"check2_by_value1_class", "check2_by_value1_class1"},
+      {{{-10.0, 10.0}}}, std::make_tuple(a), scalar_dv);
   pypp::check_with_random_values<1>(
       &RandomValuesTests::check3_by_not_null2<double>, test_class,
       {"PyppPyTests"}, {"check2_by_value2_class", "check2_by_value2_class1"},
@@ -815,13 +763,11 @@ SPECTRE_TEST_CASE("Unit.Pypp.CheckRandomValues", "[Pypp][Unit]") {
       {"PyppPyTests"}, {"check2_by_value2_class", "check2_by_value2_class1"},
       {{{-10.0, 10.0}}}, std::make_tuple(a, b), dv);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null2_scalar<Scalar<double>>,
-      test_class, {"PyppPyTests"},
-      {"check2_by_value2_class", "check2_by_value2_class1"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), scalar_double);
+      &RandomValuesTests::check3_by_not_null2<Scalar<double>>, test_class,
+      {"PyppPyTests"}, {"check2_by_value2_class", "check2_by_value2_class1"},
+      {{{-10.0, 10.0}}}, std::make_tuple(a, b), scalar_double);
   pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null2_scalar<Scalar<DataVector>>,
-      test_class, "PyppPyTests",
-      {"check2_by_value2_class", "check2_by_value2_class1"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), scalar_dv);
+      &RandomValuesTests::check3_by_not_null2<Scalar<DataVector>>, test_class,
+      "PyppPyTests", {"check2_by_value2_class", "check2_by_value2_class1"},
+      {{{-10.0, 10.0}}}, std::make_tuple(a, b), scalar_dv);
 }

--- a/tests/Unit/Framework/Tests/Test_PyppRandomValues.cpp
+++ b/tests/Unit/Framework/Tests/Test_PyppRandomValues.cpp
@@ -325,6 +325,129 @@ class RandomValuesTests {
   double b_ = 0;
   std::array<double, 3> c_{};
 };
+
+template <typename T>
+void test_free(const T& value) {
+  pypp::check_with_random_values<1>(&check_single_not_null0<T>, "PyppPyTests",
+                                    {"check_single_not_null0"},
+                                    {{{-10.0, 10.0}}}, value);
+  pypp::check_with_random_values<1>(&check_single_not_null1<T>, "PyppPyTests",
+                                    {"check_single_not_null1"},
+                                    {{{-10.0, 10.0}}}, value);
+  pypp::check_with_random_values<2>(&check_single_not_null2<T>, "PyppPyTests",
+                                    {"check_single_not_null2"},
+                                    {{{0.0, 10.0}, {-10.0, 0.0}}}, value);
+
+  pypp::check_with_random_values<1>(
+      &check_double_not_null0<T>, "PyppPyTests",
+      {"check_double_not_null0_result0", "check_double_not_null0_result1"},
+      {{{-10.0, 10.0}}}, value);
+  pypp::check_with_random_values<1>(
+      &check_double_not_null1<T>, "PyppPyTests",
+      {"check_double_not_null1_result0", "check_double_not_null1_result1"},
+      {{{-10.0, 10.0}}}, value);
+  /// [cxx_two_not_null]
+  pypp::check_with_random_values<2>(
+      &check_double_not_null2<T>, "PyppPyTests",
+      {"check_double_not_null2_result0", "check_double_not_null2_result1"},
+      {{{0.0, 10.0}, {-10.0, 0.0}}}, value);
+  /// [cxx_two_not_null]
+
+  pypp::check_with_random_values<1>(&check_by_value0<T>, "PyppPyTests",
+                                    "check_by_value0", {{{-10.0, 10.0}}},
+                                    value);
+  pypp::check_with_random_values<1>(&check_by_value1<T>, "PyppPyTests",
+                                    "check_by_value1", {{{-10.0, 10.0}}},
+                                    value);
+  pypp::check_with_random_values<2>(&check_by_value2<T>, "PyppPyTests",
+                                    "check_by_value2",
+                                    {{{0.0, 10.0}, {-10.0, 0.0}}}, value);
+}
+
+template <typename T>
+void test_member_functions(const T& value) {
+  const double a = 3.1;
+  const double b = 7.24;
+  const std::array<double, 3> c{{4.23, -8.3, 5.4}};
+  const RandomValuesTests test_class{a, b, c};
+
+  // by value, single argument
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_value0<T>, test_class, "PyppPyTests",
+      "check_by_value0", {{{-10.0, 10.0}}}, std::make_tuple(), value);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_value1<T>, test_class, "PyppPyTests",
+      "check_by_value1_class", {{{-10.0, 10.0}}}, std::make_tuple(a), value);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_value2<T>, test_class, "PyppPyTests",
+      "check_by_value2_class", {{{-10.0, 10.0}}}, std::make_tuple(a, b), value);
+  pypp::check_with_random_values<1>(&RandomValuesTests::check_by_value3<T>,
+                                    test_class, "PyppPyTests",
+                                    "check_by_value3_class", {{{-10.0, 10.0}}},
+                                    std::make_tuple(a, b, c), value);
+
+  // by value, two arguments
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_value0<T>, test_class, "PyppPyTests",
+      "check_by_value1", {{{-10.0, 10.0}}}, std::make_tuple(), value);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_value1<T>, test_class, "PyppPyTests",
+      "check2_by_value1_class", {{{-10.0, 10.0}}}, std::make_tuple(a), value);
+  pypp::check_with_random_values<1>(&RandomValuesTests::check2_by_value2<T>,
+                                    test_class, "PyppPyTests",
+                                    "check2_by_value2_class", {{{-10.0, 10.0}}},
+                                    std::make_tuple(a, b), value);
+  pypp::check_with_random_values<1>(&RandomValuesTests::check2_by_value3<T>,
+                                    test_class, "PyppPyTests",
+                                    "check2_by_value3_class", {{{-10.0, 10.0}}},
+                                    std::make_tuple(a, b, c), value);
+
+  // Single not_null, single argument
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_not_null0<T>, test_class, "PyppPyTests"s,
+      {"check_by_value0"s}, {{{-10.0, 10.0}}}, std::make_tuple(), value);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_not_null1<T>, test_class, "PyppPyTests",
+      {"check_by_value1_class"}, {{{-10.0, 10.0}}}, std::make_tuple(a), value);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_not_null2<T>, test_class, "PyppPyTests",
+      {"check_by_value2_class"}, {{{-10.0, 10.0}}}, std::make_tuple(a, b),
+      value);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check_by_not_null3<T>, test_class, "PyppPyTests",
+      {"check_by_value3_class"}, {{{-10.0, 10.0}}}, std::make_tuple(a, b, c),
+      value);
+
+  // Single not_null, two arguments
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_not_null0<T>, test_class, "PyppPyTests",
+      {"check_by_value1"}, {{{-10.0, 10.0}}}, std::make_tuple(), value);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_not_null1<T>, test_class, {"PyppPyTests"},
+      {"check2_by_value1_class"}, {{{-10.0, 10.0}}}, std::make_tuple(a), value);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_not_null2<T>, test_class, {"PyppPyTests"},
+      {"check2_by_value2_class"}, {{{-10.0, 10.0}}}, std::make_tuple(a, b),
+      value);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check2_by_not_null3<T>, test_class, {"PyppPyTests"},
+      {"check2_by_value3_class"}, {{{-10.0, 10.0}}}, std::make_tuple(a, b, c),
+      value);
+
+  // Double not_null, two arguments
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check3_by_not_null0<T>, test_class, "PyppPyTests",
+      {"check_double_not_null1_result0", "check_double_not_null1_result1"},
+      {{{-10.0, 10.0}}}, std::make_tuple(), value);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check3_by_not_null1<T>, test_class, {"PyppPyTests"},
+      {"check2_by_value1_class", "check2_by_value1_class1"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a), value);
+  pypp::check_with_random_values<1>(
+      &RandomValuesTests::check3_by_not_null2<T>, test_class, {"PyppPyTests"},
+      {"check2_by_value2_class", "check2_by_value2_class1"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a, b), value);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Pypp.CheckRandomValues", "[Pypp][Unit]") {
@@ -334,440 +457,14 @@ SPECTRE_TEST_CASE("Unit.Pypp.CheckRandomValues", "[Pypp][Unit]") {
   const double doub(0.);
   const Scalar<double> scalar_double{5.0};
   const Scalar<DataVector> scalar_dv{size};
-  pypp::check_with_random_values<1>(&check_single_not_null0<double>,
-                                    "PyppPyTests", {"check_single_not_null0"},
-                                    {{{-10.0, 10.0}}}, doub);
-  pypp::check_with_random_values<1>(&check_single_not_null0<DataVector>,
-                                    "PyppPyTests", {"check_single_not_null0"},
-                                    {{{-10.0, 10.0}}}, dv);
-  pypp::check_with_random_values<1>(&check_single_not_null1<double>,
-                                    "PyppPyTests", {"check_single_not_null1"},
-                                    {{{-10.0, 10.0}}}, doub);
-  pypp::check_with_random_values<1>(&check_single_not_null1<DataVector>,
-                                    "PyppPyTests", {"check_single_not_null1"},
-                                    {{{-10.0, 10.0}}}, dv);
-  pypp::check_with_random_values<2>(&check_single_not_null2<double>,
-                                    "PyppPyTests", {"check_single_not_null2"},
-                                    {{{0.0, 10.0}, {-10.0, 0.0}}}, doub);
-  pypp::check_with_random_values<2>(&check_single_not_null2<DataVector>,
-                                    "PyppPyTests", {"check_single_not_null2"},
-                                    {{{0.0, 10.0}, {-10.0, 0.0}}}, dv);
-  pypp::check_with_random_values<1>(&check_single_not_null0<Scalar<double>>,
-                                    "PyppPyTests", {"check_single_not_null0"},
-                                    {{{-10.0, 10.0}}}, scalar_double);
-  pypp::check_with_random_values<1>(&check_single_not_null0<Scalar<DataVector>>,
-                                    "PyppPyTests", {"check_single_not_null0"},
-                                    {{{-10.0, 10.0}}}, scalar_dv);
-  pypp::check_with_random_values<1>(&check_single_not_null1<Scalar<double>>,
-                                    "PyppPyTests", {"check_single_not_null1"},
-                                    {{{-10.0, 10.0}}}, scalar_double);
-  pypp::check_with_random_values<1>(&check_single_not_null1<Scalar<DataVector>>,
-                                    "PyppPyTests", {"check_single_not_null1"},
-                                    {{{-10.0, 10.0}}}, scalar_dv);
-  pypp::check_with_random_values<2>(
-      &check_single_not_null2<Scalar<double>>, "PyppPyTests",
-      {"check_single_not_null2"}, {{{0.0, 10.0}, {-10.0, 0.0}}}, scalar_double);
-  pypp::check_with_random_values<2>(&check_single_not_null2<Scalar<DataVector>>,
-                                    "PyppPyTests", {"check_single_not_null2"},
-                                    {{{0.0, 10.0}, {-10.0, 0.0}}}, scalar_dv);
-
-  pypp::check_with_random_values<1>(
-      &check_double_not_null0<double>, "PyppPyTests",
-      {"check_double_not_null0_result0", "check_double_not_null0_result1"},
-      {{{-10.0, 10.0}}}, doub);
-  pypp::check_with_random_values<1>(
-      &check_double_not_null0<DataVector>, "PyppPyTests",
-      {"check_double_not_null0_result0", "check_double_not_null0_result1"},
-      {{{-10.0, 10.0}}}, dv);
-  pypp::check_with_random_values<1>(
-      &check_double_not_null1<double>, "PyppPyTests",
-      {"check_double_not_null1_result0", "check_double_not_null1_result1"},
-      {{{-10.0, 10.0}}}, doub);
-  pypp::check_with_random_values<1>(
-      &check_double_not_null1<DataVector>, "PyppPyTests",
-      {"check_double_not_null1_result0", "check_double_not_null1_result1"},
-      {{{-10.0, 10.0}}}, dv);
-  pypp::check_with_random_values<2>(
-      &check_double_not_null2<double>, "PyppPyTests",
-      {"check_double_not_null2_result0", "check_double_not_null2_result1"},
-      {{{0.0, 10.0}, {-10.0, 0.0}}}, doub);
-  pypp::check_with_random_values<2>(
-      &check_double_not_null2<DataVector>, "PyppPyTests",
-      {"check_double_not_null2_result0", "check_double_not_null2_result1"},
-      {{{0.0, 10.0}, {-10.0, 0.0}}}, dv);
-  pypp::check_with_random_values<1>(
-      &check_double_not_null0<Scalar<double>>, "PyppPyTests",
-      {"check_double_not_null0_result0", "check_double_not_null0_result1"},
-      {{{-10.0, 10.0}}}, scalar_double);
-  pypp::check_with_random_values<1>(
-      &check_double_not_null0<Scalar<DataVector>>, "PyppPyTests",
-      {"check_double_not_null0_result0", "check_double_not_null0_result1"},
-      {{{-10.0, 10.0}}}, scalar_dv);
-  pypp::check_with_random_values<1>(
-      &check_double_not_null1<Scalar<double>>, "PyppPyTests",
-      {"check_double_not_null1_result0", "check_double_not_null1_result1"},
-      {{{-10.0, 10.0}}}, scalar_double);
-  pypp::check_with_random_values<1>(
-      &check_double_not_null1<Scalar<DataVector>>, "PyppPyTests",
-      {"check_double_not_null1_result0", "check_double_not_null1_result1"},
-      {{{-10.0, 10.0}}}, scalar_dv);
-  pypp::check_with_random_values<2>(
-      &check_double_not_null2<Scalar<double>>, "PyppPyTests",
-      {"check_double_not_null2_result0", "check_double_not_null2_result1"},
-      {{{0.0, 10.0}, {-10.0, 0.0}}}, scalar_double);
-  /// [cxx_two_not_null]
-  pypp::check_with_random_values<2>(
-      &check_double_not_null2<Scalar<DataVector>>, "PyppPyTests",
-      {"check_double_not_null2_result0", "check_double_not_null2_result1"},
-      {{{0.0, 10.0}, {-10.0, 0.0}}}, scalar_dv);
-  /// [cxx_two_not_null]
-
-  pypp::check_with_random_values<1>(&check_by_value0<double>, "PyppPyTests",
-                                    "check_by_value0", {{{-10.0, 10.0}}}, doub);
-  pypp::check_with_random_values<1>(&check_by_value0<DataVector>, "PyppPyTests",
-                                    "check_by_value0", {{{-10.0, 10.0}}}, dv);
-  pypp::check_with_random_values<1>(&check_by_value1<double>, "PyppPyTests",
-                                    "check_by_value1", {{{-10.0, 10.0}}}, doub);
-  pypp::check_with_random_values<1>(&check_by_value1<DataVector>, "PyppPyTests",
-                                    "check_by_value1", {{{-10.0, 10.0}}}, dv);
-  pypp::check_with_random_values<2>(&check_by_value2<double>, "PyppPyTests",
-                                    "check_by_value2",
-                                    {{{0.0, 10.0}, {-10.0, 0.0}}}, doub);
-  pypp::check_with_random_values<2>(&check_by_value2<DataVector>, "PyppPyTests",
-                                    "check_by_value2",
-                                    {{{0.0, 10.0}, {-10.0, 0.0}}}, dv);
-  pypp::check_with_random_values<1>(&check_by_value0<Scalar<double>>,
-                                    "PyppPyTests", "check_by_value0",
-                                    {{{-10.0, 10.0}}}, scalar_double);
-  pypp::check_with_random_values<1>(&check_by_value0<Scalar<DataVector>>,
-                                    "PyppPyTests", "check_by_value0",
-                                    {{{-10.0, 10.0}}}, scalar_dv);
-  pypp::check_with_random_values<1>(&check_by_value1<Scalar<double>>,
-                                    "PyppPyTests", "check_by_value1",
-                                    {{{-10.0, 10.0}}}, scalar_double);
-  pypp::check_with_random_values<1>(&check_by_value1<Scalar<DataVector>>,
-                                    "PyppPyTests", "check_by_value1",
-                                    {{{-10.0, 10.0}}}, scalar_dv);
-  pypp::check_with_random_values<2>(
-      &check_by_value2<Scalar<double>>, "PyppPyTests", "check_by_value2",
-      {{{0.0, 10.0}, {-10.0, 0.0}}}, scalar_double);
-  pypp::check_with_random_values<2>(&check_by_value2<Scalar<DataVector>>,
-                                    "PyppPyTests", "check_by_value2",
-                                    {{{0.0, 10.0}, {-10.0, 0.0}}}, scalar_dv);
+  test_free(doub);
+  test_free(dv);
+  test_free(scalar_double);
+  test_free(scalar_dv);
 
   // Test member functions
-  const double a = 3.1;
-  const double b = 7.24;
-  const std::array<double, 3> c{{4.23, -8.3, 5.4}};
-  const RandomValuesTests test_class{a, b, c};
-  // by value, single argument
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value0<double>, test_class, "PyppPyTests",
-      "check_by_value0", {{{-10.0, 10.0}}}, std::make_tuple(), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value0<DataVector>, test_class,
-      "PyppPyTests", "check_by_value0", {{{-10.0, 10.0}}}, std::make_tuple(),
-      dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value0<Scalar<double>>, test_class,
-      "PyppPyTests", "check_by_value0", {{{-10.0, 10.0}}}, std::make_tuple(),
-      scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value0<Scalar<DataVector>>, test_class,
-      "PyppPyTests", "check_by_value0", {{{-10.0, 10.0}}}, std::make_tuple(),
-      scalar_dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value1<double>, test_class, "PyppPyTests",
-      "check_by_value1_class", {{{-10.0, 10.0}}}, std::make_tuple(a), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value1<DataVector>, test_class,
-      "PyppPyTests", "check_by_value1_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value1<Scalar<double>>, test_class,
-      "PyppPyTests", "check_by_value1_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value1<Scalar<DataVector>>, test_class,
-      "PyppPyTests", "check_by_value1_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a), scalar_dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value2<double>, test_class, "PyppPyTests",
-      "check_by_value2_class", {{{-10.0, 10.0}}}, std::make_tuple(a, b), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value2<DataVector>, test_class,
-      "PyppPyTests", "check_by_value2_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value2<Scalar<double>>, test_class,
-      "PyppPyTests", "check_by_value2_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value2<Scalar<DataVector>>, test_class,
-      "PyppPyTests", "check_by_value2_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), scalar_dv);
-  pypp::check_with_random_values<1>(&RandomValuesTests::check_by_value3<double>,
-                                    test_class, "PyppPyTests",
-                                    "check_by_value3_class", {{{-10.0, 10.0}}},
-                                    std::make_tuple(a, b, c), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value3<DataVector>, test_class,
-      "PyppPyTests", "check_by_value3_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a, b, c), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value3<Scalar<double>>, test_class,
-      "PyppPyTests", "check_by_value3_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a, b, c), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_value3<Scalar<DataVector>>, test_class,
-      "PyppPyTests", "check_by_value3_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a, b, c), scalar_dv);
-
-  // by value, two arguments
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value0<double>, test_class, "PyppPyTests",
-      "check_by_value1", {{{-10.0, 10.0}}}, std::make_tuple(), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value0<DataVector>, test_class,
-      "PyppPyTests", "check_by_value1", {{{-10.0, 10.0}}}, std::make_tuple(),
-      dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value0<Scalar<double>>, test_class,
-      "PyppPyTests", "check_by_value1", {{{-10.0, 10.0}}}, std::make_tuple(),
-      scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value0<Scalar<DataVector>>, test_class,
-      "PyppPyTests", "check_by_value1", {{{-10.0, 10.0}}}, std::make_tuple(),
-      scalar_dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value1<double>, test_class, "PyppPyTests",
-      "check2_by_value1_class", {{{-10.0, 10.0}}}, std::make_tuple(a), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value1<DataVector>, test_class,
-      "PyppPyTests", "check2_by_value1_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value1<Scalar<double>>, test_class,
-      "PyppPyTests", "check2_by_value1_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value1<Scalar<DataVector>>, test_class,
-      "PyppPyTests", "check2_by_value1_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a), scalar_dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value2<double>, test_class, "PyppPyTests",
-      "check2_by_value2_class", {{{-10.0, 10.0}}}, std::make_tuple(a, b), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value2<DataVector>, test_class,
-      "PyppPyTests", "check2_by_value2_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value2<Scalar<double>>, test_class,
-      "PyppPyTests", "check2_by_value2_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value2<Scalar<DataVector>>, test_class,
-      "PyppPyTests", "check2_by_value2_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), scalar_dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value3<double>, test_class, "PyppPyTests",
-      "check2_by_value3_class", {{{-10.0, 10.0}}}, std::make_tuple(a, b, c),
-      doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value3<DataVector>, test_class,
-      "PyppPyTests", "check2_by_value3_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a, b, c), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value3<Scalar<double>>, test_class,
-      "PyppPyTests", "check2_by_value3_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a, b, c), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_value3<Scalar<DataVector>>, test_class,
-      "PyppPyTests", "check2_by_value3_class", {{{-10.0, 10.0}}},
-      std::make_tuple(a, b, c), scalar_dv);
-
-  // Single not_null, single argument
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null0<double>, test_class,
-      "PyppPyTests"s, {"check_by_value0"s}, {{{-10.0, 10.0}}},
-      std::make_tuple(), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null0<DataVector>, test_class,
-      "PyppPyTests", {"check_by_value0"}, {{{-10.0, 10.0}}}, std::make_tuple(),
-      dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null0<Scalar<double>>, test_class,
-      "PyppPyTests", {"check_by_value0"}, {{{-10.0, 10.0}}}, std::make_tuple(),
-      scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null0<Scalar<DataVector>>, test_class,
-      "PyppPyTests", {"check_by_value0"}, {{{-10.0, 10.0}}}, std::make_tuple(),
-      scalar_dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null1<double>, test_class, "PyppPyTests",
-      {"check_by_value1_class"}, {{{-10.0, 10.0}}}, std::make_tuple(a), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null1<DataVector>, test_class,
-      "PyppPyTests", {"check_by_value1_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null1<Scalar<double>>, test_class,
-      "PyppPyTests", {"check_by_value1_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null1<Scalar<DataVector>>, test_class,
-      "PyppPyTests", {"check_by_value1_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a), scalar_dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null2<double>, test_class, "PyppPyTests",
-      {"check_by_value2_class"}, {{{-10.0, 10.0}}}, std::make_tuple(a, b),
-      doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null2<DataVector>, test_class,
-      "PyppPyTests", {"check_by_value2_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null2<Scalar<double>>, test_class,
-      "PyppPyTests", {"check_by_value2_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null2<Scalar<DataVector>>, test_class,
-      "PyppPyTests", {"check_by_value2_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), scalar_dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null3<double>, test_class, "PyppPyTests",
-      {"check_by_value3_class"}, {{{-10.0, 10.0}}}, std::make_tuple(a, b, c),
-      doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null3<DataVector>, test_class,
-      "PyppPyTests", {"check_by_value3_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b, c), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null3<Scalar<double>>, test_class,
-      "PyppPyTests", {"check_by_value3_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b, c), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check_by_not_null3<Scalar<DataVector>>, test_class,
-      "PyppPyTests", {"check_by_value3_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b, c), scalar_dv);
-
-  // Single not_null, two arguments
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null0<double>, test_class,
-      "PyppPyTests", {"check_by_value1"}, {{{-10.0, 10.0}}}, std::make_tuple(),
-      doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null0<DataVector>, test_class,
-      {"PyppPyTests"}, {"check_by_value1"}, {{{-10.0, 10.0}}},
-      std::make_tuple(), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null0<Scalar<double>>, test_class,
-      {"PyppPyTests"}, {"check_by_value1"}, {{{-10.0, 10.0}}},
-      std::make_tuple(), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null0<Scalar<DataVector>>, test_class,
-      {"PyppPyTests"}, {"check_by_value1"}, {{{-10.0, 10.0}}},
-      std::make_tuple(), scalar_dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null1<double>, test_class,
-      {"PyppPyTests"}, {"check2_by_value1_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null1<DataVector>, test_class,
-      {"PyppPyTests"}, {"check2_by_value1_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null1<Scalar<double>>, test_class,
-      {"PyppPyTests"}, {"check2_by_value1_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null1<Scalar<DataVector>>, test_class,
-      {"PyppPyTests"}, {"check2_by_value1_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a), scalar_dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null2<double>, test_class,
-      {"PyppPyTests"}, {"check2_by_value2_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null2<DataVector>, test_class,
-      {"PyppPyTests"}, {"check2_by_value2_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null2<Scalar<double>>, test_class,
-      {"PyppPyTests"}, {"check2_by_value2_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null2<Scalar<DataVector>>, test_class,
-      "PyppPyTests", {"check2_by_value2_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b), scalar_dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null3<double>, test_class,
-      {"PyppPyTests"}, {"check2_by_value3_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b, c), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null3<DataVector>, test_class,
-      {"PyppPyTests"}, {"check2_by_value3_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b, c), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null3<Scalar<double>>, test_class,
-      {"PyppPyTests"}, {"check2_by_value3_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b, c), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check2_by_not_null3<Scalar<DataVector>>, test_class,
-      "PyppPyTests", {"check2_by_value3_class"}, {{{-10.0, 10.0}}},
-      std::make_tuple(a, b, c), scalar_dv);
-
-  // Double not_null, two arguments
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null0<double>, test_class,
-      "PyppPyTests",
-      {"check_double_not_null1_result0", "check_double_not_null1_result1"},
-      {{{-10.0, 10.0}}}, std::make_tuple(), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null0<DataVector>, test_class,
-      {"PyppPyTests"},
-      {"check_double_not_null1_result0", "check_double_not_null1_result1"},
-      {{{-10.0, 10.0}}}, std::make_tuple(), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null0<Scalar<double>>, test_class,
-      {"PyppPyTests"},
-      {"check_double_not_null1_result0", "check_double_not_null1_result1"},
-      {{{-10.0, 10.0}}}, std::make_tuple(), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null0<Scalar<DataVector>>, test_class,
-      {"PyppPyTests"},
-      {"check_double_not_null1_result0", "check_double_not_null1_result1"},
-      {{{-10.0, 10.0}}}, std::make_tuple(), scalar_dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null1<double>, test_class,
-      {"PyppPyTests"}, {"check2_by_value1_class", "check2_by_value1_class1"},
-      {{{-10.0, 10.0}}}, std::make_tuple(a), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null1<DataVector>, test_class,
-      {"PyppPyTests"}, {"check2_by_value1_class", "check2_by_value1_class1"},
-      {{{-10.0, 10.0}}}, std::make_tuple(a), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null1<Scalar<double>>, test_class,
-      {"PyppPyTests"}, {"check2_by_value1_class", "check2_by_value1_class1"},
-      {{{-10.0, 10.0}}}, std::make_tuple(a), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null1<Scalar<DataVector>>, test_class,
-      {"PyppPyTests"}, {"check2_by_value1_class", "check2_by_value1_class1"},
-      {{{-10.0, 10.0}}}, std::make_tuple(a), scalar_dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null2<double>, test_class,
-      {"PyppPyTests"}, {"check2_by_value2_class", "check2_by_value2_class1"},
-      {{{-10.0, 10.0}}}, std::make_tuple(a, b), doub);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null2<DataVector>, test_class,
-      {"PyppPyTests"}, {"check2_by_value2_class", "check2_by_value2_class1"},
-      {{{-10.0, 10.0}}}, std::make_tuple(a, b), dv);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null2<Scalar<double>>, test_class,
-      {"PyppPyTests"}, {"check2_by_value2_class", "check2_by_value2_class1"},
-      {{{-10.0, 10.0}}}, std::make_tuple(a, b), scalar_double);
-  pypp::check_with_random_values<1>(
-      &RandomValuesTests::check3_by_not_null2<Scalar<DataVector>>, test_class,
-      "PyppPyTests", {"check2_by_value2_class", "check2_by_value2_class1"},
-      {{{-10.0, 10.0}}}, std::make_tuple(a, b), scalar_dv);
+  test_member_functions(doub);
+  test_member_functions(dv);
+  test_member_functions(scalar_double);
+  test_member_functions(scalar_dv);
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticData/Burgers/Test_Sinusoid.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/Burgers/Test_Sinusoid.cpp
@@ -38,7 +38,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticData.Burgers.Sinusoid",
   test_move_semantics(Burgers::AnalyticData::Sinusoid{},
                       Burgers::AnalyticData::Sinusoid{});
 
-  pypp::check_with_random_values<1, tmpl::list<Burgers::Tags::U>>(
+  pypp::check_with_random_values<1>(
       &BurgersSinusoidProxy::variables, BurgersSinusoidProxy{},
       "PointwiseFunctions.AnalyticData.Burgers.Sinusoid", {"u_variable"},
       {{{0.0, M_PI}}}, {}, DataVector(5));

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_BondiHoyleAccretion.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_BondiHoyleAccretion.cpp
@@ -100,16 +100,14 @@ void test_variables(const DataType& used_for_size) {
       bh_mass, bh_dimless_spin, rest_mass_density, flow_speed,
       mag_field_strength, polytropic_constant, polytropic_exponent);
 
-  pypp::check_with_random_values<
-      1, BondiHoyleAccretionProxy::hydro_variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &BondiHoyleAccretionProxy::hydro_variables<DataType>, accretion,
       "PointwiseFunctions.AnalyticData.GrMhd.BondiHoyleAccretion",
       {"rest_mass_density", "spatial_velocity", "specific_internal_energy",
        "pressure", "lorentz_factor", "specific_enthalpy"},
       {{{-10., 10.}}}, member_variables, used_for_size);
 
-  pypp::check_with_random_values<
-      1, BondiHoyleAccretionProxy::grmhd_variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &BondiHoyleAccretionProxy::grmhd_variables<DataType>, accretion,
       "PointwiseFunctions.AnalyticData.GrMhd.BondiHoyleAccretion",
       {"rest_mass_density", "spatial_velocity", "specific_internal_energy",

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_CylindricalBlastWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_CylindricalBlastWave.cpp
@@ -117,16 +117,14 @@ void test_variables(const DataType& used_for_size) noexcept {
   // Note: I select random numbers in the range {{-1.1, 1.1}} so that
   // sometimes the random points are in the transition region and sometimes
   // in the fixed region.
-  pypp::check_with_random_values<
-      1, CylindricalBlastWaveProxy::hydro_variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &CylindricalBlastWaveProxy::hydro_variables<DataType>,
       cylindrical_blast_wave, "CylindricalBlastWave",
       {"rest_mass_density", "spatial_velocity", "specific_internal_energy",
        "pressure", "lorentz_factor", "specific_enthalpy"},
       {{{-1.1, 1.1}}}, member_variables, used_for_size);
 
-  pypp::check_with_random_values<
-      1, CylindricalBlastWaveProxy::grmhd_variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &CylindricalBlastWaveProxy::grmhd_variables<DataType>,
       cylindrical_blast_wave, "CylindricalBlastWave",
       {"rest_mass_density", "spatial_velocity", "specific_internal_energy",

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagneticFieldLoop.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagneticFieldLoop.cpp
@@ -112,8 +112,7 @@ void test_variables(const DataType& used_for_size) noexcept {
       pressure, rest_mass_density, adiabatic_index, advection_velocity,
       magnetic_field_magnitude, inner_radius, outer_radius);
 
-  pypp::check_with_random_values<
-      1, MagneticFieldLoopProxy::hydro_variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &MagneticFieldLoopProxy::hydro_variables<DataType>, magnetic_field_loop,
       "MagneticFieldLoop",
       {"compute_rest_mass_density", "spatial_velocity",
@@ -121,8 +120,7 @@ void test_variables(const DataType& used_for_size) noexcept {
        "specific_enthalpy"},
       {{{-1.0, 1.0}}}, member_variables, used_for_size);
 
-  pypp::check_with_random_values<
-      1, MagneticFieldLoopProxy::grmhd_variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &MagneticFieldLoopProxy::grmhd_variables<DataType>, magnetic_field_loop,
       "MagneticFieldLoop",
       {"compute_rest_mass_density", "spatial_velocity",

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagneticRotor.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagneticRotor.cpp
@@ -110,16 +110,14 @@ void test_variables(const DataType& used_for_size) noexcept {
       rotor_radius, rotor_density, background_density, pressure,
       angular_velocity, magnetic_field, adiabatic_index);
 
-  pypp::check_with_random_values<
-      1, MagneticRotorProxy::hydro_variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &MagneticRotorProxy::hydro_variables<DataType>, magnetic_rotor,
       "MagneticRotor",
       {"rest_mass_density", "spatial_velocity", "specific_internal_energy",
        "compute_pressure", "lorentz_factor", "specific_enthalpy"},
       {{{-1.0, 1.0}}}, member_variables, used_for_size);
 
-  pypp::check_with_random_values<
-      1, MagneticRotorProxy::grmhd_variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &MagneticRotorProxy::grmhd_variables<DataType>, magnetic_rotor,
       "MagneticRotor",
       {"rest_mass_density", "spatial_velocity", "specific_internal_energy",

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagnetizedFmDisk.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagnetizedFmDisk.cpp
@@ -115,8 +115,7 @@ void test_variables(const DataType& used_for_size) {
       polytropic_constant, polytropic_exponent, threshold_density,
       inverse_plasma_beta);
 
-  pypp::check_with_random_values<
-      1, MagnetizedFmDiskProxy::grmhd_variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &MagnetizedFmDiskProxy::grmhd_variables<DataType>, disk,
       "PointwiseFunctions.AnalyticData.GrMhd.MagnetizedFmDisk",
       {"rest_mass_density", "spatial_velocity", "specific_internal_energy",
@@ -155,8 +154,7 @@ void test_variables(const DataType& used_for_size) {
       bh_mass, bh_dimless_spin, inner_edge_radius, max_pressure_radius,
       polytropic_constant, polytropic_exponent, threshold_density, 0.0, 4);
 
-  pypp::check_with_random_values<
-      1, MagnetizedFmDiskProxy::hydro_variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &MagnetizedFmDiskProxy::hydro_variables<DataType>, another_disk,
       "PointwiseFunctions.AnalyticData.GrMhd.MagnetizedFmDisk",
       {"rest_mass_density", "spatial_velocity", "specific_internal_energy",

--- a/tests/Unit/PointwiseFunctions/AnalyticData/NewtonianEuler/Test_KhInstability.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/NewtonianEuler/Test_KhInstability.cpp
@@ -62,8 +62,7 @@ void test_analytic_data(const DataType& used_for_size) noexcept {
       adiabatic_index, strip_bimedian_height, strip_thickness, strip_density,
       strip_velocity, background_density, background_velocity, pressure,
       perturbation_amplitude, perturbation_width);
-  pypp::check_with_random_values<
-      1, typename KhInstabilityProxy<Dim>::template variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &KhInstabilityProxy<Dim>::template primitive_variables<DataType>, kh_inst,
       "KhInstability",
       {"mass_density", "velocity", "specific_internal_energy", "pressure"},
@@ -90,8 +89,7 @@ void test_analytic_data(const DataType& used_for_size) noexcept {
   test_move_semantics(std::move(kh_inst_to_move), kh_inst);  //  NOLINT
 
   // run post-serialized state through checks with random numbers
-  pypp::check_with_random_values<
-      1, typename KhInstabilityProxy<Dim>::template variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &KhInstabilityProxy<Dim>::template primitive_variables<DataType>,
       serialize_and_deserialize(kh_inst), "KhInstability",
       {"mass_density", "velocity", "specific_internal_energy", "pressure"},

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_BentBeam.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_BentBeam.cpp
@@ -110,19 +110,16 @@ SPECTRE_TEST_CASE(
   CHECK_VARIABLES_APPROX(solution_vars, expected_vars);
   CHECK(solution.potential_energy() == approx(0.075));
 
-  pypp::check_with_random_values<
-      1, tmpl::list<Elasticity::Tags::Displacement<2>,
-                    Elasticity::Tags::Strain<2>, Elasticity::Tags::Stress<2>>>(
+  pypp::check_with_random_values<1>(
       &BentBeamProxy::field_variables, solution,
       "AnalyticSolutions.Elasticity.BentBeam",
       {"displacement", "strain", "stress"}, {{{-5., 5.}}},
       std::make_tuple(5., 1., 0.5, 79.36507936507935, 38.75968992248062),
       DataVector(5));
-  pypp::check_with_random_values<
-      1, tmpl::list<Tags::FixedSource<Elasticity::Tags::Displacement<2>>>>(
-      &BentBeamProxy::source_variables, solution,
-      "AnalyticSolutions.Elasticity.BentBeam", {"source"}, {{{-5., 5.}}},
-      std::make_tuple(), DataVector(5));
+  pypp::check_with_random_values<1>(&BentBeamProxy::source_variables, solution,
+                                    "AnalyticSolutions.Elasticity.BentBeam",
+                                    {"source"}, {{{-5., 5.}}},
+                                    std::make_tuple(), DataVector(5));
 
   using AffineMap = domain::CoordinateMaps::Affine;
   using AffineMap2D =

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_HalfSpaceMirror.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_HalfSpaceMirror.cpp
@@ -83,16 +83,13 @@ SPECTRE_TEST_CASE(
       constitutive_relation{36.36363636363637, 30.76923076923077};
   const HalfSpaceMirrorProxy solution{0.177, constitutive_relation, 350, 1e-11,
                                       1e-11};
-  pypp::check_with_random_values<1,
-                                 tmpl::list<Elasticity::Tags::Displacement<dim>,
-                                            Elasticity::Tags::Strain<dim>>>(
+  pypp::check_with_random_values<1>(
       &HalfSpaceMirrorProxy::field_variables, solution,
       "AnalyticSolutions.Elasticity.HalfSpaceMirror",
       {"displacement", "strain"}, {{{0., 3.}}},
       std::make_tuple(0.177, 36.36363636363637, 30.76923076923077),
       DataVector(5), 1e-10);
-  pypp::check_with_random_values<
-      1, tmpl::list<Tags::FixedSource<Elasticity::Tags::Displacement<dim>>>>(
+  pypp::check_with_random_values<1>(
       &HalfSpaceMirrorProxy::source_variables, solution,
       "AnalyticSolutions.Elasticity.HalfSpaceMirror", {"source"}, {{{0., 3.}}},
       std::make_tuple(), DataVector(5), 1e-10);

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_GaugeWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_GaugeWave.cpp
@@ -200,8 +200,7 @@ void test_gauge_wave(const gr::Solutions::GaugeWave<Dim>& solution,
   // Check with random values
   pypp::SetupLocalPythonEnvironment local_python_env{
       "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/"};
-  pypp::check_with_random_values<
-      1, typename GaugeWaveProxy<Dim>::template variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &GaugeWaveProxy<Dim>::template test_variables<DataType>,
       GaugeWaveProxy<Dim>(amplitude, wavelength), "GaugeWave",
       {"gauge_wave_lapse", "gauge_wave_dt_lapse", "gauge_wave_d_lapse",

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_AlfvenWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_AlfvenWave.cpp
@@ -109,8 +109,7 @@ void test_variables(const DataType& used_for_size) {
        0.7 * cos(M_PI_4 + M_PI_2) * sin(0.5 * M_PI_4),
        0.7 * sin(M_PI_4 + M_PI_2)}};
 
-  pypp::check_with_random_values<
-      1, AlfvenWaveProxy::hydro_variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &AlfvenWaveProxy::hydro_variables<DataType>,
       AlfvenWaveProxy(wavenumber, pressure, rest_mass_density, adiabatic_index,
                       bkgd_magnetic_field, wave_magnetic_field),
@@ -123,8 +122,7 @@ void test_variables(const DataType& used_for_size) {
                       bkgd_magnetic_field, wave_magnetic_field),
       used_for_size);
 
-  pypp::check_with_random_values<
-      1, AlfvenWaveProxy::grmhd_variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &AlfvenWaveProxy::grmhd_variables<DataType>,
       AlfvenWaveProxy(wavenumber, pressure, rest_mass_density, adiabatic_index,
                       bkgd_magnetic_field, wave_magnetic_field),

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_BondiMichel.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_BondiMichel.cpp
@@ -92,8 +92,7 @@ void test_variables(const DataType& used_for_size) {
   const double polytropic_exponent = 4. / 3.;
   const double mag_field_strength = 2.3;
 
-  pypp::check_with_random_values<
-      1, BondiMichelProxy::hydro_variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &BondiMichelProxy::hydro_variables<DataType>,
       BondiMichelProxy(mass, sonic_radius, sonic_density, polytropic_exponent,
                        mag_field_strength),
@@ -106,8 +105,7 @@ void test_variables(const DataType& used_for_size) {
                       mag_field_strength),
       used_for_size);
 
-  pypp::check_with_random_values<
-      1, BondiMichelProxy::grmhd_variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &BondiMichelProxy::grmhd_variables<DataType>,
       BondiMichelProxy(mass, sonic_radius, sonic_density, polytropic_exponent,
                        mag_field_strength),

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_KomissarovShock.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_KomissarovShock.cpp
@@ -174,16 +174,14 @@ void test_variables(const DataType& used_for_size) noexcept {
       std::array<double, 3>{{10., 18.28, 0.}},
       std::array<double, 3>{{10., 14.49, 0.}}, 0.5);
 
-  pypp::check_with_random_values<
-      1, KomissarovShockProxy::hydro_variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &KomissarovShockProxy::hydro_variables<DataType>, komissarov_shock,
       "KomissarovShock",
       {"rest_mass_density", "spatial_velocity", "specific_internal_energy",
        "pressure", "lorentz_factor", "specific_enthalpy"},
       {{{-1., 1.}}}, member_variables, used_for_size);
 
-  pypp::check_with_random_values<
-      1, KomissarovShockProxy::grmhd_variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &KomissarovShockProxy::grmhd_variables<DataType>, komissarov_shock,
       "KomissarovShock",
       {"rest_mass_density", "spatial_velocity", "specific_internal_energy",

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_SmoothFlow.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_SmoothFlow.cpp
@@ -101,8 +101,7 @@ void test_variables(const DataType& used_for_size) {
   const double adiabatic_index = 4. / 3.;
   const double perturbation_size = 0.78;
 
-  pypp::check_with_random_values<
-      1, SmoothFlowProxy::hydro_variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &SmoothFlowProxy::hydro_variables<DataType>,
       SmoothFlowProxy(mean_velocity, wave_vector, pressure, adiabatic_index,
                       perturbation_size),
@@ -114,8 +113,7 @@ void test_variables(const DataType& used_for_size) {
                       perturbation_size),
       used_for_size);
 
-  pypp::check_with_random_values<
-      1, SmoothFlowProxy::grmhd_variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &SmoothFlowProxy::grmhd_variables<DataType>,
       SmoothFlowProxy(mean_velocity, wave_vector, pressure, adiabatic_index,
                       perturbation_size),

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Hydro/Test_SmoothFlow.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Hydro/Test_SmoothFlow.cpp
@@ -93,9 +93,7 @@ void test_solution(const DataType& used_for_size,
   SmoothFlowProxy<Dim, IsRelativistic> solution(
       mean_velocity, wave_vector, pressure, adiabatic_index, perturbation_size);
   if constexpr (IsRelativistic) {
-    pypp::check_with_random_values<
-        1, typename SmoothFlowProxy<
-               Dim, IsRelativistic>::template variables_tags<DataType>>(
+    pypp::check_with_random_values<1>(
         &SmoothFlowProxy<Dim, IsRelativistic>::template primitive_variables<
             DataType>,
         solution, "SmoothFlow",
@@ -106,9 +104,7 @@ void test_solution(const DataType& used_for_size,
                         perturbation_size),
         used_for_size);
   } else {
-    pypp::check_with_random_values<
-        1, typename SmoothFlowProxy<
-               Dim, IsRelativistic>::template variables_tags<DataType>>(
+    pypp::check_with_random_values<1>(
         &SmoothFlowProxy<Dim, IsRelativistic>::template primitive_variables<
             DataType>,
         solution, "SmoothFlow",

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_IsentropicVortex.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_IsentropicVortex.cpp
@@ -57,9 +57,7 @@ void test_solution(
     const std::string& perturbation_amplitude_option = "") noexcept {
   IsentropicVortexProxy<Dim> vortex(1.43, center, mean_velocity, 3.76,
                                     perturbation_amplitude);
-  pypp::check_with_random_values<
-      1,
-      typename IsentropicVortexProxy<Dim>::template variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &IsentropicVortexProxy<Dim>::template primitive_variables<DataType>,
       vortex, "IsentropicVortex",
       {"mass_density", "velocity", "specific_internal_energy", "pressure"},

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_LaneEmdenStar.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_LaneEmdenStar.cpp
@@ -67,8 +67,7 @@ void test_solution(const DataType& used_for_size,
                    const double central_mass_density,
                    const double polytropic_constant) noexcept {
   const LaneEmdenStarProxy star(central_mass_density, polytropic_constant);
-  pypp::check_with_random_values<
-      1, typename LaneEmdenStarProxy::template variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &LaneEmdenStarProxy::template primitive_variables<DataType>, star,
       "LaneEmdenStar",
       {"mass_density", "velocity", "specific_internal_energy", "pressure"},
@@ -78,8 +77,7 @@ void test_solution(const DataType& used_for_size,
       used_for_size);
 
   const auto star_sd = serialize_and_deserialize(star);
-  pypp::check_with_random_values<
-      1, typename LaneEmdenStarProxy::template variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &LaneEmdenStarProxy::template primitive_variables<DataType>, star_sd,
       "LaneEmdenStar",
       {"mass_density", "velocity", "specific_internal_energy", "pressure"},

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_RiemannProblem.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_RiemannProblem.cpp
@@ -53,8 +53,7 @@ void test_solution(const std::array<double, Dim> left_velocity,
   // new parameters in the star region must be given in the python modules.
   RiemannProblemProxy<Dim> solution(1.4, 0.5, 1.0, left_velocity, 1.0, 0.125,
                                     right_velocity, 0.1, 1.e-6);
-  pypp::check_with_random_values<
-      1, typename RiemannProblemProxy<Dim>::template variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &RiemannProblemProxy<Dim>::template primitive_variables<DataType>,
       solution, "RiemannProblem",
       {"mass_density", "velocity", "pressure", "specific_internal_energy"},

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_SmoothFlow.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_SmoothFlow.cpp
@@ -74,8 +74,7 @@ void test_solution(const DataType& used_for_size,
 
   SmoothFlowProxy<Dim> solution(mean_velocity, wave_vector, pressure,
                                 adiabatic_index, perturbation_size);
-  pypp::check_with_random_values<
-      1, typename SmoothFlowProxy<Dim>::template variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &SmoothFlowProxy<Dim>::template primitive_variables<DataType>, solution,
       "Hydro.SmoothFlow",
       {"rest_mass_density", "spatial_velocity", "specific_internal_energy",
@@ -84,8 +83,7 @@ void test_solution(const DataType& used_for_size,
       std::make_tuple(mean_velocity, wave_vector, pressure, adiabatic_index,
                       perturbation_size),
       used_for_size);
-  pypp::check_with_random_values<
-      1, typename SmoothFlowProxy<Dim>::template ne_variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &SmoothFlowProxy<Dim>::template ne_primitive_variables<DataType>,
       solution, "Hydro.SmoothFlow",
       {"rest_mass_density", "spatial_velocity", "specific_internal_energy",

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Lorentzian.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Lorentzian.cpp
@@ -53,15 +53,11 @@ struct LorentzianProxy : Poisson::Solutions::Lorentzian<Dim> {
 template <size_t Dim>
 void test_solution() {
   const LorentzianProxy<Dim> solution{};
-  pypp::check_with_random_values<
-      1, tmpl::list<Poisson::Tags::Field,
-                    ::Tags::deriv<Poisson::Tags::Field, tmpl::size_t<Dim>,
-                                  Frame::Inertial>>>(
-      &LorentzianProxy<Dim>::field_variables, solution, "Lorentzian",
-      {"field", "field_gradient"}, {{{-5., 5.}}}, std::make_tuple(),
-      DataVector(5));
-  pypp::check_with_random_values<
-      1, tmpl::list<Tags::FixedSource<Poisson::Tags::Field>>>(
+  pypp::check_with_random_values<1>(&LorentzianProxy<Dim>::field_variables,
+                                    solution, "Lorentzian",
+                                    {"field", "field_gradient"}, {{{-5., 5.}}},
+                                    std::make_tuple(), DataVector(5));
+  pypp::check_with_random_values<1>(
       &LorentzianProxy<Dim>::source_variables, solution, "Lorentzian",
       {"source"}, {{{-5., 5.}}}, std::make_tuple(), DataVector(5));
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Moustache.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Moustache.cpp
@@ -54,15 +54,11 @@ struct MoustacheProxy : Poisson::Solutions::Moustache<Dim> {
 template <size_t Dim>
 void test_solution() {
   const MoustacheProxy<Dim> solution{};
-  pypp::check_with_random_values<
-      1, tmpl::list<Poisson::Tags::Field,
-                    ::Tags::deriv<Poisson::Tags::Field, tmpl::size_t<Dim>,
-                                  Frame::Inertial>>>(
-      &MoustacheProxy<Dim>::field_variables, solution, "Moustache",
-      {"field", "field_gradient"}, {{{0., 1.}}}, std::make_tuple(),
-      DataVector(5));
-  pypp::check_with_random_values<
-      1, tmpl::list<Tags::FixedSource<Poisson::Tags::Field>>>(
+  pypp::check_with_random_values<1>(&MoustacheProxy<Dim>::field_variables,
+                                    solution, "Moustache",
+                                    {"field", "field_gradient"}, {{{0., 1.}}},
+                                    std::make_tuple(), DataVector(5));
+  pypp::check_with_random_values<1>(
       &MoustacheProxy<Dim>::source_variables, solution, "Moustache", {"source"},
       {{{0., 1.}}}, std::make_tuple(), DataVector(5));
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_ProductOfSinusoids.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_ProductOfSinusoids.cpp
@@ -60,15 +60,11 @@ template <size_t Dim>
 void test_solution(const std::array<double, Dim>& wave_numbers,
                    const std::string& options) {
   const ProductOfSinusoidsProxy<Dim> solution(wave_numbers);
-  pypp::check_with_random_values<
-      1, tmpl::list<Poisson::Tags::Field,
-                    ::Tags::deriv<Poisson::Tags::Field, tmpl::size_t<Dim>,
-                                  Frame::Inertial>>>(
+  pypp::check_with_random_values<1>(
       &ProductOfSinusoidsProxy<Dim>::field_variables, solution,
       "ProductOfSinusoids", {"field", "field_gradient"}, {{{0., 2. * M_PI}}},
       std::make_tuple(wave_numbers), DataVector(5));
-  pypp::check_with_random_values<
-      1, tmpl::list<Tags::FixedSource<Poisson::Tags::Field>>>(
+  pypp::check_with_random_values<1>(
       &ProductOfSinusoidsProxy<Dim>::source_variables, solution,
       "ProductOfSinusoids", {"source"}, {{{0., 2. * M_PI}}},
       std::make_tuple(wave_numbers), DataVector(5));

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/Test_ConstantM1.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/Test_ConstantM1.cpp
@@ -85,14 +85,14 @@ void test_variables(const DataVector& used_for_size) {
   const double comoving_energy_density = 1.3;
 
   // Test M1 variables
-  pypp::check_with_random_values<1, ConstantM1Proxy::m1_variables_tags>(
+  pypp::check_with_random_values<1>(
       &ConstantM1Proxy::m1_variables,
       ConstantM1Proxy(mean_velocity, comoving_energy_density), "TestFunctions",
       {"constant_m1_tildeE", "constant_m1_tildeS"}, {{{-15., 15.}}},
       std::make_tuple(mean_velocity, comoving_energy_density), used_for_size);
 
   // Test hydro variables
-  pypp::check_with_random_values<1, ConstantM1Proxy::hydro_variables_tags>(
+  pypp::check_with_random_values<1>(
       &ConstantM1Proxy::hydro_variables,
       ConstantM1Proxy(mean_velocity, comoving_energy_density), "TestFunctions",
       {"constant_m1_spatial_velocity", "constant_m1_lorentz_factor"},

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_FishboneMoncriefDisk.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_FishboneMoncriefDisk.cpp
@@ -110,16 +110,14 @@ void test_variables(const DataType& used_for_size) noexcept {
       bh_mass, bh_dimless_spin, inner_edge_radius, max_pressure_radius,
       polytropic_constant, polytropic_exponent);
 
-  pypp::check_with_random_values<
-      1, FishboneMoncriefDiskProxy::hydro_variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &FishboneMoncriefDiskProxy::hydro_variables<DataType>, disk,
       "FishboneMoncriefDisk",
       {"rest_mass_density", "spatial_velocity", "specific_internal_energy",
        "pressure", "lorentz_factor", "specific_enthalpy"},
       {{{-15., 15.}}}, member_variables, used_for_size);
 
-  pypp::check_with_random_values<
-      1, FishboneMoncriefDiskProxy::grmhd_variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &FishboneMoncriefDiskProxy::grmhd_variables<DataType>, disk,
       "FishboneMoncriefDisk",
       {"rest_mass_density", "spatial_velocity", "specific_internal_energy",

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_SmoothFlow.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_SmoothFlow.cpp
@@ -62,8 +62,7 @@ void test_solution(const DataType& used_for_size,
 
   SmoothFlowProxy<Dim> solution(mean_velocity, wave_vector, pressure,
                                 adiabatic_index, perturbation_size);
-  pypp::check_with_random_values<
-      1, typename SmoothFlowProxy<Dim>::template variables_tags<DataType>>(
+  pypp::check_with_random_values<1>(
       &SmoothFlowProxy<Dim>::template primitive_variables<DataType>, solution,
       "Hydro.SmoothFlow",
       {"rest_mass_density", "spatial_velocity", "specific_internal_energy",

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_ConstantDensityStar.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_ConstantDensityStar.cpp
@@ -54,18 +54,18 @@ void test_solution(const double density, const double radius,
                    const std::string& options) {
   const ConstantDensityStarProxy solution(density, radius);
   const double test_radius = 2. * radius;
-  pypp::check_with_random_values<1, field_tags>(
+  pypp::check_with_random_values<1>(
       &ConstantDensityStarProxy::field_variables, solution,
       "ConstantDensityStar", {"conformal_factor", "conformal_factor_gradient"},
       {{{-test_radius, test_radius}}}, std::make_tuple(density, radius),
       DataVector(5));
-  pypp::check_with_random_values<1, initial_tags>(
+  pypp::check_with_random_values<1>(
       &ConstantDensityStarProxy::initial_variables, solution,
       "ConstantDensityStar",
       {"initial_conformal_factor", "initial_conformal_factor_gradient"},
       {{{-test_radius, test_radius}}}, std::make_tuple(density, radius),
       DataVector(5));
-  pypp::check_with_random_values<1, source_tags>(
+  pypp::check_with_random_values<1>(
       &ConstantDensityStarProxy::source_variables, solution,
       "ConstantDensityStar", {"conformal_factor_source"},
       {{{-test_radius, test_radius}}}, std::make_tuple(density, radius),

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_Schwarzschild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_Schwarzschild.cpp
@@ -83,8 +83,7 @@ void test_solution(const double mass, const double expected_radius_at_horizon,
   REQUIRE(solution.radius_at_horizon() == approx(expected_radius_at_horizon));
   const double inner_radius = 0.5 * expected_radius_at_horizon;
   const double outer_radius = 2. * expected_radius_at_horizon;
-  pypp::check_with_random_values<
-      1, tmpl::append<field_tags, auxiliary_field_tags>>(
+  pypp::check_with_random_values<1>(
       &SchwarzschildProxy<Coords>::field_variables, solution, "Schwarzschild",
       {"conformal_factor_" + py_functions_suffix,
        "lapse_times_conformal_factor_" + py_functions_suffix,
@@ -93,7 +92,7 @@ void test_solution(const double mass, const double expected_radius_at_horizon,
        "lapse_times_conformal_factor_gradient_" + py_functions_suffix,
        "shift_strain_" + py_functions_suffix},
       {{{inner_radius, outer_radius}}}, std::make_tuple(mass), DataVector(5));
-  pypp::check_with_random_values<1, background_tags>(
+  pypp::check_with_random_values<1>(
       &SchwarzschildProxy<Coords>::background_variables, solution,
       "Schwarzschild",
       {"conformal_spatial_metric_" + py_functions_suffix,
@@ -101,11 +100,11 @@ void test_solution(const double mass, const double expected_radius_at_horizon,
        "extrinsic_curvature_trace_gradient_" + py_functions_suffix,
        "shift_background"},
       {{{inner_radius, outer_radius}}}, std::make_tuple(mass), DataVector(5));
-  pypp::check_with_random_values<1, matter_source_tags>(
+  pypp::check_with_random_values<1>(
       &SchwarzschildProxy<Coords>::matter_source_variables, solution,
       "Schwarzschild", {"energy_density", "stress_trace", "momentum_density"},
       {{{inner_radius, outer_radius}}}, std::make_tuple(mass), DataVector(5));
-  pypp::check_with_random_values<1, fixed_source_tags>(
+  pypp::check_with_random_values<1>(
       &SchwarzschildProxy<Coords>::fixed_source_variables, solution,
       "Schwarzschild",
       {"conformal_factor_fixed_source",


### PR DESCRIPTION
## Proposed changes

I need the ability to pass `boost::optional`s through pypp, which resulted in a fairly significant revamp of the way arguments are passed to the python code. The major additional improvement is that *any* type can be converted before being passed to the python code. Additionally, these conversions can be defined differently for each translation unit, making the design very flexible and easy to have work across many different tests. This is achieved by replacing the `SliceContainerImpl` struct with a new conversion struct that can be specialized to define how to convert types to and from python types. For example, I use this to pass two different equations of state (polytropic and ideal gas) to python code as a bool `use_polytropic_fluid`. Thus, complex types can be "passed" to the python code without having to write and use python bindings.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
