### PR TITLE
Add compute tag for elastic strain

### DIFF
--- a/src/Elliptic/Executables/Elasticity/CMakeLists.txt
+++ b/src/Elliptic/Executables/Elasticity/CMakeLists.txt
@@ -8,7 +8,7 @@ set(LIBS_TO_LINK
   DiscontinuousGalerkin
   DomainCreators
   Elasticity
-  ElasticPotentialEnergy
+  ElasticityPointwiseFunctions
   Elliptic
   EllipticDg
   Events

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp
@@ -11,6 +11,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Elliptic/Systems/Elasticity/Tags.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Elasticity/AnalyticSolution.hpp"
 #include "PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp"
 #include "Utilities/ContainerHelpers.hpp"

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/CMakeLists.txt
@@ -27,12 +27,16 @@ target_link_libraries(
   PUBLIC
   ConstitutiveRelations
   DataStructures
-  ElasticPotentialEnergy
   Elasticity
   ErrorHandling
   Options
+  Parallel
   Utilities
   PRIVATE
+  ElasticityPointwiseFunctions
   GSL::gsl
   Integration
+  INTERFACE
+  AnalyticData
+  Parallel
   )

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.hpp
@@ -11,6 +11,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Elliptic/Systems/Elasticity/Tags.hpp"
 #include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Elasticity/AnalyticSolution.hpp"
 #include "PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp"
 #include "Utilities/ContainerHelpers.hpp"

--- a/src/PointwiseFunctions/Elasticity/CMakeLists.txt
+++ b/src/PointwiseFunctions/Elasticity/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-set(LIBRARY ElasticPotentialEnergy)
+set(LIBRARY ElasticityPointwiseFunctions)
 
 add_spectre_library(${LIBRARY})
 
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   PotentialEnergy.cpp
+  Strain.cpp
   )
 
 spectre_target_headers(
@@ -16,6 +17,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   PotentialEnergy.hpp
+  Strain.hpp
   )
 
 target_link_libraries(
@@ -26,6 +28,8 @@ target_link_libraries(
   Domain
   Elasticity
   Utilities
+  PRIVATE
+  LinearOperators
   )
 
 add_subdirectory(ConstitutiveRelations)

--- a/src/PointwiseFunctions/Elasticity/Strain.cpp
+++ b/src/PointwiseFunctions/Elasticity/Strain.cpp
@@ -1,0 +1,65 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/Elasticity/Strain.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/Systems/Elasticity/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace Elasticity {
+
+template <size_t Dim>
+void strain(const gsl::not_null<tnsr::ii<DataVector, Dim>*> strain,
+            const tnsr::I<DataVector, Dim>& displacement, const Mesh<Dim>& mesh,
+            const InverseJacobian<DataVector, Dim, Frame::Logical,
+                                  Frame::Inertial>& inv_jacobian) noexcept {
+  // Copy the displacement into a Variables to take partial derivatives because
+  // at this time the `partial_derivatives` function only works with Variables.
+  // This function is only used for observing the strain and derived quantities
+  // (such as the potential energy) so performance isn't critical, but adding a
+  // `partial_derivatives` overload that takes a Tensor is an obvious
+  // optimization here.
+  Variables<tmpl::list<Tags::Displacement<Dim>>> vars{
+      mesh.number_of_grid_points()};
+  get<Tags::Displacement<Dim>>(vars) = displacement;
+  const auto displacement_gradient =
+      get<::Tags::deriv<Tags::Displacement<Dim>, tmpl::size_t<Dim>,
+                        Frame::Inertial>>(
+          partial_derivatives<tmpl::list<Tags::Displacement<Dim>>>(
+              vars, mesh, inv_jacobian));
+  // Symmetrize
+  for (size_t i = 0; i < Dim; ++i) {
+    for (size_t j = 0; j <= i; ++j) {
+      strain->get(i, j) = 0.5 * (displacement_gradient.get(i, j) +
+                                 displacement_gradient.get(j, i));
+    }
+  }
+}
+
+/// \cond
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                       \
+  template void strain<DIM(data)>(                                 \
+      gsl::not_null<tnsr::ii<DataVector, DIM(data)>*> strain,      \
+      const tnsr::I<DataVector, DIM(data)>& displacement,          \
+      const Mesh<DIM(data)>& mesh,                                 \
+      const InverseJacobian<DataVector, DIM(data), Frame::Logical, \
+                            Frame::Inertial>& inv_jacobian) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3))
+
+#undef DIM
+#undef INSTANTIATE
+/// \endcond
+
+}  // namespace Elasticity

