### PR TITLE
Use unsorted generic indices in AddSub

### DIFF
--- a/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
+++ b/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
@@ -60,7 +60,7 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
           typename T1::type,
           tmpl::transform<typename T1::symmetry, typename T2::symmetry,
                           tmpl::append<tmpl::max<tmpl::_1, tmpl::_2>>>,
-          typename T1::index_list, tmpl::sort<typename T1::args_list>> {
+          typename T1::index_list, typename T1::args_list> {
   static_assert(std::is_same<typename T1::type, typename T2::type>::value,
                 "Cannot add or subtract Tensors holding different data types.");
   static_assert(
@@ -79,7 +79,7 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
                                    tmpl::append<tmpl::max<tmpl::_1, tmpl::_2>>>;
   using index_list = typename T1::index_list;
   static constexpr auto num_tensor_indices = tmpl::size<index_list>::value;
-  using args_list = tmpl::sort<typename T1::args_list>;
+  using args_list = typename T1::args_list;
 
   AddSub(T1 t1, T2 t2) : t1_(std::move(t1)), t2_(std::move(t2)) {}
   ~AddSub() override = default;

--- a/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
@@ -153,11 +153,8 @@ struct is_tensor_index<TensorIndex<I>> : std::true_type {};
 /// \brief Marks a class as being a TensorExpression
 ///
 /// \details
-/// The empty base class that all TensorExpression`s must inherit from.
-/// \derivedrequires
-/// 1) The args_list will be the sorted args_list received as input
-///
-/// 2) The tensor indices will be swapped to conform with mathematical notation
+/// The empty base class provides a simple means for checking if a type is a
+/// TensorExpression.
 struct Expression {};
 
 // @{


### PR DESCRIPTION
## Proposed changes

This PR updates `AddSub` to use the first operand's unsorted list of generic indices as its own list of generic indices, instead of using the sorted list.

The motivation for this change is that none of the other derived `TensorExpression`s sort their generic indices, and there doesn't appear to be a benefit for sorting them here. Moreover, by not sorting them, we have a higher chance of entering [this code path](https://github.com/sxs-collaboration/spectre/blob/a949ad8a9b26c9334cb9c64dde51593d2f33b578/src/DataStructures/Tensor/Expressions/TensorAsExpression.hpp#L345) when grabbing components out of at least one of the operands - the first operand, if not also the second. This code path is for the case where the `Structure` and list of generic indices of the LHS and RHS tensor are the same, and has the benefit of avoiding having to create the storage index mapping at compile time that's done in the [alternative code path just below it](https://github.com/sxs-collaboration/spectre/blob/a949ad8a9b26c9334cb9c64dde51593d2f33b578/src/DataStructures/Tensor/Expressions/TensorAsExpression.hpp#L349).

The description for the empty base class, `Expression`, has also been updated to reflect the consistency in not sorting indices in the derived `TensorExpression`s, as well as the fact that not all concrete classes perform index reordering.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
