### PR TITLE
Add DirichletAnalytic and SphericalRadiation boundary conditions to scalar wave

### DIFF
--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/BoundaryCondition.cpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/BoundaryCondition.cpp
@@ -1,0 +1,31 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarWave/BoundaryConditions/BoundaryCondition.hpp"
+
+#include <pup.h>
+
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+/// \cond
+namespace ScalarWave::BoundaryConditions {
+template <size_t Dim>
+BoundaryCondition<Dim>::BoundaryCondition(CkMigrateMessage* const msg) noexcept
+    : domain::BoundaryConditions::BoundaryCondition(msg) {}
+
+template <size_t Dim>
+void BoundaryCondition<Dim>::pup(PUP::er& p) {
+  domain::BoundaryConditions::BoundaryCondition::pup(p);
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data) template class BoundaryCondition<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM
+}  // namespace ScalarWave::BoundaryConditions
+/// \endcond

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/BoundaryCondition.hpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/BoundaryCondition.hpp
@@ -12,6 +12,8 @@
 namespace ScalarWave::BoundaryConditions {
 template <size_t Dim>
 class DirichletAnalytic;
+template <size_t Dim>
+class SphericalRadiation;
 }  // namespace ScalarWave::BoundaryConditions
 /// \endcond
 
@@ -21,7 +23,8 @@ namespace ScalarWave::BoundaryConditions {
 template <size_t Dim>
 class BoundaryCondition : public domain::BoundaryConditions::BoundaryCondition {
  public:
-  using creatable_classes = tmpl::list<DirichletAnalytic<Dim>>;
+  using creatable_classes =
+      tmpl::list<DirichletAnalytic<Dim>, SphericalRadiation<Dim>>;
 
   BoundaryCondition() = default;
   BoundaryCondition(BoundaryCondition&&) noexcept = default;

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/BoundaryCondition.hpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/BoundaryCondition.hpp
@@ -1,0 +1,36 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pup.h>
+
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace ScalarWave::BoundaryConditions {
+template <size_t Dim>
+class DirichletAnalytic;
+}  // namespace ScalarWave::BoundaryConditions
+/// \endcond
+
+/// \brief Boundary conditions for the scalar wave system
+namespace ScalarWave::BoundaryConditions {
+/// \brief The base class off of which all boundary conditions must inherit
+template <size_t Dim>
+class BoundaryCondition : public domain::BoundaryConditions::BoundaryCondition {
+ public:
+  using creatable_classes = tmpl::list<DirichletAnalytic<Dim>>;
+
+  BoundaryCondition() = default;
+  BoundaryCondition(BoundaryCondition&&) noexcept = default;
+  BoundaryCondition& operator=(BoundaryCondition&&) noexcept = default;
+  BoundaryCondition(const BoundaryCondition&) = default;
+  BoundaryCondition& operator=(const BoundaryCondition&) = default;
+  ~BoundaryCondition() override = default;
+  explicit BoundaryCondition(CkMigrateMessage* msg) noexcept;
+
+  void pup(PUP::er& p) override;
+};
+}  // namespace ScalarWave::BoundaryConditions

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/CMakeLists.txt
@@ -7,6 +7,7 @@ spectre_target_sources(
   BoundaryCondition.cpp
   DirichletAnalytic.cpp
   RegisterDerivedWithCharm.cpp
+  SphericalRadiation.cpp
   )
 
 spectre_target_headers(
@@ -17,4 +18,5 @@ spectre_target_headers(
   DirichletAnalytic.hpp
   Factory.hpp
   RegisterDerivedWithCharm.hpp
+  SphericalRadiation.hpp
   )

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_sources(
+  ScalarWave
+  PRIVATE
+  BoundaryCondition.cpp
+  DirichletAnalytic.cpp
+  RegisterDerivedWithCharm.cpp
+  )
+
+spectre_target_headers(
+  ScalarWave
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  BoundaryCondition.hpp
+  DirichletAnalytic.hpp
+  Factory.hpp
+  RegisterDerivedWithCharm.hpp
+  )

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/DirichletAnalytic.cpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/DirichletAnalytic.cpp
@@ -1,0 +1,42 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarWave/BoundaryConditions/DirichletAnalytic.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+
+#include "Utilities/GenerateInstantiations.hpp"
+
+/// \cond
+namespace ScalarWave::BoundaryConditions {
+template <size_t Dim>
+DirichletAnalytic<Dim>::DirichletAnalytic(CkMigrateMessage* const msg) noexcept
+    : BoundaryCondition<Dim>(msg) {}
+
+template <size_t Dim>
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+DirichletAnalytic<Dim>::get_clone() const noexcept {
+  return std::make_unique<DirichletAnalytic>(*this);
+}
+
+template <size_t Dim>
+void DirichletAnalytic<Dim>::pup(PUP::er& p) {
+  BoundaryCondition<Dim>::pup(p);
+}
+
+template <size_t Dim>
+// NOLINTNEXTLINE
+PUP::able::PUP_ID DirichletAnalytic<Dim>::my_PUP_ID = 0;
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data) template class DirichletAnalytic<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM
+}  // namespace ScalarWave::BoundaryConditions
+/// \endcond

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/DirichletAnalytic.hpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/DirichletAnalytic.hpp
@@ -1,0 +1,110 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <pup.h>
+#include <string>
+#include <type_traits>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/Systems/ScalarWave/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/AnalyticData/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace domain::Tags {
+template <size_t Dim, typename Frame>
+struct Coordinates;
+}  // namespace domain::Tags
+/// \endcond
+
+namespace ScalarWave::BoundaryConditions {
+/*!
+ * \brief Sets Dirichlet boundary conditions using the analytic solution or
+ * analytic data.
+ */
+template <size_t Dim>
+class DirichletAnalytic final : public BoundaryCondition<Dim> {
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help{
+      "DirichletAnalytic boundary conditions setting the value of Psi, Phi, "
+      "and Pi to the analytic solution or analytic data."};
+  static std::string name() noexcept { return "DirichletAnalytic"; }
+
+  DirichletAnalytic() = default;
+  DirichletAnalytic(DirichletAnalytic&&) noexcept = default;
+  DirichletAnalytic& operator=(DirichletAnalytic&&) noexcept = default;
+  DirichletAnalytic(const DirichletAnalytic&) = default;
+  DirichletAnalytic& operator=(const DirichletAnalytic&) = default;
+  ~DirichletAnalytic() override = default;
+
+  explicit DirichletAnalytic(CkMigrateMessage* msg) noexcept;
+
+  WRAPPED_PUPable_decl_base_template(
+      domain::BoundaryConditions::BoundaryCondition, DirichletAnalytic);
+
+  auto get_clone() const noexcept -> std::unique_ptr<
+      domain::BoundaryConditions::BoundaryCondition> override;
+
+  static constexpr evolution::BoundaryConditions::Type bc_type =
+      evolution::BoundaryConditions::Type::Ghost;
+
+  void pup(PUP::er& p) override;
+
+  using dg_interior_evolved_variables_tags = tmpl::list<>;
+  using dg_interior_temporary_tags =
+      tmpl::list<domain::Tags::Coordinates<Dim, Frame::Inertial>,
+                 Tags::ConstraintGamma2>;
+  using dg_gridless_tags =
+      tmpl::list<::Tags::Time, ::Tags::AnalyticSolutionOrData>;
+
+  template <typename AnalyticSolutionOrData>
+  std::optional<std::string> dg_ghost(
+      const gsl::not_null<Scalar<DataVector>*> pi,
+      const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> phi,
+      const gsl::not_null<Scalar<DataVector>*> psi,
+      const gsl::not_null<Scalar<DataVector>*> gamma2,
+      const std::optional<
+          tnsr::I<DataVector, Dim, Frame::Inertial>>& /*face_mesh_velocity*/,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& /*normal_covector*/,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& coords,
+      const Scalar<DataVector>& interior_gamma2, const double time,
+      const AnalyticSolutionOrData& analytic_solution_or_data) const noexcept {
+    *gamma2 = interior_gamma2;
+    auto boundary_values = [&analytic_solution_or_data, &coords,
+                            &time]() noexcept {
+      if constexpr (std::is_base_of_v<MarkAsAnalyticSolution,
+                                      AnalyticSolutionOrData>) {
+        return analytic_solution_or_data.variables(
+            coords, time,
+            tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>,
+                       ScalarWave::Psi>{});
+
+      } else {
+        (void)time;
+        return analytic_solution_or_data.variables(
+            coords, tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>,
+                               ScalarWave::Psi>{});
+      }
+    }();
+    *pi = get<ScalarWave::Pi>(boundary_values);
+    *phi = get<ScalarWave::Phi<Dim>>(boundary_values);
+    *psi = get<ScalarWave::Psi>(boundary_values);
+    return {};
+  }
+};
+}  // namespace ScalarWave::BoundaryConditions

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/Factory.hpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/Factory.hpp
@@ -1,0 +1,7 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/Systems/ScalarWave/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/ScalarWave/BoundaryConditions/DirichletAnalytic.hpp"

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/Factory.hpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/Factory.hpp
@@ -5,3 +5,4 @@
 
 #include "Evolution/Systems/ScalarWave/BoundaryConditions/BoundaryCondition.hpp"
 #include "Evolution/Systems/ScalarWave/BoundaryConditions/DirichletAnalytic.hpp"
+#include "Evolution/Systems/ScalarWave/BoundaryConditions/SphericalRadiation.hpp"

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/RegisterDerivedWithCharm.cpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/RegisterDerivedWithCharm.cpp
@@ -5,6 +5,7 @@
 
 #include "Evolution/Systems/ScalarWave/BoundaryConditions/BoundaryCondition.hpp"
 #include "Evolution/Systems/ScalarWave/BoundaryConditions/DirichletAnalytic.hpp"
+#include "Evolution/Systems/ScalarWave/BoundaryConditions/SphericalRadiation.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 
 namespace ScalarWave::BoundaryConditions {

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/RegisterDerivedWithCharm.cpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/RegisterDerivedWithCharm.cpp
@@ -1,0 +1,19 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarWave/BoundaryConditions/RegisterDerivedWithCharm.hpp"
+
+#include "Evolution/Systems/ScalarWave/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/ScalarWave/BoundaryConditions/DirichletAnalytic.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+
+namespace ScalarWave::BoundaryConditions {
+void register_derived_with_charm() noexcept {
+  Parallel::register_classes_in_list<
+      typename BoundaryCondition<1>::creatable_classes>();
+  Parallel::register_classes_in_list<
+      typename BoundaryCondition<2>::creatable_classes>();
+  Parallel::register_classes_in_list<
+      typename BoundaryCondition<3>::creatable_classes>();
+}
+}  // namespace ScalarWave::BoundaryConditions

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/RegisterDerivedWithCharm.hpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/RegisterDerivedWithCharm.hpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace ScalarWave::BoundaryConditions {
+void register_derived_with_charm() noexcept;
+}  // namespace ScalarWave::BoundaryConditions

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/SphericalRadiation.cpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/SphericalRadiation.cpp
@@ -1,0 +1,124 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarWave/BoundaryConditions/SphericalRadiation.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <pup.h>
+#include <string>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Options/Options.hpp"
+#include "Options/ParseOptions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+namespace ScalarWave::BoundaryConditions {
+namespace detail {
+SphericalRadiationType convert_spherical_radiation_type_from_yaml(
+    const Options::Option& options) {
+  const auto type_read = options.parse_as<std::string>();
+  if ("Sommerfeld" == type_read) {
+    return SphericalRadiationType::Sommerfeld;
+  } else if ("BaylissTurkel" == type_read) {
+    return SphericalRadiationType::BaylissTurkel;
+  }
+  PARSE_ERROR(options.context(),
+              "Failed to convert \""
+                  << type_read
+                  << "\" to SphericalRadiation::Type. Must be one of "
+                     "Sommerfeld, or BaylissTurkel.");
+}
+}  // namespace detail
+
+template <size_t Dim>
+SphericalRadiation<Dim>::SphericalRadiation(
+    const detail::SphericalRadiationType type) noexcept
+    : type_(type) {}
+
+template <size_t Dim>
+SphericalRadiation<Dim>::SphericalRadiation(
+    CkMigrateMessage* const msg) noexcept
+    : BoundaryCondition<Dim>(msg) {}
+
+template <size_t Dim>
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+SphericalRadiation<Dim>::get_clone() const noexcept {
+  return std::make_unique<SphericalRadiation>(*this);
+}
+
+template <size_t Dim>
+void SphericalRadiation<Dim>::pup(PUP::er& p) {
+  BoundaryCondition<Dim>::pup(p);
+  p | type_;
+}
+
+template <size_t Dim>
+std::optional<std::string> SphericalRadiation<Dim>::dg_ghost(
+    const gsl::not_null<Scalar<DataVector>*> pi_ext,
+    const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> phi_ext,
+    const gsl::not_null<Scalar<DataVector>*> psi_ext,
+    const gsl::not_null<Scalar<DataVector>*> gamma2_ext,
+    const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+        face_mesh_velocity,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
+    const Scalar<DataVector>& psi,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& coords,
+    const Scalar<DataVector>& gamma2) const noexcept {
+  *gamma2_ext = gamma2;
+  get(*pi_ext) = get<0>(normal_covector) * get<0>(phi);
+  for (size_t i = 1; i < Dim; ++i) {
+    get(*pi_ext) += normal_covector.get(i) * phi.get(i);
+  }
+
+  if (type_ == detail::SphericalRadiationType::BaylissTurkel) {
+    // computed radius, storing int psi_ext
+    DataVector& radius = get(*psi_ext);
+    radius = square(get<0>(coords));
+    for (size_t i = 1; i < Dim; ++i) {
+      radius += square(coords.get(i));
+    }
+    radius = sqrt(radius);
+    get(*pi_ext) += get(psi) / radius;
+  }
+
+  // Spherical radiation on a spherical boundary means no changes in Phi and
+  // Psi. These would ideally be controlled by a constraint-preserving boundary
+  // condition.
+  *phi_ext = phi;
+  get(*psi_ext) = get(psi);
+
+  if (face_mesh_velocity.has_value()) {
+    const Scalar<DataVector> char_speed =
+        dot_product(*face_mesh_velocity, normal_covector);
+    if (min(-get(char_speed)) < 0.0) {
+      return {
+          "Incoming characteristic speeds for spherical radiation boundary "
+          "condition. It's unclear that proper boundary conditions are imposed "
+          "in this case. Please verify if you need this feature."};
+    }
+  }
+  return {};
+}
+
+template <size_t Dim>
+// NOLINTNEXTLINE
+PUP::able::PUP_ID SphericalRadiation<Dim>::my_PUP_ID = 0;
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data) template class SphericalRadiation<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM
+}  // namespace ScalarWave::BoundaryConditions
+/// \endcond

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/SphericalRadiation.hpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/SphericalRadiation.hpp
@@ -1,0 +1,152 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <pup.h>
+#include <string>
+#include <type_traits>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/Systems/ScalarWave/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/AnalyticData/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace domain::Tags {
+template <size_t Dim, typename Frame>
+struct Coordinates;
+}  // namespace domain::Tags
+namespace Options {
+template <typename T>
+struct create_from_yaml;
+}  // namespace Options
+/// \endcond
+
+namespace ScalarWave::BoundaryConditions {
+namespace detail {
+/// The type of spherical radiation boundary condition to impose
+enum class SphericalRadiationType {
+  /// Impose \f$(\partial_t + \partial_r)\Psi=0\f$
+  Sommerfeld,
+  /// Impose \f$(\partial_t + \partial_r + r^{-1})\Psi=0\f$
+  BaylissTurkel
+};
+
+SphericalRadiationType convert_spherical_radiation_type_from_yaml(
+    const Options::Option& options);
+}  // namespace detail
+
+/*!
+ * \brief Impose spherical radiation boundary conditions.
+ *
+ * These can be imposed in one of two forms:
+ *
+ * \f{align*}{
+ *  \Pi=\partial_r\Psi,
+ * \f}
+ *
+ * referred to as a Sommerfeld condition, or
+ *
+ * \f{align*}{
+ *  \Pi=\partial_r\Psi + \frac{1}{r}\Psi
+ * \f}
+ *
+ * referred to as a Bayliss-Turkel condition.
+ *
+ * The Bayliss-Turkel condition produces fewer reflections than the Sommerfeld
+ * condition.
+ *
+ * \warning These are implemented assuming the outer boundary is spherical and
+ * centered at the origin of the radiation because the code sets
+ * \f$\Pi=n^i\Phi_i\f$, where \f$n^i\f$ is the outward pointing unit normal
+ * vector. It might be possible to generalize the condition to non-spherical
+ * boundaries by using \f$x^i/r\f$ instead of \f$n^i\f$, but this hasn't been
+ * tested.
+ */
+template <size_t Dim>
+class SphericalRadiation final : public BoundaryCondition<Dim> {
+ public:
+  struct TypeOptionTag {
+    using type = detail::SphericalRadiationType;
+    static std::string name() noexcept { return "Type"; }
+    static constexpr Options::String help{
+        "Whether to impose Sommerfeld or first-order Bayliss-Turkel spherical "
+        "radiation boundary conditions."};
+  };
+
+  using options = tmpl::list<TypeOptionTag>;
+  static constexpr Options::String help{
+      "Spherical radiation boundary conditions setting the value of Psi, Phi, "
+      "and Pi either using the Sommerfeld or first-order Bayliss-Turkel "
+      "method."};
+  static std::string name() noexcept { return "SphericalRadiation"; }
+
+  SphericalRadiation() = default;
+  SphericalRadiation(detail::SphericalRadiationType type) noexcept;
+  SphericalRadiation(SphericalRadiation&&) noexcept = default;
+  SphericalRadiation& operator=(SphericalRadiation&&) noexcept = default;
+  SphericalRadiation(const SphericalRadiation&) = default;
+  SphericalRadiation& operator=(const SphericalRadiation&) = default;
+  ~SphericalRadiation() override = default;
+
+  explicit SphericalRadiation(CkMigrateMessage* msg) noexcept;
+
+  WRAPPED_PUPable_decl_base_template(
+      domain::BoundaryConditions::BoundaryCondition, SphericalRadiation);
+
+  auto get_clone() const noexcept -> std::unique_ptr<
+      domain::BoundaryConditions::BoundaryCondition> override;
+
+  static constexpr evolution::BoundaryConditions::Type bc_type =
+      evolution::BoundaryConditions::Type::Ghost;
+
+  void pup(PUP::er& p) override;
+
+  using dg_interior_evolved_variables_tags = tmpl::list<Phi<Dim>, Psi>;
+  using dg_interior_temporary_tags =
+      tmpl::list<domain::Tags::Coordinates<Dim, Frame::Inertial>,
+                 Tags::ConstraintGamma2>;
+  using dg_gridless_tags = tmpl::list<>;
+
+  std::optional<std::string> dg_ghost(
+      gsl::not_null<Scalar<DataVector>*> pi_ext,
+      gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> phi_ext,
+      gsl::not_null<Scalar<DataVector>*> psi_ext,
+      gsl::not_null<Scalar<DataVector>*> gamma2_ext,
+      const std::optional<
+          tnsr::I<DataVector, Dim, Frame::Inertial>>& /*face_mesh_velocity*/,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
+      const Scalar<DataVector>& psi,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& coords,
+      const Scalar<DataVector>& gamma2) const noexcept;
+
+ private:
+  detail::SphericalRadiationType type_{
+      detail::SphericalRadiationType::Sommerfeld};
+};
+}  // namespace ScalarWave::BoundaryConditions
+
+template <>
+struct Options::create_from_yaml<
+    ScalarWave::BoundaryConditions::detail::SphericalRadiationType> {
+  template <typename Metavariables>
+  static typename ScalarWave::BoundaryConditions::detail::SphericalRadiationType
+  create(const Options::Option& options) {
+    return ScalarWave::BoundaryConditions::detail::
+        convert_spherical_radiation_type_from_yaml(options);
+  }
+};

