### PR TITLE
Allow conversions of the contained type in Auto

### DIFF
--- a/src/Options/Auto.hpp
+++ b/src/Options/Auto.hpp
@@ -24,7 +24,8 @@ std::ostream& operator<<(std::ostream& os, AutoLabel label) noexcept;
 /// When an `Auto<T>` is parsed from an input file, the value may be specified
 /// either as the `AutoLabel` (defaults to "Auto") or as a value of type `T`.
 /// When this class is passed to the constructor of the class taking it as an
-/// option, it can be implicitly converted to a `std::optional<T>`.
+/// option, it can be implicitly converted to a `std::optional<U>`, for any
+/// type `U` implicitly creatable from a `T`.
 ///
 /// \snippet Test_Auto.cpp example_class
 /// \snippet Test_Auto.cpp example_create
@@ -35,7 +36,8 @@ class Auto {
   explicit Auto(T value) noexcept : value_(std::move(value)) {}
 
   // NOLINTNEXTLINE(google-explicit-constructor)
-  operator std::optional<T>() && { return std::move(value_); }
+  template <typename U>
+  operator std::optional<U>() && { return std::move(value_); }
 
   // NOLINTNEXTLINE(google-explicit-constructor)
   operator const std::optional<T>&() const { return value_; }


### PR DESCRIPTION
All conversions in the sequence Auto<T> -> optional<T> -> optional<U>
are valid if T is convertible to U, but C++ only tries single
conversions, so we have to combine them manually.

Fixes #2914

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
