### PR TITLE
Fix Boost version across CMake versions

### DIFF
--- a/cmake/SetupBoost.cmake
+++ b/cmake/SetupBoost.cmake
@@ -3,12 +3,15 @@
 
 find_package(Boost 1.60.0 REQUIRED COMPONENTS program_options)
 
+# CMake versions don't set this consistently
+set(Boost_VERSION "${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}")
+
 message(STATUS "Boost include: ${Boost_INCLUDE_DIRS}")
 message(STATUS "Boost libraries: ${Boost_LIBRARIES}")
 
 file(APPEND
   "${CMAKE_BINARY_DIR}/LibraryVersions.txt"
-  "Boost Version:  ${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}\n"
+  "Boost Version:  ${Boost_VERSION}\n"
   )
 
 # Boost organizes targets as:


### PR DESCRIPTION
## Proposed changes

Fixes #2644

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
