### PR TITLE
Cce analytic test exe

### DIFF
--- a/src/Evolution/Executables/Cce/CMakeLists.txt
+++ b/src/Evolution/Executables/Cce/CMakeLists.txt
@@ -18,6 +18,14 @@ add_spectre_parallel_executable(
   CharacteristicExtract
   CharacteristicExtract
   Evolution/Executables/Cce
-  EvolutionMetavars
+  EvolutionMetavars<Cce::H5WorldtubeBoundary>
+  "${LIBS_TO_LINK}"
+  )
+
+add_spectre_parallel_executable(
+  AnalyticTestCharacteristicExtract
+  CharacteristicExtract
+  Evolution/Executables/Cce
+  EvolutionMetavars<Cce::AnalyticWorldtubeBoundary>
   "${LIBS_TO_LINK}"
   )

--- a/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
+++ b/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
@@ -3,6 +3,13 @@
 
 #pragma once
 
+#include "Evolution/Systems/Cce/AnalyticSolutions/BouncingBlackHole.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/GaugeWave.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/RotatingSchwarzschild.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/SphericalMetricData.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/TeukolskyWave.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp"
 #include "Evolution/Systems/Cce/BoundaryData.hpp"
 #include "Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp"
 #include "Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp"
@@ -29,6 +36,7 @@
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 
+template <template <typename> class BoundaryComponent>
 struct EvolutionMetavars {
   using system = Cce::System;
 
@@ -88,7 +96,7 @@ struct EvolutionMetavars {
   using cce_angular_coordinate_tags =
       tmpl::list<Cce::Tags::CauchyAngularCoords>;
 
-  using cce_boundary_component = Cce::H5WorldtubeBoundary<EvolutionMetavars>;
+  using cce_boundary_component = BoundaryComponent<EvolutionMetavars>;
 
   using component_list =
       tmpl::list<observers::ObserverWriter<EvolutionMetavars>,
@@ -116,7 +124,8 @@ struct EvolutionMetavars {
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{
-    &setup_error_handling, &disable_openblas_multithreading,
+    &setup_error_handling,
+    &disable_openblas_multithreading,
     &Parallel::register_derived_classes_with_charm<
         Cce::InitializeJ::InitializeJ>,
     &Parallel::register_derived_classes_with_charm<
@@ -125,7 +134,9 @@ static const std::vector<void (*)()> charm_init_node_funcs{
         Cce::WorldtubeBufferUpdater<Cce::cce_bondi_input_tags>>,
     &Parallel::register_derived_classes_with_charm<Cce::WorldtubeDataManager>,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
-    &Parallel::register_derived_classes_with_charm<intrp::SpanInterpolator>};
+    &Parallel::register_derived_classes_with_charm<intrp::SpanInterpolator>,
+    &Parallel::register_derived_classes_with_charm<
+        Cce::Solutions::WorldtubeData>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};

--- a/src/Evolution/Executables/Cce/CharacteristicExtractFwd.hpp
+++ b/src/Evolution/Executables/Cce/CharacteristicExtractFwd.hpp
@@ -3,4 +3,13 @@
 
 #pragma once
 
+namespace Cce {
+template <class Metavariables>
+class H5WorldtubeBoundary;
+
+template <class Metavariables>
+class AnalyticWorldtubeBoundary;
+}
+
+template <template <typename> class BoundaryComponent>
 struct EvolutionMetavars;

--- a/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionScri.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionScri.hpp
@@ -16,8 +16,14 @@
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
+#include "Utilities/TypeTraits/IsA.hpp"
 
 namespace Cce {
+
+/// \cond
+template <class Metavariables>
+struct AnalyticWorldtubeBoundary;
+/// \endcond
 namespace Actions {
 
 /*!
@@ -39,10 +45,16 @@ namespace Actions {
  * mechanism, so `Actions::SetupDataBox` must be present in the `Initialization`
  * phase action list prior to this action.
  */
-template <typename ScriValuesToObserve>
+template <typename ScriValuesToObserve, typename BoundaryComponent>
 struct InitializeCharacteristicEvolutionScri {
-  using initialization_tags =
-      tmpl::list<InitializationTags::ScriInterpolationOrder>;
+  using initialization_tags = tmpl::flatten<tmpl::list<
+      InitializationTags::ScriInterpolationOrder,
+      tmpl::conditional_t<
+          tt::is_a_v<AnalyticWorldtubeBoundary, BoundaryComponent>,
+          tmpl::list<Tags::AnalyticBoundaryDataManager>, tmpl::list<>>>>;
+  using initialization_tags_to_keep = tmpl::conditional_t<
+      tt::is_a_v<AnalyticWorldtubeBoundary, BoundaryComponent>,
+      tmpl::list<Tags::AnalyticBoundaryDataManager>, tmpl::list<>>;
   using const_global_cache_tags =
       tmpl::list<Tags::LMax, Tags::NumberOfRadialPoints>;
 

--- a/src/Evolution/Systems/Cce/Actions/InitializeFirstHypersurface.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeFirstHypersurface.hpp
@@ -34,10 +34,16 @@ namespace Actions {
  * `InitializeScriPlusValue<Tags::InertialRetardedTime>` to perform the
  * computations. Refer to the documentation for those mutators for mathematical
  * details.
+ *
+ * \note This action accesses the base tag `Cce::Tags::InitializeJBase`,
+ * trusting that a tag that inherits from that base tag is present in the box or
+ * the global cache. Typically, this tag should be added by the worldtube
+ * boundary component, as the type of initial data is decided by the type of the
+ * worldtube boundary data.
  */
 struct InitializeFirstHypersurface {
   using const_global_cache_tags =
-      tmpl::list<Tags::LMax, Tags::NumberOfRadialPoints, Tags::InitializeJ>;
+      tmpl::list<Tags::LMax, Tags::NumberOfRadialPoints>;
 
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
@@ -50,7 +56,7 @@ struct InitializeFirstHypersurface {
       const ParallelComponent* const /*meta*/) noexcept {
     db::mutate_apply<InitializeJ::InitializeJ::mutate_tags,
                      InitializeJ::InitializeJ::argument_tags>(
-        db::get<Tags::InitializeJ>(box), make_not_null(&box));
+        db::get<Tags::InitializeJBase>(box), make_not_null(&box));
     db::mutate_apply<InitializeScriPlusValue<Tags::InertialRetardedTime>>(
         make_not_null(&box),
         db::get<::Tags::TimeStepId>(box).substep_time().value());

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/TeukolskyWave.cpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/TeukolskyWave.cpp
@@ -205,8 +205,9 @@ void TeukolskyWave::spherical_metric(
 
   get<1, 3>(*spherical_metric) = 0.0;
   get<2, 3>(*spherical_metric) = 0.0;
-  get<1, 1>(*spherical_metric) = 3.0 * square(local_cos_theta);
-  get<1, 2>(*spherical_metric) = -6.0 * local_sin_theta * local_cos_theta *
+  get<1, 1>(*spherical_metric) =
+      1.0 + coefficient_a * (2.0 - 3.0 * square(local_sin_theta));
+  get<1, 2>(*spherical_metric) = -3.0 * local_sin_theta * local_cos_theta *
                                  extraction_radius_ * coefficient_b;
   get<2, 2>(*spherical_metric) =
       (1.0 + 3.0 * square(local_sin_theta) * coefficient_c - coefficient_a) *
@@ -239,12 +240,13 @@ void TeukolskyWave::dr_spherical_metric(
     dr_spherical_metric->get(0, a) = 0.0;
   }
 
-  get<1, 1>(*dr_spherical_metric) = 0.0;
+  get<1, 1>(*dr_spherical_metric) =
+      dr_coefficient_a * (2.0 - 3.0 * square(local_sin_theta));
   get<1, 3>(*dr_spherical_metric) = 0.0;
   get<2, 3>(*dr_spherical_metric) = 0.0;
 
   get<1, 2>(*dr_spherical_metric) =
-      -6.0 * local_sin_theta * local_cos_theta *
+      -3.0 * local_sin_theta * local_cos_theta *
       (coefficient_b + extraction_radius_ * dr_coefficient_b);
   get<2, 2>(*dr_spherical_metric) =
       (2.0 *
@@ -281,10 +283,11 @@ void TeukolskyWave::dt_spherical_metric(
     dt_spherical_metric->get(0, a) = 0.0;
   }
 
-  get<1, 1>(*dt_spherical_metric) = 0.0;
+  get<1, 1>(*dt_spherical_metric) =
+      dt_coefficient_a * (2.0 - 3.0 * square(local_sin_theta));
   get<1, 3>(*dt_spherical_metric) = 0.0;
   get<2, 3>(*dt_spherical_metric) = 0.0;
-  get<1, 2>(*dt_spherical_metric) = -6.0 * local_sin_theta * local_cos_theta *
+  get<1, 2>(*dt_spherical_metric) = -3.0 * local_sin_theta * local_cos_theta *
                                     extraction_radius_ * dt_coefficient_b;
   get<2, 2>(*dt_spherical_metric) =
       ((-dt_coefficient_a + 3.0 * square(local_sin_theta) * dt_coefficient_c) *
@@ -303,7 +306,7 @@ void TeukolskyWave::variables_impl(
     tmpl::type_<Tags::News> /*meta*/) const noexcept {
   const auto local_sin_theta = sin_theta(l_max);
   get(*news).data() =
-      std::complex<double>{6.0, 0.0} * square(local_sin_theta) * amplitude_ *
+      -std::complex<double>{6.0, 0.0} * square(local_sin_theta) * amplitude_ *
       exp(-square(time - extraction_radius_) / square(duration_)) *
       (time - extraction_radius_) / pow<10>(duration_) *
       (15.0 * pow<4>(duration_) -

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/TeukolskyWave.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/TeukolskyWave.hpp
@@ -222,7 +222,7 @@ struct TeukolskyWave : public SphericalMetricData {
    *
    * \f{align*}{
    * g_{tt} &= -1\\
-   * g_{rr} &= (1 + f_{rr}) \\
+   * g_{rr} &= (1 + A f_{rr}) \\
    * g_{r \theta} &= 2 B f_{r \theta} r\\
    * g_{\theta \theta} &= (1 + C f_{\theta \theta}^{(C)}
    * + A f_{\theta \theta}^{(A)}) r^2\\
@@ -295,7 +295,8 @@ struct TeukolskyWave : public SphericalMetricData {
    * form
    *
    * \f{align*}{
-   * \partial_r g_{r \theta} &= 2 f_{r \theta} (B + r \partial_r B)\\
+   * \partial_r g_{rr} &= f_{r r} \partial_r A \\
+   * \partial_r g_{r \theta} &= f_{r \theta} (B + r \partial_r B)\\
    * \partial_r g_{\theta \theta} &= 2 (1 + C f_{\theta \theta}^{(C)}
    * + A f_{\theta \theta}^{(A)}) r
    * + (\partial_r C f_{\theta \theta}^{(C)}
@@ -347,7 +348,8 @@ struct TeukolskyWave : public SphericalMetricData {
    * form
    *
    * \f{align*}{
-   * \partial_t g_{r \theta} &= 2 f_{r \theta} r \partial_t B\\
+   * \partial_t g_{rr} &= f_{r r} \partial_t A \\
+   * \partial_t g_{r \theta} &= f_{r \theta} r \partial_t B\\
    * \partial_t g_{\theta \theta} &=
    * (\partial_t C f_{\theta \theta}^{(C)}
    * + \partial_t A f_{\theta \theta}^{(A)}) r^2 \\
@@ -393,7 +395,7 @@ struct TeukolskyWave : public SphericalMetricData {
    * \details The value of the news is
    *
    * \f{align*}{
-   * N = - \frac{3 \sin^2 \theta}{4} \partial_u^5 F(u)
+   * N = \frac{3 \sin^2 \theta}{4} \partial_u^5 F(u)
    * \f}
    *
    * where \f$F(u)\f$ is the pulse profile, taken to be
@@ -405,7 +407,7 @@ struct TeukolskyWave : public SphericalMetricData {
    * So, the news expands to
    *
    * \f[
-   * N = \frac{6 a e^{-u^2/k^2} u}{k^{10}} \left(15 k^4 - 20 k^2 u^2
+   * N = -\frac{6 a e^{-u^2/k^2} u}{k^{10}} \left(15 k^4 - 20 k^2 u^2
    * + 4 u^4\right)
    * \f]
    *

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp
@@ -8,6 +8,8 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/Cce/Initialize/InitializeJ.hpp"
+#include "Evolution/Systems/Cce/Initialize/InverseCubic.hpp"
 #include "Evolution/Systems/Cce/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
@@ -117,6 +119,11 @@ struct WorldtubeData : public PUP::able {
   }
 
   void pup(PUP::er& p) noexcept override;
+
+  virtual std::unique_ptr<Cce::InitializeJ::InitializeJ> get_initialize_j(
+      const double /*start_time*/) const noexcept {
+    return std::make_unique<Cce::InitializeJ::InverseCubic>();
+  };
 
  protected:
   template <typename Tag>

--- a/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
@@ -100,7 +100,8 @@ struct CharacteristicEvolution {
           typename Metavariables::evolved_coordinates_variables_tag,
           typename Metavariables::evolved_swsh_tag>,
       Actions::InitializeCharacteristicEvolutionScri<
-          typename Metavariables::scri_values_to_observe>,
+          typename Metavariables::scri_values_to_observe,
+          typename Metavariables::cce_boundary_component>,
       Actions::RequestBoundaryData<
           typename Metavariables::cce_boundary_component,
           CharacteristicEvolution<Metavariables>>,

--- a/src/Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp
+++ b/src/Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp
@@ -39,10 +39,6 @@ struct WorldtubeComponentBase {
                                         Metavariables::Phase::Evolve,
                                         worldtube_boundary_computation_steps>>;
 
-  using const_global_cache_tag_list =
-      Parallel::detail::get_const_global_cache_tags_from_pdal<
-          phase_dependent_action_list>;
-
   using options = tmpl::list<>;
 
   static void initialize(Parallel::CProxy_GlobalCache<
@@ -91,7 +87,7 @@ struct H5WorldtubeBoundary
   using base_type::execute_next_phase;
   using base_type::initialize;
   using typename base_type::chare_type;
-  using typename base_type::const_global_cache_tag_list;
+  using const_global_cache_tags = tmpl::list<Tags::InitializeJ>;
   using typename base_type::initialization_tags;
   using typename base_type::metavariables;
   using typename base_type::options;
@@ -133,7 +129,7 @@ struct AnalyticWorldtubeBoundary
   using base_type::execute_next_phase;
   using base_type::initialize;
   using typename base_type::chare_type;
-  using typename base_type::const_global_cache_tag_list;
+  using const_global_cache_tags = tmpl::list<Tags::AnalyticInitializeJ>;
   using typename base_type::initialization_tags;
   using typename base_type::metavariables;
   using typename base_type::options;
@@ -175,7 +171,7 @@ struct GhWorldtubeBoundary
   using base_type::execute_next_phase;
   using base_type::initialize;
   using typename base_type::chare_type;
-  using typename base_type::const_global_cache_tag_list;
+  using const_global_cache_tags = tmpl::list<Tags::InitializeJ>;
   using typename base_type::initialization_tags;
   using typename base_type::metavariables;
   using typename base_type::options;

--- a/src/Evolution/Systems/Cce/OptionTags.hpp
+++ b/src/Evolution/Systems/Cce/OptionTags.hpp
@@ -494,7 +494,12 @@ struct InterfaceManagerInterpolationStrategy : db::SimpleTag {
   }
 };
 
-struct InitializeJ : db::SimpleTag {
+/// Base tag for first-hypersurface initialization procedure
+struct InitializeJBase : db::BaseTag {};
+
+/// Tag for first-hypersurface initialization procedure specified by input
+/// options.
+struct InitializeJ : db::SimpleTag, InitializeJBase {
   using type = std::unique_ptr<::Cce::InitializeJ::InitializeJ>;
   using option_tags = tmpl::list<OptionTags::InitializeJ>;
 
@@ -503,6 +508,20 @@ struct InitializeJ : db::SimpleTag {
       const std::unique_ptr<::Cce::InitializeJ::InitializeJ>&
           initialize_j) noexcept {
     return initialize_j->get_clone();
+  }
+};
+
+// Tags that generates an `Cce::InitializeJ::InitializeJ` derived class from an
+// analytic solution.
+struct AnalyticInitializeJ : db::SimpleTag, InitializeJBase {
+  using type = std::unique_ptr<::Cce::InitializeJ::InitializeJ>;
+  using option_tags =
+      tmpl::list<OptionTags::AnalyticSolution, OptionTags::StartTime>;
+  static constexpr bool pass_metavariables = false;
+  static std::unique_ptr<::Cce::InitializeJ::InitializeJ> create_from_options(
+      const std::unique_ptr<Cce::Solutions::WorldtubeData>& worldtube_data,
+      const std::optional<double> start_time) noexcept {
+    return worldtube_data->get_initialize_j(*start_time);
   }
 };
 

--- a/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
@@ -1,0 +1,44 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: AnalyticTestCharacteristicExtract
+# Check: parse;execute_check_output
+# Timeout: 10
+# OutputFileChecks:
+#   - Label: "check_news"
+#     Subfile: "/News.dat"
+#     FileGlob: "CharacteristicExtractVolume*.h5"
+#     ExpectedDataSubfile: "/News_expected.dat"
+#     AbsoluteTolerance: 5e-5
+
+Evolution:
+  TimeStepper: RungeKutta3
+
+Observers:
+  VolumeFileName: "CharacteristicExtractVolume"
+  ReductionFileName: "CharacteristicExtractUnusedReduction"
+
+Cce:
+  LMax: 8
+  NumberOfRadialPoints: 8
+  ObservationLMax: 8
+
+  StartTime: 0.0
+  EndTime: 0.8
+  TargetStepSize: 0.1
+  ExtractionRadius: 30.0
+
+  AnalyticSolution:
+    BouncingBlackHole:
+      Period: 40.0
+      ExtractionRadius: 30.0
+      Mass: 1.0
+      Amplitude: 2.0
+
+  Filtering:
+    RadialFilterHalfPower: 24
+    RadialFilterAlpha: 35.0
+    FilterLMax: 6
+
+  ScriInterpOrder: 3
+  ScriOutputDensity: 1

--- a/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
@@ -1,0 +1,46 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: AnalyticTestCharacteristicExtract
+# Check: parse;execute_check_output
+# Timeout: 10
+# OutputFileChecks:
+#   - Label: "check_news"
+#     Subfile: "/News.dat"
+#     FileGlob: "CharacteristicExtractVolume*.h5"
+#     ExpectedDataSubfile: "/News_expected.dat"
+#     AbsoluteTolerance: 5e-10
+
+Evolution:
+  TimeStepper: RungeKutta3
+
+Observers:
+  VolumeFileName: "CharacteristicExtractVolume"
+  ReductionFileName: "CharacteristicExtractUnusedReduction"
+
+Cce:
+  LMax: 8
+  NumberOfRadialPoints: 8
+  ObservationLMax: 8
+
+  StartTime: 0.0
+  EndTime: 4.0
+  TargetStepSize: 0.4
+  ExtractionRadius: 40.0
+
+  AnalyticSolution:
+    GaugeWave:
+      ExtractionRadius: 40.0
+      Mass: 1.0
+      Frequency: 0.5
+      Amplitude: 0.1
+      PeakTime: 50.0
+      Duration: 10.0
+
+  Filtering:
+    RadialFilterHalfPower: 24
+    RadialFilterAlpha: 35.0
+    FilterLMax: 6
+
+  ScriInterpOrder: 3
+  ScriOutputDensity: 1

--- a/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
@@ -1,0 +1,43 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: AnalyticTestCharacteristicExtract
+# Check: parse;execute_check_output
+# Timeout: 10
+# OutputFileChecks:
+#   - Label: "check_news"
+#     Subfile: "/News.dat"
+#     FileGlob: "CharacteristicExtractVolume*.h5"
+#     ExpectedDataSubfile: "/News_expected.dat"
+#     AbsoluteTolerance: 1e-11
+
+Evolution:
+  TimeStepper: RungeKutta3
+
+Observers:
+  VolumeFileName: "CharacteristicExtractVolume"
+  ReductionFileName: "CharacteristicExtractUnusedReduction"
+
+Cce:
+  LMax: 8
+  NumberOfRadialPoints: 8
+  ObservationLMax: 8
+
+  StartTime: 0.0
+  EndTime: 2.4
+  TargetStepSize: 0.2
+  ExtractionRadius: 20.0
+
+  AnalyticSolution:
+    RotatingSchwarzschild:
+      ExtractionRadius: 20.0
+      Mass: 1.0
+      Frequency: 0.0
+
+  Filtering:
+    RadialFilterHalfPower: 24
+    RadialFilterAlpha: 35.0
+    FilterLMax: 6
+
+  ScriInterpOrder: 3
+  ScriOutputDensity: 1

--- a/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
@@ -1,0 +1,43 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: AnalyticTestCharacteristicExtract
+# Check: parse;execute_check_output
+# Timeout: 10
+# OutputFileChecks:
+#   - Label: "check_news"
+#     Subfile: "/News.dat"
+#     FileGlob: "CharacteristicExtractVolume*.h5"
+#     ExpectedDataSubfile: "/News_expected.dat"
+#     AbsoluteTolerance: 5e-10
+
+Evolution:
+  TimeStepper: RungeKutta3
+
+Observers:
+  VolumeFileName: "CharacteristicExtractVolume"
+  ReductionFileName: "CharacteristicExtractUnusedReduction"
+
+Cce:
+  LMax: 8
+  NumberOfRadialPoints: 8
+  ObservationLMax: 8
+
+  StartTime: -6.0
+  EndTime: -1.0
+  TargetStepSize: 0.5
+  ExtractionRadius: 40.0
+
+  AnalyticSolution:
+    TeukolskyWave:
+      ExtractionRadius: 40.0
+      Amplitude: 0.1
+      Duration: 2.0
+
+  Filtering:
+    RadialFilterHalfPower: 24
+    RadialFilterAlpha: 35.0
+    FilterLMax: 6
+
+  ScriInterpOrder: 3
+  ScriOutputDensity: 1

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
@@ -78,7 +78,8 @@ struct mock_characteristic_evolution {
           typename Metavariables::evolved_coordinates_variables_tag,
           typename Metavariables::evolved_swsh_tag>,
       Actions::InitializeCharacteristicEvolutionScri<
-          typename Metavariables::scri_values_to_observe>,
+          typename Metavariables::scri_values_to_observe,
+          typename Metavariables::cce_boundary_component>,
       Initialization::Actions::RemoveOptionsAndTerminatePhase>;
   using initialization_tags =
       Parallel::get_initialization_tags<initialize_action_list>;
@@ -183,7 +184,8 @@ SPECTRE_TEST_CASE(
                                                               1.0, frequency)};
   runner.set_phase(test_metavariables::Phase::Initialization);
   ActionTesting::emplace_component<evolution_component>(
-      &runner, 0, target_step_size, scri_plus_interpolation_order);
+      &runner, 0, target_step_size, scri_plus_interpolation_order,
+      serialize_and_deserialize(analytic_manager));
   // Serialize and deserialize to get around the lack of implicit copy
   // constructor.
   ActionTesting::emplace_component<worldtube_component>(

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
@@ -41,8 +41,7 @@
 namespace Cce {
 namespace {
 template <typename Metavariables>
-struct mock_analytic_worldtube_boundary
-    : AnalyticWorldtubeBoundary<Metavariables> {
+struct mock_analytic_worldtube_boundary {
   using component_being_mocked = AnalyticWorldtubeBoundary<Metavariables>;
   using replace_these_simple_actions = tmpl::list<>;
   using with_these_simple_actions = tmpl::list<>;

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
@@ -108,7 +108,8 @@ struct metavariables {
       Spectral::Swsh::Tags::Derivative<Tags::GaugeOmega,
                                        Spectral::Swsh::Tags::Eth>>>;
 
-  using const_global_cache_tags = tmpl::list<Tags::SpecifiedStartTime>;
+  using const_global_cache_tags =
+      tmpl::list<Tags::SpecifiedStartTime, Tags::InitializeJ>;
 
   using scri_values_to_observe = tmpl::list<>;
   using cce_integrand_tags = tmpl::flatten<tmpl::transform<
@@ -188,9 +189,9 @@ SPECTRE_TEST_CASE(
   const double target_step_size = 0.01 * value_dist(gen);
 
   ActionTesting::MockRuntimeSystem<metavariables> runner{
-      {start_time, l_max, number_of_radial_points,
-       std::make_unique<::TimeSteppers::RungeKutta3>(),
-       std::make_unique<InitializeJ::InverseCubic>()}};
+      {start_time, std::make_unique<InitializeJ::InverseCubic>(), l_max,
+       number_of_radial_points,
+       std::make_unique<::TimeSteppers::RungeKutta3>()}};
 
   ActionTesting::set_phase(make_not_null(&runner),
                            metavariables::Phase::Initialization);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
@@ -88,7 +88,8 @@ struct mock_characteristic_evolution {
           typename Metavariables::evolved_coordinates_variables_tag,
           typename Metavariables::evolved_swsh_tag>,
       Actions::InitializeCharacteristicEvolutionScri<
-          typename Metavariables::scri_values_to_observe>>;
+          typename Metavariables::scri_values_to_observe,
+          typename Metavariables::cce_boundary_component>>;
   using initialization_tags =
       Parallel::get_initialization_tags<initialize_action_list>;
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
@@ -34,6 +34,7 @@
 #include "Time/TimeSteppers/RungeKutta3.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/FileSystem.hpp"
+#include "Utilities/NoSuchType.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -52,7 +53,7 @@ struct mock_characteristic_evolution {
           typename Metavariables::evolved_coordinates_variables_tag,
           typename Metavariables::evolved_swsh_tag>,
       Actions::InitializeCharacteristicEvolutionScri<
-          typename Metavariables::scri_values_to_observe>,
+          typename Metavariables::scri_values_to_observe, NoSuchType>,
       Initialization::Actions::RemoveOptionsAndTerminatePhase>;
   using initialization_tags =
       Parallel::get_initialization_tags<initialize_action_list>;

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeFirstHypersurface.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeFirstHypersurface.cpp
@@ -9,6 +9,7 @@
 
 #include "DataStructures/ComplexDataVector.hpp"
 #include "DataStructures/ComplexModalVector.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/SpinWeighted.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Evolution/Systems/Cce/Actions/UpdateGauge.hpp"
@@ -50,6 +51,9 @@ using swsh_boundary_tags_to_compute = tmpl::list<Tags::GaugeC, Tags::GaugeD>;
 using swsh_volume_tags_to_compute = tmpl::list<Tags::BondiJ>;
 
 template <typename Metavariables>
+struct dummy_boundary {};
+
+template <typename Metavariables>
 struct mock_characteristic_evolution {
   using simple_tags = db::AddSimpleTags<
       ::Tags::Variables<real_boundary_tags_to_compute>,
@@ -60,6 +64,7 @@ struct mock_characteristic_evolution {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
+  using const_global_cache_tags = tmpl::list<Tags::InitializeJ>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
@@ -100,8 +105,8 @@ SPECTRE_TEST_CASE(
 
   using component = mock_characteristic_evolution<metavariables>;
   ActionTesting::MockRuntimeSystem<metavariables> runner{
-      {l_max, number_of_radial_points,
-       std::make_unique<InitializeJ::InverseCubic>()}};
+      {std::make_unique<InitializeJ::InverseCubic>(), l_max,
+       number_of_radial_points}};
 
   Variables<real_boundary_tags_to_compute> real_variables{
       Spectral::Swsh::number_of_swsh_collocation_points(l_max)};

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
@@ -26,6 +26,7 @@
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Utilities/NoSuchType.hpp"
 
 namespace Cce {
 namespace {
@@ -80,7 +81,7 @@ struct mock_characteristic_evolution {
           typename Metavariables::evolved_coordinates_variables_tag,
           typename Metavariables::evolved_swsh_tag>,
       Actions::InitializeCharacteristicEvolutionScri<
-          typename Metavariables::scri_values_to_observe>,
+          typename Metavariables::scri_values_to_observe, NoSuchType>,
       Initialization::Actions::RemoveOptionsAndTerminatePhase>;
   using initialization_tags =
       Parallel::get_initialization_tags<initialize_action_list>;

--- a/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/Test_BouncingBlackHole.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/Test_BouncingBlackHole.cpp
@@ -302,5 +302,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.BouncingBlackHole",
   Solutions::TestHelpers::check_adm_metric_quantities(
       boundary_tuple, mapped_schwarzschild_metric, dt_spacetime_metric,
       d_spacetime_metric);
+  Solutions::TestHelpers::test_initialize_j(
+      l_max, 5_st, extraction_radius, time,
+      std::make_unique<InitializeJ::InverseCubic>(),
+      analytic_solution.get_clone());
 }
 }  // namespace Cce

--- a/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/Test_GaugeWave.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/Test_GaugeWave.cpp
@@ -5,8 +5,11 @@
 
 #include <complex>
 #include <cstddef>
+#include <memory>
 
 #include "Evolution/Systems/Cce/AnalyticSolutions/GaugeWave.hpp"
+#include "Evolution/Systems/Cce/Initialize/InitializeJ.hpp"
+#include "Evolution/Systems/Cce/Initialize/InverseCubic.hpp"
 #include "Framework/Pypp.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Framework/TestHelpers.hpp"
@@ -37,5 +40,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.GaugeWave", "[Unit][Cce]") {
       frequency, amplitude, peak_time, duration);
   boundary_solution.test_serialize_and_deserialize(l_max,
                                                    peak_time - 0.1 * duration);
+  TestHelpers::test_initialize_j(l_max, 5_st, extraction_radius,
+                                 peak_time - 0.1 * duration,
+                                 std::make_unique<InitializeJ::InverseCubic>(),
+                                 boundary_solution.get_clone());
 }
 }  // namespace Cce::Solutions

--- a/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/Test_LinearizedBondiSachs.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/Test_LinearizedBondiSachs.cpp
@@ -374,6 +374,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.LinearizedBondiSachs",
   }
   Solutions::TestHelpers::check_adm_metric_quantities(
       boundary_data, spacetime_metric, dt_spacetime_metric, d_spacetime_metric);
+  Solutions::TestHelpers::test_initialize_j(
+      l_max, 5_st, extraction_radius, time,
+      std::make_unique<InitializeJ::InverseCubic>(),
+      boundary_solution.get_clone());
 }
 }  // namespace
 }  // namespace Cce::Solutions

--- a/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/Test_RotatingSchwarzschild.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/Test_RotatingSchwarzschild.cpp
@@ -35,5 +35,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.RotatingSchwarzschild",
                                           approx, extraction_radius, mass,
                                           frequency);
   boundary_solution.test_serialize_and_deserialize(l_max, time);
+  TestHelpers::test_initialize_j(l_max, 5_st, extraction_radius, time,
+                                 std::make_unique<InitializeJ::InverseCubic>(),
+                                 boundary_solution.get_clone());
 }
 }  // namespace Cce::Solutions

--- a/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/Test_TeukolskyWave.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/Test_TeukolskyWave.cpp
@@ -33,5 +33,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.TeukolskyWave", "[Unit][Cce]") {
                                           extraction_radius, amplitude,
                                           duration);
   boundary_solution.test_serialize_and_deserialize(l_max, time);
+  TestHelpers::test_initialize_j(l_max, 5_st, extraction_radius, time,
+                                 std::make_unique<InitializeJ::InverseCubic>(),
+                                 boundary_solution.get_clone());
 }
 }  // namespace Cce::Solutions

--- a/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
@@ -72,6 +72,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
   TestHelpers::db::test_simple_tag<Cce::Tags::AnalyticBoundaryDataManager>(
       "AnalyticBoundaryDataManager");
   TestHelpers::db::test_simple_tag<Cce::Tags::InitializeJ>("InitializeJ");
+  TestHelpers::db::test_simple_tag<Cce::Tags::AnalyticInitializeJ>(
+      "AnalyticInitializeJ");
 
   CHECK(TestHelpers::test_creation<size_t, Cce::OptionTags::LMax>("8") == 8_st);
   CHECK(TestHelpers::test_creation<size_t, Cce::OptionTags::FilterLMax>("7") ==

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/AnalyticSolutions/AnalyticDataHelpers.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/AnalyticSolutions/AnalyticDataHelpers.hpp
@@ -135,6 +135,14 @@ struct SphericalSolutionWrapper : public SphericalSolution {
   using SphericalSolution::extraction_radius_;
 };
 
+// Test the `InitializeJ` object produced by the `WorldtubeData` against an
+// expected `InitializeJ` object also provided in the arguments.
+void test_initialize_j(
+    size_t l_max, size_t number_of_radial_points, double extraction_radius,
+    double time,
+    std::unique_ptr<InitializeJ::InitializeJ> expected_initialize_j,
+    std::unique_ptr<WorldtubeData> analytic_solution) noexcept;
+
 // This function determines the Bondi-Sachs scalars from a Cartesian spacetime
 // metric, assuming that the metric is already in null form, so the spatial
 // coordinates are related to standard Bondi-Sachs coordinates by just the


### PR DESCRIPTION
## Proposed changes

Adds the CCE analytic test executable, as well as utilities for checking the outputs of the h5 file and a couple of fixes of errors in the analytic solutions that were found when verifying the outputs of the executable.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Dependencies

- [x] #2608
