### PR TITLE
Add elliptic InitializeBackgroundFields action

### DIFF
--- a/src/Elliptic/Actions/CMakeLists.txt
+++ b/src/Elliptic/Actions/CMakeLists.txt
@@ -6,6 +6,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   InitializeAnalyticSolution.hpp
+  InitializeBackgroundFields.hpp
   InitializeFields.hpp
   InitializeFixedSources.hpp
   )

--- a/src/Elliptic/Actions/InitializeBackgroundFields.hpp
+++ b/src/Elliptic/Actions/InitializeBackgroundFields.hpp
@@ -1,0 +1,79 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Tags.hpp"
+#include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace Parallel {
+template <typename Metavariables>
+struct GlobalCache;
+}  // namespace Parallel
+/// \endcond
+
+namespace elliptic::Actions {
+
+/*!
+ * \brief Initialize the variable-independent background fields for an elliptic
+ * solve.
+ *
+ * Examples for background fields would be a background metric, associated
+ * curvature quantities, or matter sources such as a mass-density in the XCTS
+ * equations.
+ *
+ * This action retrieves the `System::background_fields` from the
+ * `BackgroundTag`.
+ *
+ * Uses:
+ * - System:
+ *   - `background_fields`
+ * - DataBox:
+ *   - `BackgroundTag`
+ *   - `domain::Tags::Coordinates<Dim, Frame::Inertial>`
+ *
+ * DataBox:
+ * - Adds:
+ *   - `::Tags::Variables<background_fields>`
+ */
+template <typename System, typename BackgroundTag>
+struct InitializeBackgroundFields {
+ private:
+  using background_fields_tag =
+      ::Tags::Variables<typename System::background_fields>;
+
+ public:
+  using simple_tags = tmpl::list<background_fields_tag>;
+  using compute_tags = tmpl::list<>;
+
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            size_t Dim, typename ActionList, typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTags>&&> apply(
+      db::DataBox<DbTags>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ElementId<Dim>& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    const auto& background = db::get<BackgroundTag>(box);
+    const auto& inertial_coords =
+        get<domain::Tags::Coordinates<Dim, Frame::Inertial>>(box);
+    auto background_fields = variables_from_tagged_tuple(background.variables(
+        inertial_coords, typename background_fields_tag::tags_list{}));
+    ::Initialization::mutate_assign<simple_tags>(make_not_null(&box),
+                                                 std::move(background_fields));
+    return {std::move(box)};
+  }
+};
+
+}  // namespace elliptic::Actions

--- a/tests/Unit/Elliptic/Actions/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Actions/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_EllipticActions")
 
 set(LIBRARY_SOURCES
   Test_InitializeAnalyticSolution.cpp
+  Test_InitializeBackgroundFields.cpp
   Test_InitializeFields.cpp
   Test_InitializeFixedSources.cpp
   )

--- a/tests/Unit/Elliptic/Actions/Test_InitializeBackgroundFields.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeBackgroundFields.cpp
@@ -1,0 +1,107 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <pup.h>
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Creators/Interval.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/Actions/InitializeBackgroundFields.hpp"
+#include "Elliptic/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
+#include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+
+struct BackgroundFieldTag : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+struct System {
+  using background_fields = tmpl::list<BackgroundFieldTag>;
+};
+
+struct Background {
+  static tuples::TaggedTuple<BackgroundFieldTag> variables(
+      const tnsr::I<DataVector, 1>& x,
+      tmpl::list<BackgroundFieldTag> /*meta*/) noexcept {
+    return {Scalar<DataVector>{get<0>(x)}};
+  }
+  // NOLINTNEXTLINE
+  void pup(PUP::er& /*p*/) noexcept {}
+};
+
+template <typename Metavariables>
+struct ElementArray {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementId<1>;
+  using const_global_cache_tags = tmpl::list<domain::Tags::Domain<1>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          tmpl::list<ActionTesting::InitializeDataBox<
+                         tmpl::list<domain::Tags::InitialRefinementLevels<1>,
+                                    domain::Tags::InitialExtents<1>>>,
+                     Actions::SetupDataBox, dg::Actions::InitializeDomain<1>>>,
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          tmpl::list<::elliptic::Actions::InitializeBackgroundFields<
+              typename Metavariables::system,
+              elliptic::Tags::Background<Background>>>>>;
+};
+
+struct Metavariables {
+  using system = System;
+  using component_list = tmpl::list<ElementArray<Metavariables>>;
+  using const_global_cache_tags =
+      tmpl::list<elliptic::Tags::Background<Background>>;
+  enum class Phase { Initialization, Testing, Exit };
+};
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeBackgroundFields",
+                  "[Unit][Elliptic][Actions]") {
+  domain::creators::register_derived_with_charm();
+  // Which element we work with does not matter for this test
+  const ElementId<1> element_id{0, {{SegmentId{2, 1}}}};
+  const domain::creators::Interval domain_creator{{{-0.5}}, {{1.5}},   {{2}},
+                                                  {{4}},    {{false}}, nullptr};
+
+  using element_array = ElementArray<Metavariables>;
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{
+      {std::make_unique<Background>(), domain_creator.create_domain()}};
+  ActionTesting::emplace_component_and_initialize<element_array>(
+      &runner, element_id,
+      {domain_creator.initial_refinement_levels(),
+       domain_creator.initial_extents()});
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::next_action<element_array>(make_not_null(&runner),
+                                              element_id);
+  }
+  ActionTesting::set_phase(make_not_null(&runner),
+                           Metavariables::Phase::Testing);
+  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
+  const auto get_tag = [&runner, &element_id ](auto tag_v) -> const auto& {
+    using tag = std::decay_t<decltype(tag_v)>;
+    return ActionTesting::get_databox_tag<element_array, tag>(runner,
+                                                              element_id);
+  };
+
+  const auto& inertial_coords =
+      get_tag(domain::Tags::Coordinates<1, Frame::Inertial>{});
+  CHECK(get(get_tag(BackgroundFieldTag{})) == get<0>(inertial_coords));
+}


### PR DESCRIPTION
## Proposed changes

This action initializes the variable-independent background fields, e.g. the matter sources and geometric quantities such as the conformal metric for XCTS solves.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
