### PR TITLE
Add XCTS system equations

### DIFF
--- a/src/Elliptic/Systems/Xcts/CMakeLists.txt
+++ b/src/Elliptic/Systems/Xcts/CMakeLists.txt
@@ -3,15 +3,32 @@
 
 set(LIBRARY Xcts)
 
-add_spectre_library(${LIBRARY} INTERFACE)
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  Equations.cpp
+  )
 
 spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Equations.hpp
   Geometry.hpp
   Tags.hpp
   Xcts.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  DataStructures
+  Utilities
+  PRIVATE
+  ErrorHandling
+  GeneralRelativity
   )
 
 add_subdirectory(BoundaryConditions)

--- a/src/Elliptic/Systems/Xcts/CMakeLists.txt
+++ b/src/Elliptic/Systems/Xcts/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Geometry.hpp
   Tags.hpp
   Xcts.hpp
   )

--- a/src/Elliptic/Systems/Xcts/Equations.cpp
+++ b/src/Elliptic/Systems/Xcts/Equations.cpp
@@ -1,0 +1,784 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Elliptic/Systems/Xcts/Equations.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <functional>
+#include <optional>
+#include <string>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/TempBuffer.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Elliptic/Systems/Xcts/Geometry.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Xcts {
+namespace detail {
+void fully_contract_flat_cartesian(
+    const gsl::not_null<Scalar<DataVector>*> result,
+    const tnsr::II<DataVector, 3>& tensor1,
+    const tnsr::II<DataVector, 3>& tensor2) noexcept {
+  get(*result) = tensor1.multiplicity(0_st) * tensor1[0] * tensor2[0];
+  for (size_t i = 1; i < tensor1.size(); ++i) {
+    get(*result) += tensor1.multiplicity(i) * tensor1[i] * tensor2[i];
+  }
+}
+void fully_contract(const gsl::not_null<Scalar<DataVector>*> result,
+                    const gsl::not_null<DataVector*> buffer1,
+                    const gsl::not_null<DataVector*> buffer2,
+                    const tnsr::II<DataVector, 3>& tensor1,
+                    const tnsr::II<DataVector, 3>& tensor2,
+                    const tnsr::ii<DataVector, 3>& metric) noexcept {
+  get(*result) = 0.;
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      *buffer1 = metric.get(i, 0) * tensor1.get(0, j);
+      *buffer2 = metric.get(j, 0) * tensor2.get(i, 0);
+      for (size_t k = 1; k < 3; ++k) {
+        *buffer1 += metric.get(i, k) * tensor1.get(k, j);
+        *buffer2 += metric.get(j, k) * tensor2.get(i, k);
+      }
+      get(*result) += *buffer1 * *buffer2;
+    }
+  }
+}
+}  // namespace detail
+
+template <int ConformalMatterScale>
+void add_hamiltonian_sources(
+    const gsl::not_null<Scalar<DataVector>*> hamiltonian_constraint,
+    const Scalar<DataVector>& conformal_energy_density,
+    const Scalar<DataVector>& extrinsic_curvature_trace,
+    const Scalar<DataVector>& conformal_factor) noexcept {
+  // See BaumgarteShapiro, Eq. (3.110)
+  get(*hamiltonian_constraint) +=
+      (square(get(extrinsic_curvature_trace)) / 12. -
+       2. * M_PI * get(conformal_energy_density) /
+           pow<ConformalMatterScale>(get(conformal_factor))) *
+      pow<5>(get(conformal_factor));
+}
+
+template <int ConformalMatterScale>
+void add_linearized_hamiltonian_sources(
+    const gsl::not_null<Scalar<DataVector>*> linearized_hamiltonian_constraint,
+    const Scalar<DataVector>& conformal_energy_density,
+    const Scalar<DataVector>& extrinsic_curvature_trace,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& conformal_factor_correction) noexcept {
+  get(*linearized_hamiltonian_constraint) +=
+      ((5. / 12.) * square(get(extrinsic_curvature_trace)) -
+       2. * (5. - ConformalMatterScale) * M_PI * get(conformal_energy_density) /
+           pow<ConformalMatterScale>(get(conformal_factor))) *
+      pow<4>(get(conformal_factor)) * get(conformal_factor_correction);
+}
+
+void add_distortion_hamiltonian_sources(
+    const gsl::not_null<Scalar<DataVector>*> hamiltonian_constraint,
+    const Scalar<DataVector>&
+        longitudinal_shift_minus_dt_conformal_metric_over_lapse_square,
+    const Scalar<DataVector>& conformal_factor) noexcept {
+  // See BaumgarteShapiro, Eq. (3.110) and (3.112). Note: 0.03125 = 1 / 32
+  get(*hamiltonian_constraint) -=
+      0.03125 * pow<5>(get(conformal_factor)) *
+      get(longitudinal_shift_minus_dt_conformal_metric_over_lapse_square);
+}
+
+void add_linearized_distortion_hamiltonian_sources(
+    const gsl::not_null<Scalar<DataVector>*> linearized_hamiltonian_constraint,
+    const Scalar<DataVector>&
+        longitudinal_shift_minus_dt_conformal_metric_over_lapse_square,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& conformal_factor_correction) noexcept {
+  // Note: 0.15625 = 5 / 32
+  get(*linearized_hamiltonian_constraint) -=
+      0.15625 * pow<4>(get(conformal_factor)) *
+      get(longitudinal_shift_minus_dt_conformal_metric_over_lapse_square) *
+      get(conformal_factor_correction);
+}
+
+void add_curved_hamiltonian_or_lapse_sources(
+    const gsl::not_null<Scalar<DataVector>*> hamiltonian_or_lapse_equation,
+    const Scalar<DataVector>& conformal_ricci_scalar,
+    const Scalar<DataVector>& field) noexcept {
+  // See BaumgarteShapiro, Eq. (3.110) and (3.111). Note: 0.125 = 1 / 8
+  get(*hamiltonian_or_lapse_equation) +=
+      0.125 * get(conformal_ricci_scalar) * get(field);
+}
+
+template <int ConformalMatterScale>
+void add_lapse_sources(
+    const gsl::not_null<Scalar<DataVector>*> lapse_equation,
+    const Scalar<DataVector>& conformal_energy_density,
+    const Scalar<DataVector>& conformal_stress_trace,
+    const Scalar<DataVector>& extrinsic_curvature_trace,
+    const Scalar<DataVector>& dt_extrinsic_curvature_trace,
+    const Scalar<DataVector>& shift_dot_deriv_extrinsic_curvature_trace,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& lapse_times_conformal_factor) noexcept {
+  // See BaumgarteShapiro, Eq. (3.111)
+  get(*lapse_equation) +=
+      get(lapse_times_conformal_factor) * pow<4>(get(conformal_factor)) *
+          ((5. / 12.) * square(get(extrinsic_curvature_trace)) +
+           2. * M_PI *
+               (get(conformal_energy_density) +
+                2. * get(conformal_stress_trace)) /
+               pow<ConformalMatterScale>(get(conformal_factor))) +
+      pow<5>(get(conformal_factor)) *
+          (get(shift_dot_deriv_extrinsic_curvature_trace) -
+           get(dt_extrinsic_curvature_trace));
+}
+
+template <int ConformalMatterScale>
+void add_linearized_lapse_sources(
+    const gsl::not_null<Scalar<DataVector>*> linearized_lapse_equation,
+    const Scalar<DataVector>& conformal_energy_density,
+    const Scalar<DataVector>& conformal_stress_trace,
+    const Scalar<DataVector>& extrinsic_curvature_trace,
+    const Scalar<DataVector>& dt_extrinsic_curvature_trace,
+    const Scalar<DataVector>& shift_dot_deriv_extrinsic_curvature_trace,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& lapse_times_conformal_factor,
+    const Scalar<DataVector>& conformal_factor_correction,
+    const Scalar<DataVector>&
+        lapse_times_conformal_factor_correction) noexcept {
+  get(*linearized_lapse_equation) +=
+      pow<3>(get(conformal_factor)) *
+          ((get(conformal_factor) *
+                get(lapse_times_conformal_factor_correction) +
+            4. * get(lapse_times_conformal_factor) *
+                get(conformal_factor_correction)) *
+               5. / 12. * square(get(extrinsic_curvature_trace)) +
+           (get(conformal_factor) *
+                get(lapse_times_conformal_factor_correction) +
+            (4. - ConformalMatterScale) * get(lapse_times_conformal_factor) *
+                get(conformal_factor_correction)) *
+               2. * M_PI *
+               (get(conformal_energy_density) +
+                2 * get(conformal_stress_trace)) /
+               pow<ConformalMatterScale>(get(conformal_factor))) +
+      5. * pow<4>(get(conformal_factor)) * get(conformal_factor_correction) *
+          (get(shift_dot_deriv_extrinsic_curvature_trace) -
+           get(dt_extrinsic_curvature_trace));
+}
+
+void add_distortion_hamiltonian_and_lapse_sources(
+    gsl::not_null<Scalar<DataVector>*> hamiltonian_constraint,
+    gsl::not_null<Scalar<DataVector>*> lapse_equation,
+    const Scalar<DataVector>&
+        longitudinal_shift_minus_dt_conformal_metric_square,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& lapse_times_conformal_factor) noexcept {
+  // See BaumgarteShapiro, Eq. (3.110--3.112). Note: 0.03125 = 1 / 32 and
+  // 0.21875 = 7 / 32
+  get(*hamiltonian_constraint) -=
+      0.03125 * pow<7>(get(conformal_factor)) /
+      square(get(lapse_times_conformal_factor)) *
+      get(longitudinal_shift_minus_dt_conformal_metric_square);
+  get(*lapse_equation) +=
+      0.21875 * pow<6>(get(conformal_factor)) /
+      get(lapse_times_conformal_factor) *
+      get(longitudinal_shift_minus_dt_conformal_metric_square);
+}
+
+void add_linearized_distortion_hamiltonian_and_lapse_sources(
+    gsl::not_null<Scalar<DataVector>*> hamiltonian_constraint,
+    gsl::not_null<Scalar<DataVector>*> lapse_equation,
+    const Scalar<DataVector>&
+        longitudinal_shift_minus_dt_conformal_metric_square,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& lapse_times_conformal_factor,
+    const Scalar<DataVector>& conformal_factor_correction,
+    const Scalar<DataVector>&
+        lapse_times_conformal_factor_correction) noexcept {
+  // Note: 0.03125 = 1 / 32 and 0.21875 = 7 / 32
+  get(*hamiltonian_constraint) -=
+      0.03125 * pow<6>(get(conformal_factor)) *
+      (7. * get(conformal_factor_correction) -
+       2. * get(conformal_factor) / get(lapse_times_conformal_factor) *
+           get(lapse_times_conformal_factor_correction)) /
+      square(get(lapse_times_conformal_factor)) *
+      get(longitudinal_shift_minus_dt_conformal_metric_square);
+  get(*lapse_equation) +=
+      0.21875 * pow<5>(get(conformal_factor)) *
+      (6. * get(conformal_factor_correction) -
+       get(conformal_factor) / get(lapse_times_conformal_factor) *
+           get(lapse_times_conformal_factor_correction)) /
+      get(lapse_times_conformal_factor) *
+      get(longitudinal_shift_minus_dt_conformal_metric_square);
+}
+
+template <int ConformalMatterScale, Geometry ConformalGeometry>
+void add_momentum_sources_impl(
+    const gsl::not_null<Scalar<DataVector>*> hamiltonian_constraint,
+    const gsl::not_null<Scalar<DataVector>*> lapse_equation,
+    const gsl::not_null<tnsr::I<DataVector, 3>*> momentum_constraint,
+    const tnsr::I<DataVector, 3>& conformal_momentum_density,
+    const tnsr::i<DataVector, 3>& extrinsic_curvature_trace_gradient,
+    const std::optional<std::reference_wrapper<const tnsr::ii<DataVector, 3>>>
+        conformal_metric,
+    const std::optional<std::reference_wrapper<const tnsr::II<DataVector, 3>>>
+        inv_conformal_metric,
+    const tnsr::I<DataVector, 3>& minus_div_dt_conformal_metric,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& lapse_times_conformal_factor,
+    const tnsr::I<DataVector, 3>& conformal_factor_flux,
+    const tnsr::I<DataVector, 3>& lapse_times_conformal_factor_flux,
+    const tnsr::II<DataVector, 3>&
+        longitudinal_shift_minus_dt_conformal_metric) noexcept {
+  if constexpr (ConformalGeometry == Geometry::FlatCartesian) {
+    ASSERT(not conformal_metric.has_value() and
+               not inv_conformal_metric.has_value(),
+           "You don't need to pass a conformal metric to this function when it "
+           "is specialized for a flat conformal geometry in Cartesian "
+           "coordinates.");
+  } else {
+    ASSERT(conformal_metric.has_value() and inv_conformal_metric.has_value(),
+           "You must pass a conformal metric to this function when it is "
+           "specialized for a curved conformal geometry.");
+  }
+  const size_t num_points = get(conformal_factor).size();
+  TempBuffer<tmpl::list<::Tags::TempScalar<0>, ::Tags::TempI<1, 3>,
+                        ::Tags::Tempi<2, 3>>>
+      buffer{num_points};
+  {
+    auto& longitudinal_shift_square = get<::Tags::TempScalar<0>>(buffer);
+    if constexpr (ConformalGeometry == Geometry::FlatCartesian) {
+      detail::fully_contract_flat_cartesian(
+          make_not_null(&longitudinal_shift_square),
+          longitudinal_shift_minus_dt_conformal_metric,
+          longitudinal_shift_minus_dt_conformal_metric);
+    } else {
+      auto& buffer1 = get<0>(get<::Tags::TempI<1, 3>>(buffer));
+      auto& buffer2 = get<1>(get<::Tags::TempI<1, 3>>(buffer));
+      detail::fully_contract(make_not_null(&longitudinal_shift_square),
+                             make_not_null(&buffer1), make_not_null(&buffer2),
+                             longitudinal_shift_minus_dt_conformal_metric,
+                             longitudinal_shift_minus_dt_conformal_metric,
+                             conformal_metric->get());
+    }
+    // Add shift terms to Hamiltonian and lapse equations, see BaumgarteShapiro,
+    // Eq. (3.110--3.112). Note: 0.03125 = 1 / 32 and 0.21875 = 7 / 32
+    get(*hamiltonian_constraint) -= 0.03125 * pow<7>(get(conformal_factor)) /
+                                    square(get(lapse_times_conformal_factor)) *
+                                    get(longitudinal_shift_square);
+    get(*lapse_equation) += 0.21875 * pow<6>(get(conformal_factor)) /
+                            get(lapse_times_conformal_factor) *
+                            get(longitudinal_shift_square);
+  }
+  // Add sources to momentum constraint, see BaumgarteShapiro, Eq. (3.109)
+  {
+    // Extrinsic curvature term
+    auto& extrinsic_curvature_trace_gradient_term =
+        get<::Tags::TempI<1, 3>>(buffer);
+    if constexpr (ConformalGeometry == Geometry::FlatCartesian) {
+      get<0>(extrinsic_curvature_trace_gradient_term) =
+          get<0>(extrinsic_curvature_trace_gradient);
+      get<1>(extrinsic_curvature_trace_gradient_term) =
+          get<1>(extrinsic_curvature_trace_gradient);
+      get<2>(extrinsic_curvature_trace_gradient_term) =
+          get<2>(extrinsic_curvature_trace_gradient);
+    } else {
+      raise_or_lower_index(
+          make_not_null(&extrinsic_curvature_trace_gradient_term),
+          extrinsic_curvature_trace_gradient, inv_conformal_metric->get());
+    }
+    for (size_t i = 0; i < 3; ++i) {
+      extrinsic_curvature_trace_gradient_term.get(i) *=
+          4. / 3. * get(lapse_times_conformal_factor) / get(conformal_factor);
+      momentum_constraint->get(i) +=
+          extrinsic_curvature_trace_gradient_term.get(i);
+    }
+  }
+  {
+    // Lapse deriv term, to be contracted with longitudinal shift
+    auto& lapse_deriv_term = get<::Tags::TempI<1, 3>>(buffer);
+    for (size_t i = 0; i < 3; ++i) {
+      lapse_deriv_term.get(i) =
+          (lapse_times_conformal_factor_flux.get(i) /
+               get(lapse_times_conformal_factor) -
+           7. * conformal_factor_flux.get(i) / get(conformal_factor));
+    }
+    auto& lapse_deriv_term_lo = get<::Tags::Tempi<2, 3>>(buffer);
+    if constexpr (ConformalGeometry == Geometry::FlatCartesian) {
+      get<0>(lapse_deriv_term_lo) = get<0>(lapse_deriv_term);
+      get<1>(lapse_deriv_term_lo) = get<1>(lapse_deriv_term);
+      get<2>(lapse_deriv_term_lo) = get<2>(lapse_deriv_term);
+    } else {
+      raise_or_lower_index(make_not_null(&lapse_deriv_term_lo),
+                           lapse_deriv_term, conformal_metric->get());
+    }
+    for (size_t i = 0; i < 3; ++i) {
+      // Add momentum density term
+      momentum_constraint->get(i) +=
+          16. * M_PI * get(lapse_times_conformal_factor) *
+          pow<3 - ConformalMatterScale>(get(conformal_factor)) *
+          conformal_momentum_density.get(i);
+      // Add longitudinal shift term
+      for (size_t j = 0; j < 3; ++j) {
+        momentum_constraint->get(i) +=
+            longitudinal_shift_minus_dt_conformal_metric.get(i, j) *
+            lapse_deriv_term_lo.get(j);
+      }
+      momentum_constraint->get(i) -= minus_div_dt_conformal_metric.get(i);
+    }
+  }
+}
+
+template <int ConformalMatterScale>
+void add_curved_momentum_sources(
+    const gsl::not_null<Scalar<DataVector>*> hamiltonian_constraint,
+    const gsl::not_null<Scalar<DataVector>*> lapse_equation,
+    const gsl::not_null<tnsr::I<DataVector, 3>*> momentum_constraint,
+    const tnsr::I<DataVector, 3>& conformal_momentum_density,
+    const tnsr::i<DataVector, 3>& extrinsic_curvature_trace_gradient,
+    const tnsr::ii<DataVector, 3>& conformal_metric,
+    const tnsr::II<DataVector, 3>& inv_conformal_metric,
+    const tnsr::I<DataVector, 3>& minus_div_dt_conformal_metric,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& lapse_times_conformal_factor,
+    const tnsr::I<DataVector, 3>& conformal_factor_flux,
+    const tnsr::I<DataVector, 3>& lapse_times_conformal_factor_flux,
+    const tnsr::II<DataVector, 3>&
+        longitudinal_shift_minus_dt_conformal_metric) noexcept {
+  add_momentum_sources_impl<ConformalMatterScale, Geometry::Curved>(
+      hamiltonian_constraint, lapse_equation, momentum_constraint,
+      conformal_momentum_density, extrinsic_curvature_trace_gradient,
+      conformal_metric, inv_conformal_metric, minus_div_dt_conformal_metric,
+      conformal_factor, lapse_times_conformal_factor, conformal_factor_flux,
+      lapse_times_conformal_factor_flux,
+      longitudinal_shift_minus_dt_conformal_metric);
+}
+
+template <int ConformalMatterScale>
+void add_flat_cartesian_momentum_sources(
+    const gsl::not_null<Scalar<DataVector>*> hamiltonian_constraint,
+    const gsl::not_null<Scalar<DataVector>*> lapse_equation,
+    const gsl::not_null<tnsr::I<DataVector, 3>*> momentum_constraint,
+    const tnsr::I<DataVector, 3>& conformal_momentum_density,
+    const tnsr::i<DataVector, 3>& extrinsic_curvature_trace_gradient,
+    const tnsr::I<DataVector, 3>& minus_div_dt_conformal_metric,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& lapse_times_conformal_factor,
+    const tnsr::I<DataVector, 3>& conformal_factor_flux,
+    const tnsr::I<DataVector, 3>& lapse_times_conformal_factor_flux,
+    const tnsr::II<DataVector, 3>&
+        longitudinal_shift_minus_dt_conformal_metric) noexcept {
+  add_momentum_sources_impl<ConformalMatterScale, Geometry::FlatCartesian>(
+      hamiltonian_constraint, lapse_equation, momentum_constraint,
+      conformal_momentum_density, extrinsic_curvature_trace_gradient,
+      std::nullopt, std::nullopt, minus_div_dt_conformal_metric,
+      conformal_factor, lapse_times_conformal_factor, conformal_factor_flux,
+      lapse_times_conformal_factor_flux,
+      longitudinal_shift_minus_dt_conformal_metric);
+}
+
+template <int ConformalMatterScale, Geometry ConformalGeometry>
+void add_linearized_momentum_sources_impl(
+    const gsl::not_null<Scalar<DataVector>*> linearized_hamiltonian_constraint,
+    const gsl::not_null<Scalar<DataVector>*> linearized_lapse_equation,
+    const gsl::not_null<tnsr::I<DataVector, 3>*> linearized_momentum_constraint,
+    const tnsr::I<DataVector, 3>& conformal_momentum_density,
+    const tnsr::i<DataVector, 3>& extrinsic_curvature_trace_gradient,
+    const std::optional<std::reference_wrapper<const tnsr::ii<DataVector, 3>>>
+        conformal_metric,
+    const std::optional<std::reference_wrapper<const tnsr::II<DataVector, 3>>>
+        inv_conformal_metric,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& lapse_times_conformal_factor,
+    const tnsr::I<DataVector, 3>& conformal_factor_flux,
+    const tnsr::I<DataVector, 3>& lapse_times_conformal_factor_flux,
+    const tnsr::II<DataVector, 3>& longitudinal_shift_minus_dt_conformal_metric,
+    const Scalar<DataVector>& conformal_factor_correction,
+    const Scalar<DataVector>& lapse_times_conformal_factor_correction,
+    const tnsr::I<DataVector, 3>& shift_correction,
+    const tnsr::I<DataVector, 3>& conformal_factor_flux_correction,
+    const tnsr::I<DataVector, 3>& lapse_times_conformal_factor_flux_correction,
+    const tnsr::II<DataVector, 3>& longitudinal_shift_correction) noexcept {
+  if constexpr (ConformalGeometry == Geometry::FlatCartesian) {
+    ASSERT(not conformal_metric.has_value() and
+               not inv_conformal_metric.has_value(),
+           "You don't need to pass a conformal metric to this function when it "
+           "is specialized for a flat conformal geometry in Cartesian "
+           "coordinates.");
+  } else {
+    ASSERT(conformal_metric.has_value() and inv_conformal_metric.has_value(),
+           "You must pass a conformal metric to this function when it is "
+           "specialized for a curved conformal geometry.");
+  }
+  const size_t num_points = get(conformal_factor).size();
+  TempBuffer<tmpl::list<::Tags::TempScalar<0>, ::Tags::TempI<1, 3>,
+                        ::Tags::Tempi<2, 3>>>
+      buffer{num_points};
+  {
+    // Add shift terms to linearized Hamiltonian and lapse equations
+    auto& longitudinal_shift_square = get<::Tags::TempScalar<0>>(buffer);
+    if constexpr (ConformalGeometry == Geometry::FlatCartesian) {
+      detail::fully_contract_flat_cartesian(
+          make_not_null(&longitudinal_shift_square),
+          longitudinal_shift_minus_dt_conformal_metric,
+          longitudinal_shift_minus_dt_conformal_metric);
+    } else {
+      auto& buffer1 = get<0>(get<::Tags::TempI<1, 3>>(buffer));
+      auto& buffer2 = get<1>(get<::Tags::TempI<1, 3>>(buffer));
+      detail::fully_contract(make_not_null(&longitudinal_shift_square),
+                             make_not_null(&buffer1), make_not_null(&buffer2),
+                             longitudinal_shift_minus_dt_conformal_metric,
+                             longitudinal_shift_minus_dt_conformal_metric,
+                             conformal_metric->get());
+    }
+    // Note: 0.21875 = 7 / 32, 0.0625 = 1 / 16 and 1.3125 = 21 / 16
+    get(*linearized_hamiltonian_constraint) +=
+        -0.21875 * pow<6>(get(conformal_factor)) /
+            square(get(lapse_times_conformal_factor)) *
+            get(longitudinal_shift_square) * get(conformal_factor_correction) +
+        0.0625 * pow<7>(get(conformal_factor)) /
+            pow<3>(get(lapse_times_conformal_factor)) *
+            get(longitudinal_shift_square) *
+            get(lapse_times_conformal_factor_correction);
+    get(*linearized_lapse_equation) +=
+        1.3125 * pow<5>(get(conformal_factor)) /
+            get(lapse_times_conformal_factor) * get(longitudinal_shift_square) *
+            get(conformal_factor_correction) -
+        0.21875 * pow<6>(get(conformal_factor)) /
+            square(get(lapse_times_conformal_factor)) *
+            get(longitudinal_shift_square) *
+            get(lapse_times_conformal_factor_correction);
+  }
+  {
+    // Add shift-correction terms to linearized Hamiltonian and lapse equations,
+    // re-using the buffer used for `longitudinal_shift_square` above
+    auto& longitudinal_shift_dot_correction =
+        get<::Tags::TempScalar<0>>(buffer);
+    if constexpr (ConformalGeometry == Geometry::FlatCartesian) {
+      detail::fully_contract_flat_cartesian(
+          make_not_null(&longitudinal_shift_dot_correction),
+          longitudinal_shift_minus_dt_conformal_metric,
+          longitudinal_shift_correction);
+    } else {
+      auto& buffer1 = get<0>(get<::Tags::TempI<1, 3>>(buffer));
+      auto& buffer2 = get<1>(get<::Tags::TempI<1, 3>>(buffer));
+      detail::fully_contract(make_not_null(&longitudinal_shift_dot_correction),
+                             make_not_null(&buffer1), make_not_null(&buffer2),
+                             longitudinal_shift_minus_dt_conformal_metric,
+                             longitudinal_shift_correction,
+                             conformal_metric->get());
+    }
+    // Note: 0.0625 = 1 / 16 and 0.4375 = 7 / 16
+    get(*linearized_hamiltonian_constraint) -=
+        0.0625 * pow<7>(get(conformal_factor)) /
+        square(get(lapse_times_conformal_factor)) *
+        get(longitudinal_shift_dot_correction);
+    get(*linearized_lapse_equation) += 0.4375 * pow<6>(get(conformal_factor)) /
+                                       get(lapse_times_conformal_factor) *
+                                       get(longitudinal_shift_dot_correction);
+  }
+  {
+    // Add remaining linearization w.r.t. shift of the shift.grad(K) term to the
+    // lapse equation. The linearization w.r.t. conformal factor and lapse is
+    // already added in `linearized_lapse_sources`.
+    auto& shift_correction_dot_extrinsic_curvature_trace_gradient =
+        get<::Tags::TempScalar<0>>(buffer);
+    dot_product(
+        make_not_null(&shift_correction_dot_extrinsic_curvature_trace_gradient),
+        shift_correction, extrinsic_curvature_trace_gradient);
+    get(*linearized_lapse_equation) +=
+        pow<5>(get(conformal_factor)) *
+        get(shift_correction_dot_extrinsic_curvature_trace_gradient);
+  }
+  // Add sources to linearized momentum constraint
+  {
+    auto& extrinsic_curvature_trace_gradient_term =
+        get<::Tags::TempI<1, 3>>(buffer);
+    // Extrinsic curvature term
+    if constexpr (ConformalGeometry == Geometry::FlatCartesian) {
+      get<0>(extrinsic_curvature_trace_gradient_term) =
+          get<0>(extrinsic_curvature_trace_gradient);
+      get<1>(extrinsic_curvature_trace_gradient_term) =
+          get<1>(extrinsic_curvature_trace_gradient);
+      get<2>(extrinsic_curvature_trace_gradient_term) =
+          get<2>(extrinsic_curvature_trace_gradient);
+    } else {
+      raise_or_lower_index(
+          make_not_null(&extrinsic_curvature_trace_gradient_term),
+          extrinsic_curvature_trace_gradient, inv_conformal_metric->get());
+    }
+    for (size_t i = 0; i < 3; ++i) {
+      extrinsic_curvature_trace_gradient_term.get(i) *=
+          4. / 3. *
+          (get(lapse_times_conformal_factor_correction) /
+               get(conformal_factor) -
+           get(lapse_times_conformal_factor) / square(get(conformal_factor)) *
+               get(conformal_factor_correction));
+      linearized_momentum_constraint->get(i) +=
+          extrinsic_curvature_trace_gradient_term.get(i);
+    }
+  }
+  {
+    // Compute lapse deriv term to be contracted with longitudinal
+    // shift-correction
+    auto& lapse_deriv_term = get<::Tags::TempI<1, 3>>(buffer);
+    for (size_t i = 0; i < 3; ++i) {
+      lapse_deriv_term.get(i) =
+          (lapse_times_conformal_factor_flux.get(i) /
+               get(lapse_times_conformal_factor) -
+           7. * conformal_factor_flux.get(i) / get(conformal_factor));
+    }
+    auto& lapse_deriv_term_lo = get<::Tags::Tempi<2, 3>>(buffer);
+    if constexpr (ConformalGeometry == Geometry::FlatCartesian) {
+      get<0>(lapse_deriv_term_lo) = get<0>(lapse_deriv_term);
+      get<1>(lapse_deriv_term_lo) = get<1>(lapse_deriv_term);
+      get<2>(lapse_deriv_term_lo) = get<2>(lapse_deriv_term);
+    } else {
+      raise_or_lower_index(make_not_null(&lapse_deriv_term_lo),
+                           lapse_deriv_term, conformal_metric->get());
+    }
+    for (size_t i = 0; i < 3; ++i) {
+      // Add momentum density term
+      linearized_momentum_constraint->get(i) +=
+          16. * M_PI *
+          (pow<3 - ConformalMatterScale>(get(conformal_factor)) *
+               get(lapse_times_conformal_factor_correction) +
+           (3. - ConformalMatterScale) *
+               pow<2 - ConformalMatterScale>(get(conformal_factor)) *
+               get(lapse_times_conformal_factor) *
+               get(conformal_factor_correction)) *
+          conformal_momentum_density.get(i);
+      // Add longitudinal shift-correction term
+      for (size_t j = 0; j < 3; ++j) {
+        linearized_momentum_constraint->get(i) +=
+            longitudinal_shift_correction.get(i, j) *
+            lapse_deriv_term_lo.get(j);
+      }
+    }
+  }
+  {
+    // Compute lapse deriv correction term to be contracted with longitudinal
+    // shift
+    auto& lapse_deriv_correction_term = get<::Tags::TempI<1, 3>>(buffer);
+    for (size_t i = 0; i < 3; ++i) {
+      lapse_deriv_correction_term.get(i) =
+          (lapse_times_conformal_factor_flux_correction.get(i) /
+               get(lapse_times_conformal_factor) -
+           lapse_times_conformal_factor_flux.get(i) /
+               square(get(lapse_times_conformal_factor)) *
+               get(lapse_times_conformal_factor_correction) -
+           7. * conformal_factor_flux_correction.get(i) /
+               get(conformal_factor) +
+           7. * conformal_factor_flux.get(i) / square(get(conformal_factor)) *
+               get(conformal_factor_correction));
+    }
+    auto& lapse_deriv_correction_term_lo = get<::Tags::Tempi<2, 3>>(buffer);
+    if constexpr (ConformalGeometry == Geometry::FlatCartesian) {
+      get<0>(lapse_deriv_correction_term_lo) =
+          get<0>(lapse_deriv_correction_term);
+      get<1>(lapse_deriv_correction_term_lo) =
+          get<1>(lapse_deriv_correction_term);
+      get<2>(lapse_deriv_correction_term_lo) =
+          get<2>(lapse_deriv_correction_term);
+    } else {
+      raise_or_lower_index(make_not_null(&lapse_deriv_correction_term_lo),
+                           lapse_deriv_correction_term,
+                           conformal_metric->get());
+    }
+    for (size_t i = 0; i < 3; ++i) {
+      // Add longitudinal shift term
+      for (size_t j = 0; j < 3; ++j) {
+        linearized_momentum_constraint->get(i) +=
+            longitudinal_shift_minus_dt_conformal_metric.get(i, j) *
+            lapse_deriv_correction_term_lo.get(j);
+      }
+    }
+  }
+}
+
+template <int ConformalMatterScale>
+void add_curved_linearized_momentum_sources(
+    gsl::not_null<Scalar<DataVector>*> linearized_hamiltonian_constraint,
+    gsl::not_null<Scalar<DataVector>*> linearized_lapse_equation,
+    gsl::not_null<tnsr::I<DataVector, 3>*> linearized_momentum_constraint,
+    const tnsr::I<DataVector, 3>& conformal_momentum_density,
+    const tnsr::i<DataVector, 3>& extrinsic_curvature_trace_gradient,
+    const tnsr::ii<DataVector, 3>& conformal_metric,
+    const tnsr::II<DataVector, 3>& inv_conformal_metric,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& lapse_times_conformal_factor,
+    const tnsr::I<DataVector, 3>& conformal_factor_flux,
+    const tnsr::I<DataVector, 3>& lapse_times_conformal_factor_flux,
+    const tnsr::II<DataVector, 3>& longitudinal_shift_minus_dt_conformal_metric,
+    const Scalar<DataVector>& conformal_factor_correction,
+    const Scalar<DataVector>& lapse_times_conformal_factor_correction,
+    const tnsr::I<DataVector, 3>& shift_correction,
+    const tnsr::I<DataVector, 3>& conformal_factor_flux_correction,
+    const tnsr::I<DataVector, 3>& lapse_times_conformal_factor_flux_correction,
+    const tnsr::II<DataVector, 3>& longitudinal_shift_correction) noexcept {
+  add_linearized_momentum_sources_impl<ConformalMatterScale, Geometry::Curved>(
+      linearized_hamiltonian_constraint, linearized_lapse_equation,
+      linearized_momentum_constraint, conformal_momentum_density,
+      extrinsic_curvature_trace_gradient, conformal_metric,
+      inv_conformal_metric, conformal_factor, lapse_times_conformal_factor,
+      conformal_factor_flux, lapse_times_conformal_factor_flux,
+      longitudinal_shift_minus_dt_conformal_metric, conformal_factor_correction,
+      lapse_times_conformal_factor_correction, shift_correction,
+      conformal_factor_flux_correction,
+      lapse_times_conformal_factor_flux_correction,
+      longitudinal_shift_correction);
+}
+
+template <int ConformalMatterScale>
+void add_flat_cartesian_linearized_momentum_sources(
+    gsl::not_null<Scalar<DataVector>*> linearized_hamiltonian_constraint,
+    gsl::not_null<Scalar<DataVector>*> linearized_lapse_equation,
+    gsl::not_null<tnsr::I<DataVector, 3>*> linearized_momentum_constraint,
+    const tnsr::I<DataVector, 3>& conformal_momentum_density,
+    const tnsr::i<DataVector, 3>& extrinsic_curvature_trace_gradient,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& lapse_times_conformal_factor,
+    const tnsr::I<DataVector, 3>& conformal_factor_flux,
+    const tnsr::I<DataVector, 3>& lapse_times_conformal_factor_flux,
+    const tnsr::II<DataVector, 3>& longitudinal_shift_minus_dt_conformal_metric,
+    const Scalar<DataVector>& conformal_factor_correction,
+    const Scalar<DataVector>& lapse_times_conformal_factor_correction,
+    const tnsr::I<DataVector, 3>& shift_correction,
+    const tnsr::I<DataVector, 3>& conformal_factor_flux_correction,
+    const tnsr::I<DataVector, 3>& lapse_times_conformal_factor_flux_correction,
+    const tnsr::II<DataVector, 3>& longitudinal_shift_correction) noexcept {
+  add_linearized_momentum_sources_impl<ConformalMatterScale,
+                                       Geometry::FlatCartesian>(
+      linearized_hamiltonian_constraint, linearized_lapse_equation,
+      linearized_momentum_constraint, conformal_momentum_density,
+      extrinsic_curvature_trace_gradient, std::nullopt, std::nullopt,
+      conformal_factor, lapse_times_conformal_factor, conformal_factor_flux,
+      lapse_times_conformal_factor_flux,
+      longitudinal_shift_minus_dt_conformal_metric, conformal_factor_correction,
+      lapse_times_conformal_factor_correction, shift_correction,
+      conformal_factor_flux_correction,
+      lapse_times_conformal_factor_flux_correction,
+      longitudinal_shift_correction);
+}
+
+// Instantiate all function templates
+
+#define CONF_MATTER_SCALE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data)                                                \
+  template void add_hamiltonian_sources<CONF_MATTER_SCALE(data)>(             \
+      gsl::not_null<Scalar<DataVector>*> hamiltonian_constraint,              \
+      const Scalar<DataVector>& conformal_energy_density,                     \
+      const Scalar<DataVector>& extrinsic_curvature_trace,                    \
+      const Scalar<DataVector>& conformal_factor) noexcept;                   \
+  template void add_linearized_hamiltonian_sources<CONF_MATTER_SCALE(data)>(  \
+      gsl::not_null<Scalar<DataVector>*> linearized_hamiltonian_constraint,   \
+      const Scalar<DataVector>& conformal_energy_density,                     \
+      const Scalar<DataVector>& extrinsic_curvature_trace,                    \
+      const Scalar<DataVector>& conformal_factor,                             \
+      const Scalar<DataVector>& conformal_factor_correction) noexcept;        \
+  template void add_lapse_sources<CONF_MATTER_SCALE(data)>(                   \
+      gsl::not_null<Scalar<DataVector>*> lapse_equation,                      \
+      const Scalar<DataVector>& conformal_energy_density,                     \
+      const Scalar<DataVector>& conformal_stress_trace,                       \
+      const Scalar<DataVector>& extrinsic_curvature_trace,                    \
+      const Scalar<DataVector>& dt_extrinsic_curvature_trace,                 \
+      const Scalar<DataVector>& shift_dot_deriv_extrinsic_curvature_trace,    \
+      const Scalar<DataVector>& conformal_factor,                             \
+      const Scalar<DataVector>& lapse_times_conformal_factor) noexcept;       \
+  template void add_linearized_lapse_sources<CONF_MATTER_SCALE(data)>(        \
+      gsl::not_null<Scalar<DataVector>*> linearized_lapse_equation,           \
+      const Scalar<DataVector>& conformal_energy_density,                     \
+      const Scalar<DataVector>& conformal_stress_trace,                       \
+      const Scalar<DataVector>& extrinsic_curvature_trace,                    \
+      const Scalar<DataVector>& dt_extrinsic_curvature_trace,                 \
+      const Scalar<DataVector>& shift_dot_deriv_extrinsic_curvature_trace,    \
+      const Scalar<DataVector>& conformal_factor,                             \
+      const Scalar<DataVector>& lapse_times_conformal_factor,                 \
+      const Scalar<DataVector>& conformal_factor_correction,                  \
+      const Scalar<DataVector>&                                               \
+          lapse_times_conformal_factor_correction) noexcept;                  \
+  template void add_curved_momentum_sources<CONF_MATTER_SCALE(data)>(         \
+      gsl::not_null<Scalar<DataVector>*> hamiltonian_constraint,              \
+      gsl::not_null<Scalar<DataVector>*> lapse_equation,                      \
+      gsl::not_null<tnsr::I<DataVector, 3>*> momentum_constraint,             \
+      const tnsr::I<DataVector, 3>& conformal_momentum_density,               \
+      const tnsr::i<DataVector, 3>& extrinsic_curvature_trace_gradient,       \
+      const tnsr::ii<DataVector, 3>& conformal_metric,                        \
+      const tnsr::II<DataVector, 3>& inv_conformal_metric,                    \
+      const tnsr::I<DataVector, 3>& minus_div_dt_conformal_metric,            \
+      const Scalar<DataVector>& conformal_factor,                             \
+      const Scalar<DataVector>& lapse_times_conformal_factor,                 \
+      const tnsr::I<DataVector, 3>& conformal_factor_flux,                    \
+      const tnsr::I<DataVector, 3>& lapse_times_conformal_factor_flux,        \
+      const tnsr::II<DataVector, 3>&                                          \
+          longitudinal_shift_minus_dt_conformal_metric) noexcept;             \
+  template void add_flat_cartesian_momentum_sources<CONF_MATTER_SCALE(data)>( \
+      gsl::not_null<Scalar<DataVector>*> hamiltonian_constraint,              \
+      gsl::not_null<Scalar<DataVector>*> lapse_equation,                      \
+      gsl::not_null<tnsr::I<DataVector, 3>*> momentum_constraint,             \
+      const tnsr::I<DataVector, 3>& conformal_momentum_density,               \
+      const tnsr::i<DataVector, 3>& extrinsic_curvature_trace_gradient,       \
+      const tnsr::I<DataVector, 3>& minus_div_dt_conformal_metric,            \
+      const Scalar<DataVector>& conformal_factor,                             \
+      const Scalar<DataVector>& lapse_times_conformal_factor,                 \
+      const tnsr::I<DataVector, 3>& conformal_factor_flux,                    \
+      const tnsr::I<DataVector, 3>& lapse_times_conformal_factor_flux,        \
+      const tnsr::II<DataVector, 3>&                                          \
+          longitudinal_shift_minus_dt_conformal_metric) noexcept;             \
+  template void                                                               \
+  add_curved_linearized_momentum_sources<CONF_MATTER_SCALE(data)>(            \
+      gsl::not_null<Scalar<DataVector>*> linearized_hamiltonian_constraint,   \
+      gsl::not_null<Scalar<DataVector>*> linearized_lapse_equation,           \
+      gsl::not_null<tnsr::I<DataVector, 3>*> linearized_momentum_constraint,  \
+      const tnsr::I<DataVector, 3>& conformal_momentum_density,               \
+      const tnsr::i<DataVector, 3>& extrinsic_curvature_trace_gradient,       \
+      const tnsr::ii<DataVector, 3>& conformal_metric,                        \
+      const tnsr::II<DataVector, 3>& inv_conformal_metric,                    \
+      const Scalar<DataVector>& conformal_factor,                             \
+      const Scalar<DataVector>& lapse_times_conformal_factor,                 \
+      const tnsr::I<DataVector, 3>& conformal_factor_flux,                    \
+      const tnsr::I<DataVector, 3>& lapse_times_conformal_factor_flux,        \
+      const tnsr::II<DataVector, 3>&                                          \
+          longitudinal_shift_minus_dt_conformal_metric,                       \
+      const Scalar<DataVector>& conformal_factor_correction,                  \
+      const Scalar<DataVector>& lapse_times_conformal_factor_correction,      \
+      const tnsr::I<DataVector, 3>& shift_correction,                         \
+      const tnsr::I<DataVector, 3>& conformal_factor_flux_correction,         \
+      const tnsr::I<DataVector, 3>&                                           \
+          lapse_times_conformal_factor_flux_correction,                       \
+      const tnsr::II<DataVector, 3>& longitudinal_shift_correction) noexcept; \
+  template void                                                               \
+  add_flat_cartesian_linearized_momentum_sources<CONF_MATTER_SCALE(data)>(    \
+      gsl::not_null<Scalar<DataVector>*> linearized_hamiltonian_constraint,   \
+      gsl::not_null<Scalar<DataVector>*> linearized_lapse_equation,           \
+      gsl::not_null<tnsr::I<DataVector, 3>*> linearized_momentum_constraint,  \
+      const tnsr::I<DataVector, 3>& conformal_momentum_density,               \
+      const tnsr::i<DataVector, 3>& extrinsic_curvature_trace_gradient,       \
+      const Scalar<DataVector>& conformal_factor,                             \
+      const Scalar<DataVector>& lapse_times_conformal_factor,                 \
+      const tnsr::I<DataVector, 3>& conformal_factor_flux,                    \
+      const tnsr::I<DataVector, 3>& lapse_times_conformal_factor_flux,        \
+      const tnsr::II<DataVector, 3>&                                          \
+          longitudinal_shift_minus_dt_conformal_metric,                       \
+      const Scalar<DataVector>& conformal_factor_correction,                  \
+      const Scalar<DataVector>& lapse_times_conformal_factor_correction,      \
+      const tnsr::I<DataVector, 3>& shift_correction,                         \
+      const tnsr::I<DataVector, 3>& conformal_factor_flux_correction,         \
+      const tnsr::I<DataVector, 3>&                                           \
+          lapse_times_conformal_factor_flux_correction,                       \
+      const tnsr::II<DataVector, 3>& longitudinal_shift_correction) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (0, 6, 8))
+
+#undef CONF_MATTER_SCALE
+#undef INSTANTIATION
+
+}  // namespace Xcts

