### PR TITLE
Fix Py_None reference counting in pypp, prevent modification of RunSingleTest/CMakeLists.txt, check for TODO comments

### DIFF
--- a/docs/DevGuide/Travis.md
+++ b/docs/DevGuide/Travis.md
@@ -78,6 +78,7 @@ if any of the following are true:
     Python-binding directory,
     * does not list a `C++` file that is present in the directory
     * lists a `C++` file that is not present in the directory
+  - A `c++` or `python` file contains a `TODO` (case-insensitive) comment
   - The file `tests/Unit/RunSingleTest/CMakeLists.txt` wasn't modified
   - A python file is not formatted according to the `.style.yapf` file in the
     root of the repository.

--- a/docs/DevGuide/Travis.md
+++ b/docs/DevGuide/Travis.md
@@ -69,6 +69,8 @@ if any of the following are true:
     * contains `Ls` (use `List` instead)
     * contains additional text after `/*!` (does not render correctly in
       Doxygen)
+    * contains the string `return Py_None;` (bug prone, use `Py_RETURN_NONE`
+      instead)
   - A `c++` test,
     * uses `TEST_CASE` (use `SPECTRE_TEST_CASE` instead)
     * uses `Approx` (use `approx` instead)

--- a/docs/DevGuide/Travis.md
+++ b/docs/DevGuide/Travis.md
@@ -78,6 +78,7 @@ if any of the following are true:
     Python-binding directory,
     * does not list a `C++` file that is present in the directory
     * lists a `C++` file that is not present in the directory
+  - The file `tests/Unit/RunSingleTest/CMakeLists.txt` wasn't modified
   - A python file is not formatted according to the `.style.yapf` file in the
     root of the repository.
 * RUN_CLANG_TIDY runs the script `.travis/RunClangTidy.sh` which runs

--- a/src/DataStructures/Tensor/Expressions/Product.hpp
+++ b/src/DataStructures/Tensor/Expressions/Product.hpp
@@ -49,9 +49,6 @@ struct Product<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>>
 
   Product(const T1& t1, const T2& t2) : t1_(t1), t2_(t2) {}
 
