### PR TITLE
Add tag traits for a reference tag

### DIFF
--- a/src/DataStructures/DataBox/TagTraits.hpp
+++ b/src/DataStructures/DataBox/TagTraits.hpp
@@ -3,17 +3,14 @@
 
 #pragma once
 
-#include <cstddef>
 #include <type_traits>
-
-#include "Utilities/Requires.hpp"
-#include "Utilities/TypeTraits.hpp"
 
 /// \cond
 namespace db {
 struct SimpleTag;
 struct BaseTag;
 struct ComputeTag;
+struct ReferenceTag;
 }  // namespace db
 /// \endcond
 
@@ -34,17 +31,50 @@ constexpr bool is_compute_tag_v = is_compute_tag<Tag>::value;
 
 /*!
  * \ingroup DataBoxGroup
+ * \brief Check if `Tag` derives off of db::ReferenceTag.
+ *
+ * \see is_reference_tag_v ReferenceTag
+ */
+template <typename Tag>
+struct is_reference_tag : std::is_base_of<db::ReferenceTag, Tag> {};
+
+/// \ingroup DataBoxGroup
+/// \brief True if `Tag` derives from db::ReferenceTag.
+template <typename Tag>
+constexpr bool is_reference_tag_v = is_reference_tag<Tag>::value;
+
+/*!
+ * \ingroup DataBoxGroup
+ * \brief Check if `Tag` is a DataBox tag for an immutable item, i.e. a
+ * ComputeTag or ReferenceTag
+ *
+ * \see is_immutable_item_tag_v
+ */
+template <typename Tag>
+struct is_immutable_item_tag
+    : std::bool_constant<std::is_base_of_v<db::ReferenceTag, Tag> or
+                         std::is_base_of_v<db::ComputeTag, Tag>> {};
+
+/// \ingroup DataBoxGroup
+/// \brief True if `Tag` is a DataBox tag for an immutable item, i.e. a
+/// ComputeTag or ReferenceTag.
+template <typename Tag>
+constexpr bool is_immutable_item_tag_v = is_immutable_item_tag<Tag>::value;
+
+/*!
+ * \ingroup DataBoxGroup
  * \brief Check if `Tag` is a simple tag.
  *
  * \details This is done by deriving from std::true_type if `Tag` is derived
- * from db::SimpleTag, but not from db::ComputeTag.
+ * from db::SimpleTag, but not from db::ComputeTag or db::ReferenceTag.
  *
  * \see is_simple_tag_v SimpleTag
  */
 template <typename Tag>
 struct is_simple_tag
     : std::bool_constant<std::is_base_of_v<db::SimpleTag, Tag> and
-                         not is_compute_tag_v<Tag>> {};
+                         not is_compute_tag_v<Tag> and
+                         not is_reference_tag_v<Tag>> {};
 
 /// \ingroup DataBoxGroup
 /// \brief True if `Tag` is a simple tag.
@@ -58,9 +88,7 @@ constexpr bool is_simple_tag_v = is_simple_tag<Tag>::value;
  * \see is_non_base_tag_v BaseTag
  */
 template <typename Tag>
-struct is_non_base_tag
-    : std::bool_constant<std::is_base_of_v<db::ComputeTag, Tag> or
-                         std::is_base_of_v<db::SimpleTag, Tag>> {};
+struct is_non_base_tag : std::is_base_of<db::SimpleTag, Tag> {};
 
 /// \ingroup DataBoxGroup
 /// \brief True if `Tag` is not a base tag.
@@ -69,14 +97,13 @@ constexpr bool is_non_base_tag_v = is_non_base_tag<Tag>::value;
 
 /*!
  * \ingroup DataBoxGroup
- * \brief Check if `Tag` is a DataBox tag, i.e. a BaseTag, SimpleTag, or
- * ComputeTag
+ * \brief Check if `Tag` is a DataBox tag, i.e. a BaseTag, SimpleTag,
+ * ComputeTag, or ReferenceTag.
  *
  * \see is_tag_v
  */
 template <typename Tag>
