### PR TITLE
Have elliptic systems specify tags for their fluxes

### DIFF
--- a/tests/Unit/Elliptic/Systems/Poisson/Test_Equations.cpp
+++ b/tests/Unit/Elliptic/Systems/Poisson/Test_Equations.cpp
@@ -51,8 +51,7 @@ template <size_t Dim, Poisson::Geometry BackgroundGeometry>
 void test_computers(const DataVector& used_for_size) {
   CAPTURE(Dim);
   using system = Poisson::FirstOrderSystem<Dim, BackgroundGeometry>;
-  helpers::test_first_order_fluxes_computer<system>(
-      typename system::fluxes_computer{}, used_for_size);
+  helpers::test_first_order_fluxes_computer<system>(used_for_size);
   helpers::test_first_order_sources_computer<system>(used_for_size);
 }
 

--- a/tests/Unit/Helpers/Elliptic/FirstOrderSystem.hpp
+++ b/tests/Unit/Helpers/Elliptic/FirstOrderSystem.hpp
@@ -7,9 +7,9 @@
 #pragma once
 
 #include <cstddef>
+#include <limits>
 #include <random>
 #include <tuple>
-#include <limits>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
@@ -18,8 +18,6 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Variables.hpp"
 #include "DataStructures/VariablesTag.hpp"
