### PR TITLE
Add python bindings for mesh and regular grid interpolant

### DIFF
--- a/src/DataStructures/Python/Tensor/TensorData.cpp
+++ b/src/DataStructures/Python/Tensor/TensorData.cpp
@@ -30,18 +30,6 @@ void bind_tensordata(py::module& m) {  // NOLINT
       // NOLINTNEXTLINE(misc-redundant-expression)
       .def(py::self != py::self);
 
-  py::enum_<Spectral::Basis>(m, "SpectralBasis")
-      .value("Legendre", Spectral::Basis::Legendre)
-      .value("Chebyshev", Spectral::Basis::Chebyshev)
-      .value("FiniteDifference", Spectral::Basis::FiniteDifference)
-      .export_values();
-  py::enum_<Spectral::Quadrature>(m, "SpectralQuadrature")
-      .value("Gauss", Spectral::Quadrature::Gauss)
-      .value("GaussLobatto", Spectral::Quadrature::GaussLobatto)
-      .value("CellCentered", Spectral::Quadrature::CellCentered)
-      .value("FaceCentered", Spectral::Quadrature::FaceCentered)
-      .export_values();
-
   // Wrapper for ExtentsAndTensorVolumeData
   py::class_<ExtentsAndTensorVolumeData>(m, "ExtentsAndTensorVolumeData")
       .def(py::init<std::vector<size_t>, std::vector<TensorComponent>>(),

--- a/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -71,6 +71,7 @@ target_link_libraries(
   ApparentHorizons
   Blas
   Boost::boost
+  DataStructures
   Domain
   DomainStructure
   ErrorHandling
@@ -84,3 +85,4 @@ target_link_libraries(
 add_subdirectory(Actions)
 add_subdirectory(Callbacks)
 add_subdirectory(Events)
+add_subdirectory(Python)

--- a/src/NumericalAlgorithms/Interpolation/Python/Bindings.cpp
+++ b/src/NumericalAlgorithms/Interpolation/Python/Bindings.cpp
@@ -1,0 +1,14 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace intrp::py_bindings {
+void bind_regular_grid(py::module& m);  // NOLINT
+}  // namespace intrp::py_bindings
+
+PYBIND11_MODULE(_PyInterpolation, m) {  // NOLINT
+  intrp::py_bindings::bind_regular_grid(m);
+}

--- a/src/NumericalAlgorithms/Interpolation/Python/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Interpolation/Python/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "PyInterpolation")
+
+spectre_python_add_module(
+  Interpolation
+  LIBRARY_NAME ${LIBRARY}
+  SOURCES
+  Bindings.cpp
+  RegularGridInterpolant.cpp
+)
+
+spectre_python_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  Interpolation
+  DataStructures
+  Spectral
+  pybind11::module
+)
+
+spectre_python_add_dependencies(${LIBRARY} PyDataStructures PySpectral)

--- a/src/NumericalAlgorithms/Interpolation/Python/RegularGridInterpolant.cpp
+++ b/src/NumericalAlgorithms/Interpolation/Python/RegularGridInterpolant.cpp
@@ -1,0 +1,38 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "NumericalAlgorithms/Interpolation/RegularGridInterpolant.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+
+namespace py = pybind11;
+
+namespace intrp::py_bindings {
+
+template <size_t Dim>
+void bind_regular_grid_impl(py::module& m) {  // NOLINT
+  // the bindings are not complete and can be extended
+  py::class_<RegularGrid<Dim>>(
+      m, ("RegularGrid" + std::to_string(Dim) + "D").c_str())
+      .def(py::init<const Mesh<Dim>&, const Mesh<Dim>&,
+                    const std::array<DataVector, Dim>&>(),
+           py::arg("source_mesh"), py::arg("target_mesh"),
+           py::arg("override_target_mesh_with_1d_logical_coords") =
+               std::array<DataVector, Dim>{})
+      .def("interpolate",
+           static_cast<DataVector (RegularGrid<Dim>::*)(const DataVector&)
+                           const>(&RegularGrid<Dim>::interpolate),
+           py::arg("input"))
+      .def("interpolation_matrices", &RegularGrid<Dim>::interpolation_matrices);
+}
+
+void bind_regular_grid(py::module& m) {  // NOLINT
+  bind_regular_grid_impl<1>(m);
+  bind_regular_grid_impl<2>(m);
+  bind_regular_grid_impl<3>(m);
+}
+
+}  // namespace intrp::py_bindings

--- a/src/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -56,3 +56,5 @@ target_link_libraries(
   Boost::boost
   Lapack
   )
+
+add_subdirectory(Python)

--- a/src/NumericalAlgorithms/Spectral/Python/Bindings.cpp
+++ b/src/NumericalAlgorithms/Spectral/Python/Bindings.cpp
@@ -1,0 +1,21 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace Spectral::py_bindings {
+void bind_basis(py::module& m);       // NOLINT
+void bind_quadrature(py::module& m);  // NOLINT
+}  // namespace Spectral::py_bindings
+
+namespace py_bindings {
+void bind_mesh(py::module& m);  // NOLINT
+}  // namespace py_bindings
+
+PYBIND11_MODULE(_PySpectral, m) {  // NOLINT
+  Spectral::py_bindings::bind_basis(m);
+  Spectral::py_bindings::bind_quadrature(m);
+  py_bindings::bind_mesh(m);
+}

--- a/src/NumericalAlgorithms/Spectral/Python/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/Python/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "PySpectral")
+
+spectre_python_add_module(
+  Spectral
+  LIBRARY_NAME ${LIBRARY}
+  SOURCES
+  Bindings.cpp
+  Mesh.cpp
+  Spectral.cpp
+)
+
+spectre_python_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  Spectral
+  pybind11::module
+)

