### PR TITLE
Make preconditioners the identity when skipped

### DIFF
--- a/src/ParallelAlgorithms/LinearSolver/Actions/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/Actions/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ParallelLinearSolver
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  MakeIdentityIfSkipped.hpp
+  )

--- a/src/ParallelAlgorithms/LinearSolver/Actions/MakeIdentityIfSkipped.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Actions/MakeIdentityIfSkipped.hpp
@@ -1,0 +1,94 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "NumericalAlgorithms/Convergence/HasConverged.hpp"
+#include "NumericalAlgorithms/Convergence/Reason.hpp"
+#include "NumericalAlgorithms/Convergence/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+namespace tuples {
+template <typename... Tags>
+struct TaggedTuple;
+}  // namespace tuples
+namespace Parallel {
+template <typename Metavariables>
+struct GlobalCache;
+}  // namespace Parallel
+/// \endcond
+
+namespace LinearSolver {
+/// Actions applicable to any parallel linear solver
+namespace Actions {
+
+/*!
+ * \brief Make the iterative linear solve the identity operation on the source
+ * vector if no iterations were performed at all. Useful for disabling a
+ * preconditioner by setting its number of iterations to zero.
+ *
+ * When the linear solve is skipped, i.e. when it performs no iterations because
+ * its number of iterations is set to zero, this action assumes \f$A=1\f$ so
+ * \f$Ax=b\f$ solves to \f$x=b\f$. This is useful when the solver is used as
+ * preconditioner, because then we can disable preconditioning by just not
+ * iterating the preconditioner, i.e. by setting its number of iterations to
+ * zero in the input file.
+ *
+ * To use this action, insert it into the action list just after iterating the
+ * linear solver, i.e. after its `solve` action list:
+ *
+ * \snippet LinearSolverAlgorithmTestHelpers.hpp make_identity_if_skipped
+ *
+ * This action will set the `LinearSolverType::fields_tag` to the
+ * `LinearSolverType::source_tag` whenever the linear solver has converged with
+ * the reason `Convergence::Reason::NumIterations` or
+ * `Convergence::Reason::MaxIterations` without actually having performed any
+ * iterations.
+ *
+ * \par Details:
+ * The standard behaviour of most linear solvers (i.e. when _not_ using this
+ * action) is to keep the fields at their initial guess \f$x=x_0\f$ when it
+ * performs no iterations. That behaviour is not handled well when the solver is
+ * used as preconditioner and its parent always makes it start at \f$x_0=0\f$.
+ * This is a reasonable choice to start the preconditioner but it also means
+ * that the preconditioner doesn't reduce to the identity when it performs no
+ * iterations. Using this action means not iterating the preconditioner at all
+ * essentially disables preconditioning, switching the parent solver to an
+ * unpreconditioned solve with some runtime and memory overhead associated with
+ * initializing the preconditioner.
+ */
+template <typename LinearSolverType>
+struct MakeIdentityIfSkipped {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    const auto& has_converged = get<Convergence::Tags::HasConverged<
+        typename LinearSolverType::options_group>>(box);
+    if (has_converged and
+        (has_converged.reason() == Convergence::Reason::NumIterations or
+         has_converged.reason() == Convergence::Reason::MaxIterations) and
+        has_converged.num_iterations() == 0) {
+      db::mutate<typename LinearSolverType::fields_tag>(
+          make_not_null(&box),
+          [](const auto fields, const auto& source) noexcept {
+            *fields = source;
+          },
+          get<typename LinearSolverType::source_tag>(box));
+    }
+    return {std::move(box)};
+  }
+};
+
+}  // namespace Actions
+}  // namespace LinearSolver

--- a/src/ParallelAlgorithms/LinearSolver/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(
   Utilities
   )
 
+add_subdirectory(Actions)
 add_subdirectory(AsynchronousSolvers)
 add_subdirectory(ConjugateGradient)
 add_subdirectory(Gmres)

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
@@ -41,6 +41,7 @@
 #include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
