### PR TITLE
Improve action of Minmod limiter and TCI at external boundaries

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.cpp
@@ -74,17 +74,14 @@ double effective_difference_to_neighbor(
     const DirectionMap<VolumeDim, double>& effective_neighbor_means,
     const DirectionMap<VolumeDim, double>& effective_neighbor_sizes) noexcept {
   const auto dir = Direction<VolumeDim>(dim, side);
-  const bool has_neighbors = element.neighbors().contains(dir);
-  if (has_neighbors) {
-    const double neighbor_mean = effective_neighbor_means.at(dir);
-    const double neighbor_size = effective_neighbor_sizes.at(dir);
-    const double distance_factor =
-        0.5 * (1.0 + neighbor_size / gsl::at(element_size, dim));
-    return (side == Side::Lower ? -1.0 : 1.0) * (neighbor_mean - u_mean) /
-           distance_factor;
-  } else {
-    return 0.0;
-  }
+  ASSERT(element.neighbors().contains(dir),
+         "Minmod helper found no neighbors in direction: " << dir);
+  const double neighbor_mean = effective_neighbor_means.at(dir);
+  const double neighbor_size = effective_neighbor_sizes.at(dir);
+  const double distance_factor =
+      0.5 * (1.0 + neighbor_size / gsl::at(element_size, dim));
+  return (side == Side::Lower ? -1.0 : 1.0) * (neighbor_mean - u_mean) /
+         distance_factor;
 }
 
 // Explicit instantiations

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Minmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Minmod.cpp
@@ -633,23 +633,39 @@ void test_minmod_slopes_at_boundary(
   // Test with element that has external lower-xi boundary
   const auto element_at_lower_xi_boundary =
       TestHelpers::Limiters::make_element<1>({{Direction<1>::lower_xi()}});
-  for (const double neighbor : {-1.3, 3.6, 4.8, 13.2}) {
-    test_minmod_activates(
-        minmod_type, tvb_constant, input, mesh, element_at_lower_xi_boundary,
-        element_size, {{std::make_pair(Direction<1>::upper_xi(), neighbor)}},
-        {{std::make_pair(Direction<1>::upper_xi(), element_size[0])}},
-        make_array<1>(0.0));
+  for (const double neighbor : {-1.21, -1.19, 0.0, 1.19, 1.21}) {
+    if (minmod_type == Limiters::MinmodType::LambdaPiN and neighbor > 1.2) {
+      test_minmod_does_not_activate(
+          minmod_type, tvb_constant, input, mesh, element_at_lower_xi_boundary,
+          element_size, {{std::make_pair(Direction<1>::upper_xi(), neighbor)}},
+          {{std::make_pair(Direction<1>::upper_xi(), element_size[0])}},
+          make_array<1>(1.2));
+    } else {
+      test_minmod_activates(
+          minmod_type, tvb_constant, input, mesh, element_at_lower_xi_boundary,
+          element_size, {{std::make_pair(Direction<1>::upper_xi(), neighbor)}},
+          {{std::make_pair(Direction<1>::upper_xi(), element_size[0])}},
+          make_array<1>(0.0));
+    }
   }
 
   // Test with element that has external upper-xi boundary
   const auto element_at_upper_xi_boundary =
       TestHelpers::Limiters::make_element<1>({{Direction<1>::upper_xi()}});
-  for (const double neighbor : {-1.3, 3.6, 4.8, 13.2}) {
-    test_minmod_activates(
-        minmod_type, tvb_constant, input, mesh, element_at_upper_xi_boundary,
-        element_size, {{std::make_pair(Direction<1>::lower_xi(), neighbor)}},
-        {{std::make_pair(Direction<1>::lower_xi(), element_size[0])}},
-        make_array<1>(0.0));
+  for (const double neighbor : {-1.21, -1.19, 0.0, 1.19, 1.21}) {
+    if (minmod_type == Limiters::MinmodType::LambdaPiN and neighbor < -1.2) {
+      test_minmod_does_not_activate(
+          minmod_type, tvb_constant, input, mesh, element_at_upper_xi_boundary,
+          element_size, {{std::make_pair(Direction<1>::lower_xi(), neighbor)}},
+          {{std::make_pair(Direction<1>::lower_xi(), element_size[0])}},
+          make_array<1>(1.2));
+    } else {
+      test_minmod_activates(
+          minmod_type, tvb_constant, input, mesh, element_at_upper_xi_boundary,
+          element_size, {{std::make_pair(Direction<1>::lower_xi(), neighbor)}},
+          {{std::make_pair(Direction<1>::lower_xi(), element_size[0])}},
+          make_array<1>(0.0));
+    }
   }
 }
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Minmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Minmod.cpp
@@ -634,18 +634,20 @@ void test_minmod_slopes_at_boundary(
   const auto element_at_lower_xi_boundary =
       TestHelpers::Limiters::make_element<1>({{Direction<1>::lower_xi()}});
   for (const double neighbor : {-1.21, -1.19, 0.0, 1.19, 1.21}) {
-    if (minmod_type == Limiters::MinmodType::LambdaPiN and neighbor > 1.2) {
+    const double expected_slope =
+        std::min(std::max(0.0, neighbor), 1.2) * muscl_slope_factor;
+    if (neighbor > 1.2) {
       test_minmod_does_not_activate(
           minmod_type, tvb_constant, input, mesh, element_at_lower_xi_boundary,
           element_size, {{std::make_pair(Direction<1>::upper_xi(), neighbor)}},
           {{std::make_pair(Direction<1>::upper_xi(), element_size[0])}},
-          make_array<1>(1.2));
+          make_array<1>(expected_slope));
     } else {
       test_minmod_activates(
           minmod_type, tvb_constant, input, mesh, element_at_lower_xi_boundary,
           element_size, {{std::make_pair(Direction<1>::upper_xi(), neighbor)}},
           {{std::make_pair(Direction<1>::upper_xi(), element_size[0])}},
-          make_array<1>(0.0));
+          make_array<1>(expected_slope));
     }
   }
 
@@ -653,18 +655,20 @@ void test_minmod_slopes_at_boundary(
   const auto element_at_upper_xi_boundary =
       TestHelpers::Limiters::make_element<1>({{Direction<1>::upper_xi()}});
   for (const double neighbor : {-1.21, -1.19, 0.0, 1.19, 1.21}) {
-    if (minmod_type == Limiters::MinmodType::LambdaPiN and neighbor < -1.2) {
+    const double expected_slope =
+        std::min(std::max(0.0, -neighbor), 1.2) * muscl_slope_factor;
+    if (neighbor < -1.2) {
       test_minmod_does_not_activate(
           minmod_type, tvb_constant, input, mesh, element_at_upper_xi_boundary,
           element_size, {{std::make_pair(Direction<1>::lower_xi(), neighbor)}},
           {{std::make_pair(Direction<1>::lower_xi(), element_size[0])}},
-          make_array<1>(1.2));
+          make_array<1>(expected_slope));
     } else {
       test_minmod_activates(
           minmod_type, tvb_constant, input, mesh, element_at_upper_xi_boundary,
           element_size, {{std::make_pair(Direction<1>::lower_xi(), neighbor)}},
           {{std::make_pair(Direction<1>::lower_xi(), element_size[0])}},
-          make_array<1>(0.0));
+          make_array<1>(expected_slope));
     }
   }
 }

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_MinmodTci.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_MinmodTci.cpp
@@ -218,22 +218,31 @@ void test_tci_at_boundary(const size_t number_of_grid_points,
   // Test with element that has external lower-xi boundary
   const auto element_at_lower_xi_boundary =
       TestHelpers::Limiters::make_element<1>({{Direction<1>::lower_xi()}});
-  for (const double neighbor : {-1.3, 3.6, 4.8, 13.2}) {
+  for (const double neighbor_mean : {-1.21, -1.19, 0.0, 1.19, 1.21}) {
+    const bool expected_tci = neighbor_mean < 1.2;
     test_tci_detection(
-        true, tvb_constant, input, mesh, element_at_lower_xi_boundary,
-        element_size, {{std::make_pair(Direction<1>::upper_xi(), neighbor)}},
+        expected_tci, tvb_constant, input, mesh, element_at_lower_xi_boundary,
+        element_size,
+        {{std::make_pair(Direction<1>::upper_xi(), neighbor_mean)}},
         {{std::make_pair(Direction<1>::upper_xi(), element_size[0])}});
   }
 
   // Test with element that has external upper-xi boundary
   const auto element_at_upper_xi_boundary =
       TestHelpers::Limiters::make_element<1>({{Direction<1>::upper_xi()}});
-  for (const double neighbor : {-1.3, 3.6, 4.8, 13.2}) {
+  for (const double neighbor_mean : {-1.21, -1.19, 0.0, 1.19, 1.21}) {
+    const bool expected_tci = neighbor_mean > -1.2;
     test_tci_detection(
-        true, tvb_constant, input, mesh, element_at_upper_xi_boundary,
-        element_size, {{std::make_pair(Direction<1>::lower_xi(), neighbor)}},
+        expected_tci, tvb_constant, input, mesh, element_at_upper_xi_boundary,
+        element_size,
+        {{std::make_pair(Direction<1>::lower_xi(), neighbor_mean)}},
         {{std::make_pair(Direction<1>::lower_xi(), element_size[0])}});
   }
+
+  const auto element_with_no_neighbors = TestHelpers::Limiters::make_element<1>(
+      {{Direction<1>::lower_xi(), Direction<1>::upper_xi()}});
+  test_tci_detection(false, tvb_constant, input, mesh,
+                     element_with_no_neighbors, element_size, {{}}, {{}});
 }
 
 void test_tci_with_different_size_neighbor(


### PR DESCRIPTION
## Proposed changes

Previously, for any cell at an external boundary,
- the TCI would always identify the cell as troubled, and
- the limiter would always act to set all fields on the cell to a constant value (the cell average of the field)

These actions were not _physically_ motivated, but were the result of setting the `minmod` function's slope argument for the external side to zero. Now, instead, the value from the opposite (=internal) side is used, which has the simple effect that the external side has no effect on the result of the `minmod` function. This is equivalent to implementing a two-argument `minmod` and not passing in an argument for the external side, but with less code to write.

The current behavior has been okay because we've mostly used the limiters with simple shock tests where the solution is a constant at the external boundaries anyway. This change should enable better evolutions in tests with non-trivial external BCs.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
