### PR TITLE
Add MinRicciScalarTag to Tags.hpp

### DIFF
--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -384,6 +384,24 @@ struct MaxRicciScalarCompute : MaxRicciScalar, db::ComputeTag {
   using argument_tags = tmpl::list<RicciScalar>;
 };
 
+/// The pointwise minimum of the Strahlkorper’s intrinsic Ricci scalar
+/// curvature.
+struct MinRicciScalar : db::SimpleTag {
+  using type = double;
+};
+
+/// Computes the pointwise minimum of the Strahlkorper’s intrinsic Ricci
+/// scalar curvature.
+struct MinRicciScalarCompute : MinRicciScalar, db::ComputeTag {
+  using base = MinRicciScalar;
+  using return_type = double;
+  static void function(const gsl::not_null<double*> min_ricci_scalar,
+                       const Scalar<DataVector>& ricci_scalar) noexcept {
+    *min_ricci_scalar = min(get(ricci_scalar));
+  }
+  using argument_tags = tmpl::list<RicciScalar>;
+};
+
 // @{
 /// `Tangents(i,j)` is \f$\partial x_{\rm surf}^i/\partial q^j\f$,
 /// where \f$x_{\rm surf}^i\f$ are the Cartesian coordinates of the

--- a/src/ApparentHorizons/TagsDeclarations.hpp
+++ b/src/ApparentHorizons/TagsDeclarations.hpp
@@ -51,6 +51,8 @@ template <typename Frame>
 struct RicciScalarCompute;
 struct MaxRicciScalar;
 struct MaxRicciScalarCompute;
+struct MinRicciScalar;
+struct MinRicciScalarCompute;
 
 }  // namespace StrahlkorperTags
 

--- a/tests/Unit/ApparentHorizons/Test_Tags.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Tags.cpp
@@ -290,6 +290,15 @@ void test_max_ricci_scalar() {
   CHECK(expected_max == max);
 }
 
+void test_min_ricci_scalar() {
+  // Test min_ricci_scalar
+  Scalar<DataVector> d{{{{1., 2., 3.}}}};
+  const double expected_min{1.};
+  double min{std::numeric_limits<double>::signaling_NaN()};
+  StrahlkorperTags::MinRicciScalarCompute::function(make_not_null(&min), d);
+  CHECK(expected_min == min);
+}
+
 struct SomeType {};
 struct SomeTag : db::SimpleTag {
   using type = SomeType;
@@ -303,6 +312,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
   test_radius_and_derivs();
   test_normals();
   test_max_ricci_scalar();
+  test_min_ricci_scalar();
   TestHelpers::db::test_simple_tag<ah::Tags::FastFlow>("FastFlow");
   TestHelpers::db::test_simple_tag<StrahlkorperGr::Tags::Area>("Area");
   TestHelpers::db::test_simple_tag<StrahlkorperGr::Tags::IrreducibleMass>(
@@ -313,6 +323,8 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
       "RicciScalar");
   TestHelpers::db::test_simple_tag<StrahlkorperTags::MaxRicciScalar>(
       "MaxRicciScalar");
+  TestHelpers::db::test_simple_tag<StrahlkorperTags::MinRicciScalar>(
+      "MinRicciScalar");
   TestHelpers::db::test_simple_tag<StrahlkorperGr::Tags::SpinFunction>(
       "SpinFunction");
   TestHelpers::db::test_simple_tag<
@@ -436,6 +448,8 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
       "RicciScalar");
   TestHelpers::db::test_compute_tag<StrahlkorperTags::MaxRicciScalarCompute>(
       "MaxRicciScalar");
+  TestHelpers::db::test_compute_tag<StrahlkorperTags::MinRicciScalarCompute>(
+      "MinRicciScalar");
   TestHelpers::db::test_compute_tag<
       StrahlkorperGr::Tags::SpinFunctionCompute<Frame::Inertial>>(
       "SpinFunction");


### PR DESCRIPTION
## Proposed changes

The MinRicciScalarTag and MinRicciScalarTagCompute calculate the pointwise minimum of the Strahlkorper's intrinsic Ricci scalar curvature. 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
