### PR TITLE
Pin a package version for release script

### DIFF
--- a/.github/scripts/requirements-release.txt
+++ b/.github/scripts/requirements-release.txt
@@ -7,4 +7,4 @@ GitPython~=3.1.11
 PyGithub~=1.53
 PyYAML~=5.3.1
 tqdm~=4.55.1
-uplink~=0.9.2
+uplink==0.9.2


### PR DESCRIPTION
## Proposed changes

The [uplink patch 0.9.4](https://github.com/prkumar/uplink/releases/tag/v0.9.4) broke a type conversion in the Zenodo response handling. This PR pins the package to a version that works. I have filed an issue upstream.

This fixes the CI builds on develop that have been failing since yesterday: https://github.com/sxs-collaboration/spectre/runs/1913585581. Note that we don't run these tests on PRs or on forks because they need a Zenodo token.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
