### PR TITLE
Add YlmSpherepackTag

### DIFF
--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -366,6 +366,25 @@ struct RicciScalarCompute : RicciScalar, db::ComputeTag {
   using return_type = Scalar<DataVector>;
 };
 
+/// Stores a `YlmSpherepack` object for computing gradients and integrals on a
+/// `Strahlkorper`
+struct YlmSpherepack : db::SimpleTag {
+  using type = ::YlmSpherepack;
+};
+
+/// Computes a `YlmSpherepack` object for computing gradients and integrals on
+/// a `Strahlkorper`
+template <typename Frame>
+struct YlmSpherepackCompute : YlmSpherepack, db::ComputeTag {
+  using base = YlmSpherepack;
+  static const ::YlmSpherepack& function(
+      const ::Strahlkorper<Frame>& strahlkorper) noexcept {
+    return strahlkorper.ylm_spherepack();
+  }
+  using argument_tags = tmpl::list<Strahlkorper<Frame>>;
+  using return_type = ::YlmSpherepack;
+};
+
 // @{
 /// `Tangents(i,j)` is \f$\partial x_{\rm surf}^i/\partial q^j\f$,
 /// where \f$x_{\rm surf}^i\f$ are the Cartesian coordinates of the

--- a/src/ApparentHorizons/TagsDeclarations.hpp
+++ b/src/ApparentHorizons/TagsDeclarations.hpp
@@ -49,6 +49,9 @@ struct UnitNormalVectorCompute;
 struct RicciScalar;
 template <typename Frame>
 struct RicciScalarCompute;
+struct YlmSpherepack;
+template <typename Frame>
+struct YlmSpherepackCompute;
 
 }  // namespace StrahlkorperTags
 

--- a/tests/Unit/ApparentHorizons/Test_Tags.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Tags.cpp
@@ -300,6 +300,8 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
       "OneOverOneFormMagnitude");
   TestHelpers::db::test_simple_tag<StrahlkorperTags::RicciScalar>(
       "RicciScalar");
+  TestHelpers::db::test_simple_tag<StrahlkorperTags::YlmSpherepack>(
+      "YlmSpherepack");
   TestHelpers::db::test_simple_tag<
       StrahlkorperTags::UnitNormalOneForm<Frame::Inertial>>(
       "UnitNormalOneForm");
@@ -414,4 +416,6 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
   TestHelpers::db::test_compute_tag<
       StrahlkorperTags::RicciScalarCompute<Frame::Inertial>>(
       "RicciScalar");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::YlmSpherepackCompute<Frame::Inertial>>("YlmSpherepack");
 }


### PR DESCRIPTION
## Proposed changes

YlmSpherepackTag and YlmSpherepackCompute stores and computes a YlmSpherepack object for computing gradients and integrals on a Strahlkorper.

### Types of changes:

- [ ] Bugfix
- [x ] New feature
- [ ] Refactor

### Component:

- [ x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--

-->
