### PR TITLE
Add DG to FD projection function

### DIFF
--- a/src/Evolution/DgSubcell/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/CMakeLists.txt
@@ -12,6 +12,7 @@ spectre_target_headers(
   ActiveGrid.hpp
   DgSubcell.hpp
   Matrices.hpp
+  Projection.hpp
   )
 
 spectre_target_sources(
@@ -19,6 +20,7 @@ spectre_target_sources(
   PRIVATE
   ActiveGrid.cpp
   Matrices.cpp
+  Projection.cpp
   )
 
 target_link_libraries(

--- a/src/Evolution/DgSubcell/Projection.cpp
+++ b/src/Evolution/DgSubcell/Projection.cpp
@@ -1,0 +1,70 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/DgSubcell/Projection.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "Evolution/DgSubcell/Matrices.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/Blas.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+namespace evolution::dg::subcell::fd {
+namespace detail {
+template <size_t Dim>
+void project_impl(gsl::span<double> subcell_u,
+                  const gsl::span<const double> dg_u, const Mesh<Dim>& dg_mesh,
+                  const Index<Dim>& subcell_extents) noexcept {
+  const size_t number_of_components =
+      dg_u.size() / dg_mesh.number_of_grid_points();
+  const Matrix& proj_matrix = projection_matrix(dg_mesh, subcell_extents);
+  dgemm_<true>('N', 'N', proj_matrix.rows(), number_of_components,
+               proj_matrix.columns(), 1.0, proj_matrix.data(),
+               proj_matrix.rows(), dg_u.data(), proj_matrix.columns(), 0.0,
+               subcell_u.data(), proj_matrix.rows());
+}
+}  // namespace detail
+
+template <size_t Dim>
+void project(const gsl::not_null<DataVector*> subcell_u, const DataVector& dg_u,
+             const Mesh<Dim>& dg_mesh,
+             const Index<Dim>& subcell_extents) noexcept {
+  subcell_u->destructive_resize(subcell_extents.product());
+  detail::project_impl(gsl::span<double>{subcell_u->data(), subcell_u->size()},
+                       gsl::span<const double>{dg_u.data(), dg_u.size()},
+                       dg_mesh, subcell_extents);
+}
+
+template <size_t Dim>
+DataVector project(const DataVector& dg_u, const Mesh<Dim>& dg_mesh,
+                   const Index<Dim>& subcell_extents) noexcept {
+  DataVector subcell_u{subcell_extents.product()};
+  project(&subcell_u, dg_u, dg_mesh, subcell_extents);
+  return subcell_u;
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data)                                           \
+  template DataVector project(const DataVector&, const Mesh<DIM(data)>&, \
+                              const Index<DIM(data)>&) noexcept;         \
+  template void project(gsl::not_null<DataVector*>, const DataVector&,   \
+                        const Mesh<DIM(data)>&,                          \
+                        const Index<DIM(data)>&) noexcept;               \
+  template void detail::project_impl(                                    \
+      gsl::span<double> subcell_u, const gsl::span<const double> dg_u,   \
+      const Mesh<DIM(data)>& dg_mesh,                                    \
+      const Index<DIM(data)>& subcell_extents) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM
+}  // namespace evolution::dg::subcell::fd
+/// \endcond

--- a/src/Evolution/DgSubcell/Projection.hpp
+++ b/src/Evolution/DgSubcell/Projection.hpp
@@ -1,0 +1,78 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+template <size_t>
+class Index;
+template <size_t>
+class Mesh;
+/// \endcond
+
+namespace evolution::dg::subcell::fd {
+namespace detail {
+template <size_t Dim>
+void project_impl(gsl::span<double> subcell_u, gsl::span<const double> dg_u,
+                  const Mesh<Dim>& dg_mesh,
+                  const Index<Dim>& subcell_extents) noexcept;
+}  // namespace detail
+
+// @{
+/*!
+ * \ingroup DgSubcellGroup
+ * \brief Project the variable `dg_u` onto the subcell grid with extents
+ * `subcell_extents`.
+ *
+ * \note In the return-by-`gsl::not_null` with `Variables` interface, the
+ * `SubcellTagList` and the `DgtagList` must be the same when all tag prefixes
+ * are removed. Typically the `Tags::Inactive` prefix will be used.
+ */
+template <size_t Dim>
+DataVector project(const DataVector& dg_u, const Mesh<Dim>& dg_mesh,
+                   const Index<Dim>& subcell_extents) noexcept;
+
+template <size_t Dim>
+void project(gsl::not_null<DataVector*> subcell_u, const DataVector& dg_u,
+             const Mesh<Dim>& dg_mesh,
+             const Index<Dim>& subcell_extents) noexcept;
+
+template <typename SubcellTagList, typename DgTagList, size_t Dim>
+void project(const gsl::not_null<Variables<SubcellTagList>*> subcell_u,
+             const Variables<DgTagList>& dg_u, const Mesh<Dim>& dg_mesh,
+             const Index<Dim>& subcell_extents) noexcept {
+  static_assert(
+      std::is_same_v<
+          tmpl::transform<SubcellTagList,
+                          tmpl::bind<db::remove_all_prefixes, tmpl::_1>>,
+          tmpl::transform<DgTagList,
+                          tmpl::bind<db::remove_all_prefixes, tmpl::_1>>>,
+      "DG and subcell tag lists must be the same once prefix tags "
+      "are removed.");
+  if (UNLIKELY(subcell_u->number_of_grid_points() !=
+               subcell_extents.product())) {
+    subcell_u->initialize(subcell_extents.product());
+  }
+  detail::project_impl(gsl::span<double>{subcell_u->data(), subcell_u->size()},
+                       gsl::span<const double>{dg_u.data(), dg_u.size()},
+                       dg_mesh, subcell_extents);
+}
+
+template <typename TagList, size_t Dim>
+Variables<TagList> project(const Variables<TagList>& dg_u,
+                           const Mesh<Dim>& dg_mesh,
+                           const Index<Dim>& subcell_extents) noexcept {
+  Variables<TagList> subcell_u(subcell_extents.product());
+  project(make_not_null(&subcell_u), dg_u, dg_mesh, subcell_extents);
+  return subcell_u;
+}
+// @}
+}  // namespace evolution::dg::subcell::fd

--- a/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
+++ b/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_DgSubcell")
 set(LIBRARY_SOURCES
   Test_ActiveGrid.cpp
   Test_Matrices.cpp
+  Test_Projection.cpp
   Test_Tags.cpp
   )
 

--- a/tests/Unit/Evolution/DgSubcell/Test_Projection.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Projection.cpp
@@ -1,0 +1,140 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <algorithm>
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Evolution/DgSubcell/Projection.hpp"
+#include "Helpers/Evolution/DgSubcell/ProjectionTestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+namespace Tags {
+template <typename Tag>
+struct Prefix : db::PrefixTag {
+  using tag = Tag;
+  using type = typename Tag::type;
+};
+
+struct Scalar : db::SimpleTag {
+  using type = ::Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct Vector : db::SimpleTag {
+  using type = tnsr::I<DataVector, Dim>;
+};
+}  // namespace Tags
+
+template <size_t MaxPts, size_t Dim, Spectral::Basis BasisType,
+          Spectral::Quadrature QuadratureType>
+void test_project_fd() noexcept {
+  CAPTURE(Dim);
+  CAPTURE(BasisType);
+  CAPTURE(QuadratureType);
+
+  for (size_t num_pts_1d = std::max(
+           static_cast<size_t>(2),
+           Spectral::minimum_number_of_points<BasisType, QuadratureType>);
+       num_pts_1d < MaxPts + 1; ++num_pts_1d) {
+    CAPTURE(num_pts_1d);
+    const Mesh<Dim> dg_mesh{num_pts_1d, BasisType, QuadratureType};
+    const auto logical_coords = logical_coordinates(dg_mesh);
+    const size_t num_subcells_1d = 2 * num_pts_1d - 1;
+    const Mesh<Dim> subcell_mesh(num_subcells_1d,
+                                 Spectral::Basis::FiniteDifference,
+                                 Spectral::Quadrature::CellCentered);
+    const DataVector nodal_coeffs =
+        TestHelpers::evolution::dg::subcell::cell_values(dg_mesh.extents(0) - 2,
+                                                         logical_coords);
+    const DataVector expected_subcell_values =
+        TestHelpers::evolution::dg::subcell::cell_values(
+            dg_mesh.extents(0) - 2, logical_coordinates(subcell_mesh));
+    // Test projection of a DataVector
+    const DataVector subcell_values = evolution::dg::subcell::fd::project(
+        nodal_coeffs, dg_mesh, subcell_mesh.extents());
+    CHECK_ITERABLE_APPROX(subcell_values, expected_subcell_values);
+
+    // Test projection of a Variables using the return-by-value function
+    Variables<tmpl::list<Tags::Scalar, Tags::Vector<Dim>>> vars(
+        dg_mesh.number_of_grid_points());
+    get(get<Tags::Scalar>(vars)) = nodal_coeffs;
+    for (size_t d = 0; d < Dim; ++d) {
+      get<Tags::Vector<Dim>>(vars).get(d) = (d + 2.0) * nodal_coeffs;
+    }
+    Variables<tmpl::list<Tags::Scalar, Tags::Vector<Dim>>> subcell_vars =
+        evolution::dg::subcell::fd::project(vars, dg_mesh,
+                                            subcell_mesh.extents());
+
+    const auto check_each_field_in_vars =
+        [&expected_subcell_values](const auto& local_subcell_vars) {
+          CHECK_ITERABLE_APPROX(
+              get(get<tmpl::front<typename std::decay_t<decltype(
+                      local_subcell_vars)>::tags_list>>(local_subcell_vars)),
+              expected_subcell_values);
+          for (size_t d = 0; d < Dim; ++d) {
+            CHECK_ITERABLE_APPROX(
+                get<tmpl::back<typename std::decay_t<decltype(
+                    local_subcell_vars)>::tags_list>>(local_subcell_vars)
+                    .get(d),
+                (d + 2.0) * expected_subcell_values);
+          }
+        };
+    check_each_field_in_vars(subcell_vars);
+
+    // Check with the prefix on the subcell vars
+    Variables<
+        tmpl::list<Tags::Prefix<Tags::Scalar>, Tags::Prefix<Tags::Vector<Dim>>>>
+        prefixed_subcell_vars{subcell_mesh.number_of_grid_points()};
+    evolution::dg::subcell::fd::project(make_not_null(&prefixed_subcell_vars),
+                                        vars, dg_mesh, subcell_mesh.extents());
+    check_each_field_in_vars(prefixed_subcell_vars);
+
+    // Check with the prefix on the DG vars
+    Variables<
+        tmpl::list<Tags::Prefix<Tags::Scalar>, Tags::Prefix<Tags::Vector<Dim>>>>
+        prefixed_vars(dg_mesh.number_of_grid_points());
+    prefixed_vars = vars;
+    subcell_vars.initialize(0.0, subcell_mesh.number_of_grid_points());
+    evolution::dg::subcell::fd::project(make_not_null(&subcell_vars),
+                                        prefixed_vars, dg_mesh,
+                                        subcell_mesh.extents());
+    check_each_field_in_vars(subcell_vars);
+
+    // Check with the prefix on the DG and subcell vars
+    prefixed_subcell_vars.initialize(0.0, subcell_mesh.number_of_grid_points());
+    evolution::dg::subcell::fd::project(make_not_null(&prefixed_subcell_vars),
+                                        prefixed_vars, dg_mesh,
+                                        subcell_mesh.extents());
+    check_each_field_in_vars(prefixed_subcell_vars);
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Fd.Projection", "[Evolution][Unit]") {
+  test_project_fd<10, 1, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto>();
+  test_project_fd<10, 1, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::Gauss>();
+
+  test_project_fd<10, 2, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto>();
+  test_project_fd<10, 2, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::Gauss>();
+
+  test_project_fd<5, 3, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto>();
+  test_project_fd<4, 3, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::Gauss>();
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

Adds the function to project the DG solution to the FD grid. Really should project `u J` to get conservation perfect when `J` varies spatially.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
