### PR TITLE
[restore CI on develop] Fix catch labels to run in correct CI stage

### DIFF
--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -119,7 +119,7 @@ endfunction()
 # chance to execute.
 function(add_algorithm_test_with_balancing TEST_NAME EXECUTABLE_NAME REGEX_TO_MATCH)
   add_test(
-    NAME "\"Integration.Parallel.${TEST_NAME}\""
+    NAME "\"Unit.Parallel.${TEST_NAME}\""
     COMMAND
     ${SHELL_EXECUTABLE}
     -c "${CMAKE_BINARY_DIR}/bin/Test_${EXECUTABLE_NAME} +p2 +balancer \
@@ -128,19 +128,19 @@ function(add_algorithm_test_with_balancing TEST_NAME EXECUTABLE_NAME REGEX_TO_MA
 
   if("${REGEX_TO_MATCH}" STREQUAL "")
     set_tests_properties(
-      "\"Integration.Parallel.${TEST_NAME}\""
+      "\"Unit.Parallel.${TEST_NAME}\""
       PROPERTIES
       TIMEOUT 10
-      LABELS "integration"
+      LABELS "unit"
       ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
   else()
     set_tests_properties(
-      "\"Integration.Parallel.${TEST_NAME}\""
+      "\"Unit.Parallel.${TEST_NAME}\""
       PROPERTIES
       PASS_REGULAR_EXPRESSION
       "${REGEX_TO_MATCH}"
       TIMEOUT 10
-      LABELS "integration"
+      LABELS "unit"
       ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
   endif()
 endfunction()


### PR DESCRIPTION
This is probably pretty important to get merged quickly because all CI will fail on the current develop until we get this fixed.

My understanding is that this is a clash between @nilsdeppe 's `unit-test` target PR and my algorithm serialization PR -- we failed to notice during code review that the 'integration' test tags needed to change to 'unit', otherwise the selectors now being used in the `Tests.yaml` choose the `Test_AlgorithmParallel` with balancing to be run during a test it wasn't built for.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
