### PR TITLE
Add CMake options to make profiling easier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 include(SetupLIBCXX)
 include(SetupCxxFlags)
+include(SetupProfiling)
 include(SetupSanitizers)
 include(SetupListTargets)
 include(AddSpectreExecutable)

--- a/cmake/SetupProfiling.cmake
+++ b/cmake/SetupProfiling.cmake
@@ -1,11 +1,14 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+option(ENABLE_PROFILING, "Enables various options to make profiling easier" OFF)
+
 option(KEEP_FRAME_POINTER, "Add keep frame pointer for profiling" OFF)
 
 add_library(Profiling::KeepFramePointer IMPORTED INTERFACE)
+add_library(Profiling::EnableProfiling IMPORTED INTERFACE)
 
-if (KEEP_FRAME_POINTER)
+if (KEEP_FRAME_POINTER OR ENABLE_PROFILING)
   set_property(
     TARGET Profiling::KeepFramePointer
     APPEND PROPERTY
@@ -15,8 +18,18 @@ if (KEEP_FRAME_POINTER)
     )
 endif()
 
+if (ENABLE_PROFILING)
+  set_property(
+    TARGET Profiling::EnableProfiling
+    APPEND PROPERTY
+    INTERFACE_COMPILE_DEFINITIONS
+    $<$<COMPILE_LANGUAGE:CXX>:SPECTRE_PROFILING>
+    )
+endif()
+
 target_link_libraries(
   SpectreFlags
   INTERFACE
+  Profiling::EnableProfiling
   Profiling::KeepFramePointer
   )

--- a/cmake/SetupProfiling.cmake
+++ b/cmake/SetupProfiling.cmake
@@ -1,0 +1,22 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+option(KEEP_FRAME_POINTER, "Add keep frame pointer for profiling" OFF)
+
+add_library(Profiling::KeepFramePointer IMPORTED INTERFACE)
+
+if (KEEP_FRAME_POINTER)
+  set_property(
+    TARGET Profiling::KeepFramePointer
+    APPEND PROPERTY
+    INTERFACE_COMPILE_OPTIONS
+    $<$<COMPILE_LANGUAGE:CXX>:-fno-omit-frame-pointer>
+    $<$<COMPILE_LANGUAGE:CXX>:-mno-omit-leaf-frame-pointer>
+    )
+endif()
+
+target_link_libraries(
+  SpectreFlags
+  INTERFACE
+  Profiling::KeepFramePointer
+  )

--- a/docs/DevGuide/BuildSystem.md
+++ b/docs/DevGuide/BuildSystem.md
@@ -178,6 +178,9 @@ cmake -D FLAG1=OPT1 ... -D FLAGN=OPTN <SPECTRE_ROOT>
   - Whether or not to use debug symbols (default is `ON`)
   - Disabling debug symbols will reduce compile time and total size of the build
     directory.
+- ENABLE_PROFILING
+  - Enables various options to make profiling SpECTRE easier
+    (default is `OFF`)
 - ENABLE_WARNINGS
   - Whether or not warning flags are enabled (default is `ON`)
 - KEEP_FRAME_POINTER

--- a/docs/DevGuide/BuildSystem.md
+++ b/docs/DevGuide/BuildSystem.md
@@ -180,6 +180,10 @@ cmake -D FLAG1=OPT1 ... -D FLAGN=OPTN <SPECTRE_ROOT>
     directory.
 - ENABLE_WARNINGS
   - Whether or not warning flags are enabled (default is `ON`)
+- KEEP_FRAME_POINTER
+  - Whether to keep the frame pointer. Needed for profiling or other cases
+    where you need to be able to figure out what the call stack is.
+    (default is `OFF`)
 - MEMORY_ALLOCATOR
   - Set which memory allocator to use. If there are unexplained segfaults or
     other memory issues, it would be worth setting `MEMORY_ALLOCATOR=SYSTEM` to

--- a/src/Parallel/Invoke.hpp
+++ b/src/Parallel/Invoke.hpp
@@ -16,11 +16,13 @@ namespace detail {
 // done to avoid blowing the stack.
 inline bool max_inline_entry_methods_reached() noexcept {
   thread_local size_t approx_stack_depth = 0;
+#ifndef SPECTRE_PROFILING
   approx_stack_depth++;
   if (approx_stack_depth < 64) {
     return false;
   }
   approx_stack_depth = 0;
+#endif
   return true;
 }
 


### PR DESCRIPTION
## Proposed changes

- Add ability to keep frame pointer
- Add `ENABLE_PROFILING` CMake flag that also stops auto-inlining. I'm undecided that this is the "right" way to think about the code flow, but it makes the inclusive time a lot more useful for actions (it's basically useless otherwise).

Questions:
- Profiling is generally a lot easier/possible with shared libs. Should `ENABLE_PROFILING=ON` require `BUILD_SHARED_LIBS=ON`? For example, HPCToolkit is trivial to use with shared libs (`hpcrun NORMAL_COMMAND`), while with static libs we need to include it in the link stage. I really don't want to have to make the build system even more complicated by supporting HPCToolkit with static libs since that's easily going to be another 200+ lines of CMake code.
- In order to have LIBXSMM show up explicitly in `perf` profiles need to build LIBXSMM with `PERF=1`. I haven't written this in any of the documentation. Should this be added into a completely revamped `Profiling` Dev Guide? The current Projections dev guide is severely outdated and with some changes on our end profiling with Projections will become a lot easier.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
