### PR TITLE
Add local time stepping support to ComputeTimeDerivative and to ApplyBoundaryCorrections

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
@@ -42,6 +42,7 @@
 #include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "ParallelAlgorithms/DiscontinuousGalerkin/FluxCommunication.hpp"
+#include "Utilities/Algorithm.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -353,6 +354,24 @@ ComputeTimeDerivative<Metavariables>::apply(
   const Mesh<volume_dim>& mesh = db::get<::domain::Tags::Mesh<volume_dim>>(box);
   const ::dg::Formulation dg_formulation =
       db::get<::dg::Tags::Formulation>(box);
+  ASSERT(alg::all_of(mesh.basis(),
+                     [&mesh](const Spectral::Basis current_basis) noexcept {
+                       return current_basis == mesh.basis(0);
+                     }),
+         "An isotropic basis must be used in the evolution code. While "
+         "theoretically this restriction could be lifted, the simplification "
+         "it offers are quite substantial. Relaxing this assumption is likely "
+         "to require quite a bit of careful code refactoring and debugging.");
+  ASSERT(alg::all_of(
+             mesh.quadrature(),
+             [&mesh](const Spectral::Quadrature current_quadrature) noexcept {
+               return current_quadrature == mesh.quadrature(0);
+             }),
+         "An isotropic quadrature must be used in the evolution code. While "
+         "theoretically this restriction could be lifted, the simplification "
+         "it offers are quite substantial. Relaxing this assumption is likely "
+         "to require quite a bit of careful code refactoring and debugging.");
+
   // Allocate the Variables classes needed for the time derivative
   // computation.
   //

--- a/src/Evolution/DiscontinuousGalerkin/MortarData.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/MortarData.cpp
@@ -10,6 +10,8 @@
 #include <utility>
 #include <vector>
 
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Parallel/PupStlCpp17.hpp"
 #include "Time/TimeStepId.hpp"
@@ -57,6 +59,152 @@ void MortarData<Dim>::insert_neighbor_mortar_data(
 }
 
 template <size_t Dim>
