### PR TITLE
Rename elliptic fluxes and sources computer type aliases

### DIFF
--- a/src/Elliptic/DiscontinuousGalerkin/ImposeInhomogeneousBoundaryConditionsOnSource.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/ImposeInhomogeneousBoundaryConditionsOnSource.hpp
@@ -71,7 +71,7 @@ template <typename Metavariables>
 struct ImposeInhomogeneousBoundaryConditionsOnSource {
   using system = typename Metavariables::system;
   static constexpr size_t volume_dim = system::volume_dim;
-  using FluxesType = typename system::fluxes;
+  using FluxesType = typename system::fluxes_computer;
   using fluxes_computer_tag = elliptic::Tags::FluxesComputer<FluxesType>;
 
   using fixed_sources_tag =

--- a/src/Elliptic/Executables/Elasticity/SolveElasticityProblem.hpp
+++ b/src/Elliptic/Executables/Elasticity/SolveElasticityProblem.hpp
@@ -84,7 +84,7 @@ struct Metavariables {
       "Find the solution to a linear elasticity problem."};
 
   using fluxes_computer_tag =
-      elliptic::Tags::FluxesComputer<typename system::fluxes>;
+      elliptic::Tags::FluxesComputer<typename system::fluxes_computer>;
 
   // Only Dirichlet boundary conditions are currently supported, and they are
   // are all imposed by analytic solutions right now.
@@ -178,8 +178,9 @@ struct Metavariables {
           Metavariables>,
       dg::Actions::InitializeMortars<boundary_scheme>,
       elliptic::dg::Actions::InitializeFirstOrderOperator<
-          volume_dim, typename system::fluxes, typename system::sources,
-          linear_operand_tag, primal_variables, auxiliary_variables>,
+          volume_dim, typename system::fluxes_computer,
+          typename system::sources_computer, linear_operand_tag,
+          primal_variables, auxiliary_variables>,
       Initialization::Actions::RemoveOptionsAndTerminatePhase>;
 
   using build_linear_operator_actions = tmpl::list<

--- a/src/Elliptic/Executables/Poisson/SolvePoissonProblem.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoissonProblem.hpp
@@ -81,7 +81,7 @@ struct Metavariables {
       "Find the solution to a Poisson problem."};
 
   using fluxes_computer_tag =
-      elliptic::Tags::FluxesComputer<typename system::fluxes>;
+      elliptic::Tags::FluxesComputer<typename system::fluxes_computer>;
 
   // Only Dirichlet boundary conditions are currently supported, and they are
   // are all imposed by analytic solutions right now.
@@ -162,8 +162,9 @@ struct Metavariables {
           Metavariables>,
       dg::Actions::InitializeMortars<boundary_scheme>,
       elliptic::dg::Actions::InitializeFirstOrderOperator<
-          volume_dim, typename system::fluxes, typename system::sources,
-          linear_operand_tag, primal_variables, auxiliary_variables>,
+          volume_dim, typename system::fluxes_computer,
+          typename system::sources_computer, linear_operand_tag,
+          primal_variables, auxiliary_variables>,
       Initialization::Actions::RemoveOptionsAndTerminatePhase>;
 
   using build_linear_operator_actions = tmpl::list<

--- a/src/Elliptic/Systems/Elasticity/FirstOrderSystem.hpp
+++ b/src/Elliptic/Systems/Elasticity/FirstOrderSystem.hpp
@@ -64,8 +64,9 @@ struct FirstOrderSystem {
   using fields_tag =
       ::Tags::Variables<tmpl::append<primal_fields, auxiliary_fields>>;
 
-  using fluxes = Fluxes<Dim>;
-  using sources = Sources<Dim>;
+  // The system equations formulated as fluxes and sources
+  using fluxes_computer = Fluxes<Dim>;
+  using sources_computer = Sources<Dim>;
 
   // The tag of the operator to compute magnitudes on the manifold, e.g. to
   // normalize vectors on the faces of an element

--- a/src/Elliptic/Systems/Poisson/FirstOrderSystem.hpp
+++ b/src/Elliptic/Systems/Poisson/FirstOrderSystem.hpp
@@ -87,8 +87,9 @@ struct FirstOrderSystem {
   using fields_tag =
       ::Tags::Variables<tmpl::append<primal_fields, auxiliary_fields>>;
 
-  using fluxes = Fluxes<Dim, BackgroundGeometry>;
-  using sources = Sources<Dim, BackgroundGeometry>;
+  // The system equations formulated as fluxes and sources
+  using fluxes_computer = Fluxes<Dim, BackgroundGeometry>;
+  using sources_computer = Sources<Dim, BackgroundGeometry>;
 
   // The tag of the operator to compute magnitudes on the manifold, e.g. to
   // normalize vectors on the faces of an element

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeInhomogeneousBoundaryConditionsOnSource.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeInhomogeneousBoundaryConditionsOnSource.cpp
@@ -65,7 +65,7 @@ struct System {
   static constexpr size_t volume_dim = Dim;
   using fields_tag = Tags::Variables<tmpl::list<ScalarFieldTag>>;
   using primal_fields = tmpl::list<ScalarFieldTag>;
-  using fluxes = Fluxes<Dim>;
+  using fluxes_computer = Fluxes<Dim>;
   template <typename Tag>
   using magnitude_tag = Tags::EuclideanMagnitude<Tag>;
 };

--- a/tests/Unit/Elliptic/Systems/Poisson/Test_Equations.cpp
+++ b/tests/Unit/Elliptic/Systems/Poisson/Test_Equations.cpp
@@ -51,8 +51,8 @@ template <size_t Dim, Poisson::Geometry BackgroundGeometry>
 void test_computers(const DataVector& used_for_size) {
   CAPTURE(Dim);
   using system = Poisson::FirstOrderSystem<Dim, BackgroundGeometry>;
-  helpers::test_first_order_fluxes_computer<system>(typename system::fluxes{},
-                                                    used_for_size);
+  helpers::test_first_order_fluxes_computer<system>(
+      typename system::fluxes_computer{}, used_for_size);
   helpers::test_first_order_sources_computer<system>(used_for_size);
 }
 

--- a/tests/Unit/Helpers/Elliptic/FirstOrderSystem.hpp
+++ b/tests/Unit/Helpers/Elliptic/FirstOrderSystem.hpp
@@ -33,19 +33,20 @@ namespace TestHelpers {
 namespace elliptic {
 
 /*!
- * \brief Test the `System::fluxes` are functional
+ * \brief Test the `System::fluxes_computer` is functional
  *
- * This function tests the following properties of the `System::fluxes`:
+ * This function tests the following properties of the
+ * `System::fluxes_computer`:
  *
- * - They work with the `elliptic::first_order_fluxes` function.
- * - They can be applied to a DataBox, i.e. their argument tags are consistent
- *   with their apply function.
+ * - It works with the `elliptic::first_order_fluxes` function.
+ * - It can be applied to a DataBox, i.e. its argument tags are consistent with
+ *   its apply function.
  */
 template <typename System>
 void test_first_order_fluxes_computer(
-    const typename System::fluxes& fluxes_computer,
+    const typename System::fluxes_computer& fluxes_computer,
     const DataVector& used_for_size) {
-  using FluxesComputer = typename System::fluxes;
+  using FluxesComputer = typename System::fluxes_computer;
   static constexpr size_t volume_dim = System::volume_dim;
   using vars_tag = typename System::fields_tag;
   using primal_fields = typename System::primal_fields;
@@ -104,17 +105,18 @@ void test_first_order_fluxes_computer(
 }
 
 /*!
- * \brief Test the `System::sources` are functional
+ * \brief Test the `System::sources_computer` is functional
  *
- * This function tests the following properties of the `System::sources`:
+ * This function tests the following properties of the
+ * `System::sources_computer`:
  *
- * - They work with the `elliptic::first_order_sources` function.
- * - They can be applied to a DataBox, i.e. their argument tags are consistent
- *   with their apply function.
+ * - It works with the `elliptic::first_order_sources` function.
+ * - It can be applied to a DataBox, i.e. its argument tags are consistent with
+ *   its apply function.
  */
 template <typename System>
 void test_first_order_sources_computer(const DataVector& used_for_size) {
-  using SourcesComputer = typename System::sources;
+  using SourcesComputer = typename System::sources_computer;
   static constexpr size_t volume_dim = System::volume_dim;
   using vars_tag = typename System::fields_tag;
   using primal_fields = typename System::primal_fields;

--- a/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/FirstOrderEllipticSolutionsTestHelpers.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/FirstOrderEllipticSolutionsTestHelpers.hpp
@@ -42,7 +42,7 @@ template <typename System, typename SolutionType, typename... Maps,
           typename... FluxesArgs, typename... SourcesArgs>
 void verify_solution(
     const SolutionType& solution,
-    const typename System::fluxes& fluxes_computer,
+    const typename System::fluxes_computer& fluxes_computer,
     const Mesh<System::volume_dim>& mesh,
     const domain::CoordinateMap<Frame::Logical, Frame::Inertial, Maps...>
         coord_map,
@@ -74,10 +74,10 @@ void verify_solution(
       divergence(fluxes, mesh, coord_map.inv_jacobian(logical_coords));
   auto sources = std::apply(
       [&solution_fields, &fluxes](const auto&... expanded_sources_args) {
-        return ::elliptic::first_order_sources<System::volume_dim,
-                                               primal_fields, auxiliary_fields,
-                                               typename System::sources>(
-            solution_fields, fluxes, expanded_sources_args...);
+        return ::elliptic::first_order_sources<
+            System::volume_dim, primal_fields, auxiliary_fields,
+            typename System::sources_computer>(solution_fields, fluxes,
+                                               expanded_sources_args...);
       },
       sources_args);
   Variables<db::wrap_tags_in<Tags::OperatorAppliedTo, all_fields>>
@@ -142,7 +142,7 @@ template <typename System, typename SolutionType,
           typename PackageFluxesArgs>
 void verify_smooth_solution(
     const SolutionType& solution,
-    const typename System::fluxes& fluxes_computer,
+    const typename System::fluxes_computer& fluxes_computer,
     const domain::CoordinateMap<Frame::Logical, Frame::Inertial, Maps...>&
         coord_map,
     const double tolerance_offset, const double tolerance_scaling,
@@ -183,7 +183,7 @@ template <typename System, typename SolutionType,
           size_t Dim = System::volume_dim, typename... Maps>
 void verify_solution_with_power_law_convergence(
     const SolutionType& solution,
-    const typename System::fluxes& fluxes_computer,
+    const typename System::fluxes_computer& fluxes_computer,
     const domain::CoordinateMap<Frame::Logical, Frame::Inertial, Maps...>&
         coord_map,
     const double tolerance_offset, const double tolerance_pow) {

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_BentBeam.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_BentBeam.cpp
@@ -139,7 +139,7 @@ SPECTRE_TEST_CASE(
   {
     INFO("Test elasticity system with bent beam");
     using system = Elasticity::FirstOrderSystem<2>;
-    const typename system::fluxes fluxes_computer{};
+    const typename system::fluxes_computer fluxes_computer{};
     // Verify that the solution numerically solves the system
     FirstOrderEllipticSolutionsTestHelpers::verify_solution<system>(
         solution, fluxes_computer, mesh, coord_map,

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_HalfSpaceMirror.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_HalfSpaceMirror.cpp
@@ -132,7 +132,7 @@ SPECTRE_TEST_CASE(
     INFO("Test elasticity system with half-space mirror");
     // Verify that the solution numerically solves the system
     using system = Elasticity::FirstOrderSystem<3>;
-    const typename system::fluxes fluxes_computer{};
+    const typename system::fluxes_computer fluxes_computer{};
     using AffineMap = domain::CoordinateMaps::Affine;
     using AffineMap3D =
         domain::CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Lorentzian.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Lorentzian.cpp
@@ -85,7 +85,7 @@ SPECTRE_TEST_CASE(
     using system =
         Poisson::FirstOrderSystem<3, Poisson::Geometry::FlatCartesian>;
     const Poisson::Solutions::Lorentzian<3> solution{};
-    const typename system::fluxes fluxes_computer{};
+    const typename system::fluxes_computer fluxes_computer{};
     using AffineMap = domain::CoordinateMaps::Affine;
     using AffineMap3D =
         domain::CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
@@ -102,7 +102,7 @@ SPECTRE_TEST_CASE(
     // Euclidean metric. This is more a test of the system than of the solution.
     using system = Poisson::FirstOrderSystem<3, Poisson::Geometry::Curved>;
     const Poisson::Solutions::Lorentzian<3> solution{};
-    const typename system::fluxes fluxes_computer{};
+    const typename system::fluxes_computer fluxes_computer{};
     using AffineMap = domain::CoordinateMaps::Affine;
     using AffineMap3D =
         domain::CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Moustache.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Moustache.cpp
@@ -84,7 +84,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Poisson.Moustache",
     using system =
         Poisson::FirstOrderSystem<1, Poisson::Geometry::FlatCartesian>;
     const Poisson::Solutions::Moustache<1> solution{};
-    const typename system::fluxes fluxes_computer{};
+    const typename system::fluxes_computer fluxes_computer{};
     const domain::CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap>
         coord_map{{-1., 1., 0., 1.}};
     FirstOrderEllipticSolutionsTestHelpers::
@@ -98,7 +98,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Poisson.Moustache",
     using system =
         Poisson::FirstOrderSystem<2, Poisson::Geometry::FlatCartesian>;
     const Poisson::Solutions::Moustache<2> solution{};
-    const typename system::fluxes fluxes_computer{};
+    const typename system::fluxes_computer fluxes_computer{};
     using AffineMap2D =
         domain::CoordinateMaps::ProductOf2Maps<AffineMap, AffineMap>;
     const domain::CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap2D>

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_ProductOfSinusoids.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_ProductOfSinusoids.cpp
@@ -93,7 +93,7 @@ SPECTRE_TEST_CASE(
     using system =
         Poisson::FirstOrderSystem<1, Poisson::Geometry::FlatCartesian>;
     const Poisson::Solutions::ProductOfSinusoids<1> solution{{{0.5}}};
-    const typename system::fluxes fluxes_computer{};
+    const typename system::fluxes_computer fluxes_computer{};
     const domain::CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap>
         coord_map{{-1., 1., 0., M_PI}};
     FirstOrderEllipticSolutionsTestHelpers::verify_smooth_solution<system>(
@@ -107,7 +107,7 @@ SPECTRE_TEST_CASE(
     using system =
         Poisson::FirstOrderSystem<2, Poisson::Geometry::FlatCartesian>;
     const Poisson::Solutions::ProductOfSinusoids<2> solution{{{0.5, 0.5}}};
-    const typename system::fluxes fluxes_computer{};
+    const typename system::fluxes_computer fluxes_computer{};
     using AffineMap2D =
         domain::CoordinateMaps::ProductOf2Maps<AffineMap, AffineMap>;
     const domain::CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap2D>
@@ -123,7 +123,7 @@ SPECTRE_TEST_CASE(
     using system =
         Poisson::FirstOrderSystem<3, Poisson::Geometry::FlatCartesian>;
     const Poisson::Solutions::ProductOfSinusoids<3> solution{{{0.5, 0.5, 0.5}}};
-    const typename system::fluxes fluxes_computer{};
+    const typename system::fluxes_computer fluxes_computer{};
     using AffineMap3D =
         domain::CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
     const domain::CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap3D>


### PR DESCRIPTION
## Proposed changes

Only renames `fluxes` -> `fluxes_computer` and `sources` -> `sources_computer`. This is to avoid name clashes when I add flux tags-lists to the systems. I'll do that to give the flux tensors the appropriate symmetries, e.g. the flux for the elasticity system is the symmetric stress.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
