### PR TITLE
Propagate PCH flags to dependent targets

### DIFF
--- a/cmake/SetupPch.cmake
+++ b/cmake/SetupPch.cmake
@@ -75,14 +75,10 @@ if (USE_PCH)
   # The major remaining step is setting the PCH include flag. For
   # (Apple)Clang this is `-include-pch;${SPECTRE_PCH_PATH}`, while for GCC it
   # is `-include;${SPECTRE_PCH_HEADER_PATH}`. We add
-  # `INTERFACE_COMPILE_OPTIONS` to ${SPECTRE_PCH} that libraries can grab
-  # using generator expressions:
+  # `INTERFACE_COMPILE_OPTIONS` to ${SPECTRE_PCH} so libraries can just link
+  # the ${SPECTRE_PCH} target:
   #
-  #     target_compile_options(
-  #       ${TARGET_NAME}
-  #       PRIVATE
-  #       $<TARGET_PROPERTY:${SPECTRE_PCH},INTERFACE_COMPILE_OPTIONS>
-  #       )
+  #     target_link_libraries(${TARGET_NAME} PUBLIC ${SPECTRE_PCH})
   #
   # Source files in dependent targets must depend on the PCH file itself:
   #
@@ -177,7 +173,7 @@ if (USE_PCH)
     )
   target_link_libraries(
     ${SPECTRE_PCH_LIB}
-    PRIVATE
+    PUBLIC
     Blaze
     Brigand
     )
@@ -195,7 +191,7 @@ if (USE_PCH)
     )
   target_link_libraries(
     ${SPECTRE_PCH_LIB}
-    PRIVATE
+    PUBLIC
     SpectreFlags
     )
 
@@ -210,11 +206,10 @@ if (USE_PCH)
     )
 
   # Create the ${SPECTRE_PCH} that libraries and executables will depend on
-  add_custom_target(
+  add_library(${SPECTRE_PCH} INTERFACE)
+  target_link_libraries(
     ${SPECTRE_PCH}
-    )
-  add_dependencies(
-    ${SPECTRE_PCH}
+    INTERFACE
     ${SPECTRE_PCH_LIB}
     )
 

--- a/cmake/SpectreAddLibraries.cmake
+++ b/cmake/SpectreAddLibraries.cmake
@@ -50,17 +50,13 @@ function(ADD_SPECTRE_LIBRARY LIBRARY_NAME)
   endif (NOT ${LIBRARY_TYPE} STREQUAL INTERFACE_LIBRARY)
   if (NOT "${LIBRARY_NAME}" MATCHES "^${SPECTRE_PCH}"
       AND NOT ${LIBRARY_IS_IMPORTED}
-      AND NOT ${LIBRARY_TYPE} STREQUAL INTERFACE_LIBRARY)
-    add_dependencies(${LIBRARY_NAME} ${SPECTRE_PCH})
+      AND NOT ${LIBRARY_TYPE} STREQUAL INTERFACE_LIBRARY
+      AND TARGET ${SPECTRE_PCH})
+    target_link_libraries(${LIBRARY_NAME} PRIVATE ${SPECTRE_PCH})
     set_source_files_properties(
         ${ARGN}
         OBJECT_DEPENDS "${SPECTRE_PCH_PATH}"
         )
-    target_compile_options(
-      ${LIBRARY_NAME}
-      PRIVATE
-      $<TARGET_PROPERTY:${SPECTRE_PCH},INTERFACE_COMPILE_OPTIONS>
-      )
   endif()
   if (${LIBRARY_TYPE} STREQUAL INTERFACE_LIBRARY)
     target_link_libraries(

--- a/cmake/SpectreAddTestLibs.cmake
+++ b/cmake/SpectreAddTestLibs.cmake
@@ -122,15 +122,10 @@ function(add_test_library LIBRARY FOLDER LIBRARY_SOURCES LINK_LIBS)
 
   # Add PCH to test libs
   if(TARGET ${SPECTRE_PCH})
+    target_link_libraries(${LIBRARY} PRIVATE ${SPECTRE_PCH})
     set_source_files_properties(
       ${LIBRARY_SOURCES}
       OBJECT_DEPENDS "${SPECTRE_PCH_PATH}"
-      )
-    add_dependencies(${LIBRARY} ${SPECTRE_PCH})
-    target_compile_options(
-      ${LIBRARY}
-      PRIVATE
-      $<TARGET_PROPERTY:${SPECTRE_PCH},INTERFACE_COMPILE_OPTIONS>
       )
   endif(TARGET ${SPECTRE_PCH})
 

--- a/cmake/UpdateAddExecutables.cmake
+++ b/cmake/UpdateAddExecutables.cmake
@@ -11,15 +11,10 @@ function(add_spectre_executable TARGET_NAME)
       IMPORTED
       )
     if(NOT ${TARGET_IS_IMPORTED})
-      add_dependencies(${TARGET_NAME} ${SPECTRE_PCH})
+      target_link_libraries(${TARGET_NAME} PRIVATE ${SPECTRE_PCH})
       set_source_files_properties(
         ${ARGN}
         OBJECT_DEPENDS "${SPECTRE_PCH_PATH}"
-        )
-      target_compile_options(
-        ${TARGET_NAME}
-        PRIVATE
-        $<TARGET_PROPERTY:${SPECTRE_PCH},INTERFACE_COMPILE_OPTIONS>
         )
     endif()
   endif (USE_PCH)


### PR DESCRIPTION
## Proposed changes

In #2574 we noticed PCH flags did not properly propagate to dependent targets, which meant the compiler could not use the PCH and issued a warning if any flags mismatched. For example, a compiler definition like `-DBLAZE_XYZ` used in the PCH now propagates to targets that use the PCH.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