--- a/src/Elliptic/Systems/Xcts/Equations.hpp
+++ b/src/Elliptic/Systems/Xcts/Equations.hpp
@@ -1,0 +1,284 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+class DataVector;
+/// \endcond
+
+namespace Xcts {
+namespace detail {
+// Tensor-contraction helper functions that should be replaced by tensor
+// expressions once those work
+void fully_contract_flat_cartesian(
+    gsl::not_null<Scalar<DataVector>*> result,
+    const tnsr::II<DataVector, 3>& tensor1,
+    const tnsr::II<DataVector, 3>& tensor2) noexcept;
+void fully_contract(gsl::not_null<Scalar<DataVector>*> result,
+                    gsl::not_null<DataVector*> buffer1,
+                    gsl::not_null<DataVector*> buffer2,
+                    const tnsr::II<DataVector, 3>& tensor1,
+                    const tnsr::II<DataVector, 3>& tensor2,
+                    const tnsr::ii<DataVector, 3>& metric) noexcept;
+}  // namespace detail
+
+/*!
+ * \brief Add the nonlinear source to the Hamiltonian constraint on a flat
+ * conformal background in Cartesian coordinates and with
+ * \f$\bar{u}_{ij}=0=\beta^i\f$.
+ *
+ * Adds \f$\frac{1}{12}\psi^5 K^2 - 2\pi\psi^{5-n}\bar{\rho}\f$ where \f$n\f$ is
+ * the `ConformalMatterScale` and \f$\bar{\rho}=\psi^n\rho\f$ is the
+ * conformally-scaled energy density. Additional sources can be added with
+ * `add_distortion_hamiltonian_sources` and
+ * `add_curved_hamiltonian_or_lapse_sources`.
+ *
+ * \see Xcts
+ */
+template <int ConformalMatterScale>
+void add_hamiltonian_sources(
+    gsl::not_null<Scalar<DataVector>*> hamiltonian_constraint,
+    const Scalar<DataVector>& conformal_energy_density,
+    const Scalar<DataVector>& extrinsic_curvature_trace,
+    const Scalar<DataVector>& conformal_factor) noexcept;
+
+/// The linearization of `add_hamiltonian_sources`
+template <int ConformalMatterScale>
+void add_linearized_hamiltonian_sources(
+    gsl::not_null<Scalar<DataVector>*> linearized_hamiltonian_constraint,
+    const Scalar<DataVector>& conformal_energy_density,
+    const Scalar<DataVector>& extrinsic_curvature_trace,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& conformal_factor_correction) noexcept;
+
+/*!
+ * \brief Add the "distortion" source term to the Hamiltonian constraint.
+ *
+ * Adds \f$-\frac{1}{8}\psi^{-7}\bar{A}^{ij}\bar{A}_{ij}\f$.
+ *
+ * \see Xcts
+ * \see Xcts::Tags::LongitudinalShiftMinusDtConformalMetricOverLapseSquare
+ */
+void add_distortion_hamiltonian_sources(
+    gsl::not_null<Scalar<DataVector>*> hamiltonian_constraint,
+    const Scalar<DataVector>&
+        longitudinal_shift_minus_dt_conformal_metric_over_lapse_square,
+    const Scalar<DataVector>& conformal_factor) noexcept;
+
+/*!
+ * \brief The linearization of `add_distortion_hamiltonian_sources`
+ *
+ * Note that this linearization is only w.r.t. \f$\psi\f$.
+ */
+void add_linearized_distortion_hamiltonian_sources(
+    gsl::not_null<Scalar<DataVector>*> linearized_hamiltonian_constraint,
+    const Scalar<DataVector>&
+        longitudinal_shift_minus_dt_conformal_metric_over_lapse_square,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& conformal_factor_correction) noexcept;
+
+/*!
+ * \brief Add the contributions from a curved background geometry to the
+ * Hamiltonian constraint or lapse equation
+ *
+ * Adds \f$\frac{1}{8}\psi\bar{R}\f$. This term appears both in the Hamiltonian
+ * constraint and the lapse equation (where in the latter \f$\psi\f$ is replaced
+ * by \f$\alpha\psi\f$).
+ *
+ * This term is linear.
+ *
+ * \see Xcts
+ */
+void add_curved_hamiltonian_or_lapse_sources(
+    gsl::not_null<Scalar<DataVector>*> hamiltonian_or_lapse_equation,
+    const Scalar<DataVector>& conformal_ricci_scalar,
+    const Scalar<DataVector>& field) noexcept;
+
+/*!
+ * \brief Add the nonlinear source to the lapse equation on a flat conformal
+ * background in Cartesian coordinates and with \f$\bar{u}_{ij}=0=\beta^i\f$.
+ *
+ * Adds \f$(\alpha\psi)\left(\frac{5}{12}\psi^4 K^2 + 2\pi\psi^{4-n}
+ * \left(\bar{\rho} + 2\bar{S}\right)\right) + \psi^5
+ * \left(\beta^i\partial_i K - \partial_t K\right)\f$ where \f$n\f$ is the
+ * `ConformalMatterScale` and matter quantities are conformally-scaled.
+ * Additional sources can be added with
+ * `add_distortion_hamiltonian_and_lapse_sources` and
+ * `add_curved_hamiltonian_or_lapse_sources`.
+ *
+ * \see Xcts
+ */
+template <int ConformalMatterScale>
+void add_lapse_sources(
+    gsl::not_null<Scalar<DataVector>*> lapse_equation,
+    const Scalar<DataVector>& conformal_energy_density,
+    const Scalar<DataVector>& conformal_stress_trace,
+    const Scalar<DataVector>& extrinsic_curvature_trace,
+    const Scalar<DataVector>& dt_extrinsic_curvature_trace,
+    const Scalar<DataVector>& shift_dot_deriv_extrinsic_curvature_trace,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& lapse_times_conformal_factor) noexcept;
+
+/*!
+ * \brief The linearization of `add_lapse_sources`
+ *
+ * Note that this linearization is only w.r.t. \f$\psi\f$ and \f$\alpha\psi\f$.
+ * The linearization w.r.t. \f$\beta^i\f$ is added in
+ * `add_curved_linearized_momentum_sources` or
+ * `add_flat_cartesian_linearized_momentum_sources`.
+ */
+template <int ConformalMatterScale>
+void add_linearized_lapse_sources(
+    gsl::not_null<Scalar<DataVector>*> linearized_lapse_equation,
+    const Scalar<DataVector>& conformal_energy_density,
+    const Scalar<DataVector>& conformal_stress_trace,
+    const Scalar<DataVector>& extrinsic_curvature_trace,
+    const Scalar<DataVector>& dt_extrinsic_curvature_trace,
+    const Scalar<DataVector>& shift_dot_deriv_extrinsic_curvature_trace,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& lapse_times_conformal_factor,
+    const Scalar<DataVector>& conformal_factor_correction,
+    const Scalar<DataVector>& lapse_times_conformal_factor_correction) noexcept;
+
+/*!
+ * \brief Add the "distortion" source term to the Hamiltonian constraint and the
+ * lapse equation.
+ *
+ * Adds \f$-\frac{1}{8}\psi^{-7}\bar{A}^{ij}\bar{A}_{ij}\f$ to the Hamiltonian
+ * constraint and \f$\frac{7}{8}\alpha\psi^{-7}\bar{A}^{ij}\bar{A}_{ij}\f$ to
+ * the lapse equation.
+ *
+ * \see Xcts
+ * \see Xcts::Tags::LongitudinalShiftMinusDtConformalMetricSquare
+ */
+void add_distortion_hamiltonian_and_lapse_sources(
+    gsl::not_null<Scalar<DataVector>*> hamiltonian_constraint,
+    gsl::not_null<Scalar<DataVector>*> lapse_equation,
+    const Scalar<DataVector>&
+        longitudinal_shift_minus_dt_conformal_metric_square,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& lapse_times_conformal_factor) noexcept;
+
+/*!
+ * \brief The linearization of `add_distortion_hamiltonian_and_lapse_sources`
+ *
+ * Note that this linearization is only w.r.t. \f$\psi\f$ and \f$\alpha\psi\f$.
+ */
+void add_linearized_distortion_hamiltonian_and_lapse_sources(
+    gsl::not_null<Scalar<DataVector>*> hamiltonian_constraint,
+    gsl::not_null<Scalar<DataVector>*> lapse_equation,
+    const Scalar<DataVector>&
+        longitudinal_shift_minus_dt_conformal_metric_square,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& lapse_times_conformal_factor,
+    const Scalar<DataVector>& conformal_factor_correction,
+    const Scalar<DataVector>& lapse_times_conformal_factor_correction) noexcept;
+
+/*!
+ * \brief Add the nonlinear source to the momentum constraint and add the
+ * "distortion" source term to the Hamiltonian constraint and lapse equation.
+ *
+ * Adds \f$\left((\bar{L}\beta)^{ij} - \bar{u}^{ij}\right)
+ * \left(\frac{\partial_j (\alpha\psi)}{\alpha\psi}
+ * - 7 \frac{\partial_j \psi}{\psi}\right)
+ * + \partial_j\bar{u}^{ij}
+ * + \frac{4}{3}\frac{\alpha\psi}{\psi}\bar{\gamma}^{ij}\partial_j K
+ * + 16\pi\left(\alpha\psi\right)\psi^{3-n} \bar{S}^i\f$ to the momentum
+ * constraint, where \f$n\f$ is the `ConformalMatterScale` and
+ * \f$\bar{S}^i=\psi^n S^i\f$ is the conformally-scaled momentum density.
+ *
+ * Note that the \f$\partial_j\bar{u}^{ij}\f$ term is not the full covariant
+ * divergence, but only the partial-derivatives part of it. The curved
+ * contribution to this term can be added together with the curved contribution
+ * to the flux divergence of the dynamic shift variable with the
+ * `Elasticity::add_curved_sources` function.
+ *
+ * Also adds \f$-\frac{1}{8}\psi^{-7}\bar{A}^{ij}\bar{A}_{ij}\f$ to the
+ * Hamiltonian constraint and
+ * \f$\frac{7}{8}\alpha\psi^{-7}\bar{A}^{ij}\bar{A}_{ij}\f$ to the lapse
+ * equation.
+ *
+ * \see Xcts
+ */
+//@{
+template <int ConformalMatterScale>
+void add_curved_momentum_sources(
+    gsl::not_null<Scalar<DataVector>*> hamiltonian_constraint,
+    gsl::not_null<Scalar<DataVector>*> lapse_equation,
+    gsl::not_null<tnsr::I<DataVector, 3>*> momentum_constraint,
+    const tnsr::I<DataVector, 3>& conformal_momentum_density,
+    const tnsr::i<DataVector, 3>& extrinsic_curvature_trace_gradient,
+    const tnsr::ii<DataVector, 3>& conformal_metric,
+    const tnsr::II<DataVector, 3>& inv_conformal_metric,
+    const tnsr::I<DataVector, 3>& minus_div_dt_conformal_metric,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& lapse_times_conformal_factor,
+    const tnsr::I<DataVector, 3>& conformal_factor_flux,
+    const tnsr::I<DataVector, 3>& lapse_times_conformal_factor_flux,
+    const tnsr::II<DataVector, 3>&
+        longitudinal_shift_minus_dt_conformal_metric) noexcept;
+
+template <int ConformalMatterScale>
+void add_flat_cartesian_momentum_sources(
+    gsl::not_null<Scalar<DataVector>*> hamiltonian_constraint,
+    gsl::not_null<Scalar<DataVector>*> lapse_equation,
+    gsl::not_null<tnsr::I<DataVector, 3>*> momentum_constraint,
+    const tnsr::I<DataVector, 3>& conformal_momentum_density,
+    const tnsr::i<DataVector, 3>& extrinsic_curvature_trace_gradient,
+    const tnsr::I<DataVector, 3>& minus_div_dt_conformal_metric,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& lapse_times_conformal_factor,
+    const tnsr::I<DataVector, 3>& conformal_factor_flux,
+    const tnsr::I<DataVector, 3>& lapse_times_conformal_factor_flux,
+    const tnsr::II<DataVector, 3>&
+        longitudinal_shift_minus_dt_conformal_metric) noexcept;
+//@}
+
+/// The linearization of `add_curved_momentum_sources`
+template <int ConformalMatterScale>
+void add_curved_linearized_momentum_sources(
+    gsl::not_null<Scalar<DataVector>*> linearized_hamiltonian_constraint,
+    gsl::not_null<Scalar<DataVector>*> linearized_lapse_equation,
+    gsl::not_null<tnsr::I<DataVector, 3>*> linearized_momentum_constraint,
+    const tnsr::I<DataVector, 3>& conformal_momentum_density,
+    const tnsr::i<DataVector, 3>& extrinsic_curvature_trace_gradient,
+    const tnsr::ii<DataVector, 3>& conformal_metric,
+    const tnsr::II<DataVector, 3>& inv_conformal_metric,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& lapse_times_conformal_factor,
+    const tnsr::I<DataVector, 3>& conformal_factor_flux,
+    const tnsr::I<DataVector, 3>& lapse_times_conformal_factor_flux,
+    const tnsr::II<DataVector, 3>& longitudinal_shift_minus_dt_conformal_metric,
+    const Scalar<DataVector>& conformal_factor_correction,
+    const Scalar<DataVector>& lapse_times_conformal_factor_correction,
+    const tnsr::I<DataVector, 3>& shift_correction,
+    const tnsr::I<DataVector, 3>& conformal_factor_flux_correction,
+    const tnsr::I<DataVector, 3>& lapse_times_conformal_factor_flux_correction,
+    const tnsr::II<DataVector, 3>& longitudinal_shift_correction) noexcept;
+
+/// The linearization of `add_flat_cartesian_momentum_sources`
+template <int ConformalMatterScale>
+void add_flat_cartesian_linearized_momentum_sources(
+    gsl::not_null<Scalar<DataVector>*> linearized_hamiltonian_constraint,
+    gsl::not_null<Scalar<DataVector>*> linearized_lapse_equation,
+    gsl::not_null<tnsr::I<DataVector, 3>*> linearized_momentum_constraint,
+    const tnsr::I<DataVector, 3>& conformal_momentum_density,
+    const tnsr::i<DataVector, 3>& extrinsic_curvature_trace_gradient,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& lapse_times_conformal_factor,
+    const tnsr::I<DataVector, 3>& conformal_factor_flux,
+    const tnsr::I<DataVector, 3>& lapse_times_conformal_factor_flux,
+    const tnsr::II<DataVector, 3>& longitudinal_shift_minus_dt_conformal_metric,
+    const Scalar<DataVector>& conformal_factor_correction,
+    const Scalar<DataVector>& lapse_times_conformal_factor_correction,
+    const tnsr::I<DataVector, 3>& shift_correction,
+    const tnsr::I<DataVector, 3>& conformal_factor_flux_correction,
+    const tnsr::I<DataVector, 3>& lapse_times_conformal_factor_flux_correction,
+    const tnsr::II<DataVector, 3>& longitudinal_shift_correction) noexcept;
+}  // namespace Xcts

