### PR TITLE
Allow disabling git hooks

### DIFF
--- a/cmake/SetupGitHooks.cmake
+++ b/cmake/SetupGitHooks.cmake
@@ -1,34 +1,46 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-# Check that the source dir is writable. If it is we set up git hooks, if not
-# then there probably won't be any commits anyway...
-EXECUTE_PROCESS(COMMAND test -w ${CMAKE_SOURCE_DIR}
+# Allow disabling the Git hooks because if you are running the code in a
+# container the host may not have all the right things installed. For example,
+# if you are using python2 in the container, the host may not have python2
+# installed and we should instead be setting up hooks from the host or an
+# environment suitably similar to where the commits will be made.
+option(
+  USE_GIT_HOOKS
+  "Set up the git hooks for sanity checks."
+  ON)
+
+if(USE_GIT_HOOKS)
+  # Check that the source dir is writable. If it is we set up git hooks, if not
+  # then there probably won't be any commits anyway...
+  EXECUTE_PROCESS(COMMAND test -w ${CMAKE_SOURCE_DIR}
     RESULT_VARIABLE CHECK_SOURCE_DIR_WRITABLE_RESULT)
 
-# The logic is inverted because shell
-if(NOT CHECK_SOURCE_DIR_WRITABLE_RESULT AND EXISTS ${CMAKE_SOURCE_DIR}/.git)
-  find_package(PythonInterp REQUIRED)
+  # The logic is inverted because shell
+  if(NOT CHECK_SOURCE_DIR_WRITABLE_RESULT AND EXISTS ${CMAKE_SOURCE_DIR}/.git)
+    find_package(PythonInterp REQUIRED)
 
-  find_package(Git REQUIRED)
+    find_package(Git REQUIRED)
 
-  # We use several client-side git hooks to ensure commits are correct as
-  # early as possible.
-  configure_file(
+    # We use several client-side git hooks to ensure commits are correct as
+    # early as possible.
+    configure_file(
       ${CMAKE_SOURCE_DIR}/tools/Hooks/pre-commit.sh
       ${CMAKE_SOURCE_DIR}/.git/hooks/pre-commit
       @ONLY
-  )
+      )
 
-  configure_file(
+    configure_file(
       ${CMAKE_SOURCE_DIR}/tools/Hooks/ClangFormat.py
       ${CMAKE_SOURCE_DIR}/.git/hooks/ClangFormat.py
       @ONLY
-  )
+      )
 
-  configure_file(
+    configure_file(
       ${CMAKE_SOURCE_DIR}/tools/Hooks/CheckFileSize.py
       ${CMAKE_SOURCE_DIR}/.git/hooks/CheckFileSize.py
       @ONLY
-  )
+      )
+  endif()
 endif()

--- a/docs/DevGuide/BuildSystem.md
+++ b/docs/DevGuide/BuildSystem.md
@@ -229,6 +229,16 @@ cmake -D FLAG1=OPT1 ... -D FLAGN=OPTN <SPECTRE_ROOT>
   - Write the source tree into HDF5 files written to disk in order to increase
     reproducibility of results.
     (default is `ON`)
+- USE_GIT_HOOKS
+  - Use git hooks to perform certain sanity checks so that small goofs are
+    caught before getting to CI. Most situations where the hooks can cause
+    problems are handled automatically. The exception is when the build
+    directory is inside a (Singularity) container, we use Python 2 and the host
+    machine (where we make the commits) does not have Python 2. Except for these
+    types of cases, we strongly encourage you to keep the hooks enabled since
+    the same checks are performed during CI and there is a good reason why the
+    checks exist in the first place.
+    (default is `ON`)
 - USE_LD
   - Override the automatically chosen linker. The options are `ld`, `gold`, and
     `lld`.


### PR DESCRIPTION
## Proposed changes

I've found that the git hooks get set from build directories inside the
container, but when set with e.g. python2 I can't commit from outside the
container anymore. We will (rarely) need to disable adding the hooks.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
