### PR TITLE
Add function to compute FD mesh from DG mesh

### DIFF
--- a/src/Evolution/DgSubcell/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/CMakeLists.txt
@@ -12,6 +12,7 @@ spectre_target_headers(
   ActiveGrid.hpp
   DgSubcell.hpp
   Matrices.hpp
+  Mesh.hpp
   Projection.hpp
   )
 
@@ -20,6 +21,7 @@ spectre_target_sources(
   PRIVATE
   ActiveGrid.cpp
   Matrices.cpp
+  Mesh.cpp
   Projection.cpp
   )
 

--- a/src/Evolution/DgSubcell/Mesh.cpp
+++ b/src/Evolution/DgSubcell/Mesh.cpp
@@ -1,0 +1,40 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/DgSubcell/Mesh.hpp"
+
+#include <array>
+#include <cstddef>
+
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace evolution::dg::subcell::fd {
+template <size_t Dim>
+Mesh<Dim> mesh(const Mesh<Dim>& dg_mesh) noexcept {
+  ASSERT(dg_mesh.basis() == make_array<Dim>(Spectral::Basis::Legendre) or
+             dg_mesh.basis() == make_array<Dim>(Spectral::Basis::Chebyshev),
+         "The DG basis for computing the subcell mesh must be Legendre or "
+         "Chebyshev but got DG mesh"
+             << dg_mesh);
+  ASSERT(dg_mesh.quadrature() == make_array<Dim>(Spectral::Quadrature::Gauss) or
+             dg_mesh.quadrature() ==
+                 make_array<Dim>(Spectral::Quadrature::GaussLobatto),
+         "The DG quadrature for computing the subcell mesh must be Gauss or "
+         "GaussLobatto but got DG mesh"
+             << dg_mesh);
+  std::array<size_t, Dim> extents{};
+  for (size_t d = 0; d < Dim; ++d) {
+    gsl::at(extents, d) = 2 * dg_mesh.extents(d) - 1;
+  }
+  return Mesh<Dim>{extents, Spectral::Basis::FiniteDifference,
+                   Spectral::Quadrature::CellCentered};
+}
+
+template Mesh<1> mesh(const Mesh<1>& dg_mesh) noexcept;
+template Mesh<2> mesh(const Mesh<2>& dg_mesh) noexcept;
+template Mesh<3> mesh(const Mesh<3>& dg_mesh) noexcept;
+}  // namespace evolution::dg::subcell::fd

--- a/src/Evolution/DgSubcell/Mesh.hpp
+++ b/src/Evolution/DgSubcell/Mesh.hpp
@@ -1,0 +1,21 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+/// \cond
+template <size_t Dim>
+class Mesh;
+/// \endcond
+
+namespace evolution::dg::subcell::fd {
+/*!
+ * \brief Computes the cell-centered finite-difference mesh from the DG mesh,
+ * using \f$2N-1\f$ grid points per dimension, where \f$N\f$ is the degree of
+ * the DG basis.
+ */
+template <size_t Dim>
+Mesh<Dim> mesh(const Mesh<Dim>& dg_mesh) noexcept;
+}  // namespace evolution::dg::subcell::fd

--- a/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
+++ b/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_DgSubcell")
 set(LIBRARY_SOURCES
   Test_ActiveGrid.cpp
   Test_Matrices.cpp
+  Test_Mesh.cpp
   Test_Projection.cpp
   Test_Tags.cpp
   )

--- a/tests/Unit/Evolution/DgSubcell/Test_Mesh.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Mesh.cpp
@@ -1,0 +1,48 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+
+namespace {
+template <Spectral::Basis BasisType, Spectral::Quadrature QuadratureType>
+void test_mesh() noexcept {
+  constexpr size_t min_num_pts =
+      Spectral::minimum_number_of_points<BasisType, QuadratureType>;
+  constexpr size_t max_num_pts = Spectral::maximum_number_of_points<BasisType>;
+  for (size_t i = min_num_pts; i < max_num_pts; ++i) {
+    CHECK(evolution::dg::subcell::fd::mesh(
+              Mesh<1>(i, BasisType, QuadratureType)) ==
+          Mesh<1>{2 * i - 1, Spectral::Basis::FiniteDifference,
+                  Spectral::Quadrature::CellCentered});
+    CHECK(evolution::dg::subcell::fd::mesh(
+              Mesh<2>(i, BasisType, QuadratureType)) ==
+          Mesh<2>{2 * i - 1, Spectral::Basis::FiniteDifference,
+                  Spectral::Quadrature::CellCentered});
+    CHECK(evolution::dg::subcell::fd::mesh(
+              Mesh<3>(i, BasisType, QuadratureType)) ==
+          Mesh<3>{2 * i - 1, Spectral::Basis::FiniteDifference,
+                  Spectral::Quadrature::CellCentered});
+  }
+  CHECK(evolution::dg::subcell::fd::mesh(
+            Mesh<2>({{4, 6}}, BasisType, QuadratureType)) ==
+        Mesh<2>{{{7, 11}},
+                Spectral::Basis::FiniteDifference,
+                Spectral::Quadrature::CellCentered});
+  CHECK(evolution::dg::subcell::fd::mesh(
+            Mesh<3>({{4, 6, 7}}, BasisType, QuadratureType)) ==
+        Mesh<3>{{{7, 11, 13}},
+                Spectral::Basis::FiniteDifference,
+                Spectral::Quadrature::CellCentered});
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Subcell.FD.Mesh", "[Evolution][Unit]") {
+  test_mesh<Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>();
+  test_mesh<Spectral::Basis::Legendre, Spectral::Quadrature::Gauss>();
+  test_mesh<Spectral::Basis::Chebyshev, Spectral::Quadrature::GaussLobatto>();
+  test_mesh<Spectral::Basis::Chebyshev, Spectral::Quadrature::Gauss>();
+}


### PR DESCRIPTION
## Proposed changes

Add function to compute FD mesh from DG mesh. This assumes we want the maximum possible number of subcells, `2N+1`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
