### PR TITLE
Observe analytic solutions if available

### DIFF
--- a/src/Elliptic/Actions/InitializeAnalyticSolution.hpp
+++ b/src/Elliptic/Actions/InitializeAnalyticSolution.hpp
@@ -26,20 +26,29 @@ struct Inertial;
 }  // namespace Frame
 /// \endcond
 
-namespace elliptic {
-namespace Actions {
+namespace elliptic::Actions {
 
+// @{
 /*!
  * \brief Place the analytic solution of the system fields in the DataBox.
  *
+ * Use `InitializeAnalyticSolution` if it is clear at compile-time that an
+ * analytic solution is available, and `InitializeOptionalAnalyticSolution` if
+ * that is a runtime decision, e.g. based on a choice in the input file. The
+ * `::Tags::AnalyticSolutionsBase` tag can be retrieved from the DataBox in
+ * either case, but it will hold a `std::optional` when
+ * `InitializeOptionalAnalyticSolution` is used. In that case, the analytic
+ * solution is only evaluated and stored in the DataBox if the `BackgroundTag`
+ * holds a type that inherits from the `AnalyticSolutionType`.
+ *
  * Uses:
  * - DataBox:
- *   - `AnalyticSolutionTag`
+ *   - `AnalyticSolutionTag` or `BackgroundTag`
  *   - `Tags::Coordinates<Dim, Frame::Inertial>`
  *
  * DataBox:
  * - Adds:
- *   - `db::wrap_tags_in<::Tags::Analytic, AnalyticSolutionFields>`
+ *   - `::Tags::AnalyticSolutionsBase`
  *
  * \note This action relies on the `SetupDataBox` aggregated initialization
  * mechanism, so `Actions::SetupDataBox` must be present in the `Initialization`
@@ -47,34 +56,64 @@ namespace Actions {
  */
 template <typename AnalyticSolutionTag, typename AnalyticSolutionFields>
 struct InitializeAnalyticSolution {
-  using const_global_cache_tags = tmpl::list<AnalyticSolutionTag>;
-  using analytic_fields_tag =
-      db::add_tag_prefix<::Tags::Analytic,
-                          ::Tags::Variables<AnalyticSolutionFields>>;
+ private:
+  using analytic_fields_tag = ::Tags::AnalyticSolutions<AnalyticSolutionFields>;
 
+ public:
   using simple_tags = tmpl::list<analytic_fields_tag>;
   using compute_tags = tmpl::list<>;
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             size_t Dim, typename ActionList, typename ParallelComponent>
-  static auto apply(db::DataBox<DbTagsList>& box,
-                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-                    const Parallel::GlobalCache<Metavariables>& cache,
-                    const ElementId<Dim>& /*array_index*/,
-                    const ActionList /*meta*/,
-                    const ParallelComponent* const /*meta*/) noexcept {
-
+  static std::tuple<db::DataBox<DbTagsList>&&> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ElementId<Dim>& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
     const auto& inertial_coords =
         get<domain::Tags::Coordinates<Dim, Frame::Inertial>>(box);
-    typename analytic_fields_tag::type analytic_fields{
-        variables_from_tagged_tuple(get<AnalyticSolutionTag>(cache).variables(
-            inertial_coords, AnalyticSolutionFields{}))};
+    const auto& analytic_solution = get<AnalyticSolutionTag>(box);
+    auto analytic_fields = variables_from_tagged_tuple(
+        analytic_solution.variables(inertial_coords, AnalyticSolutionFields{}));
     Initialization::mutate_assign<simple_tags>(make_not_null(&box),
                                                std::move(analytic_fields));
-
-    return std::make_tuple(std::move(box));
+    return {std::move(box)};
   }
 };
 
-}  // namespace Actions
-}  // namespace elliptic
+template <typename BackgroundTag, typename AnalyticSolutionFields,
+          typename AnalyticSolutionType>
+struct InitializeOptionalAnalyticSolution {
+ private:
+  using analytic_fields_tag =
+      ::Tags::AnalyticSolutionsOptional<AnalyticSolutionFields>;
+
+ public:
+  using simple_tags = tmpl::list<analytic_fields_tag>;
+  using compute_tags = tmpl::list<>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            size_t Dim, typename ActionList, typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ElementId<Dim>& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    const auto analytic_solution =
+        dynamic_cast<const AnalyticSolutionType*>(&db::get<BackgroundTag>(box));
+    if (analytic_solution != nullptr) {
+      const auto& inertial_coords =
+          get<domain::Tags::Coordinates<Dim, Frame::Inertial>>(box);
+      auto analytic_fields =
+          variables_from_tagged_tuple(analytic_solution->variables(
+              inertial_coords, AnalyticSolutionFields{}));
+      Initialization::mutate_assign<simple_tags>(make_not_null(&box),
+                                                 std::move(analytic_fields));
+    }
+    return {std::move(box)};
+  }
+};
+// @}
+}  // namespace elliptic::Actions

