### PR TITLE
Add python test function for boundary corrections

### DIFF
--- a/tests/Unit/Evolution/DiscontinuousGalerkin/BoundaryCorrectionsHelper.py
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/BoundaryCorrectionsHelper.py
@@ -1,0 +1,71 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def dg_package_data_var1(var1, var2, flux_var1, flux_var2, normal_covector,
+                         mesh_velocity, normal_dot_mesh_velocity,
+                         volume_double):
+    return var1
+
+
+def dg_package_data_var1_normal_dot_flux(var1, var2, flux_var1, flux_var2,
+                                         normal_covector, mesh_velocity,
+                                         normal_dot_mesh_velocity,
+                                         volume_double):
+    return np.einsum("i,i->", flux_var1, normal_covector)
+
+
+def dg_package_data_var2(var1, var2, flux_var1, flux_var2, normal_covector,
+                         mesh_velocity, normal_dot_mesh_velocity,
+                         volume_double):
+    return var2
+
+
+def dg_package_data_var2_normal_dot_flux(var1, var2, flux_var1, flux_var2,
+                                         normal_covector, mesh_velocity,
+                                         normal_dot_mesh_velocity,
+                                         volume_double):
+    return np.einsum("ij,j->i", flux_var2, normal_covector)
+
+
+def dg_package_data_abs_char_speed(var1, var2, flux_var1, flux_var2,
+                                   normal_covector, mesh_velocity,
+                                   normal_dot_mesh_velocity, volume_double):
+    if not isinstance(volume_double, float):
+        volume_double = volume_double[0]
+    if normal_dot_mesh_velocity is None:
+        return np.abs(volume_double * var1)
+    else:
+        return np.abs(volume_double * var1 - normal_dot_mesh_velocity)
+
+
+def dg_boundary_terms_var1(var1_int, normal_dot_flux_var1_int, var2_int,
+                           normal_dot_flux_var2_int, abs_char_speed_int,
+                           var1_ext, normal_dot_flux_var1_ext, var2_ext,
+                           normal_dot_flux_var2_ext, abs_char_speed_ext,
+                           use_strong_form):
+    if use_strong_form:
+        return (-0.5 * (normal_dot_flux_var1_int + normal_dot_flux_var1_ext) -
+                0.5 * np.maximum(abs_char_speed_int, abs_char_speed_ext) *
+                (var1_ext - var1_int))
+    else:
+        return (0.5 * (normal_dot_flux_var1_int - normal_dot_flux_var1_ext) -
+                0.5 * np.maximum(abs_char_speed_int, abs_char_speed_ext) *
+                (var1_ext - var1_int))
+
+
+def dg_boundary_terms_var2(var1_int, normal_dot_flux_var1_int, var2_int,
+                           normal_dot_flux_var2_int, abs_char_speed_int,
+                           var1_ext, normal_dot_flux_var1_ext, var2_ext,
+                           normal_dot_flux_var2_ext, abs_char_speed_ext,
+                           use_strong_form):
+    if use_strong_form:
+        return (-0.5 * (normal_dot_flux_var2_int + normal_dot_flux_var2_ext) -
+                0.5 * np.maximum(abs_char_speed_int, abs_char_speed_ext) *
+                (var2_ext - var2_int))
+    else:
+        return (0.5 * (normal_dot_flux_var2_int - normal_dot_flux_var2_ext) -
+                0.5 * np.maximum(abs_char_speed_int, abs_char_speed_ext) *
+                (var2_ext - var2_int))

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_BoundaryCorrectionsHelper.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_BoundaryCorrectionsHelper.cpp
@@ -11,6 +11,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "DataStructures/VariablesTag.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
@@ -18,6 +19,33 @@
 #include "Utilities/TMPL.hpp"
 
 namespace {
+struct VolumeDouble {
+  double value;
+};
+
+struct VolumeDoubleConversion {
+  // convert to a std::array to test non-trivial type conversion
+  using unpacked_container = std::array<double, 1>;
+  using packed_container = VolumeDouble;
+  using packed_type = double;
+
+  static inline unpacked_container unpack(
+      const packed_container packed,
+      const size_t /*grid_point_index*/) noexcept {
+    return {{packed.value}};
+  }
+
+  static inline void pack(const gsl::not_null<packed_container*> packed,
+                          const unpacked_container unpacked,
+                          const size_t /*grid_point_index*/) {
+    packed->value = unpacked[0];
+  }
+
+  static inline size_t get_size(const packed_container& /*packed*/) noexcept {
+    return 1;
+  }
+};
+
 namespace Tags {
 struct Var1 : db::SimpleTag {
   using type = Scalar<DataVector>;
@@ -28,8 +56,9 @@ struct Var2 : db::SimpleTag {
   using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
 };
 
+template <typename Type>
 struct VolumeDouble : db::SimpleTag {
-  using type = double;
+  using type = Type;
 };
 }  // namespace Tags
 
@@ -52,8 +81,8 @@ struct System {
   using compute_volume_time_derivative_terms = TimeDerivativeTerms;
 };
 
-template <size_t Dim>
-struct Correction {
+template <size_t Dim, typename VolumeDoubleType>
+struct Correction final {
  private:
   struct AbsCharSpeed : db::SimpleTag {
     using type = Scalar<DataVector>;
@@ -64,7 +93,8 @@ struct Correction {
       tmpl::list<Tags::Var1, ::Tags::NormalDotFlux<Tags::Var1>, Tags::Var2<Dim>,
                  ::Tags::NormalDotFlux<Tags::Var2<Dim>>, AbsCharSpeed>;
   using dg_package_data_temporary_tags = tmpl::list<>;
-  using dg_package_data_volume_tags = tmpl::list<Tags::VolumeDouble>;
+  using dg_package_data_volume_tags =
+      tmpl::list<Tags::VolumeDouble<VolumeDoubleType>>;
 
   double dg_package_data(
       const gsl::not_null<Scalar<DataVector>*> packaged_var1,
@@ -79,10 +109,16 @@ struct Correction {
       const tnsr::I<DataVector, Dim, Frame::Inertial>& flux_var1,
       const tnsr::Ij<DataVector, Dim, Frame::Inertial>& flux_var2,
       const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
-      const boost::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
       /*mesh_velocity*/,
-      const boost::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,
-      const double volume_double) const noexcept {
+      const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,
+      const VolumeDoubleType volume_double_in) const noexcept {
+    double volume_double = 0.0;
+    if constexpr (std::is_same_v<double, VolumeDoubleType>) {
+      volume_double = volume_double_in;
+    } else {
+      volume_double = volume_double_in.value;
+    }
     *packaged_var1 = var1;
     *packaged_var2 = var2;
     dot_product(packaged_normal_dot_flux_var1, flux_var1, normal_covector);
@@ -150,20 +186,37 @@ struct Correction {
   }
 };
 
-template <size_t Dim>
+template <size_t Dim, typename VolumeDoubleType>
 void test() {
-  const Correction<Dim> correction{};
+  const Correction<Dim, VolumeDoubleType> correction{};
   const Mesh<Dim - 1> face_mesh{Dim * Dim, Spectral::Basis::Legendre,
                                 Spectral::Quadrature::Gauss};
   TestHelpers::evolution::dg::test_boundary_correction_conservation<
       System<Dim>>(correction, face_mesh,
-                   tuples::TaggedTuple<Tags::VolumeDouble>{2.3});
+                   tuples::TaggedTuple<Tags::VolumeDouble<VolumeDoubleType>>{
+                       VolumeDoubleType{2.3}});
+  TestHelpers::evolution::dg::test_boundary_correction_with_python<
+      System<Dim>, tmpl::list<VolumeDoubleConversion>>(
+      "BoundaryCorrectionsHelper",
+      {{"dg_package_data_var1", "dg_package_data_var1_normal_dot_flux",
+        "dg_package_data_var2", "dg_package_data_var2_normal_dot_flux",
+        "dg_package_data_abs_char_speed"}},
+      {{"dg_boundary_terms_var1", "dg_boundary_terms_var2"}}, correction,
+      face_mesh,
+      tuples::TaggedTuple<Tags::VolumeDouble<VolumeDoubleType>>{
+          VolumeDoubleType{2.3}});
 }
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.DG.BoundaryCorrectionsHelper",
                   "[Unit][Evolution]") {
-  test<1>();
-  test<2>();
-  test<3>();
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/DiscontinuousGalerkin/"};
+  test<1, double>();
+  test<2, double>();
+  test<3, double>();
+
+  test<1, VolumeDouble>();
+  test<2, VolumeDouble>();
+  test<3, VolumeDouble>();
 }


### PR DESCRIPTION
## Proposed changes

Add a generic function that does a random value test of the boundary corrections for DG. This means that the actual tests for boundary corrections are quite short. For example, the Rusanov solver for Burgers is:
```cpp
// Distributed under the MIT License.
// See LICENSE.txt for details.

#include "Framework/TestingFramework.hpp"

#include <cstddef>
#include <array>
#include <string>

#include "Evolution/Systems/Burgers/BoundaryCorrections/Factory.hpp"
#include "Evolution/Systems/Burgers/BoundaryCorrections/Rusanov.hpp"
#include "Evolution/Systems/Burgers/System.hpp"
#include "Framework/SetupLocalPythonEnvironment.hpp"
#include "Framework/TestCreation.hpp"
#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp"
#include "NumericalAlgorithms/Spectral/Mesh.hpp"
#include "NumericalAlgorithms/Spectral/Spectral.hpp"

SPECTRE_TEST_CASE("Unit.Burgers.Rusanov", "[Unit][Burgers]") {
  pypp::SetupLocalPythonEnvironment local_python_env{
      "Evolution/Systems/Burgers/BoundaryCorrections"};

  TestHelpers::evolution::dg::test_boundary_correction_conservation<
      Burgers::System>(
      Burgers::BoundaryCorrections::Rusanov{},
      Mesh<0>{1, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {});

  TestHelpers::evolution::dg::test_boundary_correction_with_python<
      Burgers::System>(
      "Rusanov",
      {{"dg_package_data_u", "dg_package_data_normal_dot_flux",
        "dg_package_data_abs_char_speed"}},
      {{"dg_boundary_terms_u"}}, Burgers::BoundaryCorrections::Rusanov{},
      Mesh<0>{1, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {});

  const auto rusanov = TestHelpers::test_factory_creation<
      Burgers::BoundaryCorrections::BoundaryCorrection>("Rusanov:");

  TestHelpers::evolution::dg::test_boundary_correction_with_python<
      Burgers::System>(
      "Rusanov",
      {{"dg_package_data_u", "dg_package_data_normal_dot_flux",
        "dg_package_data_abs_char_speed"}},
      {{"dg_boundary_terms_u"}},
      dynamic_cast<const Burgers::BoundaryCorrections::Rusanov&>(*rusanov),
      Mesh<0>{1, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {});
}
```
Most work/code comes in from the python implementations. There's a bit more needed if an equation of state (or some other non-DataVector-wrapping class) needs to be converted. Here's Newtonian Euler as an example:
```cpp
// Distributed under the MIT License.
// See LICENSE.txt for details.

#include "Framework/TestingFramework.hpp"

#include <cstddef>
#include <array>
#include <string>

#include "Evolution/Systems/NewtonianEuler/BoundaryCorrections/Factory.hpp"
#include "Evolution/Systems/NewtonianEuler/BoundaryCorrections/Rusanov.hpp"
#include "Evolution/Systems/NewtonianEuler/System.hpp"
#include "Framework/SetupLocalPythonEnvironment.hpp"
#include "Framework/TestCreation.hpp"
#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp"
#include "NumericalAlgorithms/Spectral/Mesh.hpp"
#include "NumericalAlgorithms/Spectral/Spectral.hpp"
#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
#include "PointwiseFunctions/Hydro/Tags.hpp"
#include "Utilities/TMPL.hpp"
#include "Utilities/TaggedTuple.hpp"

namespace {
struct ConvertPolytropic {
  using unpacked_container = bool;
  using packed_container = EquationsOfState::PolytropicFluid<false>;
  using packed_type = bool;

  static inline unpacked_container unpack(
      const packed_container& /*packed*/,
      const size_t /*grid_point_index*/) noexcept {
    return true;
  }

  [[noreturn]] static inline void pack(
      const gsl::not_null<packed_container*> /*packed*/,
      const unpacked_container& /*unpacked*/,
      const size_t /*grid_point_index*/) {
    ERROR("Should not be converting an EOS from an unpacked to a packed type");
  }

  static inline size_t get_size(const packed_container& /*packed*/) noexcept {
    return 1;
  }
};

struct ConvertIdeal {
  using unpacked_container = bool;
  using packed_container = EquationsOfState::IdealFluid<false>;
  using packed_type = bool;

  static inline unpacked_container unpack(
      const packed_container& /*packed*/,
      const size_t /*grid_point_index*/) noexcept {
    return false;
  }

  [[noreturn]] static inline void pack(
      const gsl::not_null<packed_container*> /*packed*/,
      const unpacked_container& /*unpacked*/,
      const size_t /*grid_point_index*/) {
    ERROR("Should not be converting an EOS from an unpacked to a packed type");
  }

  static inline size_t get_size(const packed_container& /*packed*/) noexcept {
    return 1;
  }
};

struct DummyInitialData {
  using argument_tags = tmpl::list<>;
  struct source_term_type {
    using sourced_variables = tmpl::list<>;
    using argument_tags = tmpl::list<>;
  };
};

template <size_t Dim, typename EosTag>
void test(const size_t num_pts,
          const tuples::TaggedTuple<EosTag>& volume_data) {
  TestHelpers::evolution::dg::test_boundary_correction_conservation<
      NewtonianEuler::System<Dim, typename EosTag::type, DummyInitialData>>(
      NewtonianEuler::BoundaryCorrections::Rusanov<Dim>{},
      Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
                    Spectral::Quadrature::Gauss},
      volume_data);

  TestHelpers::evolution::dg::test_boundary_correction_with_python<
      NewtonianEuler::System<Dim, typename EosTag::type, DummyInitialData>,
      tmpl::list<ConvertPolytropic, ConvertIdeal>>(
      "Rusanov",
      {{"dg_package_data_mass_density", "dg_package_data_momentum_density",
        "dg_package_data_energy_density",
        "dg_package_data_normal_dot_flux_mass_density",
        "dg_package_data_normal_dot_flux_momentum_density",
        "dg_package_data_normal_dot_flux_energy_density",
        "dg_package_data_abs_char_speed"}},
      {{"dg_boundary_terms_mass_density", "dg_boundary_terms_momentum_density",
        "dg_boundary_terms_energy_density"}},
      NewtonianEuler::BoundaryCorrections::Rusanov<Dim>{},
      Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
                    Spectral::Quadrature::Gauss},
      volume_data);

  const auto rusanov = TestHelpers::test_factory_creation<
      NewtonianEuler::BoundaryCorrections::BoundaryCorrection<Dim>>("Rusanov:");

  TestHelpers::evolution::dg::test_boundary_correction_with_python<
      NewtonianEuler::System<Dim, typename EosTag::type, DummyInitialData>,
      tmpl::list<ConvertPolytropic, ConvertIdeal>>(
      "Rusanov",
      {{"dg_package_data_mass_density", "dg_package_data_momentum_density",
        "dg_package_data_energy_density",
        "dg_package_data_normal_dot_flux_mass_density",
        "dg_package_data_normal_dot_flux_momentum_density",
        "dg_package_data_normal_dot_flux_energy_density",
        "dg_package_data_abs_char_speed"}},
      {{"dg_boundary_terms_mass_density", "dg_boundary_terms_momentum_density",
        "dg_boundary_terms_energy_density"}},
      dynamic_cast<const NewtonianEuler::BoundaryCorrections::Rusanov<Dim>&>(
          *rusanov),
      Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
                    Spectral::Quadrature::Gauss},
      volume_data);
}
}  // namespace

SPECTRE_TEST_CASE("Unit.NewtonianEuler.Rusanov", "[Unit][Evolution]") {
  pypp::SetupLocalPythonEnvironment local_python_env{
      "Evolution/Systems/NewtonianEuler/BoundaryCorrections"};
  test<1>(1, tuples::TaggedTuple<hydro::Tags::EquationOfState<
                 EquationsOfState::PolytropicFluid<false>>>{
                 EquationsOfState::PolytropicFluid<false>{1.0e-3, 2.0}});
  test<2>(5, tuples::TaggedTuple<hydro::Tags::EquationOfState<
                 EquationsOfState::PolytropicFluid<false>>>{
                 EquationsOfState::PolytropicFluid<false>{1.0e-3, 2.0}});
  test<3>(5, tuples::TaggedTuple<hydro::Tags::EquationOfState<
                 EquationsOfState::PolytropicFluid<false>>>{
                 EquationsOfState::PolytropicFluid<false>{1.0e-3, 2.0}});

  test<1>(
      1, tuples::TaggedTuple<
             hydro::Tags::EquationOfState<EquationsOfState::IdealFluid<false>>>{
             EquationsOfState::IdealFluid<false>{1.3}});
  test<2>(
      5, tuples::TaggedTuple<
             hydro::Tags::EquationOfState<EquationsOfState::IdealFluid<false>>>{
             EquationsOfState::IdealFluid<false>{1.3}});
  test<3>(
      5, tuples::TaggedTuple<
             hydro::Tags::EquationOfState<EquationsOfState::IdealFluid<false>>>{
             EquationsOfState::IdealFluid<false>{1.3}});
}
```

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
