### PR TITLE
Allow undefined symbols on Darwin for InfoAtLink

### DIFF
--- a/src/Domain/CMakeLists.txt
+++ b/src/Domain/CMakeLists.txt
@@ -50,6 +50,7 @@ target_link_libraries(
   ${LIBRARY}
   PUBLIC
   Boost::boost
+  CoordinateMaps
   DataStructures
   DomainStructure
   ErrorHandling
@@ -58,7 +59,6 @@ target_link_libraries(
   INTERFACE
   FunctionsOfTime
   Time
-  CoordinateMaps
   DomainCreators
   Spectral
   )

--- a/src/IO/CMakeLists.txt
+++ b/src/IO/CMakeLists.txt
@@ -28,6 +28,8 @@ target_link_libraries(
   Options
   Spectral
   Utilities
+  PRIVATE
+  Informer
   INTERFACE
   Spectral
   )

--- a/src/Informer/CMakeLists.txt
+++ b/src/Informer/CMakeLists.txt
@@ -34,6 +34,13 @@ spectre_target_headers(
   Verbosity.hpp
   )
 
+# The Darwin linker is not OK with undefined symbols at link time of the
+# library, so we need to appease it. This is needed so compiling InfoAtLink.cpp
+# can be deferred until we link an executable.
+target_link_options(
+  ${LIBRARY}
+  PUBLIC "$<$<PLATFORM_ID:Darwin>:-Wl,-U,_info_from_build>")
+
 target_link_libraries(
   ${LIBRARY}
   PUBLIC

--- a/src/Informer/InfoFromBuild.hpp
+++ b/src/Informer/InfoFromBuild.hpp
@@ -15,8 +15,21 @@
  * The information returned by this function is invaluable for identifying
  * the version of the code used in a simulation, as well as which host, the
  * date the code was compiled, and the time of linkage.
+ *
+ * We declare the function `extern "C"` so its symbol is not mangled and we can
+ * ignore that it is undefined until link time (see `CMakeLists.txt`). Note that
+ * the `std::string` return type is not compatible with C, but that's OK as long
+ * as we're not calling or defining the function in C. See Microsoft's C4190:
+ * https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4190
  */
-std::string info_from_build();
+#if defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wreturn-type-c-linkage"
+#endif  // defined(__clang__)
+extern "C" std::string info_from_build();
+#if defined(__clang__)
+#pragma GCC diagnostic pop
+#endif  // defined(__clang__)
 
 /*!
  * \ingroup LoggingGroup

--- a/src/PythonBindings/CMakeLists.txt
+++ b/src/PythonBindings/CMakeLists.txt
@@ -2,11 +2,29 @@
 # See LICENSE.txt for details.
 
 if (${BUILD_PYTHON_BINDINGS})
-  set(LIBRARY "PyBindings")
+  set(LIBRARY PyBindings)
 
-  set(LIBRARY_SOURCES
+  add_spectre_library(${LIBRARY})
+
+  spectre_target_sources(
+    ${LIBRARY}
+    PRIVATE
     CharmCompatibility.cpp
+    InfoAtLink.cpp
     )
 
-  add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+  spectre_target_headers(
+    ${LIBRARY}
+    INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+    HEADERS
+    BoundChecks.hpp
+    )
+
+  target_link_libraries(
+    ${LIBRARY}
+    PRIVATE
+    Informer
+    INTERFACE
+    Utilities
+    )
 endif()

--- a/src/PythonBindings/CharmCompatibility.cpp
+++ b/src/PythonBindings/CharmCompatibility.cpp
@@ -96,7 +96,6 @@ void LrtsDestroyLock(LrtsNodeLock /*lock*/) {
       "Charm++ and is not intended to be called."};
 }
 
-std::string info_from_build() { return "build_info"; }
 void CmiAbort(const char* msg) {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
   fprintf(stderr, "%s", msg);

--- a/src/PythonBindings/InfoAtLink.cpp
+++ b/src/PythonBindings/InfoAtLink.cpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Informer/InfoFromBuild.hpp"
+
+#include <string>
+
+std::string info_from_build() { return "build_info"; }


### PR DESCRIPTION
## Proposed changes

The Darwin linker doesn't allow undefined symbols by default, as the Linux linker does. This is needed when building with shared libs.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
