### PR TITLE
Add mocked cores and nodes to ActionTesting

### DIFF
--- a/src/Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp
@@ -23,7 +23,6 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeString.hpp"
 #include "Utilities/Requires.hpp"
-#include "Utilities/System/ParallelInfo.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 

--- a/src/IO/Observer/Actions/RegisterSingleton.hpp
+++ b/src/IO/Observer/Actions/RegisterSingleton.hpp
@@ -13,9 +13,10 @@
 #include "IO/Observer/ObserverComponent.hpp"
 #include "IO/Observer/TypeOfObservation.hpp"
 #include "Parallel/GlobalCache.hpp"
+#include "Parallel/Info.hpp"
 #include "Parallel/Invoke.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
-#include "Utilities/System/ParallelInfo.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
 namespace observers::Actions {
@@ -55,10 +56,12 @@ struct RegisterSingletonWithObserverWriter {
 
     // We call only on node 0; the observation call will occur only
     // on node 0.
+    auto& my_proxy = Parallel::get_parallel_component<ParallelComponent>(cache);
     Parallel::simple_action<Actions::RegisterReductionNodeWithWritingNode>(
         Parallel::get_parallel_component<
             observers::ObserverWriter<Metavariables>>(cache)[0],
-        observation_key, static_cast<size_t>(sys::my_node()));
+        observation_key,
+        static_cast<size_t>(Parallel::my_node(*my_proxy.ckLocal())));
     return {std::move(box), true};
   }
 };

--- a/src/IO/Observer/VolumeActions.hpp
+++ b/src/IO/Observer/VolumeActions.hpp
@@ -19,12 +19,12 @@
 #include "IO/Observer/Tags.hpp"
 #include "IO/Observer/TypeOfObservation.hpp"
 #include "Parallel/GlobalCache.hpp"
+#include "Parallel/Info.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Requires.hpp"
-#include "Utilities/System/ParallelInfo.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -300,8 +300,13 @@ struct ContributeVolumeDataToWriter {
         {
           // Scoping is for closing HDF5 file before we release the lock.
           const auto& file_prefix = Parallel::get<Tags::VolumeFileName>(cache);
+          auto& my_proxy =
+              Parallel::get_parallel_component<ParallelComponent>(cache);
           h5::H5File<h5::AccessType::ReadWrite> h5file(
-              file_prefix + std::to_string(sys::my_node()) + ".h5", true);
+              file_prefix +
+                  std::to_string(Parallel::my_node(*my_proxy.ckLocalBranch())) +
+                  ".h5",
+              true);
           constexpr size_t version_number = 0;
           auto& volume_file =
               h5file.try_insert<h5::VolumeData>(subfile_name, version_number);

--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -307,6 +307,52 @@ class AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>
   /// Check if an algorithm should continue being evaluated
   constexpr bool get_terminate() const noexcept { return terminate_; }
 
+  // {@
+  /// Wrappers for charm++ informational functions.
+
+  /// Number of processing elements
+  inline int number_of_procs() const noexcept {
+    return sys::number_of_procs();
+  }
+
+  /// %Index of my processing element.
+  inline int my_proc() const noexcept { return sys::my_proc(); }
+
+  /// Number of nodes.
+  inline int number_of_nodes() const noexcept {
+    return sys::number_of_nodes();
+  }
+
+  /// %Index of my node.
+  inline int my_node() const noexcept { return sys::my_node(); }
+
+  /// Number of processing elements on the given node.
+  inline int procs_on_node(const int node_index) const noexcept {
+    return sys::procs_on_node(node_index);
+  }
+
+  /// The local index of my processing element on my node.
+  /// This is in the interval 0, ..., procs_on_node(my_node()) - 1.
+  inline int my_local_rank() const noexcept {
+    return sys::my_local_rank();
+  }
+
+  /// %Index of first processing element on the given node.
+  inline int first_proc_on_node(const int node_index) const noexcept {
+    return sys::first_proc_on_node(node_index);
+  }
+
+  /// %Index of the node for the given processing element.
+  inline int node_of(const int proc_index) const noexcept {
+    return sys::node_of(proc_index);
+  }
+
+  /// The local index for the given processing element on its node.
+  inline int local_rank_of(const int proc_index) const noexcept {
+    return sys::local_rank_of(proc_index);
+  }
+  // @}
+
  private:
   static constexpr bool is_singleton =
       std::is_same_v<chare_type, Parallel::Algorithms::Singleton>;

--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -24,6 +24,7 @@
 #include "Parallel/Algorithms/AlgorithmSingletonDeclarations.hpp"
 #include "Parallel/CharmRegistration.hpp"
 #include "Parallel/GlobalCache.hpp"
+#include "Parallel/Info.hpp"
 #include "Parallel/NodeLock.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"

--- a/src/Parallel/CMakeLists.txt
+++ b/src/Parallel/CMakeLists.txt
@@ -27,6 +27,7 @@ spectre_target_headers(
   CreateFromOptions.hpp
   GlobalCache.hpp
   InboxInserters.hpp
+  Info.hpp
   InitializationFunctions.hpp
   Invoke.hpp
   Main.hpp

--- a/src/Parallel/Info.hpp
+++ b/src/Parallel/Info.hpp
@@ -1,0 +1,104 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines functions that provide low-level system information such as number
+/// of nodes and processors, in a way that they are mockable in ActionTesting.
+
+#pragma once
+
+/// Functionality for parallelization.
+///
+/// The functions in namespace `Parallel` that return information on
+/// nodes and cores are templated on DistribObject.  Actions should
+/// use these functions rather than the raw charm++ versions (in the
+/// sys namespace in Utilities/System/ParalleInfo.hpp) so that the
+/// mocking framework will see the mocked cores and nodes.
+namespace Parallel {
+
+/*!
+ * \ingroup ParallelGroup
+ * \brief Number of processing elements.
+ */
+template <typename DistribObject>
+int number_of_procs(const DistribObject& distributed_object) {
+  return distributed_object.number_of_procs();
+}
+
+/*!
+ * \ingroup ParallelGroup
+ * \brief %Index of my processing element.
+ */
+template <typename DistribObject>
+int my_proc(const DistribObject& distributed_object) {
+  return distributed_object.my_proc();
+}
+
+/*!
+ * \ingroup ParallelGroup
+ * \brief Number of nodes.
+ */
+template <typename DistribObject>
+int number_of_nodes(const DistribObject& distributed_object) {
+  return distributed_object.number_of_nodes();
+}
+
+ /*!
+  * \ingroup ParallelGroup
+  * \brief %Index of my node.
+  */
+template <typename DistribObject>
+int my_node(const DistribObject& distributed_object) {
+  return distributed_object.my_node();
+}
+
+/*!
+ * \ingroup ParallelGroup
+ * \brief Number of processing elements on the given node.
+ */
+template <typename DistribObject>
+int procs_on_node(const int node_index,
+                  const DistribObject& distributed_object) {
+  return distributed_object.procs_on_node(node_index);
+}
+
+/*!
+ * \ingroup ParallelGroup
+ * \brief The local index of my processing element on my node.
+ * This is in the interval 0, ..., procs_on_node(my_node()) - 1.
+ */
+template <typename DistribObject>
+int my_local_rank(const DistribObject& distributed_object) {
+  return distributed_object.my_local_rank();
+}
+
+/*!
+ * \ingroup ParallelGroup
+ * \brief %Index of first processing element on the given node.
+ */
+template <typename DistribObject>
+int first_proc_on_node(const int node_index,
+                       const DistribObject& distributed_object) {
+  return distributed_object.first_proc_on_node(node_index);
+}
+
+/*!
+ * \ingroup ParallelGroup
+ * \brief %Index of the node for the given processing element.
+ */
+template <typename DistribObject>
+int node_of(const int proc_index, const DistribObject& distributed_object) {
+  return distributed_object.node_of(proc_index);
+}
+
+/*!
+ * \ingroup ParallelGroup
+ * \brief The local index for the given processing element on its node.
+ */
+template <typename DistribObject>
+int local_rank_of(const int proc_index,
+                  const DistribObject& distributed_object) {
+  return distributed_object.local_rank_of(proc_index);
+}
+
+}  // namespace Parallel

--- a/src/Parallel/Invoke.hpp
+++ b/src/Parallel/Invoke.hpp
@@ -32,6 +32,28 @@ struct has_ckLocal_method : std::false_type {};
 template <typename T>
 struct has_ckLocal_method<T, std::void_t<decltype(std::declval<T>().ckLocal())>>
     : std::true_type {};
+
+// Any class template that disables its ckLocal() function for some
+// template parameters (via static_assert or if constexpr) should
+// define a type alias ckLocal_enabled to be std::true_type for
+// cases where ckLocal() is enabled, and std::false_type for cases
+// where ckLocal() is disabled.  If ckLocal_enabled isn't defined,
+// then ckLocal() is understood to be enabled.
+template<typename T, typename = std::void_t<>>
+struct ckLocal_enabled {
+  using type = std::true_type;
+};
+
+template <typename T>
+struct ckLocal_enabled<T, std::void_t<typename T::ckLocal_enabled>> {
+  using type = typename T::ckLocal_enabled;
+};
+
+template <typename T>
+using ckLocal_exists_and_is_enabled_t =
+    std::conditional_t<has_ckLocal_method<T>::value,
+                       typename ckLocal_enabled<T>::type, std::false_type>;
+
 }  // namespace detail
 
 // @{
