### PR TITLE
Boundary data improvements

### DIFF
--- a/src/Evolution/Systems/Cce/WorldtubeBufferUpdater.hpp
+++ b/src/Evolution/Systems/Cce/WorldtubeBufferUpdater.hpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -23,6 +24,7 @@
 #include "IO/H5/Version.hpp"
 #include "NumericalAlgorithms/Spectral/SwshTags.hpp"
 #include "Parallel/CharmPupable.hpp"
+#include "Parallel/PupStlCpp17.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -178,11 +180,12 @@ class MetricWorldtubeH5BufferUpdater
   MetricWorldtubeH5BufferUpdater() = default;
 
   /// The constructor takes the filename of the SpEC h5 file that will be used
-  /// for boundary data. Note that this assumes that the input data has
-  /// correctly-normalized radial derivatives, and that the extraction radius is
-  /// encoded as an integer in the filename.
+  /// for boundary data. The extraction radius can either be passed in directly,
+  /// or if it takes the value `std::nullopt`, then the extraction radius is
+  /// retrieved as an integer in the filename.
   explicit MetricWorldtubeH5BufferUpdater(
-      const std::string& cce_data_filename) noexcept;
+      const std::string& cce_data_filename,
+      std::optional<double> extraction_radius = std::nullopt) noexcept;
 
   WRAPPED_PUPable_decl_template(MetricWorldtubeH5BufferUpdater);  // NOLINT
 
@@ -212,7 +215,7 @@ class MetricWorldtubeH5BufferUpdater
   /// retrieves the l_max of the input file
   size_t get_l_max() const noexcept override { return l_max_; }
 
-  /// retrieves the extraction radius encoded in the filename
+  /// retrieves the extraction radius
   double get_extraction_radius() const noexcept override {
     return extraction_radius_;
   }
@@ -240,7 +243,7 @@ class MetricWorldtubeH5BufferUpdater
                      size_t time_span_end) const noexcept;
 
   bool has_version_history_ = true;
-  double extraction_radius_ = 1.0;
+  double extraction_radius_ = std::numeric_limits<double>::signaling_NaN();
   size_t l_max_ = 0;
 
   h5::H5File<h5::AccessType::ReadOnly> cce_data_file_;
@@ -263,11 +266,12 @@ class BondiWorldtubeH5BufferUpdater
   BondiWorldtubeH5BufferUpdater() = default;
 
   /// The constructor takes the filename of the SpEC h5 file that will be used
-  /// for boundary data. Note that this assumes that the input data has
-  /// correctly-normalized radial derivatives, and that the extraction radius is
-  /// encoded as an integer in the filename.
+  /// for boundary data. The extraction radius can either be passed in directly,
+  /// or if it takes the value `std::nullopt`, then the extraction radius is
+  /// retrieved as an integer in the filename.
   explicit BondiWorldtubeH5BufferUpdater(
-      const std::string& cce_data_filename) noexcept;
+      const std::string& cce_data_filename,
+      std::optional<double> extraction_radius = std::nullopt) noexcept;
 
   WRAPPED_PUPable_decl_template(BondiWorldtubeH5BufferUpdater);  // NOLINT
 
@@ -299,9 +303,16 @@ class BondiWorldtubeH5BufferUpdater
   /// retrieves the l_max of the input file
   size_t get_l_max() const noexcept override { return l_max_; }
 
-  /// retrieves the extraction radius encoded in the filename
+  /// retrieves the extraction radius. In most normal circumstances, this will
+  /// not be needed for Bondi data.
   double get_extraction_radius() const noexcept override {
-    return extraction_radius_;
+    if (not static_cast<bool>(extraction_radius_)) {
+      ERROR(
+          "Extraction radius has not been set, and was not successfully parsed "
+          "from the filename. The extraction radius has been used, so must be "
+          "set either by the input file or via the filename.");
+    }
+    return *extraction_radius_;
   }
 
   /// The time buffer is supplied by non-const reference to allow views to
@@ -326,7 +337,7 @@ class BondiWorldtubeH5BufferUpdater
                      size_t time_span_start, size_t time_span_end,
                      bool is_real) const noexcept;
 
-  double extraction_radius_ = 1.0;
+  std::optional<double> extraction_radius_ = std::nullopt;
   size_t l_max_ = 0;
 
   h5::H5File<h5::AccessType::ReadOnly> cce_data_file_;