--- a/src/Evolution/ComputeTags.hpp
+++ b/src/Evolution/ComputeTags.hpp
@@ -21,12 +21,9 @@ namespace Tags {
  */
 template <size_t Dim, typename AnalyticSolutionTag,
           typename AnalyticFieldsTagList>
-struct AnalyticCompute
-    : db::add_tag_prefix<::Tags::Analytic,
-                         ::Tags::Variables<AnalyticFieldsTagList>>,
-      db::ComputeTag {
-  using base = db::add_tag_prefix<::Tags::Analytic,
-                                  ::Tags::Variables<AnalyticFieldsTagList>>;
+struct AnalyticCompute : ::Tags::AnalyticSolutions<AnalyticFieldsTagList>,
+                         db::ComputeTag {
+  using base = ::Tags::AnalyticSolutions<AnalyticFieldsTagList>;
   using return_type = typename base::type;
   using argument_tags =
       tmpl::list<AnalyticSolutionTag,

--- a/src/PointwiseFunctions/AnalyticSolutions/Tags.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Tags.hpp
@@ -3,7 +3,11 @@
 
 #pragma once
 
+#include <optional>
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Variables.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/Serialize.hpp"
 #include "PointwiseFunctions/AnalyticData/Tags.hpp"
@@ -93,5 +97,26 @@ template <typename Tag>
 struct Error : db::PrefixTag, db::SimpleTag {
   using type = typename Tag::type;
   using tag = Tag;
+};
+
+/// Base tag for the analytic solution tensors. Retrieved values can be either
+/// `Variables` or `std::optional<Variables>`.
+///
+/// \see ::Tags::AnalyticSolutions
+struct AnalyticSolutionsBase : db::BaseTag {};
+
+/// The analytic solutions for all `FieldTags`
+template <typename FieldTags>
+struct AnalyticSolutions : AnalyticSolutionsBase, db::SimpleTag {
+  using type = ::Variables<db::wrap_tags_in<Analytic, FieldTags>>;
+};
+
+/// The analytic solutions for all `FieldTags`, or `std::nullopt` if no analytic
+/// solutions are available
+template <typename FieldTags>
+struct AnalyticSolutionsOptional : AnalyticSolutionsBase, db::SimpleTag {
+  static std::string name() noexcept { return "AnalyticSolutions"; }
+  using type =
+      std::optional<::Variables<db::wrap_tags_in<Analytic, FieldTags>>>;
 };
 }  // namespace Tags

--- a/tests/Unit/Elliptic/Actions/Test_InitializeAnalyticSolution.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeAnalyticSolution.cpp
@@ -5,6 +5,8 @@
 
 #include <array>
 #include <cstddef>
+#include <memory>
+#include <pup.h>
 #include <string>
 
 #include "DataStructures/DataBox/Tag.hpp"
@@ -14,7 +16,9 @@
 #include "Elliptic/Actions/InitializeAnalyticSolution.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/CharmPupable.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -25,87 +29,139 @@ struct ScalarFieldTag : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 
-template <size_t Dim>
-struct AnalyticSolution {
-  tuples::TaggedTuple<ScalarFieldTag> variables(
-      const tnsr::I<DataVector, Dim, Frame::Inertial>& x,
-      tmpl::list<ScalarFieldTag> /*meta*/) const noexcept {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+struct AnalyticSolution;
+
+struct AnalyticSolutionOrData : PUP::able {
+  AnalyticSolutionOrData() = default;
+  explicit AnalyticSolutionOrData(CkMigrateMessage* m) : PUP::able(m) {}
+  WRAPPED_PUPable_decl(AnalyticSolutionOrData);
+
+  // Base class does _not_ provide variables for all system fields
+};
+
+PUPable_def(AnalyticSolutionOrData)
+
+struct AnalyticSolution : AnalyticSolutionOrData {
+  AnalyticSolution() = default;
+  explicit AnalyticSolution(CkMigrateMessage* m) : AnalyticSolutionOrData(m) {}
+  WRAPPED_PUPable_decl(AnalyticSolution);
+
+  static tuples::TaggedTuple<ScalarFieldTag> variables(
+      const tnsr::I<DataVector, 1>& x,
+      tmpl::list<ScalarFieldTag> /*meta*/) noexcept {
     Scalar<DataVector> solution{2. * get<0>(x)};
-    for (size_t d = 1; d < Dim; d++) {
-      get(solution) += 2. * x.get(d);
-    }
     return {std::move(solution)};
   }
-  // clang-tidy: do not use references
-  void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
 };
 
-template <size_t Dim>
+PUPable_def(AnalyticSolution)
+#pragma GCC diagnostic pop
+
 struct AnalyticSolutionTag : db::SimpleTag {
-  using type = AnalyticSolution<Dim>;
+  using type = AnalyticSolution;
 };
 
-template <size_t Dim, typename Metavariables>
+struct AnalyticSolutionOrDataTag : db::SimpleTag {
+  using type = std::unique_ptr<AnalyticSolutionOrData>;
+};
+
+template <bool Optional, typename Metavariables>
 struct ElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
-  using array_index = ElementId<Dim>;
+  using array_index = ElementId<1>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<
-              tmpl::list<domain::Tags::Coordinates<Dim, Frame::Inertial>>>>>,
+              tmpl::list<domain::Tags::Coordinates<1, Frame::Inertial>>>>>,
 
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Testing,
           tmpl::list<
               Actions::SetupDataBox,
-              elliptic::Actions::InitializeAnalyticSolution<
-                  AnalyticSolutionTag<Dim>, tmpl::list<ScalarFieldTag>>>>>;
+              tmpl::conditional_t<
+                  Optional,
+                  elliptic::Actions::InitializeOptionalAnalyticSolution<
+                      AnalyticSolutionOrDataTag, tmpl::list<ScalarFieldTag>,
+                      AnalyticSolution>,
+                  elliptic::Actions::InitializeAnalyticSolution<
+                      AnalyticSolutionTag, tmpl::list<ScalarFieldTag>>>>>>;
 };
 
-template <size_t Dim>
+template <bool Optional>
 struct Metavariables {
-  using element_array = ElementArray<Dim, Metavariables>;
+  using element_array = ElementArray<Optional, Metavariables>;
+  using const_global_cache_tags =
+      tmpl::list<tmpl::conditional_t<Optional, AnalyticSolutionOrDataTag,
+                                     AnalyticSolutionTag>>;
   using component_list = tmpl::list<element_array>;
   enum class Phase { Initialization, Testing, Exit };
 };
 
-template <size_t Dim>
+template <bool Optional>
 void test_initialize_analytic_solution(
-    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords,
+    const tnsr::I<DataVector, 1>& inertial_coords,
     const Scalar<DataVector>& expected_solution) {
-  using metavariables = Metavariables<Dim>;
+  using metavariables = Metavariables<Optional>;
   using element_array = typename metavariables::element_array;
-  const ElementId<Dim> element_id{0};
-  ActionTesting::MockRuntimeSystem<metavariables> runner{
-      {AnalyticSolution<Dim>{}}};
-  ActionTesting::emplace_component_and_initialize<element_array>(
-      &runner, element_id, {inertial_coords});
-  ActionTesting::set_phase(make_not_null(&runner),
-                           metavariables::Phase::Testing);
-  for (size_t i = 0; i < 2; ++i) {
-    ActionTesting::next_action<element_array>(make_not_null(&runner),
-                                              element_id);
+
+  const auto initialize_analytic_solution =
+      [&inertial_coords](auto analytic_solution_or_data) {
+        ActionTesting::MockRuntimeSystem<metavariables> runner{
+            {std::move(analytic_solution_or_data)}};
+        const ElementId<1> element_id{0};
+        ActionTesting::emplace_component_and_initialize<element_array>(
+            &runner, element_id, {inertial_coords});
+        ActionTesting::set_phase(make_not_null(&runner),
+                                 metavariables::Phase::Testing);
+        for (size_t i = 0; i < 2; ++i) {
+          ActionTesting::next_action<element_array>(make_not_null(&runner),
+                                                    element_id);
+        }
+        return ActionTesting::get_databox_tag<element_array,
+                                              ::Tags::AnalyticSolutionsBase>(
+            runner, element_id);
+      };
+
+  if constexpr (Optional) {
+    {
+      INFO("Analytic solution is available");
+      const auto analytic_solutions =
+          initialize_analytic_solution(std::make_unique<AnalyticSolution>());
+      REQUIRE(analytic_solutions.has_value());
+      CHECK_ITERABLE_APPROX(
+          get(get<::Tags::Analytic<ScalarFieldTag>>(*analytic_solutions)),
+          get(expected_solution));
+    }
+    {
+      INFO("No analytic solution is available");
+      const auto no_analytic_solutions = initialize_analytic_solution(
+          std::make_unique<AnalyticSolutionOrData>());
+      CHECK_FALSE(no_analytic_solutions.has_value());
+    }
+  } else {
+    const auto analytic_solutions =
+        initialize_analytic_solution(AnalyticSolution{});
+    CHECK_ITERABLE_APPROX(
+        get(get<::Tags::Analytic<ScalarFieldTag>>(analytic_solutions)),
+        get(expected_solution));
   }
-  CHECK_ITERABLE_APPROX(
-      get(ActionTesting::get_databox_tag<element_array,
-                                         ::Tags::Analytic<ScalarFieldTag>>(
-          runner, element_id)),
-      get(expected_solution));
 }
 
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeAnalyticSolution",
                   "[Unit][Elliptic][Actions]") {
-  test_initialize_analytic_solution(
-      tnsr::I<DataVector, 1, Frame::Inertial>{{{{1., 2., 3., 4.}}}},
+  PUPable_reg(AnalyticSolutionOrData);
+  PUPable_reg(AnalyticSolution);
+
+  test_initialize_analytic_solution<false>(
+      tnsr::I<DataVector, 1>{{{{1., 2., 3., 4.}}}},
       Scalar<DataVector>{{{{2., 4., 6., 8.}}}});
-  test_initialize_analytic_solution(
-      tnsr::I<DataVector, 2, Frame::Inertial>{{{{1., 2.}, {3., 4.}}}},
-      Scalar<DataVector>{{{{8., 12.}}}});
-  test_initialize_analytic_solution(
-      tnsr::I<DataVector, 3, Frame::Inertial>{{{{1., 2.}, {3., 4.}, {5., 6.}}}},
-      Scalar<DataVector>{{{{18., 24.}}}});
+  test_initialize_analytic_solution<true>(
+      tnsr::I<DataVector, 1>{{{{1., 2., 3., 4.}}}},
+      Scalar<DataVector>{{{{2., 4., 6., 8.}}}});
 }

--- a/tests/Unit/Evolution/Test_ComputeTags.cpp
+++ b/tests/Unit/Evolution/Test_ComputeTags.cpp
@@ -55,8 +55,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.ComputeTags", "[Unit][Evolution]") {
   CHECK_ITERABLE_APPROX(get(get<::Tags::Analytic<FieldTag>>(box)), expected);
 
   TestHelpers::db::test_compute_tag<evolution::Tags::AnalyticCompute<
-      1, AnalyticSolutionTag, tmpl::list<FieldTag>>>(
-      "Variables(Analytic(FieldTag))");
+      1, AnalyticSolutionTag, tmpl::list<FieldTag>>>("AnalyticSolutions");
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.ComputeTags.Errors",

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Test_Tags.cpp
@@ -30,4 +30,11 @@ SPECTRE_TEST_CASE("Unit.AnalyticSolutions.Tags", "[Unit][PointwiseFunctions]") {
       "Analytic(DummyTag)");
   /// [analytic_name]
   TestHelpers::db::test_prefix_tag<Tags::Error<DummyTag>>("Error(DummyTag)");
+  TestHelpers::db::test_base_tag<Tags::AnalyticSolutionsBase>(
+      "AnalyticSolutionsBase");
+  TestHelpers::db::test_simple_tag<
+      Tags::AnalyticSolutionsOptional<tmpl::list<DummyTag>>>(
+      "AnalyticSolutions");
+  TestHelpers::db::test_simple_tag<
+      Tags::AnalyticSolutions<tmpl::list<DummyTag>>>("AnalyticSolutions");
 }


### PR DESCRIPTION
## Proposed changes

`ObserveFields` and `ObserveErrorNorms` now support checking at runtime whether or not an analytic solution is available. The check is disabled when no analytic solution tensors are given at compile-time. This is in preparation for #2603, i.e. to allow factory-creating the elliptic solver background (analytic solution or data).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
- If you retrieved analytic solutions from the DataBox as `::Tags::Analytic<Tag>`, update your code to retrieve `::Tags::AnalyticSolutionsBase` instead. It currently always holds a `Variables` from which you can retrieve the analytic solution fields as `::Tags::Analytic<Tag>` the same way you did before. In the future it may hold a `std::optional<Variables>` in cases where it is not clear at compile-time that analytic solutions are available.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
