### PR TITLE
Add Boundary corrections for Burgers

### DIFF
--- a/src/Evolution/Systems/Burgers/BoundaryCorrections/BoundaryCorrection.hpp
+++ b/src/Evolution/Systems/Burgers/BoundaryCorrections/BoundaryCorrection.hpp
@@ -1,0 +1,42 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <pup.h>
+
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// Boundary corrections/numerical fluxes
+namespace Burgers::BoundaryCorrections {
+/// \cond
+class Rusanov;
+/// \endcond
+
+/*!
+ * \brief The base class used to create boundary corrections from input files
+ * and store them in the global cache.
+ */
+class BoundaryCorrection : public PUP::able {
+ public:
+  BoundaryCorrection() = default;
+  BoundaryCorrection(const BoundaryCorrection&) = default;
+  BoundaryCorrection& operator=(const BoundaryCorrection&) = default;
+  BoundaryCorrection(BoundaryCorrection&&) = default;
+  BoundaryCorrection& operator=(BoundaryCorrection&&) = default;
+  ~BoundaryCorrection() override = default;
+
+  explicit BoundaryCorrection(CkMigrateMessage* msg) noexcept
+      : PUP::able(msg) {}
+
+  /// \cond
+  WRAPPED_PUPable_abstract(BoundaryCorrection);  // NOLINT
+  /// \endcond
+
+  using creatable_classes = tmpl::list<Rusanov>;
+
+  virtual std::unique_ptr<BoundaryCorrection> get_clone() const noexcept = 0;
+};
+}  // namespace Burgers::BoundaryCorrections

