### PR TITLE
Simplify periodic boundary conditions, and add None boundary condition

### DIFF
--- a/src/Domain/BoundaryConditions/CMakeLists.txt
+++ b/src/Domain/BoundaryConditions/CMakeLists.txt
@@ -8,6 +8,7 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  None.cpp
   Periodic.cpp
   )
 
@@ -17,6 +18,7 @@ spectre_target_headers(
   HEADERS
   BoundaryCondition.hpp
   GetBoundaryConditionsBase.hpp
+  None.hpp
   Periodic.hpp
   )
 

--- a/src/Domain/BoundaryConditions/None.cpp
+++ b/src/Domain/BoundaryConditions/None.cpp
@@ -1,0 +1,16 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/BoundaryConditions/None.hpp"
+
+namespace domain::BoundaryConditions {
+namespace detail {
+MarkAsNone::~MarkAsNone() = default;
+}  // namespace detail
+
+bool is_none(
+    const std::unique_ptr<BoundaryCondition>& boundary_condition) noexcept {
+  return dynamic_cast<const detail::MarkAsNone* const>(
+             boundary_condition.get()) != nullptr;
+}
+}  // namespace domain::BoundaryConditions

--- a/src/Domain/BoundaryConditions/None.hpp
+++ b/src/Domain/BoundaryConditions/None.hpp
@@ -1,0 +1,103 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <pup.h>
+
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace domain::BoundaryConditions {
+namespace detail {
+class MarkAsNone {
+ public:
+  MarkAsNone() = default;
+  MarkAsNone(MarkAsNone&&) noexcept = default;
+  MarkAsNone& operator=(MarkAsNone&&) noexcept = default;
+  MarkAsNone(const MarkAsNone&) = default;
+  MarkAsNone& operator=(const MarkAsNone&) = default;
+  virtual ~MarkAsNone() = 0;
+};
+}  // namespace detail
+
+/*!
+ * \brief None boundary conditions.
+ *
+ * This boundary condition doesn't actually do anything, and gets pretty much
+ * completely ignored by everything but the domain creator internals. The domain
+ * creator internals can use `None` as a way of specifying "boundary conditions"
+ * without a system. It can also be used in cases like the BinaryCompactObject
+ * domain where there may be no excision boundaries, and so the excision
+ * boundary condition must be `None` in that case so the domain creator can be
+ * sure the domain is set in a consistent state.
+ *
+ * To use with a specific system add:
+ *
+ * \code
+ *  domain::BoundaryConditions::None<your::system::BoundaryConditionBase>
+ * \endcode
+ *
+ * to the list of creatable classes.
+ *
+ * \warning if you want an outflow boundary condition, you must implement one,
+ * not use `None.
+ */
+template <typename SystemBoundaryConditionBaseClass>
+struct None final : public SystemBoundaryConditionBaseClass,
+                    public detail::MarkAsNone {
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help{
+      "None boundary condition. Used only during domain creation to ensure a "
+      "consistent state to the domain."};
+  static std::string name() noexcept { return "None"; }
+
+  None() = default;
+  None(None&&) noexcept = default;
+  None& operator=(None&&) noexcept = default;
+  None(const None&) = default;
+  None& operator=(const None&) = default;
+  ~None() override = default;
+
+  explicit None(CkMigrateMessage* msg) noexcept;
+
+  WRAPPED_PUPable_decl_base_template(
+      domain::BoundaryConditions::BoundaryCondition, None);
+
+  auto get_clone() const noexcept -> std::unique_ptr<
+      domain::BoundaryConditions::BoundaryCondition> override;
+
+  void pup(PUP::er& p) override;
+};
+
+template <typename SystemBoundaryConditionBaseClass>
+None<SystemBoundaryConditionBaseClass>::None(
+    CkMigrateMessage* const msg) noexcept
+    : SystemBoundaryConditionBaseClass(msg) {}
+
+template <typename SystemBoundaryConditionBaseClass>
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+None<SystemBoundaryConditionBaseClass>::get_clone() const noexcept {
+  return std::make_unique<None>(*this);
+}
+
+template <typename SystemBoundaryConditionBaseClass>
+void None<SystemBoundaryConditionBaseClass>::pup(PUP::er& p) {
+  BoundaryCondition::pup(p);
+}
+
+/// \cond
+template <typename SystemBoundaryConditionBaseClass>
+// NOLINTNEXTLINE
+PUP::able::PUP_ID None<SystemBoundaryConditionBaseClass>::my_PUP_ID = 0;
+/// \endcond
+
+/// Check if a boundary condition inherits from `MarkAsNone`, which
+/// constitutes as it being marked as a none boundary condition.
+bool is_none(
+    const std::unique_ptr<BoundaryCondition>& boundary_condition) noexcept;
+}  // namespace domain::BoundaryConditions

--- a/src/Domain/BoundaryConditions/Periodic.cpp
+++ b/src/Domain/BoundaryConditions/Periodic.cpp
@@ -4,11 +4,11 @@
 #include "Domain/BoundaryConditions/Periodic.hpp"
 
 namespace domain::BoundaryConditions {
-Periodic::~Periodic() = default;
+MarkAsPeriodic::~MarkAsPeriodic() = default;
 
 bool is_periodic(
     const std::unique_ptr<BoundaryCondition>& boundary_condition) noexcept {
-  return dynamic_cast<const Periodic* const>(boundary_condition.get()) !=
+  return dynamic_cast<const MarkAsPeriodic* const>(boundary_condition.get()) !=
          nullptr;
 }
 }  // namespace domain::BoundaryConditions

