### PR TITLE
Add laser beam boundary condition for thermal noise

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -864,6 +864,23 @@
       url            = "https://doi.org/10.1088/0264-9381/33/24/244002"
 }
 
+@article{Lovelace2017xyf,
+  author        = "Lovelace, Geoffrey and Demos, Nicholas and Khan, Haroon",
+  title         = "Numerically modeling {Brownian} thermal noise in amorphous
+                   and crystalline thin coatings",
+  eprint        = "1707.07774",
+  archivePrefix = "arXiv",
+  primaryClass  = "gr-qc",
+  reportNumber  = "LIGO-P1700183",
+  doi           = "10.1088/1361-6382/aa9ccc",
+  journal       = "Class. Quant. Grav.",
+  volume        = "35",
+  number        = "2",
+  pages         = "025017",
+  year          = "2018",
+  url           = "https://doi.org/10.1088/1361-6382/aa9ccc"
+}
+
 @Article{Michel1972,
   author  = "Michel, F. Curtis",
   title   = "Accretion of matter by condensed objects",

--- a/src/Elliptic/Systems/Elasticity/BoundaryConditions/CMakeLists.txt
+++ b/src/Elliptic/Systems/Elasticity/BoundaryConditions/CMakeLists.txt
@@ -8,6 +8,7 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  LaserBeam.cpp
   Zero.cpp
   )
 
@@ -15,6 +16,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  LaserBeam.hpp
   Zero.hpp
   )
 
@@ -25,6 +27,7 @@ target_link_libraries(
   Options
   Utilities
   INTERFACE
+  Domain
   Elliptic
   Parallel
   )

