### PR TITLE
Add Rusanov boundary correction to Newtonian Euler

### DIFF
--- a/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/BoundaryCorrection.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/BoundaryCorrection.hpp
@@ -1,0 +1,44 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <pup.h>
+
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// Boundary corrections/numerical fluxes
+namespace NewtonianEuler::BoundaryCorrections {
+/// \cond
+template <size_t Dim>
+class Rusanov;
+/// \endcond
+
+/*!
+ * \brief The base class used to create boundary corrections from input files
+ * and store them in the global cache.
+ */
+template <size_t Dim>
+class BoundaryCorrection : public PUP::able {
+ public:
+  BoundaryCorrection() = default;
+  BoundaryCorrection(const BoundaryCorrection&) = default;
+  BoundaryCorrection& operator=(const BoundaryCorrection&) = default;
+  BoundaryCorrection(BoundaryCorrection&&) = default;
+  BoundaryCorrection& operator=(BoundaryCorrection&&) = default;
+  ~BoundaryCorrection() override = default;
+
+  /// \cond
+  explicit BoundaryCorrection(CkMigrateMessage* msg) noexcept
+      : PUP::able(msg) {}
+  WRAPPED_PUPable_abstract(BoundaryCorrection<Dim>);  // NOLINT
+  /// \endcond
+
+  using creatable_classes = tmpl::list<Rusanov<Dim>>;
+
+  virtual std::unique_ptr<BoundaryCorrection<Dim>> get_clone()
+      const noexcept = 0;
+};
+}  // namespace NewtonianEuler::BoundaryCorrections

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/CMakeLists.txt
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_sources(
+  NewtonianEuler
+  PRIVATE
+  RegisterDerived.cpp
+  Rusanov.cpp
+  )
+
+spectre_target_headers(
+  NewtonianEuler
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  BoundaryCorrection.hpp
+  Factory.hpp
+  RegisterDerived.hpp
+  Rusanov.hpp
+  )

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Factory.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Factory.hpp
@@ -1,0 +1,7 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/Systems/NewtonianEuler/BoundaryCorrections/BoundaryCorrection.hpp"
+#include "Evolution/Systems/NewtonianEuler/BoundaryCorrections/Rusanov.hpp"

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/RegisterDerived.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/RegisterDerived.cpp
@@ -1,0 +1,13 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/NewtonianEuler/BoundaryCorrections/Factory.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+
+namespace NewtonianEuler::BoundaryCorrections {
+void register_derived_with_charm() noexcept {
+  Parallel::register_derived_classes_with_charm<BoundaryCorrection<1>>();
+  Parallel::register_derived_classes_with_charm<BoundaryCorrection<2>>();
+  Parallel::register_derived_classes_with_charm<BoundaryCorrection<3>>();
+}
+}  // namespace NewtonianEuler::BoundaryCorrections

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/RegisterDerived.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/RegisterDerived.hpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace NewtonianEuler::BoundaryCorrections {
+void register_derived_with_charm() noexcept;
+}  // namespace NewtonianEuler::BoundaryCorrections

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Rusanov.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Rusanov.cpp
@@ -1,0 +1,251 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/NewtonianEuler/BoundaryCorrections/Rusanov.hpp"
+
+#include <memory>
+#include <optional>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/NewtonianEuler/SoundSpeedSquared.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+namespace NewtonianEuler::BoundaryCorrections {
+template <size_t Dim>
+Rusanov<Dim>::Rusanov(CkMigrateMessage* msg) noexcept
+    : BoundaryCorrection<Dim>(msg) {}
+
+template <size_t Dim>
+std::unique_ptr<BoundaryCorrection<Dim>> Rusanov<Dim>::get_clone()
+    const noexcept {
+  return std::make_unique<Rusanov>(*this);
+}
+
+template <size_t Dim>
+void Rusanov<Dim>::pup(PUP::er& p) {
+  BoundaryCorrection<Dim>::pup(p);
+}
+
+template <size_t Dim>
+template <size_t ThermodynamicDim>
+double Rusanov<Dim>::dg_package_data(
+    const gsl::not_null<Scalar<DataVector>*> packaged_mass_density,
+    const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+        packaged_momentum_density,
+    const gsl::not_null<Scalar<DataVector>*> packaged_energy_density,
+    const gsl::not_null<Scalar<DataVector>*>
+        packaged_normal_dot_flux_mass_density,
+    const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+        packaged_normal_dot_flux_momentum_density,
+    const gsl::not_null<Scalar<DataVector>*>
+        packaged_normal_dot_flux_energy_density,
+    const gsl::not_null<Scalar<DataVector>*> packaged_abs_char_speed,
+
+    const Scalar<DataVector>& mass_density,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& momentum_density,
+    const Scalar<DataVector>& energy_density,
+
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& flux_mass_density,
+    const tnsr::IJ<DataVector, Dim, Frame::Inertial>& flux_momentum_density,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& flux_energy_density,
+
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& velocity,
+    const Scalar<DataVector>& specific_internal_energy,
+
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+    const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+    /*mesh_velocity*/,
+    const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,
+    const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
+        equation_of_state) const noexcept {
+  {
+    // Compute sound speed
+    Scalar<DataVector>& sound_speed = *packaged_mass_density;
+    Scalar<DataVector>& normal_dot_velocity = *packaged_energy_density;
+    sound_speed_squared(make_not_null(&sound_speed), mass_density,
+                        specific_internal_energy, equation_of_state);
+    get(sound_speed) = sqrt(get(sound_speed));
+    dot_product(make_not_null(&normal_dot_velocity), velocity, normal_covector);
+    if (normal_dot_mesh_velocity.has_value()) {
+      get(*packaged_abs_char_speed) =
+          max(abs(get(normal_dot_velocity) + get(sound_speed) -
+                  get(*normal_dot_mesh_velocity)),
+              abs(get(normal_dot_velocity) - get(sound_speed) -
+                  get(*normal_dot_mesh_velocity)));
+    } else {
+      get(*packaged_abs_char_speed) =
+          max(abs(get(normal_dot_velocity) + get(sound_speed)),
+              abs(get(normal_dot_velocity) - get(sound_speed)));
+    }
+  }
+
+  *packaged_mass_density = mass_density;
+  *packaged_momentum_density = momentum_density;
+  *packaged_energy_density = energy_density;
+
+  dot_product(packaged_normal_dot_flux_mass_density, flux_mass_density,
+              normal_covector);
+  for (size_t i = 0; i < Dim; ++i) {
+    packaged_normal_dot_flux_momentum_density->get(i) =
+        get<0>(normal_covector) * flux_momentum_density.get(0, i);
+    for (size_t j = 1; j < Dim; ++j) {
+      packaged_normal_dot_flux_momentum_density->get(i) +=
+          normal_covector.get(j) * flux_momentum_density.get(j, i);
+    }
+  }
+  dot_product(packaged_normal_dot_flux_energy_density, flux_energy_density,
+              normal_covector);
+
+  return max(get(*packaged_abs_char_speed));
+}
+
+template <size_t Dim>
+void Rusanov<Dim>::dg_boundary_terms(
+    const gsl::not_null<Scalar<DataVector>*> boundary_correction_mass_density,
+    const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+        boundary_correction_momentum_density,
+    const gsl::not_null<Scalar<DataVector>*> boundary_correction_energy_density,
+    const Scalar<DataVector>& mass_density_int,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& momentum_density_int,
+    const Scalar<DataVector>& energy_density_int,
+    const Scalar<DataVector>& normal_dot_flux_mass_density_int,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>&
+        normal_dot_flux_momentum_density_int,
+    const Scalar<DataVector>& normal_dot_flux_energy_density_int,
+    const Scalar<DataVector>& abs_char_speed_int,
+    const Scalar<DataVector>& mass_density_ext,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& momentum_density_ext,
+    const Scalar<DataVector>& energy_density_ext,
+    const Scalar<DataVector>& normal_dot_flux_mass_density_ext,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>&
+        normal_dot_flux_momentum_density_ext,
+    const Scalar<DataVector>& normal_dot_flux_energy_density_ext,
+    const Scalar<DataVector>& abs_char_speed_ext,
+    const dg::Formulation dg_formulation) const noexcept {
+  if (dg_formulation == dg::Formulation::WeakInertial) {
+    get(*boundary_correction_mass_density) =
+        0.5 * (get(normal_dot_flux_mass_density_int) -
+               get(normal_dot_flux_mass_density_ext)) -
+        0.5 * max(get(abs_char_speed_int), get(abs_char_speed_ext)) *
+            (get(mass_density_ext) - get(mass_density_int));
+    for (size_t i = 0; i < Dim; ++i) {
+      boundary_correction_momentum_density->get(i) =
+          0.5 * (normal_dot_flux_momentum_density_int.get(i) -
+                 normal_dot_flux_momentum_density_ext.get(i)) -
+          0.5 * max(get(abs_char_speed_int), get(abs_char_speed_ext)) *
+              (momentum_density_ext.get(i) - momentum_density_int.get(i));
+    }
+    get(*boundary_correction_energy_density) =
+        0.5 * (get(normal_dot_flux_energy_density_int) -
+               get(normal_dot_flux_energy_density_ext)) -
+        0.5 * max(get(abs_char_speed_int), get(abs_char_speed_ext)) *
+            (get(energy_density_ext) - get(energy_density_int));
+  } else {
+    get(*boundary_correction_mass_density) =
+        -0.5 * (get(normal_dot_flux_mass_density_int) +
+                get(normal_dot_flux_mass_density_ext)) -
+        0.5 * max(get(abs_char_speed_int), get(abs_char_speed_ext)) *
+            (get(mass_density_ext) - get(mass_density_int));
+    for (size_t i = 0; i < Dim; ++i) {
+      boundary_correction_momentum_density->get(i) =
+          -0.5 * (normal_dot_flux_momentum_density_int.get(i) +
+                  normal_dot_flux_momentum_density_ext.get(i)) -
+          0.5 * max(get(abs_char_speed_int), get(abs_char_speed_ext)) *
+              (momentum_density_ext.get(i) - momentum_density_int.get(i));
+    }
+    get(*boundary_correction_energy_density) =
+        -0.5 * (get(normal_dot_flux_energy_density_int) +
+                get(normal_dot_flux_energy_density_ext)) -
+        0.5 * max(get(abs_char_speed_int), get(abs_char_speed_ext)) *
+            (get(energy_density_ext) - get(energy_density_int));
+  }
+}
+
+template <size_t Dim>
+// NOLINTNEXTLINE
+PUP::able::PUP_ID Rusanov<Dim>::my_PUP_ID = 0;
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(_, data)                                                 \
+  template class Rusanov<DIM(data)>;                                           \
+  template double Rusanov<DIM(data)>::dg_package_data<1>(                      \
+      gsl::not_null<Scalar<DataVector>*> packaged_mass_density,                \
+      gsl::not_null<tnsr::I<DataVector, DIM(data), Frame::Inertial>*>          \
+          packaged_momentum_density,                                           \
+      gsl::not_null<Scalar<DataVector>*> packaged_energy_density,              \
+      gsl::not_null<Scalar<DataVector>*>                                       \
+          packaged_normal_dot_flux_mass_density,                               \
+      gsl::not_null<tnsr::I<DataVector, DIM(data), Frame::Inertial>*>          \
+          packaged_normal_dot_flux_momentum_density,                           \
+      gsl::not_null<Scalar<DataVector>*>                                       \
+          packaged_normal_dot_flux_energy_density,                             \
+      gsl::not_null<Scalar<DataVector>*> packaged_abs_char_speed,              \
+                                                                               \
+      const Scalar<DataVector>& mass_density,                                  \
+      const tnsr::I<DataVector, DIM(data), Frame::Inertial>& momentum_density, \
+      const Scalar<DataVector>& energy_density,                                \
+                                                                               \
+      const tnsr::I<DataVector, DIM(data), Frame::Inertial>&                   \
+          flux_mass_density,                                                   \
+      const tnsr::IJ<DataVector, DIM(data), Frame::Inertial>&                  \
+          flux_momentum_density,                                               \
+      const tnsr::I<DataVector, DIM(data), Frame::Inertial>&                   \
+          flux_energy_density,                                                 \
+                                                                               \
+      const tnsr::I<DataVector, DIM(data), Frame::Inertial>& velocity,         \
+      const Scalar<DataVector>& specific_internal_energy,                      \
+                                                                               \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& normal_covector,  \
+      const std::optional<tnsr::I<DataVector, DIM(data), Frame::Inertial>>&    \
+          mesh_velocity,                                                       \
+      const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,       \
+      const EquationsOfState::EquationOfState<false, 1>& equation_of_state)    \
+      const noexcept;                                                          \
+  template double Rusanov<DIM(data)>::dg_package_data<2>(                      \
+      gsl::not_null<Scalar<DataVector>*> packaged_mass_density,                \
+      gsl::not_null<tnsr::I<DataVector, DIM(data), Frame::Inertial>*>          \
+          packaged_momentum_density,                                           \
+      gsl::not_null<Scalar<DataVector>*> packaged_energy_density,              \
+      gsl::not_null<Scalar<DataVector>*>                                       \
+          packaged_normal_dot_flux_mass_density,                               \
+      gsl::not_null<tnsr::I<DataVector, DIM(data), Frame::Inertial>*>          \
+          packaged_normal_dot_flux_momentum_density,                           \
+      gsl::not_null<Scalar<DataVector>*>                                       \
+          packaged_normal_dot_flux_energy_density,                             \
+      gsl::not_null<Scalar<DataVector>*> packaged_abs_char_speed,              \
+                                                                               \
+      const Scalar<DataVector>& mass_density,                                  \
+      const tnsr::I<DataVector, DIM(data), Frame::Inertial>& momentum_density, \
+      const Scalar<DataVector>& energy_density,                                \
+                                                                               \
+      const tnsr::I<DataVector, DIM(data), Frame::Inertial>&                   \
+          flux_mass_density,                                                   \
+      const tnsr::IJ<DataVector, DIM(data), Frame::Inertial>&                  \
+          flux_momentum_density,                                               \
+      const tnsr::I<DataVector, DIM(data), Frame::Inertial>&                   \
+          flux_energy_density,                                                 \
+                                                                               \
+      const tnsr::I<DataVector, DIM(data), Frame::Inertial>& velocity,         \
+      const Scalar<DataVector>& specific_internal_energy,                      \
+                                                                               \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& normal_covector,  \
+      const std::optional<tnsr::I<DataVector, DIM(data), Frame::Inertial>>&    \
+          mesh_velocity,                                                       \
+      const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,       \
+      const EquationsOfState::EquationOfState<false, 2>& equation_of_state)    \
+      const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM
+}  // namespace NewtonianEuler::BoundaryCorrections
+/// \endcond

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Rusanov.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Rusanov.hpp
@@ -1,0 +1,160 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/NewtonianEuler/BoundaryCorrections/BoundaryCorrection.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace NewtonianEuler::BoundaryCorrections {
+/*!
+ * \brief A Rusanov/local Lax-Friedrichs Riemann solver
+ *
+ * Let \f$U\f$ be the state vector of evolved variables, \f$F^i\f$ the
+ * corresponding fluxes, and \f$n_i\f$ be the outward directed unit normal to
+ * the interface. Denoting \f$F := n_i F^i\f$, the %Rusanov boundary correction
+ * is
+ *
+ * \f{align*}
+ * G_\text{Rusanov} = \frac{F_\text{int} - F_\text{ext}}{2} -
+ * \frac{\text{max}\left(\{|\lambda_\text{int}|\},
+ * \{|\lambda_\text{ext}|\}\right)}{2} \left(U_\text{ext} - U_\text{int}\right),
+ * \f}
+ *
+ * where "int" and "ext" stand for interior and exterior, and
+ * \f$\{|\lambda|\}\f$ is the set of characteristic/signal speeds. The minus
+ * sign in front of the \f$F_{\text{ext}}\f$ is necessary because the outward
+ * directed normal of the neighboring element has the opposite sign, i.e.
+ * \f$n_i^{\text{ext}}=-n_i^{\text{int}}\f$. The characteristic/signal speeds
+ * are given by:
+ *
+ * \f{align*}
+ * \lambda_{\pm}&=v^i n_i \pm c_s, \\
+ * \lambda_v&=v^i n_i
+ * \f}
+ *
+ * where \f$v^i\f$ is the spatial velocity and \f$c_s\f$ the sound speed.
+ *
+ * \note In the strong form the `dg_boundary_terms` function returns
+ * \f$G - F_\text{int}\f$
+ */
+template <size_t Dim>
+class Rusanov final : public BoundaryCorrection<Dim> {
+ private:
+  struct AbsCharSpeed : db::SimpleTag {
+    using type = Scalar<DataVector>;
+  };
+
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help = {
+      "Computes the Rusanov or local Lax-Friedrichs boundary correction term "
+      "for the Newtonian Euler/hydrodynamics system."};
+
+  Rusanov() = default;
+  Rusanov(const Rusanov&) = default;
+  Rusanov& operator=(const Rusanov&) = default;
+  Rusanov(Rusanov&&) = default;
+  Rusanov& operator=(Rusanov&&) = default;
+  ~Rusanov() override = default;
+
+  /// \cond
+  explicit Rusanov(CkMigrateMessage* msg) noexcept;
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Rusanov);  // NOLINT
+  /// \endcond
+  void pup(PUP::er& p) override;  // NOLINT
+
+  std::unique_ptr<BoundaryCorrection<Dim>> get_clone() const noexcept override;
+
+  using dg_package_field_tags =
+      tmpl::list<Tags::MassDensityCons, Tags::MomentumDensity<Dim>,
+                 Tags::EnergyDensity,
+                 ::Tags::NormalDotFlux<Tags::MassDensityCons>,
+                 ::Tags::NormalDotFlux<Tags::MomentumDensity<Dim>>,
+                 ::Tags::NormalDotFlux<Tags::EnergyDensity>, AbsCharSpeed>;
+  using dg_package_data_temporary_tags = tmpl::list<>;
+  using dg_package_data_primitive_tags =
+      tmpl::list<NewtonianEuler::Tags::Velocity<DataVector, Dim>,
+                 NewtonianEuler::Tags::SpecificInternalEnergy<DataVector>>;
+  using dg_package_data_volume_tags =
+      tmpl::list<hydro::Tags::EquationOfStateBase>;
+
+  template <size_t ThermodynamicDim>
+  double dg_package_data(
+      gsl::not_null<Scalar<DataVector>*> packaged_mass_density,
+      gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+          packaged_momentum_density,
+      gsl::not_null<Scalar<DataVector>*> packaged_energy_density,
+      gsl::not_null<Scalar<DataVector>*> packaged_normal_dot_flux_mass_density,
+      gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+          packaged_normal_dot_flux_momentum_density,
+      gsl::not_null<Scalar<DataVector>*>
+          packaged_normal_dot_flux_energy_density,
+      gsl::not_null<Scalar<DataVector>*> packaged_abs_char_speed,
+
+      const Scalar<DataVector>& mass_density,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& momentum_density,
+      const Scalar<DataVector>& energy_density,
+
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& flux_mass_density,
+      const tnsr::IJ<DataVector, Dim, Frame::Inertial>& flux_momentum_density,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& flux_energy_density,
+
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& velocity,
+      const Scalar<DataVector>& specific_internal_energy,
+
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+      /*mesh_velocity*/,
+      const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,
+      const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
+          equation_of_state) const noexcept;
+
+  void dg_boundary_terms(
+      gsl::not_null<Scalar<DataVector>*> boundary_correction_mass_density,
+      gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+          boundary_correction_momentum_density,
+      gsl::not_null<Scalar<DataVector>*> boundary_correction_energy_density,
+      const Scalar<DataVector>& mass_density_int,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& momentum_density_int,
+      const Scalar<DataVector>& energy_density_int,
+      const Scalar<DataVector>& normal_dot_flux_mass_density_int,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>&
+          normal_dot_flux_momentum_density_int,
+      const Scalar<DataVector>& normal_dot_flux_energy_density_int,
+      const Scalar<DataVector>& abs_char_speed_int,
+      const Scalar<DataVector>& mass_density_ext,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& momentum_density_ext,
+      const Scalar<DataVector>& energy_density_ext,
+      const Scalar<DataVector>& normal_dot_flux_mass_density_ext,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>&
+          normal_dot_flux_momentum_density_ext,
+      const Scalar<DataVector>& normal_dot_flux_energy_density_ext,
+      const Scalar<DataVector>& abs_char_speed_ext,
+      dg::Formulation dg_formulation) const noexcept;
+};
+}  // namespace Burgers::BoundaryCorrections

