### PR TITLE
Add action to reset Schwarz subdomain solver

### DIFF
--- a/src/NumericalAlgorithms/Convergence/HasConverged.cpp
+++ b/src/NumericalAlgorithms/Convergence/HasConverged.cpp
@@ -10,6 +10,7 @@
 #include "Parallel/PupStlCpp17.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GetOutput.hpp"
 
 namespace Convergence {
 
@@ -84,15 +85,16 @@ std::ostream& operator<<(std::ostream& os,
       case Reason::AbsoluteResidual:
         return os
                << "AbsoluteResidual - The residual magnitude has decreased to "
-               << has_converged.criteria_.absolute_residual << " or below ("
-               << has_converged.residual_magnitude_ << ").";
+               << get_output(has_converged.criteria_.absolute_residual)
+               << " or below (" << get_output(has_converged.residual_magnitude_)
+               << ").";
       case Reason::RelativeResidual:
         return os << "RelativeResidual - The residual magnitude has decreased "
                      "to a fraction of "
-                  << has_converged.criteria_.relative_residual
+                  << get_output(has_converged.criteria_.relative_residual)
                   << " of its initial value or below ("
-                  << has_converged.residual_magnitude_ /
-                         has_converged.initial_residual_magnitude_
+                  << get_output(has_converged.residual_magnitude_ /
+                                has_converged.initial_residual_magnitude_)
                   << ").";
       default:
         ERROR("Unknown convergence reason");

--- a/src/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/ElementActions.hpp
@@ -84,16 +84,16 @@ void contribute_to_residual_observation(
                ::Verbosity::Verbose)) {
     if (iteration_id == 0) {
       Parallel::printf(
-          "Linear solver '" + Options::name<OptionsGroup>() +
-              "' initialized on element %s. Remaining local residual: %e\n",
-          get_output(array_index), sqrt(residual_magnitude_square));
+          "Linear solver '%s' initialized on element %s. Remaining local "
+          "residual: %e\n",
+          Options::name<OptionsGroup>(), get_output(array_index),
+          sqrt(residual_magnitude_square));
     } else {
-      Parallel::printf("Linear solver '" +
-                           Options::name<OptionsGroup>() +
-                           "' iteration %zu done on element %s. Remaining "
-                           "local residual: %e\n",
-                       iteration_id, get_output(array_index),
-                       sqrt(residual_magnitude_square));
+      Parallel::printf(
+          "Linear solver '%s' iteration %zu done on element %s. Remaining "
+          "local residual: %e\n",
+          Options::name<OptionsGroup>(), iteration_id, get_output(array_index),
+          sqrt(residual_magnitude_square));
     }
   }
 }

--- a/src/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/ElementActions.hpp
@@ -81,18 +81,15 @@ void contribute_to_residual_observation(
       std::vector<std::string>{"Iteration", "Residual"},
       reduction_data{iteration_id, residual_magnitude_square});
   if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(cache) >=
