### PR TITLE
Add elliptic AnalyticSolution boundary condition

### DIFF
--- a/src/Elliptic/BoundaryConditions/AnalyticSolution.hpp
+++ b/src/Elliptic/BoundaryConditions/AnalyticSolution.hpp
@@ -1,0 +1,250 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <ostream>
+#include <pup.h>
+#include <string>
+
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Slice.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/IndexToSliceAt.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryConditionType.hpp"
+#include "Elliptic/BoundaryConditions/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "Utilities/TypeTraits/IsA.hpp"
+
+namespace elliptic::BoundaryConditions {
+
+/// \cond
+template <typename System, size_t Dim, typename FieldTags, typename FluxTags,
+          typename Registrars>
+struct AnalyticSolution;
+
+namespace Registrars {
+template <typename System, size_t Dim = System::volume_dim,
+          typename FieldTags = typename System::primal_fields,
+          typename FluxTags = typename System::primal_fluxes>
+struct AnalyticSolution {
+  template <typename Registrars>
+  using f = BoundaryConditions::AnalyticSolution<System, Dim, FieldTags,
+                                                 FluxTags, Registrars>;
+};
+}  // namespace Registrars
+
+template <typename System, size_t Dim = System::volume_dim,
+          typename FieldTags = typename System::primal_fields,
+          typename FluxTags = typename System::primal_fluxes,
+          typename Registrars =
+              tmpl::list<BoundaryConditions::Registrars::AnalyticSolution<
+                  System, Dim, FieldTags, FluxTags>>>
+struct AnalyticSolution;
+/// \endcond
+
+/*!
+ * \brief Impose the analytic solution on the boundary. Works only if an
+ * analytic solution exists.
+ *
+ * The analytic solution is retrieved from `::Tags::AnalyticSolutionsBase`. It
+ * must hold solutions for both the `System::primal_fields` and the
+ * `System::primal_fluxes`. The user can select to impose the analytic solution
+ * as Dirichlet or Neumann boundary conditions for each field separately.
+ * Dirichlet boundary conditions are imposed on the fields and Neumann boundary
+ * conditions are imposed on the fluxes.
+ *
+ * See `elliptic::Actions::InitializeAnalyticSolutions` for an action that can
+ * add the analytic solutions to the DataBox.
+ */
+template <typename System, size_t Dim, typename... FieldTags,
+          typename... FluxTags, typename Registrars>
+class AnalyticSolution<System, Dim, tmpl::list<FieldTags...>,
+                       tmpl::list<FluxTags...>, Registrars>
+    : public BoundaryCondition<Dim, Registrars> {
+ private:
+  using Base = BoundaryCondition<Dim, Registrars>;
+
+ public:
+  using options =
+      tmpl::list<elliptic::OptionTags::BoundaryConditionType<FieldTags>...>;
+  static constexpr Options::String help =
+      "Boundary conditions from the analytic solution";
+
+  AnalyticSolution() = default;
+  AnalyticSolution(const AnalyticSolution&) noexcept = default;
+  AnalyticSolution& operator=(const AnalyticSolution&) noexcept = default;
+  AnalyticSolution(AnalyticSolution&&) noexcept = default;
+  AnalyticSolution& operator=(AnalyticSolution&&) noexcept = default;
+  ~AnalyticSolution() noexcept = default;
+
+  /// \cond
+  explicit AnalyticSolution(CkMigrateMessage* m) noexcept : Base(m) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(AnalyticSolution);
+  /// \endcond
+
+  /// Select which `elliptic::BoundaryConditionType` to apply for each field
+  explicit AnalyticSolution(
+      // This pack expansion repeats the type `elliptic::BoundaryConditionType`
+      // for each system field
+      const typename elliptic::OptionTags::BoundaryConditionType<
+          FieldTags>::type... boundary_condition_types) noexcept
+      : boundary_condition_types_{boundary_condition_types...} {}
+
+  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> get_clone()
+      const noexcept override {
+    return std::make_unique<AnalyticSolution>(*this);
+  }
+
+  const auto& boundary_condition_types() const noexcept {
+    return boundary_condition_types_;
+  }
+
+  using argument_tags =
+      tmpl::list<::Tags::AnalyticSolutionsBase, domain::Tags::Mesh<Dim>,
+                 domain::Tags::Direction<Dim>,
+                 ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<
+                     Dim, Frame::Inertial>>>;
+  using volume_tags =
+      tmpl::list<::Tags::AnalyticSolutionsBase, domain::Tags::Mesh<Dim>>;
+
+  template <typename OptionalAnalyticSolutions>
+  void apply(const gsl::not_null<typename FieldTags::type*>... fields,
+             const gsl::not_null<typename FieldTags::type*>... n_dot_fluxes,
+             const OptionalAnalyticSolutions& optional_analytic_solutions,
+             const Mesh<Dim>& volume_mesh, const Direction<Dim>& direction,
+             const tnsr::i<DataVector, Dim>& face_normal) const noexcept {
+    const auto& analytic_solutions = [&optional_analytic_solutions]() noexcept
+        -> const auto& {
+      if constexpr (tt::is_a_v<std::optional, OptionalAnalyticSolutions>) {
+        if (not optional_analytic_solutions.has_value()) {
+          ERROR_NO_TRACE(
+              "Trying to impose boundary conditions from an analytic solution, "
+              "but no analytic solution is available. You probably selected "
+              "the 'AnalyticSolution' boundary condition but chose to solve a "
+              "problem that has no analytic solution. If this is the case, you "
+              "should probably select a different boundary condition.");
+        }
+        return *optional_analytic_solutions;
+      } else {
+        return optional_analytic_solutions;
+      }
+    }
+    ();
+    const size_t slice_index =
+        index_to_slice_at(volume_mesh.extents(), direction);
+    const auto impose_boundary_condition = [this, &analytic_solutions,
+                                            &volume_mesh, &direction,
+                                            &slice_index, &face_normal](
+                                               auto field_tag_v,
+                                               auto flux_tag_v,
+                                               const auto field,
+                                               const auto n_dot_flux) noexcept {
+      using field_tag = decltype(field_tag_v);
+      using flux_tag = decltype(flux_tag_v);
+      switch (get<elliptic::Tags::BoundaryConditionType<field_tag>>(
+          boundary_condition_types())) {
+        case elliptic::BoundaryConditionType::Dirichlet:
+          data_on_slice(
+              field, get<::Tags::Analytic<field_tag>>(analytic_solutions),
+              volume_mesh.extents(), direction.dimension(), slice_index);
+          break;
+        case elliptic::BoundaryConditionType::Neumann:
+          normal_dot_flux(
+              n_dot_flux, face_normal,
+              data_on_slice(get<::Tags::Analytic<flux_tag>>(analytic_solutions),
+                            volume_mesh.extents(), direction.dimension(),
+                            slice_index));
+          break;
+        default:
+          ERROR("Unsupported boundary condition type: "
+                << get<elliptic::Tags::BoundaryConditionType<field_tag>>(
+                       boundary_condition_types()));
+      }
+    };
+    EXPAND_PACK_LEFT_TO_RIGHT(impose_boundary_condition(FieldTags{}, FluxTags{},
+                                                        fields, n_dot_fluxes));
+  }
+
+  using argument_tags_linearized = tmpl::list<>;
+  using volume_tags_linearized = tmpl::list<>;
+
+  void apply_linearized(
+      const gsl::not_null<typename FieldTags::type*>... fields,
+      const gsl::not_null<typename FieldTags::type*>... n_dot_fluxes)
+      const noexcept {
+    const auto impose_boundary_condition = [this](
+                                               auto field_tag_v,
+                                               const auto field,
+                                               const auto n_dot_flux) noexcept {
+      using field_tag = decltype(field_tag_v);
+      switch (get<elliptic::Tags::BoundaryConditionType<field_tag>>(
+          boundary_condition_types())) {
+        case elliptic::BoundaryConditionType::Dirichlet:
+          for (auto& field_component : *field) {
+            field_component = 0.;
+          }
+          break;
+        case elliptic::BoundaryConditionType::Neumann:
+          for (auto& n_dot_flux_component : *n_dot_flux) {
+            n_dot_flux_component = 0.;
+          }
+          break;
+        default:
+          ERROR("Unsupported boundary condition type: "
+                << get<elliptic::Tags::BoundaryConditionType<field_tag>>(
+                       boundary_condition_types()));
+      }
+    };
+    EXPAND_PACK_LEFT_TO_RIGHT(
+        impose_boundary_condition(FieldTags{}, fields, n_dot_fluxes));
+  }
+
+  // NOLINTNEXTLINE
+  void pup(PUP::er& p) noexcept override;
+
+ private:
+  friend bool operator==(const AnalyticSolution& lhs,
+                         const AnalyticSolution& rhs) noexcept {
+    return lhs.boundary_condition_types_ == rhs.boundary_condition_types_;
+  }
+
+  friend bool operator!=(const AnalyticSolution& lhs,
+                         const AnalyticSolution& rhs) noexcept {
+    return not(lhs == rhs);
+  }
+
+  tuples::TaggedTuple<elliptic::Tags::BoundaryConditionType<FieldTags>...>
+      boundary_condition_types_{};
+};
+
+template <typename System, size_t Dim, typename... FieldTags,
+          typename... FluxTags, typename Registrars>
+void AnalyticSolution<System, Dim, tmpl::list<FieldTags...>,
+                      tmpl::list<FluxTags...>,
+                      Registrars>::pup(PUP::er& p) noexcept {
+  Base::pup(p);
+  p | boundary_condition_types_;
+}
+
+/// \cond
+template <typename System, size_t Dim, typename... FieldTags,
+          typename... FluxTags, typename Registrars>
+PUP::able::PUP_ID AnalyticSolution<System, Dim, tmpl::list<FieldTags...>,
+                                   tmpl::list<FluxTags...>,
+                                   Registrars>::my_PUP_ID = 0;  // NOLINT
+/// \endcond
+
+}  // namespace elliptic::BoundaryConditions

