### PR TITLE
Add struct for marking DataBox tags for a reference item

### DIFF
--- a/src/DataStructures/DataBox/Tag.hpp
+++ b/src/DataStructures/DataBox/Tag.hpp
@@ -155,4 +155,35 @@ struct PrefixTag {};
  * \see DataBoxGroup SimpleTag
  */
 struct ComputeTag {};
+
+/*!
+ * \ingroup DataBoxGroup
+ * \brief Mark a struct as a reference tag by inheriting from this.
+ *
+ * \details
+ * A reference tag is used to identify an item in a DataBox that is a const
+ * reference to a sub-item of another item (such as a Variables or GlobalCache)
+ * in the DataBox
+ *
+ * \derivedrequires
+ * - type alias `base` that is the simple tag from which the reference tag is
+ *   derived
+ * - type alias `parent_tag` that is the tag for the item from which the
+ *   reference item is retrieved
+ * - static function `get` that, given the item fetched by `parent_tag`, returns
+ *   a const reference to the sub-item
+ * - type alias `argument_tags` that is `tmpl::list<parent_tag>`
+ *
+ * A reference tag may optionally specify a static `std::string name()` method
+ * to override the default name produced by db::tag_name.
+ *
+ * \warning A reference tag should only be derived from a simple tag and
+ * db::ReferenceTag.
+ *
+ * \example
+ * \snippet Test_DataBox.cpp databox_reference_tag_example
+ *
+ * \see DataBoxGroup SimpleTag
+ */
+struct ReferenceTag {};
 }  // namespace db

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -2653,6 +2653,27 @@ void serialization_of_pointers() noexcept {
   check(box);
   check(serialize_and_deserialize(box));  // after compute items evaluated
 }
+
+namespace test_databox_tags {
+/// [databox_reference_tag_example]
+template <typename... Tags>
+struct TaggedTuple : db::SimpleTag {
+  using type = tuples::TaggedTuple<Tags...>;
+};
+
+template <typename Tag, typename ParentTag>
+struct FromTaggedTuple : Tag, db::ReferenceTag {
+  using base = Tag;
+  using parent_tag = ParentTag;
+
+  static const auto& get(const typename parent_tag::type& tagged_tuple) {
+    return tuples::get<Tag>(tagged_tuple);
+  }
+
+  using argument_tags = tmpl::list<parent_tag>;
+};
+/// [databox_reference_tag_example]
+}  // namespace test_databox_tags
 }  // namespace
 
 void test_serialization() noexcept {


### PR DESCRIPTION
A reference item refers to a part of another item (usually a tagged
container such as GlobalCache or a Variables) stored in a DataBox.
Currently these items are either tagged with a db::ComputeTag that
returns by reference, or with a db::SimpleTag that is added to the
typelist compute_with_subitems_tags of the DataBox.  This new tag
is being introduced to distinguish the tags for these items from
the tags for simple and compute items which store a type.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
