### PR TITLE
Make TensorExpression abstract

### DIFF
--- a/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
+++ b/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
@@ -135,12 +135,7 @@ SPECTRE_ALWAYS_INLINE auto operator+(
   static_assert(tmpl::equal_members<Args1, Args2>::value,
                 "The indices when adding two tensors must be equal. This error "
                 "occurs from expressions like A(_a, _b) + B(_c, _a)");
-  return TensorExpressions::AddSub<
-      tmpl::conditional_t<std::is_base_of<Expression, T1>::value, T1,
-                          TensorExpression<T1, X, Symm1, IndexList1, Args1>>,
-      tmpl::conditional_t<std::is_base_of<Expression, T2>::value, T2,
-                          TensorExpression<T2, X, Symm2, IndexList2, Args2>>,
-      Args1, Args2, 1>(~t1, ~t2);
+  return TensorExpressions::AddSub<T1, T2, Args1, Args2, 1>(~t1, ~t2);
 }
 
 /*!
@@ -157,10 +152,5 @@ SPECTRE_ALWAYS_INLINE auto operator-(
   static_assert(tmpl::equal_members<Args1, Args2>::value,
                 "The indices when adding two tensors must be equal. This error "
                 "occurs from expressions like A(_a, _b) - B(_c, _a)");
-  return TensorExpressions::AddSub<
-      tmpl::conditional_t<std::is_base_of<Expression, T1>::value, T1,
-                          TensorExpression<T1, X, Symm1, IndexList1, Args1>>,
-      tmpl::conditional_t<std::is_base_of<Expression, T2>::value, T2,
-                          TensorExpression<T2, X, Symm2, IndexList2, Args2>>,
-      Args1, Args2, -1>(~t1, ~t2);
+  return TensorExpressions::AddSub<T1, T2, Args1, Args2, -1>(~t1, ~t2);
 }

--- a/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
+++ b/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
@@ -82,6 +82,7 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
   using args_list = tmpl::sort<typename T1::args_list>;
 
   AddSub(T1 t1, T2 t2) : t1_(std::move(t1)), t2_(std::move(t2)) {}
+  ~AddSub() override = default;
 
   template <typename... LhsIndices, typename T>
   SPECTRE_ALWAYS_INLINE decltype(auto) get(

--- a/src/DataStructures/Tensor/Expressions/CMakeLists.txt
+++ b/src/DataStructures/Tensor/Expressions/CMakeLists.txt
@@ -10,5 +10,6 @@ spectre_target_headers(
   Evaluate.hpp
   LhsTensorSymmAndIndices.hpp
   Product.hpp
+  TensorAsExpression.hpp
   TensorExpression.hpp
   )

--- a/src/DataStructures/Tensor/Expressions/Contract.hpp
+++ b/src/DataStructures/Tensor/Expressions/Contract.hpp
@@ -138,6 +138,7 @@ struct TensorContract
   explicit TensorContract(
       const TensorExpression<T, X, Symm, IndexList, ArgsList>& t)
       : t_(~t) {}
+  ~TensorContract() override = default;
 
   template <size_t I, size_t Rank>
   SPECTRE_ALWAYS_INLINE void fill_contracting_tensor_index(

--- a/src/DataStructures/Tensor/Expressions/Contract.hpp
+++ b/src/DataStructures/Tensor/Expressions/Contract.hpp
@@ -460,9 +460,7 @@ struct TensorContract
   }
 
  private:
-  const std::conditional_t<std::is_base_of<Expression, T>::value, T,
-                           TensorExpression<T, X, Symm, IndexList, ArgsList>>
-      t_;
+  const T t_;
 };
 
 /*!

--- a/src/DataStructures/Tensor/Expressions/TensorAsExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorAsExpression.hpp
@@ -145,6 +145,7 @@ struct TensorAsExpression<Tensor<X, Symm, IndexList<Indices...>>,
   /// Construct an expression from a Tensor
   explicit TensorAsExpression(const Tensor<X, Symm, IndexList<Indices...>>& t)
       : t_(&t) {}
+  ~TensorAsExpression() override = default;
 
   // @{
   /// \cond HIDDEN_SYMBOLS

--- a/src/DataStructures/Tensor/Expressions/TensorAsExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorAsExpression.hpp
@@ -1,0 +1,363 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines expressions that represent tensors
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/Tensor/Expressions/LhsTensorSymmAndIndices.hpp"
+#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/Structure.hpp"
+#include "DataStructures/Tensor/Symmetry.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ForceInline.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits/IsA.hpp"
+
+namespace TensorExpressions {
+namespace detail {
+template <typename State, typename Element, typename LHS>
+struct rhs_elements_in_lhs_helper {
+  using type = std::conditional_t<not std::is_same<tmpl::index_of<LHS, Element>,
+                                                   tmpl::no_such_type_>::value,
+                                  tmpl::push_back<State, Element>, State>;
+};
+}  // namespace detail
+
+/// \ingroup TensorExpressionsGroup
+/// Returns a list of all the elements in the typelist Rhs that are also in the
+/// typelist Lhs.
+///
+/// \details
+/// Given two typelists `Lhs` and `Rhs`, returns a typelist of all the elements
+/// in `Rhs` that are also in `Lhs` in the same order that they are in the
+/// `Rhs`.
+///
+/// ### Usage
+/// For typelists `List1` and `List2`,
+/// \code{.cpp}
+/// using result = rhs_elements_in_lhs<List1, List2>;
+/// \endcode
+/// \metareturns
+/// typelist
+///
+/// \semantics
+/// If `Lhs = tmpl::list<A, B, C, D>` and `Rhs = tmpl::list<B, E, A>`, then
+/// \code{.cpp}
+/// result = tmpl::list<B, A>;
+/// \endcode
+template <typename Lhs, typename Rhs>
+using rhs_elements_in_lhs =
+    tmpl::fold<Rhs, tmpl::list<>,
+               detail::rhs_elements_in_lhs_helper<tmpl::_state, tmpl::_element,
+                                                  tmpl::pin<Lhs>>>;
+
+namespace detail {
+template <typename Element, typename Iteration, typename Lhs, typename Rhs,
+          typename RhsWithOnlyLhs, typename IndexInLhs>
+struct generate_transformation_helper {
+  using tensor_index_to_find = tmpl::at<RhsWithOnlyLhs, IndexInLhs>;
+  using index_to_replace_with = tmpl::index_of<Rhs, tensor_index_to_find>;
+  using type = tmpl::size_t<index_to_replace_with::value>;
+};
+
+template <typename Element, typename Iteration, typename Lhs, typename Rhs,
+          typename RhsWithOnlyLhs>
+struct generate_transformation_helper<Element, Iteration, Lhs, Rhs,
+                                      RhsWithOnlyLhs, tmpl::no_such_type_> {
+  using type = tmpl::size_t<Iteration::value>;
+};
+
+template <typename State, typename Element, typename Iteration, typename Lhs,
+          typename Rhs, typename RhsWithOnlyLhs>
+struct generate_transformation_impl {
+  using index_in_lhs = tmpl::index_of<Lhs, Element>;
+  using type = tmpl::push_back<State, typename generate_transformation_helper<
+                                          Element, Iteration, Lhs, Rhs,
+                                          RhsWithOnlyLhs, index_in_lhs>::type>;
+};
+}  // namespace detail
+
+/// \ingroup TensorExpressionsGroup
+/// \brief Generate transformation to account for index order difference in RHS
+/// and LHS.
+///
+/// \details
+/// Generates the transformation \f$\mathcal{T}\f$ that rearranges the Tensor
+/// index array to account for index order differences between the LHS and RHS
+/// of the tensor expression.
+///
+/// ### Usage
+/// For typelists `Rhs`, `Lhs` and `RhsOnyWithLhs`, where `RhsOnlyWithLhs` is
+/// the result of the metafunction rhs_elements_in_lhs,
+/// \code{.cpp}
+/// using result = generate_transformation<Rhs, Lhs, RhsOnlyWithLhs>;
+/// \endcode
+/// \metareturns
+/// typelist
+template <typename Rhs, typename Lhs, typename RhsOnyWithLhs>
+using generate_transformation = tmpl::enumerated_fold<
+    Rhs, tmpl::list<>,
+    detail::generate_transformation_impl<tmpl::_state, tmpl::_element, tmpl::_3,
+                                         tmpl::pin<Lhs>, tmpl::pin<Rhs>,
+                                         tmpl::pin<RhsOnyWithLhs>>>;
+
+/// \ingroup TensorExpressionsGroup
+/// \brief Defines an expression representing a Tensor
+///
+/// \details
+/// In order to represent a tensor as an expression, instead of having Tensor
+/// derive off of TensorExpression, a TensorAsExpression derives off of
+/// TensorExpression and contains a pointer to a Tensor. The reason having
+/// Tensor derive off of TensorExpression is problematic is that the index
+/// structure is part of the type of the TensorExpression, so every possible
+/// permutation and combination of indices must be derived from. For a rank 3
+/// tensor, this is already over 500 base classes, which the Intel compiler
+/// takes too long to compile.
+///
+/// \tparam T the type of Tensor being represented as an expression
+/// \tparam ArgsList the tensor indices, e.g. `_a` and `_b` in `F(_a, _b)`
+template <typename T, typename ArgsList>
+struct TensorAsExpression;
+
+template <typename X, typename Symm, template <typename...> class IndexList,
+          typename... Indices, template <typename...> class ArgsList,
+          typename... Args>
+struct TensorAsExpression<Tensor<X, Symm, IndexList<Indices...>>,
+                          ArgsList<Args...>>
+    : public TensorExpression<
+          TensorAsExpression<Tensor<X, Symm, IndexList<Indices...>>,
+                             ArgsList<Args...>>,
+          X, Symm, IndexList<Indices...>, ArgsList<Args...>> {
+  using type = X;
+  using symmetry = Symm;
+  using index_list = IndexList<Indices...>;
+  static constexpr auto num_tensor_indices = tmpl::size<index_list>::value;
+  using args_list = ArgsList<Args...>;
+  using structure = Tensor_detail::Structure<symmetry, Indices...>;
+
+  /// Construct an expression from a Tensor
+  explicit TensorAsExpression(const Tensor<X, Symm, IndexList<Indices...>>& t)
+      : t_(&t) {}
+
+  // @{
+  /// \cond HIDDEN_SYMBOLS
+  /// \ingroup TensorExpressionsGroup
+  /// Helper struct to compute the correct tensor index array from a
+  /// typelist of std::integral_constant's indicating the ordering. This is
+  /// needed for dealing with expressions such as \f$T_{ab} = F_{ba}\f$ and gets
+  /// the ordering on the RHS to be correct compared with where the indices are
+  /// on the LHS.
+  template <typename U>
+  struct ComputeCorrectTensorIndex;
+
+  template <template <typename...> class RedArgsList, typename... RedArgs>
+  struct ComputeCorrectTensorIndex<RedArgsList<RedArgs...>> {
+    template <typename U, std::size_t Size>
+    SPECTRE_ALWAYS_INLINE static constexpr std::array<U, Size> apply(
+        const std::array<U, Size>& tensor_index) {
+      return std::array<U, Size>{{tensor_index[RedArgs::value]...}};
+    }
+  };
+  /// \endcond
+  // @}
+
+  /// \brief Returns the value of type DataType with tensor index `tensor_index`
+  ///
+  /// \details
+  /// One big challenge with TensorExpression implementation is the reordering
+  /// of the Indices on the RHS and LHS of the expression. This algorithm
+  /// implemented in ::rhs_elements_in_lhs and ::generate_transformation handles
+  /// the index sorting.
+  ///
+  /// Here are some examples of what the algorithm does:
+  ///
+  /// LhsIndices is the desired ordering.
+  ///
+  /// LHS:
+  /// \code
+  /// <0, 1>
+  /// \endcode
+  /// RHS:
+  /// \code
+  /// <1, 2, 3, 0> -Transform> <3, 1, 2, 0>
+  /// \endcode
+  ///
+  /// LHS:
+  /// \code
+  /// <0, 1, 2> <a, b, c>
+  /// \endcode
+  /// RHS:
+  /// \code
+  /// <2, 0, 1> -Transform> <2 , 1, 0>
+  /// \endcode
+  ///
+  /// Below is pseudo-code of the algorithm written in a non-functional way
+  /// \verbatim
+  /// for Element in RHS:
+  ///   if (Element in LHS):
+  ///     index_in_LHS = index_of<LHS, Element>
+  ///     tensor_index_to_find = at<RHS_with_only_LHS, index_in_LHS>
+  ///     index_to_replace_with = index_of<RHS, tensor_index_to_find>
+  ///     T_RHS = push_back<T_RHS, index_to_replace_with>
+  ///   else:
+  ///     T_RHS = push_back<T_RHS, iteration>
+  ///   endif
+  /// end for
+  /// \endverbatim
+  ///
+  /// \tparam LhsIndices the tensor indices on the LHS on the expression
+  /// \param tensor_index the tensor component to retrieve
+  /// \return the value of the DataType of component `tensor_index`
+  template <typename... LhsIndices, typename ArrayValueType>
+  SPECTRE_ALWAYS_INLINE decltype(auto) get(
+      const std::array<ArrayValueType, num_tensor_indices>& tensor_index)
+      const noexcept {
+    ASSERT(t_ != nullptr,
+           "A TensorExpression that should be holding a pointer to a Tensor "
+           "is holding a nullptr.");
+    using rhs = args_list;
+    // To deal with Tensor products we need the ordering of only the subset of
+    // tensor indices present in this term
+    using lhs = rhs_elements_in_lhs<rhs, tmpl::list<LhsIndices...>>;
+    using rhs_only_with_lhs = rhs_elements_in_lhs<lhs, rhs>;
+    using transformation = generate_transformation<rhs, lhs, rhs_only_with_lhs>;
+    return t_->get(
+        ComputeCorrectTensorIndex<transformation>::apply(tensor_index));
+  }
+
+  /// \brief Computes the right hand side tensor multi-index that corresponds to
+  /// the left hand side tensor multi-index, according to their generic indices
+  ///
+  /// \details
+  /// Given the order of the generic indices for the left hand side (LHS) and
+  /// right hand side (RHS) and a specific LHS tensor multi-index, the
+  /// computation of the equivalent multi-index for the RHS tensor accounts for
+  /// differences in the ordering of the generic indices on the LHS and RHS.
+  ///
+  /// Here, the elements of `lhs_index_order` and `rhs_index_order` refer to
+  /// TensorIndex::values that correspond to generic tensor indices,
+  /// `lhs_tensor_multi_index` is a multi-index for the LHS tensor, and the
+  /// equivalent RHS tensor multi-index is returned. If we have LHS tensor
+  /// \f$L_{ab}\f$, RHS tensor \f$R_{ba}\f$, and the LHS component \f$L_{31}\f$,
+  /// the corresponding RHS component is \f$R_{13}\f$.
+  ///
+  /// Here is an example of what the algorithm does:
+  ///
+  /// `lhs_index_order`:
+  /// \code
+  /// [0, 1, 2] // i.e. abc
+  /// \endcode
+  /// `rhs_index_order`:
+  /// \code
+  /// [1, 2, 0] // i.e. bca
+  /// \endcode
+  /// `lhs_tensor_multi_index`:
+  /// \code
+  /// [4, 0, 3] // i.e. a = 4, b = 0, c = 3
+  /// \endcode
+  /// returned RHS tensor multi-index:
+  /// \code
+  /// [0, 3, 4] // i.e. b = 0, c = 3, a = 4
+  /// \endcode
+  ///
+  /// \param lhs_index_order the generic index order of the LHS tensor
+  /// \param rhs_index_order the generic index order of the RHS tensor
+  /// \param lhs_tensor_multi_index the specific LHS tensor multi-index
+  /// \return the RHS tensor multi-index that corresponds to
+  /// `lhs_tensor_multi_index`, according to the index orders in
+  /// `lhs_index_order` and `rhs_index_order`
+  SPECTRE_ALWAYS_INLINE static constexpr std::array<size_t, sizeof...(Indices)>
+  compute_rhs_tensor_index(
+      const std::array<size_t, sizeof...(Indices)>& lhs_index_order,
+      const std::array<size_t, sizeof...(Indices)>& rhs_index_order,
+      const std::array<size_t, sizeof...(Indices)>&
+          lhs_tensor_multi_index) noexcept {
+    std::array<size_t, sizeof...(Indices)> rhs_tensor_multi_index{};
+    for (size_t i = 0; i < sizeof...(Indices); ++i) {
+      gsl::at(rhs_tensor_multi_index,
+              static_cast<unsigned long>(std::distance(
+                  rhs_index_order.begin(),
+                  alg::find(rhs_index_order, gsl::at(lhs_index_order, i))))) =
+          gsl::at(lhs_tensor_multi_index, i);
+    }
+    return rhs_tensor_multi_index;
+  }
+
+  /// \brief Computes a mapping from the storage indices of the left hand side
+  /// tensor to the right hand side tensor
+  ///
+  /// \tparam LhsStructure the Structure of the Tensor on the left hand side of
+  /// the TensorExpression
+  /// \tparam LhsIndices the TensorIndexs of the Tensor on the left hand side
+  /// \return the mapping from the left hand side to the right hand side storage
+  /// indices
+  template <typename LhsStructure, typename... LhsIndices>
+  SPECTRE_ALWAYS_INLINE static constexpr std::array<size_t,
+                                                    LhsStructure::size()>
+  compute_lhs_to_rhs_map() noexcept {
+    constexpr size_t num_components = LhsStructure::size();
+    std::array<size_t, num_components> lhs_to_rhs_map{};
+    const auto lhs_storage_to_tensor_indices =
+        LhsStructure::storage_to_tensor_index();
+    for (size_t lhs_storage_index = 0; lhs_storage_index < num_components;
+         ++lhs_storage_index) {
+      // `compute_rhs_tensor_index` will return the RHS tensor multi-index that
+      // corresponds to the LHS tensor multi-index, according to the order of
+      // the generic indices for the LHS and RHS. structure::get_storage_index
+      // will then get the RHS storage index that corresponds to this RHS
+      // tensor multi-index.
+      gsl::at(lhs_to_rhs_map, lhs_storage_index) =
+          structure::get_storage_index(compute_rhs_tensor_index(
+              {{LhsIndices::value...}}, {{Args::value...}},
+              lhs_storage_to_tensor_indices[lhs_storage_index]));
+    }
+    return lhs_to_rhs_map;
+  }
+
+  /// \brief Returns the value at a left hand side tensor's storage index
+  ///
+  /// \details
+  /// One big challenge with TensorExpression implementation is the reordering
+  /// of the indices on the left hand side (LHS) and right hand side (RHS) of
+  /// the expression. The algorithms implemented in `compute_lhs_to_rhs_map` and
+  /// `compute_rhs_tensor_index` handle the index sorting by mapping between the
+  /// generic index orders of the LHS and RHS.
+  ///
+  /// \tparam LhsStructure the Structure of the Tensor on the LHS of the
+  /// TensorExpression
+  /// \tparam LhsIndices the TensorIndexs of the Tensor on the LHS of the tensor
+  /// expression
+  /// \param lhs_storage_index the storage index of the LHS tensor component to
+  /// retrieve
+  /// \return the value of the DataType of the component at `lhs_storage_index`
+  /// in the LHS tensor
+  template <typename LhsStructure, typename... LhsIndices>
+  SPECTRE_ALWAYS_INLINE decltype(auto) get(
+      const size_t lhs_storage_index) const noexcept {
+    if constexpr (std::is_same_v<LhsStructure, structure> and
+                  std::is_same_v<tmpl::list<LhsIndices...>,
+                                 tmpl::list<Args...>>) {
+      return (*t_)[lhs_storage_index];
+    } else {
+      constexpr std::array<size_t, LhsStructure::size()> lhs_to_rhs_map =
+          compute_lhs_to_rhs_map<LhsStructure, LhsIndices...>();
+      return (*t_)[gsl::at(lhs_to_rhs_map, lhs_storage_index)];
+    }
+  }
+
+  /// Retrieve the i'th entry of the Tensor being held
+  SPECTRE_ALWAYS_INLINE type operator[](const size_t i) const {
+    return t_->operator[](i);
+  }
+
+ private:
+  const Tensor<X, Symm, IndexList<Indices...>>* t_ = nullptr;
+};
+}  // namespace TensorExpressions

--- a/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
@@ -2,20 +2,18 @@
 // See LICENSE.txt for details.
 
 /// \file
-/// Defines class
+/// Defines base class for all tensor expressions and the generic tensor indices
+/// that they use
 
 #pragma once
 
 #include <array>
 #include <cstddef>
 
-#include "DataStructures/Tensor/Structure.hpp"
-#include "Utilities/Algorithm.hpp"
-#include "Utilities/ErrorHandling/Assert.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/IndexType.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
-#include "Utilities/TypeTraits/IsA.hpp"  // IWYU pragma: keep
 
 // The below values are used to separate upper indices from lower indices and
 // spatial indices from spacetime indices.
@@ -151,93 +149,6 @@ template <size_t I>
 struct is_tensor_index<TensorIndex<I>> : std::true_type {};
 }  // namespace tt
 
-namespace detail {
-template <typename State, typename Element, typename LHS>
-struct rhs_elements_in_lhs_helper {
-  using type = std::conditional_t<not std::is_same<tmpl::index_of<LHS, Element>,
-                                                   tmpl::no_such_type_>::value,
-                                  tmpl::push_back<State, Element>, State>;
-};
-}  // namespace detail
-
-/// \ingroup TensorExpressionsGroup
-/// Returns a list of all the elements in the typelist Rhs that are also in the
-/// typelist Lhs.
-///
-/// \details
-/// Given two typelists `Lhs` and `Rhs`, returns a typelist of all the elements
-/// in `Rhs` that are also in `Lhs` in the same order that they are in the
-/// `Rhs`.
-///
-/// ### Usage
-/// For typelists `List1` and `List2`,
-/// \code{.cpp}
-/// using result = rhs_elements_in_lhs<List1, List2>;
-/// \endcode
-/// \metareturns
-/// typelist
-///
-/// \semantics
-/// If `Lhs = tmpl::list<A, B, C, D>` and `Rhs = tmpl::list<B, E, A>`, then
-/// \code{.cpp}
-/// result = tmpl::list<B, A>;
-/// \endcode
-template <typename Lhs, typename Rhs>
-using rhs_elements_in_lhs =
-    tmpl::fold<Rhs, tmpl::list<>,
-               detail::rhs_elements_in_lhs_helper<tmpl::_state, tmpl::_element,
-                                                  tmpl::pin<Lhs>>>;
-
-namespace detail {
-template <typename Element, typename Iteration, typename Lhs, typename Rhs,
-          typename RhsWithOnlyLhs, typename IndexInLhs>
-struct generate_transformation_helper {
-  using tensor_index_to_find = tmpl::at<RhsWithOnlyLhs, IndexInLhs>;
-  using index_to_replace_with = tmpl::index_of<Rhs, tensor_index_to_find>;
-  using type = tmpl::size_t<index_to_replace_with::value>;
-};
-
-template <typename Element, typename Iteration, typename Lhs, typename Rhs,
-          typename RhsWithOnlyLhs>
-struct generate_transformation_helper<Element, Iteration, Lhs, Rhs,
-                                      RhsWithOnlyLhs, tmpl::no_such_type_> {
-  using type = tmpl::size_t<Iteration::value>;
-};
-
-template <typename State, typename Element, typename Iteration, typename Lhs,
-          typename Rhs, typename RhsWithOnlyLhs>
-struct generate_transformation_impl {
-  using index_in_lhs = tmpl::index_of<Lhs, Element>;
-  using type = tmpl::push_back<State, typename generate_transformation_helper<
-                                          Element, Iteration, Lhs, Rhs,
-                                          RhsWithOnlyLhs, index_in_lhs>::type>;
-};
-}  // namespace detail
-
-/// \ingroup TensorExpressionsGroup
-/// \brief Generate transformation to account for index order difference in RHS
-/// and LHS.
-///
-/// \details
-/// Generates the transformation \f$\mathcal{T}\f$ that rearranges the Tensor
-/// index array to account for index order differences between the LHS and RHS
-/// of the tensor expression.
-///
-/// ### Usage
-/// For typelists `Rhs`, `Lhs` and `RhsOnyWithLhs`, where `RhsOnlyWithLhs` is
-/// the result of the metafunction rhs_elements_in_lhs,
-/// \code{.cpp}
-/// using result = generate_transformation<Rhs, Lhs, RhsOnlyWithLhs>;
-/// \endcode
-/// \metareturns
-/// typelist
-template <typename Rhs, typename Lhs, typename RhsOnyWithLhs>
-using generate_transformation = tmpl::enumerated_fold<
-    Rhs, tmpl::list<>,
-    detail::generate_transformation_impl<tmpl::_state, tmpl::_element, tmpl::_3,
-                                         tmpl::pin<Lhs>, tmpl::pin<Rhs>,
-                                         tmpl::pin<RhsOnyWithLhs>>>;
-
 /// \ingroup TensorExpressionsGroup
 /// \brief Marks a class as being a TensorExpression
 ///
@@ -248,11 +159,6 @@ using generate_transformation = tmpl::enumerated_fold<
 ///
 /// 2) The tensor indices will be swapped to conform with mathematical notation
 struct Expression {};
-
-/// \cond
-template <typename DataType, typename Symm, typename IndexList>
-class Tensor;
-/// \endcond
 
 // @{
 /// \ingroup TensorExpressionsGroup
@@ -285,296 +191,16 @@ struct TensorExpression<Derived, DataType, Symm, tmpl::list<Indices...>,
   static constexpr auto num_tensor_indices = tmpl::size<index_list>::value;
   /// Typelist of the tensor indices, e.g. `_a_t` and `_b_t` in `F(_a, _b)`
   using args_list = ArgsList<Args...>;
-  using structure = Tensor_detail::Structure<symmetry, Indices...>;
 
   // @{
-  /// If Derived is a TensorExpression, it is casted down to the derived
-  /// class. This is enabled by the
+  /// Derived is casted down to the derived class. This is enabled by the
   /// [CRTP](https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern)
-  ///
-  /// Otherwise, it is a Tensor. Since Tensor is not derived from
-  /// TensorExpression (because of complications arising from the indices being
-  /// part of the expression, specifically Tensor may need to derive off of
-  /// hundreds or thousands of base classes, which is not feasible), return a
-  /// reference to a TensorExpression, which has a sufficient interface to
-  /// evaluate the expression.
   ///
   /// \returns const TensorExpression<Derived, DataType, Symm, IndexList,
   /// ArgsList<Args...>>&
   SPECTRE_ALWAYS_INLINE const auto& operator~() const noexcept {
-    if constexpr (tt::is_a_v<Tensor, Derived>) {
-      return *this;
-    } else {
       return static_cast<const Derived&>(*this);
-    }
   }
-
   // @}
-
-  // @{
-  /// \cond HIDDEN_SYMBOLS
-  /// \ingroup TensorExpressionsGroup
-  /// Helper struct to compute the correct tensor index array from a
-  /// typelist of std::integral_constant's indicating the ordering. This is
-  /// needed for dealing with expressions such as \f$T_{ab} = F_{ba}\f$ and gets
-  /// the ordering on the RHS to be correct compared with where the indices are
-  /// on the LHS.
-  template <typename U>
-  struct ComputeCorrectTensorIndex;
-
-  template <template <typename...> class RedArgsList, typename... RedArgs>
-  struct ComputeCorrectTensorIndex<RedArgsList<RedArgs...>> {
-    template <typename U, std::size_t Size>
-    SPECTRE_ALWAYS_INLINE static constexpr std::array<U, Size> apply(
-        const std::array<U, Size>& tensor_index) {
-      return std::array<U, Size>{{tensor_index[RedArgs::value]...}};
-    }
-  };
-  /// \endcond
-  // @}
-
-  /// \brief return the value of type DataType with tensor index `tensor_index`
-  ///
-  /// \details
-  /// If Derived is a TensorExpression, `tensor_index` is forwarded onto the
-  /// concrete derived TensorExpression.
-  ///
-  /// Otherwise, it is a Tensor, where one big challenge with TensorExpression
-  /// implementation is the reordering of the Indices on the RHS and LHS of the
-  /// expression. This algorithm implemented in ::rhs_elements_in_lhs and
-  /// ::generate_transformation handles the index sorting.
-  ///
-  /// Here are some examples of what the algorithm does:
-  ///
-  /// LhsIndices is the desired ordering.
-  ///
-  /// LHS:
-  /// \code
-  /// <0, 1>
-  /// \endcode
-  /// RHS:
-  /// \code
-  /// <1, 2, 3, 0> -Transform> <3, 1, 2, 0>
-  /// \endcode
-  ///
-  /// LHS:
-  /// \code
-  /// <0, 1, 2> <a, b, c>
-  /// \endcode
-  /// RHS:
-  /// \code
-  /// <2, 0, 1> -Transform> <2 , 1, 0>
-  /// \endcode
-  ///
-  /// Below is pseudo-code of the algorithm written in a non-functional way
-  /// \verbatim
-  /// for Element in RHS:
-  ///   if (Element in LHS):
-  ///     index_in_LHS = index_of<LHS, Element>
-  ///     tensor_index_to_find = at<RHS_with_only_LHS, index_in_LHS>
-  ///     index_to_replace_with = index_of<RHS, tensor_index_to_find>
-  ///     T_RHS = push_back<T_RHS, index_to_replace_with>
-  ///   else:
-  ///     T_RHS = push_back<T_RHS, iteration>
-  ///   endif
-  /// end for
-  /// \endverbatim
-  ///
-  /// \tparam LhsIndices the tensor indices on the LHS on the expression
-  /// \param tensor_index the tensor component to retrieve
-  /// \return the value of the DataType of component `tensor_index`
-  template <typename... LhsIndices, typename ArrayValueType>
-  SPECTRE_ALWAYS_INLINE decltype(auto)
-  get(const std::array<ArrayValueType, num_tensor_indices>& tensor_index)
-      const noexcept {
-    if constexpr (tt::is_a_v<Tensor, Derived>) {
-      ASSERT(t_ != nullptr,
-             "A TensorExpression that should be holding a pointer to a Tensor "
-             "is holding a nullptr.");
-      using rhs = args_list;
-      // To deal with Tensor products we need the ordering of only the subset of
-      // tensor indices present in this term
-      using lhs = rhs_elements_in_lhs<rhs, tmpl::list<LhsIndices...>>;
-      using rhs_only_with_lhs = rhs_elements_in_lhs<lhs, rhs>;
-      using transformation =
-          generate_transformation<rhs, lhs, rhs_only_with_lhs>;
-      return t_->get(
-          ComputeCorrectTensorIndex<transformation>::apply(tensor_index));
-    } else {
-      ASSERT(t_ == nullptr,
-             "A TensorExpression that shouldn't be holding a pointer to a "
-             "Tensor is holding one.");
-      return (~*this).template get<LhsIndices...>(tensor_index);
-    }
-  }
-
-  /// \brief Computes the right hand side tensor multi-index that corresponds to
-  /// the left hand side tensor multi-index, according to their generic indices
-  ///
-  /// \details
-  /// Given the order of the generic indices for the left hand side (LHS) and
-  /// right hand side (RHS) and a specific LHS tensor multi-index, the
-  /// computation of the equivalent multi-index for the RHS tensor accounts for
-  /// differences in the ordering of the generic indices on the LHS and RHS.
-  ///
-  /// Here, the elements of `lhs_index_order` and `rhs_index_order` refer to
-  /// TensorIndex::values that correspond to generic tensor indices,
-  /// `lhs_tensor_multi_index` is a multi-index for the LHS tensor, and the
-  /// equivalent RHS tensor multi-index is returned. If we have LHS tensor
-  /// \f$L_{ab}\f$, RHS tensor \f$R_{ba}\f$, and the LHS component \f$L_{31}\f$,
-  /// the corresponding RHS component is \f$R_{13}\f$.
-  ///
-  /// Here is an example of what the algorithm does:
-  ///
-  /// `lhs_index_order`:
-  /// \code
-  /// [0, 1, 2] // i.e. abc
-  /// \endcode
-  /// `rhs_index_order`:
-  /// \code
-  /// [1, 2, 0] // i.e. bca
-  /// \endcode
-  /// `lhs_tensor_multi_index`:
-  /// \code
-  /// [4, 0, 3] // i.e. a = 4, b = 0, c = 3
-  /// \endcode
-  /// returned RHS tensor multi-index:
-  /// \code
-  /// [0, 3, 4] // i.e. b = 0, c = 3, a = 4
-  /// \endcode
-  ///
-  /// \param lhs_index_order the generic index order of the LHS tensor
-  /// \param rhs_index_order the generic index order of the RHS tensor
-  /// \param lhs_tensor_multi_index the specific LHS tensor multi-index
-  /// \return the RHS tensor multi-index that corresponds to
-  /// `lhs_tensor_multi_index`, according to the index orders in
-  /// `lhs_index_order` and `rhs_index_order`
-  SPECTRE_ALWAYS_INLINE static constexpr std::array<size_t, sizeof...(Indices)>
-  compute_rhs_tensor_index(
-      const std::array<size_t, sizeof...(Indices)>& lhs_index_order,
-      const std::array<size_t, sizeof...(Indices)>& rhs_index_order,
-      const std::array<size_t, sizeof...(Indices)>&
-          lhs_tensor_multi_index) noexcept {
-    std::array<size_t, sizeof...(Indices)> rhs_tensor_multi_index{};
-    for (size_t i = 0; i < sizeof...(Indices); ++i) {
-      gsl::at(rhs_tensor_multi_index,
-              static_cast<unsigned long>(std::distance(
-                  rhs_index_order.begin(),
-                  alg::find(rhs_index_order, gsl::at(lhs_index_order, i))))) =
-          gsl::at(lhs_tensor_multi_index, i);
-    }
-    return rhs_tensor_multi_index;
-  }
-
-  /// \brief Computes a mapping from the storage indices of the left hand side
-  /// tensor to the right hand side tensor
-  ///
-  /// \tparam LhsStructure the Structure of the Tensor on the left hand side of
-  /// the TensorExpression
-  /// \tparam LhsIndices the TensorIndexs of the Tensor on the left hand side
-  /// \return the mapping from the left hand side to the right hand side storage
-  /// indices
-  template <typename LhsStructure, typename... LhsIndices>
-  SPECTRE_ALWAYS_INLINE static constexpr std::array<size_t,
-                                                    LhsStructure::size()>
-  compute_lhs_to_rhs_map() noexcept {
-    constexpr size_t num_components = LhsStructure::size();
-    std::array<size_t, num_components> lhs_to_rhs_map{};
-    const auto lhs_storage_to_tensor_indices =
-        LhsStructure::storage_to_tensor_index();
-    for (size_t lhs_storage_index = 0; lhs_storage_index < num_components;
-         ++lhs_storage_index) {
-      // `compute_rhs_tensor_index` will return the RHS tensor multi-index that
-      // corresponds to the LHS tensor multi-index, according to the order of
-      // the generic indices for the LHS and RHS. structure::get_storage_index
-      // will then get the RHS storage index that corresponds to this RHS
-      // tensor multi-index.
-      gsl::at(lhs_to_rhs_map, lhs_storage_index) =
-          structure::get_storage_index(compute_rhs_tensor_index(
-              {{LhsIndices::value...}}, {{Args::value...}},
-              lhs_storage_to_tensor_indices[lhs_storage_index]));
-    }
-    return lhs_to_rhs_map;
-  }
-
-  /// \brief return the value at a left hand side tensor's storage index
-  ///
-  /// \details
-  /// If Derived is a TensorExpression, `storage_index` is forwarded onto the
-  /// concrete derived TensorExpression.
-  ///
-  /// Otherwise, it is a Tensor, where one big challenge with TensorExpression
-  /// implementation is the reordering of the indices on the left hand side
-  /// (LHS) and right hand side (RHS) of the expression. The algorithms
-  /// implemented in `compute_lhs_to_rhs_map` and `compute_rhs_tensor_index`
-  /// handle the index sorting by mapping between the generic index orders of
-  /// the LHS and RHS.
-  ///
-  /// \tparam LhsStructure the Structure of the Tensor on the LHS of the
-  /// TensorExpression
-  /// \tparam LhsIndices the TensorIndexs of the Tensor on the LHS of the tensor
-  /// expression
-  /// \param lhs_storage_index the storage index of the LHS tensor component to
-  /// retrieve
-  /// \return the value of the DataType of the component at `lhs_storage_index`
-  /// in the LHS tensor
-  template <typename LhsStructure, typename... LhsIndices>
-  SPECTRE_ALWAYS_INLINE decltype(auto)
-  get(const size_t lhs_storage_index) const noexcept {
-    if constexpr (not tt::is_a_v<Tensor, Derived>) {
-      return static_cast<const Derived&>(*this)
-          .template get<LhsStructure, LhsIndices...>(lhs_storage_index);
-    } else if constexpr (std::is_same_v<LhsStructure, structure> and
-                         std::is_same_v<tmpl::list<LhsIndices...>,
-                                        tmpl::list<Args...>>) {
-      // the LHS and RHS tensors have the same structure and generic index
-      // order, so the RHS storage index is equivalent to the LHS storage index
-      return (*t_)[lhs_storage_index];
-    } else {
-      // the LHS and RHS tensors do not have the same structure or generic index
-      // order, so we must map the LHS storage index to its corresponding RHS
-      // storage index
-      constexpr std::array<size_t, LhsStructure::size()> lhs_to_rhs_map =
-          compute_lhs_to_rhs_map<LhsStructure, LhsIndices...>();
-      return (*t_)[gsl::at(lhs_to_rhs_map, lhs_storage_index)];
-    }
-  }
-
-  /// Retrieve the i'th entry of the Tensor being held
-  template <typename V = Derived,
-            Requires<tt::is_a<Tensor, V>::value> = nullptr>
-  SPECTRE_ALWAYS_INLINE type operator[](const size_t i) const {
-    return t_->operator[](i);
-  }
-
-  /// \brief Construct a TensorExpression from another TensorExpression.
-  ///
-  /// In this case we do not need to store a pointer to the TensorExpression
-  /// since we can cast back to the derived class using operator~.
-  template <typename V = Derived,
-            Requires<not tt::is_a<Tensor, V>::value> = nullptr>
-  TensorExpression() {}  // NOLINT
-
-  /// \brief Construct a TensorExpression from a Tensor.
-  ///
-  /// We need to store a pointer to the Tensor in a member variable in order
-  /// to be able to access the data when later evaluating the tensor expression.
-  explicit TensorExpression(const Tensor<DataType, Symm, index_list>& t)
-      : t_(&t) {}
-
- private:
-  /// Holds a pointer to a Tensor if the TensorExpression represents one.
-  ///
-  /// The pointer is needed so that the Tensor class need not derive from
-  /// TensorExpression. The reason deriving off of TensorExpression is
-  /// problematic for Tensor is that the index structure is part of the type
-  /// of the TensorExpression, so every possible permutation and combination of
-  /// indices must be derived from. For a rank-3 tensor this is already over 500
-  /// base classes, which the Intel compiler takes too long to compile.
-  ///
-  /// Benchmarking shows that GCC 6 and Clang 3.9.0 can derive off of 672 base
-  /// classes with compilation time of about 5 seconds, while the Intel compiler
-  /// v16.3 takes around 8 minutes. These tests were done on a Haswell Core i5.
-  const Derived* t_ = nullptr;
 };
 // @}

--- a/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
@@ -192,6 +192,8 @@ struct TensorExpression<Derived, DataType, Symm, tmpl::list<Indices...>,
   /// Typelist of the tensor indices, e.g. `_a_t` and `_b_t` in `F(_a, _b)`
   using args_list = ArgsList<Args...>;
 
+  virtual ~TensorExpression() = 0;
+
   // @{
   /// Derived is casted down to the derived class. This is enabled by the
   /// [CRTP](https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern)
@@ -203,4 +205,10 @@ struct TensorExpression<Derived, DataType, Symm, tmpl::list<Indices...>,
   }
   // @}
 };
+
+template <typename Derived, typename DataType, typename Symm,
+          typename... Indices, template <typename...> class ArgsList,
+          typename... Args>
+TensorExpression<Derived, DataType, Symm, tmpl::list<Indices...>,
+                 ArgsList<Args...>>::~TensorExpression() = default;
 // @}

--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -16,6 +16,7 @@
 #include "DataStructures/ModalVector.hpp"
 #include "DataStructures/SpinWeighted.hpp"
 #include "DataStructures/Tensor/Expressions/Contract.hpp"
+#include "DataStructures/Tensor/Expressions/TensorAsExpression.hpp"
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Structure.hpp"
@@ -126,8 +127,8 @@ class Tensor<X, Symm, IndexList<Indices...>> {
   /// The type of the TensorExpression that would represent this Tensor in a
   /// tensor expression.
   template <typename ArgsList>
-  using TE = TensorExpression<Tensor<X, Symm, tmpl::list<Indices...>>, X, Symm,
-                              tmpl::list<Indices...>, ArgsList>;
+  using TE = TensorExpressions::TensorAsExpression<
+      Tensor<X, Symm, IndexList<Indices...>>, ArgsList>;
 
   Tensor() = default;
   ~Tensor() = default;


### PR DESCRIPTION
## Proposed changes

This PR makes `TensorExpression`, the base struct for all expression structs, abstract. As part of this effort, the current portions of `TensorExpression` that handle representing and grabbing components out of `Tensor`s have been factored out into a new derived expression class specifically for representing `Tensor`s. The motivation for this change is to ensure that `TensorExpression` cannot be instantiated.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
