### PR TITLE
Add upwind penalty boundary correction for scalar wave

### DIFF
--- a/src/Evolution/Systems/ScalarWave/BoundaryCorrections/BoundaryCorrection.hpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryCorrections/BoundaryCorrection.hpp
@@ -1,0 +1,44 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <pup.h>
+
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// Boundary corrections/numerical fluxes
+namespace ScalarWave::BoundaryCorrections {
+/// \cond
+template <size_t Dim>
+class UpwindPenalty;
+/// \endcond
+
+/*!
+ * \brief The base class used to make boundary corrections factory createable so
+ * they can be specified in the input file.
+ */
+template <size_t Dim>
+class BoundaryCorrection : public PUP::able {
+ public:
+  BoundaryCorrection() = default;
+  BoundaryCorrection(const BoundaryCorrection&) = default;
+  BoundaryCorrection& operator=(const BoundaryCorrection&) = default;
+  BoundaryCorrection(BoundaryCorrection&&) = default;
+  BoundaryCorrection& operator=(BoundaryCorrection&&) = default;
+  ~BoundaryCorrection() override = default;
+
+  /// \cond
+  explicit BoundaryCorrection(CkMigrateMessage* msg) noexcept
+      : PUP::able(msg) {}
+  WRAPPED_PUPable_abstract(BoundaryCorrection<Dim>);  // NOLINT
+  /// \endcond
+
+  using creatable_classes = tmpl::list<UpwindPenalty<Dim>>;
+
+  virtual std::unique_ptr<BoundaryCorrection<Dim>> get_clone()
+      const noexcept = 0;
+};
+}  // namespace ScalarWave::BoundaryCorrections

--- a/src/Evolution/Systems/ScalarWave/BoundaryCorrections/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarWave/BoundaryCorrections/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_sources(
+  ScalarWave
+  PRIVATE
+  RegisterDerived.cpp
+  UpwindPenalty.cpp
+  )
+
+spectre_target_headers(
+  ScalarWave
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  BoundaryCorrection.hpp
+  Factory.hpp
+  RegisterDerived.hpp
+  UpwindPenalty.hpp
+  )

--- a/src/Evolution/Systems/ScalarWave/BoundaryCorrections/Factory.hpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryCorrections/Factory.hpp
@@ -1,0 +1,7 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/Systems/ScalarWave/BoundaryCorrections/BoundaryCorrection.hpp"
+#include "Evolution/Systems/ScalarWave/BoundaryCorrections/UpwindPenalty.hpp"

--- a/src/Evolution/Systems/ScalarWave/BoundaryCorrections/RegisterDerived.cpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryCorrections/RegisterDerived.cpp
@@ -1,0 +1,13 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarWave/BoundaryCorrections/Factory.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+
+namespace ScalarWave::BoundaryCorrections {
+void register_derived_with_charm() noexcept {
+  Parallel::register_derived_classes_with_charm<BoundaryCorrection<1>>();
+  Parallel::register_derived_classes_with_charm<BoundaryCorrection<2>>();
+  Parallel::register_derived_classes_with_charm<BoundaryCorrection<3>>();
+}
+}  // namespace ScalarWave::BoundaryCorrections

--- a/src/Evolution/Systems/ScalarWave/BoundaryCorrections/RegisterDerived.hpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryCorrections/RegisterDerived.hpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace ScalarWave::BoundaryCorrections {
+void register_derived_with_charm() noexcept;
+}  // namespace ScalarWave::BoundaryCorrections

