### PR TITLE
Add error measures to steppers

### DIFF
--- a/src/Time/TimeSteppers/RungeKutta3.cpp
+++ b/src/Time/TimeSteppers/RungeKutta3.cpp
@@ -10,13 +10,13 @@
 
 namespace TimeSteppers {
 
-uint64_t RungeKutta3::number_of_substeps() const noexcept {
+uint64_t RungeKutta3::number_of_substeps() const noexcept { return 3; }
+
+uint64_t RungeKutta3::number_of_substeps_for_error() const noexcept {
   return 3;
 }
 
-size_t RungeKutta3::number_of_past_steps() const noexcept {
-  return 0;
-}
+size_t RungeKutta3::number_of_past_steps() const noexcept { return 0; }
 
 double RungeKutta3::stable_step() const noexcept {
   // This is the condition for  y' = -k y  to go to zero.
@@ -49,6 +49,11 @@ TimeStepId RungeKutta3::next_time_id(
   }
 }
 
+TimeStepId RungeKutta3::next_time_id_for_error(
+    const TimeStepId& current_id,
+    const TimeDelta& time_step) const noexcept {
+  return next_time_id(current_id, time_step);
+}
 }  // namespace TimeSteppers
 
 /// \cond

--- a/src/Time/TimeSteppers/RungeKutta4.cpp
+++ b/src/Time/TimeSteppers/RungeKutta4.cpp
@@ -13,6 +13,10 @@ namespace TimeSteppers {
 
 uint64_t RungeKutta4::number_of_substeps() const noexcept { return 4; }
 
+uint64_t RungeKutta4::number_of_substeps_for_error() const noexcept {
+  return 5;
+}
+
 size_t RungeKutta4::number_of_past_steps() const noexcept { return 0; }
 
 // The growth function for RK4 is (e.g. page 60 of
@@ -69,6 +73,35 @@ TimeStepId RungeKutta4::next_time_id(const TimeStepId& current_id,
   }
 }
 
+TimeStepId RungeKutta4::next_time_id_for_error(
+    const TimeStepId& current_id, const TimeDelta& time_step) const noexcept {
+  if (current_id.substep() < 3) {
+    return next_time_id(current_id, time_step);
+  }
+  // The embedded Zonneveld 4(3) scheme adds an extra substep at 3/4 that is
+  // used only by the third-order error estimation scheme
+  switch (current_id.substep()) {
+    case 3:
+      ASSERT(current_id.substep_time() == current_id.step_time() + time_step,
+             "In adaptive RK4 substep 3, the substep time ("
+                 << current_id.substep_time() << ") should equal t0+dt ("
+                 << current_id.step_time() + time_step << ")");
+      return {current_id.time_runs_forward(), current_id.slab_number(),
+              current_id.step_time(), 4,
+              current_id.step_time() + 3 * time_step / 4};
+    case 4:
+      ASSERT(current_id.substep_time() ==
+                 current_id.step_time() + 3 * time_step / 4,
+             "In adaptive RK4 substep 4, the substep time ("
+                 << current_id.substep_time() << ") should equal t0+dt ("
+                 << current_id.step_time() + 3 * time_step / 4 << ")");
+      return {current_id.time_runs_forward(), current_id.slab_number(),
+              current_id.step_time() + time_step};
+    default:
+      ERROR("In adaptive RK4 substep should be one of 0,1,2,3,4 not "
+            << current_id.substep());
+  }
+}
 }  // namespace TimeSteppers
 
 /// \cond

--- a/tests/Unit/Helpers/Time/TimeSteppers/TimeStepperTestUtils.hpp
+++ b/tests/Unit/Helpers/Time/TimeSteppers/TimeStepperTestUtils.hpp
@@ -28,6 +28,11 @@ void integrate_variable_test(const TimeStepper& stepper,
                              size_t number_of_past_steps,
                              double epsilon) noexcept;
 
