### PR TITLE
Add DimensionfulSpinMagnitudeTag to Tags.hpp

### DIFF
--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -627,5 +627,27 @@ struct SpinFunctionCompute : SpinFunction, db::ComputeTag {
   using return_type = Scalar<DataVector>;
 };
 
+/// The approximate-Killing-Vector quasilocal spin magnitude of a Strahlkorper
+/// (see Sec. 2.2 of \cite Boyle2019kee and references therein).
+struct DimensionfulSpinMagnitude : db::SimpleTag {
+  using type = double;
+};
+
+/// Computes the approximate-Killing-Vector quasilocal spin magnitude of a
+/// Strahlkorper
+template <typename Frame>
+struct DimensionfulSpinMagnitudeCompute : DimensionfulSpinMagnitude,
+                                          db::ComputeTag {
+  using base = DimensionfulSpinMagnitude;
+  using return_type = double;
+  static constexpr auto function =
+      &StrahlkorperGr::dimensionful_spin_magnitude<Frame>;
+  using argument_tags =
+      tmpl::list<StrahlkorperTags::RicciScalar, SpinFunction,
+                 gr::Tags::SpatialMetric<3, Frame>,
+                 StrahlkorperTags::Tangents<Frame>,
+                 StrahlkorperTags::Strahlkorper<Frame>, AreaElement<Frame>>;
+};
+
 }  // namespace Tags
 }  // namespace StrahlkorperGr

--- a/src/ApparentHorizons/TagsDeclarations.hpp
+++ b/src/ApparentHorizons/TagsDeclarations.hpp
@@ -67,6 +67,9 @@ struct IrreducibleMassCompute;
 struct SpinFunction;
 template <typename Frame>
 struct SpinFunctionCompute;
+struct DimensionfulSpinMagnitude;
+template <typename Frame>
+struct DimensionfulSpinMagnitudeCompute;
 
 }  // namespace Tags
 }  // namespace StrahlkorperGr

--- a/tests/Unit/ApparentHorizons/Test_Tags.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Tags.cpp
@@ -303,6 +303,9 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
   TestHelpers::db::test_simple_tag<StrahlkorperGr::Tags::SpinFunction>(
       "SpinFunction");
   TestHelpers::db::test_simple_tag<
+      StrahlkorperGr::Tags::DimensionfulSpinMagnitude>(
+      "DimensionfulSpinMagnitude");
+  TestHelpers::db::test_simple_tag<
       StrahlkorperTags::UnitNormalOneForm<Frame::Inertial>>(
       "UnitNormalOneForm");
   TestHelpers::db::test_simple_tag<
@@ -419,4 +422,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
   TestHelpers::db::test_compute_tag<
       StrahlkorperGr::Tags::SpinFunctionCompute<Frame::Inertial>>(
       "SpinFunction");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperGr::Tags::DimensionfulSpinMagnitudeCompute<Frame::Inertial>>(
+      "DimensionfulSpinMagnitude");
 }


### PR DESCRIPTION
## Proposed changes

The DimensionfulSpinMagnitudeTag and DimensionfulSpinMagnitudeCompute measure the approximate-Killing-Vector quasilocal spin magnitude of a Strahlkorper.
### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

