### PR TITLE
Mock cores/nodes cleanup

### DIFF
--- a/src/Parallel/Info.hpp
+++ b/src/Parallel/Info.hpp
@@ -21,7 +21,7 @@ namespace Parallel {
  * \brief Number of processing elements.
  */
 template <typename DistribObject>
-int number_of_procs(const DistribObject& distributed_object) {
+int number_of_procs(const DistribObject& distributed_object) noexcept {
   return distributed_object.number_of_procs();
 }
 
@@ -30,7 +30,7 @@ int number_of_procs(const DistribObject& distributed_object) {
  * \brief %Index of my processing element.
  */
 template <typename DistribObject>
-int my_proc(const DistribObject& distributed_object) {
+int my_proc(const DistribObject& distributed_object) noexcept {
   return distributed_object.my_proc();
 }
 
@@ -39,7 +39,7 @@ int my_proc(const DistribObject& distributed_object) {
  * \brief Number of nodes.
  */
 template <typename DistribObject>
-int number_of_nodes(const DistribObject& distributed_object) {
+int number_of_nodes(const DistribObject& distributed_object) noexcept {
   return distributed_object.number_of_nodes();
 }
 
@@ -48,7 +48,7 @@ int number_of_nodes(const DistribObject& distributed_object) {
   * \brief %Index of my node.
   */
 template <typename DistribObject>
-int my_node(const DistribObject& distributed_object) {
+int my_node(const DistribObject& distributed_object) noexcept {
   return distributed_object.my_node();
 }
 
@@ -58,7 +58,7 @@ int my_node(const DistribObject& distributed_object) {
  */
 template <typename DistribObject>
 int procs_on_node(const int node_index,
-                  const DistribObject& distributed_object) {
+                  const DistribObject& distributed_object) noexcept {
   return distributed_object.procs_on_node(node_index);
 }
 
@@ -68,7 +68,7 @@ int procs_on_node(const int node_index,
  * This is in the interval 0, ..., procs_on_node(my_node()) - 1.
  */
 template <typename DistribObject>
-int my_local_rank(const DistribObject& distributed_object) {
+int my_local_rank(const DistribObject& distributed_object) noexcept {
   return distributed_object.my_local_rank();
 }
 
@@ -78,7 +78,7 @@ int my_local_rank(const DistribObject& distributed_object) {
  */
 template <typename DistribObject>
 int first_proc_on_node(const int node_index,
-                       const DistribObject& distributed_object) {
+                       const DistribObject& distributed_object) noexcept {
   return distributed_object.first_proc_on_node(node_index);
 }
 
@@ -87,7 +87,8 @@ int first_proc_on_node(const int node_index,
  * \brief %Index of the node for the given processing element.
  */
 template <typename DistribObject>
-int node_of(const int proc_index, const DistribObject& distributed_object) {
+int node_of(const int proc_index,
+            const DistribObject& distributed_object) noexcept {
   return distributed_object.node_of(proc_index);
 }
 
@@ -97,7 +98,7 @@ int node_of(const int proc_index, const DistribObject& distributed_object) {
  */
 template <typename DistribObject>
 int local_rank_of(const int proc_index,
-                  const DistribObject& distributed_object) {
+                  const DistribObject& distributed_object) noexcept {
   return distributed_object.local_rank_of(proc_index);
 }
 

--- a/tests/Unit/Framework/ActionTesting.hpp
+++ b/tests/Unit/Framework/ActionTesting.hpp
@@ -643,7 +643,7 @@ class MockCollectionOfDistributedObjectsProxy {
   // mock_node_, mock_local_core_, and mock_global_core_ are the
   // (mock) node and core that the
   // MockCollectionOfDistributedObjectsProxy lives on.  This is
-  // different than the (mock) nodes and cores that each element ofthe
+  // different than the (mock) nodes and cores that each element of the
   // referred-to CollectionOfMockDistributedObjects lives on.
   size_t mock_node_{0};
   size_t mock_local_core_{0};

--- a/tests/Unit/Framework/ActionTesting.hpp
+++ b/tests/Unit/Framework/ActionTesting.hpp
@@ -567,16 +567,10 @@ class MockCollectionOfDistributedObjectsProxy {
     }
   }
 
-  // ckLocal_enabled is used by Parallel/Invoke.hpp to allow or
-  // prevent compilation of ckLocal (the idea is to prevent
-  // compilation in cases where it will static_assert).
-  // ckLocal_enabled can be eliminated if we replace the static_assert
-  // in ckLocal() by an 'if constexpr' that returns nullptr when
-  // ChareType is not a singleton, but that comes at the expense of a
-  // compile-time check.
-  using ckLocal_enabled = std::is_same<ChareType, MockSingletonChare>;
-
   // ckLocal should be called only on a singleton.
+  template <typename U = ChareType,
+            typename = Requires<std::is_same_v<U, ChareType> and
+                                std::is_same_v<U, MockSingletonChare>>>
   MockDistributedObject<Component>* ckLocal() noexcept {
     static_assert(std::is_same_v<ChareType, MockSingletonChare>,
                   "Do not call ckLocal for other than a Singleton");

--- a/tests/Unit/Framework/MockRuntimeSystem.hpp
+++ b/tests/Unit/Framework/MockRuntimeSystem.hpp
@@ -140,30 +140,38 @@ class MockRuntimeSystem {
       const std::vector<size_t>& number_of_mock_cores_on_each_mock_node = {1})
       : mock_global_cores_(
             [&number_of_mock_cores_on_each_mock_node]() noexcept {
-              std::vector<std::vector<size_t>> mock_global_cores{};
+              std::unordered_map<NodeId,
+                                 std::unordered_map<LocalCoreId, GlobalCoreId>>
+                  mock_global_cores{};
               size_t global_core = 0;
-              for (auto num_cores_on_this_node :
-                   number_of_mock_cores_on_each_mock_node) {
-                std::vector<size_t> global_cores(num_cores_on_this_node);
-                std::iota(global_cores.begin(), global_cores.end(),
-                          global_core);
-                mock_global_cores.emplace_back(std::move(global_cores));
-                global_core += num_cores_on_this_node;
+              for (size_t node = 0;
+                   node < number_of_mock_cores_on_each_mock_node.size();
+                   ++node) {
+                std::unordered_map<LocalCoreId, GlobalCoreId> global_cores;
+                for (size_t local_core = 0;
+                     local_core < number_of_mock_cores_on_each_mock_node[node];
+                     ++local_core, ++global_core) {
+                  global_cores.insert(
+                      {LocalCoreId{local_core}, GlobalCoreId{global_core}});
+                }
+                mock_global_cores.insert({NodeId{node}, global_cores});
               }
               return mock_global_cores;
             }()),
         mock_nodes_and_local_cores_(
             [&number_of_mock_cores_on_each_mock_node]() noexcept {
-              std::vector<std::pair<size_t, size_t>>
+              std::unordered_map<GlobalCoreId, std::pair<NodeId, LocalCoreId>>
                   mock_nodes_and_local_cores{};
+              size_t global_core = 0;
               for (size_t node = 0;
                    node < number_of_mock_cores_on_each_mock_node.size();
                    ++node) {
                 for (size_t local_core = 0;
                      local_core < number_of_mock_cores_on_each_mock_node[node];
-                     ++local_core) {
-                  mock_nodes_and_local_cores.emplace_back(
-                      std::make_pair(node, local_core));
+                     ++local_core, ++global_core) {
+                  mock_nodes_and_local_cores.insert(
+                      {GlobalCoreId{global_core},
+                       std::make_pair(NodeId{node}, LocalCoreId{local_core})});
                 }
               }
               return mock_nodes_and_local_cores;
@@ -176,27 +184,28 @@ class MockRuntimeSystem {
     // passed the mock node and mock core associated with that cache.
     // The actual chares held in each cache are emplaced by the user explicitly
     // on a chosen node and core, via `emplace_component`.
-    for (const auto& [node, local_core] : mock_nodes_and_local_cores_) {
-      const size_t global_core = mock_global_cores_.at(node).at(local_core);
+    for (const auto& [global_core_id, node_and_local_core] :
+         mock_nodes_and_local_cores_) {
+      const size_t global_core = global_core_id.value;
       mutable_caches_.at(global_core) =
-                std::make_unique<Parallel::MutableGlobalCache<Metavariables>>(
-                    serialize_and_deserialize(mutable_cache_contents));
+          std::make_unique<Parallel::MutableGlobalCache<Metavariables>>(
+              serialize_and_deserialize(mutable_cache_contents));
       caches_.at(global_core) = std::make_unique<GlobalCache>(
           serialize_and_deserialize(cache_contents),
           mutable_caches_.at(global_core).get());
       // Note that lambdas cannot capture structured bindings,
       // so we define node and local_core here.
-      const auto& node_ref = node;
-      const auto& local_core_ref = local_core;
+      const auto& node = node_and_local_core.first.value;
+      const auto& local_core = node_and_local_core.second.value;
       tmpl::for_each<typename Metavariables::component_list>(
-          [this, &global_core, &node_ref, &local_core_ref](auto component) {
+          [this, &global_core, &node, &local_core](auto component) {
             using Component = tmpl::type_from<decltype(component)>;
             Parallel::get_parallel_component<Component>(
                 *caches_.at(global_core))
                 .set_data(&tuples::get<MockDistributedObjectsTag<Component>>(
                               mock_distributed_objects_),
                           &tuples::get<InboxesTag<Component>>(inboxes_),
-                          node_ref, local_core_ref, global_core);
+                          node, local_core, global_core);
           });
     }
   }
@@ -225,9 +234,7 @@ class MockRuntimeSystem {
         MockDistributedObject<Component>(
             node_id, local_core_id, mock_global_cores_,
             mock_nodes_and_local_cores_, array_index,
-            caches_
-                .at(mock_global_cores_.at(node_id.value)
-                        .at(local_core_id.value))
+            caches_.at(mock_global_cores_.at(node_id).at(local_core_id).value)
                 .get(),
             // Next line inserts element into inboxes_ and returns ptr to it.
             &(tuples::get<InboxesTag<Component>>(inboxes_)[array_index]),
@@ -249,9 +256,7 @@ class MockRuntimeSystem {
         MockDistributedObject<Component>(
             node_id, local_core_id, mock_global_cores_,
             mock_nodes_and_local_cores_, array_index,
-            caches_
-                .at(mock_global_cores_.at(node_id.value)
-                        .at(local_core_id.value))
+            caches_.at(mock_global_cores_.at(node_id).at(local_core_id).value)
                 .get(),
             // Next line inserts element into inboxes_ and returns ptr to it.
             &(tuples::get<InboxesTag<Component>>(inboxes_)[array_index]),
@@ -265,14 +270,15 @@ class MockRuntimeSystem {
         std::is_same_v<typename Component::chare_type, MockGroupChare>,
         "emplace_group_component expects a MockGroupChare");
     // Emplace once for each core, index by global_core.
-    for (const auto& [node, local_core] : mock_nodes_and_local_cores_) {
-      const size_t global_core = mock_global_cores_.at(node).at(local_core);
+    for (const auto& [global_core_id, node_and_local_core] :
+         mock_nodes_and_local_cores_) {
+      const size_t global_core = global_core_id.value;
       const typename Component::array_index array_index = global_core;
       mock_distributed_objects<Component>().emplace(
           array_index,
           MockDistributedObject<Component>(
-              NodeId{node}, LocalCoreId{local_core}, mock_global_cores_,
-              mock_nodes_and_local_cores_, array_index,
+              node_and_local_core.first, node_and_local_core.second,
+              mock_global_cores_, mock_nodes_and_local_cores_, array_index,
               caches_.at(global_core).get(),
               // Next line inserts element into inboxes_ and returns ptr to it.
               &(tuples::get<InboxesTag<Component>>(inboxes_)[array_index]),
@@ -287,14 +293,15 @@ class MockRuntimeSystem {
         std::is_same_v<typename Component::chare_type, MockNodeGroupChare>,
         "emplace_nodegroup_component expects a MockNodeGroupChare");
     // Emplace once for each node, index by node number.
-    for (size_t node = 0; node < mock_global_cores_.size(); ++node) {
-      const typename Component::array_index array_index = node;
+    for (const auto& [node, local_and_global_cores] : mock_global_cores_) {
+      const typename Component::array_index array_index = node.value;
       // Use first proc on each node as global_core
-      const size_t global_core = mock_global_cores_.at(node).front();
+      const size_t global_core =
+          local_and_global_cores.at(LocalCoreId{0}).value;
       mock_distributed_objects<Component>().emplace(
           array_index,
           MockDistributedObject<Component>(
-              NodeId{node}, LocalCoreId{0}, mock_global_cores_,
+              node, LocalCoreId{0}, mock_global_cores_,
               mock_nodes_and_local_cores_, array_index,
               caches_.at(global_core).get(),
               // Next line inserts element into inboxes_ and returns ptr to it.
@@ -331,8 +338,7 @@ class MockRuntimeSystem {
                 node_id, local_core_id, mock_global_cores_,
                 mock_nodes_and_local_cores_, array_index,
                 caches_
-                    .at(mock_global_cores_.at(node_id.value)
-                            .at(local_core_id.value))
+                    .at(mock_global_cores_.at(node_id).at(local_core_id).value)
                     .get(),
                 // Next line inserts element into inboxes_ and returns ptr to
                 // it.
@@ -369,8 +375,7 @@ class MockRuntimeSystem {
                 node_id, local_core_id, mock_global_cores_,
                 mock_nodes_and_local_cores_, array_index,
                 caches_
-                    .at(mock_global_cores_.at(node_id.value)
-                            .at(local_core_id.value))
+                    .at(mock_global_cores_.at(node_id).at(local_core_id).value)
                     .get(),
                 // Next line inserts element into inboxes_ and returns ptr to
                 // it.
@@ -395,19 +400,20 @@ class MockRuntimeSystem {
         std::is_same_v<typename Component::chare_type, MockGroupChare>,
         "emplace_group_component_and_initialize expects a MockGroupChare");
     // Emplace once for each core, index by global_core.
-    for (const auto& [node, local_core] : mock_nodes_and_local_cores_) {
+    for (const auto& [global_core_id, node_and_local_core] :
+         mock_nodes_and_local_cores_) {
       // Need to set initial values for each component, since the
       // InitialDataBox action does a std::move.
       detail::get_initialization<Component>::initialize_databox_action::
           set_initial_values(initial_values);
-      const size_t global_core = mock_global_cores_.at(node).at(local_core);
+      const size_t global_core = global_core_id.value;
       const typename Component::array_index array_index = global_core;
       auto [iterator, emplace_was_successful] =
           mock_distributed_objects<Component>().emplace(
               array_index,
               MockDistributedObject<Component>(
-                  NodeId{node}, LocalCoreId{local_core}, mock_global_cores_,
-                  mock_nodes_and_local_cores_, array_index,
+                  node_and_local_core.first, node_and_local_core.second,
+                  mock_global_cores_, mock_nodes_and_local_cores_, array_index,
                   caches_.at(global_core).get(),
                   // Next line inserts element into inboxes_ and returns ptr to
                   // it.
@@ -434,19 +440,20 @@ class MockRuntimeSystem {
         "emplace_nodegroup_component_and_initialize expects a "
         "MockNodeGroupChare");
     // Emplace once for each node, index by node number.
-    for (size_t node = 0; node < mock_global_cores_.size(); ++node) {
+    for (const auto& [node, local_and_global_cores] : mock_global_cores_) {
       // Need to set initial values for each component, since the
       // InitialDataBox action does a std::move.
       detail::get_initialization<Component>::initialize_databox_action::
           set_initial_values(initial_values);
-      const typename Component::array_index array_index = node;
+      const typename Component::array_index array_index = node.value;
       // Use first proc on each node as global_core
-      const size_t global_core = mock_global_cores_.at(node).front();
+      const size_t global_core =
+          local_and_global_cores.at(LocalCoreId{0}).value;
       auto [iterator, emplace_was_successful] =
           mock_distributed_objects<Component>().emplace(
               array_index,
               MockDistributedObject<Component>(
-                  NodeId{node}, LocalCoreId{0}, mock_global_cores_,
+                  node, LocalCoreId{0}, mock_global_cores_,
                   mock_nodes_and_local_cores_, array_index,
                   caches_.at(global_core).get(),
                   // Next line inserts element into inboxes_ and returns ptr to
@@ -461,7 +468,7 @@ class MockRuntimeSystem {
       iterator->second.set_phase(Metavariables::Phase::Initialization);
       iterator->second.next_action();
     }
-  }
+    }
 
   /// Emplace a component that needs to be initialized.
   /// emplace_component_and_initialize is deprecated in favor of
@@ -688,8 +695,7 @@ class MockRuntimeSystem {
 
   GlobalCache& cache(const NodeId node_id,
                      const LocalCoreId local_core_id) noexcept {
-    return *caches_.at(
-        mock_global_cores_.at(node_id.value).at(local_core_id.value));
+    return *caches_.at(mock_global_cores_.at(node_id).at(local_core_id).value);
   }
 
   GlobalCache& cache() noexcept { return cache(NodeId{0}, LocalCoreId{0}); }
@@ -706,10 +712,10 @@ class MockRuntimeSystem {
   }
 
  private:
-  // mock_global_cores[node][local_core] is the global_core.
-  std::vector<std::vector<size_t>> mock_global_cores_{};
-  // mock_nodes_and_local_cores_[global_core] is the pair node,local_core.
-  std::vector<std::pair<size_t, size_t>> mock_nodes_and_local_cores_{};
+  std::unordered_map<NodeId, std::unordered_map<LocalCoreId, GlobalCoreId>>
+      mock_global_cores_{};
+  std::unordered_map<GlobalCoreId, std::pair<NodeId, LocalCoreId>>
+      mock_nodes_and_local_cores_{};
   // There is one MutableGlobalCache and one GlobalCache per
   // global_core.  We need to keep a vector of unique_ptrs rather than
   // a vector of objects because MutableGlobalCache and GlobalCache

--- a/tests/Unit/Framework/MockRuntimeSystem.hpp
+++ b/tests/Unit/Framework/MockRuntimeSystem.hpp
@@ -176,25 +176,27 @@ class MockRuntimeSystem {
     // passed the mock node and mock core associated with that cache.
     // The actual chares held in each cache are emplaced by the user explicitly
     // on a chosen node and core, via `emplace_component`.
-    for (const auto& node_and_core : mock_nodes_and_local_cores_) {
-      const size_t global_core =
-          mock_global_cores_.at(node_and_core.first).at(node_and_core.second);
+    for (const auto& [node, local_core] : mock_nodes_and_local_cores_) {
+      const size_t global_core = mock_global_cores_.at(node).at(local_core);
       mutable_caches_.at(global_core) =
                 std::make_unique<Parallel::MutableGlobalCache<Metavariables>>(
                     serialize_and_deserialize(mutable_cache_contents));
       caches_.at(global_core) = std::make_unique<GlobalCache>(
           serialize_and_deserialize(cache_contents),
           mutable_caches_.at(global_core).get());
+      // Note that lambdas cannot capture structured bindings,
+      // so we define node and local_core here.
+      const auto& node_ref = node;
+      const auto& local_core_ref = local_core;
       tmpl::for_each<typename Metavariables::component_list>(
-          [this, &global_core, &node_and_core](auto component) {
+          [this, &global_core, &node_ref, &local_core_ref](auto component) {
             using Component = tmpl::type_from<decltype(component)>;
             Parallel::get_parallel_component<Component>(
                 *caches_.at(global_core))
                 .set_data(&tuples::get<MockDistributedObjectsTag<Component>>(
                               mock_distributed_objects_),
                           &tuples::get<InboxesTag<Component>>(inboxes_),
-                          node_and_core.first, node_and_core.second,
-                          global_core);
+                          node_ref, local_core_ref, global_core);
           });
     }
   }
@@ -263,15 +265,14 @@ class MockRuntimeSystem {
         std::is_same_v<typename Component::chare_type, MockGroupChare>,
         "emplace_group_component expects a MockGroupChare");
     // Emplace once for each core, index by global_core.
-    for (const auto& node_core_pair : mock_nodes_and_local_cores_) {
-      const size_t global_core =
-          mock_global_cores_.at(node_core_pair.first).at(node_core_pair.second);
+    for (const auto& [node, local_core] : mock_nodes_and_local_cores_) {
+      const size_t global_core = mock_global_cores_.at(node).at(local_core);
       const typename Component::array_index array_index = global_core;
       mock_distributed_objects<Component>().emplace(
           array_index,
           MockDistributedObject<Component>(
-              NodeId{node_core_pair.first}, LocalCoreId{node_core_pair.second},
-              mock_global_cores_, mock_nodes_and_local_cores_, array_index,
+              NodeId{node}, LocalCoreId{local_core}, mock_global_cores_,
+              mock_nodes_and_local_cores_, array_index,
               caches_.at(global_core).get(),
               // Next line inserts element into inboxes_ and returns ptr to it.
               &(tuples::get<InboxesTag<Component>>(inboxes_)[array_index]),
@@ -323,25 +324,27 @@ class MockRuntimeSystem {
       Options&&... opts) noexcept {
     detail::get_initialization<Component>::initialize_databox_action::
         set_initial_values(initial_values);
-    auto iterator_bool = mock_distributed_objects<Component>().emplace(
-        array_index,
-        MockDistributedObject<Component>(
-            node_id, local_core_id, mock_global_cores_,
-            mock_nodes_and_local_cores_, array_index,
-            caches_
-                .at(mock_global_cores_.at(node_id.value)
-                        .at(local_core_id.value))
-                .get(),
-            // Next line inserts element into inboxes_ and returns ptr to it.
-            &(tuples::get<InboxesTag<Component>>(inboxes_)[array_index]),
-            std::forward<Options>(opts)...));
-    if (not iterator_bool.second) {
+    auto [iterator, emplace_was_successful] =
+        mock_distributed_objects<Component>().emplace(
+            array_index,
+            MockDistributedObject<Component>(
+                node_id, local_core_id, mock_global_cores_,
+                mock_nodes_and_local_cores_, array_index,
+                caches_
+                    .at(mock_global_cores_.at(node_id.value)
+                            .at(local_core_id.value))
+                    .get(),
+                // Next line inserts element into inboxes_ and returns ptr to
+                // it.
+                &(tuples::get<InboxesTag<Component>>(inboxes_)[array_index]),
+                std::forward<Options>(opts)...));
+    if (not emplace_was_successful) {
       ERROR("Failed to insert parallel component '"
             << pretty_type::get_name<Component>() << "' with index "
             << array_index);
     }
-    iterator_bool.first->second.set_phase(Metavariables::Phase::Initialization);
-    iterator_bool.first->second.next_action();
+    iterator->second.set_phase(Metavariables::Phase::Initialization);
+    iterator->second.next_action();
   }
 
   /// Emplace a singleton component that needs to be initialized.
@@ -359,25 +362,27 @@ class MockRuntimeSystem {
     const typename Component::array_index& array_index{0};
     detail::get_initialization<Component>::initialize_databox_action::
         set_initial_values(initial_values);
-    auto iterator_bool = mock_distributed_objects<Component>().emplace(
-        array_index,
-        MockDistributedObject<Component>(
-            node_id, local_core_id, mock_global_cores_,
-            mock_nodes_and_local_cores_, array_index,
-            caches_
-                .at(mock_global_cores_.at(node_id.value)
-                        .at(local_core_id.value))
-                .get(),
-            // Next line inserts element into inboxes_ and returns ptr to it.
-            &(tuples::get<InboxesTag<Component>>(inboxes_)[array_index]),
-            std::forward<Options>(opts)...));
-    if (not iterator_bool.second) {
+    auto [iterator, emplace_was_successful] =
+        mock_distributed_objects<Component>().emplace(
+            array_index,
+            MockDistributedObject<Component>(
+                node_id, local_core_id, mock_global_cores_,
+                mock_nodes_and_local_cores_, array_index,
+                caches_
+                    .at(mock_global_cores_.at(node_id.value)
+                            .at(local_core_id.value))
+                    .get(),
+                // Next line inserts element into inboxes_ and returns ptr to
+                // it.
+                &(tuples::get<InboxesTag<Component>>(inboxes_)[array_index]),
+                std::forward<Options>(opts)...));
+    if (not emplace_was_successful) {
       ERROR("Failed to insert parallel component '"
             << pretty_type::get_name<Component>() << "' with index "
             << array_index);
     }
-    iterator_bool.first->second.set_phase(Metavariables::Phase::Initialization);
-    iterator_bool.first->second.next_action();
+    iterator->second.set_phase(Metavariables::Phase::Initialization);
+    iterator->second.next_action();
   }
 
   /// Emplace a group component that needs to be initialized.
@@ -390,31 +395,31 @@ class MockRuntimeSystem {
         std::is_same_v<typename Component::chare_type, MockGroupChare>,
         "emplace_group_component_and_initialize expects a MockGroupChare");
     // Emplace once for each core, index by global_core.
-    for (const auto& node_core_pair : mock_nodes_and_local_cores_) {
+    for (const auto& [node, local_core] : mock_nodes_and_local_cores_) {
       // Need to set initial values for each component, since the
       // InitialDataBox action does a std::move.
       detail::get_initialization<Component>::initialize_databox_action::
           set_initial_values(initial_values);
-      const size_t global_core =
-          mock_global_cores_.at(node_core_pair.first).at(node_core_pair.second);
+      const size_t global_core = mock_global_cores_.at(node).at(local_core);
       const typename Component::array_index array_index = global_core;
-      auto iterator_bool = mock_distributed_objects<Component>().emplace(
-          array_index,
-          MockDistributedObject<Component>(
-              NodeId{node_core_pair.first}, LocalCoreId{node_core_pair.second},
-              mock_global_cores_, mock_nodes_and_local_cores_, array_index,
-              caches_.at(global_core).get(),
-              // Next line inserts element into inboxes_ and returns ptr to it.
-              &(tuples::get<InboxesTag<Component>>(inboxes_)[array_index]),
-              std::forward<Options>(opts)...));
-      if (not iterator_bool.second) {
+      auto [iterator, emplace_was_successful] =
+          mock_distributed_objects<Component>().emplace(
+              array_index,
+              MockDistributedObject<Component>(
+                  NodeId{node}, LocalCoreId{local_core}, mock_global_cores_,
+                  mock_nodes_and_local_cores_, array_index,
+                  caches_.at(global_core).get(),
+                  // Next line inserts element into inboxes_ and returns ptr to
+                  // it.
+                  &(tuples::get<InboxesTag<Component>>(inboxes_)[array_index]),
+                  std::forward<Options>(opts)...));
+      if (not emplace_was_successful) {
         ERROR("Failed to insert parallel component '"
               << pretty_type::get_name<Component>() << "' with index "
               << array_index);
       }
-      iterator_bool.first->second.set_phase(
-          Metavariables::Phase::Initialization);
-      iterator_bool.first->second.next_action();
+      iterator->second.set_phase(Metavariables::Phase::Initialization);
+      iterator->second.next_action();
     }
   }
 
@@ -437,23 +442,24 @@ class MockRuntimeSystem {
       const typename Component::array_index array_index = node;
       // Use first proc on each node as global_core
       const size_t global_core = mock_global_cores_.at(node).front();
-      auto iterator_bool = mock_distributed_objects<Component>().emplace(
-          array_index,
-          MockDistributedObject<Component>(
-              NodeId{node}, LocalCoreId{0}, mock_global_cores_,
-              mock_nodes_and_local_cores_, array_index,
-              caches_.at(global_core).get(),
-              // Next line inserts element into inboxes_ and returns ptr to it.
-              &(tuples::get<InboxesTag<Component>>(inboxes_)[array_index]),
-              std::forward<Options>(opts)...));
-      if (not iterator_bool.second) {
+      auto [iterator, emplace_was_successful] =
+          mock_distributed_objects<Component>().emplace(
+              array_index,
+              MockDistributedObject<Component>(
+                  NodeId{node}, LocalCoreId{0}, mock_global_cores_,
+                  mock_nodes_and_local_cores_, array_index,
+                  caches_.at(global_core).get(),
+                  // Next line inserts element into inboxes_ and returns ptr to
+                  // it.
+                  &(tuples::get<InboxesTag<Component>>(inboxes_)[array_index]),
+                  std::forward<Options>(opts)...));
+      if (not emplace_was_successful) {
         ERROR("Failed to insert parallel component '"
               << pretty_type::get_name<Component>() << "' with index "
               << array_index);
       }
-      iterator_bool.first->second.set_phase(
-          Metavariables::Phase::Initialization);
-      iterator_bool.first->second.next_action();
+      iterator->second.set_phase(Metavariables::Phase::Initialization);
+      iterator->second.next_action();
     }
   }
 

--- a/tests/Unit/Framework/MockRuntimeSystem.hpp
+++ b/tests/Unit/Framework/MockRuntimeSystem.hpp
@@ -171,10 +171,10 @@ class MockRuntimeSystem {
         mutable_caches_(mock_nodes_and_local_cores_.size()),
         caches_(mock_nodes_and_local_cores_.size()) {
     // Fill the parallel components in each cache.  There is one cache
-    // per mock core.  The parallel components on each cache (i.e. the
+    // per mock core.  The parallel components held in each cache (i.e. the
     // MockProxies) are filled with the same GlobalCache data, and are
     // passed the mock node and mock core associated with that cache.
-    // The actual chares on each cache are emplaced by the user explicitly
+    // The actual chares held in each cache are emplaced by the user explicitly
     // on a chosen node and core, via `emplace_component`.
     for (const auto& node_and_core : mock_nodes_and_local_cores_) {
       const size_t global_core =


### PR DESCRIPTION
## Proposed changes

Cleans up some of the ActionTesting code enabling mocking cores and nodes,
following comments made by @kidder and @nilsdeppe from PR #2792

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
