### PR TITLE
Check that det(Jacobian) is positive in coordinate maps using discrete rotations

### DIFF
--- a/src/Domain/CoordinateMaps/Frustum.cpp
+++ b/src/Domain/CoordinateMaps/Frustum.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <pup.h>
 
+#include "DataStructures/Tensor/EagerMath/Determinant.hpp"
 #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Structure/Direction.hpp"
@@ -65,6 +66,11 @@ Frustum::Frustum(const std::array<std::array<double, 2>, 4>& face_vertices,
   ASSERT(upper_bound > lower_bound,
          "The lower bound for a coordinate must be numerically less"
          " than the upper bound for that coordinate.");
+  ASSERT(get(determinant(discrete_rotation_jacobian(orientation_of_frustum_))) >
+             0.0,
+         "Frustum rotations must be done in such a manner that the sign of "
+         "the determinant of the discrete rotation is positive. This is to "
+         "preserve handedness of the coordinates.");
   sigma_x_ = 0.25 * (lower_x_upper_base + upper_x_upper_base +
                      lower_x_lower_base + upper_x_lower_base);
   delta_x_zeta_ = 0.25 * (lower_x_upper_base + upper_x_upper_base -

--- a/src/Domain/CoordinateMaps/Wedge2D.cpp
+++ b/src/Domain/CoordinateMaps/Wedge2D.cpp
@@ -6,6 +6,8 @@
 #include <cmath>
 #include <pup.h>
 
+#include "DataStructures/Tensor/EagerMath/Determinant.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
@@ -41,6 +43,11 @@ Wedge2D::Wedge2D(double radius_inner, double radius_outer,
                  ((1.0 - circularity_inner) / sqrt(2.0) + circularity_inner),
          "The arguments passed into the constructor for Wedge2D result in an "
          "object where the outer surface is pierced by the inner surface.");
+  ASSERT(
+      get(determinant(discrete_rotation_jacobian(orientation_of_wedge_))) > 0.0,
+      "Wedge2D rotations must be done in such a manner that the sign of "
+      "the determinant of the discrete rotation is positive. This is to "
+      "preserve handedness of the coordinates.");
   scaled_trapezoid_zero_ =
       0.5 / sqrt(2.0) * ((1.0 - circularity_outer) * radius_outer +
                          (1.0 - circularity_inner) * radius_inner);

--- a/src/Domain/CoordinateMaps/Wedge3D.cpp
+++ b/src/Domain/CoordinateMaps/Wedge3D.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <pup.h>
 
+#include "DataStructures/Tensor/EagerMath/Determinant.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Utilities/ConstantExpressions.hpp"
@@ -51,6 +52,11 @@ Wedge3D::Wedge3D(const double radius_inner, const double radius_outer,
              (with_logarithmic_map_ and sphericity_inner_ == 1.0 and
               sphericity_outer_ == 1.0),
          "The logarithmic map is only supported for spherical wedges.");
+  ASSERT(
+      get(determinant(discrete_rotation_jacobian(orientation_of_wedge_))) > 0.0,
+      "Wedge3D rotations must be done in such a manner that the sign of "
+      "the determinant of the discrete rotation is positive. This is to "
+      "preserve handedness of the coordinates.");
   if (with_logarithmic_map_) {
     scaled_frustum_zero_ = 0.0;
     sphere_zero_ = 0.5 * (log(radius_outer * radius_inner));

--- a/src/Domain/Structure/OrientationMap.hpp
+++ b/src/Domain/Structure/OrientationMap.hpp
@@ -8,6 +8,7 @@
 #include <iosfwd>
 
 #include "Domain/Structure/Direction.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Structure/SegmentId.hpp"  // IWYU pragma: keep
 #include "Domain/Structure/Side.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
@@ -138,3 +139,24 @@ template <size_t VolumeDim, typename T>
 std::array<tt::remove_cvref_wrap_t<T>, VolumeDim> discrete_rotation(
     const OrientationMap<VolumeDim>& rotation,
     std::array<T, VolumeDim> source_coords) noexcept;
+
+/*!
+ * \ingroup ComputationalDomainGroup
+ * \brief Computes the Jacobian of the transformation that is computed by
+ * `discrete_rotation()`
+ *
+ * \note This always returns a `double` because the Jacobian is spatially
+ * constant.
+ */
+template <size_t VolumeDim>
+tnsr::Ij<double, VolumeDim, Frame::NoFrame> discrete_rotation_jacobian(
+    const OrientationMap<VolumeDim>& orientation) noexcept;
+
+/*!
+ * \ingroup ComputationalDomainGroup
+ * \brief Computes the inverse Jacobian of the transformation that is computed
+ * by `discrete_rotation()`
+ */
+template <size_t VolumeDim>
+tnsr::Ij<double, VolumeDim, Frame::NoFrame> discrete_rotation_inverse_jacobian(
+    const OrientationMap<VolumeDim>& orientation) noexcept;

--- a/src/Domain/Structure/OrientationMap.hpp
+++ b/src/Domain/Structure/OrientationMap.hpp
@@ -137,16 +137,4 @@ std::array<T, VolumeDim> OrientationMap<VolumeDim>::permute_from_neighbor(
 template <size_t VolumeDim, typename T>
 std::array<tt::remove_cvref_wrap_t<T>, VolumeDim> discrete_rotation(
     const OrientationMap<VolumeDim>& rotation,
-    std::array<T, VolumeDim> source_coords) noexcept {
-  using ReturnType = tt::remove_cvref_wrap_t<T>;
-  std::array<ReturnType, VolumeDim> new_coords{};
-  for (size_t i = 0; i < VolumeDim; i++) {
-    const auto new_direction = rotation(Direction<VolumeDim>(i, Side::Upper));
-    gsl::at(new_coords, i) =
-        std::move(gsl::at(source_coords, new_direction.dimension()));
-    if (new_direction.side() != Side::Upper) {
-      gsl::at(new_coords, i) *= -1.0;
-    }
-  }
-  return new_coords;
-}
+    std::array<T, VolumeDim> source_coords) noexcept;

--- a/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
@@ -676,7 +676,7 @@ void test_coordinate_map_with_rotation_wedge() {
   const auto second_map =
       Wedge2D(3.0, 7.0, 0.0, 1.0,
               OrientationMap<2>{std::array<Direction<2>, 2>{
-                  {Direction<2>::lower_eta(), Direction<2>::lower_xi()}}},
+                  {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}},
               false);
 
   const auto composed_map =

--- a/tests/Unit/Domain/CoordinateMaps/Test_DiscreteRotation.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_DiscreteRotation.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <pup.h>
 
+#include "DataStructures/Tensor/EagerMath/Determinant.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
@@ -95,10 +96,16 @@ void test_3d() {
 void test_with_orientation() {
   INFO("With orientation");
   for (OrientationMapIterator<2> map_i{}; map_i; ++map_i) {
+    if (get(determinant(discrete_rotation_jacobian(*map_i))) < 0.0) {
+      continue;
+    }
     const CoordinateMaps::DiscreteRotation<2> coord_map{map_i()};
     test_suite_for_map_on_unit_cube(coord_map);
   }
   for (OrientationMapIterator<3> map_i{}; map_i; ++map_i) {
+    if (get(determinant(discrete_rotation_jacobian(*map_i))) < 0.0) {
+      continue;
+    }
     const CoordinateMaps::DiscreteRotation<3> coord_map{map_i()};
     test_suite_for_map_on_unit_cube(coord_map);
   }

--- a/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
@@ -10,6 +10,7 @@
 #include <pup.h>
 #include <random>
 
+#include "DataStructures/Tensor/EagerMath/Determinant.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/Frustum.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
@@ -45,6 +46,9 @@ void test_suite_for_frustum(const bool with_equiangular_map) {
   CAPTURE(upper_y_upper_base);
 
   for (OrientationMapIterator<3> map_i{}; map_i; ++map_i) {
+    if (get(determinant(discrete_rotation_jacobian(*map_i))) < 0.0) {
+      continue;
+    }
     const std::array<std::array<double, 2>, 4> face_vertices{
         {{{lower_x_lower_base, lower_y_lower_base}},
          {{upper_x_lower_base, upper_y_lower_base}},

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
@@ -8,6 +8,7 @@
 #include <optional>
 #include <random>
 
+#include "DataStructures/Tensor/EagerMath/Determinant.hpp"
 #include "Domain/CoordinateMaps/Wedge2D.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
@@ -63,7 +64,7 @@ void test_wedge2d_all_orientations(const bool with_equiangular_map) {
   const CoordinateMaps::Wedge2D map_upper_eta(
       random_inner_radius_upper_eta, random_outer_radius_upper_eta, 0.0, 1.0,
       OrientationMap<2>{std::array<Direction<2>, 2>{
-          {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
+          {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}},
       with_equiangular_map);
   const CoordinateMaps::Wedge2D map_lower_xi(
       random_inner_radius_lower_xi, random_outer_radius_lower_xi, 0.0, 1.0,
@@ -73,7 +74,7 @@ void test_wedge2d_all_orientations(const bool with_equiangular_map) {
   const CoordinateMaps::Wedge2D map_lower_eta(
       random_inner_radius_lower_eta, random_outer_radius_lower_eta, 0.0, 1.0,
       OrientationMap<2>{std::array<Direction<2>, 2>{
-          {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}},
+          {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
       with_equiangular_map);
   CHECK(map_lower_eta != map_lower_xi);
   CHECK(map_upper_eta != map_lower_eta);
@@ -82,11 +83,11 @@ void test_wedge2d_all_orientations(const bool with_equiangular_map) {
   CHECK(map_upper_xi(lower_right_corner)[0] ==
         approx(random_outer_radius_upper_xi / sqrt(2.0)));
   CHECK(map_upper_eta(lower_right_corner)[1] ==
-        approx(random_outer_radius_upper_eta / sqrt(2.0)));
+        approx(-random_outer_radius_upper_eta / sqrt(2.0)));
   CHECK(map_lower_xi(upper_right_corner)[0] ==
         approx(-random_outer_radius_lower_xi / sqrt(2.0)));
   CHECK(map_lower_eta(upper_right_corner)[1] ==
-        approx(-random_outer_radius_lower_eta / sqrt(2.0)));
+        approx(random_outer_radius_lower_eta / sqrt(2.0)));
 
   // Check that random points on the edges of the reference square map to the
   // correct edges of the wedge.
@@ -100,7 +101,7 @@ void test_wedge2d_all_orientations(const bool with_equiangular_map) {
   CHECK(magnitude(map_upper_eta(random_right_edge)) ==
         approx(random_outer_radius_upper_eta));
   CHECK(map_upper_eta(random_left_edge)[1] ==
-        approx(random_inner_radius_upper_eta / sqrt(2.0)));
+        approx(-random_inner_radius_upper_eta / sqrt(2.0)));
   CHECK(magnitude(map_lower_xi(random_right_edge)) ==
         approx(random_outer_radius_lower_xi));
   CHECK(map_lower_xi(random_left_edge)[0] ==
@@ -108,7 +109,7 @@ void test_wedge2d_all_orientations(const bool with_equiangular_map) {
   CHECK(magnitude(map_lower_eta(random_right_edge)) ==
         approx(random_outer_radius_lower_eta));
   CHECK(map_lower_eta(random_left_edge)[1] ==
-        approx(-random_inner_radius_lower_eta / sqrt(2.0)));
+        approx(random_inner_radius_lower_eta / sqrt(2.0)));
 
   const double inner_radius = inner_dis(gen);
   CAPTURE(inner_radius);
@@ -120,6 +121,9 @@ void test_wedge2d_all_orientations(const bool with_equiangular_map) {
   CAPTURE(outer_circularity);
 
   for (OrientationMapIterator<2> map_i{}; map_i; ++map_i) {
+    if (get(determinant(discrete_rotation_jacobian(*map_i))) < 0.0) {
+      continue;
+    }
     test_suite_for_map_on_unit_cube(CoordinateMaps::Wedge2D{
         inner_radius, outer_radius, inner_circularity, outer_circularity,
         map_i(), with_equiangular_map});
@@ -165,7 +169,7 @@ void test_equality() {
   const auto wedge2d_orientation_map_changed = CoordinateMaps::Wedge2D(
       0.2, 4.0, 0.0, 1.0,
       OrientationMap<2>{std::array<Direction<2>, 2>{
-          {Direction<2>::upper_eta(), Direction<2>::upper_xi()}}},
+          {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}},
       true);
   const auto wedge2d_use_equiangular_map_changed =
       CoordinateMaps::Wedge2D(0.2, 4.0, 0.0, 1.0, OrientationMap<2>{}, false);

--- a/tests/Unit/Domain/Test_ElementMap.cpp
+++ b/tests/Unit/Domain/Test_ElementMap.cpp
@@ -148,7 +148,7 @@ void test_element_map<2>() {
       false, element_id, affine_map, first_map,
       Wedge2D(3., 7., 0.0, 1.0,
               OrientationMap<2>{std::array<Direction<2>, 2>{
-                  {Direction<2>::lower_eta(), Direction<2>::lower_xi()}}},
+                  {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}},
               false),
       logical_point_double, logical_point_dv);
 }


### PR DESCRIPTION
## Proposed changes

Having a negative determinant of the Jacobian means the map changes the handedness of the coordinate system. While there's nothing really wrong with this, it isn't a necessary feature to support as far as I can tell and life is easier if we can assume the the determinant of the Jacobian is positive. None of the domain creators (except RotatedIntervals) have a handedness change, but some of the tests do. This PR changes it so we no longer change handedness in 2d and 3d. In 1d, because of the simplicity of the Jacobian (1x1 matrix) having a negative determinant doesn't really make life difficult like it does in 2d and 3d.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
