### PR TITLE
Support multiplication of doubles and TensorExpressions

### DIFF
--- a/src/DataStructures/Tensor/Expressions/CMakeLists.txt
+++ b/src/DataStructures/Tensor/Expressions/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_headers(
   Evaluate.hpp
   LhsTensorSymmAndIndices.hpp
   Product.hpp
+  NumberAsExpression.hpp
   TensorAsExpression.hpp
   TensorExpression.hpp
   )

--- a/src/DataStructures/Tensor/Expressions/NumberAsExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/NumberAsExpression.hpp
@@ -1,0 +1,53 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/Structure.hpp"
+#include "Utilities/ForceInline.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace TensorExpressions {
+/// \ingroup TensorExpressionsGroup
+/// \brief Defines an expression representing a `double`
+struct NumberAsExpression
+    : public TensorExpression<NumberAsExpression, double, tmpl::list<>,
+                              tmpl::list<>, tmpl::list<>> {
+  using type = double;
+  using symmetry = tmpl::list<>;
+  using index_list = tmpl::list<>;
+  using args_list = tmpl::list<>;
+  using structure = Tensor_detail::Structure<symmetry>;
+  static constexpr auto num_tensor_indices = 0;
+
+  NumberAsExpression(const double number) : number_(number) {}
+  ~NumberAsExpression() override = default;
+
+  /// \brief Returns the number represented by the expression
+  ///
+  /// \details
+  /// While a NumberAsExpression does not store a rank 0 Tensor, it does
+  /// represent one. This is why, unlike other derived TensorExpression types,
+  /// there is no second variadic template parameter for the generic indices.
+  /// In addition, this is why this template is only instantiated for the case
+  /// where `Structure` is equal to the Structure of a rank 0 Tensor.
+  ///
+  /// \tparam Structure the Structure of the rank 0 Tensor represented by this
+  /// expression
+  /// \return the number represented by this expression
+  template <typename Structure>
+  SPECTRE_ALWAYS_INLINE double get(
+      const size_t /*storage_index*/) const noexcept {
+    static_assert(std::is_same_v<Structure, structure>,
+                  "In retrieving the number stored by a NumberAsExpression, "
+                  "the provided Structure should be that of a rank 0 Tensor.");
+    return number_;
+  }
+
+ private:
+  double number_;
+};
+}  // namespace TensorExpressions

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Product.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Product.cpp
@@ -34,6 +34,53 @@ void assign_unique_values_to_tensor(
 }
 
 /// \ingroup TestingFrameworkGroup
+/// \brief Test the outer product of a `double` and tensor is correctly
+/// evaluated
+///
+/// \details
+/// The outer product cases tested are:
+/// - \f$L_{ij} = R * S_{ij}\f$
+/// - \f$L_{ij} = S_{ij} * R\f$
+/// - \f$L_{ij} = R * S_{ij} * T\f$
+///
+/// where \f$R\f$ and \f$T\f$ are `double`s and \f$S\f$ and \f$L\f$ are Tensors
+/// with data type `double` or DataVector.
+///
+/// \tparam DataType the type of data being stored in the tensor operand of the
+/// products
+template <typename DataType>
+void test_outer_product_double(const DataType& used_for_size) noexcept {
+  constexpr size_t dim = 3;
+  using tensor_type =
+      Tensor<DataType, Symmetry<1, 1>,
+             index_list<SpatialIndex<dim, UpLo::Lo, Frame::Inertial>,
+                        SpatialIndex<dim, UpLo::Lo, Frame::Inertial>>>;
+
+  tensor_type S(used_for_size);
+  assign_unique_values_to_tensor(make_not_null(&S));
+
+  // \f$L_{ij} = R * S_{ij}\f$
+  // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
+  // return type of `evaluate`
+  const tensor_type Lij_from_R_Sij =
+      TensorExpressions::evaluate<ti_i, ti_j>(5.6 * S(ti_i, ti_j));
+  // \f$L_{ij} = S_{ij} * R\f$
+  const tensor_type Lij_from_Sij_R =
+      TensorExpressions::evaluate<ti_i, ti_j>(S(ti_i, ti_j) * -8.1);
+  // \f$L_{ij} = R * S_{ij} * T\f$
+  const tensor_type Lij_from_R_Sij_T =
+      TensorExpressions::evaluate<ti_i, ti_j>(-1.7 * S(ti_i, ti_j) * 0.6);
+
+  for (size_t i = 0; i < dim; i++) {
+    for (size_t j = 0; j < dim; j++) {
+      CHECK(Lij_from_R_Sij.get(i, j) == 5.6 * S.get(i, j));
+      CHECK(Lij_from_Sij_R.get(i, j) == S.get(i, j) * -8.1);
+      CHECK(Lij_from_R_Sij_T.get(i, j) == -1.7 * S.get(i, j) * 0.6);
+    }
+  }
+}
+
+/// \ingroup TestingFrameworkGroup
 /// \brief Test the outer product of a rank 0 tensor with another tensor is
 /// correctly evaluated
 ///
@@ -1077,6 +1124,7 @@ void test_three_term_inner_outer_product(
 
 template <typename DataType>
 void test_products(const DataType& used_for_size) noexcept {
+  test_outer_product_double(used_for_size);
   test_outer_product_rank_0_operand(used_for_size);
   test_outer_product_rank_1_operand(used_for_size);
   test_outer_product_rank_2x2_operands(used_for_size);


### PR DESCRIPTION
## Proposed changes

This PR creates a new `TensorExpression` type for storing `double`s, implements the multiplication of `double`s with `TensorExpression`s, and adds a test for these products.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
