### PR TITLE
Update ocean to cmake 3.18.5

### DIFF
--- a/support/Environments/ocean_clang.sh
+++ b/support/Environments/ocean_clang.sh
@@ -22,7 +22,7 @@ spectre_unload_modules() {
     module unload gnu7/7.3.0
     module unload openmpi/1.10.7
     module unload prun/1.2
-    module unload cmake-3.13.1-gcc-7.3.0-r7qr3qo
+    module unload cmake/3.18.5
     module unload git-2.19.2-gcc-7.3.0-jfnpgdh
     module unload blaze-3.7-gcc-7.3.0-6o4boto
     module unload brigand-master-gcc-7.3.0-3m5ibui
@@ -47,7 +47,7 @@ spectre_load_modules() {
     module load prun/1.2
     module load llvm/10.0.1
     source /opt/ohpc/pub/apps/spack/0.12.0/share/spack/setup-env.sh
-    module load cmake-3.13.1-gcc-7.3.0-r7qr3qo
+    module load cmake/3.18.5
     module load git-2.19.2-gcc-7.3.0-jfnpgdh
     module load blaze-3.7-gcc-7.3.0-6o4boto
     module load brigand-master-gcc-7.3.0-3m5ibui

--- a/support/Environments/ocean_gcc.sh
+++ b/support/Environments/ocean_gcc.sh
@@ -26,7 +26,7 @@ spectre_unload_modules() {
     module unload blaze-3.5-gcc-7.3.0-dtnocst
     module unload brigand-master-gcc-7.3.0-3m5ibui
     module unload libsharp-2018-01-17-gcc-7.3.0-4xamgaw
-    module unload catch2-2.11.3-gcc-7.3.0-l7lqzrg
+    module unload cmake/3.18.5
     module unload gsl-2.5-gcc-7.3.0-i7icadp
     module unload jemalloc-4.5.0-gcc-7.3.0-wlf2m7r
     module unload libxsmm-1.10-gcc-7.3.0-sjh5yzv
@@ -50,7 +50,7 @@ spectre_load_modules() {
     module load blaze-3.5-gcc-7.3.0-dtnocst
     module load brigand-master-gcc-7.3.0-3m5ibui
     module load libsharp-2018-01-17-gcc-7.3.0-4xamgaw
-    module load catch2-2.11.3-gcc-7.3.0-l7lqzrg
+    module load cmake/3.18.5
     module load gsl-2.5-gcc-7.3.0-i7icadp
     module load jemalloc-4.5.0-gcc-7.3.0-wlf2m7r
     module load libxsmm-1.10-gcc-7.3.0-sjh5yzv


### PR DESCRIPTION
## Proposed changes

Update CMake to 3.18.5 on ocean.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
