### PR TITLE
Add getter for remote mortar data

### DIFF
--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/SimpleMortarData.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/SimpleMortarData.hpp
@@ -43,6 +43,15 @@ class SimpleMortarData {
     return *local_data_;
   };
 
+  /// Retrieve the remote data at `temporal_id`
+  const RemoteVars& remote_data(const TemporalId& temporal_id) const noexcept {
+    ASSERT(remote_data_, "Remote data not available.");
+    ASSERT(temporal_id == temporal_id_,
+           "Only have remote data at temporal_id "
+               << temporal_id_ << ", but requesting at " << temporal_id);
+    return *remote_data_;
+  };
+
  private:
   TemporalId temporal_id_{};
   std::optional<LocalVars> local_data_{};

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_SimpleMortarData.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_SimpleMortarData.cpp
@@ -20,6 +20,8 @@ SPECTRE_TEST_CASE("Unit.DG.SimpleMortarData", "[Unit][NumericalAlgorithms]") {
   data.local_insert(0, "string 1");
   data = serialize_and_deserialize(data);
   data.remote_insert(0, 1.234);
+  CHECK(data.local_data(0) == "string 1");
+  CHECK(data.remote_data(0) == 1.234);
   CHECK(data.extract() == std::make_pair("string 1"s, 1.234));
   data = serialize_and_deserialize(data);
   data.remote_insert(1, 2.345);


### PR DESCRIPTION
## Proposed changes

The elliptic DG operator needs this to look up mortar data and apply boundary corrections for the auxiliary variables before actually extracting and removing the mortar data when applying boundary corrections for the primal variables.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
