### PR TITLE
Make DampingFunctions return by not_null

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/DampingFunction.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/DampingFunction.hpp
@@ -10,6 +10,7 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Parallel/CharmPupable.hpp"
+#include "Utilities/Gsl.hpp"
 
 /// \cond
 class DataVector;
@@ -52,13 +53,15 @@ class DampingFunction : public PUP::able {
 
   //@{
   /// Returns the value of the function at the coordinate 'x'.
-  virtual Scalar<double> operator()(
+  virtual void operator()(
+      const gsl::not_null<Scalar<double>*> value_at_x,
       const tnsr::I<double, VolumeDim, Fr>& x, double time,
       const std::unordered_map<
           std::string,
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time) const noexcept = 0;
-  virtual Scalar<DataVector> operator()(
+  virtual void operator()(
+      const gsl::not_null<Scalar<DataVector>*> value_at_x,
       const tnsr::I<DataVector, VolumeDim, Fr>& x, double time,
       const std::unordered_map<
           std::string,

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/GaussianPlusConstant.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/GaussianPlusConstant.hpp
@@ -85,18 +85,18 @@ class GaussianPlusConstant : public DampingFunction<VolumeDim, Fr> {
   GaussianPlusConstant& operator=(GaussianPlusConstant&& /*rhs*/) noexcept =
       default;
 
-  Scalar<double> operator()(
-      const tnsr::I<double, VolumeDim, Fr>& x, double time,
-      const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time) const noexcept override;
-  Scalar<DataVector> operator()(
-      const tnsr::I<DataVector, VolumeDim, Fr>& x, double time,
-      const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time) const noexcept override;
+  void operator()(const gsl::not_null<Scalar<double>*> value_at_x,
+                  const tnsr::I<double, VolumeDim, Fr>& x, double time,
+                  const std::unordered_map<
+                      std::string,
+                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+                      functions_of_time) const noexcept override;
+  void operator()(const gsl::not_null<Scalar<DataVector>*> value_at_x,
+                  const tnsr::I<DataVector, VolumeDim, Fr>& x, double time,
+                  const std::unordered_map<
+                      std::string,
+                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+                      functions_of_time) const noexcept override;
 
   auto get_clone() const noexcept
       -> std::unique_ptr<DampingFunction<VolumeDim, Fr>> override;
@@ -119,11 +119,8 @@ class GaussianPlusConstant : public DampingFunction<VolumeDim, Fr> {
   std::array<double, VolumeDim> center_{};
 
   template <typename T>
-  tnsr::I<T, VolumeDim, Fr> centered_coordinates(
-      const tnsr::I<T, VolumeDim, Fr>& x) const noexcept;
-  template <typename T>
-  Scalar<T> apply_call_operator(
-      const tnsr::I<T, VolumeDim, Fr>& centered_coords) const noexcept;
+  void apply_call_operator(const gsl::not_null<Scalar<T>*> value_at_x,
+                           const tnsr::I<T, VolumeDim, Fr>& x) const noexcept;
 };
 
 template <size_t VolumeDim, typename Fr>

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ConstraintGammas.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ConstraintGammas.hpp
@@ -58,8 +58,7 @@ struct ConstraintGamma0Compute : ConstraintGamma0, db::ComputeTag {
           std::string,
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time) noexcept {
-    destructive_resize_components(gamma, get<0>(coords).size());
-    get(*gamma) = get(damping_function(coords, time, functions_of_time));
+    damping_function(gamma, coords, time, functions_of_time);
   }
 
   using base = ConstraintGamma0;
@@ -89,8 +88,7 @@ struct ConstraintGamma1Compute : ConstraintGamma1, db::ComputeTag {
           std::string,
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time) noexcept {
-    destructive_resize_components(gamma1, get<0>(coords).size());
-    get(*gamma1) = get(damping_function(coords, time, functions_of_time));
+    damping_function(gamma1, coords, time, functions_of_time);
   }
 
   using base = ConstraintGamma1;
@@ -120,8 +118,7 @@ struct ConstraintGamma2Compute : ConstraintGamma2, db::ComputeTag {
           std::string,
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time) noexcept {
-    destructive_resize_components(gamma, get<0>(coords).size());
-    get(*gamma) = get(damping_function(coords, time, functions_of_time));
+    damping_function(gamma, coords, time, functions_of_time);
   }
 
   using base = ConstraintGamma2;

--- a/tests/Unit/Helpers/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TestHelpers.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TestHelpers.hpp
@@ -69,8 +69,15 @@ void check_impl(
                   0.0,
                   std::array<DataVector, 4>{{{1.0}, {0.2}, {0.03}, {0.004}}},
                   std::numeric_limits<double>::max());
-              return gh_damping_function->operator()(coordinates, time,
-                                                     functions_of_time);
+              // Default-construct the scalar, to test that the damping
+              // function's call operator correctly resizes it
+              // (in the case T is a DataVector) with
+              // destructive_resize_components()
+              Scalar<T> value_at_coordinates{};
+              gh_damping_function->operator()(
+                  make_not_null(&value_at_coordinates), coordinates, time,
+                  functions_of_time);
+              return value_at_coordinates;
             };
 
         pypp::check_with_random_values<1>(


### PR DESCRIPTION
## Proposed changes

As suggested by @nilsdeppe, this changes the interface to GH DampingFunctions so they pass by not_null instead of by value.

### Types of changes:

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
