### PR TITLE
Compute elliptic sources in two steps

### DIFF
--- a/src/Elliptic/Systems/Elasticity/Equations.cpp
+++ b/src/Elliptic/Systems/Elasticity/Equations.cpp
@@ -95,6 +95,41 @@ void add_curved_auxiliary_sources(
   }
 }
 
+/// \cond
+template <size_t Dim>
+void Fluxes<Dim>::apply(
+    const gsl::not_null<tnsr::IJ<DataVector, Dim>*> flux_for_displacement,
+    const ConstitutiveRelations::ConstitutiveRelation<Dim>&
+        constitutive_relation,
+    const tnsr::I<DataVector, Dim>& coordinates,
+    const tnsr::ii<DataVector, Dim>& strain) noexcept {
+  primal_fluxes(flux_for_displacement, strain, constitutive_relation,
+                coordinates);
+}
+
+template <size_t Dim>
+void Fluxes<Dim>::apply(
+    const gsl::not_null<tnsr::Ijj<DataVector, Dim>*> flux_for_strain,
+    const ConstitutiveRelations::ConstitutiveRelation<
+        Dim>& /*constitutive_relation*/,
+    const tnsr::I<DataVector, Dim>& /*coordinates*/,
+    const tnsr::I<DataVector, Dim>& displacement) noexcept {
+  auxiliary_fluxes(flux_for_strain, displacement);
+}
+
+template <size_t Dim>
+void Sources<Dim>::apply(
+    const gsl::not_null<
+        tnsr::I<DataVector, Dim>*> /*equation_for_displacement*/,
+    const tnsr::I<DataVector, Dim>& /*displacement*/,
+    const tnsr::IJ<DataVector, Dim>& /*minus_stress*/) noexcept {}
+
+template <size_t Dim>
+void Sources<Dim>::apply(
+    const gsl::not_null<tnsr::ii<DataVector, Dim>*> /*equation_for_strain*/,
+    const tnsr::I<DataVector, Dim>& /*displacement*/) noexcept {}
+/// \endcond
+
 }  // namespace Elasticity
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
@@ -121,7 +156,9 @@ void add_curved_auxiliary_sources(
   template void Elasticity::add_curved_auxiliary_sources<DIM(data)>(     \
       gsl::not_null<tnsr::ii<DataVector, DIM(data)>*>,                   \
       const tnsr::ijj<DataVector, DIM(data)>&,                           \
-      const tnsr::I<DataVector, DIM(data)>&) noexcept;
+      const tnsr::I<DataVector, DIM(data)>&) noexcept;                   \
+  template class Elasticity::Sources<DIM(data)>;                         \
+  template class Elasticity::Fluxes<DIM(data)>;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3))
 

--- a/src/Elliptic/Systems/Elasticity/Equations.hpp
+++ b/src/Elliptic/Systems/Elasticity/Equations.hpp
@@ -106,28 +106,22 @@ struct Fluxes {
                  domain::Tags::Coordinates<Dim, Frame::Inertial>>;
   using volume_tags = tmpl::list<Tags::ConstitutiveRelationBase>;
   static void apply(
-      const gsl::not_null<tnsr::IJ<DataVector, Dim>*> flux_for_displacement,
+      gsl::not_null<tnsr::IJ<DataVector, Dim>*> flux_for_displacement,
       const ConstitutiveRelations::ConstitutiveRelation<Dim>&
           constitutive_relation,
       const tnsr::I<DataVector, Dim>& coordinates,
-      const tnsr::ii<DataVector, Dim>& strain) noexcept {
-    primal_fluxes(flux_for_displacement, strain, constitutive_relation,
-                  coordinates);
-  }
-  static void apply(
-      const gsl::not_null<tnsr::Ijj<DataVector, Dim>*> flux_for_strain,
-      const ConstitutiveRelations::ConstitutiveRelation<
-          Dim>& /*constitutive_relation*/,
-      const tnsr::I<DataVector, Dim>& /*coordinates*/,
-      const tnsr::I<DataVector, Dim>& displacement) noexcept {
-    auxiliary_fluxes(flux_for_strain, displacement);
-  }
+      const tnsr::ii<DataVector, Dim>& strain) noexcept;
+  static void apply(gsl::not_null<tnsr::Ijj<DataVector, Dim>*> flux_for_strain,
+                    const ConstitutiveRelations::ConstitutiveRelation<Dim>&
+                        constitutive_relation,
+                    const tnsr::I<DataVector, Dim>& coordinates,
+                    const tnsr::I<DataVector, Dim>& displacement) noexcept;
   // clang-tidy: no runtime references
   void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
 };
 
 /*!
- * \brief Compute the sources \f$S_A\f$ for the Elasticity equation.
+ * \brief Add the sources \f$S_A\f$ for the Elasticity equation.
  *
  * \see Elasticity::FirstOrderSystem
  */