--- a/src/Elliptic/Systems/Elasticity/BoundaryConditions/LaserBeam.cpp
+++ b/src/Elliptic/Systems/Elasticity/BoundaryConditions/LaserBeam.cpp
@@ -1,0 +1,48 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Elliptic/Systems/Elasticity/BoundaryConditions/LaserBeam.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Elasticity::BoundaryConditions::detail {
+
+void LaserBeamImpl::apply(
+    const gsl::not_null<tnsr::I<DataVector, 3>*> /*displacement*/,
+    const gsl::not_null<tnsr::I<DataVector, 3>*> n_dot_minus_stress,
+    const tnsr::I<DataVector, 3>& x,
+    const tnsr::i<DataVector, 3>& face_normal) const noexcept {
+  const auto n_dot_x = get<0>(face_normal) * get<0>(x) +
+                       get<1>(face_normal) * get<1>(x) +
+                       get<2>(face_normal) * get<2>(x);
+  const auto r_sq = square(get<0>(x)) + square(get<1>(x)) + square(get<2>(x)) -
+                    square(n_dot_x);
+  const DataVector beam_profile =
+      exp(-r_sq / square(beam_width_)) / (M_PI * square(beam_width_));
+  get<0>(*n_dot_minus_stress) = -beam_profile * get<0>(face_normal);
+  get<1>(*n_dot_minus_stress) = -beam_profile * get<1>(face_normal);
+  get<2>(*n_dot_minus_stress) = -beam_profile * get<2>(face_normal);
+}
+
+void LaserBeamImpl::apply_linearized(
+    const gsl::not_null<tnsr::I<DataVector, 3>*> /*displacement*/,
+    const gsl::not_null<tnsr::I<DataVector, 3>*> n_dot_minus_stress) noexcept {
+  get<0>(*n_dot_minus_stress) = 0.;
+  get<1>(*n_dot_minus_stress) = 0.;
+  get<2>(*n_dot_minus_stress) = 0.;
+}
+
+bool operator==(const LaserBeamImpl& lhs, const LaserBeamImpl& rhs) noexcept {
+  return lhs.beam_width() == rhs.beam_width();
+}
+
+bool operator!=(const LaserBeamImpl& lhs, const LaserBeamImpl& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+}  // namespace Elasticity::BoundaryConditions::detail

--- a/src/Elliptic/Systems/Elasticity/BoundaryConditions/LaserBeam.hpp
+++ b/src/Elliptic/Systems/Elasticity/BoundaryConditions/LaserBeam.hpp
@@ -1,0 +1,160 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <pup.h>
+#include <string>
+
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryConditionType.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+/// \endcond
+
+namespace Elasticity::BoundaryConditions {
+namespace detail {
+
+struct LaserBeamImpl {
+  struct BeamWidth {
+    using type = double;
+    static constexpr Options::String help =
+        "The width r_0 of the Gaussian beam profile, such that FWHM = 2 * "
+        "sqrt(ln 2) * r_0";
+    static type lower_bound() noexcept { return 0.0; }
+  };
+
+  static constexpr Options::String help =
+      "A laser beam with Gaussian profile normally incident to the surface.";
+  using options = tmpl::list<BeamWidth>;
+
+  LaserBeamImpl() = default;
+  LaserBeamImpl(const LaserBeamImpl&) noexcept = default;
+  LaserBeamImpl& operator=(const LaserBeamImpl&) noexcept = default;
+  LaserBeamImpl(LaserBeamImpl&&) noexcept = default;
+  LaserBeamImpl& operator=(LaserBeamImpl&&) noexcept = default;
+  ~LaserBeamImpl() noexcept = default;
+
+  LaserBeamImpl(double beam_width) noexcept : beam_width_(beam_width) {}
+
+  double beam_width() const noexcept { return beam_width_; }
+
+  using argument_tags =
+      tmpl::list<domain::Tags::Coordinates<3, Frame::Inertial>,
+                 ::Tags::Normalized<
+                     domain::Tags::UnnormalizedFaceNormal<3, Frame::Inertial>>>;
+  using volume_tags = tmpl::list<>;
+
+  void apply(gsl::not_null<tnsr::I<DataVector, 3>*> displacement,
+             gsl::not_null<tnsr::I<DataVector, 3>*> n_dot_minus_stress,
+             const tnsr::I<DataVector, 3>& x,
+             const tnsr::i<DataVector, 3>& face_normal) const noexcept;
+
+  using argument_tags_linearized = tmpl::list<>;
+  using volume_tags_linearized = tmpl::list<>;
+
+  static void apply_linearized(
+      gsl::not_null<tnsr::I<DataVector, 3>*> displacement,
+      gsl::not_null<tnsr::I<DataVector, 3>*> n_dot_minus_stress) noexcept;
+
+  // NOLINTNEXTLINE
+  void pup(PUP::er& p) noexcept { p | beam_width_; }
+
+ private:
+  double beam_width_{std::numeric_limits<double>::signaling_NaN()};
+};
+
+bool operator==(const LaserBeamImpl& lhs, const LaserBeamImpl& rhs) noexcept;
+
+bool operator!=(const LaserBeamImpl& lhs, const LaserBeamImpl& rhs) noexcept;
+
+}  // namespace detail
+
+// The following implements the registration and factory-creation mechanism
+
+/// \cond
+template <typename Registrars>
+struct LaserBeam;
+
+namespace Registrars {
+struct LaserBeam {
+  template <typename Registrars>
+  using f = BoundaryConditions::LaserBeam<Registrars>;
+};
+}  // namespace Registrars
+/// \endcond
+
+/*!
+ * \brief A laser beam with Gaussian profile normally incident to the surface
+ *
+ * This boundary condition represents a laser beam with Gaussian profile that
+ * exerts pressure normal to the surface of a reflecting material. The pressure
+ * we are considering here is
+ *
+ * \f{align}
+ * n_i T^{ij} = -n^j \frac{e^{-\frac{r^2}{r_0^2}}}{\pi r_0^2}
+ * \f}
+ *
+ * where \f$n_i\f$ is the unit normal pointing _out_ of the surface, \f$r\f$ is
+ * the coordinate distance from the origin in the plane perpendicular to
+ * \f$n_i\f$ and \f$r_0\f$ is the "beam width" parameter. The pressure profile
+ * and the angle of incidence can be generalized in future work. Note that we
+ * follow the convention of \cite Lovelace2007tn and \cite Lovelace2017xyf in
+ * defining the beam width, and other publications may include a a factor of
+ * \f$\sqrt{2}\f$ in its definition.
+ *
+ * This boundary condition is used to simulate thermal noise induced in a mirror
+ * by the laser, as detailed for instance in \cite Lovelace2007tn and
+ * \cite Lovelace2017xyf. See also `Elasticity::Solutions::HalfSpaceMirror` for
+ * an analytic solution that involves this boundary condition.
+ */
+template <typename Registrars = tmpl::list<Registrars::LaserBeam>>
+class LaserBeam
+    : public elliptic::BoundaryConditions::BoundaryCondition<3, Registrars>,
+      public detail::LaserBeamImpl {
+ private:
+  using Base = elliptic::BoundaryConditions::BoundaryCondition<3, Registrars>;
+
+ public:
+  LaserBeam() = default;
+  LaserBeam(const LaserBeam&) noexcept = default;
+  LaserBeam& operator=(const LaserBeam&) noexcept = default;
+  LaserBeam(LaserBeam&&) noexcept = default;
+  LaserBeam& operator=(LaserBeam&&) noexcept = default;
+  ~LaserBeam() noexcept = default;
+
+  using LaserBeamImpl::LaserBeamImpl;
+
+  /// \cond
+  explicit LaserBeam(CkMigrateMessage* m) noexcept : Base(m) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(LaserBeam);
+  /// \endcond
+
+  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> get_clone()
+      const noexcept override {
+    return std::make_unique<LaserBeam>(*this);
+  }
+
+  void pup(PUP::er& p) noexcept override {
+    Base::pup(p);
+    detail::LaserBeamImpl::pup(p);
+  }
+};
+
+/// \cond
+template <typename Registrars>
+PUP::able::PUP_ID LaserBeam<Registrars>::my_PUP_ID = 0;  // NOLINT
+/// \endcond
+
+}  // namespace Elasticity::BoundaryConditions

--- a/tests/Unit/Elliptic/Systems/Elasticity/BoundaryConditions/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/Elasticity/BoundaryConditions/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_ElasticityBoundaryConditions")
 
 set(LIBRARY_SOURCES
+  Test_LaserBeam.cpp
   Test_Zero.cpp
   )
 
@@ -18,7 +19,10 @@ target_link_libraries(
   ${LIBRARY}
   PRIVATE
   DataStructures
+  Domain
+  DomainStructure
   ElasticityBoundaryConditions
+  ElasticitySolutions
   Elliptic
   Utilities
   )

--- a/tests/Unit/Elliptic/Systems/Elasticity/BoundaryConditions/LaserBeam.py
+++ b/tests/Unit/Elliptic/Systems/Elasticity/BoundaryConditions/LaserBeam.py
@@ -1,0 +1,16 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+from numpy import sqrt, exp, pi
+
+
+def normal_dot_minus_stress(x, n, beam_width):
+    n /= np.linalg.norm(n)
+    r = sqrt(np.linalg.norm(x)**2 - np.dot(x, n)**2)
+    beam_profile = exp(-(r / beam_width)**2) / pi / beam_width**2
+    return np.tensordot(-n, beam_profile, axes=0)
+
+
+def normal_dot_minus_stress_linearized(x, n, beam_width):
+    return np.zeros(3)

--- a/tests/Unit/Elliptic/Systems/Elasticity/BoundaryConditions/Test_LaserBeam.cpp
+++ b/tests/Unit/Elliptic/Systems/Elasticity/BoundaryConditions/Test_LaserBeam.cpp
@@ -1,0 +1,138 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/BoundaryConditions/ApplyBoundaryCondition.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/Systems/Elasticity/BoundaryConditions/LaserBeam.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.hpp"
+#include "PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Elasticity::BoundaryConditions {
+
+namespace {
+template <bool Linearized>
+void apply_boundary_condition(
+    const gsl::not_null<tnsr::I<DataVector, 3>*> n_dot_minus_stress,
+    const tnsr::I<DataVector, 3>& x, tnsr::i<DataVector, 3> face_normal,
+    const double beam_width) {
+  const LaserBeam<> laser_beam{beam_width};
+  const auto direction = Direction<3>::lower_xi();
+  // Normalize the randomly-generated face normal
+  const auto face_normal_magnitude = magnitude(face_normal);
+  for (size_t d = 0; d < 3; ++d) {
+    face_normal.get(d) /= get(face_normal_magnitude);
+  }
+  const auto box = db::create<db::AddSimpleTags<
+      domain::Tags::Interface<domain::Tags::BoundaryDirectionsInterior<3>,
+                              domain::Tags::Coordinates<3, Frame::Inertial>>,
+      domain::Tags::Interface<
+          domain::Tags::BoundaryDirectionsInterior<3>,
+          ::Tags::Normalized<
+              domain::Tags::UnnormalizedFaceNormal<3, Frame::Inertial>>>>>(
+      std::unordered_map<Direction<3>, tnsr::I<DataVector, 3>>{{direction, x}},
+      std::unordered_map<Direction<3>, tnsr::i<DataVector, 3>>{
+          {direction, face_normal}});
+  tnsr::I<DataVector, 3> displacement{x.begin()->size(),
+                                      std::numeric_limits<double>::max()};
+  elliptic::apply_boundary_condition<Linearized>(laser_beam, box, direction,
+                                                 make_not_null(&displacement),
+                                                 n_dot_minus_stress);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Elasticity.BoundaryConditions.LaserBeam",
+                  "[Unit][Elliptic]") {
+  // Test factory-creation
+  const auto created = TestHelpers::test_factory_creation<
+      elliptic::BoundaryConditions::BoundaryCondition<
+          3, tmpl::list<Registrars::LaserBeam>>>(
+      "LaserBeam:\n"
+      "  BeamWidth: 2.");
+
+  {
+    INFO("Semantics");
+    REQUIRE(dynamic_cast<const LaserBeam<>*>(created.get()) != nullptr);
+    const auto& laser_beam = dynamic_cast<const LaserBeam<>&>(*created);
+    test_serialization(laser_beam);
+    test_copy_semantics(laser_beam);
+    auto move_laser_beam = laser_beam;
+    test_move_semantics(std::move(move_laser_beam), laser_beam);
+  }
+
+  // Test applying the boundary conditions
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "Elliptic/Systems/Elasticity/BoundaryConditions/");
+  pypp::check_with_random_values<3>(&apply_boundary_condition<false>,
+                                    "LaserBeam", {"normal_dot_minus_stress"},
+                                    {{{-2., 2.}, {-1., 1.}, {0.5, 2.}}},
+                                    DataVector{3});
+  pypp::check_with_random_values<3>(
+      &apply_boundary_condition<true>, "LaserBeam",
+      {"normal_dot_minus_stress_linearized"},
+      {{{-2., 2.}, {-1., 1.}, {0.5, 2.}}}, DataVector{3});
+
+  {
+    INFO("Consistency with half-space mirror solution");
+    const double beam_width = 2.;
+    const DataVector used_for_size{5};
+    // Choose an arbitrary set of points on the z=0 surface of the mirror
+    MAKE_GENERATOR(generator);
+    std::uniform_real_distribution<> dist(-2. * beam_width, 2. * beam_width);
+    auto x = make_with_random_values<tnsr::I<DataVector, 3>>(
+        make_not_null(&generator), make_not_null(&dist), used_for_size);
+    get<2>(x) = 0.;
+    // Choose a constitutive relation with arbitrary parameters
+    const ConstitutiveRelations::IsotropicHomogeneous<3> constitutive_relation{
+        1., 2.};
+    // Get the surface stress from the half-space mirror solution
+    const Solutions::HalfSpaceMirror<> half_space_mirror{beam_width,
+                                                         constitutive_relation};
+    const auto minus_stress_solution = get<Tags::MinusStress<3>>(
+        half_space_mirror.variables(x, tmpl::list<Tags::MinusStress<3>>{}));
+    // Get the stress normal to the surface. The solution assumes the material
+    // extends in positive z-direction, so the normal is (0, 0, -1)
+    tnsr::I<DataVector, 3> n_dot_minus_stress_solution{used_for_size.size()};
+    get<0>(n_dot_minus_stress_solution) = -get<2, 0>(minus_stress_solution);
+    get<1>(n_dot_minus_stress_solution) = -get<2, 1>(minus_stress_solution);
+    get<2>(n_dot_minus_stress_solution) = -get<2, 2>(minus_stress_solution);
+    auto face_normal = make_with_value<tnsr::i<DataVector, 3>>(x, 0.);
+    get<2>(face_normal) = -1;
+    // Shift the plane where we evaluate the boundary condition along the
+    // z-direction, just because it shouldn't affect the result and it might
+    // catch issues with computing the coordinate distance
+    get<2>(x) += 2.;
+    // Compare to the boundary conditions
+    const LaserBeam<> laser_beam{beam_width};
+    tnsr::I<DataVector, 3> displacement{used_for_size.size(),
+                                        std::numeric_limits<double>::max()};
+    tnsr::I<DataVector, 3> n_dot_minus_stress{
+        used_for_size.size(), std::numeric_limits<double>::max()};
+    laser_beam.apply(make_not_null(&displacement),
+                     make_not_null(&n_dot_minus_stress), x, face_normal);
+    for (size_t d = 0; d < 3; ++d) {
+      CAPTURE(d);
+      CHECK_ITERABLE_APPROX(n_dot_minus_stress.get(d),
+                            n_dot_minus_stress_solution.get(d));
+    }
+  }
+}
+
+}  // namespace Elasticity::BoundaryConditions


### PR DESCRIPTION
## Proposed changes

This boundary condition is used to simulate thermal noise induced in a mirror by a laser.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
