### PR TITLE
Test_CylindricalEndcap: relax conditions of test.

### DIFF
--- a/tests/Unit/Domain/CoordinateMaps/Test_CylindricalEndcap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CylindricalEndcap.cpp
@@ -45,10 +45,10 @@ void test_cylindrical_endcap() {
   CAPTURE(radius_one);
 
   // Make sure z_plane intersects sphere_one on the +z side of the
-  // center. We don't allow the plane to be displaced by less than 10%
+  // center. We don't allow the plane to be displaced by less than 20%
   // or more than 90% of the radius.
   const double z_plane =
-      center_one[2] + (0.1 + 0.8 * unit_dis(gen)) * radius_one;
+      center_one[2] + (0.2 + 0.7 * unit_dis(gen)) * radius_one;
   CAPTURE(z_plane);
 
   // Now construct sphere_two which we make sure encloses sphere_one,


### PR DESCRIPTION
Fixes #2879 by relaxing the domain of validity of the inputs that are passed into the constructor in the test.

The test will be rewritten anyway by #2587, and #2587 is a better solution, so only merge this PR if #2879 is getting in the way of others making progress.
### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
