### PR TITLE
Replace boost::optional -> std::optional in CoordinateMaps

### DIFF
--- a/src/Domain/BlockLogicalCoordinates.cpp
+++ b/src/Domain/BlockLogicalCoordinates.cpp
@@ -52,10 +52,10 @@ std::vector<block_logical_coord_holder<Dim>> block_logical_coordinates(
             continue;
           }
           // logical to grid map is time-independent.
-          const auto inv =
-              block.moving_mesh_logical_to_grid_map().inverse(moving_inv.get());
+          const auto inv = block.moving_mesh_logical_to_grid_map().inverse(
+              moving_inv.value());
           if (inv) {
-            x_logical = inv.get();
+            x_logical = inv.value();
           } else {
             continue;  // Not in this block
           }
@@ -74,7 +74,7 @@ std::vector<block_logical_coord_holder<Dim>> block_logical_coordinates(
           const auto inv =
               block.moving_mesh_logical_to_grid_map().inverse(x_frame);
           if (inv) {
-            x_logical = inv.get();
+            x_logical = inv.value();
           } else {
             continue;  // Not in this block
           }
@@ -83,7 +83,7 @@ std::vector<block_logical_coord_holder<Dim>> block_logical_coordinates(
         if constexpr (std::is_same_v<Frame, ::Frame::Inertial>) {
           const auto inv = block.stationary_map().inverse(x_frame);
           if (inv) {
-            x_logical = inv.get();
+            x_logical = inv.value();
           } else {
             continue;  // Not in this block
           }
@@ -101,7 +101,7 @@ std::vector<block_logical_coord_holder<Dim>> block_logical_coordinates(
           }
           const auto inv = block.stationary_map().inverse(x_inertial);
           if (inv) {
-            x_logical = inv.get();
+            x_logical = inv.value();
           } else {
             continue;  // Not in this block
           }

--- a/src/Domain/CoordinateMaps/Affine.cpp
+++ b/src/Domain/CoordinateMaps/Affine.cpp
@@ -11,8 +11,7 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-namespace domain {
-namespace CoordinateMaps {
+namespace domain::CoordinateMaps {
 
 Affine::Affine(const double A, const double B, const double a, const double b)
     : A_(A),
@@ -96,5 +95,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
 #undef DTYPE
 #undef INSTANTIATE
 /// \endcond
-}  // namespace CoordinateMaps
-}  // namespace domain
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/Affine.cpp
+++ b/src/Domain/CoordinateMaps/Affine.cpp
@@ -32,7 +32,7 @@ std::array<tt::remove_cvref_wrap_t<T>, 1> Affine::operator()(
            length_of_domain_}};
 }
 
-boost::optional<std::array<double, 1>> Affine::inverse(
+std::optional<std::array<double, 1>> Affine::inverse(
     const std::array<double, 1>& target_coords) const noexcept {
   return {{{(length_of_domain_ * target_coords[0] - a_ * B_ + b_ * A_) /
             length_of_range_}}};

--- a/src/Domain/CoordinateMaps/Affine.hpp
+++ b/src/Domain/CoordinateMaps/Affine.hpp
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <array>
-#include <boost/optional.hpp>
 #include <cstddef>
+#include <optional>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
@@ -51,7 +51,7 @@ class Affine {
   std::array<tt::remove_cvref_wrap_t<T>, 1> operator()(
       const std::array<T, 1>& source_coords) const noexcept;
 
-  boost::optional<std::array<double, 1>> inverse(
+  std::optional<std::array<double, 1>> inverse(
       const std::array<double, 1>& target_coords) const noexcept;
 
   template <typename T>

--- a/src/Domain/CoordinateMaps/BulgedCube.cpp
+++ b/src/Domain/CoordinateMaps/BulgedCube.cpp
@@ -3,12 +3,11 @@
 
 #include "Domain/CoordinateMaps/BulgedCube.hpp"
 
-#include <boost/none.hpp>
-#include <boost/optional.hpp>
 #include <cmath>
 #include <exception>
 #include <functional>  // for std::reference_wrapper
 #include <limits>
+#include <optional>
 #include <pup.h>
 
 #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
@@ -68,7 +67,7 @@ class RootFunction {
   const double z_sq_;
 };
 
-boost::optional<double> scaling_factor(RootFunction&& rootfunction) noexcept {
+std::optional<double> scaling_factor(RootFunction&& rootfunction) noexcept {
   const double physical_r_squared = rootfunction.get_r_sq();
   try {
     constexpr double tol = 10.0 * std::numeric_limits<double>::epsilon();
@@ -83,7 +82,7 @@ boost::optional<double> scaling_factor(RootFunction&& rootfunction) noexcept {
     rho /= sqrt(physical_r_squared);
     return rho;
   } catch (std::exception& exception) {
-    return boost::none;
+    return std::nullopt;
   }
 }
 }  // namespace
@@ -142,7 +141,7 @@ std::array<tt::remove_cvref_wrap_t<T>, 3> BulgedCube::operator()(
                               dereference_wrapper(source_coords[2]));
 }
 
-boost::optional<std::array<double, 3>> BulgedCube::inverse(
+std::optional<std::array<double, 3>> BulgedCube::inverse(
     const std::array<double, 3>& target_coords) const noexcept {
   const double& physical_x = target_coords[0];
   const double& physical_y = target_coords[1];
@@ -165,16 +164,16 @@ boost::optional<std::array<double, 3>> BulgedCube::inverse(
       ::scaling_factor(
       RootFunction{radius_, sphericity_, physical_r_squared, x_sq, y_sq, z_sq});
   if (not scaling_factor) {
-    return boost::none;
+    return std::nullopt;
   }
   if (use_equiangular_map_) {
-    return {{{2.0 * M_2_PI * atan(physical_x * scaling_factor.get()),
-              2.0 * M_2_PI * atan(physical_y * scaling_factor.get()),
-              2.0 * M_2_PI * atan(physical_z * scaling_factor.get())}}};
+    return {{{2.0 * M_2_PI * atan(physical_x * scaling_factor.value()),
+              2.0 * M_2_PI * atan(physical_y * scaling_factor.value()),
+              2.0 * M_2_PI * atan(physical_z * scaling_factor.value())}}};
   }
-  return {
-      {{physical_x * scaling_factor.get(), physical_y * scaling_factor.get(),
-        physical_z * scaling_factor.get()}}};
+  return {{{physical_x * scaling_factor.value(),
+            physical_y * scaling_factor.value(),
+            physical_z * scaling_factor.value()}}};
 }
 
 template <typename T>

--- a/src/Domain/CoordinateMaps/BulgedCube.cpp
+++ b/src/Domain/CoordinateMaps/BulgedCube.cpp
@@ -87,8 +87,7 @@ std::optional<double> scaling_factor(RootFunction&& rootfunction) noexcept {
 }
 }  // namespace
 
-namespace domain {
-namespace CoordinateMaps {
+namespace domain::CoordinateMaps {
 BulgedCube::BulgedCube(const double radius, const double sphericity,
                        const bool use_equiangular_map) noexcept
     : radius_(radius),
@@ -300,5 +299,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
 #undef DTYPE
 #undef INSTANTIATE
 /// \endcond
-}  // namespace CoordinateMaps
-}  // namespace domain
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/BulgedCube.hpp
+++ b/src/Domain/CoordinateMaps/BulgedCube.hpp
@@ -6,9 +6,9 @@
 #pragma once
 
 #include <array>
-#include <boost/optional.hpp>
 #include <cstddef>
 #include <limits>
+#include <optional>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
@@ -503,7 +503,7 @@ class BulgedCube {
   std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
       const std::array<T, 3>& source_coords) const noexcept;
 
-  boost::optional<std::array<double, 3>> inverse(
+  std::optional<std::array<double, 3>> inverse(
       const std::array<double, 3>& target_coords) const noexcept;
 
   template <typename T>

--- a/src/Domain/CoordinateMaps/CoordinateMap.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.hpp
@@ -6,10 +6,10 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
 #include <cstddef>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <pup.h>
 #include <string>
 #include <tuple>
@@ -104,11 +104,11 @@ class CoordinateMapBase : public PUP::able {
 
   // @{
   /// Apply the inverse `Maps` to the point(s) `target_point`.
-  /// The returned boost::optional is invalid if the map is not invertible
+  /// The returned std::optional is invalid if the map is not invertible
   /// at `target_point`, or if `target_point` can be easily determined to not
   /// make sense for the map.  An example of the latter is passing a
   /// point with a negative value of z into a positive-z Wedge3D inverse map.
-  virtual boost::optional<tnsr::I<double, Dim, SourceFrame>> inverse(
+  virtual std::optional<tnsr::I<double, Dim, SourceFrame>> inverse(
       tnsr::I<double, Dim, TargetFrame> target_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
       const std::unordered_map<
@@ -312,7 +312,7 @@ class CoordinateMap
 
   // @{
   /// Apply the inverse `Maps...` to the point(s) `target_point`
-  constexpr boost::optional<tnsr::I<double, dim, SourceFrame>> inverse(
+  constexpr std::optional<tnsr::I<double, dim, SourceFrame>> inverse(
       tnsr::I<double, dim, TargetFrame> target_point,
       const double time = std::numeric_limits<double>::signaling_NaN(),
       const std::unordered_map<
@@ -491,7 +491,7 @@ class CoordinateMap
       std::index_sequence<Is...> /*meta*/) const noexcept;
 
   template <typename T, size_t... Is>
-  boost::optional<tnsr::I<T, dim, SourceFrame>> inverse_impl(
+  std::optional<tnsr::I<T, dim, SourceFrame>> inverse_impl(
       tnsr::I<T, dim, TargetFrame>&& target_point, double time,
       const std::unordered_map<
           std::string,

--- a/src/Domain/CoordinateMaps/DiscreteRotation.cpp
+++ b/src/Domain/CoordinateMaps/DiscreteRotation.cpp
@@ -27,7 +27,7 @@ operator()(const std::array<T, VolumeDim>& source_coords) const noexcept {
 }
 
 template <size_t VolumeDim>
-boost::optional<std::array<double, VolumeDim>>
+std::optional<std::array<double, VolumeDim>>
 DiscreteRotation<VolumeDim>::inverse(
     const std::array<double, VolumeDim>& target_coords) const noexcept {
   return discrete_rotation(orientation_.inverse_map(), target_coords);

--- a/src/Domain/CoordinateMaps/DiscreteRotation.hpp
+++ b/src/Domain/CoordinateMaps/DiscreteRotation.hpp
@@ -4,8 +4,8 @@
 #pragma once
 
 #include <array>
-#include <boost/optional.hpp>
 #include <cstddef>
+#include <optional>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
@@ -45,7 +45,7 @@ class DiscreteRotation {
   std::array<tt::remove_cvref_wrap_t<T>, VolumeDim> operator()(
       const std::array<T, VolumeDim>& source_coords) const noexcept;
 
-  boost::optional<std::array<double, VolumeDim>> inverse(
+  std::optional<std::array<double, VolumeDim>> inverse(
       const std::array<double, VolumeDim>& target_coords) const noexcept;
 
   template <typename T>

--- a/src/Domain/CoordinateMaps/EquatorialCompression.cpp
+++ b/src/Domain/CoordinateMaps/EquatorialCompression.cpp
@@ -126,7 +126,7 @@ std::array<tt::remove_cvref_wrap_t<T>, 3> EquatorialCompression::operator()(
   return angular_distortion(source_coords, inverse_aspect_ratio_);
 }
 
-boost::optional<std::array<double, 3>> EquatorialCompression::inverse(
+std::optional<std::array<double, 3>> EquatorialCompression::inverse(
     const std::array<double, 3>& target_coords) const noexcept {
   return angular_distortion(target_coords, aspect_ratio_);
 }

--- a/src/Domain/CoordinateMaps/EquatorialCompression.cpp
+++ b/src/Domain/CoordinateMaps/EquatorialCompression.cpp
@@ -16,8 +16,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-namespace domain {
-namespace CoordinateMaps {
+namespace domain::CoordinateMaps {
 
 EquatorialCompression::EquatorialCompression(const double aspect_ratio) noexcept
     : aspect_ratio_(aspect_ratio),
@@ -184,5 +183,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
 #undef DTYPE
 #undef INSTANTIATE
 /// \endcond
-}  // namespace CoordinateMaps
-}  // namespace domain
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/EquatorialCompression.hpp
+++ b/src/Domain/CoordinateMaps/EquatorialCompression.hpp
@@ -4,9 +4,9 @@
 #pragma once
 
 #include <array>
-#include <boost/optional.hpp>
 #include <cstddef>
 #include <limits>
+#include <optional>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
@@ -68,7 +68,7 @@ class EquatorialCompression {
   std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
       const std::array<T, 3>& source_coords) const noexcept;
 
-  boost::optional<std::array<double, 3>> inverse(
+  std::optional<std::array<double, 3>> inverse(
       const std::array<double, 3>& target_coords) const noexcept;
 
   template <typename T>

--- a/src/Domain/CoordinateMaps/Equiangular.cpp
+++ b/src/Domain/CoordinateMaps/Equiangular.cpp
@@ -13,8 +13,7 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-namespace domain {
-namespace CoordinateMaps {
+namespace domain::CoordinateMaps {
 
 Equiangular::Equiangular(const double A, const double B, const double a,
                          const double b) noexcept
@@ -125,5 +124,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
 #undef DTYPE
 #undef INSTANTIATE
 /// \endcond
-}  // namespace CoordinateMaps
-}  // namespace domain
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/Equiangular.cpp
+++ b/src/Domain/CoordinateMaps/Equiangular.cpp
@@ -40,7 +40,7 @@ std::array<tt::remove_cvref_wrap_t<T>, 1> Equiangular::operator()(
                                      (-B_ - A_ + 2.0 * source_coords[0])))}};
 }
 
-boost::optional<std::array<double, 1>> Equiangular::inverse(
+std::optional<std::array<double, 1>> Equiangular::inverse(
     const std::array<double, 1>& target_coords) const noexcept {
   return {{{0.5 * (A_ + B_ +
                    length_of_domain_over_m_pi_4_ *

--- a/src/Domain/CoordinateMaps/Equiangular.hpp
+++ b/src/Domain/CoordinateMaps/Equiangular.hpp
@@ -7,9 +7,9 @@
 #pragma once
 
 #include <array>
-#include <boost/optional.hpp>
 #include <cmath>
 #include <cstddef>
+#include <optional>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
@@ -67,7 +67,7 @@ class Equiangular {
   std::array<tt::remove_cvref_wrap_t<T>, 1> operator()(
       const std::array<T, 1>& source_coords) const noexcept;
 
-  boost::optional<std::array<double, 1>> inverse(
+  std::optional<std::array<double, 1>> inverse(
       const std::array<double, 1>& target_coords) const noexcept;
 
   template <typename T>

--- a/src/Domain/CoordinateMaps/Frustum.cpp
+++ b/src/Domain/CoordinateMaps/Frustum.cpp
@@ -4,7 +4,6 @@
 #include "Domain/CoordinateMaps/Frustum.hpp"
 
 #include <algorithm>
-#include <boost/none.hpp>
 #include <cmath>
 #include <pup.h>
 
@@ -123,7 +122,7 @@ std::array<tt::remove_cvref_wrap_t<T>, 3> Frustum::operator()(
   return discrete_rotation(orientation_of_frustum_, std::move(physical_coords));
 }
 
-boost::optional<std::array<double, 3>> Frustum::inverse(
+std::optional<std::array<double, 3>> Frustum::inverse(
     const std::array<double, 3>& target_coords) const noexcept {
   // physical coords {x,y,z}
   std::array<double, 3> physical_coords =
@@ -138,7 +137,7 @@ boost::optional<std::array<double, 3>> Frustum::inverse(
   // denom0 and denom1 are always positive inside the frustum.
   if (denom0 < 0.0 or equal_within_roundoff(denom0, 0.0) or denom1 < 0.0 or
       equal_within_roundoff(denom1, 0.0)) {
-    return boost::none;
+    return std::nullopt;
   }
 
   logical_coords[0] =

--- a/src/Domain/CoordinateMaps/Frustum.hpp
+++ b/src/Domain/CoordinateMaps/Frustum.hpp
@@ -4,9 +4,9 @@
 #pragma once
 
 #include <array>
-#include <boost/optional.hpp>
 #include <cstddef>
 #include <limits>
+#include <optional>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
@@ -185,7 +185,7 @@ class Frustum {
   /// the apex of the pyramid, tetrahedron, or triangular prism that is
   /// formed by extending the `Frustum` (for a
   /// \f$z\f$-oriented `Frustum`).
-  boost::optional<std::array<double, 3>> inverse(
+  std::optional<std::array<double, 3>> inverse(
       const std::array<double, 3>& target_coords) const noexcept;
 
   template <typename T>

--- a/src/Domain/CoordinateMaps/Identity.cpp
+++ b/src/Domain/CoordinateMaps/Identity.cpp
@@ -19,7 +19,7 @@ std::array<tt::remove_cvref_wrap_t<T>, Dim> Identity<Dim>::operator()(
 }
 
 template <size_t Dim>
-boost::optional<std::array<double, Dim>> Identity<Dim>::inverse(
+std::optional<std::array<double, Dim>> Identity<Dim>::inverse(
     const std::array<double, Dim>& target_coords) const noexcept {
   return make_array<double, Dim>(target_coords);
 }

--- a/src/Domain/CoordinateMaps/Identity.cpp
+++ b/src/Domain/CoordinateMaps/Identity.cpp
@@ -8,8 +8,7 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeArray.hpp"
 
-namespace domain {
-namespace CoordinateMaps {
+namespace domain::CoordinateMaps {
 
 template <size_t Dim>
 template <typename T>
@@ -72,5 +71,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
 #undef INSTANTIATE
 /// \endcond
 
-}  // namespace CoordinateMaps
-}  // namespace domain
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/Identity.hpp
+++ b/src/Domain/CoordinateMaps/Identity.hpp
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <array>
-#include <boost/optional.hpp>
 #include <cstddef>
+#include <optional>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
@@ -40,7 +40,7 @@ class Identity {
   std::array<tt::remove_cvref_wrap_t<T>, Dim> operator()(
       const std::array<T, Dim>& source_coords) const noexcept;
 
-  boost::optional<std::array<double, Dim>> inverse(
+  std::optional<std::array<double, Dim>> inverse(
       const std::array<double, Dim>& target_coords) const noexcept;
 
   template <typename T>

--- a/src/Domain/CoordinateMaps/MapInstantiationMacros.hpp
+++ b/src/Domain/CoordinateMaps/MapInstantiationMacros.hpp
@@ -3,13 +3,13 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
 #include <boost/preprocessor/punctuation/comma_if.hpp>
 #include <boost/preprocessor/repetition/repeat.hpp>
 #include <boost/preprocessor/tuple/elem.hpp>
 #include <boost/preprocessor/tuple/enum.hpp>
 #include <boost/preprocessor/tuple/size.hpp>
 #include <memory>
+#include <optional>
 #include <pup.h>
 #include <string>
 #include <tuple>
@@ -88,7 +88,7 @@
                   unsigned long,                                             \
                   INSTANTIATE_COORD_MAP_DETAIL_GET_FILLED_INDEX_SEQUENCE(    \
                       data)>) const noexcept;                                \
-  template boost::optional<                                                  \
+  template std::optional<                                                    \
       tnsr::I<double, INSTANTIATE_COORD_MAP_DETAIL_GET_MAPS_DIM(data),       \
               INSTANTIATE_COORD_MAP_DETAIL_GET_SOURCE_FRAME(data)>>          \
   domain::CoordinateMap<INSTANTIATE_COORD_MAP_DETAIL_GET_SOURCE_FRAME(data), \

--- a/src/Domain/CoordinateMaps/ProductMaps.hpp
+++ b/src/Domain/CoordinateMaps/ProductMaps.hpp
@@ -7,9 +7,9 @@
 #pragma once
 
 #include <array>
-#include <boost/optional.hpp>
 #include <cstddef>
 #include <functional>
+#include <optional>
 #include <utility>
 
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -48,7 +48,7 @@ class ProductOf2Maps {
   std::array<tt::remove_cvref_wrap_t<T>, dim> operator()(
       const std::array<T, dim>& source_coords) const noexcept;
 
-  boost::optional<std::array<double, dim>> inverse(
+  std::optional<std::array<double, dim>> inverse(
       const std::array<double, dim>& target_coords) const noexcept;
 
   template <typename T>
@@ -98,7 +98,7 @@ class ProductOf3Maps {
   std::array<tt::remove_cvref_wrap_t<T>, dim> operator()(
       const std::array<T, dim>& source_coords) const noexcept;
 
-  boost::optional<std::array<double, dim>> inverse(
+  std::optional<std::array<double, dim>> inverse(
       const std::array<double, dim>& target_coords) const noexcept;
 
   template <typename T>

--- a/src/Domain/CoordinateMaps/ProductMaps.tpp
+++ b/src/Domain/CoordinateMaps/ProductMaps.tpp
@@ -6,10 +6,9 @@
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 
 #include <array>
-#include <boost/none.hpp>
-#include <boost/optional.hpp>
 #include <cstddef>
 #include <functional>
+#include <optional>
 #include <pup.h>
 #include <utility>
 
@@ -42,7 +41,7 @@ std::array<tt::remove_cvref_wrap_t<T>, Size> apply_call(
 
 template <size_t Size, typename Map1, typename Map2, typename Function,
           size_t... Is, size_t... Js>
-boost::optional<std::array<double, Size>> apply_inverse(
+std::optional<std::array<double, Size>> apply_inverse(
     const std::array<double, Size>& coords, const Map1& map1, const Map2& map2,
     const Function func, std::integer_sequence<size_t, Is...> /*meta*/,
     std::integer_sequence<size_t, Js...> /*meta*/) noexcept {
@@ -51,9 +50,9 @@ boost::optional<std::array<double, Size>> apply_inverse(
   auto map2_func = func(
       std::array<double, sizeof...(Js)>{{coords[Map1::dim + Js]...}}, map2);
   if (map1_func and map2_func) {
-    return {{{map1_func.get()[Is]..., map2_func.get()[Js]...}}};
+    return {{{map1_func.value()[Is]..., map2_func.value()[Js]...}}};
   } else {
-    return boost::none;
+    return std::nullopt;
   }
 }
 
@@ -108,7 +107,7 @@ ProductOf2Maps<Map1, Map2>::operator()(
 }
 
 template <typename Map1, typename Map2>
-boost::optional<std::array<double, ProductOf2Maps<Map1, Map2>::dim>>
+std::optional<std::array<double, ProductOf2Maps<Map1, Map2>::dim>>
 ProductOf2Maps<Map1, Map2>::inverse(
     const std::array<double, dim>& target_coords) const noexcept {
   return product_detail::apply_inverse(
@@ -187,16 +186,16 @@ ProductOf3Maps<Map1, Map2, Map3>::operator()(
 }
 
 template <typename Map1, typename Map2, typename Map3>
-boost::optional<std::array<double, ProductOf3Maps<Map1, Map2, Map3>::dim>>
+std::optional<std::array<double, ProductOf3Maps<Map1, Map2, Map3>::dim>>
 ProductOf3Maps<Map1, Map2, Map3>::inverse(
     const std::array<double, dim>& target_coords) const noexcept {
   auto c1 = map1_.inverse(std::array<double, 1>{{target_coords[0]}});
   auto c2 = map2_.inverse(std::array<double, 1>{{target_coords[1]}});
   auto c3 = map3_.inverse(std::array<double, 1>{{target_coords[2]}});
   if (c1 and c2 and c3) {
-    return {{{c1.get()[0], c2.get()[0], c3.get()[0]}}};
+    return {{{c1.value()[0], c2.value()[0], c3.value()[0]}}};
   } else {
-    return boost::none;
+    return std::nullopt;
   }
 }
 

--- a/src/Domain/CoordinateMaps/Rotation.cpp
+++ b/src/Domain/CoordinateMaps/Rotation.cpp
@@ -10,8 +10,7 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-namespace domain {
-namespace CoordinateMaps {
+namespace domain::CoordinateMaps {
 
 Rotation<2>::Rotation(const double rotation_angle)
     : rotation_angle_(rotation_angle),
@@ -225,5 +224,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3),
 #undef INSTANTIATE
 /// \endcond
 
-}  // namespace CoordinateMaps
-}  // namespace domain
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/Rotation.cpp
+++ b/src/Domain/CoordinateMaps/Rotation.cpp
@@ -34,7 +34,7 @@ std::array<tt::remove_cvref_wrap_t<T>, 2> Rotation<2>::operator()(
                source_coords[1] * get<1, 1>(rotation_matrix_)}};
 }
 
-boost::optional<std::array<double, 2>> Rotation<2>::inverse(
+std::optional<std::array<double, 2>> Rotation<2>::inverse(
     const std::array<double, 2>& target_coords) const noexcept {
   return {{{target_coords[0] * get<0, 0>(rotation_matrix_) +
                 target_coords[1] * get<1, 0>(rotation_matrix_),
@@ -129,7 +129,7 @@ std::array<tt::remove_cvref_wrap_t<T>, 3> Rotation<3>::operator()(
                source_coords[2] * get<2, 2>(rotation_matrix_)}};
 }
 
-boost::optional<std::array<double, 3>> Rotation<3>::inverse(
+std::optional<std::array<double, 3>> Rotation<3>::inverse(
     const std::array<double, 3>& target_coords) const noexcept {
   // Inverse rotation matrix is the same as the transpose.
   return {{{target_coords[0] * get<0, 0>(rotation_matrix_) +

--- a/src/Domain/CoordinateMaps/Rotation.hpp
+++ b/src/Domain/CoordinateMaps/Rotation.hpp
@@ -7,9 +7,9 @@
 #pragma once
 
 #include <array>
-#include <boost/optional.hpp>
 #include <cstddef>
 #include <limits>
+#include <optional>
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
@@ -63,7 +63,7 @@ class Rotation<2> {
   std::array<tt::remove_cvref_wrap_t<T>, 2> operator()(
       const std::array<T, 2>& source_coords) const noexcept;
 
-  boost::optional<std::array<double, 2>> inverse(
+  std::optional<std::array<double, 2>> inverse(
       const std::array<double, 2>& target_coords) const noexcept;
 
   template <typename T>
@@ -137,7 +137,7 @@ class Rotation<3> {
   std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
       const std::array<T, 3>& source_coords) const noexcept;
 
-  boost::optional<std::array<double, 3>> inverse(
+  std::optional<std::array<double, 3>> inverse(
       const std::array<double, 3>& target_coords) const noexcept;
 
   template <typename T>

--- a/src/Domain/CoordinateMaps/SpecialMobius.cpp
+++ b/src/Domain/CoordinateMaps/SpecialMobius.cpp
@@ -3,9 +3,8 @@
 
 #include "Domain/CoordinateMaps/SpecialMobius.hpp"
 
-#include <boost/none.hpp>
-#include <boost/optional.hpp>
 #include <cmath>
+#include <optional>
 #include <pup.h>
 
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -84,14 +83,14 @@ std::array<tt::remove_cvref_wrap_t<T>, 3> SpecialMobius::operator()(
   return mobius_distortion(source_coords, mu_);
 }
 
-boost::optional<std::array<double, 3>> SpecialMobius::inverse(
+std::optional<std::array<double, 3>> SpecialMobius::inverse(
     const std::array<double, 3>& target_coords) const noexcept {
   // Invert only points inside or on the unit sphere.
   const auto r_squared = magnitude(target_coords);
   if (r_squared <= 1.0 or equal_within_roundoff(r_squared,1.0)) {
     return mobius_distortion(target_coords, -mu_);
   }
-  return boost::none;
+  return std::nullopt;
 }
 
 template <typename T>

--- a/src/Domain/CoordinateMaps/SpecialMobius.cpp
+++ b/src/Domain/CoordinateMaps/SpecialMobius.cpp
@@ -16,8 +16,7 @@
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 
-namespace domain {
-namespace CoordinateMaps {
+namespace domain::CoordinateMaps {
 
 SpecialMobius::SpecialMobius(const double mu) noexcept
     : mu_(mu), is_identity_(mu_ == 0.0) {
@@ -140,5 +139,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
 #undef DTYPE
 #undef INSTANTIATE
 /// \endcond
-}  // namespace CoordinateMaps
-}  // namespace domain
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/SpecialMobius.hpp
+++ b/src/Domain/CoordinateMaps/SpecialMobius.hpp
@@ -4,9 +4,9 @@
 #pragma once
 
 #include <array>
-#include <boost/optional.hpp>
 #include <cstddef>
 #include <limits>
+#include <optional>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
@@ -99,7 +99,7 @@ class SpecialMobius {
       const std::array<T, 3>& source_coords) const noexcept;
 
   /// Returns boost::none for target_coords outside the unit sphere.
-  boost::optional<std::array<double, 3>> inverse(
+  std::optional<std::array<double, 3>> inverse(
       const std::array<double, 3>& target_coords) const noexcept;
 
   template <typename T>

--- a/src/Domain/CoordinateMaps/TimeDependent/CubicScale.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/CubicScale.cpp
@@ -4,10 +4,9 @@
 #include "Domain/CoordinateMaps/TimeDependent/CubicScale.hpp"
 
 #include <array>
-#include <boost/none.hpp>
-#include <boost/optional.hpp>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <pup.h>
 #include <pup_stl.h>
@@ -97,7 +96,7 @@ std::array<tt::remove_cvref_wrap_t<T>, Dim> CubicScale<Dim>::operator()(
 
 template <size_t Dim>
 template <typename T>
-boost::optional<std::array<tt::remove_cvref_wrap_t<T>, Dim>>
+std::optional<std::array<tt::remove_cvref_wrap_t<T>, Dim>>
 CubicScale<Dim>::inverse(
     const std::array<T, Dim>& target_coords, const double time,
     const std::unordered_map<
@@ -117,10 +116,10 @@ CubicScale<Dim>::inverse(
     const double one_over_a_of_t =
         1.0 / functions_of_time.at(f_of_t_a_)->func(time)[0][0];
 
-    // Construct boost::optional to have a default value of an empty array.
-    // Doing just result{} would construct a boost::optional that doesn't hold a
+    // Construct std::optional to have a default value of an empty array.
+    // Doing just result{} would construct a std::optional that doesn't hold a
     // value and so *result would throw an exception.
-    boost::optional<std::array<tt::remove_cvref_wrap_t<T>, Dim>> result{
+    std::optional<std::array<tt::remove_cvref_wrap_t<T>, Dim>> result{
         std::array<tt::remove_cvref_wrap_t<T>, Dim>{}};
     for (size_t i = 0; i < Dim; ++i) {
       gsl::at(*result, i) = one_over_a_of_t * gsl::at(target_coords, i);
@@ -162,7 +161,7 @@ CubicScale<Dim>::inverse(
   // support epsilon above b(t).
   if (UNLIKELY(target_dimensionless_radius >
                b_of_t * (1.0 + 2.0 * std::numeric_limits<double>::epsilon()))) {
-    return boost::none;
+    return std::nullopt;
   }
 
   // For an initial guess, we provide a linearly approximated solution for
@@ -418,7 +417,7 @@ bool operator==(const CubicScale<Dim>& lhs,
 
 #define INSTANTIATE(_, data)                                                 \
   template class CubicScale<DIM(data)>;                                      \
-  template boost::optional<                                                  \
+  template std::optional<                                                    \
       std::array<tt::remove_cvref_wrap_t<double>, DIM(data)>>                \
   CubicScale<DIM(data)>::inverse(                                            \
       const std::array<double, DIM(data)>& target_coords, const double time, \
@@ -426,7 +425,7 @@ bool operator==(const CubicScale<Dim>& lhs,
           std::string,                                                       \
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&         \
           functions_of_time) const noexcept;                                 \
-  template boost::optional<std::array<                                       \
+  template std::optional<std::array<                                         \
       tt::remove_cvref_wrap_t<std::reference_wrapper<const double>>,         \
       DIM(data)>>                                                            \
   CubicScale<DIM(data)>::inverse(                                            \

--- a/src/Domain/CoordinateMaps/TimeDependent/CubicScale.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/CubicScale.cpp
@@ -29,9 +29,7 @@
 #include "Utilities/StdHelpers.hpp"
 #include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
 
-namespace domain {
-namespace CoordinateMaps {
-namespace TimeDependent {
+namespace domain::CoordinateMaps::TimeDependent {
 
 template <size_t Dim>
 CubicScale<Dim>::CubicScale(const double outer_boundary,
@@ -489,6 +487,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
 #undef DTYPE
 #undef INSTANTIATE
 /// \endcond
-}  // namespace TimeDependent
-}  // namespace CoordinateMaps
-}  // namespace domain
+}  // namespace domain::CoordinateMaps::TimeDependent

--- a/src/Domain/CoordinateMaps/TimeDependent/CubicScale.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/CubicScale.hpp
@@ -4,10 +4,10 @@
 #pragma once
 
 #include <array>
-#include <boost/optional.hpp>
 #include <cstddef>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -115,7 +115,7 @@ class CubicScale {
 
   /// Returns boost::none if the point is outside the range of the map.
   template <typename T>
-  boost::optional<std::array<tt::remove_cvref_wrap_t<T>, Dim>> inverse(
+  std::optional<std::array<tt::remove_cvref_wrap_t<T>, Dim>> inverse(
       const std::array<T, Dim>& target_coords, double time,
       const std::unordered_map<
           std::string,

--- a/src/Domain/CoordinateMaps/TimeDependent/ProductMaps.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ProductMaps.hpp
@@ -4,10 +4,10 @@
 #pragma once
 
 #include <array>
-#include <boost/optional.hpp>
 #include <cstddef>
 #include <functional>
 #include <limits>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -61,7 +61,7 @@ class ProductOf2Maps {
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time) const noexcept;
 
-  boost::optional<std::array<double, dim>> inverse(
+  std::optional<std::array<double, dim>> inverse(
       const std::array<double, dim>& target_coords, double time,
       const std::unordered_map<
           std::string,
@@ -142,7 +142,7 @@ class ProductOf3Maps {
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time) const noexcept;
 
-  boost::optional<std::array<double, dim>> inverse(
+  std::optional<std::array<double, dim>> inverse(
       const std::array<double, dim>& target_coords, double time,
       const std::unordered_map<
           std::string,

--- a/src/Domain/CoordinateMaps/TimeDependent/ProductMaps.tpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ProductMaps.tpp
@@ -6,10 +6,9 @@
 #include "Domain/CoordinateMaps/TimeDependent/ProductMaps.hpp"
 
 #include <array>
-#include <boost/none.hpp>
-#include <boost/optional.hpp>
 #include <cstddef>
 #include <functional>
+#include <optional>
 #include <pup.h>
 #include <utility>
 
@@ -50,7 +49,7 @@ std::array<tt::remove_cvref_wrap_t<T>, Size> apply_map(
 }
 
 template <size_t Size, typename Map1, typename Map2, size_t... Is, size_t... Js>
-boost::optional<std::array<double, Size>> apply_inverse(
+std::optional<std::array<double, Size>> apply_inverse(
     const std::array<double, Size>& coords, const Map1& map1, const Map2& map2,
     const double time,
     const std::unordered_map<
@@ -65,9 +64,9 @@ boost::optional<std::array<double, Size>> apply_inverse(
       map2, std::array<double, sizeof...(Js)>{{coords[Map1::dim + Js]...}},
       time, functions_of_time, domain::is_map_time_dependent_t<Map2>{});
   if (map1_func and map2_func) {
-    return {{{map1_func.get()[Is]..., map2_func.get()[Js]...}}};
+    return {{{map1_func.value()[Is]..., map2_func.value()[Js]...}}};
   } else {
-    return boost::none;
+    return std::nullopt;
   }
 }
 
@@ -148,7 +147,7 @@ ProductOf2Maps<Map1, Map2>::operator()(
 }
 
 template <typename Map1, typename Map2>
-boost::optional<std::array<double, ProductOf2Maps<Map1, Map2>::dim>>
+std::optional<std::array<double, ProductOf2Maps<Map1, Map2>::dim>>
 ProductOf2Maps<Map1, Map2>::inverse(
     const std::array<double, dim>& target_coords, const double time,
     const std::unordered_map<
@@ -266,7 +265,7 @@ ProductOf3Maps<Map1, Map2, Map3>::operator()(
 }
 
 template <typename Map1, typename Map2, typename Map3>
-boost::optional<std::array<double, ProductOf3Maps<Map1, Map2, Map3>::dim>>
+std::optional<std::array<double, ProductOf3Maps<Map1, Map2, Map3>::dim>>
 ProductOf3Maps<Map1, Map2, Map3>::inverse(
     const std::array<double, dim>& target_coords, const double time,
     const std::unordered_map<
@@ -282,9 +281,9 @@ ProductOf3Maps<Map1, Map2, Map3>::inverse(
       map3_, std::array<double, 1>{{target_coords[2]}}, time, functions_of_time,
       domain::is_map_time_dependent_t<Map3>{});
   if (c1 and c2 and c3) {
-    return {{{c1.get()[0], c2.get()[0], c3.get()[0]}}};
+    return {{{c1.value()[0], c2.value()[0], c3.value()[0]}}};
   } else {
-    return boost::none;
+    return std::nullopt;
   }
 }
 

--- a/src/Domain/CoordinateMaps/TimeDependent/Rotation.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Rotation.cpp
@@ -64,7 +64,7 @@ std::array<tt::remove_cvref_wrap_t<T>, 2> Rotation<2>::operator()(
                source_coords[1] * rot_matrix(1, 1)}};
 }
 
-boost::optional<std::array<double, 2>> Rotation<2>::inverse(
+std::optional<std::array<double, 2>> Rotation<2>::inverse(
     const std::array<double, 2>& target_coords, const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&

--- a/src/Domain/CoordinateMaps/TimeDependent/Rotation.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Rotation.cpp
@@ -38,9 +38,7 @@ Matrix rotation_matrix(
 }
 }  // namespace
 
-namespace domain {
-namespace CoordinateMaps {
-namespace TimeDependent {
+namespace domain::CoordinateMaps::TimeDependent {
 
 Rotation<2>::Rotation(std::string function_of_time_name) noexcept
     : f_of_t_name_(std::move(function_of_time_name)) {}
@@ -218,6 +216,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (2),
 #undef INSTANTIATE
 /// \endcond
 
-}  // namespace TimeDependent
-}  // namespace CoordinateMaps
-}  // namespace domain
+}  // namespace domain::CoordinateMaps::TimeDependent

--- a/src/Domain/CoordinateMaps/TimeDependent/Rotation.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Rotation.cpp
@@ -32,9 +32,8 @@ Matrix rotation_matrix(
                                   << keys_of(functions_of_time));
   const double rotation_angle =
       functions_of_time.at(f_of_t_name)->func(time)[0][0];
-  const Matrix rot_matrix{{cos(rotation_angle), -sin(rotation_angle)},
+  return Matrix{{cos(rotation_angle), -sin(rotation_angle)},
                           {sin(rotation_angle), cos(rotation_angle)}};
-  return rot_matrix;
 }
 }  // namespace
 
@@ -54,7 +53,7 @@ std::array<tt::remove_cvref_wrap_t<T>, 2> Rotation<2>::operator()(
              << f_of_t_name_ << "' in functions of time. Known functions are "
              << keys_of(functions_of_time));
 
-  const Matrix& rot_matrix =
+  const Matrix rot_matrix =
       rotation_matrix(f_of_t_name_, time, functions_of_time);
   return {{source_coords[0] * rot_matrix(0, 0) +
                source_coords[1] * rot_matrix(0, 1),
@@ -72,7 +71,7 @@ std::optional<std::array<double, 2>> Rotation<2>::inverse(
              << f_of_t_name_ << "' in functions of time. Known functions are "
              << keys_of(functions_of_time));
 
-  const Matrix& rot_matrix =
+  const Matrix rot_matrix =
       rotation_matrix(f_of_t_name_, time, functions_of_time);
   // The inverse map uses the inverse rotation matrix, which is just the
   // transpose of the rotation matrix
@@ -101,7 +100,7 @@ std::array<tt::remove_cvref_wrap_t<T>, 2> Rotation<2>::frame_velocity(
   // The frame velocity is
   //   dx/dt = (-\sin(\alpha) \xi - \cos(\alpha)\eta) * d\alpha/dt
   //   dy/dt = (\cos(\alpha) \xi -\sin(\alpha) \eta) * d\alpha/dt
-  const Matrix& rot_matrix =
+  const Matrix rot_matrix =
       rotation_matrix(f_of_t_name_, time, functions_of_time);
   const double rotation_angular_velocity =
       functions_of_time.at(f_of_t_name_)->func_and_deriv(time)[1][0];
@@ -124,7 +123,7 @@ tnsr::Ij<tt::remove_cvref_wrap_t<T>, 2, Frame::NoFrame> Rotation<2>::jacobian(
              << f_of_t_name_ << "' in functions of time. Known functions are "
              << keys_of(functions_of_time));
 
-  const Matrix& rot_matrix =
+  const Matrix rot_matrix =
       rotation_matrix(f_of_t_name_, time, functions_of_time);
   tnsr::Ij<tt::remove_cvref_wrap_t<T>, 2, Frame::NoFrame> jacobian_matrix{
       make_with_value<tt::remove_cvref_wrap_t<T>>(
@@ -147,7 +146,7 @@ Rotation<2>::inv_jacobian(
              << f_of_t_name_ << "' in functions of time. Known functions are "
              << keys_of(functions_of_time));
 
-  const Matrix& rot_matrix =
+  const Matrix rot_matrix =
       rotation_matrix(f_of_t_name_, time, functions_of_time);
   tnsr::Ij<tt::remove_cvref_wrap_t<T>, 2, Frame::NoFrame> inv_jacobian_matrix{
       make_with_value<tt::remove_cvref_wrap_t<T>>(

--- a/src/Domain/CoordinateMaps/TimeDependent/Rotation.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Rotation.hpp
@@ -4,9 +4,9 @@
 #pragma once
 
 #include <array>
-#include <boost/optional.hpp>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -69,7 +69,7 @@ class Rotation<2> {
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time) const noexcept;
 
-  boost::optional<std::array<double, 2>> inverse(
+  std::optional<std::array<double, 2>> inverse(
       const std::array<double, 2>& target_coords, double time,
       const std::unordered_map<
           std::string,

--- a/src/Domain/CoordinateMaps/TimeDependent/Translation.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Translation.cpp
@@ -17,9 +17,7 @@
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/StdHelpers.hpp"
 
-namespace domain {
-namespace CoordinateMaps {
-namespace TimeDependent {
+namespace domain::CoordinateMaps::TimeDependent {
 
 Translation::Translation(std::string function_of_time_name) noexcept
     : f_of_t_name_(std::move(function_of_time_name)) {}
@@ -120,6 +118,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
 #undef DTYPE
 #undef INSTANTIATE
 /// \endcond
-}  // namespace TimeDependent
-}  // namespace CoordinateMaps
-}  // namespace domain
+}  // namespace domain::CoordinateMaps::TimeDependent

--- a/src/Domain/CoordinateMaps/TimeDependent/Translation.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Translation.cpp
@@ -39,7 +39,7 @@ std::array<tt::remove_cvref_wrap_t<T>, 1> Translation::operator()(
            functions_of_time.at(f_of_t_name_)->func(time)[0][0]}};
 }
 
-boost::optional<std::array<double, 1>> Translation::inverse(
+std::optional<std::array<double, 1>> Translation::inverse(
     const std::array<double, 1>& target_coords, const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&

--- a/src/Domain/CoordinateMaps/TimeDependent/Translation.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Translation.hpp
@@ -4,9 +4,9 @@
 #pragma once
 
 #include <array>
-#include <boost/optional.hpp>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -49,7 +49,7 @@ class Translation {
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time) const noexcept;
 
-  boost::optional<std::array<double, 1>> inverse(
+  std::optional<std::array<double, 1>> inverse(
       const std::array<double, 1>& target_coords, double time,
       const std::unordered_map<
           std::string,

--- a/src/Domain/CoordinateMaps/Wedge2D.cpp
+++ b/src/Domain/CoordinateMaps/Wedge2D.cpp
@@ -3,7 +3,6 @@
 
 #include "Domain/CoordinateMaps/Wedge2D.hpp"
 
-#include <boost/none.hpp>
 #include <cmath>
 #include <pup.h>
 
@@ -70,7 +69,7 @@ std::array<tt::remove_cvref_wrap_t<T>, 2> Wedge2D::operator()(
   return discrete_rotation(orientation_of_wedge_, std::move(physical_coords));
 }
 
-boost::optional<std::array<double, 2>> Wedge2D::inverse(
+std::optional<std::array<double, 2>> Wedge2D::inverse(
     const std::array<double, 2>& target_coords) const noexcept {
   const std::array<double, 2> physical_coords =
       discrete_rotation(orientation_of_wedge_.inverse_map(), target_coords);
@@ -78,7 +77,7 @@ boost::optional<std::array<double, 2>> Wedge2D::inverse(
   const double& physical_y = physical_coords[1];
 
   if (physical_x < 0.0 or equal_within_roundoff(physical_x, 0.0)) {
-    return boost::none;
+    return std::nullopt;
   }
 
   const double cap_eta = physical_y / physical_x;

--- a/src/Domain/CoordinateMaps/Wedge2D.hpp
+++ b/src/Domain/CoordinateMaps/Wedge2D.hpp
@@ -7,9 +7,9 @@
 #pragma once
 
 #include <array>
-#include <boost/optional.hpp>
 #include <cstddef>
 #include <limits>
+#include <optional>
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
@@ -139,7 +139,7 @@ class Wedge2D {
       const std::array<T, 2>& source_coords) const noexcept;
 
   /// Returns invalid if \f$x<=0\f$ (for a \f$+x\f$-oriented `Wedge2D`).
-  boost::optional<std::array<double, 2>> inverse(
+  std::optional<std::array<double, 2>> inverse(
       const std::array<double, 2>& target_coords) const noexcept;
 
   template <typename T>

--- a/src/Domain/CoordinateMaps/Wedge3D.cpp
+++ b/src/Domain/CoordinateMaps/Wedge3D.cpp
@@ -3,7 +3,6 @@
 
 #include "Domain/CoordinateMaps/Wedge3D.hpp"
 
-#include <boost/none.hpp>
 #include <cmath>
 #include <pup.h>
 
@@ -115,7 +114,7 @@ std::array<tt::remove_cvref_wrap_t<T>, 3> Wedge3D::operator()(
   return discrete_rotation(orientation_of_wedge_, std::move(physical_coords));
 }
 
-boost::optional<std::array<double, 3>> Wedge3D::inverse(
+std::optional<std::array<double, 3>> Wedge3D::inverse(
     const std::array<double, 3>& target_coords) const noexcept {
   const std::array<double, 3> physical_coords =
       discrete_rotation(orientation_of_wedge_.inverse_map(), target_coords);
@@ -124,7 +123,7 @@ boost::optional<std::array<double, 3>> Wedge3D::inverse(
   const double& physical_z = physical_coords[2];
 
   if (physical_z < 0.0 or equal_within_roundoff(physical_z, 0.0)) {
-    return boost::none;
+    return std::nullopt;
   }
 
   const double cap_xi = physical_x / physical_z;
@@ -136,7 +135,7 @@ boost::optional<std::array<double, 3>> Wedge3D::inverse(
   // If -sphere_rate_/scaled_frustum_rate_ > 1, then
   // there exists a cone in x,y,z space given by the surface
   // zeta_coefficient=0; the map is singular on this surface.
-  // We return boost::none if we are on or outside this cone.
+  // We return nullopt if we are on or outside this cone.
   // If scaled_frustum_rate_ > 0, then outside the cone
   // corresponds to zeta_coefficient > 0, and if scaled_frustum_rate_
   // < 0, then outside the cone corresponds to zeta_coefficient < 0.
@@ -146,7 +145,7 @@ boost::optional<std::array<double, 3>> Wedge3D::inverse(
       (scaled_frustum_rate_ < 0.0 and scaled_frustum_rate_ > -sphere_rate_ and
        zeta_coefficient < 0.0) or
       equal_within_roundoff(zeta_coefficient, 0.0)) {
-    return boost::none;
+    return std::nullopt;
   }
   const auto z_zero = (scaled_frustum_zero_ + sphere_zero_ * one_over_rho);
   const double zeta =

--- a/src/Domain/CoordinateMaps/Wedge3D.hpp
+++ b/src/Domain/CoordinateMaps/Wedge3D.hpp
@@ -4,9 +4,9 @@
 #pragma once
 
 #include <array>
-#include <boost/optional.hpp>
 #include <cstddef>
 #include <limits>
+#include <optional>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
@@ -283,7 +283,7 @@ class Wedge3D {
   /// Here \f$s_0,s_1\f$ and \f$r_0,r_1\f$ are the specified sphericities
   /// and radii of the inner and outer \f$z\f$ surfaces.  The map is singular on
   /// the cone and on the xy plane.
-  boost::optional<std::array<double, 3>> inverse(
+  std::optional<std::array<double, 3>> inverse(
       const std::array<double, 3>& target_coords) const noexcept;
 
   template <typename T>

--- a/src/Domain/ElementMap.hpp
+++ b/src/Domain/ElementMap.hpp
@@ -63,7 +63,7 @@ class ElementMap {
   tnsr::I<T, Dim, Frame::Logical> inverse(
       tnsr::I<T, Dim, TargetFrame> target_point) const noexcept {
     auto source_point{
-        block_map_->inverse(std::move(target_point)).get()};
+        block_map_->inverse(std::move(target_point)).value()};
     // Apply the affine map to the points
     for (size_t d = 0; d < Dim; ++d) {
       source_point.get(d) =

--- a/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
@@ -26,7 +26,7 @@ add_test_library(
   ${LIBRARY}
   "Domain/CoordinateMaps"
   "${LIBRARY_SOURCES}"
-  "Boost::boost;CoordinateMaps;FunctionsOfTime"
+  "CoordinateMaps;FunctionsOfTime"
   )
 
 add_subdirectory(TimeDependent)

--- a/tests/Unit/Domain/CoordinateMaps/Test_Affine.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Affine.cpp
@@ -4,8 +4,8 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <array>
-#include <boost/optional.hpp>
 #include <memory>
+#include <optional>
 #include <pup.h>
 
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -36,9 +36,9 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Affine", "[Domain][Unit]") {
   CHECK(affine_map(point_B) == point_b);
   CHECK(affine_map(point_xi) == point_x);
 
-  CHECK(affine_map.inverse(point_a).get() == point_A);
-  CHECK(affine_map.inverse(point_b).get() == point_B);
-  CHECK(affine_map.inverse(point_x).get() == point_xi);
+  CHECK(affine_map.inverse(point_a).value() == point_A);
+  CHECK(affine_map.inverse(point_b).value() == point_B);
+  CHECK(affine_map.inverse(point_x).value() == point_xi);
 
   const double inv_jacobian_00 = (xB - xA) / (xb - xa);
 

--- a/tests/Unit/Domain/CoordinateMaps/Test_BulgedCube.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_BulgedCube.cpp
@@ -4,9 +4,9 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <array>
-#include <boost/optional.hpp>
 #include <cmath>
 #include <memory>
+#include <optional>
 #include <pup.h>
 
 #include "DataStructures/DataVector.hpp"
@@ -32,7 +32,7 @@ void test_bulged_cube_fail() {
 
   // These points are outside the mapped BulgedCube. So inverse should either
   // return the correct inverse (which happens to be computable for
-  // these points) or it should return boost::none.
+  // these points) or it should return nullopt.
   const std::array<double, 3> test_mapped_point4{{2.0, 2.0, 2.0}};
   const std::array<double, 3> test_mapped_point5{{3.0, 0.0, 0.0}};
 
@@ -40,11 +40,11 @@ void test_bulged_cube_fail() {
   CHECK_FALSE(static_cast<bool>(map.inverse(test_mapped_point2)));
   CHECK_FALSE(static_cast<bool>(map.inverse(test_mapped_point3)));
   if (map.inverse(test_mapped_point4)) {
-    CHECK_ITERABLE_APPROX(map(map.inverse(test_mapped_point4).get()),
+    CHECK_ITERABLE_APPROX(map(map.inverse(test_mapped_point4).value()),
                           test_mapped_point4);
   }
   if (map.inverse(test_mapped_point5)) {
-    CHECK_ITERABLE_APPROX(map(map.inverse(test_mapped_point5).get()),
+    CHECK_ITERABLE_APPROX(map(map.inverse(test_mapped_point5).value()),
                           test_mapped_point5);
   }
 }

--- a/tests/Unit/Domain/CoordinateMaps/Test_Equiangular.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Equiangular.cpp
@@ -4,8 +4,8 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <array>
-#include <boost/optional.hpp>
 #include <cmath>
+#include <optional>
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
@@ -44,12 +44,12 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Equiangular", "[Domain][Unit]") {
   CHECK(equiangular_map(point_r2)[0] ==
         approx(-0.5 + 2.5 * tan(M_PI_4 * (2.0 * r2 - 1.0) / 3.0)));
 
-  CHECK(equiangular_map.inverse(point_a).get()[0] == approx(point_A[0]));
-  CHECK(equiangular_map.inverse(point_b).get()[0] == approx(point_B[0]));
-  CHECK(equiangular_map.inverse(point_x).get()[0] == approx(point_xi[0]));
-  CHECK(equiangular_map.inverse(point_r1).get()[0] ==
+  CHECK(equiangular_map.inverse(point_a).value()[0] == approx(point_A[0]));
+  CHECK(equiangular_map.inverse(point_b).value()[0] == approx(point_B[0]));
+  CHECK(equiangular_map.inverse(point_x).value()[0] == approx(point_xi[0]));
+  CHECK(equiangular_map.inverse(point_r1).value()[0] ==
         approx(0.5 + 3.0 * atan(0.4 * r1 + 0.2) / M_PI_2));
-  CHECK(equiangular_map.inverse(point_r2).get()[0] ==
+  CHECK(equiangular_map.inverse(point_r2).value()[0] ==
         approx(0.5 + 3.0 * atan(0.4 * r2 + 0.2) / M_PI_2));
 
   CHECK((get<0, 0>(equiangular_map.inv_jacobian(point_A))) *

--- a/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
@@ -4,9 +4,9 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <array>
-#include <boost/optional.hpp>
 #include <cmath>
 #include <memory>
+#include <optional>
 #include <pup.h>
 #include <random>
 
@@ -70,14 +70,14 @@ void test_frustum_fail() noexcept {
 
   // This is outside the mapped frustum, so inverse should either
   // return the correct inverse (which happens to be computable for
-  // this point) or it should return boost::none.
+  // this point) or it should return nullopt.
   const std::array<double, 3> test_mapped_point4{{0.0, 0.0, 9.0}};
 
   CHECK_FALSE(static_cast<bool>(map.inverse(test_mapped_point1)));
   CHECK_FALSE(static_cast<bool>(map.inverse(test_mapped_point2)));
   CHECK_FALSE(static_cast<bool>(map.inverse(test_mapped_point3)));
   if (map.inverse(test_mapped_point4)) {
-    CHECK_ITERABLE_APPROX(map(map.inverse(test_mapped_point4).get()),
+    CHECK_ITERABLE_APPROX(map(map.inverse(test_mapped_point4).value()),
                           test_mapped_point4);
   }
 }

--- a/tests/Unit/Domain/CoordinateMaps/Test_Identity.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Identity.cpp
@@ -19,7 +19,7 @@ void test_identity() {
   const auto xi = make_array<Dim>(1.0);
   const auto x = make_array<Dim>(1.0);
   CHECK(identity_map(xi) == x);
-  CHECK(identity_map.inverse(x).get() == xi);
+  CHECK(identity_map.inverse(x).value() == xi);
   const auto inv_jac = identity_map.inv_jacobian(xi);
   const auto jac = identity_map.jacobian(xi);
   for (size_t i = 0; i < Dim; ++i) {

--- a/tests/Unit/Domain/CoordinateMaps/Test_ProductMaps.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_ProductMaps.cpp
@@ -4,9 +4,9 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <array>
-#include <boost/optional.hpp>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <pup.h>
 
 #include "DataStructures/DataVector.hpp"
@@ -41,7 +41,8 @@ void test_product_two_maps_fail() {
 
     CHECK_FALSE(static_cast<bool>(map.inverse(mapped_point1)));
     CHECK(static_cast<bool>(map.inverse(mapped_point2)));
-    CHECK_ITERABLE_APPROX(map(map.inverse(mapped_point2).get()), mapped_point2);
+    CHECK_ITERABLE_APPROX(map(map.inverse(mapped_point2).value()),
+                          mapped_point2);
   }
 
   {
@@ -56,7 +57,8 @@ void test_product_two_maps_fail() {
 
     CHECK_FALSE(static_cast<bool>(map.inverse(mapped_point1)));
     CHECK(static_cast<bool>(map.inverse(mapped_point2)));
-    CHECK_ITERABLE_APPROX(map(map.inverse(mapped_point2).get()), mapped_point2);
+    CHECK_ITERABLE_APPROX(map(map.inverse(mapped_point2).value()),
+                          mapped_point2);
   }
 }
 void test_product_of_2_maps() {
@@ -95,9 +97,9 @@ void test_product_of_2_maps() {
   CHECK(affine_map_xy(point_B) == point_b);
   CHECK(affine_map_xy(point_xi) == point_x);
 
-  CHECK(affine_map_xy.inverse(point_a).get() == point_A);
-  CHECK(affine_map_xy.inverse(point_b).get() == point_B);
-  CHECK(affine_map_xy.inverse(point_x).get() == point_xi);
+  CHECK(affine_map_xy.inverse(point_a).value() == point_A);
+  CHECK(affine_map_xy.inverse(point_b).value() == point_B);
+  CHECK(affine_map_xy.inverse(point_x).value() == point_xi);
 
   const double inv_jacobian_00 = (xB - xA) / (xb - xa);
   const double inv_jacobian_11 = (yB - yA) / (yb - ya);
@@ -232,9 +234,9 @@ void test_product_of_3_maps() {
   CHECK(affine_map_xyz(point_B) == point_b);
   CHECK(affine_map_xyz(point_xi) == point_x);
 
-  CHECK(affine_map_xyz.inverse(point_a).get() == point_A);
-  CHECK(affine_map_xyz.inverse(point_b).get() == point_B);
-  CHECK(affine_map_xyz.inverse(point_x).get() == point_xi);
+  CHECK(affine_map_xyz.inverse(point_a).value() == point_A);
+  CHECK(affine_map_xyz.inverse(point_b).value() == point_B);
+  CHECK(affine_map_xyz.inverse(point_x).value() == point_xi);
 
   const double inv_jacobian_00 = (xB - xA) / (xb - xa);
   const double inv_jacobian_11 = (yB - yA) / (yb - ya);

--- a/tests/Unit/Domain/CoordinateMaps/Test_Rotation.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Rotation.cpp
@@ -4,10 +4,10 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <array>
-#include <boost/optional.hpp>
 #include <cmath>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <pup.h>
 
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -43,13 +43,13 @@ void test_rotation_3(const CoordinateMaps::Rotation<3>& three_dim_rotation_map,
           approx(gsl::at(eta_hat, i)));
     CHECK(gsl::at(three_dim_rotation_map(zeta), i) ==
           approx(gsl::at(zeta_hat, i)));
-    CHECK(gsl::at(three_dim_rotation_map.inverse(zero_grid).get(), i) ==
+    CHECK(gsl::at(three_dim_rotation_map.inverse(zero_grid).value(), i) ==
           approx(gsl::at(zero_logical, i)));
-    CHECK(gsl::at(three_dim_rotation_map.inverse(xi_hat).get(), i) ==
+    CHECK(gsl::at(three_dim_rotation_map.inverse(xi_hat).value(), i) ==
           approx(gsl::at(xi, i)));
-    CHECK(gsl::at(three_dim_rotation_map.inverse(eta_hat).get(), i) ==
+    CHECK(gsl::at(three_dim_rotation_map.inverse(eta_hat).value(), i) ==
           approx(gsl::at(eta, i)));
-    CHECK(gsl::at(three_dim_rotation_map.inverse(zeta_hat).get(), i) ==
+    CHECK(gsl::at(three_dim_rotation_map.inverse(zeta_hat).value(), i) ==
           approx(gsl::at(zeta, i)));
     CHECK(inv_jac.get(0, i) == approx(gsl::at(xi_hat, i)));
     CHECK(inv_jac.get(1, i) == approx(gsl::at(eta_hat, i)));
@@ -75,8 +75,8 @@ void test_rotation_2() {
   CHECK(half_pi_rotation_map(xi0)[0] == approx(x0[0]));
   CHECK(half_pi_rotation_map(xi0)[1] == approx(x0[1]));
 
-  CHECK(half_pi_rotation_map.inverse(x0).get()[0] == approx(xi0[0]));
-  CHECK(half_pi_rotation_map.inverse(x0).get()[1] == approx(xi0[1]));
+  CHECK(half_pi_rotation_map.inverse(x0).value()[0] == approx(xi0[0]));
+  CHECK(half_pi_rotation_map.inverse(x0).value()[1] == approx(xi0[1]));
 
   const std::array<double, 2> xi1{{1.0, 0.0}};
   const std::array<double, 2> x1{{0.0, 1.0}};
@@ -84,8 +84,8 @@ void test_rotation_2() {
   CHECK(half_pi_rotation_map(xi1)[0] == approx(x1[0]));
   CHECK(half_pi_rotation_map(xi1)[1] == approx(x1[1]));
 
-  CHECK(half_pi_rotation_map.inverse(x1).get()[0] == approx(xi1[0]));
-  CHECK(half_pi_rotation_map.inverse(x1).get()[1] == approx(xi1[1]));
+  CHECK(half_pi_rotation_map.inverse(x1).value()[0] == approx(xi1[0]));
+  CHECK(half_pi_rotation_map.inverse(x1).value()[1] == approx(xi1[1]));
 
   const std::array<double, 2> xi2{{0.0, 1.0}};
   const std::array<double, 2> x2{{-1.0, 0.0}};
@@ -93,8 +93,8 @@ void test_rotation_2() {
   CHECK(half_pi_rotation_map(xi2)[0] == approx(x2[0]));
   CHECK(half_pi_rotation_map(xi2)[1] == approx(x2[1]));
 
-  CHECK(half_pi_rotation_map.inverse(x2).get()[0] == approx(xi2[0]));
-  CHECK(half_pi_rotation_map.inverse(x2).get()[1] == approx(xi2[1]));
+  CHECK(half_pi_rotation_map.inverse(x2).value()[0] == approx(xi2[0]));
+  CHECK(half_pi_rotation_map.inverse(x2).value()[1] == approx(xi2[1]));
 
   const auto inv_jac = half_pi_rotation_map.inv_jacobian(xi2);
   CHECK((get<0, 0>(inv_jac)) == approx(0.0));

--- a/tests/Unit/Domain/CoordinateMaps/Test_RotationTimeDep.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_RotationTimeDep.cpp
@@ -4,10 +4,10 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <array>
-#include <boost/optional.hpp>
 #include <cmath>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -79,8 +79,9 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.RotationTimeDep",
         expected_mapped_point(initial_unmapped_point, t)};
     CHECK_ITERABLE_APPROX(rotation_map(initial_unmapped_point, t, f_of_t_list),
                           expected);
-    CHECK_ITERABLE_APPROX(rotation_map.inverse(expected, t, f_of_t_list).get(),
-                          initial_unmapped_point);
+    CHECK_ITERABLE_APPROX(
+        rotation_map.inverse(expected, t, f_of_t_list).value(),
+        initial_unmapped_point);
     CHECK_ITERABLE_APPROX(
         rotation_map.frame_velocity(initial_unmapped_point, t, f_of_t_list),
         expected_frame_velocity(initial_unmapped_point, t));
@@ -89,7 +90,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.RotationTimeDep",
         rotation_map_deserialized(initial_unmapped_point, t, f_of_t_list),
         expected);
     CHECK_ITERABLE_APPROX(
-        rotation_map_deserialized.inverse(expected, t, f_of_t_list).get(),
+        rotation_map_deserialized.inverse(expected, t, f_of_t_list).value(),
         initial_unmapped_point);
     CHECK_ITERABLE_APPROX(rotation_map_deserialized.frame_velocity(
                               initial_unmapped_point, t, f_of_t_list),

--- a/tests/Unit/Domain/CoordinateMaps/Test_SpecialMobius.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_SpecialMobius.cpp
@@ -4,7 +4,6 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <array>
-#include <boost/optional/optional.hpp>
 #include <cmath>
 #include <memory>
 #include <pup.h>
@@ -98,7 +97,7 @@ void test_large_mu() {
   const CoordinateMaps::SpecialMobius special_mobius_map(mu);
   const auto result_point = special_mobius_map(input_point);
   const auto expected_input_point =
-      special_mobius_map.inverse(result_point).get();
+      special_mobius_map.inverse(result_point).value();
   const auto& result_y = result_point[1];
   const auto& result_z = result_point[2];
   // The SpecialMobius map should map the unit sphere to itself:

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
@@ -4,8 +4,8 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <array>
-#include <boost/optional.hpp>
 #include <cmath>
+#include <optional>
 #include <random>
 
 #include "Domain/CoordinateMaps/Wedge2D.hpp"
@@ -138,14 +138,14 @@ void test_wedge2d_fail() noexcept {
 
   // This point is outside the mapped wedge.  So inverse should either
   // return the correct inverse (which happens to be computable for
-  // this point) or it should return boost::none.
+  // this point) or it should return nullopt.
   const std::array<double, 2> test_mapped_point4{{100.0, -6.0}};
 
   CHECK_FALSE(static_cast<bool>(map.inverse(test_mapped_point1)));
   CHECK_FALSE(static_cast<bool>(map.inverse(test_mapped_point2)));
   CHECK_FALSE(static_cast<bool>(map.inverse(test_mapped_point3)));
   if (map.inverse(test_mapped_point4)) {
-    CHECK_ITERABLE_APPROX(map(map.inverse(test_mapped_point4).get()),
+    CHECK_ITERABLE_APPROX(map(map.inverse(test_mapped_point4).value()),
                           test_mapped_point4);
   }
 }

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
@@ -4,8 +4,8 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <array>
-#include <boost/optional.hpp>
 #include <cmath>
+#include <optional>
 #include <random>
 
 #include "Domain/CoordinateMaps/Wedge3D.hpp"
@@ -284,7 +284,7 @@ void test_wedge3d_fail() noexcept {
 
   // These points are outside the mapped wedge. So inverse should either
   // return the correct inverse (which happens to be computable for
-  // these points) or it should return boost::none.
+  // these points) or it should return nullopt.
   const std::array<double, 3> test_mapped_point6{{30.0, sqrt(298.0), 1.0}};
   const std::array<double, 3> test_mapped_point7{{2.0, 4.0, 6.0}};
 
@@ -295,11 +295,11 @@ void test_wedge3d_fail() noexcept {
   CHECK_FALSE(static_cast<bool>(map.inverse(test_mapped_point5)));
   if (map.inverse(test_mapped_point6)) {
     Approx my_approx = Approx::custom().epsilon(1.e-10).scale(1.0);
-    CHECK_ITERABLE_CUSTOM_APPROX(map(map.inverse(test_mapped_point6).get()),
+    CHECK_ITERABLE_CUSTOM_APPROX(map(map.inverse(test_mapped_point6).value()),
                                  test_mapped_point6, my_approx);
   }
   if (map.inverse(test_mapped_point7)) {
-    CHECK_ITERABLE_APPROX(map(map.inverse(test_mapped_point7).get()),
+    CHECK_ITERABLE_APPROX(map(map.inverse(test_mapped_point7).value()),
                           test_mapped_point7);
   }
 }

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_CubicScale.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_CubicScale.cpp
@@ -4,8 +4,8 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <array>
-#include <boost/optional.hpp>
 #include <cstddef>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -102,7 +102,7 @@ void test_boundaries() {
       REQUIRE(
           static_cast<bool>(scale_map.inverse(mapped_point, t, f_of_t_list)));
       CHECK_ITERABLE_APPROX(
-          scale_map.inverse(mapped_point, t, f_of_t_list).get(), point_xi);
+          scale_map.inverse(mapped_point, t, f_of_t_list).value(), point_xi);
       t += dt;
     }
   };
@@ -197,11 +197,11 @@ void test(const bool linear_expansion) {
 
       CHECK_ITERABLE_APPROX(scale_map(point_xi, t, f_of_t_list), mapped_point);
       CHECK_ITERABLE_APPROX(
-          scale_map.inverse(mapped_point, t, f_of_t_list).get(), point_xi);
+          scale_map.inverse(mapped_point, t, f_of_t_list).value(), point_xi);
       CHECK_ITERABLE_APPROX(scale_map_deserialized(point_xi, t, f_of_t_list),
                             mapped_point);
       CHECK_ITERABLE_APPROX(
-          scale_map_deserialized.inverse(mapped_point, t, f_of_t_list).get(),
+          scale_map_deserialized.inverse(mapped_point, t, f_of_t_list).value(),
           point_xi);
 
       if (not linear_expansion) {

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_ProductMaps.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_ProductMaps.cpp
@@ -4,9 +4,9 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <array>
-#include <boost/optional.hpp>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <pup.h>
 #include <string>
 #include <unordered_map>
@@ -58,11 +58,11 @@ void test_product_of_2_maps_time_dep(
   CHECK(map2d(point_source_b, time, functions_of_time) == point_target_b);
   CHECK(map2d(point_xi, time, functions_of_time) == point_x);
 
-  CHECK(map2d.inverse(point_target_a, time, functions_of_time).get() ==
+  CHECK(map2d.inverse(point_target_a, time, functions_of_time).value() ==
         point_source_a);
-  CHECK(map2d.inverse(point_target_b, time, functions_of_time).get() ==
+  CHECK(map2d.inverse(point_target_b, time, functions_of_time).value() ==
         point_source_b);
-  CHECK_ITERABLE_APPROX(map2d.inverse(point_x, time, functions_of_time).get(),
+  CHECK_ITERABLE_APPROX(map2d.inverse(point_x, time, functions_of_time).value(),
                         point_xi);
 
   const double inv_jacobian_00 =
@@ -317,11 +317,11 @@ void test_product_of_3_maps_time_dep(
   CHECK(map3d(point_source_b, time, functions_of_time) == point_target_b);
   CHECK(map3d(point_xi, time, functions_of_time) == point_x);
 
-  CHECK(map3d.inverse(point_target_a, time, functions_of_time).get() ==
+  CHECK(map3d.inverse(point_target_a, time, functions_of_time).value() ==
         point_source_a);
-  CHECK(map3d.inverse(point_target_b, time, functions_of_time).get() ==
+  CHECK(map3d.inverse(point_target_b, time, functions_of_time).value() ==
         point_source_b);
-  CHECK_ITERABLE_APPROX(map3d.inverse(point_x, time, functions_of_time).get(),
+  CHECK_ITERABLE_APPROX(map3d.inverse(point_x, time, functions_of_time).value(),
                         point_xi);
 
   const double inv_jacobian_00 =

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_Translation.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_Translation.cpp
@@ -4,9 +4,9 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <array>
-#include <boost/optional.hpp>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -54,7 +54,8 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.TimeDependent.Translation",
     CHECK_ITERABLE_APPROX(trans_map(point_xi, t, f_of_t_list),
                           point_xi + trans_x);
     CHECK_ITERABLE_APPROX(
-        trans_map.inverse(point_xi + trans_x, t, f_of_t_list).get(), point_xi);
+        trans_map.inverse(point_xi + trans_x, t, f_of_t_list).value(),
+        point_xi);
     CHECK_ITERABLE_APPROX(trans_map.frame_velocity(point_xi, t, f_of_t_list),
                           frame_vel);
 
@@ -62,7 +63,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.TimeDependent.Translation",
                           point_xi + trans_x);
     CHECK_ITERABLE_APPROX(
         trans_map_deserialized.inverse(point_xi + trans_x, t, f_of_t_list)
-            .get(),
+            .value(),
         point_xi);
     CHECK_ITERABLE_APPROX(trans_map_deserialized.frame_velocity(
                               point_xi + trans_x, t, f_of_t_list),

--- a/tests/Unit/Domain/Test_Block.cpp
+++ b/tests/Unit/Domain/Test_Block.cpp
@@ -56,7 +56,7 @@ void test_block_time_independent() {
     const tnsr::I<double, Dim, Frame::Logical> xi(1.0);
     const tnsr::I<double, Dim, Frame::Inertial> x(1.0);
     CHECK(map(xi) == x);
-    CHECK(map.inverse(x).get() == xi);
+    CHECK(map.inverse(x).value() == xi);
   };
 
   check_block(original_block);
@@ -160,11 +160,10 @@ void test_block_time_dependent() {
     const tnsr::I<double, Dim, Frame::Inertial> x(1.0 + time);
     CHECK(grid_to_inertial_map(logical_to_grid_map(xi), time,
                                functions_of_time) == x);
-    CHECK(
-        logical_to_grid_map
-            .inverse(
-                grid_to_inertial_map.inverse(x, time, functions_of_time).get())
-            .get() == xi);
+    CHECK(logical_to_grid_map
+              .inverse(grid_to_inertial_map.inverse(x, time, functions_of_time)
+                           .value())
+              .value() == xi);
   };
 
   check_block(original_block);

--- a/tests/Unit/Domain/Test_ElementMap.cpp
+++ b/tests/Unit/Domain/Test_ElementMap.cpp
@@ -64,9 +64,9 @@ void test_element_impl(
 
   if (test_inverse) {
     CHECK(element_map.inverse(inertial_point_double) ==
-          composed_map.inverse(inertial_point_double).get());
+          composed_map.inverse(inertial_point_double).value());
     CHECK(element_map_deserialized.inverse(inertial_point_double) ==
-          composed_map.inverse(inertial_point_double).get());
+          composed_map.inverse(inertial_point_double).value());
   }
 
   CHECK_ITERABLE_APPROX(element_map.inv_jacobian(logical_point_dv),

--- a/tests/Unit/Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -392,7 +392,7 @@ void test_coordinate_map_argument_types(
 template <typename Map, typename T>
 void test_inverse_map(const Map& map,
                       const std::array<T, Map::dim>& test_point) noexcept {
-  CHECK_ITERABLE_APPROX(test_point, map.inverse(map(test_point)).get());
+  CHECK_ITERABLE_APPROX(test_point, map.inverse(map(test_point)).value());
 }
 
 /*!

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
@@ -4,9 +4,9 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <array>
-#include <boost/optional.hpp>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <pup.h>
 #include <random>
 #include <string>
@@ -127,7 +127,7 @@ void test_interpolate_to_points(const Mesh<Dim>& mesh) noexcept {
       for (size_t d = 0; d < Dim; ++d) {
         x_inertial_local.get(d) = target_x_inertial.get(d)[s];
       }
-      const auto x_local = coordinate_map.inverse(x_inertial_local).get();
+      const auto x_local = coordinate_map.inverse(x_inertial_local).value();
       for (size_t d = 0; d < Dim; ++d) {
         result.get(d)[s] = x_local.get(d);
       }


### PR DESCRIPTION
## Proposed changes

Replace boost::optional -> std::optional in CoordinateMaps

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

This will fail clang-tidy with
1. The usual complaints from the boost toms rootfinder internals
2. A warning about moving out of a helper function... seems strange to me because I'd expect this to fall under RVO. Is this a false positive or am I missing something?