### PR TITLE
Raise a sigtrap so debuggers work without having to specify env variables

### DIFF
--- a/src/ErrorHandling/AbortWithErrorMessage.cpp
+++ b/src/ErrorHandling/AbortWithErrorMessage.cpp
@@ -5,6 +5,7 @@
 
 #include <sstream>
 
+#include "ErrorHandling/Breakpoint.hpp"
 #include "Parallel/Abort.hpp"
 #include "Parallel/Info.hpp"
 #include "Parallel/Printf.hpp"
@@ -27,6 +28,7 @@ void abort_with_error_message(const char* expression, const char* file,
   // case of an executable not using Charm++'s main function the call to abort
   // will segfault before anything is printed.
   Parallel::printf_error(os.str());
+  breakpoint();
   Parallel::abort("");
 }
 
@@ -47,5 +49,6 @@ void abort_with_error_message(const char* file, const int line,
   // case of an executable not using Charm++'s main function the call to abort
   // will segfault before anything is printed.
   Parallel::printf_error(os.str());
+  breakpoint();
   Parallel::abort("");
 }

--- a/src/ErrorHandling/Breakpoint.cpp
+++ b/src/ErrorHandling/Breakpoint.cpp
@@ -1,0 +1,22 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ErrorHandling/Breakpoint.hpp"
+
+#include <csignal>
+
+void breakpoint() noexcept {
+  // We send ourselves a SIGTRAP and ignore it.  If we're not being
+  // traced (e.g. being run in a debugger), that doesn't do much, but if we are
+  // then the tracer (debugger) can see the signal delivery.  We don't reset the
+  // signal handler afterwards in case this is called on multiple threads; we
+  // don't want one thread reenabling the default handler just before another
+  // calls raise().
+
+  struct sigaction handler{};
+  handler.sa_handler = SIG_IGN;  // NOLINT
+  handler.sa_flags = 0;
+  sigemptyset(&handler.sa_mask);
+  sigaction(SIGTRAP, &handler, nullptr);
+  raise(SIGTRAP);
+}

--- a/src/ErrorHandling/Breakpoint.hpp
+++ b/src/ErrorHandling/Breakpoint.hpp
@@ -1,0 +1,9 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+/*!
+ * \brief Raise `SIGTRAP` so that debuggers will trap.
+ */
+void breakpoint() noexcept;

--- a/src/ErrorHandling/CMakeLists.txt
+++ b/src/ErrorHandling/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   AbortWithErrorMessage.cpp
+  Breakpoint.cpp
   FloatingPointExceptions.cpp
   )
 
@@ -18,6 +19,7 @@ spectre_target_headers(
   HEADERS
   AbortWithErrorMessage.hpp
   Assert.hpp
+  Breakpoint.hpp
   Error.hpp
   Exceptions.hpp
   ExpectsAndEnsures.hpp

--- a/src/Parallel/Abort.hpp
+++ b/src/Parallel/Abort.hpp
@@ -26,10 +26,6 @@ namespace Parallel {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
   CkPrintf("%s\n", message.c_str());
 #pragma GCC diagnostic pop
-  char* const trap_for_debugger = std::getenv("SPECTRE_TRAP_ON_ERROR");
-  if (trap_for_debugger != nullptr) {
-    std::raise(SIGTRAP);
-  }
   CkExit(1);
   // the following call is never reached, but suppresses the warning that
   // a 'noreturn' function does return


### PR DESCRIPTION
## Proposed changes

Fixes #2448

I tested this by modifying the test:
```
SPECTRE_TEST_CASE("Unit.DataStructures.DataVector", "[DataStructures][Unit]") {
  ASSERT(false, "Uh oh");
```
and making sure that gdb correctly catches the sigtrap but that running the executable behaves normally.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