--- a/src/Elliptic/BoundaryConditions/ApplyBoundaryCondition.hpp
+++ b/src/Elliptic/BoundaryConditions/ApplyBoundaryCondition.hpp
@@ -62,9 +62,9 @@ void apply_boundary_condition(
             volume_tags>(
             [&derived, &fields_and_fluxes...](const auto&... args) noexcept {
               if constexpr (Linearized) {
-                derived->apply_linearized(args..., fields_and_fluxes...);
+                derived->apply_linearized(fields_and_fluxes..., args...);
               } else {
-                derived->apply(args..., fields_and_fluxes...);
+                derived->apply(fields_and_fluxes..., args...);
               }
             },
             box, direction);

--- a/src/Elliptic/BoundaryConditions/BoundaryCondition.hpp
+++ b/src/Elliptic/BoundaryConditions/BoundaryCondition.hpp
@@ -64,10 +64,10 @@ namespace BoundaryConditions {
  * - They have `apply` and `apply_linearized` member functions that take these
  *   arguments (in this order):
  *
- *   1. The types held by the argument tags.
- *   2. The dynamic fields as not-null pointers.
- *   3. The normal-dot-fluxes corresponding to the dynamic fields as not-null
+ *   1. The dynamic fields as not-null pointers.
+ *   2. The normal-dot-fluxes corresponding to the dynamic fields as not-null
  *      pointers. These have the same types as the dynamic fields.
+ *   3. The types held by the argument tags.
  *
  *   For first-order systems that involve auxiliary variables, only the
  *   non-auxiliary ("primal") variables are included in the lists above. For

--- a/src/Elliptic/BoundaryConditions/CMakeLists.txt
+++ b/src/Elliptic/BoundaryConditions/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_headers(
   Elliptic
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  AnalyticSolution.hpp
   ApplyBoundaryCondition.hpp
   BoundaryCondition.hpp
   BoundaryConditionType.hpp

--- a/tests/Unit/Elliptic/BoundaryConditions/CMakeLists.txt
+++ b/tests/Unit/Elliptic/BoundaryConditions/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_EllipticBoundaryConditions")
 
 set(LIBRARY_SOURCES
+  Test_AnalyticSolution.cpp
   Test_BoundaryCondition.cpp
   Test_BoundaryConditionType.cpp
   Test_Tags.cpp
@@ -26,5 +27,6 @@ target_link_libraries(
   Elliptic
   Options
   Parallel
+  Spectral
   Utilities
   )

--- a/tests/Unit/Elliptic/BoundaryConditions/Test_AnalyticSolution.cpp
+++ b/tests/Unit/Elliptic/BoundaryConditions/Test_AnalyticSolution.cpp
@@ -1,0 +1,190 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/BoundaryConditions/AnalyticSolution.hpp"
+#include "Elliptic/BoundaryConditions/ApplyBoundaryCondition.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace elliptic::BoundaryConditions {
+
+namespace {
+
+template <size_t N>
+struct ScalarFieldTag : db::SimpleTag {
+  static std::string name() noexcept { return "Field" + std::to_string(N); }
+  using type = Scalar<DataVector>;
+};
+
+template <size_t Dim, size_t N>
+struct FluxTag : db::SimpleTag {
+  using type = tnsr::I<DataVector, Dim>;
+};
+
+template <size_t Dim>
+struct System {
+  static constexpr size_t volume_dim = Dim;
+  using primal_fields = tmpl::list<ScalarFieldTag<1>, ScalarFieldTag<2>>;
+  using primal_fluxes = tmpl::list<FluxTag<Dim, 1>, FluxTag<Dim, 2>>;
+};
+
+template <size_t Dim>
+void test_analytic_solution() noexcept {
+  CAPTURE(Dim);
+  // Test factory-creation
+  using Registrar = Registrars::AnalyticSolution<System<Dim>>;
+  const auto boundary_condition_base = TestHelpers::test_factory_creation<
+      BoundaryCondition<Dim, tmpl::list<Registrar>>>(
+      "AnalyticSolution:\n"
+      "  Field1: Dirichlet\n"
+      "  Field2: Neumann");
+  using BoundaryConditionType =
+      typename Registrar::template f<tmpl::list<Registrar>>;
+  REQUIRE(dynamic_cast<const BoundaryConditionType*>(
+              boundary_condition_base.get()) != nullptr);
+  const auto& boundary_condition =
+      dynamic_cast<const BoundaryConditionType&>(*boundary_condition_base);
+  {
+    INFO("Semantics");
+    test_serialization(boundary_condition);
+    test_copy_semantics(boundary_condition);
+    auto move_boundary_condition = boundary_condition;
+    test_move_semantics(std::move(move_boundary_condition), boundary_condition);
+  }
+  {
+    INFO("Test applying the boundary conditions");
+    const Mesh<Dim> volume_mesh{3, Spectral::Basis::Legendre,
+                                Spectral::Quadrature::GaussLobatto};
+    const size_t volume_num_points = volume_mesh.number_of_grid_points();
+    const auto direction = Direction<Dim>::lower_xi();
+    const auto face_mesh = volume_mesh.slice_away(direction.dimension());
+    const size_t face_num_points = face_mesh.number_of_grid_points();
+    tnsr::i<DataVector, Dim> face_normal{face_num_points, 0.};
+    get<0>(face_normal) = -2.;
+    // Create arbitrary analytic solution data
+    Variables<tmpl::list<::Tags::Analytic<ScalarFieldTag<1>>,
+                         ::Tags::Analytic<ScalarFieldTag<2>>,
+                         ::Tags::Analytic<FluxTag<Dim, 1>>,
+                         ::Tags::Analytic<FluxTag<Dim, 2>>>>
+        analytic_solutions{volume_num_points};
+    std::iota(analytic_solutions.data(),
+              analytic_solutions.data() + analytic_solutions.size(), 1.);
+    const auto box = db::create<db::AddSimpleTags<
+        domain::Tags::Mesh<Dim>,
+        ::Tags::AnalyticSolutions<
+            tmpl::list<ScalarFieldTag<1>, ScalarFieldTag<2>, FluxTag<Dim, 1>,
+                       FluxTag<Dim, 2>>>,
+        domain::Tags::Interface<domain::Tags::BoundaryDirectionsInterior<Dim>,
+                                domain::Tags::Direction<Dim>>,
+        domain::Tags::Interface<
+            domain::Tags::BoundaryDirectionsInterior<Dim>,
+            ::Tags::Normalized<
+                domain::Tags::UnnormalizedFaceNormal<Dim, Frame::Inertial>>>>>(
+        volume_mesh, std::move(analytic_solutions),
+        std::unordered_map<Direction<Dim>, Direction<Dim>>{
+            {direction, direction}},
+        std::unordered_map<Direction<Dim>, tnsr::i<DataVector, Dim>>{
+            {direction, face_normal}});
+    Variables<tmpl::list<ScalarFieldTag<1>, ScalarFieldTag<2>,
+                         ::Tags::NormalDotFlux<ScalarFieldTag<1>>,
+                         ::Tags::NormalDotFlux<ScalarFieldTag<2>>>>
+        vars{face_num_points, std::numeric_limits<double>::max()};
+    // Inhomogeneous boundary conditions
+    elliptic::apply_boundary_condition<false>(
+        boundary_condition, box, direction,
+        make_not_null(&get<ScalarFieldTag<1>>(vars)),
+        make_not_null(&get<ScalarFieldTag<2>>(vars)),
+        make_not_null(&get<::Tags::NormalDotFlux<ScalarFieldTag<1>>>(vars)),
+        make_not_null(&get<::Tags::NormalDotFlux<ScalarFieldTag<2>>>(vars)));
+    // Imposed Dirichlet conditions on field 1
+    const auto expected_dirichlet_field = []() -> DataVector {
+      if constexpr (Dim == 1) {
+        return {1.};
+      } else if constexpr (Dim == 2) {
+        return {1., 4., 7.};
+      } else if constexpr (Dim == 3) {
+        return {1., 4., 7., 10., 13., 16., 19., 22., 25.};
+      }
+    }();
+    CHECK_ITERABLE_APPROX(get(get<ScalarFieldTag<1>>(vars)),
+                          expected_dirichlet_field);
+    CHECK_ITERABLE_APPROX(
+        get(get<::Tags::NormalDotFlux<ScalarFieldTag<1>>>(vars)),
+        SINGLE_ARG(
+            DataVector{face_num_points, std::numeric_limits<double>::max()}));
+    // Imposed Neumann conditions on field 2
+    const auto expected_neumann_field = []() -> DataVector {
+      if constexpr (Dim == 1) {
+        return {-20.};
+      } else if constexpr (Dim == 2) {
+        return {-74., -80., -86.};
+      } else if constexpr (Dim == 3) {
+        return {-272., -278., -284., -290., -296., -302., -308., -314., -320.};
+      }
+    }();
+    CHECK_ITERABLE_APPROX(
+        get(get<ScalarFieldTag<2>>(vars)),
+        SINGLE_ARG(
+            DataVector{face_num_points, std::numeric_limits<double>::max()}));
+    CHECK_ITERABLE_APPROX(
+        get(get<::Tags::NormalDotFlux<ScalarFieldTag<2>>>(vars)),
+        expected_neumann_field);
+    // Homogeneous (linearized) boundary conditions
+    elliptic::apply_boundary_condition<true>(
+        boundary_condition, box, direction,
+        make_not_null(&get<ScalarFieldTag<1>>(vars)),
+        make_not_null(&get<ScalarFieldTag<2>>(vars)),
+        make_not_null(&get<::Tags::NormalDotFlux<ScalarFieldTag<1>>>(vars)),
+        make_not_null(&get<::Tags::NormalDotFlux<ScalarFieldTag<2>>>(vars)));
+    // Imposed Dirichlet conditions on field 1
+    CHECK_ITERABLE_APPROX(get(get<ScalarFieldTag<1>>(vars)),
+                          SINGLE_ARG(DataVector{face_num_points, 0.}));
+    CHECK_ITERABLE_APPROX(
+        get(get<::Tags::NormalDotFlux<ScalarFieldTag<1>>>(vars)),
+        SINGLE_ARG(
+            DataVector{face_num_points, std::numeric_limits<double>::max()}));
+    // Imposed Neumann conditions on field 2
+    CHECK_ITERABLE_APPROX(
+        get(get<ScalarFieldTag<2>>(vars)),
+        SINGLE_ARG(
+            DataVector{face_num_points, std::numeric_limits<double>::max()}));
+    CHECK_ITERABLE_APPROX(
+        get(get<::Tags::NormalDotFlux<ScalarFieldTag<2>>>(vars)),
+        SINGLE_ARG(DataVector{face_num_points, 0.}));
+  }
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Elliptic.BoundaryConditions.AnalyticSolution",
+                  "[Unit][Elliptic]") {
+  test_analytic_solution<1>();
+  test_analytic_solution<2>();
+  test_analytic_solution<3>();
+}
+
+}  // namespace elliptic::BoundaryConditions

--- a/tests/Unit/Elliptic/BoundaryConditions/Test_BoundaryCondition.cpp
+++ b/tests/Unit/Elliptic/BoundaryConditions/Test_BoundaryCondition.cpp
@@ -76,10 +76,10 @@ class TestBoundaryCondition : public BoundaryCondition<1, Registrars> {
   using volume_tags = tmpl::list<VolumeArgumentTag>;
 
   /// [example_poisson_fields]
-  static void apply(
-      const int arg_on_face, const bool arg_from_volume,
-      const int arg_nonlinear, const gsl::not_null<Scalar<DataVector>*> field,
-      const gsl::not_null<Scalar<DataVector>*> n_dot_flux) noexcept {
+  static void apply(const gsl::not_null<Scalar<DataVector>*> field,
+                    const gsl::not_null<Scalar<DataVector>*> n_dot_flux,
+                    const int arg_on_face, const bool arg_from_volume,
+                    const int arg_nonlinear) noexcept {
     /// [example_poisson_fields]
     CHECK(arg_on_face == 1);
     CHECK(arg_from_volume);
@@ -92,9 +92,9 @@ class TestBoundaryCondition : public BoundaryCondition<1, Registrars> {
   using volume_tags_linearized = tmpl::list<VolumeArgumentTag>;
 
   static void apply_linearized(
-      const int arg_on_face, const bool arg_from_volume,
       const gsl::not_null<Scalar<DataVector>*> field_correction,
-      const gsl::not_null<Scalar<DataVector>*> n_dot_flux_correction) noexcept {
+      const gsl::not_null<Scalar<DataVector>*> n_dot_flux_correction,
+      const int arg_on_face, const bool arg_from_volume) noexcept {
     CHECK(arg_on_face == 1);
     CHECK(arg_from_volume);
     std::fill(field_correction->begin(), field_correction->end(), 3.);


### PR DESCRIPTION
## Proposed changes

This boundary condition can be used by any elliptic system to impose Dirichlet or Neumann boundary conditions from an analytic solution.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
