### PR TITLE
Change python interface for opening h5 files in modes like `readonly` or `readwrite`

### DIFF
--- a/src/IO/H5/File.hpp
+++ b/src/IO/H5/File.hpp
@@ -151,7 +151,7 @@ class H5File {
   void close_current_object() const noexcept { current_object_ = nullptr; }
 
   template <typename ObjectType>
-  bool exists(const std::string& path) noexcept {
+  bool exists(const std::string& path) const noexcept {
     auto exists_group_name = check_if_object_exists<ObjectType>(path);
     return std::get<0>(exists_group_name);
   }

--- a/src/IO/H5/Python/CMakeLists.txt
+++ b/src/IO/H5/Python/CMakeLists.txt
@@ -17,6 +17,7 @@ spectre_python_add_module(
 spectre_python_link_libraries(
   ${LIBRARY}
   PRIVATE
+  Boost::boost
   DataStructures
   IO
   pybind11::module

--- a/src/IO/H5/Python/File.cpp
+++ b/src/IO/H5/Python/File.cpp
@@ -1,6 +1,7 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include <boost/algorithm/string/join.hpp>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <string>
@@ -9,42 +10,145 @@
 #include "IO/H5/Dat.hpp"
 #include "IO/H5/File.hpp"
 #include "IO/H5/VolumeData.hpp"
+#include "Utilities/MakeString.hpp"
 
 namespace py = pybind11;
 
 namespace py_bindings {
-void bind_h5file(py::module& m) {  // NOLINT
+template <h5::AccessType Access_t>
+void bind_h5file_impl(py::module& m) {  // NOLINT
   // Wrapper for basic H5File operations
-  using h5_file_rw = h5::H5File<h5::AccessType::ReadWrite>;
-  py::class_<h5_file_rw>(m, "H5File")
-      .def(py::init<std::string, bool>(), py::arg("file_name"),
-           py::arg("append_to_file") = false)
-      .def("name", &h5_file_rw::name)
-      .def(
-          "get_dat",
-          +[](const h5_file_rw& f, const std::string& path) -> const h5::Dat& {
-            return f.get<h5::Dat>(path);
-          },
-          py::return_value_policy::reference, py::arg("path"))
-      .def(
-          "insert_dat",
-          +[](h5_file_rw& f, const std::string& path,
-              const std::vector<std::string>& legend, const uint32_t version) {
-            f.insert<h5::Dat>(path, legend, version);
-          },
-          py::arg("path"), py::arg("legend"), py::arg("version"))
-      .def("close", &h5_file_rw::close_current_object)
-      .def("groups", &h5_file_rw::groups)
-      .def(
-          "get_vol",
-          +[](const h5_file_rw& f, const std::string& path)
-              -> const h5::VolumeData& { return f.get<h5::VolumeData>(path); },
-          py::return_value_policy::reference, py::arg("path"))
-      .def(
-          "insert_vol",
-          +[](h5_file_rw& f, const std::string& path, const uint32_t version) {
-            f.insert<h5::VolumeData>(path, version);
-          },
-          py::arg("path"), py::arg("version"));
+  // Manually check for existence as we currently can not propagate exceptions
+  // that can be caught by pybind, see issue #2312
+  using H5File = h5::H5File<Access_t>;
+  auto bind_h5_file =
+      py::class_<H5File>(
+          m,
+          (std::string("_H5File") +
+           (Access_t == h5::AccessType::ReadWrite ? "ReadWrite" : "ReadOnly"))
+              .c_str())
+          .def("name", &H5File::name)
+          .def(
+              "get_dat",
+              [](const H5File& f, const std::string& path) -> const h5::Dat& {
+                if (not f.template exists<h5::Dat>(path)) {
+                  const auto subfiles =
+                      boost::algorithm::join(f.groups(), ", ");
+                  throw std::runtime_error(
+                      "Subfile `" + path + "` was not found in file `" +
+                      f.name() + "`. Available subfiles are:\n" + subfiles);
+                }
+                return f.template get<h5::Dat>(path);
+              },
+              py::return_value_policy::reference, py::arg("path"))
+          .def("close", &H5File::close_current_object)
+          .def("groups", &H5File::groups)
+          .def(
+              "get_vol",
+              [](const H5File& f,
+                 const std::string& path) -> const h5::VolumeData& {
+                if (not f.template exists<h5::VolumeData>(path)) {
+                  const auto subfiles =
+                      boost::algorithm::join(f.groups(), ", ");
+                  throw std::runtime_error(
+                      "Subfile `" + path + "` was not found in file `" +
+                      f.name() + "`. Available subfiles are:\n" + subfiles);
+                }
+                return f.template get<h5::VolumeData>(path);
+              },
+              py::return_value_policy::reference, py::arg("path"))
+          .def("__enter__", [](H5File& file) -> H5File& { return file; })
+          .def("__exit__", [](H5File& f, const py::object& /* exception_type */,
+                              const py::object& /* val */,
+                              const py::object& /* traceback */) {
+            f.close_current_object();
+          });
+
+  if constexpr (Access_t == h5::AccessType::ReadWrite) {
+    bind_h5_file
+        .def(
+            "insert_dat",
+            [](H5File& f, const std::string& path,
+               const std::vector<std::string>& legend,
+               const uint32_t version) -> h5::Dat& {
+              if (f.template exists<h5::Dat>(path)) {
+                throw std::runtime_error("A subfile with name `" + path +
+                                         "` already exists in file `" +
+                                         f.name() + "`.");
+              }
+              return f.template insert<h5::Dat>(path, legend, version);
+            },
+            py::return_value_policy::reference, py::arg("path"),
+            py::arg("legend"), py::arg("version"))
+        .def(
+            "insert_vol",
+            [](H5File& f, const std::string& path,
+               const uint32_t version) -> h5::VolumeData& {
+              if (f.template exists<h5::VolumeData>(path)) {
+                throw std::runtime_error("A subfile with name `" + path +
+                                         "` already exists in file `" +
+                                         f.name() + "`.");
+              }
+              return f.template insert<h5::VolumeData>(path, version);
+            },
+            py::return_value_policy::reference, py::arg("path"),
+            py::arg("version"));
+  }
+}
+void bind_h5file(py::module& m) {  // NOLINT
+  bind_h5file_impl<h5::AccessType::ReadOnly>(m);
+  bind_h5file_impl<h5::AccessType::ReadWrite>(m);
+
+  m.def(
+      "H5File",
+      [](const std::string& file_name, const std::string& mode) {
+        const bool file_exists = file_system::check_if_file_exists(file_name);
+        if (mode == "r") {
+          // Readonly, file must exist (default)
+          if (not file_exists) {
+            throw std::runtime_error(
+                "File " + file_name +
+                " does not exist. To create the file open in another mode");
+          }
+          return py::cast(
+              h5::H5File<h5::AccessType::ReadOnly>{file_name, false});
+        } else if (mode == "r+") {
+          // Read/write, file must exist
+          if (not file_exists) {
+            throw std::runtime_error(
+                "File " + file_name +
+                " does not exist. To create the file open in another mode");
+          }
+          return py::cast(
+              h5::H5File<h5::AccessType::ReadWrite>{file_name, true});
+        } else if (mode == "w") {
+          // Create file, truncate if exists
+          std::invalid_argument(
+              "Overwriting files is not implemented. Open the file in 'a' mode "
+              "to append to it.");
+        } else if (mode == "w-" or mode == "x") {
+          // Create file, fail if exists
+          if (file_exists) {
+            throw std::runtime_error(
+                "File " + file_name +
+                " already exists. Please access it in a different mode.");
+          }
+          return py::cast(
+              h5::H5File<h5::AccessType::ReadWrite>{file_name, false});
+        } else if (mode == "a") {
+          // Read/write if exists, create otherwise
+          return py::cast(
+              h5::H5File<h5::AccessType::ReadWrite>{file_name, true});
+        }
+        throw std::invalid_argument(
+            "'" + mode + "'" +
+            "is not a valid mode. Available modes are 'r', "
+            "'r+', 'w-', 'x', and 'a'");
+      },
+      py::arg("file_name"), py::arg("mode") = "r",
+      "Open an H5File object\n\nfile_name: the name of the H5File to "
+      "open\nmode: mode to open the file. Available modes are 'r', 'r+', 'w-', "
+      "'x', and 'a'. For details see "
+      "https://docs.h5py.org/en/stable/high/file.html");
 }
 }  // namespace py_bindings

--- a/tests/Unit/IO/Test_VolumeData.py
+++ b/tests/Unit/IO/Test_VolumeData.py
@@ -20,8 +20,7 @@ class TestVolumeDataWriting(unittest.TestCase):
                                       "IO/TestVolumeDataWriting.h5")
         if os.path.isfile(self.file_name):
             os.remove(self.file_name)
-        self.h5_file = spectre_h5.H5File(file_name=self.file_name,
-                                         append_to_file=True)
+        self.h5_file = spectre_h5.H5File(file_name=self.file_name, mode="a")
 
     def tearDown(self):
         self.h5_file.close()
@@ -52,8 +51,7 @@ class TestVolumeData(unittest.TestCase):
         if os.path.isfile(self.file_name):
             os.remove(self.file_name)
 
-        self.h5_file = spectre_h5.H5File(file_name=self.file_name,
-                                         append_to_file=True)
+        self.h5_file = spectre_h5.H5File(file_name=self.file_name, mode="a")
         self.tensor_component_data = np.random.rand(4, 8)
         observation_ids = [0, 1]
         observation_values = {0: 7.0, 1: 1.3}


### PR DESCRIPTION
## Proposed changes
The python bindings for opening h5 files are extended to include a `readonly` and `readwrite` mode. Exceptions are explicitly thrown so the python kernel does not crash ever time an error is encountered. This is a fix for a lot of cases of #2312 though  exception propagation on the C++ side would be ideal.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
When opening h5 files with python bindings, you now have to specify the opening mode, see https://docs.h5py.org/en/stable/high/file.html
The old version is equivalent to opening with `a` (append) mode.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
