### PR TITLE
Convert from multi-index to storage index without canonicalization

### DIFF
--- a/src/DataStructures/Tensor/Structure.hpp
+++ b/src/DataStructures/Tensor/Structure.hpp
@@ -424,11 +424,7 @@ struct Structure {
     return gsl::at(
         collapsed_to_storage,
         compute_collapsed_index(
-            canonicalize_tensor_index(
-                cpp20::array<size_t, sizeof...(N)>{
-                    {static_cast<size_t>(args)...}},
-                make_cpp20_array_from_list<
-                    tmpl::conditional_t<0 != sizeof...(Indices), Symm, int>>()),
+            cpp20::array<size_t, sizeof...(N)>{{static_cast<size_t>(args)...}},
             make_cpp20_array_from_list<tmpl::conditional_t<
                 0 != sizeof...(Indices), index_list, size_t>>()));
   }
@@ -438,15 +434,11 @@ struct Structure {
   SPECTRE_ALWAYS_INLINE static constexpr std::size_t get_storage_index(
       const std::array<I, sizeof...(Indices)>& tensor_index) noexcept {
     constexpr auto collapsed_to_storage = collapsed_to_storage_;
-    return gsl::at(
-        collapsed_to_storage,
-        compute_collapsed_index(
-            canonicalize_tensor_index(
-                convert_to_cpp20_array(tensor_index),
-                make_cpp20_array_from_list<
-                    tmpl::conditional_t<0 != sizeof...(Indices), Symm, int>>()),
-            make_cpp20_array_from_list<tmpl::conditional_t<
-                0 != sizeof...(Indices), index_list, size_t>>()));
+    return gsl::at(collapsed_to_storage,
+                   compute_collapsed_index(
+                       convert_to_cpp20_array(tensor_index),
+                       make_cpp20_array_from_list<tmpl::conditional_t<
+                           0 != sizeof...(Indices), index_list, size_t>>()));
   }
 
   template <int... N, Requires<(sizeof...(N) > 0)> = nullptr>
@@ -456,9 +448,7 @@ struct Structure {
                   "the number arguments must be equal to rank_");
     constexpr std::size_t storage_index =
         collapsed_to_storage_[compute_collapsed_index(
-            canonicalize_tensor_index(
-                cpp20::array<size_t, sizeof...(N)>{{N...}},
-                make_cpp20_array_from_list<Symm>()),
+            cpp20::array<size_t, sizeof...(N)>{{N...}},
             make_cpp20_array_from_list<index_list>())];
     return storage_index;
   }


### PR DESCRIPTION
## Proposed changes

This PR removes (what I believe to be) the unnecessary canonicalization of tensor multi-indices in converting them to their corresponding `Tensor` storage indices. The motivation for this is to improve the efficiency of `Structure::get_storage_index`.

`Structure` provides a means to convert between these through index mappings and functions that it defines. [Here](https://github.com/sxs-collaboration/spectre/blob/2693c35b13a4eeeb1a6f55847ea0ba98ba93987f/src/DataStructures/Tensor/Structure.hpp#L294) are the different types of index terms that it defines. The key parts of  `Structure` for this PR as I understand them are:
1. There is a 1:1 mapping between tensor multi-indices and collapsed indices. The collapsed indices appear to be just like a flattening of  a multi-dimensional array into a 1D array.
2. `Structure::collapsed_to_storage_` is a not-necessarily-1:1 mapping of collapsed indices to storage indices, depending on whether symmetries are present. It appears to be that, in generating this array, each unique multi-index is canonicalized ([short example comment of canonicalization](https://github.com/sxs-collaboration/spectre/blob/2693c35b13a4eeeb1a6f55847ea0ba98ba93987f/src/DataStructures/Tensor/Structure.hpp#L156)), and all multi-indices with the same canonical form are assigned the same storage index.
3. You can give the function, `Structure::get_storage_index`, a multi-index to get its corresponding storage index back out. Currently, this function first canonicalizes the given multi-index before computing its collapsed index, and then indexes into `collapsed_to_storage_` with the computed collapsed index to retrieve the storage index.

However, because there is a 1:1 mapping between multi-indices and collapsed indices, I don't believe this canonicalization step in `get_storage_index` is needed - I believe computing the collapsed index of the the original `tensor_index` argument in `get_storage_index` suffices since `collapsed_to_storage_` contains a storage index for each multi-index, not just the subset of them in the canonical form.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
