### PR TITLE
Add enum for elliptic boundary condition types

### DIFF
--- a/src/Elliptic/BoundaryConditions/BoundaryConditionType.cpp
+++ b/src/Elliptic/BoundaryConditions/BoundaryConditionType.cpp
@@ -1,0 +1,45 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Elliptic/BoundaryConditions/BoundaryConditionType.hpp"
+
+#include <ostream>
+#include <string>
+
+#include "ErrorHandling/Error.hpp"
+#include "Options/Options.hpp"
+#include "Options/ParseOptions.hpp"
+
+/// \cond
+namespace elliptic {
+std::ostream& operator<<(
+    std::ostream& os,
+    const elliptic::BoundaryConditionType boundary_condition_type) noexcept {
+  switch (boundary_condition_type) {
+    case elliptic::BoundaryConditionType::Dirichlet:
+      return os << "Dirichlet";
+    case elliptic::BoundaryConditionType::Neumann:
+      return os << "Neumann";
+    default:
+      ERROR("Missing case for operator<<(elliptic::BoundaryConditionType).");
+  }
+}
+}  // namespace elliptic
+
+template <>
+elliptic::BoundaryConditionType
+Options::create_from_yaml<elliptic::BoundaryConditionType>::create<void>(
+    const Options::Option& options) {
+  const auto type_read = options.parse_as<std::string>();
+  if ("Dirichlet" == type_read) {
+    return elliptic::BoundaryConditionType::Dirichlet;
+  } else if ("Neumann" == type_read) {
+    return elliptic::BoundaryConditionType::Neumann;
+  }
+  PARSE_ERROR(options.context(),
+              "Failed to convert \""
+                  << type_read
+                  << "\" to elliptic::BoundaryConditionType. Must be "
+                     "either 'Dirichlet' or 'Neumann'.");
+}
+/// \endcond

--- a/src/Elliptic/BoundaryConditions/BoundaryConditionType.hpp
+++ b/src/Elliptic/BoundaryConditions/BoundaryConditionType.hpp
@@ -1,0 +1,46 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <ostream>
+
+/// \cond
+namespace Options {
+class Option;
+template <typename T>
+struct create_from_yaml;
+}  // namespace Options
+/// \endcond
+
+namespace elliptic {
+
+/// Identify types of boundary conditions for elliptic equations
+enum class BoundaryConditionType {
+  /// Dirichlet boundary conditions like \f$u(x_0)=u_0\f$
+  Dirichlet,
+  /// Neumann boundary conditions like \f$n^i\partial_i u(x_0)=v_0\f$, where
+  /// \f$\boldsymbol{n}\f$ is the normal to the domain boundary
+  Neumann
+};
+
+std::ostream& operator<<(
+    std::ostream& os, BoundaryConditionType boundary_condition_type) noexcept;
+
+}  // namespace elliptic
+
+/// \cond
+template <>
+struct Options::create_from_yaml<elliptic::BoundaryConditionType> {
+  template <typename Metavariables>
+  static elliptic::BoundaryConditionType create(
+      const Options::Option& options) {
+    return create<void>(options);
+  }
+};
+
+template <>
+elliptic::BoundaryConditionType
+Options::create_from_yaml<elliptic::BoundaryConditionType>::create<void>(
+    const Options::Option& options);
+/// \endcond

--- a/src/Elliptic/BoundaryConditions/CMakeLists.txt
+++ b/src/Elliptic/BoundaryConditions/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_sources(
+  Elliptic
+  PRIVATE
+  BoundaryConditionType.cpp
+  )
+
+spectre_target_headers(
+  Elliptic
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  BoundaryConditionType.hpp
+  Tags.hpp
+  )

--- a/src/Elliptic/BoundaryConditions/Tags.hpp
+++ b/src/Elliptic/BoundaryConditions/Tags.hpp
@@ -1,0 +1,47 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <string>
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataBox/TagName.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryConditionType.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace elliptic {
+namespace OptionTags {
+
+template <typename Tag>
+struct BoundaryConditionType {
+  static std::string name() noexcept { return db::tag_name<Tag>(); }
+  using type = elliptic::BoundaryConditionType;
+  static constexpr Options::String help =
+      "Type of boundary conditions to impose on this variable";
+};
+
+}  // namespace OptionTags
+
+namespace Tags {
+
+/// The `elliptic::BoundaryConditionType` to impose on the variable represented
+/// by `Tag`, e.g. Dirichlet or Neumann boundary conditions
+template <typename Tag>
+struct BoundaryConditionType : db::PrefixTag, db::SimpleTag {
+  using type = elliptic::BoundaryConditionType;
+  using tag = Tag;
+};
+
+/// The `elliptic::BoundaryConditionType` to impose on the variables represented
+/// by `Tags`, e.g. Dirichlet or Neumann boundary conditions
+template <typename Tags>
+struct BoundaryConditionTypes : db::SimpleTag {
+  using type = tuples::tagged_tuple_from_typelist<
+      db::wrap_tags_in<elliptic::Tags::BoundaryConditionType, Tags>>;
+};
+
+}  // namespace Tags
+}  // namespace elliptic

