### PR TITLE
Cce analytic test: Robinson-Trautman

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -499,6 +499,16 @@
   SLACcitation   = "%%CITATION = ARXIV:1802.08682;%%"
 }
 
+@article{Derry1970fk,
+  author =       "Derry, L. and Isaacson, R. and Winicour, J.",
+  title =        "{Shear-free gravitational radiation}",
+  doi =          "10.1103/PhysRev.185.1647",
+  journal =      "Phys.Rev.",
+  volume =       "185",
+  pages =        "1647--1655",
+  year =         "1969"
+}
+
 @article{Diot2013,
   author  = {Diot, S. and Loubère, R. and Clain, S.},
   title   = {The Multidimensional Optimal Order Detection method in the

--- a/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
+++ b/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
@@ -6,6 +6,7 @@
 #include "Evolution/Systems/Cce/AnalyticSolutions/BouncingBlackHole.hpp"
 #include "Evolution/Systems/Cce/AnalyticSolutions/GaugeWave.hpp"
 #include "Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/RobinsonTrautman.hpp"
 #include "Evolution/Systems/Cce/AnalyticSolutions/RotatingSchwarzschild.hpp"
 #include "Evolution/Systems/Cce/AnalyticSolutions/SphericalMetricData.hpp"
 #include "Evolution/Systems/Cce/AnalyticSolutions/TeukolskyWave.hpp"

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/BouncingBlackHole.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/BouncingBlackHole.hpp
@@ -71,7 +71,8 @@ struct BouncingBlackHole : public WorldtubeData {
 
   WRAPPED_PUPable_decl_template(BouncingBlackHole);  // NOLINT
 
-  explicit BouncingBlackHole(CkMigrateMessage* /*unused*/) noexcept {}
+  explicit BouncingBlackHole(CkMigrateMessage* msg) noexcept
+      : WorldtubeData(msg) {}
 
   // clang doesn't manage to use = default correctly in this case
   // NOLINTNEXTLINE(modernize-use-equals-default)

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_sources(
   BouncingBlackHole.cpp
   LinearizedBondiSachs.cpp
   GaugeWave.cpp
+  RobinsonTrautman.cpp
   RotatingSchwarzschild.cpp
   SphericalMetricData.cpp
   TeukolskyWave.cpp
@@ -24,6 +25,7 @@ spectre_target_headers(
   BouncingBlackHole.hpp
   LinearizedBondiSachs.hpp
   GaugeWave.hpp
+  RobinsonTrautman.hpp
   RotatingSchwarzschild.hpp
   SphericalMetricData.hpp
   TeukolskyWave.hpp

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/GaugeWave.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/GaugeWave.hpp
@@ -91,7 +91,8 @@ struct GaugeWave : public SphericalMetricData {
 
   WRAPPED_PUPable_decl_template(GaugeWave);  // NOLINT
 
-  explicit GaugeWave(CkMigrateMessage* /*unused*/) noexcept {}
+  explicit GaugeWave(CkMigrateMessage* msg) noexcept
+      : SphericalMetricData(msg) {}
 
   // clang doesn't manage to use = default correctly in this case
   // NOLINTNEXTLINE(modernize-use-equals-default)

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.hpp
@@ -136,7 +136,8 @@ struct LinearizedBondiSachs : public SphericalMetricData {
 
   WRAPPED_PUPable_decl_template(LinearizedBondiSachs);  // NOLINT
 
-  explicit LinearizedBondiSachs(CkMigrateMessage* /*unused*/) noexcept {}
+  explicit LinearizedBondiSachs(CkMigrateMessage* msg) noexcept
+      : SphericalMetricData(msg) {}
 
   // clang doesn't manage to use = default correctly in this case
   // NOLINTNEXTLINE(hicpp-use-equals-default,modernize-use-equals-default)

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/RobinsonTrautman.cpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/RobinsonTrautman.cpp
@@ -1,0 +1,473 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Cce/AnalyticSolutions/RobinsonTrautman.hpp"
+
+#include <algorithm>
+#include <complex>
+#include <cstddef>
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/SphericalMetricData.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+#include "NumericalAlgorithms/OdeIntegration/OdeIntegration.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCoefficients.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "NumericalAlgorithms/Spectral/SwshDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/SwshFiltering.hpp"
+#include "NumericalAlgorithms/Spectral/SwshTransform.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Cce::Solutions {
+
+RobinsonTrautman::RobinsonTrautman(
+    std::vector<std::complex<double>> initial_modes,
+    const double extraction_radius, const size_t l_max, const double tolerance,
+    const double start_time, const Options::Context& context)
+    : SphericalMetricData{extraction_radius},
+      dense_output_rt_scalar_{
+          Spectral::Swsh::number_of_swsh_collocation_points(l_max)},
+      dense_output_du_rt_scalar_{
+          Spectral::Swsh::number_of_swsh_collocation_points(l_max)},
+      l_max_{l_max},
+      tolerance_{tolerance},
+      start_time_{start_time},
+      initial_modes_{std::move(initial_modes)} {
+  if (initial_modes_.size() > square(l_max + 1)) {
+    PARSE_ERROR(context,
+                "There must not be more than (l_max + 1)^2 modes specified for "
+                "InitialModes");
+  }
+  if (tolerance == 0.0) {
+    PARSE_ERROR(context,
+                "A target tolerance of 0.0 is not permitted, as it will cause "
+                "the time-stepper to enter an infinite loop.");
+  }
+  initialize_stepper_from_start();
+}
+
+void RobinsonTrautman::initialize_stepper_from_start() noexcept {
+  // create the initial data
+  SpinWeighted<ComplexModalVector, 0> goldberg_modes{square(l_max_ + 1), 0.0};
+  for (size_t i = 0; i < std::min(initial_modes_.size(), goldberg_modes.size());
+       ++i) {
+    goldberg_modes.data()[i] = gsl::at(initial_modes_, i);
+  }
+
+  SpinWeighted<ComplexModalVector, 0> libsharp_modes{
+      Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max_)};
+  const auto& coefficients_metadata =
+      Spectral::Swsh::cached_coefficients_metadata(l_max_);
+  for (const auto& coefficient : coefficients_metadata) {
+    Spectral::Swsh::goldberg_modes_to_libsharp_modes_single_pair(
+        coefficient, make_not_null(&libsharp_modes), 0,
+        goldberg_modes.data()[Spectral::Swsh::goldberg_mode_index(
+            l_max_, coefficient.l, static_cast<int>(coefficient.m), 0)],
+        goldberg_modes.data()[Spectral::Swsh::goldberg_mode_index(
+            l_max_, coefficient.l, -static_cast<int>(coefficient.m), 0)]);
+  }
+
+  {
+    // re-use the `dense_output_rt_scalar_` buffers to reduce allocations
+    auto& initial_rt_scalar = get(dense_output_rt_scalar_);
+    auto& initial_du_rt_scalar = get(dense_output_du_rt_scalar_);
+
+    Spectral::Swsh::inverse_swsh_transform(
+        l_max_, 1, make_not_null(&initial_rt_scalar), libsharp_modes);
+    // Add the modes specified in the input file to the leading-order solution
+    // of 1.0 for the Robinson-Trautman scalar.
+    initial_rt_scalar.data() =
+        1.0 + std::complex<double>(1.0, 0.0) * real(initial_rt_scalar.data());
+    du_rt_scalar(make_not_null(&initial_du_rt_scalar), initial_rt_scalar);
+    stepper_ = boost::numeric::odeint::make_dense_output(
+        tolerance_ * 0.01, tolerance_,
+        boost::numeric::odeint::runge_kutta_dopri5<ComplexDataVector>{});
+    const double rt_scalar_scale = max(abs(initial_rt_scalar.data()));
+    const double du_rt_scalar_scale = max(abs(initial_du_rt_scalar.data()));
+
+    // Take as an initial step guess a conservative factor multiplied by the
+    // rough scaling of the grid spacing. Typically, the initial_step should be
+    // set by the guess based on the scale of the fields inside the `if`, but
+    // this guess is typically acceptable when the field scale is not usable for
+    // step estimation.
+    double initial_step = extraction_radius_ * 1.0e-4 / square(l_max_);
+    if (rt_scalar_scale > 1.0e-5 and du_rt_scalar_scale > 1.0e-5) {
+      // set initial step size according to the first couple of steps in section
+      // II.4 of Solving Ordinary Differential equations by Hairer, Norsett, and
+      // Wanner
+      initial_step =
+          0.1 * rt_scalar_scale / (du_rt_scalar_scale * square(l_max_));
+    }
+    stepper_.initialize(initial_rt_scalar.data(), start_time_, initial_step);
+    // scoped to destruct buffer reference
+  }
+  const auto rt_system = [this](const ComplexDataVector& local_rt_scalar,
+                                ComplexDataVector& local_du_rt_scalar,
+                                const double /*t*/) noexcept {
+    local_du_rt_scalar.destructive_resize(local_rt_scalar.size());
+    const SpinWeighted<ComplexDataVector, 0> rt_scalar_reference;
+    make_const_view(make_not_null(&rt_scalar_reference.data()), local_rt_scalar,
+                    0, local_rt_scalar.size());
+    SpinWeighted<ComplexDataVector, 0> du_rt_scalar_reference;
+    du_rt_scalar_reference.set_data_ref(local_du_rt_scalar.data(),
+                                        local_du_rt_scalar.size());
+    du_rt_scalar(make_not_null(&du_rt_scalar_reference), rt_scalar_reference);
+    Spectral::Swsh::filter_swsh_boundary_quantity(
+        make_not_null(&du_rt_scalar_reference), l_max_, l_max_ - 3);
+  };
+  step_range_ = stepper_.do_step(rt_system);
+}
+
+std::unique_ptr<WorldtubeData> RobinsonTrautman::get_clone() const noexcept {
+  return std::make_unique<RobinsonTrautman>(*this);
+}
+
+void RobinsonTrautman::prepare_solution(const size_t l_max,
+                                        const double time) const noexcept {
+  ASSERT(l_max == l_max_,
+         "The Robinson-Trautman solution only supports the l_max resolution "
+         "specified at construction, as it must internally store the evolved "
+         "scalar at the desired resolution");
+  if (step_range_.first > time) {
+    ERROR(
+        "The Robinson-Trautman solution does not support stepping backwards in "
+        "time during the internal evolution. This error likely means that the "
+        "corresponding evolution test should be using a multistep time-stepper "
+        "so that the requested boundary data is monotonic.");
+  }
+  // step until the target time is within the current timestep
+  const auto rt_system = [this](const ComplexDataVector& local_rt_scalar,
+                                ComplexDataVector& local_du_rt_scalar,
+                                const double /*t*/) noexcept {
+    local_du_rt_scalar.destructive_resize(local_rt_scalar.size());
+    const SpinWeighted<ComplexDataVector, 0> rt_scalar_reference;
+    make_const_view(make_not_null(&rt_scalar_reference.data()), local_rt_scalar,
+                    0, local_rt_scalar.size());
+    SpinWeighted<ComplexDataVector, 0> du_rt_scalar_reference;
+    du_rt_scalar_reference.set_data_ref(local_du_rt_scalar.data(),
+                                        local_du_rt_scalar.size());
+    du_rt_scalar(make_not_null(&du_rt_scalar_reference), rt_scalar_reference);
+    Spectral::Swsh::filter_swsh_boundary_quantity(
+        make_not_null(&du_rt_scalar_reference), l_max_, l_max_ - 3);
+  };
+  while (step_range_.second < time) {
+    step_range_ = stepper_.do_step(rt_system);
+  }
+  stepper_.calc_state(time, get(dense_output_rt_scalar_).data());
+  du_rt_scalar(make_not_null(&get(dense_output_du_rt_scalar_)),
+               get(dense_output_rt_scalar_));
+  Spectral::Swsh::filter_swsh_boundary_quantity(
+      make_not_null(&get(dense_output_du_rt_scalar_)), l_max_, l_max_ - 3);
+  prepared_time_ = time;
+}
+
+void RobinsonTrautman::variables_impl(
+    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, -2>>*> news,
+    const size_t l_max, const double time,
+    tmpl::type_<Tags::News> /*meta*/) const noexcept {
+  ASSERT(time == prepared_time_,
+         "The Robinson-Trautman solution is being calculated in an "
+         "inconsistent state. The public interface should always call "
+         "`prepare_solution` before calculating any metric components, so this "
+         "may indicate inconsistent use of the internal Robinson-Trautman "
+         "calculation functions.");
+  ASSERT(l_max == l_max_,
+         "The Robinson-Trautman solution only supports the l_max resolution "
+         "specified at construction, as it must internally store the evolved "
+         "scalar at the desired resolution");
+  Spectral::Swsh::angular_derivatives<
+      tmpl::list<Spectral::Swsh::Tags::EthbarEthbar>>(
+      l_max_, 1, make_not_null(&get(*news)), get(dense_output_rt_scalar_));
+  get(*news).data() /= get(dense_output_rt_scalar_).data();
+}
+
+void RobinsonTrautman::du_rt_scalar(
+    const gsl::not_null<SpinWeighted<ComplexDataVector, 0>*> local_du_rt_scalar,
+    const SpinWeighted<ComplexDataVector, 0>& rt_scalar) const noexcept {
+  using rt_tag = ::Tags::SpinWeighted<::Tags::TempScalar<0, ComplexDataVector>,
+                                      std::integral_constant<int, 0>>;
+  using ethbar_ethbar_rt_tag =
+      Spectral::Swsh::Tags::Derivative<rt_tag,
+                                       Spectral::Swsh::Tags::EthbarEthbar>;
+  using eth_eth_ethbar_ethbar_rt_tag =
+      Spectral::Swsh::Tags::Derivative<ethbar_ethbar_rt_tag,
+                                       Spectral::Swsh::Tags::EthEth>;
+  Variables<tmpl::list<ethbar_ethbar_rt_tag, eth_eth_ethbar_ethbar_rt_tag>>
+      temporary_variables{
+          Spectral::Swsh::number_of_swsh_collocation_points(l_max_)};
+  auto& ethbar_ethbar_rt_scalar =
+      get<ethbar_ethbar_rt_tag>(temporary_variables);
+  auto& eth_eth_ethbar_ethbar_rt_scalar =
+      get<eth_eth_ethbar_ethbar_rt_tag>(temporary_variables);
+  Spectral::Swsh::angular_derivatives<
+      tmpl::list<Spectral::Swsh::Tags::EthbarEthbar>>(
+      l_max_, 1, make_not_null(&get(ethbar_ethbar_rt_scalar)), rt_scalar);
+  Spectral::Swsh::angular_derivatives<tmpl::list<Spectral::Swsh::Tags::EthEth>>(
+      l_max_, 1, make_not_null(&get(eth_eth_ethbar_ethbar_rt_scalar)),
+      get(ethbar_ethbar_rt_scalar));
+  *local_du_rt_scalar =
+      (-pow<4>(rt_scalar) * get(eth_eth_ethbar_ethbar_rt_scalar) +
+       pow<3>(rt_scalar) * get(ethbar_ethbar_rt_scalar) *
+           conj(get(ethbar_ethbar_rt_scalar))) /
+      12.0;
+}
+
+void RobinsonTrautman::bondi_u(
+    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 1>>*> bondi_u,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& rt_scalar)
+    const noexcept {
+  Spectral::Swsh::angular_derivatives<tmpl::list<Spectral::Swsh::Tags::Eth>>(
+      l_max_, 1, make_not_null(&get(*bondi_u)), get(rt_scalar));
+  get(*bondi_u).data() /= extraction_radius_;
+}
+
+void RobinsonTrautman::bondi_w(
+    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*> bondi_w,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& rt_scalar)
+    const noexcept {
+  Spectral::Swsh::angular_derivatives<
+      tmpl::list<Spectral::Swsh::Tags::EthEthbar>>(
+      l_max_, 1, make_not_null(&get(*bondi_w)), get(rt_scalar));
+  get(*bondi_w) = (get(rt_scalar) + get(*bondi_w) - 1.0) / extraction_radius_ -
+                  2.0 / square(extraction_radius_ * get(rt_scalar));
+}
+
+void RobinsonTrautman::dr_bondi_w(
+    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*> dr_bondi_w,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& rt_scalar)
+    const noexcept {
+  SpinWeighted<ComplexDataVector, 0> bondi_w{get(*dr_bondi_w).size()};
+  Spectral::Swsh::angular_derivatives<
+      tmpl::list<Spectral::Swsh::Tags::EthEthbar>>(
+      l_max_, 1, make_not_null(&bondi_w), get(rt_scalar));
+  get(*dr_bondi_w) =
+      -(get(rt_scalar) + bondi_w - 1.0) / square(extraction_radius_) +
+      4.0 / (pow<3>(extraction_radius_) * square(get(rt_scalar)));
+}
+
+void RobinsonTrautman::du_bondi_w(
+    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*> du_bondi_w,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& local_du_rt_scalar,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& rt_scalar)
+    const noexcept {
+  Spectral::Swsh::angular_derivatives<
+      tmpl::list<Spectral::Swsh::Tags::EthEthbar>>(
+      l_max_, 1, make_not_null(&get(*du_bondi_w)), get(local_du_rt_scalar));
+  get(*du_bondi_w) =
+      (get(local_du_rt_scalar) + get(*du_bondi_w)) / extraction_radius_ +
+      4.0 * get(local_du_rt_scalar) /
+          (square(extraction_radius_) * pow<3>(get(rt_scalar)));
+}
+
+void RobinsonTrautman::spherical_metric(
+    const gsl::not_null<
+        tnsr::aa<DataVector, 3, ::Frame::Spherical<::Frame::Inertial>>*>
+        spherical_metric,
+    const size_t l_max, const double time) const noexcept {
+  ASSERT(time == prepared_time_,
+         "The Robinson-Trautman solution is being calculated in an "
+         "inconsistent state. The public interface should always call "
+         "`prepare_solution` before calculating any metric components, so this "
+         "may indicate inconsistent use of the internal Robinson-Trautman "
+         "calculation functions.");
+  ASSERT(l_max == l_max_,
+         "The Robinson-Trautman solution only supports the l_max resolution "
+         "specified at construction, as it must internally store the evolved "
+         "scalar at the desired resolution");
+  Variables<tmpl::list<Tags::BondiW, Tags::BondiU>> temporary_variables{
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max_)};
+  auto& local_bondi_u = get<Tags::BondiU>(temporary_variables);
+  auto& local_bondi_w = get<Tags::BondiW>(temporary_variables);
+
+  bondi_u(make_not_null(&local_bondi_u), dense_output_rt_scalar_);
+  bondi_w(make_not_null(&local_bondi_w), dense_output_rt_scalar_);
+
+  get<0, 0>(*spherical_metric) =
+      -real(get(dense_output_rt_scalar_).data() *
+                (extraction_radius_ * get(local_bondi_w).data() + 1.0) -
+            square(extraction_radius_) * get(local_bondi_u).data() *
+                conj(get(local_bondi_u).data()));
+  get<0, 1>(*spherical_metric) =
+      -get<0, 0>(*spherical_metric) - real(get(dense_output_rt_scalar_).data());
+  get<1, 1>(*spherical_metric) =
+      get<0, 0>(*spherical_metric) +
+      2.0 * real(get(dense_output_rt_scalar_).data());
+
+  get<0, 2>(*spherical_metric) =
+      square(extraction_radius_) * real(get(local_bondi_u).data());
+  get<1, 2>(*spherical_metric) =
+      -square(extraction_radius_) * real(get(local_bondi_u).data());
+  // note: using 'pfaffian' components, because otherwise the sin(theta)s lose
+  // precision at the poles
+  get<0, 3>(*spherical_metric) =
+      square(extraction_radius_) * imag(get(local_bondi_u).data());
+  get<1, 3>(*spherical_metric) =
+      -square(extraction_radius_) * imag(get(local_bondi_u).data());
+
+  // note: pfaffian components
+  get<2, 2>(*spherical_metric) = square(extraction_radius_);
+  get<2, 3>(*spherical_metric) = 0.0;
+  get<3, 3>(*spherical_metric) = square(extraction_radius_);
+}
+
+void RobinsonTrautman::dr_spherical_metric(
+    const gsl::not_null<
+        tnsr::aa<DataVector, 3, ::Frame::Spherical<::Frame::Inertial>>*>
+        dr_spherical_metric,
+    const size_t l_max, const double time) const noexcept {
+  ASSERT(time == prepared_time_,
+         "The Robinson-Trautman solution is being calculated in an "
+         "inconsistent state. The public interface should always call "
+         "`prepare_solution` before calculating any metric components, so this "
+         "may indicate inconsistent use of the internal Robinson-Trautman "
+         "calculation functions.");
+  ASSERT(l_max == l_max_,
+         "The Robinson-Trautman solution only supports the l_max resolution "
+         "specified at construction, as it must internally store the evolved "
+         "scalar at the desired resolution");
+  Variables<tmpl::list<Tags::BondiW, Tags::Dr<Tags::BondiW>, Tags::BondiU>>
+      temporary_variables{
+          Spectral::Swsh::number_of_swsh_collocation_points(l_max_)};
+  auto& local_dr_bondi_w = get<Tags::Dr<Tags::BondiW>>(temporary_variables);
+  auto& local_bondi_w = get<Tags::BondiW>(temporary_variables);
+  auto& local_bondi_u = get<Tags::BondiU>(temporary_variables);
+
+  bondi_u(make_not_null(&local_bondi_u), dense_output_rt_scalar_);
+  dr_bondi_w(make_not_null(&local_dr_bondi_w), dense_output_rt_scalar_);
+  bondi_w(make_not_null(&local_bondi_w), dense_output_rt_scalar_);
+
+  dt_spherical_metric(dr_spherical_metric, l_max, time);
+
+  // note: bondi_u is proportional to 1/r, so when comparing to the values in
+  // `spherical_metric`, this (correctly) doesn't have a factor of two where you
+  // might naively expect one.
+  get<0, 0>(*dr_spherical_metric) =
+      -get<0, 0>(*dr_spherical_metric) -
+      real(get(dense_output_rt_scalar_).data() *
+           (extraction_radius_ * get(local_dr_bondi_w).data() +
+            get(local_bondi_w).data()));
+  get<0, 1>(*dr_spherical_metric) =
+      real(get(dense_output_rt_scalar_).data() *
+           (extraction_radius_ * get(local_dr_bondi_w).data() +
+            get(local_bondi_w).data())) -
+      get<0, 1>(*dr_spherical_metric);
+  get<1, 1>(*dr_spherical_metric) =
+      -real(get(dense_output_rt_scalar_).data() *
+            (extraction_radius_ * get(local_dr_bondi_w).data() +
+             get(local_bondi_w).data())) -
+      get<1, 1>(*dr_spherical_metric);
+
+  get<0, 2>(*dr_spherical_metric) =
+      -get<0, 2>(*dr_spherical_metric) +
+      extraction_radius_ * real(get(local_bondi_u).data());
+  get<1, 2>(*dr_spherical_metric) =
+      -get<1, 2>(*dr_spherical_metric) +
+      -extraction_radius_ * real(get(local_bondi_u).data());
+  // note: using 'pfaffian' components, because otherwise the factors of
+  // sin(theta) lose precision at the poles
+  get<0, 3>(*dr_spherical_metric) =
+      -get<0, 3>(*dr_spherical_metric) +
+      extraction_radius_ * imag(get(local_bondi_u).data());
+  get<1, 3>(*dr_spherical_metric) =
+      -get<1, 3>(*dr_spherical_metric) +
+      -extraction_radius_ * imag(get(local_bondi_u).data());
+
+  // note: pfaffian components
+  get<2, 2>(*dr_spherical_metric) =
+      -get<2, 2>(*dr_spherical_metric) + 2.0 * extraction_radius_;
+  get<2, 3>(*dr_spherical_metric) = 0.0;
+  get<3, 3>(*dr_spherical_metric) =
+      -get<3, 3>(*dr_spherical_metric) + 2.0 * extraction_radius_;
+}
+
+void RobinsonTrautman::dt_spherical_metric(
+    const gsl::not_null<
+        tnsr::aa<DataVector, 3, ::Frame::Spherical<::Frame::Inertial>>*>
+        dt_spherical_metric,
+    const size_t l_max, const double time) const noexcept {
+  ASSERT(time == prepared_time_,
+         "The Robinson-Trautman solution is being calculated in an "
+         "inconsistent state. The public interface should always call "
+         "`prepare_solution` before calculating any metric components, so this "
+         "may indicate inconsistent use of the internal Robinson-Trautman "
+         "calculation functions.");
+  ASSERT(l_max == l_max_,
+         "The Robinson-Trautman solution only supports the l_max resolution "
+         "specified at construction, as it must internally store the evolved "
+         "scalar at the desired resolution");
+  Variables<tmpl::list<Tags::BondiW, Tags::Du<Tags::BondiW>, Tags::BondiU,
+                       Tags::Du<Tags::BondiU>>>
+      temporary_variables{
+          Spectral::Swsh::number_of_swsh_collocation_points(l_max_)};
+  auto& local_bondi_w = get<Tags::BondiW>(temporary_variables);
+  auto& local_bondi_u = get<Tags::BondiU>(temporary_variables);
+  auto& local_du_bondi_w = get<Tags::Du<Tags::BondiW>>(temporary_variables);
+  auto& local_du_bondi_u = get<Tags::Du<Tags::BondiU>>(temporary_variables);
+  bondi_u(make_not_null(&local_du_bondi_u), dense_output_du_rt_scalar_);
+  bondi_u(make_not_null(&local_bondi_u), dense_output_rt_scalar_);
+  du_bondi_w(make_not_null(&local_du_bondi_w), dense_output_du_rt_scalar_,
+             dense_output_rt_scalar_);
+  bondi_w(make_not_null(&local_bondi_w), dense_output_rt_scalar_);
+
+  get<0, 0>(*dt_spherical_metric) = -real(
+      get(dense_output_du_rt_scalar_).data() *
+          (extraction_radius_ * get(local_bondi_w).data() + 1.0) +
+      get(dense_output_rt_scalar_).data() * extraction_radius_ *
+          get(local_du_bondi_w).data() -
+      square(extraction_radius_) *
+          (get(local_du_bondi_u).data() * conj(get(local_bondi_u).data()) +
+           conj(get(local_du_bondi_u).data()) * get(local_bondi_u).data()));
+  get<0, 1>(*dt_spherical_metric) =
+      -get<0, 0>(*dt_spherical_metric) -
+      real(get(dense_output_du_rt_scalar_).data());
+  get<1, 1>(*dt_spherical_metric) =
+      get<0, 0>(*dt_spherical_metric) +
+      2.0 * real(get(dense_output_du_rt_scalar_).data());
+
+  get<0, 2>(*dt_spherical_metric) =
+      square(extraction_radius_) * real(get(local_du_bondi_u).data());
+  get<1, 2>(*dt_spherical_metric) =
+      -square(extraction_radius_) * real(get(local_du_bondi_u).data());
+  get<0, 3>(*dt_spherical_metric) =
+      square(extraction_radius_) * imag(get(local_du_bondi_u).data());
+  get<1, 3>(*dt_spherical_metric) =
+      -square(extraction_radius_) * imag(get(local_du_bondi_u).data());
+  for (size_t A = 0; A < 2; ++A) {
+    for (size_t B = A; B < 2; ++B) {
+      dt_spherical_metric->get(A + 2, B + 2) = 0.0;
+    }
+  }
+}
+
+void RobinsonTrautman::pup(PUP::er& p) noexcept {
+  SphericalMetricData::pup(p);
+  p | tolerance_;
+  p | start_time_;
+  p | dense_output_rt_scalar_;
+  p | dense_output_du_rt_scalar_;
+  p | l_max_;
+  p | initial_modes_;
+  // it is difficult to serialize the stepper, but because it will usually not
+  // migrate, it should be fine to just re-initialize it with the candidate
+  // starting step size at the starting time. It will need to 'catch up' to the
+  // current evolution each time it is migrated.
+  // This procedure should be reconsidered if this analytic solution is used in
+  // a context (e.g. in a chare array) where it may need to migrate frequently.
+  if (p.isUnpacking()) {
+    initialize_stepper_from_start();
+  }
+}
+
+PUP::able::PUP_ID RobinsonTrautman::my_PUP_ID = 0;
+}  // namespace Cce::Solutions

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/RobinsonTrautman.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/RobinsonTrautman.hpp
@@ -1,0 +1,321 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <complex>
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/SphericalMetricData.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp"
+#include "NumericalAlgorithms/OdeIntegration/OdeIntegration.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Time/History.hpp"
+#include "Time/TimeSteppers/RungeKutta3.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Cce {
+namespace Solutions {
+/*!
+ * \brief An analytic solution representing a specialization of the radiative
+ * Robinson-Trautman solution described in \cite Derry1970fk.
+ *
+ * \details This solution is not quite analytic, in the sense that there is a
+ * single scalar field that must be evolved. Ultimately, it is a partial
+ * specialization of the Characteristic equations such that \f$J = 0\f$ and the
+ * evolution equations have been manipulated to give a time evolution equation
+ * for \f$e^{-2 \beta}\f$, which is equivalent to the Robinson-Trautman scalar
+ * \f$\omega_{\text{RT}}\f$ (denoted \f$W\f$ in \cite Derry1970fk -- we deviate
+ * from their notation because the symbol \f$W\f$ is already used elsewhere in
+ * the CCE system).
+ *
+ * \note The value of \f$\omega_{\text{RT}}\f$ should be real and near 1, which
+ * is imposed by the solution itself, any modes specified in the input file are
+ * treated as perturbations to the leading value of 1.0 for the
+ * Robinson-Trautman scalar \f$\omega_{\text{RT}}\f$.
+ */
+struct RobinsonTrautman : public SphericalMetricData {
+  struct InitialModes {
+    using type = std::vector<std::complex<double>>;
+    static constexpr Options::String help{
+        "The initial modes of the Robinson-Trautman scalar, denoted W in "
+        "[Derry 1970] and omega_RT in the rendered documentation. "
+        "These are taken in ascending l and m order, m varies fastest. Note "
+        "that the modes are treated as perturbations to the leading-order "
+        "solution of 1.0 for omega_RT and only the real part of the field is "
+        "used."};
+  };
+  struct ExtractionRadius {
+    using type = double;
+    static constexpr Options::String help{
+        "The extraction radius of the spherical solution"};
+    static type lower_bound() noexcept { return 0.0; }
+    static type suggested_value() noexcept { return 20.0; }
+  };
+  struct LMax {
+    using type = size_t;
+    static constexpr Options::String help{
+        "The maximum l value for the internal computation of the analytic "
+        "solution"};
+    static type lower_bound() noexcept { return 4; }
+  };
+  struct Tolerance {
+    using type = double;
+    static constexpr Options::String help{
+        "The tolerance for the time evolution part of the calculation of the "
+        "semi-analytic Robinson-Trautman solution"};
+    static type lower_bound() noexcept { return 0.0; }
+    static type suggested_value() noexcept { return 1.0e-11; }
+  };
+  struct StartTime {
+    using type = double;
+    static constexpr Options::String help{
+        "The starting time for the Robinson-Trautman evolution"};
+    static type lower_bound() noexcept { return 0.0; }
+    static type suggested_value() noexcept { return 0.0; }
+  };
+
+  using options =
+      tmpl::list<InitialModes, ExtractionRadius, LMax, Tolerance, StartTime>;
+
+  static constexpr Options::String help = {
+      "Analytic solution representing worldtube data for the nonlinear "
+      "semi-analytic Robinson-Trautman metric, which requires a single "
+      "scalar on the boundary to be evolved to determine the metric"};
+
+  WRAPPED_PUPable_decl_template(RobinsonTrautman);  // NOLINT
+
+  explicit RobinsonTrautman(CkMigrateMessage* /*unused*/) noexcept {}
+
+  RobinsonTrautman() = default;
+
+  RobinsonTrautman(std::vector<std::complex<double>> initial_modes,
+                   double extraction_radius, size_t l_max, double tolerance,
+                   double start_time, const Options::Context& context);
+
+  std::unique_ptr<WorldtubeData> get_clone() const noexcept override;
+
+  void pup(PUP::er& p) noexcept override;
+
+  bool use_noninertial_news() const noexcept override { return true; }
+
+ private:
+  void du_rt_scalar(
+      gsl::not_null<SpinWeighted<ComplexDataVector, 0>*> local_du_rt_scalar,
+      const SpinWeighted<ComplexDataVector, 0>& rt_scalar) const noexcept;
+
+  void du_bondi_w(
+      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*> du_bondi_w,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& local_du_rt_scalar,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& rt_scalar)
+      const noexcept;
+
+  void bondi_u(
+      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 1>>*> bondi_u,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& rt_scalar)
+      const noexcept;
+
+  void bondi_w(
+      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*> bondi_w,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& rt_scalar)
+      const noexcept;
+
+  void dr_bondi_w(
+      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*> dr_bondi_w,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& rt_scalar)
+      const noexcept;
+
+  void initialize_stepper_from_start() noexcept;
+
+ protected:
+  /*!
+   * \brief The Robinson-Trautman solution performs the time-stepping to advance
+   * the internal member scalar used to generate the metric solution to the
+   * correct state for `time`.
+   *
+   * \details The generating scalar \f$\omega_{\text{RT}}\f$ is evolved
+   * using equation (2.5) from \cite Derry1970fk (manipulated to a form
+   * convenient for our numerical utilities)
+   *
+   * \f[
+   * \partial_u \omega_{\text{RT}} = -
+   * \left(\omega^4_{\text{RT}} \eth^2 \bar \eth^2 \omega_{\text{RT}}
+   *  - \omega_{\text{RT}}^3 (\eth^2 \omega_{\text{RT}})
+   * (\bar \eth^2  \omega_{\text{RT}}) \right)
+   * \f]
+   *
+   * As the scalar \f$\omega_{\text{RT}}\f$ is evolved, it is filtered by
+   * zeroing the highest two angular modes.
+   */
+  void prepare_solution(size_t output_l_max,
+                        double time) const noexcept override;
+
+  /*!
+   * \brief Compute the spherical coordinate metric of the Robinson-Trautman
+   * solution generated by the time-evolved scalar \f$\omega_{\text{RT}}\f$.
+   *
+   * \details The spacetime metric of the Robinson-Trautman solution can be
+   * expressed as a specialization of the Bondi-Sachs metric (note the metric
+   * signature change as compared to equation (1.2) from \cite Derry1970fk)
+   *
+   * \f[
+   * ds^2 = -((r W + 1) \omega_{\text{RT}} - r^2 U \bar U) (dt - dr)^2
+   * - 2 \omega_{\text{RT}} (dt - dr) dr
+   * - 2 r^2 U^A q_{AB} dx^B (dt - dr) + r^2 q_{A B} dx^A dx^B,
+   * \f]
+   *
+   * where \f$q_{A B}\f$ represents the angular unit sphere metric, and the
+   * remaining Bondi-Sachs scalars and angular tensors are defined in terms of
+   * the Robinson-Trautman scalar \f$\omega_{\text{RT}}\f$
+   *
+   * \f{align*}{
+   * W &= \frac{1}{r}\left(\omega_{\text{RT}} + \eth \bar \eth
+   * \omega_{\text{RT}} - 1\right) - \frac{2}{r^2 \omega_{\text{RT}}^2}\\
+   * U &\equiv U^A q_A = \frac{\eth \omega_{\text{RT}}}{r}.
+   * \f}
+   * and \f$q_A\f$ is the angular dyad on the unit sphere.
+   *
+   * The angular part of the metric can be expressed in terms of the \f$U\f$
+   * scalar as
+   *
+   * \f{align*}{
+   * g_{u \theta} &= r^2 \Re U\\
+   * g_{u \phi} &= r^2 \Im U
+   * \f}
+   */
+  void spherical_metric(
+      gsl::not_null<
+          tnsr::aa<DataVector, 3, ::Frame::Spherical<::Frame::Inertial>>*>
+          spherical_metric,
+      size_t l_max, double time) const noexcept override;
+
+  /*!
+   * \brief Compute radial derivative of the spherical coordinate metric of the
+   * Robinson-Trautman solution generated by the time-evolved scalar
+   * \f$\omega_{\text{RT}}\f$.
+   *
+   * \details The radial derivative (at constant time t) of the
+   * Robinson-Trautman solution is obtained by differentiating the expressions
+   * from the documentation for `RobinsonTrautman::spherical_metric()`:
+   *
+   * \f{align*}{
+   * (\partial_r g_{a b} + \partial_t g_{a b}) dx^a dx^b =
+   * - (\omega_{\text{RT}} (r \partial_r W + W) - 2 r U \bar U
+   * - r^2 (\bar U\partial_r U + U \partial_r \bar U)) (dt - dr)^2
+   * - 2 r U^A q_{A B} dx^B (dt - dr) +  2 r q_{A B} dx^A dx^B
+   * \f}
+   *
+   * where \f$q_{A B}\f$ represents the angular unit sphere metric, and the
+   * remaining Bondi-Sachs scalars and angular tensors are defined in terms of
+   * the Robinson-Trautman scalar \f$\omega_{\text{RT}}\f$
+   *
+   * \f{align*}{
+   * W &= \frac{1}{r}\left(\omega_{\text{RT}}
+   * + \eth \bar \eth \omega_{\text{RT}} - 1\right)
+   * - \frac{2}{r^2 \omega_{\text{RT}}^2}\\
+   * \partial_r W &= -\frac{1}{r^2} \left(\omega_{\text{RT}}
+   * + \eth \bar \eth \omega_{\text{RT}} - 1\right)
+   * + \frac{4}{r^3 \omega_{\text{RT}}^2}\\
+   * U &\equiv U^A q_A = \frac{\eth \omega_{\text{RT}}}{r}.
+   * \f}
+   * and \f$q_A\f$ is the angular dyad on the unit sphere. The Robinson-Trautman
+   * scalar \f$\omega_{\text{RT}}\f$ is independent of the Bondi radius \f$r\f$,
+   * so all radial derivatives of \f$\omega_{\text{RT}}\f$ have been dropped
+   */
+  void dr_spherical_metric(
+      gsl::not_null<
+          tnsr::aa<DataVector, 3, ::Frame::Spherical<::Frame::Inertial>>*>
+          dr_spherical_metric,
+      size_t l_max, double time) const noexcept override;
+
+  /*!
+   * \brief Compute time derivative of the spherical coordinate metric of the
+   * Robinson-Trautman solution generated by the time-evolved scalar
+   * \f$\omega_{\text{RT}}\f$.
+   *
+   * \details The time derivative of the Robinson-Trautman solution is obtained
+   * by differentiating the expressions from the documentation for
+   * `RobinsonTrautman::spherical_metric()`:
+   *
+   * \f{align*}{
+   * \partial_t g_{a b} dx^a dx^b =  -( \partial_u \omega_{\text{RT}} (r W + 1)
+   *  + \omega_{\text{RT}} \partial_u W
+   * - r^2 (\bar U \partial_u U + U \partial_u \bar U)) (dt - dr)^2
+   * - 2 \partial_u \omega_{\text{RT}} (dt - dr) dr
+   * - 2 r^2 \partial_u U^A q_{AB} dx^B (dt - dr),
+   * \f}
+   *
+   * where \f$q_{A B}\f$ represents the angular unit sphere metric, and the
+   * remaining Bondi-Sachs scalars and angular tensors are defined in terms of
+   * the Robinson-Trautman scalar \f$\omega_{\text{RT}}\f$
+   *
+   * \f{align*}{
+   * W &= \frac{1}{r}\left(\omega_{\text{RT}}
+   * + \eth \bar \eth \omega_{\text{RT}} - 1\right)
+   * - \frac{2}{r^2 \omega_{\text{RT}}^2}\\
+   * \partial_u W &= \frac{1}{r}\left(\partial_u \omega_{\text{RT}}
+   * + \eth \bar \eth \partial_u \omega_{\text{RT}}\right)
+   * + \frac{4 \partial_u \omega_{\text{RT}}}{r^2 \omega_{\text{RT}}^3} \\
+   * \partial_u U &= q_A \partial_u U^A = \frac{\eth \partial_u
+   * \omega_{\text{RT}}}{r}, \f}
+   *
+   * and \f$q_A\f$ is the angular dyad on the unit sphere; and the time
+   * derivative of the Robinson-Trautman scalar \f$\omega_{\text{RT}}\f$ is
+   *
+   * \f[
+   * \partial_u \omega_{\text{RT}} =
+   * \frac{1}{12} \left(-\omega^4_{\text{RT}} \eth^2 \bar \eth^2
+   * \omega_{\text{RT}} + \omega_{\text{RT}}^3 (\eth^2 \omega_{\text{RT}})
+   * (\bar \eth^2  \omega_{\text{RT}}) \right)
+   * \f]
+   */
+  void dt_spherical_metric(
+      gsl::not_null<
+          tnsr::aa<DataVector, 3, ::Frame::Spherical<::Frame::Inertial>>*>
+          dt_spherical_metric,
+      size_t l_max, double time) const noexcept override;
+
+  /*!
+   * \brief Compute the news associated with the Robinson-Trautman solution
+   * generated by the time-evolved scalar \f$\omega_{\text{RT}}\f$.
+   *
+   * \details The Bondi-Sachs news in the Robinson-Trautman solution is
+   *
+   * \f{align*}{
+   * N = \frac{\bar \eth \bar \eth \omega_{\text{RT}}}{\omega_{\text{RT}}}
+   * \f}
+   */
+  void variables_impl(
+      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, -2>>*> News,
+      size_t l_max, double time,
+      tmpl::type_<Tags::News> /*meta*/) const noexcept override;
+
+  using WorldtubeData::variables_impl;
+
+  using SphericalMetricData::variables_impl;
+ private:
+  mutable std::pair<double, double> step_range_;
+
+  mutable boost::numeric::odeint::dense_output_runge_kutta<
+      boost::numeric::odeint::controlled_runge_kutta<
+          boost::numeric::odeint::runge_kutta_dopri5<ComplexDataVector>>>
+      stepper_;
+
+  mutable Scalar<SpinWeighted<ComplexDataVector, 0>> dense_output_rt_scalar_;
+  mutable Scalar<SpinWeighted<ComplexDataVector, 0>> dense_output_du_rt_scalar_;
+  size_t l_max_ = 0;
+  mutable double prepared_time_ = std::numeric_limits<double>::signaling_NaN();
+  double tolerance_ = std::numeric_limits<double>::signaling_NaN();
+  double start_time_ = std::numeric_limits<double>::signaling_NaN();
+  std::vector<std::complex<double>> initial_modes_;
+};
+}  // namespace Solutions
+}  // namespace Cce

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/RobinsonTrautman.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/RobinsonTrautman.hpp
@@ -93,7 +93,8 @@ struct RobinsonTrautman : public SphericalMetricData {
 
   WRAPPED_PUPable_decl_template(RobinsonTrautman);  // NOLINT
 
-  explicit RobinsonTrautman(CkMigrateMessage* /*unused*/) noexcept {}
+  explicit RobinsonTrautman(CkMigrateMessage* msg) noexcept
+      : SphericalMetricData(msg) {}
 
   RobinsonTrautman() = default;
 

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/RotatingSchwarzschild.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/RotatingSchwarzschild.hpp
@@ -62,7 +62,8 @@ struct RotatingSchwarzschild : public SphericalMetricData {
 
   WRAPPED_PUPable_decl_template(RotatingSchwarzschild);  // NOLINT
 
-  explicit RotatingSchwarzschild(CkMigrateMessage* /*unused*/) noexcept {}
+  explicit RotatingSchwarzschild(CkMigrateMessage* msg) noexcept
+      : SphericalMetricData(msg) {}
 
   // clang doesn't manage to use = default correctly in this case
   // NOLINTNEXTLINE(modernize-use-equals-default)

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/SphericalMetricData.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/SphericalMetricData.hpp
@@ -45,6 +45,9 @@ struct SphericalMetricData : public WorldtubeData {
 
   SphericalMetricData() noexcept = default;
 
+  explicit SphericalMetricData(CkMigrateMessage* msg) noexcept
+      : WorldtubeData(msg) {}
+
   explicit SphericalMetricData(const double extraction_radius) noexcept
       : WorldtubeData{extraction_radius} {}
 

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/TeukolskyWave.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/TeukolskyWave.hpp
@@ -65,7 +65,8 @@ struct TeukolskyWave : public SphericalMetricData {
 
   WRAPPED_PUPable_decl_template(TeukolskyWave);  // NOLINT
 
-  explicit TeukolskyWave(CkMigrateMessage* /*unused*/) noexcept {}
+  explicit TeukolskyWave(CkMigrateMessage* msg) noexcept
+      : SphericalMetricData(msg) {}
 
   // clang doesn't manage to use = default correctly in this case
   // NOLINTNEXTLINE(modernize-use-equals-default)

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp
@@ -100,6 +100,8 @@ struct WorldtubeData : public PUP::able {
   explicit WorldtubeData(const double extraction_radius) noexcept
       : extraction_radius_{extraction_radius} {}
 
+  explicit WorldtubeData(CkMigrateMessage* msg) noexcept : PUP::able(msg) {}
+
   virtual std::unique_ptr<WorldtubeData> get_clone() const noexcept = 0;
 
   /*!

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp
@@ -23,12 +23,14 @@
 #include "Utilities/TaggedTuple.hpp"
 
 namespace Cce {
+/// Analytic solutions for CCE worldtube data and corresponding waveform News
 namespace Solutions {
 
 /// \cond
 class BouncingBlackHole;
 class GaugeWave;
 class LinearizedBondiSachs;
+class RobinsonTrautman;
 class RotatingSchwarzschild;
 class TeukolskyWave;
 /// \endcond
@@ -71,7 +73,7 @@ class TeukolskyWave;
 struct WorldtubeData : public PUP::able {
   using creatable_classes =
       tmpl::list<BouncingBlackHole, GaugeWave, LinearizedBondiSachs,
-                 RotatingSchwarzschild, TeukolskyWave>;
+                 RobinsonTrautman, RotatingSchwarzschild, TeukolskyWave>;
 
   /// The set of available tags provided by the analytic solution
   using tags = tmpl::list<

--- a/src/NumericalAlgorithms/OdeIntegration/OdeIntegration.hpp
+++ b/src/NumericalAlgorithms/OdeIntegration/OdeIntegration.hpp
@@ -63,6 +63,26 @@ struct set_unit_value_impl<ComplexModalVector, V, void> {
 };
 }  // namespace detail
 
+// In some integration contexts, boost requires the ability to resize the
+// integration arguments in preparation for writing to output buffers passed by
+// reference. These specializations make the resize work correctly with spectre
+// vector types.
+template <class VectorType1, class VectorType2>
+struct resize_impl_sfinae<VectorType1, VectorType2,
+                          typename boost::enable_if_c<
+                              is_derived_of_vector_impl_v<VectorType1> and
+                              is_derived_of_vector_impl_v<VectorType2>>::type> {
+  static void resize(VectorType1& x1, const VectorType2& x2) noexcept {
+    x1.destructive_resize(x2.size());
+  }
+};
+
+template <class VectorType>
+struct is_resizeable_sfinae<
+    VectorType,
+    typename boost::enable_if_c<is_derived_of_vector_impl_v<VectorType>>::type>
+    : boost::true_type {};
+
 template <>
 struct algebra_dispatcher<DataVector> {
   using algebra_type = ::detail::vector_impl_algebra;

--- a/tests/InputFiles/Cce/RobinsonTrautman.yaml
+++ b/tests/InputFiles/Cce/RobinsonTrautman.yaml
@@ -1,0 +1,55 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: AnalyticTestCharacteristicExtract
+# Check: parse;execute_check_output
+# Timeout: 8
+# OutputFileChecks:
+#   - Label: "check_news"
+#     Subfile: "/News_Noninertial.dat"
+#     FileGlob: "CharacteristicExtractVolume*.h5"
+#     ExpectedDataSubfile: "/News_Noninertial_expected.dat"
+#     AbsoluteTolerance: 5e-11
+
+Evolution:
+  TimeStepper:
+    AdamsBashforthN:
+      Order: 3
+
+Observers:
+  VolumeFileName: "CharacteristicExtractVolume"
+  ReductionFileName: "CharacteristicExtractUnusedReduction"
+
+Cce:
+  LMax: 12
+  NumberOfRadialPoints: 12
+  ObservationLMax: 8
+
+  StartTime: 0.0
+  EndTime: 0.6
+  TargetStepSize: 0.1
+  ExtractionRadius: 40.0
+
+  AnalyticSolution:
+    RobinsonTrautman:
+      InitialModes:
+        # l = 0
+        - [0.0, 0.0]
+        # l = 1
+        - [0.0, 0.0]
+        - [0.0, 0.0]
+        - [0.0, 0.0]
+        # l = 2
+        - [0.01, 0.005]
+      ExtractionRadius: 40.0
+      LMax: 12
+      Tolerance: 1e-10
+      StartTime: 0.0
+
+  Filtering:
+    RadialFilterHalfPower: 24
+    RadialFilterAlpha: 35.0
+    FilterLMax: 10
+
+  ScriInterpOrder: 5
+  ScriOutputDensity: 1

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
@@ -15,11 +15,7 @@
 #include "Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp"
 #include "Evolution/Systems/Cce/Actions/ReceiveWorldtubeData.hpp"
 #include "Evolution/Systems/Cce/Actions/RequestBoundaryData.hpp"
-#include "Evolution/Systems/Cce/AnalyticSolutions/BouncingBlackHole.hpp"
-#include "Evolution/Systems/Cce/AnalyticSolutions/GaugeWave.hpp"
-#include "Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.hpp"
 #include "Evolution/Systems/Cce/AnalyticSolutions/RotatingSchwarzschild.hpp"
-#include "Evolution/Systems/Cce/AnalyticSolutions/TeukolskyWave.hpp"
 #include "Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp"
 #include "Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp"
 #include "Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp"
@@ -152,8 +148,8 @@ struct test_metavariables {
 SPECTRE_TEST_CASE(
     "Unit.Evolution.Systems.Cce.Actions.AnalyticBoundaryCommunication",
     "[Unit][Cce]") {
-  Parallel::register_derived_classes_with_charm<
-      Cce::Solutions::WorldtubeData>();
+  Parallel::register_classes_with_charm<
+      Cce::Solutions::RotatingSchwarzschild>();
   Parallel::register_derived_classes_with_charm<TimeStepper>();
   using evolution_component = mock_characteristic_evolution<test_metavariables>;
   using worldtube_component =

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
@@ -11,11 +11,7 @@
 #include "Evolution/Systems/Cce/Actions/InsertInterpolationScriData.hpp"
 #include "Evolution/Systems/Cce/Actions/ReceiveWorldtubeData.hpp"
 #include "Evolution/Systems/Cce/Actions/RequestBoundaryData.hpp"
-#include "Evolution/Systems/Cce/AnalyticSolutions/BouncingBlackHole.hpp"
-#include "Evolution/Systems/Cce/AnalyticSolutions/GaugeWave.hpp"
-#include "Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.hpp"
 #include "Evolution/Systems/Cce/AnalyticSolutions/RotatingSchwarzschild.hpp"
-#include "Evolution/Systems/Cce/AnalyticSolutions/TeukolskyWave.hpp"
 #include "Evolution/Systems/Cce/BoundaryData.hpp"
 #include "Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp"
 #include "Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp"
@@ -240,10 +236,10 @@ SPECTRE_TEST_CASE(
     "Unit.Evolution.Systems.Cce.Actions.InsertInterpolationScriData",
     "[Unit][Cce]") {
   Parallel::register_derived_classes_with_charm<TimeStepper>();
-  Parallel::register_derived_classes_with_charm<
-      Cce::Solutions::WorldtubeData>();
-  PUPable_reg2(RotatingSchwarzschildWithNoninertialNews,
-               typeid(RotatingSchwarzschildWithNoninertialNews).name());
+  Parallel::register_classes_with_charm<
+      Cce::Solutions::RotatingSchwarzschild>();
+  Parallel::register_classes_with_charm<
+      RotatingSchwarzschildWithNoninertialNews>();
   using evolution_component = MockCharacteristicEvolution<test_metavariables>;
   using observation_component = MockObserver<test_metavariables>;
   MAKE_GENERATOR(gen);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
@@ -17,9 +17,6 @@
 #include "Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionVariables.hpp"
 #include "Evolution/Systems/Cce/Actions/InsertInterpolationScriData.hpp"
 #include "Evolution/Systems/Cce/Actions/ScriObserveInterpolated.hpp"
-#include "Evolution/Systems/Cce/AnalyticSolutions/BouncingBlackHole.hpp"
-#include "Evolution/Systems/Cce/AnalyticSolutions/GaugeWave.hpp"
-#include "Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.hpp"
 #include "Evolution/Systems/Cce/AnalyticSolutions/RotatingSchwarzschild.hpp"
 #include "Evolution/Systems/Cce/AnalyticSolutions/TeukolskyWave.hpp"
 #include "Evolution/Systems/Cce/BoundaryData.hpp"
@@ -234,8 +231,9 @@ ComplexDataVector compute_expected_field_from_pypp(
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.ScriObserveInterpolated",
                   "[Unit][Cce]") {
   Parallel::register_derived_classes_with_charm<TimeStepper>();
-  Parallel::register_derived_classes_with_charm<
-      Cce::Solutions::WorldtubeData>();
+  Parallel::register_classes_with_charm<
+      Cce::Solutions::RotatingSchwarzschild>();
+  Parallel::register_classes_with_charm<Cce::Solutions::TeukolskyWave>();
   using evolution_component = mock_characteristic_evolution<test_metavariables>;
   using observation_component = mock_observer<test_metavariables>;
   pypp::SetupLocalPythonEnvironment local_python_env{

--- a/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_BouncingBlackHole.cpp
   Test_GaugeWave.cpp
   Test_LinearizedBondiSachs.cpp
+  Test_RobinsonTrautman.cpp
   Test_RotatingSchwarzschild.cpp
   Test_TeukolskyWave.cpp
   )

--- a/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/Test_RobinsonTrautman.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/Test_RobinsonTrautman.cpp
@@ -1,0 +1,218 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <complex>
+#include <cstddef>
+#include <vector>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/RobinsonTrautman.hpp"
+#include "Evolution/Systems/Cce/BoundaryData.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/Evolution/Systems/Cce/AnalyticSolutions/AnalyticDataHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "NumericalAlgorithms/Spectral/SwshDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/SwshFiltering.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Cce::Solutions {
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.RobinsonTrautman",
+                  "[Unit][Cce]") {
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<double> radius_dist{10.0, 20.0};
+  UniformCustomDistribution<double> parameter_dist{0.001, 0.01};
+  const double extraction_radius = radius_dist(gen);
+  const double start_time = 0.0;
+  // the system is somewhat stiff, so to save time in the test, we only evolve
+  // for a short time compared to the extraction radius.
+  const double time = 0.02;
+  const size_t l_max = 16;
+  // the l=2 modes are what we should care most about, so we test with only the
+  // (2, -2) entry populated.
+  std::vector<std::complex<double>> modes{0.0, 0.0, 0.0, 0.0,
+                                          parameter_dist(gen)};
+  Options::Context context{};
+  const RobinsonTrautman boundary_solution{
+      std::move(modes), extraction_radius, l_max, 1.0e-13, start_time, context};
+
+  const auto boundary_data = boundary_solution.variables(
+      l_max, time,
+      tmpl::list<
+          Tags::Dr<Tags::CauchyCartesianCoords>,
+          gr::Tags::SpacetimeMetric<3, ::Frame::Inertial, DataVector>,
+          ::Tags::dt<
+              gr::Tags::SpacetimeMetric<3, ::Frame::Inertial, DataVector>>,
+          GeneralizedHarmonic::Tags::Phi<3, ::Frame::Inertial>, Tags::News>{});
+
+  const auto& spacetime_metric =
+      get<gr::Tags::SpacetimeMetric<3, ::Frame::Inertial, DataVector>>(
+          boundary_data);
+
+
+  CartesianiSphericalJ inverse_jacobian{get<0, 0>(spacetime_metric).size()};
+  boundary_solution.inverse_jacobian(make_not_null(&inverse_jacobian), l_max);
+
+  const auto bondi_quantities =
+      TestHelpers::extract_bondi_scalars_from_cartesian_metric(
+          spacetime_metric, inverse_jacobian, extraction_radius);
+
+  const auto& dt_spacetime_metric = get<
+      ::Tags::dt<gr::Tags::SpacetimeMetric<3, ::Frame::Inertial, DataVector>>>(
+      boundary_data);
+  const auto dt_bondi_quantities =
+      TestHelpers::extract_dt_bondi_scalars_from_cartesian_metric(
+          dt_spacetime_metric, spacetime_metric, inverse_jacobian,
+          extraction_radius);
+  CartesianiSphericalJ dr_inverse_jacobian{get<0, 0>(spacetime_metric).size()};
+  boundary_solution.dr_inverse_jacobian(make_not_null(&dr_inverse_jacobian),
+                                        l_max);
+  const auto& d_spacetime_metric =
+      get<GeneralizedHarmonic::Tags::Phi<3, ::Frame::Inertial>>(boundary_data);
+  const auto& dr_cartesian_coordinates =
+      get<Tags::Dr<Tags::CauchyCartesianCoords>>(boundary_data);
+  tnsr::aa<DataVector, 3> dr_spacetime_metric{
+      get<0, 0>(spacetime_metric).size(), 0.0};
+  for (size_t a = 0; a < 4; ++a) {
+    for (size_t b = a; b < 4; ++b) {
+      for (size_t i = 0; i < 3; ++i) {
+        dr_spacetime_metric.get(a, b) +=
+            dr_cartesian_coordinates.get(i) * d_spacetime_metric.get(i, a, b);
+      }
+    }
+  }
+  const auto dr_bondi_quantities =
+      TestHelpers::extract_dr_bondi_scalars_from_cartesian_metric(
+          dr_spacetime_metric, spacetime_metric, inverse_jacobian,
+          dr_inverse_jacobian, extraction_radius);
+
+  Approx bondi_approx =
+      Approx::custom()
+          .epsilon(std::numeric_limits<double>::epsilon() * 1.0e5)
+          .scale(1.0);
+
+  // we use the specific form of the Robinson-Trautman solution to determine
+  // the generating scalar, then use that to check that the remaining parts
+  // of the metric are appropriately related.
+  const SpinWeighted<ComplexDataVector, 0> inferred_rt_scalar =
+      exp(-2.0 * get(get<Tags::BondiBeta>(bondi_quantities)));
+  const SpinWeighted<ComplexDataVector, 1> expected_bondi_u =
+      Spectral::Swsh::angular_derivative<Spectral::Swsh::Tags::Eth>(
+          l_max, 1, inferred_rt_scalar) /
+      extraction_radius;
+  const SpinWeighted<ComplexDataVector, 0> expected_bondi_w =
+      (inferred_rt_scalar +
+       Spectral::Swsh::angular_derivative<Spectral::Swsh::Tags::EthEthbar>(
+           l_max, 1, inferred_rt_scalar) -
+       1.0) /
+          extraction_radius -
+      2.0 / square(extraction_radius * inferred_rt_scalar);
+  const SpinWeighted<ComplexDataVector, 2> expected_bondi_j{
+      inferred_rt_scalar.size(), 0.0};
+  CHECK_ITERABLE_CUSTOM_APPROX(get(get<Tags::BondiU>(bondi_quantities)),
+                               expected_bondi_u, bondi_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(get(get<Tags::BondiW>(bondi_quantities)),
+                               expected_bondi_w, bondi_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(get(get<Tags::BondiJ>(bondi_quantities)),
+                               expected_bondi_j, bondi_approx);
+
+  const auto ethbar_ethbar_rt_scalar =
+      Spectral::Swsh::angular_derivative<Spectral::Swsh::Tags::EthbarEthbar>(
+          l_max, 1, inferred_rt_scalar);
+  SpinWeighted<ComplexDataVector, 0> expected_dt_rt_scalar =
+      (-pow<4>(inferred_rt_scalar) *
+           Spectral::Swsh::angular_derivative<Spectral::Swsh::Tags::EthEth>(
+               l_max, 1, ethbar_ethbar_rt_scalar) +
+       pow<3>(inferred_rt_scalar) * ethbar_ethbar_rt_scalar *
+           conj(ethbar_ethbar_rt_scalar)) /
+      12.0;
+  Spectral::Swsh::filter_swsh_boundary_quantity(
+      make_not_null(&expected_dt_rt_scalar), l_max, l_max - 3);
+
+  // the evolution equation involves a fourth angular derivative, so requires a
+  // somewhat looser tolerance
+  Approx derivative_bondi_approx =
+      Approx::custom()
+      .epsilon(std::numeric_limits<double>::epsilon() * 1.0e6)
+      .scale(1.0);
+
+  const SpinWeighted<ComplexDataVector, 0> expected_dt_bondi_beta =
+      expected_dt_rt_scalar / (2.0 * inferred_rt_scalar);
+  const SpinWeighted<ComplexDataVector, 1> expected_dt_bondi_u =
+      Spectral::Swsh::angular_derivative<Spectral::Swsh::Tags::Eth>(
+          l_max, 1, expected_dt_rt_scalar) /
+      extraction_radius;
+  const SpinWeighted<ComplexDataVector, 0> expected_dt_bondi_w =
+      (expected_dt_rt_scalar +
+       Spectral::Swsh::angular_derivative<Spectral::Swsh::Tags::EthEthbar>(
+           l_max, 1, expected_dt_rt_scalar)) /
+          extraction_radius +
+      4.0 * expected_dt_rt_scalar /
+          (square(extraction_radius) * pow<3>(inferred_rt_scalar));
+  const SpinWeighted<ComplexDataVector, 2> expected_dt_bondi_j{
+      inferred_rt_scalar.size(), 0.0};
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(get<::Tags::dt<Tags::BondiBeta>>(dt_bondi_quantities)),
+      expected_dt_bondi_beta, derivative_bondi_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(get<::Tags::dt<Tags::BondiU>>(dt_bondi_quantities)),
+      expected_dt_bondi_u, derivative_bondi_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(get<::Tags::dt<Tags::BondiW>>(dt_bondi_quantities)),
+      expected_dt_bondi_w, derivative_bondi_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(get<::Tags::dt<Tags::BondiJ>>(dt_bondi_quantities)),
+      expected_dt_bondi_j, derivative_bondi_approx);
+
+  const SpinWeighted<ComplexDataVector, 0> expected_dr_bondi_beta =
+      -expected_dt_bondi_beta;
+  const SpinWeighted<ComplexDataVector, 1> expected_dr_bondi_u =
+      -expected_dt_bondi_u -
+      Spectral::Swsh::angular_derivative<Spectral::Swsh::Tags::Eth>(
+          l_max, 1, inferred_rt_scalar) /
+          square(extraction_radius);
+  const SpinWeighted<ComplexDataVector, 0> expected_dr_bondi_w =
+      -expected_dt_bondi_w -
+      (inferred_rt_scalar +
+       Spectral::Swsh::angular_derivative<Spectral::Swsh::Tags::EthEthbar>(
+           l_max, 1, inferred_rt_scalar) -
+       1.0) /
+          square(extraction_radius) +
+      4.0 / (pow<3>(extraction_radius) * square(inferred_rt_scalar));
+  const SpinWeighted<ComplexDataVector, 2> expected_dr_bondi_j{
+      inferred_rt_scalar.size(), 0.0};
+
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(get<Tags::Dr<Tags::BondiBeta>>(dr_bondi_quantities)),
+      expected_dr_bondi_beta, bondi_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(get<Tags::Dr<Tags::BondiU>>(dr_bondi_quantities)),
+      expected_dr_bondi_u, bondi_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(get<Tags::Dr<Tags::BondiW>>(dr_bondi_quantities)),
+      expected_dr_bondi_w, bondi_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(get<Tags::Dr<Tags::BondiJ>>(dr_bondi_quantities)),
+      expected_dr_bondi_j, bondi_approx);
+
+  const auto& news = get(get<Tags::News>(boundary_data));
+  const SpinWeighted<ComplexDataVector, -2> expected_news =
+      Spectral::Swsh::angular_derivative<Spectral::Swsh::Tags::EthbarEthbar>(
+          l_max, 1, inferred_rt_scalar) /
+      inferred_rt_scalar;
+  CHECK_ITERABLE_CUSTOM_APPROX(news, expected_news, bondi_approx);
+}
+}  // namespace Cce::Solutions

--- a/tests/Unit/Evolution/Systems/Cce/Test_AnalyticBoundaryDataManager.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_AnalyticBoundaryDataManager.cpp
@@ -101,7 +101,8 @@ struct metavariables {
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.AnalyticBoundaryDataManager",
                   "[Unit][Cce]") {
-  Parallel::register_classes_with_charm<Cce::Solutions::LinearizedBondiSachs>();
+  Parallel::register_classes_with_charm<
+      Cce::Solutions::LinearizedBondiSachs>();
   // set up the analytic data parameters
   MAKE_GENERATOR(gen);
   UniformCustomDistribution<size_t> sdist{7, 10};

--- a/tests/Unit/Evolution/Systems/Cce/Test_AnalyticBoundaryDataManager.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_AnalyticBoundaryDataManager.cpp
@@ -12,11 +12,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/SpinWeighted.hpp"
 #include "Evolution/Systems/Cce/AnalyticBoundaryDataManager.hpp"
-#include "Evolution/Systems/Cce/AnalyticSolutions/BouncingBlackHole.hpp"
-#include "Evolution/Systems/Cce/AnalyticSolutions/GaugeWave.hpp"
 #include "Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.hpp"
-#include "Evolution/Systems/Cce/AnalyticSolutions/RotatingSchwarzschild.hpp"
-#include "Evolution/Systems/Cce/AnalyticSolutions/TeukolskyWave.hpp"
 #include "Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp"
 #include "Evolution/Systems/Cce/BoundaryData.hpp"
 #include "Evolution/Systems/Cce/OptionTags.hpp"
@@ -105,6 +101,7 @@ struct metavariables {
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.AnalyticBoundaryDataManager",
                   "[Unit][Cce]") {
+  Parallel::register_classes_with_charm<Cce::Solutions::LinearizedBondiSachs>();
   // set up the analytic data parameters
   MAKE_GENERATOR(gen);
   UniformCustomDistribution<size_t> sdist{7, 10};
@@ -154,8 +151,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.AnalyticBoundaryDataManager",
                               get<tag>(expected_boundary_variables));
       });
 
-  Parallel::register_derived_classes_with_charm<
-      Cce::Solutions::WorldtubeData>();
   // test writing news
   ActionTesting::MockRuntimeSystem<metavariables> runner{{l_max}};
   runner.set_phase(metavariables::Phase::Initialization);

--- a/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
@@ -12,6 +12,7 @@
 #include "Evolution/Systems/Cce/AnalyticSolutions/BouncingBlackHole.hpp"
 #include "Evolution/Systems/Cce/AnalyticSolutions/GaugeWave.hpp"
 #include "Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/RobinsonTrautman.hpp"
 #include "Evolution/Systems/Cce/AnalyticSolutions/RotatingSchwarzschild.hpp"
 #include "Evolution/Systems/Cce/AnalyticSolutions/TeukolskyWave.hpp"
 #include "Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp"
@@ -137,6 +138,18 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
       "  ExtractionRadius: 40.0\n"
       "  InitialModes: [[0.20, 0.10], [0.08, 0.04]]\n"
       "  Frequency: 0.2");
+  TestHelpers::test_option_tag<Cce::OptionTags::AnalyticSolution>(
+      "RobinsonTrautman:\n"
+      "  InitialModes:\n"
+      "    - [0.0, 0.0]\n"
+      "    - [0.0, 0.0]\n"
+      "    - [0.0, 0.0]\n"
+      "    - [0.0, 0.0]\n"
+      "    - [1.0, 0.5]\n"
+      "  ExtractionRadius: 20.0\n"
+      "  LMax: 16\n"
+      "  Tolerance: 1e-10\n"
+      "  StartTime: 0.0");
   TestHelpers::test_option_tag<Cce::OptionTags::AnalyticSolution>(
       "RotatingSchwarzschild:\n"
       "  ExtractionRadius: 20.0\n"


### PR DESCRIPTION
## Proposed changes

Adds the Robinson-Trautman analytic solution for testing the CCE system.
My reviewers will be reassured to know that this is the final analytic solution I intend to add to CCE for the near future.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Dependencies

- [x] #2608
- [x] #2609
- [x] #3044 
