### PR TITLE
Add boundary condition support to AlignedLattice domain creator

### DIFF
--- a/src/Domain/Creators/AlignedLattice.cpp
+++ b/src/Domain/Creators/AlignedLattice.cpp
@@ -3,6 +3,13 @@
 
 #include "Domain/Creators/AlignedLattice.hpp"
 
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
 #include "Utilities/Algorithm.hpp"
@@ -25,12 +32,13 @@ std::ostream& operator<<(
 template <size_t VolumeDim>
 AlignedLattice<VolumeDim>::AlignedLattice(
     const typename BlockBounds::type block_bounds,
-    const typename IsPeriodicIn::type is_periodic_in,
     const typename InitialLevels::type initial_refinement_levels,
     const typename InitialGridPoints::type initial_number_of_grid_points,
     typename RefinedLevels::type refined_refinement,
     typename RefinedGridPoints::type refined_grid_points,
-    typename BlocksToExclude::type blocks_to_exclude) noexcept
+    typename BlocksToExclude::type blocks_to_exclude,
+    const typename IsPeriodicIn::type is_periodic_in,
+    const Options::Context& context)
     // clang-tidy: trivially copyable
     : block_bounds_(std::move(block_bounds)),         // NOLINT
       is_periodic_in_(std::move(is_periodic_in)),     // NOLINT
@@ -43,20 +51,21 @@ AlignedLattice<VolumeDim>::AlignedLattice(
       blocks_to_exclude_(std::move(blocks_to_exclude)),
       number_of_blocks_by_dim_{map_array(
           block_bounds_,
-          [](const std::vector<double>& v) noexcept { return v.size() - 1; })} {
+          [](const std::vector<double>& v) noexcept { return v.size() - 1; })},
+      boundary_condition_(nullptr) {
   if (not blocks_to_exclude_.empty() and
       alg::any_of(is_periodic_in_, [](const bool t) noexcept { return t; })) {
-    ERROR(
-        "Cannot exclude blocks as well as have periodic boundary "
-        "conditions!");
+    PARSE_ERROR(context,
+                "Cannot exclude blocks as well as have periodic boundary "
+                "conditions!");
   }
   for (const auto& refinement_region : refined_grid_points_) {
     for (size_t i = 0; i < VolumeDim; ++i) {
       if (gsl::at(refinement_region.upper_corner_index, i) >=
           gsl::at(block_bounds_, i).size()) {
-        ERROR("Refinement region extends to "
-              << refinement_region.upper_corner_index
-              << ", which is outside the domain");
+        PARSE_ERROR(context, "Refinement region extends to "
+                                 << refinement_region.upper_corner_index
+                                 << ", which is outside the domain");
       }
     }
   }
@@ -64,9 +73,69 @@ AlignedLattice<VolumeDim>::AlignedLattice(
     for (size_t i = 0; i < VolumeDim; ++i) {
       if (gsl::at(refinement_region.upper_corner_index, i) >=
           gsl::at(block_bounds_, i).size()) {
-        ERROR("Refinement region extends to "
-              << refinement_region.upper_corner_index
-              << ", which is outside the domain");
+        PARSE_ERROR(context, "Refinement region extends to "
+                                 << refinement_region.upper_corner_index
+                                 << ", which is outside the domain");
+      }
+    }
+  }
+}
+
+template <size_t VolumeDim>
+AlignedLattice<VolumeDim>::AlignedLattice(
+    const typename BlockBounds::type block_bounds,
+    const typename InitialLevels::type initial_refinement_levels,
+    const typename InitialGridPoints::type initial_number_of_grid_points,
+    typename RefinedLevels::type refined_refinement,
+    typename RefinedGridPoints::type refined_grid_points,
+    typename BlocksToExclude::type blocks_to_exclude,
+    std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+        boundary_condition,
+    const Options::Context& context)
+    // clang-tidy: trivially copyable
+    : block_bounds_(std::move(block_bounds)),  // NOLINT
+      is_periodic_in_(make_array<VolumeDim>(false)),
+      initial_refinement_levels_(                     // NOLINT
+          std::move(initial_refinement_levels)),      // NOLINT
+      initial_number_of_grid_points_(                 // NOLINT
+          std::move(initial_number_of_grid_points)),  // NOLINT
+      refined_refinement_(std::move(refined_refinement)),
+      refined_grid_points_(std::move(refined_grid_points)),
+      blocks_to_exclude_(std::move(blocks_to_exclude)),
+      number_of_blocks_by_dim_{map_array(
+          block_bounds_,
+          [](const std::vector<double>& v) noexcept { return v.size() - 1; })},
+      boundary_condition_(std::move(boundary_condition)) {
+  using domain::BoundaryConditions::is_periodic;
+  if (is_periodic(boundary_condition_)) {
+    is_periodic_in_[0] = true;
+    is_periodic_in_[1] = true;
+    is_periodic_in_[2] = true;
+    boundary_condition_ = nullptr;
+  }
+  if (not blocks_to_exclude_.empty() and
+      alg::any_of(is_periodic_in_, [](const bool t) noexcept { return t; })) {
+    PARSE_ERROR(context,
+                "Cannot exclude blocks as well as have periodic boundary "
+                "conditions!");
+  }
+  for (const auto& refinement_region : refined_grid_points_) {
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      if (gsl::at(refinement_region.upper_corner_index, i) >=
+          gsl::at(block_bounds_, i).size()) {
+        PARSE_ERROR(context, "Refinement region extends to "
+                                 << refinement_region.upper_corner_index
+                                 << ", which is outside the domain");
+      }
+    }
+  }
+  for (const auto& refinement_region : refined_refinement_) {
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      if (gsl::at(refinement_region.upper_corner_index, i) >=
+          gsl::at(block_bounds_, i).size()) {
+        PARSE_ERROR(context, "Refinement region extends to "
+                                 << refinement_region.upper_corner_index
+                                 << ", which is outside the domain");
       }
     }
   }