-#include "Elliptic/FirstOrderComputeTags.hpp"
-#include "Elliptic/FirstOrderOperator.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Framework/TestingFramework.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
@@ -31,31 +29,23 @@ namespace TestHelpers {
 /// \ingroup TestingFrameworkGroup
 /// Helper functions to test elliptic first-order systems
 namespace elliptic {
+namespace detail {
 
-/*!
- * \brief Test the `System::fluxes_computer` is functional
- *
- * This function tests the following properties of the
- * `System::fluxes_computer`:
- *
- * - It works with the `elliptic::first_order_fluxes` function.
- * - It can be applied to a DataBox, i.e. its argument tags are consistent with
- *   its apply function.
- */
-template <typename System>
-void test_first_order_fluxes_computer(
-    const typename System::fluxes_computer& fluxes_computer,
-    const DataVector& used_for_size) {
-  using FluxesComputer = typename System::fluxes_computer;
-  static constexpr size_t volume_dim = System::volume_dim;
-  using vars_tag = typename System::fields_tag;
-  using primal_fields = typename System::primal_fields;
-  using auxiliary_fields = typename System::auxiliary_fields;
+template <typename FluxesComputer, typename... PrimalFields,
+          typename... AuxiliaryFields, typename... PrimalFluxes,
+          typename... AuxiliaryFluxes, typename... FluxesArgsTags>
+void test_first_order_fluxes_computer_impl(
+    const DataVector& used_for_size, tmpl::list<PrimalFields...> /*meta*/,
+    tmpl::list<AuxiliaryFields...> /*meta*/,
+    tmpl::list<PrimalFluxes...> /*meta*/,
+    tmpl::list<AuxiliaryFluxes...> /*meta*/,
+    tmpl::list<FluxesArgsTags...> /*meta*/) {
+  using vars_tag =
+      ::Tags::Variables<tmpl::list<PrimalFields..., AuxiliaryFields...>>;
   using VarsType = typename vars_tag::type;
   using fluxes_tag =
-      db::add_tag_prefix<::Tags::Flux, vars_tag, tmpl::size_t<volume_dim>,
-                         Frame::Inertial>;
-  using argument_tags = typename FluxesComputer::argument_tags;
+      ::Tags::Variables<tmpl::list<PrimalFluxes..., AuxiliaryFluxes...>>;
+  using FluxesType = typename fluxes_tag::type;
 
   MAKE_GENERATOR(generator);
   std::uniform_real_distribution<> dist(0.5, 2.);
@@ -65,72 +55,79 @@ void test_first_order_fluxes_computer(
       make_not_null(&generator), make_not_null(&dist), used_for_size);
 
   // Generate fluxes from the variables with random arguments
-  tuples::tagged_tuple_from_typelist<argument_tags> args{};
-  tmpl::for_each<argument_tags>(
-      [&args, &generator, &dist, &used_for_size](auto tag_v) {
-        using tag = tmpl::type_from<decltype(tag_v)>;
-        get<tag>(args) = make_with_random_values<typename tag::type>(
-            make_not_null(&generator), make_not_null(&dist), used_for_size);
-      });
-  const auto expected_fluxes = tuples::apply(
-      [&vars, &fluxes_computer](const auto&... expanded_args) {
-        return ::elliptic::first_order_fluxes<volume_dim, primal_fields,
-                                              auxiliary_fields>(
-            vars, fluxes_computer, expanded_args...);
-      },
-      args);
+  tuples::TaggedTuple<FluxesArgsTags...> fluxes_args{
+      make_with_random_values<typename FluxesArgsTags::type>(
+          make_not_null(&generator), make_not_null(&dist), used_for_size)...};
+  // Silence unused variable warning when fluxes args is empty
+  (void)fluxes_args;
+  FluxesType expected_fluxes{used_for_size.size()};
+  FluxesComputer::apply(make_not_null(&get<PrimalFluxes>(expected_fluxes))...,
+                        get<FluxesArgsTags>(fluxes_args)...,
+                        get<AuxiliaryFields>(vars)...);
+  FluxesComputer::apply(
+      make_not_null(&get<AuxiliaryFluxes>(expected_fluxes))...,
+      get<FluxesArgsTags>(fluxes_args)..., get<PrimalFields>(vars)...);
 
   // Create a DataBox
-  auto box = tuples::apply(
-      [&vars, &used_for_size](const auto&... expanded_args) {
-        return db::create<tmpl::append<db::AddSimpleTags<vars_tag, fluxes_tag>,
-                                       argument_tags>>(
-            vars,
-            make_with_value<typename fluxes_tag::type>(
-                used_for_size, std::numeric_limits<double>::signaling_NaN()),
-            expanded_args...);
-      },
-      args);
+  auto box =
+      db::create<db::AddSimpleTags<vars_tag, fluxes_tag, FluxesArgsTags...>>(
+          vars,
+          make_with_value<typename fluxes_tag::type>(
+              used_for_size, std::numeric_limits<double>::signaling_NaN()),
+          get<FluxesArgsTags>(fluxes_args)...);
 
   // Apply the fluxes computer to the DataBox
-  db::mutate_apply<db::wrap_tags_in<::Tags::Flux, primal_fields,
-                                    tmpl::size_t<volume_dim>, Frame::Inertial>,
-                   tmpl::append<argument_tags, auxiliary_fields>>(
-      fluxes_computer, make_not_null(&box));
-  db::mutate_apply<db::wrap_tags_in<::Tags::Flux, auxiliary_fields,
-                                    tmpl::size_t<volume_dim>, Frame::Inertial>,
-                   tmpl::append<argument_tags, primal_fields>>(
-      fluxes_computer, make_not_null(&box));
+  db::mutate_apply<tmpl::list<PrimalFluxes...>,
+                   tmpl::list<FluxesArgsTags..., AuxiliaryFields...>>(
+      FluxesComputer{}, make_not_null(&box));
+  db::mutate_apply<tmpl::list<AuxiliaryFluxes...>,
+                   tmpl::list<FluxesArgsTags..., PrimalFields...>>(
+      FluxesComputer{}, make_not_null(&box));
   CHECK(expected_fluxes == get<fluxes_tag>(box));
 }
 
+}  // namespace detail
+
 /*!
- * \brief Test the `System::sources_computer` is functional
+ * \brief Test the `System::fluxes_computer` is functional
  *
  * This function tests the following properties of the
- * `System::sources_computer`:
+ * `System::fluxes_computer`:
  *
- * - It works with the `elliptic::first_order_sources` function.
+ * - It works with the fields and fluxes specified in the `System`.
  * - It can be applied to a DataBox, i.e. its argument tags are consistent with
  *   its apply function.
  */
 template <typename System>
-void test_first_order_sources_computer(const DataVector& used_for_size) {
-  using SourcesComputer = typename System::sources_computer;
-  static constexpr size_t volume_dim = System::volume_dim;
-  using vars_tag = typename System::fields_tag;
-  using primal_fields = typename System::primal_fields;
-  using auxiliary_fields = typename System::auxiliary_fields;
+void test_first_order_fluxes_computer(const DataVector& used_for_size) {
+  detail::test_first_order_fluxes_computer_impl<
+      typename System::fluxes_computer>(
+      used_for_size, typename System::primal_fields{},
+      typename System::auxiliary_fields{}, typename System::primal_fluxes{},
+      typename System::auxiliary_fluxes{},
+      typename System::fluxes_computer::argument_tags{});
+}
+
+namespace detail {
+
+template <typename SourcesComputer, typename... PrimalFields,
+          typename... AuxiliaryFields, typename... PrimalFluxes,
+          typename... SourcesArgsTags>
+void test_first_order_sources_computer_impl(
+    const DataVector& used_for_size, tmpl::list<PrimalFields...> /*meta*/,
+    tmpl::list<AuxiliaryFields...> /*meta*/,
+    tmpl::list<PrimalFluxes...> /*meta*/,
+    tmpl::list<SourcesArgsTags...> /*meta*/) {
+  using vars_tag =
+      ::Tags::Variables<tmpl::list<PrimalFields..., AuxiliaryFields...>>;
   using VarsType = typename vars_tag::type;
-  using fluxes_tag =
-      db::add_tag_prefix<::Tags::Flux, vars_tag, tmpl::size_t<volume_dim>,
-                         Frame::Inertial>;
+  using fluxes_tag = ::Tags::Variables<tmpl::list<PrimalFluxes...>>;
   using FluxesType = typename fluxes_tag::type;
   using sources_tag = db::add_tag_prefix<::Tags::Source, vars_tag>;
-  using argument_tags = typename SourcesComputer::argument_tags;
+  using SourcesType = typename sources_tag::type;
 
   MAKE_GENERATOR(generator);
-  std::uniform_real_distribution<> dist(-1., 1.);
+  std::uniform_real_distribution<> dist(0.5, 2.);
 
   // Generate random variables and fluxes. Note that the sources make use of the
   // pre-computed fluxes as an optimization (see elliptic::first_order_sources),
@@ -142,50 +139,57 @@ void test_first_order_sources_computer(const DataVector& used_for_size) {
       make_not_null(&generator), make_not_null(&dist), used_for_size);
 
   // Generate sources from the variables with random arguments
-  tuples::tagged_tuple_from_typelist<argument_tags> args{};
-  tmpl::for_each<argument_tags>(
-      [&args, &generator, &dist, &used_for_size](auto tag_v) {
-        using tag = tmpl::type_from<decltype(tag_v)>;
-        get<tag>(args) = make_with_random_values<typename tag::type>(
-            make_not_null(&generator), make_not_null(&dist), used_for_size);
-      });
-  const auto expected_sources = tuples::apply(
-      [&vars, &fluxes](const auto&... expanded_args) {
-        return ::elliptic::first_order_sources<
-            volume_dim, primal_fields, auxiliary_fields, SourcesComputer>(
-            vars, fluxes, expanded_args...);
-      },
-      args);
+  tuples::TaggedTuple<SourcesArgsTags...> sources_args{
+      make_with_random_values<typename SourcesArgsTags::type>(
+          make_not_null(&generator), make_not_null(&dist), used_for_size)...};
+  // Silence unused variable warning when sources args is empty
+  (void)sources_args;
+  SourcesType expected_sources{used_for_size.size(), 0.};
+  SourcesComputer::apply(
+      make_not_null(&get<::Tags::Source<AuxiliaryFields>>(expected_sources))...,
+      get<SourcesArgsTags>(sources_args)..., get<PrimalFields>(vars)...);
+  SourcesComputer::apply(
+      make_not_null(&get<::Tags::Source<PrimalFields>>(expected_sources))...,
+      get<SourcesArgsTags>(sources_args)..., get<PrimalFields>(vars)...,
+      get<PrimalFluxes>(fluxes)...);
 
   // Create a DataBox
-  auto box = tuples::apply(
-      [&vars, &fluxes, &used_for_size](const auto&... expanded_args) {
-        return db::create<
-            tmpl::append<db::AddSimpleTags<vars_tag, fluxes_tag, sources_tag>,
-                         argument_tags>>(
-            vars, fluxes,
-            make_with_value<typename sources_tag::type>(used_for_size, 0.),
-            expanded_args...);
-      },
-      args);
-  tmpl::for_each<auxiliary_fields>([&vars, &box](auto tag_v) {
-    using tag = tmpl::type_from<decltype(tag_v)>;
-    db::mutate<::Tags::Source<tag>>(
-        make_not_null(&box),
-        [&vars](const auto aux_source) { *aux_source = get<tag>(vars); });
-  });
+  auto box = db::create<
+      db::AddSimpleTags<vars_tag, fluxes_tag, sources_tag, SourcesArgsTags...>>(
+      vars, fluxes,
+      make_with_value<typename sources_tag::type>(used_for_size, 0.),
+      get<SourcesArgsTags>(sources_args)...);
 
   // Apply the sources computer to the DataBox
-  db::mutate_apply<db::wrap_tags_in<::Tags::Source, auxiliary_fields>,
-                   tmpl::append<argument_tags, primal_fields>>(
+  db::mutate_apply<tmpl::list<::Tags::Source<AuxiliaryFields>...>,
+                   tmpl::list<SourcesArgsTags..., PrimalFields...>>(
       SourcesComputer{}, make_not_null(&box));
-  db::mutate_apply<db::wrap_tags_in<::Tags::Source, primal_fields>,
-                   tmpl::append<argument_tags, primal_fields,
-                                db::wrap_tags_in<::Tags::Flux, primal_fields,
-                                                 tmpl::size_t<volume_dim>,
-                                                 Frame::Inertial>>>(
+  db::mutate_apply<
+      tmpl::list<::Tags::Source<PrimalFields>...>,
+      tmpl::list<SourcesArgsTags..., PrimalFields..., PrimalFluxes...>>(
       SourcesComputer{}, make_not_null(&box));
   CHECK(expected_sources == get<sources_tag>(box));
+}
+
+}  // namespace detail
+
+/*!
+ * \brief Test the `System::sources_computer` is functional
+ *
+ * This function tests the following properties of the
+ * `System::sources_computer`:
+ *
+ * - It works with the fields and fluxes specified in the `System`.
+ * - It can be applied to a DataBox, i.e. its argument tags are consistent with
+ *   its apply function.
+ */
+template <typename System>
+void test_first_order_sources_computer(const DataVector& used_for_size) {
+  using sources_computer = typename System::sources_computer;
+  detail::test_first_order_sources_computer_impl<sources_computer>(
+      used_for_size, typename System::primal_fields{},
+      typename System::auxiliary_fields{}, typename System::primal_fluxes{},
+      typename sources_computer::argument_tags{});
 }
 
 }  // namespace elliptic

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_BentBeam.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_BentBeam.cpp
@@ -139,10 +139,9 @@ SPECTRE_TEST_CASE(
   {
     INFO("Test elasticity system with bent beam");
     using system = Elasticity::FirstOrderSystem<2>;
-    const typename system::fluxes_computer fluxes_computer{};
     // Verify that the solution numerically solves the system
     FirstOrderEllipticSolutionsTestHelpers::verify_solution<system>(
-        solution, fluxes_computer, mesh, coord_map,
+        solution, mesh, coord_map,
         std::numeric_limits<double>::epsilon() * 100.,
         std::make_tuple(constitutive_relation, inertial_coords));
   };

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_HalfSpaceMirror.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_HalfSpaceMirror.cpp
@@ -135,7 +135,6 @@ SPECTRE_TEST_CASE(
     INFO("Test elasticity system with half-space mirror");
     // Verify that the solution numerically solves the system
     using system = Elasticity::FirstOrderSystem<3>;
-    const typename system::fluxes_computer fluxes_computer{};
     using AffineMap = domain::CoordinateMaps::Affine;
     using AffineMap3D =
         domain::CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
@@ -146,7 +145,7 @@ SPECTRE_TEST_CASE(
     const auto logical_coords = logical_coordinates(mesh);
     const auto inertial_coords = coord_map(logical_coords);
     FirstOrderEllipticSolutionsTestHelpers::verify_solution<system>(
-        solution, fluxes_computer, mesh, coord_map, 0.05,
+        solution, mesh, coord_map, 0.05,
         std::make_tuple(constitutive_relation, inertial_coords));
   };
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_Zero.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Elasticity/Test_Zero.cpp
@@ -58,12 +58,11 @@ void test_solution() {
   using system = Elasticity::FirstOrderSystem<Dim>;
   Elasticity::ConstitutiveRelations::IsotropicHomogeneous<Dim>
       constitutive_relation{1., 1.};
-  const typename system::fluxes_computer fluxes_computer{};
   const Mesh<Dim> mesh{12, Spectral::Basis::Legendre,
                        Spectral::Quadrature::GaussLobatto};
   const auto coord_map = make_coord_map<Dim>();
   FirstOrderEllipticSolutionsTestHelpers::verify_solution<system>(
-      solution, fluxes_computer, mesh, coord_map, 1.e-14,
+      solution, mesh, coord_map, 1.e-14,
       std::make_tuple(constitutive_relation,
                       coord_map(logical_coordinates(mesh))));
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Lorentzian.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Lorentzian.cpp
@@ -86,7 +86,6 @@ SPECTRE_TEST_CASE(
     using system =
         Poisson::FirstOrderSystem<3, Poisson::Geometry::FlatCartesian>;
     const Poisson::Solutions::Lorentzian<3> solution{};
-    const typename system::fluxes_computer fluxes_computer{};
     using AffineMap = domain::CoordinateMaps::Affine;
     using AffineMap3D =
         domain::CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
@@ -94,7 +93,7 @@ SPECTRE_TEST_CASE(
         coord_map{
             {{-1., 1., -0.5, 0.5}, {-1., 1., -0.5, 0.5}, {-1., 1., -0.5, 0.5}}};
     FirstOrderEllipticSolutionsTestHelpers::verify_smooth_solution<system>(
-        solution, fluxes_computer, coord_map, 5.e1, 1.2,
+        solution, coord_map, 5.e1, 1.2,
         [](const auto&... /*unused*/) noexcept { return std::tuple<>{}; });
   }
 
@@ -103,7 +102,6 @@ SPECTRE_TEST_CASE(
     // Euclidean metric. This is more a test of the system than of the solution.
     using system = Poisson::FirstOrderSystem<3, Poisson::Geometry::Curved>;
     const Poisson::Solutions::Lorentzian<3> solution{};
-    const typename system::fluxes_computer fluxes_computer{};
     using AffineMap = domain::CoordinateMaps::Affine;
     using AffineMap3D =
         domain::CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
@@ -121,8 +119,7 @@ SPECTRE_TEST_CASE(
     const auto spatial_christoffel_contracted =
         make_with_value<tnsr::i<DataVector, 3>>(used_for_size, 0.);
     FirstOrderEllipticSolutionsTestHelpers::verify_solution<system>(
-        solution, fluxes_computer, mesh, coord_map, 0.1,
-        std::make_tuple(inv_spatial_metric),
+        solution, mesh, coord_map, 0.1, std::make_tuple(inv_spatial_metric),
         std::make_tuple(spatial_christoffel_contracted));
   }
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Moustache.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Moustache.cpp
@@ -85,12 +85,11 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Poisson.Moustache",
     using system =
         Poisson::FirstOrderSystem<1, Poisson::Geometry::FlatCartesian>;
     const Poisson::Solutions::Moustache<1> solution{};
-    const typename system::fluxes_computer fluxes_computer{};
     const domain::CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap>
         coord_map{{-1., 1., 0., 1.}};
     FirstOrderEllipticSolutionsTestHelpers::
-        verify_solution_with_power_law_convergence<system>(
-            solution, fluxes_computer, coord_map, 3.e1, 2.5);
+        verify_solution_with_power_law_convergence<system>(solution, coord_map,
+                                                           3.e1, 2.5);
   }
   {
     INFO("2D");
@@ -99,13 +98,12 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Poisson.Moustache",
     using system =
         Poisson::FirstOrderSystem<2, Poisson::Geometry::FlatCartesian>;
     const Poisson::Solutions::Moustache<2> solution{};
-    const typename system::fluxes_computer fluxes_computer{};
     using AffineMap2D =
         domain::CoordinateMaps::ProductOf2Maps<AffineMap, AffineMap>;
     const domain::CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap2D>
         coord_map{{{-1., 1., 0., 1.}, {-1., 1., 0., 1.}}};
     FirstOrderEllipticSolutionsTestHelpers::
-        verify_solution_with_power_law_convergence<system>(
-            solution, fluxes_computer, coord_map, 5., 2.);
+        verify_solution_with_power_law_convergence<system>(solution, coord_map,
+                                                           5., 2.);
   }
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_ProductOfSinusoids.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_ProductOfSinusoids.cpp
@@ -94,11 +94,10 @@ SPECTRE_TEST_CASE(
     using system =
         Poisson::FirstOrderSystem<1, Poisson::Geometry::FlatCartesian>;
     const Poisson::Solutions::ProductOfSinusoids<1> solution{{{0.5}}};
-    const typename system::fluxes_computer fluxes_computer{};
     const domain::CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap>
         coord_map{{-1., 1., 0., M_PI}};
     FirstOrderEllipticSolutionsTestHelpers::verify_smooth_solution<system>(
-        solution, fluxes_computer, coord_map, 1.e5, 3.,
+        solution, coord_map, 1.e5, 3.,
         [](const auto&... /*unused*/) noexcept { return std::tuple<>{}; });
   }
   {
@@ -108,13 +107,12 @@ SPECTRE_TEST_CASE(
     using system =
         Poisson::FirstOrderSystem<2, Poisson::Geometry::FlatCartesian>;
     const Poisson::Solutions::ProductOfSinusoids<2> solution{{{0.5, 0.5}}};
-    const typename system::fluxes_computer fluxes_computer{};
     using AffineMap2D =
         domain::CoordinateMaps::ProductOf2Maps<AffineMap, AffineMap>;
     const domain::CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap2D>
         coord_map{{{-1., 1., 0., M_PI}, {-1., 1., 0., M_PI}}};
     FirstOrderEllipticSolutionsTestHelpers::verify_smooth_solution<system>(
-        solution, fluxes_computer, coord_map, 1.e5, 3.,
+        solution, coord_map, 1.e5, 3.,
         [](const auto&... /*unused*/) noexcept { return std::tuple<>{}; });
   }
   {
@@ -124,14 +122,13 @@ SPECTRE_TEST_CASE(
     using system =
         Poisson::FirstOrderSystem<3, Poisson::Geometry::FlatCartesian>;
     const Poisson::Solutions::ProductOfSinusoids<3> solution{{{0.5, 0.5, 0.5}}};
-    const typename system::fluxes_computer fluxes_computer{};
     using AffineMap3D =
         domain::CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
     const domain::CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap3D>
         coord_map{
             {{-1., 1., 0., M_PI}, {-1., 1., 0., M_PI}, {-1., 1., 0., M_PI}}};
     FirstOrderEllipticSolutionsTestHelpers::verify_smooth_solution<system>(
-        solution, fluxes_computer, coord_map, 1.e5, 3.,
+        solution, coord_map, 1.e5, 3.,
         [](const auto&... /*unused*/) noexcept { return std::tuple<>{}; });
   }
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Zero.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Zero.cpp
@@ -56,12 +56,11 @@ void test_solution() {
 
   using system =
       Poisson::FirstOrderSystem<Dim, Poisson::Geometry::FlatCartesian>;
-  const typename system::fluxes_computer fluxes_computer{};
   const Mesh<Dim> mesh{12, Spectral::Basis::Legendre,
                        Spectral::Quadrature::GaussLobatto};
   const auto coord_map = make_coord_map<Dim>();
   FirstOrderEllipticSolutionsTestHelpers::verify_solution<system>(
-      solution, fluxes_computer, mesh, coord_map, 1.e-14);
+      solution, mesh, coord_map, 1.e-14);
 }
 
 }  // namespace


### PR DESCRIPTION
## Proposed changes

The upcoming elliptic DG operator will support fluxes with symmetries as an optimization, e.g. for elasticity systems the symmetric "stress" tag will be used because that's what the divergence is taken of. For the XCTS system one of the tags will be the symmetric "longitudinal shift".

This PR adds the type lists to the systems and updates the test helpers to support them. As a perk this actually makes the test helpers independent of the code in `Elliptic/FirstOrderOperator.hpp` and `Elliptic/FirstOrderComputeTags.hpp`, so those files can just be deleted with the upcoming elliptic DG operator.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
