### PR TITLE
Make the elastic constitutive relation a reference tag

### DIFF
--- a/src/Elliptic/Executables/Elasticity/SolveElasticityProblem.hpp
+++ b/src/Elliptic/Executables/Elasticity/SolveElasticityProblem.hpp
@@ -92,12 +92,6 @@ struct Metavariables {
   using analytic_solution = boundary_conditions;
   using analytic_solution_tag = Tags::AnalyticSolution<analytic_solution>;
 
-  // We retrieve the constitutive relation from the analytic solution
-  using constitutive_relation_type =
-      typename analytic_solution::constitutive_relation_type;
-  using constitutive_relation_provider_option_tag =
-      OptionTags::AnalyticSolution<analytic_solution>;
-
   // The linear solver algorithm. We must use GMRES since the operator is
   // not positive-definite for the first-order system.
   using linear_solver =
@@ -147,10 +141,10 @@ struct Metavariables {
       linear_solver_iteration_id>>;
 
   // Collect all items to store in the cache.
-  using const_global_cache_tags = tmpl::list<
-      analytic_solution_tag, fluxes_computer_tag, normal_dot_numerical_flux,
-      Elasticity::Tags::ConstitutiveRelation<constitutive_relation_type>,
-      Tags::EventsAndTriggers<events, triggers>>;
+  using const_global_cache_tags =
+      tmpl::list<analytic_solution_tag, fluxes_computer_tag,
+                 normal_dot_numerical_flux,
+                 Tags::EventsAndTriggers<events, triggers>>;
 
   // Collect all reduction tags for observers
   using observed_reduction_data_tags =
@@ -171,6 +165,8 @@ struct Metavariables {
       typename linear_solver::initialize_element,
       elliptic::Actions::InitializeSystem<system>,
       Initialization::Actions::AddComputeTags<tmpl::list<
+          Elasticity::Tags::ConstitutiveRelationReference<
+              volume_dim, analytic_solution_tag>,
           Elasticity::Tags::PotentialEnergyDensityCompute<volume_dim>>>,
       elliptic::Actions::InitializeAnalyticSolution<analytic_solution_tag,
                                                     analytic_solution_fields>,

--- a/src/Elliptic/Systems/Elasticity/Equations.hpp
+++ b/src/Elliptic/Systems/Elasticity/Equations.hpp
@@ -102,9 +102,9 @@ void add_curved_auxiliary_sources(
 template <size_t Dim>
 struct Fluxes {
   using argument_tags =
-      tmpl::list<Tags::ConstitutiveRelationBase,
+      tmpl::list<Tags::ConstitutiveRelation<Dim>,
                  domain::Tags::Coordinates<Dim, Frame::Inertial>>;
-  using volume_tags = tmpl::list<Tags::ConstitutiveRelationBase>;
+  using volume_tags = tmpl::list<Tags::ConstitutiveRelation<Dim>>;
   static void apply(
       gsl::not_null<tnsr::IJ<DataVector, Dim>*> flux_for_displacement,
       const ConstitutiveRelations::ConstitutiveRelation<Dim>&

--- a/src/PointwiseFunctions/Elasticity/PotentialEnergy.hpp
+++ b/src/PointwiseFunctions/Elasticity/PotentialEnergy.hpp
@@ -57,7 +57,7 @@ struct PotentialEnergyDensityCompute
   using argument_tags =
       tmpl::list<Elasticity::Tags::Strain<Dim>,
                  domain::Tags::Coordinates<Dim, Frame::Inertial>,
-                 Elasticity::Tags::ConstitutiveRelationBase>;
+                 Elasticity::Tags::ConstitutiveRelation<Dim>>;
   static constexpr auto function = static_cast<void (*)(
       gsl::not_null<Scalar<DataVector>*>, const tnsr::ii<DataVector, Dim>&,
       const tnsr::I<DataVector, Dim>&,

--- a/tests/Unit/Elliptic/Systems/Elasticity/Test_Equations.cpp
+++ b/tests/Unit/Elliptic/Systems/Elasticity/Test_Equations.cpp
@@ -94,12 +94,16 @@ void test_computers(const DataVector& used_for_size) {
       ::Tags::Flux<auxiliary_field_tag, tmpl::size_t<Dim>, Frame::Inertial>;
   using field_source_tag = ::Tags::Source<field_tag>;
   using auxiliary_source_tag = ::Tags::Source<auxiliary_field_tag>;
-  using constitutive_relation_tag = Elasticity::Tags::ConstitutiveRelation<
-      Elasticity::ConstitutiveRelations::IsotropicHomogeneous<Dim>>;
+  using constitutive_relation_tag = Elasticity::Tags::ConstitutiveRelation<Dim>;
   using coordinates_tag = domain::Tags::Coordinates<Dim, Frame::Inertial>;
   const size_t num_points = used_for_size.size();
   {
     INFO("Fluxes" << Dim << "D");
+    std::unique_ptr<
+        Elasticity::ConstitutiveRelations::ConstitutiveRelation<Dim>>
+        constitutive_relation = std::make_unique<
+            Elasticity::ConstitutiveRelations::IsotropicHomogeneous<Dim>>(1.,
+                                                                          2.);
     auto box = db::create<db::AddSimpleTags<
         field_tag, auxiliary_field_tag, field_flux_tag, auxiliary_flux_tag,
         constitutive_relation_tag, coordinates_tag>>(
@@ -109,7 +113,7 @@ void test_computers(const DataVector& used_for_size) {
                                   std::numeric_limits<double>::signaling_NaN()},
         tnsr::Ijj<DataVector, Dim>{
             num_points, std::numeric_limits<double>::signaling_NaN()},
-        Elasticity::ConstitutiveRelations::IsotropicHomogeneous<Dim>{1., 2.},
+        std::move(constitutive_relation),
         tnsr::I<DataVector, Dim>{num_points, 6.});
 
     const Elasticity::Fluxes<Dim> fluxes_computer{};


### PR DESCRIPTION
## Proposed changes

Reference the constitutive relation from the solution / the background in the global cache, instead of copying it.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
