### PR TITLE
Add expiration to FunctionOfTime::PiecewisePolynomial

### DIFF
--- a/src/ControlSystem/FunctionOfTimeUpdater.cpp
+++ b/src/ControlSystem/FunctionOfTimeUpdater.cpp
@@ -28,7 +28,7 @@ void FunctionOfTimeUpdater<DerivOrder>::modify(
     const gsl::not_null<
         domain::FunctionsOfTime::PiecewisePolynomial<DerivOrder>*>
         f_of_t,
-    const double time) noexcept {
+    const double time, const double expiration_time) noexcept {
   if (averager_(time)) {
     std::array<DataVector, DerivOrder + 1> q_and_derivs = averager_(time).get();
     // get the time offset due to averaging
@@ -39,8 +39,11 @@ void FunctionOfTimeUpdater<DerivOrder>::modify(
     const DataVector control_signal =
         controller_(timescale_tuner_.current_timescale(), q_and_derivs,
                     t_offset_of_q, t_offset_of_qdot);
-    f_of_t->update(averager_.last_time_updated(), control_signal);
+    f_of_t->update(averager_.last_time_updated(), control_signal,
+                   expiration_time);
     timescale_tuner_.update_timescale({{q_and_derivs[0], q_and_derivs[1]}});
+  } else {
+    f_of_t->reset_expiration_time(expiration_time);
   }
 }
 

--- a/src/ControlSystem/FunctionOfTimeUpdater.hpp
+++ b/src/ControlSystem/FunctionOfTimeUpdater.hpp
@@ -53,10 +53,13 @@ class FunctionOfTimeUpdater {
 
   /// Computes the control signal, updates the FunctionOfTime and updates the
   /// TimescaleTuner
+  /// `expiration_time` is the time at which the FunctionOfTime is supposed
+  /// to expire, i.e. the time by which we demand that `modify` is
+  /// called again.
   void modify(
       gsl::not_null<domain::FunctionsOfTime::PiecewisePolynomial<DerivOrder>*>
           f_of_t,
-      double time) noexcept;
+      double time, double expiration_time) noexcept;
 
  private:
   Averager<DerivOrder> averager_;

--- a/src/Domain/Creators/TimeDependence/CubicScale.cpp
+++ b/src/Domain/Creators/TimeDependence/CubicScale.cpp
@@ -25,8 +25,7 @@
 #include "Utilities/Gsl.hpp"
 
 namespace domain {
-namespace creators {
-namespace time_dependence {
+namespace creators::time_dependence {
 template <size_t MeshDim>
 CubicScale<MeshDim>::CubicScale(
     const double initial_time,
@@ -140,8 +139,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef INSTANTIATION
 #undef GET_DIM
-}  // namespace time_dependence
-}  // namespace creators
+}  // namespace creators::time_dependence
 
 INSTANTIATE_MAPS_FUNCTIONS(((CoordinateMaps::TimeDependent::CubicScale<1>),
                             (CoordinateMaps::TimeDependent::CubicScale<2>),

--- a/src/Domain/Creators/TimeDependence/CubicScale.hpp
+++ b/src/Domain/Creators/TimeDependence/CubicScale.hpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -14,6 +15,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/CubicScale.hpp"
 #include "Domain/Creators/TimeDependence/TimeDependence.hpp"
+#include "Options/Auto.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -59,6 +61,14 @@ class CubicScale final : public TimeDependence<MeshDim> {
     static constexpr Options::String help = {
         "The initial time of the functions of time"};
   };
+  /// \brief The initial time interval for updates of the functions of time.
+  struct InitialExpirationDeltaT {
+    using type = Options::Auto<double>;
+    static constexpr Options::String help = {
+        "The initial time interval for updates of the functions of time. If "
+        "Auto, then the functions of time do not expire, nor can they be "
+        "updated."};
+  };
   /// \brief The outer boundary or pivot point of the
   /// `domain::CoordinateMaps::TimeDependent::CubicScale` map
   struct OuterBoundary {
@@ -97,8 +107,9 @@ class CubicScale final : public TimeDependence<MeshDim> {
     }
   };
 
-  using options = tmpl::list<InitialTime, OuterBoundary, FunctionOfTimeNames,
-                             InitialExpansion, Velocity, Acceleration>;
+  using options =
+      tmpl::list<InitialTime, InitialExpirationDeltaT, OuterBoundary,
+                 FunctionOfTimeNames, InitialExpansion, Velocity, Acceleration>;
 
   static constexpr Options::String help = {
       "A spatial radial scaling either based on a cubic scaling or a simple\n"
@@ -118,6 +129,7 @@ class CubicScale final : public TimeDependence<MeshDim> {
   CubicScale& operator=(CubicScale&&) noexcept = default;
 
   CubicScale(double initial_time,
+             std::optional<double> initial_expiration_delta_t,
              double outer_boundary,
              std::array<std::string, 2> functions_of_time_names,
              const std::array<double, 2>& initial_expansion,
@@ -146,6 +158,7 @@ class CubicScale final : public TimeDependence<MeshDim> {
                          const CubicScale<LocalDim>& rhs) noexcept;
 
   double initial_time_{std::numeric_limits<double>::signaling_NaN()};
+  std::optional<double> initial_expiration_delta_t_{};
   double outer_boundary_{std::numeric_limits<double>::signaling_NaN()};
   std::array<std::string, 2> functions_of_time_names_{};
   std::array<double, 2> initial_expansion_{};

--- a/src/Domain/Creators/TimeDependence/UniformRotationAboutZAxis.cpp
+++ b/src/Domain/Creators/TimeDependence/UniformRotationAboutZAxis.cpp
@@ -27,8 +27,7 @@
 #include "Utilities/Gsl.hpp"
 
 namespace domain {
-namespace creators {
-namespace time_dependence {
+namespace creators::time_dependence {
 
 template <size_t MeshDim>
 UniformRotationAboutZAxis<MeshDim>::UniformRotationAboutZAxis(
@@ -134,8 +133,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (2, 3))
 #undef GET_DIM
 #undef INSTANTIATION
 /// \endcond
-}  // namespace time_dependence
-}  // namespace creators
+}  // namespace creators::time_dependence
 
 using Identity = CoordinateMaps::Identity<1>;
 using Rotation2d = CoordinateMaps::TimeDependent::Rotation<2>;

--- a/src/Domain/Creators/TimeDependence/UniformRotationAboutZAxis.cpp
+++ b/src/Domain/Creators/TimeDependence/UniformRotationAboutZAxis.cpp
@@ -5,7 +5,9 @@
 
 #include <array>
 #include <cstddef>
+#include <limits>
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <string>
 #include <unordered_map>
@@ -30,9 +32,11 @@ namespace time_dependence {
 
 template <size_t MeshDim>
 UniformRotationAboutZAxis<MeshDim>::UniformRotationAboutZAxis(
-    const double initial_time, const double angular_velocity,
-    std::string function_of_time_name) noexcept
+    const double initial_time,
+    const std::optional<double> initial_expiration_delta_t,
+    const double angular_velocity, std::string function_of_time_name) noexcept
     : initial_time_(initial_time),
+      initial_expiration_delta_t_(initial_expiration_delta_t),
       angular_velocity_(angular_velocity),
       function_of_time_name_(std::move(function_of_time_name)) {}
 
@@ -40,7 +44,8 @@ template <size_t MeshDim>
 std::unique_ptr<TimeDependence<MeshDim>>
 UniformRotationAboutZAxis<MeshDim>::get_clone() const noexcept {
   return std::make_unique<UniformRotationAboutZAxis>(
-      initial_time_, angular_velocity_, function_of_time_name_);
+      initial_time_, initial_expiration_delta_t_, angular_velocity_,
+      function_of_time_name_);
 }
 
 template <size_t MeshDim>
@@ -71,7 +76,10 @@ UniformRotationAboutZAxis<MeshDim>::functions_of_time() const noexcept {
   result[function_of_time_name_] =
       std::make_unique<FunctionsOfTime::PiecewisePolynomial<2>>(
           initial_time_,
-          std::array<DataVector, 3>{{{0.0}, {angular_velocity_}, {0.0}}});
+          std::array<DataVector, 3>{{{0.0}, {angular_velocity_}, {0.0}}},
+          initial_expiration_delta_t_
+              ? initial_time_ + *initial_expiration_delta_t_
+              : std::numeric_limits<double>::max());
   return result;
 }
 
@@ -99,6 +107,7 @@ template <size_t Dim>
 bool operator==(const UniformRotationAboutZAxis<Dim>& lhs,
                 const UniformRotationAboutZAxis<Dim>& rhs) noexcept {
   return lhs.initial_time_ == rhs.initial_time_ and
+         lhs.initial_expiration_delta_t_ == rhs.initial_expiration_delta_t_ and
          lhs.angular_velocity_ == rhs.angular_velocity_ and
          lhs.function_of_time_name_ == rhs.function_of_time_name_;
 }

--- a/src/Domain/Creators/TimeDependence/UniformRotationAboutZAxis.hpp
+++ b/src/Domain/Creators/TimeDependence/UniformRotationAboutZAxis.hpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -17,6 +18,7 @@
 #include "Domain/Creators/TimeDependence/GenerateCoordinateMap.hpp"
 #include "Domain/Creators/TimeDependence/TimeDependence.hpp"
 #include "ErrorHandling/Assert.hpp"
+#include "Options/Auto.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -81,6 +83,14 @@ class UniformRotationAboutZAxis final : public TimeDependence<MeshDim> {
     static constexpr Options::String help = {
         "The initial time of the function of time"};
   };
+  /// \brief The time interval for updates of the functions of time.
+  struct InitialExpirationDeltaT {
+    using type = Options::Auto<double>;
+    static constexpr Options::String help = {
+        "The initial time interval for updates of the functions of time. If "
+        "Auto, then the functions of time do not expire, nor can they be "
+        "updated."};
+  };
   /// \brief The \f$x\f$-, \f$y\f$-, and \f$z\f$-velocity.
   struct AngularVelocity {
     using type = double;
@@ -104,7 +114,8 @@ class UniformRotationAboutZAxis final : public TimeDependence<MeshDim> {
                                      domain::CoordinateMaps::TimeDependent::
                                          ProductOf2Maps<Rotation, Identity>>>>;
 
-  using options = tmpl::list<InitialTime, AngularVelocity, FunctionOfTimeName>;
+  using options = tmpl::list<InitialTime, InitialExpirationDeltaT,
+                             AngularVelocity, FunctionOfTimeName>;
 
   static constexpr Options::String help = {
       "A spatially uniform rotation about the z axis initialized with a "
@@ -120,7 +131,8 @@ class UniformRotationAboutZAxis final : public TimeDependence<MeshDim> {
       default;
 
   UniformRotationAboutZAxis(
-      double initial_time, double angular_velocity,
+      double initial_time, std::optional<double> initial_expiration_delta_t,
+      double angular_velocity,
       std::string function_of_time_name = "RotationAngle") noexcept;
 
   auto get_clone() const noexcept
@@ -146,6 +158,7 @@ class UniformRotationAboutZAxis final : public TimeDependence<MeshDim> {
       const UniformRotationAboutZAxis<LocalDim>& rhs) noexcept;
 
   double initial_time_{std::numeric_limits<double>::signaling_NaN()};
+  std::optional<double> initial_expiration_delta_t_{};
   double angular_velocity_{std::numeric_limits<double>::signaling_NaN()};
   std::string function_of_time_name_{};
 };

--- a/src/Domain/Creators/TimeDependence/UniformTranslation.cpp
+++ b/src/Domain/Creators/TimeDependence/UniformTranslation.cpp
@@ -5,7 +5,9 @@
 
 #include <array>
 #include <cstddef>
+#include <limits>
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <string>
 #include <vector>
@@ -34,24 +36,28 @@ std::array<std::string, 3> default_function_names_impl() noexcept {
 
 template <size_t MeshDim>
 UniformTranslation<MeshDim>::UniformTranslation(
-    const double initial_time, const std::array<double, MeshDim>& velocity,
+    const double initial_time,
+    const std::optional<double> initial_expiration_delta_t,
+    const std::array<double, MeshDim>& velocity,
     std::array<std::string, MeshDim> functions_of_time_names) noexcept
     : initial_time_(initial_time),
+      initial_expiration_delta_t_(initial_expiration_delta_t),
       velocity_(velocity),
       functions_of_time_names_(std::move(functions_of_time_names)) {}
 
 template <size_t MeshDim>
 std::unique_ptr<TimeDependence<MeshDim>>
 UniformTranslation<MeshDim>::get_clone() const noexcept {
-  return std::make_unique<UniformTranslation>(initial_time_, velocity_,
-                                              functions_of_time_names_);
+  return std::make_unique<UniformTranslation>(
+      initial_time_, initial_expiration_delta_t_, velocity_,
+      functions_of_time_names_);
 }
 
 template <size_t MeshDim>
 std::vector<std::unique_ptr<
     domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, MeshDim>>>
-UniformTranslation<MeshDim>::block_maps(const size_t number_of_blocks) const
-    noexcept {
+UniformTranslation<MeshDim>::block_maps(
+    const size_t number_of_blocks) const noexcept {
   ASSERT(number_of_blocks > 0, "Must have at least one block to create.");
   std::vector<std::unique_ptr<
       domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, MeshDim>>>
@@ -70,23 +76,31 @@ UniformTranslation<MeshDim>::functions_of_time() const noexcept {
   std::unordered_map<std::string,
                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
       result{};
+
+  const double initial_expiration_time =
+      initial_expiration_delta_t_ ? initial_time_ + *initial_expiration_delta_t_
+                                  : std::numeric_limits<double>::max();
+
   // We use a `PiecewisePolynomial` with 2 derivs since some transformations
   // between different frames for moving meshes can require Hessians.
   result[functions_of_time_names_[0]] =
       std::make_unique<FunctionsOfTime::PiecewisePolynomial<2>>(
           initial_time_,
-          std::array<DataVector, 3>{{{0.0}, {velocity_[0]}, {0.0}}});
+          std::array<DataVector, 3>{{{0.0}, {velocity_[0]}, {0.0}}},
+          initial_expiration_time);
   if (MeshDim > 1) {
     result[gsl::at(functions_of_time_names_, 1)] =
         std::make_unique<FunctionsOfTime::PiecewisePolynomial<2>>(
             initial_time_,
-            std::array<DataVector, 3>{{{0.0}, {gsl::at(velocity_, 1)}, {0.0}}});
+            std::array<DataVector, 3>{{{0.0}, {gsl::at(velocity_, 1)}, {0.0}}},
+            initial_expiration_time);
   }
   if (MeshDim > 2) {
     result[gsl::at(functions_of_time_names_, 2)] =
         std::make_unique<FunctionsOfTime::PiecewisePolynomial<2>>(
             initial_time_,
-            std::array<DataVector, 3>{{{0.0}, {gsl::at(velocity_, 2)}, {0.0}}});
+            std::array<DataVector, 3>{{{0.0}, {gsl::at(velocity_, 2)}, {0.0}}},
+            initial_expiration_time);
   }
   return result;
 }
@@ -143,6 +157,7 @@ template <size_t Dim>
 bool operator==(const UniformTranslation<Dim>& lhs,
                 const UniformTranslation<Dim>& rhs) noexcept {
   return lhs.initial_time_ == rhs.initial_time_ and
+         lhs.initial_expiration_delta_t_ == rhs.initial_expiration_delta_t_ and
          lhs.velocity_ == rhs.velocity_ and
          lhs.functions_of_time_names_ == rhs.functions_of_time_names_;
 }

--- a/src/Domain/Creators/TimeDependence/UniformTranslation.cpp
+++ b/src/Domain/Creators/TimeDependence/UniformTranslation.cpp
@@ -26,8 +26,7 @@
 #include "Utilities/Gsl.hpp"
 
 namespace domain {
-namespace creators {
-namespace time_dependence {
+namespace creators::time_dependence {
 namespace {
 std::array<std::string, 3> default_function_names_impl() noexcept {
   return {{"TranslationX", "TranslationY", "TranslationZ"}};
@@ -184,8 +183,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef GET_DIM
 #undef INSTANTIATION
 /// \endcond
-}  // namespace time_dependence
-}  // namespace creators
+}  // namespace creators::time_dependence
 
 using Translation = CoordinateMaps::TimeDependent::Translation;
 using Translation2d =

--- a/src/Domain/Creators/TimeDependence/UniformTranslation.hpp
+++ b/src/Domain/Creators/TimeDependence/UniformTranslation.hpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -15,6 +16,7 @@
 #include "Domain/CoordinateMaps/TimeDependent/Translation.hpp"
 #include "Domain/Creators/TimeDependence/GenerateCoordinateMap.hpp"
 #include "Domain/Creators/TimeDependence/TimeDependence.hpp"
+#include "Options/Auto.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -79,6 +81,14 @@ class UniformTranslation final : public TimeDependence<MeshDim> {
     static constexpr Options::String help = {
         "The initial time of the functions of time"};
   };
+  /// \brief The time interval for updates of the functions of time.
+  struct InitialExpirationDeltaT {
+    using type = Options::Auto<double>;
+    static constexpr Options::String help = {
+        "The time interval for updates of the functions of time. If "
+        "Auto, then the functions of time do not expire, nor can they be "
+        "updated."};
+  };
   /// \brief The \f$x\f$-, \f$y\f$-, and \f$z\f$-velocity.
   struct Velocity {
     using type = std::array<double, MeshDim>;
@@ -106,7 +116,8 @@ class UniformTranslation final : public TimeDependence<MeshDim> {
               domain::CoordinateMaps::TimeDependent::ProductOf3Maps<
                   Translation, Translation, Translation>>>>>;
 
-  using options = tmpl::list<InitialTime, Velocity, FunctionOfTimeNames>;
+  using options = tmpl::list<InitialTime, InitialExpirationDeltaT, Velocity,
+                             FunctionOfTimeNames>;
 
   static constexpr Options::String help = {
       "A spatially uniform translation initialized with a constant velocity."};
@@ -119,6 +130,7 @@ class UniformTranslation final : public TimeDependence<MeshDim> {
   UniformTranslation& operator=(UniformTranslation&&) noexcept = default;
 
   UniformTranslation(double initial_time,
+                     std::optional<double> initial_expiration_delta_t,
                      const std::array<double, MeshDim>& velocity,
                      std::array<std::string, MeshDim> functions_of_time_names =
                          default_function_names()) noexcept;
@@ -147,6 +159,7 @@ class UniformTranslation final : public TimeDependence<MeshDim> {
                          const UniformTranslation<LocalDim>& rhs) noexcept;
 
   double initial_time_{std::numeric_limits<double>::signaling_NaN()};
+  std::optional<double> initial_expiration_delta_t_{};
   std::array<double, MeshDim> velocity_{};
   std::array<std::string, MeshDim> functions_of_time_names_{};
 };

--- a/src/Domain/FunctionsOfTime/FunctionOfTime.hpp
+++ b/src/Domain/FunctionsOfTime/FunctionOfTime.hpp
@@ -29,6 +29,10 @@ class FunctionOfTime : public PUP::able {
   virtual auto get_clone() const noexcept
       -> std::unique_ptr<FunctionOfTime> = 0;
 
+  /// Returns the domain of validity of the function.
+  /// For FunctionsOfTime that allow a small amount of time extrapolation,
+  /// `time_bounds` tells you the bounds including the allowed extrapolation
+  /// interval.
   virtual std::array<double, 2> time_bounds() const noexcept = 0;
 
   virtual std::array<DataVector, 1> func(double t) const noexcept = 0;

--- a/src/Domain/FunctionsOfTime/PiecewisePolynomial.cpp
+++ b/src/Domain/FunctionsOfTime/PiecewisePolynomial.cpp
@@ -17,16 +17,17 @@
 #include "Utilities/Literals.hpp"
 #include "Utilities/MakeArray.hpp"
 
-namespace domain {
-namespace FunctionsOfTime {
+namespace domain::FunctionsOfTime {
 template <size_t MaxDeriv>
 PiecewisePolynomial<MaxDeriv>::PiecewisePolynomial(
-    const double t, value_type initial_func_and_derivs) noexcept
-    : deriv_info_at_update_times_{{t, std::move(initial_func_and_derivs)}} {}
+    const double t, value_type initial_func_and_derivs,
+    const double expiration_time) noexcept
+    : deriv_info_at_update_times_{{t, std::move(initial_func_and_derivs)}},
+      expiration_time_(expiration_time) {}
 
 template <size_t MaxDeriv>
-std::unique_ptr<FunctionOfTime> PiecewisePolynomial<MaxDeriv>::get_clone() const
-    noexcept {
+std::unique_ptr<FunctionOfTime> PiecewisePolynomial<MaxDeriv>::get_clone()
+    const noexcept {
   return std::make_unique<PiecewisePolynomial>(*this);
 }
 
@@ -34,6 +35,12 @@ template <size_t MaxDeriv>
 template <size_t MaxDerivReturned>
 std::array<DataVector, MaxDerivReturned + 1>
 PiecewisePolynomial<MaxDeriv>::func_and_derivs(const double t) const noexcept {
+  if (t > expiration_time_) {
+    ERROR("Attempt to evaluate PiecewisePolynomial at a time "
+          << t << " that is after the expiration time " << expiration_time_
+          << ". The difference between times is " << t - expiration_time_
+          << ".");
+  }
   const auto& deriv_info_at_t = deriv_info_from_upper_bound(t);
   const double dt = t - deriv_info_at_t.time;
   const value_type& coefs = deriv_info_at_t.derivs_coefs;
@@ -63,13 +70,45 @@ PiecewisePolynomial<MaxDeriv>::func_and_derivs(const double t) const noexcept {
 
 template <size_t MaxDeriv>
 void PiecewisePolynomial<MaxDeriv>::update(
-    const double time_of_update, DataVector updated_max_deriv) noexcept {
+    // Clang-tidy says to use 'const DataVector& updated_max_deriv'.
+    // However, updated_max_deriv is std::moved out of inside this function.
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    const double time_of_update, DataVector updated_max_deriv,
+    const double next_expiration_time) noexcept {
   if (time_of_update <= deriv_info_at_update_times_.back().time) {
     ERROR("t must be increasing from call to call. "
           << "Attempted to update at time " << time_of_update
           << ", which precedes the previous update time of "
           << deriv_info_at_update_times_.back().time << ".");
   }
+  if (next_expiration_time < expiration_time_) {
+    ERROR("expiration_time must be nondecreasing from call to call. "
+          << "Attempted to change expiration time to " << next_expiration_time
+          << ", which precedes the previous expiration time of "
+          << expiration_time_ << ".");
+  }
+  if (time_of_update < expiration_time_) {
+    ERROR("Attempt to update PiecewisePolynomial at a time "
+          << time_of_update
+          << " that is earlier than the previous expiration time of "
+          << expiration_time_
+          << ". This is bad because some asynchronous process may have already "
+             "used PiecewisePolynomial at a time later than the current time "
+          << time_of_update << ".");
+  }
+  if (time_of_update > next_expiration_time) {
+    ERROR(
+        "Attempt to set the expiration time of PiecewisePolynomial "
+        "to a value "
+        << next_expiration_time << " that is earlier than the current time "
+        << time_of_update << ".");
+  }
+
+  // Normally, func_and_derivs(t) throws an error if t>expiration_time_.
+  // But here, we want to allow time_of_update to
+  // be greater than the *previous* expiration time, so we need to
+  // reset expiration_time_ before the call to func_and_derivs.
+  expiration_time_ = next_expiration_time;
 
   // get the current values, before updating the `MaxDeriv'th deriv
   value_type func = func_and_derivs(time_of_update);
@@ -84,6 +123,18 @@ void PiecewisePolynomial<MaxDeriv>::update(
 
   func[MaxDeriv] = std::move(updated_max_deriv);
   deriv_info_at_update_times_.emplace_back(time_of_update, std::move(func));
+}
+
+template <size_t MaxDeriv>
+void PiecewisePolynomial<MaxDeriv>::reset_expiration_time(
+    const double next_expiration_time) noexcept {
+  if (next_expiration_time < expiration_time_) {
+    ERROR("Attempted to change expiration time to "
+          << next_expiration_time
+          << ", which precedes the previous expiration time of "
+          << expiration_time_ << ".");
+  }
+  expiration_time_ = next_expiration_time;
 }
 
 template <size_t MaxDeriv>
@@ -113,8 +164,8 @@ bool PiecewisePolynomial<MaxDeriv>::DerivInfo::operator==(
 
 template <size_t MaxDeriv>
 const typename PiecewisePolynomial<MaxDeriv>::DerivInfo&
-PiecewisePolynomial<MaxDeriv>::deriv_info_from_upper_bound(const double t) const
-    noexcept {
+PiecewisePolynomial<MaxDeriv>::deriv_info_from_upper_bound(
+    const double t) const noexcept {
   // this function assumes that the times in deriv_info_at_update_times is
   // sorted, which is enforced by the update function.
 
@@ -144,12 +195,14 @@ template <size_t MaxDeriv>
 void PiecewisePolynomial<MaxDeriv>::pup(PUP::er& p) {
   FunctionOfTime::pup(p);
   p | deriv_info_at_update_times_;
+  p | expiration_time_;
 }
 
 template <size_t MaxDeriv>
 bool operator==(const PiecewisePolynomial<MaxDeriv>& lhs,
                 const PiecewisePolynomial<MaxDeriv>& rhs) noexcept {
-  return lhs.deriv_info_at_update_times_ == rhs.deriv_info_at_update_times_;
+  return lhs.deriv_info_at_update_times_ == rhs.deriv_info_at_update_times_ and
+         lhs.expiration_time_ == rhs.expiration_time_;
 }
 
 template <size_t MaxDeriv>
@@ -190,5 +243,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (4), (0, 1, 2, 3, 4))
 #undef DIMRETURNED
 #undef INSTANTIATE
 /// \endcond
-}  // namespace FunctionsOfTime
-}  // namespace domain
+}  // namespace domain::FunctionsOfTime

--- a/src/IO/Importers/Actions/ReadSpecThirdOrderPiecewisePolynomial.hpp
+++ b/src/IO/Importers/Actions/ReadSpecThirdOrderPiecewisePolynomial.hpp
@@ -133,8 +133,8 @@ struct ReadSpecThirdOrderPiecewisePolynomial {
         }
       }
       spec_functions_of_time[spectre_name] =
-          domain::FunctionsOfTime::PiecewisePolynomial<3>(start_time,
-                                                          initial_coefficients);
+          domain::FunctionsOfTime::PiecewisePolynomial<3>(
+              start_time, initial_coefficients, start_time);
 
       // Loop over the remaining times, updating the function of time
       DataVector highest_derivative(number_of_components);
@@ -148,8 +148,8 @@ struct ReadSpecThirdOrderPiecewisePolynomial {
             highest_derivative[a] =
                 dat_data(row, 5 + (max_deriv + 1) * a + max_deriv);
           }
-          spec_functions_of_time[spectre_name].update(time_last_updated,
-                                                      highest_derivative);
+          spec_functions_of_time[spectre_name].update(
+              time_last_updated, highest_derivative, time_last_updated);
         } else {
           file.reset();
           ERROR("Non-monotonic time found in FunctionOfTime data. "

--- a/tests/InputFiles/ExportCoordinates/Input1D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input1D.yaml
@@ -16,6 +16,7 @@ DomainCreator:
     TimeDependence:
       UniformTranslation:
         InitialTime: 0.0
+        InitialExpirationDeltaT: 5.0
         Velocity: [0.5]
         FunctionOfTimeNames: ["TranslationX"]
 

--- a/tests/InputFiles/ExportCoordinates/Input2D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input2D.yaml
@@ -16,6 +16,7 @@ DomainCreator:
     TimeDependence:
       UniformTranslation:
         InitialTime: 0.0
+        InitialExpirationDeltaT: 5.0
         Velocity: [0.5, 0.0]
         FunctionOfTimeNames: ["TranslationX", "TranslationY"]
 

--- a/tests/InputFiles/ExportCoordinates/Input3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input3D.yaml
@@ -16,6 +16,7 @@ DomainCreator:
     TimeDependence:
       UniformTranslation:
         InitialTime: 0.0
+        InitialExpirationDeltaT: 5.0
         Velocity: [0.5, 0.0, 0.0]
         FunctionOfTimeNames: ["TranslationX", "TranslationY", "TranslationZ"]
 

--- a/tests/Unit/ControlSystem/Test_Controller.cpp
+++ b/tests/Unit/ControlSystem/Test_Controller.cpp
@@ -39,10 +39,12 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Controller", "[ControlSystem][Unit]") {
   std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> f_of_t =
       std::make_unique<
           domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>>(
-          t, std::array<DataVector, deriv_order + 1>{
-                 {{std::sin(freq * t)},
-                  {freq * std::cos(freq * t)},
-                  {-square(freq) * std::sin(freq * t)}}});
+          t,
+          std::array<DataVector, deriv_order + 1>{
+              {{std::sin(freq * t)},
+               {freq * std::cos(freq * t)},
+               {-square(freq) * std::sin(freq * t)}}},
+          t + dt);
   auto& f_of_t_derived =
       dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>&>(
           *f_of_t);
@@ -71,7 +73,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Controller", "[ControlSystem][Unit]") {
                                         t_offset, t_offset);
 
     t += dt;
-    f_of_t_derived.update(t, {U});
+    f_of_t_derived.update(t, {U}, t + dt);
 
     // update the timescale
     tst.update_timescale({{q_and_derivs[0], q_and_derivs[1]}});
@@ -108,10 +110,12 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Controller.TimeOffsets",
   std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> f_of_t =
       std::make_unique<
           domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>>(
-          t, std::array<DataVector, deriv_order + 1>{
-                 {{std::sin(freq * t)},
-                  {freq * std::cos(freq * t)},
-                  {-square(freq) * std::sin(freq * t)}}});
+          t,
+          std::array<DataVector, deriv_order + 1>{
+              {{std::sin(freq * t)},
+               {freq * std::cos(freq * t)},
+               {-square(freq) * std::sin(freq * t)}}},
+          t + dt);
   auto& f_of_t_derived =
       dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>&>(
           *f_of_t);
@@ -153,7 +157,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Controller.TimeOffsets",
         control_signal(tst.current_timescale(), avg_qs, t_offset, t_offset);
 
     t += dt;
-    f_of_t_derived.update(t, {U});
+    f_of_t_derived.update(t, {U}, t + dt);
 
     // update the timescale
     tst.update_timescale({{avg_qs[0], avg_qs[1]}});
@@ -190,10 +194,12 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Controller.TimeOffsets_DontAverageQ",
   std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> f_of_t =
       std::make_unique<
           domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>>(
-          t, std::array<DataVector, deriv_order + 1>{
-                 {{std::sin(freq * t)},
-                  {freq * std::cos(freq * t)},
-                  {-square(freq) * std::sin(freq * t)}}});
+          t,
+          std::array<DataVector, deriv_order + 1>{
+              {{std::sin(freq * t)},
+               {freq * std::cos(freq * t)},
+               {-square(freq) * std::sin(freq * t)}}},
+          t + dt);
   auto& f_of_t_derived =
       dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>&>(
           *f_of_t);
@@ -237,7 +243,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Controller.TimeOffsets_DontAverageQ",
         control_signal(tst.current_timescale(), avg_qs, q_t_offset, t_offset);
 
     t += dt;
-    f_of_t_derived.update(t, {U});
+    f_of_t_derived.update(t, {U}, t + dt);
 
     // update the timescale
     tst.update_timescale({{avg_qs[0], avg_qs[1]}});

--- a/tests/Unit/ControlSystem/Test_FuntionOfTimeUpdater.cpp
+++ b/tests/Unit/ControlSystem/Test_FuntionOfTimeUpdater.cpp
@@ -53,8 +53,8 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.FunctionOfTimeUpdater.Translation",
   // initialize our FunctionOfTime to agree at t=0
   const std::array<DataVector, deriv_order + 1> init_func{
       {{0.0, 0.0}, {amp1 * omega1, amp2 * omega2}, {0.0, 0.0}}};
-  domain::FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(t,
-                                                                   init_func);
+  domain::FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(t, init_func,
+                                                                   t + dt);
 
   Averager<deriv_order> averager(0.25, false);
   Controller<deriv_order> control_signal;
@@ -82,7 +82,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.FunctionOfTimeUpdater.Translation",
     // make the error measurement
     trans_error(&updater, f_of_t, t, inertial_coords);
     // update the FunctionOfTime
-    updater.modify(&f_of_t, t);
+    updater.modify(&f_of_t, t, t + dt);
     // check that Q is within the specified tolerance
     CHECK(fabs(inertial_coords[0] - grid_coords[0] - f_of_t.func(t)[0][0]) <=
           decrease_timescale_threshold);

--- a/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
@@ -1077,7 +1077,7 @@ void test_time_dependent_map() {
                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
       functions_of_time{};
   functions_of_time["Translation"] =
-      std::make_unique<Polynomial>(initial_time, init_func);
+      std::make_unique<Polynomial>(initial_time, init_func, final_time);
 
   const CoordinateMaps::TimeDependent::Translation trans_map{"Translation"};
 
@@ -1329,6 +1329,7 @@ void test_coords_frame_velocity_jacobians() noexcept {
                                                     trans_map>;
 
   const double initial_time = 0.0;
+  const double final_time   = 2.0;
   const double time = 2.0;
   constexpr size_t deriv_order = 3;
 
@@ -1338,19 +1339,24 @@ void test_coords_frame_velocity_jacobians() noexcept {
       functions_of_time{};
   functions_of_time["trans_x"] = std::make_unique<Polynomial>(
       initial_time,
-      std::array<DataVector, deriv_order + 1>{{{1.0}, {-2.0}, {0.0}, {0.0}}});
+      std::array<DataVector, deriv_order + 1>{{{1.0}, {-2.0}, {0.0}, {0.0}}},
+      final_time);
   functions_of_time["trans_y"] = std::make_unique<Polynomial>(
       initial_time,
-      std::array<DataVector, deriv_order + 1>{{{1.0}, {3.0}, {0.0}, {0.0}}});
+      std::array<DataVector, deriv_order + 1>{{{1.0}, {3.0}, {0.0}, {0.0}}},
+      final_time);
   functions_of_time["trans_z"] = std::make_unique<Polynomial>(
       initial_time,
-      std::array<DataVector, deriv_order + 1>{{{1.0}, {4.5}, {0.0}, {0.0}}});
+      std::array<DataVector, deriv_order + 1>{{{1.0}, {4.5}, {0.0}, {0.0}}},
+      final_time);
   functions_of_time["ExpansionA"] = std::make_unique<Polynomial>(
       initial_time,
-      std::array<DataVector, deriv_order + 1>{{{1.0}, {-0.01}, {0.0}, {0.0}}});
+      std::array<DataVector, deriv_order + 1>{{{1.0}, {-0.01}, {0.0}, {0.0}}},
+      final_time);
   functions_of_time["ExpansionB"] = std::make_unique<Polynomial>(
       initial_time,
-      std::array<DataVector, deriv_order + 1>{{{1.0}, {0.0}, {0.0}, {0.0}}});
+      std::array<DataVector, deriv_order + 1>{{{1.0}, {0.0}, {0.0}, {0.0}}},
+      final_time);
 
   const auto composed_map_1d =
       make_coordinate_map<Frame::Logical, Frame::Inertial>(

--- a/tests/Unit/Domain/CoordinateMaps/Test_RotationTimeDep.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_RotationTimeDep.cpp
@@ -66,7 +66,8 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.RotationTimeDep",
   const std::array<DataVector, deriv_order + 1> init_func{
       {{1.0}, {-2.0}, {2.0}, {0.0}}};
   std::unordered_map<std::string, FoftPtr> f_of_t_list{};
-  f_of_t_list[f_of_t_name] = std::make_unique<Polynomial>(t, init_func);
+  f_of_t_list[f_of_t_name] =
+      std::make_unique<Polynomial>(t, init_func, final_time + dt);
 
   const CoordinateMaps::TimeDependent::Rotation<spatial_dim> rotation_map{
       f_of_t_name};

--- a/tests/Unit/Domain/CoordinateMaps/Test_RotationTimeDep.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_RotationTimeDep.cpp
@@ -19,11 +19,9 @@
 #include "Utilities/ConstantExpressions.hpp"
 
 class DataVector;
-namespace domain {
-namespace FunctionsOfTime {
+namespace domain::FunctionsOfTime {
 class FunctionOfTime;
-}  // namespace FunctionsOfTime
-}  // namespace domain
+}  // namespace domain::FunctionsOfTime
 
 namespace {
 std::array<double, 2> expected_mapped_point(

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_CubicScale.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_CubicScale.cpp
@@ -27,6 +27,7 @@ namespace {
 void cubic_scale_non_invertible(const double a0, const double b0,
                                 const double outer_boundary) noexcept {
   double t = 4.0;
+  const double delta_t = 20.0;
   constexpr size_t deriv_order = 2;
 
   const std::array<DataVector, deriv_order + 1> init_func_a{
@@ -37,8 +38,10 @@ void cubic_scale_non_invertible(const double a0, const double b0,
   using Polynomial = domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>;
   using FoftPtr = std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>;
   std::unordered_map<std::string, FoftPtr> f_of_t_list{};
-  f_of_t_list["expansion_a"] = std::make_unique<Polynomial>(t, init_func_a);
-  f_of_t_list["expansion_b"] = std::make_unique<Polynomial>(t, init_func_b);
+  f_of_t_list["expansion_a"] =
+      std::make_unique<Polynomial>(t, init_func_a, t + delta_t);
+  f_of_t_list["expansion_b"] =
+      std::make_unique<Polynomial>(t, init_func_b, t + delta_t);
 
   const FoftPtr& expansion_a_base = f_of_t_list.at("expansion_a");
   const FoftPtr& expansion_b_base = f_of_t_list.at("expansion_b");
@@ -75,8 +78,10 @@ void test_boundaries() {
         domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>;
     using FoftPtr = std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>;
     std::unordered_map<std::string, FoftPtr> f_of_t_list{};
-    f_of_t_list["expansion_a"] = std::make_unique<Polynomial>(t, init_func_a);
-    f_of_t_list["expansion_b"] = std::make_unique<Polynomial>(t, init_func_b);
+    f_of_t_list["expansion_a"] =
+        std::make_unique<Polynomial>(t, init_func_a, final_time);
+    f_of_t_list["expansion_b"] =
+        std::make_unique<Polynomial>(t, init_func_b, final_time);
 
     const FoftPtr& expansion_a_base = f_of_t_list.at("expansion_a");
     const FoftPtr& expansion_b_base = f_of_t_list.at("expansion_b");
@@ -166,10 +171,10 @@ void test(const bool linear_expansion) {
         domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>;
     using FoftPtr = std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>;
     std::unordered_map<std::string, FoftPtr> f_of_t_list{};
-    f_of_t_list["expansion_a"] =
-        std::make_unique<Polynomial>(initial_time, init_func_a);
-    f_of_t_list["expansion_b"] =
-        std::make_unique<Polynomial>(initial_time, init_func_b);
+    f_of_t_list["expansion_a"] = std::make_unique<Polynomial>(
+        initial_time, init_func_a, final_time);
+    f_of_t_list["expansion_b"] = std::make_unique<Polynomial>(
+        initial_time, init_func_b, final_time);
 
     const FoftPtr& expansion_a_base = f_of_t_list.at("expansion_a");
     const FoftPtr& expansion_b_base = f_of_t_list.at("expansion_b");

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_ProductMaps.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_ProductMaps.cpp
@@ -159,7 +159,8 @@ void test_product_of_2_maps_time_dep() noexcept {
   using Polynomial = domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>;
   using FoftPtr = std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>;
   std::unordered_map<std::string, FoftPtr> functions_of_time{};
-  functions_of_time[f_of_t_name] = std::make_unique<Polynomial>(0.0, init_func);
+  functions_of_time[f_of_t_name] =
+      std::make_unique<Polynomial>(0.0, init_func, 4.0);
 
   {
     // Test one time-dependent and one time-independent map case.
@@ -232,10 +233,12 @@ void test_product_of_2_maps_time_dep() noexcept {
 
     functions_of_time[f_of_t_name_x] = std::make_unique<Polynomial>(
         0.0,
-        std::array<DataVector, deriv_order + 1>{{{1.0}, {-3.0}, {2.0}, {0.0}}});
+        std::array<DataVector, deriv_order + 1>{{{1.0}, {-3.0}, {2.0}, {0.0}}},
+        4.0);
     functions_of_time[f_of_t_name_y] = std::make_unique<Polynomial>(
         0.0,
-        std::array<DataVector, deriv_order + 1>{{{1.0}, {2.4}, {2.0}, {0.0}}});
+        std::array<DataVector, deriv_order + 1>{{{1.0}, {2.4}, {2.0}, {0.0}}},
+        4.0);
 
     const double x_source_a = -1.0;
     const double x_source_b = 1.0;
@@ -435,13 +438,16 @@ void test_product_of_3_maps() noexcept {
   std::unordered_map<std::string, FoftPtr> functions_of_time{};
   functions_of_time[f_of_t_name_x] = std::make_unique<Polynomial>(
       0.0,
-      std::array<DataVector, deriv_order + 1>{{{1.0}, {-3.0}, {1.3}, {0.0}}});
+      std::array<DataVector, deriv_order + 1>{{{1.0}, {-3.0}, {1.3}, {0.0}}},
+      4.0);
   functions_of_time[f_of_t_name_y] = std::make_unique<Polynomial>(
       0.0,
-      std::array<DataVector, deriv_order + 1>{{{1.0}, {2.4}, {2.0}, {0.0}}});
+      std::array<DataVector, deriv_order + 1>{{{1.0}, {2.4}, {2.0}, {0.0}}},
+      4.0);
   functions_of_time[f_of_t_name_z] = std::make_unique<Polynomial>(
       0.0,
-      std::array<DataVector, deriv_order + 1>{{{1.0}, {0.4}, {4.0}, {0.0}}});
+      std::array<DataVector, deriv_order + 1>{{{1.0}, {0.4}, {4.0}, {0.0}}},
+      4.0);
 
   {
     // Test one time-dependent and two time-independent map case.

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_Translation.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_Translation.cpp
@@ -36,7 +36,8 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.TimeDependent.Translation",
   using Polynomial = domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>;
   using FoftPtr = std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>;
   std::unordered_map<std::string, FoftPtr> f_of_t_list{};
-  f_of_t_list["translation"] = std::make_unique<Polynomial>(t, init_func);
+  f_of_t_list["translation"] =
+      std::make_unique<Polynomial>(t, init_func, final_time + dt);
 
   const FoftPtr& f_of_t = f_of_t_list.at("translation");
 

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -155,13 +155,17 @@ void test_bbh_time_dependent_factory() {
           "    TimeDependence:\n"
           "      UniformTranslation:\n"
           "        InitialTime: 1.0\n"
+          "        InitialExpirationDeltaT: 9.0\n"
           "        Velocity: [2.3, -0.3, 0.5]\n"
           "        FunctionOfTimeNames: [TranslationX, TranslationY, "
           "TranslationZ]");
   const std::array<double, 4> times_to_check{{0.0, 4.4, 7.8}};
 
   constexpr double initial_time = 0.0;
+  constexpr double expiration_time = 10.0;
   constexpr double expected_time = 1.0; // matches InitialTime: 1.0 above
+  constexpr double expected_update_delta_t =
+      9.0;  // matches InitialExpirationDeltaT: 9.0 above
   std::array<DataVector, 3> function_of_time_coefficients_x{
       {{0.0}, {2.3}, {0.0}}};
   const std::array<DataVector, 3> function_of_time_coefficients_y{
@@ -177,27 +181,30 @@ void test_bbh_time_dependent_factory() {
           std::pair<std::string,
                     domain::FunctionsOfTime::PiecewisePolynomial<2>>{
               "TranslationX"s,
-              {expected_time, function_of_time_coefficients_x}},
+              {expected_time, function_of_time_coefficients_x,
+               expected_time + expected_update_delta_t}},
           std::pair<std::string,
                     domain::FunctionsOfTime::PiecewisePolynomial<2>>{
               "TranslationY"s,
-              {expected_time, function_of_time_coefficients_y}},
+              {expected_time, function_of_time_coefficients_y,
+               expected_time + expected_update_delta_t}},
           std::pair<std::string,
                     domain::FunctionsOfTime::PiecewisePolynomial<2>>{
               "TranslationZ"s,
-              {expected_time, function_of_time_coefficients_z}});
+              {expected_time, function_of_time_coefficients_z,
+               expected_time + expected_update_delta_t}});
   std::unordered_map<std::string,
                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
       functions_of_time{};
   functions_of_time["TranslationX"] =
       std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
-          initial_time, function_of_time_coefficients_x);
+          initial_time, function_of_time_coefficients_x, expiration_time);
   functions_of_time["TranslationY"] =
       std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
-          initial_time, function_of_time_coefficients_y);
+          initial_time, function_of_time_coefficients_y, expiration_time);
   functions_of_time["TranslationZ"] =
       std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
-          initial_time, function_of_time_coefficients_z);
+          initial_time, function_of_time_coefficients_z, expiration_time);
 
   for (const double time : times_to_check) {
     test_binary_compact_object_construction(

--- a/tests/Unit/Domain/Creators/Test_Brick.cpp
+++ b/tests/Unit/Domain/Creators/Test_Brick.cpp
@@ -263,6 +263,7 @@ void test_brick_factory() {
             "  TimeDependence:\n"
             "    UniformTranslation:\n"
             "      InitialTime: 1.0\n"
+            "      InitialExpirationDeltaT: 9.0\n"
             "      Velocity: [2.3, -0.3, 0.5]\n"
             "      FunctionOfTimeNames: [TranslationX, TranslationY, "
             "TranslationZ]");
@@ -282,15 +283,15 @@ void test_brick_factory() {
             std::pair<std::string,
                       domain::FunctionsOfTime::PiecewisePolynomial<2>>{
                 "TranslationX",
-                {1.0, std::array<DataVector, 3>{{{0.0}, {2.3}, {0.0}}}}},
+                {1.0, std::array<DataVector, 3>{{{0.0}, {2.3}, {0.0}}}, 10.0}},
             std::pair<std::string,
                       domain::FunctionsOfTime::PiecewisePolynomial<2>>{
                 "TranslationY",
-                {1.0, std::array<DataVector, 3>{{{0.0}, {-0.3}, {0.0}}}}},
+                {1.0, std::array<DataVector, 3>{{{0.0}, {-0.3}, {0.0}}}, 10.0}},
             std::pair<std::string,
                       domain::FunctionsOfTime::PiecewisePolynomial<2>>{
                 "TranslationZ",
-                {1.0, std::array<DataVector, 3>{{{0.0}, {0.5}, {0.0}}}}}),
+                {1.0, std::array<DataVector, 3>{{{0.0}, {0.5}, {0.0}}}, 10.0}}),
         make_vector_coordinate_map_base<Frame::Grid, Frame::Inertial>(
             Translation3D{Translation{"TranslationX"},
                           Translation{"TranslationY"},

--- a/tests/Unit/Domain/Creators/Test_Interval.cpp
+++ b/tests/Unit/Domain/Creators/Test_Interval.cpp
@@ -138,6 +138,7 @@ void test_interval_factory() {
             "  TimeDependence:\n"
             "    UniformTranslation:\n"
             "      InitialTime: 1.0\n"
+            "      InitialExpirationDeltaT: 9.0\n"
             "      Velocity: [2.3]\n"
             "      FunctionOfTimeNames: [TranslationX]");
     const auto* interval_creator =
@@ -152,7 +153,7 @@ void test_interval_factory() {
             std::pair<std::string,
                       domain::FunctionsOfTime::PiecewisePolynomial<2>>{
                 "TranslationX",
-                {1.0, std::array<DataVector, 3>{{{0.0}, {2.3}, {0.0}}}}}),
+                {1.0, std::array<DataVector, 3>{{{0.0}, {2.3}, {0.0}}}, 10.0}}),
         make_vector_coordinate_map_base<Frame::Grid, Frame::Inertial>(
             CoordinateMaps::TimeDependent::Translation{"TranslationX"}));
   }

--- a/tests/Unit/Domain/Creators/Test_Rectangle.cpp
+++ b/tests/Unit/Domain/Creators/Test_Rectangle.cpp
@@ -178,6 +178,7 @@ void test_rectangle_factory() {
             "  TimeDependence:\n"
             "    UniformTranslation:\n"
             "      InitialTime: 1.0\n"
+            "      InitialExpirationDeltaT: 9.0\n"
             "      Velocity: [2.3, -0.3]\n"
             "      FunctionOfTimeNames: [TranslationX, TranslationY]");
     const auto* rectangle_creator =
@@ -193,11 +194,12 @@ void test_rectangle_factory() {
             std::pair<std::string,
                       domain::FunctionsOfTime::PiecewisePolynomial<2>>{
                 "TranslationX",
-                {1.0, std::array<DataVector, 3>{{{0.0}, {2.3}, {0.0}}}}},
+                {1.0, std::array<DataVector, 3>{{{0.0}, {2.3}, {0.0}}}, 10.0}},
             std::pair<std::string,
                       domain::FunctionsOfTime::PiecewisePolynomial<2>>{
                 "TranslationY",
-                {1.0, std::array<DataVector, 3>{{{0.0}, {-0.3}, {0.0}}}}}),
+                {1.0, std::array<DataVector, 3>{{{0.0}, {-0.3}, {0.0}}},
+                 10.0}}),
         make_vector_coordinate_map_base<Frame::Grid, Frame::Inertial>(
             Translation2D{Translation{"TranslationX"},
                           Translation{"TranslationY"}}));

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_Composition.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_Composition.cpp
@@ -19,9 +19,7 @@
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/Domain/Creators/TimeDependence/TestHelpers.hpp"
 
-namespace domain {
-namespace creators {
-namespace time_dependence {
+namespace domain::creators::time_dependence {
 
 namespace {
 using Translation = domain::CoordinateMaps::TimeDependent::Translation;
@@ -239,6 +237,4 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.Composition",
   test_composition_3d(make_not_null(&gen), initial_time, update_delta_t);
 }
 }  // namespace
-}  // namespace time_dependence
-}  // namespace creators
-}  // namespace domain
+}  // namespace domain::creators::time_dependence

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_Composition.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_Composition.cpp
@@ -114,7 +114,8 @@ void test_impl(
 
 template <typename T>
 void test_composition_1d(const gsl::not_null<T> gen,
-                         const double initial_time) noexcept {
+                         const double initial_time,
+                         const double update_delta_t) noexcept {
   using Composition1d =
       Composition<TimeDependenceCompositionTag<UniformTranslation<1>>,
                   TimeDependenceCompositionTag<UniformTranslation<1>, 1>>;
@@ -126,14 +127,14 @@ void test_composition_1d(const gsl::not_null<T> gen,
 
   std::unique_ptr<domain::creators::time_dependence::TimeDependence<1>>
       time_dep0 = std::make_unique<UniformTranslation<1>>(
-          initial_time, velocity0, f_of_t_names0);
+          initial_time, update_delta_t, velocity0, f_of_t_names0);
   std::unique_ptr<domain::creators::time_dependence::TimeDependence<1>>
       time_dep1 = std::make_unique<UniformTranslation<1>>(
-          initial_time, velocity1, f_of_t_names1);
+          initial_time, update_delta_t, velocity1, f_of_t_names1);
 
   const std::unique_ptr<domain::creators::time_dependence::TimeDependence<1>>
       expected_time_dep = std::make_unique<UniformTranslation<1>>(
-          initial_time, velocity0 + velocity1,
+          initial_time, update_delta_t, velocity0 + velocity1,
           std::array<std::string, 1>{{"TranslationX"}});
 
   const std::unique_ptr<domain::creators::time_dependence::TimeDependence<1>>
@@ -149,7 +150,8 @@ void test_composition_1d(const gsl::not_null<T> gen,
 
 template <typename T>
 void test_composition_2d(const gsl::not_null<T> gen,
-                         const double initial_time) noexcept {
+                         const double initial_time,
+                         const double update_delta_t) noexcept {
   using Composition2d =
       Composition<TimeDependenceCompositionTag<UniformTranslation<2>>,
                   TimeDependenceCompositionTag<UniformTranslation<2>, 1>>;
@@ -163,14 +165,14 @@ void test_composition_2d(const gsl::not_null<T> gen,
 
   std::unique_ptr<domain::creators::time_dependence::TimeDependence<2>>
       time_dep0 = std::make_unique<UniformTranslation<2>>(
-          initial_time, velocity0, f_of_t_names0);
+          initial_time, update_delta_t, velocity0, f_of_t_names0);
   std::unique_ptr<domain::creators::time_dependence::TimeDependence<2>>
       time_dep1 = std::make_unique<UniformTranslation<2>>(
-          initial_time, velocity1, f_of_t_names1);
+          initial_time, update_delta_t, velocity1, f_of_t_names1);
 
   const std::unique_ptr<domain::creators::time_dependence::TimeDependence<2>>
       expected_time_dep = std::make_unique<UniformTranslation<2>>(
-          initial_time, velocity0 + velocity1,
+          initial_time, update_delta_t, velocity0 + velocity1,
           std::array<std::string, 2>{{"TranslationX", "TranslationY"}});
 
   const std::unique_ptr<domain::creators::time_dependence::TimeDependence<2>>
@@ -188,7 +190,8 @@ void test_composition_2d(const gsl::not_null<T> gen,
 
 template <typename T>
 void test_composition_3d(const gsl::not_null<T> gen,
-                         const double initial_time) noexcept {
+                         const double initial_time,
+                         const double update_delta_t) noexcept {
   using Composition3d =
       Composition<TimeDependenceCompositionTag<UniformTranslation<3>>,
                   TimeDependenceCompositionTag<UniformTranslation<3>, 1>>;
@@ -202,14 +205,14 @@ void test_composition_3d(const gsl::not_null<T> gen,
 
   std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
       time_dep0 = std::make_unique<UniformTranslation<3>>(
-          initial_time, velocity0, f_of_t_names0);
+          initial_time, update_delta_t, velocity0, f_of_t_names0);
   std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
       time_dep1 = std::make_unique<UniformTranslation<3>>(
-          initial_time, velocity1, f_of_t_names1);
+          initial_time, update_delta_t, velocity1, f_of_t_names1);
 
   const std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
       expected_time_dep = std::make_unique<UniformTranslation<3>>(
-          initial_time, velocity0 + velocity1,
+          initial_time, update_delta_t, velocity0 + velocity1,
           std::array<std::string, 3>{
               {"TranslationX", "TranslationY", "TranslationZ"}});
 
@@ -230,9 +233,10 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.Composition",
                   "[Domain][Unit]") {
   MAKE_GENERATOR(gen);
   const double initial_time = 1.3;
-  test_composition_1d(make_not_null(&gen), initial_time);
-  test_composition_2d(make_not_null(&gen), initial_time);
-  test_composition_3d(make_not_null(&gen), initial_time);
+  const double update_delta_t = 2.5;
+  test_composition_1d(make_not_null(&gen), initial_time, update_delta_t);
+  test_composition_2d(make_not_null(&gen), initial_time, update_delta_t);
+  test_composition_3d(make_not_null(&gen), initial_time, update_delta_t);
 }
 }  // namespace
 }  // namespace time_dependence

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_CubicScale.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_CubicScale.cpp
@@ -49,13 +49,14 @@ CoordMap<MeshDim> create_coord_map(
 template <size_t MeshDim>
 void test_impl(
     const std::unique_ptr<TimeDependence<MeshDim>>& time_dep_unique_ptr,
-    const double initial_time, const double outer_boundary,
-    const std::array<double, 2>& initial_expansion,
+    const double initial_time, const double update_delta_t,
+    const double outer_boundary, const std::array<double, 2>& initial_expansion,
     const std::array<double, 2>& velocity,
     const std::array<double, 2>& acceleration,
     const std::array<std::string, 2>& f_of_t_names) noexcept {
   MAKE_GENERATOR(gen);
   CAPTURE(initial_time);
+  CAPTURE(update_delta_t);
   CAPTURE(outer_boundary);
   CAPTURE(initial_expansion);
   CAPTURE(velocity);
@@ -152,6 +153,7 @@ void test_impl(
 template <size_t MeshDim>
 void test() noexcept {
   const double initial_time = 1.3;
+  const double update_delta_t = 2.5;
   const double outer_boundary = 10.4;
   const std::array<double, 2> initial_expansion{{1.0, 1.0}};
   const std::array<double, 2> velocity{{-0.1, 0.0}};
@@ -161,71 +163,76 @@ void test() noexcept {
   const std::unique_ptr<
       domain::creators::time_dependence::TimeDependence<MeshDim>>
       time_dep = std::make_unique<CubicScale<MeshDim>>(
-          initial_time, outer_boundary, f_of_t_names, initial_expansion,
-          velocity, acceleration);
-  test_impl(time_dep, initial_time, outer_boundary, initial_expansion, velocity,
-            acceleration, f_of_t_names);
-  test_impl(time_dep->get_clone(), initial_time, outer_boundary,
+          initial_time, update_delta_t, outer_boundary, f_of_t_names,
+          initial_expansion, velocity, acceleration);
+  test_impl(time_dep, initial_time, update_delta_t, outer_boundary,
+            initial_expansion, velocity, acceleration, f_of_t_names);
+  test_impl(time_dep->get_clone(), initial_time, update_delta_t, outer_boundary,
             initial_expansion, velocity, acceleration, f_of_t_names);
 
   test_impl(TestHelpers::test_factory_creation<TimeDependence<MeshDim>>(
                 "CubicScale:\n"
                 "  InitialTime: 1.3\n"
+                "  InitialExpirationDeltaT: 2.5\n"
                 "  OuterBoundary: 10.4\n"
                 "  InitialExpansion: [1.0, 1.0]\n"
                 "  Velocity: [-0.1, 0.0]\n"
                 "  Acceleration: [0.0, 0.0]\n"
                 "  FunctionOfTimeNames: [Expansion0, Expansion1]\n"),
-            initial_time, outer_boundary, initial_expansion, velocity,
-            acceleration, f_of_t_names);
+            initial_time, update_delta_t, outer_boundary, initial_expansion,
+            velocity, acceleration, f_of_t_names);
 
   test_impl(TestHelpers::test_factory_creation<TimeDependence<MeshDim>>(
                 "CubicScale:\n"
                 "  InitialTime: 1.3\n"
+                "  InitialExpirationDeltaT: 2.5\n"
                 "  OuterBoundary: 10.4\n"
                 "  InitialExpansion: [1.0, 1.0]\n"
                 "  Velocity: [-0.1, 0.0]\n"
                 "  Acceleration: [0.0, 0.0]\n"),
-            initial_time, outer_boundary, initial_expansion, velocity,
-            acceleration, {{"ExpansionA", "ExpansionB"}});
+            initial_time, update_delta_t, outer_boundary, initial_expansion,
+            velocity, acceleration, {{"ExpansionA", "ExpansionB"}});
 
   INFO("Check equivalence operators");
   CubicScale<MeshDim> cubic_scale0{
-      1.0,          2.0,           {{"ExpansionA", "ExpansionB"}},
+      1.0,          2.5,           2.0,         {{"ExpansionA", "ExpansionB"}},
       {{1.0, 2.0}}, {{-1.0, 3.0}}, {{0.2, 0.9}}};
   CubicScale<MeshDim> cubic_scale1{
-      1.2,          2.0,           {{"ExpansionA", "ExpansionB"}},
+      1.2,          2.5,           2.0,         {{"ExpansionA", "ExpansionB"}},
       {{1.0, 2.0}}, {{-1.0, 3.0}}, {{0.2, 0.9}}};
   CubicScale<MeshDim> cubic_scale2{
-      1.0,          3.0,           {{"ExpansionA0", "ExpansionB"}},
+      1.0,          2.5,           3.0,         {{"ExpansionA0", "ExpansionB"}},
       {{1.0, 2.0}}, {{-1.0, 3.0}}, {{0.2, 0.9}}};
   CubicScale<MeshDim> cubic_scale3{
-      1.0,          2.0,           {{"ExpansionA", "ExpansionB0"}},
+      1.0,          2.5,           2.0,         {{"ExpansionA", "ExpansionB0"}},
       {{1.0, 2.0}}, {{-1.0, 3.0}}, {{0.2, 0.9}}};
   CubicScale<MeshDim> cubic_scale4{
-      1.0,          2.0,           {{"ExpansionC", "ExpansionB"}},
+      1.0,          2.5,           2.0,         {{"ExpansionC", "ExpansionB"}},
       {{1.0, 2.0}}, {{-1.0, 3.0}}, {{0.2, 0.9}}};
   CubicScale<MeshDim> cubic_scale5{
-      1.0,          2.0,           {{"ExpansionA", "ExpansionC"}},
+      1.0,          2.5,           2.0,         {{"ExpansionA", "ExpansionC"}},
       {{1.0, 2.0}}, {{-1.0, 3.0}}, {{0.2, 0.9}}};
   CubicScale<MeshDim> cubic_scale6{
-      1.0,          2.0,           {{"ExpansionA", "ExpansionB"}},
+      1.0,          2.5,           2.0,         {{"ExpansionA", "ExpansionB"}},
       {{3.0, 2.0}}, {{-1.0, 3.0}}, {{0.2, 0.9}}};
   CubicScale<MeshDim> cubic_scale7{
-      1.0,          2.0,           {{"ExpansionA", "ExpansionB"}},
+      1.0,          2.5,           2.0,         {{"ExpansionA", "ExpansionB"}},
       {{1.0, 0.0}}, {{-1.0, 3.0}}, {{0.2, 0.9}}};
   CubicScale<MeshDim> cubic_scale8{
-      1.0,          2.0,           {{"ExpansionA", "ExpansionB"}},
+      1.0,          2.5,           2.0,         {{"ExpansionA", "ExpansionB"}},
       {{1.0, 2.0}}, {{-2.0, 3.0}}, {{0.2, 0.9}}};
   CubicScale<MeshDim> cubic_scale9{
-      1.0,          2.0,           {{"ExpansionA", "ExpansionB"}},
+      1.0,          2.5,           2.0,         {{"ExpansionA", "ExpansionB"}},
       {{1.0, 2.0}}, {{-1.0, 7.0}}, {{0.2, 0.9}}};
   CubicScale<MeshDim> cubic_scale10{
-      1.0,          2.0,           {{"ExpansionA", "ExpansionB"}},
+      1.0,          2.5,           2.0,         {{"ExpansionA", "ExpansionB"}},
       {{1.0, 2.0}}, {{-1.0, 3.0}}, {{3.2, 0.9}}};
   CubicScale<MeshDim> cubic_scale11{
-      1.0,          2.0,           {{"ExpansionA", "ExpansionB"}},
+      1.0,          2.5,           2.0,          {{"ExpansionA", "ExpansionB"}},
       {{1.0, 2.0}}, {{-1.0, 3.0}}, {{0.2, 10.9}}};
+  CubicScale<MeshDim> cubic_scale12{
+      1.0,          2.6,           2.0,         {{"ExpansionA", "ExpansionB"}},
+      {{1.0, 2.0}}, {{-1.0, 3.0}}, {{0.2, 0.9}}};
 
   CHECK(cubic_scale0 == cubic_scale0);
   CHECK_FALSE(cubic_scale0 != cubic_scale0);
@@ -251,6 +258,8 @@ void test() noexcept {
   CHECK_FALSE(cubic_scale0 == cubic_scale10);
   CHECK(cubic_scale0 != cubic_scale11);
   CHECK_FALSE(cubic_scale0 == cubic_scale11);
+  CHECK(cubic_scale0 != cubic_scale12);
+  CHECK_FALSE(cubic_scale0 == cubic_scale12);
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.CubicScale",

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_CubicScale.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_CubicScale.cpp
@@ -26,9 +26,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace domain {
-namespace creators {
-namespace time_dependence {
+namespace domain::creators::time_dependence {
 namespace {
 template <size_t MeshDim>
 using CubicScaleMap =
@@ -269,6 +267,4 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.CubicScale",
   test<3>();
 }
 }  // namespace
-}  // namespace time_dependence
-}  // namespace creators
-}  // namespace domain
+}  // namespace domain::creators::time_dependence

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_UniformRotationAboutZAxis.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_UniformRotationAboutZAxis.cpp
@@ -29,9 +29,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace domain {
-namespace creators {
-namespace time_dependence {
+namespace domain::creators::time_dependence {
 
 namespace {
 using Identity = domain::CoordinateMaps::Identity<1>;
@@ -244,6 +242,4 @@ SPECTRE_TEST_CASE(
 }
 }  // namespace
 
-}  // namespace time_dependence
-}  // namespace creators
-}  // namespace domain
+}  // namespace domain::creators::time_dependence

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_UniformRotationAboutZAxis.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_UniformRotationAboutZAxis.cpp
@@ -150,10 +150,11 @@ void test(const std::unique_ptr<TimeDependence<MeshDim>>& time_dep_unique_ptr,
 
 void test_equivalence() noexcept {
   {
-    UniformRotationAboutZAxis<2> ur0{1.0, 2.0, "RotationAnglePhi"};
-    UniformRotationAboutZAxis<2> ur1{1.2, 2.0, "RotationAnglePhi"};
-    UniformRotationAboutZAxis<2> ur2{1.0, 3.0, "RotationAnglePhi"};
-    UniformRotationAboutZAxis<2> ur3{1.0, 2.0, "RotationAngleTheta"};
+    UniformRotationAboutZAxis<2> ur0{1.0, 2.5, 2.0, "RotationAnglePhi"};
+    UniformRotationAboutZAxis<2> ur1{1.2, 2.5, 2.0, "RotationAnglePhi"};
+    UniformRotationAboutZAxis<2> ur2{1.0, 2.5, 3.0, "RotationAnglePhi"};
+    UniformRotationAboutZAxis<2> ur3{1.0, 2.5, 2.0, "RotationAngleTheta"};
+    UniformRotationAboutZAxis<2> ur4{1.0, 2.6, 2.0, "RotationAnglePhi"};
     CHECK(ur0 == ur0);
     CHECK_FALSE(ur0 != ur0);
     CHECK(ur0 != ur1);
@@ -162,12 +163,15 @@ void test_equivalence() noexcept {
     CHECK_FALSE(ur0 == ur2);
     CHECK(ur0 != ur3);
     CHECK_FALSE(ur0 == ur3);
+    CHECK(ur0 != ur4);
+    CHECK_FALSE(ur0 == ur4);
   }
   {
-    UniformRotationAboutZAxis<3> ur0{1.0, 2.0, "RotationAnglePhi"};
-    UniformRotationAboutZAxis<3> ur1{1.2, 2.0, "RotationAnglePhi"};
-    UniformRotationAboutZAxis<3> ur2{1.0, 3.0, "RotationAnglePhi"};
-    UniformRotationAboutZAxis<3> ur3{1.0, 2.0, "RotationAngleTheta"};
+    UniformRotationAboutZAxis<3> ur0{1.0, 2.5, 2.0, "RotationAnglePhi"};
+    UniformRotationAboutZAxis<3> ur1{1.2, 2.5, 2.0, "RotationAnglePhi"};
+    UniformRotationAboutZAxis<3> ur2{1.0, 2.5, 3.0, "RotationAnglePhi"};
+    UniformRotationAboutZAxis<3> ur3{1.0, 2.5, 2.0, "RotationAngleTheta"};
+    UniformRotationAboutZAxis<3> ur4{1.0, 2.6, 2.0, "RotationAnglePhi"};
     CHECK(ur0 == ur0);
     CHECK_FALSE(ur0 != ur0);
     CHECK(ur0 != ur1);
@@ -176,6 +180,8 @@ void test_equivalence() noexcept {
     CHECK_FALSE(ur0 == ur2);
     CHECK(ur0 != ur3);
     CHECK_FALSE(ur0 == ur3);
+    CHECK(ur0 != ur4);
+    CHECK_FALSE(ur0 == ur4);
   }
 }
 
@@ -183,19 +189,21 @@ SPECTRE_TEST_CASE(
     "Unit.Domain.Creators.TimeDependence.UniformRotationAboutZAxis",
     "[Domain][Unit]") {
   const double initial_time = 1.3;
+  const double update_delta_t = 2.5;
   constexpr double angular_velocity = 2.4;
   const std::string f_of_t_name{"RotationAngle"};
   {
     // 2d
     const std::unique_ptr<domain::creators::time_dependence::TimeDependence<2>>
         time_dep = std::make_unique<UniformRotationAboutZAxis<2>>(
-            initial_time, angular_velocity, f_of_t_name);
+            initial_time, update_delta_t, angular_velocity, f_of_t_name);
     test(time_dep, initial_time, f_of_t_name);
     test(time_dep->get_clone(), initial_time, f_of_t_name);
 
     test(TestHelpers::test_factory_creation<TimeDependence<2>>(
              "UniformRotationAboutZAxis:\n"
              "  InitialTime: 1.3\n"
+             "  InitialExpirationDeltaT: 2.5\n"
              "  AngularVelocity: 2.4\n"
              "  FunctionOfTimeName: RotationAngle\n"),
          initial_time, f_of_t_name);
@@ -203,6 +211,7 @@ SPECTRE_TEST_CASE(
     test(TestHelpers::test_factory_creation<TimeDependence<2>>(
              "UniformRotationAboutZAxis:\n"
              "  InitialTime: 1.3\n"
+             "  InitialExpirationDeltaT: 2.5\n"
              "  AngularVelocity: 2.4\n"),
          initial_time, "RotationAngle");
   }
@@ -211,13 +220,14 @@ SPECTRE_TEST_CASE(
     // 3d
     const std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
         time_dep = std::make_unique<UniformRotationAboutZAxis<3>>(
-            initial_time, angular_velocity, f_of_t_name);
+            initial_time, update_delta_t, angular_velocity, f_of_t_name);
     test(time_dep, initial_time, f_of_t_name);
     test(time_dep->get_clone(), initial_time, f_of_t_name);
 
     test(TestHelpers::test_factory_creation<TimeDependence<3>>(
              "UniformRotationAboutZAxis:\n"
              "  InitialTime: 1.3\n"
+             "  InitialExpirationDeltaT: Auto\n"
              "  AngularVelocity: 2.4\n"
              "  FunctionOfTimeName: RotationAngle\n"),
          initial_time, f_of_t_name);
@@ -225,6 +235,7 @@ SPECTRE_TEST_CASE(
     test(TestHelpers::test_factory_creation<TimeDependence<3>>(
              "UniformRotationAboutZAxis:\n"
              "  InitialTime: 1.3\n"
+             "  InitialExpirationDeltaT: Auto\n"
              "  AngularVelocity: 2.4\n"),
          initial_time, "RotationAngle");
   }

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_UniformTranslation.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_UniformTranslation.cpp
@@ -170,10 +170,11 @@ void test(const std::unique_ptr<TimeDependence<MeshDim>>& time_dep_unique_ptr,
 
 void test_equivalence() noexcept {
   {
-    UniformTranslation<1> ut0{1.0, {{2.0}}, {{"TranslationX"}}};
-    UniformTranslation<1> ut1{1.2, {{2.0}}, {{"TranslationX"}}};
-    UniformTranslation<1> ut2{1.0, {{3.0}}, {{"TranslationX"}}};
-    UniformTranslation<1> ut3{1.0, {{2.0}}, {{"TranslationY"}}};
+    UniformTranslation<1> ut0{1.0, 2.5, {{2.0}}, {{"TranslationX"}}};
+    UniformTranslation<1> ut1{1.2, 2.5, {{2.0}}, {{"TranslationX"}}};
+    UniformTranslation<1> ut2{1.0, 2.5, {{3.0}}, {{"TranslationX"}}};
+    UniformTranslation<1> ut3{1.0, 2.5, {{2.0}}, {{"TranslationY"}}};
+    UniformTranslation<1> ut4{1.0, 2.6, {{2.0}}, {{"TranslationX"}}};
     CHECK(ut0 == ut0);
     CHECK_FALSE(ut0 != ut0);
     CHECK(ut0 != ut1);
@@ -182,20 +183,24 @@ void test_equivalence() noexcept {
     CHECK_FALSE(ut0 == ut2);
     CHECK(ut0 != ut3);
     CHECK_FALSE(ut0 == ut3);
+    CHECK(ut0 != ut4);
+    CHECK_FALSE(ut0 == ut4);
   }
   {
     UniformTranslation<2> ut0{
-        1.0, {{2.0, 4.0}}, {{"TranslationX", "TranslationY"}}};
+        1.0, 2.5, {{2.0, 4.0}}, {{"TranslationX", "TranslationY"}}};
     UniformTranslation<2> ut1{
-        1.2, {{2.0, 4.0}}, {{"TranslationX", "TranslationY"}}};
+        1.2, 2.5, {{2.0, 4.0}}, {{"TranslationX", "TranslationY"}}};
     UniformTranslation<2> ut2{
-        1.0, {{3.0, 4.0}}, {{"TranslationX", "TranslationY"}}};
+        1.0, 2.5, {{3.0, 4.0}}, {{"TranslationX", "TranslationY"}}};
     UniformTranslation<2> ut3{
-        1.0, {{2.0, 5.0}}, {{"TranslationX", "TranslationY"}}};
+        1.0, 2.5, {{2.0, 5.0}}, {{"TranslationX", "TranslationY"}}};
     UniformTranslation<2> ut4{
-        1.0, {{2.0, 4.0}}, {{"TranslationZ", "TranslationY"}}};
+        1.0, 2.5, {{2.0, 4.0}}, {{"TranslationZ", "TranslationY"}}};
     UniformTranslation<2> ut5{
-        1.0, {{2.0, 4.0}}, {{"TranslationX", "TranslationZ"}}};
+        1.0, 2.5, {{2.0, 4.0}}, {{"TranslationX", "TranslationZ"}}};
+    UniformTranslation<2> ut6{
+        1.0, 2.6, {{2.0, 4.0}}, {{"TranslationX", "TranslationY"}}};
     CHECK(ut0 == ut0);
     CHECK_FALSE(ut0 != ut0);
     CHECK(ut0 != ut1);
@@ -208,40 +213,55 @@ void test_equivalence() noexcept {
     CHECK_FALSE(ut0 == ut4);
     CHECK(ut0 != ut5);
     CHECK_FALSE(ut0 == ut5);
+    CHECK(ut0 != ut6);
+    CHECK_FALSE(ut0 == ut6);
   }
   {
     UniformTranslation<3> ut0{
         1.0,
+        2.5,
         {{2.0, 4.0, 6.0}},
         {{"TranslationX", "TranslationY", "TranslationZ"}}};
     UniformTranslation<3> ut1{
         1.2,
+        2.5,
         {{2.0, 4.0, 6.0}},
         {{"TranslationX", "TranslationY", "TranslationZ"}}};
     UniformTranslation<3> ut2{
         1.0,
+        2.5,
         {{3.0, 4.0, 6.0}},
         {{"TranslationX", "TranslationY", "TranslationZ"}}};
     UniformTranslation<3> ut3{
         1.0,
+        2.5,
         {{2.0, 5.0, 6.0}},
         {{"TranslationX", "TranslationY", "TranslationZ"}}};
     UniformTranslation<3> ut4{
         1.0,
+        2.5,
         {{2.0, 4.0, 7.0}},
         {{"TranslationX", "TranslationY", "TranslationZ"}}};
     UniformTranslation<3> ut5{
         1.0,
+        2.5,
         {{2.0, 4.0, 6.0}},
         {{"TranslationW", "TranslationY", "TranslationZ"}}};
     UniformTranslation<3> ut6{
         1.0,
+        2.5,
         {{2.0, 4.0, 6.0}},
         {{"TranslationX", "TranslationW", "TranslationZ"}}};
     UniformTranslation<3> ut7{
         1.0,
+        2.5,
         {{2.0, 4.0, 6.0}},
         {{"TranslationX", "TranslationY", "TranslationW"}}};
+    UniformTranslation<3> ut8{
+        1.0,
+        2.6,
+        {{2.0, 4.0, 6.0}},
+        {{"TranslationX", "TranslationY", "TranslationZ"}}};
     CHECK(ut0 == ut0);
     CHECK_FALSE(ut0 != ut0);
     CHECK(ut0 != ut1);
@@ -258,12 +278,15 @@ void test_equivalence() noexcept {
     CHECK_FALSE(ut0 == ut6);
     CHECK(ut0 != ut7);
     CHECK_FALSE(ut0 == ut7);
+    CHECK(ut0 != ut8);
+    CHECK_FALSE(ut0 == ut8);
   }
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.UniformTranslation",
                   "[Domain][Unit]") {
   const double initial_time = 1.3;
+  const double update_delta_t = 2.5;
 
   {
     // 1d
@@ -271,13 +294,14 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.UniformTranslation",
     const std::array<std::string, 1> f_of_t_names{{"TranslationInX"}};
     const std::unique_ptr<domain::creators::time_dependence::TimeDependence<1>>
         time_dep = std::make_unique<UniformTranslation<1>>(
-            initial_time, velocity, f_of_t_names);
+            initial_time, update_delta_t, velocity, f_of_t_names);
     test(time_dep, initial_time, f_of_t_names);
     test(time_dep->get_clone(), initial_time, f_of_t_names);
 
     test(TestHelpers::test_factory_creation<TimeDependence<1>>(
              "UniformTranslation:\n"
              "  InitialTime: 1.3\n"
+             "  InitialExpirationDeltaT: 2.5\n"
              "  Velocity: [2.4]\n"
              "  FunctionOfTimeNames: [TranslationInX]\n"),
          initial_time, f_of_t_names);
@@ -285,6 +309,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.UniformTranslation",
     test(TestHelpers::test_factory_creation<TimeDependence<1>>(
              "UniformTranslation:\n"
              "  InitialTime: 1.3\n"
+             "  InitialExpirationDeltaT: 2.5\n"
              "  Velocity: [2.4]\n"),
          initial_time, {{"TranslationX"}});
   }
@@ -296,13 +321,14 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.UniformTranslation",
         {"TranslationInX", "TranslationInY"}};
     const std::unique_ptr<domain::creators::time_dependence::TimeDependence<2>>
         time_dep = std::make_unique<UniformTranslation<2>>(
-            initial_time, velocity, f_of_t_names);
+            initial_time, update_delta_t, velocity, f_of_t_names);
     test(time_dep, initial_time, f_of_t_names);
     test(time_dep->get_clone(), initial_time, f_of_t_names);
 
     test(TestHelpers::test_factory_creation<TimeDependence<2>>(
              "UniformTranslation:\n"
              "  InitialTime: 1.3\n"
+             "  InitialExpirationDeltaT: 2.5\n"
              "  Velocity: [2.4, 3.1]\n"
              "  FunctionOfTimeNames: [TranslationInX, TranslationInY]\n"),
          initial_time, f_of_t_names);
@@ -310,6 +336,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.UniformTranslation",
     test(TestHelpers::test_factory_creation<TimeDependence<2>>(
              "UniformTranslation:\n"
              "  InitialTime: 1.3\n"
+             "  InitialExpirationDeltaT: 2.5\n"
              "  Velocity: [2.4, 3.1]\n"),
          initial_time, {{"TranslationX", "TranslationY"}});
   }
@@ -321,13 +348,14 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.UniformTranslation",
         {"TranslationInX", "TranslationInY", "TranslationInZ"}};
     const std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
         time_dep = std::make_unique<UniformTranslation<3>>(
-            initial_time, velocity, f_of_t_names);
+            initial_time, update_delta_t, velocity, f_of_t_names);
     test(time_dep, initial_time, f_of_t_names);
     test(time_dep->get_clone(), initial_time, f_of_t_names);
 
     test(TestHelpers::test_factory_creation<TimeDependence<3>>(
              "UniformTranslation:\n"
              "  InitialTime: 1.3\n"
+             "  InitialExpirationDeltaT: Auto\n"
              "  Velocity: [2.4, 3.1, -1.2]\n"
              "  FunctionOfTimeNames: [TranslationInX, TranslationInY, "
              "TranslationInZ]\n"),
@@ -336,6 +364,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.UniformTranslation",
     test(TestHelpers::test_factory_creation<TimeDependence<3>>(
              "UniformTranslation:\n"
              "  InitialTime: 1.3\n"
+             "  InitialExpirationDeltaT: Auto\n"
              "  Velocity: [2.4, 3.1, -1.2]\n"),
          initial_time, {{"TranslationX", "TranslationY", "TranslationZ"}});
   }

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_UniformTranslation.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_UniformTranslation.cpp
@@ -28,9 +28,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace domain {
-namespace creators {
-namespace time_dependence {
+namespace domain::creators::time_dependence {
 
 namespace {
 using Translation = domain::CoordinateMaps::TimeDependent::Translation;
@@ -373,6 +371,4 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.UniformTranslation",
 }
 }  // namespace
 
-}  // namespace time_dependence
-}  // namespace creators
-}  // namespace domain
+}  // namespace domain::creators::time_dependence

--- a/tests/Unit/Domain/Test_Block.cpp
+++ b/tests/Unit/Domain/Test_Block.cpp
@@ -142,7 +142,7 @@ void test_block_time_dependent() {
 
     functions_of_time["Translation"] =
         std::make_unique<FunctionsOfTime::PiecewisePolynomial<2>>(
-            0.0, std::array<DataVector, 3>{{{0.0}, {1.0}, {0.0}}});
+            0.0, std::array<DataVector, 3>{{{0.0}, {1.0}, {0.0}}}, 2.5);
 
     // Test external boundaries:
     CHECK((block.external_boundaries().size()) == 2 * Dim);

--- a/tests/Unit/Domain/Test_BlockAndElementLogicalCoordinates.cpp
+++ b/tests/Unit/Domain/Test_BlockAndElementLogicalCoordinates.cpp
@@ -296,7 +296,7 @@ void fuzzy_test_block_and_element_logical_coordinates_time_dependent_brick(
     const size_t n_pts) noexcept {
   const auto uniform_translation =
       domain::creators::time_dependence::UniformTranslation<3>(
-          0.0, {{0.1, 0.2, 0.3}});
+          0.0, 2.5, {{0.1, 0.2, 0.3}});
   const auto brick = domain::creators::Brick(
       {{-0.1, -0.2, -0.3}}, {{0.1, 0.2, 0.3}}, {{false, false, false}},
       {{0, 0, 0}}, {{3, 3, 3}}, uniform_translation.get_clone());

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -149,10 +149,10 @@ void test_1d_domains() {
         functions_of_time{};
     functions_of_time["Translation0"] =
         std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
-            1.0, std::array<DataVector, 3>{{{0.0}, {2.3}, {0.0}}});
+            1.0, std::array<DataVector, 3>{{{0.0}, {2.3}, {0.0}}}, 10.0);
     functions_of_time["Translation1"] =
         std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
-            1.0, std::array<DataVector, 3>{{{0.0}, {5.3}, {0.0}}});
+            1.0, std::array<DataVector, 3>{{{0.0}, {5.3}, {0.0}}}, 10.0);
 
     test_domain_construction(domain_from_corners, expected_neighbors,
                              expected_boundaries, expected_logical_to_grid_maps,

--- a/tests/Unit/Domain/Test_FaceNormal.cpp
+++ b/tests/Unit/Domain/Test_FaceNormal.cpp
@@ -275,10 +275,11 @@ void test_face_normal_moving_mesh() {
   const std::array<DataVector, 3> init_func_a{{{1.0}, {-0.1}, {0.0}}};
   const std::array<DataVector, 3> init_func_b{{{1.0}, {0.0}, {0.0}}};
   const double initial_time = 0.0;
+  const double expiration_time = 10.0;
   functions_of_time["ExpansionA"] =
-      std::make_unique<Polynomial>(initial_time, init_func_a);
+      std::make_unique<Polynomial>(initial_time, init_func_a, expiration_time);
   functions_of_time["ExpansionB"] =
-      std::make_unique<Polynomial>(initial_time, init_func_b);
+      std::make_unique<Polynomial>(initial_time, init_func_b, expiration_time);
 
   {
     INFO("1d");

--- a/tests/Unit/Domain/Test_InterfaceItems.cpp
+++ b/tests/Unit/Domain/Test_InterfaceItems.cpp
@@ -657,10 +657,11 @@ void test_boundary_coordinates_moving_mesh() {
   const std::array<DataVector, 3> init_func_a{{{1.0}, {-0.1}, {0.0}}};
   const std::array<DataVector, 3> init_func_b{{{1.0}, {0.0}, {0.0}}};
   const double initial_time = 0.0;
+  const double expiration_time = 10.0;
   functions_of_time["ExpansionA"] =
-      std::make_unique<Polynomial>(initial_time, init_func_a);
+      std::make_unique<Polynomial>(initial_time, init_func_a, expiration_time);
   functions_of_time["ExpansionB"] =
-      std::make_unique<Polynomial>(initial_time, init_func_b);
+      std::make_unique<Polynomial>(initial_time, init_func_b, expiration_time);
 
   const auto perform_checks = [&functions_of_time, &times_to_check](
                                   const auto& element_id,

--- a/tests/Unit/Domain/Test_SizeOfElement.cpp
+++ b/tests/Unit/Domain/Test_SizeOfElement.cpp
@@ -85,13 +85,15 @@ std::unordered_map<std::string,
                    std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
 make_single_expansion_functions_of_time() noexcept {
   const double initial_time = 0.0;
+  const double expiration_time = 10.0;
   std::unordered_map<std::string,
                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
       functions_of_time{};
   functions_of_time.insert(std::make_pair(
       "Expansion",
       std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
-          initial_time, std::array<DataVector, 3>{{{0.0}, {1.0}, {0.0}}})));
+          initial_time, std::array<DataVector, 3>{{{0.0}, {1.0}, {0.0}}},
+          expiration_time)));
   return functions_of_time;
 }
 

--- a/tests/Unit/Domain/Test_TagsTimeDependent.cpp
+++ b/tests/Unit/Domain/Test_TagsTimeDependent.cpp
@@ -137,6 +137,7 @@ void test() noexcept {
   MAKE_GENERATOR(gen);
   const std::array<double, 3> velocity{{1.2, 0.2, -8.9}};
   const double initial_time = 0.0;
+  const double expiration_time = 5.0;
   const std::array<std::string, 3> functions_of_time_names{
       {"TranslationX", "TranslationY", "TranslationZ"}};
 
@@ -158,15 +159,18 @@ void test() noexcept {
   functions_of_time[functions_of_time_names[0]] =
       std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
           initial_time,
-          std::array<DataVector, 3>{{{0.0}, {velocity[0]}, {0.0}}});
+          std::array<DataVector, 3>{{{0.0}, {velocity[0]}, {0.0}}},
+          expiration_time);
   functions_of_time[functions_of_time_names[1]] =
       std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
           initial_time,
-          std::array<DataVector, 3>{{{0.0}, {velocity[1]}, {0.0}}});
+          std::array<DataVector, 3>{{{0.0}, {velocity[1]}, {0.0}}},
+          expiration_time);
   functions_of_time[functions_of_time_names[2]] =
       std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
           initial_time,
