### PR TITLE
Add Rusanov boundary correction for GRMHD, make lapse, shift, inv spatial metric temp tags

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/BoundaryCorrection.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/BoundaryCorrection.hpp
@@ -1,0 +1,39 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <pup.h>
+
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// Boundary corrections/numerical fluxes
+namespace grmhd::ValenciaDivClean::BoundaryCorrections {
+/// \cond
+class Rusanov;
+/// \endcond
+
+/*!
+ * \brief The base class used to make boundary corrections factory createable so
+ * they can be specified in the input file.
+ */
+class BoundaryCorrection : public PUP::able {
+ public:
+  BoundaryCorrection() = default;
+  BoundaryCorrection(const BoundaryCorrection&) = default;
+  BoundaryCorrection& operator=(const BoundaryCorrection&) = default;
+  BoundaryCorrection(BoundaryCorrection&&) = default;
+  BoundaryCorrection& operator=(BoundaryCorrection&&) = default;
+  ~BoundaryCorrection() override = default;
+
+  /// \cond
+  WRAPPED_PUPable_abstract(BoundaryCorrection);  // NOLINT
+  /// \endcond
+
+  using creatable_classes = tmpl::list<Rusanov>;
+
+  virtual std::unique_ptr<BoundaryCorrection> get_clone() const noexcept = 0;
+};
+}  // namespace grmhd::ValenciaDivClean::BoundaryCorrections

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/CMakeLists.txt
@@ -1,0 +1,20 @@
+#
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_sources(
+  ValenciaDivClean
+  PRIVATE
+  RegisterDerived.cpp
+  Rusanov.cpp
+  )
+
+spectre_target_headers(
+  ValenciaDivClean
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  BoundaryCorrection.hpp
+  Factory.hpp
+  RegisterDerived.hpp
+  Rusanov.hpp
+  )

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Factory.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Factory.hpp
@@ -1,0 +1,7 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/BoundaryCorrection.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Rusanov.hpp"

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/RegisterDerived.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/RegisterDerived.cpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Factory.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+
+namespace grmhd::ValenciaDivClean::BoundaryCorrections {
+void register_derived_with_charm() noexcept {
+  Parallel::register_derived_classes_with_charm<BoundaryCorrection>();
+}
+}  // namespace grmhd::ValenciaDivClean::BoundaryCorrections

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/RegisterDerived.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/RegisterDerived.hpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace grmhd::ValenciaDivClean::BoundaryCorrections {
+void register_derived_with_charm() noexcept;
+}  // namespace grmhd::ValenciaDivClean::BoundaryCorrections

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Rusanov.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Rusanov.cpp
@@ -1,0 +1,204 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Rusanov.hpp"
+
+#include <memory>
+#include <optional>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+namespace grmhd::ValenciaDivClean::BoundaryCorrections {
+Rusanov::Rusanov(CkMigrateMessage* /*unused*/) noexcept {}
+
+std::unique_ptr<BoundaryCorrection> Rusanov::get_clone() const noexcept {
+  return std::make_unique<Rusanov>(*this);
+}
+
+void Rusanov::pup(PUP::er& p) { BoundaryCorrection::pup(p); }
+
+double Rusanov::dg_package_data(
+    const gsl::not_null<Scalar<DataVector>*> packaged_tilde_d,
+    const gsl::not_null<Scalar<DataVector>*> packaged_tilde_tau,
+    const gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*>
+        packaged_tilde_s,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        packaged_tilde_b,
+    const gsl::not_null<Scalar<DataVector>*> packaged_tilde_phi,
+    const gsl::not_null<Scalar<DataVector>*> packaged_normal_dot_flux_tilde_d,
+    const gsl::not_null<Scalar<DataVector>*> packaged_normal_dot_flux_tilde_tau,
+    const gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*>
+        packaged_normal_dot_flux_tilde_s,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        packaged_normal_dot_flux_tilde_b,
+    const gsl::not_null<Scalar<DataVector>*> packaged_normal_dot_flux_tilde_phi,
+    const gsl::not_null<Scalar<DataVector>*> packaged_abs_char_speed,
+
+    const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
+    const Scalar<DataVector>& tilde_phi,
+
+    const tnsr::I<DataVector, 3, Frame::Inertial>& flux_tilde_d,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& flux_tilde_tau,
+    const tnsr::Ij<DataVector, 3, Frame::Inertial>& flux_tilde_s,
+    const tnsr::IJ<DataVector, 3, Frame::Inertial>& flux_tilde_b,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& flux_tilde_phi,
+
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
+
+    const tnsr::i<DataVector, 3, Frame::Inertial>& normal_covector,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& /*normal_vector*/,
+    const std::optional<tnsr::I<DataVector, 3, Frame::Inertial>>&
+    /*mesh_velocity*/,
+    const std::optional<Scalar<DataVector>>&
+        normal_dot_mesh_velocity) noexcept {
+  {
+    // Compute max abs char speed
+    Scalar<DataVector>& shift_dot_normal = *packaged_tilde_d;
+    dot_product(make_not_null(&shift_dot_normal), shift, normal_covector);
+    if (normal_dot_mesh_velocity.has_value()) {
+      get(*packaged_abs_char_speed) =
+          max(abs(-get(lapse) - get(shift_dot_normal) -
+                  get(*normal_dot_mesh_velocity)),
+              abs(get(lapse) - get(shift_dot_normal) -
+                  get(*normal_dot_mesh_velocity)));
+    } else {
+      get(*packaged_abs_char_speed) =
+          max(abs(-get(lapse) - get(shift_dot_normal)),
+              abs(get(lapse) - get(shift_dot_normal)));
+    }
+  }
+
+  *packaged_tilde_d = tilde_d;
+  *packaged_tilde_tau = tilde_tau;
+  *packaged_tilde_s = tilde_s;
+  *packaged_tilde_b = tilde_b;
+  *packaged_tilde_phi = tilde_phi;
+
+  dot_product(packaged_normal_dot_flux_tilde_d, flux_tilde_d, normal_covector);
+  dot_product(packaged_normal_dot_flux_tilde_tau, flux_tilde_tau,
+              normal_covector);
+  dot_product(packaged_normal_dot_flux_tilde_phi, flux_tilde_phi,
+              normal_covector);
+  for (size_t i = 0; i < 3; ++i) {
+    packaged_normal_dot_flux_tilde_s->get(i) =
+        get<0>(normal_covector) * flux_tilde_s.get(0, i);
+    packaged_normal_dot_flux_tilde_b->get(i) =
+        get<0>(normal_covector) * flux_tilde_b.get(0, i);
+    for (size_t j = 1; j < 3; ++j) {
+      packaged_normal_dot_flux_tilde_s->get(i) +=
+          normal_covector.get(j) * flux_tilde_s.get(j, i);
+      packaged_normal_dot_flux_tilde_b->get(i) +=
+          normal_covector.get(j) * flux_tilde_b.get(j, i);
+    }
+  }
+
+  return max(get(*packaged_abs_char_speed));
+}
+
+void Rusanov::dg_boundary_terms(
+    const gsl::not_null<Scalar<DataVector>*> boundary_correction_tilde_d,
+    const gsl::not_null<Scalar<DataVector>*> boundary_correction_tilde_tau,
+    const gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*>
+        boundary_correction_tilde_s,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        boundary_correction_tilde_b,
+    const gsl::not_null<Scalar<DataVector>*> boundary_correction_tilde_phi,
+    const Scalar<DataVector>& tilde_d_int,
+    const Scalar<DataVector>& tilde_tau_int,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s_int,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b_int,
+    const Scalar<DataVector>& tilde_phi_int,
+    const Scalar<DataVector>& normal_dot_flux_tilde_d_int,
+    const Scalar<DataVector>& normal_dot_flux_tilde_tau_int,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& normal_dot_flux_tilde_s_int,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& normal_dot_flux_tilde_b_int,
+    const Scalar<DataVector>& normal_dot_flux_tilde_phi_int,
+    const Scalar<DataVector>& abs_char_speed_int,
+    const Scalar<DataVector>& tilde_d_ext,
+    const Scalar<DataVector>& tilde_tau_ext,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s_ext,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b_ext,
+    const Scalar<DataVector>& tilde_phi_ext,
+    const Scalar<DataVector>& normal_dot_flux_tilde_d_ext,
+    const Scalar<DataVector>& normal_dot_flux_tilde_tau_ext,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& normal_dot_flux_tilde_s_ext,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& normal_dot_flux_tilde_b_ext,
+    const Scalar<DataVector>& normal_dot_flux_tilde_phi_ext,
+    const Scalar<DataVector>& abs_char_speed_ext,
+    const dg::Formulation dg_formulation) noexcept {
+  if (dg_formulation == dg::Formulation::WeakInertial) {
+    get(*boundary_correction_tilde_d) =
+        0.5 * (get(normal_dot_flux_tilde_d_int) -
+               get(normal_dot_flux_tilde_d_ext)) -
+        0.5 * max(get(abs_char_speed_int), get(abs_char_speed_ext)) *
+            (get(tilde_d_ext) - get(tilde_d_int));
+    get(*boundary_correction_tilde_tau) =
+        0.5 * (get(normal_dot_flux_tilde_tau_int) -
+               get(normal_dot_flux_tilde_tau_ext)) -
+        0.5 * max(get(abs_char_speed_int), get(abs_char_speed_ext)) *
+            (get(tilde_tau_ext) - get(tilde_tau_int));
+    get(*boundary_correction_tilde_phi) =
+        0.5 * (get(normal_dot_flux_tilde_phi_int) -
+               get(normal_dot_flux_tilde_phi_ext)) -
+        0.5 * max(get(abs_char_speed_int), get(abs_char_speed_ext)) *
+            (get(tilde_phi_ext) - get(tilde_phi_int));
+
+    for (size_t i = 0; i < 3; ++i) {
+      boundary_correction_tilde_s->get(i) =
+          0.5 * (normal_dot_flux_tilde_s_int.get(i) -
+                 normal_dot_flux_tilde_s_ext.get(i)) -
+          0.5 * max(get(abs_char_speed_int), get(abs_char_speed_ext)) *
+              (tilde_s_ext.get(i) - tilde_s_int.get(i));
+      boundary_correction_tilde_b->get(i) =
+          0.5 * (normal_dot_flux_tilde_b_int.get(i) -
+                 normal_dot_flux_tilde_b_ext.get(i)) -
+          0.5 * max(get(abs_char_speed_int), get(abs_char_speed_ext)) *
+              (tilde_b_ext.get(i) - tilde_b_int.get(i));
+    }
+  } else {
+    get(*boundary_correction_tilde_d) =
+        -0.5 * (get(normal_dot_flux_tilde_d_int) +
+                get(normal_dot_flux_tilde_d_ext)) -
+        0.5 * max(get(abs_char_speed_int), get(abs_char_speed_ext)) *
+            (get(tilde_d_ext) - get(tilde_d_int));
+    get(*boundary_correction_tilde_tau) =
+        -0.5 * (get(normal_dot_flux_tilde_tau_int) +
+                get(normal_dot_flux_tilde_tau_ext)) -
+        0.5 * max(get(abs_char_speed_int), get(abs_char_speed_ext)) *
+            (get(tilde_tau_ext) - get(tilde_tau_int));
+    get(*boundary_correction_tilde_phi) =
+        -0.5 * (get(normal_dot_flux_tilde_phi_int) +
+                get(normal_dot_flux_tilde_phi_ext)) -
+        0.5 * max(get(abs_char_speed_int), get(abs_char_speed_ext)) *
+            (get(tilde_phi_ext) - get(tilde_phi_int));
+
+    for (size_t i = 0; i < 3; ++i) {
+      boundary_correction_tilde_s->get(i) =
+          -0.5 * (normal_dot_flux_tilde_s_int.get(i) +
+                  normal_dot_flux_tilde_s_ext.get(i)) -
+          0.5 * max(get(abs_char_speed_int), get(abs_char_speed_ext)) *
+              (tilde_s_ext.get(i) - tilde_s_int.get(i));
+      boundary_correction_tilde_b->get(i) =
+          -0.5 * (normal_dot_flux_tilde_b_int.get(i) +
+                  normal_dot_flux_tilde_b_ext.get(i)) -
+          0.5 * max(get(abs_char_speed_int), get(abs_char_speed_ext)) *
+              (tilde_b_ext.get(i) - tilde_b_int.get(i));
+    }
+  }
+}
+
+// NOLINTNEXTLINE
+PUP::able::PUP_ID Rusanov::my_PUP_ID = 0;
+}  // namespace grmhd::ValenciaDivClean::BoundaryCorrections
+/// \endcond

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Rusanov.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Rusanov.hpp
@@ -1,0 +1,183 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/BoundaryCorrection.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace grmhd::ValenciaDivClean::BoundaryCorrections {
+/*!
+ * \brief A Rusanov/local Lax-Friedrichs Riemann solver
+ *
+ * Let \f$U\f$ be the state vector of evolved variables, \f$F^i\f$ the
+ * corresponding fluxes, and \f$n_i\f$ be the outward directed unit normal to
+ * the interface. Denoting \f$F := n_i F^i\f$, the %Rusanov boundary correction
+ * is
+ *
+ * \f{align*}
+ * G_\text{Rusanov} = \frac{F_\text{int} - F_\text{ext}}{2} -
+ * \frac{\text{max}\left(\{|\lambda_\text{int}|\},
+ * \{|\lambda_\text{ext}|\}\right)}{2} \left(U_\text{ext} - U_\text{int}\right),
+ * \f}
+ *
+ * where "int" and "ext" stand for interior and exterior, and
+ * \f$\{|\lambda|\}\f$ is the set of characteristic/signal speeds. The minus
+ * sign in front of the \f$F_{\text{ext}}\f$ is necessary because the outward
+ * directed normal of the neighboring element has the opposite sign, i.e.
+ * \f$n_i^{\text{ext}}=-n_i^{\text{int}}\f$. The characteristic/signal speeds
+ * are given in the documentation for
+ * grmhd::ValenciaDivClean::characteristic_speeds(). Since the fluid is
+ * travelling slower than the speed of light, the speeds we are interested in
+ * are
+ *
+ * \f{align*}{
+ *   \lambda_{\pm}&=\pm\alpha-\beta^i n_i,
+ * \f}
+ *
+ * which correspond to the divergence cleaning field.
+ *
+ * \note
+ * - In the strong form the `dg_boundary_terms` function returns
+ * \f$G - F_\text{int}\f$
+ * - It may be possible to use the slower speeds for the magnetic field and
+ * fluid part of the system in order to make the flux less dissipative for
+ * those variables.
+ */
+class Rusanov final : public BoundaryCorrection {
+ private:
+  struct AbsCharSpeed : db::SimpleTag {
+    using type = Scalar<DataVector>;
+  };
+
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help = {
+      "Computes the Rusanov or local Lax-Friedrichs boundary correction term "
+      "for the GRMHD system."};
+
+  Rusanov() = default;
+  Rusanov(const Rusanov&) = default;
+  Rusanov& operator=(const Rusanov&) = default;
+  Rusanov(Rusanov&&) = default;
+  Rusanov& operator=(Rusanov&&) = default;
+  ~Rusanov() override = default;
+
+  /// \cond
+  explicit Rusanov(CkMigrateMessage* /*unused*/) noexcept;
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Rusanov);  // NOLINT
+  /// \endcond
+  void pup(PUP::er& p) override;  // NOLINT
+
+  std::unique_ptr<BoundaryCorrection> get_clone() const noexcept override;
+
+  using dg_package_field_tags =
+      tmpl::list<Tags::TildeD, Tags::TildeTau, Tags::TildeS<Frame::Inertial>,
+                 Tags::TildeB<Frame::Inertial>, Tags::TildePhi,
+                 ::Tags::NormalDotFlux<Tags::TildeD>,
+                 ::Tags::NormalDotFlux<Tags::TildeTau>,
+                 ::Tags::NormalDotFlux<Tags::TildeS<Frame::Inertial>>,
+                 ::Tags::NormalDotFlux<Tags::TildeB<Frame::Inertial>>,
+                 ::Tags::NormalDotFlux<Tags::TildePhi>, AbsCharSpeed>;
+  using dg_package_data_temporary_tags =
+      tmpl::list<gr::Tags::Lapse<DataVector>,
+                 gr::Tags::Shift<3, Frame::Inertial, DataVector>>;
+  using dg_package_data_primitive_tags = tmpl::list<>;
+  using dg_package_data_volume_tags = tmpl::list<>;
+
+  static double dg_package_data(
+      gsl::not_null<Scalar<DataVector>*> packaged_tilde_d,
+      gsl::not_null<Scalar<DataVector>*> packaged_tilde_tau,
+      gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*> packaged_tilde_s,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> packaged_tilde_b,
+      gsl::not_null<Scalar<DataVector>*> packaged_tilde_phi,
+      gsl::not_null<Scalar<DataVector>*> packaged_normal_dot_flux_tilde_d,
+      gsl::not_null<Scalar<DataVector>*> packaged_normal_dot_flux_tilde_tau,
+      gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*>
+          packaged_normal_dot_flux_tilde_s,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+          packaged_normal_dot_flux_tilde_b,
+      gsl::not_null<Scalar<DataVector>*> packaged_normal_dot_flux_tilde_phi,
+      gsl::not_null<Scalar<DataVector>*> packaged_abs_char_speed,
+
+      const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
+      const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
+      const Scalar<DataVector>& tilde_phi,
+
+      const tnsr::I<DataVector, 3, Frame::Inertial>& flux_tilde_d,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& flux_tilde_tau,
+      const tnsr::Ij<DataVector, 3, Frame::Inertial>& flux_tilde_s,
+      const tnsr::IJ<DataVector, 3, Frame::Inertial>& flux_tilde_b,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& flux_tilde_phi,
+
+      const Scalar<DataVector>& lapse,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
+
+      const tnsr::i<DataVector, 3, Frame::Inertial>& normal_covector,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& normal_vector,
+      const std::optional<tnsr::I<DataVector, 3, Frame::Inertial>>&
+      /*mesh_velocity*/,
+      const std::optional<Scalar<DataVector>>&
+          normal_dot_mesh_velocity) noexcept;
+
+  static void dg_boundary_terms(
+      gsl::not_null<Scalar<DataVector>*> boundary_correction_tilde_d,
+      gsl::not_null<Scalar<DataVector>*> boundary_correction_tilde_tau,
+      gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*>
+          boundary_correction_tilde_s,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+          boundary_correction_tilde_b,
+      gsl::not_null<Scalar<DataVector>*> boundary_correction_tilde_phi,
+      const Scalar<DataVector>& tilde_d_int,
+      const Scalar<DataVector>& tilde_tau_int,
+      const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s_int,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b_int,
+      const Scalar<DataVector>& tilde_phi_int,
+      const Scalar<DataVector>& normal_dot_flux_tilde_d_int,
+      const Scalar<DataVector>& normal_dot_flux_tilde_tau_int,
+      const tnsr::i<DataVector, 3, Frame::Inertial>&
+          normal_dot_flux_tilde_s_int,
+      const tnsr::I<DataVector, 3, Frame::Inertial>&
+          normal_dot_flux_tilde_b_int,
+      const Scalar<DataVector>& normal_dot_flux_tilde_phi_int,
+      const Scalar<DataVector>& abs_char_speed_int,
+      const Scalar<DataVector>& tilde_d_ext,
+      const Scalar<DataVector>& tilde_tau_ext,
+      const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s_ext,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b_ext,
+      const Scalar<DataVector>& tilde_phi_ext,
+      const Scalar<DataVector>& normal_dot_flux_tilde_d_ext,
+      const Scalar<DataVector>& normal_dot_flux_tilde_tau_ext,
+      const tnsr::i<DataVector, 3, Frame::Inertial>&
+          normal_dot_flux_tilde_s_ext,
+      const tnsr::I<DataVector, 3, Frame::Inertial>&
+          normal_dot_flux_tilde_b_ext,
+      const Scalar<DataVector>& normal_dot_flux_tilde_phi_ext,
+      const Scalar<DataVector>& abs_char_speed_ext,
+      dg::Formulation dg_formulation) noexcept;
+};
+}  // namespace grmhd::ValenciaDivClean::BoundaryCorrections

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -52,3 +52,5 @@ target_link_libraries(
   Valencia
   VariableFixing
   )
