### PR TITLE
Run Python executables in correct environment

### DIFF
--- a/cmake/SpectrePythonExecutable.sh
+++ b/cmake/SpectrePythonExecutable.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+PYTHONPATH="@CMAKE_BINARY_DIR@/bin/python:$PYTHONPATH" @Python_EXECUTABLE@ \
+  -m @PYTHON_MODULE_LOCATION@.@PYTHON_FILE_JUST_NAME_WE@

--- a/docs/DevGuide/PythonBindings.md
+++ b/docs/DevGuide/PythonBindings.md
@@ -25,12 +25,16 @@ the CMake function. If you specify `SOURCES`, you must also specify a
 `LIBRARY_NAME`. A good `LIBRARY_NAME` is the name of the C++ library for which
 bindings are being built prefixed with `Py`, e.g. `PyDataStructures`. If the
 Python module will only consist of Python files, then the `SOURCES` option
-should not be specified. Python files that should be part
-of the module can be passed with the keyword `PYTHON_FILES`, e.g.
-`PYTHON_FILES Hello.py HelloWorld.py`. Finally, the `MODULE_PATH` named argument
-can be passed with a string that is the path to where the module should be. For
-example, `MODULE_PATH "submodule0/submodule1/"` would mean the module is
-accessed from python using `import spectre.submodule0.submodule1.MODULE_NAME`.
+should not be specified. Python files that should be part of the module can be
+passed with the keywords `PYTHON_FILES` or `PYTHON_EXECUTABLES`, where the
+latter exposes them in `bin/` in the SpECTRE build directory. For example, the
+arguments `PYTHON_FILES Hello.py PYTHON_EXECUTABLES HelloWorld.py` produce a
+Python module that contains both files, but `HelloWorld.py` can be run directly
+as `bin/HelloWorld` from the SpECTRE build directory. Finally, the `MODULE_PATH`
+named argument can be passed with a string that is the path to where the module
+should be. For example, `MODULE_PATH "submodule0/submodule1/"` would mean the
+module is accessed from python using
+`import spectre.submodule0.submodule1.MODULE_NAME`.
 
 Here is a complete example of how to call the `spectre_python_add_module`
 function:
@@ -42,6 +46,7 @@ spectre_python_add_module(
   MODULE_PATH "DataStructures/"
   SOURCES Bindings.cpp MyCoolDataStructure.cpp
   PYTHON_FILES CoolPythonDataStructure.py
+  PYTHON_EXECUTABLES HelloWorld.py
   )
 \endcode
 

--- a/src/Visualization/Python/CMakeLists.txt
+++ b/src/Visualization/Python/CMakeLists.txt
@@ -5,17 +5,7 @@ set(LIBRARY "PyVisualization")
 
 spectre_python_add_module(
   Visualization
-  PYTHON_FILES
-  Visualization/Python/GenerateXdmf.py
-  Visualization/Python/Render1D.py
+  PYTHON_EXECUTABLES
+  GenerateXdmf.py
+  Render1D.py
   )
-
-spectre_python_add_executable(
-  GenerateXdmf
-  Visualization/GenerateXdmf.py
-)
-
-spectre_python_add_executable(
-  Render1D
-  Visualization/Render1D.py
-)


### PR DESCRIPTION
## Proposed changes

Python executables exposed in bin/ now always run in the Python
environment used when configuring CMake. This makes it much easier to
run them because you don't have to make sure you're in the right environment.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