--- a/src/Evolution/Systems/ScalarWave/BoundaryCorrections/UpwindPenalty.cpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryCorrections/UpwindPenalty.cpp
@@ -1,0 +1,223 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarWave/BoundaryCorrections/UpwindPenalty.hpp"
+
+#include <memory>
+#include <optional>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"  // IWYU pragma: keep
+
+/// \cond
+namespace ScalarWave::BoundaryCorrections {
+template <size_t Dim>
+UpwindPenalty<Dim>::UpwindPenalty(CkMigrateMessage* msg) noexcept
+    : BoundaryCorrection<Dim>(msg) {}
+
+template <size_t Dim>
+std::unique_ptr<BoundaryCorrection<Dim>> UpwindPenalty<Dim>::get_clone()
+    const noexcept {
+  return std::make_unique<UpwindPenalty>(*this);
+}
+
+template <size_t Dim>
+void UpwindPenalty<Dim>::pup(PUP::er& p) {
+  BoundaryCorrection<Dim>::pup(p);
+}
+
+template <size_t Dim>
+double UpwindPenalty<Dim>::dg_package_data(
+    const gsl::not_null<Scalar<DataVector>*> packaged_char_speed_v_psi,
+    const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+        packaged_char_speed_v_zero,
+    const gsl::not_null<Scalar<DataVector>*> packaged_char_speed_v_plus,
+    const gsl::not_null<Scalar<DataVector>*> packaged_char_speed_v_minus,
+    const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+        packaged_char_speed_n_times_v_plus,
+    const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+        packaged_char_speed_n_times_v_minus,
+    const gsl::not_null<Scalar<DataVector>*> packaged_char_speed_gamma2_v_psi,
+    const gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*>
+        packaged_char_speeds,
+
+    const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
+    const Scalar<DataVector>& psi,
+
+    const Scalar<DataVector>& constraint_gamma2,
+
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+    const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+    /*mesh_velocity*/,
+    const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity)
+    const noexcept {
+  if (normal_dot_mesh_velocity.has_value()) {
+    get<0>(*packaged_char_speeds) = -get(*normal_dot_mesh_velocity);
+    get<1>(*packaged_char_speeds) = 1.0 - get(*normal_dot_mesh_velocity);
+    get<2>(*packaged_char_speeds) = -1.0 - get(*normal_dot_mesh_velocity);
+  } else {
+    get<0>(*packaged_char_speeds) = 0.0;
+    get<1>(*packaged_char_speeds) = 1.0;
+    get<2>(*packaged_char_speeds) = -1.0;
+  }
+
+  // Computes the contribution to the boundary correction from one side of the
+  // interface.
+  //
+  // Note: when UpwindPenalty::dg_boundary_terms() is called, an Element passes
+  // in its own packaged data to fill the interior fields, and its neighbor's
+  // packaged data to fill the exterior fields. This introduces a sign flip for
+  // each normal used in computing the exterior fields.
+  get(*packaged_char_speed_gamma2_v_psi) = get(constraint_gamma2) * get(psi);
+  {
+    // Use v_psi allocation as n^i Phi_i
+    dot_product(packaged_char_speed_v_psi, normal_covector, phi);
+    const auto& normal_dot_phi = get(*packaged_char_speed_v_psi);
+
+    for (size_t i = 0; i < Dim; ++i) {
+      packaged_char_speed_v_zero->get(i) =
+          get<0>(*packaged_char_speeds) *
+          (phi.get(i) - normal_covector.get(i) * normal_dot_phi);
+    }
+
+    get(*packaged_char_speed_v_plus) =
+        get<1>(*packaged_char_speeds) *
+        (get(pi) + normal_dot_phi - get(*packaged_char_speed_gamma2_v_psi));
+    get(*packaged_char_speed_v_minus) =
+        get<2>(*packaged_char_speeds) *
+        (get(pi) - normal_dot_phi - get(*packaged_char_speed_gamma2_v_psi));
+  }
+
+  for (size_t d = 0; d < Dim; ++d) {
+    packaged_char_speed_n_times_v_plus->get(d) =
+        get(*packaged_char_speed_v_plus) * normal_covector.get(d);
+    packaged_char_speed_n_times_v_minus->get(d) =
+        get(*packaged_char_speed_v_minus) * normal_covector.get(d);
+  }
+
+  get(*packaged_char_speed_v_psi) = get<0>(*packaged_char_speeds) * get(psi);
+  get(*packaged_char_speed_gamma2_v_psi) *= get<0>(*packaged_char_speeds);
+
+  return max(max(get<0>(*packaged_char_speeds), get<1>(*packaged_char_speeds),
+                 get<2>(*packaged_char_speeds)));
+}
+
+template <size_t Dim>
+void UpwindPenalty<Dim>::dg_boundary_terms(
+    const gsl::not_null<Scalar<DataVector>*> pi_boundary_correction,
+    const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+        phi_boundary_correction,
+    const gsl::not_null<Scalar<DataVector>*> psi_boundary_correction,
+
+    const Scalar<DataVector>& char_speed_v_psi_int,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& char_speed_v_zero_int,
+    const Scalar<DataVector>& char_speed_v_plus_int,
+    const Scalar<DataVector>& char_speed_v_minus_int,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>&
+        char_speed_normal_times_v_plus_int,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>&
+        char_speed_normal_times_v_minus_int,
+    const Scalar<DataVector>& char_speed_constraint_gamma2_v_psi_int,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& char_speeds_int,
+
+    const Scalar<DataVector>& char_speed_v_psi_ext,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& char_speed_v_zero_ext,
+    const Scalar<DataVector>& char_speed_v_plus_ext,
+    const Scalar<DataVector>& char_speed_v_minus_ext,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>&
+        char_speed_minus_normal_times_v_plus_ext,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>&
+        char_speed_minus_normal_times_v_minus_ext,
+    const Scalar<DataVector>& char_speed_constraint_gamma2_v_psi_ext,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& char_speeds_ext,
+    dg::Formulation /*dg_formulation*/) const noexcept {
+  const size_t num_pts = char_speeds_int[0].size();
+  Variables<tmpl::list<::Tags::TempScalar<0>, ::Tags::TempScalar<1>,
+                       ::Tags::TempScalar<2>, ::Tags::TempScalar<3>,
+                       ::Tags::TempScalar<4>, ::Tags::TempScalar<5>,
+                       ::Tags::TempScalar<6>, ::Tags::TempScalar<7>>>
+      buffer(num_pts);
+  DataVector& weighted_lambda_psi_int = get(get<::Tags::TempScalar<0>>(buffer));
+  weighted_lambda_psi_int = step_function(-char_speeds_int[0]);
+  DataVector& weighted_lambda_psi_ext = get(get<::Tags::TempScalar<1>>(buffer));
+  weighted_lambda_psi_ext = -step_function(char_speeds_ext[0]);
+
+  DataVector& weighted_lambda_zero_int =
+      get(get<::Tags::TempScalar<2>>(buffer));
+  weighted_lambda_zero_int = step_function(-char_speeds_int[0]);
+  DataVector& weighted_lambda_zero_ext =
+      get(get<::Tags::TempScalar<3>>(buffer));
+  weighted_lambda_zero_ext = -step_function(char_speeds_ext[0]);
+
+  DataVector& weighted_lambda_plus_int =
+      get(get<::Tags::TempScalar<4>>(buffer));
+  weighted_lambda_plus_int = step_function(-char_speeds_int[1]);
+  DataVector& weighted_lambda_plus_ext =
+      get(get<::Tags::TempScalar<5>>(buffer));
+  weighted_lambda_plus_ext = -step_function(char_speeds_ext[1]);
+
+  DataVector& weighted_lambda_minus_int =
+      get(get<::Tags::TempScalar<6>>(buffer));
+  weighted_lambda_minus_int = step_function(-char_speeds_int[2]);
+  DataVector& weighted_lambda_minus_ext =
+      get(get<::Tags::TempScalar<7>>(buffer));
+  weighted_lambda_minus_ext = -step_function(char_speeds_ext[2]);
+
+  // D_psi = Theta(-lambda_psi^{ext}) lambda_psi^{ext} v_psi^{ext}
+  //       - Theta(-lambda_psi^{int}) lambda_psi^{int} v_psi^{int}
+  // where the unit normals on both sides point in the same direction, out
+  // of the current element. Since lambda_psi from the neighbor is computing
+  // with the normal vector pointing into the current element in the code,
+  // we need to swap the sign of lambda_psi^{ext}. Theta is the heaviside step
+  // function.
+  psi_boundary_correction->get() =
+      weighted_lambda_psi_ext * get(char_speed_v_psi_ext) -
+      weighted_lambda_psi_int * get(char_speed_v_psi_int);
+
+  get(*pi_boundary_correction) =
+      0.5 * (weighted_lambda_plus_ext * get(char_speed_v_plus_ext) +
+             weighted_lambda_minus_ext * get(char_speed_v_minus_ext)) +
+      weighted_lambda_psi_ext * get(char_speed_constraint_gamma2_v_psi_ext)
+
+      - 0.5 * (weighted_lambda_plus_int * get(char_speed_v_plus_int) +
+               weighted_lambda_minus_int * get(char_speed_v_minus_int)) -
+      weighted_lambda_psi_int * get(char_speed_constraint_gamma2_v_psi_int);
+
+  for (size_t d = 0; d < Dim; ++d) {
+    phi_boundary_correction->get(d) =
+        0.5 * (weighted_lambda_plus_ext *
+                   char_speed_minus_normal_times_v_plus_ext.get(d) -
+               weighted_lambda_minus_ext *
+                   char_speed_minus_normal_times_v_minus_ext.get(d)) +
+        weighted_lambda_zero_ext * char_speed_v_zero_ext.get(d)
+
+        - 0.5 * (weighted_lambda_plus_int *
+                     char_speed_normal_times_v_plus_int.get(d) -
+                 weighted_lambda_minus_int *
+                     char_speed_normal_times_v_minus_int.get(d)) -
+        weighted_lambda_zero_int * char_speed_v_zero_int.get(d);
+  }
+}
+
+template <size_t Dim>
+// NOLINTNEXTLINE
+PUP::able::PUP_ID UpwindPenalty<Dim>::my_PUP_ID = 0;
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(_, data) template class UpwindPenalty<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM
+}  // namespace ScalarWave::BoundaryCorrections
+/// \endcond

