### PR TITLE
Prepare curved Poisson and Elasticity systems for use in XCTS equations

### DIFF
--- a/src/Elliptic/Executables/Poisson/CMakeLists.txt
+++ b/src/Elliptic/Executables/Poisson/CMakeLists.txt
@@ -35,7 +35,7 @@ endfunction(add_poisson_executable)
 # The solution is only implemented in 3D so far
 add_poisson_executable(
   Lorentzian3D
-  "Poisson::FirstOrderSystem<3, Poisson::Geometry::Euclidean>"
+  "Poisson::FirstOrderSystem<3, Poisson::Geometry::FlatCartesian>"
   Poisson::Solutions::Lorentzian<3>
   Poisson::Solutions::Lorentzian<3>
   )
@@ -50,7 +50,7 @@ target_link_libraries(
 function(add_poisson_moustache_executable DIM)
   add_poisson_executable(
     Moustache${DIM}D
-    "Poisson::FirstOrderSystem<${DIM}, Poisson::Geometry::Euclidean>"
+    "Poisson::FirstOrderSystem<${DIM}, Poisson::Geometry::FlatCartesian>"
     Poisson::Solutions::Moustache<${DIM}>
     Poisson::Solutions::Moustache<${DIM}>
     "PoissonSolutions"
@@ -68,7 +68,7 @@ add_poisson_moustache_executable(2)
 function(add_poisson_product_of_sinusoids_executable DIM)
   add_poisson_executable(
     ProductOfSinusoids${DIM}D
-    "Poisson::FirstOrderSystem<${DIM}, Poisson::Geometry::Euclidean>"
+    "Poisson::FirstOrderSystem<${DIM}, Poisson::Geometry::FlatCartesian>"
     Poisson::Solutions::ProductOfSinusoids<${DIM}>
     Poisson::Solutions::ProductOfSinusoids<${DIM}>
     "PoissonSolutions"

--- a/src/Elliptic/Systems/Elasticity/CMakeLists.txt
+++ b/src/Elliptic/Systems/Elasticity/CMakeLists.txt
@@ -22,8 +22,13 @@ spectre_target_headers(
 
 target_link_libraries(
   ${LIBRARY}
-  PUBLIC DataStructures
-  INTERFACE ErrorHandling
-  INTERFACE LinearOperators
-  INTERFACE Spectral
+  PUBLIC
+  ConstitutiveRelations
+  DataStructures
+  Domain
+  Utilities
+  INTERFACE
+  LinearOperators
+  PRIVATE
+  GeneralRelativity
   )

--- a/src/Elliptic/Systems/Elasticity/Equations.cpp
+++ b/src/Elliptic/Systems/Elasticity/Equations.cpp
@@ -3,16 +3,15 @@
 
 #include "Elliptic/Systems/Elasticity/Equations.hpp"
 
+#include <algorithm>
 #include <cstddef>
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Elliptic/Systems/Elasticity/FirstOrderSystem.hpp"
-#include "Elliptic/Systems/Elasticity/Tags.hpp"
-#include "NumericalAlgorithms/LinearOperators/Divergence.tpp"
 #include "PointwiseFunctions/Elasticity/ConstitutiveRelations/ConstitutiveRelation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -39,6 +38,24 @@ void primal_fluxes(
 }
 
 template <size_t Dim>
+void add_curved_sources(
+    const gsl::not_null<tnsr::I<DataVector, Dim>*> source_for_displacement,
+    const tnsr::Ijj<DataVector, Dim>& christoffel_second_kind,
+    const tnsr::i<DataVector, Dim>& christoffel_contracted,
+    const tnsr::II<DataVector, Dim>& stress) noexcept {
+  for (size_t i = 0; i < Dim; ++i) {
+    for (size_t j = 0; j < Dim; ++j) {
+      source_for_displacement->get(j) -=
+          christoffel_contracted.get(i) * stress.get(i, j);
+      for (size_t k = 0; k < Dim; ++k) {
+        source_for_displacement->get(j) -=
+            christoffel_second_kind.get(j, i, k) * stress.get(i, k);
+      }
+    }
+  }
+}
+
+template <size_t Dim>
 void auxiliary_fluxes(
     const gsl::not_null<tnsr::Ijj<DataVector, Dim>*> flux_for_strain,
     const tnsr::I<DataVector, Dim>& displacement) noexcept {
@@ -55,6 +72,36 @@ void auxiliary_fluxes(
   }
 }
 
+template <size_t Dim>
+void curved_auxiliary_fluxes(
+    const gsl::not_null<tnsr::Ijj<DataVector, Dim>*> flux_for_strain,
+    const tnsr::ii<DataVector, Dim>& metric,
+    const tnsr::I<DataVector, Dim>& displacement) noexcept {
+  const auto co_displacement = raise_or_lower_index(displacement, metric);
+  std::fill(flux_for_strain->begin(), flux_for_strain->end(), 0.);
+  for (size_t d = 0; d < Dim; d++) {
+    flux_for_strain->get(d, d, d) += 0.5 * co_displacement.get(d);
+    for (size_t e = 0; e < Dim; e++) {
+      flux_for_strain->get(d, e, d) += 0.5 * co_displacement.get(e);
+    }
+  }
+}
+
+template <size_t Dim>
+void add_curved_auxiliary_sources(
+    const gsl::not_null<tnsr::ii<DataVector, Dim>*> source_for_strain,
+    const tnsr::ijj<DataVector, Dim>& christoffel_first_kind,
+    const tnsr::I<DataVector, Dim>& displacement) noexcept {
+  for (size_t i = 0; i < Dim; ++i) {
+    for (size_t j = 0; j <= i; ++j) {
+      for (size_t k = 0; k < Dim; ++k) {
+        source_for_strain->get(i, j) +=
+            christoffel_first_kind.get(k, i, j) * displacement.get(k);
+      }
+    }
+  }
+}
+
 }  // namespace Elasticity
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
@@ -66,8 +113,21 @@ void auxiliary_fluxes(
       const Elasticity::ConstitutiveRelations::ConstitutiveRelation<DIM( \
           data)>&,                                                       \
       const tnsr::I<DataVector, DIM(data)>&) noexcept;                   \
+  template void Elasticity::add_curved_sources<DIM(data)>(               \
+      gsl::not_null<tnsr::I<DataVector, DIM(data)>*>,                    \
+      const tnsr::Ijj<DataVector, DIM(data)>&,                           \
+      const tnsr::i<DataVector, DIM(data)>&,                             \
+      const tnsr::II<DataVector, DIM(data)>&) noexcept;                  \
   template void Elasticity::auxiliary_fluxes<DIM(data)>(                 \
       gsl::not_null<tnsr::Ijj<DataVector, DIM(data)>*>,                  \
+      const tnsr::I<DataVector, DIM(data)>&) noexcept;                   \
+  template void Elasticity::curved_auxiliary_fluxes<DIM(data)>(          \
+      gsl::not_null<tnsr::Ijj<DataVector, DIM(data)>*>,                  \
+      const tnsr::ii<DataVector, DIM(data)>&,                            \
+      const tnsr::I<DataVector, DIM(data)>&) noexcept;                   \
+  template void Elasticity::add_curved_auxiliary_sources<DIM(data)>(     \
+      gsl::not_null<tnsr::ii<DataVector, DIM(data)>*>,                   \
+      const tnsr::ijj<DataVector, DIM(data)>&,                           \
       const tnsr::I<DataVector, DIM(data)>&) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3))