-               ::Verbosity::Verbose)) {
+               ::Verbosity::Debug)) {
     if (iteration_id == 0) {
-      Parallel::printf(
-          "Linear solver '%s' initialized on element %s. Remaining local "
-          "residual: %e\n",
-          Options::name<OptionsGroup>(), get_output(array_index),
-          sqrt(residual_magnitude_square));
+      Parallel::printf("%s %s initialized with local residual: %e\n",
+                       array_index, Options::name<OptionsGroup>(),
+                       sqrt(residual_magnitude_square));
     } else {
       Parallel::printf(
-          "Linear solver '%s' iteration %zu done on element %s. Remaining "
-          "local residual: %e\n",
-          Options::name<OptionsGroup>(), iteration_id, get_output(array_index),
+          "%s %s(%zu) iteration complete. Remaining local residual: %e\n",
+          array_index, Options::name<OptionsGroup>(), iteration_id,
           sqrt(residual_magnitude_square));
     }
   }

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp
@@ -78,17 +78,14 @@ struct InitializeResidual {
     // Do some logging
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(cache) >=
                  ::Verbosity::Verbose)) {
-      Parallel::printf("Linear solver '" +
-                           Options::name<OptionsGroup>() +
-                           "' initialized with residual: %e\n",
-                       residual_magnitude);
+      Parallel::printf("Linear solver '%s' initialized with residual: %e\n",
+                       Options::name<OptionsGroup>(), residual_magnitude);
     }
     if (UNLIKELY(has_converged and get<logging::Tags::Verbosity<OptionsGroup>>(
                                        cache) >= ::Verbosity::Quiet)) {
-      Parallel::printf("The linear solver '" +
-                           Options::name<OptionsGroup>() +
-                           "' has converged without any iterations: %s\n",
-                       has_converged);
+      Parallel::printf(
+          "The linear solver '%s' has converged without any iterations: %s\n",
+          Options::name<OptionsGroup>(), has_converged);
     }
 
     Parallel::receive_data<Tags::InitialHasConverged<OptionsGroup>>(
@@ -172,17 +169,16 @@ struct UpdateResidual {
     // Do some logging
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(cache) >=
                  ::Verbosity::Verbose)) {
-      Parallel::printf("Linear solver '" +
-                           Options::name<OptionsGroup>() +
-                           "' iteration %zu done. Remaining residual: %e\n",
-                       completed_iterations, residual_magnitude);
+      Parallel::printf(
+          "Linear solver '%s' iteration %zu done. Remaining residual: %e\n",
+          Options::name<OptionsGroup>(), completed_iterations,
+          residual_magnitude);
     }
     if (UNLIKELY(has_converged and get<logging::Tags::Verbosity<OptionsGroup>>(
                                        cache) >= ::Verbosity::Quiet)) {
-      Parallel::printf("The linear solver '" +
-                           Options::name<OptionsGroup>() +
-                           "' has converged in %zu iterations: %s\n",
-                       completed_iterations, has_converged);
+      Parallel::printf(
+          "The linear solver '%s' has converged in %zu iterations: %s\n",
+          Options::name<OptionsGroup>(), completed_iterations, has_converged);
     }
 
     Parallel::receive_data<Tags::ResidualRatioAndHasConverged<OptionsGroup>>(

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp
@@ -77,14 +77,14 @@ struct InitializeResidual {
 
     // Do some logging
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(cache) >=
-                 ::Verbosity::Verbose)) {
-      Parallel::printf("Linear solver '%s' initialized with residual: %e\n",
+                 ::Verbosity::Quiet)) {
+      Parallel::printf("%s initialized with residual: %e\n",
                        Options::name<OptionsGroup>(), residual_magnitude);
     }
     if (UNLIKELY(has_converged and get<logging::Tags::Verbosity<OptionsGroup>>(
                                        cache) >= ::Verbosity::Quiet)) {
       Parallel::printf(
-          "The linear solver '%s' has converged without any iterations: %s\n",
+          "%s has converged without any iterations: %s\n",
           Options::name<OptionsGroup>(), has_converged);
     }
 