--- a/src/Evolution/Systems/ScalarWave/BoundaryCorrections/UpwindPenalty.hpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryCorrections/UpwindPenalty.hpp
@@ -1,0 +1,273 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/ScalarWave/BoundaryCorrections/BoundaryCorrection.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace ScalarWave::BoundaryCorrections {
+/*!
+ * \brief Computes the scalar wave upwind multipenalty boundary
+ * correction.
+ *
+ * This implements the upwind multipenalty boundary correction term
+ * \f$D_\beta\f$. The general form is given by:
+ *
+ * \f{align*}{
+ *   D_\beta =
+ *   T_{\beta\hat{\beta}}^{\mathrm{ext}}
+ *   \Lambda^{\mathrm{ext},-}_{\hat{\beta}\hat{\alpha}}
+ *   v^{\mathrm{ext}}_{\hat{\alpha}}
+ *   -T_{\beta\hat{\beta}}^{\mathrm{int}}
+ *   \Lambda^{\mathrm{int},-}_{\hat{\beta}\hat{\alpha}}
+ *   v^{\mathrm{int}}_{\hat{\alpha}}.
+ * \f}
+ *
+ * We denote the evolved fields by \f$u_{\alpha}\f$, the characteristic fields
+ * by \f$v_{\hat{\alpha}}\f$, and implicitly sum over reapeated indices.
+ * \f$T_{\beta\hat{\beta}}\f$ transforms characteristic fields to evolved
+ * fields, while \f$\Lambda_{\hat{\beta}\hat{\alpha}}^-\f$ is a diagonal matrix
+ * with only the negative characteristic speeds, and has zeros on the diagonal
+ * for all other entries. The int and ext superscripts denote quantities on the
+ * internal and external side of the mortar. Note that Eq. (6.3) of
+ * \cite Teukolsky2015ega is not exactly what's implemented since that boundary
+ * term does not consistently treat both sides of the interface on the same
+ * footing.
+ *
+ * For the scalar wave system the correction is:
+ *
+ * \f{align}{
+ *   D_{\Psi} &= \lambda_{v^{\Psi}}^{\mathrm{ext},-}
+ *                v^{\mathrm{ext},\Psi}
+ *                - \lambda_{v^{\Psi}}^{\mathrm{int},-}
+ *                v^{\mathrm{int},\Psi}, \\
+ *   D_{\Pi} &= \frac{1}{2}\left(\lambda_{v^+}^{\mathrm{ext},-}
+ *             v^{\mathrm{ext},+} +
+ *             \lambda_{v^-}^{\mathrm{ext},-}
+ *             v^{\mathrm{ext},-}\right)
+ *             + \lambda_{v^\Psi}^{\mathrm{ext},-}\gamma_2
+ *             v^{\mathrm{ext},\Psi}
+ *             \notag \\
+ *           &-\frac{1}{2}\left(\lambda_{v^+}^{\mathrm{int},-}
+ *             v^{\mathrm{int},+} +
+ *             \lambda_{v^-}^{\mathrm{int},-}
+ *             v^{\mathrm{int},-}\right)
+ *             - \lambda_{v^\Psi}^{\mathrm{int},-}\gamma_2
+ *             v^{\mathrm{int},\Psi} , \\
+ *   D_{\Phi_{i}}
+ *              &= \frac{1}{2}\left(\lambda_{v^+}^{\mathrm{ext},-}
+ *                v^{\mathrm{ext},+}
+ *                - \lambda_{v^-}^{\mathrm{ext},-}
+ *                v^{\mathrm{ext},-}\right)n_i^{\mathrm{ext}}
+ *                + \lambda_{v^0}^{\mathrm{ext},-}
+ *                v^{\mathrm{ext},0}_{i}
+ *                \notag \\
+ *              &-
+ *                \frac{1}{2}\left(\lambda_{v^+}^{\mathrm{int},-}
+ *                v^{\mathrm{int},+}
+ *                - \lambda_{v^-}^{\mathrm{int},-}
+ *                v^{\mathrm{int},-}\right)n_i^{\mathrm{int}}
+ *                - \lambda_{v^0}^{\mathrm{int},-}
+ *                v^{\mathrm{int},0}_{i},
+ * \f}
+ *
+ * with characteristic fields
+ *
+ * \f{align}{
+ *   v^{\Psi} &= \Psi, \\
+ *   v^{0}_{i} &= (\delta^k_i-n^k n_i)\Phi_{k}, \\
+ *   v^{\pm} &= \Pi\pm n^i\Phi_{i} -\gamma_2 \Psi,
+ * \f}
+ *
+ * and characteristic speeds
+ *
+ * \f{align}{
+ *   \lambda_{v^\Psi} =& -v^i_g n_i, \\
+ *   \lambda_{v^0} =& -v^i_g n_i, \\
+ *   \lambda_{v^\pm} =& \pm 1 - v^i_g n_i,
+ * \f}
+ *
+ * where \f$v_g^i\f$ is the mesh velocity and \f$n_i\f$ is the outward directed
+ * unit normal covector to the interface. We have also defined
+ *
+ * \f{align}{
+ *   \lambda^{\pm}_{\hat{\alpha}} =
+ *    \left\{
+ *        \begin{array}{ll}
+ *          \lambda_{\hat{\alpha}} &
+ *            \mathrm{if}\;\pm\lambda_{\hat{\alpha}}> 0 \\
+ *          0 & \mathrm{otherwise}
+ *        \end{array}\right.
+ * \f}
+ *
+ * In the implementation we store the speeds in a rank-3 tensor with the zeroth
+ * component being \f$\lambda_{v^\Psi}\f$, the first being \f$\lambda_{v^+}\f$
+ * and the second being \f$\lambda_{v^-}\f$.
+ *
+ * Note that we have assumed \f$n_i^{\mathrm{ext}}\f$ points in the same
+ * direction as \f$n_i^{\mathrm{int}}\f$, but in the code they point in opposite
+ * directions. If \f$n_i^{\mathrm{ext}}\f$ points in the opposite direction the
+ * external speeds have their sign flipped and the \f$\pm\f$ fields and their
+ * speeds reverse roles (i.e. the \f$v^{\mathrm{ext},+}\f$ field is now flowing
+ * into the element, while \f$v^{\mathrm{ext},-}\f$ flows out). In our
+ * implementation this reversal actually cancels out, and we have the following
+ * equations:
+ *
+ * \f{align}{
+ *   D_{\Psi} &= -\lambda_{v^{\Psi}}^{\mathrm{ext},+}
+ *                v^{\mathrm{ext},\Psi}
+ *                - \lambda_{v^{\Psi}}^{\mathrm{int},-}
+ *                v^{\mathrm{int},\Psi}, \\
+ *   D_{\Pi}
+ *              &= \frac{1}{2}\left(-\lambda_{v^+}^{\mathrm{ext},+}
+ *                v^{\mathrm{ext},+} -
+ *                \lambda_{v^-}^{\mathrm{ext},+}
+ *                v^{\mathrm{ext},-}\right)
+ *                - \lambda_{v^\Psi}^{\mathrm{ext},+}\gamma_2
+ *                v^{\mathrm{ext},\Psi}
+ *                \notag \\
+ *              &-\frac{1}{2}\left(\lambda_{v^+}^{\mathrm{int},-}
+ *                v^{\mathrm{int},+} +
+ *                \lambda_{v^-}^{\mathrm{int},-}
+ *                v^{\mathrm{int},-}\right)
+ *                - \lambda_{v^\Psi}^{\mathrm{int},-}\gamma_2
+ *                v^{\mathrm{int},\Psi} , \\
+ *   D_{\Phi_{i}}
+ *              &= \frac{1}{2}\left(-\lambda_{v^+}^{\mathrm{ext},+}
+ *                v^{\mathrm{ext},+}
+ *                + \lambda_{v^-}^{\mathrm{ext},+}
+ *                v^{\mathrm{ext},-}\right)n_i^{\mathrm{ext}}
+ *                - \lambda_{v^0}^{\mathrm{ext},+}
+ *                v^{\mathrm{ext},0}_{i}
+ *                \notag \\
+ *              &-
+ *                \frac{1}{2}\left(\lambda_{v^+}^{\mathrm{int},-}
+ *                v^{\mathrm{int},+}
+ *                - \lambda_{v^-}^{\mathrm{int},-}
+ *                v^{\mathrm{int},-}\right)n_i^{\mathrm{int}}
+ *                - \lambda_{v^0}^{\mathrm{int},-}
+ *                v^{\mathrm{int},0}_{i},
+ * \f}
+ */
+template <size_t Dim>
+class UpwindPenalty final : public BoundaryCorrection<Dim> {
+ private:
+  struct NormalTimesVPlus : db::SimpleTag {
+    using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
+  };
+  struct NormalTimesVMinus : db::SimpleTag {
+    using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
+  };
+  struct Gamma2VPsi : db::SimpleTag {
+    using type = Scalar<DataVector>;
+  };
+  struct CharSpeedsTensor : db::SimpleTag {
+    using type = tnsr::i<DataVector, 3, Frame::Inertial>;
+  };
+
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help = {
+      "Computes the UpwindPenalty boundary correction term for the scalar wave "
+      "system."};
+
+  UpwindPenalty() = default;
+  UpwindPenalty(const UpwindPenalty&) = default;
+  UpwindPenalty& operator=(const UpwindPenalty&) = default;
+  UpwindPenalty(UpwindPenalty&&) = default;
+  UpwindPenalty& operator=(UpwindPenalty&&) = default;
+  ~UpwindPenalty() override = default;
+
+  /// \cond
+  explicit UpwindPenalty(CkMigrateMessage* msg) noexcept;
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(UpwindPenalty);  // NOLINT
+  /// \endcond
+  void pup(PUP::er& p) override;  // NOLINT
+
+  std::unique_ptr<BoundaryCorrection<Dim>> get_clone() const noexcept override;
+
+  using dg_package_field_tags =
+      tmpl::list<Tags::VPsi, Tags::VZero<Dim>, Tags::VPlus, Tags::VMinus,
+                 NormalTimesVPlus, NormalTimesVMinus, Gamma2VPsi,
+                 CharSpeedsTensor>;
+  using dg_package_data_temporary_tags = tmpl::list<Tags::ConstraintGamma2>;
+  using dg_package_data_volume_tags = tmpl::list<>;
+
+  double dg_package_data(
+      gsl::not_null<Scalar<DataVector>*> packaged_char_speed_v_psi,
+      gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+          packaged_char_speed_v_zero,
+      gsl::not_null<Scalar<DataVector>*> packaged_char_speed_v_plus,
+      gsl::not_null<Scalar<DataVector>*> packaged_char_speed_v_minus,
+      gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+          packaged_char_speed_n_times_v_plus,
+      gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+          packaged_char_speed_n_times_v_minus,
+      gsl::not_null<Scalar<DataVector>*> packaged_char_speed_gamma2_v_psi,
+      gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*>
+          packaged_char_speeds,
+
+      const Scalar<DataVector>& pi,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
+      const Scalar<DataVector>& psi,
+
+      const Scalar<DataVector>& constraint_gamma2,
+
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+      /*mesh_velocity*/,
+      const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity)
+      const noexcept;
+
+  void dg_boundary_terms(
+      gsl::not_null<Scalar<DataVector>*> pi_boundary_correction,
+      gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+          phi_boundary_correction,
+      gsl::not_null<Scalar<DataVector>*> psi_boundary_correction,
+
+      const Scalar<DataVector>& char_speed_v_psi_int,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& char_speed_v_zero_int,
+      const Scalar<DataVector>& char_speed_v_plus_int,
+      const Scalar<DataVector>& char_speed_v_minus_int,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>&
+          char_speed_normal_times_v_plus_int,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>&
+          char_speed_normal_times_v_minus_int,
+      const Scalar<DataVector>& char_speed_constraint_gamma2_v_psi_int,
+      const tnsr::i<DataVector, 3, Frame::Inertial>& char_speeds_int,
+
+      const Scalar<DataVector>& char_speed_v_psi_ext,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& char_speed_v_zero_ext,
+      const Scalar<DataVector>& char_speed_v_plus_ext,
+      const Scalar<DataVector>& char_speed_v_minus_ext,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>&
+          char_speed_minus_normal_times_v_plus_ext,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>&
+          char_speed_minus_normal_times_v_minus_ext,
+      const Scalar<DataVector>& char_speed_constraint_gamma2_v_psi_ext,
+      const tnsr::i<DataVector, 3, Frame::Inertial>& char_speeds_ext,
+      dg::Formulation /*dg_formulation*/) const noexcept;
+};
+}  // namespace ScalarWave::BoundaryCorrections

