### PR TITLE
Add Boundary conditions test helpers

### DIFF
--- a/src/Domain/BoundaryConditions/CMakeLists.txt
+++ b/src/Domain/BoundaryConditions/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   BoundaryCondition.hpp
+  GetBoundaryConditionsBase.hpp
   )
 
 target_link_libraries(

--- a/src/Domain/BoundaryConditions/GetBoundaryConditionsBase.hpp
+++ b/src/Domain/BoundaryConditions/GetBoundaryConditionsBase.hpp
@@ -1,0 +1,34 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <type_traits>
+
+#include "Utilities/TypeTraits/CreateHasTypeAlias.hpp"
+
+namespace domain::BoundaryConditions {
+CREATE_HAS_TYPE_ALIAS(boundary_conditions_base)
+CREATE_HAS_TYPE_ALIAS_V(boundary_conditions_base)
+
+namespace detail {
+// used as passive error message
+struct TheSystemHasNoBoundaryConditionsBaseTypeAlias {};
+
+template <typename T, typename = std::void_t<>>
+struct get_boundary_conditions_base {
+  using type = TheSystemHasNoBoundaryConditionsBaseTypeAlias;
+};
+
+template <typename T>
+struct get_boundary_conditions_base<
+    T, std::void_t<typename T::boundary_conditions_base>> {
+  using type = typename T::boundary_conditions_base;
+};
+}  // namespace detail
+
+/// Returns `T::boundary_condition_base` or a placeholder class.
+template <typename T>
+using get_boundary_conditions_base =
+    typename detail::get_boundary_conditions_base<T>::type;
+}  // namespace domain::BoundaryConditions

--- a/tests/Unit/Domain/BoundaryConditions/CMakeLists.txt
+++ b/tests/Unit/Domain/BoundaryConditions/CMakeLists.txt
@@ -19,5 +19,6 @@ target_link_libraries(
   ${LIBRARY}
   PRIVATE
   DomainBoundaryConditions
+  DomainBoundaryConditionsHelpers
   Utilities
   )

--- a/tests/Unit/Domain/BoundaryConditions/CMakeLists.txt
+++ b/tests/Unit/Domain/BoundaryConditions/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_DomainBoundaryConditions")
 
 set(LIBRARY_SOURCES
   Test_BoundaryCondition.cpp
+  Test_GetBoundaryConditionsBase.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Domain/BoundaryConditions/Test_GetBoundaryConditionsBase.cpp
+++ b/tests/Unit/Domain/BoundaryConditions/Test_GetBoundaryConditionsBase.cpp
@@ -1,0 +1,28 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <type_traits>
+
+#include "Domain/BoundaryConditions/GetBoundaryConditionsBase.hpp"
+
+namespace domain::BoundaryConditions {
+namespace {
+struct SystemNoBoundaryConditionsBase {};
+
+struct BoundaryConditionsBase {};
+struct SystemWithBoundaryConditionsBase {
+  using boundary_conditions_base = BoundaryConditionsBase;
+};
+
+static_assert(
+    not has_boundary_conditions_base_v<SystemNoBoundaryConditionsBase>);
+static_assert(has_boundary_conditions_base_v<SystemWithBoundaryConditionsBase>);
+
+static_assert(std::is_same_v<
+              get_boundary_conditions_base<SystemWithBoundaryConditionsBase>,
+              BoundaryConditionsBase>);
+static_assert(
+    std::is_same_v<get_boundary_conditions_base<SystemNoBoundaryConditionsBase>,
+                   detail::TheSystemHasNoBoundaryConditionsBaseTypeAlias>);
+}  // namespace
+}  // namespace domain::BoundaryConditions

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(
   ${LIBRARY}
   PRIVATE
   Domain
+  DomainBoundaryConditionsHelpers
   DomainCreators
   DomainHelpers
   Utilities

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -522,6 +522,7 @@ void test_nsbh_equidistant_factory() {
 }
 }  // namespace
 
+// [[Timeout, 6]]
 SPECTRE_TEST_CASE("Unit.Domain.Creators.BinaryCompactObject.FactoryTests",
                   "[Domain][Unit]") {
   test_connectivity();

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -31,6 +31,7 @@
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Domain/Tags.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Helpers/Domain/DomainTestHelpers.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GetOutput.hpp"
@@ -39,40 +40,7 @@
 
 namespace domain {
 namespace {
-template <size_t Dim>
-class TestBoundaryCondition : public BoundaryConditions::BoundaryCondition {
- public:
-  TestBoundaryCondition() = default;
-  explicit TestBoundaryCondition(Direction<Dim> direction)
-      : direction_(std::move(direction)) {}
-  TestBoundaryCondition(TestBoundaryCondition&&) noexcept = default;
-  TestBoundaryCondition& operator=(TestBoundaryCondition&&) noexcept = default;
-  TestBoundaryCondition(const TestBoundaryCondition&) = default;
-  TestBoundaryCondition& operator=(const TestBoundaryCondition&) = default;
-  ~TestBoundaryCondition() override = default;
-  explicit TestBoundaryCondition(CkMigrateMessage* const msg) noexcept
-      : BoundaryConditions::BoundaryCondition(msg) {}
-
-  WRAPPED_PUPable_decl_base_template(BoundaryConditions::BoundaryCondition,
-                                     TestBoundaryCondition<Dim>);
-
-  const Direction<Dim>& direction() const noexcept { return direction_; }
-
-  auto get_clone() const noexcept
-      -> std::unique_ptr<BoundaryCondition> override {
-    return std::make_unique<TestBoundaryCondition>(*this);
-  }
-
-  void pup(PUP::er& p) override {
-    BoundaryConditions::BoundaryCondition::pup(p);
-  }
-
- private:
-  Direction<Dim> direction_;
-};
-
-template <size_t Dim>
-PUP::able::PUP_ID TestBoundaryCondition<Dim>::my_PUP_ID = 0;  // NOLINT
+namespace helpers = ::TestHelpers::domain::BoundaryConditions;
 
 void test_1d_domains() {
   using Translation = domain::CoordinateMaps::TimeDependent::Translation;
@@ -283,7 +251,8 @@ auto compute_boundary_conditions(
     MapType boundary_conditions_for_block{};
     for (const auto& direction : external_boundaries_of_block) {
       boundary_conditions_for_block.emplace(
-          direction, std::make_unique<TestBoundaryCondition<Dim>>(direction));
+          direction,
+          std::make_unique<helpers::TestBoundaryCondition<Dim>>(direction));
     }
     boundary_conditions[i] = std::move(boundary_conditions_for_block);
   }
@@ -313,7 +282,7 @@ void test_1d_rectilinear_domains() {
       for (const auto& direction : expected_external_boundaries[i]) {
         CAPTURE(direction);
         CHECK(direction ==
-              dynamic_cast<const TestBoundaryCondition<1>&>(
+              dynamic_cast<const helpers::TestBoundaryCondition<1>&>(
                   *domain.blocks()[i].external_boundary_conditions().at(
                       direction))
                   .direction());
@@ -346,7 +315,7 @@ void test_1d_rectilinear_domains() {
       for (const auto& direction : expected_external_boundaries[i]) {
         CAPTURE(direction);
         CHECK(direction ==
-              dynamic_cast<const TestBoundaryCondition<1>&>(
+              dynamic_cast<const helpers::TestBoundaryCondition<1>&>(
                   *domain.blocks()[i].external_boundary_conditions().at(
                       direction))
                   .direction());
@@ -398,7 +367,7 @@ void test_2d_rectilinear_domains() {
       CAPTURE(direction);
       CHECK(
           direction ==
-          dynamic_cast<const TestBoundaryCondition<2>&>(
+          dynamic_cast<const helpers::TestBoundaryCondition<2>&>(
               *domain.blocks()[i].external_boundary_conditions().at(direction))
               .direction());
     }
@@ -440,7 +409,7 @@ void test_3d_rectilinear_domains() {
       CAPTURE(direction);
       CHECK(
           direction ==
-          dynamic_cast<const TestBoundaryCondition<3>&>(
+          dynamic_cast<const helpers::TestBoundaryCondition<3>&>(
               *domain.blocks()[i].external_boundary_conditions().at(direction))
               .direction());
     }

--- a/tests/Unit/Helpers/Domain/BoundaryConditions/BoundaryCondition.cpp
+++ b/tests/Unit/Helpers/Domain/BoundaryConditions/BoundaryCondition.cpp
@@ -1,0 +1,119 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+namespace TestHelpers::domain::BoundaryConditions {
+template <size_t Dim>
+BoundaryConditionBase<Dim>::BoundaryConditionBase(
+    CkMigrateMessage* const msg) noexcept
+    : ::domain::BoundaryConditions::BoundaryCondition(msg) {}
+
+template <size_t Dim>
+void BoundaryConditionBase<Dim>::pup(PUP::er& p) {
+  ::domain::BoundaryConditions::BoundaryCondition::pup(p);
+}
+
+template <size_t Dim>
+TestBoundaryCondition<Dim>::TestBoundaryCondition(Direction<Dim> direction,
+                                                  size_t block_id)
+    : direction_(std::move(direction)), block_id_(block_id) {}
+
+template <size_t Dim>
+TestBoundaryCondition<Dim>::TestBoundaryCondition(const std::string& direction,
+                                                  size_t block_id)
+    : block_id_(block_id) {
+  std::array<std::pair<std::string, Direction<Dim>>, 6> known_directions{};
+  known_directions[0] = std::pair{"lower-xi", Direction<Dim>::lower_xi()};
+  known_directions[1] = std::pair{"upper-xi", Direction<Dim>::upper_xi()};
+  if constexpr (Dim > 1) {
+    known_directions[2] = std::pair{"lower-eta", Direction<Dim>::lower_eta()};
+    known_directions[3] = std::pair{"upper-eta", Direction<Dim>::upper_eta()};
+  }
+  if constexpr (Dim > 2) {
+    known_directions[4] = std::pair{"lower-zeta", Direction<Dim>::lower_zeta()};
+    known_directions[5] = std::pair{"upper-zeta", Direction<Dim>::upper_zeta()};
+  }
+  for (size_t i = 0; i < 2 * Dim; ++i) {
+    if (direction == gsl::at(known_directions, i).first) {
+      direction_ = gsl::at(known_directions, i).second;
+      break;
+    }
+    if (i == 2 * Dim - 1) {
+      std::string known_dirs{};
+      for (const auto& dir : known_directions) {
+        known_dirs += " " + dir.first;
+      }
+      ERROR("Unknown direction: " << direction
+                                  << "\nKnown directions are: " << known_dirs);
+    }
+  }
+}
+
+template <size_t Dim>
+TestBoundaryCondition<Dim>::TestBoundaryCondition(
+    CkMigrateMessage* const msg) noexcept
+    : BoundaryConditionBase<Dim>(msg) {}
+
+template <size_t Dim>
+auto TestBoundaryCondition<Dim>::get_clone() const noexcept
+    -> std::unique_ptr<::domain::BoundaryConditions::BoundaryCondition> {
+  return std::make_unique<TestBoundaryCondition<Dim>>(*this);
+}
+
+template <size_t Dim>
+void TestBoundaryCondition<Dim>::pup(PUP::er& p) {
+  BoundaryConditionBase<Dim>::pup(p);
+  p | direction_;
+  p | block_id_;
+}
+
+template <size_t Dim>
+bool operator==(const TestBoundaryCondition<Dim>& lhs,
+                const TestBoundaryCondition<Dim>& rhs) noexcept {
+  return lhs.direction() == rhs.direction() and
+         lhs.block_id() == rhs.block_id();
+}
+
+template <size_t Dim>
+bool operator!=(const TestBoundaryCondition<Dim>& lhs,
+                const TestBoundaryCondition<Dim>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+template <size_t Dim>
+PUP::able::PUP_ID TestBoundaryCondition<Dim>::my_PUP_ID = 0;  // NOLINT
+
+void register_derived_with_charm() noexcept {
+  Parallel::register_derived_classes_with_charm<BoundaryConditionBase<1>>();
+  Parallel::register_derived_classes_with_charm<BoundaryConditionBase<2>>();
+  Parallel::register_derived_classes_with_charm<BoundaryConditionBase<3>>();
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data)                               \
+  template class BoundaryConditionBase<DIM(data)>;           \
+  template class TestBoundaryCondition<DIM(data)>;           \
+  template bool operator==(                                  \
+      const TestBoundaryCondition<DIM(data)>& lhs,           \
+      const TestBoundaryCondition<DIM(data)>& rhs) noexcept; \
+  template bool operator!=(                                  \
+      const TestBoundaryCondition<DIM(data)>& lhs,           \
+      const TestBoundaryCondition<DIM(data)>& rhs) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATION
+}  // namespace TestHelpers::domain::BoundaryConditions
+/// \endcond

--- a/tests/Unit/Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp
+++ b/tests/Unit/Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp
@@ -1,0 +1,127 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+#include <string>
+
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \ingroup TestingFrameworkGroup
+/// \brief Helpers for boundary conditions
+namespace TestHelpers::domain::BoundaryConditions {
+/// \cond
+template <size_t Dim>
+class TestBoundaryCondition;
+/// \endcond
+
+/// \brief A system-specific boundary condition base class.
+///
+/// To be used in conjunction with `SystemWithBoundaryConditions`
+template <size_t Dim>
+class BoundaryConditionBase
+    : public ::domain::BoundaryConditions::BoundaryCondition {
+ public:
+  using creatable_classes = tmpl::list<TestBoundaryCondition<Dim>>;
+
+  BoundaryConditionBase() = default;
+  BoundaryConditionBase(BoundaryConditionBase&&) noexcept = default;
+  BoundaryConditionBase& operator=(BoundaryConditionBase&&) noexcept = default;
+  BoundaryConditionBase(const BoundaryConditionBase&) = default;
+  BoundaryConditionBase& operator=(const BoundaryConditionBase&) = default;
+  ~BoundaryConditionBase() override = default;
+
+  explicit BoundaryConditionBase(CkMigrateMessage* msg) noexcept;
+
+  void pup(PUP::er& p) override;
+
+  static constexpr Options::String help = {"Boundary conditions for tests."};
+};
+
+/// \brief Concrete boundary condition
+template <size_t Dim>
+class TestBoundaryCondition final : public BoundaryConditionBase<Dim> {
+ public:
+  TestBoundaryCondition() = default;
+  explicit TestBoundaryCondition(Direction<Dim> direction, size_t block_id = 0);
+  TestBoundaryCondition(const std::string& direction, size_t block_id);
+  TestBoundaryCondition(TestBoundaryCondition&&) noexcept = default;
+  TestBoundaryCondition& operator=(TestBoundaryCondition&&) noexcept = default;
+  TestBoundaryCondition(const TestBoundaryCondition&) = default;
+  TestBoundaryCondition& operator=(const TestBoundaryCondition&) = default;
+  ~TestBoundaryCondition() override = default;
+  explicit TestBoundaryCondition(CkMigrateMessage* const msg) noexcept;
+
+  struct DirectionOptionTag {
+    using type = std::string;
+    static std::string name() noexcept { return "Direction"; }
+    static constexpr Options::String help =
+        "The direction the boundary condition operates in.";
+  };
+  struct BlockIdOptionTag {
+    using type = size_t;
+    static std::string name() noexcept { return "BlockId"; }
+    static constexpr Options::String help =
+        "The id of the block the boundary condition operates in.";
+  };
+
+  using options = tmpl::list<DirectionOptionTag, BlockIdOptionTag>;
+
+  static constexpr Options::String help = {"Boundary condition for testing."};
+
+  WRAPPED_PUPable_decl_base_template(
+      ::domain::BoundaryConditions::BoundaryCondition,
+      TestBoundaryCondition<Dim>);
+
+  const Direction<Dim>& direction() const noexcept { return direction_; }
+  size_t block_id() const noexcept { return block_id_; }
+
+  auto get_clone() const noexcept -> std::unique_ptr<
+      ::domain::BoundaryConditions::BoundaryCondition> override;
+
+  void pup(PUP::er& p) override;
+
+ private:
+  Direction<Dim> direction_{};
+  size_t block_id_{0};
+};
+
+template <size_t Dim>
+bool operator==(const TestBoundaryCondition<Dim>& lhs,
+                const TestBoundaryCondition<Dim>& rhs) noexcept;
+
+template <size_t Dim>
+bool operator!=(const TestBoundaryCondition<Dim>& lhs,
+                const TestBoundaryCondition<Dim>& rhs) noexcept;
+
+/// Empty system that has boundary conditions
+template <size_t Dim>
+struct SystemWithBoundaryConditions {
+  using boundary_conditions_base = BoundaryConditionBase<Dim>;
+};
+
+/// Empty system that doesn't have boundary conditions
+template <size_t Dim>
+struct SystemWithoutBoundaryConditions {};
+
+/// Metavariables with a system that has boundary conditions
+template <size_t Dim>
+struct MetavariablesWithBoundaryConditions {
+  using system = SystemWithBoundaryConditions<Dim>;
+};
+
+/// Metavariables with a system that doesn't have boundary conditions
+template <size_t Dim>
+struct MetavariablesWithoutBoundaryConditions {
+  using system = SystemWithoutBoundaryConditions<Dim>;
+};
+
+void register_derived_with_charm() noexcept;
+}  // namespace TestHelpers::domain::BoundaryConditions

--- a/tests/Unit/Helpers/Domain/BoundaryConditions/CMakeLists.txt
+++ b/tests/Unit/Helpers/Domain/BoundaryConditions/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "DomainBoundaryConditionsHelpers")
+
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  BoundaryCondition.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/tests/Unit
+  HEADERS
+  BoundaryCondition.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  DomainBoundaryConditions
+  DomainStructure
+  Options
+  Parallel
+  Utilities
+  )

--- a/tests/Unit/Helpers/Domain/CMakeLists.txt
+++ b/tests/Unit/Helpers/Domain/CMakeLists.txt
@@ -26,3 +26,5 @@ target_link_libraries(
   DomainStructure
   Utilities
   )
+
+add_subdirectory(BoundaryConditions)

--- a/tests/Unit/Helpers/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Helpers/Domain/DomainTestHelpers.cpp
@@ -34,6 +34,7 @@
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
+#include "Utilities/Algorithm.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/ForceInline.hpp"
@@ -186,12 +187,10 @@ void test_refinement_levels_of_neighbors(
 template <size_t VolumeDim>
 bool blocks_are_neighbors(const Block<VolumeDim>& host_block,
                           const Block<VolumeDim>& neighbor_block) noexcept {
-  for (const auto& neighbor : host_block.neighbors()) {
-    if (neighbor.second.id() == neighbor_block.id()) {
-      return true;
-    }
-  }
-  return false;
+  return alg::any_of(host_block.neighbors(),
+                     [&neighbor_block](const auto& neighbor) {
+                       return neighbor.second.id() == neighbor_block.id();
+                     });
 }
 
 // Finds the OrientationMap of a neighboring Block relative to a host Block.

--- a/tests/Unit/Helpers/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Helpers/Domain/DomainTestHelpers.cpp
@@ -18,6 +18,7 @@
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
 #include "Domain/Block.hpp"                  // IWYU pragma: keep
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Domain/CreateInitialElement.hpp"
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Domain.hpp"  // IWYU pragma: keep
@@ -31,6 +32,7 @@
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Domain/Structure/Side.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
@@ -382,30 +384,77 @@ void test_domain_construction(
         functions_of_time,
     const std::vector<std::unique_ptr<
         domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, VolumeDim>>>&
-        expected_grid_to_inertial_maps) noexcept {
-  const auto& blocks = domain.blocks();
-  CHECK(blocks.size() == expected_external_boundaries.size());
-  CHECK(blocks.size() == expected_block_neighbors.size());
-  CHECK(blocks.size() == expected_maps.size());
-  for (size_t i = 0; i < blocks.size(); ++i) {
-    const auto& block = blocks[i];
-    CHECK(block.id() == i);
-    CHECK(block.neighbors() == expected_block_neighbors[i]);
-    CHECK(block.external_boundaries() == expected_external_boundaries[i]);
-    dispatch_check_if_maps_are_equal(block, *expected_maps[i], time,
-                                     functions_of_time);
-    if (std::is_same<TargetFrameGridOrInertial, Frame::Grid>::value) {
-      if (expected_grid_to_inertial_maps.size() != blocks.size()) {
-        ERROR("Need at least one grid to inertial map for each block ("
-              << blocks.size() << " blocks in total) but received "
-              << expected_grid_to_inertial_maps.size() << " instead.");
-      }
-      dispatch_check_if_maps_are_equal(
-          block, *expected_grid_to_inertial_maps[i], time, functions_of_time);
-    }
-  }
+        expected_grid_to_inertial_maps,
+    const std::vector<DirectionMap<
+        VolumeDim,
+        std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>&
+        expected_boundary_conditions) {
+  const auto perform_checks =
+      [&expected_block_neighbors, &expected_external_boundaries, &expected_maps,
+       &time, &functions_of_time, &expected_grid_to_inertial_maps,
+       &expected_boundary_conditions](const auto& local_domain) {
+        const auto& blocks = local_domain.blocks();
+        CHECK(blocks.size() == expected_external_boundaries.size());
+        CHECK(blocks.size() == expected_block_neighbors.size());
+        CHECK(blocks.size() == expected_maps.size());
+        for (size_t i = 0; i < blocks.size(); ++i) {
+          const auto& block = blocks[i];
+          CHECK(block.id() == i);
+          CHECK(block.neighbors() == expected_block_neighbors[i]);
+          CHECK(block.external_boundaries() == expected_external_boundaries[i]);
+          dispatch_check_if_maps_are_equal(block, *expected_maps[i], time,
+                                           functions_of_time);
+          if (std::is_same<TargetFrameGridOrInertial, Frame::Grid>::value) {
+            if (expected_grid_to_inertial_maps.size() != blocks.size()) {
+              ERROR("Need at least one grid to inertial map for each block ("
+                    << blocks.size() << " blocks in total) but received "
+                    << expected_grid_to_inertial_maps.size() << " instead.");
+            }
+            dispatch_check_if_maps_are_equal(block,
+                                             *expected_grid_to_inertial_maps[i],
+                                             time, functions_of_time);
+          }
+        }
+        if (not expected_boundary_conditions.empty()) {
+          for (size_t block_id = 0;
+               block_id < expected_boundary_conditions.size(); ++block_id) {
+            CAPTURE(block_id);
+            REQUIRE(expected_boundary_conditions[block_id].size() ==
+                    expected_external_boundaries[block_id].size());
+            REQUIRE(expected_boundary_conditions[block_id].size() ==
+                    blocks[block_id].external_boundary_conditions().size());
+            const auto& boundary_conditions_in_block =
+                blocks[block_id].external_boundary_conditions();
+            for (const auto& [direction, expected_boundary_condition_ptr] :
+                 expected_boundary_conditions[block_id]) {
+              CAPTURE(direction);
+              CAPTURE(boundary_conditions_in_block.size());
+              REQUIRE(boundary_conditions_in_block.count(direction) == 1);
+              REQUIRE(boundary_conditions_in_block.at(direction) != nullptr);
+              const auto& boundary_condition_in_direction =
+                  dynamic_cast<const TestHelpers::domain::BoundaryConditions::
+                                   TestBoundaryCondition<VolumeDim>&>(
+                      *boundary_conditions_in_block.at(direction));
+              const auto& expected_boundary_condition =
+                  dynamic_cast<const TestHelpers::domain::BoundaryConditions::
+                                   TestBoundaryCondition<VolumeDim>&>(
+                      *expected_boundary_condition_ptr);
+              CHECK(expected_boundary_condition.direction() ==
+                    boundary_condition_in_direction.direction());
+              CHECK(expected_boundary_condition.block_id() ==
+                    boundary_condition_in_direction.block_id());
+            }
+          }
+        }
+      };
+  perform_checks(domain);
   domain::creators::register_derived_with_charm();
-  test_serialization(domain);
+  TestHelpers::domain::BoundaryConditions::register_derived_with_charm();
+  {
+    INFO("Serialization");
+    test_serialization(domain);
+    perform_checks(serialize_and_deserialize(domain));
+  }
   // test operator !=
   CHECK_FALSE(domain != domain);
 }
@@ -522,7 +571,11 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
           functions_of_time,                                                \
       const std::vector<std::unique_ptr<domain::CoordinateMapBase<          \
           Frame::Grid, Frame::Inertial, DIM(data)>>>&                       \
-          expected_logical_to_grid_maps) noexcept;
+          expected_logical_to_grid_maps,                                    \
+      const std::vector<DirectionMap<                                       \
+          DIM(data),                                                        \
+          std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>& \
+          expected_boundary_conditions);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial))
 

--- a/tests/Unit/Helpers/Domain/DomainTestHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/DomainTestHelpers.hpp
@@ -36,9 +36,16 @@ template <size_t VolumeDim>
 class Domain;
 template <size_t VolumeDim>
 class ElementId;
+namespace domain::BoundaryConditions {
+class BoundaryCondition;
+}  // namespace domain::BoundaryConditions
 /// \endcond
 
 // Test that the Blocks in the Domain are constructed correctly.
+//
+// The boundary conditions test assumes that the
+// `TestHelpers::domain::BoundaryConditions::TestBoundaryCondition` class is
+// used as the concrete boundary condition.
 template <size_t VolumeDim, typename TargetFrameGridOrInertial>
 void test_domain_construction(
     const Domain<VolumeDim>& domain,
@@ -54,7 +61,11 @@ void test_domain_construction(
         functions_of_time = {},
     const std::vector<std::unique_ptr<
         domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, VolumeDim>>>&
-        expected_grid_to_inertial_maps = {}) noexcept;
+        expected_grid_to_inertial_maps = {},
+    const std::vector<DirectionMap<
+        VolumeDim,
+        std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>&
+        expected_boundary_conditions = {});
 
 // Test that two neighboring Blocks abut each other.
 template <size_t VolumeDim>


### PR DESCRIPTION
## Proposed changes

- Add a metafunction for getting the boundary condition base class from the system
- Add a `TestBoundaryCondition` class in the test helpers since we will need a placeholder-type boundary condition in all the domain creator tests
- Use test helper boundary condition in Domain and Block tests
- Increase binary domain timeout. This test very nearly always times out on my machine when running on many threads at once

This is now the last bit of code before I can submit PRs for all the domain creators to have boundary condition support.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
