### PR TITLE
Add Inactive tag to Dg-subcell

### DIFF
--- a/src/Evolution/DgSubcell/Tags/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/Tags/CMakeLists.txt
@@ -8,5 +8,6 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ActiveGrid.hpp
+  Inactive.hpp
   TciGridHistory.hpp
   )

--- a/src/Evolution/DgSubcell/Tags/Inactive.hpp
+++ b/src/Evolution/DgSubcell/Tags/Inactive.hpp
@@ -1,0 +1,34 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Evolution/DgSubcell/ActiveGrid.hpp"
+
+/// \cond
+template <typename TagsList>
+class Variables;
+/// \endcond
+
+namespace evolution::dg::subcell::Tags {
+/// Mark a tag as holding data for the inactive grid.
+///
+/// As an example, if the evolution in the element is currently being done on
+/// the DG grid then the subcell evolved variables would be in
+/// `Inactive<evolved_vars>`.
+template <typename Tag>
+struct Inactive : db::PrefixTag, db::SimpleTag {
+  using tag = Tag;
+  using type = typename tag::type;
+};
+
+/// \copydoc Inactive
+template <typename TagList>
+struct Inactive<::Tags::Variables<TagList>> : db::PrefixTag, db::SimpleTag {
+  using tag = ::Tags::Variables<TagList>;
+  using type = Variables<db::wrap_tags_in<Inactive, TagList>>;
+};
+}  // namespace evolution::dg::subcell::Tags

--- a/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
@@ -5,14 +5,35 @@
 
 #include <string>
 
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesTag.hpp"
 #include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Tags/Inactive.hpp"
 #include "Evolution/DgSubcell/Tags/TciGridHistory.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+
+/// \cond
+class DataVector;
+/// \endcond
+
+namespace {
+struct Var1 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+struct Var2 : db::SimpleTag {
+  using type = tnsr::i<DataVector, 3, Frame::Inertial>;
+};
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Tags",
                   "[Evolution][Unit]") {
   TestHelpers::db::test_simple_tag<evolution::dg::subcell::Tags::ActiveGrid>(
       "ActiveGrid");
+  TestHelpers::db::test_simple_tag<
+      evolution::dg::subcell::Tags::Inactive<Var1>>("Inactive(Var1)");
+  TestHelpers::db::test_simple_tag<evolution::dg::subcell::Tags::Inactive<
+      ::Tags::Variables<tmpl::list<Var1, Var2>>>>(
+      "Inactive(Variables(Var1,Var2))");
   TestHelpers::db::test_simple_tag<
       evolution::dg::subcell::Tags::TciGridHistory>("TciGridHistory");
 }


### PR DESCRIPTION
## Proposed changes

We need to (mostly) persistently store the data on the inactive grid, so we need a way of keeping them around in the DataBox. the `Tags::Inactive` prefix is used to mark variables/fields on the inactive grid, while tags without the prefix are on the active grid (mostly, there will be some caveats, but those should be transparent to the user).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
