### PR TITLE
Print back trace from ERROR and ASSERT macros, add ERROR_NO_TRACE macro

### DIFF
--- a/src/Options/Options.hpp
+++ b/src/Options/Options.hpp
@@ -72,7 +72,7 @@ inline std::ostream& operator<<(std::ostream& s, const Context& c) noexcept {
   do {                                                                  \
     if ((context).top_level) {                                          \
       /* clang-tidy: macro arg in parentheses */                        \
-      ERROR("\n" << (context) << m); /* NOLINT */                       \
+      ERROR_NO_TRACE("\n" << (context) << m); /* NOLINT */              \
     } else {                                                            \
       std::ostringstream avoid_name_collisions_PARSE_ERROR;             \
       /* clang-tidy: macro arg in parentheses */                        \

--- a/src/Parallel/InitializationFunctions.hpp
+++ b/src/Parallel/InitializationFunctions.hpp
@@ -5,11 +5,11 @@
 
 #include <exception>
 
-#include "Utilities/System/Abort.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 
 inline void setup_error_handling() {
   std::set_terminate([]() {
-    sys::abort(
+    ERROR(
         "Terminate was called, calling Charm++'s abort function to properly "
         "terminate execution.");
   });

--- a/src/Utilities/ErrorHandling/AbortWithErrorMessage.cpp
+++ b/src/Utilities/ErrorHandling/AbortWithErrorMessage.cpp
@@ -3,12 +3,61 @@
 
 #include "Utilities/ErrorHandling/AbortWithErrorMessage.hpp"
 
+#include <array>
 #include <charm++.h>
+#include <execinfo.h>
+#include <memory>
 #include <sstream>
 
 #include "Utilities/ErrorHandling/Breakpoint.hpp"
 #include "Utilities/System/Abort.hpp"
 #include "Utilities/System/ParallelInfo.hpp"
+
+namespace {
+struct FillBacktrace {};
+
+std::ostream& operator<<(std::ostream& os, const FillBacktrace& /*unused*/) {
+  // 3 for the stream operator and abort_with_error_message, 10 for the
+  // stack.
+  constexpr size_t max_stack_depth_printed = 13;
+  std::array<void*, max_stack_depth_printed> trace_elems{};
+  int trace_elem_count = backtrace(trace_elems.data(), max_stack_depth_printed);
+  std::unique_ptr<char*, decltype(free)*> stack_syms{
+      backtrace_symbols(trace_elems.data(), trace_elem_count), free};
+  // Start at 3 to ignore stream operator and abort_with_error_message
+  for (int i = 3; i < trace_elem_count; ++i) {
+    os << stack_syms.get()[i] << "\n";
+  }
+  return os;
+}
+
+template <bool ShowTrace>
+[[noreturn]] void abort_with_error_message_impl(const char* file,
+                                                const int line,
+                                                const char* pretty_function,
+                                                const std::string& message) {
+  std::ostringstream os;
+  os << "\n"
+     << "############ ERROR ############\n";
+  if constexpr (ShowTrace) {
+    os << "Shortened stack trace is:\n"
+       << FillBacktrace{} << "End shortened stack trace.\n\n";
+  }
+  os << "Node: " << sys::my_node() << " Proc: " << sys::my_proc() << "\n"
+     << "Line: " << line << " of " << file << "\n"
+     << "Function: " << pretty_function << "\n"
+     << message << "\n"
+     << "############ ERROR ############\n"
+     << "\n";
+  // We use CkError instead of abort to print the error message because in the
+  // case of an executable not using Charm++'s main function the call to abort
+  // will segfault before anything is printed.
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+  CkError("%s", os.str().c_str());
+  breakpoint();
+  sys::abort("");
+}
+}  // namespace
 
 void abort_with_error_message(const char* expression, const char* file,
                               const int line, const char* pretty_function,
@@ -16,6 +65,8 @@ void abort_with_error_message(const char* expression, const char* file,
   std::ostringstream os;
   os << "\n"
      << "############ ASSERT FAILED ############\n"
+     << "Shortened stack trace is:\n"
+     << FillBacktrace{} << "End shortened stack trace.\n\n"
      << "Node: " << sys::my_node() << " Proc: " << sys::my_proc() << "\n"
      << "Line: " << line << " of " << file << "\n"
      << "'" << expression << "' violated!\n"
@@ -32,23 +83,15 @@ void abort_with_error_message(const char* expression, const char* file,
   sys::abort("");
 }
 
+
 void abort_with_error_message(const char* file, const int line,
                               const char* pretty_function,
                               const std::string& message) {
-  std::ostringstream os;
-  os << "\n"
-     << "############ ERROR ############\n"
-     << "Node: " << sys::my_node() << " Proc: " << sys::my_proc() << "\n"
-     << "Line: " << line << " of " << file << "\n"
-     << "Function: " << pretty_function << "\n"
-     << message << "\n"
-     << "############ ERROR ############\n"
-     << "\n";
-  // We use CkError instead of abort to print the error message because in the
-  // case of an executable not using Charm++'s main function the call to abort
-  // will segfault before anything is printed.
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
-  CkError("%s", os.str().c_str());
-  breakpoint();
-  sys::abort("");
+  abort_with_error_message_impl<true>(file, line, pretty_function, message);
+}
+
+void abort_with_error_message_no_trace(const char* file, const int line,
+                                       const char* pretty_function,
+                                       const std::string& message) {
+  abort_with_error_message_impl<false>(file, line, pretty_function, message);
 }

--- a/src/Utilities/ErrorHandling/AbortWithErrorMessage.hpp
+++ b/src/Utilities/ErrorHandling/AbortWithErrorMessage.hpp
@@ -9,14 +9,21 @@
 #include <string>
 
 /// \ingroup ErrorHandlingGroup
-/// Compose an error message with an expression and abort the program.
+/// Compose an error message with an expression and a backtrace, then abort the
+/// program.
 [[noreturn]] void abort_with_error_message(const char* expression,
                                            const char* file, int line,
                                            const char* pretty_function,
                                            const std::string& message);
 
 /// \ingroup ErrorHandlingGroup
-/// Compose an error message and abort the program.
+/// Compose an error message including a backtrace and abort the program.
 [[noreturn]] void abort_with_error_message(const char* file, int line,
                                            const char* pretty_function,
                                            const std::string& message);
+
+/// \ingroup ErrorHandlingGroup
+/// Compose an error message without a backtrace and abort the program.
+[[noreturn]] void abort_with_error_message_no_trace(const char* file, int line,
+                                                    const char* pretty_function,
+                                                    const std::string& message);

--- a/src/Utilities/ErrorHandling/Error.hpp
+++ b/src/Utilities/ErrorHandling/Error.hpp
@@ -61,3 +61,19 @@
                m + /* NOLINT */                                               \
                "\n#######################################\n"s);               \
   } while (false)
+
+/*!
+ * \ingroup ErrorHandlingGroup
+ * \brief Same as ERROR but does not print a backtrace. Intended to be used for
+ * user errors, such as incorrect values in an input file.
+ */
+#define ERROR_NO_TRACE(m)                                                  \
+  do {                                                                     \
+    disable_floating_point_exceptions();                                   \
+    std::ostringstream avoid_name_collisions_ERROR;                        \
+    /* clang-tidy: macro arg in parentheses */                             \
+    avoid_name_collisions_ERROR << m; /* NOLINT */                         \
+    abort_with_error_message_no_trace(                                     \
+        __FILE__, __LINE__, static_cast<const char*>(__PRETTY_FUNCTION__), \
+        avoid_name_collisions_ERROR.str());                                \
+  } while (false)


### PR DESCRIPTION
## Proposed changes

- Prints 10 frames (excluding the internals of the macros) when an ERROR or ASSERT is triggered
- This would be annoying for input file adjustments, so an `ERROR_NO_TRACE` macro is added and used in `PARSE_ERROR`
- Replaces the `sys::abort` call with `ERROR` in `std::set_terminate`. The most common place where a back trace is useful is when an uncaught exception causes `std::terminate` to be called.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
