### PR TITLE
Simplify code in DataBoxTag.hpp

### DIFF
--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -1115,26 +1115,25 @@ SPECTRE_ALWAYS_INLINE constexpr decltype(auto) mutate_apply(
       "Cannot pass a DataBox to mutate_apply since the db::get won't work "
       "inside mutate_apply.");
   if constexpr (is_apply_callable_v<
-                    F, const gsl::not_null<item_type<ReturnTags, BoxTags>*>...,
+                    F, const gsl::not_null<typename ReturnTags::type*>...,
                     const_item_type<ArgumentTags, BoxTags>..., Args...>) {
     return ::db::mutate<ReturnTags...>(
         box,
-        [](const gsl::not_null<
-               item_type<ReturnTags, BoxTags>*>... mutated_items,
+        [](const gsl::not_null<typename ReturnTags::type*>... mutated_items,
            const_item_type<ArgumentTags, BoxTags>... args_items,
            decltype(std::forward<Args>(args))... l_args) noexcept {
           return std::decay_t<F>::apply(mutated_items..., args_items...,
                                         std::forward<Args>(l_args)...);
         },
         db::get<ArgumentTags>(*box)..., std::forward<Args>(args)...);
-  } else if constexpr (
-      ::tt::is_callable_v<
-          F, const gsl::not_null<item_type<ReturnTags, BoxTags>*>...,
-          const_item_type<ArgumentTags, BoxTags>..., Args...>) {
+  } else if constexpr (::tt::is_callable_v<
+                           F,
+                           const gsl::not_null<typename ReturnTags::type*>...,
+                           const_item_type<ArgumentTags, BoxTags>...,
+                           Args...>) {
     return ::db::mutate<ReturnTags...>(
         box,
-        [&f](const gsl::not_null<
-                 item_type<ReturnTags, BoxTags>*>... mutated_items,
+        [&f](const gsl::not_null<typename ReturnTags::type*>... mutated_items,
              const_item_type<ArgumentTags, BoxTags>... args_items,
              decltype(std::forward<Args>(args))... l_args) noexcept {
           return f(mutated_items..., args_items...,
@@ -1142,9 +1141,9 @@ SPECTRE_ALWAYS_INLINE constexpr decltype(auto) mutate_apply(
         },
         db::get<ArgumentTags>(*box)..., std::forward<Args>(args)...);
   } else {
-    error_function_not_callable<
-        F, gsl::not_null<item_type<ReturnTags, BoxTags>*>...,
-        const_item_type<ArgumentTags, BoxTags>..., Args...>();
+    error_function_not_callable<F, gsl::not_null<typename ReturnTags::type*>...,
+                                const_item_type<ArgumentTags, BoxTags>...,
+                                Args...>();
   }
 }
 }  // namespace detail

--- a/src/DataStructures/DataBox/DataBoxTag.hpp
+++ b/src/DataStructures/DataBox/DataBoxTag.hpp
@@ -37,9 +37,9 @@ namespace Tags {
  * \snippet Test_DataBox.cpp databox_self_tag_example
  */
 struct DataBox {
-  // Trick to get friend function declaration to compile but a const void& is
-  // rather useless
-  using type = void;
+  // Trick to get friend function declaration to compile but a const
+  // NoSuchtype****& is rather useless
+  using type = NoSuchType****;
 };
 }  // namespace Tags
 
@@ -98,18 +98,6 @@ using has_no_matching_tag_t = typename has_no_matching_tag<TagList, Tag>::type;
 template <typename TagList, typename Tag>
 constexpr bool has_no_matching_tag_v = has_no_matching_tag<TagList, Tag>::value;
 
-template <class T, class = void>
-struct has_return_type_member : std::false_type {};
-template <class T>
-struct has_return_type_member<T, std::void_t<typename T::return_type>>
-    : std::true_type {};
-
-/*!
- * \brief `true` if `T` has nested type alias named `return_type`
- */
-template <class T>
-constexpr bool has_return_type_member_v = has_return_type_member<T>::value;
-
 template <typename T>
 struct ConvertToConst {
   using type = const T&;
@@ -120,159 +108,20 @@ struct ConvertToConst<std::unique_ptr<T>> {
   using type = const T&;
 };
 
-template <typename T>
-const T& convert_to_const_type(const T& item) noexcept {
-  return item;
-}
-
-template <typename T>
-const T& convert_to_const_type(const std::unique_ptr<T>& item) noexcept {
-  return *item;
-}
-
-template <typename TagList, typename Tag>
-struct storage_type_impl;
-
-template <int SelectTagType>
-struct dispatch_storage_type;
-
-template <typename ArgsList>
-struct compute_item_type;
-
-template <typename TagList, typename Tag>
-struct storage_type_impl {
-  // storage_type_impl is intentionally a lazy metafunction rather than a
-  // metaclosure or a metacontinuation. The reason is that it is quite likely we
-  // call `db::item_type<Tag>` multiple times within the same translation unit
-  // and so we want to memoize the resulting type. However, we do not want to
-  // memoize the dispatch calls.
-  using type = typename dispatch_storage_type<
-      is_base_tag_v<Tag>
-          ? 4
-          : (is_compute_tag_v<Tag>and has_return_type_member_v<Tag>)
-                ? 3
-                : is_immutable_item_tag_v<Tag>
-                      ? 2
-                      : std::is_base_of_v<db::SimpleTag, Tag> ? 1 : 0>::
-      template f<TagList, Tag>;
+template <typename Tag, typename TagsList, bool = db::is_base_tag_v<Tag>>
+struct const_item_type_impl {
+  using type = typename db::detail::ConvertToConst<
+      std::decay_t<typename Tag::type>>::type;
 };
 
-template <>
-struct dispatch_storage_type<0> {
-  // Tag is not a tag. This is necessary for SFINAE friendliness, specifically
-  // if someone calls Requires<tt::is_a_v<std::vector, db::item_type<Tag>>>
-  // with, say Tag = double, then this should probably SFINAE away, not fail to
-  // compile.
-  template <typename TagList, typename Tag>
-  using f = NoSuchType;
+template <typename Tag, typename TagsList>
+struct const_item_type_impl<Tag, TagsList, true> {
+  using type = typename db::detail::ConvertToConst<std::decay_t<
+      typename db::detail::first_matching_tag<TagsList, Tag>::type>>::type;
 };
 
-template <>
-struct dispatch_storage_type<1> {
-  // simple item
-  template <typename TagList, typename Tag>
-  using f = typename Tag::type;
-};
+template <typename Tag, typename TagsList>
+using const_item_type = typename const_item_type_impl<Tag, TagsList>::type;
 
-template <>
-struct dispatch_storage_type<2> {
-  // compute item
-  template <typename TagList, typename Tag>
-  using f = typename compute_item_type<typename Tag::argument_tags>::template f<
-      TagList, Tag>;
-};
-
-template <>
-struct dispatch_storage_type<3> {
-  // mutating compute item
-  template <typename TagList, typename Tag>
-  using f = typename Tag::return_type;
-};
-
-template <typename TagList, typename Tag>
-struct get_first_derived_tag_for_base_tag {
-  static_assert(
-      not std::is_same_v<TagList, NoSuchType>,
-      "Can't retrieve the storage type of a base tag without the full tag "
-      "list. If you're using 'item_type' or 'const_item_type' then make sure "
-      "you pass the DataBox's tag list as the second template parameter to "
-      "those metafunctions. The base tag for which the storage type is being"
-      "retrieved is listed as the second template argument to the "
-      "'get_first_derived_tag_for_base_tag' class below");
-  using type = first_matching_tag<TagList, Tag>;
-};
-
-template <>
-struct dispatch_storage_type<4> {
-  // base tag item: retrieve the derived tag from the tag list then call
-  // storage_type_impl on the result.
-  // We do not check that there is only one matching tag in the DataBox because
-  // the uniqueness is only checked in get and mutate. The reason for that is
-  // that it is fine to have multiple derived tags in the DataBox as long as
-  // they all have the same type. We do not check that the types are all the
-  // same, it is undefined behavior if they are not and the user's
-  // responsibility.
-  template <typename TagList, typename Tag>
-  using f = typename storage_type_impl<
-      TagList,
-      tmpl::type_from<get_first_derived_tag_for_base_tag<TagList, Tag>>>::type;
-};
-
-// The type internally stored in a simple or compute item.  For
-// convenience in implementing the various tag type metafunctions,
-// this will also look up types for db::BaseTags, even though they
-// cannot actually store anything.
-template <typename Tag, typename TagList>
-using storage_type = typename storage_type_impl<TagList, Tag>::type;
-
-template <typename TagList, typename Tag>
-struct item_type_impl {
-  static_assert(not is_compute_tag_v<Tag>,
-                "Can't call item_type on a compute item because compute items "
-                "cannot be modified.  You probably wanted const_item_type.");
-  using type = detail::storage_type<Tag, TagList>;
-};
-
-// Get the type that is returned by `get<Tag>`. If it is a base tag then a
-// `TagList` must be passed as a second argument.
-template <typename Tag, typename TagList = NoSuchType>
-using const_item_type =
-    typename ConvertToConst<std::decay_t<storage_type<Tag, TagList>>>::type;
-
-// Get the type that can be written to the `Tag`. If it is a base tag then a
-// `TagList` must be passed as a second argument.
-template <typename Tag, typename TagList = NoSuchType>
-using item_type = typename item_type_impl<TagList, Tag>::type;
-
-CREATE_IS_CALLABLE(get)
-CREATE_IS_CALLABLE_V(get)
-
-template <typename Tag, typename TagList, typename TagTypesList>
-struct check_compute_item_is_invokable;
-
-template <typename Tag, typename... Tags, typename... TagTypes>
-struct check_compute_item_is_invokable<Tag, tmpl::list<Tags...>,
-                                       tmpl::list<TagTypes...>> {
-  static_assert(
-      is_get_callable_v<Tag, TagTypes...>,
-      "The compute item is not callable with the types that the tags hold. The "
-      "compute item tag that is the problem should be shown in the first line "
-      " after the static assert error: "
-      "'check_compute_item_is_invokable<TheItemThatsFailingToBeCalled, "
-      "brigand::list<PassedTags...>, "
-      "brigand::list<const_item_type<PassedTags>...>>'");
-};
-
-template <typename... Args>
-struct compute_item_type<tmpl::list<Args...>> {
-  template <typename TagList, typename Tag>
-  using f = decltype(
-#ifdef SPECTRE_DEBUG
-      (void)check_compute_item_is_invokable<
-          Tag, tmpl::list<Args...>,
-          tmpl::list<const_item_type<Args, TagList>...>>{},
-#endif  // SPECTRE_DEBUG
-      Tag::get(std::declval<const_item_type<Args, TagList>>()...));
-};
 }  // namespace detail
 }  // namespace db


### PR DESCRIPTION
With the recent changes in the implementation of DataBox, additional
simplifications are possible in implmentation details found in DataBoxTag.cpp

First, db::detail::item_type<Tag> can be eliminated as it should always Tag::type.
This removes the ability to specify a base tag for the `return_tags` type alias
of the functor used by db::mutate::apply.  This was ability was only used in
Test_DataBox and seems sketchy as I am not sure how you mutate an object without
knowing its type.

Second, since db::detail::const_item_type is no longer publically exposed and only
used in the implementation of DataBox, it can be greatly simplified.  Now it always
takes the tags list as a second template parameter.  And since all tags except base
tags are derived from a simple tag, the lookup of the type is greatly simplified.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
