### PR TITLE
Add helper metafunction to get sources computer from elliptic systems, add background fields to elliptic systems

### DIFF
--- a/src/Elliptic/Systems/CMakeLists.txt
+++ b/src/Elliptic/Systems/CMakeLists.txt
@@ -1,6 +1,17 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+set(LIBRARY EllipticSystems)
+
+add_spectre_library(${LIBRARY} INTERFACE)
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  GetSourcesComputer.hpp
+  )
+
 add_subdirectory(Elasticity)
 add_subdirectory(Poisson)
 add_subdirectory(Xcts)

--- a/src/Elliptic/Systems/Elasticity/FirstOrderSystem.hpp
+++ b/src/Elliptic/Systems/Elasticity/FirstOrderSystem.hpp
@@ -72,6 +72,10 @@ struct FirstOrderSystem {
   using auxiliary_fluxes =
       tmpl::list<::Tags::Flux<strain, tmpl::size_t<Dim>, Frame::Inertial>>;
 
+  // The variable-independent background fields in the equations
+  using background_fields = tmpl::list<>;
+  using inv_metric_tag = void;
+
   // The system equations formulated as fluxes and sources
   using fluxes_computer = Fluxes<Dim>;
   using sources_computer = Sources<Dim>;

--- a/src/Elliptic/Systems/GetSourcesComputer.hpp
+++ b/src/Elliptic/Systems/GetSourcesComputer.hpp
@@ -1,0 +1,29 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <type_traits>
+
+namespace elliptic {
+namespace detail {
+template <typename System, typename = std::void_t<>>
+struct sources_computer_linearized {
+  using type = typename System::sources_computer;
+};
+template <typename System>
+struct sources_computer_linearized<
+    System, std::void_t<typename System::sources_computer_linearized>> {
+  using type = typename System::sources_computer_linearized;
+};
+}  // namespace detail
+
+/// The `System::sources_computer` or the `System::sources_computer_linearized`,
+/// depending on the `Linearized` parameter. If the system has no
+/// `sources_computer_linearized` alias it is assumed to be linear, so the
+/// `System::sources_computer` is returned either way.
+template <typename System, bool Linearized>
+using get_sources_computer = tmpl::conditional_t<
+    Linearized, typename detail::sources_computer_linearized<System>::type,
+    typename System::sources_computer>;
+}  // namespace elliptic

--- a/src/Elliptic/Systems/Poisson/FirstOrderSystem.hpp
+++ b/src/Elliptic/Systems/Poisson/FirstOrderSystem.hpp
@@ -98,6 +98,17 @@ struct FirstOrderSystem {
   using auxiliary_fluxes = tmpl::list<
       ::Tags::Flux<field_gradient, tmpl::size_t<Dim>, Frame::Inertial>>;
 
+  // The variable-independent background fields in the equations
+  using background_fields = tmpl::conditional_t<
+      BackgroundGeometry == Geometry::FlatCartesian, tmpl::list<>,
+      tmpl::list<
+          gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>,
+          gr::Tags::SpatialChristoffelSecondKindContracted<Dim, Frame::Inertial,
+                                                           DataVector>>>;
+  using inv_metric_tag = tmpl::conditional_t<
+      BackgroundGeometry == Geometry::FlatCartesian, void,
+      gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>>;
+
   // The system equations formulated as fluxes and sources
   using fluxes_computer = Fluxes<Dim, BackgroundGeometry>;
   using sources_computer = Sources<Dim, BackgroundGeometry>;
@@ -111,9 +122,6 @@ struct FirstOrderSystem {
 
   // The tag of the operator to compute magnitudes on the manifold, e.g. to
   // normalize vectors on the faces of an element
-  using inv_metric_tag = tmpl::conditional_t<
-      BackgroundGeometry == Geometry::FlatCartesian, void,
-      gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>>;
   template <typename Tag>
   using magnitude_tag =
       tmpl::conditional_t<BackgroundGeometry == Geometry::FlatCartesian,

--- a/tests/Unit/Elliptic/Systems/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/CMakeLists.txt
@@ -1,6 +1,25 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+set(LIBRARY "Test_EllipticSystems")
+
+set(LIBRARY_SOURCES
+  Test_GetSourcesComputer.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "Elliptic/Systems/"
+  "${LIBRARY_SOURCES}"
+  ""
+  )
+
+target_link_libraries(
+  Test_EllipticSystems
+  PRIVATE
+  EllipticSystems
+  )
+
 add_subdirectory(Elasticity)
 add_subdirectory(Poisson)
 add_subdirectory(Xcts)

--- a/tests/Unit/Elliptic/Systems/Test_GetSourcesComputer.cpp
+++ b/tests/Unit/Elliptic/Systems/Test_GetSourcesComputer.cpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <type_traits>
+
+#include "Elliptic/Systems/GetSourcesComputer.hpp"
+
+namespace elliptic {
+namespace {
+struct LinearSources {};
+struct NonlinearSources {};
+
+struct LinearSystem {
+  using sources_computer = LinearSources;
+};
+
+struct NonlinearSystem {
+  using sources_computer = NonlinearSources;
+  using sources_computer_linearized = LinearSources;
+};
+
+static_assert(
+    std::is_same_v<get_sources_computer<LinearSystem, false>, LinearSources>);
+static_assert(
+    std::is_same_v<get_sources_computer<LinearSystem, true>, LinearSources>);
+static_assert(std::is_same_v<get_sources_computer<NonlinearSystem, false>,
+                             NonlinearSources>);
+static_assert(
+    std::is_same_v<get_sources_computer<NonlinearSystem, true>, LinearSources>);
+}  // namespace
+}  // namespace elliptic


### PR DESCRIPTION
## Proposed changes

- Adds a metafunction that gets the nonlinear or linear/linearized sources computer from an elliptic system.
- The first commit adds background fields to the elliptic systems. I figured it's better to merge this tiny commit here to make #2912 a bit smaller.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
