### PR TITLE
Support Pypp random-tests for functions that mutate their result buffer

### DIFF
--- a/tests/Unit/Elliptic/Systems/Elasticity/Test_Equations.cpp
+++ b/tests/Unit/Elliptic/Systems/Elasticity/Test_Equations.cpp
@@ -42,37 +42,14 @@ void primal_fluxes(
 }
 
 template <size_t Dim>
-void add_curved_sources(
-    const gsl::not_null<tnsr::I<DataVector, Dim>*> source_for_displacement,
-    const tnsr::Ijj<DataVector, Dim>& christoffel_second_kind,
-    const tnsr::i<DataVector, Dim>& christoffel_contracted,
-    const tnsr::II<DataVector, Dim>& stress) noexcept {
-  std::fill(source_for_displacement->begin(), source_for_displacement->end(),
-            0.);
-  Elasticity::add_curved_sources(source_for_displacement,
-                                 christoffel_second_kind,
-                                 christoffel_contracted, stress);
-}
-
-template <size_t Dim>
-void add_curved_auxiliary_sources(
-    const gsl::not_null<tnsr::ii<DataVector, Dim>*> source_for_strain,
-    const tnsr::ijj<DataVector, Dim>& christoffel_first_kind,
-    const tnsr::I<DataVector, Dim>& displacement) noexcept {
-  std::fill(source_for_strain->begin(), source_for_strain->end(), 0.);
-  Elasticity::add_curved_auxiliary_sources(
-      source_for_strain, christoffel_first_kind, displacement);
-}
-
-template <size_t Dim>
 void test_equations(const DataVector& used_for_size) {
   pypp::check_with_random_values<4>(
       &primal_fluxes<Dim>, "Equations",
       {MakeString{} << "primal_fluxes_" << Dim << "d"},
       {{{-1., 1.}, {-1., 1.}, {0., 1.}, {0., 1.}}}, used_for_size);
-  pypp::check_with_random_values<1>(&add_curved_sources<Dim>, "Equations",
-                                    {"add_curved_sources"}, {{{-1., 1.}}},
-                                    used_for_size);
+  pypp::check_with_random_values<1>(
+      &Elasticity::add_curved_sources<Dim>, "Equations", {"add_curved_sources"},
+      {{{-1., 1.}}}, used_for_size, 1.e-12, {}, 0.);
   pypp::check_with_random_values<1>(&Elasticity::auxiliary_fluxes<Dim>,
                                     "Equations", {"auxiliary_fluxes"},
                                     {{{-1., 1.}}}, used_for_size);
@@ -80,8 +57,9 @@ void test_equations(const DataVector& used_for_size) {
                                     "Equations", {"curved_auxiliary_fluxes"},
                                     {{{-1., 1.}}}, used_for_size);
   pypp::check_with_random_values<1>(
-      &add_curved_auxiliary_sources<Dim>, "Equations",
-      {"add_curved_auxiliary_sources"}, {{{-1., 1.}}}, used_for_size);
+      &Elasticity::add_curved_auxiliary_sources<Dim>, "Equations",
+      {"add_curved_auxiliary_sources"}, {{{-1., 1.}}}, used_for_size, 1.e-12,
+      {}, 0.);
 }
 
 template <size_t Dim>

--- a/tests/Unit/Elliptic/Systems/Poisson/Test_Equations.cpp
+++ b/tests/Unit/Elliptic/Systems/Poisson/Test_Equations.cpp
@@ -21,16 +21,6 @@ namespace helpers = TestHelpers::elliptic;
 namespace {
 
 template <size_t Dim>
-void add_curved_sources(
-    const gsl::not_null<Scalar<DataVector>*> source_for_field,
-    const tnsr::i<DataVector, Dim>& christoffel_contracted,
-    const tnsr::I<DataVector, Dim>& flux_for_field) {
-  std::fill(source_for_field->begin(), source_for_field->end(), 0.);
-  Poisson::add_curved_sources(source_for_field, christoffel_contracted,
-                              flux_for_field);
-}
-
-template <size_t Dim>
 void test_equations(const DataVector& used_for_size) {
   pypp::check_with_random_values<1>(&Poisson::flat_cartesian_fluxes<Dim>,
                                     "Equations", {"flat_cartesian_fluxes"},
@@ -38,9 +28,9 @@ void test_equations(const DataVector& used_for_size) {
   pypp::check_with_random_values<1>(&Poisson::curved_fluxes<Dim>, "Equations",
                                     {"curved_fluxes"}, {{{0., 1.}}},
                                     used_for_size);
-  pypp::check_with_random_values<1>(&add_curved_sources<Dim>, "Equations",
-                                    {"add_curved_sources"}, {{{0., 1.}}},
-                                    used_for_size);
+  pypp::check_with_random_values<1>(
+      &Poisson::add_curved_sources<Dim>, "Equations", {"add_curved_sources"},
+      {{{0., 1.}}}, used_for_size, 1.e-12, {}, 0.);
   pypp::check_with_random_values<1>(
       &Poisson::auxiliary_fluxes<Dim>, "Equations",
       {MakeString{} << "auxiliary_fluxes_" << Dim << "d"}, {{{0., 1.}}},

--- a/tests/Unit/Framework/Tests/Test_PyppRandomValues.cpp
+++ b/tests/Unit/Framework/Tests/Test_PyppRandomValues.cpp
@@ -53,6 +53,17 @@ void check_single_not_null2(const gsl::not_null<T*> result, const T& t0,
 }
 
 template <typename T>
+void check_single_not_null3(const gsl::not_null<T*> result,
+                            const T& t0) noexcept {
+  // This function _adds_ to the result tensor, instead of assigning to it
+  if constexpr (tt::is_a_v<Tensor, T>) {
+    get(*result) += get(t0) + 3.0;
+  } else {
+    *result += t0 + 3.0;
+  }
+}
+
+template <typename T>
 void check_double_not_null0(const gsl::not_null<T*> result0,
                             const gsl::not_null<T*> result1,
                             const T& t0) noexcept {
@@ -337,6 +348,9 @@ void test_free(const T& value) {
   pypp::check_with_random_values<2>(&check_single_not_null2<T>, "PyppPyTests",
                                     {"check_single_not_null2"},
                                     {{{0.0, 10.0}, {-10.0, 0.0}}}, value);
+  pypp::check_with_random_values<1>(&check_single_not_null3<T>, "PyppPyTests",
+                                    {"check_single_not_null0"},
+                                    {{{-10.0, 10.0}}}, value, 1.e-12, {}, 2.);
 
   pypp::check_with_random_values<1>(
       &check_double_not_null0<T>, "PyppPyTests",


### PR DESCRIPTION
## Proposed changes

This adds an optional argument to `check_with_random_values` that allows initializing the `gsl::not_null` arguments with a particular value instead of random data, to test functions that _mutate_ the result buffer instead of assigning to it. This saves ~200 lines of wrapping code in the XCTS tests in #2667. The second commit gives an example for how it simplifies the tests.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
