### PR TITLE
Finish removing uses of boost::optional

### DIFF
--- a/cmake/SetupBoost.cmake
+++ b/cmake/SetupBoost.cmake
@@ -35,14 +35,12 @@ add_interface_lib_headers(
   boost/multi_array.hpp
   boost/multi_array/base.hpp
   boost/multi_array/extent_gen.hpp
-  boost/none.hpp
   boost/numeric/odeint.hpp
   boost/numeric/odeint/integrate/integrate_adaptive.hpp>
   boost/numeric/odeint/stepper/controlled_runge_kutta.hpp
   boost/numeric/odeint/stepper/dense_output_runge_kutta.hpp
   boost/numeric/odeint/stepper/generation/make_dense_output.hpp
   boost/numeric/odeint/stepper/runge_kutta_dopri5.hpp
-  boost/optional.hpp
   boost/parameter/name.hpp
   boost/preprocessor.hpp
   boost/preprocessor/arithmetic/dec.hpp

--- a/src/ControlSystem/Averager.cpp
+++ b/src/ControlSystem/Averager.cpp
@@ -3,7 +3,6 @@
 
 #include "ControlSystem/Averager.hpp"
 
-#include <boost/none.hpp>
 #include <ostream>
 
 #include "Utilities/ErrorHandling/Error.hpp"
@@ -28,7 +27,7 @@ Averager<DerivOrder>::Averager(Averager&& rhs) noexcept
     : avg_tscale_frac_(std::move(rhs.avg_tscale_frac_)),
       average_0th_deriv_of_q_(std::move(rhs.average_0th_deriv_of_q_)),
       averaged_values_(std::move(rhs.averaged_values_)),
-      boost_none_(std::move(rhs.boost_none_)),
+      nullopt_(std::move(rhs.nullopt_)),
       times_(std::move(rhs.times_)),
       raw_qs_(std::move(rhs.raw_qs_)),
       weight_k_(std::move(rhs.weight_k_)),
@@ -40,7 +39,7 @@ Averager<DerivOrder>& Averager<DerivOrder>::operator=(Averager&& rhs) noexcept {
     avg_tscale_frac_ = std::move(rhs.avg_tscale_frac_);
     average_0th_deriv_of_q_ = std::move(rhs.average_0th_deriv_of_q_);
     averaged_values_ = std::move(rhs.averaged_values_);
-    boost_none_ = std::move(rhs.boost_none_);
+    nullopt_ = std::move(rhs.nullopt_);
     times_ = std::move(rhs.times_);
     raw_qs_ = std::move(rhs.raw_qs_);
     weight_k_ = std::move(rhs.weight_k_);
@@ -50,17 +49,17 @@ Averager<DerivOrder>& Averager<DerivOrder>::operator=(Averager&& rhs) noexcept {
 }
 
 template <size_t DerivOrder>
-const boost::optional<std::array<DataVector, DerivOrder + 1>>&
+const std::optional<std::array<DataVector, DerivOrder + 1>>&
 Averager<DerivOrder>::operator()(const double time) const noexcept {
   if (times_.size() > DerivOrder and time == times_[0]) {
     return averaged_values_;
   }
-  return boost_none_;
+  return nullopt_;
 }
 
 template <size_t DerivOrder>
 void Averager<DerivOrder>::clear() noexcept {
-  averaged_values_ = boost::none;
+  averaged_values_ = std::nullopt;
   times_.clear();
   raw_qs_.clear();
   weight_k_ = 0.0;

--- a/src/ControlSystem/Averager.hpp
+++ b/src/ControlSystem/Averager.hpp
@@ -4,10 +4,9 @@
 #pragma once
 
 #include <array>
-#include <boost/none.hpp>
-#include <boost/optional.hpp>
 #include <cstddef>
 #include <deque>
+#include <optional>
 
 #include "DataStructures/DataVector.hpp"
 
@@ -62,9 +61,9 @@ class Averager {
   /// averaged derivatives of \f$Q\f$ up to the `DerivOrder`'th derivative, at
   /// \f$t=\f$`time`. If `using_average_0th_deriv_of_q()` is `true`, then the
   /// returned 0th derivative of \f$Q\f$ is also averaged. In the case that
-  /// there is insufficient data, the operator returns an
-  /// unitialized `boost::optional` (`boost::none`).
-  const boost::optional<std::array<DataVector, DerivOrder + 1>>& operator()(
+  /// there is insufficient data, the operator returns an invalid
+  /// `std::optional`.
+  const std::optional<std::array<DataVector, DerivOrder + 1>>& operator()(
       double time) const noexcept;
   /// A function that allows for resetting the averager.
   void clear() noexcept;
@@ -103,9 +102,8 @@ class Averager {
 
   double avg_tscale_frac_;
   bool average_0th_deriv_of_q_;
-  boost::optional<std::array<DataVector, DerivOrder + 1>> averaged_values_{};
-  boost::optional<std::array<DataVector, DerivOrder + 1>> boost_none_ =
-      boost::none;
+  std::optional<std::array<DataVector, DerivOrder + 1>> averaged_values_{};
+  std::optional<std::array<DataVector, DerivOrder + 1>> nullopt_ = std::nullopt;
   std::deque<double> times_;
   std::deque<DataVector> raw_qs_;
   double weight_k_ = 0.0;

--- a/src/ControlSystem/FunctionOfTimeUpdater.cpp
+++ b/src/ControlSystem/FunctionOfTimeUpdater.cpp
@@ -29,8 +29,9 @@ void FunctionOfTimeUpdater<DerivOrder>::modify(
         domain::FunctionsOfTime::PiecewisePolynomial<DerivOrder>*>
         f_of_t,
     const double time, const double expiration_time) noexcept {
-  if (averager_(time)) {
-    std::array<DataVector, DerivOrder + 1> q_and_derivs = averager_(time).get();
+  if (averager_(time).has_value()) {
+    std::array<DataVector, DerivOrder + 1> q_and_derivs =
+        averager_(time).value();
     // get the time offset due to averaging
     const double t_offset_of_qdot = time - averager_.average_time(time);
     const double t_offset_of_q =

--- a/src/Domain/BlockLogicalCoordinates.cpp
+++ b/src/Domain/BlockLogicalCoordinates.cpp
@@ -17,7 +17,7 @@
 namespace {
 // Define this alias so we don't need to keep typing this monster.
 template <size_t Dim>
-using block_logical_coord_holder = boost::optional<
+using block_logical_coord_holder = std::optional<
     IdPair<domain::BlockId, tnsr::I<double, Dim, typename ::Frame::Logical>>>;
 using functions_of_time_type = std::unordered_map<
     std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>;

--- a/src/Domain/BlockLogicalCoordinates.hpp
+++ b/src/Domain/BlockLogicalCoordinates.hpp
@@ -3,9 +3,9 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -29,12 +29,12 @@ class IdPair;
 /// Computes the block logical coordinates and the containing `BlockId` of
 /// a set of points, given coordinates in a particular frame.
 ///
-/// \details Returns a std::vector<boost::optional<IdPair<BlockId,coords>>>,
+/// \details Returns a std::vector<std::optional<IdPair<BlockId,coords>>>,
 /// where the vector runs over the points and is indexed in the same order as
 /// the input coordinates `x`. For each point, the `IdPair` holds the
 /// block logical coords of that point and the `BlockId` of the `Block` that
 /// contains that point.
-/// The boost::optional is empty if the point is not in any Block.
+/// The std::optional is invalid if the point is not in any Block.
 /// If a point is on a shared boundary of two or more `Block`s, it is
 /// returned only once, and is considered to belong to the `Block`
 /// with the smaller `BlockId`.
@@ -48,5 +48,5 @@ auto block_logical_coordinates(
             std::string,
             std::unique_ptr<
                 domain::FunctionsOfTime::FunctionOfTime>>{}) noexcept
-    -> std::vector<boost::optional<
+    -> std::vector<std::optional<
         IdPair<domain::BlockId, tnsr::I<double, Dim, ::Frame::Logical>>>>;

--- a/src/Domain/CoordinateMaps/Frustum.hpp
+++ b/src/Domain/CoordinateMaps/Frustum.hpp
@@ -181,7 +181,7 @@ class Frustum {
   std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
       const std::array<T, 3>& source_coords) const noexcept;
 
-  /// Returns boost::none if \f$z\f$ is at or beyond the \f$z\f$-coordinate of
+  /// Returns std::nullopt if \f$z\f$ is at or beyond the \f$z\f$-coordinate of
   /// the apex of the pyramid, tetrahedron, or triangular prism that is
   /// formed by extending the `Frustum` (for a
   /// \f$z\f$-oriented `Frustum`).

--- a/src/Domain/CoordinateMaps/SpecialMobius.hpp
+++ b/src/Domain/CoordinateMaps/SpecialMobius.hpp
@@ -98,7 +98,7 @@ class SpecialMobius {
   std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
       const std::array<T, 3>& source_coords) const noexcept;
 
-  /// Returns boost::none for target_coords outside the unit sphere.
+  /// Returns std::nullopt for target_coords outside the unit sphere.
   std::optional<std::array<double, 3>> inverse(
       const std::array<double, 3>& target_coords) const noexcept;
 

--- a/src/Domain/CoordinateMaps/TimeDependent/CubicScale.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/CubicScale.hpp
@@ -113,7 +113,7 @@ class CubicScale {
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time) const noexcept;
 
-  /// Returns boost::none if the point is outside the range of the map.
+  /// Returns std::nullopt if the point is outside the range of the map.
   template <typename T>
   std::optional<std::array<tt::remove_cvref_wrap_t<T>, Dim>> inverse(
       const std::array<T, Dim>& target_coords, double time,

--- a/src/Domain/ElementLogicalCoordinates.cpp
+++ b/src/Domain/ElementLogicalCoordinates.cpp
@@ -22,7 +22,7 @@
 namespace {
 // Define this alias so we don't need to keep typing this monster.
 template <size_t Dim>
-using block_logical_coord_holder = boost::optional<
+using block_logical_coord_holder = std::optional<
     IdPair<domain::BlockId, tnsr::I<double, Dim, typename ::Frame::Logical>>>;
 }  // namespace
 
@@ -41,12 +41,12 @@ element_logical_coordinates(const std::vector<ElementId<Dim>>& element_ids,
   // Loop over points
   for (size_t offset = 0; offset < block_coord_holders.size(); ++offset) {
     // Skip points that are not in any block.
-    if (not block_coord_holders[offset]) {
+    if (not block_coord_holders[offset].has_value()) {
       continue;
     }
 
-    const auto& block_id = block_coord_holders[offset].get().id;
-    const auto& x_block_logical = block_coord_holders[offset].get().data;
+    const auto& block_id = block_coord_holders[offset].value().id;
+    const auto& x_block_logical = block_coord_holders[offset].value().data;
     // Need to loop over elements, because the block doesn't know
     // things like the refinement_level of each element.
     for (size_t index = 0; index < element_ids.size(); ++index) {

--- a/src/Domain/ElementLogicalCoordinates.hpp
+++ b/src/Domain/ElementLogicalCoordinates.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
 #include <cstddef>
+#include <optional>
 #include <unordered_map>
 #include <vector>
 
@@ -88,7 +88,7 @@ struct ElementLogicalCoordHolder {
 template <size_t Dim>
 auto element_logical_coordinates(
     const std::vector<ElementId<Dim>>& element_ids,
-    const std::vector<boost::optional<IdPair<
+    const std::vector<std::optional<IdPair<
         domain::BlockId, tnsr::I<double, Dim, typename Frame::Logical>>>>&
         block_coord_holders) noexcept
     -> std::unordered_map<ElementId<Dim>, ElementLogicalCoordHolder<Dim>>;

--- a/src/Evolution/Systems/Cce/Actions/SendNextTimeToCce.hpp
+++ b/src/Evolution/Systems/Cce/Actions/SendNextTimeToCce.hpp
@@ -68,11 +68,11 @@ struct SendNextTimeToCce {
             db::get<intrp::Tags::InterpPointInfo<Metavariables>>(box));
     const std::vector<ElementId<Metavariables::volume_dim>> element_ids{
         {array_index}};
-    std::vector<boost::optional<IdPair<
+    std::vector<std::optional<IdPair<
         domain::BlockId, tnsr::I<double, 3_st, typename ::Frame::Logical>>>>
         first_valid_block_logical_coords;
     for (const auto& coordinate : block_logical_coords) {
-      if (static_cast<bool>(coordinate)) {
+      if (coordinate.has_value()) {
         first_valid_block_logical_coords.push_back(coordinate);
         break;
       }

--- a/src/Evolution/Systems/Cce/InterfaceManagers/GhInterfaceManager.hpp
+++ b/src/Evolution/Systems/Cce/InterfaceManagers/GhInterfaceManager.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
 #include <memory>
+#include <optional>
 #include <tuple>
 
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -38,11 +38,11 @@ class GhLockstep;
  * - `GhInterfaceManager::request_gh_data()`: should register requests
  * from the CCE evolution for boundary data.
  * - `GhInterfaceManager::retrieve_and_remove_first_ready_gh_data()`:
- * should return a `boost::optional<std::tuple<TimeStepId,
+ * should return a `std::optional<std::tuple<TimeStepId,
  * tnsr::aa<DataVector, 3>, tnsr::iaa<DataVector, 3>, tnsr::aa<DataVector, 3>>>`
  * containing the boundary data associated with the oldest requested timestep if
  * enough data has been supplied via `insert_gh_data()` to determine the
- * boundary data. Otherwise, return a `boost::none` to indicate that the CCE
+ * boundary data. Otherwise, return a `std::nullopt` to indicate that the CCE
  * system must continue waiting for generalized harmonic input.
  * - `GhInterfaceManager::number_of_pending_requests()`: should return
  * the number of requests that have been registered to the class that do not yet
@@ -77,7 +77,7 @@ class GhInterfaceManager : public PUP::able {
   virtual void request_gh_data(const TimeStepId&) noexcept = 0;
 
   virtual auto retrieve_and_remove_first_ready_gh_data() noexcept
-      -> boost::optional<std::tuple<TimeStepId, gh_variables>> = 0;
+      -> std::optional<std::tuple<TimeStepId, gh_variables>> = 0;
 
   virtual size_t number_of_pending_requests() const noexcept = 0;
 

--- a/src/Evolution/Systems/Cce/InterfaceManagers/GhLocalTimeStepping.cpp
+++ b/src/Evolution/Systems/Cce/InterfaceManagers/GhLocalTimeStepping.cpp
@@ -13,11 +13,11 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "Parallel/CharmPupable.hpp"
+#include "Parallel/PupStlCpp17.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Time/History.hpp"
 #include "Time/TimeStepId.hpp"
 #include "Utilities/Algorithm.hpp"
-#include "Utilities/BoostHelpers.hpp"
 
 namespace Cce::InterfaceManagers {
 
@@ -51,9 +51,9 @@ void GhLocalTimeStepping::insert_gh_data(
   // inserted for this data
   auto previous_deque_entry = alg::find_if(
       pre_history_,
-      [&time_id](const std::tuple<TimeStepId, boost::optional<gh_variables>,
-                                  boost::optional<TimeStepId>,
-                                  boost::optional<dt_gh_variables>>&
+      [&time_id](const std::tuple<TimeStepId, std::optional<gh_variables>,
+                                  std::optional<TimeStepId>,
+                                  std::optional<dt_gh_variables>>&
                      deque_entry) noexcept {
         return get<0>(deque_entry) == time_id;
       });
@@ -66,7 +66,7 @@ void GhLocalTimeStepping::insert_gh_data(
     if(previous_deque_entry == pre_history_.end()) {
       // NOLINTNEXTLINE(performance-move-const-arg)
       pre_history_.emplace_back(std::move(time_id),
-                                std::move(input_gh_variables), boost::none,
+                                std::move(input_gh_variables), std::nullopt,
                                 std::move(input_dt_gh_variables));
     } else {
       get<1>(*previous_deque_entry) = std::move(input_gh_variables);
@@ -97,9 +97,9 @@ void GhLocalTimeStepping::insert_next_gh_time(
   // inserted for this data
   const auto previous_deque_entry = alg::find_if(
       pre_history_,
-      [&time_id](const std::tuple<TimeStepId, boost::optional<gh_variables>,
-                                  boost::optional<TimeStepId>,
-                                  boost::optional<dt_gh_variables>>&
+      [&time_id](const std::tuple<TimeStepId, std::optional<gh_variables>,
+                                  std::optional<TimeStepId>,
+                                  std::optional<dt_gh_variables>>&
                      deque_entry) noexcept {
         return get<0>(deque_entry) == time_id;
       });
@@ -108,9 +108,9 @@ void GhLocalTimeStepping::insert_next_gh_time(
   // just stash the data in the deque.
   if(previous_deque_entry == pre_history_.end()) {
     // NOLINTNEXTLINE(performance-move-const-arg)
-    pre_history_.emplace_back(std::move(time_id), boost::none,
+    pre_history_.emplace_back(std::move(time_id), std::nullopt,
                               // NOLINTNEXTLINE(performance-move-const-arg)
-                              std::move(next_time_id), boost::none);
+                              std::move(next_time_id), std::nullopt);
     return;
   } else if (requests_.empty() or
              requests_.front().substep_time().value() <=
@@ -168,9 +168,9 @@ void GhLocalTimeStepping::update_history() noexcept {
 }
 
 auto GhLocalTimeStepping::retrieve_and_remove_first_ready_gh_data() noexcept
-    -> boost::optional<std::tuple<TimeStepId, gh_variables>> {
+    -> std::optional<std::tuple<TimeStepId, gh_variables>> {
   if (requests_.empty()) {
-    return boost::none;
+    return std::nullopt;
   }
   const double first_request = requests_.front().substep_time().value();
   if (boundary_history_.size() > 0 and
@@ -190,7 +190,7 @@ auto GhLocalTimeStepping::retrieve_and_remove_first_ready_gh_data() noexcept
     update_history();
     return requested_data;
   }
-  return boost::none;
+  return std::nullopt;
 }
 
 void GhLocalTimeStepping::pup(PUP::er& p) noexcept {

--- a/src/Evolution/Systems/Cce/InterfaceManagers/GhLocalTimeStepping.hpp
+++ b/src/Evolution/Systems/Cce/InterfaceManagers/GhLocalTimeStepping.hpp
@@ -3,10 +3,10 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
 #include <cstddef>
 #include <deque>
 #include <memory>
+#include <optional>
 #include <tuple>
 
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -98,11 +98,11 @@ class GhLocalTimeStepping : public GhInterfaceManager {
   /// output from the provided GH data.
   void request_gh_data(const TimeStepId& time_id) noexcept override;
 
-  /// \brief Return a `boost::optional` of either the dense-output data at the
-  /// least recently requested time, or `boost::none` if not enough GH data has
+  /// \brief Return a `std::optional` of either the dense-output data at the
+  /// least recently requested time, or `std::nullopt` if not enough GH data has
   /// been supplied yet.
   auto retrieve_and_remove_first_ready_gh_data() noexcept
-      -> boost::optional<std::tuple<TimeStepId, gh_variables>> override;
+      -> std::optional<std::tuple<TimeStepId, gh_variables>> override;
 
   /// The number of requests that have been submitted and not yet retrieved.
   size_t number_of_pending_requests() const noexcept override {
@@ -132,8 +132,8 @@ class GhLocalTimeStepping : public GhInterfaceManager {
   size_t order_ = 3;
 
   std::deque<
-      std::tuple<TimeStepId, boost::optional<gh_variables>,
-                 boost::optional<TimeStepId>, boost::optional<dt_gh_variables>>>
+      std::tuple<TimeStepId, std::optional<gh_variables>,
+                 std::optional<TimeStepId>, std::optional<dt_gh_variables>>>
       pre_history_;
   std::deque<TimeStepId> requests_;
 

--- a/src/Evolution/Systems/Cce/InterfaceManagers/GhLockstep.cpp
+++ b/src/Evolution/Systems/Cce/InterfaceManagers/GhLockstep.cpp
@@ -40,9 +40,9 @@ void GhLockstep::insert_gh_data(
 }
 
 auto GhLockstep::retrieve_and_remove_first_ready_gh_data() noexcept
-    -> boost::optional<std::tuple<TimeStepId, gh_variables>> {
+    -> std::optional<std::tuple<TimeStepId, gh_variables>> {
   if (provided_data_.empty()) {
-    return boost::none;
+    return std::nullopt;
   }
   const auto return_data = std::move(provided_data_.front());
   provided_data_.pop_front();

--- a/src/Evolution/Systems/Cce/InterfaceManagers/GhLockstep.hpp
+++ b/src/Evolution/Systems/Cce/InterfaceManagers/GhLockstep.hpp
@@ -3,9 +3,9 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
 #include <deque>
 #include <memory>
+#include <optional>
 #include <tuple>
 
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -73,11 +73,11 @@ class GhLockstep : public GhInterfaceManager {
   /// \brief Requests are ignored by this implementation, so this is a no-op.
   void request_gh_data(const TimeStepId& /*time_id*/) noexcept override {}
 
-  /// \brief Return a `boost::optional<std::tuple>` of the least recently
+  /// \brief Return a `std::optional<std::tuple>` of the least recently
   /// submitted generalized harmonic boundary data if any exists and removes it
-  /// from the internal `std::deque`, otherwise returns `boost::none`.
+  /// from the internal `std::deque`, otherwise returns `std::nullopt`.
   auto retrieve_and_remove_first_ready_gh_data() noexcept
-      -> boost::optional<std::tuple<TimeStepId, gh_variables>> override;
+      -> std::optional<std::tuple<TimeStepId, gh_variables>> override;
 
   /// \brief This class ignores requests to ensure a one-way communication
   /// pattern, so the number of requests is always 0.

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
 #include <cstddef>
+#include <optional>
 #include <string>
 
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
@@ -50,7 +50,7 @@ struct PrimitiveRecoveryData;
 class NewmanHamlin {
  public:
   template <size_t ThermodynamicDim>
-  static boost::optional<PrimitiveRecoveryData> apply(
+  static std::optional<PrimitiveRecoveryData> apply(
       double initial_guess_for_pressure, double total_energy_density,
       double momentum_density_squared,
       double momentum_density_dot_magnetic_field, double magnetic_field_squared,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.cpp
@@ -3,7 +3,6 @@
 
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.hpp"
 
-#include <boost/none.hpp>
 #include <cmath>
 #include <exception>
 #include <limits>
@@ -96,7 +95,7 @@ class FunctionOfX {
 }  // namespace
 
 template <size_t ThermodynamicDim>
-boost::optional<PrimitiveRecoveryData> PalenzuelaEtAl::apply(
+std::optional<PrimitiveRecoveryData> PalenzuelaEtAl::apply(
     const double /*initial_guess_pressure*/, const double total_energy_density,
     const double momentum_density_squared,
     const double momentum_density_dot_magnetic_field,
@@ -125,7 +124,7 @@ boost::optional<PrimitiveRecoveryData> PalenzuelaEtAl::apply(
                             absolute_tolerance_, relative_tolerance_,
                             max_iterations_);
   } catch (std::exception& exception) {
-    return boost::none;
+    return std::nullopt;
   }
   const double lorentz_factor =
       f_of_x.lorentz_factor(specific_enthalpy_times_lorentz_factor);
@@ -150,18 +149,18 @@ boost::optional<PrimitiveRecoveryData> PalenzuelaEtAl::apply(
 }  // namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes
 
 #define THERMODIM(data) BOOST_PP_TUPLE_ELEM(0, data)
-#define INSTANTIATION(_, data)                                                 \
-  template boost::optional<grmhd::ValenciaDivClean::PrimitiveRecoverySchemes:: \
-                               PrimitiveRecoveryData>                          \
-  grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::PalenzuelaEtAl::apply<    \
-      THERMODIM(data)>(                                                        \
-      const double /*initial_guess_pressure*/,                                 \
-      const double total_energy_density,                                       \
-      const double momentum_density_squared,                                   \
-      const double momentum_density_dot_magnetic_field,                        \
-      const double magnetic_field_squared,                                     \
-      const double rest_mass_density_times_lorentz_factor,                     \
-      const EquationsOfState::EquationOfState<true, THERMODIM(data)>&          \
+#define INSTANTIATION(_, data)                                               \
+  template std::optional<grmhd::ValenciaDivClean::PrimitiveRecoverySchemes:: \
+                             PrimitiveRecoveryData>                          \
+  grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::PalenzuelaEtAl::apply<  \
+      THERMODIM(data)>(                                                      \
+      const double /*initial_guess_pressure*/,                               \
+      const double total_energy_density,                                     \
+      const double momentum_density_squared,                                 \
+      const double momentum_density_dot_magnetic_field,                      \
+      const double magnetic_field_squared,                                   \
+      const double rest_mass_density_times_lorentz_factor,                   \
+      const EquationsOfState::EquationOfState<true, THERMODIM(data)>&        \
           equation_of_state) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.hpp
@@ -3,9 +3,9 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
 #include <cstddef>
 #include <limits>
+#include <optional>
 #include <string>
 
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
@@ -51,7 +51,7 @@ struct PrimitiveRecoveryData;
 class PalenzuelaEtAl {
  public:
   template <size_t ThermodynamicDim>
-  static boost::optional<PrimitiveRecoveryData> apply(
+  static std::optional<PrimitiveRecoveryData> apply(
       double /*initial_guess_pressure*/, double total_energy_density,
       double momentum_density_squared,
       double momentum_density_dot_magnetic_field, double magnetic_field_squared,

--- a/src/NumericalAlgorithms/Interpolation/Actions/ElementReceiveInterpPoints.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Actions/ElementReceiveInterpPoints.hpp
@@ -38,7 +38,7 @@ struct ElementReceiveInterpPoints {
       db::DataBox<DbTags>& box,
       Parallel::GlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/,
-      std::vector<boost::optional<
+      std::vector<std::optional<
           IdPair<domain::BlockId, tnsr::I<double, Metavariables::volume_dim,
                                           typename ::Frame::Logical>>>>&&
           block_logical_coords) noexcept {

--- a/src/NumericalAlgorithms/Interpolation/InterpolatedVars.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolatedVars.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
 #include <cstddef>
+#include <optional>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -40,7 +40,7 @@ struct Info {
   /// `block_coord_holders` even after all `Element`s have sent their
   /// data (this is because this `Info` lives only on a single core,
   /// and this core will have access only to the local `Element`s).
-  std::vector<boost::optional<IdPair<
+  std::vector<std::optional<IdPair<
       domain::BlockId, tnsr::I<double, VolumeDim, typename ::Frame::Logical>>>>
       block_coord_holders;
   /// `vars` holds the interpolated `Variables` on some subset of the

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetDetail.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetDetail.hpp
@@ -434,7 +434,7 @@ template <typename InterpolationTargetTag, typename DbTags, size_t VolumeDim,
 void set_up_interpolation(
     const gsl::not_null<db::DataBox<DbTags>*> box,
     const TemporalId& temporal_id,
-    const std::vector<boost::optional<
+    const std::vector<std::optional<
         IdPair<domain::BlockId,
                tnsr::I<double, VolumeDim, typename ::Frame::Logical>>>>&
         block_logical_coords) noexcept {
@@ -460,7 +460,7 @@ void set_up_interpolation(
         // Set the indices of invalid points.
         indices_of_invalid_points->erase(temporal_id);
         for (size_t i = 0; i < block_logical_coords.size(); ++i) {
-          if (not block_logical_coords[i]) {
+          if (not block_logical_coords[i].has_value()) {
             (*indices_of_invalid_points)[temporal_id].insert(i);
           }
         }

--- a/src/NumericalAlgorithms/Interpolation/InterpolatorReceivePoints.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolatorReceivePoints.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
 #include <cstddef>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -70,7 +70,7 @@ struct ReceivePoints {
       Parallel::GlobalCache<Metavariables>& cache,
       const ArrayIndex& /*array_index*/,
       const typename Metavariables::temporal_id::type& temporal_id,
-      std::vector<boost::optional<
+      std::vector<std::optional<
           IdPair<domain::BlockId,
                  tnsr::I<double, VolumeDim, typename ::Frame::Logical>>>>&&
           block_logical_coords) noexcept {

--- a/src/NumericalAlgorithms/Interpolation/PointInfoTag.hpp
+++ b/src/NumericalAlgorithms/Interpolation/PointInfoTag.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
+#include <optional>
 #include <vector>
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
@@ -21,7 +21,7 @@ struct PointInfoTag {
   /// logical coordinates) that need to be interpolated onto for a
   /// given `InterpolationTarget`.  Only a subset of those points
   /// will be contained in the `Element` that uses this Tag.
-  using type = std::vector<boost::optional<IdPair<
+  using type = std::vector<std::optional<IdPair<
       domain::BlockId, tnsr::I<double, VolumeDim, typename ::Frame::Logical>>>>;
 };
 }  // namespace Vars

--- a/src/Utilities/BoostHelpers.hpp
+++ b/src/Utilities/BoostHelpers.hpp
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <array>
-#include <boost/none.hpp>
 #include <boost/variant.hpp>
 #include <cstddef>
 #include <initializer_list>
@@ -18,13 +17,6 @@
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
-
-/// \cond
-namespace boost {
-template <typename T>
-class optional;
-}  // namespace boost
-/// \endcond
 
 namespace detail {
 template <typename Sequence>
@@ -99,24 +91,3 @@ std::string type_of_current_state(
       {pretty_type::get_name<Ts>()...}}[static_cast<size_t>(variant.which())];
   // clang-format on
 }
-
-namespace PUP {
-template <class T>
-void pup(er& p, boost::optional<T>& var) noexcept {  // NOLINT
-  bool has_data = var != boost::none;
-  p | has_data;
-  if (has_data) {
-    if (p.isUnpacking()) {
-      var.emplace();
-    }
-    p | *var;
-  } else {
-    var = boost::none;
-  }
-}
-
-template <typename T>
-inline void operator|(er& p, boost::optional<T>& var) noexcept {  // NOLINT
-  pup(p, var);
-}
-}  // namespace PUP

--- a/src/Utilities/StdHelpers.hpp
+++ b/src/Utilities/StdHelpers.hpp
@@ -14,6 +14,7 @@
 #include <list>
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <sstream>
 #include <string>
@@ -197,6 +198,21 @@ template <typename T, typename U>
 inline std::ostream& operator<<(std::ostream& os,
                                 const std::pair<T, U>& t) noexcept {
   return os << "(" << t.first << ", " << t.second << ")";
+}
+
+/*!
+ * \ingroup UtilitiesGroup
+ * \brief Stream operator for std::optional
+ */
+template <typename T>
+inline std::ostream& operator<<(std::ostream& os,
+                                const std::optional<T>& t) noexcept {
+  // Match boost::optional behavior and print "--" when invalid
+  if (t.has_value()) {
+    return os << t.value();
+  } else {
+    return os << "--";
+  }
 }
 
 /*!

--- a/src/Utilities/StlStreamDeclarations.hpp
+++ b/src/Utilities/StlStreamDeclarations.hpp
@@ -19,6 +19,7 @@
 #include <list>
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <tuple>
 #include <unordered_map>
@@ -76,3 +77,6 @@ std::ostream& operator<<(std::ostream& os,
 
 template <typename T, typename U>
 std::ostream& operator<<(std::ostream& os, const std::pair<T, U>& t) noexcept;
+
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const std::optional<T>& t) noexcept;

--- a/tests/Unit/ControlSystem/Test_Averager.cpp
+++ b/tests/Unit/ControlSystem/Test_Averager.cpp
@@ -5,8 +5,8 @@
 
 #include <algorithm>
 #include <array>
-#include <boost/optional/optional.hpp>
 #include <cstddef>
+#include <optional>
 #include <type_traits>
 
 #include "ControlSystem/Averager.hpp"
@@ -39,7 +39,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Averager.Linear",
     averager_f.update(t, {analytic_func[0]}, {0.1});
     // compare values once averager has sufficient data
     if (averager_t(t)) {
-      const auto result_t = averager_t(t).get();
+      const auto result_t = averager_t(t).value();
       // check function value, which should agree with the effective time
       CHECK(approx(result_t[0][0]) == averager_t.average_time(t));
       // check first derivative
@@ -51,7 +51,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Averager.Linear",
       CHECK(custom_approx(result_t[2][0]) == analytic_func[2]);
     }
     if (averager_f(t)) {
-      const auto result_f = averager_f(t).get();
+      const auto result_f = averager_f(t).value();
       // check function value, which should agree with the true time `t`
       CHECK(approx(result_f[0][0]) == t);
       // check first derivative
@@ -116,7 +116,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Averager.SemiAnalytic",
       avg_values[1] = alpha * analytic_func[1] + (1.0 - alpha) * avg_values[1];
       avg_values[2] = alpha * analytic_func[2] + (1.0 - alpha) * avg_values[2];
 
-      auto result = averager(t).get();
+      auto result = averager(t).value();
 
       // check that the effective times agree with the averaged time
       CHECK(approx(averager.average_time(t)) == avg_time);
@@ -163,7 +163,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Averager.Functionality",
   averager.update(t, {t}, {0.1});
   // data should be valid now
   CHECK(static_cast<bool>(averager(t)));
-  CHECK(averager(t).get()[0][0] == t);
+  CHECK(averager(t).value()[0][0] == t);
   t += dt;
   // data should currently be invalid since there was no update at this new `t`
   CHECK_FALSE(static_cast<bool>(averager(t)));
@@ -264,14 +264,14 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Averager.TestMove",
   auto last_time = averager.last_time_updated();
   auto avg_time = averager.average_time(0.9);
   auto avg_q = averager.using_average_0th_deriv_of_q();
-  auto avg_values = averager(0.9).get();
+  auto avg_values = averager(0.9).value();
   // test move constructor
   auto new_averager(std::move(averager));
   // check moved values against stored values
   CHECK(last_time == new_averager.last_time_updated());
   CHECK(avg_time == new_averager.average_time(0.9));
   CHECK(avg_q == new_averager.using_average_0th_deriv_of_q());
-  CHECK(avg_values[0][0] == new_averager(0.9).get()[0][0]);
+  CHECK(avg_values[0][0] == new_averager(0.9).value()[0][0]);
   // test move assignment
   Averager<2> new_averager2(0.1, true);
   new_averager2 = std::move(new_averager);
@@ -279,5 +279,5 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Averager.TestMove",
   CHECK(last_time == new_averager2.last_time_updated());
   CHECK(avg_time == new_averager2.average_time(0.9));
   CHECK(avg_q == new_averager2.using_average_0th_deriv_of_q());
-  CHECK(avg_values[0][0] == new_averager2(0.9).get()[0][0]);
+  CHECK(avg_values[0][0] == new_averager2(0.9).value()[0][0]);
 }

--- a/tests/Unit/DataStructures/Tensor/Test_Slice.cpp
+++ b/tests/Unit/DataStructures/Tensor/Test_Slice.cpp
@@ -123,7 +123,7 @@ void test_variables_slice() noexcept {
                     extents, 0, x_offset)
           .has_value());
 
-  // Test not_null<boost::option<Tensor>>
+  // Test not_null<std::optional<Tensor>> interface
   using TensorType = tnsr::I<VectorType, 3>;
   auto optional_tensor = std::make_optional(TensorType{});
   CHECK(optional_tensor.has_value());

--- a/tests/Unit/Domain/Creators/Test_Shell.cpp
+++ b/tests/Unit/Domain/Creators/Test_Shell.cpp
@@ -540,7 +540,7 @@ void test_radial_block_layers(const double inner_radius,
   const auto blogical_coords =
       block_logical_coordinates(domain, interior_inertial_coords);
   for (size_t s = 0; s < expected_block_ids.size(); ++s) {
-    CHECK(blogical_coords[s].get().id.get_index() == expected_block_ids[s]);
+    CHECK(blogical_coords[s].value().id.get_index() == expected_block_ids[s]);
   }
   size_t element_count = 0;
   for (const auto& block : domain.blocks()) {

--- a/tests/Unit/Domain/Test_BlockAndElementLogicalCoordinates.cpp
+++ b/tests/Unit/Domain/Test_BlockAndElementLogicalCoordinates.cpp
@@ -5,12 +5,11 @@
 
 #include <algorithm>
 #include <array>
-#include <boost/optional.hpp>
-#include <boost/optional/optional_io.hpp>
 #include <cstddef>
 #include <iterator>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <random>
 #include <unordered_map>
 #include <vector>
@@ -145,7 +144,7 @@ void fuzzy_test_block_and_element_logical_coordinates(
   test_serialization(block_logical_result);
 
   for (size_t s = 0; s < n_pts; ++s) {
-    CHECK(block_logical_result[s].get().id.get_index() ==
+    CHECK(block_logical_result[s].value().id.get_index() ==
           element_ids[s].block_id());
     // We don't know block logical coordinates here, so we can't
     // test them.
@@ -244,8 +243,9 @@ void fuzzy_test_block_and_element_logical_coordinates_unrefined(
   test_serialization(block_logical_result);
 
   for (size_t s = 0; s < n_pts; ++s) {
-    CHECK(block_logical_result[s].get().id.get_index() == block_ids[s]);
-    CHECK_ITERABLE_APPROX(block_logical_result[s].get().data, block_coords[s]);
+    CHECK(block_logical_result[s].value().id.get_index() == block_ids[s]);
+    CHECK_ITERABLE_APPROX(block_logical_result[s].value().data,
+                          block_coords[s]);
   }
 
   // Map to grid coords
@@ -278,8 +278,9 @@ void fuzzy_test_block_and_element_logical_coordinates_unrefined(
       block_logical_coordinates(domain, grid_coords, time, functions_of_time);
   test_serialization(block_logical_result);
   for (size_t s = 0; s < n_pts; ++s) {
-    CHECK(block_logical_result[s].get().id.get_index() == block_ids[s]);
-    CHECK_ITERABLE_APPROX(block_logical_result[s].get().data, block_coords[s]);
+    CHECK(block_logical_result[s].value().id.get_index() == block_ids[s]);
+    CHECK_ITERABLE_APPROX(block_logical_result[s].value().data,
+                          block_coords[s]);
   }
 }
 
@@ -380,9 +381,9 @@ void test_block_and_element_logical_coordinates(
   const auto block_logical_result =
       block_logical_coordinates(domain, inertial_coords);
   for (size_t s = 0; s < x_inertial.size(); ++s) {
-    CHECK(block_logical_result[s].get().id.get_index() ==
+    CHECK(block_logical_result[s].value().id.get_index() ==
           expected_block_ids[s]);
-    CHECK_ITERABLE_APPROX(block_logical_result[s].get().data,
+    CHECK_ITERABLE_APPROX(block_logical_result[s].value().data,
                           expected_logical_coords[s]);
   }
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_BoundaryCorrectionsHelper.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_BoundaryCorrectionsHelper.cpp
@@ -131,7 +131,7 @@ struct Correction final {
       }
     }
 
-    if (static_cast<bool>(normal_dot_mesh_velocity)) {
+    if (normal_dot_mesh_velocity.has_value()) {
       get(*packaged_abs_char_speed) =
           abs(volume_double * get(var1) - get(*normal_dot_mesh_velocity));
     } else {

--- a/tests/Unit/Evolution/Systems/Cce/InterfaceManagers/Test_GhLocalTimeStepping.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/InterfaceManagers/Test_GhLocalTimeStepping.cpp
@@ -3,8 +3,6 @@
 
 #include "Framework/TestingFramework.hpp"
 
-#include <boost/optional.hpp>
-#include <boost/optional/optional_io.hpp>
 #include <cstddef>
 #include <memory>
 #include <tuple>

--- a/tests/Unit/Evolution/Systems/Cce/InterfaceManagers/Test_GhLockstep.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/InterfaceManagers/Test_GhLockstep.cpp
@@ -3,8 +3,6 @@
 
 #include "Framework/TestingFramework.hpp"
 
-#include <boost/optional.hpp>
-#include <boost/optional/optional_io.hpp>
 #include <cstddef>
 #include <memory>
 #include <tuple>

--- a/tests/Unit/Framework/Pypp.hpp
+++ b/tests/Unit/Framework/Pypp.hpp
@@ -8,7 +8,6 @@
 
 #include <Python.h>
 #include <array>
-#include <boost/optional.hpp>
 #include <boost/range/combine.hpp>
 #include <cstddef>
 #include <optional>
@@ -221,51 +220,6 @@ struct ContainerPackAndUnpack<Scalar<SpinWeighted<ValueType, Spin>>,
   static inline size_t get_size(const packed_container& packed) noexcept {
     return ContainerPackAndUnpack<ValueType, ConversionClassList>::get_size(
         packed[0].data());
-  }
-};
-
-template <typename T, typename ConversionClassList>
-struct ContainerPackAndUnpack<boost::optional<T>, ConversionClassList,
-                              std::nullptr_t> {
-  using unpacked_container = boost::optional<typename ContainerPackAndUnpack<
-      T, ConversionClassList>::unpacked_container>;
-  using packed_container = boost::optional<typename ContainerPackAndUnpack<
-      T, ConversionClassList>::packed_container>;
-  using packed_type =
-      typename ContainerPackAndUnpack<T, ConversionClassList>::packed_type;
-
-  static inline unpacked_container unpack(
-      const packed_container& packed, const size_t grid_point_index) noexcept {
-    if (static_cast<bool>(packed)) {
-      return unpacked_container{
-          ContainerPackAndUnpack<T, ConversionClassList>::unpack(
-              *packed, grid_point_index)};
-    }
-    return unpacked_container{};
-  }
-
-  static inline void pack(const gsl::not_null<packed_container*> packed,
-                          const unpacked_container& unpacked,
-                          const size_t grid_point_index) {
-    if ((std::is_same_v<packed_type, DataVector> or
-         std::is_same_v<
-             packed_type,
-             ComplexDataVector>)and UNLIKELY(not static_cast<bool>(unpacked))) {
-      throw std::runtime_error(
-          "Returned type is None in one element of the boost::optional's "
-          "packed type (DataVector or ComplexDataVector). We can't support "
-          "this because we can't just make one element of the packed type be "
-          "an invalid optional.");
-    }
-    ContainerPackAndUnpack<T, ConversionClassList>::pack(
-        make_not_null(&*packed), unpacked, grid_point_index);
-  }
-
-  static inline size_t get_size(const packed_container& packed) noexcept {
-    if (static_cast<bool>(packed)) {
-      return ContainerPackAndUnpack<T, ConversionClassList>::get_size(*packed);
-    }
-    return 1;
   }
 };
 

--- a/tests/Unit/Framework/PyppFundamentals.hpp
+++ b/tests/Unit/Framework/PyppFundamentals.hpp
@@ -8,7 +8,6 @@
 
 #include <Python.h>
 #include <array>
-#include <boost/optional.hpp>
 #include <cstddef>
 #include <initializer_list>
 #include <optional>
@@ -632,26 +631,6 @@ template <typename T>
 struct ToPyObject<Scalar<T>, Requires<is_any_spin_weighted_v<T>>> {
   static PyObject* convert(const Scalar<T>& t) {
     return ToPyObject<typename T::value_type>::convert(get(t).data());
-  }
-};
-
-template <typename T>
-struct FromPyObject<boost::optional<T>> {
-  static boost::optional<T> convert(PyObject* p) {
-    if (p == Py_None) {
-      return boost::optional<T>{};
-    }
-    return FromPyObject<T>::convert(p);
-  }
-};
-
-template <typename T>
-struct ToPyObject<boost::optional<T>> {
-  static PyObject* convert(const boost::optional<T>& t) {
-    if (static_cast<bool>(t)) {
-      return to_py_object(*t);
-    }
-    Py_RETURN_NONE;
   }
 };
 

--- a/tests/Unit/Framework/Tests/Test_Pypp.cpp
+++ b/tests/Unit/Framework/Tests/Test_Pypp.cpp
@@ -4,7 +4,6 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <array>
-#include <boost/optional.hpp>
 #include <cmath>
 #include <complex>
 #include <cstddef>
@@ -537,7 +536,6 @@ SPECTRE_TEST_CASE("Unit.Pypp", "[Pypp][Unit]") {
   test_einsum<double>(0.);
   test_einsum<DataVector>(DataVector(5));
   test_function_of_time();
-  test_optional<boost::optional>();
   test_optional<std::optional>();
   test_custom_conversion();
 }

--- a/tests/Unit/Helpers/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
+++ b/tests/Unit/Helpers/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
@@ -5,8 +5,8 @@
 
 #include "Framework/TestingFramework.hpp"
 
-#include <boost/optional.hpp>
 #include <cstddef>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -94,7 +94,7 @@ struct MockReceivePoints {
       Parallel::GlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/,
       const typename Metavariables::temporal_id::type& temporal_id,
-      std::vector<boost::optional<
+      std::vector<std::optional<
           IdPair<domain::BlockId,
                  tnsr::I<double, VolumeDim, typename Frame::Logical>>>>&&
           block_coord_holders) noexcept {
@@ -218,10 +218,10 @@ void test_interpolation_target(
   CHECK(block_coord_holders.size() == number_of_points);
 
   for (size_t i = 0; i < number_of_points; ++i) {
-    CHECK(block_coord_holders[i].get().id ==
-          expected_block_coord_holders[i].get().id);
-    CHECK_ITERABLE_APPROX(block_coord_holders[i].get().data,
-                          expected_block_coord_holders[i].get().data);
+    CHECK(block_coord_holders[i].value().id ==
+          expected_block_coord_holders[i].value().id);
+    CHECK_ITERABLE_APPROX(block_coord_holders[i].value().data,
+                          expected_block_coord_holders[i].value().data);
   }
 
   // Call again at a different temporal_id
@@ -238,10 +238,10 @@ void test_interpolation_target(
   const auto& new_block_coord_holders =
       vars_infos.at(new_temporal_id).block_coord_holders;
   for (size_t i = 0; i < number_of_points; ++i) {
-    CHECK(new_block_coord_holders[i].get().id ==
-          expected_block_coord_holders[i].get().id);
-    CHECK_ITERABLE_APPROX(new_block_coord_holders[i].get().data,
-                          expected_block_coord_holders[i].get().data);
+    CHECK(new_block_coord_holders[i].value().id ==
+          expected_block_coord_holders[i].value().id);
+    CHECK_ITERABLE_APPROX(new_block_coord_holders[i].value().data,
+                          expected_block_coord_holders[i].value().data);
   }
 }
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ElementReceiveInterpPoints.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ElementReceiveInterpPoints.cpp
@@ -3,8 +3,8 @@
 
 #include "Framework/TestingFramework.hpp"
 
-#include <boost/optional/optional_io.hpp>
 #include <cstddef>
+#include <optional>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
@@ -149,7 +149,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ElementReceivePoints",
   ActionTesting::set_phase(make_not_null(&runner),
                            metavars::Phase::Registration);
 
-  using point_info_type = std::vector<boost::optional<
+  using point_info_type = std::vector<std::optional<
       IdPair<domain::BlockId, tnsr::I<double, metavars::volume_dim,
                                       typename ::Frame::Logical>>>>;
 
@@ -220,8 +220,8 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ElementReceivePoints",
     const size_t number_of_points = expected.size();
     CHECK(result.size() == number_of_points);
     for (size_t i = 0; i < number_of_points; ++i) {
-      CHECK(result[i].get().id == expected[i].get().id);
-      CHECK_ITERABLE_APPROX(result[i].get().data, expected[i].get().data);
+      CHECK(result[i].value().id == expected[i].value().id);
+      CHECK_ITERABLE_APPROX(result[i].value().data, expected[i].value().data);
     }
   };
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
@@ -4,8 +4,8 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <array>
-#include <boost/optional/optional_io.hpp>
 #include <cstddef>
+#include <optional>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -37,6 +37,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Rational.hpp"
 #include "Utilities/Requires.hpp"
+#include "Utilities/StdHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 

--- a/tests/Unit/NumericalAlgorithms/RootFinding/Test_RootBracketing.cpp
+++ b/tests/Unit/NumericalAlgorithms/RootFinding/Test_RootBracketing.cpp
@@ -3,9 +3,8 @@
 
 #include "Framework/TestingFramework.hpp"
 
-#include <boost/none.hpp>
-#include <boost/optional.hpp>
 #include <cmath>
+#include <optional>
 #include <random>
 
 #include "DataStructures/DataVector.hpp"
@@ -15,28 +14,28 @@
 #include "Utilities/Gsl.hpp"
 
 namespace {
-boost::optional<double> f_free(double x) noexcept {
-  return (x < 1.0 or x > 2.0) ? boost::none
-                              : boost::optional<double>(2.0 - square(x));
+std::optional<double> f_free(double x) noexcept {
+  return (x < 1.0 or x > 2.0) ? std::nullopt
+                              : std::optional<double>(2.0 - square(x));
 }
 struct F {
-  boost::optional<double> operator()(double x) const noexcept {
-    return (x < 1.0 or x > 2.0) ? boost::none
-                                : boost::optional<double>(2.0 - square(x));
+  std::optional<double> operator()(double x) const noexcept {
+    return (x < 1.0 or x > 2.0) ? std::nullopt
+                                : std::optional<double>(2.0 - square(x));
   }
 };
 
 template <typename Function>
 void test_bracketing_simple_one_function(
     const Function& f, const std::array<double, 2>& bounds,
-    const boost::optional<double>& guess) noexcept {
+    const std::optional<double>& guess) noexcept {
   double lower = bounds[0];
   double upper = bounds[1];
   double f_at_lower = std::numeric_limits<double>::signaling_NaN();
   double f_at_upper = std::numeric_limits<double>::signaling_NaN();
-  if (guess) {
+  if (guess.has_value()) {
     RootFinder::bracket_possibly_undefined_function_in_interval(
-        &lower, &upper, &f_at_lower, &f_at_upper, f, guess.get());
+        &lower, &upper, &f_at_lower, &f_at_upper, f, guess.value());
   } else {
     RootFinder::bracket_possibly_undefined_function_in_interval(
         &lower, &upper, &f_at_lower, &f_at_upper, f);
@@ -48,10 +47,10 @@ void test_bracketing_simple_one_function(
 
 void test_bracketing_simple_multiple_functions(
     const std::array<double, 2>& bounds,
-    const boost::optional<double>& guess) noexcept {
-  const auto f_lambda = [](double x) noexcept->boost::optional<double> {
-    return (x < 1.0 or x > 2.0) ? boost::none
-                                : boost::optional<double>(2.0 - square(x));
+    const std::optional<double>& guess) noexcept {
+  const auto f_lambda = [](double x) noexcept -> std::optional<double> {
+    return (x < 1.0 or x > 2.0) ? std::nullopt
+                                : std::optional<double>(2.0 - square(x));
   };
   const F f_functor{};
 
@@ -87,7 +86,7 @@ void test_bracketing_simple() noexcept {
 
   const auto test_with_and_without_guess =
       [&gen, &unit_dis ](const std::array<double, 2>& bounds) noexcept {
-    test_bracketing_simple_multiple_functions(bounds, boost::none);
+    test_bracketing_simple_multiple_functions(bounds, std::nullopt);
     test_bracketing_simple_multiple_functions(
         bounds, bounds[0] + unit_dis(gen) * (bounds[1] - bounds[0]));
   };
@@ -117,21 +116,22 @@ void test_bracketing_datavector() noexcept {
                       unit_dis(gen)};
 
   const auto f_lambda = [](double x,
-                           size_t /*i*/) noexcept->boost::optional<double> {
-    return (x < 1.0 or x > 2.0) ? boost::none
-                                : boost::optional<double>(2.0 - square(x));
+                           size_t /*i*/) noexcept -> std::optional<double> {
+    return (x < 1.0 or x > 2.0) ? std::nullopt
+                                : std::optional<double>(2.0 - square(x));
   };
 
   const auto do_test = [&f_lambda](
       DataVector lower_l, DataVector upper_l,
-      const boost::optional<DataVector>& guess) noexcept {
+      const std::optional<DataVector>& guess) noexcept {
     DataVector f_at_lower(lower_l.size(),
                           std::numeric_limits<double>::signaling_NaN());
     DataVector f_at_upper(upper_l.size(),
                           std::numeric_limits<double>::signaling_NaN());
-    if (guess) {
+    if (guess.has_value()) {
       RootFinder::bracket_possibly_undefined_function_in_interval(
-          &lower_l, &upper_l, &f_at_lower, &f_at_upper, f_lambda, guess.get());
+          &lower_l, &upper_l, &f_at_lower, &f_at_upper, f_lambda,
+          guess.value());
     } else {
       RootFinder::bracket_possibly_undefined_function_in_interval(
           &lower_l, &upper_l, &f_at_lower, &f_at_upper, f_lambda);
@@ -143,7 +143,7 @@ void test_bracketing_datavector() noexcept {
     }
   };
 
-  do_test(lower, upper, boost::none);
+  do_test(lower, upper, std::nullopt);
   do_test(lower, upper, DataVector(lower + (upper - lower) * unit_dis(gen)));
 }
 

--- a/tests/Unit/Utilities/Test_BoostHelpers.cpp
+++ b/tests/Unit/Utilities/Test_BoostHelpers.cpp
@@ -3,8 +3,6 @@
 
 #include "Framework/TestingFramework.hpp"
 
-#include <boost/optional.hpp>
-#include <boost/optional/optional_io.hpp>
 #include <string>
 
 #include "Framework/TestHelpers.hpp"
@@ -46,10 +44,4 @@ SPECTRE_TEST_CASE("Unit.Utilities.BoostHelpers.Variant.Names",
   CHECK(type_of_current_state(var = 1) == "int");
   CHECK(type_of_current_state(var = 'A') == "char");
   CHECK(type_of_current_state(var = 2.8) == "double");
-}
-
-SPECTRE_TEST_CASE("Unit.Utilities.BoostHelpers.Optional.Pup",
-                  "[Unit][Utilities]") {
-  test_serialization(boost::optional<double>{});
-  test_serialization(boost::optional<double>{1.2});
 }

--- a/tests/Unit/Utilities/Test_StdHelpers.cpp
+++ b/tests/Unit/Utilities/Test_StdHelpers.cpp
@@ -10,6 +10,7 @@
 #include <list>
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
 #include <tuple>
@@ -56,6 +57,13 @@ SPECTRE_TEST_CASE("Unit.Utilities.StdHelpers.Output", "[Utilities][Unit]") {
   CHECK(get_output(tuple1) == "(1,1.87,test)");
   std::tuple<> tuple0{};
   CHECK(get_output(tuple0) == "()");
+
+  std::optional<int> opt{};
+  CHECK(get_output(opt) == "--");
+  opt = -42;
+  CHECK(get_output(opt) == "-42");
+  opt = std::nullopt;
+  CHECK(get_output(opt) == "--");
 
   std::unordered_map<std::string, int, boost::hash<std::string>>
       my_unordered_map;

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -244,6 +244,39 @@ lrtslock_test() {
 }
 standard_checks+=(lrtslock)
 
+# Check for boost::optional headers (we favor std::optional)
+# (see related check for boost/none header below)
+boost_optional() {
+    is_c++ "$1" && staged_grep -q '#include <boost/optional.*>' "$1"
+}
+boost_optional_report() {
+    echo "Found boost::optional header (use std::optional instead):"
+    pretty_grep '#include <boost/optional.*>' "$@"
+}
+boost_optional_test() {
+    test_check pass foo.cpp '#include <optional>'$'\n'
+    test_check pass foo.cpp '#include <boost/none.hpp>'$'\n'
+    test_check fail foo.cpp '#include <boost/optional.hpp>'$'\n'
+    test_check fail foo.cpp '#include <boost/optional/optional_io.hpp>'$'\n'
+}
+standard_checks+=(boost_optional)
+
+# Check for boost/none header
+# (see related check for boost/optional* headers above)
+boost_none() {
+    is_c++ "$1" && staged_grep -q '#include <boost/none.hpp>' "$1"
+}
+boost_none_report() {
+    echo "Found boost/none.hpp header:"
+    pretty_grep '#include <boost/none.hpp>' "$@"
+}
+boost_none_test() {
+    test_check pass foo.cpp '#include <optional>'$'\n'
+    test_check pass foo.cpp '#include <boost/optional.hpp>'$'\n'
+    test_check fail foo.cpp '#include <boost/none.hpp>'$'\n'
+}
+standard_checks+=(boost_none)
+
 # Check for files containing tabs
 tabs() {
     whitelist "$1" '.h5' '.png' &&

--- a/tools/Iwyu/boost-custom.imp
+++ b/tools/Iwyu/boost-custom.imp
@@ -38,6 +38,4 @@
               "<boost/preprocessor/facilities/apply.hpp>", public]},
   { include: ["<boost/preprocessor/detail/check.hpp>", private,
               "<boost/parameter/preprocessor.hpp>", public]},
-  { include: ["<boost/optional/optional.hpp>", public,
-              "<boost/optional.hpp>", public]},
 ]


### PR DESCRIPTION
## Proposed changes

Each commit removes `boost::optional` from one particular context.

In addition, adds a stream helper for `std::optional` — this was needed by some tests.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
