### PR TITLE
Use a custom demangler in pretty_type::short_name

### DIFF
--- a/src/Options/OptionsDetails.hpp
+++ b/src/Options/OptionsDetails.hpp
@@ -75,7 +75,7 @@ using options_in_group = tmpl::filter<OptionList, is_in_group<tmpl::_1, Group>>;
 // information.
 template <typename T>
 struct yaml_type {
-  static std::string value() noexcept { return pretty_type::get_name<T>(); }
+  static std::string value() noexcept { return pretty_type::short_name<T>(); }
 };
 
 template <typename T>

--- a/src/Utilities/PrettyType.cpp
+++ b/src/Utilities/PrettyType.cpp
@@ -4,24 +4,198 @@
 #include "Utilities/PrettyType.hpp"
 
 #include <cstddef>
-#include <regex>
+#include <string>
+#include <string_view>
 
-namespace pretty_type {
-std::string extract_short_name(std::string name) {
-  // Remove all template arguments
-  const std::regex template_pattern("<[^<>]*>");
-  size_t previous_size = 0;
-  while (name.size() != previous_size) {
-    previous_size = name.size();
-    name = std::regex_replace(name, template_pattern, "");
-  }
+#include "ErrorHandling/Assert.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
 
-  // Remove namespaces, etc.
-  const size_t last_colon = name.rfind(':');
-  if (last_colon != std::string::npos) {
-    name.replace(0, last_colon + 1, "");
-  }
-
-  return name;
+namespace pretty_type::detail {
+namespace {
+// Remove characters until a character in target is found.  This is
+// used to skip characters we know we don't care about or do not
+// understand.
+void remove_until(const gsl::not_null<std::string_view*> remainder,
+                  const char* targets) noexcept {
+  const auto next_target = remainder->find_first_of(targets);
+  ASSERT(next_target != remainder->npos,
+         "Overran string " << *remainder << " looking for " << targets);
+  remainder->remove_prefix(next_target);
 }
-}  // namespace pretty_type
+
+std::string_view process_type_or_value(
+    gsl::not_null<std::string_view*> remainder) noexcept;
+void process_literal(gsl::not_null<std::string_view*> remainder) noexcept;
+std::string_view process_item_sequence(
+    gsl::not_null<std::string_view*> remainder) noexcept;
+void process_substitution(
+    gsl::not_null<std::string_view*> remainder) noexcept;
+std::string_view process_identifier(
+    gsl::not_null<std::string_view*> remainder) noexcept;
+
+// An entity of undetermined type.
+std::string_view process_type_or_value(
+    const gsl::not_null<std::string_view*> remainder) noexcept {
+  remove_until(remainder, "0123456789LNS");
+  std::string_view result = "";
+  switch ((*remainder)[0]) {
+    // Note that the first two cases return and the second two break.
+    case 'L':
+      process_literal(remainder);
+      return "";
+    case 'N':
+      return process_item_sequence(remainder);
+    case 'S':
+      process_substitution(remainder);
+      break;
+    default:
+      result = process_identifier(remainder);
+      break;
+  }
+  // The last two cases can be templates, and so may be followed by
+  // template parameters.
+  if (not remainder->empty() and (*remainder)[0] == 'I') {
+    process_item_sequence(remainder);
+  }
+  return result;
+}
+
+// A value (such as for a non-type template parameter) encoded as
+// L<type><value>E
+void process_literal(
+    const gsl::not_null<std::string_view*> remainder) noexcept {
+  remainder->remove_prefix(1);
+  if (not ('a' <= (*remainder)[0] and (*remainder)[0] <= 'z')) {
+    // A named enum class
+    process_type_or_value(remainder);
+  }
+  remove_until(remainder, "E");
+  remainder->remove_prefix(1);
+}
+
+// A sequence of items without separators, such as namespaces or
+// template parameters.
+std::string_view process_item_sequence(
+    const gsl::not_null<std::string_view*> remainder) noexcept {
+  remainder->remove_prefix(1);
+  std::string_view result;
+  for (;;) {
+    // List from process_type_or_value with J and E added
+    remove_until(remainder, "0123456789LNSJE");
+    if ((*remainder)[0] == 'E') {
+      // E = end
+      remainder->remove_prefix(1);
+      return result;
+    } else if ((*remainder)[0] == 'J') {
+      // A parameter pack.  Only allowed immediately inside a list of
+      // template parameters, so doesn't have to be handled anywhere
+      // else in the processing.
+      process_item_sequence(remainder);
+    } else {
+      result = process_type_or_value(remainder);
+    }
+  }
+  return result;
+}
+
+// A "substitution" (i.e., an abbreviation of some sort).  There are
+// three types:
+//   St          - "std::", which will be followed by more parts
+//   S[a-z]      - some other standard library thing
+//   S[0-9A-Z]*_ - a back-reference to some previously seen entity
+// All cases where these could occur outside of template parameters
+// were handled as special cases at the start, so we don't care about
+// any of them.
+void process_substitution(
+    const gsl::not_null<std::string_view*> remainder) noexcept {
+  remainder->remove_prefix(1);
+  if ((*remainder)[0] == 't') {
+    remainder->remove_prefix(1);
+    process_type_or_value(remainder);
+  } else if ('a' <= (*remainder)[0] and (*remainder)[0] <= 'z') {
+    remainder->remove_prefix(1);
+  } else {
+    remove_until(remainder, "_");
+    remainder->remove_prefix(1);
+  }
+}
+
+// Identifier coded as <name length><name>
+std::string_view process_identifier(
+    const gsl::not_null<std::string_view*> remainder) noexcept {
+  size_t length_chars = 0;
+  const size_t identifier_chars =
+      static_cast<size_t>(std::stoi(std::string(*remainder), &length_chars));
+  std::string_view identifier =
+      remainder->substr(length_chars, identifier_chars);
+  remainder->remove_prefix(length_chars + identifier_chars);
+  return identifier;
+}
+}  // namespace
+
+std::string extract_short_name(const std::string& name) noexcept {
+  // This ignores some of the less common language features (e.g., C
+  // array types) and a lot of things that are not relevant to types.
+
+  ASSERT(not name.empty(), "Cannot get type from an empty string");
+
+  // Special-case a few standard library types.  These can be encoded
+  // either using a special notation or using the standard namespace
+  // notation, and some of them are type aliases in the latter case.
+  // This makes them consistent.
+  if (name == typeid(std::string).name()) {
+    return "string";
+  } else if (name == typeid(std::istream).name()) {
+    return "istream";
+  } else if (name == typeid(std::ostream).name()) {
+    return "ostream";
+  } else if (name == typeid(std::iostream).name()) {
+    return "iostream";
+  }
+
+  // Short circuit for fundamentals and some standard library types.
+  // These can occur in complicated types, but never as the component
+  // we care about (which is always a struct or struct template name).
+  if (name.size() == 1) {
+    switch (name[0]) {
+      case 'v': return "void";
+      case 'b': return "bool";
+      case 'c': return "char";
+      case 'a': return "signed char";
+      case 'h': return "unsigned char";
+      case 's': return "short";
+      case 't': return "unsigned short";
+      case 'i': return "int";
+      case 'j': return "unsigned int";
+      case 'l': return "long";
+      case 'm': return "unsigned long";
+      case 'x': return "long long";
+      case 'y': return "unsigned long long";
+      case 'f': return "float";
+      case 'd': return "double";
+      case 'e': return "long double";
+      default: ERROR("Builtin type " << name << " not handled");
+    }
+  } else if (name[0] == 'S') {
+    // More possible standard library special cases, but with template
+    // parameters.
+    switch (name[1]) {
+      case 'a': return "allocator";
+      case 'b': return "basic_string";  // but not a std::string
+      default:;
+    }
+  }
+
+  std::string_view name_view(name);
+  if (name[0] == 'S' and name[1] == 't') {
+    // "St" is an abbreviation for the std:: prefix.  We don't care
+    // about namespaces, so we can just drop it.
+    name_view.remove_prefix(2);
+  }
+
+  std::string result(process_type_or_value(&name_view));
+  ASSERT(name_view.empty(), "Type name was not fully processed");
+  return result;
+}
+}  // namespace pretty_type::detail

--- a/src/Utilities/PrettyType.hpp
+++ b/src/Utilities/PrettyType.hpp
@@ -17,6 +17,7 @@
 #include <sstream>
 #include <stack>
 #include <string>
+#include <type_traits>
 #include <typeinfo>
 #include <unordered_map>
 #include <unordered_set>
@@ -691,12 +692,9 @@ std::string get_runtime_type_name(const T& x) {
   return boost::core::demangle(typeid(x).name());
 }
 
-/*!
- * \ingroup PrettyTypeGroup
- * \brief Extract the "short name" from a name, that is, the name
- * without template parameters or scopes.
- */
-std::string extract_short_name(std::string name);
+namespace detail {
+std::string extract_short_name(const std::string& name) noexcept;
+}  // namespace detail
 
 /*!
  * \ingroup PrettyTypeGroup
@@ -705,6 +703,6 @@ std::string extract_short_name(std::string name);
  */
 template <typename T>
 std::string short_name() {
-  return extract_short_name(get_name<T>());
+  return detail::extract_short_name(typeid(T).name());
 }
 }  // namespace pretty_type

