### PR TITLE
Add ChristodoulouMass compute tag

### DIFF
--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -649,5 +649,21 @@ struct DimensionfulSpinMagnitudeCompute : DimensionfulSpinMagnitude,
                  StrahlkorperTags::Strahlkorper<Frame>, AreaElement<Frame>>;
 };
 
+/// The Christodoulou mass, which is a function of the dimensionful spin
+/// angular momentum and the irreducible mass of a Strahlkorper.
+struct ChristodoulouMass : db::SimpleTag {
+  using type = double;
+};
+
+/// Computes the Christodoulou mass from the dimensionful spin angular momentum
+/// and the irreducible mass of a Strahlkorper.
+template <typename Frame>
+struct ChristodoulouMassCompute : ChristodoulouMass, db::ComputeTag {
+  using base = ChristodoulouMass;
+  using return_type = double;
+  static constexpr auto function = &StrahlkorperGr::christodoulou_mass;
+  using argument_tags = tmpl::list<DimensionfulSpinMagnitude, IrreducibleMass>;
+};
+
 }  // namespace Tags
 }  // namespace StrahlkorperGr

--- a/src/ApparentHorizons/TagsDeclarations.hpp
+++ b/src/ApparentHorizons/TagsDeclarations.hpp
@@ -70,6 +70,9 @@ struct SpinFunctionCompute;
 struct DimensionfulSpinMagnitude;
 template <typename Frame>
 struct DimensionfulSpinMagnitudeCompute;
+struct ChristodoulouMass;
+template <typename Frame>
+struct ChristodoulouMassCompute;
 
 }  // namespace Tags
 }  // namespace StrahlkorperGr

--- a/tests/Unit/ApparentHorizons/Test_Tags.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Tags.cpp
@@ -305,6 +305,8 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
   TestHelpers::db::test_simple_tag<
       StrahlkorperGr::Tags::DimensionfulSpinMagnitude>(
       "DimensionfulSpinMagnitude");
+  TestHelpers::db::test_simple_tag<StrahlkorperGr::Tags::ChristodoulouMass>(
+      "ChristodoulouMass");
   TestHelpers::db::test_simple_tag<
       StrahlkorperTags::UnitNormalOneForm<Frame::Inertial>>(
       "UnitNormalOneForm");
@@ -425,4 +427,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
   TestHelpers::db::test_compute_tag<
       StrahlkorperGr::Tags::DimensionfulSpinMagnitudeCompute<Frame::Inertial>>(
       "DimensionfulSpinMagnitude");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperGr::Tags::ChristodoulouMassCompute<Frame::Inertial>>(
+      "ChristodoulouMass");
 }


### PR DESCRIPTION
## Proposed changes

The ChristodoulouMassTag and ChristodoulouMassTagCompute calculate the magnitude of the spin angular momentum of a Strahlkorper. 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