--- a/src/Evolution/Systems/Cce/WorldtubeDataManager.cpp
+++ b/src/Evolution/Systems/Cce/WorldtubeDataManager.cpp
@@ -37,20 +37,32 @@ MetricWorldtubeDataManager::MetricWorldtubeDataManager(
           Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max)},
       buffer_depth_{buffer_depth},
       interpolator_{std::move(interpolator)} {
-  if (UNLIKELY(buffer_updater_->get_time_buffer().size() <
-               2 * interpolator_->required_number_of_points_before_and_after() +
-                   buffer_depth)) {
+  if (UNLIKELY(
+          buffer_updater_->get_time_buffer().size() <
+          2 * interpolator_->required_number_of_points_before_and_after())) {
     ERROR(
         "The specified buffer updater doesn't have enough time points to "
-        "supply the requested interpolation buffer. This almost certainly "
+        "supply the requested interpolator. This almost certainly "
         "indicates that the corresponding file hasn't been created properly, "
-        "but might indicate that the `buffer_depth` template parameter is "
-        "too large or the specified Interpolator requests too many points");
+        "but might indicate that the specified Interpolator requests too many "
+        "points");
+  }
+  // This will actually change the buffer depth in the case where the buffer
+  // depth passed to the constructor is too large for the worldtube file size.
+  // In that case, the worldtube data wouldn't be able to fill the buffer, so
+  // here we shrink the buffer depth down to be no larger than the length of the
+  // worldtube file.
+  if (UNLIKELY(buffer_updater_->get_time_buffer().size() <
+               2 * interpolator_->required_number_of_points_before_and_after() +
+                   buffer_depth_)) {
+    buffer_depth_ =
+        buffer_updater_->get_time_buffer().size() -
+        2 * interpolator_->required_number_of_points_before_and_after();
   }
 
   const size_t size_of_buffer =
       square(l_max + 1) *
-      (buffer_depth +
+      (buffer_depth_ +
        2 * interpolator_->required_number_of_points_before_and_after());
   coefficients_buffers_ = Variables<cce_metric_input_tags>{size_of_buffer};
 }
@@ -261,20 +273,31 @@ BondiWorldtubeDataManager::BondiWorldtubeDataManager(
           Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max)},
       buffer_depth_{buffer_depth},
       interpolator_{std::move(interpolator)} {
-  if (UNLIKELY(buffer_updater_->get_time_buffer().size() <
-               2 * interpolator_->required_number_of_points_before_and_after() +
-                   buffer_depth)) {
+  if (UNLIKELY(
+          buffer_updater_->get_time_buffer().size() <
+          2 * interpolator_->required_number_of_points_before_and_after())) {
     ERROR(
         "The specified buffer updater doesn't have enough time points to "
-        "supply the requested interpolation buffer. This almost certainly "
+        "supply the requested interpolator. This almost certainly "
         "indicates that the corresponding file hasn't been created properly, "
-        "but might indicate that the `buffer_depth` template parameter is "
-        "too large or the specified SpanInterpolator requests too many "
+        "but might indicate that the specified Interpolator requests too many "
         "points");
+  }
+  // This will actually change the buffer depth in the case where the buffer
+  // depth passed to the constructor is too large for the worldtube file size.
+  // In that case, the worldtube data wouldn't be able to fill the buffer, so
+  // here we shrink the buffer depth down to be no larger than the length of the
+  // worldtube file.
+  if (UNLIKELY(buffer_updater_->get_time_buffer().size() <
+               2 * interpolator_->required_number_of_points_before_and_after() +
+                   buffer_depth_)) {
+    buffer_depth_ =
+        buffer_updater_->get_time_buffer().size() -
+        2 * interpolator_->required_number_of_points_before_and_after();
   }
   coefficients_buffers_ = Variables<cce_bondi_input_tags>{
       square(l_max + 1) *
-      (buffer_depth +
+      (buffer_depth_ +
        2 * interpolator_->required_number_of_points_before_and_after())};
 }
 

--- a/tests/InputFiles/Cce/CharacteristicExtract.yaml
+++ b/tests/InputFiles/Cce/CharacteristicExtract.yaml
@@ -27,6 +27,7 @@ Cce:
     BarycentricRationalSpanInterpolator:
       MinOrder: 10
       MaxOrder: 10
+  ExtractionRadius: 257.0
   FixSpecNormalization: False
 
   H5LookaheadTimes: 10000

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "DataStructures/ComplexModalVector.hpp"
@@ -207,7 +208,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.H5BoundaryCommunication",
       Tags::H5WorldtubeBoundaryDataManager::create_from_options(
           l_max, filename, buffer_size,
           std::make_unique<intrp::BarycentricRationalSpanInterpolator>(3u, 4u),
-          false, false));
+          false, false, std::optional<double>{}));
 
   // this should run the initializations
   ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -86,7 +87,7 @@ void test_h5_initialization(const gsl::not_null<Generator*> gen) noexcept {
       Tags::H5WorldtubeBoundaryDataManager::create_from_options(
           l_max, filename, buffer_size,
           std::make_unique<intrp::BarycentricRationalSpanInterpolator>(3u, 4u),
-          false, false));
+          false, false, std::optional<double>{}));
 
   // this should run the initialization
   ActionTesting::next_action<component>(make_not_null(&runner), 0);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -190,7 +191,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.RequestBoundaryData",
           l_max, filename, buffer_size,
           std::make_unique<intrp::BarycentricRationalSpanInterpolator>(3_st,
                                                                        4_st),
-          false, false));
+          false, false, std::optional<double>{}));
 
   // this should run the initializations
   ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);

--- a/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
@@ -79,6 +79,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
           "3") == 3_st);
   CHECK(TestHelpers::test_creation<double, Cce::OptionTags::ExtractionRadius>(
             "100.0") == 100.0);
+  CHECK(TestHelpers::test_creation<std::optional<double>,
+                                   Cce::OptionTags::ExtractionRadius>(
+            "100.0") == std::optional<double>{100.0});
 
   CHECK(TestHelpers::test_creation<std::optional<double>,
                                    Cce::OptionTags::EndTime>("4.0") ==
@@ -128,7 +131,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
       "H5WorldtubeBoundaryDataManager");
   CHECK(Cce::Tags::H5WorldtubeBoundaryDataManager::create_from_options(
             8, filename, 3, std::make_unique<intrp::CubicSpanInterpolator>(),
-            false, true)
+            false, true, std::nullopt)
             ->get_l_max() == 8);
 
   CHECK(Cce::Tags::LMax::create_from_options(8u) == 8u);

--- a/tests/Unit/Evolution/Systems/Cce/Test_WorldtubeData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_WorldtubeData.cpp
@@ -385,7 +385,7 @@ void test_data_manager_with_dummy_buffer_updater(
   const double target_time = 50.0 * value_dist(*gen);
 
   const size_t buffer_size = 4;
-  const size_t l_max = 12;
+  const size_t l_max = 8;
 
   DataVector time_buffer{30};
   for (size_t i = 0; i < time_buffer.size(); ++i) {
@@ -604,8 +604,8 @@ void test_reduced_spec_worldtube_buffer_updater(
 
   const size_t buffer_size = 4;
   const size_t interpolator_length = 3;
-  const size_t file_l_max = 12;
-  const size_t computation_l_max = 14;
+  const size_t file_l_max = 8;
+  const size_t computation_l_max = 10;
 
   Variables<cce_bondi_input_tags> coefficients_buffers_from_file{
       (buffer_size + 2 * interpolator_length) * square(computation_l_max + 1)};
@@ -643,8 +643,8 @@ void test_reduced_spec_worldtube_buffer_updater(
   // scoped to close the file
   {
     Cce::ReducedWorldtubeModeRecorder recorder{filename};
-    for (size_t t = 0; t < 30; ++t) {
-      const double time = 0.01 * t + target_time - .15;
+    for (size_t t = 0; t < 20; ++t) {
+      const double time = 0.01 * t + target_time - 0.1;
       TestHelpers::create_fake_time_varying_modal_data(
           make_not_null(&spatial_metric_coefficients),
           make_not_null(&dt_spatial_metric_coefficients),
@@ -736,13 +736,13 @@ void test_reduced_spec_worldtube_buffer_updater(
   time_span_end = 0;
   const auto& time_buffer = buffer_updater.get_time_buffer();
   for (size_t i = 0; i < time_buffer.size(); ++i) {
-    CHECK(time_buffer[i] == approx(target_time - .15 + 0.01 * i));
+    CHECK(time_buffer[i] == approx(target_time - 0.1 + 0.01 * i));
   }
   const auto& time_buffer_from_serialized =
       serialized_and_deserialized_updater.get_time_buffer();
   for (size_t i = 0; i < time_buffer.size(); ++i) {
     CHECK(time_buffer_from_serialized[i] ==
-          approx(target_time - .15 + 0.01 * i));
+          approx(target_time - 0.1 + 0.01 * i));
   }
 
   const ReducedDummyBufferUpdater dummy_buffer_updater{

--- a/tests/Unit/Evolution/Systems/Cce/Test_WorldtubeData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_WorldtubeData.cpp
@@ -36,7 +36,7 @@ class DummyBufferUpdater
  public:
   DummyBufferUpdater(DataVector time_buffer,
                      const gr::Solutions::KerrSchild& solution,
-                     const double extraction_radius,
+                     const std::optional<double> extraction_radius,
                      const double coordinate_amplitude,
                      const double coordinate_frequency, const size_t l_max,
                      const bool apply_normalization_bug = false,
@@ -99,7 +99,8 @@ class DummyBufferUpdater
           make_not_null(&dr_shift_coefficients),
           make_not_null(&lapse_coefficients),
           make_not_null(&dt_lapse_coefficients),
-          make_not_null(&dr_lapse_coefficients), solution_, extraction_radius_,
+          make_not_null(&dr_lapse_coefficients), solution_,
+          extraction_radius_.value_or(default_extraction_radius_),
           coordinate_amplitude_, coordinate_frequency_,
           time_buffer_[time_index + *time_span_start], l_max_, true,
           apply_normalization_bug_);
@@ -155,7 +156,7 @@ class DummyBufferUpdater
   size_t get_l_max() const noexcept override { return l_max_; }
 
   double get_extraction_radius() const noexcept override {
-    return extraction_radius_;
+    return extraction_radius_.value_or(default_extraction_radius_);
   }
 
   bool has_version_history() const noexcept override {
@@ -170,6 +171,7 @@ class DummyBufferUpdater
     p | extraction_radius_;
     p | coordinate_amplitude_;
     p | coordinate_frequency_;
+    p | default_extraction_radius_;
     p | l_max_;
     p | apply_normalization_bug_;
     p | has_version_history_;
@@ -192,7 +194,8 @@ class DummyBufferUpdater
 
   DataVector time_buffer_;
   gr::Solutions::KerrSchild solution_;
-  double extraction_radius_;
+  std::optional<double> extraction_radius_;
+  double default_extraction_radius_ = 100.0;
   double coordinate_amplitude_;
   double coordinate_frequency_;
   size_t l_max_;
@@ -205,7 +208,7 @@ class ReducedDummyBufferUpdater
  public:
   ReducedDummyBufferUpdater(DataVector time_buffer,
                             const gr::Solutions::KerrSchild& solution,
-                            const double extraction_radius,
+                            const std::optional<double> extraction_radius,
                             const double coordinate_amplitude,
                             const double coordinate_frequency,
                             const size_t l_max,
@@ -269,7 +272,8 @@ class ReducedDummyBufferUpdater
           make_not_null(&dr_shift_coefficients),
           make_not_null(&lapse_coefficients),
           make_not_null(&dt_lapse_coefficients),
-          make_not_null(&dr_lapse_coefficients), solution_, extraction_radius_,
+          make_not_null(&dr_lapse_coefficients), solution_,
+          extraction_radius_.value_or(default_extraction_radius_),
           coordinate_amplitude_, coordinate_frequency_,
           time_buffer_[time_index + *time_span_start], l_max_, false);
 
@@ -278,7 +282,7 @@ class ReducedDummyBufferUpdater
           dt_spatial_metric_coefficients, dr_spatial_metric_coefficients,
           shift_coefficients, dt_shift_coefficients, dr_shift_coefficients,
           lapse_coefficients, dt_lapse_coefficients, dr_lapse_coefficients,
-          extraction_radius_, l_max);
+          extraction_radius_.value_or(default_extraction_radius_), l_max);
       tmpl::for_each<tmpl::transform<
           cce_bondi_input_tags, tmpl::bind<db::remove_tag_prefix, tmpl::_1>>>(
           [this, &boundary_variables, &buffers, &time_index, &time_span_end,
@@ -310,7 +314,7 @@ class ReducedDummyBufferUpdater
   size_t get_l_max() const noexcept override { return l_max_; }
 
   double get_extraction_radius() const noexcept override {
-    return extraction_radius_;
+    return extraction_radius_.value_or(default_extraction_radius_);
   }
 
   DataVector& get_time_buffer() noexcept override { return time_buffer_; }
@@ -343,7 +347,8 @@ class ReducedDummyBufferUpdater
 
   DataVector time_buffer_;
   gr::Solutions::KerrSchild solution_;
-  double extraction_radius_ = 1.0;
+  std::optional<double> extraction_radius_;
+  double default_extraction_radius_ = 100.0;
   double coordinate_amplitude_ = 0.0;
   double coordinate_frequency_ = 0.0;
   size_t l_max_ = 0;
@@ -357,8 +362,12 @@ namespace {
 template <typename DataManager, typename DummyUpdater, typename Generator>
 void test_data_manager_with_dummy_buffer_updater(
     const gsl::not_null<Generator*> gen,
-    const bool apply_normalization_bug = false,
-    const bool is_spec_input = true) noexcept {
+    const bool apply_normalization_bug = false, const bool is_spec_input = true,
+    const std::optional<double> extraction_radius = std::nullopt) noexcept {
+  // note that the default_extraction_radius is what will be reported
+  // from the buffer updater when the extraction_radius is the default
+  // `std::nullopt`.
+  const double default_extraction_radius = 100.0;
   UniformCustomDistribution<double> value_dist{0.1, 0.5};
   // first prepare the input for the modal version
   const double mass = value_dist(*gen);
@@ -368,7 +377,6 @@ void test_data_manager_with_dummy_buffer_updater(
       {value_dist(*gen), value_dist(*gen), value_dist(*gen)}};
   gr::Solutions::KerrSchild solution{mass, spin, center};
 
-  const double extraction_radius = 100.0;
 
   // acceptable parameters for the fake sinusoid variation in the input
   // parameters
@@ -445,15 +453,16 @@ void test_data_manager_with_dummy_buffer_updater(
       make_not_null(&shift_coefficients), make_not_null(&dt_shift_coefficients),
       make_not_null(&dr_shift_coefficients), make_not_null(&lapse_coefficients),
       make_not_null(&dt_lapse_coefficients),
-      make_not_null(&dr_lapse_coefficients), solution, extraction_radius,
-      amplitude, frequency, target_time, l_max, false);
+      make_not_null(&dr_lapse_coefficients), solution,
+      extraction_radius.value_or(default_extraction_radius), amplitude,
+      frequency, target_time, l_max, false);
 
   create_bondi_boundary_data(
       make_not_null(&expected_boundary_variables), spatial_metric_coefficients,
       dt_spatial_metric_coefficients, dr_spatial_metric_coefficients,
       shift_coefficients, dt_shift_coefficients, dr_shift_coefficients,
       lapse_coefficients, dt_lapse_coefficients, dr_lapse_coefficients,
-      extraction_radius, l_max);
+      extraction_radius.value_or(default_extraction_radius), l_max);
   Approx angular_derivative_approx =
       Approx::custom()
           .epsilon(std::numeric_limits<double>::epsilon() * 1.0e4)
@@ -474,7 +483,8 @@ void test_data_manager_with_dummy_buffer_updater(
 
 template <typename Generator>
 void test_spec_worldtube_buffer_updater(
-    const gsl::not_null<Generator*> gen) noexcept {
+    const gsl::not_null<Generator*> gen,
+    const bool extraction_radius_in_filename) noexcept {
   UniformCustomDistribution<double> value_dist{0.1, 0.5};
   // first prepare the input for the modal version
   const double mass = value_dist(*gen);
@@ -500,7 +510,9 @@ void test_spec_worldtube_buffer_updater(
       (buffer_size + 2 * interpolator_length) * square(l_max + 1)};
   Variables<cce_metric_input_tags> expected_coefficients_buffers{
       (buffer_size + 2 * interpolator_length) * square(l_max + 1)};
-  const std::string filename = "BoundaryDataH5Test_CceR0100.h5";
+  const std::string filename = extraction_radius_in_filename
+                                   ? "BoundaryDataH5Test_CceR0100.h5"
+                                   : "BoundaryDataH5Test.h5";
   if (file_system::check_if_file_exists(filename)) {
     file_system::rm(filename, true);
   }
@@ -508,7 +520,10 @@ void test_spec_worldtube_buffer_updater(
                                extraction_radius, frequency, amplitude, l_max);
 
   // request an appropriate buffer
-  MetricWorldtubeH5BufferUpdater buffer_updater{filename};
+  auto buffer_updater =
+      extraction_radius_in_filename
+          ? MetricWorldtubeH5BufferUpdater{filename}
+          : MetricWorldtubeH5BufferUpdater{filename, extraction_radius};
   auto serialized_and_deserialized_updater =
       serialize_and_deserialize(buffer_updater);
   size_t time_span_start = 0;
@@ -563,11 +578,13 @@ void test_spec_worldtube_buffer_updater(
             get<tag>(coefficients_buffers_from_serialized);
         CHECK_ITERABLE_APPROX(test_lhs, test_rhs_from_serialized);
       });
+  CHECK(buffer_updater.get_extraction_radius() == 100.0);
 }
 
 template <typename Generator>
 void test_reduced_spec_worldtube_buffer_updater(
-    const gsl::not_null<Generator*> gen) noexcept {
+    const gsl::not_null<Generator*> gen,
+    const bool extraction_radius_in_filename) noexcept {
   UniformCustomDistribution<double> value_dist{0.1, 0.5};
   // first prepare the input for the modal version
   const double mass = value_dist(*gen);
@@ -577,7 +594,7 @@ void test_reduced_spec_worldtube_buffer_updater(
       {value_dist(*gen), value_dist(*gen), value_dist(*gen)}};
   gr::Solutions::KerrSchild solution{mass, spin, center};
 
-  const double extraction_radius = 10.0;
+  const double extraction_radius = 100.0;
 
   // acceptable parameters for the fake sinusoid variation in the input
   // parameters
@@ -612,7 +629,9 @@ void test_reduced_spec_worldtube_buffer_updater(
       boundary_data_variables{number_of_angular_points};
 
   // write times to file for several steps before and after the target time
-  const std::string filename = "BoundaryDataH5Test_CceR0100.h5";
+  const std::string filename = extraction_radius_in_filename
+      ? "BoundaryDataH5Test_CceR0100.h5"
+      : "BoundaryDataH5Test.h5";
   if (file_system::check_if_file_exists(filename)) {
     file_system::rm(filename, true);
   }
@@ -687,7 +706,10 @@ void test_reduced_spec_worldtube_buffer_updater(
     }
   }
   // request an appropriate buffer
-  BondiWorldtubeH5BufferUpdater buffer_updater{filename};
+  auto buffer_updater =
+      extraction_radius_in_filename
+          ? BondiWorldtubeH5BufferUpdater{filename}
+          : BondiWorldtubeH5BufferUpdater{filename, extraction_radius};
   auto serialized_and_deserialized_updater =
       serialize_and_deserialize(buffer_updater);
   size_t time_span_start = 0;
@@ -754,6 +776,7 @@ void test_reduced_spec_worldtube_buffer_updater(
         CHECK_ITERABLE_CUSTOM_APPROX(test_lhs, test_rhs_from_serialized,
                                      modal_approx);
       });
+  CHECK(buffer_updater.get_extraction_radius() == 100.0);
 }
 }  // namespace
 
@@ -772,8 +795,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.ReadBoundaryDataH5",
   MAKE_GENERATOR(gen);
   {
     INFO("Testing buffer updaters");
-    test_spec_worldtube_buffer_updater(make_not_null(&gen));
-    test_reduced_spec_worldtube_buffer_updater(make_not_null(&gen));
+    test_spec_worldtube_buffer_updater(make_not_null(&gen), true);
+    test_spec_worldtube_buffer_updater(make_not_null(&gen), false);
+    test_reduced_spec_worldtube_buffer_updater(make_not_null(&gen), true);
+    test_reduced_spec_worldtube_buffer_updater(make_not_null(&gen), false);
   }
   {
     INFO("Testing data managers");
@@ -790,6 +815,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.ReadBoundaryDataH5",
     test_data_manager_with_dummy_buffer_updater<MetricWorldtubeDataManager,
                                                 DummyBufferUpdater>(
         make_not_null(&gen), false, false);
+    // check the case for an explicitly provided extraction radius.
+    test_data_manager_with_dummy_buffer_updater<MetricWorldtubeDataManager,
+                                                DummyBufferUpdater>(
+        make_not_null(&gen), false, false, 200.0);
     test_data_manager_with_dummy_buffer_updater<BondiWorldtubeDataManager,
                                                 ReducedDummyBufferUpdater>(
         make_not_null(&gen));


### PR DESCRIPTION
## Proposed changes

Makes some improvements to the boundary data system, moving away from taking the extraction radius via the filenames and reducing the incidence of an error that is confusing for users.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