--- a/src/Domain/BoundaryConditions/Periodic.hpp
+++ b/src/Domain/BoundaryConditions/Periodic.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <memory>
 #include <pup.h>
 
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
@@ -18,18 +19,83 @@ namespace domain::BoundaryConditions {
 /// determine what boundaries are periodic. Across each matching pair of
 /// periodic boundary conditions, the domain creator should specify that the DG
 /// elements are neighbors of each other.
-class Periodic {
+class MarkAsPeriodic {
  public:
+  MarkAsPeriodic() = default;
+  MarkAsPeriodic(MarkAsPeriodic&&) noexcept = default;
+  MarkAsPeriodic& operator=(MarkAsPeriodic&&) noexcept = default;
+  MarkAsPeriodic(const MarkAsPeriodic&) = default;
+  MarkAsPeriodic& operator=(const MarkAsPeriodic&) = default;
+  virtual ~MarkAsPeriodic() = 0;
+};
+
+/*!
+ * \brief Periodic boundary conditions.
+ *
+ * To use with a specific system add:
+ *
+ * \code
+ *  domain::BoundaryConditions::Periodic<your::system::BoundaryConditionBase>
+ * \endcode
+ *
+ * to the list of creatable classes.
+ *
+ * \note Not all domain creators will allow you to specify periodic boundary
+ * conditions since they may not make sense.
+ */
+template <typename SystemBoundaryConditionBaseClass>
+struct Periodic final : public SystemBoundaryConditionBaseClass,
+                        public MarkAsPeriodic {
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help{
+      "Periodic boundary conditions.\n\nNote: Not all domain creators will "
+      "allow you to specify periodic boundary conditions since they may not "
+      "make sense."};
+  static std::string name() noexcept { return "Periodic"; }
+
   Periodic() = default;
   Periodic(Periodic&&) noexcept = default;
   Periodic& operator=(Periodic&&) noexcept = default;
   Periodic(const Periodic&) = default;
   Periodic& operator=(const Periodic&) = default;
-  virtual ~Periodic() = 0;
+  ~Periodic() override = default;
+
+  explicit Periodic(CkMigrateMessage* msg) noexcept;
+
+  WRAPPED_PUPable_decl_base_template(
+      domain::BoundaryConditions::BoundaryCondition, Periodic);
+
+  auto get_clone() const noexcept -> std::unique_ptr<
+      domain::BoundaryConditions::BoundaryCondition> override;
+
+  void pup(PUP::er& p) override;
 };
 
-/// Check if a boundary condition inherits from `Periodic`, which constitutes as
-/// it being marked as a periodic boundary condition.
+template <typename SystemBoundaryConditionBaseClass>
+Periodic<SystemBoundaryConditionBaseClass>::Periodic(
+    CkMigrateMessage* const msg) noexcept
+    : SystemBoundaryConditionBaseClass(msg) {}
+
+template <typename SystemBoundaryConditionBaseClass>
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+Periodic<SystemBoundaryConditionBaseClass>::get_clone() const noexcept {
+  return std::make_unique<Periodic>(*this);
+}
+
+template <typename SystemBoundaryConditionBaseClass>
+void Periodic<SystemBoundaryConditionBaseClass>::pup(PUP::er& p) {
+  BoundaryCondition::pup(p);
+}
+
+/// \cond
+template <typename SystemBoundaryConditionBaseClass>
+// NOLINTNEXTLINE
+PUP::able::PUP_ID Periodic<SystemBoundaryConditionBaseClass>::my_PUP_ID = 0;
+/// \endcond
+
+/// Check if a boundary condition inherits from `MarkAsPeriodic`, which
+/// constitutes as it being marked as a periodic boundary condition.
 bool is_periodic(
     const std::unique_ptr<BoundaryCondition>& boundary_condition) noexcept;
 }  // namespace domain::BoundaryConditions

--- a/src/Domain/Creators/AlignedLattice.cpp
+++ b/src/Domain/Creators/AlignedLattice.cpp
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "Domain/BoundaryConditions/None.hpp"
 #include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
@@ -106,6 +107,13 @@ AlignedLattice<VolumeDim>::AlignedLattice(
           block_bounds_,
           [](const std::vector<double>& v) noexcept { return v.size() - 1; })},
       boundary_condition_(std::move(boundary_condition)) {
+  using domain::BoundaryConditions::is_none;
+  if (is_none(boundary_condition_)) {
+    PARSE_ERROR(
+        context,
+        "None boundary condition is not supported. If you would like an "
+        "outflow boundary condition, you must use that.");
+  }
   using domain::BoundaryConditions::is_periodic;
   if (is_periodic(boundary_condition_)) {
     is_periodic_in_[0] = true;

--- a/src/Domain/Creators/Brick.cpp
+++ b/src/Domain/Creators/Brick.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "Domain/Block.hpp"  // IWYU pragma: keep
+#include "Domain/BoundaryConditions/None.hpp"
 #include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
@@ -59,7 +60,8 @@ Brick::Brick(
     std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
         boundary_condition,
     std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
-        time_dependence) noexcept
+        time_dependence,
+    const Options::Context& context)
     // clang-tidy: trivially copyable
     : lower_xyz_(std::move(lower_xyz)),  // NOLINT
       upper_xyz_(std::move(upper_xyz)),  // NOLINT
@@ -73,6 +75,13 @@ Brick::Brick(
   if (time_dependence_ == nullptr) {
     time_dependence_ =
         std::make_unique<domain::creators::time_dependence::None<3>>();
+  }
+  using domain::BoundaryConditions::is_none;
+  if (is_none(boundary_condition_)) {
+    PARSE_ERROR(
+        context,
+        "None boundary condition is not supported. If you would like an "
+        "outflow boundary condition, you must use that.");
   }
   using domain::BoundaryConditions::is_periodic;
   if (is_periodic(boundary_condition_)) {

--- a/src/Domain/Creators/Brick.hpp
+++ b/src/Domain/Creators/Brick.hpp
@@ -122,7 +122,8 @@ class Brick : public DomainCreator<3> {
         std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
             boundary_condition = nullptr,
         std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
-            time_dependence = nullptr) noexcept;
+            time_dependence = nullptr,
+        const Options::Context& context = {});
 
   Brick() = default;
   Brick(const Brick&) = delete;

--- a/src/Domain/Creators/Cylinder.cpp
+++ b/src/Domain/Creators/Cylinder.cpp
@@ -9,6 +9,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "Domain/BoundaryConditions/None.hpp"
 #include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Domain.hpp"
@@ -68,6 +69,13 @@ Cylinder::Cylinder(
                 "Periodic boundary conditions are not supported in the radial "
                 "direction. If you need periodic boundary conditions along the "
                 "axis of symmetry, use the is_periodic_in_z option.");
+  }
+  using domain::BoundaryConditions::is_none;
+  if (is_none(boundary_condition_)) {
+    PARSE_ERROR(
+        context,
+        "None boundary condition is not supported. If you would like an "
+        "outflow boundary condition, you must use that.");
   }
 }
 