@@ -74,15 +143,42 @@ AlignedLattice<VolumeDim>::AlignedLattice(
 
 template <size_t VolumeDim>
 Domain<VolumeDim> AlignedLattice<VolumeDim>::create_domain() const noexcept {
-  if (blocks_to_exclude_.empty()) {
-    return rectilinear_domain<VolumeDim>(
-        number_of_blocks_by_dim_, block_bounds_, {}, {}, {}, is_periodic_in_);
+  using BoundaryCondVector = std::vector<DirectionMap<
+      VolumeDim,
+      std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>;
+
+  const auto compute_domain = [this](BoundaryCondVector boundary_conditions) {
+    if (blocks_to_exclude_.empty()) {
+      return rectilinear_domain<VolumeDim>(
+          number_of_blocks_by_dim_, block_bounds_,
+          std::move(boundary_conditions), {}, {}, is_periodic_in_, {}, false);
+    } else {
+      return rectilinear_domain<VolumeDim>(
+          number_of_blocks_by_dim_, block_bounds_,
+          std::move(boundary_conditions),
+          {std::vector<Index<VolumeDim>>(blocks_to_exclude_.begin(),
+                                         blocks_to_exclude_.end())},
+          {}, make_array<VolumeDim>(false), {}, false);
+    }
+  };
+  Domain<VolumeDim> domain = compute_domain({});
+
+  if (boundary_condition_ != nullptr) {
+    // Set boundary conditions by using the computed domain's external
+    // boundaries
+    const auto& blocks = domain.blocks();
+    BoundaryCondVector boundary_conditions{blocks.size()};
+    for (size_t block_id = 0; block_id < blocks.size(); ++block_id) {
+      for (const Direction<VolumeDim>& external_direction :
+           blocks[block_id].external_boundaries()) {
+        boundary_conditions[block_id][external_direction] =
+            boundary_condition_->get_clone();
+      }
+    }
+    domain = compute_domain(std::move(boundary_conditions));
   }
-  return rectilinear_domain<VolumeDim>(
-      number_of_blocks_by_dim_, block_bounds_, {},
-      {std::vector<Index<VolumeDim>>(blocks_to_exclude_.begin(),
-                                     blocks_to_exclude_.end())},
-      {}, make_array<VolumeDim>(false));
+
+  return domain;
 }
 
 namespace {

--- a/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
+++ b/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
@@ -34,35 +35,184 @@ struct Inertial;
 namespace domain {
 namespace {
 template <size_t VolumeDim>
-void test_aligned_blocks(
-    const creators::AlignedLattice<VolumeDim>& aligned_blocks) noexcept {
-  const auto domain = aligned_blocks.create_domain();
-  test_initial_domain(domain, aligned_blocks.initial_refinement_levels());
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+create_boundary_condition() {
+  return std::make_unique<TestHelpers::domain::BoundaryConditions::
+                              TestBoundaryCondition<VolumeDim>>(
+      Direction<VolumeDim>::upper_xi(), 100);
+}
 
+template <size_t VolumeDim>
+void test_aligned_blocks(
+    const creators::AlignedLattice<VolumeDim>& aligned_lattice,
+    const std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>&
+        expected_boundary_condition) noexcept {
   Parallel::register_classes_in_list<
       typename creators::AlignedLattice<VolumeDim>::maps_list>();
-  test_serialization(domain);
+
+  const auto test_impl = [&expected_boundary_condition,
+                          &aligned_lattice](const auto& domain) {
+    test_initial_domain(domain, aligned_lattice.initial_refinement_levels());
+
+    if (expected_boundary_condition != nullptr) {
+      const auto& blocks = domain.blocks();
+      for (size_t block_id = 0; block_id < blocks.size(); ++block_id) {
+        CAPTURE(block_id);
+        const auto& block = domain.blocks()[block_id];
+        REQUIRE(block.external_boundaries().size() ==
+                block.external_boundary_conditions().size());
+        for (const auto& direction : block.external_boundaries()) {
+          CAPTURE(direction);
+          REQUIRE(block.external_boundary_conditions().count(direction) == 1);
+          REQUIRE(block.external_boundary_conditions().at(direction) !=
+                  nullptr);
+          const auto& bc =
+              dynamic_cast<const TestHelpers::domain::BoundaryConditions::
+                               TestBoundaryCondition<VolumeDim>&>(
+                  *block.external_boundary_conditions().at(direction));
+          const auto& expected_bc =
+              dynamic_cast<const TestHelpers::domain::BoundaryConditions::
+                               TestBoundaryCondition<VolumeDim>&>(
+                  *expected_boundary_condition);
+          CHECK(bc.direction() == expected_bc.direction());
+          CHECK(bc.block_id() == expected_bc.block_id());
+        }
+      }
+    }
+  };
+
+  test_impl(aligned_lattice.create_domain());
+  test_impl(serialize_and_deserialize(aligned_lattice.create_domain()));
+}
+
+template <size_t VolumeDim>
+auto make_domain_creator(const std::string& opt_string,
+                         const bool use_boundary_condition) {
+  if (use_boundary_condition) {
+    return TestHelpers::test_factory_creation<
+        DomainCreator<VolumeDim>, domain::OptionTags::DomainCreator<VolumeDim>,
+        TestHelpers::domain::BoundaryConditions::
+            MetavariablesWithBoundaryConditions<VolumeDim>>(
+        opt_string + std::string{"  BoundaryCondition:\n"
+                                 "    TestBoundaryCondition:\n"
+                                 "      Direction: upper-xi\n"
+                                 "      BlockId: 100\n"});
+  } else {
+    return TestHelpers::test_factory_creation<
+        DomainCreator<VolumeDim>, domain::OptionTags::DomainCreator<VolumeDim>,
+        TestHelpers::domain::BoundaryConditions::
+            MetavariablesWithoutBoundaryConditions<VolumeDim>>(opt_string);
+  }
 }
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
-  const auto domain_creator_1d = TestHelpers::test_factory_creation<
-      DomainCreator<1>, domain::OptionTags::DomainCreator<1>,
-      TestHelpers::domain::BoundaryConditions::
-          MetavariablesWithBoundaryConditions<1>>(
-      "AlignedLattice:\n"
-      "  BlockBounds: [[0.1, 2.6, 5.1, 5.2, 7.2]]\n"
-      "  IsPeriodicIn: [false]\n"
-      "  InitialGridPoints: [3]\n"
-      "  InitialLevels: [2]\n"
-      "  RefinedLevels: []\n"
-      "  RefinedGridPoints: []\n"
-      "  BlocksToExclude: []\n");
-  const auto* aligned_blocks_creator_1d =
-      dynamic_cast<const creators::AlignedLattice<1>*>(domain_creator_1d.get());
-  test_aligned_blocks(*aligned_blocks_creator_1d);
+  TestHelpers::domain::BoundaryConditions::register_derived_with_charm();
 
-  const auto domain_creator_2d = TestHelpers::test_factory_creation<
+  for (const bool use_boundary_condition : {true, false}) {
+    const std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+        expected_boundary_condition_1d =
+            use_boundary_condition ? create_boundary_condition<1>() : nullptr;
+    const std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+        expected_boundary_condition_2d =
+            use_boundary_condition ? create_boundary_condition<2>() : nullptr;
+    const std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+        expected_boundary_condition_3d =
+            use_boundary_condition ? create_boundary_condition<3>() : nullptr;
+
+    const auto domain_creator_1d = make_domain_creator<1>(
+        "AlignedLattice:\n"
+        "  BlockBounds: [[0.1, 2.6, 5.1, 5.2, 7.2]]\n" +
+            std::string{use_boundary_condition ? ""
+                                               : "  IsPeriodicIn: [false]\n"} +
+            "  InitialGridPoints: [3]\n"
+            "  InitialLevels: [2]\n"
+            "  RefinedLevels: []\n"
+            "  RefinedGridPoints: []\n"
+            "  BlocksToExclude: []\n",
+        use_boundary_condition);
+    const auto* aligned_blocks_creator_1d =
+        dynamic_cast<const creators::AlignedLattice<1>*>(
+            domain_creator_1d.get());
+    test_aligned_blocks(*aligned_blocks_creator_1d,
+                        expected_boundary_condition_1d);
+
+    const auto domain_creator_2d = make_domain_creator<2>(
+        "AlignedLattice:\n"
+        "  BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2, 8.9]]\n" +
+            std::string{use_boundary_condition
+                            ? ""
+                            : "  IsPeriodicIn: [false, false]\n"} +
+            "  InitialGridPoints: [3, 4]\n"
+            "  InitialLevels: [2, 1]\n"
+            "  RefinedLevels: []\n"
+            "  RefinedGridPoints: []\n"
+            "  BlocksToExclude: []\n",
+        use_boundary_condition);
+    const auto* aligned_blocks_creator_2d =
+        dynamic_cast<const creators::AlignedLattice<2>*>(
+            domain_creator_2d.get());
+    test_aligned_blocks(*aligned_blocks_creator_2d,
+                        expected_boundary_condition_2d);
+
+    const auto domain_creator_3d = make_domain_creator<3>(
+        "AlignedLattice:\n"
+        "  BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2], [-0.2, 3.2]]\n" +
+            std::string{use_boundary_condition
+                            ? ""
+                            : "  IsPeriodicIn: [false, false, false]\n"} +
+            "  InitialGridPoints: [3, 4, 5]\n"
+            "  InitialLevels: [2, 1, 0]\n"
+            "  RefinedLevels: []\n"
+            "  RefinedGridPoints: []\n"
+            "  BlocksToExclude: []\n",
+        use_boundary_condition);
+    const auto* aligned_blocks_creator_3d =
+        dynamic_cast<const creators::AlignedLattice<3>*>(
+            domain_creator_3d.get());
+    test_aligned_blocks(*aligned_blocks_creator_3d,
+                        expected_boundary_condition_3d);
+
+    const auto cubical_shell_domain = make_domain_creator<3>(
+        "AlignedLattice:\n"
+        "  BlockBounds: [[0.1, 2.6, 5.1, 6.0], [-0.4, 3.2, 6.2, 7.0], "
+        "[-0.2, 3.2, 4.0, 5.2]]\n" +
+            std::string{use_boundary_condition
+                            ? ""
+                            : "  IsPeriodicIn: [false, false, false]\n"} +
+            "  InitialGridPoints: [3, 4, 5]\n"
+            "  InitialLevels: [2, 1, 0]\n"
+            "  RefinedLevels: []\n"
+            "  RefinedGridPoints: []\n"
+            "  BlocksToExclude: [[1, 1, 1]]\n",
+        use_boundary_condition);
+    const auto* cubical_shell_creator_3d =
+        dynamic_cast<const creators::AlignedLattice<3>*>(
+            cubical_shell_domain.get());
+    test_aligned_blocks(*cubical_shell_creator_3d,
+                        expected_boundary_condition_3d);
+
+    const auto unit_cubical_shell_domain = make_domain_creator<3>(
+        "AlignedLattice:\n"
+        "  BlockBounds: [[-1.5, -0.5, 0.5, 1.5], [-1.5, -0.5, 0.5, 1.5], "
+        "[-1.5, -0.5, 0.5, 1.5]]\n" +
+            std::string{use_boundary_condition
+                            ? ""
+                            : "  IsPeriodicIn: [false, false, false]\n"} +
+            "  InitialGridPoints: [5, 5, 5]\n"
+            "  InitialLevels: [1, 1, 1]\n"
+            "  RefinedLevels: []\n"
+            "  RefinedGridPoints: []\n"
+            "  BlocksToExclude: [[1, 1, 1]]\n",
+        use_boundary_condition);
+    const auto* unit_cubical_shell_creator_3d =
+        dynamic_cast<const creators::AlignedLattice<3>*>(
+            unit_cubical_shell_domain.get());
+    test_aligned_blocks(*unit_cubical_shell_creator_3d,
+                        expected_boundary_condition_3d);
+  }
+
+  const auto domain_creator_2d_periodic = TestHelpers::test_factory_creation<
       DomainCreator<2>, domain::OptionTags::DomainCreator<2>,
       TestHelpers::domain::BoundaryConditions::
           MetavariablesWithoutBoundaryConditions<2>>(
@@ -74,11 +224,12 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
       "  RefinedLevels: []\n"
       "  RefinedGridPoints: []\n"
       "  BlocksToExclude: []\n");
-  const auto* aligned_blocks_creator_2d =
-      dynamic_cast<const creators::AlignedLattice<2>*>(domain_creator_2d.get());
-  test_aligned_blocks(*aligned_blocks_creator_2d);
+  const auto* aligned_blocks_creator_2d_periodic =
+      dynamic_cast<const creators::AlignedLattice<2>*>(
+          domain_creator_2d_periodic.get());
+  test_aligned_blocks(*aligned_blocks_creator_2d_periodic, nullptr);
 
-  const auto domain_creator_3d = TestHelpers::test_factory_creation<
+  const auto domain_creator_3d_periodic = TestHelpers::test_factory_creation<
       DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
       TestHelpers::domain::BoundaryConditions::
           MetavariablesWithoutBoundaryConditions<3>>(
@@ -90,45 +241,10 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
       "  RefinedLevels: []\n"
       "  RefinedGridPoints: []\n"
       "  BlocksToExclude: []\n");
-  const auto* aligned_blocks_creator_3d =
-      dynamic_cast<const creators::AlignedLattice<3>*>(domain_creator_3d.get());
-  test_aligned_blocks(*aligned_blocks_creator_3d);
-
-  const auto cubical_shell_domain = TestHelpers::test_factory_creation<
-      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
-      TestHelpers::domain::BoundaryConditions::
-          MetavariablesWithoutBoundaryConditions<3>>(
-      "AlignedLattice:\n"
-      "  BlockBounds: [[0.1, 2.6, 5.1, 6.0], [-0.4, 3.2, 6.2, 7.0], "
-      "[-0.2, 3.2, 4.0, 5.2]]\n"
-      "  IsPeriodicIn: [false, false, false]\n"
-      "  InitialGridPoints: [3, 4, 5]\n"
-      "  InitialLevels: [2, 1, 0]\n"
-      "  RefinedLevels: []\n"
-      "  RefinedGridPoints: []\n"
-      "  BlocksToExclude: [[1, 1, 1]]");
-  const auto* cubical_shell_creator_3d =
+  const auto* aligned_blocks_creator_3d_periodic =
       dynamic_cast<const creators::AlignedLattice<3>*>(
-          cubical_shell_domain.get());
-  test_aligned_blocks(*cubical_shell_creator_3d);
-
-  const auto unit_cubical_shell_domain = TestHelpers::test_factory_creation<
-      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
-      TestHelpers::domain::BoundaryConditions::
-          MetavariablesWithoutBoundaryConditions<3>>(
-      "AlignedLattice:\n"
-      "  BlockBounds: [[-1.5, -0.5, 0.5, 1.5], [-1.5, -0.5, 0.5, 1.5], "
-      "[-1.5, -0.5, 0.5, 1.5]]\n"
-      "  IsPeriodicIn: [false, false, false]\n"
-      "  InitialGridPoints: [5, 5, 5]\n"
-      "  InitialLevels: [1, 1, 1]\n"
-      "  RefinedLevels: []\n"
-      "  RefinedGridPoints: []\n"
-      "  BlocksToExclude: [[1, 1, 1]]");
-  const auto* unit_cubical_shell_creator_3d =
-      dynamic_cast<const creators::AlignedLattice<3>*>(
-          unit_cubical_shell_domain.get());
-  test_aligned_blocks(*unit_cubical_shell_creator_3d);
+          domain_creator_3d_periodic.get());
+  test_aligned_blocks(*aligned_blocks_creator_3d_periodic, nullptr);
 
   {
     // Expected domain refinement:

--- a/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
+++ b/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
@@ -349,25 +349,44 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
     CAPTURE(expected_blocks);
     CHECK(expected_blocks.empty());
   }
-}
 
-// [[OutputRegex, Cannot exclude blocks as well as have periodic boundary
-// conditions!]]
-SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice.Error",
-                  "[Unit][ErrorHandling]") {
-  ERROR_TEST();
-  const auto failed_cubical_shell_domain = TestHelpers::test_factory_creation<
-      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
-      TestHelpers::domain::BoundaryConditions::
-          MetavariablesWithoutBoundaryConditions<3>>(
-      "AlignedLattice:\n"
-      "  BlockBounds: [[-1.5, -0.5, 0.5, 1.5], [-1.5, -0.5, 0.5, 1.5], "
-      "[-1.5, -0.5, 0.5, 1.5]]\n"
-      "  IsPeriodicIn: [true, false, false]\n"
-      "  InitialGridPoints: [5, 5, 5]\n"
-      "  InitialLevels: [1, 1, 1]\n"
-      "  RefinedLevels: []\n"
-      "  RefinedGridPoints: []\n"
-      "  BlocksToExclude: [[1, 1, 1]]");
+  CHECK_THROWS_WITH(
+      creators::AlignedLattice<3>({{{{-1.5, -0.5, 0.5, 1.5}},
+                                    {{1.5, -0.5, 0.5, 1.5}},
+                                    {{-1.5, -0.5, 0.5, 1.5}}}},
+                                  {{1, 1, 1}}, {{5, 5, 5}}, {}, {},
+                                  {{{{1, 1, 1}}}}, {{true, false, false}},
+                                  Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::Contains(
+          "Cannot exclude blocks as well as have periodic boundary"));
+  CHECK_THROWS_WITH(
+      creators::AlignedLattice<3>({{{{-1.5, -0.5, 0.5, 1.5}},
+                                    {{1.5, -0.5, 0.5, 1.5}},
+                                    {{-1.5, -0.5, 0.5, 1.5}}}},
+                                  {{1, 1, 1}}, {{5, 5, 5}}, {}, {},
+                                  {{{{1, 1, 1}}}}, {{false, true, false}},
+                                  Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::Contains(
+          "Cannot exclude blocks as well as have periodic boundary"));
+  CHECK_THROWS_WITH(
+      creators::AlignedLattice<3>({{{{-1.5, -0.5, 0.5, 1.5}},
+                                    {{1.5, -0.5, 0.5, 1.5}},
+                                    {{-1.5, -0.5, 0.5, 1.5}}}},
+                                  {{1, 1, 1}}, {{5, 5, 5}}, {}, {},
+                                  {{{{1, 1, 1}}}}, {{true, false, true}},
+                                  Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::Contains(
+          "Cannot exclude blocks as well as have periodic boundary"));
+  CHECK_THROWS_WITH(
+      creators::AlignedLattice<3>(
+          {{{{-1.5, -0.5, 0.5, 1.5}},
+            {{1.5, -0.5, 0.5, 1.5}},
+            {{-1.5, -0.5, 0.5, 1.5}}}},
+          {{1, 1, 1}}, {{5, 5, 5}}, {}, {}, {{{{1, 1, 1}}}},
+          std::make_unique<TestHelpers::domain::BoundaryConditions::
+                               TestPeriodicBoundaryCondition<3>>(),
+          Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::Contains(
+          "Cannot exclude blocks as well as have periodic boundary"));
 }
 }  // namespace domain


### PR DESCRIPTION
## Proposed changes

- Add boundary condition support to AlignedLattice domain creator
- Replace a CTest-based error test with a Catch-based error test to reduce the number of test cases.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
