### PR TITLE
Add functions to compute Weyl char modes U8

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -666,6 +666,20 @@
   url     = "https://doi.org/10.1007/s10915-006-9105-9"
 }
 
+@article{Kidder2004rw,
+    author        = "Kidder, Lawrence E. and Lindblom, Lee and
+                     Scheel, Mark A. and Buchman, Luisa T. and
+                     Pfeiffer, Harald P.",
+    title         = "{Boundary conditions for the Einstein evolution system}",
+    eprint        = "gr-qc/0412116",
+    archivePrefix = "arXiv",
+    doi           = "10.1103/PhysRevD.71.064020",
+    journal       = "Phys. Rev. D",
+    volume        = "71",
+    pages         = "064020",
+    year          = "2005"
+}
+
 @article{Kidder2016hev,
   author         = "Kidder, Lawrence E. and Field, Scott E. and Foucart,
                     Francois and Schnetter, Erik and Teukolsky, Saul A. and

--- a/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -24,6 +24,7 @@ spectre_target_sources(
   SpatialMetric.cpp
   TimeDerivativeOfSpacetimeMetric.cpp
   WeylElectric.cpp
+  WeylPropagating.cpp
   )
 
 spectre_target_headers(
@@ -49,6 +50,7 @@ spectre_target_headers(
   TagsDeclarations.hpp
   TimeDerivativeOfSpacetimeMetric.hpp
   WeylElectric.hpp
+  WeylPropagating.hpp
   )
 
 target_link_libraries(

--- a/src/PointwiseFunctions/GeneralRelativity/WeylPropagating.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/WeylPropagating.cpp
@@ -1,0 +1,144 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/GeneralRelativity/WeylPropagating.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/TempBuffer.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/GeneralRelativity/WeylElectric.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+/// \cond
+namespace gr {
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::ii<DataType, SpatialDim, Frame> weyl_propagating(
+    const tnsr::ii<DataType, SpatialDim, Frame>& ricci,
+    const tnsr::ii<DataType, SpatialDim, Frame>& extrinsic_curvature,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::ijj<DataType, SpatialDim, Frame>& cov_deriv_extrinsic_curvature,
+    const tnsr::I<DataType, SpatialDim, Frame>& unit_interface_normal_vector,
+    const tnsr::II<DataType, SpatialDim, Frame>& projection_IJ,
+    const tnsr::ii<DataType, SpatialDim, Frame>& projection_ij,
+    const tnsr::Ij<DataType, SpatialDim, Frame>& projection_Ij,
+    const double sign) noexcept {
+  tnsr::ii<DataType, SpatialDim, Frame> weyl_prop(
+      get_size(get<0>(unit_interface_normal_vector)));
+  weyl_propagating<SpatialDim, Frame, DataType>(
+      make_not_null(&weyl_prop), ricci, extrinsic_curvature,
+      inverse_spatial_metric, cov_deriv_extrinsic_curvature,
+      unit_interface_normal_vector, projection_IJ, projection_ij, projection_Ij,
+      sign);
+  return weyl_prop;
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void weyl_propagating(
+    const gsl::not_null<tnsr::ii<DataType, SpatialDim, Frame>*> weyl_prop_u8,
+    const tnsr::ii<DataType, SpatialDim, Frame>& ricci,
+    const tnsr::ii<DataType, SpatialDim, Frame>& extrinsic_curvature,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::ijj<DataType, SpatialDim, Frame>& cov_deriv_extrinsic_curvature,
+    const tnsr::I<DataType, SpatialDim, Frame>& unit_interface_normal_vector,
+    const tnsr::II<DataType, SpatialDim, Frame>& projection_IJ,
+    const tnsr::ii<DataType, SpatialDim, Frame>& projection_ij,
+    const tnsr::Ij<DataType, SpatialDim, Frame>& projection_Ij,
+    const double sign) noexcept {
+  ASSERT((sign == 1.) or (sign == -1.),
+         "Calculation of weyl propagating modes accepts only +1/-1 to indicate "
+         "which of U8+/- is needed.");
+  destructive_resize_components(weyl_prop_u8,
+                                get_size(get<0>(unit_interface_normal_vector)));
+
+  TempBuffer<tmpl::list<::Tags::Tempii<0, SpatialDim, Frame, DataType>>>
+      unprojected_weyl_prop_u8_vars(
+          get_size(get<0>(unit_interface_normal_vector)));
+
+  auto& unprojected_weyl_prop_u8 =
+      get<::Tags::Tempii<0, SpatialDim, Frame, DataType>>(
+          unprojected_weyl_prop_u8_vars);
+
+  gr::weyl_electric(make_not_null(&unprojected_weyl_prop_u8), ricci,
+                    extrinsic_curvature, inverse_spatial_metric);
+
+  // Compute the portion that the projections act on
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = i; j < SpatialDim; ++j) {  // Symmetry
+      for (size_t k = 0; k < SpatialDim; ++k) {
+        unprojected_weyl_prop_u8.get(i, j) -=
+            sign * unit_interface_normal_vector.get(k) *
+            (cov_deriv_extrinsic_curvature.get(k, i, j) -
+             0.5 * (cov_deriv_extrinsic_curvature.get(j, i, k) +
+                    cov_deriv_extrinsic_curvature.get(i, j, k)));
+      }
+    }
+  }
+
+  // Now project
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = i; j < SpatialDim; ++j) {  // Symmetry
+      weyl_prop_u8->get(i, j) = 0.;
+      for (size_t k = 0; k < SpatialDim; ++k) {
+        for (size_t l = 0; l < SpatialDim; ++l) {
+          weyl_prop_u8->get(i, j) +=
+              (projection_Ij.get(k, i) * projection_Ij.get(l, j) -
+               0.5 * projection_IJ.get(k, l) * projection_ij.get(i, j)) *
+              unprojected_weyl_prop_u8.get(k, l);
+        }
+      }
+    }
+  }
+}
+}  // namespace gr
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                                   \
+  template tnsr::ii<DTYPE(data), DIM(data), FRAME(data)> gr::weyl_propagating( \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& ricci,              \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          extrinsic_curvature,                                                 \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          inverse_spatial_metric,                                              \
+      const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          cov_deriv_extrinsic_curvature,                                       \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>&                      \
+          unit_interface_normal_vector,                                        \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>& projection_IJ,      \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& projection_ij,      \
+      const tnsr::Ij<DTYPE(data), DIM(data), FRAME(data)>& projection_Ij,      \
+      const double sign) noexcept;                                             \
+  template void gr::weyl_propagating(                                          \
+      const gsl::not_null<tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>*>      \
+          weyl_prop_u8,                                                        \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& ricci,              \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          extrinsic_curvature,                                                 \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          inverse_spatial_metric,                                              \
+      const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          cov_deriv_extrinsic_curvature,                                       \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>&                      \
+          unit_interface_normal_vector,                                        \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>& projection_IJ,      \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& projection_ij,      \
+      const tnsr::Ij<DTYPE(data), DIM(data), FRAME(data)>& projection_Ij,      \
+      const double sign) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
+                        (Frame::Grid, Frame::Inertial))
+
+#undef DIM
+#undef DTYPE
+#undef FRAME
+#undef INSTANTIATE
+/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/WeylPropagating.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/WeylPropagating.hpp
@@ -1,0 +1,72 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+
+/// \cond
+namespace gsl {
+template <typename>
+struct not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace gr {
+// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes the propagating modes of the Weyl tensor
+ *
+ * \details The Weyl tensor evolution system in vacuum has six characteristic
+ * fields, of which two (\f$ U^{8\pm}\f$) are proportional to the
+ * Newman-Penrose components of the Weyl tensor \f$\Psi_4\f$ and \f$\Psi_0\f$.
+ * These represent the true gravitational-wave degrees of freedom, and
+ * can be written down in terms of \f$3+1\f$ quantities as
+ * \cite Kidder2004rw (see Eq. 75):
+ *
+ * \f{align}
+ * U^{8\pm}_{ij} &= \left(P^{k}_i P^{l}_j - \frac{1}{2} P_{ij} P^{kl}\right)
+ *                  \left(R_{kl} + K K_{kl} - K_k^m K_{ml}
+ *                       \mp n^m \nabla_m K_{kl} \pm n^m \nabla_{(k}K_{l)m}
+ *                       \right),\\
+ *               &= \left(P^{k}_i P^{l}_j - \frac{1}{2} P_{ij} P^{kl}\right)
+ *                  \left(E_{kl} \mp n^m \nabla_m K_{kl}
+ *                        \pm n^m \nabla_{(k}K_{l)m}\right),
+ * \f}
+ *
+ * where \f$R_{ij}\f$ is the spatial Ricci tensor, \f$K_{ij}\f$ is the
+ * extrinsic curvature, \f$K\f$ is the trace of \f$K_{ij}\f$, \f$E_{ij}\f$ is
+ * the electric part of the Weyl tensor in vacuum, \f$n^i\f$ is the outward
+ * directed unit normal vector to the interface, \f$\nabla_i\f$ denotes the
+ * covariant derivative, and \f$P^{ij}\f$ and its index-raised and lowered forms
+ * project tensors transverse to \f$n^i\f$.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::ii<DataType, SpatialDim, Frame> weyl_propagating(
+    const tnsr::ii<DataType, SpatialDim, Frame>& ricci,
+    const tnsr::ii<DataType, SpatialDim, Frame>& extrinsic_curvature,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::ijj<DataType, SpatialDim, Frame>& cov_deriv_extrinsic_curvature,
+    const tnsr::I<DataType, SpatialDim, Frame>& unit_interface_normal_vector,
+    const tnsr::II<DataType, SpatialDim, Frame>& projection_IJ,
+    const tnsr::ii<DataType, SpatialDim, Frame>& projection_ij,
+    const tnsr::Ij<DataType, SpatialDim, Frame>& projection_Ij,
+    const double sign) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void weyl_propagating(
+    gsl::not_null<tnsr::ii<DataType, SpatialDim, Frame>*> weyl_prop_u8,
+    const tnsr::ii<DataType, SpatialDim, Frame>& ricci,
+    const tnsr::ii<DataType, SpatialDim, Frame>& extrinsic_curvature,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::ijj<DataType, SpatialDim, Frame>& cov_deriv_extrinsic_curvature,
+    const tnsr::I<DataType, SpatialDim, Frame>& unit_interface_normal_vector,
+    const tnsr::II<DataType, SpatialDim, Frame>& projection_IJ,
+    const tnsr::ii<DataType, SpatialDim, Frame>& projection_ij,
+    const tnsr::Ij<DataType, SpatialDim, Frame>& projection_Ij,
+    const double sign) noexcept;
+// @}
+}  // namespace gr

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBRARY_SOURCES
   Test_Ricci.cpp
   Test_Tags.cpp
   Test_WeylElectric.cpp