--- a/src/Evolution/Systems/ScalarWave/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarWave/CMakeLists.txt
@@ -39,4 +39,5 @@ target_link_libraries(
   Options
   )
 
+add_subdirectory(BoundaryConditions)
 add_subdirectory(BoundaryCorrections)

--- a/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/DirichletAnalytic.py
+++ b/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/DirichletAnalytic.py
@@ -1,0 +1,87 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def error(face_mesh_velocity, outward_directed_normal_covector, coords,
+          interior_gamma2, time, dim):
+    return None
+
+
+def _gauss_amplitude():
+    return 0.9
+
+
+def _gauss_width():
+    return 0.6
+
+
+def _gauss_center():
+    return 0.0
+
+
+def _center(dim):
+    center = [1.1]
+    if dim > 1:
+        center.append(0.1)
+        if dim > 2:
+            center.append(-0.9)
+    return np.asarray(center)
+
+
+def _wave_vector(dim):
+    wave_vector = [0.1]
+    if dim > 1:
+        wave_vector.append(1.1)
+        if dim > 2:
+            wave_vector.append(2.1)
+    return np.asarray(wave_vector)
+
+
+def _omega(dim):
+    wave_vector = _wave_vector(dim)
+    return np.sqrt(wave_vector.dot(wave_vector))
+
+
+def _1d_u(coords, time, dim):
+    result = -_omega(dim) * time
+    for i in range(dim):
+        result += _wave_vector(dim)[i] * (coords[i] - _center(dim)[i])
+    return result
+
+
+def _profile(u):
+    return _gauss_amplitude() * np.exp(
+        -(u - _gauss_center())**2 / _gauss_width()**2)
+
+
+def _first_deriv(u):
+    return (-2.0 * _gauss_amplitude() /
+            _gauss_width()**2) * (u - _gauss_center()) * np.exp(
+                -(u - _gauss_center())**2 / _gauss_width()**2)
+
+
+def pi(face_mesh_velocity, outward_directed_normal_covector, coords,
+       interior_gamma2, time, dim):
+    return _omega(dim) * _first_deriv(_1d_u(coords, time, dim))
+
+
+def phi(face_mesh_velocity, outward_directed_normal_covector, coords,
+        interior_gamma2, time, dim):
+    result = np.empty([dim])
+    du = _first_deriv(_1d_u(coords, time, dim))
+    for i in range(dim):
+        result[i] = _wave_vector(dim)[i] * du
+    return result
+
+
+def psi(face_mesh_velocity, outward_directed_normal_covector, coords,
+        interior_gamma2, time, dim):
+    return _profile(_1d_u(coords, time, dim))
+
+
+def constraint_gamma2(face_mesh_velocity, outward_directed_normal_covector,
+                      coords, interior_gamma2, time, dim):
+    assert interior_gamma2 >= 0.0  # make sure random gamma_2 is positive
+    return interior_gamma2

