### PR TITLE
Error stepper action reorder

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
@@ -42,6 +42,9 @@
 #include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "ParallelAlgorithms/DiscontinuousGalerkin/FluxCommunication.hpp"
+#include "Time/Actions/SelfStartActions.hpp"
+#include "Time/Tags.hpp"
+#include "Time/TakeStep.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -291,11 +294,19 @@ struct ComputeTimeDerivative {
       typename GetFluxInboxTag<Metavariables>::type,
       tmpl::list<evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<
           Metavariables::volume_dim>>>;
-  using const_global_cache_tags = tmpl::conditional_t<
-      detail::has_boundary_correction_v<typename Metavariables::system>,
-      tmpl::list<::dg::Tags::Formulation, evolution::Tags::BoundaryCorrection<
-                                              typename Metavariables::system>>,
-      tmpl::list<::dg::Tags::Formulation>>;
+  using const_global_cache_tags = tmpl::append<
+      tmpl::conditional_t<
+          detail::has_boundary_correction_v<typename Metavariables::system>,
+          tmpl::list<::dg::Tags::Formulation,
+                     evolution::Tags::BoundaryCorrection<
+                         typename Metavariables::system>>,
+          tmpl::list<::dg::Tags::Formulation>>,
+      tmpl::conditional_t<
+          Metavariables::local_time_stepping,
+          tmpl::list<
+              ::Tags::StepChoosers<typename Metavariables::step_choosers>,
+              ::Tags::StepController, ::Tags::TimeStepper<LtsTimeStepper>>,
+          tmpl::list<>>>;
 
   template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
             typename ActionList, typename ParallelComponent>