--- a/src/PointwiseFunctions/Elasticity/Strain.hpp
+++ b/src/PointwiseFunctions/Elasticity/Strain.hpp
@@ -1,0 +1,46 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/Systems/Elasticity/Tags.hpp"
+
+namespace Elasticity {
+
+/*!
+ * \brief The symmetric strain \f$S_{ij}=\nabla_{(i} \xi_{j)}\f$ in the elastic
+ * material.
+ *
+ * Note that this function involves a numeric differentiation of the
+ * displacement vector.
+ */
+template <size_t Dim>
+void strain(gsl::not_null<tnsr::ii<DataVector, Dim>*> strain,
+            const tnsr::I<DataVector, Dim>& displacement, const Mesh<Dim>& mesh,
+            const InverseJacobian<DataVector, Dim, Frame::Logical,
+                                  Frame::Inertial>& inv_jacobian) noexcept;
+
+namespace Tags {
+
+/*!
+ * \brief The symmetric strain \f$S_{ij}=\nabla_{(i} \xi_{j)}\f$ in the elastic
+ * material.
+ *
+ * \see `Elasticity::strain`
+ */
+template <size_t Dim>
+struct StrainCompute : Elasticity::Tags::Strain<Dim>, db::ComputeTag {
+  using base = Elasticity::Tags::Strain<Dim>;
+  using return_type = tnsr::ii<DataVector, Dim>;
+  using argument_tags = tmpl::list<
+      Elasticity::Tags::Displacement<Dim>, domain::Tags::Mesh<Dim>,
+      domain::Tags::InverseJacobian<Dim, Frame::Logical, Frame::Inertial>>;
+  static constexpr auto function = &strain<Dim>;
+};
+
+}  // namespace Tags
+}  // namespace Elasticity

--- a/tests/Unit/PointwiseFunctions/Elasticity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Elasticity/CMakeLists.txt
@@ -3,15 +3,27 @@
 
 add_subdirectory(ConstitutiveRelations)
 
-set(LIBRARY Test_ElasticPotentialEnergy)
+set(LIBRARY Test_ElasticityPointwiseFunctions)
 
 set(LIBRARY_SOURCES
   Test_PotentialEnergy.cpp
+  Test_Strain.cpp
   )
 
