### PR TITLE
Handle reference tags in db::tag_name

### DIFF
--- a/src/DataStructures/DataBox/TagName.hpp
+++ b/src/DataStructures/DataBox/TagName.hpp
@@ -3,15 +3,11 @@
 
 #pragma once
 
-#include <cstddef>
 #include <string>
 #include <type_traits>
 
 #include "DataStructures/DataBox/TagTraits.hpp"
 #include "Utilities/PrettyType.hpp"
-#include "Utilities/Requires.hpp"
-#include "Utilities/TypeTraits.hpp"
-#include "Utilities/TypeTraits/CreateHasTypeAlias.hpp"
 #include "Utilities/TypeTraits/CreateIsCallable.hpp"
 
 /// \cond
@@ -25,8 +21,6 @@ namespace db {
 namespace detail {
 CREATE_IS_CALLABLE(name)
 CREATE_IS_CALLABLE_V(name)
-CREATE_HAS_TYPE_ALIAS(base)
-CREATE_HAS_TYPE_ALIAS_V(base)
 }  // namespace detail
 
 /*!
@@ -44,9 +38,7 @@ template <typename Tag>
 std::string tag_name() noexcept {
   if constexpr (detail::is_name_callable_v<Tag>) {
     return Tag::name();
-  } else if constexpr (db::is_compute_tag_v<Tag>) {
-    static_assert(detail::has_base_v<Tag>,
-                  "Compute tags must have a name function or a base alias");
+  } else if constexpr (db::is_immutable_item_tag_v<Tag>) {
     return tag_name<typename Tag::base>();
   } else if constexpr (std::is_base_of_v<db::PrefixTag, Tag>) {
     return pretty_type::short_name<Tag>() + "(" +

--- a/tests/Unit/DataStructures/DataBox/Test_TagName.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_TagName.cpp
@@ -77,6 +77,57 @@ struct NamedSimpleWithNamedBaseCompute : NamedSimpleWithNamedBase,
   using base = NamedSimpleWithNamedBase;
 };
 
+struct SimpleNamedReference : TestHelpers::db::Tags::Simple, db::ReferenceTag {
+  static std::string name() noexcept { return "NameOfSimpleReference"; }
+};
+
+struct NamedSimpleNamedReference : NamedSimple, db::ReferenceTag {
+  static std::string name() noexcept { return "NameOfNamedSimpleReference"; }
+};
+
+struct NamedSimpleReference : NamedSimple, db::ReferenceTag {
+  using base = NamedSimple;
+};
+
+struct SimpleWithBaseNamedReference : TestHelpers::db::Tags::SimpleWithBase,
+                                      db::ReferenceTag {
+  static std::string name() noexcept { return "NameOfSimpleWithBaseReference"; }
+};
+
+struct NamedSimpleWithBaseNamedReference : NamedSimpleWithBase,
+                                           db::ReferenceTag {
+  static std::string name() noexcept {
+    return "NameOfNamedSimpleWithBaseReference";
+  }
+};
+
+struct NamedSimpleWithBaseReference : NamedSimpleWithBase, db::ReferenceTag {
+  using base = NamedSimpleWithBase;
+};
+
+struct SimpleWithNamedBaseNamedReference : SimpleWithNamedBase,
+                                           db::ReferenceTag {
+  static std::string name() noexcept {
+    return "NameOfSimpleWithNamedBaseReference";
+  }
+};
+
+struct SimpleWithNamedBaseReference : SimpleWithNamedBase, db::ReferenceTag {
+  using base = SimpleWithNamedBase;
+};
+
+struct NamedSimpleWithNamedBaseNamedReference : NamedSimpleWithNamedBase,
+                                                db::ReferenceTag {
+  static std::string name() noexcept {
+    return "NameOfNamedSimpleWithNamedBaseReference";
+  }
+};
+
+struct NamedSimpleWithNamedBaseReference : NamedSimpleWithNamedBase,
+                                           db::ReferenceTag {
+  using base = NamedSimpleWithNamedBase;
+};
+
 template <typename Tag>
 struct NamedLabel : db::PrefixTag, db::SimpleTag {
   using tag = Tag;
@@ -118,6 +169,9 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.TagName",
   CHECK(db::tag_name<TestHelpers::db::Tags::SimpleCompute>() == "Simple");
   CHECK(db::tag_name<TestHelpers::db::Tags::SimpleWithBaseCompute>() ==
         "SimpleWithBase");
+  CHECK(db::tag_name<TestHelpers::db::Tags::SimpleReference>() == "Simple");
+  CHECK(db::tag_name<TestHelpers::db::Tags::SimpleWithBaseReference>() ==
+        "SimpleWithBase");
   CHECK(db::tag_name<NamedSimple>() == "NameOfSimple");
   CHECK(db::tag_name<NamedBase>() == "NameOfBase");
   CHECK(db::tag_name<NamedSimpleWithBase>() == "NameOfSimpleWithBase");
@@ -138,6 +192,22 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.TagName",
   CHECK(db::tag_name<NamedSimpleWithNamedBaseNamedCompute>() ==
         "NameOfNamedSimpleWithNamedBaseCompute");
   CHECK(db::tag_name<NamedSimpleWithNamedBaseCompute>() ==
+        "NameOfSimpleWithNamedBase");
+  CHECK(db::tag_name<SimpleNamedReference>() == "NameOfSimpleReference");
+  CHECK(db::tag_name<NamedSimpleNamedReference>() ==
+        "NameOfNamedSimpleReference");
+  CHECK(db::tag_name<NamedSimpleReference>() == "NameOfSimple");
+  CHECK(db::tag_name<SimpleWithBaseNamedReference>() ==
+        "NameOfSimpleWithBaseReference");
+  CHECK(db::tag_name<NamedSimpleWithBaseNamedReference>() ==
+        "NameOfNamedSimpleWithBaseReference");
+  CHECK(db::tag_name<NamedSimpleWithBaseReference>() == "NameOfSimpleWithBase");
+  CHECK(db::tag_name<SimpleWithNamedBaseNamedReference>() ==
+        "NameOfSimpleWithNamedBaseReference");
+  CHECK(db::tag_name<SimpleWithNamedBaseReference>() == "NameOfBase");
+  CHECK(db::tag_name<NamedSimpleWithNamedBaseNamedReference>() ==
+        "NameOfNamedSimpleWithNamedBaseReference");
+  CHECK(db::tag_name<NamedSimpleWithNamedBaseReference>() ==
         "NameOfSimpleWithNamedBase");
 
   CHECK(db::tag_name<

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp
@@ -11,9 +11,9 @@
 #include <string>
 #include <type_traits>
 
-#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataBox/TagName.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
@@ -27,6 +27,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
+#include "Utilities/TypeTraits/CreateHasTypeAlias.hpp"
 
 namespace TestHelpers::evolution::dg {
 namespace detail {


### PR DESCRIPTION
## Proposed changes

- Adds support for automatic generation of db::tag_name for a reference tag
- Clean up some includes

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