--- a/src/Evolution/Systems/NewtonianEuler/CMakeLists.txt
+++ b/src/Evolution/Systems/NewtonianEuler/CMakeLists.txt
@@ -48,6 +48,7 @@ target_link_libraries(
   INTERFACE Hydro
   )
 
+add_subdirectory(BoundaryCorrections)
 add_subdirectory(Limiters)
 add_subdirectory(NumericalFluxes)
 add_subdirectory(Sources)

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Rusanov.py
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Rusanov.py
@@ -1,0 +1,153 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def dg_package_data_mass_density(
+    mass_density, momentum_density, energy_density, flux_mass_density,
+    flux_momentum_density, flux_energy_density, velocity,
+    specific_internal_energy, normal_covector, mesh_velocity,
+    normal_dot_mesh_velocity, use_polytropic_fluid):
+    return mass_density
+
+
+def dg_package_data_momentum_density(
+    mass_density, momentum_density, energy_density, flux_mass_density,
+    flux_momentum_density, flux_energy_density, velocity,
+    specific_internal_energy, normal_covector, mesh_velocity,
+    normal_dot_mesh_velocity, use_polytropic_fluid):
+    return momentum_density
+
+
+def dg_package_data_energy_density(
+    mass_density, momentum_density, energy_density, flux_mass_density,
+    flux_momentum_density, flux_energy_density, velocity,
+    specific_internal_energy, normal_covector, mesh_velocity,
+    normal_dot_mesh_velocity, use_polytropic_fluid):
+    return energy_density
+
+
+def dg_package_data_normal_dot_flux_mass_density(
+    mass_density, momentum_density, energy_density, flux_mass_density,
+    flux_momentum_density, flux_energy_density, velocity,
+    specific_internal_energy, normal_covector, mesh_velocity,
+    normal_dot_mesh_velocity, use_polytropic_fluid):
+    return np.einsum("i,i", normal_covector, flux_mass_density)
+
+
+def dg_package_data_normal_dot_flux_momentum_density(
+    mass_density, momentum_density, energy_density, flux_mass_density,
+    flux_momentum_density, flux_energy_density, velocity,
+    specific_internal_energy, normal_covector, mesh_velocity,
+    normal_dot_mesh_velocity, use_polytropic_fluid):
+    return np.einsum("i,ij->j", normal_covector, flux_momentum_density)
+
+
+def dg_package_data_normal_dot_flux_energy_density(
+    mass_density, momentum_density, energy_density, flux_mass_density,
+    flux_momentum_density, flux_energy_density, velocity,
+    specific_internal_energy, normal_covector, mesh_velocity,
+    normal_dot_mesh_velocity, use_polytropic_fluid):
+    return np.einsum("i,i", normal_covector, flux_energy_density)
+
+
+def dg_package_data_abs_char_speed(
+    mass_density, momentum_density, energy_density, flux_mass_density,
+    flux_momentum_density, flux_energy_density, velocity,
+    specific_internal_energy, normal_covector, mesh_velocity,
+    normal_dot_mesh_velocity, use_polytropic_fluid):
+    velocity_dot_normal = np.einsum("i,i", normal_covector, velocity)
+    if use_polytropic_fluid:
+        polytropic_constant = 1.0e-3
+        polytropic_exponent = 2.0
+        sound_speed = np.sqrt(polytropic_constant * polytropic_exponent *
+                              pow(mass_density, polytropic_exponent - 1.0))
+    else:
+        adiabatic_index = 1.3
+        chi = specific_internal_energy * (adiabatic_index - 1.0)
+        kappa_times_p_over_rho_squared = ((adiabatic_index - 1.0)**2 *
+                                          specific_internal_energy)
+        sound_speed = np.sqrt(chi + kappa_times_p_over_rho_squared)
+
+    if normal_dot_mesh_velocity is None:
+        return np.maximum(np.abs(velocity_dot_normal - sound_speed),
+                          np.abs(velocity_dot_normal + sound_speed))
+    else:
+        return np.maximum(
+            np.abs(velocity_dot_normal - sound_speed -
+                   normal_dot_mesh_velocity),
+            np.abs(velocity_dot_normal + sound_speed -
+                   normal_dot_mesh_velocity))
+
+
+def dg_boundary_terms_mass_density(
+    interior_mass_density, interior_momentum_density, interior_energy_density,
+    interior_normal_dot_flux_mass_density,
+    interior_normal_dot_flux_momentum_density,
+    interior_normal_dot_flux_energy_density, interior_abs_char_speed,
+    exterior_mass_density, exterior_momentum_density, exterior_energy_density,
+    exterior_normal_dot_flux_mass_density,
+    exterior_normal_dot_flux_momentum_density,
+    exterior_normal_dot_flux_energy_density, exterior_abs_char_speed,
+    use_strong_form):
+    if use_strong_form:
+        return -0.5 * (
+            interior_normal_dot_flux_mass_density +
+            exterior_normal_dot_flux_mass_density) - 0.5 * np.maximum(
+                interior_abs_char_speed, exterior_abs_char_speed) * (
+                    exterior_mass_density - interior_mass_density)
+    else:
+        return 0.5 * (
+            interior_normal_dot_flux_mass_density -
+            exterior_normal_dot_flux_mass_density) - 0.5 * np.maximum(
+                interior_abs_char_speed, exterior_abs_char_speed) * (
+                    exterior_mass_density - interior_mass_density)
+
+
+def dg_boundary_terms_momentum_density(
+    interior_mass_density, interior_momentum_density, interior_energy_density,
+    interior_normal_dot_flux_mass_density,
+    interior_normal_dot_flux_momentum_density,
+    interior_normal_dot_flux_energy_density, interior_abs_char_speed,
+    exterior_mass_density, exterior_momentum_density, exterior_energy_density,
+    exterior_normal_dot_flux_mass_density,
+    exterior_normal_dot_flux_momentum_density,
+    exterior_normal_dot_flux_energy_density, exterior_abs_char_speed,
+    use_strong_form):
+    if use_strong_form:
+        return -0.5 * (
+            interior_normal_dot_flux_momentum_density +
+            exterior_normal_dot_flux_momentum_density) - 0.5 * np.maximum(
+                interior_abs_char_speed, exterior_abs_char_speed) * (
+                    exterior_momentum_density - interior_momentum_density)
+    else:
+        return 0.5 * (
+            interior_normal_dot_flux_momentum_density -
+            exterior_normal_dot_flux_momentum_density) - 0.5 * np.maximum(
+                interior_abs_char_speed, exterior_abs_char_speed) * (
+                    exterior_momentum_density - interior_momentum_density)
+
+
+def dg_boundary_terms_energy_density(
+    interior_mass_density, interior_momentum_density, interior_energy_density,
+    interior_normal_dot_flux_mass_density,
+    interior_normal_dot_flux_momentum_density,
+    interior_normal_dot_flux_energy_density, interior_abs_char_speed,
+    exterior_mass_density, exterior_momentum_density, exterior_energy_density,
+    exterior_normal_dot_flux_mass_density,
+    exterior_normal_dot_flux_momentum_density,
+    exterior_normal_dot_flux_energy_density, exterior_abs_char_speed,
+    use_strong_form):
+    if use_strong_form:
+        return -0.5 * (
+            interior_normal_dot_flux_energy_density +
+            exterior_normal_dot_flux_energy_density) - 0.5 * np.maximum(
+                interior_abs_char_speed, exterior_abs_char_speed) * (
+                    exterior_energy_density - interior_energy_density)
+    else:
+        return 0.5 * (
+            interior_normal_dot_flux_energy_density -
+            exterior_normal_dot_flux_energy_density) - 0.5 * np.maximum(
+                interior_abs_char_speed, exterior_abs_char_speed) * (
+                    exterior_energy_density - interior_energy_density)

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Test_Rusanov.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Test_Rusanov.cpp
@@ -1,0 +1,154 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <string>
+
+#include "Evolution/Systems/NewtonianEuler/BoundaryCorrections/Factory.hpp"
+#include "Evolution/Systems/NewtonianEuler/BoundaryCorrections/Rusanov.hpp"
+#include "Evolution/Systems/NewtonianEuler/System.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+struct ConvertPolytropic {
+  using unpacked_container = bool;
+  using packed_container = EquationsOfState::PolytropicFluid<false>;
+  using packed_type = bool;
+
+  static inline unpacked_container unpack(
+      const packed_container& /*packed*/,
+      const size_t /*grid_point_index*/) noexcept {
+    return true;
+  }
+
+  [[noreturn]] static inline void pack(
+      const gsl::not_null<packed_container*> /*packed*/,
+      const unpacked_container& /*unpacked*/,
+      const size_t /*grid_point_index*/) {
+    ERROR("Should not be converting an EOS from an unpacked to a packed type");
+  }
+
+  static inline size_t get_size(const packed_container& /*packed*/) noexcept {
+    return 1;
+  }
+};
+
+struct ConvertIdeal {
+  using unpacked_container = bool;
+  using packed_container = EquationsOfState::IdealFluid<false>;
+  using packed_type = bool;
+
+  static inline unpacked_container unpack(
+      const packed_container& /*packed*/,
+      const size_t /*grid_point_index*/) noexcept {
+    return false;
+  }
+
+  [[noreturn]] static inline void pack(
+      const gsl::not_null<packed_container*> /*packed*/,
+      const unpacked_container& /*unpacked*/,
+      const size_t /*grid_point_index*/) {
+    ERROR("Should not be converting an EOS from an unpacked to a packed type");
+  }
+
+  static inline size_t get_size(const packed_container& /*packed*/) noexcept {
+    return 1;
+  }
+};
+
+struct DummyInitialData {
+  using argument_tags = tmpl::list<>;
+  struct source_term_type {
+    using sourced_variables = tmpl::list<>;
+    using argument_tags = tmpl::list<>;
+  };
+};
+
+template <size_t Dim, typename EosTag>
+void test(const size_t num_pts,
+          const tuples::TaggedTuple<EosTag>& volume_data) {
+  TestHelpers::evolution::dg::test_boundary_correction_conservation<
+      NewtonianEuler::System<Dim, typename EosTag::type, DummyInitialData>>(
+      NewtonianEuler::BoundaryCorrections::Rusanov<Dim>{},
+      Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
+                    Spectral::Quadrature::Gauss},
+      volume_data);
+
+  TestHelpers::evolution::dg::test_boundary_correction_with_python<
+      NewtonianEuler::System<Dim, typename EosTag::type, DummyInitialData>,
+      tmpl::list<ConvertPolytropic, ConvertIdeal>>(
+      "Rusanov",
+      {{"dg_package_data_mass_density", "dg_package_data_momentum_density",
+        "dg_package_data_energy_density",
+        "dg_package_data_normal_dot_flux_mass_density",
+        "dg_package_data_normal_dot_flux_momentum_density",
+        "dg_package_data_normal_dot_flux_energy_density",
+        "dg_package_data_abs_char_speed"}},
+      {{"dg_boundary_terms_mass_density", "dg_boundary_terms_momentum_density",
+        "dg_boundary_terms_energy_density"}},
+      NewtonianEuler::BoundaryCorrections::Rusanov<Dim>{},
+      Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
+                    Spectral::Quadrature::Gauss},
+      volume_data);
+
+  const auto rusanov = TestHelpers::test_factory_creation<
+      NewtonianEuler::BoundaryCorrections::BoundaryCorrection<Dim>>("Rusanov:");
+
+  TestHelpers::evolution::dg::test_boundary_correction_with_python<
+      NewtonianEuler::System<Dim, typename EosTag::type, DummyInitialData>,
+      tmpl::list<ConvertPolytropic, ConvertIdeal>>(
+      "Rusanov",
+      {{"dg_package_data_mass_density", "dg_package_data_momentum_density",
+        "dg_package_data_energy_density",
+        "dg_package_data_normal_dot_flux_mass_density",
+        "dg_package_data_normal_dot_flux_momentum_density",
+        "dg_package_data_normal_dot_flux_energy_density",
+        "dg_package_data_abs_char_speed"}},
+      {{"dg_boundary_terms_mass_density", "dg_boundary_terms_momentum_density",
+        "dg_boundary_terms_energy_density"}},
+      dynamic_cast<const NewtonianEuler::BoundaryCorrections::Rusanov<Dim>&>(
+          *rusanov),
+      Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
+                    Spectral::Quadrature::Gauss},
+      volume_data);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.NewtonianEuler.Rusanov", "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/NewtonianEuler/BoundaryCorrections"};
+  test<1>(1, tuples::TaggedTuple<hydro::Tags::EquationOfState<
+                 EquationsOfState::PolytropicFluid<false>>>{
+                 EquationsOfState::PolytropicFluid<false>{1.0e-3, 2.0}});
+  test<2>(5, tuples::TaggedTuple<hydro::Tags::EquationOfState<
+                 EquationsOfState::PolytropicFluid<false>>>{
+                 EquationsOfState::PolytropicFluid<false>{1.0e-3, 2.0}});
+  test<3>(5, tuples::TaggedTuple<hydro::Tags::EquationOfState<
+                 EquationsOfState::PolytropicFluid<false>>>{
+                 EquationsOfState::PolytropicFluid<false>{1.0e-3, 2.0}});
+
+  test<1>(
+      1, tuples::TaggedTuple<
+             hydro::Tags::EquationOfState<EquationsOfState::IdealFluid<false>>>{
+             EquationsOfState::IdealFluid<false>{1.3}});
+  test<2>(
+      5, tuples::TaggedTuple<
+             hydro::Tags::EquationOfState<EquationsOfState::IdealFluid<false>>>{
+             EquationsOfState::IdealFluid<false>{1.3}});
+  test<3>(
+      5, tuples::TaggedTuple<
+             hydro::Tags::EquationOfState<EquationsOfState::IdealFluid<false>>>{
+             EquationsOfState::IdealFluid<false>{1.3}});
+}

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_NewtonianEuler")
 
 set(LIBRARY_SOURCES
+  BoundaryCorrections/Test_Rusanov.cpp
   Test_Characteristics.cpp
   Test_ConservativeFromPrimitive.cpp
   Test_Fluxes.cpp


### PR DESCRIPTION
## Proposed changes

Adds a Rusanov solver for Newtonian Euler, but implemented in the new boundary corrections framework.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
