### PR TITLE
Fix typo in clang-tidy runs

### DIFF
--- a/tools/ClangTidyAll.sh
+++ b/tools/ClangTidyAll.sh
@@ -43,20 +43,20 @@ EXIT_CODE=0
 # Check for run-clang-tidy, then run-clang-tidy-LLVM_VERSION, and
 # if we can't find those, then just loop over the files one at a time.
 RAN_CLANG_TIDY=no
-for run-clang-tidy in run-clang-tidy run-clang-tidy.py "${RUN_CLANG_TIDY_BIN}" ;
+for run_clang_tidy in run-clang-tidy run-clang-tidy.py "${RUN_CLANG_TIDY_BIN}" ;
 do
-    if command -v "${run-clang-tidy}" > /dev/null 2>&1; then
-        ${run-clang-tidy} -quiet ${THREADING_FLAG} -p ${BUILD_DIR} \
+    if command -v "${run_clang_tidy}" > /dev/null 2>&1; then
+        ${run_clang_tidy} -quiet ${THREADING_FLAG} -p ${BUILD_DIR} \
                           ${ALL_SOURCE_FILES} || EXIT_CODE=1
         RAN_CLANG_TIDY=yes
         break
     fi
 done
 if [ ${RAN_CLANG_TIDY} == no ]; then
-    for file in ${ALL_SOURCE_FILES};
+    for FILENAME in ${ALL_SOURCE_FILES};
     do
         printf "\nChecking file $FILENAME...\n"
-        make clang-tidy FILE=${file} || EXIT_CODE=1
+        make clang-tidy FILE=${FILENAME} || EXIT_CODE=1
     done
 fi
 

--- a/tools/ClangTidyHash.sh
+++ b/tools/ClangTidyHash.sh
@@ -60,7 +60,7 @@ EXIT_CODE=0
 RAN_CLANG_TIDY=no
 for run_clang_tidy in run-clang-tidy run-clang-tidy.py "${RUN_CLANG_TIDY_BIN}" ;
 do
-    if command -v "${run-clang-tidy}" > /dev/null 2>&1; then
+    if command -v "${run_clang_tidy}" > /dev/null 2>&1; then
         ${run_clang_tidy} -quiet ${THREADING_FLAG} -p ${BUILD_DIR} \
                           ${MODIFIED_FILES[@]} || EXIT_CODE=1
         RAN_CLANG_TIDY=yes


### PR DESCRIPTION
## Proposed changes

These didn't get caught on my system because I have `run-clang-tidy`
installed. I tested in the container that this works now.

### Types of changes:

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
