### PR TITLE
Add unit-tests target

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -424,7 +424,18 @@ jobs:
         if: matrix.use_pch == 'ON'
         working-directory: /work/build
         run: |
-          make -j2 RunTests
+          make -j2 unit-tests
+      - name: Run unit tests
+        if: matrix.use_pch == 'ON'
+        working-directory: /work/build
+        run: |
+          # We get occasional random timeouts, repeat tests to see if
+          # it is a random timeout or systematic.
+          #
+          # We run ctest -L unit before build test-executables to make
+          # sure that all the unit tests are actually built by the
+          # unit-tests target.
+          ctest -j2 -L unit --output-on-failure --repeat after-timeout:3
       # Build the executables in a single thread to reduce memory usage
       # sufficiently so they compile on the GitHub-hosted runners
       - name: Build executables
@@ -444,13 +455,13 @@ jobs:
       - name: Diagnose ccache
         run: |
           ccache -s
-      - name: Run unit tests
+      - name: Run non-unit tests
         if: matrix.use_pch == 'ON'
         working-directory: /work/build
         run: |
           # We get occasional random timeouts, repeat tests to see if
           # it is a random timeout or systematic
-          ctest -j2 --output-on-failure --repeat after-timeout:3
+          ctest -j2 -LE unit --output-on-failure --repeat after-timeout:3
       - name: Run input file tests without PCH
         if: matrix.use_pch == 'OFF'
         working-directory: /work/build

--- a/cmake/SpectreAddCatchTests.cmake
+++ b/cmake/SpectreAddCatchTests.cmake
@@ -37,6 +37,8 @@
 #               example, to match "some (word) and" you must specify the
 #               string "some \(word\) and".
 
+add_custom_target(unit-tests)
+
 option(SPECTRE_UNIT_TEST_TIMEOUT_FACTOR
   "Multiply timeout for unit tests by this factor"
   1)

--- a/cmake/SpectreSetupPythonPackage.cmake
+++ b/cmake/SpectreSetupPythonPackage.cmake
@@ -308,7 +308,11 @@ endfunction()
 #
 # - TAGS         A semicolon separated list of labels for the test,
 #                e.g. "Unit;DataStructures;Python"
-function(SPECTRE_ADD_PYTHON_TEST TEST_NAME FILE TAGS)
+# - PY_MODULE_DEPENDENCY
+#                The python module that this test depends on
+#                Set to None if there is no python module dependency
+function(SPECTRE_ADD_PYTHON_TEST TEST_NAME FILE TAGS
+    PY_MODULE_DEPENDENCY)
   get_filename_component(FILE "${FILE}" ABSOLUTE)
   string(TOLOWER "${TAGS}" TAGS)
 
@@ -337,6 +341,15 @@ function(SPECTRE_ADD_PYTHON_TEST TEST_NAME FILE TAGS)
     LABELS "${TAGS};Python"
     ENVIRONMENT "PYTHONPATH=${SPECTRE_PYTHON_PREFIX_PARENT}:\$PYTHONPATH"
     )
+  # check if this is a unit test, and if so add it to the dependencies
+  foreach(LABEL ${TAGS})
+    string(TOLOWER "${LABEL}" LOWER_LABEL)
+    string(TOLOWER "${PY_MODULE_DEPENDENCY}" LOWER_DEP)
+    if("${LOWER_LABEL}" STREQUAL "unit"
+        AND NOT "${LOWER_DEP}" STREQUAL "none")
+      add_dependencies(unit-tests ${PY_MODULE_DEPENDENCY})
+    endif()
+  endforeach()
 endfunction()
 
 # Register a python test file that uses bindings with ctest.
@@ -347,9 +360,13 @@ endfunction()
 #
 # - TAGS         A semicolon separated list of labels for the test,
 #                e.g. "Unit;DataStructures;Python"
-function(SPECTRE_ADD_PYTHON_BINDINGS_TEST TEST_NAME FILE TAGS)
+# - PY_MODULE_DEPENDENCY
+#                The python module that this test depends on
+#                Set to None if there is no python module dependency
+function(SPECTRE_ADD_PYTHON_BINDINGS_TEST TEST_NAME FILE TAGS
+    PY_MODULE_DEPENDENCY)
   if(NOT BUILD_PYTHON_BINDINGS)
     return()
   endif()
-  spectre_add_python_test(${TEST_NAME} ${FILE} ${TAGS})
+  spectre_add_python_test(${TEST_NAME} ${FILE} "${TAGS}" ${PY_MODULE_DEPENDENCY})
 endfunction()