--- a/src/Evolution/Systems/Burgers/BoundaryCorrections/BoundaryCorrection.hpp
+++ b/src/Evolution/Systems/Burgers/BoundaryCorrections/BoundaryCorrection.hpp
@@ -12,6 +12,7 @@
 /// Boundary corrections/numerical fluxes
 namespace Burgers::BoundaryCorrections {
 /// \cond
+class Hll;
 class Rusanov;
 /// \endcond
 
@@ -35,7 +36,7 @@ class BoundaryCorrection : public PUP::able {
   WRAPPED_PUPable_abstract(BoundaryCorrection);  // NOLINT
   /// \endcond
 
-  using creatable_classes = tmpl::list<Rusanov>;
+  using creatable_classes = tmpl::list<Hll, Rusanov>;
 
   virtual std::unique_ptr<BoundaryCorrection> get_clone() const noexcept = 0;
 };

--- a/src/Evolution/Systems/Burgers/BoundaryCorrections/CMakeLists.txt
+++ b/src/Evolution/Systems/Burgers/BoundaryCorrections/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+
+spectre_target_sources(
+  Burgers
+  PRIVATE
+  RegisterDerived.cpp
+  Rusanov.cpp
+  )
+
+spectre_target_headers(
+  Burgers
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  BoundaryCorrection.hpp
+  Factory.hpp
+  RegisterDerived.hpp
+  Rusanov.hpp
+  )

--- a/src/Evolution/Systems/Burgers/BoundaryCorrections/CMakeLists.txt
+++ b/src/Evolution/Systems/Burgers/BoundaryCorrections/CMakeLists.txt
@@ -6,6 +6,7 @@ spectre_target_sources(
   Burgers
   PRIVATE
   RegisterDerived.cpp
+  Hll.cpp
   Rusanov.cpp
   )
 
@@ -15,6 +16,7 @@ spectre_target_headers(
   HEADERS
   BoundaryCorrection.hpp
   Factory.hpp
+  Hll.hpp
   RegisterDerived.hpp
   Rusanov.hpp
   )

--- a/src/Evolution/Systems/Burgers/BoundaryCorrections/Factory.hpp
+++ b/src/Evolution/Systems/Burgers/BoundaryCorrections/Factory.hpp
@@ -4,4 +4,5 @@
 #pragma once
 
 #include "Evolution/Systems/Burgers/BoundaryCorrections/BoundaryCorrection.hpp"
+#include "Evolution/Systems/Burgers/BoundaryCorrections/Hll.hpp"
 #include "Evolution/Systems/Burgers/BoundaryCorrections/Rusanov.hpp"

--- a/src/Evolution/Systems/Burgers/BoundaryCorrections/Factory.hpp
+++ b/src/Evolution/Systems/Burgers/BoundaryCorrections/Factory.hpp
@@ -1,0 +1,7 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/Systems/Burgers/BoundaryCorrections/BoundaryCorrection.hpp"
+#include "Evolution/Systems/Burgers/BoundaryCorrections/Rusanov.hpp"

--- a/src/Evolution/Systems/Burgers/BoundaryCorrections/Hll.cpp
+++ b/src/Evolution/Systems/Burgers/BoundaryCorrections/Hll.cpp
@@ -1,0 +1,79 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Burgers/BoundaryCorrections/Hll.hpp"
+
+#include <memory>
+#include <optional>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+namespace Burgers::BoundaryCorrections {
+Hll::Hll(CkMigrateMessage* msg) noexcept : BoundaryCorrection(msg) {}
+
+std::unique_ptr<BoundaryCorrection> Hll::get_clone() const noexcept {
+  return std::make_unique<Hll>(*this);
+}
+
+void Hll::pup(PUP::er& p) { BoundaryCorrection::pup(p); }
+
+double Hll::dg_package_data(
+    const gsl::not_null<Scalar<DataVector>*> packaged_u,
+    const gsl::not_null<Scalar<DataVector>*> packaged_normal_dot_flux_u,
+    const gsl::not_null<Scalar<DataVector>*> packaged_char_speed,
+    const Scalar<DataVector>& u,
+    const tnsr::I<DataVector, 1, Frame::Inertial>& flux_u,
+    const tnsr::i<DataVector, 1, Frame::Inertial>& normal_covector,
+    const std::optional<tnsr::I<DataVector, 1, Frame::Inertial>>&
+    /*mesh_velocity*/,
+    const std::optional<Scalar<DataVector>>&
+        normal_dot_mesh_velocity) noexcept {
+  get(*packaged_char_speed) =
+      get<0>(normal_covector)[0] > 0.0 ? get(u) : -get(u);
+  if (normal_dot_mesh_velocity.has_value()) {
+    get(*packaged_char_speed) -= get(*normal_dot_mesh_velocity);
+  }
+  *packaged_u = u;
+  normal_dot_flux(packaged_normal_dot_flux_u, normal_covector, flux_u);
+  return max(abs(get(*packaged_char_speed)));
+}
+
+void Hll::dg_boundary_terms(
+    const gsl::not_null<Scalar<DataVector>*> boundary_correction_u,
+    const Scalar<DataVector>& u_int,
+    const Scalar<DataVector>& normal_dot_flux_u_int,
+    const Scalar<DataVector>& char_speed_int, const Scalar<DataVector>& u_ext,
+    const Scalar<DataVector>& normal_dot_flux_u_ext,
+    const Scalar<DataVector>& char_speed_ext,
+    const dg::Formulation dg_formulation) noexcept {
+  Variables<tmpl::list<::Tags::TempScalar<0>, ::Tags::TempScalar<1>>> temps{
+      get(u_int).size()};
+  get(get<::Tags::TempScalar<0>>(temps)) =
+      min(0.0, get(char_speed_int), -get(char_speed_ext));
+  get(get<::Tags::TempScalar<1>>(temps)) =
+      max(0.0, get(char_speed_int), -get(char_speed_ext));
+  const DataVector& lambda_min = get(get<::Tags::TempScalar<0>>(temps));
+  const DataVector& lambda_max = get(get<::Tags::TempScalar<1>>(temps));
+
+  get(*boundary_correction_u) =
+      ((lambda_max * get(normal_dot_flux_u_int) +
+        lambda_min * get(normal_dot_flux_u_ext)) +
+       lambda_max * lambda_min * (get(u_ext) - get(u_int))) /
+      (lambda_max - lambda_min);
+  if (dg_formulation == dg::Formulation::StrongInertial) {
+    get(*boundary_correction_u) -= get(normal_dot_flux_u_int);
+  }
+}
+}  // namespace Burgers::BoundaryCorrections
+
+// NOLINTNEXTLINE
+PUP::able::PUP_ID Burgers::BoundaryCorrections::Hll::my_PUP_ID = 0;
+/// \endcond

