### PR TITLE
ScalarWave ConstraintPreservingSphericalRadiation and Periodic boundary conditions

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -120,6 +120,19 @@
   publisher = {Cambridge University Press}
 }
 
+@article{BaylissTurkel,
+  author =  {Bayliss, Alvin and Turkel, Eli},
+  title =   {Radiation boundary conditions for wave-like equations},
+  journal = {Communications on Pure and Applied Mathematics},
+  volume =  33,
+  number =  6,
+  pages =   {707-725},
+  doi =     {10.1002/cpa.3160330603},
+  url =     {https://onlinelibrary.wiley.com/doi/abs/10.1002/cpa.3160330603},
+  eprint =  {https://onlinelibrary.wiley.com/doi/pdf/10.1002/cpa.3160330603},
+  year =    1980
+}
+
 @article{Beckwith2011iy,
   author         = "Beckwith, Kris and Stone, James M.",
   title          = "A Second-order {Godunov} Method for Multi-dimensional
@@ -1054,6 +1067,16 @@
   doi =     {https://doi.org/10.1016/0021-9991(78)90023-2},
   url =     {https://www.sciencedirect.com/science/article/pii/0021999178900232},
   author =  {Gary A Sod},
+}
+
+@book{Sommerfeld1949,
+  author =    {Sommerfeld, Arnold},
+  title =     {Partial Differential Equations in Physics},
+  publisher = {Academic Press},
+  year =      1949,
+  isbn =      {978-0-12-654658-3},
+  doi =       {10.1016/B978-0-12-654658-3.50001-X},
+  url = {https://www.sciencedirect.com/science/article/pii/B978012654658350001X}
 }
 
 @InProceedings{Sonntag2014,

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/BoundaryCondition.hpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/BoundaryCondition.hpp
@@ -11,6 +11,8 @@
 /// \cond
 namespace ScalarWave::BoundaryConditions {
 template <size_t Dim>
+class ConstraintPreservingSphericalRadiation;
+template <size_t Dim>
 class DirichletAnalytic;
 template <size_t Dim>
 class SphericalRadiation;
@@ -24,7 +26,8 @@ template <size_t Dim>
 class BoundaryCondition : public domain::BoundaryConditions::BoundaryCondition {
  public:
   using creatable_classes =
-      tmpl::list<DirichletAnalytic<Dim>, SphericalRadiation<Dim>>;
+      tmpl::list<ConstraintPreservingSphericalRadiation<Dim>,
+                 DirichletAnalytic<Dim>, SphericalRadiation<Dim>>;
 
   BoundaryCondition() = default;
   BoundaryCondition(BoundaryCondition&&) noexcept = default;

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/BoundaryCondition.hpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/BoundaryCondition.hpp
@@ -6,6 +6,7 @@
 #include <pup.h>
 
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -27,7 +28,9 @@ class BoundaryCondition : public domain::BoundaryConditions::BoundaryCondition {
  public:
   using creatable_classes =
       tmpl::list<ConstraintPreservingSphericalRadiation<Dim>,
-                 DirichletAnalytic<Dim>, SphericalRadiation<Dim>>;
+                 DirichletAnalytic<Dim>,
+                 domain::BoundaryConditions::Periodic<BoundaryCondition<Dim>>,
+                 SphericalRadiation<Dim>>;
 
   BoundaryCondition() = default;
   BoundaryCondition(BoundaryCondition&&) noexcept = default;

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/CMakeLists.txt
@@ -5,6 +5,7 @@ spectre_target_sources(
   ScalarWave
   PRIVATE
   BoundaryCondition.cpp
+  ConstraintPreservingSphericalRadiation.cpp
   DirichletAnalytic.cpp
   RegisterDerivedWithCharm.cpp
   SphericalRadiation.cpp
@@ -15,6 +16,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   BoundaryCondition.hpp
+  ConstraintPreservingSphericalRadiation.hpp
   DirichletAnalytic.hpp
   Factory.hpp
   RegisterDerivedWithCharm.hpp

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.cpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.cpp
@@ -1,0 +1,178 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Options/ParseOptions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+/// \cond
+namespace ScalarWave::BoundaryConditions {
+namespace detail {
+ConstraintPreservingSphericalRadiationType
+convert_constraint_preserving_spherical_radiation_type_from_yaml(
+    const Options::Option& options) {
+  const auto type_read = options.parse_as<std::string>();
+  if ("Sommerfeld" == type_read) {
+    return ConstraintPreservingSphericalRadiationType::Sommerfeld;
+  } else if ("FirstOrderBaylissTurkel" == type_read) {
+    return ConstraintPreservingSphericalRadiationType::FirstOrderBaylissTurkel;
+  } else if ("SecondOrderBaylissTurkel" == type_read) {
+    return ConstraintPreservingSphericalRadiationType::SecondOrderBaylissTurkel;
+  }
+  PARSE_ERROR(options.context(),
+              "Failed to convert \""
+                  << type_read
+                  << "\" to ConstraintPreservingSphericalRadiation::Type. Must "
+                     "be one of Sommerfeld, FirstOrderBaylissTurkel, or "
+                     "SecondOrderBaylissTurkel.");
+}
+}  // namespace detail
+
+template <size_t Dim>
+ConstraintPreservingSphericalRadiation<Dim>::
+    ConstraintPreservingSphericalRadiation(
+        const detail::ConstraintPreservingSphericalRadiationType type) noexcept
+    : type_(type) {}
+
+template <size_t Dim>
+ConstraintPreservingSphericalRadiation<Dim>::
+    ConstraintPreservingSphericalRadiation(CkMigrateMessage* const msg) noexcept
+    : BoundaryCondition<Dim>(msg) {}
+
+template <size_t Dim>
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+ConstraintPreservingSphericalRadiation<Dim>::get_clone() const noexcept {
+  return std::make_unique<ConstraintPreservingSphericalRadiation>(*this);
+}
+
+template <size_t Dim>
+void ConstraintPreservingSphericalRadiation<Dim>::pup(PUP::er& p) {
+  BoundaryCondition<Dim>::pup(p);
+  p | type_;
+}
+
+template <size_t Dim>
+std::optional<std::string>
+ConstraintPreservingSphericalRadiation<Dim>::dg_time_derivative(
+    const gsl::not_null<Scalar<DataVector>*> dt_pi_correction,
+    const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+        dt_phi_correction,
+    const gsl::not_null<Scalar<DataVector>*> dt_psi_correction,
+    const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+        face_mesh_velocity,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+    const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
+    const Scalar<DataVector>& psi,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& coords,
+    const Scalar<DataVector>& gamma2, const Scalar<DataVector>& dt_pi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& dt_phi,
+    const Scalar<DataVector>& dt_psi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& d_pi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& d_psi,
+    const tnsr::ij<DataVector, Dim, Frame::Inertial>& d_phi) const noexcept {
+  {
+    if (type_ ==
+        detail::ConstraintPreservingSphericalRadiationType::Sommerfeld) {
+      get(*dt_pi_correction) = -get(dt_pi);
+      for (size_t i = 0; i < Dim; ++i) {
+        get(*dt_pi_correction) += normal_covector.get(i) * dt_phi.get(i);
+      }
+    } else {
+      DataVector& inv_radius = get(*dt_psi_correction);
+      magnitude(dt_psi_correction, coords);
+      inv_radius = 1.0 / inv_radius;
+
+      if (type_ == detail::ConstraintPreservingSphericalRadiationType::
+                       FirstOrderBaylissTurkel) {
+        get(*dt_pi_correction) = -get(dt_pi) + inv_radius * get(dt_psi);
+        for (size_t i = 0; i < Dim; ++i) {
+          get(*dt_pi_correction) += normal_covector.get(i) * dt_phi.get(i);
+        }
+      } else {
+        // second-order Bayliss-Turkel
+        get(*dt_pi_correction) =
+            -get(dt_pi) -
+            2.0 * inv_radius * (2.0 * get(pi) - inv_radius * get(psi));
+        for (size_t i = 0; i < Dim; ++i) {
+          // Note: here we are handling `dt dr Psi` as `n^i dt Phi_i` and
+          // `dr dt Psi` as `-n^i d_i Pi`. The only thing we are assuming is
+          // that `d_r` is time-independent. This is why we have `n^i (dt Phi_i
+          // - d_i Pi)` instead of `2 n^i dt Phi_i`.
+          get(*dt_pi_correction) +=
+              normal_covector.get(i) *
+              (dt_phi.get(i) - d_pi.get(i) + 4.0 * inv_radius * phi.get(i));
+          for (size_t j = 0; j < Dim; ++j) {
+            get(*dt_pi_correction) += normal_covector.get(i) *
+                                      normal_covector.get(j) * d_phi.get(i, j);
+          }
+        }
+      }
+    }
+  }
+  if (face_mesh_velocity.has_value()) {
+    // Compute dt psi correction
+    get(*dt_psi_correction) =
+        get<0>(normal_covector) * (get<0>(d_psi) - get<0>(phi));
+    for (size_t i = 1; i < Dim; ++i) {
+      get(*dt_psi_correction) +=
+          normal_covector.get(i) * (d_psi.get(i) - phi.get(i));
+    }
+    const auto negative_lambda0 =
+        dot_product(normal_covector, *face_mesh_velocity);
+    get(*dt_psi_correction) *= -get(negative_lambda0);
+    get(*dt_pi_correction) += get(gamma2) * get(*dt_psi_correction);
+
+    // Compute dt Phi 2-index constraint correction
+    for (size_t i = 0; i < Dim; ++i) {
+      dt_phi_correction->get(i) =
+          get<0>(normal_covector) * (d_phi.get(0, i) - d_phi.get(i, 0));
+      for (size_t j = 1; j < Dim; ++j) {
+        dt_phi_correction->get(i) +=
+            normal_covector.get(j) * (d_phi.get(j, i) - d_phi.get(i, j));
+      }
+      dt_phi_correction->get(i) *= -0.5 * get(negative_lambda0);
+    }
+    if (min(-get(negative_lambda0)) < 0.0) {
+      return {
+          "Incoming characteristic speeds for constraint preserving spherical "
+          "radiation boundary condition. It's unclear that proper boundary "
+          "conditions are imposed in this case. Please verify if you need this "
+          "feature."};
+    }
+  } else {
+    // Since the constraint-preserving terms are all multiplied by the
+    // characteristic speeds, when those speeds are zero there are no
+    // constraint-preserving terms to add.
+    get(*dt_psi_correction) = 0.0;
+    for (size_t i = 0; i < Dim; ++i) {
+      dt_phi_correction->get(i) = 0.0;
+    }
+  }
+  return {};
+}
+
+template <size_t Dim>
+// NOLINTNEXTLINE
+PUP::able::PUP_ID ConstraintPreservingSphericalRadiation<Dim>::my_PUP_ID = 0;
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data) \
+  template class ConstraintPreservingSphericalRadiation<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM
+}  // namespace ScalarWave::BoundaryConditions
+/// \endcond

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.hpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.hpp
@@ -1,0 +1,267 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <pup.h>
+#include <string>
+#include <type_traits>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/Systems/ScalarWave/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/AnalyticData/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace domain::Tags {
+template <size_t Dim, typename Frame>
+struct Coordinates;
+}  // namespace domain::Tags
+/// \endcond
+
+namespace ScalarWave::BoundaryConditions {
+namespace detail {
+/// The type of spherical radiation boundary condition to impose
+enum class ConstraintPreservingSphericalRadiationType {
+  /// Impose \f$(\partial_t + \partial_r)\Psi=0\f$
+  Sommerfeld,
+  /// Impose \f$(\partial_t + \partial_r + r^{-1})\Psi=0\f$
+  FirstOrderBaylissTurkel,
+  /// Imposes a second-order Bayliss-Turkel boundary condition
+  SecondOrderBaylissTurkel
+};
+
+ConstraintPreservingSphericalRadiationType
+convert_constraint_preserving_spherical_radiation_type_from_yaml(
+    const Options::Option& options);
+}  // namespace detail
+
+/*!
+ * \brief Constraint-preserving spherical radiation boundary condition that
+ * seeks to avoid ingoing constraint violations and radiation.
+ *
+ * The constraint-preserving part of the boundary condition imposes the
+ * following condition on the time derivatives of the characteristic fields:
+ *
+ * \f{align*}{
+ *   d_tw^\Psi&\to d_tw^{\Psi}+\lambda_{\Psi}n^i\mathcal{C}_i, \\
+ *   d_tw^0_i&\to d_tw^{0}_i+\lambda_{0}n^jP^k_i\mathcal{C}_{ik},
+ * \f}
+ *
+ * where
+ *
+ * \f{align*}{
+ * P^k{}_i=\delta^k_i-n^kn_i
+ * \f}
+ *
+ * projects a tensor onto the spatial surface to which \f$n_i\f$ is normal, and
+ * \f$d_t w\f$ is the evolved to characteristic field transformation applied to
+ * the time derivatives of the evolved fields. That is,
+ *
+ * \f{align*}{
+ * d_t w^\Psi&=\partial_t \Psi, \\
+ * d_t w_i^0&=(\delta^k_i-n^k n_i)\partial_t \Phi_k, \\
+ * d_t w^{\pm}&=\partial_t\Pi\pm n^k\partial_t\Phi_k - \gamma_2\partial_t\Psi.
+ * \f}
+ *
+ * The constraints are defined as:
+ *
+ * \f{align*}{
+ *  \mathcal{C}_i&=\partial_i\Psi - \Phi_i=0, \\
+ *  \mathcal{C}_{ij}&=\partial_{[i}\Phi_{j]}=0
+ * \f}
+ *
+ * Radiation boundary conditions impose a condition on \f$\Pi\f$ or its time
+ * derivative. We denote the boundary condition value of the time derivative of
+ * \f$\Pi\f$ by \f$\partial_t\Pi^{\mathrm{BC}}\f$. With this, we can impose
+ * boundary conditions on the time derivatives of the evolved variables as
+ * follows:
+ *
+ * \f{align*}{
+ * \partial_{t} \Psi&\to\partial_{t}\Psi +
+ *                    \lambda_\Psi n^i \mathcal{C}_i, \\
+ * \partial_{t}\Pi&\to\partial_{t}\Pi-\left(\partial_t\Pi
+ *                  - \partial_t\Pi^{\mathrm{BC}}\right)
+ *                  +\gamma_2\lambda_\Psi n^i \mathcal{C}_i
+ *                  =\partial_t\Pi^{\mathrm{BC}}
+ *                  +\gamma_2\lambda_\Psi n^i \mathcal{C}_i, \\
+ * \partial_{t}\Phi_i&\to\partial_{t}\Phi_i+
+ *                     \lambda_0n^jP^k{}_i\mathcal{C}_{jk}
+ *   = \partial_{t}\Phi_i+ \lambda_0n^j \mathcal{C}_{ji}.
+ * \f}
+ *
+ * Below we assume the normal vector \f$n^i\f$ is the radial unit normal vector.
+ * That is, we assume the outer boundary is spherical. A Sommerfeld
+ * \cite Sommerfeld1949 radiation condition is given by
+ *
+ * \f{align*}{
+ *  \partial_t\Psi=n^i\Phi_i
+ * \f}
+ *
+ * Or, assuming that \f$\partial_tn^i=0\f$ (or is very small),
+ *
+ * \f{align*}{
+ *  \partial_t\Pi^{\mathrm{BC}}=n^i\partial_t\Phi_i
+ * \f}
+ *
+ * The Bayliss-Turkel \cite BaylissTurkel boundary conditions are given by:
+ *
+ * \f{align*}{
+ *  \left(\partial_t + \partial_r + r^{-1}\right)^m\Psi=0
+ * \f}
+ *
+ * The first-order form is
+ *
+ * \f{align*}{
+ *  \partial_t\Pi^{\mathrm{BC}}=n^i\partial_t\Phi_i + \frac{1}{r}\partial_t\Psi,
+ * \f}
+ *
+ * assuming \f$\partial_t n^i=0\f$ and \f$\partial_t r=0\f$.
+ *
+ * The second-order boundary condition is given by,
+ *
+ * \f{align*}{
+ *  \partial_t\Pi^{\mathrm{BC}}
+ *   &=\left(\partial_t\partial_r + \partial_r\partial_t +
+ *     \partial_r^2+\frac{4}{r}\partial_t
+ *     +\frac{4}{r}\partial_r + \frac{2}{r^2}\right)\Psi \notag \\
+ *     &=n^i(\partial_t\Phi_i-\partial_i\Pi) + n^i n^j\partial_i\Phi_j -
+ *     \frac{4}{r}\Pi+\frac{4}{r}n^i\Phi_i + \frac{2}{r^2}\Psi,
+ * \f}
+ *
+ * assuming \f$\partial_t n^i=0\f$ and \f$\partial_t r=0\f$.
+ *
+ * The moving mesh can be accounted for by using
+ *
+ * \f{align*}{
+ * \partial_t r = \frac{1}{r}x^i\delta_{ij}\partial_t x^j
+ * \f}
+ *
+ * \note It is not clear if \f$\partial_t\Phi_i\f$ should be replaced by
+ * \f$-\partial_i\Pi\f$, which is the evolution equation but without the
+ * constraint.
+ *
+ * \note On a moving mesh the characteristic speeds change according to
+ * \f$\lambda\to\lambda-v^i_gn_i\f$ where \f$v^i_g\f$ is the mesh velocity.
+ *
+ * \note For the scalar wave system \f$\lambda_0 = \lambda_\psi\f$
+ *
+ * \warning The boundary conditions are implemented assuming the outer boundary
+ * is spherical. It might be possible to generalize the condition to
+ * non-spherical boundaries by using \f$x^i/r\f$ instead of \f$n^i\f$, but this
+ * hasn't been tested.
+ */
+template <size_t Dim>
+class ConstraintPreservingSphericalRadiation final
+    : public BoundaryCondition<Dim> {
+ public:
+  struct TypeOptionTag {
+    using type = detail::ConstraintPreservingSphericalRadiationType;
+    static std::string name() noexcept { return "Type"; }
+    static constexpr Options::String help{
+        "Whether to impose Sommerfeld, first-order Bayliss-Turkel, or "
+        "second-order Bayliss-Turkel spherical radiation boundary conditions."};
+  };
+
+  using options = tmpl::list<TypeOptionTag>;
+  static constexpr Options::String help{
+      "Constraint-preserving spherical radiation boundary conditions setting "
+      "the time derivatives of Psi, Phi, and Pi to avoid incoming constraint "
+      "violations, and imposing radiation boundary conditions."};
+
+  ConstraintPreservingSphericalRadiation(
+      detail::ConstraintPreservingSphericalRadiationType type) noexcept;
+
+  ConstraintPreservingSphericalRadiation() = default;
+  /// \cond
+  ConstraintPreservingSphericalRadiation(
+      ConstraintPreservingSphericalRadiation&&) noexcept = default;
+  ConstraintPreservingSphericalRadiation& operator=(
+      ConstraintPreservingSphericalRadiation&&) noexcept = default;
+  ConstraintPreservingSphericalRadiation(
+      const ConstraintPreservingSphericalRadiation&) = default;
+  ConstraintPreservingSphericalRadiation& operator=(
+      const ConstraintPreservingSphericalRadiation&) = default;
+  /// \endcond
+  ~ConstraintPreservingSphericalRadiation() override = default;
+
+  explicit ConstraintPreservingSphericalRadiation(
+      CkMigrateMessage* msg) noexcept;
+
+  WRAPPED_PUPable_decl_base_template(
+      domain::BoundaryConditions::BoundaryCondition,
+      ConstraintPreservingSphericalRadiation);
+
+  auto get_clone() const noexcept -> std::unique_ptr<
+      domain::BoundaryConditions::BoundaryCondition> override;
+
+  static constexpr evolution::BoundaryConditions::Type bc_type =
+      evolution::BoundaryConditions::Type::TimeDerivative;
+
+  void pup(PUP::er& p) override;
+
+  using dg_interior_evolved_variables_tags =
+      tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>;
+  using dg_interior_temporary_tags =
+      tmpl::list<domain::Tags::Coordinates<Dim, Frame::Inertial>,
+                 Tags::ConstraintGamma2>;
+  using dg_interior_dt_vars_tags =
+      tmpl::list<::Tags::dt<ScalarWave::Pi>, ::Tags::dt<ScalarWave::Phi<Dim>>,
+                 ::Tags::dt<ScalarWave::Psi>>;
+  using dg_interior_deriv_vars_tags = tmpl::list<
+      ::Tags::deriv<ScalarWave::Pi, tmpl::size_t<Dim>, Frame::Inertial>,
+      ::Tags::deriv<ScalarWave::Psi, tmpl::size_t<Dim>, Frame::Inertial>,
+      ::Tags::deriv<ScalarWave::Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>>;
+  using dg_gridless_tags = tmpl::list<>;
+
+  std::optional<std::string> dg_time_derivative(
+      gsl::not_null<Scalar<DataVector>*> dt_pi_correction,
+      gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+          dt_phi_correction,
+      gsl::not_null<Scalar<DataVector>*> dt_psi_correction,
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+          face_mesh_velocity,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+      const Scalar<DataVector>& pi,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
+      const Scalar<DataVector>& psi,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& coords,
+      const Scalar<DataVector>& gamma2, const Scalar<DataVector>& dt_pi,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& dt_phi,
+      const Scalar<DataVector>& dt_psi,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& d_pi,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& d_psi,
+      const tnsr::ij<DataVector, Dim, Frame::Inertial>& d_phi) const noexcept;
+
+ private:
+  detail::ConstraintPreservingSphericalRadiationType type_{
+      detail::ConstraintPreservingSphericalRadiationType::Sommerfeld};
+};
+}  // namespace ScalarWave::BoundaryConditions
+
+template <>
+struct Options::create_from_yaml<
+    ScalarWave::BoundaryConditions::detail::
+        ConstraintPreservingSphericalRadiationType> {
+  template <typename Metavariables>
+  static typename ScalarWave::BoundaryConditions::detail::
+      ConstraintPreservingSphericalRadiationType
+      create(const Options::Option& options) {
+    return ScalarWave::BoundaryConditions::detail::
+        convert_constraint_preserving_spherical_radiation_type_from_yaml(
+            options);
+  }
+};

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/Factory.hpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/Factory.hpp
@@ -4,5 +4,6 @@
 #pragma once
 
 #include "Evolution/Systems/ScalarWave/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/ScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.hpp"
 #include "Evolution/Systems/ScalarWave/BoundaryConditions/DirichletAnalytic.hpp"
 #include "Evolution/Systems/ScalarWave/BoundaryConditions/SphericalRadiation.hpp"

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/RegisterDerivedWithCharm.cpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/RegisterDerivedWithCharm.cpp
@@ -4,6 +4,7 @@
 #include "Evolution/Systems/ScalarWave/BoundaryConditions/RegisterDerivedWithCharm.hpp"
 
 #include "Evolution/Systems/ScalarWave/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/ScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.hpp"
 #include "Evolution/Systems/ScalarWave/BoundaryConditions/DirichletAnalytic.hpp"
 #include "Evolution/Systems/ScalarWave/BoundaryConditions/SphericalRadiation.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"

--- a/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.py
+++ b/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.py
@@ -1,0 +1,73 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def error(face_mesh_velocity, outward_directed_normal_covector, pi, phi, psi,
+          coords, interior_gamma2, dt_pi, dt_phi, dt_psi, d_pi, d_psi, d_phi):
+    if not face_mesh_velocity is None and -np.dot(
+            face_mesh_velocity, outward_directed_normal_covector) < 0.0:
+        return ("Incoming characteristic speeds for constraint preserving "
+                "spherical radiation boundary.*")
+    return None
+
+
+def _dt_psi(face_mesh_velocity, outward_directed_normal_covector, phi, d_psi):
+    if face_mesh_velocity is None:
+        return 0.0
+
+    return -np.dot(outward_directed_normal_covector,
+                   face_mesh_velocity) * np.dot(
+                       outward_directed_normal_covector, d_psi - phi)
+
+
+def dt_pi_Sommerfeld(face_mesh_velocity, outward_directed_normal_covector, pi,
+                     phi, psi, coords, interior_gamma2, dt_pi, dt_phi, dt_psi,
+                     d_pi, d_psi, d_phi):
+    return -dt_pi + np.dot(
+        outward_directed_normal_covector, dt_phi) + interior_gamma2 * _dt_psi(
+            face_mesh_velocity, outward_directed_normal_covector, phi, d_psi)
+
+
+def dt_pi_FirstOrderBaylissTurkel(face_mesh_velocity,
+                                  outward_directed_normal_covector, pi, phi,
+                                  psi, coords, interior_gamma2, dt_pi, dt_phi,
+                                  dt_psi, d_pi, d_psi, d_phi):
+    radius = np.sqrt(np.dot(coords, coords))
+    return -dt_pi + np.dot(
+        outward_directed_normal_covector,
+        dt_phi) + dt_psi / radius + interior_gamma2 * _dt_psi(
+            face_mesh_velocity, outward_directed_normal_covector, phi, d_psi)
+
+
+def dt_pi_SecondOrderBaylissTurkel(face_mesh_velocity,
+                                   outward_directed_normal_covector, pi, phi,
+                                   psi, coords, interior_gamma2, dt_pi, dt_phi,
+                                   dt_psi, d_pi, d_psi, d_phi):
+    radius = np.sqrt(np.dot(coords, coords))
+    return -dt_pi + (
+        np.dot(outward_directed_normal_covector, dt_phi - d_pi) + np.einsum(
+            "i,j,ij->", outward_directed_normal_covector,
+            outward_directed_normal_covector, d_phi) - 4.0 / radius * pi +
+        4.0 / radius * np.dot(outward_directed_normal_covector, phi) +
+        2.0 * psi / radius**2) + interior_gamma2 * _dt_psi(
+            face_mesh_velocity, outward_directed_normal_covector, phi, d_psi)
+
+
+def dt_phi(face_mesh_velocity, outward_directed_normal_covector, pi, phi, psi,
+           coords, interior_gamma2, dt_pi, dt_phi, dt_psi, d_pi, d_psi, d_phi):
+    if face_mesh_velocity is None:
+        return 0.0 * dt_phi
+
+    return -np.dot(outward_directed_normal_covector,
+                   face_mesh_velocity) * 0.5 * np.einsum(
+                       "i, ij->j", outward_directed_normal_covector,
+                       d_phi - np.transpose(d_phi))
+
+
+def dt_psi(face_mesh_velocity, outward_directed_normal_covector, pi, phi, psi,
+           coords, interior_gamma2, dt_pi, dt_phi, dt_psi, d_pi, d_psi, d_phi):
+    assert interior_gamma2 >= 0.0  # make sure random gamma_2 is positive
+    return _dt_psi(face_mesh_velocity, outward_directed_normal_covector, phi,
+                   d_psi)

--- a/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/Test_ConstraintPreservingSphericalRadiation.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/Test_ConstraintPreservingSphericalRadiation.cpp
@@ -1,0 +1,64 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Index.hpp"
+#include "Evolution/Systems/ScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.hpp"
+#include "Evolution/Systems/ScalarWave/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/ScalarWave/BoundaryCorrections/UpwindPenalty.hpp"
+#include "Evolution/Systems/ScalarWave/System.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace helpers = TestHelpers::evolution::dg;
+
+namespace {
+template <size_t Dim>
+void test() {
+  CAPTURE(Dim);
+  MAKE_GENERATOR(gen);
+  for (const std::string& bc_string :
+       {"Sommerfeld", "FirstOrderBaylissTurkel", "SecondOrderBaylissTurkel"}) {
+    CAPTURE(bc_string);
+    helpers::test_boundary_condition_with_python<
+        ScalarWave::BoundaryConditions::ConstraintPreservingSphericalRadiation<
+            Dim>,
+        ScalarWave::BoundaryConditions::BoundaryCondition<Dim>,
+        ScalarWave::System<Dim>,
+        tmpl::list<ScalarWave::BoundaryCorrections::UpwindPenalty<Dim>>>(
+        make_not_null(&gen), "ConstraintPreservingSphericalRadiation",
+        tuples::TaggedTuple<
+            helpers::Tags::PythonFunctionForErrorMessage<>,
+            helpers::Tags::PythonFunctionName<::Tags::dt<ScalarWave::Psi>>,
+            helpers::Tags::PythonFunctionName<::Tags::dt<ScalarWave::Pi>>,
+            helpers::Tags::PythonFunctionName<
+                ::Tags::dt<ScalarWave::Phi<Dim>>>>{
+            "error", "dt_psi", "dt_pi_" + bc_string, "dt_phi"},
+        "ConstraintPreservingSphericalRadiation:\n"
+        "  Type: " +
+            bc_string,
+        Index<Dim - 1>{Dim == 1 ? 1 : 5}, db::DataBox<tmpl::list<>>{},
+        tuples::TaggedTuple<
+            helpers::Tags::Range<ScalarWave::Tags::ConstraintGamma2>>{
+            std::array{0.0, 1.0}});
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.ScalarWave.BoundaryConditions.ConstraintPreservingSphericalRadiation",
+    "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/ScalarWave/BoundaryConditions/"};
+  test<1>();
+  test<2>();
+  test<3>();
+}

--- a/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/Test_Periodic.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/Test_Periodic.cpp
@@ -1,0 +1,32 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "Domain/BoundaryConditions/Periodic.hpp"
+#include "Evolution/Systems/ScalarWave/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/ScalarWave/BoundaryConditions/Factory.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp"
+
+namespace helpers = TestHelpers::evolution::dg;
+
+namespace {
+template <size_t Dim>
+void test() {
+  CAPTURE(Dim);
+  helpers::test_periodic_condition<
+      domain::BoundaryConditions::Periodic<
+          ScalarWave::BoundaryConditions::BoundaryCondition<Dim>>,
+      ScalarWave::BoundaryConditions::BoundaryCondition<Dim>>("Periodic:\n");
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ScalarWave.BoundaryConditions.Periodic",
+                  "[Unit][Evolution]") {
+  test<1>();
+  test<2>();
+  test<3>();
+}

--- a/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY Test_ScalarWave)
 set(LIBRARY_SOURCES
   BoundaryConditions/Test_ConstraintPreservingSphericalRadiation.cpp
   BoundaryConditions/Test_DirichletAnalytic.cpp
+  BoundaryConditions/Test_Periodic.cpp
   BoundaryConditions/Test_SphericalRadiation.cpp
   BoundaryCorrections/Test_UpwindPenalty.cpp
   Test_Characteristics.cpp

--- a/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY Test_ScalarWave)
 
 set(LIBRARY_SOURCES
+  BoundaryConditions/Test_ConstraintPreservingSphericalRadiation.cpp
   BoundaryConditions/Test_DirichletAnalytic.cpp
   BoundaryConditions/Test_SphericalRadiation.cpp
   BoundaryCorrections/Test_UpwindPenalty.cpp


### PR DESCRIPTION
## Proposed changes

- Add constraint-preserving spherical radiation boundary conditions. These are basically Sommerfeld or Bayliss-Turkel combined with the constraint-preserving boundary condition.
- Periodic boundary condition :shrug: 

These are the last system-specific boundary conditions I have on my branch. The only remaining thing is the addition to the `ComptueTimeDerivative` action to apply the boundary condition.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
