### PR TITLE
Generalize WENO limiters to handle Gauss points

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Limiters/SimpleWenoImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/SimpleWenoImpl.hpp
@@ -55,6 +55,18 @@ void simple_weno_impl(
         std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, PackagedData,
         boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
         neighbor_data) noexcept {
+  // Check that basis is LGL or LG
+  // Note that the SimpleWeno implementation should generalize well to other
+  // bases beyond LGL or LG, once the oscillation_indicator function has been
+  // generalized.
+  ASSERT(mesh.basis() == make_array<VolumeDim>(Spectral::Basis::Legendre),
+         "Unsupported basis: " << mesh);
+  ASSERT(mesh.quadrature() ==
+                 make_array<VolumeDim>(Spectral::Quadrature::GaussLobatto) or
+             mesh.quadrature() ==
+                 make_array<VolumeDim>(Spectral::Quadrature::Gauss),
+         "Unsupported quadrature: " << mesh);
+
   ASSERT(
       modified_neighbor_solution_buffer->size() == neighbor_data.size(),
       "modified_neighbor_solution_buffer->size() = "

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_SimpleWenoImpl.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_SimpleWenoImpl.cpp
@@ -191,12 +191,13 @@ void test_simple_weno_work(
   CHECK_ITERABLE_CUSTOM_APPROX(expected_vector, vector_to_limit, local_approx);
 }
 
-void test_simple_weno_1d(const std::unordered_set<Direction<1>>&
-                             directions_of_external_boundaries = {}) noexcept {
-  INFO("Test simple_weno_impl in 1D");
+void test_simple_weno_1d_impl(
+    const Spectral::Quadrature quadrature,
+    const std::unordered_set<Direction<1>>& directions_of_external_boundaries =
+        {}) noexcept {
+  CAPTURE(quadrature);
   CAPTURE(directions_of_external_boundaries);
-  const auto mesh =
-      Mesh<1>(3, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto);
+  const auto mesh = Mesh<1>(3, Spectral::Basis::Legendre, quadrature);
   const auto element =
       TestHelpers::Limiters::make_element<1>(directions_of_external_boundaries);
   const auto logical_coords = logical_coordinates(mesh);
@@ -265,9 +266,24 @@ void test_simple_weno_1d(const std::unordered_set<Direction<1>>&
                            neighbor_modified_vars);
 }
 
-void test_simple_weno_2d(const std::unordered_set<Direction<2>>&
-                             directions_of_external_boundaries = {}) noexcept {
+void test_simple_weno_1d() noexcept {
+  INFO("Test simple_weno_impl in 1D");
+  const auto gl = Spectral::Quadrature::GaussLobatto;
+  const auto gauss = Spectral::Quadrature::Gauss;
+
+  test_simple_weno_1d_impl(gl);
+  test_simple_weno_1d_impl(gauss);
+
+  // Test with particular boundaries labeled as external
+  test_simple_weno_1d_impl(gl, {{Direction<1>::lower_xi()}});
+}
+
+void test_simple_weno_2d_impl(
+    const Spectral::Quadrature quadrature,
+    const std::unordered_set<Direction<2>>& directions_of_external_boundaries =
+        {}) noexcept {
   INFO("Test simple_weno_impl in 2D");
+  CAPTURE(quadrature);
   CAPTURE(directions_of_external_boundaries);
   const auto mesh =
       Mesh<2>(3, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto);
@@ -373,12 +389,28 @@ void test_simple_weno_2d(const std::unordered_set<Direction<2>>&
                            neighbor_modified_vars);
 }
 
-void test_simple_weno_3d(const std::unordered_set<Direction<3>>&
-                             directions_of_external_boundaries = {}) noexcept {
-  INFO("Test simple_weno_impl in 3D");
+void test_simple_weno_2d() noexcept {
+  INFO("Test simple_weno_impl in 2D");
+  const auto gl = Spectral::Quadrature::GaussLobatto;
+  const auto gauss = Spectral::Quadrature::Gauss;
+
+  test_simple_weno_2d_impl(gl);
+  test_simple_weno_2d_impl(gauss);
+
+  // Test with particular boundaries labeled as external
+  test_simple_weno_2d_impl(gl, {{Direction<2>::lower_eta()}});
+  test_simple_weno_2d_impl(
+      gl, {{Direction<2>::lower_xi(), Direction<2>::lower_eta(),
+            Direction<2>::upper_eta()}});
+}
+
+void test_simple_weno_3d_impl(
+    const Spectral::Quadrature quadrature,
+    const std::unordered_set<Direction<3>>& directions_of_external_boundaries =
+        {}) noexcept {
+  CAPTURE(quadrature);
   CAPTURE(directions_of_external_boundaries);
-  const auto mesh = Mesh<3>({{3, 4, 5}}, Spectral::Basis::Legendre,
-                            Spectral::Quadrature::GaussLobatto);
+  const auto mesh = Mesh<3>({{3, 4, 5}}, Spectral::Basis::Legendre, quadrature);
   const auto element =
       TestHelpers::Limiters::make_element<3>(directions_of_external_boundaries);
   const auto logical_coords = logical_coordinates(mesh);
@@ -526,6 +558,22 @@ void test_simple_weno_3d(const std::unordered_set<Direction<3>>&
                            neighbor_modified_vars, custom_approx);
 }
 
+void test_simple_weno_3d() noexcept {
+  INFO("Test simple_weno_impl in 3D");
+  const auto gl = Spectral::Quadrature::GaussLobatto;
+  const auto gauss = Spectral::Quadrature::Gauss;
+
+  test_simple_weno_3d_impl(gl);
+  test_simple_weno_3d_impl(gauss);
+
+  // Test with particular boundaries labeled as external
+  test_simple_weno_3d_impl(gl, {{Direction<3>::lower_zeta()}});
+  test_simple_weno_3d_impl(
+      gl, {{Direction<3>::lower_xi(), Direction<3>::upper_xi(),
+            Direction<3>::lower_eta(), Direction<3>::lower_zeta(),
+            Direction<3>::lower_zeta()}});
+}
+
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.SimpleWenoImpl",
@@ -533,14 +581,4 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.SimpleWenoImpl",
   test_simple_weno_1d();
   test_simple_weno_2d();
   test_simple_weno_3d();
-
-  // Test with particular boundaries labeled as external
-  test_simple_weno_1d({{Direction<1>::lower_xi()}});
-  test_simple_weno_2d({{Direction<2>::lower_eta()}});
-  test_simple_weno_2d({{Direction<2>::lower_xi(), Direction<2>::lower_eta(),
-                        Direction<2>::upper_eta()}});
-  test_simple_weno_3d({{Direction<3>::lower_zeta()}});
-  test_simple_weno_3d({{Direction<3>::lower_xi(), Direction<3>::upper_xi(),
-                        Direction<3>::lower_eta(), Direction<3>::lower_zeta(),
-                        Direction<3>::lower_zeta()}});
 }

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Weno.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Weno.cpp
@@ -528,7 +528,7 @@ void test_simple_weno(const std::array<size_t, VolumeDim>& extents) noexcept {
   INFO("Test simple WENO limiter");
   CAPTURE(VolumeDim);
   const auto mesh = Mesh<VolumeDim>(extents, Spectral::Basis::Legendre,
-                                    Spectral::Quadrature::GaussLobatto);
+                                    Spectral::Quadrature::Gauss);
   const auto element = TestHelpers::Limiters::make_element<VolumeDim>();
   const auto element_size = make_array<VolumeDim>(1.2);
 
@@ -680,6 +680,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.Weno", "[Limiters][Unit]") {
   test_package_data_3d();
 
   // The simple WENO reconstruction is tested in Test_SimpleWenoImpl.cpp.
+  // There, both LGL and LG points are used. Here we only use Gauss points.
   // Here we test that
   // - the TCI correctly acts component-by-component
   // - the limiter is indeed calling `simple_weno_impl`
@@ -688,6 +689,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.Limiters.Weno", "[Limiters][Unit]") {
   test_simple_weno<3>({{3, 4, 5}});
 
   // The HWENO reconstruction is tested in Test_HwenoImpl.cpp.
+  // There, both LGL and LG points are used. Here we only use LGL points.
   // Here we test that
   // - the TCI correctly triggers limiting on all tensors at once
   // - the limiter is indeed calling `hweno_impl`

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoHelpers.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoHelpers.cpp
@@ -23,10 +23,11 @@
 
 namespace {
 
-void test_reconstruction_1d() noexcept {
+void test_reconstruction_1d_impl(
+    const Spectral::Quadrature quadrature) noexcept {
+  CAPTURE(quadrature);
   const double neighbor_linear_weight = 0.005;
-  const Mesh<1> mesh(5, Spectral::Basis::Legendre,
-                     Spectral::Quadrature::GaussLobatto);
+  const Mesh<1> mesh(5, Spectral::Basis::Legendre, quadrature);
   const auto coords = logical_coordinates(mesh);
 
   const auto evaluate_polynomial =
@@ -67,10 +68,17 @@ void test_reconstruction_1d() noexcept {
   CHECK_ITERABLE_APPROX(local_data, expected_reconstructed_data);
 }
 
-void test_reconstruction_2d() noexcept {
+void test_reconstruction_1d() noexcept {
+  INFO("Testing WENO reconstruction in 1D");
+  test_reconstruction_1d_impl(Spectral::Quadrature::GaussLobatto);
+  test_reconstruction_1d_impl(Spectral::Quadrature::Gauss);
+}
+
+void test_reconstruction_2d_impl(
+    const Spectral::Quadrature quadrature) noexcept {
+  CAPTURE(quadrature);
   const double neighbor_linear_weight = 0.001;
-  const Mesh<2> mesh({{3, 3}}, Spectral::Basis::Legendre,
-                     Spectral::Quadrature::GaussLobatto);
+  const Mesh<2> mesh({{3, 3}}, Spectral::Basis::Legendre, quadrature);
   const auto coords = logical_coordinates(mesh);
 
   const auto evaluate_polynomial =
@@ -124,10 +132,17 @@ void test_reconstruction_2d() noexcept {
   CHECK_ITERABLE_APPROX(local_data, expected_reconstructed_data);
 }
 
-void test_reconstruction_3d() noexcept {
+void test_reconstruction_2d() noexcept {
+  INFO("Testing WENO reconstruction in 2D");
+  test_reconstruction_2d_impl(Spectral::Quadrature::GaussLobatto);
+  test_reconstruction_2d_impl(Spectral::Quadrature::Gauss);
+}
+
+void test_reconstruction_3d_impl(
+    const Spectral::Quadrature quadrature) noexcept {
+  CAPTURE(quadrature);
   const double neighbor_linear_weight = 0.001;
-  const Mesh<3> mesh({{3, 3, 3}}, Spectral::Basis::Legendre,
-                     Spectral::Quadrature::GaussLobatto);
+  const Mesh<3> mesh({{3, 3, 3}}, Spectral::Basis::Legendre, quadrature);
   const auto coords = logical_coordinates(mesh);
 
   // 3D case has so many modes... so we simplify by only setting 6 of them, the
@@ -183,6 +198,12 @@ void test_reconstruction_3d() noexcept {
       Limiters::Weno_detail::DerivativeWeight::Unity, mesh, neighbor_data);
   CHECK(mean_value(local_data, mesh) == approx(expected_local_mean));
   CHECK_ITERABLE_APPROX(local_data, expected_reconstructed_data);
+}
+
+void test_reconstruction_3d() noexcept {
+  INFO("Testing WENO reconstruction in 3D");
+  test_reconstruction_3d_impl(Spectral::Quadrature::GaussLobatto);
+  test_reconstruction_3d_impl(Spectral::Quadrature::Gauss);
 }
 
 }  // namespace

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoOscillationIndicator.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoOscillationIndicator.cpp
@@ -28,10 +28,16 @@ void test_derivative_weight() noexcept {
       "PowTwoEllOverEllFactorial");
 }
 
-void test_oscillation_indicator_1d() noexcept {
-  INFO("Test oscillation_indicator in 1D");
-  const Mesh<1> mesh(5, Spectral::Basis::Legendre,
-                     Spectral::Quadrature::GaussLobatto);
+void test_oscillation_indicator_1d_impl(
+    const size_t number_of_points,
+    const Spectral::Quadrature quadrature) noexcept {
+  // Sanity check there are enough grid points to resolve test function
+  if (number_of_points < 5) {
+    ERROR("test_oscillation_indicator_1d_impl needs 5+ grid points");
+  }
+  CAPTURE(number_of_points);
+  CAPTURE(quadrature);
+  const Mesh<1> mesh(number_of_points, Spectral::Basis::Legendre, quadrature);
   const auto logical_coords = logical_coordinates(mesh);
   const DataVector& x = get<0>(logical_coords);
 
@@ -62,10 +68,20 @@ void test_oscillation_indicator_1d() noexcept {
   CHECK(indicator3 == approx(expected3));
 }
 
-void test_oscillation_indicator_2d() noexcept {
-  INFO("Test oscillation_indicator in 2D");
-  const Mesh<2> mesh({{4, 5}}, Spectral::Basis::Legendre,
-                     Spectral::Quadrature::GaussLobatto);
+void test_oscillation_indicator_1d() noexcept {
+  INFO("Test oscillation_indicator in 1D");
+  // Call with multiple resolutions to verify that the caching of the indicator
+  // matrix correctly accounts for the input mesh
+  test_oscillation_indicator_1d_impl(5, Spectral::Quadrature::GaussLobatto);
+  test_oscillation_indicator_1d_impl(6, Spectral::Quadrature::GaussLobatto);
+  test_oscillation_indicator_1d_impl(5, Spectral::Quadrature::Gauss);
+  test_oscillation_indicator_1d_impl(6, Spectral::Quadrature::Gauss);
+}
+
+void test_oscillation_indicator_2d_impl(
+    const Spectral::Quadrature quadrature) noexcept {
+  CAPTURE(quadrature);
+  const Mesh<2> mesh({{4, 5}}, Spectral::Basis::Legendre, quadrature);
   const auto logical_coords = logical_coordinates(mesh);
   const DataVector& x = get<0>(logical_coords);
   const DataVector& y = get<1>(logical_coords);
@@ -101,10 +117,16 @@ void test_oscillation_indicator_2d() noexcept {
   CHECK(indicator3 == approx(expected3));
 }
 
-void test_oscillation_indicator_3d() noexcept {
-  INFO("Test oscillation_indicator in 3D");
-  const Mesh<3> mesh({{4, 3, 5}}, Spectral::Basis::Legendre,
-                     Spectral::Quadrature::GaussLobatto);
+void test_oscillation_indicator_2d() noexcept {
+  INFO("Test oscillation_indicator in 2D");
+  test_oscillation_indicator_2d_impl(Spectral::Quadrature::GaussLobatto);
+  test_oscillation_indicator_2d_impl(Spectral::Quadrature::Gauss);
+}
+
+void test_oscillation_indicator_3d_impl(
+    const Spectral::Quadrature quadrature) noexcept {
+  CAPTURE(quadrature);
+  const Mesh<3> mesh({{4, 3, 5}}, Spectral::Basis::Legendre, quadrature);
   const auto logical_coords = logical_coordinates(mesh);
   const DataVector& x = get<0>(logical_coords);
   const DataVector& y = get<1>(logical_coords);
@@ -146,6 +168,12 @@ void test_oscillation_indicator_3d() noexcept {
       mesh);
   const double expected3 = 54886604. / 525.;
   CHECK(indicator3 == approx(expected3));
+}
+
+void test_oscillation_indicator_3d() noexcept {
+  INFO("Test oscillation_indicator in 3D");
+  test_oscillation_indicator_3d_impl(Spectral::Quadrature::GaussLobatto);
+  test_oscillation_indicator_3d_impl(Spectral::Quadrature::Gauss);
 }
 
 }  // namespace


### PR DESCRIPTION
## Proposed changes

Generalize the WENO limiters to handle Gauss points
- changes the caching of the oscillation indicator matrix to handle multiple different meshes
- adds tests of various different WENO functions with LGL and LG points

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
