### PR TITLE
Clarify contributing guide: PRs don't need everyone's re-approval before merging

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -283,9 +283,12 @@ following manner:
   and may either also fix final suggested changes, or create an issue
   with the suggested changes, which will be addressed in a subsequent
   pull request by the author.
-- The SpECTRE core developer will merge the pull request once all
-  comments have been addressed, the code passes CI, and all pull
-  requests the pull request depends on have been merged.
+- The SpECTRE core developer will merge the pull request once all comments have
+  been addressed, all reviewers have approved the PR, the code passes CI and all
+  pull requests the pull request depends on have been merged. When approvals are
+  dismissed by minor changes, such as rebasing, squashing fixup commits or
+  adding a missing include, the core developer may merge the PR without waiting
+  for all reviewers to re-approve the PR.
 
 Critical bug fixes (i.e. the code is broken) can be merged after two
 expedited reviews by SpECTRE core developers.  If necessary, an issue


### PR DESCRIPTION
## Proposed changes

This is a proposal to reduce the number of times that reviewers have to go back and re-approve a PR. For example, when a PR has been approved but then needs a rebase or a clang-tidy fix I suggest it doesn't have to be re-approved by all reviewers if the core dev responsible for merging it determines the changes were sufficiently trivial. Of course the core dev can decide to ping the reviewers and ask for their explicit re-approval nonetheless, if they think that would be useful in the specific case.

When editing the review guidelines I found that they don't actually say that all reviewers have to approve again, so I just added a small note to clarify.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
