### PR TITLE
Functions and tags for computing normal vectors in general spacetimes

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/CMakeLists.txt
@@ -6,4 +6,5 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ComputeTimeDerivative.hpp
+  NormalCovectorAndMagnitude.hpp
   )

--- a/src/Evolution/DiscontinuousGalerkin/Actions/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  Evolution
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  ComputeTimeDerivative.hpp
+  )

--- a/src/Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp
@@ -1,0 +1,148 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Evolution/DiscontinuousGalerkin/NormalVectorTags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits/CreateHasTypeAlias.hpp"
+
+namespace evolution::dg::Actions::detail {
+CREATE_HAS_TYPE_ALIAS(inverse_spatial_metric_tag)
+CREATE_HAS_TYPE_ALIAS_V(inverse_spatial_metric_tag)
+
+struct OneOverNormalVectorMagnitude : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct NormalVector : db::SimpleTag {
+  using type = tnsr::I<DataVector, Dim, Frame::Inertial>;
+};
+
+/*!
+ * \brief Computes the normal covector, magnitude of the unnormalized normal
+ * covector, and in curved spacetimes the normal vector.
+ *
+ * The `fields_on_face` argument is used as a temporary buffer via the
+ * `OneOverNormalVectorMagnitude` tag and also used to return the normalized
+ * normal vector via the `NormalVector<Dim>` tag. The `fields_on_face` argument
+ * also serves as the input for the inverse spatial metric when the spacetime is
+ * curved. The `fields_on_face` argument must have tags `NormalVector<Dim>` and
+ * `OneOverNormalVectorMagnitude`. If the system specifies
+ * `System::inverse_spatial_metric_tag` then this tag must also be in the
+ * Variables.
+ */
+template <typename System, size_t Dim, typename FieldsOnFaceTags>
+void unit_normal_vector_and_covector_and_magnitude_impl(
+    const gsl::not_null<Scalar<DataVector>*> face_normal_magnitude,
+    const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+        unit_normal_covector,
+    const gsl::not_null<Variables<FieldsOnFaceTags>*> fields_on_face,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>&
+        unnormalized_normal_covector) noexcept {
+  if constexpr (has_inverse_spatial_metric_tag_v<System>) {
+    using inverse_spatial_metric_tag =
+        typename System::inverse_spatial_metric_tag;
+    auto& normal_vector = get<NormalVector<Dim>>(*fields_on_face);
+    const auto& inverse_spatial_metric =
+        get<inverse_spatial_metric_tag>(*fields_on_face);
+    // Compute unnormalized normal vector
+    for (size_t i = 0; i < Dim; ++i) {
+      normal_vector.get(i) = inverse_spatial_metric.get(i, 0) *
+                             get<0>(unnormalized_normal_covector);
+      for (size_t j = 1; j < Dim; ++j) {
+        normal_vector.get(i) += inverse_spatial_metric.get(i, j) *
+                                unnormalized_normal_covector.get(j);
+      }
+    }
+    // Perform normalization
+    dot_product(face_normal_magnitude, normal_vector,
+                unnormalized_normal_covector);
+    get(*face_normal_magnitude) = sqrt(get(*face_normal_magnitude));
+    auto& one_over_normal_vector_magnitude =
+        get<OneOverNormalVectorMagnitude>(*fields_on_face);
+    get(one_over_normal_vector_magnitude) = 1.0 / get(*face_normal_magnitude);
+    for (size_t i = 0; i < Dim; ++i) {
+      unit_normal_covector->get(i) = unnormalized_normal_covector.get(i) *
+                                     get(one_over_normal_vector_magnitude);
+      normal_vector.get(i) *= get(one_over_normal_vector_magnitude);
+    }
+  } else {
+    magnitude(face_normal_magnitude, unnormalized_normal_covector);
+    auto& one_over_normal_vector_magnitude =
+        get<OneOverNormalVectorMagnitude>(*fields_on_face);
+    get(one_over_normal_vector_magnitude) = 1.0 / get(*face_normal_magnitude);
+    for (size_t i = 0; i < Dim; ++i) {
+      unit_normal_covector->get(i) = unnormalized_normal_covector.get(i) *
+                                     get(one_over_normal_vector_magnitude);
+    }
+  }
+}
+
+/*!
+ * \brief Computes the normal vector, covector, and their magnitude on the face
+ * in the given direction.
+ *
+ * The normal covector and its magnitude are returned using the
+ * `normal_covector_quantities` function argument. The `fields_on_face` argument
+ * is used as a temporary buffer via the `OneOverNormalVectorMagnitude` tag and
+ * also used to return the normalized normal vector via the `NormalVector<Dim>`
+ * tag. The `fields_on_face` argument also serves as the input for the inverse
+ * spatial metric when the spacetime is curved. The `fields_on_face` argument
+ * must have tags `NormalVector<Dim>` and `OneOverNormalVectorMagnitude`. If the
+ * system specifies `System::inverse_spatial_metric_tag` then this tag must also
+ * be in the Variables.
+ */
+template <typename System, size_t Dim, typename FieldsOnFaceTags>
+void unit_normal_vector_and_covector_and_magnitude(
+    const gsl::not_null<DirectionMap<
+        Dim, std::optional<Variables<tmpl::list<
+                 evolution::dg::Tags::InternalFace::MagnitudeOfNormal,
+                 evolution::dg::Tags::InternalFace::NormalCovector<Dim>>>>>*>
+        normal_covector_quantities,
+    const gsl::not_null<Variables<FieldsOnFaceTags>*> fields_on_face,
+    const Direction<Dim>& direction,
+    const std::unordered_map<Direction<Dim>, tnsr::i<DataVector, Dim>>&
+        unnormalized_normal_covectors,
+    const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, Dim>&
+        moving_mesh_map) noexcept {
+  const bool mesh_is_moving = not moving_mesh_map.is_identity();
+  const auto& unnormalized_normal_covector =
+      unnormalized_normal_covectors.at(direction);
+
+  if (auto& normal_covector_quantity =
+          normal_covector_quantities->at(direction);
+      detail::has_inverse_spatial_metric_tag_v<System> or mesh_is_moving or
+      not normal_covector_quantity.has_value()) {
+    if (not normal_covector_quantity.has_value()) {
+      normal_covector_quantity = Variables<
+          tmpl::list<evolution::dg::Tags::InternalFace::MagnitudeOfNormal,
+                     evolution::dg::Tags::InternalFace::NormalCovector<Dim>>>{
+          fields_on_face->number_of_grid_points()};
+    }
+    detail::unit_normal_vector_and_covector_and_magnitude_impl<System>(
+        make_not_null(
+            &get<evolution::dg::Tags::InternalFace::MagnitudeOfNormal>(
+                *normal_covector_quantity)),
+        make_not_null(
+            &get<evolution::dg::Tags::InternalFace::NormalCovector<Dim>>(
+                *normal_covector_quantity)),
+        fields_on_face, unnormalized_normal_covector);
+  }
+}
+}  // namespace evolution::dg::Actions::detail