--- a/src/Elliptic/Systems/Elasticity/Equations.hpp
+++ b/src/Elliptic/Systems/Elasticity/Equations.hpp
@@ -41,14 +41,56 @@ void primal_fluxes(
     const tnsr::I<DataVector, Dim>& coordinates) noexcept;
 
 /*!
+ * \brief Add the contribution \f$-\Gamma^i_{ik}T^{kj} - \Gamma^j_{ik}T^{ik}\f$
+ * to the displacement source for the curved-space elasticity equations on a
+ * metric \f$\gamma_{ij}\f$.
+ *
+ * These sources arise from the non-principal part of the divergence on a
+ * curved background.
+ */
+template <size_t Dim>
+void add_curved_sources(
+    gsl::not_null<tnsr::I<DataVector, Dim>*> source_for_displacement,
+    const tnsr::Ijj<DataVector, Dim>& christoffel_second_kind,
+    const tnsr::i<DataVector, Dim>& christoffel_contracted,
+    const tnsr::II<DataVector, Dim>& stress) noexcept;
+
+/*!
  * \brief Compute the fluxes \f$F^i_{jk}=\delta^{i}_{(j} \xi_{k)}\f$ for the
- * auxiliary field in the first-order formulation of the Elasticity equation.
+ * auxiliary (strain) field in the first-order formulation of the Elasticity
+ * equation.
  *
  * \see Elasticity::FirstOrderSystem
  */
 template <size_t Dim>
 void auxiliary_fluxes(
     gsl::not_null<tnsr::Ijj<DataVector, Dim>*> flux_for_strain,
+    const tnsr::I<DataVector, Dim>& displacement) noexcept;
+
+/*!
+ * \brief Compute the fluxes \f$F^i_{jk}=\delta^{i}_{(j}\gamma_{k)l}\xi^l\f$
+ * for the auxiliary (strain) field in the first-order formulation of the
+ * curved-space elasticity equations on a metric \f$\gamma_{ij}\f$.
+ *
+ * \see Elasticity::FirstOrderSystem
+ */
+template <size_t Dim>
+void curved_auxiliary_fluxes(
+    gsl::not_null<tnsr::Ijj<DataVector, Dim>*> flux_for_strain,
+    const tnsr::ii<DataVector, Dim>& metric,
+    const tnsr::I<DataVector, Dim>& displacement) noexcept;
+
+/*!
+ * \brief Add the contribution \f$\Gamma_{ijk}\xi^i\f$ to the strain source for
+ * the curved-space elasticity equations on a metric \f$\gamma_{ij}\f$.
+ *
+ * These sources arise from the non-principal part of the divergence on a
+ * curved background.
+ */
+template <size_t Dim>
+void add_curved_auxiliary_sources(
+    gsl::not_null<tnsr::ii<DataVector, Dim>*> source_for_strain,
+    const tnsr::ijj<DataVector, Dim>& christoffel_first_kind,
     const tnsr::I<DataVector, Dim>& displacement) noexcept;
 
 /*!

--- a/src/Elliptic/Systems/Elasticity/Equations.hpp
+++ b/src/Elliptic/Systems/Elasticity/Equations.hpp
@@ -29,8 +29,8 @@ class ConstitutiveRelation;
 namespace Elasticity {
 
 /*!
- * \brief Compute the fluxes \f$F^{ij}=Y^{ijkl}(x) S_{kl}(x)\f$ for
- * the Elasticity equation on a flat spatial metric in Cartesian coordinates.
+ * \brief Compute the fluxes \f$F^{ij}=Y^{ijkl}(x) S_{kl}(x)=-T^{ij}\f$ for
+ * the Elasticity equation.
  */
 template <size_t Dim>
 void primal_fluxes(

--- a/src/Elliptic/Systems/Poisson/CMakeLists.txt
+++ b/src/Elliptic/Systems/Poisson/CMakeLists.txt
@@ -27,5 +27,7 @@ target_link_libraries(
   DataStructures
   ErrorHandling
   GeneralRelativity
+  Utilities
+  INTERFACE
   LinearOperators
   )

--- a/src/Elliptic/Systems/Poisson/FirstOrderSystem.hpp
+++ b/src/Elliptic/Systems/Poisson/FirstOrderSystem.hpp
@@ -85,7 +85,7 @@ struct FirstOrderSystem {
       ::Tags::Variables<tmpl::append<primal_fields, auxiliary_fields>>;
 
   using fluxes =
-      tmpl::conditional_t<BackgroundGeometry == Geometry::Euclidean,
+      tmpl::conditional_t<BackgroundGeometry == Geometry::FlatCartesian,
                           EuclideanFluxes<Dim>, NonEuclideanFluxes<Dim>>;
   using sources = Sources;
 
@@ -93,7 +93,7 @@ struct FirstOrderSystem {
   // normalize vectors on the faces of an element
   template <typename Tag>
   using magnitude_tag = tmpl::conditional_t<
-      BackgroundGeometry == Geometry::Euclidean,
+      BackgroundGeometry == Geometry::FlatCartesian,
       ::Tags::EuclideanMagnitude<Tag>,
       ::Tags::NonEuclideanMagnitude<
           Tag, gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataVector>>>;

--- a/src/Elliptic/Systems/Poisson/FirstOrderSystem.hpp
+++ b/src/Elliptic/Systems/Poisson/FirstOrderSystem.hpp
@@ -28,11 +28,18 @@ namespace Poisson {
  * first-order PDEs
  *
  * \f[
- * -\frac{1}{\sqrt{\gamma}} \partial_i \sqrt{\gamma}\gamma^{ij} v_j(x) = f(x) \\
+ * -\partial_i \gamma^{ij} v_j(x) - \Gamma^i_{ij}\gamma^{jk}v_k = f(x) \\
  * -\partial_i u(x) + v_i(x) = 0
  * \f]
  *
- * where we have chosen the field gradient as an auxiliary variable \f$v_i\f$.
+ * where we have chosen the field gradient as an auxiliary variable \f$v_i\f$
+ * and where \f$\Gamma^i_{jk}=\frac{1}{2}\gamma^{il}\left(\partial_j\gamma_{kl}
+ * +\partial_k\gamma_{jl}-\partial_l\gamma_{jk}\right)\f$ are the Christoffel
+ * symbols of the second kind of the background metric \f$\gamma_{ij}\f$. The
+ * background metric \f$\gamma_{ij}\f$ and the Christoffel symbols derived from
+ * it are assumed to be independent of the variables \f$u\f$ and \f$v_i\f$, i.e.
+ * constant throughout an iterative elliptic solve.
+ *
  * This scheme also goes by the name of _mixed_ or _flux_ formulation (see e.g.
  * \cite Arnold2002). The reason for the latter name is that we can write the
  * set of coupled first-order PDEs in flux-form
@@ -45,9 +52,9 @@ namespace Poisson {
  * \f$u(x)\f$ and \f$v_i(x)\f$ as
  *
  * \f{align*}
- * F^i_u &= \sqrt{\gamma}\gamma^{ij} v_j(x) \\
- * S_u &= 0 \\
- * f_u &= \sqrt{\gamma} f(x) \\
+ * F^i_u &= \gamma^{ij} v_j(x) \\
+ * S_u &= -\Gamma^i_{ij}\gamma^{jk}v_k \\
+ * f_u &= f(x) \\
  * F^i_{v_j} &= u \delta^i_j \\
  * S_{v_j} &= v_j \\
  * f_{v_j} &= 0 \text{.}
@@ -58,15 +65,11 @@ namespace Poisson {
  * Also note that we have defined the _fixed sources_ \f$f_A\f$ as those source
  * terms that are independent of the system variables.
  *
- * The field gradient \f$v_i\f$ is treated on the same footing as the field
- * \f$u\f$ in this first-order formulation. This allows us to make use of the DG
- * architecture developed for coupled first-order hyperbolic PDEs in flux-form,
- * in particular the flux communication and lifting code. It does, however,
- * introduce auxiliary degrees of freedom that can be avoided in the
- * second-order (or _primal_) formulation. Furthermore, the linear operator that
- * represents the DG discretization for this system is not symmetric. This
- * property further increase the computational cost (see \ref LinearSolverGroup)
- * and is remedied in the second-order formulation.
+ * The fluxes und sources simplify significantly when the background metric is
+ * flat and we employ Cartesian coordinates so \f$\gamma_{ij} = delta_{ij}\f$
+ * and \f$\Gamma^i_{jk} = 0\f$. Set the template parameter `BackgroundGeometry`
+ * to `Poisson::Geometry::FlatCartesian` to specialise the system for this case.
+ * Set it to `Poisson::Geometry::Curved` for the general case.
  */
 template <size_t Dim, Geometry BackgroundGeometry>
 struct FirstOrderSystem {
@@ -84,18 +87,18 @@ struct FirstOrderSystem {
   using fields_tag =
       ::Tags::Variables<tmpl::append<primal_fields, auxiliary_fields>>;
 
-  using fluxes =
-      tmpl::conditional_t<BackgroundGeometry == Geometry::FlatCartesian,
-                          EuclideanFluxes<Dim>, NonEuclideanFluxes<Dim>>;
-  using sources = Sources;
+  using fluxes = Fluxes<Dim, BackgroundGeometry>;
+  using sources = Sources<Dim, BackgroundGeometry>;
 
   // The tag of the operator to compute magnitudes on the manifold, e.g. to
   // normalize vectors on the faces of an element
+  using inv_metric_tag = tmpl::conditional_t<
+      BackgroundGeometry == Geometry::FlatCartesian, void,
+      gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>>;
   template <typename Tag>
-  using magnitude_tag = tmpl::conditional_t<
-      BackgroundGeometry == Geometry::FlatCartesian,
-      ::Tags::EuclideanMagnitude<Tag>,
-      ::Tags::NonEuclideanMagnitude<
-          Tag, gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataVector>>>;
+  using magnitude_tag =
+      tmpl::conditional_t<BackgroundGeometry == Geometry::FlatCartesian,
+                          ::Tags::EuclideanMagnitude<Tag>,
+                          ::Tags::NonEuclideanMagnitude<Tag, inv_metric_tag>>;
 };
 }  // namespace Poisson

--- a/src/Elliptic/Systems/Poisson/Geometry.hpp
+++ b/src/Elliptic/Systems/Poisson/Geometry.hpp
@@ -4,6 +4,14 @@
 #pragma once
 
 namespace Poisson {
-/// \brief Euclidean or non-Euclidean background geometry
-enum class Geometry { Euclidean, NonEuclidean };
+/// \brief Types of background geometries for the Poisson equation
+enum class Geometry {
+  /// Euclidean (flat) manifold with Cartesian coordinates, i.e. the metric has
+  /// components \f$\gamma_{ij} = \delta_{ij}\f$ in these coordinates and thus
+  /// all Christoffel symbols vanish: \f$\Gamma^i_{jk}=0\f$.
+  FlatCartesian,
+  /// The manifold is either curved or employs curved coordinates, so
+  /// non-vanishing Christoffel symbols must be taken into account.
+  Curved
+};
 }  // namespace Poisson

--- a/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/ConstitutiveRelation.cpp
+++ b/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/ConstitutiveRelation.cpp
@@ -5,30 +5,26 @@
 
 #include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
 #include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-namespace Elasticity {
-namespace ConstitutiveRelations {
-
-template <size_t Dim>
-tnsr::II<DataVector, Dim> ConstitutiveRelation<Dim>::stress(
-    const tnsr::iJ<DataVector, Dim>& grad_displacement,
-    const tnsr::I<DataVector, Dim>& x) const noexcept {
-  auto strain =
-      make_with_value<tnsr::ii<DataVector, Dim>>(grad_displacement, 0.);
-  for (size_t i = 0; i < Dim; i++) {
-    // Diagonal elements
-    strain.get(i, i) = grad_displacement.get(i, i);
-    // Symmetric off-diagonal elements
-    for (size_t j = 0; j < i; j++) {
-      strain.get(i, j) =
-          0.5 * (grad_displacement.get(i, j) + grad_displacement.get(j, i));
-    }
-  }
-  return stress(std::move(strain), x);
-}
+namespace Elasticity::ConstitutiveRelations {
 
 /// \cond
+template <size_t Dim>
+void ConstitutiveRelation<Dim>::stress(
+    const gsl::not_null<tnsr::IJ<DataVector, Dim>*> stress,
+    const tnsr::ii<DataVector, Dim>& strain,
+    const tnsr::I<DataVector, Dim>& x) const noexcept {
+  tnsr::II<DataVector, Dim> symmetric_stress{x.begin()->size()};
+  this->stress(make_not_null(&symmetric_stress), strain, x);
+  for (size_t i = 0; i < Dim; ++i) {
+    for (size_t j = 0; j < Dim; ++j) {
+      stress->get(i, j) = symmetric_stress.get(i, j);
+    }
+  }
+}
+
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data) template class ConstitutiveRelation<DIM(data)>;
@@ -39,5 +35,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3))
 #undef INSTANTIATE
 /// \endcond
 
-}  // namespace ConstitutiveRelations
-}  // namespace Elasticity
+}  // namespace Elasticity::ConstitutiveRelations

--- a/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/ConstitutiveRelation.hpp
+++ b/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/ConstitutiveRelation.hpp
@@ -8,6 +8,7 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Parallel/CharmPupable.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -67,17 +68,20 @@ class ConstitutiveRelation : public PUP::able {
 
   WRAPPED_PUPable_abstract(ConstitutiveRelation);  // NOLINT
 
+  // @{
   /// The constitutive relation that characterizes the elastic properties of a
   /// material
-  virtual tnsr::II<DataVector, Dim> stress(
-      const tnsr::ii<DataVector, Dim>& strain,
-      const tnsr::I<DataVector, Dim>& x) const noexcept = 0;
+  virtual void stress(gsl::not_null<tnsr::II<DataVector, Dim>*> stress,
+                      const tnsr::ii<DataVector, Dim>& strain,
+                      const tnsr::I<DataVector, Dim>& x) const noexcept = 0;
 
-  /// Symmmetrize the displacement gradient to compute the strain, then pass it
-  /// to the constitutive relation
-  tnsr::II<DataVector, Dim> stress(
-      const tnsr::iJ<DataVector, Dim>& grad_displacement,
-      const tnsr::I<DataVector, Dim>& x) const noexcept;
+  // This overload is provided for the situation where the `stress` variable
+  // holds a non-symmetric tensor, as is currently the case when it is held in a
+  // `Tags::Flux`. The overload can be removed once it is no longer used.
+  void stress(gsl::not_null<tnsr::IJ<DataVector, Dim>*> stress,
+              const tnsr::ii<DataVector, Dim>& strain,
+              const tnsr::I<DataVector, Dim>& x) const noexcept;
+  // @}
 };
 
 }  // namespace ConstitutiveRelations

--- a/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/CubicCrystal.cpp
+++ b/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/CubicCrystal.cpp
@@ -27,21 +27,20 @@ CubicCrystal::CubicCrystal(const double c_11, const double c_12,
              "must be positive and the poisson ratio smaller or equal to 0.5.");
 }
 
