### PR TITLE
CylindricalEndcap: Allow target sphere to be inside source sphere.

### DIFF
--- a/src/Domain/CoordinateMaps/CylindricalEndcap.hpp
+++ b/src/Domain/CoordinateMaps/CylindricalEndcap.hpp
@@ -48,6 +48,11 @@ namespace domain::CoordinateMaps {
  * mapped to a point on sphere 1 and \f$\bar{z}=+1\f$ is mapped to a
  * point on sphere 2.
  *
+ * Note that Sphere 1 and Sphere 2 are not equivalent, because the
+ * mapped portion of Sphere 1 is bounded by a plane of constant
+ * \f$z\f$ but the mapped portion of Sphere 2 is not (except for
+ * special choices of \f$C_1\f$, \f$C_2\f$, and \f$P\f$).
+ *
  * CylindricalEndcap is intended to be composed with Wedge2D maps to
  * construct a portion of a cylindrical domain for a binary system.
  *
@@ -55,14 +60,17 @@ namespace domain::CoordinateMaps {
  * \cite Buchman:2012dw.
  * CylindricalEndcap is used to construct the blocks labeled 'CA
  * wedge', 'EA wedge', 'CB wedge', 'EE wedge', and 'EB wedge' in
- * Figure 20 of that paper.
+ * Figure 20 of that paper.  Note that 'CA wedge', 'CB wedge', and
+ * 'EE wedge' have Sphere 1 contained in Sphere 2, and 'EA wedge'
+ * and 'EB wedge' have Sphere 2 contained in Sphere 1.
  *
  * CylindricalEndcap is implemented using `FocallyLiftedMap`
  * and `FocallyLiftedInnerMaps::Endcap`; see those classes for details.
  *
  * ### Restrictions on map parameters.
  *
- * We demand that Sphere 1 is fully contained inside Sphere 2. It is
+ * We demand that either Sphere 1 is fully contained inside Sphere 2, or
+ * that Sphere 2 is fully contained inside Sphere 1. It is
  * possible to construct a valid map without this assumption, but the
  * assumption simplifies the code, and the expected use cases obey
  * this restriction.
@@ -96,24 +104,33 @@ namespace domain::CoordinateMaps {
  * In addition to invertibility and the two additional restrictions
  * already mentioned above, we demand a few more restrictions on the
  * map parameters to simplify the logic for the expected use cases and
- * to ensure that jacobians do not get too large. We demand:
+ * to ensure that jacobians do not get too large. The numbers in the
+ * restrictions below were chosen empirically so that the unit tests pass
+ * with errors less than 100 times machine roundoff; we do not expect to
+ * run into these restrictions in normal usage. We demand:
  *
  * - \f$P\f$ is not too close to the edge of the invertibility cone.
  *   Here we demand that the angle between \f$P\f$ and \f$S\f$
- *   is less than \f$0.95 (\pi/2-\theta)\f$ (note that if this
+ *   is less than \f$0.85 (\pi/2-\theta)\f$ (note that if this
  *   angle is exactly \f$\pi/2-\theta\f$ it is exactly on the
- *   invertibility cone); The 0.95 was chosen empirically based on
+ *   invertibility cone); The 0.85 was chosen empirically based on
  *   unit tests.
- * - \f$P\f$ is contained in sphere 2.
- * - \f$P\f$ is to the left of \f$z_\mathrm{P}\f$.
  * - \f$z_\mathrm{P}\f$ is not too close to the center or the edge of sphere 1.
- *   Here we demand that \f$0.1 \leq \cos(\theta) \leq 0.9\f$, where
- *   the values 0.1 and 0.9 were chosen empirically based on unit tests.
- * - If a line segment is drawn between \f$P\f$ and any point on the
- *   intersection circle (the circle where sphere 1 intersects the
- *   plane \f$z=z_\mathrm{P}\f$), the angle between the line segment and
- *   the z-axis is smaller than \f$\pi/3\f$.
- *
+ *   Here we demand that \f$0.2 \leq \cos(\theta) \leq 0.95\f$, where
+ *   the values 0.2 and 0.95 were chosen empirically based on unit tests.
+ * - \f$P\f$ is contained in sphere 2.
+ * - If sphere 2 is contained in sphere 1, then
+ *   - \f$0.25 R_1 \leq R_2 \leq 0.85 (R_1 - |C_1-C_2|)\f$,
+ *     This prevents the two spheres from having a very narrow space between
+ *     them, and it prevents sphere 2 from being very small.
+ *   - \f$|P - C_2| < 0.1 R_2\f$, i.e. \f$P\f$ is near the center of sphere 2.
+ * - If sphere 1 is contained in sphere 2, then
+ *   - \f$ R_2 \geq 1.01 (R_1 + |C_1-C_2|)\f$, where the 1.01
+ *     prevents the spheres from (barely) touching.
+ *   - If a line segment is drawn between \f$P\f$ and any point on the
+ *     intersection circle (the circle where sphere 1 intersects the
+ *     plane \f$z=z_\mathrm{P}\f$), the angle between the line segment
+ *     and the z-axis is smaller than \f$\pi/3\f$.
  */
 class CylindricalEndcap {
  public:

--- a/src/Domain/CoordinateMaps/FocallyLiftedEndcap.cpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedEndcap.cpp
@@ -320,15 +320,20 @@ void Endcap::dxbar_dsigma(
 
 std::optional<double> Endcap::lambda_tilde(
     const std::array<double, 3>& parent_mapped_target_coords,
-    const std::array<double, 3>& projection_point) const noexcept {
+    const std::array<double, 3>& projection_point,
+    const bool source_is_between_focus_and_target) const noexcept {
   // Try to find lambda_tilde going from target_coords to sphere.
-  // This lambda_tilde should be positive and less than or equal to unity.
-  // If there are two such roots, we choose based on where the points are.
+  // If the target surface is outside the sphere (that is,
+  // source_is_between_focus_and_target is true), then lambda_tilde should be
+  // positive and less than or equal to unity. If the target surface is inside
+  // the sphere, then lambda_tilde should be greater than or equal
+  // to unity. If there are two such roots, we choose based on where the points
+  // are.
   const bool choose_larger_root =
       parent_mapped_target_coords[2] > projection_point[2];
   return FocallyLiftedMapHelpers::try_scale_factor(
       parent_mapped_target_coords, projection_point, center_, radius_,
-      choose_larger_root, false);
+      choose_larger_root, not source_is_between_focus_and_target);
 }
 
 template <typename T>

--- a/src/Domain/CoordinateMaps/FocallyLiftedEndcap.hpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedEndcap.hpp
@@ -422,7 +422,8 @@ class Endcap {
 
   std::optional<double> lambda_tilde(
       const std::array<double, 3>& parent_mapped_target_coords,
-      const std::array<double, 3>& projection_point) const noexcept;
+      const std::array<double, 3>& projection_point,
+      bool source_is_between_focus_and_target) const noexcept;
 
   template <typename T>
   void deriv_lambda_tilde(

--- a/src/Domain/CoordinateMaps/FocallyLiftedEndcap.hpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedEndcap.hpp
@@ -436,10 +436,6 @@ class Endcap {
 
   static bool is_identity() noexcept { return false; }
 
-  static bool projection_source_is_between_focus_and_target() noexcept {
-    return true;
-  }
-
  private:
   friend bool operator==(const Endcap& lhs, const Endcap& rhs) noexcept;
   std::array<double, 3> center_{};

--- a/src/Domain/CoordinateMaps/FocallyLiftedMap.cpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedMap.cpp
@@ -267,8 +267,8 @@ template <typename InnerMap>
 std::optional<std::array<double, 3>> FocallyLiftedMap<InnerMap>::inverse(
     const std::array<double, 3>& target_coords) const noexcept {
   // Scale factor taking target_coords to lower_coords.
-  const auto lambda_tilde =
-      inner_map_.lambda_tilde(target_coords, proj_center_);
+  const auto lambda_tilde = inner_map_.lambda_tilde(
+      target_coords, proj_center_, source_is_between_focus_and_target_);
 
   // Cannot find scale factor, so we are out of range of the map.
   if (not lambda_tilde) {

--- a/src/Domain/CoordinateMaps/FocallyLiftedMap.cpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedMap.cpp
@@ -23,10 +23,11 @@ template <typename InnerMap>
 FocallyLiftedMap<InnerMap>::FocallyLiftedMap(
     const std::array<double, 3>& center,
     const std::array<double, 3>& proj_center, double radius,
-    InnerMap inner_map) noexcept
+    const bool source_is_between_focus_and_target, InnerMap inner_map) noexcept
     : center_(center),
       proj_center_(proj_center),
       radius_(radius),
+      source_is_between_focus_and_target_(source_is_between_focus_and_target),
       inner_map_(std::move(inner_map)) {}
 
 template <typename InnerMap>
@@ -47,7 +48,7 @@ operator()(const std::array<T, 3>& source_coords) const noexcept {
   ReturnType& lambda = temp_scalar;
   FocallyLiftedMapHelpers::scale_factor(
       &lambda, lower_coords, proj_center_, center_, radius_,
-      InnerMap::projection_source_is_between_focus_and_target());
+      source_is_between_focus_and_target_);
 
   std::array<ReturnType, 3> upper_coords{};
   for (size_t i = 0; i < 3; ++i) {
@@ -92,7 +93,7 @@ FocallyLiftedMap<InnerMap>::jacobian(
   ReturnType lambda{};
   FocallyLiftedMapHelpers::scale_factor(
       &lambda, lower_coords, proj_center_, center_, radius_,
-      InnerMap::projection_source_is_between_focus_and_target());
+      source_is_between_focus_and_target_);
 
   // upper_coords are the mapped coords on the surface of the sphere.
   std::array<ReturnType, 3>& upper_coords = temp_vector_one;
@@ -183,7 +184,7 @@ FocallyLiftedMap<InnerMap>::inv_jacobian(
   ReturnType lambda{};
   FocallyLiftedMapHelpers::scale_factor(
       &lambda, lower_coords, proj_center_, center_, radius_,
-      InnerMap::projection_source_is_between_focus_and_target());
+      source_is_between_focus_and_target_);
 
   // upper_coords are the mapped coords on the surface of the sphere.
   std::array<ReturnType, 3> upper_coords{};
@@ -277,8 +278,8 @@ std::optional<std::array<double, 3>> FocallyLiftedMap<InnerMap>::inverse(
   // Try to find lambda_bar going from target_coords to sphere.
   const auto lambda_bar = FocallyLiftedMapHelpers::try_scale_factor(
       target_coords, proj_center_, center_, radius_,
-      not InnerMap::projection_source_is_between_focus_and_target(),
-      InnerMap::projection_source_is_between_focus_and_target());
+      not source_is_between_focus_and_target_,
+      source_is_between_focus_and_target_);
 
   // Cannot find scale factor, so we are out of range of the map.
   if (not lambda_bar) {
@@ -334,6 +335,7 @@ void FocallyLiftedMap<InnerMap>::pup(PUP::er& p) noexcept {
   p | center_;
   p | proj_center_;
   p | radius_;
+  p | source_is_between_focus_and_target_;
   p | inner_map_;
 }
 
@@ -347,7 +349,10 @@ template <typename InnerMap>
 bool operator==(const FocallyLiftedMap<InnerMap>& lhs,
                 const FocallyLiftedMap<InnerMap>& rhs) noexcept {
   return lhs.center_ == rhs.center_ and lhs.proj_center_ == rhs.proj_center_ and
-         lhs.radius_ == rhs.radius_ and lhs.inner_map_ == rhs.inner_map_;
+         lhs.radius_ == rhs.radius_ and
+         lhs.source_is_between_focus_and_target_ ==
+             rhs.source_is_between_focus_and_target_ and
+         lhs.inner_map_ == rhs.inner_map_;
 }
 
 // Explicit instantiations

--- a/src/Domain/CoordinateMaps/FocallyLiftedMap.hpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedMap.hpp
@@ -99,6 +99,17 @@ bool operator==(const FocallyLiftedMap<InnerMap>& lhs,
  * and we demand that the \f$\sigma=0\f$ and \f$\sigma=1\f$ surfaces do
  * not intersect; otherwise the map is singular.
  *
+ * Also note that the quadratic Eq. (2) typically has more than one
+ * root, corresponding to two intersections of the sphere.  The
+ * boolean parameter `source_is_between_focus_and_target` that is
+ * passed into the constructor of `FocallyLiftedMap` is used to choose the
+ * appropriate root, or to error if a suitable
+ * root is not found. `source_is_between_focus_and_target` should be
+ * true if the source point lies between the projection point
+ * \f$P^i\f$ and the sphere.  `source_is_between_focus_and_target` is
+ * known only by each particular `CoordinateMap` that uses
+ * `FocallyLiftedMap`.
+ *
  * ### Jacobian
  *
  * Differentiating Eq. (1) above yields
@@ -304,6 +315,7 @@ class FocallyLiftedMap {
   static constexpr size_t dim = 3;
   FocallyLiftedMap(const std::array<double, 3>& center,
                    const std::array<double, 3>& proj_center, double radius,
+                   bool source_is_between_focus_and_target,
                    InnerMap inner_map) noexcept;
 
   FocallyLiftedMap() = default;
@@ -339,6 +351,7 @@ class FocallyLiftedMap {
                  const FocallyLiftedMap<InnerMap>& rhs) noexcept;
   std::array<double, 3> center_{}, proj_center_{};
   double radius_{std::numeric_limits<double>::signaling_NaN()};
+  bool source_is_between_focus_and_target_;
   InnerMap inner_map_;
 };
 template <typename InnerMap>

--- a/tests/Unit/Domain/CoordinateMaps/Test_CylindricalEndcap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CylindricalEndcap.cpp
@@ -15,11 +15,13 @@
 
 namespace domain {
 namespace {
-void test_cylindrical_endcap() {
-  INFO("CylindricalEndcap");
+
+void test_cylindrical_endcap_sphere_two_small() {
+  // Here sphere_two is contained in sphere_one.
+  INFO("CylindricalEndcapSphereTwoSmall");
+
   // Set up random number generator
   MAKE_GENERATOR(gen);
-
   std::uniform_real_distribution<> unit_dis(0.0, 1.0);
   std::uniform_real_distribution<> interval_dis(-1.0, 1.0);
   std::uniform_real_distribution<> angle_dis(0.0, 2.0 * M_PI);
@@ -31,186 +33,242 @@ void test_cylindrical_endcap() {
   const std::array<double, 3> center_two = {
       interval_dis(gen), interval_dis(gen), interval_dis(gen)};
   CAPTURE(center_two);
+
   const double dist_between_spheres =
       sqrt(square(center_two[0] - center_one[0]) +
            square(center_two[1] - center_one[1]) +
            square(center_two[2] - center_one[2]));
 
-  // Pick radius of sphere_one not too small compared to the distance
-  // between the centers.  We choose 0.3*dist_between_spheres so that
-  // we don't have a microscopic sphere (without that term the radius could be
-  // arbitrarily small), but still allow the radius to be smaller than
-  // the distance between the centers.
-  const double radius_one = 0.3 * dist_between_spheres + unit_dis(gen);
+  // First pick the radius of the larger sphere to be large enough
+  // that the centers of both spheres are reasonably well inside.
+  // Note that choosing 6.0 means that center_two[2]-center_one[2] is
+  // less than radius_one/6, so that center_two[2] will be less than
+  // z_plane below.
+  const double radius_one = 6.0 * (unit_dis(gen) + 1.0) * dist_between_spheres;
   CAPTURE(radius_one);
 
   // Make sure z_plane intersects sphere_one on the +z side of the
   // center. We don't allow the plane to be displaced by less than 20%
-  // or more than 90% of the radius.
+  // or more than 95% of the radius.
   const double z_plane =
-      center_one[2] + (0.2 + 0.7 * unit_dis(gen)) * radius_one;
+      center_one[2] + (0.2 + 0.75 * unit_dis(gen)) * radius_one;
   CAPTURE(z_plane);
 
-  // Now construct sphere_two which we make sure encloses sphere_one,
-  // but doesn't have too large of a radius.
-  const double radius_two =
-      (unit_dis(gen) + 1.0) * (radius_one + dist_between_spheres);
+  // Choose radius_two.
+  const double radius_two = [&radius_one, &dist_between_spheres, &unit_dis,
+                             &gen]() noexcept {
+    // Choose radius_two to be small enough that the space between the
+    // two spheres is not too cramped.
+    const double max_radius_two = 0.85 * (radius_one - dist_between_spheres);
+
+    // Choose radius_two to be not too small compared to radius_one.
+    const double min_radius_two = 0.25 * radius_one;
+
+    return min_radius_two + unit_dis(gen) * (max_radius_two - min_radius_two);
+  }();
   CAPTURE(radius_two);
 
-  const std::array<double, 3> proj_center = [&z_plane, &center_one, &radius_one,
-                                             &center_two, &radius_two, &gen,
-                                             &unit_dis, &angle_dis]() noexcept {
-    // Consider a cone formed by taking the intersection of z_plane and
-    // sphere_one (this is a circle called circle_one) and connecting it to
-    // center_one. Compute theta, where 2*theta is the opening angle of this
-    // cone. Call this cone 'cone_one'.
-    // cone_one is the cone centered at C_1 in the "Allowed region for P"
-    // figure in the doxygen documentation for ClyndricalEndcap.hpp.
-    const double cos_theta = (z_plane - center_one[2]) / radius_one;
-
-    // We will construct two new cones. The first we will call
-    // cone_regular. It is constructed so that cone_regular and
-    // cone_one intersect each other on circle_one at right angles.
-    // Cone_regular opens in the -z direction with opening angle 2*(pi/2-theta).
-    // cone_regular is the cone centered at S in the "Allowed region for P"
-    // figure in the doxygen documentation for ClyndricalEndcap.hpp.
-    // The apex of cone_regular is cone_regular_apex, defined as follows:
-    const std::array<double, 3> cone_regular_apex = {
-        center_one[0], center_one[1], center_one[2] + radius_one / cos_theta};
-    // A necessary condition for the map being
-    // invertible is that proj_center must lie either inside
-    // cone_regular (which opens in the -z direction and intersects
-    // cone_one), or proj_center must lie inside the reflection of
-    // cone_regular (which opens in the +z direction).  If proj_center
-    // is inside cone_regular (i.e. the one that opens in the -z
-    // direction), an additional condition for the map being
-    // invertible is that proj_center cannot lie between sphere_one
-    // and the center of cone_regular.
-
-    // The second cone we will construct we will call cone_opening.
-    // It will have some maximum opening angle that we choose freely.
-    const double max_opening_angle = M_PI / 3.0;
-    // max_opening_angle determines the maximum possible x-coordinate
-    // of proj_center.
-    const double max_proj_center_z =
-        z_plane -
-        radius_one * sqrt(1.0 - square(cos_theta)) / tan(max_opening_angle);
-    // Cone_opening has apex
-    // (center_one[0], center_one[1], max_proj_center_z). Note that if
-    // max_opening_angle > pi/4 and if z_plane > center_one[2] then
-    // the apex of cone_opening is inside sphere_one.
-
-    // Now that we have two cones, cone_regular and cone_opening.  We
-    // will choose proj_center so that it lies inside of both cones,
-    // and that it lies inside of sphere_two.
-    const double cone_regular_opening_angle = asin(cos_theta);
-
-    if (max_opening_angle < cone_regular_opening_angle) {
-      // The easier case.  We need to worry only about max_opening_angle.
-
-      // Choose some smaller cone inside of cone_opening.
-      // We will place proj_center on this smaller cone.
-      const double beta = unit_dis(gen) * max_opening_angle;
-
-      // Choose an azimuthal coordinate for the point on the cone.
-      const double phi = angle_dis(gen);
-
-      // Choose a radius for the point on the cone that will be
-      // proj_center. The point should be inside sphere_two.  So
-      // determine the radius at which the point intersects
-      // sphere_two. This radius is the solution of a quadratic equation
-      // ax^2 + bx + c = 0
-      const double a = 1.0;
-      const double b =
-          2.0 * (-(max_proj_center_z - center_two[2]) * cos(beta) +
-                 (center_one[0] - center_two[0]) * sin(beta) * cos(phi) +
-                 (center_one[1] - center_two[1]) * sin(beta) * sin(phi));
-      const double c = square(max_proj_center_z - center_two[2]) +
-                       square(center_one[0] - center_two[0]) +
-                       square(center_one[1] - center_two[1]) -
-                       square(radius_two);
-      ASSERT(c < 0.0,
-             "max_proj_center_z is too negative. The apex "
-             "is not inside sphere_two");
-      // Should be two real roots. Choose the positive one.
-      const double r_max = positive_root(a, b, c);
-
-      const double proj_radius = unit_dis(gen) * r_max;
-      return std::array<double, 3>{
-          center_one[0] + proj_radius * sin(beta) * cos(phi),
-          center_one[1] + proj_radius * sin(beta) * sin(phi),
-          max_proj_center_z - proj_radius * cos(beta)};
-    } else {
-      // The more difficult case.
-
-      // We may need to try several values of alpha.
-      // When one works, exit.
-      // Failure is rare; most of the time it should succeed on the first try.
-      while (true) {
-        // Choose some smaller cone inside of cone_regular.
-        // We will place proj_center on this smaller cone.
-        // We do not allow the smaller cone to go all the way to
-        // cone_regular_opening_angle.
-        const double alpha = unit_dis(gen) * 0.95 * cone_regular_opening_angle;
-
-        // Consider the circle at which the smaller cone intersects
-        // cone_opening, and find the distance from cone_regular_apex to
-        // this circle.
-        const double radius_coord_circle =
-            (cone_regular_apex[2] - max_proj_center_z) *
-            tan(max_opening_angle) / (tan(max_opening_angle) - tan(alpha)) /
-            cos(alpha);
-
-        // Choose an azimuthal coordinate for the point on the cone.
+  // Now choose projection point to be very near the center of sphere_two.
+  const auto proj_center =
+      [&center_two, &radius_two, &angle_dis, &unit_dis, &gen]() noexcept {
+        const double radius = 0.1 * radius_two * unit_dis(gen);
+        const double theta = 0.5 * angle_dis(gen);
         const double phi = angle_dis(gen);
-
-        // Choose a radius for the point on the cone that will be
-        // proj_center. The point should be inside sphere_two.  So
-        // determine the radius at which the point intersects
-        // sphere_two. This radius is the solution of a quadratic equation
-        // ax^2 + bx + c = 0
-        const double a = 1.0;
-        const double b =
-            2.0 * (-(cone_regular_apex[2] - center_two[2]) * cos(alpha) +
-                   (center_one[0] - center_two[0]) * sin(alpha) * cos(phi) +
-                   (center_one[1] - center_two[1]) * sin(alpha) * sin(phi));
-        const double c = square(cone_regular_apex[2] - center_two[2]) +
-                         square(center_one[0] - center_two[0]) +
-                         square(center_one[1] - center_two[1]) -
-                         square(radius_two);
-
-        double x0 = std::numeric_limits<double>::signaling_NaN();
-        double x1 = std::numeric_limits<double>::signaling_NaN();
-        const int num_real_roots = gsl_poly_solve_quadratic(a, b, c, &x0, &x1);
-        double r_max = 0.0;
-        if (num_real_roots == 2) {
-          // Take the largest root.  The smallest one is negative if
-          // cone_regular_apex[0] is inside sphere_two, positive if
-          // cone_regular_apex[0] is outside sphere_two.
-          r_max = std::max(x0, x1);
-        } else if (num_real_roots == 1) {
-          r_max = x0;
-        } else {
-          ASSERT(false,
-                 "No roots were found. This means that the cone does not "
-                 "intersect sphere_two, which should not happen based on the "
-                 "construction above.");
-        }
-
-        if (r_max <= radius_coord_circle) {
-          // We cannot satisfy all the conditions because sphere_two is
-          // too small. So try again with a different alpha.
-          continue;
-        }
-        const double proj_radius =
-            radius_coord_circle + unit_dis(gen) * (r_max - radius_coord_circle);
         return std::array<double, 3>{
-            center_one[0] + proj_radius * sin(alpha) * cos(phi),
-            center_one[1] + proj_radius * sin(alpha) * sin(phi),
-            cone_regular_apex[2] - proj_radius * cos(alpha)};
-      }
+            center_two[0] + radius * sin(theta) * cos(phi),
+            center_two[1] + radius * sin(theta) * sin(phi),
+            center_two[2] + radius * cos(theta)};
+      }();
+  CAPTURE(proj_center);
+
+  const CoordinateMaps::CylindricalEndcap map(
+      center_one, center_two, proj_center, radius_one, radius_two, z_plane);
+  test_suite_for_map_on_cylinder(map, 0.0, 1.0);
+}
+
+void test_cylindrical_endcap_sphere_two_large() {
+  // Here sphere_one is contained in sphere_two.
+  INFO("CylindricalEndcapSphereTwoLarge");
+
+  // Set up random number generator
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> unit_dis(0.0, 1.0);
+  std::uniform_real_distribution<> interval_dis(-1.0, 1.0);
+  std::uniform_real_distribution<> angle_dis(0.0, 2.0 * M_PI);
+
+  // Choose some random centers for sphere_one and sphere_two
+  const std::array<double, 3> center_one = {
+      interval_dis(gen), interval_dis(gen), interval_dis(gen)};
+  CAPTURE(center_one);
+  const std::array<double, 3> center_two = {
+      interval_dis(gen), interval_dis(gen), interval_dis(gen)};
+  CAPTURE(center_two);
+
+  // Computes the maximum possible z-coordinate of the projection
+  // point, such that proj_center obeys the max_opening_angle
+  // restriction.  Consider a cone extending in the minus-z direction
+  // from the apex (center_one[0],center_one[1],max_proj_center_z),
+  // with an opening angle of max_opening_angle.  proj_center must lie
+  // inside that cone.
+  auto compute_max_proj_center_z =
+      [](double radius_one, double z_plane, double max_opening_angle,
+         const std::array<double, 3>& center_one_local) noexcept -> double {
+    const double cos_theta = (z_plane - center_one_local[2]) / radius_one;
+    return z_plane -
+           radius_one * sqrt(1.0 - square(cos_theta)) / tan(max_opening_angle);
+  };
+
+  const double dist_between_spheres =
+      sqrt(square(center_two[0] - center_one[0]) +
+           square(center_two[1] - center_one[1]) +
+           square(center_two[2] - center_one[2]));
+
+  // The choice of the maximum opening angle must agree with the
+  // value chosen in the sanity checks in CylindricalEndcap.cpp, or
+  // else the test will test configurations that do not correspond to
+  // those sanity checks.
+  // This opening angle is the maximum angle between the z-axis and
+  // the line segment that connects the projection point and any
+  // point on the circle where the z-plane intersects sphere_one.
+  const double max_opening_angle = M_PI / 3.0;
+
+  // Pick the radius of the smaller sphere to be not too small
+  // compared to the distance between the centers.  We choose
+  // 0.4*dist_between_spheres so that we don't have a microscopic
+  // sphere (without that term the radius could be arbitrarily small),
+  // but still allow the radius to be smaller than the distance
+  // between the centers.
+  const double radius_one = 0.4 * dist_between_spheres + unit_dis(gen);
+  CAPTURE(radius_one);
+
+  // Make sure z_plane intersects sphere_one on the +z side of the
+  // center. We don't allow the plane to be displaced by less than 20%
+  // or more than 95% of the radius.
+  const double z_plane =
+      center_one[2] + (0.2 + 0.75 * unit_dis(gen)) * radius_one;
+  CAPTURE(z_plane);
+
+  // Consider a cone formed by taking the intersection of z_plane and
+  // sphere_one (this is a circle called circle_one) and connecting it to
+  // center_one. Compute theta, where 2*theta is the opening angle of this
+  // cone. Call this cone 'cone_one'.
+  // cone_one is the cone centered at C_1 in the "Allowed region for P"
+  // figure in the doxygen documentation for ClyndricalEndcap.hpp.
+  const double cos_theta = (z_plane - center_one[2]) / radius_one;
+
+  // We will construct two new cones. The first we will call
+  // cone_regular. It is constructed so that cone_regular and
+  // cone_one intersect each other on circle_one at right angles.
+  // Cone_regular opens in the -z direction with opening angle
+  // 2*(pi/2-theta).
+  // cone_regular is the cone centered at S in the "Allowed region for P"
+  // figure in the doxygen documentation for ClyndricalEndcap.hpp.
+  // The apex of cone_regular is cone_regular_apex,
+  // defined as follows:
+  const std::array<double, 3> cone_regular_apex = {
+      center_one[0], center_one[1], center_one[2] + radius_one / cos_theta};
+  // A necessary condition for the map being
+  // invertible is that proj_center must lie either inside
+  // cone_regular (which opens in the -z direction and intersects
+  // cone_one), or proj_center must lie inside the reflection of
+  // cone_regular (which opens in the +z direction).  If proj_center
+  // is inside cone_regular (i.e. the one that opens in the -z
+  // direction), an additional condition for the map being
+  // invertible is that proj_center cannot lie between sphere_one
+  // and the center of cone_regular.
+
+  // The second cone, cone_opening, is the cone extending in the
+  // minus-z direction from the apex
+  // (center_one[0],center_one[1],max_proj_center_z).  proj_center
+  // must lie inside that cone.  Note that if max_opening_angle >
+  // pi/4 and if z_plane > center_one[2] then the apex of
+  // cone_opening is inside sphere_one.
+  const double max_proj_center_z = compute_max_proj_center_z(
+      radius_one, z_plane, max_opening_angle, center_one);
+
+  // Now that we have two cones, cone_regular and cone_opening.  We
+  // will choose proj_center so that it lies inside of both cones,
+  // and that it lies inside of sphere_two.
+  // [Note asin(cos_theta) = pi/2-theta]
+  const double cone_regular_opening_angle = asin(cos_theta);
+
+  // Because we have two cones, we do the random choice of proj_center
+  // and radius_two by rejection.  That is, we choose a proj_center
+  // inside cone_opening, and if this point is outside (or sufficiently near)
+  // cone_regular we reject proj_center and try again.
+  double radius_two = std::numeric_limits<double>::signaling_NaN();
+  std::array<double, 3> proj_center{z_plane, z_plane, z_plane};
+  bool found_proj_center = false;
+  while (not found_proj_center) {
+    // We typically expect success on the first iteration or the first
+    // few iterations if we get unlucky.  Let V_O be the volume of
+    // cone_opening that is contained inside sphere_two.  If
+    // cone_regular (modulo a small buffer angle, the 0.85 below)
+    // contains V_O, then success is certain the first
+    // time. Otherwise, the probability of success is roughly V_R/V_O,
+    // where V_R is the volume of the portion of cone_regular (modulo
+    // a small buffer angle, the 0.85 below) that is contained inside
+    // V_O.
+
+    // Pick radius of the larger sphere to enclose the smaller one
+    // (and not have too large a radius).
+    // The 1.01 is there so that the spheres do not almost touch, which
+    // causes problems with roundoff.
+    radius_two = (unit_dis(gen) + 1.01) * (radius_one + dist_between_spheres);
+
+    // Choose some smaller cone inside of cone_opening.
+    // We will place proj_center on this smaller cone.
+    const double beta = unit_dis(gen) * max_opening_angle;
+
+    // Choose an azimuthal coordinate for the point on the cone.
+    const double phi = angle_dis(gen);
+
+    // Choose the distance proj_dist between the apex of the cone and
+    // proj_center. proj_center must be inside sphere_two.  So
+    // determine the distance proj_dist_max at which the point intersects
+    // sphere_two. This radius is the solution of a quadratic equation
+    // a proj_dist_max^2 + b proj_dist_max + c = 0
+    const double a = 1.0;
+    const double b =
+        2.0 * (-(max_proj_center_z - center_two[2]) * cos(beta) +
+               (center_one[0] - center_two[0]) * sin(beta) * cos(phi) +
+               (center_one[1] - center_two[1]) * sin(beta) * sin(phi));
+    const double c = square(max_proj_center_z - center_two[2]) +
+                     square(center_one[0] - center_two[0]) +
+                     square(center_one[1] - center_two[1]) - square(radius_two);
+    ASSERT(c < 0.0,
+           "max_proj_center_z is too negative. The apex "
+           "is not inside sphere_two");
+
+    // Should be two real roots, one positive and one
+    // negative. Choose the positive one.
+    const double proj_dist_max = positive_root(a, b, c);
+
+    // Now get the distance along the cone
+    const double proj_dist = unit_dis(gen) * proj_dist_max;
+
+    // Now for the rejection.  We reject the point if it is outside
+    // cone_opening, and we also reject the point if it is too close
+    // to cone_opening (using a factor 0.85 that is the same as the
+    // factor in the ASSERTS in the CylindricalEndcap constructor).
+    const double alpha = 0.85 * cone_regular_opening_angle;
+
+    // If beta <= alpha, then there is no max distance, i.e.
+    // all distances are ok.
+    // If beta < alpha, then the max distance is given by
+    // (cone_regular_apex[2]-max_proj_center_z)*sin(alpha)/ sin(beta-alpha)
+    if (beta <= alpha or
+        proj_dist < (cone_regular_apex[2] - max_proj_center_z) * sin(alpha) /
+                        sin(beta - alpha)) {
+      // accept.
+      proj_center = std::array<double, 3>{
+          center_one[0] + proj_dist * sin(beta) * cos(phi),
+          center_one[1] + proj_dist * sin(beta) * sin(phi),
+          max_proj_center_z - proj_dist * cos(beta)};
+      found_proj_center = true;
     }
-  }();
+  }
+  CAPTURE(radius_two);
   CAPTURE(proj_center);
 
   const CoordinateMaps::CylindricalEndcap map(
@@ -221,7 +279,8 @@ void test_cylindrical_endcap() {
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.CylindricalEndcap",
                   "[Domain][Unit]") {
-  test_cylindrical_endcap();
+  test_cylindrical_endcap_sphere_two_large();
+  test_cylindrical_endcap_sphere_two_small();
   CHECK(not CoordinateMaps::CylindricalEndcap{}.is_identity());
 }
 }  // namespace domain


### PR DESCRIPTION
## Proposed changes

CylindricalEndcap is a map that maps a 3d unit right cylinder to the portion of a volume contained between two spheres, where the volume is bounded by the intersection of the 'source' sphere with a z=constant plane.
For convenience and simplicity, CylindricalEndcap demands that the 'target' sphere contains the 'source' sphere.
However, it turns out that for the cylindrical BBH domain we also need CylindricalEndcap for the case in which the 'source' sphere contains the 'target' sphere.

This PR modifies CylindricalEndcap so that it allows the case in which the 'source' sphere contains the 'target' sphere.
The changes necessary were:
  - Change the logic choosing a particular root of a quadratic equation in the formula for the map and its inverse; the correct root to choose depends on the relationship between the two spheres.
  - Change the sanity checks in the CylindricalEndcap constructor, which now allow either sphere to be contained in the other.
  - Add the newly allowed configurations to Test_CylindricalEndcap.cpp.
  - Simplify the existing test in Test_CylindricalEndcap.cpp and make it (and the matching sanity checks in CylindricalEndcap.cpp) more robust.
  - Update the documentation.
  
 This should fix #2879

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