-          std::array<DataVector, 3>{{{0.0}, {velocity[2]}, {0.0}}});
+          std::array<DataVector, 3>{{{0.0}, {velocity[2]}, {0.0}}},
+          expiration_time);
 
   using MapPtr = std::unique_ptr<
       domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, Dim>>;

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActionsWithMinmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActionsWithMinmod.cpp
@@ -138,13 +138,15 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.LimiterActions.Minmod",
               CubicScaleMap{10.0, "Expansion", "Expansion"});
 
   const double initial_time = 0.0;
+  const double expiration_time = 2.5;
   std::unordered_map<std::string,
                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
       functions_of_time{};
   functions_of_time.insert(std::make_pair(
       "Expansion",
       std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
-          initial_time, std::array<DataVector, 3>{{{0.0}, {1.0}, {0.0}}})));
+          initial_time, std::array<DataVector, 3>{{{0.0}, {1.0}, {0.0}}},
+          expiration_time)));
 
   auto var = Scalar<DataVector>(mesh.number_of_grid_points(), 1234.);
 

--- a/tests/Unit/Evolution/Initialization/Test_DgDomain.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_DgDomain.cpp
@@ -194,6 +194,7 @@ void test() noexcept {
   const size_t num_pts = pow<Dim>(4_st);
   const std::array<double, 3> velocity{{1.2, 0.2, -8.9}};
   const double initial_time = 0.0;
+  const double expiration_time = 2.5;
   const std::array<std::string, 3> functions_of_time_names{
       {"TranslationX", "TranslationY", "TranslationZ"}};
   std::unordered_map<std::string,
@@ -203,8 +204,9 @@ void test() noexcept {
     functions_of_time.insert(std::make_pair(
         gsl::at(functions_of_time_names, i),
         std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
-            initial_time, std::array<DataVector, 3>{
-                              {{0.0}, {gsl::at(velocity, i)}, {0.0}}})));
+            initial_time,
+            std::array<DataVector, 3>{{{0.0}, {gsl::at(velocity, i)}, {0.0}}},
+            expiration_time)));
   }
 
   std::vector<Block<Dim>> blocks{1};