-tnsr::II<DataVector, 3> CubicCrystal::stress(
-    const tnsr::ii<DataVector, 3>& strain,
-    const tnsr::I<DataVector, 3>& /*x*/) const noexcept {
-  auto result = make_with_value<tnsr::II<DataVector, 3>>(strain, 0.);
-  for (size_t i = 0; i < 3; i++) {
-    result.get(2, 2) -= strain.get(i, i);
+void CubicCrystal::stress(const gsl::not_null<tnsr::II<DataVector, 3>*> stress,
+                          const tnsr::ii<DataVector, 3>& strain,
+                          const tnsr::I<DataVector, 3>& /*x*/) const noexcept {
+  get<2, 2>(*stress) = -get<0, 0>(strain);
+  for (size_t i = 1; i < 3; ++i) {
+    stress->get(2, 2) -= strain.get(i, i);
   }
-  result.get(2, 2) *= c_12_;
-  for (size_t i = 0; i < 3; i++) {
-    result.get(i, i) = result.get(2, 2) - (c_11_ - c_12_) * strain.get(i, i);
-    for (size_t j = 0; j < i; j++) {
-      result.get(i, j) = -2. * c_44_ * strain.get(i, j);
+  stress->get(2, 2) *= c_12_;
+  for (size_t i = 0; i < 3; ++i) {
+    stress->get(i, i) = stress->get(2, 2) - (c_11_ - c_12_) * strain.get(i, i);
+    for (size_t j = 0; j < i; ++j) {
+      stress->get(i, j) = -2. * c_44_ * strain.get(i, j);
     }
   }
-  return result;
 }
 
 double CubicCrystal::c_11() const noexcept { return c_11_; }

--- a/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/CubicCrystal.hpp
+++ b/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/CubicCrystal.hpp
@@ -113,9 +113,9 @@ class CubicCrystal : public ConstitutiveRelation<3> {
 
   /// The constitutive relation that characterizes the elastic properties of a
   /// material
-  tnsr::II<DataVector, 3> stress(const tnsr::ii<DataVector, 3>& strain,
-                                 const tnsr::I<DataVector, 3>& x) const
-      noexcept override;
+  void stress(gsl::not_null<tnsr::II<DataVector, 3>*> stress,
+              const tnsr::ii<DataVector, 3>& strain,
+              const tnsr::I<DataVector, 3>& x) const noexcept override;
 
   /// The 1st group parameter \f$c_{11} = \frac{1 - \nu}{\nu} \lambda\f$
   double c_11() const noexcept;

--- a/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp
+++ b/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp
@@ -11,6 +11,7 @@
 #include "Options/Options.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/Elasticity/ConstitutiveRelations/ConstitutiveRelation.hpp"  // IWYU pragma: keep
+#include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -128,9 +129,9 @@ class IsotropicHomogeneous : public ConstitutiveRelation<Dim> {
 
   /// The constitutive relation that characterizes the elastic properties of a
   /// material
-  tnsr::II<DataVector, Dim> stress(const tnsr::ii<DataVector, Dim>& strain,
-                                   const tnsr::I<DataVector, Dim>& x) const
-      noexcept override;
+  void stress(gsl::not_null<tnsr::II<DataVector, Dim>*> stress,
+              const tnsr::ii<DataVector, Dim>& strain,
+              const tnsr::I<DataVector, Dim>& x) const noexcept override;
 
   /// The bulk modulus (or incompressibility) \f$K\f$
   double bulk_modulus() const noexcept;

--- a/src/PointwiseFunctions/Elasticity/PotentialEnergy.cpp
+++ b/src/PointwiseFunctions/Elasticity/PotentialEnergy.cpp
@@ -27,14 +27,14 @@ void potential_energy_density(
         constitutive_relation) noexcept {
   destructive_resize_components(potential_energy_density,
                                 coordinates.begin()->size());
+  tnsr::II<DataVector, Dim> stress{coordinates.begin()->size()};
+  constitutive_relation.stress(make_not_null(&stress), strain, coordinates);
   get(*potential_energy_density) = 0.;
-  const auto stress = constitutive_relation.stress(strain, coordinates);
-  for (size_t i = 0; i < Dim; i++) {
-    for (size_t j = 0; j < Dim; j++) {
-      get(*potential_energy_density) -=
-          0.5 * stress.get(i, j) * strain.get(i, j);
-    }
+  for (size_t i = 0; i < stress.size(); ++i) {
+    get(*potential_energy_density) -=
+        stress.multiplicity(i) * stress[i] * strain[i];
   }
+  get(*potential_energy_density) *= 0.5;
 }
 
 template <size_t Dim>

--- a/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
@@ -105,6 +105,12 @@ template <size_t Dim, typename Frame, typename DataType>
 struct TraceSpatialChristoffelSecondKind : db::SimpleTag {
   using type = tnsr::I<DataType, Dim, Frame>;
 };
+/// Contraction of the first two indices of the spatial Christoffel symbols:
+/// \f$\Gamma^i_{ij}\f$. Useful for covariant divergences.
+template <size_t Dim, typename Frame, typename DataType>
+struct SpatialChristoffelSecondKindContracted : db::SimpleTag {
+  using type = tnsr::i<DataType, Dim, Frame>;
+};
 
 template <size_t Dim, typename Frame, typename DataType>
 struct ExtrinsicCurvature : db::SimpleTag {

--- a/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
@@ -68,6 +68,9 @@ template <size_t Dim, typename Frame = Frame::Inertial,
 struct TraceSpatialChristoffelSecondKind;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
+struct SpatialChristoffelSecondKindContracted;
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
 struct ExtrinsicCurvature;
 template <typename DataType = DataVector>
 struct TraceExtrinsicCurvature;

--- a/tests/Unit/Elliptic/Systems/Elasticity/Equations.py
+++ b/tests/Unit/Elliptic/Systems/Elasticity/Equations.py
@@ -25,16 +25,24 @@ def primal_fluxes_3d(strain, coordinates, bulk_modulus, shear_modulus):
     return -constitutive_relation_3d(strain, bulk_modulus, shear_modulus)
 
 
-def auxiliary_fluxes(field, dim):
+def add_curved_sources(christoffel_second_kind, christoffel_contracted,
+                       stress):
+    return (-np.einsum('i,ij', christoffel_contracted, stress) -
+            np.einsum('ijk,jk', christoffel_second_kind, stress))
+
+
+def auxiliary_fluxes(displacement):
+    dim = len(displacement)
     # Compute the tensor product with a Kronecker delta and symmetrize the last
     # two indices.
-    tensor_product = np.tensordot(np.eye(dim), field, axes=0)
+    tensor_product = np.tensordot(np.eye(dim), displacement, axes=0)
     return 0.5 * (tensor_product + np.transpose(tensor_product, (0, 2, 1)))
 
 
-def auxiliary_fluxes_2d(field):
-    return auxiliary_fluxes(field, 2)
+def curved_auxiliary_fluxes(metric, displacement):
+    co_displacement = np.einsum('ij,j', metric, displacement)
+    return auxiliary_fluxes(co_displacement)
 
 
-def auxiliary_fluxes_3d(field):
-    return auxiliary_fluxes(field, 3)
+def add_curved_auxiliary_sources(christoffel_first_kind, displacement):
+    return np.einsum('ijk,i', christoffel_first_kind, displacement)

--- a/tests/Unit/Elliptic/Systems/Elasticity/Test_Equations.cpp
+++ b/tests/Unit/Elliptic/Systems/Elasticity/Test_Equations.cpp
@@ -42,15 +42,46 @@ void primal_fluxes(
 }
 
 template <size_t Dim>
+void add_curved_sources(
+    const gsl::not_null<tnsr::I<DataVector, Dim>*> source_for_displacement,
+    const tnsr::Ijj<DataVector, Dim>& christoffel_second_kind,
+    const tnsr::i<DataVector, Dim>& christoffel_contracted,
+    const tnsr::II<DataVector, Dim>& stress) noexcept {
+  std::fill(source_for_displacement->begin(), source_for_displacement->end(),
+            0.);
+  Elasticity::add_curved_sources(source_for_displacement,
+                                 christoffel_second_kind,
+                                 christoffel_contracted, stress);
+}
+
+template <size_t Dim>
+void add_curved_auxiliary_sources(
+    const gsl::not_null<tnsr::ii<DataVector, Dim>*> source_for_strain,
+    const tnsr::ijj<DataVector, Dim>& christoffel_first_kind,
+    const tnsr::I<DataVector, Dim>& displacement) noexcept {
+  std::fill(source_for_strain->begin(), source_for_strain->end(), 0.);
+  Elasticity::add_curved_auxiliary_sources(
+      source_for_strain, christoffel_first_kind, displacement);
+}
+
+template <size_t Dim>
 void test_equations(const DataVector& used_for_size) {
   pypp::check_with_random_values<4>(
       &primal_fluxes<Dim>, "Equations",
       {MakeString{} << "primal_fluxes_" << Dim << "d"},
       {{{-1., 1.}, {-1., 1.}, {0., 1.}, {0., 1.}}}, used_for_size);
+  pypp::check_with_random_values<1>(&add_curved_sources<Dim>, "Equations",
+                                    {"add_curved_sources"}, {{{-1., 1.}}},
+                                    used_for_size);
+  pypp::check_with_random_values<1>(&Elasticity::auxiliary_fluxes<Dim>,
+                                    "Equations", {"auxiliary_fluxes"},
+                                    {{{-1., 1.}}}, used_for_size);
+  pypp::check_with_random_values<1>(&Elasticity::curved_auxiliary_fluxes<Dim>,
+                                    "Equations", {"curved_auxiliary_fluxes"},
+                                    {{{-1., 1.}}}, used_for_size);
   pypp::check_with_random_values<1>(
-      &Elasticity::auxiliary_fluxes<Dim>, "Equations",
-      {MakeString{} << "auxiliary_fluxes_" << Dim << "d"}, {{{-1., 1.}}},
-      used_for_size);
+      &add_curved_auxiliary_sources<Dim>, "Equations",
+      {"add_curved_auxiliary_sources"}, {{{-1., 1.}}}, used_for_size);
 }
 
 template <size_t Dim>

--- a/tests/Unit/Elliptic/Systems/Poisson/Equations.py
+++ b/tests/Unit/Elliptic/Systems/Poisson/Equations.py
@@ -4,14 +4,16 @@
 import numpy as np
 
 
-def euclidean_fluxes(field_gradient):
+def flat_cartesian_fluxes(field_gradient):
     return field_gradient
 
 
-def non_euclidean_fluxes(inv_spatial_metric, det_spatial_metric,
-                         field_gradient):
-    return np.sqrt(det_spatial_metric) * np.einsum('ij,j', inv_spatial_metric,
-                                                   field_gradient)
+def curved_fluxes(inv_spatial_metric, field_gradient):
+    return np.einsum('ij,j', inv_spatial_metric, field_gradient)
+
+
+def add_curved_sources(christoffel_contracted, field_flux):
+    return -np.einsum('i,i', christoffel_contracted, field_flux)
 
 
 def auxiliary_fluxes(field, dim):

--- a/tests/Unit/Elliptic/Systems/Poisson/Test_Equations.cpp
+++ b/tests/Unit/Elliptic/Systems/Poisson/Test_Equations.cpp
@@ -53,5 +53,5 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Poisson", "[Unit][Elliptic]") {
   CHECK_FOR_DATAVECTORS(test_equations, (1, 2, 3));
   CHECK_FOR_DATAVECTORS(
       test_computers, (1, 2, 3),
-      (Poisson::Geometry::Euclidean, Poisson::Geometry::NonEuclidean));
+      (Poisson::Geometry::FlatCartesian, Poisson::Geometry::Curved));
 }

--- a/tests/Unit/Elliptic/Systems/Poisson/Test_Equations.cpp
+++ b/tests/Unit/Elliptic/Systems/Poisson/Test_Equations.cpp
@@ -21,13 +21,26 @@ namespace helpers = TestHelpers::elliptic;
 namespace {
 
 template <size_t Dim>
+void add_curved_sources(
+    const gsl::not_null<Scalar<DataVector>*> source_for_field,
+    const tnsr::i<DataVector, Dim>& christoffel_contracted,
+    const tnsr::I<DataVector, Dim>& flux_for_field) {
+  std::fill(source_for_field->begin(), source_for_field->end(), 0.);
+  Poisson::add_curved_sources(source_for_field, christoffel_contracted,
+                              flux_for_field);
+}
+
+template <size_t Dim>
 void test_equations(const DataVector& used_for_size) {
-  pypp::check_with_random_values<1>(&Poisson::euclidean_fluxes<Dim>,
-                                    "Equations", {"euclidean_fluxes"},
+  pypp::check_with_random_values<1>(&Poisson::flat_cartesian_fluxes<Dim>,
+                                    "Equations", {"flat_cartesian_fluxes"},
                                     {{{0., 1.}}}, used_for_size);
-  pypp::check_with_random_values<1>(&Poisson::non_euclidean_fluxes<Dim>,
-                                    "Equations", {"non_euclidean_fluxes"},
-                                    {{{0., 1.}}}, used_for_size);
+  pypp::check_with_random_values<1>(&Poisson::curved_fluxes<Dim>, "Equations",
+                                    {"curved_fluxes"}, {{{0., 1.}}},
+                                    used_for_size);
+  pypp::check_with_random_values<1>(&add_curved_sources<Dim>, "Equations",
+                                    {"add_curved_sources"}, {{{0., 1.}}},
+                                    used_for_size);
   pypp::check_with_random_values<1>(
       &Poisson::auxiliary_fluxes<Dim>, "Equations",
       {MakeString{} << "auxiliary_fluxes_" << Dim << "d"}, {{{0., 1.}}},

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Lorentzian.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Lorentzian.cpp
@@ -81,7 +81,8 @@ SPECTRE_TEST_CASE(
   {
     // Verify that the solution numerically solves the system and that the
     // discretization error decreases exponentially with polynomial order
-    using system = Poisson::FirstOrderSystem<3, Poisson::Geometry::Euclidean>;
+    using system =
+        Poisson::FirstOrderSystem<3, Poisson::Geometry::FlatCartesian>;
     const Poisson::Solutions::Lorentzian<3> solution{};
     const typename system::fluxes fluxes_computer{};
     using AffineMap = domain::CoordinateMaps::Affine;
@@ -98,8 +99,7 @@ SPECTRE_TEST_CASE(
   {
     // Verify that the solution also solves the non-euclidean system with a
     // Euclidean metric. This is more a test of the system than of the solution.
-    using system =
-        Poisson::FirstOrderSystem<3, Poisson::Geometry::NonEuclidean>;
+    using system = Poisson::FirstOrderSystem<3, Poisson::Geometry::Curved>;
     const Poisson::Solutions::Lorentzian<3> solution{};
     const typename system::fluxes fluxes_computer{};
     using AffineMap = domain::CoordinateMaps::Affine;

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Lorentzian.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Lorentzian.cpp
@@ -116,10 +116,11 @@ SPECTRE_TEST_CASE(
     get<0, 0>(inv_spatial_metric) = 1.;
     get<1, 1>(inv_spatial_metric) = 1.;
     get<2, 2>(inv_spatial_metric) = 1.;
-    const auto det_spatial_metric =
-        make_with_value<Scalar<DataVector>>(used_for_size, 1.);
+    const auto spatial_christoffel_contracted =
+        make_with_value<tnsr::i<DataVector, 3>>(used_for_size, 0.);
     FirstOrderEllipticSolutionsTestHelpers::verify_solution<system>(
         solution, fluxes_computer, mesh, coord_map, 0.1,
-        std::make_tuple(inv_spatial_metric, det_spatial_metric));
+        std::make_tuple(inv_spatial_metric),
+        std::make_tuple(spatial_christoffel_contracted));
   }
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Moustache.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Moustache.cpp
@@ -80,7 +80,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Poisson.Moustache",
     INFO("1D");
     test_solution<1>();
 
-    using system = Poisson::FirstOrderSystem<1, Poisson::Geometry::Euclidean>;
+    using system =
+        Poisson::FirstOrderSystem<1, Poisson::Geometry::FlatCartesian>;
     const Poisson::Solutions::Moustache<1> solution{};
     const typename system::fluxes fluxes_computer{};
     const domain::CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap>
@@ -93,7 +94,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Poisson.Moustache",
     INFO("2D");
     test_solution<2>();
 
-    using system = Poisson::FirstOrderSystem<2, Poisson::Geometry::Euclidean>;
+    using system =
+        Poisson::FirstOrderSystem<2, Poisson::Geometry::FlatCartesian>;
     const Poisson::Solutions::Moustache<2> solution{};
     const typename system::fluxes fluxes_computer{};
     using AffineMap2D =

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_ProductOfSinusoids.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_ProductOfSinusoids.cpp
@@ -89,7 +89,8 @@ SPECTRE_TEST_CASE(
     INFO("1D");
     test_solution<1>({{0.5}}, "[0.5]");
 
-    using system = Poisson::FirstOrderSystem<1, Poisson::Geometry::Euclidean>;
+    using system =
+        Poisson::FirstOrderSystem<1, Poisson::Geometry::FlatCartesian>;
     const Poisson::Solutions::ProductOfSinusoids<1> solution{{{0.5}}};
     const typename system::fluxes fluxes_computer{};
     const domain::CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap>
@@ -102,7 +103,8 @@ SPECTRE_TEST_CASE(
     INFO("2D");
     test_solution<2>({{0.5, 1.}}, "[0.5, 1.]");
 
-    using system = Poisson::FirstOrderSystem<2, Poisson::Geometry::Euclidean>;
+    using system =
+        Poisson::FirstOrderSystem<2, Poisson::Geometry::FlatCartesian>;
     const Poisson::Solutions::ProductOfSinusoids<2> solution{{{0.5, 0.5}}};
     const typename system::fluxes fluxes_computer{};
     using AffineMap2D =
@@ -117,7 +119,8 @@ SPECTRE_TEST_CASE(
     INFO("3D");
     test_solution<3>({{1., 0.5, 1.5}}, "[1., 0.5, 1.5]");
 
-    using system = Poisson::FirstOrderSystem<3, Poisson::Geometry::Euclidean>;
+    using system =
+        Poisson::FirstOrderSystem<3, Poisson::Geometry::FlatCartesian>;
     const Poisson::Solutions::ProductOfSinusoids<3> solution{{{0.5, 0.5, 0.5}}};
     const typename system::fluxes fluxes_computer{};
     using AffineMap3D =

--- a/tests/Unit/PointwiseFunctions/Elasticity/Test_PotentialEnergy.cpp
+++ b/tests/Unit/PointwiseFunctions/Elasticity/Test_PotentialEnergy.cpp
@@ -77,7 +77,7 @@ void test_compute_tags(const DataVector& used_for_size) noexcept {
 
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Elasticity",
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Elasticity.PotentialEnergy",
                   "[Unit][PointwiseFunctions]") {
   pypp::SetupLocalPythonEnvironment local_python_env{"PointwiseFunctions"};
   GENERATE_UNINITIALIZED_DATAVECTOR;

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Tags.cpp
@@ -61,6 +61,9 @@ void test_simple_tags() {
       gr::Tags::TraceSpatialChristoffelSecondKind<Dim, Frame, Type>>(
       "TraceSpatialChristoffelSecondKind");
   TestHelpers::db::test_simple_tag<
+      gr::Tags::SpatialChristoffelSecondKindContracted<Dim, Frame, Type>>(
+      "SpatialChristoffelSecondKindContracted");
+  TestHelpers::db::test_simple_tag<
       gr::Tags::ExtrinsicCurvature<Dim, Frame, Type>>("ExtrinsicCurvature");
   TestHelpers::db::test_simple_tag<gr::Tags::TraceExtrinsicCurvature<Type>>(
       "TraceExtrinsicCurvature");


### PR DESCRIPTION
## Proposed changes

The upcoming XCTS equations #2667 make use of the Poisson and Elasticity systems. This PR gets their non-Euclidean terms in order.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
