### PR TITLE
Add lock-retrieval 'local sync action', use to lock h5 access in CCE

### DIFF
--- a/docs/Tutorials/CCE.md
+++ b/docs/Tutorials/CCE.md
@@ -7,9 +7,6 @@ See LICENSE.txt for details.
 The basic instructions for getting up and running with a stand-alone
 CCE using external data are:
 - Clone spectre and build the CharacteristicExtract target
-- *Note*: CCE currently requires the linked HDF5 library to be built
-  thread-safe. As this is a significant restriction on many systems,
-  we hope to eliminate this requirement in the future.
 - At this point (provided the build succeeds) you should have the
   executable `bin/CharacteristicExtract` in the build directory; You can now
   run it using an input file to provide options. The input file

--- a/src/Evolution/Systems/Cce/WorldtubeDataManager.cpp
+++ b/src/Evolution/Systems/Cce/WorldtubeDataManager.cpp
@@ -71,15 +71,18 @@ bool MetricWorldtubeDataManager::populate_hypersurface_boundary_data(
     const gsl::not_null<Variables<
         Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>>*>
         boundary_data_variables,
-    const double time) const noexcept {
+    const double time,
+    const gsl::not_null<Parallel::NodeLock*> hdf5_lock) const noexcept {
   if (buffer_updater_->time_is_outside_range(time)) {
     return false;
   }
+  hdf5_lock->lock();
   buffer_updater_->update_buffers_for_time(
       make_not_null(&coefficients_buffers_), make_not_null(&time_span_start_),
       make_not_null(&time_span_end_), time, l_max_,
       interpolator_->required_number_of_points_before_and_after(),
       buffer_depth_);
+  hdf5_lock->unlock();
   const auto interpolation_time_span = detail::create_span_for_time_value(
       time, 0, interpolator_->required_number_of_points_before_and_after(),
       time_span_start_, time_span_end_, buffer_updater_->get_time_buffer());
@@ -305,15 +308,18 @@ bool BondiWorldtubeDataManager::populate_hypersurface_boundary_data(
     const gsl::not_null<Variables<
         Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>>*>
         boundary_data_variables,
-    const double time) const noexcept {
+    const double time,
+    const gsl::not_null<Parallel::NodeLock*> hdf5_lock) const noexcept {
   if (buffer_updater_->time_is_outside_range(time)) {
     return false;
   }
+  hdf5_lock->lock();
   buffer_updater_->update_buffers_for_time(
       make_not_null(&coefficients_buffers_), make_not_null(&time_span_start_),
       make_not_null(&time_span_end_), time, l_max_,
       interpolator_->required_number_of_points_before_and_after(),
       buffer_depth_);
+  hdf5_lock->unlock();
   auto interpolation_time_span = detail::create_span_for_time_value(
       time, 0, interpolator_->required_number_of_points_before_and_after(),
       time_span_start_, time_span_end_, buffer_updater_->get_time_buffer());

--- a/src/Evolution/Systems/Cce/WorldtubeDataManager.hpp
+++ b/src/Evolution/Systems/Cce/WorldtubeDataManager.hpp
@@ -14,6 +14,7 @@
 #include "Evolution/Systems/Cce/WorldtubeBufferUpdater.hpp"
 #include "NumericalAlgorithms/Interpolation/SpanInterpolator.hpp"
 #include "Parallel/CharmPupable.hpp"
+#include "Parallel/NodeLock.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -58,7 +59,8 @@ class WorldtubeDataManager : public PUP::able {
       gsl::not_null<Variables<
           Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>>*>
           boundary_data_variables,
-      double time) const noexcept = 0;
+      double time,
+      gsl::not_null<Parallel::NodeLock*> hdf5_lock) const noexcept = 0;
 
   virtual std::unique_ptr<WorldtubeDataManager> get_clone() const noexcept = 0;
 
@@ -117,7 +119,8 @@ class MetricWorldtubeDataManager : public WorldtubeDataManager {
       gsl::not_null<Variables<
           Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>>*>
           boundary_data_variables,
-      double time) const noexcept override;
+      double time,
+      gsl::not_null<Parallel::NodeLock*> hdf5_lock) const noexcept override;
 
   std::unique_ptr<WorldtubeDataManager> get_clone() const noexcept override;
 
