### PR TITLE
Restore behaviour of InitializeMortars

### DIFF
--- a/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp
+++ b/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp
@@ -112,7 +112,7 @@ struct InitializeDomain {
     }
     ElementMap<Dim, Frame::Inertial> element_map{
         element_id, my_block.stationary_map().get_clone()};
-    Initialization::mutate_assign<simple_tags>(
+    ::Initialization::mutate_assign<simple_tags>(
         make_not_null(&box), std::move(mesh), std::move(element),
         std::move(element_map));
 


### PR DESCRIPTION
## Proposed changes

Before this action was converted to use SetupDataBox it only initialized the "next" temporal ID when it was needed. This commit restores that behaviour.

This action will likely merge into the evolution and/or elliptic DG schemes in the near future. But until that happens I'd like to fix this bug.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
