### PR TITLE
Add Shu-Osher shock tube and Sod explosion analytic data

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -910,6 +910,19 @@
   url     = {https://ui.adsabs.harvard.edu/abs/1983bhwd.book.....S},
 }
 
+@article{Shu1988439,
+  title =        "Efficient implementation of essentially non-oscillatory
+                  shock-capturing schemes",
+  journal =      "Journal of Computational Physics",
+  volume =       77,
+  number =       2,
+  pages =        "439 - 471",
+  year =         1988,
+  issn =         "0021-9991",
+  doi =          "10.1016/0021-9991(88)90177-5",
+  author =       "Chi-Wang Shu and Stanley Osher",
+}
+
 @article{Stamm2010,
   author   = "Stamm, Benjamin and Wihler, Thomas P.",
   title    = "{hp-Optimal} discontinuous {Galerkin} methods for linear elliptic

--- a/docs/References.bib
+++ b/docs/References.bib
@@ -923,6 +923,20 @@
   author =       "Chi-Wang Shu and Stanley Osher",
 }
 
+@article{Sod19781,
+  title =   {A survey of several finite difference methods for systems of
+             nonlinear hyperbolic conservation laws},
+  journal = {Journal of Computational Physics},
+  volume =  27,
+  number =  1,
+  pages =   {1-31},
+  year =    1978,
+  issn =    {0021-9991},
+  doi =     {https://doi.org/10.1016/0021-9991(78)90023-2},
+  url =     {https://www.sciencedirect.com/science/article/pii/0021999178900232},
+  author =  {Gary A Sod},
+}
+
 @article{Stamm2010,
   author   = "Stamm, Benjamin and Wihler, Thomas P.",
   title    = "{hp-Optimal} discontinuous {Galerkin} methods for linear elliptic

--- a/src/PointwiseFunctions/AnalyticData/NewtonianEuler/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticData/NewtonianEuler/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   KhInstability.cpp
   ShuOsherTube.cpp
+  SodExplosion.cpp
   )
 
 spectre_target_headers(
@@ -19,6 +20,7 @@ spectre_target_headers(
   AnalyticData.hpp
   KhInstability.hpp
   ShuOsherTube.hpp
+  SodExplosion.hpp
   )
 
 target_link_libraries(

--- a/src/PointwiseFunctions/AnalyticData/NewtonianEuler/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticData/NewtonianEuler/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   KhInstability.cpp
+  ShuOsherTube.cpp
   )
 
 spectre_target_headers(
@@ -17,6 +18,7 @@ spectre_target_headers(
   HEADERS
   AnalyticData.hpp
   KhInstability.hpp
+  ShuOsherTube.hpp
   )
 
 target_link_libraries(

--- a/src/PointwiseFunctions/AnalyticData/NewtonianEuler/ShuOsherTube.cpp
+++ b/src/PointwiseFunctions/AnalyticData/NewtonianEuler/ShuOsherTube.cpp
@@ -1,0 +1,162 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticData/NewtonianEuler/ShuOsherTube.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/Math.hpp"
+
+namespace NewtonianEuler::AnalyticData {
+ShuOsherTube::ShuOsherTube(const double jump_position,
+                           const double mass_density_l, const double velocity_l,
+                           const double pressure_l, const double velocity_r,
+                           const double pressure_r, const double epsilon,
+                           const double lambda) noexcept
+    : mass_density_l_(mass_density_l),
+      velocity_l_(velocity_l),
+      pressure_l_(pressure_l),
+      jump_position_(jump_position),
+      epsilon_(epsilon),
+      lambda_(lambda),
+      velocity_r_(velocity_r),
+      pressure_r_(pressure_r) {
+  ASSERT(mass_density_l_ > 0.0,
+         "The left mass_density must be greater than 0 but is "
+             << mass_density_l_);
+  ASSERT(pressure_l_ > 0.0,
+         "The left pressure must be greater than 0 but is " << pressure_l_);
+  ASSERT(pressure_r_ > 0.0,
+         "The right pressure must be greater than 0 but is " << pressure_r_);
+  ASSERT(epsilon_ > 0.0,
+         "The sinusoid amplitude must be greater than 0 but is " << epsilon_);
+  ASSERT(epsilon_ < 1.0,
+         "The sinusoid amplitude must be less than 1 but is " << epsilon_);
+}
+
+void ShuOsherTube::pup(PUP::er& p) noexcept {
+  p | mass_density_l_;
+  p | velocity_l_;
+  p | pressure_l_;
+  p | jump_position_;
+  p | epsilon_;
+  p | lambda_;
+  p | velocity_r_;
+  p | pressure_r_;
+  p | adiabatic_index_;
+  p | equation_of_state_;
+}
+
+bool operator==(const ShuOsherTube& lhs, const ShuOsherTube& rhs) noexcept {
+  // No comparison for equation_of_state_. Comparing adiabatic_index_ should
+  // suffice.
+  return lhs.mass_density_l_ == rhs.mass_density_l_ and
+         lhs.velocity_l_ == rhs.velocity_l_ and
+         lhs.pressure_l_ == rhs.pressure_l_ and
+         lhs.jump_position_ == rhs.jump_position_ and
+         lhs.epsilon_ == rhs.epsilon_ and lhs.lambda_ == rhs.lambda_ and
+         lhs.velocity_r_ == rhs.velocity_r_ and
+         lhs.pressure_r_ == rhs.pressure_r_ and
+         lhs.adiabatic_index_ == rhs.adiabatic_index_;
+}
+
+bool operator!=(const ShuOsherTube& lhs, const ShuOsherTube& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+template <typename DataType>
+tuples::TaggedTuple<Tags::MassDensity<DataType>> ShuOsherTube::variables(
+    const tnsr::I<DataType, 1, Frame::Inertial>& x,
+    tmpl::list<Tags::MassDensity<DataType>> /*meta*/) const noexcept {
+  auto mass_density = make_with_value<Scalar<DataType>>(x, 0.0);
+  for (size_t s = 0; s < get_size(get<0>(x)); ++s) {
+    const double x_s = get_element(get<0>(x), s);
+    get_element(get(mass_density), s) =
+        x_s < jump_position_ ? mass_density_l_
+                             : 1.0 + epsilon_ * sin(lambda_ * x_s);
+  }
+  return mass_density;
+}
+
+template <typename DataType>
+tuples::TaggedTuple<Tags::Velocity<DataType, 1, Frame::Inertial>>
+ShuOsherTube::variables(
+    const tnsr::I<DataType, 1, Frame::Inertial>& x,
+    tmpl::list<Tags::Velocity<DataType, 1, Frame::Inertial>> /*meta*/)
+    const noexcept {
+  auto velocity =
+      make_with_value<tnsr::I<DataType, 1, Frame::Inertial>>(x, 0.0);
+  for (size_t s = 0; s < get_size(get<0>(x)); ++s) {
+    const double x_s = get_element(get<0>(x), s);
+    get_element(get<0>(velocity), s) =
+        x_s < jump_position_ ? velocity_l_ : velocity_r_;
+  }
+  return velocity;
+}
+
+template <typename DataType>
+tuples::TaggedTuple<Tags::Pressure<DataType>> ShuOsherTube::variables(
+    const tnsr::I<DataType, 1, Frame::Inertial>& x,
+    tmpl::list<Tags::Pressure<DataType>> /*meta*/) const noexcept {
+  auto pressure = make_with_value<Scalar<DataType>>(x, 0.0);
+  for (size_t s = 0; s < get_size(get<0>(x)); ++s) {
+    const double x_s = get_element(get<0>(x), s);
+    get_element(get(pressure), s) =
+        x_s < jump_position_ ? pressure_l_ : pressure_r_;
+  }
+  return pressure;
+}
+
+template <typename DataType>
+tuples::TaggedTuple<Tags::SpecificInternalEnergy<DataType>>
+ShuOsherTube::variables(
+    const tnsr::I<DataType, 1, Frame::Inertial>& x,
+    tmpl::list<Tags::SpecificInternalEnergy<DataType>> /*meta*/)
+    const noexcept {
+  return equation_of_state_.specific_internal_energy_from_density_and_pressure(
+      get<Tags::MassDensity<DataType>>(
+          variables(x, tmpl::list<Tags::MassDensity<DataType>>{})),
+      get<Tags::Pressure<DataType>>(
+          variables(x, tmpl::list<Tags::Pressure<DataType>>{})));
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define TAG(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE_SCALARS(_, data)                                         \
+  template tuples::TaggedTuple<TAG(data) < DTYPE(data)> >                    \
+      ShuOsherTube::variables(                                               \
+          const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>& x_shifted, \
+          tmpl::list<TAG(data) < DTYPE(data)> >) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_SCALARS, (1), (double, DataVector),
+                        (Tags::MassDensity, Tags::Pressure,
+                         Tags::SpecificInternalEnergy))
+
+#define INSTANTIATE_VELOCITY(_, data)                                        \
+  template tuples::TaggedTuple<TAG(data) < DTYPE(data), DIM(data),           \
+                               Frame::Inertial> >                            \
+      ShuOsherTube::variables(                                               \
+          const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>& x_shifted, \
+          tmpl::list<TAG(data) < DTYPE(data), DIM(data), Frame::Inertial> >) \
+          const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_VELOCITY, (1), (double, DataVector),
+                        (Tags::Velocity))
+
+#undef DIM
+#undef DTYPE
+#undef TAG
+#undef INSTANTIATE_SCALARS
+#undef INSTANTIATE_VELOCITY
+}  // namespace NewtonianEuler::AnalyticData

--- a/src/PointwiseFunctions/AnalyticData/NewtonianEuler/ShuOsherTube.hpp
+++ b/src/PointwiseFunctions/AnalyticData/NewtonianEuler/ShuOsherTube.hpp
@@ -1,0 +1,186 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/NewtonianEuler/Sources/NoSource.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace PUP {
+class er;  // IWYU pragma: keep
+}  // namespace PUP
+/// \endcond
+
+namespace NewtonianEuler::AnalyticData {
+/*!
+ * \brief Initial data for the Shu-Osher oscillatory shock tube \cite Shu1988439
+ *
+ * The general initial data is given by:
+ *
+ * \f{align*}{
+ *  \{\rho,v^x,p\}=
+ * \left\{
+ * \begin{array}{ll}
+ *   \left\{\rho_L, v^x_L, p_L\right\} &\mathrm{if} \;\;\; x<\Delta \\
+ *   \left\{1+\epsilon\sin(\lambda x), v^x_R, p_R\right\} &\mathrm{if} \;\;\;
+ *    x\ge \Delta
+ * \end{array}\right.
+ * \f}
+ *
+ * with the adiabatic index being 1.4.
+ *
+ * With the standard parameters given below, this is a Mach-3 shock moving into
+ * a sinusoidal density profile.
+ *
+ * \f{align*}{
+ *  \{\rho,v^x,p\}=
+ * \left\{
+ * \begin{array}{ll}
+ *   \left\{3.857143, 2.629369, 10.33333\right\} &\mathrm{if} \;\;\; x<-4 \\
+ *   \left\{1+0.2\sin(5x), 0, 1\right\} &\mathrm{if} \;\;\; x\ge -4
+ * \end{array}\right.
+ * \f}
+ *
+ * With these values the usual final time is 1.8.
+ */
+class ShuOsherTube : public MarkAsAnalyticData {
+ public:
+  using equation_of_state_type = EquationsOfState::IdealFluid<false>;
+  using source_term_type = Sources::NoSource;
+
+  /// Initial postition of the discontinuity
+  struct JumpPosition {
+    using type = double;
+    static constexpr Options::String help = {
+        "The initial position of the discontinuity."};
+  };
+
+  struct LeftMassDensity {
+    using type = double;
+    static constexpr Options::String help = {"The left mass density."};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+
+  struct LeftVelocity {
+    using type = double;
+    static constexpr Options::String help = {"The left velocity."};
+  };
+
+  struct LeftPressure {
+    using type = double;
+    static constexpr Options::String help = {"The left pressure."};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+
+  struct RightVelocity {
+    using type = double;
+    static constexpr Options::String help = {"The right velocity."};
+  };
+
+  struct RightPressure {
+    using type = double;
+    static constexpr Options::String help = {"The right pressure."};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+
+  struct Epsilon {
+    using type = double;
+    static constexpr Options::String help = {"Sinusoid amplitude."};
+    static type lower_bound() noexcept { return 0.0; }
+    static type upper_bound() noexcept { return 1.0; }
+  };
+
+  struct Lambda {
+    using type = double;
+    static constexpr Options::String help = {"Sinusoid wavelength."};
+  };
+
+  static constexpr Options::String help = {
+      "1D Shu-Osher oscillatory shock tube."};
+
+  using options =
+      tmpl::list<JumpPosition, LeftMassDensity, LeftVelocity, LeftPressure,
+                 RightVelocity, RightPressure, Epsilon, Lambda>;
+
+  ShuOsherTube(double jump_position, double mass_density_l, double velocity_l,
+               double pressure_l, double velocity_r, double pressure_r,
+               double epsilon, double lambda) noexcept;
+  ShuOsherTube() = default;
+  ShuOsherTube(const ShuOsherTube& /*rhs*/) = delete;
+  ShuOsherTube& operator=(const ShuOsherTube& /*rhs*/) = delete;
+  ShuOsherTube(ShuOsherTube&& /*rhs*/) noexcept = default;
+  ShuOsherTube& operator=(ShuOsherTube&& /*rhs*/) noexcept = default;
+  ~ShuOsherTube() = default;
+
+  template <typename DataType, typename... Tags>
+  tuples::TaggedTuple<Tags...> variables(
+      const tnsr::I<DataType, 1, Frame::Inertial>& x,
+      tmpl::list<Tags...> /*meta*/) const noexcept {
+    return {tuples::get<Tags>(variables(x, tmpl::list<Tags>{}))...};
+  }
+
+  const EquationsOfState::IdealFluid<false>& equation_of_state()
+      const noexcept {
+    return equation_of_state_;
+  }
+
+  // clang-tidy: no runtime references
+  void pup(PUP::er& p) noexcept;  //  NOLINT
+
+ private:
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, 1, Frame::Inertial>& x,
+                 tmpl::list<Tags::MassDensity<DataType>> /*meta*/)
+      const noexcept -> tuples::TaggedTuple<Tags::MassDensity<DataType>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, 1, Frame::Inertial>& x,
+      tmpl::list<Tags::Velocity<DataType, 1, Frame::Inertial>> /*meta*/)
+      const noexcept
+      -> tuples::TaggedTuple<Tags::Velocity<DataType, 1, Frame::Inertial>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, 1, Frame::Inertial>& x,
+                 tmpl::list<Tags::Pressure<DataType>> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<Tags::Pressure<DataType>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, 1, Frame::Inertial>& x,
+                 tmpl::list<Tags::SpecificInternalEnergy<DataType>> /*meta*/)
+      const noexcept
+      -> tuples::TaggedTuple<Tags::SpecificInternalEnergy<DataType>>;
+
+  friend bool
+  operator==(  // NOLINT (clang-tidy: readability-redundant-declaration)
+      const ShuOsherTube& lhs, const ShuOsherTube& rhs) noexcept;
+
+  double mass_density_l_ = std::numeric_limits<double>::signaling_NaN();
+  double velocity_l_ = std::numeric_limits<double>::signaling_NaN();
+  double pressure_l_ = std::numeric_limits<double>::signaling_NaN();
+  double jump_position_ = std::numeric_limits<double>::signaling_NaN();
+  double epsilon_ = std::numeric_limits<double>::signaling_NaN();
+  double lambda_ = std::numeric_limits<double>::signaling_NaN();
+  double velocity_r_ = std::numeric_limits<double>::signaling_NaN();
+  double pressure_r_ = std::numeric_limits<double>::signaling_NaN();
+  double adiabatic_index_ = 1.4;
+  EquationsOfState::IdealFluid<false> equation_of_state_{adiabatic_index_};
+};
+
+bool operator!=(const ShuOsherTube& lhs, const ShuOsherTube& rhs) noexcept;
+}  // namespace NewtonianEuler::AnalyticData

--- a/src/PointwiseFunctions/AnalyticData/NewtonianEuler/SodExplosion.cpp
+++ b/src/PointwiseFunctions/AnalyticData/NewtonianEuler/SodExplosion.cpp
@@ -1,0 +1,158 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticData/NewtonianEuler/SodExplosion.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/Math.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
+
+/// \cond
+namespace NewtonianEuler::AnalyticData {
+template <size_t Dim>
+SodExplosion<Dim>::SodExplosion(const double initial_radius,
+                                const double inner_mass_density,
+                                const double inner_pressure,
+                                const double outer_mass_density,
+                                const double outer_pressure,
+                                const Options::Context& context)
+    : initial_radius_(initial_radius),
+      inner_mass_density_(inner_mass_density),
+      inner_pressure_(inner_pressure),
+      outer_mass_density_(outer_mass_density),
+      outer_pressure_(outer_pressure),
+      equation_of_state_(1.4) {
+  ASSERT(initial_radius_ > 0.0,
+         "The initial radius must be positive but is " << initial_radius_);
+  ASSERT(
+      inner_mass_density_ > 0.0,
+      "The inner mass density must be positive but is " << inner_mass_density_);
+  ASSERT(inner_pressure_ > 0.0,
+         "The inner pressure must be positive but is " << inner_pressure_);
+  ASSERT(
+      outer_mass_density_ > 0.0,
+      "The outer mass density must be positive but is " << outer_mass_density_);
+  ASSERT(outer_pressure_ > 0.0,
+         "The outer pressure must be positive but is " << outer_pressure_);
+  if (outer_mass_density_ > inner_mass_density_) {
+    PARSE_ERROR(context, "The inner mass density ("
+                             << inner_mass_density_
+                             << ") must be larger than the outer mass density ("
+                             << outer_mass_density_
+                             << ") so the shock moves radially outward.");
+  }
+  if (outer_pressure_ > inner_pressure_) {
+    PARSE_ERROR(context, "The inner pressure ("
+                             << inner_pressure_
+                             << ") must be larger than the outer pressure ("
+                             << outer_pressure_
+                             << ") so the shock moves radially outward.");
+  }
+}
+
+template <size_t Dim>
+void SodExplosion<Dim>::pup(PUP::er& p) noexcept {
+  p | initial_radius_;
+  p | inner_mass_density_;
+  p | inner_pressure_;
+  p | outer_mass_density_;
+  p | outer_pressure_;
+  p | equation_of_state_;
+}
+
+template <size_t Dim>
+bool operator==(const SodExplosion<Dim>& lhs,
+                const SodExplosion<Dim>& rhs) noexcept {
+  // No comparison for equation_of_state_. The adiabatic index is hard-coded.
+  return lhs.initial_radius_ == rhs.initial_radius_ and
+         lhs.inner_mass_density_ == rhs.inner_mass_density_ and
+         lhs.inner_pressure_ == rhs.inner_pressure_ and
+         lhs.outer_mass_density_ == rhs.outer_mass_density_ and
+         lhs.outer_pressure_ == rhs.outer_pressure_;
+}
+
+template <size_t Dim>
+bool operator!=(const SodExplosion<Dim>& lhs,
+                const SodExplosion<Dim>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+template <size_t Dim>
+tuples::TaggedTuple<Tags::MassDensity<DataVector>> SodExplosion<Dim>::variables(
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& x,
+    tmpl::list<Tags::MassDensity<DataVector>> /*meta*/) const noexcept {
+  auto mass_density = make_with_value<Scalar<DataVector>>(x, 0.0);
+  std::array<double, Dim> coords{};
+  for (size_t s = 0; s < get_size(get<0>(x)); ++s) {
+    for (size_t d = 0; d < Dim; ++d) {
+      gsl::at(coords, d) = get_element(x.get(d), s);
+    }
+    const double radius = magnitude(coords);
+    get_element(get(mass_density), s) =
+        radius > initial_radius_ ? outer_mass_density_ : inner_mass_density_;
+  }
+  return mass_density;
+}
+
+template <size_t Dim>
+tuples::TaggedTuple<Tags::Velocity<DataVector, Dim, Frame::Inertial>>
+SodExplosion<Dim>::variables(
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& x,
+    tmpl::list<Tags::Velocity<DataVector, Dim, Frame::Inertial>> /*meta*/)
+    const noexcept {
+  auto velocity = make_with_value<tnsr::I<DataVector, Dim, Frame::Inertial>>(
+      get<0>(x), 0.0);
+  return velocity;
+}
+
+template <size_t Dim>
+tuples::TaggedTuple<Tags::Pressure<DataVector>> SodExplosion<Dim>::variables(
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& x,
+    tmpl::list<Tags::Pressure<DataVector>> /*meta*/) const noexcept {
+  auto pressure = make_with_value<Scalar<DataVector>>(x, 0.0);
+  std::array<double, Dim> coords{};
+  for (size_t s = 0; s < get_size(get<0>(x)); ++s) {
+    for (size_t d = 0; d < Dim; ++d) {
+      gsl::at(coords, d) = get_element(x.get(d), s);
+    }
+    const double radius = magnitude(coords);
+    get_element(get(pressure), s) =
+        radius > initial_radius_ ? outer_pressure_ : inner_pressure_;
+  }
+  return pressure;
+}
+
+template <size_t Dim>
+tuples::TaggedTuple<Tags::SpecificInternalEnergy<DataVector>>
+SodExplosion<Dim>::variables(
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& x,
+    tmpl::list<Tags::SpecificInternalEnergy<DataVector>> /*meta*/)
+    const noexcept {
+  return equation_of_state_.specific_internal_energy_from_density_and_pressure(
+      get<Tags::MassDensity<DataVector>>(
+          variables(x, tmpl::list<Tags::MassDensity<DataVector>>{})),
+      get<Tags::Pressure<DataVector>>(
+          variables(x, tmpl::list<Tags::Pressure<DataVector>>{})));
+}
+
+template class SodExplosion<2>;
+template class SodExplosion<3>;
+template bool operator==(const SodExplosion<2>& lhs,
+                         const SodExplosion<2>& rhs) noexcept;
+template bool operator==(const SodExplosion<3>& lhs,
+                         const SodExplosion<3>& rhs) noexcept;
+template bool operator!=(const SodExplosion<2>& lhs,
+                         const SodExplosion<2>& rhs) noexcept;
+template bool operator!=(const SodExplosion<3>& lhs,
+                         const SodExplosion<3>& rhs) noexcept;
+}  // namespace NewtonianEuler::AnalyticData
+/// \endcond

--- a/src/PointwiseFunctions/AnalyticData/NewtonianEuler/SodExplosion.hpp
+++ b/src/PointwiseFunctions/AnalyticData/NewtonianEuler/SodExplosion.hpp
@@ -1,0 +1,158 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/NewtonianEuler/Sources/NoSource.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace PUP {
+class er;  // IWYU pragma: keep
+}  // namespace PUP
+/// \endcond
+
+namespace NewtonianEuler::AnalyticData {
+/*!
+ * \brief A cylindrical or spherical Sod explosion \cite Toro2009 \cite Sod19781
+ *
+ * Common initial conditions are:
+ *
+ * \f{align*}{
+ * (\rho, v^i, p) =
+ * &\left\{
+ * \begin{array}{ll}
+ *   (1 ,0, 1) & \mathrm{if} \; r \le 0.5 \\
+ *   (0.125 ,0, 0.1) & \mathrm{if} \; r > 0.5
+ * \end{array}\right.
+ * \f}
+ *
+ * where \f$r\f$ is the cylindrical (2d) or spherical (3d) radius. This test
+ * problem uses an adiabatic index of 1.4. A reference solution can be computed
+ * in 1d by solving the Newtonian Euler equations in cylindrical or spherical
+ * symmetry. Note that the inner and outer density and pressure, as well as
+ * where the initial discontinuity is can be chosen arbitrarily.
+ */
+template <size_t Dim>
+class SodExplosion : public MarkAsAnalyticData {
+ public:
+  static_assert(Dim > 1, "Sod explosion is a 2d and 3d problem.");
+  using equation_of_state_type = EquationsOfState::IdealFluid<false>;
+  using source_term_type = Sources::NoSource;
+
+  /// Initial radius of the discontinuity
+  struct InitialRadius {
+    using type = double;
+    static constexpr Options::String help = {
+        "The initial radius of the discontinuity."};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+
+  struct InnerMassDensity {
+    using type = double;
+    static constexpr Options::String help = {"The inner mass density."};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+
+  struct InnerPressure {
+    using type = double;
+    static constexpr Options::String help = {"The inner pressure."};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+
+  struct OuterMassDensity {
+    using type = double;
+    static constexpr Options::String help = {"The outer mass density."};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+
+  struct OuterPressure {
+    using type = double;
+    static constexpr Options::String help = {"The outer pressure."};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+
+  using options = tmpl::list<InitialRadius, InnerMassDensity, InnerPressure,
+                             OuterMassDensity, OuterPressure>;
+
+  static constexpr Options::String help = {
+      "Cylindrical or spherical Sod explosion."};
+
+  SodExplosion() = default;
+  SodExplosion(const SodExplosion& /*rhs*/) = delete;
+  SodExplosion& operator=(const SodExplosion& /*rhs*/) = delete;
+  SodExplosion(SodExplosion&& /*rhs*/) noexcept = default;
+  SodExplosion& operator=(SodExplosion&& /*rhs*/) noexcept = default;
+  ~SodExplosion() = default;
+
+  SodExplosion(double initial_radius, double inner_mass_density,
+               double inner_pressure, double outer_mass_density,
+               double outer_pressure, const Options::Context& context = {});
+
+  /// Retrieve a collection of hydrodynamic variables at position x
+  template <typename... Tags>
+  tuples::TaggedTuple<Tags...> variables(
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& x,
+      tmpl::list<Tags...> /*meta*/) const noexcept {
+    return {tuples::get<Tags>(variables(x, tmpl::list<Tags>{}))...};
+  }
+
+  const equation_of_state_type& equation_of_state() const noexcept {
+    return equation_of_state_;
+  }
+
+  // clang-tidy: no runtime references
+  void pup(PUP::er& /*p*/) noexcept;  //  NOLINT
+
+ private:
+  tuples::TaggedTuple<Tags::MassDensity<DataVector>> variables(
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& x,
+      tmpl::list<Tags::MassDensity<DataVector>> /*meta*/) const noexcept;
+
+  tuples::TaggedTuple<Tags::Velocity<DataVector, Dim, Frame::Inertial>>
+  variables(
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& x,
+      tmpl::list<Tags::Velocity<DataVector, Dim, Frame::Inertial>> /*meta*/)
+      const noexcept;
+
+  tuples::TaggedTuple<Tags::Pressure<DataVector>> variables(
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& x,
+      tmpl::list<Tags::Pressure<DataVector>> /*meta*/) const noexcept;
+
+  tuples::TaggedTuple<Tags::SpecificInternalEnergy<DataVector>> variables(
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& x,
+      tmpl::list<Tags::SpecificInternalEnergy<DataVector>> /*meta*/)
+      const noexcept;
+
+  template <size_t SpatialDim>
+  friend bool
+  operator==(  // NOLINT (clang-tidy: readability-redundant-declaration)
+      const SodExplosion<SpatialDim>& lhs,
+      const SodExplosion<SpatialDim>& rhs) noexcept;
+
+  double initial_radius_ = std::numeric_limits<double>::signaling_NaN();
+  double inner_mass_density_ = std::numeric_limits<double>::signaling_NaN();
+  double inner_pressure_ = std::numeric_limits<double>::signaling_NaN();
+  double outer_mass_density_ = std::numeric_limits<double>::signaling_NaN();
+  double outer_pressure_ = std::numeric_limits<double>::signaling_NaN();
+  equation_of_state_type equation_of_state_{};
+};
+
+template <size_t Dim>
+bool operator!=(const SodExplosion<Dim>& lhs,
+                const SodExplosion<Dim>& rhs) noexcept;
+}  // namespace NewtonianEuler::AnalyticData

--- a/tests/Unit/PointwiseFunctions/AnalyticData/NewtonianEuler/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/NewtonianEuler/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_NewtonianEulerAnalyticData")
 
 set(LIBRARY_SOURCES
   Test_KhInstability.cpp
+  Test_ShuOsherTube.cpp
   )
 
 add_test_library(

--- a/tests/Unit/PointwiseFunctions/AnalyticData/NewtonianEuler/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/NewtonianEuler/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_NewtonianEulerAnalyticData")
 set(LIBRARY_SOURCES
   Test_KhInstability.cpp
   Test_ShuOsherTube.cpp
+  Test_SodExplosion.cpp
   )
 
 add_test_library(

--- a/tests/Unit/PointwiseFunctions/AnalyticData/NewtonianEuler/ShuOsherTube.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/NewtonianEuler/ShuOsherTube.py
@@ -1,0 +1,33 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def mass_density(x, mass_density_l, velocity_l, pressure_l, jump_position,
+                 epsilon, wave_length, velocity_r, pressure_r,
+                 adiabatic_index):
+    if x < jump_position:
+        return mass_density_l
+    return 1.0 + epsilon * np.sin(wave_length * x[0])
+
+
+def velocity(x, mass_density_l, velocity_l, pressure_l, jump_position, epsilon,
+             wave_length, velocity_r, pressure_r, adiabatic_index):
+    return np.asarray([velocity_l if x < jump_position else velocity_r])
+
+
+def pressure(x, mass_density_l, velocity_l, pressure_l, jump_position, epsilon,
+             wave_length, velocity_r, pressure_r, adiabatic_index):
+    return pressure_l if x < jump_position else pressure_r
+
+
+def specific_internal_energy(x, mass_density_l, velocity_l, pressure_l,
+                             jump_position, epsilon, wave_length, velocity_r,
+                             pressure_r, adiabatic_index):
+    return pressure(
+        x, mass_density_l, velocity_l, pressure_l, jump_position, epsilon,
+        wave_length, velocity_r, pressure_r, adiabatic_index) / mass_density(
+            x, mass_density_l, velocity_l, pressure_l, jump_position, epsilon,
+            wave_length, velocity_r, pressure_r,
+            adiabatic_index) / (adiabatic_index - 1.0)

--- a/tests/Unit/PointwiseFunctions/AnalyticData/NewtonianEuler/SodExplosion.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/NewtonianEuler/SodExplosion.py
@@ -1,0 +1,33 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def mass_density(coords, initial_radius, inner_mass_density, inner_pressure,
+                 outer_mass_density, outer_pressure):
+    radius = np.sqrt(np.dot(coords, coords))
+    return (inner_mass_density
+            if radius <= initial_radius else outer_mass_density)
+
+
+def pressure(coords, initial_radius, inner_mass_density, inner_pressure,
+             outer_mass_density, outer_pressure):
+    radius = np.sqrt(np.dot(coords, coords))
+    return (inner_pressure if radius <= initial_radius else outer_pressure)
+
+
+def velocity(coords, initial_radius, inner_mass_density, inner_pressure,
+             outer_mass_density, outer_pressure):
+    return np.zeros([len(coords)])
+
+
+def specific_internal_energy(coords, initial_radius, inner_mass_density,
+                             inner_pressure, outer_mass_density,
+                             outer_pressure):
+    adiabatic_index = 1.4
+    return pressure(coords, initial_radius, inner_mass_density, inner_pressure,
+                    outer_mass_density, outer_pressure) / mass_density(
+                        coords, initial_radius, inner_mass_density,
+                        inner_pressure, outer_mass_density,
+                        outer_pressure) / (adiabatic_index - 1.0)

--- a/tests/Unit/PointwiseFunctions/AnalyticData/NewtonianEuler/Test_ShuOsherTube.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/NewtonianEuler/Test_ShuOsherTube.cpp
@@ -1,0 +1,93 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+#include <tuple>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "PointwiseFunctions/AnalyticData/NewtonianEuler/ShuOsherTube.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+struct ShuOsherTubeProxy : NewtonianEuler::AnalyticData::ShuOsherTube {
+  using NewtonianEuler::AnalyticData::ShuOsherTube::ShuOsherTube;
+
+  template <typename DataType>
+  using variables_tags =
+      tmpl::list<NewtonianEuler::Tags::MassDensity<DataType>,
+                 NewtonianEuler::Tags::Velocity<DataType, 1, Frame::Inertial>,
+                 NewtonianEuler::Tags::SpecificInternalEnergy<DataType>,
+                 NewtonianEuler::Tags::Pressure<DataType>>;
+
+  template <typename DataType>
+  tuples::tagged_tuple_from_typelist<variables_tags<DataType>>
+  primitive_variables(
+      const tnsr::I<DataType, 1, Frame::Inertial>& x) const noexcept {
+    return this->variables(x, variables_tags<DataType>{});
+  }
+};
+
+template <size_t Dim, typename DataType>
+void test_analytic_data(const DataType& used_for_size) noexcept {
+  const double mass_density_l = 3.857143;
+  const double velocity_l = 2.629369;
+  const double pressure_l = 10.33333;
+  const double jump_position = -4.0;
+  const double epsilon = 0.2;
+  const double lambda = 5.0;
+  const double velocity_r = 0.0;
+  const double pressure_r = 1.0;
+  const double adiabatic_index = 1.4;
+  const auto members =
+      std::make_tuple(mass_density_l, velocity_l, pressure_l, jump_position,
+                      epsilon, lambda, velocity_r, pressure_r, adiabatic_index);
+
+  ShuOsherTubeProxy shu_osher(jump_position, mass_density_l, velocity_l,
+                              pressure_l, velocity_r, pressure_r, epsilon,
+                              lambda);
+  pypp::check_with_random_values<1>(
+      &ShuOsherTubeProxy::template primitive_variables<DataType>, shu_osher,
+      "ShuOsherTube",
+      {"mass_density", "velocity", "specific_internal_energy", "pressure"},
+      {{{0.0, 1.0}}}, members, used_for_size);
+
+  const auto shu_osher_from_options =
+      TestHelpers::test_creation<NewtonianEuler::AnalyticData::ShuOsherTube>(
+          "  JumpPosition: -4.0\n"
+          "  LeftMassDensity: 3.857143\n"
+          "  LeftVelocity: 2.629369\n"
+          "  LeftPressure: 10.33333\n"
+          "  RightVelocity: 0.0\n"
+          "  RightPressure: 1.0\n"
+          "  Epsilon: 0.2\n"
+          "  Lambda: 5.0\n");
+  CHECK(shu_osher_from_options == shu_osher);
+
+  // run post-serialized state through checks with random numbers
+  pypp::check_with_random_values<1>(
+      &ShuOsherTubeProxy::template primitive_variables<DataType>,
+      serialize_and_deserialize(shu_osher), "ShuOsherTube",
+      {"mass_density", "velocity", "specific_internal_energy", "pressure"},
+      {{{0.0, 1.0}}}, members, used_for_size);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticData.NewtEuler.ShuOsherTube",
+                  "[Unit][PointwiseFunctions]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/AnalyticData/NewtonianEuler"};
+
+  GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_analytic_data, (1));
+}

--- a/tests/Unit/PointwiseFunctions/AnalyticData/NewtonianEuler/Test_SodExplosion.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/NewtonianEuler/Test_SodExplosion.cpp
@@ -1,0 +1,102 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+#include <tuple>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "PointwiseFunctions/AnalyticData/NewtonianEuler/SodExplosion.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+
+template <size_t Dim>
+struct SodExplosionProxy : NewtonianEuler::AnalyticData::SodExplosion<Dim> {
+  using NewtonianEuler::AnalyticData::SodExplosion<Dim>::SodExplosion;
+
+  template <typename DataType>
+  using variables_tags =
+      tmpl::list<NewtonianEuler::Tags::MassDensity<DataType>,
+                 NewtonianEuler::Tags::Velocity<DataType, Dim, Frame::Inertial>,
+                 NewtonianEuler::Tags::SpecificInternalEnergy<DataType>,
+                 NewtonianEuler::Tags::Pressure<DataType>>;
+
+  tuples::tagged_tuple_from_typelist<variables_tags<DataVector>>
+  primitive_variables(
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& x) const noexcept {
+    return this->variables(x, variables_tags<DataVector>{});
+  }
+};
+
+template <size_t Dim>
+void test_analytic_data(const DataVector& used_for_size) noexcept {
+  const double initial_radius = 0.5;
+  const double inner_mass_density = 1.0;
+  const double inner_pressure = 1.0;
+  const double outer_mass_density = 0.125;
+  const double outer_pressure = 0.1;
+
+  const auto members =
+      std::make_tuple(initial_radius, inner_mass_density, inner_pressure,
+                      outer_mass_density, outer_pressure);
+
+  const SodExplosionProxy<Dim> sod_explosion(initial_radius, inner_mass_density,
+                                             inner_pressure, outer_mass_density,
+                                             outer_pressure);
+  pypp::check_with_random_values<1>(
+      &SodExplosionProxy<Dim>::primitive_variables, sod_explosion,
+      "SodExplosion",
+      {"mass_density", "velocity", "specific_internal_energy", "pressure"},
+      {{{0.0, 1.0}}}, members, used_for_size);
+
+  const auto sod_explosion_from_options = TestHelpers::test_creation<
+      NewtonianEuler::AnalyticData::SodExplosion<Dim>>(
+      "InitialRadius: 0.5\n"
+      "InnerMassDensity: 1.0\n"
+      "InnerPressure: 1.0\n"
+      "OuterMassDensity: 0.125\n"
+      "OuterPressure: 0.1\n");
+  CHECK(sod_explosion_from_options == sod_explosion);
+
+  // run post-serialized state through checks with random numbers
+  pypp::check_with_random_values<1>(
+      &SodExplosionProxy<Dim>::primitive_variables,
+      serialize_and_deserialize(sod_explosion), "SodExplosion",
+      {"mass_density", "velocity", "specific_internal_energy", "pressure"},
+      {{{0.0, 1.0}}}, members, used_for_size);
+
+  CHECK_THROWS_WITH(NewtonianEuler::AnalyticData::SodExplosion<Dim>(
+                        initial_radius, inner_mass_density, inner_pressure,
+                        outer_mass_density + 100.0, outer_pressure,
+                        Options::Context{false, {}, 1, 1}),
+                    Catch::Matchers::Contains("The inner mass density ("));
+  CHECK_THROWS_WITH(NewtonianEuler::AnalyticData::SodExplosion<Dim>(
+                        initial_radius, inner_mass_density, inner_pressure,
+                        outer_mass_density, outer_pressure + 100.0,
+                        Options::Context{false, {}, 1, 1}),
+                    Catch::Matchers::Contains("The inner pressure ("));
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticData.NewtEuler.SodExplosion",
+                  "[Unit][PointwiseFunctions]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/AnalyticData/NewtonianEuler"};
+
+  DataVector used_for_size{5};
+  test_analytic_data<2>(used_for_size);
+  test_analytic_data<3>(used_for_size);
+}


### PR DESCRIPTION
## Proposed changes

These are nice 1d and 2d/3d test problems I was using for DG-subcell. The Sod explosion is useful for deformed meshes since we can use a disk and see how well the subcell code tracks the radial shocks.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