--- a/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/SphericalRadiation.py
+++ b/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/SphericalRadiation.py
@@ -1,0 +1,41 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def error(face_mesh_velocity, outward_directed_normal_covector, phi, psi,
+          coords, interior_gamma2):
+    if not face_mesh_velocity is None and -np.dot(
+            face_mesh_velocity, outward_directed_normal_covector) < 0.0:
+        return (
+            "Incoming characteristic speeds for spherical radiation boundary.*"
+        )
+    return None
+
+
+def pi_Sommerfeld(face_mesh_velocity, outward_directed_normal_covector, phi,
+                  psi, coords, interior_gamma2):
+    return np.dot(outward_directed_normal_covector, phi)
+
+
+def pi_BaylissTurkel(face_mesh_velocity, outward_directed_normal_covector, phi,
+                     psi, coords, interior_gamma2):
+    radius = np.sqrt(np.dot(coords, coords))
+    return np.dot(outward_directed_normal_covector, phi) + psi / radius
+
+
+def phi(face_mesh_velocity, outward_directed_normal_covector, phi, psi, coords,
+        interior_gamma2):
+    return phi
+
+
+def psi(face_mesh_velocity, outward_directed_normal_covector, phi, psi, coords,
+        interior_gamma2):
+    return psi
+
+
+def constraint_gamma2(face_mesh_velocity, outward_directed_normal_covector,
+                      phi, psi, coords, interior_gamma2):
+    assert interior_gamma2 >= 0.0  # make sure random gamma_2 is positive
+    return interior_gamma2

