### PR TITLE
Add automatic versioning

### DIFF
--- a/.github/scripts/Release.py
+++ b/.github/scripts/Release.py
@@ -1,0 +1,554 @@
+#!/usr/bin/env python
+
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import difflib
+import git
+import logging
+import operator
+import os
+import pathlib
+import re
+import requests
+import tempfile
+import uplink
+import urllib
+import yaml
+
+logger = logging.getLogger(__name__)
+
+VERSION_PATTERN = r'(\d{4})\.(\d{2})\.(\d{2})(\.\d+)?'
+PUBLICATION_DATE_PATTERN = r'\d{4}-\d{2}-\d{2}'
+DOI_PATTERN = r'10\.\d{4,9}/zenodo\.\d+'
+ZENODO_ID_PATTERN = r'\d+'
+
+
+def report_check_only(msg: str):
+    logger.info(f"CHECK ONLY: {msg}")
+
+
+def new_version_id_from_response(response):
+    """Retrieves the ID of the new version draft from the API response
+
+    The "New version" action of the Zenodo API returns the ID of the created
+    version draft in the 'links' section, as documented
+    [here](https://developers.zenodo.org/#new-version). This function parses the
+    ID out of the link.
+    """
+    new_version_url = response.json()['links']['latest_draft']
+    return int(
+        pathlib.PurePosixPath(
+            urllib.parse.urlparse(new_version_url).path).parts[-1])
+
+
+def raise_for_status(response):
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as err:
+        if response.status_code >= 400 and response.status_code < 500:
+            raise requests.exceptions.HTTPError(
+                yaml.safe_dump(response.json(), allow_unicode=True)) from err
+        else:
+            raise
+    return response
+
+
+@uplink.response_handler(raise_for_status)
+class Zenodo(uplink.Consumer):
+    """Abstraction of the [Zenodo API](https://developers.zenodo.org)"""
+
+    @uplink.returns.json
+    @uplink.get('deposit/depositions/{id}')
+    def get_deposition(self, id: uplink.Path):
+        """Retrieves a deposition by ID."""
+        pass
+
+    @uplink.returns.json
+    @uplink.get('records/{id}')
+    def get_record(self, id: uplink.Path):
+        """Retrieves a published record by ID."""
+        pass
+
+    @uplink.returns.json(key=('metadata', 'relations', 'version', 0,
+                              'last_child', 'pid_value'),
+                         type=int)
+    @uplink.get('records/{id}')
+    def get_latest_version_id(self, record_id: uplink.Path(name='id')):
+        """Retrieves only the latest version ID of a record."""
+        pass
+
+    @uplink.response_handler(new_version_id_from_response)
+    @uplink.post('deposit/depositions/{id}/actions/newversion')
+    def new_version(self, latest_version_id: uplink.Path(name='id')):
+        """Invoke the "New version" action on a deposition.
+
+        Returns:
+          The ID of the new version.
+        """
+        pass
+
+    @uplink.returns.json
+    @uplink.post('deposit/depositions/{id}/actions/publish')
+    def publish(self, id: uplink.Path):
+        """Invoke the "Publish" action on a deposition."""
+        pass
+
+    @uplink.json
+    @uplink.returns.json
+    @uplink.put('deposit/depositions/{id}')
+    def update_deposition(self, id: uplink.Path, **body: uplink.Body):
+        """Update the deposition with the metadata"""
+        pass
+
+    @uplink.returns.json
+    @uplink.put('files/{bucket_id}/{filename}')
+    def upload_file(self, bucket_id: uplink.Path, filename: uplink.Path,
+                    file: uplink.Body):
+        """Uploads a file to the bucket."""
+        pass
+
+
+@uplink.response_handler(raise_for_status)
+class Github(uplink.Consumer):
+    """Abstraction of the [GitHub REST API](https://docs.github.com/en/rest)"""
+
+    # This endpoint is not currently implemented in PyGithub, so we wrap it
+    # here manually
+    @uplink.headers({'Content-Type': 'text/x-markdown'})
+    @uplink.response_handler(operator.attrgetter('text'))
+    @uplink.post('markdown/raw')
+    def render_markdown_raw(self, text: uplink.Body):
+        """Render Markdown in plain format like a README.md file on GitHub"""
+        pass
+
+    @uplink.returns.json
+    @uplink.get('repos/{user}/{repo}/releases/tags/{tag}')
+    def get_release_by_tag(self, user: uplink.Path, repo: uplink.Path,
+                           tag: uplink.Path):
+        pass
+
+    @uplink.returns.json
+    @uplink.get('repos/{user}/{repo}/releases/{release_id}/assets')
+    def get_assets(self, user: uplink.Path, repo: uplink.Path,
+                   release_id: uplink.Path):
+        pass
+
+
+def collect_zenodo_metadata(metadata: dict, github: Github) -> dict:
+    """Produces the metadata that we send to Zenodo
+
+    Args:
+      metadata: The project metadata read from the YAML file. This is the main
+        source of information for this function.
+      github: The GitHub API client. We use it to render the description to
+        HTML in a way that's consistent with GitHub's rendering.
+
+    Returns:
+      Metadata in the format that the Zenodo API expects.
+    """
+    # Generate the DOI author list from the authors in the project metadata
+    zenodo_creators = []
+    for author_tier in ['Core', 'Developers', 'Contributors']:
+        for author in metadata['Authors'][author_tier]['List']:
+            zenodo_creator = dict(name=author['Name'])
+            if 'Orcid' in author:
+                zenodo_creator['orcid'] = author['Orcid']
+            if 'Affiliations' in author and len(author['Affiliations']) > 0:
+                zenodo_creator['affiliation'] = ' and '.join(
+                    author['Affiliations'])
+            zenodo_creators.append(zenodo_creator)
+    # Render the description to HTML
+    rendered_description = github.render_markdown_raw(metadata['Description'])
+    # Construct Zenodo metadata
+    return dict(title=metadata['Name'],
+                version=metadata['Version'],
+                publication_date=metadata['PublicationDate'],
+                doi=metadata['Doi'],
+                description=rendered_description,
+                creators=zenodo_creators,
+                related_identifiers=[
+                    dict(identifier=metadata['Homepage'],
+                         relation='isDocumentedBy',
+                         scheme='url',
+                         resource_type='publication-softwaredocumentation'),
+                    dict(identifier=('https://github.com/' +
+                                     metadata['GitHub']),
+                         relation='isSupplementTo',
+                         scheme='url',
+                         resource_type='software')
+                ],
+                language='eng',
+                communities=[dict(identifier='sxs')],
+                keywords=metadata['Keywords'],
+                license=metadata['License'],
+                upload_type='software',
+                access_right='open')
+
+
+def prepare(metadata: dict, version_name: str, metadata_file: str,
+            readme_file: str, zenodo: Zenodo, github: Github,
+            update_only: bool, check_only: bool):
+    # Validate new version name
+    match_version_name = re.match(VERSION_PATTERN + '$', version_name)
+    if not match_version_name:
+        raise ValueError(f"Version name '{version_name}' doesn't match "
+                         f"pattern '{VERSION_PATTERN}'.")
+    publication_date = '{}-{}-{}'.format(*match_version_name.groups()[:3])
+
+    if update_only:
+        # Don't try to create a new version draft on Zenodo but update the
+        # existing one. We assume that the metadata in the repository already
+        # point to the existing version draft on Zenodo that we want to update.
+        # This is the case when the user has run this script without the
+        # `--update-only` option before and has thus created the new version
+        # draft on Zenodo, and is now running it again with the `--update-only`
+        # option to push updated metadata to the draft.
+        new_version_id = metadata['ZenodoId']
+    else:
+        # Zenodo doesn't have a draft for the new version yet, or the metadata
+        # in the repository is not yet updated. Either way, we use the ID from
+        # the metadata to obtain the latest version on Zenodo and create a new
+        # draft. Zenodo doesn't create another draft if one already exists, but
+        # just returns it.
+        latest_version_id = metadata['ZenodoId']
+        try:
+            latest_version_id_on_zenodo = zenodo.get_latest_version_id(
+                record_id=latest_version_id)
+        except requests.exceptions.HTTPError as err:
+            raise requests.exceptions.HTTPError(
+                f"No published record with ID {latest_version_id} found on "
+                "Zenodo. Use the '--update-only' flag if you're re-running "
+                "the script over a repository that already has an unpublished "
+                "new version ID inserted into Metadata.yaml.") from err
+        assert latest_version_id == latest_version_id_on_zenodo, (
+            "The latest Zenodo version ID in the repository is "
+            f"{latest_version_id}, but Zenodo "
+            f"reports {latest_version_id_on_zenodo}.")
+        logger.info(f"The latest Zenodo version ID is {latest_version_id}.")
+        # Reserve a DOI by creating a new version on Zenodo. It will remain a
+        # draft until we publish it in the `publish` subprogram.
+        if check_only:
+            report_check_only("Would create new version on Zenodo with "
+                              f"ID {latest_version_id}.")
+            new_version_id = latest_version_id
+        else:
+            new_version_id = zenodo.new_version(
+                latest_version_id=latest_version_id)
+    new_version_draft = zenodo.get_deposition(id=new_version_id)
+    new_version_doi = new_version_draft['doi']
+    assert new_version_doi, (
+        "Zenodo did not return a reserved DOI for the new version draft. "
+        "You may want to visit {} to reserve one, save the draft and re-run "
+        "this script with the '--update-only' flag.").format(
+            new_version_draft['links']['html'])
+    logger.info(f"The new version draft on Zenodo has "
+                f"ID {new_version_id} and DOI {new_version_doi}.")
+
+    # Insert the new version information into the metadata file. We have to
+    # resort to regex-replacements because pyyaml doesn't support
+    # format-preserving round-trips.
+    def replace_in_yaml(content, key, value, validate_value_pattern):
+        content, num_subs = re.subn(r'^{}: {}$'.format(key,
+                                                       validate_value_pattern),
+                                    r'{}: {}'.format(key, value),
+                                    content,
+                                    flags=re.MULTILINE)
+        if num_subs == 0:
+            match = re.search(r'^{}: (.*)$'.format(key),
+                              content,
+                              flags=re.MULTILINE)
+            if match:
+                raise ValueError(
+                    f"The value of '{key}' in the file '{metadata_file}' "
+                    f"does not match the pattern '{validate_value_pattern}': "
+                    f"{match.group(1)}")
+            else:
+                raise ValueError(f"Could not find '{key}' in root of "
+                                 f"file '{metadata_file}'.")
+        elif num_subs > 1:
+            raise ValueError(f"Found more than one '{key}' in "
+                             f"file '{metadata_file}'.")
+        return content
+
+    with open(metadata_file,
+              'r' if check_only else 'r+') as open_metadata_file:
+        content_original = open_metadata_file.read()
+        content_new = replace_in_yaml(content_original, 'Version',
+                                      version_name, VERSION_PATTERN)
+        content_new = replace_in_yaml(content_new, 'PublicationDate',
+                                      publication_date,
+                                      PUBLICATION_DATE_PATTERN)
+        content_new = replace_in_yaml(content_new, 'Doi', new_version_doi,
+                                      DOI_PATTERN)
+        content_new = replace_in_yaml(content_new, 'ZenodoId', new_version_id,
+                                      ZENODO_ID_PATTERN)
+        content_diff = '\n'.join(
+            difflib.context_diff(content_original.split('\n'),
+                                 content_new.split('\n'),
+                                 lineterm='',
+                                 fromfile=metadata_file,
+                                 tofile=metadata_file))
+        if check_only:
+            report_check_only(f"Would apply diff:\n{content_diff}")
+        else:
+            logger.debug(f"Applying diff:\n{content_diff}")
+            open_metadata_file.seek(0)
+            open_metadata_file.write(content_new)
+            open_metadata_file.truncate()
+    logger.info(f"Inserted new version info into '{metadata_file}'.")
+    # Also update the the metadata dict to make sure we don't accidentally use
+    # the old values somewhere
+    metadata['Version'] = version_name
+    metadata['PublicationDate'] = publication_date
+    metadata['Doi'] = new_version_doi
+    metadata['ZenodoId'] = new_version_id
+
+    # Insert the new version information into the README
+    def replace_badge_in_readme(content, key, image_url, link_url):
+        content, num_subs = re.subn(r'\[!\[{}\]\(.*\)\]\(.*\)'.format(key),
+                                    r'[![{}]({})]({})'.format(
+                                        key, image_url, link_url),
+                                    content,
+                                    flags=re.MULTILINE)
+        assert num_subs > 0, (f"Could not find badge '{key}' in "
+                              f"file '{readme_file}'.")
+        return content
+
+    def replace_doi_in_readme(content, doi, doi_url):
+        content, num_subs = re.subn(r'DOI: \[{}\]\(.*\)'.format(DOI_PATTERN),
+                                    r'DOI: [{}]({})'.format(doi, doi_url),
+                                    content,
+                                    flags=re.MULTILINE)
+        assert num_subs > 0, (
+            "Could not find DOI (matching '{}') with link in file '{}'.".
+            format(DOI_PATTERN, readme_file))
+        return content
+
+    def replace_link_in_readme(content, link_text, link_url):
+        content, num_subs = re.subn(r'\[{}\]\(.*\)'.format(link_text),
+                                    r'[{}]({})'.format(link_text, link_url),
+                                    content,
+                                    flags=re.MULTILINE)
+        assert num_subs > 0, (
+            f"Could not find link with text '{link_text}' in "
+            f"file '{readme_file}'.")
+        return content
+
+    with open(readme_file, 'r' if check_only else 'r+') as open_readme_file:
+        content = open_readme_file.read()
+        content = replace_badge_in_readme(
+            content, 'release',
+            f'https://img.shields.io/badge/release-v{version_name}-informational',
+            'https://github.com/{}/releases/tag/v{}'.format(
+                metadata['GitHub'], version_name))
+        content = replace_badge_in_readme(content, 'DOI',
+                                          new_version_draft['links']['badge'],
+                                          new_version_draft['links']['doi'])
+        content = replace_link_in_readme(
+            content, "Find BibTeX entry for this version on Zenodo",
+            f'https://zenodo.org/record/{new_version_id}/export/hx')
+        content = replace_doi_in_readme(content, new_version_doi,
+                                        new_version_draft['links']['doi'])
+        if not check_only:
+            open_readme_file.seek(0)
+            open_readme_file.write(content)
+            open_readme_file.truncate()
+
+    # Upload the updated metadata to Zenodo
+    zenodo_metadata = collect_zenodo_metadata(metadata, github)
+    logger.debug("The metadata we'll send to Zenodo are:\n{}".format(
+        yaml.safe_dump(zenodo_metadata, allow_unicode=True)))
+    if check_only:
+        report_check_only("Would upload metadata to Zenodo.")
+    else:
+        zenodo.update_deposition(id=new_version_id, metadata=zenodo_metadata)
+    logger.debug(("New Zenodo version draft is now prepared. You can edit "
+                  "it here:\n{}").format(new_version_draft['links']['html']))
+
+
+def publish(metadata: dict, zenodo: Zenodo, github: Github, auto_publish: bool,
+            check_only: bool):
+    version_name = metadata['Version']
+    new_version_id = metadata['ZenodoId']
+
+    # Retrieve the Zenodo deposition for the version draft that we have
+    # prepared before
+    new_version_draft = zenodo.get_deposition(id=new_version_id)
+
+    # Retrieve the file "bucket" ID for uploading data
+    bucket_id = pathlib.PurePosixPath(
+        urllib.parse.urlparse(
+            new_version_draft['links']['bucket']).path).parts[-1]
+
+    # Retrieve the URL of the GitHub release archive that we want to upload
+    # to Zenodo
+    gh_user, gh_repo = metadata['GitHub'].split('/')
+    # Alternatively we could use the release ID that GitHub's
+    # 'actions/create-release' returns to retrieve the release
+    gh_release = github.get_release_by_tag(user=gh_user,
+                                           repo=gh_repo,
+                                           tag='v' + version_name)
+    logger.debug("The release on GitHub is:\n{}".format(
+        yaml.safe_dump(gh_release, allow_unicode=True)))
+    zipball_url = gh_release['zipball_url']
+
+    # Stream the release archive to Zenodo.
+    # We keep the file name for the archive on Zenodo the same for each
+    # release so we can just overwrite it. Note that the _unpacked_ directory
+    # name contains the version as expected, since the unpacked directory name
+    # is determined by the GitHub release.
+    archive_filename = gh_repo + '.zip'
+    if check_only:
+        report_check_only(
+            f"Would stream release zipball '{zipball_url}' as "
+            f"filename '{archive_filename}' to bucket '{bucket_id}'.")
+    else:
+        # Download the zipball from GitHub, then upload to Zenodo.
+        # Note: Something like this should also work to stream the file
+        # directly from GitHub to Zenodo without temporarily saving it, but
+        # Zenodo doesn't currently document their new "bucket" file API so it
+        # is difficult to debug:
+        # with requests.get(zipball_url, stream=True) as zipball_stream:
+        #     zipball_stream.raise_for_status()
+        #     uploaded_file = zenodo.upload_file(bucket_id=bucket_id,
+        #                                        file=zipball_stream,
+        #                                        filename=archive_filename)
+        zipball_download = requests.get(zipball_url, stream=True)
+        with tempfile.TemporaryFile() as open_tmp_file:
+            for chunk in zipball_download.iter_content():
+                open_tmp_file.write(chunk)
+            open_tmp_file.seek(0)
+            uploaded_file = zenodo.upload_file(bucket_id=bucket_id,
+                                               file=open_tmp_file,
+                                               filename=archive_filename)
+        logger.debug("Release archive upload complete:\n{}".format(
+            yaml.safe_dump(uploaded_file, allow_unicode=True)))
+
+    # Publish!
+    if auto_publish:
+        if check_only:
+            report_check_only(
+                f"Would publish Zenodo record {new_version_id} now!")
+        else:
+            published_record = zenodo.publish(id=new_version_id)
+            logger.debug("Zenodo record published:\n{}".format(
+                yaml.safe_dump(published_record, allow_unicode=True)))
+            logger.info(("Zenodo record is now public! Here's the link to the "
+                         "record:\n{}").format(
+                             published_record['links']['record_html']))
+    else:
+        logger.info(
+            ("Release is ready to be published on Zenodo. Go to this "
+             "website, make sure everything looks fine and then hit the "
+             "'Publish' button:\n{}").format(
+                 new_version_draft['links']['html']))
+
+
+if __name__ == "__main__":
+    # Always work with the repository that contains this file
+    repo = git.Repo(__file__, search_parent_directories=True)
+
+    import argparse
+    parser = argparse.ArgumentParser(description=(
+        "Prepare the repository and publish releases on Zenodo as part of the "
+        "automatic versioning procedure. This script is not intended to be run "
+        "outside of GitHub actions. The 'prepare' subprogram reserves a "
+        "DOI on Zenodo and inserts it into the repository along with the new "
+        "version name. Once the release archive has been created, the 'publish'"
+        f"subprogram uploads it to Zenodo. Repository: {repo.working_dir}."))
+    parent_parser = argparse.ArgumentParser(add_help=False)
+    parent_parser.add_argument(
+        '--zenodo-token',
+        required=True,
+        help=("Zenodo access token. Refer to the Zenodo documentation "
+              "for instructions on creating a personal access token."))
+    parent_parser.add_argument(
+        '--zenodo-sandbox',
+        action='store_true',
+        help=("Use the Zenodo sandbox instead of the public version of Zenodo"))
+    parent_parser.add_argument(
+        '--github-token',
+        required=False,
+        help=
+        ("Access token for GitHub queries. Refer to the GitHub documentation "
+         "for instructions on creating a personal access token."))
+    parent_parser.add_argument('-v',
+                               '--verbose',
+                               action='count',
+                               default=0,
+                               help="Verbosity (-v, -vv, ...)")
+    parent_parser.add_argument(
+        '--check-only',
+        action='store_true',
+        help=
+        ("Dry mode, only check that all files are consistent. Nothing is "
+         "edited or uploaded to Zenodo. Used in CI tests to make sure changes "
+         "to the repository remain compatible with this script."))
+    subparsers = parser.add_subparsers()
+    parser_prepare = subparsers.add_parser('prepare', parents=[parent_parser])
+    parser_prepare.set_defaults(subprogram=prepare)
+    parser_prepare.add_argument(
+        '--update-only',
+        action='store_true',
+        help=(
+            "Only update an existing version draft on Zenodo, not creating a "
+            "new one. Use this flag if the metadata in the repository already "
+            "reference the new version draft on Zenodo."))
+    parser_prepare.add_argument(
+        '--version-name',
+        required=False,
+        help=("The name of the new version. Will be inserted into the "
+              "'--metadata-file'. Required unless '--check-only'."))
+    parser_publish = subparsers.add_parser('publish', parents=[parent_parser])
+    parser_publish.set_defaults(subprogram=publish)
+    parser_publish.add_argument(
+        '--auto-publish',
+        action='store_true',
+        help=("Publish the Zenodo record once it's ready. "
+              "WARNING: Published records cannot be deleted and editing is "
+              "limited. Omit this argument to print out the link to the "
+              "prepared draft on Zenodo so you can do a manual sanity-check "
+              "before publishing it."))
+    args = parser.parse_args()
+
+    # Set the log level
+    logging.basicConfig(level=logging.WARNING - args.verbose * 10)
+    del args.verbose
+
+    # Load the project metadata
+    metadata_file = os.path.join(repo.working_dir, 'Metadata.yaml')
+    args.metadata = yaml.safe_load(open(metadata_file, 'r'))
+    if args.subprogram == prepare:
+        args.metadata_file = metadata_file
+
+    # Make passing a version name optional in check-only mode
+    if args.subprogram == prepare:
+        assert args.check_only or args.version_name, (
+            "The '--version-name' argument is required unless you run in "
+            "'--check-only' mode.")
+        if args.check_only and not args.version_name:
+            args.version_name = args.metadata['Version']
+
+    # Locate the project README
+    if args.subprogram == prepare:
+        args.readme_file = os.path.join(repo.working_dir, 'README.md')
+
+    # Configure the Zenodo API client
+    args.zenodo = Zenodo(
+        base_url=('https://sandbox.zenodo.org/api/'
+                  if args.zenodo_sandbox else 'https://zenodo.org/api/'),
+        auth=uplink.auth.BearerToken(args.zenodo_token))
+    del args.zenodo_sandbox
+    del args.zenodo_token
+
+    # Configure the GitHub API client
+    args.github = Github(base_url='https://api.github.com/',
+                         auth=(uplink.auth.BearerToken(args.github_token)
+                               if args.github_token else None))
+    del args.github_token
+
+    # Dispatch to the selected subprogram
+    subprogram = args.subprogram
+    del args.subprogram
+    subprogram(**vars(args))

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -1,7 +1,8 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-# Continuous integration tests that pull requests are required to pass
+# Continuous integration tests that pull requests are required to pass. This
+# workflow also triggers a version release every month.
 name: Tests
 
 # Set any defaults for the runs below.
