### PR TITLE
Require LIBXSMM 1.16.1

### DIFF
--- a/cmake/SetupLIBXSMM.cmake
+++ b/cmake/SetupLIBXSMM.cmake
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-find_package(LIBXSMM REQUIRED)
+find_package(LIBXSMM 1.16.1 REQUIRED)
 
 message(STATUS "LIBXSMM libs: " ${LIBXSMM_LIBRARIES})
 message(STATUS "LIBXSMM incl: " ${LIBXSMM_INCLUDE_DIRS})

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -36,7 +36,7 @@ environment differently, read on!
 * [libsharp](https://github.com/Libsharp/libsharp) should be built with
   support disabled for openmp and mpi, as we want all of our parallelism to
   be accomplished via Charm++.
-* [LIBXSMM](https://github.com/hfp/libxsmm)
+* [LIBXSMM](https://github.com/hfp/libxsmm) version 1.16.1 or later
 * [yaml-cpp](https://github.com/jbeder/yaml-cpp) version 0.6.3 is
   recommended. Building with shared library support is also recommended.
 * [Python](https://www.python.org/) 2.7, or 3.5 or later


### PR DESCRIPTION
## Proposed changes

There's a bug fix somewhere between 1.9 and 1.16.1 that fixes single-row matrix
multiplication. Since LIBXSMM is easy to install manually, this bumps to most
recent rather than spending time figuring out which release fixes the bug.
<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Upgrade your local LIBXSMM installation to 1.16.1 or newer, or update to the latest container
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