@@ -43,9 +65,9 @@ struct has_ckLocal_method<T, std::void_t<decltype(std::declval<T>().ckLocal())>>
  * If the algorithm was previously disabled, set `enable_if_disabled` to true to
  * enable the algorithm on the parallel component.
  */
-template <
-    typename ReceiveTag, typename Proxy, typename ReceiveDataType,
-    Requires<detail::has_ckLocal_method<std::decay_t<Proxy>>::value> = nullptr>
+template <typename ReceiveTag, typename Proxy, typename ReceiveDataType,
+          Requires<detail::ckLocal_exists_and_is_enabled_t<
+              std::decay_t<Proxy>>::value> = nullptr>
 void receive_data(Proxy&& proxy, typename ReceiveTag::temporal_id temporal_id,
                   ReceiveDataType&& receive_data,
                   const bool enable_if_disabled = false) noexcept {
@@ -64,8 +86,8 @@ void receive_data(Proxy&& proxy, typename ReceiveTag::temporal_id temporal_id,
 }
 
 template <typename ReceiveTag, typename Proxy, typename ReceiveDataType,
-          Requires<not detail::has_ckLocal_method<std::decay_t<Proxy>>::value> =
-              nullptr>
+          Requires<not detail::ckLocal_exists_and_is_enabled_t<
+              std::decay_t<Proxy>>::value> = nullptr>
 void receive_data(Proxy&& proxy, typename ReceiveTag::temporal_id temporal_id,
                   ReceiveDataType&& receive_data,
                   const bool enable_if_disabled = false) noexcept {

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp
@@ -67,7 +67,8 @@ struct InitializeResidual {
         });
 
     LinearSolver::observe_detail::contribute_to_reduction_observer<
-        OptionsGroup>(iteration_id, residual_magnitude, cache);
+        OptionsGroup, ParallelComponent>(iteration_id, residual_magnitude,
+                                         cache);
 
     // Determine whether the linear solver has converged
     Convergence::HasConverged has_converged{
@@ -159,7 +160,8 @@ struct UpdateResidual {
     const size_t completed_iterations = iteration_id + 1;
     const double residual_magnitude = sqrt(residual_square);
     LinearSolver::observe_detail::contribute_to_reduction_observer<
-        OptionsGroup>(completed_iterations, residual_magnitude, cache);
+        OptionsGroup, ParallelComponent>(completed_iterations,
+                                         residual_magnitude, cache);
 
     // Determine whether the linear solver has converged
     Convergence::HasConverged has_converged{

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitorActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitorActions.hpp
@@ -63,7 +63,8 @@ struct InitializeResidualMagnitude {
         });
 
     LinearSolver::observe_detail::contribute_to_reduction_observer<
-        OptionsGroup>(iteration_id, residual_magnitude, cache);
+        OptionsGroup, ParallelComponent>(iteration_id, residual_magnitude,
+                                         cache);
 
     // Determine whether the linear solver has already converged
     Convergence::HasConverged has_converged{
@@ -178,7 +179,8 @@ struct StoreOrthogonalization {
 
     const size_t completed_iterations = iteration_id + 1;
     LinearSolver::observe_detail::contribute_to_reduction_observer<
-        OptionsGroup>(completed_iterations, residual_magnitude, cache);
+        OptionsGroup, ParallelComponent>(completed_iterations,
+                                         residual_magnitude, cache);
 
     // Determine whether the linear solver has converged
     Convergence::HasConverged has_converged{

--- a/src/Utilities/System/ParallelInfo.hpp
+++ b/src/Utilities/System/ParallelInfo.hpp
@@ -3,7 +3,9 @@
 
 /// \file
 /// Defines functions that provide low-level system information such as number
-/// of nodes and processors.
+/// of nodes and processors.  When working with distributed objects, one should
+/// use the corresponding functions in Parallel/Info.hpp instead of the
+/// low-level functions here.
 
 #pragma once
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
@@ -95,7 +95,7 @@ struct mock_observer {
       Parallel::get_initialization_tags<initialize_action_list>;
 
   using metavariables = Metavariables;
-  using chare_type = ActionTesting::MockArrayChare;
+  using chare_type = ActionTesting::MockGroupChare;
   using array_index = size_t;
 
   using phase_dependent_action_list = tmpl::list<

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
@@ -125,7 +125,7 @@ struct mock_characteristic_evolution {
       Parallel::get_initialization_tags<initialize_action_list>;
 
   using metavariables = Metavariables;
-  using chare_type = ActionTesting::MockArrayChare;
+  using chare_type = ActionTesting::MockSingletonChare;
   using array_index = size_t;
 
   using phase_dependent_action_list = tmpl::list<

--- a/tests/Unit/Evolution/Systems/Cce/Test_AnalyticBoundaryDataManager.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_AnalyticBoundaryDataManager.cpp
@@ -58,8 +58,9 @@ struct TestCallWriteNews {
   static void apply(const db::DataBox<tmpl::list<DbTags...>>& box,
                     Parallel::GlobalCache<Metavariables>& cache,
                     const ArrayIndex& /*array_index*/) noexcept {
-    db::get<Tags::AnalyticBoundaryDataManager>(box).write_news(
-        cache, db::get<::Tags::TimeStepId>(box).substep_time().value());
+    db::get<Tags::AnalyticBoundaryDataManager>(box)
+        .template write_news<ParallelComponent>(
+            cache, db::get<::Tags::TimeStepId>(box).substep_time().value());
   }
 };
 

--- a/tests/Unit/Evolution/Systems/Cce/Test_AnalyticBoundaryDataManager.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_AnalyticBoundaryDataManager.cpp
@@ -85,7 +85,7 @@ struct mock_boundary {
   using simple_tags =
       tmpl::list<Tags::AnalyticBoundaryDataManager, ::Tags::TimeStepId>;
   using metavariables = Metavariables;
-  using chare_type = ActionTesting::MockArrayChare;
+  using chare_type = ActionTesting::MockSingletonChare;
   using array_index = size_t;
   using const_global_cache_tags = tmpl::list<Tags::ObservationLMax>;
 

--- a/tests/Unit/Framework/MockRuntimeSystemFreeFunctions.hpp
+++ b/tests/Unit/Framework/MockRuntimeSystemFreeFunctions.hpp
@@ -38,6 +38,61 @@ void emplace_component(
                                                 std::forward<Options>(opts)...);
 }
 
+/// Emplaces a distributed array object with index `array_index` into
+/// the parallel component `Component`. The options `opts` are
+/// forwarded to be used in a call to
+/// `detail::ForwardAllOptionsToDataBox::apply`.
+template <typename Component, typename... Options>
+void emplace_array_component(
+    const gsl::not_null<MockRuntimeSystem<typename Component::metavariables>*>
+        runner,
+    const NodeId node_id, const LocalCoreId local_core_id,
+    const typename Component::array_index& array_index,
+    Options&&... opts) noexcept {
+  runner->template emplace_array_component<Component>(
+      node_id, local_core_id, array_index, std::forward<Options>(opts)...);
+}
+
+/// Emplaces a distributed singleton object into
+/// the parallel component `Component`. The options `opts` are
+/// forwarded to be used in a call to
+/// `detail::ForwardAllOptionsToDataBox::apply`.
+template <typename Component, typename... Options>
+void emplace_singleton_component(
+    const gsl::not_null<MockRuntimeSystem<typename Component::metavariables>*>
+        runner,
+    const NodeId node_id, const LocalCoreId local_core_id,
+    Options&&... opts) noexcept {
+  runner->template emplace_singleton_component<Component>(
+      node_id, local_core_id, std::forward<Options>(opts)...);
+}
+
+/// Emplaces a distributed group object into
+/// the parallel component `Component`. The options `opts` are
+/// forwarded to be used in a call to
+/// `detail::ForwardAllOptionsToDataBox::apply`.
+template <typename Component, typename... Options>
+void emplace_group_component(
+    const gsl::not_null<MockRuntimeSystem<typename Component::metavariables>*>
+        runner,
+    Options&&... opts) noexcept {
+  runner->template emplace_group_component<Component>(
+      std::forward<Options>(opts)...);
+}
+
+/// Emplaces a distributed nodegroup object into
+/// the parallel component `Component`. The options `opts` are
+/// forwarded to be used in a call to
+/// `detail::ForwardAllOptionsToDataBox::apply`.
+template <typename Component, typename... Options>
+void emplace_nodegroup_component(
+    const gsl::not_null<MockRuntimeSystem<typename Component::metavariables>*>
+        runner,
+    Options&&... opts) noexcept {
+  runner->template emplace_nodegroup_component<Component>(
+      std::forward<Options>(opts)...);
+}
+
 /// Emplaces a distributed object with index `array_index` into the parallel
 /// component `Component`. The options `opts` are forwarded to be used in a call
 /// to `detail::ForwardAllOptionsToDataBox::apply` Additionally, the simple tags
@@ -54,6 +109,82 @@ void emplace_component_and_initialize(
     Options&&... opts) noexcept {
   runner->template emplace_component_and_initialize<Component>(
       array_index, initial_values, std::forward<Options>(opts)...);
+}
+
+/// Emplaces a distributed array object with index `array_index` into the
+/// parallel component `Component`. The options `opts` are forwarded to be used
+/// in a call to `detail::ForwardAllOptionsToDataBox::apply` Additionally, the
+/// simple tags in the DataBox are initialized from the values set in
+/// `initial_values`.
+template <typename Component, typename... Options,
+          typename Metavars = typename Component::metavariables,
+          Requires<detail::has_initialization_phase_v<Metavars>> = nullptr>
+void emplace_array_component_and_initialize(
+    const gsl::not_null<MockRuntimeSystem<typename Component::metavariables>*>
+        runner,
+    const NodeId node_id, const LocalCoreId local_core_id,
+    const typename Component::array_index& array_index,
+    const typename detail::get_initialization<Component>::InitialValues&
+        initial_values,
+    Options&&... opts) noexcept {
+  runner->template emplace_array_component_and_initialize<Component>(
+      node_id, local_core_id, array_index, initial_values,
+      std::forward<Options>(opts)...);
+}
+
+/// Emplaces a distributed singleton object into the parallel
+/// component `Component`. The options `opts` are forwarded to be used
+/// in a call to `detail::ForwardAllOptionsToDataBox::apply`
+/// Additionally, the simple tags in the DataBox are initialized from
+/// the values set in `initial_values`.
+template <typename Component, typename... Options,
+          typename Metavars = typename Component::metavariables,
+          Requires<detail::has_initialization_phase_v<Metavars>> = nullptr>
+void emplace_singleton_component_and_initialize(
+    const gsl::not_null<MockRuntimeSystem<typename Component::metavariables>*>
+        runner,
+    const NodeId node_id, const LocalCoreId local_core_id,
+    const typename detail::get_initialization<Component>::InitialValues&
+        initial_values,
+    Options&&... opts) noexcept {
+  runner->template emplace_singleton_component_and_initialize<Component>(
+      node_id, local_core_id, initial_values, std::forward<Options>(opts)...);
+}
+
+/// Emplaces a distributed group object into the
+/// parallel component `Component`. The options `opts` are forwarded to be used
+/// in a call to `detail::ForwardAllOptionsToDataBox::apply` Additionally, the
+/// simple tags in the DataBox are initialized from the values set in
+/// `initial_values`.
+template <typename Component, typename... Options,
+          typename Metavars = typename Component::metavariables,
+          Requires<detail::has_initialization_phase_v<Metavars>> = nullptr>
+void emplace_group_component_and_initialize(
+    const gsl::not_null<MockRuntimeSystem<typename Component::metavariables>*>
+        runner,
+    const typename detail::get_initialization<Component>::InitialValues&
+        initial_values,
+    Options&&... opts) noexcept {
+  runner->template emplace_group_component_and_initialize<Component>(
+      initial_values, std::forward<Options>(opts)...);
+}
+
+/// Emplaces a distributed nodegroup object into the
+/// parallel component `Component`. The options `opts` are forwarded to be used
+/// in a call to `detail::ForwardAllOptionsToDataBox::apply` Additionally, the
+/// simple tags in the DataBox are initialized from the values set in
+/// `initial_values`.
+template <typename Component, typename... Options,
+          typename Metavars = typename Component::metavariables,
+          Requires<detail::has_initialization_phase_v<Metavars>> = nullptr>
+void emplace_nodegroup_component_and_initialize(
+    const gsl::not_null<MockRuntimeSystem<typename Component::metavariables>*>
+        runner,
+    const typename detail::get_initialization<Component>::InitialValues&
+        initial_values,
+    Options&&... opts) noexcept {
+  runner->template emplace_nodegroup_component_and_initialize<Component>(
+      initial_values, std::forward<Options>(opts)...);
 }
 
 // @{

--- a/tests/Unit/Framework/Tests/Test_ActionTesting.cpp
+++ b/tests/Unit/Framework/Tests/Test_ActionTesting.cpp
@@ -11,13 +11,13 @@
 #include "Framework/ActionTesting.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/InboxInserters.hpp"
+#include "Parallel/Info.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/NodeLock.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Requires.hpp"
-#include "Utilities/System/ParallelInfo.hpp"
 #include "Utilities/TMPL.hpp"
 
 // IWYU pragma: no_forward_declare db::DataBox
@@ -570,35 +570,35 @@ struct ComponentA {
 struct MyProc {
   template <typename MyProxy, typename ArrayIndex>
   static int f(MyProxy& my_proxy, const ArrayIndex& array_index) noexcept {
-    return sys::my_proc(*my_proxy[array_index].ckLocal());
+    return Parallel::my_proc(*my_proxy[array_index].ckLocal());
   }
 };
 
 struct MyNode {
   template <typename MyProxy, typename ArrayIndex>
   static int f(MyProxy& my_proxy, const ArrayIndex& array_index) noexcept {
-    return sys::my_node(*my_proxy[array_index].ckLocal());
+    return Parallel::my_node(*my_proxy[array_index].ckLocal());
   }
 };
 
 struct LocalRank {
   template <typename MyProxy, typename ArrayIndex>
   static int f(MyProxy& my_proxy, const ArrayIndex& array_index) noexcept {
-    return sys::my_local_rank(*my_proxy[array_index].ckLocal());
+    return Parallel::my_local_rank(*my_proxy[array_index].ckLocal());
   }
 };
 
 struct NumProcs {
   template <typename MyProxy, typename ArrayIndex>
   static int f(MyProxy& my_proxy, const ArrayIndex& array_index) noexcept {
-    return sys::number_of_procs(*my_proxy[array_index].ckLocal());
+    return Parallel::number_of_procs(*my_proxy[array_index].ckLocal());
   }
 };
 
 struct NumNodes {
   template <typename MyProxy, typename ArrayIndex>
   static int f(MyProxy& my_proxy, const ArrayIndex& array_index) noexcept {
-    return sys::number_of_nodes(*my_proxy[array_index].ckLocal());
+    return Parallel::number_of_nodes(*my_proxy[array_index].ckLocal());
   }
 };
 
@@ -606,7 +606,7 @@ template<int NodeIndex>
 struct ProcsOnNode {
   template <typename MyProxy, typename ArrayIndex>
   static int f(MyProxy& my_proxy, const ArrayIndex& array_index) noexcept {
-    return sys::procs_on_node(NodeIndex, *my_proxy[array_index].ckLocal());
+    return Parallel::procs_on_node(NodeIndex, *my_proxy[array_index].ckLocal());
   }
 };
 
@@ -614,7 +614,8 @@ template<int NodeIndex>
 struct FirstProcOnNode {
   template <typename MyProxy, typename ArrayIndex>
   static int f(MyProxy& my_proxy, const ArrayIndex& array_index) noexcept {
-    return sys::first_proc_on_node(NodeIndex, *my_proxy[array_index].ckLocal());
+    return Parallel::first_proc_on_node(NodeIndex,
+                                        *my_proxy[array_index].ckLocal());
   }
 };
 
@@ -622,7 +623,7 @@ template <int ProcIndex>
 struct NodeOf {
   template <typename MyProxy, typename ArrayIndex>
   static int f(MyProxy& my_proxy, const ArrayIndex& array_index) noexcept {
-    return sys::node_of(ProcIndex, *my_proxy[array_index].ckLocal());
+    return Parallel::node_of(ProcIndex, *my_proxy[array_index].ckLocal());
   }
 };
 
@@ -630,7 +631,7 @@ template <int ProcIndex>
 struct LocalRankOf {
   template <typename MyProxy, typename ArrayIndex>
   static int f(MyProxy& my_proxy, const ArrayIndex& array_index) noexcept {
-    return sys::local_rank_of(ProcIndex, *my_proxy[array_index].ckLocal());
+    return Parallel::local_rank_of(ProcIndex, *my_proxy[array_index].ckLocal());
   }
 };
 

--- a/tests/Unit/Framework/Tests/Test_ActionTesting.cpp
+++ b/tests/Unit/Framework/Tests/Test_ActionTesting.cpp
@@ -17,6 +17,7 @@
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Requires.hpp"
+#include "Utilities/System/ParallelInfo.hpp"
 #include "Utilities/TMPL.hpp"
 
 // IWYU pragma: no_forward_declare db::DataBox
@@ -542,4 +543,414 @@ SPECTRE_TEST_CASE("Unit.ActionTesting.MockComponent", "[Unit]") {
   /// [component b mock checks]
 }
 }  // namespace TestComponentMocking
+
+namespace TestNodesAndCores {
+
+struct ValueTag : db::SimpleTag {
+  using type = int;
+};
+
+template <typename Metavariables>
+struct ComponentA {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+
+  using component_being_mocked = void;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          tmpl::list<
+              ActionTesting::InitializeDataBox<db::AddSimpleTags<ValueTag>>>>,
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Testing, tmpl::list<>>>;
+};
+
+struct MyProc {
+  template <typename MyProxy, typename ArrayIndex>
+  static int f(MyProxy& my_proxy, const ArrayIndex& array_index) noexcept {
+    return sys::my_proc(*my_proxy[array_index].ckLocal());
+  }
+};
+
+struct MyNode {
+  template <typename MyProxy, typename ArrayIndex>
+  static int f(MyProxy& my_proxy, const ArrayIndex& array_index) noexcept {
+    return sys::my_node(*my_proxy[array_index].ckLocal());
+  }
+};
+
+struct LocalRank {
+  template <typename MyProxy, typename ArrayIndex>
+  static int f(MyProxy& my_proxy, const ArrayIndex& array_index) noexcept {
+    return sys::my_local_rank(*my_proxy[array_index].ckLocal());
+  }
+};
+
+struct NumProcs {
+  template <typename MyProxy, typename ArrayIndex>
+  static int f(MyProxy& my_proxy, const ArrayIndex& array_index) noexcept {
+    return sys::number_of_procs(*my_proxy[array_index].ckLocal());
+  }
+};
+
+struct NumNodes {
+  template <typename MyProxy, typename ArrayIndex>
+  static int f(MyProxy& my_proxy, const ArrayIndex& array_index) noexcept {
+    return sys::number_of_nodes(*my_proxy[array_index].ckLocal());
+  }
+};
+
+template<int NodeIndex>
+struct ProcsOnNode {
+  template <typename MyProxy, typename ArrayIndex>
+  static int f(MyProxy& my_proxy, const ArrayIndex& array_index) noexcept {
+    return sys::procs_on_node(NodeIndex, *my_proxy[array_index].ckLocal());
+  }
+};
+
+template<int NodeIndex>
+struct FirstProcOnNode {
+  template <typename MyProxy, typename ArrayIndex>
+  static int f(MyProxy& my_proxy, const ArrayIndex& array_index) noexcept {
+    return sys::first_proc_on_node(NodeIndex, *my_proxy[array_index].ckLocal());
+  }
+};
+
+template <int ProcIndex>
+struct NodeOf {
+  template <typename MyProxy, typename ArrayIndex>
+  static int f(MyProxy& my_proxy, const ArrayIndex& array_index) noexcept {
+    return sys::node_of(ProcIndex, *my_proxy[array_index].ckLocal());
+  }
+};
+
+template <int ProcIndex>
+struct LocalRankOf {
+  template <typename MyProxy, typename ArrayIndex>
+  static int f(MyProxy& my_proxy, const ArrayIndex& array_index) noexcept {
+    return sys::local_rank_of(ProcIndex, *my_proxy[array_index].ckLocal());
+  }
+};
+
+template <typename Functor>
+struct ActionSetValueTo {
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables, typename ArrayIndex,
+            Requires<tmpl::list_contains_v<DbTagsList, ValueTag>> = nullptr>
+  static void apply(db::DataBox<DbTagsList>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& array_index) noexcept {
+    auto& my_proxy = Parallel::get_parallel_component<ParallelComponent>(cache);
+    auto function_value = Functor::f(my_proxy, array_index);
+    db::mutate<ValueTag>(
+        make_not_null(&box),
+        [&function_value](const gsl::not_null<int*> value) noexcept {
+          *value = function_value;
+        });
+  }
+};
+
+struct MetavariablesOneComponent {
+  using component_list = tmpl::list<ComponentA<MetavariablesOneComponent>>;
+
+  enum class Phase { Initialization, Testing, Exit };
+};
+
+void test_parallel_info_functions() noexcept {
+  using metavars = MetavariablesOneComponent;
+  using component_a = ComponentA<metavars>;
+
+  // Choose 2 nodes with 3 cores on first node and 2 cores on second node.
+  ActionTesting::MockRuntimeSystem<metavars> runner{{}, {}, {3, 2}};
+
+  // Choose array indices by hand, not in simple order, and choose
+  // arbitrary initial values.
+  ActionTesting::emplace_array_component_and_initialize<component_a>(
+      &runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0}, 0,
+      {-1});
+  ActionTesting::emplace_array_component_and_initialize<component_a>(
+      &runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{1}, 2,
+      {-2});
+  ActionTesting::emplace_array_component_and_initialize<component_a>(
+      &runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{2}, 4,
+      {-3});
+  ActionTesting::emplace_array_component_and_initialize<component_a>(
+      &runner, ActionTesting::NodeId{1}, ActionTesting::LocalCoreId{0}, 1,
+      {-4});
+  ActionTesting::emplace_array_component_and_initialize<component_a>(
+      &runner, ActionTesting::NodeId{1}, ActionTesting::LocalCoreId{1}, 3,
+      {-5});
+
+  ActionTesting::set_phase(make_not_null(&runner), metavars::Phase::Testing);
+
+  // Check that initial values are correct.
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 0) == -1);
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 1) == -4);
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 2) == -2);
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 3) == -5);
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 4) == -3);
+
+  for(size_t i=0;i<5;++i) {
+    ActionTesting::simple_action<component_a, ActionSetValueTo<MyProc>>(
+        make_not_null(&runner), i);
+  }
+  // Should all be set to proc (which Mark computed by hand)
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 0) == 0);
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 1) == 3);
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 2) == 1);
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 3) == 4);
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 4) == 2);
+
+  for (size_t i = 0; i < 5; ++i) {
+    ActionTesting::simple_action<component_a, ActionSetValueTo<MyNode>>(
+        make_not_null(&runner), i);
+  }
+  // Should all be set to node (which Mark computed by hand)
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 0) == 0);
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 1) == 1);
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 2) == 0);
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 3) == 1);
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 4) == 0);
+
+  for(size_t i=0;i<5;++i) {
+    ActionTesting::simple_action<component_a, ActionSetValueTo<LocalRank>>(
+        make_not_null(&runner), i);
+  }
+  // Should all be set to local rank (which Mark computed by hand)
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 0) == 0);
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 1) == 0);
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 2) == 1);
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 3) == 1);
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 4) == 2);
+
+  for (size_t i = 0; i < 5; ++i) {
+    ActionTesting::simple_action<component_a, ActionSetValueTo<NumProcs>>(
+        make_not_null(&runner), i);
+    CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, i) ==
+          5);
+  }
+  for (size_t i = 0; i < 5; ++i) {
+    ActionTesting::simple_action<component_a, ActionSetValueTo<NumNodes>>(
+        make_not_null(&runner), i);
+    CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, i) ==
+          2);
+  }
+
+  // procs_on_node for the 2 nodes.
+  ActionTesting::simple_action<component_a, ActionSetValueTo<ProcsOnNode<0>>>(
+      make_not_null(&runner), 0);
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 0) == 3);
+  ActionTesting::simple_action<component_a, ActionSetValueTo<ProcsOnNode<1>>>(
+      make_not_null(&runner), 2);
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 2) == 2);
+
+  // first_proc_on_node for the 2 nodes.
+  ActionTesting::simple_action<component_a,
+                               ActionSetValueTo<FirstProcOnNode<0>>>(
+      make_not_null(&runner), 1);
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 1) == 0);
+  ActionTesting::simple_action<component_a,
+                               ActionSetValueTo<FirstProcOnNode<1>>>(
+      make_not_null(&runner), 3);
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 3) == 3);
+
+  // node_of
+  ActionTesting::simple_action<component_a, ActionSetValueTo<NodeOf<0>>>(
+      make_not_null(&runner), 0);
+  ActionTesting::simple_action<component_a, ActionSetValueTo<NodeOf<1>>>(
+      make_not_null(&runner), 1);
+  ActionTesting::simple_action<component_a, ActionSetValueTo<NodeOf<2>>>(
+      make_not_null(&runner), 2);
+  ActionTesting::simple_action<component_a, ActionSetValueTo<NodeOf<3>>>(
+      make_not_null(&runner), 3);
+  ActionTesting::simple_action<component_a, ActionSetValueTo<NodeOf<4>>>(
+      make_not_null(&runner), 4);
+  // Check if set to values that Mark computed by hand.
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 0) == 0);
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 1) == 0);
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 2) == 0);
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 3) == 1);
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 4) == 1);
+
+  // local_rank_of
+  ActionTesting::simple_action<component_a, ActionSetValueTo<LocalRankOf<0>>>(
+      make_not_null(&runner), 0);
+  ActionTesting::simple_action<component_a, ActionSetValueTo<LocalRankOf<1>>>(
+      make_not_null(&runner), 1);
+  ActionTesting::simple_action<component_a, ActionSetValueTo<LocalRankOf<2>>>(
+      make_not_null(&runner), 2);
+  ActionTesting::simple_action<component_a, ActionSetValueTo<LocalRankOf<3>>>(
+      make_not_null(&runner), 3);
+  ActionTesting::simple_action<component_a, ActionSetValueTo<LocalRankOf<4>>>(
+      make_not_null(&runner), 4);
+  // Check if set to values that Mark computed by hand.
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 0) == 0);
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 1) == 1);
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 2) == 2);
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 3) == 0);
+  CHECK(ActionTesting::get_databox_tag<component_a, ValueTag>(runner, 4) == 1);
+}
+
+
+template <typename Metavariables>
+struct GroupComponent {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockGroupChare;
+  using array_index = size_t;
+
+  using component_being_mocked = void;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          tmpl::list<
+              ActionTesting::InitializeDataBox<db::AddSimpleTags<ValueTag>>>>,
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Testing, tmpl::list<>>>;
+};
+
+struct MetavariablesGroupComponent {
+  using component_list =
+      tmpl::list<GroupComponent<MetavariablesGroupComponent>>;
+
+  enum class Phase { Initialization, Testing, Exit };
+};
+
+void test_group_emplace() noexcept {
+  using metavars = MetavariablesGroupComponent;
+  using component = GroupComponent<metavars>;
+
+  // Choose 2 nodes with 3 cores on first node and 2 cores on second node.
+  ActionTesting::MockRuntimeSystem<metavars> runner{{},{},{3,2}};
+
+  ActionTesting::emplace_group_component_and_initialize<component>(&runner,
+                                                                   {-3});
+
+  // Check initial values for all components of the group.
+  for (size_t i = 0; i < 5; ++i) {
+    CHECK(ActionTesting::get_databox_tag<component, ValueTag>(runner, i) == -3);
+  }
+
+  ActionTesting::set_phase(make_not_null(&runner), metavars::Phase::Testing);
+
+  // Number of procs should be 5 for all indices.
+  for (size_t i = 0; i < 5; ++i) {
+    ActionTesting::simple_action<component, ActionSetValueTo<NumProcs>>(
+        make_not_null(&runner), i);
+    CHECK(ActionTesting::get_databox_tag<component, ValueTag>(runner, i) == 5);
+  }
+
+  // Number of nodes should be 2 for all indices.
+  for (size_t i = 0; i < 5; ++i) {
+    ActionTesting::simple_action<component, ActionSetValueTo<NumNodes>>(
+        make_not_null(&runner), i);
+    CHECK(ActionTesting::get_databox_tag<component, ValueTag>(runner, i) == 2);
+  }
+
+  for (size_t i = 0; i < 5; ++i) {
+    ActionTesting::simple_action<component, ActionSetValueTo<MyProc>>(
+        make_not_null(&runner), i);
+  }
+
+  // Should all be set to proc (which Mark computed by hand)
+  CHECK(ActionTesting::get_databox_tag<component, ValueTag>(runner, 0) == 0);
+  CHECK(ActionTesting::get_databox_tag<component, ValueTag>(runner, 1) == 1);
+  CHECK(ActionTesting::get_databox_tag<component, ValueTag>(runner, 2) == 2);
+  CHECK(ActionTesting::get_databox_tag<component, ValueTag>(runner, 3) == 3);
+  CHECK(ActionTesting::get_databox_tag<component, ValueTag>(runner, 4) == 4);
+
+  for (size_t i = 0; i < 5; ++i) {
+    ActionTesting::simple_action<component, ActionSetValueTo<MyNode>>(
+        make_not_null(&runner), i);
+  }
+  // Should all be set to node (which Mark computed by hand)
+  CHECK(ActionTesting::get_databox_tag<component, ValueTag>(runner, 0) == 0);
+  CHECK(ActionTesting::get_databox_tag<component, ValueTag>(runner, 1) == 0);
+  CHECK(ActionTesting::get_databox_tag<component, ValueTag>(runner, 2) == 0);
+  CHECK(ActionTesting::get_databox_tag<component, ValueTag>(runner, 3) == 1);
+  CHECK(ActionTesting::get_databox_tag<component, ValueTag>(runner, 4) == 1);
+}
+
+template <typename Metavariables>
+struct NodeGroupComponent {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockNodeGroupChare;
+  using array_index = size_t;
+
+  using component_being_mocked = void;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          tmpl::list<
+              ActionTesting::InitializeDataBox<db::AddSimpleTags<ValueTag>>>>,
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Testing, tmpl::list<>>>;
+};
+
+struct MetavariablesNodeGroupComponent {
+  using component_list =
+      tmpl::list<NodeGroupComponent<MetavariablesNodeGroupComponent>>;
+
+  enum class Phase { Initialization, Testing, Exit };
+};
+
+void test_nodegroup_emplace() noexcept {
+  using metavars = MetavariablesNodeGroupComponent;
+  using component = NodeGroupComponent<metavars>;
+
+  // Choose 2 nodes with 3 cores on first node and 2 cores on second node.
+  ActionTesting::MockRuntimeSystem<metavars> runner{{},{},{3,2}};
+
+  ActionTesting::emplace_nodegroup_component_and_initialize<component>(&runner,
+                                                                       {-3});
+
+  // Check initial values for all components of the nodegroup.
+  for (size_t i = 0; i < 2; ++i) {
+    CHECK(ActionTesting::get_databox_tag<component, ValueTag>(runner, i) == -3);
+  }
+
+  ActionTesting::set_phase(make_not_null(&runner), metavars::Phase::Testing);
+
+  // Number of procs should be 5 for all indices.
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::simple_action<component, ActionSetValueTo<NumProcs>>(
+        make_not_null(&runner), i);
+    CHECK(ActionTesting::get_databox_tag<component, ValueTag>(runner, i) == 5);
+  }
+
+  // Number of nodes should be 2 for all indices.
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::simple_action<component, ActionSetValueTo<NumNodes>>(
+        make_not_null(&runner), i);
+    CHECK(ActionTesting::get_databox_tag<component, ValueTag>(runner, i) == 2);
+  }
+
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::simple_action<component, ActionSetValueTo<MyProc>>(
+        make_not_null(&runner), i);
+  }
+
+  // Should all be set to proc (which Mark computed by hand)
+  CHECK(ActionTesting::get_databox_tag<component, ValueTag>(runner, 0) == 0);
+  CHECK(ActionTesting::get_databox_tag<component, ValueTag>(runner, 1) == 3);
+
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::simple_action<component, ActionSetValueTo<MyNode>>(
+        make_not_null(&runner), i);
+  }
+  // Should all be set to node (which Mark computed by hand)
+  CHECK(ActionTesting::get_databox_tag<component, ValueTag>(runner, 0) == 0);
+  CHECK(ActionTesting::get_databox_tag<component, ValueTag>(runner, 1) == 1);
+}
+
+SPECTRE_TEST_CASE("Unit.ActionTesting.NodesAndCores", "[Unit]") {
+  test_parallel_info_functions();
+  test_group_emplace();
+  test_nodegroup_emplace();
+}
+
+}  // namespace TestNodesAndCores
 }  // namespace

