### PR TITLE
Use DampingFunctions for GH evolutions

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBS_TO_LINK
   GeneralRelativity
   GeneralizedHarmonic
   GeneralizedHarmonicGaugeSourceFunctions
+  GhConstraintDamping
   IO
   Informer
   Interpolation

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -28,6 +28,7 @@
 #include "Evolution/Initialization/NonconservativeSystem.hpp"
 #include "Evolution/Initialization/SetVariables.hpp"
 #include "Evolution/NumericInitialData.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Equations.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/InitializeDampedHarmonic.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Initialize.hpp"
@@ -303,21 +304,21 @@ struct EvolutionMetavars {
               gr::Tags::Lapse<DataVector>>,
           dg::Initialization::face_compute_tags<
               domain::Tags::BoundaryCoordinates<volume_dim, true>,
-              GeneralizedHarmonic::Tags::ConstraintGamma0Compute<volume_dim,
-                                                                 frame>,
-              GeneralizedHarmonic::Tags::ConstraintGamma1Compute<volume_dim,
-                                                                 frame>,
-              GeneralizedHarmonic::Tags::ConstraintGamma2Compute<volume_dim,
-                                                                 frame>,
+              GeneralizedHarmonic::ConstraintDamping::Tags::
+                  ConstraintGamma0Compute<volume_dim, frame>,
+              GeneralizedHarmonic::ConstraintDamping::Tags::
+                  ConstraintGamma1Compute<volume_dim, frame>,
+              GeneralizedHarmonic::ConstraintDamping::Tags::
+                  ConstraintGamma2Compute<volume_dim, frame>,
               GeneralizedHarmonic::CharacteristicFieldsCompute<volume_dim,
                                                                frame>>,
           dg::Initialization::exterior_compute_tags<
-              GeneralizedHarmonic::Tags::ConstraintGamma0Compute<volume_dim,
-                                                                 frame>,
-              GeneralizedHarmonic::Tags::ConstraintGamma1Compute<volume_dim,
-                                                                 frame>,
-              GeneralizedHarmonic::Tags::ConstraintGamma2Compute<volume_dim,
-                                                                 frame>,
+              GeneralizedHarmonic::ConstraintDamping::Tags::
+                  ConstraintGamma0Compute<volume_dim, frame>,
+              GeneralizedHarmonic::ConstraintDamping::Tags::
+                  ConstraintGamma1Compute<volume_dim, frame>,
+              GeneralizedHarmonic::ConstraintDamping::Tags::
+                  ConstraintGamma2Compute<volume_dim, frame>,
               GeneralizedHarmonic::CharacteristicFieldsCompute<volume_dim,
                                                                frame>>,
           true, true>,

--- a/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
@@ -8,6 +8,7 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/FaceNormal.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/TMPL.hpp"
@@ -75,8 +76,8 @@ struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds<Dim, Frame>,
   using base = Tags::CharacteristicSpeeds<Dim, Frame>;
   using type = typename base::type;
   using argument_tags = tmpl::list<
-      Tags::ConstraintGamma1, gr::Tags::Lapse<DataVector>,
-      gr::Tags::Shift<Dim, Frame, DataVector>,
+      ::GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1,
+      gr::Tags::Lapse<DataVector>, gr::Tags::Shift<Dim, Frame, DataVector>,
       ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim, Frame>>>;
 
   using return_type = typename base::type;
@@ -163,7 +164,7 @@ struct CharacteristicFieldsCompute : Tags::CharacteristicFields<Dim, Frame>,
   using base = Tags::CharacteristicFields<Dim, Frame>;
   using return_type = typename base::type;
   using argument_tags = tmpl::list<
-      Tags::ConstraintGamma2,
+      ::GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2,
       gr::Tags::InverseSpatialMetric<Dim, Frame, DataVector>,
       gr::Tags::SpacetimeMetric<Dim, Frame, DataVector>, Tags::Pi<Dim, Frame>,
       Tags::Phi<Dim, Frame>,
@@ -213,9 +214,9 @@ struct EvolvedFieldsFromCharacteristicFieldsCompute
   using base = Tags::EvolvedFieldsFromCharacteristicFields<Dim, Frame>;
   using return_type = typename base::type;
   using argument_tags = tmpl::list<
-      Tags::ConstraintGamma2, Tags::VSpacetimeMetric<Dim, Frame>,
-      Tags::VZero<Dim, Frame>, Tags::VPlus<Dim, Frame>,
-      Tags::VMinus<Dim, Frame>,
+      GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2,
+      Tags::VSpacetimeMetric<Dim, Frame>, Tags::VZero<Dim, Frame>,
+      Tags::VPlus<Dim, Frame>, Tags::VMinus<Dim, Frame>,
       ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim, Frame>>>;
 
   static constexpr auto function = static_cast<void (*)(
@@ -234,10 +235,10 @@ struct EvolvedFieldsFromCharacteristicFieldsCompute
  */
 template <size_t Dim, typename Frame>
 struct ComputeLargestCharacteristicSpeed {
-  using argument_tags =
-      tmpl::list<Tags::ConstraintGamma1, gr::Tags::Lapse<DataVector>,
-                 gr::Tags::Shift<Dim, Frame, DataVector>,
-                 gr::Tags::SpatialMetric<Dim, Frame, DataVector>>;
+  using argument_tags = tmpl::list<
+      ::GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1,
+      gr::Tags::Lapse<DataVector>, gr::Tags::Shift<Dim, Frame, DataVector>,
+      gr::Tags::SpatialMetric<Dim, Frame, DataVector>>;
   static double apply(
       const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
       const tnsr::I<DataVector, Dim, Frame>& shift,

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/CMakeLists.txt
@@ -9,14 +9,17 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   GaussianPlusConstant.cpp
+  RegisterDerivedWithCharm.cpp
   )
 
 spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
-  GaussianPlusConstant.hpp
   DampingFunction.hpp
+  GaussianPlusConstant.hpp
+  RegisterDerivedWithCharm.hpp
+  Tags.hpp
   )
 
 target_link_libraries(

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/DampingFunction.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/DampingFunction.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+#include <memory>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Parallel/CharmPupable.hpp"
@@ -38,8 +39,8 @@ class DampingFunction : public PUP::able {
   WRAPPED_PUPable_abstract(DampingFunction);  // NOLINT
 
   DampingFunction() = default;
-  DampingFunction(const DampingFunction& /*rhs*/) = delete;
-  DampingFunction& operator=(const DampingFunction& /*rhs*/) = delete;
+  DampingFunction(const DampingFunction& /*rhs*/) = default;
+  DampingFunction& operator=(const DampingFunction& /*rhs*/) = default;
   DampingFunction(DampingFunction&& /*rhs*/) noexcept = default;
   DampingFunction& operator=(DampingFunction&& /*rhs*/) noexcept = default;
   ~DampingFunction() override = default;
@@ -51,6 +52,9 @@ class DampingFunction : public PUP::able {
   virtual Scalar<DataVector> operator()(
       const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept = 0;
   //@}
+
+  virtual auto get_clone() const noexcept
+      -> std::unique_ptr<DampingFunction<VolumeDim, Fr>> = 0;
 };
 }  // namespace GeneralizedHarmonic::ConstraintDamping
 

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/GaussianPlusConstant.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/GaussianPlusConstant.cpp
@@ -5,6 +5,7 @@
 
 #include <cmath>
 #include <cstddef>
+#include <memory>
 #include <pup.h>
 #include <pup_stl.h>
 
@@ -67,6 +68,12 @@ void GaussianPlusConstant<VolumeDim, Fr>::pup(PUP::er& p) {
   p | inverse_width_;
   p | center_;
 }
+
+template <size_t VolumeDim, typename Fr>
+auto GaussianPlusConstant<VolumeDim, Fr>::get_clone() const noexcept
+    -> std::unique_ptr<DampingFunction<VolumeDim, Fr>> {
+  return std::make_unique<GaussianPlusConstant<VolumeDim, Fr>>(*this);
+}
 }  // namespace GeneralizedHarmonic::ConstraintDamping
 
 /// \cond
@@ -78,7 +85,10 @@ void GaussianPlusConstant<VolumeDim, Fr>::pup(PUP::er& p) {
           const double constant, const double amplitude, const double width,  \
           const std::array<double, DIM(data)>& center) noexcept;              \
   template void GeneralizedHarmonic::ConstraintDamping::GaussianPlusConstant< \
-      DIM(data), FRAME(data)>::pup(PUP::er& p);
+      DIM(data), FRAME(data)>::pup(PUP::er& p);                               \
+  template auto GeneralizedHarmonic::ConstraintDamping::GaussianPlusConstant< \
+      DIM(data), FRAME(data)>::get_clone() const noexcept                     \
+      ->std::unique_ptr<DampingFunction<DIM(data), FRAME(data)>>;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial))
 #undef DIM

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/GaussianPlusConstant.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/GaussianPlusConstant.hpp
@@ -72,8 +72,9 @@ class GaussianPlusConstant : public DampingFunction<VolumeDim, Fr> {
 
   GaussianPlusConstant() = default;
   ~GaussianPlusConstant() override = default;
-  GaussianPlusConstant(const GaussianPlusConstant& /*rhs*/) = delete;
-  GaussianPlusConstant& operator=(const GaussianPlusConstant& /*rhs*/) = delete;
+  GaussianPlusConstant(const GaussianPlusConstant& /*rhs*/) = default;
+  GaussianPlusConstant& operator=(const GaussianPlusConstant& /*rhs*/) =
+      default;
   GaussianPlusConstant(GaussianPlusConstant&& /*rhs*/) noexcept = default;
   GaussianPlusConstant& operator=(GaussianPlusConstant&& /*rhs*/) noexcept =
       default;
@@ -82,6 +83,9 @@ class GaussianPlusConstant : public DampingFunction<VolumeDim, Fr> {
       const tnsr::I<double, VolumeDim, Fr>& x) const noexcept override;
   Scalar<DataVector> operator()(
       const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept override;
+
+  auto get_clone() const noexcept
+      -> std::unique_ptr<DampingFunction<VolumeDim, Fr>> override;
 
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p) override;  // NOLINT

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/RegisterDerivedWithCharm.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/RegisterDerivedWithCharm.cpp
@@ -1,0 +1,31 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <cstddef>
+
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/DampingFunction.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+
+namespace Frame {
+struct Grid;
+struct Inertial;
+}  // namespace Frame
+
+namespace GeneralizedHarmonic::ConstraintDamping {
+namespace {
+template <size_t Dim, typename Fr>
+void register_damping_functions_with_charm() noexcept {
+  Parallel::register_classes_in_list<
+      typename DampingFunction<Dim, Fr>::creatable_classes>();
+}
+}  // namespace
+
+void register_derived_with_charm() noexcept {
+  register_damping_functions_with_charm<1, Frame::Grid>();
+  register_damping_functions_with_charm<2, Frame::Grid>();
+  register_damping_functions_with_charm<3, Frame::Grid>();
+  register_damping_functions_with_charm<1, Frame::Inertial>();
+  register_damping_functions_with_charm<2, Frame::Inertial>();
+  register_damping_functions_with_charm<3, Frame::Inertial>();
+}
+}  // namespace GeneralizedHarmonic::ConstraintDamping

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/RegisterDerivedWithCharm.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/RegisterDerivedWithCharm.hpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace GeneralizedHarmonic::ConstraintDamping {
+void register_derived_with_charm() noexcept;
+}  // namespace GeneralizedHarmonic::ConstraintDamping

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp
@@ -3,9 +3,50 @@
 
 #pragma once
 
-#include "DataStructures/DataBox/Prefixes.hpp"
+#include <cstddef>
+#include <memory>
 
-namespace GeneralizedHarmonic::ConstraintDamping::Tags {
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/DampingFunction.hpp"
+#include "Options/Options.hpp"
+
+/// \cond
+namespace GeneralizedHarmonic::OptionTags {
+struct Group;
+}  // namespace GeneralizedHarmonic::OptionTags
+/// \endcond
+
+namespace GeneralizedHarmonic::ConstraintDamping {
+namespace OptionTags {
+template <size_t VolumeDim, typename Fr>
+struct DampingFunctionGamma0 {
+  using type = std::unique_ptr<
+      ::GeneralizedHarmonic::ConstraintDamping::DampingFunction<VolumeDim, Fr>>;
+  static constexpr Options::String help{
+      "DampingFunction for damping parameter gamma0"};
+  using group = GeneralizedHarmonic::OptionTags::Group;
+};
+
+template <size_t VolumeDim, typename Fr>
+struct DampingFunctionGamma1 {
+  using type = std::unique_ptr<
+      ::GeneralizedHarmonic::ConstraintDamping::DampingFunction<VolumeDim, Fr>>;
+  static constexpr Options::String help{
+      "DampingFunction for damping parameter gamma1"};
+  using group = GeneralizedHarmonic::OptionTags::Group;
+};
+
+template <size_t VolumeDim, typename Fr>
+struct DampingFunctionGamma2 {
+  using type = std::unique_ptr<
+      ::GeneralizedHarmonic::ConstraintDamping::DampingFunction<VolumeDim, Fr>>;
+  static constexpr Options::String help{
+      "DampingFunction for damping parameter gamma2"};
+  using group = GeneralizedHarmonic::OptionTags::Group;
+};
+}  // namespace OptionTags
+
+namespace Tags {
 /*!
  * \brief Constraint dammping parameter \f$\gamma_0\f$ for the generalized
  * harmonic system (cf. \cite Lindblom2005qh).
@@ -29,4 +70,62 @@ struct ConstraintGamma1 : db::SimpleTag {
 struct ConstraintGamma2 : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
-}  // namespace GeneralizedHarmonic::ConstraintDamping::Tags
+
+/*!
+ * \brief A DampingFunction to compute the constraint damping parameter
+ * \f$\gamma_0\f$.
+ */
+template <size_t VolumeDim, typename Fr>
+struct DampingFunctionGamma0 : db::SimpleTag {
+  using DampingFunctionType =
+      ::GeneralizedHarmonic::ConstraintDamping::DampingFunction<VolumeDim, Fr>;
+  using type = std::unique_ptr<DampingFunctionType>;
+  using option_tags =
+      tmpl::list<::GeneralizedHarmonic::ConstraintDamping::OptionTags::
+                     DampingFunctionGamma0<VolumeDim, Fr>>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& damping_function) noexcept {
+    return damping_function->get_clone();
+  }
+};
+
+/*!
+ * \brief A DampingFunction to compute the constraint damping parameter
+ * \f$\gamma_0\f$.
+ */
+template <size_t VolumeDim, typename Fr>
+struct DampingFunctionGamma1 : db::SimpleTag {
+  using DampingFunctionType =
+      ::GeneralizedHarmonic::ConstraintDamping::DampingFunction<VolumeDim, Fr>;
+  using type = std::unique_ptr<DampingFunctionType>;
+  using option_tags =
+      tmpl::list<::GeneralizedHarmonic::ConstraintDamping::OptionTags::
+                     DampingFunctionGamma1<VolumeDim, Fr>>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& damping_function) noexcept {
+    return std::move(damping_function->get_clone());
+  }
+};
+
+/*!
+ * \brief A DampingFunction to compute the constraint damping parameter
+ * \f$\gamma_0\f$.
+ */
+template <size_t VolumeDim, typename Fr>
+struct DampingFunctionGamma2 : db::SimpleTag {
+  using DampingFunctionType =
+      ::GeneralizedHarmonic::ConstraintDamping::DampingFunction<VolumeDim, Fr>;
+  using type = std::unique_ptr<DampingFunctionType>;
+  using option_tags =
+      tmpl::list<::GeneralizedHarmonic::ConstraintDamping::OptionTags::
+                     DampingFunctionGamma2<VolumeDim, Fr>>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& damping_function) noexcept {
+    return std::move(damping_function->get_clone());
+  }
+};
+}  // namespace Tags
+}  // namespace GeneralizedHarmonic::ConstraintDamping

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp
@@ -1,0 +1,32 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+
+namespace GeneralizedHarmonic::ConstraintDamping::Tags {
+/*!
+ * \brief Constraint dammping parameter \f$\gamma_0\f$ for the generalized
+ * harmonic system (cf. \cite Lindblom2005qh).
+ */
+struct ConstraintGamma0 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+/*!
+ * \brief Constraint dammping parameter \f$\gamma_1\f$ for the generalized
+ * harmonic system (cf. \cite Lindblom2005qh).
+ */
+struct ConstraintGamma1 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+/*!
+ * \brief Constraint dammping parameter \f$\gamma_2\f$ for the generalized
+ * harmonic system (cf. \cite Lindblom2005qh).
+ */
+struct ConstraintGamma2 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+}  // namespace GeneralizedHarmonic::ConstraintDamping::Tags

