### PR TITLE
Enable use of reference items in the DataBox

### DIFF
--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -241,19 +241,13 @@ class DataBox<tmpl::list<Tags...>>
   using mutable_item_tags =
       tmpl::list_difference<tags_list, immutable_item_tags>;
 
-  /// A list of the simple items that have subitems, without expanding the
-  /// subitems out
-  using simple_subitems_tags =
-      tmpl::filter<mutable_item_tags,
-                   tmpl::bind<detail::has_subitems, tmpl::_1>>;
-
   /// A list of the expanded simple subitems, not including the main Subitem
   /// tags themselves.
   ///
   /// Specifically, if there is a `Variables<Tag0, Tag1>`, then this list would
   /// contain `Tag0, Tag1`.
-  using simple_only_expanded_subitems_tags = tmpl::flatten<
-      tmpl::transform<simple_subitems_tags, db::Subitems<tmpl::_1>>>;
+  using mutable_subitem_tags = tmpl::flatten<
+      tmpl::transform<mutable_item_tags, db::Subitems<tmpl::_1>>>;
 
   /// \cond HIDDEN_SYMBOLS
   /*!
@@ -303,7 +297,7 @@ class DataBox<tmpl::list<Tags...>>
   void pup(PUP::er& p) noexcept {  // NOLINT
     using non_subitems_tags =
         tmpl::list_difference<mutable_item_tags,
-                              simple_only_expanded_subitems_tags>;
+                              mutable_subitem_tags>;
 
     // We do not send subitems for both simple items and compute items since
     // they can be reconstructed very cheaply.
@@ -1162,7 +1156,7 @@ SPECTRE_ALWAYS_INLINE constexpr auto create_from(Box&& box,
   using compute_only_expand_subitems_tags = tmpl::flatten<
       tmpl::transform<compute_subitems_tags, db::Subitems<tmpl::_1>>>;
   using all_only_subitems_tags = tmpl::append<
-      typename std::decay_t<Box>::simple_only_expanded_subitems_tags,
+      typename std::decay_t<Box>::mutable_subitem_tags,
       compute_only_expand_subitems_tags>;
   using non_expand_subitems_remove_tags =
       tmpl::list_difference<RemoveTags, all_only_subitems_tags>;

--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -456,7 +456,7 @@ struct compute_item_function_impl<false> {
   static decltype(auto) apply(
       const storage_type<ComputeItemArgumentsTags,
                          FullTagList>&... args) noexcept {
-    return ComputeItem::function(convert_to_const_type(args)...);
+    return ComputeItem::get(convert_to_const_type(args)...);
   }
 };
 

--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -1007,43 +1007,24 @@ using AddComputeTags = tmpl::flatten<tmpl::list<Tags...>>;
 
 
 namespace detail {
-template <class ItemsList, class ComputeItemsList>
-struct compute_dbox_type;
-
-template <class... ItemsPack, class ComputeItemsList>
-struct compute_dbox_type<tmpl::list<ItemsPack...>, ComputeItemsList> {
-  using full_items = detail::expand_subitems<tmpl::list<ItemsPack...>>;
-  using full_compute_items = detail::expand_subitems<ComputeItemsList>;
-  using type = DataBox<tmpl::append<full_items, full_compute_items>>;
+template <typename TagList>
+struct compute_dbox_type {
+  using immutable_item_tags = detail::expand_subitems<
+      tmpl::filter<TagList, db::is_immutable_item_tag<tmpl::_1>>>;
+  using mutable_item_tags = detail::expand_subitems<tmpl::filter<
+      TagList, tmpl::not_<tmpl::bind<db::is_immutable_item_tag, tmpl::_1>>>>;
+  using type = DataBox<tmpl::append<mutable_item_tags, immutable_item_tags>>;
 };
 }  // namespace detail
-
-/*!
- * \ingroup DataBoxGroup
- * \brief Get all the Tags that are compute items from the `TagList`
- */
-template <class TagList>
-using get_compute_items =
-    tmpl::filter<TagList, db::is_immutable_item_tag<tmpl::_1>>;
-
-/*!
- * \ingroup DataBoxGroup
- * \brief Get all the Tags that are items from the `TagList`
- */
-template <class TagList>
-using get_items =
-    tmpl::filter<TagList,
-                 tmpl::not_<tmpl::bind<db::is_immutable_item_tag, tmpl::_1>>>;
 
 /*!
  * \ingroup DataBoxGroup
  * \brief Returns the type of the DataBox that would be constructed from the
  * `TagList` of tags.
  */
