### PR TITLE
Fix linking of DomainBoundaryConditions lib

### DIFF
--- a/src/Domain/BoundaryConditions/CMakeLists.txt
+++ b/src/Domain/BoundaryConditions/CMakeLists.txt
@@ -22,7 +22,10 @@ spectre_target_headers(
 
 target_link_libraries(
   ${LIBRARY}
+  PUBLIC
+  Options
+  Parallel
+  Utilities
   INTERFACE
   ErrorHandling
-  Parallel
   )


### PR DESCRIPTION
## Proposed changes

This fix is needed to compile with AppleClang. The libs must be public because they are needed to compile the Periodic.cpp source file, which includes headers from these libs.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
