### PR TITLE
Relax HwenoImpl test tolerance

### DIFF
--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_HwenoImpl.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_HwenoImpl.cpp
@@ -251,7 +251,11 @@ void test_constrained_fit_1d(const Spectral::Quadrature quadrature =
       return DataVector{c[0] + c[1] * x + c[2] * square(x)};
     }();
 
-    Approx local_approx = Approx::custom().epsilon(1e-11).scale(1.);
+    // Fit procedure has somewhat larger error scale than default
+    // Error further increases when using Gauss points
+    const double gauss_tol =
+        (quadrature == Spectral::Quadrature::Gauss ? 10. : 1.);
+    Approx local_approx = Approx::custom().epsilon(gauss_tol * 1e-11).scale(1.);
     CHECK_ITERABLE_CUSTOM_APPROX(constrained_fit, expected, local_approx);
     CHECK(mean_value(constrained_fit, mesh) ==
           local_approx(mean_value(local_data, mesh)));
@@ -299,6 +303,7 @@ void test_constrained_fit_1d(const Spectral::Quadrature quadrature =
       return DataVector{c[0] + c[1] * x + c[2] * square(x)};
     }();
 
+    // Fit procedure has somewhat larger error scale than default
     Approx local_approx = Approx::custom().epsilon(1e-11).scale(1.);
     CHECK_ITERABLE_CUSTOM_APPROX(constrained_fit, expected, local_approx);
     CHECK(mean_value(constrained_fit, mesh) ==
@@ -510,7 +515,10 @@ void test_constrained_fit_2d_vector(
     }();
 
     // Fit procedure has somewhat larger error scale than default
-    Approx local_approx = Approx::custom().epsilon(1e-10).scale(1.);
+    // Error further increases when using Gauss points
+    const double gauss_tol =
+        (quadrature == Spectral::Quadrature::Gauss ? 10. : 1.);
+    Approx local_approx = Approx::custom().epsilon(gauss_tol * 1e-10).scale(1.);
     CHECK_ITERABLE_CUSTOM_APPROX(constrained_fit, expected, local_approx);
     // Verify that the constraint is in fact satisfied
     CHECK(mean_value(get<0>(constrained_fit), mesh) ==
@@ -583,7 +591,10 @@ void test_constrained_fit_2d_vector(
     }();
 
     // Fit procedure has somewhat larger error scale than default
-    Approx local_approx = Approx::custom().epsilon(1e-9).scale(1.);
+    // Error further increases when using Gauss points
+    const double gauss_tol =
+        (quadrature == Spectral::Quadrature::Gauss ? 100. : 1.);
+    Approx local_approx = Approx::custom().epsilon(gauss_tol * 1e-10).scale(1.);
     CHECK_ITERABLE_CUSTOM_APPROX(constrained_fit, expected, local_approx);
     // Verify that the constraint is in fact satisfied
     CHECK(mean_value(get<0>(constrained_fit), mesh) ==


### PR DESCRIPTION
## Proposed changes

When testing the Hweno limiter with Gauss points, I needed to loosen the tolerance in one of the 2D tests. In another test I saw the error increase but remain within tolerance... but issue #2905 suggests the tolerance can be exceeded on some machines. So here I'm bumping the tolerance for that test as well.

Should resolve issue #2905

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
