### PR TITLE
Require catch 2.8, print more digits in catch output

### DIFF
--- a/cmake/SetupCatch.cmake
+++ b/cmake/SetupCatch.cmake
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-find_package(Catch 2.1.0 REQUIRED)
+find_package(Catch 2.8.0 REQUIRED)
 
 spectre_include_directories("${CATCH_INCLUDE_DIR}")
 message(STATUS "Catch include: ${CATCH_INCLUDE_DIR}")

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -21,7 +21,7 @@ installation_on_clusters "Installation on clusters" page.
 * [Blaze](https://bitbucket.org/blaze-lib/blaze/overview) v3.5
 * [Boost](http://www.boost.org/) 1.60.0 or later
 * [Brigand](https://github.com/edouarda/brigand)
-* [Catch](https://github.com/philsquared/Catch) 2.1.0 or later
+* [Catch](https://github.com/philsquared/Catch) 2.8.0 or later
 * [GSL](https://www.gnu.org/software/gsl/)
 * [HDF5](https://support.hdfgroup.org/HDF5/) (non-mpi version on macOS)
 * [jemalloc](https://github.com/jemalloc/jemalloc)

--- a/tests/Unit/ApparentHorizons/Test_Strahlkorper.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Strahlkorper.cpp
@@ -45,7 +45,7 @@ void test_invert_spec_phys_transform() {
       r += delta_radius * ran(gen);
     }
   }
-  CAPTURE_PRECISE(radius);
+  CAPTURE(radius);
 
   // Initialize a strahlkorper of l_max=l_grid
   const Strahlkorper<Frame::Inertial> sk(l_grid, l_grid, radius, center);

--- a/tests/Unit/Domain/CoordinateMaps/Test_EquatorialCompression.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_EquatorialCompression.cpp
@@ -25,7 +25,7 @@ void test_suite() {  // Set up random number generator
   std::uniform_real_distribution<> aspect_ratio_dis(0.1, 10);
 
   const double aspect_ratio = aspect_ratio_dis(gen);
-  CAPTURE_PRECISE(aspect_ratio);
+  CAPTURE(aspect_ratio);
   const CoordinateMaps::EquatorialCompression angular_compression_map(
       aspect_ratio);
   test_suite_for_map_on_unit_cube(angular_compression_map);
@@ -38,13 +38,13 @@ void test_radius() {
   std::uniform_real_distribution<> real_dis(-10, 10);
   std::uniform_real_distribution<> aspect_ratio_dis(0.1, 10);
   const double x = real_dis(gen);
-  CAPTURE_PRECISE(x);
+  CAPTURE(x);
   const double y = real_dis(gen);
-  CAPTURE_PRECISE(y);
+  CAPTURE(y);
   const double z = real_dis(gen);
-  CAPTURE_PRECISE(z);
+  CAPTURE(z);
   const double aspect_ratio = aspect_ratio_dis(gen);
-  CAPTURE_PRECISE(aspect_ratio);
+  CAPTURE(aspect_ratio);
   const std::array<double, 3> input_point{{x, y, z}};
   const CoordinateMaps::EquatorialCompression angular_compression_map(
       aspect_ratio);

--- a/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
@@ -28,21 +28,21 @@ void test_suite_for_frustum(const bool with_equiangular_map) {
   std::uniform_real_distribution<> upper_bound_dis(2, 14);
 
   const double lower_x_lower_base = lower_bound_dis(gen);
-  CAPTURE_PRECISE(lower_x_lower_base);
+  CAPTURE(lower_x_lower_base);
   const double lower_y_lower_base = lower_bound_dis(gen);
-  CAPTURE_PRECISE(lower_y_lower_base);
+  CAPTURE(lower_y_lower_base);
   const double upper_x_lower_base = upper_bound_dis(gen);
-  CAPTURE_PRECISE(upper_x_lower_base);
+  CAPTURE(upper_x_lower_base);
   const double upper_y_lower_base = upper_bound_dis(gen);
-  CAPTURE_PRECISE(upper_y_lower_base);
+  CAPTURE(upper_y_lower_base);
   const double lower_x_upper_base = lower_bound_dis(gen);
-  CAPTURE_PRECISE(lower_x_upper_base);
+  CAPTURE(lower_x_upper_base);
   const double lower_y_upper_base = lower_bound_dis(gen);
-  CAPTURE_PRECISE(lower_y_upper_base);
+  CAPTURE(lower_y_upper_base);
   const double upper_x_upper_base = upper_bound_dis(gen);
-  CAPTURE_PRECISE(upper_x_upper_base);
+  CAPTURE(upper_x_upper_base);
   const double upper_y_upper_base = upper_bound_dis(gen);
-  CAPTURE_PRECISE(upper_y_upper_base);
+  CAPTURE(upper_y_upper_base);
 
   for (OrientationMapIterator<3> map_i{}; map_i; ++map_i) {
     const std::array<std::array<double, 2>, 4> face_vertices{
@@ -184,27 +184,27 @@ void test_auto_projective_scale_factor() {
   std::uniform_real_distribution<> logical_dis(-1, 1);
 
   const double lower_x_lower_base = lower_bound_dis(gen);
-  CAPTURE_PRECISE(lower_x_lower_base);
+  CAPTURE(lower_x_lower_base);
   const double lower_y_lower_base = lower_bound_dis(gen);
-  CAPTURE_PRECISE(lower_y_lower_base);
+  CAPTURE(lower_y_lower_base);
   const double upper_x_lower_base = upper_bound_dis(gen);
-  CAPTURE_PRECISE(upper_x_lower_base);
+  CAPTURE(upper_x_lower_base);
   const double upper_y_lower_base = upper_bound_dis(gen);
-  CAPTURE_PRECISE(upper_y_lower_base);
+  CAPTURE(upper_y_lower_base);
   const double lower_x_upper_base = lower_bound_dis(gen);
-  CAPTURE_PRECISE(lower_x_upper_base);
+  CAPTURE(lower_x_upper_base);
   const double lower_y_upper_base = lower_bound_dis(gen);
-  CAPTURE_PRECISE(lower_y_upper_base);
+  CAPTURE(lower_y_upper_base);
   const double upper_x_upper_base = upper_bound_dis(gen);
-  CAPTURE_PRECISE(upper_x_upper_base);
+  CAPTURE(upper_x_upper_base);
   const double upper_y_upper_base = upper_bound_dis(gen);
-  CAPTURE_PRECISE(upper_y_upper_base);
+  CAPTURE(upper_y_upper_base);
   const double xi = logical_dis(gen);
-  CAPTURE_PRECISE(xi);
+  CAPTURE(xi);
   const double eta = logical_dis(gen);
-  CAPTURE_PRECISE(eta);
+  CAPTURE(eta);
   const double zeta = logical_dis(gen);
-  CAPTURE_PRECISE(zeta);
+  CAPTURE(zeta);
 
   const std::array<double, 3> logical_coord{{0.0, 0.0, zeta}};
   const double lower_bound = 2.0;

--- a/tests/Unit/Domain/CoordinateMaps/Test_SpecialMobius.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_SpecialMobius.cpp
@@ -29,7 +29,7 @@ void test_suite() {  // Set up random number generator
   std::uniform_real_distribution<> mu_dis(-0.85, 0.85);
 
   const double mu = mu_dis(gen);
-  CAPTURE_PRECISE(mu);
+  CAPTURE(mu);
   const CoordinateMaps::SpecialMobius special_mobius_map(mu);
   test_suite_for_map_on_sphere(special_mobius_map);
 }
@@ -45,19 +45,19 @@ void test_map() {
   // to 12 decimal places for mu = 0.96.
   std::uniform_real_distribution<> mu_dis(-0.90, 0.90);
   const double theta = theta_dis(gen);
-  CAPTURE_PRECISE(theta);
+  CAPTURE(theta);
   const double phi = phi_dis(gen);
-  CAPTURE_PRECISE(phi);
+  CAPTURE(phi);
   const double radius = radius_dis(gen);
-  CAPTURE_PRECISE(radius);
+  CAPTURE(radius);
   const double x = radius * sin(theta) * cos(phi);
-  CAPTURE_PRECISE(x);
+  CAPTURE(x);
   const double y = radius * sin(theta) * sin(phi);
-  CAPTURE_PRECISE(y);
+  CAPTURE(y);
   const double z = radius * cos(theta);
-  CAPTURE_PRECISE(z);
+  CAPTURE(z);
   const double mu = mu_dis(gen);
-  CAPTURE_PRECISE(mu);
+  CAPTURE(mu);
   const std::array<double, 3> input_point{{x, y, z}};
   const CoordinateMaps::SpecialMobius special_mobius_map(mu);
   const auto result_point = special_mobius_map(input_point);
@@ -92,7 +92,7 @@ void test_map() {
 void test_large_mu() {
   INFO("Large mu");
   const double mu = 0.95;
-  CAPTURE_PRECISE(mu);
+  CAPTURE(mu);
   // A point on the unit sphere with x=0, y!=z:
   const std::array<double, 3> input_point{{0.0, 0.6, 0.8}};
   const CoordinateMaps::SpecialMobius special_mobius_map(mu);

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
@@ -33,27 +33,27 @@ void test_wedge2d_all_orientations(const bool with_equiangular_map) {
   // corners of the wedge.
   const std::array<double, 2> lower_right_corner{{1.0, -1.0}};
   const std::array<double, 2> upper_right_corner{{1.0, 1.0}};
-  CAPTURE_PRECISE(gsl::at(lower_right_corner, 0));
-  CAPTURE_PRECISE(gsl::at(upper_right_corner, 0));
-  CAPTURE_PRECISE(gsl::at(lower_right_corner, 1));
-  CAPTURE_PRECISE(gsl::at(upper_right_corner, 1));
+  CAPTURE(gsl::at(lower_right_corner, 0));
+  CAPTURE(gsl::at(upper_right_corner, 0));
+  CAPTURE(gsl::at(lower_right_corner, 1));
+  CAPTURE(gsl::at(upper_right_corner, 1));
 
   const double random_inner_radius_upper_xi = inner_dis(gen);
-  CAPTURE_PRECISE(random_inner_radius_upper_xi);
+  CAPTURE(random_inner_radius_upper_xi);
   const double random_inner_radius_upper_eta = inner_dis(gen);
-  CAPTURE_PRECISE(random_inner_radius_upper_eta);
+  CAPTURE(random_inner_radius_upper_eta);
   const double random_inner_radius_lower_xi = inner_dis(gen);
-  CAPTURE_PRECISE(random_inner_radius_lower_xi);
+  CAPTURE(random_inner_radius_lower_xi);
   const double random_inner_radius_lower_eta = inner_dis(gen);
-  CAPTURE_PRECISE(random_inner_radius_lower_eta);
+  CAPTURE(random_inner_radius_lower_eta);
   const double random_outer_radius_upper_xi = outer_dis(gen);
-  CAPTURE_PRECISE(random_outer_radius_upper_xi);
+  CAPTURE(random_outer_radius_upper_xi);
   const double random_outer_radius_upper_eta = outer_dis(gen);
-  CAPTURE_PRECISE(random_outer_radius_upper_eta);
+  CAPTURE(random_outer_radius_upper_eta);
   const double random_outer_radius_lower_xi = outer_dis(gen);
-  CAPTURE_PRECISE(random_outer_radius_lower_xi);
+  CAPTURE(random_outer_radius_lower_xi);
   const double random_outer_radius_lower_eta = outer_dis(gen);
-  CAPTURE_PRECISE(random_outer_radius_lower_eta);
+  CAPTURE(random_outer_radius_lower_eta);
 
   const CoordinateMaps::Wedge2D map_upper_xi(
       random_inner_radius_upper_xi, random_outer_radius_upper_xi, 0.0, 1.0,
@@ -111,13 +111,13 @@ void test_wedge2d_all_orientations(const bool with_equiangular_map) {
         approx(-random_inner_radius_lower_eta / sqrt(2.0)));
 
   const double inner_radius = inner_dis(gen);
-  CAPTURE_PRECISE(inner_radius);
+  CAPTURE(inner_radius);
   const double outer_radius = outer_dis(gen);
-  CAPTURE_PRECISE(outer_radius);
+  CAPTURE(outer_radius);
   const double inner_circularity = unit_dis(gen);
-  CAPTURE_PRECISE(inner_circularity);
+  CAPTURE(inner_circularity);
   const double outer_circularity = unit_dis(gen);
-  CAPTURE_PRECISE(outer_circularity);
+  CAPTURE(outer_circularity);
 
   for (OrientationMapIterator<2> map_i{}; map_i; ++map_i) {
     test_suite_for_map_on_unit_cube(CoordinateMaps::Wedge2D{

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
@@ -26,13 +26,13 @@ void test_wedge3d_all_directions() {
   std::uniform_real_distribution<> inner_dis(1, 3);
   std::uniform_real_distribution<> outer_dis(5.2, 7);
   const double inner_radius = inner_dis(gen);
-  CAPTURE_PRECISE(inner_radius);
+  CAPTURE(inner_radius);
   const double outer_radius = outer_dis(gen);
-  CAPTURE_PRECISE(outer_radius);
+  CAPTURE(outer_radius);
   const double inner_sphericity = unit_dis(gen);
-  CAPTURE_PRECISE(inner_sphericity);
+  CAPTURE(inner_sphericity);
   const double outer_sphericity = unit_dis(gen);
-  CAPTURE_PRECISE(outer_sphericity);
+  CAPTURE(outer_sphericity);
 
   using WedgeHalves = CoordinateMaps::Wedge3D::WedgeHalves;
   const std::array<WedgeHalves, 3> halves_array = {
@@ -167,30 +167,30 @@ void test_wedge3d_random_radii() {
   const std::array<double, 3> inner_corner{{-1.0, -1.0, -1.0}};
   const std::array<double, 3> outer_corner{{1.0, 1.0, 1.0}};
   const double random_inner_radius_lower_xi = inner_dis(gen);
-  CAPTURE_PRECISE(random_inner_radius_lower_xi);
+  CAPTURE(random_inner_radius_lower_xi);
   const double random_inner_radius_lower_eta = inner_dis(gen);
-  CAPTURE_PRECISE(random_inner_radius_lower_eta);
+  CAPTURE(random_inner_radius_lower_eta);
   const double random_inner_radius_lower_zeta = inner_dis(gen);
-  CAPTURE_PRECISE(random_inner_radius_lower_zeta);
+  CAPTURE(random_inner_radius_lower_zeta);
   const double random_inner_radius_upper_xi = inner_dis(gen);
-  CAPTURE_PRECISE(random_inner_radius_upper_xi);
+  CAPTURE(random_inner_radius_upper_xi);
   const double random_inner_radius_upper_eta = inner_dis(gen);
-  CAPTURE_PRECISE(random_inner_radius_upper_eta);
+  CAPTURE(random_inner_radius_upper_eta);
   const double random_inner_radius_upper_zeta = inner_dis(gen);
-  CAPTURE_PRECISE(random_inner_radius_upper_zeta);
+  CAPTURE(random_inner_radius_upper_zeta);
 
   const double random_outer_radius_lower_xi = outer_dis(gen);
-  CAPTURE_PRECISE(random_outer_radius_lower_xi);
+  CAPTURE(random_outer_radius_lower_xi);
   const double random_outer_radius_lower_eta = outer_dis(gen);
-  CAPTURE_PRECISE(random_outer_radius_lower_eta);
+  CAPTURE(random_outer_radius_lower_eta);
   const double random_outer_radius_lower_zeta = outer_dis(gen);
-  CAPTURE_PRECISE(random_outer_radius_lower_zeta);
+  CAPTURE(random_outer_radius_lower_zeta);
   const double random_outer_radius_upper_xi = outer_dis(gen);
-  CAPTURE_PRECISE(random_outer_radius_upper_xi);
+  CAPTURE(random_outer_radius_upper_xi);
   const double random_outer_radius_upper_eta = outer_dis(gen);
-  CAPTURE_PRECISE(random_outer_radius_upper_eta);
+  CAPTURE(random_outer_radius_upper_eta);
   const double random_outer_radius_upper_zeta = outer_dis(gen);
-  CAPTURE_PRECISE(random_outer_radius_upper_zeta);
+  CAPTURE(random_outer_radius_upper_zeta);
 
   using WedgeHalves = CoordinateMaps::Wedge3D::WedgeHalves;
   const auto wedge_directions = all_wedge_directions();
@@ -240,8 +240,8 @@ void test_wedge3d_random_radii() {
           {real_dis(gen), real_dis(gen), 1.0}};
       const std::array<double, 3> random_inner_face{
           {real_dis(gen), real_dis(gen), -1.0}};
-      CAPTURE_PRECISE(random_outer_face);
-      CAPTURE_PRECISE(random_inner_face);
+      CAPTURE(random_outer_face);
+      CAPTURE(random_inner_face);
 
       if (not with_logarithmic_map) {
         CHECK(map_lower_xi(random_inner_face)[0] ==

--- a/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
+++ b/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
@@ -164,7 +164,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
       CAPTURE(extents[i]);
       CHECK(expected_blocks.erase({location, extents[i]}) == 1);
     }
-    CAPTURE_PRECISE(expected_blocks);
+    CAPTURE(expected_blocks);
     CHECK(expected_blocks.empty());
   }
 
@@ -214,7 +214,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
       CAPTURE(refinement_levels[i]);
       CHECK(expected_blocks.erase({location, refinement_levels[i]}) == 1);
     }
-    CAPTURE_PRECISE(expected_blocks);
+    CAPTURE(expected_blocks);
     CHECK(expected_blocks.empty());
   }
 }

--- a/tests/Unit/Domain/Test_BlockAndElementLogicalCoordinates.cpp
+++ b/tests/Unit/Domain/Test_BlockAndElementLogicalCoordinates.cpp
@@ -58,7 +58,7 @@ void fuzzy_test_block_and_element_logical_coordinates(
     }
     return ids;
   }();
-  CAPTURE_PRECISE(element_ids);
+  CAPTURE(element_ids);
 
   // Random element logical coords for each point
   const auto element_coords = [&n_pts]() noexcept {
@@ -73,7 +73,7 @@ void fuzzy_test_block_and_element_logical_coordinates(
     }
     return coords;
   }();
-  CAPTURE_PRECISE(element_coords);
+  CAPTURE(element_coords);
 
   // Compute expected map of element_ids to ElementLogicalCoordHolders.
   // This is just re-organizing and re-bookkeeping element_ids and
@@ -197,7 +197,7 @@ void fuzzy_test_block_and_element_logical_coordinates_unrefined(
     }
     return ids;
   }();
-  CAPTURE_PRECISE(block_ids);
+  CAPTURE(block_ids);
 
   // Random block logical coords for each point
   // (block logical coords == element logical coords)
@@ -213,7 +213,7 @@ void fuzzy_test_block_and_element_logical_coordinates_unrefined(
     }
     return coords;
   }();
-  CAPTURE_PRECISE(block_coords);
+  CAPTURE(block_coords);
 
   // Map to inertial coords
   const auto inertial_coords = [

--- a/tests/Unit/Framework/TestingFramework.hpp
+++ b/tests/Unit/Framework/TestingFramework.hpp
@@ -34,23 +34,6 @@ void SPECTRE_TEST_REGISTER_FUNCTION() noexcept {}  // NOLINT
 #endif  // SPECTRE_TEST_REGISTER_FUNCTION
 /// \endcond
 
-namespace TestHelpers_detail {
-template <typename T>
-std::string format_capture_precise(const T& t) noexcept {
-  std::ostringstream os;
-  os << std::scientific << std::setprecision(18) << t;
-  return os.str();
-}
-}  // namespace TestHelpers_detail
-
-/*!
- * \ingroup TestingFrameworkGroup
- * \brief Alternative to Catch's CAPTURE that prints more digits.
- */
-#define CAPTURE_PRECISE(variable) \
-  INFO(#variable << ": "          \
-                 << TestHelpers_detail::format_capture_precise(variable))
-
 /*!
  * \ingroup TestingFrameworkGroup
  * \brief A replacement for Catch's TEST_CASE that silences clang-tidy warnings
@@ -161,8 +144,6 @@ template <typename T, typename = std::nullptr_t>
 struct check_iterable_approx {
   // clang-tidy: non-const reference
   static void apply(const T& a, const T& b, Approx& appx = approx) {  // NOLINT
-    CAPTURE_PRECISE(a);
-    CAPTURE_PRECISE(b);
     CHECK(a == appx(b));
   }
 };
@@ -183,8 +164,8 @@ struct check_iterable_approx<
                 not tt::is_a_v<std::unordered_set, T>>> {
   // clang-tidy: non-const reference
   static void apply(const T& a, const T& b, Approx& appx = approx) {  // NOLINT
-    CAPTURE_PRECISE(a);
-    CAPTURE_PRECISE(b);
+    CAPTURE(a);
+    CAPTURE(b);
     auto a_it = a.begin();
     auto b_it = b.begin();
     CHECK(a_it != a.end());
@@ -211,8 +192,6 @@ struct check_iterable_approx<T, Requires<tt::is_a_v<std::unordered_set, T>>> {
   // clang-tidy: non-const reference
   static void apply(const T& a, const T& b,
                     Approx& /*appx*/ = approx) {  // NOLINT
-    CAPTURE_PRECISE(a);
-    CAPTURE_PRECISE(b);
     // Approximate comparison of unordered sets is difficult
     CHECK(a == b);
   }
@@ -223,8 +202,8 @@ struct check_iterable_approx<
     T, Requires<tt::is_maplike_v<T> and tt::is_iterable_v<T>>> {
   // clang-tidy: non-const reference
   static void apply(const T& a, const T& b, Approx& appx = approx) {  // NOLINT
-    CAPTURE_PRECISE(a);
-    CAPTURE_PRECISE(b);
+    CAPTURE(a);
+    CAPTURE(b);
     for (const auto& kv : a) {
       const auto& key = kv.first;
       try {
@@ -278,8 +257,8 @@ struct check_matrix_approx {
     // column, and takes its index as argument.
     CHECK(a.columns() == b.columns());
     for (size_t j = 0; j < a.columns(); j++) {
-      CAPTURE_PRECISE(a);
-      CAPTURE_PRECISE(b);
+      CAPTURE(a);
+      CAPTURE(b);
       auto a_it = a.cbegin(j);
       auto b_it = b.cbegin(j);
       CHECK(a_it != a.cend(j));

--- a/tests/Unit/Framework/Tests/Test_TestHelpers.cpp
+++ b/tests/Unit/Framework/Tests/Test_TestHelpers.cpp
@@ -73,13 +73,6 @@ SPECTRE_TEST_CASE("Unit.TestHelpers", "[Unit]") {
   vecmap_b[1][1] += 1e-12;
   CHECK_ITERABLE_CUSTOM_APPROX(vecmap_a, vecmap_b, larger_approx);
 
-  // Check that CAPTURE_PRECISE accepts an STL type (we cannot test
-  // the output because that is only produced on a Catch failure,
-  // which would fail the test.
-  {
-    CAPTURE_PRECISE((std::array<double, 1>{{1.5}}));
-  }
-
   // Check that CHECK_ITERABLE_APPROX works on various containers
   {
     const std::set<int> a{1, 2, 3};

--- a/tests/Unit/Helpers/DataStructures/VectorImplTestHelper.hpp
+++ b/tests/Unit/Helpers/DataStructures/VectorImplTestHelper.hpp
@@ -57,7 +57,7 @@ void vector_test_construct_and_assign(
   alg::for_each(value_size_constructed, [
     generated_value1, &value_size_constructed
   ](typename VectorType::value_type element) noexcept {
-    CAPTURE_PRECISE(value_size_constructed);
+    CAPTURE(value_size_constructed);
     CHECK(element == generated_value1);
   });
 

--- a/tests/Unit/Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -69,7 +69,7 @@ void check_if_maps_are_equal(
     for (size_t d = 0; d < VolumeDim; ++d) {
       source_point.get(d) = real_dis(gen);
     }
-    CAPTURE_PRECISE(source_point);
+    CAPTURE(source_point);
     CHECK_ITERABLE_APPROX(map_one(source_point, time, functions_of_time),
                           map_two(source_point, time, functions_of_time));
     CHECK_ITERABLE_APPROX(
@@ -258,10 +258,6 @@ void test_coordinate_map_implementation(const Map& map) noexcept {
     }
     return p;
   }();
-
-  for (size_t i = 0; i < Map::dim; ++i) {
-    CAPTURE_PRECISE(gsl::at(test_point, i));
-  }
 
   const auto test_point_tensor = [&test_point]() {
     tnsr::I<double, Map::dim, Frame::Logical> point_as_tensor{};
@@ -477,11 +473,11 @@ void test_suite_for_map_on_sphere(
   std::uniform_real_distribution<> phi_dis(0, 2.0 * M_PI);
 
   const double theta = theta_dis(gen);
-  CAPTURE_PRECISE(theta);
+  CAPTURE(theta);
   const double phi = phi_dis(gen);
-  CAPTURE_PRECISE(phi);
+  CAPTURE(phi);
   const double radius = radius_dis(gen);
-  CAPTURE_PRECISE(radius);
+  CAPTURE(radius);
 
   const std::array<double, 3> random_point{{radius * sin(theta) * cos(phi),
                                             radius * sin(theta) * sin(phi),

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_CubicSpline.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_CubicSpline.cpp
@@ -87,8 +87,8 @@ void test_cubic_spline(const F& function, const double lower_bound,
   }
   // Output information on the precision the interpolation achieved when it
   // failed to stay within the given tolerances
-  CAPTURE_PRECISE(max_error);
-  CAPTURE_PRECISE(max_error_interior);
+  CAPTURE(max_error);
+  CAPTURE(max_error_interior);
   // These checks are needed to trigger the max_error captures above
   CHECK(interpolant(max_error_x_value) ==
         custom_approx(function(max_error_x_value)));

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
@@ -148,8 +148,6 @@ void test_divergence_impl(
   CHECK(Dim * div_fluxes.size() == fluxes.size());
   for (size_t n = 0; n < div_fluxes.size(); ++n) {
     // clang-tidy: pointer arithmetic
-    CAPTURE_PRECISE(div_fluxes.data()[n] -                         // NOLINT
-                    expected_div_fluxes.data()[n]);                // NOLINT
     CHECK(div_fluxes.data()[n] ==                                  // NOLINT
           approx(expected_div_fluxes.data()[n]).epsilon(1.e-11));  // NOLINT
   }
@@ -257,8 +255,6 @@ void test_divergence_compute_item_impl(
   CHECK(div_fluxes.size() == expected_div_fluxes.size());
   for (size_t n = 0; n < div_fluxes.size(); ++n) {
     // clang-tidy: pointer arithmetic
-    CAPTURE_PRECISE(div_fluxes.data()[n] -                         // NOLINT
-                    expected_div_fluxes.data()[n]);                // NOLINT
     CHECK(div_fluxes.data()[n] ==                                  // NOLINT
           approx(expected_div_fluxes.data()[n]).epsilon(1.e-11));  // NOLINT
   }

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -277,7 +277,6 @@ void test_partial_derivatives_1d(const Mesh<1>& mesh) {
 
     const auto helper = [&](const auto& du) noexcept {
       for (size_t n = 0; n < du.size(); ++n) {
-        CAPTURE_PRECISE(du.data()[n] - expected_du.data()[n]);  // NOLINT
         CHECK(du.data()[n] == approx(expected_du.data()[n]));   // NOLINT
       }
     };
@@ -328,7 +327,6 @@ void test_partial_derivatives_2d(const Mesh<2>& mesh) {
 
       const auto helper = [&](const auto& du) noexcept {
         for (size_t n = 0; n < du.size(); ++n) {
-          CAPTURE_PRECISE(du.data()[n] - expected_du.data()[n]);  // NOLINT
           CHECK(du.data()[n] ==                                   // NOLINT
                 approx(expected_du.data()[n]).epsilon(1.e-13));   // NOLINT
         }
@@ -385,7 +383,6 @@ void test_partial_derivatives_3d(const Mesh<3>& mesh) {
 
         const auto helper = [&](const auto& du) noexcept {
           for (size_t n = 0; n < du.size(); ++n) {
-            CAPTURE_PRECISE(du.data()[n] - expected_du.data()[n]);  // NOLINT
             CHECK(du.data()[n] ==                                   // NOLINT
                   approx(expected_du.data()[n]).epsilon(1.e-11));
           }
@@ -541,7 +538,6 @@ void test_partial_derivatives_compute_item(
 
   for (size_t n = 0; n < du.size(); ++n) {
     // clang-tidy: pointer arithmetic
-    CAPTURE_PRECISE(du.data()[n] - expected_du.data()[n]);  // NOLINT
     CHECK(du.data()[n] == approx(expected_du.data()[n]));   // NOLINT
   }
 

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Test_Lapack.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Test_Lapack.cpp
@@ -41,12 +41,12 @@ void test_square_general_matrix_linear_solve(
   for (size_t i = 0; i < rows; ++i) {
     operator_matrix(i, i) += 1.0;
   }
-  CAPTURE_PRECISE(operator_matrix);
+  CAPTURE(operator_matrix);
   // the vector b
   auto input_vector = apply_matrices<DataVector, Matrix>(
       {{operator_matrix, Matrix{}}}, expected_solution_vector,
       Index<2>{rows, number_of_rhs});
-  CAPTURE_PRECISE(input_vector);
+  CAPTURE(input_vector);
   // version which copies the matrix, and preserves the input
   DataVector solution_vector{number_of_rhs * rows, 0.0};
   lapack::general_matrix_linear_solve(make_not_null(&solution_vector),

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Filtering.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Filtering.cpp
@@ -110,7 +110,6 @@ void test_zero_lowest_modes() noexcept {
           to_modal_coefficients(filtered_nodal_coeffs, mesh);
       for (size_t i = 0; i < num_pts; ++i) {
         CAPTURE(i);
-        CAPTURE_PRECISE(filtered_modal_coeffs[i]);
         if (i < number_of_modes_to_filter) {
           CHECK(fabs(filtered_modal_coeffs[i]) < 1.0e-13);
         } else {

--- a/tests/Unit/RunTests.cpp
+++ b/tests/Unit/RunTests.cpp
@@ -10,6 +10,7 @@
 #include <charm++.h>
 #include <cstddef>
 #include <exception>
+#include <limits>
 #include <memory>
 #include <string>
 
@@ -27,6 +28,10 @@ RunTests::RunTests(CkArgMsg* msg) {
   register_run_tests_libs();
   Parallel::printf("%s", info_from_build().c_str());
   enable_floating_point_exceptions();
+  Catch::StringMaker<double>::precision =
+      std::numeric_limits<double>::max_digits10;
+  Catch::StringMaker<float>::precision =
+      std::numeric_limits<float>::max_digits10;
   const int result = Catch::Session().run(msg->argc, msg->argv);
   // In the case where we run all the non-failure tests at once we must ensure
   // that we only initialize and finalize the python env once. Initialization is

--- a/tests/Unit/Time/Triggers/Test_NearTimes.cpp
+++ b/tests/Unit/Time/Triggers/Test_NearTimes.cpp
@@ -40,12 +40,12 @@ SPECTRE_TEST_CASE("Unit.Time.Triggers.NearTimes", "[Unit][Time]") {
       const auto check_calls = [&direction, &expected, &range, &unit](
           std::vector<double> trigger_times, const double time,
           const TimeDelta& time_step) noexcept {
-        CAPTURE_PRECISE(trigger_times);
-        CAPTURE_PRECISE(range);
-        CAPTURE_PRECISE(static_cast<int>(unit));
-        CAPTURE_PRECISE(static_cast<int>(direction));
-        CAPTURE_PRECISE(time);
-        CAPTURE_PRECISE(time_step);
+        CAPTURE(trigger_times);
+        CAPTURE(range);
+        CAPTURE(static_cast<int>(unit));
+        CAPTURE(static_cast<int>(direction));
+        CAPTURE(time);
+        CAPTURE(time_step);
         const std::unique_ptr<TriggerType> trigger =
             std::make_unique<Triggers::NearTimes<>>(
                 std::make_unique<TimeSequences::Specified<double>>(

--- a/tests/Unit/Time/Triggers/Test_Times.cpp
+++ b/tests/Unit/Time/Triggers/Test_Times.cpp
@@ -32,9 +32,9 @@ SPECTRE_TEST_CASE("Unit.Time.Triggers.Times", "[Unit][Time]") {
   const auto check = [](const double time, const double slab_size,
                         const std::vector<double>& trigger_times,
                         const bool expected) noexcept {
-    CAPTURE_PRECISE(time);
-    CAPTURE_PRECISE(slab_size);
-    CAPTURE_PRECISE(trigger_times);
+    CAPTURE(time);
+    CAPTURE(slab_size);
+    CAPTURE(trigger_times);
     const auto slab = Slab::with_duration_from_start(0.8 * time, slab_size);
     // None of the arguments here should matter, except that they are
     // based on the correct slab.

--- a/tests/Unit/Utilities/Test_FractionUtilities.cpp
+++ b/tests/Unit/Utilities/Test_FractionUtilities.cpp
@@ -62,7 +62,6 @@ SPECTRE_TEST_CASE("Unit.Utilities.FractionUtilities.ContinuedFraction",
   {
     std::uniform_real_distribution<> dist(-10., 10.);
     const double value = dist(gen);
-    CAPTURE_PRECISE(value);
     // Set the scale because the fractional part of a negative number
     // (defined as `x - floor(x)`) can be larger than the number.
     auto approx_value = approx.scale(std::abs(std::floor(value)))(value);
@@ -74,8 +73,8 @@ SPECTRE_TEST_CASE("Unit.Utilities.FractionUtilities.ContinuedFraction",
       summer.insert(*source);
       terms.push_back(*source);
       convergents.push_back(boost::rational_cast<double>(summer.value()));
-      CAPTURE_PRECISE(terms);
-      CAPTURE_PRECISE(convergents);
+      CAPTURE(terms);
+      CAPTURE(convergents);
 
       // Convergents to a continued fraction always alternate between
       // over- and underestimates.
@@ -88,8 +87,8 @@ SPECTRE_TEST_CASE("Unit.Utilities.FractionUtilities.ContinuedFraction",
       }
       should_be_smaller = !should_be_smaller;
     }
-    CAPTURE_PRECISE(terms);
-    CAPTURE_PRECISE(convergents);
+    CAPTURE(terms);
+    CAPTURE(convergents);
     CHECK(convergents.back() == approx_value);
   }
 }


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