--- a/src/Evolution/Systems/Burgers/BoundaryCorrections/Hll.hpp
+++ b/src/Evolution/Systems/Burgers/BoundaryCorrections/Hll.hpp
@@ -1,0 +1,120 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/Burgers/BoundaryCorrections/BoundaryCorrection.hpp"
+#include "Evolution/Systems/Burgers/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace Burgers::BoundaryCorrections {
+/*!
+ * \brief An HLL (Harten-Lax-van Leer) Riemann solver
+ *
+ * Let \f$U\f$ be the evolved variable, \f$F^i\f$ the flux, and \f$n_i\f$ be
+ * the outward directed unit normal to the interface. Denoting \f$F := n_i
+ * F^i\f$, the HLL boundary correction is \cite Harten1983
+ *
+ * \f{align*}
+ * G_\text{HLL} = \frac{\lambda_\text{max} F_\text{int} +
+ * \lambda_\text{min} F_\text{ext}}{\lambda_\text{max} - \lambda_\text{min}}
+ * - \frac{\lambda_\text{min}\lambda_\text{max}}{\lambda_\text{max} -
+ * \lambda_\text{min}} \left(U_\text{int} - U_\text{ext}\right)
+ * \f}
+ *
+ * where "int" and "ext" stand for interior and exterior, and \cite Davis1988
+ *
+ * \f{align*}
+ * \lambda_\text{min} &= \text{min}\left(U_\text{int},-U_\text{ext}, 0\right) \\
+ * \lambda_\text{max} &= \text{max}\left(U_\text{int},-U_\text{ext}, 0\right),
+ * \f}
+ *
+ * The positive sign in front of the \f$F_{\text{ext}}\f$ in \f$G_\text{HLL}\f$
+ * and the minus signs in front of the \f$U_\text{ext}\f$ terms in
+ * \f$\lambda_\text{min}\f$ and \f$\lambda_\text{max}\f$ terms are necessary
+ * because the outward directed normal of the neighboring element has the
+ * opposite sign, i.e. \f$n_i^{\text{ext}}=-n_i^{\text{int}}\f$. Note that for
+ * either \f$\lambda_\text{min} = 0\f$ or \f$\lambda_\text{max} = 0\f$ (i.e. all
+ * characteristics move in the same direction) the HLL boundary correction
+ * reduces to pure upwinding.
+ *
+ * \note
+ * - In the strong form the `dg_boundary_terms` function returns
+ * \f$G - F_\text{int}\f$
+ * - Some references use \f$S\f$ instead of \f$\lambda\f$ for the
+ * signal/characteristic speeds
+ */
+class Hll final : public BoundaryCorrection {
+ private:
+  struct CharSpeed : db::SimpleTag {
+    using type = Scalar<DataVector>;
+  };
+
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help = {
+      "Computes the HLL boundary correction term for the Burgers system."};
+
+  Hll() = default;
+  Hll(const Hll&) = default;
+  Hll& operator=(const Hll&) = default;
+  Hll(Hll&&) = default;
+  Hll& operator=(Hll&&) = default;
+  ~Hll() override = default;
+
+  /// \cond
+  explicit Hll(CkMigrateMessage* msg) noexcept;
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Hll);  // NOLINT
+  /// \endcond
+  void pup(PUP::er& p) override;  // NOLINT
+
+  std::unique_ptr<BoundaryCorrection> get_clone() const noexcept override;
+
+  using dg_package_field_tags =
+      tmpl::list<Tags::U, ::Tags::NormalDotFlux<Tags::U>, CharSpeed>;
+  using dg_package_data_temporary_tags = tmpl::list<>;
+  using dg_package_data_volume_tags = tmpl::list<>;
+
+  static double dg_package_data(
+      gsl::not_null<Scalar<DataVector>*> packaged_u,
+      gsl::not_null<Scalar<DataVector>*> packaged_normal_dot_flux,
+      gsl::not_null<Scalar<DataVector>*> packaged_char_speed,
+      const Scalar<DataVector>& u,
+      const tnsr::I<DataVector, 1, Frame::Inertial>& flux_u,
+      const tnsr::i<DataVector, 1, Frame::Inertial>& normal_covector,
+      const std::optional<tnsr::I<DataVector, 1, Frame::Inertial>>&
+          mesh_velocity,
+      const std::optional<Scalar<DataVector>>&
+          normal_dot_mesh_velocity) noexcept;
+
+  static void dg_boundary_terms(
+      gsl::not_null<Scalar<DataVector>*> boundary_correction_u,
+      const Scalar<DataVector>& u_int,
+      const Scalar<DataVector>& normal_dot_flux_u_int,
+      const Scalar<DataVector>& abs_char_speed_int,
+      const Scalar<DataVector>& u_ext,
+      const Scalar<DataVector>& normal_dot_flux_u_ext,
+      const Scalar<DataVector>& abs_char_speed_ext,
+      dg::Formulation dg_formulation) noexcept;
+};
+}  // namespace Burgers::BoundaryCorrections