@@ -168,16 +168,16 @@ struct UpdateResidual {
 
     // Do some logging
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(cache) >=
-                 ::Verbosity::Verbose)) {
+                 ::Verbosity::Quiet)) {
       Parallel::printf(
-          "Linear solver '%s' iteration %zu done. Remaining residual: %e\n",
+          "%s(%zu) iteration complete. Remaining residual: %e\n",
           Options::name<OptionsGroup>(), completed_iterations,
           residual_magnitude);
     }
     if (UNLIKELY(has_converged and get<logging::Tags::Verbosity<OptionsGroup>>(
                                        cache) >= ::Verbosity::Quiet)) {
       Parallel::printf(
-          "The linear solver '%s' has converged in %zu iterations: %s\n",
+          "%s has converged in %zu iterations: %s\n",
           Options::name<OptionsGroup>(), completed_iterations, has_converged);
     }
 

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitorActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitorActions.hpp
@@ -73,15 +73,14 @@ struct InitializeResidualMagnitude {
 
     // Do some logging
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(cache) >=
-                 ::Verbosity::Verbose)) {
-      Parallel::printf("Linear solver '%s' initialized with residual: %e\n",
+                 ::Verbosity::Quiet)) {
+      Parallel::printf("%s initialized with residual: %e\n",
                        Options::name<OptionsGroup>(), residual_magnitude);
     }
     if (UNLIKELY(has_converged and get<logging::Tags::Verbosity<OptionsGroup>>(
                                        cache) >= ::Verbosity::Quiet)) {
-      Parallel::printf(
-          "The linear solver '%s' has converged without any iterations: %s\n",
-          Options::name<OptionsGroup>(), has_converged);
+      Parallel::printf("%s has converged without any iterations: %s\n",
+                       Options::name<OptionsGroup>(), has_converged);
     }
 
     Parallel::receive_data<Tags::InitialOrthogonalization<OptionsGroup>>(
@@ -187,17 +186,16 @@ struct StoreOrthogonalization {
 
     // Do some logging
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(cache) >=
-                 ::Verbosity::Verbose)) {
-      Parallel::printf(
-          "Linear solver '%s' iteration %zu done. Remaining residual: %e\n",
-          Options::name<OptionsGroup>(), completed_iterations,
-          residual_magnitude);
+                 ::Verbosity::Quiet)) {
+      Parallel::printf("%s(%zu) iteration complete. Remaining residual: %e\n",
+                       Options::name<OptionsGroup>(), completed_iterations,
+                       residual_magnitude);
     }
     if (UNLIKELY(has_converged and get<logging::Tags::Verbosity<OptionsGroup>>(
                                        cache) >= ::Verbosity::Quiet)) {
-      Parallel::printf(
-          "The linear solver '%s' has converged in %zu iterations: %s\n",
-          Options::name<OptionsGroup>(), completed_iterations, has_converged);
+      Parallel::printf("%s has converged in %zu iterations: %s\n",
+                       Options::name<OptionsGroup>(), completed_iterations,
+                       has_converged);
     }
 
     Parallel::receive_data<Tags::FinalOrthogonalization<OptionsGroup>>(

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitorActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitorActions.hpp
@@ -74,17 +74,14 @@ struct InitializeResidualMagnitude {
     // Do some logging
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(cache) >=
                  ::Verbosity::Verbose)) {
-      Parallel::printf("Linear solver '" +
-                           Options::name<OptionsGroup>() +
-                           "' initialized with residual: %e\n",
-                       residual_magnitude);
+      Parallel::printf("Linear solver '%s' initialized with residual: %e\n",
+                       Options::name<OptionsGroup>(), residual_magnitude);
     }
     if (UNLIKELY(has_converged and get<logging::Tags::Verbosity<OptionsGroup>>(
                                        cache) >= ::Verbosity::Quiet)) {
-      Parallel::printf("The linear solver '" +
-                           Options::name<OptionsGroup>() +
-                           "' has converged without any iterations: %s\n",
-                       has_converged);
+      Parallel::printf(
+          "The linear solver '%s' has converged without any iterations: %s\n",
+          Options::name<OptionsGroup>(), has_converged);
     }
 
     Parallel::receive_data<Tags::InitialOrthogonalization<OptionsGroup>>(
@@ -191,17 +188,16 @@ struct StoreOrthogonalization {
     // Do some logging
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(cache) >=
                  ::Verbosity::Verbose)) {
-      Parallel::printf("Linear solver '" +
-                           Options::name<OptionsGroup>() +
-                           "' iteration %zu done. Remaining residual: %e\n",
-                       completed_iterations, residual_magnitude);
+      Parallel::printf(
+          "Linear solver '%s' iteration %zu done. Remaining residual: %e\n",
+          Options::name<OptionsGroup>(), completed_iterations,
+          residual_magnitude);
     }
     if (UNLIKELY(has_converged and get<logging::Tags::Verbosity<OptionsGroup>>(
                                        cache) >= ::Verbosity::Quiet)) {
-      Parallel::printf("The linear solver '" +
-                           Options::name<OptionsGroup>() +
-                           "' has converged in %zu iterations: %s\n",
-                       completed_iterations, has_converged);
+      Parallel::printf(
+          "The linear solver '%s' has converged in %zu iterations: %s\n",
+          Options::name<OptionsGroup>(), completed_iterations, has_converged);
     }
 
     Parallel::receive_data<Tags::FinalOrthogonalization<OptionsGroup>>(

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/Actions/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/Actions/CMakeLists.txt
@@ -6,4 +6,5 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   CommunicateOverlapFields.hpp
+  ResetSubdomainSolver.hpp
   )

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/Actions/CommunicateOverlapFields.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/Actions/CommunicateOverlapFields.hpp
@@ -97,9 +97,8 @@ struct SendOverlapFields<tmpl::list<OverlapFields...>, OptionsGroup,
         get<Convergence::Tags::IterationId<OptionsGroup>>(box);
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                  ::Verbosity::Debug)) {
-      Parallel::printf("%s " + Options::name<OptionsGroup>() +
-                           "(%zu): Send overlap fields\n",
-                       element_id, iteration_id);
+      Parallel::printf("%s %s(%zu): Send overlap fields\n", element_id,
+                       Options::name<OptionsGroup>(), iteration_id);
     }
 
     // Send data on intruding overlaps to the corresponding neighbors