@@ -204,7 +207,8 @@ class BondiWorldtubeDataManager : public WorldtubeDataManager {
       gsl::not_null<Variables<
           Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>>*>
           boundary_data_variables,
-      double time) const noexcept override;
+      double time,
+      gsl::not_null<Parallel::NodeLock*> hdf5_lock) const noexcept override;
 
   std::unique_ptr<WorldtubeDataManager> get_clone() const noexcept override;
 

--- a/src/IO/Observer/Actions/CMakeLists.txt
+++ b/src/IO/Observer/Actions/CMakeLists.txt
@@ -5,6 +5,7 @@ spectre_target_headers(
   IO
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  GetLockPointer.hpp
   ObserverRegistration.hpp
   RegisterEvents.hpp
   RegisterSingleton.hpp

--- a/src/IO/Observer/Actions/GetLockPointer.hpp
+++ b/src/IO/Observer/Actions/GetLockPointer.hpp
@@ -1,0 +1,51 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Parallel/NodeLock.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace observers::Actions {
+
+/// Local synchronous action for retrieving a pointer to the `NodeLock` with tag
+/// `LockTag` on the component.
+///
+/// \warning The retrieved pointer to a lock must only be treated as 'good'
+/// during the execution of the action from which this synchronous action is
+/// called. This is because we can only trust that charm will not migrate the
+/// component on which the action is running until after the action has
+/// completed, and it will not migrate the Nodegroup to which the lock points
+/// until a checkpoint.
+template <typename LockTag>
+struct GetLockPointer {
+  using return_type = Parallel::NodeLock*;
+
+  template <typename ParallelComponent, typename DbTagList>
+  static return_type apply(
+      db::DataBox<DbTagList>& box,
+      const gsl::not_null<Parallel::NodeLock*> node_lock) noexcept {
+    if constexpr (tmpl::list_contains_v<DbTagList, LockTag>) {
+      Parallel::NodeLock* result_lock;
+      node_lock->lock();
+      db::mutate<LockTag>(
+          make_not_null(&box),
+          [&result_lock](
+              const gsl::not_null<Parallel::NodeLock*> lock) noexcept {
+            result_lock = lock;
+          });
+      node_lock->unlock();
+      return result_lock;
+    } else {
+      // silence 'unused variable' warnings
+      (void)node_lock;
+      ERROR("Could not find required tag " << pretty_type::get_name<LockTag>()
+                                           << " in the databox");
+    }
+  }
+};
+}  // namespace observers::Actions

--- a/tests/Unit/Evolution/Systems/Cce/Test_WorldtubeData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_WorldtubeData.cpp
@@ -25,6 +25,7 @@
 #include "NumericalAlgorithms/Interpolation/CubicSpanInterpolator.hpp"
 #include "NumericalAlgorithms/Interpolation/LinearSpanInterpolator.hpp"
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "Parallel/NodeLock.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Utilities/FileSystem.hpp"
 #include "Utilities/Gsl.hpp"
@@ -430,8 +431,10 @@ void test_data_manager_with_dummy_buffer_updater(
   Variables<Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>>
       interpolated_boundary_variables{number_of_angular_points};
 
+  Parallel::NodeLock hdf5_lock{};
   boundary_data_manager.populate_hypersurface_boundary_data(
-      make_not_null(&interpolated_boundary_variables), target_time);
+      make_not_null(&interpolated_boundary_variables), target_time,
+      make_not_null(&hdf5_lock));
 
   // populate the expected variables with the result from the analytic modes
   // passed to the boundary data computation.

--- a/tests/Unit/IO/CMakeLists.txt
+++ b/tests/Unit/IO/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY "Test_IO")
 
 set(LIBRARY_SOURCES
   Observers/Test_ArrayComponentId.cpp
+  Observers/Test_GetLockPointer.cpp
   Observers/Test_Initialize.cpp
   Observers/Test_RegisterElements.cpp
   Observers/Test_RegisterEvents.cpp

--- a/tests/Unit/IO/Observers/Test_GetLockPointer.cpp
+++ b/tests/Unit/IO/Observers/Test_GetLockPointer.cpp
@@ -1,0 +1,120 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <type_traits>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "IO/Observer/Actions/GetLockPointer.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/Tags.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/NodeLock.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+Parallel::NodeLock* h5_lock_to_check;
+Parallel::NodeLock* volume_lock_to_check;
+
+template <typename LockTag>
+struct mock_lock_retrieval_action {
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables, typename ArrayIndex>
+  static void apply(const db::DataBox<DbTagList>& /*box*/,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/) noexcept {
+    auto lock = Parallel::get_parallel_component<
+                    observers::ObserverWriter<Metavariables>>(cache)
+                    .ckLocalBranch()
+                    ->template local_synchronous_action<
+                        observers::Actions::GetLockPointer<LockTag>>();
+    if constexpr(std::is_same_v<LockTag, observers::Tags::H5FileLock>) {
+      h5_lock_to_check = lock;
+    } else {
+      volume_lock_to_check = lock;
+    }
+  }
+};
+
+template <typename Metavariables>
+struct mock_observer_writer {
+  using chare_type = ActionTesting::MockNodeGroupChare;
+  using component_being_mocked = observers::ObserverWriter<Metavariables>;
+  using replace_these_simple_actions = tmpl::list<>;
+  using with_these_simple_actions = tmpl::list<>;
+
+  using simple_tags =
+      tmpl::list<observers::Tags::H5FileLock, observers::Tags::VolumeDataLock>;
+
+  using const_global_cache_tags = tmpl::list<>;
+
+  using metavariables = Metavariables;
+  using array_index = size_t;
+
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+    tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
+};
+
+template <typename Metavariables>
+struct mock_array {
+  using chare_type = ActionTesting::MockArrayChare;
+  using replace_these_simple_actions = tmpl::list<>;
+  using with_these_simple_actions = tmpl::list<>;
+
+  using const_global_cache_tags = tmpl::list<>;
+
+  using metavariables = Metavariables;
+  using array_index = size_t;
+
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Initialization,
+                                        tmpl::list<>>>;
+};
+
+struct test_metavariables {
+  using component_list = tmpl::list<mock_observer_writer<test_metavariables>,
+                                    mock_array<test_metavariables>>;
+  enum class Phase { Initialization, Evolve, Exit };
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.IO.Observer.GetNodeLockPointer", "[Unit][Cce]") {
+  using array_component = mock_array<test_metavariables>;
+  using writer_component = mock_observer_writer<test_metavariables>;
+
+  ActionTesting::MockRuntimeSystem<test_metavariables> runner{{}};
+
+  ActionTesting::set_phase(make_not_null(&runner),
+                           test_metavariables::Phase::Initialization);
+  ActionTesting::emplace_array_component_and_initialize<writer_component>(
+      &runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0}, 0,
+      {Parallel::NodeLock{}, Parallel::NodeLock{}});
+  ActionTesting::emplace_array_component<array_component>(
+      &runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0}, 0);
+
+  ActionTesting::simple_action<
+      array_component, mock_lock_retrieval_action<observers::Tags::H5FileLock>>(
+      make_not_null(&runner), 0);
+  ActionTesting::simple_action<
+      array_component,
+      mock_lock_retrieval_action<observers::Tags::VolumeDataLock>>(
+      make_not_null(&runner), 0);
+
+  db::mutate<observers::Tags::H5FileLock, observers::Tags::VolumeDataLock>(
+      make_not_null(
+          &ActionTesting::get_databox<
+              writer_component, tmpl::list<observers::Tags::H5FileLock,
+                                           observers::Tags::VolumeDataLock>>(
+              make_not_null(&runner), 0)),
+      [](const gsl::not_null<Parallel::NodeLock*> h5_lock,
+         const gsl::not_null<Parallel::NodeLock*> volume_lock) noexcept {
+        CHECK(h5_lock.get() == h5_lock_to_check);
+        CHECK(volume_lock.get() == volume_lock_to_check);
+      });
+}


### PR DESCRIPTION
## Proposed changes

This PR adds a 'local sync action' that calls a function to extract a `Parallel::NodeLock` from a component -- this is mostly to be used with the `ObserverWriter`s, as they hold most of the interesting node locks so far.
Then, I use that method to borrow the file lock from the observer writer during a CCE evolution so that we can guarantee that the h5 read and write never happen simultaneously on a given node.
This relieves the requirement of CCE needing thread-safe hdf5, and therefore ensures that any CCE user does not need to alter their environment from the globally accepted spectre env or to use work-arounds like forcing the entire file to be read at CCE startup.

The commit `Move first surface data to Evolve phase` is shared with #2323 . I'll drop that commit from whichever PR is merged later.

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->
No need for thread-safe hdf5 for CCE runs anymore.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Dependencies
- [x] #2902 
- [x] #2903