-struct is_tag : std::bool_constant<std::is_base_of_v<db::ComputeTag, Tag> or
-                                   std::is_base_of_v<db::SimpleTag, Tag> or
+struct is_tag : std::bool_constant<std::is_base_of_v<db::SimpleTag, Tag> or
                                    std::is_base_of_v<db::BaseTag, Tag>> {};
 
 /// \ingroup DataBoxGroup
@@ -93,8 +120,7 @@ constexpr bool is_tag_v = is_tag<Tag>::value;
 template <typename Tag>
 struct is_base_tag
     : std::bool_constant<std::is_base_of_v<db::BaseTag, Tag> and
-                         not std::is_base_of_v<db::SimpleTag, Tag> and
-                         not is_compute_tag_v<Tag>> {};
+                         not std::is_base_of_v<db::SimpleTag, Tag>> {};
 
 /// \ingroup DataBoxGroup
 /// \brief True if `Tag` is a base tag.

--- a/src/Parallel/GlobalCache.hpp
+++ b/src/Parallel/GlobalCache.hpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataBox/TagTraits.hpp"
 #include "Parallel/CharmRegistration.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
@@ -660,6 +661,7 @@ struct GlobalCacheImpl : GlobalCache, db::SimpleTag {
 /// recommended way for compute tags to retrieve data out of the global cache.
 template <class CacheTag>
 struct FromGlobalCache : CacheTag, db::ComputeTag {
+  static_assert(db::is_simple_tag_v<CacheTag>);
   static std::string name() noexcept {
     return "FromGlobalCache(" + pretty_type::short_name<CacheTag>() + ")";
   }

--- a/tests/Unit/DataStructures/DataBox/Test_TagTraits.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_TagTraits.cpp
@@ -4,156 +4,95 @@
 #include "DataStructures/DataBox/TagTraits.hpp"
 #include "Helpers/DataStructures/DataBox/TestTags.hpp"
 
-static_assert(not db::is_compute_tag_v<TestHelpers::db::Tags::Bad>,
-              "Failed testing is_compute_tag");
-static_assert(not db::is_compute_tag_v<TestHelpers::db::Tags::Simple>,
-              "Failed testing is_compute_tag");
-static_assert(not db::is_compute_tag_v<TestHelpers::db::Tags::Base>,
-              "Failed testing is_compute_tag");
-static_assert(not db::is_compute_tag_v<TestHelpers::db::Tags::SimpleWithBase>,
-              "Failed testing is_compute_tag");
-static_assert(db::is_compute_tag_v<TestHelpers::db::Tags::SimpleCompute>,
-              "Failed testing is_compute_tag");
+static_assert(not db::is_compute_tag_v<TestHelpers::db::Tags::Bad>);
+static_assert(not db::is_compute_tag_v<TestHelpers::db::Tags::Simple>);
+static_assert(not db::is_compute_tag_v<TestHelpers::db::Tags::Base>);
+static_assert(not db::is_compute_tag_v<TestHelpers::db::Tags::SimpleWithBase>);
+static_assert(db::is_compute_tag_v<TestHelpers::db::Tags::SimpleCompute>);
 static_assert(
-    db::is_compute_tag_v<TestHelpers::db::Tags::SimpleWithBaseCompute>,
-    "Failed testing is_compute_tag");
-static_assert(not db::is_compute_tag_v<TestHelpers::db::Tags::SimpleReference>,
-              "Failed testing is_compute_tag");
+    db::is_compute_tag_v<TestHelpers::db::Tags::SimpleWithBaseCompute>);
+static_assert(not db::is_compute_tag_v<TestHelpers::db::Tags::SimpleReference>);
 static_assert(
-    not db::is_compute_tag_v<TestHelpers::db::Tags::SimpleWithBaseReference>,
-    "Failed testing is_compute_tag");
+    not db::is_compute_tag_v<TestHelpers::db::Tags::SimpleWithBaseReference>);
 static_assert(not db::is_compute_tag_v<
-                  TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>,
-              "Failed testing is_compute_tag");
+              TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>);
 