--- a/src/Evolution/Systems/Burgers/BoundaryCorrections/RegisterDerived.cpp
+++ b/src/Evolution/Systems/Burgers/BoundaryCorrections/RegisterDerived.cpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Burgers/BoundaryCorrections/Factory.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+
+namespace Burgers::BoundaryCorrections {
+void register_derived_with_charm() noexcept {
+  Parallel::register_derived_classes_with_charm<BoundaryCorrection>();
+}
+}  // namespace Burgers::BoundaryCorrections

--- a/src/Evolution/Systems/Burgers/BoundaryCorrections/RegisterDerived.hpp
+++ b/src/Evolution/Systems/Burgers/BoundaryCorrections/RegisterDerived.hpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace Burgers::BoundaryCorrections {
+void register_derived_with_charm() noexcept;
+}  // namespace Burgers::BoundaryCorrections

--- a/src/Evolution/Systems/Burgers/BoundaryCorrections/Rusanov.cpp
+++ b/src/Evolution/Systems/Burgers/BoundaryCorrections/Rusanov.cpp
@@ -1,0 +1,73 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Burgers/BoundaryCorrections/Rusanov.hpp"
+
+#include <memory>
+#include <optional>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+namespace Burgers::BoundaryCorrections {
+Rusanov::Rusanov(CkMigrateMessage* msg) noexcept : BoundaryCorrection(msg) {}
+
+std::unique_ptr<BoundaryCorrection> Rusanov::get_clone() const noexcept {
+  return std::make_unique<Rusanov>(*this);
+}
+
+void Rusanov::pup(PUP::er& p) { BoundaryCorrection::pup(p); }
+
+double Rusanov::dg_package_data(
+    const gsl::not_null<Scalar<DataVector>*> packaged_u,
+    const gsl::not_null<Scalar<DataVector>*> packaged_normal_dot_flux_u,
+    const gsl::not_null<Scalar<DataVector>*> packaged_abs_char_speed,
+    const Scalar<DataVector>& u,
+    const tnsr::I<DataVector, 1, Frame::Inertial>& flux_u,
+    const tnsr::i<DataVector, 1, Frame::Inertial>& normal_covector,
+    const std::optional<tnsr::I<DataVector, 1, Frame::Inertial>>&
+    /*mesh_velocity*/,
+    const std::optional<Scalar<DataVector>>&
+        normal_dot_mesh_velocity) noexcept {
+  if (normal_dot_mesh_velocity.has_value()) {
+    get(*packaged_abs_char_speed) =
+        abs(get(u) - get(*normal_dot_mesh_velocity));
+  } else {
+    get(*packaged_abs_char_speed) = abs(get(u));
+  }
+  *packaged_u = u;
+  normal_dot_flux(packaged_normal_dot_flux_u, normal_covector, flux_u);
+  return max(get(*packaged_abs_char_speed));
+}
+
+void Rusanov::dg_boundary_terms(
+    const gsl::not_null<Scalar<DataVector>*> boundary_correction_u,
+    const Scalar<DataVector>& u_int,
+    const Scalar<DataVector>& normal_dot_flux_u_int,
+    const Scalar<DataVector>& abs_char_speed_int,
+    const Scalar<DataVector>& u_ext,
+    const Scalar<DataVector>& normal_dot_flux_u_ext,
+    const Scalar<DataVector>& abs_char_speed_ext,
+    const dg::Formulation dg_formulation) noexcept {
+  if (dg_formulation == dg::Formulation::WeakInertial) {
+    get(*boundary_correction_u) =
+        0.5 * (get(normal_dot_flux_u_int) - get(normal_dot_flux_u_ext)) -
+        0.5 * max(get(abs_char_speed_int), get(abs_char_speed_ext)) *
+            (get(u_ext) - get(u_int));
+  } else {
+    get(*boundary_correction_u) =
+        -0.5 * (get(normal_dot_flux_u_int) + get(normal_dot_flux_u_ext)) -
+        0.5 * max(get(abs_char_speed_int), get(abs_char_speed_ext)) *
+            (get(u_ext) - get(u_int));
+  }
+}
+}  // namespace Burgers::BoundaryCorrections
+
+// NOLINTNEXTLINE
+PUP::able::PUP_ID Burgers::BoundaryCorrections::Rusanov::my_PUP_ID = 0;
+/// \endcond

