### PR TITLE
Add Robin boundary conditions for Poisson system

### DIFF
--- a/src/Elliptic/Systems/Poisson/BoundaryConditions/CMakeLists.txt
+++ b/src/Elliptic/Systems/Poisson/BoundaryConditions/CMakeLists.txt
@@ -1,35 +1,29 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-set(LIBRARY Poisson)
+set(LIBRARY PoissonBoundaryConditions)
 
 add_spectre_library(${LIBRARY})
 
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
-  Equations.cpp
+  Robin.cpp
   )
 
 spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
-  Equations.hpp
-  FirstOrderSystem.hpp
-  Geometry.hpp
-  Tags.hpp
+  Robin.hpp
   )
 
 target_link_libraries(
   ${LIBRARY}
   PUBLIC
   DataStructures
-  ErrorHandling
-  GeneralRelativity
+  Elliptic
+  Options
+  Parallel
   Utilities
-  INTERFACE
-  LinearOperators
   )
-
-add_subdirectory(BoundaryConditions)

--- a/src/Elliptic/Systems/Poisson/BoundaryConditions/Robin.cpp
+++ b/src/Elliptic/Systems/Poisson/BoundaryConditions/Robin.cpp
@@ -1,0 +1,83 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Elliptic/Systems/Poisson/BoundaryConditions/Robin.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Poisson::BoundaryConditions::detail {
+
+RobinImpl::RobinImpl(const double dirichlet_weight, const double neumann_weight,
+                     const double constant, const Options::Context& context)
+    : dirichlet_weight_(dirichlet_weight),
+      neumann_weight_(neumann_weight),
+      constant_(constant) {
+  if (dirichlet_weight == 0. and neumann_weight == 0.) {
+    PARSE_ERROR(
+        context,
+        "Either the dirichlet_weight or the neumann_weight must be non-zero "
+        "(or both).");
+  }
+}
+
+double RobinImpl::dirichlet_weight() const noexcept {
+  return dirichlet_weight_;
+}
+double RobinImpl::neumann_weight() const noexcept { return neumann_weight_; }
+double RobinImpl::constant() const noexcept { return constant_; }
+
+void RobinImpl::apply(const gsl::not_null<Scalar<DataVector>*> field,
+                      const gsl::not_null<Scalar<DataVector>*>
+                          n_dot_field_gradient) const noexcept {
+  if (neumann_weight_ == 0.) {
+    ASSERT(
+        not equal_within_roundoff(dirichlet_weight_, 0.),
+        "The dirichlet_weight is close to zero. Set it to a non-zero value to "
+        "avoid divisions by small numbers.");
+    get(*field) = constant_ / dirichlet_weight_;
+  } else {
+    ASSERT(not equal_within_roundoff(neumann_weight_, 0.),
+           "The neumann_weight is close to zero. Set it to a non-zero value to "
+           "avoid divisions by small numbers.");
+    get(*n_dot_field_gradient) =
+        (constant_ - dirichlet_weight_ * get(*field)) / neumann_weight_;
+  }
+}
+
+void RobinImpl::apply_linearized(
+    const gsl::not_null<Scalar<DataVector>*> field_correction,
+    const gsl::not_null<Scalar<DataVector>*> n_dot_field_gradient_correction)
+    const noexcept {
+  if (neumann_weight_ == 0.) {
+    get(*field_correction) = 0.;
+  } else {
+    ASSERT(not equal_within_roundoff(neumann_weight_, 0.),
+           "The neumann_weight is close to zero. Set it to a non-zero value to "
+           "avoid divisions by small numbers.");
+    get(*n_dot_field_gradient_correction) =
+        -dirichlet_weight_ / neumann_weight_ * get(*field_correction);
+  }
+}
+
+void RobinImpl::pup(PUP::er& p) noexcept {
+  p | dirichlet_weight_;
+  p | neumann_weight_;
+  p | constant_;
+}
+
+bool operator==(const RobinImpl& lhs, const RobinImpl& rhs) noexcept {
+  return lhs.dirichlet_weight() == rhs.dirichlet_weight() and
+         lhs.neumann_weight() == rhs.neumann_weight() and
+         lhs.constant() == rhs.constant();
+}
+
+bool operator!=(const RobinImpl& lhs, const RobinImpl& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+}  // namespace Poisson::BoundaryConditions::detail

--- a/src/Elliptic/Systems/Poisson/BoundaryConditions/Robin.hpp
+++ b/src/Elliptic/Systems/Poisson/BoundaryConditions/Robin.hpp
@@ -1,0 +1,145 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <pup.h>
+#include <string>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+/// \endcond
+
+namespace Poisson::BoundaryConditions {
+namespace detail {
+
+struct RobinImpl {
+  static constexpr Options::String help =
+      "Robin boundary conditions a * u + b * n_i grad(u)^i = c. The boundary "
+      "condition is imposed as Neumann-type (i.e. on n_i grad(u)^i) if abs(b) "
+      "> 0 and as Dirichlet-type (i.e. on u) if b = 0.";
+
+  struct DirichletWeight {
+    using type = double;
+    static constexpr Options::String help = "The parameter 'a'";
+  };
+
+  struct NeumannWeight {
+    using type = double;
+    static constexpr Options::String help = "The parameter 'b'";
+  };
+
+  struct Constant {
+    using type = double;
+    static constexpr Options::String help = "The parameter 'c'";
+  };
+
+  using options = tmpl::list<DirichletWeight, NeumannWeight, Constant>;
+
+  RobinImpl() = default;
+  RobinImpl(const RobinImpl&) noexcept = default;
+  RobinImpl& operator=(const RobinImpl&) noexcept = default;
+  RobinImpl(RobinImpl&&) noexcept = default;
+  RobinImpl& operator=(RobinImpl&&) noexcept = default;
+  ~RobinImpl() noexcept = default;
+
+  RobinImpl(double dirichlet_weight, double neumann_weight, double constant,
+            const Options::Context& context = {});
+
+  double dirichlet_weight() const noexcept;
+  double neumann_weight() const noexcept;
+  double constant() const noexcept;
+
+  using argument_tags = tmpl::list<>;
+  using volume_tags = tmpl::list<>;
+
+  void apply(
+      gsl::not_null<Scalar<DataVector>*> field,
+      gsl::not_null<Scalar<DataVector>*> n_dot_field_gradient) const noexcept;
+
+  using argument_tags_linearized = tmpl::list<>;
+  using volume_tags_linearized = tmpl::list<>;
+
+  void apply_linearized(gsl::not_null<Scalar<DataVector>*> field_correction,
+                        gsl::not_null<Scalar<DataVector>*>
+                            n_dot_field_gradient_correction) const noexcept;
+
+  void pup(PUP::er& p) noexcept;
+
+ private:
+  double dirichlet_weight_ = std::numeric_limits<double>::signaling_NaN();
+  double neumann_weight_ = std::numeric_limits<double>::signaling_NaN();
+  double constant_ = std::numeric_limits<double>::signaling_NaN();
+};
+
+bool operator==(const RobinImpl& lhs, const RobinImpl& rhs) noexcept;
+bool operator!=(const RobinImpl& lhs, const RobinImpl& rhs) noexcept;
+
+}  // namespace detail
+
+// The following implements the registration and factory-creation mechanism
+
+/// \cond
+template <size_t Dim, typename Registrars>
+struct Robin;
+
+namespace Registrars {
+template <size_t Dim>
+struct Robin {
+  template <typename Registrars>
+  using f = BoundaryConditions::Robin<Dim, Registrars>;
+};
+}  // namespace Registrars
+/// \endcond
+
+/// Impose Robin boundary conditions \f$a u + b n_i \nabla^i u = c\f$. The
+/// boundary condition is imposed as Neumann-type (i.e. on \f$n_i \nabla^i u\f$)
+/// if \f$|b| > 0\f$ and as Dirichlet-type (i.e. on \f$u\f$) if \f$b = 0\f$.
+template <size_t Dim, typename Registrars = tmpl::list<Registrars::Robin<Dim>>>
+class Robin
+    : public elliptic::BoundaryConditions::BoundaryCondition<Dim, Registrars>,
+      public detail::RobinImpl {
+ private:
+  using Base = elliptic::BoundaryConditions::BoundaryCondition<Dim, Registrars>;
+
+ public:
+  Robin() = default;
+  Robin(const Robin&) noexcept = default;
+  Robin& operator=(const Robin&) noexcept = default;
+  Robin(Robin&&) noexcept = default;
+  Robin& operator=(Robin&&) noexcept = default;
+  ~Robin() noexcept = default;
+  using RobinImpl::RobinImpl;
+
+  /// \cond
+  explicit Robin(CkMigrateMessage* m) noexcept : Base(m) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Robin);
+  /// \endcond
+
+  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> get_clone()
+      const noexcept override {
+    return std::make_unique<Robin>(*this);
+  }
+
+  void pup(PUP::er& p) noexcept override {
+    Base::pup(p);
+    RobinImpl::pup(p);
+  }
+};
+
+/// \cond
+template <size_t Dim, typename Registrars>
+PUP::able::PUP_ID Robin<Dim,
+                        Registrars>::my_PUP_ID = 0;  // NOLINT
+/// \endcond
+
+}  // namespace Poisson::BoundaryConditions

