### PR TITLE
Move penalty function for elliptic DG to its own file

### DIFF
--- a/src/Elliptic/DiscontinuousGalerkin/CMakeLists.txt
+++ b/src/Elliptic/DiscontinuousGalerkin/CMakeLists.txt
@@ -16,6 +16,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   DgElementArray.hpp
+  DiscontinuousGalerkin.hpp
   ImposeBoundaryConditions.hpp
   ImposeInhomogeneousBoundaryConditionsOnSource.hpp
   InitializeFirstOrderOperator.hpp

--- a/src/Elliptic/DiscontinuousGalerkin/CMakeLists.txt
+++ b/src/Elliptic/DiscontinuousGalerkin/CMakeLists.txt
@@ -5,6 +5,12 @@ set(LIBRARY EllipticDg)
 
 add_spectre_library(${LIBRARY})
 
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  Penalty.cpp
+)
+
 spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
@@ -13,6 +19,7 @@ spectre_target_headers(
   ImposeBoundaryConditions.hpp
   ImposeInhomogeneousBoundaryConditionsOnSource.hpp
   InitializeFirstOrderOperator.hpp
+  Penalty.hpp
   Tags.hpp
   )
 

--- a/src/Elliptic/DiscontinuousGalerkin/DiscontinuousGalerkin.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/DiscontinuousGalerkin.hpp
@@ -1,0 +1,13 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Documents the elliptic::dg namespace
+
+#pragma once
+
+namespace elliptic {
+/// Functionality related to discontinuous Galerkin discretizations of elliptic
+/// equations
+namespace dg {}
+}  // namespace elliptic