--- a/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/Test_DirichletAnalytic.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/Test_DirichletAnalytic.cpp
@@ -1,0 +1,104 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Index.hpp"
+#include "Evolution/Systems/ScalarWave/BoundaryConditions/DirichletAnalytic.hpp"
+#include "Evolution/Systems/ScalarWave/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/ScalarWave/BoundaryCorrections/UpwindPenalty.hpp"
+#include "Evolution/Systems/ScalarWave/System.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"
+#include "PointwiseFunctions/MathFunctions/Gaussian.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace helpers = TestHelpers::evolution::dg;
+
+namespace {
+template <size_t Dim>
+struct ConvertPlaneWave {
+  using unpacked_container = int;
+  using packed_container = ScalarWave::Solutions::PlaneWave<Dim>;
+  using packed_type = double;
+
+  static packed_container create_container() {
+    std::array<double, Dim> wave_vector{};
+    for (size_t i = 0; i < Dim; ++i) {
+      gsl::at(wave_vector, i) = 0.1 + i;
+    }
+    std::array<double, Dim> center{};
+    for (size_t i = 0; i < Dim; ++i) {
+      gsl::at(center, i) = 1.1 - i;
+    }
+    return {wave_vector, center,
+            std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(
+                0.9, 0.6, 0.0)};
+  }
+
+  static inline unpacked_container unpack(
+      const packed_container& /*packed*/,
+      const size_t /*grid_point_index*/) noexcept {
+    // No way of getting the args from the boundary condition.
+    return Dim;
+  }
+
+  static inline void pack(const gsl::not_null<packed_container*> packed,
+                          const unpacked_container /*unpacked*/,
+                          const size_t /*grid_point_index*/) {
+    *packed = create_container();
+  }
+
+  static inline size_t get_size(const packed_container& /*packed*/) noexcept {
+    return 1;
+  }
+};
+
+template <size_t Dim>
+void test() {
+  CAPTURE(Dim);
+  MAKE_GENERATOR(gen);
+  const auto box_analytic_soln = db::create<db::AddSimpleTags<
+      Tags::Time,
+      Tags::AnalyticSolution<ScalarWave::Solutions::PlaneWave<Dim>>>>(
+      0.5, ConvertPlaneWave<Dim>::create_container());
+
+  helpers::test_boundary_condition_with_python<
+      ScalarWave::BoundaryConditions::DirichletAnalytic<Dim>,
+      ScalarWave::BoundaryConditions::BoundaryCondition<Dim>,
+      ScalarWave::System<Dim>,
+      tmpl::list<ScalarWave::BoundaryCorrections::UpwindPenalty<Dim>>,
+      tmpl::list<ConvertPlaneWave<Dim>>>(
+      make_not_null(&gen), "DirichletAnalytic",
+      tuples::TaggedTuple<
+          helpers::Tags::PythonFunctionForErrorMessage<>,
+          helpers::Tags::PythonFunctionName<ScalarWave::Psi>,
+          helpers::Tags::PythonFunctionName<ScalarWave::Pi>,
+          helpers::Tags::PythonFunctionName<ScalarWave::Phi<Dim>>,
+          helpers::Tags::PythonFunctionName<
+              ScalarWave::Tags::ConstraintGamma2>>{"error", "psi", "pi", "phi",
+                                                   "constraint_gamma2"},
+      "DirichletAnalytic:\n", Index<Dim - 1>{Dim == 1 ? 1 : 5},
+      box_analytic_soln,
+      tuples::TaggedTuple<
+          helpers::Tags::Range<ScalarWave::Tags::ConstraintGamma2>>{
+          std::array{0.0, 1.0}});
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ScalarWave.BoundaryConditions.DirichletAnalytic",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/ScalarWave/BoundaryConditions/"};
+  test<1>();
+  test<2>();
+  test<3>();
+}

