### PR TITLE
Add Parallel::Callback for use in MutableGlobalCache.

### DIFF
--- a/src/Parallel/CMakeLists.txt
+++ b/src/Parallel/CMakeLists.txt
@@ -21,6 +21,7 @@ spectre_target_headers(
   Algorithm.hpp
   AlgorithmMetafunctions.hpp
   ArrayIndex.hpp
+  Callback.hpp
   CharmMain.tpp
   CharmPupable.hpp
   CharmRegistration.hpp

--- a/src/Parallel/Callback.hpp
+++ b/src/Parallel/Callback.hpp
@@ -1,0 +1,98 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines Parallel::Callback.
+
+#pragma once
+
+#include <pup.h>
+#include <tuple>
+#include <utility>
+
+#include "Parallel/CharmPupable.hpp"
+#include "Parallel/Invoke.hpp"
+
+namespace Parallel {
+/// An abstract base class, whose derived class holds a function that
+/// can be invoked at a later time.  The function is intended to be
+/// invoked only once.
+class Callback : public PUP::able {
+ public:
+  WRAPPED_PUPable_abstract(Callback);  // NOLINT
+  Callback() = default;
+  Callback(const Callback&) = default;
+  Callback& operator=(const Callback&) = default;
+  Callback(Callback&&) = default;
+  Callback& operator=(Callback&&) = default;
+  virtual ~Callback() = default;
+  virtual void invoke() noexcept = 0;
+};
+
+/// Wraps a call to a simple action and its arguments.
+/// Can be invoked only once.
+template <typename SimpleAction, typename Proxy, typename... Args>
+class SimpleActionCallback : public Callback {
+ public:
+  WRAPPED_PUPable_decl_template(SimpleActionCallback);  // NOLINT
+  SimpleActionCallback(Proxy proxy, Args&&... args)
+      : proxy_(proxy), args_(std::make_tuple<Args...>(args...)) {}
+  void invoke() noexcept override {
+    std::apply(
+        [this](auto&&... args) noexcept {
+          Parallel::simple_action<SimpleAction>(proxy_, args...);
+        },
+        std::move(args_));
+  }
+  void pup(PUP::er& p) noexcept override {
+    p | proxy_;
+    p | args_;
+  }
+
+ private:
+  Proxy proxy_;
+  std::tuple<Args...> args_;
+};
+
+/// Wraps a call to a simple action without arguments.
+template <typename SimpleAction, typename Proxy>
+class SimpleActionCallback<SimpleAction, Proxy> : public Callback {
+ public:
+  WRAPPED_PUPable_decl_template(SimpleActionCallback);  // NOLINT
+  SimpleActionCallback(Proxy proxy) : proxy_(proxy) {}
+  void invoke() noexcept override {
+    Parallel::simple_action<SimpleAction>(proxy_);
+  }
+
+  void pup(PUP::er& p) noexcept override { p | proxy_; }
+
+ private:
+  Proxy proxy_;
+};
+
+/// Wraps a call to perform_algorithm.
+template <typename Proxy>
+class PerformAlgorithmCallback : public Callback {
+ public:
+  WRAPPED_PUPable_decl_template(PerformAlgorithmCallback);  // NOLINT
+  PerformAlgorithmCallback(Proxy proxy) : proxy_(proxy) {}
+  void invoke() noexcept override { proxy_.perform_algorithm(); }
+  void pup(PUP::er& p) noexcept override { p | proxy_; }
+
+ private:
+  Proxy proxy_;
+};
+
+/// \cond
+template <typename Proxy>
+PUP::able::PUP_ID PerformAlgorithmCallback<Proxy>::my_PUP_ID = 0;  // NOLINT
+template <typename SimpleAction, typename Proxy, typename... Args>
+PUP::able::PUP_ID
+    SimpleActionCallback<SimpleAction, Proxy, Args...>::my_PUP_ID =
+        0;  // NOLINT
+template <typename SimpleAction, typename Proxy>
+PUP::able::PUP_ID SimpleActionCallback<SimpleAction, Proxy>::my_PUP_ID =
+    0;  // NOLINT
+/// \endcond
+
+}  // namespace Parallel

--- a/src/Parallel/ParallelComponentHelpers.hpp
+++ b/src/Parallel/ParallelComponentHelpers.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "Parallel/Callback.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -136,7 +137,8 @@ using get_mutable_global_cache_tags =
 template <typename Tag>
 struct MutableCacheTag {
   using tag  = Tag;
-  using type = std::tuple<typename Tag::type, std::vector<CkCallback>>;
+  using type =
+      std::tuple<typename Tag::type, std::vector<std::unique_ptr<Callback>>>;
 };
 
 template <typename Tag>


### PR DESCRIPTION
## Proposed changes

Currently MutableGlobalCache keeps a vector of charm `CkCallbacks`.
Now MutableGlobalCache keeps a vector of `Parallel::Callback`s , which are objects that wrap a function to be called.  In particular, they can wrap a `simple_action` or a call to `perform_algorithm`, which are the use cases that we expect in the use of MutableGlobalCache.

By eliminating the charm `CkCallback`, it is now possible to use the action testing framework to test Actions that change things in the MutableGlobalCache. (But so far no tests do so; that will be done in a future PR).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
The return type of `GlobalCache::mutable_cache_item_is_ready` is now `std::unique_ptr<Parallel::Callback>` instead of `std::optional<CkCallback>`.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
