### PR TITLE
Support factory-creating the Schwarz subdomain solver and add ExplicitInverse solver

### DIFF
--- a/src/NumericalAlgorithms/LinearSolver/CMakeLists.txt
+++ b/src/NumericalAlgorithms/LinearSolver/CMakeLists.txt
@@ -16,6 +16,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  ExplicitInverse.hpp
   Gmres.hpp
   InnerProduct.hpp
   Lapack.hpp

--- a/src/NumericalAlgorithms/LinearSolver/ExplicitInverse.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/ExplicitInverse.hpp
@@ -1,0 +1,248 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <vector>
+
+#include "DataStructures/DenseMatrix.hpp"
+#include "DataStructures/DenseVector.hpp"
+#include "NumericalAlgorithms/Convergence/HasConverged.hpp"
+#include "NumericalAlgorithms/LinearSolver/LinearSolver.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits/CreateIsCallable.hpp"
+
+namespace LinearSolver::Serial {
+
+/// \cond
+template <typename LinearSolverRegistrars>
+struct ExplicitInverse;
+/// \endcond
+
+namespace Registrars {
+/// Registers the `LinearSolver::Serial::ExplicitInverse` linear solver
+using ExplicitInverse = Registration::Registrar<Serial::ExplicitInverse>;
+}  // namespace Registrars
+
+namespace detail {
+CREATE_IS_CALLABLE(reset)
+CREATE_IS_CALLABLE_V(reset)
+}  // namespace detail
+
+/*!
+ * \brief Linear solver that builds a matrix representation of the linear
+ * operator and inverts it directly
+ *
+ * This solver first constructs an explicit matrix representation by "sniffing
+ * out" the operator, i.e. feeding it with unit vectors, and then directly
+ * inverts the matrix. The result is an operator that solves the linear problem
+ * in a single step. This means that each element has a large initialization
+ * cost, but all successive solves converge immediately.
+ *
+ * \par Advice on using this linear solver:
+ *
+ * - This solver is entirely agnostic to the structure of the linear operator.
+ *   It is usually better to implement a linear solver that is specialized for
+ *   your linear operator to take advantage of its properties. For example, if
+ *   the operator has a tensor-product structure, the linear solver might take
+ *   advantage of that. Only use this solver if no alternatives are available
+ *   and if you have verified that it speeds up your solves.
+ * - Since this linear solver stores the full inverse operator matrix it can
+ *   have significant memory demands. For example, an operator representing a 3D
+ *   first-order Elasticity system (9 variables) discretized on 12 grid points
+ *   per dimension requires ca. 2GB of memory (per element) to store the matrix,
+ *   scaling quadratically with the number of variables and with a power of 6
+ *   with the number of grid points per dimension. Therefore, make sure to
+ *   distribute the elements on a sufficient number of nodes to meet the memory
+ *   requirements.
+ * - This linear solver can be `reset()` when the operator changes (e.g. in each
+ *   nonlinear-solver iteration). However, when using this solver as
+ *   preconditioner it can be advantageous to avoid the reset and the
+ *   corresponding cost of re-building the matrix and its inverse if the
+ *   operator only changes "a little". In that case the preconditioner solves
+ *   subdomain problems only approximately, but possibly still sufficiently to
+ *   provide effective preconditioning. You can toggle this behaviour with the
+ *   `EnableResets` option.
+ */
+template <typename LinearSolverRegistrars =
+              tmpl::list<Registrars::ExplicitInverse>>
+class ExplicitInverse : public LinearSolver<LinearSolverRegistrars> {
+ private:
+  using Base = LinearSolver<LinearSolverRegistrars>;
+
+ public:
+  struct EnableResets {
+    using type = bool;
+    static constexpr Options::String help =
+        "Enable or disable resets. This only has an effect in cases where the "
+        "operator changes, e.g. between nonlinear-solver iterations. Only "
+        "disable resets when using this solver as preconditioner and thus "
+        "approximate solutions are desirable. Disabling resets avoids "
+        "expensive re-building of the operator, but comes at the cost of less "
+        "accurate preconditioning and thus potentially more preconditioned "
+        "iterations. Whether or not this helps convergence overall is highly "
+        "problem-dependent.";
+  };
+
+  using options = tmpl::list<EnableResets>;
+  static constexpr Options::String help =
+      "Build a matrix representation of the linear operator and invert it "
+      "directly. This means that the first solve has a large initialization "
+      "cost, but all subsequent solves converge immediately.";
+
+  ExplicitInverse() = default;
+  ExplicitInverse(const ExplicitInverse& /*rhs*/) = default;
+  ExplicitInverse& operator=(const ExplicitInverse& /*rhs*/) = default;
+  ExplicitInverse(ExplicitInverse&& /*rhs*/) = default;
+  ExplicitInverse& operator=(ExplicitInverse&& /*rhs*/) = default;
+  ~ExplicitInverse() = default;
+
+  explicit ExplicitInverse(bool enable_resets) noexcept
+      : enable_resets_(enable_resets) {}
+
+  /// \cond
+  explicit ExplicitInverse(CkMigrateMessage* m) noexcept : Base(m) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(ExplicitInverse);  // NOLINT
+  /// \endcond
+
+  /*!
+   * \brief Solve the equation \f$Ax=b\f$ by explicitly constructing the
+   * operator matrix \f$A\f$ and its inverse. The first solve is computationally
+   * expensive and successive solves are cheap.
+   *
+   * Building a matrix representation of the `linear_operator` requires
+   * iterating over the `SourceType` (which is also the type returned by the
+   * `linear_operator`) in a consistent way. This can be non-trivial for
+   * heterogeneous data structures because it requires they define a data
+   * ordering. Specifically, the `SourceType` must have a `size()` function as
+   * well as `begin()` and `end()` iterators that point into the data. If the
+   * iterators have a `reset()` function it is used to avoid repeatedly
+   * re-creating the `begin()` iterator. The `reset()` function must not
+   * invalidate the `end()` iterator.
+   */
+  template <typename LinearOperator, typename VarsType, typename SourceType>
+  Convergence::HasConverged solve(gsl::not_null<VarsType*> solution,
+                                  const LinearOperator& linear_operator,
+                                  const SourceType& source) const noexcept;
+
+  /// Flags the operator to require re-initialization. No memory is released.
+  /// Call this function to rebuild the solver when the operator changed.
+  void reset() noexcept override {
+    if (not enable_resets_) {
+      return;
+    }
+    size_ = std::numeric_limits<size_t>::max();
+  }
+
+  /// Size of the operator. The stored matrix will have `size^2` entries.
+  size_t size() const noexcept { return size_; }
+
+  /// The matrix representation of the solver. This matrix approximates the
+  /// inverse of the subdomain operator.
+  const DenseMatrix<double>& matrix_representation() const noexcept {
+    return inverse_;
+  }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) noexcept override {
+    p | enable_resets_;
+    p | size_;
+    p | inverse_;
+    if (p.isUnpacking() and size_ != std::numeric_limits<size_t>::max()) {
+      source_workspace_.resize(size_);
+      solution_workspace_.resize(size_);
+    }
+  }
+
+  std::unique_ptr<Base> get_clone() const noexcept override {
+    return std::make_unique<ExplicitInverse>(*this);
+  }
+
+ private:
+  bool enable_resets_{};
+
+  // Caches for successive solves of the same operator
+  mutable size_t size_ = std::numeric_limits<size_t>::max();
+  mutable DenseMatrix<double, blaze::columnMajor> inverse_{};
+
+  // Buffers to avoid re-allocating memory for applying the operator
+  mutable DenseVector<double> source_workspace_{};
+  mutable DenseVector<double> solution_workspace_{};
+};
+
+template <typename LinearSolverRegistrars>
+template <typename LinearOperator, typename VarsType, typename SourceType>
+Convergence::HasConverged ExplicitInverse<LinearSolverRegistrars>::solve(
+    const gsl::not_null<VarsType*> solution,
+    const LinearOperator& linear_operator,
+    const SourceType& source) const noexcept {
+  if (UNLIKELY(size_ == std::numeric_limits<size_t>::max())) {
+    const auto& used_for_size = source;
+    size_ = used_for_size.size();
+    source_workspace_.resize(size_);
+    solution_workspace_.resize(size_);
+    inverse_.resize(size_, size_);
+    // Construct explicit matrix representation by "sniffing out" the operator,
+    // i.e. feeding it unit vectors
+    auto unit_vector = make_with_value<VarsType>(used_for_size, 0.);
+    auto result_buffer = make_with_value<SourceType>(used_for_size, 0.);
+    auto& operator_matrix = inverse_;
+    size_t i = 0;
+    // Re-using the iterators for all operator invocations
+    auto result_iterator_begin = result_buffer.begin();
+    auto result_iterator_end = result_buffer.end();
+    for (double& unit_vector_data : unit_vector) {
+      // Add a 1 at the unit vector location i
+      unit_vector_data = 1.;
+      // Invoke the operator on the unit vector
+      linear_operator(make_not_null(&result_buffer), unit_vector);
+      // Set the unit vector back to zero
+      unit_vector_data = 0.;
+      // Reset the iterator by calling its `reset` member function or by
+      // re-creating it
+      if constexpr (detail::is_reset_callable_v<decltype(
+                        result_iterator_begin)>) {
+        result_iterator_begin.reset();
+      } else {
+        result_iterator_begin = result_buffer.begin();
+        result_iterator_end = result_buffer.end();
+      }
+      // Store the result in column i of the matrix
+      std::copy(result_iterator_begin, result_iterator_end,
+                column(operator_matrix, i).begin());
+      ++i;
+    }
+    // Directly invert the matrix
+    try {
+      blaze::invert(inverse_);
+    } catch (const std::invalid_argument& e) {
+      ERROR("Could not invert subdomain matrix (size " << size_
+                                                       << "): " << e.what());
+    }
+  }
+  // Copy source into contiguous workspace. In cases where the source and
+  // solution data are already stored contiguously we might avoid the copy and
+  // the associated workspace memory. However, compared to the cost of building
+  // and storing the matrix this is likely insignificant.
+  std::copy(source.begin(), source.end(), source_workspace_.begin());
+  // Apply inverse
+  solution_workspace_ = inverse_ * source_workspace_;
+  // Reconstruct solution data from contiguous workspace
+  std::copy(solution_workspace_.begin(), solution_workspace_.end(),
+            solution->begin());
+  return {0, 0};
+}
+
+/// \cond
+template <typename LinearSolverRegistrars>
+// NOLINTNEXTLINE
+PUP::able::PUP_ID ExplicitInverse<LinearSolverRegistrars>::my_PUP_ID = 0;
+/// \endcond
+
+}  // namespace LinearSolver::Serial

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementActions.hpp
@@ -29,6 +29,7 @@
 #include "Informer/Tags.hpp"
 #include "Informer/Verbosity.hpp"
 #include "NumericalAlgorithms/Convergence/Tags.hpp"
