### PR TITLE
Optimize serial linear solvers and support factory-creation

### DIFF
--- a/src/NumericalAlgorithms/LinearSolver/CMakeLists.txt
+++ b/src/NumericalAlgorithms/LinearSolver/CMakeLists.txt
@@ -19,6 +19,7 @@ spectre_target_headers(
   Gmres.hpp
   InnerProduct.hpp
   Lapack.hpp
+  LinearSolver.hpp
   )
 
 target_link_libraries(
@@ -28,6 +29,7 @@ target_link_libraries(
   Convergence
   DataStructures
   Options
+  Parallel
   PRIVATE
   Lapack
   )

--- a/src/NumericalAlgorithms/LinearSolver/Gmres.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Gmres.hpp
@@ -3,10 +3,12 @@
 
 #pragma once
 
-#include <boost/none.hpp>
-#include <boost/optional.hpp>
-#include <boost/optional/optional_io.hpp>
 #include <cstddef>
+#include <memory>
+#include <optional>
+#include <pup.h>
+#include <type_traits>
+#include <utility>
 
 #include "DataStructures/DenseMatrix.hpp"
 #include "DataStructures/DenseVector.hpp"
@@ -15,8 +17,13 @@
 #include "NumericalAlgorithms/Convergence/HasConverged.hpp"
 #include "NumericalAlgorithms/Convergence/Reason.hpp"
 #include "NumericalAlgorithms/LinearSolver/InnerProduct.hpp"
+#include "NumericalAlgorithms/LinearSolver/LinearSolver.hpp"
+#include "Options/Auto.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/Registration.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace LinearSolver {
 namespace gmres::detail {
@@ -76,12 +83,25 @@ DenseVector<double> minimal_residual_vector(
 
 namespace Serial {
 
-/// Indicates the linear solver uses no preconditioner. It may perform
-/// compile-time optimization for this case.
-struct NoPreconditioner {};
-
 /// Disables the iteration callback at compile-time
 struct NoIterationCallback {};
+
+/// \cond
+template <typename VarsType, typename Preconditioner,
+          typename LinearSolverRegistrars>
+struct Gmres;
+/// \endcond
+
+namespace Registrars {
+
+/// Registers the `LinearSolver::Serial::Gmres` linear solver.
+template <typename VarsType>
+struct Gmres {
+  template <typename LinearSolverRegistrars>
+  using f = Serial::Gmres<VarsType, LinearSolver<LinearSolverRegistrars>,
+                          LinearSolverRegistrars>;
+};
+}  // namespace Registrars
 
 /*!
  * \brief A serial GMRES iterative solver for nonsymmetric linear systems of
@@ -117,8 +137,8 @@ struct NoIterationCallback {};
  * solver, but note that the solver can stagnate for non-positive-definite
  * operators and is not guaranteed to converge within \f$N_A\f$ iterations
  * anymore. Set the `restart` argument of the constructor to
- * \f$N_\mathrm{restart}\f$ to activate restarting, or set it to zero to
- * deactivate restarting (default behaviour).
+ * \f$N_\mathrm{restart}\f$ to activate restarting, or set it to 'None' to
+ * deactivate restarting.
  *
  * \par Preconditioning:
  * This implementation of the GMRES algorithm also supports preconditioning.
@@ -136,18 +156,27 @@ struct NoIterationCallback {};
  * \example
  * \snippet NumericalAlgorithms/LinearSolver/Test_Gmres.cpp gmres_example
  */
-template <typename VarsType>
-struct Gmres {
+template <typename VarsType, typename Preconditioner = NoPreconditioner,
+          typename LinearSolverRegistrars =
+              tmpl::list<Registrars::Gmres<VarsType>>>
+class Gmres final : public PreconditionedLinearSolver<Preconditioner,
+                                                      LinearSolverRegistrars> {
  private:
+  using Base =
+      PreconditionedLinearSolver<Preconditioner, LinearSolverRegistrars>;
+
   struct ConvergenceCriteria {
     using type = Convergence::Criteria;
     static constexpr Options::String help =
         "Determine convergence of the algorithm";
   };
   struct Restart {
-    using type = size_t;
+    using type = Options::Auto<size_t, Options::AutoLabel::None>;
     static constexpr Options::String help =
-        "Iterations to run before restarting";
+        "Iterations to run before restarting, or 'None' to disable restarting. "
+        "Note that the solver is not guaranteed to converge anymore if you "
+        "enable restarting.";
+    static type suggested_value() noexcept { return {}; }
   };
   struct Verbosity {
     using type = ::Verbosity;
@@ -162,29 +191,46 @@ struct Gmres {
       "linear operator A, but will ideally converge to a reasonable\n"
       "approximation of the solution x in only a few iterations.\n"
       "\n"
+      "Preconditioning: Specify a preconditioner to run in every GMRES "
+      "iteration to accelerate the solve, or 'None' to disable "
+      "preconditioning. The choice of preconditioner can be crucial to obtain "
+      "good convergence.\n"
+      "\n"
       "Restarting: It is sometimes helpful to restart the algorithm every\n"
       "N_restart iterations to speed it up. Note that it can stagnate for\n"
       "non-positive-definite matrices and is not guaranteed to converge\n"
       "within N_A iterations anymore when restarting is activated.\n"
       "Activate restarting by setting the 'Restart' option to N_restart, or\n"
-      "deactivate restarting by setting it to zero (default).";
-  using options = tmpl::list<ConvergenceCriteria, Verbosity, Restart>;
+      "deactivate restarting by setting it to 'None'.";
+  using options = tmpl::flatten<tmpl::list<
+      ConvergenceCriteria, Verbosity, Restart,
+      tmpl::conditional_t<std::is_same_v<Preconditioner, NoPreconditioner>,
+                          tmpl::list<>, typename Base::PreconditionerOption>>>;
 
   Gmres(Convergence::Criteria convergence_criteria, ::Verbosity verbosity,
-        size_t restart = 0) noexcept
-      // clang-tidy: trivially copyable
-      : convergence_criteria_(std::move(convergence_criteria)),  // NOLINT
-        verbosity_(std::move(verbosity)),                        // NOLINT
-        restart_(restart > 0 ? restart : convergence_criteria_.max_iterations) {
-    initialize();
-  }
+        std::optional<size_t> restart = std::nullopt,
+        std::optional<typename Base::PreconditionerType> local_preconditioner =
+            std::nullopt,
+        const Options::Context& context = {});
 
   Gmres() = default;
-  Gmres(const Gmres& /*rhs*/) = default;
-  Gmres& operator=(const Gmres& /*rhs*/) = default;
-  Gmres(Gmres&& /*rhs*/) = default;
-  Gmres& operator=(Gmres&& /*rhs*/) = default;
-  ~Gmres() = default;
+  Gmres(Gmres&&) = default;
+  Gmres& operator=(Gmres&&) = default;
+  ~Gmres() override = default;
+
+  Gmres(const Gmres& rhs) noexcept;
+  Gmres& operator=(const Gmres& rhs) noexcept;
+
+  std::unique_ptr<LinearSolver<LinearSolverRegistrars>> get_clone() const
+      noexcept override {
+    return std::make_unique<Gmres>(*this);
+  }
+
+  /// \cond
+  explicit Gmres(CkMigrateMessage* m) noexcept;
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Gmres);  // NOLINT
+  /// \endcond
 
   void initialize() noexcept {
     orthogonalization_history_.reserve(restart_ + 1);
@@ -198,8 +244,11 @@ struct Gmres {
   const Convergence::Criteria& convergence_criteria() const noexcept {
     return convergence_criteria_;
   }
+  ::Verbosity verbosity() const noexcept { return verbosity_; }
+  size_t restart() const noexcept { return restart_; }
 
-  void pup(PUP::er& p) noexcept {  // NOLINT
+  void pup(PUP::er& p) noexcept override {  // NOLINT
+    Base::pup(p);
     p | convergence_criteria_;
     p | verbosity_;
     p | restart_;
@@ -208,26 +257,18 @@ struct Gmres {
     }
   }
 
-  /*!
-   * \brief Iteratively solve the problem \f$Ax=b\f$ for \f$x\f$ where \f$A\f$
-   * is the `linear_operator` and \f$b\f$ is the `source`, starting \f$x\f$ at
-   * `initial_guess`.
-   *
-   * Optionally provide a `preconditioner` (see class documentation).
-   *
-   * \return An instance of `Convergence::HasConverged` that provides
-   * information on the convergence status of the completed solve, and the
-   * approximate solution \f$x\f$.
-   */
   template <typename LinearOperator, typename SourceType,
-            typename Preconditioner = NoPreconditioner,
             typename IterationCallback = NoIterationCallback>
   Convergence::HasConverged solve(
       gsl::not_null<VarsType*> initial_guess_in_solution_out,
-      LinearOperator&& linear_operator, const SourceType& source,
-      Preconditioner&& preconditioner = NoPreconditioner{},
-      IterationCallback&& iteration_callback = NoIterationCallback{}) const
-      noexcept;
+      const LinearOperator& linear_operator, const SourceType& source,
+      const IterationCallback& iteration_callback =
+          NoIterationCallback{}) const noexcept;
+
+  void reset() noexcept override {
+    // Nothing to reset. Only call into base class to reset preconditioner.
+    Base::reset();
+  }
 
  private:
   Convergence::Criteria convergence_criteria_{};
@@ -257,14 +298,69 @@ struct Gmres {
   mutable std::vector<VarsType> preconditioned_basis_history_{};
 };
 
-template <typename VarsType>
-template <typename LinearOperator, typename SourceType, typename Preconditioner,
+template <typename VarsType, typename Preconditioner,
+          typename LinearSolverRegistrars>
+Gmres<VarsType, Preconditioner, LinearSolverRegistrars>::Gmres(
+    Convergence::Criteria convergence_criteria, ::Verbosity verbosity,
+    std::optional<size_t> restart,
+    std::optional<typename Base::PreconditionerType> local_preconditioner,
+    const Options::Context& context)
+    // clang-tidy: trivially copyable
+    : Base(std::move(local_preconditioner)),
+      convergence_criteria_(std::move(convergence_criteria)),  // NOLINT
+      verbosity_(std::move(verbosity)),                        // NOLINT
+      restart_(restart.value_or(convergence_criteria_.max_iterations)) {
+  if (restart_ == 0) {
+    PARSE_ERROR(context,
+                "Can't restart every '0' iterations. Set to a nonzero "
+                "number, or to 'None' if you meant to disable restarting.");
+  }
+  initialize();
+}
+
+// Define copy constructors. They don't have to copy the memory buffers but
+// only resize them. They take care of copying the preconditioner by calling
+// into the base class.
+template <typename VarsType, typename Preconditioner,
+          typename LinearSolverRegistrars>
+Gmres<VarsType, Preconditioner, LinearSolverRegistrars>::Gmres(
+    const Gmres& rhs) noexcept
+    : Base(rhs),
+      convergence_criteria_(rhs.convergence_criteria_),
+      verbosity_(rhs.verbosity_),
+      restart_(rhs.restart_) {
+  initialize();
+}
+template <typename VarsType, typename Preconditioner,
+          typename LinearSolverRegistrars>
+Gmres<VarsType, Preconditioner, LinearSolverRegistrars>&
+Gmres<VarsType, Preconditioner, LinearSolverRegistrars>::operator=(
+    const Gmres& rhs) noexcept {
+  Base::operator=(rhs);
+  convergence_criteria_ = rhs.convergence_criteria_;
+  verbosity_ = rhs.verbosity_;
+  restart_ = rhs.restart_;
+  initialize();
+  return *this;
+}
+
+/// \cond
+template <typename VarsType, typename Preconditioner,
+          typename LinearSolverRegistrars>
+Gmres<VarsType, Preconditioner, LinearSolverRegistrars>::Gmres(
+    CkMigrateMessage* m) noexcept
+    : Base(m) {}
+/// \endcond
+
+template <typename VarsType, typename Preconditioner,
+          typename LinearSolverRegistrars>
+template <typename LinearOperator, typename SourceType,
           typename IterationCallback>
-Convergence::HasConverged Gmres<VarsType>::solve(
+Convergence::HasConverged
+Gmres<VarsType, Preconditioner, LinearSolverRegistrars>::solve(
     const gsl::not_null<VarsType*> initial_guess_in_solution_out,
-    LinearOperator&& linear_operator, const SourceType& source,
-    Preconditioner&& preconditioner,
-    IterationCallback&& iteration_callback) const noexcept {
+    const LinearOperator& linear_operator, const SourceType& source,
+    const IterationCallback& iteration_callback) const noexcept {
   constexpr bool use_preconditioner =
       not std::is_same_v<Preconditioner, NoPreconditioner>;
   constexpr bool use_iteration_callback =
@@ -302,16 +398,20 @@ Convergence::HasConverged Gmres<VarsType>::solve(
     for (size_t k = 0; k < restart_; ++k) {
       auto& operand = basis_history_[k + 1];
       if constexpr (use_preconditioner) {
-        // Begin the preconditioner at an initial guess of 0. Not all
-        // preconditioners take the initial guess into account.
-        preconditioned_basis_history_[k] =
-            make_with_value<VarsType>(initial_operand, 0.);
-        preconditioner.solve(make_not_null(&preconditioned_basis_history_[k]),
-                             linear_operator, basis_history_[k]);
+        if (this->has_preconditioner()) {
+          // Begin the preconditioner at an initial guess of 0. Not all
+          // preconditioners take the initial guess into account.
+          preconditioned_basis_history_[k] =
+              make_with_value<VarsType>(initial_operand, 0.);
+          this->preconditioner().solve(
+              make_not_null(&preconditioned_basis_history_[k]), linear_operator,
+              basis_history_[k]);
+        }
       }
       linear_operator(make_not_null(&operand),
-                      use_preconditioner ? preconditioned_basis_history_[k]
-                                         : basis_history_[k]);
+                      this->has_preconditioner()
+                          ? preconditioned_basis_history_[k]
+                          : basis_history_[k]);
       // Find a new orthogonal basis vector of the Krylov subspace
       gmres::detail::arnoldi_orthogonalize(
           make_not_null(&operand), make_not_null(&orthogonalization_history_),
@@ -340,14 +440,22 @@ Convergence::HasConverged Gmres<VarsType>::solve(
     // Construct the solution from the orthogonal basis and the minimal residual
     // vector
     for (size_t i = 0; i < minres.size(); ++i) {
-      solution +=
-          minres[i] * gsl::at(use_preconditioner ? preconditioned_basis_history_
-                                                 : basis_history_,
-                              i);
+      solution += minres[i] * gsl::at(this->has_preconditioner()
+                                          ? preconditioned_basis_history_
+                                          : basis_history_,
+                                      i);
     }
   }
   return has_converged;
 }
+
+/// \cond
+template <typename VarsType, typename Preconditioner,
+          typename LinearSolverRegistrars>
+// NOLINTNEXTLINE
+PUP::able::PUP_ID
+    Gmres<VarsType, Preconditioner, LinearSolverRegistrars>::my_PUP_ID = 0;
+/// \endcond
 
 }  // namespace Serial
 }  // namespace LinearSolver

--- a/src/NumericalAlgorithms/LinearSolver/LinearSolver.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/LinearSolver.hpp
@@ -1,0 +1,283 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <pup.h>
+#include <pup_stl.h>
+#include <type_traits>
+#include <utility>
+
+#include "NumericalAlgorithms/Convergence/HasConverged.hpp"
+#include "Options/Auto.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Parallel/PupStlCpp17.hpp"
+#include "Utilities/FakeVirtual.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Registration.hpp"
+#include "Utilities/Requires.hpp"
+
+namespace LinearSolver::Serial {
+
+/// Registrars for linear solvers
+namespace Registrars {}
+
+/*!
+ * \brief Base class for serial linear solvers that supports factory-creation.
+ *
+ * Derive linear solvers from this class so they can be factory-created. If your
+ * linear solver supports preconditioning, derive from
+ * `PreconditionedLinearSolver` instead to inherit utility that allows using any
+ * other factor-creatable linear solver as preconditioner.
+ */
+template <typename LinearSolverRegistrars>
+class LinearSolver : public PUP::able {
+ protected:
+  /// \cond
+  LinearSolver() = default;
+  LinearSolver(const LinearSolver&) = default;
+  LinearSolver(LinearSolver&&) = default;
+  LinearSolver& operator=(const LinearSolver&) = default;
+  LinearSolver& operator=(LinearSolver&&) = default;
+  /// \endcond
+
+ public:
+  ~LinearSolver() override = default;
+
+  /// \cond
+  explicit LinearSolver(CkMigrateMessage* m) noexcept;
+  WRAPPED_PUPable_abstract(LinearSolver);  // NOLINT
+  /// \endcond
+
+  using creatable_classes = Registration::registrants<LinearSolverRegistrars>;
+
+  virtual std::unique_ptr<LinearSolver<LinearSolverRegistrars>> get_clone()
+      const = 0;
+
+  /*!
+   * \brief Solve the linear equation \f$Ax=b\f$ where \f$A\f$ is the
+   * `linear_operator` and \f$b\f$ is the `source`.
+   *
+   * - The (approximate) solution \f$x\f$ is returned in the
+   *   `initial_guess_in_solution_out` buffer, which also serves to provide an
+   *   initial guess for \f$x\f$. Not all solvers take the initial guess into
+   *   account, but all expect the buffer is sized correctly.
+   * - The `linear_operator` must be an invocable that takes a `VarsType` as
+   *   const-ref argument and returns a `SourceType` by reference.
+   *
+   * Each solve may mutate the private state of the solver, for example to cache
+   * quantities to accelerate successive solves for the same operator. Invoke
+   * `reset` to discard these caches.
+   */
+  template <typename LinearOperator, typename VarsType, typename SourceType,
+            typename... Args>
+  Convergence::HasConverged solve(
+      gsl::not_null<VarsType*> initial_guess_in_solution_out,
+      const LinearOperator& linear_operator, const SourceType& source,
+      Args&&... args) const noexcept;
+
+  /// Discard caches from previous solves. Use before solving a different linear
+  /// operator.
+  virtual void reset() noexcept = 0;
+};
+
+/// \cond
+template <typename LinearSolverRegistrars>
+LinearSolver<LinearSolverRegistrars>::LinearSolver(CkMigrateMessage* m) noexcept
+    : PUP::able(m) {}
+/// \endcond
+
+template <typename LinearSolverRegistrars>
+template <typename LinearOperator, typename VarsType, typename SourceType,
+          typename... Args>
+Convergence::HasConverged LinearSolver<LinearSolverRegistrars>::solve(
+    const gsl::not_null<VarsType*> initial_guess_in_solution_out,
+    const LinearOperator& linear_operator, const SourceType& source,
+    Args&&... args) const noexcept {
+  return call_with_dynamic_type<Convergence::HasConverged, creatable_classes>(
+      this, [&initial_guess_in_solution_out, &linear_operator, &source,
+             &args...](auto* const linear_solver) noexcept {
+        return linear_solver->solve(initial_guess_in_solution_out,
+                                    linear_operator, source,
+                                    std::forward<Args>(args)...);
+      });
+}
+
+/// Indicates the linear solver uses no preconditioner. It may perform
+/// compile-time optimization for this case.
+struct NoPreconditioner {};
+
+/*!
+ * \brief Base class for serial linear solvers that supports factory-creation
+ * and nested preconditioning.
+ *
+ * To enable support for preconditioning in your derived linear solver class,
+ * pass any type that has a `solve` and a `reset` function as the
+ * `Preconditioner` template parameter. It can also be an abstract
+ * `LinearSolver` type, which means that any other linear solver can be used as
+ * preconditioner. Pass `NoPreconditioner` to disable support for
+ * preconditioning.
+ */
+template <typename Preconditioner, typename LinearSolverRegistrars>
+class PreconditionedLinearSolver : public LinearSolver<LinearSolverRegistrars> {
+ private:
+  using Base = LinearSolver<LinearSolverRegistrars>;
+
+ public:
+  using PreconditionerType =
+      tmpl::conditional_t<std::is_abstract_v<Preconditioner>,
+                          std::unique_ptr<Preconditioner>, Preconditioner>;
+  struct PreconditionerOption {
+    static std::string name() noexcept { return "Preconditioner"; }
+    // Support factory-creatable preconditioners by storing them as unique-ptrs
+    using type = Options::Auto<PreconditionerType, Options::AutoLabel::None>;
+    static constexpr Options::String help =
+        "An approximate linear solve in every iteration that helps the "
+        "algorithm converge.";
+  };
+
+ protected:
+  PreconditionedLinearSolver() = default;
+  PreconditionedLinearSolver(PreconditionedLinearSolver&&) = default;
+  PreconditionedLinearSolver& operator=(PreconditionedLinearSolver&&) = default;
+
+  explicit PreconditionedLinearSolver(
+      std::optional<PreconditionerType> local_preconditioner) noexcept;
+
+  PreconditionedLinearSolver(const PreconditionedLinearSolver& rhs) noexcept;
+  PreconditionedLinearSolver& operator=(
+      const PreconditionedLinearSolver& rhs) noexcept;
+
+ public:
+  ~PreconditionedLinearSolver() override = default;
+
+  /// \cond
+  explicit PreconditionedLinearSolver(CkMigrateMessage* m) noexcept;
+  /// \endcond
+
+  void pup(PUP::er& p) noexcept override {  // NOLINT
+    PUP::able::pup(p);
+    if constexpr (not std::is_same_v<Preconditioner, NoPreconditioner>) {
+      p | preconditioner_;
+    }
+  }
+
+  /// Whether or not a preconditioner is set
+  bool has_preconditioner() const noexcept {
+    if constexpr (not std::is_same_v<Preconditioner, NoPreconditioner>) {
+      return preconditioner_.has_value();
+    } else {
+      return false;
+    }
+  }
+
+  // @{
+  /// Access to the preconditioner. Check `has_preconditioner()` before calling
+  /// this function. Calling this function when `has_preconditioner()` returns
+  /// `false` is an error.
+  template <
+      bool Enabled = not std::is_same_v<Preconditioner, NoPreconditioner>,
+      Requires<Enabled and
+               not std::is_same_v<Preconditioner, NoPreconditioner>> = nullptr>
+  const Preconditioner& preconditioner() const noexcept {
+    ASSERT(has_preconditioner(),
+           "No preconditioner is set. Please use `has_preconditioner()` to "
+           "check before trying to retrieve it.");
+    if constexpr (std::is_abstract_v<Preconditioner>) {
+      return **preconditioner_;
+    } else {
+      return *preconditioner_;
+    }
+  }
+
+  template <
+      bool Enabled = not std::is_same_v<Preconditioner, NoPreconditioner>,
+      Requires<Enabled and
+               not std::is_same_v<Preconditioner, NoPreconditioner>> = nullptr>
+  Preconditioner& preconditioner() noexcept {
+    ASSERT(has_preconditioner(),
+           "No preconditioner is set. Please use `has_preconditioner()` to "
+           "check before trying to retrieve it.");
+    if constexpr (std::is_abstract_v<Preconditioner>) {
+      return **preconditioner_;
+    } else {
+      return *preconditioner_;
+    }
+  }
+
+  // Keep the function virtual so derived classes must provide an
+  // implementation, but also provide an implementation below that derived
+  // classes can use to reset the preconditioner
+  void reset() noexcept override = 0;
+
+ protected:
+  /// Copy the preconditioner. Useful to implement `get_clone` when the
+  /// preconditioner has an abstract type.
+  template <
+      bool Enabled = not std::is_same_v<Preconditioner, NoPreconditioner>,
+      Requires<Enabled and
+               not std::is_same_v<Preconditioner, NoPreconditioner>> = nullptr>
+  std::optional<PreconditionerType> clone_preconditioner() const noexcept {
+    if constexpr (std::is_abstract_v<Preconditioner>) {
+      return has_preconditioner()
+                 ? std::optional((*preconditioner_)->get_clone())
+                 : std::nullopt;
+    } else {
+      return preconditioner_;
+    }
+  }
+
+ private:
+  // Only needed when preconditioning is enabled, but current C++ can't remove
+  // this variable at compile-time. Keeping the variable shouldn't have any
+  // noticeable overhead though.
+  std::optional<PreconditionerType> preconditioner_{};
+};
+
+template <typename Preconditioner, typename LinearSolverRegistrars>
+PreconditionedLinearSolver<Preconditioner, LinearSolverRegistrars>::
+    PreconditionedLinearSolver(
+        std::optional<PreconditionerType> local_preconditioner) noexcept
+    : preconditioner_(std::move(local_preconditioner)) {}
+
+// Override copy constructors so they can clone abstract preconditioners
+template <typename Preconditioner, typename LinearSolverRegistrars>
+PreconditionedLinearSolver<Preconditioner, LinearSolverRegistrars>::
+    PreconditionedLinearSolver(const PreconditionedLinearSolver& rhs) noexcept
+    : Base(rhs) {
+  if constexpr (not std::is_same_v<Preconditioner, NoPreconditioner>) {
+    preconditioner_ = rhs.clone_preconditioner();
+  }
+}
+template <typename Preconditioner, typename LinearSolverRegistrars>
+PreconditionedLinearSolver<Preconditioner, LinearSolverRegistrars>&
+PreconditionedLinearSolver<Preconditioner, LinearSolverRegistrars>::operator=(
+    const PreconditionedLinearSolver& rhs) noexcept {
+  Base::operator=(rhs);
+  if constexpr (not std::is_same_v<Preconditioner, NoPreconditioner>) {
+    preconditioner_ = rhs.clone_preconditioner();
+  }
+  return *this;
+}
+
+/// \cond
+template <typename Preconditioner, typename LinearSolverRegistrars>
+PreconditionedLinearSolver<Preconditioner, LinearSolverRegistrars>::
+    PreconditionedLinearSolver(CkMigrateMessage* m) noexcept
+    : Base(m) {}
+/// \endcond
+
+template <typename Preconditioner, typename LinearSolverRegistrars>
+void PreconditionedLinearSolver<Preconditioner,
+                                LinearSolverRegistrars>::reset() noexcept {
+  if constexpr (not std::is_same_v<Preconditioner, NoPreconditioner>) {
+    if (has_preconditioner()) {
+      preconditioner().reset();
+    }
+  }
+}
+
+}  // namespace LinearSolver::Serial

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementCenteredSubdomainData.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementCenteredSubdomainData.hpp
@@ -45,6 +45,25 @@ struct ElementCenteredSubdomainData {
       const size_t element_num_points) noexcept
       : element_data{element_num_points} {}
 
+  template <typename UsedForSizeTagsList>
+  void destructive_resize(
+      const ElementCenteredSubdomainData<Dim, UsedForSizeTagsList>&
+          used_for_size) noexcept {
+    if (UNLIKELY(element_data.number_of_grid_points() !=
+                 used_for_size.element_data.number_of_grid_points())) {
+      element_data.initialize(
+          used_for_size.element_data.number_of_grid_points());
+    }
+    for (const auto& [overlap_id, used_for_overlap_size] :
+         used_for_size.overlap_data) {
+      if (UNLIKELY(overlap_data[overlap_id].number_of_grid_points() !=
+                   used_for_overlap_size.number_of_grid_points())) {
+        overlap_data[overlap_id].initialize(
+            used_for_overlap_size.number_of_grid_points());
+      }
+    }
+  }
+
   ElementCenteredSubdomainData(
       Variables<TagsList> local_element_data,
       OverlapMap<Dim, Variables<TagsList>> local_overlap_data) noexcept

--- a/tests/Unit/Helpers/NumericalAlgorithms/LinearSolver/TestHelpers.hpp
+++ b/tests/Unit/Helpers/NumericalAlgorithms/LinearSolver/TestHelpers.hpp
@@ -1,0 +1,111 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <optional>
+#include <pup.h>
+
+#include "DataStructures/DenseMatrix.hpp"
+#include "DataStructures/DenseVector.hpp"
+#include "Parallel/PupStlCpp17.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace TestHelpers::LinearSolver {
+
+struct ApplyMatrix {
+  DenseMatrix<double> matrix;
+  void operator()(const gsl::not_null<DenseVector<double>*> result,
+                  const DenseVector<double>& operand) const noexcept {
+    *result = matrix * operand;
+  }
+};
+
+// Use the exact inverse of the matrix as preconditioner. This should solve
+// problems in 1 iteration.
+struct ExactInversePreconditioner {
+  void solve(const gsl::not_null<DenseVector<double>*> solution,
+             const ApplyMatrix& linear_operator,
+             const DenseVector<double>& source) const noexcept {
+    if (not inv_matrix_.has_value()) {
+      inv_matrix_ = blaze::inv(linear_operator.matrix);
+    }
+    *solution = *inv_matrix_ * source;
+  }
+
+  void reset() noexcept { inv_matrix_.reset(); }
+
+  void pup(PUP::er& p) noexcept { p | inv_matrix_; }  // NOLINT
+
+  // Make option-creatable for factory tests
+  using options = tmpl::list<>;
+  static constexpr Options::String help{"halp"};
+
+ private:
+  mutable std::optional<DenseMatrix<double>> inv_matrix_{};
+};
+
+// Use the inverse of the diagonal as preconditioner.
+struct JacobiPreconditioner {
+  void solve(const gsl::not_null<DenseVector<double>*> solution,
+             const ApplyMatrix& linear_operator,
+             const DenseVector<double>& source) const noexcept {
+    if (not inv_diagonal_.has_value()) {
+      inv_diagonal_ = DenseVector<double>(source.size(), 1.);
+      for (size_t i = 0; i < source.size(); ++i) {
+        (*inv_diagonal_)[i] /= linear_operator.matrix(i, i);
+      }
+    }
+    *solution = source;
+    for (size_t i = 0; i < solution->size(); ++i) {
+      (*solution)[i] *= (*inv_diagonal_)[i];
+    }
+  }
+
+  void reset() noexcept { inv_diagonal_.reset(); }
+
+  void pup(PUP::er& p) noexcept { p | inv_diagonal_; }  // NOLINT
+
+ private:
+  mutable std::optional<DenseVector<double>> inv_diagonal_{};
+};
+
+// Run a few Richardson iterations as preconditioner.
+struct RichardsonPreconditioner {
+  RichardsonPreconditioner() = default;
+  RichardsonPreconditioner(const double relaxation_parameter,
+                           const size_t num_iterations)
+      : relaxation_parameter_(relaxation_parameter),
+        num_iterations_(num_iterations) {}
+
+  void solve(
+      const gsl::not_null<DenseVector<double>*> initial_guess_in_solution_out,
+      const ApplyMatrix& linear_operator,
+      const DenseVector<double>& source) const noexcept {
+    for (size_t i = 0; i < num_iterations_; ++i) {
+      linear_operator(make_not_null(&correction_buffer_),
+                      *initial_guess_in_solution_out);
+      correction_buffer_ *= -1.;
+      correction_buffer_ += source;
+      *initial_guess_in_solution_out +=
+          relaxation_parameter_ * correction_buffer_;
+    }
+  }
+
+  static void reset() noexcept {}
+
+  void pup(PUP::er& p) noexcept {  // NOLINT
+    p | relaxation_parameter_;
+    p | num_iterations_;
+  }
+
+ private:
+  double relaxation_parameter_{};
+  size_t num_iterations_{};
+  mutable DenseVector<double> correction_buffer_{};
+};
+
+}  // namespace TestHelpers::LinearSolver

--- a/tests/Unit/Helpers/NumericalAlgorithms/LinearSolver/TestHelpers.hpp
+++ b/tests/Unit/Helpers/NumericalAlgorithms/LinearSolver/TestHelpers.hpp
@@ -11,6 +11,7 @@
 
 #include "DataStructures/DenseMatrix.hpp"
 #include "DataStructures/DenseVector.hpp"
+#include "Options/Options.hpp"
 #include "Parallel/PupStlCpp17.hpp"
 #include "Utilities/Gsl.hpp"
 

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Test_Gmres.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Test_Gmres.cpp
@@ -10,11 +10,14 @@
 #include "DataStructures/DenseVector.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/NumericalAlgorithms/LinearSolver/TestHelpers.hpp"
 #include "Informer/Verbosity.hpp"
 #include "NumericalAlgorithms/Convergence/Criteria.hpp"
 #include "NumericalAlgorithms/Convergence/Reason.hpp"
 #include "NumericalAlgorithms/LinearSolver/Gmres.hpp"
 #include "Utilities/Gsl.hpp"
+
+namespace helpers = TestHelpers::LinearSolver;
 
 namespace LinearSolver::Serial {
 
@@ -39,33 +42,28 @@ SPECTRE_TEST_CASE("Unit.LinearSolver.Serial.Gmres",
     matrix(0, 1) = 1.;
     matrix(1, 0) = 1.;
     matrix(1, 1) = 3.;
+    const helpers::ApplyMatrix linear_operator{std::move(matrix)};
     const DenseVector<double> source{1., 2.};
-    const DenseVector<double> initial_guess{2., 1.};
+    DenseVector<double> initial_guess_in_solution_out{2., 1.};
     const DenseVector<double> expected_solution{0.0909090909090909,
                                                 0.6363636363636364};
     const Convergence::Criteria convergence_criteria{2, 1.e-14, 0.};
     const Gmres<DenseVector<double>> gmres{convergence_criteria,
                                            ::Verbosity::Verbose};
-    const auto linear_operator =
-        [&matrix](const DenseVector<double>& arg) noexcept {
-          return matrix * arg;
-        };
     std::vector<double> recorded_residuals;
-    const auto result = gmres(
-        linear_operator, source, initial_guess,
-        IdentityPreconditioner<DenseVector<double>>{},
+    const auto has_converged = gmres.solve(
+        make_not_null(&initial_guess_in_solution_out), linear_operator, source,
+        NoPreconditioner{},
         [&recorded_residuals](const Convergence::HasConverged& has_converged) {
           recorded_residuals.push_back(has_converged.residual_magnitude());
         });
-    const auto& has_converged = result.first;
-    const auto& solution = result.second;
     REQUIRE(has_converged);
     CHECK(has_converged.reason() == Convergence::Reason::AbsoluteResidual);
     CHECK(has_converged.num_iterations() == 2);
     CHECK(has_converged.residual_magnitude() <= 1.e-14);
     CHECK(has_converged.initial_residual_magnitude() ==
           approx(8.54400374531753));
-    CHECK_ITERABLE_APPROX(solution, expected_solution);
+    CHECK_ITERABLE_APPROX(initial_guess_in_solution_out, expected_solution);
     // The residuals should decrease monotonically
     CHECK(recorded_residuals[0] == has_converged.initial_residual_magnitude());
     for (size_t i = 1; i < has_converged.num_iterations(); ++i) {
@@ -74,29 +72,29 @@ SPECTRE_TEST_CASE("Unit.LinearSolver.Serial.Gmres",
     /// [gmres_example]
     {
       INFO("Check that a solved system terminates early");
-      const auto second_result = gmres(linear_operator, source, solution);
-      const auto& second_has_converged = second_result.first;
-      const auto& second_solution = second_result.second;
+      const auto second_has_converged =
+          gmres.solve(make_not_null(&initial_guess_in_solution_out),
+                      linear_operator, source);
       REQUIRE(second_has_converged);
       CHECK(second_has_converged.reason() ==
             Convergence::Reason::AbsoluteResidual);
       CHECK(second_has_converged.num_iterations() == 0);
-      CHECK_ITERABLE_APPROX(solution, second_solution);
+      CHECK_ITERABLE_APPROX(initial_guess_in_solution_out, expected_solution);
     }
     {
       INFO("Check two successive solves with different sources");
-      const auto second_result =
-          gmres(linear_operator, DenseVector<double>{2, 1},
-                DenseVector<double>{0., 0.});
-      const auto& second_has_converged = second_result.first;
-      const auto& second_solution = second_result.second;
+      DenseVector<double> second_initial_guess_in_solution_out{0., 0.};
+      const auto second_has_converged =
+          gmres.solve(make_not_null(&second_initial_guess_in_solution_out),
+                      linear_operator, DenseVector<double>{2, 1});
       REQUIRE(second_has_converged);
       CHECK(second_has_converged.reason() ==
             Convergence::Reason::AbsoluteResidual);
       CHECK(second_has_converged.num_iterations() == 2);
       const DenseVector<double> expected_second_solution{0.454545454545455,
                                                          0.181818181818182};
-      CHECK_ITERABLE_APPROX(second_solution, expected_second_solution);
+      CHECK_ITERABLE_APPROX(second_initial_guess_in_solution_out,
+                            expected_second_solution);
     }
   }
   {
@@ -106,50 +104,49 @@ SPECTRE_TEST_CASE("Unit.LinearSolver.Serial.Gmres",
     matrix(0, 1) = 1.;
     matrix(1, 0) = 3.;
     matrix(1, 1) = 1.;
+    const helpers::ApplyMatrix linear_operator{std::move(matrix)};
     const DenseVector<double> source{1., 2.};
-    const DenseVector<double> initial_guess{2., 1.};
+    DenseVector<double> initial_guess_in_solution_out{2., 1.};
     const DenseVector<double> expected_solution{-1., 5.};
     const Convergence::Criteria convergence_criteria{2, 1.e-14, 0.};
     const Gmres<DenseVector<double>> gmres{convergence_criteria,
                                            ::Verbosity::Verbose};
-    const auto result = gmres(
-        [&matrix](const DenseVector<double>& arg) noexcept {
-          return matrix * arg;
-        },
-        source, initial_guess);
-    const auto& has_converged = result.first;
-    const auto& solution = result.second;
+    const auto has_converged = gmres.solve(
+        make_not_null(&initial_guess_in_solution_out), linear_operator, source);
     REQUIRE(has_converged);
     CHECK(has_converged.reason() == Convergence::Reason::AbsoluteResidual);
     CHECK(has_converged.num_iterations() == 2);
-    CHECK_ITERABLE_APPROX(solution, expected_solution);
+    CHECK_ITERABLE_APPROX(initial_guess_in_solution_out, expected_solution);
   }
   {
     INFO("Solve a matrix-free linear operator with Variables");
     using Vars = Variables<tmpl::list<ScalarField>>;
     constexpr size_t num_points = 2;
-    const auto linear_operator = [](const Vars& arg) noexcept {
-      const auto& data = get(get<ScalarField>(arg));
-      Vars result{num_points};
-      get(get<ScalarField>(result)) =
+    // This also tests that the linear operator can be a lambda
+    const auto linear_operator = [](const gsl::not_null<Vars*> result,
+                                    const Vars& operand) noexcept {
+      if (result->number_of_grid_points() != num_points) {
+        result->initialize(num_points);
+      }
+      const auto& data = get(get<ScalarField>(operand));
+      get(get<ScalarField>(*result)) =
           DataVector{data[0] * 4. + data[1], data[0] * 3. + data[1]};
-      return result;
     };
     // Adding a prefix to make sure prefixed sources work as well
     Variables<tmpl::list<SomePrefix<ScalarField>>> source{num_points};
     get(get<SomePrefix<ScalarField>>(source)) = DataVector{1., 2.};
-    Vars initial_guess{num_points};
-    get(get<ScalarField>(initial_guess)) = DataVector{2., 1.};
+    Vars initial_guess_in_solution_out{num_points};
+    get(get<ScalarField>(initial_guess_in_solution_out)) = DataVector{2., 1.};
     const DataVector expected_solution{-1., 5.};
     const Convergence::Criteria convergence_criteria{2, 1.e-14, 0.};
     const Gmres<Vars> gmres{convergence_criteria, ::Verbosity::Verbose};
-    const auto result = gmres(linear_operator, source, initial_guess);
-    const auto& has_converged = result.first;
-    const auto& solution = result.second;
+    const auto has_converged = gmres.solve(
+        make_not_null(&initial_guess_in_solution_out), linear_operator, source);
     REQUIRE(has_converged);
     CHECK(has_converged.reason() == Convergence::Reason::AbsoluteResidual);
     CHECK(has_converged.num_iterations() == 2);
-    CHECK_ITERABLE_APPROX(get(get<ScalarField>(solution)), expected_solution);
+    CHECK_ITERABLE_APPROX(get(get<ScalarField>(initial_guess_in_solution_out)),
+                          expected_solution);
   }
   {
     INFO("Restarting");
@@ -163,8 +160,9 @@ SPECTRE_TEST_CASE("Unit.LinearSolver.Serial.Gmres",
     matrix(2, 0) = 0.;
     matrix(2, 1) = 2.;
     matrix(2, 2) = 0.;
+    const helpers::ApplyMatrix linear_operator{std::move(matrix)};
     const DenseVector<double> source{1., 2., 1.};
-    const DenseVector<double> initial_guess{2., 1., 0.};
+    DenseVector<double> initial_guess_in_solution_out{2., 1., 0.};
     const DenseVector<double> expected_solution{0., 0.5, 0.5};
     const Convergence::Criteria convergence_criteria{100, 1.e-14, 0.};
     // Restart every other iteration. The algorithm would converge in 3
@@ -173,17 +171,12 @@ SPECTRE_TEST_CASE("Unit.LinearSolver.Serial.Gmres",
     const size_t restart = 2;
     const Gmres<DenseVector<double>> gmres{convergence_criteria,
                                            ::Verbosity::Verbose, restart};
-    const auto result = gmres(
-        [&matrix](const DenseVector<double>& arg) noexcept {
-          return matrix * arg;
-        },
-        source, initial_guess);
-    const auto& has_converged = result.first;
-    const auto& solution = result.second;
+    const auto has_converged = gmres.solve(
+        make_not_null(&initial_guess_in_solution_out), linear_operator, source);
     REQUIRE(has_converged);
     CHECK(has_converged.reason() == Convergence::Reason::AbsoluteResidual);
     CHECK(has_converged.num_iterations() == 59);
-    CHECK_ITERABLE_APPROX(solution, expected_solution);
+    CHECK_ITERABLE_APPROX(initial_guess_in_solution_out, expected_solution);
   }
   {
     INFO("Preconditioning");
@@ -192,82 +185,59 @@ SPECTRE_TEST_CASE("Unit.LinearSolver.Serial.Gmres",
     matrix(0, 1) = 1.;
     matrix(1, 0) = 1.;
     matrix(1, 1) = 3.;
-    const auto linear_operator =
-        [&matrix](const DenseVector<double>& arg) noexcept {
-          return matrix * arg;
-        };
+    const helpers::ApplyMatrix linear_operator{std::move(matrix)};
     const DenseVector<double> source{1., 2.};
-    const DenseVector<double> initial_guess{2., 1.};
+    DenseVector<double> initial_guess_in_solution_out{2., 1.};
     const DenseVector<double> expected_solution{0.0909090909090909,
                                                 0.6363636363636364};
     const Convergence::Criteria convergence_criteria{2, 1.e-14, 0.};
     const Gmres<DenseVector<double>> gmres{convergence_criteria,
                                            ::Verbosity::Verbose};
-    {
-      INFO("Exact inverse preconditioner");
-      const DenseMatrix<double> matrix_inv = blaze::inv(matrix);
-      const auto result =
-          gmres(linear_operator, source, initial_guess,
-                // Use the exact inverse of the matrix as preconditioner. This
-                // should solve the problem in 1 iteration.
-                [&matrix_inv](const DenseVector<double>& arg) noexcept {
-                  return matrix_inv * arg;
-                });
-      const auto& has_converged = result.first;
-      const auto& solution = result.second;
+    SECTION("Exact inverse preconditioner") {
+      // Use the exact inverse of the matrix as preconditioner. This
+      // should solve the problem in 1 iteration.
+      const helpers::ExactInversePreconditioner preconditioner{};
+      const auto has_converged =
+          gmres.solve(make_not_null(&initial_guess_in_solution_out),
+                      linear_operator, source, preconditioner);
       REQUIRE(has_converged);
       CHECK(has_converged.reason() == Convergence::Reason::AbsoluteResidual);
       CHECK(has_converged.num_iterations() == 1);
-      CHECK_ITERABLE_APPROX(solution, expected_solution);
+      CHECK_ITERABLE_APPROX(initial_guess_in_solution_out, expected_solution);
     }
-    {
-      INFO("Diagonal (Jacobi) preconditioner");
+    SECTION("Diagonal (Jacobi) preconditioner") {
       // Use the inverse of the diagonal as preconditioner.
-      const auto preconditioner = [](DenseVector<double> arg) noexcept {
-        arg[0] *= 0.25;
-        arg[1] *= 1. / 3.;
-        return arg;
-      };
-      const auto result =
-          gmres(linear_operator, source, initial_guess, preconditioner);
-      const auto& has_converged = result.first;
-      const auto& solution = result.second;
+      const helpers::JacobiPreconditioner preconditioner{};
+      const auto has_converged =
+          gmres.solve(make_not_null(&initial_guess_in_solution_out),
+                      linear_operator, source, preconditioner);
       REQUIRE(has_converged);
       CHECK(has_converged.reason() == Convergence::Reason::AbsoluteResidual);
       CHECK(has_converged.num_iterations() == 2);
-      CHECK_ITERABLE_APPROX(solution, expected_solution);
+      CHECK_ITERABLE_APPROX(initial_guess_in_solution_out, expected_solution);
     }
-    {
-      INFO("Richardson preconditioner");
+    SECTION("Richardson preconditioner") {
+      const helpers::RichardsonPreconditioner preconditioner{
+          // The optimal relaxation parameter for SPD matrices is 2 / (l_max +
+          // l_min) where l_max and l_min are the largest and smallest
+          // eigenvalues of the linear operator (see
+          // `LinearSolver::Richardson::Richardson`).
+          0.2857142857142857,
+          // Run two Richardson iterations
+          2};
       std::vector<double> recorded_residuals;
-      // Run a few Richardson iterations as preconditioner.
-      // The relaxation parameter is 2 / (l_max + l_min) where l_max and l_min
-      // are the largest and smallest eigenvalues of the linear operator
-      // (see `LinearSolver::Richardson::Richardson`).
-      const double relaxation_parameter = 0.2857142857142857;
-      const auto preconditioner =
-          [&linear_operator, &relaxation_parameter](
-              const DenseVector<double>& local_source) noexcept {
-            DenseVector<double> result(local_source.size(), 0.);
-            for (size_t i = 0; i < 2; ++i) {
-              result += relaxation_parameter *
-                        (local_source - linear_operator(result));
-            }
-            return result;
-          };
-      const auto result = gmres(
-          linear_operator, source, initial_guess, preconditioner,
+      const auto has_converged = gmres.solve(
+          make_not_null(&initial_guess_in_solution_out), linear_operator,
+          source, preconditioner,
           [&recorded_residuals](
               const Convergence::HasConverged& has_converged) {
             recorded_residuals.push_back(has_converged.residual_magnitude());
           });
-      const auto& has_converged = result.first;
-      const auto& solution = result.second;
       CAPTURE(recorded_residuals);
       REQUIRE(has_converged);
       CHECK(has_converged.reason() == Convergence::Reason::AbsoluteResidual);
       CHECK(has_converged.num_iterations() == 1);
-      CHECK_ITERABLE_APPROX(solution, expected_solution);
+      CHECK_ITERABLE_APPROX(initial_guess_in_solution_out, expected_solution);
     }
   }
 }

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Test_Gmres.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Test_Gmres.cpp
@@ -8,6 +8,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/DenseMatrix.hpp"
 #include "DataStructures/DenseVector.hpp"
+#include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/NumericalAlgorithms/LinearSolver/TestHelpers.hpp"
@@ -15,6 +16,7 @@
 #include "NumericalAlgorithms/Convergence/Criteria.hpp"
 #include "NumericalAlgorithms/Convergence/Reason.hpp"
 #include "NumericalAlgorithms/LinearSolver/Gmres.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/Gsl.hpp"
 
 namespace helpers = TestHelpers::LinearSolver;
@@ -50,12 +52,14 @@ SPECTRE_TEST_CASE("Unit.LinearSolver.Serial.Gmres",
     const Convergence::Criteria convergence_criteria{2, 1.e-14, 0.};
     const Gmres<DenseVector<double>> gmres{convergence_criteria,
                                            ::Verbosity::Verbose};
+    CHECK_FALSE(gmres.has_preconditioner());
     std::vector<double> recorded_residuals;
     const auto has_converged = gmres.solve(
         make_not_null(&initial_guess_in_solution_out), linear_operator, source,
-        NoPreconditioner{},
-        [&recorded_residuals](const Convergence::HasConverged& has_converged) {
-          recorded_residuals.push_back(has_converged.residual_magnitude());
+        [&recorded_residuals](
+            const Convergence::HasConverged& local_has_converged) {
+          recorded_residuals.push_back(
+              local_has_converged.residual_magnitude());
         });
     REQUIRE(has_converged);
     CHECK(has_converged.reason() == Convergence::Reason::AbsoluteResidual);
@@ -81,20 +85,35 @@ SPECTRE_TEST_CASE("Unit.LinearSolver.Serial.Gmres",
       CHECK(second_has_converged.num_iterations() == 0);
       CHECK_ITERABLE_APPROX(initial_guess_in_solution_out, expected_solution);
     }
+    const auto check_second_solve = [&linear_operator](
+                                        const auto& local_gmres) {
+      DenseVector<double> local_initial_guess_in_solution_out{0., 0.};
+      const auto local_has_converged = local_gmres.solve(
+          make_not_null(&local_initial_guess_in_solution_out), linear_operator,
+          DenseVector<double>{2, 1});
+      REQUIRE(local_has_converged);
+      CHECK(local_has_converged.reason() ==
+            Convergence::Reason::AbsoluteResidual);
+      CHECK(local_has_converged.num_iterations() == 2);
+      const DenseVector<double> expected_local_solution{0.454545454545455,
+                                                         0.181818181818182};
+      CHECK_ITERABLE_APPROX(local_initial_guess_in_solution_out,
+                            expected_local_solution);
+    };
     {
       INFO("Check two successive solves with different sources");
-      DenseVector<double> second_initial_guess_in_solution_out{0., 0.};
-      const auto second_has_converged =
-          gmres.solve(make_not_null(&second_initial_guess_in_solution_out),
-                      linear_operator, DenseVector<double>{2, 1});
-      REQUIRE(second_has_converged);
-      CHECK(second_has_converged.reason() ==
-            Convergence::Reason::AbsoluteResidual);
-      CHECK(second_has_converged.num_iterations() == 2);
-      const DenseVector<double> expected_second_solution{0.454545454545455,
-                                                         0.181818181818182};
-      CHECK_ITERABLE_APPROX(second_initial_guess_in_solution_out,
-                            expected_second_solution);
+      check_second_solve(gmres);
+    }
+    {
+      INFO("Check the solver still works after serialization");
+      const auto serialized_gmres = serialize_and_deserialize(gmres);
+      check_second_solve(serialized_gmres);
+    }
+    {
+      INFO("Check the solver still works after copying");
+      // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+      const auto copied_gmres = gmres;
+      check_second_solve(copied_gmres);
     }
   }
   {
@@ -187,37 +206,67 @@ SPECTRE_TEST_CASE("Unit.LinearSolver.Serial.Gmres",
     matrix(1, 1) = 3.;
     const helpers::ApplyMatrix linear_operator{std::move(matrix)};
     const DenseVector<double> source{1., 2.};
-    DenseVector<double> initial_guess_in_solution_out{2., 1.};
     const DenseVector<double> expected_solution{0.0909090909090909,
                                                 0.6363636363636364};
     const Convergence::Criteria convergence_criteria{2, 1.e-14, 0.};
-    const Gmres<DenseVector<double>> gmres{convergence_criteria,
-                                           ::Verbosity::Verbose};
-    SECTION("Exact inverse preconditioner") {
+    const auto check_solve = [&linear_operator, &source, &expected_solution](
+                                 const auto& local_gmres,
+                                 const size_t expected_num_iterations) {
+      REQUIRE(local_gmres.has_preconditioner());
+      DenseVector<double> local_initial_guess_in_solution_out{2., 1.};
+      std::vector<double> local_recorded_residuals;
+      const auto local_has_converged = local_gmres.solve(
+          make_not_null(&local_initial_guess_in_solution_out), linear_operator,
+          source,
+          [&local_recorded_residuals](
+              const Convergence::HasConverged& recorded_has_converged) {
+            local_recorded_residuals.push_back(
+                recorded_has_converged.residual_magnitude());
+          });
+      CAPTURE(local_recorded_residuals);
+      REQUIRE(local_has_converged);
+      CHECK(local_has_converged.reason() ==
+            Convergence::Reason::AbsoluteResidual);
+      CHECK(local_has_converged.num_iterations() == expected_num_iterations);
+      CHECK_ITERABLE_APPROX(local_initial_guess_in_solution_out,
+                            expected_solution);
+    };
+    {
+      INFO("Exact inverse preconditioner");
       // Use the exact inverse of the matrix as preconditioner. This
       // should solve the problem in 1 iteration.
-      const helpers::ExactInversePreconditioner preconditioner{};
-      const auto has_converged =
-          gmres.solve(make_not_null(&initial_guess_in_solution_out),
-                      linear_operator, source, preconditioner);
-      REQUIRE(has_converged);
-      CHECK(has_converged.reason() == Convergence::Reason::AbsoluteResidual);
-      CHECK(has_converged.num_iterations() == 1);
-      CHECK_ITERABLE_APPROX(initial_guess_in_solution_out, expected_solution);
+      helpers::ExactInversePreconditioner preconditioner{};
+      const Gmres<DenseVector<double>, helpers::ExactInversePreconditioner>
+          preconditioned_gmres{convergence_criteria, ::Verbosity::Verbose,
+                               std::nullopt, std::move(preconditioner)};
+      check_solve(preconditioned_gmres, 1);
+      // Check a second solve with the same solver and preconditioner works
+      check_solve(preconditioned_gmres, 1);
+      {
+        INFO("Check that serialization preserves the preconditioner");
+        const auto serialized_gmres =
+            serialize_and_deserialize(preconditioned_gmres);
+        check_solve(serialized_gmres, 1);
+      }
+      {
+        INFO("Check that copying preserves the preconditioner");
+        // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+        const auto copied_gmres = preconditioned_gmres;
+        check_solve(copied_gmres, 1);
+      }
     }
-    SECTION("Diagonal (Jacobi) preconditioner") {
+    {
+      INFO("Diagonal (Jacobi) preconditioner");
       // Use the inverse of the diagonal as preconditioner.
-      const helpers::JacobiPreconditioner preconditioner{};
-      const auto has_converged =
-          gmres.solve(make_not_null(&initial_guess_in_solution_out),
-                      linear_operator, source, preconditioner);
-      REQUIRE(has_converged);
-      CHECK(has_converged.reason() == Convergence::Reason::AbsoluteResidual);
-      CHECK(has_converged.num_iterations() == 2);
-      CHECK_ITERABLE_APPROX(initial_guess_in_solution_out, expected_solution);
+      helpers::JacobiPreconditioner preconditioner{};
+      const Gmres<DenseVector<double>, helpers::JacobiPreconditioner>
+          preconditioned_gmres{convergence_criteria, ::Verbosity::Verbose,
+                               std::nullopt, std::move(preconditioner)};
+      check_solve(preconditioned_gmres, 2);
     }
-    SECTION("Richardson preconditioner") {
-      const helpers::RichardsonPreconditioner preconditioner{
+    {
+      INFO("Richardson preconditioner");
+      helpers::RichardsonPreconditioner preconditioner{
           // The optimal relaxation parameter for SPD matrices is 2 / (l_max +
           // l_min) where l_max and l_min are the largest and smallest
           // eigenvalues of the linear operator (see
@@ -225,19 +274,163 @@ SPECTRE_TEST_CASE("Unit.LinearSolver.Serial.Gmres",
           0.2857142857142857,
           // Run two Richardson iterations
           2};
-      std::vector<double> recorded_residuals;
-      const auto has_converged = gmres.solve(
-          make_not_null(&initial_guess_in_solution_out), linear_operator,
-          source, preconditioner,
-          [&recorded_residuals](
-              const Convergence::HasConverged& has_converged) {
-            recorded_residuals.push_back(has_converged.residual_magnitude());
-          });
-      CAPTURE(recorded_residuals);
-      REQUIRE(has_converged);
-      CHECK(has_converged.reason() == Convergence::Reason::AbsoluteResidual);
-      CHECK(has_converged.num_iterations() == 1);
-      CHECK_ITERABLE_APPROX(initial_guess_in_solution_out, expected_solution);
+      const Gmres<DenseVector<double>, helpers::RichardsonPreconditioner>
+          preconditioned_gmres{convergence_criteria, ::Verbosity::Verbose,
+                               std::nullopt, std::move(preconditioner)};
+      check_solve(preconditioned_gmres, 1);
+    }
+    {
+      INFO("Nested linear solver as preconditioner");
+      // Running another GMRES solver for 2 iterations as preconditioner. It
+      // should already solve the problem, so the preconditioned solve only
+      // needs a single iteration.
+      const Gmres<DenseVector<double>, Gmres<DenseVector<double>>>
+          preconditioned_gmres{convergence_criteria,
+                               ::Verbosity::Verbose,
+                               std::nullopt,
+                               {{{2, 0., 0.}, ::Verbosity::Verbose}}};
+      check_solve(preconditioned_gmres, 1);
+    }
+    {
+      INFO("Nested factory-created linear solver as preconditioner");
+      // Also running another GMRES solver as preconditioner, but passing it as
+      // a factory-created abstract `LinearSolver` type.
+      using LinearSolverRegistrars =
+          tmpl::list<Registrars::Gmres<DenseVector<double>>>;
+      using LinearSolverFactory = LinearSolver<LinearSolverRegistrars>;
+      const Gmres<DenseVector<double>, LinearSolverFactory,
+                  LinearSolverRegistrars>
+          preconditioned_gmres{
+              convergence_criteria, ::Verbosity::Verbose, std::nullopt,
+              std::make_unique<Gmres<DenseVector<double>, LinearSolverFactory,
+                                     LinearSolverRegistrars>>(
+                  Convergence::Criteria{2, 0., 0.}, ::Verbosity::Verbose)};
+      check_solve(preconditioned_gmres, 1);
+      {
+        INFO("Check that serialization preserves the preconditioner");
+        Parallel::register_derived_classes_with_charm<LinearSolverFactory>();
+        const auto serialized_gmres =
+            serialize_and_deserialize(preconditioned_gmres);
+        check_solve(serialized_gmres, 1);
+      }
+      {
+        INFO("Check that copying preserves the preconditioner");
+        Parallel::register_derived_classes_with_charm<LinearSolverFactory>();
+        // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+        const auto copied_gmres = preconditioned_gmres;
+        check_solve(copied_gmres, 1);
+      }
+    }
+  }
+  {
+    INFO("Option-creation");
+    {
+      const auto solver =
+          TestHelpers::test_creation<Gmres<DenseVector<double>>>(
+              "ConvergenceCriteria:\n"
+              "  MaxIterations: 2\n"
+              "  AbsoluteResidual: 0.1\n"
+              "  RelativeResidual: 0.5\n"
+              "Restart: 50\n"
+              "Verbosity: Verbose\n");
+      CHECK(solver.convergence_criteria() ==
+            Convergence::Criteria{2, 0.1, 0.5});
+      CHECK(solver.restart() == 50);
+      CHECK(solver.verbosity() == ::Verbosity::Verbose);
+      CHECK_FALSE(solver.has_preconditioner());
+    }
+    {
+      const auto solver = TestHelpers::test_creation<
+          Gmres<DenseVector<double>, helpers::ExactInversePreconditioner>>(
+          "ConvergenceCriteria:\n"
+          "  MaxIterations: 2\n"
+          "  AbsoluteResidual: 0.1\n"
+          "  RelativeResidual: 0.5\n"
+          "Restart: None\n"
+          "Verbosity: Verbose\n"
+          "Preconditioner: None\n");
+      CHECK(solver.convergence_criteria() ==
+            Convergence::Criteria{2, 0.1, 0.5});
+      CHECK(solver.restart() == 2);
+      CHECK(solver.verbosity() == ::Verbosity::Verbose);
+      CHECK_FALSE(solver.has_preconditioner());
+    }
+    {
+      const auto solver = TestHelpers::test_creation<
+          Gmres<DenseVector<double>, helpers::ExactInversePreconditioner>>(
+          "ConvergenceCriteria:\n"
+          "  MaxIterations: 2\n"
+          "  AbsoluteResidual: 0.1\n"
+          "  RelativeResidual: 0.5\n"
+          "Restart: None\n"
+          "Verbosity: Verbose\n"
+          "Preconditioner:\n");
+      CHECK(solver.convergence_criteria() ==
+            Convergence::Criteria{2, 0.1, 0.5});
+      CHECK(solver.restart() == 2);
+      CHECK(solver.verbosity() == ::Verbosity::Verbose);
+      CHECK(solver.has_preconditioner());
+    }
+    {
+      using LinearSolverRegistrars =
+          tmpl::list<Registrars::Gmres<DenseVector<double>>>;
+      using LinearSolverFactory = LinearSolver<LinearSolverRegistrars>;
+      const auto solver =
+          TestHelpers::test_factory_creation<LinearSolverFactory>(
+              "Gmres:\n"
+              "  ConvergenceCriteria:\n"
+              "    MaxIterations: 2\n"
+              "    AbsoluteResidual: 0.1\n"
+              "    RelativeResidual: 0.5\n"
+              "  Restart: 50\n"
+              "  Verbosity: Verbose\n"
+              "  Preconditioner:\n"
+              "    Gmres:\n"
+              "      ConvergenceCriteria:\n"
+              "        MaxIterations: 1\n"
+              "        AbsoluteResidual: 0.5\n"
+              "        RelativeResidual: 0.9\n"
+              "      Restart: None\n"
+              "      Verbosity: Verbose\n"
+              "      Preconditioner: None\n");
+      REQUIRE(solver);
+      using Derived = Gmres<DenseVector<double>, LinearSolverFactory,
+                            LinearSolverRegistrars>;
+      REQUIRE_FALSE(nullptr == dynamic_cast<const Derived*>(solver.get()));
+      const auto& derived = dynamic_cast<const Derived&>(*solver);
+      CHECK(derived.convergence_criteria() ==
+            Convergence::Criteria{2, 0.1, 0.5});
+      CHECK(derived.restart() == 50);
+      CHECK(derived.verbosity() == ::Verbosity::Verbose);
+      REQUIRE(derived.has_preconditioner());
+      REQUIRE_FALSE(nullptr ==
+                    dynamic_cast<const Derived*>(&derived.preconditioner()));
+      const auto& preconditioner =
+          dynamic_cast<const Derived&>(derived.preconditioner());
+      CHECK(preconditioner.convergence_criteria() ==
+            Convergence::Criteria{1, 0.5, 0.9});
+      CHECK(preconditioner.restart() == 1);
+      CHECK(preconditioner.verbosity() == ::Verbosity::Verbose);
+      CHECK_FALSE(preconditioner.has_preconditioner());
+      {
+        INFO("Copy semantics");
+        // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+        const auto copied_solver = derived;
+        CHECK(copied_solver.convergence_criteria() ==
+              Convergence::Criteria{2, 0.1, 0.5});
+        CHECK(copied_solver.restart() == 50);
+        CHECK(copied_solver.verbosity() == ::Verbosity::Verbose);
+        REQUIRE(copied_solver.has_preconditioner());
+        REQUIRE_FALSE(nullptr == dynamic_cast<const Derived*>(
+                                     &copied_solver.preconditioner()));
+        const auto& copied_preconditioner =
+            dynamic_cast<const Derived&>(copied_solver.preconditioner());
+        CHECK(copied_preconditioner.convergence_criteria() ==
+              Convergence::Criteria{1, 0.5, 0.9});
+        CHECK(copied_preconditioner.restart() == 1);
+        CHECK(copied_preconditioner.verbosity() == ::Verbosity::Verbose);
+        CHECK_FALSE(copied_preconditioner.has_preconditioner());
+      }
     }
   }
 }

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.cpp
@@ -147,6 +147,9 @@ struct SubdomainElementOperator {
     const size_t num_elements = matrix_slices.size();
     const size_t num_points_per_element = matrix_slices.begin()->columns();
 
+    // Re-size the result buffer if necessary
+    result->destructive_resize(subdomain_data);
+
     // Assemble full operator matrix
     const auto operator_matrix = combine_matrix_slices(matrix_slices);
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.yaml
@@ -53,7 +53,7 @@ SchwarzSmoother:
       RelativeResidual: 1.e-14
       AbsoluteResidual: 1.e-14
     Verbosity: Verbose
-    Restart: 0
+    Restart: None
 
 ConvergenceReason: NumIterations
 


### PR DESCRIPTION
## Proposed changes

- Avoid memory allocations in the serial linear solvers by returning-by-reference.
- Derive the serial linear solvers from an abstract base class so they can be factory-created. This allows choosing the linear solver and its stack of preconditioners in the input file, which is important because effective preconditioning can require a lot of experimentation.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
