### PR TITLE
Add ability to return from databox mutate or mutate_apply

### DIFF
--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -268,8 +268,9 @@ class DataBox<tmpl::list<Tags...>> : private detail::Item<Tags>... {
   template <typename... MutateTags, typename TagList, typename Invokable,
             typename... Args>
   // clang-tidy: redundant declaration
-  friend void mutate(gsl::not_null<DataBox<TagList>*> box,             // NOLINT
-                     Invokable&& invokable, Args&&... args) noexcept;  // NOLINT
+  friend decltype(auto) mutate(gsl::not_null<DataBox<TagList>*> box,  // NOLINT
+                               Invokable&& invokable,
+                               Args&&... args) noexcept;  // NOLINT
 
   // evaluates the compute item corresponding to ComputeTag passing along
   // items fetched via ArgumentTags
@@ -620,11 +621,20 @@ db::DataBox<tmpl::list<Tags...>>::mutate_mutable_subitems(
  *
  * \example
  * \snippet Test_DataBox.cpp databox_mutate_example
+ *
+ * The `invokable` may have function return values, and any returns are
+ * forwarded as returns to the `db::mutate` call.
+ *
+ * \warning Using `db::mutate` returns to obtain non-const references or
+ * pointers to box items is potentially very dangerous. The \ref DataBoxGroup
+ * "DataBox" cannot track any subsequent changes to quantities that have been
+ * "unsafely" extracted in this manner, so we consider it undefined behavior to
+ * return pointers or references to \ref DataBoxGroup "DataBox" contents.
  */
 template <typename... MutateTags, typename TagList, typename Invokable,
           typename... Args>
-void mutate(const gsl::not_null<DataBox<TagList>*> box, Invokable&& invokable,
-            Args&&... args) noexcept {
+decltype(auto) mutate(const gsl::not_null<DataBox<TagList>*> box,
+                      Invokable&& invokable, Args&&... args) noexcept {
   static_assert(
       tmpl2::flat_all_v<
           detail::has_unique_matching_tag_v<TagList, MutateTags>...>,
@@ -641,11 +651,6 @@ void mutate(const gsl::not_null<DataBox<TagList>*> box, Invokable&& invokable,
         "passed to the mutate function.");
   }
   box->mutate_locked_box_ = true;
-  invokable(
-      make_not_null(&box->template get_item<
-                            detail::first_matching_tag<TagList, MutateTags>>()
-                         .mutate())...,
-      std::forward<Args>(args)...);
   using mutate_tags_list =
       tmpl::list<detail::first_matching_tag<TagList, MutateTags>...>;
   // For all the tags in the DataBox, check if one of their subtags is
@@ -671,13 +676,41 @@ void mutate(const gsl::not_null<DataBox<TagList>*> box, Invokable&& invokable,
                                               tmpl::pin<full_mutated_items>,
                                               tmpl::get_source<tmpl::_1>>>,
                       tmpl::get_destination<tmpl::_1>>>;
+  if constexpr (not std::is_same_v<
+                    decltype(invokable(
+                        make_not_null(
+                            &box->template get_item<detail::first_matching_tag<
+                                 TagList, MutateTags>>()
+                                 .mutate())...,
+                        std::forward<Args>(args)...)),
+                    void>) {
+    decltype(auto) return_value = invokable(
+        make_not_null(&box->template get_item<
+                              detail::first_matching_tag<TagList, MutateTags>>()
+                           .mutate())...,
+        std::forward<Args>(args)...);
 
-  EXPAND_PACK_LEFT_TO_RIGHT(box->template mutate_mutable_subitems<MutateTags>(
-      typename Subitems<MutateTags>::type{}));
-  box->template reset_compute_items_after_mutate(
-      first_compute_items_to_reset{});
+    EXPAND_PACK_LEFT_TO_RIGHT(box->template mutate_mutable_subitems<MutateTags>(
+        typename Subitems<MutateTags>::type{}));
+    box->template reset_compute_items_after_mutate(
+        first_compute_items_to_reset{});
 
-  box->mutate_locked_box_ = false;
+    box->mutate_locked_box_ = false;
+    return return_value;
+  } else {
+    invokable(
+        make_not_null(&box->template get_item<
+                              detail::first_matching_tag<TagList, MutateTags>>()
+                           .mutate())...,
+        std::forward<Args>(args)...);
+
+    EXPAND_PACK_LEFT_TO_RIGHT(box->template mutate_mutable_subitems<MutateTags>(
+        typename Subitems<MutateTags>::type{}));
+    box->template reset_compute_items_after_mutate(
+        first_compute_items_to_reset{});
+
+    box->mutate_locked_box_ = false;
+  }
 }
 
 ////////////////////////////////////////////////////////////////
@@ -1072,7 +1105,7 @@ SPECTRE_ALWAYS_INLINE constexpr auto apply(const DataBox<BoxTags>& box,
 namespace detail {
 template <typename... ReturnTags, typename... ArgumentTags, typename F,
           typename BoxTags, typename... Args>
-SPECTRE_ALWAYS_INLINE constexpr void mutate_apply(
+SPECTRE_ALWAYS_INLINE constexpr decltype(auto) mutate_apply(
     F&& f, const gsl::not_null<db::DataBox<BoxTags>*> box,
     tmpl::list<ReturnTags...> /*meta*/, tmpl::list<ArgumentTags...> /*meta*/,
     Args&&... args) noexcept {
@@ -1084,12 +1117,12 @@ SPECTRE_ALWAYS_INLINE constexpr void mutate_apply(
   if constexpr (is_apply_callable_v<
                     F, const gsl::not_null<item_type<ReturnTags, BoxTags>*>...,
                     const_item_type<ArgumentTags, BoxTags>..., Args...>) {
-    ::db::mutate<ReturnTags...>(
+    return ::db::mutate<ReturnTags...>(
         box,
-        [
-        ](const gsl::not_null<item_type<ReturnTags, BoxTags>*>... mutated_items,
-          const_item_type<ArgumentTags, BoxTags>... args_items,
-          decltype(std::forward<Args>(args))... l_args) noexcept {
+        [](const gsl::not_null<
+               item_type<ReturnTags, BoxTags>*>... mutated_items,
+           const_item_type<ArgumentTags, BoxTags>... args_items,
+           decltype(std::forward<Args>(args))... l_args) noexcept {
           return std::decay_t<F>::apply(mutated_items..., args_items...,
                                         std::forward<Args>(l_args)...);
         },
@@ -1098,7 +1131,7 @@ SPECTRE_ALWAYS_INLINE constexpr void mutate_apply(
       ::tt::is_callable_v<
           F, const gsl::not_null<item_type<ReturnTags, BoxTags>*>...,
           const_item_type<ArgumentTags, BoxTags>..., Args...>) {
-    ::db::mutate<ReturnTags...>(
+    return ::db::mutate<ReturnTags...>(
         box,
         [&f](const gsl::not_null<
                  item_type<ReturnTags, BoxTags>*>... mutated_items,
@@ -1132,6 +1165,9 @@ SPECTRE_ALWAYS_INLINE constexpr void mutate_apply(
  * `argument_tags` typelists, these are used for the `MutateTags` and
  * `ArgumentTags`, respectively.
  *
+ * Any return values of the invokable `f` are forwarded as returns to the
+ * `mutate_apply` call.
+ *
  * \example
  * An example of using `mutate_apply` with a lambda:
  * \snippet Test_DataBox.cpp mutate_apply_lambda_example
@@ -1154,28 +1190,28 @@ SPECTRE_ALWAYS_INLINE constexpr void mutate_apply(
  */
 template <typename MutateTags, typename ArgumentTags, typename F,
           typename BoxTags, typename... Args>
-SPECTRE_ALWAYS_INLINE constexpr void mutate_apply(
+SPECTRE_ALWAYS_INLINE constexpr decltype(auto) mutate_apply(
     F&& f, const gsl::not_null<DataBox<BoxTags>*> box,
     Args&&... args) noexcept {
   detail::check_tags_are_in_databox(BoxTags{}, MutateTags{});
   detail::check_tags_are_in_databox(BoxTags{}, ArgumentTags{});
-  detail::mutate_apply(std::forward<F>(f), box, MutateTags{}, ArgumentTags{},
-                       std::forward<Args>(args)...);
+  return detail::mutate_apply(std::forward<F>(f), box, MutateTags{},
+                              ArgumentTags{}, std::forward<Args>(args)...);
 }
 
 template <typename F, typename BoxTags, typename... Args>
-SPECTRE_ALWAYS_INLINE constexpr void mutate_apply(
+SPECTRE_ALWAYS_INLINE constexpr decltype(auto) mutate_apply(
     F&& f, const gsl::not_null<DataBox<BoxTags>*> box,
     Args&&... args) noexcept {
-  mutate_apply<typename std::decay_t<F>::return_tags,
-               typename std::decay_t<F>::argument_tags>(
+  return mutate_apply<typename std::decay_t<F>::return_tags,
+                      typename std::decay_t<F>::argument_tags>(
       std::forward<F>(f), box, std::forward<Args>(args)...);
 }
 
 template <typename F, typename BoxTags, typename... Args>
-SPECTRE_ALWAYS_INLINE constexpr void mutate_apply(
+SPECTRE_ALWAYS_INLINE constexpr decltype(auto) mutate_apply(
     const gsl::not_null<DataBox<BoxTags>*> box, Args&&... args) noexcept {
-  mutate_apply(F{}, box, std::forward<Args>(args)...);
+  return mutate_apply(F{}, box, std::forward<Args>(args)...);
 }
 // @}
 }  // namespace db


### PR DESCRIPTION
## Proposed 

The return is forwarded from the internal invokable to the return value of the mutate/mutate_apply.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
