### PR TITLE
Fix round-robin element allocation in elliptic executables

### DIFF
--- a/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
@@ -78,11 +78,11 @@ void DgElementArray<Metavariables, PhaseDepActionList>::allocate_array(
   const auto& initial_refinement_levels =
       get<domain::Tags::InitialRefinementLevels<volume_dim>>(
           initialization_items);
+  int which_proc = 0;
   for (const auto& block : domain.blocks()) {
     const auto initial_ref_levs = initial_refinement_levels[block.id()];
     const std::vector<ElementId<volume_dim>> element_ids =
         initial_element_ids(block.id(), initial_ref_levs);
-    int which_proc = 0;
     const int number_of_procs = sys::number_of_procs();
     for (size_t i = 0; i < element_ids.size(); ++i) {
       dg_element_array(ElementId<volume_dim>(element_ids[i]))


### PR DESCRIPTION
## Proposed changes

Previously the distribution of elements to CPUs was reset for each block, so a domain with only single-element blocks was not parallelized at all. This wasn't really an issue because for production runs I have been using my multigrid branch with its own strategy of distributing elements. But it would be good to fix this on develop until the multigrid solver is merged.

This is pretty much the same as #2019.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