+#include "NumericalAlgorithms/LinearSolver/ExplicitInverse.hpp"
 #include "NumericalAlgorithms/LinearSolver/Gmres.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
@@ -121,6 +122,17 @@ struct SubdomainDataBufferTag : db::SimpleTag {
   using type = SubdomainDataType;
 };
 
+// Allow factory-creating any of these serial linear solvers for use as
+// subdomain solver
+template <typename FieldsTag, typename SubdomainOperator,
+          typename SubdomainData = ElementCenteredSubdomainData<
+              SubdomainOperator::volume_dim,
+              typename db::add_tag_prefix<LinearSolver::Tags::Residual,
+                                          FieldsTag>::tags_list>>
+using subdomain_solver = LinearSolver::Serial::LinearSolver<
+    tmpl::list<::LinearSolver::Serial::Registrars::Gmres<SubdomainData>,
+               ::LinearSolver::Serial::Registrars::ExplicitInverse>>;
+
 template <typename FieldsTag, typename OptionsGroup, typename SubdomainOperator>
 struct InitializeElement {
  private:
@@ -130,12 +142,9 @@ struct InitializeElement {
   static constexpr size_t Dim = SubdomainOperator::volume_dim;
   using SubdomainData =
       ElementCenteredSubdomainData<Dim, typename residual_tag::tags_list>;
-  // Here we choose a serial GMRES linear solver to solve subdomain problems.
-  // This can be generalized to allow the user to make this choice once that
-  // becomes necessary.
-  using subdomain_solver_tag =
-      Tags::SubdomainSolver<LinearSolver::Serial::Gmres<SubdomainData>,
-                            OptionsGroup>;
+  using subdomain_solver_tag = Tags::SubdomainSolver<
+      std::unique_ptr<subdomain_solver<FieldsTag, SubdomainOperator>>,
+      OptionsGroup>;
 
  public:
   using initialization_tags =

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementCenteredSubdomainData.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementCenteredSubdomainData.hpp
@@ -13,8 +13,14 @@
 #include "NumericalAlgorithms/LinearSolver/InnerProduct.hpp"
 #include "ParallelAlgorithms/LinearSolver/Schwarz/OverlapHelpers.hpp"
 #include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace LinearSolver::Schwarz {
+
+/// \cond
+template <bool Const, size_t Dim, typename TagsList>
+struct ElementCenteredSubdomainDataIterator;
+/// \endcond
 
 /*!
  * \brief Data on an element-centered subdomain
@@ -30,6 +36,9 @@ struct ElementCenteredSubdomainData {
   static constexpr size_t volume_dim = Dim;
   using ElementData = Variables<TagsList>;
   using OverlapData = ElementData;
+  using iterator = ElementCenteredSubdomainDataIterator<false, Dim, TagsList>;
+  using const_iterator =
+      ElementCenteredSubdomainDataIterator<true, Dim, TagsList>;
 
   ElementCenteredSubdomainData() = default;
   ElementCenteredSubdomainData(const ElementCenteredSubdomainData&) = default;
@@ -69,6 +78,20 @@ struct ElementCenteredSubdomainData {
       OverlapMap<Dim, Variables<TagsList>> local_overlap_data) noexcept
       : element_data{std::move(local_element_data)},
         overlap_data{std::move(local_overlap_data)} {}
+
+  size_t size() const noexcept {
+    return std::accumulate(
+        overlap_data.begin(), overlap_data.end(), element_data.size(),
+        [](const size_t size, const auto& overlap_id_and_data) noexcept {
+          return size + overlap_id_and_data.second.size();
+        });
+  }
+  iterator begin() noexcept { return {this}; }
+  iterator end() noexcept { return {}; }
+  const_iterator begin() const noexcept { return {this}; }
+  const_iterator end() const noexcept { return {}; }
+  const_iterator cbegin() const noexcept { return begin(); }
+  const_iterator cend() const noexcept { return end(); }
 
   void pup(PUP::er& p) noexcept {  // NOLINT
     p | element_data;
@@ -181,6 +204,140 @@ bool operator!=(
     const ElementCenteredSubdomainData<Dim, TagsList>& rhs) noexcept {
   return not(lhs == rhs);
 }
+
+namespace detail {
+// Defines a consistent ordering of overlap IDs
+template <size_t Dim, typename ValueType>
+std::vector<OverlapId<Dim>> ordered_overlap_ids(
+    const OverlapMap<Dim, ValueType>& overlap_map) noexcept {
+  std::vector<OverlapId<Dim>> overlap_ids{};
+  overlap_ids.reserve(overlap_map.size());
+  std::transform(overlap_map.begin(), overlap_map.end(),
+                 std::back_inserter(overlap_ids),
+                 [](const auto& overlap_id_and_value) noexcept {
+                   return overlap_id_and_value.first;
+                 });
+  std::sort(overlap_ids.begin(), overlap_ids.end(),
+            [](const OverlapId<Dim>& lhs, const OverlapId<Dim>& rhs) noexcept {
+              if (lhs.first.axis() != rhs.first.axis()) {
+                return lhs.first.axis() < rhs.first.axis();
+              }
+              if (lhs.first.side() != rhs.first.side()) {
+                return lhs.first.side() < rhs.first.side();
+              }
+              if (lhs.second.block_id() != rhs.second.block_id()) {
+                return lhs.second.block_id() < rhs.second.block_id();
+              }
+              for (size_t d = 0; d < Dim; ++d) {
+                const auto& lhs_segment_id = lhs.second.segment_ids().at(d);
+                const auto& rhs_segment_id = rhs.second.segment_ids().at(d);
+                if (lhs_segment_id.refinement_level() !=
+                    rhs_segment_id.refinement_level()) {
+                  return lhs_segment_id.refinement_level() <
+                         rhs_segment_id.refinement_level();
+                }
+                if (lhs_segment_id.index() != rhs_segment_id.index()) {
+                  return lhs_segment_id.index() < rhs_segment_id.index();
+                }
+              }
+              return false;
+            });
+  return overlap_ids;
+}
+}  // namespace detail
+
+/*!
+ * \brief Iterate over `LinearSolver::Schwarz::ElementCenteredSubdomainData`
+ *
+ * This iterator guarantees that it steps through the data in the same order as
+ * long as these conditions are satisfied:
+ *
+ * - The set of overlap IDs in the `overlap_data` doesn't change
+ * - The extents of the `element_data` and the `overlap_data doesn't change
+ *
+ * Iterating requires sorting the overlap IDs. If you find this impacts
+ * performance, be advised to implement the internal data storage in
+ * `ElementCenteredSubdomainData` so it stores its data contiguously, e.g. by
+ * implementing non-owning variables.
+ */
+template <bool Const, size_t Dim, typename TagsList>
+struct ElementCenteredSubdomainDataIterator {
+ private:
+  using PtrType =
+      tmpl::conditional_t<Const,
+                          const ElementCenteredSubdomainData<Dim, TagsList>*,
+                          ElementCenteredSubdomainData<Dim, TagsList>*>;
+
+ public:
+  using difference_type = ptrdiff_t;
+  using value_type = double;
+  using pointer = value_type*;
+  using reference = value_type&;
+  using iterator_category = std::forward_iterator_tag;
+
+  /// Construct begin state
+  ElementCenteredSubdomainDataIterator(PtrType data) noexcept : data_(data) {
+    overlap_ids_ = detail::ordered_overlap_ids(data_->overlap_data);
+    reset();
+  }
+
+  void reset() noexcept {
+    overlap_index_ = (data_->element_data.size() == 0 and overlap_ids_.empty())
+                         ? std::numeric_limits<size_t>::max()
+                         : 0;
+    data_index_ = 0;
+  }
+
+  /// Construct end state
+  ElementCenteredSubdomainDataIterator() noexcept {
+    overlap_index_ = std::numeric_limits<size_t>::max();
+    data_index_ = 0;
+  }
+
+  ElementCenteredSubdomainDataIterator& operator++() noexcept {
+    ++data_index_;
+    if (data_index_ ==
+        (overlap_index_ == 0
+             ? data_->element_data
+             : data_->overlap_data.at(overlap_ids_[overlap_index_ - 1]))
+            .size()) {
+      ++overlap_index_;
+      data_index_ = 0;
+    }
+    if (overlap_index_ == overlap_ids_.size() + 1) {
+      overlap_index_ = std::numeric_limits<size_t>::max();
+    }
+    return *this;
+  }
+
+  tmpl::conditional_t<Const, double, double&> operator*() const noexcept {
+    if (overlap_index_ == 0) {
+      return data_->element_data.data()[data_index_];
+    } else {
+      return data_->overlap_data.at(overlap_ids_[overlap_index_ - 1])
+          .data()[data_index_];
+    }
+  }
+
+ private:
+  friend bool operator==(
+      const ElementCenteredSubdomainDataIterator& lhs,
+      const ElementCenteredSubdomainDataIterator& rhs) noexcept {
+    return lhs.overlap_index_ == rhs.overlap_index_ and
+           lhs.data_index_ == rhs.data_index_;
+  }
+
+  friend bool operator!=(
+      const ElementCenteredSubdomainDataIterator& lhs,
+      const ElementCenteredSubdomainDataIterator& rhs) noexcept {
+    return not(lhs == rhs);
+  }
+
+  PtrType data_;
+  std::vector<OverlapId<Dim>> overlap_ids_;
+  size_t overlap_index_;
+  size_t data_index_;
+};
 
 }  // namespace LinearSolver::Schwarz
 

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/Schwarz.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/Schwarz.hpp
@@ -156,6 +156,8 @@ struct Schwarz {
   using component_list = tmpl::list<>;
   using observed_reduction_data_tags = observers::make_reduction_data_tags<
       tmpl::list<async_solvers::reduction_data, detail::reduction_data>>;
+  using subdomain_solver =
+      detail::subdomain_solver<FieldsTag, SubdomainOperator>;
 
   using initialize_element = tmpl::list<
       async_solvers::InitializeElement<FieldsTag, OptionsGroup, SourceTag>,

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/Tags.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/Tags.hpp
@@ -12,7 +12,9 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Options/Auto.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/Serialize.hpp"
 #include "ParallelAlgorithms/LinearSolver/Schwarz/OverlapHelpers.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -34,8 +36,7 @@ template <typename SolverType, typename OptionsGroup>
 struct SubdomainSolver {
   using type = SolverType;
   using group = OptionsGroup;
-  static constexpr Options::String help =
-      "Options for the linear solver on subdomains";
+  static constexpr Options::String help = "The linear solver on subdomains";
 };
 
 }  // namespace OptionTags
@@ -71,7 +72,9 @@ struct SubdomainSolver : SubdomainSolverBase<OptionsGroup>, db::SimpleTag {
   static constexpr bool pass_metavariables = false;
   using option_tags =
       tmpl::list<OptionTags::SubdomainSolver<SolverType, OptionsGroup>>;
-  static type create_from_options(const type& value) noexcept { return value; }
+  static type create_from_options(const type& value) noexcept {
+    return deserialize<type>(serialize<type>(value).data());
+  }
 };
 
 /*!

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_LinearSolver")
 
 set(LIBRARY_SOURCES
+  Test_ExplicitInverse.cpp
   Test_Gmres.cpp
   Test_InnerProduct.cpp
   Test_Lapack.cpp
@@ -13,5 +14,5 @@ add_test_library(
   ${LIBRARY}
   "NumericalAlgorithms/LinearSolver/"
   "${LIBRARY_SOURCES}"
-  "DataStructures;LinearSolver"
+  "DataStructures;DomainStructure;LinearSolver;ParallelSchwarz;Utilities"
   )

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Test_ExplicitInverse.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Test_ExplicitInverse.cpp
@@ -1,0 +1,131 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <functional>
+#include <utility>
+
+#include "DataStructures/ApplyMatrices.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/DenseMatrix.hpp"
+#include "DataStructures/DenseVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/NumericalAlgorithms/LinearSolver/TestHelpers.hpp"
+#include "NumericalAlgorithms/LinearSolver/ExplicitInverse.hpp"
+#include "ParallelAlgorithms/LinearSolver/Schwarz/ElementCenteredSubdomainData.hpp"
+#include "ParallelAlgorithms/LinearSolver/Schwarz/OverlapHelpers.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace helpers = TestHelpers::LinearSolver;
+
+namespace {
+struct ScalarFieldTag {
+  using type = Scalar<DataVector>;
+};
+}  // namespace
+
+namespace LinearSolver::Serial {
+
+SPECTRE_TEST_CASE("Unit.LinearSolver.Serial.ExplicitInverse",
+                  "[Unit][NumericalAlgorithms][LinearSolver]") {
+  {
+    INFO("Solve a simple matrix");
+    const DenseMatrix<double> matrix{{4., 1.}, {3., 1.}};
+    const helpers::ApplyMatrix linear_operator{matrix};
+    const DenseVector<double> source{1., 2.};
+    const DenseVector<double> expected_solution{-1., 5.};
+    DenseVector<double> solution(2);
+    const ExplicitInverse<> solver{true};
+    const auto has_converged =
+        solver.solve(make_not_null(&solution), linear_operator, source);
+    REQUIRE(has_converged);
+    CHECK_MATRIX_APPROX(solver.matrix_representation(), blaze::inv(matrix));
+    CHECK_ITERABLE_APPROX(solution, expected_solution);
+    {
+      INFO("Resetting");
+      ExplicitInverse<> resetting_solver{true};
+      resetting_solver.solve(make_not_null(&solution), linear_operator, source);
+      // Solving a different operator after resetting should work
+      resetting_solver.reset();
+      const DenseMatrix<double> matrix2{{4., 1.}, {1., 3.}};
+      const helpers::ApplyMatrix linear_operator2{matrix2};
+      const DenseVector<double> expected_solution2{0.0909090909090909,
+                                                   0.6363636363636364};
+      resetting_solver.solve(make_not_null(&solution), linear_operator2,
+                             source);
+      CHECK_MATRIX_APPROX(resetting_solver.matrix_representation(),
+                          blaze::inv(matrix2));
+      CHECK_ITERABLE_APPROX(solution, expected_solution2);
+      // When resetting is disabled, the solver should keep applying the cached
+      // inverse even when solving a different operator
+      ExplicitInverse<> non_resetting_solver{false};
+      non_resetting_solver.solve(make_not_null(&solution), linear_operator,
+                                 source);
+      non_resetting_solver.reset();
+      non_resetting_solver.solve(make_not_null(&solution), linear_operator2,
+                                 source);
+      // Still the inverse of the operator we solved first
+      CHECK_MATRIX_APPROX(non_resetting_solver.matrix_representation(),
+                          blaze::inv(matrix));
+      CHECK_ITERABLE_APPROX(solution, blaze::inv(matrix) * source);
+    }
+  }
+  {
+    INFO("Solve a heterogeneous data structure");
+    using SubdomainData = ::LinearSolver::Schwarz::ElementCenteredSubdomainData<
+        1, tmpl::list<ScalarFieldTag>>;
+
+    const Matrix matrix_element{{4., 1., 1.}, {1., 1., 3.}, {0., 2., 0.}};
+    const Matrix matrix_overlap{{4., 1.}, {3., 1.}};
+    const ::LinearSolver::Schwarz::OverlapId<1> overlap_id{
+        Direction<1>::lower_xi(), ElementId<1>{0}};
+    const std::array<std::reference_wrapper<const Matrix>, 1> matrices_element{
+        matrix_element};
+    const std::array<std::reference_wrapper<const Matrix>, 1> matrices_overlap{
+        matrix_overlap};
+    const auto linear_operator = [&matrices_element, &matrices_overlap,
+                                  &overlap_id](
+                                     const gsl::not_null<SubdomainData*> result,
+                                     const SubdomainData& operand) noexcept {
+      apply_matrices(make_not_null(&result->element_data), matrices_element,
+                     operand.element_data, Index<1>{3});
+      apply_matrices(make_not_null(&result->overlap_data.at(overlap_id)),
+                     matrices_overlap, operand.overlap_data.at(overlap_id),
+                     Index<1>{2});
+    };
+
+    SubdomainData source{3};
+    get(get<ScalarFieldTag>(source.element_data)) = DataVector{1., 2., 1.};
+    source.overlap_data.emplace(overlap_id,
+                                typename SubdomainData::OverlapData{2});
+    get(get<ScalarFieldTag>(source.overlap_data.at(overlap_id))) =
+        DataVector{1., 2.};
+    auto expected_solution = make_with_value<SubdomainData>(source, 0.);
+    get(get<ScalarFieldTag>(expected_solution.element_data)) =
+        DataVector{0., 0.5, 0.5};
+    get(get<ScalarFieldTag>(expected_solution.overlap_data.at(overlap_id))) =
+        DataVector{-1., 5.};
+
+    const ExplicitInverse<> solver{true};
+    auto solution = make_with_value<SubdomainData>(source, 0.);
+    solver.solve(make_not_null(&solution), linear_operator, source);
+    CHECK(solver.size() == 5);
+    Matrix expected_matrix(5, 5, 0.);
+    blaze::submatrix(expected_matrix, 0, 0, 3, 3) = matrix_element;
+    blaze::submatrix(expected_matrix, 3, 3, 2, 2) = matrix_overlap;
+    blaze::invert(expected_matrix);
+    CHECK_MATRIX_APPROX(solver.matrix_representation(), expected_matrix);
+    CHECK_VARIABLES_APPROX(solution.element_data,
+                           expected_solution.element_data);
+    CHECK_VARIABLES_APPROX(solution.overlap_data.at(overlap_id),
+                           expected_solution.overlap_data.at(overlap_id));
+  }
+}
+
+}  // namespace LinearSolver::Serial

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_ElementCenteredSubdomainData.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_ElementCenteredSubdomainData.cpp
@@ -75,6 +75,13 @@ SPECTRE_TEST_CASE("Unit.ParallelSchwarz.ElementCenteredSubdomainData",
     subdomain_data1 /= 2.;
     CHECK(subdomain_data1 == subdomain_data_half);
   }
+  SECTION("Iterate raw data") {
+    CAPTURE(subdomain_data1);
+    CAPTURE(subdomain_data2);
+    std::copy(subdomain_data2.begin(), subdomain_data2.end(),
+              subdomain_data1.begin());
+    CHECK(subdomain_data1 == subdomain_data2);
+  }
   SECTION("Remaining tests") {
     test_serialization(subdomain_data1);
     test_copy_semantics(subdomain_data1);

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.cpp
@@ -22,6 +22,7 @@
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Main.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
 #include "ParallelAlgorithms/LinearSolver/Schwarz/ElementCenteredSubdomainData.hpp"
 #include "ParallelAlgorithms/LinearSolver/Schwarz/Protocols.hpp"
@@ -207,7 +208,9 @@ struct Metavariables {
 }  // namespace
 
 static const std::vector<void (*)()> charm_init_node_funcs{
-    &setup_error_handling, &domain::creators::register_derived_with_charm};
+    &setup_error_handling, &domain::creators::register_derived_with_charm,
+    &Parallel::register_derived_classes_with_charm<
+        Metavariables::linear_solver::subdomain_solver>};
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.yaml
@@ -48,12 +48,19 @@ SchwarzSmoother:
   Iterations: 9
   Verbosity: Verbose
   SubdomainSolver:
-    ConvergenceCriteria:
-      MaxIterations: 5
-      RelativeResidual: 1.e-14
-      AbsoluteResidual: 1.e-14
-    Verbosity: Verbose
-    Restart: None
+    # Testing with a preconditioned Krylov-type subdomain solver
+    Gmres:
+      ConvergenceCriteria:
+        MaxIterations: 1
+        RelativeResidual: 1.e-14
+        AbsoluteResidual: 1.e-14
+      Verbosity: Verbose
+      Restart: None
+      Preconditioner:
+        # Preconditioning with the explicitly-built inverse matrix, so all
+        # subdomain solves should converge immediately
+        ExplicitInverse:
+          EnableResets: True
 
 ConvergenceReason: NumIterations
 


### PR DESCRIPTION
## Proposed changes

- With #2629 merged the parallel Schwarz solver can now factory-create its subdomain solver (the serial linear solver that solves the subdomain problem on each element independently).
- This PR also adds an `ExplicitInverse` linear solver that "sniffs out" the operator (i.e. feeds it unit vectors to build the matrix representation) and then inverts it directly. This means it has a large initialization cost, but all subsequent solves are extremely cheap. It's the opposite to the existing GMRES solver, which has no initialization cost but every solve can take a long time. Either can work in practice, though eventually I'll add more fancy solvers that hit some sweet spot in-between these extremes.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
