### PR TITLE
Prohibit serializing a non-owning vector

### DIFF
--- a/src/DataStructures/VectorImpl.hpp
+++ b/src/DataStructures/VectorImpl.hpp
@@ -353,14 +353,14 @@ VectorImpl<T, VectorType>& VectorImpl<T, VectorType>::operator=(
 
 template <typename T, typename VectorType>
 void VectorImpl<T, VectorType>::pup(PUP::er& p) noexcept {  // NOLINT
+  ASSERT(owning_, "Cannot pup a non-owning vector!");
   auto my_size = size();
   p | my_size;
   if (my_size > 0) {
     if (p.isUnpacking()) {
       owning_ = true;
-      owned_data_.reset(my_size > 0 ? static_cast<value_type*>(
-                                          malloc(my_size * sizeof(value_type)))
-                                    : nullptr);
+      owned_data_.reset(
+          static_cast<value_type*>(malloc(my_size * sizeof(value_type))));
       reset_pointer_vector(my_size);
     }
     PUParray(p, data(), size());

--- a/tests/Unit/Helpers/DataStructures/VectorImplTestHelper.hpp
+++ b/tests/Unit/Helpers/DataStructures/VectorImplTestHelper.hpp
@@ -155,20 +155,6 @@ void vector_test_serialize(tt::get_fundamental_type_t<ValueType> low =
   CHECK(serialized_vector_test.is_owning());
   CHECK(serialized_vector_test.data() != vector_test.data());
   CHECK(vector_test.is_owning());
-  // checks serialization for reference
-  vector_ref.set_data_ref(&vector_test);
-  CHECK(vector_test.is_owning());
-  CHECK_FALSE(vector_ref.is_owning());
-  CHECK(vector_ref == vector_test);
-  const VectorType serialized_vector_ref =
-      serialize_and_deserialize(vector_ref);
-  CHECK(vector_test.is_owning());
-  CHECK(vector_test == vector_control);
-  CHECK(vector_ref == vector_test);
-  CHECK(serialized_vector_ref == vector_test);
-  CHECK(serialized_vector_ref.is_owning());
-  CHECK(serialized_vector_ref.data() != vector_ref.data());
-  CHECK_FALSE(vector_ref.is_owning());
 }
 
 /// \ingroup TestingFrameworkGroup


### PR DESCRIPTION
Previously, a non-owning vector was serialized to an owning vector, which
changes their behavior post-serialization.   Instead of serializing a non-owning
vector, higher level code needs to manage setting up the non-owning vectors
after the serialization of whatever owning vectors to which the non-owning
vectors refer.

Also simplified code within a conditional.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
