### PR TITLE
Fix a typo in Spectral docs

### DIFF
--- a/src/NumericalAlgorithms/Spectral/Spectral.hpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.hpp
@@ -404,7 +404,7 @@ const Matrix& integration_matrix(const Mesh<1>& mesh) noexcept;
  *
  * \warning For each target point located outside of the logical coordinate
  * interval covered by `BasisType` (often \f$[-1,1]\f$), the resulting matrix
- * performs polynomial extrapolation instead of interpolation. The extapolation
+ * performs polynomial extrapolation instead of interpolation. The extrapolation
  * will be correct but may suffer from reduced accuracy, especially for
  * higher-order polynomials (i.e., larger values of `num_points`).
  *


### PR DESCRIPTION
## Proposed changes

This is the smallest possible PR.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
