### PR TITLE
Update ocean batch submit script comments

### DIFF
--- a/support/SubmitScripts/OceanClang.sh
+++ b/support/SubmitScripts/OceanClang.sh
@@ -18,7 +18,8 @@
 #   and input file below.
 # - Add a file ${HOME}/.charmrunrc that does the following (replace
 #   ${SPECTRE_BUILD_DIR}/../ with the path to your spectre checkout):
-#    source ${SPECTRE_BUILD_DIR}/../support/Environments/ocean_clang_lb.sh
+#    source /etc/profile.d/lmod.sh
+#    source ${SPECTRE_BUILD_DIR}/../support/Environments/ocean_clang.sh
 #    spectre_load_modules
 #
 # NOTE: The executable will not be copied from the build directory, so if you


### PR DESCRIPTION
## Proposed changes

I learned that for users other than me on ocean, running spectre on compute nodes on bare metal (not singularity) via `support/Environments/ocean_clang.sh` and `support/SubmitScripts/OceanClang.sh` requires a `.charmrunrc` file in the user's home directory that not only loads the spectre modules but also contains a line to initialize lmod. Without this line, the module command in `.charmrunrc` will not be available, causing the spectre modules to fail to load when running an executable with charmrun.

I updated the instructions in the submit script to account for this.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [x] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
