### PR TITLE
Add error messages to generate XDMF

### DIFF
--- a/src/Visualization/Python/GenerateXdmf.py
+++ b/src/Visualization/Python/GenerateXdmf.py
@@ -21,6 +21,7 @@ def generate_xdmf(file_prefix, output, subfile_name, start_time, stop_time,
                         "python 2, which is deprecated. GenerateXdmf.py might "
                         "hang or run very slowly using python 2. Please use "
                         "python 3 instead.")
+
     h5files = [(h5py.File(filename, 'r'), filename)
                for filename in glob.glob(file_prefix + "*.h5")]
 
@@ -254,6 +255,7 @@ def parse_args():
     parser.add_argument(
         '--subfile-name',
         '-d',
+        required=True,
         help="Name of the volume data subfile in the H5 files, excluding the "
         "'.vol' extension")
     parser.add_argument("--stride",

--- a/src/Visualization/Python/GenerateXdmf.py
+++ b/src/Visualization/Python/GenerateXdmf.py
@@ -29,6 +29,10 @@ def generate_xdmf(file_prefix, output, subfile_name, start_time, stop_time,
         file_prefix)
 
     element_data = h5files[0][0].get(subfile_name + '.vol')
+    if element_data is None:
+        raise ValueError(("Could not open subfile name '{}.vol'. Available "
+                          "subfiles: {}").format(subfile_name,
+                                                 h5files[0][0].keys()))
     temporal_ids_and_values = [(x,
                                 element_data.get(x).attrs['observation_value'])
                                for x in element_data.keys()]

--- a/tests/Unit/Visualization/Python/Test_GenerateXdmf.py
+++ b/tests/Unit/Visualization/Python/Test_GenerateXdmf.py
@@ -7,6 +7,12 @@ import spectre.Informer as spectre_informer
 import unittest
 import os
 
+# For Py2 compatibility
+try:
+    unittest.TestCase.assertRaisesRegex
+except AttributeError:
+    unittest.TestCase.assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
+
 
 class TestGenerateXdmf(unittest.TestCase):
     def test_generate_xdmf(self):
@@ -29,6 +35,22 @@ class TestGenerateXdmf(unittest.TestCase):
         # details, we should refactor the script into smaller units.
         self.assertTrue(os.path.isfile(output_filename + '.xmf'))
         os.remove(output_filename + '.xmf')
+
+    def test_subfile_not_found(self):
+        data_file_prefix = os.path.join(spectre_informer.unit_test_path(),
+                                        'Visualization/Python', 'VolTestData')
+        output_filename = 'Test_GenerateXdmf_subfile_not_found'
+        if os.path.isfile(output_filename + '.xmf'):
+            os.remove(output_filename + '.xmf')
+
+        with self.assertRaisesRegex(ValueError, 'Could not open subfile'):
+            generate_xdmf(file_prefix=data_file_prefix,
+                          output=output_filename,
+                          subfile_name="unknown_subfile",
+                          start_time=0.,
+                          stop_time=1.,
+                          stride=1,
+                          coordinates='InertialCoordinates')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Proposed changes

- Raise an (intelligible) error when the subfile is not given
- Raise an (intelligible) error when the subfile specified is not found

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
