### PR TITLE
Fix CCE initialization for time stepper updates

### DIFF
--- a/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
@@ -93,11 +93,14 @@ struct InitializeCharacteristicEvolutionTime {
     TimeStepId second_time_id =
         time_stepper.next_time_id(initial_time_id, fixed_time_step);
 
-    typename ::Tags::HistoryEvolvedVariables<
-        EvolvedCoordinatesVariablesTag>::type coordinate_history;
+    const size_t starting_order =
+        time_stepper.number_of_past_steps() == 0 ? time_stepper.order() : 1;
+
+    typename ::Tags::HistoryEvolvedVariables<EvolvedCoordinatesVariablesTag>::
+        type coordinate_history(starting_order);
 
     typename ::Tags::HistoryEvolvedVariables<evolved_swsh_variables_tag>::type
-        swsh_history;
+        swsh_history(starting_order);
     Initialization::mutate_assign<simple_tags>(
         make_not_null(&box),
         std::move(initial_time_id),  // NOLINT


### PR DESCRIPTION
## Proposed changes

The CCE component was missed in the history management update (it doesn't currently run any input file tests, a problem that is fixed by #2609 ) 

This is required to make CCE usable on develop.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