--- a/tests/Unit/Options/Test_Options.cpp
+++ b/tests/Unit/Options/Test_Options.cpp
@@ -487,7 +487,7 @@ void test_options_map_empty() {
 }
 
 // [[OutputRegex, In string:.*While parsing option Map:.At line 1 column
-// 6:.Failed to convert value to type {std::string: int}: string]]
+// 6:.Failed to convert value to type {string: int}: string]]
 SPECTRE_TEST_CASE("Unit.Options.Map.invalid", "[Unit][Options]") {
   ERROR_TEST();
   Options::Parser<tmpl::list<Map>> opts("");
@@ -496,7 +496,7 @@ SPECTRE_TEST_CASE("Unit.Options.Map.invalid", "[Unit][Options]") {
 }
 
 // [[OutputRegex, In string:.*While parsing option Map:.At line 2 column
-// 6:.Failed to convert value to type {std::string: int}: A: string]]
+// 6:.Failed to convert value to type {string: int}: A: string]]
 SPECTRE_TEST_CASE("Unit.Options.Map.invalid_entry", "[Unit][Options]") {
   ERROR_TEST();
   Options::Parser<tmpl::list<Map>> opts("");

--- a/tests/Unit/Utilities/Test_PrettyType.cpp
+++ b/tests/Unit/Utilities/Test_PrettyType.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <deque>
 #include <forward_list>
+#include <istream>
 #include <list>
 #include <map>
 #include <memory>
@@ -13,11 +14,13 @@
 #include <set>
 #include <stack>
 #include <string>
+#include <typeinfo>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 #include "Utilities/PrettyType.hpp"
+#include "Utilities/TMPL.hpp"
 
 SPECTRE_TEST_CASE("Unit.Utilities.PrettyType.Fundamental",
                   "[Utilities][Unit]") {
@@ -115,12 +118,321 @@ SPECTRE_TEST_CASE("Unit.Utilities.PrettyType.Stl", "[Utilities][Unit]") {
         pretty_type::get_name<std::weak_ptr<double>>());
 }
 
+// NOTE: Do not put these in a namespace, including an anonymous
+// namespace.  These are for testing demangling things that are not in
+// a namespace.
+struct Test_PrettyType_struct {};
+template <typename>
+struct Test_PrettyType_templated_struct {};
+enum class Test_PrettyType_Enum { Zero, One, Two };
+
+namespace Test_PrettyType_namespace {
+struct NamedNamespace {};
+}  // namespace Test_PrettyType_namespace
+
+namespace {
+struct Type1Containing2Digits3 {};
+
+struct TestType {};
+
+template <typename>
+struct Template {};
+
+template <typename, typename>
+struct Template2 {};
+
+template <typename...>
+struct Pack {
+  struct Inner {};
+};
+
+template <typename, typename...>
+struct Pack2 {};
+
+struct Outer {
+  struct Inner {};
+
+  template <typename>
+  struct InnerTemplate {};
+};
+
+template <typename>
+struct OuterTemplate {
+  struct Inner {};
+
+  template <typename>
+  struct InnerTemplate {};
+};
+
+template <int>
+struct NonType {};
+
+template <int, int>
+struct NonTypeNonType {};
+
+template <typename, int>
+struct TypeNonType {};
+
+template <int, typename>
+struct NonTypeType {};
+
+template <std::nullptr_t>
+struct NullptrTemplate {};
+
+enum class LocalEnum { Zero, One, Two, Negative = -1 };
+
+template <Test_PrettyType_Enum>
+struct GlobalEnumTemplate {};
+
+template <LocalEnum>
+struct LocalEnumTemplate {};
+}  // namespace
+
 SPECTRE_TEST_CASE("Unit.Utilities.PrettyType.short_name", "[Utilities][Unit]") {
-  CHECK("Simple" == pretty_type::extract_short_name("Simple"));
-  CHECK("Qualified" == pretty_type::extract_short_name("Namespace::Qualified"));
-  CHECK("Templated" == pretty_type::extract_short_name("Templated<int>"));
-  CHECK("Nested" == pretty_type::extract_short_name("Nested<Templated<int>>"));
-  CHECK("Nested" ==
-        pretty_type::extract_short_name("Nested<Namespace::Templated<int>>"));
-  CHECK("Inner" == pretty_type::extract_short_name("Outer<int>::Inner"));
+  // Fundamentals
+  CHECK(pretty_type::short_name<bool>() == "bool");
+  CHECK(pretty_type::short_name<char>() == "char");
+  CHECK(pretty_type::short_name<signed char>() == "signed char");
+  CHECK(pretty_type::short_name<unsigned char>() == "unsigned char");
+  CHECK(pretty_type::short_name<short>() == "short");
+  CHECK(pretty_type::short_name<unsigned short>() == "unsigned short");
+  CHECK(pretty_type::short_name<int>() == "int");
+  CHECK(pretty_type::short_name<unsigned int>() == "unsigned int");
+  CHECK(pretty_type::short_name<long>() == "long");
+  CHECK(pretty_type::short_name<unsigned long>() == "unsigned long");
+  CHECK(pretty_type::short_name<long long>() == "long long");
+  CHECK(pretty_type::short_name<unsigned long long>() == "unsigned long long");
+  CHECK(pretty_type::short_name<void>() == "void");
+  CHECK(pretty_type::short_name<float>() == "float");
+  CHECK(pretty_type::short_name<double>() == "double");
+  CHECK(pretty_type::short_name<long double>() == "long double");
+
+  // Standard library
+  // Untemplated
+  CHECK(pretty_type::short_name<std::type_info>() == "type_info");
+  // Templated
+  CHECK(pretty_type::short_name<std::vector<int>>() == "vector");
+  // (Probably) special cased in mangling
+  CHECK(pretty_type::short_name<std::ostream>() == "ostream");
+  // Possibly special cased in mangling and a case we particularly care about
+  CHECK(pretty_type::short_name<std::string>() == "string");
+
+  // Types and templates with no namespaces
+  CHECK(pretty_type::short_name<Test_PrettyType_struct>() ==
+        "Test_PrettyType_struct");
+  CHECK(pretty_type::short_name<Test_PrettyType_templated_struct<int>>() ==
+        "Test_PrettyType_templated_struct");
+  CHECK(pretty_type::short_name<
+            Test_PrettyType_templated_struct<Test_PrettyType_struct>>() ==
+        "Test_PrettyType_templated_struct");
+  CHECK(pretty_type::short_name<Test_PrettyType_templated_struct<
+            Test_PrettyType_templated_struct<int>>>() ==
+        "Test_PrettyType_templated_struct");
+  CHECK(pretty_type::short_name<Test_PrettyType_templated_struct<
+            Test_PrettyType_templated_struct<Test_PrettyType_struct>>>() ==
+        "Test_PrettyType_templated_struct");
+
+  // Named namespaces
+  CHECK(pretty_type::short_name<Test_PrettyType_namespace::NamedNamespace>() ==
+        "NamedNamespace");
+
+  // Anonymous namespaces
+  CHECK(pretty_type::short_name<TestType>() == "TestType");
+
+  // Digits (special meaning in mangled names)
+  CHECK(pretty_type::short_name<Type1Containing2Digits3>() ==
+        "Type1Containing2Digits3");
+
+  using Global = Test_PrettyType_struct;
+  using Std = std::type_info;
+  using Special = std::ostream;
+  using Templated = Test_PrettyType_templated_struct<Test_PrettyType_struct>;
+
+  // const
+  CHECK(pretty_type::short_name<const int>() == "int");
+  CHECK(pretty_type::short_name<const Global>() == "Test_PrettyType_struct");
+  CHECK(pretty_type::short_name<const TestType>() == "TestType");
+  CHECK(pretty_type::short_name<const Std>() == "type_info");
+  CHECK(pretty_type::short_name<const Special>() == "ostream");
+  CHECK(pretty_type::short_name<const Templated>() ==
+        "Test_PrettyType_templated_struct");
+
+  // Template stuff
+  CHECK(pretty_type::short_name<Template<int>>() == "Template");
+  CHECK(pretty_type::short_name<Template<Global>>() == "Template");
+  CHECK(pretty_type::short_name<Template<TestType>>() == "Template");
+  CHECK(pretty_type::short_name<Template<Std>>() == "Template");
+  CHECK(pretty_type::short_name<Template<Special>>() == "Template");
+  CHECK(pretty_type::short_name<Template<Templated>>() == "Template");
+  CHECK(pretty_type::short_name<Template<const Global>>() == "Template");
+  CHECK(pretty_type::short_name<Template<const TestType>>() == "Template");
+
+  CHECK(pretty_type::short_name<Template2<int, int>>() == "Template2");
+  CHECK(pretty_type::short_name<Template2<int, Global>>() == "Template2");
+  CHECK(pretty_type::short_name<Template2<int, TestType>>() == "Template2");
+  CHECK(pretty_type::short_name<Template2<int, Std>>() == "Template2");
+  CHECK(pretty_type::short_name<Template2<int, Special>>() == "Template2");
+  CHECK(pretty_type::short_name<Template2<Global, int>>() == "Template2");
+  CHECK(pretty_type::short_name<Template2<Global, Global>>() == "Template2");
+  CHECK(pretty_type::short_name<Template2<Global, TestType>>() == "Template2");
+  CHECK(pretty_type::short_name<Template2<Global, Std>>() == "Template2");
+  CHECK(pretty_type::short_name<Template2<Global, Special>>() == "Template2");
+  CHECK(pretty_type::short_name<Template2<TestType, int>>() == "Template2");
+  CHECK(pretty_type::short_name<Template2<TestType, Global>>() == "Template2");
+  CHECK(pretty_type::short_name<Template2<TestType, TestType>>() ==
+        "Template2");
+  CHECK(pretty_type::short_name<Template2<TestType, Std>>() == "Template2");
+  CHECK(pretty_type::short_name<Template2<TestType, Special>>() == "Template2");
+  CHECK(pretty_type::short_name<Template2<Std, int>>() == "Template2");
+  CHECK(pretty_type::short_name<Template2<Std, Global>>() == "Template2");
+  CHECK(pretty_type::short_name<Template2<Std, TestType>>() == "Template2");
+  CHECK(pretty_type::short_name<Template2<Std, Std>>() == "Template2");
+  CHECK(pretty_type::short_name<Template2<Std, Special>>() == "Template2");
+  CHECK(pretty_type::short_name<Template2<Special, int>>() == "Template2");
+  CHECK(pretty_type::short_name<Template2<Special, Global>>() == "Template2");
+  CHECK(pretty_type::short_name<Template2<Special, TestType>>() == "Template2");
+  CHECK(pretty_type::short_name<Template2<Special, Std>>() == "Template2");
+  CHECK(pretty_type::short_name<Template2<Special, Special>>() == "Template2");
+
+  CHECK(pretty_type::short_name<Template2<Global, const Global>>() ==
+        "Template2");
+  CHECK(pretty_type::short_name<Template2<Global, const TestType>>() ==
+        "Template2");
+  CHECK(pretty_type::short_name<Template2<const Global, Global>>() ==
+        "Template2");
+  CHECK(pretty_type::short_name<Template2<const TestType, Global>>() ==
+        "Template2");
+
+  CHECK(pretty_type::short_name<Template<Template<int>>>() == "Template");
+  CHECK(pretty_type::short_name<Template2<Template<int>, Template<double>>>() ==
+        "Template2");
+
+  CHECK(pretty_type::short_name<Pack<>>() == "Pack");
+  CHECK(pretty_type::short_name<Pack<int>>() == "Pack");
+  CHECK(pretty_type::short_name<Pack<Global>>() == "Pack");
+  CHECK(pretty_type::short_name<Pack<TestType>>() == "Pack");
+  CHECK(pretty_type::short_name<Pack<Std>>() == "Pack");
+  CHECK(pretty_type::short_name<Pack<Special>>() == "Pack");
+  CHECK(pretty_type::short_name<Pack<Templated>>() == "Pack");
+
+  CHECK(pretty_type::short_name<Pack2<int>>() == "Pack2");
+  CHECK(pretty_type::short_name<Pack2<Global>>() == "Pack2");
+  CHECK(pretty_type::short_name<Pack2<TestType>>() == "Pack2");
+  CHECK(pretty_type::short_name<Pack2<Std>>() == "Pack2");
+  CHECK(pretty_type::short_name<Pack2<Special>>() == "Pack2");
+  CHECK(pretty_type::short_name<Pack2<Templated>>() == "Pack2");
+  CHECK(pretty_type::short_name<Pack2<TestType, TestType>>() == "Pack2");
+  CHECK(pretty_type::short_name<Pack2<Special, TestType>>() == "Pack2");
+  CHECK(pretty_type::short_name<Pack2<TestType, Special>>() == "Pack2");
+
+  // Nested types
+  CHECK(pretty_type::short_name<Outer::Inner>() == "Inner");
+  CHECK(pretty_type::short_name<Outer::InnerTemplate<int>>() ==
+        "InnerTemplate");
+  CHECK(pretty_type::short_name<Outer::InnerTemplate<Global>>() ==
+        "InnerTemplate");
+  CHECK(pretty_type::short_name<Outer::InnerTemplate<TestType>>() ==
+        "InnerTemplate");
+  CHECK(pretty_type::short_name<Outer::InnerTemplate<Special>>() ==
+        "InnerTemplate");
+  CHECK(pretty_type::short_name<OuterTemplate<int>::Inner>() == "Inner");
+  CHECK(pretty_type::short_name<OuterTemplate<Global>::Inner>() == "Inner");
+  CHECK(pretty_type::short_name<OuterTemplate<TestType>::Inner>() == "Inner");
+  CHECK(pretty_type::short_name<OuterTemplate<Special>::Inner>() == "Inner");
+
+  CHECK(pretty_type::short_name<Pack<>::Inner>() == "Inner");
+  CHECK(pretty_type::short_name<Pack<TestType>::Inner>() == "Inner");
+
+  // Non-type template parameters
+  CHECK(pretty_type::short_name<NonType<3>>() == "NonType");
+  CHECK(pretty_type::short_name<NonType<0>>() == "NonType");
+  CHECK(pretty_type::short_name<NonType<-3>>() == "NonType");
+  CHECK(pretty_type::short_name<NonTypeNonType<3, 3>>() == "NonTypeNonType");
+  CHECK(pretty_type::short_name<NonTypeNonType<3, 0>>() == "NonTypeNonType");
+  CHECK(pretty_type::short_name<NonTypeNonType<3, -3>>() == "NonTypeNonType");
+  CHECK(pretty_type::short_name<NonTypeNonType<0, 3>>() == "NonTypeNonType");
+  CHECK(pretty_type::short_name<NonTypeNonType<0, 0>>() == "NonTypeNonType");
+  CHECK(pretty_type::short_name<NonTypeNonType<0, -3>>() == "NonTypeNonType");
+  CHECK(pretty_type::short_name<NonTypeNonType<-3, 3>>() == "NonTypeNonType");
+  CHECK(pretty_type::short_name<NonTypeNonType<-3, 0>>() == "NonTypeNonType");
+  CHECK(pretty_type::short_name<NonTypeNonType<-3, -3>>() == "NonTypeNonType");
+  CHECK(pretty_type::short_name<TypeNonType<int, 3>>() == "TypeNonType");
+  CHECK(pretty_type::short_name<TypeNonType<Global, 3>>() == "TypeNonType");
+  CHECK(pretty_type::short_name<TypeNonType<TestType, 3>>() == "TypeNonType");
+  CHECK(pretty_type::short_name<TypeNonType<Special, 3>>() == "TypeNonType");
+  CHECK(pretty_type::short_name<TypeNonType<int, 0>>() == "TypeNonType");
+  CHECK(pretty_type::short_name<TypeNonType<Global, 0>>() == "TypeNonType");
+  CHECK(pretty_type::short_name<TypeNonType<TestType, 0>>() == "TypeNonType");
+  CHECK(pretty_type::short_name<TypeNonType<Special, 0>>() == "TypeNonType");
+  CHECK(pretty_type::short_name<TypeNonType<int, -3>>() == "TypeNonType");
+  CHECK(pretty_type::short_name<TypeNonType<Global, -3>>() == "TypeNonType");
+  CHECK(pretty_type::short_name<TypeNonType<TestType, -3>>() == "TypeNonType");
+  CHECK(pretty_type::short_name<TypeNonType<Special, -3>>() == "TypeNonType");
+  CHECK(pretty_type::short_name<NonTypeType<3, int>>() == "NonTypeType");
+  CHECK(pretty_type::short_name<NonTypeType<3, Global>>() == "NonTypeType");
+  CHECK(pretty_type::short_name<NonTypeType<3, TestType>>() == "NonTypeType");
+  CHECK(pretty_type::short_name<NonTypeType<3, Special>>() == "NonTypeType");
+  CHECK(pretty_type::short_name<NonTypeType<0, int>>() == "NonTypeType");
+  CHECK(pretty_type::short_name<NonTypeType<0, Global>>() == "NonTypeType");
+  CHECK(pretty_type::short_name<NonTypeType<0, TestType>>() == "NonTypeType");
+  CHECK(pretty_type::short_name<NonTypeType<0, Special>>() == "NonTypeType");
+  CHECK(pretty_type::short_name<NonTypeType<-3, int>>() == "NonTypeType");
+  CHECK(pretty_type::short_name<NonTypeType<-3, Global>>() == "NonTypeType");
+  CHECK(pretty_type::short_name<NonTypeType<-3, TestType>>() == "NonTypeType");
+  CHECK(pretty_type::short_name<NonTypeType<-3, Special>>() == "NonTypeType");
+
+  // nullptr-related things
+  CHECK(pretty_type::short_name<Template<std::nullptr_t>>() == "Template");
+  CHECK(pretty_type::short_name<Template2<std::nullptr_t, std::nullptr_t>>() ==
+        "Template2");
+  CHECK(pretty_type::short_name<Template2<int, std::nullptr_t>>() ==
+        "Template2");
+  CHECK(pretty_type::short_name<Template2<Global, std::nullptr_t>>() ==
+        "Template2");
+  CHECK(pretty_type::short_name<Template2<TestType, std::nullptr_t>>() ==
+        "Template2");
+  CHECK(pretty_type::short_name<Template2<Special, std::nullptr_t>>() ==
+        "Template2");
+  CHECK(pretty_type::short_name<Template2<std::nullptr_t, int>>() ==
+        "Template2");
+  CHECK(pretty_type::short_name<Template2<std::nullptr_t, Global>>() ==
+        "Template2");
+  CHECK(pretty_type::short_name<Template2<std::nullptr_t, TestType>>() ==
+        "Template2");
+  CHECK(pretty_type::short_name<Template2<std::nullptr_t, Special>>() ==
+        "Template2");
+  CHECK(pretty_type::short_name<NullptrTemplate<nullptr>>() ==
+        "NullptrTemplate");
+
+  // Enum non-type template parameters
+  CHECK(pretty_type::short_name<
+            GlobalEnumTemplate<Test_PrettyType_Enum::Zero>>() ==
+        "GlobalEnumTemplate");
+  CHECK(pretty_type::short_name<
+            GlobalEnumTemplate<Test_PrettyType_Enum::One>>() ==
+        "GlobalEnumTemplate");
+  CHECK(pretty_type::short_name<
+            Template2<GlobalEnumTemplate<Test_PrettyType_Enum::One>,
+                      GlobalEnumTemplate<Test_PrettyType_Enum::Two>>>() ==
+        "Template2");
+  CHECK(pretty_type::short_name<LocalEnumTemplate<LocalEnum::Zero>>() ==
+        "LocalEnumTemplate");
+  CHECK(pretty_type::short_name<LocalEnumTemplate<LocalEnum::One>>() ==
+        "LocalEnumTemplate");
+  CHECK(
+      pretty_type::short_name<Template2<LocalEnumTemplate<LocalEnum::One>,
+                                        LocalEnumTemplate<LocalEnum::Two>>>() ==
+      "Template2");
+  CHECK(pretty_type::short_name<LocalEnumTemplate<LocalEnum::Negative>>() ==
+        "LocalEnumTemplate");
+
+  // Complicated Test
+  CHECK(pretty_type::short_name<OuterTemplate<
+            Template2<OuterTemplate<Global>::InnerTemplate<TestType>,
+                      OuterTemplate<Global>::InnerTemplate<TestType>>>::
+                                    InnerTemplate<NonTypeType<1, Global>>>() ==
+        "InnerTemplate");
+
+  // Long test
+  CHECK(pretty_type::short_name<tmpl::range<int, 0, 1000>>() == "list");
 }


### PR DESCRIPTION
The GNU demangler is buggy and doesn't handle long type names.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
