### PR TITLE
Add quadrature to Mortars & DgDomain init, support Gauss pts and weak form in ComputeTimeDerivative

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp
@@ -19,6 +19,7 @@
 #include "Domain/Structure/Neighbors.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Domain/Tags.hpp"
+#include "Evolution/DiscontinuousGalerkin/Initialization/QuadratureTag.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
@@ -74,7 +75,8 @@ struct Mortars {
   using MortarMap = std::unordered_map<Key, MappedType, boost::hash<Key>>;
 
  public:
-  using initialization_tags = tmpl::list<::domain::Tags::InitialExtents<Dim>>;
+  using initialization_tags = tmpl::list<::domain::Tags::InitialExtents<Dim>,
+                                         evolution::dg::Tags::Quadrature>;
 
   using simple_tags =
       tmpl::list<Tags::MortarData<Dim>, Tags::MortarMesh<Dim>,
@@ -94,7 +96,7 @@ struct Mortars {
       auto [mortar_data, mortar_meshes, mortar_sizes,
             mortar_next_temporal_ids] =
           apply_impl(db::get<::domain::Tags::InitialExtents<Dim>>(box),
-                     Spectral::Quadrature::GaussLobatto,
+                     db::get<evolution::dg::Tags::Quadrature>(box),
                      db::get<::domain::Tags::Element<Dim>>(box),
                      db::get<::Tags::TimeStepId>(box),
                      db::get<::domain::Tags::Interface<

--- a/src/Evolution/Initialization/DgDomain.hpp
+++ b/src/Evolution/Initialization/DgDomain.hpp
@@ -24,6 +24,7 @@
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Tags.hpp"
 #include "Domain/TagsTimeDependent.hpp"
+#include "Evolution/DiscontinuousGalerkin/Initialization/QuadratureTag.hpp"
 #include "Evolution/TagsDomain.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Parallel/GlobalCache.hpp"
@@ -84,9 +85,8 @@ template <size_t Dim, bool OverrideCubicFunctionsOfTime = false>
 struct Domain {
   using initialization_tags =
       tmpl::list<::domain::Tags::InitialExtents<Dim>,
-                 ::domain::Tags::InitialRefinementLevels<Dim>>;
-
-
+                 ::domain::Tags::InitialRefinementLevels<Dim>,
+                 evolution::dg::Tags::Quadrature>;
   using const_global_cache_tags = tmpl::list<::domain::Tags::Domain<Dim>>;
 
   using mutable_global_cache_tags = tmpl::list<::domain::Tags::FunctionsOfTime>;
@@ -143,7 +143,8 @@ struct Domain {
     const ElementId<Dim> element_id{array_index};
     const auto& my_block = domain.blocks()[element_id.block_id()];
     Mesh<Dim> mesh = ::domain::Initialization::create_initial_mesh(
-        initial_extents, element_id, Spectral::Quadrature::GaussLobatto);
+        initial_extents, element_id,
+        db::get<evolution::dg::Tags::Quadrature>(box));
     Element<Dim> element = ::domain::Initialization::create_initial_element(
         element_id, my_block, initial_refinement);
     ElementMap<Dim, Frame::Grid> element_map{

--- a/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeMortars.hpp
+++ b/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeMortars.hpp
@@ -118,6 +118,7 @@ struct InitializeMortars {
     const auto& interface_meshes =
         db::get<domain::Tags::Interface<domain::Tags::InternalDirections<dim>,
                                         domain::Tags::Mesh<dim - 1>>>(box);
+    const auto quadrature = db::get<domain::Tags::Mesh<dim>>(box).quadrature(0);
     for (const auto& direction_and_neighbors : element.neighbors()) {
       const auto& direction = direction_and_neighbors.first;
       const auto& neighbors = direction_and_neighbors.second;
@@ -126,12 +127,11 @@ struct InitializeMortars {
         mortar_data[mortar_id];  // Default initialize data
         mortar_meshes.emplace(
             mortar_id,
-            dg::mortar_mesh(
-                interface_meshes.at(direction),
-                domain::Initialization::create_initial_mesh(
-                    initial_extents, neighbor,
-                    Spectral::Quadrature::GaussLobatto, neighbors.orientation())
-                    .slice_away(direction.dimension())));
+            dg::mortar_mesh(interface_meshes.at(direction),
+                            domain::Initialization::create_initial_mesh(
+                                initial_extents, neighbor, quadrature,
+                                neighbors.orientation())
+                                .slice_away(direction.dimension())));
         mortar_sizes.emplace(
             mortar_id,
             dg::mortar_size(element.id(), neighbor, direction.dimension(),

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -29,6 +29,7 @@ DomainCreator:
 SpatialDiscretization:
   DiscontinuousGalerkin:
     Formulation: StrongInertial
+    Quadrature: GaussLobatto
 
 NumericalFlux:
   LocalLaxFriedrichs:

--- a/tests/InputFiles/ExportCoordinates/Input1D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input1D.yaml
@@ -20,6 +20,10 @@ DomainCreator:
         Velocity: [0.5]
         FunctionOfTimeNames: ["TranslationX"]
 
+SpatialDiscretization:
+  DiscontinuousGalerkin:
+    Quadrature: GaussLobatto
+
 # To export a time-independent mesh, replace `? PastTime: 1.0` with `Always:`
 EventsAndTriggers:
   ? PastTime: 1.0

--- a/tests/InputFiles/ExportCoordinates/Input2D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input2D.yaml
@@ -20,6 +20,10 @@ DomainCreator:
         Velocity: [0.5, 0.0]
         FunctionOfTimeNames: ["TranslationX", "TranslationY"]
 
+SpatialDiscretization:
+  DiscontinuousGalerkin:
+    Quadrature: GaussLobatto
+
 # To export a time-independent mesh, replace `? PastTime: 1.0` with `Always:`
 EventsAndTriggers:
   ? PastTime: 1.0

--- a/tests/InputFiles/ExportCoordinates/Input3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input3D.yaml
@@ -20,6 +20,10 @@ DomainCreator:
         Velocity: [0.5, 0.0, 0.0]
         FunctionOfTimeNames: ["TranslationX", "TranslationY", "TranslationZ"]
 
+SpatialDiscretization:
+  DiscontinuousGalerkin:
+    Quadrature: GaussLobatto
+
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.01

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -66,6 +66,7 @@ EvolutionSystem:
 SpatialDiscretization:
   DiscontinuousGalerkin:
     Formulation: StrongInertial
+    Quadrature: GaussLobatto
 
 NumericalFlux:
   UpwindPenalty:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/CylindricalBlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/CylindricalBlastWave.yaml
@@ -21,6 +21,7 @@ DomainCreator:
 SpatialDiscretization:
   DiscontinuousGalerkin:
     Formulation: StrongInertial
+    Quadrature: GaussLobatto
 
 AnalyticData:
   CylindricalBlastWave:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -33,6 +33,7 @@ DomainCreator:
 SpatialDiscretization:
   DiscontinuousGalerkin:
     Formulation: StrongInertial
+    Quadrature: GaussLobatto
 
 AnalyticSolution:
   FishboneMoncriefDisk:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
@@ -22,6 +22,7 @@ DomainCreator:
 SpatialDiscretization:
   DiscontinuousGalerkin:
     Formulation: StrongInertial
+    Quadrature: GaussLobatto
 
 AnalyticSolution:
   RiemannProblem:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
@@ -22,6 +22,7 @@ DomainCreator:
 SpatialDiscretization:
   DiscontinuousGalerkin:
     Formulation: StrongInertial
+    Quadrature: GaussLobatto
 
 AnalyticSolution:
   RiemannProblem:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
@@ -22,6 +22,7 @@ DomainCreator:
 SpatialDiscretization:
   DiscontinuousGalerkin:
     Formulation: StrongInertial
+    Quadrature: GaussLobatto
 
 AnalyticSolution:
   RiemannProblem:

--- a/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
+++ b/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
@@ -30,6 +30,7 @@ AnalyticSolution:
 SpatialDiscretization:
   DiscontinuousGalerkin:
     Formulation: StrongInertial
+    Quadrature: GaussLobatto
 
 NumericalFlux:
   LocalLaxFriedrichs:

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow1D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow1D.yaml
@@ -30,6 +30,7 @@ AnalyticSolution:
 SpatialDiscretization:
   DiscontinuousGalerkin:
     Formulation: StrongInertial
+    Quadrature: GaussLobatto
 
 NumericalFlux:
   LocalLaxFriedrichs:

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow2D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow2D.yaml
@@ -30,6 +30,7 @@ AnalyticSolution:
 SpatialDiscretization:
   DiscontinuousGalerkin:
     Formulation: StrongInertial
+    Quadrature: GaussLobatto
 
 NumericalFlux:
   LocalLaxFriedrichs:

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow3D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow3D.yaml
@@ -30,6 +30,7 @@ AnalyticSolution:
 SpatialDiscretization:
   DiscontinuousGalerkin:
     Formulation: StrongInertial
+    Quadrature: GaussLobatto
 
 NumericalFlux:
   LocalLaxFriedrichs:

--- a/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
@@ -41,6 +41,7 @@ DomainCreator:
 SpatialDiscretization:
   DiscontinuousGalerkin:
     Formulation: StrongInertial
+    Quadrature: GaussLobatto
 
 # If filtering is enabled in the executable the filter can be controlled using:
 # Filtering:

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -44,6 +44,7 @@ DomainCreator:
 SpatialDiscretization:
   DiscontinuousGalerkin:
     Formulation: StrongInertial
+    Quadrature: GaussLobatto
 
 # If filtering is enabled in the executable the filter can be controlled using:
 # ExpFilter0:

--- a/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
@@ -41,6 +41,7 @@ DomainCreator:
 SpatialDiscretization:
   DiscontinuousGalerkin:
     Formulation: StrongInertial
+    Quadrature: GaussLobatto
 
 # Filtering is being tested by the 2D executable (see EvolveScalarWave.hpp)
 Filtering:

--- a/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
@@ -41,6 +41,7 @@ DomainCreator:
 SpatialDiscretization:
   DiscontinuousGalerkin:
     Formulation: StrongInertial
+    Quadrature: GaussLobatto
 
 # If filtering is enabled in the executable the filter can be controlled using:
 # Filtering:

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/CMakeLists.txt
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(
   DataStructures
   ErrorHandling
   Evolution
+  Framework
   DiscontinuousGalerkin
   Domain
   DomainStructure

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -838,6 +838,11 @@ void test_impl(const Spectral::Quadrature quadrature,
                                  UseMovingMesh, HasPrims>;
   using system = typename metavars::system;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
+  using variables_tag = typename system::variables_tag;
+  using flux_variables = typename system::flux_variables;
+  using flux_variables_tag = ::Tags::Variables<flux_variables>;
+  using fluxes_tag = db::add_tag_prefix<::Tags::Flux, flux_variables_tag,
+                                        tmpl::size_t<Dim>, Frame::Inertial>;
   // The reference element in 2d denoted by X below:
   // ^ eta
   // +-+-+> xi
@@ -892,6 +897,11 @@ void test_impl(const Spectral::Quadrature quadrature,
            std::make_unique<BoundaryTerms<Dim, HasPrims>>()}};
     }
   }();
+  const auto get_tag = [&runner, &self_id](auto tag_v) -> decltype(auto) {
+    using tag = std::decay_t<decltype(tag_v)>;
+    return ActionTesting::get_databox_tag<component<metavars>, tag>(runner,
+                                                                    self_id);
+  };
 
   const Mesh<Dim> mesh{2, Spectral::Basis::Legendre, quadrature};
 
@@ -930,8 +940,6 @@ void test_impl(const Spectral::Quadrature quadrature,
   Variables<tmpl::list<::Tags::dt<Var1>, ::Tags::dt<Var2<Dim>>>>
       dt_evolved_vars{mesh.number_of_grid_points()};
 
-  using flux_tags = typename system::flux_variables;
-
   std::unordered_map<::Direction<Dim>,
                      Variables<tmpl::list<::Tags::NormalDotFlux<Var1>,
                                           ::Tags::NormalDotFlux<Var2<Dim>>>>>
@@ -945,14 +953,15 @@ void test_impl(const Spectral::Quadrature quadrature,
   }
 
   const TimeStepId time_step_id{true, 3, Time{Slab{0.2, 3.4}, {3, 100}}};
-  if constexpr (not std::is_same_v<tmpl::list<>, flux_tags>) {
+  if constexpr (not std::is_same_v<tmpl::list<>, flux_variables>) {
     ActionTesting::emplace_component_and_initialize<component<metavars>>(
         &runner, self_id,
         {time_step_id, quadrature, evolved_vars, dt_evolved_vars, var3, mesh,
          normal_dot_fluxes_interface, element, inv_jac, mesh_velocity,
          div_mesh_velocity,
-         Variables<db::wrap_tags_in<::Tags::Flux, flux_tags, tmpl::size_t<Dim>,
-                                    Frame::Inertial>>{2, -100.}});
+         Variables<db::wrap_tags_in<::Tags::Flux, flux_variables,
+                                    tmpl::size_t<Dim>, Frame::Inertial>>{
+             2, -100.}});
     for (const auto& [direction, neighbor_ids] : neighbors) {
       (void)direction;
       for (const auto& neighbor_id : neighbor_ids) {
@@ -961,7 +970,7 @@ void test_impl(const Spectral::Quadrature quadrature,
             {time_step_id, quadrature, evolved_vars, dt_evolved_vars, var3,
              mesh, normal_dot_fluxes_interface, element, inv_jac, mesh_velocity,
              div_mesh_velocity,
-             Variables<db::wrap_tags_in<::Tags::Flux, flux_tags,
+             Variables<db::wrap_tags_in<::Tags::Flux, flux_variables,
                                         tmpl::size_t<Dim>, Frame::Inertial>>{
                  2, -100.}});
       }
@@ -1008,25 +1017,49 @@ void test_impl(const Spectral::Quadrature quadrature,
         get(get<::Tags::dt<Var1>>(expected_dt_evolved_vars))[i] = 25.5;
         get(get<::Tags::dt<Var1>>(expected_dt_evolved_vars))[i + 1] = 37.5;
       } else if (quadrature == Spectral::Quadrature::Gauss) {
-        get(get<::Tags::dt<Var1>>(expected_dt_evolved_vars))[i] = 25.5;
-        get(get<::Tags::dt<Var1>>(expected_dt_evolved_vars))[i + 1] = 25.5;
+        get(get<::Tags::dt<Var1>>(expected_dt_evolved_vars))[i] =
+            25.8660254037844375;
+        get(get<::Tags::dt<Var1>>(expected_dt_evolved_vars))[i + 1] =
+            38.598076211353316;
       } else {
         ERROR("Only support Gauss and Gauss-Lobatto quadrature in test, not "
               << quadrature);
       }
     }
     if (UseMovingMesh) {
-      get(get<::Tags::dt<Var1>>(expected_dt_evolved_vars)) +=
-          -0.5 * get<0>(*mesh_velocity);
+      if (quadrature == Spectral::Quadrature::GaussLobatto) {
+        get(get<::Tags::dt<Var1>>(expected_dt_evolved_vars)) +=
+            -0.5 * get<0>(*mesh_velocity);
+      } else {
+        const tnsr::i<DataVector, Dim> d_var1 =
+            get<::Tags::deriv<Var1, tmpl::size_t<Dim>, Frame::Inertial>>(
+                partial_derivatives<tmpl::list<Var1>>(get_tag(variables_tag{}),
+                                                      mesh, inv_jac));
+        get(get<::Tags::dt<Var1>>(expected_dt_evolved_vars)) +=
+            get<0>(d_var1) * get<0>(*mesh_velocity);
+      }
     }
   } else {
     // Deal with source terms:
     get(get<::Tags::dt<Var1>>(expected_dt_evolved_vars)) = square(get(var3));
-    // Deal with volume flux divergence
-    get(get<::Tags::dt<Var1>>(expected_dt_evolved_vars)) -= 1.5;
     if constexpr (UseMovingMesh) {
       get(get<::Tags::dt<Var1>>(expected_dt_evolved_vars)) -=
-          1.5 * get(get<Var1>(evolved_vars)) - mesh_velocity->get(0) * -0.5;
+          1.5 * get(get<Var1>(evolved_vars));
+    }
+    // Deal with volume flux divergence
+    if (quadrature == Spectral::Quadrature::GaussLobatto) {
+      get(get<::Tags::dt<Var1>>(expected_dt_evolved_vars)) -= 1.5;
+      if constexpr (UseMovingMesh) {
+        get(get<::Tags::dt<Var1>>(expected_dt_evolved_vars)) +=
+            mesh_velocity->get(0) * -0.5;
+      }
+    } else {
+      const auto div = divergence(get_tag(fluxes_tag{}), mesh, inv_jac);
+      const Scalar<DataVector>& div_var1_flux = get<
+          ::Tags::div<::Tags::Flux<Var1, tmpl::size_t<Dim>, Frame::Inertial>>>(
+          div);
+      get(get<::Tags::dt<Var1>>(expected_dt_evolved_vars)) -=
+          get(div_var1_flux);
     }
   }
   // Set dt<Var2<Dim>>
@@ -1038,36 +1071,77 @@ void test_impl(const Spectral::Quadrature quadrature,
           j * get(var3);
     }
     // Deal with volume flux divergence
-    get<0>(get<::Tags::dt<Var2<Dim>>>(expected_dt_evolved_vars)) += 2.0;
-    if constexpr (Dim > 1) {
-      get<1>(get<::Tags::dt<Var2<Dim>>>(expected_dt_evolved_vars)) -= 9.0;
-    }
-    if constexpr (Dim > 2) {
-      get<2>(get<::Tags::dt<Var2<Dim>>>(expected_dt_evolved_vars)) -= 10.5;
+    if (quadrature == Spectral::Quadrature::GaussLobatto) {
+      get<0>(get<::Tags::dt<Var2<Dim>>>(expected_dt_evolved_vars)) += 2.0;
+      if constexpr (Dim > 1) {
+        get<1>(get<::Tags::dt<Var2<Dim>>>(expected_dt_evolved_vars)) -= 9.0;
+      }
+      if constexpr (Dim > 2) {
+        get<2>(get<::Tags::dt<Var2<Dim>>>(expected_dt_evolved_vars)) -= 10.5;
+      }
+      if constexpr (UseMovingMesh) {
+        for (size_t j = 0; j < Dim; ++j) {
+          get<::Tags::dt<Var2<Dim>>>(expected_dt_evolved_vars).get(j) +=
+              mesh_velocity->get(0) * 1.0;
+        }
+      }
+    } else {
+      const auto div = divergence(get_tag(fluxes_tag{}), mesh, inv_jac);
+      const tnsr::I<DataVector, Dim>& div_var2_flux = get<::Tags::div<
+          ::Tags::Flux<Var2<Dim>, tmpl::size_t<Dim>, Frame::Inertial>>>(div);
+      for (size_t i = 0; i < Dim; ++i) {
+        get<::Tags::dt<Var2<Dim>>>(expected_dt_evolved_vars).get(i) -=
+            div_var2_flux.get(i);
+      }
     }
     if constexpr (UseMovingMesh) {
       for (size_t j = 0; j < Dim; ++j) {
         get<::Tags::dt<Var2<Dim>>>(expected_dt_evolved_vars).get(j) -=
-            1.5 * get<Var2<Dim>>(evolved_vars).get(j) -
-            mesh_velocity->get(0) * 1.0;
+            1.5 * get<Var2<Dim>>(evolved_vars).get(j);
       }
     }
   } else {
-    for (size_t i = 0; i < mesh.number_of_grid_points(); i += 2) {
-      for (size_t j = 0; j < Dim; ++j) {
-        get<::Tags::dt<Var2<Dim>>>(expected_dt_evolved_vars).get(j)[i] = -3.;
-        get<::Tags::dt<Var2<Dim>>>(expected_dt_evolved_vars).get(j)[i + 1] =
-            -6.;
+    const tnsr::iJ<DataVector, Dim> d_var2 =
+        quadrature == Spectral::Quadrature::GaussLobatto
+            ? tnsr::iJ<DataVector, Dim>{}
+            : get<::Tags::deriv<Var2<Dim>, tmpl::size_t<Dim>, Frame::Inertial>>(
+                  partial_derivatives<tmpl::list<Var1, Var2<Dim>>>(
+                      get_tag(variables_tag{}), mesh, inv_jac));
+    if (quadrature == Spectral::Quadrature::GaussLobatto) {
+      for (size_t i = 0; i < mesh.number_of_grid_points(); i += 2) {
+        for (size_t j = 0; j < Dim; ++j) {
+          get<::Tags::dt<Var2<Dim>>>(expected_dt_evolved_vars).get(j)[i] = -3.;
+          get<::Tags::dt<Var2<Dim>>>(expected_dt_evolved_vars).get(j)[i + 1] =
+              -6.;
+        }
+      }
+    } else {
+      for (size_t d = 0; d < Dim; ++d) {
+        get<::Tags::dt<Var2<Dim>>>(expected_dt_evolved_vars).get(d) =
+            -get(get<Var1>(evolved_vars)) *
+            get<0>(get<Var2<Dim>>(evolved_vars)) * d_var2.get(0, d);
+        for (size_t j = 1; j < Dim; ++j) {
+          get<0>(get<::Tags::dt<Var2<Dim>>>(expected_dt_evolved_vars)) -=
+              -get(get<Var1>(evolved_vars)) *
+              get<Var2<Dim>>(evolved_vars).get(j) * d_var2.get(j, d);
+        }
       }
     }
+
+    // source term
     for (size_t j = 0; j < Dim; ++j) {
       get<::Tags::dt<Var2<Dim>>>(expected_dt_evolved_vars).get(j) +=
           j * get(var3);
     }
     if (UseMovingMesh) {
       for (size_t j = 0; j < Dim; ++j) {
-        get<::Tags::dt<Var2<Dim>>>(expected_dt_evolved_vars).get(j) +=
-            get<0>(*mesh_velocity);
+        if (quadrature == Spectral::Quadrature::GaussLobatto) {
+          get<::Tags::dt<Var2<Dim>>>(expected_dt_evolved_vars).get(j) +=
+              get<0>(*mesh_velocity);
+        } else {
+          get<::Tags::dt<Var2<Dim>>>(expected_dt_evolved_vars).get(j) +=
+              d_var2.get(0, j) * get<0>(*mesh_velocity);
+        }
       }
     }
   }
@@ -1080,12 +1154,6 @@ void test_impl(const Spectral::Quadrature quadrature,
             db::add_tag_prefix<::Tags::dt,
                                typename metavars::system::variables_tag>>(
             runner, self_id) == expected_dt_evolved_vars);
-
-  const auto get_tag = [&runner, &self_id](auto tag_v) -> decltype(auto) {
-    using tag = std::decay_t<decltype(tag_v)>;
-    return ActionTesting::get_databox_tag<component<metavars>, tag>(runner,
-                                                                    self_id);
-  };
 
   const auto mortar_id_east =
       std::make_pair(Direction<Dim>::upper_xi(), east_id);
@@ -1129,9 +1197,7 @@ void test_impl(const Spectral::Quadrature quadrature,
     // we want to verify that the functions we expect to be called on the
     // interfaces are called. Working out all the numbers explicitly would be
     // tedious.
-    using variables_tag = typename system::variables_tag;
     using variables_tags = typename variables_tag::tags_list;
-    using flux_variables = typename system::flux_variables;
     using temporary_tags_for_face = tmpl::list<Var3Squared>;
     using primitive_tags_for_face = tmpl::conditional_t<
         system::has_primitive_and_conservative_vars,
@@ -1143,9 +1209,6 @@ void test_impl(const Spectral::Quadrature quadrature,
         tmpl::list<>>;
     using fluxes_tags = db::wrap_tags_in<::Tags::Flux, flux_variables,
                                          tmpl::size_t<Dim>, Frame::Inertial>;
-    using flux_variables_tag = ::Tags::Variables<flux_variables>;
-    using fluxes_tag = db::add_tag_prefix<::Tags::Flux, flux_variables_tag,
-                                          tmpl::size_t<Dim>, Frame::Inertial>;
     using mortar_tags_list =
         typename BoundaryTerms<Dim, HasPrims>::dg_package_field_tags;
     const auto& face_meshes =
@@ -1285,6 +1348,57 @@ void test_impl(const Spectral::Quadrature quadrature,
 template <SystemType system_type, UseBoundaryCorrection use_boundary_correction,
           size_t Dim>
 void test() noexcept {
+  // The test impl is structured in the following way:
+  // - the static mesh volume contributions are computed "by-hand" and used more
+  //   or less as a regression test. This is relatively easy for Gauss-Lobatto
+  //   points, a bit more tedious for Gauss points. We also assume the solution
+  //   is constant in the y & z direction to make the math easier. The math
+  //   implemented and checked against are the static mesh contributions coded
+  //   up in TimeDerivativeTerms, with the addition of the strong or weak flux
+  //   divergence that are computed by generic code outside the
+  //   TimeDerivativeTerms struct.
+  //
+  //   The conservative equations are:
+  //     dt var1 = -d_i (var1**2 + var2^i) + var3**2
+  //     dt var2^j = -d_i (var1 * var2^i * var2^j + delta^i_j var1**3) +var3 * j
+  //   if there are primitive variables then:
+  //     dt var1 += prim_var1
+  //
+  //   The non-conservative equations are:
+  //     dt var1 = -var2^i d_i var1 + var3**2
+  //     dt var2^j = -var1 * var2^i d_i var2^j + var3 * j
+  //
+  //   The mixed conservative non-conservative equations are:
+  //     dt var1 = -var2^i d_i var1 + var3**2
+  //     dt var2^j = -d_i (var1 * var2^i * var2^j + delta^i_j var1**3) +var3 * j
+  //   if there are primitive variables then:
+  //     dt var1 += prim_var1
+  //
+  //   The mesh only has 2 points per dimension to make the math not too
+  //   terrible. The differentiation matrices & weights for Gauss points are:
+  //    D^{strong}: {{-0.866025403784438, 0.866025403784438},
+  //                 {-0.866025403784438, 0.866025403784438}}
+  //    w: {1.0, 1.0}
+  //    D^{weak}: {{-0.866025403784438, -0.866025403784438},
+  //               {0.866025403784438, 0.866025403784438}}
+  //
+  //   Gauss-Lobatto:
+  //    D^{strong}: {{-1/2, 1/2}, {-1/2, 1/2}}
+  //    w: {1.0, 1.0}
+  //    D^{weak}: {{-1/2, -1/2}, {1/2, 1/2}}
+  //
+  //   The weak divergence matrix is given by:
+  //     D_{i,l}^{weak} = (w_l/w_i) D_{l,i}^{strong}
+  //
+  // - the additional parts, such as moving mesh and boundary corrections become
+  //   increasingly tedious (and unmaintainable) to work out separately
+  //   (implementing the entire moving-mesh DG algorithm in Python is _a lot_ of
+  //   work and extra code), so instead we verify that the expected mathematical
+  //   manipulations occur. Specifically, we check adding the mesh velocity to
+  //   the fluxes, and lifting the boundary contributions to the volume, even
+  //   though the mesh velocity and boundary contributions are not the correct
+  //   DG values
+
   Parallel::register_derived_classes_with_charm<
       BoundaryCorrection<Dim, use_boundary_correction>>();
 
@@ -1315,6 +1429,10 @@ void test() noexcept {
   for (const auto dg_formulation : {::dg::Formulation::StrongInertial}) {
     invoke_tests_with_quadrature_and_formulation(
         Spectral::Quadrature::GaussLobatto, dg_formulation);
+    if constexpr (use_boundary_correction == UseBoundaryCorrection::Yes) {
+      invoke_tests_with_quadrature_and_formulation(Spectral::Quadrature::Gauss,
+                                                   dg_formulation);
+    }
   }
 }
 }  // namespace TestHelpers::evolution::dg::Actions

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -27,6 +27,7 @@
 #include "Evolution/BoundaryCorrectionTags.hpp"
 #include "Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp"
 #include "Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp"
+#include "Evolution/DiscontinuousGalerkin/Initialization/QuadratureTag.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
 #include "Evolution/DiscontinuousGalerkin/ProjectToBoundary.hpp"
@@ -699,7 +700,8 @@ struct component {
       domain::Tags::BoundaryDirectionsInterior<Metavariables::volume_dim>;
 
   using common_simple_tags = tmpl::list<
-      ::Tags::TimeStepId, typename Metavariables::system::variables_tag,
+      ::Tags::TimeStepId, ::evolution::dg::Tags::Quadrature,
+      typename Metavariables::system::variables_tag,
       db::add_tag_prefix<::Tags::dt,
                          typename Metavariables::system::variables_tag>,
       Var3, domain::Tags::Mesh<Metavariables::volume_dim>,
@@ -946,7 +948,7 @@ void test_impl(const Spectral::Quadrature quadrature,
   if constexpr (not std::is_same_v<tmpl::list<>, flux_tags>) {
     ActionTesting::emplace_component_and_initialize<component<metavars>>(
         &runner, self_id,
-        {time_step_id, evolved_vars, dt_evolved_vars, var3, mesh,
+        {time_step_id, quadrature, evolved_vars, dt_evolved_vars, var3, mesh,
          normal_dot_fluxes_interface, element, inv_jac, mesh_velocity,
          div_mesh_velocity,
          Variables<db::wrap_tags_in<::Tags::Flux, flux_tags, tmpl::size_t<Dim>,
@@ -956,8 +958,8 @@ void test_impl(const Spectral::Quadrature quadrature,
       for (const auto& neighbor_id : neighbor_ids) {
         ActionTesting::emplace_component_and_initialize<component<metavars>>(
             &runner, neighbor_id,
-            {time_step_id, evolved_vars, dt_evolved_vars, var3, mesh,
-             normal_dot_fluxes_interface, element, inv_jac, mesh_velocity,
+            {time_step_id, quadrature, evolved_vars, dt_evolved_vars, var3,
+             mesh, normal_dot_fluxes_interface, element, inv_jac, mesh_velocity,
              div_mesh_velocity,
              Variables<db::wrap_tags_in<::Tags::Flux, flux_tags,
                                         tmpl::size_t<Dim>, Frame::Inertial>>{
@@ -967,7 +969,7 @@ void test_impl(const Spectral::Quadrature quadrature,
   } else {
     ActionTesting::emplace_component_and_initialize<component<metavars>>(
         &runner, self_id,
-        {time_step_id, evolved_vars, dt_evolved_vars, var3, mesh,
+        {time_step_id, quadrature, evolved_vars, dt_evolved_vars, var3, mesh,
          normal_dot_fluxes_interface, element, inv_jac, mesh_velocity,
          div_mesh_velocity});
     for (const auto& [direction, neighbor_ids] : neighbors) {
@@ -975,8 +977,8 @@ void test_impl(const Spectral::Quadrature quadrature,
       for (const auto& neighbor_id : neighbor_ids) {
         ActionTesting::emplace_component_and_initialize<component<metavars>>(
             &runner, neighbor_id,
-            {time_step_id, evolved_vars, dt_evolved_vars, var3, mesh,
-             normal_dot_fluxes_interface, element, inv_jac, mesh_velocity,
+            {time_step_id, quadrature, evolved_vars, dt_evolved_vars, var3,
+             mesh, normal_dot_fluxes_interface, element, inv_jac, mesh_velocity,
              div_mesh_velocity});
       }
     }

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeInterfaces.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeInterfaces.cpp
@@ -103,7 +103,8 @@ struct ElementArray {
                              dg::Actions::InitializeDomain<Dim>>>,
               ActionTesting::InitializeDataBox<tmpl::append<
                   tmpl::list<domain::Tags::InitialRefinementLevels<Dim>,
-                             domain::Tags::InitialExtents<Dim>, vars_tag,
+                             domain::Tags::InitialExtents<Dim>,
+                             evolution::dg::Tags::Quadrature, vars_tag,
                              other_vars_tag>,
                   tmpl::conditional_t<
                       use_moving_mesh,
@@ -208,7 +209,8 @@ void create_runner_and_run_tests(
       typename Metavariables::element_array>(
       &runner, element_id,
       {domain_creator.initial_refinement_levels(),
-       domain_creator.initial_extents(), vars, other_vars, 0.0, 0.1, 0.1});
+       domain_creator.initial_extents(), Spectral::Quadrature::GaussLobatto,
+       vars, other_vars, 0.0, 0.1, 0.1});
 
   ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
   ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
@@ -239,7 +241,8 @@ void create_runner_and_run_tests(
       typename Metavariables::element_array>(
       &runner, element_id,
       {domain_creator.initial_refinement_levels(),
-       domain_creator.initial_extents(), vars, other_vars});
+       domain_creator.initial_extents(), Spectral::Quadrature::GaussLobatto,
+       vars, other_vars});
 
   ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
   ActionTesting::set_phase(make_not_null(&runner),


### PR DESCRIPTION
## Proposed changes

Pretty much exactly what the title says. Some notes:
- Gauss points were already supported but they weren't tested (so I considered them unsupported). Testing also uncovered a bug in older versions of LIBXSMM. I work around this by switching from LIBXSMM to BLAS for single-row dgemm calls in the commit `Handle single row matrices separately in apply_matrices`, which will get dropped when #2706 is merged.
- The commit `Handle single row matrices separately in apply_matrices` will get dropped when #2706 is.
- The weak form doesn't fully work with metric identity satisfying Jacobians because the normal vectors aren't computed consistently. This will get updated once #2683 is merged as well as some follow-up changes to that.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
