### PR TITLE
Add Flatness solution for XCTS system

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
@@ -18,6 +18,7 @@ spectre_target_headers(
   HEADERS
   AnalyticSolution.hpp
   ConstantDensityStar.hpp
+  Flatness.hpp
   Schwarzschild.hpp
   )
 

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Flatness.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Flatness.hpp
@@ -1,0 +1,140 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <limits>
+#include <ostream>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Elliptic/Systems/Xcts/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Xcts/AnalyticSolution.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace Xcts::Solutions {
+
+/// \cond
+template <typename Registrars>
+struct Flatness;
+
+namespace Registrars {
+struct Flatness {
+  template <typename Registrars>
+  using f = Solutions::Flatness<Registrars>;
+};
+}  // namespace Registrars
+/// \endcond
+
+/// Flat spacetime in general relativity. Useful as initial guess.
+template <typename Registrars = tmpl::list<Solutions::Registrars::Flatness>>
+class Flatness : public AnalyticSolution<Registrars> {
+ private:
+  using Base = AnalyticSolution<Registrars>;
+
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help{
+      "Flat spacetime, useful as initial guess."};
+
+  Flatness() = default;
+  Flatness(const Flatness&) noexcept = default;
+  Flatness& operator=(const Flatness&) noexcept = default;
+  Flatness(Flatness&&) noexcept = default;
+  Flatness& operator=(Flatness&&) noexcept = default;
+  ~Flatness() noexcept = default;
+
+  /// \cond
+  explicit Flatness(CkMigrateMessage* m) noexcept : Base(m) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Flatness);
+  /// \endcond
+
+  template <typename DataType, typename... RequestedTags>
+  tuples::TaggedTuple<RequestedTags...> variables(
+      const tnsr::I<DataType, 3, Frame::Inertial>& x,
+      tmpl::list<RequestedTags...> /*meta*/) const noexcept {
+    using supported_tags_zero = tmpl::list<
+        ::Tags::deriv<Tags::ConformalMetric<DataType, 3, Frame::Inertial>,
+                      tmpl::size_t<3>, Frame::Inertial>,
+        Tags::ConformalChristoffelFirstKind<DataType, 3, Frame::Inertial>,
+        Tags::ConformalChristoffelSecondKind<DataType, 3, Frame::Inertial>,
+        Tags::ConformalChristoffelContracted<DataType, 3, Frame::Inertial>,
+        gr::Tags::TraceExtrinsicCurvature<DataType>,
+        ::Tags::dt<gr::Tags::TraceExtrinsicCurvature<DataType>>,
+        ::Tags::deriv<gr::Tags::TraceExtrinsicCurvature<DataType>,
+                      tmpl::size_t<3>, Frame::Inertial>,
+        ::Tags::deriv<Tags::ConformalFactor<DataType>, tmpl::size_t<3>,
+                      Frame::Inertial>,
+        ::Tags::deriv<Tags::LapseTimesConformalFactor<DataType>,
+                      tmpl::size_t<3>, Frame::Inertial>,
+        Tags::ShiftBackground<DataType, 3, Frame::Inertial>,
+        Tags::ShiftExcess<DataType, 3, Frame::Inertial>,
+        Tags::ShiftStrain<DataType, 3, Frame::Inertial>,
+        gr::Tags::EnergyDensity<DataType>, gr::Tags::StressTrace<DataType>,
+        gr::Tags::MomentumDensity<3, Frame::Inertial, DataType>,
+        ::Tags::FixedSource<Tags::ConformalFactor<DataType>>,
+        ::Tags::FixedSource<Tags::LapseTimesConformalFactor<DataType>>,
+        ::Tags::FixedSource<Tags::ShiftExcess<DataType, 3, Frame::Inertial>>>;
+    using supported_tags_one =
+        tmpl::list<Tags::ConformalFactor<DataType>,
+                   Tags::LapseTimesConformalFactor<DataType>>;
+    using supported_tags_metric =
+        tmpl::list<Tags::ConformalMetric<DataType, 3, Frame::Inertial>,
+                   Tags::InverseConformalMetric<DataType, 3, Frame::Inertial>>;
+    using supported_tags = tmpl::append<supported_tags_zero, supported_tags_one,
+                                        supported_tags_metric>;
+    static_assert(
+        std::is_same_v<
+            tmpl::list_difference<tmpl::list<RequestedTags...>, supported_tags>,
+            tmpl::list<>>,
+        "Not all requested tags are supported. The static_assert lists the "
+        "unsupported tags.");
+    const auto make_value = [&x](auto tag_v) noexcept {
+      using tag = std::decay_t<decltype(tag_v)>;
+      if constexpr (tmpl::list_contains_v<supported_tags_zero, tag>) {
+        return make_with_value<typename tag::type>(x, 0.);
+      } else if constexpr (tmpl::list_contains_v<supported_tags_one, tag>) {
+        return make_with_value<typename tag::type>(x, 1.);
+      } else if constexpr (tmpl::list_contains_v<supported_tags_metric, tag>) {
+        auto flat_metric = make_with_value<typename tag::type>(x, 0.);
+        get<0, 0>(flat_metric) = 1.;
+        get<1, 1>(flat_metric) = 1.;
+        get<2, 2>(flat_metric) = 1.;
+        return flat_metric;
+      }
+    };
+    return {make_value(RequestedTags{})...};
+  }
+};
+
+template <typename Registrars>
+bool operator==(const Flatness<Registrars>& /*lhs*/,
+                const Flatness<Registrars>& /*rhs*/) noexcept {
+  return true;
+}
+
+template <typename Registrars>
+bool operator!=(const Flatness<Registrars>& lhs,
+                const Flatness<Registrars>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+/// \cond
+template <typename Registrars>
+PUP::able::PUP_ID Flatness<Registrars>::my_PUP_ID = 0;  // NOLINT
+/// \endcond
+
+}  // namespace Xcts::Solutions

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_XctsSolutions")
 
 set(LIBRARY_SOURCES
   Test_ConstantDensityStar.cpp
+  Test_Flatness.cpp
   Test_Schwarzschild.cpp
   )
 
