### PR TITLE
Fix false negatives in db::apply callable check

### DIFF
--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -222,7 +222,7 @@
  *
  * Subitems specify requirements on the tags they act on. For example, there
  * could be a requirement that all tags with a certain type are to be treated as
- * a Subitms. Let's say that the `Parent` tag holds a `Variables`, and
+ * a Subitems. Let's say that the `Parent` tag holds a `Variables`, and
  * `Variables` can be used with the Subitems infrastructure to add the nested
  * `Tensor`s. Then all tags that hold a `Variables` will have their subitems
  * added into the DataBox. To add a new type as a subitem the `db::Subitems`

--- a/src/DataStructures/DataBox/DataBoxTag.hpp
+++ b/src/DataStructures/DataBox/DataBoxTag.hpp
@@ -111,6 +111,16 @@ template <class T>
 constexpr bool has_return_type_member_v = has_return_type_member<T>::value;
 
 template <typename T>
+struct ConvertToConst {
+  using type = const T&;
+};
+
+template <typename T>
+struct ConvertToConst<std::unique_ptr<T>> {
+  using type = const T&;
+};
+
+template <typename T>
 const T& convert_to_const_type(const T& item) noexcept {
   return item;
 }
@@ -226,8 +236,8 @@ struct item_type_impl {
 // Get the type that is returned by `get<Tag>`. If it is a base tag then a
 // `TagList` must be passed as a second argument.
 template <typename Tag, typename TagList = NoSuchType>
-using const_item_type = std::decay_t<decltype(
-    convert_to_const_type(std::declval<storage_type<Tag, TagList>>()))>;
+using const_item_type =
+    typename ConvertToConst<std::decay_t<storage_type<Tag, TagList>>>::type;
 
 // Get the type that can be written to the `Tag`. If it is a base tag then a
 // `TagList` must be passed as a second argument.

--- a/src/Domain/InterfaceHelpers.hpp
+++ b/src/Domain/InterfaceHelpers.hpp
@@ -188,7 +188,7 @@ struct InterfaceApplyImpl<DirectionsTag, tmpl::list<ArgumentTags...>,
             typename... ExtraArgs,
             Requires<is_apply_callable_v<
                 InterfaceInvokable,
-                const db::detail::const_item_type<ArgumentTags, DbTagsList>&...,
+                db::detail::const_item_type<ArgumentTags, DbTagsList>...,
                 ExtraArgs...>> = nullptr>
   static constexpr auto apply(InterfaceInvokable&& interface_invokable,
                               const db::DataBox<DbTagsList>& box,
@@ -209,7 +209,7 @@ struct InterfaceApplyImpl<DirectionsTag, tmpl::list<ArgumentTags...>,
             typename... ExtraArgs,
             Requires<not is_apply_callable_v<
                 InterfaceInvokable,
-                const db::detail::const_item_type<ArgumentTags, DbTagsList>&...,
+                db::detail::const_item_type<ArgumentTags, DbTagsList>...,
                 ExtraArgs...>> = nullptr>
   static constexpr auto apply(InterfaceInvokable&& interface_invokable,
                               const db::DataBox<DbTagsList>& box,


### PR DESCRIPTION
## Proposed changes

The checks reported failures in cases where actually calling the
function would have succeeded, because they missed a `const &`.
Using `decltype()` now to guarantee the argument type is correct.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
