### PR TITLE
Add computation of Jacobian, inverse Jacobian, and determinant of the Jacobian that satisfy the metric identities

### DIFF
--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/MetricIdentityJacobian.cpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/MetricIdentityJacobian.cpp
@@ -18,9 +18,9 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
 
-namespace dg {
+namespace {
 template <size_t Dim>
-void metric_identity_jacobian(
+void metric_identity_jacobian_impl(
     const gsl::not_null<
         InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>*>
         det_jac_times_inverse_jacobian,
@@ -28,6 +28,7 @@ void metric_identity_jacobian(
     const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords,
     const Jacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>&
         jacobian) noexcept {
+  static_assert(Dim == 1 or Dim == 2, "Generic impl handles only 1d and 2d.");
   destructive_resize_components(det_jac_times_inverse_jacobian,
                                 mesh.number_of_grid_points());
   if constexpr (Dim == 1) {
@@ -56,145 +57,187 @@ void metric_identity_jacobian(
 
     apply_matrices(make_not_null(&get<1, 1>(*det_jac_times_inverse_jacobian)),
                    diff_matrices, get<0>(inertial_coords), mesh.extents());
+  }
+}
+
+void metric_identity_jacobian_impl(
+    const gsl::not_null<
+        InverseJacobian<DataVector, 3, Frame::Logical, Frame::Inertial>*>
+        det_jac_times_inverse_jacobian,
+    const gsl::not_null<DataVector*> buffer,
+    const gsl::not_null<DataVector*> buffer_component, const Mesh<3>& mesh,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_coords,
+    const Jacobian<DataVector, 3, Frame::Logical, Frame::Inertial>&
+        jacobian) noexcept {
+  // The 3d case is handled separately because this actually requires a buffer.
+  // Basically, in 2d you can get into the situation where you have 2 unused
+  // components (and thus 2 buffers) and so taking the eta derivatives you have
+  // plenty of space for transposing. In 3d all components of the Jacobian
+  // depend on either eta or zeta derivatives and so you can't use one of them
+  // as a buffer to do a transpose.
+  //
+  // The 3d implementation is what should be generalized to higher dimensions if
+  // the need arises.
+  destructive_resize_components(det_jac_times_inverse_jacobian,
+                                mesh.number_of_grid_points());
+  const Mesh<1>& mesh0 = mesh.slice_through(0);
+  const Mesh<1>& mesh1 = mesh.slice_through(1);
+  const Mesh<1>& mesh2 = mesh.slice_through(2);
+  const Matrix identity{};
+  auto diff_matrices = make_array<3>(std::cref(identity));
+
+  ASSERT(buffer->size() == mesh.number_of_grid_points(),
+         "The size of buffer must be " << mesh.number_of_grid_points()
+                                       << " but is " << buffer->size());
+  ASSERT(buffer_component->size() == mesh.number_of_grid_points(),
+         "The size of buffer_component must be " << mesh.number_of_grid_points()
+                                                 << " but is "
+                                                 << buffer_component->size());
+
+  // Note that we will multiply everything by 0.5 once we have all terms
+  // contributing to each component computed.
+
+  // Compute all terms with logical derivatives in xi direction
+  diff_matrices[0] = Spectral::differentiation_matrix(mesh0);
+  *buffer = get<2>(inertial_coords) * get<1, 2>(jacobian) -
+            get<1>(inertial_coords) * get<2, 2>(jacobian);
+  apply_matrices(make_not_null(&get<1, 0>(*det_jac_times_inverse_jacobian)),
+                 diff_matrices, *buffer, mesh.extents());
+
+  *buffer = get<1>(inertial_coords) * get<2, 1>(jacobian) -
+            get<2>(inertial_coords) * get<1, 1>(jacobian);
+  apply_matrices(make_not_null(&get<2, 0>(*det_jac_times_inverse_jacobian)),
+                 diff_matrices, *buffer, mesh.extents());
+
+  *buffer = get<0>(inertial_coords) * get<2, 2>(jacobian) -
+            get<2>(inertial_coords) * get<0, 2>(jacobian);
+  apply_matrices(make_not_null(&get<1, 1>(*det_jac_times_inverse_jacobian)),
+                 diff_matrices, *buffer, mesh.extents());
+
+  *buffer = get<2>(inertial_coords) * get<0, 1>(jacobian) -
+            get<0>(inertial_coords) * get<2, 1>(jacobian);
+  apply_matrices(make_not_null(&get<2, 1>(*det_jac_times_inverse_jacobian)),
+                 diff_matrices, *buffer, mesh.extents());
+
+  *buffer = get<1>(inertial_coords) * get<0, 2>(jacobian) -
+            get<0>(inertial_coords) * get<1, 2>(jacobian);
+  apply_matrices(make_not_null(&get<1, 2>(*det_jac_times_inverse_jacobian)),
+                 diff_matrices, *buffer, mesh.extents());
+
+  *buffer = get<0>(inertial_coords) * get<1, 1>(jacobian) -
+            get<1>(inertial_coords) * get<0, 1>(jacobian);
+  apply_matrices(make_not_null(&get<2, 2>(*det_jac_times_inverse_jacobian)),
+                 diff_matrices, *buffer, mesh.extents());
+
+  // Compute all terms with logical derivatives in eta direction
+  diff_matrices[0] = identity;
+  diff_matrices[1] = Spectral::differentiation_matrix(mesh1);
+
+  // First do terms where the derivative can be directly written into the
+  // output buffer.
+  *buffer = get<1>(inertial_coords) * get<2, 2>(jacobian) -
+            get<2>(inertial_coords) * get<1, 2>(jacobian);
+  apply_matrices(make_not_null(&get<0, 0>(*det_jac_times_inverse_jacobian)),
+                 diff_matrices, *buffer, mesh.extents());
+
+  *buffer = get<2>(inertial_coords) * get<0, 2>(jacobian) -
+            get<0>(inertial_coords) * get<2, 2>(jacobian);
+  apply_matrices(make_not_null(&get<0, 1>(*det_jac_times_inverse_jacobian)),
+                 diff_matrices, *buffer, mesh.extents());
+
+  *buffer = get<0>(inertial_coords) * get<1, 2>(jacobian) -
+            get<1>(inertial_coords) * get<0, 2>(jacobian);
+  apply_matrices(make_not_null(&get<0, 2>(*det_jac_times_inverse_jacobian)),
+                 diff_matrices, *buffer, mesh.extents());
+
+  // Now do terms that need to be added to existing output.
+  // These we can multiply by 0.5
+  *buffer = get<2>(inertial_coords) * get<1, 0>(jacobian) -
+            get<1>(inertial_coords) * get<2, 0>(jacobian);
+  apply_matrices(buffer_component, diff_matrices, *buffer, mesh.extents());
+  get<2, 0>(*det_jac_times_inverse_jacobian) += *buffer_component;
+  get<2, 0>(*det_jac_times_inverse_jacobian) *= 0.5;
+
+  *buffer = get<0>(inertial_coords) * get<2, 0>(jacobian) -
+            get<2>(inertial_coords) * get<0, 0>(jacobian);
+  apply_matrices(buffer_component, diff_matrices, *buffer, mesh.extents());
+  get<2, 1>(*det_jac_times_inverse_jacobian) += *buffer_component;
+  get<2, 1>(*det_jac_times_inverse_jacobian) *= 0.5;
+
+  *buffer = get<1>(inertial_coords) * get<0, 0>(jacobian) -
+            get<0>(inertial_coords) * get<1, 0>(jacobian);
+  apply_matrices(buffer_component, diff_matrices, *buffer, mesh.extents());
+  get<2, 2>(*det_jac_times_inverse_jacobian) += *buffer_component;
+  get<2, 2>(*det_jac_times_inverse_jacobian) *= 0.5;
+
+  // Compute all terms with logical derivatives in eta direction
+  diff_matrices[1] = identity;
+  diff_matrices[2] = Spectral::differentiation_matrix(mesh2);
+
+  // All terms need to be added to existing output.
+  // These we multiply by 0.5
+  *buffer = get<2>(inertial_coords) * get<1, 1>(jacobian) -
+            get<1>(inertial_coords) * get<2, 1>(jacobian);
+  apply_matrices(buffer_component, diff_matrices, *buffer, mesh.extents());
+  get<0, 0>(*det_jac_times_inverse_jacobian) += *buffer_component;
+  get<0, 0>(*det_jac_times_inverse_jacobian) *= 0.5;
+
+  *buffer = get<1>(inertial_coords) * get<2, 0>(jacobian) -
+            get<2>(inertial_coords) * get<1, 0>(jacobian);
+  apply_matrices(buffer_component, diff_matrices, *buffer, mesh.extents());
+  get<1, 0>(*det_jac_times_inverse_jacobian) += *buffer_component;
+  get<1, 0>(*det_jac_times_inverse_jacobian) *= 0.5;
+
+  *buffer = get<0>(inertial_coords) * get<2, 1>(jacobian) -
+            get<2>(inertial_coords) * get<0, 1>(jacobian);
+  apply_matrices(buffer_component, diff_matrices, *buffer, mesh.extents());
+  get<0, 1>(*det_jac_times_inverse_jacobian) += *buffer_component;
+  get<0, 1>(*det_jac_times_inverse_jacobian) *= 0.5;
+
+  *buffer = get<2>(inertial_coords) * get<0, 0>(jacobian) -
+            get<0>(inertial_coords) * get<2, 0>(jacobian);
+  apply_matrices(buffer_component, diff_matrices, *buffer, mesh.extents());
+  get<1, 1>(*det_jac_times_inverse_jacobian) += *buffer_component;
+  get<1, 1>(*det_jac_times_inverse_jacobian) *= 0.5;
+
+  *buffer = get<1>(inertial_coords) * get<0, 1>(jacobian) -
+            get<0>(inertial_coords) * get<1, 1>(jacobian);
+  apply_matrices(buffer_component, diff_matrices, *buffer, mesh.extents());
+  get<0, 2>(*det_jac_times_inverse_jacobian) += *buffer_component;
+  get<0, 2>(*det_jac_times_inverse_jacobian) *= 0.5;
+
+  *buffer = get<0>(inertial_coords) * get<1, 0>(jacobian) -
+            get<1>(inertial_coords) * get<0, 0>(jacobian);
+  apply_matrices(buffer_component, diff_matrices, *buffer, mesh.extents());
+  get<1, 2>(*det_jac_times_inverse_jacobian) += *buffer_component;
+  get<1, 2>(*det_jac_times_inverse_jacobian) *= 0.5;
+}
+}  // namespace
+
+namespace dg {
+template <size_t Dim>
+void metric_identity_jacobian(
+    const gsl::not_null<
+        InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>*>
+        det_jac_times_inverse_jacobian,
+    const Mesh<Dim>& mesh,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords,
+    const Jacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>&
+        jacobian) noexcept {
+  if constexpr (Dim == 3) {
+    const size_t num_grid_points = mesh.number_of_grid_points();
+    DataVector buffers{2 * num_grid_points};
+    DataVector buffer{buffers.data(), num_grid_points};
+    // clang-tidy: no pointer math
+    DataVector buffer_component{buffers.data() + num_grid_points,  // NOLINT
+                                num_grid_points};
+
+    metric_identity_jacobian_impl(
+        det_jac_times_inverse_jacobian, make_not_null(&buffer),
+        make_not_null(&buffer_component), mesh, inertial_coords, jacobian);
   } else {
-    static_assert(Dim == 3,
-                  "The metric identity-satisfying Jacobian is only implemented "
-                  "in 1d, 2d, and 3d.");
-    const Mesh<1>& mesh0 = mesh.slice_through(0);
-    const Mesh<1>& mesh1 = mesh.slice_through(1);
-    const Mesh<1>& mesh2 = mesh.slice_through(2);
-    const Matrix identity{};
-    auto diff_matrices = make_array<Dim>(std::cref(identity));
-
-    DataVector buffer(mesh.number_of_grid_points());
-    DataVector buffer_component(mesh.number_of_grid_points());
-
-    // Note that we will multiply everything by 0.5 once we have all terms
-    // contributing to each component computed.
-
-    // Compute all terms with logical derivatives in xi direction
-    diff_matrices[0] = Spectral::differentiation_matrix(mesh0);
-    buffer = get<2>(inertial_coords) * get<1, 2>(jacobian) -
-             get<1>(inertial_coords) * get<2, 2>(jacobian);
-    apply_matrices(make_not_null(&get<1, 0>(*det_jac_times_inverse_jacobian)),
-                   diff_matrices, buffer, mesh.extents());
-
-    buffer = get<1>(inertial_coords) * get<2, 1>(jacobian) -
-             get<2>(inertial_coords) * get<1, 1>(jacobian);
-    apply_matrices(make_not_null(&get<2, 0>(*det_jac_times_inverse_jacobian)),
-                   diff_matrices, buffer, mesh.extents());
-
-    buffer = get<0>(inertial_coords) * get<2, 2>(jacobian) -
-             get<2>(inertial_coords) * get<0, 2>(jacobian);
-    apply_matrices(make_not_null(&get<1, 1>(*det_jac_times_inverse_jacobian)),
-                   diff_matrices, buffer, mesh.extents());
-
-    buffer = get<2>(inertial_coords) * get<0, 1>(jacobian) -
-             get<0>(inertial_coords) * get<2, 1>(jacobian);
-    apply_matrices(make_not_null(&get<2, 1>(*det_jac_times_inverse_jacobian)),
-                   diff_matrices, buffer, mesh.extents());
-
-    buffer = get<1>(inertial_coords) * get<0, 2>(jacobian) -
-             get<0>(inertial_coords) * get<1, 2>(jacobian);
-    apply_matrices(make_not_null(&get<1, 2>(*det_jac_times_inverse_jacobian)),
-                   diff_matrices, buffer, mesh.extents());
-
-    buffer = get<0>(inertial_coords) * get<1, 1>(jacobian) -
-             get<1>(inertial_coords) * get<0, 1>(jacobian);
-    apply_matrices(make_not_null(&get<2, 2>(*det_jac_times_inverse_jacobian)),
-                   diff_matrices, buffer, mesh.extents());
-
-    // Compute all terms with logical derivatives in eta direction
-    diff_matrices[0] = identity;
-    diff_matrices[1] = Spectral::differentiation_matrix(mesh1);
-
-    // First do terms where the derivative can be directly written into the
-    // output buffer.
-    buffer = get<1>(inertial_coords) * get<2, 2>(jacobian) -
-             get<2>(inertial_coords) * get<1, 2>(jacobian);
-    apply_matrices(make_not_null(&get<0, 0>(*det_jac_times_inverse_jacobian)),
-                   diff_matrices, buffer, mesh.extents());
-
-    buffer = get<2>(inertial_coords) * get<0, 2>(jacobian) -
-             get<0>(inertial_coords) * get<2, 2>(jacobian);
-    apply_matrices(make_not_null(&get<0, 1>(*det_jac_times_inverse_jacobian)),
-                   diff_matrices, buffer, mesh.extents());
-
-    buffer = get<0>(inertial_coords) * get<1, 2>(jacobian) -
-             get<1>(inertial_coords) * get<0, 2>(jacobian);
-    apply_matrices(make_not_null(&get<0, 2>(*det_jac_times_inverse_jacobian)),
-                   diff_matrices, buffer, mesh.extents());
-
-    // Now do terms that need to be added to existing output.
-    // These we can multiply by 0.5
-    buffer = get<2>(inertial_coords) * get<1, 0>(jacobian) -
-             get<1>(inertial_coords) * get<2, 0>(jacobian);
-    apply_matrices(make_not_null(&buffer_component), diff_matrices, buffer,
-                   mesh.extents());
-    get<2, 0>(*det_jac_times_inverse_jacobian) += buffer_component;
-    get<2, 0>(*det_jac_times_inverse_jacobian) *= 0.5;
-
-    buffer = get<0>(inertial_coords) * get<2, 0>(jacobian) -
-             get<2>(inertial_coords) * get<0, 0>(jacobian);
-    apply_matrices(make_not_null(&buffer_component), diff_matrices, buffer,
-                   mesh.extents());
-    get<2, 1>(*det_jac_times_inverse_jacobian) += buffer_component;
-    get<2, 1>(*det_jac_times_inverse_jacobian) *= 0.5;
-
-    buffer = get<1>(inertial_coords) * get<0, 0>(jacobian) -
-             get<0>(inertial_coords) * get<1, 0>(jacobian);
-    apply_matrices(make_not_null(&buffer_component), diff_matrices, buffer,
-                   mesh.extents());
-    get<2, 2>(*det_jac_times_inverse_jacobian) += buffer_component;
-    get<2, 2>(*det_jac_times_inverse_jacobian) *= 0.5;
-
-    // Compute all terms with logical derivatives in eta direction
-    diff_matrices[1] = identity;
-    diff_matrices[2] = Spectral::differentiation_matrix(mesh2);
-
-    // All terms need to be added to existing output.
-    // These we multiply by 0.5
-    buffer = get<2>(inertial_coords) * get<1, 1>(jacobian) -
-             get<1>(inertial_coords) * get<2, 1>(jacobian);
-    apply_matrices(make_not_null(&buffer_component), diff_matrices, buffer,
-                   mesh.extents());
-    get<0, 0>(*det_jac_times_inverse_jacobian) += buffer_component;
-    get<0, 0>(*det_jac_times_inverse_jacobian) *= 0.5;
-
-    buffer = get<1>(inertial_coords) * get<2, 0>(jacobian) -
-             get<2>(inertial_coords) * get<1, 0>(jacobian);
-    apply_matrices(make_not_null(&buffer_component), diff_matrices, buffer,
-                   mesh.extents());
-    get<1, 0>(*det_jac_times_inverse_jacobian) += buffer_component;
-    get<1, 0>(*det_jac_times_inverse_jacobian) *= 0.5;
-
-    buffer = get<0>(inertial_coords) * get<2, 1>(jacobian) -
-             get<2>(inertial_coords) * get<0, 1>(jacobian);
-    apply_matrices(make_not_null(&buffer_component), diff_matrices, buffer,
-                   mesh.extents());
-    get<0, 1>(*det_jac_times_inverse_jacobian) += buffer_component;
-    get<0, 1>(*det_jac_times_inverse_jacobian) *= 0.5;
-
-    buffer = get<2>(inertial_coords) * get<0, 0>(jacobian) -
-             get<0>(inertial_coords) * get<2, 0>(jacobian);
-    apply_matrices(make_not_null(&buffer_component), diff_matrices, buffer,
-                   mesh.extents());
-    get<1, 1>(*det_jac_times_inverse_jacobian) += buffer_component;
-    get<1, 1>(*det_jac_times_inverse_jacobian) *= 0.5;
-
-    buffer = get<1>(inertial_coords) * get<0, 1>(jacobian) -
-             get<0>(inertial_coords) * get<1, 1>(jacobian);
-    apply_matrices(make_not_null(&buffer_component), diff_matrices, buffer,
-                   mesh.extents());
-    get<0, 2>(*det_jac_times_inverse_jacobian) += buffer_component;
-    get<0, 2>(*det_jac_times_inverse_jacobian) *= 0.5;
-
-    buffer = get<0>(inertial_coords) * get<1, 0>(jacobian) -
-             get<1>(inertial_coords) * get<0, 0>(jacobian);
-    apply_matrices(make_not_null(&buffer_component), diff_matrices, buffer,
-                   mesh.extents());
-    get<1, 2>(*det_jac_times_inverse_jacobian) += buffer_component;
-    get<1, 2>(*det_jac_times_inverse_jacobian) *= 0.5;
+    metric_identity_jacobian_impl(det_jac_times_inverse_jacobian, mesh,
+                                  inertial_coords, jacobian);
   }
 }
 

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/MetricIdentityJacobian.cpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/MetricIdentityJacobian.cpp
@@ -25,7 +25,7 @@
 
 namespace {
 template <size_t Dim>
-void metric_identity_jacobian_impl(
+void metric_identity_det_jac_times_inv_jac_impl(
     const gsl::not_null<
         InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>*>
         det_jac_times_inverse_jacobian,
@@ -65,7 +65,7 @@ void metric_identity_jacobian_impl(
   }
 }
 
-void metric_identity_jacobian_impl(
+void metric_identity_det_jac_times_inv_jac_impl(
     const gsl::not_null<
         InverseJacobian<DataVector, 3, Frame::Logical, Frame::Inertial>*>
         det_jac_times_inverse_jacobian,
@@ -221,7 +221,7 @@ void metric_identity_jacobian_impl(
 
 namespace dg {
 template <size_t Dim>
-void metric_identity_jacobian(
+void metric_identity_det_jac_times_inv_jac(
     const gsl::not_null<
         InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>*>
         det_jac_times_inverse_jacobian,
@@ -237,12 +237,12 @@ void metric_identity_jacobian(
     DataVector buffer_component{buffers.data() + num_grid_points,  // NOLINT
                                 num_grid_points};
 
-    metric_identity_jacobian_impl(
+    metric_identity_det_jac_times_inv_jac_impl(
         det_jac_times_inverse_jacobian, make_not_null(&buffer),
         make_not_null(&buffer_component), mesh, inertial_coords, jacobian);
   } else {
-    metric_identity_jacobian_impl(det_jac_times_inverse_jacobian, mesh,
-                                  inertial_coords, jacobian);
+    metric_identity_det_jac_times_inv_jac_impl(det_jac_times_inverse_jacobian,
+                                               mesh, inertial_coords, jacobian);
   }
 }
 
@@ -281,13 +281,14 @@ void metric_identity_jacobian_quantities(
 
   if constexpr (Dim == 3) {
     // use inverse Jacobian as buffer in computation
-    metric_identity_jacobian_impl(det_jac_times_inverse_jacobian,
-                                  make_not_null(&get<0, 0>(*inverse_jacobian)),
-                                  make_not_null(&get<0, 1>(*inverse_jacobian)),
-                                  mesh, inertial_coords, *jacobian);
+    metric_identity_det_jac_times_inv_jac_impl(
+        det_jac_times_inverse_jacobian,
+        make_not_null(&get<0, 0>(*inverse_jacobian)),
+        make_not_null(&get<0, 1>(*inverse_jacobian)), mesh, inertial_coords,
+        *jacobian);
   } else {
-    metric_identity_jacobian_impl(det_jac_times_inverse_jacobian, mesh,
-                                  inertial_coords, *jacobian);
+    metric_identity_det_jac_times_inv_jac_impl(
+        det_jac_times_inverse_jacobian, mesh, inertial_coords, *jacobian);
   }
 
   // Now compute the determinant of the Jacobian, the inverse Jacobian, and the
@@ -321,7 +322,7 @@ void metric_identity_jacobian_quantities(
 #define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATION(r, data)                                                 \
-  template void metric_identity_jacobian(                                      \
+  template void metric_identity_det_jac_times_inv_jac(                         \
       gsl::not_null<InverseJacobian<DataVector, GET_DIM(data), Frame::Logical, \
                                     Frame::Inertial>*>                         \
           det_jac_times_inverse_jacobian,                                      \

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/MetricIdentityJacobian.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/MetricIdentityJacobian.hpp
@@ -183,4 +183,65 @@ void metric_identity_jacobian(
     const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords,
     const Jacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>&
         jacobian) noexcept;
+
+/*!
+ * \ingroup DiscontinuousGalerkinGroup
+ * \brief Compute the Jacobian, inverse Jacobian, and determinant of the
+ * Jacobian so that they satisfy the metric identities.
+ *
+ * Uses `dg::metric_identity_jacobian()` to compute the determinant of the
+ * Jacobian times the inverse Jacobian. By taking the determinant of this
+ * product, we can isolate \f$J\f$, the determinant of the Jacobian. In \f$d\f$
+ * dimensions, we have:
+ *
+ * \f{align}{
+ *
+ *  \mathrm{det}\left(J\frac{\partial \xi^{\hat{\imath}}}{\partial x^i}\right)
+ *  = J^{d-1}.
+ *
+ * \f}
+ *
+ * We assume the determinant of the Jacobian is positive, which means logical
+ * and inertial coordinates have the same handedness. With this assumption, we
+ * have
+ *
+ * \f{align}{
+ *
+ *  J = \sqrt[(d-1)]{\mathrm{det}\left(J\frac{\partial
+ *      \xi^{\hat{\imath}}}{\partial x^i}\right)}
+ *
+ * \f}
+ *
+ * We can now compute the inverse Jacobian using:
+ *
+ * \f{align}{
+ *
+ * \frac{\partial \xi^{\hat{\imath}}}{\partial x^i}=
+ *  \frac{1}{J}\left(J\frac{\partial \xi^{\hat{\imath}}}{\partial x^i}\right)
+ *
+ * \f}
+ *
+ * This guarantees that multiplying the determinant of the Jacobian by the
+ * inverse Jacobian gives a result that satisfies the metric identities. We also
+ * compute the Jacobian by inverting the inverse Jacobian, which guarantees they
+ * are (numerical) inverses of each other.
+ *
+ * \warning on entry `jacobian` must be the Jacobian to use for computing the
+ * determinant of the Jacobian times the inverse Jacobian so that it satisfies
+ * the metric identities. The `jacobian` can be computed analytically or
+ * numerically, either is fine. On output the `jacobian` is the inverse of the
+ * inverse Jacobian that satisfies the metric identities.
+ */
+template <size_t Dim>
+void metric_identity_jacobian_quantities(
+    gsl::not_null<
+        InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>*>
+        det_jac_times_inverse_jacobian,
+    gsl::not_null<
+        InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>*>
+        inverse_jacobian,
+    gsl::not_null<Jacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>*>
+        jacobian,
+    gsl::not_null<Scalar<DataVector>*> det_jacobian, const Mesh<Dim>& mesh,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords) noexcept;
 }  // namespace dg

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/MetricIdentityJacobian.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/MetricIdentityJacobian.hpp
@@ -175,7 +175,7 @@ namespace dg {
  * The subtraction technique is most commonly used in finite difference codes.
  */
 template <size_t Dim>
-void metric_identity_jacobian(
+void metric_identity_det_jac_times_inv_jac(
     gsl::not_null<
         InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>*>
         det_jac_times_inverse_jacobian,

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_LiftFromBoundary.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_LiftFromBoundary.cpp
@@ -141,8 +141,9 @@ void test(const double eps) {
 
   InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>
       det_jac_times_inverse_jacobian{volume_mesh.number_of_grid_points()};
-  dg::metric_identity_jacobian(make_not_null(&det_jac_times_inverse_jacobian),
-                               volume_mesh, inertial_coords, volume_jacobian);
+  dg::metric_identity_det_jac_times_inv_jac(
+      make_not_null(&det_jac_times_inverse_jacobian), volume_mesh,
+      inertial_coords, volume_jacobian);
 
   Variables<db::wrap_tags_in<
       Tags::div, typename std::decay_t<decltype(volume_fluxes)>::tags_list>>

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MetricIdentityJacobian.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MetricIdentityJacobian.cpp
@@ -33,33 +33,25 @@ using Affine = domain::CoordinateMaps::Affine;
 using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
 using Affine3D = domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
 
-template <size_t VolumeDim>
-auto make_map() noexcept;
-
-template <>
-auto make_map<1>() noexcept {
-  return domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
-      Affine{-1.0, 1.0, -0.3, 0.7});
+template <size_t Dim>
+auto make_map() noexcept {
+  if constexpr (Dim == 1) {
+    return domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
+        Affine{-1.0, 1.0, -0.3, 0.7});
+  } else if constexpr (Dim == 2) {
+    return domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
+        Affine2D{{-1.0, 1.0, -1.0, -0.99}, {-1.0, 1.0, -1.0, -0.99}},
+        domain::CoordinateMaps::Wedge2D{1.0, 2.0, 0.0, 1.0, {}, false});
+  } else {
+    return domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
+        Affine3D{{-1.0, 1.0, -1.0, -0.99},
+                 {-1.0, 1.0, -1.0, -0.99},
+                 {-1.0, 1.0, -1.0, 1.0}},
+        domain::CoordinateMaps::ProductOf2Maps<domain::CoordinateMaps::Wedge2D,
+                                               Affine>{
+            {1.0, 2.0, 0.0, 1.0, {}, false}, {0.0, 1.0, 0.0, 1.0}});
+  }
 }
-
-template <>
-auto make_map<2>() noexcept {
-  return domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
-      Affine2D{{-1.0, 1.0, -1.0, -0.99}, {-1.0, 1.0, -1.0, -0.99}},
-      domain::CoordinateMaps::Wedge2D{1.0, 2.0, 0.0, 1.0, {}, false});
-}
-
-template <>
-auto make_map<3>() noexcept {
-  return domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
-      Affine3D{{-1.0, 1.0, -1.0, -0.99},
-               {-1.0, 1.0, -1.0, -0.99},
-               {-1.0, 1.0, -1.0, 1.0}},
-      domain::CoordinateMaps::ProductOf2Maps<domain::CoordinateMaps::Wedge2D,
-                                             Affine>{
-          {1.0, 2.0, 0.0, 1.0, {}, false}, {0.0, 1.0, 0.0, 1.0}});
-}
-
 
 template <size_t Dim>
 void test(const Mesh<Dim>& mesh) {

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MetricIdentityJacobian.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MetricIdentityJacobian.cpp
@@ -72,8 +72,8 @@ void test(const Mesh<Dim>& mesh) {
 
     InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial> result{};
 
-    dg::metric_identity_jacobian(make_not_null(&result), mesh, inertial_coords,
-                                 jacobian);
+    dg::metric_identity_det_jac_times_inv_jac(make_not_null(&result), mesh,
+                                              inertial_coords, jacobian);
 
     // Check metric identities are satisfied by taking the numerical divergence
     tnsr::i<DataVector, Dim, Frame::Inertial> divergence_terms{
@@ -120,9 +120,9 @@ void test(const Mesh<Dim>& mesh) {
   InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>
       det_jac_times_inverse_jacobian{};
 
-  dg::metric_identity_jacobian(make_not_null(&det_jac_times_inverse_jacobian),
-                               mesh, map(logical_coordinates(mesh)),
-                               map.jacobian(logical_coordinates(mesh)));
+  dg::metric_identity_det_jac_times_inv_jac(
+      make_not_null(&det_jac_times_inverse_jacobian), mesh,
+      map(logical_coordinates(mesh)), map.jacobian(logical_coordinates(mesh)));
 
   Approx coarse_local_approx = Approx::custom().epsilon(1.0e-9).scale(1.);
   for (size_t i = 0; i < Dim; ++i) {

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MetricIdentityJacobian.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MetricIdentityJacobian.cpp
@@ -59,47 +59,49 @@ void test(const Mesh<Dim>& mesh) {
   CAPTURE(mesh);
   std::uniform_real_distribution<double> dist(-1.0, 2.3);
   MAKE_GENERATOR(gen);
-  tnsr::I<DataVector, Dim, Frame::Inertial> inertial_coords{
-      mesh.number_of_grid_points()};
-  Jacobian<DataVector, Dim, Frame::Logical, Frame::Inertial> jacobian{
-      mesh.number_of_grid_points()};
+  {
+    tnsr::I<DataVector, Dim, Frame::Inertial> inertial_coords{
+        mesh.number_of_grid_points()};
+    Jacobian<DataVector, Dim, Frame::Logical, Frame::Inertial> jacobian{
+        mesh.number_of_grid_points()};
 
-  fill_with_random_values(make_not_null(&inertial_coords), make_not_null(&gen),
-                          make_not_null(&dist));
-  fill_with_random_values(make_not_null(&jacobian), make_not_null(&gen),
-                          make_not_null(&dist));
+    fill_with_random_values(make_not_null(&inertial_coords),
+                            make_not_null(&gen), make_not_null(&dist));
+    fill_with_random_values(make_not_null(&jacobian), make_not_null(&gen),
+                            make_not_null(&dist));
 
-  InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial> result{};
+    InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial> result{};
 
-  dg::metric_identity_jacobian(make_not_null(&result), mesh, inertial_coords,
-                               jacobian);
+    dg::metric_identity_jacobian(make_not_null(&result), mesh, inertial_coords,
+                                 jacobian);
 
-  // Check metric identities are satisfied by taking the numerical divergence
-  tnsr::i<DataVector, Dim, Frame::Inertial> divergence_terms{
-      mesh.number_of_grid_points(), 0.0};
-  DataVector buffer(mesh.number_of_grid_points());
-  std::array<Mesh<1>, Dim> meshes_1d{};
-  for (size_t i = 0; i < Dim; ++i) {
-    gsl::at(meshes_1d, i) = mesh.slice_through(i);
-  }
-  const Matrix identity{};
-
-  for (size_t i_hat = 0; i_hat < Dim; ++i_hat) {  // logical index
-    auto diff_matrices = make_array<Dim>(std::cref(identity));
-    gsl::at(diff_matrices, i_hat) =
-        Spectral::differentiation_matrix(gsl::at(meshes_1d, i_hat));
-    for (size_t i = 0; i < Dim; ++i) {  // inertial index
-      apply_matrices(make_not_null(&buffer), diff_matrices,
-                     result.get(i_hat, i), mesh.extents());
-      divergence_terms.get(i) += buffer;
+    // Check metric identities are satisfied by taking the numerical divergence
+    tnsr::i<DataVector, Dim, Frame::Inertial> divergence_terms{
+        mesh.number_of_grid_points(), 0.0};
+    DataVector buffer(mesh.number_of_grid_points());
+    std::array<Mesh<1>, Dim> meshes_1d{};
+    for (size_t i = 0; i < Dim; ++i) {
+      gsl::at(meshes_1d, i) = mesh.slice_through(i);
     }
-  }
+    const Matrix identity{};
 
-  Approx local_approx = Approx::custom().epsilon(1.0e-12).scale(1.);
-  const DataVector expected{mesh.number_of_grid_points(), 0.0};
-  for (size_t i = 0; i < Dim; ++i) {
-    CHECK_ITERABLE_CUSTOM_APPROX(divergence_terms.get(i), expected,
-                                 local_approx);
+    for (size_t i_hat = 0; i_hat < Dim; ++i_hat) {  // logical index
+      auto diff_matrices = make_array<Dim>(std::cref(identity));
+      gsl::at(diff_matrices, i_hat) =
+          Spectral::differentiation_matrix(gsl::at(meshes_1d, i_hat));
+      for (size_t i = 0; i < Dim; ++i) {  // inertial index
+        apply_matrices(make_not_null(&buffer), diff_matrices,
+                       result.get(i_hat, i), mesh.extents());
+        divergence_terms.get(i) += buffer;
+      }
+    }
+
+    Approx local_approx = Approx::custom().epsilon(1.0e-12).scale(1.);
+    const DataVector expected{mesh.number_of_grid_points(), 0.0};
+    for (size_t i = 0; i < Dim; ++i) {
+      CHECK_ITERABLE_CUSTOM_APPROX(divergence_terms.get(i), expected,
+                                   local_approx);
+    }
   }
 
   // Now check with a map that the terms of the inverse Jacobian (times the
@@ -131,6 +133,48 @@ void test(const Mesh<Dim>& mesh) {
           det_jac_times_inverse_jacobian.get(i, j),
           analytic_det_jac_times_inverse_jacobian.get(i, j),
           coarse_local_approx);
+    }
+  }
+
+  InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>
+      det_jac_times_inverse_jacobian2{};
+  InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>
+      inverse_jacobian{};
+  Jacobian<DataVector, Dim, Frame::Logical, Frame::Inertial> jacobian =
+      map.jacobian(logical_coordinates(mesh));
+  const auto expected_jacobian = jacobian;
+  Scalar<DataVector> det_jacobian{};
+
+  dg::metric_identity_jacobian_quantities(
+      make_not_null(&det_jac_times_inverse_jacobian2),
+      make_not_null(&inverse_jacobian), make_not_null(&jacobian),
+      make_not_null(&det_jacobian), mesh, map(logical_coordinates(mesh)));
+
+  Approx identity_matrix_local_approx =
+      Approx::custom().epsilon(1.0e-12).scale(1.);
+  CHECK_ITERABLE_CUSTOM_APPROX(get(det_jacobian), get(analytic_det_jac),
+                               coarse_local_approx);
+  for (size_t i = 0; i < Dim; ++i) {
+    CAPTURE(i);
+    for (size_t j = 0; j < Dim; ++j) {
+      CAPTURE(j);
+      CHECK_ITERABLE_APPROX(det_jac_times_inverse_jacobian.get(i, j),
+                            det_jac_times_inverse_jacobian2.get(i, j));
+      CHECK_ITERABLE_APPROX(
+          DataVector{get(det_jacobian) * inverse_jacobian.get(i, j)},
+          det_jac_times_inverse_jacobian2.get(i, j));
+      CHECK_ITERABLE_CUSTOM_APPROX(
+          jacobian.get(i, j), expected_jacobian.get(i, j), coarse_local_approx);
+      DataVector jac_inv_jac_contracted =
+          jacobian.get(i, 0) * inverse_jacobian.get(0, j);
+      for (size_t k = 1; k < Dim; ++k) {
+        jac_inv_jac_contracted +=
+            jacobian.get(i, k) * inverse_jacobian.get(k, j);
+      }
+      const DataVector expected{mesh.number_of_grid_points(),
+                                i == j ? 1.0 : 0.0};
+      CHECK_ITERABLE_CUSTOM_APPROX(expected, jac_inv_jac_contracted,
+                                   identity_matrix_local_approx);
     }
   }
 }

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_WeakDivergence.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_WeakDivergence.cpp
@@ -66,8 +66,9 @@ void test_weak_divergence_random_jacobian(const Mesh<Dim>& mesh) {
   InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>
       det_jac_times_inverse_jacobian{};
 
-  dg::metric_identity_jacobian(make_not_null(&det_jac_times_inverse_jacobian),
-                               mesh, inertial_coords, jacobian);
+  dg::metric_identity_det_jac_times_inv_jac(
+      make_not_null(&det_jac_times_inverse_jacobian), mesh, inertial_coords,
+      jacobian);
   // Generate constant fluxes that aren't all the same.
   Variables<flux_tags> fluxes{mesh.number_of_grid_points(), 2.0};
   tmpl::for_each<flux_tags>([&fluxes](auto tag_v) noexcept {
@@ -180,8 +181,9 @@ void test_weak_divergence_constant_jacobian(const Mesh<Dim>& mesh) {
   InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>
       det_jac_times_inverse_jacobian{};
 
-  dg::metric_identity_jacobian(make_not_null(&det_jac_times_inverse_jacobian),
-                               mesh, inertial_coords, jacobian);
+  dg::metric_identity_det_jac_times_inv_jac(
+      make_not_null(&det_jac_times_inverse_jacobian), mesh, inertial_coords,
+      jacobian);
   const auto det_jacobian = determinant(jacobian);
   for (size_t i = 0; i < Dim; ++i) {
     for (size_t j = 0; j < Dim; ++j) {
@@ -247,7 +249,7 @@ void test_weak_divergence_constant_jacobian(const Mesh<Dim>& mesh) {
       InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>
           gl_det_jac_times_inverse_jacobian{};
 
-      dg::metric_identity_jacobian(
+      dg::metric_identity_det_jac_times_inv_jac(
           make_not_null(&gl_det_jac_times_inverse_jacobian), gl_mesh,
           gl_inertial_coords, gl_jacobian);
 


### PR DESCRIPTION
## Proposed changes

The function currently in develop only computes `J d_i xi^{\hat{i}}` (det jac times inv jac, not J and inv jac). The new function uses the one in develop but also computes the determinant of the Jacobian, inverse Jacobian, and the Jacobian such that:
 J * inv_jac satisfies metric identities
inv_jac * jac = identity

I split this into:
- a refactor into impl (+164, -130) where the code implementation is unchanged
- a commit that simplifies the `make_map` function in the test by using `if constexpr` (+18, -26)
- a commit that adds the new functionality and tests (+268, -62)

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