--- a/src/Elliptic/DiscontinuousGalerkin/NumericalFluxes/CMakeLists.txt
+++ b/src/Elliptic/DiscontinuousGalerkin/NumericalFluxes/CMakeLists.txt
@@ -1,12 +1,6 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-spectre_target_sources(
-  EllipticDg
-  PRIVATE
-  FirstOrderInternalPenalty.cpp
-  )
-
 spectre_target_headers(
   EllipticDg
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src

--- a/src/Elliptic/DiscontinuousGalerkin/NumericalFluxes/FirstOrderInternalPenalty.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/NumericalFluxes/FirstOrderInternalPenalty.hpp
@@ -15,6 +15,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Domain/FaceNormal.hpp"
 #include "Domain/Tags.hpp"
+#include "Elliptic/DiscontinuousGalerkin/Penalty.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Protocols.hpp"
 #include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
@@ -33,25 +34,6 @@ struct Normalized;
 
 /// Numerical fluxes for elliptic systems
 namespace elliptic::dg::NumericalFluxes {
-
-/*!
- * \brief The penalty factor in internal penalty fluxes
- *
- * The penalty factor is computed as
- *
- * \f{equation}
- * \sigma = C \frac{N_\text{points}^2}{h}
- * \f}
- *
- * where \f$N_\text{points} = 1 + N_p\f$ is the number of points (or one plus
- * the polynomial degree) and \f$h\f$ is a measure of the element size. Both
- * quantities are taken perpendicular to the face of the DG element that the
- * penalty is being computed on. \f$C\f$ is the *penalty parameter*.
- *
- * \see `elliptic::dg::NumericalFluxes::FirstOrderInternalPenalty` for details
- */
-DataVector penalty(const DataVector& element_size, size_t num_points,
-                   double penalty_parameter) noexcept;
 
 /*!
  * \ingroup DiscontinuousGalerkinGroup
@@ -325,7 +307,7 @@ struct FirstOrderInternalPenalty<Dim, FluxesComputerTag,
           AuxiliaryFieldTags>::type&... ndot_ndot_aux_flux_exteriors,
       const Scalar<DataVector>& element_size_exterior,
       const size_t perpendicular_num_points_exterior) const noexcept {
-    const auto penalty = ::elliptic::dg::NumericalFluxes::penalty(
+    const auto penalty = ::elliptic::dg::penalty(
         min(get(element_size_interior), get(element_size_exterior)),
         std::max(perpendicular_num_points_interior,
                  perpendicular_num_points_exterior),
@@ -389,7 +371,7 @@ struct FirstOrderInternalPenalty<Dim, FluxesComputerTag,
       const Scalar<DataVector>& face_normal_magnitude,
       const FluxesComputer& fluxes_computer,
       const FluxesArgs&... fluxes_args) const noexcept {
-    const auto penalty = ::elliptic::dg::NumericalFluxes::penalty(
+    const auto penalty = ::elliptic::dg::penalty(
         2. / get(face_normal_magnitude),
         volume_mesh.extents(direction.dimension()), penalty_parameter_);
 

--- a/src/Elliptic/DiscontinuousGalerkin/Penalty.cpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Penalty.cpp
@@ -1,18 +1,18 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include "Elliptic/DiscontinuousGalerkin/NumericalFluxes/FirstOrderInternalPenalty.hpp"
+#include "Elliptic/DiscontinuousGalerkin/Penalty.hpp"
 
-#include <cmath>
 #include <cstddef>
 
 #include "DataStructures/DataVector.hpp"
+#include "Utilities/ConstantExpressions.hpp"
 
-namespace elliptic::dg::NumericalFluxes {
+namespace elliptic::dg {
 
 DataVector penalty(const DataVector& element_size, const size_t num_points,
                    const double penalty_parameter) noexcept {
   return penalty_parameter * square(num_points) / element_size;
 }
 
-}  // namespace elliptic::dg::NumericalFluxes
+}  // namespace elliptic::dg

--- a/src/Elliptic/DiscontinuousGalerkin/Penalty.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Penalty.hpp
@@ -1,0 +1,30 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+
+namespace elliptic::dg {
+
+/*!
+ * \brief The penalty factor in internal penalty fluxes
+ *
+ * The penalty factor is computed as
+ *
+ * \f{equation}
+ * \sigma = C \frac{N_\text{points}^2}{h}
+ * \f}
+ *
+ * where \f$N_\text{points} = 1 + N_p\f$ is the number of points (or one plus
+ * the polynomial degree) and \f$h\f$ is a measure of the element size. Both
+ * quantities are taken perpendicular to the face of the DG element that the
+ * penalty is being computed on. \f$C\f$ is the "penalty parameter". For details
+ * see section 7.2 in \cite HesthavenWarburton.
+ */
+DataVector penalty(const DataVector& element_size, size_t num_points,
+                   double penalty_parameter) noexcept;
+
+}  // namespace elliptic::dg

--- a/src/Elliptic/DiscontinuousGalerkin/Tags.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Tags.hpp
@@ -7,7 +7,6 @@
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
-/// Functionality related to elliptic discontinuous Galerkin schemes
 namespace elliptic::dg {
 /// Option tags related to elliptic discontinuous Galerkin schemes
 namespace OptionTags {

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   Test_ImposeBoundaryConditions.cpp
   Test_ImposeInhomogeneousBoundaryConditionsOnSource.cpp
   Test_InitializeFirstOrderOperator.cpp
+  Test_Penalty.cpp
   Test_Tags.cpp
   )
 
@@ -16,10 +17,17 @@ add_test_library(
   ${LIBRARY}
   "Elliptic/DiscontinuousGalerkin/"
   "${LIBRARY_SOURCES}"
-  "DataStructures;Domain;DomainStructure;EllipticDg;ErrorHandling;Parallel;Utilities"
+  ""
   )
 
-add_dependencies(
+target_link_libraries(
   ${LIBRARY}
-  module_GlobalCache
+  PRIVATE
+  DataStructures
+  Domain
+  DomainStructure
+  EllipticDg
+  ErrorHandling
+  Parallel
+  Utilities
   )

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_Penalty.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_Penalty.cpp
@@ -1,0 +1,19 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "Elliptic/DiscontinuousGalerkin/Penalty.hpp"
+
+SPECTRE_TEST_CASE("Unit.Elliptic.DG.Penalty", "[Unit][Elliptic]") {
+  const size_t num_points = 3;
+  const DataVector element_size{1., 2., 3.};
+  const double penalty_parameter = 1.5;
+  const DataVector expected_penalty{13.5, 6.75, 4.5};
+  CHECK_ITERABLE_APPROX(
+      elliptic::dg::penalty(element_size, num_points, penalty_parameter),
+      expected_penalty);
+}


### PR DESCRIPTION
## Proposed changes

Move the penalty function out of the numerical flux class, because
the class will be deleted with the upcoming changes to the elliptic
DG operator.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
