### PR TITLE
Add SphericalCompression CoordMap

### DIFF
--- a/src/Domain/CoordinateMaps/Affine.hpp
+++ b/src/Domain/CoordinateMaps/Affine.hpp
@@ -51,6 +51,10 @@ class Affine {
   std::array<tt::remove_cvref_wrap_t<T>, 1> operator()(
       const std::array<T, 1>& source_coords) const noexcept;
 
+  /// The inverse function is only callable with doubles because the inverse
+  /// might fail if called for a point out of range, and it is unclear
+  /// what should happen if the inverse were to succeed for some points in a
+  /// DataVector but fail for other points.
   std::optional<std::array<double, 1>> inverse(
       const std::array<double, 1>& target_coords) const noexcept;
 

--- a/src/Domain/CoordinateMaps/BulgedCube.hpp
+++ b/src/Domain/CoordinateMaps/BulgedCube.hpp
@@ -503,6 +503,10 @@ class BulgedCube {
   std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
       const std::array<T, 3>& source_coords) const noexcept;
 
+  /// The inverse function is only callable with doubles because the inverse
+  /// might fail if called for a point out of range, and it is unclear
+  /// what should happen if the inverse were to succeed for some points in a
+  /// DataVector but fail for other points.
   std::optional<std::array<double, 3>> inverse(
       const std::array<double, 3>& target_coords) const noexcept;
 

--- a/src/Domain/CoordinateMaps/CoordinateMap.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.hpp
@@ -108,6 +108,10 @@ class CoordinateMapBase : public PUP::able {
   /// at `target_point`, or if `target_point` can be easily determined to not
   /// make sense for the map.  An example of the latter is passing a
   /// point with a negative value of z into a positive-z Wedge3D inverse map.
+  /// The inverse function is only callable with doubles because the inverse
+  /// might fail if called for a point out of range, and it is unclear
+  /// what should happen if the inverse were to succeed for some points in a
+  /// DataVector but fail for other points.
   virtual std::optional<tnsr::I<double, Dim, SourceFrame>> inverse(
       tnsr::I<double, Dim, TargetFrame> target_point,
       double time = std::numeric_limits<double>::signaling_NaN(),

--- a/src/Domain/CoordinateMaps/CylindricalEndcap.hpp
+++ b/src/Domain/CoordinateMaps/CylindricalEndcap.hpp
@@ -135,6 +135,10 @@ class CylindricalEndcap {
   std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
       const std::array<T, 3>& source_coords) const noexcept;
 
+  /// The inverse function is only callable with doubles because the inverse
+  /// might fail if called for a point out of range, and it is unclear
+  /// what should happen if the inverse were to succeed for some points in a
+  /// DataVector but fail for other points.
   std::optional<std::array<double, 3>> inverse(
       const std::array<double, 3>& target_coords) const noexcept;
 

--- a/src/Domain/CoordinateMaps/DiscreteRotation.hpp
+++ b/src/Domain/CoordinateMaps/DiscreteRotation.hpp
@@ -45,6 +45,10 @@ class DiscreteRotation {
   std::array<tt::remove_cvref_wrap_t<T>, VolumeDim> operator()(
       const std::array<T, VolumeDim>& source_coords) const noexcept;
 
+  /// The inverse function is only callable with doubles because the inverse
+  /// might fail if called for a point out of range, and it is unclear
+  /// what should happen if the inverse were to succeed for some points in a
+  /// DataVector but fail for other points.
   std::optional<std::array<double, VolumeDim>> inverse(
       const std::array<double, VolumeDim>& target_coords) const noexcept;
 

--- a/src/Domain/CoordinateMaps/EquatorialCompression.hpp
+++ b/src/Domain/CoordinateMaps/EquatorialCompression.hpp
@@ -68,6 +68,10 @@ class EquatorialCompression {
   std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
       const std::array<T, 3>& source_coords) const noexcept;
 
+  /// The inverse function is only callable with doubles because the inverse
+  /// might fail if called for a point out of range, and it is unclear
+  /// what should happen if the inverse were to succeed for some points in a
+  /// DataVector but fail for other points.
   std::optional<std::array<double, 3>> inverse(
       const std::array<double, 3>& target_coords) const noexcept;
 

--- a/src/Domain/CoordinateMaps/Equiangular.hpp
+++ b/src/Domain/CoordinateMaps/Equiangular.hpp
@@ -67,6 +67,10 @@ class Equiangular {
   std::array<tt::remove_cvref_wrap_t<T>, 1> operator()(
       const std::array<T, 1>& source_coords) const noexcept;
 
+  /// The inverse function is only callable with doubles because the inverse
+  /// might fail if called for a point out of range, and it is unclear
+  /// what should happen if the inverse were to succeed for some points in a
+  /// DataVector but fail for other points.
   std::optional<std::array<double, 1>> inverse(
       const std::array<double, 1>& target_coords) const noexcept;
 

--- a/src/Domain/CoordinateMaps/FocallyLiftedEndcap.hpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedEndcap.hpp
@@ -389,6 +389,10 @@ class Endcap {
           target_coords,
       const std::array<T, 3>& source_coords) const noexcept;
 
+  /// The inverse function is only callable with doubles because the inverse
+  /// might fail if called for a point out of range, and it is unclear
+  /// what should happen if the inverse were to succeed for some points in a
+  /// DataVector but fail for other points.
   std::optional<std::array<double, 3>> inverse(
       const std::array<double, 3>& target_coords,
       double sigma_in) const noexcept;

--- a/src/Domain/CoordinateMaps/FocallyLiftedMap.hpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedMap.hpp
@@ -317,6 +317,10 @@ class FocallyLiftedMap {
   std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
       const std::array<T, 3>& source_coords) const noexcept;
 
+  /// The inverse function is only callable with doubles because the inverse
+  /// might fail if called for a point out of range, and it is unclear
+  /// what should happen if the inverse were to succeed for some points in a
+  /// DataVector but fail for other points.
   std::optional<std::array<double, 3>> inverse(
       const std::array<double, 3>& target_coords) const noexcept;
 

--- a/src/Domain/CoordinateMaps/Frustum.hpp
+++ b/src/Domain/CoordinateMaps/Frustum.hpp
@@ -185,6 +185,10 @@ class Frustum {
   /// the apex of the pyramid, tetrahedron, or triangular prism that is
   /// formed by extending the `Frustum` (for a
   /// \f$z\f$-oriented `Frustum`).
+  /// The inverse function is only callable with doubles because the inverse
+  /// might fail if called for a point out of range, and it is unclear
+  /// what should happen if the inverse were to succeed for some points in a
+  /// DataVector but fail for other points.
   std::optional<std::array<double, 3>> inverse(
       const std::array<double, 3>& target_coords) const noexcept;
 

--- a/src/Domain/CoordinateMaps/Identity.hpp
+++ b/src/Domain/CoordinateMaps/Identity.hpp
@@ -40,6 +40,10 @@ class Identity {
   std::array<tt::remove_cvref_wrap_t<T>, Dim> operator()(
       const std::array<T, Dim>& source_coords) const noexcept;
 
+  /// The inverse function is only callable with doubles because the inverse
+  /// might fail if called for a point out of range, and it is unclear
+  /// what should happen if the inverse were to succeed for some points in a
+  /// DataVector but fail for other points.
   std::optional<std::array<double, Dim>> inverse(
       const std::array<double, Dim>& target_coords) const noexcept;
 

--- a/src/Domain/CoordinateMaps/ProductMaps.hpp
+++ b/src/Domain/CoordinateMaps/ProductMaps.hpp
@@ -48,6 +48,10 @@ class ProductOf2Maps {
   std::array<tt::remove_cvref_wrap_t<T>, dim> operator()(
       const std::array<T, dim>& source_coords) const noexcept;
 
+  /// The inverse function is only callable with doubles because the inverse
+  /// might fail if called for a point out of range, and it is unclear
+  /// what should happen if the inverse were to succeed for some points in a
+  /// DataVector but fail for other points.
   std::optional<std::array<double, dim>> inverse(
       const std::array<double, dim>& target_coords) const noexcept;
 

--- a/src/Domain/CoordinateMaps/Rotation.hpp
+++ b/src/Domain/CoordinateMaps/Rotation.hpp
@@ -63,6 +63,10 @@ class Rotation<2> {
   std::array<tt::remove_cvref_wrap_t<T>, 2> operator()(
       const std::array<T, 2>& source_coords) const noexcept;
 
+  /// The inverse function is only callable with doubles because the inverse
+  /// might fail if called for a point out of range, and it is unclear
+  /// what should happen if the inverse were to succeed for some points in a
+  /// DataVector but fail for other points.
   std::optional<std::array<double, 2>> inverse(
       const std::array<double, 2>& target_coords) const noexcept;
 

--- a/src/Domain/CoordinateMaps/SpecialMobius.hpp
+++ b/src/Domain/CoordinateMaps/SpecialMobius.hpp
@@ -99,6 +99,10 @@ class SpecialMobius {
       const std::array<T, 3>& source_coords) const noexcept;
 
   /// Returns std::nullopt for target_coords outside the unit sphere.
+  /// The inverse function is only callable with doubles because the inverse
+  /// might fail if called for a point out of range, and it is unclear
+  /// what should happen if the inverse were to succeed for some points in a
+  /// DataVector but fail for other points.
   std::optional<std::array<double, 3>> inverse(
       const std::array<double, 3>& target_coords) const noexcept;
 

--- a/src/Domain/CoordinateMaps/TimeDependent/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/TimeDependent/CMakeLists.txt
@@ -6,6 +6,7 @@ spectre_target_sources(
   PRIVATE
   CubicScale.cpp
   Rotation.cpp
+  SphericalCompression.cpp
   Translation.cpp
   )
 
@@ -17,5 +18,6 @@ spectre_target_headers(
   ProductMaps.hpp
   ProductMaps.tpp
   Rotation.hpp
+  SphericalCompression.hpp
   Translation.hpp
   )

--- a/src/Domain/CoordinateMaps/TimeDependent/CubicScale.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/CubicScale.cpp
@@ -93,10 +93,8 @@ std::array<tt::remove_cvref_wrap_t<T>, Dim> CubicScale<Dim>::operator()(
 }
 
 template <size_t Dim>
-template <typename T>
-std::optional<std::array<tt::remove_cvref_wrap_t<T>, Dim>>
-CubicScale<Dim>::inverse(
-    const std::array<T, Dim>& target_coords, const double time,
+std::optional<std::array<double, Dim>> CubicScale<Dim>::inverse(
+    const std::array<double, Dim>& target_coords, const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) const noexcept {
@@ -117,8 +115,7 @@ CubicScale<Dim>::inverse(
     // Construct std::optional to have a default value of an empty array.
     // Doing just result{} would construct a std::optional that doesn't hold a
     // value and so *result would throw an exception.
-    std::optional<std::array<tt::remove_cvref_wrap_t<T>, Dim>> result{
-        std::array<tt::remove_cvref_wrap_t<T>, Dim>{}};
+    std::optional<std::array<double, Dim>> result{std::array<double, Dim>{}};
     for (size_t i = 0; i < Dim; ++i) {
       gsl::at(*result, i) = one_over_a_of_t * gsl::at(target_coords, i);
     }
@@ -146,7 +143,7 @@ CubicScale<Dim>::inverse(
 
   // To invert the map we work in the dimensionless radius,
   // r / R_{outer_boundary}.
-  tt::remove_cvref_wrap_t<T> target_dimensionless_radius =
+  const double target_dimensionless_radius =
       magnitude(target_coords) * one_over_outer_boundary_;
 
   if (UNLIKELY(target_dimensionless_radius == 0.0)) {
@@ -164,8 +161,7 @@ CubicScale<Dim>::inverse(
 
   // For an initial guess, we provide a linearly approximated solution for
   // q, which is just r / (R b).
-  const tt::remove_cvref_wrap_t<T> initial_guess =
-      target_dimensionless_radius / b_of_t;
+  const double initial_guess = target_dimensionless_radius / b_of_t;
   const double cubic_coef_a = (b_of_t - a_of_t);
 
   // Solve the modified equation:
@@ -199,7 +195,7 @@ CubicScale<Dim>::inverse(
       RootFinder::newton_raphson(cubic_and_deriv, initial_guess, 0.0, 1.0, 14) /
       target_dimensionless_radius;
 
-  std::array<tt::remove_cvref_wrap_t<T>, Dim> result{};
+  std::array<double, Dim> result{};
   for (size_t i = 0; i < Dim; ++i) {
     gsl::at(result, i) = scale_factor * gsl::at(target_coords, i);
   }
@@ -415,25 +411,6 @@ bool operator==(const CubicScale<Dim>& lhs,
 
 #define INSTANTIATE(_, data)                                                 \
   template class CubicScale<DIM(data)>;                                      \
-  template std::optional<                                                    \
-      std::array<tt::remove_cvref_wrap_t<double>, DIM(data)>>                \
-  CubicScale<DIM(data)>::inverse(                                            \
-      const std::array<double, DIM(data)>& target_coords, const double time, \
-      const std::unordered_map<                                              \
-          std::string,                                                       \
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&         \
-          functions_of_time) const noexcept;                                 \
-  template std::optional<std::array<                                         \
-      tt::remove_cvref_wrap_t<std::reference_wrapper<const double>>,         \
-      DIM(data)>>                                                            \
-  CubicScale<DIM(data)>::inverse(                                            \
-      const std::array<std::reference_wrapper<const double>, DIM(data)>&     \
-          target_coords,                                                     \
-      const double time,                                                     \
-      const std::unordered_map<                                              \
-          std::string,                                                       \
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&         \
-          functions_of_time) const noexcept;                                 \
   template bool operator==(const CubicScale<DIM(data)>&,                     \
                            const CubicScale<DIM(data)>&) noexcept;
 

--- a/src/Domain/CoordinateMaps/TimeDependent/CubicScale.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/CubicScale.hpp
@@ -114,9 +114,12 @@ class CubicScale {
           functions_of_time) const noexcept;
 
   /// Returns std::nullopt if the point is outside the range of the map.
-  template <typename T>
-  std::optional<std::array<tt::remove_cvref_wrap_t<T>, Dim>> inverse(
-      const std::array<T, Dim>& target_coords, double time,
+  /// The inverse function is only callable with doubles because the inverse
+  /// might fail if called for a point out of range, and it is unclear
+  /// what should happen if the inverse were to succeed for some points in a
+  /// DataVector but fail for other points.
+  std::optional<std::array<double, Dim>> inverse(
+      const std::array<double, Dim>& target_coords, double time,
       const std::unordered_map<
           std::string,
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&

--- a/src/Domain/CoordinateMaps/TimeDependent/ProductMaps.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ProductMaps.hpp
@@ -61,6 +61,10 @@ class ProductOf2Maps {
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time) const noexcept;
 
+  /// The inverse function is only callable with doubles because the inverse
+  /// might fail if called for a point out of range, and it is unclear
+  /// what should happen if the inverse were to succeed for some points in a
+  /// DataVector but fail for other points.
   std::optional<std::array<double, dim>> inverse(
       const std::array<double, dim>& target_coords, double time,
       const std::unordered_map<

--- a/src/Domain/CoordinateMaps/TimeDependent/Rotation.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Rotation.hpp
@@ -69,6 +69,10 @@ class Rotation<2> {
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time) const noexcept;
 
+  /// The inverse function is only callable with doubles because the inverse
+  /// might fail if called for a point out of range, and it is unclear
+  /// what should happen if the inverse were to succeed for some points in a
+  /// DataVector but fail for other points.
   std::optional<std::array<double, 2>> inverse(
       const std::array<double, 2>& target_coords, double time,
       const std::unordered_map<

--- a/src/Domain/CoordinateMaps/TimeDependent/SphericalCompression.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/SphericalCompression.cpp
@@ -1,0 +1,356 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/TimeDependent/SphericalCompression.hpp"
+
+#include <array>
+#include <cmath>
+#include <iomanip>
+#include <limits>
+#include <pup.h>
+#include <pup_stl.h>
+#include <string>
+#include <type_traits>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/StdHelpers.hpp"
+
+namespace {
+template <typename T>
+using ResultType = tt::remove_cvref_wrap_t<T>;
+
+// Evaluate \f$\lambda_{00}(t) * Y_{00} = \lambda_{00}(t) / sqrt{4\pi}\f$.
+double lambda00_y00(
+    const std::string& f_of_t_name, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) noexcept {
+  ASSERT(functions_of_time.find(f_of_t_name) != functions_of_time.end(),
+         "Could not find function of time: '"
+             << f_of_t_name << "' in functions of time. Known functions are "
+             << keys_of(functions_of_time));
+  return functions_of_time.at(f_of_t_name)->func(time)[0][0] * 0.25 *
+         M_2_SQRTPI;
+}
+
+// Evaluate \f$\lambda_{00}^{\prime}(t) / sqrt{4\pi}\f$.
+double dt_lambda00_y00(
+    const std::string& f_of_t_name, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) noexcept {
+  ASSERT(functions_of_time.find(f_of_t_name) != functions_of_time.end(),
+         "Could not find function of time: '"
+             << f_of_t_name << "' in functions of time. Known functions are "
+             << keys_of(functions_of_time));
+  return functions_of_time.at(f_of_t_name)->func_and_deriv(time)[1][0] * 0.25 *
+         M_2_SQRTPI;
+}
+
+// Evaluate \f$\rho^i = \xi^i - C^i\f$ or \f$r^i = x^i - C^i\f$.
+template <typename T>
+std::array<ResultType<T>, 3> radial_position(
+    const std::array<T, 3>& coords,
+    const std::array<double, 3>& center) noexcept {
+  std::array<ResultType<T>, 3> result{};
+  for (size_t i = 0; i < 3; ++i) {
+    gsl::at(result, i) = gsl::at(coords, i) - gsl::at(center, i);
+  }
+  return result;
+}
+
+// Adds the correction (terms other than the source coordinates) to
+// compute either the mapped coordinate (if input is initially the source
+// coordinates and and lambda_y is lambda00'(t) /sqrt(4*M_PI)) or the frame
+// velocity (if input is initially zero and lambda_y is lambda00'(t)
+// /sqrt(4*M_PI)).
+template <bool InteriorMap, typename T>
+void correct_mapped_coordinate_or_frame_velocity(
+    const gsl::not_null<ResultType<T>*> input, const T& source_radial_coord,
+    const T& source_radius, const double lambda_y, const double min_radius,
+    const double max_radius) noexcept {
+  if constexpr (InteriorMap) {
+    *input -= lambda_y * source_radial_coord / min_radius;
+  } else {
+    *input -= lambda_y * source_radial_coord *
+              (max_radius / source_radius - 1.0) / (max_radius - min_radius);
+  }
+}
+
+template <bool InteriorMap, typename T>
+bool check_radius(const T& radius, const double min_radius,
+                  const double max_radius) {
+  auto radius_in_expected_range =
+      [](const T& source_radius, const double min_rad, const double max_rad) {
+        constexpr double eps = 100 * std::numeric_limits<double>::epsilon();
+        if constexpr (std::is_floating_point<ResultType<T>>::value) {
+          if constexpr (InteriorMap) {
+            return source_radius <= min_rad + eps;
+          } else {
+            return source_radius >= min_rad - eps and
+                   source_radius <= max_rad + eps;
+          }
+        } else {
+          if constexpr (InteriorMap) {
+            return max(source_radius) <= min_rad + eps;
+          } else {
+            return min(source_radius) >= min_rad - eps and
+                   max(source_radius) <= max_rad + eps;
+          }
+        }
+      };
+  return radius_in_expected_range(radius, min_radius, max_radius);
+}
+
+template <bool InteriorMap, typename T>
+void check_source_radius(const T& radius, const double min_radius,
+                         const double max_radius) {
+  if (!check_radius<InteriorMap, T>(radius, min_radius, max_radius)) {
+    ERROR("Source radius " << std::setprecision(20) << radius
+                           << " not in expected range. min_radius == "
+                           << min_radius << ", max_radius == " << max_radius
+                           << ", InteriorMap == " << InteriorMap << "\n");
+  }
+}
+
+template <bool InteriorMap, typename T>
+bool check_target_radius(const T& radius, const double min_radius,
+                         const double max_radius) {
+  return check_radius<InteriorMap, T>(radius, min_radius, max_radius);
+}
+}  // namespace
+
+namespace domain::CoordinateMaps::TimeDependent {
+template <bool InteriorMap>
+SphericalCompression<InteriorMap>::SphericalCompression(
+    std::string function_of_time_name, const double min_radius,
+    const double max_radius, const std::array<double, 3>& center) noexcept
+    : f_of_t_name_(std::move(function_of_time_name)),
+      min_radius_(min_radius),
+      max_radius_(max_radius),
+      center_(center) {
+  ASSERT(max_radius - min_radius > 1.0e-10,
+         "max_radius must be greater than min_radius, but max_radius - "
+         "min_radius == "
+             << max_radius - min_radius);
+}
+
+template <bool InteriorMap>
+template <typename T>
+std::array<ResultType<T>, 3> SphericalCompression<InteriorMap>::operator()(
+    const std::array<T, 3>& source_coords, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept {
+  const std::array<ResultType<T>, 3> source_rad_position{
+      radial_position(source_coords, center_)};
+  const ResultType<T> source_radius{magnitude(source_rad_position)};
+  check_source_radius<InteriorMap>(source_radius, min_radius_, max_radius_);
+  std::array<ResultType<T>, 3> result{};
+  for (size_t i = 0; i < 3; ++i) {
+    gsl::at(result, i) = gsl::at(source_coords, i);
+    correct_mapped_coordinate_or_frame_velocity<InteriorMap>(
+        make_not_null(&gsl::at(result, i)), gsl::at(source_rad_position, i),
+        source_radius, lambda00_y00(f_of_t_name_, time, functions_of_time),
+        min_radius_, max_radius_);
+  }
+  return result;
+}
+
+template <bool InteriorMap>
+std::optional<std::array<double, 3>> SphericalCompression<InteriorMap>::inverse(
+    const std::array<double, 3>& target_coords, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept {
+  const double lambda_y{lambda00_y00(f_of_t_name_, time, functions_of_time)};
+  if (UNLIKELY(min_radius_ - max_radius_ > lambda_y or
+               lambda_y > min_radius_)) {
+    return {};  // map not invertible
+  } else {
+    const std::array<double, 3> target_radial_position{
+        radial_position(target_coords, center_)};
+    const double target_radius{magnitude(target_radial_position)};
+    if (!check_target_radius<InteriorMap>(target_radius, min_radius_ - lambda_y,
+                                          max_radius_)) {
+      return std::nullopt;
+    }
+
+    double scale{std::numeric_limits<double>::signaling_NaN()};
+    if constexpr (InteriorMap) {
+      scale = 1.0 / (1.0 - lambda_y / min_radius_);
+    } else {
+      scale =
+          (max_radius_ - min_radius_ + lambda_y * max_radius_ / target_radius) /
+          (max_radius_ - min_radius_ + lambda_y);
+    }
+    std::array<double, 3> result{target_radial_position};
+    result[0] = result[0] * scale + center_[0];
+    result[1] = result[1] * scale + center_[1];
+    result[2] = result[2] * scale + center_[2];
+    return {result};
+  }
+}
+
+template <bool InteriorMap>
+template <typename T>
+std::array<ResultType<T>, 3> SphericalCompression<InteriorMap>::frame_velocity(
+    const std::array<T, 3>& source_coords, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept {
+  const std::array<ResultType<T>, 3> source_rad_position{
+      radial_position(source_coords, center_)};
+  const ResultType<T> source_radius{magnitude(source_rad_position)};
+  check_source_radius<InteriorMap>(source_radius, min_radius_, max_radius_);
+  auto result =
+      make_with_value<std::array<ResultType<T>, 3>>(source_radius, 0.0);
+  for (size_t i = 0; i < 3; ++i) {
+    gsl::at(result, i) = 0.0;
+    correct_mapped_coordinate_or_frame_velocity<InteriorMap>(
+        make_not_null(&gsl::at(result, i)), gsl::at(source_rad_position, i),
+        source_radius, dt_lambda00_y00(f_of_t_name_, time, functions_of_time),
+        min_radius_, max_radius_);
+  }
+  return result;
+}
+
+template <bool InteriorMap>
+template <typename T>
+tnsr::Ij<ResultType<T>, 3, Frame::NoFrame>
+SphericalCompression<InteriorMap>::jacobian(
+    const std::array<T, 3>& source_coords, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept {
+  const std::array<ResultType<T>, 3> source_rad_position{
+      radial_position(source_coords, center_)};
+  const ResultType<T> source_radius{magnitude(source_rad_position)};
+  const double lambda_y{lambda00_y00(f_of_t_name_, time, functions_of_time)};
+  check_source_radius<InteriorMap>(source_radius, min_radius_, max_radius_);
+  auto jacobian_matrix{
+      make_with_value<tnsr::Ij<ResultType<T>, 3, Frame::NoFrame>>(
+          dereference_wrapper(source_coords[0]),
+          std::numeric_limits<double>::signaling_NaN())};
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      if constexpr (not InteriorMap) {
+        jacobian_matrix.get(i, j) =
+            gsl::at(source_rad_position, i) * gsl::at(source_rad_position, j) *
+            lambda_y * (max_radius_) / (max_radius_ - min_radius_) /
+            cube(source_radius);
+        if (i == j) {
+          jacobian_matrix.get(i, j) +=
+              (1.0 - lambda_y * (max_radius_ / source_radius - 1.0) /
+                         (max_radius_ - min_radius_));
+        }
+      } else {
+        if (i == j) {
+          jacobian_matrix.get(i, j) = 1.0 - lambda_y / min_radius_;
+        } else {
+          jacobian_matrix.get(i, j) = 0.0;
+        }
+      }
+    }
+  }
+  return jacobian_matrix;
+}
+
+template <bool InteriorMap>
+template <typename T>
+tnsr::Ij<ResultType<T>, 3, Frame::NoFrame>
+SphericalCompression<InteriorMap>::inv_jacobian(
+    const std::array<T, 3>& source_coords, const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const noexcept {
+  // Obtain the Jacobian and then compute its inverse numerically.
+  // There is a clear opportunity here for a potential future optimization:
+  // instead of taking the determinant and inverse numerically, it is
+  // likely possible to compute them analytically.
+  return determinant_and_inverse(
+             jacobian(source_coords, time, functions_of_time))
+      .second;
+}
+
+template <bool InteriorMap>
+void SphericalCompression<InteriorMap>::pup(PUP::er& p) noexcept {
+  p | f_of_t_name_;
+  p | min_radius_;
+  p | max_radius_;
+  p | center_;
+}
+
+/// \cond
+#define INTERIOR_MAP(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                                 \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>               \
+  SphericalCompression<INTERIOR_MAP(data)>::operator()(                      \
+      const std::array<DTYPE(data), 3>& source_coords, const double time,    \
+      const std::unordered_map<                                              \
+          std::string,                                                       \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&         \
+          functions_of_time) const noexcept;                                 \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>               \
+  SphericalCompression<INTERIOR_MAP(data)>::frame_velocity(                  \
+      const std::array<DTYPE(data), 3>& source_coords, const double time,    \
+      const std::unordered_map<                                              \
+          std::string,                                                       \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&         \
+          functions_of_time) const noexcept;                                 \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame> \
+  SphericalCompression<INTERIOR_MAP(data)>::jacobian(                        \
+      const std::array<DTYPE(data), 3>& source_coords, double time,          \
+      const std::unordered_map<                                              \
+          std::string,                                                       \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&         \
+          functions_of_time) const noexcept;                                 \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame> \
+  SphericalCompression<INTERIOR_MAP(data)>::inv_jacobian(                    \
+      const std::array<DTYPE(data), 3>& source_coords, double time,          \
+      const std::unordered_map<                                              \
+          std::string,                                                       \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&         \
+          functions_of_time) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (true, false),
+                        (double, DataVector,
+                         std::reference_wrapper<const double>,
+                         std::reference_wrapper<const DataVector>))
+#undef DTYPE
+#undef INSTANTIATE
+
+#define INSTANTIATE(_, data)                                                  \
+  template SphericalCompression<INTERIOR_MAP(data)>::SphericalCompression(    \
+      std::string function_of_time_name, const double min_radius,             \
+      const double max_radius, const std::array<double, 3>& center) noexcept; \
+  template std::optional<std::array<double, 3>>                               \
+  SphericalCompression<INTERIOR_MAP(data)>::inverse(                          \
+      const std::array<double, 3>& target_coords, const double time,          \
+      const std::unordered_map<                                               \
+          std::string,                                                        \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&          \
+          functions_of_time) const noexcept;                                  \
+  template void SphericalCompression<INTERIOR_MAP(data)>::pup(                \
+      PUP::er& p) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (true, false))
+#undef INTERIOR_MAP
+#undef INSTANTIATE
+
+/// \endcond
+
+}  // namespace domain::CoordinateMaps::TimeDependent

--- a/src/Domain/CoordinateMaps/TimeDependent/SphericalCompression.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/SphericalCompression.hpp
@@ -1,0 +1,322 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
+
+/// \cond
+namespace domain::FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace domain::FunctionsOfTime
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace domain::CoordinateMaps::TimeDependent {
+/*!
+ * \ingroup CoordMapsTimeDependentGroup
+ * \brief Time-dependent compression of a finite 3D spherical volume.
+ *
+ * \details Let \f$\xi^i\f$ be the unmapped coordinates, and let \f$\rho\f$ be
+ * the Euclidean radius corresponding to these coordinates with respect to
+ * some center \f$C^i\f$. The transformation implemented by this map is
+ * equivalent to the following transformation: at each point, the mapped
+ * coordinates are the same as the unmapped coordinates, except in
+ * a spherical region \f$\rho \leq \rho_{\rm max}\f$, where instead coordinates
+ * are mapped using a compression that is spherically symmetric about the center
+ * \f$C^i\f$. The amount of compression decreases linearly from a maximum at
+ * \f$\rho = \rho_{\rm min}\f$ to zero at \f$\rho = \rho_{\rm max}\f$. A
+ * scalar domain::FunctionsOfTime::FunctionOfTime \f$\lambda_{00}(t)\f$ controls
+ * the amount of compression.
+ *
+ * The mapped coordinates are a continuous function of the unmapped
+ * coordinates, but the Jacobians are not continuous at \f$\rho_{\rm min}\f$
+ * and \f$\rho_{\rm max}\f$. Therefore, \f$\rho_{\rm min}\f$ and \f$\rho_{\rm
+ * max}\f$ should both be surfaces corresponding to block boundaries. Therefore,
+ * this class implements the transformation described above as follows: the
+ * if the template parameter `InteriorMap` is true, the map is the one
+ * appropriate for \f$\rho < \rho_{\rm min}\f$, while if `InteriorMap` is false,
+ * the map is the one appropriate for \f$\rho_{\rm min} \leq \rho \leq \rho_{\rm
+ * max}\f$. To use this map, add it to the blocks where the transformation is
+ * not the identity, using the appropriate template parameter, depending on
+ * which region the block is in.
+ *
+ * \note Currently, this map only performs a compression. A generalization of
+ * this map could also change the region's shape as well as its size, by
+ * including more terms than the spherically symmetric term included here.
+ *
+ * ### Mapped coordinates
+ *
+ * The mapped coordinates
+ * \f$x^i\f$ are related to the unmapped coordinates \f$\xi^i\f$
+ * as follows:
+ * \f{align}{
+ * x^i &= \left\{\begin{array}{ll}\xi^i - \frac{\lambda_{00}(t)}{\sqrt{4\pi}}
+ * \frac{\rho^i}{\rho_{\rm min}}, & \rho < \rho_{\rm min}, \\
+ * \xi^i - \frac{\lambda_{00}(t)}{\sqrt{4\pi}}
+ * \frac{\rho_{\rm max} / \rho - 1}{\rho_{\rm max} - \rho_{\rm min}} \rho^i, &
+ * \rho_{\rm min} \leq \rho \leq \rho_{\rm max}, \\
+ * \xi^i, & \rho_{\rm max} < \rho,\end{array}\right.
+ * \f}
+ * where \f$\rho^i = \xi^i - C^i\f$ is the Euclidean radial position vector in
+ * the unmapped coordinates with respect to the center \f$C^i\f$, \f$\rho =
+ * \sqrt{\delta_{kl}\left(\xi^k - C^l\right)\left(\xi^l - C^l\right)}\f$ is the
+ * Euclidean magnitude of \f$\rho^i\f$, and \f$\rho_j = \delta_{ij} \rho^i\f$.
+ *
+ * ### Frame velocity
+ *
+ * The frame velocity \f$v^i \equiv dx^i/dt\f$ is then
+ * \f{align}{
+ * v^i &= \left\{\begin{array}{ll} - \frac{\lambda_{00}^\prime(t)}{\sqrt{4\pi}}
+ * \frac{\rho^i}{\rho_{\rm min}}, & \rho < \rho_{\rm min}, \\
+ * - \frac{\lambda_{00}^\prime(t)}{\sqrt{4\pi}}
+ * \frac{\rho_{\rm max} / \rho - 1}{\rho_{\rm max} - \rho_{\rm min}} \rho^i,
+ * & \rho_{\rm min} \leq \rho \leq \rho_{\rm max}, \\
+ * 0, & \rho_{\rm max} < \rho,\end{array}\right.
+ * \f} where \f$\lambda_{00}^\prime(t) \equiv d\lambda_{00}/dt\f$.
+ *
+ * ### Jacobian
+ *
+ * Differentiating the equations for \f$x^i\f$ gives the Jacobian
+ * \f$\partial x^i / \partial \xi^j\f$. Using the result
+ * \f{align}{
+ * \frac{\partial \rho^i}{\partial \xi^j} &= \frac{\partial}{\partial \xi^j}
+ * \left(\xi^i - C^i\right) = \frac{\partial \xi^i}{\partial \xi^j}
+ * = \delta^i_{j}
+ * \f}
+ * and taking the derivatives yields
+ * \f{align}{
+ * \frac{\partial x^i}{\partial \xi^j} &= \left\{\begin{array}{ll}
+ * \delta^i_j \left(1
+ * - \frac{\lambda_{00}(t)}{\sqrt{4\pi}} \frac{1}{\rho_{\rm min}}\right),
+ * & \rho < \rho_{\rm min},\\
+ * \delta^i_j
+ * \left(1 - \frac{\lambda_{00}(t)}{\sqrt{4\pi}}
+ * \frac{\rho_{\rm max} / \rho - 1}{\rho_{\rm max} - \rho_{\rm min}}\right)
+ * - \rho^i \frac{\lambda_{00}(t)}{\sqrt{4\pi}}
+ * \frac{\partial}{\partial \xi^j}\left(
+ * \frac{\rho_{\rm max} / \rho - 1}{\rho_{\rm max} - \rho_{\rm min}}\right),
+ * & \rho_{\rm min} \leq \rho < \rho_{\rm max},\\
+ * \delta^i_j, & \rho_{\rm max} < \rho.\end{array}\right.
+ * \f}
+ * Inserting
+ * \f{align}{
+ * \frac{\partial}{\partial \xi^j}\left(
+ * \frac{\rho_{\rm max} / \rho - 1}{\rho_{\rm max} - \rho_{\rm min}}\right)
+ * &= \frac{\rho_{\rm max}}{\rho_{\rm max} - \rho_{\rm min}}
+ * \frac{\partial}{\partial \xi^j}\left(\frac{1}{\rho}\right)
+ * = - \frac{\rho_{\rm max}}{\rho_{\rm max} - \rho_{\rm min}} \frac{1}{\rho^2}
+ * \frac{\partial \rho}{\partial \xi^j}
+ * \f}
+ * and
+ * \f{align}{
+ * \frac{\partial \rho}{\partial \xi^j} &= \frac{\rho_j}{\rho}.
+ * \f}
+ * into the Jacobian yields
+ * \f{align}{
+ * \frac{\partial x^i}{\partial \xi^j} &= \left\{\begin{array}{ll}
+ * \delta^i_j \left(1
+ * - \frac{\lambda_{00}(t)}{\sqrt{4\pi}} \frac{1}{\rho_{\rm min}}\right),
+ * & \rho < \rho_{\rm min},\\
+ * \delta^i_j
+ * \left(1 - \frac{\lambda_{00}(t)}{\sqrt{4\pi}}
+ * \frac{\rho_{\rm max} / \rho - 1}{\rho_{\rm max} - \rho_{\rm min}}\right)
+ * + \rho^i \rho_j \frac{\lambda_{00}(t)}{\sqrt{4\pi}}
+ * \frac{\rho_{\rm max}}{\rho_{\rm max} - \rho_{\rm min}}\frac{1}{\rho^3},
+ * & \rho_{\rm min} \leq \rho < \rho_{\rm max},\\
+ * \delta^i_j, & \rho_{\rm max} < \rho.\end{array}\right.
+ * \f}
+ *
+ * ### Inverse Jacobian
+ *
+ * This map finds the inverse Jacobian by first finding the Jacobian and then
+ * numerically inverting it.
+ *
+ * ### Inverse map
+ *
+ * For \f$\lambda_{00}(t)\f$ that satisfy
+ * \f{align}{
+ * \rho_{\rm min} - \rho_{\rm max} < \lambda_{00}(t) / \sqrt{4\pi} <
+ * \rho_{\rm min},
+ * \f}
+ * the map will be invertible and nonsingular. For simplicity, here we
+ * enforce this condition, even though perhaps the map might be generalized to
+ * handle cases that are still invertible but violate this condition. This
+ * avoids the need to specially handle the cases
+ * \f$\lambda_{00}(t) / \sqrt{4\pi} = \rho_{\rm min} - \rho_{\rm max}\f$
+ * and \f$\lambda_{00}(t) / \sqrt{4\pi} = \rho_{\rm min}\f$, both of which
+ * yield a singular map, and it also avoids cases where the map behaves
+ * in undesirable ways (such as a larger \f$\lambda_{00}(t)\f$ leading to
+ * an expansion and a coordinate inversion instead of a compression).
+ *
+ * After
+ * requiring the above inequality to be satisfied, however, the inverse mapping
+ * can be derived as follows. Let \f$r^i \equiv x^i - C^i\f$. In terms of
+ * \f$r^i\f$, the map is \f{align}{ r^i &= \left\{\begin{array}{ll}\rho^i
+ * \left(1 - \frac{\lambda_{00}(t)}{\sqrt{4\pi}}
+ * \frac{1}{\rho_{\rm min}}\right), & \rho < \rho_{\rm min}, \\
+ * \rho^i\left(1 - \frac{\lambda_{00}(t)}{\sqrt{4\pi}}
+ * \frac{\rho_{\rm max} / \rho - 1}{\rho_{\rm max} - \rho_{\rm min}}\right),
+ * & \rho_{\rm min} \leq \rho \leq \rho_{\rm max}, \\
+ * \rho^i, & \rho_{\rm max} < \rho.\end{array}\right.
+ * \f}
+ *
+ * Taking the Euclidean magnitude of both sides and simplifying yields
+ * \f{align}{
+ * \frac{r}{\rho} &= \left\{\begin{array}{ll}
+ * 1 - \frac{\lambda_{00}(t)}{\sqrt{4\pi}}
+ * \frac{1}{\rho_{\rm min}}, & \rho < \rho_{\rm min}, \\
+ * 1 - \frac{\lambda_{00}(t)}{\sqrt{4\pi}}
+ * \frac{\rho_{\rm max}/\rho - 1}{\rho_{\rm max} - \rho_{\rm min}},
+ * & \rho_{\rm min} \leq \rho \leq \rho_{\rm max}, \\
+ * 1, & \rho_{\rm max} < \rho,\end{array}\right.
+ * \f}
+ * which implies
+ * \f{align}{
+ * r^i = \rho^i \frac{r}{\rho} \Rightarrow \rho^i = r^i \frac{\rho}{r}.
+ * \f}
+ *
+ * Inserting \f$\rho_{\rm min}\f$ or \f$\rho_{\rm max}\f$ then gives the
+ * corresponding bounds in the mapped coordinates: \f{align}{
+ * r_{\rm min} &= \rho_{\rm min} - \frac{\lambda_{00}(t)}{\sqrt{4\pi}},\\
+ * r_{\rm max} &= \rho_{\rm max}.
+ * \f}
+ *
+ * In the regime \f$\rho_{\rm min} \leq \rho < \rho_{\rm max}\f$, rearranging
+ * yields a linear relationship between \f$\rho\f$ and \f$r\f$, which
+ * can then be solved for \f$\rho(r)\f$:
+ * \f{align}{
+ * r &= \rho - \frac{\lambda_{00}(t)}{\sqrt{4\pi}}
+ * \frac{\rho_{\rm max} - \rho}{\rho_{\rm max} - \rho_{\rm min}}\\
+ * \Rightarrow r &= \rho \left(1 + \frac{\lambda_{00}(t)}{\sqrt{4\pi}}
+ * \frac{1}{\rho_{\rm max} - \rho_{\rm min}}\right)
+ * - \frac{\lambda_{00}(t)}{\sqrt{4\pi}}
+ * \frac{\rho_{\rm max}}{\rho_{\rm max} - \rho_{\rm min}}.
+ * \f}
+ * Solving this linear equation for \f$\rho\f$ yields
+ * \f{align}{
+ * \rho &= \left(r+\frac{\lambda_{00}(t)}{\sqrt{4\pi}}\frac{\rho_{\rm
+ * max}}{\rho_{\rm max}-\rho_{\rm min}}\right)
+ * \left(1 + \frac{\lambda_{00}(t)}{\sqrt{4\pi}}
+ * \frac{1}{\rho_{\rm max} - \rho_{\rm min}}\right)^{-1}.
+ * \f}
+ *
+ * Inserting the expressions for \f$\rho\f$ into the equation
+ * \f{align}{
+ * \rho^i = r^i \frac{\rho}{r}
+ * \f}
+ * then gives
+ * \f{align}{
+ * \rho^i &= \left\{\begin{array}{ll}
+ * r^i\left(1 - \frac{\lambda_{00}(t)}{\sqrt{4\pi}}
+ * \frac{1}{\rho_{\rm min}}\right)^{-1},
+ * & r < \rho_{\rm min} - \frac{\lambda_{00}(t)}{\sqrt{4\pi}},\\
+ * r^i
+ * \left(1+\frac{1}{r}\frac{\lambda_{00}(t)}{\sqrt{4\pi}}\frac{\rho_{\rm
+ * max}}{\rho_{\rm max}-\rho_{\rm min}}\right)\left(1 +
+ * \frac{\lambda_{00}(t)}{\sqrt{4\pi}} \frac{1}{\rho_{\rm max} - \rho_{\rm
+ * min}}\right)^{-1}, & \rho_{\rm min} - \frac{\lambda_{00}(t)}{\sqrt{4\pi}}
+ * \leq r
+ * \leq \rho_{\rm max},\\
+ * r^i, & \rho_{\rm max} < r.\end{array}\right.
+ * \f}
+ * Finally, inserting \f$\rho^i = \xi^i - C^i\f$ yields the inverse map:
+ * \f{align}{
+ * \xi^i &= \left\{\begin{array}{ll}
+ * r^i\left(1 - \frac{\lambda_{00}(t)}{\sqrt{4\pi}}
+ * \frac{1}{\rho_{\rm min}}\right)^{-1} + C^i,
+ * & r < \rho_{\rm min} - \frac{\lambda_{00}(t)}{\sqrt{4\pi}},\\
+ * r^i
+ * \left(1+\frac{1}{r}\frac{\lambda_{00}(t)}{\sqrt{4\pi}}\frac{\rho_{\rm
+ * max}}{\rho_{\rm max}-\rho_{\rm min}}\right)\left(1 +
+ * \frac{\lambda_{00}(t)}{\sqrt{4\pi}} \frac{1}{\rho_{\rm max} - \rho_{\rm
+ * min}}\right)^{-1} + C^i, & \rho_{\rm min} -
+ * \frac{\lambda_{00}(t)}{\sqrt{4\pi}} \leq r
+ * \leq \rho_{\rm max},\\
+ * r^i + C^i = x^i, & \rho_{\rm max} < r.\end{array}\right.
+ * \f}
+ *
+ */
+template <bool InteriorMap>
+class SphericalCompression {
+ public:
+  static constexpr size_t dim = 3;
+
+  explicit SphericalCompression(std::string function_of_time_name,
+                                double min_radius, double max_radius,
+                                const std::array<double, 3>& center) noexcept;
+  SphericalCompression() = default;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
+      const std::array<T, 3>& source_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
+
+  std::optional<std::array<double, 3>> inverse(
+      const std::array<double, 3>& target_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, 3> frame_velocity(
+      const std::array<T, 3>& source_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> jacobian(
+      const std::array<T, 3>& source_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> inv_jacobian(
+      const std::array<T, 3>& source_coords, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time) const noexcept;
+
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+  static bool is_identity() noexcept { return false; }
+
+ private:
+  friend bool operator==(const SphericalCompression& lhs,
+                         const SphericalCompression& rhs) noexcept {
+    return lhs.f_of_t_name_ == rhs.f_of_t_name_ and
+           lhs.min_radius_ == rhs.min_radius_ and
+           lhs.max_radius_ == rhs.max_radius_ and lhs.center_ == rhs.center_;
+  }
+  std::string f_of_t_name_;
+  double min_radius_ = std::numeric_limits<double>::signaling_NaN();
+  double max_radius_ = std::numeric_limits<double>::signaling_NaN();
+  std::array<double, 3> center_;
+};
+
+template <bool InteriorMap>
+bool operator!=(const SphericalCompression<InteriorMap>& lhs,
+                const SphericalCompression<InteriorMap>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+}  // namespace domain::CoordinateMaps::TimeDependent

--- a/src/Domain/CoordinateMaps/TimeDependent/SphericalCompression.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/SphericalCompression.hpp
@@ -266,6 +266,10 @@ class SphericalCompression {
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time) const noexcept;
 
+  /// The inverse function is only callable with doubles because the inverse
+  /// might fail if called for a point out of range, and it is unclear
+  /// what should happen if the inverse were to succeed for some points in a
+  /// DataVector but fail for other points.
   std::optional<std::array<double, 3>> inverse(
       const std::array<double, 3>& target_coords, double time,
       const std::unordered_map<

--- a/src/Domain/CoordinateMaps/TimeDependent/Translation.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Translation.hpp
@@ -49,6 +49,10 @@ class Translation {
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time) const noexcept;
 
+  /// The inverse function is only callable with doubles because the inverse
+  /// might fail if called for a point out of range, and it is unclear
+  /// what should happen if the inverse were to succeed for some points in a
+  /// DataVector but fail for other points.
   std::optional<std::array<double, 1>> inverse(
       const std::array<double, 1>& target_coords, double time,
       const std::unordered_map<

--- a/src/Domain/CoordinateMaps/Wedge2D.hpp
+++ b/src/Domain/CoordinateMaps/Wedge2D.hpp
@@ -139,6 +139,10 @@ class Wedge2D {
       const std::array<T, 2>& source_coords) const noexcept;
 
   /// Returns invalid if \f$x<=0\f$ (for a \f$+x\f$-oriented `Wedge2D`).
+  /// The inverse function is only callable with doubles because the inverse
+  /// might fail if called for a point out of range, and it is unclear
+  /// what should happen if the inverse were to succeed for some points in a
+  /// DataVector but fail for other points.
   std::optional<std::array<double, 2>> inverse(
       const std::array<double, 2>& target_coords) const noexcept;
 

--- a/src/Domain/CoordinateMaps/Wedge3D.hpp
+++ b/src/Domain/CoordinateMaps/Wedge3D.hpp
@@ -283,6 +283,10 @@ class Wedge3D {
   /// Here \f$s_0,s_1\f$ and \f$r_0,r_1\f$ are the specified sphericities
   /// and radii of the inner and outer \f$z\f$ surfaces.  The map is singular on
   /// the cone and on the xy plane.
+  /// The inverse function is only callable with doubles because the inverse
+  /// might fail if called for a point out of range, and it is unclear
+  /// what should happen if the inverse were to succeed for some points in a
+  /// DataVector but fail for other points.
   std::optional<std::array<double, 3>> inverse(
       const std::array<double, 3>& target_coords) const noexcept;
 

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_CubicScale.cpp
   Test_ProductMaps.cpp
   Test_Rotation.cpp
+  Test_SphericalCompression.cpp
   Test_Translation.cpp
   )
 

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_SphericalCompression.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_SphericalCompression.cpp
@@ -1,0 +1,549 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <pup.h>
+#include <random>
+#include <sstream>
+#include <string>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/SphericalCompression.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
+
+namespace {
+// Generate a point in a random direction at a given radius
+auto points_in_random_direction_generator(
+    const gsl::not_null<std::mt19937*> generator,
+    const std::array<double, 3>& center) noexcept {
+  std::uniform_real_distribution<> phi_dis(0, 2.0 * M_PI);
+  std::uniform_real_distribution<> theta_dis(0, M_PI);
+  const double theta{theta_dis(*generator)};
+  const double phi{phi_dis(*generator)};
+
+  // Choose a point of unit radius with the randomly selected theta, phi.
+  // This test will rescale this point to place it in different regions.
+  const double rho_x0{sin(theta) * cos(phi)};
+  const double rho_y0{sin(theta) * sin(phi)};
+  const double rho_z0{cos(theta)};
+
+  // A helper that returns a point given a radius
+  auto point = [rho_x0, rho_y0, rho_z0, center](const double& radius) {
+    return std::array<double, 3>{{radius * rho_x0 + center[0],
+                                  radius * rho_y0 + center[1],
+                                  radius * rho_z0 + center[2]}};
+  };
+  return point;
+}
+
+// Generates the map, time, and a FunctionOfTime
+template <bool InteriorMap>
+void generate_map_time_and_f_of_time(
+    const gsl::not_null<domain::CoordinateMaps::TimeDependent::
+                            SphericalCompression<InteriorMap>*>
+        map,
+    const gsl::not_null<double*> time,
+    const gsl::not_null<std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>*>
+        functions_of_time,
+    const gsl::not_null<double*> min_radius,
+    const gsl::not_null<double*> max_radius,
+    const gsl::not_null<std::array<double, 3>*> center,
+    const gsl::not_null<std::mt19937*> generator,
+    const bool bad_max_radius = false,
+    const bool missing_f_of_t = false) noexcept {
+  std::string f_of_t_name{"ExpansionFactor"};
+  // Set up the map
+  if (missing_f_of_t) {
+    f_of_t_name = "WrongFunctionOfTimeName"s;
+  }
+  std::uniform_real_distribution<> rad_dis{0.4, 0.7};
+  std::uniform_real_distribution<> drad_dis{0.1, 0.2};
+  const double rad{rad_dis(*generator)};
+  *min_radius = rad - drad_dis(*generator);
+  *max_radius = rad + drad_dis(*generator);
+  if (bad_max_radius) {
+    *max_radius = *min_radius;
+  }
+  std::uniform_real_distribution<> center_dis{-0.05, 0.05};
+  *center = std::array<double, 3>{
+      {center_dis(*generator), center_dis(*generator), center_dis(*generator)}};
+  domain::CoordinateMaps::TimeDependent::SphericalCompression<InteriorMap>
+      random_map{f_of_t_name, *min_radius, *max_radius, *center};
+  *map = random_map;
+
+  // Choose a random time for evaluating the FunctionOfTime
+  std::uniform_real_distribution<> time_dis{-1.0, 1.0};
+  *time = time_dis(*generator);
+
+  // Create a FunctionsOfTime containing a FunctionOfTime that, when evaluated
+  // at time, is invertible. Recall that the map is invertible if
+  // min_radius - max_radius < lambda(t) / sqrt(4*pi) < min_radius. So
+  // lambda(t) = (min_radius - eps * max_radius) * sqrt(4*pi) is guaranteed
+  // invertible for 0 < eps < 1. So set the constant term in the piecewise
+  // polynomial to a0 = (min_radius - eps * max_radius) * sqrt(4*pi).
+  // The remaining coefficients a1, a2, a3 will be chosen as a random
+  // small factor of a0, to ensure that these terms don't make the map
+  // non-invertible.
+  std::uniform_real_distribution<> eps_dis{0.2, 0.8};
+  std::uniform_real_distribution<> higher_coef_dis{-0.01, 0.01};
+  const double a0{(*min_radius - eps_dis(*generator) * *max_radius) /
+                  (0.25 * M_2_SQRTPI)};
+  const std::array<DataVector, 4> initial_coefficients{
+      {{{a0}},
+       {{higher_coef_dis(*generator) * a0}},
+       {{higher_coef_dis(*generator) * a0}},
+       {{higher_coef_dis(*generator) * a0}}}};
+  std::uniform_real_distribution<> dt_dis{0.1, 0.5};
+  const double initial_time{*time - dt_dis(*generator)};
+  const double expiration_time{*time + dt_dis(*generator)};
+  (*functions_of_time)[f_of_t_name] =
+      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<3>>(
+          initial_time, initial_coefficients, expiration_time);
+}
+
+// Generates the map, time, and a FunctionOfTime, but hides internal details
+// (min radius, max radius, and center) when not needed
+template <bool InteriorMap>
+void generate_map_time_and_f_of_time(
+    const gsl::not_null<domain::CoordinateMaps::TimeDependent::
+                            SphericalCompression<InteriorMap>*>
+        map,
+    const gsl::not_null<double*> time,
+    const gsl::not_null<std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>*>
+        functions_of_time,
+    const gsl::not_null<std::mt19937*> generator,
+    const bool bad_max_radius = false,
+    const bool missing_f_of_t = false) noexcept {
+  double min_radius{std::numeric_limits<double>::signaling_NaN()};
+  double max_radius{std::numeric_limits<double>::signaling_NaN()};
+  std::array<double, 3> center{};
+  generate_map_time_and_f_of_time<InteriorMap>(
+      map, time, functions_of_time, make_not_null(&min_radius),
+      make_not_null(&max_radius), make_not_null(&center), generator,
+      bad_max_radius, missing_f_of_t);
+}
+
+bool random_bool(const gsl::not_null<std::mt19937*> generator) noexcept {
+  std::uniform_int_distribution<> bool_dis{0, 1};
+  return static_cast<bool>(bool_dis(*generator));
+}
+
+template <bool InteriorMap>
+void test_out_of_bounds(const gsl::not_null<std::mt19937*> generator) noexcept {
+  domain::CoordinateMaps::TimeDependent::SphericalCompression<InteriorMap>
+      map{};
+  double time{std::numeric_limits<double>::signaling_NaN()};
+  std::unordered_map<std::string,
+                     std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+
+  double min_radius{std::numeric_limits<double>::signaling_NaN()};
+  double max_radius{std::numeric_limits<double>::signaling_NaN()};
+  std::array<double, 3> center{};
+  generate_map_time_and_f_of_time(
+      make_not_null(&map), make_not_null(&time),
+      make_not_null(&functions_of_time), make_not_null(&min_radius),
+      make_not_null(&max_radius), make_not_null(&center), generator);
+
+  // A helper that returns a point given a radius
+  auto point = points_in_random_direction_generator(generator, center);
+
+  std::uniform_real_distribution<> rad_dis(
+      std::numeric_limits<double>::epsilon(),
+      1.0 - std::numeric_limits<double>::epsilon());
+  double radius = std::numeric_limits<double>::signaling_NaN();
+  if constexpr (InteriorMap) {
+    // Choose a radius that's out of bounds
+    radius = min_radius + rad_dis(*generator) * max_radius +
+             std::numeric_limits<double>::epsilon();
+  } else {
+    // Randomly choose on which side the radius is out of bounds
+    if (random_bool(generator)) {
+      radius = max_radius + rad_dis(*generator) * min_radius +
+               std::numeric_limits<double>::epsilon();
+    } else {
+      radius = rad_dis(*generator) * min_radius -
+               std::numeric_limits<double>::epsilon();
+    }
+  }
+  map(point(radius), time, functions_of_time);
+  std::stringstream message;
+  message << "radius should have been out of bounds, but "
+          << "radius == " << radius << ", min_radius == " << min_radius
+          << ", max_radius == " << max_radius
+          << ", InteriorMap == " << InteriorMap;
+  ERROR(message.str());
+}
+
+template <bool InteriorMap>
+void test_out_of_bounds_inverse(
+    const gsl::not_null<std::mt19937*> generator) noexcept {
+  domain::CoordinateMaps::TimeDependent::SphericalCompression<InteriorMap>
+      map{};
+  double time{std::numeric_limits<double>::signaling_NaN()};
+  std::unordered_map<std::string,
+                     std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+
+  double min_radius{std::numeric_limits<double>::signaling_NaN()};
+  double max_radius{std::numeric_limits<double>::signaling_NaN()};
+  std::array<double, 3> center{};
+  generate_map_time_and_f_of_time(
+      make_not_null(&map), make_not_null(&time),
+      make_not_null(&functions_of_time), make_not_null(&min_radius),
+      make_not_null(&max_radius), make_not_null(&center), generator);
+
+  auto point = points_in_random_direction_generator(generator, center);
+
+  // Get lambda_y needed to determine the bounds for the target radius
+  const std::string f_of_t_name{"ExpansionFactor"};
+  const double lambda_y{functions_of_time.at(f_of_t_name)->func(time)[0][0] *
+                        0.25 * M_2_SQRTPI};
+
+  std::uniform_real_distribution<> rad_dis(
+      std::numeric_limits<double>::epsilon(),
+      1.0 - std::numeric_limits<double>::epsilon());
+  double target_radius = std::numeric_limits<double>::signaling_NaN();
+  if constexpr (InteriorMap) {
+    // Choose a radius that's out of bounds
+    target_radius = min_radius - lambda_y + rad_dis(*generator) * max_radius +
+                    std::numeric_limits<double>::epsilon();
+  } else {
+    // Randomly choose on which side the radius is out of bounds
+    if (random_bool(generator)) {
+      target_radius = max_radius + rad_dis(*generator) * min_radius +
+                      std::numeric_limits<double>::epsilon();
+    } else {
+      target_radius = min_radius - lambda_y - rad_dis(*generator) * min_radius -
+                      std::numeric_limits<double>::epsilon();
+    }
+  }
+  CHECK_FALSE(
+      map.inverse(point(target_radius), time, functions_of_time).has_value());
+}
+}  // namespace
+
+namespace domain {
+namespace {
+template <bool InteriorMap>
+void test_suite(const gsl::not_null<std::mt19937*> generator) noexcept {
+  INFO("Suite");
+
+  // Create the map, select a time, and create a FunctionsOfTime
+  CoordinateMaps::TimeDependent::SphericalCompression<InteriorMap> map{};
+  double time{std::numeric_limits<double>::signaling_NaN()};
+  std::unordered_map<std::string,
+                     std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+
+  double min_radius{std::numeric_limits<double>::signaling_NaN()};
+  double max_radius{std::numeric_limits<double>::signaling_NaN()};
+  std::array<double, 3> center{};
+  generate_map_time_and_f_of_time(
+      make_not_null(&map), make_not_null(&time),
+      make_not_null(&functions_of_time), make_not_null(&min_radius),
+      make_not_null(&max_radius), make_not_null(&center), generator);
+  CAPTURE(time);
+  CAPTURE(min_radius);
+  CAPTURE(max_radius);
+
+  // Check map against a suite of functions in
+  // tests/Unit/Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp
+  std::uniform_real_distribution<> theta_dis(0, M_PI);
+  std::uniform_real_distribution<> phi_dis(0, 2.0 * M_PI);
+
+  const double theta = theta_dis(*generator);
+  CAPTURE(theta);
+  const double phi = phi_dis(*generator);
+  CAPTURE(phi);
+
+  // The Jacobian test computes finite-difference derivatives using a distance
+  // of 1.e-4, so keep all test points much farther away from the boundaries
+  // and the origin than that. Also ensure all points are within some finite
+  // maximum radius, which here is taken to be ten times the max radius.
+  constexpr double distance_from_boundaries{5.e-3};
+  double lower_rad = min_radius + distance_from_boundaries;
+  double upper_rad = max_radius - distance_from_boundaries;
+  if constexpr (InteriorMap) {
+    lower_rad = distance_from_boundaries;
+    upper_rad = min_radius - distance_from_boundaries;
+  }
+  std::uniform_real_distribution<> radius_dis(lower_rad, upper_rad);
+
+  const double radius = radius_dis(*generator);
+  CAPTURE(radius);
+
+  // Select a random point. Make sure that the point is not too close to the
+  // junctions where the Jacobian becomes discontinuous, to ensure that the
+  // jacobian test passes
+  const std::array<double, 3> random_point{
+      {radius * sin(theta) * cos(phi) + center[0],
+       radius * sin(theta) * sin(phi) + center[1],
+       radius * cos(theta) + center[2]}};
+
+  const auto test_helper = [&random_point, &time, &functions_of_time](
+                               const auto& map_to_test) noexcept {
+    test_serialization(map_to_test);
+    CHECK_FALSE(map_to_test != map_to_test);
+
+    test_coordinate_map_argument_types(map_to_test, random_point, time,
+                                       functions_of_time);
+    test_frame_velocity(map_to_test, random_point, time, functions_of_time);
+    test_jacobian(map_to_test, random_point, time, functions_of_time);
+    test_inv_jacobian(map_to_test, random_point, time, functions_of_time);
+    test_inverse_map(map_to_test, random_point, time, functions_of_time);
+  };
+  test_helper(map);
+
+  const auto check_map_equality = [&random_point, &time, &functions_of_time](
+                                      const auto& map_one,
+                                      const auto& map_two) {
+    tnsr::I<double, 3, Frame::Logical> source_point{};
+    for (size_t i = 0; i < 3; ++i) {
+      source_point.get(i) = gsl::at(random_point, i);
+    }
+    CHECK_ITERABLE_APPROX(map_one(source_point, time, functions_of_time),
+                          map_two(source_point, time, functions_of_time));
+    CHECK_ITERABLE_APPROX(
+        map_one.jacobian(source_point, time, functions_of_time),
+        map_two.jacobian(source_point, time, functions_of_time));
+    CHECK_ITERABLE_APPROX(
+        map_one.inv_jacobian(source_point, time, functions_of_time),
+        map_two.inv_jacobian(source_point, time, functions_of_time));
+  };
+  const auto map2 = serialize_and_deserialize(map);
+  check_map_equality(
+      domain::make_coordinate_map<Frame::Logical, Frame::Grid>(map),
+      domain::make_coordinate_map<Frame::Logical, Frame::Grid>(map2));
+  test_helper(map2);
+}
+
+template <bool InteriorMap>
+void test_map(const gsl::not_null<std::mt19937*> generator) noexcept {
+  INFO("Map");
+  // Create a map, choose a time, and create a FunctionOfTime.
+  // Set up the map
+  CoordinateMaps::TimeDependent::SphericalCompression<InteriorMap> map{};
+  double time{std::numeric_limits<double>::signaling_NaN()};
+  std::unordered_map<std::string,
+                     std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+
+  double min_radius{std::numeric_limits<double>::signaling_NaN()};
+  double max_radius{std::numeric_limits<double>::signaling_NaN()};
+  std::array<double, 3> center{std::numeric_limits<double>::signaling_NaN()};
+  generate_map_time_and_f_of_time(
+      make_not_null(&map), make_not_null(&time),
+      make_not_null(&functions_of_time), make_not_null(&min_radius),
+      make_not_null(&max_radius), make_not_null(&center), generator);
+
+  auto point = points_in_random_direction_generator(generator, center);
+
+  // A helper that checks if two points are scaled by the same factor
+  // or not
+  auto check_point_scale_factors =
+      [&center, &map, &time, &functions_of_time](
+          const std::array<double, 3>& orig_point_1,
+          const std::array<double, 3>& orig_point_2,
+          const bool check_if_equal) {
+        const std::array<double, 3> mapped_point_1{
+            map(orig_point_1, time, functions_of_time)};
+        const std::array<double, 3> mapped_point_2{
+            map(orig_point_2, time, functions_of_time)};
+        Approx custom_approx = Approx::custom().epsilon(1.0e-9).scale(1.0);
+        auto scale_factor_component =
+            [&center](const std::array<double, 3>& orig_point,
+                      const std::array<double, 3>& mapped_point,
+                      const size_t i) {
+              return (gsl::at(orig_point, i) - gsl::at(mapped_point, i)) /
+                     (gsl::at(orig_point, i) - gsl::at(center, i));
+            };
+        for (size_t i = 0; i < 3; ++i) {
+          if (check_if_equal) {
+            CHECK(scale_factor_component(orig_point_1, mapped_point_1, i) ==
+                  custom_approx(
+                      scale_factor_component(orig_point_2, mapped_point_2, i)));
+          } else {
+            CHECK(scale_factor_component(orig_point_1, mapped_point_1, i) !=
+                  custom_approx(
+                      scale_factor_component(orig_point_2, mapped_point_2, i)));
+          }
+        }
+      };
+
+  // Set up distributions for choosing radii in the three regions:
+  // smaller than min_radius, larger than max_radius, and in between
+  constexpr double eps{0.01};
+
+  double lower_radius = min_radius + eps;
+  double upper_radius = max_radius - eps;
+  if constexpr (InteriorMap) {
+    lower_radius = eps;
+    upper_radius = min_radius - eps;
+  }
+  std::uniform_real_distribution<> radius_dis{lower_radius, upper_radius};
+  if constexpr (InteriorMap) {
+    // In the interior, two random points should change radius by the same
+    // factor, and that factor is the same as for a point exactly at
+    // the minimum radius
+    check_point_scale_factors(point(radius_dis(*generator)),
+                              point(radius_dis(*generator)), true);
+    check_point_scale_factors(point(radius_dis(*generator)), point(min_radius),
+                              true);
+  } else {
+    // In the middle, two points should only move radially, but by
+    // a different amount
+    check_point_scale_factors(point(radius_dis(*generator)),
+                              point(radius_dis(*generator)), false);
+  }
+
+  // Check that a point is invertible with the supplied functions_of_time
+  CHECK(map.inverse(map(point(radius_dis(*generator)), time, functions_of_time),
+                    time, functions_of_time)
+            .has_value());
+
+  // Check that a point is not invertible if the function of time is
+  // too big or too small
+  std::uniform_real_distribution<> higher_coef_dis{-0.01, 0.01};
+  const double a0{(min_radius - max_radius - 0.5) / (0.25 * M_2_SQRTPI)};
+  const std::array<DataVector, 4> initial_coefficients{
+      {{{a0}},
+       {{higher_coef_dis(*generator) * a0}},
+       {{higher_coef_dis(*generator) * a0}},
+       {{higher_coef_dis(*generator) * a0}}}};
+  const double b0{(min_radius + 0.5) / (0.25 * M_2_SQRTPI)};
+  const std::array<DataVector, 4> initial_coefficients_b{
+      {{{b0}},
+       {{higher_coef_dis(*generator) * b0}},
+       {{higher_coef_dis(*generator) * b0}},
+       {{higher_coef_dis(*generator) * b0}}}};
+  std::uniform_real_distribution<> dt_dis{0.1, 0.5};
+  const double initial_time{time - dt_dis(*generator)};
+  const double expiration_time{time + dt_dis(*generator)};
+
+  const std::string f_of_t_name{"ExpansionFactor"};
+  functions_of_time[f_of_t_name] =
+      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<3>>(
+          initial_time, initial_coefficients, expiration_time);
+  CHECK_FALSE(
+      map.inverse(map(point(radius_dis(*generator)), time, functions_of_time),
+                  time, functions_of_time)
+          .has_value());
+  functions_of_time[f_of_t_name] =
+      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<3>>(
+          initial_time, initial_coefficients_b, expiration_time);
+  CHECK_FALSE(
+      map.inverse(map(point(radius_dis(*generator)), time, functions_of_time),
+                  time, functions_of_time)
+          .has_value());
+}
+
+template <bool InteriorMap>
+void test_is_identity(const gsl::not_null<std::mt19937*> generator) noexcept {
+  INFO("Is identity");
+  CoordinateMaps::TimeDependent::SphericalCompression<InteriorMap> map{};
+  double time{std::numeric_limits<double>::signaling_NaN()};
+  std::unordered_map<std::string,
+                     std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+  generate_map_time_and_f_of_time(make_not_null(&map), make_not_null(&time),
+                                  make_not_null(&functions_of_time), generator);
+  CHECK(not map.is_identity());
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.SphericalCompression",
+                  "[Domain][Unit]") {
+  MAKE_GENERATOR(gen);
+  test_suite<true>(make_not_null(&gen));
+  test_map<true>(make_not_null(&gen));
+  test_is_identity<true>(make_not_null(&gen));
+  test_out_of_bounds_inverse<true>(make_not_null(&gen));
+  test_suite<false>(make_not_null(&gen));
+  test_map<false>(make_not_null(&gen));
+  test_is_identity<false>(make_not_null(&gen));
+  test_out_of_bounds_inverse<false>(make_not_null(&gen));
+}
+
+// [[OutputRegex, max_radius must be greater]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Domain.CoordinateMaps.SphericalCompression.MaxGreater",
+    "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  MAKE_GENERATOR(gen);
+  CoordinateMaps::TimeDependent::SphericalCompression<false> map{};
+  double time{std::numeric_limits<double>::signaling_NaN()};
+  std::unordered_map<std::string,
+                     std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+  generate_map_time_and_f_of_time(make_not_null(&map), make_not_null(&time),
+                                  make_not_null(&functions_of_time),
+                                  make_not_null(&gen), true, false);
+  test_suite<false>(make_not_null(&gen));
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Could not find function of time]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Domain.CoordinateMaps.SphericalCompression.MissingFofT",
+    "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  MAKE_GENERATOR(gen);
+  CoordinateMaps::TimeDependent::SphericalCompression<false> map{};
+  double time{std::numeric_limits<double>::signaling_NaN()};
+  std::unordered_map<std::string,
+                     std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+  double min_radius{std::numeric_limits<double>::signaling_NaN()};
+  double max_radius{std::numeric_limits<double>::signaling_NaN()};
+  std::array<double, 3> center{};
+  generate_map_time_and_f_of_time(
+      make_not_null(&map), make_not_null(&time),
+      make_not_null(&functions_of_time), make_not_null(&min_radius),
+      make_not_null(&max_radius), make_not_null(&center), make_not_null(&gen),
+      false, false);
+  CoordinateMaps::TimeDependent::SphericalCompression<false> bad_map{};
+  double bad_time{std::numeric_limits<double>::signaling_NaN()};
+  std::unordered_map<std::string,
+                     std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>
+      bad_functions_of_time{};
+  generate_map_time_and_f_of_time(
+      make_not_null(&bad_map), make_not_null(&bad_time),
+      make_not_null(&bad_functions_of_time), make_not_null(&gen), false, true);
+  const std::array<double, 3> point{
+      {0.5 * (max_radius + min_radius) + center[0], center[1], center[2]}};
+  map(point, 0.4, bad_functions_of_time);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+}  // namespace domain
+
+// [[OutputRegex, not in expected range]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Domain.CoordinateMaps.SphericalCompression.MapOutOfBounds",
+    "[Domain][Unit]") {
+  ERROR_TEST();
+  MAKE_GENERATOR(gen);
+  if (random_bool(make_not_null(&gen))) {
+    test_out_of_bounds<true>(make_not_null(&gen));
+  } else {
+    test_out_of_bounds<false>(make_not_null(&gen));
+  }
+  ERROR("Failed to trigger ERROR in an error test");
+}

--- a/tests/Unit/Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -385,6 +385,7 @@ void test_coordinate_map_argument_types(
                  args...);
 }
 
+// @{
 /*!
  * \ingroup TestingFrameworkGroup
  * \brief Given a Map `map`, checks that the inverse map gives expected results
@@ -394,6 +395,20 @@ void test_inverse_map(const Map& map,
                       const std::array<T, Map::dim>& test_point) noexcept {
   CHECK_ITERABLE_APPROX(test_point, map.inverse(map(test_point)).value());
 }
+
+template <typename Map, typename T>
+void test_inverse_map(
+    const Map& map, const std::array<T, Map::dim>& test_point,
+    const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) noexcept {
+  CHECK_ITERABLE_APPROX(
+      test_point, map.inverse(map(test_point, time, functions_of_time), time,
+                              functions_of_time)
+                      .value());
+}
+// @}
 
 /*!
  * \ingroup TestingFrameworkGroup


### PR DESCRIPTION
## Proposed changes

Add a time-dependent CoordMap that implements a "size control" style map, equivalent to using DistortedSphereMapFunctionSphere in SpEC. The map compresses a spherical region, with the amount of compression going to zero at some max radius and leveling off to a constant value at some min radius.

As far as I can tell, this is the first CoordMap whose behavior depends on the region. Specifically, while the map is continuous, the Jacobian is not.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
There is not yet a use for the map, so there is nothing to upgrade. This PR is the first step toward implementing a TimeDependence that can track the growth of the black holes in a binary as they move closer together.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
