### PR TITLE
Fix the function used to calculate the largest char speed for curved SWs

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/Characteristics.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Characteristics.cpp
@@ -9,6 +9,7 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
@@ -152,11 +153,15 @@ evolved_fields_from_characteristic_fields(
 
 template <size_t SpatialDim>
 double ComputeLargestCharacteristicSpeed<SpatialDim>::apply(
-    const std::array<DataVector, 4>& char_speeds) noexcept {
-  std::array<double, 4> max_speeds{
-      {max(abs(char_speeds[0])), max(abs(char_speeds[1])),
-       max(abs(char_speeds[2])), max(abs(char_speeds[3]))}};
-  return *std::max_element(max_speeds.begin(), max_speeds.end());
+    const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, SpatialDim, Frame::Inertial>& shift,
+    const tnsr::ii<DataVector, SpatialDim, Frame::Inertial>&
+        spatial_metric) noexcept {
+  const auto shift_magnitude = magnitude(shift, spatial_metric);
+  return std::max(
+      max(abs(1. + get(gamma_1)) * get(shift_magnitude)),  // v(VPsi)
+      max(get(shift_magnitude) +
+          abs(get(lapse))));  // v(VZero), v(VPlus),v(VMinus)
 }
 }  // namespace CurvedScalarWave
 

--- a/src/Evolution/Systems/CurvedScalarWave/Characteristics.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Characteristics.hpp
@@ -229,10 +229,29 @@ struct EvolvedFieldsFromCharacteristicFieldsCompute
 
 /*!
  * \brief Computes the largest magnitude of the characteristic speeds.
+ *
+ * \details Returns the magnitude of the largest characteristic speed
+ * along any direction at a given point in space, considering all
+ * characteristic fields. This is useful, for e.g., in computing the
+ * Courant factor. The coordinate characteristic speeds for this system are
+ * \f$\{-(1+\gamma_1)n_k N^k, -n_k N^k, -n_k N^k \pm N\}\f$. At any point
+ * in space, these are maximized when the normal vector is parallel to the
+ * shift vector, i.e. \f$ n^j = N^j / \sqrt{N^i N_i}\f$, and \f$ n_k N^k
+ * = g_{jk} N^j N^k / \sqrt{N^i N_i} = \sqrt{N^i N_i} =\f$
+ * `magnitude(shift, spatial_metric)`. The maximum characteristic speed
+ * is therefore calculated as \f$ \rm{max}(\vert 1+\gamma_1\vert\sqrt{N^i
+ * N_i},\, \sqrt{N^i N_i}+\vert N\vert) \f$.
  */
 template <size_t SpatialDim>
 struct ComputeLargestCharacteristicSpeed {
-  using argument_tags = tmpl::list<Tags::CharacteristicSpeeds<SpatialDim>>;
-  static double apply(const std::array<DataVector, 4>& char_speeds) noexcept;
+  using argument_tags = tmpl::list<
+      Tags::ConstraintGamma1, gr::Tags::Lapse<DataVector>,
+      gr::Tags::Shift<SpatialDim, Frame::Inertial, DataVector>,
+      gr::Tags::SpatialMetric<SpatialDim, Frame::Inertial, DataVector>>;
+  static double apply(
+      const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
+      const tnsr::I<DataVector, SpatialDim, Frame::Inertial>& shift,
+      const tnsr::ii<DataVector, SpatialDim, Frame::Inertial>&
+          spatial_metric) noexcept;
 };
 }  // namespace CurvedScalarWave

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_Characteristics.cpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cstddef>
+#include <limits>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
@@ -17,6 +18,9 @@
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Helpers/DataStructures/RandomUnitNormal.hpp"
+#include "Helpers/PointwiseFunctions/GeneralRelativity/TestHelpers.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 
 namespace {
@@ -229,34 +233,137 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Characteristics",
   test_characteristics_compute_tags<1>();
   test_characteristics_compute_tags<2>();
   test_characteristics_compute_tags<3>();
-
-  CHECK(CurvedScalarWave::ComputeLargestCharacteristicSpeed<1>::apply(
-            {{DataVector{1., -4., 3.4, 2., 5.},
-              DataVector{22., -8., 190., 6., 4.},
-              DataVector{1., -7., 31., 2., 5.},
-              DataVector{7., 8.9, 4., 2., 1.}}}) == 190.);
-  CHECK(CurvedScalarWave::ComputeLargestCharacteristicSpeed<1>::apply(
-            {{DataVector{1., 4., 3., 2., 5.}, DataVector{2., 8., -10., 6., 4.},
-              DataVector{1., 7., 3., -11., 5.},
-              DataVector{7., 3., 4., 2., 1.}}}) == 11.);
-
-  CHECK(CurvedScalarWave::ComputeLargestCharacteristicSpeed<2>::apply(
-            {{DataVector{1., -4., 3.4, 2., 5.},
-              DataVector{22., -8., 190., 6., 4.},
-              DataVector{1., -7., 31., 2., 5.},
-              DataVector{7., 8.9, 4., 2., 1.}}}) == 190.);
-  CHECK(CurvedScalarWave::ComputeLargestCharacteristicSpeed<2>::apply(
-            {{DataVector{1., 4., 3., 2., 5.}, DataVector{2., 8., -10., 6., 4.},
-              DataVector{1., 7., 3., -11., 5.},
-              DataVector{7., 3., 4., 2., 1.}}}) == 11.);
-
-  CHECK(CurvedScalarWave::ComputeLargestCharacteristicSpeed<3>::apply(
-            {{DataVector{1., -4., 3.4, 2., 5.},
-              DataVector{22., -8., 190., 6., 4.},
-              DataVector{1., -7., 31., 2., 5.},
-              DataVector{7., 8.9, 4., 2., 1.}}}) == 190.);
-  CHECK(CurvedScalarWave::ComputeLargestCharacteristicSpeed<3>::apply(
-            {{DataVector{1., 4., 3., 2., 5.}, DataVector{2., 8., -10., 6., 4.},
-              DataVector{1., 7., 3., -11., 5.},
-              DataVector{7., 3., 4., 2., 1.}}}) == 11.);
 }
