### PR TITLE
Support division of TensorExpressions by doubles

### DIFF
--- a/src/DataStructures/Tensor/Expressions/Product.hpp
+++ b/src/DataStructures/Tensor/Expressions/Product.hpp
@@ -271,3 +271,27 @@ SPECTRE_ALWAYS_INLINE auto operator*(
   return TensorExpressions::NumberAsExpression(number) * t;
 }
 // @}
+
+/// \ingroup TensorExpressionsGroup
+/// \brief Returns the tensor expression representing the quotient of a tensor
+/// expression and a `double`
+///
+/// \note The implementation instead uses the operation, `t * (1.0 / number)`
+///
+/// \tparam T the derived TensorExpression type of the tensor expression operand
+/// of the quotient
+/// \tparam X the type of data stored in the tensor expression operand of the
+/// quotient
+/// \tparam ArgsList the TensorIndexs of the tensor expression operand of the
+/// quotient
+/// \param t the tensor expression operand of the quotient
+/// \param number the `double` operand of the quotient
+/// \return the tensor expression representing the quotient of a tensor
+/// expression and a `double`
+template <typename T, typename X, typename ArgsList>
+SPECTRE_ALWAYS_INLINE auto operator/(
+    const TensorExpression<T, X, typename T::symmetry, typename T::index_list,
+                           ArgsList>& t,
+    const double number) {
+  return t * TensorExpressions::NumberAsExpression(1.0 / number);
+}

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Product.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Product.cpp
@@ -33,7 +33,8 @@ void assign_unique_values_to_tensor(
   }
 }
 
-// \brief Test the outer product of a `double` and tensor is correctly evaluated
+// \brief Test the outer product and quotient of a tensor and `double` is
+// correctly evaluated
 //
 // \details
 // The outer product cases tested are:
@@ -41,13 +42,18 @@ void assign_unique_values_to_tensor(
 // - \f$L_{ij} = S_{ij} * R\f$
 // - \f$L_{ij} = R * S_{ij} * T\f$
 //
+// The division cases tested are:
+// - \f$L_{ij} = S_{ij} / R\f$
+// - \f$L_{ij} = R * S_{ij} / T\f$
+//
 // where \f$R\f$ and \f$T\f$ are `double`s and \f$S\f$ and \f$L\f$ are Tensors
 // with data type `double` or DataVector.
 //
 // \tparam DataType the type of data being stored in the tensor operand of the
 // products
 template <typename DataType>
-void test_outer_product_double(const DataType& used_for_size) noexcept {
+void test_outer_product_quotient_double(
+    const DataType& used_for_size) noexcept {
   constexpr size_t dim = 3;
   using tensor_type =
       Tensor<DataType, Symmetry<1, 1>,
@@ -69,11 +75,21 @@ void test_outer_product_double(const DataType& used_for_size) noexcept {
   const tensor_type Lij_from_R_Sij_T =
       TensorExpressions::evaluate<ti_i, ti_j>(-1.7 * S(ti_i, ti_j) * 0.6);
 
+  // \f$L_{ij} = S_{ij} / R\f$
+  const tensor_type Lij_from_Sij_over_R =
+      TensorExpressions::evaluate<ti_i, ti_j>(S(ti_i, ti_j) / 4.3);
+  // \f$L_{ij} = R * S_{ij} / T\f$
+  const tensor_type Lij_from_R_Sij_over_T =
+      TensorExpressions::evaluate<ti_i, ti_j>(-5.2 * S(ti_i, ti_j) / 1.6);
+
   for (size_t i = 0; i < dim; i++) {
     for (size_t j = 0; j < dim; j++) {
       CHECK(Lij_from_R_Sij.get(i, j) == 5.6 * S.get(i, j));
       CHECK(Lij_from_Sij_R.get(i, j) == S.get(i, j) * -8.1);
       CHECK(Lij_from_R_Sij_T.get(i, j) == -1.7 * S.get(i, j) * 0.6);
+
+      CHECK(Lij_from_Sij_over_R.get(i, j) == S.get(i, j) / 4.3);
+      CHECK(Lij_from_R_Sij_over_T.get(i, j) == -5.2 * S.get(i, j) / 1.6);
     }
   }
 }
@@ -1114,7 +1130,7 @@ void test_three_term_inner_outer_product(
 
 template <typename DataType>
 void test_products(const DataType& used_for_size) noexcept {
-  test_outer_product_double(used_for_size);
+  test_outer_product_quotient_double(used_for_size);
   test_outer_product_rank_0_operand(used_for_size);
   test_outer_product_rank_1_operand(used_for_size);
   test_outer_product_rank_2x2_operands(used_for_size);


### PR DESCRIPTION
## Proposed changes

This PR implements the division of `TensorExpression`s by `double`s and adds a test for it.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
