### PR TITLE
Update Blaze version requirements to 3.7

### DIFF
--- a/cmake/SetupBlaze.cmake
+++ b/cmake/SetupBlaze.cmake
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-find_package(Blaze 3.5 REQUIRED)
+find_package(Blaze 3.7 REQUIRED)
 
 message(STATUS "Blaze incl: ${BLAZE_INCLUDE_DIR}")
 message(STATUS "Blaze vers: ${BLAZE_VERSION}")

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -25,7 +25,7 @@ environment differently, read on!
 * [Charm++](http://charm.cs.illinois.edu/) 6.10.2
 * [Git](https://git-scm.com/)
 * BLAS (e.g. [OpenBLAS](http://www.openblas.net))
-* [Blaze](https://bitbucket.org/blaze-lib/blaze/overview) v3.5
+* [Blaze](https://bitbucket.org/blaze-lib/blaze/overview) v3.7
 * [Boost](http://www.boost.org/) 1.60.0 or later
 * [Brigand](https://github.com/edouarda/brigand)
 * [Catch](https://github.com/philsquared/Catch) 2.8.0 or later
@@ -186,8 +186,8 @@ To use Singularity you must:
    source, and build directories, let's call it WORKDIR. The WORKDIR must be
    somewhere in your home directory. If this does not work for you, follow the
    Singularity instructions on setting up additional [bind
-   points](https://sylabs.io/guides/3.7/user-guide/bind_paths_and_mounts.html) 
-   (version 3.7. For other versions, see the [docs](https://sylabs.io/docs/)). 
+   points](https://sylabs.io/guides/3.7/user-guide/bind_paths_and_mounts.html)
+   (version 3.7. For other versions, see the [docs](https://sylabs.io/docs/)).
    Once inside the WORKDIR, clone SpECTRE into `WORKDIR/SPECTRE_ROOT`.
 3. Run `sudo singularity build spectre.img
    docker://sxscollaboration/spectrebuildenv:latest`.
@@ -268,7 +268,7 @@ To use modules with Spack, enable Spack's shell support by adding
 Once you have Spack installed and configured with OpenSSL and LMod, you can
 install the SpECTRE dependencies using
 ```
-spack install blaze@3.2
+spack install blaze@3.7
 spack install brigand@master
 spack install libsharp -openmp -mpi
 spack install catch2


### PR DESCRIPTION
## Proposed changes

Recent commits require blaze v3.7 to compile, but our docs and CMake only require v3.5. This commit *only* bumps the version in these two places, but leaves the hard work of cleaning up our blaze interface to PR #2574.

By keeping this PR simple, I hope it will be easy to rebase the more complicated changes in #2574 

Finally, I have no problem with skipping this PR in favor of merging #2574 directly. However, since current `develop` does not compile with its listed requirements, I felt this quick stopgap or "FYI" PR might be worth putting in.

### Upgrade instructions

Upgrade Blaze to v3.7

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments
