### PR TITLE
Fix AppleClang 12 warnings about non-reference iterators

### DIFF
--- a/src/Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.cpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.cpp
@@ -59,7 +59,7 @@ void LinearizedBondiSachs::assign_components_from_l_factors(
   const auto& collocation_metadata =
       Spectral::Swsh::cached_collocation_metadata<
           Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
-  for (const auto& collocation_point : collocation_metadata) {
+  for (const auto collocation_point : collocation_metadata) {
     // assign to collocation points
     const std::complex<double> z_22_factor =
         (y_22.evaluate(collocation_point.theta, collocation_point.phi) +
@@ -93,7 +93,7 @@ void LinearizedBondiSachs::assign_du_components_from_l_factors(
   const auto& collocation_metadata =
       Spectral::Swsh::cached_collocation_metadata<
           Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
-  for (const auto& collocation_point : collocation_metadata) {
+  for (const auto collocation_point : collocation_metadata) {
     // assign to collocation points
     const std::complex<double> z_22_factor =
         (y_22.evaluate(collocation_point.theta, collocation_point.phi) +

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/RotatingSchwarzschild.cpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/RotatingSchwarzschild.cpp
@@ -54,7 +54,7 @@ void RotatingSchwarzschild::spherical_metric(
 
   const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
       Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
-  for (const auto& collocation_point : collocation) {
+  for (const auto collocation_point : collocation) {
     get<0, 0>(*spherical_metric)[collocation_point.offset] =
         -(1.0 - 2.0 * mass_ / extraction_radius_ -
           square(frequency_) * square(extraction_radius_) *
@@ -86,7 +86,7 @@ void RotatingSchwarzschild::dr_spherical_metric(
 
   const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
       Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
-  for (const auto& collocation_point : collocation) {
+  for (const auto collocation_point : collocation) {
     get<0, 0>(*dr_spherical_metric)[collocation_point.offset] =
         -(2.0 * mass_ / square(extraction_radius_) -
           2.0 * square(frequency_) * extraction_radius_ *

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/SphericalMetricData.cpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/SphericalMetricData.cpp
@@ -273,7 +273,7 @@ void SphericalMetricData::inverse_jacobian(
     const size_t l_max) const noexcept {
   const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
       Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
-  for (const auto& collocation_point : collocation) {
+  for (const auto collocation_point : collocation) {
     // dr/dx   dtheta/dx   dphi/dx * sin(theta)
     get<0, 0>(*inverse_jacobian)[collocation_point.offset] =
         cos(collocation_point.phi) * sin(collocation_point.theta);
@@ -304,7 +304,7 @@ void SphericalMetricData::jacobian(
     const size_t l_max) const noexcept {
   const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
       Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
-  for (const auto& collocation_point : collocation) {
+  for (const auto collocation_point : collocation) {
     // dx/dr   dy/dr  dz/dr
     get<0, 0>(*jacobian)[collocation_point.offset] =
         sin(collocation_point.theta) * cos(collocation_point.phi);
@@ -335,7 +335,7 @@ void SphericalMetricData::dr_inverse_jacobian(
     const size_t l_max) const noexcept {
   const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
       Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
-  for (const auto& collocation_point : collocation) {
+  for (const auto collocation_point : collocation) {
     // radial derivatives of:
     // dr/dx   dtheta/dx   dphi/dx * sin(theta)
     get<0, 0>(*dr_inverse_jacobian)[collocation_point.offset] = 0.0;
@@ -366,7 +366,7 @@ void SphericalMetricData::dr_jacobian(
     const size_t l_max) noexcept {
   const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
       Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
-  for (const auto& collocation_point : collocation) {
+  for (const auto collocation_point : collocation) {
     // dx/dr   dy/dr  dz/dr
     get<0, 0>(*dr_jacobian)[collocation_point.offset] = 0.0;
     get<0, 1>(*dr_jacobian)[collocation_point.offset] = 0.0;

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/TeukolskyWave.cpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/TeukolskyWave.cpp
@@ -169,7 +169,7 @@ DataVector TeukolskyWave::sin_theta(const size_t l_max) noexcept {
       Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
   const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
       Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
-  for (const auto& collocation_point : collocation) {
+  for (const auto collocation_point : collocation) {
     sin_theta_result[collocation_point.offset] = sin(collocation_point.theta);
   }
   return sin_theta_result;
@@ -180,7 +180,7 @@ DataVector TeukolskyWave::cos_theta(const size_t l_max) noexcept {
       Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
   const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
       Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
-  for (const auto& collocation_point : collocation) {
+  for (const auto collocation_point : collocation) {
     cos_theta_result[collocation_point.offset] = cos(collocation_point.theta);
   }
   return cos_theta_result;

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.cpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.cpp
@@ -35,7 +35,7 @@ void WorldtubeData::variables_impl(
     tmpl::type_<Tags::CauchyCartesianCoords> /*meta*/) const noexcept {
   const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
       Spectral::Swsh::ComplexRepresentation::Interleaved>(output_l_max);
-  for (const auto& collocation_point : collocation) {
+  for (const auto collocation_point : collocation) {
     get<0>(*cartesian_coordinates)[collocation_point.offset] =
         extraction_radius_ * cos(collocation_point.phi) *
         sin(collocation_point.theta);
@@ -54,7 +54,7 @@ void WorldtubeData::variables_impl(
     const noexcept {
   const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
       Spectral::Swsh::ComplexRepresentation::Interleaved>(output_l_max);
-  for (const auto& collocation_point : collocation) {
+  for (const auto collocation_point : collocation) {
     get<0>(*dr_cartesian_coordinates)[collocation_point.offset] =
         cos(collocation_point.phi) * sin(collocation_point.theta);
     get<1>(*dr_cartesian_coordinates)[collocation_point.offset] =

--- a/src/Evolution/Systems/Cce/BoundaryData.cpp
+++ b/src/Evolution/Systems/Cce/BoundaryData.cpp
@@ -34,7 +34,7 @@ void trigonometric_functions_on_swsh_collocation(
 
   const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
       Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
-  for (const auto& collocation_point : collocation) {
+  for (const auto collocation_point : collocation) {
     get(*sin_theta)[collocation_point.offset] = sin(collocation_point.theta);
     get(*cos_theta)[collocation_point.offset] = cos(collocation_point.theta);
     get(*sin_phi)[collocation_point.offset] = sin(collocation_point.phi);

--- a/src/Evolution/Systems/Cce/GaugeTransformBoundaryData.cpp
+++ b/src/Evolution/Systems/Cce/GaugeTransformBoundaryData.cpp
@@ -673,7 +673,7 @@ void InitializeGauge::apply(
     const size_t l_max) noexcept {
   const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
       Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
-  for (const auto& collocation_point : collocation) {
+  for (const auto collocation_point : collocation) {
     get<0>(*angular_cauchy_coordinates)[collocation_point.offset] =
         collocation_point.theta;
     get<1>(*angular_cauchy_coordinates)[collocation_point.offset] =

--- a/src/Evolution/Systems/Cce/Initialize/InitializeJ.cpp
+++ b/src/Evolution/Systems/Cce/Initialize/InitializeJ.cpp
@@ -51,7 +51,7 @@ double adjust_angular_coordinates_for_j(
 
   const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
       Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
-  for (const auto& collocation_point : collocation) {
+  for (const auto collocation_point : collocation) {
     get<0>(*angular_cauchy_coordinates)[collocation_point.offset] =
         collocation_point.theta;
     get<1>(*angular_cauchy_coordinates)[collocation_point.offset] =

--- a/src/Evolution/Systems/Cce/Initialize/InverseCubic.cpp
+++ b/src/Evolution/Systems/Cce/Initialize/InverseCubic.cpp
@@ -60,7 +60,7 @@ void InverseCubic::operator()(
   }
   const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
       Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
-  for (const auto& collocation_point : collocation) {
+  for (const auto collocation_point : collocation) {
     get<0>(*angular_cauchy_coordinates)[collocation_point.offset] =
         collocation_point.theta;
     get<1>(*angular_cauchy_coordinates)[collocation_point.offset] =

--- a/src/Evolution/Systems/Cce/Initialize/InverseCubic.cpp
+++ b/src/Evolution/Systems/Cce/Initialize/InverseCubic.cpp
@@ -19,8 +19,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace Cce {
-namespace InitializeJ {
+namespace Cce::InitializeJ {
 
 std::unique_ptr<InitializeJ> InverseCubic::get_clone() const
     noexcept {
@@ -81,5 +80,4 @@ void InverseCubic::pup(PUP::er& /*p*/) noexcept {}
 /// \cond
 PUP::able::PUP_ID InverseCubic::my_PUP_ID = 0;
 /// \endcond
-}  // namespace InitializeJ
-}  // namespace Cce
+}  // namespace Cce::InitializeJ

--- a/src/Evolution/Systems/Cce/WorldtubeDataManager.cpp
+++ b/src/Evolution/Systems/Cce/WorldtubeDataManager.cpp
@@ -119,7 +119,7 @@ bool MetricWorldtubeDataManager::populate_hypersurface_boundary_data(
   // the swsh interface requirement that the spin-weight be labelled with
   // `SpinWeighted`
   SpinWeighted<ComplexModalVector, 0> spin_weighted_buffer;
-  for (const auto& libsharp_mode :
+  for (const auto libsharp_mode :
        Spectral::Swsh::cached_coefficients_metadata(l_max_)) {
     for (size_t i = 0; i < 3; ++i) {
       for (size_t j = i; j < 3; ++j) {
@@ -347,7 +347,7 @@ bool BondiWorldtubeDataManager::populate_hypersurface_boundary_data(
   // the ComplexModalVectors should be provided from the buffer_updater_ in
   // 'Goldberg' format, so we iterate over modes and convert to libsharp
   // format.
-  for (const auto& libsharp_mode :
+  for (const auto libsharp_mode :
        Spectral::Swsh::cached_coefficients_metadata(l_max_)) {
     tmpl::for_each<cce_bondi_input_tags>(
         [this, &libsharp_mode, &interpolate_from_column](auto tag_v) noexcept {

--- a/src/NumericalAlgorithms/Spectral/SwshCoefficients.cpp
+++ b/src/NumericalAlgorithms/Spectral/SwshCoefficients.cpp
@@ -156,7 +156,7 @@ void libsharp_to_goldberg_modes(
 
   const auto& coefficients_metadata = cached_coefficients_metadata(l_max);
   for (size_t i = 0; i < number_of_radial_grid_points; ++i) {
-    for (const auto& coefficient_info : coefficients_metadata) {
+    for (const auto coefficient_info : coefficients_metadata) {
       goldberg_modes->data()[goldberg_mode_index(
           coefficient_info.l_max, coefficient_info.l,
           static_cast<int>(coefficient_info.m), i)] =
@@ -190,7 +190,7 @@ void goldberg_to_libsharp_modes(
   const size_t number_of_radial_grid_points =
       goldberg_modes.data().size() / square(l_max + 1);
   for(size_t i = 0; i < number_of_radial_grid_points; ++i) {
-    for (const auto& mode : cached_coefficients_metadata(l_max)) {
+    for (const auto mode : cached_coefficients_metadata(l_max)) {
       goldberg_modes_to_libsharp_modes_single_pair(
           mode, libsharp_modes, i,
           goldberg_modes.data()[goldberg_mode_index(

--- a/src/NumericalAlgorithms/Spectral/SwshCoefficients.cpp
+++ b/src/NumericalAlgorithms/Spectral/SwshCoefficients.cpp
@@ -19,12 +19,11 @@
 
 // IWYU pragma: no_forward_declare SpinWeighted
 
-namespace Spectral {
-namespace Swsh {
+namespace Spectral::Swsh {
 
 CoefficientsMetadata::CoefficientsMetadata(const size_t l_max) noexcept
     : l_max_(l_max) {
-  sharp_alm_info* alm_to_initialize;
+  sharp_alm_info* alm_to_initialize = nullptr;
   sharp_make_triangular_alm_info(l_max, l_max, 1, &alm_to_initialize);
   alm_info_.reset(alm_to_initialize);
 }
@@ -262,5 +261,4 @@ GENERATE_INSTANTIATIONS(LIBSHARP_TO_GOLDBERG_INSTANTIATION, (-2, -1, 0, 1, 2))
 #undef LIBSHARP_TO_GOLDBERG_INSTANTIATION
 #undef GET_SPIN
 
-}  // namespace Swsh
-}  // namespace Spectral
+}  // namespace Spectral::Swsh

--- a/src/NumericalAlgorithms/Spectral/SwshDerivatives.cpp
+++ b/src/NumericalAlgorithms/Spectral/SwshDerivatives.cpp
@@ -16,8 +16,7 @@
 
 // IWYU pragma: no_forward_declare SpinWeighted
 
-namespace Spectral {
-namespace Swsh {
+namespace Spectral::Swsh {
 namespace detail {
 namespace {
 template <typename DerivativeKind, int Spin>
@@ -181,5 +180,4 @@ GENERATE_INSTANTIATIONS(FULL_DERIVATIVE_INSTANTIATION,
 #undef GET_SPIN
 #undef GET_DERIVKIND
 #undef GET_REPRESENTATION
-}  // namespace Swsh
-}  // namespace Spectral
+}  // namespace Spectral::Swsh

--- a/src/NumericalAlgorithms/Spectral/SwshDerivatives.cpp
+++ b/src/NumericalAlgorithms/Spectral/SwshDerivatives.cpp
@@ -24,7 +24,7 @@ template <typename DerivativeKind, int Spin>
 ComplexDiagonalModalOperator derivative_factors(const size_t l_max) noexcept {
   ComplexDiagonalModalOperator derivative_factors{
       size_of_libsharp_coefficient_vector(l_max)};
-  for (const auto& mode : cached_coefficients_metadata(l_max)) {
+  for (const auto mode : cached_coefficients_metadata(l_max)) {
     // note that the libsharp transform data is stored as a pair of complex
     // vectors: one for the transform of the real part and one for the transform
     // of the imaginary part of the collocation data.

--- a/src/NumericalAlgorithms/Spectral/SwshFiltering.cpp
+++ b/src/NumericalAlgorithms/Spectral/SwshFiltering.cpp
@@ -58,7 +58,7 @@ void filter_swsh_volume_quantity(
                    *to_filter);
     const auto& coefficients_metadata = cached_coefficients_metadata(l_max);
     for (size_t i = 0; i < number_of_radial_grid_points; ++i) {
-      for (const auto& mode : coefficients_metadata) {
+      for (const auto mode : coefficients_metadata) {
         if (mode.l > limit_l) {
           transform_buffer->data()[mode.transform_of_real_part_offset +
                                    i * coefficients_metadata.size()] = 0.0;
@@ -99,7 +99,7 @@ void filter_swsh_boundary_quantity(
         size_of_libsharp_coefficient_vector(l_max));
     swsh_transform(l_max, 1, transform_buffer, *to_filter);
     const auto& coefficients_metadata = cached_coefficients_metadata(l_max);
-    for (const auto& mode : coefficients_metadata) {
+    for (const auto mode : coefficients_metadata) {
       if (mode.l > limit_l) {
         transform_buffer->data()[mode.transform_of_real_part_offset] = 0.0;
         transform_buffer->data()[mode.transform_of_imag_part_offset] = 0.0;

--- a/src/NumericalAlgorithms/Spectral/SwshTransform.cpp
+++ b/src/NumericalAlgorithms/Spectral/SwshTransform.cpp
@@ -12,8 +12,7 @@
 
 // IWYU pragma: no_forward_declare SpinWeighted
 
-namespace Spectral {
-namespace Swsh {
+namespace Spectral::Swsh {
 
 namespace detail {
 template <ComplexRepresentation Representation>
@@ -258,5 +257,4 @@ GENERATE_INSTANTIATIONS(SWSH_INTERPOLATION_INSTANTIATION, (-2, -1, 0, 1, 2))
 #undef SWSH_TRANSFORM_INSTANTIATION
 #undef SWSH_TRANSFORM_UTILITIES_INSTANTIATION
 
-}  // namespace Swsh
-}  // namespace Spectral
+}  // namespace Spectral::Swsh

--- a/src/NumericalAlgorithms/Spectral/SwshTransform.cpp
+++ b/src/NumericalAlgorithms/Spectral/SwshTransform.cpp
@@ -143,7 +143,7 @@ void interpolate_to_collocation(
   for (size_t i = 0; i < number_of_radial_points; ++i) {
     auto source_coefficient_metadata_iterator =
         cached_coefficients_metadata(source_l_max).begin();
-    for (const auto& coefficient : target_coefficient_metadata) {
+    for (const auto coefficient : target_coefficient_metadata) {
       // first, we advance `source_coefficient_metadata_iterator` to the same
       // mode that is represented by `coefficient`, or to the next mode
       // following `coefficient` that is present in the source resolution, or to

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/Weighting.cpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/Weighting.cpp
@@ -141,7 +141,7 @@ void intruding_weight(
           return false;
         };
     Scalar<DataVector> corner_weight{num_points};
-    for (const auto& corner : VertexIterator<Dim - 1>{}) {
+    for (const auto corner : VertexIterator<Dim - 1>{}) {
       if (skip_corner(corner)) {
         continue;
       }
@@ -157,7 +157,7 @@ void intruding_weight(
     }
     if constexpr (Dim == 3) {
       Scalar<DataVector> edge_weight{num_points};
-      for (const auto& edge : EdgeIterator<Dim - 1>{}) {
+      for (const auto edge : EdgeIterator<Dim - 1>{}) {
         const size_t d_perp =
             dim_in_volume(dim_in_volume(0, edge.dimension_in_parent()),
                           direction.dimension());

--- a/tests/Unit/DataStructures/Test_ApplyMatrices.cpp
+++ b/tests/Unit/DataStructures/Test_ApplyMatrices.cpp
@@ -118,7 +118,7 @@ struct CheckApply<LocalScalarTag, LocalTensorTag, Dim, Dim> {
         dest_mesh, powers, fill_value);
     // Using this over CHECK_ITERABLE_APPROX speeds the test up by a
     // factor of 6 or so.
-    for (const auto& p : result - expected) {
+    for (const auto p : result - expected) {
       CHECK_COMPLEX_APPROX(p, 0.0);
     }
     const auto ref_matrices =
@@ -127,7 +127,7 @@ struct CheckApply<LocalScalarTag, LocalTensorTag, Dim, Dim> {
           result);
     const auto vector_result = apply_matrices(
         matrices, get(get<LocalScalarTag>(source_data)), source_mesh.extents());
-    for (const auto& p : vector_result - get(get<LocalScalarTag>(expected))) {
+    for (const auto p : vector_result - get(get<LocalScalarTag>(expected))) {
       CHECK_COMPLEX_APPROX(p, 0.0);
     }
     CHECK(apply_matrices(ref_matrices, get(get<LocalScalarTag>(source_data)),

--- a/tests/Unit/Domain/Structure/Test_Hypercube.cpp
+++ b/tests/Unit/Domain/Structure/Test_Hypercube.cpp
@@ -28,7 +28,7 @@ void test_hypercube_iterator(
   CHECK(elements_iterator !=
         HypercubeElementsIterator<ElementDim, HypercubeDim>::end());
   size_t i = 0;
-  for (const auto& element : elements_iterator) {
+  for (const auto element : elements_iterator) {
     CAPTURE(i);
     CAPTURE(element);
     CHECK(element == gsl::at(expected_elements, i));

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_FilterSwshVolumeQuantity.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_FilterSwshVolumeQuantity.cpp
@@ -89,7 +89,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.FilterSwshVolumeQuantity",
   generated_modes.data() = make_with_random_values<ComplexModalVector>(
       make_not_null(&gen), make_not_null(&coefficient_distribution),
       Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max));
-  for (const auto& mode : Spectral::Swsh::cached_coefficients_metadata(l_max)) {
+  for (const auto mode : Spectral::Swsh::cached_coefficients_metadata(l_max)) {
     if (mode.l < 2) {
       generated_modes.data()[mode.transform_of_real_part_offset] = 0.0;
       generated_modes.data()[mode.transform_of_imag_part_offset] = 0.0;

--- a/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/Test_BouncingBlackHole.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/AnalyticSolutions/Test_BouncingBlackHole.cpp
@@ -94,7 +94,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.BouncingBlackHole",
   const auto& collocation_metadata =
       Spectral::Swsh::cached_collocation_metadata<
           Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
-  for (const auto& collocation_point : collocation_metadata) {
+  for (const auto collocation_point : collocation_metadata) {
     get<1>(unmapped_coordinates)[collocation_point.offset] =
         extraction_radius * cos(collocation_point.phi) *
         sin(collocation_point.theta);

--- a/tests/Unit/Evolution/Systems/Cce/Test_BoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_BoundaryData.cpp
@@ -213,7 +213,7 @@ void test_d_bondi_r_identities(const gsl::not_null<Generator*> gen) noexcept {
   // angular derivatives should be.
   const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
       Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
-  for (const auto& collocation_point : collocation) {
+  for (const auto collocation_point : collocation) {
     get(bondi_r).data()[collocation_point.offset] =
         5.0 + sin(collocation_point.theta) * cos(collocation_point.phi);
   }
@@ -257,7 +257,7 @@ void test_d_bondi_r_identities(const gsl::not_null<Generator*> gen) noexcept {
                  du_null_metric, inverse_null_metric, l_max);
   DataVector expected_dtheta_r{number_of_angular_points};
   DataVector expected_dphi_r{number_of_angular_points};
-  for (const auto& collocation_point : collocation) {
+  for (const auto collocation_point : collocation) {
     expected_dtheta_r[collocation_point.offset] =
         cos(collocation_point.theta) * cos(collocation_point.phi);
     // note 'pfaffian' derivative with the 1/sin(theta)
@@ -336,7 +336,7 @@ void dispatch_to_gh_worldtube_computation_from_analytic(
   tnsr::I<DataVector, 3> collocation_points{number_of_angular_points};
   const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
       Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
-  for (const auto& collocation_point : collocation) {
+  for (const auto collocation_point : collocation) {
     get<0>(collocation_points)[collocation_point.offset] =
         extraction_radius * sin(collocation_point.theta) *
         cos(collocation_point.phi);
@@ -394,7 +394,7 @@ void dispatch_to_modal_worldtube_computation_from_analytic(
       Spectral::Swsh::number_of_swsh_collocation_points(l_max);
   // create the vector of collocation points that we want to interpolate to
   tnsr::I<DataVector, 3> collocation_coordinates{number_of_angular_points};
-  for (const auto& collocation_point :
+  for (const auto collocation_point :
        Spectral::Swsh::cached_collocation_metadata<
            Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max)) {
     get<0>(collocation_coordinates)[collocation_point.offset] =

--- a/tests/Unit/Evolution/Systems/Cce/Test_GaugeTransformBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_GaugeTransformBoundaryData.cpp
@@ -186,7 +186,7 @@ void test_gauge_transforms_via_inverse_coordinate_map(
         (void)l_max;
         const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
             Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
-        for (const auto& collocation_point : collocation) {
+        for (const auto collocation_point : collocation) {
           get<1>(cauchy_angular_coordinates)[collocation_point.offset] =
               collocation_point.phi + 1.0e-2 * variation_amplitude *
                                           cos(collocation_point.phi) *
@@ -230,7 +230,7 @@ void test_gauge_transforms_via_inverse_coordinate_map(
         (void)l_max;
         const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
             Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
-        for (const auto& collocation_point : collocation) {
+        for (const auto collocation_point : collocation) {
           auto rootfind = RootFinder::toms748(
               [&collocation_point, &variation_amplitude](const double x) {
                 return collocation_point.phi -
@@ -264,7 +264,7 @@ void test_gauge_transforms_via_inverse_coordinate_map(
         db::get<Tags::CauchyAngularCoords>(forward_transform_box);
     const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
         Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
-    for (const auto& collocation_point : collocation) {
+    for (const auto collocation_point : collocation) {
       angular_phi = collocation_point.phi + 1.0e-2 * variation_amplitude *
                                                 cos(collocation_point.phi) *
                                                 sin(collocation_point.theta);

--- a/tests/Unit/Evolution/Systems/Cce/Test_LinearSolve.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_LinearSolve.cpp
@@ -357,7 +357,7 @@ void test_pole_integration_with_linear_operator(
                           make_not_null(&dist));
   const auto& coefficients_metadata =
       Spectral::Swsh::cached_coefficients_metadata(l_max);
-  for (const auto& mode : coefficients_metadata) {
+  for (const auto mode : coefficients_metadata) {
     if (mode.l > l_max - 2) {
       random_angular_modes.data()[mode.transform_of_real_part_offset] = 0.0;
       random_angular_modes.data()[mode.transform_of_imag_part_offset] = 0.0;

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Limiters/TestHelpers.hpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Limiters/TestHelpers.hpp
@@ -30,7 +30,7 @@ Element<VolumeDim> make_element(
     const std::unordered_set<Direction<VolumeDim>>&
         directions_of_external_boundaries = {}) noexcept {
   typename Element<VolumeDim>::Neighbors_t neighbors;
-  for (const auto dir : Direction<VolumeDim>::all_directions()) {
+  for (const auto& dir : Direction<VolumeDim>::all_directions()) {
     // Element has neighbors in directions with internal boundaries
     if (directions_of_external_boundaries.count(dir) == 0) {
       const size_t index =

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/AnalyticSolutions/AnalyticDataHelpers.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/AnalyticSolutions/AnalyticDataHelpers.hpp
@@ -54,7 +54,7 @@ struct SphericalSolutionWrapper : public SphericalSolution {
     Scalar<DataVector> cos_theta{size};
     const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
         Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
-    for (const auto& collocation_point : collocation) {
+    for (const auto collocation_point : collocation) {
       get(sin_theta)[collocation_point.offset] = sin(collocation_point.theta);
       get(cos_theta)[collocation_point.offset] = cos(collocation_point.theta);
     }

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/BoundaryTestHelpers.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/BoundaryTestHelpers.hpp
@@ -72,7 +72,7 @@ void create_fake_time_varying_gh_nodal_data(
   tnsr::I<DataVector, 3> collocation_points{number_of_angular_points};
   const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
       Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
-  for (const auto& collocation_point : collocation) {
+  for (const auto collocation_point : collocation) {
     get<0>(collocation_points)[collocation_point.offset] =
         extraction_radius * (1.0 + amplitude * sin(frequency * time)) *
         sin(collocation_point.theta) * cos(collocation_point.phi);
@@ -144,7 +144,7 @@ void create_fake_time_varying_modal_data(
   tnsr::I<DataVector, 3> collocation_points{number_of_angular_points};
   const auto& collocation = Spectral::Swsh::cached_collocation_metadata<
       Spectral::Swsh::ComplexRepresentation::Interleaved>(l_max);
-  for (const auto& collocation_point : collocation) {
+  for (const auto collocation_point : collocation) {
     get<0>(collocation_points)[collocation_point.offset] =
         extraction_radius * (1.0 + amplitude * sin(frequency * time)) *
         sin(collocation_point.theta) * cos(collocation_point.phi);

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshCoefficients.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshCoefficients.cpp
@@ -24,8 +24,7 @@
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
 
-namespace Spectral {
-namespace Swsh {
+namespace Spectral::Swsh {
 namespace {
 
 void test_swsh_coefficients_class_interface() noexcept {
@@ -49,7 +48,7 @@ void test_swsh_coefficients_class_interface() noexcept {
   CHECK(precomputed_libsharp_lm.l_max() == l_max);
   CHECK(computed_coefficients.l_max() == l_max);
 
-  sharp_alm_info* expected_sharp_alm_info;
+  sharp_alm_info* expected_sharp_alm_info = nullptr;
   sharp_make_triangular_alm_info(l_max, l_max, 1, &expected_sharp_alm_info);
 
   // check that all of the precomputed coefficients, the directly constructed
@@ -275,5 +274,4 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.SwshCoefficients",
   ERROR("Failed to trigger ERROR in an error test");
 }
 }  // namespace
-}  // namespace Swsh
-}  // namespace Spectral
+}  // namespace Spectral::Swsh

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshCoefficients.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshCoefficients.cpp
@@ -104,7 +104,7 @@ void test_swsh_coefficients_class_interface() noexcept {
   size_t offset_counter = 0;
   size_t expected_l = 0;
   size_t expected_m = 0;
-  for (const auto& coefficient_info : precomputed_libsharp_lm) {
+  for (const auto coefficient_info : precomputed_libsharp_lm) {
     CHECK(coefficient_info.transform_of_real_part_offset == offset_counter);
     CHECK(coefficient_info.transform_of_imag_part_offset -
               coefficient_info.transform_of_real_part_offset ==
@@ -157,7 +157,7 @@ void check_goldberg_mode_conversion() {
   for (size_t i = 0; i < number_of_radial_points; ++i) {
     for (int l = 0; l <= static_cast<int>(l_max); ++l) {
       for (int m = -l; m <= l; ++m) {
-        for (const auto& collocation_point :
+        for (const auto collocation_point :
              cached_collocation_metadata<Representation>(l_max)) {
           goldberg_collocation_points
               .data()[collocation_point.offset +
@@ -185,7 +185,7 @@ void check_goldberg_mode_conversion() {
                                swsh_approx);
 
   for (size_t i = 0; i < number_of_radial_points; ++i) {
-    for (const auto& coefficient_info : precomputed_libsharp_lm) {
+    for (const auto coefficient_info : precomputed_libsharp_lm) {
       auto goldberg_mode_plus_m =
           libsharp_mode_to_goldberg_plus_m(coefficient_info, test_modes, i);
       // should be the same value computed using the other interface

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshCollocation.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshCollocation.cpp
@@ -82,7 +82,7 @@ void test_spherical_harmonic_collocation() noexcept {
         precomputed_collocation_value.cend());
   CHECK(precomputed_collocation_value.begin() !=
         precomputed_collocation_value.end());
-  for (const auto& collocation_point : precomputed_collocation_value) {
+  for (const auto collocation_point : precomputed_collocation_value) {
     CHECK(collocation_point.offset == offset_counter);
     CHECK(collocation_point.theta ==
           computed_collocation.theta(offset_counter));

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshCollocation.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshCollocation.cpp
@@ -14,8 +14,7 @@
 #include "NumericalAlgorithms/Spectral/ComplexDataView.hpp"
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
 
-namespace Spectral {
-namespace Swsh {
+namespace Spectral::Swsh {
 namespace {
 
 // IWYU pragma: no_include <sharp_geomhelpers.h>
@@ -45,9 +44,10 @@ void test_spherical_harmonic_collocation() noexcept {
 
   const int expected_stride = detail::ComplexDataView<Representation>::stride();
 
-  sharp_geom_info* manual_sgi;
+  sharp_geom_info* manual_sgi = nullptr;
   sharp_make_gauss_geom_info(
-      l_max + 1, 2 * l_max + 1, 0.0, expected_stride,
+      static_cast<int>(l_max) + 1, 2 * static_cast<int>(l_max) + 1, 0.0,
+      expected_stride,
       static_cast<unsigned long>(expected_stride) * (2 * l_max + 1),
       &manual_sgi);
 
@@ -147,5 +147,4 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.SwshCollocation",
   ERROR("Failed to trigger ERROR in an error test");
 }
 }  // namespace
-}  // namespace Swsh
-}  // namespace Spectral
+}  // namespace Spectral::Swsh

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshFiltering.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshFiltering.cpp
@@ -41,7 +41,7 @@ void test_angular_filtering() noexcept {
   generated_modes.data() = make_with_random_values<ComplexModalVector>(
       make_not_null(&gen), make_not_null(&coefficient_distribution),
       size_of_libsharp_coefficient_vector(l_max));
-  for (const auto& mode : cached_coefficients_metadata(l_max)) {
+  for (const auto mode : cached_coefficients_metadata(l_max)) {
     if (mode.l < static_cast<size_t>(abs(Spin))) {
       generated_modes.data()[mode.transform_of_real_part_offset] = 0.0;
       generated_modes.data()[mode.transform_of_imag_part_offset] = 0.0;
@@ -59,7 +59,7 @@ void test_angular_filtering() noexcept {
       pre_filter_angular_data.data(), number_of_radial_points)};
 
   // remove the top few modes, emulating the filter process
-  for (const auto& mode : cached_coefficients_metadata(l_max)) {
+  for (const auto mode : cached_coefficients_metadata(l_max)) {
     if (mode.l > (l_max - 3)) {
       generated_modes.data()[mode.transform_of_real_part_offset] = 0.0;
       generated_modes.data()[mode.transform_of_imag_part_offset] = 0.0;

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
@@ -346,7 +346,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN.Boundary",
 
   // Local stepping with constant step sizes
   const Slab slab(0., 1.);
-  for (const auto full : {slab.duration(), -slab.duration()}) {
+  for (const auto& full : {slab.duration(), -slab.duration()}) {
     do_lts_test({{full / 4, full / 4}});
     do_lts_test({{full / 4, full / 8}});
     do_lts_test({{full / 8, full / 4}});


### PR DESCRIPTION
## Proposed changes

AppleClang 12 emits these warnings:

```console
.../src/NumericalAlgorithms/Spectral/SwshDerivatives.cpp:27:20: warning: loop variable 'mode' is always a copy because the range of type 'const Spectral::Swsh::CoefficientsMetadata' does not return a reference [-Wrange-loop-analysis]
  for (const auto& mode : cached_coefficients_metadata(l_max)) {
```

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
