### PR TITLE
Binary domain: boundary conditions and cleanup

### DIFF
--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -14,6 +14,8 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Block.hpp"  // IWYU pragma: keep
+#include "Domain/BoundaryConditions/None.hpp"
+#include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
@@ -61,6 +63,10 @@ BinaryCompactObject::BinaryCompactObject(
         addition_to_object_B_radial_refinement_level,
     std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
         time_dependence,
+    std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+        inner_boundary_condition,
+    std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+        outer_boundary_condition,
     const Options::Context& context)
     // clang-tidy: trivially copyable
     : inner_radius_object_A_(std::move(inner_radius_object_A)),        // NOLINT
@@ -90,7 +96,9 @@ BinaryCompactObject::BinaryCompactObject(
           std::move(use_logarithmic_map_object_B)),  // NOLINT
       addition_to_object_B_radial_refinement_level_(
           addition_to_object_B_radial_refinement_level),  // NOLINT
-      time_dependence_(std::move(time_dependence)) {
+      time_dependence_(std::move(time_dependence)),
+      inner_boundary_condition_(std::move(inner_boundary_condition)),
+      outer_boundary_condition_(std::move(outer_boundary_condition)) {
   // Determination of parameters for domain construction:
   translation_ = 0.5 * (xcoord_object_B_ + xcoord_object_A_);
   length_inner_cube_ = abs(xcoord_object_A_ - xcoord_object_B_);
@@ -146,6 +154,28 @@ BinaryCompactObject::BinaryCompactObject(
         "of Layer 1 enveloping Object B requires excising the interior of "
         "Object B");
   }
+  using domain::BoundaryConditions::is_none;
+  if (outer_boundary_condition_ != nullptr and
+      ((not excise_interior_A_ and not excise_interior_B_) and
+       (inner_boundary_condition_ == nullptr or
+        not is_none(inner_boundary_condition_)))) {
+    PARSE_ERROR(context,
+                "Inner boundary condition must be None if ExciseInteriorA and "
+                "ExciseInteriorB are both false");
+  }
+  if ((outer_boundary_condition_ == nullptr) xor
+      (inner_boundary_condition_ == nullptr)) {
+    PARSE_ERROR(context,
+                "Must specify either both inner and outer boundary conditions "
+                "or neither.");
+  }
+  using domain::BoundaryConditions::is_periodic;
+  if (is_periodic(inner_boundary_condition_) or
+      is_periodic(outer_boundary_condition_)) {
+    PARSE_ERROR(
+        context,
+        "Cannot have periodic boundary conditions with a binary domain");
+  }
 
   // Calculate number of blocks
   // Layers 1, 2, 3, 4, and 5 have 12, 12, 10, 10, and 10 blocks, respectively,
@@ -167,8 +197,12 @@ Domain<3> BinaryCompactObject::create_domain() const noexcept {
 
   using Maps = std::vector<
       std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>>;
+  using BcMap = DirectionMap<
+      3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>;
 
-  Maps maps;
+  std::vector<BcMap> boundary_conditions_all_blocks{};
+
+  Maps maps{};
   // ObjectA/B is on the left/right, respectively.
   Maps maps_center_A = sph_wedge_coordinate_maps<Frame::Inertial>(
       inner_radius_object_A_, outer_radius_object_A_, inner_sphericity_A, 1.0,
@@ -188,11 +222,41 @@ Domain<3> BinaryCompactObject::create_domain() const noexcept {
       length_inner_cube_, length_outer_cube_, use_equiangular_map_,
       {{-translation_, 0.0, 0.0}}, projective_scale_factor_);
 
+  if (inner_boundary_condition_ != nullptr) {
+    for (size_t i = 0; i < maps_center_A.size(); ++i) {
+      BcMap bcs{};
+      if (excise_interior_A_) {
+        bcs[Direction<3>::lower_zeta()] =
+            inner_boundary_condition_->get_clone();
+      }
+      boundary_conditions_all_blocks.push_back(std::move(bcs));
+    }
+  }
   std::move(maps_center_A.begin(), maps_center_A.end(),
             std::back_inserter(maps));
+  if (inner_boundary_condition_ != nullptr) {
+    for (size_t i = 0; i < maps_cube_A.size(); ++i) {
+      boundary_conditions_all_blocks.push_back(BcMap{});
+    }
+  }
   std::move(maps_cube_A.begin(), maps_cube_A.end(), std::back_inserter(maps));
+  if (inner_boundary_condition_ != nullptr) {
+    for (size_t i = 0; i < maps_center_B.size(); ++i) {
+      BcMap bcs{};
+      if (excise_interior_B_) {
+        bcs[Direction<3>::lower_zeta()] =
+            inner_boundary_condition_->get_clone();
+      }
+      boundary_conditions_all_blocks.push_back(std::move(bcs));
+    }
+  }
   std::move(maps_center_B.begin(), maps_center_B.end(),
             std::back_inserter(maps));
+  if (inner_boundary_condition_ != nullptr) {
+    for (size_t i = 0; i < maps_cube_B.size() + maps_frustums.size(); ++i) {
+      boundary_conditions_all_blocks.push_back(BcMap{});
+    }
+  }
   std::move(maps_cube_B.begin(), maps_cube_B.end(), std::back_inserter(maps));
   std::move(maps_frustums.begin(), maps_frustums.end(),
             std::back_inserter(maps));
@@ -226,6 +290,19 @@ Domain<3> BinaryCompactObject::create_domain() const noexcept {
       outer_radius_first_outer_shell, radius_enveloping_sphere_, 1.0, 1.0,
       use_equiangular_map_, 0.0, true, 1.0,
       use_logarithmic_map_outer_spherical_shell_, ShellWedges::All, 1);
+  if (outer_boundary_condition_ != nullptr) {
+    // The outer 10 wedges all have to have the outer boundary condition applied
+    for (size_t i = 0; i < maps_first_outer_shell.size() +
+                               maps_second_outer_shell.size() - 10;
+         ++i) {
+      boundary_conditions_all_blocks.push_back(BcMap{});
+    }
+    for (size_t i = 0; i < 10; ++i) {
+      BcMap bcs{};
+      bcs[Direction<3>::upper_zeta()] = outer_boundary_condition_->get_clone();
+      boundary_conditions_all_blocks.push_back(std::move(bcs));
+    }
+  }
   std::move(maps_first_outer_shell.begin(), maps_first_outer_shell.end(),
             std::back_inserter(maps));
   std::move(maps_second_outer_shell.begin(), maps_second_outer_shell.end(),
@@ -239,6 +316,10 @@ Domain<3> BinaryCompactObject::create_domain() const noexcept {
       CoordinateMaps::ProductOf3Maps<Equiangular, Equiangular, Equiangular>;
   using Identity2D = CoordinateMaps::Identity<2>;
   if (not excise_interior_A_) {
+    if (inner_boundary_condition_ != nullptr) {
+      boundary_conditions_all_blocks.push_back(BcMap{});
+    }
+
     auto shift_1d_A =
         Affine{-1.0, 1.0, -1.0 + xcoord_object_A_, 1.0 + xcoord_object_A_};
     const auto translation_A =
@@ -267,6 +348,10 @@ Domain<3> BinaryCompactObject::create_domain() const noexcept {
     }
   }
   if (not excise_interior_B_) {
+    if (inner_boundary_condition_ != nullptr) {
+      boundary_conditions_all_blocks.push_back(BcMap{});
+    }
+
     auto shift_1d_B =
         Affine{-1.0, 1.0, -1.0 + xcoord_object_B_, 1.0 + xcoord_object_B_};
     const auto translation_B =
@@ -295,7 +380,9 @@ Domain<3> BinaryCompactObject::create_domain() const noexcept {
   }
   Domain<3> domain{std::move(maps),
                    corners_for_biradially_layered_domains(
-                       2, 3, not excise_interior_A_, not excise_interior_B_)};
+                       2, 3, not excise_interior_A_, not excise_interior_B_),
+                   {},
+                   std::move(boundary_conditions_all_blocks)};
   if (not time_dependence_->is_none()) {
     for (size_t block = 0; block < number_of_blocks_; ++block) {
       domain.inject_time_dependent_map_for_block(

--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -236,7 +236,7 @@ Domain<3> BinaryCompactObject::create_domain() const noexcept {
             std::back_inserter(maps));
   if (inner_boundary_condition_ != nullptr) {
     for (size_t i = 0; i < maps_cube_A.size(); ++i) {
-      boundary_conditions_all_blocks.push_back(BcMap{});
+      boundary_conditions_all_blocks.emplace_back(BcMap{});
     }
   }
   std::move(maps_cube_A.begin(), maps_cube_A.end(), std::back_inserter(maps));
@@ -254,7 +254,7 @@ Domain<3> BinaryCompactObject::create_domain() const noexcept {
             std::back_inserter(maps));
   if (inner_boundary_condition_ != nullptr) {
     for (size_t i = 0; i < maps_cube_B.size() + maps_frustums.size(); ++i) {
-      boundary_conditions_all_blocks.push_back(BcMap{});
+      boundary_conditions_all_blocks.emplace_back(BcMap{});
     }
   }
   std::move(maps_cube_B.begin(), maps_cube_B.end(), std::back_inserter(maps));
@@ -295,7 +295,7 @@ Domain<3> BinaryCompactObject::create_domain() const noexcept {
     for (size_t i = 0; i < maps_first_outer_shell.size() +
                                maps_second_outer_shell.size() - 10;
          ++i) {
-      boundary_conditions_all_blocks.push_back(BcMap{});
+      boundary_conditions_all_blocks.emplace_back(BcMap{});
     }
     for (size_t i = 0; i < 10; ++i) {
       BcMap bcs{};
@@ -317,7 +317,7 @@ Domain<3> BinaryCompactObject::create_domain() const noexcept {
   using Identity2D = CoordinateMaps::Identity<2>;
   if (not excise_interior_A_) {
     if (inner_boundary_condition_ != nullptr) {
-      boundary_conditions_all_blocks.push_back(BcMap{});
+      boundary_conditions_all_blocks.emplace_back(BcMap{});
     }
 
     auto shift_1d_A =
@@ -349,7 +349,7 @@ Domain<3> BinaryCompactObject::create_domain() const noexcept {
   }
   if (not excise_interior_B_) {
     if (inner_boundary_condition_ != nullptr) {
-      boundary_conditions_all_blocks.push_back(BcMap{});
+      boundary_conditions_all_blocks.emplace_back(BcMap{});
     }
 
     auto shift_1d_B =

--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -48,7 +48,6 @@ BinaryCompactObject::BinaryCompactObject(
     typename RadiusOuterSphere::type radius_enveloping_sphere,
     typename InitialRefinement::type initial_refinement,
     typename InitialGridPoints::type initial_grid_points_per_dim,
-    typename UseEquiangularMap::type use_equiangular_map,
     typename UseProjectiveMap::type use_projective_map,
     typename UseLogarithmicMapOuterSphericalShell::type
         use_logarithmic_map_outer_spherical_shell,
@@ -78,7 +77,6 @@ BinaryCompactObject::BinaryCompactObject(
           std::move(initial_refinement)),                              // NOLINT
       initial_grid_points_per_dim_(                                    // NOLINT
           std::move(initial_grid_points_per_dim)),                     // NOLINT
-      use_equiangular_map_(std::move(use_equiangular_map)),            // NOLINT
       use_projective_map_(std::move(use_projective_map)),              // NOLINT
       use_logarithmic_map_outer_spherical_shell_(
           std::move(use_logarithmic_map_outer_spherical_shell)),  // NOLINT

--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -240,17 +240,13 @@ Domain<3> BinaryCompactObject::create_domain() const noexcept {
   using Equiangular3D =
       CoordinateMaps::ProductOf3Maps<Equiangular, Equiangular, Equiangular>;
   using Identity2D = CoordinateMaps::Identity<2>;
-  auto shift_1d_A =
-      Affine{-1.0, 1.0, -1.0 + xcoord_object_A_, 1.0 + xcoord_object_A_};
-  auto shift_1d_B =
-      Affine{-1.0, 1.0, -1.0 + xcoord_object_B_, 1.0 + xcoord_object_B_};
-
-  // clang-tidy: trivially copyable
-  const auto translation_A = CoordinateMaps::ProductOf2Maps<Affine, Identity2D>(
-      std::move(shift_1d_A), Identity2D{});  // NOLINT
-  const auto translation_B = CoordinateMaps::ProductOf2Maps<Affine, Identity2D>(
-      std::move(shift_1d_B), Identity2D{});  // NOLINT
   if (not excise_interior_A_) {
+    auto shift_1d_A =
+        Affine{-1.0, 1.0, -1.0 + xcoord_object_A_, 1.0 + xcoord_object_A_};
+    const auto translation_A =
+        CoordinateMaps::ProductOf2Maps<Affine, Identity2D>(shift_1d_A,
+                                                           Identity2D{});
+
     const double scaled_r_inner_A = inner_radius_object_A_ / sqrt(3.0);
     if (use_equiangular_map_) {
       maps.emplace_back(
@@ -273,6 +269,11 @@ Domain<3> BinaryCompactObject::create_domain() const noexcept {
     }
   }
   if (not excise_interior_B_) {
+    auto shift_1d_B =
+        Affine{-1.0, 1.0, -1.0 + xcoord_object_B_, 1.0 + xcoord_object_B_};
+    const auto translation_B =
+        CoordinateMaps::ProductOf2Maps<Affine, Identity2D>(shift_1d_B,
+                                                           Identity2D{});
     const double scaled_r_inner_B = inner_radius_object_B_ / sqrt(3.0);
     if (use_equiangular_map_) {
       maps.emplace_back(

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -10,6 +10,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/BoundaryConditions/GetBoundaryConditionsBase.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/TimeDependence/TimeDependence.hpp"
@@ -264,7 +266,28 @@ class BinaryCompactObject : public DomainCreator<3> {
         "The time dependence of the moving mesh domain."};
   };
 
-  using options = tmpl::list<
+  struct BoundaryConditions {
+    static constexpr Options::String help = "The boundary conditions to apply.";
+  };
+  template <typename BoundaryConditionsBase>
+  struct InnerBoundaryCondition {
+    static std::string name() noexcept { return "InnerBoundary"; }
+    static constexpr Options::String help =
+        "Options for the inner boundary conditions.";
+    using type = std::unique_ptr<BoundaryConditionsBase>;
+    using group = BoundaryConditions;
+  };
+
+  template <typename BoundaryConditionsBase>
+  struct OuterBoundaryCondition {
+    static std::string name() noexcept { return "OuterBoundary"; }
+    static constexpr Options::String help =
+        "Options for the outer boundary conditions.";
+    using type = std::unique_ptr<BoundaryConditionsBase>;
+    using group = BoundaryConditions;
+  };
+
+  using basic_options = tmpl::list<
       InnerRadiusObjectA, OuterRadiusObjectA, XCoordObjectA, ExciseInteriorA,
       InnerRadiusObjectB, OuterRadiusObjectB, XCoordObjectB, ExciseInteriorB,
       RadiusOuterCube, RadiusOuterSphere, InitialRefinement, InitialGridPoints,
@@ -272,6 +295,20 @@ class BinaryCompactObject : public DomainCreator<3> {
       AdditionToOuterLayerRadialRefinementLevel, UseLogarithmicMapObjectA,
       AdditionToObjectARadialRefinementLevel, UseLogarithmicMapObjectB,
       AdditionToObjectBRadialRefinementLevel, TimeDependence>;
+
+  template <typename Metavariables>
+  using options = tmpl::conditional_t<
+      domain::BoundaryConditions::has_boundary_conditions_base_v<
+          typename Metavariables::system>,
+      tmpl::push_back<
+          basic_options,
+          InnerBoundaryCondition<
+              domain::BoundaryConditions::get_boundary_conditions_base<
+                  typename Metavariables::system>>,
+          OuterBoundaryCondition<
+              domain::BoundaryConditions::get_boundary_conditions_base<
+                  typename Metavariables::system>>>,
+      basic_options>;
 
   static constexpr Options::String help{
       "The BinaryCompactObject domain is a general domain for two compact "
@@ -328,6 +365,10 @@ class BinaryCompactObject : public DomainCreator<3> {
           addition_to_object_B_radial_refinement_level = 0,
       std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
           time_dependence = nullptr,
+      std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+          inner_boundary_condition = nullptr,
+      std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+          outer_boundary_condition = nullptr,
       const Options::Context& context = {});
 
   BinaryCompactObject() = default;
@@ -381,6 +422,10 @@ class BinaryCompactObject : public DomainCreator<3> {
   size_t number_of_blocks_{};
   std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
       time_dependence_;
+  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+      inner_boundary_condition_;
+  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+      outer_boundary_condition_;
 };
 }  // namespace creators
 }  // namespace domain

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -208,12 +208,6 @@ class BinaryCompactObject : public DomainCreator<3> {
         "Initial number of grid points in each dim per element."};
   };
 
-  struct UseEquiangularMap {
-    using type = bool;
-    static constexpr Options::String help = {
-        "Use equiangular instead of equidistant coordinates."};
-  };
-
   struct UseProjectiveMap {
     using type = bool;
     static constexpr Options::String help = {
@@ -274,7 +268,7 @@ class BinaryCompactObject : public DomainCreator<3> {
       InnerRadiusObjectA, OuterRadiusObjectA, XCoordObjectA, ExciseInteriorA,
       InnerRadiusObjectB, OuterRadiusObjectB, XCoordObjectB, ExciseInteriorB,
       RadiusOuterCube, RadiusOuterSphere, InitialRefinement, InitialGridPoints,
-      UseEquiangularMap, UseProjectiveMap, UseLogarithmicMapOuterSphericalShell,
+      UseProjectiveMap, UseLogarithmicMapOuterSphericalShell,
       AdditionToOuterLayerRadialRefinementLevel, UseLogarithmicMapObjectA,
       AdditionToObjectARadialRefinementLevel, UseLogarithmicMapObjectB,
       AdditionToObjectBRadialRefinementLevel, TimeDependence>;
@@ -319,7 +313,6 @@ class BinaryCompactObject : public DomainCreator<3> {
       typename RadiusOuterSphere::type radius_enveloping_sphere,
       typename InitialRefinement::type initial_refinement,
       typename InitialGridPoints::type initial_grid_points_per_dim,
-      typename UseEquiangularMap::type use_equiangular_map,
       typename UseProjectiveMap::type use_projective_map = true,
       typename UseLogarithmicMapOuterSphericalShell::type
           use_logarithmic_map_outer_spherical_shell = false,
@@ -368,7 +361,8 @@ class BinaryCompactObject : public DomainCreator<3> {
   typename RadiusOuterSphere::type radius_enveloping_sphere_{};
   typename InitialRefinement::type initial_refinement_{};
   typename InitialGridPoints::type initial_grid_points_per_dim_{};
-  typename UseEquiangularMap::type use_equiangular_map_ = true;
+  static constexpr bool use_equiangular_map_ =
+      false;  // Doesn't work properly yet
   typename UseProjectiveMap::type use_projective_map_ = true;
   typename UseLogarithmicMapOuterSphericalShell::type
       use_logarithmic_map_outer_spherical_shell_ = false;

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -85,53 +85,50 @@ void test_connectivity() {
 
   for (const bool excise_interiorA : {true, false}) {
     for (const bool excise_interiorB : {true, false}) {
-      for (const bool use_equiangular_map : {true, false}) {
-        for (const bool use_logarithmic_map_outer_spherical_shell :
-             {true, false}) {
-          const domain::creators::BinaryCompactObject binary_compact_object{
-              inner_radius_objectA,
-              outer_radius_objectA,
-              xcoord_objectA,
-              excise_interiorA,
-              inner_radius_objectB,
-              outer_radius_objectB,
-              xcoord_objectB,
-              excise_interiorB,
-              radius_enveloping_cube,
-              radius_enveloping_sphere,
-              refinement,
-              grid_points,
-              use_equiangular_map,
-              use_projective_map,
-              use_logarithmic_map_outer_spherical_shell,
-              addition_to_outer_layer_radial_refinement_level};
-          test_binary_compact_object_construction(binary_compact_object);
+      for (const bool use_logarithmic_map_outer_spherical_shell :
+           {true, false}) {
+        const domain::creators::BinaryCompactObject binary_compact_object{
+            inner_radius_objectA,
+            outer_radius_objectA,
+            xcoord_objectA,
+            excise_interiorA,
+            inner_radius_objectB,
+            outer_radius_objectB,
+            xcoord_objectB,
+            excise_interiorB,
+            radius_enveloping_cube,
+            radius_enveloping_sphere,
+            refinement,
+            grid_points,
+            use_projective_map,
+            use_logarithmic_map_outer_spherical_shell,
+            addition_to_outer_layer_radial_refinement_level};
+        test_binary_compact_object_construction(binary_compact_object);
 
-          // Also check whether the radius of the inner boundary of Layer 5 is
-          // chosen correctly.
-          // Compute the radius of a point in the grid frame on this boundary.
-          // Block 44 is one block whose -zeta face is on this boundary.
-          const auto map{binary_compact_object.create_domain()
-                             .blocks()[44]
-                             .stationary_map()
-                             .get_clone()};
-          tnsr::I<double, 3, Frame::Logical> logical_point(
-              std::array<double, 3>{{0.0, 0.0, -1.0}});
-          const double layer_5_inner_radius =
-              get(magnitude(std::move(map)->operator()(logical_point)));
-          // The number of radial divisions in layers 4 and 5, excluding those
-          // resulting from InitialRefinement > 0.
-          const auto radial_divisions_in_outer_layers = static_cast<double>(
-              pow(2, addition_to_outer_layer_radial_refinement_level) + 1);
-          if (use_logarithmic_map_outer_spherical_shell) {
-            CHECK(layer_5_inner_radius / radius_enveloping_cube ==
-                  approx(pow(radius_enveloping_sphere / radius_enveloping_cube,
-                             1.0 / radial_divisions_in_outer_layers)));
-          } else {
-            CHECK(layer_5_inner_radius - radius_enveloping_cube ==
-                  approx((radius_enveloping_sphere - radius_enveloping_cube) /
-                         radial_divisions_in_outer_layers));
-          }
+        // Also check whether the radius of the inner boundary of Layer 5 is
+        // chosen correctly.
+        // Compute the radius of a point in the grid frame on this boundary.
+        // Block 44 is one block whose -zeta face is on this boundary.
+        const auto map{binary_compact_object.create_domain()
+                           .blocks()[44]
+                           .stationary_map()
+                           .get_clone()};
+        tnsr::I<double, 3, Frame::Logical> logical_point(
+            std::array<double, 3>{{0.0, 0.0, -1.0}});
+        const double layer_5_inner_radius =
+            get(magnitude(std::move(map)->operator()(logical_point)));
+        // The number of radial divisions in layers 4 and 5, excluding those
+        // resulting from InitialRefinement > 0.
+        const auto radial_divisions_in_outer_layers = static_cast<double>(
+            pow(2, addition_to_outer_layer_radial_refinement_level) + 1);
+        if (use_logarithmic_map_outer_spherical_shell) {
+          CHECK(layer_5_inner_radius / radius_enveloping_cube ==
+                approx(pow(radius_enveloping_sphere / radius_enveloping_cube,
+                           1.0 / radial_divisions_in_outer_layers)));
+        } else {
+          CHECK(layer_5_inner_radius - radius_enveloping_cube ==
+                approx((radius_enveloping_sphere - radius_enveloping_cube) /
+                       radial_divisions_in_outer_layers));
         }
       }
     }
@@ -156,7 +153,6 @@ void test_bbh_time_dependent_factory() {
       "    RadiusOuterSphere: 25.0\n"
       "    InitialRefinement: 1\n"
       "    InitialGridPoints: 3\n"
-      "    UseEquiangularMap: true\n"
       "    UseProjectiveMap: true\n"
       "    UseLogarithmicMapOuterSphericalShell: false\n"
       "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
@@ -226,38 +222,6 @@ void test_bbh_time_dependent_factory() {
   }
 }
 
-void test_bbh_equiangular_factory() {
-  const auto binary_compact_object = TestHelpers::test_factory_creation<
-      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
-      TestHelpers::domain::BoundaryConditions::
-          MetavariablesWithoutBoundaryConditions<3>>(
-      "  BinaryCompactObject:\n"
-      "    InnerRadiusObjectA: 0.2\n"
-      "    OuterRadiusObjectA: 1.0\n"
-      "    XCoordObjectA: -2.0\n"
-      "    ExciseInteriorA: true\n"
-      "    InnerRadiusObjectB: 1.0\n"
-      "    OuterRadiusObjectB: 2.0\n"
-      "    XCoordObjectB: 3.0\n"
-      "    ExciseInteriorB: true\n"
-      "    RadiusOuterCube: 22.0\n"
-      "    RadiusOuterSphere: 25.0\n"
-      "    InitialRefinement: 1\n"
-      "    InitialGridPoints: 3\n"
-      "    UseEquiangularMap: true\n"
-      "    UseProjectiveMap: true\n"
-      "    UseLogarithmicMapOuterSphericalShell: false\n"
-      "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
-      "    UseLogarithmicMapObjectA: false\n"
-      "    AdditionToObjectARadialRefinementLevel: 0\n"
-      "    UseLogarithmicMapObjectB: false\n"
-      "    AdditionToObjectBRadialRefinementLevel: 0\n"
-      "    TimeDependence: None\n");
-  test_binary_compact_object_construction(
-      dynamic_cast<const domain::creators::BinaryCompactObject&>(
-          *binary_compact_object));
-}
-
 void test_bbh_2_outer_radial_refinements_linear_map_factory() {
   const auto binary_compact_object = TestHelpers::test_factory_creation<
       DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
@@ -276,7 +240,6 @@ void test_bbh_2_outer_radial_refinements_linear_map_factory() {
       "    RadiusOuterSphere: 25.0\n"
       "    InitialRefinement: 1\n"
       "    InitialGridPoints: 3\n"
-      "    UseEquiangularMap: true\n"
       "    UseProjectiveMap: true\n"
       "    UseLogarithmicMapOuterSphericalShell: false\n"
       "    AdditionToOuterLayerRadialRefinementLevel: 2\n"
@@ -308,7 +271,6 @@ void test_bbh_3_outer_radial_refinements_log_map_factory() {
       "    RadiusOuterSphere: 25.0\n"
       "    InitialRefinement: 1\n"
       "    InitialGridPoints: 3\n"
-      "    UseEquiangularMap: true\n"
       "    UseProjectiveMap: true\n"
       "    UseLogarithmicMapOuterSphericalShell: false\n"
       "    AdditionToOuterLayerRadialRefinementLevel: 3\n"
@@ -340,39 +302,6 @@ void test_bbh_equidistant_factory() {
       "    RadiusOuterSphere: 25.0\n"
       "    InitialRefinement: 1\n"
       "    InitialGridPoints: 3\n"
-      "    UseEquiangularMap: false\n"
-      "    UseProjectiveMap: true\n"
-      "    UseLogarithmicMapOuterSphericalShell: false\n"
-      "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
-      "    UseLogarithmicMapObjectA: false\n"
-      "    AdditionToObjectARadialRefinementLevel: 0\n"
-      "    UseLogarithmicMapObjectB: false\n"
-      "    AdditionToObjectBRadialRefinementLevel: 0\n"
-      "    TimeDependence: None\n");
-  test_binary_compact_object_construction(
-      dynamic_cast<const domain::creators::BinaryCompactObject&>(
-          *binary_compact_object));
-}
-
-void test_bns_equiangular_factory() {
-  const auto binary_compact_object = TestHelpers::test_factory_creation<
-      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
-      TestHelpers::domain::BoundaryConditions::
-          MetavariablesWithoutBoundaryConditions<3>>(
-      "  BinaryCompactObject:\n"
-      "    InnerRadiusObjectA: 0.2\n"
-      "    OuterRadiusObjectA: 1.0\n"
-      "    XCoordObjectA: -2.0\n"
-      "    ExciseInteriorA: false\n"
-      "    InnerRadiusObjectB: 1.0\n"
-      "    OuterRadiusObjectB: 2.0\n"
-      "    XCoordObjectB: 3.0\n"
-      "    ExciseInteriorB: false\n"
-      "    RadiusOuterCube: 22.0\n"
-      "    RadiusOuterSphere: 25.0\n"
-      "    InitialRefinement: 1\n"
-      "    InitialGridPoints: 3\n"
-      "    UseEquiangularMap: true\n"
       "    UseProjectiveMap: true\n"
       "    UseLogarithmicMapOuterSphericalShell: false\n"
       "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
@@ -404,39 +333,6 @@ void test_bns_equidistant_factory() {
       "    RadiusOuterSphere: 25.0\n"
       "    InitialRefinement: 1\n"
       "    InitialGridPoints: 3\n"
-      "    UseEquiangularMap: false\n"
-      "    UseProjectiveMap: true\n"
-      "    UseLogarithmicMapOuterSphericalShell: false\n"
-      "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
-      "    UseLogarithmicMapObjectA: false\n"
-      "    AdditionToObjectARadialRefinementLevel: 0\n"
-      "    UseLogarithmicMapObjectB: false\n"
-      "    AdditionToObjectBRadialRefinementLevel: 0\n"
-      "    TimeDependence: None\n");
-  test_binary_compact_object_construction(
-      dynamic_cast<const domain::creators::BinaryCompactObject&>(
-          *binary_compact_object));
-}
-
-void test_bhns_equiangular_factory() {
-  const auto binary_compact_object = TestHelpers::test_factory_creation<
-      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
-      TestHelpers::domain::BoundaryConditions::
-          MetavariablesWithoutBoundaryConditions<3>>(
-      "  BinaryCompactObject:\n"
-      "    InnerRadiusObjectA: 0.2\n"
-      "    OuterRadiusObjectA: 1.0\n"
-      "    XCoordObjectA: -2.0\n"
-      "    ExciseInteriorA: true\n"
-      "    InnerRadiusObjectB: 1.0\n"
-      "    OuterRadiusObjectB: 2.0\n"
-      "    XCoordObjectB: 3.0\n"
-      "    ExciseInteriorB: false\n"
-      "    RadiusOuterCube: 22.0\n"
-      "    RadiusOuterSphere: 25.0\n"
-      "    InitialRefinement: 1\n"
-      "    InitialGridPoints: 3\n"
-      "    UseEquiangularMap: true\n"
       "    UseProjectiveMap: true\n"
       "    UseLogarithmicMapOuterSphericalShell: false\n"
       "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
@@ -468,39 +364,6 @@ void test_bhns_equidistant_factory() {
       "    RadiusOuterSphere: 25.0\n"
       "    InitialRefinement: 1\n"
       "    InitialGridPoints: 3\n"
-      "    UseEquiangularMap: false\n"
-      "    UseProjectiveMap: true\n"
-      "    UseLogarithmicMapOuterSphericalShell: false\n"
-      "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
-      "    UseLogarithmicMapObjectA: false\n"
-      "    AdditionToObjectARadialRefinementLevel: 0\n"
-      "    UseLogarithmicMapObjectB: false\n"
-      "    AdditionToObjectBRadialRefinementLevel: 0\n"
-      "    TimeDependence: None\n");
-  test_binary_compact_object_construction(
-      dynamic_cast<const domain::creators::BinaryCompactObject&>(
-          *binary_compact_object));
-}
-
-void test_nsbh_equiangular_factory() {
-  const auto binary_compact_object = TestHelpers::test_factory_creation<
-      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
-      TestHelpers::domain::BoundaryConditions::
-          MetavariablesWithoutBoundaryConditions<3>>(
-      "  BinaryCompactObject:\n"
-      "    InnerRadiusObjectA: 0.2\n"
-      "    OuterRadiusObjectA: 1.0\n"
-      "    XCoordObjectA: -2.0\n"
-      "    ExciseInteriorA: false\n"
-      "    InnerRadiusObjectB: 1.0\n"
-      "    OuterRadiusObjectB: 2.0\n"
-      "    XCoordObjectB: 3.0\n"
-      "    ExciseInteriorB: true\n"
-      "    RadiusOuterCube: 22.0\n"
-      "    RadiusOuterSphere: 25.0\n"
-      "    InitialRefinement: 1\n"
-      "    InitialGridPoints: 3\n"
-      "    UseEquiangularMap: true\n"
       "    UseProjectiveMap: true\n"
       "    UseLogarithmicMapOuterSphericalShell: false\n"
       "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
@@ -532,7 +395,6 @@ void test_nsbh_equidistant_factory() {
       "    RadiusOuterSphere: 25.0\n"
       "    InitialRefinement: 1\n"
       "    InitialGridPoints: 3\n"
-      "    UseEquiangularMap: false\n"
       "    UseProjectiveMap: true\n"
       "    UseLogarithmicMapOuterSphericalShell: false\n"
       "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
@@ -555,13 +417,9 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.BinaryCompactObject.FactoryTests",
   test_bbh_2_outer_radial_refinements_linear_map_factory();
   test_bbh_3_outer_radial_refinements_log_map_factory();
   test_bbh_time_dependent_factory();
-  test_bbh_equiangular_factory();
   test_bbh_equidistant_factory();
-  test_bns_equiangular_factory();
   test_bns_equidistant_factory();
-  test_bhns_equiangular_factory();
   test_bhns_equidistant_factory();
-  test_nsbh_equiangular_factory();
   test_nsbh_equidistant_factory();
 }
 
@@ -589,14 +447,12 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.BinaryCompactObject.Options1",
   // Misc.:
   const size_t refinement = 2;
   const size_t grid_points = 6;
-  const bool use_equiangular_map = true;
 
   domain::creators::BinaryCompactObject binary_compact_object{
       inner_radius_objectA,     outer_radius_objectA, xcoord_objectA,
       excise_interiorA,         inner_radius_objectB, outer_radius_objectB,
       xcoord_objectB,           excise_interiorB,     radius_enveloping_cube,
-      radius_enveloping_sphere, refinement,           grid_points,
-      use_equiangular_map};
+      radius_enveloping_sphere, refinement,           grid_points};
 }
 // [[OutputRegex, ObjectA's inner radius must be less than its outer radius.]]
 SPECTRE_TEST_CASE("Unit.Domain.Creators.BinaryCompactObject.Options2",
@@ -621,14 +477,12 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.BinaryCompactObject.Options2",
   // Misc.:
   const size_t refinement = 2;
   const size_t grid_points = 6;
-  const bool use_equiangular_map = true;
 
   domain::creators::BinaryCompactObject binary_compact_object{
       inner_radius_objectA,     outer_radius_objectA, xcoord_objectA,
       excise_interiorA,         inner_radius_objectB, outer_radius_objectB,
       xcoord_objectB,           excise_interiorB,     radius_enveloping_cube,
-      radius_enveloping_sphere, refinement,           grid_points,
-      use_equiangular_map};
+      radius_enveloping_sphere, refinement,           grid_points};
 }
 // [[OutputRegex, ObjectB's inner radius must be less than its outer radius.]]
 SPECTRE_TEST_CASE("Unit.Domain.Creators.BinaryCompactObject.Options3",
@@ -653,12 +507,10 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.BinaryCompactObject.Options3",
   // Misc.:
   const size_t refinement = 2;
   const size_t grid_points = 6;
-  const bool use_equiangular_map = true;
 
   domain::creators::BinaryCompactObject binary_compact_object{
       inner_radius_objectA,     outer_radius_objectA, xcoord_objectA,
       excise_interiorA,         inner_radius_objectB, outer_radius_objectB,
       xcoord_objectB,           excise_interiorB,     radius_enveloping_cube,
-      radius_enveloping_sphere, refinement,           grid_points,
-      use_equiangular_map};
+      radius_enveloping_sphere, refinement,           grid_points};
 }

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -135,38 +135,65 @@ void test_connectivity() {
   }
 }
 
+std::string stringize(const bool t) { return t ? "true" : "false"; }
+
+std::string create_option_string(const bool excise_A, const bool excise_B,
+                                 const bool add_time_dependence,
+                                 const bool use_logarithmic_map_AB,
+                                 const size_t additional_refinement_outer,
+                                 const size_t additional_refinement_A,
+                                 const size_t additional_refinement_B) {
+  const std::string time_dependence{
+      add_time_dependence
+          ? "  TimeDependence:\n"
+            "    UniformTranslation:\n"
+            "      InitialTime: 1.0\n"
+            "      InitialExpirationDeltaT: 9.0\n"
+            "      Velocity: [2.3, -0.3, 0.5]\n"
+            "      FunctionOfTimeNames: [TranslationX, TranslationY, "
+            "TranslationZ]\n"
+          : "  TimeDependence: None\n"};
+  return "BinaryCompactObject:\n"
+         "  InnerRadiusObjectA: 0.2\n"
+         "  OuterRadiusObjectA: 1.0\n"
+         "  XCoordObjectA: -2.0\n"
+         "  ExciseInteriorA: " +
+         stringize(excise_A) +
+         "\n"
+         "  InnerRadiusObjectB: 1.0\n"
+         "  OuterRadiusObjectB: 2.0\n"
+         "  XCoordObjectB: 3.0\n"
+         "  ExciseInteriorB: " +
+         stringize(excise_B) +
+         "\n"
+         "  RadiusOuterCube: 22.0\n"
+         "  RadiusOuterSphere: 25.0\n"
+         "  InitialRefinement: 1\n"
+         "  InitialGridPoints: 3\n"
+         "  UseProjectiveMap: true\n"
+         "  UseLogarithmicMapOuterSphericalShell: false\n"
+         "  AdditionToOuterLayerRadialRefinementLevel: " +
+         std::to_string(additional_refinement_outer) +
+         "\n"
+         "  UseLogarithmicMapObjectA: " +
+         stringize(use_logarithmic_map_AB) +
+         "\n"
+         "  AdditionToObjectARadialRefinementLevel: " +
+         std::to_string(additional_refinement_A) +
+         "\n"
+         "  UseLogarithmicMapObjectB: " +
+         stringize(use_logarithmic_map_AB) +
+         "\n"
+         "  AdditionToObjectBRadialRefinementLevel: " +
+         std::to_string(additional_refinement_B) + "\n" + time_dependence;
+}
+
 void test_bbh_time_dependent_factory() {
   const auto binary_compact_object = TestHelpers::test_factory_creation<
       DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
       TestHelpers::domain::BoundaryConditions::
           MetavariablesWithoutBoundaryConditions<3>>(
-      "  BinaryCompactObject:\n"
-      "    InnerRadiusObjectA: 0.2\n"
-      "    OuterRadiusObjectA: 1.0\n"
-      "    XCoordObjectA: -2.0\n"
-      "    ExciseInteriorA: true\n"
-      "    InnerRadiusObjectB: 1.0\n"
-      "    OuterRadiusObjectB: 2.0\n"
-      "    XCoordObjectB: 3.0\n"
-      "    ExciseInteriorB: true\n"
-      "    RadiusOuterCube: 22.0\n"
-      "    RadiusOuterSphere: 25.0\n"
-      "    InitialRefinement: 1\n"
-      "    InitialGridPoints: 3\n"
-      "    UseProjectiveMap: true\n"
-      "    UseLogarithmicMapOuterSphericalShell: false\n"
-      "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
-      "    UseLogarithmicMapObjectA: false\n"
-      "    AdditionToObjectARadialRefinementLevel: 0\n"
-      "    UseLogarithmicMapObjectB: false\n"
-      "    AdditionToObjectBRadialRefinementLevel: 0\n"
-      "    TimeDependence:\n"
-      "      UniformTranslation:\n"
-      "        InitialTime: 1.0\n"
-      "        InitialExpirationDeltaT: 9.0\n"
-      "        Velocity: [2.3, -0.3, 0.5]\n"
-      "        FunctionOfTimeNames: [TranslationX, TranslationY, "
-      "TranslationZ]");
+      create_option_string(true, true, true, false, 0, 0, 0));
   const std::array<double, 4> times_to_check{{0.0, 4.4, 7.8}};
 
   constexpr double initial_time = 0.0;
@@ -222,190 +249,22 @@ void test_bbh_time_dependent_factory() {
   }
 }
 
-void test_bbh_2_outer_radial_refinements_linear_map_factory() {
-  const auto binary_compact_object = TestHelpers::test_factory_creation<
-      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
-      TestHelpers::domain::BoundaryConditions::
-          MetavariablesWithoutBoundaryConditions<3>>(
-      "  BinaryCompactObject:\n"
-      "    InnerRadiusObjectA: 0.2\n"
-      "    OuterRadiusObjectA: 1.0\n"
-      "    XCoordObjectA: -2.0\n"
-      "    ExciseInteriorA: true\n"
-      "    InnerRadiusObjectB: 1.0\n"
-      "    OuterRadiusObjectB: 2.0\n"
-      "    XCoordObjectB: 3.0\n"
-      "    ExciseInteriorB: true\n"
-      "    RadiusOuterCube: 22.0\n"
-      "    RadiusOuterSphere: 25.0\n"
-      "    InitialRefinement: 1\n"
-      "    InitialGridPoints: 3\n"
-      "    UseProjectiveMap: true\n"
-      "    UseLogarithmicMapOuterSphericalShell: false\n"
-      "    AdditionToOuterLayerRadialRefinementLevel: 2\n"
-      "    UseLogarithmicMapObjectA: false\n"
-      "    AdditionToObjectARadialRefinementLevel: 0\n"
-      "    UseLogarithmicMapObjectB: false\n"
-      "    AdditionToObjectBRadialRefinementLevel: 2\n"
-      "    TimeDependence: None\n");
-  test_binary_compact_object_construction(
-      dynamic_cast<const domain::creators::BinaryCompactObject&>(
-          *binary_compact_object));
-}
-
-void test_bbh_3_outer_radial_refinements_log_map_factory() {
-  const auto binary_compact_object = TestHelpers::test_factory_creation<
-      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
-      TestHelpers::domain::BoundaryConditions::
-          MetavariablesWithoutBoundaryConditions<3>>(
-      "  BinaryCompactObject:\n"
-      "    InnerRadiusObjectA: 0.2\n"
-      "    OuterRadiusObjectA: 1.0\n"
-      "    XCoordObjectA: -2.0\n"
-      "    ExciseInteriorA: true\n"
-      "    InnerRadiusObjectB: 1.0\n"
-      "    OuterRadiusObjectB: 2.0\n"
-      "    XCoordObjectB: 3.0\n"
-      "    ExciseInteriorB: true\n"
-      "    RadiusOuterCube: 22.0\n"
-      "    RadiusOuterSphere: 25.0\n"
-      "    InitialRefinement: 1\n"
-      "    InitialGridPoints: 3\n"
-      "    UseProjectiveMap: true\n"
-      "    UseLogarithmicMapOuterSphericalShell: false\n"
-      "    AdditionToOuterLayerRadialRefinementLevel: 3\n"
-      "    UseLogarithmicMapObjectA: true\n"
-      "    AdditionToObjectARadialRefinementLevel: 3\n"
-      "    UseLogarithmicMapObjectB: true\n"
-      "    AdditionToObjectBRadialRefinementLevel: 0\n"
-      "    TimeDependence: None\n");
-  test_binary_compact_object_construction(
-      dynamic_cast<const domain::creators::BinaryCompactObject&>(
-          *binary_compact_object));
-}
-
-void test_bbh_equidistant_factory() {
-  const auto binary_compact_object = TestHelpers::test_factory_creation<
-      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
-      TestHelpers::domain::BoundaryConditions::
-          MetavariablesWithoutBoundaryConditions<3>>(
-      "  BinaryCompactObject:\n"
-      "    InnerRadiusObjectA: 0.2\n"
-      "    OuterRadiusObjectA: 1.0\n"
-      "    XCoordObjectA: -2.0\n"
-      "    ExciseInteriorA: true\n"
-      "    InnerRadiusObjectB: 1.0\n"
-      "    OuterRadiusObjectB: 2.0\n"
-      "    XCoordObjectB: 3.0\n"
-      "    ExciseInteriorB: true\n"
-      "    RadiusOuterCube: 22.0\n"
-      "    RadiusOuterSphere: 25.0\n"
-      "    InitialRefinement: 1\n"
-      "    InitialGridPoints: 3\n"
-      "    UseProjectiveMap: true\n"
-      "    UseLogarithmicMapOuterSphericalShell: false\n"
-      "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
-      "    UseLogarithmicMapObjectA: false\n"
-      "    AdditionToObjectARadialRefinementLevel: 0\n"
-      "    UseLogarithmicMapObjectB: false\n"
-      "    AdditionToObjectBRadialRefinementLevel: 0\n"
-      "    TimeDependence: None\n");
-  test_binary_compact_object_construction(
-      dynamic_cast<const domain::creators::BinaryCompactObject&>(
-          *binary_compact_object));
-}
-
-void test_bns_equidistant_factory() {
-  const auto binary_compact_object = TestHelpers::test_factory_creation<
-      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
-      TestHelpers::domain::BoundaryConditions::
-          MetavariablesWithoutBoundaryConditions<3>>(
-      "  BinaryCompactObject:\n"
-      "    InnerRadiusObjectA: 0.2\n"
-      "    OuterRadiusObjectA: 1.0\n"
-      "    XCoordObjectA: -2.0\n"
-      "    ExciseInteriorA: false\n"
-      "    InnerRadiusObjectB: 1.0\n"
-      "    OuterRadiusObjectB: 2.0\n"
-      "    XCoordObjectB: 3.0\n"
-      "    ExciseInteriorB: false\n"
-      "    RadiusOuterCube: 22.0\n"
-      "    RadiusOuterSphere: 25.0\n"
-      "    InitialRefinement: 1\n"
-      "    InitialGridPoints: 3\n"
-      "    UseProjectiveMap: true\n"
-      "    UseLogarithmicMapOuterSphericalShell: false\n"
-      "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
-      "    UseLogarithmicMapObjectA: false\n"
-      "    AdditionToObjectARadialRefinementLevel: 0\n"
-      "    UseLogarithmicMapObjectB: false\n"
-      "    AdditionToObjectBRadialRefinementLevel: 0\n"
-      "    TimeDependence: None\n");
-  test_binary_compact_object_construction(
-      dynamic_cast<const domain::creators::BinaryCompactObject&>(
-          *binary_compact_object));
-}
-
-void test_bhns_equidistant_factory() {
-  const auto binary_compact_object = TestHelpers::test_factory_creation<
-      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
-      TestHelpers::domain::BoundaryConditions::
-          MetavariablesWithoutBoundaryConditions<3>>(
-      "  BinaryCompactObject:\n"
-      "    InnerRadiusObjectA: 0.2\n"
-      "    OuterRadiusObjectA: 1.0\n"
-      "    XCoordObjectA: -2.0\n"
-      "    ExciseInteriorA: true\n"
-      "    InnerRadiusObjectB: 1.0\n"
-      "    OuterRadiusObjectB: 2.0\n"
-      "    XCoordObjectB: 3.0\n"
-      "    ExciseInteriorB: false\n"
-      "    RadiusOuterCube: 22.0\n"
-      "    RadiusOuterSphere: 25.0\n"
-      "    InitialRefinement: 1\n"
-      "    InitialGridPoints: 3\n"
-      "    UseProjectiveMap: true\n"
-      "    UseLogarithmicMapOuterSphericalShell: false\n"
-      "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
-      "    UseLogarithmicMapObjectA: false\n"
-      "    AdditionToObjectARadialRefinementLevel: 0\n"
-      "    UseLogarithmicMapObjectB: false\n"
-      "    AdditionToObjectBRadialRefinementLevel: 0\n"
-      "    TimeDependence: None\n");
-  test_binary_compact_object_construction(
-      dynamic_cast<const domain::creators::BinaryCompactObject&>(
-          *binary_compact_object));
-}
-
-void test_nsbh_equidistant_factory() {
-  const auto binary_compact_object = TestHelpers::test_factory_creation<
-      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
-      TestHelpers::domain::BoundaryConditions::
-          MetavariablesWithoutBoundaryConditions<3>>(
-      "  BinaryCompactObject:\n"
-      "    InnerRadiusObjectA: 0.2\n"
-      "    OuterRadiusObjectA: 1.0\n"
-      "    XCoordObjectA: -2.0\n"
-      "    ExciseInteriorA: false\n"
-      "    InnerRadiusObjectB: 1.0\n"
-      "    OuterRadiusObjectB: 2.0\n"
-      "    XCoordObjectB: 3.0\n"
-      "    ExciseInteriorB: true\n"
-      "    RadiusOuterCube: 22.0\n"
-      "    RadiusOuterSphere: 25.0\n"
-      "    InitialRefinement: 1\n"
-      "    InitialGridPoints: 3\n"
-      "    UseProjectiveMap: true\n"
-      "    UseLogarithmicMapOuterSphericalShell: false\n"
-      "    AdditionToOuterLayerRadialRefinementLevel: 0\n"
-      "    UseLogarithmicMapObjectA: false\n"
-      "    AdditionToObjectARadialRefinementLevel: 0\n"
-      "    UseLogarithmicMapObjectB: false\n"
-      "    AdditionToObjectBRadialRefinementLevel: 0\n"
-      "    TimeDependence: None\n");
-  test_binary_compact_object_construction(
-      dynamic_cast<const domain::creators::BinaryCompactObject&>(
-          *binary_compact_object));
+void test_binary_factory() {
+  const auto check_impl = [](const std::string& opt_string) {
+    const auto binary_compact_object = TestHelpers::test_factory_creation<
+        DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+        TestHelpers::domain::BoundaryConditions::
+            MetavariablesWithoutBoundaryConditions<3>>(opt_string);
+    test_binary_compact_object_construction(
+        dynamic_cast<const domain::creators::BinaryCompactObject&>(
+            *binary_compact_object));
+  };
+  check_impl(create_option_string(true, true, false, false, 2, 0, 2));
+  check_impl(create_option_string(true, true, false, true, 3, 3, 0));
+  check_impl(create_option_string(true, true, false, false, 0, 0, 0));
+  check_impl(create_option_string(false, false, false, false, 0, 0, 0));
+  check_impl(create_option_string(true, false, false, false, 0, 0, 0));
+  check_impl(create_option_string(false, true, false, false, 0, 0, 0));
 }
 }  // namespace
 
@@ -414,13 +273,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.BinaryCompactObject.FactoryTests",
                   "[Domain][Unit]") {
   test_connectivity();
   test_bbh_time_dependent_factory();
-  test_bbh_2_outer_radial_refinements_linear_map_factory();
-  test_bbh_3_outer_radial_refinements_log_map_factory();
-  test_bbh_time_dependent_factory();
-  test_bbh_equidistant_factory();
-  test_bns_equidistant_factory();
-  test_bhns_equidistant_factory();
-  test_nsbh_equidistant_factory();
+  test_binary_factory();
 }
 
 // [[OutputRegex, The radius for the enveloping cube is too small! The Frustums

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -19,6 +19,7 @@
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"  // IWYU pragma: keep
 #include "Domain/Block.hpp"                       // IWYU pragma: keep
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/Translation.hpp"
 #include "Domain/Creators/BinaryCompactObject.hpp"
@@ -40,6 +41,54 @@ namespace {
 using Translation = domain::CoordinateMaps::TimeDependent::Translation;
 using Translation3D = domain::CoordinateMaps::TimeDependent::ProductOf3Maps<
     Translation, Translation, Translation>;
+using BoundaryCondVector = std::vector<DirectionMap<
+    3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>;
+
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+create_inner_boundary_condition() {
+  return std::make_unique<
+      TestHelpers::domain::BoundaryConditions::TestBoundaryCondition<3>>(
+      Direction<3>::lower_zeta(), 50);
+}
+
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+create_outer_boundary_condition() {
+  return std::make_unique<
+      TestHelpers::domain::BoundaryConditions::TestBoundaryCondition<3>>(
+      Direction<3>::upper_zeta(), 50);
+}
+
+auto create_boundary_conditions(const bool excise_A, const bool excise_B) {
+  size_t total_blocks = 54;
+  if (not excise_A) {
+    total_blocks++;
+  }
+  if (not excise_B) {
+    total_blocks++;
+  }
+  BoundaryCondVector boundary_conditions_all_blocks{total_blocks};
+  if (excise_A) {
+    for (size_t block_id = 0; block_id < 6; ++block_id) {
+      boundary_conditions_all_blocks[block_id][Direction<3>::lower_zeta()] =
+          create_inner_boundary_condition();
+    }
+  }
+  if (excise_B) {
+    const size_t block_offset = 12;
+    for (size_t block_id = block_offset; block_id < block_offset + 6;
+         ++block_id) {
+      boundary_conditions_all_blocks[block_id][Direction<3>::lower_zeta()] =
+          create_inner_boundary_condition();
+    }
+  }
+  const size_t block_offset = 44;
+  for (size_t block_id = block_offset; block_id < block_offset + 10;
+       ++block_id) {
+    boundary_conditions_all_blocks[block_id][Direction<3>::upper_zeta()] =
+        create_outer_boundary_condition();
+  }
+  return boundary_conditions_all_blocks;
+}
 
 template <typename... FuncsOfTime>
 void test_binary_compact_object_construction(
@@ -49,12 +98,36 @@ void test_binary_compact_object_construction(
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time = {},
     const std::tuple<std::pair<std::string, FuncsOfTime>...>&
-        expected_functions_of_time = {}) {
+        expected_functions_of_time = {},
+    const BoundaryCondVector& expected_external_boundary_conditions = {}) {
   const auto domain = binary_compact_object.create_domain();
   test_initial_domain(domain,
                       binary_compact_object.initial_refinement_levels());
   test_physical_separation(binary_compact_object.create_domain().blocks(), time,
                            functions_of_time);
+
+  for (size_t block_id = 0;
+       block_id < expected_external_boundary_conditions.size(); ++block_id) {
+    CAPTURE(block_id);
+    const auto& block = domain.blocks()[block_id];
+    REQUIRE(block.external_boundaries().size() ==
+            expected_external_boundary_conditions[block_id].size());
+    for (const auto& [direction, expected_bc_ptr] :
+         expected_external_boundary_conditions[block_id]) {
+      CAPTURE(direction);
+      REQUIRE(block.external_boundary_conditions().count(direction) == 1);
+      REQUIRE(block.external_boundary_conditions().at(direction) != nullptr);
+      const auto& bc =
+          dynamic_cast<const TestHelpers::domain::BoundaryConditions::
+                           TestBoundaryCondition<3>&>(
+              *block.external_boundary_conditions().at(direction));
+      const auto& expected_bc =
+          dynamic_cast<const TestHelpers::domain::BoundaryConditions::
+                           TestBoundaryCondition<3>&>(*expected_bc_ptr);
+      CHECK(bc.direction() == expected_bc.direction());
+      CHECK(bc.block_id() == expected_bc.block_id());
+    }
+  }
 
   TestHelpers::domain::creators::test_functions_of_time(
       binary_compact_object, expected_functions_of_time);
@@ -83,52 +156,156 @@ void test_connectivity() {
   // Options for outer sphere
   constexpr size_t addition_to_outer_layer_radial_refinement_level = 3;
 
-  for (const bool excise_interiorA : {true, false}) {
-    for (const bool excise_interiorB : {true, false}) {
-      for (const bool use_logarithmic_map_outer_spherical_shell :
-           {true, false}) {
-        const domain::creators::BinaryCompactObject binary_compact_object{
-            inner_radius_objectA,
-            outer_radius_objectA,
-            xcoord_objectA,
-            excise_interiorA,
-            inner_radius_objectB,
-            outer_radius_objectB,
-            xcoord_objectB,
-            excise_interiorB,
-            radius_enveloping_cube,
-            radius_enveloping_sphere,
-            refinement,
-            grid_points,
-            use_projective_map,
-            use_logarithmic_map_outer_spherical_shell,
-            addition_to_outer_layer_radial_refinement_level};
-        test_binary_compact_object_construction(binary_compact_object);
+  for (const bool with_boundary_conditions : {true, false}) {
+    CAPTURE(with_boundary_conditions);
+    for (const bool excise_interiorA : {true, false}) {
+      CAPTURE(excise_interiorA);
+      for (const bool excise_interiorB : {true, false}) {
+        CAPTURE(excise_interiorB);
+        for (const bool use_logarithmic_map_outer_spherical_shell :
+             {true, false}) {
+          CAPTURE(use_logarithmic_map_outer_spherical_shell);
+          const domain::creators::BinaryCompactObject binary_compact_object{
+              inner_radius_objectA,
+              outer_radius_objectA,
+              xcoord_objectA,
+              excise_interiorA,
+              inner_radius_objectB,
+              outer_radius_objectB,
+              xcoord_objectB,
+              excise_interiorB,
+              radius_enveloping_cube,
+              radius_enveloping_sphere,
+              refinement,
+              grid_points,
+              use_projective_map,
+              use_logarithmic_map_outer_spherical_shell,
+              addition_to_outer_layer_radial_refinement_level,
+              false,
+              0,
+              false,
+              0,
+              nullptr,
+              with_boundary_conditions
+                  ? (excise_interiorA or excise_interiorB
+                         ? create_inner_boundary_condition()
+                         : std::make_unique<
+                               TestHelpers::domain::BoundaryConditions::
+                                   TestNoneBoundaryCondition<3>>())
+                  : nullptr,
+              with_boundary_conditions ? create_outer_boundary_condition()
+                                       : nullptr};
+          test_binary_compact_object_construction(
+              binary_compact_object,
+              std::numeric_limits<double>::signaling_NaN(), {}, {},
+              with_boundary_conditions ? create_boundary_conditions(
+                                             excise_interiorA, excise_interiorB)
+                                       : BoundaryCondVector{});
 
-        // Also check whether the radius of the inner boundary of Layer 5 is
-        // chosen correctly.
-        // Compute the radius of a point in the grid frame on this boundary.
-        // Block 44 is one block whose -zeta face is on this boundary.
-        const auto map{binary_compact_object.create_domain()
-                           .blocks()[44]
-                           .stationary_map()
-                           .get_clone()};
-        tnsr::I<double, 3, Frame::Logical> logical_point(
-            std::array<double, 3>{{0.0, 0.0, -1.0}});
-        const double layer_5_inner_radius =
-            get(magnitude(std::move(map)->operator()(logical_point)));
-        // The number of radial divisions in layers 4 and 5, excluding those
-        // resulting from InitialRefinement > 0.
-        const auto radial_divisions_in_outer_layers = static_cast<double>(
-            pow(2, addition_to_outer_layer_radial_refinement_level) + 1);
-        if (use_logarithmic_map_outer_spherical_shell) {
-          CHECK(layer_5_inner_radius / radius_enveloping_cube ==
-                approx(pow(radius_enveloping_sphere / radius_enveloping_cube,
-                           1.0 / radial_divisions_in_outer_layers)));
-        } else {
-          CHECK(layer_5_inner_radius - radius_enveloping_cube ==
-                approx((radius_enveloping_sphere - radius_enveloping_cube) /
-                       radial_divisions_in_outer_layers));
+          // Also check whether the radius of the inner boundary of Layer 5 is
+          // chosen correctly.
+          // Compute the radius of a point in the grid frame on this boundary.
+          // Block 44 is one block whose -zeta face is on this boundary.
+          const auto map{binary_compact_object.create_domain()
+                             .blocks()[44]
+                             .stationary_map()
+                             .get_clone()};
+          tnsr::I<double, 3, Frame::Logical> logical_point(
+              std::array<double, 3>{{0.0, 0.0, -1.0}});
+          const double layer_5_inner_radius =
+              get(magnitude(std::move(map)->operator()(logical_point)));
+          // The number of radial divisions in layers 4 and 5, excluding those
+          // resulting from InitialRefinement > 0.
+          const auto radial_divisions_in_outer_layers = static_cast<double>(
+              pow(2, addition_to_outer_layer_radial_refinement_level) + 1);
+          if (use_logarithmic_map_outer_spherical_shell) {
+            CHECK(layer_5_inner_radius / radius_enveloping_cube ==
+                  approx(pow(radius_enveloping_sphere / radius_enveloping_cube,
+                             1.0 / radial_divisions_in_outer_layers)));
+          } else {
+            CHECK(layer_5_inner_radius - radius_enveloping_cube ==
+                  approx((radius_enveloping_sphere - radius_enveloping_cube) /
+                         radial_divisions_in_outer_layers));
+          }
+          if (with_boundary_conditions) {
+            CHECK_THROWS_WITH(
+                domain::creators::BinaryCompactObject(
+                    inner_radius_objectA, outer_radius_objectA, xcoord_objectA,
+                    excise_interiorA, inner_radius_objectB,
+                    outer_radius_objectB, xcoord_objectB, excise_interiorB,
+                    radius_enveloping_cube, radius_enveloping_sphere,
+                    refinement, grid_points, use_projective_map,
+                    use_logarithmic_map_outer_spherical_shell,
+                    addition_to_outer_layer_radial_refinement_level, false, 0,
+                    false, 0, nullptr,
+                    excise_interiorA or excise_interiorB
+                        ? create_inner_boundary_condition()
+                        : std::make_unique<
+                              TestHelpers::domain::BoundaryConditions::
+                                  TestNoneBoundaryCondition<3>>(),
+                    std::make_unique<TestHelpers::domain::BoundaryConditions::
+                                         TestPeriodicBoundaryCondition<3>>(),
+                    Options::Context{false, {}, 1, 1}),
+                Catch::Matchers::Contains("Cannot have periodic boundary "
+                                          "conditions with a binary domain"));
+            if (excise_interiorA or excise_interiorB) {
+              CHECK_THROWS_WITH(
+                  domain::creators::BinaryCompactObject(
+                      inner_radius_objectA, outer_radius_objectA,
+                      xcoord_objectA, excise_interiorA, inner_radius_objectB,
+                      outer_radius_objectB, xcoord_objectB, excise_interiorB,
+                      radius_enveloping_cube, radius_enveloping_sphere,
+                      refinement, grid_points, use_projective_map,
+                      use_logarithmic_map_outer_spherical_shell,
+                      addition_to_outer_layer_radial_refinement_level, false, 0,
+                      false, 0, nullptr,
+                      std::make_unique<TestHelpers::domain::BoundaryConditions::
+                                           TestPeriodicBoundaryCondition<3>>(),
+                      create_outer_boundary_condition(),
+                      Options::Context{false, {}, 1, 1}),
+                  Catch::Matchers::Contains("Cannot have periodic boundary "
+                                            "conditions with a binary domain"));
+            }
+            CHECK_THROWS_WITH(
+                domain::creators::BinaryCompactObject(
+                    inner_radius_objectA, outer_radius_objectA, xcoord_objectA,
+                    excise_interiorA, inner_radius_objectB,
+                    outer_radius_objectB, xcoord_objectB, excise_interiorB,
+                    radius_enveloping_cube, radius_enveloping_sphere,
+                    refinement, grid_points, use_projective_map,
+                    use_logarithmic_map_outer_spherical_shell,
+                    addition_to_outer_layer_radial_refinement_level, false, 0,
+                    false, 0, nullptr,
+                    excise_interiorA or excise_interiorB
+                        ? create_inner_boundary_condition()
+                        : std::make_unique<
+                              TestHelpers::domain::BoundaryConditions::
+                                  TestNoneBoundaryCondition<3>>(),
+                    nullptr, Options::Context{false, {}, 1, 1}),
+                Catch::Matchers::Contains(
+                    "Must specify either both inner and outer boundary "
+                    "conditions or neither."));
+            CHECK_THROWS_WITH(
+                domain::creators::BinaryCompactObject(
+                    inner_radius_objectA, outer_radius_objectA, xcoord_objectA,
+                    excise_interiorA, inner_radius_objectB,
+                    outer_radius_objectB, xcoord_objectB, excise_interiorB,
+                    radius_enveloping_cube, radius_enveloping_sphere,
+                    refinement, grid_points, use_projective_map,
+                    use_logarithmic_map_outer_spherical_shell,
+                    addition_to_outer_layer_radial_refinement_level, false, 0,
+                    false, 0, nullptr, nullptr,
+                    create_outer_boundary_condition(),
+                    Options::Context{false, {}, 1, 1}),
+                Catch::Matchers::Contains(
+                    excise_interiorA or excise_interiorB
+                        ? std::string{"Must specify either both inner and "
+                                      "outer boundary "
+                                      "conditions or neither."}
+                        : std::string{"Inner boundary condition must be None "
+                                      "if ExciseInteriorA and ExciseInteriorB "
+                                      "are both false"}));
+          }
         }
       }
     }
@@ -142,7 +319,8 @@ std::string create_option_string(const bool excise_A, const bool excise_B,
                                  const bool use_logarithmic_map_AB,
                                  const size_t additional_refinement_outer,
                                  const size_t additional_refinement_A,
-                                 const size_t additional_refinement_B) {
+                                 const size_t additional_refinement_B,
+                                 const bool add_boundary_condition) {
   const std::string time_dependence{
       add_time_dependence
           ? "  TimeDependence:\n"
@@ -153,6 +331,20 @@ std::string create_option_string(const bool excise_A, const bool excise_B,
             "      FunctionOfTimeNames: [TranslationX, TranslationY, "
             "TranslationZ]\n"
           : "  TimeDependence: None\n"};
+  const std::string boundary_conditions{
+      add_boundary_condition
+          ? std::string{"  BoundaryConditions:\n"
+                        "    InnerBoundary:\n" +
+                        std::string{excise_A or excise_B
+                                        ? "      TestBoundaryCondition:\n"
+                                          "        Direction: lower-zeta\n"
+                                          "        BlockId: 50\n"
+                                        : "      None:\n"} +
+                        "    OuterBoundary:\n"
+                        "      TestBoundaryCondition:\n"
+                        "        Direction: upper-zeta\n"
+                        "        BlockId: 50\n"}
+          : ""};
   return "BinaryCompactObject:\n"
          "  InnerRadiusObjectA: 0.2\n"
          "  OuterRadiusObjectA: 1.0\n"
@@ -185,15 +377,26 @@ std::string create_option_string(const bool excise_A, const bool excise_B,
          stringize(use_logarithmic_map_AB) +
          "\n"
          "  AdditionToObjectBRadialRefinementLevel: " +
-         std::to_string(additional_refinement_B) + "\n" + time_dependence;
+         std::to_string(additional_refinement_B) + "\n" + time_dependence +
+         boundary_conditions;
 }
 
-void test_bbh_time_dependent_factory() {
-  const auto binary_compact_object = TestHelpers::test_factory_creation<
-      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
-      TestHelpers::domain::BoundaryConditions::
-          MetavariablesWithoutBoundaryConditions<3>>(
-      create_option_string(true, true, true, false, 0, 0, 0));
+void test_bbh_time_dependent_factory(const bool with_boundary_conditions) {
+  const auto binary_compact_object = [&with_boundary_conditions]() {
+    if (with_boundary_conditions) {
+      return TestHelpers::test_factory_creation<
+          DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+          TestHelpers::domain::BoundaryConditions::
+              MetavariablesWithBoundaryConditions<3>>(create_option_string(
+          true, true, true, false, 0, 0, 0, with_boundary_conditions));
+    } else {
+      return TestHelpers::test_factory_creation<
+          DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+          TestHelpers::domain::BoundaryConditions::
+              MetavariablesWithoutBoundaryConditions<3>>(create_option_string(
+          true, true, true, false, 0, 0, 0, with_boundary_conditions));
+    }
+  }();
   const std::array<double, 4> times_to_check{{0.0, 4.4, 7.8}};
 
   constexpr double initial_time = 0.0;
@@ -245,34 +448,62 @@ void test_bbh_time_dependent_factory() {
     test_binary_compact_object_construction(
         dynamic_cast<const domain::creators::BinaryCompactObject&>(
             *binary_compact_object),
-        time, functions_of_time, expected_functions_of_time);
+        time, functions_of_time, expected_functions_of_time,
+        with_boundary_conditions ? create_boundary_conditions(true, true)
+                                 : BoundaryCondVector{});
   }
 }
 
 void test_binary_factory() {
-  const auto check_impl = [](const std::string& opt_string) {
-    const auto binary_compact_object = TestHelpers::test_factory_creation<
-        DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
-        TestHelpers::domain::BoundaryConditions::
-            MetavariablesWithoutBoundaryConditions<3>>(opt_string);
+  const auto check_impl = [](const std::string& opt_string,
+                             const bool with_boundary_conditions) {
+    const auto binary_compact_object = [&opt_string,
+                                        &with_boundary_conditions]() {
+      if (with_boundary_conditions) {
+        return TestHelpers::test_factory_creation<
+            DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+            TestHelpers::domain::BoundaryConditions::
+                MetavariablesWithBoundaryConditions<3>>(opt_string);
+      } else {
+        return TestHelpers::test_factory_creation<
+            DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+            TestHelpers::domain::BoundaryConditions::
+                MetavariablesWithoutBoundaryConditions<3>>(opt_string);
+      }
+    }();
     test_binary_compact_object_construction(
         dynamic_cast<const domain::creators::BinaryCompactObject&>(
             *binary_compact_object));
   };
-  check_impl(create_option_string(true, true, false, false, 2, 0, 2));
-  check_impl(create_option_string(true, true, false, true, 3, 3, 0));
-  check_impl(create_option_string(true, true, false, false, 0, 0, 0));
-  check_impl(create_option_string(false, false, false, false, 0, 0, 0));
-  check_impl(create_option_string(true, false, false, false, 0, 0, 0));
-  check_impl(create_option_string(false, true, false, false, 0, 0, 0));
+  for (const bool with_boundary_conds : {true, false}) {
+    check_impl(create_option_string(true, true, false, false, 2, 0, 2,
+                                    with_boundary_conds),
+               with_boundary_conds);
+    check_impl(create_option_string(true, true, false, true, 3, 3, 0,
+                                    with_boundary_conds),
+               with_boundary_conds);
+    check_impl(create_option_string(true, true, false, false, 0, 0, 0,
+                                    with_boundary_conds),
+               with_boundary_conds);
+    check_impl(create_option_string(false, false, false, false, 0, 0, 0,
+                                    with_boundary_conds),
+               with_boundary_conds);
+    check_impl(create_option_string(true, false, false, false, 0, 0, 0,
+                                    with_boundary_conds),
+               with_boundary_conds);
+    check_impl(create_option_string(false, true, false, false, 0, 0, 0,
+                                    with_boundary_conds),
+               with_boundary_conds);
+  }
 }
 }  // namespace
 
-// [[Timeout, 6]]
+// [[Timeout, 15]]
 SPECTRE_TEST_CASE("Unit.Domain.Creators.BinaryCompactObject.FactoryTests",
                   "[Domain][Unit]") {
   test_connectivity();
-  test_bbh_time_dependent_factory();
+  test_bbh_time_dependent_factory(true);
+  test_bbh_time_dependent_factory(false);
   test_binary_factory();
 }
 

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -117,8 +117,8 @@ void test_connectivity() {
                              .get_clone()};
           tnsr::I<double, 3, Frame::Logical> logical_point(
               std::array<double, 3>{{0.0, 0.0, -1.0}});
-          const double layer_5_inner_radius = get(
-              magnitude(std::move(map)->operator()(logical_point)));
+          const double layer_5_inner_radius =
+              get(magnitude(std::move(map)->operator()(logical_point)));
           // The number of radial divisions in layers 4 and 5, excluding those
           // resulting from InitialRefinement > 0.
           const auto radial_divisions_in_outer_layers = static_cast<double>(
@@ -134,9 +134,10 @@ void test_connectivity() {
           }
         }
       }
+    }
   }
 }
-}
+
 void test_bbh_time_dependent_factory() {
   const auto binary_compact_object = TestHelpers::test_factory_creation<
       DomainCreator<3>, domain::OptionTags::DomainCreator<3>,


### PR DESCRIPTION
## Proposed changes

- Quite a bit of cleanup and simplifications in the tests. This was largely motivated by me wanting to make adding the boundary conditions easier for myself
- Remove the equiangular option since the resulting domain is incorrect
- Add boundary conditions to the binary domain
- Some clang-tidy stuff, yay

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
