### PR TITLE
Loosen restrictions on divergence return buffer tags

### DIFF
--- a/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
@@ -63,11 +63,11 @@ auto divergence(
         inverse_jacobian) noexcept
     -> Variables<db::wrap_tags_in<Tags::div, FluxTags>>;
 
-template <typename FluxTags, size_t Dim, typename DerivativeFrame>
+template <typename... DivTags, typename... FluxTags, size_t Dim,
+          typename DerivativeFrame>
 void divergence(
-    gsl::not_null<Variables<db::wrap_tags_in<Tags::div, FluxTags>>*>
-        divergence_of_F,
-    const Variables<FluxTags>& F, const Mesh<Dim>& mesh,
+    gsl::not_null<Variables<tmpl::list<DivTags...>>*> divergence_of_F,
+    const Variables<tmpl::list<FluxTags...>>& F, const Mesh<Dim>& mesh,
     const InverseJacobian<DataVector, Dim, Frame::Logical, DerivativeFrame>&
         inverse_jacobian) noexcept;
 // @}
@@ -127,11 +127,9 @@ struct DivVariablesCompute : db::add_tag_prefix<div, Tag>, db::ComputeTag {
  public:
   using base = db::add_tag_prefix<div, Tag>;
   using return_type = typename base::type;
-  static constexpr void (*function)(const gsl::not_null<return_type*>,
-                                    const typename Tag::type&, const Mesh<dim>&,
-                                    const typename InverseJacobianTag::type&) =
-      divergence<typename Tag::type::tags_list, dim,
-                 typename tmpl::back<inv_jac_indices>::Frame>;
+  static constexpr void (*function)(
+      const gsl::not_null<return_type*>, const typename Tag::type&,
+      const Mesh<dim>&, const typename InverseJacobianTag::type&) = divergence;
   using argument_tags =
       tmpl::list<Tag, domain::Tags::Mesh<dim>, InverseJacobianTag>;
 };


### PR DESCRIPTION
## Proposed changes

Allow the divergence function to write the result into any Variables
that holds compatible tags, not only `::Tags::div<FluxTags>`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
