### PR TITLE
Ensure GlobalCache contents are serializable in ActionTesting

### DIFF
--- a/src/Evolution/Systems/Cce/Initialize/InitializeJ.hpp
+++ b/src/Evolution/Systems/Cce/Initialize/InitializeJ.hpp
@@ -131,3 +131,7 @@ struct InitializeJ : public PUP::able {
 };
 }  // namespace InitializeJ
 }  // namespace Cce
+
+#include "Evolution/Systems/Cce/Initialize/InverseCubic.hpp"
+#include "Evolution/Systems/Cce/Initialize/NoIncomingRadiation.hpp"
+#include "Evolution/Systems/Cce/Initialize/ZeroNonSmooth.hpp"

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.cpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.cpp
@@ -36,12 +36,15 @@ void KerrHorizon::pup(PUP::er& p) noexcept {
   p | center;
   p | mass;
   p | dimensionless_spin;
+  p | theta_varies_fastest_memory_layout;
 }
 
 bool operator==(const KerrHorizon& lhs, const KerrHorizon& rhs) noexcept {
   return lhs.l_max == rhs.l_max and lhs.center == rhs.center and
          lhs.mass == rhs.mass and
-         lhs.dimensionless_spin == rhs.dimensionless_spin;
+         lhs.dimensionless_spin == rhs.dimensionless_spin and
+         lhs.theta_varies_fastest_memory_layout ==
+             rhs.theta_varies_fastest_memory_layout;
 }
 
 bool operator!=(const KerrHorizon& lhs, const KerrHorizon& rhs) noexcept {

--- a/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
@@ -20,6 +20,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Block.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/Shell.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/ElementMap.hpp"
@@ -395,6 +396,7 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
 
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ApparentHorizonFinder",
                   "[Unit]") {
+  domain::creators::register_derived_with_charm();
   test_apparent_horizon<TestSchwarzschildHorizon>(
       &test_schwarzschild_horizon_called, 3, 3, 1.0, {{0.0, 0.0, 0.0}});
   test_apparent_horizon<TestKerrHorizon>(&test_kerr_horizon_called, 3, 5, 1.1,

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
@@ -33,6 +33,7 @@
 #include "NumericalAlgorithms/Spectral/SwshInterpolation.hpp"
 #include "NumericalAlgorithms/Spectral/SwshTags.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/Tags.hpp"
@@ -157,6 +158,8 @@ struct TestSendToEvolution {
 SPECTRE_TEST_CASE(
     "Unit.Evolution.Systems.Cce.Actions.CharacteristicBondiCalculations",
     "[Unit][Cce]") {
+  Parallel::register_derived_classes_with_charm<InitializeJ::InitializeJ>();
+  Parallel::register_derived_classes_with_charm<TimeStepper>();
   using component = mock_characteristic_evolution<metavariables>;
   const size_t number_of_radial_points = 10;
   const size_t l_max = 8;

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
@@ -38,6 +38,7 @@
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
 #include "NumericalAlgorithms/Spectral/SwshTags.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"
@@ -164,6 +165,7 @@ struct test_metavariables {
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.GhBoundaryCommunication",
                   "[Unit][Cce]") {
+  Parallel::register_derived_classes_with_charm<TimeStepper>();
   using evolution_component = mock_characteristic_evolution<test_metavariables>;
   using worldtube_component = mock_gh_worldtube_boundary<test_metavariables>;
   const size_t number_of_radial_points = 10;

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
@@ -36,6 +36,7 @@
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
 #include "NumericalAlgorithms/Spectral/SwshTags.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"
@@ -163,6 +164,7 @@ struct test_metavariables {
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.H5BoundaryCommunication",
                   "[Unit][Cce]") {
+  Parallel::register_derived_classes_with_charm<TimeStepper>();
   using evolution_component = mock_characteristic_evolution<test_metavariables>;
   using worldtube_component = mock_h5_worldtube_boundary<test_metavariables>;
   const size_t number_of_radial_points = 10;

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
@@ -28,6 +28,7 @@
 #include "NumericalAlgorithms/Spectral/SwshTags.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/GlobalCache.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"
@@ -123,6 +124,7 @@ struct metavariables {
 SPECTRE_TEST_CASE(
     "Unit.Evolution.Systems.Cce.Actions.InitializeCharacteristicEvolution",
     "[Unit][Cce]") {
+  Parallel::register_derived_classes_with_charm<TimeStepper>();
   using component = mock_characteristic_evolution<metavariables>;
   const size_t number_of_radial_points = 10;
   const size_t l_max = 8;

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeFirstHypersurface.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeFirstHypersurface.cpp
@@ -26,6 +26,7 @@
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
 #include "NumericalAlgorithms/Spectral/SwshFiltering.hpp"
 #include "NumericalAlgorithms/Spectral/SwshTransform.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
 #include "Time/Tags.hpp"
 #include "Utilities/Gsl.hpp"
@@ -86,6 +87,8 @@ struct metavariables {
 SPECTRE_TEST_CASE(
     "Unit.Evolution.Systems.Cce.Actions.InitializeFirstHypersurface",
     "[Unit][Cce]") {
+  Parallel::register_derived_classes_with_charm<InitializeJ::InitializeJ>();
+
   MAKE_GENERATOR(gen);
   // limited l_max distribution because test depends on an analytic
   // basis function with factorials.

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
@@ -21,6 +21,7 @@
 #include "Helpers/Evolution/Systems/Cce/BoundaryTestHelpers.hpp"
 #include "NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"
@@ -162,6 +163,7 @@ struct test_metavariables {
 SPECTRE_TEST_CASE(
     "Unit.Evolution.Systems.Cce.Actions.InsertInterpolationScriData",
     "[Unit][Cce]") {
+  Parallel::register_derived_classes_with_charm<TimeStepper>();
   using evolution_component = mock_characteristic_evolution<test_metavariables>;
   MAKE_GENERATOR(gen);
   UniformCustomDistribution<double> value_dist{0.1, 0.5};

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
@@ -24,6 +24,7 @@
 #include "Helpers/Evolution/Systems/Cce/BoundaryTestHelpers.hpp"
 #include "NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"
@@ -143,6 +144,7 @@ struct test_metavariables {
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.RequestBoundaryData",
                   "[Unit][Cce]") {
+  Parallel::register_derived_classes_with_charm<TimeStepper>();
   using evolution_component = mock_characteristic_evolution<test_metavariables>;
   using worldtube_component = mock_h5_worldtube_boundary<test_metavariables>;
   const size_t number_of_radial_points = 10;

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
@@ -34,6 +34,7 @@
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/GlobalCache.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
@@ -219,6 +220,7 @@ ComplexDataVector compute_expected_field_from_pypp(
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.ScriObserveInterpolated",
                   "[Unit][Cce]") {
+  Parallel::register_derived_classes_with_charm<TimeStepper>();
   using evolution_component = mock_characteristic_evolution<test_metavariables>;
   using observation_component = mock_observer<test_metavariables>;
   pypp::SetupLocalPythonEnvironment local_python_env{

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_SendNextTimeToCce.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_SendNextTimeToCce.cpp
@@ -15,6 +15,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/NumericalAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/FileSystem.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -170,6 +171,7 @@ struct initialize_elements_and_queue_simple_actions {
 void test_send_time_to_cce(const bool substep) noexcept {
   Parallel::register_derived_classes_with_charm<
       Cce::InterfaceManagers::GhInterfaceManager>();
+  Parallel::register_derived_classes_with_charm<TimeStepper>();
   using metavars = test_metavariables;
   using elem_component = mock_element<metavars>;
   TimeStepId time_step_id;

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_InitializeDampedHarmonic.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_InitializeDampedHarmonic.cpp
@@ -21,6 +21,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/Tags.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/Tags.hpp"
 #include "Domain/Tags.hpp"
@@ -42,6 +43,7 @@
 #include "Options/Options.hpp"
 #include "Options/ParseOptions.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/GeneralRelativity/SpacetimeMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Time/Tags.hpp"
@@ -412,6 +414,17 @@ void test_create_from_options() noexcept {
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.GH.Gauge.InitializeDampedHarmonic",
                   "[Unit][Evolution][Actions]") {
+  domain::creators::register_derived_with_charm();
+  Parallel::register_derived_classes_with_charm<
+      GeneralizedHarmonic::ConstraintDamping::DampingFunction<
+          1, Frame::Inertial>>();
+  Parallel::register_derived_classes_with_charm<
+      GeneralizedHarmonic::ConstraintDamping::DampingFunction<
+          2, Frame::Inertial>>();
+  Parallel::register_derived_classes_with_charm<
+      GeneralizedHarmonic::ConstraintDamping::DampingFunction<
+          3, Frame::Inertial>>();
+
   MAKE_GENERATOR(generator);
   test<1, true>(make_not_null(&generator));
   test<2, true>(make_not_null(&generator));

--- a/tests/Unit/Framework/MockRuntimeSystem.hpp
+++ b/tests/Unit/Framework/MockRuntimeSystem.hpp
@@ -11,6 +11,7 @@
 #include <utility>
 
 #include "ErrorHandling/Error.hpp"
+#include "Framework/TestHelpers.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -127,7 +128,11 @@ class MockRuntimeSystem {
   /// Construct from the tuple of GlobalCache objects.
   explicit MockRuntimeSystem(CacheTuple cache_contents)
       : mutable_cache_(tuples::TaggedTuple<>{}),
-        cache_(std::move(cache_contents), &mutable_cache_) {
+        // serialize_and_deserialize is not necessary here, but we
+        // serialize_and_deserialize to reveal bugs in ActionTesting
+        // tests where cache contents are not serializable.
+        cache_(serialize_and_deserialize(cache_contents), &mutable_cache_)
+  {
     tmpl::for_each<typename Metavariables::component_list>(
         [this](auto component) {
           using Component = tmpl::type_from<decltype(component)>;

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -41,6 +41,7 @@
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeMortars.hpp"
 #include "Time/Tags.hpp"
 #include "Utilities/Gsl.hpp"
@@ -1251,6 +1252,9 @@ void test_impl(const Spectral::Quadrature quadrature,
 template <SystemType system_type, UseBoundaryCorrection use_boundary_correction,
           size_t Dim>
 void test() noexcept {
+  Parallel::register_derived_classes_with_charm<
+      BoundaryCorrection<Dim, use_boundary_correction>>();
+
   const auto invoke_tests_with_quadrature_and_formulation =
       [](const Spectral::Quadrature quadrature,
          const ::dg::Formulation local_dg_formulation) noexcept {

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
@@ -10,6 +10,7 @@
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/Shell.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/Tags.hpp"
@@ -216,6 +217,7 @@ void test_add_temporal_ids() {
 }
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.AddTemporalIds",
                   "[Unit]") {
+  domain::creators::register_derived_with_charm();
   test_add_temporal_ids<std::true_type>();
   test_add_temporal_ids<std::false_type>();
 }

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ElementReceiveInterpPoints.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ElementReceiveInterpPoints.cpp
@@ -10,6 +10,7 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/Shell.hpp"
 #include "Domain/Domain.hpp"
 #include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"
@@ -102,6 +103,8 @@ struct MockMetavariables {
 
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ElementReceivePoints",
                   "[Unit]") {
+  domain::creators::register_derived_with_charm();
+
   using metavars = MockMetavariables;
   using target_component_a =
       mock_interpolation_target<metavars,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
@@ -12,6 +12,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/Shell.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/Tags.hpp"
@@ -59,6 +60,7 @@ struct Metavariables {
 
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.Initialize",
                   "[Unit]") {
+  domain::creators::register_derived_with_charm();
   using metavars = Metavariables;
   using temporal_id_type = typename metavars::temporal_id::type;
   using component =

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
@@ -14,6 +14,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/Shell.hpp"
 #include "Domain/Domain.hpp"
 #include "Framework/TestCreation.hpp"
@@ -53,6 +54,8 @@ struct MockMetavariables {
 
 SPECTRE_TEST_CASE(
     "Unit.NumericalAlgorithms.InterpolationTarget.ApparentHorizon", "[Unit]") {
+  domain::creators::register_derived_with_charm();
+
   // Constants used in this test.
   // We use l_max=12 to get enough points that the surface is
   // represented to roundoff error; for smaller l_max we would need to

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
@@ -12,6 +12,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/Shell.hpp"
 #include "Domain/Domain.hpp"
 #include "Framework/TestCreation.hpp"
@@ -158,6 +159,7 @@ void test_interpolation_target_kerr_horizon(
 
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.KerrHorizon",
                   "[Unit]") {
+  domain::creators::register_derived_with_charm();
   test_interpolation_target_kerr_horizon(true);
   test_interpolation_target_kerr_horizon(false);
 }

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
@@ -71,7 +71,8 @@ void test_interpolation_target_kerr_horizon(
           "DimensionlessSpin: [0.2, 0.3, 0.4]\n"
           "Lmax: 18\n"
           "Mass: 1.8\n"
-          "ThetaVariesFastest: true");
+          "ThetaVariesFastest: " +
+          std::string(theta_varies_fastest ? "true" : "false"));
   CHECK(created_opts == kerr_horizon_opts);
 
   const auto domain_creator =

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
@@ -11,6 +11,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/Shell.hpp"
 #include "Domain/Domain.hpp"
 #include "Framework/TestCreation.hpp"
@@ -45,6 +46,7 @@ struct MockMetavariables {
 
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.LineSegment",
                   "[Unit]") {
+  domain::creators::register_derived_with_charm();
   // Options for LineSegment
   intrp::OptionHolders::LineSegment<3> line_segment_opts({{1.0, 1.0, 1.0}},
                                                          {{2.4, 2.4, 2.4}}, 15);

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
@@ -14,6 +14,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"  // IWYU pragma: keep
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/Shell.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/Tags.hpp"
@@ -527,6 +528,7 @@ void test_interpolation_target_receive_vars() noexcept {
 
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.ReceiveVars",
                   "[Unit]") {
+  domain::creators::register_derived_with_charm();
   test_interpolation_target_receive_vars<MockPostInterpolationCallback, 1, 0>();
   test_interpolation_target_receive_vars<MockPostInterpolationCallbackNoCleanup,
                                          0, 0>();

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetVarsFromElement.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetVarsFromElement.cpp
@@ -10,6 +10,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/Shell.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/Tags.hpp"
@@ -134,6 +135,8 @@ struct MockMetavariables {
 
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.TargetVarsFromElement",
                   "[Unit]") {
+  domain::creators::register_derived_with_charm();
+
   using metavars = MockMetavariables;
   using temporal_id_type = typename metavars::temporal_id::type;
   using target_component =

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
@@ -12,6 +12,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/Shell.hpp"
 #include "Domain/Domain.hpp"
 #include "Framework/TestCreation.hpp"
@@ -139,6 +140,7 @@ void test_r_theta_uniform() noexcept {
 SPECTRE_TEST_CASE(
     "Unit.NumericalAlgorithms.InterpolationTarget.WedgeSectionTorus",
     "[Unit]") {
+  domain::creators::register_derived_with_charm();
   // Check creating the options
   const auto created_torus =
       TestHelpers::test_creation<intrp::OptionHolders::WedgeSectionTorus>(

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
@@ -15,6 +15,7 @@
 #include "DataStructures/IdPair.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/Shell.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/Structure/BlockId.hpp"
@@ -162,6 +163,7 @@ struct Metavariables {
 
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ReceivePoints",
                   "[Unit]") {
+  domain::creators::register_derived_with_charm();
   using metavars = Metavariables;
   using target_component =
       mock_interpolation_target<metavars,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
@@ -23,6 +23,7 @@
 #include "Domain/Block.hpp"
 #include "Domain/BlockLogicalCoordinates.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/Shell.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/ElementMap.hpp"
@@ -223,6 +224,8 @@ struct MockMetavariables {
 
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ReceiveVolumeData",
                   "[Unit]") {
+  domain::creators::register_derived_with_charm();
+
   using metavars = MockMetavariables;
   using temporal_id_type = typename metavars::temporal_id::type;
   using target_component =

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
@@ -20,6 +20,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Domain/Block.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/Shell.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/ElementMap.hpp"
@@ -280,6 +281,8 @@ struct MockMetavariables {
 SPECTRE_TEST_CASE(
     "Unit.NumericalAlgorithms.Interpolator.ObserveTimeSeriesOnSurface",
     "[Unit]") {
+  domain::creators::register_derived_with_charm();
+
   const std::string h5_file_prefix = "Test_ObserveTimeSeriesOnSurface";
   const auto h5_file_name = h5_file_prefix + ".h5";
   if (file_system::check_if_file_exists(h5_file_name)) {

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
@@ -19,6 +19,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Domain/Block.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/Shell.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/ElementMap.hpp"
@@ -261,6 +262,8 @@ struct MockMetavariables {
 // work together as they are supposed to.
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.Integration",
                   "[Unit]") {
+  domain::creators::register_derived_with_charm();
+
   using metavars = MockMetavariables;
   using interp_component = mock_interpolator<metavars>;
   using target_a_component =

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeInterfaces.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeInterfaces.cpp
@@ -19,6 +19,7 @@
 #include "Domain/Creators/Brick.hpp"
 #include "Domain/Creators/Interval.hpp"
 #include "Domain/Creators/Rectangle.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Tags.hpp"
@@ -27,6 +28,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp"
 #include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeInterfaces.hpp"
 #include "Time/Slab.hpp"
@@ -309,6 +311,9 @@ void test_3d() {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeInterfaces", "[Unit][Actions]") {
+  domain::creators::register_derived_with_charm();
+  Parallel::register_derived_classes_with_charm<TimeStepper>();
+
   test_1d<false>();
   test_2d<false>();
   test_3d<false>();

--- a/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
+++ b/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
@@ -11,7 +11,8 @@
 #include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
 #include "Framework/ActionTesting.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
-#include "Time/Actions/AdvanceTime.hpp"           // IWYU pragma: keep
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "Time/Actions/AdvanceTime.hpp"  // IWYU pragma: keep
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"  // IWYU pragma: keep
 #include "Time/Time.hpp"
@@ -139,6 +140,7 @@ void check_abn(const Time& start, const TimeDelta& time_step) {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Time.Actions.AdvanceTime", "[Unit][Time][Actions]") {
+  Parallel::register_derived_classes_with_charm<TimeStepper>();
   const Slab slab(0., 1.);
   check_rk3(slab.start(), slab.duration() / 2);
   check_rk3(slab.end(), -slab.duration() / 2);

--- a/tests/Unit/Time/Actions/Test_ChangeSlabSize.cpp
+++ b/tests/Unit/Time/Actions/Test_ChangeSlabSize.cpp
@@ -16,6 +16,7 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Time/Actions/ChangeSlabSize.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
@@ -70,6 +71,8 @@ struct Component {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Time.Actions.ChangeSlabSize", "[Unit][Time][Actions]") {
+  Parallel::register_derived_classes_with_charm<TimeStepper>();
+
   ActionTesting::MockRuntimeSystem<Metavariables> runner{
       {std::make_unique<TimeSteppers::RungeKutta3>()}};
 

--- a/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
+++ b/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
@@ -12,6 +12,7 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Time/Actions/ChangeStepSize.hpp"
 #include "Time/History.hpp"
 #include "Time/Slab.hpp"
@@ -116,6 +117,9 @@ void check(const bool time_runs_forward,
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Time.Actions.ChangeStepSize", "[Unit][Time][Actions]") {
+  Parallel::register_derived_classes_with_charm<TimeStepper>();
+  Parallel::register_derived_classes_with_charm<StepChooser<step_choosers>>();
+  Parallel::register_derived_classes_with_charm<StepController>();
   const Slab slab(-5., -2.);
   const double slab_length = slab.duration().value();
   check(true, std::make_unique<TimeSteppers::AdamsBashforthN>(1),

--- a/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
+++ b/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
@@ -20,6 +20,7 @@
 #include "Evolution/Conservative/UpdatePrimitives.hpp"  // IWYU pragma: keep
 #include "Framework/ActionTesting.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"   // IWYU pragma: keep
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Time/Actions/RecordTimeStepperData.hpp"  // IWYU pragma: keep
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Actions/UpdateU.hpp"  // IWYU pragma: keep
@@ -406,6 +407,7 @@ void test_convergence(const size_t order, const bool forward_in_time) noexcept {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Time.Actions.SelfStart", "[Unit][Time][Actions]") {
+  Parallel::register_derived_classes_with_charm<TimeStepper>();
   for (size_t order = 1; order < 5; ++order) {
     CAPTURE(order);
     for (const int step_denominator : {1, -1, 2, -2, 20, -20}) {

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -16,7 +16,8 @@
 #include "DataStructures/Variables.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
-#include "Time/Actions/UpdateU.hpp"               // IWYU pragma: keep
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "Time/Actions/UpdateU.hpp"  // IWYU pragma: keep
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
@@ -101,6 +102,8 @@ struct Metavariables {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Time.Actions.UpdateU", "[Unit][Time][Actions]") {
+  Parallel::register_derived_classes_with_charm<TimeStepper>();
+
   const Slab slab(1., 3.);
   const TimeDelta time_step = slab.duration() / 2;
 


### PR DESCRIPTION
## Proposed changes

ActionTesting tests now ensure that the contents of GlobalCache are serializable.  
This PR does three things:
 - Calls serialize_and_deserialize on GlobalCache contents inside of MockRuntimeSystem.  This produces (usually runtime) errors for GlobalCache contents that are not serializable.  Note that in a future PR that makes MockRuntimeSystem handle mock nodes and cores, there will be a vector of GlobalCaches (one for each mock core), so serialize_and_deserialize will be necessary to copy the GlobalCache contents into each element of the vector.
 - Fixes bugs in a pup function.
 - In many unit tests that use ActionTesting, now calls the appropriate register_derived_classes_with_charm functions for derived classes that are in the GlobalCache.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
