### PR TITLE
Add boundary condition support to Creators::Interval

### DIFF
--- a/src/Domain/BoundaryConditions/CMakeLists.txt
+++ b/src/Domain/BoundaryConditions/CMakeLists.txt
@@ -3,7 +3,13 @@
 
 set(LIBRARY DomainBoundaryConditions)
 
-add_spectre_library(${LIBRARY} INTERFACE)
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  Periodic.cpp
+  )
 
 spectre_target_headers(
   ${LIBRARY}
@@ -11,6 +17,7 @@ spectre_target_headers(
   HEADERS
   BoundaryCondition.hpp
   GetBoundaryConditionsBase.hpp
+  Periodic.hpp
   )
 
 target_link_libraries(

--- a/src/Domain/BoundaryConditions/Periodic.cpp
+++ b/src/Domain/BoundaryConditions/Periodic.cpp
@@ -1,0 +1,14 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/BoundaryConditions/Periodic.hpp"
+
+namespace domain::BoundaryConditions {
+Periodic::~Periodic() = default;
+
+bool is_periodic(
+    const std::unique_ptr<BoundaryCondition>& boundary_condition) noexcept {
+  return dynamic_cast<const Periodic* const>(boundary_condition.get()) !=
+         nullptr;
+}
+}  // namespace domain::BoundaryConditions

--- a/src/Domain/BoundaryConditions/Periodic.hpp
+++ b/src/Domain/BoundaryConditions/Periodic.hpp
@@ -1,0 +1,35 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pup.h>
+
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace domain::BoundaryConditions {
+/// Mark a boundary condition as being periodic.
+///
+/// Periodic boundary conditions shouldn't require any implementation outside of
+/// a check in the domain creator using the `is_periodic()` function to
+/// determine what boundaries are periodic. Across each matching pair of
+/// periodic boundary conditions, the domain creator should specify that the DG
+/// elements are neighbors of each other.
+class Periodic {
+ public:
+  Periodic() = default;
+  Periodic(Periodic&&) noexcept = default;
+  Periodic& operator=(Periodic&&) noexcept = default;
+  Periodic(const Periodic&) = default;
+  Periodic& operator=(const Periodic&) = default;
+  virtual ~Periodic() = 0;
+};
+
+/// Check if a boundary condition inherits from `Periodic`, which constitutes as
+/// it being marked as a periodic boundary condition.
+bool is_periodic(
+    const std::unique_ptr<BoundaryCondition>& boundary_condition) noexcept;
+}  // namespace domain::BoundaryConditions

--- a/src/Domain/Creators/Interval.hpp
+++ b/src/Domain/Creators/Interval.hpp
@@ -11,6 +11,8 @@
 #include <memory>
 #include <vector>
 
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/BoundaryConditions/GetBoundaryConditionsBase.hpp"
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Creators/TimeDependence/TimeDependence.hpp"
 #include "Domain/Domain.hpp"
@@ -69,19 +71,66 @@ class Interval : public DomainCreator<1> {
     static constexpr Options::String help = {
         "The time dependence of the moving mesh domain."};
   };
+  struct BoundaryConditions {
+    static constexpr Options::String help = "The boundary conditions to apply.";
+  };
+  template <typename BoundaryConditionsBase>
+  struct UpperBoundaryCondition {
+    static std::string name() noexcept { return "UpperBoundary"; }
+    static constexpr Options::String help =
+        "Options for the boundary condition applied at the upper boundary.";
+    using type = std::unique_ptr<BoundaryConditionsBase>;
+    using group = BoundaryConditions;
+  };
+  template <typename BoundaryConditionsBase>
+  struct LowerBoundaryCondition {
+    static std::string name() noexcept { return "LowerBoundary"; }
+    static constexpr Options::String help =
+        "Options for the boundary condition applied at the lower boundary.";
+    using type = std::unique_ptr<BoundaryConditionsBase>;
+    using group = BoundaryConditions;
+  };
 
-  using options =
-      tmpl::list<LowerBound, UpperBound, IsPeriodicIn, InitialRefinement,
-                 InitialGridPoints, TimeDependence>;
+  using common_options =
+      tmpl::list<LowerBound, UpperBound, InitialRefinement, InitialGridPoints>;
+
+  using options_periodic = tmpl::list<IsPeriodicIn>;
+  template <typename System>
+  using options_boundary_conditions = tmpl::list<
+      LowerBoundaryCondition<
+          domain::BoundaryConditions::get_boundary_conditions_base<System>>,
+      UpperBoundaryCondition<
+          domain::BoundaryConditions::get_boundary_conditions_base<System>>>;
+
+  template <typename Metavariables>
+  using options = tmpl::append<
+      common_options,
+      tmpl::conditional_t<
+          domain::BoundaryConditions::has_boundary_conditions_base_v<
+              typename Metavariables::system>,
+          options_boundary_conditions<typename Metavariables::system>,
+          options_periodic>,
+      tmpl::list<TimeDependence>>;
 
   static constexpr Options::String help = {"Creates a 1D interval."};
 
-  Interval(typename LowerBound::type lower_x, typename UpperBound::type upper_x,
-           typename IsPeriodicIn::type is_periodic_in_x,
-           typename InitialRefinement::type initial_refinement_level_x,
-           typename InitialGridPoints::type initial_number_of_grid_points_in_x,
+  Interval(std::array<double, 1> lower_x, std::array<double, 1> upper_x,
+           std::array<size_t, 1> initial_refinement_level_x,
+           std::array<size_t, 1> initial_number_of_grid_points_in_x,
+           std::array<bool, 1> is_periodic_in_x,
            std::unique_ptr<domain::creators::time_dependence::TimeDependence<1>>
-               time_dependence = nullptr) noexcept;
+               time_dependence) noexcept;
+
+  Interval(std::array<double, 1> lower_x, std::array<double, 1> upper_x,
+           std::array<size_t, 1> initial_refinement_level_x,
+           std::array<size_t, 1> initial_number_of_grid_points_in_x,
+           std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+               lower_boundary_condition,
+           std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+               upper_boundary_condition,
+           std::unique_ptr<domain::creators::time_dependence::TimeDependence<1>>
+               time_dependence,
+           const Options::Context& context = {});
 
   Interval() = default;
   Interval(const Interval&) = delete;
@@ -107,6 +156,10 @@ class Interval : public DomainCreator<1> {
   typename IsPeriodicIn::type is_periodic_in_x_{};
   typename InitialRefinement::type initial_refinement_level_x_{};
   typename InitialGridPoints::type initial_number_of_grid_points_in_x_{};
+  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+      lower_boundary_condition_;
+  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+      upper_boundary_condition_;
   std::unique_ptr<domain::creators::time_dependence::TimeDependence<1>>
       time_dependence_;
 };

--- a/src/Domain/Creators/Python/Interval.cpp
+++ b/src/Domain/Creators/Python/Interval.cpp
@@ -12,9 +12,7 @@
 
 namespace py = pybind11;
 
-namespace domain {
-namespace creators {
-namespace py_bindings {
+namespace domain::creators::py_bindings {
 void bind_interval(py::module& m) {  // NOLINT
   py::class_<Interval, DomainCreator<1>>(m, "Interval")
       .def(
@@ -37,6 +35,4 @@ void bind_interval(py::module& m) {  // NOLINT
           py::arg("initial_number_of_grid_points_in_x"),
           py::arg("is_periodic_in_x"));
 }
-}  // namespace py_bindings
-}  // namespace creators
-}  // namespace domain
+}  // namespace domain::creators::py_bindings

--- a/src/Domain/Creators/Python/Interval.cpp
+++ b/src/Domain/Creators/Python/Interval.cpp
@@ -17,12 +17,25 @@ namespace creators {
 namespace py_bindings {
 void bind_interval(py::module& m) {  // NOLINT
   py::class_<Interval, DomainCreator<1>>(m, "Interval")
-      .def(py::init<std::array<double, 1>, std::array<double, 1>,
-                    std::array<bool, 1>, std::array<size_t, 1>,
-                    std::array<size_t, 1>>(),
-           py::arg("lower_x"), py::arg("upper_x"), py::arg("is_periodic_in_x"),
-           py::arg("initial_refinement_level_x"),
-           py::arg("initial_number_of_grid_points_in_x"));
+      .def(
+          py::init(
+              [](const std::array<double, 1> lower_x,
+                 const std::array<double, 1> upper_x,
+                 const std::array<size_t, 1> initial_refinement_level_x,
+                 const std::array<size_t, 1> initial_number_of_grid_points_in_x,
+                 const std::array<bool, 1> is_periodic_in_x) {
+                return domain::creators::Interval{
+                    lower_x,
+                    upper_x,
+                    initial_refinement_level_x,
+                    initial_number_of_grid_points_in_x,
+                    is_periodic_in_x,
+                    nullptr};
+              }),
+          py::arg("lower_x"), py::arg("upper_x"),
+          py::arg("initial_refinement_level_x"),
+          py::arg("initial_number_of_grid_points_in_x"),
+          py::arg("is_periodic_in_x"));
 }
 }  // namespace py_bindings
 }  // namespace creators

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -180,6 +180,8 @@ template <size_t Dim>
 struct Metavariables {
   static constexpr size_t volume_dim = Dim;
   static constexpr bool local_time_stepping = false;
+  // A placeholder system for the domain creators
+  struct system {};
 
   using triggers = Triggers::time_triggers;
   using events = tmpl::list<>;

--- a/tests/Unit/Domain/BoundaryConditions/CMakeLists.txt
+++ b/tests/Unit/Domain/BoundaryConditions/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_DomainBoundaryConditions")
 set(LIBRARY_SOURCES
   Test_BoundaryCondition.cpp
   Test_GetBoundaryConditionsBase.cpp
+  Test_Periodic.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Domain/BoundaryConditions/Test_Periodic.cpp
+++ b/tests/Unit/Domain/BoundaryConditions/Test_Periodic.cpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <memory>
+#include <pup.h>
+#include <string>
+
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/BoundaryConditions/Periodic.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Parallel/CharmPupable.hpp"
+
+namespace {
+namespace helpers = TestHelpers::domain::BoundaryConditions;
+
+SPECTRE_TEST_CASE("Unit.Domain.BoundaryConditions.Periodic", "[Unit][Domain]") {
+  helpers::register_derived_with_charm();
+
+  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> periodic =
+      std::make_unique<helpers::TestPeriodicBoundaryCondition<1>>();
+  CHECK(is_periodic(periodic));
+  CHECK(is_periodic(serialize_and_deserialize(periodic)));
+
+  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> not_periodic =
+      std::make_unique<helpers::TestBoundaryCondition<1>>();
+  CHECK_FALSE(is_periodic(not_periodic));
+  CHECK_FALSE(is_periodic(serialize_and_deserialize(not_periodic)));
+}
+}  // namespace
+// }  // namespace domain::BoundaryConditions

--- a/tests/Unit/Domain/Creators/CMakeLists.txt
+++ b/tests/Unit/Domain/Creators/CMakeLists.txt
@@ -26,5 +26,16 @@ add_test_library(
   ${LIBRARY}
   "Domain/Creators"
   "${LIBRARY_SOURCES}"
-  "DomainCreators;Domain;DomainHelpers;Test_Domain"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  Domain
+  DomainBoundaryConditions
+  DomainBoundaryConditionsHelpers
+  DomainCreators
+  DomainHelpers
+  Test_Domain
   )

--- a/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
+++ b/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
@@ -20,8 +20,10 @@
 #include "Domain/Creators/AlignedLattice.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Domain.hpp"
+#include "Domain/OptionTags.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Helpers/Domain/DomainTestHelpers.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 
@@ -44,16 +46,18 @@ void test_aligned_blocks(
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
-  const auto domain_creator_1d =
-      TestHelpers::test_factory_creation<DomainCreator<1>>(
-          "AlignedLattice:\n"
-          "  BlockBounds: [[0.1, 2.6, 5.1, 5.2, 7.2]]\n"
-          "  IsPeriodicIn: [false]\n"
-          "  InitialGridPoints: [3]\n"
-          "  InitialLevels: [2]\n"
-          "  RefinedLevels: []\n"
-          "  RefinedGridPoints: []\n"
-          "  BlocksToExclude: []\n");
+  const auto domain_creator_1d = TestHelpers::test_factory_creation<
+      DomainCreator<1>, domain::OptionTags::DomainCreator<1>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithBoundaryConditions<1>>(
+      "AlignedLattice:\n"
+      "  BlockBounds: [[0.1, 2.6, 5.1, 5.2, 7.2]]\n"
+      "  IsPeriodicIn: [false]\n"
+      "  InitialGridPoints: [3]\n"
+      "  InitialLevels: [2]\n"
+      "  RefinedLevels: []\n"
+      "  RefinedGridPoints: []\n"
+      "  BlocksToExclude: []\n");
   const auto* aligned_blocks_creator_1d =
       dynamic_cast<const creators::AlignedLattice<1>*>(domain_creator_1d.get());
   test_aligned_blocks(*aligned_blocks_creator_1d);

--- a/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
@@ -19,12 +19,14 @@
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/RotatedIntervals.hpp"
 #include "Domain/Domain.hpp"
+#include "Domain/OptionTags.hpp"
 #include "Domain/Structure/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Helpers/Domain/DomainTestHelpers.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/MakeVector.hpp"
@@ -109,15 +111,17 @@ void test_rotated_intervals_factory() {
   INFO("Rotated intervals factory");
   const OrientationMap<1> flipped{
       std::array<Direction<1>, 1>{{Direction<1>::lower_xi()}}};
-  const auto domain_creator =
-      TestHelpers::test_factory_creation<DomainCreator<1>>(
-          "RotatedIntervals:\n"
-          "  LowerBound: [0.0]\n"
-          "  Midpoint:   [0.5]\n"
-          "  UpperBound: [1.0]\n"
-          "  IsPeriodicIn: [True]\n"
-          "  InitialGridPoints: [[3,2]]\n"
-          "  InitialRefinement: [2]\n");
+  const auto domain_creator = TestHelpers::test_factory_creation<
+      DomainCreator<1>, domain::OptionTags::DomainCreator<1>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<1>>(
+      "RotatedIntervals:\n"
+      "  LowerBound: [0.0]\n"
+      "  Midpoint:   [0.5]\n"
+      "  UpperBound: [1.0]\n"
+      "  IsPeriodicIn: [True]\n"
+      "  InitialGridPoints: [[3,2]]\n"
+      "  InitialRefinement: [2]\n");
   const auto* rotated_intervals_creator =
       dynamic_cast<const creators::RotatedIntervals*>(domain_creator.get());
   test_rotated_intervals_construction(

--- a/tests/Unit/Elliptic/Actions/Test_InitializeSystem.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeSystem.cpp
@@ -114,7 +114,7 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeSystem",
     // Which element we work with does not matter for this test
     const ElementId<1> element_id{0, {{SegmentId{2, 1}}}};
     const domain::creators::Interval domain_creator{
-        {{-0.5}}, {{1.5}}, {{false}}, {{2}}, {{4}}};
+        {{-0.5}}, {{1.5}}, {{2}}, {{4}}, {{false}}, nullptr};
 
     using metavariables = Metavariables<1>;
     using element_array = ElementArray<1, metavariables>;

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeInhomogeneousBoundaryConditionsOnSource.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeInhomogeneousBoundaryConditionsOnSource.cpp
@@ -192,7 +192,7 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Actions.InhomogeneousBoundaryConditions",
     // -0.5       1.5
     const ElementId<1> element_id{0, {{SegmentId{2, 0}}}};
     const domain::creators::Interval domain_creator{
-        {{-0.5}}, {{1.5}}, {{false}}, {{2}}, {{4}}};
+        {{-0.5}}, {{1.5}}, {{2}}, {{4}}, {{false}}, nullptr};
 
     // Expected boundary contribution to source in element X:
     // [ -24 0 0 0 | -> xi

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFirstOrderOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFirstOrderOperator.cpp
@@ -237,7 +237,7 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Actions.InitializeFirstOrderOperator",
     // [X| | | ]-> xi
     const ElementId<1> element_id{0, {{{2, 0}}}};
     const domain::creators::Interval domain_creator{
-        {{-0.5}}, {{1.5}}, {{false}}, {{2}}, {{4}}};
+        {{-0.5}}, {{1.5}}, {{2}}, {{4}}, {{false}}, nullptr};
 
     test_initialize_fluxes(domain_creator, element_id);
   }

--- a/tests/Unit/Helpers/Domain/BoundaryConditions/BoundaryCondition.cpp
+++ b/tests/Unit/Helpers/Domain/BoundaryConditions/BoundaryCondition.cpp
@@ -91,7 +91,26 @@ bool operator!=(const TestBoundaryCondition<Dim>& lhs,
 }
 
 template <size_t Dim>
+TestPeriodicBoundaryCondition<Dim>::TestPeriodicBoundaryCondition(
+    CkMigrateMessage* const msg) noexcept
+    : BoundaryConditionBase<Dim>(msg) {}
+
+template <size_t Dim>
+auto TestPeriodicBoundaryCondition<Dim>::get_clone() const noexcept
+    -> std::unique_ptr<::domain::BoundaryConditions::BoundaryCondition> {
+  return std::make_unique<TestPeriodicBoundaryCondition<Dim>>(*this);
+}
+
+template <size_t Dim>
+void TestPeriodicBoundaryCondition<Dim>::pup(PUP::er& p) {
+  BoundaryConditionBase<Dim>::pup(p);
+}
+
+template <size_t Dim>
 PUP::able::PUP_ID TestBoundaryCondition<Dim>::my_PUP_ID = 0;  // NOLINT
+
+template <size_t Dim>
+PUP::able::PUP_ID TestPeriodicBoundaryCondition<Dim>::my_PUP_ID = 0;  // NOLINT
 
 void register_derived_with_charm() noexcept {
   Parallel::register_derived_classes_with_charm<BoundaryConditionBase<1>>();
@@ -104,6 +123,7 @@ void register_derived_with_charm() noexcept {
 #define INSTANTIATION(r, data)                               \
   template class BoundaryConditionBase<DIM(data)>;           \
   template class TestBoundaryCondition<DIM(data)>;           \
+  template class TestPeriodicBoundaryCondition<DIM(data)>;   \
   template bool operator==(                                  \
       const TestBoundaryCondition<DIM(data)>& lhs,           \
       const TestBoundaryCondition<DIM(data)>& rhs) noexcept; \

--- a/tests/Unit/Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp
+++ b/tests/Unit/Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/CharmPupable.hpp"
@@ -20,6 +21,8 @@ namespace TestHelpers::domain::BoundaryConditions {
 /// \cond
 template <size_t Dim>
 class TestBoundaryCondition;
+template <size_t Dim>
+class TestPeriodicBoundaryCondition;
 /// \endcond
 
 /// \brief A system-specific boundary condition base class.
@@ -29,7 +32,8 @@ template <size_t Dim>
 class BoundaryConditionBase
     : public ::domain::BoundaryConditions::BoundaryCondition {
  public:
-  using creatable_classes = tmpl::list<TestBoundaryCondition<Dim>>;
+  using creatable_classes = tmpl::list<TestBoundaryCondition<Dim>,
+                                       TestPeriodicBoundaryCondition<Dim>>;
 
   BoundaryConditionBase() = default;
   BoundaryConditionBase(BoundaryConditionBase&&) noexcept = default;
@@ -100,6 +104,36 @@ bool operator==(const TestBoundaryCondition<Dim>& lhs,
 template <size_t Dim>
 bool operator!=(const TestBoundaryCondition<Dim>& lhs,
                 const TestBoundaryCondition<Dim>& rhs) noexcept;
+
+template <size_t Dim>
+class TestPeriodicBoundaryCondition final
+    : public BoundaryConditionBase<Dim>,
+      public ::domain::BoundaryConditions::Periodic {
+ public:
+  TestPeriodicBoundaryCondition() = default;
+  TestPeriodicBoundaryCondition(TestPeriodicBoundaryCondition&&) noexcept =
+      default;
+  TestPeriodicBoundaryCondition& operator=(
+      TestPeriodicBoundaryCondition&&) noexcept = default;
+  TestPeriodicBoundaryCondition(const TestPeriodicBoundaryCondition&) = default;
+  TestPeriodicBoundaryCondition& operator=(
+      const TestPeriodicBoundaryCondition&) = default;
+  ~TestPeriodicBoundaryCondition() override = default;
+  explicit TestPeriodicBoundaryCondition(CkMigrateMessage* const msg) noexcept;
+
+  using options = tmpl::list<>;
+  static constexpr Options::String help = {
+      "Periodic boundary condition for testing."};
+
+  WRAPPED_PUPable_decl_base_template(
+      ::domain::BoundaryConditions::BoundaryCondition,
+      TestPeriodicBoundaryCondition<Dim>);
+
+  auto get_clone() const noexcept -> std::unique_ptr<
+      ::domain::BoundaryConditions::BoundaryCondition> override;
+
+  void pup(PUP::er& p) override;
+};
 
 /// Empty system that has boundary conditions
 template <size_t Dim>

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeDomain.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeDomain.cpp
@@ -92,7 +92,7 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeDomain", "[Unit][Actions]") {
     // [ |X| | ]-> xi
     const ElementId<1> element_id{0, {{SegmentId{2, 1}}}};
     const domain::creators::Interval domain_creator{
-        {{-0.5}}, {{1.5}}, {{false}}, {{2}}, {{4}}};
+        {{-0.5}}, {{1.5}}, {{2}}, {{4}}, {{false}}, nullptr};
     // Register the coordinate map for serialization
     PUPable_reg(
         SINGLE_ARG(domain::CoordinateMap<Frame::Logical, Frame::Inertial,

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeInterfaces.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeInterfaces.cpp
@@ -258,8 +258,8 @@ void test_1d() {
   // Reference element:
   // [ |X| | ]-> xi
   const ElementId<1> element_id{0, {{SegmentId{2, 1}}}};
-  const domain::creators::Interval domain_creator{
-      {{-0.5}}, {{1.5}}, {{false}}, {{2}}, {{4}}};
+  const domain::creators::Interval domain_creator{{{-0.5}}, {{1.5}},   {{2}},
+                                                  {{4}},    {{false}}, nullptr};
   // Register the coordinate map for serialization
   PUPable_reg(
       SINGLE_ARG(domain::CoordinateMap<Frame::Logical, Frame::Inertial,

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeMortars.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeMortars.cpp
@@ -190,7 +190,7 @@ SPECTRE_TEST_CASE("Unit.ParallelDG.InitializeMortars", "[Unit][Actions]") {
     // [X| | | ]-> xi
     const ElementId<1> element_id{0, {{{2, 0}}}};
     const domain::creators::Interval domain_creator{
-        {{-0.5}}, {{1.5}}, {{false}}, {{2}}, {{4}}};
+        {{-0.5}}, {{1.5}}, {{2}}, {{4}}, {{false}}, nullptr};
     // We are working with 2 mortars here: a domain boundary at lower xi
     // and an interface at upper xi.
     const auto boundary_mortar_id = std::make_pair(

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
@@ -153,7 +153,8 @@ std::unique_ptr<DomainCreator<SpatialDim>> domain_creator() noexcept;
 template <>
 std::unique_ptr<DomainCreator<1>> domain_creator() noexcept {
   return std::make_unique<domain::creators::Interval>(
-      domain::creators::Interval({{-0.5}}, {{0.5}}, {{false}}, {{0}}, {{4}}));
+      domain::creators::Interval({{-0.5}}, {{0.5}}, {{0}}, {{4}}, {{false}},
+                                 nullptr));
 }
 
 template <>

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
@@ -70,6 +70,7 @@ struct MockContributeReductionData {
     double volume;
     std::vector<double> volume_integrals{};
   };
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static Results results;
 
   template <typename ParallelComponent, typename... DbTags,
@@ -91,6 +92,7 @@ struct MockContributeReductionData {
   }
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 MockContributeReductionData::Results MockContributeReductionData::results{};
 
 template <typename Metavariables>

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/CMakeLists.txt
@@ -70,6 +70,7 @@ function(add_distributed_linear_solver_algorithm_test TEST_NAME)
     Test_${TEST_NAME}
     PRIVATE
     Domain
+    DomainBoundaryConditionsHelpers
     DomainCreators
     )
 endfunction()

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp"
 #include "Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp"
 #include "Parallel/InitializationFunctions.hpp"
@@ -29,6 +30,9 @@ struct Metavariables {
       "Test the conjugate gradient linear solver algorithm on multiple "
       "elements"};
   static constexpr size_t volume_dim = 1;
+  using system =
+      TestHelpers::domain::BoundaryConditions::SystemWithoutBoundaryConditions<
+          volume_dim>;
 
   using linear_solver = LinearSolver::cg::ConjugateGradient<
       Metavariables, typename helpers_distributed::fields_tag, ParallelCg>;
@@ -46,7 +50,8 @@ struct Metavariables {
 }  // namespace
 
 static const std::vector<void (*)()> charm_init_node_funcs{
-    &setup_error_handling, &domain::creators::register_derived_with_charm};
+    &setup_error_handling, &domain::creators::register_derived_with_charm,
+    &TestHelpers::domain::BoundaryConditions::register_derived_with_charm};
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp"
 #include "Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp"
 #include "Parallel/InitializationFunctions.hpp"
@@ -28,6 +29,9 @@ struct Metavariables {
   static constexpr const char* const help{
       "Test the GMRES linear solver algorithm on multiple elements"};
   static constexpr size_t volume_dim = 1;
+  using system =
+      TestHelpers::domain::BoundaryConditions::SystemWithoutBoundaryConditions<
+          volume_dim>;
 
   using linear_solver =
       LinearSolver::gmres::Gmres<Metavariables, helpers_distributed::fields_tag,
@@ -46,7 +50,8 @@ struct Metavariables {
 }  // namespace
 
 static const std::vector<void (*)()> charm_init_node_funcs{
-    &setup_error_handling, &domain::creators::register_derived_with_charm};
+    &setup_error_handling, &domain::creators::register_derived_with_charm,
+    &TestHelpers::domain::BoundaryConditions::register_derived_with_charm};
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresPreconditionedAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresPreconditionedAlgorithm.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp"
 #include "Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp"
 #include "Parallel/InitializationFunctions.hpp"
@@ -34,6 +35,9 @@ struct Metavariables {
       "Test the preconditioned GMRES linear solver algorithm on multiple "
       "elements"};
   static constexpr size_t volume_dim = 1;
+  using system =
+      TestHelpers::domain::BoundaryConditions::SystemWithoutBoundaryConditions<
+          volume_dim>;
 
   using linear_solver =
       LinearSolver::gmres::Gmres<Metavariables, helpers_distributed::fields_tag,
@@ -54,7 +58,8 @@ struct Metavariables {
 }  // namespace
 
 static const std::vector<void (*)()> charm_init_node_funcs{
-    &setup_error_handling, &domain::creators::register_derived_with_charm};
+    &setup_error_handling, &domain::creators::register_derived_with_charm,
+    &TestHelpers::domain::BoundaryConditions::register_derived_with_charm};
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/Test_DistributedRichardsonAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/Test_DistributedRichardsonAlgorithm.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp"
 #include "Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp"
 #include "Parallel/InitializationFunctions.hpp"
@@ -28,6 +29,9 @@ struct Metavariables {
   static constexpr const char* const help{
       "Test the Richardson linear solver algorithm on multiple elements"};
   static constexpr size_t volume_dim = 1;
+  using system =
+      TestHelpers::domain::BoundaryConditions::SystemWithoutBoundaryConditions<
+          volume_dim>;
 
   using linear_solver = LinearSolver::Richardson::Richardson<
       typename helpers_distributed::fields_tag, ParallelRichardson>;
@@ -45,7 +49,8 @@ struct Metavariables {
 }  // namespace
 
 static const std::vector<void (*)()> charm_init_node_funcs{
-    &setup_error_handling, &domain::creators::register_derived_with_charm};
+    &setup_error_handling, &domain::creators::register_derived_with_charm,
+    &TestHelpers::domain::BoundaryConditions::register_derived_with_charm};
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.cpp
@@ -15,6 +15,7 @@
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Tags.hpp"
 #include "Elliptic/DiscontinuousGalerkin/DgElementArray.hpp"
+#include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp"
 #include "Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
@@ -190,6 +191,9 @@ struct Metavariables {
   static constexpr const char* const help{
       "Test the Schwarz linear solver algorithm"};
   static constexpr size_t volume_dim = 1;
+  using system =
+      TestHelpers::domain::BoundaryConditions::SystemWithoutBoundaryConditions<
+          volume_dim>;
 
   using linear_solver =
       LinearSolver::Schwarz::Schwarz<helpers_distributed::fields_tag,
@@ -210,7 +214,8 @@ struct Metavariables {
 static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &domain::creators::register_derived_with_charm,
     &Parallel::register_derived_classes_with_charm<
-        Metavariables::linear_solver::subdomain_solver>};
+        Metavariables::linear_solver::subdomain_solver>,
+    &TestHelpers::domain::BoundaryConditions::register_derived_with_charm};
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};
 


### PR DESCRIPTION
## Proposed changes

Adds support for specifying boundary conditions at runtime and adding them to the domain to the interval domain creator.

Some notes:
- In order to not break develop and not have one 15,000 line PR (not an exaggeration...) I have to support both having and not having boundary conditions specified in the systems. Once all the systems (both elliptic and evolution) are migrated over to supporting boundary conditions, we can clean up the code. This is noted in #2779 along with some related cleanups
- There are some "extra" or "unexpected" changes, such as the need to register boundary conditions in some of the elliptic test executables.
- Once folks have had a chance to look at the interface, I'll open up PRs for all the remaining domain creators. I have not added boundary condition support for all conceivable cases of option values to all domain creators because I'm not sure we will ever use some of them, and if we do, adding them isn't so difficult that whoever wants that configuration couldn't add the support.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