--- a/src/Elliptic/CMakeLists.txt
+++ b/src/Elliptic/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 set(LIBRARY Elliptic)
 
-add_spectre_library(${LIBRARY} INTERFACE)
+add_spectre_library(${LIBRARY})
 
 spectre_target_headers(
   ${LIBRARY}
@@ -16,6 +16,9 @@ spectre_target_headers(
 
 target_link_libraries(
   ${LIBRARY}
+  PRIVATE
+  ErrorHandling
+  Options
   INTERFACE
   DataStructures
   Domain
@@ -24,6 +27,7 @@ target_link_libraries(
   )
 
 add_subdirectory(Actions)
+add_subdirectory(BoundaryConditions)
 add_subdirectory(DiscontinuousGalerkin)
 add_subdirectory(Executables)
 add_subdirectory(Systems)

--- a/tests/Unit/Elliptic/BoundaryConditions/CMakeLists.txt
+++ b/tests/Unit/Elliptic/BoundaryConditions/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_EllipticBoundaryConditions")
+
+set(LIBRARY_SOURCES
+  Test_BoundaryConditionType.cpp
+  Test_Tags.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "Elliptic/BoundaryConditions/"
+  "${LIBRARY_SOURCES}"
+  "Elliptic;Utilities"
+  )

--- a/tests/Unit/Elliptic/BoundaryConditions/Test_BoundaryConditionType.cpp
+++ b/tests/Unit/Elliptic/BoundaryConditions/Test_BoundaryConditionType.cpp
@@ -1,0 +1,30 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "Elliptic/BoundaryConditions/BoundaryConditionType.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Utilities/GetOutput.hpp"
+
+namespace elliptic {
+
+SPECTRE_TEST_CASE("Unit.Elliptic.BoundaryConditionType", "[Unit][Elliptic]") {
+  CHECK(get_output(BoundaryConditionType::Dirichlet) == "Dirichlet");
+  CHECK(get_output(BoundaryConditionType::Neumann) == "Neumann");
+  CHECK(TestHelpers::test_creation<BoundaryConditionType>("Dirichlet") ==
+        BoundaryConditionType::Dirichlet);
+  CHECK(TestHelpers::test_creation<BoundaryConditionType>("Neumann") ==
+        BoundaryConditionType::Neumann);
+}
+
+// [[OutputRegex, Failed to convert "nil" to elliptic::BoundaryConditionType.]]
+SPECTRE_TEST_CASE("Unit.Elliptic.BoundaryConditionType.ParseError",
+                  "[Unit][Elliptic]") {
+  ERROR_TEST();
+  TestHelpers::test_creation<elliptic::BoundaryConditionType>("nil");
+}
+
+}  // namespace elliptic

--- a/tests/Unit/Elliptic/BoundaryConditions/Test_Tags.cpp
+++ b/tests/Unit/Elliptic/BoundaryConditions/Test_Tags.cpp
@@ -1,0 +1,22 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "Elliptic/BoundaryConditions/Tags.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+
+namespace {
+struct FieldTag {};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Elliptic.BoundaryConditions.Tags", "[Unit][Elliptic]") {
+  TestHelpers::db::test_prefix_tag<
+      elliptic::Tags::BoundaryConditionType<FieldTag>>(
+      "BoundaryConditionType(FieldTag)");
+  TestHelpers::db::test_simple_tag<
+      elliptic::Tags::BoundaryConditionTypes<tmpl::list<FieldTag>>>(
+      "BoundaryConditionTypes");
+}

--- a/tests/Unit/Elliptic/CMakeLists.txt
+++ b/tests/Unit/Elliptic/CMakeLists.txt
@@ -2,6 +2,7 @@
 # See LICENSE.txt for details.
 
 add_subdirectory(Actions)
+add_subdirectory(BoundaryConditions)
 add_subdirectory(DiscontinuousGalerkin)
 add_subdirectory(Systems)
 add_subdirectory(Triggers)


### PR DESCRIPTION
## Proposed changes

This enum will be used to select the type of boundary conditions in
some boundary condition classes that support such choice, e.g.
when using an analytic solution or when imposing homogeneous (zero)
boundary conditions. This choice can be made in the input file.

For example, the idea is the user can write this in the input file:

```yaml
BoundaryConditions:
  AnalyticSolution:
    ConformalFactor: Neumann
    LapseTimesConformalFactor: Dirichlet
    Shift: Dirichlet
```

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