@@ -204,9 +203,8 @@ struct ReceiveOverlapFields<Dim, tmpl::list<OverlapFields...>, OptionsGroup> {
         get<Convergence::Tags::IterationId<OptionsGroup>>(box);
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                  ::Verbosity::Debug)) {
-      Parallel::printf("%s " + Options::name<OptionsGroup>() +
-                           "(%zu): Receive overlap fields\n",
-                       element_id, iteration_id);
+      Parallel::printf("%s %s(%zu): Receive overlap fields\n", element_id,
+                       Options::name<OptionsGroup>(), iteration_id);
     }
 
     // Move received overlap data into DataBox

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/Actions/ResetSubdomainSolver.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/Actions/ResetSubdomainSolver.hpp
@@ -1,0 +1,94 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <tuple>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Informer/Tags.hpp"
+#include "Informer/Verbosity.hpp"
+#include "Parallel/Printf.hpp"
+#include "ParallelAlgorithms/LinearSolver/Schwarz/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Parallel {
+template <typename Metavariables>
+struct GlobalCache;
+}  // namespace Parallel
+namespace tuples {
+template <typename...>
+struct TaggedTuple;
+}  // namespace tuples
+/// \endcond
+
+namespace LinearSolver::Schwarz::Actions {
+
+/*!
+ * \brief Reset the subdomain solver, clearing its caches related to the linear
+ * operator it has solved so far.
+ *
+ * Invoke this action when the linear operator has changed. For example, an
+ * operator representing the linearization of a nonlinear operator changes
+ * whenever the point around which it is being linearized gets updated, i.e. in
+ * every iteration of a nonlinear solve. Note that the operator does _not_
+ * change between iterations of a linear solve, so make sure you place this
+ * action _outside_ the looping action list for the linear solve.
+ *
+ * \par Skipping the reset:
+ * Depending on the subdomain solver in use, the reset may incur significant
+ * re-initialization cost the next time the subdomain solver is invoked. See the
+ * `LinearSolver::Serial::ExplicitInverse` solver for an example of a subdomain
+ * solver with high initialization cost. For this reason the reset can be
+ * skipped with the option
+ * `LinearSolver::Schwarz::Tags::SkipSubdomainSolverResets`. Skipping resets
+ * means that caches built up for the linear operator are never cleared, so
+ * expensive re-initializations are avoided but the subdomain solves may be
+ * increasingly inaccurate or slow down as the linear operator changes over
+ * nonlinear solver iterations. Whether or not skipping resets helps with the
+ * overall convergence of the solve is highly problem-dependent. A possible
+ * optimization would be to decide at runtime whether or not to reset the
+ * subdomain solver.
+ */
+template <typename OptionsGroup>
+struct ResetSubdomainSolver {
+  using const_global_cache_tags = tmpl::list<
+      LinearSolver::Schwarz::Tags::SkipSubdomainSolverResets<OptionsGroup>,
+      logging::Tags::Verbosity<OptionsGroup>>;
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            size_t Dim, typename ActionList, typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ElementId<Dim>& element_id, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    if (not get<LinearSolver::Schwarz::Tags::SkipSubdomainSolverResets<
+            OptionsGroup>>(box)) {
+      if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
+                   ::Verbosity::Debug)) {
+        Parallel::printf("%s %s: Reset subdomain solver\n", element_id,
+                         Options::name<OptionsGroup>());
+      }
+      db::mutate<
+          LinearSolver::Schwarz::Tags::SubdomainSolverBase<OptionsGroup>>(
+          make_not_null(&box), [](const auto subdomain_solver) noexcept {
+            // Dereference the gsl::not_null pointer, and then the
+            // std::unique_ptr for the subdomain solver's abstract superclass.
+            // This needs adjustment if the subdomain solver is stored in the
+            // DataBox directly as a derived class and thus there's no
+            // std::unique_ptr. Note that std::unique_ptr also has a `reset`
+            // function, which must not be confused with the serial linear
+            // solver's `reset` function here.
+            (*subdomain_solver)->reset();
+          });
+    }
+    return {std::move(box)};
+  }
+};
+
+}  // namespace LinearSolver::Schwarz::Actions

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementActions.hpp
@@ -300,16 +300,19 @@ struct SolveSubdomain {
           subdomain_solve_has_converged.reason() ==
               Convergence::Reason::MaxIterations) {
         Parallel::printf(
-            "%s WARNING: Subdomain solver did not converge in %zu iterations: "
-            "%e -> %e\n",
-            element_id, subdomain_solve_has_converged.num_iterations(),
+            "%s %s(%zu): WARNING: Subdomain solver did not converge in %zu "
+            "iterations: %e -> %e\n",
+            element_id, Options::name<OptionsGroup>(), iteration_id,
+            subdomain_solve_has_converged.num_iterations(),
             subdomain_solve_has_converged.initial_residual_magnitude(),
             subdomain_solve_has_converged.residual_magnitude());
       } else if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                           ::Verbosity::Debug)) {
         Parallel::printf(
-            "%s Subdomain solver converged in %zu iterations (%s): %e -> %e\n",
-            element_id, subdomain_solve_has_converged.num_iterations(),
+            "%s %s(%zu): Subdomain solver converged in %zu iterations (%s): %e "
+            "-> %e\n",
+            element_id, Options::name<OptionsGroup>(), iteration_id,
+            subdomain_solve_has_converged.num_iterations(),
             subdomain_solve_has_converged.reason(),
             subdomain_solve_has_converged.initial_residual_magnitude(),
             subdomain_solve_has_converged.residual_magnitude());

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementActions.hpp
@@ -244,9 +244,8 @@ struct SolveSubdomain {
     // Do some logging
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                  ::Verbosity::Debug)) {
-      Parallel::printf(
-          "%s " + Options::name<OptionsGroup>() + "(%zu): Solve subdomain\n",
-          element_id, iteration_id);
+      Parallel::printf("%s %s(%zu): Solve subdomain\n", element_id,
+                       Options::name<OptionsGroup>(), iteration_id);
     }
 
     const auto& element = db::get<domain::Tags::Element<Dim>>(box);