--- a/src/Evolution/Systems/ScalarWave/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarWave/CMakeLists.txt
@@ -37,3 +37,5 @@ target_link_libraries(
   ErrorHandling
   Options
   )
+
+add_subdirectory(BoundaryCorrections)

--- a/src/Evolution/Systems/ScalarWave/TimeDerivative.hpp
+++ b/src/Evolution/Systems/ScalarWave/TimeDerivative.hpp
@@ -24,7 +24,7 @@ namespace ScalarWave {
  */
 template <size_t Dim>
 struct TimeDerivative {
-  using temporary_tags = tmpl::list<>;
+  using temporary_tags = tmpl::list<Tags::ConstraintGamma2>;
   using argument_tags = tmpl::list<Pi, Phi<Dim>, Tags::ConstraintGamma2>;
 
   static void apply(
@@ -33,6 +33,8 @@ struct TimeDerivative {
       gsl::not_null<Scalar<DataVector>*> dt_pi,
       gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> dt_phi,
       gsl::not_null<Scalar<DataVector>*> dt_psi,
+
+      gsl::not_null<Scalar<DataVector>*> result_gamma2,
 
       // Partial derivative arguments. Listed in the system struct as
       // gradient_variables.

--- a/tests/Unit/Evolution/Systems/ScalarWave/BoundaryCorrections/Test_UpwindPenalty.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/BoundaryCorrections/Test_UpwindPenalty.cpp
@@ -1,0 +1,78 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <pup.h>
+#include <string>
+
+#include "Evolution/Systems/ScalarWave/BoundaryCorrections/Factory.hpp"
+#include "Evolution/Systems/ScalarWave/BoundaryCorrections/UpwindPenalty.hpp"
+#include "Evolution/Systems/ScalarWave/System.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+
+namespace {
+template <size_t Dim>
+void test(const size_t num_pts) {
+  PUPable_reg(ScalarWave::BoundaryCorrections::UpwindPenalty<Dim>);
+  TestHelpers::evolution::dg::test_boundary_correction_conservation<
+      ScalarWave::System<Dim>>(
+      ScalarWave::BoundaryCorrections::UpwindPenalty<Dim>{},
+      Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
+                    Spectral::Quadrature::Gauss},
+      {});
+
+  TestHelpers::evolution::dg::test_boundary_correction_with_python<
+      ScalarWave::System<Dim>>(
+      "UpwindPenalty",
+      {{"dg_package_data_char_speed_v_psi", "dg_package_data_char_speed_v_zero",
+        "dg_package_data_char_speed_v_plus",
+        "dg_package_data_char_speed_v_minus",
+        "dg_package_data_char_speed_v_plus_times_normal",
+        "dg_package_data_char_speed_v_minus_times_normal",
+        "dg_package_data_char_speed_gamma2_v_psi",
+        "dg_package_data_char_speeds"}},
+      {{"dg_boundary_terms_pi", "dg_boundary_terms_phi",
+        "dg_boundary_terms_psi"}},
+      ScalarWave::BoundaryCorrections::UpwindPenalty<Dim>{},
+      Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
+                    Spectral::Quadrature::Gauss},
+      {});
+
+  const auto upwind_penalty = TestHelpers::test_factory_creation<
+      ScalarWave::BoundaryCorrections::BoundaryCorrection<Dim>>(
+      "UpwindPenalty:");
+
+  TestHelpers::evolution::dg::test_boundary_correction_with_python<
+      ScalarWave::System<Dim>>(
+      "UpwindPenalty",
+      {{"dg_package_data_char_speed_v_psi", "dg_package_data_char_speed_v_zero",
+        "dg_package_data_char_speed_v_plus",
+        "dg_package_data_char_speed_v_minus",
+        "dg_package_data_char_speed_v_plus_times_normal",
+        "dg_package_data_char_speed_v_minus_times_normal",
+        "dg_package_data_char_speed_gamma2_v_psi",
+        "dg_package_data_char_speeds"}},
+      {{"dg_boundary_terms_pi", "dg_boundary_terms_phi",
+        "dg_boundary_terms_psi"}},
+      dynamic_cast<const ScalarWave::BoundaryCorrections::UpwindPenalty<Dim>&>(
+          *upwind_penalty),
+      Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
+                    Spectral::Quadrature::Gauss},
+      {});
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ScalarWave.UpwindPenalty", "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/ScalarWave/BoundaryCorrections"};
+  test<1>(1);
+  test<2>(5);
+  test<3>(5);
+}

--- a/tests/Unit/Evolution/Systems/ScalarWave/BoundaryCorrections/UpwindPenalty.py
+++ b/tests/Unit/Evolution/Systems/ScalarWave/BoundaryCorrections/UpwindPenalty.py
@@ -1,0 +1,163 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def dg_package_data_char_speed_v_psi(pi, phi, psi, constraint_gamma2,
+                                     normal_covector, mesh_velocity,
+                                     normal_dot_mesh_velocity):
+    if normal_dot_mesh_velocity is None:
+        return 0.0 * psi
+    else:
+        return -normal_dot_mesh_velocity * psi
+
+
+def dg_package_data_char_speed_v_zero(pi, phi, psi, constraint_gamma2,
+                                      normal_covector, mesh_velocity,
+                                      normal_dot_mesh_velocity):
+    if normal_dot_mesh_velocity is None:
+        return 0.0 * phi
+    else:
+        normal_dot_phi = np.dot(phi, normal_covector)
+        result = phi
+        for i in range(len(phi)):
+            result[i] -= normal_covector[i] * normal_dot_phi
+        char_speed = -normal_dot_mesh_velocity
+        result *= char_speed
+        return result
+
+
+def dg_package_data_char_speed_v_plus(pi, phi, psi, constraint_gamma2,
+                                      normal_covector, mesh_velocity,
+                                      normal_dot_mesh_velocity):
+    result = pi + np.dot(phi, normal_covector) - constraint_gamma2 * psi
+    result *= (1.0 if normal_dot_mesh_velocity is None else 1.0 -
+               normal_dot_mesh_velocity)
+    return result
+
+
+def dg_package_data_char_speed_v_minus(pi, phi, psi, constraint_gamma2,
+                                       normal_covector, mesh_velocity,
+                                       normal_dot_mesh_velocity):
+    result = pi - np.dot(phi, normal_covector) - constraint_gamma2 * psi
+    result *= (-1.0 if normal_dot_mesh_velocity is None else -1.0 -
+               normal_dot_mesh_velocity)
+    return result
+
+
+def dg_package_data_char_speed_v_plus_times_normal(pi, phi, psi,
+                                                   constraint_gamma2,
+                                                   normal_covector,
+                                                   mesh_velocity,
+                                                   normal_dot_mesh_velocity):
+    return normal_covector * dg_package_data_char_speed_v_plus(
+        pi, phi, psi, constraint_gamma2, normal_covector, mesh_velocity,
+        normal_dot_mesh_velocity)
+
+
+def dg_package_data_char_speed_v_minus_times_normal(pi, phi, psi,
+                                                    constraint_gamma2,
+                                                    normal_covector,
+                                                    mesh_velocity,
+                                                    normal_dot_mesh_velocity):
+    return normal_covector * dg_package_data_char_speed_v_minus(
+        pi, phi, psi, constraint_gamma2, normal_covector, mesh_velocity,
+        normal_dot_mesh_velocity)
+
+
+def dg_package_data_char_speed_gamma2_v_psi(pi, phi, psi, constraint_gamma2,
+                                            normal_covector, mesh_velocity,
+                                            normal_dot_mesh_velocity):
+    if normal_dot_mesh_velocity is None:
+        return 0.0 * psi * constraint_gamma2
+    else:
+        return -normal_dot_mesh_velocity * psi * constraint_gamma2
+
+
+def dg_package_data_char_speeds(pi, phi, psi, constraint_gamma2,
+                                normal_covector, mesh_velocity,
+                                normal_dot_mesh_velocity):
+    result = np.zeros([3])
+    result[0] = (0.0 if normal_dot_mesh_velocity is None else
+                 -normal_dot_mesh_velocity)
+    result[1] = (1.0 if normal_dot_mesh_velocity is None else 1.0 -
+                 normal_dot_mesh_velocity)
+    result[2] = (-1.0 if normal_dot_mesh_velocity is None else -1.0 -
+                 normal_dot_mesh_velocity)
+    return result
+
+
+def dg_boundary_terms_pi(
+    int_char_speed_v_psi, int_char_speed_v_zero, int_char_speed_v_plus,
+    int_char_speed_v_minus, int_char_speed_v_plus_times_normal,
+    int_char_speed_v_minus_times_normal, int_char_speed_gamma2_v_psi,
+    int_char_speeds, ext_char_speed_v_psi, ext_char_speed_v_zero,
+    ext_char_speed_v_plus, ext_char_speed_v_minus,
+    ext_char_speed_v_plus_times_normal, ext_char_speed_v_minus_times_normal,
+    ext_char_speed_gamma2_v_psi, ext_char_speeds, use_strong_form):
+    result = int_char_speed_v_psi * 0.
+    # Add v^+ terms
+    if ext_char_speeds[1] > 0.:
+        result -= 0.5 * ext_char_speed_v_plus
+    if int_char_speeds[1] < 0.:
+        result -= 0.5 * int_char_speed_v_plus
+
+    # Add v^- terms
+    if ext_char_speeds[2] > 0.:
+        result -= 0.5 * ext_char_speed_v_minus
+    if int_char_speeds[2] < 0.:
+        result -= 0.5 * int_char_speed_v_minus
+
+    # Add v^\Psi terms
+    if ext_char_speeds[0] > 0.:
+        result -= ext_char_speed_gamma2_v_psi
+    if int_char_speeds[0] < 0.:
+        result -= int_char_speed_gamma2_v_psi
+    return result
+
+
+def dg_boundary_terms_phi(
+    int_char_speed_v_psi, int_char_speed_v_zero, int_char_speed_v_plus,
+    int_char_speed_v_minus, int_char_speed_v_plus_times_normal,
+    int_char_speed_v_minus_times_normal, int_char_speed_gamma2_v_psi,
+    int_char_speeds, ext_char_speed_v_psi, ext_char_speed_v_zero,
+    ext_char_speed_v_plus, ext_char_speed_v_minus,
+    ext_char_speed_v_plus_times_normal, ext_char_speed_v_minus_times_normal,
+    ext_char_speed_gamma2_v_psi, ext_char_speeds, use_strong_form):
+    result = int_char_speed_v_zero * 0.
+
+    # Add v^+ terms
+    if ext_char_speeds[1] >= 0.:
+        result -= 0.5 * ext_char_speed_v_plus_times_normal
+    if int_char_speeds[1] < 0.:
+        result -= 0.5 * int_char_speed_v_plus_times_normal
+
+    # Add v^- terms
+    if ext_char_speeds[2] >= 0.:
+        result += 0.5 * ext_char_speed_v_minus_times_normal
+    if int_char_speeds[2] < 0.:
+        result += 0.5 * int_char_speed_v_minus_times_normal
+
+    # Add v^0 terms
+    if ext_char_speeds[0] >= 0.:
+        result -= ext_char_speed_v_zero
+    if int_char_speeds[0] < 0.:
+        result -= int_char_speed_v_zero
+    return result
+
+
+def dg_boundary_terms_psi(
+    int_char_speed_v_psi, int_char_speed_v_zero, int_char_speed_v_plus,
+    int_char_speed_v_minus, int_char_speed_v_plus_times_normal,
+    int_char_speed_v_minus_times_normal, int_char_speed_gamma2_v_psi,
+    int_char_speeds, ext_char_speed_v_psi, ext_char_speed_v_zero,
+    ext_char_speed_v_plus, ext_char_speed_v_minus,
+    ext_char_speed_v_plus_times_normal, ext_char_speed_v_minus_times_normal,
+    ext_char_speed_gamma2_v_psi, ext_char_speeds, use_strong_form):
+    result = int_char_speed_v_psi * 0.
+    if ext_char_speeds[0] >= 0.:
+        result -= ext_char_speed_v_psi
+    if int_char_speeds[0] < 0.:
+        result -= int_char_speed_v_psi
+    return result

--- a/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_ScalarWave")
 
 set(LIBRARY_SOURCES
+  BoundaryCorrections/Test_UpwindPenalty.cpp
   Test_Characteristics.cpp
   Test_Constraints.cpp
   Test_Equations.cpp


### PR DESCRIPTION
## Proposed changes

- Have the damping parameter `gamma2` be a temporary tag in the `TimeDerivative` struct. This is needed for boundary corrections. In the future I'd like the `TimeDerivative` struct to actually compute the damping parameter as opposed to having it be a compute tag, but until that happens we need this design. I don't want to allow slicing of arbitrary data from the DataBox because that encourages compute tag use, which we are trying to reduce.
- Add upwind penalty boundary correction. This is basically a refactor of the existing one, changing it to conform to the new interface (as in, the math doesn't change). However, since I don't want to break scalar wave evolutions in develop (and nobody wants to review a 25k line PR), I'm copy-pasting (with some refactor) the boundary correction, and will delete the old one once the evolution code is completely ported. The missing major piece is boundary corrections for the switch to happen.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