--- a/src/Evolution/Systems/Burgers/BoundaryCorrections/Rusanov.hpp
+++ b/src/Evolution/Systems/Burgers/BoundaryCorrections/Rusanov.hpp
@@ -1,0 +1,106 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/Burgers/BoundaryCorrections/BoundaryCorrection.hpp"
+#include "Evolution/Systems/Burgers/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace Burgers::BoundaryCorrections {
+/*!
+ * \brief A Rusanov/local Lax-Friedrichs Riemann solver
+ *
+ * Let \f$U\f$ be the evolved variable, \f$F^i\f$ the flux, and \f$n_i\f$ be
+ * the outward directed unit normal to the interface. Denoting \f$F := n_i
+ * F^i\f$, the %Rusanov boundary correction is
+ *
+ * \f{align*}
+ * G_\text{Rusanov} = \frac{F_\text{int} - F_\text{ext}}{2} -
+ * \frac{\text{max}\left(|U_\text{int}|, |U_\text{ext}|\right)}{2}
+ * \left(U_\text{ext} - U_\text{int}\right),
+ * \f}
+ *
+ * where "int" and "ext" stand for interior and exterior. The minus sign in
+ * front of the \f$F_{\text{ext}}\f$ is necessary because the outward directed
+ * normal of the neighboring element has the opposite sign, i.e.
+ * \f$n_i^{\text{ext}}=-n_i^{\text{int}}\f$.
+ *
+ * \note In the strong form the `dg_boundary_terms` function returns
+ * \f$G - F_\text{int}\f$
+ */
+class Rusanov final : public BoundaryCorrection {
+ private:
+  struct AbsCharSpeed : db::SimpleTag {
+    using type = Scalar<DataVector>;
+  };
+
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help = {
+      "Computes the Rusanov or local Lax-Friedrichs boundary correction term "
+      "for the Burgers system."};
+
+  Rusanov() = default;
+  Rusanov(const Rusanov&) = default;
+  Rusanov& operator=(const Rusanov&) = default;
+  Rusanov(Rusanov&&) = default;
+  Rusanov& operator=(Rusanov&&) = default;
+  ~Rusanov() override = default;
+
+  /// \cond
+  explicit Rusanov(CkMigrateMessage* msg) noexcept;
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Rusanov);  // NOLINT
+  /// \endcond
+  void pup(PUP::er& p) override;  // NOLINT
+
+  std::unique_ptr<BoundaryCorrection> get_clone() const noexcept override;
+
+  using dg_package_field_tags =
+      tmpl::list<Tags::U, ::Tags::NormalDotFlux<Tags::U>, AbsCharSpeed>;
+  using dg_package_data_temporary_tags = tmpl::list<>;
+  using dg_package_data_volume_tags = tmpl::list<>;
+
+  static double dg_package_data(
+      gsl::not_null<Scalar<DataVector>*> packaged_u,
+      gsl::not_null<Scalar<DataVector>*> packaged_normal_dot_flux,
+      gsl::not_null<Scalar<DataVector>*> packaged_abs_char_speed,
+      const Scalar<DataVector>& u,
+      const tnsr::I<DataVector, 1, Frame::Inertial>& flux_u,
+      const tnsr::i<DataVector, 1, Frame::Inertial>& normal_covector,
+      const std::optional<tnsr::I<DataVector, 1, Frame::Inertial>>&
+          mesh_velocity,
+      const std::optional<Scalar<DataVector>>&
+          normal_dot_mesh_velocity) noexcept;
+
+  static void dg_boundary_terms(
+      gsl::not_null<Scalar<DataVector>*> boundary_correction_u,
+      const Scalar<DataVector>& u_int,
+      const Scalar<DataVector>& normal_dot_flux_u_int,
+      const Scalar<DataVector>& abs_char_speed_int,
+      const Scalar<DataVector>& u_ext,
+      const Scalar<DataVector>& normal_dot_flux_u_ext,
+      const Scalar<DataVector>& abs_char_speed_ext,
+      dg::Formulation dg_formulation) noexcept;
+};
+}  // namespace Burgers::BoundaryCorrections