@@ -408,9 +407,8 @@ struct ReceiveOverlapSolution {
     // Do some logging
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                  ::Verbosity::Debug)) {
-      Parallel::printf("%s " + Options::name<OptionsGroup>() +
-                           "(%zu): Receive overlap solution\n",
-                       element_id, iteration_id);
+      Parallel::printf("%s %s(%zu): Receive overlap solution\n", element_id,
+                       Options::name<OptionsGroup>(), iteration_id);
     }
 
     // Add solutions on overlaps to this element's solution in a weighted sum

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/Tags.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/Tags.hpp
@@ -39,6 +39,20 @@ struct SubdomainSolver {
   static constexpr Options::String help = "The linear solver on subdomains";
 };
 
+template <typename OptionsGroup>
+struct SkipSubdomainSolverResets {
+  static std::string name() noexcept { return "SkipResets"; }
+  using type = bool;
+  using group = OptionsGroup;
+  static constexpr Options::String help =
+      "Skip resets of the subdomain solver. This only has an effect in cases "
+      "where the operator changes, e.g. between nonlinear-solver iterations. "
+      "Skipping resets avoids expensive re-building of the operator, but comes "
+      "at the cost of less accurate preconditioning and thus potentially more "
+      "preconditioned iterations. Whether or not this helps convergence "
+      "overall is highly problem-dependent.";
+};
+
 }  // namespace OptionTags
 
 /// Tags related to the Schwarz solver
@@ -75,6 +89,18 @@ struct SubdomainSolver : SubdomainSolverBase<OptionsGroup>, db::SimpleTag {
   static type create_from_options(const type& value) noexcept {
     return deserialize<type>(serialize<type>(value).data());
   }
+};
+
+/// Skip resets of the subdomain solver.
+///
+/// \see LinearSolver::Schwarz::Actions::ResetSubdomainSolver
+template <typename OptionsGroup>
+struct SkipSubdomainSolverResets : db::SimpleTag {
+  using type = bool;
+  static constexpr bool pass_metavariables = false;
+  using option_tags =
+      tmpl::list<OptionTags::SkipSubdomainSolverResets<OptionsGroup>>;
+  static bool create_from_options(const bool value) noexcept { return value; }
 };
 
 /*!

--- a/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ElementActions.hpp
+++ b/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ElementActions.hpp
@@ -127,9 +127,8 @@ struct PrepareSolve {
       const ParallelComponent* const /*meta*/) noexcept {
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                  ::Verbosity::Debug)) {
-      Parallel::printf(
-          "%s " + Options::name<OptionsGroup>() + ": Prepare solve\n",
-          array_index);
+      Parallel::printf("%s %s: Prepare solve\n", array_index,
+                       Options::name<OptionsGroup>());
     }
 
     db::mutate<Convergence::Tags::IterationId<OptionsGroup>>(
@@ -253,8 +252,8 @@ struct PrepareStep {
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                  ::Verbosity::Debug)) {
       Parallel::printf(
-          "%s " + Options::name<OptionsGroup>() + "(%zu): Prepare step\n",
-          array_index,
+          "%s %s(%zu): Prepare step\n", array_index,
+          Options::name<OptionsGroup>(),
           db::get<Convergence::Tags::IterationId<OptionsGroup>>(box) + 1);
     }
 
@@ -324,9 +323,8 @@ struct PerformStep {
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                  ::Verbosity::Debug)) {
       Parallel::printf(
-          "%s " + Options::name<OptionsGroup>() +
-              "(%zu): Perform step with length %f\n",
-          array_index,
+          "%s %s(%zu): Perform step with length %f\n", array_index,
+          Options::name<OptionsGroup>(),
           db::get<Convergence::Tags::IterationId<OptionsGroup>>(box),
           db::get<NonlinearSolver::Tags::StepLength<OptionsGroup>>(box));
     }