+
+namespace {
+template <size_t SpatialDim>
+void check_max_char_speed(const DataVector& used_for_size) noexcept {
+  CAPTURE(SpatialDim);
+  MAKE_GENERATOR(gen);
+
+  // For a thorough numerical test of the function that claims to be
+  // computing the maximum characteristic speed at a given point, we
+  // calculate the char speeds along a reasonably large number of random
+  // unit directions and check that the claimed maximum is higher
+  // than the maximum speed along each of those directions.
+  //
+  // A reasonable number of trials can be defined by asking that at
+  // least one of the randomly generated normal furnishes a max
+  // char speed (along that normal) that is within some fraction of the
+  // claimed globally max char speed. Below, that fraction is called
+  // `check_minimum`. Assuming a small but finite chance that this
+  // condition on the number of trials is not satisfied
+  // ('failure_tolerance`), this gives the number of trials to be
+  // log(failure_tolerance) / log(check_minimum) + 1.
+  //
+  // In each trial below we check that the max char speed along that trial's
+  // random unit normal remains smaller than the claimed maximum (within
+  // some numerical tolerance of course, given below by `check_maximum`).
+  // Having this tolerance is necessary in 1D as we only have two directions
+  // possible for the unit normal.
+  //
+  // At the end, we also check that indeed the largest of the char
+  // speeds coming from all trials is larger than the fraction
+  // `check_minimum` of the claimed absolute max char speed, as we intended
+  // in the first place.
+
+  // Fraction of times the test can randomly fail
+  const double failure_tolerance = 1e-10;
+  // Minimum fraction of the claimed result that must be found in some
+  // random trial
+  const double check_minimum = 0.9;
+  // Minimum fraction of the claimed result that can be found in any
+  // random trial (generally only important for 1D where the random
+  // vector will point along the maximum speed direction)
+  const double check_maximum = 1.0 + 1e-12;
+
+  const double trial_failure_rate =
+      SpatialDim == 1
+          ? 0.1  // correct value is 0.0, but cannot take log of that
+          : (SpatialDim == 2 ? 1.0 - 2.0 * acos(check_minimum) / M_PI
+                             : check_minimum);
+
+  const size_t num_trials =
+      static_cast<size_t>(log(failure_tolerance) / log(trial_failure_rate)) + 1;
+
+  const auto lapse = TestHelpers::gr::random_lapse(&gen, used_for_size);
+  const auto shift =
+      TestHelpers::gr::random_shift<SpatialDim>(&gen, used_for_size);
+  const auto spatial_metric =
+      TestHelpers::gr::random_spatial_metric<SpatialDim>(&gen, used_for_size);
+  std::uniform_real_distribution<> gamma_1_dist(0.0, 5.0);
+  const auto gamma_1 = make_with_random_values<Scalar<DataVector>>(
+      make_not_null(&gen), make_not_null(&gamma_1_dist), used_for_size);
+  const double max_char_speed =
+      CurvedScalarWave::ComputeLargestCharacteristicSpeed<SpatialDim>::apply(
+          gamma_1, lapse, shift, spatial_metric);
+
+  double maximum_observed = -std::numeric_limits<double>::infinity();
+  for (size_t i = 0; i < num_trials; ++i) {
+    const auto unit_one_form = raise_or_lower_index(
+        random_unit_normal(&gen, spatial_metric), spatial_metric);
+
+    const auto characteristic_speeds = CurvedScalarWave::characteristic_speeds(
+        gamma_1, lapse, shift, unit_one_form);
+
+    double max_speed_in_chosen_direction =
+        -std::numeric_limits<double>::infinity();
+    for (const auto& speed : characteristic_speeds) {
+      max_speed_in_chosen_direction =
+          std::max(max_speed_in_chosen_direction, max(abs(speed)));
+    }
+
+    CHECK(max_speed_in_chosen_direction <= max_char_speed * check_maximum);
+    maximum_observed =
+        std::max(maximum_observed, max_speed_in_chosen_direction);
+  }
+  CHECK(maximum_observed >= check_minimum * max_char_speed);
+}
+
+template <size_t SpatialDim>
+void check_max_char_speed_compute_tag(
+    const DataVector& used_for_size) noexcept {
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> distribution(0.0, 1.0);
+
+  const auto nn_generator = make_not_null(&generator);
+  const auto nn_distribution = make_not_null(&distribution);
+
+  // Randomized tensors
+  const auto gamma_1 = make_with_random_values<Scalar<DataVector>>(
+      nn_generator, nn_distribution, used_for_size);
+  const auto lapse = make_with_random_values<Scalar<DataVector>>(
+      nn_generator, nn_distribution, used_for_size);
+  const auto shift =
+      make_with_random_values<tnsr::I<DataVector, SpatialDim, Frame::Inertial>>(
+          nn_generator, nn_distribution, used_for_size);
+  const auto spatial_metric = make_with_random_values<
+      tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(
+      nn_generator, nn_distribution, used_for_size);
+
+  // Insert into databox
+  const auto box = db::create<
+      db::AddSimpleTags<
+          CurvedScalarWave::Tags::ConstraintGamma1, gr::Tags::Lapse<DataVector>,
+          gr::Tags::Shift<SpatialDim, Frame::Inertial, DataVector>,
+          gr::Tags::SpatialMetric<SpatialDim, Frame::Inertial, DataVector>>,
+      db::AddComputeTags<>>(gamma_1, lapse, shift, spatial_metric);
+  // Test compute tag for computing max char speed
+  CHECK(db::apply<
+            CurvedScalarWave::ComputeLargestCharacteristicSpeed<SpatialDim>>(
+            box) ==
+        CurvedScalarWave::ComputeLargestCharacteristicSpeed<SpatialDim>::apply(
+            gamma_1, lapse, shift, spatial_metric));
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.MaxCharSpeed",
+                  "[Unit][Evolution]") {
+  check_max_char_speed<1>(DataVector(5));
+  check_max_char_speed<2>(DataVector(5));
+  check_max_char_speed<3>(DataVector(5));
+
+  check_max_char_speed_compute_tag<1>(DataVector(5));
+  check_max_char_speed_compute_tag<2>(DataVector(5));
+  check_max_char_speed_compute_tag<3>(DataVector(5));
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

The purpose of `ComputeLargestCharacteristicSpeed` is to estimate the largest characteristic speed in the bulk, such that the same can be used to estimate the Courant factor when adjusting timestep size. The current version could only do that for a given surface along which normals are known. This PR changes that to get the bulk maximum characteristic speed instead, which would correspond to the maximum over all points in the bulk with an optimally directed normal assumed at each point.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).