### PR TITLE
Template YlmSpherepack interpolation so it can use DataVectors and doubles

### DIFF
--- a/src/ApparentHorizons/Strahlkorper.cpp
+++ b/src/ApparentHorizons/Strahlkorper.cpp
@@ -115,9 +115,9 @@ double Strahlkorper<Frame>::average_radius() const noexcept {
 }
 
 template <typename Frame>
-double Strahlkorper<Frame>::radius(const double theta, const double phi) const
-    noexcept {
-  return ylm_.interpolate_from_coefs(strahlkorper_coefs_, {{{theta, phi}}})[0];
+double Strahlkorper<Frame>::radius(const double theta,
+                                   const double phi) const noexcept {
+  return ylm_.interpolate_from_coefs<double>(strahlkorper_coefs_, {theta, phi});
 }
 
 template <typename Frame>

--- a/src/ApparentHorizons/YlmSpherepack.cpp
+++ b/src/ApparentHorizons/YlmSpherepack.cpp
@@ -638,11 +638,12 @@ YlmSpherepack::InterpolationInfo<T> YlmSpherepack::set_up_interpolation_info(
     // First do m=0.
     size_t idx = 0;
     for (size_t n = n_theta_ - 1; n > 0; --n, ++idx) {
-      const double tnp1 = 2.0 * n + 1;
-      const double np1sq = n * n + 2.0 * n + 1.0;
+      const auto n_dbl = static_cast<double>(n);
+      const double tnp1 = 2.0 * n_dbl + 1;
+      const double np1sq = n_dbl * n_dbl + 2.0 * n_dbl + 1.0;
       alpha[idx] = sqrt(tnp1 * (tnp1 + 2.0) / np1sq);
-      beta[idx] = -sqrt((tnp1 + 4.0) / tnp1 * np1sq / (np1sq + 2 * n + 3));
-      index[idx] = n * l1;
+      beta[idx] = -sqrt((tnp1 + 4.0) / tnp1 * np1sq / (np1sq + 2 * n_dbl + 3));
+      index[idx] = n_dbl * l1;
     }
     // The next value of beta stores beta(n=1,m=0).
     // The next value of alpha stores Pbar(n=1,m=0)/(x*Pbar(n=0,m=0)).
@@ -915,8 +916,8 @@ DataVector YlmSpherepack::prolong_or_restrict(
   ASSERT(spectral_coefs.size() == spectral_size(),
          "Expecting " << spectral_size() << ", got " << spectral_coefs.size());
   DataVector result(target.spectral_size(), 0.0);
-  SpherepackIterator src_it(l_max_, m_max_),
-      dest_it(target.l_max_, target.m_max_);
+  SpherepackIterator src_it(l_max_, m_max_);
+  SpherepackIterator dest_it(target.l_max_, target.m_max_);
   for (; dest_it; ++dest_it) {
     if (dest_it.l() <= src_it.l_max() and dest_it.m() <= src_it.m_max()) {
       src_it.set(dest_it.l(), dest_it.m(), dest_it.coefficient_array());

--- a/tests/Unit/ApparentHorizons/Test_YlmSpherepack.cpp
+++ b/tests/Unit/ApparentHorizons/Test_YlmSpherepack.cpp
@@ -6,7 +6,6 @@
 #include <array>
 #include <cmath>
 #include <cstddef>
-#include <memory>
 #include <random>
 #include <utility>
 #include <vector>
@@ -14,7 +13,6 @@
 #include "ApparentHorizons/YlmSpherepack.hpp"
 #include "ApparentHorizons/YlmSpherepackHelper.hpp"
 #include "DataStructures/DataVector.hpp"
-#include "DataStructures/Tensor/Tensor.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/ApparentHorizons/YlmTestFunctions.hpp"
 #include "Utilities/Gsl.hpp"
@@ -64,7 +62,8 @@ void test_loop_over_offset(
   // Fill data vectors
   const size_t physical_size = ylm_spherepack.physical_size() * physical_stride;
   const size_t spectral_size = ylm_spherepack.spectral_size() * physical_stride;
-  DataVector u(physical_size), u_spec(spectral_size);
+  DataVector u(physical_size);
+  DataVector u_spec(spectral_size);
 
   // Fill analytic solution
   const std::vector<double>& theta = ylm_spherepack.theta_points();
@@ -100,7 +99,9 @@ void test_loop_over_offset(
 
   // Test gradient
   {
-    std::vector<std::vector<double>> duteststor(2), dustor(2), duSpecstor(2);
+    std::vector<std::vector<double>> duteststor(2);
+    std::vector<std::vector<double>> dustor(2);
+    std::vector<std::vector<double>> duSpecstor(2);
     for (size_t i = 0; i < 2; ++i) {
       dustor[i].resize(physical_size);
       duteststor[i].resize(physical_size);
@@ -186,7 +187,8 @@ void test_phys_to_spec(const size_t l_max, const size_t m_max,
   const auto& theta = ylm_spherepack.theta_points();
   const auto& phi = ylm_spherepack.phi_points();
 
-  DataVector u(physical_size), u_spec(spectral_size);
+  DataVector u(physical_size);
+  DataVector u_spec(spectral_size);
 
   // Fill with analytic function
   func.func(&u, physical_stride, 0, theta, phi);
@@ -197,7 +199,8 @@ void test_phys_to_spec(const size_t l_max, const size_t m_max,
 
   // Test whether phys_to_spec and spec_to_phys are inverses.
   {
-    std::vector<double> u_test(physical_size), u_spec_test(spectral_size);
+    std::vector<double> u_test(physical_size);
+    std::vector<double> u_spec_test(spectral_size);
     ylm_spherepack.phys_to_spec(u_spec_test.data(), u.data(), physical_stride,
                                 0, spectral_stride, 0);
     ylm_spherepack.spec_to_phys(u_test.data(), u_spec.data(), spectral_stride,
@@ -230,7 +233,8 @@ void test_gradient(const size_t l_max, const size_t m_max,
   const auto& theta = ylm_spherepack.theta_points();
   const auto& phi = ylm_spherepack.phi_points();
 
-  DataVector u(physical_size), u_spec(spectral_size);
+  DataVector u(physical_size);
+  DataVector u_spec(spectral_size);
 
   // Fill with analytic function
   func.func(&u, physical_stride, 0, theta, phi);
@@ -241,7 +245,9 @@ void test_gradient(const size_t l_max, const size_t m_max,
 
   // Test gradient
   {
-    std::vector<std::vector<double>> duteststor(2), dustor(2), duSpecstor(2);
+    std::vector<std::vector<double>> duteststor(2);
+    std::vector<std::vector<double>> dustor(2);
+    std::vector<std::vector<double>> duSpecstor(2);
     for (size_t i = 0; i < 2; ++i) {
       dustor[i].resize(physical_size);
       duteststor[i].resize(physical_size);
@@ -322,7 +328,8 @@ void test_second_derivative(
   const auto& theta = ylm_spherepack.theta_points();
   const auto& phi = ylm_spherepack.phi_points();
 
-  DataVector u(physical_size), u_spec(spectral_size);
+  DataVector u(physical_size);
+  DataVector u_spec(spectral_size);
 
   // Fill with analytic function
   func.func(&u, physical_stride, 0, theta, phi);
@@ -333,7 +340,8 @@ void test_second_derivative(
 
   // Test second_derivative
   {
-    SecondDeriv ddu(physical_size), ddutest(physical_size);
+    SecondDeriv ddu(physical_size);
+    SecondDeriv ddutest(physical_size);
 
     std::vector<std::vector<double>> dustor(2);
     for (size_t i = 0; i < 2; ++i) {
@@ -388,7 +396,8 @@ void test_scalar_laplacian(
   const auto& theta = ylm_spherepack.theta_points();
   const auto& phi = ylm_spherepack.phi_points();
 
-  DataVector u(physical_size), u_spec(spectral_size);
+  DataVector u(physical_size);
+  DataVector u_spec(spectral_size);
 
   // Fill with analytic function
   func.func(&u, physical_stride, 0, theta, phi);
@@ -399,8 +408,9 @@ void test_scalar_laplacian(
 
   // Test scalar_laplacian
   {
-    DataVector slaptest(physical_size), slap(physical_size),
-        slapSpec(physical_size);
+    DataVector slaptest(physical_size);
+    DataVector slap(physical_size);
+    DataVector slapSpec(physical_size);
 
     // Differentiate
     ylm_spherepack.scalar_laplacian(slap.data(), u.data(), physical_stride, 0);
@@ -442,7 +452,8 @@ void test_interpolation(
   const auto& theta = ylm_spherepack.theta_points();
   const auto& phi = ylm_spherepack.phi_points();
 
-  DataVector u(physical_size), u_spec(spectral_size);
+  DataVector u(physical_size);
+  DataVector u_spec(spectral_size);
 
   // Fill with analytic function
   func.func(&u, physical_stride, 0, theta, phi);
@@ -560,7 +571,8 @@ void test_integral(const size_t l_max, const size_t m_max,
   const auto& theta = ylm_spherepack.theta_points();
   const auto& phi = ylm_spherepack.phi_points();
 
-  DataVector u(physical_size), u_spec(spectral_size);
+  DataVector u(physical_size);
+  DataVector u_spec(spectral_size);
 
   // Fill with analytic function
   func.func(&u, physical_stride, 0, theta, phi);


### PR DESCRIPTION
The interface of YlmSpherepack is changed so that the interpolation now acts on `std::array<T, 2>` instead of `std::vector<std::array<double, 2>>`, where T will usually be `DataVector` or `double`. 

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions
The interpolation functions of YlmSpherepack now need to be called with `DataVector` or `double`
<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