-  // TODO: The args will need to be reduced in a careful manner, which means
-  // they need to be reduced together, then split at the correct length so that
-  // the indexing is correct.
   template <typename... LhsIndices, typename U>
   SPECTRE_ALWAYS_INLINE type
   get(const std::array<U, num_tensor_indices>& tensor_index) const {

--- a/src/Domain/CreateInitialElement.cpp
+++ b/src/Domain/CreateInitialElement.cpp
@@ -37,7 +37,6 @@ Element<VolumeDim> create_initial_element(
           const Direction<VolumeDim>& direction) noexcept {
     const auto& block_neighbor = neighbors_of_block.at(direction);
     const auto& orientation = block_neighbor.orientation();
-    // TODO(): An illustration of what is happening here would be useful
     const auto direction_in_neighbor = orientation(direction);
 
     // SegmentIds of the current element using the neighbor's axes.

--- a/tests/Unit/Framework/PyppFundamentals.hpp
+++ b/tests/Unit/Framework/PyppFundamentals.hpp
@@ -87,7 +87,9 @@ PyObject* make_py_tuple(const Args&... t) {
 ///\cond
 template <>
 struct ToPyObject<void, std::nullptr_t> {
-  static PyObject* convert() { return Py_None; }
+  static PyObject* convert() {
+    Py_RETURN_NONE;
+  }
 };
 
 template <typename T>
@@ -649,7 +651,7 @@ struct ToPyObject<boost::optional<T>> {
     if (static_cast<bool>(t)) {
       return to_py_object(*t);
     }
-    return Py_None;
+    Py_RETURN_NONE;
   }
 };
 
@@ -669,7 +671,7 @@ struct ToPyObject<std::optional<T>> {
     if (static_cast<bool>(t)) {
       return to_py_object(*t);
     }
-    return Py_None;
+    Py_RETURN_NONE;
   }
 };
 

--- a/tools/CheckFiles.sh
+++ b/tools/CheckFiles.sh
@@ -144,6 +144,60 @@ check_cmakelists_for_extra_cxx_test() {
 }
 ci_checks+=(check_cmakelists_for_extra_cxx)
 
+# Check for "to do" comments because these should be issues instead
+prevent_todo_comments() {
+    regex="//[[:space:]]*TODO.*\|.*\*[[:space:]]*TODO.*\|.*#[[:space:]]*TODO.*"
+    is_c++_or_python "$1" \
+        && staged_grep -q -i "${regex}" "$1"
+}
+prevent_todo_comments_report() {
+    regex="//[[:space:]]*TODO.*\|.*\*[[:space:]]*TODO.*\|.*#[[:space:]]*TODO.*"
+    echo "Found TODO comments. Please file issues instead."
+    pretty_grep -i "${regex}" "$@"
+}
+prevent_todo_comments_test() {
+    test_check pass foo.hpp ''
+    test_check pass foo.cpp ''
+    test_check pass foo.tpp ''
+    test_check pass foo.tpp 'christodoulou'
+    test_check fail foo.hpp '// TODO blah'
+    test_check fail foo.cpp '// TODO blah'
+    test_check fail foo.tpp '// TODO blah'
+    test_check fail foo.hpp '// TODO: blah'
+    test_check fail foo.hpp '//TODO blah'
+    test_check fail foo.hpp '//TODO'
+    test_check fail foo.hpp ' * TODO blah'
+    test_check fail foo.hpp ' * TODO: blah'
+    test_check fail foo.hpp ' *TODO blah'
+    test_check fail foo.hpp ' *TODO'
+    test_check fail foo.hpp '// todo blah'
+    test_check fail foo.hpp '// todo: blah'
+    test_check fail foo.hpp '//todo blah'
+    test_check fail foo.hpp '//todo'
+    test_check fail foo.hpp ' * todo blah'
+    test_check fail foo.hpp ' * todo: blah'
+    test_check fail foo.hpp ' *todo blah'
+    test_check fail foo.hpp ' *todo'
+    test_check fail foo.hpp '// Todo blah'
+    test_check fail foo.hpp '// Todo: blah'
+    test_check fail foo.hpp '//Todo blah'
+    test_check fail foo.hpp '//Todo'
+    test_check fail foo.hpp ' * Todo blah'
+    test_check fail foo.hpp ' * Todo: blah'
+    test_check fail foo.hpp ' *Todo blah'
+    test_check fail foo.hpp ' *Todo'
+    test_check pass foo.py 'christodoulou'
+    test_check fail foo.py '#TODO: blah'
+    test_check fail foo.py '  #TODO: blah'
+    test_check fail foo.py '# TODO: blah'
+    test_check fail foo.py '  # TODO: blah'
+    test_check fail foo.py '#TODO blah'
+    test_check fail foo.py '  #TODO blah'
+    test_check fail foo.py '# TODO blah'
+    test_check fail foo.py '  # TODO blah'
+}
+ci_checks+=(prevent_todo_comments)
+
 if [ "$1" = --test ] ; then
     run_tests "${ci_checks[@]}"
     exit 0

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -418,6 +418,35 @@ pragma_once_test() {
 }
 standard_checks+=(pragma_once)
 
+# Check for 'return Py_None;' in all C++ files
+py_return_none() {
+    is_c++ "$1" && \
+        whitelist "$1" && \
+        staged_grep -q -x '.*return Py_None;.*' "$1"
+}
+py_return_none_report() {
+    echo "Found 'return Py_None;' in files. Use Py_RETURN_NONE instead."
+    pretty_grep ".*return Py_None;.*" "$@"
+}
+py_return_none_test() {
+    test_check pass foo.cpp ''
+    test_check pass foo.hpp ''
+    test_check pass foo.tpp ''
+    test_check fail foo.hpp '  return Py_None;'$'\n'
+    test_check fail foo.cpp '  return Py_None;'$'\n'
+    test_check fail foo.tpp '  return Py_None;'$'\n'
+    test_check fail foo.hpp '//return Py_None;'$'\n'
+    test_check fail foo.cpp '//return Py_None;'$'\n'
+    test_check fail foo.tpp '//return Py_None;'$'\n'
+    test_check fail foo.hpp '  return Py_None; '$'\n'
+    test_check fail foo.cpp '  return Py_None; '$'\n'
+    test_check fail foo.tpp '  return Py_None; '$'\n'
+    test_check pass foo.hpp '//return Py_None'$'\n'
+    test_check pass foo.cpp '//return Py_None'$'\n'
+    test_check pass foo.tpp '//return Py_None'$'\n'
+}
+standard_checks+=(py_return_none)
+
 # Check for a newline at end of file
 final_newline() {
     whitelist "$1" '.h5' '.nojekyll' '.png' '.svg' &&

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -81,6 +81,8 @@ pretty_grep() {
 # Utility functions for checks classifying a file based on its name
 is_includible() { [[ $1 =~ \.hpp$ ]] || [[ $1 =~ \.tpp$ ]] ; }
 is_c++() { [[ $1 =~ \.cpp$ ]] || [[ $1 =~ \.hpp$ ]] || [[ $1 =~ \.tpp$ ]] ; }
+is_c++_or_python() { [[ $1 =~ \.cpp$ ]] || [[ $1 =~ \.hpp$ ]] \
+                         || [[ $1 =~ \.tpp$ ]] || [[ $1 =~ \.py$ ]] ; }
 
 # Utility function for checks that returns false if the first argument
 # matches any of the shell regexes passed as subsequent arguments.

--- a/tools/Hooks/pre-commit.sh
+++ b/tools/Hooks/pre-commit.sh
@@ -28,7 +28,8 @@ found_error=0
 @Python_EXECUTABLE@ @CMAKE_SOURCE_DIR@/.git/hooks/CheckFileSize.py
 [ "$?" -ne 0 ] && found_error=1
 
-printf '%s\0' "${commit_files[@]}" | run_checks "${standard_checks[@]}"
+printf '%s\0' "${commit_files[@]}" | \
+    run_checks "${standard_checks[@]}" prevent_run_single_test_changes
 [ $? -ne 0 ] && found_error=1
 
 ###############################################################################


### PR DESCRIPTION
## Proposed changes

This caused the fun and easy to understand error:

Fatal Python error: deallocating None

The backtrace was basically useless ("something went wrong with the python call,
good luck!")

There's not really a good way to test for this. I only discovered this by making a dozen or more calls into pypp with `std::optional`. 

Fix #549

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
