### PR TITLE
Require the dg_package_data function to return a double

### DIFF
--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp
@@ -72,7 +72,7 @@ using get_system_primitive_vars = typename get_system_primitive_vars_impl<
 template <typename BoundaryCorrection, typename... PackageTags,
           typename... FaceTags, typename... VolumeTags,
           typename... FaceTagsToForward, size_t Dim>
-void call_dg_package_data(
+double call_dg_package_data(
     const gsl::not_null<Variables<tmpl::list<PackageTags...>>*> package_data,
     const BoundaryCorrection& correction,
     const Variables<tmpl::list<FaceTags...>>& face_variables,
@@ -86,16 +86,17 @@ void call_dg_package_data(
     normal_dot_mesh_velocity =
         dot_product(*mesh_velocity, unit_normal_covector);
   }
-  correction.dg_package_data(
+  const double max_speed = correction.dg_package_data(
       make_not_null(&get<PackageTags>(*package_data))...,
       get<FaceTagsToForward>(face_variables)..., unit_normal_covector,
       mesh_velocity, normal_dot_mesh_velocity, get<VolumeTags>(volume_data)...);
+  return max_speed;
 }
 
 template <typename BoundaryCorrection, typename... PackageTags,
           typename... FaceTags, typename... VolumeTags,
           typename... FaceTagsToForward, size_t Dim>
-void call_dg_package_data(
+double call_dg_package_data(
     const gsl::not_null<Variables<tmpl::list<PackageTags...>>*> package_data,
     const BoundaryCorrection& correction,
     const Variables<tmpl::list<FaceTags...>>& face_variables,
@@ -110,11 +111,12 @@ void call_dg_package_data(
     normal_dot_mesh_velocity =
         dot_product(*mesh_velocity, unit_normal_covector);
   }
-  correction.dg_package_data(make_not_null(&get<PackageTags>(*package_data))...,
-                             get<FaceTagsToForward>(face_variables)...,
-                             unit_normal_covector, unit_normal_vector,
-                             mesh_velocity, normal_dot_mesh_velocity,
-                             get<VolumeTags>(volume_data)...);
+  const double max_speed = correction.dg_package_data(
+      make_not_null(&get<PackageTags>(*package_data))...,
+      get<FaceTagsToForward>(face_variables)..., unit_normal_covector,
+      unit_normal_vector, mesh_velocity, normal_dot_mesh_velocity,
+      get<VolumeTags>(volume_data)...);
+  return max_speed;
 }
 
 template <typename BoundaryCorrection, typename... BoundaryCorrectionTags,


### PR DESCRIPTION
## Proposed changes

This part of the interface needs to be tested, otherwise the code won't work in
production.

It would be nice to check the actual return value, but that will require a bit bigger of a rewrite of the test functions.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
