### PR TITLE
Fix tensor expression contractions to be operational

### DIFF
--- a/src/DataStructures/Tensor/Expressions/Contract.hpp
+++ b/src/DataStructures/Tensor/Expressions/Contract.hpp
@@ -20,10 +20,10 @@ namespace TensorExpressions {
 namespace detail {
 
 template <typename I1, typename I2>
-using indices_contractible =
-    std::integral_constant<bool,
-                           I1::dim == I2::dim and I1::ul != I2::ul and
-                               I1::fr == I2::fr and I1::index == I2::index>;
+using indices_contractible = std::integral_constant<
+    bool, I1::dim == I2::dim and I1::ul != I2::ul and
+              std::is_same_v<typename I1::Frame, typename I2::Frame> and
+              I1::index_type == I2::index_type>;
 
 template <typename T, typename X, typename SymmList, typename IndexList,
           typename Args>
@@ -36,122 +36,128 @@ struct ComputeContractedTypeImpl<T, X, SymmList<Symm...>, IndexList, Args> {
       TensorExpression<T, X, Symmetry<Symm::value...>, IndexList, Args>;
 };
 
-template <typename Index1, typename Index2, typename T, typename X,
+template <typename ReplacedArg1, typename ReplacedArg2, typename T, typename X,
           typename Symm, typename IndexList, typename Args>
 using ComputeContractedType = typename ComputeContractedTypeImpl<
-    T, X, tmpl::erase<tmpl::erase<Symm, Index2>, Index1>,
-    tmpl::erase<tmpl::erase<IndexList, Index2>, Index1>,
-    tmpl::erase<tmpl::erase<Args, Index2>, Index1>>::type;
+    T, X,
+    tmpl::erase<tmpl::erase<Symm, tmpl::index_of<
+                                      Args, TensorIndex<ReplacedArg2::value>>>,
+                tmpl::index_of<Args, TensorIndex<ReplacedArg1::value>>>,
+    tmpl::erase<
+        tmpl::erase<IndexList,
+                    tmpl::index_of<Args, TensorIndex<ReplacedArg2::value>>>,
+        tmpl::index_of<Args, TensorIndex<ReplacedArg1::value>>>,
+    tmpl::erase<tmpl::erase<Args, tmpl::index_of<
+                                      Args, TensorIndex<ReplacedArg2::value>>>,
+                tmpl::index_of<Args, TensorIndex<ReplacedArg1::value>>>>::type;
 
-template <int I, typename Index1, typename Index2>
-struct ComputeContractionImpl {
-  template <typename... LhsIndices, typename T, typename S>
-  static SPECTRE_ALWAYS_INLINE typename T::type apply(S tensor_index,
-                                                      const T& t1) {
-    tensor_index[Index1::value] = I;
-    tensor_index[Index2::value] = I;
-    return t1.template get<LhsIndices...>(tensor_index) +
-           ComputeContractionImpl<I - 1, Index1, Index2>::template apply<
-               LhsIndices...>(tensor_index, t1);
-  }
-};
-
-template <typename Index1, typename Index2>
-struct ComputeContractionImpl<0, Index1, Index2> {
-  template <typename... LhsIndices, typename T, typename S>
-  static SPECTRE_ALWAYS_INLINE typename T::type apply(S tensor_index,
-                                                      const T& t1) {
-    tensor_index[Index1::value] = 0;
-    tensor_index[Index2::value] = 0;
+template <size_t I, size_t Index1, size_t Index2, typename... LhsIndices,
+          typename T, typename S>
+static SPECTRE_ALWAYS_INLINE decltype(auto) compute_contraction(S tensor_index,
+                                                                const T& t1) {
+  if constexpr (I == 0) {
+    tensor_index[Index1] = 0;
+    tensor_index[Index2] = 0;
     return t1.template get<LhsIndices...>(tensor_index);
+  } else {
+    tensor_index[Index1] = I;
+    tensor_index[Index2] = I;
+    return t1.template get<LhsIndices...>(tensor_index) +
+           compute_contraction<I - 1, Index1, Index2, LhsIndices...>(
+               tensor_index, t1);
   }
-};
+}
 }  // namespace detail
 
 /*!
  * \ingroup TensorExpressionsGroup
  */
-template <typename Index1, typename Index2, typename T, typename X,
+template <typename ReplacedArg1, typename ReplacedArg2, typename T, typename X,
           typename Symm, typename IndexList, typename ArgsList>
 struct TensorContract
-    : public TensorExpression<
-          TensorContract<Index1, Index2, T, X, Symm, IndexList, ArgsList>, X,
-          typename detail::ComputeContractedType<Index1, Index2, T, X, Symm,
-                                                 IndexList, ArgsList>::symmetry,
-          typename detail::ComputeContractedType<
-              Index1, Index2, T, X, Symm, IndexList, ArgsList>::index_list,
-          typename detail::ComputeContractedType<
-              Index1, Index2, T, X, Symm, IndexList, ArgsList>::args_list> {
-  using CI1 = tmpl::at<IndexList, Index1>;
-  using CI2 = tmpl::at<IndexList, Index2>;
+    : public TensorExpression<TensorContract<ReplacedArg1, ReplacedArg2, T, X,
+                                             Symm, IndexList, ArgsList>,
+                              X,
+                              typename detail::ComputeContractedType<
+                                  ReplacedArg1, ReplacedArg2, T, X, Symm,
+                                  IndexList, ArgsList>::symmetry,
+                              typename detail::ComputeContractedType<
+                                  ReplacedArg1, ReplacedArg2, T, X, Symm,
+                                  IndexList, ArgsList>::index_list,
+                              typename detail::ComputeContractedType<
+                                  ReplacedArg1, ReplacedArg2, T, X, Symm,
+                                  IndexList, ArgsList>::args_list> {
+  static constexpr size_t Index1 =
+      tmpl::index_of<ArgsList, TensorIndex<ReplacedArg1::value>>::value;
+  static constexpr size_t Index2 =
+      tmpl::index_of<ArgsList, TensorIndex<ReplacedArg2::value>>::value;
+  using CI1 = tmpl::at_c<IndexList, Index1>;
+  using CI2 = tmpl::at_c<IndexList, Index2>;
   static_assert(tmpl::size<Symm>::value > 1 and
                     tmpl::size<IndexList>::value > 1,
                 "Cannot contract indices on a Tensor with rank less than 2");
   static_assert(detail::indices_contractible<CI1, CI2>::value,
                 "Cannot contract the requested indices.");
 
-  using new_type = detail::ComputeContractedType<Index1, Index2, T, X, Symm,
-                                                 IndexList, ArgsList>;
+  using new_type = detail::ComputeContractedType<ReplacedArg1, ReplacedArg2, T,
+                                                 X, Symm, IndexList, ArgsList>;
 
   using type = X;
   using symmetry = typename new_type::symmetry;
   using index_list = typename new_type::index_list;
-  static constexpr auto num_tensor_indices =
-      tmpl::size<index_list>::value == 0 ? 1 : tmpl::size<index_list>::value;
-  using args_list = tmpl::sort<typename new_type::args_list>;
+  static constexpr auto num_tensor_indices = tmpl::size<index_list>::value;
+  using args_list = typename new_type::args_list;
 
   explicit TensorContract(
       const TensorExpression<T, X, Symm, IndexList, ArgsList>& t)
       : t_(~t) {}
 
-  template <size_t I, size_t Rank, Requires<(I <= Index1::value)> = nullptr>
+  template <size_t I, size_t Rank>
   SPECTRE_ALWAYS_INLINE void fill_contracting_tensor_index(
-      std::array<int, Rank>& tensor_index_in,
-      const std::array<int, num_tensor_indices>& tensor_index) const {
-    // -100 is for the slot that will be set later. Easy to debug.
-    tensor_index_in[I] = I == Index1::value ? -100 : tensor_index[I];
-    fill_contracting_tensor_index<I + 1>(tensor_index_in, tensor_index);
-  }
-
-  template <size_t I, size_t Rank,
-            Requires<(I > Index1::value and I <= Index2::value and
-                      I < Rank - 1)> = nullptr>
-  SPECTRE_ALWAYS_INLINE void fill_contracting_tensor_index(
-      std::array<int, Rank>& tensor_index_in,
-      const std::array<int, Rank - 2>& tensor_index) const {
-    // tensor_index is Rank - 2 since it shouldn't be called for Rank 2 case
-    // -200 is for the slot that will be set later. Easy to debug.
-    tensor_index_in[I] = I == Index2::value ? -200 : tensor_index[I - 1];
-    fill_contracting_tensor_index<I + 1>(tensor_index_in, tensor_index);
-  }
-
-  template <size_t I, size_t Rank,
-            Requires<(I > Index2::value and I < Rank - 1)> = nullptr>
-  SPECTRE_ALWAYS_INLINE void fill_contracting_tensor_index(
-      std::array<int, Rank>& tensor_index_in,
-      const std::array<int, Rank - 2>& tensor_index) const {
-    // Left as Rank - 2 since it should never be called for the Rank 2 case
-    tensor_index_in[I] = tensor_index[I - 2];
-    fill_contracting_tensor_index<I + 1>(tensor_index_in, tensor_index);
-  }
-
-  template <size_t I, size_t Rank, Requires<(I == Rank - 1)> = nullptr>
-  SPECTRE_ALWAYS_INLINE void fill_contracting_tensor_index(
-      std::array<int, Rank>& tensor_index_in,
-      const std::array<int, num_tensor_indices>& tensor_index) const {
-    tensor_index_in[I] = tensor_index[I - 2];
+      std::array<size_t, Rank>& tensor_index_in,
+      const std::array<size_t, num_tensor_indices>& tensor_index) const {
+    if constexpr (I < Index1) {
+      tensor_index_in[I] = tensor_index[I];
+      fill_contracting_tensor_index<I + 1>(tensor_index_in, tensor_index);
+    } else if constexpr (I == Index1) {
+      // 10000 is for the slot that will be set later. Easy to debug.
+      tensor_index_in[I] = 10000;
+      fill_contracting_tensor_index<I + 1>(tensor_index_in, tensor_index);
+    } else if constexpr (I > Index1 and I <= Index2 and I < Rank - 1) {
+      // tensor_index is Rank - 2 since it shouldn't be called for Rank 2 case
+      // 20000 is for the slot that will be set later. Easy to debug.
+      tensor_index_in[I] = I == Index2 ? 20000 : tensor_index[I - 1];
+      fill_contracting_tensor_index<I + 1>(tensor_index_in, tensor_index);
+    } else if constexpr (I > Index2 and I < Rank - 1) {
+      // Left as Rank - 2 since it should never be called for the Rank 2 case
+      tensor_index_in[I] = tensor_index[I - 2];
+      fill_contracting_tensor_index<I + 1>(tensor_index_in, tensor_index);
+    } else if constexpr (I == Index2) {
+      tensor_index_in[I] = 20000;
+    } else {
+      tensor_index_in[I] = tensor_index[I - 2];
+    }
   }
 
   template <typename... LhsIndices, typename U>
-  SPECTRE_ALWAYS_INLINE type
-  get(const std::array<U, num_tensor_indices>& new_tensor_index) const {
+  SPECTRE_ALWAYS_INLINE decltype(auto) get(
+      const std::array<U, num_tensor_indices>& new_tensor_index) const {
     // new_tensor_index is the one with _fewer_ components, ie post-contraction
-    std::array<int, tmpl::size<Symm>::value> tensor_index;
+    std::array<size_t, tmpl::size<Symm>::value> tensor_index{};
     // Manually unrolled for loops to compute the tensor_index from the
     // new_tensor_index
     fill_contracting_tensor_index<0>(tensor_index, new_tensor_index);
-    return detail::ComputeContractionImpl<CI1::dim - 1, Index1, Index2>::
-        template apply<LhsIndices...>(tensor_index, t_);
+    return detail::compute_contraction<CI1::dim - 1, Index1, Index2,
+                                       LhsIndices...>(tensor_index, t_);
+  }
+
+  template <typename LhsStructure, typename... LhsIndices>
+  SPECTRE_ALWAYS_INLINE decltype(auto) get(
+      const size_t lhs_storage_index) const {
+    const std::array<size_t, num_tensor_indices>& new_tensor_index =
+        LhsStructure::template get_canonical_tensor_index<num_tensor_indices>(
+            lhs_storage_index);
+    return get<LhsStructure, LhsIndices...>(new_tensor_index);
   }
 
  private:
@@ -163,63 +169,28 @@ struct TensorContract
 /*!
  * \ingroup TensorExpressionsGroup
  */
-template <int Index1, int Index2, typename T, typename X, typename Symm,
-          typename IndexList, typename Args>
+template <size_t ReplacedArg1, size_t ReplacedArg2, typename T, typename X,
+          typename Symm, typename IndexList, typename Args>
 SPECTRE_ALWAYS_INLINE auto contract(
     const TensorExpression<T, X, Symm, IndexList, Args>& t) {
-  return TensorContract<tmpl::int32_t<Index1>, tmpl::int32_t<Index2>, T, X,
-                        Symm, IndexList, Args>(~t);
+  return TensorContract<tmpl::size_t<ReplacedArg1>,
+                        tmpl::size_t<ReplacedArg2>, T, X, Symm, IndexList,
+                        Args>(~t);
 }
 
 namespace detail {
 // Helper struct to allow contractions by using repeated indices in operator()
 // calls to tensor.
-template <template <typename> class TE, typename ReplacedArgList, typename I,
-          typename TotalContracted>
-struct fully_contract_helper {
-  template <typename T>
-  SPECTRE_ALWAYS_INLINE static constexpr auto apply(const T& t) -> decltype(
-      contract<
-          tmpl::index_of<ReplacedArgList, ti_contracted_t<I::value>>::value,
-          tmpl::index_of<ReplacedArgList,
-                         ti_contracted_t<I::value + 1>>::value>(
-          fully_contract_helper<TE, ReplacedArgList, tmpl::next<I>,
-                                TotalContracted>::apply(t))) {
-    return contract<
-        tmpl::index_of<ReplacedArgList, ti_contracted_t<I::value>>::value,
-        tmpl::index_of<ReplacedArgList, ti_contracted_t<I::value + 1>>::value>(
-        fully_contract_helper<TE, ReplacedArgList, tmpl::next<I>,
-                              TotalContracted>::apply(t));
-  }
-};
-
-template <template <typename> class TE, typename ReplacedArgList,
-          typename TotalContracted>
-struct fully_contract_helper<TE, ReplacedArgList,
-                             tmpl::int32_t<TotalContracted::value - 1>,
-                             TotalContracted> {
-  using I = tmpl::int32_t<TotalContracted::value - 1>;
-  template <typename T>
-  SPECTRE_ALWAYS_INLINE static constexpr auto apply(const T& t) -> decltype(
-      contract<
-          tmpl::index_of<ReplacedArgList, ti_contracted_t<I::value>>::value,
-          tmpl::index_of<ReplacedArgList,
-                         ti_contracted_t<I::value + 1>>::value>(
-          TE<ReplacedArgList>(t))) {
-    return contract<
-        tmpl::index_of<ReplacedArgList, ti_contracted_t<I::value>>::value,
-        tmpl::index_of<ReplacedArgList, ti_contracted_t<I::value + 1>>::value>(
+template <template <typename> class TE, typename ReplacedArgList, size_t I,
+          typename TotalContracted, typename T>
+SPECTRE_ALWAYS_INLINE static constexpr auto fully_contract(const T& t) {
+  if constexpr (I == 2 * (TotalContracted::value - 1)) {
+    return contract<ti_contracted_t<I>::value, ti_contracted_t<I + 1>::value>(
         TE<ReplacedArgList>(t));
+  } else {
+    return contract<ti_contracted_t<I>::value, ti_contracted_t<I + 1>::value>(
+        fully_contract<TE, ReplacedArgList, I + 2, TotalContracted>(t));
   }
-};
+}
 }  // namespace detail
-
-/*!
- * \ingroup TensorExpressionsGroup
- * \brief Represents a fully contracted Tensor
- */
-template <template <typename> class TE, typename ReplacedArgList, typename I,
-          typename TotalContracted>
-using fully_contracted =
-    detail::fully_contract_helper<TE, ReplacedArgList, I, TotalContracted>;
 }  // namespace TensorExpressions

--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -274,15 +274,14 @@ class Tensor<X, Symm, IndexList<Indices...>> {
                      not tmpl::is_set<N...>::value> = nullptr>
   SPECTRE_ALWAYS_INLINE constexpr auto operator()(N... /*meta*/) const noexcept
       -> decltype(
-          TensorExpressions::fully_contracted<
+          TensorExpressions::detail::fully_contract<
               TE, replace_indices<tmpl::list<N...>, repeated<tmpl::list<N...>>>,
-              tmpl::int32_t<0>,
-              tmpl::size<repeated<tmpl::list<N...>>>>::apply(*this)) {
+              0, tmpl::size<repeated<tmpl::list<N...>>>>(*this)) {
     using args_list = tmpl::list<N...>;
     using repeated_args_list = repeated<args_list>;
-    return TensorExpressions::fully_contracted<
-        TE, replace_indices<args_list, repeated_args_list>, tmpl::int32_t<0>,
-        tmpl::size<repeated_args_list>>::apply(*this);
+    return TensorExpressions::detail::fully_contract<
+        TE, replace_indices<args_list, repeated_args_list>, 0,
+        tmpl::size<repeated_args_list>>(*this);
   }
   // @}
 

--- a/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
+++ b/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_Expressions")
 
 set(LIBRARY_SOURCES
   Test_AddSubtract.cpp
+  Test_Contract.cpp
   Test_TensorExpressions.cpp
   )
 

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Contract.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Contract.cpp
@@ -1,0 +1,540 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <iterator>
+#include <numeric>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Expressions/Contract.hpp"
+#include "DataStructures/Tensor/Expressions/Evaluate.hpp"
+#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/Requires.hpp"
+
+namespace {
+template <typename... Ts>
+void create_tensor(gsl::not_null<Tensor<double, Ts...>*> tensor) noexcept {
+  std::iota(tensor->begin(), tensor->end(), 0.0);
+}
+
+template <typename... Ts>
+void create_tensor(gsl::not_null<Tensor<DataVector, Ts...>*> tensor) noexcept {
+  double value = 0.0;
+  for (auto index_it = tensor->begin(); index_it != tensor->end(); index_it++) {
+    for (auto vector_it = index_it->begin(); vector_it != index_it->end();
+         vector_it++) {
+      *vector_it = value;
+      value += 1.0;
+    }
+  }
+}
+
+template <typename DataType>
+void test_contractions_rank2(const DataType& used_for_size) noexcept {
+  // Contract (upper, lower) tensor
+  // Use explicit type (vs auto) so the compiler checks the return type of
+  // `evaluate`
+  Tensor<DataType, Symmetry<2, 1>,
+         index_list<SpatialIndex<3, UpLo::Up, Frame::Inertial>,
+                    SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
+      Rul(used_for_size);
+  create_tensor(make_not_null(&Rul));
+
+  const Tensor<DataType> RIi_contracted =
+      TensorExpressions::evaluate(Rul(ti_I, ti_i));
+
+  DataType expected_RIi_sum = make_with_value<DataType>(used_for_size, 0.0);
+  for (size_t i = 0; i < 3; i++) {
+    expected_RIi_sum += Rul.get(i, i);
+  }
+  CHECK(RIi_contracted.get() == expected_RIi_sum);
+
+  // Contract (lower, upper) tensor
+  Tensor<DataType, Symmetry<2, 1>,
+         index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>
+      Rlu(used_for_size);
+  create_tensor(make_not_null(&Rlu));
+
+  const Tensor<DataType> RgG_contracted =
+      TensorExpressions::evaluate(Rlu(ti_g, ti_G));
+
+  DataType expected_RgG_sum = make_with_value<DataType>(used_for_size, 0.0);
+  for (size_t g = 0; g < 4; g++) {
+    expected_RgG_sum += Rlu.get(g, g);
+  }
+  CHECK(RgG_contracted.get() == expected_RgG_sum);
+}
+
+template <typename DataType>
+void test_contractions_rank3(const DataType& used_for_size) noexcept {
+  // Contract first and second indices of (lower, upper, lower) tensor
+  // Use explicit type (vs auto) so the compiler checks the return type of
+  // `evaluate`
+  Tensor<DataType, Symmetry<3, 2, 1>,
+         index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpatialIndex<3, UpLo::Up, Frame::Grid>,
+                    SpatialIndex<4, UpLo::Lo, Frame::Grid>>>
+      Rlul(used_for_size);
+  create_tensor(make_not_null(&Rlul));
+
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpatialIndex<4, UpLo::Lo, Frame::Grid>>>
+      RiIj_contracted =
+          TensorExpressions::evaluate<ti_j_t>(Rlul(ti_i, ti_I, ti_j));
+
+  for (size_t j = 0; j < 4; j++) {
+    DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
+    for (size_t i = 0; i < 3; i++) {
+      expected_sum += Rlul.get(i, i, j);
+    }
+    CHECK(RiIj_contracted.get(j) == expected_sum);
+  }
+
+  // Contract first and third indices of (upper, upper, lower) tensor
+  Tensor<DataType, Symmetry<2, 2, 1>,
+         index_list<SpatialIndex<3, UpLo::Up, Frame::Grid>,
+                    SpatialIndex<3, UpLo::Up, Frame::Grid>,
+                    SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
+      Ruul(used_for_size);
+  create_tensor(make_not_null(&Ruul));
+
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpatialIndex<3, UpLo::Up, Frame::Grid>>>
+      RJLj_contracted =
+          TensorExpressions::evaluate<ti_L_t>(Ruul(ti_J, ti_L, ti_j));
+
+  for (size_t l = 0; l < 3; l++) {
+    DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
+    for (size_t j = 0; j < 3; j++) {
+      expected_sum += Ruul.get(j, l, j);
+    }
+    CHECK(RJLj_contracted.get(l) == expected_sum);
+  }
+
+  // Contract second and third indices of (upper, lower, upper) tensor
+  Tensor<DataType, Symmetry<2, 1, 2>,
+         index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                    SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                    SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>>
+      Rulu(used_for_size);
+  create_tensor(make_not_null(&Rulu));
+
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>>
+      RBfF_contracted =
+          TensorExpressions::evaluate<ti_B_t>(Rulu(ti_B, ti_f, ti_F));
+
+  for (size_t b = 0; b < 4; b++) {
+    DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
+    for (size_t f = 0; f < 4; f++) {
+      expected_sum += Rulu.get(b, f, f);
+    }
+    CHECK(RBfF_contracted.get(b) == expected_sum);
+  }
+
+  // Contract first and third indices of (lower, lower, upper) tensor with mixed
+  // TensorIndexTypes
+  Tensor<DataType, Symmetry<3, 2, 1>,
+         index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpatialIndex<3, UpLo::Up, Frame::Grid>>>
+      Rllu(used_for_size);
+  create_tensor(make_not_null(&Rllu));
+
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
+      RiaI_contracted =
+          TensorExpressions::evaluate<ti_a_t>(Rllu(ti_i, ti_a, ti_I));
+
+  for (size_t a = 0; a < 4; a++) {
+    DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
+    for (size_t i = 0; i < 3; i++) {
+      expected_sum += Rllu.get(i, a, i);
+    }
+    CHECK(RiaI_contracted.get(a) == expected_sum);
+  }
+}
+
+template <typename DataType>
+void test_contractions_rank4(const DataType& used_for_size) noexcept {
+  // Contract first and second indices of (lower, upper, upper, lower) tensor to
+  // rank 2 tensor
+  // Use explicit type (vs auto) so the compiler checks the return type of
+  // `evaluate`
+  Tensor<DataType, Symmetry<4, 3, 2, 1>,
+         index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                    SpatialIndex<3, UpLo::Up, Frame::Inertial>,
+                    SpatialIndex<4, UpLo::Up, Frame::Inertial>,
+                    SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
+      Rluul(used_for_size);
+  create_tensor(make_not_null(&Rluul));
+
+  const Tensor<DataType, Symmetry<2, 1>,
+               index_list<SpatialIndex<4, UpLo::Up, Frame::Inertial>,
+                          SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
+      RiIKj_contracted = TensorExpressions::evaluate<ti_K_t, ti_j_t>(
+          Rluul(ti_i, ti_I, ti_K, ti_j));
+
+  for (size_t k = 0; k < 4; k++) {
+    for (size_t j = 0; j < 3; j++) {
+      DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
+      for (size_t i = 0; i < 3; i++) {
+        expected_sum += Rluul.get(i, i, k, j);
+      }
+      CHECK(RiIKj_contracted.get(k, j) == expected_sum);
+    }
+  }
+
+  // Contract first and third indices of (upper, upper, lower, lower) tensor to
+  // rank 2 tensor
+  Tensor<DataType, Symmetry<4, 3, 2, 1>,
+         index_list<SpacetimeIndex<4, UpLo::Up, Frame::Grid>,
+                    SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                    SpacetimeIndex<4, UpLo::Lo, Frame::Grid>,
+                    SpacetimeIndex<4, UpLo::Lo, Frame::Grid>>>
+      Ruull(used_for_size);
+  create_tensor(make_not_null(&Ruull));
+
+  const Tensor<DataType, Symmetry<2, 1>,
+               index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                          SpacetimeIndex<4, UpLo::Lo, Frame::Grid>>>
+      RABac_contracted = TensorExpressions::evaluate<ti_B_t, ti_c_t>(
+          Ruull(ti_A, ti_B, ti_a, ti_c));
+
+  for (size_t b = 0; b < 4; b++) {
+    for (size_t c = 0; c < 5; c++) {
+      DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
+      for (size_t a = 0; a < 5; a++) {
+        expected_sum += Ruull.get(a, b, a, c);
+      }
+      CHECK(RABac_contracted.get(b, c) == expected_sum);
+    }
+  }
+
+  // Contract first and fourth indices of (upper, upper, upper, lower) tensor to
+  // rank 2 tensor
+  Tensor<DataType, Symmetry<3, 2, 3, 1>,
+         index_list<SpatialIndex<3, UpLo::Up, Frame::Grid>,
+                    SpatialIndex<4, UpLo::Up, Frame::Grid>,
+                    SpatialIndex<3, UpLo::Up, Frame::Grid>,
+                    SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
+      Ruuul(used_for_size);
+  create_tensor(make_not_null(&Ruuul));
+
+  const Tensor<DataType, Symmetry<2, 1>,
+               index_list<SpatialIndex<4, UpLo::Up, Frame::Grid>,
+                          SpatialIndex<3, UpLo::Up, Frame::Grid>>>
+      RLJIl_contracted = TensorExpressions::evaluate<ti_J_t, ti_I_t>(
+          Ruuul(ti_L, ti_J, ti_I, ti_l));
+
+  for (size_t j = 0; j < 4; j++) {
+    for (size_t i = 0; i < 3; i++) {
+      DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
+      for (size_t l = 0; l < 3; l++) {
+        expected_sum += Ruuul.get(l, j, i, l);
+      }
+      CHECK(RLJIl_contracted.get(j, i) == expected_sum);
+    }
+  }
+
+  // Contract second and third indices of (upper, upper, lower, upper) tensor to
+  // rank 2 tensor
+  Tensor<DataType, Symmetry<2, 2, 1, 2>,
+         index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                    SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>
+      Ruulu(used_for_size);
+  create_tensor(make_not_null(&Ruulu));
+
+  const Tensor<DataType, Symmetry<1, 1>,
+               index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                          SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>
+      REDdA_contracted = TensorExpressions::evaluate<ti_E_t, ti_A_t>(
+          Ruulu(ti_E, ti_D, ti_d, ti_A));
+
+  for (size_t e = 0; e < 4; e++) {
+    for (size_t a = 0; a < 4; a++) {
+      DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
+      for (size_t d = 0; d < 4; d++) {
+        expected_sum += Ruulu.get(e, d, d, a);
+      }
+      CHECK(REDdA_contracted.get(e, a) == expected_sum);
+    }
+  }
+
+  // Contract second and fourth indices of (lower, upper, lower, lower) tensor
+  // to rank 2 tensor
+  Tensor<DataType, Symmetry<4, 3, 2, 1>,
+         index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                    SpatialIndex<3, UpLo::Up, Frame::Inertial>,
+                    SpatialIndex<4, UpLo::Lo, Frame::Inertial>,
+                    SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
+      Rlull(used_for_size);
+  create_tensor(make_not_null(&Rlull));
+
+  const Tensor<DataType, Symmetry<2, 1>,
+               index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                          SpatialIndex<4, UpLo::Lo, Frame::Inertial>>>
+      RkJij_contracted = TensorExpressions::evaluate<ti_k_t, ti_i_t>(
+          Rlull(ti_k, ti_J, ti_i, ti_j));
+
+  for (size_t k = 0; k < 3; k++) {
+    for (size_t i = 0; i < 4; i++) {
+      DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
+      for (size_t j = 0; j < 3; j++) {
+        expected_sum += Rlull.get(k, j, i, j);
+      }
+      CHECK(RkJij_contracted.get(k, i) == expected_sum);
+    }
+  }
+
+  // Contract third and fourth indices of (upper, lower, lower, upper) tensor to
+  // rank 2 tensor
+  Tensor<DataType, Symmetry<3, 2, 2, 1>,
+         index_list<SpacetimeIndex<4, UpLo::Up, Frame::Inertial>,
+                    SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                    SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                    SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>>
+      Rullu(used_for_size);
+  create_tensor(make_not_null(&Rullu));
+
+  const Tensor<DataType, Symmetry<2, 1>,
+               index_list<SpacetimeIndex<4, UpLo::Up, Frame::Inertial>,
+                          SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>
+      RFcgG_contracted = TensorExpressions::evaluate<ti_F_t, ti_c_t>(
+          Rullu(ti_F, ti_c, ti_g, ti_G));
+
+  for (size_t f = 0; f < 5; f++) {
+    for (size_t c = 0; c < 4; c++) {
+      DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
+      for (size_t g = 0; g < 4; g++) {
+        expected_sum += Rullu.get(f, c, g, g);
+      }
+      CHECK(RFcgG_contracted.get(f, c) == expected_sum);
+    }
+  }
+
+  // Contract first and second indices of (upper, lower, upper, upper) tensor to
+  // rank 2 tensor and reorder indices
+  Tensor<DataType, Symmetry<3, 2, 3, 1>,
+         index_list<SpatialIndex<3, UpLo::Up, Frame::Grid>,
+                    SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpatialIndex<3, UpLo::Up, Frame::Grid>,
+                    SpatialIndex<2, UpLo::Up, Frame::Grid>>>
+      Ruluu(used_for_size);
+  create_tensor(make_not_null(&Ruluu));
+
+  const Tensor<DataType, Symmetry<2, 1>,
+               index_list<SpatialIndex<2, UpLo::Up, Frame::Grid>,
+                          SpatialIndex<3, UpLo::Up, Frame::Grid>>>
+      RKkIJ_contracted_to_JI = TensorExpressions::evaluate<ti_J_t, ti_I_t>(
+          Ruluu(ti_K, ti_k, ti_I, ti_J));
+
+  for (size_t j = 0; j < 2; j++) {
+    for (size_t i = 0; i < 3; i++) {
+      DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
+      for (size_t k = 0; k < 3; k++) {
+        expected_sum += Ruluu.get(k, k, i, j);
+      }
+      CHECK(RKkIJ_contracted_to_JI.get(j, i) == expected_sum);
+    }
+  }
+
+  // Contract first and third indices of (lower, upper, upper, upper) tensor to
+  // rank 2 tensor and reorder indices
+  Tensor<DataType, Symmetry<3, 2, 1, 2>,
+         index_list<SpacetimeIndex<2, UpLo::Lo, Frame::Grid>,
+                    SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
+                    SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
+                    SpacetimeIndex<2, UpLo::Up, Frame::Grid>>>
+      Rluuu(used_for_size);
+  create_tensor(make_not_null(&Rluuu));
+
+  const Tensor<DataType, Symmetry<1, 1>,
+               index_list<SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
+                          SpacetimeIndex<2, UpLo::Up, Frame::Grid>>>
+      RbCBE_contracted_to_EC = TensorExpressions::evaluate<ti_E_t, ti_C_t>(
+          Rluuu(ti_b, ti_C, ti_B, ti_E));
+
+  for (size_t e = 0; e < 3; e++) {
+    for (size_t c = 0; c < 3; c++) {
+      DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
+      for (size_t b = 0; b < 3; b++) {
+        expected_sum += Rluuu.get(b, c, b, e);
+      }
+      CHECK(RbCBE_contracted_to_EC.get(e, c) == expected_sum);
+    }
+  }
+
+  // Contract first and fourth indices of (upper, lower, lower, lower) tensor to
+  // rank 2 tensor and reorder indices
+  Tensor<DataType, Symmetry<2, 1, 1, 1>,
+         index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
+      Rulll(used_for_size);
+  create_tensor(make_not_null(&Rulll));
+
+  const Tensor<DataType, Symmetry<1, 1>,
+               index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
+      RAdba_contracted_to_bd = TensorExpressions::evaluate<ti_b_t, ti_d_t>(
+          Rulll(ti_A, ti_d, ti_b, ti_a));
+
+  for (size_t b = 0; b < 4; b++) {
+    for (size_t d = 0; d < 4; d++) {
+      DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
+      for (size_t a = 0; a < 4; a++) {
+        expected_sum += Rulll.get(a, d, b, a);
+      }
+      CHECK(RAdba_contracted_to_bd.get(b, d) == expected_sum);
+    }
+  }
+
+  // Contract second and third indices of (lower, lower, upper, lower) tensor to
+  // rank 2 tensor and reorder indices
+  Tensor<DataType, Symmetry<4, 3, 2, 1>,
+         index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpatialIndex<3, UpLo::Up, Frame::Grid>,
+                    SpatialIndex<4, UpLo::Lo, Frame::Grid>>>
+      Rllul(used_for_size);
+  create_tensor(make_not_null(&Rllul));
+
+  const Tensor<DataType, Symmetry<2, 1>,
+               index_list<SpatialIndex<4, UpLo::Lo, Frame::Grid>,
+                          SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
+      RljJi_contracted_to_il = TensorExpressions::evaluate<ti_i_t, ti_l_t>(
+          Rllul(ti_l, ti_j, ti_J, ti_i));
+
+  for (size_t i = 0; i < 4; i++) {
+    for (size_t l = 0; l < 3; l++) {
+      DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
+      for (size_t j = 0; j < 3; j++) {
+        expected_sum += Rllul.get(l, j, j, i);
+      }
+      CHECK(RljJi_contracted_to_il.get(i, l) == expected_sum);
+    }
+  }
+
+  // Contract second and fourth indices of (lower, lower, upper, upper) tensor
+  // to rank 2 tensor and reorder indices
+  Tensor<DataType, Symmetry<2, 2, 1, 1>,
+         index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                    SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                    SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                    SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>>
+      Rlluu(used_for_size);
+  create_tensor(make_not_null(&Rlluu));
+
+  const Tensor<DataType, Symmetry<2, 1>,
+               index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                          SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>
+      RagDG_contracted_to_Da = TensorExpressions::evaluate<ti_D_t, ti_a_t>(
+          Rlluu(ti_a, ti_g, ti_D, ti_G));
+
+  for (size_t d = 0; d < 4; d++) {
+    for (size_t a = 0; a < 4; a++) {
+      DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
+      for (size_t g = 0; g < 4; g++) {
+        expected_sum += Rlluu.get(a, g, d, g);
+      }
+      CHECK(RagDG_contracted_to_Da.get(d, a) == expected_sum);
+    }
+  }
+
+  // Contract third and fourth indices of (lower, upper, lower, upper) tensor to
+  // rank 2 tensor and reorder indices
+  Tensor<DataType, Symmetry<2, 1, 2, 1>,
+         index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                    SpatialIndex<3, UpLo::Up, Frame::Inertial>,
+                    SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                    SpatialIndex<3, UpLo::Up, Frame::Inertial>>>
+      Rlulu(used_for_size);
+  create_tensor(make_not_null(&Rlulu));
+
+  const Tensor<DataType, Symmetry<2, 1>,
+               index_list<SpatialIndex<3, UpLo::Up, Frame::Inertial>,
+                          SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
+      RlJiI_contracted_to_Jl = TensorExpressions::evaluate<ti_J_t, ti_l_t>(
+          Rlulu(ti_l, ti_J, ti_i, ti_I));
+
+  for (size_t j = 0; j < 3; j++) {
+    for (size_t l = 0; l < 3; l++) {
+      DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
+      for (size_t i = 0; i < 3; i++) {
+        expected_sum += Rlulu.get(l, j, i, i);
+      }
+      CHECK(RlJiI_contracted_to_Jl.get(j, l) == expected_sum);
+    }
+  }
+
+  // Contract first and second indices AND third and fourth indices to rank 0
+  // tensor
+  Tensor<DataType, Symmetry<4, 3, 2, 1>,
+         index_list<SpatialIndex<3, UpLo::Up, Frame::Grid>,
+                    SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpatialIndex<4, UpLo::Up, Frame::Grid>,
+                    SpatialIndex<4, UpLo::Lo, Frame::Grid>>>
+      Rulul(used_for_size);
+  create_tensor(make_not_null(&Rulul));
+
+  const Tensor<DataType> RKkLl_contracted =
+      TensorExpressions::evaluate(Rulul(ti_K, ti_k, ti_L, ti_l));
+
+  DataType expected_RKkLl_sum = make_with_value<DataType>(used_for_size, 0.0);
+  for (size_t k = 0; k < 3; k++) {
+    for (size_t l = 0; l < 4; l++) {
+      expected_RKkLl_sum += Rulul.get(k, k, l, l);
+    }
+  }
+  CHECK(RKkLl_contracted.get() == expected_RKkLl_sum);
+
+  // Contract first and third indices and second and fourth indices to rank 0
+  // tensor
+  const Tensor<DataType> RcaCA_contracted =
+      TensorExpressions::evaluate(Rlluu(ti_c, ti_a, ti_C, ti_A));
+
+  DataType expected_RcaCA_sum = make_with_value<DataType>(used_for_size, 0.0);
+  for (size_t c = 0; c < 4; c++) {
+    for (size_t a = 0; a < 4; a++) {
+      expected_RcaCA_sum += Rlluu.get(c, a, c, a);
+    }
+  }
+  CHECK(RcaCA_contracted.get() == expected_RcaCA_sum);
+
+  // Contract first and fourth indices and second and third indices to rank 0
+  // tensor
+  const Tensor<DataType> RjIiJ_contracted =
+      TensorExpressions::evaluate(Rlulu(ti_j, ti_I, ti_i, ti_J));
+
+  DataType expected_RjIiJ_sum = make_with_value<DataType>(used_for_size, 0.0);
+  for (size_t j = 0; j < 3; j++) {
+    for (size_t i = 0; i < 3; i++) {
+      expected_RjIiJ_sum += Rlulu.get(j, i, i, j);
+    }
+  }
+  CHECK(RjIiJ_contracted.get() == expected_RjIiJ_sum);
+}
+
+template <typename DataType>
+void test_contractions(const DataType& used_for_size) noexcept {
+  test_contractions_rank2(used_for_size);
+  test_contractions_rank3(used_for_size);
+  test_contractions_rank4(used_for_size);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Contract",
+                  "[DataStructures][Unit]") {
+  test_contractions(std::numeric_limits<double>::signaling_NaN());
+  test_contractions(
+      DataVector(5, std::numeric_limits<double>::signaling_NaN()));
+}


### PR DESCRIPTION
## Proposed changes

This PR fixes various bugs in the tensor expression contraction code to make contractions operational and adds a unit test for contractions. See unit test case details in the **Further Comments** section below.

### Types of changes:

- [x] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

#### Why so many changes in one PR
This PR involves a large number of changes to the contraction code, so I want to mention that almost all of the changes made here were necessary together to make it operational. Otherwise, this would have been segmented into more than one PR.

#### Unit test details
The unit test added covers the following contraction cases:
- Rank 2 contracted to rank 0
- Rank 3 contracted to rank 1
- Rank 4 contracted to rank 2
- Rank 4 contracted to rank 0 (two contractions)

For the rank 3 cases, each possible pair of contracted positions is tested:
- Contracting 1st and 2nd indices
- Contracting 1st and 3rd indices
- Contracting 2nd and 3rd indices

For the rank 4 cases, each possible single pair and two pairs of contracted positions is tested:
- Contracting 1st and 2nd indices
- Contracting 1st and 3rd indices
- Contracting 1st and 4th indices *
- Contracting 2nd and 3rd indices *
- Contracting 2nd and 4th indices
- Contracting 3rd and 4th indices
- Contracting 1st and 2nd indices AND contracting 3rd and 4th indices
- Contracting 1st and 3rd indices AND contracting 2nd and 4th indices
- Contracting 1st and 4th indices AND contracting 2nd and 3rd indices

For all the rank 4 -> rank 2 cases above, the order of non-contracted indices was _preserved_ on the LHS, e.g. L_{ab} = R_{acbC}.
For the two asterisked (*) rank 4 -> rank 2 cases above, an additional test case was included where the order of non-contracted indices was _swapped_ on the LHS, e.g. L_{ba} = R_{acbC}

Each case is run twice: once with a `Tensor` storing `double`s and once with a `Tensor` storing `DataVector`s

There is no specific iteration over all frame types, symmetries, or dimensions for each case, but an attempt was made to try and decently vary these across the test cases. The reason for not doing this with something like `GENERATE_INSTANTIATION`s was because there didn't seem to be an obvious and not overly-complex way to generalize the `for` loops that generate and check the contraction sums - specifically, passing in the correct parameters in the correct positions to calls to `Tensor::get` on the test tensors. Generalizing this seemed like it would lead to a very large number of different helper functions to handle all of the different cases. I'm happy to hear suggestions on this, though, if it is worth doing and there is an organized/clean way to do it!

**Note:** One important test case that is not including in the new unit test, as of now, is any case with tensors that have mixed `TensorIndexType`s. **All** tensors used in this test have index lists that are all `SpacetimeIndex` or all `SpatialIndex`