### PR TITLE
Update ocean gcc environments to use charm 6.10.2

### DIFF
--- a/support/Environments/ocean_gcc.sh
+++ b/support/Environments/ocean_gcc.sh
@@ -35,7 +35,7 @@ spectre_unload_modules() {
     module unload hdf5-1.10.4-gcc-7.3.0-ytt4j54
     module unload openblas-0.3.4-gcc-7.3.0-tt2coe7
     module unload python/3.7.0
-    module unload charm
+    module unload charm-6.10.2-libs
 }
 
 spectre_load_modules() {
@@ -58,7 +58,7 @@ spectre_load_modules() {
     module load boost-1.68.0-gcc-7.3.0-vgl6ofr
     module load hdf5-1.10.4-gcc-7.3.0-ytt4j54
     module load openblas-0.3.4-gcc-7.3.0-tt2coe7
-    module load charm
+    module load charm-6.10.2-libs
 }
 
 spectre_run_cmake() {

--- a/support/Environments/ocean_orca0_gcc.sh
+++ b/support/Environments/ocean_orca0_gcc.sh
@@ -32,7 +32,7 @@ spectre_unload_modules() {
     spack unload boost@1.69.0
     spack unload hdf5@1.10.5~hl
     spack unload openblas@0.3.5
-    module unload orca0/charm
+    module unload orca0/charm-6.10.2-libs
     module unload orca0/python/3.7.0
 }
 
@@ -54,7 +54,7 @@ spectre_load_modules() {
     spack load boost@1.69.0
     spack load hdf5@1.10.5~hl
     spack load openblas@0.3.5
-    module load orca0/charm
+    module load orca0/charm-6.10.2-libs
     module load orca0/python/3.7.0
 }
 


### PR DESCRIPTION
## Proposed changes

This updates the ocean gcc environments to charm 6.10.2. Note that I recommend using ocean_clang.sh, not either of these gcc environments, to build spectre on ocean. ocean_clang.sh already uses the correct charm-6.10.2 module. However, in case we ever want to build with gcc on ocean, I figure we should keep these other environments around.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