--- a/src/Evolution/Systems/Burgers/CMakeLists.txt
+++ b/src/Evolution/Systems/Burgers/CMakeLists.txt
@@ -31,3 +31,5 @@ target_link_libraries(
   PUBLIC DataStructures
   INTERFACE ErrorHandling
   )
+
+add_subdirectory(BoundaryCorrections)

--- a/tests/Unit/Evolution/Systems/Burgers/BoundaryCorrections/Hll.py
+++ b/tests/Unit/Evolution/Systems/Burgers/BoundaryCorrections/Hll.py
@@ -1,0 +1,41 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def dg_package_data_u(u, flux_u, normal_covector, mesh_velocity,
+                      normal_dot_mesh_velocity):
+    return u
+
+
+def dg_package_data_normal_dot_flux(u, flux_u, normal_covector, mesh_velocity,
+                                    normal_dot_mesh_velocity):
+    return np.einsum("i,i", normal_covector, flux_u)
+
+
+def dg_package_data_char_speed(u, flux_u, normal_covector, mesh_velocity,
+                               normal_dot_mesh_velocity):
+    result = u if normal_covector[0] > 0.0 else -u
+    if normal_dot_mesh_velocity is None:
+        return result
+    else:
+        return result - normal_dot_mesh_velocity
+
+
+def dg_boundary_terms_u(interior_u, interior_normal_dot_flux_u,
+                        interior_char_speed, exterior_u,
+                        exterior_normal_dot_flux_u, exterior_char_speed,
+                        use_strong_form):
+    lambda_min = np.minimum(np.minimum(0.0, interior_char_speed),
+                            -exterior_char_speed)
+    lambda_max = np.maximum(np.maximum(0.0, interior_char_speed),
+                            -exterior_char_speed)
+    result = (
+        (lambda_max * interior_normal_dot_flux_u +
+         lambda_min * exterior_normal_dot_flux_u) + lambda_max * lambda_min *
+        (exterior_u - interior_u)) / (lambda_max - lambda_min)
+
+    if use_strong_form:
+        result -= interior_normal_dot_flux_u
+    return result