@@ -28,6 +29,23 @@ on:
   push:
     branches-ignore:
       - gh-pages
+  # Once a month we run the tests and release a new version (see the dev guide
+  # on "Automatic versioning"). The scheduled workflow always runs on the
+  # repository's default branch (`develop`).
+  # The automatic versioning is not yet enabled so we have some time to test the
+  # release workflow. Releases can be created with the `workflow_dispatch`
+  # trigger (see below).
+  # schedule:
+  #   - cron: '0 0 1 * *'
+  # Also allow running the workflow manually. This can be used to manually
+  # release a version. (see the dev guide on "Automatic versioning")
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: >
+          Enter a version name YYYY.MM.DD[.TWEAK] to create a release on success
+        required: false
+        default: ''
 
 jobs:
   # Make sure no commits are prefixed with `fixup` or similar keywords. See
@@ -83,7 +101,10 @@ jobs:
         run: |
           pip3 install \
             GitPython~=3.1.11 \
+            PyGithub~=1.53 \
             PyYAML~=5.3.1 \
+            tqdm~=4.51.0 \
+            uplink~=0.9.2
       - name: Test tools
         run: |
           python3 -m unittest discover -p 'Test_*' tests.tools -v
@@ -102,6 +123,24 @@ jobs:
       - name: Check metadata
         run: |
           python3 tools/CheckMetadata.py
