### PR TITLE
Support 'None' label for Options::Auto

### DIFF
--- a/src/Options/Auto.cpp
+++ b/src/Options/Auto.cpp
@@ -1,0 +1,24 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Options/Auto.hpp"
+
+#include <ostream>
+#include <string>
+
+#include "ErrorHandling/Error.hpp"
+
+namespace Options {
+
+std::ostream& operator<<(std::ostream& os, const AutoLabel label) noexcept {
+  switch (label) {
+    case AutoLabel::Auto:
+      return os << "Auto";
+    case AutoLabel::None:
+      return os << "None";
+    default:
+      ERROR("Invalid label");
+  }
+}
+
+}  // namespace Options

--- a/src/Options/CMakeLists.txt
+++ b/src/Options/CMakeLists.txt
@@ -3,7 +3,13 @@
 
 set(LIBRARY Options)
 
-add_spectre_library(${LIBRARY} INTERFACE)
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  Auto.cpp
+  )
 
 spectre_target_headers(
   ${LIBRARY}
@@ -18,8 +24,9 @@ spectre_target_headers(
 
 target_link_libraries(
   ${LIBRARY}
-  INTERFACE
+  PUBLIC
   ErrorHandling
   Utilities
+  INTERFACE
   YamlCpp
   )

--- a/src/Options/OptionsDetails.hpp
+++ b/src/Options/OptionsDetails.hpp
@@ -68,7 +68,8 @@ struct is_in_group<Tag, Group, std::void_t<typename Tag::group>>
 
 /// The subset of tags in `OptionList` that are in the hierarchy of `Group`
 template <typename OptionList, typename Group>
-using options_in_group = tmpl::filter<OptionList, is_in_group<tmpl::_1, Group>>;
+using options_in_group =
+    tmpl::filter<OptionList, is_in_group<tmpl::_1, tmpl::pin<Group>>>;
 
 // Display a type in a pseudo-YAML form, leaving out likely irrelevant
 // information.

--- a/src/Options/ParseOptions.hpp
+++ b/src/Options/ParseOptions.hpp
@@ -203,7 +203,7 @@ class Parser {
   /// `OptionList` is either in this list or in the hierarchy of one of the
   /// groups in this list.
   using tags_and_subgroups_list = tmpl::remove_duplicates<tmpl::transform<
-      OptionList, Options_detail::find_subgroup<tmpl::_1, Group>>>;
+      OptionList, Options_detail::find_subgroup<tmpl::_1, tmpl::pin<Group>>>>;
 
   // The maximum length of an option label.
   static constexpr int max_label_size_ = 70;

--- a/tests/Unit/Options/Test_Auto.cpp
+++ b/tests/Unit/Options/Test_Auto.cpp
@@ -113,15 +113,21 @@ class ExampleClass {
     static constexpr Options::String help =
         "Integer that can be automatically chosen";
   };
+  struct OptionalArg {
+    using type = Options::Auto<double, Options::AutoLabel::None>;
+    static constexpr Options::String help = "Optional parameter";
+  };
 
   static constexpr Options::String help =
       "A class that can automatically choose an argument";
-  using options = tmpl::list<AutoArg>;
+  using options = tmpl::list<AutoArg, OptionalArg>;
 
-  explicit ExampleClass(std::optional<int> auto_arg) noexcept
-      : value(auto_arg ? *auto_arg : -12) {}
+  explicit ExampleClass(std::optional<int> auto_arg,
+                        std::optional<double> opt_arg) noexcept
+      : value(auto_arg ? *auto_arg : -12), optional_value(opt_arg) {}
 
   int value{};
+  std::optional<double> optional_value{};
 };
 /// [example_class]
 #if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 8 && __GNUC__ < 11
@@ -146,8 +152,16 @@ class NonCopyableArgument {
 
 void test_use_as_option() noexcept {
   /// [example_create]
-  CHECK(TestHelpers::test_creation<ExampleClass>("AutoArg: 7").value == 7);
-  CHECK(TestHelpers::test_creation<ExampleClass>("AutoArg: Auto").value == -12);
+  const auto example1 = TestHelpers::test_creation<ExampleClass>(
+      "AutoArg: 7\n"
+      "OptionalArg: 10.");
+  CHECK(example1.value == 7);
+  CHECK(example1.optional_value == 10.);
+  const auto example2 = TestHelpers::test_creation<ExampleClass>(
+      "AutoArg: Auto\n"
+      "OptionalArg: None");
+  CHECK(example2.value == -12);
+  CHECK(example2.optional_value == std::nullopt);
   /// [example_create]
 
   // Make sure this compiles.


### PR DESCRIPTION
## Proposed changes

- Adds the option to label the absence of a value with 'None' instead of 'Auto', as discussed in #2559.
- Also fixes a minor bug with Option groups that I sometimes hit. This fixes the issue so I haven't investigated it any further.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