--- a/tests/Unit/Elliptic/Systems/Poisson/BoundaryConditions/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/Poisson/BoundaryConditions/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_PoissonBoundaryConditions")
+
+set(LIBRARY_SOURCES
+  Test_Robin.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "Elliptic/Systems/Poisson/BoundaryConditions/"
+  "${LIBRARY_SOURCES}"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DataStructures
+  DomainStructure
+  Elliptic
+  PoissonBoundaryConditions
+  Utilities
+  )

--- a/tests/Unit/Elliptic/Systems/Poisson/BoundaryConditions/Robin.py
+++ b/tests/Unit/Elliptic/Systems/Poisson/BoundaryConditions/Robin.py
@@ -1,0 +1,21 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+
+def dirichlet_field(dirichlet_weight, constant, used_for_size):
+    return constant / dirichlet_weight
+
+
+def dirichlet_field_linearized(dirichlet_weight, constant, used_for_size):
+    return 0.
+
+
+def neumann_normal_dot_field_gradient(field, dirichlet_weight, neumann_weight,
+                                      constant):
+    return (constant - dirichlet_weight * field) / neumann_weight
+
+
+def neumann_normal_dot_field_gradient_linearized(field_correction,
+                                                 dirichlet_weight,
+                                                 neumann_weight, constant):
+    return -dirichlet_weight / neumann_weight * field_correction

