### PR TITLE
Orient std::vector on slices

### DIFF
--- a/src/Domain/Structure/OrientationMapHelpers.hpp
+++ b/src/Domain/Structure/OrientationMapHelpers.hpp
@@ -111,6 +111,7 @@ Variables<TagsList> orient_variables_on_slice(
 }
 // }@
 
+// @{
 /// \ingroup ComputationalDomainGroup
 /// Orient data in a `std::vector<double>` representing one or more tensor
 /// components.
@@ -126,3 +127,10 @@ template <size_t VolumeDim>
 std::vector<double> orient_variables(
     const std::vector<double>& variables, const Index<VolumeDim>& extents,
     const OrientationMap<VolumeDim>& orientation_of_neighbor) noexcept;
+
+template <size_t VolumeDim>
+std::vector<double> orient_variables_on_slice(
+    const std::vector<double>& variables_on_slice,
+    const Index<VolumeDim - 1>& slice_extents, size_t sliced_dim,
+    const OrientationMap<VolumeDim>& orientation_of_neighbor) noexcept;
+// }@

--- a/tests/Unit/Domain/Structure/Test_OrientationMapHelpers.cpp
+++ b/tests/Unit/Domain/Structure/Test_OrientationMapHelpers.cpp
@@ -267,6 +267,21 @@ void test_3d_orient_variables() noexcept {
   CHECK(number_of_orientations_checked == 48);
 }
 
+template <typename TagsList, size_t Dim>
+void check_vector(const Variables<TagsList>& vars,
+                  const Variables<TagsList>& expected_vars,
+                  const Index<Dim - 1>& slice_extents, const size_t sliced_dim,
+                  const OrientationMap<Dim>& orientation_map) {
+  // NOLINTNEXTLINE
+  const std::vector<double> vars_vector{vars.data(), vars.data() + vars.size()};
+  const auto oriented_vars_vector = orient_variables_on_slice(
+      vars_vector, slice_extents, sliced_dim, orientation_map);
+  const std::vector<double> expected_vars_vector{
+      // NOLINTNEXTLINE
+      expected_vars.data(), expected_vars.data() + expected_vars.size()};
+  CHECK(oriented_vars_vector == expected_vars_vector);
+}
+
 // Test 0D slice of a 1D element
 void test_0d_orient_variables_on_slice() noexcept {
   const Index<0> slice_extents{1};
@@ -281,6 +296,7 @@ void test_0d_orient_variables_on_slice() noexcept {
         orient_variables_on_slice(vars, slice_extents, 0, orientation_map);
     // 1D boundary is a point, so no change expected
     CHECK(oriented_vars == vars);
+    check_vector(vars, oriented_vars, slice_extents, 0, orientation_map);
   }
 }
 
@@ -324,6 +340,9 @@ void test_1d_slice_with_orientation(
     get<Coords<1>>(expected_vars) = map_oriented(
         logical_coordinates(slice_orientation_map.inverse_map()(slice_mesh)));
     CHECK(oriented_vars == expected_vars);
+
+    check_vector(vars, oriented_vars, slice_extents, sliced_dim,
+                 orientation_map);
   }
 }
 
@@ -414,6 +433,9 @@ void test_2d_slice_with_orientation(
     get<0>(get<Coords<2>>(expected_vars)) = oriented_mapped_coords[0];
     get<1>(get<Coords<2>>(expected_vars)) = oriented_mapped_coords[1];
     CHECK(oriented_vars == expected_vars);
+
+    check_vector(vars, oriented_vars, slice_extents, sliced_dim,
+                 orientation_map);
   }
 }
 


### PR DESCRIPTION
## Proposed changes

This is needed since the evolution code sends a std::vector instead of a
Variables for the mortar data. This will also be necessary for DG-subcell since ghost points will need to be re-oriented.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
