### PR TITLE
Rewrite ActionTesting::invoke_random_queued_action

### DIFF
--- a/tests/Unit/Framework/MockRuntimeSystem.hpp
+++ b/tests/Unit/Framework/MockRuntimeSystem.hpp
@@ -704,6 +704,14 @@ class MockRuntimeSystem {
         });
   }
 
+  /// Return number of (mock) global cores.
+  size_t num_global_cores() const noexcept {
+    return mock_nodes_and_local_cores_.size();
+  }
+
+  /// Return number of (mock) nodes.
+  size_t num_nodes() const noexcept { return mock_global_cores_.size(); }
+
  private:
   std::unordered_map<NodeId, std::unordered_map<LocalCoreId, GlobalCoreId>>
       mock_global_cores_{};


### PR DESCRIPTION
## Proposed changes

ActionTesting::invoke_random_queued_action now works with mocked cores and nodes.

Tests that use invoke_random_queued_action have been updated accordingly, and these tests also now use more than a single mocked node and core.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Usage of invoke_random_queued_action is slightly different, as it now uses the new function array_indices_with_queued_actions.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