--- a/src/NumericalAlgorithms/Spectral/Python/Mesh.cpp
+++ b/src/NumericalAlgorithms/Spectral/Python/Mesh.cpp
@@ -1,0 +1,68 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <string>
+
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+
+namespace py = pybind11;
+
+namespace py_bindings {
+
+template <size_t Dim>
+void bind_mesh_impl(py::module& m) {  // NOLINT
+  // the bindings here are not complete
+  py::class_<Mesh<Dim>>(m, ("Mesh" + std::to_string(Dim) + "D").c_str())
+      .def_property_readonly_static(
+          "dim", [](const py::object& /*self */) { return Dim; })
+      .def(py::init<const size_t, const Spectral::Basis,
+                    const Spectral::Quadrature>(),
+           py::arg("isotropic_extents"), py::arg("basis"),
+           py::arg("quadrature"))
+      .def(py::init<std::array<size_t, Dim>, const Spectral::Basis,
+                    const Spectral::Quadrature>(),
+           py::arg("extents"), py::arg("basis"), py::arg("quadrature"))
+      .def(py::init<std::array<size_t, Dim>, std::array<Spectral::Basis, Dim>,
+                    std::array<Spectral::Quadrature, Dim>>(),
+           py::arg("extents"), py::arg("bases"), py::arg("quadratures"))
+      .def(
+          "extents",
+          [](const Mesh<Dim>& mesh) { return mesh.extents().indices(); },
+          "The number of grid points in each dimension of the grid.")
+      .def(
+          "extents",
+          static_cast<size_t (Mesh<Dim>::*)(size_t) const>(&Mesh<Dim>::extents),
+          py::arg("d"),
+          "The number of grid points in the requested dimension of the grid.")
+      .def("number_of_grid_points", &Mesh<Dim>::number_of_grid_points,
+           "The total number of grid points in all dimensions.")
+      .def("basis",
+           static_cast<const std::array<Spectral::Basis, Dim>& (Mesh<Dim>::*)()
+                           const>(&Mesh<Dim>::basis),
+           "The basis chosen in each dimension of the grid.")
+      .def("basis",
+           static_cast<Spectral::Basis (Mesh<Dim>::*)(const size_t) const>(
+               &Mesh<Dim>::basis),
+           py::arg("d"),
+           "The basis chosen in the requested dimension of the grid.")
+      .def("quadrature",
+           static_cast<const std::array<Spectral::Quadrature, Dim>& (
+               Mesh<Dim>::*)() const>(&Mesh<Dim>::quadrature),
+           "The quadrature chosen in each dimension of the grid.")
+      .def("quadrature",
+           static_cast<Spectral::Quadrature (Mesh<Dim>::*)(const size_t) const>(
+               &Mesh<Dim>::quadrature),
+           py::arg("d"),
+           "The quadrature chosen in the requested dimension of the grid.");
+}
+
+void bind_mesh(py::module& m) {  // NOLINT
+  bind_mesh_impl<1>(m);
+  bind_mesh_impl<2>(m);
+  bind_mesh_impl<3>(m);
+}
+
+}  // namespace py_bindings

