### PR TITLE
Precompute storage indices to sum for contractions

### DIFF
--- a/src/DataStructures/Tensor/Expressions/CMakeLists.txt
+++ b/src/DataStructures/Tensor/Expressions/CMakeLists.txt
@@ -8,6 +8,7 @@ spectre_target_headers(
   AddSubtract.hpp
   Contract.hpp
   Evaluate.hpp
+  LhsTensorSymmAndIndices.hpp
   Product.hpp
   TensorExpression.hpp
   )

--- a/src/DataStructures/Tensor/Expressions/Contract.hpp
+++ b/src/DataStructures/Tensor/Expressions/Contract.hpp
@@ -7,9 +7,16 @@
 
 #pragma once
 
+#include <array>
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/Tensor/Expressions/LhsTensorSymmAndIndices.hpp"
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/Structure.hpp"
 #include "DataStructures/Tensor/Symmetry.hpp"
 #include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
 
 /*!
  * \ingroup TensorExpressionsGroup
@@ -123,7 +130,10 @@ struct TensorContract
   using symmetry = typename new_type::symmetry;
   using index_list = typename new_type::index_list;
   static constexpr auto num_tensor_indices = tmpl::size<index_list>::value;
+  static constexpr auto num_uncontracted_tensor_indices =
+      tmpl::size<Symm>::value;
   using args_list = typename new_type::args_list;
+  using structure = Tensor_detail::Structure<symmetry, index_list>;
 
   explicit TensorContract(
       const TensorExpression<T, X, Symm, IndexList, ArgsList>& t)
@@ -172,13 +182,281 @@ struct TensorContract
         tensor_index, t_);
   }
 
+  /// \brief Return the tensor multi-index of one uncontracted LHS component to
+  /// be summed to compute a contracted LHS component
+  ///
+  /// \details
+  /// Example: If we have RHS tensor \f$R^{a}{}_{abc}\f$ and we want to contract
+  /// it to the LHS tensor \f$L_{cb}\f$, then \f$L_{cb}\f$ represents the
+  /// contracted LHS, while \f$L^{a}{}_{acb}\f$ represents the uncontracted
+  /// LHS. This function takes a concrete contracted LHS multi-index as input,
+  /// representing the  multi-index of a component of the contracted LHS that we
+  /// wish to compute. If `lhs_contracted_multi_index == [1, 2]`, this
+  /// represents \f$L_{12}\f$, the contracted LHS component we wish to compute.
+  /// In this case, we will need to sum \f$L^{a}{}_{a12}\f$ for all values of
+  /// \f$a\f$. `contracted_index_value` represents one such concrete value that
+  /// is filled in for \f$a\f$. In continuing the example, if
+  /// `contracted_index_value == 3`, then this function returns the multi-index
+  /// that represents \f$L^{3}{}_{312}\f$, which is `[3, 3, 1, 2]`. In this way,
+  /// what is constructed and returned is one such concrete multi-index of the
+  /// uncontracted LHS tensor to be summed as part of computing a component of
+  /// the contracted LHS tensor.
+  ///
+  /// \param lhs_contracted_multi_index the tensor multi-index of a contracted
+  /// LHS component to be computed
+  /// \param contracted_index_value the concrete value inserted for the indices
+  /// to contract
+  /// \return the tensor multi-index of one uncontracted LHS component to be
+  /// summed for computing the contracted LHS component at
+  /// `lhs_contracted_multi_index`
+  SPECTRE_ALWAYS_INLINE static constexpr std::array<
+      size_t, num_uncontracted_tensor_indices>
+  get_tensor_index_to_sum(
+      const std::array<size_t, num_tensor_indices>& lhs_contracted_multi_index,
+      const size_t contracted_index_value) noexcept {
+    std::array<size_t, num_uncontracted_tensor_indices>
+        contracting_tensor_index{};
+
+    for (size_t i = 0; i < FirstContractedIndexPos; i++) {
+      gsl::at(contracting_tensor_index, i) =
+          gsl::at(lhs_contracted_multi_index, i);
+    }
+    contracting_tensor_index[FirstContractedIndexPos] = contracted_index_value;
+    for (size_t i = FirstContractedIndexPos + 1; i < SecondContractedIndexPos;
+         i++) {
+      gsl::at(contracting_tensor_index, i) =
+          gsl::at(lhs_contracted_multi_index, i - 1);
+    }
+    contracting_tensor_index[SecondContractedIndexPos] = contracted_index_value;
+    for (size_t i = SecondContractedIndexPos + 1;
+         i < num_uncontracted_tensor_indices; i++) {
+      gsl::at(contracting_tensor_index, i) =
+          gsl::at(lhs_contracted_multi_index, i - 2);
+    }
+    return contracting_tensor_index;
+  }
+
+  /// \brief Return the storage indices of the uncontracted LHS components to
+  /// be summed to compute a contracted LHS component
+  ///
+  /// \details
+  /// Example: If we have RHS tensor \f$R^{a}{}_{abc}\f$ and we want to contract
+  /// it to the LHS tensor \f$L_{cb}\f$, then \f$L_{cb}\f$ represents the
+  /// contracted LHS, while \f$L^{a}{}_{acb}\f$ represents the uncontracted
+  /// LHS. `I` represents the storage index of the component \f$L_{cb}\f$ for
+  /// some \f$c\f$ and \f$b\f$, an uncontracted LHS component that we wish to
+  /// compute. If `c == 1` and `b == 2`, then this function computes and returns
+  /// the list of storage indices of components \f$L^{a}{}_{a12}\f$ for all
+  /// values of \f$a\f$, i.e. the components to sum to compute the component
+  /// \f$L_{12}\f$.
+  ///
+  /// \tparam I the storage index of a contracted LHS component to be computed
+  /// \tparam UncontractedLhsStructure the Structure of the uncontracted LHS
+  /// tensor
+  /// \tparam ContractedLhsStructure the Structure of the contracted LHS tensor
+  /// \tparam Ints a sequence of integers from [0, dimension of contracted
+  /// indices)
+  /// \return the storage indices of the uncontracted LHS components to be
+  /// summed to compute a contracted LHS component
+  template <size_t I, typename UncontractedLhsStructure,
+            typename ContractedLhsStructure, size_t... Ints>
+  SPECTRE_ALWAYS_INLINE static constexpr std::array<size_t,
+                                                    first_contracted_index::dim>
+  get_storage_indices_to_sum(
+      const std::index_sequence<Ints...>& /*dim_seq*/) noexcept {
+    constexpr std::array<size_t, num_tensor_indices>
+        lhs_contracted_multi_index =
+            ContractedLhsStructure::get_canonical_tensor_index(I);
+    return {{UncontractedLhsStructure::get_storage_index(
+        get_tensor_index_to_sum(lhs_contracted_multi_index, Ints))...}};
+  }
+
+  /// \brief Computes a mapping between the storage indices of the contracted
+  /// LHS components and the uncontracted LHS components to sum for a
+  /// contraction
+  ///
+  /// \details
+  /// Example: If we have RHS tensor \f$R^{a}{}_{abc}\f$ and we want to contract
+  /// it to the LHS tensor \f$L_{cb}\f$, then \f$L_{cb}\f$ represents the
+  /// contracted LHS, while \f$L^{a}{}_{acb}\f$ represents the uncontracted
+  /// LHS. This function computes and returns a mapping between the storage
+  /// indices of (1) each component of \f$L_{cb}\f$ and (2) the corresponding
+  /// lists of components of \f$L^{a}{}_{acb}\f$ to sum to compute each
+  /// component of \f$L_{cb}\f$.
+  ///
+  /// \tparam ContractedLhsNumComponents the number of components in the
+  /// contracted LHS tensor
+  /// \tparam UncontractedLhsStructure the Structure of the uncontracted LHS
+  /// tensor
+  /// \tparam ContractedLhsStructure the Structure of the contracted LHS tensor
+  /// \tparam Ints a sequence of integers from [0, `ContractedLhsNumComponents`)
+  /// \return a mapping between the storage indices of the contracted LHS
+  /// components and the uncontracted LHS components to sum for a contraction
+  template <size_t ContractedLhsNumComponents,
+            typename UncontractedLhsStructure, typename ContractedLhsStructure,
+            size_t... Ints>
+  SPECTRE_ALWAYS_INLINE static constexpr std::array<
+      std::array<size_t, first_contracted_index::dim>,
+      ContractedLhsNumComponents>
+  get_map_of_components_to_sum(
+      const std::index_sequence<Ints...>& /*index_seq*/) noexcept {
+    constexpr std::make_index_sequence<first_contracted_index::dim> dim_seq{};
+    return {{get_storage_indices_to_sum<Ints, UncontractedLhsStructure,
+                                        ContractedLhsStructure>(dim_seq)...}};
+  }
+
+  // Inserts the first contracted TensorIndex into the list of contracted LHS
+  // TensorIndexs
+  template <typename... LhsIndices>
+  using get_uncontracted_lhs_tensorindex_list_helper = tmpl::append<
+      tmpl::front<tmpl::split_at<tmpl::list<LhsIndices...>,
+                                 tmpl::size_t<FirstContractedIndexPos>>>,
+      tmpl::list<tmpl::at_c<ArgsList, FirstContractedIndexPos>>,
+      tmpl::back<tmpl::split_at<tmpl::list<LhsIndices...>,
+                                tmpl::size_t<FirstContractedIndexPos>>>>;
+
+  /// Constructs the uncontracted LHS's list of TensorIndexs by inserting the
+  /// pair of indices being contracted into the list of contracted LHS
+  /// TensorIndexs
+  ///
+  /// Example: If we contract RHS tensor \f$R^{a}{}_{bac}\f$ to LHS tensor
+  /// \f$L_{cb}\f$, the RHS list of generic indices (`ArgsList`) is
+  /// `tmpl::list<ti_A_t, ti_b_t, ti_a_t, ti_c_t>` and the LHS generic indices
+  /// (`LhsIndices`) are `ti_c_t, ti_b_t`. `ti_A_t` and `ti_a_t` are inserted
+  /// into `LhsIndices` at their positions from the RHS, which yields:
+  /// `tmpl::list<ti_A_t, ti_c_t, ti_a_t, ti_b_t>`.
+  template <typename... LhsIndices>
+  using get_uncontracted_lhs_tensorindex_list = tmpl::append<
+      tmpl::front<tmpl::split_at<
+          get_uncontracted_lhs_tensorindex_list_helper<LhsIndices...>,
+          tmpl::size_t<SecondContractedIndexPos>>>,
+      tmpl::list<tmpl::at_c<ArgsList, SecondContractedIndexPos>>,
+      tmpl::back<tmpl::split_at<
+          get_uncontracted_lhs_tensorindex_list_helper<LhsIndices...>,
+          tmpl::size_t<SecondContractedIndexPos>>>>;
+
+  /// \brief Helper struct for computing the contraction of one pair of indices
+  ///
+  /// \tparam UncontractedLhsTensorIndexList the typelist of TensorIndexs of the
+  /// uncontracted LHS tensor
+  template <typename UncontractedLhsTensorIndexList>
+  struct ComputeContraction;
+
+  template <typename... UncontractedLhsTensorIndices>
+  struct ComputeContraction<tmpl::list<UncontractedLhsTensorIndices...>> {
+    /// \brief Computes the value of the component in the contracted LHS tensor
+    /// at a given storage index
+    ///
+    /// \details
+    /// This function recursively computes the value of the component in the
+    /// contracted LHS tensor at a given storage index by iterating over the
+    /// list of storage indices of uncontracted LHS components to sum. This list
+    /// is stored at `map_of_components_to_sum[lhs_storage_index]`, and the
+    /// current component being summed is at
+    /// `map_of_components_to_sum[lhs_storage_index][Index]`.
+    ///
+    /// \tparam UncontractedLhsStructure the Structure of the uncontracted LHS
+    /// tensor
+    /// \tparam ContractedLhsNumComponents the number of components in the
+    /// contracted LHS tensor
+    /// \tparam Index for a given list of uncontracted LHS storage indices whose
+    /// components are summed to compute a contracted LHS component, this is the
+    /// position of one such storage index in that list
+    /// \param map_of_components_to_sum a mapping between the storage indices of
+    /// the contracted LHS components and the uncontracted LHS components to sum
+    /// to compute the former
+    /// \param t1 the expression contained within the RHS contraction expression
+    /// \param lhs_storage_index the storage index of the LHS tensor component
+    /// to compute
+    /// \return the computed value of the component at `lhs_storage_index` in
+    /// the contracted LHS tensor
+    template <typename UncontractedLhsStructure,
+              size_t ContractedLhsNumComponents, size_t Index, typename T1>
+    static SPECTRE_ALWAYS_INLINE decltype(auto) apply(
+        const std::array<std::array<size_t, first_contracted_index::dim>,
+                         ContractedLhsNumComponents>& map_of_components_to_sum,
+        const T1& t1, const size_t& lhs_storage_index) noexcept {
+      if constexpr (Index < first_contracted_index::dim - 1) {
+        // We have more than one component left to sum
+        return apply<UncontractedLhsStructure, ContractedLhsNumComponents,
+                     Index + 1>(map_of_components_to_sum, t1,
+                                lhs_storage_index) +
+               t1.template get<UncontractedLhsStructure,
+                               UncontractedLhsTensorIndices...>(
+                   gsl::at(gsl::at(map_of_components_to_sum, lhs_storage_index),
+                           Index));
+      } else {
+        // We only have one final component to sum
+        return t1.template get<UncontractedLhsStructure,
+                               UncontractedLhsTensorIndices...>(
+            gsl::at(gsl::at(map_of_components_to_sum, lhs_storage_index),
+                    first_contracted_index::dim - 1));
+      }
+    }
+  };
+
+  /// \brief Return the value of the component of the contracted LHS tensor at a
+  /// given storage index
+  ///
+  /// \details
+  /// Given a RHS tensor to be contracted, the uncontracted LHS represents the
+  /// uncontracted RHS tensor arranged with the LHS's generic index order. The
+  /// contracted LHS represents the result of contracting this uncontracted
+  /// LHS. For example, if we have RHS tensor \f$R^{a}{}_{abc}\f$ and we want to
+  /// contract it to the LHS tensor \f$L_{cb}\f$, then \f$L_{cb}\f$ represents
+  /// the contracted LHS, while \f$L^{a}{}_{acb}\f$ represents the uncontracted
+  /// LHS. Note that the relative ordering of the LHS generic indices \f$c\f$
+  /// and \f$b\f$ in the contracted LHS is preserved in the uncontracted LHS.
+  ///
+  /// To compute a contraction, we need to get all the uncontracted LHS
+  /// components to sum. In the example above, this means that in order to
+  /// compute \f$L_{cb}\f$ for some \f$c\f$ and \f$b\f$, we need to sum the
+  /// components \f$L^{a}{}_{acb}\f$ for all values of \f$a\f$. This function
+  /// first constructs the list of generic indices (TensorIndexs) of the
+  /// uncontracted LHS, then uses a series of helper functions to compute a
+  /// mapping from (1) the storage indices of the components in the contracted
+  /// LHS tensor to (2) their corresponding lists of storage indices of
+  /// components in the uncontracted LHS tensor that need to be summed to
+  /// compute each contracted LHS component. Finally, the `ComputeContraction`
+  /// helper struct is used to compute the contracted component at
+  /// `lhs_storage_index` by leveraging this precomputed map's lists of indices
+  /// to sum for each contracted LHS component's storage index.
+  ///
+  /// \tparam LhsStructure the Structure of the contracted LHS tensor
+  /// \tparam LhsIndices the TensorIndexs of the contracted LHS tensor, e.g.
+  /// `ti_a_t`, `ti_b_t`, `ti_c_t`
+  /// \param lhs_storage_index the storage index of the contracted LHS tensor
+  /// component to retrieve
+  /// \return the value of the component at `lhs_storage_index` in the
+  /// contracted LHS tensor
   template <typename LhsStructure, typename... LhsIndices>
   SPECTRE_ALWAYS_INLINE decltype(auto) get(
       const size_t lhs_storage_index) const {
-    const std::array<size_t, num_tensor_indices>& new_tensor_index =
-        LhsStructure::template get_canonical_tensor_index<num_tensor_indices>(
-            lhs_storage_index);
-    return get<LhsIndices...>(new_tensor_index);
+    constexpr size_t contracted_lhs_num_components = LhsStructure::size();
+    using uncontracted_lhs_tensorindex_list =
+        get_uncontracted_lhs_tensorindex_list<LhsIndices...>;
+    using uncontracted_lhs_structure =
+        typename LhsTensorSymmAndIndices<ArgsList,
+                                         uncontracted_lhs_tensorindex_list,
+                                         Symm, IndexList>::structure;
+
+    constexpr std::make_index_sequence<contracted_lhs_num_components> map_seq{};
+
+    // A map from contracted LHS storage indices to lists of uncontracted LHS
+    // storage indices of components to sum for contraction
+    constexpr std::array<std::array<size_t, first_contracted_index::dim>,
+                         contracted_lhs_num_components>
+        map_of_components_to_sum =
+            get_map_of_components_to_sum<contracted_lhs_num_components,
+                                         uncontracted_lhs_structure,
+                                         LhsStructure>(map_seq);
+
+    // This returns the value of the component stored at `lhs_storage_index` in
+    // the contracted LHS tensor
+    return ComputeContraction<uncontracted_lhs_tensorindex_list>::
+        template apply<uncontracted_lhs_structure,
+                       contracted_lhs_num_components, 0>(
+            map_of_components_to_sum, t_, lhs_storage_index);
   }
 
  private:
