### PR TITLE
Update dox for MutableGlobalCache.

### DIFF
--- a/docs/DevGuide/Parallelization.md
+++ b/docs/DevGuide/Parallelization.md
@@ -654,8 +654,8 @@ then it can be used.  `Parallel::mutable_cache_item_is_ready` takes a
 lambda as an argument.  This lambda is passed a single argument: a
 const reference to the item being retrieved.  The lambda should
 determine whether the item is up-to-date. If so, it should return a
-default_constructed `std::optional<CkCallback>`; if not, it should
-return a `std::optional<CkCallback>` to a callback function that will
+default_constructed `std::unique_ptr<Parallel::Callback>`; if not, it should
+return a `std::unique_ptr<Parallel::Callback>` to a callback function that will
 be called on the next `Parallel::mutate` of that item. The callback
 will typically check again if the item is up-to-date and if so will
 execute some code that gets the item via `Parallel::get`.
@@ -663,7 +663,10 @@ execute some code that gets the item via `Parallel::get`.
 For the case of iterable actions, `Parallel::mutable_cache_item_is_ready`
 is typically called from the `is_ready` function of the iterable action,
 and the callback is `perform_algorithm()`.  In the example below, the
-vector is considered up-to-date if it is non-empty:
+vector is considered up-to-date if it is non-empty. If the vector is not
+up-to-date, then when it becomes up-to-date the callback function will
+be invoked; in this case the callback function re-runs `perform_algorithm`,
+which will call the same `is_ready` function again.
 
 \snippet Test_AlgorithmGlobalCache.cpp check_mutable_cache_item_is_ready
 


### PR DESCRIPTION
Dox still mentioned CkCallback, not the new Parallel::Callback.

## Proposed changes

Updates documentation for MutableGlobalCache.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
