### PR TITLE
Use system without boundary condition in 3d domain creator tests

### DIFF
--- a/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
+++ b/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
@@ -76,47 +76,53 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
       dynamic_cast<const creators::AlignedLattice<2>*>(domain_creator_2d.get());
   test_aligned_blocks(*aligned_blocks_creator_2d);
 
-  const auto domain_creator_3d =
-      TestHelpers::test_factory_creation<DomainCreator<3>>(
-          "AlignedLattice:\n"
-          "  BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2], [-0.2, 3.2]]\n"
-          "  IsPeriodicIn: [false, true, false]\n"
-          "  InitialGridPoints: [3, 4, 5]\n"
-          "  InitialLevels: [2, 1, 0]\n"
-          "  RefinedLevels: []\n"
-          "  RefinedGridPoints: []\n"
-          "  BlocksToExclude: []\n");
+  const auto domain_creator_3d = TestHelpers::test_factory_creation<
+      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
+      "AlignedLattice:\n"
+      "  BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2], [-0.2, 3.2]]\n"
+      "  IsPeriodicIn: [false, true, false]\n"
+      "  InitialGridPoints: [3, 4, 5]\n"
+      "  InitialLevels: [2, 1, 0]\n"
+      "  RefinedLevels: []\n"
+      "  RefinedGridPoints: []\n"
+      "  BlocksToExclude: []\n");
   const auto* aligned_blocks_creator_3d =
       dynamic_cast<const creators::AlignedLattice<3>*>(domain_creator_3d.get());
   test_aligned_blocks(*aligned_blocks_creator_3d);
 
-  const auto cubical_shell_domain =
-      TestHelpers::test_factory_creation<DomainCreator<3>>(
-          "AlignedLattice:\n"
-          "  BlockBounds: [[0.1, 2.6, 5.1, 6.0], [-0.4, 3.2, 6.2, 7.0], "
-          "[-0.2, 3.2, 4.0, 5.2]]\n"
-          "  IsPeriodicIn: [false, false, false]\n"
-          "  InitialGridPoints: [3, 4, 5]\n"
-          "  InitialLevels: [2, 1, 0]\n"
-          "  RefinedLevels: []\n"
-          "  RefinedGridPoints: []\n"
-          "  BlocksToExclude: [[1, 1, 1]]");
+  const auto cubical_shell_domain = TestHelpers::test_factory_creation<
+      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
+      "AlignedLattice:\n"
+      "  BlockBounds: [[0.1, 2.6, 5.1, 6.0], [-0.4, 3.2, 6.2, 7.0], "
+      "[-0.2, 3.2, 4.0, 5.2]]\n"
+      "  IsPeriodicIn: [false, false, false]\n"
+      "  InitialGridPoints: [3, 4, 5]\n"
+      "  InitialLevels: [2, 1, 0]\n"
+      "  RefinedLevels: []\n"
+      "  RefinedGridPoints: []\n"
+      "  BlocksToExclude: [[1, 1, 1]]");
   const auto* cubical_shell_creator_3d =
       dynamic_cast<const creators::AlignedLattice<3>*>(
           cubical_shell_domain.get());
   test_aligned_blocks(*cubical_shell_creator_3d);
 
-  const auto unit_cubical_shell_domain =
-      TestHelpers::test_factory_creation<DomainCreator<3>>(
-          "AlignedLattice:\n"
-          "  BlockBounds: [[-1.5, -0.5, 0.5, 1.5], [-1.5, -0.5, 0.5, 1.5], "
-          "[-1.5, -0.5, 0.5, 1.5]]\n"
-          "  IsPeriodicIn: [false, false, false]\n"
-          "  InitialGridPoints: [5, 5, 5]\n"
-          "  InitialLevels: [1, 1, 1]\n"
-          "  RefinedLevels: []\n"
-          "  RefinedGridPoints: []\n"
-          "  BlocksToExclude: [[1, 1, 1]]");
+  const auto unit_cubical_shell_domain = TestHelpers::test_factory_creation<
+      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
+      "AlignedLattice:\n"
+      "  BlockBounds: [[-1.5, -0.5, 0.5, 1.5], [-1.5, -0.5, 0.5, 1.5], "
+      "[-1.5, -0.5, 0.5, 1.5]]\n"
+      "  IsPeriodicIn: [false, false, false]\n"
+      "  InitialGridPoints: [5, 5, 5]\n"
+      "  InitialLevels: [1, 1, 1]\n"
+      "  RefinedLevels: []\n"
+      "  RefinedGridPoints: []\n"
+      "  BlocksToExclude: [[1, 1, 1]]");
   const auto* unit_cubical_shell_creator_3d =
       dynamic_cast<const creators::AlignedLattice<3>*>(
           unit_cubical_shell_domain.get());
@@ -228,16 +234,18 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
 SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice.Error",
                   "[Unit][ErrorHandling]") {
   ERROR_TEST();
-  const auto failed_cubical_shell_domain =
-      TestHelpers::test_factory_creation<DomainCreator<3>>(
-          "AlignedLattice:\n"
-          "  BlockBounds: [[-1.5, -0.5, 0.5, 1.5], [-1.5, -0.5, 0.5, 1.5], "
-          "[-1.5, -0.5, 0.5, 1.5]]\n"
-          "  IsPeriodicIn: [true, false, false]\n"
-          "  InitialGridPoints: [5, 5, 5]\n"
-          "  InitialLevels: [1, 1, 1]\n"
-          "  RefinedLevels: []\n"
-          "  RefinedGridPoints: []\n"
-          "  BlocksToExclude: [[1, 1, 1]]");
+  const auto failed_cubical_shell_domain = TestHelpers::test_factory_creation<
+      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
+      "AlignedLattice:\n"
+      "  BlockBounds: [[-1.5, -0.5, 0.5, 1.5], [-1.5, -0.5, 0.5, 1.5], "
+      "[-1.5, -0.5, 0.5, 1.5]]\n"
+      "  IsPeriodicIn: [true, false, false]\n"
+      "  InitialGridPoints: [5, 5, 5]\n"
+      "  InitialLevels: [1, 1, 1]\n"
+      "  RefinedLevels: []\n"
+      "  RefinedGridPoints: []\n"
+      "  BlocksToExclude: [[1, 1, 1]]");
 }
 }  // namespace domain

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -25,8 +25,10 @@
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/OptionTags.hpp"
 #include "Domain/Structure/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Framework/TestCreation.hpp"
+#include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Helpers/Domain/Creators/TestHelpers.hpp"
 #include "Helpers/Domain/DomainTestHelpers.hpp"
 
