### PR TITLE
Covariant derivative of extrinsic curvature

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/CMakeLists.txt
@@ -4,6 +4,7 @@
 spectre_target_sources(
   GeneralRelativity
   PRIVATE
+  CovariantDerivOfExtrinsicCurvature.cpp
   DerivSpatialMetric.cpp
   ExtrinsicCurvature.cpp
   GaugeSource.cpp
@@ -26,6 +27,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ConstraintGammas.hpp
+  CovariantDerivOfExtrinsicCurvature.hpp
   DerivSpatialMetric.hpp
   ExtrinsicCurvature.hpp
   GaugeSource.hpp

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/CovariantDerivOfExtrinsicCurvature.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/CovariantDerivOfExtrinsicCurvature.cpp
@@ -1,0 +1,140 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/CovariantDerivOfExtrinsicCurvature.hpp"
+
+#include "DataStructures/DataVector.hpp"     // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+/// \cond
+namespace GeneralizedHarmonic {
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::ijj<DataType, SpatialDim, Frame> covariant_deriv_of_extrinsic_curvature(
+    const tnsr::ii<DataType, SpatialDim, Frame>& extrinsic_curvature,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal_vector,
+    const tnsr::Ijj<DataType, SpatialDim, Frame>&
+        spatial_christoffel_second_kind,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& d_pi,
+    const tnsr::ijaa<DataType, SpatialDim, Frame>& d_phi) noexcept {
+  tnsr::ijj<DataType, SpatialDim, Frame> d_extrinsic_curvature(
+      get_size(get<0>(spacetime_unit_normal_vector)));
+  GeneralizedHarmonic::covariant_deriv_of_extrinsic_curvature<SpatialDim, Frame,
+                                                              DataType>(
+      make_not_null(&d_extrinsic_curvature), extrinsic_curvature,
+      spacetime_unit_normal_vector, spatial_christoffel_second_kind,
+      inverse_spacetime_metric, phi, d_pi, d_phi);
+  return d_extrinsic_curvature;
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void covariant_deriv_of_extrinsic_curvature(
+    const gsl::not_null<tnsr::ijj<DataType, SpatialDim, Frame>*>
+        d_extrinsic_curvature,
+    const tnsr::ii<DataType, SpatialDim, Frame>& extrinsic_curvature,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal_vector,
+    const tnsr::Ijj<DataType, SpatialDim, Frame>&
+        spatial_christoffel_second_kind,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& d_pi,
+    const tnsr::ijaa<DataType, SpatialDim, Frame>& d_phi) noexcept {
+  destructive_resize_components(d_extrinsic_curvature,
+                                get_size(get<0>(spacetime_unit_normal_vector)));
+
+  // Ordinary derivative first
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = i; j < SpatialDim; ++j) {
+      for (size_t k = 0; k < SpatialDim; ++k) {
+        d_extrinsic_curvature->get(k, i, j) = d_pi.get(k, i + 1, j + 1);
+        for (size_t a = 0; a <= SpatialDim; ++a) {
+          d_extrinsic_curvature->get(k, i, j) +=
+              (d_phi.get(k, i, j + 1, a) + d_phi.get(k, j, i + 1, a)) *
+              spacetime_unit_normal_vector.get(a);
+          for (size_t b = 0; b <= SpatialDim; ++b) {
+            for (size_t c = 0; c <= SpatialDim; ++c) {
+              d_extrinsic_curvature->get(k, i, j) -=
+                  (phi.get(i, j + 1, a) + phi.get(j, i + 1, a)) *
+                  spacetime_unit_normal_vector.get(b) *
+                  (inverse_spacetime_metric.get(c, a) +
+                   0.5 * spacetime_unit_normal_vector.get(c) *
+                       spacetime_unit_normal_vector.get(a)) *
+                  phi.get(k, c, b);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Now add gamma terms
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = i; j < SpatialDim; ++j) {
+      for (size_t k = 0; k < SpatialDim; ++k) {
+        d_extrinsic_curvature->get(k, i, j) =
+            0.5 * d_extrinsic_curvature->get(k, i, j) -
+            spatial_christoffel_second_kind.get(0, i, k) *
+                extrinsic_curvature.get(0, j) -
+            spatial_christoffel_second_kind.get(0, j, k) *
+                extrinsic_curvature.get(0, i);
+        for (size_t l = 1; l < SpatialDim; ++l) {
+          d_extrinsic_curvature->get(k, i, j) -=
+              spatial_christoffel_second_kind.get(l, i, k) *
+                  extrinsic_curvature.get(l, j) +
+              spatial_christoffel_second_kind.get(l, j, k) *
+                  extrinsic_curvature.get(l, i);
+        }
+      }
+    }
+  }
+}
+}  // namespace GeneralizedHarmonic
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                                  \
+  template tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>                     \
+  GeneralizedHarmonic::covariant_deriv_of_extrinsic_curvature(                \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          extrinsic_curvature,                                                \
+      const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          spacetime_unit_normal_vector,                                       \
+      const tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>&                   \
+          spatial_christoffel_second_kind,                                    \
+      const tnsr::AA<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          inverse_spacetime_metric,                                           \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,              \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& d_pi,             \
+      const tnsr::ijaa<DTYPE(data), DIM(data), FRAME(data)>& d_phi) noexcept; \
+  template void GeneralizedHarmonic::covariant_deriv_of_extrinsic_curvature(  \
+      gsl::not_null<tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>*>          \
+          d_extrinsic_curvature,                                              \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          extrinsic_curvature,                                                \
+      const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          spacetime_unit_normal_vector,                                       \
+      const tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>&                   \
+          spatial_christoffel_second_kind,                                    \
+      const tnsr::AA<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          inverse_spacetime_metric,                                           \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,              \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& d_pi,             \
+      const tnsr::ijaa<DTYPE(data), DIM(data), FRAME(data)>& d_phi) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
+                        (Frame::Grid, Frame::Inertial))
+
+#undef DIM
+#undef DTYPE
+#undef FRAME
+#undef INSTANTIATE
+/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/CovariantDerivOfExtrinsicCurvature.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/CovariantDerivOfExtrinsicCurvature.hpp
@@ -1,0 +1,116 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace gsl {
+template <typename>
+struct not_null;
+}  // namespace gsl
+class DataVector;
+/// \endcond
+
+namespace GeneralizedHarmonic {
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes the covariant derivative of extrinsic curvature from
+ * generalized harmonic variables and the spacetime normal vector.
+ *
+ * \details If \f$ \Pi_{ab} \f$ and \f$ \Phi_{iab} \f$ are the generalized
+ * harmonic conjugate momentum and spatial derivative variables, and if
+ * \f$n^a\f$ is the spacetime normal vector, then the extrinsic curvature
+ * can be written as
+ * \f{equation}\label{eq:kij}
+ *     K_{ij} = \frac{1}{2} \Pi_{ij} + \Phi_{(ij)a} n^a,
+ * \f}
+ * and its covariant derivative as
+ * \f{equation}\label{eq:covkij}
+ * \nabla_k K_{ij} = \partial_k K_{ij} - \Gamma^l{}_{ik} K_{lj}
+ *                                     - \Gamma^l{}_{jk} K_{li},
+ * \f}
+ * where \f$\Gamma^k{}_{ij}\f$ are Christoffel symbols of the second kind.
+ * The partial derivatives of extrinsic curvature can be computed as
+ * \f{equation}\label{eq:pdkij}
+ * \partial_k K_{ij} =
+ *     \frac{1}{2}\left(\partial_k \Pi_{ij} +
+ *                      \left(\partial_k \Phi_{ija} +
+ *                            \partial_k \Phi_{jia}\right) n^a +
+ *                      \left(\Phi_{ija} + \Phi_{jia}\right) \partial_k n^a
+ *               \right),
+ * \f}
+ * where we have access to all terms except the spatial derivatives of the
+ * spacetime unit normal vector \f$\partial_k n^a\f$. Given that
+ * \f$n^a=(1/\alpha, -\beta^i /\alpha)\f$, the temporal portion of
+ * \f$\partial_k n^a\f$ can be computed as:
+ * \f{align}
+ * \partial_k n^0 =& -\frac{1}{\alpha^2} \partial_k \alpha, \nonumber \\
+ *                =& -\frac{1}{\alpha^2} (-\alpha/2) n^a \Phi_{kab} n^b,
+ *                   \nonumber \\
+ *                =& \frac{1}{2\alpha} n^a \Phi_{kab} n^b, \nonumber \\
+ *                =& \frac{1}{2} n^0 n^a \Phi_{kab} n^b, \nonumber \\
+ *                =& -\left(g^{0a} +
+ *                          \frac{1}{2}n^0 n^a\right) \Phi_{kab} n^b,
+ * \f}
+ * where we use the expression for \f$\partial_k \alpha\f$ from
+ * \ref spatial_deriv_of_lapse; while the spatial portion of the same can be
+ * computed as:
+ * \f{align}
+ * \partial_k n^i =& -\partial_k (\beta^i/\alpha)
+ *                 = -\frac{1}{\alpha}\partial_k \beta^i
+ *                   + \frac{\beta^i}{\alpha^2}\partial_k \alpha ,\nonumber \\
+ *                =& -\frac{1}{2}\frac{\beta^i}{\alpha} n^a\Phi_{kab}n^b
+ *                   -\left(g^{ia}
+ *                          + n^i n^a\right) \Phi_{kab} n^b, \nonumber\\
+ *                =& -\left(g^{ia} + \frac{1}{2}n^i n^a\right) \Phi_{kab}n^b,
+ * \f}
+ * where we use the expression for \f$\partial_k \beta^i\f$ from
+ * \ref spatial_deriv_of_shift. Combining the last two equations, we find that
+ * \f{equation}
+ * \partial_k n^a = -\left(g^{ab} + \frac{1}{2}n^a n^b\right)\Phi_{kbc}n^c,
+ * \f}
+ * and using Eq.(\f$\ref{eq:covkij}\f$) and Eq.(\f$\ref{eq:pdkij}\f$) with this,
+ * we can compute the covariant derivative of the extrinsic curvature as:
+ * \f{equation}
+ * \nabla_k K_{ij} =
+ *     \frac{1}{2}\left(\partial_k \Pi_{ij} +
+ *                      \left(\partial_k \Phi_{ija} +
+ *                            \partial_k \Phi_{jia}\right) n^a -
+ *                      \left(\Phi_{ija} + \Phi_{jia}\right)
+ *                      \left(g^{ab} + \frac{1}{2}n^a n^b\right)
+ *                      \Phi_{kbc}n^c
+ *                \right) - \Gamma^l{}_{ik} K_{lj} - \Gamma^l{}_{jk} K_{li} \f}.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::ijj<DataType, SpatialDim, Frame> covariant_deriv_of_extrinsic_curvature(
+    const tnsr::ii<DataType, SpatialDim, Frame>& extrinsic_curvature,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal_vector,
+    const tnsr::Ijj<DataType, SpatialDim, Frame>&
+        spatial_christoffel_second_kind,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& d_pi,
+    const tnsr::ijaa<DataType, SpatialDim, Frame>& d_phi) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void covariant_deriv_of_extrinsic_curvature(
+    gsl::not_null<tnsr::ijj<DataType, SpatialDim, Frame>*>
+        d_extrinsic_curvature,
+    const tnsr::ii<DataType, SpatialDim, Frame>& extrinsic_curvature,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal_vector,
+    const tnsr::Ijj<DataType, SpatialDim, Frame>&
+        spatial_christoffel_second_kind,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& d_pi,
+    const tnsr::ijaa<DataType, SpatialDim, Frame>& d_phi) noexcept;
+}  // namespace GeneralizedHarmonic

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.py
@@ -129,3 +129,36 @@ def spacetime_deriv_detg(sqrt_det_spatial_metric, inverse_spatial_metric,
     dg[0] = dtg
     dg[1:] = dxg
     return dg
+
+
+def covariant_deriv_extrinsic_curvture(extrinsic_curvature,
+                                       spacetime_unit_nomal_vector,
+                                       spatial_christoffel_second_kind,
+                                       inverse_spacetime_metric, phi, d_pi,
+                                       d_phi):
+    term4 = np.einsum('ija,b,ca,kcb->kij', phi[:, 1:, :],
+                      spacetime_unit_nomal_vector, inverse_spacetime_metric,
+                      phi)
+    term5 = np.einsum('jia,b,ca,kcb->kij', phi[:, 1:, :],
+                      spacetime_unit_nomal_vector, inverse_spacetime_metric,
+                      phi)
+    term6 = np.einsum('ija,b,c,a,kcb->kij', phi[:, 1:, :],
+                      spacetime_unit_nomal_vector,
+                      0.5 * spacetime_unit_nomal_vector,
+                      spacetime_unit_nomal_vector, phi)
+    term7 = np.einsum('jia,b,c,a,kcb->kij', phi[:, 1:, :],
+                      spacetime_unit_nomal_vector,
+                      0.5 * spacetime_unit_nomal_vector,
+                      spacetime_unit_nomal_vector, phi)
+
+    cdk = d_pi[:, 1:, 1:] + np.einsum(
+        'kija,a->kij',
+        d_phi[:, :, 1:, :], spacetime_unit_nomal_vector) + np.einsum(
+            'kjia,a->kij', d_phi[:, :, 1:, :],
+            spacetime_unit_nomal_vector) - term4 - term5 - term6 - term7
+
+    return 0.5 * cdk - np.einsum(
+        'lik,lj->kij',
+        spatial_christoffel_second_kind, extrinsic_curvature) - np.einsum(
+            'ljk,li->kij', spatial_christoffel_second_kind,
+            extrinsic_curvature)

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
@@ -38,6 +38,7 @@
 #include "PointwiseFunctions/GeneralRelativity/DerivativesOfSpacetimeMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/ExtrinsicCurvature.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ConstraintGammas.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/CovariantDerivOfExtrinsicCurvature.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/DerivSpatialMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ExtrinsicCurvature.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/GaugeSource.hpp"
@@ -626,6 +627,24 @@ void test_spacetime_derivative_of_spacetime_metric(
   }
 }
 
