### PR TITLE
Fix version name validation in release workflow

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -601,6 +601,7 @@ jobs:
             [ $(date +'%d') != ${BASH_REMATCH[3]} ]; then
               TODAY=$(date +'%Y.%m.%d')
               echo "'$RELEASE_VERSION' doesn't match current date '$TODAY'"
+              exit 1
             fi
           else
             echo "'$RELEASE_VERSION' doesn't match '$VERSION_PATTERN'"


### PR DESCRIPTION
## Proposed changes

The validation caught the version name mismatch, but didn't fail the workflow 🤦‍♂️

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