+#include "ParallelAlgorithms/LinearSolver/Actions/MakeIdentityIfSkipped.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
@@ -288,7 +289,8 @@ struct run_preconditioner_impl {
   using type =
       tmpl::list<ComputeOperatorAction<typename Preconditioner::fields_tag>,
                  typename Preconditioner::template solve<ComputeOperatorAction<
-                     typename Preconditioner::operand_tag>>>;
+                     typename Preconditioner::operand_tag>>,
+                 LinearSolver::Actions::MakeIdentityIfSkipped<Preconditioner>>;
 };
 
 template <>

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
@@ -36,6 +36,7 @@
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
+#include "ParallelAlgorithms/LinearSolver/Actions/MakeIdentityIfSkipped.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
@@ -240,8 +241,12 @@ template <typename Preconditioner>
 struct run_preconditioner_impl {
   using type =
       tmpl::list<ComputeOperatorAction<typename Preconditioner::fields_tag>,
+                 // [make_identity_if_skipped]
                  typename Preconditioner::template solve<ComputeOperatorAction<
-                     typename Preconditioner::operand_tag>>>;
+                     typename Preconditioner::operand_tag>>,
+                 LinearSolver::Actions::MakeIdentityIfSkipped<Preconditioner>
+                 // [make_identity_if_skipped]
+                 >;
 };
 
 template <>

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Actions/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Actions/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_LinearSolverActions")
+
+set(LIBRARY_SOURCES
+  Test_MakeIdentityIfSkipped.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "ParallelAlgorithms/LinearSolver/Actions"
+  "${LIBRARY_SOURCES}"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  Convergence
+  DataStructures
+  Parallel
+  Utilities
+  )

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Actions/Test_MakeIdentityIfSkipped.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Actions/Test_MakeIdentityIfSkipped.cpp
@@ -1,0 +1,84 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DenseVector.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "NumericalAlgorithms/Convergence/Tags.hpp"
+#include "Parallel/Actions/TerminatePhase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "ParallelAlgorithms/LinearSolver/Actions/MakeIdentityIfSkipped.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+
+struct TestOptionsGroup {};
+
+struct FieldsTag : db::SimpleTag {
+  using type = DenseVector<double>;
+};
+
+struct SourceTag : db::SimpleTag {
+  using type = DenseVector<double>;
+};
+
+struct TestLinearSolver {
+  using options_group = TestOptionsGroup;
+  using fields_tag = FieldsTag;
+  using source_tag = SourceTag;
+};
+
+template <typename Metavariables>
+struct ElementArray {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          tmpl::list<ActionTesting::InitializeDataBox<
+              tmpl::list<Convergence::Tags::HasConverged<TestOptionsGroup>,
+                         FieldsTag, SourceTag>>>>,
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          tmpl::list<
+              LinearSolver::Actions::MakeIdentityIfSkipped<TestLinearSolver>,
+              Parallel::Actions::TerminatePhase>>>;
+};
+
+struct Metavariables {
+  using element_array = ElementArray<Metavariables>;
+  using component_list = tmpl::list<element_array>;
+  enum class Phase { Initialization, Testing, Exit };
+};
+
+void test_make_identity_if_skipped(const bool skipped) {
+  CAPTURE(skipped);
+  Convergence::HasConverged has_converged{skipped ? 0_st : 1_st, 0};
+  using element_array = typename Metavariables::element_array;
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{{}};
+  ActionTesting::emplace_component_and_initialize<element_array>(
+      make_not_null(&runner), 0,
+      {has_converged, DenseVector<double>{3, 1.}, DenseVector<double>{3, 2.}});
+  ActionTesting::set_phase(make_not_null(&runner),
+                           Metavariables::Phase::Testing);
+  ActionTesting::next_action<element_array>(make_not_null(&runner), 0);
+  const auto get_tag = [&runner](auto tag_v) -> decltype(auto) {
+    using tag = std::decay_t<decltype(tag_v)>;
+    return ActionTesting::get_databox_tag<element_array, tag>(runner, 0);
+  };
+  CHECK(get_tag(SourceTag{}) == DenseVector<double>{3, 2.});
+  CHECK(get_tag(FieldsTag{}) ==
+        (skipped ? DenseVector<double>{3, 2.} : DenseVector<double>{3, 1.}));
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ParallelLinearSolver.Actions.MakeIdentityIfSkipped",
+                  "[Unit][ParallelAlgorithms][LinearSolver][Actions]") {
+  test_make_identity_if_skipped(false);
+  test_make_identity_if_skipped(true);
+}

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/CMakeLists.txt
@@ -75,6 +75,7 @@ function(add_distributed_linear_solver_algorithm_test TEST_NAME)
     )
 endfunction()
 
+add_subdirectory(Actions)
 add_subdirectory(AsynchronousSolvers)
 add_subdirectory(ConjugateGradient)
 add_subdirectory(Gmres)


### PR DESCRIPTION
## Proposed changes

Add an action that makes an iterative linear solve the identity operation
if no steps were performed at all, i.e. assume A=1 so Ax=b solves to x=b.
This is useful when the solver is used as preconditioner, because then we
can disable preconditioning by just not iterating the preconditioner, i.e.
by setting its number of iterations to 0 in the input file. The alternative 
(when not using this action) is to keep the fields at their initial guess x=x0.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