--- a/tests/Unit/Evolution/Initialization/Test_SetVariables.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_SetVariables.cpp
@@ -152,7 +152,7 @@ template <size_t Dim, typename Metavariables>
 auto emplace_component(
     const gsl::not_null<ActionTesting::MockRuntimeSystem<Metavariables>*>
         runner,
-    const double initial_time) {
+    const double initial_time, const double expiration_time) {
   using comp = component<Dim, Metavariables>;
 
   const auto logical_coords = logical_coordinates(Mesh<Dim>{
@@ -173,7 +173,8 @@ auto emplace_component(
   functions_of_time.insert(std::make_pair(
       expansion_factor,
       std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
-          initial_time, std::array<DataVector, 3>{{{1.0}, {-0.1}, {0.0}}})));
+          initial_time, std::array<DataVector, 3>{{{1.0}, {-0.1}, {0.0}}},
+          expiration_time)));
   Variables<tmpl::list<Var>> var(get<0>(logical_coords).size(), 8.9999);
   Variables<tmpl::list<PrimVar>> prim_var(get<0>(logical_coords).size(),
                                           9.9999);
@@ -214,8 +215,9 @@ void test_analytic_solution() noexcept {
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
   MockRuntimeSystem runner{{SystemAnalyticSolution{}}};
   const double initial_time = 1.3;
-  const auto inertial_coords =
-      emplace_component<Dim>(make_not_null(&runner), initial_time);
+  const double expiration_time = 2.5;
+  const auto inertial_coords = emplace_component<Dim>(
+      make_not_null(&runner), initial_time, expiration_time);
   Variables<tmpl::list<Var>> var(get<0>(inertial_coords).size(), 8.9999);
   Variables<tmpl::list<PrimVar>> prim_var(get<0>(inertial_coords).size(),
                                           9.9999);
@@ -257,8 +259,9 @@ void test_analytic_data() noexcept {
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
   MockRuntimeSystem runner{{SystemAnalyticData{}}};
   const double initial_time = 1.3;
-  const auto inertial_coords =
-      emplace_component<Dim>(make_not_null(&runner), initial_time);
+  const double expiration_time = 2.5;
+  const auto inertial_coords = emplace_component<Dim>(
+      make_not_null(&runner), initial_time, expiration_time);
   Variables<tmpl::list<Var>> var(get<0>(inertial_coords).size(), 8.9999);
   Variables<tmpl::list<PrimVar>> prim_var(get<0>(inertial_coords).size(),
                                           9.9999);

--- a/tests/Unit/Evolution/Test_TagsDomain.cpp
+++ b/tests/Unit/Evolution/Test_TagsDomain.cpp
@@ -117,6 +117,7 @@ void test() noexcept {
 
   const std::array<double, 3> velocity{{1.2, 0.2, -8.9}};
   const double initial_time = 0.0;
+  const double expiration_time = 4.5;
   // In 1d, the helper function create_coord_map will only use the first name,
   // i.e., TranslationX. In 2d, it uses the first two names, TranslationX and
   // TranslationY.
@@ -144,15 +145,18 @@ void test() noexcept {
   functions_of_time[functions_of_time_names[0]] =
       std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
           initial_time,
-          std::array<DataVector, 3>{{{0.0}, {velocity[0]}, {0.0}}});
+          std::array<DataVector, 3>{{{0.0}, {velocity[0]}, {0.0}}},
+          expiration_time);
   functions_of_time[functions_of_time_names[1]] =
       std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
           initial_time,
-          std::array<DataVector, 3>{{{0.0}, {velocity[1]}, {0.0}}});
+          std::array<DataVector, 3>{{{0.0}, {velocity[1]}, {0.0}}},
+          expiration_time);
   functions_of_time[functions_of_time_names[2]] =
       std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
           initial_time,