@@ -428,8 +426,8 @@ struct Globalize {
       if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                    ::Verbosity::Debug)) {
         Parallel::printf(
-            "%s " + Options::name<OptionsGroup>() + "(%zu): Globalize(%zu)\n",
-            array_index,
+            "%s %s(%zu): Globalize(%zu)\n", array_index,
+            Options::name<OptionsGroup>(),
             db::get<Convergence::Tags::IterationId<OptionsGroup>>(box),
             db::get<NonlinearSolver::Tags::Globalization<
                 Convergence::Tags::IterationId<OptionsGroup>>>(box));
@@ -491,8 +489,8 @@ struct CompleteStep {
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                  ::Verbosity::Debug)) {
       Parallel::printf(
-          "%s " + Options::name<OptionsGroup>() + "(%zu): Complete step\n",
-          array_index,
+          "%s %s(%zu): Complete step\n", array_index,
+          Options::name<OptionsGroup>(),
           db::get<Convergence::Tags::IterationId<OptionsGroup>>(box));
     }
 

--- a/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ElementActions.hpp
+++ b/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ElementActions.hpp
@@ -323,7 +323,7 @@ struct PerformStep {
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                  ::Verbosity::Debug)) {
       Parallel::printf(
-          "%s %s(%zu): Perform step with length %f\n", array_index,
+          "%s %s(%zu): Perform step with length: %g\n", array_index,
           Options::name<OptionsGroup>(),
           db::get<Convergence::Tags::IterationId<OptionsGroup>>(box),
           db::get<NonlinearSolver::Tags::StepLength<OptionsGroup>>(box));

--- a/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ResidualMonitorActions.hpp
+++ b/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ResidualMonitorActions.hpp
@@ -20,7 +20,6 @@
 #include "ParallelAlgorithms/NonlinearSolver/Tags.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
 #include "Utilities/Functional.hpp"
-#include "Utilities/GetOutput.hpp"
 
 /// \cond
 namespace tuples {
@@ -136,16 +135,15 @@ struct CheckResidualMagnitude {
           if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                        ::Verbosity::Verbose)) {
             Parallel::printf(
-                "Step with length %s didn't sufficiently decrease the '%s' "
-                "iteration %zu residual (possible overshoot). Residual: "
-                "%s. Next step length: %s.\n",
-                get_output(step_length), Options::name<OptionsGroup>(),
-                iteration_id, get_output(residual_magnitude),
-                get_output(next_step_length));
+                "%s(%zu): Step with length %g didn't sufficiently decrease the "
+                "residual (possible overshoot). Residual: %e. Next step "
+                "length: %g.\n",
+                Options::name<OptionsGroup>(), iteration_id, step_length,
+                residual_magnitude, next_step_length);
             if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                          ::Verbosity::Debug)) {
-              Parallel::printf("Residual magnitude slope: %s\n",
-                               get_output(residual_magnitude_square_slope));
+              Parallel::printf("Residual magnitude slope: %e\n",
+                               residual_magnitude_square_slope);
             }
           }
           // Broadcast back to the elements signaling that they should perform a
@@ -159,10 +157,10 @@ struct CheckResidualMagnitude {
         } else if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                             ::Verbosity::Quiet)) {
           Parallel::printf(
-              "WARNING: Failed to sufficiently decrease the '%s' iteration %zu "
-              "residual in %zu globalization steps. This is usually indicative "
-              "of an ill-posed problem, for example when the linearization of "
-              "the nonlinear operator is not computed correctly.",
+              "%s(%zu): WARNING: Failed to sufficiently decrease the residual "
+              "in %zu globalization steps. This is usually indicative of an "
+              "ill-posed problem, for example when the linearization of the "
+              "nonlinear operator is not computed correctly.",
               Options::name<OptionsGroup>(), iteration_id,
               globalization_iteration_id);
         }  // min_step_length
