### PR TITLE
Fix protocol assert_conforms_to, relax NumericalFlux requirements for evolution DG transition

### DIFF
--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Protocols.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Protocols.hpp
@@ -94,15 +94,12 @@ struct NumericalFlux {
     using argument_tags = typename ConformingType::argument_tags;
     using package_field_tags = typename ConformingType::package_field_tags;
     using package_extra_tags = typename ConformingType::package_extra_tags;
-    // We can't currently check that the package_data function is callable
-    // because the `argument_tags` may contain base tags and we can't resolve
-    // their types.
-    static_assert(
-        std::is_same_v<typename detail::TestCallOperatorImpl<
-                           ConformingType, variables_tags, package_field_tags,
-                           package_extra_tags>::type,
-                       void>,
-        "The 'operator()' must return 'void'.");
+    // - We can't currently check that the package_data function is callable
+    //   because the `argument_tags` may contain base tags and we can't resolve
+    //   their types.
+    // - The evolution schemes don't follow the interface documented above
+    //   anymore, so we relax the conditions and don't check for a valid call
+    //   operator to make the transition easier.
   };
 };
 

--- a/src/Utilities/ProtocolHelpers.hpp
+++ b/src/Utilities/ProtocolHelpers.hpp
@@ -60,7 +60,10 @@ struct AssertConformsToImpl : std::true_type {
       "and the protocol is listed as the second template parameter. "
       "Have you forgotten to (publicly) inherit the type from "
       "tt::ConformsTo<Protocol>?");
-  using test = typename Protocol::template test<ConformingType>;
+  // Implicitly instantiate Protocol::test in order to test conformance
+  static_assert(
+      not std::is_same_v<
+          decltype(typename Protocol::template test<ConformingType>{}), void>);
 };
 
 }  // namespace detail


### PR DESCRIPTION
## Proposed changes

- Fix a bug in `tt::assert_conforms_to` that made compilers optimize out an unused type alias
- Relax the requirements in the `NumericalFlux` protocol because the evolution DG schemes don't follow the interface documented in the protocol anymore.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