+
+add_subdirectory(BoundaryCorrections)

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp
@@ -74,6 +74,9 @@ struct System {
   template <typename Tag>
   using magnitude_tag = ::Tags::NonEuclideanMagnitude<
       Tag, gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>>;
+
+  using inverse_spatial_metric_tag =
+      gr::Tags::InverseSpatialMetric<volume_dim, Frame::Inertial, DataVector>;
 };
 }  // namespace ValenciaDivClean
 }  // namespace grmhd

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/TimeDerivativeTerms.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/TimeDerivativeTerms.cpp
@@ -121,6 +121,11 @@ void TimeDerivativeTerms::apply(
         trace_spatial_christoffel_second,
     const gsl::not_null<Scalar<DataVector>*> h_rho_w_squared_plus_b_squared,
 
+    const gsl::not_null<Scalar<DataVector>*> temp_lapse,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> temp_shift,
+    const gsl::not_null<tnsr::II<DataVector, 3, Frame::Inertial>*>
+        temp_inverse_spatial_metric,
+
     const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
     const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
@@ -141,6 +146,12 @@ void TimeDerivativeTerms::apply(
     const Scalar<DataVector>& specific_enthalpy,
     const tnsr::ii<DataVector, 3, Frame::Inertial>& extrinsic_curvature,
     const double constraint_damping_parameter) noexcept {
+  // Note that if the temp_lapse and lapse arguments point to the same object
+  // then the copy is elided internally.
+  *temp_lapse = lapse;
+  *temp_shift = shift;
+  *temp_inverse_spatial_metric = inv_spatial_metric;
+
   raise_or_lower_index(spatial_velocity_one_form, spatial_velocity,
                        spatial_metric);
   raise_or_lower_index(magnetic_field_one_form, magnetic_field, spatial_metric);

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/TimeDerivativeTerms.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/TimeDerivativeTerms.hpp
@@ -71,7 +71,11 @@ struct TimeDerivativeTerms {
       gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial, DataVector>,
       gr::Tags::TraceSpatialChristoffelSecondKind<3, Frame::Inertial,
                                                   DataVector>,
-      EnthalpyTimesDensityWSquaredPlusBSquared>;
+      EnthalpyTimesDensityWSquaredPlusBSquared,
+
+      // Need lapse, shift, and inverse spatial metric to be projected to the
+      // boundary for Riemann solvers.
+      gr::Tags::Lapse<>, gr::Tags::Shift<3>, gr::Tags::InverseSpatialMetric<3>>;
   using argument_tags = tmpl::list<
       grmhd::ValenciaDivClean::Tags::TildeD,
       grmhd::ValenciaDivClean::Tags::TildeTau,
@@ -133,6 +137,11 @@ struct TimeDerivativeTerms {
       gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
           trace_spatial_christoffel_second,
       gsl::not_null<Scalar<DataVector>*> h_rho_w_squared_plus_b_squared,
+
+      gsl::not_null<Scalar<DataVector>*> temp_lapse,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> temp_shift,
+      gsl::not_null<tnsr::II<DataVector, 3, Frame::Inertial>*>
+          temp_inverse_spatial_metric,
 
       const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
       const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Rusanov.py
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Rusanov.py
@@ -1,0 +1,211 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def dg_package_data_tilde_d(tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi,
+                            flux_tilde_d, flux_tilde_tau, flux_tilde_s,
+                            flux_tilde_b, flux_tilde_phi, lapse, shift,
+                            normal_covector, normal_vector, mesh_velocity,
+                            normal_dot_mesh_velocity):
+    return tilde_d
+
+
+def dg_package_data_tilde_tau(tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi,
+                              flux_tilde_d, flux_tilde_tau, flux_tilde_s,
+                              flux_tilde_b, flux_tilde_phi, lapse, shift,
+                              normal_covector, normal_vector, mesh_velocity,
+                              normal_dot_mesh_velocity):
+    return tilde_tau
+
+
+def dg_package_data_tilde_s(tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi,
+                            flux_tilde_d, flux_tilde_tau, flux_tilde_s,
+                            flux_tilde_b, flux_tilde_phi, lapse, shift,
+                            normal_covector, normal_vector, mesh_velocity,
+                            normal_dot_mesh_velocity):
+    return tilde_s
+
+
+def dg_package_data_tilde_b(tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi,
+                            flux_tilde_d, flux_tilde_tau, flux_tilde_s,
+                            flux_tilde_b, flux_tilde_phi, lapse, shift,
+                            normal_covector, normal_vector, mesh_velocity,
+                            normal_dot_mesh_velocity):
+    return tilde_b
+
+
+def dg_package_data_tilde_phi(tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi,
+                              flux_tilde_d, flux_tilde_tau, flux_tilde_s,
+                              flux_tilde_b, flux_tilde_phi, lapse, shift,
+                              normal_covector, normal_vector, mesh_velocity,
+                              normal_dot_mesh_velocity):
+    return tilde_phi
+
+
+def dg_package_data_normal_dot_flux_tilde_d(
+    tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi, flux_tilde_d,
+    flux_tilde_tau, flux_tilde_s, flux_tilde_b, flux_tilde_phi, lapse, shift,
+    normal_covector, normal_vector, mesh_velocity, normal_dot_mesh_velocity):
+    return np.dot(flux_tilde_d, normal_covector)
+
+
+def dg_package_data_normal_dot_flux_tilde_tau(
+    tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi, flux_tilde_d,
+    flux_tilde_tau, flux_tilde_s, flux_tilde_b, flux_tilde_phi, lapse, shift,
+    normal_covector, normal_vector, mesh_velocity, normal_dot_mesh_velocity):
+    return np.dot(flux_tilde_tau, normal_covector)
+
+
+def dg_package_data_normal_dot_flux_tilde_s(
+    tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi, flux_tilde_d,
+    flux_tilde_tau, flux_tilde_s, flux_tilde_b, flux_tilde_phi, lapse, shift,
+    normal_covector, normal_vector, mesh_velocity, normal_dot_mesh_velocity):
+    return np.einsum("ij,i->j", flux_tilde_s, normal_covector)
+
+
+def dg_package_data_normal_dot_flux_tilde_b(
+    tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi, flux_tilde_d,
+    flux_tilde_tau, flux_tilde_s, flux_tilde_b, flux_tilde_phi, lapse, shift,
+    normal_covector, normal_vector, mesh_velocity, normal_dot_mesh_velocity):
+    return np.einsum("ij,i->j", flux_tilde_b, normal_covector)
+
+
+def dg_package_data_normal_dot_flux_tilde_phi(
+    tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi, flux_tilde_d,
+    flux_tilde_tau, flux_tilde_s, flux_tilde_b, flux_tilde_phi, lapse, shift,
+    normal_covector, normal_vector, mesh_velocity, normal_dot_mesh_velocity):
+    return np.dot(flux_tilde_phi, normal_covector)
+
+
+def dg_package_data_abs_char_speed(tilde_d, tilde_tau, tilde_s, tilde_b,
+                                   tilde_phi, flux_tilde_d, flux_tilde_tau,
+                                   flux_tilde_s, flux_tilde_b, flux_tilde_phi,
+                                   lapse, shift, normal_covector,
+                                   normal_vector, mesh_velocity,
+                                   normal_dot_mesh_velocity):
+    if normal_dot_mesh_velocity is None:
+        return np.maximum(np.abs(lapse - np.dot(shift, normal_covector)),
+                          np.abs(-lapse - np.dot(shift, normal_covector)))
+    else:
+        return np.maximum(
+            np.abs(lapse - np.dot(shift, normal_covector) -
+                   normal_dot_mesh_velocity),
+            np.abs(-lapse - np.dot(shift, normal_covector) -
+                   normal_dot_mesh_velocity))
+
+
+def dg_boundary_terms_tilde_d(
+    interior_tilde_d, interior_tilde_tau, interior_tilde_s, interior_tilde_b,
+    interior_tilde_phi, interior_normal_dot_flux_tilde_d,
+    interior_normal_dot_flux_tilde_tau, interior_normal_dot_flux_tilde_s,
+    interior_normal_dot_flux_tilde_b, interior_normal_dot_flux_tilde_phi,
+    interior_abs_char_speed, exterior_tilde_d, exterior_tilde_tau,
+    exterior_tilde_s, exterior_tilde_b, exterior_tilde_phi,
+    exterior_normal_dot_flux_tilde_d, exterior_normal_dot_flux_tilde_tau,
+    exterior_normal_dot_flux_tilde_s, exterior_normal_dot_flux_tilde_b,
+    exterior_normal_dot_flux_tilde_phi, exterior_abs_char_speed,
+    use_strong_form):
+    if use_strong_form:
+        return -0.5 * (interior_normal_dot_flux_tilde_d +
+                       exterior_normal_dot_flux_tilde_d) - 0.5 * np.maximum(
+                           interior_abs_char_speed, exterior_abs_char_speed
+                       ) * (exterior_tilde_d - interior_tilde_d)
+    else:
+        return 0.5 * (interior_normal_dot_flux_tilde_d -
+                      exterior_normal_dot_flux_tilde_d) - 0.5 * np.maximum(
+                          interior_abs_char_speed, exterior_abs_char_speed) * (
+                              exterior_tilde_d - interior_tilde_d)
+
+
+def dg_boundary_terms_tilde_tau(
+    interior_tilde_d, interior_tilde_tau, interior_tilde_s, interior_tilde_b,
+    interior_tilde_phi, interior_normal_dot_flux_tilde_d,
+    interior_normal_dot_flux_tilde_tau, interior_normal_dot_flux_tilde_s,
+    interior_normal_dot_flux_tilde_b, interior_normal_dot_flux_tilde_phi,
+    interior_abs_char_speed, exterior_tilde_d, exterior_tilde_tau,
+    exterior_tilde_s, exterior_tilde_b, exterior_tilde_phi,
+    exterior_normal_dot_flux_tilde_d, exterior_normal_dot_flux_tilde_tau,
+    exterior_normal_dot_flux_tilde_s, exterior_normal_dot_flux_tilde_b,
+    exterior_normal_dot_flux_tilde_phi, exterior_abs_char_speed,
+    use_strong_form):
+    if use_strong_form:
+        return -0.5 * (interior_normal_dot_flux_tilde_tau +
+                       exterior_normal_dot_flux_tilde_tau) - 0.5 * np.maximum(
+                           interior_abs_char_speed, exterior_abs_char_speed
+                       ) * (exterior_tilde_tau - interior_tilde_tau)
+    else:
+        return 0.5 * (interior_normal_dot_flux_tilde_tau -
+                      exterior_normal_dot_flux_tilde_tau) - 0.5 * np.maximum(
+                          interior_abs_char_speed, exterior_abs_char_speed) * (
+                              exterior_tilde_tau - interior_tilde_tau)
+
+
+def dg_boundary_terms_tilde_s(
+    interior_tilde_d, interior_tilde_tau, interior_tilde_s, interior_tilde_b,
+    interior_tilde_phi, interior_normal_dot_flux_tilde_d,
+    interior_normal_dot_flux_tilde_tau, interior_normal_dot_flux_tilde_s,
+    interior_normal_dot_flux_tilde_b, interior_normal_dot_flux_tilde_phi,
+    interior_abs_char_speed, exterior_tilde_d, exterior_tilde_tau,
+    exterior_tilde_s, exterior_tilde_b, exterior_tilde_phi,
+    exterior_normal_dot_flux_tilde_d, exterior_normal_dot_flux_tilde_tau,
+    exterior_normal_dot_flux_tilde_s, exterior_normal_dot_flux_tilde_b,
+    exterior_normal_dot_flux_tilde_phi, exterior_abs_char_speed,
+    use_strong_form):
+    if use_strong_form:
+        return -0.5 * (interior_normal_dot_flux_tilde_s +
+                       exterior_normal_dot_flux_tilde_s) - 0.5 * np.maximum(
+                           interior_abs_char_speed, exterior_abs_char_speed
+                       ) * (exterior_tilde_s - interior_tilde_s)
+    else:
+        return 0.5 * (interior_normal_dot_flux_tilde_s -
+                      exterior_normal_dot_flux_tilde_s) - 0.5 * np.maximum(
+                          interior_abs_char_speed, exterior_abs_char_speed) * (
+                              exterior_tilde_s - interior_tilde_s)
+
+
+def dg_boundary_terms_tilde_b(
+    interior_tilde_d, interior_tilde_tau, interior_tilde_s, interior_tilde_b,
+    interior_tilde_phi, interior_normal_dot_flux_tilde_d,
+    interior_normal_dot_flux_tilde_tau, interior_normal_dot_flux_tilde_s,
+    interior_normal_dot_flux_tilde_b, interior_normal_dot_flux_tilde_phi,
+    interior_abs_char_speed, exterior_tilde_d, exterior_tilde_tau,
+    exterior_tilde_s, exterior_tilde_b, exterior_tilde_phi,
+    exterior_normal_dot_flux_tilde_d, exterior_normal_dot_flux_tilde_tau,
+    exterior_normal_dot_flux_tilde_s, exterior_normal_dot_flux_tilde_b,
+    exterior_normal_dot_flux_tilde_phi, exterior_abs_char_speed,
+    use_strong_form):
+    if use_strong_form:
+        return -0.5 * (interior_normal_dot_flux_tilde_b +
+                       exterior_normal_dot_flux_tilde_b) - 0.5 * np.maximum(
+                           interior_abs_char_speed, exterior_abs_char_speed
+                       ) * (exterior_tilde_b - interior_tilde_b)
+    else:
+        return 0.5 * (interior_normal_dot_flux_tilde_b -
+                      exterior_normal_dot_flux_tilde_b) - 0.5 * np.maximum(
+                          interior_abs_char_speed, exterior_abs_char_speed) * (
+                              exterior_tilde_b - interior_tilde_b)
+
+
+def dg_boundary_terms_tilde_phi(
+    interior_tilde_d, interior_tilde_tau, interior_tilde_s, interior_tilde_b,
+    interior_tilde_phi, interior_normal_dot_flux_tilde_d,
+    interior_normal_dot_flux_tilde_tau, interior_normal_dot_flux_tilde_s,
+    interior_normal_dot_flux_tilde_b, interior_normal_dot_flux_tilde_phi,
+    interior_abs_char_speed, exterior_tilde_d, exterior_tilde_tau,
+    exterior_tilde_s, exterior_tilde_b, exterior_tilde_phi,
+    exterior_normal_dot_flux_tilde_d, exterior_normal_dot_flux_tilde_tau,
+    exterior_normal_dot_flux_tilde_s, exterior_normal_dot_flux_tilde_b,
+    exterior_normal_dot_flux_tilde_phi, exterior_abs_char_speed,
+    use_strong_form):
+    if use_strong_form:
+        return -0.5 * (interior_normal_dot_flux_tilde_phi +
+                       exterior_normal_dot_flux_tilde_phi) - 0.5 * np.maximum(
+                           interior_abs_char_speed, exterior_abs_char_speed
+                       ) * (exterior_tilde_phi - interior_tilde_phi)
+    else:
+        return 0.5 * (interior_normal_dot_flux_tilde_phi -
+                      exterior_normal_dot_flux_tilde_phi) - 0.5 * np.maximum(
+                          interior_abs_char_speed, exterior_abs_char_speed) * (
+                              exterior_tilde_phi - interior_tilde_phi)

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Test_Rusanov.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Test_Rusanov.cpp
@@ -1,0 +1,72 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <string>
+
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Factory.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Rusanov.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.Rusanov", "[Unit][GrMhd]") {
+  PUPable_reg(grmhd::ValenciaDivClean::BoundaryCorrections::Rusanov);
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections"};
+  // need some equation of state. Rusanov doesn't care about it since the max
+  // speed is set by the speed of light.
+  using system =
+      grmhd::ValenciaDivClean::System<EquationsOfState::IdealFluid<true>>;
+
+  TestHelpers::evolution::dg::test_boundary_correction_conservation<system>(
+      grmhd::ValenciaDivClean::BoundaryCorrections::Rusanov{},
+      Mesh<2>{5, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {});
+
+  TestHelpers::evolution::dg::test_boundary_correction_with_python<system>(
+      "Rusanov",
+      {{"dg_package_data_tilde_d", "dg_package_data_tilde_tau",
+        "dg_package_data_tilde_s", "dg_package_data_tilde_b",
+        "dg_package_data_tilde_phi", "dg_package_data_normal_dot_flux_tilde_d",
+        "dg_package_data_normal_dot_flux_tilde_tau",
+        "dg_package_data_normal_dot_flux_tilde_s",
+        "dg_package_data_normal_dot_flux_tilde_b",
+        "dg_package_data_normal_dot_flux_tilde_phi",
+        "dg_package_data_abs_char_speed"}},
+      {{"dg_boundary_terms_tilde_d", "dg_boundary_terms_tilde_tau",
+        "dg_boundary_terms_tilde_s", "dg_boundary_terms_tilde_b",
+        "dg_boundary_terms_tilde_phi"}},
+      grmhd::ValenciaDivClean::BoundaryCorrections::Rusanov{},
+      Mesh<2>{5, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {});
+
+  const auto rusanov = TestHelpers::test_factory_creation<
+      grmhd::ValenciaDivClean::BoundaryCorrections::BoundaryCorrection>(
+      "Rusanov:");
+
+  TestHelpers::evolution::dg::test_boundary_correction_with_python<system>(
+      "Rusanov",
+      {{"dg_package_data_tilde_d", "dg_package_data_tilde_tau",
+        "dg_package_data_tilde_s", "dg_package_data_tilde_b",
+        "dg_package_data_tilde_phi", "dg_package_data_normal_dot_flux_tilde_d",
+        "dg_package_data_normal_dot_flux_tilde_tau",
+        "dg_package_data_normal_dot_flux_tilde_s",
+        "dg_package_data_normal_dot_flux_tilde_b",
+        "dg_package_data_normal_dot_flux_tilde_phi",
+        "dg_package_data_abs_char_speed"}},
+      {{"dg_boundary_terms_tilde_d", "dg_boundary_terms_tilde_tau",
+        "dg_boundary_terms_tilde_s", "dg_boundary_terms_tilde_b",
+        "dg_boundary_terms_tilde_phi"}},
+      dynamic_cast<
+          const grmhd::ValenciaDivClean::BoundaryCorrections::Rusanov&>(
+          *rusanov),
+      Mesh<2>{5, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {});
+}

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_ValenciaDivClean")
 
 set(LIBRARY_SOURCES
+  BoundaryCorrections/Test_Rusanov.cpp
   Test_Characteristics.cpp
   Test_ConservativeFromPrimitive.cpp
   Test_FixConservatives.cpp

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_TimeDerivativeTerms.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_TimeDerivativeTerms.cpp
@@ -102,6 +102,10 @@ void forward_to_time_deriv(
       make_not_null(&get<typename grmhd::ValenciaDivClean::TimeDerivativeTerms::
                              EnthalpyTimesDensityWSquaredPlusBSquared>(temp)),
 
+      make_not_null(&get<gr::Tags::Lapse<>>(temp)),
+      make_not_null(&get<gr::Tags::Shift<3>>(temp)),
+      make_not_null(&get<gr::Tags::InverseSpatialMetric<3>>(temp)),
+
       tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi, lapse, shift,
       sqrt_det_spatial_metric, spatial_metric, inv_spatial_metric, d_lapse,
       d_shift, d_spatial_metric, pressure, spatial_velocity, lorentz_factor,
@@ -109,6 +113,10 @@ void forward_to_time_deriv(
 
       rest_mass_density, specific_enthalpy, extrinsic_curvature,
       constraint_damping_parameter);
+
+  CHECK(get<gr::Tags::Lapse<>>(temp) == lapse);
+  CHECK(get<gr::Tags::Shift<3>>(temp) == shift);
+  CHECK(get<gr::Tags::InverseSpatialMetric<3>>(temp) == inv_spatial_metric);
 }
 }  // namespace
 


### PR DESCRIPTION
## Proposed changes

- We need temporary tags to be able to project them to the interface, and we need lapse, shift for char speeds, and inverse spatial metric for normalizing the normal vectors
- Rusanov Riemann solver...

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