--- a/src/Domain/Creators/Disk.cpp
+++ b/src/Domain/Creators/Disk.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 
 #include "Domain/Block.hpp"  // IWYU pragma: keep
+#include "Domain/BoundaryConditions/None.hpp"
 #include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
@@ -46,6 +47,13 @@ Disk::Disk(typename InnerRadius::type inner_radius,
           std::move(initial_number_of_grid_points)),  // NOLINT
       use_equiangular_map_(use_equiangular_map),      // NOLINT
       boundary_condition_(std::move(boundary_condition)) {
+  using domain::BoundaryConditions::is_none;
+  if (is_none(boundary_condition_)) {
+    PARSE_ERROR(
+        context,
+        "None boundary condition is not supported. If you would like an "
+        "outflow boundary condition, you must use that.");
+  }
   using domain::BoundaryConditions::is_periodic;
   if (boundary_condition_ != nullptr and is_periodic(boundary_condition_)) {
     PARSE_ERROR(context, "Cannot have periodic boundary conditions on a disk.");

--- a/src/Domain/Creators/FrustalCloak.cpp
+++ b/src/Domain/Creators/FrustalCloak.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "Domain/Block.hpp"                   // IWYU pragma: keep
+#include "Domain/BoundaryConditions/None.hpp"
 #include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Domain.hpp"
@@ -50,6 +51,13 @@ FrustalCloak::FrustalCloak(
       length_outer_cube_(length_outer_cube),          // NOLINT
       origin_preimage_(origin_preimage),              // NOLINT
       boundary_condition_(std::move(boundary_condition)) {
+  using domain::BoundaryConditions::is_none;
+  if (is_none(boundary_condition_)) {
+    PARSE_ERROR(
+        context,
+        "None boundary condition is not supported. If you would like an "
+        "outflow boundary condition, you must use that.");
+  }
   using domain::BoundaryConditions::is_periodic;
   if (boundary_condition_ != nullptr and is_periodic(boundary_condition_)) {
     PARSE_ERROR(

--- a/src/Domain/Creators/Interval.cpp
+++ b/src/Domain/Creators/Interval.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "Domain/Block.hpp"  // IWYU pragma: keep
+#include "Domain/BoundaryConditions/None.hpp"
 #include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
@@ -70,6 +71,14 @@ Interval::Interval(
   if (time_dependence_ == nullptr) {
     time_dependence_ =
         std::make_unique<domain::creators::time_dependence::None<1>>();
+  }
+  using domain::BoundaryConditions::is_none;
+  if (is_none(lower_boundary_condition_) or
+      is_none(upper_boundary_condition_)) {
+    PARSE_ERROR(
+        context,
+        "None boundary condition is not supported. If you would like an "
+        "outflow boundary condition, you must use that.");
   }
   using domain::BoundaryConditions::is_periodic;
   if (is_periodic(lower_boundary_condition_) !=

--- a/src/Domain/Creators/Rectangle.cpp
+++ b/src/Domain/Creators/Rectangle.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "Domain/Block.hpp"  // IWYU pragma: keep
+#include "Domain/BoundaryConditions/None.hpp"
 #include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
@@ -60,7 +61,8 @@ Rectangle::Rectangle(
     std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
         boundary_condition,
     std::unique_ptr<domain::creators::time_dependence::TimeDependence<2>>
-        time_dependence)
+        time_dependence,
+    const Options::Context& context)
     : lower_xy_(lower_xy),
       upper_xy_(upper_xy),
       is_periodic_in_xy_{{false, false}},
@@ -71,6 +73,13 @@ Rectangle::Rectangle(
   if (time_dependence_ == nullptr) {
     time_dependence_ =
         std::make_unique<domain::creators::time_dependence::None<2>>();
+  }
+  using domain::BoundaryConditions::is_none;
+  if (is_none(boundary_condition_)) {
+    PARSE_ERROR(
+        context,
+        "None boundary condition is not supported. If you would like an "
+        "outflow boundary condition, you must use that.");
   }
   using domain::BoundaryConditions::is_periodic;
   if (is_periodic(boundary_condition_)) {

--- a/src/Domain/Creators/Rectangle.hpp
+++ b/src/Domain/Creators/Rectangle.hpp
@@ -119,7 +119,8 @@ class Rectangle : public DomainCreator<2> {
       std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
           boundary_condition,
       std::unique_ptr<domain::creators::time_dependence::TimeDependence<2>>
-          time_dependence);
+          time_dependence,
+      const Options::Context& context = {});
 
   Rectangle() = default;
   Rectangle(const Rectangle&) = delete;

--- a/src/Domain/Creators/RotatedBricks.cpp
+++ b/src/Domain/Creators/RotatedBricks.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "DataStructures/Index.hpp"
+#include "Domain/BoundaryConditions/None.hpp"
 #include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
@@ -42,7 +43,8 @@ RotatedBricks::RotatedBricks(
     const typename InitialRefinement::type initial_refinement_level_xyz,
     const typename InitialGridPoints::type initial_number_of_grid_points_in_xyz,
     std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-        boundary_condition) noexcept
+        boundary_condition,
+    const Options::Context& context)
     // clang-tidy: trivially copyable
     : lower_xyz_(std::move(lower_xyz)),                      // NOLINT
       midpoint_xyz_(std::move(midpoint_xyz)),                // NOLINT
@@ -53,6 +55,13 @@ RotatedBricks::RotatedBricks(
       initial_number_of_grid_points_in_xyz_(                 // NOLINT
           std::move(initial_number_of_grid_points_in_xyz)),  // NOLINT
       boundary_condition_(std::move(boundary_condition)) {
+  using domain::BoundaryConditions::is_none;
+  if (is_none(boundary_condition_)) {
+    PARSE_ERROR(
+        context,
+        "None boundary condition is not supported. If you would like an "
+        "outflow boundary condition, you must use that.");
+  }
   using domain::BoundaryConditions::is_periodic;
   if (is_periodic(boundary_condition_)) {
     is_periodic_in_[0] = true;

--- a/src/Domain/Creators/RotatedBricks.hpp
+++ b/src/Domain/Creators/RotatedBricks.hpp
@@ -180,7 +180,8 @@ class RotatedBricks : public DomainCreator<3> {
       typename InitialRefinement::type initial_refinement_level_xyz,
       typename InitialGridPoints::type initial_number_of_grid_points_in_xyz,
       std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-          boundary_condition) noexcept;
+          boundary_condition,
+      const Options::Context& context = {});
 
   RotatedBricks() = default;
   RotatedBricks(const RotatedBricks&) = delete;

--- a/src/Domain/Creators/RotatedIntervals.cpp
+++ b/src/Domain/Creators/RotatedIntervals.cpp
@@ -5,6 +5,7 @@
 
 #include "DataStructures/Index.hpp"
 #include "Domain/Block.hpp"  // IWYU pragma: keep
+#include "Domain/BoundaryConditions/None.hpp"
 #include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Domain.hpp"
@@ -50,6 +51,14 @@ RotatedIntervals::RotatedIntervals(
       initial_number_of_grid_points_in_x_(initial_number_of_grid_points_in_x),
       lower_boundary_condition_(std::move(lower_boundary_condition)),
       upper_boundary_condition_(std::move(upper_boundary_condition)) {
+  using domain::BoundaryConditions::is_none;
+  if (is_none(lower_boundary_condition_) or
+      is_none(upper_boundary_condition_)) {
+    PARSE_ERROR(
+        context,
+        "None boundary condition is not supported. If you would like an "
+        "outflow boundary condition, you must use that.");
+  }
   using domain::BoundaryConditions::is_periodic;
   if (is_periodic(lower_boundary_condition_) !=
       is_periodic(upper_boundary_condition_)) {

--- a/src/Domain/Creators/RotatedRectangles.cpp
+++ b/src/Domain/Creators/RotatedRectangles.cpp
@@ -4,6 +4,7 @@
 #include "Domain/Creators/RotatedRectangles.hpp"
 
 #include "DataStructures/Index.hpp"  // for Index
+#include "Domain/BoundaryConditions/None.hpp"
 #include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
@@ -37,7 +38,8 @@ RotatedRectangles::RotatedRectangles(
     const typename InitialRefinement::type initial_refinement_level_xy,
     const typename InitialGridPoints::type initial_number_of_grid_points_in_xy,
     std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-        boundary_condition) noexcept
+        boundary_condition,
+    const Options::Context& context)
     : lower_xy_(lower_xy),
       midpoint_xy_(midpoint_xy),
       upper_xy_(upper_xy),
@@ -45,6 +47,13 @@ RotatedRectangles::RotatedRectangles(
       initial_refinement_level_xy_(initial_refinement_level_xy),
       initial_number_of_grid_points_in_xy_(initial_number_of_grid_points_in_xy),
       boundary_condition_(std::move(boundary_condition)) {
+  using domain::BoundaryConditions::is_none;
+  if (is_none(boundary_condition_)) {
+    PARSE_ERROR(
+        context,
+        "None boundary condition is not supported. If you would like an "
+        "outflow boundary condition, you must use that.");
+  }
   using domain::BoundaryConditions::is_periodic;
   if (is_periodic(boundary_condition_)) {
     is_periodic_in_[0] = true;

--- a/src/Domain/Creators/RotatedRectangles.hpp
+++ b/src/Domain/Creators/RotatedRectangles.hpp
@@ -139,7 +139,8 @@ class RotatedRectangles : public DomainCreator<2> {
       typename InitialRefinement::type initial_refinement_level_xy,
       typename InitialGridPoints::type initial_number_of_grid_points_in_xy,
       std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-          boundary_condition) noexcept;
+          boundary_condition,
+      const Options::Context& context = {});
 
   RotatedRectangles() = default;
   RotatedRectangles(const RotatedRectangles&) = delete;

--- a/src/Domain/Creators/Shell.cpp
+++ b/src/Domain/Creators/Shell.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "Domain/Block.hpp"  // IWYU pragma: keep
+#include "Domain/BoundaryConditions/None.hpp"
 #include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Domain.hpp"
@@ -65,6 +66,14 @@ Shell::Shell(typename InnerRadius::type inner_radius,
                 "Can only apply boundary conditions when using the full shell. "
                 "Additional cases can be supported by adding them to the Shell "
                 "domain creator's create_domain function.");
+  }
+  using domain::BoundaryConditions::is_none;
+  if (is_none(inner_boundary_condition_) or
+      is_none(outer_boundary_condition_)) {
+    PARSE_ERROR(
+        context,
+        "None boundary condition is not supported. If you would like an "
+        "outflow boundary condition, you must use that.");
   }
   using domain::BoundaryConditions::is_periodic;
   if (is_periodic(inner_boundary_condition_) or

--- a/src/Domain/Creators/Sphere.cpp
+++ b/src/Domain/Creators/Sphere.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include "Domain/Block.hpp"  // IWYU pragma: keep
+#include "Domain/BoundaryConditions/None.hpp"
 #include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
@@ -46,6 +47,13 @@ Sphere::Sphere(typename InnerRadius::type inner_radius,
           std::move(initial_number_of_grid_points)),         // NOLINT
       use_equiangular_map_(std::move(use_equiangular_map)),  // NOLINT
       boundary_condition_(std::move(boundary_condition)) {
+  using domain::BoundaryConditions::is_none;
+  if (is_none(boundary_condition_)) {
+    PARSE_ERROR(
+        context,
+        "None boundary condition is not supported. If you would like an "
+        "outflow boundary condition, you must use that.");
+  }
   using domain::BoundaryConditions::is_periodic;
   if (is_periodic(boundary_condition_)) {
     PARSE_ERROR(context,

--- a/tests/Unit/Domain/BoundaryConditions/CMakeLists.txt
+++ b/tests/Unit/Domain/BoundaryConditions/CMakeLists.txt
@@ -5,8 +5,8 @@ set(LIBRARY "Test_DomainBoundaryConditions")
 
 set(LIBRARY_SOURCES
   Test_BoundaryCondition.cpp
+  Test_GenericBcs.cpp
   Test_GetBoundaryConditionsBase.cpp
-  Test_Periodic.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Domain/BoundaryConditions/Test_GenericBcs.cpp
+++ b/tests/Unit/Domain/BoundaryConditions/Test_GenericBcs.cpp
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/BoundaryConditions/None.hpp"
 #include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
@@ -16,18 +17,29 @@
 namespace {
 namespace helpers = TestHelpers::domain::BoundaryConditions;
 
-SPECTRE_TEST_CASE("Unit.Domain.BoundaryConditions.Periodic", "[Unit][Domain]") {
+SPECTRE_TEST_CASE("Unit.Domain.BoundaryConditions.GenericBcs",
+                  "[Unit][Domain]") {
   helpers::register_derived_with_charm();
 
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> periodic =
       std::make_unique<helpers::TestPeriodicBoundaryCondition<1>>();
   CHECK(is_periodic(periodic));
   CHECK(is_periodic(serialize_and_deserialize(periodic)));
+  CHECK_FALSE(is_none(periodic));
+  CHECK_FALSE(is_none(serialize_and_deserialize(periodic)));
 
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> not_periodic =
       std::make_unique<helpers::TestBoundaryCondition<1>>();
   CHECK_FALSE(is_periodic(not_periodic));
   CHECK_FALSE(is_periodic(serialize_and_deserialize(not_periodic)));
+  CHECK_FALSE(is_none(not_periodic));
+  CHECK_FALSE(is_none(serialize_and_deserialize(not_periodic)));
+
+  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> none =
+      std::make_unique<helpers::TestNoneBoundaryCondition<1>>();
+  CHECK(is_none(none));
+  CHECK(is_none(serialize_and_deserialize(none)));
+  CHECK_FALSE(is_periodic(none));
+  CHECK_FALSE(is_periodic(serialize_and_deserialize(none)));
 }
 }  // namespace
-// }  // namespace domain::BoundaryConditions

--- a/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
+++ b/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
@@ -388,5 +388,17 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "Cannot exclude blocks as well as have periodic boundary"));
+  CHECK_THROWS_WITH(
+      creators::AlignedLattice<3>(
+          {{{{-1.5, -0.5, 0.5, 1.5}},
+            {{1.5, -0.5, 0.5, 1.5}},
+            {{-1.5, -0.5, 0.5, 1.5}}}},
+          {{1, 1, 1}}, {{5, 5, 5}}, {}, {}, {{{{1, 1, 1}}}},
+          std::make_unique<TestHelpers::domain::BoundaryConditions::
+                               TestNoneBoundaryCondition<3>>(),
+          Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::Contains(
+          "None boundary condition is not supported. If you would like an "
+          "outflow boundary condition, you must use that."));
 }
 }  // namespace domain

--- a/tests/Unit/Domain/Creators/Test_Brick.cpp
+++ b/tests/Unit/Domain/Creators/Test_Brick.cpp
@@ -283,6 +283,16 @@ void test_brick() {
                               Affine{-1., 1., lower_bound[1], upper_bound[1]},
                               Affine{-1., 1., lower_bound[2], upper_bound[2]}}),
                  *serialize_and_deserialize(base_map));
+
+  CHECK_THROWS_WITH(
+      creators::Brick(lower_bound, upper_bound, refinement_level[0],
+                      grid_points[0],
+                      std::make_unique<TestHelpers::domain::BoundaryConditions::
+                                           TestNoneBoundaryCondition<3>>(),
+                      nullptr, Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::Contains(
+          "None boundary condition is not supported. If you would like an "
+          "outflow boundary condition, you must use that."));
 }
 
 void test_brick_factory() {

--- a/tests/Unit/Domain/Creators/Test_Cylinder.cpp
+++ b/tests/Unit/Domain/Creators/Test_Cylinder.cpp
@@ -354,6 +354,17 @@ void test_cylinder_no_refinement() {
                   "multiple height partitionings. The domain creator code to "
                   "support this is written but untested. To enable, please add "
                   "tests."));
+          CHECK_THROWS_WITH(
+              creators::Cylinder(
+                  inner_radius, outer_radius, lower_bound, upper_bound,
+                  periodic_in_z, refinement_level, grid_points, equiangular_map,
+                  {}, {},
+                  std::make_unique<TestHelpers::domain::BoundaryConditions::
+                                       TestNoneBoundaryCondition<3>>(),
+                  Options::Context{false, {}, 1, 1}),
+              Catch::Matchers::Contains(
+                  "None boundary condition is not supported. If you would like "
+                  "an outflow boundary condition, you must use that."));
         }
       }
     }

--- a/tests/Unit/Domain/Creators/Test_Disk.cpp
+++ b/tests/Unit/Domain/Creators/Test_Disk.cpp
@@ -257,6 +257,15 @@ void test_disk_boundaries_equidistant() {
                      Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "Cannot have periodic boundary conditions on a disk"));
+  CHECK_THROWS_WITH(
+      creators::Disk(inner_radius, outer_radius, refinement_level, grid_points,
+                     false,
+                     std::make_unique<TestHelpers::domain::BoundaryConditions::
+                                          TestNoneBoundaryCondition<2>>(),
+                     Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::Contains(
+          "None boundary condition is not supported. If you would like an "
+          "outflow boundary condition, you must use that."));
 }
 
 void test_disk_factory_equidistant() {

--- a/tests/Unit/Domain/Creators/Test_FrustalCloak.cpp
+++ b/tests/Unit/Domain/Creators/Test_FrustalCloak.cpp
@@ -159,6 +159,16 @@ void test_connectivity() {
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "Cannot have periodic boundary conditions with a frustal cloak"));
+  CHECK_THROWS_WITH(
+      domain::creators::FrustalCloak(
+          refinement, grid_points, true, projective_scale_factor,
+          length_inner_cube, length_outer_cube, origin_preimage,
+          std::make_unique<TestHelpers::domain::BoundaryConditions::
+                               TestNoneBoundaryCondition<3>>(),
+          Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::Contains(
+          "None boundary condition is not supported. If you would like an "
+          "outflow boundary condition, you must use that."));
 }
 }  // namespace
 

--- a/tests/Unit/Domain/Creators/Test_Interval.cpp
+++ b/tests/Unit/Domain/Creators/Test_Interval.cpp
@@ -182,6 +182,28 @@ void test_interval() {
             nullptr, Options::Context{false, {}, 1, 1}),
         Catch::Matchers::Contains("Both the upper and lower boundary condition "
                                   "must be set to periodic if"));
+    CHECK_THROWS_WITH(
+        creators::Interval(
+            lower_bound, upper_bound, refinement_level[0], grid_points[0],
+            expected_boundary_conditions[0][Direction<1>::lower_xi()]
+                ->get_clone(),
+            std::make_unique<TestHelpers::domain::BoundaryConditions::
+                                 TestNoneBoundaryCondition<3>>(),
+            nullptr, Options::Context{false, {}, 1, 1}),
+        Catch::Matchers::Contains(
+            "None boundary condition is not supported. If you would like an "
+            "outflow boundary condition, you must use that."));
+    CHECK_THROWS_WITH(
+        creators::Interval(
+            lower_bound, upper_bound, refinement_level[0], grid_points[0],
+            std::make_unique<TestHelpers::domain::BoundaryConditions::
+                                 TestNoneBoundaryCondition<3>>(),
+            expected_boundary_conditions[0][Direction<1>::lower_xi()]
+                ->get_clone(),
+            nullptr, Options::Context{false, {}, 1, 1}),
+        Catch::Matchers::Contains(
+            "None boundary condition is not supported. If you would like an "
+            "outflow boundary condition, you must use that."));
   }
 }
 

--- a/tests/Unit/Domain/Creators/Test_Rectangle.cpp
+++ b/tests/Unit/Domain/Creators/Test_Rectangle.cpp
@@ -196,6 +196,15 @@ void test_rectangle() {
              {Direction<2>::upper_eta(), {0, aligned_orientation}}}},
         std::vector<std::unordered_set<Direction<2>>>{{}});
   }
+  CHECK_THROWS_WITH(
+      creators::Rectangle(
+          lower_bound, upper_bound, refinement_level[0], grid_points[0],
+          std::make_unique<TestHelpers::domain::BoundaryConditions::
+                               TestNoneBoundaryCondition<3>>(),
+          nullptr, Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::Contains(
+          "None boundary condition is not supported. If you would like an "
+          "outflow boundary condition, you must use that."));
 }
 
 void test_rectangle_factory() {

--- a/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
@@ -348,6 +348,21 @@ void test_rotated_bricks() {
         std::vector<std::unordered_set<Direction<3>>>{
             {}, {}, {}, {}, {}, {}, {}, {}});
   }
+
+  CHECK_THROWS_WITH(
+      creators::RotatedBricks(
+          lower_bound, midpoint, upper_bound,
+          {{refinement_level[0][0], refinement_level[0][1],
+            refinement_level[0][2]}},
+          {{{{grid_points[0][0], grid_points[1][2]}},
+            {{grid_points[0][1], grid_points[2][2]}},
+            {{grid_points[0][2], grid_points[4][2]}}}},
+          std::make_unique<TestHelpers::domain::BoundaryConditions::
+                               TestNoneBoundaryCondition<3>>(),
+          Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::Contains(
+          "None boundary condition is not supported. If you would like "
+          "an outflow boundary condition, you must use that."));
 }
 
 void test_rotated_bricks_factory() {

--- a/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
@@ -190,6 +190,30 @@ void test_rotated_intervals() {
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains("Both the upper and lower boundary condition "
                                 "must be set to periodic if"));
+  CHECK_THROWS_WITH(
+      creators::RotatedIntervals(
+          lower_bound, midpoint, upper_bound, refinement_level[0],
+          {{{{grid_points[0][0], grid_points[1][0]}}}},
+          std::make_unique<TestHelpers::domain::BoundaryConditions::
+                               TestNoneBoundaryCondition<3>>(),
+          expected_boundary_conditions[0][Direction<1>::lower_xi()]
+              ->get_clone(),
+          Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::Contains(
+          "None boundary condition is not supported. If you would like "
+          "an outflow boundary condition, you must use that."));
+  CHECK_THROWS_WITH(
+      creators::RotatedIntervals(
+          lower_bound, midpoint, upper_bound, refinement_level[0],
+          {{{{grid_points[0][0], grid_points[1][0]}}}},
+          expected_boundary_conditions[0][Direction<1>::lower_xi()]
+              ->get_clone(),
+          std::make_unique<TestHelpers::domain::BoundaryConditions::
+                               TestNoneBoundaryCondition<3>>(),
+          Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::Contains(
+          "None boundary condition is not supported. If you would like "
+          "an outflow boundary condition, you must use that."));
 }
 
 void test_rotated_intervals_factory() {

--- a/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
@@ -261,6 +261,19 @@ void test_rotated_rectangles() {
            {Direction<2>::lower_xi(), {1, quarter_turn_cw}},
            {Direction<2>::upper_eta(), {2, half_turn}}}},
       std::vector<std::unordered_set<Direction<2>>>{{}, {}, {}, {}});
+
+  CHECK_THROWS_WITH(
+      creators::RotatedRectangles(
+          lower_bound, midpoint, upper_bound,
+          {{refinement_level[0][0], refinement_level[0][1]}},
+          {{{{grid_points[0][0], grid_points[1][0]}},
+            {{grid_points[0][1], grid_points[2][0]}}}},
+          std::make_unique<TestHelpers::domain::BoundaryConditions::
+                               TestNoneBoundaryCondition<2>>(),
+          Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::Contains(
+          "None boundary condition is not supported. If you would like "
+          "an outflow boundary condition, you must use that."));
 }
 
 void test_rotated_rectangles_factory() {

--- a/tests/Unit/Domain/Creators/Test_Shell.cpp
+++ b/tests/Unit/Domain/Creators/Test_Shell.cpp
@@ -603,6 +603,27 @@ void test_shell_boundaries_logarithmic_map() {
                       Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "Cannot have periodic boundary conditions with a shell"));
+  CHECK_THROWS_WITH(
+      creators::Shell(inner_radius, outer_radius, refinement_level,
+                      grid_points_r_angular, false, aspect_ratio,
+                      use_logarithmic_map, ShellWedges::All, 1,
+                      create_inner_boundary_condition(),
+                      std::make_unique<TestHelpers::domain::BoundaryConditions::
+                                           TestNoneBoundaryCondition<3>>(),
+                      Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::Contains(
+          "None boundary condition is not supported. If you would like "
+          "an outflow boundary condition, you must use that."));
+  CHECK_THROWS_WITH(
+      creators::Shell(
+          inner_radius, outer_radius, refinement_level, grid_points_r_angular,
+          false, aspect_ratio, use_logarithmic_map, ShellWedges::All, 1,
+          std::make_unique<TestHelpers::domain::BoundaryConditions::
+                               TestNoneBoundaryCondition<3>>(),
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::Contains(
+          "None boundary condition is not supported. If you would like "
+          "an outflow boundary condition, you must use that."));
 }
 
 void test_shell_factory_logarithmic_map() {

--- a/tests/Unit/Domain/Creators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/Test_Sphere.cpp
@@ -281,6 +281,15 @@ void test_sphere_boundaries_equiangular() {
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "Cannot have periodic boundary conditions with a Sphere"));
+  CHECK_THROWS_WITH(
+      creators::Sphere(
+          inner_radius, outer_radius, refinement, grid_points_r_angular, true,
+          std::make_unique<TestHelpers::domain::BoundaryConditions::
+                               TestNoneBoundaryCondition<3>>(),
+          Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::Contains(
+          "None boundary condition is not supported. If you would like "
+          "an outflow boundary condition, you must use that."));
 }
 
 void test_sphere_factory_equiangular() {

--- a/tests/Unit/Helpers/Domain/BoundaryConditions/BoundaryCondition.cpp
+++ b/tests/Unit/Helpers/Domain/BoundaryConditions/BoundaryCondition.cpp
@@ -91,26 +91,7 @@ bool operator!=(const TestBoundaryCondition<Dim>& lhs,
 }
 
 template <size_t Dim>
-TestPeriodicBoundaryCondition<Dim>::TestPeriodicBoundaryCondition(
-    CkMigrateMessage* const msg) noexcept
-    : BoundaryConditionBase<Dim>(msg) {}
-
-template <size_t Dim>
-auto TestPeriodicBoundaryCondition<Dim>::get_clone() const noexcept
-    -> std::unique_ptr<::domain::BoundaryConditions::BoundaryCondition> {
-  return std::make_unique<TestPeriodicBoundaryCondition<Dim>>(*this);
-}
-
-template <size_t Dim>
-void TestPeriodicBoundaryCondition<Dim>::pup(PUP::er& p) {
-  BoundaryConditionBase<Dim>::pup(p);
-}
-
-template <size_t Dim>
 PUP::able::PUP_ID TestBoundaryCondition<Dim>::my_PUP_ID = 0;  // NOLINT
-
-template <size_t Dim>
-PUP::able::PUP_ID TestPeriodicBoundaryCondition<Dim>::my_PUP_ID = 0;  // NOLINT
 
 void register_derived_with_charm() noexcept {
   Parallel::register_derived_classes_with_charm<BoundaryConditionBase<1>>();
@@ -123,7 +104,6 @@ void register_derived_with_charm() noexcept {
 #define INSTANTIATION(r, data)                               \
   template class BoundaryConditionBase<DIM(data)>;           \
   template class TestBoundaryCondition<DIM(data)>;           \
-  template class TestPeriodicBoundaryCondition<DIM(data)>;   \
   template bool operator==(                                  \
       const TestBoundaryCondition<DIM(data)>& lhs,           \
       const TestBoundaryCondition<DIM(data)>& rhs) noexcept; \

--- a/tests/Unit/Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp
+++ b/tests/Unit/Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/BoundaryConditions/None.hpp"
 #include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Options/Options.hpp"
@@ -32,6 +33,7 @@ class BoundaryConditionBase
  public:
   using creatable_classes = tmpl::list<
       TestBoundaryCondition<Dim>,
+      ::domain::BoundaryConditions::None<BoundaryConditionBase<Dim>>,
       ::domain::BoundaryConditions::Periodic<BoundaryConditionBase<Dim>>>;
 
   BoundaryConditionBase() = default;
@@ -107,6 +109,10 @@ bool operator!=(const TestBoundaryCondition<Dim>& lhs,
 template <size_t Dim>
 using TestPeriodicBoundaryCondition =
     ::domain::BoundaryConditions::Periodic<BoundaryConditionBase<Dim>>;
+
+template <size_t Dim>
+using TestNoneBoundaryCondition =
+    ::domain::BoundaryConditions::None<BoundaryConditionBase<Dim>>;
 
 /// Empty system that has boundary conditions
 template <size_t Dim>

--- a/tests/Unit/Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp
+++ b/tests/Unit/Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp
@@ -21,8 +21,6 @@ namespace TestHelpers::domain::BoundaryConditions {
 /// \cond
 template <size_t Dim>
 class TestBoundaryCondition;
-template <size_t Dim>
-class TestPeriodicBoundaryCondition;
 /// \endcond
 
 /// \brief A system-specific boundary condition base class.
@@ -32,8 +30,9 @@ template <size_t Dim>
 class BoundaryConditionBase
     : public ::domain::BoundaryConditions::BoundaryCondition {
  public:
-  using creatable_classes = tmpl::list<TestBoundaryCondition<Dim>,
-                                       TestPeriodicBoundaryCondition<Dim>>;
+  using creatable_classes = tmpl::list<
+      TestBoundaryCondition<Dim>,
+      ::domain::BoundaryConditions::Periodic<BoundaryConditionBase<Dim>>>;
 
   BoundaryConditionBase() = default;
   BoundaryConditionBase(BoundaryConditionBase&&) noexcept = default;
@@ -106,34 +105,8 @@ bool operator!=(const TestBoundaryCondition<Dim>& lhs,
                 const TestBoundaryCondition<Dim>& rhs) noexcept;
 
 template <size_t Dim>
-class TestPeriodicBoundaryCondition final
-    : public BoundaryConditionBase<Dim>,
-      public ::domain::BoundaryConditions::Periodic {
- public:
-  TestPeriodicBoundaryCondition() = default;
-  TestPeriodicBoundaryCondition(TestPeriodicBoundaryCondition&&) noexcept =
-      default;
-  TestPeriodicBoundaryCondition& operator=(
-      TestPeriodicBoundaryCondition&&) noexcept = default;
-  TestPeriodicBoundaryCondition(const TestPeriodicBoundaryCondition&) = default;
-  TestPeriodicBoundaryCondition& operator=(
-      const TestPeriodicBoundaryCondition&) = default;
-  ~TestPeriodicBoundaryCondition() override = default;
-  explicit TestPeriodicBoundaryCondition(CkMigrateMessage* const msg) noexcept;
-
-  using options = tmpl::list<>;
-  static constexpr Options::String help = {
-      "Periodic boundary condition for testing."};
-
-  WRAPPED_PUPable_decl_base_template(
-      ::domain::BoundaryConditions::BoundaryCondition,
-      TestPeriodicBoundaryCondition<Dim>);
-
-  auto get_clone() const noexcept -> std::unique_ptr<
-      ::domain::BoundaryConditions::BoundaryCondition> override;
-
-  void pup(PUP::er& p) override;
-};
+using TestPeriodicBoundaryCondition =
+    ::domain::BoundaryConditions::Periodic<BoundaryConditionBase<Dim>>;
 
 /// Empty system that has boundary conditions
 template <size_t Dim>


### PR DESCRIPTION
## Proposed changes

- Make it so that systems don't need to implement a full periodic boundary condition class, they can just use a generic one. This will save us _a lot_ of code.
- Add a `None` boundary condition that will be used in the Binary domain creator, and also in some other cases internally to effectively say "I have thought about this being an external boundary, don't do anything". Not that `None` is _not_ equivalent to `Outflow` and domain creators for the most part should error if `None` is used.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
