### PR TITLE
Evolution: remove InterfaceTags, support unaligned meshes, stop copying fluxes

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
@@ -271,11 +271,24 @@ namespace evolution::dg::Actions {
  */
 template <typename Metavariables>
 struct ComputeTimeDerivative {
+ private:
+  template <typename LocalMetaVars, typename = std::void_t<>>
+  struct GetFluxInboxTag {
+    using type = tmpl::list<>;
+  };
+
+  template <typename LocalMetaVars>
+  struct GetFluxInboxTag<LocalMetaVars,
+                         std::void_t<typename LocalMetaVars::boundary_scheme>> {
+    using type = tmpl::list<
+        ::dg::FluxesInboxTag<typename Metavariables::boundary_scheme>>;
+  };
+
  public:
-  using inbox_tags =
-      tmpl::list<::dg::FluxesInboxTag<typename Metavariables::boundary_scheme>,
-                 evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<
-                     Metavariables::volume_dim>>;
+  using inbox_tags = tmpl::append<
+      typename GetFluxInboxTag<Metavariables>::type,
+      tmpl::list<evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<
+          Metavariables::volume_dim>>>;
   using const_global_cache_tags = tmpl::conditional_t<
       detail::has_boundary_correction_v<typename Metavariables::system>,
       tmpl::list<::dg::Tags::Formulation, evolution::Tags::BoundaryCorrection<

--- a/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.cpp
@@ -25,9 +25,7 @@ template <size_t Dim>
 auto Mortars<Dim>::apply_impl(
     const std::vector<std::array<size_t, Dim>>& initial_extents,
     const Spectral::Quadrature quadrature, const Element<Dim>& element,
-    const TimeStepId& next_temporal_id,
-    const std::unordered_map<Direction<Dim>, Mesh<Dim - 1>>&
-        interface_meshes) noexcept
+    const TimeStepId& next_temporal_id, const Mesh<Dim>& volume_mesh) noexcept
     -> std::tuple<
         MortarMap<evolution::dg::MortarData<Dim>>, MortarMap<Mesh<Dim - 1>>,
         MortarMap<std::array<Spectral::MortarSize, Dim - 1>>,
@@ -50,7 +48,7 @@ auto Mortars<Dim>::apply_impl(
       mortar_data[mortar_id];  // Default initialize data
       mortar_meshes.emplace(
           mortar_id,
-          ::dg::mortar_mesh(interface_meshes.at(direction),
+          ::dg::mortar_mesh(volume_mesh.slice_away(direction.dimension()),
                             ::domain::Initialization::create_initial_mesh(
                                 initial_extents, neighbor, quadrature,
                                 neighbors.orientation())

--- a/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp
@@ -52,9 +52,6 @@ namespace evolution::dg::Initialization {
  *   - `Tags::Element<Dim>`
  *   - `Tags::Mesh<Dim>`
  *   - `BoundaryScheme::receive_temporal_id`
- *   - `Tags::Interface<Tags::InternalDirections<Dim>, Tags::Mesh<Dim - 1>>`
- *   - `Tags::Interface<
- *   Tags::BoundaryDirectionsInterior<Dim>, Tags::Mesh<Dim - 1>>`
  *
  * DataBox changes:
  * - Adds:
@@ -62,6 +59,7 @@ namespace evolution::dg::Initialization {
  *   - `Tags::MortarMesh<Dim>`
  *   - `Tags::MortarSize<Dim>`
  *   - `Tags::MortarNextTemporalId<Dim>`
+ *   - `evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>`
  * - Removes: nothing
  * - Modifies: nothing
  */
@@ -98,9 +96,7 @@ struct Mortars {
                      db::get<evolution::dg::Tags::Quadrature>(box),
                      db::get<::domain::Tags::Element<Dim>>(box),
                      db::get<::Tags::TimeStepId>(box),
-                     db::get<::domain::Tags::Interface<
-                         ::domain::Tags::InternalDirections<Dim>,
-                         ::domain::Tags::Mesh<Dim - 1>>>(box));
+                     db::get<::domain::Tags::Mesh<Dim>>(box));
       ::Initialization::mutate_assign<simple_tags>(
           make_not_null(&box), std::move(mortar_data), std::move(mortar_meshes),
           std::move(mortar_sizes), std::move(mortar_next_temporal_ids),
@@ -126,7 +122,6 @@ struct Mortars {
   apply_impl(const std::vector<std::array<size_t, Dim>>& initial_extents,
              Spectral::Quadrature quadrature, const Element<Dim>& element,
              const TimeStepId& next_temporal_id,
-             const std::unordered_map<Direction<Dim>, Mesh<Dim - 1>>&
-                 interface_meshes) noexcept;
+             const Mesh<Dim>& volume_mesh) noexcept;
 };
 }  // namespace evolution::dg::Initialization

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
@@ -44,24 +44,6 @@ struct Var2 : db::SimpleTag {
 };
 
 template <size_t Dim>
-struct SimpleFaceNormalMagnitude
-    : db::ComputeTag,
-      ::Tags::Magnitude<domain::Tags::UnnormalizedFaceNormal<Dim>> {
-  using base = ::Tags::Magnitude<domain::Tags::UnnormalizedFaceNormal<Dim>>;
-  using return_type = typename base::type;
-  static void function(const gsl::not_null<return_type*> result,
-                       const Mesh<Dim - 1>& face_mesh,
-                       const Direction<Dim>& direction) noexcept {
-    result->get() =
-        DataVector{face_mesh.number_of_grid_points(),
-                   1.0 + (direction.side() == Side::Upper ? 1.0 : 0.5) +
-                       (direction.sign() == 1.0 ? 0.25 : 0.125)};
-  }
-  using argument_tags =
-      tmpl::list<domain::Tags::Mesh<Dim - 1>, domain::Tags::Direction<Dim>>;
-};
-
-template <size_t Dim>
 struct BoundaryTerms;
 
 template <size_t Dim>
@@ -277,30 +259,7 @@ struct component {
       domain::Tags::JacobianCompute<Metavariables::volume_dim, Frame::Logical,
                                     Frame::Inertial>,
       domain::Tags::DetInvJacobianCompute<Metavariables::volume_dim,
-                                          Frame::Logical, Frame::Inertial>,
-
-      domain::Tags::InternalDirectionsCompute<Metavariables::volume_dim>,
-      domain::Tags::InterfaceCompute<
-          internal_directions,
-          domain::Tags::Direction<Metavariables::volume_dim>>,
-      domain::Tags::InterfaceCompute<
-          internal_directions,
-          domain::Tags::InterfaceMesh<Metavariables::volume_dim>>,
-      domain::Tags::InterfaceCompute<
-          internal_directions,
-          SimpleFaceNormalMagnitude<Metavariables::volume_dim>>,
-
-      domain::Tags::BoundaryDirectionsInteriorCompute<
-          Metavariables::volume_dim>,
-      domain::Tags::InterfaceCompute<
-          boundary_directions_interior,
-          domain::Tags::Direction<Metavariables::volume_dim>>,
-      domain::Tags::InterfaceCompute<
-          boundary_directions_interior,
-          domain::Tags::InterfaceMesh<Metavariables::volume_dim>>,
-      domain::Tags::InterfaceCompute<
-          boundary_directions_interior,
-          SimpleFaceNormalMagnitude<Metavariables::volume_dim>>>;
+                                          Frame::Logical, Frame::Inertial>>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
@@ -11,7 +11,6 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "DataStructures/VariablesTag.hpp"
-#include "Domain/InterfaceComputeTags.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp"
 #include "Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp"
@@ -19,6 +18,7 @@
 #include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
 #include "Framework/ActionTesting.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/Evolution/DiscontinuousGalerkin/Actions/SystemType.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags/Formulation.hpp"
@@ -170,11 +170,9 @@ struct SetLocalMortarData {
       const ParallelComponent* const /*meta*/) noexcept {  // NOLINT
     constexpr size_t volume_dim = Metavariables::volume_dim;
     const auto& element = db::get<domain::Tags::Element<volume_dim>>(box);
+    const auto& volume_mesh = db::get<domain::Tags::Mesh<volume_dim>>(box);
     const auto& mortar_meshes =
         db::get<evolution::dg::Tags::MortarMesh<volume_dim>>(box);
-    const auto& face_meshes = db::get<
-        domain::Tags::Interface<domain::Tags::InternalDirections<volume_dim>,
-                                domain::Tags::Mesh<volume_dim - 1>>>(box);
     const auto& time_step_id = db::get<::Tags::TimeStepId>(box);
     const auto& next_time_step_id =
         db::get<::Tags::Next<::Tags::TimeStepId>>(box);
@@ -183,8 +181,29 @@ struct SetLocalMortarData {
     constexpr size_t number_of_dg_package_tags_components =
         Variables<mortar_tags_list>::number_of_independent_components;
 
+    MAKE_GENERATOR(generator);
+    std::uniform_real_distribution<> dist_positive(0.5, 1.);
+
+    using CovectorAndMag =
+        Variables<tmpl::list<evolution::dg::Tags::MagnitudeOfNormal,
+                             evolution::dg::Tags::NormalCovector<volume_dim>>>;
     for (const auto& [direction, neighbor_ids] : element.neighbors()) {
       size_t count = 0;
+      const Mesh<volume_dim - 1> face_mesh =
+          volume_mesh.slice_away(direction.dimension());
+      CovectorAndMag covector_and_mag{face_mesh.number_of_grid_points()};
+      get<evolution::dg::Tags::MagnitudeOfNormal>(covector_and_mag) =
+          make_with_random_values<Scalar<DataVector>>(
+              make_not_null(&generator), make_not_null(&dist_positive),
+              face_mesh.number_of_grid_points());
+      db::mutate<evolution::dg::Tags::NormalCovectorAndMagnitude<volume_dim>>(
+          make_not_null(&box),
+          [&covector_and_mag](const auto covector_and_mag_ptr,
+                              const auto& local_direction) {
+            (*covector_and_mag_ptr)[local_direction] = covector_and_mag;
+          },
+          direction);
+
       for (const auto& neighbor_id : neighbor_ids) {
         std::pair mortar_id{direction, neighbor_id};
         const Mesh<volume_dim - 1>& mortar_mesh = mortar_meshes.at(mortar_id);
@@ -199,14 +218,13 @@ struct SetLocalMortarData {
 
         db::mutate<evolution::dg::Tags::MortarData<volume_dim>>(
             make_not_null(&box),
-            [&face_meshes, &mortar_id, &next_time_step_id, &time_step_id,
+            [&face_mesh, &mortar_id, &next_time_step_id, &time_step_id,
              &type_erased_boundary_data_on_mortar](
                 const auto mortar_data_ptr) noexcept {
               mortar_data_ptr->at(mortar_id).insert_local_mortar_data(
                   Metavariables::local_time_stepping ? next_time_step_id
                                                      : time_step_id,
-                  face_meshes.at(mortar_id.first),
-                  std::move(type_erased_boundary_data_on_mortar));
+                  face_mesh, std::move(type_erased_boundary_data_on_mortar));
             });
         ++count;
       }
@@ -260,6 +278,7 @@ struct component {
                                     Frame::Inertial>,
       domain::Tags::DetInvJacobianCompute<Metavariables::volume_dim,
                                           Frame::Logical, Frame::Inertial>,
+
       domain::Tags::InternalDirectionsCompute<Metavariables::volume_dim>,
       domain::Tags::InterfaceCompute<
           internal_directions,
@@ -429,10 +448,6 @@ void test_impl(const Spectral::Quadrature quadrature,
       get_tag<evolution::dg::Tags::MortarData<Dim>>(runner, self_id);
 
   // "Send" mortar data to element
-  const auto& face_meshes =
-      get_tag<domain::Tags::Interface<domain::Tags::InternalDirections<Dim>,
-                                      domain::Tags::Mesh<Dim - 1>>>(runner,
-                                                                    self_id);
   const auto& mortar_meshes =
       get_tag<evolution::dg::Tags::MortarMesh<Dim>>(runner, self_id);
   using mortar_tags_list = typename BoundaryTerms<Dim>::dg_package_field_tags;
@@ -440,6 +455,7 @@ void test_impl(const Spectral::Quadrature quadrature,
       Variables<mortar_tags_list>::number_of_independent_components;
   for (const auto& [direction, neighbor_ids] : neighbors) {
     size_t count = 0;
+    const Mesh<Dim - 1> face_mesh = mesh.slice_away(direction.dimension());
     for (const auto& neighbor_id : neighbor_ids) {
       std::pair mortar_id{direction, neighbor_id};
       const Mesh<Dim - 1>& mortar_mesh = mortar_meshes.at(mortar_id);
@@ -452,7 +468,7 @@ void test_impl(const Spectral::Quadrature quadrature,
                     100 * count);
       std::tuple<Mesh<Dim - 1>, std::optional<std::vector<double>>,
                  std::optional<std::vector<double>>, ::TimeStepId>
-          data{face_meshes.at(direction),
+          data{face_mesh,
                {},
                {flux_data},
                {metavars::local_time_stepping ? next_time_step_id
@@ -465,7 +481,7 @@ void test_impl(const Spectral::Quadrature quadrature,
               time_step_id, std::pair{std::pair{direction, neighbor_id}, data});
       all_mortar_data.at(mortar_id).insert_neighbor_mortar_data(
           metavars::local_time_stepping ? next_time_step_id : time_step_id,
-          face_meshes.at(direction), flux_data);
+          face_mesh, flux_data);
       ++count;
     }
   }
@@ -566,19 +582,11 @@ void test_impl(const Spectral::Quadrature quadrature,
 
     // Lift the boundary terms from the face into the volume
     const auto& magnitude_of_face_normal =
-        mortar_id.second == ElementId<Dim>::external_boundary_id()
-            ? get_tag<domain::Tags::Interface<
-                  domain::Tags::BoundaryDirectionsInterior<Dim>,
-                  ::Tags::Magnitude<
-                      domain::Tags::UnnormalizedFaceNormal<Dim>>>>(runner,
-                                                                   self_id)
-                  .at(direction)
-            : get_tag<domain::Tags::Interface<
-                  domain::Tags::InternalDirections<Dim>,
-                  ::Tags::Magnitude<
-                      domain::Tags::UnnormalizedFaceNormal<Dim>>>>(runner,
-                                                                   self_id)
-                  .at(direction);
+        get<evolution::dg::Tags::MagnitudeOfNormal>(
+            *get_tag<evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>>(
+                 runner, self_id)
+                 .at(direction));
+
     if (mesh.quadrature(0) == Spectral::Quadrature::GaussLobatto) {
       // The lift_flux function lifts only on the slice, it does not add
       // the contribution to the volume.

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_Mortars.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_Mortars.cpp
@@ -11,7 +11,6 @@
 #include <utility>
 
 #include "DataStructures/DataBox/Tag.hpp"
-#include "Domain/InterfaceComputeTags.hpp"
 #include "Domain/Structure/CreateInitialMesh.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
@@ -48,23 +47,7 @@ struct component {
                  domain::Tags::Element<Metavariables::volume_dim>,
                  domain::Tags::Mesh<Metavariables::volume_dim>,
                  evolution::dg::Tags::Quadrature>;
-  using compute_tags = tmpl::list<
-      domain::Tags::InternalDirectionsCompute<Metavariables::volume_dim>,
-      domain::Tags::InterfaceCompute<
-          internal_directions,
-          domain::Tags::Direction<Metavariables::volume_dim>>,
-      domain::Tags::InterfaceCompute<
-          internal_directions,
-          domain::Tags::InterfaceMesh<Metavariables::volume_dim>>,
-
-      domain::Tags::BoundaryDirectionsInteriorCompute<
-          Metavariables::volume_dim>,
-      domain::Tags::InterfaceCompute<
-          boundary_directions_interior,
-          domain::Tags::Direction<Metavariables::volume_dim>>,
-      domain::Tags::InterfaceCompute<
-          boundary_directions_interior,
-          domain::Tags::InterfaceMesh<Metavariables::volume_dim>>>;
+  using compute_tags = tmpl::list<>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<


### PR DESCRIPTION
## Proposed changes

- The new evolution approach doesn't need any InterfaceTags after these changes. However, before this can be used in the evolution systems we still need boundary conditions to be completed.
- Making the `boundary_scheme` optional means we can completely remove them from some systems, making the transition easier.
- Add support for unaligned meshes, including tests (I couldn't find that the current code in develop actually tests unaligned meshes)
- Stop copying the fluxes over into the DataBox when using the new evolution scheme. Once the switch is complete we will remove the fluxes from the DataBox completely anyway, so the code has to work without the extra copy.

The major missing components in the new evolution scheme after this are:
- boundary conditions
- local time stepping support

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