--- a/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/Test_SphericalRadiation.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/Test_SphericalRadiation.cpp
@@ -1,0 +1,62 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Index.hpp"
+#include "Evolution/Systems/ScalarWave/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/ScalarWave/BoundaryConditions/SphericalRadiation.hpp"
+#include "Evolution/Systems/ScalarWave/BoundaryCorrections/UpwindPenalty.hpp"
+#include "Evolution/Systems/ScalarWave/System.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace helpers = TestHelpers::evolution::dg;
+
+namespace {
+template <size_t Dim>
+void test() {
+  CAPTURE(Dim);
+  MAKE_GENERATOR(gen);
+  for (const std::string& bc_string : {"Sommerfeld", "BaylissTurkel"}) {
+    CAPTURE(bc_string);
+    helpers::test_boundary_condition_with_python<
+        ScalarWave::BoundaryConditions::SphericalRadiation<Dim>,
+        ScalarWave::BoundaryConditions::BoundaryCondition<Dim>,
+        ScalarWave::System<Dim>,
+        tmpl::list<ScalarWave::BoundaryCorrections::UpwindPenalty<Dim>>>(
+        make_not_null(&gen), "SphericalRadiation",
+        tuples::TaggedTuple<
+            helpers::Tags::PythonFunctionForErrorMessage<>,
+            helpers::Tags::PythonFunctionName<ScalarWave::Psi>,
+            helpers::Tags::PythonFunctionName<ScalarWave::Pi>,
+            helpers::Tags::PythonFunctionName<ScalarWave::Phi<Dim>>,
+            helpers::Tags::PythonFunctionName<
+                ScalarWave::Tags::ConstraintGamma2>>{
+            "error", "psi", "pi_" + bc_string, "phi", "constraint_gamma2"},
+        "SphericalRadiation:\n"
+        "  Type: " +
+            bc_string,
+        Index<Dim - 1>{Dim == 1 ? 1 : 5}, db::DataBox<tmpl::list<>>{},
+        tuples::TaggedTuple<
+            helpers::Tags::Range<ScalarWave::Tags::ConstraintGamma2>>{
+            std::array{0.0, 1.0}});
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ScalarWave.BoundaryConditions.SphericalRadiation",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/ScalarWave/BoundaryConditions/"};
+  test<1>();
+  test<2>();
+  test<3>();
+}

--- a/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
@@ -1,9 +1,10 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-set(LIBRARY "Test_ScalarWave")
+set(LIBRARY Test_ScalarWave)
 
 set(LIBRARY_SOURCES
+  BoundaryConditions/Test_DirichletAnalytic.cpp
   BoundaryCorrections/Test_UpwindPenalty.cpp
   Test_Characteristics.cpp
   Test_Constraints.cpp
@@ -15,5 +16,17 @@ set(LIBRARY_SOURCES
 add_test_library(
   ${LIBRARY}
   "Evolution/Systems/ScalarWave/"
-  "${LIBRARY_SOURCES}" "ScalarWave;MathFunctions;WaveEquationSolutions"
+  "${LIBRARY_SOURCES}"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DataStructures
+  MathFunctions
+  ScalarWave
+  Time
+  Utilities
+  WaveEquationSolutions
   )

--- a/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY Test_ScalarWave)
 
 set(LIBRARY_SOURCES
   BoundaryConditions/Test_DirichletAnalytic.cpp
+  BoundaryConditions/Test_SphericalRadiation.cpp
   BoundaryCorrections/Test_UpwindPenalty.cpp
   Test_Characteristics.cpp
   Test_Constraints.cpp


### PR DESCRIPTION
## Proposed changes

The SphericalRadiation boundary conditions are either Sommerfeld or the first-order Bayliss-Turkel boundary conditions imposed through the boundary correction. In a followup PR I'll add imposing constraint-preserving spherical radiation boundary conditions allowing for second-order BT terms.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
