### PR TITLE
Global cache serialization functions

### DIFF
--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -414,8 +414,7 @@ AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>::
                      typename ParallelComponent::initialization_tags>>>,
       db::AddComputeTags<
           db::wrap_tags_in<Tags::FromGlobalCache, all_cache_tags>>>(
-      static_cast<const Parallel::GlobalCache<metavariables>*>(
-          global_cache_),
+          global_cache_,
       std::move(get<InitializationTags>(initialization_items))...);
 }
 

--- a/src/Parallel/GlobalCache.hpp
+++ b/src/Parallel/GlobalCache.hpp
@@ -137,6 +137,8 @@ class MutableGlobalCache : public CBase_MutableGlobalCache<Metavariables> {
   template <typename GlobalCacheTag, typename Function>
   bool mutable_cache_item_is_ready(const Function& function) noexcept;
 
+  void pup(PUP::er& p) noexcept override;  // NOLINT
+
  private:
   tuples::tagged_tuple_from_typelist<
       get_mutable_global_cache_tag_storage<Metavariables>>
@@ -218,6 +220,11 @@ void MutableGlobalCache<Metavariables>::mutate(
   }
   std::get<1>(tuples::get<tag>(mutable_global_cache_)).clear();
   std::get<1>(tuples::get<tag>(mutable_global_cache_)).shrink_to_fit();
+}
+
+template <typename Metavariables>
+void MutableGlobalCache<Metavariables>::pup(PUP::er& p) noexcept {
+  p | mutable_global_cache_;
 }
 
 /// \ingroup ParallelGroup

--- a/src/Parallel/GlobalCache.hpp
+++ b/src/Parallel/GlobalCache.hpp
@@ -6,7 +6,9 @@
 
 #pragma once
 
+#include <charm++.h>
 #include <optional>
+#include <pup.h>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -267,6 +269,7 @@ class GlobalCache : public CBase_GlobalCache<Metavariables> {
           tmpl::bind<Parallel::proxy_from_parallel_component, tmpl::_1>>>;
 
  public:
+  using proxy_type = CProxy_GlobalCache<Metavariables>;
   /// Access to the Metavariables template parameter
   using metavariables = Metavariables;
   /// Typelist of the ParallelComponents stored in the GlobalCache
@@ -332,6 +335,9 @@ class GlobalCache : public CBase_GlobalCache<Metavariables> {
   /// `args` as subsequent arguments.
   template <typename GlobalCacheTag, typename Function, typename... Args>
   void mutate(const std::tuple<Args...>& args) noexcept;
+
+  /// Retrieve the proxy to the global cache
+  proxy_type get_this_proxy() noexcept;
 
  private:
   // clang-tidy: false positive, redundant declaration
@@ -440,6 +446,12 @@ void GlobalCache<Metavariables>::mutate(
     // version that bypasses proxies.  Just call the function.
     mutable_global_cache_->template mutate<GlobalCacheTag, Function>(args);
   }
+}
+
+template <typename Metavariables>
+typename Parallel::GlobalCache<Metavariables>::proxy_type
+GlobalCache<Metavariables>::get_this_proxy() noexcept {
+  return this->thisProxy;
 }
 
 // @{

--- a/tests/Unit/Framework/MockDistributedObject.hpp
+++ b/tests/Unit/Framework/MockDistributedObject.hpp
@@ -298,8 +298,7 @@ class MockDistributedObject {
             db::AddSimpleTags<Parallel::Tags::GlobalCacheImpl<metavariables>>,
             db::AddComputeTags<db::wrap_tags_in<Parallel::Tags::FromGlobalCache,
                                                 all_cache_tags>>>(
-            static_cast<const Parallel::GlobalCache<metavariables>*>(
-                global_cache_)),
+            global_cache_),
         std::forward<Options>(opts)...);
   }
 

