### PR TITLE
Make DampingFunctions depend on FunctionsOfTime

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/DampingFunction.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/DampingFunction.hpp
@@ -5,12 +5,17 @@
 
 #include <cstddef>
 #include <memory>
+#include <string>
+#include <unordered_map>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Parallel/CharmPupable.hpp"
 
 /// \cond
 class DataVector;
+namespace domain::FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace domain::FunctionsOfTime
 /// \endcond
 
 /// Holds classes implementing DampingFunction (functions \f$R^n \to R\f$).
@@ -48,9 +53,17 @@ class DampingFunction : public PUP::able {
   //@{
   /// Returns the value of the function at the coordinate 'x'.
   virtual Scalar<double> operator()(
-      const tnsr::I<double, VolumeDim, Fr>& x) const noexcept = 0;
+      const tnsr::I<double, VolumeDim, Fr>& x, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept = 0;
   virtual Scalar<DataVector> operator()(
-      const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept = 0;
+      const tnsr::I<DataVector, VolumeDim, Fr>& x, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept = 0;
   //@}
 
   virtual auto get_clone() const noexcept

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/GaussianPlusConstant.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/GaussianPlusConstant.cpp
@@ -8,6 +8,8 @@
 #include <memory>
 #include <pup.h>
 #include <pup_stl.h>
+#include <string>
+#include <unordered_map>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
@@ -15,6 +17,12 @@
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+
+/// \cond
+namespace domain::FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace domain::FunctionsOfTime
+/// \endcond
 
 namespace GeneralizedHarmonic::ConstraintDamping {
 
@@ -51,12 +59,22 @@ Scalar<T> GaussianPlusConstant<VolumeDim, Fr>::apply_call_operator(
 
 template <size_t VolumeDim, typename Fr>
 Scalar<double> GaussianPlusConstant<VolumeDim, Fr>::operator()(
-    const tnsr::I<double, VolumeDim, Fr>& x) const noexcept {
+    const tnsr::I<double, VolumeDim, Fr>& x, const double /*time*/,
+    const std::unordered_map<
+        std::string,
+        std::unique_ptr<
+            domain::FunctionsOfTime::FunctionOfTime>>& /*funtions_of_time*/)
+    const noexcept {
   return apply_call_operator(centered_coordinates(x));
 }
 template <size_t VolumeDim, typename Fr>
 Scalar<DataVector> GaussianPlusConstant<VolumeDim, Fr>::operator()(
-    const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept {
+    const tnsr::I<DataVector, VolumeDim, Fr>& x, const double /*time*/,
+    const std::unordered_map<
+        std::string,
+        std::unique_ptr<
+            domain::FunctionsOfTime::FunctionOfTime>>& /*funtions_of_time*/)
+    const noexcept {
   return apply_call_operator(centered_coordinates(x));
 }
 
@@ -99,10 +117,15 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial))
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(2, data)
 
-#define INSTANTIATE(_, data)                                            \
-  template Scalar<DTYPE(data)> GeneralizedHarmonic::ConstraintDamping:: \
-      GaussianPlusConstant<DIM(data), FRAME(data)>::operator()(         \
-          const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& x)        \
+#define INSTANTIATE(_, data)                                               \
+  template Scalar<DTYPE(data)> GeneralizedHarmonic::ConstraintDamping::    \
+      GaussianPlusConstant<DIM(data), FRAME(data)>::operator()(            \
+          const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& x,           \
+          const double /*time*/,                                           \
+          const std::unordered_map<                                        \
+              std::string,                                                 \
+              std::unique_ptr<domain::FunctionsOfTime::                    \
+                                  FunctionOfTime>>& /*functions_of_time*/) \
           const noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial),

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/GaussianPlusConstant.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/GaussianPlusConstant.hpp
@@ -6,6 +6,9 @@
 #include <array>
 #include <cstddef>
 #include <limits>
+#include <memory>
+#include <string>
+#include <unordered_map>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/DampingFunction.hpp"
@@ -18,6 +21,9 @@ class DataVector;
 namespace PUP {
 class er;
 }  // namespace PUP
+namespace domain::FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace domain::FunctionsOfTime
 /// \endcond
 
 namespace GeneralizedHarmonic::ConstraintDamping {
@@ -80,9 +86,17 @@ class GaussianPlusConstant : public DampingFunction<VolumeDim, Fr> {
       default;
 
   Scalar<double> operator()(
-      const tnsr::I<double, VolumeDim, Fr>& x) const noexcept override;
+      const tnsr::I<double, VolumeDim, Fr>& x, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept override;
   Scalar<DataVector> operator()(
-      const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept override;
+      const tnsr::I<DataVector, VolumeDim, Fr>& x, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept override;
 
   auto get_clone() const noexcept
       -> std::unique_ptr<DampingFunction<VolumeDim, Fr>> override;

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ConstraintGammas.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ConstraintGammas.hpp
@@ -10,9 +10,11 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Tags.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -43,16 +45,21 @@ template <size_t SpatialDim, typename Frame>
 struct ConstraintGamma0Compute : ConstraintGamma0, db::ComputeTag {
   using argument_tags =
       tmpl::list<DampingFunctionGamma0<SpatialDim, Frame>,
-                 domain::Tags::Coordinates<SpatialDim, Frame>>;
+                 domain::Tags::Coordinates<SpatialDim, Frame>, ::Tags::Time,
+                 ::domain::Tags::FunctionsOfTime>;
   using return_type = Scalar<DataVector>;
 
   static constexpr void function(
       const gsl::not_null<Scalar<DataVector>*> gamma,
       const ::GeneralizedHarmonic::ConstraintDamping::DampingFunction<
           SpatialDim, Frame>& damping_function,
-      const tnsr::I<DataVector, SpatialDim, Frame>& coords) noexcept {
+      const tnsr::I<DataVector, SpatialDim, Frame>& coords, const double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) noexcept {
     destructive_resize_components(gamma, get<0>(coords).size());
-    get(*gamma) = get(damping_function(coords));
+    get(*gamma) = get(damping_function(coords, time, functions_of_time));
   }
 
   using base = ConstraintGamma0;
@@ -69,16 +76,21 @@ template <size_t SpatialDim, typename Frame>
 struct ConstraintGamma1Compute : ConstraintGamma1, db::ComputeTag {
   using argument_tags =
       tmpl::list<DampingFunctionGamma1<SpatialDim, Frame>,
-                 domain::Tags::Coordinates<SpatialDim, Frame>>;
+                 domain::Tags::Coordinates<SpatialDim, Frame>, ::Tags::Time,
+                 ::domain::Tags::FunctionsOfTime>;
   using return_type = Scalar<DataVector>;
 
   static constexpr void function(
       const gsl::not_null<Scalar<DataVector>*> gamma1,
       const ::GeneralizedHarmonic::ConstraintDamping::DampingFunction<
           SpatialDim, Frame>& damping_function,
-      const tnsr::I<DataVector, SpatialDim, Frame>& coords) noexcept {
+      const tnsr::I<DataVector, SpatialDim, Frame>& coords, const double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) noexcept {
     destructive_resize_components(gamma1, get<0>(coords).size());
-    get(*gamma1) = get(damping_function(coords));
+    get(*gamma1) = get(damping_function(coords, time, functions_of_time));
   }
 
   using base = ConstraintGamma1;
@@ -95,16 +107,21 @@ template <size_t SpatialDim, typename Frame>
 struct ConstraintGamma2Compute : ConstraintGamma2, db::ComputeTag {
   using argument_tags =
       tmpl::list<DampingFunctionGamma2<SpatialDim, Frame>,
-                 domain::Tags::Coordinates<SpatialDim, Frame>>;
+                 domain::Tags::Coordinates<SpatialDim, Frame>, ::Tags::Time,
+                 ::domain::Tags::FunctionsOfTime>;
   using return_type = Scalar<DataVector>;
 
   static constexpr void function(
       const gsl::not_null<Scalar<DataVector>*> gamma,
       const ::GeneralizedHarmonic::ConstraintDamping::DampingFunction<
           SpatialDim, Frame>& damping_function,
-      const tnsr::I<DataVector, SpatialDim, Frame>& coords) noexcept {
+      const tnsr::I<DataVector, SpatialDim, Frame>& coords, const double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) noexcept {
     destructive_resize_components(gamma, get<0>(coords).size());
-    get(*gamma) = get(damping_function(coords));
+    get(*gamma) = get(damping_function(coords, time, functions_of_time));
   }
 
   using base = ConstraintGamma2;

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Python/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Python/TestFunctions.py
@@ -12,8 +12,8 @@ def squared_distance_from_center(centered_coords, center):
     return np.einsum("i,i", centered_coords, centered_coords)
 
 
-def gaussian_plus_constant_call_operator(coords, constant, amplitude, width,
-                                         center):
+def gaussian_plus_constant_call_operator(coords, time, constant, amplitude,
+                                         width, center):
     one_over_width = 1.0 / width
     distance = squared_distance_from_center(
         centered_coordinates(coords, center), center)


### PR DESCRIPTION
## Proposed changes

Currently, generalized harmonic DampingFunctions are like MathFunctions: their call operators only take the spatial coordinates as inputs. This PR generalizes them to also take Time and FunctionsOfTime, so that you can have a DampingFunction that tracks the motion of the black holes in a binary-black-hole inspiral. E.g. in SpEC, the width of the gaussians scales with the expansion factor.

Note that currently the only DampingFunction implemented, GaussianPlusConstant, does not actually use time dependence. In a followup PR, I will use the changes added here to implement a TripleGaussian time-dependent DampingFunction that reproduces SpEC's BBH DampingFunction, including scaling the Gaussian widths.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
