### PR TITLE
Add spec data option

### DIFF
--- a/src/Evolution/Systems/Cce/OptionTags.hpp
+++ b/src/Evolution/Systems/Cce/OptionTags.hpp
@@ -134,6 +134,16 @@ struct H5IsBondiData {
   using group = Cce;
 };
 
+struct FixSpecNormalization {
+  using type = bool;
+  static constexpr Options::String help{
+      "Set to true if corrections for SpEC data impurities should be applied "
+      "automatically based on the `VersionHist.ver` data set in the H5. "
+      "Typically, this should be set to true if the metric data is created "
+      "from SpEC, and false otherwise."};
+  using group = Cce;
+};
+
 struct GhInterfaceManager {
   using type = std::unique_ptr<InterfaceManagers::GhInterfaceManager>;
   static constexpr Options::String help{
@@ -217,14 +227,14 @@ struct H5WorldtubeBoundaryDataManager : db::SimpleTag {
   using option_tags =
       tmpl::list<OptionTags::LMax, OptionTags::BoundaryDataFilename,
                  OptionTags::H5LookaheadTimes, OptionTags::H5Interpolator,
-                 OptionTags::H5IsBondiData>;
+                 OptionTags::H5IsBondiData, OptionTags::FixSpecNormalization>;
 
   static constexpr bool pass_metavariables = false;
   static type create_from_options(
       const size_t l_max, const std::string& filename,
       const size_t number_of_lookahead_times,
       const std::unique_ptr<intrp::SpanInterpolator>& interpolator,
-      const bool h5_is_bondi_data) noexcept {
+      const bool h5_is_bondi_data, const bool fix_spec_normalization) noexcept {
     if (h5_is_bondi_data) {
       return std::make_unique<BondiWorldtubeDataManager>(
           std::make_unique<BondiWorldtubeH5BufferUpdater>(filename), l_max,
@@ -232,7 +242,8 @@ struct H5WorldtubeBoundaryDataManager : db::SimpleTag {
     } else {
       return std::make_unique<MetricWorldtubeDataManager>(
           std::make_unique<MetricWorldtubeH5BufferUpdater>(filename), l_max,
-          number_of_lookahead_times, interpolator->get_clone());
+          number_of_lookahead_times, interpolator->get_clone(),
+          fix_spec_normalization);
     }
   }
 };

--- a/src/Evolution/Systems/Cce/ScriPlusInterpolationManager.hpp
+++ b/src/Evolution/Systems/Cce/ScriPlusInterpolationManager.hpp
@@ -153,8 +153,8 @@ struct ScriPlusInterpolationManager {
   std::deque<VectorTypeToInterpolate> to_interpolate_values_;
   std::deque<std::pair<double, double>> u_bondi_ranges_;
   std::deque<double> target_times_;
-  size_t vector_size_;
-  size_t target_number_of_points_;
+  size_t vector_size_ = 0;
+  size_t target_number_of_points_ = 0;
   std::unique_ptr<intrp::SpanInterpolator> interpolator_;
 };
 

--- a/src/Evolution/Systems/Cce/WorldtubeBufferUpdater.cpp
+++ b/src/Evolution/Systems/Cce/WorldtubeBufferUpdater.cpp
@@ -98,8 +98,7 @@ MetricWorldtubeH5BufferUpdater::MetricWorldtubeH5BufferUpdater(
   // file format. This line determines whether or not the radial derivatives
   // require renormalization based on whether the SpEC version that produced it
   // was an old one that had a particular normalization bug
-  radial_derivatives_need_renormalization_ =
-      not cce_data_file_.exists<h5::Version>("/VersionHist");
+  has_version_history_ = cce_data_file_.exists<h5::Version>("/VersionHist");
 
   // We assume that the filename has the extraction radius encoded as an
   // integer between the last occurrence of 'R' and the last occurrence of
@@ -215,7 +214,7 @@ bool MetricWorldtubeH5BufferUpdater::time_is_outside_range(
 
 void MetricWorldtubeH5BufferUpdater::pup(PUP::er& p) noexcept {
   p | time_buffer_;
-  p | radial_derivatives_need_renormalization_;
+  p | has_version_history_;
   p | filename_;
   p | l_max_;
   p | extraction_radius_;

--- a/src/Evolution/Systems/Cce/WorldtubeBufferUpdater.hpp
+++ b/src/Evolution/Systems/Cce/WorldtubeBufferUpdater.hpp
@@ -164,7 +164,7 @@ class WorldtubeBufferUpdater : public PUP::able {
 
   virtual double get_extraction_radius() const noexcept = 0;
 
-  virtual bool radial_derivatives_need_renormalization() const noexcept = 0;
+  virtual bool has_version_history() const noexcept = 0;
 
   virtual DataVector& get_time_buffer() noexcept = 0;
 };
@@ -226,8 +226,8 @@ class MetricWorldtubeH5BufferUpdater
   /// type.
   DataVector& get_time_buffer() noexcept override { return time_buffer_; }
 
-  bool radial_derivatives_need_renormalization() const noexcept override {
-    return radial_derivatives_need_renormalization_;
+  bool has_version_history() const noexcept override {
+    return has_version_history_;
   }
 
   /// Serialization for Charm++.
@@ -239,7 +239,7 @@ class MetricWorldtubeH5BufferUpdater
                      size_t time_span_start,
                      size_t time_span_end) const noexcept;
 
-  bool radial_derivatives_need_renormalization_ = false;
+  bool has_version_history_ = true;
   double extraction_radius_ = 1.0;
   size_t l_max_ = 0;
 
@@ -313,8 +313,8 @@ class BondiWorldtubeH5BufferUpdater
   /// type.
   DataVector& get_time_buffer() noexcept override { return time_buffer_; }
 
-  bool radial_derivatives_need_renormalization() const noexcept override {
-    return false;
+  bool has_version_history() const noexcept override {
+    return true;
   }
 
   /// Serialization for Charm++.

--- a/src/Evolution/Systems/Cce/WorldtubeDataManager.cpp
+++ b/src/Evolution/Systems/Cce/WorldtubeDataManager.cpp
@@ -181,7 +181,7 @@ bool MetricWorldtubeDataManager::populate_hypersurface_boundary_data(
   // coefficients. This is what the boundary data calculation utility takes
   // as an input, so we now hand off the control flow to the boundary and
   // gauge transform utility
-  if (buffer_updater_->radial_derivatives_need_renormalization()) {
+  if (not buffer_updater_->has_version_history()) {
     create_bondi_boundary_data_from_unnormalized_spec_modes(
         boundary_data_variables,
         get<Tags::detail::SpatialMetric>(interpolated_coefficients_),

--- a/src/Evolution/Systems/Cce/WorldtubeDataManager.hpp
+++ b/src/Evolution/Systems/Cce/WorldtubeDataManager.hpp
@@ -90,7 +90,8 @@ class MetricWorldtubeDataManager : public WorldtubeDataManager {
       std::unique_ptr<WorldtubeBufferUpdater<cce_metric_input_tags>>
           buffer_updater,
       size_t l_max, size_t buffer_depth,
-      std::unique_ptr<intrp::SpanInterpolator> interpolator) noexcept;
+      std::unique_ptr<intrp::SpanInterpolator> interpolator,
+      bool fix_spec_normalization) noexcept;
 
   WRAPPED_PUPable_decl_template(MetricWorldtubeDataManager);  // NOLINT
 
@@ -138,6 +139,7 @@ class MetricWorldtubeDataManager : public WorldtubeDataManager {
   mutable size_t time_span_start_ = 0;
   mutable size_t time_span_end_ = 0;
   size_t l_max_ = 0;
+  bool fix_spec_normalization_ = false;
 
   // These buffers are just kept around to avoid allocations; they're
   // updated every time a time is requested

--- a/src/Executables/ReduceCceWorldtube/ReduceCceWorldtube.cpp
+++ b/src/Executables/ReduceCceWorldtube/ReduceCceWorldtube.cpp
@@ -208,7 +208,7 @@ void perform_cce_worldtube_reduction(const std::string& input_file,
         time_span_end - time_span_start, i - time_span_start, l_max,
         computation_l_max);
 
-    if (buffer_updater.radial_derivatives_need_renormalization()) {
+    if (not buffer_updater.has_version_history()) {
       Cce::create_bondi_boundary_data_from_unnormalized_spec_modes(
           make_not_null(&boundary_data_variables),
           get<Cce::Tags::detail::SpatialMetric>(coefficients_set),

--- a/tests/InputFiles/Cce/CharacteristicExtract.yaml
+++ b/tests/InputFiles/Cce/CharacteristicExtract.yaml
@@ -27,6 +27,7 @@ Cce:
     BarycentricRationalSpanInterpolator:
       MinOrder: 10
       MaxOrder: 10
+  FixSpecNormalization: False
 
   H5LookaheadTimes: 10000
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
@@ -207,7 +207,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.H5BoundaryCommunication",
       Tags::H5WorldtubeBoundaryDataManager::create_from_options(
           l_max, filename, buffer_size,
           std::make_unique<intrp::BarycentricRationalSpanInterpolator>(3u, 4u),
-          false));
+          false, false));
 
   // this should run the initializations
   ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
@@ -86,7 +86,7 @@ void test_h5_initialization(const gsl::not_null<Generator*> gen) noexcept {
       Tags::H5WorldtubeBoundaryDataManager::create_from_options(
           l_max, filename, buffer_size,
           std::make_unique<intrp::BarycentricRationalSpanInterpolator>(3u, 4u),
-          false));
+          false, false));
 
   // this should run the initialization
   ActionTesting::next_action<component>(make_not_null(&runner), 0);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
@@ -190,7 +190,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.RequestBoundaryData",
           l_max, filename, buffer_size,
           std::make_unique<intrp::BarycentricRationalSpanInterpolator>(3_st,
                                                                        4_st),
-          false));
+          false, false));
 
   // this should run the initializations
   ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);

--- a/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
@@ -128,7 +128,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
       "H5WorldtubeBoundaryDataManager");
   CHECK(Cce::Tags::H5WorldtubeBoundaryDataManager::create_from_options(
             8, filename, 3, std::make_unique<intrp::CubicSpanInterpolator>(),
-            false)
+            false, true)
             ->get_l_max() == 8);
 
   CHECK(Cce::Tags::LMax::create_from_options(8u) == 8u);

--- a/tests/Unit/Evolution/Systems/Cce/Test_WorldtubeData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_WorldtubeData.cpp
@@ -156,8 +156,8 @@ class DummyBufferUpdater
     return extraction_radius_;
   }
 
-  bool radial_derivatives_need_renormalization() const noexcept override {
-    return apply_normalization_bug_;
+  bool has_version_history() const noexcept override {
+    return not apply_normalization_bug_;
   }
 
   DataVector& get_time_buffer() noexcept override { return time_buffer_; }
@@ -311,8 +311,8 @@ class ReducedDummyBufferUpdater
 
   DataVector& get_time_buffer() noexcept override { return time_buffer_; }
 
-  bool radial_derivatives_need_renormalization() const noexcept override {
-    return false;
+  bool has_version_history() const noexcept override {
+    return true;
   }
 
   void pup(PUP::er& p) noexcept override {


### PR DESCRIPTION
## Proposed changes

We claim to support metric data from non-spec sources, so this removes the automatic renormalization for a spec bug unless it's requested in the input file.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
