### PR TITLE
Add script to compile release notes, update PR template and add tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,29 +4,26 @@
 At a high level, describe what this PR does.
 -->
 
-### Types of changes:
+### Upgrade instructions
 
-- [ ] Bugfix
-- [ ] New feature
-- [ ] Refactor
+<!--
+If this PR makes changes that other people should be aware of when upgrading
+their code, describe what they should do between the two UPGRADE INSTRUCTIONS
+lines below.
+-->
+<!-- UPGRADE INSTRUCTIONS -->
 
-### Component:
-
-- [ ] Code
-- [ ] Documentation
-- [ ] Build system
-- [ ] Continuous integration
+<!-- UPGRADE INSTRUCTIONS -->
 
 ### Code review checklist
 
-- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
-  For instructions on how to perform the CI checks locally refer to the [Dev
-  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
 - [ ] The code is documented and the documentation renders correctly. Run
   `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
   Then open `index.html`.
 - [ ] The code follows the stylistic and code quality guidelines listed in the
   [code review guide](https://spectre-code.org/code_review_guide.html).
+- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
+  `major new feature` if appropriate.
 
 ### Further comments
 

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -71,12 +71,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Install Python dependencies
         run: |
           pip3 install \
             GitPython~=3.1.11 \
             PyYAML~=5.3.1 \
-      - name: Check python formatting
+      - name: Test tools
+        run: |
+          python3 -m unittest discover -p 'Test_*' tests.tools -v
+      - name: Check Python formatting
         run: |
           cd $GITHUB_WORKSPACE
           ./tools/CheckPythonFormatting.sh

--- a/docs/DevGuide/CodeReviewGuide.md
+++ b/docs/DevGuide/CodeReviewGuide.md
@@ -8,7 +8,8 @@ Code must follow the
 <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md">C++ Core Guidelines</a>
 and the [Google style guide](https://google.github.io/styleguide/cppguide.html).
 If the Google style guide disagrees with the Core Guidelines, follow the Core
-Guidelines.
+Guidelines. Python code must also follow the
+[Google style guide](https://google.github.io/styleguide/pyguide.html).
 
 Here we summarize what we view as the more important portions of the guides.
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.

--- a/tests/tools/Test_CompileReleaseNotes.py
+++ b/tests/tools/Test_CompileReleaseNotes.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python
+
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import git
+import os
+import textwrap
+import unittest
+import yaml
+from tools.CompileReleaseNotes import (get_last_release,
+                                       get_merged_pull_requests,
+                                       get_upgrade_instructions,
+                                       compile_release_notes, PullRequest)
+
+
+class TestCompileReleaseNotes(unittest.TestCase):
+    def test_get_last_release(self):
+        repo = git.Repo(path=__file__, search_parent_directories=True)
+        with open(os.path.join(repo.working_dir, 'Metadata.yaml'),
+                  'r') as open_metadata_file:
+            metadata = yaml.safe_load(open_metadata_file)
+        expected_tag_name = 'v' + metadata['Version']
+        last_release = get_last_release(repo, head_rev='HEAD')
+        self.assertEqual(
+            str(last_release), expected_tag_name,
+            (f"The last release '{last_release}' doesn't match the expected "
+             f"tag name '{expected_tag_name}' listed in the repo metadata."))
+        also_last_release = get_last_release(repo, head_rev=last_release)
+        self.assertEqual(
+            last_release, also_last_release,
+            (f"Should find the last release '{last_release}' when HEAD is the "
+             f"release tag, but found '{also_last_release}'."))
+        earlier_release = get_last_release(repo,
+                                           head_rev=str(last_release) + '~1')
+        self.assertNotEqual(
+            earlier_release, last_release,
+            ("Should find an earlier release when HEAD is before "
+             f"'{last_release}', not the same release."))
+
+    def test_get_merged_pull_requests(self):
+        repo = git.Repo(path=__file__, search_parent_directories=True)
+        last_release = get_last_release(repo)
+        merged_prs = get_merged_pull_requests(repo,
+                                              from_rev=(str(last_release) +
+                                                        '~1'),
+                                              to_rev=last_release)
+        self.assertTrue(
+            len(merged_prs) > 0,
+            (f"The last release '{last_release}' should be a merge commit, "
+             "so we should have been able to parse its corresponding "
+             "pull request."))
+
+    def test_get_upgrade_instructions(self):
+        upgrade_instructions = get_upgrade_instructions(
+            textwrap.dedent("""\
+            ### Upgrade instructions
+            Here's what you should do when rebasing on this PR:
+            <!-- UPGRADE INSTRUCTIONS -->
+            - Add the option `Evolution.InitialTime` to evolution input files.
+              Set it to the value `0.` to keep the behavior the same as before.
+            <!-- UPGRADE INSTRUCTIONS -->
+            """))
+        self.assertEqual(
+            upgrade_instructions,
+            "- Add the option `Evolution.InitialTime` to evolution input "
+            "files.\n  Set it to the value `0.` to keep the behavior the same "
+            "as before.")
+        self.assertIsNone(
+            get_upgrade_instructions(
+                "<!-- UPGRADE INSTRUCTIONS --> <!-- UPGRADE INSTRUCTIONS -->"),
+            "Not all whitespace is stripped")
+        self.assertIsNone(
+            get_upgrade_instructions(
+                "<!-- UPGRADE INSTRUCTIONS -->\n<!-- UPGRADE INSTRUCTIONS -->"
+            ), "Not all whitespace is stripped")
+        self.assertEqual(
+            get_upgrade_instructions(
+                ("<!-- UPGRADE INSTRUCTIONS -->\n\n\n   Do this and that."
+                 "  \n\n<!-- UPGRADE INSTRUCTIONS -->")), "Do this and that.",
+            "Not all whitespace is stripped")
+
+    def test_compile_release_notes(self):
+        self.assertEqual(
+            compile_release_notes([]),
+            textwrap.dedent("""\
+                ## Merged pull-requests
+
+                _None_
+                """))
+        pr1 = PullRequest(id=1, title="Add this")
+        pr2 = PullRequest(id=2,
+                          title="Also add this new feature",
+                          url="https://github.com/2")
+        self.assertEqual(
+            compile_release_notes([pr1, pr2]),
+            textwrap.dedent("""\
+                ## Merged pull-requests
+
+                **General changes:**
+
+                - Add this (#1)
+                - Also add this new feature ([#2](https://github.com/2))
+                """))
+        major_pr1 = PullRequest(id=3,
+                                title="This is big",
+                                group='major new feature',
+                                upgrade_instructions="- Do this.\n- And that.")
+        major_pr2 = PullRequest(id=4,
+                                title="Another feature",
+                                group='major new feature')
+        bugfix_pr1 = PullRequest(
+            id=5,
+            title="Fixed this bug",
+            url='https://github.com/5',
+            group='bugfix',
+            upgrade_instructions="You'll have to rerun your simulation.")
+        bugfix_pr2 = PullRequest(id=6,
+                                 title="Fixed another bug",
+                                 group='bugfix')
+        self.assertEqual(
+            compile_release_notes(
+                [pr1, major_pr1, pr2, bugfix_pr1, bugfix_pr2, major_pr2]),
+            textwrap.dedent("""\
+                ## Upgrade instructions
+
+                **From #3 (This is big):**
+
+                - Do this.
+                - And that.
+
+                **From [#5](https://github.com/5) (Fixed this bug):**
+
+                You'll have to rerun your simulation.
+
+                ## Merged pull-requests
+
+                **Major new features:**
+
+                - This is big (#3)
+                - Another feature (#4)
+
+                **General changes:**
+
+                - Add this (#1)
+                - Also add this new feature ([#2](https://github.com/2))
+
+                **Bugfixes:**
+
+                - Fixed this bug ([#5](https://github.com/5))
+                - Fixed another bug (#6)
+                """))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/tools/__init__.py
+++ b/tests/tools/__init__.py
@@ -1,0 +1,2 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.

--- a/tools/CompileReleaseNotes.py
+++ b/tools/CompileReleaseNotes.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python
+
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import git
+import itertools
+import logging
+import re
+from dataclasses import dataclass
+from typing import List, Optional, Union
+
+logger = logging.getLogger(__name__)
+
+Revision = Union[str, git.TagReference]
+
+
+def get_last_release(
+        repo: git.Repo,
+        head_rev: Revision = 'HEAD') -> Optional[git.TagReference]:
+    """Retrieve the release closest to the `head_rev` in its git history
+
+    Returns:
+      The tag representing the latest release, as measured by number of commits
+      to the `head_rev`, or `None` if no release is in the history of
+      `head_rev`.
+    """
+    def is_version_tag(tag):
+        return str(tag).startswith('v')
+
+    def distance_from_head(tag):
+        return sum(1 for _ in repo.iter_commits(rev=f'{tag}~1..{head_rev}',
+                                                first_parent=True))
+
+    def is_in_history(tag):
+        return distance_from_head(tag) > 0
+
+    try:
+        return min(filter(is_in_history, filter(is_version_tag, repo.tags)),
+                   key=distance_from_head)
+    except ValueError:
+        return None
+
+
+@dataclass
+class PullRequest:
+    id: int
+    title: str
+    url: Optional[str] = None
+    group: Optional[str] = None
+    upgrade_instructions: Optional[str] = None
+
+
+# These should correspond to labels on GitHub
+PULL_REQUEST_GROUPS = ['major new feature', None, 'bugfix']
+
+
+def get_merged_pull_requests(repo: git.Repo, from_rev: Revision,
+                             to_rev: Revision) -> List[PullRequest]:
+    """Parses list of merged PRs from merge commits.
+
+    Parses merge commits in the repository between the revisions `from_rev` and
+    `to_rev`. This is faster than querying GitHub and we can filter by commit
+    SHAs instead of date.
+
+    Returns:
+      Merged pull-requests, ordered from least-recently merged to most-recently
+      merged.
+    """
+    merge_commit_msg_pattern = '^Merge pull request #([0-9]+) from'
+    merged_prs = []
+    for commit in repo.iter_commits(rev=f'{from_rev}..{to_rev}',
+                                    first_parent=True):
+        merge_commit_match = re.match(merge_commit_msg_pattern,
+                                      commit.message,
+                                      flags=re.MULTILINE)
+        if not merge_commit_match:
+            continue
+        merged_prs.append(
+            PullRequest(id=int(merge_commit_match.group(1)),
+                        title=' '.join(commit.message.splitlines(False)[2:])))
+    return merged_prs[::-1]
+
+
+def get_upgrade_instructions(pr_description: str) -> Optional[str]:
+    """Parse a section labeled "Upgrade instructions" from the PR description.
+
+    This function looks for a section in the PR description that is enclosed in
+    the HTML-comments `<!-- UPGRADE INSTRUCTIONS -->`. For example:
+
+    ```md
+    ### Upgrade instructions
+
+    <!-- UPGRADE INSTRUCTIONS -->
+    - Add the option `Evolution.InitialTime` to evolution input files. Set it
+      to the value `0.` to keep the behavior the same as before.
+    <!-- UPGRADE INSTRUCTIONS -->
+    ```
+    """
+    FENCE_PATTERN = '<!-- UPGRADE INSTRUCTIONS -->'
+    match = re.search(FENCE_PATTERN + '(.*)' + FENCE_PATTERN,
+                      pr_description,
+                      flags=re.DOTALL)
+    if match is None:
+        return None
+    match = match.group(1).strip()
+    if not match or match.isspace():
+        return None
+    return match
+
+
+def compile_release_notes(merged_prs: List[PullRequest]) -> str:
+    """Compile nicely-formatted release-notes.
+
+    Args:
+      merged_prs: The list of merged PRs since the last release, ordered from
+        least-recently merged to most-recently merged. The format of the
+        release notes depends on what information is available for the PRs.
+
+    Returns:
+      The Markdown-formatted release notes, ready to write to a file or print
+      to screen.
+    """
+    # Sort PRs into their groups, ordered first by group then by the order they
+    # were merged
+    grouped_prs = itertools.groupby(
+        sorted(merged_prs,
+               key=lambda pr:
+               (PULL_REQUEST_GROUPS.index(pr.group), merged_prs.index(pr))),
+        key=lambda pr: pr.group)
+
+    def format_pr_link(pr):
+        return f"#{pr.id}" if pr.url is None else f"[#{pr.id}]({pr.url})"
+
+    def format_list_of_prs(prs):
+        return [f"- {pr.title} ({format_pr_link(pr)})" for pr in prs]
+
+    release_notes_content = []
+
+    prs_with_upgrade_instructions = list(
+        filter(lambda pr: pr.upgrade_instructions, merged_prs))
+    if len(prs_with_upgrade_instructions) > 0:
+        release_notes_content += ["## Upgrade instructions", ""]
+        for pr in prs_with_upgrade_instructions:
+            release_notes_content += [
+                f"**From {format_pr_link(pr)} ({pr.title}):**", "",
+                pr.upgrade_instructions, ""
+            ]
+
+    release_notes_content += ["## Merged pull-requests", ""]
+    if len(merged_prs) > 0:
+        for group, prs in grouped_prs:
+            group_header = {
+                'major new feature': "Major new features",
+                'bugfix': "Bugfixes",
+                None: "General changes",
+            }[group]
+            release_notes_content += ([f"**{group_header}:**", ""] +
+                                      format_list_of_prs(prs)) + [""]
+    else:
+        release_notes_content += ["_None_", ""]
+
+    return '\n'.join(release_notes_content)
+
+
+if __name__ == "__main__":
+    # The release notes always refer to the repository that contains this file
+    repo = git.Repo(__file__, search_parent_directories=True)
+
+    import argparse
+    parser = argparse.ArgumentParser(
+        description=("Compile release notes based on merged pull-requests. "
+                     f"Repository: {repo.working_dir}. "
+                     f"Branch: {repo.active_branch}."),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        '--output',
+        '-o',
+        required=False,
+        help=(
+            "Name of the output file, e.g. 'release_notes.md'. If you omit "
+            "this argument the Markdown-formatted output will be printed "
+            "to stdout. Hint: Pipe the output to a CLI Markdown-renderer to "
+            "improve readability, e.g. https://github.com/charmbracelet/glow."
+        ))
+    parser.add_argument(
+        '--from',
+        required=False,
+        dest='from_rev',
+        help=("Git revision that marks the last release, used as starting "
+              "point for the release notes. Can be any commit SHA or tag. "
+              "Defaults to the last release in the git history of "
+              "the '--to' revision."))
+    parser.add_argument(
+        '--to',
+        required=False,
+        dest='to_rev',
+        default='HEAD',
+        help=("Git revision that marks this release. Can be any commit SHA "
+              "or tag."))
+    parser.add_argument(
+        '--github-repository',
+        required=False,
+        default='sxs-collaboration/spectre',
+        help=("GitHub repository associated with pull-request IDs in merge "
+              "commits."))
+    parser_github_auth = parser.add_mutually_exclusive_group(required=False)
+    parser_github_auth.add_argument(
+        '--github-token',
+        required=False,
+        help=
+        ("Access token for GitHub queries. Refer to the GitHub documentation "
+         "for instructions on creating a personal access token."))
+    parser_github_auth.add_argument(
+        '--no-github',
+        action='store_true',
+        help=("Disable GitHub queries, working only with the local "
+              "repository."))
+    parser_logging = parser.add_mutually_exclusive_group(required=False)
+    parser_logging.add_argument('-v',
+                                '--verbose',
+                                action='count',
+                                default=0,
+                                help="Verbosity (-v, -vv, ...)")
+    parser_logging.add_argument('--silent',
+                                action='store_true',
+                                help="Disable any logging")
+    args = parser.parse_args()
+
+    # Set the log level
+    logging.basicConfig(
+        level=logging.CRITICAL if args.silent else (logging.WARNING -
+                                                    args.verbose * 10))
+
+    # Default `from_rev` to last release
+    if args.from_rev is None:
+        args.from_rev = get_last_release(repo=repo, head_rev=args.to_rev)
+        logging.info(f"Last release is: {args.from_rev}")
+
+    # Retrieve list of merged PRs since last release
+    merged_prs = get_merged_pull_requests(repo=repo,
+                                          from_rev=args.from_rev,
+                                          to_rev=args.to_rev)
+    logger.info("Merged PRs since last release:\n{}".format('\n'.join(
+        map(str, merged_prs))))
+
+    # Try to query GitHub for further information on the merged PRs
+    if not args.no_github:
+        import github
+        gh = github.Github(args.github_token)
+        gh_repo = gh.get_repo(args.github_repository)
+        if args.silent:
+            prs_iterator = iter(merged_prs)
+        else:
+            import tqdm
+            prs_iterator = tqdm.tqdm(merged_prs,
+                                     desc="Downloading PR data",
+                                     unit="PR")
+        for pr in prs_iterator:
+            # First, download data
+            pr_gh = gh_repo.get_pull(pr.id)
+            # Update the title (it may have changed since the PR was merged)
+            pr.title = pr_gh.title
+            # Add missing metadata to PR
+            pr.url = pr_gh.html_url
+            # Add group information to PR
+            labels = [label.name for label in pr_gh.labels]
+            for group in PULL_REQUEST_GROUPS:
+                if group is None:
+                    continue
+                if group in labels:
+                    pr.group = group
+                    break
+            # Add upgrade instructions to PR
+            pr.upgrade_instructions = get_upgrade_instructions(pr_gh.body)
+
+    # Assemble everything into a nicely formatted string
+    release_notes_content = compile_release_notes(merged_prs=merged_prs)
+
+    # Output
+    if args.output:
+        with open(args.output, 'w') as output_file:
+            output_file.write(release_notes_content)
+        logging.info(f"Release notes written to file: '{args.output}'")
+    else:
+        logging.info("Compiled release notes:")
+        print(release_notes_content)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,2 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.


### PR DESCRIPTION
## Proposed changes

- Adds a script that compiles release notes based on merged PRs. It's also useful to see what happened between any two commits in the repo. You can try it like this:

  ```sh
  $ pip3 install GitPython
  $ python3 -m tools.CompileReleaseNotes
   ```
  
  It's particularly fancy if you pipe the output to a CLI Markdown renderer. E.g. install https://github.com/charmbracelet/glow and try this:

  ```sh
   $ python3 -m tools.CompileReleaseNotes | glow -
   ```
- Adds tests for this script in `tests/tools` and runs them on CI.
- Updates the PR template to reflect what information is pulled into the release notes. Removes the checkboxes for "bugfix" etc. because these can just be labels and I haven't seen them used in a useful way, most people don't tick them at all. As labels they are more visible and can be used in release notes.
- Since the release notes are compiled from PRs it would be good if we make sure they pass some basic checks. As an idea I added a CI test that checks the "code review checklist" below is ticked. I think that is a very quick thing to do and it makes sure the PR author has considered these items. I removed the "automated checks must pass" item from the checklist since that one is not necessary to check manually, it's built into the GitHub UI and checks can even be labeled "required". Ideally we would move more and more items from the checklist to automated tests.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two comments below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
