### PR TITLE
Support square root of rank 0 TensorExpressions

### DIFF
--- a/src/DataStructures/Tensor/Expressions/CMakeLists.txt
+++ b/src/DataStructures/Tensor/Expressions/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_headers(
   LhsTensorSymmAndIndices.hpp
   Product.hpp
   NumberAsExpression.hpp
+  SquareRoot.hpp
   TensorAsExpression.hpp
   TensorExpression.hpp
   )

--- a/src/DataStructures/Tensor/Expressions/SquareRoot.hpp
+++ b/src/DataStructures/Tensor/Expressions/SquareRoot.hpp
@@ -1,0 +1,92 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/Structure.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ForceInline.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace TensorExpressions {
+/// \ingroup TensorExpressionsGroup
+/// \brief Defines the tensor expression representing the square root of a
+/// tensor expression that evaluates to a rank 0 tensor
+///
+/// \tparam T the type of the tensor expression of which to take the square
+/// root
+template <typename T>
+struct SquareRoot
+    : public TensorExpression<SquareRoot<T>, typename T::type, tmpl::list<>,
+                              tmpl::list<>, tmpl::list<>> {
+  static_assert(
+      std::is_base_of<TensorExpression<T, typename T::type, tmpl::list<>,
+                                       tmpl::list<>, tmpl::list<>>,
+                      T>::value,
+      "Can only take the square root of a tensor expression that evaluates to "
+      "a rank 0 tensor.");
+  using type = typename T::type;
+  using symmetry = tmpl::list<>;
+  using index_list = tmpl::list<>;
+  using args_list = tmpl::list<>;
+  using structure = Tensor_detail::Structure<symmetry>;
+  static constexpr auto num_tensor_indices = 0;
+
+  SquareRoot(T t) : t_(std::move(t)) {}
+  ~SquareRoot() override = default;
+
+  /// \brief Returns the square root of the component of the tensor evaluated
+  /// from the RHS tensor expression
+  ///
+  /// \details
+  /// SquareRoot only supports tensor expressions that evaluate to a rank 0
+  /// Tensor. This is why, unlike other derived TensorExpression types, there is
+  /// no second variadic template parameter for the generic indices. In
+  /// addition, this is why this template is only instantiated for the case
+  /// where `Structure` is equal to the Structure of a rank 0 Tensor.
+  ///
+  /// \tparam Structure the Structure of the rank 0 Tensor represented by this
+  /// expression
+  /// \param storage_index the storage index of the component of which to take
+  /// the square root
+  /// \return the square root of the component of the tensor evaluated from the
+  /// RHS tensor expression
+  template <typename Structure>
+  SPECTRE_ALWAYS_INLINE decltype(auto) get(
+      const size_t storage_index) const noexcept {
+    static_assert(std::is_same_v<Structure, structure>,
+                  "In retrieving the square root of a tensor expression, the "
+                  "provided Structure should be that of a rank 0 Tensor.");
+    ASSERT(storage_index == 0,
+           "In retrieving the square root of a tensor expression, the provided "
+           "storage_index should be 0.");
+    return sqrt(t_.template get<Structure>(storage_index));
+  }
+
+ private:
+  T t_;
+};
+}  // namespace TensorExpressions
+
+/// \ingroup TensorExpressionsGroup
+/// \brief Returns the tensor expression representing the square root of a
+/// tensor expression that evaluates to a rank 0 tensor
+///
+/// \details
+/// `t` must be an expression that, when evaluated, would be a rank 0 tensor.
+/// For example, if `R` and `S` are Tensors, here is a non-exhaustive list of
+/// some of the acceptable forms that `t` could take:
+/// - `R()`
+/// - `R(ti_A, ti_a)`
+/// - `(R(ti_A, ti_B) * S(ti_a, ti_b))`
+///
+/// \param t the type of the tensor expression of which to take the square root
+template <typename T>
+SPECTRE_ALWAYS_INLINE auto sqrt(
+    const TensorExpression<T, typename T::type, tmpl::list<>, tmpl::list<>,
+                           tmpl::list<>>& t) {
+  return TensorExpressions::SquareRoot(~t);
+}

