### PR TITLE
Fix HalfSpaceMirror test timeouts

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/CMakeLists.txt
@@ -23,10 +23,13 @@ spectre_target_headers(
 
 target_link_libraries(
   ${LIBRARY}
-  PUBLIC ConstitutiveRelations
-  PUBLIC DataStructures
-  PUBLIC ErrorHandling
-  PUBLIC Integration
-  PUBLIC Utilities
-  PRIVATE GSL::gsl
+  PUBLIC
+  ConstitutiveRelations
+  DataStructures
+  Elasticity
+  ErrorHandling
+  Options
+  Utilities
+  PRIVATE
+  Integration
   )

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/CMakeLists.txt
@@ -12,5 +12,5 @@ add_test_library(
   ${LIBRARY}
   "PointwiseFunctions/AnalyticSolutions/Elasticity/"
   "${LIBRARY_SOURCES}"
-  "ElasticitySolutions;Utilities;Integration"
+  "ConstitutiveRelations;CoordinateMaps;DataStructures;Domain;Elasticity;ElasticitySolutions;Spectral;Utilities"
   )

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_HalfSpaceMirror.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_HalfSpaceMirror.cpp
@@ -127,8 +127,7 @@ SPECTRE_TEST_CASE(
 
   {
     INFO("Test elasticity system with half-space mirror");
-    // Verify that the solution numerically solves the system and that the
-    // discretization error decreases exponentially with polynomial order
+    // Verify that the solution numerically solves the system
     using system = Elasticity::FirstOrderSystem<dim>;
     const typename system::fluxes fluxes_computer{};
     using AffineMap = domain::CoordinateMaps::Affine;
@@ -136,13 +135,13 @@ SPECTRE_TEST_CASE(
         domain::CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
     const domain::CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap3D>
         coord_map{{{-1., 1., 0., 0.5}, {-1., 1., 0., 0.5}, {-1., 1., 0., 0.5}}};
-    FirstOrderEllipticSolutionsTestHelpers::verify_smooth_solution<system>(
-        solution, fluxes_computer, coord_map, 1.e4, 1.,
-        [&constitutive_relation, &coord_map](const Mesh<3>& mesh) {
-          const auto logical_coords = logical_coordinates(mesh);
-          const auto inertial_coords = coord_map(logical_coords);
-          return std::make_tuple(constitutive_relation, inertial_coords);
-        });
+    const Mesh<3> mesh{12, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+    const auto logical_coords = logical_coordinates(mesh);
+    const auto inertial_coords = coord_map(logical_coords);
+    FirstOrderEllipticSolutionsTestHelpers::verify_solution<system>(
+        solution, fluxes_computer, mesh, coord_map, 0.05,
+        std::make_tuple(constitutive_relation, inertial_coords));
   };
 }
 


### PR DESCRIPTION
## Proposed changes

I ran the test 1e3 times with no timeout on my machine.

Fixes #2566 

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
