### PR TITLE
Support shared libs with python bindings, switch CI to mostly use shared libs

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -322,12 +322,11 @@ jobs:
             build_type: Debug
             PYTHON_EXECUTABLE: /usr/bin/python2
           - compiler: clang-9
-            # The python bindings don't work with shared libs currently, but we
-            # support shared libs, so add at least one build to test that
-            # nothing is very broken with shared libs.
-            build_type: Debug
-            BUILD_PYTHON_BINDINGS: OFF
-            BUILD_SHARED_LIBS: ON
+            build_type: Release
+            # Test building with static libraries. Do so with clang in release
+            # mode because these builds use up little disk space compared to GCC
+            # builds or clang Debug builds
+            BUILD_SHARED_LIBS: OFF
             MEMORY_ALLOCATOR: JEMALLOC
 
     container:
@@ -409,7 +408,7 @@ jobs:
           -D USE_CCACHE=ON
           -D BUILD_PYTHON_BINDINGS=${BUILD_PYTHON_BINDINGS:-'ON'}
           -D PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE:-'/usr/bin/python3'}
-          -D BUILD_SHARED_LIBS=${BUILD_SHARED_LIBS:-'OFF'}
+          -D BUILD_SHARED_LIBS=${BUILD_SHARED_LIBS:-'ON'}
           -D ASAN=${ASAN:-'OFF'}
           -D UBSAN_UNDEFINED=${UBSAN_UNDEFINED:-'OFF'}
           -D UBSAN_INTEGER=${UBSAN_INTEGER:-'OFF'}

--- a/cmake/PrintUsefulCMakeInfo.cmake
+++ b/cmake/PrintUsefulCMakeInfo.cmake
@@ -71,3 +71,11 @@ if(DOXYGEN_FOUND)
 else()
   message(STATUS "Doxygen: Not found, documentation cannot be built.")
 endif()
+
+if(BUILD_PYTHON_BINDINGS AND "${JEMALLOC_LIB_TYPE}" STREQUAL SHARED)
+  message(STATUS
+    "When using the python bindings you must run python as:\n"
+    "   LD_PRELOAD=${JEMALLOC_LIBRARIES} python ...\n"
+    "Alternatively, use the system allocator by setting \n"
+    "-D MEMORY_ALLOCATOR=SYSTEM")
+endif()

--- a/cmake/SetupAllocator.cmake
+++ b/cmake/SetupAllocator.cmake
@@ -17,6 +17,9 @@ add_library(SpectreAllocator INTERFACE)
 option(MEMORY_ALLOCATOR
   "Which allocator to use: SYSTEM, TCMALLOC, JEMALLOC (default)"
   OFF)
+
+set(JEMALLOC_LIB_TYPE "")
+
 # We need to link custom allocators before we link anything else so that
 # any third-party libraries, which generally should all be built as shared
 # libraries, use the allocator that we use. Unfortunately, how exactly

--- a/cmake/SetupJemalloc.cmake
+++ b/cmake/SetupJemalloc.cmake
@@ -22,3 +22,40 @@ set_property(
   GLOBAL APPEND PROPERTY SPECTRE_THIRD_PARTY_LIBS
   Jemalloc
   )
+
+# Determine whether we are using JEMALLOC as a shared or static library
+get_filename_component(
+  JEMALLOC_LIB_NAME
+  ${JEMALLOC_LIBRARIES}
+  NAME
+  )
+get_filename_component(
+  JEMALLOC_LIB_TYPE
+  ${JEMALLOC_LIB_NAME}
+  LAST_EXT
+  )
+while(NOT "${JEMALLOC_LIB_TYPE}" STREQUAL ".so"
+    AND NOT "${JEMALLOC_LIB_TYPE}" STREQUAL ".a"
+    AND NOT "${JEMALLOC_LIB_TYPE}" STREQUAL ".dylib")
+  get_filename_component(
+    JEMALLOC_LIB_NAME
+    ${JEMALLOC_LIB_NAME}
+    NAME_WLE
+    )
+  get_filename_component(
+    JEMALLOC_LIB_TYPE
+    ${JEMALLOC_LIB_NAME}
+    LAST_EXT
+    )
+endwhile()
+
+if("${JEMALLOC_LIB_TYPE}" STREQUAL ".a")
+  set(JEMALLOC_LIB_TYPE STATIC)
+elseif("${JEMALLOC_LIB_TYPE}" STREQUAL ".so" OR
+    "${JEMALLOC_LIB_TYPE}" STREQUAL ".dylib")
+  set(JEMALLOC_LIB_TYPE SHARED)
+else()
+  message(FATAL_ERROR "Couldn't determine whether JEMALLOC is a static "
+    "or shared/dynamic library.")
+endif()
+mark_as_advanced(JEMALLOC_LIB_TYPE)

--- a/cmake/SpectreSetupPythonPackage.cmake
+++ b/cmake/SpectreSetupPythonPackage.cmake
@@ -127,7 +127,8 @@ function(SPECTRE_PYTHON_ADD_MODULE MODULE_NAME)
       target_compile_options(${ARG_LIBRARY_NAME}
         PRIVATE -fsized-deallocation)
     endif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    # We don't want the 'lib' prefix for python modules, so we set the output name
