### PR TITLE
Fix buffer size in dot_product

### DIFF
--- a/src/DataStructures/Tensor/EagerMath/DotProduct.hpp
+++ b/src/DataStructures/Tensor/EagerMath/DotProduct.hpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
 // @{
@@ -35,7 +36,7 @@ template <typename DataType, typename Index>
 Scalar<DataType> dot_product(
     const Tensor<DataType, Symmetry<1>, index_list<Index>>& vector_a,
     const Tensor<DataType, Symmetry<1>, index_list<Index>>& vector_b) noexcept {
-  Scalar<DataType> dot_product(vector_a.size());
+  Scalar<DataType> dot_product(get_size(get<0>(vector_a)));
   ::dot_product(make_not_null(&dot_product), vector_a, vector_b);
   return dot_product;
 }
@@ -70,7 +71,7 @@ Scalar<DataType> dot_product(
     const Tensor<DataType, Symmetry<1>, index_list<Index>>& vector_a,
     const Tensor<DataType, Symmetry<1>, index_list<change_index_up_lo<Index>>>&
         vector_b) noexcept {
-  Scalar<DataType> dot_product(vector_a.size());
+  Scalar<DataType> dot_product(get_size(get<0>(vector_a)));
   ::dot_product(make_not_null(&dot_product), vector_a, vector_b);
   return dot_product;
 }
@@ -114,7 +115,7 @@ Scalar<DataType> dot_product(
     const Tensor<DataType, Symmetry<1, 1>,
                  index_list<change_index_up_lo<Index>,
                             change_index_up_lo<Index>>>& metric) noexcept {
-  Scalar<DataType> dot_product(vector_a.size());
+  Scalar<DataType> dot_product(get_size(get<0>(vector_a)));
   ::dot_product(make_not_null(&dot_product), vector_a, vector_b, metric);
   return dot_product;
 }


### PR DESCRIPTION
## Proposed changes

Previous code created a buffer that was neither default constructed nor the correct size. This means a resize (= an additional allocation) happened every call.

New code creates buffer with correct size.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
