### PR TITLE
Make std::variant option-parsable

### DIFF
--- a/docs/DevGuide/OptionParsing.md
+++ b/docs/DevGuide/OptionParsing.md
@@ -34,8 +34,9 @@ The option type can be any type understood natively by yaml-cpp
 (fundamentals, `std::string`, and `std::map`, `std::vector`,
 `std::list`, `std::array`, and `std::pair` of parsable types) and
 types SpECTRE adds support for.  SpECTRE adds `std::unordered_map`
-(but only with ordered keys), and various classes marked as
-constructible in their declarations.
+(but only with ordered keys), `std::variant` (with alternatives tested
+in order), and various classes marked as constructible in their
+declarations.
 
 An option tag can be placed in a group by adding a `group` type alias to the
 struct. The alias should refer to a type that, like option tags, defines a help


### PR DESCRIPTION
The alternatives are tried in order.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