-template <class TagList>
-using compute_databox_type =
-    typename detail::compute_dbox_type<get_items<TagList>,
-                                       get_compute_items<TagList>>::type;
+template <typename TagList>
+using compute_databox_type = typename detail::compute_dbox_type<TagList>::type;
+
 /*!
  * \ingroup DataBoxGroup
  * \brief Create a new DataBox

--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -237,15 +237,14 @@ class DataBox<tmpl::list<Tags...>>
   using immutable_item_tags =
       detail::expand_subitems<immutable_item_creation_tags>;
 
-  /// A list of all the simple items, including subitems from the simple
-  /// items
-  using simple_item_tags =
+  /// A list of all the mutable item tags, including their subitems
+  using mutable_item_tags =
       tmpl::list_difference<tags_list, immutable_item_tags>;
 
   /// A list of the simple items that have subitems, without expanding the
   /// subitems out
   using simple_subitems_tags =
-      tmpl::filter<simple_item_tags,
+      tmpl::filter<mutable_item_tags,
                    tmpl::bind<detail::has_subitems, tmpl::_1>>;
 
   /// A list of the expanded simple subitems, not including the main Subitem
@@ -303,7 +302,7 @@ class DataBox<tmpl::list<Tags...>>
   // clang-tidy: no non-const references
   void pup(PUP::er& p) noexcept {  // NOLINT
     using non_subitems_tags =
-        tmpl::list_difference<simple_item_tags,
+        tmpl::list_difference<mutable_item_tags,
                               simple_only_expanded_subitems_tags>;
 
     // We do not send subitems for both simple items and compute items since
@@ -1130,7 +1129,7 @@ SPECTRE_ALWAYS_INLINE constexpr auto create_from(Box&& box,
   // 4. Create new list of tags by removing all the remove tags, and adding all
   // the AddTags, including subitems
   using simple_tags_to_keep =
-      tmpl::list_difference<typename std::decay_t<Box>::simple_item_tags,
+      tmpl::list_difference<typename std::decay_t<Box>::mutable_item_tags,
                             simple_tags_to_remove_with_subitems>;
   using new_simple_tags =
       tmpl::append<simple_tags_to_keep, simple_tags_to_add_with_subitems>;

--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -1111,8 +1111,9 @@ SPECTRE_ALWAYS_INLINE constexpr auto create_from(Box&& box,
   // 2. Expand subitems of tags to remove
   using immutable_item_tags_to_remove = expand_subitems<
       tmpl::filter<remove_tags, db::is_immutable_item_tag<tmpl::_1>>>;
-  using mutable_item_tags_to_remove = expand_subitems<
-      tmpl::list_difference<remove_tags, immutable_item_tags_to_remove>>;
+  using mutable_item_tags_to_remove = expand_subitems<tmpl::filter<
+      remove_tags,
+      tmpl::not_<tmpl::bind<db::is_immutable_item_tag, tmpl::_1>>>>;
 
   // 3. Expand subitems of tags to add
   using mutable_item_tags_to_add = expand_subitems<AddTags>;

--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -233,14 +233,14 @@ class DataBox<tmpl::list<Tags...>>
   using immutable_item_creation_tags =
       tmpl::filter<tags_list, db::is_immutable_item_tag<tmpl::_1>>;
 
-  /// A list of all the compute items, including subitems from the compute items
-  using compute_with_subitems_tags =
+  /// A list of all the immutable item tags, including their subitems
+  using immutable_item_tags =
       detail::expand_subitems<immutable_item_creation_tags>;
 
   /// A list of all the simple items, including subitems from the simple
   /// items
   using simple_item_tags =
-      tmpl::list_difference<tags_list, compute_with_subitems_tags>;
+      tmpl::list_difference<tags_list, immutable_item_tags>;
 
   /// A list of the simple items that have subitems, without expanding the
   /// subitems out
@@ -870,7 +870,7 @@ void mutate(const gsl::not_null<DataBox<TagList>*> box, Invokable&& invokable,
       "One of the tags being mutated could not be found in the DataBox or "
       "is a base tag identifying more than one tag.");
   static_assert(not tmpl2::flat_any_v<tmpl::list_contains_v<
-                    typename DataBox<TagList>::compute_with_subitems_tags,
+                    typename DataBox<TagList>::immutable_item_tags,
                     detail::first_matching_tag<TagList, MutateTags>>...>,
                 "Cannot mutate a compute item");
   if (UNLIKELY(box->mutate_locked_box_)) {
@@ -1137,7 +1137,7 @@ SPECTRE_ALWAYS_INLINE constexpr auto create_from(Box&& box,
 
   // 5. Create the list of compute items with the RemoveTags removed
   using compute_tags_to_keep = tmpl::list_difference<
-      typename std::decay_t<Box>::compute_with_subitems_tags,
+      typename std::decay_t<Box>::immutable_item_tags,
       compute_tags_to_remove_with_subitems>;
 
   // 6. List of the old tags that are being kept

--- a/src/DataStructures/DataBox/DataBoxTag.hpp
+++ b/src/DataStructures/DataBox/DataBoxTag.hpp
@@ -151,10 +151,10 @@ struct storage_type_impl {
           ? 4
           : (is_compute_tag_v<Tag>and has_return_type_member_v<Tag>)
                 ? 3
-                : is_compute_tag_v<Tag> ? 2
-                                        : std::is_base_of_v<db::SimpleTag, Tag>
-                                              ? 1
-                                              : 0>::template f<TagList, Tag>;
+                : is_immutable_item_tag_v<Tag>
+                      ? 2
+                      : std::is_base_of_v<db::SimpleTag, Tag> ? 1 : 0>::
+      template f<TagList, Tag>;
 };
 
 template <>

--- a/src/DataStructures/DataBox/DataBoxTag.hpp
+++ b/src/DataStructures/DataBox/DataBoxTag.hpp
@@ -244,8 +244,8 @@ using const_item_type =
 template <typename Tag, typename TagList = NoSuchType>
 using item_type = typename item_type_impl<TagList, Tag>::type;
 
-CREATE_IS_CALLABLE(function)
-CREATE_IS_CALLABLE_V(function)
+CREATE_IS_CALLABLE(get)
+CREATE_IS_CALLABLE_V(get)
 
 template <typename Tag, typename TagList, typename TagTypesList>
 struct check_compute_item_is_invokable;
@@ -254,7 +254,7 @@ template <typename Tag, typename... Tags, typename... TagTypes>
 struct check_compute_item_is_invokable<Tag, tmpl::list<Tags...>,
                                        tmpl::list<TagTypes...>> {
   static_assert(
-      is_function_callable_v<Tag, TagTypes...>,
+      is_get_callable_v<Tag, TagTypes...>,
       "The compute item is not callable with the types that the tags hold. The "
       "compute item tag that is the problem should be shown in the first line "
       " after the static assert error: "
@@ -272,7 +272,7 @@ struct compute_item_type<tmpl::list<Args...>> {
           Tag, tmpl::list<Args...>,
           tmpl::list<const_item_type<Args, TagList>...>>{},
 #endif  // SPECTRE_DEBUG
-      Tag::function(std::declval<const_item_type<Args, TagList>>()...));
+      Tag::get(std::declval<const_item_type<Args, TagList>>()...));
 };
 }  // namespace detail
 }  // namespace db

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -91,15 +91,15 @@ struct TimeAndTimeStep {
       typename DbTagsList, typename... InboxTags, typename ArrayIndex,
       typename ActionList, typename ParallelComponent,
       Requires<tmpl::list_contains_v<
-                   typename db::DataBox<DbTagsList>::simple_item_tags,
+                   typename db::DataBox<DbTagsList>::mutable_item_tags,
                    Initialization::Tags::InitialTime> and
 
                tmpl::list_contains_v<
-                   typename db::DataBox<DbTagsList>::simple_item_tags,
+                   typename db::DataBox<DbTagsList>::mutable_item_tags,
                    Initialization::Tags::InitialTimeDelta> and
 
                tmpl::list_contains_v<
-                   typename db::DataBox<DbTagsList>::simple_item_tags,
+                   typename db::DataBox<DbTagsList>::mutable_item_tags,
                    Tags::InitialSlabSize<Metavariables::local_time_stepping>>> =
           nullptr>
   static auto apply(db::DataBox<DbTagsList>& box,
@@ -146,15 +146,15 @@ struct TimeAndTimeStep {
       typename ActionList, typename ParallelComponent,
       Requires<
           not(tmpl::list_contains_v<
-                  typename db::DataBox<DbTagsList>::simple_item_tags,
+                  typename db::DataBox<DbTagsList>::mutable_item_tags,
                   Initialization::Tags::InitialTime> and
 
               tmpl::list_contains_v<
-                  typename db::DataBox<DbTagsList>::simple_item_tags,
+                  typename db::DataBox<DbTagsList>::mutable_item_tags,
                   Initialization::Tags::InitialTimeDelta> and
 
               tmpl::list_contains_v<
-                  typename db::DataBox<DbTagsList>::simple_item_tags,
+                  typename db::DataBox<DbTagsList>::mutable_item_tags,
                   Tags::InitialSlabSize<Metavariables::local_time_stepping>>)> =
           nullptr>
   static std::tuple<db::DataBox<DbTagsList>&&> apply(
@@ -220,11 +220,11 @@ struct TimeStepperHistory {
   template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
             typename ActionList, typename ParallelComponent,
             Requires<tmpl::list_contains_v<
-                         typename db::DataBox<DbTagsList>::simple_item_tags,
+                         typename db::DataBox<DbTagsList>::mutable_item_tags,
                          domain::Tags::Mesh<dim>> and
 
                      tmpl::list_contains_v<
-                         typename db::DataBox<DbTagsList>::simple_item_tags,
+                         typename db::DataBox<DbTagsList>::mutable_item_tags,
                          variables_tag>> = nullptr>
   static auto apply(db::DataBox<DbTagsList>& box,
                     const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
@@ -246,15 +246,16 @@ struct TimeStepperHistory {
     return std::make_tuple(std::move(box));
   }
 
-  template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
-            typename ActionList, typename ParallelComponent,
-            Requires<not(tmpl::list_contains_v<
-                             typename db::DataBox<DbTagsList>::simple_item_tags,
-                             domain::Tags::Mesh<dim>> and
+  template <
+      typename DbTagsList, typename... InboxTags, typename ArrayIndex,
+      typename ActionList, typename ParallelComponent,
+      Requires<not(tmpl::list_contains_v<
+                       typename db::DataBox<DbTagsList>::mutable_item_tags,
+                       domain::Tags::Mesh<dim>> and
 
-                         tmpl::list_contains_v<
-                             typename db::DataBox<DbTagsList>::simple_item_tags,
-                             variables_tag>)> = nullptr>
+                   tmpl::list_contains_v<
+                       typename db::DataBox<DbTagsList>::mutable_item_tags,
+                       variables_tag>)> = nullptr>
   static std::tuple<db::DataBox<DbTagsList>&&> apply(
       db::DataBox<DbTagsList>& /*box*/,
       const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,

