### PR TITLE
Specify DG formulation at runtime in dg::ComputeTimeDerivative

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
@@ -19,6 +19,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags/Formulation.hpp"
 #include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
@@ -132,6 +133,8 @@ namespace evolution::dg::Actions {
 template <typename Metavariables>
 struct ComputeTimeDerivative {
  public:
+  using const_global_cache_tags = tmpl::list<::dg::Tags::Formulation>;
+
   template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
             typename ActionList, typename ParallelComponent>
   static std::tuple<db::DataBox<DbTagsList>&&> apply(
@@ -255,7 +258,7 @@ ComputeTimeDerivative<Metavariables>::apply(
   volume_terms<volume_dim, compute_volume_time_derivative_terms>(
       make_not_null(&box), make_not_null(&volume_fluxes),
       make_not_null(&partial_derivs), make_not_null(&temporaries),
-      Metavariables::dg_formulation, variables_tags{},
+      db::get<::dg::Tags::Formulation>(box), variables_tags{},
       typename compute_volume_time_derivative_terms::argument_tags{});
 
   // The below if-else and fill_mortar_data_for_internal_boundaries are for

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -25,6 +25,10 @@ DomainCreator:
     InitialRefinement: [2]
     InitialGridPoints: [7]
 
+SpatialDiscretization:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+
 NumericalFlux:
   LocalLaxFriedrichs:
 

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -44,6 +44,10 @@ EvolutionSystem:
       Amplitudes: [1.0, 1.0, 1.0]
       Exponents: [4, 4, 4]
 
+SpatialDiscretization:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+
 NumericalFlux:
   UpwindPenalty:
 

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/CylindricalBlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/CylindricalBlastWave.yaml
@@ -17,6 +17,10 @@ DomainCreator:
     InitialRefinement: [2, 2, 0]
     InitialGridPoints: [2, 2, 2]
 
+SpatialDiscretization:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+
 AnalyticData:
   CylindricalBlastWave:
     InnerRadius: 0.8

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -29,6 +29,10 @@ DomainCreator:
     InitialRefinement: [0, 0, 0]
     InitialGridPoints: [5, 5, 5]
 
+SpatialDiscretization:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+
 AnalyticSolution:
   FishboneMoncriefDisk:
     BhMass: &BhMass 1.0

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
@@ -18,6 +18,10 @@ DomainCreator:
     InitialRefinement: [1]
     InitialGridPoints: [2]
 
+SpatialDiscretization:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+
 AnalyticSolution:
   RiemannProblem:
     AdiabaticIndex: 1.4

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
@@ -18,6 +18,10 @@ DomainCreator:
     InitialRefinement: [4, 0]
     InitialGridPoints: [2, 2]
 
+SpatialDiscretization:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+
 AnalyticSolution:
   RiemannProblem:
     AdiabaticIndex: 1.4

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
@@ -18,6 +18,10 @@ DomainCreator:
     InitialRefinement: [4, 0, 0]
     InitialGridPoints: [2, 2, 2]
 
+SpatialDiscretization:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+
 AnalyticSolution:
   RiemannProblem:
     AdiabaticIndex: 1.4

--- a/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
+++ b/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
@@ -26,6 +26,10 @@ AnalyticSolution:
     MeanVelocity: [0.1, 0.2, 0.15]
     ComovingEnergyDensity: 1.0
 
+SpatialDiscretization:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+
 NumericalFlux:
   LocalLaxFriedrichs:
 

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow1D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow1D.yaml
@@ -26,6 +26,10 @@ AnalyticSolution:
     AdiabaticIndex: 1.4
     PerturbationSize: 0.8
 
+SpatialDiscretization:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+
 NumericalFlux:
   LocalLaxFriedrichs:
 

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow2D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow2D.yaml
@@ -26,6 +26,10 @@ AnalyticSolution:
     AdiabaticIndex: 1.4
     PerturbationSize: 0.7
 
+SpatialDiscretization:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+
 NumericalFlux:
   LocalLaxFriedrichs:
 

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow3D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow3D.yaml
@@ -26,6 +26,10 @@ AnalyticSolution:
     AdiabaticIndex: 1.4
     PerturbationSize: 0.7
 
+SpatialDiscretization:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+
 NumericalFlux:
   LocalLaxFriedrichs:
 

--- a/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
@@ -37,6 +37,10 @@ DomainCreator:
     InitialRefinement: [2]
     InitialGridPoints: [7]
 
+SpatialDiscretization:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+
 # If filtering is enabled in the executable the filter can be controlled using:
 # Filtering:
 #   ExpFilter0:

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -40,6 +40,10 @@ DomainCreator:
     InitialRefinement: [2]
     InitialGridPoints: [7]
 
+SpatialDiscretization:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+
 # If filtering is enabled in the executable the filter can be controlled using:
 # ExpFilter0:
 #   Alpha: 12

--- a/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
@@ -37,6 +37,10 @@ DomainCreator:
     InitialRefinement: [2, 2]
     InitialGridPoints: [4, 4]
 
+SpatialDiscretization:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+
 # Filtering is being tested by the 2D executable (see EvolveScalarWave.hpp)
 Filtering:
   ExpFilter0:

--- a/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
@@ -37,6 +37,10 @@ DomainCreator:
     InitialRefinement: [1, 1, 1]
     InitialGridPoints: [5, 5, 5]
 
+SpatialDiscretization:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+
 # If filtering is enabled in the executable the filter can be controlled using:
 # Filtering:
 #   ExpFilter0:

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ComputeTimeDerivative.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ComputeTimeDerivative.cpp
@@ -286,8 +286,6 @@ struct component {
 
 template <size_t Dim, SystemType SystemTypeIn>
 struct Metavariables {
-  static constexpr dg::Formulation dg_formulation =
-      dg::Formulation::StrongInertial;
   static constexpr size_t volume_dim = Dim;
   static constexpr SystemType system_type = SystemTypeIn;
   using system = System<Dim, system_type>;
@@ -305,6 +303,8 @@ struct Metavariables {
 
 template <bool UseMovingMesh, size_t Dim, SystemType system_type>
 void test_impl() noexcept {
+
+  const ::dg::Formulation dg_formulation = ::dg::Formulation::StrongInertial;
   using metavars = Metavariables<Dim, system_type>;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
   // The reference element in 2d denoted by X below:
@@ -349,7 +349,7 @@ void test_impl() noexcept {
   MockRuntimeSystem runner{
       {std::vector<std::array<size_t, Dim>>{make_array<Dim>(2_st),
                                             make_array<Dim>(3_st)},
-       typename metavars::normal_dot_numerical_flux::type{}}};
+       typename metavars::normal_dot_numerical_flux::type{}, dg_formulation}};
 
   const Mesh<Dim> mesh{2, Spectral::Basis::Legendre,
                        Spectral::Quadrature::GaussLobatto};

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
@@ -139,8 +139,6 @@ struct Component {
 
 struct Metavariables {
   static constexpr size_t volume_dim = 1;
-  static constexpr dg::Formulation dg_formulation =
-      dg::Formulation::StrongInertial;
   using system = ScalarWave::System<1>;
   using boundary_scheme = dg::FirstOrderScheme::FirstOrderScheme<
       1, typename system::variables_tag,
@@ -162,7 +160,8 @@ std::pair<tnsr::I<DataVector, 1>, EvolvedVariables> evaluate_rhs(
   using component = Component<Metavariables>;
 
   ActionTesting::MockRuntimeSystem<Metavariables> runner{
-      {ScalarWave::UpwindPenaltyCorrection<1>{}}};
+      {ScalarWave::UpwindPenaltyCorrection<1>{},
+       ::dg::Formulation::StrongInertial}};
 
   const Slab slab(time, time + 1.0);
   const TimeStepId current_time(true, 0, slab.start());


### PR DESCRIPTION
## Proposed changes

- Allows specifying at the input file level the DG formulation to use

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