-static_assert(not db::is_reference_tag_v<TestHelpers::db::Tags::Bad>,
-              "Failed testing is_reference_tag");
-static_assert(not db::is_reference_tag_v<TestHelpers::db::Tags::Simple>,
-              "Failed testing is_reference_tag");
-static_assert(not db::is_reference_tag_v<TestHelpers::db::Tags::Base>,
-              "Failed testing is_reference_tag");
-static_assert(not db::is_reference_tag_v<TestHelpers::db::Tags::SimpleWithBase>,
-              "Failed testing is_reference_tag");
-static_assert(not db::is_reference_tag_v<TestHelpers::db::Tags::SimpleCompute>,
-              "Failed testing is_reference_tag");
+static_assert(not db::is_reference_tag_v<TestHelpers::db::Tags::Bad>);
+static_assert(not db::is_reference_tag_v<TestHelpers::db::Tags::Simple>);
+static_assert(not db::is_reference_tag_v<TestHelpers::db::Tags::Base>);
 static_assert(
-    not db::is_reference_tag_v<TestHelpers::db::Tags::SimpleWithBaseCompute>,
-    "Failed testing is_reference_tag");
-static_assert(db::is_reference_tag_v<TestHelpers::db::Tags::SimpleReference>,
-              "Failed testing is_reference_tag");
+    not db::is_reference_tag_v<TestHelpers::db::Tags::SimpleWithBase>);
+static_assert(not db::is_reference_tag_v<TestHelpers::db::Tags::SimpleCompute>);
 static_assert(
-    db::is_reference_tag_v<TestHelpers::db::Tags::SimpleWithBaseReference>,
-    "Failed testing is_reference_tag");
+    not db::is_reference_tag_v<TestHelpers::db::Tags::SimpleWithBaseCompute>);
+static_assert(db::is_reference_tag_v<TestHelpers::db::Tags::SimpleReference>);
+static_assert(
+    db::is_reference_tag_v<TestHelpers::db::Tags::SimpleWithBaseReference>);
 static_assert(not db::is_reference_tag_v<
-                  TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>,
-              "Failed testing is_reference_tag");
+              TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>);
 
-static_assert(not db::is_immutable_item_tag_v<TestHelpers::db::Tags::Bad>,
-              "Failed testing is_immutable_item_tag");
-static_assert(not db::is_immutable_item_tag_v<TestHelpers::db::Tags::Simple>,
-              "Failed testing is_immutable_item_tag");
-static_assert(not db::is_immutable_item_tag_v<TestHelpers::db::Tags::Base>,
-              "Failed testing is_immutable_item_tag");
+static_assert(not db::is_immutable_item_tag_v<TestHelpers::db::Tags::Bad>);
+static_assert(not db::is_immutable_item_tag_v<TestHelpers::db::Tags::Simple>);
+static_assert(not db::is_immutable_item_tag_v<TestHelpers::db::Tags::Base>);
 static_assert(
-    not db::is_immutable_item_tag_v<TestHelpers::db::Tags::SimpleWithBase>,
-    "Failed testing is_immutable_item_tag");
-static_assert(db::is_immutable_item_tag_v<TestHelpers::db::Tags::SimpleCompute>,
-              "Failed testing is_immutable_item_tag");
+    not db::is_immutable_item_tag_v<TestHelpers::db::Tags::SimpleWithBase>);
 static_assert(
-    db::is_immutable_item_tag_v<TestHelpers::db::Tags::SimpleWithBaseCompute>,
-    "Failed testing is_immutable_item_tag");
+    db::is_immutable_item_tag_v<TestHelpers::db::Tags::SimpleCompute>);
 static_assert(
-    db::is_immutable_item_tag_v<TestHelpers::db::Tags::SimpleReference>,
-    "Failed testing is_immutable_item_tag");
+    db::is_immutable_item_tag_v<TestHelpers::db::Tags::SimpleWithBaseCompute>);
 static_assert(
-    db::is_immutable_item_tag_v<TestHelpers::db::Tags::SimpleWithBaseReference>,
-    "Failed testing is_immutable_item_tag");
+    db::is_immutable_item_tag_v<TestHelpers::db::Tags::SimpleReference>);
+static_assert(db::is_immutable_item_tag_v<
+              TestHelpers::db::Tags::SimpleWithBaseReference>);
 static_assert(not db::is_immutable_item_tag_v<
-                  TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>,
-              "Failed testing is_immutable_item_tag");
+              TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>);
 
