### PR TITLE
Re-arrange Blaze template expressions

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -339,16 +339,6 @@ jobs:
           - compiler: clang-9
             build_type: Debug
             use_pch: OFF
-        exclude:
-          # The following tests segfault in release mode:
-          # - Unit.Evolution.Systems.Cce.Equations
-          # - Unit.Evolution.Systems.Cce.InitializeJ
-          # - Unit.Evolution.Systems.Cce.NewmanPenrose
-          # Test_BulgedCube is fixed. This is either a GCC-10 optimizer bug or
-          # some weird Blaze behavior with GCC-10.
-          - use_pch: ON
-            build_type: Release
-            compiler: gcc-10
 
     container:
       image: sxscollaboration/spectrebuildenv:latest

--- a/src/Evolution/Systems/Cce/NewmanPenrose.cpp
+++ b/src/Evolution/Systems/Cce/NewmanPenrose.cpp
@@ -20,14 +20,13 @@ void weyl_psi0_impl(
     const SpinWeighted<ComplexDataVector, 0>& bondi_k,
     const SpinWeighted<ComplexDataVector, 0>& bondi_r,
     const SpinWeighted<ComplexDataVector, 0>& one_minus_y) noexcept {
-  // note: intential use of expression template instead of allocation
-  const auto dy_beta = 0.125 * one_minus_y *
-                 (dy_j * conj(dy_j) -
-                  0.25 * square(bondi_j * conj(dy_j) + conj(bondi_j) * dy_j) /
-                      square(bondi_k));
   *psi_0 = pow<4>(one_minus_y) * 0.0625 / (square(bondi_r) * bondi_k) *
-           (dy_beta * ((1.0 + bondi_k) * dy_j -
-                       square(bondi_j) * conj(dy_j) / (1.0 + bondi_k)) -
+           (0.125 * one_minus_y *
+                (dy_j * conj(dy_j) -
+                 0.25 * square(bondi_j * conj(dy_j) + conj(bondi_j) * dy_j) /
+                     square(bondi_k)) *
+                ((1.0 + bondi_k) * dy_j -
+                 square(bondi_j) * conj(dy_j) / (1.0 + bondi_k)) -
             0.5 * (1.0 + bondi_k) * dy_dy_j +
             0.5 * square(bondi_j) * conj(dy_dy_j) / (1.0 + bondi_k) +
             (-0.25 * bondi_j *

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
@@ -144,7 +144,8 @@ void test_weak_differentiation() {
         const auto analytic_derivative =
             unit_polynomial_derivative(p, collocation_pts);
         for (size_t i = 1; i < n - 1; ++i) {
-          CHECK(numeric_derivative[i] == approx(-analytic_derivative[i]));
+          Approx local_approx = Approx::custom().epsilon(1e-12).scale(1.);
+          CHECK(local_approx(numeric_derivative[i]) == -analytic_derivative[i]);
         }
       }
     }


### PR DESCRIPTION
This avoids a segfault that appears to be generated by certain GCC-10
optimizations for particularly intricate Blaze template expressions.

fixes #2718

Since we do not yet have GCC-10 in the CI (clearly), I'll have to ask @nilsdeppe to review this and verify that it fixes the problem he found.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

