### PR TITLE
Pass OverrideCubicFunctionsOfTime parameter to InitialFunctionsOfTime

### DIFF
--- a/src/Evolution/Initialization/DgDomain.hpp
+++ b/src/Evolution/Initialization/DgDomain.hpp
@@ -150,7 +150,8 @@ struct Domain {
                         : my_block.stationary_map().get_to_grid_frame()};
 
     const auto& initial_functions_of_time =
-        db::get<::domain::Tags::InitialFunctionsOfTime<Dim>>(box);
+        db::get<::domain::Tags::InitialFunctionsOfTime<
+            Dim, OverrideCubicFunctionsOfTime>>(box);
 
     std::unordered_map<
         std::string, std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>


### PR DESCRIPTION
## Proposed changes

When initializing the domain, the tag `domain::Tags::InitialFunctionsOfTime` takes two template parameters, `Dim` and OverrideCubicFunctionsOfTime. But `DgDomain.hpp` forgot to pass `OverrideCubicFunctionsOfTime`, which causes the code to fail to compile when `OverrideCubicFunctionsOfTime` is true (normally it is false). 

The case `OverrideCubicFunctionsOfTime == false` is the default, to avoid requiring adding this option all over the code, when it is currently only used by EvolveGeneralizedHarmonic. This is why this issue only comes up if `OverrideCubicFunctionsOfTime == true`. But the case `OverrideCubicFunctionsOfTime == true` is not tested, because it's so expensive to build variants of the EvolveGh executable, and `OverrideCubicFunctionsOfTime` is currently only used in experimental binary-black-hole evolutions.

Thanks to @nilsdeppe for helping me track down this bug!

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
