### PR TITLE
Support printing messages on reductions

### DIFF
--- a/src/IO/Observer/CMakeLists.txt
+++ b/src/IO/Observer/CMakeLists.txt
@@ -26,3 +26,4 @@ spectre_target_headers(
   )
 
 add_subdirectory(Actions)
+add_subdirectory(Protocols)

--- a/src/IO/Observer/Protocols/CMakeLists.txt
+++ b/src/IO/Observer/Protocols/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  IO
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  ReductionDataFormatter.hpp
+  )

--- a/src/IO/Observer/Protocols/ReductionDataFormatter.hpp
+++ b/src/IO/Observer/Protocols/ReductionDataFormatter.hpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+/// Protocols related to observers
+namespace observers::protocols {
+/*!
+ * \brief Conforming classes can create an informative message from reduction
+ * data. The message will be printed to screen when the formatter is passed to a
+ * reduction action such as `observers::Actions::ContributeReductionData`.
+ *
+ * Conforming classes must provide the following type aliases:
+ * - `reduction_data`: The `Parallel::ReductionData` that the formatter is
+ *   applicable to.
+ *
+ * Conforming classes must implement the following member functions:
+ * - `operator()`: A call operator that takes the values of the reduction data
+ *   and returns a `std::string`. The string should be an informative message
+ *   such as "Global minimum grid spacing at time 5.4 is: 0.1".
+ * - `pup`: A PUP function for serialization.
+ *
+ * Here's an example for a formatter:
+ *
+ * \snippet Test_ReductionObserver.cpp formatter_example
+ */
+struct ReductionDataFormatter {
+  template <typename ConformingType>
+  struct test {
+    using reduction_data = typename ConformingType::reduction_data;
+  };
+};
+}  // namespace observers::protocols


### PR DESCRIPTION
## Proposed changes

A `ReductionDataFormatter` can optionally be passed along with a reduction to print a message when the reduction is complete.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
