### PR TITLE
Find newer versions of LIBXSMM and add clang-11 to CI

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -297,9 +297,11 @@ jobs:
           - gcc-7
           - gcc-8
           - gcc-9
+          - gcc-10
           - clang-8
           - clang-9
           - clang-10
+          - clang-11
         build_type: [Debug, Release]
         use_pch: [ON]
         include:
@@ -339,6 +341,16 @@ jobs:
           - compiler: clang-9
             build_type: Debug
             use_pch: OFF
+        exclude:
+          # The following tests segfault in release mode:
+          # - Unit.Evolution.Systems.Cce.Equations
+          # - Unit.Evolution.Systems.Cce.InitializeJ
+          # - Unit.Evolution.Systems.Cce.NewmanPenrose
+          # Test_BulgedCube is fixed. This is either a GCC-10 optimizer bug or
+          # some weird Blaze behavior with GCC-10.
+          - use_pch: ON
+            build_type: Release
+            compiler: gcc-10
 
     container:
       image: sxscollaboration/spectrebuildenv:latest

--- a/cmake/FindLIBXSMM.cmake
+++ b/cmake/FindLIBXSMM.cmake
@@ -69,6 +69,13 @@ get_libxsmm_version(
   "#define LIBXSMM_CONFIG_VERSION_UPDATE "
   )
 