@@ -136,36 +138,38 @@ void test_connectivity() {
 }
 }
 void test_bbh_time_dependent_factory() {
-  const auto binary_compact_object =
-      TestHelpers::test_factory_creation<DomainCreator<3>>(
-          "  BinaryCompactObject:\n"
-          "    InnerRadiusObjectA: 0.2\n"
-          "    OuterRadiusObjectA: 1.0\n"
-          "    XCoordObjectA: -2.0\n"
-          "    ExciseInteriorA: true\n"
-          "    InnerRadiusObjectB: 1.0\n"
-          "    OuterRadiusObjectB: 2.0\n"
-          "    XCoordObjectB: 3.0\n"
-          "    ExciseInteriorB: true\n"
-          "    RadiusOuterCube: 22.0\n"
-          "    RadiusOuterSphere: 25.0\n"
-          "    InitialRefinement: 1\n"
-          "    InitialGridPoints: 3\n"
-          "    UseEquiangularMap: true\n"
-          "    UseProjectiveMap: true\n"
-          "    UseLogarithmicMapOuterSphericalShell: false\n"
-          "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
-          "    UseLogarithmicMapObjectA: false\n"
-          "    AdditionToObjectARadialRefinementLevel: 0\n"
-          "    UseLogarithmicMapObjectB: false\n"
-          "    AdditionToObjectBRadialRefinementLevel: 0\n"
-          "    TimeDependence:\n"
-          "      UniformTranslation:\n"
-          "        InitialTime: 1.0\n"
-          "        InitialExpirationDeltaT: 9.0\n"
-          "        Velocity: [2.3, -0.3, 0.5]\n"
-          "        FunctionOfTimeNames: [TranslationX, TranslationY, "
-          "TranslationZ]");
+  const auto binary_compact_object = TestHelpers::test_factory_creation<
+      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
+      "  BinaryCompactObject:\n"
+      "    InnerRadiusObjectA: 0.2\n"
+      "    OuterRadiusObjectA: 1.0\n"
+      "    XCoordObjectA: -2.0\n"
+      "    ExciseInteriorA: true\n"
+      "    InnerRadiusObjectB: 1.0\n"
+      "    OuterRadiusObjectB: 2.0\n"
+      "    XCoordObjectB: 3.0\n"
+      "    ExciseInteriorB: true\n"
+      "    RadiusOuterCube: 22.0\n"
+      "    RadiusOuterSphere: 25.0\n"
+      "    InitialRefinement: 1\n"
+      "    InitialGridPoints: 3\n"
+      "    UseEquiangularMap: true\n"
+      "    UseProjectiveMap: true\n"
+      "    UseLogarithmicMapOuterSphericalShell: false\n"
+      "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
+      "    UseLogarithmicMapObjectA: false\n"
+      "    AdditionToObjectARadialRefinementLevel: 0\n"
+      "    UseLogarithmicMapObjectB: false\n"
+      "    AdditionToObjectBRadialRefinementLevel: 0\n"
+      "    TimeDependence:\n"
+      "      UniformTranslation:\n"
+      "        InitialTime: 1.0\n"
+      "        InitialExpirationDeltaT: 9.0\n"
+      "        Velocity: [2.3, -0.3, 0.5]\n"
+      "        FunctionOfTimeNames: [TranslationX, TranslationY, "
+      "TranslationZ]");
   const std::array<double, 4> times_to_check{{0.0, 4.4, 7.8}};
 
   constexpr double initial_time = 0.0;
