### PR TITLE
Replace MockRuntimeSystem cache() function.

### DIFF
--- a/tests/Unit/Framework/MockDistributedObject.hpp
+++ b/tests/Unit/Framework/MockDistributedObject.hpp
@@ -618,6 +618,10 @@ class MockDistributedObject {
         std::forward<Data>(data));
   }
 
+  Parallel::GlobalCache<typename Component::metavariables>& cache() noexcept {
+    return *global_cache_;
+  }
+
   // {@
   /// Wrappers for charm++ informational functions.
 

--- a/tests/Unit/Framework/MockRuntimeSystem.hpp
+++ b/tests/Unit/Framework/MockRuntimeSystem.hpp
@@ -693,13 +693,6 @@ class MockRuntimeSystem {
         mock_distributed_objects_);
   }
 
-  GlobalCache& cache(const NodeId node_id,
-                     const LocalCoreId local_core_id) noexcept {
-    return *caches_.at(mock_global_cores_.at(node_id).at(local_core_id).value);
-  }
-
-  GlobalCache& cache() noexcept { return cache(NodeId{0}, LocalCoreId{0}); }
-
   /// Set the phase of all parallel components to `next_phase`
   void set_phase(const typename Metavariables::Phase next_phase) noexcept {
     tmpl::for_each<mock_objects_tags>(

--- a/tests/Unit/Framework/MockRuntimeSystemFreeFunctions.hpp
+++ b/tests/Unit/Framework/MockRuntimeSystemFreeFunctions.hpp
@@ -357,6 +357,16 @@ bool get_terminate(
       .get_terminate();
 }
 
+/// Returns the GlobalCache of `Component` with index `array_index`.
+template <typename Component, typename Metavariables, typename ArrayIndex>
+Parallel::GlobalCache<Metavariables>& cache(
+    MockRuntimeSystem<Metavariables>& runner,
+    const ArrayIndex& array_index) noexcept {
+  return runner.template mock_distributed_objects<Component>()
+      .at(array_index)
+      .cache();
+}
+
 /// Returns a vector of all the indices of the Components
 /// in the ComponentList that have queued actions.
 template <typename ComponentList, typename MockRuntimeSystem,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
@@ -89,7 +89,8 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.Initialize",
             component, ::intrp::Tags::TemporalIds<temporal_id_type>>(runner, 0)
             .empty());
 
-  CHECK(Parallel::get<domain::Tags::Domain<3>>(runner.cache()) ==
+  const auto& cache = ActionTesting::cache<component>(runner, 0_st);
+  CHECK(Parallel::get<domain::Tags::Domain<3>>(cache) ==
         domain_creator.create_domain());
 
   CHECK(ActionTesting::get_databox_tag<

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateEvent.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateEvent.cpp
@@ -217,8 +217,8 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.InterpolateEvent",
                              metavars::InterpolatorTargetA,
                              metavars::interpolator_source_vars> event{};
 
-  event.run(box, runner.cache(), array_index,
-            std::add_pointer_t<elem_component>{});
+  event.run(box, ActionTesting::cache<elem_component>(runner, array_index),
+            array_index, std::add_pointer_t<elem_component>{});
 
   // Invoke all actions
   runner.invoke_queued_simple_action<interp_component>(0);

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateWithoutInterpComponent.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateWithoutInterpComponent.cpp
@@ -77,8 +77,9 @@ struct initialize_elements_and_queue_simple_actions {
 
       // 3. Run the event.  This will invoke simple actions on
       // InterpolationTarget.
-      event.run(box, runner.cache(), element_id,
-                std::add_pointer_t<elem_component>{});
+      event.run(box,
+                ActionTesting::cache<elem_component>(runner, element_id),
+                element_id, std::add_pointer_t<elem_component>{});
     }
   }
 };

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveErrorNorms.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveErrorNorms.cpp
@@ -275,8 +275,9 @@ void test_observe(const std::unique_ptr<ObserveEvent> observe,
   CHECK(ids_to_register->first == observers::TypeOfObservation::Reduction);
   CHECK(ids_to_register->second == expected_observation_key_for_reg);
 
-  observe->run(box, runner.cache(), array_index,
-               std::add_pointer_t<element_component>{});
+  observe->run(box,
+               ActionTesting::cache<element_component>(runner, array_index),
+               array_index, std::add_pointer_t<element_component>{});
 
   if (not HasAnalyticSolutions and not has_analytic_solutions) {
     CHECK(runner.template is_simple_action_queue_empty<observer_component>(0));

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
@@ -362,8 +362,9 @@ void test_observe(
         }
       }());
 
-  observe->run(box, runner.cache(), array_index,
-               std::add_pointer_t<element_component>{});
+  observe->run(box,
+               ActionTesting::cache<element_component>(runner, array_index),
+               array_index, std::add_pointer_t<element_component>{});
 
   // Process the data
   runner.template invoke_queued_simple_action<observer_component>(0);

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStep.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStep.cpp
@@ -184,7 +184,8 @@ void test_observe(const Observer& observer,
   const double expected_effective_step = expected_slab_size / 4.0;
 
   for (size_t index = 0; index < element_boxes.size(); ++index) {
-    observer.run(element_boxes[index], runner.cache(),
+    observer.run(element_boxes[index],
+                 ActionTesting::cache<element_component>(runner, index),
                  static_cast<element_component::array_index>(index),
                  std::add_pointer_t<element_component>{});
   }

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
@@ -236,8 +236,9 @@ void test_observe(const std::unique_ptr<ObserveEvent> observe) noexcept {
                                                       0);
   ActionTesting::emplace_group_component<observer_component>(&runner);
 
-  observe->run(box, runner.cache(), array_index,
-               std::add_pointer_t<element_component>{});
+  observe->run(box,
+               ActionTesting::cache<element_component>(runner, array_index),
+               array_index, std::add_pointer_t<element_component>{});
 
   // Process the data
   runner.invoke_queued_simple_action<observer_component>(0);


### PR DESCRIPTION
## Proposed changes

MockRuntimeSystem had a cache() function that returns a GlobalCache. But now different (mock) nodes and cores have different `GlobalCache`s, so now there is a new ActionTesting::cache() function that takes Component as a template parameter and an ArrayIndex as an argument, and returns the correct cache.

Various tests that used cache() have been updated.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
`ActionTesting::cache()` now has a template parameter and an argument.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
