### PR TITLE
Make `NodeLock.cpp` a private library source

### DIFF
--- a/src/Elliptic/Executables/Elasticity/CMakeLists.txt
+++ b/src/Elliptic/Executables/Elasticity/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBS_TO_LINK
   IO
   LinearOperators
   Options
+  Parallel
   ParallelLinearSolver
   Utilities
   )

--- a/src/Elliptic/Executables/Poisson/CMakeLists.txt
+++ b/src/Elliptic/Executables/Poisson/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBS_TO_LINK
   LinearOperators
   MathFunctions
   Options
+  Parallel
   ParallelLinearSolver
   Poisson
   Utilities

--- a/src/Evolution/Executables/Burgers/CMakeLists.txt
+++ b/src/Evolution/Executables/Burgers/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBS_TO_LINK
   Limiters
   LinearOperators
   Options
+  Parallel
   Time
   Utilities
   )

--- a/src/Evolution/Executables/Cce/CMakeLists.txt
+++ b/src/Evolution/Executables/Cce/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBS_TO_LINK
   Spectral
   LinearOperators
   Options
+  Parallel
   Utilities
   )
 

--- a/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
@@ -17,6 +17,7 @@ set(LIBS_TO_LINK
   LinearOperators
   MathFunctions
   Options
+  Parallel
   Time
   Utilities
   )

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -17,6 +17,7 @@ set(LIBS_TO_LINK
   MathFunctions
   RelativisticEulerSolutions
   Options
+  Parallel
   Time
   Utilities
   ValenciaDivClean

--- a/src/Evolution/Executables/NewtonianEuler/CMakeLists.txt
+++ b/src/Evolution/Executables/NewtonianEuler/CMakeLists.txt
@@ -18,6 +18,7 @@ set(LIBS_TO_LINK
   NewtonianEulerSolutions
   NewtonianEulerSources
   Options
+  Parallel
   Time
   Utilities
   )

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/CMakeLists.txt
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/CMakeLists.txt
@@ -16,6 +16,7 @@ set(LIBS_TO_LINK
   M1Grey
   M1GreySolutions
   Options
+  Parallel
   Time
   Utilities
   )

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/CMakeLists.txt
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/CMakeLists.txt
@@ -16,6 +16,7 @@ set(LIBS_TO_LINK
   RelativisticEulerSolutions
   Time
   Options
+  Parallel
   Utilities
   Valencia
   )

--- a/src/Evolution/Executables/ScalarWave/CMakeLists.txt
+++ b/src/Evolution/Executables/ScalarWave/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBS_TO_LINK
   ScalarWave
   Time
   Options
+  Parallel
   Utilities
   WaveEquationSolutions
   )

--- a/src/Executables/ExportCoordinates/CMakeLists.txt
+++ b/src/Executables/ExportCoordinates/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBS_TO_LINK
   Informer
   IO
   Options
+  Parallel
   Time
   Utilities
   )

--- a/src/Executables/ParallelInfo/CMakeLists.txt
+++ b/src/Executables/ParallelInfo/CMakeLists.txt
@@ -26,4 +26,5 @@ target_link_libraries(
   PRIVATE
   ErrorHandling
   Informer
+  Parallel
   )

--- a/src/Parallel/CMakeLists.txt
+++ b/src/Parallel/CMakeLists.txt
@@ -10,7 +10,7 @@ add_spectre_library(${LIBRARY})
 
 spectre_target_sources(
   ${LIBRARY}
-  PUBLIC
+  PRIVATE
   NodeLock.cpp
   )
 

--- a/tests/Unit/IO/Importers/CMakeLists.txt
+++ b/tests/Unit/IO/Importers/CMakeLists.txt
@@ -31,7 +31,7 @@ function(add_algorithm_test TEST_NAME DIM)
     ${HPP_NAME}
     IO/Importers
     Metavariables<${DIM}>
-    "DataStructures;Domain;ErrorHandling;Informer;IO;Options"
+    "DataStructures;Domain;ErrorHandling;Informer;IO;Options;Parallel"
     )
 
   add_dependencies(test-executables ${EXECUTABLE_NAME})


### PR DESCRIPTION
## Proposed changes

resolves #2446 -- it was a CMake mistake on my part.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

