### PR TITLE
Fix uninitialized array in OuterProduct

### DIFF
--- a/src/DataStructures/Tensor/Expressions/Product.hpp
+++ b/src/DataStructures/Tensor/Expressions/Product.hpp
@@ -132,7 +132,8 @@ struct OuterProduct<T1, T2, IndexList1<Indices1...>, IndexList2<Indices2...>,
           operand_tensorindex_vals = {{OperandTensorIndices::value...}};
 
       // the operand component's tensor multi-index to compute
-      std::array<size_t, operand_num_tensor_indices> operand_tensor_multi_index;
+      std::array<size_t, operand_num_tensor_indices>
+          operand_tensor_multi_index{};
       for (size_t i = 0; i < operand_num_tensor_indices; i++) {
         gsl::at(operand_tensor_multi_index, i) =
             gsl::at(lhs_tensor_multi_index,


### PR DESCRIPTION
## Proposed changes

This initializes a currently uninitialized `std::array` in `OuterProduct`. Although this was not generating errors that caused builds to fail, it was being noted multiple times in the raw logs associated with [this gcc-7 build](https://github.com/nilsdeppe/spectre/runs/1731686470?check_suite_focus=true), which no longer appear with this fix.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
