### PR TITLE
Remove suggested values from ObserveFields

### DIFF
--- a/src/ParallelAlgorithms/Events/ObserveFields.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveFields.hpp
@@ -119,9 +119,6 @@ class ObserveFields<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
     static constexpr Options::String help = "Subset of variables to observe";
     using type = std::vector<std::string>;
     static size_t lower_bound_on_size() noexcept { return 1; }
-    static type suggested_value() noexcept {
-      return {db::tag_name<Tensors>()...};
-    }
   };
 
   using options = tmpl::list<SubfileName, VariablesToObserve>;


### PR DESCRIPTION
## Proposed changes

These are a bit awkward and lead to confusing warnings like:
The following options differ from their suggested values:
```
VariablesToObserve, line 76:
  Specified: (Psi,Pi,Phi)
  Suggested: (Pi,Phi,Psi)
```
(Only the order differs)

I also don't think we should be suggesting people observing "everything".

### Types of changes:

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
