### PR TITLE
compute_databox_type now works for incomplete types.

### DIFF
--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -802,6 +802,10 @@ struct ScalarTag4 : db::SimpleTag {
 struct VectorTag4 : db::SimpleTag {
   using type = tnsr::I<DataVector, 3>;
 };
+struct IncompleteType; // Forward declare, do not define on purpose.
+struct TagForIncompleteType : db::SimpleTag {
+  using type = IncompleteType;
+};
 }  // namespace test_databox_tags
 
 namespace {
@@ -1481,6 +1485,13 @@ static_assert(
             test_databox_tags::MultiplyScalarByTwoCompute,
             test_databox_tags::ScalarTag2, test_databox_tags::VectorTag2>>>,
     "Failed testing db::compute_databox_type");
+
+static_assert(
+    std::is_same_v<
+        db::compute_databox_type<
+            tmpl::list<test_databox_tags::TagForIncompleteType>>,
+        db::DataBox<tmpl::list<test_databox_tags::TagForIncompleteType>>>,
+    "Failed testing db::compute_databox_type for incomplete type");
 
 void multiply_by_two_mutate(const gsl::not_null<std::vector<double>*> t,
                             const double value) {


### PR DESCRIPTION
## Proposed changes

compute_datbox_type and const_item_type now work for incomplete types.
Also added a test that fails for the old implementation.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