-  add_test_library(
+add_test_library(
   ${LIBRARY}
   "PointwiseFunctions/Elasticity/"
   "${LIBRARY_SOURCES}"
-  "ElasticPotentialEnergy;Utilities"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  ConstitutiveRelations
+  CoordinateMaps
+  DataStructures
+  Elasticity
+  ElasticityPointwiseFunctions
+  Utilities
   )

--- a/tests/Unit/PointwiseFunctions/Elasticity/Test_PotentialEnergy.cpp
+++ b/tests/Unit/PointwiseFunctions/Elasticity/Test_PotentialEnergy.cpp
@@ -3,7 +3,6 @@
 
 #include "Framework/TestingFramework.hpp"
 
-#include <array>
 #include <cstddef>
 #include <string>
 
@@ -14,11 +13,9 @@
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
-#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp"
 #include "PointwiseFunctions/Elasticity/ConstitutiveRelations/Tags.hpp"
 #include "PointwiseFunctions/Elasticity/PotentialEnergy.hpp"
-#include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace {

--- a/tests/Unit/PointwiseFunctions/Elasticity/Test_Strain.cpp
+++ b/tests/Unit/PointwiseFunctions/Elasticity/Test_Strain.cpp
@@ -1,0 +1,114 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Elliptic/Systems/Elasticity/Tags.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "PointwiseFunctions/Elasticity/Strain.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+
+// Polynomial functions of max. degree 2, so the differentiation is exact on 3
+// grid points
+template <size_t Dim>
+tnsr::I<DataVector, Dim> polynomial_displacement(
+    const tnsr::I<DataVector, Dim>& x) {
+  tnsr::I<DataVector, Dim> displacement{x.begin()->size()};
+  get<0>(displacement) = square(get<0>(x)) + 2. * get<1>(x);
+  get<1>(displacement) = square(get<1>(x)) + 3. * get<0>(x);
+  if constexpr (Dim == 3) {
+    get<2>(displacement) = square(get<2>(x)) + get<0>(x) + 4. * get<1>(x);
+  }
+  return displacement;
+}
+
+// This is the symmetrized gradient of `polynomial_displacement`
+template <size_t Dim>
+tnsr::ii<DataVector, Dim> polynomial_strain(const tnsr::I<DataVector, Dim>& x) {
+  tnsr::ii<DataVector, Dim> strain{x.begin()->size()};
+  get<0, 0>(strain) = 2. * get<0>(x);
+  get<1, 1>(strain) = 2. * get<1>(x);
+  get<0, 1>(strain) = 2.5;
+  if constexpr (Dim == 3) {
+    get<2, 2>(strain) = 2. * get<2>(x);
+    get<0, 2>(strain) = 0.5;
+    get<1, 2>(strain) = 2.;
+  }
+  return strain;
+}
+
+template <size_t Dim>
+auto make_coord_map() {
+  using AffineMap = domain::CoordinateMaps::Affine;
+  if constexpr (Dim == 1) {
+    return domain::CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap>{
+        {-1., 1., 0., M_PI}};
+  } else if constexpr (Dim == 2) {
+    using AffineMap2D =
+        domain::CoordinateMaps::ProductOf2Maps<AffineMap, AffineMap>;
+    return domain::CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap2D>{
+        {{-1., 1., 0., M_PI}, {-1., 1., 0., M_PI}}};
+  } else {
+    using AffineMap3D =
+        domain::CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
+    return domain::CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap3D>{
+        {{-1., 1., 0., M_PI}, {-1., 1., 0., M_PI}, {-1., 1., 0., M_PI}}};
+  }
+}
+
+template <size_t Dim>
+void test_strain() noexcept {
+  CAPTURE(Dim);
+  const Mesh<Dim> mesh{3, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+  const auto logical_coords = logical_coordinates(mesh);
+  const auto coord_map = make_coord_map<Dim>();
+  const auto inertial_coords = coord_map(logical_coords);
+  const auto inv_jacobian = coord_map.inv_jacobian(logical_coords);
+  const auto displacement = polynomial_displacement(inertial_coords);
+  const auto expected_strain = polynomial_strain(inertial_coords);
+  tnsr::ii<DataVector, Dim> strain{mesh.number_of_grid_points()};
+  Elasticity::strain(make_not_null(&strain), displacement, mesh, inv_jacobian);
+  for (size_t i = 0; i < strain.size(); ++i) {
+    const auto component_name =
+        strain.component_name(strain.get_tensor_index(i));
+    CAPTURE(component_name);
+    CHECK_ITERABLE_APPROX(strain[i], expected_strain[i]);
+  }
+  {
+    INFO("Test the compute tag");
+    TestHelpers::db::test_compute_tag<Elasticity::Tags::StrainCompute<Dim>>(
+        "Strain");
+    const auto box =
+        db::create<db::AddSimpleTags<Elasticity::Tags::Displacement<Dim>,
+                                     domain::Tags::Mesh<Dim>,
+                                     domain::Tags::InverseJacobian<
+                                         Dim, Frame::Logical, Frame::Inertial>>,
+                   db::AddComputeTags<Elasticity::Tags::StrainCompute<Dim>>>(
+            displacement, mesh, inv_jacobian);
+    CHECK(get<Elasticity::Tags::Strain<Dim>>(box) == strain);
+  }
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Elasticity.Strain",
+                  "[Unit][PointwiseFunctions]") {
+  test_strain<2>();
+  test_strain<3>();
+}


### PR DESCRIPTION
## Proposed changes

The strain won't be explicitly solved for anymore with the upcoming second-order DG operator, so this compute tag is used to observe it and dependent quantities such as the potential energy.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