@@ -487,6 +498,11 @@ ComputeTimeDerivative<Metavariables>::apply(
     fill_mortar_data_for_internal_boundaries<
         volume_dim, typename Metavariables::boundary_scheme>(
         make_not_null(&box));
+  }
+
+  if constexpr (Metavariables::local_time_stepping) {
+    take_step<typename Metavariables::step_choosers>(make_not_null(&box),
+                                                     cache);
   }
 
   send_data_for_fluxes<ParallelComponent>(make_not_null(&cache),

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -244,10 +244,11 @@ struct EvolutionMetavars {
                   Phase, Phase::Evolve,
                   tmpl::list<
                       Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
+                      step_actions,
                       tmpl::conditional_t<
                           local_time_stepping,
                           Actions::ChangeStepSize<step_choosers>, tmpl::list<>>,
-                      step_actions, Actions::AdvanceTime>>>>>;
+                      Actions::AdvanceTime>>>>>;
 
   static constexpr Options::String help{
       "Evolve the Burgers equation.\n\n"

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -180,12 +180,11 @@ struct EvolutionMetavars {
           boundary_scheme,
           domain::Tags::BoundaryDirectionsInterior<volume_dim>>,
       dg::Actions::ReceiveDataForFluxes<boundary_scheme>,
-      tmpl::conditional_t<local_time_stepping,
-                          tmpl::list<Actions::RecordTimeStepperData<>,
-                                     Actions::MutateApply<boundary_scheme>>,
-                          tmpl::list<Actions::MutateApply<boundary_scheme>,
-                                     Actions::RecordTimeStepperData<>>>,
-      Actions::UpdateU<>, Limiters::Actions::SendData<EvolutionMetavars>,
+      Actions::MutateApply<boundary_scheme>,
+      tmpl::conditional_t<
+          local_time_stepping, tmpl::list<>,
+          tmpl::list<Actions::RecordTimeStepperData<>, Actions::UpdateU<>>>,
+      Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>>>;
 
   enum class Phase {
@@ -242,13 +241,9 @@ struct EvolutionMetavars {
 
               Parallel::PhaseActions<
                   Phase, Phase::Evolve,
-                  tmpl::list<
-                      Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
-                      step_actions,
-                      tmpl::conditional_t<
-                          local_time_stepping,
-                          Actions::ChangeStepSize<step_choosers>, tmpl::list<>>,
-                      Actions::AdvanceTime>>>>>;
+                  tmpl::list<Actions::RunEventsAndTriggers,
+                             Actions::ChangeSlabSize, step_actions,
+                             Actions::AdvanceTime>>>>>;
 
   static constexpr Options::String help{
       "Evolve the Burgers equation.\n\n"

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -270,12 +270,10 @@ struct EvolutionMetavars {
           boundary_scheme,
           domain::Tags::BoundaryDirectionsInterior<volume_dim>>,
       dg::Actions::ReceiveDataForFluxes<boundary_scheme>,
-      tmpl::conditional_t<local_time_stepping,
-                          tmpl::list<Actions::RecordTimeStepperData<>,
-                                     Actions::MutateApply<boundary_scheme>>,
-                          tmpl::list<Actions::MutateApply<boundary_scheme>,
-                                     Actions::RecordTimeStepperData<>>>,
-      Actions::UpdateU<>>;
+      Actions::MutateApply<boundary_scheme>,
+      tmpl::conditional_t<
+          local_time_stepping, tmpl::list<>,
+          tmpl::list<Actions::RecordTimeStepperData<>, Actions::UpdateU<>>>>;
 
   enum class Phase {
     Initialization,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -244,12 +244,11 @@ struct EvolutionMetavars {
           boundary_scheme,
           domain::Tags::BoundaryDirectionsInterior<volume_dim>>,
       dg::Actions::ReceiveDataForFluxes<boundary_scheme>,
-      tmpl::conditional_t<local_time_stepping,
-                          tmpl::list<Actions::RecordTimeStepperData<>,
-                                     Actions::MutateApply<boundary_scheme>>,
-                          tmpl::list<Actions::MutateApply<boundary_scheme>,
-                                     Actions::RecordTimeStepperData<>>>,
-      Actions::UpdateU<>, Limiters::Actions::SendData<EvolutionMetavars>,
+      Actions::MutateApply<boundary_scheme>,
+      tmpl::conditional_t<
+          local_time_stepping, tmpl::list<>,
+          tmpl::list<Actions::RecordTimeStepperData<>, Actions::UpdateU<>>>,
+      Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,
       VariableFixing::Actions::FixVariables<
           grmhd::ValenciaDivClean::FixConservatives>,
@@ -318,16 +317,12 @@ struct EvolutionMetavars {
 
           Parallel::PhaseActions<
               Phase, Phase::Evolve,
-              tmpl::list<
-                  VariableFixing::Actions::FixVariables<
-                      VariableFixing::FixToAtmosphere<volume_dim,
-                                                      thermodynamic_dim>>,
-                  Actions::UpdateConservatives, Actions::RunEventsAndTriggers,
-                  Actions::ChangeSlabSize, step_actions,
-                  tmpl::conditional_t<local_time_stepping,
-                                      Actions::ChangeStepSize<step_choosers>,
-                                      tmpl::list<>>,
-                  Actions::AdvanceTime>>>>;
+              tmpl::list<VariableFixing::Actions::FixVariables<
+                             VariableFixing::FixToAtmosphere<
+                                 volume_dim, thermodynamic_dim>>,
+                         Actions::UpdateConservatives,
+                         Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
+                         step_actions, Actions::AdvanceTime>>>>;
   using component_list = tmpl::list<
       observers::Observer<EvolutionMetavars>,
       observers::ObserverWriter<EvolutionMetavars>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -323,11 +323,11 @@ struct EvolutionMetavars {
                       VariableFixing::FixToAtmosphere<volume_dim,
                                                       thermodynamic_dim>>,
                   Actions::UpdateConservatives, Actions::RunEventsAndTriggers,
-                  Actions::ChangeSlabSize,
+                  Actions::ChangeSlabSize, step_actions,
                   tmpl::conditional_t<local_time_stepping,
                                       Actions::ChangeStepSize<step_choosers>,
                                       tmpl::list<>>,
-                  step_actions, Actions::AdvanceTime>>>>;
+                  Actions::AdvanceTime>>>>;
   using component_list = tmpl::list<
       observers::Observer<EvolutionMetavars>,
       observers::ObserverWriter<EvolutionMetavars>,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -202,12 +202,11 @@ struct EvolutionMetavars {
           boundary_scheme,
           domain::Tags::BoundaryDirectionsInterior<volume_dim>>,
       dg::Actions::ReceiveDataForFluxes<boundary_scheme>,
-      tmpl::conditional_t<local_time_stepping,
-                          tmpl::list<Actions::RecordTimeStepperData<>,
-                                     Actions::MutateApply<boundary_scheme>>,
-                          tmpl::list<Actions::MutateApply<boundary_scheme>,
-                                     Actions::RecordTimeStepperData<>>>,
-      Actions::UpdateU<>, Limiters::Actions::SendData<EvolutionMetavars>,
+      Actions::MutateApply<boundary_scheme>,
+      tmpl::conditional_t<
+          local_time_stepping, tmpl::list<>,
+          tmpl::list<Actions::RecordTimeStepperData<>, Actions::UpdateU<>>>,
+      Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,
       // Conservative `UpdatePrimitives` expects system to possess
       // list of recovery schemes so we use `MutateApply` instead.
@@ -276,14 +275,10 @@ struct EvolutionMetavars {
 
               Parallel::PhaseActions<
                   Phase, Phase::Evolve,
-                  tmpl::list<
-                      Actions::UpdateConservatives,
-                      Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
-                      step_actions,
-                      tmpl::conditional_t<
-                          local_time_stepping,
-                          Actions::ChangeStepSize<step_choosers>, tmpl::list<>>,
-                      Actions::AdvanceTime>>>>>;
+                  tmpl::list<Actions::UpdateConservatives,
+                             Actions::RunEventsAndTriggers,
+                             Actions::ChangeSlabSize, step_actions,
+                             Actions::AdvanceTime>>>>>;
 
   using const_global_cache_tags = tmpl::list<
       initial_data_tag,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -279,10 +279,11 @@ struct EvolutionMetavars {
                   tmpl::list<
                       Actions::UpdateConservatives,
                       Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
+                      step_actions,
                       tmpl::conditional_t<
                           local_time_stepping,
                           Actions::ChangeStepSize<step_choosers>, tmpl::list<>>,
-                      step_actions, Actions::AdvanceTime>>>>>;
+                      Actions::AdvanceTime>>>>>;
 
   using const_global_cache_tags = tmpl::list<
       initial_data_tag,

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -267,10 +267,11 @@ struct EvolutionMetavars {
                   Phase, Phase::Evolve,
                   tmpl::list<
                       Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
+                      step_actions,
                       tmpl::conditional_t<
                           local_time_stepping,
                           Actions::ChangeStepSize<step_choosers>, tmpl::list<>>,
-                      step_actions, Actions::AdvanceTime>>>>>;
+                      Actions::AdvanceTime>>>>>;
 
   using const_global_cache_tags =
       tmpl::list<initial_data_tag, normal_dot_numerical_flux, time_stepper_tag,

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -189,12 +189,11 @@ struct EvolutionMetavars {
           boundary_scheme,
           domain::Tags::BoundaryDirectionsInterior<volume_dim>>,
       dg::Actions::ReceiveDataForFluxes<boundary_scheme>,
-      tmpl::conditional_t<local_time_stepping,
-                          tmpl::list<Actions::RecordTimeStepperData<>,
-                                     Actions::MutateApply<boundary_scheme>>,
-                          tmpl::list<Actions::MutateApply<boundary_scheme>,
-                                     Actions::RecordTimeStepperData<>>>,
-      Actions::UpdateU<>, Limiters::Actions::SendData<EvolutionMetavars>,
+      Actions::MutateApply<boundary_scheme>,
+      tmpl::conditional_t<
+          local_time_stepping, tmpl::list<>,
+          tmpl::list<Actions::RecordTimeStepperData<>, Actions::UpdateU<>>>,
+      Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,
       Actions::MutateApply<typename RadiationTransport::M1Grey::
                                ComputeM1Closure<neutrino_species>>,
@@ -265,13 +264,9 @@ struct EvolutionMetavars {
 
               Parallel::PhaseActions<
                   Phase, Phase::Evolve,
-                  tmpl::list<
-                      Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
-                      step_actions,
-                      tmpl::conditional_t<
-                          local_time_stepping,
-                          Actions::ChangeStepSize<step_choosers>, tmpl::list<>>,
-                      Actions::AdvanceTime>>>>>;
+                  tmpl::list<Actions::RunEventsAndTriggers,
+                             Actions::ChangeSlabSize, step_actions,
+                             Actions::AdvanceTime>>>>>;
 
   using const_global_cache_tags =
       tmpl::list<initial_data_tag, normal_dot_numerical_flux, time_stepper_tag,

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -284,10 +284,11 @@ struct EvolutionMetavars {
                                                           thermodynamic_dim>>,
                       Actions::UpdateConservatives,
                       Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
+                      step_actions,
                       tmpl::conditional_t<
                           local_time_stepping,
                           Actions::ChangeStepSize<step_choosers>, tmpl::list<>>,
-                      step_actions, Actions::AdvanceTime>>>>>;
+                      Actions::AdvanceTime>>>>>;
 
   using const_global_cache_tags =
       tmpl::list<initial_data_tag, normal_dot_numerical_flux, time_stepper_tag,

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -198,12 +198,11 @@ struct EvolutionMetavars {
           boundary_scheme,
           domain::Tags::BoundaryDirectionsInterior<volume_dim>>,
       dg::Actions::ReceiveDataForFluxes<boundary_scheme>,
-      tmpl::conditional_t<local_time_stepping,
-                          tmpl::list<Actions::RecordTimeStepperData<>,
-                                     Actions::MutateApply<boundary_scheme>>,
-                          tmpl::list<Actions::MutateApply<boundary_scheme>,
-                                     Actions::RecordTimeStepperData<>>>,
-      Actions::UpdateU<>, Limiters::Actions::SendData<EvolutionMetavars>,
+      Actions::MutateApply<boundary_scheme>,
+      tmpl::conditional_t<
+          local_time_stepping, tmpl::list<>,
+          tmpl::list<Actions::RecordTimeStepperData<>, Actions::UpdateU<>>>,
+      Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,
       VariableFixing::Actions::FixVariables<
           RelativisticEuler::Valencia::FixConservatives<Dim>>,
@@ -278,17 +277,13 @@ struct EvolutionMetavars {
 
               Parallel::PhaseActions<
                   Phase, Phase::Evolve,
-                  tmpl::list<
-                      VariableFixing::Actions::FixVariables<
-                          VariableFixing::FixToAtmosphere<volume_dim,
-                                                          thermodynamic_dim>>,
-                      Actions::UpdateConservatives,
-                      Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
-                      step_actions,
-                      tmpl::conditional_t<
-                          local_time_stepping,
-                          Actions::ChangeStepSize<step_choosers>, tmpl::list<>>,
-                      Actions::AdvanceTime>>>>>;
+                  tmpl::list<VariableFixing::Actions::FixVariables<
+                                 VariableFixing::FixToAtmosphere<
+                                     volume_dim, thermodynamic_dim>>,
+                             Actions::UpdateConservatives,
+                             Actions::RunEventsAndTriggers,
+                             Actions::ChangeSlabSize, step_actions,
+                             Actions::AdvanceTime>>>>>;
 
   using const_global_cache_tags =
       tmpl::list<initial_data_tag, normal_dot_numerical_flux, time_stepper_tag,

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -253,10 +253,11 @@ struct EvolutionMetavars {
                   Phase, Phase::Evolve,
                   tmpl::list<
                       Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
+                      step_actions,
                       tmpl::conditional_t<
                           local_time_stepping,
                           Actions::ChangeStepSize<step_choosers>, tmpl::list<>>,
-                      step_actions, Actions::AdvanceTime>>>>>;
+                      Actions::AdvanceTime>>>>>;
 
   static constexpr Options::String help{
       "Evolve a Scalar Wave in Dim spatial dimension.\n\n"

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -182,12 +182,10 @@ struct EvolutionMetavars {
           boundary_scheme,
           domain::Tags::BoundaryDirectionsInterior<volume_dim>>,
       dg::Actions::ReceiveDataForFluxes<boundary_scheme>,
-      tmpl::conditional_t<local_time_stepping,
-                          tmpl::list<Actions::RecordTimeStepperData<>,
-                                     Actions::MutateApply<boundary_scheme>>,
-                          tmpl::list<Actions::MutateApply<boundary_scheme>,
-                                     Actions::RecordTimeStepperData<>>>,
-      Actions::UpdateU<>,
+      Actions::MutateApply<boundary_scheme>,
+      tmpl::conditional_t<
+          local_time_stepping, tmpl::list<>,
+          tmpl::list<Actions::RecordTimeStepperData<>, Actions::UpdateU<>>>,
       tmpl::conditional_t<
           use_filtering,
           dg::Actions::Filter<Filters::Exponential<0>,
@@ -251,13 +249,9 @@ struct EvolutionMetavars {
 
               Parallel::PhaseActions<
                   Phase, Phase::Evolve,
-                  tmpl::list<
-                      Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
-                      step_actions,
-                      tmpl::conditional_t<
-                          local_time_stepping,
-                          Actions::ChangeStepSize<step_choosers>, tmpl::list<>>,
-                      Actions::AdvanceTime>>>>>;
+                  tmpl::list<Actions::RunEventsAndTriggers,
+                             Actions::ChangeSlabSize, step_actions,
+                             Actions::AdvanceTime>>>>>;
 
   static constexpr Options::String help{
       "Evolve a Scalar Wave in Dim spatial dimension.\n\n"

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -84,7 +84,8 @@ struct TimeAndTimeStep {
 
   using simple_tags =
       tmpl::list<::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>,
-                 ::Tags::Time, ::Tags::TimeStep>;
+                 ::Tags::Time, ::Tags::TimeStep,
+                 ::Tags::Next<::Tags::TimeStep>>;
   using compute_tags = tmpl::list<::Tags::SubstepTimeCompute>;
 
   template <
@@ -133,11 +134,11 @@ struct TimeAndTimeStep {
         -static_cast<int64_t>(time_stepper.number_of_past_steps()),
         initial_time);
 
-    Initialization::mutate_assign<
-        tmpl::list<::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>,
-                   ::Tags::Time, ::Tags::TimeStep>>(
+    Initialization::mutate_assign<tmpl::list<
+        ::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>, ::Tags::Time,
+        ::Tags::TimeStep, ::Tags::Next<::Tags::TimeStep>>>(
         make_not_null(&box), TimeStepId{}, time_id,
-        std::numeric_limits<double>::signaling_NaN(), initial_dt);
+        std::numeric_limits<double>::signaling_NaN(), initial_dt, initial_dt);
     return std::make_tuple(std::move(box));
   }
 

--- a/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
@@ -66,7 +66,7 @@ struct InitializeCharacteristicEvolutionTime {
       ::Tags::Variables<tmpl::list<EvolvedSwshTag>>;
   using simple_tags = tmpl::list<
       ::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>, ::Tags::TimeStep,
-      ::Tags::Time,
+      ::Tags::Next<::Tags::TimeStep>, ::Tags::Time,
       ::Tags::HistoryEvolvedVariables<EvolvedCoordinatesVariablesTag>,
       ::Tags::HistoryEvolvedVariables<evolved_swsh_variables_tag>>;
   using compute_tags = tmpl::list<::Tags::SubstepTimeCompute>;
@@ -105,8 +105,8 @@ struct InitializeCharacteristicEvolutionTime {
         make_not_null(&box),
         std::move(initial_time_id),  // NOLINT
         std::move(second_time_id),   // NOLINT
-        fixed_time_step, initial_time_value, std::move(coordinate_history),
-        std::move(swsh_history));
+        fixed_time_step, fixed_time_step, initial_time_value,
+        std::move(coordinate_history), std::move(swsh_history));
     return std::make_tuple(std::move(box));
   }
 };

--- a/src/Time/Actions/AdvanceTime.hpp
+++ b/src/Time/Actions/AdvanceTime.hpp
@@ -57,16 +57,20 @@ struct AdvanceTime {
       const ArrayIndex& /*array_index*/, ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) noexcept {  // NOLINT const
     db::mutate<Tags::TimeStepId, Tags::Next<Tags::TimeStepId>, Tags::TimeStep,
-               Tags::Time>(
+               Tags::Time, Tags::Next<Tags::TimeStep>>(
         make_not_null(&box),
         [](const gsl::not_null<TimeStepId*> time_id,
            const gsl::not_null<TimeStepId*> next_time_id,
            const gsl::not_null<TimeDelta*> time_step,
            const gsl::not_null<double*> time,
+           const gsl::not_null<TimeDelta*> next_time_step,
            const TimeStepper& time_stepper) noexcept {
           *time_id = *next_time_id;
-          *time_step = time_step->with_slab(time_id->step_time().slab());
+          *time_step = next_time_step->with_slab(time_id->step_time().slab());
+
           *next_time_id = time_stepper.next_time_id(*next_time_id, *time_step);
+          *next_time_step =
+              time_step->with_slab(next_time_id->step_time().slab());
           *time = time_id->substep_time().value();
         },
         db::get<Tags::TimeStepper<>>(box));

--- a/src/Time/Actions/ChangeSlabSize.hpp
+++ b/src/Time/Actions/ChangeSlabSize.hpp
@@ -166,14 +166,17 @@ struct ChangeSlabSize {
     const auto new_next_time_step_id =
         time_stepper.next_time_id(new_time_step_id, new_step);
 
-    db::mutate<Tags::Next<Tags::TimeStepId>, Tags::TimeStep, Tags::TimeStepId>(
+    db::mutate<Tags::Next<Tags::TimeStepId>, Tags::TimeStep,
+               Tags::Next<Tags::TimeStep>, Tags::TimeStepId>(
         make_not_null(&box),
         [&new_next_time_step_id, &new_step, &new_time_step_id](
             const gsl::not_null<TimeStepId*> next_time_step_id,
             const gsl::not_null<TimeDelta*> time_step,
+            const gsl::not_null<TimeDelta*> next_time_step,
             const gsl::not_null<TimeStepId*> local_time_step_id) noexcept {
           *next_time_step_id = new_next_time_step_id;
           *time_step = new_step;
+          *next_time_step = new_step;
           *local_time_step_id = new_time_step_id;
         });
 

--- a/src/Time/Actions/ChangeStepSize.hpp
+++ b/src/Time/Actions/ChangeStepSize.hpp
@@ -25,6 +25,68 @@ struct Next;
 // IWYU pragma: no_forward_declare db::DataBox
 /// \endcond
 
+/// Adjust the step size for local time stepping
+///
+/// \note this is a free function version of `Actions::ChangeStepSize`.
+/// This free function alternative permits the inclusion of the time step
+/// procedure in the middle of another action. When used as a free function, the
+/// calling action is responsible for specifying the const global cache tags
+/// needed by this function (`Tags::StepChoosers<StepChooserRegistrars>`,
+/// `Tags::StepController`).
+template <typename StepChooserRegistrars, typename DbTags,
+          typename Metavariables>
+void change_step_size(
+    const gsl::not_null<db::DataBox<DbTags>*> box,
+    const Parallel::GlobalCache<Metavariables>& cache) noexcept {
+  using step_choosers_tag = Tags::StepChoosers<StepChooserRegistrars>;
+
+  const LtsTimeStepper& time_stepper = db::get<Tags::TimeStepper<>>(*box);
+  const auto& step_choosers = db::get<step_choosers_tag>(*box);
+  const auto& step_controller = db::get<Tags::StepController>(*box);
+
+  const auto& time_id = db::get<Tags::TimeStepId>(*box);
+  const auto& history = db::get<Tags::HistoryEvolvedVariables<>>(*box);
+
+  if (not time_stepper.can_change_step_size(time_id, history)) {
+    return;
+  }
+
+  const auto& current_step = db::get<Tags::TimeStep>(*box);
+
+  const double last_step_size =
+      history.size() > 0 ? abs(time_id.step_time() -
+                               (history.end() - 1).time_step_id().step_time())
+                               .value()
+                         : std::numeric_limits<double>::infinity();
+
+  // The step choosers return the magnitude of the desired step, so
+  // we always want the minimum requirement, but we have to negate
+  // the final answer if time is running backwards.
+  double desired_step = std::numeric_limits<double>::infinity();
+  for (const auto& step_chooser : step_choosers) {
+    desired_step =
+        std::min(desired_step,
+                 step_chooser->desired_step(last_step_size, *box, cache).first);
+  }
+  if (not current_step.is_positive()) {
+    desired_step = -desired_step;
+  }
+
+  const auto new_step =
+      step_controller.choose_step(time_id.step_time(), desired_step);
+  if (new_step != current_step) {
+    const auto new_next_time_id = time_stepper.next_time_id(time_id, new_step);
+
+    db::mutate<Tags::Next<Tags::TimeStepId>, Tags::TimeStep>(
+        box, [&new_next_time_id, &new_step](
+                 const gsl::not_null<TimeStepId*> next_time_id,
+                 const gsl::not_null<TimeDelta*> time_step) noexcept {
+          *next_time_id = new_next_time_id;
+          *time_step = new_step;
+        });
+  }
+}
+
 namespace Actions {
 /// \ingroup ActionsGroup
 /// \ingroup TimeGroup
@@ -60,55 +122,7 @@ struct ChangeStepSize {
       const ParallelComponent* const /*meta*/) noexcept {
     static_assert(Metavariables::local_time_stepping,
                   "ChangeStepSize can only be used with local time-stepping.");
-
-    const LtsTimeStepper& time_stepper = db::get<Tags::TimeStepper<>>(box);
-    const auto& step_choosers = Parallel::get<step_choosers_tag>(cache);
-    const auto& step_controller = Parallel::get<Tags::StepController>(cache);
-
-    const auto& time_id = db::get<Tags::TimeStepId>(box);
-    const auto& history = db::get<Tags::HistoryEvolvedVariables<>>(box);
-
-    if (not time_stepper.can_change_step_size(time_id, history)) {
-      return std::forward_as_tuple(std::move(box));
-    }
-
-    const auto& current_step = db::get<Tags::TimeStep>(box);
-
-    const double last_step_size =
-        history.size() > 0 ? abs(time_id.step_time() -
-                                 (history.end() - 1).time_step_id().step_time())
-                                 .value()
-                           : std::numeric_limits<double>::infinity();
-
-    // The step choosers return the magnitude of the desired step, so
-    // we always want the minimum requirement, but we have to negate
-    // the final answer if time is running backwards.
-    double desired_step = std::numeric_limits<double>::infinity();
-    for (const auto& step_chooser : step_choosers) {
-      desired_step = std::min(
-          desired_step,
-          step_chooser->desired_step(last_step_size, box, cache).first);
-    }
-    if (not current_step.is_positive()) {
-      desired_step = -desired_step;
-    }
-
-    const auto new_step =
-        step_controller.choose_step(time_id.step_time(), desired_step);
-    if (new_step != current_step) {
-      const auto new_next_time_id =
-          time_stepper.next_time_id(time_id, new_step);
-
-      db::mutate<Tags::Next<Tags::TimeStepId>, Tags::TimeStep>(
-          make_not_null(&box),
-          [&new_next_time_id, &new_step](
-              const gsl::not_null<TimeStepId*> next_time_id,
-              const gsl::not_null<TimeDelta*> time_step) noexcept {
-            *next_time_id = new_next_time_id;
-            *time_step = new_step;
-          });
-    }
-
+    change_step_size<StepChooserRegistrars>(make_not_null(&box), cache);
     return std::forward_as_tuple(std::move(box));
   }
 };

--- a/src/Time/Actions/ChangeStepSize.hpp
+++ b/src/Time/Actions/ChangeStepSize.hpp
@@ -9,6 +9,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep  // for Tags::Next
 #include "Parallel/GlobalCache.hpp"
+#include "Time/Actions/UpdateU.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/Gsl.hpp"
@@ -25,7 +26,8 @@ struct Next;
 // IWYU pragma: no_forward_declare db::DataBox
 /// \endcond
 
-/// Adjust the step size for local time stepping
+/// Adjust the step size for local time stepping, returning true if the step
+/// just completed is accepted, and false if it is rejected.
 ///
 /// \note this is a free function version of `Actions::ChangeStepSize`.
 /// This free function alternative permits the inclusion of the time step
@@ -35,7 +37,7 @@ struct Next;
 /// `Tags::StepController`).
 template <typename StepChooserRegistrars, typename DbTags,
           typename Metavariables>
-void change_step_size(
+bool change_step_size(
     const gsl::not_null<db::DataBox<DbTags>*> box,
     const Parallel::GlobalCache<Metavariables>& cache) noexcept {
   using step_choosers_tag = Tags::StepChoosers<StepChooserRegistrars>;
@@ -48,20 +50,23 @@ void change_step_size(
   const auto& history = db::get<Tags::HistoryEvolvedVariables<>>(*box);
 
   if (not time_stepper.can_change_step_size(next_time_id, history)) {
-    return;
+    return true;
   }
 
   const auto& current_step = db::get<Tags::TimeStep>(*box);
+
   const double last_step_size = std::abs(db::get<Tags::TimeStep>(*box).value());
 
   // The step choosers return the magnitude of the desired step, so
   // we always want the minimum requirement, but we have to negate
   // the final answer if time is running backwards.
   double desired_step = std::numeric_limits<double>::infinity();
+  bool step_accepted = true;
   for (const auto& step_chooser : step_choosers) {
-    desired_step =
-        std::min(desired_step,
-                 step_chooser->desired_step(last_step_size, *box, cache).first);
+    const auto [step_choice, step_choice_accepted] =
+        step_chooser->desired_step(last_step_size, *box, cache);
+    desired_step = std::min(desired_step, step_choice);
+    step_accepted = step_accepted and step_choice_accepted;
   }
   if (not current_step.is_positive()) {
     desired_step = -desired_step;
@@ -69,11 +74,28 @@ void change_step_size(
 
   const auto new_step =
       step_controller.choose_step(next_time_id.step_time(), desired_step);
-  if (new_step != current_step) {
-    db::mutate<Tags::Next<Tags::TimeStep>>(
-        box, [&new_step](const gsl::not_null<TimeDelta*> next_step) noexcept {
-          *next_step = new_step;
-        });
+  db::mutate<Tags::Next<Tags::TimeStep>>(
+      box, [&new_step](const gsl::not_null<TimeDelta*> next_step) noexcept {
+        *next_step = new_step;
+      });
+  // if step accepted, just proceed. Otherwise, change Time::Next and jump
+  // back to the first instance of `UpdateU`.
+  if (step_accepted) {
+    return true;
+  } else {
+    db::mutate<Tags::Next<Tags::TimeStepId>, Tags::TimeStep>(
+        box,
+        [&time_stepper, &step_controller, &desired_step](
+            const gsl::not_null<TimeStepId*> local_next_time_id,
+            const gsl::not_null<TimeDelta*> time_step,
+            const TimeStepId& time_id) noexcept {
+          *time_step = step_controller.choose_step(
+              time_id.step_time(), desired_step);
+          *local_next_time_id = time_stepper.next_time_id(
+              time_id, *time_step);
+        },
+        db::get<Tags::TimeStepId>(*box));
+    return false;
   }
 }
 
@@ -105,15 +127,32 @@ struct ChangeStepSize {
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>
-  static std::tuple<db::DataBox<DbTags>&&> apply(
+  static std::tuple<db::DataBox<DbTags>&&, bool, size_t> apply(
       db::DataBox<DbTags>& box, tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
       const Parallel::GlobalCache<Metavariables>& cache,
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) noexcept {
     static_assert(Metavariables::local_time_stepping,
                   "ChangeStepSize can only be used with local time-stepping.");
-    change_step_size<StepChooserRegistrars>(make_not_null(&box), cache);
-    return std::forward_as_tuple(std::move(box));
+    static_assert(
+        tmpl::any<ActionList,
+                  tt::is_a_lambda<Actions::UpdateU, tmpl::_1>>::value,
+        "The ChangeStepSize action requires that you also use the UpdateU "
+        "action to permit step-unwinding. If you are stepping within "
+        "an action that is not UpdateU, consider using the take_step function "
+        "to handle both stepping and step-choosing instead of the "
+        "ChangeStepSize action.");
+    const bool step_successful =
+        change_step_size<StepChooserRegistrars>(make_not_null(&box), cache);
+    if (step_successful) {
+      return {std::move(box), false,
+              tmpl::index_of<ActionList, ChangeStepSize>::value};
+    } else {
+      return {
+          std::move(box), false,
+          tmpl::index_if<ActionList,
+                         tt::is_a_lambda<Actions::UpdateU, tmpl::_1>>::value};
+    }
   }
 };
 }  // namespace Actions

--- a/src/Time/CMakeLists.txt
+++ b/src/Time/CMakeLists.txt
@@ -24,6 +24,7 @@ spectre_target_headers(
   History.hpp
   Slab.hpp
   Tags.hpp
+  TakeStep.hpp
   Time.hpp
   TimeSequence.hpp
   TimeStepId.hpp

--- a/src/Time/StepChoosers/Cfl.hpp
+++ b/src/Time/StepChoosers/Cfl.hpp
@@ -75,17 +75,17 @@ class Cfl : public StepChooser<StepChooserRegistrars> {
       const double minimum_grid_spacing, const db::DataBox<DbTags>& box,
       const typename Metavariables::time_stepper_tag::type::element_type&
           time_stepper,
-      const double /*last_step_magnitude*/,
-      const Parallel::GlobalCache<Metavariables>& /*cache*/) const
-      noexcept {
+      const double last_step_magnitude,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/) const noexcept {
     using compute_largest_characteristic_speed =
         typename Metavariables::system::compute_largest_characteristic_speed;
     const double speed = db::apply<compute_largest_characteristic_speed>(box);
     const double time_stepper_stability_factor = time_stepper.stable_step();
 
-    return std::make_pair(safety_factor_ * time_stepper_stability_factor *
-                              minimum_grid_spacing / speed,
-                          true);
+    const double step_size = safety_factor_ * time_stepper_stability_factor *
+                             minimum_grid_spacing / speed;
+    // Reject the step if the CFL condition is violated.
+    return std::make_pair(step_size, last_step_magnitude <= step_size);
   }
 
   // NOLINTNEXTLINE(google-runtime-references)

--- a/src/Time/StepChoosers/StepToTimes.hpp
+++ b/src/Time/StepChoosers/StepToTimes.hpp
@@ -44,6 +44,12 @@ using StepToTimes = Registration::Registrar<StepChoosers::StepToTimes>;
 /// changing immediately is inefficient, it may be best to use
 /// triggers to only activate this check near (within a few slabs of)
 /// the desired time.
+/// \warning This step chooser should be used only to choose slabs, not steps in
+/// an LTS scheme. Because the times are chosen based on the current time step
+/// id, using this as a step chooser in local time stepping will act
+/// unintuitively. Further, roundoff-level fluctuations arising from taking
+/// floating-point time differences will tend to interact poorly with
+/// `StepController`s.
 template <typename StepChooserRegistrars = tmpl::list<Registrars::StepToTimes>>
 class StepToTimes : public StepChooser<StepChooserRegistrars> {
  public:

--- a/src/Time/TakeStep.hpp
+++ b/src/Time/TakeStep.hpp
@@ -1,0 +1,26 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Time/Actions/ChangeStepSize.hpp"
+#include "Time/Actions/RecordTimeStepperData.hpp"
+#include "Time/Actions/UpdateU.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// Bundled method for recording the current system state in the history, and
+/// updating the evolved variables and step size.
+///
+/// This function is used to encapsulate any needed logic for updating the
+/// system, and in the case for which step parameters may need to be rejected
+/// and re-tried, looping until an acceptable step is performed.
+template <typename StepChooserRegistrars, typename VariablesTag = NoSuchType,
+          typename DbTags, typename Metavariables>
+void take_step(const gsl::not_null<db::DataBox<DbTags>*> box,
+               const Parallel::GlobalCache<Metavariables>& cache) noexcept {
+  record_time_stepper_data<typename Metavariables::system, VariablesTag>(box);
+  update_u<typename Metavariables::system, VariablesTag>(box);
+  change_step_size<StepChooserRegistrars>(box, cache);
+}

--- a/src/Time/TakeStep.hpp
+++ b/src/Time/TakeStep.hpp
@@ -21,6 +21,8 @@ template <typename StepChooserRegistrars, typename VariablesTag = NoSuchType,
 void take_step(const gsl::not_null<db::DataBox<DbTags>*> box,
                const Parallel::GlobalCache<Metavariables>& cache) noexcept {
   record_time_stepper_data<typename Metavariables::system, VariablesTag>(box);
-  update_u<typename Metavariables::system, VariablesTag>(box);
-  change_step_size<StepChooserRegistrars>(box, cache);
+  do {
+    update_u<typename Metavariables::system, VariablesTag>(box);
+  } while (Metavariables::local_time_stepping and
+           not change_step_size<StepChooserRegistrars>(box, cache));
 }

--- a/src/Utilities/TypeTraits/IsA.hpp
+++ b/src/Utilities/TypeTraits/IsA.hpp
@@ -54,4 +54,17 @@ template <template <typename...> class U, typename... Args>
 using is_a_t = typename is_a<U, Args...>::type;
 // @}
 
+namespace detail {
+template <template <typename> class U>
+struct is_a_wrapper;
+
+template <typename U, typename T>
+struct wrapped_is_a;
+
+template <template <typename> class U, typename T>
+struct wrapped_is_a<is_a_wrapper<U>, T> : tt::is_a<U, T> {};
+}  // namespace detail
+
+template <template <typename> class U, typename T>
+using is_a_lambda = detail::wrapped_is_a<detail::is_a_wrapper<U>, T>;
 }  // namespace tt

--- a/tests/Unit/Helpers/Time/TimeSteppers/TimeStepperTestUtils.cpp
+++ b/tests/Unit/Helpers/Time/TimeSteppers/TimeStepperTestUtils.cpp
@@ -80,31 +80,6 @@ void take_step_and_check_error(
   *time = time_id.substep_time();
 }
 
-template <typename F1, typename F2>
-void initialize_history(
-    Time time,
-    const gsl::not_null<TimeSteppers::History<double, double>*> history,
-    F1&& analytic,
-    F2&& rhs,
-    TimeDelta step_size,
-    const size_t number_of_past_steps) noexcept {
-  int64_t slab_number = -1;
-  for (size_t j = 0; j < number_of_past_steps; ++j) {
-    ASSERT(time.slab() == step_size.slab(), "Slab mismatch");
-    if ((step_size.is_positive() and time.is_at_slab_start()) or
-        (not step_size.is_positive() and time.is_at_slab_end())) {
-      const Slab new_slab = time.slab().advance_towards(-step_size);
-      time = time.with_slab(new_slab);
-      step_size = step_size.with_slab(new_slab);
-      --slab_number;
-    }
-    time -= step_size;
-    history->insert_initial(
-        TimeStepId(step_size.is_positive(), slab_number, time),
-        analytic(time.value()), rhs(analytic(time.value()), time.value()));
-  }
-}
-
 template <typename F>
 double convergence_rate(const int32_t large_steps, const int32_t small_steps,
                         F&& error) noexcept {
@@ -174,7 +149,7 @@ void integrate_test(const TimeStepper& stepper, const size_t order,
   double y = analytic(time.value());
   TimeSteppers::History<double, double> history{order};
 
-  initialize_history(time, &history, analytic, rhs, step_size,
+  initialize_history(time, make_not_null(&history), analytic, rhs, step_size,
                      number_of_past_steps);
 
   for (uint64_t i = 0; i < num_steps; ++i) {
@@ -212,11 +187,11 @@ void integrate_test_explicit_time_dependence(const TimeStepper& stepper,
   double y = analytic(time.value());
   TimeSteppers::History<double, double> history{order};
 
-  initialize_history(time, &history, analytic, rhs, step_size,
+  initialize_history(time, make_not_null(&history), analytic, rhs, step_size,
                      number_of_past_steps);
 
   for (uint64_t i = 0; i < num_steps; ++i) {
-    take_step(&time, &y, &history, stepper, rhs, step_size);
+    take_step(&time, &y, make_not_null(&history), stepper, rhs, step_size);
     // This check needs a looser tolerance for lower-order time steppers.
     CHECK(y == approx(analytic(time.value())).epsilon(epsilon));
   }
@@ -299,15 +274,16 @@ void integrate_variable_test(const TimeStepper& stepper,
   double y = analytic(time.value());
 
   TimeSteppers::History<double, double> history{order};
-  initialize_history(time, &history, analytic, rhs, slab.duration(),
-                     number_of_past_steps);
+  initialize_history(time, make_not_null(&history), analytic, rhs,
+                     slab.duration(), number_of_past_steps);
 
   for (uint64_t i = 0; i < num_steps; ++i) {
     slab = slab.advance().with_duration_from_start(
         (1. + 0.5 * sin(i)) * average_step);
     time = time.with_slab(slab);
 
-    take_step(&time, &y, &history, stepper, rhs, slab.duration());
+    take_step(&time, &y, make_not_null(&history), stepper, rhs,
+              slab.duration());
     // This check needs a looser tolerance for lower-order time steppers.
     CHECK(y == approx(analytic(time.value())).epsilon(epsilon));
   }
@@ -333,11 +309,12 @@ void stability_test(const TimeStepper& stepper) noexcept {
       return -2. * v;
     };
     initialize_history(
-        time, &history, [](const double t) noexcept { return exp(-2. * t); },
-        rhs, step_size, stepper.number_of_past_steps());
+        time, make_not_null(&history),
+        [](const double t) noexcept { return exp(-2. * t); }, rhs, step_size,
+        stepper.number_of_past_steps());
 
     for (uint64_t i = 0; i < num_steps; ++i) {
-      take_step(&time, &y, &history, stepper, rhs, step_size);
+      take_step(&time, &y, make_not_null(&history), stepper, rhs, step_size);
       CHECK(std::abs(y) < 10.);
     }
   }
@@ -355,11 +332,12 @@ void stability_test(const TimeStepper& stepper) noexcept {
       return -2. * v;
     };
     initialize_history(
-        time, &history, [](const double t) noexcept { return exp(-2. * t); },
-        rhs, step_size, stepper.number_of_past_steps());
+        time, make_not_null(&history),
+        [](const double t) noexcept { return exp(-2. * t); }, rhs, step_size,
+        stepper.number_of_past_steps());
 
     for (uint64_t i = 0; i < num_steps; ++i) {
-      take_step(&time, &y, &history, stepper, rhs, step_size);
+      take_step(&time, &y, make_not_null(&history), stepper, rhs, step_size);
       if (std::abs(y) > 10.) {
         return;
       }
@@ -455,8 +433,9 @@ void check_convergence_order(const TimeStepper& stepper) noexcept {
       return v;
     };
     initialize_history(
-        time, &history, [](const double t) noexcept { return exp(t); }, rhs,
-        step_size, stepper.number_of_past_steps());
+        time, make_not_null(&history),
+        [](const double t) noexcept { return exp(t); }, rhs, step_size,
+        stepper.number_of_past_steps());
     while (time < slab.end()) {
       take_step(&time, &y, &history, stepper, rhs, step_size);
     }
@@ -482,7 +461,7 @@ void check_dense_output(const TimeStepper& stepper) noexcept {
       double y = 1.;
       TimeSteppers::History<double, double> history{stepper.order()};
       initialize_history(
-          time_id.substep_time(), &history,
+          time_id.substep_time(), make_not_null(&history),
           [](const double t) noexcept { return exp(t); },
           [](const double v, const double /*t*/) noexcept { return v; },
           step_size, stepper.number_of_past_steps());
@@ -528,8 +507,9 @@ void check_dense_output(const TimeStepper& stepper) noexcept {
         return v;
       };
       initialize_history(
-          time, &history, [](const double t) noexcept { return exp(t); }, rhs,
-          time_step, stepper.number_of_past_steps());
+          time, make_not_null(&history),
+          [](const double t) noexcept { return exp(t); }, rhs, time_step,
+          stepper.number_of_past_steps());
       take_step(&time, &y, &history, stepper, rhs, time_step);
 
       // Some time steppers special-case the endpoints of the

--- a/tests/Unit/Helpers/Time/TimeSteppers/TimeStepperTestUtils.hpp
+++ b/tests/Unit/Helpers/Time/TimeSteppers/TimeStepperTestUtils.hpp
@@ -5,6 +5,12 @@
 
 #include <cstddef>
 
+#include "Time/History.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+
 /// \cond
 class LtsTimeStepper;
 class TimeStepper;
@@ -34,6 +40,30 @@ void integrate_error_test(const TimeStepper& stepper, size_t order,
                           size_t number_of_past_steps, double integration_time,
                           double epsilon, size_t num_steps, double error_factor,
                           bool test_apply_twice = false) noexcept;
+
+template <typename F1, typename F2, typename EvolvedType>
+void initialize_history(
+    Time time,
+    const gsl::not_null<TimeSteppers::History<EvolvedType, EvolvedType>*>
+        history,
+    F1&& analytic, F2&& rhs, TimeDelta step_size,
+    const size_t number_of_past_steps) noexcept {
+  int64_t slab_number = -1;
+  for (size_t j = 0; j < number_of_past_steps; ++j) {
+    ASSERT(time.slab() == step_size.slab(), "Slab mismatch");
+    if ((step_size.is_positive() and time.is_at_slab_start()) or
+        (not step_size.is_positive() and time.is_at_slab_end())) {
+      const Slab new_slab = time.slab().advance_towards(-step_size);
+      time = time.with_slab(new_slab);
+      step_size = step_size.with_slab(new_slab);
+      --slab_number;
+    }
+    time -= step_size;
+    history->insert_initial(
+        TimeStepId(step_size.is_positive(), slab_number, time),
+        analytic(time.value()), rhs(analytic(time.value()), time.value()));
+  }
+}
 
 void stability_test(const TimeStepper& stepper) noexcept;
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SemidiscretizedDg.cpp
@@ -144,6 +144,8 @@ struct Metavariables {
       db::add_tag_prefix<::Tags::dt, typename system::variables_tag>,
       Tags::NumericalFlux<ScalarWave::UpwindPenaltyCorrection<1>>,
       Tags::TimeStepId>;
+  static constexpr bool local_time_stepping = false;
+  using step_choosers = tmpl::list<>;
 
   using component_list = tmpl::list<Component<Metavariables>>;
   using temporal_id = Tags::TimeStepId;

--- a/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
+++ b/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
@@ -39,7 +39,7 @@ struct Component {
 
   using simple_tags =
       db::AddSimpleTags<Tags::TimeStepId, Tags::Next<Tags::TimeStepId>,
-                        Tags::TimeStep, Tags::Time>;
+                        Tags::TimeStep, Tags::Next<Tags::TimeStep>, Tags::Time>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
@@ -68,7 +68,7 @@ void check_rk3(const Time& start, const TimeDelta& time_step) {
       {TimeStepId(time_step.is_positive(), 8, start),
        TimeStepId(time_step.is_positive(), 8, start, 1,
                   start + substep_offsets[1]),
-       time_step, start.value()});
+       time_step, time_step, start.value()});
   ActionTesting::set_phase(make_not_null(&runner),
                            Metavariables::Phase::Testing);
 
@@ -110,7 +110,7 @@ void check_abn(const Time& start, const TimeDelta& time_step) {
       &runner, 0,
       {TimeStepId(time_step.is_positive(), 8, start),
        TimeStepId(time_step.is_positive(), 8, start + time_step), time_step,
-       start.value()});
+       time_step, start.value()});
   ActionTesting::set_phase(make_not_null(&runner),
                            Metavariables::Phase::Testing);
 

--- a/tests/Unit/Time/Actions/Test_ChangeSlabSize.cpp
+++ b/tests/Unit/Time/Actions/Test_ChangeSlabSize.cpp
@@ -57,9 +57,9 @@ struct Component {
 
   using const_global_cache_tags = tmpl::list<Tags::TimeStepper<TimeStepper>>;
 
-  using simple_tags =
-      tmpl::list<Tags::TimeStepId, Tags::Next<Tags::TimeStepId>, Tags::TimeStep,
-                 Tags::HistoryEvolvedVariables<Var>>;
+  using simple_tags = tmpl::list<Tags::TimeStepId, Tags::Next<Tags::TimeStepId>,
+                                 Tags::TimeStep, Tags::Next<Tags::TimeStep>,
+                                 Tags::HistoryEvolvedVariables<Var>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -105,15 +105,18 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.ChangeSlabSize", "[Unit][Time][Actions]") {
              id.step_time().slab().duration() / 2;
     };
 
-    db::mutate<Tags::TimeStepId, Tags::Next<Tags::TimeStepId>, Tags::TimeStep>(
+    db::mutate<Tags::TimeStepId, Tags::Next<Tags::TimeStepId>, Tags::TimeStep,
+               Tags::Next<Tags::TimeStep>>(
         make_not_null(&box),
         [&get_step, &start_time, &time_runs_forward](
             const gsl::not_null<TimeStepId*> id,
             const gsl::not_null<TimeStepId*> next_id,
             const gsl::not_null<TimeDelta*> step,
+            const gsl::not_null<TimeDelta*> next_step,
             const TimeStepper& stepper) noexcept {
           *id = TimeStepId(time_runs_forward, 3, start_time);
           *step = get_step(*id);
+          *next_step = get_step(*id);
           *next_id = stepper.next_time_id(*id, *step);
         },
         db::get<Tags::TimeStepper<>>(box));

--- a/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
+++ b/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
@@ -193,23 +193,9 @@ void emplace_component_and_initialize<true>(
        initial_time_step, std::numeric_limits<double>::signaling_NaN()});
 }
 
-namespace detail {
-template <template <typename> class U>
-struct is_a_wrapper;
-
-template <typename U, typename T>
-struct wrapped_is_a;
-
-template <template <typename> class U, typename T>
-struct wrapped_is_a<is_a_wrapper<U>, T> : tt::is_a<U, T> {};
-}  // namespace detail
-
-template <template <typename> class U, typename T>
-using is_a_lambda = detail::wrapped_is_a<detail::is_a_wrapper<U>, T>;
-
 using not_self_start_action = std::negation<std::disjunction<
-    is_a_lambda<SelfStart::Actions::Initialize, tmpl::_1>,
-    is_a_lambda<SelfStart::Actions::CheckForCompletion, tmpl::_1>,
+    tt::is_a_lambda<SelfStart::Actions::Initialize, tmpl::_1>,
+    tt::is_a_lambda<SelfStart::Actions::CheckForCompletion, tmpl::_1>,
     std::is_same<SelfStart::Actions::CheckForOrderIncrease, tmpl::_1>,
     std::is_same<SelfStart::Actions::Cleanup, tmpl::_1>>>;
 
@@ -269,7 +255,7 @@ void test_actions(const size_t order, const int step_denominator) noexcept {
   {
     INFO("Initialize");
     const bool jumped =
-        run_past<is_a_lambda<SelfStart::Actions::Initialize, tmpl::_1>,
+        run_past<tt::is_a_lambda<SelfStart::Actions::Initialize, tmpl::_1>,
                  not_self_start_action>(make_not_null(&runner));
     CHECK(not jumped);
     CHECK(
@@ -296,7 +282,7 @@ void test_actions(const size_t order, const int step_denominator) noexcept {
       {
         INFO("CheckForCompletion");
         const bool jumped = run_past<
-            is_a_lambda<SelfStart::Actions::CheckForCompletion, tmpl::_1>,
+            tt::is_a_lambda<SelfStart::Actions::CheckForCompletion, tmpl::_1>,
             not_self_start_action>(make_not_null(&runner));
         CHECK(not jumped);
         CHECK(ActionTesting::get_databox_tag<Component<Metavariables<>>,
@@ -321,9 +307,9 @@ void test_actions(const size_t order, const int step_denominator) noexcept {
 
   {
     INFO("CheckForCompletion");
-    const bool jumped =
-        run_past<is_a_lambda<SelfStart::Actions::CheckForCompletion, tmpl::_1>,
-                 not_self_start_action>(make_not_null(&runner));
+    const bool jumped = run_past<
+        tt::is_a_lambda<SelfStart::Actions::CheckForCompletion, tmpl::_1>,
+        not_self_start_action>(make_not_null(&runner));
     CHECK(jumped);
   }
   {

--- a/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
+++ b/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
@@ -131,7 +131,7 @@ struct Component {
       db::add_tag_prefix<Tags::dt,
                          typename metavariables::system::variables_tag>,
       history_tag, Tags::TimeStepId, Tags::Next<Tags::TimeStepId>,
-      Tags::TimeStep, Tags::Time>>;
+      Tags::TimeStep, Tags::Next<Tags::TimeStep>, Tags::Time>>;
   using compute_tags = db::AddComputeTags<Tags::SubstepTimeCompute>;
 
   static constexpr bool has_primitives = Metavariables::has_primitives;
@@ -174,7 +174,8 @@ void emplace_component_and_initialize(
       {initial_value, 0., typename history_tag::type{1}, TimeStepId{},
        TimeStepId(forward_in_time, 1 - static_cast<int64_t>(order),
                   initial_time),
-       initial_time_step, std::numeric_limits<double>::signaling_NaN()});
+       initial_time_step, initial_time_step,
+       std::numeric_limits<double>::signaling_NaN()});
 }
 
 template <>
@@ -190,7 +191,8 @@ void emplace_component_and_initialize<true>(
        TimeStepId{},
        TimeStepId(forward_in_time, 1 - static_cast<int64_t>(order),
                   initial_time),
-       initial_time_step, std::numeric_limits<double>::signaling_NaN()});
+       initial_time_step, initial_time_step,
+       std::numeric_limits<double>::signaling_NaN()});
 }
 
 using not_self_start_action = std::negation<std::disjunction<

--- a/tests/Unit/Time/CMakeLists.txt
+++ b/tests/Unit/Time/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_History.cpp
   Test_Slab.cpp
   Test_Tags.cpp
+  Test_TakeStep.cpp
   Test_Time.cpp
   Test_TimeSequence.cpp
   Test_TimeStepId.cpp

--- a/tests/Unit/Time/StepChoosers/Test_Cfl.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_Cfl.cpp
@@ -79,7 +79,10 @@ std::pair<double, bool> get_suggestion(const size_t stepper_order,
   const double current_step = std::numeric_limits<double>::infinity();
   const auto result =
       cfl(grid_spacing, box, time_stepper, current_step, cache);
-  CHECK(result.second);
+  CHECK_FALSE(result.second);
+  const auto accepted_step_result =
+      cfl(grid_spacing, box, time_stepper, result.first * 0.7, cache);
+  CHECK(accepted_step_result.second);
   CHECK(cfl_base->desired_step(current_step, box, cache) == result);
   CHECK(serialize_and_deserialize(cfl)(grid_spacing, box, time_stepper,
                                        current_step, cache) == result);

--- a/tests/Unit/Time/Test_TakeStep.cpp
+++ b/tests/Unit/Time/Test_TakeStep.cpp
@@ -1,0 +1,129 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <memory>
+#include <random>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/Time/TimeSteppers/TimeStepperTestUtils.hpp"
+#include "Time/StepChoosers/Increase.hpp"
+#include "Time/StepControllers/BinaryFraction.hpp"
+#include "Time/Tags.hpp"
+#include "Time/TakeStep.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeSequence.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Utilities/Literals.hpp"
+
+namespace {
+struct EvolvedVariable : db::SimpleTag {
+  using type = DataVector;
+};
+
+struct Metavariables {
+  struct system {
+    using variables_tag = EvolvedVariable;
+  };
+  using component_list = tmpl::list<>;
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Time.TakeStep", "[Unit][Time]") {
+  using step_chooser_list = tmpl::list<StepChoosers::Registrars::Increase>;
+  const Slab slab{0.0, 1.00};
+  const TimeDelta time_step = slab.duration() / 4;
+
+  const Parallel::GlobalCache<Metavariables> cache{};
+  std::vector<std::unique_ptr<StepChooser<step_chooser_list>>> step_choosers;
+  step_choosers.emplace_back(std::make_unique<StepChoosers::Increase<>>(2.0));
+
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> dist{-1.0, 1.0};
+
+  const auto initial_values = make_with_random_values<DataVector>(
+      make_not_null(&generator), make_not_null(&dist), DataVector{5});
+
+  // exponential function
+  const auto update_rhs = [](const gsl::not_null<DataVector*> dt_y,
+                             const DataVector& y) noexcept {
+    *dt_y = 1.0e-2 * y;
+  };
+
+  typename ::Tags::HistoryEvolvedVariables<EvolvedVariable>::type history{5};
+  // prepare history so that the Adams-Bashforth is ready to take steps
+  TimeStepperTestUtils::initialize_history(
+      slab.start(), make_not_null(&history),
+      [&initial_values](const auto t) noexcept {
+        return initial_values * exp(1.0e-2 * t);
+      },
+      [](const auto y, const auto /*t*/) noexcept { return 1.0e-2 * y; },
+      time_step, 4);
+
+  auto box = db::create<db::AddSimpleTags<
+      Tags::TimeStepId, Tags::Next<Tags::TimeStepId>, Tags::TimeStep,
+      Tags::Next<Tags::TimeStep>, EvolvedVariable, Tags::dt<EvolvedVariable>,
+      Tags::HistoryEvolvedVariables<EvolvedVariable>,
+      Tags::TimeStepper<LtsTimeStepper>, Tags::StepChoosers<step_chooser_list>,
+      Tags::StepController>>(
+      TimeStepId{true, 0_st, slab.start()},
+      TimeStepId{true, 0_st, Time{slab, {1, 4}}}, time_step, time_step,
+      initial_values, DataVector{5, 0.0}, std::move(history),
+      static_cast<std::unique_ptr<LtsTimeStepper>>(
+          std::make_unique<TimeSteppers::AdamsBashforthN>(5)),
+      std::move(step_choosers),
+      static_cast<std::unique_ptr<StepController>>(
+          std::make_unique<StepControllers::BinaryFraction>()));
+
+  // update the rhs
+  db::mutate<Tags::dt<EvolvedVariable>>(make_not_null(&box), update_rhs,
+                                         db::get<EvolvedVariable>(box));
+  take_step<step_chooser_list>(make_not_null(&box), cache);
+  // check that the state is as expected
+  CHECK(db::get<Tags::TimeStepId>(box).substep_time().value() == 0.0);
+  CHECK(db::get<Tags::Next<Tags::TimeStepId>>(box).substep_time().value() ==
+        approx(0.25));
+  CHECK(db::get<Tags::Next<Tags::TimeStep>>(box) == TimeDelta{slab, {1, 4}});
+  CHECK_ITERABLE_APPROX(db::get<EvolvedVariable>(box),
+                        initial_values * exp(0.0025));
+  CHECK_ITERABLE_APPROX(db::get<Tags::dt<EvolvedVariable>>(box),
+                        1.0e-2 * initial_values);
+
+  // advance time
+  db::mutate<Tags::TimeStepId, Tags::Next<Tags::TimeStepId>, Tags::TimeStep,
+             Tags::Next<Tags::TimeStep>>(
+      make_not_null(&box),
+      [](const gsl::not_null<TimeStepId*> time_id,
+         const gsl::not_null<TimeStepId*> next_time_id,
+         const gsl::not_null<TimeDelta*> local_time_step,
+         const gsl::not_null<TimeDelta*> next_time_step,
+         const TimeStepper& time_stepper) noexcept {
+        *time_id = *next_time_id;
+        *local_time_step =
+            next_time_step->with_slab(time_id->step_time().slab());
+
+        *next_time_id =
+            time_stepper.next_time_id(*next_time_id, *local_time_step);
+        *next_time_step =
+            local_time_step->with_slab(next_time_id->step_time().slab());
+      },
+      db::get<Tags::TimeStepper<>>(box));
+
+  db::mutate<Tags::dt<EvolvedVariable>>(make_not_null(&box), update_rhs,
+                                        db::get<EvolvedVariable>(box));
+  take_step<step_chooser_list>(make_not_null(&box), cache);
+  // check that the state is as expected
+  CHECK(db::get<Tags::TimeStepId>(box).substep_time().value() == approx(0.25));
+  CHECK(db::get<Tags::Next<Tags::TimeStep>>(box) == TimeDelta{slab, {1, 2}});
+  CHECK_ITERABLE_APPROX(db::get<EvolvedVariable>(box),
+                        initial_values * exp(0.005));
+  CHECK_ITERABLE_APPROX(db::get<Tags::dt<EvolvedVariable>>(box),
+                        1.0e-2 * initial_values * exp(0.0025));
+}


### PR DESCRIPTION
## Proposed changes

This factors time stepper routines into free functions so that they can be performed as a subroutine of `ComputeTimeDerivative`, and perform the alteration of the order of operations in the local-time-stepping case to support step unwinding -- to be able to reject and re-try a step based on information from a step chooser, the step chooser must run after the time-stepper `update_u` and before the component sends flux information to the neighbors, so the entire loop must be placed as a subroutine of `ComputeTimeDerivative` .

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->
Be sure to update any local time-stepping action lists to match the control flow in the `EvolveScalarWave.hpp` in this PR.
Note that when using local time-stepping and not in self-start, the `ComputeTimeDerivative` action now performs the steps previously done by `RecordTimeStepperData`, `UpdateU`, and `ChangeStepSize`.
Those actions are still available for cases in which either local time-stepping is not used or `ComputeTimeDerivative` is not used.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
