### PR TITLE
Automatically deduce return type of TensorExpression get

### DIFF
--- a/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
+++ b/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
@@ -84,8 +84,8 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
   AddSub(T1 t1, T2 t2) : t1_(std::move(t1)), t2_(std::move(t2)) {}
 
   template <typename... LhsIndices, typename T>
-  SPECTRE_ALWAYS_INLINE type
-  get(const std::array<T, num_tensor_indices>& tensor_index) const {
+  SPECTRE_ALWAYS_INLINE decltype(auto) get(
+      const std::array<T, num_tensor_indices>& tensor_index) const {
     if constexpr (Sign == 1) {
       return t1_.template get<LhsIndices...>(tensor_index) +
              t2_.template get<LhsIndices...>(tensor_index);
@@ -96,7 +96,8 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
   }
 
   template <typename LhsStructure, typename... LhsIndices>
-  SPECTRE_ALWAYS_INLINE type get(const size_t lhs_storage_index) const {
+  SPECTRE_ALWAYS_INLINE decltype(auto) get(
+      const size_t lhs_storage_index) const {
     if constexpr (Sign == 1) {
       return t1_.template get<LhsStructure, LhsIndices...>(lhs_storage_index) +
              t2_.template get<LhsStructure, LhsIndices...>(lhs_storage_index);

--- a/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
@@ -413,7 +413,7 @@ struct TensorExpression<Derived, DataType, Symm, tmpl::list<Indices...>,
   /// \param tensor_index the tensor component to retrieve
   /// \return the value of the DataType of component `tensor_index`
   template <typename... LhsIndices, typename ArrayValueType>
-  SPECTRE_ALWAYS_INLINE type
+  SPECTRE_ALWAYS_INLINE decltype(auto)
   get(const std::array<ArrayValueType, num_tensor_indices>& tensor_index)
       const noexcept {
     if constexpr (tt::is_a_v<Tensor, Derived>) {
@@ -548,7 +548,7 @@ struct TensorExpression<Derived, DataType, Symm, tmpl::list<Indices...>,
   /// \return the value of the DataType of the component at `lhs_storage_index`
   /// in the LHS tensor
   template <typename LhsStructure, typename... LhsIndices>
-  SPECTRE_ALWAYS_INLINE type
+  SPECTRE_ALWAYS_INLINE decltype(auto)
   get(const size_t lhs_storage_index) const noexcept {
     if constexpr (not tt::is_a_v<Tensor, Derived>) {
       return static_cast<const Derived&>(*this)


### PR DESCRIPTION
## Proposed changes
This PR changes the return type of the `get` functions of `TensorExpression` and `AddSub` to be automatically deduced, as opposed to being explicitly set to the type of data being stored in the tensors (`double` or `DataVector`). The motivation is to avoid unnecessary extra allocations of  `DataVector`s when the data type of the tensor(s) in expressions is `DataVector`. 

For `TensorExpression`:
Currently, if the data type stored in the tensor is `DataVector`, a call to either of the `get`s has the return type `DataVector`. With the change in this PR, it is `const DataVector&`.

For `AddSub`:
Currently, if the data type stored by two added tensors is `DataVector`, a call to either of the `get`s has the return type `DataVector`. With the change in this PR, it is `const blaze::DVecDVecAddExpr<PointerVector<double, blaze::unaligned, blaze::unpadded, false, DataVector>, PointerVector<double, blaze::unaligned, blaze::unpadded, false, DataVector>, false>`.


### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
