### PR TITLE
Factor temp tags out of GH::TimeDerivative

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.hpp
@@ -7,6 +7,7 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/DuDtTempTags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"  // IWYU pragma: keep
@@ -85,7 +86,31 @@ namespace GeneralizedHarmonic {
 template <size_t Dim>
 struct TimeDerivative {
  public:
-  using temporary_tags = tmpl::list<>;
+  using temporary_tags = tmpl::list<
+      ::GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma0,
+      ::GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1,
+      Tags::Gamma1Gamma2, Tags::PiTwoNormals, Tags::NormalDotOneIndexConstraint,
+      Tags::Gamma1Plus1, Tags::PiOneNormal<Dim>,
+      Tags::GaugeConstraint<Dim, Frame::Inertial>, Tags::PhiTwoNormals<Dim>,
+      Tags::ShiftDotThreeIndexConstraint<Dim>, Tags::PhiOneNormal<Dim>,
+      Tags::PiSecondIndexUp<Dim>,
+      Tags::ThreeIndexConstraint<Dim, Frame::Inertial>,
+      Tags::PhiFirstIndexUp<Dim>, Tags::PhiThirdIndexUp<Dim>,
+      Tags::SpacetimeChristoffelFirstKindThirdIndexUp<Dim>,
+      gr::Tags::Lapse<DataVector>,
+      gr::Tags::Shift<Dim, Frame::Inertial, DataVector>,
+      gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataVector>,
+      gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>,
+      gr::Tags::DetSpatialMetric<DataVector>,
+      gr::Tags::InverseSpacetimeMetric<Dim, Frame::Inertial, DataVector>,
+      gr::Tags::SpacetimeChristoffelFirstKind<Dim, Frame::Inertial, DataVector>,
+      gr::Tags::SpacetimeChristoffelSecondKind<Dim, Frame::Inertial,
+                                               DataVector>,
+      gr::Tags::TraceSpacetimeChristoffelFirstKind<Dim, Frame::Inertial,
+                                                   DataVector>,
+      gr::Tags::SpacetimeNormalVector<Dim, Frame::Inertial, DataVector>,
+      gr::Tags::SpacetimeNormalOneForm<Dim, Frame::Inertial, DataVector>,
+      gr::Tags::DerivativesOfSpacetimeMetric<Dim, Frame::Inertial, DataVector>>;
   using argument_tags = tmpl::list<
       gr::Tags::SpacetimeMetric<Dim>, Tags::Pi<Dim>, Tags::Phi<Dim>,
       ::GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma0,
@@ -97,6 +122,35 @@ struct TimeDerivative {
       gsl::not_null<tnsr::aa<DataVector, Dim>*> dt_spacetime_metric,
       gsl::not_null<tnsr::aa<DataVector, Dim>*> dt_pi,
       gsl::not_null<tnsr::iaa<DataVector, Dim>*> dt_phi,
+      gsl::not_null<Scalar<DataVector>*> temp_gamma1,
+      gsl::not_null<Scalar<DataVector>*> temp_gamma2,
+      gsl::not_null<Scalar<DataVector>*> gamma1gamma2,
+      gsl::not_null<Scalar<DataVector>*> pi_two_normals,
+      gsl::not_null<Scalar<DataVector>*> normal_dot_gauge_constraint,
+      gsl::not_null<Scalar<DataVector>*> gamma1_plus_1,
+      gsl::not_null<tnsr::a<DataVector, Dim>*> pi_one_normal,
+      gsl::not_null<tnsr::a<DataVector, Dim>*> gauge_constraint,
+      gsl::not_null<tnsr::i<DataVector, Dim>*> phi_two_normals,
+      gsl::not_null<tnsr::aa<DataVector, Dim>*>
+          shift_dot_three_index_constraint,
+      gsl::not_null<tnsr::ia<DataVector, Dim>*> phi_one_normal,
+      gsl::not_null<tnsr::aB<DataVector, Dim>*> pi_2_up,
+      gsl::not_null<tnsr::iaa<DataVector, Dim>*> three_index_constraint,
+      gsl::not_null<tnsr::Iaa<DataVector, Dim>*> phi_1_up,
+      gsl::not_null<tnsr::iaB<DataVector, Dim>*> phi_3_up,
+      gsl::not_null<tnsr::abC<DataVector, Dim>*> christoffel_first_kind_3_up,
+      gsl::not_null<Scalar<DataVector>*> lapse,
+      gsl::not_null<tnsr::I<DataVector, Dim>*> shift,
+      gsl::not_null<tnsr::ii<DataVector, Dim>*> spatial_metric,
+      gsl::not_null<tnsr::II<DataVector, Dim>*> inverse_spatial_metric,
+      gsl::not_null<Scalar<DataVector>*> det_spatial_metric,
+      gsl::not_null<tnsr::AA<DataVector, Dim>*> inverse_spacetime_metric,
+      gsl::not_null<tnsr::abb<DataVector, Dim>*> christoffel_first_kind,
+      gsl::not_null<tnsr::Abb<DataVector, Dim>*> christoffel_second_kind,
+      gsl::not_null<tnsr::a<DataVector, Dim>*> trace_christoffel,
+      gsl::not_null<tnsr::A<DataVector, Dim>*> normal_spacetime_vector,
+      gsl::not_null<tnsr::a<DataVector, Dim>*> normal_spacetime_one_form,
+      gsl::not_null<tnsr::abb<DataVector, Dim>*> da_spacetime_metric,
       const tnsr::iaa<DataVector, Dim>& d_spacetime_metric,
       const tnsr::iaa<DataVector, Dim>& d_pi,
       const tnsr::ijaa<DataVector, Dim>& d_phi,

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_DuDt.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_DuDt.cpp
@@ -12,6 +12,8 @@
 #include "DataStructures/Tensor/Identity.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/DuDtTempTags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/TimeDerivative.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
@@ -560,11 +562,112 @@ void test_compute_dudt(const gsl::not_null<Generator*> generator) noexcept {
   tnsr::iaa<DataVector, Dim, Frame::Inertial> dt_phi(
       mesh.number_of_grid_points());
 
+  Variables<tmpl::list<
+      GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1,
+      GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2,
+      GeneralizedHarmonic::Tags::Gamma1Gamma2,
+      GeneralizedHarmonic::Tags::PiTwoNormals,
+      GeneralizedHarmonic::Tags::NormalDotOneIndexConstraint,
+      GeneralizedHarmonic::Tags::Gamma1Plus1,
+      GeneralizedHarmonic::Tags::PiOneNormal<Dim>,
+      GeneralizedHarmonic::Tags::GaugeConstraint<Dim, Frame::Inertial>,
+      GeneralizedHarmonic::Tags::PhiTwoNormals<Dim>,
+      GeneralizedHarmonic::Tags::ShiftDotThreeIndexConstraint<Dim>,
+      GeneralizedHarmonic::Tags::PhiOneNormal<Dim>,
+      GeneralizedHarmonic::Tags::PiSecondIndexUp<Dim>,
+      GeneralizedHarmonic::Tags::ThreeIndexConstraint<Dim, Frame::Inertial>,
+      GeneralizedHarmonic::Tags::PhiFirstIndexUp<Dim>,
+      GeneralizedHarmonic::Tags::PhiThirdIndexUp<Dim>,
+      GeneralizedHarmonic::Tags::SpacetimeChristoffelFirstKindThirdIndexUp<Dim>,
+      gr::Tags::Lapse<DataVector>,
+      gr::Tags::Shift<Dim, Frame::Inertial, DataVector>,
+      gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataVector>,
+      gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>,
+      gr::Tags::DetSpatialMetric<DataVector>,
+      gr::Tags::InverseSpacetimeMetric<Dim, Frame::Inertial, DataVector>,
+      gr::Tags::SpacetimeChristoffelFirstKind<Dim, Frame::Inertial, DataVector>,
+      gr::Tags::SpacetimeChristoffelSecondKind<Dim, Frame::Inertial,
+                                               DataVector>,
+      gr::Tags::TraceSpacetimeChristoffelFirstKind<Dim, Frame::Inertial,
+                                                   DataVector>,
+      gr::Tags::SpacetimeNormalVector<Dim, Frame::Inertial, DataVector>,
+      gr::Tags::SpacetimeNormalOneForm<Dim, Frame::Inertial, DataVector>,
+      gr::Tags::DerivativesOfSpacetimeMetric<Dim, Frame::Inertial, DataVector>>>
+      buffer(mesh.number_of_grid_points());
+
   GeneralizedHarmonic::TimeDerivative<Dim>::apply(
       make_not_null(&dt_spacetime_metric), make_not_null(&dt_pi),
-      make_not_null(&dt_phi), d_spacetime_metric, d_pi, d_phi, spacetime_metric,
-      pi, phi, gamma0, gamma1, gamma2, gauge_function,
-      spacetime_deriv_gauge_function);
+      make_not_null(&dt_phi),
+      make_not_null(
+          &get<GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1>(
+              buffer)),
+      make_not_null(
+          &get<GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2>(
+              buffer)),
+      make_not_null(&get<GeneralizedHarmonic::Tags::Gamma1Gamma2>(buffer)),
+      make_not_null(&get<GeneralizedHarmonic::Tags::PiTwoNormals>(buffer)),
+      make_not_null(
+          &get<GeneralizedHarmonic::Tags::NormalDotOneIndexConstraint>(buffer)),
+      make_not_null(&get<GeneralizedHarmonic::Tags::Gamma1Plus1>(buffer)),
+      make_not_null(&get<GeneralizedHarmonic::Tags::PiOneNormal<Dim>>(buffer)),
+      make_not_null(
+          &get<
+              GeneralizedHarmonic::Tags::GaugeConstraint<Dim, Frame::Inertial>>(
+              buffer)),
+      make_not_null(
+          &get<GeneralizedHarmonic::Tags::PhiTwoNormals<Dim>>(buffer)),
+      make_not_null(
+          &get<GeneralizedHarmonic::Tags::ShiftDotThreeIndexConstraint<Dim>>(
+              buffer)),
+      make_not_null(&get<GeneralizedHarmonic::Tags::PhiOneNormal<Dim>>(buffer)),
+      make_not_null(
+          &get<GeneralizedHarmonic::Tags::PiSecondIndexUp<Dim>>(buffer)),
+      make_not_null(&get<GeneralizedHarmonic::Tags::ThreeIndexConstraint<
+                        Dim, Frame::Inertial>>(buffer)),
+      make_not_null(
+          &get<GeneralizedHarmonic::Tags::PhiFirstIndexUp<Dim>>(buffer)),
+      make_not_null(
+          &get<GeneralizedHarmonic::Tags::PhiThirdIndexUp<Dim>>(buffer)),
+      make_not_null(
+          &get<GeneralizedHarmonic::Tags::
+                   SpacetimeChristoffelFirstKindThirdIndexUp<Dim>>(buffer)),
+      make_not_null(&get<gr::Tags::Lapse<DataVector>>(buffer)),
+      make_not_null(
+          &get<gr::Tags::Shift<Dim, Frame::Inertial, DataVector>>(buffer)),
+      make_not_null(
+          &get<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataVector>>(
+              buffer)),
+      make_not_null(&get<gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial,
+                                                        DataVector>>(buffer)),
+      make_not_null(&get<gr::Tags::DetSpatialMetric<DataVector>>(buffer)),
+      make_not_null(&get<gr::Tags::InverseSpacetimeMetric<Dim, Frame::Inertial,
+                                                          DataVector>>(buffer)),
+      make_not_null(
+          &get<gr::Tags::SpacetimeChristoffelFirstKind<Dim, Frame::Inertial,
+                                                       DataVector>>(buffer)),
+      make_not_null(
+          &get<gr::Tags::SpacetimeChristoffelSecondKind<Dim, Frame::Inertial,
+                                                        DataVector>>(buffer)),
+      make_not_null(&get<gr::Tags::TraceSpacetimeChristoffelFirstKind<
+                        Dim, Frame::Inertial, DataVector>>(buffer)),
+      make_not_null(&get<gr::Tags::SpacetimeNormalVector<Dim, Frame::Inertial,
+                                                         DataVector>>(buffer)),
+      make_not_null(&get<gr::Tags::SpacetimeNormalOneForm<Dim, Frame::Inertial,
+                                                          DataVector>>(buffer)),
+      make_not_null(
+          &get<gr::Tags::DerivativesOfSpacetimeMetric<Dim, Frame::Inertial,
+                                                      DataVector>>(buffer)),
+      d_spacetime_metric, d_pi, d_phi, spacetime_metric, pi, phi, gamma0,
+      gamma1, gamma2, gauge_function, spacetime_deriv_gauge_function);
+
+  CHECK_ITERABLE_APPROX(
+      get<GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1>(
+          buffer),
+      gamma1);
+  CHECK_ITERABLE_APPROX(
+      get<GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2>(
+          buffer),
+      gamma2);
 
   CHECK_ITERABLE_APPROX(expected_dt_spacetime_metric, dt_spacetime_metric);
   CHECK_ITERABLE_APPROX(expected_dt_pi, dt_pi);

--- a/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp
@@ -20,6 +20,7 @@
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Constraints.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/DuDtTempTags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/TimeDerivative.hpp"
 #include "Evolution/TypeTraits.hpp"  // IWYU pragma: keep
@@ -238,8 +239,99 @@ void verify_time_independent_einstein_solution(
       make_with_value<tnsr::aa<DataVector, 3, Frame::Inertial>>(x, 0.0);
   auto dt_phi =
       make_with_value<tnsr::iaa<DataVector, 3, Frame::Inertial>>(x, 0.0);
+  Variables<tmpl::list<
+      GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1,
+      GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2,
+      GeneralizedHarmonic::Tags::Gamma1Gamma2,
+      GeneralizedHarmonic::Tags::PiTwoNormals,
+      GeneralizedHarmonic::Tags::NormalDotOneIndexConstraint,
+      GeneralizedHarmonic::Tags::Gamma1Plus1,
+      GeneralizedHarmonic::Tags::PiOneNormal<3>,
+      GeneralizedHarmonic::Tags::GaugeConstraint<3, Frame::Inertial>,
+      GeneralizedHarmonic::Tags::PhiTwoNormals<3>,
+      GeneralizedHarmonic::Tags::ShiftDotThreeIndexConstraint<3>,
+      GeneralizedHarmonic::Tags::PhiOneNormal<3>,
+      GeneralizedHarmonic::Tags::PiSecondIndexUp<3>,
+      GeneralizedHarmonic::Tags::ThreeIndexConstraint<3, Frame::Inertial>,
+      GeneralizedHarmonic::Tags::PhiFirstIndexUp<3>,
+      GeneralizedHarmonic::Tags::PhiThirdIndexUp<3>,
+      GeneralizedHarmonic::Tags::SpacetimeChristoffelFirstKindThirdIndexUp<3>,
+      gr::Tags::Lapse<DataVector>,
+      gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+      gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+      gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>,
+      gr::Tags::DetSpatialMetric<DataVector>,
+      gr::Tags::InverseSpacetimeMetric<3, Frame::Inertial, DataVector>,
+      gr::Tags::SpacetimeChristoffelFirstKind<3, Frame::Inertial, DataVector>,
+      gr::Tags::SpacetimeChristoffelSecondKind<3, Frame::Inertial, DataVector>,
+      gr::Tags::TraceSpacetimeChristoffelFirstKind<3, Frame::Inertial,
+                                                   DataVector>,
+      gr::Tags::SpacetimeNormalVector<3, Frame::Inertial, DataVector>,
+      gr::Tags::SpacetimeNormalOneForm<3, Frame::Inertial, DataVector>,
+      gr::Tags::DerivativesOfSpacetimeMetric<3, Frame::Inertial, DataVector>>>
+      buffer(mesh.number_of_grid_points());
+
   GeneralizedHarmonic::TimeDerivative<3>::apply(
       make_not_null(&dt_psi), make_not_null(&dt_pi), make_not_null(&dt_phi),
+      make_not_null(
+          &get<GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1>(
+              buffer)),
+      make_not_null(
+          &get<GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2>(
+              buffer)),
+      make_not_null(&get<GeneralizedHarmonic::Tags::Gamma1Gamma2>(buffer)),
+      make_not_null(&get<GeneralizedHarmonic::Tags::PiTwoNormals>(buffer)),
+      make_not_null(
+          &get<GeneralizedHarmonic::Tags::NormalDotOneIndexConstraint>(buffer)),
+      make_not_null(&get<GeneralizedHarmonic::Tags::Gamma1Plus1>(buffer)),
+      make_not_null(&get<GeneralizedHarmonic::Tags::PiOneNormal<3>>(buffer)),
+      make_not_null(
+          &get<GeneralizedHarmonic::Tags::GaugeConstraint<3, Frame::Inertial>>(
+              buffer)),
+      make_not_null(&get<GeneralizedHarmonic::Tags::PhiTwoNormals<3>>(buffer)),
+      make_not_null(
+          &get<GeneralizedHarmonic::Tags::ShiftDotThreeIndexConstraint<3>>(
+              buffer)),
+      make_not_null(&get<GeneralizedHarmonic::Tags::PhiOneNormal<3>>(buffer)),
+      make_not_null(
+          &get<GeneralizedHarmonic::Tags::PiSecondIndexUp<3>>(buffer)),
+      make_not_null(&get<GeneralizedHarmonic::Tags::ThreeIndexConstraint<
+                        3, Frame::Inertial>>(buffer)),
+      make_not_null(
+          &get<GeneralizedHarmonic::Tags::PhiFirstIndexUp<3>>(buffer)),
+      make_not_null(
+          &get<GeneralizedHarmonic::Tags::PhiThirdIndexUp<3>>(buffer)),
+      make_not_null(
+          &get<GeneralizedHarmonic::Tags::
+                   SpacetimeChristoffelFirstKindThirdIndexUp<3>>(buffer)),
+      make_not_null(&get<gr::Tags::Lapse<DataVector>>(buffer)),
+      make_not_null(
+          &get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(buffer)),
+      make_not_null(
+          &get<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>(
+              buffer)),
+      make_not_null(
+          &get<gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>>(
+              buffer)),
+      make_not_null(&get<gr::Tags::DetSpatialMetric<DataVector>>(buffer)),
+      make_not_null(&get<gr::Tags::InverseSpacetimeMetric<3, Frame::Inertial,
+                                                          DataVector>>(buffer)),
+      make_not_null(
+          &get<gr::Tags::SpacetimeChristoffelFirstKind<3, Frame::Inertial,
+                                                       DataVector>>(buffer)),
+      make_not_null(
+          &get<gr::Tags::SpacetimeChristoffelSecondKind<3, Frame::Inertial,
+                                                        DataVector>>(buffer)),
+      make_not_null(&get<gr::Tags::TraceSpacetimeChristoffelFirstKind<
+                        3, Frame::Inertial, DataVector>>(buffer)),
+      make_not_null(
+          &get<gr::Tags::SpacetimeNormalVector<3, Frame::Inertial, DataVector>>(
+              buffer)),
+      make_not_null(&get<gr::Tags::SpacetimeNormalOneForm<3, Frame::Inertial,
+                                                          DataVector>>(buffer)),
+      make_not_null(
+          &get<gr::Tags::DerivativesOfSpacetimeMetric<3, Frame::Inertial,
+                                                      DataVector>>(buffer)),
       d_psi, d_pi, d_phi, psi, pi, phi, gamma0, gamma1, gamma2, gauge_function,
       d4_H);
 


### PR DESCRIPTION
## Proposed changes

We need the temp tags to be return (by not_null) in order to be able to project
the inv spatial metric, lapse, shift needed for boundary corrections.

This will also be needed for efficiently combining GH with other systems, e.g. GRMHD.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
