### PR TITLE
Remove TensorIndex type aliases

### DIFF
--- a/src/DataStructures/Tensor/Expressions/Contract.hpp
+++ b/src/DataStructures/Tensor/Expressions/Contract.hpp
@@ -319,12 +319,13 @@ struct TensorContract
   /// pair of indices being contracted into the list of contracted LHS
   /// TensorIndexs
   ///
-  /// Example: If we contract RHS tensor \f$R^{a}{}_{bac}\f$ to LHS tensor
-  /// \f$L_{cb}\f$, the RHS list of generic indices (`ArgsList`) is
-  /// `tmpl::list<ti_A_t, ti_b_t, ti_a_t, ti_c_t>` and the LHS generic indices
-  /// (`LhsIndices`) are `ti_c_t, ti_b_t`. `ti_A_t` and `ti_a_t` are inserted
-  /// into `LhsIndices` at their positions from the RHS, which yields:
-  /// `tmpl::list<ti_A_t, ti_c_t, ti_a_t, ti_b_t>`.
+  /// Example: Let `ti_a_t` denote the type of `ti_a`, and apply the same
+  /// convention for other generic indices. If we contract RHS tensor
+  /// \f$R^{a}{}_{bac}\f$ to LHS tensor \f$L_{cb}\f$, the RHS list of generic
+  /// indices (`ArgsList`) is `tmpl::list<ti_A_t, ti_b_t, ti_a_t, ti_c_t>` and
+  /// the LHS generic indices (`LhsIndices`) are `ti_c_t, ti_b_t`. `ti_A_t` and
+  /// `ti_a_t` are inserted into `LhsIndices` at their positions from the RHS,
+  /// which yields: `tmpl::list<ti_A_t, ti_c_t, ti_a_t, ti_b_t>`.
   template <typename... LhsIndices>
   using get_uncontracted_lhs_tensorindex_list = tmpl::append<
       tmpl::front<tmpl::split_at<
@@ -423,8 +424,7 @@ struct TensorContract
   /// to sum for each contracted LHS component's storage index.
   ///
   /// \tparam LhsStructure the Structure of the contracted LHS tensor
-  /// \tparam LhsIndices the TensorIndexs of the contracted LHS tensor, e.g.
-  /// `ti_a_t`, `ti_b_t`, `ti_c_t`
+  /// \tparam LhsIndices the TensorIndexs of the contracted LHS tensor
   /// \param lhs_storage_index the storage index of the contracted LHS tensor
   /// component to retrieve
   /// \return the value of the component at `lhs_storage_index` in the
@@ -473,13 +473,13 @@ struct TensorContract
  * \details Given a list of values that represent an expression's generic index
  * encodings, this function looks to see if it can find a pair of values that
  * encode one generic index and the generic index with opposite valence, such as
- * `ti_A_t` and `ti_a_t`. This denotes a pair of indices that will need to be
+ * `ti_A` and `ti_a`. This denotes a pair of indices that will need to be
  * contracted. If there exists more than one such pair of indices in the
  * expression, the first pair of values found will be returned.
  *
  * For example, if we have tensor \f$R^{ab}{}_{ab}\f$ represented by the tensor
  * expression, `R(ti_A, ti_B, ti_a, ti_b)`, then this will return the positions
- * of the pair of values encoding `ti_A_t` and `ti_a_t`, which would be (0, 2)
+ * of the pair of values encoding `ti_A` and `ti_a`, which would be (0, 2)
  *
  * @param tensorindex_values the TensorIndex values of a tensor expression
  * @return the positions of the first pair of TensorIndex values to contract