+      - name: Check the metadata is consistent with the releases
+        # No need to check this on forks. They would need to set a Zenodo token
+        # for this test. Also disable on PRs because they don't have access to
+        # the repo's secrets.
+        if: >
+          github.repository == 'sxs-collaboration/spectre'
+            && github.event_name != 'pull_request'
+        run: |
+          python3 .github/scripts/Release.py prepare -vv --check-only \
+            --zenodo-token ${{ secrets.ZENODO_READONLY_TOKEN }} \
+            --github-token ${{ secrets.GITHUB_TOKEN }}
+          python3 .github/scripts/Release.py publish -vv --check-only \
+            --zenodo-token ${{ secrets.ZENODO_READONLY_TOKEN }} \
+            --github-token ${{ secrets.GITHUB_TOKEN }}
+      - name: Check release notes
+        run: |
+          python3 tools/CompileReleaseNotes.py -vv \
+            --github-token ${{ secrets.GITHUB_TOKEN }}
 
   # Lint with clang-tidy. We check only code that changed relative to the
   # nearest common ancestor commit with `sxs-collaboration/spectre/develop`.
@@ -508,3 +547,139 @@ jobs:
           make EvolveBurgersStep -j2
 
           ctest -j2 -R InputFiles.Burgers.Step.yaml