@@ -12,5 +13,14 @@ add_test_library(
   ${LIBRARY}
   "PointwiseFunctions/AnalyticSolutions/Xcts/"
   "${LIBRARY_SOURCES}"
-  "DataStructures;Utilities;Xcts;XctsSolutions"
+  ""
+  )
+
+target_link_libraries(
+  Test_XctsSolutions
+  PRIVATE
+  DataStructures
+  Utilities
+  Xcts
+  XctsSolutions
   )

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_Flatness.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_Flatness.cpp
@@ -1,0 +1,65 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <tuple>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Elliptic/Systems/Xcts/Tags.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Xcts/Flatness.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace Xcts::Solutions {
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Xcts.Flatness",
+                  "[PointwiseFunctions][Unit]") {
+  const auto created =
+      TestHelpers::test_factory_creation<Xcts::Solutions::AnalyticSolution<
+          tmpl::list<Xcts::Solutions::Registrars::Flatness>>>("Flatness");
+  REQUIRE(dynamic_cast<const Flatness<>*>(created.get()) != nullptr);
+  const auto& solution = dynamic_cast<const Flatness<>&>(*created);
+  {
+    INFO("Semantics");
+    test_serialization(solution);
+    test_copy_semantics(solution);
+    auto move_solution = solution;
+    test_move_semantics(std::move(move_solution), solution);
+  }
+  // Testing that each tag is either 1 or 0 is not so useful, since it just
+  // duplicates the logic that is being tested. Instead, this test should verify
+  // the solution solves the XCTS equations once those are implemented. Until
+  // then, just check a selection of variables to test the solution runs without
+  // error.
+  const size_t num_points = 3;
+  const tnsr::I<DataVector, 3> x{num_points,
+                                 std::numeric_limits<double>::signaling_NaN()};
+  const auto vars = solution.variables(
+      x, tmpl::list<Tags::ConformalFactor<DataVector>,
+                    Tags::ShiftExcess<DataVector, 3, Frame::Inertial>,
+                    Tags::ConformalMetric<DataVector, 3, Frame::Inertial>>{});
+  CHECK(get(get<Tags::ConformalFactor<DataVector>>(vars)) ==
+        DataVector(num_points, 1.));
+  const auto& shift_excess =
+      get<Tags::ShiftExcess<DataVector, 3, Frame::Inertial>>(vars);
+  for (size_t i = 0; i < 3; ++i) {
+    CHECK(shift_excess.get(i) == DataVector(num_points, 0.));
+  }
+  const auto& conformal_metric =
+      get<Tags::ConformalMetric<DataVector, 3, Frame::Inertial>>(vars);
+  for (size_t i = 0; i < 3; ++i) {
+    CHECK(conformal_metric.get(i, i) == DataVector(num_points, 1.));
+    for (size_t j = 0; j < i; ++j) {
+      CHECK(conformal_metric.get(i, j) == DataVector(num_points, 0.));
+    }
+  }
+}
+
+}  // namespace Xcts::Solutions


### PR DESCRIPTION
## Proposed changes

Flat spacetime to use as initial guess for XCTS solves, and for superpositions.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
