### PR TITLE
Add interpolation option for ObserveFields

### DIFF
--- a/src/Elliptic/Executables/Elasticity/CMakeLists.txt
+++ b/src/Elliptic/Executables/Elasticity/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBS_TO_LINK
   ElasticPotentialEnergy
   Elliptic
   EllipticDg
+  Events
   Informer
   IO
   LinearOperators

--- a/src/Elliptic/Executables/Poisson/CMakeLists.txt
+++ b/src/Elliptic/Executables/Poisson/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBS_TO_LINK
   DomainCreators
   Elliptic
   EllipticDg
+  Events
   Informer
   IO
   LinearOperators

--- a/src/Evolution/Executables/ScalarWave/CMakeLists.txt
+++ b/src/Evolution/Executables/ScalarWave/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBS_TO_LINK
   CoordinateMaps
   DiscontinuousGalerkin
   DomainCreators
+  Events
   Evolution
   IO
   Informer

--- a/src/NumericalAlgorithms/Interpolation/RegularGridInterpolant.cpp
+++ b/src/NumericalAlgorithms/Interpolation/RegularGridInterpolant.cpp
@@ -3,8 +3,7 @@
 
 #include "RegularGridInterpolant.hpp"
 
-#include "Domain/LogicalCoordinates.hpp"
-#include "NumericalAlgorithms/Spectral/Mesh.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
@@ -25,7 +24,7 @@ RegularGrid<Dim>::RegularGrid(
       // constructed matrix is given instead, apply_matrices does no work.
       if (source_mesh_1d != target_mesh_1d) {
         gsl::at(interpolation_matrices_, d) = Spectral::interpolation_matrix(
-            source_mesh_1d, get<0>(logical_coordinates(target_mesh_1d)));
+            source_mesh_1d, Spectral::collocation_points(target_mesh_1d));
       }
       number_of_target_points_ *= target_mesh_1d.number_of_grid_points();
     } else {

--- a/src/NumericalAlgorithms/Interpolation/RegularGridInterpolant.hpp
+++ b/src/NumericalAlgorithms/Interpolation/RegularGridInterpolant.hpp
@@ -12,7 +12,6 @@
 #include "DataStructures/Matrix.hpp"  // IWYU pragma: keep
 #include "DataStructures/Variables.hpp"
 #include "Utilities/Gsl.hpp"
-#include "Utilities/MakeArray.hpp"
 
 // IWYU pragma: no_forward_declare Variables
 
@@ -56,8 +55,7 @@ class RegularGrid {
   /// coordinates which will override the default coordinates of `target_mesh`.
   RegularGrid(const Mesh<Dim>& source_mesh, const Mesh<Dim>& target_mesh,
               const std::array<DataVector, Dim>&
-                  override_target_mesh_with_1d_logical_coords =
-                      make_array<Dim>(DataVector())) noexcept;
+                  override_target_mesh_with_1d_logical_coords = {}) noexcept;
 
   RegularGrid();
 
@@ -70,8 +68,8 @@ class RegularGrid {
   void interpolate(gsl::not_null<Variables<TagsList>*> result,
                    const Variables<TagsList>& vars) const noexcept;
   template <typename TagsList>
-  Variables<TagsList> interpolate(const Variables<TagsList>& vars) const
-      noexcept;
+  Variables<TagsList> interpolate(
+      const Variables<TagsList>& vars) const noexcept;
   //@}
 
   //@{

--- a/src/ParallelAlgorithms/Events/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Events/CMakeLists.txt
@@ -22,5 +22,7 @@ target_link_libraries(
   Domain
   DomainStructure
   ErrorHandling
+  Interpolation
+  Options
   Utilities
   )

--- a/tests/InputFiles/Elasticity/BentBeam.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam.yaml
@@ -51,3 +51,4 @@ EventsAndTriggers:
     - ObserveFields:
         SubfileName: "element_data"
         VariablesToObserve: [Displacement, Strain]
+        InterpolateToMesh: None

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -61,3 +61,4 @@ EventsAndTriggers:
   : - ObserveFields:
         SubfileName: VolumeData
         VariablesToObserve: [Displacement, Strain]
+        InterpolateToMesh: None

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -90,6 +90,7 @@ EventsAndTriggers:
           - PointwiseL2Norm(GaugeConstraint)
           - PointwiseL2Norm(ThreeIndexConstraint)
           - PointwiseL2Norm(FourIndexConstraint)
+        InterpolateToMesh: None
   ? Slabs:
       EvenlySpaced:
         Interval: 5

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -44,3 +44,4 @@ EventsAndTriggers:
     - ObserveFields:
         SubfileName: VolumeData
         VariablesToObserve: [Field, deriv(Field)]
+        InterpolateToMesh: None

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -44,3 +44,4 @@ EventsAndTriggers:
     - ObserveFields:
         SubfileName: VolumeData
         VariablesToObserve: [Field, deriv(Field)]
+        InterpolateToMesh: None

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -44,3 +44,4 @@ EventsAndTriggers:
     - ObserveFields:
         SubfileName: VolumeData
         VariablesToObserve: [Field, deriv(Field)]
+        InterpolateToMesh: None

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -67,6 +67,7 @@ EventsAndTriggers:
   : - ObserveFields:
         SubfileName: VolumePsi0And100
         VariablesToObserve: ["Psi"]
+        InterpolateToMesh: None
   ? Slabs:
       EvenlySpaced:
         Interval: 50
@@ -74,6 +75,7 @@ EventsAndTriggers:
   : - ObserveFields:
         SubfileName: VolumePsiPiPhiEvery50Slabs
         VariablesToObserve: ["Psi", "Pi", "Phi"]
+        InterpolateToMesh: None
   ? Slabs:
       Specified:
         Values: [100]


### PR DESCRIPTION
## Proposed changes

an optional Mesh can now be passed to the ObserveFields constructor to which all specified tensors are interpolated

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments
I found Test_ObserveFields.cpp to be almost completely unreadable and quite rigid so I was unable to add the interpolation in a more elegant way. Maybe you can think of a nicer way without completely rewriting the unit test.

The test now basically recreates the internals of the interpolation of ObserveFields and checks it against the final result of ObserveFields. Maybe it would make more sense for the unit test to check against some analytical solution.