+void MortarData<Dim>::insert_local_geometric_quantities(
+    const Scalar<DataVector>& local_volume_det_inv_jacobian,
+    const Scalar<DataVector>& local_face_det_jacobian,
+    const Scalar<DataVector>& local_face_normal_magnitude) noexcept {
+  ASSERT(local_mortar_data_.has_value(),
+         "Must set local mortar data before setting the geometric quantities.");
+  ASSERT(local_face_det_jacobian[0].size() ==
+             local_face_normal_magnitude[0].size(),
+         "The determinant of the local face Jacobian has "
+             << local_face_det_jacobian[0].size()
+             << " grid points, and the magnitude of the local face normal has "
+             << local_face_normal_magnitude[0].size()
+             << " but they must be the same");
+  ASSERT(local_face_det_jacobian[0].size() ==
+             std::get<0>(*local_mortar_data()).number_of_grid_points(),
+         "The number of grid points ("
+             << std::get<0>(*local_mortar_data()).number_of_grid_points()
+             << ") on the local face must match the number of grid points "
+                "passed in for the face Jacobian determinant and normal vector "
+                "magnitude ("
+             << local_face_det_jacobian[0].size() << ")");
+  ASSERT(not using_only_face_normal_magnitude_,
+         "The face normal, volume inverse Jacobian determinant, and face "
+         "Jacobian determinant cannot be inserted because the only the face "
+         "normal is being used.");
+  using_volume_and_face_jacobians_ = true;
+  const size_t required_storage_size = local_volume_det_inv_jacobian[0].size() +
+                                       2 * local_face_det_jacobian[0].size();
+  if (local_geometric_quantities_.size() != required_storage_size) {
+    local_geometric_quantities_.resize(required_storage_size);
+  }
+  std::copy(local_volume_det_inv_jacobian[0].begin(),
+            local_volume_det_inv_jacobian[0].end(),
+            local_geometric_quantities_.begin());
+  std::copy(
+      local_face_det_jacobian[0].begin(), local_face_det_jacobian[0].end(),
+      local_geometric_quantities_.begin() +
+          static_cast<std::ptrdiff_t>(local_volume_det_inv_jacobian[0].size()));
+  std::copy(
+      local_face_normal_magnitude[0].begin(),
+      local_face_normal_magnitude[0].end(),
+      local_geometric_quantities_.begin() +
+          static_cast<std::ptrdiff_t>(local_volume_det_inv_jacobian[0].size() +
+                                      local_face_det_jacobian[0].size()));
+}
+
+template <size_t Dim>
+void MortarData<Dim>::insert_local_face_normal_magnitude(
+    const Scalar<DataVector>& local_face_normal_magnitude) noexcept {
+  ASSERT(local_mortar_data_.has_value(),
+         "Must set local mortar data before setting the local face normal.");
+  ASSERT(not using_volume_and_face_jacobians_,
+         "The face normal magnitude cannot be inserted if the face normal, "
+         "volume inverse Jacobian determinant, and face Jacobian determinant "
+         "are being used.");
+  using_only_face_normal_magnitude_ = true;
+  const size_t required_storage_size = local_face_normal_magnitude[0].size();
+  if (local_geometric_quantities_.size() != required_storage_size) {
+    local_geometric_quantities_.resize(required_storage_size);
+  }
+  std::copy(local_face_normal_magnitude[0].begin(),
+            local_face_normal_magnitude[0].end(),
+            local_geometric_quantities_.begin());
+}
+
+template <size_t Dim>
+void MortarData<Dim>::get_local_volume_det_inv_jacobian(
+    const gsl::not_null<Scalar<DataVector>*> local_volume_det_inv_jacobian)
+    const noexcept {
+  ASSERT(local_mortar_data_.has_value(),
+         "Must set local mortar data before getting the local volume inverse "
+         "Jacobian determinant.");
+  ASSERT(
+      local_geometric_quantities_.size() >
+          2 * std::get<0>(*local_mortar_data()).number_of_grid_points(),
+      "Cannot retrieve the volume inverse Jacobian determinant because it was "
+      "not inserted.");
+  ASSERT(
+      using_volume_and_face_jacobians_,
+      "Cannot retrieve the volume inverse Jacobian determinant because it was "
+      "not inserted.");
+  ASSERT(not using_only_face_normal_magnitude_,
+         "Inconsistent internal state: we are apparently using both the volume "
+         "and face Jacobians, as well as only the face normal.");
+  const size_t num_face_points =
+      std::get<0>(*local_mortar_data()).number_of_grid_points();
+  const size_t num_volume_points =
+      local_geometric_quantities_.size() - 2 * num_face_points;
+  get(*local_volume_det_inv_jacobian)
+      .set_data_ref(const_cast<double*>(  // NOLINT
+                        local_geometric_quantities_.data()),
+                    num_volume_points);
+}
+
+template <size_t Dim>
+void MortarData<Dim>::get_local_face_det_jacobian(
+    const gsl::not_null<Scalar<DataVector>*> local_face_det_jacobian)
+    const noexcept {
+  ASSERT(local_mortar_data_.has_value(),
+         "Must set local mortar data before getting the local face Jacobian "
+         "determinant.");
+  ASSERT(local_geometric_quantities_.size() >
+             2 * std::get<0>(*local_mortar_data()).number_of_grid_points(),
+         "Cannot retrieve the face Jacobian determinant because it was not "
+         "inserted.");
+  ASSERT(using_volume_and_face_jacobians_,
+         "Cannot retrieve the face Jacobian determinant because it was not "
+         "inserted.");
+  ASSERT(not using_only_face_normal_magnitude_,
+         "Inconsistent internal state: we are apparently using both the volume "
+         "and face Jacobians, as well as only the face normal.");
+  const size_t num_face_points =
+      std::get<0>(*local_mortar_data()).number_of_grid_points();
+  const size_t offset =
+      local_geometric_quantities_.size() - 2 * num_face_points;
+  get(*local_face_det_jacobian)
+      .set_data_ref(
+          // NOLINTNEXTLINE
+          const_cast<double*>(  // NOLINTNEXTLINE
+              local_geometric_quantities_.data() + offset),
+          num_face_points);
+}
+
+template <size_t Dim>
+void MortarData<Dim>::get_local_face_normal_magnitude(
+    const gsl::not_null<Scalar<DataVector>*> local_face_normal_magnitude)
+    const noexcept {
+  ASSERT(local_mortar_data_.has_value(),
+         "Must set local mortar data before getting the local face normal "
+         "magnitude.");
+  const size_t num_face_points =
+      std::get<0>(*local_mortar_data()).number_of_grid_points();
+  ASSERT(local_geometric_quantities_.size() == num_face_points or
+             local_geometric_quantities_.size() > 2 * num_face_points,
+         "Cannot retrieve the face normal magnitude because it was not "
+         "inserted.");
+  const size_t offset = local_geometric_quantities_.size() - num_face_points;
+  get(*local_face_normal_magnitude)
+      .set_data_ref(
+          // NOLINTNEXTLINE
+          const_cast<double*>(  // NOLINTNEXTLINE
+              local_geometric_quantities_.data() + offset),
+          num_face_points);
+}
+
+template <size_t Dim>
 std::pair<std::pair<Mesh<Dim - 1>, std::vector<double>>,
           std::pair<Mesh<Dim - 1>, std::vector<double>>>
 MortarData<Dim>::extract() noexcept {
@@ -78,6 +226,9 @@ void MortarData<Dim>::pup(PUP::er& p) noexcept {
   p | time_step_id_;
   p | local_mortar_data_;
   p | neighbor_mortar_data_;
+  p | local_geometric_quantities_;
+  p | using_volume_and_face_jacobians_;
+  p | using_only_face_normal_magnitude_;
 }
 
 template <size_t Dim>
@@ -85,7 +236,12 @@ bool operator==(const MortarData<Dim>& lhs,
                 const MortarData<Dim>& rhs) noexcept {
   return lhs.time_step_id() == rhs.time_step_id() and
          lhs.local_mortar_data() == rhs.local_mortar_data() and
-         lhs.neighbor_mortar_data() == rhs.neighbor_mortar_data();
+         lhs.neighbor_mortar_data() == rhs.neighbor_mortar_data() and
+         lhs.local_geometric_quantities_ == rhs.local_geometric_quantities_ and
+         lhs.using_volume_and_face_jacobians_ ==
+             rhs.using_volume_and_face_jacobians_ and
+         lhs.using_only_face_normal_magnitude_ ==
+             rhs.using_only_face_normal_magnitude_;
 }
 
 template <size_t Dim>

--- a/src/Evolution/DiscontinuousGalerkin/MortarTags.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/MortarTags.hpp
@@ -15,6 +15,7 @@
 #include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Projection.hpp"  // for MortarSize
+#include "Time/BoundaryHistory.hpp"
 #include "Time/TimeStepId.hpp"
 
 /// %Tags used for DG evolution scheme.
@@ -27,6 +28,26 @@ struct MortarData : db::SimpleTag {
   using Key = std::pair<Direction<Dim>, ElementId<Dim>>;
   using type =
       std::unordered_map<Key, evolution::dg::MortarData<Dim>, boost::hash<Key>>;
+};
+
+/// History of the data on mortars, indexed by (Direction, ElementId) pairs, and
+/// used by the linear multistep local time stepping code.
+///
+/// The `Dim` is the volume dimension, not the face dimension.
+///
+/// `CouplingResult` is the result of calling a functor of type `Coupling` used
+/// in `TimeSteppers::BoundaryHistory`. It is also the result of
+/// `LtsTimeStepper::compute_boundary_delta()`, which again has a `Coupling`
+/// template parameter.
+template <size_t Dim, typename CouplingResult>
+struct MortarDataHistory : db::SimpleTag {
+  using Key = std::pair<Direction<Dim>, ElementId<Dim>>;
+  using type =
+      std::unordered_map<Key,
+                         TimeSteppers::BoundaryHistory<
+                             ::evolution::dg::MortarData<Dim>,
+                             ::evolution::dg::MortarData<Dim>, CouplingResult>,
+                         boost::hash<Key>>;
 };
 
 /// Mesh on the mortars, indexed by (Direction, ElementId) pairs

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
@@ -268,7 +268,7 @@ struct component {
               ActionTesting::InitializeDataBox<simple_tags, compute_tags>,
               ::Actions::SetupDataBox,
               ::evolution::dg::Initialization::Mortars<
-                  Metavariables::volume_dim>,
+                  Metavariables::volume_dim, typename Metavariables::system>,
               SetLocalMortarData>>,
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Testing,

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
@@ -4,7 +4,14 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <cstddef>
+#include <functional>
+#include <memory>
+#include <random>
+#include <tuple>
+#include <utility>
+#include <vector>
 
+#include "DataStructures/ApplyMatrices.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
@@ -17,6 +24,7 @@
 #include "Evolution/DiscontinuousGalerkin/Initialization/QuadratureTag.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
+#include "Evolution/DiscontinuousGalerkin/NormalVectorTags.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/Evolution/DiscontinuousGalerkin/Actions/SystemType.hpp"
@@ -25,10 +33,15 @@
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "Time/BoundaryHistory.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
 #include "Time/TimeStepId.hpp"
+#include "Time/TimeSteppers/AdamsBashforthN.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace {
@@ -111,7 +124,6 @@ struct BoundaryTerms final : public BoundaryCorrection<Dim> {
       const tnsr::I<DataVector, Dim, Frame::Inertial>& exterior_var2,
       const Scalar<DataVector>& exterior_max_abs_char_speed,
       const dg::Formulation dg_formulation) const noexcept {
-    // using std::max;
     // extra minus sign on exterior normal dot flux because normal faces
     // opposite direction
     get(*boundary_correction_var1) =
@@ -150,35 +162,40 @@ struct SetLocalMortarData {
       Parallel::GlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/, ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) noexcept {  // NOLINT
-    constexpr size_t volume_dim = Metavariables::volume_dim;
-    const auto& element = db::get<domain::Tags::Element<volume_dim>>(box);
-    const auto& volume_mesh = db::get<domain::Tags::Mesh<volume_dim>>(box);
+    const auto& element =
+        db::get<domain::Tags::Element<Metavariables::volume_dim>>(box);
+    const auto& volume_mesh =
+        db::get<domain::Tags::Mesh<Metavariables::volume_dim>>(box);
     const auto& mortar_meshes =
-        db::get<evolution::dg::Tags::MortarMesh<volume_dim>>(box);
+        db::get<evolution::dg::Tags::MortarMesh<Metavariables::volume_dim>>(
+            box);
     const auto& time_step_id = db::get<::Tags::TimeStepId>(box);
-    const auto& next_time_step_id =
-        db::get<::Tags::Next<::Tags::TimeStepId>>(box);
-    using mortar_tags_list =
-        typename BoundaryTerms<volume_dim>::dg_package_field_tags;
+    using mortar_tags_list = typename BoundaryTerms<
+        Metavariables::volume_dim>::dg_package_field_tags;
     constexpr size_t number_of_dg_package_tags_components =
         Variables<mortar_tags_list>::number_of_independent_components;
 
     MAKE_GENERATOR(generator);
     std::uniform_real_distribution<> dist_positive(0.5, 1.);
 
-    using CovectorAndMag =
-        Variables<tmpl::list<evolution::dg::Tags::MagnitudeOfNormal,
-                             evolution::dg::Tags::NormalCovector<volume_dim>>>;
+    using CovectorAndMag = Variables<tmpl::list<
+        evolution::dg::Tags::MagnitudeOfNormal,
+        evolution::dg::Tags::NormalCovector<Metavariables::volume_dim>>>;
+    const Scalar<DataVector> det_inv_jacobian = determinant(
+        db::get<::domain::Tags::InverseJacobian<
+            Metavariables::volume_dim, Frame::Logical, Frame::Inertial>>(box));
+
     for (const auto& [direction, neighbor_ids] : element.neighbors()) {
       size_t count = 0;
-      const Mesh<volume_dim - 1> face_mesh =
+      const Mesh<Metavariables::volume_dim - 1> face_mesh =
           volume_mesh.slice_away(direction.dimension());
       CovectorAndMag covector_and_mag{face_mesh.number_of_grid_points()};
       get<evolution::dg::Tags::MagnitudeOfNormal>(covector_and_mag) =
           make_with_random_values<Scalar<DataVector>>(
               make_not_null(&generator), make_not_null(&dist_positive),
               face_mesh.number_of_grid_points());
-      db::mutate<evolution::dg::Tags::NormalCovectorAndMagnitude<volume_dim>>(
+      db::mutate<evolution::dg::Tags::NormalCovectorAndMagnitude<
+          Metavariables::volume_dim>>(
           make_not_null(&box),
           [&covector_and_mag](const auto covector_and_mag_ptr,
                               const auto& local_direction) {
@@ -188,7 +205,8 @@ struct SetLocalMortarData {
 
       for (const auto& neighbor_id : neighbor_ids) {
         std::pair mortar_id{direction, neighbor_id};
-        const Mesh<volume_dim - 1>& mortar_mesh = mortar_meshes.at(mortar_id);
+        const Mesh<Metavariables::volume_dim - 1>& mortar_mesh =
+            mortar_meshes.at(mortar_id);
 
         std::vector<double> type_erased_boundary_data_on_mortar(
             mortar_mesh.number_of_grid_points() *
@@ -198,17 +216,135 @@ struct SetLocalMortarData {
                       10 * static_cast<unsigned long>(direction.side()) +
                       100 * count + 1000);
 
-        db::mutate<evolution::dg::Tags::MortarData<volume_dim>>(
-            make_not_null(&box),
-            [&face_mesh, &mortar_id, &next_time_step_id, &time_step_id,
-             &type_erased_boundary_data_on_mortar](
-                const auto mortar_data_ptr) noexcept {
+        db::mutate<evolution::dg::Tags::MortarData<Metavariables::volume_dim>>(
+            make_not_null(&box), [&face_mesh, &mortar_id, &time_step_id,
+                                  &type_erased_boundary_data_on_mortar](
+                                     const auto mortar_data_ptr) noexcept {
+              // when using local time stepping, the ApplyBoundaryCorrections
+              // action copies the local data into the MortarDataHistory tag.
               mortar_data_ptr->at(mortar_id).insert_local_mortar_data(
-                  Metavariables::local_time_stepping ? next_time_step_id
-                                                     : time_step_id,
-                  face_mesh, std::move(type_erased_boundary_data_on_mortar));
+                  time_step_id, face_mesh,
+                  std::move(type_erased_boundary_data_on_mortar));
             });
         ++count;
+        if (Metavariables::local_time_stepping) {
+          const TimeStepId past_time_step_id{true, 3,
+                                             Time{Slab{0.2, 3.4}, {1, 4}}};
+          // When doing local time stepping we need a past history, starting an
+          // 1/4 the slab.
+          db::mutate<evolution::dg::Tags::MortarNextTemporalId<
+              Metavariables::volume_dim>>(
+              make_not_null(&box), [&mortar_id, &past_time_step_id](
+                                       const auto mortar_next_temporal_id_ptr) {
+                mortar_next_temporal_id_ptr->at(mortar_id) = past_time_step_id;
+              });
+          // We also need to set the local history one step back to get to 2nd
+          // order in time.
+          type_erased_boundary_data_on_mortar.resize(
+              mortar_mesh.number_of_grid_points() *
+              number_of_dg_package_tags_components);
+          alg::iota(type_erased_boundary_data_on_mortar,
+                    direction.dimension() +
+                        10 * static_cast<unsigned long>(direction.side()) +
+                        100 * count + 1000);
+          count++;
+          evolution::dg::MortarData<Metavariables::volume_dim>
+              past_mortar_data{};
+          past_mortar_data.insert_local_mortar_data(
+              past_time_step_id, face_mesh,
+              std::move(type_erased_boundary_data_on_mortar));
+          Scalar<DataVector> local_face_normal_magnitude{
+              face_mesh.number_of_grid_points()};
+          alg::iota(get(local_face_normal_magnitude),
+                    direction.dimension() +
+                        10 * static_cast<unsigned long>(direction.side()) +
+                        100 * count + 100000);
+          if (volume_mesh.quadrature(0) == Spectral::Quadrature::Gauss) {
+            Scalar<DataVector> local_face_det_jacobian{
+                face_mesh.number_of_grid_points()};
+            alg::iota(get(local_face_det_jacobian),
+                      direction.dimension() +
+                          10 * static_cast<unsigned long>(direction.side()) +
+                          100 * count + 200000);
+            Scalar<DataVector> local_volume_det_inv_jacobian{
+                volume_mesh.number_of_grid_points()};
+            alg::iota(get(local_volume_det_inv_jacobian),
+                      direction.dimension() +
+                          10 * static_cast<unsigned long>(direction.side()) +
+                          100 * count + 300000);
+            past_mortar_data.insert_local_geometric_quantities(
+                local_volume_det_inv_jacobian, local_face_det_jacobian,
+                local_face_normal_magnitude);
+          } else {
+            past_mortar_data.insert_local_face_normal_magnitude(
+                local_face_normal_magnitude);
+          }
+          using dt_variables_tag =
+              db::add_tag_prefix<::Tags::dt,
+                                 typename Metavariables::system::variables_tag>;
+          db::mutate<
+              evolution::dg::Tags::MortarData<Metavariables::volume_dim>,
+              evolution::dg::Tags::MortarDataHistory<
+                  Metavariables::volume_dim, typename dt_variables_tag::type>>(
+              make_not_null(&box),
+              [&det_inv_jacobian, &mortar_id, &past_mortar_data,
+               &past_time_step_id, &time_step_id](
+                  const auto mortar_data_ptr,
+                  const auto mortar_data_history_ptr,
+                  const Mesh<Metavariables::volume_dim>& mesh,
+                  const DirectionMap<Metavariables::volume_dim,
+                                     std::optional<Variables<tmpl::list<
+                                         evolution::dg::Tags::MagnitudeOfNormal,
+                                         evolution::dg::Tags::NormalCovector<
+                                             Metavariables::volume_dim>>>>>&
+                      normal_covector_and_magnitude) {
+                mortar_data_history_ptr->at(mortar_id).local_insert(
+                    past_time_step_id, past_mortar_data);
+
+                // Now add the current data into the history.
+                evolution::dg::MortarData<Metavariables::volume_dim>&
+                    local_mortar_data = mortar_data_ptr->at(mortar_id);
+
+                const Scalar<DataVector>& face_normal_magnitude =
+                    get<evolution::dg::Tags::MagnitudeOfNormal>(
+                        *normal_covector_and_magnitude.at(mortar_id.first));
+
+                const bool using_gauss_points =
+                    mesh.quadrature() == make_array<Metavariables::volume_dim>(
+                                             Spectral::Quadrature::Gauss);
+                if (using_gauss_points) {
+                  const Scalar<DataVector> det_jacobian{
+                      DataVector{1.0 / get(det_inv_jacobian)}};
+                  Scalar<DataVector> face_det_jacobian{
+                      mesh.slice_away(mortar_id.first.dimension())
+                          .number_of_grid_points()};
+                  const Matrix identity{};
+                  auto interpolation_matrices =
+                      make_array<Metavariables::volume_dim>(
+                          std::cref(identity));
+                  const std::pair<Matrix, Matrix>& matrices =
+                      Spectral::boundary_interpolation_matrices(
+                          mesh.slice_through(mortar_id.first.dimension()));
+                  gsl::at(interpolation_matrices, mortar_id.first.dimension()) =
+                      mortar_id.first.side() == Side::Upper ? matrices.second
+                                                            : matrices.first;
+                  apply_matrices(make_not_null(&get(face_det_jacobian)),
+                                 interpolation_matrices, get(det_jacobian),
+                                 mesh.extents());
+                  local_mortar_data.insert_local_geometric_quantities(
+                      det_inv_jacobian, face_det_jacobian,
+                      face_normal_magnitude);
+                } else {
+                  local_mortar_data.insert_local_face_normal_magnitude(
+                      face_normal_magnitude);
+                }
+                mortar_data_history_ptr->at(mortar_id).local_insert(
+                    time_step_id, std::move(local_mortar_data));
+              },
+              db::get<domain::Tags::Mesh<Metavariables::volume_dim>>(box),
+              db::get<evolution::dg::Tags::NormalCovectorAndMagnitude<
+                  Metavariables::volume_dim>>(box));
+        }
       }
     }
     return {std::move(box)};
@@ -246,9 +382,11 @@ struct component {
       domain::Tags::BoundaryDirectionsInterior<Metavariables::volume_dim>;
 
   using simple_tags = tmpl::list<
-      ::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>,
+      ::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>, ::Tags::TimeStep,
+      typename Metavariables::time_stepper_tag,
       db::add_tag_prefix<::Tags::dt,
                          typename Metavariables::system::variables_tag>,
+      typename Metavariables::system::variables_tag,
       domain::Tags::Mesh<Metavariables::volume_dim>,
       domain::Tags::Element<Metavariables::volume_dim>,
       domain::Tags::Coordinates<Metavariables::volume_dim, Frame::Inertial>,
@@ -281,7 +419,8 @@ template <size_t Dim, TestHelpers::SystemType SystemType,
 struct Metavariables {
   static constexpr TestHelpers::SystemType system_type = SystemType;
   static constexpr size_t volume_dim = Dim;
-  static constexpr bool local_time_stepping = false;
+  static constexpr bool local_time_stepping = LocalTimeStepping;
+  using time_stepper_tag = Tags::TimeStepper<TimeSteppers::AdamsBashforthN>;
   using system = System<Dim, SystemType>;
   using const_global_cache_tags = tmpl::list<domain::Tags::InitialExtents<Dim>>;
 
@@ -297,15 +436,25 @@ const auto& get_tag(
                                                                        self_id);
 }
 
-template <size_t Dim, TestHelpers::SystemType SystemType>
+template <size_t Dim, TestHelpers::SystemType SystemType,
+          bool UseLocalTimeStepping>
 void test_impl(const Spectral::Quadrature quadrature,
                const ::dg::Formulation dg_formulation) {
   CAPTURE(Dim);
   CAPTURE(SystemType);
   CAPTURE(quadrature);
   Parallel::register_derived_classes_with_charm<BoundaryCorrection<Dim>>();
-  using metavars = Metavariables<Dim, SystemType, false>;
+  using metavars = Metavariables<Dim, SystemType, UseLocalTimeStepping>;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
+  using variables_tag = typename metavars::system::variables_tag;
+  using variables_tags = typename variables_tag::tags_list;
+  using dt_variables_tag = db::add_tag_prefix<::Tags::dt, variables_tag>;
+  using dt_variables_tags = db::wrap_tags_in<::Tags::dt, variables_tags>;
+  using mortar_tags_list = typename BoundaryTerms<Dim>::dg_package_field_tags;
+
+  // Use a second-order time stepper so that we test the local Jacobian and
+  // normal magnitude history is handled correctly.
+  const TimeSteppers::AdamsBashforthN time_stepper{2};
 
   // The reference element in 2d denoted by X below:
   // ^ eta
@@ -322,10 +471,15 @@ void test_impl(const Spectral::Quadrature quadrature,
   //
   // In 1d there aren't any projections to test, and in 3d we only have 1
   // element in the z-direction.
+  //
+  // We choose the east_id element to be running at a refinement of 2 in time
+  // relative to the self_id element.
   DirectionMap<Dim, Neighbors<Dim>> neighbors{};
   ElementId<Dim> self_id{};
   ElementId<Dim> east_id{};
   ElementId<Dim> south_id{};  // not used in 1d
+  std::vector<std::pair<Direction<Dim>, ElementId<Dim>>>
+      order_to_send_neighbor_data_in{};
 
   if constexpr (Dim == 1) {
     self_id = ElementId<Dim>{0, {{{1, 0}}}};
@@ -345,6 +499,13 @@ void test_impl(const Spectral::Quadrature quadrature,
     neighbors[Direction<Dim>::upper_xi()] = Neighbors<Dim>{{east_id}, {}};
     neighbors[Direction<Dim>::lower_eta()] = Neighbors<Dim>{{south_id}, {}};
   }
+  if constexpr (Dim > 1) {
+    order_to_send_neighbor_data_in.push_back(
+        std::pair{Direction<Dim>::lower_eta(), south_id});
+  }
+  order_to_send_neighbor_data_in.push_back(
+      std::pair{Direction<Dim>::upper_xi(), east_id});
+
   const Element<Dim> element{self_id, neighbors};
 
   MockRuntimeSystem runner{{std::vector<std::array<size_t, Dim>>{
@@ -377,16 +538,32 @@ void test_impl(const Spectral::Quadrature quadrature,
 
   Variables<tmpl::list<::Tags::dt<Var1>, ::Tags::dt<Var2<Dim>>>>
       dt_evolved_vars{mesh.number_of_grid_points(), 0.0};
+  Variables<tmpl::list<Var1, Var2<Dim>>> evolved_vars{
+      mesh.number_of_grid_points(), 0.0};
 
-  const TimeStepId time_step_id{true, 3, Time{Slab{0.2, 3.4}, {3, 100}}};
-  // next_time_step_id will actually be used once we support local time
-  // stepping. Until then we include it as a place holder to make adding local
-  // time stepping easier.
-  const TimeStepId next_time_step_id{true, 3, Time{Slab{0.2, 3.4}, {3, 100}}};
+  const TimeDelta time_step{Slab{0.2, 3.4}, {1, 4}};
+  const TimeStepId time_step_id{true, 3, Time{Slab{0.2, 3.4}, {2, 4}}};
+  const TimeStepId local_next_time_step_id{true, 3,
+                                           Time{Slab{0.2, 3.4}, {3, 4}}};
+  const std::vector<TimeStepId> east_id_time_steps{
+      {true, 3, Time{Slab{0.2, 3.4}, {2, 8}}},
+      {true, 3, Time{Slab{0.2, 3.4}, {3, 8}}},
+      {true, 3, Time{Slab{0.2, 3.4}, {4, 8}}},
+      {true, 3, Time{Slab{0.2, 3.4}, {5, 8}}},
+      {true, 3, Time{Slab{0.2, 3.4}, {6, 8}}}};
+  const std::vector<TimeStepId> east_id_next_time_steps{
+      {true, 3, Time{Slab{0.2, 3.4}, {3, 8}}},
+      {true, 3, Time{Slab{0.2, 3.4}, {4, 8}}},
+      {true, 3, Time{Slab{0.2, 3.4}, {5, 8}}},
+      {true, 3, Time{Slab{0.2, 3.4}, {6, 8}}},
+      {true, 3, Time{Slab{0.2, 3.4}, {7, 8}}}};
+
   ActionTesting::emplace_component_and_initialize<component<metavars>>(
       &runner, self_id,
-      {time_step_id, next_time_step_id, dt_evolved_vars, mesh, element,
-       inertial_coords, inv_jac, quadrature});
+      {time_step_id, local_next_time_step_id, time_step,
+       std::make_unique<TimeSteppers::AdamsBashforthN>(time_stepper),
+       dt_evolved_vars, evolved_vars, mesh, element, inertial_coords, inv_jac,
+       quadrature});
 
   // Run SetupDataBox action.
   ActionTesting::next_action<component<metavars>>(make_not_null(&runner),
@@ -405,6 +582,36 @@ void test_impl(const Spectral::Quadrature quadrature,
   // Make a copy of the mortar data so we can check against it locally
   auto all_mortar_data =
       get_tag<evolution::dg::Tags::MortarData<Dim>>(runner, self_id);
+  typename evolution::dg::Tags::MortarDataHistory<
+      Dim, typename dt_variables_tag::type>::type mortar_data_history{};
+  if (UseLocalTimeStepping) {
+    const TimeStepId past_time_step_id{true, 3, Time{Slab{0.2, 3.4}, {1, 4}}};
+    // Copy local mortar data from all_mortar_data to mortar_data_history
+    for (const auto& [direction, neighbors_in_direction] :
+         element.neighbors()) {
+      for (const auto& neighbor : neighbors_in_direction) {
+        const std::pair mortar_id{direction, neighbor};
+        // Copy past and current mortar data from element's DataBox
+        mortar_data_history[mortar_id].local_insert(
+            past_time_step_id,
+            get_tag<evolution::dg::Tags::MortarDataHistory<
+                Dim, typename dt_variables_tag::type>>(runner, self_id)
+                .at(mortar_id)
+                .local_data(past_time_step_id));
+        mortar_data_history[mortar_id].local_insert(
+            time_step_id,
+            get_tag<evolution::dg::Tags::MortarDataHistory<
+                Dim, typename dt_variables_tag::type>>(runner, self_id)
+                .at(mortar_id)
+                .local_data(time_step_id));
+      }
+    }
+    // If the local history doesn't agree, the rest of the test will fail.
+    const auto& element_mortar_data_hist =
+        get_tag<evolution::dg::Tags::MortarDataHistory<
+            Dim, typename dt_variables_tag::type>>(runner, self_id);
+    REQUIRE(mortar_data_history.size() == element_mortar_data_hist.size());
+  }
 
   // "Send" mortar data to element
   const auto& mortar_meshes =
@@ -412,10 +619,23 @@ void test_impl(const Spectral::Quadrature quadrature,
   using mortar_tags_list = typename BoundaryTerms<Dim>::dg_package_field_tags;
   constexpr size_t number_of_dg_package_tags_components =
       Variables<mortar_tags_list>::number_of_independent_components;
-  for (const auto& [direction, neighbor_ids] : neighbors) {
+  for (const auto& direction_and_neighbor_id : order_to_send_neighbor_data_in) {
+    const auto& direction = direction_and_neighbor_id.first;
+    const auto& neighbor_id = direction_and_neighbor_id.second;
+    CAPTURE(direction);
+    CAPTURE(neighbor_id);
+
     size_t count = 0;
     const Mesh<Dim - 1> face_mesh = mesh.slice_away(direction.dimension());
-    for (const auto& neighbor_id : neighbor_ids) {
+    const auto insert_neighbor_data = [&all_mortar_data, &count, &direction,
+                                       &face_mesh, &local_next_time_step_id,
+                                       &mortar_data_history, &mortar_meshes,
+                                       &neighbor_id, &runner, &self_id](
+                                          const TimeStepId&
+                                              neighbor_time_step_id,
+                                          const TimeStepId&
+                                              neighbor_next_time_step_id) {
+      CAPTURE(neighbor_next_time_step_id);
       std::pair mortar_id{direction, neighbor_id};
       const Mesh<Dim - 1>& mortar_mesh = mortar_meshes.at(mortar_id);
 
@@ -427,21 +647,57 @@ void test_impl(const Spectral::Quadrature quadrature,
                     100 * count);
       std::tuple<Mesh<Dim - 1>, std::optional<std::vector<double>>,
                  std::optional<std::vector<double>>, ::TimeStepId>
-          data{face_mesh,
-               {},
-               {flux_data},
-               {metavars::local_time_stepping ? next_time_step_id
-                                              : time_step_id}};
+          data{face_mesh, {}, {flux_data}, {neighbor_next_time_step_id}};
 
       runner.template mock_distributed_objects<component<metavars>>()
           .at(self_id)
           .template receive_data<
               evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<Dim>>(
-              time_step_id, std::pair{std::pair{direction, neighbor_id}, data});
-      all_mortar_data.at(mortar_id).insert_neighbor_mortar_data(
-          metavars::local_time_stepping ? next_time_step_id : time_step_id,
-          face_mesh, flux_data);
+              neighbor_time_step_id,
+              std::pair{std::pair{direction, neighbor_id}, data});
+      if (UseLocalTimeStepping) {
+        if (neighbor_time_step_id < local_next_time_step_id) {
+          evolution::dg::MortarData<Dim> nhbr_mortar_data{};
+          nhbr_mortar_data.insert_neighbor_mortar_data(neighbor_time_step_id,
+                                                       face_mesh, flux_data);
+          mortar_data_history.at(mortar_id).remote_insert(
+              neighbor_time_step_id, std::move(nhbr_mortar_data));
+        }
+      } else {
+        all_mortar_data.at(mortar_id).insert_neighbor_mortar_data(
+            neighbor_time_step_id, face_mesh, flux_data);
+      }
       ++count;
+    };
+    if (neighbor_id == east_id and UseLocalTimeStepping) {
+      for (size_t east_id_time_steps_index = 0;
+           east_id_time_steps_index < east_id_next_time_steps.size();
+           ++east_id_time_steps_index) {
+        if (east_id_time_steps_index < east_id_next_time_steps.size() - 1) {
+          CHECK(not ActionTesting::is_ready<component<metavars>>(runner,
+                                                                 self_id));
+        } else {
+          CHECK(ActionTesting::is_ready<component<metavars>>(runner, self_id));
+        }
+        insert_neighbor_data(east_id_time_steps[east_id_time_steps_index],
+                             east_id_next_time_steps[east_id_time_steps_index]);
+      }
+    } else {
+      // Insert the mortar data (history) running at the same speed as the
+      // self_id.
+      CHECK(not ActionTesting::is_ready<component<metavars>>(runner, self_id));
+      if (UseLocalTimeStepping) {
+        // Insert the past time, since we are using a 2nd order time stepper.
+        const Time prev_time = time_step_id.step_time() - time_step;
+        insert_neighbor_data(TimeStepId{time_step_id.time_runs_forward(),
+                                        time_step_id.slab_number(), prev_time},
+                             time_step_id);
+        CHECK(
+            not ActionTesting::is_ready<component<metavars>>(runner, self_id));
+      }
+      insert_neighbor_data(time_step_id, UseLocalTimeStepping
+                                             ? local_next_time_step_id
+                                             : time_step_id);
     }
   }
   // Check expected inboxes
@@ -451,27 +707,31 @@ void test_impl(const Spectral::Quadrature quadrature,
               component<metavars>,
               evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<Dim>>()
           .size() == 1);
-
   REQUIRE(ActionTesting::is_ready<component<metavars>>(runner, self_id));
+  // At this point we've completed testing the `is_ready` part of
+  // ApplyBoundaryCorrections
 
   ActionTesting::next_action<component<metavars>>(make_not_null(&runner),
                                                   self_id);
 
-  // Check the inboxes are empty
-  REQUIRE(
-      runner
-          .template nonempty_inboxes<
-              component<metavars>,
-              evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<Dim>>()
-          .empty());
+  // Check the inboxes are empty when doing global time stepping
+  if (not UseLocalTimeStepping) {
+    REQUIRE(runner
+                .template nonempty_inboxes<
+                    component<metavars>,
+                    evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<
+                        Dim>>()
+                .empty());
+  } else {
+    CHECK(runner
+              .template nonempty_inboxes<
+                  component<metavars>,
+                  evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<
+                      Dim>>()
+              .size() == 1);
+  }
 
   // Now retrieve dt tag and check that values are correct
-  using variables_tag = typename metavars::system::variables_tag;
-  using variables_tags = typename variables_tag::tags_list;
-  using dt_variables_tag = db::add_tag_prefix<::Tags::dt, variables_tag>;
-  using dt_variables_tags = db::wrap_tags_in<::Tags::dt, variables_tags>;
-  using mortar_tags_list = typename BoundaryTerms<Dim>::dg_package_field_tags;
-
   const auto& mortar_sizes =
       get_tag<evolution::dg::Tags::MortarSize<Dim>>(runner, self_id);
 
@@ -479,23 +739,44 @@ void test_impl(const Spectral::Quadrature quadrature,
   Variables<dt_variables_tags> dt_boundary_correction_projected_onto_face{};
   Variables<dt_variables_tags> expected_dt_variables_volume{
       mesh.number_of_grid_points(), 0.0};
-  for (auto& [mortar_id, mortar_data] : all_mortar_data) {
-    if (mortar_id.second == ElementId<Dim>::external_boundary_id()) {
-      continue;
-    }
+  const std::pair<Direction<Dim>, ElementId<Dim>>* mortar_id_ptr = nullptr;
+
+  const auto compute_correction_coupling =
+      [&det_inv_jacobian, &dg_formulation, &dt_boundary_correction_on_mortar,
+       &dt_boundary_correction_projected_onto_face,
+       &expected_dt_variables_volume, &mesh, &mortar_id_ptr, &mortar_meshes,
+       &mortar_sizes, &quadrature, &runner, &self_id](
+          const evolution::dg::MortarData<Dim>& local_mortar_data,
+          const evolution::dg::MortarData<Dim>& neighbor_mortar_data) noexcept
+      -> Variables<db::wrap_tags_in<::Tags::dt, variables_tags>> {
+    const auto& mortar_id = *mortar_id_ptr;
     const auto& direction = mortar_id.first;
+    const auto& mortar_mesh = mortar_meshes.at(mortar_id);
     const size_t dimension = direction.dimension();
-    const Mesh<Dim - 1>& mortar_mesh = mortar_meshes.at(mortar_id);
+
+    if (UseLocalTimeStepping and quadrature == Spectral::Quadrature::Gauss) {
+      // This needs to be updated every call because the Jacobian may be
+      // time-dependent. In the case of time-independent maps and local
+      // time stepping we could first perform the integral on the
+      // boundaries, and then lift to the volume. This is left as a future
+      // optimization.
+      local_mortar_data.get_local_volume_det_inv_jacobian(make_not_null(
+          &const_cast<Scalar<DataVector>&>(det_inv_jacobian)));  // NOLINT
+    }
 
     Variables<mortar_tags_list> local_data_on_mortar{
         mortar_mesh.number_of_grid_points()};
     Variables<mortar_tags_list> neighbor_data_on_mortar{
         mortar_mesh.number_of_grid_points()};
-    std::copy(mortar_data.local_mortar_data()->second.begin(),
-              mortar_data.local_mortar_data()->second.end(),
+    const std::pair<Mesh<Dim - 1>, std::vector<double>>& local_mesh_and_data =
+        *local_mortar_data.local_mortar_data();
+    const std::pair<Mesh<Dim - 1>, std::vector<double>>&
+        neighbor_mesh_and_data = *neighbor_mortar_data.neighbor_mortar_data();
+    std::copy(std::get<1>(local_mesh_and_data).begin(),
+              std::get<1>(local_mesh_and_data).end(),
               local_data_on_mortar.data());
-    std::copy(mortar_data.neighbor_mortar_data()->second.begin(),
-              mortar_data.neighbor_mortar_data()->second.end(),
+    std::copy(std::get<1>(neighbor_mesh_and_data).begin(),
+              std::get<1>(neighbor_mesh_and_data).end(),
               neighbor_data_on_mortar.data());
 
     if (dt_boundary_correction_on_mortar.number_of_grid_points() !=
@@ -540,71 +821,147 @@ void test_impl(const Spectral::Quadrature quadrature,
     }();
 
     // Lift the boundary terms from the face into the volume
-    const auto& magnitude_of_face_normal =
-        get<evolution::dg::Tags::MagnitudeOfNormal>(
-            *get_tag<evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>>(
-                 runner, self_id)
-                 .at(direction));
+    Scalar<DataVector> magnitude_of_face_normal{};
+    if (UseLocalTimeStepping) {
+      local_mortar_data.get_local_face_normal_magnitude(
+          &magnitude_of_face_normal);
+    } else {
+      magnitude_of_face_normal = get<evolution::dg::Tags::MagnitudeOfNormal>(
+          *get_tag<evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>>(
+               runner, self_id)
+               .at(direction));
+    }
 
-    if (mesh.quadrature(0) == Spectral::Quadrature::GaussLobatto) {
+    if (quadrature == Spectral::Quadrature::GaussLobatto) {
       // The lift_flux function lifts only on the slice, it does not add
       // the contribution to the volume.
       ::dg::lift_flux(make_not_null(&dt_boundary_correction),
                       mesh.extents(dimension), magnitude_of_face_normal);
-
-      // Add the flux contribution to the volume data
-      add_slice_to_data(make_not_null(&expected_dt_variables_volume),
-                        dt_boundary_correction, mesh.extents(), dimension,
-                        index_to_slice_at(mesh.extents(), direction));
+      if (UseLocalTimeStepping) {
+        return dt_boundary_correction;
+      } else {
+        // Add the flux contribution to the volume data
+        add_slice_to_data(make_not_null(&expected_dt_variables_volume),
+                          dt_boundary_correction, mesh.extents(), dimension,
+                          index_to_slice_at(mesh.extents(), direction));
+      }
     } else {
-      // Project the volume det jacobian to the face
-      Scalar<DataVector> face_det_jacobian{face_mesh.number_of_grid_points()};
-      const Matrix identity{};
-      auto interpolation_matrices = make_array<Dim>(std::cref(identity));
-      const std::pair<Matrix, Matrix>& matrices =
-          Spectral::boundary_interpolation_matrices(
-              mesh.slice_through(direction.dimension()));
-      gsl::at(interpolation_matrices, direction.dimension()) =
-          direction.side() == Side::Upper ? matrices.second : matrices.first;
-      apply_matrices(make_not_null(&get(face_det_jacobian)),
-                     interpolation_matrices,
-                     DataVector{1.0 / get(det_inv_jacobian)}, mesh.extents());
+      if (UseLocalTimeStepping) {
+        Scalar<DataVector> face_det_jacobian{};
+        local_mortar_data.get_local_face_det_jacobian(
+            make_not_null(&face_det_jacobian));
 
-      // Lift from the Gauss points into the volume
-      evolution::dg::lift_boundary_terms_gauss_points(
-          make_not_null(&expected_dt_variables_volume), det_inv_jacobian, mesh,
-          direction, dt_boundary_correction, magnitude_of_face_normal,
-          face_det_jacobian);
+        Variables<db::wrap_tags_in<::Tags::dt, variables_tags>>
+            volume_dt_correction{mesh.number_of_grid_points(), 0.0};
+        evolution::dg::lift_boundary_terms_gauss_points(
+            make_not_null(&volume_dt_correction), det_inv_jacobian, mesh,
+            direction, dt_boundary_correction, magnitude_of_face_normal,
+            face_det_jacobian);
+        return volume_dt_correction;
+      } else {
+        // Project the volume det jacobian to the face
+        Scalar<DataVector> face_det_jacobian{face_mesh.number_of_grid_points()};
+        const Matrix identity{};
+        auto interpolation_matrices = make_array<Dim>(std::cref(identity));
+        const std::pair<Matrix, Matrix>& matrices =
+            Spectral::boundary_interpolation_matrices(
+                mesh.slice_through(direction.dimension()));
+        gsl::at(interpolation_matrices, direction.dimension()) =
+            direction.side() == Side::Upper ? matrices.second : matrices.first;
+        apply_matrices(make_not_null(&get(face_det_jacobian)),
+                       interpolation_matrices,
+                       DataVector{1.0 / get(det_inv_jacobian)}, mesh.extents());
+
+        // Lift from the Gauss points into the volume
+        evolution::dg::lift_boundary_terms_gauss_points(
+            make_not_null(&expected_dt_variables_volume), det_inv_jacobian,
+            mesh, direction, dt_boundary_correction, magnitude_of_face_normal,
+            face_det_jacobian);
+      }
     }
+
+    ASSERT(not UseLocalTimeStepping,
+           "We shouldn't be returning empty data when using local time "
+           "stepping. Some logic in the lambda this assert is in is bad. Might "
+           "be a missing return?");
+    return {};
+  };
+
+  Variables<variables_tags> expected_evolved_variables{
+      mesh.number_of_grid_points(), 0.0};
+  if (UseLocalTimeStepping) {
+    for (auto& mortar_id_and_data : mortar_data_history) {
+      const auto& mortar_id = mortar_id_and_data.first;
+      auto& mortar_data_hist = mortar_id_and_data.second;
+      mortar_id_ptr = &mortar_id;
+      auto lifted_volume_data = time_stepper.compute_boundary_delta(
+          compute_correction_coupling, make_not_null(&mortar_data_hist),
+          time_step);
+      if (quadrature == Spectral::Quadrature::GaussLobatto) {
+        const auto& direction = mortar_id.first;
+        // Add the flux contribution to the volume data
+        add_slice_to_data(make_not_null(&expected_evolved_variables),
+                          lifted_volume_data, mesh.extents(),
+                          direction.dimension(),
+                          index_to_slice_at(mesh.extents(), direction));
+      } else {
+        expected_evolved_variables += lifted_volume_data;
+      }
+    }
+
+    // dt_variables should be identically zero in both cases
+    CHECK(expected_dt_variables_volume ==
+          get_tag<dt_variables_tag>(runner, self_id));
+    tmpl::for_each<variables_tags>([&expected_evolved_variables, &runner,
+                                    &self_id](auto tag_v) noexcept {
+      using tag = tmpl::type_from<decltype(tag_v)>;
+      CHECK_ITERABLE_APPROX(get<tag>(get_tag<variables_tag>(runner, self_id)),
+                            get<tag>(expected_evolved_variables));
+    });
+  } else {
+    for (auto& [mortar_id, mortar_data] : all_mortar_data) {
+      if (mortar_id.second == ElementId<Dim>::external_boundary_id()) {
+        continue;
+      }
+      mortar_id_ptr = &mortar_id;
+      compute_correction_coupling(mortar_data, mortar_data);
+    }
+    tmpl::for_each<dt_variables_tags>([&expected_dt_variables_volume, &runner,
+                                       &self_id](auto tag_v) noexcept {
+      using tag = tmpl::type_from<decltype(tag_v)>;
+      CHECK_ITERABLE_APPROX(
+          get<tag>(get_tag<dt_variables_tag>(runner, self_id)),
+          get<tag>(expected_dt_variables_volume));
+    });
+    CHECK(expected_evolved_variables ==
+          get_tag<variables_tag>(runner, self_id));
   }
-  tmpl::for_each<dt_variables_tags>([&expected_dt_variables_volume, &runner,
-                                     &self_id](auto tag_v) noexcept {
-    using tag = tmpl::type_from<decltype(tag_v)>;
-    CHECK_ITERABLE_APPROX(get<tag>(get_tag<dt_variables_tag>(runner, self_id)),
-                          get<tag>(expected_dt_variables_volume));
-  });
 }
 
-template <size_t Dim>
-void test() noexcept {
+template <size_t Dim, bool UseLocalTimeStepping>
+void test() {
   for (const auto dg_formulation :
        {::dg::Formulation::StrongInertial, ::dg::Formulation::WeakInertial}) {
     for (const auto quadrature :
          {Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss}) {
-      test_impl<Dim, TestHelpers::SystemType::Conservative>(quadrature,
-                                                            dg_formulation);
-      test_impl<Dim, TestHelpers::SystemType::Nonconservative>(quadrature,
-                                                               dg_formulation);
-      test_impl<Dim, TestHelpers::SystemType::Mixed>(quadrature,
-                                                     dg_formulation);
+      test_impl<Dim, TestHelpers::SystemType::Conservative,
+                UseLocalTimeStepping>(quadrature, dg_formulation);
+      test_impl<Dim, TestHelpers::SystemType::Nonconservative,
+                UseLocalTimeStepping>(quadrature, dg_formulation);
+      test_impl<Dim, TestHelpers::SystemType::Mixed, UseLocalTimeStepping>(
+          quadrature, dg_formulation);
     }
   }
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.DG.ApplyBoundaryCorrections",
                   "[Unit][Evolution][Actions]") {
-  test<1>();
-  test<2>();
-  test<3>();
+  PUPable_reg(TimeSteppers::AdamsBashforthN);
+  test<1, false>();
+  test<1, true>();
+  test<2, false>();
+  test<2, true>();
+  test<3, false>();
+  test<3, true>();
 }
 }  // namespace

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -34,9 +34,11 @@ target_link_libraries(
   CoordinateMaps
   DiscontinuousGalerkin
   Domain
+  DomainStructure
   Evolution
   EvolutionDgActionsHelpers
   Spectral
+  Time
   )
 
 add_dependencies(

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_Mortars.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_Mortars.cpp
@@ -11,6 +11,10 @@
 #include <utility>
 
 #include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
 #include "Domain/Structure/CreateInitialMesh.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
@@ -54,17 +58,31 @@ struct component {
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
           tmpl::list<
               ActionTesting::InitializeDataBox<simple_tags, compute_tags>>>,
-      Parallel::PhaseActions<typename Metavariables::Phase,
-                             Metavariables::Phase::Testing,
-                             tmpl::list<Actions::SetupDataBox,
-                                        evolution::dg::Initialization::Mortars<
-                                            Metavariables::volume_dim>>>>;
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          tmpl::list<
+              Actions::SetupDataBox,
+              evolution::dg::Initialization::Mortars<
+                  Metavariables::volume_dim, typename Metavariables::system>>>>;
+};
+
+struct Var1 : db::SimpleTag {
+  using type = Scalar<DataVector>;
 };
 
 template <size_t Dim>
+struct Var2 : db::SimpleTag {
+  using type = tnsr::I<DataVector, Dim, Frame::Inertial>;
+};
+
+template <size_t Dim, bool LocalTimeStepping>
 struct Metavariables {
   static constexpr size_t volume_dim = Dim;
+  static constexpr bool local_time_stepping = LocalTimeStepping;
   using const_global_cache_tags = tmpl::list<domain::Tags::InitialExtents<Dim>>;
+  struct system {
+    using variables_tag = ::Tags::Variables<tmpl::list<Var1, Var2<Dim>>>;
+  };
 
   using component_list = tmpl::list<component<Metavariables>>;
   enum class Phase { Initialization, Testing, Exit };
@@ -75,7 +93,7 @@ using MortarMap =
     std::unordered_map<std::pair<Direction<Dim>, ElementId<Dim>>, MappedType,
                        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>;
 
-template <size_t Dim>
+template <bool LocalTimeStepping, size_t Dim>
 void test_impl(
     const std::vector<std::array<size_t, Dim>>& initial_extents,
     const Element<Dim>& element, const TimeStepId& time_step_id,
@@ -87,7 +105,7 @@ void test_impl(
                                 evolution::dg::Tags::MagnitudeOfNormal,
                                 evolution::dg::Tags::NormalCovector<Dim>>>>>&
         expected_normal_covector_quantities) {
-  using metavars = Metavariables<Dim>;
+  using metavars = Metavariables<Dim, LocalTimeStepping>;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
   MockRuntimeSystem runner{initial_extents};
   ActionTesting::emplace_component_and_initialize<component<metavars>>(
@@ -117,9 +135,18 @@ void test_impl(
   const auto& mortar_sizes = get_tag(Tags::MortarSize<Dim>{});
   CHECK(mortar_sizes == expected_mortar_sizes);
   const auto& mortar_data = get_tag(Tags::MortarData<Dim>{});
+  const auto& boundary_data_history = get_tag(
+      Tags::MortarDataHistory<
+          Dim,
+          typename db::add_tag_prefix<
+              ::Tags::dt, typename metavars::system::variables_tag>::type>{});
   for (const auto& mortar_id_and_mesh : expected_mortar_meshes) {
     // Just make sure this exists, it is not expected to hold any data
     CHECK(mortar_data.find(mortar_id_and_mesh.first) != mortar_data.end());
+    if (LocalTimeStepping) {
+      CHECK(boundary_data_history.find(mortar_id_and_mesh.first) !=
+            boundary_data_history.end());
+    }
   }
 
   const auto& mortar_next_temporal_ids =
@@ -138,173 +165,187 @@ void test_impl(
       expected_normal_covector_quantities));
 }
 
-template <size_t Dim>
-void test(Spectral::Quadrature quadrature);
+template <size_t Dim, bool LocalTimeStepping>
+struct Test;
 
-template <>
-void test<1>(const Spectral::Quadrature quadrature) {
-  INFO("1D");
-  // Reference element is denoted by X, has one internal boundary and one
-  // external boundary:
-  //
-  // [X| | | ]-> xi
+template <bool LocalTimeStepping>
+struct Test<1, LocalTimeStepping> {
+  static void apply(const Spectral::Quadrature quadrature) {
+    INFO("1D");
+    // Reference element is denoted by X, has one internal boundary and one
+    // external boundary:
+    //
+    // [X| | | ]-> xi
 
-  const ElementId<1> element_id{0, {{{2, 0}}}};
-  const ElementId<1> east_id{0, {{{2, 1}}}};
-  const std::vector initial_extents{make_array<1>(2_st)};
+    const ElementId<1> element_id{0, {{{2, 0}}}};
+    const ElementId<1> east_id{0, {{{2, 1}}}};
+    const std::vector initial_extents{make_array<1>(2_st)};
 
-  DirectionMap<1, Neighbors<1>> neighbors{};
-  neighbors[Direction<1>::upper_xi()] = Neighbors<1>{{east_id}, {}};
-  const Element<1> element{element_id, neighbors};
-  const TimeStepId time_step_id{true, 3, Time{Slab{0.2, 3.4}, {3, 100}}};
+    DirectionMap<1, Neighbors<1>> neighbors{};
+    neighbors[Direction<1>::upper_xi()] = Neighbors<1>{{east_id}, {}};
+    const Element<1> element{element_id, neighbors};
+    const TimeStepId time_step_id{true, 3, Time{Slab{0.2, 3.4}, {3, 100}}};
 
-  // We are working with 2 mortars here: a domain boundary at lower xi
-  // and an interface at upper xi.
-  const auto interface_mortar_id =
-      std::make_pair(Direction<1>::upper_xi(), east_id);
-  const MortarMap<1, Mesh<0>> expected_mortar_meshes{{interface_mortar_id, {}}};
-  const MortarMap<1, std::array<Spectral::MortarSize, 0>> expected_mortar_sizes{
-      {interface_mortar_id, {}}};
+    // We are working with 2 mortars here: a domain boundary at lower xi
+    // and an interface at upper xi.
+    const auto interface_mortar_id =
+        std::make_pair(Direction<1>::upper_xi(), east_id);
+    const MortarMap<1, Mesh<0>> expected_mortar_meshes{
+        {interface_mortar_id, {}}};
+    const MortarMap<1, std::array<Spectral::MortarSize, 0>>
+        expected_mortar_sizes{{interface_mortar_id, {}}};
 
-  const DirectionMap<
-      1, std::optional<
-             Variables<tmpl::list<evolution::dg::Tags::MagnitudeOfNormal,
-                                  evolution::dg::Tags::NormalCovector<1>>>>>
-      expected_normal_covector_quantities{{Direction<1>::lower_xi(), {}},
-                                          {Direction<1>::upper_xi(), {}}};
+    const DirectionMap<
+        1, std::optional<
+               Variables<tmpl::list<evolution::dg::Tags::MagnitudeOfNormal,
+                                    evolution::dg::Tags::NormalCovector<1>>>>>
+        expected_normal_covector_quantities{{Direction<1>::lower_xi(), {}},
+                                            {Direction<1>::upper_xi(), {}}};
 
-  test_impl(initial_extents, element, time_step_id, quadrature,
-            expected_mortar_meshes, expected_mortar_sizes,
-            expected_normal_covector_quantities);
-}
-
-template <>
-void test<2>(const Spectral::Quadrature quadrature) {
-  INFO("2D");
-  // Reference element is denoted by X, has two internal boundaries (east and
-  // south) and two external boundaries (west and north):
-  //
-  // ^ eta
-  // +-+-+> xi
-  // |X| |
-  // +-+-+
-  // | | |
-  // +-+-+
-
-  const ElementId<2> element_id{0, {{{1, 0}, {1, 1}}}};
-  const ElementId<2> east_id(0, {{SegmentId{1, 1}, SegmentId{1, 1}}});
-  const ElementId<2> south_id(0, {{SegmentId{1, 0}, SegmentId{1, 0}}});
-  const std::vector initial_extents{std::array{3_st, 2_st}};
-
-  DirectionMap<2, Neighbors<2>> neighbors{};
-  neighbors[Direction<2>::upper_xi()] = Neighbors<2>{{east_id}, {}};
-  neighbors[Direction<2>::lower_eta()] = Neighbors<2>{{south_id}, {}};
-
-  const Element<2> element{element_id, neighbors};
-  const TimeStepId time_step_id{true, 3, Time{Slab{0.2, 3.4}, {3, 100}}};
-
-  // We are working with 4 mortars here: the domain boundary west and north,
-  // and interfaces south and east.
-  const auto interface_mortar_id_east =
-      std::make_pair(Direction<2>::upper_xi(), east_id);
-  const auto interface_mortar_id_south =
-      std::make_pair(Direction<2>::lower_eta(), south_id);
-
-  const MortarMap<2, Mesh<1>> expected_mortar_meshes{
-      {interface_mortar_id_east,
-       Mesh<1>(2, Spectral::Basis::Legendre, quadrature)},
-      {interface_mortar_id_south,
-       Mesh<1>(3, Spectral::Basis::Legendre, quadrature)}};
-  MortarMap<2, std::array<Spectral::MortarSize, 1>> expected_mortar_sizes{};
-  for (const auto& mortar_id_and_mesh : expected_mortar_meshes) {
-    expected_mortar_sizes[mortar_id_and_mesh.first] = {
-        {Spectral::MortarSize::Full}};
+    test_impl<LocalTimeStepping>(initial_extents, element, time_step_id,
+                                 quadrature, expected_mortar_meshes,
+                                 expected_mortar_sizes,
+                                 expected_normal_covector_quantities);
   }
+};
 
-  const DirectionMap<
-      2, std::optional<
-             Variables<tmpl::list<evolution::dg::Tags::MagnitudeOfNormal,
-                                  evolution::dg::Tags::NormalCovector<2>>>>>
-      expected_normal_covector_quantities{{Direction<2>::lower_xi(), {}},
-                                          {Direction<2>::upper_xi(), {}},
-                                          {Direction<2>::lower_eta(), {}},
-                                          {Direction<2>::upper_eta(), {}}};
+template <bool LocalTimeStepping>
+struct Test<2, LocalTimeStepping> {
+  static void apply(const Spectral::Quadrature quadrature) {
+    INFO("2D");
+    // Reference element is denoted by X, has two internal boundaries (east and
+    // south) and two external boundaries (west and north):
+    //
+    // ^ eta
+    // +-+-+> xi
+    // |X| |
+    // +-+-+
+    // | | |
+    // +-+-+
 
-  test_impl(initial_extents, element, time_step_id, quadrature,
-            expected_mortar_meshes, expected_mortar_sizes,
-            expected_normal_covector_quantities);
-}
+    const ElementId<2> element_id{0, {{{1, 0}, {1, 1}}}};
+    const ElementId<2> east_id(0, {{SegmentId{1, 1}, SegmentId{1, 1}}});
+    const ElementId<2> south_id(0, {{SegmentId{1, 0}, SegmentId{1, 0}}});
+    const std::vector initial_extents{std::array{3_st, 2_st}};
 
-template <>
-void test<3>(const Spectral::Quadrature quadrature) {
-  INFO("3D");
-  // Neighboring elements in:
-  // - upper-xi (right id)
-  // - lower-eta (front id)
-  // - upper-zeta (top id)
-  //
-  // All other directions don't have neighbors.
+    DirectionMap<2, Neighbors<2>> neighbors{};
+    neighbors[Direction<2>::upper_xi()] = Neighbors<2>{{east_id}, {}};
+    neighbors[Direction<2>::lower_eta()] = Neighbors<2>{{south_id}, {}};
 
-  const ElementId<3> element_id{
-      0, {{SegmentId{1, 0}, SegmentId{1, 1}, SegmentId{1, 0}}}};
-  const ElementId<3> right_id(
-      0, {{SegmentId{1, 1}, SegmentId{1, 1}, SegmentId{1, 0}}});
-  const ElementId<3> front_id(
-      0, {{SegmentId{1, 0}, SegmentId{1, 0}, SegmentId{1, 0}}});
-  const ElementId<3> top_id(
-      0, {{SegmentId{1, 0}, SegmentId{1, 1}, SegmentId{1, 1}}});
-  const std::vector initial_extents{std::array{2_st, 3_st, 4_st}};
+    const Element<2> element{element_id, neighbors};
+    const TimeStepId time_step_id{true, 3, Time{Slab{0.2, 3.4}, {3, 100}}};
 
-  DirectionMap<3, Neighbors<3>> neighbors{};
-  neighbors[Direction<3>::upper_xi()] = Neighbors<3>{{right_id}, {}};
-  neighbors[Direction<3>::lower_eta()] = Neighbors<3>{{front_id}, {}};
-  neighbors[Direction<3>::upper_zeta()] = Neighbors<3>{{top_id}, {}};
+    // We are working with 4 mortars here: the domain boundary west and north,
+    // and interfaces south and east.
+    const auto interface_mortar_id_east =
+        std::make_pair(Direction<2>::upper_xi(), east_id);
+    const auto interface_mortar_id_south =
+        std::make_pair(Direction<2>::lower_eta(), south_id);
 
-  const Element<3> element{element_id, neighbors};
-  const TimeStepId time_step_id{true, 3, Time{Slab{0.2, 3.4}, {3, 100}}};
+    const MortarMap<2, Mesh<1>> expected_mortar_meshes{
+        {interface_mortar_id_east,
+         Mesh<1>(2, Spectral::Basis::Legendre, quadrature)},
+        {interface_mortar_id_south,
+         Mesh<1>(3, Spectral::Basis::Legendre, quadrature)}};
+    MortarMap<2, std::array<Spectral::MortarSize, 1>> expected_mortar_sizes{};
+    for (const auto& mortar_id_and_mesh : expected_mortar_meshes) {
+      expected_mortar_sizes[mortar_id_and_mesh.first] = {
+          {Spectral::MortarSize::Full}};
+    }
 
-  const auto interface_mortar_id_right =
-      std::make_pair(Direction<3>::upper_xi(), right_id);
-  const auto interface_mortar_id_front =
-      std::make_pair(Direction<3>::lower_eta(), front_id);
-  const auto interface_mortar_id_top =
-      std::make_pair(Direction<3>::upper_zeta(), top_id);
+    const DirectionMap<
+        2, std::optional<
+               Variables<tmpl::list<evolution::dg::Tags::MagnitudeOfNormal,
+                                    evolution::dg::Tags::NormalCovector<2>>>>>
+        expected_normal_covector_quantities{{Direction<2>::lower_xi(), {}},
+                                            {Direction<2>::upper_xi(), {}},
+                                            {Direction<2>::lower_eta(), {}},
+                                            {Direction<2>::upper_eta(), {}}};
 
-  const MortarMap<3, Mesh<2>> expected_mortar_meshes{
-      {interface_mortar_id_right,
-       Mesh<2>({{3, 4}}, Spectral::Basis::Legendre, quadrature)},
-      {interface_mortar_id_front,
-       Mesh<2>({{2, 4}}, Spectral::Basis::Legendre, quadrature)},
-      {interface_mortar_id_top,
-       Mesh<2>({{2, 3}}, Spectral::Basis::Legendre, quadrature)}};
-  MortarMap<3, std::array<Spectral::MortarSize, 2>> expected_mortar_sizes{};
-  for (const auto& mortar_id_and_mesh : expected_mortar_meshes) {
-    expected_mortar_sizes[mortar_id_and_mesh.first] = {
-        {Spectral::MortarSize::Full, Spectral::MortarSize::Full}};
+    test_impl<LocalTimeStepping>(initial_extents, element, time_step_id,
+                                 quadrature, expected_mortar_meshes,
+                                 expected_mortar_sizes,
+                                 expected_normal_covector_quantities);
   }
+};
 
-  const DirectionMap<
-      3, std::optional<
-             Variables<tmpl::list<evolution::dg::Tags::MagnitudeOfNormal,
-                                  evolution::dg::Tags::NormalCovector<3>>>>>
-      expected_normal_covector_quantities{
-          {Direction<3>::lower_xi(), {}},   {Direction<3>::upper_xi(), {}},
-          {Direction<3>::lower_eta(), {}},  {Direction<3>::upper_eta(), {}},
-          {Direction<3>::lower_zeta(), {}}, {Direction<3>::upper_zeta(), {}}};
+template <bool LocalTimeStepping>
+struct Test<3, LocalTimeStepping> {
+  static void apply(const Spectral::Quadrature quadrature) {
+    INFO("3D");
+    // Neighboring elements in:
+    // - upper-xi (right id)
+    // - lower-eta (front id)
+    // - upper-zeta (top id)
+    //
+    // All other directions don't have neighbors.
 
-  test_impl(initial_extents, element, time_step_id, quadrature,
-            expected_mortar_meshes, expected_mortar_sizes,
-            expected_normal_covector_quantities);
-}
+    const ElementId<3> element_id{
+        0, {{SegmentId{1, 0}, SegmentId{1, 1}, SegmentId{1, 0}}}};
+    const ElementId<3> right_id(
+        0, {{SegmentId{1, 1}, SegmentId{1, 1}, SegmentId{1, 0}}});
+    const ElementId<3> front_id(
+        0, {{SegmentId{1, 0}, SegmentId{1, 0}, SegmentId{1, 0}}});
+    const ElementId<3> top_id(
+        0, {{SegmentId{1, 0}, SegmentId{1, 1}, SegmentId{1, 1}}});
+    const std::vector initial_extents{std::array{2_st, 3_st, 4_st}};
+
+    DirectionMap<3, Neighbors<3>> neighbors{};
+    neighbors[Direction<3>::upper_xi()] = Neighbors<3>{{right_id}, {}};
+    neighbors[Direction<3>::lower_eta()] = Neighbors<3>{{front_id}, {}};
+    neighbors[Direction<3>::upper_zeta()] = Neighbors<3>{{top_id}, {}};
+
+    const Element<3> element{element_id, neighbors};
+    const TimeStepId time_step_id{true, 3, Time{Slab{0.2, 3.4}, {3, 100}}};
+
+    const auto interface_mortar_id_right =
+        std::make_pair(Direction<3>::upper_xi(), right_id);
+    const auto interface_mortar_id_front =
+        std::make_pair(Direction<3>::lower_eta(), front_id);
+    const auto interface_mortar_id_top =
+        std::make_pair(Direction<3>::upper_zeta(), top_id);
+
+    const MortarMap<3, Mesh<2>> expected_mortar_meshes{
+        {interface_mortar_id_right,
+         Mesh<2>({{3, 4}}, Spectral::Basis::Legendre, quadrature)},
+        {interface_mortar_id_front,
+         Mesh<2>({{2, 4}}, Spectral::Basis::Legendre, quadrature)},
+        {interface_mortar_id_top,
+         Mesh<2>({{2, 3}}, Spectral::Basis::Legendre, quadrature)}};
+    MortarMap<3, std::array<Spectral::MortarSize, 2>> expected_mortar_sizes{};
+    for (const auto& mortar_id_and_mesh : expected_mortar_meshes) {
+      expected_mortar_sizes[mortar_id_and_mesh.first] = {
+          {Spectral::MortarSize::Full, Spectral::MortarSize::Full}};
+    }
+
+    const DirectionMap<
+        3, std::optional<
+               Variables<tmpl::list<evolution::dg::Tags::MagnitudeOfNormal,
+                                    evolution::dg::Tags::NormalCovector<3>>>>>
+        expected_normal_covector_quantities{
+            {Direction<3>::lower_xi(), {}},   {Direction<3>::upper_xi(), {}},
+            {Direction<3>::lower_eta(), {}},  {Direction<3>::upper_eta(), {}},
+            {Direction<3>::lower_zeta(), {}}, {Direction<3>::upper_zeta(), {}}};
+
+    test_impl<LocalTimeStepping>(initial_extents, element, time_step_id,
+                                 quadrature, expected_mortar_meshes,
+                                 expected_mortar_sizes,
+                                 expected_normal_covector_quantities);
+  }
+};
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.DG.Initialization.Mortars",
                   "[Unit][Evolution]") {
   for (const auto quadrature :
        {Spectral::Quadrature::Gauss, Spectral::Quadrature::GaussLobatto}) {
-    test<1>(quadrature);
-    test<2>(quadrature);
-    test<3>(quadrature);
+    Test<1, true>::apply(quadrature);
+    Test<2, true>::apply(quadrature);
+    Test<3, true>::apply(quadrature);
+
+    Test<1, false>::apply(quadrature);
+    Test<2, false>::apply(quadrature);
+    Test<3, false>::apply(quadrature);
   }
 }
 }  // namespace evolution::dg

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_MortarData.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_MortarData.cpp
@@ -22,7 +22,7 @@
 namespace evolution::dg {
 namespace {
 template <size_t Dim>
-void test() {
+void test_global_time_stepping_usage() {
   std::uniform_real_distribution<double> dist(-1.0, 2.3);
   MAKE_GENERATOR(gen);
   constexpr size_t number_of_components = 1 + Dim;
@@ -47,18 +47,18 @@ void test() {
   fill_with_random_values(make_not_null(&local_data), make_not_null(&gen),
                           make_not_null(&dist));
 
-  CHECK_FALSE(static_cast<bool>(mortar_data.local_mortar_data()));
-  CHECK_FALSE(static_cast<bool>(mortar_data.neighbor_mortar_data()));
+  CHECK_FALSE(mortar_data.local_mortar_data().has_value());
+  CHECK_FALSE(mortar_data.neighbor_mortar_data().has_value());
 
   mortar_data.insert_local_mortar_data(time_step_id, local_mesh, local_data);
 
-  CHECK(static_cast<bool>(mortar_data.local_mortar_data()));
-  CHECK_FALSE(static_cast<bool>(mortar_data.neighbor_mortar_data()));
+  CHECK(mortar_data.local_mortar_data().has_value());
+  CHECK_FALSE(mortar_data.neighbor_mortar_data().has_value());
 
   mortar_data.insert_neighbor_mortar_data(time_step_id, neighbor_mesh,
                                           neighbor_data);
-  CHECK(static_cast<bool>(mortar_data.local_mortar_data()));
-  CHECK(static_cast<bool>(mortar_data.neighbor_mortar_data()));
+  CHECK(mortar_data.local_mortar_data().has_value());
+  CHECK(mortar_data.neighbor_mortar_data().has_value());
 
   const auto deserialized_mortar_data = serialize_and_deserialize(mortar_data);
 
@@ -75,6 +75,99 @@ void test() {
   CHECK(extracted_data.second ==
         *deserialized_mortar_data.neighbor_mortar_data());
 }
+
+template <size_t Dim>
+void test_local_time_stepping_usage(const bool use_gauss_points) {
+  CAPTURE(Dim);
+  CAPTURE(use_gauss_points);
+  std::uniform_real_distribution<double> dist(-1.0, 2.3);
+  MAKE_GENERATOR(gen);
+  constexpr size_t number_of_components = 1 + Dim;
+
+  MortarData<Dim> mortar_data{};
+  const TimeStepId time_step_id{true, 3, Time{Slab{0.2, 7.1}, {2, 51}}};
+
+  const Mesh<Dim - 1> mortar_mesh{4, Spectral::Basis::Legendre,
+                                  Spectral::Quadrature::Gauss};
+
+  const Mesh<Dim - 1> local_mesh{4, Spectral::Basis::Legendre,
+                                 Spectral::Quadrature::GaussLobatto};
+  std::vector<double> local_data(mortar_mesh.number_of_grid_points() *
+                                 number_of_components);
+  fill_with_random_values(make_not_null(&local_data), make_not_null(&gen),
+                          make_not_null(&dist));
+
+  CHECK_FALSE(mortar_data.local_mortar_data().has_value());
+  CHECK_FALSE(mortar_data.neighbor_mortar_data().has_value());
+
+  mortar_data.insert_local_mortar_data(time_step_id, local_mesh, local_data);
+
+  CHECK(mortar_data.local_mortar_data().has_value());
+  CHECK_FALSE(mortar_data.neighbor_mortar_data().has_value());
+
+  const auto local_volume_det_inv_jacobian =
+      make_with_random_values<Scalar<DataVector>>(
+          make_not_null(&gen), make_not_null(&dist),
+          mortar_mesh.number_of_grid_points() * 4);
+  const auto local_face_det_jacobian =
+      make_with_random_values<Scalar<DataVector>>(
+          make_not_null(&gen), make_not_null(&dist),
+          mortar_mesh.number_of_grid_points());
+  const auto local_face_normal_magnitude =
+      make_with_random_values<Scalar<DataVector>>(
+          make_not_null(&gen), make_not_null(&dist),
+          mortar_mesh.number_of_grid_points());
+
+  if (use_gauss_points) {
+    mortar_data.insert_local_geometric_quantities(local_volume_det_inv_jacobian,
+                                                  local_face_det_jacobian,
+                                                  local_face_normal_magnitude);
+  } else {
+    mortar_data.insert_local_face_normal_magnitude(local_face_normal_magnitude);
+  }
+
+  const auto check_geometric_quantities = [&local_face_det_jacobian,
+                                           &local_volume_det_inv_jacobian,
+                                           &local_face_normal_magnitude,
+                                           use_gauss_points](
+                                              const auto& mortar_data_local) {
+    if (use_gauss_points) {
+      Scalar<DataVector> retrieved_local_face_det_jacobian{};
+      Scalar<DataVector> retrieved_local_volume_det_inv_jacobian{};
+      mortar_data_local.get_local_face_det_jacobian(
+          &retrieved_local_face_det_jacobian);
+      mortar_data_local.get_local_volume_det_inv_jacobian(
+          &retrieved_local_volume_det_inv_jacobian);
+      CHECK(retrieved_local_face_det_jacobian == local_face_det_jacobian);
+      CHECK(retrieved_local_volume_det_inv_jacobian ==
+            local_volume_det_inv_jacobian);
+    }
+    Scalar<DataVector> retrieved_local_face_normal_magnitude{};
+    mortar_data_local.get_local_face_normal_magnitude(
+        &retrieved_local_face_normal_magnitude);
+    CHECK(retrieved_local_face_normal_magnitude == local_face_normal_magnitude);
+  };
+
+  check_geometric_quantities(mortar_data);
+
+  const auto deserialized_mortar_data = serialize_and_deserialize(mortar_data);
+
+  CHECK(*mortar_data.local_mortar_data() ==
+        *deserialized_mortar_data.local_mortar_data());
+  CHECK_FALSE(deserialized_mortar_data.neighbor_mortar_data().has_value());
+  check_geometric_quantities(deserialized_mortar_data);
+
+  CHECK(mortar_data == deserialized_mortar_data);
+  CHECK_FALSE(mortar_data != deserialized_mortar_data);
+}
+
+template <size_t Dim>
+void test() {
+  test_global_time_stepping_usage<Dim>();
+  test_local_time_stepping_usage<Dim>(true);
+  test_local_time_stepping_usage<Dim>(false);
+}
+
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.DG.MortarData", "[Unit][Evolution]") {

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_MortarTags.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_MortarTags.cpp
@@ -13,6 +13,9 @@ namespace {
 template <size_t Dim>
 void test() {
   TestHelpers::db::test_simple_tag<Tags::MortarData<Dim>>("MortarData");
+  // can use any CouplingResult in MortarDataHistory, just use double for now.
+  TestHelpers::db::test_simple_tag<Tags::MortarDataHistory<Dim, double>>(
+      "MortarDataHistory");
   TestHelpers::db::test_simple_tag<Tags::MortarMesh<Dim>>("MortarMesh");
   TestHelpers::db::test_simple_tag<Tags::MortarSize<Dim>>("MortarSize");
   TestHelpers::db::test_simple_tag<Tags::MortarNextTemporalId<Dim>>(

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/CMakeLists.txt
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/CMakeLists.txt
@@ -33,6 +33,7 @@ target_link_libraries(
   DiscontinuousGalerkin
   Domain
   DomainStructure
+  Interpolation
   Spectral
   Time
   Utilities

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -16,6 +16,7 @@
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
@@ -41,6 +42,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/MetricIdentityJacobian.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
+#include "NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp"
 #include "NumericalAlgorithms/LinearOperators/Divergence.tpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
 #include "NumericalAlgorithms/LinearOperators/WeakDivergence.hpp"
@@ -50,7 +52,10 @@
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeMortars.hpp"
+#include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeStepId.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
@@ -706,7 +711,8 @@ struct component {
       domain::Tags::BoundaryDirectionsInterior<Metavariables::volume_dim>;
 
   using common_simple_tags = tmpl::list<
-      ::Tags::TimeStepId, ::evolution::dg::Tags::Quadrature,
+      ::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>,
+      ::evolution::dg::Tags::Quadrature,
       typename Metavariables::system::variables_tag,
       db::add_tag_prefix<::Tags::dt,
                          typename Metavariables::system::variables_tag>,
@@ -798,15 +804,15 @@ struct component {
 };
 
 template <size_t Dim, SystemType SystemTypeIn,
-          UseBoundaryCorrection UseBoundaryCorrectionIn, bool UseMovingMesh,
-          bool HasPrimitiveVariables>
+          UseBoundaryCorrection UseBoundaryCorrectionIn, bool LocalTimeStepping,
+          bool UseMovingMesh, bool HasPrimitiveVariables>
 struct Metavariables {
   static constexpr size_t volume_dim = Dim;
   static constexpr SystemType system_type = SystemTypeIn;
   static constexpr UseBoundaryCorrection use_boundary_correction =
       UseBoundaryCorrectionIn;
   static constexpr bool use_moving_mesh = UseMovingMesh;
-  static constexpr bool local_time_stepping = false;
+  static constexpr bool local_time_stepping = LocalTimeStepping;
   using system =
       System<Dim, system_type, use_boundary_correction, HasPrimitiveVariables>;
   using boundary_scheme = ::dg::FirstOrderScheme::FirstOrderScheme<
@@ -842,10 +848,12 @@ double dg_package_data(
       mesh_velocity, normal_dot_mesh_velocity, get_tag(VolumeTags{})...);
 }
 
-template <bool UseMovingMesh, size_t Dim, SystemType system_type,
-          UseBoundaryCorrection use_boundary_correction, bool HasPrims>
+template <bool LocalTimeStepping, bool UseMovingMesh, size_t Dim,
+          SystemType system_type, UseBoundaryCorrection use_boundary_correction,
+          bool HasPrims>
 void test_impl(const Spectral::Quadrature quadrature,
                const ::dg::Formulation dg_formulation) noexcept {
+  CAPTURE(LocalTimeStepping);
   CAPTURE(UseMovingMesh);
   CAPTURE(Dim);
   CAPTURE(system_type);
@@ -853,7 +861,7 @@ void test_impl(const Spectral::Quadrature quadrature,
   CAPTURE(quadrature);
   CAPTURE(dg_formulation);
   using metavars = Metavariables<Dim, system_type, use_boundary_correction,
-                                 UseMovingMesh, HasPrims>;
+                                 LocalTimeStepping, UseMovingMesh, HasPrims>;
   using system = typename metavars::system;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
   using variables_tag = typename system::variables_tag;
@@ -861,6 +869,7 @@ void test_impl(const Spectral::Quadrature quadrature,
   using flux_variables_tag = ::Tags::Variables<flux_variables>;
   using fluxes_tag = db::add_tag_prefix<::Tags::Flux, flux_variables_tag,
                                         tmpl::size_t<Dim>, Frame::Inertial>;
+  using dt_variables_tag = db::add_tag_prefix<::Tags::dt, variables_tag>;
   // The reference element in 2d denoted by X below:
   // ^ eta
   // +-+-+> xi
@@ -1068,14 +1077,20 @@ void test_impl(const Spectral::Quadrature quadrature,
       domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
           domain::CoordinateMaps::Identity<Dim>{});
 
-  const TimeStepId time_step_id{true, 3, Time{Slab{0.2, 3.4}, {3, 100}}};
+  const Slab time_slab{0.2, 3.4};
+  const TimeDelta time_step{time_slab, {4, 100}};
+  const TimeStepId time_step_id{true, 3, Time{time_slab, {3, 100}}};
+  const TimeStepId next_time_step_id{time_step_id.time_runs_forward(),
+                                     time_step_id.slab_number(),
+                                     time_step_id.step_time() + time_step};
   if constexpr (not std::is_same_v<tmpl::list<>, flux_variables> and
                 use_boundary_correction == UseBoundaryCorrection::No) {
     ActionTesting::emplace_component_and_initialize<component<metavars>>(
         &runner, self_id,
-        {time_step_id, quadrature, evolved_vars, dt_evolved_vars, var3, mesh,
-         grid_to_inertial_map->get_clone(), normal_dot_fluxes_interface,
-         element, inertial_coords, inv_jac, mesh_velocity, div_mesh_velocity,
+        {time_step_id, next_time_step_id, quadrature, evolved_vars,
+         dt_evolved_vars, var3, mesh, grid_to_inertial_map->get_clone(),
+         normal_dot_fluxes_interface, element, inertial_coords, inv_jac,
+         mesh_velocity, div_mesh_velocity,
          Variables<db::wrap_tags_in<::Tags::Flux, flux_variables,
                                     tmpl::size_t<Dim>, Frame::Inertial>>{
              mesh.number_of_grid_points(), -100.}});
@@ -1084,8 +1099,8 @@ void test_impl(const Spectral::Quadrature quadrature,
       for (const auto& neighbor_id : neighbor_ids) {
         ActionTesting::emplace_component_and_initialize<component<metavars>>(
             &runner, neighbor_id,
-            {time_step_id, quadrature, evolved_vars, dt_evolved_vars, var3,
-             mesh, grid_to_inertial_map->get_clone(),
+            {time_step_id, next_time_step_id, quadrature, evolved_vars,
+             dt_evolved_vars, var3, mesh, grid_to_inertial_map->get_clone(),
              normal_dot_fluxes_interface, element, inertial_coords, inv_jac,
              mesh_velocity, div_mesh_velocity,
              Variables<db::wrap_tags_in<::Tags::Flux, flux_variables,
@@ -1096,16 +1111,17 @@ void test_impl(const Spectral::Quadrature quadrature,
   } else {
     ActionTesting::emplace_component_and_initialize<component<metavars>>(
         &runner, self_id,
-        {time_step_id, quadrature, evolved_vars, dt_evolved_vars, var3, mesh,
-         grid_to_inertial_map->get_clone(), normal_dot_fluxes_interface,
-         element, inertial_coords, inv_jac, mesh_velocity, div_mesh_velocity});
+        {time_step_id, next_time_step_id, quadrature, evolved_vars,
+         dt_evolved_vars, var3, mesh, grid_to_inertial_map->get_clone(),
+         normal_dot_fluxes_interface, element, inertial_coords, inv_jac,
+         mesh_velocity, div_mesh_velocity});
     for (const auto& [direction, neighbor_ids] : neighbors) {
       (void)direction;
       for (const auto& neighbor_id : neighbor_ids) {
         ActionTesting::emplace_component_and_initialize<component<metavars>>(
             &runner, neighbor_id,
-            {time_step_id, quadrature, evolved_vars, dt_evolved_vars, var3,
-             mesh, grid_to_inertial_map->get_clone(),
+            {time_step_id, next_time_step_id, quadrature, evolved_vars,
+             dt_evolved_vars, var3, mesh, grid_to_inertial_map->get_clone(),
              normal_dot_fluxes_interface, element, inertial_coords, inv_jac,
              mesh_velocity, div_mesh_velocity});
       }
@@ -1494,13 +1510,70 @@ void test_impl(const Spectral::Quadrature quadrature,
           }
         };
 
-    CHECK_ITERABLE_APPROX(
-        get_tag(::evolution::dg::Tags::MortarData<Dim>{})
-            .at(mortar_id_east)
-            .local_mortar_data()
-            ->second,
-        compute_expected_mortar_data(mortar_id_east.first,
-                                     mortar_id_east.second, true));
+    const auto check_mortar_data = [&compute_expected_mortar_data,
+                                    &det_inv_jacobian, &get_tag, &mesh,
+                                    &quadrature](const auto& mortar_data,
+                                                 const auto& mortar_id) {
+      CHECK_ITERABLE_APPROX(mortar_data.local_mortar_data()->second,
+                            compute_expected_mortar_data(
+                                mortar_id.first, mortar_id.second, true));
+
+      // Check face normal and/or Jacobians
+      const bool using_gauss_points = quadrature == Spectral::Quadrature::Gauss;
+
+      Scalar<DataVector> local_face_normal_magnitude{};
+      mortar_data.get_local_face_normal_magnitude(
+          make_not_null(&local_face_normal_magnitude));
+      CHECK(
+          local_face_normal_magnitude ==
+          get<::evolution::dg::Tags::MagnitudeOfNormal>(
+              *get_tag(::evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>{})
+                   .at(mortar_id.first)));
+
+      if (using_gauss_points) {
+        Scalar<DataVector> local_volume_det_inv_jacobian{};
+        mortar_data.get_local_volume_det_inv_jacobian(
+            make_not_null(&local_volume_det_inv_jacobian));
+        CHECK(local_volume_det_inv_jacobian == det_inv_jacobian);
+
+        // We use IrregularGridInterpolant to avoid reusing/copying the
+        // apply_matrices-based interpolation in the source tree.
+        const Mesh<Dim - 1> face_mesh =
+            mesh.slice_away(mortar_id.first.dimension());
+        const intrp::Irregular<Dim> interpolator{
+            mesh,
+            interface_logical_coordinates(face_mesh, mortar_id.first)};
+        Variables<tmpl::list<::Tags::TempScalar<0>>> volume_det_jacobian{
+            mesh.number_of_grid_points()};
+        get(get<::Tags::TempScalar<0>>(volume_det_jacobian)) =
+            1.0 / get(det_inv_jacobian);
+        const Scalar<DataVector> expected_local_face_det_jacobian =
+            get<::Tags::TempScalar<0>>(
+                interpolator.interpolate(volume_det_jacobian));
+
+        Scalar<DataVector> local_face_det_jacobian{};
+        mortar_data.get_local_face_det_jacobian(
+            make_not_null(&local_face_det_jacobian));
+        CHECK_ITERABLE_APPROX(local_face_det_jacobian,
+                              expected_local_face_det_jacobian);
+      }
+    };
+    if (LocalTimeStepping) {
+      const auto& east_mortar_data =
+          get_tag(::evolution::dg::Tags::MortarDataHistory<
+                      Dim, typename dt_variables_tag::type>{})
+              .at(mortar_id_east)
+              .local_data(time_step_id);
+      check_mortar_data(east_mortar_data, mortar_id_east);
+    } else {
+      CHECK_ITERABLE_APPROX(
+          get_tag(::evolution::dg::Tags::MortarData<Dim>{})
+              .at(mortar_id_east)
+              .local_mortar_data()
+              ->second,
+          compute_expected_mortar_data(mortar_id_east.first,
+                                       mortar_id_east.second, true));
+    }
     CHECK_ITERABLE_APPROX(
         *std::get<2>(
             ActionTesting::get_inbox_tag<
@@ -1516,15 +1589,50 @@ void test_impl(const Spectral::Quadrature quadrature,
         compute_expected_mortar_data(mortar_id_east.first,
                                      mortar_id_east.second, false));
 
+    CHECK(std::get<3>(
+              ActionTesting::get_inbox_tag<
+                  component<metavars>,
+                  ::evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<
+                      Dim>>(runner, mortar_id_east.second)
+                  .at(time_step_id)
+                  .at(std::pair{
+                      element.neighbors()
+                          .at(mortar_id_east.first)
+                          .orientation()(mortar_id_east.first.opposite()),
+                      element.id()})) ==
+          (LocalTimeStepping ? next_time_step_id : time_step_id));
+
     if constexpr (Dim > 1) {
       const auto mortar_id_south =
           std::make_pair(Direction<Dim>::lower_eta(), south_id);
-      CHECK_ITERABLE_APPROX(get_tag(::evolution::dg::Tags::MortarData<Dim>{})
-                                .at(mortar_id_south)
-                                .local_mortar_data()
-                                ->second,
-                            compute_expected_mortar_data(
-                                Direction<Dim>::lower_eta(), south_id, true));
+      CHECK(std::get<3>(
+                ActionTesting::get_inbox_tag<
+                    component<metavars>,
+                    ::evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<
+                        Dim>>(runner, mortar_id_south.second)
+                    .at(time_step_id)
+                    .at(std::pair{
+                        element.neighbors()
+                            .at(mortar_id_south.first)
+                            .orientation()(mortar_id_south.first.opposite()),
+                        element.id()})) ==
+            (LocalTimeStepping ? next_time_step_id : time_step_id));
+
+      if (LocalTimeStepping) {
+        const auto& south_mortar_data =
+            get_tag(::evolution::dg::Tags::MortarDataHistory<
+                        Dim, typename dt_variables_tag::type>{})
+                .at(mortar_id_south)
+                .local_data(time_step_id);
+        check_mortar_data(south_mortar_data, mortar_id_south);
+      } else {
+        CHECK_ITERABLE_APPROX(get_tag(::evolution::dg::Tags::MortarData<Dim>{})
+                                  .at(mortar_id_south)
+                                  .local_mortar_data()
+                                  ->second,
+                              compute_expected_mortar_data(
+                                  Direction<Dim>::lower_eta(), south_id, true));
+      }
       CHECK_ITERABLE_APPROX(
           *std::get<2>(
               ActionTesting::get_inbox_tag<
@@ -1543,8 +1651,8 @@ void test_impl(const Spectral::Quadrature quadrature,
   }
 }
 
-template <SystemType system_type, UseBoundaryCorrection use_boundary_correction,
-          size_t Dim>
+template <SystemType system_type,
+          UseBoundaryCorrection use_boundary_correction, size_t Dim>
 void test() noexcept {
   // The test impl is structured in the following way:
   // - the static mesh volume contributions are computed "by-hand" and used more
@@ -1614,7 +1722,11 @@ void test() noexcept {
             (void)moving_mesh;
             if constexpr (not(decltype(use_prims)::value and system_type ==
                               SystemType::Nonconservative)) {
-              test_impl<std::decay_t<decltype(moving_mesh)>::value, Dim,
+              test_impl<false, std::decay_t<decltype(moving_mesh)>::value, Dim,
+                        system_type, use_boundary_correction,
+                        std::decay_t<decltype(use_prims)>::value>(
+                  quadrature, local_dg_formulation);
+              test_impl<true, std::decay_t<decltype(moving_mesh)>::value, Dim,
                         system_type, use_boundary_correction,
                         std::decay_t<decltype(use_prims)>::value>(
                   quadrature, local_dg_formulation);

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -790,7 +790,7 @@ struct component {
                                       typename Metavariables::boundary_scheme>,
                                   tmpl::list<>>,
               ::evolution::dg::Initialization::Mortars<
-                  Metavariables::volume_dim>>>>,
+                  Metavariables::volume_dim, typename Metavariables::system>>>>,
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Testing,
           tmpl::list<


### PR DESCRIPTION
## Proposed changes

- Pretty all of the LTS support is in the `ApplyBoundaryCorrections` action.
- When using Gauss points we need to keep a history of the determinant of the Jacobian both on the face and in the volume, in addition to the magnitude of the normal vector on the face.
- the test uses 2nd order in time to test that the Jacobian history is correct.
- The logic for receiving data comes from the `ReceiveDataForFluxes` action, while the lifting part comes from the `FirstOrderLtsScheme.hpp` boundary scheme. 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