-          std::array<DataVector, 3>{{{0.0}, {velocity[2]}, {0.0}}});
+          std::array<DataVector, 3>{{{0.0}, {velocity[2]}, {0.0}}},
+          expiration_time);
 
   using MapPtr = std::unique_ptr<
       domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, Dim>>;

--- a/tests/Unit/IO/Importers/Test_ReadSpecThirdOrderPiecewisePolynomial.cpp
+++ b/tests/Unit/IO/Importers/Test_ReadSpecThirdOrderPiecewisePolynomial.cpp
@@ -101,6 +101,7 @@ SPECTRE_TEST_CASE("Unit.IO.ReadSpecThirdOrderPiecewisePolynomial",
   h5::H5File<h5::AccessType::ReadWrite> test_file(test_filename);
 
   constexpr size_t number_of_times = 3;
+  const double final_expiration_time = 0.3;
   const std::array<double, number_of_times> expected_times{{0.0, 0.1, 0.2}};
   const std::array<std::string, 2> expected_names{
       {"ExpansionFactor", "RotationAngle"}};
@@ -110,9 +111,12 @@ SPECTRE_TEST_CASE("Unit.IO.ReadSpecThirdOrderPiecewisePolynomial",
   const std::array<DataVector, number_of_times - 1> next_expansion_third_deriv{
       {{{0.5}}, {{0.75}}}};
   domain::FunctionsOfTime::PiecewisePolynomial<3> expansion(expected_times[0],
-                                                            initial_expansion);
-  expansion.update(expected_times[1], next_expansion_third_deriv[0]);
-  expansion.update(expected_times[2], next_expansion_third_deriv[1]);
+                                                            initial_expansion,
+                                                            expected_times[1]);
+  expansion.update(expected_times[1], next_expansion_third_deriv[0],
+                   expected_times[2]);
+  expansion.update(expected_times[2], next_expansion_third_deriv[1],
+                   final_expiration_time);
   const std::array<std::array<DataVector, 3>, number_of_times - 1>&
       expansion_func_and_2_derivs_next{
           {expansion.func_and_2_derivs(expected_times[1]),
@@ -122,10 +126,12 @@ SPECTRE_TEST_CASE("Unit.IO.ReadSpecThirdOrderPiecewisePolynomial",
       {{{2.0}}, {{-0.1}}, {{-0.02}}, {{-0.003}}}};
   const std::array<DataVector, number_of_times - 1> next_rotation_third_deriv{
       {{{-0.5}}, {{-0.75}}}};
-  domain::FunctionsOfTime::PiecewisePolynomial<3> rotation(expected_times[0],
-                                                           initial_rotation);
-  rotation.update(expected_times[1], {{next_rotation_third_deriv[0]}});
-  rotation.update(expected_times[2], {{next_rotation_third_deriv[1]}});
+  domain::FunctionsOfTime::PiecewisePolynomial<3> rotation(
+      expected_times[0], initial_rotation, expected_times[1]);
+  rotation.update(expected_times[1], {{next_rotation_third_deriv[0]}},
+                  expected_times[2]);
+  rotation.update(expected_times[2], {{next_rotation_third_deriv[1]}},
+                  final_expiration_time);
   const std::array<std::array<DataVector, 3>, number_of_times - 1>&
       rotation_func_and_2_derivs_next{
           {rotation.func_and_2_derivs(expected_times[1]),
@@ -185,10 +191,10 @@ SPECTRE_TEST_CASE("Unit.IO.ReadSpecThirdOrderPiecewisePolynomial",
       {{0.0}, {0.0}, {0.0}, {0.0}}};
   initial_functions_of_time["ExpansionFactor"] =
       std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<3>>(
-          0.0, initial_coefficients);
+          0.0, initial_coefficients, 0.1);
   initial_functions_of_time["RotationAngle"] =
       std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<3>>(
-          0.0, initial_coefficients);
+          0.0, initial_coefficients, 0.1);
 
   ActionTesting::emplace_component_and_initialize<component<Metavariables>>(
       &runner, self_id, {std::move(initial_functions_of_time)});
@@ -284,7 +290,7 @@ SPECTRE_TEST_CASE("Unit.IO.ReadSpecThirdOrderPiecewisePolynomialNonmonotonic",
       {{0.0}, {0.0}, {0.0}, {0.0}}};
   initial_functions_of_time["RotationAngle"] =
       std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<3>>(
-          0.0, initial_coefficients);
+          0.0, initial_coefficients, 0.1);
 
   ActionTesting::emplace_component_and_initialize<component<Metavariables>>(
       &runner, self_id, {std::move(initial_functions_of_time)});


### PR DESCRIPTION
## Proposed changes

The expiration time will be used to tell whether the
FunctionsOfTime in the GlobalCache are up to date.

Interface changes:
 - The one nontrival constructor of PiecewisePolynomial now takes
   an additional value expiration_time.
 - The update function of PiecewisePolynomial now takes an
   expiration_time.
 - PiecewisePolynomial::time_bounds() now returns expiration_time as
   its upper bounds.
 - FunctionOfTime::time_bounds() documentation now states that the
   bounds includes any allowed time-extrapolation.
 - Many tests have been changed to accomodate the interface changes
   in PiecewisePolynomial; this accounts for the vast majority of
   file changes in this commit.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

My current model is to use the upper bound of FunctionOfTime::time_bounds() to determine whether a FunctionOfTime is out of date. Alternatively I could add a new member function FunctionOfTime::expiration_time() expressly for that purpose, but I chose to keep fewer member functions in the interface.
