### PR TITLE
Time dependent triple gaussian

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   GaussianPlusConstant.cpp
   RegisterDerivedWithCharm.cpp
+  TimeDependentTripleGaussian.cpp
   )
 
 spectre_target_headers(
@@ -20,6 +21,7 @@ spectre_target_headers(
   GaussianPlusConstant.hpp
   RegisterDerivedWithCharm.hpp
   Tags.hpp
+  TimeDependentTripleGaussian.hpp
   )
 
 target_link_libraries(

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/DampingFunction.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/DampingFunction.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
@@ -24,6 +25,7 @@ namespace GeneralizedHarmonic::ConstraintDamping {
 /// \cond
 template <size_t VolumeDim, typename Fr>
 class GaussianPlusConstant;
+class TimeDependentTripleGaussian;
 /// \endcond
 
 /*!
@@ -36,9 +38,14 @@ class GaussianPlusConstant;
 template <size_t VolumeDim, typename Fr>
 class DampingFunction : public PUP::able {
  public:
-  using creatable_classes =
+  using creatable_classes = tmpl::conditional_t<
+      (VolumeDim == 3 and std::is_same<Fr, Frame::Grid>::value),
+      tmpl::list<
+          GeneralizedHarmonic::ConstraintDamping::GaussianPlusConstant<
+              VolumeDim, Fr>,
+          GeneralizedHarmonic::ConstraintDamping::TimeDependentTripleGaussian>,
       tmpl::list<GeneralizedHarmonic::ConstraintDamping::GaussianPlusConstant<
-          VolumeDim, Fr>>;
+          VolumeDim, Fr>>>;
   constexpr static size_t volume_dim = VolumeDim;
   using frame = Fr;
 
@@ -77,3 +84,4 @@ class DampingFunction : public PUP::able {
 }  // namespace GeneralizedHarmonic::ConstraintDamping
 
 #include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/GaussianPlusConstant.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TimeDependentTripleGaussian.hpp"

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/DampingFunction.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/DampingFunction.hpp
@@ -51,6 +51,8 @@ class DampingFunction : public PUP::able {
   DampingFunction& operator=(DampingFunction&& /*rhs*/) noexcept = default;
   ~DampingFunction() override = default;
 
+  explicit DampingFunction(CkMigrateMessage* msg) noexcept : PUP::able(msg) {}
+
   //@{
   /// Returns the value of the function at the coordinate 'x'.
   virtual void operator()(

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/GaussianPlusConstant.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/GaussianPlusConstant.cpp
@@ -46,8 +46,8 @@ void GaussianPlusConstant<VolumeDim, Fr>::apply_call_operator(
     centered_coords.get(i) -= gsl::at(center_, i);
   }
   dot_product(value_at_x, centered_coords, centered_coords);
-  value_at_x->get() =
-      constant_ + amplitude_ * exp(-value_at_x->get() * square(inverse_width_));
+  get(*value_at_x) =
+      constant_ + amplitude_ * exp(-get(*value_at_x) * square(inverse_width_));
 }
 
 template <size_t VolumeDim, typename Fr>
@@ -56,7 +56,7 @@ void GaussianPlusConstant<VolumeDim, Fr>::operator()(
     const tnsr::I<double, VolumeDim, Fr>& x, const double /*time*/,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-    /*funtions_of_time*/) const noexcept {
+    /*functions_of_time*/) const noexcept {
   apply_call_operator(value_at_x, x);
 }
 template <size_t VolumeDim, typename Fr>
@@ -65,7 +65,7 @@ void GaussianPlusConstant<VolumeDim, Fr>::operator()(
     const tnsr::I<DataVector, VolumeDim, Fr>& x, const double /*time*/,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-    /*funtions_of_time*/) const noexcept {
+    /*functions_of_time*/) const noexcept {
   destructive_resize_components(value_at_x, get<0>(x).size());
   apply_call_operator(value_at_x, x);
 }

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/GaussianPlusConstant.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/GaussianPlusConstant.cpp
@@ -26,6 +26,12 @@ class FunctionOfTime;
 /// \endcond
 
 namespace GeneralizedHarmonic::ConstraintDamping {
+/// \cond
+template <size_t VolumeDim, typename Fr>
+GaussianPlusConstant<VolumeDim, Fr>::GaussianPlusConstant(
+    CkMigrateMessage* msg) noexcept
+    : DampingFunction<VolumeDim, Fr>(msg) {}
+/// \endcond
 
 template <size_t VolumeDim, typename Fr>
 GaussianPlusConstant<VolumeDim, Fr>::GaussianPlusConstant(
@@ -90,6 +96,9 @@ auto GaussianPlusConstant<VolumeDim, Fr>::get_clone() const noexcept
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define INSTANTIATE(_, data)                                                  \
+  template GeneralizedHarmonic::ConstraintDamping::                           \
+      GaussianPlusConstant<DIM(data), FRAME(data)>::GaussianPlusConstant(     \
+          CkMigrateMessage* msg) noexcept;                                    \
   template GeneralizedHarmonic::ConstraintDamping::                           \
       GaussianPlusConstant<DIM(data), FRAME(data)>::GaussianPlusConstant(     \
           const double constant, const double amplitude, const double width,  \

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/GaussianPlusConstant.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/GaussianPlusConstant.hpp
@@ -70,7 +70,7 @@ class GaussianPlusConstant : public DampingFunction<VolumeDim, Fr> {
   WRAPPED_PUPable_decl_base_template(SINGLE_ARG(DampingFunction<VolumeDim, Fr>),
                                      GaussianPlusConstant);  // NOLINT
 
-  explicit GaussianPlusConstant(CkMigrateMessage* /*unused*/) noexcept {}
+  explicit GaussianPlusConstant(CkMigrateMessage* msg) noexcept;
   /// \endcond
 
   GaussianPlusConstant(double constant, double amplitude, double width,

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TimeDependentTripleGaussian.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TimeDependentTripleGaussian.cpp
@@ -1,0 +1,138 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TimeDependentTripleGaussian.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+#include <pup_stl.h>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace GeneralizedHarmonic::ConstraintDamping {
+TimeDependentTripleGaussian::TimeDependentTripleGaussian(
+    CkMigrateMessage* msg) noexcept
+    : DampingFunction<3, Frame::Grid>(msg) {}
+
+TimeDependentTripleGaussian::TimeDependentTripleGaussian(
+    const double constant, const double amplitude_1, const double width_1,
+    const std::array<double, 3>& center_1, const double amplitude_2,
+    const double width_2, const std::array<double, 3>& center_2,
+    const double amplitude_3, const double width_3,
+    const std::array<double, 3>& center_3,
+    std::string function_of_time_for_scaling) noexcept
+    : constant_(constant),
+      amplitude_1_(amplitude_1),
+      inverse_width_1_(1.0 / width_1),
+      center_1_(center_1),
+      amplitude_2_(amplitude_2),
+      inverse_width_2_(1.0 / width_2),
+      center_2_(center_2),
+      amplitude_3_(amplitude_3),
+      inverse_width_3_(1.0 / width_3),
+      center_3_(center_3),
+      function_of_time_for_scaling_(std::move(function_of_time_for_scaling)) {}
+
+template <typename T>
+void TimeDependentTripleGaussian::apply_call_operator(
+    const gsl::not_null<Scalar<T>*> value_at_x,
+    const tnsr::I<T, 3, Frame::Grid>& x, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept {
+  ASSERT(functions_of_time.at(function_of_time_for_scaling_)
+                 ->func(time)[0]
+                 .size() == 1,
+         "FunctionOfTimeForScaling in TimeDependentTripleGaussian must be a "
+         "scalar FunctionOfTime, not "
+             << functions_of_time.at(function_of_time_for_scaling_)
+                    ->func(time)[0]
+                    .size());
+  const double function_of_time_value =
+      functions_of_time.at(function_of_time_for_scaling_)->func(time)[0][0];
+
+  // Start by setting the result to the constant
+  get(*value_at_x) = constant_;
+
+  // Loop over the three Gaussians, adding each to the result
+  auto centered_coords = make_with_value<tnsr::I<T, 3, Frame::Grid>>(
+      get<0>(x), std::numeric_limits<double>::signaling_NaN());
+
+  const auto add_gauss_to_value_at_x =
+      [&value_at_x, &centered_coords, &x, &function_of_time_value](
+          const double amplitude, const double inverse_width,
+          const std::array<double, 3>& center) {
+        for (size_t i = 0; i < 3; ++i) {
+          centered_coords.get(i) = x.get(i) - gsl::at(center, i);
+        }
+        get(*value_at_x) +=
+            amplitude *
+            exp(-get(dot_product(centered_coords, centered_coords)) *
+                square(inverse_width * function_of_time_value));
+      };
+  add_gauss_to_value_at_x(amplitude_1_, inverse_width_1_, center_1_);
+  add_gauss_to_value_at_x(amplitude_2_, inverse_width_2_, center_2_);
+  add_gauss_to_value_at_x(amplitude_3_, inverse_width_3_, center_3_);
+}  // namespace GeneralizedHarmonic::ConstraintDamping
+
+void TimeDependentTripleGaussian::operator()(
+    const gsl::not_null<Scalar<double>*> value_at_x,
+    const tnsr::I<double, 3, Frame::Grid>& x, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept {
+  apply_call_operator(value_at_x, x, time, functions_of_time);
+}
+void TimeDependentTripleGaussian::operator()(
+    const gsl::not_null<Scalar<DataVector>*> value_at_x,
+    const tnsr::I<DataVector, 3, Frame::Grid>& x, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept {
+  destructive_resize_components(value_at_x, get<0>(x).size());
+  apply_call_operator(value_at_x, x, time, functions_of_time);
+}
+
+void TimeDependentTripleGaussian::pup(PUP::er& p) {
+  DampingFunction<3, Frame::Grid>::pup(p);
+  p | constant_;
+  p | amplitude_1_;
+  p | inverse_width_1_;
+  p | center_1_;
+  p | amplitude_2_;
+  p | inverse_width_2_;
+  p | center_2_;
+  p | amplitude_3_;
+  p | inverse_width_3_;
+  p | center_3_;
+  p | function_of_time_for_scaling_;
+}
+
+auto TimeDependentTripleGaussian::get_clone() const noexcept
+    -> std::unique_ptr<DampingFunction<3, Frame::Grid>> {
+  return std::make_unique<TimeDependentTripleGaussian>(*this);
+}
+
+bool operator!=(const TimeDependentTripleGaussian& lhs,
+                const TimeDependentTripleGaussian& rhs) noexcept {
+  return not(lhs == rhs);
+}
+}  // namespace GeneralizedHarmonic::ConstraintDamping
+/// \cond
+PUP::able::PUP_ID GeneralizedHarmonic::ConstraintDamping::
+    TimeDependentTripleGaussian::my_PUP_ID = 0;  // NOLINT
+/// \endcond

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TimeDependentTripleGaussian.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TimeDependentTripleGaussian.hpp
@@ -1,0 +1,189 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/DampingFunction.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace PUP {
+class er;
+}  // namespace PUP
+namespace domain::FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace domain::FunctionsOfTime
+/// \endcond
+
+namespace GeneralizedHarmonic::ConstraintDamping {
+/*!
+ * \brief A sum of three Gaussians plus a constant, where the Gaussian widths
+ * are scaled by a domain::FunctionsOfTime::FunctionOfTime.
+ *
+ * \details The function \f$f\f$ is given by
+ * \f{align}{
+ * f = C + \sum_{\alpha=1}^3
+ * A_\alpha \exp\left(-\frac{(x-(x_0)_\alpha)^2}{w_\alpha^2(t)}\right).
+ * \f}
+ * Input file options are: `Constant` \f$C\f$, `Amplitude[1-3]`
+ * \f$A_\alpha\f$, `Width[1-3]` \f$w_\alpha\f$, `Center[1-3]
+ * `\f$(x_0)_\alpha\f$, and `FunctionOfTimeForScaling`, a string naming a
+ * domain::FunctionsOfTime::FunctionOfTime in the domain::Tags::FunctionsOfTime
+ * that will be passed to the call operator. The function takes input
+ * coordinates \f$x\f$ of type `tnsr::I<T, 3, Frame::Grid>`, where `T` is e.g.
+ * `double` or `DataVector`; note that this DampingFunction is only defined
+ * for three spatial dimensions and for the grid frame. The Gaussian widths
+ * \f$w_\alpha\f$ are scaled by the inverse of the value of a scalar
+ * domain::FunctionsOfTime::FunctionOfTime \f$f(t)\f$ named
+ * `FunctionOfTimeForScaling`: \f$w_\alpha(t) = w_\alpha / f(t)\f$.
+ */
+class TimeDependentTripleGaussian : public DampingFunction<3, Frame::Grid> {
+ public:
+  template <size_t GaussianNumber>
+  struct Gaussian {
+    static constexpr Options::String help = {
+        "Parameters for one of the Gaussians."};
+    static std::string name() noexcept {
+      return "Gaussian" + std::to_string(GaussianNumber);
+    };
+  };
+  struct Constant {
+    using type = double;
+    static constexpr Options::String help = {"The constant."};
+  };
+
+  template <typename Group>
+  struct Amplitude {
+    using group = Group;
+    using type = double;
+    static constexpr Options::String help = {"The amplitude of the Gaussian."};
+  };
+
+  template <typename Group>
+  struct Width {
+    using group = Group;
+    using type = double;
+    static constexpr Options::String help = {
+        "The unscaled width of the Gaussian."};
+    static type lower_bound() noexcept { return 0.; }
+  };
+
+  template <typename Group>
+  struct Center {
+    using group = Group;
+    using type = std::array<double, 3>;
+    static constexpr Options::String help = {"The center of the Gaussian."};
+  };
+
+  struct FunctionOfTimeForScaling {
+    using type = std::string;
+    static constexpr Options::String help = {"The name of the FunctionOfTime."};
+  };
+
+  using options =
+      tmpl::list<Constant, Amplitude<Gaussian<1>>, Width<Gaussian<1>>,
+                 Center<Gaussian<1>>, Amplitude<Gaussian<2>>,
+                 Width<Gaussian<2>>, Center<Gaussian<2>>,
+                 Amplitude<Gaussian<3>>, Width<Gaussian<3>>,
+                 Center<Gaussian<3>>, FunctionOfTimeForScaling>;
+
+  static constexpr Options::String help = {
+      "Computes a sum of a constant and 3 Gaussians (each with its own "
+      "amplitude, width, and coordinate center), with the Gaussian widths "
+      "scaled by the inverse of a FunctionOfTime."};
+
+  /// \cond
+  WRAPPED_PUPable_decl_base_template(
+      SINGLE_ARG(DampingFunction<3, Frame::Grid>),
+      TimeDependentTripleGaussian);  // NOLINT
+  /// \endcond
+
+  explicit TimeDependentTripleGaussian(CkMigrateMessage* msg) noexcept;
+
+  TimeDependentTripleGaussian(
+      double constant, double amplitude_1, double width_1,
+      const std::array<double, 3>& center_1, double amplitude_2, double width_2,
+      const std::array<double, 3>& center_2, double amplitude_3, double width_3,
+      const std::array<double, 3>& center_3,
+      std::string function_of_time_for_scaling) noexcept;
+
+  TimeDependentTripleGaussian() = default;
+  ~TimeDependentTripleGaussian() override = default;
+  TimeDependentTripleGaussian(const TimeDependentTripleGaussian& /*rhs*/) =
+      default;
+  TimeDependentTripleGaussian& operator=(
+      const TimeDependentTripleGaussian& /*rhs*/) = default;
+  TimeDependentTripleGaussian(TimeDependentTripleGaussian&& /*rhs*/) noexcept =
+      default;
+  TimeDependentTripleGaussian& operator=(
+      TimeDependentTripleGaussian&& /*rhs*/) noexcept = default;
+
+  void operator()(const gsl::not_null<Scalar<double>*> value_at_x,
+                  const tnsr::I<double, 3, Frame::Grid>& x, double time,
+                  const std::unordered_map<
+                      std::string,
+                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+                      functions_of_time) const noexcept override;
+  void operator()(const gsl::not_null<Scalar<DataVector>*> value_at_x,
+                  const tnsr::I<DataVector, 3, Frame::Grid>& x, double time,
+                  const std::unordered_map<
+                      std::string,
+                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+                      functions_of_time) const noexcept override;
+
+  auto get_clone() const noexcept
+      -> std::unique_ptr<DampingFunction<3, Frame::Grid>> override;
+
+  // clang-tidy: google-runtime-references
+  void pup(PUP::er& p) override;  // NOLINT
+
+ private:
+  friend bool operator==(const TimeDependentTripleGaussian& lhs,
+                         const TimeDependentTripleGaussian& rhs) noexcept {
+    return lhs.constant_ == rhs.constant_ and
+           lhs.amplitude_1_ == rhs.amplitude_1_ and
+           lhs.inverse_width_1_ == rhs.inverse_width_1_ and
+           lhs.center_1_ == rhs.center_1_ and
+           lhs.amplitude_2_ == rhs.amplitude_2_ and
+           lhs.inverse_width_2_ == rhs.inverse_width_2_ and
+           lhs.center_2_ == rhs.center_2_ and
+           lhs.amplitude_3_ == rhs.amplitude_3_ and
+           lhs.inverse_width_3_ == rhs.inverse_width_3_ and
+           lhs.center_3_ == rhs.center_3_ and
+           lhs.function_of_time_for_scaling_ ==
+               rhs.function_of_time_for_scaling_;
+  }
+
+  double constant_ = std::numeric_limits<double>::signaling_NaN();
+  double amplitude_1_ = std::numeric_limits<double>::signaling_NaN();
+  double inverse_width_1_ = std::numeric_limits<double>::signaling_NaN();
+  std::array<double, 3> center_1_{};
+  double amplitude_2_ = std::numeric_limits<double>::signaling_NaN();
+  double inverse_width_2_ = std::numeric_limits<double>::signaling_NaN();
+  std::array<double, 3> center_2_{};
+  double amplitude_3_ = std::numeric_limits<double>::signaling_NaN();
+  double inverse_width_3_ = std::numeric_limits<double>::signaling_NaN();
+  std::array<double, 3> center_3_{};
+  std::string function_of_time_for_scaling_;
+
+  template <typename T>
+  void apply_call_operator(
+      const gsl::not_null<Scalar<T>*> value_at_x,
+      const tnsr::I<T, 3, Frame::Grid>& x, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
+};
+}  // namespace GeneralizedHarmonic::ConstraintDamping

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_GhConstraintDamping")
 
 set(LIBRARY_SOURCES
   Test_GaussianPlusConstant.cpp
+  Test_TimeDependentTripleGaussian.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Python/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Python/TestFunctions.py
@@ -15,7 +15,29 @@ def squared_distance_from_center(centered_coords, center):
 def gaussian_plus_constant_call_operator(coords, time, constant, amplitude,
                                          width, center):
     one_over_width = 1.0 / width
-    distance = squared_distance_from_center(
+    distance_squared = squared_distance_from_center(
         centered_coordinates(coords, center), center)
     return amplitude * np.exp(
-        -1.0 * distance * np.square(one_over_width)) + constant
+        -1.0 * distance_squared * np.square(one_over_width)) + constant
+
+
+def function_of_time(time):
+    # The test in tests/Unit/Helpers/Evolution/Systems/GeneralizedHarmonic/ \
+    # ConstraintDamping/TestHelpers.hpp hard-codes the following
+    # FunctionOfTime for evaluating time-dependent DampingFunctions
+    a = [1.0, 0.2, 0.03, 0.004]
+    return a[0] + a[1] * (time + 1.0) + a[2] * np.square(time + 1.0) + a[3] * (
+        time + 1.0) * (time + 1.0) * (time + 1.0)
+
+
+def time_dependent_triple_gaussian_call_operator(
+    coords, time, constant, amplitude_1, width_1, center_1, amplitude_2,
+    width_2, center_2, amplitude_3, width_3, center_3):
+    factor_scaling_widths = 1.0 / function_of_time(time)
+    return gaussian_plus_constant_call_operator(
+        coords, time, constant, amplitude_1, width_1 * factor_scaling_widths,
+        center_1) + gaussian_plus_constant_call_operator(
+            coords, time, 0.0, amplitude_2, width_2 * factor_scaling_widths,
+            center_2) + gaussian_plus_constant_call_operator(
+                coords, time, 0.0, amplitude_3,
+                width_3 * factor_scaling_widths, center_3)

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Test_GaussianPlusConstant.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Test_GaussianPlusConstant.cpp
@@ -47,7 +47,8 @@ void test_gaussian_plus_constant_random(
 
   TestHelpers::GeneralizedHarmonic::ConstraintDamping::check(
       std::move(gauss_plus_const), "gaussian_plus_constant", used_for_size,
-      {{{-1.0, 1.0}}}, constant, amplitude, width, center);
+      {{{-1.0, 1.0}}}, {"IgnoredFunctionOfTime"}, constant, amplitude, width,
+      center);
 
   std::unique_ptr<GeneralizedHarmonic::ConstraintDamping::GaussianPlusConstant<
       VolumeDim, Fr>>
@@ -58,8 +59,8 @@ void test_gaussian_plus_constant_random(
 
   TestHelpers::GeneralizedHarmonic::ConstraintDamping::check(
       std::move(gauss_plus_const_unique_ptr->get_clone()),
-      "gaussian_plus_constant", used_for_size, {{{-1.0, 1.0}}}, constant,
-      amplitude, width, center);
+      "gaussian_plus_constant", used_for_size, {{{-1.0, 1.0}}},
+      {"IgnoredFunctionOfTime"}, constant, amplitude, width, center);
 }
 }  // namespace
 

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Test_TimeDependentTripleGaussian.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Test_TimeDependentTripleGaussian.cpp
@@ -1,0 +1,165 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <random>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/DampingFunction.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TimeDependentTripleGaussian.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TestHelpers.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+template <typename DataType>
+void test_triple_gaussian_random(const DataType& used_for_size) noexcept {
+  Parallel::register_derived_classes_with_charm<
+      GeneralizedHarmonic::ConstraintDamping::TimeDependentTripleGaussian>();
+
+  // Generate the amplitude and width
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> real_dis(-1.0, 1.0);
+  std::uniform_real_distribution<> positive_dis(0.0, 1.0);
+
+  const double constant = real_dis(gen);
+
+  const double amplitude_1{positive_dis(gen)};
+  const double amplitude_2{positive_dis(gen)};
+  const double amplitude_3{positive_dis(gen)};
+
+  const double width_1{positive_dis(gen) + 0.5};
+  const double width_2{positive_dis(gen) + 0.5};
+  const double width_3{positive_dis(gen) + 0.5};
+
+  // Generate the center
+  std::array<double, 3> center_1{};
+  std::array<double, 3> center_2{};
+  std::array<double, 3> center_3{};
+  for (size_t i = 0; i < 3; ++i) {
+    gsl::at(center_1, i) = real_dis(gen);
+    gsl::at(center_2, i) = real_dis(gen);
+    gsl::at(center_3, i) = real_dis(gen);
+  }
+
+  // Name of FunctionOfTime to read
+  const std::string function_of_time_for_scaling{"ExpansionFactor"s};
+
+  GeneralizedHarmonic::ConstraintDamping::TimeDependentTripleGaussian
+      triple_gauss{constant,
+                   amplitude_1,
+                   width_1,
+                   center_1,
+                   amplitude_2,
+                   width_2,
+                   center_2,
+                   amplitude_3,
+                   width_3,
+                   center_3,
+                   function_of_time_for_scaling};
+
+  TestHelpers::GeneralizedHarmonic::ConstraintDamping::check(
+      std::move(triple_gauss), "time_dependent_triple_gaussian", used_for_size,
+      {{{-1.0, 1.0}}}, {function_of_time_for_scaling}, constant, amplitude_1,
+      width_1, center_1, amplitude_2, width_2, center_2, amplitude_3, width_3,
+      center_3);
+
+  std::unique_ptr<
+      GeneralizedHarmonic::ConstraintDamping::TimeDependentTripleGaussian>
+      triple_gauss_unique_ptr = std::make_unique<
+          GeneralizedHarmonic::ConstraintDamping::TimeDependentTripleGaussian>(
+          constant, amplitude_1, width_1, center_1, amplitude_2, width_2,
+          center_2, amplitude_3, width_3, center_3,
+          function_of_time_for_scaling);
+
+  TestHelpers::GeneralizedHarmonic::ConstraintDamping::check(
+      std::move(triple_gauss_unique_ptr->get_clone()),
+      "time_dependent_triple_gaussian", used_for_size, {{{-1.0, 1.0}}},
+      {function_of_time_for_scaling}, constant, amplitude_1, width_1, center_1,
+      amplitude_2, width_2, center_2, amplitude_3, width_3, center_3);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.GeneralizedHarmonic.ConstraintDamp.TimeDep3Gauss",
+    "[PointwiseFunctions][Unit]") {
+  const DataVector dv{5};
+
+  pypp::SetupLocalPythonEnvironment{
+      "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Python"};
+
+  test_triple_gaussian_random<DataVector>(dv);
+  test_triple_gaussian_random<double>(
+      std::numeric_limits<double>::signaling_NaN());
+
+  const double constant_3d{5.0};
+  const double amplitude_1_3d{4.0};
+  const double width_1_3d{1.5};
+  const std::array<double, 3> center_1_3d{{1.1, -2.2, 3.3}};
+  const double amplitude_2_3d{3.0};
+  const double width_2_3d{2.0};
+  const std::array<double, 3> center_2_3d{{4.4, -5.5, 6.6}};
+  const double amplitude_3_3d{5.0};
+  const double width_3_3d{1.0};
+  const std::array<double, 3> center_3_3d{{7.7, -8.8, 9.9}};
+
+  // Name of FunctionOfTime to read
+  const std::string function_of_time_for_scaling{"ExpansionFactor"s};
+  const GeneralizedHarmonic::ConstraintDamping::TimeDependentTripleGaussian
+      triple_gauss_3d{constant_3d,
+                      amplitude_1_3d,
+                      width_1_3d,
+                      center_1_3d,
+                      amplitude_2_3d,
+                      width_2_3d,
+                      center_2_3d,
+                      amplitude_3_3d,
+                      width_3_3d,
+                      center_3_3d,
+                      function_of_time_for_scaling};
+  const auto created_triple_gauss = TestHelpers::test_creation<
+      GeneralizedHarmonic::ConstraintDamping::TimeDependentTripleGaussian>(
+      "Constant: 5.0\n"
+      "Gaussian1:\n"
+      "  Amplitude: 4.0\n"
+      "  Width: 1.5\n"
+      "  Center: [1.1, -2.2, 3.3]\n"
+      "Gaussian2:\n"
+      "  Amplitude: 3.0\n"
+      "  Width: 2.0\n"
+      "  Center: [4.4, -5.5, 6.6]\n"
+      "Gaussian3:\n"
+      "  Amplitude: 5.0\n"
+      "  Width: 1.0\n"
+      "  Center: [7.7, -8.8, 9.9]\n"
+      "FunctionOfTimeForScaling: ExpansionFactor");
+  CHECK(created_triple_gauss == triple_gauss_3d);
+  const auto created_triple_gauss_gh_damping_function =
+      TestHelpers::test_factory_creation<
+          GeneralizedHarmonic::ConstraintDamping::DampingFunction<3,
+                                                                  Frame::Grid>>(
+          "TimeDependentTripleGaussian:\n"
+          "  Constant: 5.0\n"
+          "  Gaussian1:\n"
+          "    Amplitude: 4.0\n"
+          "    Width: 1.5\n"
+          "    Center: [1.1, -2.2, 3.3]\n"
+          "  Gaussian2:\n"
+          "    Amplitude: 3.0\n"
+          "    Width: 2.0\n"
+          "    Center: [4.4, -5.5, 6.6]\n"
+          "  Gaussian3:\n"
+          "    Amplitude: 5.0\n"
+          "    Width: 1.0\n"
+          "    Center: [7.7, -8.8, 9.9]\n"
+          "  FunctionOfTimeForScaling: ExpansionFactor");
+
+  test_serialization(triple_gauss_3d);
+}

--- a/tests/Unit/Helpers/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TestHelpers.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TestHelpers.hpp
@@ -5,6 +5,7 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <algorithm>
 #include <array>
 #include <limits>
 #include <memory>
@@ -12,6 +13,7 @@
 #include <string>
 #include <tuple>
 #include <utility>
+#include <vector>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -37,6 +39,7 @@ void check_impl(
             VolumeDim, Fr>>& in_gh_damping_function,
     const std::string& python_function_prefix, const T& used_for_size,
     const std::array<std::pair<double, double>, 1> random_value_bounds,
+    const std::vector<std::string>& function_of_time_names,
     const MemberArgs&... member_args) noexcept {
   using GhDampingFunc =
       ::GeneralizedHarmonic::ConstraintDamping::DampingFunction<VolumeDim, Fr>;
@@ -44,31 +47,47 @@ void check_impl(
   const auto member_args_tuple = std::make_tuple(member_args...);
   const auto helper =
       [&python_function_prefix, &random_value_bounds, &member_args_tuple,
-       &used_for_size](
+       &function_of_time_names, &used_for_size](
           const std::unique_ptr<GhDampingFunc>& gh_damping_function) noexcept {
         INFO("Testing call operator...")
-
         // Make a lambda that calls the damping function's call operator
         // with a hard-coded FunctionsOfTime, since check_with_random_values
         // cannot convert a FunctionsOfTime into a python type.
         // The FunctionsOfTime contains a single FunctionOfTime
-        // \f$f(t) = a_0 + a_1 t + a_2 t^2 + a_3 t^3\f$, where
-        // \f$a_0 = 1.0\f$, \f$a_1 = 0.2\f$, \f$a_3 = 0.03,\f$ and
-        // \f$a_4 = 0.004\f$. The corresponding python function should use
-        // the same hard-coded coefficients to evaluate \f$f(t)\f$.
-        // Note that the FunctionOfTime never expires.
+        // \f$f(t) = a_0 + a_1 (t-t_0) + a_2 (t-t_0)^2 + a_3 (t-t_0)^3\f$, where
+        // \f$a_0 = 1.0\f$, \f$a_1 = 0.2\f$, \f$a_2 = 0.03,\f$,
+        // \f$a_3 = 0.004\f$, and \f$t_0\f$ is the smallest possible value
+        // of the randomly selected time.
+        //
+        // The corresponding python function should use
+        // the same hard-coded coefficients to evaluate \f$f(t)\f$ as well
+        // as the same value of \f$t_0\f$.
+        // However, here the PiecewisePolynomial must be initialized not
+        // with the polynomial coefficients but with the values of \f$f(t)\f$
+        // and its derivatives evaluated at \f$t=t_0\f$: these are,
+        // respectively, \f$a_0,a_1,2 a_2,6 a_3\f$.
+        //
+        // Finally, note that the FunctionOfTime never expires.
         const auto damping_function_call_operator_helper =
-            [&gh_damping_function](const tnsr::I<T, VolumeDim, Fr>& coordinates,
-                                   const double time) {
+            [&gh_damping_function, &random_value_bounds,
+             &function_of_time_names](
+                const tnsr::I<T, VolumeDim, Fr>& coordinates,
+                const double time) {
               std::unordered_map<
                   std::string,
                   std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>
                   functions_of_time{};
-              functions_of_time["ExpansionFactor"] = std::make_unique<
-                  ::domain::FunctionsOfTime::PiecewisePolynomial<3>>(
-                  0.0,
-                  std::array<DataVector, 4>{{{1.0}, {0.2}, {0.03}, {0.004}}},
-                  std::numeric_limits<double>::max());
+              for (auto function_of_time_name : function_of_time_names) {
+                // The randomly selected time will be between the
+                // random_value_bounds, so set the earliest time of the
+                // function_of_times to the lower bound in random_value_bounds.
+                functions_of_time[function_of_time_name] = std::make_unique<
+                    ::domain::FunctionsOfTime::PiecewisePolynomial<3>>(
+                    std::min(gsl::at(random_value_bounds, 0).first,
+                             gsl::at(random_value_bounds, 0).second),
+                    std::array<DataVector, 4>{{{1.0}, {0.2}, {0.06}, {0.024}}},
+                    std::numeric_limits<double>::max());
+              }
               // Default-construct the scalar, to test that the damping
               // function's call operator correctly resizes it
               // (in the case T is a DataVector) with
@@ -105,6 +124,13 @@ void check_impl(
  * DampingFunction is arbitrary, but should generally be descriptive (e.g.
  * 'gaussian_plus_constant') of the DampingFunction.
  *
+ * The input parameter `function_of_time_name` is the name of the FunctionOfTime
+ * that will be included in the FunctionsOfTime passed to the DampingFunction's
+ * call operator. For time-dependent DampingFunctions, this parameter must be
+ * consistent with the FunctionOfTime name that the call operator of
+ * `in_gh_damping_function` expects. For time-independent DampingFunctions,
+ * `function_of_time_name` will be ignored.
+ *
  * If a DampingFunction class has member variables set by its constructor, then
  * these member variables must be passed in as the last arguments to the `check`
  * function`. Each python function must take these same arguments as the
@@ -114,31 +140,31 @@ template <class DampingFunctionType, class T, class... MemberArgs>
 void check(std::unique_ptr<DampingFunctionType> in_gh_damping_function,
            const std::string& python_function_prefix, const T& used_for_size,
            const std::array<std::pair<double, double>, 1>& random_value_bounds,
+           const std::vector<std::string>& function_of_time_names,
            const MemberArgs&... member_args) noexcept {
   detail::check_impl(
-      std::unique_ptr<
-          ::GeneralizedHarmonic::ConstraintDamping::DampingFunction<
-              DampingFunctionType::volume_dim,
-              typename DampingFunctionType::frame>>(
+      std::unique_ptr<::GeneralizedHarmonic::ConstraintDamping::DampingFunction<
+          DampingFunctionType::volume_dim,
+          typename DampingFunctionType::frame>>(
           std::move(in_gh_damping_function)),
       python_function_prefix, used_for_size, random_value_bounds,
-      member_args...);
+      function_of_time_names, member_args...);
 }
 
 template <class DampingFunctionType, class T, class... MemberArgs>
 void check(DampingFunctionType in_gh_damping_function,
            const std::string& python_function_prefix, const T& used_for_size,
            const std::array<std::pair<double, double>, 1>& random_value_bounds,
+           const std::vector<std::string>& function_of_time_names,
            const MemberArgs&... member_args) noexcept {
   detail::check_impl(
-      std::unique_ptr<
-          ::GeneralizedHarmonic::ConstraintDamping::DampingFunction<
-              DampingFunctionType::volume_dim,
-              typename DampingFunctionType::frame>>(
+      std::unique_ptr<::GeneralizedHarmonic::ConstraintDamping::DampingFunction<
+          DampingFunctionType::volume_dim,
+          typename DampingFunctionType::frame>>(
           std::make_unique<DampingFunctionType>(
               std::move(in_gh_damping_function))),
       python_function_prefix, used_for_size, random_value_bounds,
-      member_args...);
+      function_of_time_names, member_args...);
 }
 // @}
 }  // namespace TestHelpers::GeneralizedHarmonic::ConstraintDamping


### PR DESCRIPTION
## Proposed changes

Adds the first time-dependent generalized harmonic DampingFunction, a sum of three gaussians and a constant, whose widths scale according to a FunctionOfTime. This DampingFunction follows the behavior of SpEC's constraint damping functions used for binary black holes.

The previous DampingFunction test helper did not actually work with time-dependent DampingFunctions, although it was meant to. This PR fixes the DampingFunction test helper to work with time-dependent DampingFunctions as well as with time-independent DampingFunctions.

Finally, this PR implements a quick fix to the time-independent GaussianPlusConstant DampingFunction: in a couple of places, a run-time get() was used when instead a compile-time get() should have been used.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
This PR only modifies the generalized harmonic DampingFunction infrastructure. When using the test helper to test a DampingFunction, there is now a new required argument to the helper's check() function: a string naming which FunctionOfTime in the FunctionsOfTime passed to the call operator should be used. For time-independent DampingFunctions, this string can be anything, because time-independent damping functions should ignore the passed-in FunctionsOfTime entirely.

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