--- a/tests/Unit/Parallel/Test_GlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_GlobalCache.cpp
@@ -248,6 +248,22 @@ void TestArrayChare<Metavariables>::run_test_one() noexcept {
                                     serialized_and_deserialized_local_cache)
                                     .number_of_sides());
 
+  CkMigrateMessage empty_message{};
+  Parallel::GlobalCache<TestMetavariables>
+      serialized_and_deserialized_global_cache{&empty_message};
+  serialize_and_deserialize(
+      make_not_null(&serialized_and_deserialized_global_cache), local_cache);
+  SPECTRE_PARALLEL_REQUIRE(
+      "Nobody" ==
+      Parallel::get<name>(serialized_and_deserialized_global_cache));
+  SPECTRE_PARALLEL_REQUIRE(
+      178 == Parallel::get<age>(serialized_and_deserialized_global_cache));
+  SPECTRE_PARALLEL_REQUIRE(
+      2.2 == Parallel::get<height>(serialized_and_deserialized_global_cache));
+  SPECTRE_PARALLEL_REQUIRE(4 == Parallel::get<shape_of_nametag>(
+                                    serialized_and_deserialized_global_cache)
+                                    .number_of_sides());
+
   // Mutate the weight to 150.
   Parallel::mutate<weight, modify_value<double>>(global_cache_proxy_, 150.0);
   run_test_two();
