### PR TITLE
Add CMake option to remove unit-tests from test-executables

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -411,7 +411,7 @@ jobs:
           -D CHARM_ROOT=/work/charm_6_10_2/multicore-linux-x86_64-${CHARM_CC}
           -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}
           -D DEBUG_SYMBOLS=OFF
-          -D RUN_TESTS_IN_TEST_EXECUTABLES=OFF
+          -D UNIT_TESTS_IN_TEST_EXECUTABLES=OFF
           -D STRIP_SYMBOLS=ON
           -D STUB_EXECUTABLE_OBJECT_FILES=ON
           -D STUB_LIBRARY_OBJECT_FILES=ON
@@ -466,19 +466,11 @@ jobs:
         run: |
           ccache -s
       - name: Run non-unit tests
-        if: matrix.use_pch == 'ON'
         working-directory: /work/build
         run: |
           # We get occasional random timeouts, repeat tests to see if
           # it is a random timeout or systematic
           ctest -j2 -LE unit --output-on-failure --repeat after-timeout:3
-      - name: Run input file tests without PCH
-        if: matrix.use_pch == 'OFF'
-        working-directory: /work/build
-        run: |
-          # We get occasional random timeouts, repeat tests to see if
-          # it is a random timeout or systematic
-          ctest -j2 --output-on-failure -L inputfiles --repeat after-timeout:3
       - name: Test formaline tar can be built
         if: matrix.build_type == 'Debug'
         working-directory: /work/build
@@ -534,7 +526,7 @@ jobs:
           -D CHARM_ROOT=/work/charm_6_10_2/multicore-linux-x86_64-${CHARM_CC}
           -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}
           -D DEBUG_SYMBOLS=OFF
-          -D RUN_TESTS_IN_TEST_EXECUTABLES=OFF
+          -D UNIT_TESTS_IN_TEST_EXECUTABLES=OFF
           -D STRIP_SYMBOLS=ON
           -D STUB_EXECUTABLE_OBJECT_FILES=ON
           -D STUB_LIBRARY_OBJECT_FILES=ON

--- a/docs/DevGuide/BuildSystem.md
+++ b/docs/DevGuide/BuildSystem.md
@@ -225,6 +225,10 @@ cmake -D FLAG1=OPT1 ... -D FLAGN=OPTN <SPECTRE_ROOT>
     [undefined
     behavior](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html)
     compile flags (`-fsanitize=undefined`) (default is `OFF`)
+- UNIT_TESTS_IN_TEST_EXECUTABLES
+  - Whether to build the `unit-tests` target as part of the `test-executables`
+    target. This is used to build only the non-unit tests in the CI build
+    that doesn't use the PCH. (default is `ON`)
 - USE_CCACHE
   - Use ccache to cache build output so that rebuilding parts of the source tree
     is faster. The cache will use up space on disk, with the default being

--- a/tests/Unit/CMakeLists.txt
+++ b/tests/Unit/CMakeLists.txt
@@ -72,16 +72,6 @@ add_dependencies(
 
 add_dependencies(unit-tests ${executable})
 
-option(
-  RUN_TESTS_IN_TEST_EXECUTABLES
-  "Build RunTests as part of test-executables"
-  ON
-  )
-
-if (RUN_TESTS_IN_TEST_EXECUTABLES)
-  add_dependencies(test-executables ${executable})
-endif (RUN_TESTS_IN_TEST_EXECUTABLES)
-
 spectre_add_catch_tests(${executable} "${SPECTRE_TESTS_LIBRARIES}")
 
 # Setup code coverage for unit tests
@@ -103,4 +93,12 @@ endif()
 
 add_subdirectory(RunSingleTest)
 
-add_dependencies(test-executables unit-tests)
+option(
+  UNIT_TESTS_IN_TEST_EXECUTABLES
+  "Build unit-tests as part of test-executables"
+  ON
+  )
+
+if (UNIT_TESTS_IN_TEST_EXECUTABLES)
+  add_dependencies(test-executables unit-tests)
+endif (UNIT_TESTS_IN_TEST_EXECUTABLES)


### PR DESCRIPTION
## Proposed changes

This was missed when adding the `unit-tests` target. We had only been building the executables for the non-unit tests before the unit-tests target was added to keep build time of the no-PCH CI build down. This PR restores that and documents the flag.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
