### PR TITLE
Add function to check conservation for new boundary corrections

### DIFF
--- a/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   Actions/Test_ComputeTimeDerivative.cpp
   Initialization/Test_Mortars.cpp
   Initialization/Test_QuadratureTag.cpp
+  Test_BoundaryCorrectionsHelper.cpp
   Test_InboxTags.cpp
   Test_LiftFromBoundary.cpp
   Test_MortarData.cpp

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_BoundaryCorrectionsHelper.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_BoundaryCorrectionsHelper.cpp
@@ -1,0 +1,169 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+namespace Tags {
+struct Var1 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct Var2 : db::SimpleTag {
+  using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
+};
+
+struct VolumeDouble : db::SimpleTag {
+  using type = double;
+};
+}  // namespace Tags
+
+template <size_t Dim>
+struct System {
+  static constexpr bool is_in_flux_conservative_form = true;
+  static constexpr bool has_primitive_and_conservative_vars = false;
+  static constexpr size_t volume_dim = Dim;
+
+  using variables_tag =
+      ::Tags::Variables<tmpl::list<Tags::Var1, Tags::Var2<Dim>>>;
+  using flux_variables = tmpl::list<Tags::Var1, Tags::Var2<Dim>>;
+  using gradient_variables = tmpl::list<>;
+  using sourced_variables = tmpl::list<>;
+
+  struct TimeDerivativeTerms {
+    using temporary_tags = tmpl::list<>;
+  };
+
+  using compute_volume_time_derivative_terms = TimeDerivativeTerms;
+};
+
+template <size_t Dim>
+struct Correction {
+ private:
+  struct AbsCharSpeed : db::SimpleTag {
+    using type = Scalar<DataVector>;
+  };
+
+ public:
+  using dg_package_field_tags =
+      tmpl::list<Tags::Var1, ::Tags::NormalDotFlux<Tags::Var1>, Tags::Var2<Dim>,
+                 ::Tags::NormalDotFlux<Tags::Var2<Dim>>, AbsCharSpeed>;
+  using dg_package_data_temporary_tags = tmpl::list<>;
+  using dg_package_data_volume_tags = tmpl::list<Tags::VolumeDouble>;
+
+  double dg_package_data(
+      const gsl::not_null<Scalar<DataVector>*> packaged_var1,
+      const gsl::not_null<Scalar<DataVector>*> packaged_normal_dot_flux_var1,
+      const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+          packaged_var2,
+      const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+          packaged_normal_dot_flux_var2,
+      const gsl::not_null<Scalar<DataVector>*> packaged_abs_char_speed,
+      const Scalar<DataVector>& var1,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& var2,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& flux_var1,
+      const tnsr::Ij<DataVector, Dim, Frame::Inertial>& flux_var2,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+      const boost::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+      /*mesh_velocity*/,
+      const boost::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,
+      const double volume_double) const noexcept {
+    *packaged_var1 = var1;
+    *packaged_var2 = var2;
+    dot_product(packaged_normal_dot_flux_var1, flux_var1, normal_covector);
+    for (size_t i = 0; i < Dim; ++i) {
+      packaged_normal_dot_flux_var2->get(i) =
+          flux_var2.get(i, 0) * get<0>(normal_covector);
+      for (size_t j = 1; j < Dim; ++j) {
+        packaged_normal_dot_flux_var2->get(i) +=
+            flux_var2.get(i, j) * normal_covector.get(j);
+      }
+    }
+
+    if (static_cast<bool>(normal_dot_mesh_velocity)) {
+      get(*packaged_abs_char_speed) =
+          abs(volume_double * get(var1) - get(*normal_dot_mesh_velocity));
+    } else {
+      get(*packaged_abs_char_speed) = abs(volume_double * get(var1));
+    }
+    return max(get(*packaged_abs_char_speed));
+  }
+
+  void dg_boundary_terms(
+      const gsl::not_null<Scalar<DataVector>*> boundary_correction_var1,
+      const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+          boundary_correction_var2,
+      const Scalar<DataVector>& var1_int,
+      const Scalar<DataVector>& normal_dot_flux_var1_int,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& var2_int,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_dot_flux_var2_int,
+      const Scalar<DataVector>& abs_char_speed_int,
+      const Scalar<DataVector>& var1_ext,
+      const Scalar<DataVector>& normal_dot_flux_var1_ext,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& var2_ext,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_dot_flux_var2_ext,
+      const Scalar<DataVector>& abs_char_speed_ext,
+      const dg::Formulation dg_formulation) const noexcept {
+    // The below code is a Rusanov solver.
+    if (dg_formulation == dg::Formulation::WeakInertial) {
+      get(*boundary_correction_var1) =
+          0.5 *
+              (get(normal_dot_flux_var1_int) - get(normal_dot_flux_var1_ext)) -
+          0.5 * max(get(abs_char_speed_int), get(abs_char_speed_ext)) *
+              (get(var1_ext) - get(var1_int));
+      for (size_t i = 0; i < Dim; ++i) {
+        boundary_correction_var2->get(i) =
+            0.5 * (normal_dot_flux_var2_int.get(i) -
+                   normal_dot_flux_var2_ext.get(i)) -
+            0.5 * max(get(abs_char_speed_int), get(abs_char_speed_ext)) *
+                (var2_ext.get(i) - var2_int.get(i));
+      }
+    } else {
+      get(*boundary_correction_var1) =
+          -0.5 *
+              (get(normal_dot_flux_var1_int) + get(normal_dot_flux_var1_ext)) -
+          0.5 * max(get(abs_char_speed_int), get(abs_char_speed_ext)) *
+              (get(var1_ext) - get(var1_int));
+      for (size_t i = 0; i < Dim; ++i) {
+        boundary_correction_var2->get(i) =
+            -0.5 * (normal_dot_flux_var2_int.get(i) +
+                    normal_dot_flux_var2_ext.get(i)) -
+            0.5 * max(get(abs_char_speed_int), get(abs_char_speed_ext)) *
+                (var2_ext.get(i) - var2_int.get(i));
+      }
+    }
+  }
+};
+
+template <size_t Dim>
+void test() {
+  const Correction<Dim> correction{};
+  const Mesh<Dim - 1> face_mesh{Dim * Dim, Spectral::Basis::Legendre,
+                                Spectral::Quadrature::Gauss};
+  TestHelpers::evolution::dg::test_boundary_correction_conservation<
+      System<Dim>>(correction, face_mesh,
+                   tuples::TaggedTuple<Tags::VolumeDouble>{2.3});
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.DG.BoundaryCorrectionsHelper",
+                  "[Unit][Evolution]") {
+  test<1>();
+  test<2>();
+  test<3>();
+}

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp
@@ -1,0 +1,318 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Framework/TestingFramework.hpp"
+
+#include <boost/optional.hpp>
+#include <cstddef>
+#include <random>
+#include <string>
+#include <type_traits>
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace TestHelpers::evolution::dg {
+/// Indicate if the boundary correction should be zero when the solution is
+/// smooth (should pretty much always be `Yes`)
+enum class ZeroOnSmoothSolution { Yes, No };
+
+namespace detail {
+template <bool HasPrimitiveVars = false>
+struct get_correction_primitive_vars_impl {
+  template <typename BoundaryCorrection>
+  using f = tmpl::list<>;
+};
+
+template <>
+struct get_correction_primitive_vars_impl<true> {
+  template <typename BoundaryCorrection>
+  using f = typename BoundaryCorrection::dg_package_data_primitive_tags;
+};
+
+template <bool HasPrimitiveVars, typename BoundaryCorrection>
+using get_correction_primitive_vars =
+    typename get_correction_primitive_vars_impl<HasPrimitiveVars>::template f<
+        BoundaryCorrection>;
+
+template <bool HasPrimitiveVars = false>
+struct get_system_primitive_vars_impl {
+  template <typename System>
+  using f = tmpl::list<>;
+};
+
+template <>
+struct get_system_primitive_vars_impl<true> {
+  template <typename System>
+  using f = typename System::primitive_variables_tag::tags_list;
+};
+
+template <bool HasPrimitiveVars, typename System>
+using get_system_primitive_vars = typename get_system_primitive_vars_impl<
+    HasPrimitiveVars>::template f<System>;
+
+template <typename BoundaryCorrection, typename... PackageTags,
+          typename... FaceTags, typename... VolumeTags, size_t Dim>
+void call_dg_package_data(
+    const gsl::not_null<Variables<tmpl::list<PackageTags...>>*> package_data,
+    const BoundaryCorrection& correction,
+    const Variables<tmpl::list<FaceTags...>>& face_variables,
+    const tuples::TaggedTuple<VolumeTags...>& volume_data,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& unit_normal_covector,
+    const boost::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+        mesh_velocity) {
+  boost::optional<Scalar<DataVector>> normal_dot_mesh_velocity{};
+  if (static_cast<bool>(mesh_velocity)) {
+    normal_dot_mesh_velocity =
+        dot_product(*mesh_velocity, unit_normal_covector);
+  }
+  correction.dg_package_data(
+      make_not_null(&get<PackageTags>(*package_data))...,
+      get<FaceTags>(face_variables)..., unit_normal_covector, mesh_velocity,
+      normal_dot_mesh_velocity, get<VolumeTags>(volume_data)...);
+}
+
+template <typename BoundaryCorrection, typename... BoundaryCorrectionTags,
+          typename... PackageTags>
+void call_dg_boundary_terms(
+    const gsl::not_null<Variables<tmpl::list<BoundaryCorrectionTags...>>*>
+        boundary_corrections,
+    const BoundaryCorrection& correction,
+    const Variables<tmpl::list<PackageTags...>>& interior_package_data,
+    const Variables<tmpl::list<PackageTags...>>& exterior_package_data,
+    const ::dg::Formulation dg_formulation) {
+  correction.dg_boundary_terms(
+      make_not_null(&get<BoundaryCorrectionTags>(*boundary_corrections))...,
+      get<PackageTags>(interior_package_data)...,
+      get<PackageTags>(exterior_package_data)..., dg_formulation);
+}
+
+template <typename System, typename BoundaryCorrection, size_t FaceDim,
+          typename... VolumeTags>
+void test_boundary_correction_impl(
+    const BoundaryCorrection& correction, const Mesh<FaceDim>& face_mesh,
+    const tuples::TaggedTuple<VolumeTags...>& volume_data,
+    const bool use_moving_mesh, const ::dg::Formulation dg_formulation,
+    const ZeroOnSmoothSolution zero_on_smooth_solution) {
+  CAPTURE(use_moving_mesh);
+  CAPTURE(dg_formulation);
+  CAPTURE(FaceDim);
+  using variables_tags = typename System::variables_tag::tags_list;
+  using primitive_variables_tags = detail::get_system_primitive_vars<
+      System::has_primitive_and_conservative_vars, System>;
+  using flux_variables = typename System::flux_variables;
+  using flux_tags =
+      db::wrap_tags_in<::Tags::Flux, flux_variables, tmpl::size_t<FaceDim + 1>,
+                       Frame::Inertial>;
+  using temporary_tags =
+      typename System::compute_volume_time_derivative_terms::temporary_tags;
+  using dt_variables_tags = db::wrap_tags_in<::Tags::dt, variables_tags>;
+
+  using dg_package_field_tags =
+      typename BoundaryCorrection::dg_package_field_tags;
+  using package_temporary_tags =
+      typename BoundaryCorrection::dg_package_data_temporary_tags;
+  using package_primitive_tags = detail::get_correction_primitive_vars<
+      System::has_primitive_and_conservative_vars, BoundaryCorrection>;
+
+  // Check that the temporary tags needed on the boundary
+  // (package_temporary_tags) are listed as temporary tags for the volume time
+  // derivative computation (temporary_tags).
+  static_assert(
+      std::is_same_v<
+          tmpl::list_difference<package_temporary_tags, temporary_tags>,
+          tmpl::list<>>,
+      "There are temporary tags needed by the boundary correction that are not "
+      "computed as temporary tags by the system");
+
+  // Check that the primitive tags needed on the boundary
+  // (package_primitive_tags) are listed as the primitive tags in
+  // the system (primitive_variables_tags).
+  static_assert(
+      std::is_same_v<tmpl::list_difference<package_primitive_tags,
+                                           primitive_variables_tags>,
+                     tmpl::list<>>,
+      "There are primitive tags needed by the boundary correction that are not "
+      "listed in the system as being primitive variables");
+
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> dist(0.0, 1.0);
+  std::uniform_real_distribution<> pos_neg_dist(-1.0, 1.0);
+  DataVector used_for_size{face_mesh.number_of_grid_points()};
+
+  boost::optional<tnsr::I<DataVector, FaceDim + 1, Frame::Inertial>>
+      mesh_velocity{};
+  if (use_moving_mesh) {
+    mesh_velocity = make_with_random_values<
+        tnsr::I<DataVector, FaceDim + 1, Frame::Inertial>>(
+        make_not_null(&gen), make_not_null(&dist), used_for_size);
+  }
+
+  Variables<dg_package_field_tags> interior_package_data{used_for_size.size()};
+  const auto interior_fields_on_face = make_with_random_values<
+      Variables<tmpl::append<variables_tags, flux_tags, package_temporary_tags,
+                             package_primitive_tags>>>(
+      make_not_null(&gen), make_not_null(&dist), used_for_size);
+
+  Variables<dg_package_field_tags> exterior_package_data{used_for_size.size()};
+  const auto exterior_fields_on_face = make_with_random_values<
+      Variables<tmpl::append<variables_tags, flux_tags, package_temporary_tags,
+                             package_primitive_tags>>>(
+      make_not_null(&gen), make_not_null(&dist), used_for_size);
+
+  // Compute the interior and exterior normal vectors so they are pointing in
+  // opposite directions.
+  auto interior_unit_normal_covector = make_with_random_values<
+      tnsr::i<DataVector, FaceDim + 1, Frame::Inertial>>(
+      make_not_null(&gen), make_not_null(&pos_neg_dist), used_for_size);
+  const Scalar<DataVector> interior_normal_magnitude =
+      magnitude(interior_unit_normal_covector);
+  for (auto& t : interior_unit_normal_covector) {
+    t /= get(interior_normal_magnitude);
+  }
+  auto exterior_unit_normal_covector = interior_unit_normal_covector;
+  for (auto& t : exterior_unit_normal_covector) {
+    t *= -1.0;
+  }
+
+  call_dg_package_data(make_not_null(&interior_package_data), correction,
+                       interior_fields_on_face, volume_data,
+                       interior_unit_normal_covector, mesh_velocity);
+  call_dg_package_data(make_not_null(&exterior_package_data), correction,
+                       exterior_fields_on_face, volume_data,
+                       exterior_unit_normal_covector, mesh_velocity);
+
+  Variables<dt_variables_tags> boundary_corrections{
+      face_mesh.number_of_grid_points()};
+  call_dg_boundary_terms(make_not_null(&boundary_corrections), correction,
+                         interior_package_data, exterior_package_data,
+                         dg_formulation);
+
+  if (dg_formulation == ::dg::Formulation::StrongInertial) {
+    // The strong form should be (WeakForm - (n_i F^i)_{interior}).
+    // Since we also test conservation for the weak form we just need to test
+    // that the strong form satisfies the above definition.
+
+    Variables<dt_variables_tags> expected_boundary_corrections{
+        face_mesh.number_of_grid_points()};
+    call_dg_boundary_terms(make_not_null(&expected_boundary_corrections),
+                           correction, interior_package_data,
+                           exterior_package_data,
+                           ::dg::Formulation::WeakInertial);
+
+    tmpl::for_each<flux_variables>([&interior_package_data,
+                                    &expected_boundary_corrections](
+                                       auto flux_variable_tag_v) noexcept {
+      using flux_variable_tag = tmpl::type_from<decltype(flux_variable_tag_v)>;
+      using normal_dot_flux_tag = ::Tags::NormalDotFlux<flux_variable_tag>;
+      using dt_tag = ::Tags::dt<flux_variable_tag>;
+      const auto& normal_dot_flux =
+          get<normal_dot_flux_tag>(interior_package_data);
+      auto& expected_boundary_correction =
+          get<dt_tag>(expected_boundary_corrections);
+      for (size_t tensor_index = 0;
+           tensor_index < expected_boundary_correction.size(); ++tensor_index) {
+        expected_boundary_correction[tensor_index] -=
+            normal_dot_flux[tensor_index];
+      }
+    });
+    {
+      INFO("Check weak and strong boundary terms match.");
+      CHECK(boundary_corrections == expected_boundary_corrections);
+    }
+
+    if (zero_on_smooth_solution == ZeroOnSmoothSolution::Yes) {
+      INFO(
+          "Testing that if the solution is the same on both sides the "
+          "StrongInertial correction is identically zero.");
+      Variables<dg_package_field_tags> interior_package_data_opposite_signs{
+          used_for_size.size()};
+      call_dg_package_data(make_not_null(&interior_package_data_opposite_signs),
+                           correction, interior_fields_on_face, volume_data,
+                           exterior_unit_normal_covector, mesh_velocity);
+      Variables<dt_variables_tags> zero_boundary_correction{
+          face_mesh.number_of_grid_points()};
+      call_dg_boundary_terms(make_not_null(&zero_boundary_correction),
+                             correction, interior_package_data,
+                             interior_package_data_opposite_signs,
+                             ::dg::Formulation::StrongInertial);
+      Variables<dt_variables_tags> expected_zero_boundary_correction{
+          face_mesh.number_of_grid_points(), 0.0};
+      tmpl::for_each<dt_variables_tags>([&expected_zero_boundary_correction,
+                                         &zero_boundary_correction](
+                                            auto dt_variables_tag_v) noexcept {
+        using dt_variables_tag = tmpl::type_from<decltype(dt_variables_tag_v)>;
+        const std::string tag_name = db::tag_name<dt_variables_tag>();
+        CAPTURE(tag_name);
+        Approx custom_approx = Approx::custom().epsilon(1.e-12).scale(1.0);
+        CHECK_ITERABLE_CUSTOM_APPROX(
+            get<dt_variables_tag>(zero_boundary_correction),
+            get<dt_variables_tag>(expected_zero_boundary_correction),
+            custom_approx);
+      });
+    }
+  } else if (dg_formulation == ::dg::Formulation::WeakInertial) {
+    INFO(
+        "Checking that swapping the two sides results in an overall minus "
+        "sign.");
+    Variables<dt_variables_tags> reverse_side_boundary_corrections{
+        face_mesh.number_of_grid_points()};
+    call_dg_boundary_terms(make_not_null(&reverse_side_boundary_corrections),
+                           correction, exterior_package_data,
+                           interior_package_data, dg_formulation);
+    // Check that the flux leaving one element equals the flux entering its
+    // neighbor, i.e., F*(interior, exterior) == -F*(exterior, interior)
+    reverse_side_boundary_corrections *= -1.0;
+    tmpl::for_each<flux_variables>([&boundary_corrections,
+                                    &reverse_side_boundary_corrections](
+                                       auto flux_variable_tag_v) {
+      using flux_variable_tag = tmpl::type_from<decltype(flux_variable_tag_v)>;
+      const std::string tag_name = db::tag_name<flux_variable_tag>();
+      CAPTURE(tag_name);
+      CHECK_ITERABLE_APPROX(
+          get<::Tags::dt<flux_variable_tag>>(reverse_side_boundary_corrections),
+          get<::Tags::dt<flux_variable_tag>>(boundary_corrections));
+    });
+  } else {
+    ERROR("DG formulation must be StrongInertial or WeakInertial, not "
+          << dg_formulation);
+  }
+}
+}  // namespace detail
+
+/*!
+ * \ingroup TestingFrameworkGroup
+ * \brief Checks that the boundary correction is conservative and that for
+ * smooth solutions the strong-form correction is zero.
+ */
+template <typename System, typename BoundaryCorrection, size_t FaceDim,
+          typename... VolumeTags>
+void test_boundary_correction_conservation(
+    const BoundaryCorrection& correction, const Mesh<FaceDim>& face_mesh,
+    const tuples::TaggedTuple<VolumeTags...>& volume_data,
+    const ZeroOnSmoothSolution zero_on_smooth_solution =
+        ZeroOnSmoothSolution::Yes) {
+  for (const auto use_moving_mesh : {true, false}) {
+    for (const auto& dg_formulation :
+         {::dg::Formulation::StrongInertial, ::dg::Formulation::WeakInertial}) {
+      detail::test_boundary_correction_impl<System>(
+          correction, face_mesh, volume_data, use_moving_mesh, dg_formulation,
+          zero_on_smooth_solution);
+    }
+  }
+}
+}  // namespace TestHelpers::evolution::dg


### PR DESCRIPTION
## Proposed changes

The boundary corrections are still a few PRs away, but here is the most basic check that they were coded up correctly. We have a similar function currently in develop that we use.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
