### PR TITLE
Make EllipticDg separate library, fix linking

### DIFF
--- a/src/Elliptic/CMakeLists.txt
+++ b/src/Elliptic/CMakeLists.txt
@@ -14,6 +14,15 @@ spectre_target_headers(
   Tags.hpp
   )
 
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE
+  DataStructures
+  Domain
+  LinearOperators
+  Utilities
+  )
+
 add_subdirectory(Actions)
 add_subdirectory(DiscontinuousGalerkin)
 add_subdirectory(Executables)

--- a/src/Elliptic/DiscontinuousGalerkin/CMakeLists.txt
+++ b/src/Elliptic/DiscontinuousGalerkin/CMakeLists.txt
@@ -1,14 +1,36 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+set(LIBRARY EllipticDg)
+
+add_spectre_library(${LIBRARY})
+
 spectre_target_headers(
-  Elliptic
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   DgElementArray.hpp
   ImposeBoundaryConditions.hpp
   ImposeInhomogeneousBoundaryConditionsOnSource.hpp
   InitializeFirstOrderOperator.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  DataStructures
+  INTERFACE
+  DiscontinuousGalerkin
+  Domain
+  DomainCreators
+  DomainStructure
+  Elliptic
+  Initialization
+  LinearOperators
+  Options
+  Parallel
+  Spectral
+  Utilities
   )
 
 add_subdirectory(NumericalFluxes)

--- a/src/Elliptic/DiscontinuousGalerkin/NumericalFluxes/CMakeLists.txt
+++ b/src/Elliptic/DiscontinuousGalerkin/NumericalFluxes/CMakeLists.txt
@@ -1,8 +1,14 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+spectre_target_sources(
+  EllipticDg
+  PRIVATE
+  FirstOrderInternalPenalty.cpp
+  )
+
 spectre_target_headers(
-  Elliptic
+  EllipticDg
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   FirstOrderInternalPenalty.hpp

--- a/src/Elliptic/DiscontinuousGalerkin/NumericalFluxes/FirstOrderInternalPenalty.cpp
+++ b/src/Elliptic/DiscontinuousGalerkin/NumericalFluxes/FirstOrderInternalPenalty.cpp
@@ -1,0 +1,18 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Elliptic/DiscontinuousGalerkin/NumericalFluxes/FirstOrderInternalPenalty.hpp"
+
+#include <cmath>
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+
+namespace elliptic::dg::NumericalFluxes {
+
+DataVector penalty(const DataVector& element_size, const size_t num_points,
+                   const double penalty_parameter) noexcept {
+  return penalty_parameter * square(num_points) / element_size;
+}
+
+}  // namespace elliptic::dg::NumericalFluxes

--- a/src/Elliptic/DiscontinuousGalerkin/NumericalFluxes/FirstOrderInternalPenalty.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/NumericalFluxes/FirstOrderInternalPenalty.hpp
@@ -50,10 +50,8 @@ namespace elliptic::dg::NumericalFluxes {
  *
  * \see `elliptic::dg::NumericalFluxes::FirstOrderInternalPenalty` for details
  */
-DataVector penalty(const DataVector& element_size, const size_t num_points,
-                   const double penalty_parameter) noexcept {
-  return penalty_parameter * square(num_points) / element_size;
-}
+DataVector penalty(const DataVector& element_size, size_t num_points,
+                   double penalty_parameter) noexcept;
 
 /*!
  * \ingroup DiscontinuousGalerkinGroup

--- a/src/Elliptic/Executables/Elasticity/CMakeLists.txt
+++ b/src/Elliptic/Executables/Elasticity/CMakeLists.txt
@@ -9,6 +9,8 @@ set(LIBS_TO_LINK
   DomainCreators
   Elasticity
   ElasticPotentialEnergy
+  Elliptic
+  EllipticDg
   Informer
   IO
   LinearOperators

--- a/src/Elliptic/Executables/Poisson/CMakeLists.txt
+++ b/src/Elliptic/Executables/Poisson/CMakeLists.txt
@@ -6,6 +6,8 @@ set(LIBS_TO_LINK
   CoordinateMaps
   DiscontinuousGalerkin
   DomainCreators
+  Elliptic
+  EllipticDg
   Informer
   IO
   LinearOperators

--- a/tests/Unit/Elliptic/Actions/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Actions/CMakeLists.txt
@@ -12,7 +12,7 @@ add_test_library(
   ${LIBRARY}
   "Elliptic/Actions/"
   "${LIBRARY_SOURCES}"
-  "DataStructures;Domain;ErrorHandling"
+  "CoordinateMaps;DataStructures;Domain;DomainCreators;DomainStructure;Elliptic;ErrorHandling;Parallel;AnalyticSolutions;Utilities"
   )
 
 add_dependencies(

--- a/tests/Unit/Elliptic/CMakeLists.txt
+++ b/tests/Unit/Elliptic/CMakeLists.txt
@@ -18,5 +18,5 @@ add_test_library(
   ${LIBRARY}
   "Elliptic/"
   "${LIBRARY_SOURCES}"
-  "DataStructures;Utilities"
+  "DataStructures;Elliptic;LinearOperators;Utilities"
   )

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/CMakeLists.txt
@@ -15,7 +15,7 @@ add_test_library(
   ${LIBRARY}
   "Elliptic/DiscontinuousGalerkin/"
   "${LIBRARY_SOURCES}"
-  "DataStructures;Domain;ErrorHandling"
+  "DataStructures;Domain;DomainStructure;EllipticDg;ErrorHandling;Parallel;Utilities"
   )
 
 add_dependencies(

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/NumericalFluxes/CMakeLists.txt
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/NumericalFluxes/CMakeLists.txt
@@ -11,7 +11,7 @@ add_test_library(
   ${LIBRARY}
   "Elliptic/DiscontinuousGalerkin/NumericalFluxes"
   "${LIBRARY_SOURCES}"
-  "DataStructures;Domain;ErrorHandling"
+  "DataStructures;DiscontinuousGalerkin;Domain;EllipticDg;ErrorHandling;Spectral;Utilities"
   )
 
 add_dependencies(

--- a/tests/Unit/Elliptic/Systems/Elasticity/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/Elasticity/CMakeLists.txt
@@ -12,5 +12,5 @@ add_test_library(
   ${LIBRARY}
   "Elliptic/Systems/Elasticity/"
   "${LIBRARY_SOURCES}"
-  "ConstitutiveRelations;Elasticity"
+  "ConstitutiveRelations;DataStructures;Domain;Elasticity;LinearOperators;Utilities"
   )

--- a/tests/Unit/Elliptic/Systems/Poisson/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/Poisson/CMakeLists.txt
@@ -12,5 +12,5 @@ add_test_library(
   ${LIBRARY}
   "Elliptic/Systems/Poisson/"
   "${LIBRARY_SOURCES}"
-  "DataStructures;Poisson;Utilities"
+  "DataStructures;GeneralRelativity;LinearOperators;Poisson;Utilities"
   )

--- a/tests/Unit/Elliptic/Triggers/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Triggers/CMakeLists.txt
@@ -11,5 +11,5 @@ add_test_library(
   ${LIBRARY}
   "Elliptic/Triggers/"
   "${LIBRARY_SOURCES}"
-  "DataStructures"
+  "DataStructures;Elliptic;Parallel;EventsAndTriggers;Utilities"
   )


### PR DESCRIPTION
## Proposed changes

Cleaning up the elliptic libraries a bit, adding missing dependencies in response to comments in #2608.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
