### PR TITLE
Fetch upstream tags on forks to fix CI

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -73,6 +73,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      # Some tests involve release tags, which may not have been pushed to
+      # forks. Fetching them here.
+      - name: Fetch upstream tags on forks
+        if: github.repository != 'sxs-collaboration/spectre'
+        run: |
+          git fetch --tags https://github.com/sxs-collaboration/spectre
       - name: Install Python dependencies
         run: |
           pip3 install \
@@ -103,7 +109,7 @@ jobs:
     name: Clang-tidy
     if: >
       (github.event_name == 'pull_request'
-       && github.repository =='sxs-collaboration/spectre'
+       && github.repository == 'sxs-collaboration/spectre'
        && github.base_ref == 'develop')
       || github.ref != 'refs/heads/develop'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Proposed changes

CI builds broke on forks because the release tags may not have been pushed there.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
