### PR TITLE
Change interpolation in ObserveFields so that exact inertial coordina…

### DIFF
--- a/tests/Unit/ParallelAlgorithms/Events/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Events/CMakeLists.txt
@@ -14,10 +14,22 @@ add_test_library(
   ${LIBRARY}
   "ParallelAlgorithms/Events/"
   "${LIBRARY_SOURCES}"
-  "DataStructures;Domain;ErrorHandling;IO;Spectral;Time;Utilities"
+  ""
   )
 
 add_dependencies(
   ${LIBRARY}
   module_GlobalCache
   )
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  CoordinateMaps
+  DataStructures
+  Domain
+  ErrorHandling
+  IO;Spectral
+  Time
+  Utilities
+)


### PR DESCRIPTION


## Proposed changes
fixes a bug where the returned inertial coordinates were not a exact but an approximation
<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
