### PR TITLE
Pypp: better error msg, better string support, factor normal vector boundary correction helper code

### DIFF
--- a/tests/Unit/Framework/Pypp.hpp
+++ b/tests/Unit/Framework/Pypp.hpp
@@ -271,7 +271,8 @@ struct ContainerPackAndUnpack<std::optional<T>, ConversionClassList,
 template <typename T, typename ConversionClassList>
 struct ContainerPackAndUnpack<
     T, ConversionClassList,
-    Requires<std::is_floating_point_v<T> or std::is_integral_v<T>>> {
+    Requires<std::is_floating_point_v<T> or std::is_integral_v<T> or
+             std::is_same_v<T, std::string>>> {
   using unpacked_container = T;
   using packed_container = T;
   using packed_type = packed_container;

--- a/tests/Unit/Framework/PyppFundamentals.hpp
+++ b/tests/Unit/Framework/PyppFundamentals.hpp
@@ -495,7 +495,10 @@ T tensor_conversion_impl(PyObject* p) {
   }
   // clang-tidy: c-style casts. (Expanded from macro)
   if (not PyArray_CheckExact(p)) {  // NOLINT
-    throw std::runtime_error{"Cannot convert non-array type to Tensor."};
+    const std::string python_type{Py_TYPE(p)->tp_name};
+    throw std::runtime_error{
+        "Cannot convert non-array type (" + python_type +
+        ") to Tensor. Must be a NumPy array to convert to a Tensor."};
   }
   // clang-tidy: reinterpret_cast
   const auto npy_array = reinterpret_cast<PyArrayObject*>(p);  // NOLINT

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp
@@ -22,6 +22,7 @@
 #include "Framework/Pypp.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/NormalVectors.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Utilities/Gsl.hpp"
@@ -29,70 +30,6 @@
 #include "Utilities/TaggedTuple.hpp"
 
 namespace TestHelpers::evolution::dg {
-namespace detail {
-CREATE_HAS_TYPE_ALIAS(inverse_spatial_metric_tag)
-CREATE_HAS_TYPE_ALIAS_V(inverse_spatial_metric_tag)
-
-template <bool HasInverseSpatialMetricTag = false>
-struct inverse_spatial_metric_tag {
-  template <typename System>
-  using f = tmpl::list<>;
-};
-
-template <>
-struct inverse_spatial_metric_tag<true> {
-  template <typename System>
-  using f = typename System::inverse_spatial_metric_tag;
-};
-
-// On input `inv_spatial_metric` is expected to have components on the interval
-// [0, 1]. The components are rescaled by 0.01, and 1 is added to the diagonal.
-// This is to give an inverse spatial metric of the form:
-//  \delta^{ij} + small^{ij}
-// This is done to give a physically reasonable inverse spatial metric
-template <size_t Dim>
-void adjust_inverse_spatial_metric(
-    const gsl::not_null<tnsr::II<DataVector, Dim>*> inv_spatial_metric) {
-  for (size_t i = 0; i < Dim; ++i) {
-    for (size_t j = i; j < Dim; ++j) {
-      inv_spatial_metric->get(i, j) *= 0.01;
-    }
-  }
-  for (size_t i = 0; i < Dim; ++i) {
-    inv_spatial_metric->get(i, i) += 1.0;
-  }
-}
-
-// On input the `unit_normal_covector` is the unnormalized normal covector. On
-// output `unit_normal_covector` is the normalized (and hence actually unit)
-// normal covector, and `unit_normal_vector` is the unit normal vector. The
-// inverse spatial metric is used for computing the magnitude of the
-// unnormalized normal vector.
-template <size_t Dim>
-void normalize_vector_and_covector(
-    const gsl::not_null<tnsr::i<DataVector, Dim>*> unit_normal_covector,
-    const gsl::not_null<tnsr::I<DataVector, Dim>*> unit_normal_vector,
-    const tnsr::II<DataVector, Dim>& inv_spatial_metric) {
-  for (size_t i = 0; i < Dim; ++i) {
-    unit_normal_vector->get(i) =
-        inv_spatial_metric.get(i, 0) * get<0>(*unit_normal_covector);
-    for (size_t j = 1; j < Dim; ++j) {
-      unit_normal_vector->get(i) +=
-          inv_spatial_metric.get(i, j) * unit_normal_covector->get(j);
-    }
-  }
-
-  const DataVector normal_magnitude =
-      sqrt(get(dot_product(*unit_normal_covector, *unit_normal_vector)));
-  for (auto& t : *unit_normal_covector) {
-    t /= normal_magnitude;
-  }
-  for (auto& t : *unit_normal_vector) {
-    t /= normal_magnitude;
-  }
-}
-}  // namespace detail
-
 /// Indicate if the boundary correction should be zero when the solution is
 /// smooth (should pretty much always be `Yes`)
 enum class ZeroOnSmoothSolution { Yes, No };

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/NormalVectors.hpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/NormalVectors.hpp
@@ -1,0 +1,77 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits/CreateHasTypeAlias.hpp"
+
+namespace TestHelpers::evolution::dg::detail {
+CREATE_HAS_TYPE_ALIAS(inverse_spatial_metric_tag)
+CREATE_HAS_TYPE_ALIAS_V(inverse_spatial_metric_tag)
+
+template <bool HasInverseSpatialMetricTag = false>
+struct inverse_spatial_metric_tag {
+  template <typename System>
+  using f = tmpl::list<>;
+};
+
+template <>
+struct inverse_spatial_metric_tag<true> {
+  template <typename System>
+  using f = typename System::inverse_spatial_metric_tag;
+};
+
+// On input `inv_spatial_metric` is expected to have components on the interval
+// [0, 1]. The components are rescaled by 0.01, and 1 is added to the diagonal.
+// This is to give an inverse spatial metric of the form:
+//  \delta^{ij} + small^{ij}
+// This is done to give a physically reasonable inverse spatial metric
+template <size_t Dim>
+void adjust_inverse_spatial_metric(
+    const gsl::not_null<tnsr::II<DataVector, Dim>*> inv_spatial_metric) {
+  for (size_t i = 0; i < Dim; ++i) {
+    for (size_t j = i; j < Dim; ++j) {
+      inv_spatial_metric->get(i, j) *= 0.01;
+    }
+  }
+  for (size_t i = 0; i < Dim; ++i) {
+    inv_spatial_metric->get(i, i) += 1.0;
+  }
+}
+
+// On input the `unit_normal_covector` is the unnormalized normal covector. On
+// output `unit_normal_covector` is the normalized (and hence actually unit)
+// normal covector, and `unit_normal_vector` is the unit normal vector. The
+// inverse spatial metric is used for computing the magnitude of the
+// unnormalized normal vector.
+template <size_t Dim>
+void normalize_vector_and_covector(
+    const gsl::not_null<tnsr::i<DataVector, Dim>*> unit_normal_covector,
+    const gsl::not_null<tnsr::I<DataVector, Dim>*> unit_normal_vector,
+    const tnsr::II<DataVector, Dim>& inv_spatial_metric) {
+  for (size_t i = 0; i < Dim; ++i) {
+    unit_normal_vector->get(i) =
+        inv_spatial_metric.get(i, 0) * get<0>(*unit_normal_covector);
+    for (size_t j = 1; j < Dim; ++j) {
+      unit_normal_vector->get(i) +=
+          inv_spatial_metric.get(i, j) * unit_normal_covector->get(j);
+    }
+  }
+
+  const DataVector normal_magnitude =
+      sqrt(get(dot_product(*unit_normal_covector, *unit_normal_vector)));
+  for (auto& t : *unit_normal_covector) {
+    t /= normal_magnitude;
+  }
+  for (auto& t : *unit_normal_vector) {
+    t /= normal_magnitude;
+  }
+}
+}  // namespace TestHelpers::evolution::dg::detail


### PR DESCRIPTION
## Proposed changes

- Support `std::string` in the conversion code in pypp. I need this because the boundary conditions return `std::optional<std::string>` that is used to return an errror message
- Print the python type that couldn't be converted to a Tensor. This makes debugging _a lot_ easier
- Factor the normal vector and inverse spatial metric helper functions from `BoundaryCorrections.hpp`. I need these exactly same calculations for the boundary conditions

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