+void integrate_error_test(const TimeStepper& stepper,
+                          size_t number_of_past_steps, double integration_time,
+                          double epsilon, size_t num_steps,
+                          double error_factor) noexcept;
+
 void stability_test(const TimeStepper& stepper) noexcept;
 
 void equal_rate_boundary(const LtsTimeStepper& stepper,

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
@@ -38,6 +38,15 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN", "[Unit][Time]") {
       TimeStepperTestUtils::integrate_test(stepper, start_points, 1., epsilon);
       TimeStepperTestUtils::integrate_test_explicit_time_dependence(
           stepper, start_points, 1., epsilon);
+      if (start_points > 0) {
+        CAPTURE(order);
+        const double large_step_epsilon =
+            std::max(1.0e3 * std::pow(2.0e-2, start_points + 1), 1e-14);
+        TimeStepperTestUtils::integrate_error_test(
+            stepper, start_points, 1.0, large_step_epsilon, 20, 1.0e-4);
+        TimeStepperTestUtils::integrate_error_test(
+            stepper, start_points, -1.0, large_step_epsilon, 20, 1.0e-4);
+      }
     }
     TimeStepperTestUtils::check_convergence_order(stepper, order);
     TimeStepperTestUtils::check_dense_output(stepper, order);

--- a/tests/Unit/Time/TimeSteppers/Test_DormandPrince5.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_DormandPrince5.cpp
@@ -16,6 +16,10 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.DormandPrince5", "[Unit][Time]") {
   TimeStepperTestUtils::integrate_test(stepper, 0, -1.0, 1.0e-9);
   TimeStepperTestUtils::integrate_test_explicit_time_dependence(stepper, 0,
                                                                 -1.0, 1.0e-9);
+  TimeStepperTestUtils::integrate_error_test(stepper, 0, 1.0, 1.0e-8, 8,
+                                             1.0e-2);
+  TimeStepperTestUtils::integrate_error_test(stepper, 0, -1.0, 1.0e-8, 8,
+                                             1.0e-2);
   TimeStepperTestUtils::integrate_variable_test(stepper, 0, 1.0e-9);
   TimeStepperTestUtils::check_convergence_order(stepper, 5);
   TimeStepperTestUtils::stability_test(stepper);

--- a/tests/Unit/Time/TimeSteppers/Test_RungeKutta3.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_RungeKutta3.cpp
@@ -16,6 +16,10 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3", "[Unit][Time]") {
   TimeStepperTestUtils::integrate_test(stepper, 0, -1., 1e-9);
   TimeStepperTestUtils::integrate_test_explicit_time_dependence(stepper, 0,
                                                                 -1.0, 1.0e-9);
+  TimeStepperTestUtils::integrate_error_test(stepper, 0, 1.0, 1.0e-8, 100,
+                                             1.0e-4);
+  TimeStepperTestUtils::integrate_error_test(stepper, 0, -1.0, 1.0e-8, 100,
+                                             1.0e-4);
   TimeStepperTestUtils::integrate_variable_test(stepper, 0, 1e-9);
   TimeStepperTestUtils::stability_test(stepper);
   TimeStepperTestUtils::check_convergence_order(stepper, 3);

--- a/tests/Unit/Time/TimeSteppers/Test_RungeKutta4.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_RungeKutta4.cpp
@@ -16,6 +16,10 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta4", "[Unit][Time]") {
   TimeStepperTestUtils::integrate_test(stepper, 0, -1.0, 1.0e-9);
   TimeStepperTestUtils::integrate_test_explicit_time_dependence(stepper, 0,
                                                                 -1.0, 1.0e-9);
+  TimeStepperTestUtils::integrate_error_test(stepper, 0, 1.0, 1.0e-8, 50,
+                                             1.0e-2);
+  TimeStepperTestUtils::integrate_error_test(stepper, 0, -1.0, 1.0e-8, 50,
+                                             1.0e-2);
   TimeStepperTestUtils::integrate_variable_test(stepper, 0, 1.0e-9);
   TimeStepperTestUtils::check_convergence_order(stepper, 4);
   TimeStepperTestUtils::stability_test(stepper);


### PR DESCRIPTION
## Proposed changes

Adds function overloads to the time steppers for reporting error measures needed for adaptive methods.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