--- a/tests/Unit/CMakeLists.txt
+++ b/tests/Unit/CMakeLists.txt
@@ -77,6 +77,8 @@ target_include_directories(
   PUBLIC ${PYTHON_INCLUDE_DIRS}
   )
 
+add_dependencies(unit-tests ${executable})
+
 option(
   RUN_TESTS_IN_TEST_EXECUTABLES
   "Build RunTests as part of test-executables"

--- a/tests/Unit/CMakeLists.txt
+++ b/tests/Unit/CMakeLists.txt
@@ -109,3 +109,5 @@ if(COVERAGE)
 endif()
 
 add_subdirectory(RunSingleTest)
+
+add_dependencies(test-executables unit-tests)

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -62,9 +62,11 @@ target_link_libraries(
 spectre_add_python_bindings_test(
   "Unit.DataStructures.Python.DataVector"
   Test_DataVector.py
-  "Unit;DataStructures;Python")
+  "Unit;DataStructures;Python"
+  PyDataStructures)
 # [example_add_pybindings_test]
 spectre_add_python_bindings_test(
   "Unit.DataStructures.Python.Matrix"
   Test_Matrix.py
-  "Unit;DataStructures;Python")
+  "Unit;DataStructures;Python"
+  PyDataStructures)

--- a/tests/Unit/DataStructures/Tensor/CMakeLists.txt
+++ b/tests/Unit/DataStructures/Tensor/CMakeLists.txt
@@ -23,4 +23,5 @@ add_test_library(
 spectre_add_python_bindings_test(
   "Unit.DataStructures.Tensor.Python.TensorData"
   Test_TensorData.py
-  "Unit;DataStructures;Tensor;Python")
+  "Unit;DataStructures;Tensor;Python"
+  PyDataStructures)

--- a/tests/Unit/Domain/Creators/Python/CMakeLists.txt
+++ b/tests/Unit/Domain/Creators/Python/CMakeLists.txt
@@ -4,29 +4,35 @@
 spectre_add_python_bindings_test(
   "Unit.Domain.Creators.Python.Brick"
   Test_Brick.py
-  "Unit;Domain")
+  "Unit;Domain"
+  PyDomainCreators)
 
 spectre_add_python_bindings_test(
   "Unit.Domain.Creators.Python.Cylinder"
   Test_Cylinder.py
-  "Unit;Domain")
+  "Unit;Domain"
+  PyDomainCreators)
 
 spectre_add_python_bindings_test(
   "Unit.Domain.Creators.Python.Interval"
   Test_Interval.py
-  "Unit;Domain")
+  "Unit;Domain"
+  PyDomainCreators)
 
 spectre_add_python_bindings_test(
   "Unit.Domain.Creators.Python.Rectangle"
   Test_Rectangle.py
-  "Unit;Domain")
+  "Unit;Domain"
+  PyDomainCreators)
 
 spectre_add_python_bindings_test(
   "Unit.Domain.Creators.Python.Shell"
   Test_Shell.py
-  "Unit;Domain")
+  "Unit;Domain"
+  PyDomainCreators)
 
 spectre_add_python_bindings_test(
   "Unit.Domain.Creators.Python.Sphere"
   Test_Sphere.py
-  "Unit;Domain")
+  "Unit;Domain"
+  PyDomainCreators)

--- a/tests/Unit/Domain/Python/CMakeLists.txt
+++ b/tests/Unit/Domain/Python/CMakeLists.txt
@@ -4,8 +4,11 @@
 spectre_add_python_bindings_test(
   "Unit.Domain.Python.ElementId"
   Test_ElementId.py
-  "Unit;Domain")
+  "Unit;Domain"
+  PyDomain)
+
 spectre_add_python_bindings_test(
   "Unit.Domain.Python.SegmentId"
   Test_SegmentId.py
-  "Unit;Domain")
+  "Unit;Domain"
+  PyDomain)

--- a/tests/Unit/IO/CMakeLists.txt
+++ b/tests/Unit/IO/CMakeLists.txt
@@ -37,10 +37,12 @@ add_dependencies(
 spectre_add_python_bindings_test(
   "Unit.IO.H5.Python"
   "Test_H5.py"
-  "unit;IO;H5;python")
+  "unit;IO;H5;python"
+  PyH5)
 
 spectre_add_python_bindings_test(
   "Unit.IO.H5.VolumeData.Python"
   "Test_VolumeData.py"
   "unit;IO;H5;Python"
+  PyH5
   )

--- a/tests/Unit/Informer/CMakeLists.txt
+++ b/tests/Unit/Informer/CMakeLists.txt
@@ -17,4 +17,6 @@ add_test_library(
 spectre_add_python_bindings_test(
   "Unit.Informer.Python"
   "Test_InfoAtCompile.py"
-  "Unit;Informer;Python")
+  "Unit;Informer;Python"
+  PyInformer
+  )

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -28,7 +28,7 @@ function(add_algorithm_test EXECUTABLE_NAME)
     Utilities
     )
 