+get_libxsmm_version(
+  ${LIBXSMM_INCLUDE_DIRS}/libxsmm_version.h
+  "#define LIBXSMM_CONFIG_VERSION_MAJOR "
+  "#define LIBXSMM_CONFIG_VERSION_MINOR "
+  "#define LIBXSMM_CONFIG_VERSION_UPDATE "
+  )
+
 if("${LIBXSMM_VERSION}" STREQUAL "")
   message(WARNING "Failed to detect LIBXSMM version.")
 endif()

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -154,7 +154,7 @@ RUN wget https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.7.tar.gz -O bla
     && mv auto/lib/* /usr/local/lib \
     && cd ../ \
     && rm -r libsharp* \
-    && wget https://github.com/hfp/libxsmm/archive/1.9.tar.gz -O libxsmm.tar.gz \
+    && wget https://github.com/hfp/libxsmm/archive/1.16.1.tar.gz -O libxsmm.tar.gz \
     && tar -xzf libxsmm.tar.gz \
     && mv libxsmm-* libxsmm \
     && cd libxsmm \

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -219,15 +219,16 @@ RUN ln -s $(which clang++-10) /usr/local/bin/clang++ \
 # Charm++ stores non-temporary files (such as headers) that are needed when
 # building with Charm++ in the `tmp` directories.
 #
-# We do not build  with debug symbols and build with O2 to reduce build size.
+# We build  with debug symbols to make debugging Charm++-interoperability
+# easier for people, and build with O2 to reduce build size.
 RUN git clone --single-branch --branch v6.10.2 --depth 1 \
         https://github.com/UIUC-PPL/charm charm_6_10_2 \
     && cd /work/charm_6_10_2 \
     && git checkout v6.10.2 \
     && ./build LIBS multicore-linux-x86_64 gcc \
-      ${PARALLEL_MAKE_ARG} -g -O0 --build-shared \
+      ${PARALLEL_MAKE_ARG} -g -O2 --build-shared \
     && ./build LIBS multicore-linux-x86_64 clang \
-      ${PARALLEL_MAKE_ARG} -g -O0 --build-shared\
+      ${PARALLEL_MAKE_ARG} -g -O2 --build-shared\
     && rm -r /work/charm_6_10_2/doc /work/charm_6_10_2/examples
 
 # - Set the environment variable SPECTRE_CONTAINER so we can check if we are

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -47,6 +47,11 @@ RUN apt-get update -y \
                           libboost-thread-dev libboost-tools-dev libssl-dev \
                           libbenchmark-dev
 
+# Install clang-11
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
+    && add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main' \
+    && apt-get update -y && apt-get install -y clang-11
+
 # Install libc++ and jemalloc
 # The second `apt-get update` is to ensure that anything that depends on
 # libc++-dev is properly found. This was an issue on older versions of Ubuntu


### PR DESCRIPTION
## Proposed changes

- LIBXSMM has changed where they store version info yet again, so add another file to search. There is a major bug in LIBXSMM 1.9 that's fixed at least in 1.16.1 (I'm not sure exactly where it got fixed) but LIBXSMM 1.9 (what we are using in CI) fails to multiply 1x2 matrices (maybe other single-row matrices, haven't tested). Before updating to and requiring 1.16.1 I want to add the ability to correctly identify the newer versions so CI isn't broken.
- Add clang-11 to container and to CI
- I've added the LIBXSMM 1.16.1 switch in the Dockerfile here so I can just push the new container once this is merged. I'll submit a separate PR to mark the version as required.

I tried add GCC 10 but get the following failure:
```
2020-12-23T02:39:33.3069660Z           Start 1124: Unit.Utilities.PrettyType.short_name
2020-12-23T02:39:33.6569809Z 1073/1142 Test #1124: Unit.Utilities.PrettyType.short_name ........................................***Failed    0.35 sec
2020-12-23T02:39:33.6570416Z 
2020-12-23T02:39:33.6570762Z ############ ASSERT FAILED ############
2020-12-23T02:39:33.6571131Z Node: 0 Proc: 0
2020-12-23T02:39:33.6571627Z Line: 22 of /__w/spectre/spectre/src/Utilities/PrettyType.cpp
2020-12-23T02:39:33.6572857Z 'next_target != remainder->npos' violated!
2020-12-23T02:39:33.6573863Z Function: void pretty_type::detail::{anonymous}::remove_until(gsl::not_null<std::basic_string_view<char>*>, const char*)
2020-12-23T02:39:33.6574562Z Overran string DnEEE looking for 0123456789LNS
2020-12-23T02:39:33.6574980Z ############ ASSERT FAILED ############
2020-12-23T02:39:33.6575222Z 
2020-12-23T02:39:33.6575711Z Charm++> No provisioning arguments specified. Running with a single PE.
2020-12-23T02:39:33.6576746Z          Use +auto-provision to fully subscribe resources or +p1 to silence this message.
2020-12-23T02:39:33.6577408Z Charm++: standalone mode (not using charmrun)
2020-12-23T02:39:33.6577952Z Charm++> Running in Multicore mode: 1 threads (PEs)
2020-12-23T02:39:33.6578633Z Converse/Charm++ Commit ID: v6.10.2-0-g7bf00fa
2020-12-23T02:39:33.6580196Z Warning> Randomization of virtual memory (ASLR) is turned on in the kernel, thread migration may not work! Run 'echo 0 > /proc/sys/kernel/randomize_va_space' as root to disable it, or try running with '+isomalloc_sync'.
2020-12-23T02:39:33.6581202Z CharmLB> Load balancer assumes all CPUs are same.
2020-12-23T02:39:33.6581963Z Charm++> Running on 1 hosts (1 sockets x 2 cores x 1 PUs = 2-way SMP)
2020-12-23T02:39:33.6582536Z Charm++> cpu topology info is gathered in 0.000 seconds.
2020-12-23T02:39:33.6583043Z SpECTRE Build Information:
2020-12-23T02:39:33.6583428Z Version:                      2020.12.7
2020-12-23T02:39:33.6584175Z Compiled on host:             63db91c3ad25
2020-12-23T02:39:33.6584734Z Compiled in directory:        /work/build
2020-12-23T02:39:33.6585348Z Source directory is:          /__w/spectre/spectre
2020-12-23T02:39:33.6585961Z Compiled on git branch:       container_updates
2020-12-23T02:39:33.6586572Z Compiled on git revision:     NOT_IN_GIT_REPO
2020-12-23T02:39:33.6587260Z Linked on:                    Wed Dec 23 02:35:16 2020
2020-12-23T02:39:33.6588032Z Filters: "Unit.Utilities.PrettyType.short_name"
2020-12-23T02:39:33.6588588Z 
```
@wthrowe maybe you have some insight into this? I can file an issue if that's helpful

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