--- a/src/NumericalAlgorithms/Spectral/Python/Spectral.cpp
+++ b/src/NumericalAlgorithms/Spectral/Python/Spectral.cpp
@@ -1,0 +1,27 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <pybind11/pybind11.h>
+
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+
+namespace py = pybind11;
+
+namespace Spectral::py_bindings {
+
+void bind_basis(py::module& m) {  // NOLINT
+  py::enum_<Spectral::Basis>(m, "Basis")
+      .value("Legendre", Spectral::Basis::Legendre)
+      .value("Chebyshev", Spectral::Basis::Chebyshev)
+      .value("FiniteDifference", Spectral::Basis::FiniteDifference);
+}
+
+void bind_quadrature(py::module& m) {  // NOLINT
+  py::enum_<Spectral::Quadrature>(m, "Quadrature")
+      .value("Gauss", Spectral::Quadrature::Gauss)
+      .value("GaussLobatto", Spectral::Quadrature::GaussLobatto)
+      .value("CellCentered", Spectral::Quadrature::CellCentered)
+      .value("FaceCentered", Spectral::Quadrature::FaceCentered);
+}
+
+}  // namespace Spectral::py_bindings

--- a/tests/Unit/DataStructures/Tensor/Test_TensorData.py
+++ b/tests/Unit/DataStructures/Tensor/Test_TensorData.py
@@ -62,7 +62,7 @@ class TestTensorData(unittest.TestCase):
             "((5,6,7,8),((tensor component one, (1.5,1.1)"
             "),(tensor component one, (1.5,1.1))))")
 
-        # Tests for ExtentsAndTensorVolumeData functions
+    # Tests for ExtentsAndTensorVolumeData functions
     def test_element_volume_data(self):
         # Set up Extents and Tensor Volume data
         tensor_component_1 = TensorComponent("tensor component one",

--- a/tests/Unit/DataStructures/Tensor/Test_TensorData.py
+++ b/tests/Unit/DataStructures/Tensor/Test_TensorData.py
@@ -2,9 +2,8 @@
 # See LICENSE.txt for details.
 
 from spectre.DataStructures import (DataVector, ExtentsAndTensorVolumeData,
-                                    TensorComponent, Legendre, Gauss,
-                                    ElementVolumeData)
-
+                                    TensorComponent, ElementVolumeData)
+from spectre.Spectral import Basis, Quadrature
 import unittest
 import numpy as np
 import numpy.testing as npt
@@ -70,8 +69,8 @@ class TestTensorData(unittest.TestCase):
                                              DataVector([1.5, 1.1]))
         tensor_component_2 = TensorComponent("tensor component two",
                                              DataVector([7.1, 5]))
-        basis = Legendre
-        quad = Gauss
+        basis = Basis.Legendre
+        quad = Quadrature.Gauss
         element_data = ElementVolumeData(
             [1, 2, 3, 4], [tensor_component_1, tensor_component_2],
             [basis, basis], [quad, quad])

--- a/tests/Unit/IO/Test_VolumeData.py
+++ b/tests/Unit/IO/Test_VolumeData.py
@@ -2,6 +2,7 @@
 # See LICENSE.txt for details.
 
 from spectre import DataStructures as ds
+from spectre.Spectral import Basis, Quadrature
 import spectre.IO.H5 as spectre_h5
 from spectre import Informer
 import unittest
@@ -57,8 +58,8 @@ class TestVolumeData(unittest.TestCase):
         observation_ids = [0, 1]
         observation_values = {0: 7.0, 1: 1.3}
         grid_names = ["grid_1", "grid_2"]
-        basis = ds.Legendre
-        quad = ds.Gauss
+        basis = Basis.Legendre
+        quad = Quadrature.Gauss
 
         # Insert .vol file to h5 file
         self.h5_file.insert_vol("/element_data", version=0)

