### PR TITLE
Add functions to compute interface projection operators

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -15,6 +15,7 @@ spectre_target_sources(
   InverseSpacetimeMetric.cpp
   KerrSchildCoords.cpp
   Lapse.cpp
+  ProjectionOperators.cpp
   Ricci.cpp
   Shift.cpp
   SpacetimeMetric.cpp
@@ -37,6 +38,7 @@ spectre_target_headers(
   InverseSpacetimeMetric.hpp
   KerrSchildCoords.hpp
   Lapse.hpp
+  ProjectionOperators.hpp
   Ricci.hpp
   Shift.hpp
   SpacetimeMetric.hpp

--- a/src/PointwiseFunctions/GeneralRelativity/ProjectionOperators.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ProjectionOperators.cpp
@@ -1,0 +1,150 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/GeneralRelativity/ProjectionOperators.hpp"
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+namespace gr {
+template <size_t VolumeDim, typename Frame, typename DataType>
+tnsr::II<DataType, VolumeDim, Frame> transverse_projection_operator(
+    const tnsr::II<DataType, VolumeDim, Frame>& inverse_spatial_metric,
+    const tnsr::I<DataType, VolumeDim, Frame>& normal_vector) noexcept {
+  tnsr::II<DataType, VolumeDim, Frame> projection_tensor(
+      get_size(get<0>(normal_vector)));
+  transverse_projection_operator(make_not_null(&projection_tensor),
+                                 inverse_spatial_metric, normal_vector);
+  return projection_tensor;
+}
+
+template <size_t VolumeDim, typename Frame, typename DataType>
+void transverse_projection_operator(
+    const gsl::not_null<tnsr::II<DataType, VolumeDim, Frame>*>
+        projection_tensor,
+    const tnsr::II<DataType, VolumeDim, Frame>& inverse_spatial_metric,
+    const tnsr::I<DataType, VolumeDim, Frame>& normal_vector) noexcept {
+  destructive_resize_components(projection_tensor,
+                                get_size(get<0>(normal_vector)));
+
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    for (size_t j = i; j < VolumeDim; ++j) {
+      projection_tensor->get(i, j) =
+          inverse_spatial_metric.get(i, j) -
+          normal_vector.get(i) * normal_vector.get(j);
+    }
+  }
+}
+
+template <size_t VolumeDim, typename Frame, typename DataType>
+tnsr::ii<DataType, VolumeDim, Frame> transverse_projection_operator(
+    const tnsr::ii<DataType, VolumeDim, Frame>& spatial_metric,
+    const tnsr::i<DataType, VolumeDim, Frame>& normal_one_form) noexcept {
+  tnsr::ii<DataType, VolumeDim, Frame> projection_tensor(
+      get_size(get<0>(normal_one_form)));
+  transverse_projection_operator(make_not_null(&projection_tensor),
+                                 spatial_metric, normal_one_form);
+  return projection_tensor;
+}
+
+template <size_t VolumeDim, typename Frame, typename DataType>
+void transverse_projection_operator(
+    const gsl::not_null<tnsr::ii<DataType, VolumeDim, Frame>*>
+        projection_tensor,
+    const tnsr::ii<DataType, VolumeDim, Frame>& spatial_metric,
+    const tnsr::i<DataType, VolumeDim, Frame>& normal_one_form) noexcept {
+  destructive_resize_components(projection_tensor,
+                                get_size(get<0>(normal_one_form)));
+
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    for (size_t j = i; j < VolumeDim; ++j) {
+      projection_tensor->get(i, j) =
+          spatial_metric.get(i, j) -
+          normal_one_form.get(i) * normal_one_form.get(j);
+    }
+  }
+}
+
+template <size_t VolumeDim, typename Frame, typename DataType>
+tnsr::Ij<DataType, VolumeDim, Frame> transverse_projection_operator(
+    const tnsr::I<DataType, VolumeDim, Frame>& normal_vector,
+    const tnsr::i<DataType, VolumeDim, Frame>& normal_one_form) noexcept {
+  tnsr::Ij<DataType, VolumeDim, Frame> projection_tensor(
+      get_size(get<0>(normal_vector)));
+  transverse_projection_operator(make_not_null(&projection_tensor),
+                                 normal_vector, normal_one_form);
+  return projection_tensor;
+}
+
+template <size_t VolumeDim, typename Frame, typename DataType>
+void transverse_projection_operator(
+    const gsl::not_null<tnsr::Ij<DataType, VolumeDim, Frame>*>
+        projection_tensor,
+    const tnsr::I<DataType, VolumeDim, Frame>& normal_vector,
+    const tnsr::i<DataType, VolumeDim, Frame>& normal_one_form) noexcept {
+  destructive_resize_components(projection_tensor,
+                                get_size(get<0>(normal_vector)));
+
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    for (size_t j = 0; j < VolumeDim; ++j) {
+      projection_tensor->get(i, j) =
+          -normal_vector.get(i) * normal_one_form.get(j);
+    }
+    projection_tensor->get(i, i) += 1.;
+  }
+}
+// @}
+}  // namespace gr
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                               \
+  template tnsr::II<DTYPE(data), DIM(data), FRAME(data)>                   \
+  gr::transverse_projection_operator(                                      \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                 \
+          inverse_spatial_metric,                                          \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>&                  \
+          normal_vector) noexcept;                                         \
+  template tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>                   \
+  gr::transverse_projection_operator(                                      \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& spatial_metric, \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&                  \
+          normal_one_form) noexcept;                                       \
+  template tnsr::Ij<DTYPE(data), DIM(data), FRAME(data)>                   \
+  gr::transverse_projection_operator(                                      \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& normal_vector,   \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&                  \
+          normal_one_form) noexcept;                                       \
+  template void gr::transverse_projection_operator(                        \
+      const gsl::not_null<tnsr::II<DTYPE(data), DIM(data), FRAME(data)>*>  \
+          projection_tensor,                                               \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                 \
+          inverse_spatial_metric,                                          \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>&                  \
+          normal_vector) noexcept;                                         \
+  template void gr::transverse_projection_operator(                        \
+      const gsl::not_null<tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>*>  \
+          projection_tensor,                                               \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& spatial_metric, \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&                  \
+          normal_one_form) noexcept;                                       \
+  template void gr::transverse_projection_operator(                        \
+      const gsl::not_null<tnsr::Ij<DTYPE(data), DIM(data), FRAME(data)>*>  \
+          projection_tensor,                                               \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& normal_vector,   \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&                  \
+          normal_one_form) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
+                        (Frame::Grid, Frame::Inertial))
+
+#undef DIM
+#undef DTYPE
+#undef FRAME
+#undef INSTANTIATE
+/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/ProjectionOperators.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ProjectionOperators.hpp
@@ -1,0 +1,83 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+
+/// \cond
+namespace gsl {
+template <typename>
+struct not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace gr {
+
+// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute projection operator onto an interface
+ *
+ * \details Returns the operator \f$P^{ij} = g^{ij} - n^i n^j\f$,
+ * where \f$g^{ij}\f$ is the inverse spatial metric, and
+ * \f$n^i\f$ is the normal vector to the interface in question.
+ *
+ */
+template <size_t VolumeDim, typename Frame, typename DataType>
+tnsr::II<DataType, VolumeDim, Frame> transverse_projection_operator(
+    const tnsr::II<DataType, VolumeDim, Frame>& inverse_spatial_metric,
+    const tnsr::I<DataType, VolumeDim, Frame>& normal_vector) noexcept;
+
+template <size_t VolumeDim, typename Frame, typename DataType>
+void transverse_projection_operator(
+    gsl::not_null<tnsr::II<DataType, VolumeDim, Frame>*> projection_tensor,
+    const tnsr::II<DataType, VolumeDim, Frame>& inverse_spatial_metric,
+    const tnsr::I<DataType, VolumeDim, Frame>& normal_vector) noexcept;
+// @}
+
+// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute projection operator onto an interface
+ *
+ * \details Returns the operator \f$P_{ij} = g_{ij} - n_i n_j\f$,
+ * where \f$ g_{ij}\f$ is the spatial metric, and \f$ n_i\f$ is
+ * the normal one-form to the interface in question.
+ */
+template <size_t VolumeDim, typename Frame, typename DataType>
+tnsr::ii<DataType, VolumeDim, Frame> transverse_projection_operator(
+    const tnsr::ii<DataType, VolumeDim, Frame>& spatial_metric,
+    const tnsr::i<DataType, VolumeDim, Frame>& normal_one_form) noexcept;
+
+template <size_t VolumeDim, typename Frame, typename DataType>
+void transverse_projection_operator(
+    gsl::not_null<tnsr::ii<DataType, VolumeDim, Frame>*> projection_tensor,
+    const tnsr::ii<DataType, VolumeDim, Frame>& spatial_metric,
+    const tnsr::i<DataType, VolumeDim, Frame>& normal_one_form) noexcept;
+// @}
+
+// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute projection operator onto an interface
+ *
+ * \details Returns the operator \f$P^{i}_{j} = \delta^{i}_{j} - n^i n_j\f$,
+ * where \f$n^i\f$ and \f$n_i\f$ are the normal vector and normal one-form
+ * to the interface in question.
+ */
+template <size_t VolumeDim, typename Frame, typename DataType>
+tnsr::Ij<DataType, VolumeDim, Frame> transverse_projection_operator(
+    const tnsr::I<DataType, VolumeDim, Frame>& normal_vector,
+    const tnsr::i<DataType, VolumeDim, Frame>& normal_one_form) noexcept;
+
+template <size_t VolumeDim, typename Frame, typename DataType>
+void transverse_projection_operator(
+    gsl::not_null<tnsr::Ij<DataType, VolumeDim, Frame>*> projection_tensor,
+    const tnsr::I<DataType, VolumeDim, Frame>& normal_vector,
+    const tnsr::i<DataType, VolumeDim, Frame>& normal_one_form) noexcept;
+// @}
+}  // namespace gr

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   Test_ComputeSpacetimeQuantities.cpp
   Test_IndexManipulation.cpp
   Test_KerrSchildCoords.cpp
+  Test_ProjectionOperators.cpp
   Test_Ricci.cpp
   Test_Tags.cpp
   Test_WeylElectric.cpp

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/ProjectionOperators.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/ProjectionOperators.py
@@ -1,0 +1,21 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def transverse_projection_operator(spatial_metric_or_its_inverse,
+                                   normal_vector_or_one_form):
+    dim_offset = np.shape(normal_vector_or_one_form)[0] - np.shape(
+        spatial_metric_or_its_inverse)[1]
+    if dim_offset != 0 and dim_offset != 1:
+        raise RuntimeError("Incompatible inputs passed")
+    return (spatial_metric_or_its_inverse -
+            np.einsum('i,j->ij', normal_vector_or_one_form[dim_offset:],
+                      normal_vector_or_one_form[dim_offset:]))
+
+
+def transverse_projection_operator_mixed_from_spatial_input(
+    normal_vector, normal_one_form):
+    return (np.eye(np.shape(normal_vector)[0]) -
+            np.einsum('i,j->ij', normal_vector, normal_one_form))

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ProjectionOperators.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ProjectionOperators.cpp
@@ -1,0 +1,248 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Side.hpp"
+#include "Domain/Tags.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ProjectionOperators.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
+
+namespace {
+template <size_t SpatialDim, typename DataType>
+void test_projection_operator(const DataType& used_for_size) {
+  {
+    tnsr::II<DataType, SpatialDim, Frame::Inertial> (*f)(
+        const tnsr::II<DataType, SpatialDim, Frame::Inertial>&,
+        const tnsr::I<DataType, SpatialDim, Frame::Inertial>&) =
+        &gr::transverse_projection_operator<SpatialDim, Frame::Inertial,
+                                            DataType>;
+    pypp::check_with_random_values<1>(f, "ProjectionOperators",
+                                      "transverse_projection_operator",
+                                      {{{-1., 1.}}}, used_for_size);
+  }
+
+  {
+    tnsr::ii<DataType, SpatialDim, Frame::Inertial> (*f)(
+        const tnsr::ii<DataType, SpatialDim, Frame::Inertial>&,
+        const tnsr::i<DataType, SpatialDim, Frame::Inertial>&) =
+        &gr::transverse_projection_operator<SpatialDim, Frame::Inertial,
+                                            DataType>;
+    pypp::check_with_random_values<1>(f, "ProjectionOperators",
+                                      "transverse_projection_operator",
+                                      {{{-1., 1.}}}, used_for_size);
+  }
+
+  {
+    tnsr::Ij<DataType, SpatialDim, Frame::Inertial> (*f)(
+        const tnsr::I<DataType, SpatialDim, Frame::Inertial>&,
+        const tnsr::i<DataType, SpatialDim, Frame::Inertial>&) =
+        &gr::transverse_projection_operator<SpatialDim, Frame::Inertial,
+                                            DataType>;
+    pypp::check_with_random_values<1>(
+        f, "ProjectionOperators",
+        "transverse_projection_operator_mixed_from_spatial_input",
+        {{{-1., 1.}}}, used_for_size);
+  }
+}
+}  // namespace
+
+namespace {
+using Affine = domain::CoordinateMaps::Affine;
+using Affine3D = domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+using frame = Frame::Inertial;
+constexpr size_t SpatialDim = 3;
+
+// Test projection operators by comparing to values from SpEC
+void test_spatial_projection_tensors_3D(
+    const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound) noexcept {
+  // Setup grid
+  Mesh<SpatialDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Setup coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  const Direction<SpatialDim> direction(1, Side::Upper);  // +y direction
+  const size_t slice_grid_points =
+      mesh.extents().slice_away(direction.dimension()).product();
+  const auto inertial_coords = [&slice_grid_points, &lower_bound]() {
+    tnsr::I<DataVector, SpatialDim, frame> tmp(slice_grid_points, 0.);
+    // +y direction
+    get<1>(tmp) = 0.5;
+    for (size_t i = 0; i < SpatialDim; ++i) {
+      for (size_t j = 0; j < SpatialDim; ++j) {
+        get<0>(tmp)[i * SpatialDim + j] =
+            lower_bound[0] + 0.5 * static_cast<double>(i);
+        get<2>(tmp)[i * SpatialDim + j] =
+            lower_bound[2] + 0.5 * static_cast<double>(j);
+      }
+    }
+    return tmp;
+  }();
+
+  // 1. Projection IJ
+  auto local_inverse_spatial_metric =
+      make_with_value<tnsr::II<DataVector, SpatialDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+  auto local_unit_interface_normal_vector =
+      make_with_value<tnsr::I<DataVector, SpatialDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+  auto local_spatial_projection_IJ =
+      make_with_value<tnsr::II<DataVector, SpatialDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+
+  // Setting inverse_spatial_metric to compare with values from SpEC
+  for (size_t i = 0; i < get<0>(inertial_coords).size(); ++i) {
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      local_inverse_spatial_metric.get(0, j)[i] = 41.;
+      local_inverse_spatial_metric.get(1, j)[i] = 43.;
+      local_inverse_spatial_metric.get(2, j)[i] = 47.;
+    }
+  }
+  // Setting unit_interface_normal_vector to compare with values from SpEC
+  get<0>(local_unit_interface_normal_vector) = -1.;
+  get<1>(local_unit_interface_normal_vector) = 1.;
+  get<2>(local_unit_interface_normal_vector) = 1.;
+
+  // Call tested function
+  gr::transverse_projection_operator(
+      make_not_null(&local_spatial_projection_IJ), local_inverse_spatial_metric,
+      local_unit_interface_normal_vector);
+
+  // Initialize with values from SpEC
+  auto spec_spatial_projection_IJ =
+      make_with_value<tnsr::II<DataVector, SpatialDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+  {
+    const std::array<double, 9> spec_vals = {
+        {40., 42., 42., 42., 42., 42., 42., 42., 46.}};
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      for (size_t k = j; k < SpatialDim; ++k) {
+        spec_spatial_projection_IJ.get(j, k) =
+            gsl::at(spec_vals, j * SpatialDim + k);
+      }
+    }
+  }
+
+  // Compare values returned to those from SpEC
+  CHECK_ITERABLE_APPROX(local_spatial_projection_IJ,
+                        spec_spatial_projection_IJ);
+
+  // 2. Projection ij
+  auto local_spatial_metric =
+      make_with_value<tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+  auto local_unit_interface_normal_one_form =
+      make_with_value<tnsr::i<DataVector, SpatialDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+  auto local_spatial_projection_ij =
+      make_with_value<tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+
+  // Setting inverse_spatial_metric to compare with values from SpEC
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    local_spatial_metric.get(0, i) = 263.;
+    local_spatial_metric.get(1, i) = 269.;
+    local_spatial_metric.get(2, i) = 271.;
+  }
+  // Setting unit_interface_normal_vector to compare with values from SpEC
+  get<0>(local_unit_interface_normal_one_form) = -1.;
+  get<1>(local_unit_interface_normal_one_form) = 1.;
+  get<2>(local_unit_interface_normal_one_form) = 1.;
+
+  // Call tested function
+  gr::transverse_projection_operator(
+      make_not_null(&local_spatial_projection_ij), local_spatial_metric,
+      local_unit_interface_normal_one_form);
+
+  // Initialize with values from SpEC
+  auto spec_spatial_projection_ij =
+      make_with_value<tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+  {
+    const std::array<double, 9> spec_vals = {
+        {262., 264., 264., 264., 268., 268., 264., 268., 270.}};
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      for (size_t k = j; k < SpatialDim; ++k) {
+        spec_spatial_projection_ij.get(j, k) =
+            gsl::at(spec_vals, j * SpatialDim + k);
+      }
+    }
+  }
+
+  // Compare values returned to those from SpEC
+  CHECK_ITERABLE_APPROX(local_spatial_projection_ij,
+                        spec_spatial_projection_ij);
+
+  // 3. Projection Ij
+  auto local_spatial_projection_Ij =
+      make_with_value<tnsr::Ij<DataVector, SpatialDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+
+  // Call tested function
+  gr::transverse_projection_operator(
+      make_not_null(&local_spatial_projection_Ij),
+      local_unit_interface_normal_vector, local_unit_interface_normal_one_form);
+
+  // Initialize with values from SpEC
+  auto spec_spatial_projection_Ij =
+      make_with_value<tnsr::Ij<DataVector, SpatialDim, Frame::Inertial>>(
+          inertial_coords, 0.);
+  {
+    const std::array<double, 9> spec_vals = {
+        {0., 1., 1., 1., 0., -1., 1., -1., 0.}};
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      for (size_t k = 0; k < SpatialDim; ++k) {
+        spec_spatial_projection_Ij.get(j, k) =
+            gsl::at(spec_vals, j * SpatialDim + k);
+      }
+    }
+  }
+
+  // Compare values returned to those from SpEC
+  CHECK_ITERABLE_APPROX(local_spatial_projection_Ij,
+                        spec_spatial_projection_Ij);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.ProjectionOps",
+                  "[PointwiseFunctions][Unit]") {
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "PointwiseFunctions/GeneralRelativity/");
+
+  GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
+
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_projection_operator, (1, 2, 3));
+
+  const size_t grid_size = 3;
+  const std::array<double, 3> lower_bound{{299., -0.5, -0.5}};
+  const std::array<double, 3> upper_bound{{300., 0.5, 0.5}};
+
+  test_spatial_projection_tensors_3D(grid_size, lower_bound, upper_bound);
+}


### PR DESCRIPTION
## Proposed changes

Add functions to compute operators to project spatial tensors onto an interface.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