-static_assert(not db::is_simple_tag_v<TestHelpers::db::Tags::Bad>,
-              "Failed testing is_simple_tag");
-static_assert(db::is_simple_tag_v<TestHelpers::db::Tags::Simple>,
-              "Failed testing is_simple_tag");
-static_assert(not db::is_simple_tag_v<TestHelpers::db::Tags::Base>,
-              "Failed testing is_simple_tag");
-static_assert(db::is_simple_tag_v<TestHelpers::db::Tags::SimpleWithBase>,
-              "Failed testing is_simple_tag");
-static_assert(not db::is_simple_tag_v<TestHelpers::db::Tags::SimpleCompute>,
-              "Failed testing is_simple_tag");
+static_assert(not db::is_simple_tag_v<TestHelpers::db::Tags::Bad>);
+static_assert(db::is_simple_tag_v<TestHelpers::db::Tags::Simple>);
+static_assert(not db::is_simple_tag_v<TestHelpers::db::Tags::Base>);
+static_assert(db::is_simple_tag_v<TestHelpers::db::Tags::SimpleWithBase>);
+static_assert(not db::is_simple_tag_v<TestHelpers::db::Tags::SimpleCompute>);
 static_assert(
-    not db::is_simple_tag_v<TestHelpers::db::Tags::SimpleWithBaseCompute>,
-    "Failed testing is_simple_tag");
-static_assert(not db::is_simple_tag_v<TestHelpers::db::Tags::SimpleReference>,
-              "Failed testing is_simple_tag");
+    not db::is_simple_tag_v<TestHelpers::db::Tags::SimpleWithBaseCompute>);
+static_assert(not db::is_simple_tag_v<TestHelpers::db::Tags::SimpleReference>);
 static_assert(
-    not db::is_simple_tag_v<TestHelpers::db::Tags::SimpleWithBaseReference>,
-    "Failed testing is_simple_tag");
+    not db::is_simple_tag_v<TestHelpers::db::Tags::SimpleWithBaseReference>);
 static_assert(db::is_simple_tag_v<
-                  TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>,
-              "Failed testing is_simple_tag");
+              TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>);
 
-static_assert(not db::is_non_base_tag_v<TestHelpers::db::Tags::Bad>,
-              "Failed testing is_non_base_tag");
-static_assert(db::is_non_base_tag_v<TestHelpers::db::Tags::Simple>,
-              "Failed testing is_non_base_tag");
-static_assert(not db::is_non_base_tag_v<TestHelpers::db::Tags::Base>,
-              "Failed testing is_non_base_tag");
-static_assert(db::is_non_base_tag_v<TestHelpers::db::Tags::SimpleWithBase>,
-              "Failed testing is_non_base_tag");
-static_assert(db::is_non_base_tag_v<TestHelpers::db::Tags::SimpleCompute>,
-              "Failed testing is_non_base_tag");
+static_assert(not db::is_non_base_tag_v<TestHelpers::db::Tags::Bad>);
+static_assert(db::is_non_base_tag_v<TestHelpers::db::Tags::Simple>);
+static_assert(not db::is_non_base_tag_v<TestHelpers::db::Tags::Base>);
+static_assert(db::is_non_base_tag_v<TestHelpers::db::Tags::SimpleWithBase>);
+static_assert(db::is_non_base_tag_v<TestHelpers::db::Tags::SimpleCompute>);
 static_assert(
-    db::is_non_base_tag_v<TestHelpers::db::Tags::SimpleWithBaseCompute>,
-    "Failed testing is_non_base_tag");
-static_assert(db::is_non_base_tag_v<TestHelpers::db::Tags::SimpleReference>,
-              "Failed testing is_non_base_tag");
+    db::is_non_base_tag_v<TestHelpers::db::Tags::SimpleWithBaseCompute>);
+static_assert(db::is_non_base_tag_v<TestHelpers::db::Tags::SimpleReference>);
 static_assert(
-    db::is_non_base_tag_v<TestHelpers::db::Tags::SimpleWithBaseReference>,
-    "Failed testing is_non_base_tag");
+    db::is_non_base_tag_v<TestHelpers::db::Tags::SimpleWithBaseReference>);
 static_assert(db::is_non_base_tag_v<
-                  TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>,
-              "Failed testing is_non_base_tag");
+              TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>);
 
