### PR TITLE
Add SpatialRicciScalarTag

### DIFF
--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -344,6 +344,29 @@ struct UnitNormalVectorCompute : UnitNormalVector<Frame>, db::ComputeTag {
   using return_type = tnsr::I<DataVector, 3, Frame>;
 };
 
+/// Ricci scalar is the two-dimensional intrinsic Ricci scalar curvature
+/// of a Strahlkorper
+struct RicciScalar : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+/// Computes the two-dimensional intrinsic Ricci scalar of a Strahlkorper
+template <typename Frame>
+struct RicciScalarCompute : RicciScalar, db::ComputeTag {
+  using base = RicciScalar;
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<Scalar<DataVector>*>, const tnsr::ii<DataVector, 3, Frame>&,
+      const tnsr::I<DataVector, 3, Frame>&,
+      const tnsr::ii<DataVector, 3, Frame>&,
+      const tnsr::II<DataVector, 3, Frame>&) noexcept>(
+      &StrahlkorperGr::ricci_scalar<Frame>);
+  using argument_tags =
+      tmpl::list<gr::Tags::SpatialRicci<3, Frame, DataVector>,
+                 UnitNormalVector<Frame>, gr::Tags::ExtrinsicCurvature<3>,
+                 gr::Tags::InverseSpatialMetric<3, Frame, DataVector>>;
+  using return_type = Scalar<DataVector>;
+};
+
 // @{
 /// `Tangents(i,j)` is \f$\partial x_{\rm surf}^i/\partial q^j\f$,
 /// where \f$x_{\rm surf}^i\f$ are the Cartesian coordinates of the

--- a/src/ApparentHorizons/TagsDeclarations.hpp
+++ b/src/ApparentHorizons/TagsDeclarations.hpp
@@ -46,6 +46,9 @@ template <typename Frame>
 struct UnitNormalVector;
 template <typename Frame>
 struct UnitNormalVectorCompute;
+struct RicciScalar;
+template <typename Frame>
+struct RicciScalarCompute;
 
 }  // namespace StrahlkorperTags
 

--- a/tests/Unit/ApparentHorizons/Test_Tags.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Tags.cpp
@@ -298,6 +298,8 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
       "IrreducibleMass");
   TestHelpers::db::test_simple_tag<StrahlkorperTags::OneOverOneFormMagnitude>(
       "OneOverOneFormMagnitude");
+  TestHelpers::db::test_simple_tag<StrahlkorperTags::RicciScalar>(
+      "RicciScalar");
   TestHelpers::db::test_simple_tag<
       StrahlkorperTags::UnitNormalOneForm<Frame::Inertial>>(
       "UnitNormalOneForm");
@@ -409,4 +411,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
   TestHelpers::db::test_compute_tag<
       StrahlkorperTags::UnitNormalVectorCompute<Frame::Inertial>>(
       "UnitNormalVector");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::RicciScalarCompute<Frame::Inertial>>(
+      "RicciScalar");
 }


### PR DESCRIPTION
## Proposed changes

Add SpatialRicciScalarTag and SpatialRicciScalarCompute for computing the two-dimensional intrinsic Ricci scalar of a Strahlkorper. 

### Types of changes:

- [ ] Bugfix
- [ x] New feature
- [ ] Refactor

### Component:

- [ x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
-->