--- a/src/Elliptic/Systems/Xcts/Geometry.hpp
+++ b/src/Elliptic/Systems/Xcts/Geometry.hpp
@@ -1,0 +1,18 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace Xcts {
+/// \brief Types of conformal geometries for the XCTS equations
+enum class Geometry {
+  /// Euclidean (flat) manifold with Cartesian coordinates, i.e. the conformal
+  /// metric has components \f$\bar{\gamma}_{ij} = \delta_{ij}\f$ in these
+  /// coordinates and thus all Christoffel symbols vanish:
+  /// \f$\bar{\Gamma}^i_{jk}=0\f$.
+  FlatCartesian,
+  /// The conformal geometry is either curved or employs curved coordinates, so
+  /// non-vanishing Christoffel symbols must be taken into account.
+  Curved
+};
+}  // namespace Xcts

--- a/tests/Unit/Elliptic/Systems/Xcts/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/Xcts/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_Xcts")
 
 set(LIBRARY_SOURCES
+  Test_Equations.cpp
   Test_Tags.cpp
   )
 
@@ -12,6 +13,14 @@ add_test_library(
   "Elliptic/Systems/Xcts/"
   "${LIBRARY_SOURCES}"
   "DataStructuresHelpers;Xcts"
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DataStructures
+  Utilities
+  Xcts
   )
 
 add_subdirectory(BoundaryConditions)

