### PR TITLE
Improve/fix FixedHashMap & std::optional serialization

### DIFF
--- a/src/DataStructures/FixedHashMap.hpp
+++ b/src/DataStructures/FixedHashMap.hpp
@@ -4,15 +4,16 @@
 #pragma once
 
 #include <array>
-#include <boost/none.hpp>
-#include <boost/optional.hpp>
 #include <cstddef>
 #include <iterator>
+#include <memory>  // std::addressof
+#include <optional>
 #include <pup.h>
 #include <pup_stl.h>
 #include <type_traits>
 
 #include "ErrorHandling/Assert.hpp"
+#include "Parallel/PupStlCpp17.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/BoostHelpers.hpp"  // IWYU pragma: keep
 #include "Utilities/ConstantExpressions.hpp"
@@ -200,7 +201,7 @@ class FixedHashMap {
   std::pair<iterator, bool> insert_or_assign_impl(key_type&& key,
                                                   M&& obj) noexcept;
 
-  using storage_type = std::array<boost::optional<value_type>, MaxSize>;
+  using storage_type = std::array<std::optional<value_type>, MaxSize>;
 
   SPECTRE_ALWAYS_INLINE size_type hash(const key_type& key) const noexcept {
     if constexpr (hash_is_perfect) {
@@ -225,7 +226,7 @@ class FixedHashMap {
   }
 
   SPECTRE_ALWAYS_INLINE static bool is_set(
-      const boost::optional<value_type>& opt) noexcept {
+      const std::optional<value_type>& opt) noexcept {
     return static_cast<bool>(opt);
   }
 
@@ -257,14 +258,14 @@ class FixedHashMapIterator {
     ASSERT(entry_ != nullptr, "Invalid FixedHashMapIterator");
     ASSERT(is_set(*entry_),
            "FixedHashMapIterator points to an invalid value in the map.");
-    // deference pointer, then dereference boost::optional
-    return **entry_;
+    // deference pointer, then dereference std::optional
+    return entry_->value();
   }
   pointer operator->() const noexcept {
     ASSERT(entry_ != nullptr, "Invalid FixedHashMapIterator");
     ASSERT(is_set(*entry_),
            "FixedHashMapIterator points to an invalid value in the map.");
-    return entry_->get_ptr();
+    return std::addressof(entry_->value());
   }
 
   FixedHashMapIterator& operator++() noexcept;
@@ -307,7 +308,7 @@ class FixedHashMapIterator {
     return not(a < b);
   }
 
-  using map_optional_type = boost::optional<std::remove_const_t<ValueType>>;
+  using map_optional_type = std::optional<std::remove_const_t<ValueType>>;
   using optional_type =
       tmpl::conditional_t<std::is_const<ValueType>::value,
                           const map_optional_type, map_optional_type>;
@@ -372,7 +373,7 @@ FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>::operator=(
   for (size_t i = 0; i < data_.size(); ++i) {
     const auto& other_optional = gsl::at(other.data_, i);
     if (is_set(other_optional)) {
-      // The boost::optionals cannot be assigned to because they
+      // The std::optionals cannot be assigned to because they
       // contain the map keys, which are const, so we have to replace
       // the contents instead, since that counts as a destroy +
       // initialize.
@@ -395,7 +396,7 @@ FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>::operator=(
   for (size_t i = 0; i < data_.size(); ++i) {
     auto& other_optional = gsl::at(other.data_, i);
     if (is_set(other_optional)) {
-      // The boost::optionals cannot be assigned to because they
+      // The std::optionals cannot be assigned to because they
       // contain the map keys, which are const, so we have to replace
       // the contents instead, since that counts as a destroy +
       // initialize.
@@ -419,7 +420,7 @@ template <size_t MaxSize, class Key, class ValueType, class Hash,
           class KeyEqual>
 void FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>::clear() noexcept {
   for (auto& entry : data_) {
-    entry = boost::none;
+    entry.reset();
   }
   size_ = 0;
 }
@@ -460,7 +461,7 @@ auto FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>::erase(
     const const_iterator& pos) noexcept -> iterator {
   auto next_it = &(unconst(pos).get_optional());
   --size_;
-  *next_it = boost::none;
+  next_it->reset();
   // pos now points to an unset entry, advance to next valid one
   do {
     ++next_it;
@@ -482,7 +483,7 @@ size_t FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>::erase(
   if (it == data_.end() or not is_set(*it)) {
     return 0;
   }
-  *it = boost::none;
+  it->reset();
   --size_;
   return 1;
 }
@@ -495,7 +496,7 @@ auto FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>::at(
   if (it == data_.end() or not is_set(*it)) {
     throw std::out_of_range(get_output(key) + " not in FixedHashMap");
   }
-  return (**it).second;
+  return it->value().second;
 }
 
 template <size_t MaxSize, class Key, class ValueType, class Hash,
@@ -525,7 +526,7 @@ auto FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>::operator[](
     ++size_;
     it->emplace(key, mapped_type{});
   }
-  return (**it).second;
+  return it->value().second;
 }
 
 template <size_t MaxSize, class Key, class ValueType, class Hash,
@@ -545,7 +546,7 @@ auto FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>::get_data_entry(
   auto it = data_.begin() + hashed_key;
   if constexpr (not hash_is_perfect) {
     // First search for an existing key.
-    while (not is_set(*it) or (**it).first != key) {
+    while (not is_set(*it) or it->value().first != key) {
       if (++it == data_.end()) {
         it = data_.begin();
       }

--- a/src/DataStructures/FixedHashMap.hpp
+++ b/src/DataStructures/FixedHashMap.hpp
@@ -582,9 +582,9 @@ bool operator==(
   if (a.size_ != b.size_) {
     return false;
   }
-  for (const auto& key_and_value : a) {
-    const auto found_in_b = b.find(key_and_value.first);
-    if (found_in_b == b.end() or found_in_b->second != key_and_value.second) {
+  for (const auto& [key, value] : a) {
+    const auto found_in_b = b.find(key);
+    if (found_in_b == b.end() or found_in_b->second != value) {
       return false;
     }
   }

--- a/src/Parallel/PupStlCpp17.hpp
+++ b/src/Parallel/PupStlCpp17.hpp
@@ -20,9 +20,13 @@ void pup(er& p, std::optional<T>& t) noexcept {  // NOLINT
   if (p.isUnpacking()) {
     p | valid;
     if (valid) {
-      T value{};
-      p | value;
-      t = std::move(value);
+      // default construct in a manner that doesn't require a copy.
+      // This is necessary when holding objects like pair<const Key, unique_ptr>
+      // in unordered map-type structures. The reason this case is tricky is
+      // because the const Key is non-movable while the unique_ptr is
+      // non-copyable. Our only option is in-place construction.
+      t.emplace();
+      p | *t;
     } else {
       t.reset();
     }

--- a/tests/Unit/Parallel/Test_PupStlCpp17.cpp
+++ b/tests/Unit/Parallel/Test_PupStlCpp17.cpp
@@ -9,6 +9,25 @@
 
 #include "Framework/TestHelpers.hpp"
 #include "Parallel/PupStlCpp17.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+struct LocalNoCopyMove {
+  LocalNoCopyMove() = default;
+  explicit LocalNoCopyMove(const size_t in_t) : t(in_t) {}
+  LocalNoCopyMove(const LocalNoCopyMove&) = delete;
+  LocalNoCopyMove& operator=(const LocalNoCopyMove&) = delete;
+  LocalNoCopyMove(LocalNoCopyMove&&) = delete;
+  LocalNoCopyMove& operator=(LocalNoCopyMove&&) = delete;
+  ~LocalNoCopyMove() = default;
+
+  void pup(PUP::er& p) {  // NOLINT
+    p | t;
+  }
+
+  size_t t;
+};
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.Serialization.PupStlCpp17", "[Serialization][Unit]") {
   {
@@ -19,10 +38,20 @@ SPECTRE_TEST_CASE("Unit.Serialization.PupStlCpp17", "[Serialization][Unit]") {
     CHECK_FALSE(t_not_set_deserialized.has_value());
 
     const std::optional<int> t_set{10};
-    REQUIRE(t_set.value());
+    REQUIRE(t_set.value() == 10);
     const auto t_set_deserialized = serialize_and_deserialize(t_set);
     REQUIRE(t_set_deserialized.value());
     CHECK(*t_set_deserialized == 10);
+
+    // Test that we can handle a non-copyable and non-movable class. This occurs
+    // when you have a hashtable where the mapped type is a
+    // std::optional<NonCopyable>
+    const std::optional<LocalNoCopyMove> t_nc{10};
+    REQUIRE(t_nc.value().t == 10);
+    std::optional<LocalNoCopyMove> t_nc_deserialized{};
+    serialize_and_deserialize(make_not_null(&t_nc_deserialized), t_nc);
+    REQUIRE(t_nc_deserialized.value().t == 10);
+    CHECK(t_nc_deserialized->t == 10);
   }
   {
     INFO("Variant");


### PR DESCRIPTION
## Proposed changes

- serialize non-copyables in std::optional
- support non-copyables in FixedHashMap. achieved by switch to std::optional (I don't know why, but I'll take it as an easy fix)

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