--- a/src/DataStructures/Tensor/Expressions/LhsTensorSymmAndIndices.hpp
+++ b/src/DataStructures/Tensor/Expressions/LhsTensorSymmAndIndices.hpp
@@ -25,9 +25,9 @@ namespace TensorExpressions {
  * \ref SpacetimeIndex "TensorIndexType"s.
  *
  * @tparam RhsTensorIndexList the typelist of TensorIndex of the RHS
- * TensorExpression, e.g. `ti_a_t`, `ti_b_t`, `ti_c_t`
+ * TensorExpression
  * @tparam LhsTensorIndexList the typelist of TensorIndexs of the desired LHS
- * tensor, e.g. `ti_b_t`, `ti_c_t`, `ti_a_t`
+ * tensor
  * @tparam RhsSymmetry the ::Symmetry of the RHS indices
  * @tparam RhsTensorIndexTypeList the RHS TensorExpression's typelist of
  * \ref SpacetimeIndex "TensorIndexType"s

--- a/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
@@ -56,11 +56,12 @@ static constexpr size_t max_sentinel = 2000;
  * Used to denote a tensor index in a tensor slot. This allows the following
  * type of expressions to work:
  * \code{.cpp}
- * auto T = evaluate<ti_a_t, ti_b_t>(F(ti_a, ti_b) + S(ti_b, ti_a));
+ * auto T = evaluate<ti_a, ti_b>(F(ti_a, ti_b) + S(ti_b, ti_a));
  * \endcode
- * where `using ti_a_t = TensorIndex<0>;` and `TensorIndex<0> ti_a;`, that is,
- * `ti_a` and `ti_b` are place holders for objects of type `TensorIndex<0>` and
- * `TensorIndex<1>` respectively.
+ * where `decltype(ti_a) == TensorIndex<0>` and
+ * `decltype(ti_b) == TensorIndex<1>`. That is, `ti_a` and `ti_b` are
+ * placeholders for objects of type `TensorIndex<0>` and `TensorIndex<1>`,
+ * respectively.
  */
 template <std::size_t I, Requires<(I < max_sentinel)> = nullptr>
 struct TensorIndex {
@@ -84,10 +85,9 @@ struct TensorIndex {
  * spatial. This function returns the value that corresponds to the encoding of
  * the TensorIndex with the same index type, but opposite valence.
  *
- * For example, 0 is the TensorIndex value for `ti_a_t`. If `i == 0`,
- * then 500 will be returned, which is the TensorIndex value for `ti_A_t`.
- * If `i == 500` (representing `ti_A_t`), then 0 (representing `ti_a_t`) is
- * returned.
+ * For example, 0 is the TensorIndex value for `ti_a`. If `i == 0`, then 500
+ * will be returned, which is the TensorIndex value for `ti_A`. If `i == 500`
+ * (representing `ti_A`), then 0 (representing `ti_a`) is returned.
  *
  * @param i a TensorIndex value that represents a generic index
  * @return the TensorIndex value that encodes the generic index with the
@@ -114,55 +114,30 @@ get_tensorindex_value_with_opposite_valence(const size_t i) noexcept {
  * Available tensor indices to use in a Tensor Expression.
  * \snippet Test_AddSubtract.cpp use_tensor_index
  */
-static TensorIndex<0> ti_a{};
-static TensorIndex<upper_sentinel> ti_A{};
-static TensorIndex<1> ti_b{};
-static TensorIndex<upper_sentinel + 1> ti_B{};
-static TensorIndex<2> ti_c{};
-static TensorIndex<upper_sentinel + 2> ti_C{};
-static TensorIndex<3> ti_d{};
-static TensorIndex<upper_sentinel + 3> ti_D{};
-static TensorIndex<4> ti_e{};
-static TensorIndex<upper_sentinel + 4> ti_E{};
-static TensorIndex<5> ti_f{};
-static TensorIndex<upper_sentinel + 5> ti_F{};
-static TensorIndex<6> ti_g{};
-static TensorIndex<upper_sentinel + 6> ti_G{};
-static TensorIndex<7> ti_h{};
-static TensorIndex<upper_sentinel + 7> ti_H{};
-static TensorIndex<spatial_sentinel> ti_i{};
-static TensorIndex<upper_spatial_sentinel> ti_I{};
-static TensorIndex<spatial_sentinel + 1> ti_j{};
-static TensorIndex<upper_spatial_sentinel + 1> ti_J{};
-static TensorIndex<spatial_sentinel + 2> ti_k{};
-static TensorIndex<upper_spatial_sentinel + 2> ti_K{};
-static TensorIndex<spatial_sentinel + 3> ti_l{};
-static TensorIndex<upper_spatial_sentinel + 3> ti_L{};
-
-using ti_a_t = decltype(ti_a);
-using ti_A_t = decltype(ti_A);
-using ti_b_t = decltype(ti_b);
-using ti_B_t = decltype(ti_B);
-using ti_c_t = decltype(ti_c);
-using ti_C_t = decltype(ti_C);
-using ti_d_t = decltype(ti_d);
-using ti_D_t = decltype(ti_D);
-using ti_e_t = decltype(ti_e);
-using ti_E_t = decltype(ti_E);
-using ti_f_t = decltype(ti_f);
-using ti_F_t = decltype(ti_F);
-using ti_g_t = decltype(ti_g);
-using ti_G_t = decltype(ti_G);
-using ti_h_t = decltype(ti_h);
-using ti_H_t = decltype(ti_H);
-using ti_i_t = decltype(ti_i);
-using ti_I_t = decltype(ti_I);
-using ti_j_t = decltype(ti_j);
-using ti_J_t = decltype(ti_J);
-using ti_k_t = decltype(ti_k);
-using ti_K_t = decltype(ti_K);
-using ti_l_t = decltype(ti_l);
-using ti_L_t = decltype(ti_L);
+static constexpr TensorIndex<0> ti_a{};
+static constexpr TensorIndex<upper_sentinel> ti_A{};
+static constexpr TensorIndex<1> ti_b{};
+static constexpr TensorIndex<upper_sentinel + 1> ti_B{};
+static constexpr TensorIndex<2> ti_c{};
+static constexpr TensorIndex<upper_sentinel + 2> ti_C{};
+static constexpr TensorIndex<3> ti_d{};
+static constexpr TensorIndex<upper_sentinel + 3> ti_D{};
+static constexpr TensorIndex<4> ti_e{};
+static constexpr TensorIndex<upper_sentinel + 4> ti_E{};
+static constexpr TensorIndex<5> ti_f{};
+static constexpr TensorIndex<upper_sentinel + 5> ti_F{};
+static constexpr TensorIndex<6> ti_g{};
+static constexpr TensorIndex<upper_sentinel + 6> ti_G{};
+static constexpr TensorIndex<7> ti_h{};
+static constexpr TensorIndex<upper_sentinel + 7> ti_H{};
+static constexpr TensorIndex<spatial_sentinel> ti_i{};
+static constexpr TensorIndex<upper_spatial_sentinel> ti_I{};
+static constexpr TensorIndex<spatial_sentinel + 1> ti_j{};
+static constexpr TensorIndex<upper_spatial_sentinel + 1> ti_J{};
+static constexpr TensorIndex<spatial_sentinel + 2> ti_k{};
+static constexpr TensorIndex<upper_spatial_sentinel + 2> ti_K{};
+static constexpr TensorIndex<spatial_sentinel + 3> ti_l{};
+static constexpr TensorIndex<upper_spatial_sentinel + 3> ti_L{};
 // @}
 
 namespace tt {
@@ -538,7 +513,7 @@ struct TensorExpression<Derived, DataType, Symm, tmpl::list<Indices...>,
   /// \tparam LhsStructure the Structure of the Tensor on the LHS of the
   /// TensorExpression
   /// \tparam LhsIndices the TensorIndexs of the Tensor on the LHS of the tensor
-  /// expression, e.g. `ti_a_t`, `ti_b_t`, `ti_c_t`
+  /// expression
   /// \param lhs_storage_index the storage index of the LHS tensor component to
   /// retrieve
   /// \return the value of the DataType of the component at `lhs_storage_index`

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubtract.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubtract.cpp
@@ -32,11 +32,11 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
       Hll{};
   std::iota(Hll.begin(), Hll.end(), 0.0);
   /// [use_tensor_index]
-  auto Gll = TensorExpressions::evaluate<ti_a_t, ti_b_t>(All(ti_a, ti_b) +
-                                                         Hll(ti_a, ti_b));
-  auto Gll2 = TensorExpressions::evaluate<ti_a_t, ti_b_t>(All(ti_a, ti_b) +
-                                                          Hll(ti_b, ti_a));
-  auto Gll3 = TensorExpressions::evaluate<ti_a_t, ti_b_t>(
+  auto Gll = TensorExpressions::evaluate<ti_a, ti_b>(All(ti_a, ti_b) +
+                                                     Hll(ti_a, ti_b));
+  auto Gll2 = TensorExpressions::evaluate<ti_a, ti_b>(All(ti_a, ti_b) +
+                                                      Hll(ti_b, ti_a));
+  auto Gll3 = TensorExpressions::evaluate<ti_a, ti_b>(
       All(ti_a, ti_b) + Hll(ti_b, ti_a) + All(ti_b, ti_a) - Hll(ti_b, ti_a));
   /// [use_tensor_index]
   for (int i = 0; i < 4; ++i) {
@@ -59,11 +59,11 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
                     SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
       Hlll{};
   std::iota(Hlll.begin(), Hlll.end(), 0.0);
-  auto Glll = TensorExpressions::evaluate<ti_a_t, ti_b_t, ti_c_t>(
+  auto Glll = TensorExpressions::evaluate<ti_a, ti_b, ti_c>(
       Alll(ti_a, ti_b, ti_c) + Hlll(ti_a, ti_b, ti_c));
-  auto Glll2 = TensorExpressions::evaluate<ti_a_t, ti_b_t, ti_c_t>(
+  auto Glll2 = TensorExpressions::evaluate<ti_a, ti_b, ti_c>(
       Alll(ti_a, ti_b, ti_c) + Hlll(ti_b, ti_a, ti_c));
-  auto Glll3 = TensorExpressions::evaluate<ti_a_t, ti_b_t, ti_c_t>(
+  auto Glll3 = TensorExpressions::evaluate<ti_a, ti_b, ti_c>(
       Alll(ti_a, ti_b, ti_c) + Hlll(ti_b, ti_a, ti_c) + Alll(ti_b, ti_a, ti_c) -
       Hlll(ti_b, ti_a, ti_c));
   for (int i = 0; i < 4; ++i) {

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Contract.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Contract.cpp
@@ -93,7 +93,7 @@ void test_contractions_rank3(const DataType& used_for_size) noexcept {
   const auto RiIj_expr = Rlul(ti_i, ti_I, ti_j);
   const Tensor<DataType, Symmetry<1>,
                index_list<SpatialIndex<4, UpLo::Lo, Frame::Grid>>>
-      RiIj_contracted = TensorExpressions::evaluate<ti_j_t>(RiIj_expr);
+      RiIj_contracted = TensorExpressions::evaluate<ti_j>(RiIj_expr);
 
   for (size_t j = 0; j < 4; j++) {
     DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
@@ -119,7 +119,7 @@ void test_contractions_rank3(const DataType& used_for_size) noexcept {
   const auto RJLj_expr = Ruul(ti_J, ti_L, ti_j);
   const Tensor<DataType, Symmetry<1>,
                index_list<SpatialIndex<3, UpLo::Up, Frame::Grid>>>
-      RJLj_contracted = TensorExpressions::evaluate<ti_L_t>(RJLj_expr);
+      RJLj_contracted = TensorExpressions::evaluate<ti_L>(RJLj_expr);
 
   for (size_t l = 0; l < 3; l++) {
     DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
@@ -145,7 +145,7 @@ void test_contractions_rank3(const DataType& used_for_size) noexcept {
   const auto RBfF_expr = Rulu(ti_B, ti_f, ti_F);
   const Tensor<DataType, Symmetry<1>,
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>>
-      RBfF_contracted = TensorExpressions::evaluate<ti_B_t>(RBfF_expr);
+      RBfF_contracted = TensorExpressions::evaluate<ti_B>(RBfF_expr);
 
   for (size_t b = 0; b < 4; b++) {
     DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
@@ -172,7 +172,7 @@ void test_contractions_rank3(const DataType& used_for_size) noexcept {
   const auto RiaI_expr = Rllu(ti_i, ti_a, ti_I);
   const Tensor<DataType, Symmetry<1>,
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
-      RiaI_contracted = TensorExpressions::evaluate<ti_a_t>(RiaI_expr);
+      RiaI_contracted = TensorExpressions::evaluate<ti_a>(RiaI_expr);
 
   for (size_t a = 0; a < 4; a++) {
     DataType expected_sum = make_with_value<DataType>(used_for_size, 0.0);
@@ -207,7 +207,7 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
                index_list<SpatialIndex<4, UpLo::Up, Frame::Inertial>,
                           SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
       RiIKj_contracted =
-          TensorExpressions::evaluate<ti_K_t, ti_j_t>(RiIKj_expr);
+          TensorExpressions::evaluate<ti_K, ti_j>(RiIKj_expr);
 
   for (size_t k = 0; k < 4; k++) {
     for (size_t j = 0; j < 3; j++) {
@@ -239,7 +239,7 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                           SpacetimeIndex<4, UpLo::Lo, Frame::Grid>>>
       RABac_contracted =
-          TensorExpressions::evaluate<ti_B_t, ti_c_t>(RABac_expr);
+          TensorExpressions::evaluate<ti_B, ti_c>(RABac_expr);
 
   for (size_t b = 0; b < 4; b++) {
     for (size_t c = 0; c < 5; c++) {
@@ -271,7 +271,7 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
                index_list<SpatialIndex<4, UpLo::Up, Frame::Grid>,
                           SpatialIndex<3, UpLo::Up, Frame::Grid>>>
       RLJIl_contracted =
-          TensorExpressions::evaluate<ti_J_t, ti_I_t>(RLJIl_expr);
+          TensorExpressions::evaluate<ti_J, ti_I>(RLJIl_expr);
 
   for (size_t j = 0; j < 4; j++) {
     for (size_t i = 0; i < 3; i++) {
@@ -303,7 +303,7 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>
       REDdA_contracted =
-          TensorExpressions::evaluate<ti_E_t, ti_A_t>(REDdA_expr);
+          TensorExpressions::evaluate<ti_E, ti_A>(REDdA_expr);
 
   for (size_t e = 0; e < 4; e++) {
     for (size_t a = 0; a < 4; a++) {
@@ -335,7 +335,7 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
                index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
                           SpatialIndex<4, UpLo::Lo, Frame::Inertial>>>
       RkJij_contracted =
-          TensorExpressions::evaluate<ti_k_t, ti_i_t>(RkJij_expr);
+          TensorExpressions::evaluate<ti_k, ti_i>(RkJij_expr);
 
   for (size_t k = 0; k < 3; k++) {
     for (size_t i = 0; i < 4; i++) {
@@ -367,7 +367,7 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
                index_list<SpacetimeIndex<4, UpLo::Up, Frame::Inertial>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>
       RFcgG_contracted =
-          TensorExpressions::evaluate<ti_F_t, ti_c_t>(RFcgG_expr);
+          TensorExpressions::evaluate<ti_F, ti_c>(RFcgG_expr);
 
   for (size_t f = 0; f < 5; f++) {
     for (size_t c = 0; c < 4; c++) {
@@ -399,7 +399,7 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
                index_list<SpatialIndex<2, UpLo::Up, Frame::Grid>,
                           SpatialIndex<3, UpLo::Up, Frame::Grid>>>
       RKkIJ_contracted_to_JI =
-          TensorExpressions::evaluate<ti_J_t, ti_I_t>(RKkIJ_expr);
+          TensorExpressions::evaluate<ti_J, ti_I>(RKkIJ_expr);
 
   for (size_t j = 0; j < 2; j++) {
     for (size_t i = 0; i < 3; i++) {
@@ -431,7 +431,7 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
                index_list<SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
                           SpacetimeIndex<2, UpLo::Up, Frame::Grid>>>
       RbCBE_contracted_to_EC =
-          TensorExpressions::evaluate<ti_E_t, ti_C_t>(RbCBE_expr);
+          TensorExpressions::evaluate<ti_E, ti_C>(RbCBE_expr);
 
   for (size_t e = 0; e < 3; e++) {
     for (size_t c = 0; c < 3; c++) {
@@ -463,7 +463,7 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
                index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
       RAdba_contracted_to_bd =
-          TensorExpressions::evaluate<ti_b_t, ti_d_t>(RAdba_expr);
+          TensorExpressions::evaluate<ti_b, ti_d>(RAdba_expr);
 
   for (size_t b = 0; b < 4; b++) {
     for (size_t d = 0; d < 4; d++) {
@@ -495,7 +495,7 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
                index_list<SpatialIndex<4, UpLo::Lo, Frame::Grid>,
                           SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
       RljJi_contracted_to_il =
-          TensorExpressions::evaluate<ti_i_t, ti_l_t>(RljJi_expr);
+          TensorExpressions::evaluate<ti_i, ti_l>(RljJi_expr);
 
   for (size_t i = 0; i < 4; i++) {
     for (size_t l = 0; l < 3; l++) {
@@ -527,7 +527,7 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
                index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
                           SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>
       RagDG_contracted_to_Da =
-          TensorExpressions::evaluate<ti_D_t, ti_a_t>(RagDG_expr);
+          TensorExpressions::evaluate<ti_D, ti_a>(RagDG_expr);
 
   for (size_t d = 0; d < 4; d++) {
     for (size_t a = 0; a < 4; a++) {
@@ -559,7 +559,7 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
                index_list<SpatialIndex<3, UpLo::Up, Frame::Inertial>,
                           SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
       RlJiI_contracted_to_Jl =
-          TensorExpressions::evaluate<ti_J_t, ti_l_t>(RlJiI_expr);
+          TensorExpressions::evaluate<ti_J, ti_l>(RlJiI_expr);
 
   for (size_t j = 0; j < 3; j++) {
     for (size_t l = 0; l < 3; l++) {

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_TensorExpressions.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_TensorExpressions.cpp
@@ -30,150 +30,150 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Evaluate",
 
   // Rank 1: double; spacetime
   TestHelpers::TensorExpressions::test_evaluate_rank_1<double, SpacetimeIndex,
-                                                       UpLo::Lo>(ti_a);
+                                                       UpLo::Lo, ti_a>();
   TestHelpers::TensorExpressions::test_evaluate_rank_1<double, SpacetimeIndex,
-                                                       UpLo::Lo>(ti_b);
+                                                       UpLo::Lo, ti_b>();
   TestHelpers::TensorExpressions::test_evaluate_rank_1<double, SpacetimeIndex,
-                                                       UpLo::Up>(ti_A);
+                                                       UpLo::Up, ti_A>();
   TestHelpers::TensorExpressions::test_evaluate_rank_1<double, SpacetimeIndex,
-                                                       UpLo::Up>(ti_B);
+                                                       UpLo::Up, ti_B>();
 
   // Rank 1: double; spatial
   TestHelpers::TensorExpressions::test_evaluate_rank_1<double, SpatialIndex,
-                                                       UpLo::Lo>(ti_i);
+                                                       UpLo::Lo, ti_i>();
   TestHelpers::TensorExpressions::test_evaluate_rank_1<double, SpatialIndex,
-                                                       UpLo::Lo>(ti_j);
+                                                       UpLo::Lo, ti_j>();
   TestHelpers::TensorExpressions::test_evaluate_rank_1<double, SpatialIndex,
-                                                       UpLo::Up>(ti_I);
+                                                       UpLo::Up, ti_I>();
   TestHelpers::TensorExpressions::test_evaluate_rank_1<double, SpatialIndex,
-                                                       UpLo::Up>(ti_J);
+                                                       UpLo::Up, ti_J>();
 
   // Rank 1: DataVector
   TestHelpers::TensorExpressions::test_evaluate_rank_1<DataVector, SpatialIndex,
-                                                       UpLo::Up>(ti_L);
+                                                       UpLo::Up, ti_L>();
 
   // Rank 2: double; nonsymmetric; spacetime only
   TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo>(ti_a, ti_b);
+      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo, ti_a, ti_b>();
   TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Up>(ti_A, ti_B);
+      double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Up, ti_A, ti_B>();
   TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo>(ti_d, ti_c);
+      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo, ti_d, ti_c>();
   TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Up>(ti_D, ti_C);
+      double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Up, ti_D, ti_C>();
   TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up>(ti_e, ti_F);
+      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti_e, ti_F>();
   TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo>(ti_F, ti_e);
+      double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo, ti_F, ti_e>();
   TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up>(ti_g, ti_B);
+      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti_g, ti_B>();
   TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo>(ti_G, ti_b);
+      double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo, ti_G, ti_b>();
 
   // Rank 2: double; nonsymmetric; spatial only
   TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Lo>(ti_i, ti_j);
+      double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Lo, ti_i, ti_j>();
   TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Up>(ti_I, ti_J);
+      double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Up, ti_I, ti_J>();
   TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Lo>(ti_j, ti_i);
+      double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Lo, ti_j, ti_i>();
   TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Up>(ti_J, ti_I);
+      double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Up, ti_J, ti_I>();
   TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Up>(ti_i, ti_J);
+      double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Up, ti_i, ti_J>();
   TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Lo>(ti_I, ti_j);
+      double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Lo, ti_I, ti_j>();
   TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Up>(ti_j, ti_I);
+      double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Up, ti_j, ti_I>();
   TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Lo>(ti_J, ti_i);
+      double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Lo, ti_J, ti_i>();
 
   // Rank 2: double; nonsymmetric; spacetime and spatial mixed
   TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Up>(ti_c, ti_I);
+      double, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Up, ti_c, ti_I>();
   TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpatialIndex, UpLo::Up, UpLo::Lo>(ti_A, ti_i);
+      double, SpacetimeIndex, SpatialIndex, UpLo::Up, UpLo::Lo, ti_A, ti_i>();
   TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo>(ti_J, ti_a);
+      double, SpatialIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo, ti_J, ti_a>();
   TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up>(ti_i, ti_B);
+      double, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti_i, ti_B>();
   TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Lo>(ti_e, ti_j);
+      double, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Lo, ti_e, ti_j>();
   TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo>(ti_i, ti_d);
+      double, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo, ti_i, ti_d>();
   TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpatialIndex, UpLo::Up, UpLo::Up>(ti_C, ti_I);
+      double, SpacetimeIndex, SpatialIndex, UpLo::Up, UpLo::Up, ti_C, ti_I>();
   TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpacetimeIndex, UpLo::Up, UpLo::Up>(ti_J, ti_A);
+      double, SpatialIndex, SpacetimeIndex, UpLo::Up, UpLo::Up, ti_J, ti_A>();
 
   // Rank 2: double; symmetric; spacetime
   TestHelpers::TensorExpressions::test_evaluate_rank_2_symmetric<
-      double, SpacetimeIndex, UpLo::Lo>(ti_a, ti_d);
+      double, SpacetimeIndex, UpLo::Lo, ti_a, ti_d>();
   TestHelpers::TensorExpressions::test_evaluate_rank_2_symmetric<
-      double, SpacetimeIndex, UpLo::Up>(ti_G, ti_B);
+      double, SpacetimeIndex, UpLo::Up, ti_G, ti_B>();
 
   // Rank 2: double; symmetric; spatial
   TestHelpers::TensorExpressions::test_evaluate_rank_2_symmetric<
-      double, SpatialIndex, UpLo::Lo>(ti_j, ti_i);
+      double, SpatialIndex, UpLo::Lo, ti_j, ti_i>();
   TestHelpers::TensorExpressions::test_evaluate_rank_2_symmetric<
-      double, SpatialIndex, UpLo::Up>(ti_I, ti_J);
+      double, SpatialIndex, UpLo::Up, ti_I, ti_J>();
 
   // Rank 2: DataVector; nonsymmetric
   TestHelpers::TensorExpressions::test_evaluate_rank_2_no_symmetry<
-      DataVector, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up>(ti_f,
-                                                                      ti_G);
+      DataVector, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti_f,
+      ti_G>();
 
   // Rank 2: DataVector; symmetric
   TestHelpers::TensorExpressions::test_evaluate_rank_2_symmetric<
-      DataVector, SpatialIndex, UpLo::Lo>(ti_j, ti_i);
+      DataVector, SpatialIndex, UpLo::Lo, ti_j, ti_i>();
 
   // Rank 3: double; nonsymmetric
   TestHelpers::TensorExpressions::test_evaluate_rank_3_no_symmetry<
       double, SpacetimeIndex, SpatialIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo,
-      UpLo::Up>(ti_D, ti_j, ti_B);
+      UpLo::Up, ti_D, ti_j, ti_B>();
 
   // Rank 3: double; first and second indices symmetric
   TestHelpers::TensorExpressions::test_evaluate_rank_3_ab_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up>(ti_b, ti_a,
-                                                                  ti_C);
+      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti_b, ti_a,
+      ti_C>();
 
   // Rank 3: double; first and third indices symmetric
   TestHelpers::TensorExpressions::test_evaluate_rank_3_ac_symmetry<
-      double, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo>(ti_i, ti_f,
-                                                                ti_j);
+      double, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo, ti_i, ti_f,
+      ti_j>();
 
   // Rank 3: double; second and third indices symmetric
   TestHelpers::TensorExpressions::test_evaluate_rank_3_bc_symmetry<
-      double, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Up>(ti_d, ti_J,
-                                                                ti_I);
+      double, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Up, ti_d, ti_J,
+      ti_I>();
 
   // Rank 3: double; symmetric
   TestHelpers::TensorExpressions::test_evaluate_rank_3_abc_symmetry<
-      double, SpacetimeIndex, UpLo::Lo>(ti_f, ti_d, ti_a);
+      double, SpacetimeIndex, UpLo::Lo, ti_f, ti_d, ti_a>();
 
   // Rank 3: DataVector; nonsymmetric
   TestHelpers::TensorExpressions::test_evaluate_rank_3_no_symmetry<
       DataVector, SpacetimeIndex, SpatialIndex, SpacetimeIndex, UpLo::Up,
-      UpLo::Lo, UpLo::Up>(ti_D, ti_j, ti_B);
+      UpLo::Lo, UpLo::Up, ti_D, ti_j, ti_B>();
 
   // Rank 3: DataVector; first and second indices symmetric
   TestHelpers::TensorExpressions::test_evaluate_rank_3_ab_symmetry<
-      DataVector, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up>(
-      ti_b, ti_a, ti_C);
+      DataVector, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti_b,
+      ti_a, ti_C>();
 
   // Rank 3: DataVector; first and third indices symmetric
   TestHelpers::TensorExpressions::test_evaluate_rank_3_ac_symmetry<
-      DataVector, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo>(ti_i, ti_f,
-                                                                    ti_j);
+      DataVector, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo, ti_i, ti_f,
+      ti_j>();
 
   // Rank 3: DataVector; second and third indices symmetric
   TestHelpers::TensorExpressions::test_evaluate_rank_3_bc_symmetry<
-      DataVector, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Up>(ti_d, ti_J,
-                                                                    ti_I);
+      DataVector, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Up, ti_d, ti_J,
+      ti_I>();
 
   // Rank 3: DataVector; symmetric
   TestHelpers::TensorExpressions::test_evaluate_rank_3_abc_symmetry<
-      DataVector, SpacetimeIndex, UpLo::Lo>(ti_f, ti_d, ti_a);
+      DataVector, SpacetimeIndex, UpLo::Lo, ti_f, ti_d, ti_a>();
 
   // Rank 4: double; nonsymmetric
   TestHelpers::TensorExpressions::test_evaluate_rank_4<
@@ -181,8 +181,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Evaluate",
       index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
                  SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
                  SpatialIndex<1, UpLo::Lo, Frame::Inertial>,
-                 SpatialIndex<2, UpLo::Lo, Frame::Inertial>>>(ti_b, ti_A, ti_k,
-                                                              ti_l);
+                 SpatialIndex<2, UpLo::Lo, Frame::Inertial>>,
+      ti_b, ti_A, ti_k, ti_l>();
 
   // Rank 4: double; second and third indices symmetric
   TestHelpers::TensorExpressions::test_evaluate_rank_4<
@@ -190,8 +190,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Evaluate",
       index_list<SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
                  SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                  SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                 SpatialIndex<1, UpLo::Lo, Frame::Grid>>>(ti_G, ti_d, ti_a,
-                                                          ti_j);
+                 SpatialIndex<1, UpLo::Lo, Frame::Grid>>,
+      ti_G, ti_d, ti_a, ti_j>();
 
   // Rank 4: double; first, second, and fourth indices symmetric
   TestHelpers::TensorExpressions::test_evaluate_rank_4<
@@ -199,8 +199,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Evaluate",
       index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
                  SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
                  SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
-                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>(ti_j, ti_i, ti_k,
-                                                              ti_l);
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti_j, ti_i, ti_k, ti_l>();
 
   // Rank 4: double; symmetric
   TestHelpers::TensorExpressions::test_evaluate_rank_4<
@@ -208,8 +208,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Evaluate",
       index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                  SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                  SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
-                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>(ti_F, ti_A, ti_C,
-                                                            ti_D);
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>>,
+      ti_F, ti_A, ti_C, ti_D>();
 
   // Rank 4: DataVector; nonsymmetric
   TestHelpers::TensorExpressions::test_evaluate_rank_4<
@@ -217,8 +217,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Evaluate",
       index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
                  SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
                  SpatialIndex<1, UpLo::Lo, Frame::Inertial>,
-                 SpatialIndex<2, UpLo::Lo, Frame::Inertial>>>(ti_b, ti_A, ti_k,
-                                                              ti_l);
+                 SpatialIndex<2, UpLo::Lo, Frame::Inertial>>,
+      ti_b, ti_A, ti_k, ti_l>();
 
   // Rank 4: DataVector; second and third indices symmetric
   TestHelpers::TensorExpressions::test_evaluate_rank_4<
@@ -226,8 +226,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Evaluate",
       index_list<SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
                  SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                  SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                 SpatialIndex<1, UpLo::Lo, Frame::Grid>>>(ti_G, ti_d, ti_a,
-                                                          ti_j);
+                 SpatialIndex<1, UpLo::Lo, Frame::Grid>>,
+      ti_G, ti_d, ti_a, ti_j>();
 
   // Rank 4: DataVector; first, second, and fourth indices symmetric
   TestHelpers::TensorExpressions::test_evaluate_rank_4<
@@ -235,8 +235,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Evaluate",
       index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
                  SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
                  SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
-                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>(ti_j, ti_i, ti_k,
-                                                              ti_l);
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti_j, ti_i, ti_k, ti_l>();
 
   // Rank 4: DataVector; symmetric
   TestHelpers::TensorExpressions::test_evaluate_rank_4<
@@ -244,8 +244,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Evaluate",
       index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                  SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                  SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
-                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>(ti_F, ti_A, ti_C,
-                                                            ti_D);
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>>,
+      ti_F, ti_A, ti_C, ti_D>();
 }
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.ComputeRhsTensorIndex",

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/ComputeRhsTensorIndexRank2TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/ComputeRhsTensorIndexRank2TestHelpers.hpp
@@ -18,7 +18,7 @@ namespace TestHelpers::TensorExpressions {
 /// their generic indices
 ///
 /// \details `TensorIndexA` and `TensorIndexB` can be any type of TensorIndex
-/// and are not necessarily `ti_a_t` and `ti_b_t`. The "A" and "B" suffixes just
+/// and are not necessarily `ti_a` and `ti_b`. The "A" and "B" suffixes just
 /// denote the ordering of the generic indices of the RHS tensor expression. In
 /// the RHS tensor expression, it means `TensorIndexA` is the first index used
 /// and `TensorIndexB` is the second index used.
@@ -81,7 +81,7 @@ void test_compute_rhs_tensor_index_rank_2_impl(
 /// - <1, 1> (`test_compute_rhs_tensor_index_rank_2_symmetric`)
 ///
 /// \details `TensorIndexA` and `TensorIndexB` can be any type of TensorIndex
-/// and are not necessarily `ti_a_t` and `ti_b_t`. The "A" and "B" suffixes just
+/// and are not necessarily `ti_a` and `ti_b`. The "A" and "B" suffixes just
 /// denote the ordering of the generic indices of the RHS tensor expression. In
 /// the RHS tensor expression, it means `TensorIndexA` is the first index used
 /// and `TensorIndexB` is the second index used.

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/ComputeRhsTensorIndexRank3TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/ComputeRhsTensorIndexRank3TestHelpers.hpp
@@ -18,7 +18,7 @@ namespace TestHelpers::TensorExpressions {
 /// their generic indices
 ///
 /// \details `TensorIndexA`, `TensorIndexB`, and `TensorIndexC` can be any type
-/// of TensorIndex and are not necessarily `ti_a_t`, `ti_b_t`, and `ti_c_t`. The
+/// of TensorIndex and are not necessarily `ti_a`, `ti_b`, and `ti_c`. The
 /// "A", "B", and "C" suffixes just denote the ordering of the generic indices
 /// of the RHS tensor expression. In the RHS tensor expression, it means
 /// `TensorIndexA` is the first index used, `TensorIndexB` is the second index
@@ -115,7 +115,7 @@ void test_compute_rhs_tensor_index_rank_3_impl(
 /// - <1, 1, 1> (`test_compute_rhs_tensor_index_rank_3_abc_symmetry`)
 ///
 /// \details `TensorIndexA`, `TensorIndexB`, and `TensorIndexC` can be any type
-/// of TensorIndex and are not necessarily `ti_a_t`, `ti_b_t`, and `ti_c_t`. The
+/// of TensorIndex and are not necessarily `ti_a`, `ti_b`, and `ti_c`. The
 /// "A", "B", and "C" suffixes just denote the ordering of the generic indices
 /// of the RHS tensor expression. In the RHS tensor expression, it means
 /// `TensorIndexA` is the first index used, `TensorIndexB` is the second index

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/ComputeRhsTensorIndexRank4TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/ComputeRhsTensorIndexRank4TestHelpers.hpp
@@ -18,8 +18,8 @@ namespace TestHelpers::TensorExpressions {
 /// their generic indices
 ///
 /// \details `TensorIndexA`, `TensorIndexB`, `TensorIndexC`, and  `TensorIndexD`
-/// can be any type of TensorIndex and are not necessarily `ti_a_t`, `ti_b_t`,
-/// `ti_c_t`, and `ti_d_t`. The "A", "B", "C", and "D" suffixes just denote the
+/// can be any type of TensorIndex and are not necessarily `ti_a`, `ti_b`,
+/// `ti_c`, and `ti_d`. The "A", "B", "C", and "D" suffixes just denote the
 /// ordering of the generic indices of the RHS tensor expression. In the RHS
 /// tensor expression, it means `TensorIndexA` is the first index used,
 /// `TensorIndexB` is the second index used, `TensorIndexC` is the third index

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank1TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank1TestHelpers.hpp
@@ -23,10 +23,10 @@ namespace TestHelpers::TensorExpressions {
 /// \tparam DataType the type of data being stored in the Tensors
 /// \tparam TensorIndexTypeList the Tensors' typelist containing their
 /// \ref SpacetimeIndex "TensorIndexType"
-/// \param tensorindex the TensorIndex used in the the TensorExpression,
+/// \tparam TensorIndex the TensorIndex used in the the TensorExpression,
 /// e.g. `ti_a`
-template <typename DataType, typename TensorIndexTypeList, typename TensorIndex>
-void test_evaluate_rank_1_impl(const TensorIndex& tensorindex) noexcept {
+template <typename DataType, typename TensorIndexTypeList, auto& TensorIndex>
+void test_evaluate_rank_1_impl() noexcept {
   Tensor<DataType, Symmetry<1>, TensorIndexTypeList> R_a(5_st);
   std::iota(R_a.begin(), R_a.end(), 0.0);
 
@@ -34,7 +34,7 @@ void test_evaluate_rank_1_impl(const TensorIndex& tensorindex) noexcept {
   // Use explicit type (vs auto) so the compiler checks return type of
   // `evaluate`
   const Tensor<DataType, Symmetry<1>, TensorIndexTypeList> L_a =
-      ::TensorExpressions::evaluate<TensorIndex>(R_a(tensorindex));
+      ::TensorExpressions::evaluate<TensorIndex>(R_a(TensorIndex));
 
   const size_t dim = tmpl::at_c<TensorIndexTypeList, 0>::dim;
 
@@ -51,19 +51,19 @@ void test_evaluate_rank_1_impl(const TensorIndex& tensorindex) noexcept {
 /// \tparam DataType the type of data being stored in the Tensors
 /// \tparam TensorIndexType the Tensors' \ref SpacetimeIndex "TensorIndexType"
 /// \tparam Valence the valence of the Tensors' index
-/// \param tensorindex the TensorIndex used in the the TensorExpression,
+/// \tparam TensorIndex the TensorIndex used in the the TensorExpression,
 /// e.g. `ti_a`
 template <typename DataType,
           template <size_t, UpLo, typename> class TensorIndexType, UpLo Valence,
-          typename TensorIndex>
-void test_evaluate_rank_1(const TensorIndex& tensorindex) noexcept {
+          auto& TensorIndex>
+void test_evaluate_rank_1() noexcept {
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define CALL_TEST_EVALUATE_RANK_1_IMPL(_, data)                                \
-  test_evaluate_rank_1_impl<                                                   \
-      DataType, index_list<TensorIndexType<DIM(data), Valence, FRAME(data)>>>( \
-      tensorindex);
+#define CALL_TEST_EVALUATE_RANK_1_IMPL(_, data)                               \
+  test_evaluate_rank_1_impl<                                                  \
+      DataType, index_list<TensorIndexType<DIM(data), Valence, FRAME(data)>>, \
+      TensorIndex>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_1_IMPL, (1, 2, 3),
                           (Frame::Grid, Frame::Inertial))

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank2TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank2TestHelpers.hpp
@@ -21,7 +21,7 @@ namespace TestHelpers::TensorExpressions {
 /// side tensor
 ///
 /// \details `TensorIndexA` and `TensorIndexB` can be any type of TensorIndex
-/// and are not necessarily `ti_a_t` and `ti_b_t`. The "A" and "B" suffixes just
+/// and are not necessarily `ti_a` and `ti_b`. The "A" and "B" suffixes just
 /// denote the ordering of the generic indices of the RHS tensor expression. In
 /// the RHS tensor expression, it means `TensorIndexA` is the first index used
 /// and `TensorIndexB` is the second index used.
@@ -36,15 +36,14 @@ namespace TestHelpers::TensorExpressions {
 /// \tparam RhsSymmetry the ::Symmetry of the RHS Tensor
 /// \tparam RhsTensorIndexTypeList the RHS Tensor's typelist of
 /// \ref SpacetimeIndex "TensorIndexType"s
-/// \param tensorindex_a the first TensorIndex used on the RHS of the
+/// \tparam TensorIndexA the first TensorIndex used on the RHS of the
 /// TensorExpression, e.g. `ti_a`
-/// \param tensorindex_b the second TensorIndex used on the RHS of the
+/// \tparam TensorIndexB the second TensorIndex used on the RHS of the
 /// TensorExpression, e.g. `ti_B`
 template <typename DataType, typename RhsSymmetry,
-          typename RhsTensorIndexTypeList, typename TensorIndexA,
-          typename TensorIndexB>
-void test_evaluate_rank_2_impl(const TensorIndexA& tensorindex_a,
-                               const TensorIndexB& tensorindex_b) noexcept {
+          typename RhsTensorIndexTypeList, auto& TensorIndexA,
+          auto& TensorIndexB>
+void test_evaluate_rank_2_impl() noexcept {
   Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList> R_ab(5_st);
   std::iota(R_ab.begin(), R_ab.end(), 0.0);
 
@@ -53,7 +52,7 @@ void test_evaluate_rank_2_impl(const TensorIndexA& tensorindex_a,
   // `evaluate`
   const Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList> L_ab =
       ::TensorExpressions::evaluate<TensorIndexA, TensorIndexB>(
-          R_ab(tensorindex_a, tensorindex_b));
+          R_ab(TensorIndexA, TensorIndexB));
 
   // L_{ba} = R_{ab}
   using L_ba_tensorindextype_list =
@@ -61,7 +60,7 @@ void test_evaluate_rank_2_impl(const TensorIndexA& tensorindex_a,
                  tmpl::at_c<RhsTensorIndexTypeList, 0>>;
   const Tensor<DataType, RhsSymmetry, L_ba_tensorindextype_list> L_ba =
       ::TensorExpressions::evaluate<TensorIndexB, TensorIndexA>(
-          R_ab(tensorindex_a, tensorindex_b));
+          R_ab(TensorIndexA, TensorIndexB));
 
   const size_t dim_a = tmpl::at_c<RhsTensorIndexTypeList, 0>::dim;
   const size_t dim_b = tmpl::at_c<RhsTensorIndexTypeList, 1>::dim;
@@ -87,7 +86,7 @@ void test_evaluate_rank_2_impl(const TensorIndexA& tensorindex_a,
 /// - <1, 1> (`test_evaluate_rank_2_symmetric`)
 ///
 /// \details `TensorIndexA` and `TensorIndexB` can be any type of TensorIndex
-/// and are not necessarily `ti_a_t` and `ti_b_t`. The "A" and "B" suffixes just
+/// and are not necessarily `ti_a` and `ti_b`. The "A" and "B" suffixes just
 /// denote the ordering of the generic indices of the RHS tensor expression. In
 /// the RHS tensor expression, it means `TensorIndexA` is the first index used
 /// and `TensorIndexB` is the second index used.
@@ -105,27 +104,25 @@ void test_evaluate_rank_2_impl(const TensorIndexA& tensorindex_a,
 /// TensorExpression
 /// \tparam ValenceB the valence of the second index used on the RHS of the
 /// TensorExpression
-/// \param tensorindex_a the first TensorIndex used on the RHS of the
+/// \tparam TensorIndexA the first TensorIndex used on the RHS of the
 /// TensorExpression, e.g. `ti_a`
-/// \param tensorindex_b the second TensorIndex used on the RHS of the
+/// \tparam TensorIndexB the second TensorIndex used on the RHS of the
 /// TensorExpression, e.g. `ti_B`
-template <
-    typename DataType, template <size_t, UpLo, typename> class TensorIndexTypeA,
-    template <size_t, UpLo, typename> class TensorIndexTypeB, UpLo ValenceA,
-    UpLo ValenceB, typename TensorIndexA, typename TensorIndexB>
-void test_evaluate_rank_2_no_symmetry(
-    const TensorIndexA& tensorindex_a,
-    const TensorIndexB& tensorindex_b) noexcept {
+template <typename DataType,
+          template <size_t, UpLo, typename> class TensorIndexTypeA,
+          template <size_t, UpLo, typename> class TensorIndexTypeB,
+          UpLo ValenceA, UpLo ValenceB, auto& TensorIndexA, auto& TensorIndexB>
+void test_evaluate_rank_2_no_symmetry() noexcept {
 #define DIM_A(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DIM_B(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
 
-#define CALL_TEST_EVALUATE_RANK_2_IMPL(_, data)                          \
-  test_evaluate_rank_2_impl<                                             \
-      DataType, Symmetry<2, 1>,                                          \
-      index_list<TensorIndexTypeA<DIM_A(data), ValenceA, FRAME(data)>,   \
-                 TensorIndexTypeB<DIM_B(data), ValenceB, FRAME(data)>>>( \
-      tensorindex_a, tensorindex_b);
+#define CALL_TEST_EVALUATE_RANK_2_IMPL(_, data)                         \
+  test_evaluate_rank_2_impl<                                            \
+      DataType, Symmetry<2, 1>,                                         \
+      index_list<TensorIndexTypeA<DIM_A(data), ValenceA, FRAME(data)>,  \
+                 TensorIndexTypeB<DIM_B(data), ValenceB, FRAME(data)>>, \
+      TensorIndexA, TensorIndexB>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_2_IMPL, (1, 2, 3), (1, 2, 3),
                           (Frame::Grid, Frame::Inertial))
@@ -138,12 +135,10 @@ void test_evaluate_rank_2_no_symmetry(
 
 /// \ingroup TestingFrameworkGroup
 /// \copydoc test_evaluate_rank_2_no_symmetry()
-template <
-    typename DataType, template <size_t, UpLo, typename> class TensorIndexType,
-    UpLo Valence, typename TensorIndexA, typename TensorIndexB>
-void test_evaluate_rank_2_symmetric(
-    const TensorIndexA& tensorindex_a,
-    const TensorIndexB& tensorindex_b) noexcept {
+template <typename DataType,
+          template <size_t, UpLo, typename> class TensorIndexType, UpLo Valence,
+          auto& TensorIndexA, auto& TensorIndexB>
+void test_evaluate_rank_2_symmetric() noexcept {
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 
@@ -152,7 +147,7 @@ void test_evaluate_rank_2_symmetric(
       DataType, Symmetry<1, 1>,                                     \
       index_list<TensorIndexType<DIM(data), Valence, FRAME(data)>,  \
                  TensorIndexType<DIM(data), Valence, FRAME(data)>>, \
-      TensorIndexA, TensorIndexB>(tensorindex_a, tensorindex_b);
+      TensorIndexA, TensorIndexB>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_2_IMPL, (1, 2, 3),
                           (Frame::Grid, Frame::Inertial))

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank3TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank3TestHelpers.hpp
@@ -22,7 +22,7 @@ namespace TestHelpers::TensorExpressions {
 /// side tensor
 ///
 /// \details `TensorIndexA`, `TensorIndexB`, and `TensorIndexC` can be any type
-/// of TensorIndex and are not necessarily `ti_a_t`, `ti_b_t`, and `ti_c_t`. The
+/// of TensorIndex and are not necessarily `ti_a`, `ti_b`, and `ti_c`. The
 /// "A", "B", and "C" suffixes just denote the ordering of the generic indices
 /// of the RHS tensor expression. In the RHS tensor expression, it means
 /// `TensorIndexA` is the first index used, `TensorIndexB` is the second index
@@ -38,18 +38,16 @@ namespace TestHelpers::TensorExpressions {
 /// \tparam RhsSymmetry the ::Symmetry of the RHS Tensor
 /// \tparam RhsTensorIndexTypeList the RHS Tensor's typelist of
 /// \ref SpacetimeIndex "TensorIndexType"s
-/// \param tensorindex_a the first TensorIndex used on the RHS of the
+/// \tparam TensorIndexA the first TensorIndex used on the RHS of the
 /// TensorExpression, e.g. `ti_a`
-/// \param tensorindex_b the second TensorIndex used on the RHS of the
+/// \tparam TensorIndexB the second TensorIndex used on the RHS of the
 /// TensorExpression, e.g. `ti_B`
-/// \param tensorindex_c the third TensorIndex used on the RHS of the
+/// \tparam TensorIndexC the third TensorIndex used on the RHS of the
 /// TensorExpression, e.g. `ti_c`
 template <typename DataType, typename RhsSymmetry,
-          typename RhsTensorIndexTypeList, typename TensorIndexA,
-          typename TensorIndexB, typename TensorIndexC>
-void test_evaluate_rank_3_impl(const TensorIndexA& tensorindex_a,
-                               const TensorIndexB& tensorindex_b,
-                               const TensorIndexC& tensorindex_c) noexcept {
+          typename RhsTensorIndexTypeList, auto& TensorIndexA,
+          auto& TensorIndexB, auto& TensorIndexC>
+void test_evaluate_rank_3_impl() noexcept {
   Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList> R_abc(5_st);
   std::iota(R_abc.begin(), R_abc.end(), 0.0);
 
@@ -67,7 +65,7 @@ void test_evaluate_rank_3_impl(const TensorIndexA& tensorindex_a,
   // `evaluate`
   const Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList> L_abc =
       ::TensorExpressions::evaluate<TensorIndexA, TensorIndexB, TensorIndexC>(
-          R_abc(tensorindex_a, tensorindex_b, tensorindex_c));
+          R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
 
   // L_{acb} = R_{abc}
   using L_acb_symmetry =
@@ -78,7 +76,7 @@ void test_evaluate_rank_3_impl(const TensorIndexA& tensorindex_a,
                  rhs_tensorindextype_b>;
   const Tensor<DataType, L_acb_symmetry, L_acb_tensorindextype_list> L_acb =
       ::TensorExpressions::evaluate<TensorIndexA, TensorIndexC, TensorIndexB>(
-          R_abc(tensorindex_a, tensorindex_b, tensorindex_c));
+          R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
 
   // L_{bac} = R_{abc}
   using L_bac_symmetry =
@@ -89,7 +87,7 @@ void test_evaluate_rank_3_impl(const TensorIndexA& tensorindex_a,
                  rhs_tensorindextype_c>;
   const Tensor<DataType, L_bac_symmetry, L_bac_tensorindextype_list> L_bac =
       ::TensorExpressions::evaluate<TensorIndexB, TensorIndexA, TensorIndexC>(
-          R_abc(tensorindex_a, tensorindex_b, tensorindex_c));
+          R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
 
   // L_{bca} = R_{abc}
   using L_bca_symmetry =
@@ -100,7 +98,7 @@ void test_evaluate_rank_3_impl(const TensorIndexA& tensorindex_a,
                  rhs_tensorindextype_a>;
   const Tensor<DataType, L_bca_symmetry, L_bca_tensorindextype_list> L_bca =
       ::TensorExpressions::evaluate<TensorIndexB, TensorIndexC, TensorIndexA>(
-          R_abc(tensorindex_a, tensorindex_b, tensorindex_c));
+          R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
 
   // L_{cab} = R_{abc}
   using L_cab_symmetry =
@@ -111,7 +109,7 @@ void test_evaluate_rank_3_impl(const TensorIndexA& tensorindex_a,
                  rhs_tensorindextype_b>;
   const Tensor<DataType, L_cab_symmetry, L_cab_tensorindextype_list> L_cab =
       ::TensorExpressions::evaluate<TensorIndexC, TensorIndexA, TensorIndexB>(
-          R_abc(tensorindex_a, tensorindex_b, tensorindex_c));
+          R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
 
   // L_{cba} = R_{abc}
   using L_cba_symmetry =
@@ -122,7 +120,7 @@ void test_evaluate_rank_3_impl(const TensorIndexA& tensorindex_a,
                  rhs_tensorindextype_a>;
   const Tensor<DataType, L_cba_symmetry, L_cba_tensorindextype_list> L_cba =
       ::TensorExpressions::evaluate<TensorIndexC, TensorIndexB, TensorIndexA>(
-          R_abc(tensorindex_a, tensorindex_b, tensorindex_c));
+          R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
 
   const size_t dim_a = tmpl::at_c<RhsTensorIndexTypeList, 0>::dim;
   const size_t dim_b = tmpl::at_c<RhsTensorIndexTypeList, 1>::dim;
@@ -162,7 +160,7 @@ void test_evaluate_rank_3_impl(const TensorIndexA& tensorindex_a,
 /// - <1, 1, 1> (`test_evaluate_rank_3_abc_symmetry`)
 ///
 /// \details `TensorIndexA`, `TensorIndexB`, and `TensorIndexC` can be any type
-/// of TensorIndex and are not necessarily `ti_a_t`, `ti_b_t`, and `ti_c_t`. The
+/// of TensorIndex and are not necessarily `ti_a`, `ti_b`, and `ti_c`. The
 /// "A", "B", and "C" suffixes just denote the ordering of the generic indices
 /// of the RHS tensor expression. In the RHS tensor expression, it means
 /// `TensorIndexA` is the first index used, `TensorIndexB` is the second index
@@ -185,33 +183,31 @@ void test_evaluate_rank_3_impl(const TensorIndexA& tensorindex_a,
 /// TensorExpression
 /// \tparam ValenceC the valence of the third index used on the RHS of the
 /// TensorExpression
-/// \param tensorindex_a the first TensorIndex used on the RHS of the
+/// \tparam TensorIndexA the first TensorIndex used on the RHS of the
 /// TensorExpression, e.g. `ti_a`
-/// \param tensorindex_b the second TensorIndex used on the RHS of the
+/// \tparam TensorIndexB the second TensorIndex used on the RHS of the
 /// TensorExpression, e.g. `ti_B`
-/// \param tensorindex_c the third TensorIndex used on the RHS of the
+/// \tparam TensorIndexC the third TensorIndex used on the RHS of the
 /// TensorExpression, e.g. `ti_c`
 template <typename DataType,
           template <size_t, UpLo, typename> class TensorIndexTypeA,
           template <size_t, UpLo, typename> class TensorIndexTypeB,
           template <size_t, UpLo, typename> class TensorIndexTypeC,
-          UpLo ValenceA, UpLo ValenceB, UpLo ValenceC, typename TensorIndexA,
-          typename TensorIndexB, typename TensorIndexC>
-void test_evaluate_rank_3_no_symmetry(
-    const TensorIndexA& tensorindex_a, const TensorIndexB& tensorindex_b,
-    const TensorIndexC& tensorindex_c) noexcept {
+          UpLo ValenceA, UpLo ValenceB, UpLo ValenceC, auto& TensorIndexA,
+          auto& TensorIndexB, auto& TensorIndexC>
+void test_evaluate_rank_3_no_symmetry() noexcept {
 #define DIM_A(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DIM_B(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define DIM_C(data) BOOST_PP_TUPLE_ELEM(2, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(3, data)
 
-#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                          \
-  test_evaluate_rank_3_impl<                                             \
-      DataType, Symmetry<3, 2, 1>,                                       \
-      index_list<TensorIndexTypeA<DIM_A(data), ValenceA, FRAME(data)>,   \
-                 TensorIndexTypeB<DIM_B(data), ValenceB, FRAME(data)>,   \
-                 TensorIndexTypeC<DIM_C(data), ValenceC, FRAME(data)>>>( \
-      tensorindex_a, tensorindex_b, tensorindex_c);
+#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                         \
+  test_evaluate_rank_3_impl<                                            \
+      DataType, Symmetry<3, 2, 1>,                                      \
+      index_list<TensorIndexTypeA<DIM_A(data), ValenceA, FRAME(data)>,  \
+                 TensorIndexTypeB<DIM_B(data), ValenceB, FRAME(data)>,  \
+                 TensorIndexTypeC<DIM_C(data), ValenceC, FRAME(data)>>, \
+      TensorIndexA, TensorIndexB, TensorIndexC>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3), (1, 2, 3),
                           (1, 2, 3), (Frame::Grid, Frame::Inertial))
@@ -228,22 +224,20 @@ void test_evaluate_rank_3_no_symmetry(
 template <typename DataType,
           template <size_t, UpLo, typename> class TensorIndexTypeAB,
           template <size_t, UpLo, typename> class TensorIndexTypeC,
-          UpLo ValenceAB, UpLo ValenceC, typename TensorIndexA,
-          typename TensorIndexB, typename TensorIndexC>
-void test_evaluate_rank_3_ab_symmetry(
-    const TensorIndexA& tensorindex_a, const TensorIndexB& tensorindex_b,
-    const TensorIndexC& tensorindex_c) noexcept {
+          UpLo ValenceAB, UpLo ValenceC, auto& TensorIndexA, auto& TensorIndexB,
+          auto& TensorIndexC>
+void test_evaluate_rank_3_ab_symmetry() noexcept {
 #define DIM_AB(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DIM_C(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
 
-#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                            \
-  test_evaluate_rank_3_impl<                                               \
-      DataType, Symmetry<2, 2, 1>,                                         \
-      index_list<TensorIndexTypeAB<DIM_AB(data), ValenceAB, FRAME(data)>,  \
-                 TensorIndexTypeAB<DIM_AB(data), ValenceAB, FRAME(data)>,  \
-                 TensorIndexTypeC<DIM_C(data), ValenceC, FRAME(data)>>>(   \
-      tensorindex_a, tensorindex_b, tensorindex_c);
+#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                           \
+  test_evaluate_rank_3_impl<                                              \
+      DataType, Symmetry<2, 2, 1>,                                        \
+      index_list<TensorIndexTypeAB<DIM_AB(data), ValenceAB, FRAME(data)>, \
+                 TensorIndexTypeAB<DIM_AB(data), ValenceAB, FRAME(data)>, \
+                 TensorIndexTypeC<DIM_C(data), ValenceC, FRAME(data)>>,   \
+      TensorIndexA, TensorIndexB, TensorIndexC>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3), (1, 2, 3),
                           (Frame::Grid, Frame::Inertial))
@@ -259,22 +253,20 @@ void test_evaluate_rank_3_ab_symmetry(
 template <typename DataType,
           template <size_t, UpLo, typename> class TensorIndexTypeAC,
           template <size_t, UpLo, typename> class TensorIndexTypeB,
-          UpLo ValenceAC, UpLo ValenceB, typename TensorIndexA,
-          typename TensorIndexB, typename TensorIndexC>
-void test_evaluate_rank_3_ac_symmetry(
-    const TensorIndexA& tensorindex_a, const TensorIndexB& tensorindex_b,
-    const TensorIndexC& tensorindex_c) noexcept {
+          UpLo ValenceAC, UpLo ValenceB, auto& TensorIndexA, auto& TensorIndexB,
+          auto& TensorIndexC>
+void test_evaluate_rank_3_ac_symmetry() noexcept {
 #define DIM_AC(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DIM_B(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
 
-#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                             \
-  test_evaluate_rank_3_impl<                                                \
-      DataType, Symmetry<2, 1, 2>,                                          \
-      index_list<TensorIndexTypeAC<DIM_AC(data), ValenceAC, FRAME(data)>,   \
-                 TensorIndexTypeB<DIM_B(data), ValenceB, FRAME(data)>,      \
-                 TensorIndexTypeAC<DIM_AC(data), ValenceAC, FRAME(data)>>>( \
-      tensorindex_a, tensorindex_b, tensorindex_c);
+#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                            \
+  test_evaluate_rank_3_impl<                                               \
+      DataType, Symmetry<2, 1, 2>,                                         \
+      index_list<TensorIndexTypeAC<DIM_AC(data), ValenceAC, FRAME(data)>,  \
+                 TensorIndexTypeB<DIM_B(data), ValenceB, FRAME(data)>,     \
+                 TensorIndexTypeAC<DIM_AC(data), ValenceAC, FRAME(data)>>, \
+      TensorIndexA, TensorIndexB, TensorIndexC>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3), (1, 2, 3),
                           (Frame::Grid, Frame::Inertial))
@@ -287,25 +279,22 @@ void test_evaluate_rank_3_ac_symmetry(
 
 /// \ingroup TestingFrameworkGroup
 /// \copydoc test_evaluate_rank_3_no_symmetry()
-template <typename DataType,
-          template <size_t, UpLo, typename> class TensorIndexTypeA,
-          template <size_t, UpLo, typename> class TensorIndexTypeBC,
-          UpLo ValenceA, UpLo ValenceBC, typename TensorIndexA,
-          typename TensorIndexB, typename TensorIndexC>
-void test_evaluate_rank_3_bc_symmetry(
-    const TensorIndexA& tensorindex_a, const TensorIndexB& tensorindex_b,
-    const TensorIndexC& tensorindex_c) noexcept {
+template <
+    typename DataType, template <size_t, UpLo, typename> class TensorIndexTypeA,
+    template <size_t, UpLo, typename> class TensorIndexTypeBC, UpLo ValenceA,
+    UpLo ValenceBC, auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC>
+void test_evaluate_rank_3_bc_symmetry() noexcept {
 #define DIM_A(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DIM_BC(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
 
-#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                             \
-  test_evaluate_rank_3_impl<                                                \
-      DataType, Symmetry<2, 1, 1>,                                          \
-      index_list<TensorIndexTypeA<DIM_A(data), ValenceA, FRAME(data)>,      \
-                 TensorIndexTypeBC<DIM_BC(data), ValenceBC, FRAME(data)>,   \
-                 TensorIndexTypeBC<DIM_BC(data), ValenceBC, FRAME(data)>>>( \
-      tensorindex_a, tensorindex_b, tensorindex_c);
+#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                            \
+  test_evaluate_rank_3_impl<                                               \
+      DataType, Symmetry<2, 1, 1>,                                         \
+      index_list<TensorIndexTypeA<DIM_A(data), ValenceA, FRAME(data)>,     \
+                 TensorIndexTypeBC<DIM_BC(data), ValenceBC, FRAME(data)>,  \
+                 TensorIndexTypeBC<DIM_BC(data), ValenceBC, FRAME(data)>>, \
+      TensorIndexA, TensorIndexB, TensorIndexC>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3), (1, 2, 3),
                           (Frame::Grid, Frame::Inertial))
@@ -320,20 +309,18 @@ void test_evaluate_rank_3_bc_symmetry(
 /// \copydoc test_evaluate_rank_3_no_symmetry()
 template <typename DataType,
           template <size_t, UpLo, typename> class TensorIndexType, UpLo Valence,
-          typename TensorIndexA, typename TensorIndexB, typename TensorIndexC>
-void test_evaluate_rank_3_abc_symmetry(
-    const TensorIndexA& tensorindex_a, const TensorIndexB& tensorindex_b,
-    const TensorIndexC& tensorindex_c) noexcept {
+          auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC>
+void test_evaluate_rank_3_abc_symmetry() noexcept {
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                      \
-  test_evaluate_rank_3_impl<                                         \
-      DataType, Symmetry<1, 1, 1>,                                   \
-      index_list<TensorIndexType<DIM(data), Valence, FRAME(data)>,   \
-                 TensorIndexType<DIM(data), Valence, FRAME(data)>,   \
-                 TensorIndexType<DIM(data), Valence, FRAME(data)>>>( \
-      tensorindex_a, tensorindex_b, tensorindex_c);
+#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                     \
+  test_evaluate_rank_3_impl<                                        \
+      DataType, Symmetry<1, 1, 1>,                                  \
+      index_list<TensorIndexType<DIM(data), Valence, FRAME(data)>,  \
+                 TensorIndexType<DIM(data), Valence, FRAME(data)>,  \
+                 TensorIndexType<DIM(data), Valence, FRAME(data)>>, \
+      TensorIndexA, TensorIndexB, TensorIndexC>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3),
                           (Frame::Grid, Frame::Inertial))

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank4TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank4TestHelpers.hpp
@@ -20,8 +20,8 @@ namespace TestHelpers::TensorExpressions {
 /// side tensor
 ///
 /// \details `TensorIndexA`, `TensorIndexB`, `TensorIndexC`, and  `TensorIndexD`
-/// can be any type of TensorIndex and are not necessarily `ti_a_t`, `ti_b_t`,
-/// `ti_c_t`, and `ti_d_t`. The "A", "B", "C", and "D" suffixes just denote the
+/// can be any type of TensorIndex and are not necessarily `ti_a`, `ti_b`,
+/// `ti_c`, and `ti_d`. The "A", "B", "C", and "D" suffixes just denote the
 /// ordering of the generic indices of the RHS tensor expression. In the RHS
 /// tensor expression, it means `TensorIndexA` is the first index used,
 /// `TensorIndexB` is the second index used, `TensorIndexC` is the third index
@@ -37,21 +37,18 @@ namespace TestHelpers::TensorExpressions {
 /// \tparam RhsSymmetry the ::Symmetry of the RHS Tensor
 /// \tparam RhsTensorIndexTypeList the RHS Tensor's typelist of
 /// \ref SpacetimeIndex "TensorIndexType"s
-/// \param tensorindex_a the first TensorIndex used on the RHS of the
+/// \tparam TensorIndexA the first TensorIndex used on the RHS of the
 /// TensorExpression, e.g. `ti_a`
-/// \param tensorindex_b the second TensorIndex used on the RHS of the
+/// \tparam TensorIndexB the second TensorIndex used on the RHS of the
 /// TensorExpression, e.g. `ti_B`
-/// \param tensorindex_c the third TensorIndex used on the RHS of the
+/// \tparam TensorIndexC the third TensorIndex used on the RHS of the
 /// TensorExpression, e.g. `ti_c`
-/// \param tensorindex_d the fourth TensorIndex used on the RHS of the
+/// \tparam TensorIndexD the fourth TensorIndex used on the RHS of the
 /// TensorExpression, e.g. `ti_D`
 template <typename DataType, typename RhsSymmetry,
-          typename RhsTensorIndexTypeList, typename TensorIndexA,
-          typename TensorIndexB, typename TensorIndexC, typename TensorIndexD>
-void test_evaluate_rank_4(const TensorIndexA& tensorindex_a,
-                          const TensorIndexB& tensorindex_b,
-                          const TensorIndexC& tensorindex_c,
-                          const TensorIndexD& tensorindex_d) noexcept {
+          typename RhsTensorIndexTypeList, auto& TensorIndexA,
+          auto& TensorIndexB, auto& TensorIndexC, auto& TensorIndexD>
+void test_evaluate_rank_4() noexcept {
   Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList> R_abcd(5_st);
   std::iota(R_abcd.begin(), R_abcd.end(), 0.0);
 
@@ -72,7 +69,7 @@ void test_evaluate_rank_4(const TensorIndexA& tensorindex_a,
   const Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList> L_abcd =
       ::TensorExpressions::evaluate<TensorIndexA, TensorIndexB, TensorIndexC,
                                     TensorIndexD>(
-          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{abdc} = R_{abcd}
   using L_abdc_symmetry =
@@ -84,7 +81,7 @@ void test_evaluate_rank_4(const TensorIndexA& tensorindex_a,
   const Tensor<DataType, L_abdc_symmetry, L_abdc_tensorindextype_list> L_abdc =
       ::TensorExpressions::evaluate<TensorIndexA, TensorIndexB, TensorIndexD,
                                     TensorIndexC>(
-          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{acbd} = R_{abcd}
   using L_acbd_symmetry =
@@ -96,7 +93,7 @@ void test_evaluate_rank_4(const TensorIndexA& tensorindex_a,
   const Tensor<DataType, L_acbd_symmetry, L_acbd_tensorindextype_list> L_acbd =
       ::TensorExpressions::evaluate<TensorIndexA, TensorIndexC, TensorIndexB,
                                     TensorIndexD>(
-          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{acdb} = R_{abcd}
   using L_acdb_symmetry =
@@ -108,7 +105,7 @@ void test_evaluate_rank_4(const TensorIndexA& tensorindex_a,
   const Tensor<DataType, L_acdb_symmetry, L_acdb_tensorindextype_list> L_acdb =
       ::TensorExpressions::evaluate<TensorIndexA, TensorIndexC, TensorIndexD,
                                     TensorIndexB>(
-          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{adbc} = R_{abcd}
   using L_adbc_symmetry =
@@ -120,7 +117,7 @@ void test_evaluate_rank_4(const TensorIndexA& tensorindex_a,
   const Tensor<DataType, L_adbc_symmetry, L_adbc_tensorindextype_list> L_adbc =
       ::TensorExpressions::evaluate<TensorIndexA, TensorIndexD, TensorIndexB,
                                     TensorIndexC>(
-          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{adcb} = R_{abcd}
   using L_adcb_symmetry =
@@ -132,7 +129,7 @@ void test_evaluate_rank_4(const TensorIndexA& tensorindex_a,
   const Tensor<DataType, L_adcb_symmetry, L_adcb_tensorindextype_list> L_adcb =
       ::TensorExpressions::evaluate<TensorIndexA, TensorIndexD, TensorIndexC,
                                     TensorIndexB>(
-          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{bacd} = R_{abcd}
   using L_bacd_symmetry =
@@ -144,7 +141,7 @@ void test_evaluate_rank_4(const TensorIndexA& tensorindex_a,
   const Tensor<DataType, L_bacd_symmetry, L_bacd_tensorindextype_list> L_bacd =
       ::TensorExpressions::evaluate<TensorIndexB, TensorIndexA, TensorIndexC,
                                     TensorIndexD>(
-          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{badc} = R_{abcd}
   using L_badc_symmetry =
@@ -156,7 +153,7 @@ void test_evaluate_rank_4(const TensorIndexA& tensorindex_a,
   const Tensor<DataType, L_badc_symmetry, L_badc_tensorindextype_list> L_badc =
       ::TensorExpressions::evaluate<TensorIndexB, TensorIndexA, TensorIndexD,
                                     TensorIndexC>(
-          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{bcad} = R_{abcd}
   using L_bcad_symmetry =
@@ -168,7 +165,7 @@ void test_evaluate_rank_4(const TensorIndexA& tensorindex_a,
   const Tensor<DataType, L_bcad_symmetry, L_bcad_tensorindextype_list> L_bcad =
       ::TensorExpressions::evaluate<TensorIndexB, TensorIndexC, TensorIndexA,
                                     TensorIndexD>(
-          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{bcda} = R_{abcd}
   using L_bcda_symmetry =
@@ -180,7 +177,7 @@ void test_evaluate_rank_4(const TensorIndexA& tensorindex_a,
   const Tensor<DataType, L_bcda_symmetry, L_bcda_tensorindextype_list> L_bcda =
       ::TensorExpressions::evaluate<TensorIndexB, TensorIndexC, TensorIndexD,
                                     TensorIndexA>(
-          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{bdac} = R_{abcd}
   using L_bdac_symmetry =
@@ -192,7 +189,7 @@ void test_evaluate_rank_4(const TensorIndexA& tensorindex_a,
   const Tensor<DataType, L_bdac_symmetry, L_bdac_tensorindextype_list> L_bdac =
       ::TensorExpressions::evaluate<TensorIndexB, TensorIndexD, TensorIndexA,
                                     TensorIndexC>(
-          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{bdca} = R_{abcd}
   using L_bdca_symmetry =
@@ -204,7 +201,7 @@ void test_evaluate_rank_4(const TensorIndexA& tensorindex_a,
   const Tensor<DataType, L_bdca_symmetry, L_bdca_tensorindextype_list> L_bdca =
       ::TensorExpressions::evaluate<TensorIndexB, TensorIndexD, TensorIndexC,
                                     TensorIndexA>(
-          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{cabd} = R_{abcd}
   using L_cabd_symmetry =
@@ -216,7 +213,7 @@ void test_evaluate_rank_4(const TensorIndexA& tensorindex_a,
   const Tensor<DataType, L_cabd_symmetry, L_cabd_tensorindextype_list> L_cabd =
       ::TensorExpressions::evaluate<TensorIndexC, TensorIndexA, TensorIndexB,
                                     TensorIndexD>(
-          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{cadb} = R_{abcd}
   using L_cadb_symmetry =
@@ -228,7 +225,7 @@ void test_evaluate_rank_4(const TensorIndexA& tensorindex_a,
   const Tensor<DataType, L_cadb_symmetry, L_cadb_tensorindextype_list> L_cadb =
       ::TensorExpressions::evaluate<TensorIndexC, TensorIndexA, TensorIndexD,
                                     TensorIndexB>(
-          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{cbad} = R_{abcd}
   using L_cbad_symmetry =
@@ -240,7 +237,7 @@ void test_evaluate_rank_4(const TensorIndexA& tensorindex_a,
   const Tensor<DataType, L_cbad_symmetry, L_cbad_tensorindextype_list> L_cbad =
       ::TensorExpressions::evaluate<TensorIndexC, TensorIndexB, TensorIndexA,
                                     TensorIndexD>(
-          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{cbda} = R_{abcd}
   using L_cbda_symmetry =
@@ -252,7 +249,7 @@ void test_evaluate_rank_4(const TensorIndexA& tensorindex_a,
   const Tensor<DataType, L_cbda_symmetry, L_cbda_tensorindextype_list> L_cbda =
       ::TensorExpressions::evaluate<TensorIndexC, TensorIndexB, TensorIndexD,
                                     TensorIndexA>(
-          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{cdab} = R_{abcd}
   using L_cdab_symmetry =
@@ -264,7 +261,7 @@ void test_evaluate_rank_4(const TensorIndexA& tensorindex_a,
   const Tensor<DataType, L_cdab_symmetry, L_cdab_tensorindextype_list> L_cdab =
       ::TensorExpressions::evaluate<TensorIndexC, TensorIndexD, TensorIndexA,
                                     TensorIndexB>(
-          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{cdba} = R_{abcd}
   using L_cdba_symmetry =
@@ -276,7 +273,7 @@ void test_evaluate_rank_4(const TensorIndexA& tensorindex_a,
   const Tensor<DataType, L_cdba_symmetry, L_cdba_tensorindextype_list> L_cdba =
       ::TensorExpressions::evaluate<TensorIndexC, TensorIndexD, TensorIndexB,
                                     TensorIndexA>(
-          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{dabc} = R_{abcd}
   using L_dabc_symmetry =
@@ -288,7 +285,7 @@ void test_evaluate_rank_4(const TensorIndexA& tensorindex_a,
   const Tensor<DataType, L_dabc_symmetry, L_dabc_tensorindextype_list> L_dabc =
       ::TensorExpressions::evaluate<TensorIndexD, TensorIndexA, TensorIndexB,
                                     TensorIndexC>(
-          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{dacb} = R_{abcd}
   using L_dacb_symmetry =
@@ -300,7 +297,7 @@ void test_evaluate_rank_4(const TensorIndexA& tensorindex_a,
   const Tensor<DataType, L_dacb_symmetry, L_dacb_tensorindextype_list> L_dacb =
       ::TensorExpressions::evaluate<TensorIndexD, TensorIndexA, TensorIndexC,
                                     TensorIndexB>(
-          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{dbac} = R_{abcd}
   using L_dbac_symmetry =
@@ -312,7 +309,7 @@ void test_evaluate_rank_4(const TensorIndexA& tensorindex_a,
   const Tensor<DataType, L_dbac_symmetry, L_dbac_tensorindextype_list> L_dbac =
       ::TensorExpressions::evaluate<TensorIndexD, TensorIndexB, TensorIndexA,
                                     TensorIndexC>(
-          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{dbca} = R_{abcd}
   using L_dbca_symmetry =
@@ -324,7 +321,7 @@ void test_evaluate_rank_4(const TensorIndexA& tensorindex_a,
   const Tensor<DataType, L_dbca_symmetry, L_dbca_tensorindextype_list> L_dbca =
       ::TensorExpressions::evaluate<TensorIndexD, TensorIndexB, TensorIndexC,
                                     TensorIndexA>(
-          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{dcab} = R_{abcd}
   using L_dcab_symmetry =
@@ -336,7 +333,7 @@ void test_evaluate_rank_4(const TensorIndexA& tensorindex_a,
   const Tensor<DataType, L_dcab_symmetry, L_dcab_tensorindextype_list> L_dcab =
       ::TensorExpressions::evaluate<TensorIndexD, TensorIndexC, TensorIndexA,
                                     TensorIndexB>(
-          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{dcba} = R_{abcd}
   using L_dcba_symmetry =
@@ -348,7 +345,7 @@ void test_evaluate_rank_4(const TensorIndexA& tensorindex_a,
   const Tensor<DataType, L_dcba_symmetry, L_dcba_tensorindextype_list> L_dcba =
       ::TensorExpressions::evaluate<TensorIndexD, TensorIndexC, TensorIndexB,
                                     TensorIndexA>(
-          R_abcd(tensorindex_a, tensorindex_b, tensorindex_c, tensorindex_d));
+          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   const size_t dim_a = tmpl::at_c<RhsTensorIndexTypeList, 0>::dim;
   const size_t dim_b = tmpl::at_c<RhsTensorIndexTypeList, 1>::dim;


### PR DESCRIPTION
## Proposed changes

In short, when we evaluate a `TensorExpression` to a LHS tensor, we currently write the LHS indices (template parameters for `evaluate`) using `TensorIndex` type aliases instead of instances (i.e. with `ti_a_t` instead of `ti_a`):
```
auto L_ab = TensorExpressions::evaluate<ti_a_t, ti_b_t>(R(ti_a, ti_b) + S(ti_a, ti_b));
```
and with these changes, we instead do:
```
auto L_ab = TensorExpressions::evaluate<ti_a, ti_b>(R(ti_a, ti_b) + S(ti_a, ti_b));
```

These `TensorIndex` aliases are currently only used as template parameters to the `TensorExpressions::evaluate` function. This PR removes the `TensorIndex` type aliases entirely, and updates `TensorExpressions::evaluate` to take the `TensorIndex` instances, instead. The motivation for this is to have to type less when specifying the LHS indices, and also to make it consistent with using the instances on the RHS in expressions, which is more intuitive as a user.

In addition to updating `TensorExpressions::evaluate`, references to the type aliases have been removed from other parts of the code, and test functions have been updated to follow this new convention.

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