+  Test_WeylPropagating.cpp
   )
 
 add_test_library(

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_WeylPropagating.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_WeylPropagating.cpp
@@ -1,0 +1,90 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "PointwiseFunctions/GeneralRelativity/WeylPropagating.hpp"
+
+namespace {
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::ii<DataType, SpatialDim, Frame> weyl_propagating_plus_wrapper(
+    const tnsr::ii<DataType, SpatialDim, Frame>& ricci,
+    const tnsr::ii<DataType, SpatialDim, Frame>& extrinsic_curvature,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::ijj<DataType, SpatialDim, Frame>& cov_deriv_extrinsic_curvature,
+    const tnsr::I<DataType, SpatialDim, Frame>& unit_interface_normal_vector,
+    const tnsr::II<DataType, SpatialDim, Frame>& projection_IJ,
+    const tnsr::ii<DataType, SpatialDim, Frame>& projection_ij,
+    const tnsr::Ij<DataType, SpatialDim, Frame>& projection_Ij) noexcept {
+  return gr::weyl_propagating<SpatialDim, Frame, DataType>(
+      ricci, extrinsic_curvature, inverse_spatial_metric,
+      cov_deriv_extrinsic_curvature, unit_interface_normal_vector,
+      projection_IJ, projection_ij, projection_Ij, 1.);
+}
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::ii<DataType, SpatialDim, Frame> weyl_propagating_minus_wrapper(
+    const tnsr::ii<DataType, SpatialDim, Frame>& ricci,
+    const tnsr::ii<DataType, SpatialDim, Frame>& extrinsic_curvature,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::ijj<DataType, SpatialDim, Frame>& cov_deriv_extrinsic_curvature,
+    const tnsr::I<DataType, SpatialDim, Frame>& unit_interface_normal_vector,
+    const tnsr::II<DataType, SpatialDim, Frame>& projection_IJ,
+    const tnsr::ii<DataType, SpatialDim, Frame>& projection_ij,
+    const tnsr::Ij<DataType, SpatialDim, Frame>& projection_Ij) noexcept {
+  return gr::weyl_propagating<SpatialDim, Frame, DataType>(
+      ricci, extrinsic_curvature, inverse_spatial_metric,
+      cov_deriv_extrinsic_curvature, unit_interface_normal_vector,
+      projection_IJ, projection_ij, projection_Ij, -1.);
+}
+
+template <size_t SpatialDim, typename DataType>
+void test_weyl_propagating(const DataType& used_for_size) {
+  {
+    tnsr::ii<DataType, SpatialDim, Frame::Inertial> (*f)(
+        const tnsr::ii<DataType, SpatialDim, Frame::Inertial>&,
+        const tnsr::ii<DataType, SpatialDim, Frame::Inertial>&,
+        const tnsr::II<DataType, SpatialDim, Frame::Inertial>&,
+        const tnsr::ijj<DataType, SpatialDim, Frame::Inertial>&,
+        const tnsr::I<DataType, SpatialDim, Frame::Inertial>&,
+        const tnsr::II<DataType, SpatialDim, Frame::Inertial>&,
+        const tnsr::ii<DataType, SpatialDim, Frame::Inertial>&,
+        const tnsr::Ij<DataType, SpatialDim, Frame::Inertial>&) =
+        &weyl_propagating_plus_wrapper<SpatialDim, Frame::Inertial, DataType>;
+    pypp::check_with_random_values<1>(f, "WeylPropagating",
+                                      "weyl_propagating_mode_plus",
+                                      {{{-1., 1.}}}, used_for_size);
+  }
+  {
+    tnsr::ii<DataType, SpatialDim, Frame::Inertial> (*f)(
+        const tnsr::ii<DataType, SpatialDim, Frame::Inertial>&,
+        const tnsr::ii<DataType, SpatialDim, Frame::Inertial>&,
+        const tnsr::II<DataType, SpatialDim, Frame::Inertial>&,
+        const tnsr::ijj<DataType, SpatialDim, Frame::Inertial>&,
+        const tnsr::I<DataType, SpatialDim, Frame::Inertial>&,
+        const tnsr::II<DataType, SpatialDim, Frame::Inertial>&,
+        const tnsr::ii<DataType, SpatialDim, Frame::Inertial>&,
+        const tnsr::Ij<DataType, SpatialDim, Frame::Inertial>&) =
+        &weyl_propagating_minus_wrapper<SpatialDim, Frame::Inertial, DataType>;
+    pypp::check_with_random_values<1>(f, "WeylPropagating",
+                                      "weyl_propagating_mode_minus",
+                                      {{{-1., 1.}}}, used_for_size);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.WeylPropagating",
+                  "[PointwiseFunctions][Unit]") {
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "PointwiseFunctions/GeneralRelativity/");
+
+  GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
+
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_weyl_propagating, (1, 2, 3));
+}

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/WeylPropagating.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/WeylPropagating.py
@@ -1,0 +1,43 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+from WeylElectric import weyl_electric_tensor
+
+
+def weyl_propagating_modes(ricci, extrinsic_curvature, inverse_spatial_metric,
+                           cov_deriv_ex_curv, unit_normal_vector,
+                           projection_IJ, projection_ij, projection_Ij, sign):
+    tmp = weyl_electric_tensor(ricci, extrinsic_curvature,
+                               inverse_spatial_metric)
+    tmp = tmp - sign * np.einsum('k,kij->ij', unit_normal_vector,
+                                 cov_deriv_ex_curv)
+    tmp = tmp + sign * 0.5 * np.einsum('k,jik->ij', unit_normal_vector,
+                                       cov_deriv_ex_curv)
+    tmp = tmp + sign * 0.5 * np.einsum('k,ijk->ij', unit_normal_vector,
+                                       cov_deriv_ex_curv)
+
+    return np.einsum('ki,lj,kl->ij', projection_Ij,
+                     projection_Ij, tmp) - 0.5 * np.einsum(
+                         'kl,ij,kl->ij', projection_IJ, projection_ij, tmp)
+
+
+def weyl_propagating_mode_plus(ricci, extrinsic_curvature,
+                               inverse_spatial_metric, cov_deriv_ex_curv,
+                               unit_normal_vector, projection_IJ,
+                               projection_ij, projection_Ij):
+    return weyl_propagating_modes(ricci, extrinsic_curvature,
+                                  inverse_spatial_metric, cov_deriv_ex_curv,
+                                  unit_normal_vector, projection_IJ,
+                                  projection_ij, projection_Ij, 1)
+
+
+def weyl_propagating_mode_minus(ricci, extrinsic_curvature,
+                                inverse_spatial_metric, cov_deriv_ex_curv,
+                                unit_normal_vector, projection_IJ,
+                                projection_ij, projection_Ij):
+    return weyl_propagating_modes(ricci, extrinsic_curvature,
+                                  inverse_spatial_metric, cov_deriv_ex_curv,
+                                  unit_normal_vector, projection_IJ,
+                                  projection_ij, projection_Ij, -1)


### PR DESCRIPTION
## Proposed changes

Adds functions to compute characteristic modes of the Weyl tensor that represent GW degrees of freedom in vacuum. These are currently of interest when setting the physical part of boundary conditions for the GH system.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