--- a/tests/Unit/Helpers/IO/Observers/ObserverHelpers.hpp
+++ b/tests/Unit/Helpers/IO/Observers/ObserverHelpers.hpp
@@ -56,7 +56,7 @@ struct element_component {
 template <typename Metavariables>
 struct observer_component {
   using metavariables = Metavariables;
-  using chare_type = ActionTesting::MockArrayChare;
+  using chare_type = ActionTesting::MockGroupChare;
   using array_index = int;
 
   using component_being_mocked = observers::Observer<Metavariables>;
@@ -74,7 +74,7 @@ struct observer_component {
 template <typename Metavariables>
 struct observer_writer_component {
   using metavariables = Metavariables;
-  using chare_type = ActionTesting::MockArrayChare;
+  using chare_type = ActionTesting::MockNodeGroupChare;
   using array_index = int;
   using const_global_cache_tags = tmpl::list<observers::Tags::ReductionFileName,
                                              observers::Tags::VolumeFileName>;

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderActions.cpp
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderActions.cpp
@@ -77,7 +77,7 @@ template <typename Metavariables>
 struct MockVolumeDataReader {
   using component_being_mocked = importers::ElementDataReader<Metavariables>;
   using metavariables = Metavariables;
-  using chare_type = ActionTesting::MockArrayChare;
+  using chare_type = ActionTesting::MockNodeGroupChare;
   using array_index = size_t;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderActions.cpp
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderActions.cpp
@@ -102,7 +102,8 @@ SPECTRE_TEST_CASE("Unit.IO.Importers.VolumeDataReaderActions", "[Unit][IO]") {
       {"TestVolumeData.h5", "element_data", 0.}};
 
   // Setup mock data file reader
-  ActionTesting::emplace_component<reader_component>(make_not_null(&runner), 0);
+  ActionTesting::emplace_nodegroup_component<reader_component>(
+      make_not_null(&runner));
   for (size_t i = 0; i < 2; ++i) {
     ActionTesting::next_action<reader_component>(make_not_null(&runner), 0);
   }

--- a/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
@@ -56,11 +56,11 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.ReductionObserver", "[Unit][Observers]") {
       tuples::get<observers::Tags::ReductionFileName>(cache_data) =
           "./Unit.IO.Observers.ReductionObserver";
   ActionTesting::MockRuntimeSystem<metavariables> runner{cache_data};
-  ActionTesting::emplace_component<obs_component>(&runner, 0);
+  ActionTesting::emplace_group_component<obs_component>(&runner);
   for (size_t i = 0; i < 2; ++i) {
     ActionTesting::next_action<obs_component>(make_not_null(&runner), 0);
   }
-  ActionTesting::emplace_component<obs_writer>(&runner, 0);
+  ActionTesting::emplace_nodegroup_component<obs_writer>(&runner);
   for (size_t i = 0; i < 2; ++i) {
     ActionTesting::next_action<obs_writer>(make_not_null(&runner), 0);
   }

--- a/tests/Unit/IO/Observers/Test_RegisterElements.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterElements.cpp
@@ -40,11 +40,11 @@ void check_observer_registration() {
   using element_comp = element_component<metavariables, registration_list>;
 
   ActionTesting::MockRuntimeSystem<metavariables> runner{{}};
-  ActionTesting::emplace_component<obs_component>(&runner, 0);
+  ActionTesting::emplace_group_component<obs_component>(&runner);
   for (size_t i = 0; i < 2; ++i) {
     ActionTesting::next_action<obs_component>(make_not_null(&runner), 0);
   }
-  ActionTesting::emplace_component<obs_writer>(&runner, 0);
+  ActionTesting::emplace_nodegroup_component<obs_writer>(&runner);
   for (size_t i = 0; i < 2; ++i) {
     ActionTesting::next_action<obs_writer>(make_not_null(&runner), 0);
   }

--- a/tests/Unit/IO/Observers/Test_RegisterEvents.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterEvents.cpp
@@ -162,7 +162,7 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.RegisterEvents", "[Unit][Observers]") {
       {serialize_and_deserialize(events_and_triggers)}};
   ActionTesting::emplace_component<my_component>(&runner, 0);
   ActionTesting::emplace_component<my_component>(&runner, 1);
-  ActionTesting::emplace_component<obs_component>(&runner, 0);
+  ActionTesting::emplace_group_component<obs_component>(&runner);
   ActionTesting::set_phase(make_not_null(&runner),
                            Metavariables::Phase::Testing);
 

--- a/tests/Unit/IO/Observers/Test_RegisterEvents.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterEvents.cpp
@@ -121,7 +121,7 @@ MockRegisterContributorWithObserver::Result
 template <typename Metavariables>
 struct MockObserverComponent {
   using metavariables = Metavariables;
-  using chare_type = ActionTesting::MockArrayChare;
+  using chare_type = ActionTesting::MockGroupChare;
   using array_index = int;
   using const_global_cache_tags = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<

--- a/tests/Unit/IO/Observers/Test_RegisterSingleton.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterSingleton.cpp
@@ -35,7 +35,7 @@ template <typename Metavariables>
 struct Component {
   using metavariables = Metavariables;
   using component_being_mocked = void;
-  using chare_type = ActionTesting::MockArrayChare;
+  using chare_type = ActionTesting::MockSingletonChare;
   using array_index = int;
   using const_global_cache_tags = tmpl::list<>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<

--- a/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
@@ -64,11 +64,11 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.VolumeObserver", "[Unit][Observers]") {
       tuples::get<observers::Tags::VolumeFileName>(cache_data) =
           "./Unit.IO.Observers.VolumeObserver";
   ActionTesting::MockRuntimeSystem<metavariables> runner{cache_data};
-  ActionTesting::emplace_component<obs_component>(&runner, 0);
+  ActionTesting::emplace_group_component<obs_component>(&runner);
   for (size_t i = 0; i < 2; ++i) {
     ActionTesting::next_action<obs_component>(make_not_null(&runner), 0);
   }
-  ActionTesting::emplace_component<obs_writer>(&runner, 0);
+  ActionTesting::emplace_nodegroup_component<obs_writer>(&runner);
   for (size_t i = 0; i < 2; ++i) {
     ActionTesting::next_action<obs_writer>(make_not_null(&runner), 0);
   }

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateEvent.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateEvent.cpp
@@ -113,7 +113,7 @@ struct mock_interpolator {
       tmpl::list<MockInterpolatorReceiveVolumeData>;
 
   using metavariables = Metavariables;
-  using chare_type = ActionTesting::MockArrayChare;
+  using chare_type = ActionTesting::MockGroupChare;
   using array_index = size_t;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateEvent.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateEvent.cpp
@@ -190,7 +190,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.InterpolateEvent",
   ActionTesting::MockRuntimeSystem<metavars> runner{{}};
   ActionTesting::set_phase(make_not_null(&runner),
                            metavars::Phase::Initialization);
-  ActionTesting::emplace_component<interp_component>(&runner, 0);
+  ActionTesting::emplace_group_component<interp_component>(&runner);
   ActionTesting::next_action<interp_component>(make_not_null(&runner), 0);
   ActionTesting::emplace_component<interp_target_component>(&runner, 0);
   ActionTesting::next_action<interp_target_component>(make_not_null(&runner),

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
@@ -88,7 +88,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.RegisterElement",
   ActionTesting::MockRuntimeSystem<metavars> runner{{}};
   ActionTesting::set_phase(make_not_null(&runner),
                            metavars::Phase::Initialization);
-  ActionTesting::emplace_component<interp_component>(&runner, 0);
+  ActionTesting::emplace_group_component<interp_component>(&runner);
   for (size_t i = 0; i < 2; ++i) {
     ActionTesting::next_action<interp_component>(make_not_null(&runner), 0);
   }

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
@@ -30,7 +30,7 @@ namespace {
 template <typename Metavariables>
 struct mock_interpolator {
   using metavariables = Metavariables;
-  using chare_type = ActionTesting::MockArrayChare;
+  using chare_type = ActionTesting::MockGroupChare;
   using array_index = size_t;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
@@ -156,7 +156,7 @@ struct MockInterpolationTarget {
 
  public:
   using metavariables = Metavariables;
-  using chare_type = ActionTesting::MockArrayChare;
+  using chare_type = ActionTesting::MockSingletonChare;
   using array_index = size_t;
   using const_global_cache_tags = tmpl::flatten<tmpl::append<
       Parallel::get_const_global_cache_tags_from_actions<tmpl::list<

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
@@ -117,7 +117,7 @@ struct NegateCompute : Negate, db::ComputeTag {
 template <typename Metavariables>
 struct MockObserverWriter {
   using metavariables = Metavariables;
-  using chare_type = ActionTesting::MockArrayChare;
+  using chare_type = ActionTesting::MockNodeGroupChare;
   using array_index = size_t;
   using const_global_cache_tags =
       tmpl::list<observers::Tags::ReductionFileName>;

--- a/tests/Unit/Parallel/Test_Parallel.cpp
+++ b/tests/Unit/Parallel/Test_Parallel.cpp
@@ -45,8 +45,11 @@ std::ostream& operator<<(std::ostream& os, const TestEnum& t) noexcept {
 // 2 3 abf a o e u Value 2]]
 SPECTRE_TEST_CASE("Unit.Parallel.printf", "[Unit][Parallel]") {
   OUTPUT_TEST();
-  const char c_string0[40] = {"test 1 2 3"};
-  auto* c_string1 = new char[80];
+  // clang-tidy doesn't want c-style arrays, but here we are trying
+  // to test them explicitly.
+  const char c_string0[40] = {"test 1 2 3"}; // NOLINT
+  // clang-tidy doesn't want raw pointers, wants gsl::owner<>.
+  auto* c_string1 = new char[80]; // NOLINT
   // clang-tidy: do not use pointer arithmetic
   c_string1[0] = 'a';   // NOLINT
   c_string1[1] = 'b';   // NOLINT
@@ -55,7 +58,8 @@ SPECTRE_TEST_CASE("Unit.Parallel.printf", "[Unit][Parallel]") {
   constexpr const char* const c_string2 = {"a o e u"};
   Parallel::printf("%d %lld %s %s %s %s %s\n", -100, 3000000000, TestStream{},
                    c_string0, c_string1, c_string2, TestEnum::Value2);
-  delete[] c_string1;
+  // clang-tidy doesn't want delete on anything without gsl::owner<>.
+  delete[] c_string1; // NOLINT
 }
 /// [output_test_example]
 

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveErrorNorms.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveErrorNorms.cpp
@@ -250,7 +250,7 @@ void test_observe(const std::unique_ptr<ObserveEvent> observe,
           std::move(analytic_solution)});
   ActionTesting::emplace_component<element_component>(make_not_null(&runner),
                                                       0);
-  ActionTesting::emplace_component<observer_component>(&runner, 0);
+  ActionTesting::emplace_group_component<observer_component>(&runner);
 
   const auto box = db::create<db::AddSimpleTags<
       ObservationTimeTag, Tags::Variables<typename decltype(vars)::tags_list>,

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveErrorNorms.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveErrorNorms.cpp
@@ -123,7 +123,7 @@ struct MockObserverComponent {
   using with_these_simple_actions = tmpl::list<MockContributeReductionData>;
 
   using metavariables = Metavariables;
-  using chare_type = ActionTesting::MockArrayChare;
+  using chare_type = ActionTesting::MockGroupChare;
   using array_index = int;
   using phase_dependent_action_list =
       tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
@@ -130,7 +130,7 @@ struct MockObserverComponent {
   using with_these_simple_actions = tmpl::list<MockContributeVolumeData>;
 
   using metavariables = Metavariables;
-  using chare_type = ActionTesting::MockArrayChare;
+  using chare_type = ActionTesting::MockGroupChare;
   using array_index = int;
   using phase_dependent_action_list =
       tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
@@ -342,7 +342,7 @@ void test_observe(
           std::move(analytic_solution)});
   ActionTesting::emplace_component<element_component>(make_not_null(&runner),
                                                       element_id);
-  ActionTesting::emplace_component<observer_component>(&runner, 0);
+  ActionTesting::emplace_group_component<observer_component>(&runner);
 
   const auto box = db::create<db::AddSimpleTags<
       ObservationTimeTag, domain::Tags::Mesh<volume_dim>,

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStep.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStep.cpp
@@ -107,7 +107,7 @@ struct MockObserverComponent {
       tmpl::list<MockContributeReductionData<Metavariables>>;
 
   using metavariables = Metavariables;
-  using chare_type = ActionTesting::MockArrayChare;
+  using chare_type = ActionTesting::MockGroupChare;
   using array_index = int;
   using phase_dependent_action_list =
       tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStep.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStep.cpp
@@ -141,7 +141,7 @@ void test_observe(const Observer& observer,
   results.reset();
 
   ActionTesting::MockRuntimeSystem<Metavariables> runner{{}};
-  ActionTesting::emplace_component<observer_component>(&runner, 0);
+  ActionTesting::emplace_group_component<observer_component>(&runner);
 
   const double observation_time = 2.0;
   const Slab slab(1.23, 4.56);

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
@@ -115,7 +115,7 @@ struct MockObserverComponent {
 
   using metavariables = Metavariables;
   using array_index = int;
-  using chare_type = ActionTesting::MockArrayChare;
+  using chare_type = ActionTesting::MockGroupChare;
   using phase_dependent_action_list =
       tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
                                         Metavariables::Phase::Initialization,

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
@@ -231,7 +231,7 @@ void test_observe(const std::unique_ptr<ObserveEvent> observe) noexcept {
   ActionTesting::MockRuntimeSystem<metavariables> runner{{}};
   ActionTesting::emplace_component<element_component>(make_not_null(&runner),
                                                       0);
-  ActionTesting::emplace_component<observer_component>(&runner, 0);
+  ActionTesting::emplace_group_component<observer_component>(&runner);
 
   observe->run(box, runner.cache(), array_index,
                std::add_pointer_t<element_component>{});

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/Test_ElementActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/Test_ElementActions.cpp
@@ -130,11 +130,11 @@ SPECTRE_TEST_CASE("Unit.ParallelLinearSolver.Asynchronous.ElementActions",
   };
 
   // Setup mock observers
-  ActionTesting::emplace_component<obs_component>(&runner, 0);
+  ActionTesting::emplace_group_component<obs_component>(&runner);
   for (size_t i = 0; i < 2; ++i) {
     ActionTesting::next_action<obs_component>(make_not_null(&runner), 0);
   }
-  ActionTesting::emplace_component<obs_writer>(&runner, 0);
+  ActionTesting::emplace_nodegroup_component<obs_writer>(&runner);
   for (size_t i = 0; i < 2; ++i) {
     ActionTesting::next_action<obs_writer>(make_not_null(&runner), 0);
   }

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ResidualMonitorActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ResidualMonitorActions.cpp
@@ -58,9 +58,7 @@ struct MockResidualMonitor {
       LinearSolver::cg::detail::ResidualMonitor<Metavariables, fields_tag,
                                                 TestLinearSolver>;
   using metavariables = Metavariables;
-  // We represent the singleton as an array with only one element for the action
-  // testing framework
-  using chare_type = ActionTesting::MockArrayChare;
+  using chare_type = ActionTesting::MockSingletonChare;
   using array_index = int;
   using const_global_cache_tags =
       typename LinearSolver::cg::detail::ResidualMonitor<

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ResidualMonitorActions.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_ResidualMonitorActions.cpp
@@ -59,9 +59,7 @@ struct MockResidualMonitor {
       LinearSolver::gmres::detail::ResidualMonitor<Metavariables, fields_tag,
                                                    TestLinearSolver>;
   using metavariables = Metavariables;
-  // We represent the singleton as an array with only one element for the action
-  // testing framework
-  using chare_type = ActionTesting::MockArrayChare;
+  using chare_type = ActionTesting::MockSingletonChare;
   using array_index = int;
   using const_global_cache_tags =
       typename LinearSolver::gmres::detail::ResidualMonitor<


### PR DESCRIPTION
## Proposed changes

The ActionTesting framework now can simulate running on multiple nodes and cores.

MockRuntimeSystem now has a `std::vector<size_t>` passed into its constructor, specifying the number of (mock) cores on each (mock) node of the mocked runtime system.  Each `MockDistributedObject` and their proxies keep track of the mock node and core that it lives on. The various member functions in ActionTesting have been updated to do the right thing for multiple nodes and cores.

Test_ActionTesting tests much of the new functionality.

Many of the other tests have been updated to work with the new changes.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
- In ActionTesting, if you are mocking a Group, Nodegroup, or Singleton component, these should now have `chare_type` set to `MockGroupChare`, `MockNodeGroupChare`, or `MockSingletonChare` instead of `MockArrayChare`.  Note that `MockArrayChare` will *sometimes* work for these components for some tests, but not if `ckLocal` or `ckLocalBranch` is ever called on those components.
- In ActionTesting, the new functions `emplace_singleton_component`, `emplace_group_component`, `emplace_array_component`, and `emplace_nodegroup_component` should be used instead of `emplace_component`.  Note that `emplace_component` still works but will be removed in the future.
- The functions in Utilities/System/ParallelInfo now have two versions: the low-level charm++ version (in the `sys` namespace) and a new version templated on the `DistributedObject`.  The `sys` version should be used only for low-level things like `AbortWithErrorMessage` or the `ParallelInfo` executable where you know they will never be mocked; the templated version should be used everywhere else.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