+
+  # Release a new version on scheduled or manual events when the tests pass.
+  # Only enable this on the `sxs-collaboration/spectre` repository (not on
+  # forks).
+  release_version:
+    name: Release version
+    runs-on: ubuntu-latest
+    # Run in the container so we can build docs and tests
+    container:
+      image: sxscollaboration/spectrebuildenv:latest
+    if: >
+      github.repository == 'sxs-collaboration/spectre' &&
+        github.ref == 'refs/heads/develop' &&
+        (github.event_name == 'schedule'
+          || (github.event_name == 'workflow_dispatch'
+            && github.event.inputs.release_version != ''))
+    needs:
+      - check_files_and_formatting
+      - doc_check
+      - unit_tests
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install Python dependencies
+        run: |
+          pip3 install \
+            GitPython~=3.1.11 \
+            PyGithub~=1.53 \
+            PyYAML~=5.3.1 \
+            tqdm~=4.51.0 \
+            uplink~=0.9.2
+      # We use the current date as tag name, unless a tag name was specified
+      # as input to the `workflow_dispatch` event
+      - name: Determine release version
+        id: get_version
+        run: |
+          INPUT_RELEASE_VERSION=${{ github.event.inputs.release_version }}
+          RELEASE_VERSION=${INPUT_RELEASE_VERSION:-$(date +'%Y.%m.%d')}
+          echo "Release version is: ${RELEASE_VERSION}"
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
+      - name: Validate release version
+        run: |
+          VERSION_PATTERN="^([0-9]{4})\.([0-9]{2})\.([0-9]{2})(\.[0-9]+)?$"
+          if [[ $RELEASE_VERSION =~ $VERSION_PATTERN ]]; then
+            if [ $(date +'%Y') != ${BASH_REMATCH[1]} ] ||
+            [ $(date +'%m') != ${BASH_REMATCH[2]} ] ||
+            [ $(date +'%d') != ${BASH_REMATCH[3]} ]; then
+              TODAY=$(date +'%Y.%m.%d')
+              echo "'$RELEASE_VERSION' doesn't match current date '$TODAY'"
+            fi
+          else
+            echo "'$RELEASE_VERSION' doesn't match '$VERSION_PATTERN'"
+            exit 1
+          fi
+          if [ $(git tag -l "v$RELEASE_VERSION") ]; then
+            echo "Tag 'v$RELEASE_VERSION' already exists"
+            exit 1
+          fi
+          if [ $(git rev-parse HEAD) == $(git rev-parse origin/release) ]; then
+            echo "Nothing changed since last release $(git describe release)."
+            exit 1
+          fi
+      - name: Reserve Zenodo DOI and prepare repository
+        run: |
+          python3 .github/scripts/Release.py prepare -vv \
+            --version $RELEASE_VERSION \
+            --zenodo-token ${{ secrets.ZENODO_READWRITE_TOKEN }} \
+            --github-token ${{ secrets.GITHUB_TOKEN }}
+          git diff
+      - name: Compile release notes
+        run: |
+          python3 tools/CompileReleaseNotes.py -v -o /work/release_notes.md \
+            --github-token ${{ secrets.GITHUB_TOKEN }}
+      # Push a commit with the new version to the branch we're on (should be
+      # `develop` unless the workflow was triggered manually on another branch).
+      # The push won't trigger the workflow again because GitHub prevents
+      # actions from triggering workflows (this uses the default GITHUB_TOKEN).
+      - name: Commit and push
+        run: |
+          git config user.name sxs-bot
+          git config user.email sxs-bot@black-holes.org
+          git commit -a -m "Prepare release $RELEASE_VERSION"
+          git show HEAD
+          git status
+          git push
+          git push origin HEAD:release
+      - name: Tag and release
+        uses: actions/create-release@v1
+        env:
+          # If we need this event to trigger other workflows we could use a
+          # personal access token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ env.RELEASE_VERSION }}
+          release_name: Release ${{ env.RELEASE_VERSION }}
+          body_path: /work/release_notes.md
+      # The release is now public on GitHub. We build the release documentation
+      # from the archive and also build an executable to make sure the archive
+      # is functional.
+      - name: Build release documentation and an executable
+        working-directory: /work
+        run: |
+          wget https://github.com/${{ github.repository }}/archive/v${RELEASE_VERSION}.tar.gz -O spectre.tar.gz
+          tar -xzf spectre.tar.gz && mv spectre-* spectre
+          mkdir build && cd build
+          cmake \
+            -D CMAKE_C_COMPILER=clang \
+            -D CMAKE_CXX_COMPILER=clang++ \
+            -D CMAKE_Fortran_COMPILER=gfortran-8 \
+            -D CHARM_ROOT=/work/charm_6_10_2/multicore-linux-x86_64-clang \
+            -D OVERRIDE_ARCH=x86-64 \
+            -D CMAKE_BUILD_TYPE=Release \
+            -D DEBUG_SYMBOLS=OFF \
+            ../spectre
+          make doc-check
+          make -j2 ExportCoordinates1D
+          ctest -R InputFiles.ExportCoordinates.Input1D.yaml.execute
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          publish_dir: /work/build/docs/html
+          cname: spectre-code.org
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          force_orphan: true
+      # This action currently doesn't publish the Zenodo record automatically.
+      # Instead it prints a link to the website where we can go and hit the
+      # "Publish" button when everything looks correct. Once we're convinced the
+      # automation works well enough we can add the `--auto-publish` flag to
+      # the command below.
+      - name: Publish to Zenodo
+        run: |
+          python3 .github/scripts/Release.py publish -vv \
+            --zenodo-token ${{ secrets.ZENODO_PUBLISH_TOKEN }} \
+            --github-token ${{ secrets.GITHUB_TOKEN }}

