### PR TITLE
Add TensorExpressions::evaluate overload that takes LHS Tensor as an argument

### DIFF
--- a/src/DataStructures/Tensor/Expressions/Evaluate.hpp
+++ b/src/DataStructures/Tensor/Expressions/Evaluate.hpp
@@ -6,8 +6,11 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include "DataStructures/Tensor/Expressions/LhsTensorSymmAndIndices.hpp"
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/Structure.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Requires.hpp"
@@ -41,11 +44,114 @@ constexpr bool contains_indices_to_contract(
  * set in the template parameters
  *
  * \details Uses the right hand side (RHS) TensorExpression's index ordering
- * (`T::args_list`) and the desired left hand side (LHS) tensor's index ordering
- * (`LhsTensorIndices`) to construct a LHS Tensor with that LHS index ordering.
- * This can carry out the evaluation of a RHS tensor expression to a LHS tensor
- * with the same index ordering, such as \f$L_{ab} = R_{ab}\f$, or different
- * ordering, such as \f$L_{ba} = R_{ab}\f$.
+ * (`RhsTE::args_list`) and the desired left hand side (LHS) tensor's index
+ * ordering (`LhsTensorIndices`) to fill the provided LHS Tensor with that LHS
+ * index ordering. This can carry out the evaluation of a RHS tensor expression
+ * to a LHS tensor with the same index ordering, such as \f$L_{ab} = R_{ab}\f$,
+ * or different ordering, such as \f$L_{ba} = R_{ab}\f$.
+ *
+ * The symmetry of the provided LHS Tensor need not match the symmetry
+ * determined from evaluating the RHS TensorExpression according to its order of
+ * operations. This allows one to specify LHS symmetries (via `lhs_tensor`) that
+ * may not be preserved by the RHS expression's order of operations, which
+ * depends on how the expression is written and implemented.
+ *
+ * ### Example usage
+ * Given two rank 2 Tensors `R` and `S` with index order (a, b), add them
+ * together and fill the provided resultant LHS Tensor `L` with index order
+ * (b, a):
+ * \code{.cpp}
+ * TensorExpressions::evaluate<ti_b, ti_a>(
+ *     make_not_null(&L), R(ti_a, ti_b) + S(ti_a, ti_b));
+ * \endcode
+ *
+ * This represents evaluating: \f$L_{ba} = R_{ab} + S_{ab}\f$
+ *
+ * Note: `LhsTensorIndices` must be passed by reference because non-type
+ * template parameters cannot be class types until C++20.
+ *
+ * @tparam LhsTensorIndices the TensorIndexs of the Tensor on the LHS of the
+ * tensor expression, e.g. `ti_a`, `ti_b`, `ti_c`
+ * @param lhs_tensor pointer to the resultant LHS Tensor to fill
+ * @param rhs_tensorexpression the RHS TensorExpression to be evaluated
+ */
+template <auto&... LhsTensorIndices, typename X, typename LhsSymmetry,
+          typename LhsIndexList, typename RhsTE,
+          Requires<std::is_base_of_v<Expression, RhsTE>> = nullptr>
+void evaluate(
+    const gsl::not_null<Tensor<X, LhsSymmetry, LhsIndexList>*> lhs_tensor,
+    const RhsTE& rhs_tensorexpression) {
+  using lhs_tensorindex_list =
+      tmpl::list<std::decay_t<decltype(LhsTensorIndices)>...>;
+  using rhs_tensorindex_list = typename RhsTE::args_list;
+  static_assert(
+      tmpl::equal_members<lhs_tensorindex_list, rhs_tensorindex_list>::value,
+      "The generic indices on the LHS of a tensor equation (that is, the "
+      "template parameters specified in evaluate<...>) must match the generic "
+      "indices of the RHS TensorExpression. This error occurs as a result of a "
+      "call like evaluate<ti_a, ti_b>(R(ti_A, ti_b) * S(ti_a, ti_c)), where "
+      "the generic indices of the evaluated RHS expression are ti_b and ti_c, "
+      "but the generic indices provided for the LHS are ti_a and ti_b.");
+  static_assert(
+      tmpl::is_set<std::decay_t<decltype(LhsTensorIndices)>...>::value,
+      "Cannot evaluate a tensor expression to a LHS tensor with a repeated "
+      "generic index, e.g. evaluate<ti_a, ti_a>.");
+  static_assert(
+      not detail::contains_indices_to_contract<sizeof...(LhsTensorIndices)>(
+          {{std::decay_t<decltype(LhsTensorIndices)>::value...}}),
+      "Cannot evaluate a tensor expression to a LHS tensor with generic "
+      "indices that would be contracted, e.g. evaluate<ti_A, ti_a>.");
+  using rhs_symmetry = typename RhsTE::symmetry;
+  using rhs_tensorindextype_list = typename RhsTE::index_list;
+
+  // Stores (potentially reordered) symmetry and indices expected for the LHS
+  // tensor, with index order specified by LhsTensorIndices
+  using lhs_tensor_symm_and_indices =
+      LhsTensorSymmAndIndices<rhs_tensorindex_list, lhs_tensorindex_list,
+                              rhs_symmetry, rhs_tensorindextype_list>;
+  // Instead of simply checking that the LHS Tensor type is correct, individual
+  // checks for the data type and index list are carried out because it provides
+  // more fine-grained feedback and because the provided LHS symmetry may differ
+  // from the symmetry determined by the order of operations in the RHS
+  // expression.
+  static_assert(
+      std::is_same_v<X, typename RhsTE::type>,
+      "The data type stored by the LHS tensor does not match the data type "
+      "stored by the RHS expression.");
+  static_assert(
+      std::is_same_v<
+          LhsIndexList,
+          typename lhs_tensor_symm_and_indices::tensorindextype_list>,
+      "The index list of the LHS tensor does not match the index list of the "
+      "evaluated RHS expression.");
+
+  using lhs_tensor_type = typename std::decay_t<decltype(*lhs_tensor)>;
+
+  for (size_t i = 0; i < lhs_tensor_type::size(); i++) {
+    (*lhs_tensor)[i] =
+        rhs_tensorexpression
+            .template get<std::decay_t<decltype(LhsTensorIndices)>...>(
+                lhs_tensor_type::structure::get_canonical_tensor_index(i));
+  }
+}
+
+/*!
+ * \ingroup TensorExpressionsGroup
+ * \brief Evaluate a RHS tensor expression to a tensor with the LHS index order
+ * set in the template parameters
+ *
+ * \details Uses the right hand side (RHS) TensorExpression's index ordering
+ * (`RhsTE::args_list`) and the desired left hand side (LHS) tensor's index
+ * ordering (`LhsTensorIndices`) to construct a LHS Tensor with that LHS index
+ * ordering. This can carry out the evaluation of a RHS tensor expression to a
+ * LHS tensor with the same index ordering, such as \f$L_{ab} = R_{ab}\f$, or
+ * different ordering, such as \f$L_{ba} = R_{ab}\f$.
+ *
+ * The symmetry of the returned LHS Tensor depends on the order of operations in
+ * the RHS TensorExpression, i.e. how the expression is written. If you would
+ * like to specify the symmetry of the LHS Tensor instead of it being determined
+ * by the order of operations in the RHS expression, please use the other
+ * `evaluate` overload that takes an empty LHS Tensor as its first argument.
  *
  * ### Example usage
  * Given two rank 2 Tensors `R` and `S` with index order (a, b), add them
@@ -63,45 +169,30 @@ constexpr bool contains_indices_to_contract(
  *
  * @tparam LhsTensorIndices the TensorIndexs of the Tensor on the LHS of the
  * tensor expression, e.g. `ti_a`, `ti_b`, `ti_c`
- * @tparam T the type of the RHS TensorExpression
- * @param rhs_te the RHS TensorExpression to be evaluated
- * @return the LHS Tensor with index order specified by LhsTensorIndices
+ * @param rhs_tensorexpression the RHS TensorExpression to be evaluated
+ * @return the resultant LHS Tensor with index order specified by
+ * LhsTensorIndices
  */
-template <auto&... LhsTensorIndices, typename T,
-          Requires<std::is_base_of<Expression, T>::value> = nullptr>
-auto evaluate(const T& rhs_te) {
+template <auto&... LhsTensorIndices, typename RhsTE,
+          Requires<std::is_base_of_v<Expression, RhsTE>> = nullptr>
+auto evaluate(const RhsTE& rhs_tensorexpression) {
   using lhs_tensorindex_list =
       tmpl::list<std::decay_t<decltype(LhsTensorIndices)>...>;
-  using rhs_tensorindex_list = typename T::args_list;
-  static_assert(
-      tmpl::equal_members<lhs_tensorindex_list, rhs_tensorindex_list>::value,
-      "The generic indices on the LHS of a tensor equation (that is, the "
-      "template parameters specified in evaluate<...>) must match the generic "
-      "indices of the RHS TensorExpression. This error occurs as a result of a "
-      "call like evaluate<ti_a, ti_b>(R(ti_A, ti_b) * S(ti_a, ti_c)), where "
-      "the generic indices of the evaluated RHS expression are ti_b and ti_c, "
-      "but the indices provided for the LHS are ti_a and ti_b.");
-  static_assert(
-      tmpl::is_set<std::decay_t<decltype(LhsTensorIndices)>...>::value,
-      "Cannot evaluate a tensor expression to a LHS tensor with a repeated "
-      "generic index, e.g. evaluate<ti_a, ti_a>.");
-  static_assert(
-      not detail::contains_indices_to_contract<sizeof...(LhsTensorIndices)>(
-          {{std::decay_t<decltype(LhsTensorIndices)>::value...}}),
-      "Cannot evaluate a tensor expression to a LHS tensor with generic "
-      "indices that would be contracted, e.g. evaluate<ti_A, ti_a>.");
-  using rhs_symmetry = typename T::symmetry;
-  using rhs_tensorindextype_list = typename T::index_list;
+  using rhs_tensorindex_list = typename RhsTE::args_list;
+  using rhs_symmetry = typename RhsTE::symmetry;
+  using rhs_tensorindextype_list = typename RhsTE::index_list;
 
   // Stores (potentially reordered) symmetry and indices needed for constructing
-  // the LHS tensor with index order specified by LhsTensorIndices
-  using lhs_tensor =
+  // the LHS tensor, with index order specified by LhsTensorIndices
+  using lhs_tensor_symm_and_indices =
       LhsTensorSymmAndIndices<rhs_tensorindex_list, lhs_tensorindex_list,
                               rhs_symmetry, rhs_tensorindextype_list>;
 
-  // Construct and return LHS tensor
-  return Tensor<typename T::type, typename lhs_tensor::symmetry,
-                typename lhs_tensor::tensorindextype_list>(
-      rhs_te, lhs_tensorindex_list{});
+  Tensor<typename RhsTE::type, typename lhs_tensor_symm_and_indices::symmetry,
+         typename lhs_tensor_symm_and_indices::tensorindextype_list>
+      lhs_tensor{};
+  evaluate<LhsTensorIndices...>(make_not_null(&lhs_tensor),
+                                rhs_tensorexpression);
+  return lhs_tensor;
 }
 }  // namespace TensorExpressions

--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -100,13 +100,6 @@ class Tensor<X, Symm, IndexList<Indices...>> {
       "allowed. While other types are technically possible it is not "
       "clear that Tensor is the correct container for them. Please "
       "seek advice on the topic by discussing with the SpECTRE developers.");
-  /// The Tensor_detail::Structure for the particular tensor index structure
-  ///
-  /// Each tensor index structure, e.g. \f$T_{ab}\f$, \f$T_a{}^b\f$ or
-  /// \f$T^{ab}\f$ has its own Tensor_detail::TensorStructure that holds
-  /// information about how the data is stored, what the multiplicity of the
-  /// stored indices are, the number of (independent) components, etc.
-  using structure = Tensor_detail::Structure<Symm, Indices...>;
 
  public:
   /// The type of the sequence that holds the data
@@ -124,6 +117,13 @@ class Tensor<X, Symm, IndexList<Indices...>> {
   /// Typelist of the \ref SpacetimeIndex "TensorIndexType"'s that the
   /// Tensor has
   using index_list = tmpl::list<Indices...>;
+  /// The Tensor_detail::Structure for the particular tensor index structure
+  ///
+  /// Each tensor index structure, e.g. \f$T_{ab}\f$, \f$T_a{}^b\f$ or
+  /// \f$T^{ab}\f$ has its own Tensor_detail::TensorStructure that holds
+  /// information about how the data is stored, what the multiplicity of the
+  /// stored indices are, the number of (independent) components, etc.
+  using structure = Tensor_detail::Structure<Symm, Indices...>;
   /// The type of the TensorExpression that would represent this Tensor in a
   /// tensor expression.
   template <typename ArgsList>
@@ -136,30 +136,6 @@ class Tensor<X, Symm, IndexList<Indices...>> {
   Tensor(Tensor&&) noexcept = default;
   Tensor& operator=(const Tensor&) = default;
   Tensor& operator=(Tensor&&) noexcept = default;
-
-  /// \cond HIDDEN_SYMBOLS
-  /// Constructor from a TensorExpression.
-  ///
-  /// \tparam LhsIndices the indices on the LHS of the tensor expression
-  /// \tparam T the type of the TensorExpression
-  /// \param tensor_expression the tensor expression being evaluated
-  template <typename... LhsIndices, typename T,
-            Requires<std::is_base_of<Expression, T>::value> = nullptr>
-  Tensor(const T& tensor_expression,
-         tmpl::list<LhsIndices...> /*meta*/) noexcept {
-    static_assert(
-        sizeof...(LhsIndices) == sizeof...(Indices),
-        "When calling evaluate<...>(...) you must pass the same "
-        "number of indices as template parameters as there are free "
-        "indices on the resulting tensor. For example, auto F = "
-        "evaluate<_a_t, _b_t>(G); if G has 2 free indices and you want "
-        "the LHS of the equation to be F_{ab} rather than F_{ba}.");
-    for (size_t i = 0; i < size(); ++i) {
-      gsl::at(data_, i) = tensor_expression.template get<LhsIndices...>(
-          structure::get_canonical_tensor_index(i));
-    }
-  }
-  /// \endcond
 
   /// Initialize a vector or scalar from an array
   ///

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank0TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank0TestHelpers.hpp
@@ -3,9 +3,14 @@
 
 #pragma once
 
+#include <type_traits>
+
+#include "DataStructures/Tags/TempTensor.hpp"
 #include "DataStructures/Tensor/Expressions/Evaluate.hpp"
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Utilities/Gsl.hpp"
 
 namespace TestHelpers::TensorExpressions {
 
@@ -21,9 +26,23 @@ void test_evaluate_rank_0(const DataType& data) noexcept {
 
   // Use explicit type (vs auto) so the compiler checks the return type of
   // `evaluate`
-  const Tensor<DataType> L = ::TensorExpressions::evaluate(R());
+  const Tensor<DataType> L_returned = ::TensorExpressions::evaluate(R());
+  Tensor<DataType> L_filled{};
+  ::TensorExpressions::evaluate(make_not_null(&L_filled), R());
 
-  CHECK(L.get() == data);
+  CHECK(L_returned.get() == data);
+  CHECK(L_filled.get() == data);
+
+  // Test with TempTensor for LHS tensor
+  if constexpr (not std::is_same_v<DataType, double>) {
+    Variables<tmpl::list<::Tags::TempTensor<1, Tensor<DataType>>>> L_var{
+        data.size()};
+    Tensor<DataType>& L_temp =
+        get<::Tags::TempTensor<1, Tensor<DataType>>>(L_var);
+    ::TensorExpressions::evaluate(make_not_null(&L_temp), R());
+
+    CHECK(L_temp.get() == data);
+  }
 }
 
 }  // namespace TestHelpers::TensorExpressions

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank3TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank3TestHelpers.hpp
@@ -6,11 +6,15 @@
 #include <cstddef>
 #include <iterator>
 #include <numeric>
+#include <type_traits>
 
+#include "DataStructures/Tags/TempTensor.hpp"
 #include "DataStructures/Tensor/Expressions/Evaluate.hpp"
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -48,7 +52,8 @@ template <typename DataType, typename RhsSymmetry,
           typename RhsTensorIndexTypeList, auto& TensorIndexA,
           auto& TensorIndexB, auto& TensorIndexC>
 void test_evaluate_rank_3_impl() noexcept {
-  Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList> R_abc(5_st);
+  const size_t used_for_size = 5;
+  Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList> R_abc(used_for_size);
   std::iota(R_abc.begin(), R_abc.end(), 0.0);
 
   // Used for enforcing the ordering of the symmetry and TensorIndexTypes of the
@@ -63,9 +68,14 @@ void test_evaluate_rank_3_impl() noexcept {
   // L_{abc} = R_{abc}
   // Use explicit type (vs auto) so the compiler checks the return type of
   // `evaluate`
-  const Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList> L_abc =
+  using L_abc_type = Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList>;
+  const L_abc_type L_abc_returned =
       ::TensorExpressions::evaluate<TensorIndexA, TensorIndexB, TensorIndexC>(
           R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
+  L_abc_type L_abc_filled{};
+  ::TensorExpressions::evaluate<TensorIndexA, TensorIndexB, TensorIndexC>(
+      make_not_null(&L_abc_filled),
+      R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
 
   // L_{acb} = R_{abc}
   using L_acb_symmetry =
@@ -74,9 +84,15 @@ void test_evaluate_rank_3_impl() noexcept {
   using L_acb_tensorindextype_list =
       tmpl::list<rhs_tensorindextype_a, rhs_tensorindextype_c,
                  rhs_tensorindextype_b>;
-  const Tensor<DataType, L_acb_symmetry, L_acb_tensorindextype_list> L_acb =
+  using L_acb_type =
+      Tensor<DataType, L_acb_symmetry, L_acb_tensorindextype_list>;
+  const L_acb_type L_acb_returned =
       ::TensorExpressions::evaluate<TensorIndexA, TensorIndexC, TensorIndexB>(
           R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
+  L_acb_type L_acb_filled{};
+  ::TensorExpressions::evaluate<TensorIndexA, TensorIndexC, TensorIndexB>(
+      make_not_null(&L_acb_filled),
+      R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
 
   // L_{bac} = R_{abc}
   using L_bac_symmetry =
@@ -85,9 +101,15 @@ void test_evaluate_rank_3_impl() noexcept {
   using L_bac_tensorindextype_list =
       tmpl::list<rhs_tensorindextype_b, rhs_tensorindextype_a,
                  rhs_tensorindextype_c>;
-  const Tensor<DataType, L_bac_symmetry, L_bac_tensorindextype_list> L_bac =
+  using L_bac_type =
+      Tensor<DataType, L_bac_symmetry, L_bac_tensorindextype_list>;
+  const L_bac_type L_bac_returned =
       ::TensorExpressions::evaluate<TensorIndexB, TensorIndexA, TensorIndexC>(
           R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
+  L_bac_type L_bac_filled{};
+  ::TensorExpressions::evaluate<TensorIndexB, TensorIndexA, TensorIndexC>(
+      make_not_null(&L_bac_filled),
+      R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
 
   // L_{bca} = R_{abc}
   using L_bca_symmetry =
@@ -96,9 +118,15 @@ void test_evaluate_rank_3_impl() noexcept {
   using L_bca_tensorindextype_list =
       tmpl::list<rhs_tensorindextype_b, rhs_tensorindextype_c,
                  rhs_tensorindextype_a>;
-  const Tensor<DataType, L_bca_symmetry, L_bca_tensorindextype_list> L_bca =
+  using L_bca_type =
+      Tensor<DataType, L_bca_symmetry, L_bca_tensorindextype_list>;
+  const L_bca_type L_bca_returned =
       ::TensorExpressions::evaluate<TensorIndexB, TensorIndexC, TensorIndexA>(
           R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
+  L_bca_type L_bca_filled{};
+  ::TensorExpressions::evaluate<TensorIndexB, TensorIndexC, TensorIndexA>(
+      make_not_null(&L_bca_filled),
+      R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
 
   // L_{cab} = R_{abc}
   using L_cab_symmetry =
@@ -107,9 +135,15 @@ void test_evaluate_rank_3_impl() noexcept {
   using L_cab_tensorindextype_list =
       tmpl::list<rhs_tensorindextype_c, rhs_tensorindextype_a,
                  rhs_tensorindextype_b>;
-  const Tensor<DataType, L_cab_symmetry, L_cab_tensorindextype_list> L_cab =
+  using L_cab_type =
+      Tensor<DataType, L_cab_symmetry, L_cab_tensorindextype_list>;
+  const L_cab_type L_cab_returned =
       ::TensorExpressions::evaluate<TensorIndexC, TensorIndexA, TensorIndexB>(
           R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
+  L_cab_type L_cab_filled{};
+  ::TensorExpressions::evaluate<TensorIndexC, TensorIndexA, TensorIndexB>(
+      make_not_null(&L_cab_filled),
+      R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
 
   // L_{cba} = R_{abc}
   using L_cba_symmetry =
@@ -118,9 +152,15 @@ void test_evaluate_rank_3_impl() noexcept {
   using L_cba_tensorindextype_list =
       tmpl::list<rhs_tensorindextype_c, rhs_tensorindextype_b,
                  rhs_tensorindextype_a>;
-  const Tensor<DataType, L_cba_symmetry, L_cba_tensorindextype_list> L_cba =
+  using L_cba_type =
+      Tensor<DataType, L_cba_symmetry, L_cba_tensorindextype_list>;
+  const L_cba_type L_cba_returned =
       ::TensorExpressions::evaluate<TensorIndexC, TensorIndexB, TensorIndexA>(
           R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
+  L_cba_type L_cba_filled{};
+  ::TensorExpressions::evaluate<TensorIndexC, TensorIndexB, TensorIndexA>(
+      make_not_null(&L_cba_filled),
+      R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
 
   const size_t dim_a = tmpl::at_c<RhsTensorIndexTypeList, 0>::dim;
   const size_t dim_b = tmpl::at_c<RhsTensorIndexTypeList, 1>::dim;
@@ -130,17 +170,93 @@ void test_evaluate_rank_3_impl() noexcept {
     for (size_t j = 0; j < dim_b; ++j) {
       for (size_t k = 0; k < dim_c; ++k) {
         // For L_{abc} = R_{abc}, check that L_{ijk} == R_{ijk}
-        CHECK(L_abc.get(i, j, k) == R_abc.get(i, j, k));
+        CHECK(L_abc_returned.get(i, j, k) == R_abc.get(i, j, k));
+        CHECK(L_abc_filled.get(i, j, k) == R_abc.get(i, j, k));
         // For L_{acb} = R_{abc}, check that L_{ikj} == R_{ijk}
-        CHECK(L_acb.get(i, k, j) == R_abc.get(i, j, k));
+        CHECK(L_acb_returned.get(i, k, j) == R_abc.get(i, j, k));
+        CHECK(L_acb_filled.get(i, k, j) == R_abc.get(i, j, k));
         // For L_{bac} = R_{abc}, check that L_{jik} == R_{ijk}
-        CHECK(L_bac.get(j, i, k) == R_abc.get(i, j, k));
+        CHECK(L_bac_returned.get(j, i, k) == R_abc.get(i, j, k));
+        CHECK(L_bac_filled.get(j, i, k) == R_abc.get(i, j, k));
         // For L_{bca} = R_{abc}, check that L_{jki} == R_{ijk}
-        CHECK(L_bca.get(j, k, i) == R_abc.get(i, j, k));
+        CHECK(L_bca_returned.get(j, k, i) == R_abc.get(i, j, k));
+        CHECK(L_bca_filled.get(j, k, i) == R_abc.get(i, j, k));
         // For L_{cab} = R_{abc}, check that L_{kij} == R_{ijk}
-        CHECK(L_cab.get(k, i, j) == R_abc.get(i, j, k));
+        CHECK(L_cab_returned.get(k, i, j) == R_abc.get(i, j, k));
+        CHECK(L_cab_filled.get(k, i, j) == R_abc.get(i, j, k));
         // For L_{cba} = R_{abc}, check that L_{kji} == R_{ijk}
-        CHECK(L_cba.get(k, j, i) == R_abc.get(i, j, k));
+        CHECK(L_cba_returned.get(k, j, i) == R_abc.get(i, j, k));
+        CHECK(L_cba_filled.get(k, j, i) == R_abc.get(i, j, k));
+      }
+    }
+  }
+
+  // Test with TempTensor for LHS tensor
+  if constexpr (not std::is_same_v<DataType, double>) {
+    // L_{abc} = R_{abc}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_abc_type>>> L_abc_var{
+        used_for_size};
+    L_abc_type& L_abc_temp = get<::Tags::TempTensor<1, L_abc_type>>(L_abc_var);
+    ::TensorExpressions::evaluate<TensorIndexA, TensorIndexB, TensorIndexC>(
+        make_not_null(&L_abc_temp),
+        R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
+
+    // L_{acb} = R_{abc}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_acb_type>>> L_acb_var{
+        used_for_size};
+    L_acb_type& L_acb_temp = get<::Tags::TempTensor<1, L_acb_type>>(L_acb_var);
+    ::TensorExpressions::evaluate<TensorIndexA, TensorIndexC, TensorIndexB>(
+        make_not_null(&L_acb_temp),
+        R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
+
+    // L_{bac} = R_{abc}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_bac_type>>> L_bac_var{
+        used_for_size};
+    L_bac_type& L_bac_temp = get<::Tags::TempTensor<1, L_bac_type>>(L_bac_var);
+    ::TensorExpressions::evaluate<TensorIndexB, TensorIndexA, TensorIndexC>(
+        make_not_null(&L_bac_temp),
+        R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
+
+    // L_{bca} = R_{abc}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_bca_type>>> L_bca_var{
+        used_for_size};
+    L_bca_type& L_bca_temp = get<::Tags::TempTensor<1, L_bca_type>>(L_bca_var);
+    ::TensorExpressions::evaluate<TensorIndexB, TensorIndexC, TensorIndexA>(
+        make_not_null(&L_bca_temp),
+        R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
+
+    // L_{cab} = R_{abc}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_cab_type>>> L_cab_var{
+        used_for_size};
+    L_cab_type& L_cab_temp = get<::Tags::TempTensor<1, L_cab_type>>(L_cab_var);
+    ::TensorExpressions::evaluate<TensorIndexC, TensorIndexA, TensorIndexB>(
+        make_not_null(&L_cab_temp),
+        R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
+
+    // L_{cba} = R_{abc}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_cba_type>>> L_cba_var{
+        used_for_size};
+    L_cba_type& L_cba_temp = get<::Tags::TempTensor<1, L_cba_type>>(L_cba_var);
+    ::TensorExpressions::evaluate<TensorIndexC, TensorIndexB, TensorIndexA>(
+        make_not_null(&L_cba_temp),
+        R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
+
+    for (size_t i = 0; i < dim_a; ++i) {
+      for (size_t j = 0; j < dim_b; ++j) {
+        for (size_t k = 0; k < dim_c; ++k) {
+          // For L_{abc} = R_{abc}, check that L_{ijk} == R_{ijk}
+          CHECK(L_abc_temp.get(i, j, k) == R_abc.get(i, j, k));
+          // For L_{acb} = R_{abc}, check that L_{ikj} == R_{ijk}
+          CHECK(L_acb_temp.get(i, k, j) == R_abc.get(i, j, k));
+          // For L_{bac} = R_{abc}, check that L_{jik} == R_{ijk}
+          CHECK(L_bac_temp.get(j, i, k) == R_abc.get(i, j, k));
+          // For L_{bca} = R_{abc}, check that L_{jki} == R_{ijk}
+          CHECK(L_bca_temp.get(j, k, i) == R_abc.get(i, j, k));
+          // For L_{cab} = R_{abc}, check that L_{kij} == R_{ijk}
+          CHECK(L_cab_temp.get(k, i, j) == R_abc.get(i, j, k));
+          // For L_{cba} = R_{abc}, check that L_{kji} == R_{ijk}
+          CHECK(L_cba_temp.get(k, j, i) == R_abc.get(i, j, k));
+        }
       }
     }
   }

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank4TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank4TestHelpers.hpp
@@ -6,10 +6,14 @@
 #include <cstddef>
 #include <iterator>
 #include <numeric>
+#include <type_traits>
 
+#include "DataStructures/Tags/TempTensor.hpp"
 #include "DataStructures/Tensor/Expressions/Evaluate.hpp"
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace TestHelpers::TensorExpressions {
@@ -49,7 +53,8 @@ template <typename DataType, typename RhsSymmetry,
           typename RhsTensorIndexTypeList, auto& TensorIndexA,
           auto& TensorIndexB, auto& TensorIndexC, auto& TensorIndexD>
 void test_evaluate_rank_4() noexcept {
-  Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList> R_abcd(5_st);
+  const size_t used_for_size = 5;
+  Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList> R_abcd(used_for_size);
   std::iota(R_abcd.begin(), R_abcd.end(), 0.0);
 
   // Used for enforcing the ordering of the symmetry and TensorIndexTypes of the
@@ -66,10 +71,16 @@ void test_evaluate_rank_4() noexcept {
   // L_{abcd} = R_{abcd}
   // Use explicit type (vs auto) so the compiler checks the return type of
   // `evaluate`
-  const Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList> L_abcd =
+  using L_abcd_type = Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList>;
+  const L_abcd_type L_abcd_returned =
       ::TensorExpressions::evaluate<TensorIndexA, TensorIndexB, TensorIndexC,
                                     TensorIndexD>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  L_abcd_type L_abcd_filled{};
+  ::TensorExpressions::evaluate<TensorIndexA, TensorIndexB, TensorIndexC,
+                                TensorIndexD>(
+      make_not_null(&L_abcd_filled),
+      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{abdc} = R_{abcd}
   using L_abdc_symmetry =
@@ -78,10 +89,17 @@ void test_evaluate_rank_4() noexcept {
   using L_abdc_tensorindextype_list =
       tmpl::list<rhs_tensorindextype_a, rhs_tensorindextype_b,
                  rhs_tensorindextype_d, rhs_tensorindextype_c>;
-  const Tensor<DataType, L_abdc_symmetry, L_abdc_tensorindextype_list> L_abdc =
+  using L_abdc_type =
+      Tensor<DataType, L_abdc_symmetry, L_abdc_tensorindextype_list>;
+  const L_abdc_type L_abdc_returned =
       ::TensorExpressions::evaluate<TensorIndexA, TensorIndexB, TensorIndexD,
                                     TensorIndexC>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  L_abdc_type L_abdc_filled{};
+  ::TensorExpressions::evaluate<TensorIndexA, TensorIndexB, TensorIndexD,
+                                TensorIndexC>(
+      make_not_null(&L_abdc_filled),
+      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{acbd} = R_{abcd}
   using L_acbd_symmetry =
@@ -90,10 +108,17 @@ void test_evaluate_rank_4() noexcept {
   using L_acbd_tensorindextype_list =
       tmpl::list<rhs_tensorindextype_a, rhs_tensorindextype_c,
                  rhs_tensorindextype_b, rhs_tensorindextype_d>;
-  const Tensor<DataType, L_acbd_symmetry, L_acbd_tensorindextype_list> L_acbd =
+  using L_acbd_type =
+      Tensor<DataType, L_acbd_symmetry, L_acbd_tensorindextype_list>;
+  const L_acbd_type L_acbd_returned =
       ::TensorExpressions::evaluate<TensorIndexA, TensorIndexC, TensorIndexB,
                                     TensorIndexD>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  L_acbd_type L_acbd_filled{};
+  ::TensorExpressions::evaluate<TensorIndexA, TensorIndexC, TensorIndexB,
+                                TensorIndexD>(
+      make_not_null(&L_acbd_filled),
+      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{acdb} = R_{abcd}
   using L_acdb_symmetry =
@@ -102,10 +127,17 @@ void test_evaluate_rank_4() noexcept {
   using L_acdb_tensorindextype_list =
       tmpl::list<rhs_tensorindextype_a, rhs_tensorindextype_c,
                  rhs_tensorindextype_d, rhs_tensorindextype_b>;
-  const Tensor<DataType, L_acdb_symmetry, L_acdb_tensorindextype_list> L_acdb =
+  using L_acdb_type =
+      Tensor<DataType, L_acdb_symmetry, L_acdb_tensorindextype_list>;
+  const L_acdb_type L_acdb_returned =
       ::TensorExpressions::evaluate<TensorIndexA, TensorIndexC, TensorIndexD,
                                     TensorIndexB>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  L_acdb_type L_acdb_filled{};
+  ::TensorExpressions::evaluate<TensorIndexA, TensorIndexC, TensorIndexD,
+                                TensorIndexB>(
+      make_not_null(&L_acdb_filled),
+      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{adbc} = R_{abcd}
   using L_adbc_symmetry =
@@ -114,10 +146,17 @@ void test_evaluate_rank_4() noexcept {
   using L_adbc_tensorindextype_list =
       tmpl::list<rhs_tensorindextype_a, rhs_tensorindextype_d,
                  rhs_tensorindextype_b, rhs_tensorindextype_c>;
-  const Tensor<DataType, L_adbc_symmetry, L_adbc_tensorindextype_list> L_adbc =
+  using L_adbc_type =
+      Tensor<DataType, L_adbc_symmetry, L_adbc_tensorindextype_list>;
+  const L_adbc_type L_adbc_returned =
       ::TensorExpressions::evaluate<TensorIndexA, TensorIndexD, TensorIndexB,
                                     TensorIndexC>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  L_adbc_type L_adbc_filled{};
+  ::TensorExpressions::evaluate<TensorIndexA, TensorIndexD, TensorIndexB,
+                                TensorIndexC>(
+      make_not_null(&L_adbc_filled),
+      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{adcb} = R_{abcd}
   using L_adcb_symmetry =
@@ -126,10 +165,17 @@ void test_evaluate_rank_4() noexcept {
   using L_adcb_tensorindextype_list =
       tmpl::list<rhs_tensorindextype_a, rhs_tensorindextype_d,
                  rhs_tensorindextype_c, rhs_tensorindextype_b>;
-  const Tensor<DataType, L_adcb_symmetry, L_adcb_tensorindextype_list> L_adcb =
+  using L_adcb_type =
+      Tensor<DataType, L_adcb_symmetry, L_adcb_tensorindextype_list>;
+  const L_adcb_type L_adcb_returned =
       ::TensorExpressions::evaluate<TensorIndexA, TensorIndexD, TensorIndexC,
                                     TensorIndexB>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  L_adcb_type L_adcb_filled{};
+  ::TensorExpressions::evaluate<TensorIndexA, TensorIndexD, TensorIndexC,
+                                TensorIndexB>(
+      make_not_null(&L_adcb_filled),
+      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{bacd} = R_{abcd}
   using L_bacd_symmetry =
@@ -138,10 +184,17 @@ void test_evaluate_rank_4() noexcept {
   using L_bacd_tensorindextype_list =
       tmpl::list<rhs_tensorindextype_b, rhs_tensorindextype_a,
                  rhs_tensorindextype_c, rhs_tensorindextype_d>;
-  const Tensor<DataType, L_bacd_symmetry, L_bacd_tensorindextype_list> L_bacd =
+  using L_bacd_type =
+      Tensor<DataType, L_bacd_symmetry, L_bacd_tensorindextype_list>;
+  const L_bacd_type L_bacd_returned =
       ::TensorExpressions::evaluate<TensorIndexB, TensorIndexA, TensorIndexC,
                                     TensorIndexD>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  L_bacd_type L_bacd_filled{};
+  ::TensorExpressions::evaluate<TensorIndexB, TensorIndexA, TensorIndexC,
+                                TensorIndexD>(
+      make_not_null(&L_bacd_filled),
+      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{badc} = R_{abcd}
   using L_badc_symmetry =
@@ -150,10 +203,17 @@ void test_evaluate_rank_4() noexcept {
   using L_badc_tensorindextype_list =
       tmpl::list<rhs_tensorindextype_b, rhs_tensorindextype_a,
                  rhs_tensorindextype_d, rhs_tensorindextype_c>;
-  const Tensor<DataType, L_badc_symmetry, L_badc_tensorindextype_list> L_badc =
+  using L_badc_type =
+      Tensor<DataType, L_badc_symmetry, L_badc_tensorindextype_list>;
+  const L_badc_type L_badc_returned =
       ::TensorExpressions::evaluate<TensorIndexB, TensorIndexA, TensorIndexD,
                                     TensorIndexC>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  L_badc_type L_badc_filled{};
+  ::TensorExpressions::evaluate<TensorIndexB, TensorIndexA, TensorIndexD,
+                                TensorIndexC>(
+      make_not_null(&L_badc_filled),
+      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{bcad} = R_{abcd}
   using L_bcad_symmetry =
@@ -162,10 +222,17 @@ void test_evaluate_rank_4() noexcept {
   using L_bcad_tensorindextype_list =
       tmpl::list<rhs_tensorindextype_b, rhs_tensorindextype_c,
                  rhs_tensorindextype_a, rhs_tensorindextype_d>;
-  const Tensor<DataType, L_bcad_symmetry, L_bcad_tensorindextype_list> L_bcad =
+  using L_bcad_type =
+      Tensor<DataType, L_bcad_symmetry, L_bcad_tensorindextype_list>;
+  const L_bcad_type L_bcad_returned =
       ::TensorExpressions::evaluate<TensorIndexB, TensorIndexC, TensorIndexA,
                                     TensorIndexD>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  L_bcad_type L_bcad_filled{};
+  ::TensorExpressions::evaluate<TensorIndexB, TensorIndexC, TensorIndexA,
+                                TensorIndexD>(
+      make_not_null(&L_bcad_filled),
+      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{bcda} = R_{abcd}
   using L_bcda_symmetry =
@@ -174,10 +241,17 @@ void test_evaluate_rank_4() noexcept {
   using L_bcda_tensorindextype_list =
       tmpl::list<rhs_tensorindextype_b, rhs_tensorindextype_c,
                  rhs_tensorindextype_d, rhs_tensorindextype_a>;
-  const Tensor<DataType, L_bcda_symmetry, L_bcda_tensorindextype_list> L_bcda =
+  using L_bcda_type =
+      Tensor<DataType, L_bcda_symmetry, L_bcda_tensorindextype_list>;
+  const L_bcda_type L_bcda_returned =
       ::TensorExpressions::evaluate<TensorIndexB, TensorIndexC, TensorIndexD,
                                     TensorIndexA>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  L_bcda_type L_bcda_filled{};
+  ::TensorExpressions::evaluate<TensorIndexB, TensorIndexC, TensorIndexD,
+                                TensorIndexA>(
+      make_not_null(&L_bcda_filled),
+      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{bdac} = R_{abcd}
   using L_bdac_symmetry =
@@ -186,10 +260,17 @@ void test_evaluate_rank_4() noexcept {
   using L_bdac_tensorindextype_list =
       tmpl::list<rhs_tensorindextype_b, rhs_tensorindextype_d,
                  rhs_tensorindextype_a, rhs_tensorindextype_c>;
-  const Tensor<DataType, L_bdac_symmetry, L_bdac_tensorindextype_list> L_bdac =
+  using L_bdac_type =
+      Tensor<DataType, L_bdac_symmetry, L_bdac_tensorindextype_list>;
+  const L_bdac_type L_bdac_returned =
       ::TensorExpressions::evaluate<TensorIndexB, TensorIndexD, TensorIndexA,
                                     TensorIndexC>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  L_bdac_type L_bdac_filled{};
+  ::TensorExpressions::evaluate<TensorIndexB, TensorIndexD, TensorIndexA,
+                                TensorIndexC>(
+      make_not_null(&L_bdac_filled),
+      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{bdca} = R_{abcd}
   using L_bdca_symmetry =
@@ -198,10 +279,17 @@ void test_evaluate_rank_4() noexcept {
   using L_bdca_tensorindextype_list =
       tmpl::list<rhs_tensorindextype_b, rhs_tensorindextype_d,
                  rhs_tensorindextype_c, rhs_tensorindextype_a>;
-  const Tensor<DataType, L_bdca_symmetry, L_bdca_tensorindextype_list> L_bdca =
+  using L_bdca_type =
+      Tensor<DataType, L_bdca_symmetry, L_bdca_tensorindextype_list>;
+  const L_bdca_type L_bdca_returned =
       ::TensorExpressions::evaluate<TensorIndexB, TensorIndexD, TensorIndexC,
                                     TensorIndexA>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  L_bdca_type L_bdca_filled{};
+  ::TensorExpressions::evaluate<TensorIndexB, TensorIndexD, TensorIndexC,
+                                TensorIndexA>(
+      make_not_null(&L_bdca_filled),
+      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{cabd} = R_{abcd}
   using L_cabd_symmetry =
@@ -210,10 +298,17 @@ void test_evaluate_rank_4() noexcept {
   using L_cabd_tensorindextype_list =
       tmpl::list<rhs_tensorindextype_c, rhs_tensorindextype_a,
                  rhs_tensorindextype_b, rhs_tensorindextype_d>;
-  const Tensor<DataType, L_cabd_symmetry, L_cabd_tensorindextype_list> L_cabd =
+  using L_cabd_type =
+      Tensor<DataType, L_cabd_symmetry, L_cabd_tensorindextype_list>;
+  const L_cabd_type L_cabd_returned =
       ::TensorExpressions::evaluate<TensorIndexC, TensorIndexA, TensorIndexB,
                                     TensorIndexD>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  L_cabd_type L_cabd_filled{};
+  ::TensorExpressions::evaluate<TensorIndexC, TensorIndexA, TensorIndexB,
+                                TensorIndexD>(
+      make_not_null(&L_cabd_filled),
+      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{cadb} = R_{abcd}
   using L_cadb_symmetry =
@@ -222,10 +317,17 @@ void test_evaluate_rank_4() noexcept {
   using L_cadb_tensorindextype_list =
       tmpl::list<rhs_tensorindextype_c, rhs_tensorindextype_a,
                  rhs_tensorindextype_d, rhs_tensorindextype_b>;
-  const Tensor<DataType, L_cadb_symmetry, L_cadb_tensorindextype_list> L_cadb =
+  using L_cadb_type =
+      Tensor<DataType, L_cadb_symmetry, L_cadb_tensorindextype_list>;
+  const L_cadb_type L_cadb_returned =
       ::TensorExpressions::evaluate<TensorIndexC, TensorIndexA, TensorIndexD,
                                     TensorIndexB>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  L_cadb_type L_cadb_filled{};
+  ::TensorExpressions::evaluate<TensorIndexC, TensorIndexA, TensorIndexD,
+                                TensorIndexB>(
+      make_not_null(&L_cadb_filled),
+      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{cbad} = R_{abcd}
   using L_cbad_symmetry =
@@ -234,10 +336,17 @@ void test_evaluate_rank_4() noexcept {
   using L_cbad_tensorindextype_list =
       tmpl::list<rhs_tensorindextype_c, rhs_tensorindextype_b,
                  rhs_tensorindextype_a, rhs_tensorindextype_d>;
-  const Tensor<DataType, L_cbad_symmetry, L_cbad_tensorindextype_list> L_cbad =
+  using L_cbad_type =
+      Tensor<DataType, L_cbad_symmetry, L_cbad_tensorindextype_list>;
+  const L_cbad_type L_cbad_returned =
       ::TensorExpressions::evaluate<TensorIndexC, TensorIndexB, TensorIndexA,
                                     TensorIndexD>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  L_cbad_type L_cbad_filled{};
+  ::TensorExpressions::evaluate<TensorIndexC, TensorIndexB, TensorIndexA,
+                                TensorIndexD>(
+      make_not_null(&L_cbad_filled),
+      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{cbda} = R_{abcd}
   using L_cbda_symmetry =
@@ -246,10 +355,17 @@ void test_evaluate_rank_4() noexcept {
   using L_cbda_tensorindextype_list =
       tmpl::list<rhs_tensorindextype_c, rhs_tensorindextype_b,
                  rhs_tensorindextype_d, rhs_tensorindextype_a>;
-  const Tensor<DataType, L_cbda_symmetry, L_cbda_tensorindextype_list> L_cbda =
+  using L_cbda_type =
+      Tensor<DataType, L_cbda_symmetry, L_cbda_tensorindextype_list>;
+  const L_cbda_type L_cbda_returned =
       ::TensorExpressions::evaluate<TensorIndexC, TensorIndexB, TensorIndexD,
                                     TensorIndexA>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  L_cbda_type L_cbda_filled{};
+  ::TensorExpressions::evaluate<TensorIndexC, TensorIndexB, TensorIndexD,
+                                TensorIndexA>(
+      make_not_null(&L_cbda_filled),
+      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{cdab} = R_{abcd}
   using L_cdab_symmetry =
@@ -258,10 +374,17 @@ void test_evaluate_rank_4() noexcept {
   using L_cdab_tensorindextype_list =
       tmpl::list<rhs_tensorindextype_c, rhs_tensorindextype_d,
                  rhs_tensorindextype_a, rhs_tensorindextype_b>;
-  const Tensor<DataType, L_cdab_symmetry, L_cdab_tensorindextype_list> L_cdab =
+  using L_cdab_type =
+      Tensor<DataType, L_cdab_symmetry, L_cdab_tensorindextype_list>;
+  const L_cdab_type L_cdab_returned =
       ::TensorExpressions::evaluate<TensorIndexC, TensorIndexD, TensorIndexA,
                                     TensorIndexB>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  L_cdab_type L_cdab_filled{};
+  ::TensorExpressions::evaluate<TensorIndexC, TensorIndexD, TensorIndexA,
+                                TensorIndexB>(
+      make_not_null(&L_cdab_filled),
+      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{cdba} = R_{abcd}
   using L_cdba_symmetry =
@@ -270,10 +393,17 @@ void test_evaluate_rank_4() noexcept {
   using L_cdba_tensorindextype_list =
       tmpl::list<rhs_tensorindextype_c, rhs_tensorindextype_d,
                  rhs_tensorindextype_b, rhs_tensorindextype_a>;
-  const Tensor<DataType, L_cdba_symmetry, L_cdba_tensorindextype_list> L_cdba =
+  using L_cdba_type =
+      Tensor<DataType, L_cdba_symmetry, L_cdba_tensorindextype_list>;
+  const L_cdba_type L_cdba_returned =
       ::TensorExpressions::evaluate<TensorIndexC, TensorIndexD, TensorIndexB,
                                     TensorIndexA>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  L_cdba_type L_cdba_filled{};
+  ::TensorExpressions::evaluate<TensorIndexC, TensorIndexD, TensorIndexB,
+                                TensorIndexA>(
+      make_not_null(&L_cdba_filled),
+      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{dabc} = R_{abcd}
   using L_dabc_symmetry =
@@ -282,10 +412,17 @@ void test_evaluate_rank_4() noexcept {
   using L_dabc_tensorindextype_list =
       tmpl::list<rhs_tensorindextype_d, rhs_tensorindextype_a,
                  rhs_tensorindextype_b, rhs_tensorindextype_c>;
-  const Tensor<DataType, L_dabc_symmetry, L_dabc_tensorindextype_list> L_dabc =
+  using L_dabc_type =
+      Tensor<DataType, L_dabc_symmetry, L_dabc_tensorindextype_list>;
+  const L_dabc_type L_dabc_returned =
       ::TensorExpressions::evaluate<TensorIndexD, TensorIndexA, TensorIndexB,
                                     TensorIndexC>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  L_dabc_type L_dabc_filled{};
+  ::TensorExpressions::evaluate<TensorIndexD, TensorIndexA, TensorIndexB,
+                                TensorIndexC>(
+      make_not_null(&L_dabc_filled),
+      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{dacb} = R_{abcd}
   using L_dacb_symmetry =
@@ -294,10 +431,17 @@ void test_evaluate_rank_4() noexcept {
   using L_dacb_tensorindextype_list =
       tmpl::list<rhs_tensorindextype_d, rhs_tensorindextype_a,
                  rhs_tensorindextype_c, rhs_tensorindextype_b>;
-  const Tensor<DataType, L_dacb_symmetry, L_dacb_tensorindextype_list> L_dacb =
+  using L_dacb_type =
+      Tensor<DataType, L_dacb_symmetry, L_dacb_tensorindextype_list>;
+  const L_dacb_type L_dacb_returned =
       ::TensorExpressions::evaluate<TensorIndexD, TensorIndexA, TensorIndexC,
                                     TensorIndexB>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  L_dacb_type L_dacb_filled{};
+  ::TensorExpressions::evaluate<TensorIndexD, TensorIndexA, TensorIndexC,
+                                TensorIndexB>(
+      make_not_null(&L_dacb_filled),
+      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{dbac} = R_{abcd}
   using L_dbac_symmetry =
@@ -306,10 +450,17 @@ void test_evaluate_rank_4() noexcept {
   using L_dbac_tensorindextype_list =
       tmpl::list<rhs_tensorindextype_d, rhs_tensorindextype_b,
                  rhs_tensorindextype_a, rhs_tensorindextype_c>;
-  const Tensor<DataType, L_dbac_symmetry, L_dbac_tensorindextype_list> L_dbac =
+  using L_dbac_type =
+      Tensor<DataType, L_dbac_symmetry, L_dbac_tensorindextype_list>;
+  const L_dbac_type L_dbac_returned =
       ::TensorExpressions::evaluate<TensorIndexD, TensorIndexB, TensorIndexA,
                                     TensorIndexC>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  L_dbac_type L_dbac_filled{};
+  ::TensorExpressions::evaluate<TensorIndexD, TensorIndexB, TensorIndexA,
+                                TensorIndexC>(
+      make_not_null(&L_dbac_filled),
+      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{dbca} = R_{abcd}
   using L_dbca_symmetry =
@@ -318,10 +469,17 @@ void test_evaluate_rank_4() noexcept {
   using L_dbca_tensorindextype_list =
       tmpl::list<rhs_tensorindextype_d, rhs_tensorindextype_b,
                  rhs_tensorindextype_c, rhs_tensorindextype_a>;
-  const Tensor<DataType, L_dbca_symmetry, L_dbca_tensorindextype_list> L_dbca =
+  using L_dbca_type =
+      Tensor<DataType, L_dbca_symmetry, L_dbca_tensorindextype_list>;
+  const L_dbca_type L_dbca_returned =
       ::TensorExpressions::evaluate<TensorIndexD, TensorIndexB, TensorIndexC,
                                     TensorIndexA>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  L_dbca_type L_dbca_filled{};
+  ::TensorExpressions::evaluate<TensorIndexD, TensorIndexB, TensorIndexC,
+                                TensorIndexA>(
+      make_not_null(&L_dbca_filled),
+      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{dcab} = R_{abcd}
   using L_dcab_symmetry =
@@ -330,10 +488,17 @@ void test_evaluate_rank_4() noexcept {
   using L_dcab_tensorindextype_list =
       tmpl::list<rhs_tensorindextype_d, rhs_tensorindextype_c,
                  rhs_tensorindextype_a, rhs_tensorindextype_b>;
-  const Tensor<DataType, L_dcab_symmetry, L_dcab_tensorindextype_list> L_dcab =
+  using L_dcab_type =
+      Tensor<DataType, L_dcab_symmetry, L_dcab_tensorindextype_list>;
+  const L_dcab_type L_dcab_returned =
       ::TensorExpressions::evaluate<TensorIndexD, TensorIndexC, TensorIndexA,
                                     TensorIndexB>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  L_dcab_type L_dcab_filled{};
+  ::TensorExpressions::evaluate<TensorIndexD, TensorIndexC, TensorIndexA,
+                                TensorIndexB>(
+      make_not_null(&L_dcab_filled),
+      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   // L_{dcba} = R_{abcd}
   using L_dcba_symmetry =
@@ -342,10 +507,17 @@ void test_evaluate_rank_4() noexcept {
   using L_dcba_tensorindextype_list =
       tmpl::list<rhs_tensorindextype_d, rhs_tensorindextype_c,
                  rhs_tensorindextype_b, rhs_tensorindextype_a>;
-  const Tensor<DataType, L_dcba_symmetry, L_dcba_tensorindextype_list> L_dcba =
+  using L_dcba_type =
+      Tensor<DataType, L_dcba_symmetry, L_dcba_tensorindextype_list>;
+  const L_dcba_type L_dcba_returned =
       ::TensorExpressions::evaluate<TensorIndexD, TensorIndexC, TensorIndexB,
                                     TensorIndexA>(
           R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  L_dcba_type L_dcba_filled{};
+  ::TensorExpressions::evaluate<TensorIndexD, TensorIndexC, TensorIndexB,
+                                TensorIndexA>(
+      make_not_null(&L_dcba_filled),
+      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
 
   const size_t dim_a = tmpl::at_c<RhsTensorIndexTypeList, 0>::dim;
   const size_t dim_b = tmpl::at_c<RhsTensorIndexTypeList, 1>::dim;
@@ -357,53 +529,377 @@ void test_evaluate_rank_4() noexcept {
       for (size_t k = 0; k < dim_c; ++k) {
           for (size_t l = 0; l < dim_d; ++l) {
             // For L_{abcd} = R_{abcd}, check that L_{ijkl} == R_{ijkl}
-            CHECK(L_abcd.get(i, j, k, l) == R_abcd.get(i, j, k, l));
+            CHECK(L_abcd_returned.get(i, j, k, l) == R_abcd.get(i, j, k, l));
+            CHECK(L_abcd_filled.get(i, j, k, l) == R_abcd.get(i, j, k, l));
             // For L_{abdc} = R_{abcd}, check that L_{ijlk} == R_{ijkl}
-            CHECK(L_abdc.get(i, j, l, k) == R_abcd.get(i, j, k, l));
+            CHECK(L_abdc_returned.get(i, j, l, k) == R_abcd.get(i, j, k, l));
+            CHECK(L_abdc_filled.get(i, j, l, k) == R_abcd.get(i, j, k, l));
             // For L_{acbd} = R_{abcd}, check that L_{ikjl} == R_{ijkl}
-            CHECK(L_acbd.get(i, k, j, l) == R_abcd.get(i, j, k, l));
+            CHECK(L_acbd_returned.get(i, k, j, l) == R_abcd.get(i, j, k, l));
+            CHECK(L_acbd_filled.get(i, k, j, l) == R_abcd.get(i, j, k, l));
             // For L_{acdb} = R_{abcd}, check that L_{iklj} == R_{ijkl}
-            CHECK(L_acdb.get(i, k, l, j) == R_abcd.get(i, j, k, l));
+            CHECK(L_acdb_returned.get(i, k, l, j) == R_abcd.get(i, j, k, l));
+            CHECK(L_acdb_filled.get(i, k, l, j) == R_abcd.get(i, j, k, l));
             // For L_{adbc} = R_{abcd}, check that L_{iljk} == R_{ijkl}
-            CHECK(L_adbc.get(i, l, j, k) == R_abcd.get(i, j, k, l));
+            CHECK(L_adbc_returned.get(i, l, j, k) == R_abcd.get(i, j, k, l));
+            CHECK(L_adbc_filled.get(i, l, j, k) == R_abcd.get(i, j, k, l));
             // For L_{adcb} = R_{abcd}, check that L_{ilkj} == R_{ijkl}
-            CHECK(L_adcb.get(i, l, k, j) == R_abcd.get(i, j, k, l));
+            CHECK(L_adcb_returned.get(i, l, k, j) == R_abcd.get(i, j, k, l));
+            CHECK(L_adcb_filled.get(i, l, k, j) == R_abcd.get(i, j, k, l));
             // For L_{bacd} = R_{abcd}, check that L_{jikl} == R_{ijkl}
-            CHECK(L_bacd.get(j, i, k, l) == R_abcd.get(i, j, k, l));
+            CHECK(L_bacd_returned.get(j, i, k, l) == R_abcd.get(i, j, k, l));
+            CHECK(L_bacd_filled.get(j, i, k, l) == R_abcd.get(i, j, k, l));
             // For L_{badc} = R_{abcd}, check that L_{jilk} == R_{ijkl}
-            CHECK(L_badc.get(j, i, l, k) == R_abcd.get(i, j, k, l));
+            CHECK(L_badc_returned.get(j, i, l, k) == R_abcd.get(i, j, k, l));
+            CHECK(L_badc_filled.get(j, i, l, k) == R_abcd.get(i, j, k, l));
             // For L_{bcad} = R_{abcd}, check that L_{jkil} == R_{ijkl}
-            CHECK(L_bcad.get(j, k, i, l) == R_abcd.get(i, j, k, l));
+            CHECK(L_bcad_returned.get(j, k, i, l) == R_abcd.get(i, j, k, l));
+            CHECK(L_bcad_filled.get(j, k, i, l) == R_abcd.get(i, j, k, l));
             // For L_{bcda} = R_{abcd}, check that L_{jkli} == R_{ijkl}
-            CHECK(L_bcda.get(j, k, l, i) == R_abcd.get(i, j, k, l));
+            CHECK(L_bcda_returned.get(j, k, l, i) == R_abcd.get(i, j, k, l));
+            CHECK(L_bcda_filled.get(j, k, l, i) == R_abcd.get(i, j, k, l));
             // For L_{bdac} = R_{abcd}, check that L_{jlik} == R_{ijkl}
-            CHECK(L_bdac.get(j, l, i, k) == R_abcd.get(i, j, k, l));
+            CHECK(L_bdac_returned.get(j, l, i, k) == R_abcd.get(i, j, k, l));
+            CHECK(L_bdac_filled.get(j, l, i, k) == R_abcd.get(i, j, k, l));
             // For L_{bdca} = R_{abcd}, check that L_{jlki} == R_{ijkl}
-            CHECK(L_bdca.get(j, l, k, i) == R_abcd.get(i, j, k, l));
+            CHECK(L_bdca_returned.get(j, l, k, i) == R_abcd.get(i, j, k, l));
+            CHECK(L_bdca_filled.get(j, l, k, i) == R_abcd.get(i, j, k, l));
             // For L_{cabd} = R_{abcd}, check that L_{kijl} == R_{ijkl}
-            CHECK(L_cabd.get(k, i, j, l) == R_abcd.get(i, j, k, l));
+            CHECK(L_cabd_returned.get(k, i, j, l) == R_abcd.get(i, j, k, l));
+            CHECK(L_cabd_filled.get(k, i, j, l) == R_abcd.get(i, j, k, l));
             // For L_{cadb} = R_{abcd}, check that L_{kilj} == R_{ijkl}
-            CHECK(L_cadb.get(k, i, l, j) == R_abcd.get(i, j, k, l));
+            CHECK(L_cadb_returned.get(k, i, l, j) == R_abcd.get(i, j, k, l));
+            CHECK(L_cadb_filled.get(k, i, l, j) == R_abcd.get(i, j, k, l));
             // For L_{cbad} = R_{abcd}, check that L_{kjil} == R_{ijkl}
-            CHECK(L_cbad.get(k, j, i, l) == R_abcd.get(i, j, k, l));
+            CHECK(L_cbad_returned.get(k, j, i, l) == R_abcd.get(i, j, k, l));
+            CHECK(L_cbad_filled.get(k, j, i, l) == R_abcd.get(i, j, k, l));
             // For L_{cbda} = R_{abcd}, check that L_{kjli} == R_{ijkl}
-            CHECK(L_cbda.get(k, j, l, i) == R_abcd.get(i, j, k, l));
+            CHECK(L_cbda_returned.get(k, j, l, i) == R_abcd.get(i, j, k, l));
+            CHECK(L_cbda_filled.get(k, j, l, i) == R_abcd.get(i, j, k, l));
             // For L_{cdab} = R_{abcd}, check that L_{klij} == R_{ijkl}
-            CHECK(L_cdab.get(k, l, i, j) == R_abcd.get(i, j, k, l));
+            CHECK(L_cdab_returned.get(k, l, i, j) == R_abcd.get(i, j, k, l));
+            CHECK(L_cdab_filled.get(k, l, i, j) == R_abcd.get(i, j, k, l));
             // For L_{cdba} = R_{abcd}, check that L_{klji} == R_{ijkl}
-            CHECK(L_cdba.get(k, l, j, i) == R_abcd.get(i, j, k, l));
+            CHECK(L_cdba_returned.get(k, l, j, i) == R_abcd.get(i, j, k, l));
+            CHECK(L_cdba_filled.get(k, l, j, i) == R_abcd.get(i, j, k, l));
             // For L_{dabc} = R_{abcd}, check that L_{lijk} == R_{ijkl}
-            CHECK(L_dabc.get(l, i, j, k) == R_abcd.get(i, j, k, l));
+            CHECK(L_dabc_returned.get(l, i, j, k) == R_abcd.get(i, j, k, l));
+            CHECK(L_dabc_filled.get(l, i, j, k) == R_abcd.get(i, j, k, l));
             // For L_{dacb} = R_{abcd}, check that L_{likj} == R_{ijkl}
-            CHECK(L_dacb.get(l, i, k, j) == R_abcd.get(i, j, k, l));
+            CHECK(L_dacb_returned.get(l, i, k, j) == R_abcd.get(i, j, k, l));
+            CHECK(L_dacb_filled.get(l, i, k, j) == R_abcd.get(i, j, k, l));
             // For L_{dbac} = R_{abcd}, check that L_{ljik} == R_{ijkl}
-            CHECK(L_dbac.get(l, j, i, k) == R_abcd.get(i, j, k, l));
+            CHECK(L_dbac_returned.get(l, j, i, k) == R_abcd.get(i, j, k, l));
+            CHECK(L_dbac_filled.get(l, j, i, k) == R_abcd.get(i, j, k, l));
             // For L_{dbca} = R_{abcd}, check that L_{ljki} == R_{ijkl}
-            CHECK(L_dbca.get(l, j, k, i) == R_abcd.get(i, j, k, l));
+            CHECK(L_dbca_returned.get(l, j, k, i) == R_abcd.get(i, j, k, l));
+            CHECK(L_dbca_filled.get(l, j, k, i) == R_abcd.get(i, j, k, l));
             // For L_{dcab} = R_{abcd}, check that L_{lkij} == R_{ijkl}
-            CHECK(L_dcab.get(l, k, i, j) == R_abcd.get(i, j, k, l));
+            CHECK(L_dcab_returned.get(l, k, i, j) == R_abcd.get(i, j, k, l));
+            CHECK(L_dcab_filled.get(l, k, i, j) == R_abcd.get(i, j, k, l));
             // For L_{dcba} = R_{abcd}, check that L_{lkji} == R_{ijkl}
-            CHECK(L_dcba.get(l, k, j, i) == R_abcd.get(i, j, k, l));
+            CHECK(L_dcba_returned.get(l, k, j, i) == R_abcd.get(i, j, k, l));
+            CHECK(L_dcba_filled.get(l, k, j, i) == R_abcd.get(i, j, k, l));
+        }
+      }
+    }
+  }
+
+  // Test with TempTensor for LHS tensor
+  if constexpr (not std::is_same_v<DataType, double>) {
+    // L_{abcd} = R_{abcd}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_abcd_type>>> L_abcd_var{
+        used_for_size};
+    L_abcd_type& L_abcd_temp =
+        get<::Tags::TempTensor<1, L_abcd_type>>(L_abcd_var);
+    ::TensorExpressions::evaluate<TensorIndexA, TensorIndexB, TensorIndexC,
+                                  TensorIndexD>(
+        make_not_null(&L_abcd_temp),
+        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+
+    // L_{abdc} = R_{abcd}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_abdc_type>>> L_abdc_var{
+        used_for_size};
+    L_abdc_type& L_abdc_temp =
+        get<::Tags::TempTensor<1, L_abdc_type>>(L_abdc_var);
+    ::TensorExpressions::evaluate<TensorIndexA, TensorIndexB, TensorIndexD,
+                                  TensorIndexC>(
+        make_not_null(&L_abdc_temp),
+        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+
+    // L_{acbd} = R_{abcd}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_acbd_type>>> L_acbd_var{
+        used_for_size};
+    L_acbd_type& L_acbd_temp =
+        get<::Tags::TempTensor<1, L_acbd_type>>(L_acbd_var);
+    ::TensorExpressions::evaluate<TensorIndexA, TensorIndexC, TensorIndexB,
+                                  TensorIndexD>(
+        make_not_null(&L_acbd_temp),
+        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+
+    // L_{acdb} = R_{abcd}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_acdb_type>>> L_acdb_var{
+        used_for_size};
+    L_acdb_type& L_acdb_temp =
+        get<::Tags::TempTensor<1, L_acdb_type>>(L_acdb_var);
+    ::TensorExpressions::evaluate<TensorIndexA, TensorIndexC, TensorIndexD,
+                                  TensorIndexB>(
+        make_not_null(&L_acdb_temp),
+        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+
+    // L_{adbc} = R_{abcd}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_adbc_type>>> L_adbc_var{
+        used_for_size};
+    L_adbc_type& L_adbc_temp =
+        get<::Tags::TempTensor<1, L_adbc_type>>(L_adbc_var);
+    ::TensorExpressions::evaluate<TensorIndexA, TensorIndexD, TensorIndexB,
+                                  TensorIndexC>(
+        make_not_null(&L_adbc_temp),
+        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+
+    // L_{adcb} = R_{abcd}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_adcb_type>>> L_adcb_var{
+        used_for_size};
+    L_adcb_type& L_adcb_temp =
+        get<::Tags::TempTensor<1, L_adcb_type>>(L_adcb_var);
+    ::TensorExpressions::evaluate<TensorIndexA, TensorIndexD, TensorIndexC,
+                                  TensorIndexB>(
+        make_not_null(&L_adcb_temp),
+        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+
+    // L_{bacd} = R_{abcd}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_bacd_type>>> L_bacd_var{
+        used_for_size};
+    L_bacd_type& L_bacd_temp =
+        get<::Tags::TempTensor<1, L_bacd_type>>(L_bacd_var);
+    ::TensorExpressions::evaluate<TensorIndexB, TensorIndexA, TensorIndexC,
+                                  TensorIndexD>(
+        make_not_null(&L_bacd_temp),
+        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+
+    // L_{badc} = R_{abcd}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_badc_type>>> L_badc_var{
+        used_for_size};
+    L_badc_type& L_badc_temp =
+        get<::Tags::TempTensor<1, L_badc_type>>(L_badc_var);
+    ::TensorExpressions::evaluate<TensorIndexB, TensorIndexA, TensorIndexD,
+                                  TensorIndexC>(
+        make_not_null(&L_badc_temp),
+        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+
+    // L_{bcad} = R_{abcd}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_bcad_type>>> L_bcad_var{
+        used_for_size};
+    L_bcad_type& L_bcad_temp =
+        get<::Tags::TempTensor<1, L_bcad_type>>(L_bcad_var);
+    ::TensorExpressions::evaluate<TensorIndexB, TensorIndexC, TensorIndexA,
+                                  TensorIndexD>(
+        make_not_null(&L_bcad_temp),
+        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+
+    // L_{bcda} = R_{abcd}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_bcda_type>>> L_bcda_var{
+        used_for_size};
+    L_bcda_type& L_bcda_temp =
+        get<::Tags::TempTensor<1, L_bcda_type>>(L_bcda_var);
+    ::TensorExpressions::evaluate<TensorIndexB, TensorIndexC, TensorIndexD,
+                                  TensorIndexA>(
+        make_not_null(&L_bcda_temp),
+        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+
+    // L_{bdac} = R_{abcd}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_bdac_type>>> L_bdac_var{
+        used_for_size};
+    L_bdac_type& L_bdac_temp =
+        get<::Tags::TempTensor<1, L_bdac_type>>(L_bdac_var);
+    ::TensorExpressions::evaluate<TensorIndexB, TensorIndexD, TensorIndexA,
+                                  TensorIndexC>(
+        make_not_null(&L_bdac_temp),
+        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+
+    // L_{bdca} = R_{abcd}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_bdca_type>>> L_bdca_var{
+        used_for_size};
+    L_bdca_type& L_bdca_temp =
+        get<::Tags::TempTensor<1, L_bdca_type>>(L_bdca_var);
+    ::TensorExpressions::evaluate<TensorIndexB, TensorIndexD, TensorIndexC,
+                                  TensorIndexA>(
+        make_not_null(&L_bdca_temp),
+        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+
+    // L_{cabd} = R_{abcd}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_cabd_type>>> L_cabd_var{
+        used_for_size};
+    L_cabd_type& L_cabd_temp =
+        get<::Tags::TempTensor<1, L_cabd_type>>(L_cabd_var);
+    ::TensorExpressions::evaluate<TensorIndexC, TensorIndexA, TensorIndexB,
+                                  TensorIndexD>(
+        make_not_null(&L_cabd_temp),
+        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+
+    // L_{cadb} = R_{abcd}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_cadb_type>>> L_cadb_var{
+        used_for_size};
+    L_cadb_type& L_cadb_temp =
+        get<::Tags::TempTensor<1, L_cadb_type>>(L_cadb_var);
+    ::TensorExpressions::evaluate<TensorIndexC, TensorIndexA, TensorIndexD,
+                                  TensorIndexB>(
+        make_not_null(&L_cadb_temp),
+        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+
+    // L_{cbad} = R_{abcd}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_cbad_type>>> L_cbad_var{
+        used_for_size};
+    L_cbad_type& L_cbad_temp =
+        get<::Tags::TempTensor<1, L_cbad_type>>(L_cbad_var);
+    ::TensorExpressions::evaluate<TensorIndexC, TensorIndexB, TensorIndexA,
+                                  TensorIndexD>(
+        make_not_null(&L_cbad_temp),
+        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+
+    // L_{cbda} = R_{abcd}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_cbda_type>>> L_cbda_var{
+        used_for_size};
+    L_cbda_type& L_cbda_temp =
+        get<::Tags::TempTensor<1, L_cbda_type>>(L_cbda_var);
+    ::TensorExpressions::evaluate<TensorIndexC, TensorIndexB, TensorIndexD,
+                                  TensorIndexA>(
+        make_not_null(&L_cbda_temp),
+        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+
+    // L_{cdab} = R_{abcd}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_cdab_type>>> L_cdab_var{
+        used_for_size};
+    L_cdab_type& L_cdab_temp =
+        get<::Tags::TempTensor<1, L_cdab_type>>(L_cdab_var);
+    ::TensorExpressions::evaluate<TensorIndexC, TensorIndexD, TensorIndexA,
+                                  TensorIndexB>(
+        make_not_null(&L_cdab_temp),
+        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+
+    // L_{cdba} = R_{abcd}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_cdba_type>>> L_cdba_var{
+        used_for_size};
+    L_cdba_type& L_cdba_temp =
+        get<::Tags::TempTensor<1, L_cdba_type>>(L_cdba_var);
+    ::TensorExpressions::evaluate<TensorIndexC, TensorIndexD, TensorIndexB,
+                                  TensorIndexA>(
+        make_not_null(&L_cdba_temp),
+        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+
+    // L_{dabc} = R_{abcd}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_dabc_type>>> L_dabc_var{
+        used_for_size};
+    L_dabc_type& L_dabc_temp =
+        get<::Tags::TempTensor<1, L_dabc_type>>(L_dabc_var);
+    ::TensorExpressions::evaluate<TensorIndexD, TensorIndexA, TensorIndexB,
+                                  TensorIndexC>(
+        make_not_null(&L_dabc_temp),
+        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+
+    // L_{dacb} = R_{abcd}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_dacb_type>>> L_dacb_var{
+        used_for_size};
+    L_dacb_type& L_dacb_temp =
+        get<::Tags::TempTensor<1, L_dacb_type>>(L_dacb_var);
+    ::TensorExpressions::evaluate<TensorIndexD, TensorIndexA, TensorIndexC,
+                                  TensorIndexB>(
+        make_not_null(&L_dacb_temp),
+        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+
+    // L_{dbac} = R_{abcd}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_dbac_type>>> L_dbac_var{
+        used_for_size};
+    L_dbac_type& L_dbac_temp =
+        get<::Tags::TempTensor<1, L_dbac_type>>(L_dbac_var);
+    ::TensorExpressions::evaluate<TensorIndexD, TensorIndexB, TensorIndexA,
+                                  TensorIndexC>(
+        make_not_null(&L_dbac_temp),
+        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+
+    // L_{dbca} = R_{abcd}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_dbca_type>>> L_dbca_var{
+        used_for_size};
+    L_dbca_type& L_dbca_temp =
+        get<::Tags::TempTensor<1, L_dbca_type>>(L_dbca_var);
+    ::TensorExpressions::evaluate<TensorIndexD, TensorIndexB, TensorIndexC,
+                                  TensorIndexA>(
+        make_not_null(&L_dbca_temp),
+        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+
+    // L_{dcab} = R_{abcd}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_dcab_type>>> L_dcab_var{
+        used_for_size};
+    L_dcab_type& L_dcab_temp =
+        get<::Tags::TempTensor<1, L_dcab_type>>(L_dcab_var);
+    ::TensorExpressions::evaluate<TensorIndexD, TensorIndexC, TensorIndexA,
+                                  TensorIndexB>(
+        make_not_null(&L_dcab_temp),
+        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+
+    // L_{dcba} = R_{abcd}
+    Variables<tmpl::list<::Tags::TempTensor<1, L_dcba_type>>> L_dcba_var{
+        used_for_size};
+    L_dcba_type& L_dcba_temp =
+        get<::Tags::TempTensor<1, L_dcba_type>>(L_dcba_var);
+    ::TensorExpressions::evaluate<TensorIndexD, TensorIndexC, TensorIndexB,
+                                  TensorIndexA>(
+        make_not_null(&L_dcba_temp),
+        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+
+    for (size_t i = 0; i < dim_a; ++i) {
+      for (size_t j = 0; j < dim_b; ++j) {
+        for (size_t k = 0; k < dim_c; ++k) {
+          for (size_t l = 0; l < dim_d; ++l) {
+            // For L_{abcd} = R_{abcd}, check that L_{ijkl} == R_{ijkl}
+            CHECK(L_abcd_temp.get(i, j, k, l) == R_abcd.get(i, j, k, l));
+            // For L_{abdc} = R_{abcd}, check that L_{ijlk} == R_{ijkl}
+            CHECK(L_abdc_temp.get(i, j, l, k) == R_abcd.get(i, j, k, l));
+            // For L_{acbd} = R_{abcd}, check that L_{ikjl} == R_{ijkl}
+            CHECK(L_acbd_temp.get(i, k, j, l) == R_abcd.get(i, j, k, l));
+            // For L_{acdb} = R_{abcd}, check that L_{iklj} == R_{ijkl}
+            CHECK(L_acdb_temp.get(i, k, l, j) == R_abcd.get(i, j, k, l));
+            // For L_{adbc} = R_{abcd}, check that L_{iljk} == R_{ijkl}
+            CHECK(L_adbc_temp.get(i, l, j, k) == R_abcd.get(i, j, k, l));
+            // For L_{adcb} = R_{abcd}, check that L_{ilkj} == R_{ijkl}
+            CHECK(L_adcb_temp.get(i, l, k, j) == R_abcd.get(i, j, k, l));
+            // For L_{bacd} = R_{abcd}, check that L_{jikl} == R_{ijkl}
+            CHECK(L_bacd_temp.get(j, i, k, l) == R_abcd.get(i, j, k, l));
+            // For L_{badc} = R_{abcd}, check that L_{jilk} == R_{ijkl}
+            CHECK(L_badc_temp.get(j, i, l, k) == R_abcd.get(i, j, k, l));
+            // For L_{bcad} = R_{abcd}, check that L_{jkil} == R_{ijkl}
+            CHECK(L_bcad_temp.get(j, k, i, l) == R_abcd.get(i, j, k, l));
+            // For L_{bcda} = R_{abcd}, check that L_{jkli} == R_{ijkl}
+            CHECK(L_bcda_temp.get(j, k, l, i) == R_abcd.get(i, j, k, l));
+            // For L_{bdac} = R_{abcd}, check that L_{jlik} == R_{ijkl}
+            CHECK(L_bdac_temp.get(j, l, i, k) == R_abcd.get(i, j, k, l));
+            // For L_{bdca} = R_{abcd}, check that L_{jlki} == R_{ijkl}
+            CHECK(L_bdca_temp.get(j, l, k, i) == R_abcd.get(i, j, k, l));
+            // For L_{cabd} = R_{abcd}, check that L_{kijl} == R_{ijkl}
+            CHECK(L_cabd_temp.get(k, i, j, l) == R_abcd.get(i, j, k, l));
+            // For L_{cadb} = R_{abcd}, check that L_{kilj} == R_{ijkl}
+            CHECK(L_cadb_temp.get(k, i, l, j) == R_abcd.get(i, j, k, l));
+            // For L_{cbad} = R_{abcd}, check that L_{kjil} == R_{ijkl}
+            CHECK(L_cbad_temp.get(k, j, i, l) == R_abcd.get(i, j, k, l));
+            // For L_{cbda} = R_{abcd}, check that L_{kjli} == R_{ijkl}
+            CHECK(L_cbda_temp.get(k, j, l, i) == R_abcd.get(i, j, k, l));
+            // For L_{cdab} = R_{abcd}, check that L_{klij} == R_{ijkl}
+            CHECK(L_cdab_temp.get(k, l, i, j) == R_abcd.get(i, j, k, l));
+            // For L_{cdba} = R_{abcd}, check that L_{klji} == R_{ijkl}
+            CHECK(L_cdba_temp.get(k, l, j, i) == R_abcd.get(i, j, k, l));
+            // For L_{dabc} = R_{abcd}, check that L_{lijk} == R_{ijkl}
+            CHECK(L_dabc_temp.get(l, i, j, k) == R_abcd.get(i, j, k, l));
+            // For L_{dacb} = R_{abcd}, check that L_{likj} == R_{ijkl}
+            CHECK(L_dacb_temp.get(l, i, k, j) == R_abcd.get(i, j, k, l));
+            // For L_{dbac} = R_{abcd}, check that L_{ljik} == R_{ijkl}
+            CHECK(L_dbac_temp.get(l, j, i, k) == R_abcd.get(i, j, k, l));
+            // For L_{dbca} = R_{abcd}, check that L_{ljki} == R_{ijkl}
+            CHECK(L_dbca_temp.get(l, j, k, i) == R_abcd.get(i, j, k, l));
+            // For L_{dcab} = R_{abcd}, check that L_{lkij} == R_{ijkl}
+            CHECK(L_dcab_temp.get(l, k, i, j) == R_abcd.get(i, j, k, l));
+            // For L_{dcba} = R_{abcd}, check that L_{lkji} == R_{ijkl}
+            CHECK(L_dcba_temp.get(l, k, j, i) == R_abcd.get(i, j, k, l));
+          }
         }
       }
     }


### PR DESCRIPTION
## Proposed changes

This PR adds and tests an overload of `TensorExpressions::evaluate` that takes the resultant LHS `Tensor` as an argument to be filled by `evaluate`, as opposed to being constructed and returned. The motivation for this PR is to have tensor expressions support computing the components of previously-constructed/allocated `Tensor`s.

The existing `evaluate` is used like:
```
auto L = TensorExpressions::evaluate<ti_a, ti_b>(R(ti_a, ti_b) + S(ti_a, ti_b));
```
The `evaluate` overload added in this PR is instead used like:
```
Tensor<...> L{};
TensorExpressions::evaluate<ti_a, ti_b>(make_not_null(&L), R(ti_a, ti_b) + S(ti_a, ti_b));
```

Existing lower level tests for `TensorExpressions::evaluate` as well as the higher level test in `Test_MixedOperations.cpp` have been extended to now test both overloads.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
