### PR TITLE
Boundary conditions for Burgers

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeHelpers.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeHelpers.hpp
@@ -94,4 +94,41 @@ struct get_primitive_vars_tags_from_system_impl<System, false> {
 template <typename System>
 using get_primitive_vars_tags_from_system =
     typename get_primitive_vars_tags_from_system_impl<System>::type;
+
+template <typename BoundaryCondition, typename = std::void_t<>>
+struct get_dt_vars_from_boundary_condition_impl {
+  using type = tmpl::list<>;
+};
+
+template <typename BoundaryCondition>
+struct get_dt_vars_from_boundary_condition_impl<
+    BoundaryCondition,
+    std::void_t<typename BoundaryCondition::dg_interior_dt_vars_tags>> {
+  using type = typename BoundaryCondition::dg_interior_dt_vars_tags;
+};
+
+/// Returns the `dg_interior_dt_vars_tags` if the boundary condition specifies
+/// them, otherwise returns an empty list.
+template <typename BoundaryCondition>
+using get_dt_vars_from_boundary_condition =
+    typename get_dt_vars_from_boundary_condition_impl<BoundaryCondition>::type;
+
+template <typename BoundaryCondition, typename = std::void_t<>>
+struct get_deriv_vars_from_boundary_condition_impl {
+  using type = tmpl::list<>;
+};
+
+template <typename BoundaryCondition>
+struct get_deriv_vars_from_boundary_condition_impl<
+    BoundaryCondition,
+    std::void_t<typename BoundaryCondition::dg_interior_deriv_vars_tags>> {
+  using type = typename BoundaryCondition::dg_interior_deriv_vars_tags;
+};
+
+/// Returns the `dg_interior_deriv_vars_tags` if the boundary condition
+/// specifies them, otherwise returns an empty list.
+template <typename BoundaryCondition>
+using get_deriv_vars_from_boundary_condition =
+    typename get_deriv_vars_from_boundary_condition_impl<
+        BoundaryCondition>::type;
 }  // namespace evolution::dg::Actions::detail

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.cpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.cpp
@@ -1,0 +1,17 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.hpp"
+
+#include <pup.h>
+
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+
+namespace Burgers::BoundaryConditions {
+BoundaryCondition::BoundaryCondition(CkMigrateMessage* const msg) noexcept
+    : domain::BoundaryConditions::BoundaryCondition(msg) {}
+
+void BoundaryCondition::pup(PUP::er& p) {
+  domain::BoundaryConditions::BoundaryCondition::pup(p);
+}
+}  // namespace Burgers::BoundaryConditions

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.hpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.hpp
@@ -6,6 +6,7 @@
 #include <pup.h>
 
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -21,7 +22,9 @@ namespace Burgers::BoundaryConditions {
 /// \brief The base class off of which all boundary conditions must inherit
 class BoundaryCondition : public domain::BoundaryConditions::BoundaryCondition {
  public:
-  using creatable_classes = tmpl::list<Dirichlet, DirichletAnalytic, Outflow>;
+  using creatable_classes =
+      tmpl::list<Dirichlet, DirichletAnalytic, Outflow,
+                 domain::BoundaryConditions::Periodic<BoundaryCondition>>;
 
   BoundaryCondition() = default;
   BoundaryCondition(BoundaryCondition&&) noexcept = default;

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.hpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.hpp
@@ -10,6 +10,7 @@
 
 /// \cond
 namespace Burgers::BoundaryConditions {
+class DirichletAnalytic;
 class Outflow;
 }  // namespace Burgers::BoundaryConditions
 /// \endcond
@@ -19,7 +20,7 @@ namespace Burgers::BoundaryConditions {
 /// \brief The base class off of which all boundary conditions must inherit
 class BoundaryCondition : public domain::BoundaryConditions::BoundaryCondition {
  public:
-  using creatable_classes = tmpl::list<Outflow>;
+  using creatable_classes = tmpl::list<DirichletAnalytic, Outflow>;
 
   BoundaryCondition() = default;
   BoundaryCondition(BoundaryCondition&&) noexcept = default;

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.hpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.hpp
@@ -1,0 +1,35 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pup.h>
+
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Burgers::BoundaryConditions {
+class Outflow;
+}  // namespace Burgers::BoundaryConditions
+/// \endcond
+
+/// \brief Boundary conditions for the Burgers system
+namespace Burgers::BoundaryConditions {
+/// \brief The base class off of which all boundary conditions must inherit
+class BoundaryCondition : public domain::BoundaryConditions::BoundaryCondition {
+ public:
+  using creatable_classes = tmpl::list<Outflow>;
+
+  BoundaryCondition() = default;
+  BoundaryCondition(BoundaryCondition&&) noexcept = default;
+  BoundaryCondition& operator=(BoundaryCondition&&) noexcept = default;
+  BoundaryCondition(const BoundaryCondition&) = default;
+  BoundaryCondition& operator=(const BoundaryCondition&) = default;
+  ~BoundaryCondition() override = default;
+
+  explicit BoundaryCondition(CkMigrateMessage* msg) noexcept;
+
+  void pup(PUP::er& p) override;
+};
+}  // namespace Burgers::BoundaryConditions

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.hpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.hpp
@@ -10,6 +10,7 @@
 
 /// \cond
 namespace Burgers::BoundaryConditions {
+class Dirichlet;
 class DirichletAnalytic;
 class Outflow;
 }  // namespace Burgers::BoundaryConditions
@@ -20,7 +21,7 @@ namespace Burgers::BoundaryConditions {
 /// \brief The base class off of which all boundary conditions must inherit
 class BoundaryCondition : public domain::BoundaryConditions::BoundaryCondition {
  public:
-  using creatable_classes = tmpl::list<DirichletAnalytic, Outflow>;
+  using creatable_classes = tmpl::list<Dirichlet, DirichletAnalytic, Outflow>;
 
   BoundaryCondition() = default;
   BoundaryCondition(BoundaryCondition&&) noexcept = default;

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/CMakeLists.txt
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_sources(
+  Burgers
+  PRIVATE
+  BoundaryCondition.cpp
+  Outflow.cpp
+  RegisterDerivedWithCharm.cpp
+  )
+
+spectre_target_headers(
+  Burgers
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  BoundaryCondition.hpp
+  Factory.hpp
+  Outflow.hpp
+  RegisterDerivedWithCharm.hpp
+  )

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/CMakeLists.txt
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/CMakeLists.txt
@@ -5,6 +5,7 @@ spectre_target_sources(
   Burgers
   PRIVATE
   BoundaryCondition.cpp
+  DirichletAnalytic.cpp
   Outflow.cpp
   RegisterDerivedWithCharm.cpp
   )
@@ -14,6 +15,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   BoundaryCondition.hpp
+  DirichletAnalytic.hpp
   Factory.hpp
   Outflow.hpp
   RegisterDerivedWithCharm.hpp

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/CMakeLists.txt
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/CMakeLists.txt
@@ -5,6 +5,7 @@ spectre_target_sources(
   Burgers
   PRIVATE
   BoundaryCondition.cpp
+  Dirichlet.cpp
   DirichletAnalytic.cpp
   Outflow.cpp
   RegisterDerivedWithCharm.cpp
@@ -15,6 +16,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   BoundaryCondition.hpp
+  Dirichlet.hpp
   DirichletAnalytic.hpp
   Factory.hpp
   Outflow.hpp

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/Dirichlet.cpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/Dirichlet.cpp
@@ -1,0 +1,48 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Burgers/BoundaryConditions/Dirichlet.hpp"
+
+#include <memory>
+#include <optional>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/Burgers/Fluxes.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+namespace Burgers::BoundaryConditions {
+Dirichlet::Dirichlet(const double u_value) noexcept : u_value_(u_value) {}
+
+Dirichlet::Dirichlet(CkMigrateMessage* const msg) noexcept
+    : BoundaryCondition(msg) {}
+
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+Dirichlet::get_clone() const noexcept {
+  return std::make_unique<Dirichlet>(*this);
+}
+
+void Dirichlet::pup(PUP::er& p) {
+  BoundaryCondition::pup(p);
+  p | u_value_;
+}
+
+std::optional<std::string> Dirichlet::dg_ghost(
+    const gsl::not_null<Scalar<DataVector>*> u,
+    const gsl::not_null<tnsr::I<DataVector, 1, Frame::Inertial>*> flux_u,
+    const std::optional<
+        tnsr::I<DataVector, 1, Frame::Inertial>>& /*face_mesh_velocity*/,
+    const tnsr::i<DataVector, 1, Frame::Inertial>& /*normal_covector*/)
+    const noexcept {
+  get(*u) = u_value_;
+  Burgers::Fluxes::apply(flux_u, *u);
+  return {};
+}
+
+// NOLINTNEXTLINE
+PUP::able::PUP_ID Dirichlet::my_PUP_ID = 0;
+}  // namespace Burgers::BoundaryConditions
+/// \endcond

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/Dirichlet.hpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/Dirichlet.hpp
@@ -1,0 +1,91 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/Burgers/Tags.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Burgers::BoundaryConditions {
+class Dirichlet;
+}  // namespace Burgers::boundary_conditions
+class DataVector;
+namespace PUP {
+class er;
+}  // namespace PUP
+template <typename>
+class Variables;
+/// \endcond
+
+namespace Burgers::BoundaryConditions {
+class Dirichlet final : public BoundaryCondition {
+ private:
+  using flux_tag =
+      ::Tags::Flux<Burgers::Tags::U, tmpl::size_t<1>, Frame::Inertial>;
+
+ public:
+  struct U {
+    using type = double;
+    static constexpr Options::String help{"The value for U on the boundary"};
+  };
+
+  using options = tmpl::list<U>;
+  static constexpr Options::String help{
+      "Dirichlet boundary condition setting the value of U to "
+      "a time-independent constant."};
+
+  Dirichlet(double u_value) noexcept;
+
+  Dirichlet() = default;
+  Dirichlet(Dirichlet&&) noexcept = default;
+  Dirichlet& operator=(Dirichlet&&) noexcept = default;
+  Dirichlet(const Dirichlet&) = default;
+  Dirichlet& operator=(const Dirichlet&) = default;
+  ~Dirichlet() override = default;
+
+  explicit Dirichlet(CkMigrateMessage* msg) noexcept;
+
+  WRAPPED_PUPable_decl_base_template(BoundaryCondition, Dirichlet);
+
+  auto get_clone() const noexcept -> std::unique_ptr<
+      domain::BoundaryConditions::BoundaryCondition> override;
+
+  static constexpr evolution::BoundaryConditions::Type bc_type =
+      evolution::BoundaryConditions::Type::Ghost;
+
+  void pup(PUP::er& p) override;
+
+  using dg_interior_evolved_variables_tags = tmpl::list<>;
+  using dg_interior_temporary_tags = tmpl::list<>;
+  using dg_gridless_tags = tmpl::list<>;
+
+  std::optional<std::string> dg_ghost(
+      gsl::not_null<Scalar<DataVector>*> u,
+      gsl::not_null<tnsr::I<DataVector, 1, Frame::Inertial>*> flux_u,
+      const std::optional<
+          tnsr::I<DataVector, 1, Frame::Inertial>>& /*face_mesh_velocity*/,
+      const tnsr::i<DataVector, 1, Frame::Inertial>& /*normal_covector*/)
+      const noexcept;
+
+ private:
+  void dg_ghost_impl(
+      gsl::not_null<tnsr::I<DataVector, 1, Frame::Inertial>*> flux,
+      gsl::not_null<Scalar<DataVector>*> u) const noexcept;
+
+  double u_value_ = std::numeric_limits<double>::signaling_NaN();
+};
+}  // namespace Burgers::BoundaryConditions

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/DirichletAnalytic.cpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/DirichletAnalytic.cpp
@@ -1,0 +1,35 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Burgers/BoundaryConditions/DirichletAnalytic.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/Burgers/Fluxes.hpp"
+
+/// \cond
+namespace Burgers::BoundaryConditions {
+DirichletAnalytic::DirichletAnalytic(CkMigrateMessage* const msg) noexcept
+    : BoundaryCondition(msg) {}
+
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+DirichletAnalytic::get_clone() const noexcept {
+  return std::make_unique<DirichletAnalytic>(*this);
+}
+
+void DirichletAnalytic::pup(PUP::er& p) { BoundaryCondition::pup(p); }
+
+void DirichletAnalytic::flux_impl(
+    const gsl::not_null<tnsr::I<DataVector, 1, Frame::Inertial>*> flux,
+    const Scalar<DataVector>& u_analytic) noexcept {
+  Burgers::Fluxes::apply(flux, u_analytic);
+}
+
+// NOLINTNEXTLINE
+PUP::able::PUP_ID DirichletAnalytic::my_PUP_ID = 0;
+/// \endcond
+}  // namespace Burgers::BoundaryConditions

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/DirichletAnalytic.hpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/DirichletAnalytic.hpp
@@ -1,0 +1,100 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <pup.h>
+#include <string>
+#include <type_traits>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/Burgers/Tags.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/AnalyticData/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace domain::Tags {
+template <size_t Dim, typename Frame>
+struct Coordinates;
+}  // namespace domain::Tags
+/// \endcond
+
+namespace Burgers::BoundaryConditions {
+class DirichletAnalytic final : public BoundaryCondition {
+ private:
+  using flux_tag =
+      ::Tags::Flux<Burgers::Tags::U, tmpl::size_t<1>, Frame::Inertial>;
+
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help{
+      "DirichletAnalytic boundary conditions setting the value of U to "
+      "the analytic solution or analytic data."};
+  static std::string name() noexcept { return "DirichletAnalytic"; }
+
+  DirichletAnalytic() = default;
+  DirichletAnalytic(DirichletAnalytic&&) noexcept = default;
+  DirichletAnalytic& operator=(DirichletAnalytic&&) noexcept = default;
+  DirichletAnalytic(const DirichletAnalytic&) = default;
+  DirichletAnalytic& operator=(const DirichletAnalytic&) = default;
+  ~DirichletAnalytic() override = default;
+
+  explicit DirichletAnalytic(CkMigrateMessage* msg) noexcept;
+
+  WRAPPED_PUPable_decl_base_template(
+      domain::BoundaryConditions::BoundaryCondition, DirichletAnalytic);
+
+  auto get_clone() const noexcept -> std::unique_ptr<
+      domain::BoundaryConditions::BoundaryCondition> override;
+
+  static constexpr evolution::BoundaryConditions::Type bc_type =
+      evolution::BoundaryConditions::Type::Ghost;
+
+  void pup(PUP::er& p) override;
+
+  using dg_interior_evolved_variables_tags = tmpl::list<>;
+  using dg_interior_temporary_tags =
+      tmpl::list<domain::Tags::Coordinates<1, Frame::Inertial>>;
+  using dg_gridless_tags =
+      tmpl::list<::Tags::Time, ::Tags::AnalyticSolutionOrData>;
+
+  template <typename AnalyticSolutionOrData>
+  std::optional<std::string> dg_ghost(
+      const gsl::not_null<Scalar<DataVector>*> u,
+      const gsl::not_null<tnsr::I<DataVector, 1, Frame::Inertial>*> flux_u,
+      const std::optional<
+          tnsr::I<DataVector, 1, Frame::Inertial>>& /*face_mesh_velocity*/,
+      const tnsr::i<DataVector, 1, Frame::Inertial>& /*normal_covector*/,
+      const tnsr::I<DataVector, 1, Frame::Inertial>& coords,
+      [[maybe_unused]] const double time,
+      const AnalyticSolutionOrData& analytic_solution_or_data) const noexcept {
+    if constexpr (std::is_base_of_v<MarkAsAnalyticSolution,
+                                    AnalyticSolutionOrData>) {
+      *u = get<Burgers::Tags::U>(analytic_solution_or_data.variables(
+          coords, time, tmpl::list<Burgers::Tags::U>{}));
+    } else {
+      *u = get<Burgers::Tags::U>(analytic_solution_or_data.variables(
+          coords, tmpl::list<Burgers::Tags::U>{}));
+    }
+    flux_impl(flux_u, *u);
+    return {};
+  }
+
+ private:
+  static void flux_impl(
+      gsl::not_null<tnsr::I<DataVector, 1, Frame::Inertial>*> flux,
+      const Scalar<DataVector>& u_analytic) noexcept;
+};
+}  // namespace Burgers::BoundaryConditions

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/Factory.hpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/Factory.hpp
@@ -4,5 +4,6 @@
 #pragma once
 
 #include "Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/Burgers/BoundaryConditions/Dirichlet.hpp"
 #include "Evolution/Systems/Burgers/BoundaryConditions/DirichletAnalytic.hpp"
 #include "Evolution/Systems/Burgers/BoundaryConditions/Outflow.hpp"

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/Factory.hpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/Factory.hpp
@@ -1,0 +1,7 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/Burgers/BoundaryConditions/Outflow.hpp"

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/Factory.hpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/Factory.hpp
@@ -4,4 +4,5 @@
 #pragma once
 
 #include "Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/Burgers/BoundaryConditions/DirichletAnalytic.hpp"
 #include "Evolution/Systems/Burgers/BoundaryConditions/Outflow.hpp"

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/Outflow.cpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/Outflow.cpp
@@ -1,0 +1,52 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Burgers/BoundaryConditions/Outflow.hpp"
+
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/Burgers/Fluxes.hpp"
+#include "Utilities/MakeString.hpp"
+
+namespace Burgers::BoundaryConditions {
+Outflow::Outflow(CkMigrateMessage* const msg) noexcept
+    : BoundaryCondition(msg) {}
+
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+Outflow::get_clone() const noexcept {
+  return std::make_unique<Outflow>(*this);
+}
+
+void Outflow::pup(PUP::er& p) { BoundaryCondition::pup(p); }
+
+std::optional<std::string> Outflow::dg_outflow(
+    const std::optional<tnsr::I<DataVector, 1, Frame::Inertial>>&
+        face_mesh_velocity,
+    const tnsr::i<DataVector, 1, Frame::Inertial>&
+        outward_directed_normal_covector,
+    const Scalar<DataVector>& u) noexcept {
+  double min_speed = std::numeric_limits<double>::signaling_NaN();
+  if (face_mesh_velocity.has_value()) {
+    min_speed = min(get<0>(outward_directed_normal_covector) *
+                    (get(u) - get<0>(*face_mesh_velocity)));
+  } else {
+    min_speed = min(get<0>(outward_directed_normal_covector) * get(u));
+  }
+  if (min_speed < 0.0) {
+    return {MakeString{}
+            << "Outflow boundary condition violated with speed U ingoing: "
+            << min_speed << "\nU: " << u
+            << "\nn_i: " << outward_directed_normal_covector << "\n"};
+  }
+  return std::nullopt;
+}
+
+/// \cond
+// NOLINTNEXTLINE
+PUP::able::PUP_ID Outflow::my_PUP_ID = 0;
+/// \endcond
+}  // namespace Burgers::BoundaryConditions

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/Outflow.hpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/Outflow.hpp
@@ -1,0 +1,63 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <pup.h>
+#include <string>
+#include <type_traits>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/Burgers/Tags.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Burgers::BoundaryConditions {
+class Outflow final : public BoundaryCondition {
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help{
+      "Outflow boundary condition that only verifies the characteristic speeds "
+      "are all directed out of the domain."};
+  static std::string name() noexcept { return "Outflow"; }
+
+  Outflow() = default;
+  Outflow(Outflow&&) noexcept = default;
+  Outflow& operator=(Outflow&&) noexcept = default;
+  Outflow(const Outflow&) = default;
+  Outflow& operator=(const Outflow&) = default;
+  ~Outflow() override = default;
+
+  explicit Outflow(CkMigrateMessage* msg) noexcept;
+
+  WRAPPED_PUPable_decl_base_template(
+      domain::BoundaryConditions::BoundaryCondition, Outflow);
+
+  auto get_clone() const noexcept -> std::unique_ptr<
+      domain::BoundaryConditions::BoundaryCondition> override;
+
+  static constexpr evolution::BoundaryConditions::Type bc_type =
+      evolution::BoundaryConditions::Type::Outflow;
+
+  void pup(PUP::er& p) override;
+
+  using dg_interior_evolved_variables_tags = tmpl::list<Tags::U>;
+  using dg_interior_temporary_tags = tmpl::list<>;
+  using dg_gridless_tags = tmpl::list<>;
+
+  static std::optional<std::string> dg_outflow(
+      const std::optional<tnsr::I<DataVector, 1, Frame::Inertial>>&
+          face_mesh_velocity,
+      const tnsr::i<DataVector, 1, Frame::Inertial>&
+          outward_directed_normal_covector,
+      const Scalar<DataVector>& u) noexcept;
+};
+}  // namespace Burgers::BoundaryConditions

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/RegisterDerivedWithCharm.cpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/RegisterDerivedWithCharm.cpp
@@ -4,6 +4,7 @@
 #include "Evolution/Systems/Burgers/BoundaryConditions/RegisterDerivedWithCharm.hpp"
 
 #include "Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/Burgers/BoundaryConditions/Dirichlet.hpp"
 #include "Evolution/Systems/Burgers/BoundaryConditions/DirichletAnalytic.hpp"
 #include "Evolution/Systems/Burgers/BoundaryConditions/Outflow.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/RegisterDerivedWithCharm.cpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/RegisterDerivedWithCharm.cpp
@@ -4,6 +4,7 @@
 #include "Evolution/Systems/Burgers/BoundaryConditions/RegisterDerivedWithCharm.hpp"
 
 #include "Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/Burgers/BoundaryConditions/DirichletAnalytic.hpp"
 #include "Evolution/Systems/Burgers/BoundaryConditions/Outflow.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/RegisterDerivedWithCharm.cpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/RegisterDerivedWithCharm.cpp
@@ -1,0 +1,15 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Burgers/BoundaryConditions/RegisterDerivedWithCharm.hpp"
+
+#include "Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/Burgers/BoundaryConditions/Outflow.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+
+namespace Burgers::BoundaryConditions {
+void register_derived_with_charm() noexcept {
+  Parallel::register_classes_in_list<
+      typename BoundaryCondition::creatable_classes>();
+}
+}  // namespace Burgers::BoundaryConditions

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/RegisterDerivedWithCharm.hpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/RegisterDerivedWithCharm.hpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace Burgers::BoundaryConditions {
+void register_derived_with_charm() noexcept;
+}  // namespace Burgers::BoundaryConditions

--- a/src/Evolution/Systems/Burgers/CMakeLists.txt
+++ b/src/Evolution/Systems/Burgers/CMakeLists.txt
@@ -33,4 +33,5 @@ target_link_libraries(
   INTERFACE ErrorHandling
   )
 
+add_subdirectory(BoundaryConditions)
 add_subdirectory(BoundaryCorrections)

--- a/tests/Unit/Evolution/Systems/Burgers/BoundaryConditions/Dirichlet.py
+++ b/tests/Unit/Evolution/Systems/Burgers/BoundaryConditions/Dirichlet.py
@@ -1,0 +1,24 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def error(face_mesh_velocity, outward_directed_normal_covector):
+    return None
+
+
+def flux_1(face_mesh_velocity, outward_directed_normal_covector):
+    return np.asarray([0.5])
+
+
+def u_1(face_mesh_velocity, outward_directed_normal_covector):
+    return 1.0
+
+
+def flux_m1(face_mesh_velocity, outward_directed_normal_covector):
+    return np.asarray([0.5])
+
+
+def u_m1(face_mesh_velocity, outward_directed_normal_covector):
+    return -1.0

--- a/tests/Unit/Evolution/Systems/Burgers/BoundaryConditions/DirichletAnalytic.py
+++ b/tests/Unit/Evolution/Systems/Burgers/BoundaryConditions/DirichletAnalytic.py
@@ -1,0 +1,43 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def error_sinusoid(face_mesh_velocity, outward_directed_normal_covector,
+                   coords, time, ignored_argument_for_analytic_data):
+    return None
+
+
+def u_sinusoid(face_mesh_velocity, outward_directed_normal_covector, coords,
+               time, ignored_argument_for_analytic_data):
+    return np.sin(coords[0])
+
+
+def flux_sinusoid(face_mesh_velocity, outward_directed_normal_covector, coords,
+                  time, ignored_argument_for_analytic_data):
+    u = np.sin(coords[0])
+    return np.asarray([0.5 * u**2])
+
+
+def error_step(face_mesh_velocity, outward_directed_normal_covector, coords,
+               time, ignored_argument_for_analytic_data):
+    return None
+
+
+def u_step(face_mesh_velocity, outward_directed_normal_covector, coords, time,
+           analytic_soln_params):
+    current_shock_position = analytic_soln_params[2] + 0.5 * (
+        analytic_soln_params[0] + analytic_soln_params[1]) * time
+    if coords[0] - current_shock_position < 0.0:
+        return analytic_soln_params[0]
+    else:
+        return analytic_soln_params[1]
+
+
+def flux_step(face_mesh_velocity, outward_directed_normal_covector, coords,
+              time, analytic_soln_params):
+    return np.asarray([
+        0.5 * u_step(face_mesh_velocity, outward_directed_normal_covector,
+                     coords, time, analytic_soln_params)**2
+    ])

--- a/tests/Unit/Evolution/Systems/Burgers/BoundaryConditions/Outflow.py
+++ b/tests/Unit/Evolution/Systems/Burgers/BoundaryConditions/Outflow.py
@@ -1,0 +1,14 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def error(face_mesh_velocity, outward_directed_normal_covector, u):
+    speed = outward_directed_normal_covector[0] * u
+    if not face_mesh_velocity is None:
+        speed -= face_mesh_velocity[0] * outward_directed_normal_covector[0]
+
+    if speed < 0.0:
+        return "Outflow boundary condition violated with speed U ingoing:.*"
+    return None

--- a/tests/Unit/Evolution/Systems/Burgers/BoundaryConditions/Test_Dirichlet.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/BoundaryConditions/Test_Dirichlet.cpp
@@ -1,0 +1,55 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Index.hpp"
+#include "Evolution/Systems/Burgers/BoundaryConditions/Dirichlet.hpp"
+#include "Evolution/Systems/Burgers/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/Burgers/BoundaryCorrections/Rusanov.hpp"
+#include "Evolution/Systems/Burgers/System.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace helpers = TestHelpers::evolution::dg;
+
+SPECTRE_TEST_CASE("Unit.Burgers.BoundaryConditions.Dirichlet",
+                  "[Unit][Burgers]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/Burgers/BoundaryConditions/"};
+  MAKE_GENERATOR(gen);
+  helpers::test_boundary_condition_with_python<
+      Burgers::BoundaryConditions::Dirichlet,
+      Burgers::BoundaryConditions::BoundaryCondition, Burgers::System,
+      tmpl::list<Burgers::BoundaryCorrections::Rusanov>>(
+      make_not_null(&gen), "Dirichlet",
+      tuples::TaggedTuple<
+          helpers::Tags::PythonFunctionForErrorMessage<>,
+          helpers::Tags::PythonFunctionName<Burgers::Tags::U>,
+          helpers::Tags::PythonFunctionName<::Tags::Flux<
+              Burgers::Tags::U, tmpl::size_t<1>, Frame::Inertial>>>{
+          "error", "u_1", "flux_1"},
+      "Dirichlet:\n"
+      "  U: 1.0\n",
+      Index<0>{1}, db::DataBox<tmpl::list<>>{}, tuples::TaggedTuple<>{});
+
+  helpers::test_boundary_condition_with_python<
+      Burgers::BoundaryConditions::Dirichlet,
+      Burgers::BoundaryConditions::BoundaryCondition, Burgers::System,
+      tmpl::list<Burgers::BoundaryCorrections::Rusanov>>(
+      make_not_null(&gen), "Dirichlet",
+      tuples::TaggedTuple<
+          helpers::Tags::PythonFunctionForErrorMessage<>,
+          helpers::Tags::PythonFunctionName<Burgers::Tags::U>,
+          helpers::Tags::PythonFunctionName<::Tags::Flux<
+              Burgers::Tags::U, tmpl::size_t<1>, Frame::Inertial>>>{
+          "error", "u_m1", "flux_m1"},
+      "Dirichlet:\n"
+      "  U: -1.0\n",
+      Index<0>{1}, db::DataBox<tmpl::list<>>{}, tuples::TaggedTuple<>{});
+}

--- a/tests/Unit/Evolution/Systems/Burgers/BoundaryConditions/Test_DirichletAnalytic.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/BoundaryConditions/Test_DirichletAnalytic.cpp
@@ -1,0 +1,117 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Index.hpp"
+#include "Evolution/Systems/Burgers/BoundaryConditions/DirichletAnalytic.hpp"
+#include "Evolution/Systems/Burgers/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/Burgers/BoundaryCorrections/Rusanov.hpp"
+#include "Evolution/Systems/Burgers/System.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp"
+#include "PointwiseFunctions/AnalyticData/Burgers/Sinusoid.hpp"
+#include "PointwiseFunctions/AnalyticData/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Burgers/Step.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace helpers = TestHelpers::evolution::dg;
+
+namespace {
+struct ConvertSinusoid {
+  using unpacked_container = double;
+  using packed_container = Burgers::AnalyticData::Sinusoid;
+  using packed_type = double;
+
+  static inline unpacked_container unpack(
+      const packed_container /*packed*/,
+      const size_t /*grid_point_index*/) noexcept {
+    return 0.0;  // no parameter but we need some placeholder type
+  }
+
+  static inline void pack(const gsl::not_null<packed_container*> /*packed*/,
+                          const unpacked_container /*unpacked*/,
+                          const size_t /*grid_point_index*/) {
+    // no parameters but we need a placeholder function
+  }
+
+  static inline size_t get_size(const packed_container& /*packed*/) noexcept {
+    return 1;
+  }
+};
+
+struct ConvertStep {
+  using unpacked_container = std::array<double, 3>;
+  using packed_container = Burgers::Solutions::Step;
+  using packed_type = double;
+
+  static packed_container create_container() { return {2.0, 1.0, 0.5}; }
+
+  static inline unpacked_container unpack(
+      const packed_container /*packed*/,
+      const size_t /*grid_point_index*/) noexcept {
+    // No way of getting the args from the boundary condition.
+    return {{2.0, 1.0, 0.5}};
+  }
+
+  static inline void pack(const gsl::not_null<packed_container*> packed,
+                          const unpacked_container unpacked,
+                          const size_t /*grid_point_index*/) {
+    *packed = packed_container{unpacked[0], unpacked[1], unpacked[2]};
+  }
+
+  static inline size_t get_size(const packed_container& /*packed*/) noexcept {
+    return 1;
+  }
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Burgers.BoundaryConditions.DirichletAnalytic",
+                  "[Unit][Burgers]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/Burgers/BoundaryConditions/"};
+  MAKE_GENERATOR(gen);
+  const auto box_analytic_data = db::create<db::AddSimpleTags<
+      Tags::Time, Tags::AnalyticData<Burgers::AnalyticData::Sinusoid>>>(
+      0.4, Burgers::AnalyticData::Sinusoid{});
+
+  helpers::test_boundary_condition_with_python<
+      Burgers::BoundaryConditions::DirichletAnalytic,
+      Burgers::BoundaryConditions::BoundaryCondition, Burgers::System,
+      tmpl::list<Burgers::BoundaryCorrections::Rusanov>,
+      tmpl::list<ConvertSinusoid>>(
+      make_not_null(&gen), "DirichletAnalytic",
+      tuples::TaggedTuple<
+          helpers::Tags::PythonFunctionForErrorMessage<>,
+          helpers::Tags::PythonFunctionName<Burgers::Tags::U>,
+          helpers::Tags::PythonFunctionName<::Tags::Flux<
+              Burgers::Tags::U, tmpl::size_t<1>, Frame::Inertial>>>{
+          "error_sinusoid", "u_sinusoid", "flux_sinusoid"},
+      "DirichletAnalytic:\n", Index<0>{1}, box_analytic_data,
+      tuples::TaggedTuple<>{});
+
+  const auto box_analytic_soln = db::create<db::AddSimpleTags<
+      Tags::Time, Tags::AnalyticSolution<Burgers::Solutions::Step>>>(
+      0.5, ConvertStep::create_container());
+
+  helpers::test_boundary_condition_with_python<
+      Burgers::BoundaryConditions::DirichletAnalytic,
+      Burgers::BoundaryConditions::BoundaryCondition, Burgers::System,
+      tmpl::list<Burgers::BoundaryCorrections::Rusanov>,
+      tmpl::list<ConvertStep>>(
+      make_not_null(&gen), "DirichletAnalytic",
+      tuples::TaggedTuple<
+          helpers::Tags::PythonFunctionForErrorMessage<>,
+          helpers::Tags::PythonFunctionName<Burgers::Tags::U>,
+          helpers::Tags::PythonFunctionName<::Tags::Flux<
+              Burgers::Tags::U, tmpl::size_t<1>, Frame::Inertial>>>{
+          "error_step", "u_step", "flux_step"},
+      "DirichletAnalytic:\n", Index<0>{1}, box_analytic_soln,
+      tuples::TaggedTuple<>{});
+}

--- a/tests/Unit/Evolution/Systems/Burgers/BoundaryConditions/Test_Outflow.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/BoundaryConditions/Test_Outflow.cpp
@@ -1,0 +1,42 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Index.hpp"
+#include "Evolution/Systems/Burgers/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/Burgers/BoundaryConditions/Outflow.hpp"
+#include "Evolution/Systems/Burgers/BoundaryCorrections/Rusanov.hpp"
+#include "Evolution/Systems/Burgers/System.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace helpers = TestHelpers::evolution::dg;
+
+SPECTRE_TEST_CASE("Unit.Burgers.BoundaryConditions.Outflow",
+                  "[Unit][Burgers]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/Burgers/BoundaryConditions/"};
+  MAKE_GENERATOR(gen);
+  const std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+      boundary_condition = TestHelpers::test_factory_creation<
+          Burgers::BoundaryConditions::BoundaryCondition>("Outflow:\n");
+
+  helpers::test_boundary_condition_with_python<
+      Burgers::BoundaryConditions::Outflow,
+      Burgers::BoundaryConditions::BoundaryCondition, Burgers::System,
+      tmpl::list<Burgers::BoundaryCorrections::Rusanov>>(
+      make_not_null(&gen), "Outflow",
+      tuples::TaggedTuple<helpers::Tags::PythonFunctionForErrorMessage<>>{
+          "error"},
+      "Outflow:\n", Index<0>{1}, db::DataBox<tmpl::list<>>{},
+      tuples::TaggedTuple<>{});
+}

--- a/tests/Unit/Evolution/Systems/Burgers/BoundaryConditions/Test_Periodic.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/BoundaryConditions/Test_Periodic.cpp
@@ -1,0 +1,20 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Domain/BoundaryConditions/Periodic.hpp"
+#include "Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/Burgers/BoundaryConditions/Factory.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp"
+
+namespace helpers = TestHelpers::evolution::dg;
+
+SPECTRE_TEST_CASE("Unit.Burgers.BoundaryConditions.Periodic",
+                  "[Unit][Burgers]") {
+  helpers::test_periodic_condition<
+      domain::BoundaryConditions::Periodic<
+          Burgers::BoundaryConditions::BoundaryCondition>,
+      Burgers::BoundaryConditions::BoundaryCondition>("Periodic:\n");
+}

--- a/tests/Unit/Evolution/Systems/Burgers/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Burgers/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY Test_Burgers)
 
 set(LIBRARY_SOURCES
+  BoundaryConditions/Test_DirichletAnalytic.cpp
   BoundaryConditions/Test_Outflow.cpp
   BoundaryCorrections/Test_Hll.cpp
   BoundaryCorrections/Test_Rusanov.cpp

--- a/tests/Unit/Evolution/Systems/Burgers/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Burgers/CMakeLists.txt
@@ -1,9 +1,10 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-set(LIBRARY "Test_Burgers")
+set(LIBRARY Test_Burgers)
 
 set(LIBRARY_SOURCES
+  BoundaryConditions/Test_Outflow.cpp
   BoundaryCorrections/Test_Hll.cpp
   BoundaryCorrections/Test_Rusanov.cpp
   Test_Characteristics.cpp
@@ -16,5 +17,16 @@ add_test_library(
   ${LIBRARY}
   "Evolution/Systems/Burgers/"
   "${LIBRARY_SOURCES}"
-  "Burgers"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  Burgers
+  BurgersAnalyticData
+  BurgersSolutions
+  DataStructures
+  Time
+  Utilities
   )

--- a/tests/Unit/Evolution/Systems/Burgers/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Burgers/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   BoundaryConditions/Test_Dirichlet.cpp
   BoundaryConditions/Test_DirichletAnalytic.cpp
   BoundaryConditions/Test_Outflow.cpp
+  BoundaryConditions/Test_Periodic.cpp
   BoundaryCorrections/Test_Hll.cpp
   BoundaryCorrections/Test_Rusanov.cpp
   Test_Characteristics.cpp

--- a/tests/Unit/Evolution/Systems/Burgers/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Burgers/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY Test_Burgers)
 
 set(LIBRARY_SOURCES
+  BoundaryConditions/Test_Dirichlet.cpp
   BoundaryConditions/Test_DirichletAnalytic.cpp
   BoundaryConditions/Test_Outflow.cpp
   BoundaryCorrections/Test_Hll.cpp

--- a/tests/Unit/Helpers/DataStructures/MakeWithRandomValues.hpp
+++ b/tests/Unit/Helpers/DataStructures/MakeWithRandomValues.hpp
@@ -93,8 +93,10 @@ struct FillWithRandomValuesImpl<Variables<tmpl::list<Tags...>>,
             typename RandomNumberDistribution>
   static void apply(
       const gsl::not_null<Variables<tmpl::list<Tags...>>*> data,
-      const gsl::not_null<UniformRandomBitGenerator*> generator,
-      const gsl::not_null<RandomNumberDistribution*> distribution) noexcept {
+      [[maybe_unused]] const gsl::not_null<UniformRandomBitGenerator*>
+          generator,
+      [[maybe_unused]] const gsl::not_null<RandomNumberDistribution*>
+          distribution) noexcept {
     EXPAND_PACK_LEFT_TO_RIGHT(
         FillWithRandomValuesImpl<
             std::decay_t<decltype(get<Tags>(*data))>>::apply(&get<Tags>(*data),

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp
@@ -1,0 +1,625 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <memory>
+#include <optional>
+#include <random>
+#include <regex>
+#include <stdexcept>
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/BoundaryConditions/Periodic.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeHelpers.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"
+#include "Framework/Pypp.hpp"
+#include "Framework/PyppFundamentals.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/NormalVectors.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/NoSuchType.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace TestHelpers::evolution::dg {
+/// Tags for testing DG code
+namespace Tags {
+/// Tag for a `TaggedTuple` that holds the name of the python function that
+/// gives the result for computing what `Tag` should be.
+///
+/// If a Tag is only needed for or different for a specific boundary correction,
+/// then the `BoundaryCorrection` template parameter must be set.
+///
+/// The `Tag` template parameter is an input to the `dg_package_data` function.
+/// That is, the tag is one of the evolved variables, fluxes, or any other
+/// `dg_package_data_temporary_tags` that the boundary correction needs.
+template <typename Tag, typename BoundaryCorrection = NoSuchType>
+struct PythonFunctionName {
+  using tag = Tag;
+  using boundary_correction = BoundaryCorrection;
+  using type = std::string;
+};
+
+/// The name of the python function that returns the error message.
+///
+/// If `BoundaryCorrection` is `NoSuchType` then the same function will be used
+/// for all boundary corrections.
+///
+/// The python function must return `None` if there shouldn't be an error
+/// message.
+template <typename BoundaryCorrection = NoSuchType>
+struct PythonFunctionForErrorMessage {
+  using boundary_correction = BoundaryCorrection;
+  using type = std::string;
+};
+
+/// Tag for a `TaggedTuple` that holds the range of validity for the variable
+/// associated with `Tag`.
+template <typename Tag>
+struct Range {
+  using tag = Tag;
+  using type = std::array<double, 2>;
+};
+}  // namespace Tags
+
+namespace detail {
+template <typename ConversionClassList, typename... Args>
+static std::optional<std::string> call_for_error_message(
+    const std::string& module_name, const std::string& function_name,
+    const Args&... t) {
+  static_assert(sizeof...(Args) > 0,
+                "Call to python which returns a Tensor of DataVectors must "
+                "pass at least one argument");
+  using ReturnType = std::optional<std::string>;
+
+  PyObject* python_module = PyImport_ImportModule(module_name.c_str());
+  if (python_module == nullptr) {
+    PyErr_Print();
+    throw std::runtime_error{std::string("Could not find python module.\n") +
+                             module_name};
+  }
+  PyObject* func = PyObject_GetAttrString(python_module, function_name.c_str());
+  if (func == nullptr or not PyCallable_Check(func)) {
+    if (PyErr_Occurred()) {
+      PyErr_Print();
+    }
+    throw std::runtime_error{"Could not find python function in module.\n"};
+  }
+
+  const std::array<size_t, sizeof...(Args)> arg_sizes{
+      {pypp::detail::ContainerPackAndUnpack<
+          Args, ConversionClassList>::get_size(t)...}};
+  const size_t npts = *std::max_element(arg_sizes.begin(), arg_sizes.end());
+  for (size_t i = 0; i < arg_sizes.size(); ++i) {
+    if (gsl::at(arg_sizes, i) != 1 and gsl::at(arg_sizes, i) != npts) {
+      ERROR("Each argument must return size 1 or "
+            << npts
+            << " (the number of points in the DataVector), but argument number "
+            << i << " has size " << gsl::at(arg_sizes, i));
+    }
+  }
+  ReturnType result{};
+
+  for (size_t s = 0; s < npts; ++s) {
+    PyObject* args = pypp::make_py_tuple(
+        pypp::detail::ContainerPackAndUnpack<Args, ConversionClassList>::unpack(
+            t, s)...);
+    auto ret =
+        pypp::detail::call_work<typename pypp::detail::ContainerPackAndUnpack<
+            ReturnType, ConversionClassList>::unpacked_container>(python_module,
+                                                                  func, args);
+    if (ret.has_value()) {
+      result = std::move(ret);
+      break;
+    }
+  }
+  Py_DECREF(func);           // NOLINT
+  Py_DECREF(python_module);  // NOLINT
+  return result;
+}
+
+template <typename BoundaryCorrection, typename... PythonFunctionNameTags>
+const std::string& get_python_error_message_function(
+    const tuples::TaggedTuple<PythonFunctionNameTags...>&
+        python_boundary_condition_functions) {
+  return tuples::get<tmpl::conditional_t<
+      tmpl::list_contains_v<tmpl::list<PythonFunctionNameTags...>,
+                            Tags::PythonFunctionForErrorMessage<NoSuchType>>,
+      Tags::PythonFunctionForErrorMessage<NoSuchType>,
+      Tags::PythonFunctionForErrorMessage<BoundaryCorrection>>>(
+      python_boundary_condition_functions);
+}
+
+template <typename Tag, typename BoundaryCorrection,
+          typename... PythonFunctionNameTags>
+const std::string& get_python_tag_function(
+    const tuples::TaggedTuple<PythonFunctionNameTags...>&
+        python_boundary_condition_functions) {
+  return tuples::get<tmpl::conditional_t<
+      tmpl::list_contains_v<tmpl::list<PythonFunctionNameTags...>,
+                            Tags::PythonFunctionName<Tag, NoSuchType>>,
+      Tags::PythonFunctionName<Tag, NoSuchType>,
+      Tags::PythonFunctionName<Tag, BoundaryCorrection>>>(
+      python_boundary_condition_functions);
+}
+
+template <typename BoundaryConditionHelper, typename AllTagsOnFaceList,
+          typename... TagsFromFace, typename... VolumeArgs>
+void apply_boundary_condition_impl(
+    BoundaryConditionHelper& boundary_condition_helper,
+    const Variables<AllTagsOnFaceList>& fields_on_interior_face,
+    tmpl::list<TagsFromFace...> /*meta*/,
+    const VolumeArgs&... volume_args) noexcept {
+  boundary_condition_helper(get<TagsFromFace>(fields_on_interior_face)...,
+                            volume_args...);
+}
+
+template <typename System, typename ConversionClassList,
+          typename BoundaryCorrection, typename... PythonFunctionNameTags,
+          typename BoundaryCondition, size_t FaceDim, typename DbTagsList,
+          typename... RangeTags, typename... EvolvedVariablesTags,
+          typename... BoundaryCorrectionPackagedDataInputTags,
+          typename... BoundaryConditionVolumeTags>
+void test_boundary_condition_with_python_impl(
+    const gsl::not_null<std::mt19937*> generator,
+    const std::string& python_module,
+    const tuples::TaggedTuple<PythonFunctionNameTags...>&
+        python_boundary_condition_functions,
+    const BoundaryCondition& boundary_condition,
+    const Index<FaceDim>& face_points,
+    const db::DataBox<DbTagsList>& box_of_volume_data,
+    const tuples::TaggedTuple<Tags::Range<RangeTags>...>& ranges,
+    const bool use_moving_mesh, tmpl::list<EvolvedVariablesTags...> /*meta*/,
+    tmpl::list<BoundaryCorrectionPackagedDataInputTags...> /*meta*/,
+    tmpl::list<BoundaryConditionVolumeTags...> /*meta*/, const double epsilon) {
+  CAPTURE(FaceDim);
+  CAPTURE(python_module);
+  CAPTURE(face_points);
+  CAPTURE(use_moving_mesh);
+  CAPTURE(epsilon);
+  CAPTURE(pretty_type::short_name<BoundaryCorrection>());
+  const size_t number_of_points_on_face = face_points.product();
+
+  using variables_tag = typename System::variables_tag;
+  using variables_tags = typename variables_tag::tags_list;
+  using flux_variables = typename System::flux_variables;
+  using dt_variables_tags = db::wrap_tags_in<::Tags::dt, variables_tags>;
+
+  constexpr bool uses_ghost =
+      BoundaryCondition::bc_type ==
+          ::evolution::BoundaryConditions::Type::Ghost or
+      BoundaryCondition::bc_type ==
+          ::evolution::BoundaryConditions::Type::GhostAndTimeDerivative;
+  constexpr bool uses_time_derivative_condition =
+      BoundaryCondition::bc_type ==
+          ::evolution::BoundaryConditions::Type::TimeDerivative or
+      BoundaryCondition::bc_type ==
+          ::evolution::BoundaryConditions::Type::GhostAndTimeDerivative;
+
+  // List that holds the inverse spatial metric if it's needed
+  using inverse_spatial_metric_list =
+      ::evolution::dg::Actions::detail::inverse_spatial_metric_tag<System>;
+  constexpr bool has_inv_spatial_metric =
+      ::evolution::dg::Actions::detail::has_inverse_spatial_metric_tag_v<
+          System>;
+
+  // Set up tags for boundary conditions
+  using bcondition_interior_temp_tags =
+      typename BoundaryCondition::dg_interior_temporary_tags;
+  using bcondition_interior_prim_tags =
+      typename ::evolution::dg::Actions::detail::get_primitive_vars<
+          System::has_primitive_and_conservative_vars>::
+          template boundary_condition_interior_tags<BoundaryCondition>;
+  using bcondition_interior_evolved_vars_tags =
+      typename BoundaryCondition::dg_interior_evolved_variables_tags;
+  using bcondition_interior_dt_evolved_vars_tags =
+      ::evolution::dg::Actions::detail::get_dt_vars_from_boundary_condition<
+          BoundaryCondition>;
+  using bcondition_interior_deriv_evolved_vars_tags =
+      ::evolution::dg::Actions::detail::get_deriv_vars_from_boundary_condition<
+          BoundaryCondition>;
+  using bcondition_interior_tags = tmpl::remove_duplicates<tmpl::append<
+      tmpl::conditional_t<has_inv_spatial_metric,
+                          tmpl::list<::evolution::dg::Actions::detail::
+                                         NormalVector<FaceDim + 1>>,
+                          tmpl::list<>>,
+      bcondition_interior_evolved_vars_tags, bcondition_interior_prim_tags,
+      bcondition_interior_temp_tags, bcondition_interior_dt_evolved_vars_tags,
+      bcondition_interior_deriv_evolved_vars_tags>>;
+
+  std::uniform_real_distribution<> dist(-1., 1.);
+
+  Variables<tmpl::remove_duplicates<
+      tmpl::append<bcondition_interior_tags, inverse_spatial_metric_list>>>
+      interior_face_fields{number_of_points_on_face};
+  fill_with_random_values(make_not_null(&interior_face_fields), generator,
+                          make_not_null(&dist));
+
+  tmpl::for_each<tmpl::list<RangeTags...>>([&generator, &interior_face_fields,
+                                            &ranges](auto tag_v) {
+    using tag = tmpl::type_from<decltype(tag_v)>;
+    const std::array<double, 2>& range = tuples::get<Tags::Range<tag>>(ranges);
+    std::uniform_real_distribution<> local_dist(range[0], range[1]);
+    fill_with_random_values(make_not_null(&get<tag>(interior_face_fields)),
+                            generator, make_not_null(&local_dist));
+  });
+
+  auto interior_normal_covector =  // Unnormalized at this point
+      make_with_random_values<
+          tnsr::i<DataVector, FaceDim + 1, Frame::Inertial>>(
+          generator, make_not_null(&dist), number_of_points_on_face);
+  if constexpr (has_inv_spatial_metric) {
+    auto& inv_spatial_metric =
+        get<tmpl::front<inverse_spatial_metric_list>>(interior_face_fields);
+    detail::adjust_inverse_spatial_metric(make_not_null(&inv_spatial_metric));
+    auto& normal_vector =
+        get<::evolution::dg::Actions::detail::NormalVector<FaceDim + 1>>(
+            interior_face_fields);
+    detail::normalize_vector_and_covector(
+        make_not_null(&interior_normal_covector), make_not_null(&normal_vector),
+        inv_spatial_metric);
+  } else {
+    const Scalar<DataVector> magnitude = ::magnitude(interior_normal_covector);
+    for (DataVector& component : interior_normal_covector) {
+      component /= get(magnitude);
+    }
+  }
+
+  // Set a random mesh velocity. We allow for velocities above 1 to test "faster
+  // than light" mesh movement.
+  std::optional<tnsr::I<DataVector, FaceDim + 1>> face_mesh_velocity{};
+  if (use_moving_mesh) {
+    std::uniform_real_distribution<> local_dist(-2., 2.);
+    face_mesh_velocity =
+        make_with_random_values<tnsr::I<DataVector, FaceDim + 1>>(
+            generator, make_not_null(&local_dist), number_of_points_on_face);
+  }
+
+  if constexpr (BoundaryCondition::bc_type ==
+                ::evolution::BoundaryConditions::Type::Outflow) {
+    // Outflow boundary conditions only check that all characteristic speeds
+    // are directed out of the element. If there are any inward directed
+    // fields then the boundary condition should error.
+    const auto apply_bc =
+        [&boundary_condition, &face_mesh_velocity, &interior_normal_covector,
+         &python_boundary_condition_functions,
+         &python_module](const auto&... face_and_volume_args) noexcept {
+          const std::optional<std::string> error_msg =
+              boundary_condition.dg_outflow(face_mesh_velocity,
+                                            interior_normal_covector,
+                                            face_and_volume_args...);
+          const std::string& python_error_msg_function =
+              get_python_error_message_function<BoundaryCorrection>(
+                  python_boundary_condition_functions);
+          const auto python_error_message =
+              call_for_error_message<ConversionClassList>(
+                  python_module, python_error_msg_function, face_mesh_velocity,
+                  interior_normal_covector, face_and_volume_args...);
+          CAPTURE(python_error_msg_function);
+          CAPTURE(python_error_message.value_or(""));
+          CAPTURE(error_msg.value_or(""));
+          REQUIRE(python_error_message.has_value() == error_msg.has_value());
+          if (python_error_message.has_value() and error_msg.has_value()) {
+            std::smatch matcher{};
+            CHECK(std::regex_search(*error_msg, matcher,
+                                    std::regex{*python_error_message}));
+          }
+        };
+    apply_boundary_condition_impl(
+        apply_bc, interior_face_fields, bcondition_interior_tags{},
+        db::get<BoundaryConditionVolumeTags>(box_of_volume_data)...);
+  }
+
+  if constexpr (uses_time_derivative_condition) {
+    Variables<dt_variables_tags> time_derivative_correction{
+        number_of_points_on_face};
+    auto apply_bc = [&boundary_condition, epsilon, &face_mesh_velocity,
+                     &interior_normal_covector,
+                     &python_boundary_condition_functions, &python_module,
+                     &time_derivative_correction](
+                        const auto&... interior_face_and_volume_args) {
+      const std::optional<std::string> error_msg =
+          boundary_condition.dg_time_derivative(
+              make_not_null(&get<::Tags::dt<EvolvedVariablesTags>>(
+                  time_derivative_correction))...,
+              face_mesh_velocity, interior_normal_covector,
+              interior_face_and_volume_args...);
+
+      const std::string& python_error_msg_function =
+          get_python_error_message_function<BoundaryCorrection>(
+              python_boundary_condition_functions);
+      const auto python_error_message =
+          call_for_error_message<ConversionClassList>(
+              python_module, python_error_msg_function, face_mesh_velocity,
+              interior_normal_covector, interior_face_and_volume_args...);
+      CAPTURE(python_error_msg_function);
+      CAPTURE(python_error_message.value_or(""));
+      CAPTURE(error_msg.value_or(""));
+      REQUIRE(python_error_message.has_value() == error_msg.has_value());
+      if (python_error_message.has_value() and error_msg.has_value()) {
+        std::smatch matcher{};
+        CHECK(std::regex_search(*error_msg, matcher,
+                                std::regex{*python_error_message}));
+      }
+
+      // Check that the values were set correctly
+      tmpl::for_each<dt_variables_tags>([&](auto dt_var_tag_v) {
+        using DtVarTag = tmpl::type_from<decltype(dt_var_tag_v)>;
+        // Use NoSuchType for the BoundaryCorrection since dt-type corrections
+        // should be boundary correction agnostic.
+        const std::string& python_tag_function =
+            get_python_tag_function<DtVarTag, NoSuchType>(
+                python_boundary_condition_functions);
+        CAPTURE(python_tag_function);
+        CAPTURE(pretty_type::short_name<DtVarTag>());
+        typename DtVarTag::type python_result{};
+        try {
+          python_result =
+              pypp::call<typename DtVarTag::type, ConversionClassList>(
+                  python_module, python_tag_function, face_mesh_velocity,
+                  interior_normal_covector, interior_face_and_volume_args...);
+        } catch (const std::exception& e) {
+          INFO("Failed python call with '" << e.what() << "'");
+          // Use REQUIRE(false) to print all the CAPTURE variables
+          REQUIRE(false);
+        }
+        CHECK_ITERABLE_CUSTOM_APPROX(
+            get<DtVarTag>(time_derivative_correction), python_result,
+            Approx::custom().epsilon(epsilon).scale(1.0));
+      });
+    };
+    apply_boundary_condition_impl(
+        apply_bc, interior_face_fields, bcondition_interior_tags{},
+        db::get<BoundaryConditionVolumeTags>(box_of_volume_data)...);
+  }
+
+  if constexpr (uses_ghost) {
+    using fluxes_tags =
+        db::wrap_tags_in<::Tags::Flux, flux_variables,
+                         tmpl::size_t<FaceDim + 1>, Frame::Inertial>;
+    using correction_temp_tags =
+        typename BoundaryCorrection::dg_package_data_temporary_tags;
+    using correction_prim_tags =
+        typename ::evolution::dg::Actions::detail::get_primitive_vars<
+            System::has_primitive_and_conservative_vars>::
+            template f<BoundaryCorrection>;
+    using tags_on_exterior_face = tmpl::append<
+        variables_tags, fluxes_tags, correction_temp_tags, correction_prim_tags,
+        inverse_spatial_metric_list,
+        tmpl::list<
+            ::evolution::dg::Actions::detail::OneOverNormalVectorMagnitude,
+            ::evolution::dg::Actions::detail::NormalVector<FaceDim + 1>,
+            ::evolution::dg::Tags::NormalCovector<FaceDim + 1>>>;
+    Variables<tags_on_exterior_face> exterior_face_fields{
+        number_of_points_on_face};
+    auto apply_bc = [&boundary_condition, epsilon, &exterior_face_fields,
+                     &face_mesh_velocity, &interior_normal_covector,
+                     &python_boundary_condition_functions, &python_module](
+                        const auto&... interior_face_and_volume_args) {
+      const std::optional<std::string> error_msg = boundary_condition.dg_ghost(
+          make_not_null(&get<BoundaryCorrectionPackagedDataInputTags>(
+              exterior_face_fields))...,
+          face_mesh_velocity, interior_normal_covector,
+          interior_face_and_volume_args...);
+
+      const std::string& python_error_msg_function =
+          get_python_error_message_function<BoundaryCorrection>(
+              python_boundary_condition_functions);
+      const auto python_error_message =
+          call_for_error_message<ConversionClassList>(
+              python_module, python_error_msg_function, face_mesh_velocity,
+              interior_normal_covector, interior_face_and_volume_args...);
+      CAPTURE(python_error_msg_function);
+      CAPTURE(python_error_message.value_or(""));
+      CAPTURE(error_msg.value_or(""));
+      REQUIRE(python_error_message.has_value() == error_msg.has_value());
+      if (python_error_message.has_value() and error_msg.has_value()) {
+        std::smatch matcher{};
+        CHECK(std::regex_search(*error_msg, matcher,
+                                std::regex{*python_error_message}));
+      }
+      if (python_error_message.has_value()) {
+        return;
+      }
+
+      // Check that the values were set correctly
+      tmpl::for_each<tmpl::list<BoundaryCorrectionPackagedDataInputTags...>>(
+          [&](auto boundary_correction_tag_v) {
+            using BoundaryCorrectionTag =
+                tmpl::type_from<decltype(boundary_correction_tag_v)>;
+            const std::string& python_tag_function =
+                get_python_tag_function<BoundaryCorrectionTag,
+                                        BoundaryCorrection>(
+                    python_boundary_condition_functions);
+            CAPTURE(python_tag_function);
+            CAPTURE(pretty_type::short_name<BoundaryCorrectionTag>());
+            typename BoundaryCorrectionTag::type python_result{};
+            try {
+              python_result = pypp::call<typename BoundaryCorrectionTag::type,
+                                         ConversionClassList>(
+                  python_module, python_tag_function, face_mesh_velocity,
+                  interior_normal_covector, interior_face_and_volume_args...);
+            } catch (const std::exception& e) {
+              INFO("Failed python call with '" << e.what() << "'");
+              // Use REQUIRE(false) to print all the CAPTURE variables
+              REQUIRE(false);
+            }
+            CHECK_ITERABLE_CUSTOM_APPROX(
+                get<BoundaryCorrectionTag>(exterior_face_fields), python_result,
+                Approx::custom().epsilon(epsilon).scale(1.0));
+          });
+    };
+    // Since any of the variables in `exterior_face_fields` could be mutated
+    // from their projected state, we don't pass in the interior tags explicitly
+    // since that will likely give a false sense of "no aliasing"
+    apply_boundary_condition_impl(
+        apply_bc, interior_face_fields, bcondition_interior_tags{},
+        db::get<BoundaryConditionVolumeTags>(box_of_volume_data)...);
+  }
+}
+
+template <typename T, typename = std::void_t<>>
+struct get_boundary_conditions_impl {
+  using type = tmpl::list<>;
+};
+
+template <typename T>
+struct get_boundary_conditions_impl<
+    T, std::void_t<typename T::boundary_conditions_base>> {
+  using type = typename T::boundary_conditions_base::creatable_classes;
+};
+
+template <typename T>
+using get_boundary_conditions = typename get_boundary_conditions_impl<T>::type;
+}  // namespace detail
+
+/*!
+ * \brief Test a boundary condition against python code and that it satisfies
+ * the required interface.
+ *
+ * The boundary conditions return a `std::optional<std::string>` that is the
+ * error message. For ghost cell boundary conditions they must also return the
+ * arguments needed by the boundary correction's `dg_package_data` function by
+ * `gsl::not_null`. Time derivative boundary conditions return the correction
+ * added to the time derivatives by `gsl::not_null`, while outflow boundary
+ * conditions should only check that the boundary is actually an outflow
+ * boundary. Therefore, the comparison implementation in python must have a
+ * function for each of these. Which function is called is specified using a
+ * `python_boundary_condition_functions` and `Tags::PythonFunctionName`.
+ *
+ * The specific boundary condition and system need to be explicitly given.
+ * Once the boundary condition and boundary correction base classes are
+ * listed/available in the `System` class we can remove needing to specify
+ * those. The `ConversionClassList` is forwarded to `pypp` to allow custom
+ * conversions of classes to python, such as analytic solutions or equations of
+ * state.
+ *
+ * - The random number generator is passed in so that the seed can be easily
+ *   controlled externally. Use, e.g. `MAKE_GENERATOR(gen)` to create a
+ *   generator.
+ * - The python function names are given in a `TaggedTuple`. A
+ *   `TestHelpers::evolution::dg::Tags::PythonFunctionForErrorMessage` tag must
+ *   be given for specifying the error message that the boundary condition
+ *   returns. In many cases this function will simply return `None`. The tag can
+ *   optionally specify the boundary correction for which it is to be used, so
+ *   that a different error message could be printed if a different boundary
+ *   correction is used.
+ *   The `TestHelpers::evolution::dg::Tags::PythonFunctionName` tag is used to
+ *   give the name of the python function for each return argument. The tags are
+ *   the input to the `package_data` function for Ghost boundary conditions, and
+ *   `::Tags::dt<evolved_var_tag>` for time derivative boundary conditions.
+ * - `factory_string` is a string used to create the boundary condition from the
+ *   factory
+ * - `face_points` is the grid points on the interface. Generally 5 grid points
+ *   per dimension in 2d and 3d is recommended to catch indexing errors. In 1d
+ *   there is only ever one point on the interface
+ * - `box_of_volume_data` is a `db::DataBox` that contains all of the
+ *   `dg_gridless_tags` of the boundary condition. This is not a `TaggedTuple`
+ *   so that all the different types of tags, like base tags, can be supported
+ *   and easily tested.
+ * - `ranges` is a `TaggedTuple` of
+ *   `TestHelpers::evolution::dg::Tags::Range<tag>` specifying a custom range in
+ *   which to generate the random values. This can be used for ensuring that
+ *   positive quantities are randomly generated on the interval
+ *   `[lower_bound,upper_bound)`, choosing `lower_bound` to be `0` or some small
+ *   number. The default interval if a tag is not listed is `[-1,1)`.
+ * - `epsilon` is the relative tolerance to use in the random tests
+ */
+template <typename BoundaryCondition, typename BoundaryConditionBase,
+          typename System, typename BoundaryCorrectionsList,
+          typename ConversionClassList = tmpl::list<>, size_t FaceDim,
+          typename DbTagsList, typename... RangeTags,
+          typename... PythonFunctionNameTags>
+void test_boundary_condition_with_python(
+    const gsl::not_null<std::mt19937*> generator,
+    const std::string& python_module,
+    const tuples::TaggedTuple<PythonFunctionNameTags...>&
+        python_boundary_condition_functions,
+    const std::string& factory_string, const Index<FaceDim>& face_points,
+    const db::DataBox<DbTagsList>& box_of_volume_data,
+    const tuples::TaggedTuple<Tags::Range<RangeTags>...>& ranges,
+    const double epsilon = 1.0e-12) {
+  PUPable_reg(BoundaryCondition);
+  static_assert(std::is_final_v<std::decay_t<BoundaryCondition>>,
+                "All boundary condition classes must be marked `final`.");
+  using variables_tags = typename System::variables_tag::tags_list;
+  using flux_variables = typename System::flux_variables;
+  using fluxes_tags =
+      db::wrap_tags_in<::Tags::Flux, flux_variables, tmpl::size_t<FaceDim + 1>,
+                       Frame::Inertial>;
+  const std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+      boundary_condition =
+          TestHelpers::test_factory_creation<BoundaryConditionBase>(
+              factory_string);
+
+  REQUIRE_FALSE(
+      domain::BoundaryConditions::is_periodic(boundary_condition->get_clone()));
+
+  tmpl::for_each<BoundaryCorrectionsList>(
+      [&boundary_condition, &box_of_volume_data, epsilon, &face_points,
+       &generator, &python_boundary_condition_functions, &python_module,
+       &ranges](auto boundary_correction_v) {
+        using BoundaryCorrection =
+            tmpl::type_from<decltype(boundary_correction_v)>;
+        using package_data_input_tags = tmpl::append<
+            variables_tags, fluxes_tags,
+            typename BoundaryCorrection::dg_package_data_temporary_tags,
+            typename ::evolution::dg::Actions::detail::get_primitive_vars<
+                System::has_primitive_and_conservative_vars>::
+                template f<BoundaryCorrection>>;
+        using boundary_condition_dg_gridless_tags =
+            typename BoundaryCondition::dg_gridless_tags;
+        for (const auto use_moving_mesh : {false, true}) {
+          detail::test_boundary_condition_with_python_impl<
+              System, ConversionClassList, BoundaryCorrection>(
+              generator, python_module, python_boundary_condition_functions,
+              dynamic_cast<const BoundaryCondition&>(*boundary_condition),
+              face_points, box_of_volume_data, ranges, use_moving_mesh,
+              variables_tags{}, package_data_input_tags{},
+              boundary_condition_dg_gridless_tags{}, epsilon);
+          // Now serialize and deserialize and test again
+          INFO("Test boundary condition after serialization.");
+          const auto deserialized_bc =
+              serialize_and_deserialize(boundary_condition);
+          detail::test_boundary_condition_with_python_impl<
+              System, ConversionClassList, BoundaryCorrection>(
+              generator, python_module, python_boundary_condition_functions,
+              dynamic_cast<const BoundaryCondition&>(*deserialized_bc),
+              face_points, box_of_volume_data, ranges, use_moving_mesh,
+              variables_tags{}, package_data_input_tags{},
+              boundary_condition_dg_gridless_tags{}, epsilon);
+        }
+      });
+}
+
+/// Test that a boundary condition is correctly identified as periodic.
+template <typename BoundaryCondition, typename BoundaryConditionBase>
+void test_periodic_condition(const std::string& factory_string) {
+  PUPable_reg(BoundaryCondition);
+  const auto boundary_condition =
+      TestHelpers::test_factory_creation<BoundaryConditionBase>(factory_string);
+  REQUIRE(typeid(*boundary_condition.get()) == typeid(BoundaryCondition));
+  const auto bc_clone = boundary_condition->get_clone();
+  CHECK(domain::BoundaryConditions::is_periodic(bc_clone));
+  const auto bc_deserialized = serialize_and_deserialize(bc_clone);
+  CHECK(domain::BoundaryConditions::is_periodic(bc_deserialized));
+}
+}  // namespace TestHelpers::evolution::dg


### PR DESCRIPTION
## Proposed changes

- Adds some generic metafunctions and a test helper that calls into python and verifies the boundary condition class satisfies the interface used in the actual evolution code.
- Fixes an unused variable warning
- Adds Outflow, DirichletAnalytic, and Dirichlet boundary conditions for Burgers


I can easily factor this into a few smaller PRs, but I would like to give an overview of what the interface looks like, how tests will work, etc.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