+    # We don't want the 'lib' prefix for python modules, so we set the output
+    # name
     set_target_properties(
       ${ARG_LIBRARY_NAME}
       PROPERTIES
@@ -135,10 +136,17 @@ function(SPECTRE_PYTHON_ADD_MODULE MODULE_NAME)
       LIBRARY_OUTPUT_NAME "_${ARG_LIBRARY_NAME}"
       LIBRARY_OUTPUT_DIRECTORY ${MODULE_LOCATION}
       )
+    # We need --no-as-needed since each python module needs to depend on all the
+    # shared libraries in order to run successfully.
+    set(PY_LIB_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS}")
+    if(NOT APPLE)
+      set(PY_LIB_LINK_FLAGS
+        "${CMAKE_CXX_LINK_FLAGS} -Wl,--no-as-needed")
+    endif()
     set_target_properties(
       ${ARG_LIBRARY_NAME}
       PROPERTIES
-      LINK_FLAGS ${CMAKE_CXX_LINK_FLAGS}
+      LINK_FLAGS "${PY_LIB_LINK_FLAGS}"
       )
     set(SPECTRE_PYTHON_MODULE_IMPORT "from ._${ARG_LIBRARY_NAME} import *")
     add_dependencies(test-executables ${ARG_LIBRARY_NAME})

--- a/src/Domain/Creators/CMakeLists.txt
+++ b/src/Domain/Creators/CMakeLists.txt
@@ -52,9 +52,9 @@ target_link_libraries(
   PUBLIC
   CoordinateMaps
   DataStructures
+  DomainTimeDependence
   INTERFACE
   Domain
-  DomainTimeDependence
   ErrorHandling
   Options
   )

--- a/src/Evolution/Systems/Cce/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/CMakeLists.txt
@@ -57,6 +57,7 @@ target_link_libraries(
   LinearSolver
   PUBLIC
   Boost::boost
+  CceAnalyticSolutions
   DataStructures
   ErrorHandling
   IO

--- a/src/PythonBindings/CharmCompatibility.cpp
+++ b/src/PythonBindings/CharmCompatibility.cpp
@@ -44,20 +44,65 @@ void CmiError(const char* fmt, ...) {
   va_end(args);  // NOLINT
 }
 
+// Identification on system
+#ifndef CmiMyPe
 int CmiMyPe() { return 0; }
+#endif
+int _Cmi_mype = 0;
+int _Cmi_numpes = 1;
+int _Cmi_mynodesize = 1;
 int _Cmi_mynode = 0;
-std::string info_from_build() { return "build_info"; }
+int _Cmi_numnodes = 1;
+
+// CmiWallTimer support
+double _cpu_speed_factor = 0.0;
+double CmiTimer(void) { return 0.0; }
+#ifndef CmiWallTimer
+double CmiWallTimer(void) { return 0.0; }
+#endif
+
+// We need to maintain Charm-compatibility, which means not marking things with
+// attributes.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-noreturn"
+// Charm LRTS locks. These should never be called from the python code so we
+// throw an exception if they are.
+LrtsNodeLock LrtsCreateLock() {
+  throw std::runtime_error{
+      "The function 'LrtsCreateLock' is provided for compatibility with "
+      "Charm++ and is not intended to be called."};
+  // clang-tidy wants us to use nullptr but I'm worried that LrtsNodeLock isn't
+  // always a pointer
+  return 0;  // NOLINT
+}
+void LrtsLock(LrtsNodeLock /*lock*/) {
+  throw std::runtime_error{
+      "The function 'LrtsLock' is provided for compatibility with "
+      "Charm++ and is not intended to be called."};
+}
+void LrtsUnlock(LrtsNodeLock /*lock*/) {
+  throw std::runtime_error{
+      "The function 'LrtsUnlock' is provided for compatibility with "
+      "Charm++ and is not intended to be called."};
+}
+int LrtsTryLock(LrtsNodeLock /*lock*/) {
+  throw std::runtime_error{
+      "The function 'LrtsTryLock' is provided for compatibility with "
+      "Charm++ and is not intended to be called."};
+}
+void LrtsDestroyLock(LrtsNodeLock /*lock*/) {
+  throw std::runtime_error{
+      "The function 'LrtsDestroyLock' is provided for compatibility with "
+      "Charm++ and is not intended to be called."};
+}
+
+std::string info_from_build() { return "build_info"; }
 void CmiAbort(const char* msg) {
-#pragma GCC diagnostic pop
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
   fprintf(stderr, "%s", msg);
   abort();
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmissing-noreturn"
 void realCkExit(int exitcode) { exit(exitcode); }
 #pragma GCC diagnostic pop
 


### PR DESCRIPTION
## Proposed changes

- Add remaining Charm compatibility functions and use `-Wl,--no-as-needed` flag for python libraries. Together this makes the python bindings work correctly when built with shared libraries.
-  Add tricks to deal with dlopen'ing issues and JEMALLOC. Basically, jemalloc needs to be LD_PRELOAD'd if JEMALLOC is used with python bindings
- Switch CI to build with shared libs. For GCC debug builds this reduces disk space by about 2GB and for clang debug by 1.5GB. Release builds were already pretty small before.

Fixes #1961 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