--- a/tests/Unit/Elliptic/Systems/Xcts/Equations.py
+++ b/tests/Unit/Elliptic/Systems/Xcts/Equations.py
@@ -1,0 +1,343 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+from numpy import pi
+
+
+def hamiltonian_sources(conformal_energy_density,
+                        extrinsic_curvature_trace,
+                        conformal_factor,
+                        conformal_matter_scale=0):
+    return (conformal_factor**5 * extrinsic_curvature_trace**2 / 12. -
+            2. * pi * conformal_factor**(5 - conformal_matter_scale) *
+            conformal_energy_density)
+
+
+def hamiltonian_sources_conf(*args, **kwargs):
+    return hamiltonian_sources(*args, conformal_matter_scale=6, **kwargs)
+
+
+def linearized_hamiltonian_sources(conformal_energy_density,
+                                   extrinsic_curvature_trace,
+                                   conformal_factor,
+                                   conformal_factor_correction,
+                                   conformal_matter_scale=0):
+    return (5. * conformal_factor**4 * extrinsic_curvature_trace**2 / 12. -
+            2. * pi * (5. - conformal_matter_scale) * conformal_factor**
+            (4 - conformal_matter_scale) *
+            conformal_energy_density) * conformal_factor_correction
+
+
+def linearized_hamiltonian_sources_conf(*args, **kwargs):
+    return linearized_hamiltonian_sources(*args,
+                                          conformal_matter_scale=6,
+                                          **kwargs)
+
+
+def distortion_hamiltonian_sources(
+    longitudinal_shift_minus_dt_conformal_metric_over_lapse_square,
+    conformal_factor):
+    return (-1. / 32. * conformal_factor**5 *
+            longitudinal_shift_minus_dt_conformal_metric_over_lapse_square)
+
+
+def linearized_distortion_hamiltonian_sources(
+    longitudinal_shift_minus_dt_conformal_metric_over_lapse_square,
+    conformal_factor, conformal_factor_correction):
+    return (-5. / 32. * conformal_factor**4 * conformal_factor_correction *
+            longitudinal_shift_minus_dt_conformal_metric_over_lapse_square)
+
+
+def curved_hamiltonian_or_lapse_sources(conformal_ricci_scalar, field):
+    return field * conformal_ricci_scalar / 8.
+
+
+def lapse_sources(conformal_energy_density,
+                  conformal_stress_trace,
+                  extrinsic_curvature_trace,
+                  dt_extrinsic_curvature_trace,
+                  shift_dot_deriv_extrinsic_curvature_trace,
+                  conformal_factor,
+                  lapse_times_conformal_factor,
+                  conformal_matter_scale=0):
+    return (lapse_times_conformal_factor * conformal_factor**4 *
+            (5. / 12. * extrinsic_curvature_trace**2 + 2. * pi *
+             (conformal_energy_density + 2. * conformal_stress_trace) /
+             conformal_factor**conformal_matter_scale) + conformal_factor**5 *
+            (shift_dot_deriv_extrinsic_curvature_trace -
+             dt_extrinsic_curvature_trace))
+
+
+def lapse_sources_conf(*args, **kwargs):
+    return lapse_sources(*args, conformal_matter_scale=6, **kwargs)
+
+
+def linearized_lapse_sources(conformal_energy_density,
+                             conformal_stress_trace,
+                             extrinsic_curvature_trace,
+                             dt_extrinsic_curvature_trace,
+                             shift_dot_deriv_extrinsic_curvature_trace,
+                             conformal_factor,
+                             lapse_times_conformal_factor,
+                             conformal_factor_correction,
+                             lapse_times_conformal_factor_correction,
+                             conformal_matter_scale=0):
+    return ((4. * lapse_times_conformal_factor * conformal_factor**3 *
+             conformal_factor_correction +
+             conformal_factor**4 * lapse_times_conformal_factor_correction) *
+            5. / 12. * extrinsic_curvature_trace**2 +
+            ((4. - conformal_matter_scale) * lapse_times_conformal_factor *
+             conformal_factor**
+             (3 - conformal_matter_scale) * conformal_factor_correction +
+             conformal_factor**(4 - conformal_matter_scale) *
+             lapse_times_conformal_factor_correction) * 2. * pi *
+            (conformal_energy_density + 2. * conformal_stress_trace) +
+            5. * conformal_factor**4 * conformal_factor_correction *
+            (shift_dot_deriv_extrinsic_curvature_trace -
+             dt_extrinsic_curvature_trace))
+
+
+def linearized_lapse_sources_conf(*args, **kwargs):
+    return linearized_lapse_sources(*args, conformal_matter_scale=6, **kwargs)
+
+
+def distortion_hamiltonian_sources_with_lapse(
+    longitudinal_shift_minus_dt_conformal_metric_square, conformal_factor,
+    lapse_times_conformal_factor):
+    return (-1. / 32. * conformal_factor**7 / lapse_times_conformal_factor**2 *
+            longitudinal_shift_minus_dt_conformal_metric_square)
+
+
+def linearized_distortion_hamiltonian_sources_with_lapse(
+    longitudinal_shift_minus_dt_conformal_metric_square, conformal_factor,
+    lapse_times_conformal_factor, conformal_factor_correction,
+    lapse_times_conformal_factor_correction):
+    return (-1. / 32. *
+            (7. * conformal_factor**6 * conformal_factor_correction /
+             lapse_times_conformal_factor**2 -
+             2. * conformal_factor**7 / lapse_times_conformal_factor**3 *
+             lapse_times_conformal_factor_correction) *
+            longitudinal_shift_minus_dt_conformal_metric_square)
+
+
+def distortion_lapse_sources(
+    longitudinal_shift_minus_dt_conformal_metric_square, conformal_factor,
+    lapse_times_conformal_factor):
+    return (7. / 32. * conformal_factor**6 / lapse_times_conformal_factor *
+            longitudinal_shift_minus_dt_conformal_metric_square)
+
+
+def linearized_distortion_lapse_sources(
+    longitudinal_shift_minus_dt_conformal_metric_square, conformal_factor,
+    lapse_times_conformal_factor, conformal_factor_correction,
+    lapse_times_conformal_factor_correction):
+    return (7. / 32. *
+            (6. * conformal_factor**5 / lapse_times_conformal_factor *
+             conformal_factor_correction -
+             conformal_factor**6 / lapse_times_conformal_factor**2 *
+             lapse_times_conformal_factor_correction) *
+            longitudinal_shift_minus_dt_conformal_metric_square)
+
+
+def momentum_sources(conformal_momentum_density,
+                     extrinsic_curvature_trace_gradient,
+                     conformal_metric,
+                     inv_conformal_metric,
+                     minus_div_dt_conformal_metric,
+                     conformal_factor,
+                     lapse_times_conformal_factor,
+                     conformal_factor_flux,
+                     lapse_times_conformal_factor_flux,
+                     longitudinal_shift,
+                     conformal_matter_scale=0):
+    return (
+        np.einsum(
+            'ij,jk,k', longitudinal_shift, conformal_metric,
+            lapse_times_conformal_factor_flux / lapse_times_conformal_factor -
+            7. * conformal_factor_flux / conformal_factor) -
+        minus_div_dt_conformal_metric +
+        4. / 3. * lapse_times_conformal_factor / conformal_factor * np.einsum(
+            'ij,j', inv_conformal_metric, extrinsic_curvature_trace_gradient) +
+        16. * pi * lapse_times_conformal_factor * conformal_factor**
+        (3 - conformal_matter_scale) * conformal_momentum_density)
+
+
+def momentum_sources_conf(*args, **kwargs):
+    return momentum_sources(*args, conformal_matter_scale=6, **kwargs)
+
+
+def flat_cartesian_momentum_sources(conformal_momentum_density,
+                                    extrinsic_curvature_trace_gradient, *args,
+                                    **kwargs):
+    return momentum_sources(conformal_momentum_density,
+                            extrinsic_curvature_trace_gradient, np.identity(3),
+                            np.identity(3), *args, **kwargs)
+
+
+def flat_cartesian_momentum_sources_conf(*args, **kwargs):
+    return flat_cartesian_momentum_sources(*args,
+                                           conformal_matter_scale=6,
+                                           **kwargs)
+
+
+def linearized_momentum_sources(conformal_momentum_density,
+                                extrinsic_curvature_trace_gradient,
+                                conformal_metric,
+                                inv_conformal_metric,
+                                conformal_factor,
+                                lapse_times_conformal_factor,
+                                conformal_factor_flux,
+                                lapse_times_conformal_factor_flux,
+                                longitudinal_shift,
+                                conformal_factor_correction,
+                                lapse_times_conformal_factor_correction,
+                                shift_correction,
+                                conformal_factor_flux_correction,
+                                lapse_times_conformal_factor_flux_correction,
+                                longitudinal_shift_correction,
+                                conformal_matter_scale=0):
+    return (
+        np.einsum(
+            'ij,jk,k', longitudinal_shift, conformal_metric,
+            (lapse_times_conformal_factor_flux_correction /
+             lapse_times_conformal_factor - lapse_times_conformal_factor_flux /
+             (lapse_times_conformal_factor**2) *
+             lapse_times_conformal_factor_correction) - 7. *
+            (conformal_factor_flux_correction / conformal_factor -
+             conformal_factor_flux / conformal_factor**2 *
+             conformal_factor_correction)) +
+        np.einsum(
+            'ij,jk,k', longitudinal_shift_correction, conformal_metric,
+            lapse_times_conformal_factor_flux / lapse_times_conformal_factor -
+            7. * conformal_factor_flux / conformal_factor) + 4. / 3. *
+        (lapse_times_conformal_factor_correction / conformal_factor -
+         lapse_times_conformal_factor / conformal_factor**2 *
+         conformal_factor_correction) * np.einsum(
+             'ij,j', inv_conformal_metric, extrinsic_curvature_trace_gradient)
+        + 16. * pi *
+        ((3. - conformal_matter_scale) * lapse_times_conformal_factor *
+         conformal_factor**
+         (2 - conformal_matter_scale) * conformal_factor_correction +
+         conformal_factor**(3 - conformal_matter_scale) *
+         lapse_times_conformal_factor_correction) * conformal_momentum_density)
+
+
+def linearized_momentum_sources_conf(*args, **kwargs):
+    return linearized_momentum_sources(*args,
+                                       conformal_matter_scale=6,
+                                       **kwargs)
+
+
+def flat_cartesian_linearized_momentum_sources(
+    momentum_density, extrinsic_curvature_trace_gradient, *args, **kwargs):
+    return linearized_momentum_sources(momentum_density,
+                                       extrinsic_curvature_trace_gradient,
+                                       np.identity(3), np.identity(3), *args,
+                                       **kwargs)
+
+
+def flat_cartesian_linearized_momentum_sources_conf(*args, **kwargs):
+    return flat_cartesian_linearized_momentum_sources(*args,
+                                                      conformal_matter_scale=6,
+                                                      **kwargs)
+
+
+def distortion_hamiltonian_sources_full(
+    momentum_density, extrinsic_curvature_trace_gradient, conformal_metric,
+    inv_conformal_metric, minus_div_dt_conformal_metric, conformal_factor,
+    lapse_times_conformal_factor, conformal_factor_flux,
+    lapse_times_conformal_factor_flux, longitudinal_shift):
+    return (-1. / 32. * conformal_factor**7 / lapse_times_conformal_factor**2 *
+            np.einsum('ij,kl,ik,jl', conformal_metric, conformal_metric,
+                      longitudinal_shift, longitudinal_shift))
+
+
+def flat_cartesian_distortion_hamiltonian_sources_full(
+    momentum_density, extrinsic_curvature_trace_gradient, *args, **kwargs):
+    return distortion_hamiltonian_sources_full(
+        momentum_density, extrinsic_curvature_trace_gradient, np.identity(3),
+        np.identity(3), *args, **kwargs)
+
+
+def linearized_distortion_hamiltonian_sources_full(
+    momentum_density, extrinsic_curvature_trace_gradient, conformal_metric,
+    inv_conformal_metric, conformal_factor, lapse_times_conformal_factor,
+    conformal_factor_flux, lapse_times_conformal_factor_flux,
+    longitudinal_shift, conformal_factor_correction,
+    lapse_times_conformal_factor_correction, shift_correction,
+    conformal_factor_flux_correction,
+    lapse_times_conformal_factor_flux_correction,
+    longitudinal_shift_correction):
+    longitudinal_shift_square = np.einsum('ij,kl,ik,jl', conformal_metric,
+                                          conformal_metric, longitudinal_shift,
+                                          longitudinal_shift)
+    longitudinal_shift_dot_correction = np.einsum(
+        'ij,kl,ik,jl', conformal_metric, conformal_metric, longitudinal_shift,
+        longitudinal_shift_correction)
+    return -1. / 32. * (
+        7. * conformal_factor**6 / lapse_times_conformal_factor**2 *
+        longitudinal_shift_square * conformal_factor_correction -
+        2. * conformal_factor**7 / lapse_times_conformal_factor**3 *
+        longitudinal_shift_square * lapse_times_conformal_factor_correction +
+        2. * conformal_factor**7 / lapse_times_conformal_factor**2 *
+        longitudinal_shift_dot_correction)
+
+
+def flat_cartesian_linearized_distortion_hamiltonian_sources_full(
+    momentum_density, extrinsic_curvature_trace_gradient, conformal_factor,
+    lapse_times_conformal_factor, *args, **kwargs):
+    return linearized_distortion_hamiltonian_sources_full(
+        momentum_density, extrinsic_curvature_trace_gradient, np.identity(3),
+        np.identity(3), conformal_factor, lapse_times_conformal_factor, *args,
+        **kwargs)
+
+
+def distortion_lapse_sources_with_shift(
+    momentum_density, extrinsic_curvature_trace_gradient, conformal_metric,
+    inv_conformal_metric, minus_div_dt_conformal_metric, conformal_factor,
+    lapse_times_conformal_factor, conformal_factor_flux,
+    lapse_times_conformal_factor_flux, longitudinal_shift):
+    return (7. / 32. * conformal_factor**6 / lapse_times_conformal_factor *
+            np.einsum('ij,kl,ik,jl', conformal_metric, conformal_metric,
+                      longitudinal_shift, longitudinal_shift))
+
+
+def flat_cartesian_distortion_lapse_sources_with_shift(
+    momentum_density, extrinsic_curvature_trace_gradient, *args, **kwargs):
+    return distortion_lapse_sources_with_shift(
+        momentum_density, extrinsic_curvature_trace_gradient, np.identity(3),
+        np.identity(3), *args, **kwargs)
+
+
+def linearized_distortion_lapse_sources_with_shift(
+    momentum_density, extrinsic_curvature_trace_gradient, conformal_metric,
+    inv_conformal_metric, conformal_factor, lapse_times_conformal_factor,
+    conformal_factor_flux, lapse_times_conformal_factor_flux,
+    longitudinal_shift, conformal_factor_correction,
+    lapse_times_conformal_factor_correction, shift_correction,
+    conformal_factor_flux_correction,
+    lapse_times_conformal_factor_flux_correction,
+    longitudinal_shift_correction):
+    longitudinal_shift_square = np.einsum('ij,kl,ik,jl', conformal_metric,
+                                          conformal_metric, longitudinal_shift,
+                                          longitudinal_shift)
+    longitudinal_shift_dot_correction = np.einsum(
+        'ij,kl,ik,jl', conformal_metric, conformal_metric, longitudinal_shift,
+        longitudinal_shift_correction)
+    return (
+        7. / 32. *
+        (6. * conformal_factor**5 / lapse_times_conformal_factor *
+         longitudinal_shift_square * conformal_factor_correction -
+         conformal_factor**6 / lapse_times_conformal_factor**2 *
+         longitudinal_shift_square * lapse_times_conformal_factor_correction +
+         2. * conformal_factor**6 / lapse_times_conformal_factor *
+         longitudinal_shift_dot_correction) + conformal_factor**5 *
+        np.einsum('i,i', shift_correction, extrinsic_curvature_trace_gradient))
+
+
+def flat_cartesian_linearized_distortion_lapse_sources_with_shift(
+    momentum_density, extrinsic_curvature_trace_gradient, *args, **kwargs):
+    return linearized_distortion_lapse_sources_with_shift(
+        momentum_density, extrinsic_curvature_trace_gradient, np.identity(3),
+        np.identity(3), *args, **kwargs)