@@ -188,27 +186,25 @@ struct CheckResidualMagnitude {
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                  ::Verbosity::Quiet)) {
       if (UNLIKELY(iteration_id == 0)) {
-        Parallel::printf(
-            "Nonlinear solver '%s' initialized with residual %e.\n",
-            Options::name<OptionsGroup>(), residual_magnitude);
+        Parallel::printf("%s initialized with residual: %e\n",
+                         Options::name<OptionsGroup>(), residual_magnitude);
       } else {
         Parallel::printf(
-            "Nonlinear solver '%s' iteration %zu done. Remaining residual: "
-            "%e\n",
-            Options::name<OptionsGroup>(), iteration_id, residual_magnitude);
+            "%s(%zu) iteration complete (%zu globalization steps, step length "
+            "%g). Remaining residual: %e\n",
+            Options::name<OptionsGroup>(), iteration_id,
+            globalization_iteration_id, step_length, residual_magnitude);
       }
     }
     if (UNLIKELY(has_converged and get<logging::Tags::Verbosity<OptionsGroup>>(
                                        box) >= ::Verbosity::Quiet)) {
       if (UNLIKELY(iteration_id == 0)) {
-        Parallel::printf(
-            "The nonlinear solver '%s' has converged without any iterations: "
-            "%s\n",
-            Options::name<OptionsGroup>(), has_converged);
+        Parallel::printf("%s has converged without any iterations: %s\n",
+                         Options::name<OptionsGroup>(), has_converged);
       } else {
-        Parallel::printf(
-            "The nonlinear solver '%s' has converged in %zu iterations: %s\n",
-            Options::name<OptionsGroup>(), iteration_id, has_converged);
+        Parallel::printf("%s has converged in %zu iterations: %s\n",
+                         Options::name<OptionsGroup>(), iteration_id,
+                         has_converged);
       }
     }
 

--- a/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ResidualMonitorActions.hpp
+++ b/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ResidualMonitorActions.hpp
@@ -136,12 +136,12 @@ struct CheckResidualMagnitude {
           if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                        ::Verbosity::Verbose)) {
             Parallel::printf(
-                "Step with length %s didn't sufficiently decrease the '" +
-                    Options::name<OptionsGroup>() +
-                    "' iteration %zu residual (possible overshoot). Residual: "
-                    "%s. Next step length: %s.\n",
-                get_output(step_length), iteration_id,
-                get_output(residual_magnitude), get_output(next_step_length));
+                "Step with length %s didn't sufficiently decrease the '%s' "
+                "iteration %zu residual (possible overshoot). Residual: "
+                "%s. Next step length: %s.\n",
+                get_output(step_length), Options::name<OptionsGroup>(),
+                iteration_id, get_output(residual_magnitude),
+                get_output(next_step_length));
             if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                          ::Verbosity::Debug)) {
               Parallel::printf("Residual magnitude slope: %s\n",
@@ -159,13 +159,12 @@ struct CheckResidualMagnitude {
         } else if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                             ::Verbosity::Quiet)) {
           Parallel::printf(
-              "WARNING: Failed to sufficiently decrease the '" +
-                  Options::name<OptionsGroup>() +
-                  "' iteration %zu residual in %zu globalization steps. This "
-                  "is usually indicative of an ill-posed problem, for "
-                  "example when the linearization of the nonlinear operator "
-                  "is not computed correctly.",
-              iteration_id, globalization_iteration_id);
+              "WARNING: Failed to sufficiently decrease the '%s' iteration %zu "
+              "residual in %zu globalization steps. This is usually indicative "
+              "of an ill-posed problem, for example when the linearization of "
+              "the nonlinear operator is not computed correctly.",
+              Options::name<OptionsGroup>(), iteration_id,
+              globalization_iteration_id);
         }  // min_step_length
       }    // sufficient decrease condition
     }      // initial iteration