--- a/src/Evolution/Systems/GeneralizedHarmonic/Constraints.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Constraints.hpp
@@ -12,6 +12,7 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "Utilities/ContainerHelpers.hpp"
@@ -547,7 +548,8 @@ struct FConstraintCompute : FConstraint<SpatialDim, Frame>, db::ComputeTag {
       Pi<SpatialDim, Frame>, Phi<SpatialDim, Frame>,
       ::Tags::deriv<Pi<SpatialDim, Frame>, tmpl::size_t<SpatialDim>, Frame>,
       ::Tags::deriv<Phi<SpatialDim, Frame>, tmpl::size_t<SpatialDim>, Frame>,
-      ConstraintGamma2, ThreeIndexConstraint<SpatialDim, Frame>>;
+      ::GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2,
+      ThreeIndexConstraint<SpatialDim, Frame>>;
 
   using return_type = tnsr::a<DataVector, SpatialDim, Frame>;
 
@@ -589,7 +591,8 @@ struct TwoIndexConstraintCompute : TwoIndexConstraint<SpatialDim, Frame>,
       Pi<SpatialDim, Frame>, Phi<SpatialDim, Frame>,
       ::Tags::deriv<Pi<SpatialDim, Frame>, tmpl::size_t<SpatialDim>, Frame>,
       ::Tags::deriv<Phi<SpatialDim, Frame>, tmpl::size_t<SpatialDim>, Frame>,
-      ConstraintGamma2, ThreeIndexConstraint<SpatialDim, Frame>>;
+      ::GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2,
+      ThreeIndexConstraint<SpatialDim, Frame>>;
 
   using return_type = tnsr::ia<DataVector, SpatialDim, Frame>;
 

--- a/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
@@ -96,6 +96,14 @@ template <size_t Dim>
 struct InitializeGhAnd3Plus1Variables {
   using frame = Frame::Inertial;
 
+  using const_global_cache_tags = tmpl::list<
+      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma0<
+          Dim, frame>,
+      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma1<
+          Dim, frame>,
+      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma2<
+          Dim, frame>>;
+
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>

--- a/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Initialize.hpp
@@ -15,6 +15,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Tags.hpp"
 #include "ErrorHandling/Assert.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Constraints.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
@@ -114,9 +115,12 @@ struct InitializeGhAnd3Plus1Variables {
         gr::Tags::SpacetimeNormalVectorCompute<Dim, frame, DataVector>,
         gr::Tags::InverseSpacetimeMetricCompute<Dim, frame, DataVector>,
         GeneralizedHarmonic::Tags::ThreeIndexConstraintCompute<Dim, frame>,
-        GeneralizedHarmonic::Tags::ConstraintGamma0Compute<Dim, frame>,
-        GeneralizedHarmonic::Tags::ConstraintGamma1Compute<Dim, frame>,
-        GeneralizedHarmonic::Tags::ConstraintGamma2Compute<Dim, frame>>;
+        GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma0Compute<
+            Dim, frame>,
+        GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1Compute<
+            Dim, frame>,
+        GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2Compute<
+            Dim, frame>>;
 
     return std::make_tuple(
         Initialization::merge_into_databox<InitializeGhAnd3Plus1Variables,

--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -41,16 +41,6 @@ struct Phi : db::SimpleTag {
   using type = tnsr::iaa<DataVector, Dim, Frame>;
 };
 
-struct ConstraintGamma0 : db::SimpleTag {
-  using type = Scalar<DataVector>;
-};
-struct ConstraintGamma1 : db::SimpleTag {
-  using type = Scalar<DataVector>;
-};
-struct ConstraintGamma2 : db::SimpleTag {
-  using type = Scalar<DataVector>;
-};
-
 /*!
  * \brief Gauge source function for the generalized harmonic system.
  *

--- a/src/Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp
@@ -16,9 +16,6 @@ struct Pi;
 template <size_t Dim, typename Frame = Frame::Inertial>
 struct Phi;
 
-struct ConstraintGamma0;
-struct ConstraintGamma1;
-struct ConstraintGamma2;
 template <size_t Dim, typename Frame = Frame::Inertial>
 struct InitialGaugeH;
 template <size_t Dim, typename Frame = Frame::Inertial>

--- a/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.cpp
@@ -7,6 +7,7 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/DuDtTempTags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"

--- a/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"  // IWYU pragma: keep
@@ -85,11 +86,12 @@ template <size_t Dim>
 struct TimeDerivative {
  public:
   using temporary_tags = tmpl::list<>;
-  using argument_tags =
-      tmpl::list<gr::Tags::SpacetimeMetric<Dim>, Tags::Pi<Dim>, Tags::Phi<Dim>,
-                 Tags::ConstraintGamma0, Tags::ConstraintGamma1,
-                 Tags::ConstraintGamma2, Tags::GaugeH<Dim>,
-                 Tags::SpacetimeDerivGaugeH<Dim>>;
+  using argument_tags = tmpl::list<
+      gr::Tags::SpacetimeMetric<Dim>, Tags::Pi<Dim>, Tags::Phi<Dim>,
+      ::GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma0,
+      ::GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1,
+      ::GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2,
+      Tags::GaugeH<Dim>, Tags::SpacetimeDerivGaugeH<Dim>>;
 
   static void apply(
       gsl::not_null<tnsr::aa<DataVector, Dim>*> dt_spacetime_metric,

--- a/src/Evolution/Systems/GeneralizedHarmonic/UpwindPenaltyCorrection.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/UpwindPenaltyCorrection.hpp
@@ -11,6 +11,7 @@
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/FaceNormal.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Protocols.hpp"
 #include "Options/Options.hpp"
@@ -225,7 +226,8 @@ struct UpwindPenaltyCorrection : tt::ConformsTo<dg::protocols::NumericalFlux> {
       Tags::VSpacetimeMetric<Dim, Frame::Inertial>,
       Tags::VZero<Dim, Frame::Inertial>, Tags::VPlus<Dim, Frame::Inertial>,
       Tags::VMinus<Dim, Frame::Inertial>,
-      Tags::CharacteristicSpeeds<Dim, Frame::Inertial>, Tags::ConstraintGamma2,
+      Tags::CharacteristicSpeeds<Dim, Frame::Inertial>,
+      ::GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2,
       ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>>;
 
   void package_data(

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ConstraintGammas.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ConstraintGammas.hpp
@@ -10,6 +10,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/ContainerHelpers.hpp"
@@ -30,16 +31,15 @@ template <typename X, typename Symm, typename IndexList>
 class Tensor;
 /// \endcond
 
-namespace GeneralizedHarmonic {
-namespace Tags {
+namespace GeneralizedHarmonic::ConstraintDamping::Tags {
 /*!
  * \brief Compute items to compute constraint-damping parameters for a
  * single-BH evolution.
  *
  * \details Can be retrieved using
- * `GeneralizedHarmonic::Tags::ConstraintGamma0`,
- * `GeneralizedHarmonic::Tags::ConstraintGamma1`, and
- * `GeneralizedHarmonic::Tags::ConstraintGamma2`.
+ * `GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma0`,
+ * `GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1`, and
+ * `GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2`.
  */
 template <size_t SpatialDim, typename Frame>
 struct ConstraintGamma0Compute : ConstraintGamma0, db::ComputeTag {
@@ -92,5 +92,4 @@ struct ConstraintGamma2Compute : ConstraintGamma2, db::ComputeTag {
 
   using base = ConstraintGamma2;
 };
-}  // namespace Tags
-}  // namespace GeneralizedHarmonic
+}  // namespace GeneralizedHarmonic::ConstraintDamping::Tags

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ConstraintGammas.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ConstraintGammas.hpp
@@ -33,61 +33,78 @@ class Tensor;
 
 namespace GeneralizedHarmonic::ConstraintDamping::Tags {
 /*!
- * \brief Compute items to compute constraint-damping parameters for a
- * single-BH evolution.
+ * \brief Computes the constraint damping parameter \f$\gamma_0\f$ from the
+ * coordinates and a DampingFunction.
  *
  * \details Can be retrieved using
- * `GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma0`,
- * `GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1`, and
- * `GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2`.
+ * `GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma0`.
  */
 template <size_t SpatialDim, typename Frame>
 struct ConstraintGamma0Compute : ConstraintGamma0, db::ComputeTag {
   using argument_tags =
-      tmpl::list<domain::Tags::Coordinates<SpatialDim, Frame>>;
-
+      tmpl::list<DampingFunctionGamma0<SpatialDim, Frame>,
+                 domain::Tags::Coordinates<SpatialDim, Frame>>;
   using return_type = Scalar<DataVector>;
 
   static constexpr void function(
       const gsl::not_null<Scalar<DataVector>*> gamma,
+      const ::GeneralizedHarmonic::ConstraintDamping::DampingFunction<
+          SpatialDim, Frame>& damping_function,
       const tnsr::I<DataVector, SpatialDim, Frame>& coords) noexcept {
     destructive_resize_components(gamma, get<0>(coords).size());
-    get(*gamma) =
-        3. * exp(-0.0078125 * get(dot_product(coords, coords))) + 0.001;
+    get(*gamma) = get(damping_function(coords));
   }
 
   using base = ConstraintGamma0;
 };
-/// \copydoc ConstraintGamma0Compute
+
+/*!
+ * \brief Computes the constraint damping parameter \f$\gamma_1\f$ from the
+ * coordinates and a DampingFunction.
+ *
+ * \details Can be retrieved using
+ * `GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1`.
+ */
 template <size_t SpatialDim, typename Frame>
 struct ConstraintGamma1Compute : ConstraintGamma1, db::ComputeTag {
   using argument_tags =
-      tmpl::list<domain::Tags::Coordinates<SpatialDim, Frame>>;
-
+      tmpl::list<DampingFunctionGamma1<SpatialDim, Frame>,
+                 domain::Tags::Coordinates<SpatialDim, Frame>>;
   using return_type = Scalar<DataVector>;
 
   static constexpr void function(
       const gsl::not_null<Scalar<DataVector>*> gamma1,
+      const ::GeneralizedHarmonic::ConstraintDamping::DampingFunction<
+          SpatialDim, Frame>& damping_function,
       const tnsr::I<DataVector, SpatialDim, Frame>& coords) noexcept {
     destructive_resize_components(gamma1, get<0>(coords).size());
-    get(*gamma1) = -1.;
+    get(*gamma1) = get(damping_function(coords));
   }
 
   using base = ConstraintGamma1;
 };
-/// \copydoc ConstraintGamma0Compute
+
+/*!
+ * \brief Computes the constraint damping parameter \f$\gamma_2\f$ from the
+ * coordinates and a DampingFunction.
+ *
+ * \details Can be retrieved using
+ * `GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2`.
+ */
 template <size_t SpatialDim, typename Frame>
 struct ConstraintGamma2Compute : ConstraintGamma2, db::ComputeTag {
   using argument_tags =
-      tmpl::list<domain::Tags::Coordinates<SpatialDim, Frame>>;
-
+      tmpl::list<DampingFunctionGamma2<SpatialDim, Frame>,
+                 domain::Tags::Coordinates<SpatialDim, Frame>>;
   using return_type = Scalar<DataVector>;
 
   static constexpr void function(
       const gsl::not_null<Scalar<DataVector>*> gamma,
+      const ::GeneralizedHarmonic::ConstraintDamping::DampingFunction<
+          SpatialDim, Frame>& damping_function,
       const tnsr::I<DataVector, SpatialDim, Frame>& coords) noexcept {
     destructive_resize_components(gamma, get<0>(coords).size());
-    get(*gamma) = exp(-0.0078125 * get(dot_product(coords, coords))) + 0.001;
+    get(*gamma) = get(damping_function(coords));
   }
 
   using base = ConstraintGamma2;

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -43,6 +43,24 @@ EvolutionSystem:
       SpatialDecayWidth: 50.0
       Amplitudes: [1.0, 1.0, 1.0]
       Exponents: [4, 4, 4]
+    DampingFunctionGamma0:
+      GaussianPlusConstant:
+        Constant: 0.001
+        Amplitude: 3.0
+        Width: 11.313708499
+        Center: [0.0, 0.0, 0.0]
+    DampingFunctionGamma1:
+      GaussianPlusConstant:
+        Constant: -1.0
+        Amplitude: 0.0
+        Width: 11.313708499
+        Center: [0.0, 0.0, 0.0]
+    DampingFunctionGamma2:
+      GaussianPlusConstant:
+        Constant: 0.001
+        Amplitude: 1.0
+        Width: 11.313708499
+        Center: [0.0, 0.0, 0.0]
 
 SpatialDiscretization:
   DiscontinuousGalerkin:

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Test_GaussianPlusConstant.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Test_GaussianPlusConstant.cpp
@@ -48,6 +48,18 @@ void test_gaussian_plus_constant_random(
   TestHelpers::GeneralizedHarmonic::ConstraintDamping::check(
       std::move(gauss_plus_const), "gaussian_plus_constant", used_for_size,
       {{{-1.0, 1.0}}}, constant, amplitude, width, center);
+
+  std::unique_ptr<GeneralizedHarmonic::ConstraintDamping::GaussianPlusConstant<
+      VolumeDim, Fr>>
+      gauss_plus_const_unique_ptr =
+          std::make_unique<GeneralizedHarmonic::ConstraintDamping::
+                               GaussianPlusConstant<VolumeDim, Fr>>(
+              constant, amplitude, width, center);
+
+  TestHelpers::GeneralizedHarmonic::ConstraintDamping::check(
+      std::move(gauss_plus_const_unique_ptr->get_clone()),
+      "gaussian_plus_constant", used_for_size, {{{-1.0, 1.0}}}, constant,
+      amplitude, width, center);
 }
 }  // namespace
 

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
@@ -24,6 +24,8 @@
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Tags.hpp"  // IWYU pragma: keep
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/DampingFunction.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/GaussianPlusConstant.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Constraints.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
@@ -839,6 +841,16 @@ void test_constraint_compute_items(
                                     time_deriv_gauge_source,
                                     deriv_gauge_source);
 
+  // Make DampingFunctions for the constraint damping parameters
+  // Note: these parameters are taken from SpEC single-black-hole simulations
+  constexpr double constant_02 = 0.001;
+  constexpr double amplitude_0 = 3.0;
+  constexpr double amplitude_2 = 1.0;
+  constexpr double constant_1 = -1.0;
+  constexpr double amplitude_1 = 0.0;
+  constexpr double width = 11.3137084989848;  // sqrt(128.0)
+  const std::array<double, 3> center{{0.0, 0.0, 0.0}};
+
   // Insert into databox
   const auto box = db::create<
       db::AddSimpleTags<
@@ -864,7 +876,13 @@ void test_constraint_compute_items(
           ::Tags::deriv<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
                         tmpl::size_t<3>, Frame::Inertial>,
           ::Tags::deriv<GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
-                        tmpl::size_t<3>, Frame::Inertial>>,
+                        tmpl::size_t<3>, Frame::Inertial>,
+          GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma0<
+              3, Frame::Inertial>,
+          GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma1<
+              3, Frame::Inertial>,
+          GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma2<
+              3, Frame::Inertial>>,
       db::AddComputeTags<
           GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma0Compute<
               3, Frame::Inertial>,
@@ -907,18 +925,48 @@ void test_constraint_compute_items(
       x, spatial_metric, lapse, shift, deriv_spatial_metric, deriv_lapse,
       deriv_shift, time_deriv_spatial_metric, time_deriv_lapse,
       time_deriv_shift, deriv_gauge_source, time_deriv_gauge_source,
-      deriv_spacetime_metric, deriv_phi, deriv_pi);
+      deriv_spacetime_metric, deriv_phi, deriv_pi,
+      std::move(
+          static_cast<std::unique_ptr<GeneralizedHarmonic::ConstraintDamping::
+                                          DampingFunction<3, Frame::Inertial>>>(
+              std::make_unique<GeneralizedHarmonic::ConstraintDamping::
+                                   GaussianPlusConstant<3, Frame::Inertial>>(
+                  constant_02, amplitude_0, width, center))),
+      std::move(
+          static_cast<std::unique_ptr<GeneralizedHarmonic::ConstraintDamping::
+                                          DampingFunction<3, Frame::Inertial>>>(
+              std::make_unique<GeneralizedHarmonic::ConstraintDamping::
+                                   GaussianPlusConstant<3, Frame::Inertial>>(
+                  constant_1, amplitude_1, width, center))),
+      std::move(
+          static_cast<std::unique_ptr<GeneralizedHarmonic::ConstraintDamping::
+                                          DampingFunction<3, Frame::Inertial>>>(
+              std::make_unique<GeneralizedHarmonic::ConstraintDamping::
+                                   GaussianPlusConstant<3, Frame::Inertial>>(
+                  constant_02, amplitude_2, width, center))));
 
   // Compute tested quantities locally
   Scalar<DataVector> gamma0{};
-  GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma0Compute<
-      3, Frame::Inertial>::function(make_not_null(&gamma0), x);
+  GeneralizedHarmonic::ConstraintDamping::Tags::
+      ConstraintGamma0Compute<3, Frame::Inertial>::function(
+          make_not_null(&gamma0),
+          GeneralizedHarmonic::ConstraintDamping::GaussianPlusConstant<
+              3, Frame::Inertial>{constant_02, amplitude_0, width, center},
+          x);
   Scalar<DataVector> gamma1{};
-  GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1Compute<
-      3, Frame::Inertial>::function(make_not_null(&gamma1), x);
+  GeneralizedHarmonic::ConstraintDamping::Tags::
+      ConstraintGamma1Compute<3, Frame::Inertial>::function(
+          make_not_null(&gamma1),
+          GeneralizedHarmonic::ConstraintDamping::GaussianPlusConstant<
+              3, Frame::Inertial>{constant_1, amplitude_1, width, center},
+          x);
   Scalar<DataVector> gamma2{};
-  GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2Compute<
-      3, Frame::Inertial>::function(make_not_null(&gamma2), x);
+  GeneralizedHarmonic::ConstraintDamping::Tags::
+      ConstraintGamma2Compute<3, Frame::Inertial>::function(
+          make_not_null(&gamma2),
+          GeneralizedHarmonic::ConstraintDamping::GaussianPlusConstant<
+              3, Frame::Inertial>{constant_02, amplitude_2, width, center},
+          x);
 
   const auto four_index_constraint =
       GeneralizedHarmonic::four_index_constraint(deriv_phi);

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
@@ -24,6 +24,7 @@
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Tags.hpp"  // IWYU pragma: keep
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Constraints.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "Framework/CheckWithRandomValues.hpp"
@@ -686,14 +687,14 @@ void test_constraint_compute_items(
     const std::array<double, 3>& upper_bound) noexcept {
   // Check that compute items are named correctly
   TestHelpers::db::test_compute_tag<
-      GeneralizedHarmonic::Tags::ConstraintGamma0Compute<3, Frame::Inertial>>(
-      "ConstraintGamma0");
+      GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma0Compute<
+          3, Frame::Inertial>>("ConstraintGamma0");
   TestHelpers::db::test_compute_tag<
-      GeneralizedHarmonic::Tags::ConstraintGamma1Compute<3, Frame::Inertial>>(
-      "ConstraintGamma1");
+      GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1Compute<
+          3, Frame::Inertial>>("ConstraintGamma1");
   TestHelpers::db::test_compute_tag<
-      GeneralizedHarmonic::Tags::ConstraintGamma2Compute<3, Frame::Inertial>>(
-      "ConstraintGamma2");
+      GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2Compute<
+          3, Frame::Inertial>>("ConstraintGamma2");
   TestHelpers::db::test_compute_tag<
       GeneralizedHarmonic::Tags::GaugeHImplicitFrom3p1QuantitiesCompute<
           3, Frame::Inertial>>("GaugeH");
@@ -865,16 +866,16 @@ void test_constraint_compute_items(
           ::Tags::deriv<GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
                         tmpl::size_t<3>, Frame::Inertial>>,
       db::AddComputeTags<
-          GeneralizedHarmonic::Tags::ConstraintGamma0Compute<3,
-                                                             Frame::Inertial>,
-          GeneralizedHarmonic::Tags::ConstraintGamma1Compute<3,
-                                                             Frame::Inertial>,
-          GeneralizedHarmonic::Tags::ConstraintGamma2Compute<3,
-                                                             Frame::Inertial>,
+          GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma0Compute<
+              3, Frame::Inertial>,
+          GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1Compute<
+              3, Frame::Inertial>,
+          GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2Compute<
+              3, Frame::Inertial>,
           gr::Tags::SpacetimeNormalOneFormCompute<3, Frame::Inertial,
                                                   DataVector>,
-          gr::Tags::SpacetimeNormalVectorCompute<3,
-                                                 Frame::Inertial, DataVector>,
+          gr::Tags::SpacetimeNormalVectorCompute<3, Frame::Inertial,
+                                                 DataVector>,
           gr::Tags::DetAndInverseSpatialMetricCompute<3, Frame::Inertial,
                                                       DataVector>,
           gr::Tags::InverseSpacetimeMetricCompute<3, Frame::Inertial,
@@ -910,13 +911,13 @@ void test_constraint_compute_items(
 
   // Compute tested quantities locally
   Scalar<DataVector> gamma0{};
-  GeneralizedHarmonic::Tags::ConstraintGamma0Compute<
+  GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma0Compute<
       3, Frame::Inertial>::function(make_not_null(&gamma0), x);
   Scalar<DataVector> gamma1{};
-  GeneralizedHarmonic::Tags::ConstraintGamma1Compute<
+  GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1Compute<
       3, Frame::Inertial>::function(make_not_null(&gamma1), x);
   Scalar<DataVector> gamma2{};
-  GeneralizedHarmonic::Tags::ConstraintGamma2Compute<
+  GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2Compute<
       3, Frame::Inertial>::function(make_not_null(&gamma2), x);
 
   const auto four_index_constraint =
@@ -940,9 +941,12 @@ void test_constraint_compute_items(
       det_spatial_metric);
 
   // Check that their compute items in databox furnish identical values
-  CHECK(db::get<GeneralizedHarmonic::Tags::ConstraintGamma0>(box) == gamma0);
-  CHECK(db::get<GeneralizedHarmonic::Tags::ConstraintGamma1>(box) == gamma1);
-  CHECK(db::get<GeneralizedHarmonic::Tags::ConstraintGamma2>(box) == gamma2);
+  CHECK(db::get<GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma0>(
+            box) == gamma0);
+  CHECK(db::get<GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1>(
+            box) == gamma1);
+  CHECK(db::get<GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2>(
+            box) == gamma2);
   CHECK(db::get<GeneralizedHarmonic::Tags::GaugeH<3, Frame::Inertial>>(box) ==
         gauge_source);
   CHECK(

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Tags.cpp
@@ -5,6 +5,8 @@
 
 #include <string>
 
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 
@@ -18,11 +20,14 @@ void test_simple_tags() {
       "Pi");
   TestHelpers::db::test_simple_tag<GeneralizedHarmonic::Tags::Phi<Dim, Frame>>(
       "Phi");
-  TestHelpers::db::test_simple_tag<GeneralizedHarmonic::Tags::ConstraintGamma0>(
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma0>(
       "ConstraintGamma0");
-  TestHelpers::db::test_simple_tag<GeneralizedHarmonic::Tags::ConstraintGamma1>(
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1>(
       "ConstraintGamma1");
-  TestHelpers::db::test_simple_tag<GeneralizedHarmonic::Tags::ConstraintGamma2>(
+  TestHelpers::db::test_simple_tag<
+      GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2>(
       "ConstraintGamma2");
   TestHelpers::db::test_simple_tag<
       GeneralizedHarmonic::Tags::GaugeH<Dim, Frame>>("GaugeH");

--- a/tests/Unit/Helpers/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TestHelpers.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TestHelpers.hpp
@@ -78,7 +78,7 @@ void check_impl(
 template <class DampingFunctionType, class T, class... MemberArgs>
 void check(std::unique_ptr<DampingFunctionType> in_gh_damping_function,
            const std::string& python_function_prefix, const T& used_for_size,
-           const std::array<std::pair<double, double>, 1> random_value_bounds,
+           const std::array<std::pair<double, double>, 1>& random_value_bounds,
            const MemberArgs&... member_args) noexcept {
   detail::check_impl(
       std::unique_ptr<
@@ -93,7 +93,7 @@ void check(std::unique_ptr<DampingFunctionType> in_gh_damping_function,
 template <class DampingFunctionType, class T, class... MemberArgs>
 void check(DampingFunctionType in_gh_damping_function,
            const std::string& python_function_prefix, const T& used_for_size,
-           const std::array<std::pair<double, double>, 1> random_value_bounds,
+           const std::array<std::pair<double, double>, 1>& random_value_bounds,
            const MemberArgs&... member_args) noexcept {
   detail::check_impl(
       std::unique_ptr<

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
@@ -23,6 +23,7 @@
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/LogicalCoordinates.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
@@ -734,14 +735,14 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.GhQuantities",
       GeneralizedHarmonic::Tags::TraceExtrinsicCurvatureCompute<
           3, Frame::Inertial>>("TraceExtrinsicCurvature");
   TestHelpers::db::test_compute_tag<
-      GeneralizedHarmonic::Tags::ConstraintGamma0Compute<3, Frame::Inertial>>(
-      "ConstraintGamma0");
+      GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma0Compute<
+          3, Frame::Inertial>>("ConstraintGamma0");
   TestHelpers::db::test_compute_tag<
-      GeneralizedHarmonic::Tags::ConstraintGamma1Compute<3, Frame::Inertial>>(
-      "ConstraintGamma1");
+      GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1Compute<
+          3, Frame::Inertial>>("ConstraintGamma1");
   TestHelpers::db::test_compute_tag<
-      GeneralizedHarmonic::Tags::ConstraintGamma2Compute<3, Frame::Inertial>>(
-      "ConstraintGamma2");
+      GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2Compute<
+          3, Frame::Inertial>>("ConstraintGamma2");
   TestHelpers::db::test_compute_tag<
       GeneralizedHarmonic::Tags::SpacetimeDerivGaugeHCompute<3,
                                                              Frame::Inertial>>(


### PR DESCRIPTION
## Proposed changes

For the generalized harmonic system, this PR replaces hard-coded constraint damping parameter functions with DampingFunctions whose parameters are specified in the yaml input file. The value of the parameters in the unit tests and in KerrSchild.yaml are the same as the previously hard-coded values, which originally came from SpEC input files for a single black hole.

Since the constraint damping functions now live in a namespace GeneralizedHarmonic::ConstraintDamping, this PR also moves the other tags relevant to constraint damping parameters from GeneralizedHarmonic into GeneralizedHarmonic::ConstraintDamping.

Note: the DampingFunctions currently are constant in time. A future PR will make DampingFunctions aware of FunctionsOfTime, so that, e.g., you can scale the damping parameters by the expansion factor (as SpEC does for binary black hole mergers).

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