-  add_dependencies(test-executables ${EXECUTABLE_NAME})
+  add_dependencies(unit-tests ${EXECUTABLE_NAME})
 endfunction()
 
 add_algorithm_test(Test_AlgorithmCore)
@@ -54,9 +54,7 @@ add_dependencies(
   module_Test_GlobalCache
   )
 
-add_dependencies(test-executables Test_GlobalCache)
-
-# Add integration tests. For tests that result in a failure it is necessary to
+# Add unit tests. For tests that result in a failure it is necessary to
 # redirect output from stderr to stdout. However, it was necessary at least on
 # some systems to do this redirect inside a shell command.
 find_program(SHELL_EXECUTABLE "sh")
@@ -67,7 +65,7 @@ endif()
 
 function(add_algorithm_test TEST_NAME REGEX_TO_MATCH)
   add_test(
-    NAME "\"Integration.Parallel.${TEST_NAME}\""
+    NAME "\"Unit.Parallel.${TEST_NAME}\""
     COMMAND
     ${SHELL_EXECUTABLE}
     -c
@@ -76,38 +74,38 @@ function(add_algorithm_test TEST_NAME REGEX_TO_MATCH)
 
   if("${REGEX_TO_MATCH}" STREQUAL "")
     set_tests_properties(
-      "\"Integration.Parallel.${TEST_NAME}\""
+      "\"Unit.Parallel.${TEST_NAME}\""
       PROPERTIES
       TIMEOUT 10
-      LABELS "integration"
+      LABELS "unit"
       ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
   else()
     set_tests_properties(
-      "\"Integration.Parallel.${TEST_NAME}\""
+      "\"Unit.Parallel.${TEST_NAME}\""
       PROPERTIES
       PASS_REGULAR_EXPRESSION
       "${REGEX_TO_MATCH}"
       TIMEOUT 10
-      LABELS "integration"
+      LABELS "unit"
       ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
   endif()
 endfunction()
 
 function(add_algorithm_test_with_input_file TEST_NAME INPUT_FILE_DIR)
   add_test(
-    NAME "\"Integration.Parallel.${TEST_NAME}\""
+    NAME "\"Unit.Parallel.${TEST_NAME}\""
     COMMAND
     ${SHELL_EXECUTABLE}
     -c
     "${CMAKE_BINARY_DIR}/bin/Test_${TEST_NAME} --input-file \
      ${CMAKE_SOURCE_DIR}/tests/${INPUT_FILE_DIR}/Test_${TEST_NAME}.yaml 2>&1"
     )
-    set_tests_properties(
-      "\"Integration.Parallel.${TEST_NAME}\""
-      PROPERTIES
-      TIMEOUT 10
-      LABELS "integration"
-      ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
+  set_tests_properties(
+    "\"Unit.Parallel.${TEST_NAME}\""
+    PROPERTIES
+    TIMEOUT 10
+    LABELS "unit"
+    ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
 endfunction()
 
 add_algorithm_test("AlgorithmCore" "")

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Python/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Python/CMakeLists.txt
@@ -4,4 +4,5 @@
 spectre_add_python_bindings_test(
   "Unit.AnalyticSolutions.GeneralRelativity.Python.Tov"
   "Test_Tov.py"
-  "Unit;PointwiseFunctions;Python")
+  "Unit;PointwiseFunctions;Python"
+  PyGeneralRelativitySolutions)

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Python/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Python/CMakeLists.txt
@@ -4,4 +4,5 @@
 spectre_add_python_bindings_test(
   "Unit.Hydro.EquationsOfState.Python.PolytropicFluid"
   "Test_PolytropicFluid.py"
-  "Unit;EquationsOfState;Python")
+  "Unit;EquationsOfState;Python"
+  PyEquationsOfState)

--- a/tests/Unit/Visualization/Python/CMakeLists.txt
+++ b/tests/Unit/Visualization/Python/CMakeLists.txt
@@ -4,9 +4,11 @@
 spectre_add_python_bindings_test(
   "Unit.Visualization.Python.GenerateXdmf"
   Test_GenerateXdmf.py
-  "unit;visualization;python")
+  "unit;visualization;python"
+  None)
 
 spectre_add_python_test(
   "Unit.Visualization.Python.Render1D"
   Test_Render1D.py
-  "unit;visualization;python")
+  "unit;visualization;python"
+  None)


### PR DESCRIPTION
## Proposed changes

Adds a `unit-tests` target that builds everything needed to run `ctest -L unit`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