@@ -405,9 +421,13 @@ void Test_GlobalCache<Metavariables>::run_single_core_test() noexcept {
   SPECTRE_PARALLEL_REQUIRE(30 ==
                            Parallel::get<animal_base>(cache).number_of_legs());
 
+  // Check the serialization of the mutable global cache
+  CkMigrateMessage empty_message{};
   Parallel::MutableGlobalCache<TestMetavariables>
-      serialized_and_deserialized_mutable_cache =
-          serialize_and_deserialize(mutable_cache);
+      serialized_and_deserialized_mutable_cache{&empty_message};
+  serialize_and_deserialize(
+      make_not_null(&serialized_and_deserialized_mutable_cache), mutable_cache);
+
   Parallel::GlobalCache<TestMetavariables> cache_with_serialized_mutable_cache(
       tuples::tagged_tuple_from_typelist<const_tag_list>{
           "Nobody", 178, 2.2, std::make_unique<Square>()},

--- a/tests/Unit/Parallel/Test_GlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_GlobalCache.cpp
@@ -229,6 +229,11 @@ void TestArrayChare<Metavariables>::run_test_one() noexcept {
   SPECTRE_PARALLEL_REQUIRE(
       6 == Parallel::get<animal_base>(local_cache).number_of_legs());
 
+  const auto local_cache_from_proxy =
+      local_cache.get_this_proxy().ckLocalBranch();
+  SPECTRE_PARALLEL_REQUIRE(local_cache_from_proxy ==
+                           global_cache_proxy_.ckLocalBranch());
+
   // Mutate the weight to 150.
   Parallel::mutate<weight, modify_value<double>>(global_cache_proxy_, 150.0);
   run_test_two();

--- a/tests/Unit/Parallel/Test_GlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_GlobalCache.cpp
@@ -17,6 +17,7 @@
 #include <tuple>
 
 #include "ErrorHandling/FloatingPointExceptions.hpp"
+#include "Framework/TestHelpers.hpp"
 #include "Parallel/Algorithms/AlgorithmArray.hpp"
 #include "Parallel/Algorithms/AlgorithmGroup.hpp"
 #include "Parallel/Algorithms/AlgorithmNodegroup.hpp"
@@ -233,6 +234,19 @@ void TestArrayChare<Metavariables>::run_test_one() noexcept {
       local_cache.get_this_proxy().ckLocalBranch();
   SPECTRE_PARALLEL_REQUIRE(local_cache_from_proxy ==
                            global_cache_proxy_.ckLocalBranch());
+
+  // test the serialization of the caches
+  auto& serialized_and_deserialized_local_cache =
+      *serialize_and_deserialize(global_cache_proxy_.ckLocalBranch());
+  SPECTRE_PARALLEL_REQUIRE(
+      "Nobody" == Parallel::get<name>(serialized_and_deserialized_local_cache));
+  SPECTRE_PARALLEL_REQUIRE(
+      178 == Parallel::get<age>(serialized_and_deserialized_local_cache));
+  SPECTRE_PARALLEL_REQUIRE(
+      2.2 == Parallel::get<height>(serialized_and_deserialized_local_cache));
+  SPECTRE_PARALLEL_REQUIRE(4 == Parallel::get<shape_of_nametag>(
+                                    serialized_and_deserialized_local_cache)
+                                    .number_of_sides());
 
   // Mutate the weight to 150.
   Parallel::mutate<weight, modify_value<double>>(global_cache_proxy_, 150.0);

--- a/tests/Unit/Parallel/Test_GlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_GlobalCache.cpp
@@ -404,6 +404,25 @@ void Test_GlobalCache<Metavariables>::run_single_core_test() noexcept {
   SPECTRE_PARALLEL_REQUIRE(30 == Parallel::get<animal>(cache).number_of_legs());
   SPECTRE_PARALLEL_REQUIRE(30 ==
                            Parallel::get<animal_base>(cache).number_of_legs());
+
+  Parallel::MutableGlobalCache<TestMetavariables>
+      serialized_and_deserialized_mutable_cache =
+          serialize_and_deserialize(mutable_cache);
+  Parallel::GlobalCache<TestMetavariables> cache_with_serialized_mutable_cache(
+      tuples::tagged_tuple_from_typelist<const_tag_list>{
+          "Nobody", 178, 2.2, std::make_unique<Square>()},
+      &serialized_and_deserialized_mutable_cache);
+  SPECTRE_PARALLEL_REQUIRE(
+      150 == Parallel::get<weight>(cache_with_serialized_mutable_cache));
+  SPECTRE_PARALLEL_REQUIRE(
+      "isaac@newton.com" ==
+      Parallel::get<email>(cache_with_serialized_mutable_cache));
+  SPECTRE_PARALLEL_REQUIRE(
+      30 == Parallel::get<animal>(cache_with_serialized_mutable_cache)
+                .number_of_legs());
+  SPECTRE_PARALLEL_REQUIRE(
+      30 == Parallel::get<animal_base>(cache_with_serialized_mutable_cache)
+                .number_of_legs());
 }
 
 template <typename Metavariables>

--- a/tests/Unit/Parallel/Test_GlobalCacheDataBox.cpp
+++ b/tests/Unit/Parallel/Test_GlobalCacheDataBox.cpp
@@ -49,7 +49,7 @@ SPECTRE_TEST_CASE("Unit.Parallel.GlobalCacheDataBox", "[Unit][Parallel]") {
                  db::AddComputeTags<
                      Tags::FromGlobalCache<Tags::IntegerList>,
                      Tags::FromGlobalCache<Tags::UniquePtrIntegerList>>>(
-          &std::as_const(cache));
+          &cache);
   CHECK(db::get<Tags::GlobalCache>(box) == &cache);
   CHECK(std::array<int, 3>{{-1, 3, 7}} == db::get<Tags::IntegerList>(box));
   CHECK(std::array<int, 3>{{1, 5, -8}} ==
@@ -68,7 +68,7 @@ SPECTRE_TEST_CASE("Unit.Parallel.GlobalCacheDataBox", "[Unit][Parallel]") {
   db::mutate<Tags::GlobalCache>(
       make_not_null(&box),
       [&cache2](
-          const gsl::not_null<const Parallel::GlobalCache<Metavars>**> t) {
+          const gsl::not_null<Parallel::GlobalCache<Metavars>**> t) {
         *t = std::addressof(cache2);
       });
 


### PR DESCRIPTION
## Proposed changes

Adds serialization utilities for the global cache and mutable global cache. Split out from #2374.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Dependencies

- [x] #2623 