--- a/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
+++ b/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_Contract.cpp
   Test_MixedOperations.cpp
   Test_Product.cpp
+  Test_SquareRoot.cpp
   Test_TensorExpressions.cpp
   )
 

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_SquareRoot.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_SquareRoot.cpp
@@ -1,0 +1,92 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <iterator>
+#include <numeric>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Expressions/Evaluate.hpp"
+#include "DataStructures/Tensor/Expressions/Product.hpp"
+#include "DataStructures/Tensor/Expressions/SquareRoot.hpp"
+#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace {
+template <typename... Ts>
+void assign_unique_values_to_tensor(
+    const gsl::not_null<Tensor<double, Ts...>*> tensor) noexcept {
+  std::iota(tensor->begin(), tensor->end(), 0.0);
+}
+
+template <typename... Ts>
+void assign_unique_values_to_tensor(
+    const gsl::not_null<Tensor<DataVector, Ts...>*> tensor) noexcept {
+  double value = 0.0;
+  for (auto index_it = tensor->begin(); index_it != tensor->end(); index_it++) {
+    for (auto vector_it = index_it->begin(); vector_it != index_it->end();
+         vector_it++) {
+      *vector_it = value;
+      value += 1.0;
+    }
+  }
+}
+
+// \brief Test the square root of a rank 0 tensor expression is correctly
+// evaluated
+//
+// \details
+// The cases tested are:
+// - \f$L = \sqrt{R}\f$
+// - \f$L = \sqrt{S_{k}{}^{k}}\f$
+// - \f$L = \sqrt{S_{k}{}^{k} * T}\f$
+//
+// where \f$R\f$ and \f$L\f$ are rank 0 Tensors, \f$S\f$ is a rank 2 Tensor,
+// and \f$T\f$ is a `double`.
+//
+// \tparam DataType the type of data being stored in the tensor operands of the
+// expressions tested
+template <typename DataType>
+void test_sqrt(const DataType& used_for_size) noexcept {
+  Tensor<DataType> R{{{used_for_size}}};
+  if (std::is_same_v<DataType, double>) {
+    // Replace tensor's value from `used_for_size` to a proper test value
+    R.get() = 5.7;
+  } else {
+    assign_unique_values_to_tensor(make_not_null(&R));
+  }
+
+  // \f$L = \sqrt{R}\f$
+  Tensor<DataType> sqrt_R = TensorExpressions::evaluate(sqrt(R()));
+  CHECK(sqrt_R.get() == sqrt(R.get()));
+
+  Tensor<DataType, Symmetry<2, 1>,
+         index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                    SpatialIndex<3, UpLo::Up, Frame::Inertial>>>
+      S(used_for_size);
+  assign_unique_values_to_tensor(make_not_null(&S));
+
+  DataType S_trace = make_with_value<DataType>(used_for_size, 0.0);
+  for (size_t i = 0; i < 3; i++) {
+    S_trace += S.get(i, i);
+  }
+
+  // \f$L = \sqrt{S_{k}{}^{k}}\f$
+  const Tensor<DataType> sqrt_S =
+      TensorExpressions::evaluate(sqrt(S(ti_k, ti_K)));
+  // \f$L = \sqrt{S_{k}{}^{k} * T}\f$
+  const Tensor<DataType> sqrt_S_T =
+      TensorExpressions::evaluate(sqrt(S(ti_k, ti_K) * 3.6));
+  CHECK(sqrt_S.get() == sqrt(S_trace));
+  CHECK(sqrt_S_T.get() == sqrt(S_trace * 3.6));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.SquareRoot",
+                  "[DataStructures][Unit]") {
+  test_sqrt(std::numeric_limits<double>::signaling_NaN());
+  test_sqrt(DataVector(5, std::numeric_limits<double>::signaling_NaN()));
+}


### PR DESCRIPTION
## Proposed changes

This PR implements and tests taking the square root of `TensorExpression`s that evaluate to rank 0 tensors.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
