### PR TITLE
Send boundary data from ComputeTimeDerivative

### DIFF
--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -172,7 +172,6 @@ struct EvolutionMetavars {
 
   using step_actions = tmpl::flatten<tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
-      dg::Actions::SendDataForFluxes<boundary_scheme>,
       tmpl::conditional_t<
           evolution::is_analytic_solution_v<initial_data>,
           dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -259,7 +259,6 @@ struct EvolutionMetavars {
 
   using step_actions = tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
-      dg::Actions::SendDataForFluxes<boundary_scheme>,
       dg::Actions::ComputeNonconservativeBoundaryFluxes<
           domain::Tags::BoundaryDirectionsInterior<volume_dim>>,
       dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -236,7 +236,6 @@ struct EvolutionMetavars {
 
   using step_actions = tmpl::flatten<tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
-      dg::Actions::SendDataForFluxes<boundary_scheme>,
       tmpl::conditional_t<
           evolution::is_analytic_solution_v<initial_data>,
           dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -193,7 +193,6 @@ struct EvolutionMetavars {
 
   using step_actions = tmpl::flatten<tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
-      dg::Actions::SendDataForFluxes<boundary_scheme>,
       tmpl::conditional_t<
           evolution::is_analytic_solution_v<initial_data>,
           dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -180,7 +180,6 @@ struct EvolutionMetavars {
 
   using step_actions = tmpl::flatten<tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
-      dg::Actions::SendDataForFluxes<boundary_scheme>,
       tmpl::conditional_t<
           evolution::is_analytic_solution_v<initial_data>,
           dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -190,7 +190,6 @@ struct EvolutionMetavars {
 
   using step_actions = tmpl::flatten<tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
-      dg::Actions::SendDataForFluxes<boundary_scheme>,
       tmpl::conditional_t<
           evolution::is_analytic_solution_v<initial_data>,
           dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -175,7 +175,6 @@ struct EvolutionMetavars {
 
   using step_actions = tmpl::flatten<tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
-      dg::Actions::SendDataForFluxes<boundary_scheme>,
       dg::Actions::ComputeNonconservativeBoundaryFluxes<
           domain::Tags::BoundaryDirectionsInterior<Dim>>,
       dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ComputeTimeDerivative.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ComputeTimeDerivative.cpp
@@ -16,6 +16,7 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Tags.hpp"
 #include "Domain/TagsTimeDependent.hpp"
@@ -414,13 +415,36 @@ void test_impl() noexcept {
          normal_dot_fluxes_interface, element, inv_jac, mesh_velocity,
          div_mesh_velocity,
          Variables<db::wrap_tags_in<::Tags::Flux, flux_tags, tmpl::size_t<Dim>,
-                                    Frame::Inertial>>{2, -100.0}});
+                                    Frame::Inertial>>{2, -100.}});
+    for (const auto& [direction, neighbor_ids] : neighbors) {
+      (void)direction;
+      for (const auto& neighbor_id : neighbor_ids) {
+        ActionTesting::emplace_component_and_initialize<component<metavars>>(
+            &runner, neighbor_id,
+            {time_step_id, evolved_vars, dt_evolved_vars, var3, mesh,
+             normal_dot_fluxes_interface, element, inv_jac, mesh_velocity,
+             div_mesh_velocity,
+             Variables<db::wrap_tags_in<::Tags::Flux, flux_tags,
+                                        tmpl::size_t<Dim>, Frame::Inertial>>{
+                 2, -100.}});
+      }
+    }
   } else {
     ActionTesting::emplace_component_and_initialize<component<metavars>>(
         &runner, self_id,
         {time_step_id, evolved_vars, dt_evolved_vars, var3, mesh,
          normal_dot_fluxes_interface, element, inv_jac, mesh_velocity,
          div_mesh_velocity});
+    for (const auto& [direction, neighbor_ids] : neighbors) {
+      (void)direction;
+      for (const auto& neighbor_id : neighbor_ids) {
+        ActionTesting::emplace_component_and_initialize<component<metavars>>(
+            &runner, neighbor_id,
+            {time_step_id, evolved_vars, dt_evolved_vars, var3, mesh,
+             normal_dot_fluxes_interface, element, inv_jac, mesh_velocity,
+             div_mesh_velocity});
+      }
+    }
   }
   // Setup the DataBox
   ActionTesting::next_action<component<metavars>>(make_not_null(&runner),

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
@@ -131,7 +131,6 @@ struct Component {
           typename Metavariables::Phase, Metavariables::Phase::Testing,
           tmpl::list<
               evolution::dg::Actions::ComputeTimeDerivative<Metavariables>,
-              dg::Actions::SendDataForFluxes<boundary_scheme>,
               dg::Actions::ReceiveDataForFluxes<boundary_scheme>,
               Actions::MutateApply<boundary_scheme>>>>;
 };
@@ -246,12 +245,12 @@ std::pair<tnsr::I<DataVector, 1>, EvolvedVariables> evaluate_rhs(
                            Metavariables::Phase::Testing);
 
   // The neighbors only have to get as far as sending data
-  for (size_t i = 0; i < 2; ++i) {
+  for (size_t i = 0; i < 1; ++i) {
     runner.next_action<component>(left_id);
     runner.next_action<component>(right_id);
   }
 
-  for (size_t i = 0; i < 4; ++i) {
+  for (size_t i = 0; i < 3; ++i) {
     runner.next_action<component>(self_id);
   }
 


### PR DESCRIPTION
## Proposed changes

Have the ComputeTimeDerivative action send the flux data for the boundary corrections currently in develop. This is an intermediate step to replacing the code used in develop and will be removed once everything is working with the new infrastructure. For this reason I didn't document anything, but am happy to if the conclusion is it's worthwhile.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
