### PR TITLE
Add evolution boundary condition type and domain boundary condition base class

### DIFF
--- a/src/Domain/BoundaryConditions/BoundaryCondition.hpp
+++ b/src/Domain/BoundaryConditions/BoundaryCondition.hpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <pup.h>
+#include <string>
+
+#include "Parallel/CharmPupable.hpp"
+
+/// \ingroup ComputationalDomainGroup
+/// \brief %Domain support for applying boundary conditions
+namespace domain::BoundaryConditions {
+/*!
+ * \brief Base class from which all system-specific base classes must inherit.
+ */
+class BoundaryCondition : public PUP::able {
+ public:
+  BoundaryCondition() = default;
+  BoundaryCondition(BoundaryCondition&&) noexcept = default;
+  BoundaryCondition& operator=(BoundaryCondition&&) noexcept = default;
+  BoundaryCondition(const BoundaryCondition&) = default;
+  BoundaryCondition& operator=(const BoundaryCondition&) = default;
+  ~BoundaryCondition() override = default;
+  explicit BoundaryCondition(CkMigrateMessage* const msg) noexcept
+      : PUP::able(msg) {}
+  WRAPPED_PUPable_abstract(BoundaryCondition);  // NOLINT
+
+  virtual auto get_clone() const noexcept
+      -> std::unique_ptr<BoundaryCondition> = 0;
+};
+}  // namespace domain::BoundaryConditions

--- a/src/Domain/BoundaryConditions/CMakeLists.txt
+++ b/src/Domain/BoundaryConditions/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY DomainBoundaryConditions)
+
+add_spectre_library(${LIBRARY} INTERFACE)
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  BoundaryCondition.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE
+  ErrorHandling
+  Parallel
+  )

--- a/src/Domain/CMakeLists.txt
+++ b/src/Domain/CMakeLists.txt
@@ -64,6 +64,7 @@ target_link_libraries(
   )
 
 add_subdirectory(Amr)
+add_subdirectory(BoundaryConditions)
 add_subdirectory(CoordinateMaps)
 add_subdirectory(Creators)
 add_subdirectory(FunctionsOfTime)

--- a/src/Evolution/BoundaryConditions/CMakeLists.txt
+++ b/src/Evolution/BoundaryConditions/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY EvolutionBoundaryConditions)
+
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  Type.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Type.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  ErrorHandling
+  )

--- a/src/Evolution/BoundaryConditions/Type.cpp
+++ b/src/Evolution/BoundaryConditions/Type.cpp
@@ -1,0 +1,28 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/BoundaryConditions/Type.hpp"
+
+#include <ostream>
+
+#include "Utilities/ErrorHandling/Error.hpp"
+
+namespace evolution::BoundaryConditions {
+std::ostream& operator<<(std::ostream& os,
+                         const Type boundary_condition_type) noexcept {
+  switch (boundary_condition_type) {
+    case Type::Ghost:
+      return os << "Ghost";
+    case Type::TimeDerivative:
+      return os << "TimeDerivative";
+    case Type::GhostAndTimeDerivative:
+      return os << "GhostAndTimeDerivative";
+    case Type::Outflow:
+      return os << "Outflow";
+    default:
+      ERROR(
+          "Unknown enumeration value. Should be one of Ghost, TimeDerivative, "
+          "GhostAndTimeDerivative, or Outflow.");
+  }
+}
+}  // namespace evolution::BoundaryConditions

--- a/src/Evolution/BoundaryConditions/Type.hpp
+++ b/src/Evolution/BoundaryConditions/Type.hpp
@@ -1,0 +1,47 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <iosfwd>
+
+namespace evolution::BoundaryConditions {
+/*!
+ * \brief The type of boundary condition.
+ *
+ * There are generally two categories or types of boundary conditions. Those
+ * that:
+ *
+ * 1. set up additional cells or elements (called ghost cells or ghost elements)
+ *    outside the computational domain and then apply boundary corrections the
+ *    same way that is done in the the interior. For example, in a discontinuous
+ *    Galerkin scheme these would impose boundary conditions through a numerical
+ *    flux boundary correction term.
+ *
+ * 2. change the time derivatives at the external boundary
+ */
+enum class Type {
+  /// Impose boundary conditions by setting values on ghost cells/elements.
+  ///
+  /// The ghost cell values can come either from internal data or from an
+  /// analytic prescription
+  Ghost,
+  /// Impose boundary conditions on the time derivative of the evolved
+  /// variables.
+  ///
+  /// These are imposed after all internal and external boundaries using a ghost
+  /// cell prescription have been handled.
+  TimeDerivative,
+  /// Impose ghost boundary conditions on some of the evolved variables and time
+  /// derivative boundary conditions on others.
+  GhostAndTimeDerivative,
+  /// Impose outflow boundary conditions on the boundary.
+  ///
+  /// Typically the outflow boundary conditions should only check that all
+  /// characteristic speeds are out of the domain.
+  Outflow
+};
+
+std::ostream& operator<<(std::ostream& os,
+                         Type boundary_condition_type) noexcept;
+}  // namespace evolution::BoundaryConditions

--- a/src/Evolution/CMakeLists.txt
+++ b/src/Evolution/CMakeLists.txt
@@ -50,6 +50,7 @@ add_dependencies(
   )
 
 add_subdirectory(Actions)