@@ -189,27 +188,27 @@ struct CheckResidualMagnitude {
     if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                  ::Verbosity::Quiet)) {
       if (UNLIKELY(iteration_id == 0)) {
-        Parallel::printf("Nonlinear solver '" + Options::name<OptionsGroup>() +
-                             "' initialized with residual %e.\n",
-                         residual_magnitude);
+        Parallel::printf(
+            "Nonlinear solver '%s' initialized with residual %e.\n",
+            Options::name<OptionsGroup>(), residual_magnitude);
       } else {
-        Parallel::printf("Nonlinear solver '" + Options::name<OptionsGroup>() +
-                             "' iteration %zu done. Remaining residual: %e\n",
-                         iteration_id, residual_magnitude);
+        Parallel::printf(
+            "Nonlinear solver '%s' iteration %zu done. Remaining residual: "
+            "%e\n",
+            Options::name<OptionsGroup>(), iteration_id, residual_magnitude);
       }
     }
     if (UNLIKELY(has_converged and get<logging::Tags::Verbosity<OptionsGroup>>(
                                        box) >= ::Verbosity::Quiet)) {
       if (UNLIKELY(iteration_id == 0)) {
-        Parallel::printf("The nonlinear solver '" +
-                             Options::name<OptionsGroup>() +
-                             "' has converged without any iterations: %s\n",
-                         has_converged);
+        Parallel::printf(
+            "The nonlinear solver '%s' has converged without any iterations: "
+            "%s\n",
+            Options::name<OptionsGroup>(), has_converged);
       } else {
-        Parallel::printf("The nonlinear solver '" +
-                             Options::name<OptionsGroup>() +
-                             "' has converged in %zu iterations: %s\n",
-                         iteration_id, has_converged);
+        Parallel::printf(
+            "The nonlinear solver '%s' has converged in %zu iterations: %s\n",
+            Options::name<OptionsGroup>(), iteration_id, has_converged);
       }
     }
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Actions/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Actions/CMakeLists.txt
@@ -5,11 +5,23 @@ set(LIBRARY "Test_ParallelSchwarzActions")
 
 set(LIBRARY_SOURCES
   Test_CommunicateOverlapFields.cpp
+  Test_ResetSubdomainSolver.cpp
   )
 
 add_test_library(
   ${LIBRARY}
   "ParallelAlgorithms/LinearSolver/Schwarz/Actions"
   "${LIBRARY_SOURCES}"
-  "Convergence;DataStructures;DomainStructure;Informer;ParallelSchwarz;Spectral"
+  ""
+  )
+
+target_link_libraries(
+  Test_ParallelSchwarzActions
+  PRIVATE
+  Convergence
+  DataStructures
+  DomainStructure
+  Informer
+  ParallelSchwarz
+  Spectral
   )

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Actions/Test_ResetSubdomainSolver.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Actions/Test_ResetSubdomainSolver.cpp
@@ -1,0 +1,90 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Informer/Tags.hpp"
+#include "Informer/Verbosity.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "ParallelAlgorithms/LinearSolver/Schwarz/Actions/ResetSubdomainSolver.hpp"
+#include "ParallelAlgorithms/LinearSolver/Schwarz/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+
+struct DummyOptionsGroup {};
+
+struct SubdomainSolver {
+  void reset() noexcept { is_reset = true; }
+  bool is_reset = false;
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) { p | is_reset; }
+};
+
+template <typename Metavariables>
+struct ElementArray {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementId<1>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          tmpl::list<ActionTesting::InitializeDataBox<
+              tmpl::list<LinearSolver::Schwarz::Tags::SubdomainSolver<
+                  std::unique_ptr<SubdomainSolver>, DummyOptionsGroup>>>>>,
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          tmpl::list<LinearSolver::Schwarz::Actions::ResetSubdomainSolver<
+              DummyOptionsGroup>>>>;
+};
+
+struct Metavariables {
+  using element_array = ElementArray<Metavariables>;
+  using component_list = tmpl::list<element_array>;
+  enum class Phase { Initialization, Testing, Exit };
+};
+
+void test_reset_subdomain_solver(const bool skip_resets) noexcept {
+  CAPTURE(skip_resets);
+
+  using element_array = typename Metavariables::element_array;
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{tuples::TaggedTuple<
+      LinearSolver::Schwarz::Tags::SkipSubdomainSolverResets<DummyOptionsGroup>,
+      logging::Tags::Verbosity<DummyOptionsGroup>>{skip_resets,
+                                                   Verbosity::Verbose}};
+  const ElementId<1> element_id{0};
+  ActionTesting::emplace_component_and_initialize<element_array>(
+      make_not_null(&runner), element_id,
+      {std::make_unique<SubdomainSolver>()});
+  ActionTesting::set_phase(make_not_null(&runner),
+                           Metavariables::Phase::Testing);
+  REQUIRE_FALSE(
+      ActionTesting::get_databox_tag<
+          element_array,
+          LinearSolver::Schwarz::Tags::SubdomainSolverBase<DummyOptionsGroup>>(
+          runner, element_id)
+          .is_reset);
+  ActionTesting::next_action<element_array>(make_not_null(&runner), element_id);
+  CHECK(
+      ActionTesting::get_databox_tag<
+          element_array,
+          LinearSolver::Schwarz::Tags::SubdomainSolverBase<DummyOptionsGroup>>(
+          runner, element_id)
+          .is_reset != skip_resets);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ParallelSchwarz.Action.ResetSubdomainSolver",
+                  "[Unit][ParallelAlgorithms][LinearSolver][Actions]") {
+  test_reset_subdomain_solver(false);
+  test_reset_subdomain_solver(true);
+}

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.yaml
@@ -59,8 +59,7 @@ SchwarzSmoother:
       Preconditioner:
         # Preconditioning with the explicitly-built inverse matrix, so all
         # subdomain solves should converge immediately
-        ExplicitInverse:
-          EnableResets: True
+        ExplicitInverse
 
 ConvergenceReason: NumIterations
 


### PR DESCRIPTION
## Proposed changes

This action will be called in nonlinear solver iterations to reset caches of the Schwarz subdomain solver. The reset can be disabled to potentially speed up solves.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