-static_assert(not db::is_tag_v<TestHelpers::db::Tags::Bad>,
-              "Failed testing is_tag");
-static_assert(db::is_tag_v<TestHelpers::db::Tags::Simple>,
-              "Failed testing is_tag");
-static_assert(db::is_tag_v<TestHelpers::db::Tags::Base>,
-              "Failed testing is_tag");
-static_assert(db::is_tag_v<TestHelpers::db::Tags::SimpleWithBase>,
-              "Failed testing is_tag");
-static_assert(db::is_tag_v<TestHelpers::db::Tags::SimpleCompute>,
-              "Failed testing is_tag");
-static_assert(db::is_tag_v<TestHelpers::db::Tags::SimpleWithBaseCompute>,
-              "Failed testing is_tag");
-static_assert(db::is_tag_v<TestHelpers::db::Tags::SimpleReference>,
-              "Failed testing is_tag");
-static_assert(db::is_tag_v<TestHelpers::db::Tags::SimpleWithBaseReference>,
-              "Failed testing is_tag");
+static_assert(not db::is_tag_v<TestHelpers::db::Tags::Bad>);
+static_assert(db::is_tag_v<TestHelpers::db::Tags::Simple>);
+static_assert(db::is_tag_v<TestHelpers::db::Tags::Base>);
+static_assert(db::is_tag_v<TestHelpers::db::Tags::SimpleWithBase>);
+static_assert(db::is_tag_v<TestHelpers::db::Tags::SimpleCompute>);
+static_assert(db::is_tag_v<TestHelpers::db::Tags::SimpleWithBaseCompute>);
+static_assert(db::is_tag_v<TestHelpers::db::Tags::SimpleReference>);
+static_assert(db::is_tag_v<TestHelpers::db::Tags::SimpleWithBaseReference>);
 static_assert(
-    db::is_tag_v<TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>,
-    "Failed testing is_tag");
+    db::is_tag_v<TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>);
 
-static_assert(not db::is_base_tag_v<TestHelpers::db::Tags::Bad>,
-              "Failed testing is_base_tag");
-static_assert(not db::is_base_tag_v<TestHelpers::db::Tags::Simple>,
-              "Failed testing is_base_tag");
-static_assert(db::is_base_tag_v<TestHelpers::db::Tags::Base>,
-              "Failed testing is_base_tag");
-static_assert(not db::is_base_tag_v<TestHelpers::db::Tags::SimpleWithBase>,
-              "Failed testing is_base_tag");
-static_assert(not db::is_base_tag_v<TestHelpers::db::Tags::SimpleCompute>,
-              "Failed testing is_base_tag");
+static_assert(not db::is_base_tag_v<TestHelpers::db::Tags::Bad>);
+static_assert(not db::is_base_tag_v<TestHelpers::db::Tags::Simple>);
+static_assert(db::is_base_tag_v<TestHelpers::db::Tags::Base>);
+static_assert(not db::is_base_tag_v<TestHelpers::db::Tags::SimpleWithBase>);
+static_assert(not db::is_base_tag_v<TestHelpers::db::Tags::SimpleCompute>);
 static_assert(
-    not db::is_base_tag_v<TestHelpers::db::Tags::SimpleWithBaseCompute>,
-    "Failed testing is_base_tag");
-static_assert(not db::is_base_tag_v<TestHelpers::db::Tags::SimpleReference>,
-              "Failed testing is_base_tag");
+    not db::is_base_tag_v<TestHelpers::db::Tags::SimpleWithBaseCompute>);
+static_assert(not db::is_base_tag_v<TestHelpers::db::Tags::SimpleReference>);
 static_assert(
-    not db::is_base_tag_v<TestHelpers::db::Tags::SimpleWithBaseReference>,
-    "Failed testing is_base_tag");
+    not db::is_base_tag_v<TestHelpers::db::Tags::SimpleWithBaseReference>);
 static_assert(not db::is_base_tag_v<
-                  TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>,
-              "Failed testing is_base_tag");
+              TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>);

