### PR TITLE
Add tags for specifying the quadrature in the input file

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Initialization/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/Initialization/CMakeLists.txt
@@ -6,6 +6,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Mortars.hpp
+  QuadratureTag.hpp
   )
 
 spectre_target_sources(

--- a/src/Evolution/DiscontinuousGalerkin/Initialization/QuadratureTag.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Initialization/QuadratureTag.hpp
@@ -1,0 +1,39 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags/OptionsGroup.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace evolution::dg {
+namespace OptionTags {
+/// The quadrature points to use.
+struct Quadrature {
+  using type = Spectral::Quadrature;
+  using group = ::dg::OptionTags::DiscontinuousGalerkinGroup;
+  static constexpr Options::String help =
+      "The point distribution/quadrature rule used.";
+};
+}  // namespace OptionTags
+
+namespace Tags {
+/// The quadrature points to use initially.
+///
+/// While they could be changed during the evolution, it is unclear there is any
+/// reason to do so or that changing them during an evolution would even be
+/// stable.
+struct Quadrature : db::SimpleTag {
+  using type = Spectral::Quadrature;
+
+  using option_tags = tmpl::list<OptionTags::Quadrature>;
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& quadrature) noexcept {
+    return quadrature;
+  }
+};
+}  // namespace Tags
+}  // namespace evolution::dg

--- a/src/NumericalAlgorithms/Spectral/Spectral.cpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.cpp
@@ -13,6 +13,8 @@
 #include "ErrorHandling/Assert.hpp"
 #include "ErrorHandling/Error.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Options/Options.hpp"
+#include "Options/ParseOptions.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
@@ -598,4 +600,23 @@ template const DataVector& Spectral::collocation_points<
 template const DataVector& Spectral::quadrature_weights<
     Spectral::Basis::FiniteDifference, Spectral::Quadrature::FaceCentered>(
     size_t) noexcept;
+/// \endcond
+
+/// \cond
+template <>
+Spectral::Quadrature
+Options::create_from_yaml<Spectral::Quadrature>::create<void>(
+    const Options::Option& options) {
+  const auto type_read = options.parse_as<std::string>();
+  if ("Gauss" == type_read) {
+    return Spectral::Quadrature::Gauss;
+  } else if ("GaussLobatto" == type_read) {
+    return Spectral::Quadrature::GaussLobatto;
+  }
+  PARSE_ERROR(options.context(),
+              "Failed to convert \""
+                  << type_read
+                  << "\" to Spectral::Quadrature. Must be one "
+                     "of Gauss or GaussLobatto.");
+}
 /// \endcond

--- a/src/NumericalAlgorithms/Spectral/Spectral.hpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.hpp
@@ -19,6 +19,11 @@ class Matrix;
 class DataVector;
 template <size_t>
 class Mesh;
+namespace Options {
+class Option;
+template <typename T>
+struct create_from_yaml;
+}  // namespace Options
 /// \endcond
 
 /*!
@@ -547,3 +552,18 @@ const Matrix& linear_filter_matrix(size_t num_points) noexcept;
 const Matrix& linear_filter_matrix(const Mesh<1>& mesh) noexcept;
 
 }  // namespace Spectral
+
+/// \cond
+template <>
+struct Options::create_from_yaml<Spectral::Quadrature> {
+  template <typename Metavariables>
+  static Spectral::Quadrature create(const Options::Option& options) {
+    return create<void>(options);
+  }
+};
+
+template <>
+Spectral::Quadrature
+Options::create_from_yaml<Spectral::Quadrature>::create<void>(
+    const Options::Option& options);
+/// \endcond

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY "Test_EvolutionDg")
 set(LIBRARY_SOURCES
   Actions/Test_ComputeTimeDerivative.cpp
   Initialization/Test_Mortars.cpp
+  Initialization/Test_QuadratureTag.cpp
   Test_InboxTags.cpp
   Test_MortarData.cpp
   Test_MortarTags.cpp

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_QuadratureTag.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_QuadratureTag.cpp
@@ -1,0 +1,23 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "Evolution/DiscontinuousGalerkin/Initialization/QuadratureTag.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.DG.Initialization.QuadratureTag",
+                  "[Unit][Evolution]") {
+  TestHelpers::db::test_simple_tag<evolution::dg::Tags::Quadrature>(
+      "Quadrature");
+  CHECK(TestHelpers::test_creation<Spectral::Quadrature,
+                                   evolution::dg::OptionTags::Quadrature>(
+            "Gauss") == Spectral::Quadrature::Gauss);
+  CHECK(TestHelpers::test_creation<Spectral::Quadrature,
+                                   evolution::dg::OptionTags::Quadrature>(
+            "GaussLobatto") == Spectral::Quadrature::GaussLobatto);
+}

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
@@ -13,6 +13,7 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Matrix.hpp"
+#include "Framework/TestCreation.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Utilities/Blas.hpp"
@@ -25,6 +26,13 @@ void test_streaming() {
 
   CHECK(get_output(Spectral::Quadrature::Gauss) == "Gauss");
   CHECK(get_output(Spectral::Quadrature::GaussLobatto) == "GaussLobatto");
+}
+
+void test_creation() {
+  CHECK(Spectral::Quadrature::Gauss ==
+        TestHelpers::test_creation<Spectral::Quadrature>("Gauss"));
+  CHECK(Spectral::Quadrature::GaussLobatto ==
+        TestHelpers::test_creation<Spectral::Quadrature>("GaussLobatto"));
 }
 
 DataVector unit_polynomial(const size_t deg, const DataVector& x) {
@@ -503,6 +511,7 @@ void test_gauss_points_boundary_interpolation_and_lifting() noexcept {
 SPECTRE_TEST_CASE("Unit.Numerical.Spectral",
                   "[NumericalAlgorithms][Spectral][Unit]") {
   test_streaming();
+  test_creation();
   test_exact_differentiation_matrices();
   test_linear_filter();
   test_exact_extrapolation();


### PR DESCRIPTION
## Proposed changes

Motivation: We want to be able to compare Gauss and Gauss-Lobatto points

- Make the quadrature enum option createable
- Add tags for the quadrature

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
