### PR TITLE
Remove extra comma in python init files

### DIFF
--- a/cmake/SpectreSetupPythonPackage.cmake
+++ b/cmake/SpectreSetupPythonPackage.cmake
@@ -280,6 +280,8 @@ function(SPECTRE_PYTHON_ADD_MODULE MODULE_NAME)
       file(REMOVE "${MODULE_LOCATION}/${CURRENT_PYTHON_MODULE}.py")
     endif()
   endforeach(CURRENT_PYTHON_MODULE in ${WRITTEN_PYTHON_ALL_WITHOUT_EXTENSIONS})
+  # Sometimes we get a "[," in the files, which can give problems.
+  string(REPLACE "[," "[" INIT_FILE_OUTPUT "${INIT_FILE_OUTPUT}")
 
   # Write the __init__.py file for the module
   if(NOT ${INIT_FILE_OUTPUT} STREQUAL "${INIT_FILE_CONTENTS}")


### PR DESCRIPTION
## Proposed changes

Sometimes (I haven't figured out exactly when) we get an extra comma at the beginning of the lists in the python files. This causes python to be unhappy. We already do some basic string manipulations to deal with similar issues, so this adds another one.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