--- a/tests/Unit/Elliptic/Systems/Xcts/Test_Equations.cpp
+++ b/tests/Unit/Elliptic/Systems/Xcts/Test_Equations.cpp
@@ -1,0 +1,127 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <random>
+#include <string>
+
+#include "Elliptic/Systems/Xcts/Equations.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+
+void test_equations(const DataVector& used_for_size) {
+  const double eps = 1.e-12;
+  const auto seed = std::random_device{}();
+  const double fill_result_tensors = 0.;
+  pypp::check_with_random_values<1>(
+      &Xcts::add_hamiltonian_sources<0>, "Equations", {"hamiltonian_sources"},
+      {{{-1., 1.}}}, used_for_size, eps, seed, fill_result_tensors);
+  pypp::check_with_random_values<1>(&Xcts::add_hamiltonian_sources<6>,
+                                    "Equations", {"hamiltonian_sources_conf"},
+                                    {{{-1., 1.}}}, used_for_size, eps, seed,
+                                    fill_result_tensors);
+  pypp::check_with_random_values<1>(
+      &Xcts::add_linearized_hamiltonian_sources<0>, "Equations",
+      {"linearized_hamiltonian_sources"}, {{{-1., 1.}}}, used_for_size, eps,
+      seed, fill_result_tensors);
+  pypp::check_with_random_values<1>(
+      &Xcts::add_linearized_hamiltonian_sources<6>, "Equations",
+      {"linearized_hamiltonian_sources_conf"}, {{{-1., 1.}}}, used_for_size,
+      eps, seed, fill_result_tensors);
+  pypp::check_with_random_values<1>(
+      &Xcts::add_distortion_hamiltonian_sources, "Equations",
+      {"distortion_hamiltonian_sources"}, {{{-1., 1.}}}, used_for_size, eps,
+      seed, fill_result_tensors);
+  pypp::check_with_random_values<1>(
+      &Xcts::add_linearized_distortion_hamiltonian_sources, "Equations",
+      {"linearized_distortion_hamiltonian_sources"}, {{{-1., 1.}}},
+      used_for_size, eps, seed, fill_result_tensors);
+  pypp::check_with_random_values<1>(
+      &Xcts::add_curved_hamiltonian_or_lapse_sources, "Equations",
+      {"curved_hamiltonian_or_lapse_sources"}, {{{-1., 1.}}}, used_for_size,
+      eps, seed, fill_result_tensors);
+  pypp::check_with_random_values<1>(
+      &Xcts::add_lapse_sources<0>, "Equations", {"lapse_sources"},
+      {{{-1., 1.}}}, used_for_size, eps, seed, fill_result_tensors);
+  pypp::check_with_random_values<1>(
+      &Xcts::add_lapse_sources<6>, "Equations", {"lapse_sources_conf"},
+      {{{-1., 1.}}}, used_for_size, eps, seed, fill_result_tensors);
+  pypp::check_with_random_values<1>(&Xcts::add_linearized_lapse_sources<0>,
+                                    "Equations", {"linearized_lapse_sources"},
+                                    {{{-1., 1.}}}, used_for_size, eps, seed,
+                                    fill_result_tensors);
+  pypp::check_with_random_values<1>(
+      &Xcts::add_linearized_lapse_sources<6>, "Equations",
+      {"linearized_lapse_sources_conf"}, {{{-1., 1.}}}, used_for_size, eps,
+      seed, fill_result_tensors);
+  pypp::check_with_random_values<1>(
+      &Xcts::add_distortion_hamiltonian_and_lapse_sources, "Equations",
+      {"distortion_hamiltonian_sources_with_lapse", "distortion_lapse_sources"},
+      {{{-1., 1.}}}, used_for_size, eps, seed, fill_result_tensors);
+  pypp::check_with_random_values<1>(
+      &Xcts::add_linearized_distortion_hamiltonian_and_lapse_sources,
+      "Equations",
+      {"linearized_distortion_hamiltonian_sources_with_lapse",
+       "linearized_distortion_lapse_sources"},
+      {{{-1., 1.}}}, used_for_size, eps, seed, fill_result_tensors);
+  pypp::check_with_random_values<1>(
+      &Xcts::add_flat_cartesian_momentum_sources<0>, "Equations",
+      {"flat_cartesian_distortion_hamiltonian_sources_full",
+       "flat_cartesian_distortion_lapse_sources_with_shift",
+       "flat_cartesian_momentum_sources"},
+      {{{-1., 1.}}}, used_for_size, eps, seed, fill_result_tensors);
+  pypp::check_with_random_values<1>(
+      &Xcts::add_flat_cartesian_momentum_sources<6>, "Equations",
+      {"flat_cartesian_distortion_hamiltonian_sources_full",
+       "flat_cartesian_distortion_lapse_sources_with_shift",
+       "flat_cartesian_momentum_sources_conf"},
+      {{{-1., 1.}}}, used_for_size, eps, seed, fill_result_tensors);
+  pypp::check_with_random_values<1>(
+      &Xcts::add_curved_momentum_sources<0>, "Equations",
+      {"distortion_hamiltonian_sources_full",
+       "distortion_lapse_sources_with_shift", "momentum_sources"},
+      {{{-1., 1.}}}, used_for_size, eps, seed, fill_result_tensors);
+  pypp::check_with_random_values<1>(
+      &Xcts::add_curved_momentum_sources<6>, "Equations",
+      {"distortion_hamiltonian_sources_full",
+       "distortion_lapse_sources_with_shift", "momentum_sources_conf"},
+      {{{-1., 1.}}}, used_for_size, eps, seed, fill_result_tensors);
+  pypp::check_with_random_values<1>(
+      &Xcts::add_flat_cartesian_linearized_momentum_sources<0>, "Equations",
+      {"flat_cartesian_linearized_distortion_hamiltonian_sources_full",
+       "flat_cartesian_linearized_distortion_lapse_sources_with_shift",
+       "flat_cartesian_linearized_momentum_sources"},
+      {{{-1., 1.}}}, used_for_size, eps, seed, fill_result_tensors);
+  pypp::check_with_random_values<1>(
+      &Xcts::add_flat_cartesian_linearized_momentum_sources<6>, "Equations",
+      {"flat_cartesian_linearized_distortion_hamiltonian_sources_full",
+       "flat_cartesian_linearized_distortion_lapse_sources_with_shift",
+       "flat_cartesian_linearized_momentum_sources_conf"},
+      {{{-1., 1.}}}, used_for_size, eps, seed, fill_result_tensors);
+  pypp::check_with_random_values<1>(
+      &Xcts::add_curved_linearized_momentum_sources<0>, "Equations",
+      {"linearized_distortion_hamiltonian_sources_full",
+       "linearized_distortion_lapse_sources_with_shift",
+       "linearized_momentum_sources"},
+      {{{-1., 1.}}}, used_for_size, eps, seed, fill_result_tensors);
+  pypp::check_with_random_values<1>(
+      &Xcts::add_curved_linearized_momentum_sources<6>, "Equations",
+      {"linearized_distortion_hamiltonian_sources_full",
+       "linearized_distortion_lapse_sources_with_shift",
+       "linearized_momentum_sources_conf"},
+      {{{-1., 1.}}}, used_for_size, eps, seed, fill_result_tensors);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Xcts", "[Unit][Elliptic]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{"Elliptic/Systems/Xcts"};
+  DataVector used_for_size{5};
+  test_equations(used_for_size);
+}


### PR DESCRIPTION
## Proposed changes

This PR adds the XCTS system equations. An upcoming PR will add the XCTS system, fluxes and sources that use these functions and that will also call into the `Poisson` and the `Elasticity` code to for the remaining operations. This is because the XCTS equations are essentially two Poisson equations and an elasticity equation on a curved geometry, coupled through nonlinear sources.

Dependencies:

- [x] #2876 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