@@ -222,300 +226,320 @@ void test_bbh_time_dependent_factory() {
 }
 
 void test_bbh_equiangular_factory() {
-  const auto binary_compact_object =
-      TestHelpers::test_factory_creation<DomainCreator<3>>(
-          "  BinaryCompactObject:\n"
-          "    InnerRadiusObjectA: 0.2\n"
-          "    OuterRadiusObjectA: 1.0\n"
-          "    XCoordObjectA: -2.0\n"
-          "    ExciseInteriorA: true\n"
-          "    InnerRadiusObjectB: 1.0\n"
-          "    OuterRadiusObjectB: 2.0\n"
-          "    XCoordObjectB: 3.0\n"
-          "    ExciseInteriorB: true\n"
-          "    RadiusOuterCube: 22.0\n"
-          "    RadiusOuterSphere: 25.0\n"
-          "    InitialRefinement: 1\n"
-          "    InitialGridPoints: 3\n"
-          "    UseEquiangularMap: true\n"
-          "    UseProjectiveMap: true\n"
-          "    UseLogarithmicMapOuterSphericalShell: false\n"
-          "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
-          "    UseLogarithmicMapObjectA: false\n"
-          "    AdditionToObjectARadialRefinementLevel: 0\n"
-          "    UseLogarithmicMapObjectB: false\n"
-          "    AdditionToObjectBRadialRefinementLevel: 0\n"
-          "    TimeDependence: None\n");
+  const auto binary_compact_object = TestHelpers::test_factory_creation<
+      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
+      "  BinaryCompactObject:\n"
+      "    InnerRadiusObjectA: 0.2\n"
+      "    OuterRadiusObjectA: 1.0\n"
+      "    XCoordObjectA: -2.0\n"
+      "    ExciseInteriorA: true\n"
+      "    InnerRadiusObjectB: 1.0\n"
+      "    OuterRadiusObjectB: 2.0\n"
+      "    XCoordObjectB: 3.0\n"
+      "    ExciseInteriorB: true\n"
+      "    RadiusOuterCube: 22.0\n"
+      "    RadiusOuterSphere: 25.0\n"
+      "    InitialRefinement: 1\n"
+      "    InitialGridPoints: 3\n"
+      "    UseEquiangularMap: true\n"
+      "    UseProjectiveMap: true\n"
+      "    UseLogarithmicMapOuterSphericalShell: false\n"
+      "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
+      "    UseLogarithmicMapObjectA: false\n"
+      "    AdditionToObjectARadialRefinementLevel: 0\n"
+      "    UseLogarithmicMapObjectB: false\n"
+      "    AdditionToObjectBRadialRefinementLevel: 0\n"
+      "    TimeDependence: None\n");
   test_binary_compact_object_construction(
       dynamic_cast<const domain::creators::BinaryCompactObject&>(
           *binary_compact_object));
 }
 
 void test_bbh_2_outer_radial_refinements_linear_map_factory() {
-  const auto binary_compact_object =
-      TestHelpers::test_factory_creation<DomainCreator<3>>(
-          "  BinaryCompactObject:\n"
-          "    InnerRadiusObjectA: 0.2\n"
-          "    OuterRadiusObjectA: 1.0\n"
-          "    XCoordObjectA: -2.0\n"
-          "    ExciseInteriorA: true\n"
-          "    InnerRadiusObjectB: 1.0\n"
-          "    OuterRadiusObjectB: 2.0\n"
-          "    XCoordObjectB: 3.0\n"
-          "    ExciseInteriorB: true\n"
-          "    RadiusOuterCube: 22.0\n"
-          "    RadiusOuterSphere: 25.0\n"
-          "    InitialRefinement: 1\n"
-          "    InitialGridPoints: 3\n"
-          "    UseEquiangularMap: true\n"
-          "    UseProjectiveMap: true\n"
-          "    UseLogarithmicMapOuterSphericalShell: false\n"
-          "    AdditionToOuterLayerRadialRefinementLevel: 2\n"
-          "    UseLogarithmicMapObjectA: false\n"
-          "    AdditionToObjectARadialRefinementLevel: 0\n"
-          "    UseLogarithmicMapObjectB: false\n"
-          "    AdditionToObjectBRadialRefinementLevel: 2\n"
-          "    TimeDependence: None\n");
+  const auto binary_compact_object = TestHelpers::test_factory_creation<
+      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
+      "  BinaryCompactObject:\n"
+      "    InnerRadiusObjectA: 0.2\n"
+      "    OuterRadiusObjectA: 1.0\n"
+      "    XCoordObjectA: -2.0\n"
+      "    ExciseInteriorA: true\n"
+      "    InnerRadiusObjectB: 1.0\n"
+      "    OuterRadiusObjectB: 2.0\n"
+      "    XCoordObjectB: 3.0\n"
+      "    ExciseInteriorB: true\n"
+      "    RadiusOuterCube: 22.0\n"
+      "    RadiusOuterSphere: 25.0\n"
+      "    InitialRefinement: 1\n"
+      "    InitialGridPoints: 3\n"
+      "    UseEquiangularMap: true\n"
+      "    UseProjectiveMap: true\n"
+      "    UseLogarithmicMapOuterSphericalShell: false\n"
+      "    AdditionToOuterLayerRadialRefinementLevel: 2\n"
+      "    UseLogarithmicMapObjectA: false\n"
+      "    AdditionToObjectARadialRefinementLevel: 0\n"
+      "    UseLogarithmicMapObjectB: false\n"
+      "    AdditionToObjectBRadialRefinementLevel: 2\n"
+      "    TimeDependence: None\n");
   test_binary_compact_object_construction(
       dynamic_cast<const domain::creators::BinaryCompactObject&>(
           *binary_compact_object));
 }
 
 void test_bbh_3_outer_radial_refinements_log_map_factory() {
-  const auto binary_compact_object =
-      TestHelpers::test_factory_creation<DomainCreator<3>>(
-          "  BinaryCompactObject:\n"
-          "    InnerRadiusObjectA: 0.2\n"
-          "    OuterRadiusObjectA: 1.0\n"
-          "    XCoordObjectA: -2.0\n"
-          "    ExciseInteriorA: true\n"
-          "    InnerRadiusObjectB: 1.0\n"
-          "    OuterRadiusObjectB: 2.0\n"
-          "    XCoordObjectB: 3.0\n"
-          "    ExciseInteriorB: true\n"
-          "    RadiusOuterCube: 22.0\n"
-          "    RadiusOuterSphere: 25.0\n"
-          "    InitialRefinement: 1\n"
-          "    InitialGridPoints: 3\n"
-          "    UseEquiangularMap: true\n"
-          "    UseProjectiveMap: true\n"
-          "    UseLogarithmicMapOuterSphericalShell: false\n"
-          "    AdditionToOuterLayerRadialRefinementLevel: 3\n"
-          "    UseLogarithmicMapObjectA: true\n"
-          "    AdditionToObjectARadialRefinementLevel: 3\n"
-          "    UseLogarithmicMapObjectB: true\n"
-          "    AdditionToObjectBRadialRefinementLevel: 0\n"
-          "    TimeDependence: None\n");
+  const auto binary_compact_object = TestHelpers::test_factory_creation<
+      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
+      "  BinaryCompactObject:\n"
+      "    InnerRadiusObjectA: 0.2\n"
+      "    OuterRadiusObjectA: 1.0\n"
+      "    XCoordObjectA: -2.0\n"
+      "    ExciseInteriorA: true\n"
+      "    InnerRadiusObjectB: 1.0\n"
+      "    OuterRadiusObjectB: 2.0\n"
+      "    XCoordObjectB: 3.0\n"
+      "    ExciseInteriorB: true\n"
+      "    RadiusOuterCube: 22.0\n"
+      "    RadiusOuterSphere: 25.0\n"
+      "    InitialRefinement: 1\n"
+      "    InitialGridPoints: 3\n"
+      "    UseEquiangularMap: true\n"
+      "    UseProjectiveMap: true\n"
+      "    UseLogarithmicMapOuterSphericalShell: false\n"
+      "    AdditionToOuterLayerRadialRefinementLevel: 3\n"
+      "    UseLogarithmicMapObjectA: true\n"
+      "    AdditionToObjectARadialRefinementLevel: 3\n"
+      "    UseLogarithmicMapObjectB: true\n"
+      "    AdditionToObjectBRadialRefinementLevel: 0\n"
+      "    TimeDependence: None\n");
   test_binary_compact_object_construction(
       dynamic_cast<const domain::creators::BinaryCompactObject&>(
           *binary_compact_object));
 }
 
 void test_bbh_equidistant_factory() {
-  const auto binary_compact_object =
-      TestHelpers::test_factory_creation<DomainCreator<3>>(
-          "  BinaryCompactObject:\n"
-          "    InnerRadiusObjectA: 0.2\n"
-          "    OuterRadiusObjectA: 1.0\n"
-          "    XCoordObjectA: -2.0\n"
-          "    ExciseInteriorA: true\n"
-          "    InnerRadiusObjectB: 1.0\n"
-          "    OuterRadiusObjectB: 2.0\n"
-          "    XCoordObjectB: 3.0\n"
-          "    ExciseInteriorB: true\n"
-          "    RadiusOuterCube: 22.0\n"
-          "    RadiusOuterSphere: 25.0\n"
-          "    InitialRefinement: 1\n"
-          "    InitialGridPoints: 3\n"
-          "    UseEquiangularMap: false\n"
-          "    UseProjectiveMap: true\n"
-          "    UseLogarithmicMapOuterSphericalShell: false\n"
-          "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
-          "    UseLogarithmicMapObjectA: false\n"
-          "    AdditionToObjectARadialRefinementLevel: 0\n"
-          "    UseLogarithmicMapObjectB: false\n"
-          "    AdditionToObjectBRadialRefinementLevel: 0\n"
-          "    TimeDependence: None\n");
+  const auto binary_compact_object = TestHelpers::test_factory_creation<
+      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
+      "  BinaryCompactObject:\n"
+      "    InnerRadiusObjectA: 0.2\n"
+      "    OuterRadiusObjectA: 1.0\n"
+      "    XCoordObjectA: -2.0\n"
+      "    ExciseInteriorA: true\n"
+      "    InnerRadiusObjectB: 1.0\n"
+      "    OuterRadiusObjectB: 2.0\n"
+      "    XCoordObjectB: 3.0\n"
+      "    ExciseInteriorB: true\n"
+      "    RadiusOuterCube: 22.0\n"
+      "    RadiusOuterSphere: 25.0\n"
+      "    InitialRefinement: 1\n"
+      "    InitialGridPoints: 3\n"
+      "    UseEquiangularMap: false\n"
+      "    UseProjectiveMap: true\n"
+      "    UseLogarithmicMapOuterSphericalShell: false\n"
+      "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
+      "    UseLogarithmicMapObjectA: false\n"
+      "    AdditionToObjectARadialRefinementLevel: 0\n"
+      "    UseLogarithmicMapObjectB: false\n"
+      "    AdditionToObjectBRadialRefinementLevel: 0\n"
+      "    TimeDependence: None\n");
   test_binary_compact_object_construction(
       dynamic_cast<const domain::creators::BinaryCompactObject&>(
           *binary_compact_object));
 }
 
 void test_bns_equiangular_factory() {
-  const auto binary_compact_object =
-      TestHelpers::test_factory_creation<DomainCreator<3>>(
-          "  BinaryCompactObject:\n"
-          "    InnerRadiusObjectA: 0.2\n"
-          "    OuterRadiusObjectA: 1.0\n"
-          "    XCoordObjectA: -2.0\n"
-          "    ExciseInteriorA: false\n"
-          "    InnerRadiusObjectB: 1.0\n"
-          "    OuterRadiusObjectB: 2.0\n"
-          "    XCoordObjectB: 3.0\n"
-          "    ExciseInteriorB: false\n"
-          "    RadiusOuterCube: 22.0\n"
-          "    RadiusOuterSphere: 25.0\n"
-          "    InitialRefinement: 1\n"
-          "    InitialGridPoints: 3\n"
-          "    UseEquiangularMap: true\n"
-          "    UseProjectiveMap: true\n"
-          "    UseLogarithmicMapOuterSphericalShell: false\n"
-          "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
-          "    UseLogarithmicMapObjectA: false\n"
-          "    AdditionToObjectARadialRefinementLevel: 0\n"
-          "    UseLogarithmicMapObjectB: false\n"
-          "    AdditionToObjectBRadialRefinementLevel: 0\n"
-          "    TimeDependence: None\n");
+  const auto binary_compact_object = TestHelpers::test_factory_creation<
+      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
+      "  BinaryCompactObject:\n"
+      "    InnerRadiusObjectA: 0.2\n"
+      "    OuterRadiusObjectA: 1.0\n"
+      "    XCoordObjectA: -2.0\n"
+      "    ExciseInteriorA: false\n"
+      "    InnerRadiusObjectB: 1.0\n"
+      "    OuterRadiusObjectB: 2.0\n"
+      "    XCoordObjectB: 3.0\n"
+      "    ExciseInteriorB: false\n"
+      "    RadiusOuterCube: 22.0\n"
+      "    RadiusOuterSphere: 25.0\n"
+      "    InitialRefinement: 1\n"
+      "    InitialGridPoints: 3\n"
+      "    UseEquiangularMap: true\n"
+      "    UseProjectiveMap: true\n"
+      "    UseLogarithmicMapOuterSphericalShell: false\n"
+      "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
+      "    UseLogarithmicMapObjectA: false\n"
+      "    AdditionToObjectARadialRefinementLevel: 0\n"
+      "    UseLogarithmicMapObjectB: false\n"
+      "    AdditionToObjectBRadialRefinementLevel: 0\n"
+      "    TimeDependence: None\n");
   test_binary_compact_object_construction(
       dynamic_cast<const domain::creators::BinaryCompactObject&>(
           *binary_compact_object));
 }
 
 void test_bns_equidistant_factory() {
-  const auto binary_compact_object =
-      TestHelpers::test_factory_creation<DomainCreator<3>>(
-          "  BinaryCompactObject:\n"
-          "    InnerRadiusObjectA: 0.2\n"
-          "    OuterRadiusObjectA: 1.0\n"
-          "    XCoordObjectA: -2.0\n"
-          "    ExciseInteriorA: false\n"
-          "    InnerRadiusObjectB: 1.0\n"
-          "    OuterRadiusObjectB: 2.0\n"
-          "    XCoordObjectB: 3.0\n"
-          "    ExciseInteriorB: false\n"
-          "    RadiusOuterCube: 22.0\n"
-          "    RadiusOuterSphere: 25.0\n"
-          "    InitialRefinement: 1\n"
-          "    InitialGridPoints: 3\n"
-          "    UseEquiangularMap: false\n"
-          "    UseProjectiveMap: true\n"
-          "    UseLogarithmicMapOuterSphericalShell: false\n"
-          "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
-          "    UseLogarithmicMapObjectA: false\n"
-          "    AdditionToObjectARadialRefinementLevel: 0\n"
-          "    UseLogarithmicMapObjectB: false\n"
-          "    AdditionToObjectBRadialRefinementLevel: 0\n"
-          "    TimeDependence: None\n");
+  const auto binary_compact_object = TestHelpers::test_factory_creation<
+      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
+      "  BinaryCompactObject:\n"
+      "    InnerRadiusObjectA: 0.2\n"
+      "    OuterRadiusObjectA: 1.0\n"
+      "    XCoordObjectA: -2.0\n"
+      "    ExciseInteriorA: false\n"
+      "    InnerRadiusObjectB: 1.0\n"
+      "    OuterRadiusObjectB: 2.0\n"
+      "    XCoordObjectB: 3.0\n"
+      "    ExciseInteriorB: false\n"
+      "    RadiusOuterCube: 22.0\n"
+      "    RadiusOuterSphere: 25.0\n"
+      "    InitialRefinement: 1\n"
+      "    InitialGridPoints: 3\n"
+      "    UseEquiangularMap: false\n"
+      "    UseProjectiveMap: true\n"
+      "    UseLogarithmicMapOuterSphericalShell: false\n"
+      "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
+      "    UseLogarithmicMapObjectA: false\n"
+      "    AdditionToObjectARadialRefinementLevel: 0\n"
+      "    UseLogarithmicMapObjectB: false\n"
+      "    AdditionToObjectBRadialRefinementLevel: 0\n"
+      "    TimeDependence: None\n");
   test_binary_compact_object_construction(
       dynamic_cast<const domain::creators::BinaryCompactObject&>(
           *binary_compact_object));
 }
 
 void test_bhns_equiangular_factory() {
-  const auto binary_compact_object =
-      TestHelpers::test_factory_creation<DomainCreator<3>>(
-          "  BinaryCompactObject:\n"
-          "    InnerRadiusObjectA: 0.2\n"
-          "    OuterRadiusObjectA: 1.0\n"
-          "    XCoordObjectA: -2.0\n"
-          "    ExciseInteriorA: true\n"
-          "    InnerRadiusObjectB: 1.0\n"
-          "    OuterRadiusObjectB: 2.0\n"
-          "    XCoordObjectB: 3.0\n"
-          "    ExciseInteriorB: false\n"
-          "    RadiusOuterCube: 22.0\n"
-          "    RadiusOuterSphere: 25.0\n"
-          "    InitialRefinement: 1\n"
-          "    InitialGridPoints: 3\n"
-          "    UseEquiangularMap: true\n"
-          "    UseProjectiveMap: true\n"
-          "    UseLogarithmicMapOuterSphericalShell: false\n"
-          "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
-          "    UseLogarithmicMapObjectA: false\n"
-          "    AdditionToObjectARadialRefinementLevel: 0\n"
-          "    UseLogarithmicMapObjectB: false\n"
-          "    AdditionToObjectBRadialRefinementLevel: 0\n"
-          "    TimeDependence: None\n");
+  const auto binary_compact_object = TestHelpers::test_factory_creation<
+      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
+      "  BinaryCompactObject:\n"
+      "    InnerRadiusObjectA: 0.2\n"
+      "    OuterRadiusObjectA: 1.0\n"
+      "    XCoordObjectA: -2.0\n"
+      "    ExciseInteriorA: true\n"
+      "    InnerRadiusObjectB: 1.0\n"
+      "    OuterRadiusObjectB: 2.0\n"
+      "    XCoordObjectB: 3.0\n"
+      "    ExciseInteriorB: false\n"
+      "    RadiusOuterCube: 22.0\n"
+      "    RadiusOuterSphere: 25.0\n"
+      "    InitialRefinement: 1\n"
+      "    InitialGridPoints: 3\n"
+      "    UseEquiangularMap: true\n"
+      "    UseProjectiveMap: true\n"
+      "    UseLogarithmicMapOuterSphericalShell: false\n"
+      "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
+      "    UseLogarithmicMapObjectA: false\n"
+      "    AdditionToObjectARadialRefinementLevel: 0\n"
+      "    UseLogarithmicMapObjectB: false\n"
+      "    AdditionToObjectBRadialRefinementLevel: 0\n"
+      "    TimeDependence: None\n");
   test_binary_compact_object_construction(
       dynamic_cast<const domain::creators::BinaryCompactObject&>(
           *binary_compact_object));
 }
 
 void test_bhns_equidistant_factory() {
-  const auto binary_compact_object =
-      TestHelpers::test_factory_creation<DomainCreator<3>>(
-          "  BinaryCompactObject:\n"
-          "    InnerRadiusObjectA: 0.2\n"
-          "    OuterRadiusObjectA: 1.0\n"
-          "    XCoordObjectA: -2.0\n"
-          "    ExciseInteriorA: true\n"
-          "    InnerRadiusObjectB: 1.0\n"
-          "    OuterRadiusObjectB: 2.0\n"
-          "    XCoordObjectB: 3.0\n"
-          "    ExciseInteriorB: false\n"
-          "    RadiusOuterCube: 22.0\n"
-          "    RadiusOuterSphere: 25.0\n"
-          "    InitialRefinement: 1\n"
-          "    InitialGridPoints: 3\n"
-          "    UseEquiangularMap: false\n"
-          "    UseProjectiveMap: true\n"
-          "    UseLogarithmicMapOuterSphericalShell: false\n"
-          "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
-          "    UseLogarithmicMapObjectA: false\n"
-          "    AdditionToObjectARadialRefinementLevel: 0\n"
-          "    UseLogarithmicMapObjectB: false\n"
-          "    AdditionToObjectBRadialRefinementLevel: 0\n"
-          "    TimeDependence: None\n");
+  const auto binary_compact_object = TestHelpers::test_factory_creation<
+      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
+      "  BinaryCompactObject:\n"
+      "    InnerRadiusObjectA: 0.2\n"
+      "    OuterRadiusObjectA: 1.0\n"
+      "    XCoordObjectA: -2.0\n"
+      "    ExciseInteriorA: true\n"
+      "    InnerRadiusObjectB: 1.0\n"
+      "    OuterRadiusObjectB: 2.0\n"
+      "    XCoordObjectB: 3.0\n"
+      "    ExciseInteriorB: false\n"
+      "    RadiusOuterCube: 22.0\n"
+      "    RadiusOuterSphere: 25.0\n"
+      "    InitialRefinement: 1\n"
+      "    InitialGridPoints: 3\n"
+      "    UseEquiangularMap: false\n"
+      "    UseProjectiveMap: true\n"
+      "    UseLogarithmicMapOuterSphericalShell: false\n"
+      "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
+      "    UseLogarithmicMapObjectA: false\n"
+      "    AdditionToObjectARadialRefinementLevel: 0\n"
+      "    UseLogarithmicMapObjectB: false\n"
+      "    AdditionToObjectBRadialRefinementLevel: 0\n"
+      "    TimeDependence: None\n");
   test_binary_compact_object_construction(
       dynamic_cast<const domain::creators::BinaryCompactObject&>(
           *binary_compact_object));
 }
 
 void test_nsbh_equiangular_factory() {
-  const auto binary_compact_object =
-      TestHelpers::test_factory_creation<DomainCreator<3>>(
-          "  BinaryCompactObject:\n"
-          "    InnerRadiusObjectA: 0.2\n"
-          "    OuterRadiusObjectA: 1.0\n"
-          "    XCoordObjectA: -2.0\n"
-          "    ExciseInteriorA: false\n"
-          "    InnerRadiusObjectB: 1.0\n"
-          "    OuterRadiusObjectB: 2.0\n"
-          "    XCoordObjectB: 3.0\n"
-          "    ExciseInteriorB: true\n"
-          "    RadiusOuterCube: 22.0\n"
-          "    RadiusOuterSphere: 25.0\n"
-          "    InitialRefinement: 1\n"
-          "    InitialGridPoints: 3\n"
-          "    UseEquiangularMap: true\n"
-          "    UseProjectiveMap: true\n"
-          "    UseLogarithmicMapOuterSphericalShell: false\n"
-          "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
-          "    UseLogarithmicMapObjectA: false\n"
-          "    AdditionToObjectARadialRefinementLevel: 0\n"
-          "    UseLogarithmicMapObjectB: false\n"
-          "    AdditionToObjectBRadialRefinementLevel: 0\n"
-          "    TimeDependence: None\n");
+  const auto binary_compact_object = TestHelpers::test_factory_creation<
+      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
+      "  BinaryCompactObject:\n"
+      "    InnerRadiusObjectA: 0.2\n"
+      "    OuterRadiusObjectA: 1.0\n"
+      "    XCoordObjectA: -2.0\n"
+      "    ExciseInteriorA: false\n"
+      "    InnerRadiusObjectB: 1.0\n"
+      "    OuterRadiusObjectB: 2.0\n"
+      "    XCoordObjectB: 3.0\n"
+      "    ExciseInteriorB: true\n"
+      "    RadiusOuterCube: 22.0\n"
+      "    RadiusOuterSphere: 25.0\n"
+      "    InitialRefinement: 1\n"
+      "    InitialGridPoints: 3\n"
+      "    UseEquiangularMap: true\n"
+      "    UseProjectiveMap: true\n"
+      "    UseLogarithmicMapOuterSphericalShell: false\n"
+      "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
+      "    UseLogarithmicMapObjectA: false\n"
+      "    AdditionToObjectARadialRefinementLevel: 0\n"
+      "    UseLogarithmicMapObjectB: false\n"
+      "    AdditionToObjectBRadialRefinementLevel: 0\n"
+      "    TimeDependence: None\n");
   test_binary_compact_object_construction(
       dynamic_cast<const domain::creators::BinaryCompactObject&>(
           *binary_compact_object));
 }
 
 void test_nsbh_equidistant_factory() {
-  const auto binary_compact_object =
-      TestHelpers::test_factory_creation<DomainCreator<3>>(
-          "  BinaryCompactObject:\n"
-          "    InnerRadiusObjectA: 0.2\n"
-          "    OuterRadiusObjectA: 1.0\n"
-          "    XCoordObjectA: -2.0\n"
-          "    ExciseInteriorA: false\n"
-          "    InnerRadiusObjectB: 1.0\n"
-          "    OuterRadiusObjectB: 2.0\n"
-          "    XCoordObjectB: 3.0\n"
-          "    ExciseInteriorB: true\n"
-          "    RadiusOuterCube: 22.0\n"
-          "    RadiusOuterSphere: 25.0\n"
-          "    InitialRefinement: 1\n"
-          "    InitialGridPoints: 3\n"
-          "    UseEquiangularMap: false\n"
-          "    UseProjectiveMap: true\n"
-          "    UseLogarithmicMapOuterSphericalShell: false\n"
-          "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
-          "    UseLogarithmicMapObjectA: false\n"
-          "    AdditionToObjectARadialRefinementLevel: 0\n"
-          "    UseLogarithmicMapObjectB: false\n"
-          "    AdditionToObjectBRadialRefinementLevel: 0\n"
-          "    TimeDependence: None\n");
+  const auto binary_compact_object = TestHelpers::test_factory_creation<
+      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
+      "  BinaryCompactObject:\n"
+      "    InnerRadiusObjectA: 0.2\n"
+      "    OuterRadiusObjectA: 1.0\n"
+      "    XCoordObjectA: -2.0\n"
+      "    ExciseInteriorA: false\n"
+      "    InnerRadiusObjectB: 1.0\n"
+      "    OuterRadiusObjectB: 2.0\n"
+      "    XCoordObjectB: 3.0\n"
+      "    ExciseInteriorB: true\n"
+      "    RadiusOuterCube: 22.0\n"
+      "    RadiusOuterSphere: 25.0\n"
+      "    InitialRefinement: 1\n"
+      "    InitialGridPoints: 3\n"
+      "    UseEquiangularMap: false\n"
+      "    UseProjectiveMap: true\n"
+      "    UseLogarithmicMapOuterSphericalShell: false\n"
+      "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
+      "    UseLogarithmicMapObjectA: false\n"
+      "    AdditionToObjectARadialRefinementLevel: 0\n"
+      "    UseLogarithmicMapObjectB: false\n"
+      "    AdditionToObjectBRadialRefinementLevel: 0\n"
+      "    TimeDependence: None\n");
   test_binary_compact_object_construction(
       dynamic_cast<const domain::creators::BinaryCompactObject&>(
           *binary_compact_object));