--- a/tests/Unit/Evolution/Systems/Burgers/BoundaryCorrections/Rusanov.py
+++ b/tests/Unit/Evolution/Systems/Burgers/BoundaryCorrections/Rusanov.py
@@ -1,0 +1,38 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def dg_package_data_u(u, flux_u, normal_covector, mesh_velocity,
+                      normal_dot_mesh_velocity):
+    return u
+
+
+def dg_package_data_normal_dot_flux(u, flux_u, normal_covector, mesh_velocity,
+                                    normal_dot_mesh_velocity):
+    return np.einsum("i,i", normal_covector, flux_u)
+
+
+def dg_package_data_abs_char_speed(u, flux_u, normal_covector, mesh_velocity,
+                                   normal_dot_mesh_velocity):
+    if normal_dot_mesh_velocity is None:
+        return np.abs(u)
+    else:
+        return np.abs(u - normal_dot_mesh_velocity)
+
+
+def dg_boundary_terms_u(interior_u, interior_normal_dot_flux_u,
+                        interior_abs_char_speed, exterior_u,
+                        exterior_normal_dot_flux_u, exterior_abs_char_speed,
+                        use_strong_form):
+    if use_strong_form:
+        return -0.5 * (interior_normal_dot_flux_u +
+                       exterior_normal_dot_flux_u) - 0.5 * np.maximum(
+                           interior_abs_char_speed,
+                           exterior_abs_char_speed) * (exterior_u - interior_u)
+    else:
+        return 0.5 * (interior_normal_dot_flux_u -
+                      exterior_normal_dot_flux_u) - 0.5 * np.maximum(
+                          interior_abs_char_speed,
+                          exterior_abs_char_speed) * (exterior_u - interior_u)

