### PR TITLE
Add SpinFunctionTags to Tags.hpp

### DIFF
--- a/src/ApparentHorizons/StrahlkorperGr.cpp
+++ b/src/ApparentHorizons/StrahlkorperGr.cpp
@@ -665,7 +665,7 @@ template <typename Frame>
 void spin_function(
     const gsl::not_null<Scalar<DataVector>*> result,
     const StrahlkorperTags::aliases::Jacobian<Frame>& tangents,
-    const YlmSpherepack& ylm,
+    const Strahlkorper<Frame>& strahlkorper,
     const tnsr::I<DataVector, 3, Frame>& unit_normal_vector,
     const Scalar<DataVector>& area_element,
     const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature) noexcept {
@@ -706,27 +706,28 @@ void spin_function(
 
   // using result as temporary
   DataVector& sin_theta = get(*result);
-  sin_theta = sin(ylm.theta_phi_points()[0]);
+  sin_theta = sin(strahlkorper.ylm_spherepack().theta_phi_points()[0]);
   get(extrinsic_curvature_theta_normal_sin_theta) *= sin_theta;
   get(extrinsic_curvature_phi_normal) *= sin_theta;
 
   // now computing actual result
-  get(*result) =
-      (get<0>(ylm.gradient(get(extrinsic_curvature_phi_normal))) -
-       get<1>(ylm.gradient(get(extrinsic_curvature_theta_normal_sin_theta)))) /
-      (sin_theta * get(area_element));
+  get(*result) = (get<0>(strahlkorper.ylm_spherepack().gradient(
+                      get(extrinsic_curvature_phi_normal))) -
+                  get<1>(strahlkorper.ylm_spherepack().gradient(
+                      get(extrinsic_curvature_theta_normal_sin_theta)))) /
+                 (sin_theta * get(area_element));
 }
 
 template <typename Frame>
 Scalar<DataVector> spin_function(
     const StrahlkorperTags::aliases::Jacobian<Frame>& tangents,
-    const YlmSpherepack& ylm,
+    const Strahlkorper<Frame>& strahlkorper,
     const tnsr::I<DataVector, 3, Frame>& unit_normal_vector,
     const Scalar<DataVector>& area_element,
     const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature) noexcept {
   Scalar<DataVector> result{};
-  spin_function(make_not_null(&result), tangents, ylm, unit_normal_vector,
-                area_element, extrinsic_curvature);
+  spin_function(make_not_null(&result), tangents, strahlkorper,
+                unit_normal_vector, area_element, extrinsic_curvature);
   return result;
 }
 
@@ -929,14 +930,14 @@ double StrahlkorperGr::euclidean_surface_integral_of_vector(
 template void StrahlkorperGr::spin_function<Frame::Inertial>(
     const gsl::not_null<Scalar<DataVector>*> result,
     const StrahlkorperTags::aliases::Jacobian<Frame::Inertial>& tangents,
-    const YlmSpherepack& ylm,
+    const Strahlkorper<Frame::Inertial>& strahlkorper,
     const tnsr::I<DataVector, 3, Frame::Inertial>& unit_normal_vector,
     const Scalar<DataVector>& area_element,
     const tnsr::ii<DataVector, 3, Frame::Inertial>&
         extrinsic_curvature) noexcept;
 template Scalar<DataVector> StrahlkorperGr::spin_function<Frame::Inertial>(
     const StrahlkorperTags::aliases::Jacobian<Frame::Inertial>& tangents,
-    const YlmSpherepack& ylm,
+    const Strahlkorper<Frame::Inertial>& strahlkorper,
     const tnsr::I<DataVector, 3, Frame::Inertial>& unit_normal_vector,
     const Scalar<DataVector>& area_element,
     const tnsr::ii<DataVector, 3, Frame::Inertial>&

--- a/src/ApparentHorizons/StrahlkorperGr.hpp
+++ b/src/ApparentHorizons/StrahlkorperGr.hpp
@@ -346,7 +346,7 @@ template <typename Frame>
 void spin_function(
     gsl::not_null<Scalar<DataVector>*> result,
     const StrahlkorperTags::aliases::Jacobian<Frame>& tangents,
-    const YlmSpherepack& ylm,
+    const Strahlkorper<Frame>& strahlkorper,
     const tnsr::I<DataVector, 3, Frame>& unit_normal_vector,
     const Scalar<DataVector>& area_element,
     const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature) noexcept;
@@ -354,7 +354,7 @@ void spin_function(
 template <typename Frame>
 Scalar<DataVector> spin_function(
     const StrahlkorperTags::aliases::Jacobian<Frame>& tangents,
-    const YlmSpherepack& ylm,
+    const Strahlkorper<Frame>& strahlkorper,
     const tnsr::I<DataVector, 3, Frame>& unit_normal_vector,
     const Scalar<DataVector>& area_element,
     const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature) noexcept;

--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -599,5 +599,33 @@ struct IrreducibleMassCompute : IrreducibleMass, db::ComputeTag {
 
   using argument_tags = tmpl::list<Area>;
 };
+
+/// The spin function is proportional to the imaginary part of the
+/// Strahlkorper’s complex scalar curvature.
+
+struct SpinFunction : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+/// Calculates the spin function which is proportional to the imaginary part of
+/// the Strahlkorper’s complex scalar curvature.
+template <typename Frame>
+struct SpinFunctionCompute : SpinFunction, db::ComputeTag {
+  using base = SpinFunction;
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<Scalar<DataVector>*>,
+      const StrahlkorperTags::aliases::Jacobian<Frame>&,
+      const Strahlkorper<Frame>&, const tnsr::I<DataVector, 3, Frame>&,
+      const Scalar<DataVector>&,
+      const tnsr::ii<DataVector, 3, Frame>&) noexcept>(
+      &StrahlkorperGr::spin_function<Frame>);
+  using argument_tags =
+      tmpl::list<StrahlkorperTags::Tangents<Frame>,
+                 StrahlkorperTags::Strahlkorper<Frame>,
+                 StrahlkorperTags::UnitNormalVector<Frame>, AreaElement<Frame>,
+                 gr::Tags::ExtrinsicCurvature<3, Frame, DataVector>>;
+  using return_type = Scalar<DataVector>;
+};
+
 }  // namespace Tags
 }  // namespace StrahlkorperGr

--- a/src/ApparentHorizons/TagsDeclarations.hpp
+++ b/src/ApparentHorizons/TagsDeclarations.hpp
@@ -64,6 +64,9 @@ struct AreaCompute;
 struct IrreducibleMass;
 template <typename Frame>
 struct IrreducibleMassCompute;
+struct SpinFunction;
+template <typename Frame>
+struct SpinFunctionCompute;
 
 }  // namespace Tags
 }  // namespace StrahlkorperGr

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
@@ -599,8 +599,9 @@ void test_spin_function(const Solution& solution,
   const auto& tangents =
       db::get<StrahlkorperTags::Tangents<Frame::Inertial>>(box);
 
-  const auto spin_function = StrahlkorperGr::spin_function(
-      tangents, ylm, unit_normal_vector, area_element, extrinsic_curvature);
+  const auto spin_function =
+      StrahlkorperGr::spin_function(tangents, strahlkorper, unit_normal_vector,
+                                    area_element, extrinsic_curvature);
 
   auto integrand = spin_function;
   get(integrand) *= get(area_element) * get(spin_function);
@@ -672,8 +673,9 @@ void test_dimensionful_spin_magnitude(
   const auto& tangents =
       db::get<StrahlkorperTags::Tangents<Frame::Inertial>>(box);
 
-  const auto spin_function = StrahlkorperGr::spin_function(
-      tangents, ylm, unit_normal_vector, area_element, extrinsic_curvature);
+  const auto spin_function =
+      StrahlkorperGr::spin_function(tangents, strahlkorper, unit_normal_vector,
+                                    area_element, extrinsic_curvature);
 
   const auto grad_unit_normal_one_form =
       StrahlkorperGr::grad_unit_normal_one_form(
@@ -757,8 +759,9 @@ void test_spin_vector(
   const auto& tangents =
       db::get<StrahlkorperTags::Tangents<Frame::Inertial>>(box);
 
-  const auto spin_function = StrahlkorperGr::spin_function(
-      tangents, ylm, unit_normal_vector, area_element, extrinsic_curvature);
+  const auto spin_function =
+      StrahlkorperGr::spin_function(tangents, strahlkorper, unit_normal_vector,
+                                    area_element, extrinsic_curvature);
 
   const auto ricci_scalar = TestHelpers::Kerr::horizon_ricci_scalar(
       horizon_radius_with_spin_on_z_axis, ylm_with_spin_on_z_axis, ylm, mass,

--- a/tests/Unit/ApparentHorizons/Test_Tags.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Tags.cpp
@@ -300,6 +300,8 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
       "OneOverOneFormMagnitude");
   TestHelpers::db::test_simple_tag<StrahlkorperTags::RicciScalar>(
       "RicciScalar");
+  TestHelpers::db::test_simple_tag<StrahlkorperGr::Tags::SpinFunction>(
+      "SpinFunction");
   TestHelpers::db::test_simple_tag<
       StrahlkorperTags::UnitNormalOneForm<Frame::Inertial>>(
       "UnitNormalOneForm");
@@ -414,4 +416,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
   TestHelpers::db::test_compute_tag<
       StrahlkorperTags::RicciScalarCompute<Frame::Inertial>>(
       "RicciScalar");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperGr::Tags::SpinFunctionCompute<Frame::Inertial>>(
+      "SpinFunction");
 }


### PR DESCRIPTION
## Proposed changes


The SpinFunctionTag and SpinFunctionCompute calculates the spin function which is proportional to the imaginary part of the Strahlkorper’s complex scalar curvature. 

Changed the spin_function to take strahlkorper instead of ylm.


### Types of changes:

- [ ] Bugfix
- [ x] New feature
- [ ] Refactor

### Component:

- [x ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--

-->