--- a/tests/Unit/DataStructures/DataBox/Test_TagTraits.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_TagTraits.cpp
@@ -17,9 +17,60 @@ static_assert(db::is_compute_tag_v<TestHelpers::db::Tags::SimpleCompute>,
 static_assert(
     db::is_compute_tag_v<TestHelpers::db::Tags::SimpleWithBaseCompute>,
     "Failed testing is_compute_tag");
+static_assert(not db::is_compute_tag_v<TestHelpers::db::Tags::SimpleReference>,
+              "Failed testing is_compute_tag");
+static_assert(
+    not db::is_compute_tag_v<TestHelpers::db::Tags::SimpleWithBaseReference>,
+    "Failed testing is_compute_tag");
 static_assert(not db::is_compute_tag_v<
                   TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>,
               "Failed testing is_compute_tag");
+
+static_assert(not db::is_reference_tag_v<TestHelpers::db::Tags::Bad>,
+              "Failed testing is_reference_tag");
+static_assert(not db::is_reference_tag_v<TestHelpers::db::Tags::Simple>,
+              "Failed testing is_reference_tag");
+static_assert(not db::is_reference_tag_v<TestHelpers::db::Tags::Base>,
+              "Failed testing is_reference_tag");
+static_assert(not db::is_reference_tag_v<TestHelpers::db::Tags::SimpleWithBase>,
+              "Failed testing is_reference_tag");
+static_assert(not db::is_reference_tag_v<TestHelpers::db::Tags::SimpleCompute>,
+              "Failed testing is_reference_tag");
+static_assert(
+    not db::is_reference_tag_v<TestHelpers::db::Tags::SimpleWithBaseCompute>,
+    "Failed testing is_reference_tag");
+static_assert(db::is_reference_tag_v<TestHelpers::db::Tags::SimpleReference>,
+              "Failed testing is_reference_tag");
+static_assert(
+    db::is_reference_tag_v<TestHelpers::db::Tags::SimpleWithBaseReference>,
+    "Failed testing is_reference_tag");
+static_assert(not db::is_reference_tag_v<
+                  TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>,
+              "Failed testing is_reference_tag");
+
+static_assert(not db::is_immutable_item_tag_v<TestHelpers::db::Tags::Bad>,
+              "Failed testing is_immutable_item_tag");
+static_assert(not db::is_immutable_item_tag_v<TestHelpers::db::Tags::Simple>,
+              "Failed testing is_immutable_item_tag");
+static_assert(not db::is_immutable_item_tag_v<TestHelpers::db::Tags::Base>,
+              "Failed testing is_immutable_item_tag");
+static_assert(
+    not db::is_immutable_item_tag_v<TestHelpers::db::Tags::SimpleWithBase>,
+    "Failed testing is_immutable_item_tag");
+static_assert(db::is_immutable_item_tag_v<TestHelpers::db::Tags::SimpleCompute>,
+              "Failed testing is_immutable_item_tag");
+static_assert(
+    db::is_immutable_item_tag_v<TestHelpers::db::Tags::SimpleWithBaseCompute>,
+    "Failed testing is_immutable_item_tag");
+static_assert(
+    db::is_immutable_item_tag_v<TestHelpers::db::Tags::SimpleReference>,
+    "Failed testing is_immutable_item_tag");
+static_assert(
+    db::is_immutable_item_tag_v<TestHelpers::db::Tags::SimpleWithBaseReference>,
+    "Failed testing is_immutable_item_tag");
+static_assert(not db::is_immutable_item_tag_v<
+                  TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>,
+              "Failed testing is_immutable_item_tag");
 
 static_assert(not db::is_simple_tag_v<TestHelpers::db::Tags::Bad>,
               "Failed testing is_simple_tag");
@@ -33,6 +84,11 @@ static_assert(not db::is_simple_tag_v<TestHelpers::db::Tags::SimpleCompute>,
               "Failed testing is_simple_tag");
 static_assert(
     not db::is_simple_tag_v<TestHelpers::db::Tags::SimpleWithBaseCompute>,
+    "Failed testing is_simple_tag");
+static_assert(not db::is_simple_tag_v<TestHelpers::db::Tags::SimpleReference>,
+              "Failed testing is_simple_tag");
+static_assert(
+    not db::is_simple_tag_v<TestHelpers::db::Tags::SimpleWithBaseReference>,
     "Failed testing is_simple_tag");
 static_assert(db::is_simple_tag_v<
                   TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>,
@@ -51,6 +107,11 @@ static_assert(db::is_non_base_tag_v<TestHelpers::db::Tags::SimpleCompute>,
 static_assert(
     db::is_non_base_tag_v<TestHelpers::db::Tags::SimpleWithBaseCompute>,
     "Failed testing is_non_base_tag");
+static_assert(db::is_non_base_tag_v<TestHelpers::db::Tags::SimpleReference>,
+              "Failed testing is_non_base_tag");
+static_assert(
+    db::is_non_base_tag_v<TestHelpers::db::Tags::SimpleWithBaseReference>,
+    "Failed testing is_non_base_tag");
 static_assert(db::is_non_base_tag_v<
                   TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>,
               "Failed testing is_non_base_tag");
@@ -66,6 +127,10 @@ static_assert(db::is_tag_v<TestHelpers::db::Tags::SimpleWithBase>,
 static_assert(db::is_tag_v<TestHelpers::db::Tags::SimpleCompute>,
               "Failed testing is_tag");
 static_assert(db::is_tag_v<TestHelpers::db::Tags::SimpleWithBaseCompute>,
+              "Failed testing is_tag");
+static_assert(db::is_tag_v<TestHelpers::db::Tags::SimpleReference>,
+              "Failed testing is_tag");
+static_assert(db::is_tag_v<TestHelpers::db::Tags::SimpleWithBaseReference>,
               "Failed testing is_tag");
 static_assert(
     db::is_tag_v<TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>,
@@ -83,6 +148,11 @@ static_assert(not db::is_base_tag_v<TestHelpers::db::Tags::SimpleCompute>,
               "Failed testing is_base_tag");
 static_assert(
     not db::is_base_tag_v<TestHelpers::db::Tags::SimpleWithBaseCompute>,
+    "Failed testing is_base_tag");
+static_assert(not db::is_base_tag_v<TestHelpers::db::Tags::SimpleReference>,
+              "Failed testing is_base_tag");
+static_assert(
+    not db::is_base_tag_v<TestHelpers::db::Tags::SimpleWithBaseReference>,
     "Failed testing is_base_tag");
 static_assert(not db::is_base_tag_v<
                   TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>,

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActions.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActions.cpp
@@ -99,7 +99,7 @@ class DummyLimiterForTest {
   void pup(const PUP::er& /*p*/) const noexcept {}
 };
 
-struct LimiterTag {
+struct LimiterTag : db::SimpleTag {
   using type = DummyLimiterForTest;
 };
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActionsWithMinmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_LimiterActionsWithMinmod.cpp
@@ -59,7 +59,7 @@ struct System {
   using variables_tag = Tags::Variables<tmpl::list<Var>>;
 };
 
-struct LimiterTag {
+struct LimiterTag : db::SimpleTag {
   using type = Limiters::Minmod<2, tmpl::list<Var>>;
 };
 

--- a/tests/Unit/Helpers/DataStructures/DataBox/TestTags.hpp
+++ b/tests/Unit/Helpers/DataStructures/DataBox/TestTags.hpp
@@ -45,6 +45,24 @@ struct SimpleWithBaseCompute : SimpleWithBase, ::db::ComputeTag {
   static constexpr auto function = do_something;
 };
 
+struct ParentTag : ::db::SimpleTag {
+  using type = SomeType;
+};
+
+struct SimpleReference : Simple, ::db::ReferenceTag {
+  using base = Simple;
+  using parent_tag = ParentTag;
+  static const auto& get(const typename parent_tag::type& /* parent_value */);
+  using argument_tags = tmpl::list<parent_tag>;
+};
+
+struct SimpleWithBaseReference : SimpleWithBase, ::db::ReferenceTag {
+  using base = SimpleWithBase;
+  using parent_tag = ParentTag;
+  static const auto& get(const typename parent_tag::type& /* parent_value */);
+  using argument_tags = tmpl::list<parent_tag>;
+};
+
 template <typename Tag>
 struct Label : ::db::PrefixTag, ::db::SimpleTag {
   using tag = Tag;

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
@@ -56,7 +56,7 @@ struct BoundaryCondition : MarkAsAnalyticSolution {
   void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
 };
 
-struct BoundaryConditionTag {
+struct BoundaryConditionTag : db::SimpleTag {
   using type = BoundaryCondition;
 };
 

--- a/tests/Unit/Parallel/Test_GlobalCacheDataBox.cpp
+++ b/tests/Unit/Parallel/Test_GlobalCacheDataBox.cpp
@@ -24,7 +24,9 @@ struct IntegerList : db::SimpleTag {
   using type = std::array<int, 3>;
 };
 
-struct UniquePtrIntegerList : db::BaseTag {
+struct UniquePtrIntegerListBase : db::BaseTag {};
+
+struct UniquePtrIntegerList : UniquePtrIntegerListBase, db::SimpleTag {
   using type = std::unique_ptr<std::array<int, 3>>;
 };
 }  // namespace Tags
@@ -54,10 +56,14 @@ SPECTRE_TEST_CASE("Unit.Parallel.GlobalCacheDataBox", "[Unit][Parallel]") {
   CHECK(std::array<int, 3>{{-1, 3, 7}} == db::get<Tags::IntegerList>(box));
   CHECK(std::array<int, 3>{{1, 5, -8}} ==
         db::get<Tags::UniquePtrIntegerList>(box));
+  CHECK(std::array<int, 3>{{1, 5, -8}} ==
+        db::get<Tags::UniquePtrIntegerListBase>(box));
   CHECK(&Parallel::get<Tags::IntegerList>(cache) ==
         &db::get<Tags::IntegerList>(box));
   CHECK(&Parallel::get<Tags::UniquePtrIntegerList>(cache) ==
         &db::get<Tags::UniquePtrIntegerList>(box));
+  CHECK(&Parallel::get<Tags::UniquePtrIntegerList>(cache) ==
+        &db::get<Tags::UniquePtrIntegerListBase>(box));
 
   tuples::TaggedTuple<Tags::IntegerList, Tags::UniquePtrIntegerList> tuple2{};
   tuples::get<Tags::IntegerList>(tuple2) = std::array<int, 3>{{10, -3, 700}};
@@ -76,10 +82,14 @@ SPECTRE_TEST_CASE("Unit.Parallel.GlobalCacheDataBox", "[Unit][Parallel]") {
   CHECK(std::array<int, 3>{{10, -3, 700}} == db::get<Tags::IntegerList>(box));
   CHECK(std::array<int, 3>{{100, -7, -300}} ==
         db::get<Tags::UniquePtrIntegerList>(box));
+  CHECK(std::array<int, 3>{{100, -7, -300}} ==
+        db::get<Tags::UniquePtrIntegerListBase>(box));
   CHECK(&Parallel::get<Tags::IntegerList>(cache2) ==
         &db::get<Tags::IntegerList>(box));
   CHECK(&Parallel::get<Tags::UniquePtrIntegerList>(cache2) ==
         &db::get<Tags::UniquePtrIntegerList>(box));
+  CHECK(&Parallel::get<Tags::UniquePtrIntegerList>(cache2) ==
+        &db::get<Tags::UniquePtrIntegerListBase>(box));
 
   TestHelpers::db::test_base_tag<Tags::GlobalCache>("GlobalCache");
   TestHelpers::db::test_simple_tag<Tags::GlobalCacheImpl<Metavars>>(


### PR DESCRIPTION
## Proposed changes

- Add static assert that the template parameter `CacheTag` of `Parallel::Tags::FromGlobalCache` is a simple tag
- Add tag_traits for a `db::ReferenceTag`
- Remove strings from static_asserts in `Test_TagTraits.cpp`

### Upgrade instructions

If a tag of a `GlobalCache` is added to the DataBox using `Parallel::Tags::FromGlobalCache` does not inherit  from `db::SimpleTag`, such inheritance must be added

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
