### PR TITLE
Add MaxRicciScalarTag to Tags.hpp

### DIFF
--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -366,6 +366,24 @@ struct RicciScalarCompute : RicciScalar, db::ComputeTag {
   using return_type = Scalar<DataVector>;
 };
 
+/// The pointwise maximum of the Strahlkorper's intrinsic Ricci scalar
+/// curvature.
+struct MaxRicciScalar : db::SimpleTag {
+  using type = double;
+};
+
+/// Computes the pointwise maximum of the Strahlkorper's intrinsic Ricci
+/// scalar curvature.
+struct MaxRicciScalarCompute : MaxRicciScalar, db::ComputeTag {
+  using base = MaxRicciScalar;
+  using return_type = double;
+  static void function(const gsl::not_null<double*> max_ricci_scalar,
+                       const Scalar<DataVector>& ricci_scalar) noexcept {
+    *max_ricci_scalar = max(get(ricci_scalar));
+  }
+  using argument_tags = tmpl::list<RicciScalar>;
+};
+
 // @{
 /// `Tangents(i,j)` is \f$\partial x_{\rm surf}^i/\partial q^j\f$,
 /// where \f$x_{\rm surf}^i\f$ are the Cartesian coordinates of the

--- a/src/ApparentHorizons/TagsDeclarations.hpp
+++ b/src/ApparentHorizons/TagsDeclarations.hpp
@@ -49,6 +49,8 @@ struct UnitNormalVectorCompute;
 struct RicciScalar;
 template <typename Frame>
 struct RicciScalarCompute;
+struct MaxRicciScalar;
+struct MaxRicciScalarCompute;
 
 }  // namespace StrahlkorperTags
 

--- a/tests/Unit/ApparentHorizons/Test_Tags.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Tags.cpp
@@ -281,10 +281,20 @@ void test_normals() {
   CHECK_ITERABLE_APPROX(expected_normal_mag, get(normal_mag));
 }
 
+void test_max_ricci_scalar() {
+  // Test max_ricci_scalar
+  Scalar<DataVector> d{{{{1., 2., 3.}}}};
+  const double expected_max{3.};
+  double max{std::numeric_limits<double>::signaling_NaN()};
+  StrahlkorperTags::MaxRicciScalarCompute::function(make_not_null(&max), d);
+  CHECK(expected_max == max);
+}
+
 struct SomeType {};
 struct SomeTag : db::SimpleTag {
   using type = SomeType;
 };
+
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
@@ -292,6 +302,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
   test_average_radius();
   test_radius_and_derivs();
   test_normals();
+  test_max_ricci_scalar();
   TestHelpers::db::test_simple_tag<ah::Tags::FastFlow>("FastFlow");
   TestHelpers::db::test_simple_tag<StrahlkorperGr::Tags::Area>("Area");
   TestHelpers::db::test_simple_tag<StrahlkorperGr::Tags::IrreducibleMass>(
@@ -300,6 +311,8 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
       "OneOverOneFormMagnitude");
   TestHelpers::db::test_simple_tag<StrahlkorperTags::RicciScalar>(
       "RicciScalar");
+  TestHelpers::db::test_simple_tag<StrahlkorperTags::MaxRicciScalar>(
+      "MaxRicciScalar");
   TestHelpers::db::test_simple_tag<StrahlkorperGr::Tags::SpinFunction>(
       "SpinFunction");
   TestHelpers::db::test_simple_tag<
@@ -421,6 +434,8 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
   TestHelpers::db::test_compute_tag<
       StrahlkorperTags::RicciScalarCompute<Frame::Inertial>>(
       "RicciScalar");
+  TestHelpers::db::test_compute_tag<StrahlkorperTags::MaxRicciScalarCompute>(
+      "MaxRicciScalar");
   TestHelpers::db::test_compute_tag<
       StrahlkorperGr::Tags::SpinFunctionCompute<Frame::Inertial>>(
       "SpinFunction");


### PR DESCRIPTION
## Proposed changes

The MaxRicciScalarTag and MaxRicciScalarTagCompute calculate the pointwise maximum of the Strahlkorper's intrinsic Ricci scalar curvature.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
