### PR TITLE
Make mesh option-parsable

### DIFF
--- a/src/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -50,6 +50,7 @@ target_link_libraries(
   DataStructures
   ErrorHandling
   Libsharp
+  Options
   PRIVATE
   Blas
   Boost::boost

--- a/src/NumericalAlgorithms/Spectral/Mesh.hpp
+++ b/src/NumericalAlgorithms/Spectral/Mesh.hpp
@@ -199,8 +199,8 @@ class Mesh {
    * \see slice_through() The templated overload of this function
    */
   template <size_t SliceDim, Requires<(SliceDim <= Dim)> = nullptr>
-  Mesh<SliceDim> slice_through(const std::array<size_t, SliceDim>& dims) const
-      noexcept;
+  Mesh<SliceDim> slice_through(
+      const std::array<size_t, SliceDim>& dims) const noexcept;
 
   /*!
    * \brief Returns the Meshes representing 1D slices of this Mesh.

--- a/src/NumericalAlgorithms/Spectral/Mesh.hpp
+++ b/src/NumericalAlgorithms/Spectral/Mesh.hpp
@@ -11,6 +11,7 @@
 
 #include "DataStructures/Index.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Options/Options.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TypeTraits.hpp"  // IWYU pragma: keep
@@ -47,6 +48,34 @@ template <size_t Dim>
 class Mesh {
  public:
   static constexpr size_t dim = Dim;
+
+  struct Extents {
+    using type = size_t;
+    static constexpr Options::String help = {
+        "The number of collocation points per dimension"};
+  };
+
+  struct Basis {
+    using type = Spectral::Basis;
+    static constexpr Options::String help = {
+        "The choice of spectral basis to compute the collocation points"};
+  };
+
+  struct Quadrature {
+    using type = Spectral::Quadrature;
+    static constexpr Options::String help = {
+        "The choice of quadrature to compute the collocation points"};
+  };
+
+  using options = tmpl::list<Extents, Basis, Quadrature>;
+
+  static constexpr Options::String help =
+      "Holds the number of grid points, basis, and quadrature in each "
+      "direction of the computational grid. "
+      "A mesh encapsulates all information necessary to construct the "
+      "placement of grid points in the computational domain. It does so "
+      "through a choice of basis functions, quadrature and number of points "
+      "in each dimension.";
 
   Mesh() noexcept = default;
 

--- a/src/NumericalAlgorithms/Spectral/Spectral.hpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.hpp
@@ -566,4 +566,16 @@ template <>
 Spectral::Quadrature
 Options::create_from_yaml<Spectral::Quadrature>::create<void>(
     const Options::Option& options);
+
+template <>
+struct Options::create_from_yaml<Spectral::Basis> {
+  template <typename Metavariables>
+  static Spectral::Basis create(const Options::Option& options) {
+    return create<void>(options);
+  }
+};
+
+template <>
+Spectral::Basis Options::create_from_yaml<Spectral::Basis>::create<void>(
+    const Options::Option& options);
 /// \endcond

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
@@ -23,16 +23,31 @@
 namespace {
 void test_streaming() {
   CHECK(get_output(Spectral::Basis::Legendre) == "Legendre");
+  CHECK(get_output(Spectral::Basis::Chebyshev) == "Chebyshev");
+  CHECK(get_output(Spectral::Basis::FiniteDifference) == "FiniteDifference");
 
   CHECK(get_output(Spectral::Quadrature::Gauss) == "Gauss");
   CHECK(get_output(Spectral::Quadrature::GaussLobatto) == "GaussLobatto");
+  CHECK(get_output(Spectral::Quadrature::CellCentered) == "CellCentered");
+  CHECK(get_output(Spectral::Quadrature::FaceCentered) == "FaceCentered");
 }
 
 void test_creation() {
+  CHECK(Spectral::Basis::Legendre ==
+        TestHelpers::test_creation<Spectral::Basis>("Legendre"));
+  CHECK(Spectral::Basis::Chebyshev ==
+        TestHelpers::test_creation<Spectral::Basis>("Chebyshev"));
+  CHECK(Spectral::Basis::FiniteDifference ==
+        TestHelpers::test_creation<Spectral::Basis>("FiniteDifference"));
+
   CHECK(Spectral::Quadrature::Gauss ==
         TestHelpers::test_creation<Spectral::Quadrature>("Gauss"));
   CHECK(Spectral::Quadrature::GaussLobatto ==
         TestHelpers::test_creation<Spectral::Quadrature>("GaussLobatto"));
+  CHECK(Spectral::Quadrature::CellCentered ==
+        TestHelpers::test_creation<Spectral::Quadrature>("CellCentered"));
+  CHECK(Spectral::Quadrature::FaceCentered ==
+        TestHelpers::test_creation<Spectral::Quadrature>("FaceCentered"));
 }
 
 DataVector unit_polynomial(const size_t deg, const DataVector& x) {


### PR DESCRIPTION
## Proposed changes

mesh can be options parsed. This will be needed to make ObserveFields options parsable to include an interpolating mesh

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

