### PR TITLE
Add CMake hints to find Pybind11 in more cases

### DIFF
--- a/cmake/SetupPybind11.cmake
+++ b/cmake/SetupPybind11.cmake
@@ -19,7 +19,14 @@ if(BUILD_PYTHON_BINDINGS)
       "determined CMake dir: ${PYBIND11_CMAKEDIR}")
   endif()
 
-  find_package(pybind11 2.6.0 REQUIRED HINTS "${PYBIND11_CMAKEDIR}")
+  find_package(pybind11 2.6.0 REQUIRED
+    HINTS
+    ${PYBIND11_CMAKEDIR}
+    ${Python_SITEARCH}
+    ${Python_SITELIB}
+    ${Python_STDARCH}
+    ${Python_STDLIB}
+    )
 
   set_property(
     GLOBAL APPEND PROPERTY SPECTRE_THIRD_PARTY_LIBS


### PR DESCRIPTION
## Proposed changes

Try to find Pybind11 in the Python environment. This finds Pybind11
when it is installed via pip in all cases I have tested, in particular
in a venv which is not activated.

fix #2705

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
