### PR TITLE
Update libxsmm on ocean to 1.16.1

### DIFF
--- a/support/Environments/ocean_clang.sh
+++ b/support/Environments/ocean_clang.sh
@@ -30,7 +30,7 @@ spectre_unload_modules() {
     module unload catch2-2.11.3-gcc-7.3.0-l7lqzrg
     module unload gsl-2.5-gcc-7.3.0-i7icadp
     module unload jemalloc-4.5.0-gcc-7.3.0-wlf2m7r
-    module unload libxsmm-1.10-gcc-7.3.0-sjh5yzv
+    module unload libxsmm/1.16.1
     module unload yaml-cpp-develop-gcc-7.3.0-qcfbbll
     module unload boost-1.68.0-gcc-7.3.0-vgl6ofr
     module unload hdf5-1.12.0-gcc-7.3.0-mknp6xv
@@ -55,7 +55,7 @@ spectre_load_modules() {
     module load catch2-2.11.3-gcc-7.3.0-l7lqzrg
     module load gsl-2.5-gcc-7.3.0-i7icadp
     module load jemalloc-4.5.0-gcc-7.3.0-wlf2m7r
-    module load libxsmm-1.10-gcc-7.3.0-sjh5yzv
+    module load libxsmm/1.16.1
     module load yaml-cpp-develop-gcc-7.3.0-qcfbbll
     module load boost-1.68.0-gcc-7.3.0-vgl6ofr
     module load hdf5-1.12.0-gcc-7.3.0-mknp6xv


### PR DESCRIPTION
## Proposed changes

Updates ocean libxsmm to 1.16.1. I verified that the code builds and the tests pass. Until this is merged, spectre will fail to build on ocean.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