--- a/tests/Unit/Domain/Creators/Test_Brick.cpp
+++ b/tests/Unit/Domain/Creators/Test_Brick.cpp
@@ -27,12 +27,14 @@
 #include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/OptionTags.hpp"
 #include "Domain/Structure/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "Helpers/Domain/Creators/TestHelpers.hpp"
 #include "Helpers/Domain/DomainTestHelpers.hpp"
@@ -229,15 +231,17 @@ void test_brick() {
 void test_brick_factory() {
   {
     INFO("Brick factory time independent");
-    const auto domain_creator =
-        TestHelpers::test_factory_creation<DomainCreator<3>>(
-            "Brick:\n"
-            "  LowerBound: [0,0,0]\n"
-            "  UpperBound: [1,2,3]\n"
-            "  IsPeriodicIn: [True,False,True]\n"
-            "  InitialGridPoints: [3,4,3]\n"
-            "  InitialRefinement: [2,3,2]\n"
-            "  TimeDependence: None\n");
+    const auto domain_creator = TestHelpers::test_factory_creation<
+        DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+        TestHelpers::domain::BoundaryConditions::
+            MetavariablesWithoutBoundaryConditions<3>>(
+        "Brick:\n"
+        "  LowerBound: [0,0,0]\n"
+        "  UpperBound: [1,2,3]\n"
+        "  IsPeriodicIn: [True,False,True]\n"
+        "  InitialGridPoints: [3,4,3]\n"
+        "  InitialRefinement: [2,3,2]\n"
+        "  TimeDependence: None\n");
     const auto* brick_creator =
         dynamic_cast<const creators::Brick*>(domain_creator.get());
     test_brick_construction(
@@ -253,21 +257,23 @@ void test_brick_factory() {
   }
   {
     INFO("Brick factory time dependent");
-    const auto domain_creator =
-        TestHelpers::test_factory_creation<DomainCreator<3>>(
-            "Brick:\n"
-            "  LowerBound: [0,0,0]\n"
-            "  UpperBound: [1,2,3]\n"
-            "  IsPeriodicIn: [True,False,True]\n"
-            "  InitialGridPoints: [3,4,3]\n"
-            "  InitialRefinement: [2,3,2]\n"
-            "  TimeDependence:\n"
-            "    UniformTranslation:\n"
-            "      InitialTime: 1.0\n"
-            "      InitialExpirationDeltaT: 9.0\n"
-            "      Velocity: [2.3, -0.3, 0.5]\n"
-            "      FunctionOfTimeNames: [TranslationX, TranslationY, "
-            "TranslationZ]");
+    const auto domain_creator = TestHelpers::test_factory_creation<
+        DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+        TestHelpers::domain::BoundaryConditions::
+            MetavariablesWithoutBoundaryConditions<3>>(
+        "Brick:\n"
+        "  LowerBound: [0,0,0]\n"
+        "  UpperBound: [1,2,3]\n"
+        "  IsPeriodicIn: [True,False,True]\n"
+        "  InitialGridPoints: [3,4,3]\n"
+        "  InitialRefinement: [2,3,2]\n"
+        "  TimeDependence:\n"
+        "    UniformTranslation:\n"
+        "      InitialTime: 1.0\n"
+        "      InitialExpirationDeltaT: 9.0\n"
+        "      Velocity: [2.3, -0.3, 0.5]\n"
+        "      FunctionOfTimeNames: [TranslationX, TranslationY, "
+        "TranslationZ]");
     const auto* brick_creator =
         dynamic_cast<const creators::Brick*>(domain_creator.get());
     test_brick_construction(

--- a/tests/Unit/Domain/Creators/Test_Cylinder.cpp
+++ b/tests/Unit/Domain/Creators/Test_Cylinder.cpp
@@ -23,12 +23,14 @@
 #include "Domain/Creators/Cylinder.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Domain.hpp"
+#include "Domain/OptionTags.hpp"
 #include "Domain/Structure/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Helpers/Domain/DomainTestHelpers.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/MakeArray.hpp"
@@ -220,7 +222,10 @@ void test_cylinder_boundaries_equiangular() {
 
 void test_cylinder_factory_equiangular() {
   INFO("Cylinder factory equiangular");
-  const auto cylinder = TestHelpers::test_factory_creation<DomainCreator<3>>(
+  const auto cylinder = TestHelpers::test_factory_creation<
+      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
       "Cylinder:\n"
       "  InnerRadius: 1.0\n"
       "  OuterRadius: 3.0\n"
@@ -265,7 +270,10 @@ void test_cylinder_boundaries_equidistant() {
 
 void test_cylinder_factory_equidistant() {
   INFO("Cylinder factory equidistant");
-  const auto cylinder = TestHelpers::test_factory_creation<DomainCreator<3>>(
+  const auto cylinder = TestHelpers::test_factory_creation<
+      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
       "Cylinder:\n"
       "  InnerRadius: 1.0\n"
       "  OuterRadius: 3.0\n"
@@ -310,7 +318,10 @@ void test_cylinder_boundaries_equiangular_not_periodic_in_z() {
 
 void test_cylinder_factory_equiangular_not_periodic_in_z() {
   INFO("Cylinder factory equiangular not periodic in z");
-  const auto cylinder = TestHelpers::test_factory_creation<DomainCreator<3>>(
+  const auto cylinder = TestHelpers::test_factory_creation<
+      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
       "Cylinder:\n"
       "  InnerRadius: 1.0\n"
       "  OuterRadius: 3.0\n"
@@ -355,7 +366,10 @@ void test_cylinder_boundaries_equidistant_not_periodic_in_z() {
 
 void test_cylinder_factory_equidistant_not_periodic_in_z() {
   INFO("Cylinder factory equidistant not periodic in z");
-  const auto cylinder = TestHelpers::test_factory_creation<DomainCreator<3>>(
+  const auto cylinder = TestHelpers::test_factory_creation<
+      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
       "Cylinder:\n"
       "  InnerRadius: 1.0\n"
       "  OuterRadius: 3.0\n"

--- a/tests/Unit/Domain/Creators/Test_FrustalCloak.cpp
+++ b/tests/Unit/Domain/Creators/Test_FrustalCloak.cpp
@@ -16,9 +16,11 @@
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/FrustalCloak.hpp"
 #include "Domain/Domain.hpp"
+#include "Domain/OptionTags.hpp"
 #include "Domain/Structure/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Helpers/Domain/DomainTestHelpers.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 
@@ -35,16 +37,18 @@ void test_frustal_cloak_construction(
 }
 
 void test_factory() {
-  const auto frustal_cloak =
-      TestHelpers::test_factory_creation<DomainCreator<3>>(
-          "FrustalCloak:\n"
-          "  InitialRefinement: 3\n"
-          "  InitialGridPoints: [2,3]\n"
-          "  UseEquiangularMap: true\n"
-          "  ProjectionFactor: 0.3\n"
-          "  LengthInnerCube: 15.5\n"
-          "  LengthOuterCube: 42.4\n"
-          "  OriginPreimage: [0.2,0.3,-0.1]");
+  const auto frustal_cloak = TestHelpers::test_factory_creation<
+      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
+      "FrustalCloak:\n"
+      "  InitialRefinement: 3\n"
+      "  InitialGridPoints: [2,3]\n"
+      "  UseEquiangularMap: true\n"
+      "  ProjectionFactor: 0.3\n"
+      "  LengthInnerCube: 15.5\n"
+      "  LengthOuterCube: 42.4\n"
+      "  OriginPreimage: [0.2,0.3,-0.1]");
   test_frustal_cloak_construction(
       dynamic_cast<const domain::creators::FrustalCloak&>(*frustal_cloak));
 }

--- a/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
@@ -20,12 +20,14 @@
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/RotatedBricks.hpp"
 #include "Domain/Domain.hpp"
+#include "Domain/OptionTags.hpp"
 #include "Domain/Structure/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Helpers/Domain/DomainTestHelpers.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 
@@ -284,15 +286,17 @@ void test_rotated_bricks_factory() {
   const OrientationMap<3> rotation_F_then_U{std::array<Direction<3>, 3>{
       {Direction<3>::lower_zeta(), Direction<3>::upper_xi(),
        Direction<3>::lower_eta()}}};
-  const auto domain_creator =
-      TestHelpers::test_factory_creation<DomainCreator<3>>(
-          "RotatedBricks:\n"
-          "  LowerBound: [0.1, -0.4, -0.2]\n"
-          "  Midpoint:   [2.6, 3.2, 1.7]\n"
-          "  UpperBound: [5.1, 6.2, 3.2]\n"
-          "  IsPeriodicIn: [false, false, false]\n"
-          "  InitialGridPoints: [[3,2],[1,4],[5,6]]\n"
-          "  InitialRefinement: [2,1,0]\n");
+  const auto domain_creator = TestHelpers::test_factory_creation<
+      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
+      "RotatedBricks:\n"
+      "  LowerBound: [0.1, -0.4, -0.2]\n"
+      "  Midpoint:   [2.6, 3.2, 1.7]\n"
+      "  UpperBound: [5.1, 6.2, 3.2]\n"
+      "  IsPeriodicIn: [false, false, false]\n"
+      "  InitialGridPoints: [[3,2],[1,4],[5,6]]\n"
+      "  InitialRefinement: [2,1,0]\n");
   const auto* rotated_bricks_creator =
       dynamic_cast<const creators::RotatedBricks*>(domain_creator.get());
   test_rotated_bricks_construction(

--- a/tests/Unit/Domain/Creators/Test_Shell.cpp
+++ b/tests/Unit/Domain/Creators/Test_Shell.cpp
@@ -31,6 +31,7 @@
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
 #include "Domain/ElementMap.hpp"
+#include "Domain/OptionTags.hpp"
 #include "Domain/Structure/BlockId.hpp"
 #include "Domain/Structure/BlockNeighbor.hpp"
 #include "Domain/Structure/Direction.hpp"
@@ -41,6 +42,7 @@
 #include "Domain/Structure/SegmentId.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Helpers/Domain/DomainTestHelpers.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/CloneUniquePtrs.hpp"
@@ -307,17 +309,20 @@ void test_shell_boundaries() {
 
 void test_shell_factory_equiangular() {
   INFO("Shell factory equiangular");
-  const auto shell = TestHelpers::test_factory_creation<DomainCreator<3>>(
-          "Shell:\n"
-          "  InnerRadius: 1\n"
-          "  OuterRadius: 3\n"
-          "  InitialRefinement: 2\n"
-          "  InitialGridPoints: [2,3]\n"
-          "  UseEquiangularMap: true\n"
-          "  AspectRatio: 1.0\n"
-          "  UseLogarithmicMap: false\n"
-          "  WhichWedges: All\n"
-          "  RadialBlockLayers: 1\n");
+  const auto shell = TestHelpers::test_factory_creation<
+      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
+      "Shell:\n"
+      "  InnerRadius: 1\n"
+      "  OuterRadius: 3\n"
+      "  InitialRefinement: 2\n"
+      "  InitialGridPoints: [2,3]\n"
+      "  UseEquiangularMap: true\n"
+      "  AspectRatio: 1.0\n"
+      "  UseLogarithmicMap: false\n"
+      "  WhichWedges: All\n"
+      "  RadialBlockLayers: 1\n");
   const double inner_radius = 1.0;
   const double outer_radius = 3.0;
   const size_t refinement_level = 2;
@@ -329,7 +334,10 @@ void test_shell_factory_equiangular() {
 
 void test_shell_factory_equidistant() {
   INFO("Shell factory equidistant");
-  const auto shell = TestHelpers::test_factory_creation<DomainCreator<3>>(
+  const auto shell = TestHelpers::test_factory_creation<
+      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
       "Shell:\n"
       "  InnerRadius: 1\n"
       "  OuterRadius: 3\n"
@@ -368,7 +376,10 @@ void test_shell_boundaries_aspect_ratio() {
 
 void test_shell_factory_aspect_ratio() {
   INFO("Shell factory aspect ratio");
-  const auto shell = TestHelpers::test_factory_creation<DomainCreator<3>>(
+  const auto shell = TestHelpers::test_factory_creation<
+      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
       "Shell:\n"
       "  InnerRadius: 1\n"
       "  OuterRadius: 3\n"
@@ -410,7 +421,10 @@ void test_shell_boundaries_logarithmic_map() {
 
 void test_shell_factory_logarithmic_map() {
   INFO("Shell factory logarithmic map");
-  const auto shell = TestHelpers::test_factory_creation<DomainCreator<3>>(
+  const auto shell = TestHelpers::test_factory_creation<
+      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
       "Shell:\n"
       "  InnerRadius: 1\n"
       "  OuterRadius: 3\n"
@@ -435,7 +449,10 @@ void test_shell_factory_logarithmic_map() {
 
 void test_shell_factory_wedges_four_on_equator() {
   INFO("Shell factory wedges four on equator");
-  const auto shell = TestHelpers::test_factory_creation<DomainCreator<3>>(
+  const auto shell = TestHelpers::test_factory_creation<
+      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
       "Shell:\n"
       "  InnerRadius: 1\n"
       "  OuterRadius: 3\n"
@@ -461,7 +478,10 @@ void test_shell_factory_wedges_four_on_equator() {
 
 void test_shell_factory_wedges_one_along_minus_x() {
   INFO("Shell factory wedges one along minus x");
-  const auto shell = TestHelpers::test_factory_creation<DomainCreator<3>>(
+  const auto shell = TestHelpers::test_factory_creation<
+      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
       "Shell:\n"
       "  InnerRadius: 2\n"
       "  OuterRadius: 3\n"
@@ -587,7 +607,10 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Shell", "[Domain][Unit]") {
 
   {
     INFO("shell factory logarithmic block layers");
-    const auto log_shell = TestHelpers::test_factory_creation<DomainCreator<3>>(
+    const auto log_shell = TestHelpers::test_factory_creation<
+        DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+        TestHelpers::domain::BoundaryConditions::
+            MetavariablesWithoutBoundaryConditions<3>>(
         "Shell:\n"
         "  InnerRadius: 1\n"
         "  OuterRadius: 3\n"

--- a/tests/Unit/Domain/Creators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/Test_Sphere.cpp
@@ -25,12 +25,14 @@
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/Sphere.hpp"
 #include "Domain/Domain.hpp"
+#include "Domain/OptionTags.hpp"
 #include "Domain/Structure/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Helpers/Domain/DomainTestHelpers.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/CloneUniquePtrs.hpp"
@@ -228,7 +230,10 @@ void test_sphere_boundaries_equiangular() {
 
 void test_sphere_factory_equiangular() {
   INFO("Sphere factory equiangular");
-  const auto sphere = TestHelpers::test_factory_creation<DomainCreator<3>>(
+  const auto sphere = TestHelpers::test_factory_creation<
+      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
       "  Sphere:\n"
       "    InnerRadius: 1\n"
       "    OuterRadius: 3\n"
@@ -263,7 +268,10 @@ void test_sphere_boundaries_equidistant() {
 
 void test_sphere_factory_equidistant() {
   INFO("Sphere factory equidistant");
-  const auto sphere = TestHelpers::test_factory_creation<DomainCreator<3>>(
+  const auto sphere = TestHelpers::test_factory_creation<
+      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
       "  Sphere:\n"
       "    InnerRadius: 1\n"
       "    OuterRadius: 3\n"

--- a/tests/Unit/Domain/FunctionsOfTime/Test_ReadSpecThirdOrderPiecewisePolynomial.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_ReadSpecThirdOrderPiecewisePolynomial.cpp
@@ -20,9 +20,11 @@
 #include "Domain/FunctionsOfTime/ReadSpecThirdOrderPiecewisePolynomial.hpp"
 #include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
 #include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Domain/OptionTags.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "IO/H5/AccessType.hpp"
 #include "IO/H5/Dat.hpp"
 #include "IO/H5/File.hpp"
@@ -195,7 +197,9 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.ReadSpecPiecewisePolynomial",
 
   const auto& created_domain_creator =
       TestHelpers::test_creation<std::unique_ptr<::DomainCreator<3>>,
-                                 domain::OptionTags::DomainCreator<3>>(
+                                 domain::OptionTags::DomainCreator<3>,
+                                 TestHelpers::domain::BoundaryConditions::
+                                     MetavariablesWithoutBoundaryConditions<3>>(
           "Brick:\n"
           "  LowerBound: [-4.0, -5.0, -6.0]\n"
           "  UpperBound: [6.0, 5.0, 4.0]\n"


### PR DESCRIPTION
## Proposed changes

**I highly recommend using the "Hide white space" GitHub feature. Most of the changes are whitespace**

This changes all the 3d domain creator tests to use Metavariables and `OptionTags::DomainCreator` when testing factory creation. Whenever the first of the 3d domain creators is switched to support boundary conditions, all the creation tests will need to be changed. My goal is to get this PR merged and then submit all the individual 3d domain creators as separate PRs since they'll all be independent at that point.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