+template <size_t SpatialDim, typename Frame, typename DataType>
+void test_cov_deriv_extrinsic_curvature(
+    const DataType& used_for_size) noexcept {
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::ijj<DataType, SpatialDim, Frame> (*)(
+          const tnsr::ii<DataType, SpatialDim, Frame>&,
+          const tnsr::A<DataType, SpatialDim, Frame>&,
+          const tnsr::Ijj<DataType, SpatialDim, Frame>&,
+          const tnsr::AA<DataType, SpatialDim, Frame>&,
+          const tnsr::iaa<DataType, SpatialDim, Frame>&,
+          const tnsr::iaa<DataType, SpatialDim, Frame>&,
+          const tnsr::ijaa<DataType, SpatialDim, Frame>&)>(
+          &::GeneralizedHarmonic::covariant_deriv_of_extrinsic_curvature<
+              SpatialDim, Frame, DataType>),
+      "GeneralRelativity.ComputeGhQuantities",
+      "covariant_deriv_extrinsic_curvture", {{{-10., 10.}}}, used_for_size);
+}
+
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.GhQuantities",
@@ -638,6 +657,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.GhQuantities",
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_compute_gauge_source, (1, 2, 3));
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(
       test_compute_extrinsic_curvature_and_deriv_metric, (1, 2, 3));
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_cov_deriv_extrinsic_curvature,
+                                    (1, 2, 3), (Frame::Grid, Frame::Inertial));
 
   const size_t num_pts = 5;
   const DataVector used_for_size(num_pts);


### PR DESCRIPTION
## Proposed changes

Add functions to compute the covariant derivative of extrinsic curvature. This is required to compute the Weyl characteristic modes U8 needed to set boundary conditions for the generalized harmonic system preventing the influx of unwanted gravitational radiation.


### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