--- a/tests/Unit/Elliptic/Systems/Poisson/BoundaryConditions/Test_Robin.cpp
+++ b/tests/Unit/Elliptic/Systems/Poisson/BoundaryConditions/Test_Robin.cpp
@@ -1,0 +1,100 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Elliptic/BoundaryConditions/ApplyBoundaryCondition.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/Systems/Poisson/BoundaryConditions/Robin.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Poisson::BoundaryConditions {
+
+namespace {
+template <bool Linearized>
+void apply_dirichlet_boundary_condition(
+    const gsl::not_null<Scalar<DataVector>*> field,
+    const double dirichlet_weight, const double constant,
+    const Scalar<DataVector>& /*used_for_size*/) {
+  const Robin<1> boundary_condition{dirichlet_weight, 0., constant};
+  const auto box = db::create<db::AddSimpleTags<>>();
+  auto n_dot_field_gradient = make_with_value<Scalar<DataVector>>(
+      *field, std::numeric_limits<double>::signaling_NaN());
+  elliptic::apply_boundary_condition<Linearized>(
+      boundary_condition, box, Direction<1>::lower_xi(), field,
+      make_not_null(&n_dot_field_gradient));
+}
+template <bool Linearized>
+void apply_neumann_boundary_condition(
+    const gsl::not_null<Scalar<DataVector>*> n_dot_field_gradient,
+    Scalar<DataVector> field, const double dirichlet_weight,
+    const double neumann_weight, const double constant) {
+  const Robin<1> boundary_condition{dirichlet_weight, neumann_weight, constant};
+  const auto box = db::create<db::AddSimpleTags<>>();
+  elliptic::apply_boundary_condition<Linearized>(
+      boundary_condition, box, Direction<1>::lower_xi(), make_not_null(&field),
+      n_dot_field_gradient);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Elasticity.BoundaryConditions.Robin",
+                  "[Unit][Elliptic]") {
+  // Test factory-creation
+  const auto created = TestHelpers::test_factory_creation<
+      elliptic::BoundaryConditions::BoundaryCondition<
+          1, tmpl::list<Registrars::Robin<1>>>>(
+      "Robin:\n"
+      "  DirichletWeight: 2.\n"
+      "  NeumannWeight: 3.\n"
+      "  Constant: 4.");
+  REQUIRE(dynamic_cast<const Robin<1>*>(created.get()) != nullptr);
+  const auto& boundary_condition = dynamic_cast<const Robin<1>&>(*created);
+  {
+    INFO("Properties");
+    CHECK(boundary_condition.dirichlet_weight() == 2.);
+    CHECK(boundary_condition.neumann_weight() == 3.);
+    CHECK(boundary_condition.constant() == 4.);
+  }
+  {
+    INFO("Semantics");
+    test_serialization(boundary_condition);
+    test_copy_semantics(boundary_condition);
+    auto move_boundary_condition = boundary_condition;
+    test_move_semantics(std::move(move_boundary_condition), boundary_condition);
+  }
+  {
+    INFO("Random-value tests")
+    pypp::SetupLocalPythonEnvironment local_python_env(
+        "Elliptic/Systems/Poisson/BoundaryConditions/");
+    pypp::check_with_random_values<3>(
+        &apply_dirichlet_boundary_condition<false>, "Robin",
+        {"dirichlet_field"}, {{{0.5, 2.}, {-1., 1.}, {-1., 1.}}},
+        DataVector{3});
+    pypp::check_with_random_values<3>(&apply_dirichlet_boundary_condition<true>,
+                                      "Robin", {"dirichlet_field_linearized"},
+                                      {{{0.5, 2.}, {-1., 1.}, {-1., 1.}}},
+                                      DataVector{3});
+    pypp::check_with_random_values<4>(
+        &apply_neumann_boundary_condition<false>, "Robin",
+        {"neumann_normal_dot_field_gradient"},
+        {{{-1., 1.}, {0.5, 2.}, {-1., 1.}, {-1., 1.}}}, DataVector{3});
+    pypp::check_with_random_values<4>(
+        &apply_neumann_boundary_condition<true>, "Robin",
+        {"neumann_normal_dot_field_gradient_linearized"},
+        {{{-1., 1.}, {0.5, 2.}, {-1., 1.}, {-1., 1.}}}, DataVector{3});
+  }
+}
+
+}  // namespace Poisson::BoundaryConditions

--- a/tests/Unit/Elliptic/Systems/Poisson/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/Poisson/CMakeLists.txt
@@ -14,3 +14,5 @@ add_test_library(
   "${LIBRARY_SOURCES}"
   "DataStructures;EllipticTestHelpers;Poisson;Utilities"
   )
+
+add_subdirectory(BoundaryConditions)


### PR DESCRIPTION
## Proposed changes

Robin boundary conditions `a * u + b * n_i grad(u)^i = c` for the Poisson system.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