+add_subdirectory(BoundaryConditions)
 add_subdirectory(Conservative)
 add_subdirectory(DiscontinuousGalerkin)
 add_subdirectory(Executables)

--- a/tests/Unit/Domain/BoundaryConditions/CMakeLists.txt
+++ b/tests/Unit/Domain/BoundaryConditions/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_DomainBoundaryConditions")
+
+set(LIBRARY_SOURCES
+  Test_BoundaryCondition.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "Domain/BoundaryConditions"
+  "${LIBRARY_SOURCES}"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DomainBoundaryConditions
+  Utilities
+  )

--- a/tests/Unit/Domain/BoundaryConditions/Test_BoundaryCondition.cpp
+++ b/tests/Unit/Domain/BoundaryConditions/Test_BoundaryCondition.cpp
@@ -1,0 +1,50 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <memory>
+#include <pup.h>
+#include <string>
+
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Parallel/CharmPupable.hpp"
+
+namespace {
+class BoundaryCondition
+    : public domain::BoundaryConditions::BoundaryCondition {
+ public:
+  BoundaryCondition() = default;
+
+  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> get_clone()
+      const noexcept override {
+    return std::make_unique<BoundaryCondition>(*this);
+  }
+
+  explicit BoundaryCondition(CkMigrateMessage* msg) noexcept
+      : domain::BoundaryConditions::BoundaryCondition(msg) {}
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+  WRAPPED_PUPable_decl_base_template(
+      domain::BoundaryConditions::BoundaryCondition, BoundaryCondition);
+#pragma GCC diagnostic pop
+
+  void pup(PUP::er& p) override {
+    domain::BoundaryConditions::BoundaryCondition::pup(p);
+  }
+};
+
+PUP::able::PUP_ID BoundaryCondition::my_PUP_ID = 0;
+
+SPECTRE_TEST_CASE("Unit.Domain.BoundaryConditions.BoundaryCondition",
+                  "[Unit][Domain]") {
+  PUPable_reg(BoundaryCondition);
+  const std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> bc =
+      std::make_unique<BoundaryCondition>();
+  const auto bc_deserialized = serialize_and_deserialize(bc);
+  CHECK(dynamic_cast<const BoundaryCondition* const>(bc_deserialized.get()) !=
+        nullptr);
+}
+}  // namespace

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -27,6 +27,7 @@ set(LIBRARY_SOURCES
   )
 
 add_subdirectory(Amr)
+add_subdirectory(BoundaryConditions)
 add_subdirectory(CoordinateMaps)
 add_subdirectory(Creators)
 add_subdirectory(Structure)

--- a/tests/Unit/Evolution/BoundaryConditions/CMakeLists.txt
+++ b/tests/Unit/Evolution/BoundaryConditions/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_EvolutionBoundaryConditions")
+
+set(LIBRARY_SOURCES
+  Test_Type.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "Evolution/BoundaryConditions"
+  "${LIBRARY_SOURCES}"
+  "EvolutionBoundaryConditions"
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  EvolutionBoundaryConditions
+  Utilities
+  )

--- a/tests/Unit/Evolution/BoundaryConditions/Test_Type.cpp
+++ b/tests/Unit/Evolution/BoundaryConditions/Test_Type.cpp
@@ -1,0 +1,20 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "Evolution/BoundaryConditions/Type.hpp"
+#include "Utilities/GetOutput.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.BoundaryConditions.Type",
+                  "[Unit][Evolution]") {
+  CHECK(get_output(evolution::BoundaryConditions::Type::Ghost) == "Ghost");
+  CHECK(get_output(evolution::BoundaryConditions::Type::TimeDerivative) ==
+        "TimeDerivative");
+  CHECK(
+      get_output(evolution::BoundaryConditions::Type::GhostAndTimeDerivative) ==
+      "GhostAndTimeDerivative");
+  CHECK(get_output(evolution::BoundaryConditions::Type::Outflow) == "Outflow");
+}

--- a/tests/Unit/Evolution/CMakeLists.txt
+++ b/tests/Unit/Evolution/CMakeLists.txt
@@ -2,6 +2,7 @@
 # See LICENSE.txt for details.
 
 add_subdirectory(Actions)
+add_subdirectory(BoundaryConditions)
 add_subdirectory(Conservative)
 add_subdirectory(DiscontinuousGalerkin)
 add_subdirectory(Initialization)


### PR DESCRIPTION
## Proposed changes

- Adds an enum representing the boundary condition type (Ghost, GhostAndTimeDerivative, and TimeDerivative) for the evolution code. We need to handle the different cases slightly differently and thus need to distinguish between them.
  We may want to add an "Outflow" type that just performs a check inside the boundary condition function to ensure all char speeds are indicative of an outflow. I'd be interested in hearing people's thoughts. There are many special cases, but I view pure outflow as one of them since this is basically "No boundary condition at all"
- Adds the boundary condition base class that will be used in the domain code. It's almost completely empty since we want to share it between the evolution and elliptic code, and we don't want the domain to depend on the system (explicitly) while the boundary conditions (inevitably) depend on the system.

Once this PR is in I'll submit the parts that start threading the boundary conditions into Block and Domain.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
