### PR TITLE
Remove unneeded TensorExpression storage index maps

### DIFF
--- a/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
@@ -524,9 +524,16 @@ struct TensorExpression<Derived, DataType, Symm, tmpl::list<Indices...>,
     if constexpr (not tt::is_a_v<Tensor, Derived>) {
       return static_cast<const Derived&>(*this)
           .template get<LhsStructure, LhsIndices...>(lhs_storage_index);
-    } else if constexpr (sizeof...(LhsIndices) < 2) {
+    } else if constexpr (std::is_same_v<LhsStructure, structure> and
+                         std::is_same_v<tmpl::list<LhsIndices...>,
+                                        tmpl::list<Args...>>) {
+      // the LHS and RHS tensors have the same structure and generic index
+      // order, so the RHS storage index is equivalent to the LHS storage index
       return (*t_)[lhs_storage_index];
     } else {
+      // the LHS and RHS tensors do not have the same structure or generic index
+      // order, so we must map the LHS storage index to its corresponding RHS
+      // storage index
       constexpr std::array<size_t, LhsStructure::size()> lhs_to_rhs_map =
           compute_lhs_to_rhs_map<LhsStructure, LhsIndices...>();
       return (*t_)[gsl::at(lhs_to_rhs_map, lhs_storage_index)];


### PR DESCRIPTION
## Proposed changes

This PR updates the storage index `TensorExpression::get` to only create a precomputed map of the LHS and RHS storage indices when the LHS and RHS tensors' generic index orders and/or structures differ (when a mapping is needed). See **Further Comments** for more details.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

When working with `TensorExpression`s, the assignment of a component of the resulting LHS tensor is done through the storage index `TensorExpression::get`. If the RHS expression is a tensor, the function gets the LHS component by finding the component in the RHS tensor. To do this, it creates a precomputed mapping between the storage indices of the LHS and RHS tensors, according to their respective generic index orders and structures. This mapping is only needed when the LHS and RHS tensors' generic index orders and/or structures differ, because if they are equal, the LHS and RHS storage indices map to the same components. This PR updates the storage index `TensorExpression::get` to only create and use this mapping when the LHS and RHS tensors' generic index orders and/or structures differ.

To demonstrate the effect, if we evaluate the expression `L_ab = R_ab` (same generic index order: a, b) and the structures of `L_ab` and `R_ab` are equivalent (i.e. their symmetries are also the same), then a precomputed mapping between the storage indices will not be generated, because the LHS and RHS storage indices correspond to the same components.
