### PR TITLE
Add NumIterations convergence reason

### DIFF
--- a/src/NumericalAlgorithms/Convergence/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Convergence/CMakeLists.txt
@@ -27,9 +27,10 @@ spectre_target_headers(
 target_link_libraries(
   ${LIBRARY}
   PUBLIC
-  Boost::boost
   DataStructures
   ErrorHandling
   Options
   Utilities
+  PRIVATE
+  Parallel
   )

--- a/src/NumericalAlgorithms/Convergence/HasConverged.hpp
+++ b/src/NumericalAlgorithms/Convergence/HasConverged.hpp
@@ -34,8 +34,18 @@ namespace Convergence {
  * refers to the state before the first iteration has begun, i.e. where the
  * `iteration_id` is zero.
  *
- * \returns a `Convergence::Reason` if the criteria are met, or
- * `std::nullopt` otherwise.
+ * \returns A `Convergence::Reason` if the criteria are met, or
+ * `std::nullopt` otherwise. The possible convergence reasons are:
+ *
+ * - `Convergence::Reason::AbsoluteResidual` if the `residual_magnitude`
+ *   meets the convergence criteria's `absolute_residual`.
+ * - `Convergence::Reason::RelativeResidual` if `residual_magnitude /
+ *   initial_residual_magnitude` meets the convergence criteria's
+ *   `relative_residual`.
+ * - `Convergence::Reason::MaxIterations` if the `iteration_id` is the
+ *   convergence_criteria's `max_iterations` or higher. This is often
+ *   interpreted as an error because the algorithm did not converge in the
+ *   alloted number of iterations.
  */
 std::optional<Reason> criteria_match(
     const Criteria& criteria, size_t iteration_id, double residual_magnitude,
@@ -67,7 +77,9 @@ struct HasConverged {
                double initial_residual_magnitude) noexcept;
 
   /// Construct at a state where `iteration_id` iterations of a total of
-  /// `num_iterations` have completed.
+  /// `num_iterations` have completed. Use when the algorithm is intended to run
+  /// for a fixed number of iterations. The convergence `reason()` will be
+  /// `Convergence::Reason::NumIterations`.
   HasConverged(size_t num_iterations, size_t iteration_id) noexcept;
 
   explicit operator bool() const noexcept { return static_cast<bool>(reason_); }

--- a/src/NumericalAlgorithms/Convergence/HasConverged.hpp
+++ b/src/NumericalAlgorithms/Convergence/HasConverged.hpp
@@ -3,10 +3,9 @@
 
 #pragma once
 
-#include <boost/none.hpp>
-#include <boost/optional.hpp>
 #include <cstddef>
 #include <iosfwd>
+#include <optional>
 
 #include "NumericalAlgorithms/Convergence/Criteria.hpp"
 #include "NumericalAlgorithms/Convergence/Reason.hpp"
@@ -36,9 +35,9 @@ namespace Convergence {
  * `iteration_id` is zero.
  *
  * \returns a `Convergence::Reason` if the criteria are met, or
- * `boost::none` otherwise.
+ * `std::nullopt` otherwise.
  */
-boost::optional<Reason> criteria_match(
+std::optional<Reason> criteria_match(
     const Criteria& criteria, size_t iteration_id, double residual_magnitude,
     double initial_residual_magnitude) noexcept;
 
@@ -103,10 +102,7 @@ struct HasConverged {
                                   const HasConverged& has_converged) noexcept;
 
  private:
-  // This default initialization is equivalent to boost::none, but works around
-  // a `-Wmaybe-uninitialized` warning on GCC 7 in Release mode
-  boost::optional<Reason> reason_ =
-      boost::make_optional(false, Reason::MaxIterations);
+  std::optional<Reason> reason_{};
   Criteria criteria_{};
   size_t iteration_id_{};
   double residual_magnitude_{};

--- a/src/NumericalAlgorithms/Convergence/Reason.cpp
+++ b/src/NumericalAlgorithms/Convergence/Reason.cpp
@@ -15,6 +15,8 @@ namespace Convergence {
 
 std::ostream& operator<<(std::ostream& os, const Reason& reason) noexcept {
   switch (reason) {
+    case Reason::NumIterations:
+      return os << "NumIterations";
     case Reason::MaxIterations:
       return os << "MaxIterations";
     case Reason::AbsoluteResidual:
@@ -32,8 +34,10 @@ template <>
 Convergence::Reason
 Options::create_from_yaml<Convergence::Reason>::create<void>(
     const Options::Option& options) {
-  const std::string type_read = options.parse_as<std::string>();
-  if (type_read == get_output(Convergence::Reason::MaxIterations)) {
+  const auto type_read = options.parse_as<std::string>();
+  if (type_read == get_output(Convergence::Reason::NumIterations)) {
+    return Convergence::Reason::NumIterations;
+  } else if (type_read == get_output(Convergence::Reason::MaxIterations)) {
     return Convergence::Reason::MaxIterations;
   } else if (type_read == get_output(Convergence::Reason::AbsoluteResidual)) {
     return Convergence::Reason::AbsoluteResidual;
@@ -43,6 +47,7 @@ Options::create_from_yaml<Convergence::Reason>::create<void>(
   PARSE_ERROR(options.context(),
               "Failed to convert \""
                   << type_read << "\" to Convergence::Reason. Must be one of '"
+                  << get_output(Convergence::Reason::NumIterations) << "', '"
                   << get_output(Convergence::Reason::MaxIterations) << "', '"
                   << get_output(Convergence::Reason::AbsoluteResidual)
                   << "' or '"

--- a/src/NumericalAlgorithms/Convergence/Reason.hpp
+++ b/src/NumericalAlgorithms/Convergence/Reason.hpp
@@ -20,7 +20,17 @@ namespace Convergence {
  *
  * \see Convergence::Criteria
  */
-enum class Reason { MaxIterations, AbsoluteResidual, RelativeResidual };
+enum class Reason {
+  /// Reached the target number of iterations
+  NumIterations,
+  /// Reached the maximum number of iterations. Can be interpreted as an error
+  /// condition.
+  MaxIterations,
+  /// Residual converged below absolute tolerance
+  AbsoluteResidual,
+  /// Residual converged below relative tolerance
+  RelativeResidual
+};
 
 std::ostream& operator<<(std::ostream& os, const Reason& reason) noexcept;
 

--- a/tests/Unit/NumericalAlgorithms/Convergence/Test_HasConverged.cpp
+++ b/tests/Unit/NumericalAlgorithms/Convergence/Test_HasConverged.cpp
@@ -93,7 +93,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.Convergence.HasConverged",
     INFO("HasConverged - fixed number of iterations complete")
     const Convergence::HasConverged has_converged{1, 1};
     CHECK(has_converged);
-    CHECK(has_converged.reason() == Convergence::Reason::MaxIterations);
+    CHECK(has_converged.reason() == Convergence::Reason::NumIterations);
     test_serialization(has_converged);
     test_copy_semantics(has_converged);
   }

--- a/tests/Unit/NumericalAlgorithms/Convergence/Test_HasConverged.cpp
+++ b/tests/Unit/NumericalAlgorithms/Convergence/Test_HasConverged.cpp
@@ -3,10 +3,7 @@
 
 #include "Framework/TestingFramework.hpp"
 
-#include <boost/none.hpp>
-#include <boost/none_t.hpp>
-#include <boost/optional.hpp>
-#include <boost/optional/optional_io.hpp>
+#include <optional>
 #include <string>
 
 #include "ErrorHandling/Error.hpp"
@@ -24,7 +21,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.Convergence.HasConverged",
 
   {
     INFO("Convergence logic");
-    CHECK(Convergence::criteria_match(criteria, 1, 1., 1.) == boost::none);
+    CHECK_FALSE(Convergence::criteria_match(criteria, 1, 1., 1.));
     CHECK(Convergence::criteria_match(criteria, 2, 1., 1.) ==
           Convergence::Reason::MaxIterations);
     CHECK(Convergence::criteria_match(criteria, 1, 0., 1.) ==

--- a/tests/Unit/NumericalAlgorithms/Convergence/Test_Reason.cpp
+++ b/tests/Unit/NumericalAlgorithms/Convergence/Test_Reason.cpp
@@ -21,12 +21,14 @@ void test_construct_from_options() noexcept {
 
 SPECTRE_TEST_CASE("Unit.Numerical.Convergence.Reason",
                   "[Unit][NumericalAlgorithms]") {
+  CHECK(get_output(Convergence::Reason::NumIterations) == "NumIterations");
   CHECK(get_output(Convergence::Reason::MaxIterations) == "MaxIterations");
   CHECK(get_output(Convergence::Reason::AbsoluteResidual) ==
         "AbsoluteResidual");
   CHECK(get_output(Convergence::Reason::RelativeResidual) ==
         "RelativeResidual");
 
+  test_construct_from_options<Convergence::Reason::NumIterations>();
   test_construct_from_options<Convergence::Reason::MaxIterations>();
   test_construct_from_options<Convergence::Reason::AbsoluteResidual>();
   test_construct_from_options<Convergence::Reason::RelativeResidual>();

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/Test_DistributedRichardsonAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/Test_DistributedRichardsonAlgorithm.yaml
@@ -51,4 +51,4 @@ ParallelRichardson:
   RelaxationParameter: 0.2916330767929102
   Verbosity: Verbose
 
-ConvergenceReason: MaxIterations
+ConvergenceReason: NumIterations

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/Test_RichardsonAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/Test_RichardsonAlgorithm.yaml
@@ -15,4 +15,4 @@ SerialRichardson:
   RelaxationParameter: 0.2857142857142857
   Verbosity: Verbose
 
-ConvergenceReason: MaxIterations
+ConvergenceReason: NumIterations

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.yaml
@@ -55,7 +55,7 @@ SchwarzSmoother:
     Verbosity: Verbose
     Restart: 0
 
-ConvergenceReason: MaxIterations
+ConvergenceReason: NumIterations
 
 Observers:
   VolumeFileName: "Test_SchwarzAlgorithm_Volume"


### PR DESCRIPTION
## Proposed changes

Hitting the "MaxIterations" convergence reason often indicates an error, so this adds "NumIterations" for when the algorithm should run a specific number of iterations.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