--- a/src/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_headers(
   LiftFromBoundary.hpp
   MortarData.hpp
   MortarTags.hpp
+  NormalVectorTags.hpp
   ProjectToBoundary.hpp
   )
 

--- a/src/Evolution/DiscontinuousGalerkin/MortarTags.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/MortarTags.hpp
@@ -17,6 +17,7 @@
 #include "NumericalAlgorithms/Spectral/Projection.hpp"  // for MortarSize
 #include "Time/TimeStepId.hpp"
 
+/// %Tags used for DG evolution scheme.
 namespace evolution::dg::Tags {
 /// Data on mortars, indexed by (Direction, ElementId) pairs
 ///

--- a/src/Evolution/DiscontinuousGalerkin/NormalVectorTags.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/NormalVectorTags.hpp
@@ -1,0 +1,41 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// %Tags used on the interior faces of the elements
+namespace evolution::dg::Tags::InternalFace {
+/// The magnitude of the unnormalized normal covector to the interface
+struct MagnitudeOfNormal : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+/// The normal covector to the interface
+template <size_t Dim>
+struct NormalCovector : db::SimpleTag {
+  using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
+};
+
+/// The normal covector and its magnitude for all internal faces of an element.
+///
+/// The combined tag is used to make the allocations be in a Variables
+///
+/// We use a `std::optional` to keep track of whether or not these values are
+/// up-to-date.
+template <size_t Dim>
+struct NormalCovectorAndMagnitude : db::SimpleTag {
+  using type = DirectionMap<
+      Dim, std::optional<
+               Variables<tmpl::list<MagnitudeOfNormal, NormalCovector<Dim>>>>>;
+};
+}  // namespace evolution::dg::Tags::InternalFace

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_NormalCovectorAndMagnitude.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_NormalCovectorAndMagnitude.cpp
@@ -1,0 +1,290 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <optional>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/InterfaceComputeTags.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+using Affine = domain::CoordinateMaps::Affine;
+using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+using Affine3D = domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+
+template <size_t VolumeDim>
+auto make_affine_map() noexcept;
+
+template <>
+auto make_affine_map<1>() noexcept {
+  return domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+      Affine{-1.0, 1.0, -0.3, 0.7});
+}
+
+template <>
+auto make_affine_map<2>() noexcept {
+  return domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+      Affine2D{Affine{-1.0, 1.0, -0.3, 0.7}, Affine{-1.0, 1.0, 0.3, 0.55}});
+}
+
+template <>
+auto make_affine_map<3>() noexcept {
+  return domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+      Affine3D{Affine{-1.0, 1.0, -0.3, 0.7}, Affine{-1.0, 1.0, 0.3, 0.55},
+               Affine{-1.0, 1.0, 2.3, 2.8}});
+}
+
+struct ScaleZeroIndex : db::SimpleTag {
+  using type = double;
+};
+
+template <size_t Dim>
+struct SimpleUnnormalizedFaceNormal
+    : db::ComputeTag,
+      domain::Tags::UnnormalizedFaceNormal<Dim> {
+  using base = domain::Tags::UnnormalizedFaceNormal<Dim>;
+  using return_type = typename base::type;
+  static void function(const gsl::not_null<return_type*> result,
+                       const double scale_zero_index,
+                       const Mesh<Dim - 1>& face_mesh,
+                       const Direction<Dim>& direction) noexcept {
+    for (size_t i = 0; i < Dim; ++i) {
+      result->get(i) =
+          DataVector{face_mesh.number_of_grid_points(),
+                     i == direction.dimension() ? 1.0 * i + 0.25 : 0.0};
+    }
+    result->get(0) *= scale_zero_index;
+  }
+  using argument_tags = tmpl::list<ScaleZeroIndex, domain::Tags::Mesh<Dim - 1>,
+                                   domain::Tags::Direction<Dim>>;
+  using volume_tags = tmpl::list<ScaleZeroIndex>;
+};
+
+struct FlatSpaceSystem {};
+
+template <size_t Dim>
+struct InverseSpatialMetric : db::SimpleTag {
+  using type = tnsr::II<DataVector, Dim, Frame::Inertial>;
+};
+
+template <size_t Dim>
+struct SystemWithInverseMetric {
+  using inverse_spatial_metric_tag = InverseSpatialMetric<Dim>;
+};
+
+template <size_t Dim>
+auto create_box(const size_t number_of_grid_points_per_dim,
+                const bool use_moving_mesh) {
+  using internal_directions = domain::Tags::InternalDirections<Dim>;
+  using simple_tags = tmpl::list<
+      ScaleZeroIndex, domain::Tags::Mesh<Dim>,
+      domain::CoordinateMaps::Tags::CoordinateMap<Dim, Frame::Grid,
+                                                  Frame::Inertial>,
+      domain::Tags::Element<Dim>,
+      evolution::dg::Tags::InternalFace::NormalCovectorAndMagnitude<Dim>>;
+  using compute_tags =
+      tmpl::list<domain::Tags::InternalDirectionsCompute<Dim>,
+                 domain::Tags::InterfaceCompute<internal_directions,
+                                                domain::Tags::Direction<Dim>>,
+                 domain::Tags::InterfaceCompute<
+                     internal_directions, domain::Tags::InterfaceMesh<Dim>>,
+                 domain::Tags::InterfaceCompute<
+                     internal_directions, SimpleUnnormalizedFaceNormal<Dim>>>;
+
+  auto grid_to_inertial_map =
+      use_moving_mesh
+          ? make_affine_map<Dim>()
+          : domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+                domain::CoordinateMaps::Identity<Dim>{});
+
+  DirectionMap<Dim, Neighbors<Dim>> neighbors{};
+  ElementId<Dim> self_id{};
+  ElementId<Dim> east_id{};
+  ElementId<Dim> south_id{};  // not used in 1d
+  ElementId<Dim> up_id{};  // not used in 1d or 2d
+
+  if constexpr (Dim == 1) {
+    self_id = ElementId<Dim>{0, {{{1, 0}}}};
+    east_id = ElementId<Dim>{0, {{{1, 1}}}};
+    neighbors[Direction<Dim>::upper_xi()] = Neighbors<Dim>{{east_id}, {}};
+  } else if constexpr (Dim == 2) {
+    self_id = ElementId<Dim>{0, {{{1, 0}, {0, 0}}}};
+    east_id = ElementId<Dim>{0, {{{1, 1}, {0, 0}}}};
+    south_id = ElementId<Dim>{1, {{{1, 0}, {0, 0}}}};
+    neighbors[Direction<Dim>::upper_xi()] = Neighbors<Dim>{{east_id}, {}};
+    neighbors[Direction<Dim>::lower_eta()] = Neighbors<Dim>{{south_id}, {}};
+  } else {
+    static_assert(Dim == 3, "Only implemented tests in 1, 2, and 3d");
+    self_id = ElementId<Dim>{0, {{{1, 0}, {0, 0}, {2, 1}}}};
+    east_id = ElementId<Dim>{0, {{{1, 1}, {0, 0}, {2, 1}}}};
+    south_id = ElementId<Dim>{1, {{{1, 0}, {0, 0}, {2, 1}}}};
+    up_id = ElementId<Dim>{0, {{{1, 0}, {0, 0}, {2, 2}}}};
+    neighbors[Direction<Dim>::upper_xi()] = Neighbors<Dim>{{east_id}, {}};
+    neighbors[Direction<Dim>::lower_eta()] = Neighbors<Dim>{{south_id}, {}};
+    neighbors[Direction<Dim>::upper_zeta()] = Neighbors<Dim>{{up_id}, {}};
+  }
+  const Element<Dim> element{self_id, neighbors};
+
+  DirectionMap<Dim,
+               std::optional<Variables<tmpl::list<
+                   evolution::dg::Tags::InternalFace::MagnitudeOfNormal,
+                   evolution::dg::Tags::InternalFace::NormalCovector<Dim>>>>>
+      normal_covector_quantities{};
+  for (const auto& [direction, local_neighbors] : element.neighbors()) {
+    (void)local_neighbors;
+    normal_covector_quantities[direction] = std::nullopt;
+  }
+
+  return db::create<simple_tags, compute_tags>(
+      1.0,
+      Mesh<Dim>{number_of_grid_points_per_dim, Spectral::Basis::Legendre,
+                Spectral::Quadrature::Gauss},
+      std::move(grid_to_inertial_map), std::move(element),
+      std::move(normal_covector_quantities));
+}
+
+template <bool UseFlatSpace, size_t Dim, typename DbTagsList>
+void check_normal_covector_quantities(
+    const gsl::not_null<db::DataBox<DbTagsList>*> box) noexcept {
+  using field_face_tags = tmpl::conditional_t<
+      UseFlatSpace,
+      tmpl::list<evolution::dg::Actions::detail::OneOverNormalVectorMagnitude>,
+      tmpl::list<evolution::dg::Actions::detail::OneOverNormalVectorMagnitude,
+                 evolution::dg::Actions::detail::NormalVector<Dim>,
+                 InverseSpatialMetric<Dim>>>;
+  using internal_directions = domain::Tags::InternalDirections<Dim>;
+  const auto& unnormalized_normal_covectors = db::get<domain::Tags::Interface<
+      internal_directions, domain::Tags::UnnormalizedFaceNormal<Dim>>>(*box);
+  for (const auto& [direction, neighbors] :
+       db::get<domain::Tags::Element<Dim>>(*box).neighbors()) {
+    (void)neighbors;
+    Variables<field_face_tags> fields_on_face{
+        db::get<domain::Tags::Interface<internal_directions,
+                                        domain::Tags::Mesh<Dim - 1>>>(*box)
+            .at(direction)
+            .number_of_grid_points()};
+    if constexpr (not UseFlatSpace) {
+      double temp = 0.1;
+      for (auto& component : get<InverseSpatialMetric<Dim>>(fields_on_face)) {
+        for (double& t : component) {
+          t = temp;
+          temp *= 1.1;
+        }
+      }
+    }
+
+    db::mutate<
+        evolution::dg::Tags::InternalFace::NormalCovectorAndMagnitude<Dim>>(
+        box,
+        &evolution::dg::Actions::detail::
+            unit_normal_vector_and_covector_and_magnitude<
+                tmpl::conditional_t<UseFlatSpace, FlatSpaceSystem,
+                                    SystemWithInverseMetric<Dim>>,
+                Dim, field_face_tags>,
+        make_not_null(&fields_on_face), direction,
+        unnormalized_normal_covectors,
+        db::get<domain::CoordinateMaps::Tags::CoordinateMap<Dim, Frame::Grid,
+                                                            Frame::Inertial>>(
+            *box));
+
+    if constexpr (UseFlatSpace) {
+      const auto& normal_covector =
+          get<evolution::dg::Tags::InternalFace::NormalCovector<Dim>>(
+              *get<evolution::dg::Tags::InternalFace::
+                       NormalCovectorAndMagnitude<Dim>>(*box)
+                   .at(direction));
+      const DataVector expected_normal_magnitude{
+          fields_on_face.number_of_grid_points(), 1.0};
+      CHECK_ITERABLE_APPROX(expected_normal_magnitude,
+                            get(magnitude(normal_covector)));
+    } else {
+      const auto& normal_covector =
+          get<evolution::dg::Tags::InternalFace::NormalCovector<Dim>>(
+              *get<evolution::dg::Tags::InternalFace::
+                       NormalCovectorAndMagnitude<Dim>>(*box)
+                   .at(direction));
+      CHECK_ITERABLE_APPROX(
+          (DataVector{fields_on_face.number_of_grid_points(), 1.0}),
+          sqrt(get(
+              dot_product(normal_covector, normal_covector,
+                          get<InverseSpatialMetric<Dim>>(fields_on_face)))));
+    }
+
+    const auto& magnitude_of_normal =
+        get(get<evolution::dg::Tags::InternalFace::MagnitudeOfNormal>(
+            *get<evolution::dg::Tags::InternalFace::NormalCovectorAndMagnitude<
+                 Dim>>(*box)
+                 .at(direction)));
+    CHECK(min(magnitude_of_normal) > 0.0);
+
+    for (size_t i = 0; i < Dim; ++i) {
+      const auto& normal_covector_and_magnitude =
+          *get<evolution::dg::Tags::InternalFace::NormalCovectorAndMagnitude<
+              Dim>>(*box)
+               .at(direction);
+      const auto& unnormalized_covector_in_dir =
+          unnormalized_normal_covectors.at(direction).get(i);
+      const DataVector expected_unnormalized_covector_in_dir{
+          get<evolution::dg::Tags::InternalFace::NormalCovector<Dim>>(
+              normal_covector_and_magnitude)
+              .get(i) *
+          get(get<evolution::dg::Tags::InternalFace::MagnitudeOfNormal>(
+              normal_covector_and_magnitude))};
+      CHECK_ITERABLE_APPROX(unnormalized_covector_in_dir,
+                            expected_unnormalized_covector_in_dir);
+    }
+  }
+}
+
+template <size_t Dim, bool IsFlatSpace>
+void test(const bool use_moving_mesh) {
+  CAPTURE(Dim);
+  CAPTURE(use_moving_mesh);
+  CAPTURE(IsFlatSpace);
+  const size_t number_of_grid_points_per_dim = 3;
+  auto box = create_box<Dim>(number_of_grid_points_per_dim, use_moving_mesh);
+  check_normal_covector_quantities<IsFlatSpace, Dim>(make_not_null(&box));
+
+  if (use_moving_mesh) {
+    // Mutate the x component of the unnormalized normal vector to simulate
+    // moving mesh
+    db::mutate<ScaleZeroIndex>(
+        make_not_null(&box),
+        [](const gsl::not_null<double*> scale_zero_index) noexcept {
+          *scale_zero_index = 2.3;
+        });
+
+    check_normal_covector_quantities<IsFlatSpace, Dim>(make_not_null(&box));
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.DG.NormalCovectorAndMagnitude",
+                  "[Unit][Evolution][Actions]") {
+  for (const auto use_moving_mesh : {true, false}) {
+    test<1, true>(use_moving_mesh);
+    test<2, true>(use_moving_mesh);
+    test<3, true>(use_moving_mesh);
+
+    test<1, false>(use_moving_mesh);
+    test<2, false>(use_moving_mesh);
+    test<3, false>(use_moving_mesh);
+  }
+}
+}  // namespace

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY "Test_EvolutionDg")
 
 set(LIBRARY_SOURCES
   Actions/Test_ComputeTimeDerivative.cpp
+  Actions/Test_NormalCovectorAndMagnitude.cpp
   Initialization/Test_Mortars.cpp
   Initialization/Test_QuadratureTag.cpp
   Test_InboxTags.cpp

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBRARY_SOURCES
   Test_LiftFromBoundary.cpp
   Test_MortarData.cpp
   Test_MortarTags.cpp
+  Test_NormalVectorTags.cpp
   Test_ProjectToBoundary.cpp
   )
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_NormalVectorTags.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_NormalVectorTags.cpp
@@ -1,0 +1,31 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/DiscontinuousGalerkin/NormalVectorTags.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace evolution::dg::Tags::InternalFace {
+namespace {
+template <size_t Dim>
+void test() {
+  TestHelpers::db::test_simple_tag<MagnitudeOfNormal>("MagnitudeOfNormal");
+  TestHelpers::db::test_simple_tag<NormalCovector<Dim>>("NormalCovector");
+  TestHelpers::db::test_simple_tag<NormalCovectorAndMagnitude<Dim>>(
+      "NormalCovectorAndMagnitude");
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.DG.InternalFaceTags", "[Unit][Evolution]") {
+  test<1>();
+  test<2>();
+  test<3>();
+}
+}  // namespace evolution::dg::Tags::InternalFace


### PR DESCRIPTION
## Proposed changes

Motivation: the new ComputeTimeDerivative is moving away from endless compute tags and so we have no way of getting the inverse spatial metric to the boundaries. It will be projected (separate PR) to the boundaries, and these functions will be used to compute the normal vector.

- Add tags for caching the normal vector computation
- Add functions to compute the normal vectors in curved spacetimes.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