--- a/docs/DevGuide/AutomaticVersioning.md
+++ b/docs/DevGuide/AutomaticVersioning.md
@@ -1,0 +1,36 @@
+\cond NEVER
+Distributed under the MIT License.
+See LICENSE.txt for details.
+\endcond
+
+# Automatic versioning {#dev_guide_automatic_versioning}
+
+Our automated tests tag and publish a release automatically on a monthly
+schedule. The automation is implemented as a [GitHub
+Actions](https://docs.github.com/actions) workflow in the file
+`.github/workflows/Tests.yaml`.
+
+# Manually creating releases
+
+The GitHub workflow responsible for automatic versioning also allows creating
+a release manually. To create a release, follow the instructions to manually
+run a workflow:
+
+- [Manually running a workflow on GitHub](https://docs.github.com/actions/managing-workflow-runs/manually-running-a-workflow)
+
+To create a release you will have to run the workflow "Tests" on the `develop`
+branch _and_ type in a valid release version name. The workflow will only create
+the release if the version name matches the format defined above and if it
+matches the date at the time the "Release version" job runs.
+
+# Release notes
+
+The release notes are compiled automatically based on the activity in the
+repository since the last release. They will contain a list of merged
+pull-requests. Pull-requests labeled "major new feature" or "bugfix" on GitHub
+will be classified as such in the release notes.
+
+The script `tools/CompileReleaseNotes.py` generates the release notes and can
+also be invoked manually with a Python 3 interpreter to retrieve an overview of
+what happened in the repository recently. The script requires you install
+`GitPython`, `PyGithub` and `tqdm` in your Python environment.

--- a/docs/DevGuide/DevGuide.md
+++ b/docs/DevGuide/DevGuide.md
@@ -57,3 +57,8 @@ Assumes a thorough familiarity and fluency in SpECTRE's usage of TMP.
 ### CoordinateMap Guide
 Methods for creating custom coordinate maps are discussed here.
 - \ref redistributing_gridpoints "Methods for redistributing gridpoints"
+
+### Continuous Integration
+Explanations on our automated tests and deployments can be found here.
+
+- \ref dev_guide_automatic_versioning

--- a/tools/CompileReleaseNotes.py
+++ b/tools/CompileReleaseNotes.py
@@ -170,8 +170,7 @@ if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser(
         description=("Compile release notes based on merged pull-requests. "
-                     f"Repository: {repo.working_dir}. "
-                     f"Branch: {repo.active_branch}."),
+                     f"Repository: {repo.working_dir}."),
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
         '--output',
@@ -197,7 +196,7 @@ if __name__ == "__main__":
         dest='to_rev',
         default='HEAD',
         help=("Git revision that marks this release. Can be any commit SHA "
-              "or tag."))
+              "or tag. Defaults to 'HEAD'."))
     parser.add_argument(
         '--github-repository',
         required=False,


### PR DESCRIPTION
## Proposed changes

Adds automatic versioning to our CI, so a new release is published every month. A release can also be published manually by [dispatching the workflow from GitHub](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/). The releases look like this: https://github.com/nilsleiffischer/spectre/releases

Note that the script `CompileReleaseNotes.py` is actually also quite useful just for checking what happened to the repository since a particular commit. Try running this (with Py3):
```sh
pip install GitPython
python tools/CompileReleaseNotes.py --from HEAD~10
```

Here's what we'll need to do before merging this PR:

- [x] Choose a date on which we want to release the initial version. Put it in `Metadata.yaml`.
  **Edit:** I selected Dec 7th, 2020 for now.
- [x] Create a draft record on Zenodo so we have a pre-reserved DOI (don't publish yet). Put the DOI into `Metadata.yaml`.
  **Edit**: Here it is: https://doi.org/10.5281/zenodo.4290405. It's not public yet, but the link should start working once we publish it.
- [x] Merge a PR with the `Metadata.yaml` into the repository some time before the initial release date. This PR should be announced so everyone in the author list gets a chance to see it.
  **Edit:** Here it is: #2606 
- [x] Tag the merge commit from the `Metadata.yaml` PR with the initial version name.
- [x] Push the initial version tag to the `release` branch.
- [x] Create a GitHub release from the initial version tag.
- [x] Upload the release zipball to Zenodo. Also update the Zenodo record so it corresponds to the `Metadata.yaml` in the repo, we can use one of the scripts in this PR for that.
- [x] Publish the Zenodo record. The automatic versioning is now ready to take over! We can merge this PR.

At any time:

- [x] Create the labels `bugfix` (self-explanatory, these PRs get moved to the bottom of the release notes) and `major new feature` (to highlight just a few major PRs at the top of the release notes) and retro-actively apply these labels to appropriate PRs merged in November. Then use the labels somewhat consistently from now on. <s>Also consistently apply the `breaking change` label to PRs merged in November, though I'm not sure that label makes a lot of sense, since, as @nilsdeppe has regularly pointed out on these occasions, most changes are breaking for someone and it's even less clear where to draw the line between "breaking" and "non-breaking" than for "bugfix" and "major new feature".</s>

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