--- a/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+add_subdirectory(Python)
+
 set(LIBRARY "Test_NumericalInterpolation")
 
 set(LIBRARY_SOURCES

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Python/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Python/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_add_python_bindings_test(
+        "Unit.Interpolation.Python.RegularGridInterpolant"
+        Test_RegularGridInterpolant.py
+        "Unit;Interpolation;Python"
+        PyInterpolation)

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Python/Test_RegularGridInterpolant.py
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Python/Test_RegularGridInterpolant.py
@@ -1,0 +1,89 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import unittest
+from spectre import Spectral
+from spectre import DataStructures
+from spectre import Interpolation
+from numpy.polynomial.legendre import Legendre
+import numpy as np
+
+
+class TestRegularGrid(unittest.TestCase):
+
+    # arbitrary polynomial functions of low order for exact interpolation
+    def polynomial(self, coords):
+        dim = len(coords)
+        if dim == 1:
+            x = coords[0]
+            return x**2 + x + 1.
+
+        elif dim == 2:
+            x, y = coords
+            return 2. * x**2 + y**2 + y + x + 2.
+
+        elif dim == 3:
+            x, y, z = coords
+            return 3. * x**2 + 2. * y**2 + z**2 + 2. * y + z + x + 2.
+
+        else:
+            raise ValueError(
+                "Coordinates must have shape (dim, N) where dim is 1, 2, or 3."
+            )
+
+    def generate_gauss_nodes(self, num_points):
+        return Legendre.basis(num_points).roots()
+
+    def generate_gauss_lobatto_nodes(self, num_points):
+        nodes = Legendre.basis(num_points - 1).deriv().roots()
+        return np.concatenate(([-1], nodes, [1]))
+
+    def logical_coordinates(self, mesh):
+        """
+        creates a uniform mesh of shape (dim, num_points) with the
+        requested quadrature
+        """
+
+        if mesh.quadrature()[0] == Spectral.Quadrature.Gauss:
+            nodes = self.generate_gauss_nodes(mesh.extents(0))
+        elif mesh.quadrature()[0] == Spectral.Quadrature.GaussLobatto:
+            nodes = self.generate_gauss_lobatto_nodes(mesh.extents(0))
+        else:
+            raise ValueError(
+                "Only Gauss or GaussLobatto are implemented quadratures")
+
+        grid_points = np.meshgrid(*(mesh.dim * (nodes, )))
+        return np.stack(grid_points, 0).reshape(mesh.dim, -1)
+
+    def test_regular_grid(self):
+        for dim in range(1, 4):
+            Mesh = [Spectral.Mesh1D, Spectral.Mesh2D, Spectral.Mesh3D][dim - 1]
+            RegularGrid = [
+                Interpolation.RegularGrid1D, Interpolation.RegularGrid2D,
+                Interpolation.RegularGrid3D
+            ][dim - 1]
+            for quadrature in [
+                    Spectral.Quadrature.Gauss, Spectral.Quadrature.GaussLobatto
+            ]:
+                for num_points in range(3, 10):
+                    source_mesh = Mesh(num_points, Spectral.Basis.Legendre,
+                                       quadrature)
+                    target_mesh = Mesh(num_points + 2, Spectral.Basis.Legendre,
+                                       quadrature)
+                    interpolant = RegularGrid(source_mesh, target_mesh)
+
+                    source_coords = self.logical_coordinates(source_mesh)
+                    target_coords = self.logical_coordinates(target_mesh)
+
+                    initial_data = self.polynomial(source_coords)
+                    target_data = self.polynomial(target_coords)
+
+                    interpolated_data = interpolant.interpolate(
+                        DataStructures.DataVector(initial_data))
+                    self.assertTrue(
+                        np.allclose(target_data, interpolated_data, 1e-14,
+                                    1e-14))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+add_subdirectory("Python")
+
 set(LIBRARY "Test_Spectral")
 
 set(LIBRARY_SOURCES

--- a/tests/Unit/NumericalAlgorithms/Spectral/Python/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Python/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_add_python_bindings_test(
+        "Unit.Spectral.Python.Mesh"
+        Test_Mesh.py
+        "Unit;Spectral;Python"
+        PySpectral)

--- a/tests/Unit/NumericalAlgorithms/Spectral/Python/Test_Mesh.py
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Python/Test_Mesh.py
@@ -1,0 +1,108 @@
+#Distributed under the MIT License.
+#See LICENSE.txt for details.
+
+from spectre.Spectral import Mesh1D, Mesh2D, Mesh3D
+from spectre.Spectral import Basis, Quadrature
+
+import numpy as np
+import unittest
+import random
+
+
+class TestMesh(unittest.TestCase):
+    def setUp(self):
+        random.seed(42)
+        self.bases = [Basis.Legendre, Basis.Chebyshev, Basis.FiniteDifference]
+        self.quadratures = [
+            Quadrature.Gauss, Quadrature.GaussLobatto, Quadrature.CellCentered,
+            Quadrature.FaceCentered
+        ]
+        self.extents = range(12)
+
+    def check_extents(self, mesh, extents):
+        self.assertEqual(mesh.extents(0), extents[0])
+        self.assertEqual(mesh.extents(), extents)
+        self.assertEqual(mesh.number_of_grid_points(), np.prod(extents))
+
+    def check_basis(self, mesh, bases):
+        self.assertEqual(mesh.basis(0), bases[0])
+        self.assertEqual(mesh.basis(), bases)
+
+    def check_quadrature(self, mesh, quadratures):
+        self.assertEqual(mesh.quadrature(0), quadratures[0])
+        self.assertEqual(mesh.quadrature(), quadratures)
+
+    def test_uniform(self):
+        for extent in range(12):
+            for basis in self.bases:
+                for quadrature in self.quadratures:
+                    m1 = Mesh1D(extent, basis, quadrature)
+                    m2 = Mesh2D(extent, basis, quadrature)
+                    m3 = Mesh3D(extent, basis, quadrature)
+
+                    self.assertEqual(m1.dim, 1)
+                    self.assertEqual(m2.dim, 2)
+                    self.assertEqual(m3.dim, 3)
+
+                    self.check_extents(m1, [extent])
+                    self.check_extents(m2, [extent, extent])
+                    self.check_extents(m3, [extent, extent, extent])
+
+                    self.check_basis(m1, [basis])
+                    self.check_basis(m2, [basis, basis])
+                    self.check_basis(m3, [basis, basis, basis])
+
+                    self.check_quadrature(m1, [quadrature])
+                    self.check_quadrature(m2, [quadrature, quadrature])
+                    self.check_quadrature(m3,
+                                          [quadrature, quadrature, quadrature])
+
+    def test_nonuniform_extents(self):
+        for basis in self.bases:
+            for quadrature in self.quadratures:
+                for i in range(100):
+                    extents1D = [random.choice(self.extents) for _ in range(1)]
+                    extents2D = [random.choice(self.extents) for _ in range(2)]
+                    extents3D = [random.choice(self.extents) for _ in range(3)]
+
+                    m1 = Mesh1D(extents1D, basis, quadrature)
+                    m2 = Mesh2D(extents2D, basis, quadrature)
+                    m3 = Mesh3D(extents3D, basis, quadrature)
+
+                    self.check_extents(m1, extents1D)
+                    self.check_extents(m2, extents2D)
+                    self.check_extents(m3, extents3D)
+
+    def test_nonuniform_all(self):
+        for i in range(100):
+            extents1D = [random.choice(self.extents) for _ in range(1)]
+            extents2D = [random.choice(self.extents) for _ in range(2)]
+            extents3D = [random.choice(self.extents) for _ in range(3)]
+
+            bases1D = [random.choice(self.bases) for _ in range(1)]
+            bases2D = [random.choice(self.bases) for _ in range(2)]
+            bases3D = [random.choice(self.bases) for _ in range(3)]
+
+            quadratures1D = [random.choice(self.quadratures) for _ in range(1)]
+            quadratures2D = [random.choice(self.quadratures) for _ in range(2)]
+            quadratures3D = [random.choice(self.quadratures) for _ in range(3)]
+
+            m1 = Mesh1D(extents1D, bases1D, quadratures1D)
+            m2 = Mesh2D(extents2D, bases2D, quadratures2D)
+            m3 = Mesh3D(extents3D, bases3D, quadratures3D)
+
+            self.check_extents(m1, extents1D)
+            self.check_extents(m2, extents2D)
+            self.check_extents(m3, extents3D)
+
+            self.check_basis(m1, bases1D)
+            self.check_basis(m2, bases2D)
+            self.check_basis(m3, bases3D)
+
+            self.check_quadrature(m1, quadratures1D)
+            self.check_quadrature(m2, quadratures2D)
+            self.check_quadrature(m3, quadratures3D)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Proposed changes

added python bindings for Mesh and RegularGridInterpolant. This is to write a script that can interpolate an h5 file in post-processing.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
