### PR TITLE
Add subcell ActiveGrid enum, tag, and tag for TCI history

### DIFF
--- a/src/Evolution/DgSubcell/ActiveGrid.cpp
+++ b/src/Evolution/DgSubcell/ActiveGrid.cpp
@@ -1,0 +1,22 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/DgSubcell/ActiveGrid.hpp"
+
+#include <ostream>
+
+#include "Utilities/ErrorHandling/Error.hpp"
+
+namespace evolution::dg::subcell {
+std::ostream& operator<<(std::ostream& os, ActiveGrid active_grid) noexcept {
+  switch (active_grid) {
+    case ActiveGrid::Dg:
+      return os << "Dg";
+    case ActiveGrid::Subcell:
+      return os << "Subcell";
+    default:
+      ERROR("ActiveGrid must be either 'Dg' or 'Subcell' but has value "
+            << static_cast<int>(active_grid));
+  }
+}
+}  // namespace evolution::dg::subcell

--- a/src/Evolution/DgSubcell/ActiveGrid.hpp
+++ b/src/Evolution/DgSubcell/ActiveGrid.hpp
@@ -1,0 +1,14 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <iosfwd>
+
+namespace evolution::dg::subcell {
+/// \ingroup DgSubcellGroup
+/// The grid that is currently being used for the DG-subcell evolution.
+enum class ActiveGrid { Dg, Subcell };
+
+std::ostream& operator<<(std::ostream& os, ActiveGrid active_grid) noexcept;
+}  // namespace evolution::dg::subcell

--- a/src/Evolution/DgSubcell/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/CMakeLists.txt
@@ -32,3 +32,5 @@ target_link_libraries(
   ErrorHandling
   Utilities
   )
+
+add_subdirectory(Tags)

--- a/src/Evolution/DgSubcell/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  ActiveGrid.hpp
   DgSubcell.hpp
   Matrices.hpp
   )
@@ -16,6 +17,7 @@ spectre_target_headers(
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  ActiveGrid.cpp
   Matrices.cpp
   )
 

--- a/src/Evolution/DgSubcell/Tags/ActiveGrid.hpp
+++ b/src/Evolution/DgSubcell/Tags/ActiveGrid.hpp
@@ -1,0 +1,14 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Evolution/DgSubcell/ActiveGrid.hpp"
+
+namespace evolution::dg::subcell::Tags {
+/// The grid currently used for the DG-subcell evolution on the element.
+struct ActiveGrid : db::SimpleTag {
+  using type = evolution::dg::subcell::ActiveGrid;
+};
+}  // namespace evolution::dg::subcell::Tags

--- a/src/Evolution/DgSubcell/Tags/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/Tags/CMakeLists.txt
@@ -8,4 +8,5 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ActiveGrid.hpp
+  TciGridHistory.hpp
   )

--- a/src/Evolution/DgSubcell/Tags/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/Tags/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY DgSubcell)
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  ActiveGrid.hpp
+  )

--- a/src/Evolution/DgSubcell/Tags/TciGridHistory.hpp
+++ b/src/Evolution/DgSubcell/Tags/TciGridHistory.hpp
@@ -1,0 +1,23 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <deque>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Evolution/DgSubcell/ActiveGrid.hpp"
+
+namespace evolution::dg::subcell::Tags {
+/// A record of which grid the TCI requested we use.
+///
+/// This is necessary because when using linear multistep methods for the time
+/// integration we need to wait until the entire history is smooth before
+/// returning to DG. For an Nth order integration in time, this means we need N
+/// steps where the TCI has decided the solution is representable using DG.
+///
+/// The front of the history is the most recent entry.
+struct TciGridHistory : db::SimpleTag {
+  using type = std::deque<evolution::dg::subcell::ActiveGrid>;
+};
+}  // namespace evolution::dg::subcell::Tags

--- a/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
+++ b/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_DgSubcell")
 
 set(LIBRARY_SOURCES
+  Test_ActiveGrid.cpp
   Test_Matrices.cpp
   )
 

--- a/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
+++ b/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_DgSubcell")
 set(LIBRARY_SOURCES
   Test_ActiveGrid.cpp
   Test_Matrices.cpp
+  Test_Tags.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Evolution/DgSubcell/Test_ActiveGrid.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_ActiveGrid.cpp
@@ -1,0 +1,14 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "Evolution/DgSubcell/ActiveGrid.hpp"
+#include "Utilities/GetOutput.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.Subcell.ActiveGrid", "[Evolution][Unit]") {
+  CHECK("Dg" == get_output(evolution::dg::subcell::ActiveGrid::Dg));
+  CHECK("Subcell" == get_output(evolution::dg::subcell::ActiveGrid::Subcell));
+}

--- a/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
@@ -1,0 +1,15 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Tags",
+                  "[Evolution][Unit]") {
+  TestHelpers::db::test_simple_tag<evolution::dg::subcell::Tags::ActiveGrid>(
+      "ActiveGrid");
+}

--- a/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
@@ -6,10 +6,13 @@
 #include <string>
 
 #include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Tags/TciGridHistory.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 
 SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Tags",
                   "[Evolution][Unit]") {
   TestHelpers::db::test_simple_tag<evolution::dg::subcell::Tags::ActiveGrid>(
       "ActiveGrid");
+  TestHelpers::db::test_simple_tag<
+      evolution::dg::subcell::Tags::TciGridHistory>("TciGridHistory");
 }


### PR DESCRIPTION
## Proposed changes

We need to keep track of whether we are using DG or subcell, and we need to know the history of the TCI decisions for which grid to use in order to avoid returning to DG when there is still a discontinuity in the history.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