--- a/src/Evolution/Initialization/SetVariables.hpp
+++ b/src/Evolution/Initialization/SetVariables.hpp
@@ -65,7 +65,7 @@ struct SetVariables {
       const ArrayIndex& /*array_index*/, ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) noexcept {
     if constexpr (tmpl::list_contains_v<
-                      typename db::DataBox<DbTagsList>::simple_item_tags,
+                      typename db::DataBox<DbTagsList>::mutable_item_tags,
                       ::Initialization::Tags::InitialTime>) {
       impl<Metavariables>(make_not_null(&box));
     } else {

--- a/src/Parallel/GlobalCache.hpp
+++ b/src/Parallel/GlobalCache.hpp
@@ -645,17 +645,18 @@ struct GlobalCacheImpl : GlobalCache, db::SimpleTag {
 /// Tag used to retrieve data from the `Parallel::GlobalCache`. This is the
 /// recommended way for compute tags to retrieve data out of the global cache.
 template <class CacheTag>
-struct FromGlobalCache : CacheTag, db::ComputeTag {
+struct FromGlobalCache : CacheTag, db::ReferenceTag {
   static_assert(db::is_simple_tag_v<CacheTag>);
-  static std::string name() noexcept {
-    return "FromGlobalCache(" + pretty_type::short_name<CacheTag>() + ")";
-  }
+  using base = CacheTag;
+  using parent_tag = GlobalCache;
+
   template <class Metavariables>
-  static const GlobalCache_detail::type_for_get<CacheTag, Metavariables>&
-  function(const Parallel::GlobalCache<Metavariables>* const& cache) {
+  static const auto& get(
+      const Parallel::GlobalCache<Metavariables>* const& cache) {
     return Parallel::get<CacheTag>(*cache);
   }
-  using argument_tags = tmpl::list<GlobalCache>;
+
+  using argument_tags = tmpl::list<parent_tag>;
 };
 }  // namespace Tags
 }  // namespace Parallel

--- a/src/ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp
+++ b/src/ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp
@@ -47,7 +47,7 @@ struct RemoveOptionsAndTerminatePhase {
         tags_to_remove,
         tmpl::bind<
             tmpl::list_contains,
-            tmpl::pin<typename db::DataBox<DbTagsList>::simple_item_tags>,
+            tmpl::pin<typename db::DataBox<DbTagsList>::mutable_item_tags>,
             tmpl::_1>>;
     static_assert(std::is_same<tmpl::back<ActionList>,
                                RemoveOptionsAndTerminatePhase>::value,

--- a/src/ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp
+++ b/src/ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp
@@ -136,7 +136,7 @@ auto merge_into_databox(db::DataBox<DbTagsList>&& box,
   using simple_tags_to_check = tmpl::filter<
       SimpleTagsList,
       tmpl::bind<tmpl::list_contains,
-                 tmpl::pin<typename db::DataBox<DbTagsList>::simple_item_tags>,
+                 tmpl::pin<typename db::DataBox<DbTagsList>::mutable_item_tags>,
                  tmpl::_1>>;
   using simple_tags_to_add =
       tmpl::remove_if<SimpleTagsList,

--- a/src/ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp
+++ b/src/ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp
@@ -96,11 +96,12 @@ auto merge_into_databox_impl(
           std::move(tuples::get<SimpleTagsToCheck>(simple_tags))));
 
   // Only add compute tags that are not in the DataBox.
-  using compute_tags_to_add = tmpl::remove_if<
-      ComputeTagsList,
-      tmpl::bind<tmpl::list_contains,
-                 tmpl::pin<typename db::DataBox<DbTagsList>::compute_item_tags>,
-                 tmpl::_1>>;
+  using compute_tags_to_add =
+      tmpl::remove_if<ComputeTagsList,
+                      tmpl::bind<tmpl::list_contains,
+                                 tmpl::pin<typename db::DataBox<
+                                     DbTagsList>::immutable_item_creation_tags>,
+                                 tmpl::_1>>;
 
   return db::create_from<db::RemoveTags<>,
                          db::AddSimpleTags<SimpleTagsToAdd...>,

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -2674,6 +2674,33 @@ struct FromTaggedTuple : Tag, db::ReferenceTag {
 };
 /// [databox_reference_tag_example]
 }  // namespace test_databox_tags
+
+void test_reference_item() noexcept {
+  INFO("test reference item");
+  using tuple_tag = test_databox_tags::TaggedTuple<test_databox_tags::Tag0,
+                                                   test_databox_tags::Tag1,
+                                                   test_databox_tags::Tag2>;
+  auto box =
+      db::create<db::AddSimpleTags<tuple_tag>,
+                 db::AddComputeTags<test_databox_tags::FromTaggedTuple<
+                                        test_databox_tags::Tag0, tuple_tag>,
+                                    test_databox_tags::FromTaggedTuple<
+                                        test_databox_tags::Tag1, tuple_tag>,
+                                    test_databox_tags::FromTaggedTuple<
+                                        test_databox_tags::Tag2, tuple_tag>>>(
+          tuples::TaggedTuple<test_databox_tags::Tag0, test_databox_tags::Tag1,
+                              test_databox_tags::Tag2>{
+              3.14, std::vector<double>{8.7, 93.2, 84.7}, "My Sample String"s});
+  const auto& tagged_tuple = get<tuple_tag>(box);
+  CHECK(get<test_databox_tags::Tag0>(tagged_tuple) == 3.14);
+  CHECK(get<test_databox_tags::Tag1>(tagged_tuple) ==
+        std::vector<double>{8.7, 93.2, 84.7});
+  CHECK(get<test_databox_tags::Tag2>(tagged_tuple) == "My Sample String"s);
+  CHECK(get<test_databox_tags::Tag0>(box) == 3.14);
+  CHECK(get<test_databox_tags::Tag1>(box) ==
+        std::vector<double>{8.7, 93.2, 84.7});
+  CHECK(get<test_databox_tags::Tag2>(box) == "My Sample String"s);
+}
 }  // namespace
 
 void test_serialization() noexcept {
@@ -2702,6 +2729,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox", "[Unit][DataStructures]") {
   test_overload_compute_tags();
   test_with_tagged_tuple();
   test_serialization();
+  test_reference_item();
 }
 
 // Test`tag_is_retrievable_v`

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -1452,23 +1452,6 @@ void test_mutate_apply() noexcept {
 }
 
 static_assert(
-    std::is_same_v<tmpl::list<test_databox_tags::Tag4Compute,
-                              test_databox_tags::Tag5Compute,
-                              test_databox_tags::MultiplyScalarByTwoCompute>,
-                   db::get_compute_items<tmpl::list<
-                       test_databox_tags::Tag0, test_databox_tags::Tag4Compute,
-                       test_databox_tags::Tag1, test_databox_tags::Tag5Compute,
-                       test_databox_tags::MultiplyScalarByTwoCompute>>>,
-    "Failed testing db::get_compute_items");
-static_assert(
-    std::is_same_v<tmpl::list<test_databox_tags::Tag0, test_databox_tags::Tag1>,
-                   db::get_items<tmpl::list<
-                       test_databox_tags::Tag0, test_databox_tags::Tag4Compute,
-                       test_databox_tags::Tag1, test_databox_tags::Tag5Compute,
-                       test_databox_tags::MultiplyScalarByTwoCompute>>>,
-    "Failed testing db::get_items");
-
-static_assert(
     std::is_same_v<
         db::compute_databox_type<tmpl::list<
             test_databox_tags::Tag0, test_databox_tags::Tag1,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_CleanUpInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_CleanUpInterpolator.cpp
@@ -44,11 +44,9 @@ struct mock_interpolator {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using simple_tags =
-      db::get_items<typename intrp::Actions::InitializeInterpolator<
-          intrp::Tags::VolumeVarsInfo<Metavariables>,
-          intrp::Tags::InterpolatedVarsHolders<Metavariables>>::
-                        return_tag_list>;
+  using simple_tags = typename intrp::Actions::InitializeInterpolator<
+      intrp::Tags::VolumeVarsInfo<Metavariables>,
+      intrp::Tags::InterpolatedVarsHolders<Metavariables>>::simple_tags;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
@@ -110,9 +110,8 @@ struct mock_interpolation_target {
       intrp::InterpolationTarget<Metavariables, InterpolationTargetTag>;
   using const_global_cache_tags =
       tmpl::list<domain::Tags::Domain<Metavariables::volume_dim>>;
-  using simple_tags =
-      db::get_items<typename intrp::Actions::InitializeInterpolationTarget<
-          Metavariables, InterpolationTargetTag>::return_tag_list>;
+  using simple_tags = typename intrp::Actions::InitializeInterpolationTarget<
+      Metavariables, InterpolationTargetTag>::simple_tags;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetVarsFromElement.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetVarsFromElement.cpp
@@ -107,9 +107,8 @@ struct mock_interpolation_target {
       intrp::InterpolationTarget<Metavariables, InterpolationTargetTag>;
   using const_global_cache_tags =
       tmpl::list<domain::Tags::Domain<Metavariables::volume_dim>>;
-  using simple_tags =
-      db::get_items<typename intrp::Actions::InitializeInterpolationTarget<
-          Metavariables, InterpolationTargetTag>::return_tag_list>;
+  using simple_tags = typename intrp::Actions::InitializeInterpolationTarget<
+      Metavariables, InterpolationTargetTag>::simple_tags;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
@@ -190,11 +190,9 @@ struct mock_interpolator {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using simple_tags =
-      db::get_items<typename intrp::Actions::InitializeInterpolator<
-          intrp::Tags::VolumeVarsInfo<Metavariables>,
-          intrp::Tags::InterpolatedVarsHolders<Metavariables>>::
-                        return_tag_list>;
+  using simple_tags = typename intrp::Actions::InitializeInterpolator<
+      intrp::Tags::VolumeVarsInfo<Metavariables>,
+      intrp::Tags::InterpolatedVarsHolders<Metavariables>>::simple_tags;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,


### PR DESCRIPTION
## Proposed changes

This PR enables the use of reference items in the DataBox.

All compute tags that derive from `db::ComputeTag` except FromGlobalCache have been converted to mutating compute tags (their member function `function` returns void and takes their `return_type` by `gsl::not_null`).  

Non-mutating compute tags will be replaced with reference tags (i.e. derive from `db::ReferenceTag`)

This PR:
- Renames some type aliases in DataBox by using mutable and immutable instead of simple and compute as this in the important distinction between the tags in the type lists.  
- Replaces `db::is_compute_tag` with `db::is_immutable_item_tag` to allow reference items in the DataBox
- Converts FromGlobalCache from a compute tag to a reference tag
- Add a test for reference items
- Removes db::get_items and db::get_compute_items

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
- Compute tags must return by reference (i.e. have a void `function` taking their `return_type` by `gsl::not_null`).
- Anything referring to the old names of the type aliases in DataBox will need to use the new name.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

Note that the tags for subitems of compute items are currently placed in the `immutable_item_tags` list in DataBox despite not being marked with `db::ComputeTag`.  A subsequent PR will mark these tags with either `db::ComputeTag` or `db::ReferenceTag` as appropriate.  

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