@@ -135,14 +129,12 @@ template <size_t Dim>
 struct Sources {
   using argument_tags = tmpl::list<>;
   static void apply(
-      const gsl::not_null<tnsr::I<DataVector, Dim>*> source_for_displacement,
-      const gsl::not_null<tnsr::ii<DataVector, Dim>*> /*source_for_strain*/,
-      const tnsr::I<DataVector, Dim>& /*displacement*/,
-      const tnsr::IJ<DataVector, Dim>& /*stress*/) noexcept {
-    for (size_t d = 0; d < Dim; d++) {
-      source_for_displacement->get(d) = 0.;
-    }
-  }
+      gsl::not_null<tnsr::I<DataVector, Dim>*> equation_for_displacement,
+      const tnsr::I<DataVector, Dim>& displacement,
+      const tnsr::IJ<DataVector, Dim>& minus_stress) noexcept;
+  static void apply(
+      gsl::not_null<tnsr::ii<DataVector, Dim>*> equation_for_strain,
+      const tnsr::I<DataVector, Dim>& displacement) noexcept;
 };
 
 }  // namespace Elasticity

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFirstOrderOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFirstOrderOperator.cpp
@@ -87,13 +87,15 @@ struct Fluxes {
 struct Sources {
   using argument_tags = tmpl::list<>;
   template <size_t Dim>
-  static void apply(
-      const gsl::not_null<Scalar<DataVector>*> source_for_field,
-      const gsl::not_null<tnsr::i<DataVector, Dim>*> /*source_for_aux_field*/,
-      const Scalar<DataVector>& field,
-      const tnsr::I<DataVector, Dim>& /*field_flux*/) {
-    get(*source_for_field) = get(field);
+  static void apply(const gsl::not_null<Scalar<DataVector>*> equation_for_field,
+                    const Scalar<DataVector>& field,
+                    const tnsr::I<DataVector, Dim>& /*field_flux*/) {
+    get(*equation_for_field) += get(field);
   }
+  template <size_t Dim>
+  static void apply(
+      const gsl::not_null<tnsr::i<DataVector, Dim>*> /*equation_for_aux_field*/,
+      const Scalar<DataVector>& /*field*/) {}
 };
 
 template <size_t Dim, typename Metavariables>

--- a/tests/Unit/Elliptic/Systems/Elasticity/Test_Equations.cpp
+++ b/tests/Unit/Elliptic/Systems/Elasticity/Test_Equations.cpp
@@ -136,23 +136,26 @@ void test_computers(const DataVector& used_for_size) {
     INFO("Sources" << Dim << "D");
     auto box =
         db::create<db::AddSimpleTags<field_source_tag, auxiliary_source_tag>>(
-            tnsr::I<DataVector, Dim>{
-                num_points, std::numeric_limits<double>::signaling_NaN()},
-            tnsr::ii<DataVector, Dim>{
-                num_points, std::numeric_limits<double>::signaling_NaN()});
+            tnsr::I<DataVector, Dim>{num_points, 0.},
+            tnsr::ii<DataVector, Dim>{num_points, 0.});
 
     const Elasticity::Sources<Dim> sources_computer{};
     using argument_tags = typename Elasticity::Sources<Dim>::argument_tags;
 
-    db::mutate_apply<tmpl::list<field_source_tag, auxiliary_source_tag>,
-                     argument_tags>(
+    db::mutate_apply<tmpl::list<auxiliary_source_tag>, argument_tags>(
+        sources_computer, make_not_null(&box),
+        tnsr::I<DataVector, Dim>{num_points,
+                                 std::numeric_limits<double>::signaling_NaN()});
+    db::mutate_apply<tmpl::list<field_source_tag>, argument_tags>(
         sources_computer, make_not_null(&box),
         tnsr::I<DataVector, Dim>{num_points,
                                  std::numeric_limits<double>::signaling_NaN()},
         tnsr::IJ<DataVector, Dim>{
             num_points, std::numeric_limits<double>::signaling_NaN()});
     auto expected_field_source = tnsr::I<DataVector, Dim>{num_points, 0.};
+    auto expected_auxiliary_source = tnsr::ii<DataVector, Dim>{num_points, 0.};
     CHECK(get<field_source_tag>(box) == expected_field_source);
+    CHECK(get<auxiliary_source_tag>(box) == expected_auxiliary_source);
   }
 }
 

--- a/tests/Unit/Elliptic/Test_FirstOrderComputeTags.cpp
+++ b/tests/Unit/Elliptic/Test_FirstOrderComputeTags.cpp
@@ -63,15 +63,18 @@ struct Fluxes {
 struct Sources {
   using argument_tags = tmpl::list<AnArgument, BaseArgumentTag>;
   template <size_t Dim>
-  static void apply(
-      const gsl::not_null<Scalar<DataVector>*> source_for_field,
-      const gsl::not_null<tnsr::i<DataVector, Dim>*> /*source_for_aux_field*/,
-      const double an_argument, const double base_tag_argument,
-      const Scalar<DataVector>& field,
-      const tnsr::I<DataVector, Dim>& /*field_flux*/) {
-    get(*source_for_field) =
+  static void apply(const gsl::not_null<Scalar<DataVector>*> equation_for_field,
+                    const double an_argument, const double base_tag_argument,
+                    const Scalar<DataVector>& field,
+                    const tnsr::I<DataVector, Dim>& /*field_flux*/) {
+    get(*equation_for_field) +=
         get(field) * square(an_argument) + base_tag_argument;
   }
+  template <size_t Dim>
+  static void apply(
+      const gsl::not_null<tnsr::i<DataVector, Dim>*> /*equation_for_aux_field*/,
+      const double /*an_argument*/, const double /*base_tag_argument*/,
+      const Scalar<DataVector>& /*field*/) {}
 };
 
 template <size_t Dim>

--- a/tests/Unit/Elliptic/Test_FirstOrderOperator.cpp
+++ b/tests/Unit/Elliptic/Test_FirstOrderOperator.cpp
@@ -65,13 +65,15 @@ struct Fluxes {
 struct Sources {
   using argument_tags = tmpl::list<AnArgument>;
   template <size_t Dim>
-  static void apply(
-      const gsl::not_null<Scalar<DataVector>*> source_for_field,
-      const gsl::not_null<tnsr::i<DataVector, Dim>*> /*source_for_aux_field*/,
-      const double an_argument, const Scalar<DataVector>& field,
-      const tnsr::I<DataVector, Dim>& /*field_flux*/) {
-    get(*source_for_field) = get(field) * square(an_argument);
+  static void apply(const gsl::not_null<Scalar<DataVector>*> equation_for_field,
+                    const double an_argument, const Scalar<DataVector>& field,
+                    const tnsr::I<DataVector, Dim>& /*field_flux*/) {
+    get(*equation_for_field) += get(field) * square(an_argument);
   }
+  template <size_t Dim>
+  static void apply(
+      const gsl::not_null<tnsr::i<DataVector, Dim>*> /*equation_for_aux_field*/,
+      const double /*an_argument*/, const Scalar<DataVector>& /*field*/) {}
 };
 
 template <size_t Dim>


### PR DESCRIPTION
## Proposed changes

Make the source computers handle primal and auxiliary sources separately. This is needed for the upcoming second-order DG operator.

Note that most of the code that this PR updates will actually be deleted with the new DG operator, but I think it's still easier to do this simple refactor now instead of making the PR for the DG operator bigger.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
