### PR TITLE
Prevent newer clang from producing FPEs

### DIFF
--- a/cmake/SetupCxxFlags.cmake
+++ b/cmake/SetupCxxFlags.cmake
@@ -38,3 +38,11 @@ set_property(TARGET SpectreFlags
   APPEND PROPERTY
   INTERFACE_COMPILE_OPTIONS
   $<$<COMPILE_LANGUAGE:CXX>:-ftemplate-backtrace-limit=0>)
+
+# By default, the LLVM optimizer assumes floating point exceptions are ignored.
+create_cxx_flag_target("-ffp-exception-behavior=maytrap" SpectreFpExceptions)
+target_link_libraries(
+  SpectreFlags
+  INTERFACE
+  SpectreFpExceptions
+  )

--- a/src/Utilities/OptimizerHacks.cpp
+++ b/src/Utilities/OptimizerHacks.cpp
@@ -3,6 +3,8 @@
 
 #include "Utilities/OptimizerHacks.hpp"
 
+#if defined(__clang__) && __clang__ < 11
 namespace optimizer_hacks {
 void indicate_value_can_be_changed(void* /*variable*/) noexcept {}
 }  // namespace optimizer_hacks
+#endif  /* defined(__clang__) && __clang__ < 11 */

--- a/src/Utilities/OptimizerHacks.hpp
+++ b/src/Utilities/OptimizerHacks.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#if defined(__clang__) && __clang__ < 11
 /// \ingroup PeoGroup
 /// Workarounds for optimizer bugs
 namespace optimizer_hacks {
@@ -13,15 +14,13 @@ namespace optimizer_hacks {
 void indicate_value_can_be_changed(void* variable) noexcept;
 }  // namespace optimizer_hacks
 
-#ifdef __clang__
 #define VARIABLE_CAUSES_CLANG_FPE(var) \
   ::optimizer_hacks::indicate_value_can_be_changed(&(var))
-#else  /* __clang__ */
+#else  /* defined(__clang__) && __clang__ < 11 */
 /// \ingroup PeoGroup
 /// Clang's optimizer has a known bug that sometimes produces spurious
 /// FPEs.  This indicates that the variable `var` can trigger that bug
-/// and prevents some optimizations.  (See [the LLVM bug
-/// report](https://llvm.org/bugs/show_bug.cgi?id=18673), which is
-/// effectively WONTFIX.)
+/// and prevents some optimizations.  This is fixed upstream in Clang
+/// 11.
 #define VARIABLE_CAUSES_CLANG_FPE(var) ((void)(var))
-#endif  /* __clang__ */
+#endif  /* defined(__clang__) && __clang__ < 11 */


### PR DESCRIPTION
The LLVM optimizer has finally learned to avoid generating spurious
FPEs, but the feature is behind a flag, so we have to enable it
explicitly.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