@@ -199,7 +477,7 @@ struct TensorContract
  * contracted. If there exists more than one such pair of indices in the
  * expression, the first pair of values found will be returned.
  *
- * For example, if we have tensor \f${R^{ab}}_{ab}\f$ represented by the tensor
+ * For example, if we have tensor \f$R^{ab}{}_{ab}\f$ represented by the tensor
  * expression, `R(ti_A, ti_B, ti_a, ti_b)`, then this will return the positions
  * of the pair of values encoding `ti_A_t` and `ti_a_t`, which would be (0, 2)
  *
@@ -238,10 +516,10 @@ get_first_index_positions_to_contract(
  * pair of indices to contract, subsequent contraction expressions are
  * recursively created, nesting one contraction expression inside another.
  *
- * For example, if we have tensor \f${R^{ab}}_{ab}\f$ represented by the tensor
+ * For example, if we have tensor \f$R^{ab}{}_{ab}\f$ represented by the tensor
  * expression, `R(ti_A, ti_B, ti_a, ti_b)`, then one contraction expression is
- * created to represent contracting \f${R^{ab}}_ab\f$ to \f${R^b}_b\f$, and a
- * second to represent contracting \f${R^b}_b\f$ to the scalar, \f${R}\f$.
+ * created to represent contracting \f$R^{ab}{}_ab\f$ to \f$R^b{}_b\f$, and a
+ * second to represent contracting \f$R^b{}_b\f$ to the scalar, \f$R\f$.
  *
  * @param t the TensorExpression to potentially contract
  * @return the input tensor expression or a contraction expression of the input

--- a/src/DataStructures/Tensor/Expressions/Evaluate.hpp
+++ b/src/DataStructures/Tensor/Expressions/Evaluate.hpp
@@ -6,59 +6,12 @@
 
 #pragma once
 
+#include "DataStructures/Tensor/Expressions/LhsTensorSymmAndIndices.hpp"
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Utilities/Algorithm.hpp"
 #include "Utilities/Requires.hpp"
 
 namespace TensorExpressions {
-/*!
- * \ingroup TensorExpressionsGroup
- * \brief Determines and stores a LHS tensor's symmetry and index list from a
- * RHS tensor expression and desired LHS index order
- *
- * \details Given the generic index order of a RHS TensorExpression and the
- * generic index order of the desired LHS Tensor, this creates a mapping between
- * the two that is used to determine the (potentially reordered) ordering of the
- * elements of the desired LHS Tensor`s ::Symmetry and typelist of
- * \ref SpacetimeIndex "TensorIndexType"s.
- *
- * @tparam RhsTensorIndexList the typelist of TensorIndex of the RHS
- * TensorExpression, e.g. `ti_a_t`, `ti_b_t`, `ti_c_t`
- * @tparam LhsTensorIndexList the typelist of TensorIndexs of the desired LHS
- * tensor, e.g. `ti_b_t`, `ti_c_t`, `ti_a_t`
- * @tparam RhsSymmetry the ::Symmetry of the RHS indices
- * @tparam RhsTensorIndexTypeList the RHS TensorExpression's typelist of
- * \ref SpacetimeIndex "TensorIndexType"s
- */
-template <typename RhsTensorIndexList, typename LhsTensorIndexList,
-          typename RhsSymmetry, typename RhsTensorIndexTypeList,
-          size_t NumIndices = tmpl::size<RhsSymmetry>::value,
-          typename IndexSequence = std::make_index_sequence<NumIndices>>
-struct LhsTensorSymmAndIndices;
-
-template <typename RhsTensorIndexList, typename... LhsTensorIndices,
-          typename RhsSymmetry, typename RhsTensorIndexTypeList,
-          size_t NumIndices, size_t... Ints>
-struct LhsTensorSymmAndIndices<
-    RhsTensorIndexList, tmpl::list<LhsTensorIndices...>, RhsSymmetry,
-    RhsTensorIndexTypeList, NumIndices, std::index_sequence<Ints...>> {
-  static constexpr std::array<size_t, NumIndices> lhs_tensorindex_values = {
-      {LhsTensorIndices::value...}};
-  static constexpr std::array<size_t, NumIndices> rhs_tensorindex_values = {
-      {tmpl::at_c<RhsTensorIndexList, Ints>::value...}};
-  static constexpr std::array<size_t, NumIndices> lhs_to_rhs_map = {
-      {std::distance(
-          rhs_tensorindex_values.begin(),
-          alg::find(rhs_tensorindex_values, lhs_tensorindex_values[Ints]))...}};
-
-  // Desired LHS Tensor's Symmetry and typelist of TensorIndexTypes
-  using symmetry =
-      Symmetry<tmpl::at_c<RhsSymmetry, lhs_to_rhs_map[Ints]>::value...>;
-  using tensorindextype_list =
-      tmpl::list<tmpl::at_c<RhsTensorIndexTypeList, lhs_to_rhs_map[Ints]>...>;
-};
-
 /*!
  * \ingroup TensorExpressionsGroup
  * \brief Evaluate a RHS tensor expression to a tensor with the LHS index order

--- a/src/DataStructures/Tensor/Expressions/LhsTensorSymmAndIndices.hpp
+++ b/src/DataStructures/Tensor/Expressions/LhsTensorSymmAndIndices.hpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <utility>
 
+#include "DataStructures/Tensor/Structure.hpp"
 #include "DataStructures/Tensor/Symmetry.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/TMPL.hpp"
@@ -52,10 +53,12 @@ struct LhsTensorSymmAndIndices<
           rhs_tensorindex_values.begin(),
           alg::find(rhs_tensorindex_values, lhs_tensorindex_values[Ints]))...}};
 
-  // Desired LHS Tensor's Symmetry and typelist of TensorIndexTypes
+  // Desired LHS Tensor's Symmetry, typelist of TensorIndexTypes, and Structure
   using symmetry =
       Symmetry<tmpl::at_c<RhsSymmetry, lhs_to_rhs_map[Ints]>::value...>;
   using tensorindextype_list =
       tmpl::list<tmpl::at_c<RhsTensorIndexTypeList, lhs_to_rhs_map[Ints]>...>;
+  using structure = Tensor_detail::Structure<
+      symmetry, tmpl::at_c<RhsTensorIndexTypeList, lhs_to_rhs_map[Ints]>...>;
 };
 }  // namespace TensorExpressions

--- a/src/DataStructures/Tensor/Expressions/LhsTensorSymmAndIndices.hpp
+++ b/src/DataStructures/Tensor/Expressions/LhsTensorSymmAndIndices.hpp
@@ -1,0 +1,61 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/Tensor/Symmetry.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace TensorExpressions {
+/*!
+ * \ingroup TensorExpressionsGroup
+ * \brief Determines and stores a LHS tensor's symmetry and index list from a
+ * RHS tensor expression and desired LHS index order
+ *
+ * \details Given the generic index order of a RHS TensorExpression and the
+ * generic index order of the desired LHS Tensor, this creates a mapping between
+ * the two that is used to determine the (potentially reordered) ordering of the
+ * elements of the desired LHS Tensor`s ::Symmetry and typelist of
+ * \ref SpacetimeIndex "TensorIndexType"s.
+ *
+ * @tparam RhsTensorIndexList the typelist of TensorIndex of the RHS
+ * TensorExpression, e.g. `ti_a_t`, `ti_b_t`, `ti_c_t`
+ * @tparam LhsTensorIndexList the typelist of TensorIndexs of the desired LHS
+ * tensor, e.g. `ti_b_t`, `ti_c_t`, `ti_a_t`
+ * @tparam RhsSymmetry the ::Symmetry of the RHS indices
+ * @tparam RhsTensorIndexTypeList the RHS TensorExpression's typelist of
+ * \ref SpacetimeIndex "TensorIndexType"s
+ */
+template <typename RhsTensorIndexList, typename LhsTensorIndexList,
+          typename RhsSymmetry, typename RhsTensorIndexTypeList,
+          size_t NumIndices = tmpl::size<RhsSymmetry>::value,
+          typename IndexSequence = std::make_index_sequence<NumIndices>>
+struct LhsTensorSymmAndIndices;
+
+template <typename RhsTensorIndexList, typename... LhsTensorIndices,
+          typename RhsSymmetry, typename RhsTensorIndexTypeList,
+          size_t NumIndices, size_t... Ints>
+struct LhsTensorSymmAndIndices<
+    RhsTensorIndexList, tmpl::list<LhsTensorIndices...>, RhsSymmetry,
+    RhsTensorIndexTypeList, NumIndices, std::index_sequence<Ints...>> {
+  static constexpr std::array<size_t, NumIndices> lhs_tensorindex_values = {
+      {LhsTensorIndices::value...}};
+  static constexpr std::array<size_t, NumIndices> rhs_tensorindex_values = {
+      {tmpl::at_c<RhsTensorIndexList, Ints>::value...}};
+  static constexpr std::array<size_t, NumIndices> lhs_to_rhs_map = {
+      {std::distance(
+          rhs_tensorindex_values.begin(),
+          alg::find(rhs_tensorindex_values, lhs_tensorindex_values[Ints]))...}};
+
+  // Desired LHS Tensor's Symmetry and typelist of TensorIndexTypes
+  using symmetry =
+      Symmetry<tmpl::at_c<RhsSymmetry, lhs_to_rhs_map[Ints]>::value...>;
+  using tensorindextype_list =
+      tmpl::list<tmpl::at_c<RhsTensorIndexTypeList, lhs_to_rhs_map[Ints]>...>;
+};
+}  // namespace TensorExpressions

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Contract.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Contract.cpp
@@ -36,20 +36,24 @@ void create_tensor(gsl::not_null<Tensor<DataVector, Ts...>*> tensor) noexcept {
 template <typename DataType>
 void test_contractions_rank2(const DataType& used_for_size) noexcept {
   // Contract (upper, lower) tensor
-  // Use explicit type (vs auto) so the compiler checks the return type of
-  // `evaluate`
+  // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
+  // return type of `evaluate`
   Tensor<DataType, Symmetry<2, 1>,
          index_list<SpatialIndex<3, UpLo::Up, Frame::Inertial>,
                     SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
       Rul(used_for_size);
   create_tensor(make_not_null(&Rul));
 
-  const Tensor<DataType> RIi_contracted =
-      TensorExpressions::evaluate(Rul(ti_I, ti_i));
+  const auto RIi_expr = Rul(ti_I, ti_i);
+  const Tensor<DataType> RIi_contracted = TensorExpressions::evaluate(RIi_expr);
 
   DataType expected_RIi_sum = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t i = 0; i < 3; i++) {
     expected_RIi_sum += Rul.get(i, i);
+
+    const std::array<size_t, 2> expected_uncontracted_lhs_tensor_index{{i, i}};
+    CHECK(RIi_expr.get_tensor_index_to_sum({{}}, i) ==
+          expected_uncontracted_lhs_tensor_index);
   }
   CHECK(RIi_contracted.get() == expected_RIi_sum);
 
@@ -60,12 +64,16 @@ void test_contractions_rank2(const DataType& used_for_size) noexcept {
       Rlu(used_for_size);
   create_tensor(make_not_null(&Rlu));
 
-  const Tensor<DataType> RgG_contracted =
-      TensorExpressions::evaluate(Rlu(ti_g, ti_G));
+  const auto RgG_expr = Rlu(ti_g, ti_G);
+  const Tensor<DataType> RgG_contracted = TensorExpressions::evaluate(RgG_expr);
 
   DataType expected_RgG_sum = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t g = 0; g < 4; g++) {
     expected_RgG_sum += Rlu.get(g, g);
+
+    const std::array<size_t, 2> expected_uncontracted_lhs_tensor_index{{g, g}};
+    CHECK(RgG_expr.get_tensor_index_to_sum({{}}, g) ==
+          expected_uncontracted_lhs_tensor_index);
   }
   CHECK(RgG_contracted.get() == expected_RgG_sum);
 }
@@ -73,8 +81,8 @@ void test_contractions_rank2(const DataType& used_for_size) noexcept {
 template <typename DataType>
 void test_contractions_rank3(const DataType& used_for_size) noexcept {
   // Contract first and second indices of (lower, upper, lower) tensor
-  // Use explicit type (vs auto) so the compiler checks the return type of
-  // `evaluate`
+  // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
+  // return type of `evaluate`
   Tensor<DataType, Symmetry<3, 2, 1>,
          index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
                     SpatialIndex<3, UpLo::Up, Frame::Grid>,
@@ -82,15 +90,20 @@ void test_contractions_rank3(const DataType& used_for_size) noexcept {
       Rlul(used_for_size);
   create_tensor(make_not_null(&Rlul));
 
+  const auto RiIj_expr = Rlul(ti_i, ti_I, ti_j);
   const Tensor<DataType, Symmetry<1>,
                index_list<SpatialIndex<4, UpLo::Lo, Frame::Grid>>>
-      RiIj_contracted =
-          TensorExpressions::evaluate<ti_j_t>(Rlul(ti_i, ti_I, ti_j));
+      RiIj_contracted = TensorExpressions::evaluate<ti_j_t>(RiIj_expr);
 
   for (size_t j = 0; j < 4; j++) {
     DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
     for (size_t i = 0; i < 3; i++) {
       expected_sum += Rlul.get(i, i, j);
+
+      const std::array<size_t, 3> expected_uncontracted_lhs_tensor_index{
+          {i, i, j}};
+      CHECK(RiIj_expr.get_tensor_index_to_sum({{j}}, i) ==
+            expected_uncontracted_lhs_tensor_index);
     }
     CHECK(RiIj_contracted.get(j) == expected_sum);
   }
@@ -103,15 +116,20 @@ void test_contractions_rank3(const DataType& used_for_size) noexcept {
       Ruul(used_for_size);
   create_tensor(make_not_null(&Ruul));
 
+  const auto RJLj_expr = Ruul(ti_J, ti_L, ti_j);
   const Tensor<DataType, Symmetry<1>,
                index_list<SpatialIndex<3, UpLo::Up, Frame::Grid>>>
-      RJLj_contracted =
-          TensorExpressions::evaluate<ti_L_t>(Ruul(ti_J, ti_L, ti_j));
+      RJLj_contracted = TensorExpressions::evaluate<ti_L_t>(RJLj_expr);
 
   for (size_t l = 0; l < 3; l++) {
     DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
     for (size_t j = 0; j < 3; j++) {
       expected_sum += Ruul.get(j, l, j);
+
+      const std::array<size_t, 3> expected_uncontracted_lhs_tensor_index{
+          {j, l, j}};
+      CHECK(RJLj_expr.get_tensor_index_to_sum({{l}}, j) ==
+            expected_uncontracted_lhs_tensor_index);
     }
     CHECK(RJLj_contracted.get(l) == expected_sum);
   }
@@ -124,15 +142,20 @@ void test_contractions_rank3(const DataType& used_for_size) noexcept {
       Rulu(used_for_size);
   create_tensor(make_not_null(&Rulu));
 
+  const auto RBfF_expr = Rulu(ti_B, ti_f, ti_F);
   const Tensor<DataType, Symmetry<1>,
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>>
-      RBfF_contracted =
-          TensorExpressions::evaluate<ti_B_t>(Rulu(ti_B, ti_f, ti_F));
+      RBfF_contracted = TensorExpressions::evaluate<ti_B_t>(RBfF_expr);
 
   for (size_t b = 0; b < 4; b++) {
     DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
     for (size_t f = 0; f < 4; f++) {
       expected_sum += Rulu.get(b, f, f);
+
+      const std::array<size_t, 3> expected_uncontracted_lhs_tensor_index{
+          {b, f, f}};
+      CHECK(RBfF_expr.get_tensor_index_to_sum({{b}}, f) ==
+            expected_uncontracted_lhs_tensor_index);
     }
     CHECK(RBfF_contracted.get(b) == expected_sum);
   }
@@ -146,15 +169,20 @@ void test_contractions_rank3(const DataType& used_for_size) noexcept {
       Rllu(used_for_size);
   create_tensor(make_not_null(&Rllu));
 
+  const auto RiaI_expr = Rllu(ti_i, ti_a, ti_I);
   const Tensor<DataType, Symmetry<1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      RiaI_contracted =
-          TensorExpressions::evaluate<ti_a_t>(Rllu(ti_i, ti_a, ti_I));
+      RiaI_contracted = TensorExpressions::evaluate<ti_a_t>(RiaI_expr);
 
   for (size_t a = 0; a < 4; a++) {
     DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
     for (size_t i = 0; i < 3; i++) {
       expected_sum += Rllu.get(i, a, i);
+
+      const std::array<size_t, 3> expected_uncontracted_lhs_tensor_index{
+          {i, a, i}};
+      CHECK(RiaI_expr.get_tensor_index_to_sum({{a}}, i) ==
+            expected_uncontracted_lhs_tensor_index);
     }
     CHECK(RiaI_contracted.get(a) == expected_sum);
   }
@@ -164,8 +192,8 @@ template <typename DataType>
 void test_contractions_rank4(const DataType& used_for_size) noexcept {
   // Contract first and second indices of (lower, upper, upper, lower) tensor to
   // rank 2 tensor
-  // Use explicit type (vs auto) so the compiler checks the return type of
-  // `evaluate`
+  // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
+  // return type of `evaluate`
   Tensor<DataType, Symmetry<4, 3, 2, 1>,
          index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
                     SpatialIndex<3, UpLo::Up, Frame::Inertial>,
@@ -174,17 +202,23 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
       Rluul(used_for_size);
   create_tensor(make_not_null(&Rluul));
 
+  const auto RiIKj_expr = Rluul(ti_i, ti_I, ti_K, ti_j);
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<4, UpLo::Up, Frame::Inertial>,
                           SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
-      RiIKj_contracted = TensorExpressions::evaluate<ti_K_t, ti_j_t>(
-          Rluul(ti_i, ti_I, ti_K, ti_j));
+      RiIKj_contracted =
+          TensorExpressions::evaluate<ti_K_t, ti_j_t>(RiIKj_expr);
 
   for (size_t k = 0; k < 4; k++) {
     for (size_t j = 0; j < 3; j++) {
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
       for (size_t i = 0; i < 3; i++) {
         expected_sum += Rluul.get(i, i, k, j);
+
+        const std::array<size_t, 4> expected_uncontracted_lhs_tensor_index{
+            {i, i, k, j}};
+        CHECK(RiIKj_expr.get_tensor_index_to_sum({{k, j}}, i) ==
+              expected_uncontracted_lhs_tensor_index);
       }
       CHECK(RiIKj_contracted.get(k, j) == expected_sum);
     }
@@ -200,17 +234,23 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
       Ruull(used_for_size);
   create_tensor(make_not_null(&Ruull));
 
+  const auto RABac_expr = Ruull(ti_A, ti_B, ti_a, ti_c);
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                           SpacetimeIndex<4, UpLo::Lo, Frame::Grid>>>
-      RABac_contracted = TensorExpressions::evaluate<ti_B_t, ti_c_t>(
-          Ruull(ti_A, ti_B, ti_a, ti_c));
+      RABac_contracted =
+          TensorExpressions::evaluate<ti_B_t, ti_c_t>(RABac_expr);
 
   for (size_t b = 0; b < 4; b++) {
     for (size_t c = 0; c < 5; c++) {
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
       for (size_t a = 0; a < 5; a++) {
         expected_sum += Ruull.get(a, b, a, c);
+
+        const std::array<size_t, 4> expected_uncontracted_lhs_tensor_index{
+            {a, b, a, c}};
+        CHECK(RABac_expr.get_tensor_index_to_sum({{b, c}}, a) ==
+              expected_uncontracted_lhs_tensor_index);
       }
       CHECK(RABac_contracted.get(b, c) == expected_sum);
     }
@@ -226,17 +266,23 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
       Ruuul(used_for_size);
   create_tensor(make_not_null(&Ruuul));
 
+  const auto RLJIl_expr = Ruuul(ti_L, ti_J, ti_I, ti_l);
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<4, UpLo::Up, Frame::Grid>,
                           SpatialIndex<3, UpLo::Up, Frame::Grid>>>
-      RLJIl_contracted = TensorExpressions::evaluate<ti_J_t, ti_I_t>(
-          Ruuul(ti_L, ti_J, ti_I, ti_l));
+      RLJIl_contracted =
+          TensorExpressions::evaluate<ti_J_t, ti_I_t>(RLJIl_expr);
 
   for (size_t j = 0; j < 4; j++) {
     for (size_t i = 0; i < 3; i++) {
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
       for (size_t l = 0; l < 3; l++) {
         expected_sum += Ruuul.get(l, j, i, l);
+
+        const std::array<size_t, 4> expected_uncontracted_lhs_tensor_index{
+            {l, j, i, l}};
+        CHECK(RLJIl_expr.get_tensor_index_to_sum({{j, i}}, l) ==
+              expected_uncontracted_lhs_tensor_index);
       }
       CHECK(RLJIl_contracted.get(j, i) == expected_sum);
     }
@@ -252,17 +298,23 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
       Ruulu(used_for_size);
   create_tensor(make_not_null(&Ruulu));
 
+  const auto REDdA_expr = Ruulu(ti_E, ti_D, ti_d, ti_A);
   const Tensor<DataType, Symmetry<1, 1>,
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>
-      REDdA_contracted = TensorExpressions::evaluate<ti_E_t, ti_A_t>(
-          Ruulu(ti_E, ti_D, ti_d, ti_A));
+      REDdA_contracted =
+          TensorExpressions::evaluate<ti_E_t, ti_A_t>(REDdA_expr);
 
   for (size_t e = 0; e < 4; e++) {
     for (size_t a = 0; a < 4; a++) {
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
       for (size_t d = 0; d < 4; d++) {
         expected_sum += Ruulu.get(e, d, d, a);
+
+        const std::array<size_t, 4> expected_uncontracted_lhs_tensor_index{
+            {e, d, d, a}};
+        CHECK(REDdA_expr.get_tensor_index_to_sum({{e, a}}, d) ==
+              expected_uncontracted_lhs_tensor_index);
       }
       CHECK(REDdA_contracted.get(e, a) == expected_sum);
     }
@@ -278,17 +330,23 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
       Rlull(used_for_size);
   create_tensor(make_not_null(&Rlull));
 
+  const auto RkJij_expr = Rlull(ti_k, ti_J, ti_i, ti_j);
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
                           SpatialIndex<4, UpLo::Lo, Frame::Inertial>>>
-      RkJij_contracted = TensorExpressions::evaluate<ti_k_t, ti_i_t>(
-          Rlull(ti_k, ti_J, ti_i, ti_j));
+      RkJij_contracted =
+          TensorExpressions::evaluate<ti_k_t, ti_i_t>(RkJij_expr);
 
   for (size_t k = 0; k < 3; k++) {
     for (size_t i = 0; i < 4; i++) {
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
       for (size_t j = 0; j < 3; j++) {
         expected_sum += Rlull.get(k, j, i, j);
+
+        const std::array<size_t, 4> expected_uncontracted_lhs_tensor_index{
+            {k, j, i, j}};
+        CHECK(RkJij_expr.get_tensor_index_to_sum({{k, i}}, j) ==
+              expected_uncontracted_lhs_tensor_index);
       }
       CHECK(RkJij_contracted.get(k, i) == expected_sum);
     }
@@ -304,17 +362,23 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
       Rullu(used_for_size);
   create_tensor(make_not_null(&Rullu));
 
+  const auto RFcgG_expr = Rullu(ti_F, ti_c, ti_g, ti_G);
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpacetimeIndex<4, UpLo::Up, Frame::Inertial>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>
-      RFcgG_contracted = TensorExpressions::evaluate<ti_F_t, ti_c_t>(
-          Rullu(ti_F, ti_c, ti_g, ti_G));
+      RFcgG_contracted =
+          TensorExpressions::evaluate<ti_F_t, ti_c_t>(RFcgG_expr);
 
   for (size_t f = 0; f < 5; f++) {
     for (size_t c = 0; c < 4; c++) {
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
       for (size_t g = 0; g < 4; g++) {
         expected_sum += Rullu.get(f, c, g, g);
+
+        const std::array<size_t, 4> expected_uncontracted_lhs_tensor_index{
+            {f, c, g, g}};
+        CHECK(RFcgG_expr.get_tensor_index_to_sum({{f, c}}, g) ==
+              expected_uncontracted_lhs_tensor_index);
       }
       CHECK(RFcgG_contracted.get(f, c) == expected_sum);
     }
@@ -330,17 +394,23 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
       Ruluu(used_for_size);
   create_tensor(make_not_null(&Ruluu));
 
+  const auto RKkIJ_expr = Ruluu(ti_K, ti_k, ti_I, ti_J);
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<2, UpLo::Up, Frame::Grid>,
                           SpatialIndex<3, UpLo::Up, Frame::Grid>>>
-      RKkIJ_contracted_to_JI = TensorExpressions::evaluate<ti_J_t, ti_I_t>(
-          Ruluu(ti_K, ti_k, ti_I, ti_J));
+      RKkIJ_contracted_to_JI =
+          TensorExpressions::evaluate<ti_J_t, ti_I_t>(RKkIJ_expr);
 
   for (size_t j = 0; j < 2; j++) {
     for (size_t i = 0; i < 3; i++) {
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
       for (size_t k = 0; k < 3; k++) {
         expected_sum += Ruluu.get(k, k, i, j);
+
+        const std::array<size_t, 4> expected_uncontracted_lhs_tensor_index{
+            {k, k, j, i}};
+        CHECK(RKkIJ_expr.get_tensor_index_to_sum({{j, i}}, k) ==
+              expected_uncontracted_lhs_tensor_index);
       }
       CHECK(RKkIJ_contracted_to_JI.get(j, i) == expected_sum);
     }
@@ -356,17 +426,23 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
       Rluuu(used_for_size);
   create_tensor(make_not_null(&Rluuu));
 
+  const auto RbCBE_expr = Rluuu(ti_b, ti_C, ti_B, ti_E);
   const Tensor<DataType, Symmetry<1, 1>,
                index_list<SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
                           SpacetimeIndex<2, UpLo::Up, Frame::Grid>>>
-      RbCBE_contracted_to_EC = TensorExpressions::evaluate<ti_E_t, ti_C_t>(
-          Rluuu(ti_b, ti_C, ti_B, ti_E));
+      RbCBE_contracted_to_EC =
+          TensorExpressions::evaluate<ti_E_t, ti_C_t>(RbCBE_expr);
 
   for (size_t e = 0; e < 3; e++) {
     for (size_t c = 0; c < 3; c++) {
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
       for (size_t b = 0; b < 3; b++) {
         expected_sum += Rluuu.get(b, c, b, e);
+
+        const std::array<size_t, 4> expected_uncontracted_lhs_tensor_index{
+            {b, e, b, c}};
+        CHECK(RbCBE_expr.get_tensor_index_to_sum({{e, c}}, b) ==
+              expected_uncontracted_lhs_tensor_index);
       }
       CHECK(RbCBE_contracted_to_EC.get(e, c) == expected_sum);
     }
@@ -382,17 +458,23 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
       Rulll(used_for_size);
   create_tensor(make_not_null(&Rulll));
 
+  const auto RAdba_expr = Rulll(ti_A, ti_d, ti_b, ti_a);
   const Tensor<DataType, Symmetry<1, 1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      RAdba_contracted_to_bd = TensorExpressions::evaluate<ti_b_t, ti_d_t>(
-          Rulll(ti_A, ti_d, ti_b, ti_a));
+      RAdba_contracted_to_bd =
+          TensorExpressions::evaluate<ti_b_t, ti_d_t>(RAdba_expr);
 
   for (size_t b = 0; b < 4; b++) {
     for (size_t d = 0; d < 4; d++) {
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
       for (size_t a = 0; a < 4; a++) {
         expected_sum += Rulll.get(a, d, b, a);
+
+        const std::array<size_t, 4> expected_uncontracted_lhs_tensor_index{
+            {a, b, d, a}};
+        CHECK(RAdba_expr.get_tensor_index_to_sum({{b, d}}, a) ==
+              expected_uncontracted_lhs_tensor_index);
       }
       CHECK(RAdba_contracted_to_bd.get(b, d) == expected_sum);
     }
@@ -408,17 +490,23 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
       Rllul(used_for_size);
   create_tensor(make_not_null(&Rllul));
 
+  const auto RljJi_expr = Rllul(ti_l, ti_j, ti_J, ti_i);
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<4, UpLo::Lo, Frame::Grid>,
                           SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
-      RljJi_contracted_to_il = TensorExpressions::evaluate<ti_i_t, ti_l_t>(
-          Rllul(ti_l, ti_j, ti_J, ti_i));
+      RljJi_contracted_to_il =
+          TensorExpressions::evaluate<ti_i_t, ti_l_t>(RljJi_expr);
 
   for (size_t i = 0; i < 4; i++) {
     for (size_t l = 0; l < 3; l++) {
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
       for (size_t j = 0; j < 3; j++) {
         expected_sum += Rllul.get(l, j, j, i);
+
+        const std::array<size_t, 4> expected_uncontracted_lhs_tensor_index{
+            {i, j, j, l}};
+        CHECK(RljJi_expr.get_tensor_index_to_sum({{i, l}}, j) ==
+              expected_uncontracted_lhs_tensor_index);
       }
       CHECK(RljJi_contracted_to_il.get(i, l) == expected_sum);
     }
@@ -434,17 +522,23 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
       Rlluu(used_for_size);
   create_tensor(make_not_null(&Rlluu));
 
+  const auto RagDG_expr = Rlluu(ti_a, ti_g, ti_D, ti_G);
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>
-      RagDG_contracted_to_Da = TensorExpressions::evaluate<ti_D_t, ti_a_t>(
-          Rlluu(ti_a, ti_g, ti_D, ti_G));
+      RagDG_contracted_to_Da =
+          TensorExpressions::evaluate<ti_D_t, ti_a_t>(RagDG_expr);
 
   for (size_t d = 0; d < 4; d++) {
     for (size_t a = 0; a < 4; a++) {
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
       for (size_t g = 0; g < 4; g++) {
         expected_sum += Rlluu.get(a, g, d, g);
+
+        const std::array<size_t, 4> expected_uncontracted_lhs_tensor_index{
+            {d, g, a, g}};
+        CHECK(RagDG_expr.get_tensor_index_to_sum({{d, a}}, g) ==
+              expected_uncontracted_lhs_tensor_index);
       }
       CHECK(RagDG_contracted_to_Da.get(d, a) == expected_sum);
     }
@@ -460,17 +554,23 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
       Rlulu(used_for_size);
   create_tensor(make_not_null(&Rlulu));
 
+  const auto RlJiI_expr = Rlulu(ti_l, ti_J, ti_i, ti_I);
   const Tensor<DataType, Symmetry<2, 1>,
                index_list<SpatialIndex<3, UpLo::Up, Frame::Inertial>,
                           SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
-      RlJiI_contracted_to_Jl = TensorExpressions::evaluate<ti_J_t, ti_l_t>(
-          Rlulu(ti_l, ti_J, ti_i, ti_I));
+      RlJiI_contracted_to_Jl =
+          TensorExpressions::evaluate<ti_J_t, ti_l_t>(RlJiI_expr);
 
   for (size_t j = 0; j < 3; j++) {
     for (size_t l = 0; l < 3; l++) {
       DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
       for (size_t i = 0; i < 3; i++) {
         expected_sum += Rlulu.get(l, j, i, i);
+
+        const std::array<size_t, 4> expected_uncontracted_lhs_tensor_index{
+            {j, l, i, i}};
+        CHECK(RlJiI_expr.get_tensor_index_to_sum({{j, l}}, i) ==
+              expected_uncontracted_lhs_tensor_index);
       }
       CHECK(RlJiI_contracted_to_Jl.get(j, l) == expected_sum);
     }
@@ -486,11 +586,25 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
       Rulul(used_for_size);
   create_tensor(make_not_null(&Rulul));
 
+  const auto RKkLl_expr = Rulul(ti_K, ti_k, ti_L, ti_l);
   const Tensor<DataType> RKkLl_contracted =
-      TensorExpressions::evaluate(Rulul(ti_K, ti_k, ti_L, ti_l));
+      TensorExpressions::evaluate(RKkLl_expr);
 
   DataType expected_RKkLl_sum = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t k = 0; k < 3; k++) {
+    // `RKkLl_expr` is a TensorContract expression that contains another
+    // TensorContract expression. The "inner" expression will contract the L/l
+    // indices, representing contracting the 3rd and 4th indices of the rank 4
+    // tensor `Rulul` to a rank 2 tensor. The "outer" expression will then
+    // contract the K/k indices, representing contracting the rank 2 tensor to
+    // the resulting scalar. This `get_tensor_index_to_sum` test checks this
+    // outer contraction of the K/k indices. Because the inner expression is
+    // private, a similar check for it is not done.
+    //
+    // This also applies to similar rank 4 -> rank 0 contraction cases below
+    const std::array<size_t, 2> expected_uncontracted_lhs_tensor_index{{k, k}};
+    CHECK(RKkLl_expr.get_tensor_index_to_sum({{}}, k) ==
+          expected_uncontracted_lhs_tensor_index);
     for (size_t l = 0; l < 4; l++) {
       expected_RKkLl_sum += Rulul.get(k, k, l, l);
     }
@@ -499,11 +613,15 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
 
   // Contract first and third indices and second and fourth indices to rank 0
   // tensor
+  const auto RcaCA_expr = Rlluu(ti_c, ti_a, ti_C, ti_A);
   const Tensor<DataType> RcaCA_contracted =
-      TensorExpressions::evaluate(Rlluu(ti_c, ti_a, ti_C, ti_A));
+      TensorExpressions::evaluate(RcaCA_expr);
 
   DataType expected_RcaCA_sum = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t c = 0; c < 4; c++) {
+    const std::array<size_t, 2> expected_uncontracted_lhs_tensor_index{{c, c}};
+    CHECK(RcaCA_expr.get_tensor_index_to_sum({{}}, c) ==
+          expected_uncontracted_lhs_tensor_index);
     for (size_t a = 0; a < 4; a++) {
       expected_RcaCA_sum += Rlluu.get(c, a, c, a);
     }
@@ -512,11 +630,15 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
 
   // Contract first and fourth indices and second and third indices to rank 0
   // tensor
+  const auto RjIiJ_expr = Rlulu(ti_j, ti_I, ti_i, ti_J);
   const Tensor<DataType> RjIiJ_contracted =
-      TensorExpressions::evaluate(Rlulu(ti_j, ti_I, ti_i, ti_J));
+      TensorExpressions::evaluate(RjIiJ_expr);
 
   DataType expected_RjIiJ_sum = make_with_value<DataType>(used_for_size, 0.0);
   for (size_t j = 0; j < 3; j++) {
+    const std::array<size_t, 2> expected_uncontracted_lhs_tensor_index{{j, j}};
+    CHECK(RjIiJ_expr.get_tensor_index_to_sum({{}}, j) ==
+          expected_uncontracted_lhs_tensor_index);
     for (size_t i = 0; i < 3; i++) {
       expected_RjIiJ_sum += Rlulu.get(j, i, i, j);
     }


### PR DESCRIPTION
## Proposed changes

This PR makes it so that the storage indices of components to sum for contractions (`TensorContract` expressions) are precomputed at compile time. Specifically, for each component to be computed in the resultant contracted tensor, the list of storage indices of the components that need to be summed is precomputed.

For more on the motivation and benefits of this change, see **Further Comments** below.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

One motivation for this PR is faster runtime lookup of components to sum in computing a contraction. Moreover, another important benefit of the changes to the storage index `TensorContract::get` is that the chain of recursive `get` calls with expressions containing `TensorContract` expressions no longer includes any calls to a multi-index `get`. By chaining together purely storage index `get` calls, we (1) don't perform unnecessary computations converting between the two and we (2) can now leverage the speedup provided by the storage index `TensorExpression::get`'s precomputed mapping between LHS and RHS storage indices (used for handling generic index order differences on each side). Without these changes, as we recurse through the syntax tree of an expression containing a `TensorContract`, because the storage index `TensorContract::get` currently calls the multi-index `TensorContract::get`, this means that when we hit the leaves of our syntax tree (base case, when we return a tensor component's value), this final `get` call is to the multi-index `TensorExpression::get` instead of the storage index `TensorExpression::get`. With these changes, the final `get` call at the leaves of a syntax tree representing an expression containing a `TensorContract` is instead to the storage index `TensorExpression::get`, where we get to leverage the speedup provided by its precomputed map. This currently existing `TensorExpression::get` precomputed map is extremely similar in nature to and was part of the inspiration for the precomputed map being added for `TensorContract` in this PR.