--- a/tests/Unit/Evolution/Systems/Burgers/BoundaryCorrections/Test_Hll.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/BoundaryCorrections/Test_Hll.cpp
@@ -1,0 +1,48 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <string>
+
+#include "Evolution/Systems/Burgers/BoundaryCorrections/Factory.hpp"
+#include "Evolution/Systems/Burgers/BoundaryCorrections/Hll.hpp"
+#include "Evolution/Systems/Burgers/System.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+
+SPECTRE_TEST_CASE("Unit.Burgers.Hll", "[Unit][Burgers]") {
+  PUPable_reg(Burgers::BoundaryCorrections::Hll);
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/Burgers/BoundaryCorrections"};
+
+  TestHelpers::evolution::dg::test_boundary_correction_conservation<
+      Burgers::System>(
+      Burgers::BoundaryCorrections::Hll{},
+      Mesh<0>{1, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {});
+
+  TestHelpers::evolution::dg::test_boundary_correction_with_python<
+      Burgers::System>(
+      "Hll",
+      {{"dg_package_data_u", "dg_package_data_normal_dot_flux",
+        "dg_package_data_char_speed"}},
+      {{"dg_boundary_terms_u"}}, Burgers::BoundaryCorrections::Hll{},
+      Mesh<0>{1, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {});
+
+  const auto Hll = TestHelpers::test_factory_creation<
+      Burgers::BoundaryCorrections::BoundaryCorrection>("Hll:");
+
+  TestHelpers::evolution::dg::test_boundary_correction_with_python<
+      Burgers::System>(
+      "Hll",
+      {{"dg_package_data_u", "dg_package_data_normal_dot_flux",
+        "dg_package_data_char_speed"}},
+      {{"dg_boundary_terms_u"}},
+      dynamic_cast<const Burgers::BoundaryCorrections::Hll&>(*Hll),
+      Mesh<0>{1, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {});
+}

--- a/tests/Unit/Evolution/Systems/Burgers/BoundaryCorrections/Test_Rusanov.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/BoundaryCorrections/Test_Rusanov.cpp
@@ -1,0 +1,48 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <string>
+
+#include "Evolution/Systems/Burgers/BoundaryCorrections/Factory.hpp"
+#include "Evolution/Systems/Burgers/BoundaryCorrections/Rusanov.hpp"
+#include "Evolution/Systems/Burgers/System.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+
+SPECTRE_TEST_CASE("Unit.Burgers.Rusanov", "[Unit][Burgers]") {
+  PUPable_reg(Burgers::BoundaryCorrections::Rusanov);
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/Burgers/BoundaryCorrections"};
+
+  TestHelpers::evolution::dg::test_boundary_correction_conservation<
+      Burgers::System>(
+      Burgers::BoundaryCorrections::Rusanov{},
+      Mesh<0>{1, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {});
+
+  TestHelpers::evolution::dg::test_boundary_correction_with_python<
+      Burgers::System>(
+      "Rusanov",
+      {{"dg_package_data_u", "dg_package_data_normal_dot_flux",
+        "dg_package_data_abs_char_speed"}},
+      {{"dg_boundary_terms_u"}}, Burgers::BoundaryCorrections::Rusanov{},
+      Mesh<0>{1, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {});
+
+  const auto rusanov = TestHelpers::test_factory_creation<
+      Burgers::BoundaryCorrections::BoundaryCorrection>("Rusanov:");
+
+  TestHelpers::evolution::dg::test_boundary_correction_with_python<
+      Burgers::System>(
+      "Rusanov",
+      {{"dg_package_data_u", "dg_package_data_normal_dot_flux",
+        "dg_package_data_abs_char_speed"}},
+      {{"dg_boundary_terms_u"}},
+      dynamic_cast<const Burgers::BoundaryCorrections::Rusanov&>(*rusanov),
+      Mesh<0>{1, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {});
+}

--- a/tests/Unit/Evolution/Systems/Burgers/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Burgers/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_Burgers")
 
 set(LIBRARY_SOURCES
+  BoundaryCorrections/Test_Hll.cpp
   BoundaryCorrections/Test_Rusanov.cpp
   Test_Characteristics.cpp
   Test_Fluxes.cpp

--- a/tests/Unit/Evolution/Systems/Burgers/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Burgers/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_Burgers")
 
 set(LIBRARY_SOURCES
+  BoundaryCorrections/Test_Rusanov.cpp
   Test_Characteristics.cpp
   Test_Fluxes.cpp
   Test_Tags.cpp

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp
@@ -197,7 +197,7 @@ void call_dg_boundary_terms(
 template <typename System, typename BoundaryCorrection, size_t FaceDim,
           typename... VolumeTags>
 void test_boundary_correction_impl(
-    const BoundaryCorrection& correction, const Mesh<FaceDim>& face_mesh,
+    const BoundaryCorrection& correction_in, const Mesh<FaceDim>& face_mesh,
     const tuples::TaggedTuple<VolumeTags...>& volume_data,
     const bool use_moving_mesh, const ::dg::Formulation dg_formulation,
     const ZeroOnSmoothSolution zero_on_smooth_solution) {
@@ -225,6 +225,11 @@ void test_boundary_correction_impl(
       typename BoundaryCorrection::dg_package_data_temporary_tags;
   using package_primitive_tags = detail::get_correction_primitive_vars<
       System::has_primitive_and_conservative_vars, BoundaryCorrection>;
+
+  const auto correction_base_ptr =
+      serialize_and_deserialize(correction_in.get_clone());
+  const auto& correction =
+      dynamic_cast<const BoundaryCorrection&>(*correction_base_ptr);
 
   // Check that the temporary tags needed on the boundary
   // (package_temporary_tags) are listed as temporary tags for the volume time


### PR DESCRIPTION
## Proposed changes

- Add a serialize/deserialize of the boundary correction to the test. This is to make sure that the boundary corrections are serializable
- Add Rusanov solver for Burgers
- Add HLL solver for Burgers

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
