### PR TITLE
Add apparent-horizon boundary conditions

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -1267,6 +1267,21 @@ eprint = {https://doi.org/10.1137/0916035}
   url       = "{http://numerical.recipes}",
 }
 
+@article{Ossokine2015yla,
+  author        = {Ossokine, Serguei and Foucart, Francois and Pfeiffer, Harald
+                   P. and Boyle, Michael and Szil\'agyi, B\'ela},
+  title         = {Improvements to the construction of binary black hole initial
+                   data},
+  eprint        = {1506.01689},
+  archiveprefix = {arXiv},
+  primaryclass  = {gr-qc},
+  doi           = {10.1088/0264-9381/32/24/245010},
+  journal       = {Class. Quant. Grav.},
+  volume        = {32},
+  pages         = {245010},
+  year          = {2015}
+}
+
 @article{Owen2009sb,
   author         = "Owen, Robert",
   title          = "The Final Remnant of Binary Black Hole Mergers:
@@ -1318,6 +1333,16 @@ eprint = {https://doi.org/10.1137/0916035}
   pages     = 112,
   year      = 2006,
   doi       = {10.2514/6.2006-112}
+}
+
+@phdthesis{Pfeiffer2005zm,
+  author        = "Pfeiffer, Harald Paul",
+  title         = "Initial data for black hole evolutions",
+  eprint        = "gr-qc/0510016",
+  archivePrefix = "arXiv",
+  reportnumber  = "UMI-31-04429",
+  school        = "Cornell U.",
+  year          = "2005"
 }
 
 @article{Porth2016rfi,

--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.cpp
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.cpp
@@ -1,0 +1,667 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.hpp"
+
+#include <array>
+#include <cstddef>
+#include <optional>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/LeviCivitaIterator.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/TempBuffer.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/Systems/Xcts/Geometry.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Xcts::BoundaryConditions::detail {
+
+template <Xcts::Geometry ConformalGeometry>
+ApparentHorizonImpl<ConformalGeometry>::ApparentHorizonImpl(
+    std::array<double, 3> center, std::array<double, 3> rotation,
+    std::optional<gr::Solutions::KerrSchild> kerr_solution_for_lapse,
+    std::optional<gr::Solutions::KerrSchild>
+        kerr_solution_for_negative_expansion,
+    const Options::Context& context)
+    : center_(center),
+      rotation_(rotation),
+      // NOLINTNEXTLINE(performance-move-const-arg)
+      kerr_solution_for_lapse_(std::move(kerr_solution_for_lapse)),
+      kerr_solution_for_negative_expansion_(
+          // NOLINTNEXTLINE(performance-move-const-arg)
+          std::move(kerr_solution_for_negative_expansion)) {
+  if (kerr_solution_for_lapse_.has_value() and
+      kerr_solution_for_lapse_->center() !=
+          std::array<double, 3>{{0., 0., 0.}}) {
+    PARSE_ERROR(
+        context,
+        "The Kerr solution supplied to the 'Lapse' option has a "
+        "non-zero 'Center'. While technically possible, this is probably not "
+        "what you want since the solution is already centered at the apparent "
+        "horizon. If you indeed want to offset the solution from the center, "
+        "edit Xcts::BoundaryConditions::ApparentHorizon. Else, just set "
+        "ApparentHorizon.Lapse.Center: [0, 0, 0].");
+  }
+  if (kerr_solution_for_negative_expansion_.has_value() and
+      kerr_solution_for_negative_expansion_->center() !=
+          std::array<double, 3>{{0., 0., 0.}}) {
+    PARSE_ERROR(
+        context,
+        "The Kerr solution supplied to the 'NegativeExpansion' option has a "
+        "non-zero 'Center'. While technically possible, this is probably not "
+        "what you want since the solution is already centered at the apparent "
+        "horizon. If you indeed want to offset the solution from the center, "
+        "edit Xcts::BoundaryConditions::ApparentHorizon. Else, just set "
+        "ApparentHorizon.Lapse.Center: [0, 0, 0].");
+  }
+}
+
+// This sets the output buffer to: \bar{m}^{ij} \bar{\nabla}_i n_j
+void normal_gradient_term_flat_cartesian(
+    const gsl::not_null<Scalar<DataVector>*> n_dot_conformal_factor_gradient,
+    const tnsr::i<DataVector, 3>& face_normal,
+    const tnsr::ij<DataVector, 3>& deriv_unnormalized_face_normal,
+    const Scalar<DataVector>& face_normal_magnitude) noexcept {
+  // Write directly into the output buffer
+  DataVector& projected_normal_gradient = get(*n_dot_conformal_factor_gradient);
+  projected_normal_gradient = (1. - square(get<0>(face_normal))) *
+                                  get<0, 0>(deriv_unnormalized_face_normal) -
+                              get<0>(face_normal) * get<1>(face_normal) *
+                                  get<0, 1>(deriv_unnormalized_face_normal) -
+                              get<0>(face_normal) * get<2>(face_normal) *
+                                  get<0, 2>(deriv_unnormalized_face_normal);
+  for (size_t i = 1; i < 3; ++i) {
+    projected_normal_gradient += deriv_unnormalized_face_normal.get(i, i);
+    for (size_t j = 0; j < 3; ++j) {
+      projected_normal_gradient -= face_normal.get(i) * face_normal.get(j) *
+                                   deriv_unnormalized_face_normal.get(i, j);
+    }
+  }
+  projected_normal_gradient /= get(face_normal_magnitude);
+}
+
+// This sets the output buffer to: \bar{m}^{ij} \bar{\nabla}_i n_j
+void normal_gradient_term_curved(
+    const gsl::not_null<Scalar<DataVector>*> n_dot_conformal_factor_gradient,
+    const gsl::not_null<DataVector*> temp_buffer,
+    const tnsr::i<DataVector, 3>& face_normal,
+    const tnsr::I<DataVector, 3>& face_normal_raised,
+    const tnsr::ij<DataVector, 3>& deriv_unnormalized_face_normal,
+    const Scalar<DataVector>& face_normal_magnitude,
+    const tnsr::II<DataVector, 3>& inv_conformal_metric,
+    const tnsr::Ijj<DataVector, 3>&
+        conformal_christoffel_second_kind) noexcept {
+  // Write directly into the output buffer
+  DataVector& projected_normal_gradient = get(*n_dot_conformal_factor_gradient);
+  DataVector& projection = *temp_buffer;
+  // Possible performance optimization: unroll the first iteration of the loop
+  // to avoid zeroing the buffer. It's very verbose to do that though.
+  *projected_normal_gradient = 0.;
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      projection = inv_conformal_metric.get(i, j) -
+                   face_normal_raised.get(i) * face_normal_raised.get(j);
+      projected_normal_gradient += projection *
+                                   deriv_unnormalized_face_normal.get(i, j) /
+                                   get(face_normal_magnitude);
+      for (size_t k = 0; k < 3; ++k) {
+        projected_normal_gradient -=
+            projection * face_normal.get(k) *
+            conformal_christoffel_second_kind.get(k, i, j);
+      }
+    }
+  }
+}
+
+// Compute the expansion Theta = m^ij (D_i s_j - K_ij) and the shift-correction
+// epsilon = shift_orthogonal - lapse of a Kerr solution
+void negative_expansion_quantities(
+    const gsl::not_null<Scalar<DataVector>*> expansion,
+    const gsl::not_null<Scalar<DataVector>*> beta_orthogonal_correction,
+    const gr::Solutions::KerrSchild& kerr_solution,
+    const tnsr::I<DataVector, 3>& x,
+    const tnsr::i<DataVector, 3>& conformal_face_normal,
+    const Scalar<DataVector>& unnormalized_conformal_face_normal_magnitude,
+    const tnsr::ij<DataVector, 3>& deriv_unnormalized_face_normal) noexcept {
+  const auto solution_vars = kerr_solution.variables(
+      x, std::numeric_limits<double>::signaling_NaN(),
+      tmpl::list<
+          gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>,
+          ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+                        tmpl::size_t<3>, Frame::Inertial>,
+          gr::Tags::Lapse<DataVector>,
+          gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+          gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>>{});
+  const auto& inv_spatial_metric =
+      get<gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>>(
+          solution_vars);
+  const auto& deriv_spatial_metric =
+      get<::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+                        tmpl::size_t<3>, Frame::Inertial>>(solution_vars);
+  const auto& lapse = get<gr::Tags::Lapse<DataVector>>(solution_vars);
+  const auto& shift =
+      get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(solution_vars);
+  const auto& extrinsic_curvature =
+      get<gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>>(
+          solution_vars);
+  // The passed-in face normal is normalized with the full conformal metric
+  // (typically a superposition of isolated metrics). Therefore, we need to
+  // normalized the face normal again with the isolated Kerr metric. Possible
+  // optimization if this turns out to have a significant computational cost:
+  // We could just re-use the face normal and the projected normal gradient
+  // from the full conformal metric, since it's probably sufficiently close to
+  // the isolated Kerr metric. However, the difference between the two metric
+  // means that the expansion is not exactly zero when the excision surface
+  // coincides with the isolated Kerr horizon, which users would probably
+  // expect.
+  TempBuffer<tmpl::list<::Tags::Tempi<0, 3>, ::Tags::TempScalar<1>,
+                        ::Tags::TempI<2, 3>, ::Tags::TempIjj<3, 3>>>
+      buffer{x.begin()->size()};
+  auto& face_normal = get<::Tags::Tempi<0, 3>>(buffer);
+  auto& face_normal_magnitude = get<::Tags::TempScalar<1>>(buffer);
+  auto& face_normal_raised = get<::Tags::TempI<2, 3>>(buffer);
+  auto& spatial_christoffel_second_kind = get<::Tags::TempIjj<3, 3>>(buffer);
+  magnitude(make_not_null(&face_normal_magnitude), conformal_face_normal,
+            inv_spatial_metric);
+  face_normal = conformal_face_normal;
+  for (size_t d = 0; d < 3; ++d) {
+    face_normal.get(d) /= get(face_normal_magnitude);
+  }
+  get(face_normal_magnitude) *=
+      get(unnormalized_conformal_face_normal_magnitude);
+  raise_or_lower_index(make_not_null(&face_normal_raised), face_normal,
+                       inv_spatial_metric);
+  gr::christoffel_second_kind(make_not_null(&spatial_christoffel_second_kind),
+                              deriv_spatial_metric, inv_spatial_metric);
+  // Compute Theta = m^ij (D_i s_j - K_ij)
+  // Use second output buffer as temporary memory
+  DataVector& projection = get(*beta_orthogonal_correction);
+  get(*expansion) = 0.;
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      projection = inv_spatial_metric.get(i, j) -
+                   face_normal_raised.get(i) * face_normal_raised.get(j);
+      // This first part is the same as `normal_gradient_term_curved` above
+      get(*expansion) += projection * deriv_unnormalized_face_normal.get(i, j) /
+                         get(face_normal_magnitude);
+      for (size_t k = 0; k < 3; ++k) {
+        get(*expansion) -= projection * face_normal.get(k) *
+                           spatial_christoffel_second_kind.get(k, i, j);
+      }
+      // Additional extrinsic-curvature term
+      get(*expansion) += projection * extrinsic_curvature.get(i, j);
+    }
+  }
+  get(*expansion) *= -1.;
+  // Compute epsilon = shift_orthogonal - lapse
+  normal_dot_flux(beta_orthogonal_correction, face_normal, shift);
+  get(*beta_orthogonal_correction) *= -1.;
+  get(*beta_orthogonal_correction) -= get(lapse);
+}
+
+template <Xcts::Geometry ConformalGeometry>
+void apparent_horizon_impl(
+    const gsl::not_null<Scalar<DataVector>*> conformal_factor,
+    const gsl::not_null<Scalar<DataVector>*> lapse_times_conformal_factor,
+    const gsl::not_null<tnsr::I<DataVector, 3>*> shift_excess,
+    const gsl::not_null<Scalar<DataVector>*> n_dot_conformal_factor_gradient,
+    const gsl::not_null<Scalar<DataVector>*>
+        n_dot_lapse_times_conformal_factor_gradient,
+    const gsl::not_null<tnsr::I<DataVector, 3>*>
+        n_dot_longitudinal_shift_excess,
+    const std::array<double, 3>& center, const std::array<double, 3>& rotation,
+    const std::optional<gr::Solutions::KerrSchild>& kerr_solution_for_lapse,
+    const std::optional<gr::Solutions::KerrSchild>&
+        kerr_solution_for_negative_expansion,
+    const tnsr::i<DataVector, 3>& face_normal,
+    const tnsr::ij<DataVector, 3>& deriv_unnormalized_face_normal,
+    const Scalar<DataVector>& face_normal_magnitude,
+    const tnsr::I<DataVector, 3>& x_offcenter,
+    const Scalar<DataVector>& extrinsic_curvature_trace,
+    const tnsr::I<DataVector, 3>& shift_background,
+    const tnsr::II<DataVector, 3>& longitudinal_shift_background,
+    [[maybe_unused]] const std::optional<
+        std::reference_wrapper<const tnsr::II<DataVector, 3>>>
+        inv_conformal_metric,
+    [[maybe_unused]] const std::optional<
+        std::reference_wrapper<const tnsr::Ijj<DataVector, 3>>>
+        conformal_christoffel_second_kind) noexcept {
+  // Allocate some temporary memory
+  TempBuffer<tmpl::list<::Tags::TempI<0, 3>, ::Tags::TempScalar<1>,
+                        ::Tags::TempI<2, 3>, ::Tags::TempScalar<3>>>
+      buffer{face_normal.begin()->size()};
+  // Center the coordinates
+  tnsr::I<DataVector, 3>& x = get<::Tags::TempI<2, 3>>(buffer);
+  x = x_offcenter;
+  get<0>(x) -= center[0];
+  get<1>(x) -= center[1];
+  get<2>(x) -= center[2];
+  // Note that the face normal points _out_ of the computational domain, i.e.
+  // _into_ the excised region. It is opposite the conformal unit normal to the
+  // horizon surface: \bar{s}_i = -n_i.
+  tnsr::I<DataVector, 3>& face_normal_raised = get<::Tags::TempI<0, 3>>(buffer);
+  if constexpr (ConformalGeometry == Xcts::Geometry::FlatCartesian) {
+    get<0>(face_normal_raised) = get<0>(face_normal);
+    get<1>(face_normal_raised) = get<1>(face_normal);
+    get<2>(face_normal_raised) = get<2>(face_normal);
+  } else {
+    raise_or_lower_index(make_not_null(&face_normal_raised), face_normal,
+                         inv_conformal_metric->get());
+  }
+
+  // Compute quantities for negative-expansion boundary conditions. We collect
+  // all calls into the analytic solution in one place so it doesn't have to
+  // compute intermediate quantities multiple times. Possible optimization:
+  // Store the result in the DataBox and use it in repeated applications of the
+  // boundary conditions.
+  Scalar<DataVector>& expansion_of_solution =
+      get<::Tags::TempScalar<3>>(buffer);
+  Scalar<DataVector>& beta_orthogonal = get<::Tags::TempScalar<1>>(buffer);
+  if (kerr_solution_for_negative_expansion.has_value()) {
+    detail::negative_expansion_quantities(
+        make_not_null(&expansion_of_solution), make_not_null(&beta_orthogonal),
+        *kerr_solution_for_negative_expansion, x, face_normal,
+        face_normal_magnitude, deriv_unnormalized_face_normal);
+  }
+
+  // Shift
+  {
+    if (kerr_solution_for_negative_expansion.has_value()) {
+      get(beta_orthogonal) /= square(get(*conformal_factor));
+    } else {
+      get(beta_orthogonal) = 0.;
+    }
+    get(beta_orthogonal) +=
+        get(*lapse_times_conformal_factor) / cube(get(*conformal_factor));
+    for (size_t i = 0; i < 3; ++i) {
+      shift_excess->get(i) = -get(beta_orthogonal) * face_normal_raised.get(i) -
+                             shift_background.get(i);
+    }
+  }
+  // At this point we're done with `beta_orthogonal`, so we can re-purpose the
+  // memory buffer.
+  for (LeviCivitaIterator<3> it; it; ++it) {
+    shift_excess->get(it[0]) +=
+        it.sign() * gsl::at(rotation, it[1]) * x.get(it[2]);
+  }
+
+  // Conformal factor
+  if constexpr (ConformalGeometry == Xcts::Geometry::FlatCartesian) {
+    normal_gradient_term_flat_cartesian(
+        n_dot_conformal_factor_gradient, face_normal,
+        deriv_unnormalized_face_normal, face_normal_magnitude);
+  } else {
+    normal_gradient_term_curved(
+        n_dot_conformal_factor_gradient,
+        make_not_null(&get(get<::Tags::TempScalar<1>>(buffer))), face_normal,
+        face_normal_raised, deriv_unnormalized_face_normal,
+        face_normal_magnitude, *inv_conformal_metric,
+        *conformal_christoffel_second_kind);
+  }
+  // At this point we're done with `face_normal_raised`, so we can re-purpose
+  // the memory buffer.
+  get(*n_dot_conformal_factor_gradient) *= -0.25 * get(*conformal_factor);
+  if (kerr_solution_for_negative_expansion.has_value()) {
+    get(*n_dot_conformal_factor_gradient) -=
+        0.25 * cube(get(*conformal_factor)) * get(expansion_of_solution);
+  }
+  {
+    tnsr::I<DataVector, 3>& n_dot_longitudinal_shift =
+        get<::Tags::TempI<0, 3>>(buffer);
+    normal_dot_flux(make_not_null(&n_dot_longitudinal_shift), face_normal,
+                    longitudinal_shift_background);
+    for (size_t i = 0; i < 3; ++i) {
+      n_dot_longitudinal_shift.get(i) +=
+          n_dot_longitudinal_shift_excess->get(i);
+    }
+    Scalar<DataVector>& nn_dot_longitudinal_shift =
+        get<::Tags::TempScalar<1>>(buffer);
+    normal_dot_flux(make_not_null(&nn_dot_longitudinal_shift), face_normal,
+                    n_dot_longitudinal_shift);
+    get(*n_dot_conformal_factor_gradient) +=
+        -get(extrinsic_curvature_trace) * cube(get(*conformal_factor)) / 6. +
+        pow<4>(get(*conformal_factor)) / 8. /
+            get(*lapse_times_conformal_factor) * get(nn_dot_longitudinal_shift);
+  }
+
+  // Lapse
+  if (kerr_solution_for_lapse.has_value()) {
+    *lapse_times_conformal_factor =
+        get<gr::Tags::Lapse<DataVector>>(kerr_solution_for_lapse->variables(
+            x, 0., tmpl::list<gr::Tags::Lapse<DataVector>>{}));
+  } else {
+    get(*n_dot_lapse_times_conformal_factor_gradient) = 0.;
+  }
+}
+
+template <Xcts::Geometry ConformalGeometry>
+void linearized_apparent_horizon_impl(
+    const gsl::not_null<Scalar<DataVector>*> conformal_factor_correction,
+    const gsl::not_null<Scalar<DataVector>*>
+        lapse_times_conformal_factor_correction,
+    const gsl::not_null<tnsr::I<DataVector, 3>*> shift_correction,
+    const gsl::not_null<Scalar<DataVector>*>
+        n_dot_conformal_factor_gradient_correction,
+    const gsl::not_null<Scalar<DataVector>*>
+        n_dot_lapse_times_conformal_factor_gradient_correction,
+    const gsl::not_null<tnsr::I<DataVector, 3>*>
+        n_dot_longitudinal_shift_correction,
+    const std::array<double, 3>& center,
+    const std::optional<gr::Solutions::KerrSchild>& kerr_solution_for_lapse,
+    const std::optional<gr::Solutions::KerrSchild>&
+        kerr_solution_for_negative_expansion,
+    const tnsr::i<DataVector, 3>& face_normal,
+    const tnsr::ij<DataVector, 3>& deriv_unnormalized_face_normal,
+    const Scalar<DataVector>& face_normal_magnitude,
+    const tnsr::I<DataVector, 3>& x_offcenter,
+    const Scalar<DataVector>& extrinsic_curvature_trace,
+    const tnsr::II<DataVector, 3>& longitudinal_shift_background,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& lapse_times_conformal_factor,
+    const tnsr::I<DataVector, 3>& n_dot_longitudinal_shift_excess,
+    [[maybe_unused]] const std::optional<
+        std::reference_wrapper<const tnsr::II<DataVector, 3>>>
+        inv_conformal_metric,
+    [[maybe_unused]] const std::optional<
+        std::reference_wrapper<const tnsr::Ijj<DataVector, 3>>>
+        conformal_christoffel_second_kind) noexcept {
+  // Allocate some temporary memory
+  TempBuffer<tmpl::list<::Tags::TempI<0, 3>, ::Tags::TempScalar<1>,
+                        ::Tags::TempScalar<2>>>
+      buffer{face_normal.begin()->size()};
+
+  // Negative-expansion quantities
+  Scalar<DataVector>& expansion_of_solution =
+      get<::Tags::TempScalar<2>>(buffer);
+  Scalar<DataVector>& beta_orthogonal_correction =
+      get<::Tags::TempScalar<1>>(buffer);
+  if (kerr_solution_for_negative_expansion.has_value()) {
+    // Center the coordinates
+    tnsr::I<DataVector, 3>& x = get<::Tags::TempI<0, 3>>(buffer);
+    x = x_offcenter;
+    get<0>(x) -= center[0];
+    get<1>(x) -= center[1];
+    get<2>(x) -= center[2];
+    detail::negative_expansion_quantities(
+        make_not_null(&expansion_of_solution),
+        make_not_null(&beta_orthogonal_correction),
+        *kerr_solution_for_negative_expansion, x, face_normal,
+        face_normal_magnitude, deriv_unnormalized_face_normal);
+  }
+
+  tnsr::I<DataVector, 3>& face_normal_raised = get<::Tags::TempI<0, 3>>(buffer);
+  if constexpr (ConformalGeometry == Xcts::Geometry::FlatCartesian) {
+    get<0>(face_normal_raised) = get<0>(face_normal);
+    get<1>(face_normal_raised) = get<1>(face_normal);
+    get<2>(face_normal_raised) = get<2>(face_normal);
+  } else {
+    raise_or_lower_index(make_not_null(&face_normal_raised), face_normal,
+                         inv_conformal_metric->get());
+  }
+
+  // Shift
+  {
+    if (kerr_solution_for_negative_expansion.has_value()) {
+      get(beta_orthogonal_correction) *=
+          -2. * get(*conformal_factor_correction) / cube(get(conformal_factor));
+    } else {
+      get(beta_orthogonal_correction) = 0.;
+    }
+    get(beta_orthogonal_correction) +=
+        get(*lapse_times_conformal_factor_correction) /
+            cube(get(conformal_factor)) -
+        3. * get(lapse_times_conformal_factor) / pow<4>(get(conformal_factor)) *
+            get(*conformal_factor_correction);
+    for (size_t i = 0; i < 3; ++i) {
+      shift_correction->get(i) =
+          -get(beta_orthogonal_correction) * face_normal_raised.get(i);
+    }
+  }
+  // At this point we're done with `beta_orthogonal_correction`, so we can
+  // re-purpose the memory buffer.
+
+  // Conformal factor
+  if constexpr (ConformalGeometry == Xcts::Geometry::FlatCartesian) {
+    normal_gradient_term_flat_cartesian(
+        n_dot_conformal_factor_gradient_correction, face_normal,
+        deriv_unnormalized_face_normal, face_normal_magnitude);
+  } else {
+    normal_gradient_term_curved(
+        n_dot_conformal_factor_gradient_correction,
+        make_not_null(&get(get<::Tags::TempScalar<1>>(buffer))), face_normal,
+        face_normal_raised, deriv_unnormalized_face_normal,
+        face_normal_magnitude, *inv_conformal_metric,
+        *conformal_christoffel_second_kind);
+  }
+  // At this point we're done with `face_normal_raised`, so we can re-purpose
+  // the memory buffer.
+  get(*n_dot_conformal_factor_gradient_correction) *=
+      -0.25 * get(*conformal_factor_correction);
+  if (kerr_solution_for_negative_expansion.has_value()) {
+    get(*n_dot_conformal_factor_gradient_correction) -=
+        0.75 * square(get(conformal_factor)) * get(expansion_of_solution) *
+        get(*conformal_factor_correction);
+  }
+  {
+    tnsr::I<DataVector, 3>& n_dot_longitudinal_shift =
+        get<::Tags::TempI<0, 3>>(buffer);
+    normal_dot_flux(make_not_null(&n_dot_longitudinal_shift), face_normal,
+                    longitudinal_shift_background);
+    for (size_t i = 0; i < 3; ++i) {
+      n_dot_longitudinal_shift.get(i) += n_dot_longitudinal_shift_excess.get(i);
+    }
+    Scalar<DataVector>& nn_dot_longitudinal_shift =
+        get<::Tags::TempScalar<1>>(buffer);
+    normal_dot_flux(make_not_null(&nn_dot_longitudinal_shift), face_normal,
+                    n_dot_longitudinal_shift);
+    get(*n_dot_conformal_factor_gradient_correction) +=
+        -0.5 * get(extrinsic_curvature_trace) * square(get(conformal_factor)) *
+            get(*conformal_factor_correction) +
+        0.5 * pow<3>(get(conformal_factor)) /
+            get(lapse_times_conformal_factor) * get(nn_dot_longitudinal_shift) *
+            get(*conformal_factor_correction) -
+        0.125 * pow<4>(get(conformal_factor)) /
+            square(get(lapse_times_conformal_factor)) *
+            get(nn_dot_longitudinal_shift) *
+            get(*lapse_times_conformal_factor_correction);
+  }
+  {
+    Scalar<DataVector>& nn_dot_longitudinal_shift_correction =
+        get<::Tags::TempScalar<1>>(buffer);
+    normal_dot_flux(make_not_null(&nn_dot_longitudinal_shift_correction),
+                    face_normal, *n_dot_longitudinal_shift_correction);
+    get(*n_dot_conformal_factor_gradient_correction) +=
+        0.125 * pow<4>(get(conformal_factor)) /
+        get(lapse_times_conformal_factor) *
+        get(nn_dot_longitudinal_shift_correction);
+  }
+
+  // Lapse
+  if (kerr_solution_for_lapse.has_value()) {
+    get(*lapse_times_conformal_factor_correction) = 0.;
+  } else {
+    get(*n_dot_lapse_times_conformal_factor_gradient_correction) = 0.;
+  }
+}
+
+template <Xcts::Geometry ConformalGeometry>
+void ApparentHorizonImpl<ConformalGeometry>::apply(
+    const gsl::not_null<Scalar<DataVector>*> conformal_factor,
+    const gsl::not_null<Scalar<DataVector>*> lapse_times_conformal_factor,
+    const gsl::not_null<tnsr::I<DataVector, 3>*> shift_excess,
+    const gsl::not_null<Scalar<DataVector>*> n_dot_conformal_factor_gradient,
+    const gsl::not_null<Scalar<DataVector>*>
+        n_dot_lapse_times_conformal_factor_gradient,
+    const gsl::not_null<tnsr::I<DataVector, 3>*>
+        n_dot_longitudinal_shift_excess,
+    const tnsr::i<DataVector, 3>& face_normal,
+    const tnsr::ij<DataVector, 3>& deriv_unnormalized_face_normal,
+    const Scalar<DataVector>& face_normal_magnitude,
+    const tnsr::I<DataVector, 3>& x,
+    const Scalar<DataVector>& extrinsic_curvature_trace,
+    const tnsr::I<DataVector, 3>& shift_background,
+    const tnsr::II<DataVector, 3>& longitudinal_shift_background)
+    const noexcept {
+  apparent_horizon_impl<ConformalGeometry>(
+      conformal_factor, lapse_times_conformal_factor, shift_excess,
+      n_dot_conformal_factor_gradient,
+      n_dot_lapse_times_conformal_factor_gradient,
+      n_dot_longitudinal_shift_excess, center_, rotation_,
+      kerr_solution_for_lapse_, kerr_solution_for_negative_expansion_,
+      face_normal, deriv_unnormalized_face_normal, face_normal_magnitude, x,
+      extrinsic_curvature_trace, shift_background,
+      longitudinal_shift_background, std::nullopt, std::nullopt);
+}
+
+template <Xcts::Geometry ConformalGeometry>
+void ApparentHorizonImpl<ConformalGeometry>::apply(
+    const gsl::not_null<Scalar<DataVector>*> conformal_factor,
+    const gsl::not_null<Scalar<DataVector>*> lapse_times_conformal_factor,
+    const gsl::not_null<tnsr::I<DataVector, 3>*> shift_excess,
+    const gsl::not_null<Scalar<DataVector>*> n_dot_conformal_factor_gradient,
+    const gsl::not_null<Scalar<DataVector>*>
+        n_dot_lapse_times_conformal_factor_gradient,
+    const gsl::not_null<tnsr::I<DataVector, 3>*>
+        n_dot_longitudinal_shift_excess,
+    const tnsr::i<DataVector, 3>& face_normal,
+    const tnsr::ij<DataVector, 3>& deriv_unnormalized_face_normal,
+    const Scalar<DataVector>& face_normal_magnitude,
+    const tnsr::I<DataVector, 3>& x,
+    const Scalar<DataVector>& extrinsic_curvature_trace,
+    const tnsr::I<DataVector, 3>& shift_background,
+    const tnsr::II<DataVector, 3>& longitudinal_shift_background,
+    const tnsr::II<DataVector, 3>& inv_conformal_metric,
+    const tnsr::Ijj<DataVector, 3>& conformal_christoffel_second_kind)
+    const noexcept {
+  apparent_horizon_impl<ConformalGeometry>(
+      conformal_factor, lapse_times_conformal_factor, shift_excess,
+      n_dot_conformal_factor_gradient,
+      n_dot_lapse_times_conformal_factor_gradient,
+      n_dot_longitudinal_shift_excess, center_, rotation_,
+      kerr_solution_for_lapse_, kerr_solution_for_negative_expansion_,
+      face_normal, deriv_unnormalized_face_normal, face_normal_magnitude, x,
+      extrinsic_curvature_trace, shift_background,
+      longitudinal_shift_background, inv_conformal_metric,
+      conformal_christoffel_second_kind);
+}
+
+template <Xcts::Geometry ConformalGeometry>
+void ApparentHorizonImpl<ConformalGeometry>::apply_linearized(
+    const gsl::not_null<Scalar<DataVector>*> conformal_factor_correction,
+    const gsl::not_null<Scalar<DataVector>*>
+        lapse_times_conformal_factor_correction,
+    const gsl::not_null<tnsr::I<DataVector, 3>*> shift_excess_correction,
+    const gsl::not_null<Scalar<DataVector>*>
+        n_dot_conformal_factor_gradient_correction,
+    const gsl::not_null<Scalar<DataVector>*>
+        n_dot_lapse_times_conformal_factor_gradient_correction,
+    const gsl::not_null<tnsr::I<DataVector, 3>*>
+        n_dot_longitudinal_shift_excess_correction,
+    const tnsr::i<DataVector, 3>& face_normal,
+    const tnsr::ij<DataVector, 3>& deriv_unnormalized_face_normal,
+    const Scalar<DataVector>& face_normal_magnitude,
+    const tnsr::I<DataVector, 3>& x,
+    const Scalar<DataVector>& extrinsic_curvature_trace,
+    const tnsr::II<DataVector, 3>& longitudinal_shift_background,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& lapse_times_conformal_factor,
+    const tnsr::I<DataVector, 3>& n_dot_longitudinal_shift_excess)
+    const noexcept {
+  linearized_apparent_horizon_impl<ConformalGeometry>(
+      conformal_factor_correction, lapse_times_conformal_factor_correction,
+      shift_excess_correction, n_dot_conformal_factor_gradient_correction,
+      n_dot_lapse_times_conformal_factor_gradient_correction,
+      n_dot_longitudinal_shift_excess_correction, center_,
+      kerr_solution_for_lapse_, kerr_solution_for_negative_expansion_,
+      face_normal, deriv_unnormalized_face_normal, face_normal_magnitude, x,
+      extrinsic_curvature_trace, longitudinal_shift_background,
+      conformal_factor, lapse_times_conformal_factor,
+      n_dot_longitudinal_shift_excess, std::nullopt, std::nullopt);
+}
+
+template <Xcts::Geometry ConformalGeometry>
+void ApparentHorizonImpl<ConformalGeometry>::apply_linearized(
+    const gsl::not_null<Scalar<DataVector>*> conformal_factor_correction,
+    const gsl::not_null<Scalar<DataVector>*>
+        lapse_times_conformal_factor_correction,
+    const gsl::not_null<tnsr::I<DataVector, 3>*> shift_excess_correction,
+    const gsl::not_null<Scalar<DataVector>*>
+        n_dot_conformal_factor_gradient_correction,
+    const gsl::not_null<Scalar<DataVector>*>
+        n_dot_lapse_times_conformal_factor_gradient_correction,
+    const gsl::not_null<tnsr::I<DataVector, 3>*>
+        n_dot_longitudinal_shift_excess_correction,
+    const tnsr::i<DataVector, 3>& face_normal,
+    const tnsr::ij<DataVector, 3>& deriv_unnormalized_face_normal,
+    const Scalar<DataVector>& face_normal_magnitude,
+    const tnsr::I<DataVector, 3>& x,
+    const Scalar<DataVector>& extrinsic_curvature_trace,
+    const tnsr::II<DataVector, 3>& longitudinal_shift_background,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& lapse_times_conformal_factor,
+    const tnsr::I<DataVector, 3>& n_dot_longitudinal_shift_excess,
+    const tnsr::II<DataVector, 3>& inv_conformal_metric,
+    const tnsr::Ijj<DataVector, 3>& conformal_christoffel_second_kind)
+    const noexcept {
+  linearized_apparent_horizon_impl<ConformalGeometry>(
+      conformal_factor_correction, lapse_times_conformal_factor_correction,
+      shift_excess_correction, n_dot_conformal_factor_gradient_correction,
+      n_dot_lapse_times_conformal_factor_gradient_correction,
+      n_dot_longitudinal_shift_excess_correction, center_,
+      kerr_solution_for_lapse_, kerr_solution_for_negative_expansion_,
+      face_normal, deriv_unnormalized_face_normal, face_normal_magnitude, x,
+      extrinsic_curvature_trace, longitudinal_shift_background,
+      conformal_factor, lapse_times_conformal_factor,
+      n_dot_longitudinal_shift_excess, inv_conformal_metric,
+      conformal_christoffel_second_kind);
+}
+
+template <Xcts::Geometry ConformalGeometry>
+void ApparentHorizonImpl<ConformalGeometry>::pup(PUP::er& p) noexcept {
+  p | center_;
+  p | rotation_;
+  p | kerr_solution_for_lapse_;
+  p | kerr_solution_for_negative_expansion_;
+}
+
+template <Xcts::Geometry ConformalGeometry>
+bool operator==(const ApparentHorizonImpl<ConformalGeometry>& lhs,
+                const ApparentHorizonImpl<ConformalGeometry>& rhs) noexcept {
+  return lhs.center() == rhs.center() and lhs.rotation() == rhs.rotation() and
+         lhs.kerr_solution_for_lapse() == rhs.kerr_solution_for_lapse() and
+         lhs.kerr_solution_for_negative_expansion() ==
+             rhs.kerr_solution_for_negative_expansion();
+}
+
+template <Xcts::Geometry ConformalGeometry>
+bool operator!=(const ApparentHorizonImpl<ConformalGeometry>& lhs,
+                const ApparentHorizonImpl<ConformalGeometry>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+template class ApparentHorizonImpl<Xcts::Geometry::FlatCartesian>;
+template class ApparentHorizonImpl<Xcts::Geometry::Curved>;
+template bool operator==(
+    const ApparentHorizonImpl<Xcts::Geometry::FlatCartesian>& lhs,
+    const ApparentHorizonImpl<Xcts::Geometry::FlatCartesian>& rhs) noexcept;
+template bool operator!=(
+    const ApparentHorizonImpl<Xcts::Geometry::FlatCartesian>& lhs,
+    const ApparentHorizonImpl<Xcts::Geometry::FlatCartesian>& rhs) noexcept;
+template bool operator==(
+    const ApparentHorizonImpl<Xcts::Geometry::Curved>& lhs,
+    const ApparentHorizonImpl<Xcts::Geometry::Curved>& rhs) noexcept;
+template bool operator!=(
+    const ApparentHorizonImpl<Xcts::Geometry::Curved>& lhs,
+    const ApparentHorizonImpl<Xcts::Geometry::Curved>& rhs) noexcept;
+
+}  // namespace Xcts::BoundaryConditions::detail

--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.hpp
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.hpp
@@ -1,0 +1,367 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <pup.h>
+#include <string>
+
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/Tags/FaceNormal.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/Systems/Xcts/Geometry.hpp"
+#include "Elliptic/Systems/Xcts/Tags.hpp"
+#include "Options/Auto.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+/// \endcond
+
+namespace Xcts::BoundaryConditions {
+namespace detail {
+
+template <Xcts::Geometry ConformalGeometry>
+struct ApparentHorizonImpl {
+  static constexpr Options::String help =
+      "Impose the boundary is a quasi-equilibrium apparent horizon.";
+
+  struct Center {
+    using type = std::array<double, 3>;
+    static constexpr Options::String help =
+        "The center of the excision surface representing the apparent-horizon "
+        "surface";
+  };
+  struct Rotation {
+    using type = std::array<double, 3>;
+    static constexpr Options::String help =
+        "The rotational parameters 'Omega' on the surface, which parametrize "
+        "the spin of the black hole. The rotational parameters enter the "
+        "Dirichlet boundary conditions for the shift in a term "
+        "'Omega x (r - Center)', where 'r' are the coordinates on the surface.";
+  };
+  struct Lapse {
+    using type = Options::Auto<gr::Solutions::KerrSchild>;
+    static constexpr Options::String help =
+        "Specify a Kerr solution to impose a Dirichlet condition on the lapse "
+        "in Kerr-Schild coordinates. Alternatively, set this option to 'None' "
+        "to impose a zero von-Neumann boundary condition on the lapse. Note "
+        "that the latter will not result in the standard Kerr-Schild slicing "
+        "for a single black hole.";
+  };
+  struct NegativeExpansion {
+    using type =
+        Options::Auto<gr::Solutions::KerrSchild, Options::AutoLabel::None>;
+    static constexpr Options::String help =
+        "Specify a Kerr solution to impose its expansion at the excision "
+        "surface. If the excision surface lies within the Kerr solution's "
+        "apparent horizon, the imposed expansion will be negative and thus the "
+        "excision surface will lie within an apparent horizon. Alternatively, "
+        "set this option to 'None' to impose the expansion is zero at the "
+        "excision surface, meaning the excision surface _is_ an apparent "
+        "horizon.";
+  };
+
+  using options = tmpl::list<Center, Rotation, Lapse, NegativeExpansion>;
+
+  ApparentHorizonImpl() = default;
+  ApparentHorizonImpl(const ApparentHorizonImpl&) = default;
+  ApparentHorizonImpl& operator=(const ApparentHorizonImpl&) = default;
+  ApparentHorizonImpl(ApparentHorizonImpl&&) = default;
+  ApparentHorizonImpl& operator=(ApparentHorizonImpl&&) = default;
+  ~ApparentHorizonImpl() = default;
+
+  ApparentHorizonImpl(
+      std::array<double, 3> center, std::array<double, 3> rotation,
+      std::optional<gr::Solutions::KerrSchild> kerr_solution_for_lapse,
+      std::optional<gr::Solutions::KerrSchild>
+          kerr_solution_for_negative_expansion,
+      const Options::Context& context = {});
+
+  const std::array<double, 3>& center() const noexcept { return center_; }
+  const std::array<double, 3>& rotation() const noexcept { return rotation_; }
+  const std::optional<gr::Solutions::KerrSchild>& kerr_solution_for_lapse()
+      const noexcept {
+    return kerr_solution_for_lapse_;
+  }
+  const std::optional<gr::Solutions::KerrSchild>&
+  kerr_solution_for_negative_expansion() const noexcept {
+    return kerr_solution_for_negative_expansion_;
+  }
+
+  using argument_tags = tmpl::flatten<tmpl::list<
+      domain::Tags::FaceNormal<3>,
+      ::Tags::deriv<domain::Tags::UnnormalizedFaceNormal<3>, tmpl::size_t<3>,
+                    Frame::Inertial>,
+      domain::Tags::UnnormalizedFaceNormalMagnitude<3>,
+      domain::Tags::Coordinates<3, Frame::Inertial>,
+      gr::Tags::TraceExtrinsicCurvature<DataVector>,
+      Tags::ShiftBackground<DataVector, 3, Frame::Inertial>,
+      Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<DataVector, 3,
+                                                              Frame::Inertial>,
+      tmpl::conditional_t<ConformalGeometry == Xcts::Geometry::Curved,
+                          tmpl::list<Tags::InverseConformalMetric<
+                                         DataVector, 3, Frame::Inertial>,
+                                     Tags::ConformalChristoffelSecondKind<
+                                         DataVector, 3, Frame::Inertial>>,
+                          tmpl::list<>>>>;
+  using volume_tags = tmpl::list<>;
+
+  void apply(
+      gsl::not_null<Scalar<DataVector>*> conformal_factor,
+      gsl::not_null<Scalar<DataVector>*> lapse_times_conformal_factor,
+      gsl::not_null<tnsr::I<DataVector, 3>*> shift_excess,
+      gsl::not_null<Scalar<DataVector>*> n_dot_conformal_factor_gradient,
+      gsl::not_null<Scalar<DataVector>*>
+          n_dot_lapse_times_conformal_factor_gradient,
+      gsl::not_null<tnsr::I<DataVector, 3>*> n_dot_longitudinal_shift_excess,
+      const tnsr::i<DataVector, 3>& face_normal,
+      const tnsr::ij<DataVector, 3>& deriv_unnormalized_face_normal,
+      const Scalar<DataVector>& face_normal_magnitude,
+      const tnsr::I<DataVector, 3>& x,
+      const Scalar<DataVector>& extrinsic_curvature_trace,
+      const tnsr::I<DataVector, 3>& shift_background,
+      const tnsr::II<DataVector, 3>& longitudinal_shift_background)
+      const noexcept;
+
+  void apply(
+      gsl::not_null<Scalar<DataVector>*> conformal_factor,
+      gsl::not_null<Scalar<DataVector>*> lapse_times_conformal_factor,
+      gsl::not_null<tnsr::I<DataVector, 3>*> shift_excess,
+      gsl::not_null<Scalar<DataVector>*> n_dot_conformal_factor_gradient,
+      gsl::not_null<Scalar<DataVector>*>
+          n_dot_lapse_times_conformal_factor_gradient,
+      gsl::not_null<tnsr::I<DataVector, 3>*> n_dot_longitudinal_shift_excess,
+      const tnsr::i<DataVector, 3>& face_normal,
+      const tnsr::ij<DataVector, 3>& deriv_unnormalized_face_normal,
+      const Scalar<DataVector>& face_normal_magnitude,
+      const tnsr::I<DataVector, 3>& x,
+      const Scalar<DataVector>& extrinsic_curvature_trace,
+      const tnsr::I<DataVector, 3>& shift_background,
+      const tnsr::II<DataVector, 3>& longitudinal_shift_background,
+      const tnsr::II<DataVector, 3>& inv_conformal_metric,
+      const tnsr::Ijj<DataVector, 3>& conformal_christoffel_second_kind)
+      const noexcept;
+
+  using argument_tags_linearized = tmpl::flatten<tmpl::list<
+      ::Tags::Normalized<
+          domain::Tags::UnnormalizedFaceNormal<3, Frame::Inertial>>,
+      ::Tags::deriv<domain::Tags::UnnormalizedFaceNormal<3, Frame::Inertial>,
+                    tmpl::size_t<3>, Frame::Inertial>,
+      ::Tags::Magnitude<
+          domain::Tags::UnnormalizedFaceNormal<3, Frame::Inertial>>,
+      domain::Tags::Coordinates<3, Frame::Inertial>,
+      gr::Tags::TraceExtrinsicCurvature<DataVector>,
+      Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<DataVector, 3,
+                                                              Frame::Inertial>,
+      Tags::ConformalFactor<DataVector>,
+      Tags::LapseTimesConformalFactor<DataVector>,
+      ::Tags::NormalDotFlux<Tags::ShiftExcess<DataVector, 3, Frame::Inertial>>,
+      tmpl::conditional_t<ConformalGeometry == Xcts::Geometry::Curved,
+                          tmpl::list<Tags::InverseConformalMetric<
+                                         DataVector, 3, Frame::Inertial>,
+                                     Tags::ConformalChristoffelSecondKind<
+                                         DataVector, 3, Frame::Inertial>>,
+                          tmpl::list<>>>>;
+  using volume_tags_linearized = tmpl::list<>;
+
+  void apply_linearized(
+      gsl::not_null<Scalar<DataVector>*> conformal_factor_correction,
+      gsl::not_null<Scalar<DataVector>*>
+          lapse_times_conformal_factor_correction,
+      gsl::not_null<tnsr::I<DataVector, 3>*> shift_excess_correction,
+      gsl::not_null<Scalar<DataVector>*>
+          n_dot_conformal_factor_gradient_correction,
+      gsl::not_null<Scalar<DataVector>*>
+          n_dot_lapse_times_conformal_factor_gradient_correction,
+      gsl::not_null<tnsr::I<DataVector, 3>*>
+          n_dot_longitudinal_shift_excess_correction,
+      const tnsr::i<DataVector, 3>& face_normal,
+      const tnsr::ij<DataVector, 3>& deriv_unnormalized_face_normal,
+      const Scalar<DataVector>& face_normal_magnitude,
+      const tnsr::I<DataVector, 3>& x,
+      const Scalar<DataVector>& extrinsic_curvature_trace,
+      const tnsr::II<DataVector, 3>& longitudinal_shift_background,
+      const Scalar<DataVector>& conformal_factor,
+      const Scalar<DataVector>& lapse_times_conformal_factor,
+      const tnsr::I<DataVector, 3>& n_dot_longitudinal_shift_excess)
+      const noexcept;
+
+  void apply_linearized(
+      gsl::not_null<Scalar<DataVector>*> conformal_factor_correction,
+      gsl::not_null<Scalar<DataVector>*>
+          lapse_times_conformal_factor_correction,
+      gsl::not_null<tnsr::I<DataVector, 3>*> shift_excess_correction,
+      gsl::not_null<Scalar<DataVector>*>
+          n_dot_conformal_factor_gradient_correction,
+      gsl::not_null<Scalar<DataVector>*>
+          n_dot_lapse_times_conformal_factor_gradient_correction,
+      gsl::not_null<tnsr::I<DataVector, 3>*>
+          n_dot_longitudinal_shift_excess_correction,
+      const tnsr::i<DataVector, 3>& face_normal,
+      const tnsr::ij<DataVector, 3>& deriv_unnormalized_face_normal,
+      const Scalar<DataVector>& face_normal_magnitude,
+      const tnsr::I<DataVector, 3>& x,
+      const Scalar<DataVector>& extrinsic_curvature_trace,
+      const tnsr::II<DataVector, 3>& longitudinal_shift_background,
+      const Scalar<DataVector>& conformal_factor,
+      const Scalar<DataVector>& lapse_times_conformal_factor,
+      const tnsr::I<DataVector, 3>& n_dot_longitudinal_shift_excess,
+      const tnsr::II<DataVector, 3>& inv_conformal_metric,
+      const tnsr::Ijj<DataVector, 3>& conformal_christoffel_second_kind)
+      const noexcept;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) noexcept;
+
+ private:
+  std::array<double, 3> center_ =
+      make_array<3>(std::numeric_limits<double>::signaling_NaN());
+  std::array<double, 3> rotation_ =
+      make_array<3>(std::numeric_limits<double>::signaling_NaN());
+  std::optional<gr::Solutions::KerrSchild> kerr_solution_for_lapse_{};
+  std::optional<gr::Solutions::KerrSchild>
+      kerr_solution_for_negative_expansion_{};
+};
+
+template <Xcts::Geometry ConformalGeometry>
+bool operator==(const ApparentHorizonImpl<ConformalGeometry>& lhs,
+                const ApparentHorizonImpl<ConformalGeometry>& rhs) noexcept;
+
+template <Xcts::Geometry ConformalGeometry>
+bool operator!=(const ApparentHorizonImpl<ConformalGeometry>& lhs,
+                const ApparentHorizonImpl<ConformalGeometry>& rhs) noexcept;
+
+}  // namespace detail
+
+// The following implements the registration and factory-creation mechanism
+
+/// \cond
+template <Xcts::Geometry ConformalGeometry, typename Registrars>
+struct ApparentHorizon;
+
+namespace Registrars {
+template <Xcts::Geometry ConformalGeometry>
+struct ApparentHorizon {
+  template <typename Registrars>
+  using f = BoundaryConditions::ApparentHorizon<ConformalGeometry, Registrars>;
+};
+}  // namespace Registrars
+/// \endcond
+
+/*!
+ * \brief Impose the surface is a quasi-equilibrium apparent horizon.
+ *
+ * These boundary conditions on the conformal factor \f$\psi\f$, the lapse
+ * \f$\alpha\f$ and the shift \f$\beta^i\f$ impose the surface is an apparent
+ * horizon, i.e. that the expansion on the surface vanishes: \f$\Theta=0\f$.
+ * Specifically, we impose:
+ *
+ * \f{align}
+ * \label{eq:ah_psi}
+ * \bar{s}^k\bar{D}_k\psi &= -\frac{\psi^3}{8\alpha}\bar{s}_i\bar{s}_j\left(
+ * (\bar{L}\beta)^{ij} - \bar{u}^{ij}\right)
+ * - \frac{\psi}{4}\bar{m}^{ij}\bar{\nabla}_i\bar{s}_j + \frac{1}{6}K\psi^3
+ * \\
+ * \label{eq:ah_beta}
+ * \beta_\mathrm{excess}^i &= \frac{\alpha}{\psi^2}\bar{s}^i
+ * + \epsilon_{ijk}\Omega^j x^k
+ * \f}
+ *
+ * following section 7.2 of \cite Pfeiffer2005zm, section 12.3.2 of
+ * \cite BaumgarteShapiro or section II.B.1 of \cite Varma2018sqd. In these
+ * equations \f$\bar{s}_i\f$ is the conformal surface normal to the apparent
+ * horizon, \f$\bar{m}^{ij}=\bar{\gamma}^{ij}-\bar{s}^i\bar{s}^j\f$ is the
+ * induced conformal surface metric (denoted \f$\tilde{h}^{ij}\f$ in
+ * \cite Pfeiffer2005zm and \cite Varma2018sqd) and \f$\bar{D}\f$ is the
+ * covariant derivative w.r.t. to the conformal metric \f$\bar{\gamma}_{ij}\f$.
+ * Note that e.g. in \cite Varma2018sqd Eq. (16) appears the surface-normal
+ * \f$s^i\f$, not the _conformal_ surface normal \f$\bar{s}^i = \psi^2 s^i\f$.
+ * To incur a spin on the apparent horizon we can freely choose the rotational
+ * parameters \f$\boldsymbol{\Omega}\f$. Note that for a Kerr solution with
+ * dimensionless spin \f$\boldsymbol{\chi}\f$ the rotational parameters at the
+ * outer horizon are \f$\boldsymbol{\Omega} =
+ * -\frac{\boldsymbol{\chi}}{2r_+}\f$, where \f$r_+ / M = 1 + \sqrt{1 -
+ * \chi^2}\f$ (see e.g. Eq. (8) in \cite Ossokine2015yla). \f$\epsilon_{ijk}\f$
+ * is the flat-space Levi-Civita symbol.
+ *
+ * Note that the quasi-equilibrium conditions don't restrict the boundary
+ * condition for the lapse. The choice for the lapse boundary condition is made
+ * by the `Lapse` input-file options. Currently implemented choices are:
+ * - A zero von-Neumann boundary condition:
+ *   \f$\bar{s}^k\bar{D}_k(\alpha\psi) = 0\f$
+ * - A Dirichlet boundary condition imposing the lapse of a Kerr-Schild analytic
+ *   solution.
+ *
+ * \par Negative-expansion boundary conditions:
+ * This class also supports negative-expansion boundary conditions following
+ * section II.B.2 of \cite Varma2018sqd by taking a Kerr solution as additional
+ * parameter and computing its expansion at the excision surface. Choosing an
+ * excision surface _within_ the apparent horizon of the Kerr solution will
+ * result in a negative expansion that is added to the boundary condition for
+ * the conformal factor. Therefore, the excision surface will lie within an
+ * apparent horizon. Specifically, we add the quantity
+ * \f$\frac{\psi^3}{4}\Theta_\mathrm{Kerr}\f$ to (\f$\ref{eq:ah_psi}\f$), where
+ * \f$\Theta_\mathrm{Kerr}\f$ is the expansion of the specified Kerr solution at
+ * the excision surface, and we add the quantity \f$\epsilon = s_i
+ * \beta_\mathrm{Kerr}^i - \alpha_\mathrm{Kerr}\f$ to the orthogonal part
+ * \f$s_i\beta_\mathrm{excess}^i\f$ of (\f$\ref{eq:ah_beta}\f$).
+ *
+ * \note When negative-expansion boundary conditions are selected, the Kerr
+ * solution gets evaluated at every boundary-condition application. This may
+ * turn out to incur a significant computational cost, in which case a future
+ * optimization might be to pre-compute the negative-expansion quantities at
+ * initialization time and store them in the DataBox.
+ */
+template <Xcts::Geometry ConformalGeometry,
+          typename Registrars =
+              tmpl::list<Registrars::ApparentHorizon<ConformalGeometry>>>
+class ApparentHorizon
+    : public elliptic::BoundaryConditions::BoundaryCondition<3, Registrars>,
+      public detail::ApparentHorizonImpl<ConformalGeometry> {
+ private:
+  using Base = elliptic::BoundaryConditions::BoundaryCondition<3, Registrars>;
+
+ public:
+  ApparentHorizon() = default;
+  ApparentHorizon(const ApparentHorizon&) = default;
+  ApparentHorizon& operator=(const ApparentHorizon&) = default;
+  ApparentHorizon(ApparentHorizon&&) = default;
+  ApparentHorizon& operator=(ApparentHorizon&&) = default;
+  ~ApparentHorizon() = default;
+
+  using detail::ApparentHorizonImpl<ConformalGeometry>::ApparentHorizonImpl;
+
+  /// \cond
+  explicit ApparentHorizon(CkMigrateMessage* m) noexcept : Base(m) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(ApparentHorizon);
+  /// \endcond
+
+  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> get_clone()
+      const noexcept override {
+    return std::make_unique<ApparentHorizon>(*this);
+  }
+
+  void pup(PUP::er& p) noexcept override {
+    Base::pup(p);
+    detail::ApparentHorizonImpl<ConformalGeometry>::pup(p);
+  }
+};
+
+/// \cond
+template <Xcts::Geometry ConformalGeometry, typename Registrars>
+PUP::able::PUP_ID ApparentHorizon<ConformalGeometry, Registrars>::my_PUP_ID =
+    0;  // NOLINT
+/// \endcond
+
+}  // namespace Xcts::BoundaryConditions

--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/CMakeLists.txt
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/CMakeLists.txt
@@ -8,6 +8,7 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  ApparentHorizon.cpp
   Flatness.cpp
   )
 
@@ -15,6 +16,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  ApparentHorizon.hpp
   Flatness.hpp
   )
 
@@ -22,7 +24,10 @@ target_link_libraries(
   ${LIBRARY}
   PUBLIC
   DataStructures
+  Domain
   Elliptic
+  ErrorHandling
+  GeneralRelativitySolutions
   Options
   Parallel
   Utilities

--- a/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.py
+++ b/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.py
@@ -1,0 +1,173 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+from numpy import sqrt, abs
+
+
+def make_metric_riemannian(inv_conformal_metric):
+    for i in range(3):
+        for j in range(i):
+            inv_conformal_metric[i, j] *= 1.e-2
+            inv_conformal_metric[j, i] *= 1.e-2
+        inv_conformal_metric[i, i] = abs(inv_conformal_metric[i, i])
+
+
+def make_spherical_face_normal(x, inv_conformal_metric):
+    proper_radius = sqrt(np.einsum('ij,i,j', inv_conformal_metric, x, x))
+    return -x / proper_radius
+
+
+# This is h^ij nabla_i s_j (all quantities conformal) in Eq. 7.12 in
+# Harald's thesis https://arxiv.org/abs/gr-qc/0510016
+def projected_normal_gradient(conformal_unit_normal, x, inv_conformal_metric,
+                              conformal_christoffel_second_kind):
+    conformal_unit_normal_raised = np.einsum('ij,j', inv_conformal_metric,
+                                             conformal_unit_normal)
+    inv_conformal_surface_metric = inv_conformal_metric - np.einsum(
+        'i,j->ij', conformal_unit_normal_raised, conformal_unit_normal_raised)
+    # Assuming here that the surface is a coordinate-sphere
+    euclidean_radius = np.linalg.norm(x)
+    unnormalized_face_normal = x / euclidean_radius
+    magnitude_of_face_normal = sqrt(
+        np.einsum('ij,i,j', inv_conformal_metric, unnormalized_face_normal,
+                  unnormalized_face_normal))  # r_curved / r_flat
+    deriv_unnormalized_face_normal = (
+        np.identity(3) / euclidean_radius -
+        np.einsum('i,j->ij', x, x) / euclidean_radius**3)
+    # The term with the derivative of the magnitude vanishes when projected on
+    # the surface metric, so it's omitted here
+    conformal_unit_normal_gradient = (
+        deriv_unnormalized_face_normal / magnitude_of_face_normal - np.einsum(
+            'i,ijk', conformal_unit_normal, conformal_christoffel_second_kind))
+    return np.einsum('ij,ij', inv_conformal_surface_metric,
+                     conformal_unit_normal_gradient)
+
+
+# This function implements the apparent-horizon boundary condition, Eq. 7.12 in
+# Harald's thesis https://arxiv.org/abs/gr-qc/0510016
+def normal_dot_conformal_factor_gradient(
+    conformal_factor, lapse_times_conformal_factor,
+    n_dot_longitudinal_shift_excess, center, spin, x,
+    extrinsic_curvature_trace, shift_background, longitudinal_shift_background,
+    inv_conformal_metric, conformal_christoffel_second_kind):
+    x -= center
+    make_metric_riemannian(inv_conformal_metric)
+    conformal_unit_normal = -make_spherical_face_normal(
+        x, inv_conformal_metric)
+    local_projected_normal_gradient = projected_normal_gradient(
+        conformal_unit_normal, x, inv_conformal_metric,
+        conformal_christoffel_second_kind)
+    lapse = lapse_times_conformal_factor / conformal_factor
+    n_dot_longitudinal_shift = n_dot_longitudinal_shift_excess + np.einsum(
+        'i,ij', -conformal_unit_normal, longitudinal_shift_background)
+    J = (2. / 3. * extrinsic_curvature_trace - 0.5 / lapse *
+         np.einsum('i,i', -conformal_unit_normal, n_dot_longitudinal_shift))
+    return (0.25 * conformal_factor *
+            (local_projected_normal_gradient - conformal_factor**2 * J))
+
+
+def normal_dot_conformal_factor_gradient_flat_cartesian(*args, **kwargs):
+    return normal_dot_conformal_factor_gradient(
+        *args,
+        inv_conformal_metric=np.identity(3),
+        conformal_christoffel_second_kind=np.zeros((3, 3, 3)),
+        **kwargs)
+
+
+def normal_dot_conformal_factor_gradient_correction(
+    conformal_factor_correction, lapse_times_conformal_factor_correction,
+    n_dot_longitudinal_shift_excess_correction, center, spin, x,
+    extrinsic_curvature_trace, longitudinal_shift_background, conformal_factor,
+    lapse_times_conformal_factor, n_dot_longitudinal_shift_excess,
+    inv_conformal_metric, conformal_christoffel_second_kind):
+    x -= center
+    make_metric_riemannian(inv_conformal_metric)
+    conformal_unit_normal = -make_spherical_face_normal(
+        x, inv_conformal_metric)
+    local_projected_normal_gradient = projected_normal_gradient(
+        conformal_unit_normal, x, inv_conformal_metric,
+        conformal_christoffel_second_kind)
+    lapse = lapse_times_conformal_factor / conformal_factor
+    n_dot_longitudinal_shift = n_dot_longitudinal_shift_excess + np.einsum(
+        'i,ij', -conformal_unit_normal, longitudinal_shift_background)
+    J = (2. / 3. * extrinsic_curvature_trace - 0.5 / lapse *
+         np.einsum('i,i', -conformal_unit_normal, n_dot_longitudinal_shift))
+    J_correction = -0.5 * (
+        (conformal_factor_correction / lapse_times_conformal_factor -
+         conformal_factor / lapse_times_conformal_factor**2 *
+         lapse_times_conformal_factor_correction) *
+        np.einsum('i,i', -conformal_unit_normal, n_dot_longitudinal_shift) +
+        1. / lapse * np.einsum('i,i', -conformal_unit_normal,
+                               n_dot_longitudinal_shift_excess_correction))
+    return 0.25 * (
+        conformal_factor_correction * local_projected_normal_gradient -
+        3. * conformal_factor**2 * conformal_factor_correction * J -
+        conformal_factor**3 * J_correction)
+
+
+def normal_dot_conformal_factor_gradient_correction_flat_cartesian(
+    *args, **kwargs):
+    return normal_dot_conformal_factor_gradient_correction(
+        *args,
+        inv_conformal_metric=np.identity(3),
+        conformal_christoffel_second_kind=np.zeros((3, 3, 3)),
+        **kwargs)
+
+
+# This is the homogeneous-Neumann boundary condition on the lapse
+def normal_dot_lapse_times_conformal_factor_gradient(*args, **kwargs):
+    return 0.
+
+
+# This function implements the quasi-equilibrium condition on the shift, i.e.
+# Eq. 7.14 in Harald's thesis https://arxiv.org/abs/gr-qc/0510016
+def shift_excess(conformal_factor, lapse_times_conformal_factor,
+                 n_dot_longitudinal_shift_excess, center, spin, x,
+                 extrinsic_curvature_trace, shift_background,
+                 longitudinal_shift_background, inv_conformal_metric,
+                 conformal_christoffel_second_kind):
+    x -= center
+    make_metric_riemannian(inv_conformal_metric)
+    conformal_unit_normal = -make_spherical_face_normal(
+        x, inv_conformal_metric)
+    conformal_unit_normal_raised = np.einsum('ij,j', inv_conformal_metric,
+                                             conformal_unit_normal)
+    shift_orthogonal = lapse_times_conformal_factor / conformal_factor**3
+    shift_parallel = np.cross(spin, x)
+    return (shift_orthogonal * conformal_unit_normal_raised + shift_parallel -
+            shift_background)
+
+
+def shift_excess_flat_cartesian(*args, **kwargs):
+    return shift_excess(*args,
+                        inv_conformal_metric=np.identity(3),
+                        conformal_christoffel_second_kind=np.zeros((3, 3, 3)),
+                        **kwargs)
+
+
+def shift_excess_correction(
+    conformal_factor_correction, lapse_times_conformal_factor_correction,
+    n_dot_longitudinal_shift_excess_correction, center, spin, x,
+    extrinsic_curvature_trace, longitudinal_shift_background, conformal_factor,
+    lapse_times_conformal_factor, n_dot_longitudinal_shift_excess,
+    inv_conformal_metric, conformal_christoffel_second_kind):
+    x -= center
+    make_metric_riemannian(inv_conformal_metric)
+    conformal_unit_normal = -make_spherical_face_normal(
+        x, inv_conformal_metric)
+    conformal_unit_normal_raised = np.einsum('ij,j', inv_conformal_metric,
+                                             conformal_unit_normal)
+    shift_orthogonal_correction = (
+        lapse_times_conformal_factor_correction / conformal_factor**3 -
+        3. * lapse_times_conformal_factor / conformal_factor**4 *
+        conformal_factor_correction)
+    return shift_orthogonal_correction * conformal_unit_normal_raised
+
+
+def shift_excess_correction_flat_cartesian(*args, **kwargs):
+    return shift_excess_correction(*args,
+                                   inv_conformal_metric=np.identity(3),
+                                   conformal_christoffel_second_kind=np.zeros(
+                                       (3, 3, 3)),
+                                   **kwargs)

--- a/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_XctsBoundaryConditions")
 
 set(LIBRARY_SOURCES
+  Test_ApparentHorizon.cpp
   Test_Flatness.cpp
   )
 
@@ -17,9 +18,12 @@ add_test_library(
 target_link_libraries(
   ${LIBRARY}
   PRIVATE
+  CoordinateMaps
   DataStructures
+  Domain
   DomainStructure
   Elliptic
   Utilities
   XctsBoundaryConditions
+  XctsSolutions
   )

--- a/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_ApparentHorizon.cpp
+++ b/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_ApparentHorizon.cpp
@@ -1,0 +1,574 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Slice.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/KerrHorizonConforming.hpp"
+#include "Domain/CoordinateMaps/Wedge.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/IndexToSliceAt.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/Tags/Faces.hpp"
+#include "Elliptic/BoundaryConditions/ApplyBoundaryCondition.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
+#include "PointwiseFunctions/AnalyticSolutions/Xcts/Kerr.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Xcts::BoundaryConditions {
+
+namespace {
+// Make a metric approximately Riemannian
+void make_metric_riemannian(
+    const gsl::not_null<tnsr::II<DataVector, 3>*> inv_conformal_metric) {
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < i; ++j) {
+      inv_conformal_metric->get(i, j) *= 1.e-2;
+    }
+    inv_conformal_metric->get(i, i) = abs(inv_conformal_metric->get(i, i));
+  }
+}
+
+// Generate a face normal pretending the surface is a coordinate sphere
+std::tuple<tnsr::i<DataVector, 3>, tnsr::ij<DataVector, 3>, Scalar<DataVector>>
+make_spherical_face_normal(
+    tnsr::I<DataVector, 3> x, const std::array<double, 3>& center,
+    const tnsr::II<DataVector, 3>& inv_conformal_metric) {
+  for (size_t d = 0; d < 3; ++d) {
+    x.get(d) -= gsl::at(center, d);
+  }
+  Scalar<DataVector> proper_radius{x.begin()->size(), 0.};
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      get(proper_radius) +=
+          inv_conformal_metric.get(i, j) * x.get(i) * x.get(j);
+    }
+  }
+  get(proper_radius) = sqrt(get(proper_radius));
+  tnsr::i<DataVector, 3> face_normal{x.begin()->size()};
+  get<0>(face_normal) = -get<0>(x) / get(proper_radius);
+  get<1>(face_normal) = -get<1>(x) / get(proper_radius);
+  get<2>(face_normal) = -get<2>(x) / get(proper_radius);
+  tnsr::ij<DataVector, 3> deriv_unnormalized_face_normal{x.begin()->size(), 0.};
+  get<0, 0>(deriv_unnormalized_face_normal) = -1.;
+  get<1, 1>(deriv_unnormalized_face_normal) = -1.;
+  get<2, 2>(deriv_unnormalized_face_normal) = -1.;
+  return {std::move(face_normal), std::move(deriv_unnormalized_face_normal),
+          std::move(proper_radius)};
+}
+std::tuple<tnsr::i<DataVector, 3>, tnsr::ij<DataVector, 3>, Scalar<DataVector>>
+make_spherical_face_normal_flat_cartesian(tnsr::I<DataVector, 3> x,
+                                          const std::array<double, 3>& center) {
+  for (size_t d = 0; d < 3; ++d) {
+    x.get(d) -= gsl::at(center, d);
+  }
+  Scalar<DataVector> euclidean_radius = magnitude(x);
+  tnsr::i<DataVector, 3> face_normal{x.begin()->size()};
+  get<0>(face_normal) = -get<0>(x) / get(euclidean_radius);
+  get<1>(face_normal) = -get<1>(x) / get(euclidean_radius);
+  get<2>(face_normal) = -get<2>(x) / get(euclidean_radius);
+  tnsr::ij<DataVector, 3> deriv_unnormalized_face_normal{x.begin()->size(), 0.};
+  get<0, 0>(deriv_unnormalized_face_normal) = -1.;
+  get<1, 1>(deriv_unnormalized_face_normal) = -1.;
+  get<2, 2>(deriv_unnormalized_face_normal) = -1.;
+  return {std::move(face_normal), std::move(deriv_unnormalized_face_normal),
+          std::move(euclidean_radius)};
+}
+
+template <Xcts::Geometry ConformalGeometry, bool Linearized, typename... Args>
+void apply_boundary_condition_impl(
+    const gsl::not_null<Scalar<DataVector>*> n_dot_conformal_factor_gradient,
+    const gsl::not_null<Scalar<DataVector>*>
+        n_dot_lapse_times_conformal_factor_gradient,
+    const gsl::not_null<tnsr::I<DataVector, 3>*> shift_excess,
+    Scalar<DataVector> conformal_factor,
+    Scalar<DataVector> lapse_times_conformal_factor,
+    tnsr::I<DataVector, 3> n_dot_longitudinal_shift_excess,
+    const std::array<double, 3>& center, const std::array<double, 3>& rotation,
+    Args&&... args) {
+  const ApparentHorizon<ConformalGeometry> boundary_condition{
+      center, rotation, std::nullopt, std::nullopt};
+  const auto direction = Direction<3>::lower_xi();
+  const auto box = db::create<domain::make_faces_tags<
+      3,
+      tmpl::conditional_t<
+          Linearized,
+          typename ApparentHorizon<ConformalGeometry>::argument_tags_linearized,
+          typename ApparentHorizon<ConformalGeometry>::argument_tags>,
+      tmpl::conditional_t<
+          Linearized,
+          typename ApparentHorizon<ConformalGeometry>::volume_tags_linearized,
+          typename ApparentHorizon<ConformalGeometry>::volume_tags>>>(
+      DirectionMap<3, std::decay_t<decltype(args)>>{
+          {direction, std::move(args)}}...);
+  elliptic::apply_boundary_condition<Linearized>(
+      boundary_condition, box, direction, make_not_null(&conformal_factor),
+      make_not_null(&lapse_times_conformal_factor), shift_excess,
+      n_dot_conformal_factor_gradient,
+      n_dot_lapse_times_conformal_factor_gradient,
+      make_not_null(&n_dot_longitudinal_shift_excess));
+}
+
+void apply_boundary_condition(
+    const gsl::not_null<Scalar<DataVector>*> n_dot_conformal_factor_gradient,
+    const gsl::not_null<Scalar<DataVector>*>
+        n_dot_lapse_times_conformal_factor_gradient,
+    const gsl::not_null<tnsr::I<DataVector, 3>*> shift_excess,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& lapse_times_conformal_factor,
+    const tnsr::I<DataVector, 3>& n_dot_longitudinal_shift_excess,
+    const std::array<double, 3>& center, const std::array<double, 3>& rotation,
+    const tnsr::I<DataVector, 3>& x,
+    const Scalar<DataVector>& extrinsic_curvature_trace,
+    const tnsr::I<DataVector, 3>& shift_background,
+    const tnsr::II<DataVector, 3>& longitudinal_shift_background,
+    tnsr::II<DataVector, 3> inv_conformal_metric,
+    const tnsr::Ijj<DataVector, 3>& conformal_christoffel_second_kind) {
+  make_metric_riemannian(make_not_null(&inv_conformal_metric));
+  auto [face_normal, deriv_unnormalized_face_normal, face_normal_magnitude] =
+      make_spherical_face_normal(x, center, inv_conformal_metric);
+  apply_boundary_condition_impl<Xcts::Geometry::Curved, false>(
+      n_dot_conformal_factor_gradient,
+      n_dot_lapse_times_conformal_factor_gradient, shift_excess,
+      conformal_factor, lapse_times_conformal_factor,
+      n_dot_longitudinal_shift_excess, center, rotation, std::move(face_normal),
+      std::move(deriv_unnormalized_face_normal),
+      std::move(face_normal_magnitude), x, extrinsic_curvature_trace,
+      shift_background, longitudinal_shift_background,
+      std::move(inv_conformal_metric), conformal_christoffel_second_kind);
+}
+
+void apply_boundary_condition_flat_cartesian(
+    const gsl::not_null<Scalar<DataVector>*> n_dot_conformal_factor_gradient,
+    const gsl::not_null<Scalar<DataVector>*>
+        n_dot_lapse_times_conformal_factor_gradient,
+    const gsl::not_null<tnsr::I<DataVector, 3>*> shift_excess,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& lapse_times_conformal_factor,
+    const tnsr::I<DataVector, 3>& n_dot_longitudinal_shift_excess,
+    const std::array<double, 3>& center, const std::array<double, 3>& rotation,
+    const tnsr::I<DataVector, 3>& x,
+    const Scalar<DataVector>& extrinsic_curvature_trace,
+    const tnsr::I<DataVector, 3>& shift_background,
+    const tnsr::II<DataVector, 3>& longitudinal_shift_background) {
+  auto [face_normal, deriv_unnormalized_face_normal, face_normal_magnitude] =
+      make_spherical_face_normal_flat_cartesian(x, center);
+  apply_boundary_condition_impl<Xcts::Geometry::FlatCartesian, false>(
+      n_dot_conformal_factor_gradient,
+      n_dot_lapse_times_conformal_factor_gradient, shift_excess,
+      conformal_factor, lapse_times_conformal_factor,
+      n_dot_longitudinal_shift_excess, center, rotation, std::move(face_normal),
+      std::move(deriv_unnormalized_face_normal),
+      std::move(face_normal_magnitude), x, extrinsic_curvature_trace,
+      shift_background, longitudinal_shift_background);
+}
+
+void apply_boundary_condition_linearized(
+    const gsl::not_null<Scalar<DataVector>*>
+        n_dot_conformal_factor_gradient_correction,
+    const gsl::not_null<Scalar<DataVector>*>
+        n_dot_lapse_times_conformal_factor_gradient_correction,
+    const gsl::not_null<tnsr::I<DataVector, 3>*> shift_excess_correction,
+    const Scalar<DataVector>& conformal_factor_correction,
+    const Scalar<DataVector>& lapse_times_conformal_factor_correction,
+    const tnsr::I<DataVector, 3>& n_dot_longitudinal_shift_excess_correction,
+    const std::array<double, 3>& center, const std::array<double, 3>& rotation,
+    const tnsr::I<DataVector, 3>& x,
+    const Scalar<DataVector>& extrinsic_curvature_trace,
+    const tnsr::II<DataVector, 3>& longitudinal_shift_background,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& lapse_times_conformal_factor,
+    const tnsr::I<DataVector, 3>& n_dot_longitudinal_shift_excess,
+    tnsr::II<DataVector, 3> inv_conformal_metric,
+    const tnsr::Ijj<DataVector, 3>& conformal_christoffel_second_kind) {
+  make_metric_riemannian(make_not_null(&inv_conformal_metric));
+  auto [face_normal, deriv_unnormalized_face_normal, face_normal_magnitude] =
+      make_spherical_face_normal(x, center, inv_conformal_metric);
+  apply_boundary_condition_impl<Xcts::Geometry::Curved, true>(
+      n_dot_conformal_factor_gradient_correction,
+      n_dot_lapse_times_conformal_factor_gradient_correction,
+      shift_excess_correction, conformal_factor_correction,
+      lapse_times_conformal_factor_correction,
+      n_dot_longitudinal_shift_excess_correction, center, rotation,
+      std::move(face_normal), std::move(deriv_unnormalized_face_normal),
+      std::move(face_normal_magnitude), x, extrinsic_curvature_trace,
+      longitudinal_shift_background, conformal_factor,
+      lapse_times_conformal_factor, n_dot_longitudinal_shift_excess,
+      std::move(inv_conformal_metric), conformal_christoffel_second_kind);
+}
+
+void apply_boundary_condition_linearized_flat_cartesian(
+    const gsl::not_null<Scalar<DataVector>*>
+        n_dot_conformal_factor_gradient_correction,
+    const gsl::not_null<Scalar<DataVector>*>
+        n_dot_lapse_times_conformal_factor_gradient_correction,
+    const gsl::not_null<tnsr::I<DataVector, 3>*> shift_excess_correction,
+    const Scalar<DataVector>& conformal_factor_correction,
+    const Scalar<DataVector>& lapse_times_conformal_factor_correction,
+    const tnsr::I<DataVector, 3>& n_dot_longitudinal_shift_excess_correction,
+    const std::array<double, 3>& center, const std::array<double, 3>& rotation,
+    const tnsr::I<DataVector, 3>& x,
+    const Scalar<DataVector>& extrinsic_curvature_trace,
+    const tnsr::II<DataVector, 3>& longitudinal_shift_background,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& lapse_times_conformal_factor,
+    const tnsr::I<DataVector, 3>& n_dot_longitudinal_shift_excess) {
+  auto [face_normal, deriv_unnormalized_face_normal, face_normal_magnitude] =
+      make_spherical_face_normal_flat_cartesian(x, center);
+  apply_boundary_condition_impl<Xcts::Geometry::FlatCartesian, true>(
+      n_dot_conformal_factor_gradient_correction,
+      n_dot_lapse_times_conformal_factor_gradient_correction,
+      shift_excess_correction, conformal_factor_correction,
+      lapse_times_conformal_factor_correction,
+      n_dot_longitudinal_shift_excess_correction, center, rotation,
+      std::move(face_normal), std::move(deriv_unnormalized_face_normal),
+      std::move(face_normal_magnitude), x, extrinsic_curvature_trace,
+      longitudinal_shift_background, conformal_factor,
+      lapse_times_conformal_factor, n_dot_longitudinal_shift_excess);
+}
+
+void test_creation(
+    const std::array<double, 3>& center, const std::array<double, 3>& rotation,
+    const std::optional<gr::Solutions::KerrSchild>& kerr_solution_for_lapse,
+    const std::optional<gr::Solutions::KerrSchild>&
+        kerr_solution_for_negative_expansion,
+    const std::string& option_string) {
+  INFO("Test factory-creation");
+  const auto created = TestHelpers::test_creation<
+      std::unique_ptr<elliptic::BoundaryConditions::BoundaryCondition<
+          3, tmpl::list<Registrars::ApparentHorizon<Xcts::Geometry::Curved>>>>>(
+      option_string);
+  REQUIRE(dynamic_cast<const ApparentHorizon<Xcts::Geometry::Curved>*>(
+              created.get()) != nullptr);
+  const auto& boundary_condition =
+      dynamic_cast<const ApparentHorizon<Xcts::Geometry::Curved>&>(*created);
+  {
+    INFO("Properties");
+    CHECK(boundary_condition.center() == center);
+    CHECK(boundary_condition.rotation() == rotation);
+    // Work around an issue where Catch2 needs a stream operator to check
+    // optionals are equal
+    CHECK(boundary_condition.kerr_solution_for_lapse().has_value() ==
+          kerr_solution_for_lapse.has_value());
+    if (kerr_solution_for_lapse.has_value()) {
+      CHECK(*boundary_condition.kerr_solution_for_lapse() ==
+            *kerr_solution_for_lapse);
+    }
+    CHECK(
+        boundary_condition.kerr_solution_for_negative_expansion().has_value() ==
+        kerr_solution_for_negative_expansion.has_value());
+    if (kerr_solution_for_negative_expansion.has_value()) {
+      CHECK(*boundary_condition.kerr_solution_for_negative_expansion() ==
+            *kerr_solution_for_negative_expansion);
+    }
+  }
+  {
+    INFO("Semantics");
+    test_serialization(boundary_condition);
+    test_copy_semantics(boundary_condition);
+    auto move_boundary_condition = boundary_condition;
+    test_move_semantics(std::move(move_boundary_condition), boundary_condition);
+  }
+}
+
+void test_with_random_values() {
+  INFO("Random-value tests");
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "Elliptic/Systems/Xcts/BoundaryConditions/");
+  pypp::check_with_random_values<11>(
+      &apply_boundary_condition, "ApparentHorizon",
+      {"normal_dot_conformal_factor_gradient",
+       "normal_dot_lapse_times_conformal_factor_gradient", "shift_excess"},
+      {{{0.5, 2.},
+        {0.5, 2.},
+        {-1., 1.},
+        {-1., 1.},
+        {-1., 1.},
+        {-1., 1.},
+        {-1., 1.},
+        {-1., 1.},
+        {-1., 1.},
+        {-1., 1.},
+        {-1., 1.}}},
+      DataVector{3});
+  pypp::check_with_random_values<9>(
+      &apply_boundary_condition_flat_cartesian, "ApparentHorizon",
+      {"normal_dot_conformal_factor_gradient_flat_cartesian",
+       "normal_dot_lapse_times_conformal_factor_gradient",
+       "shift_excess_flat_cartesian"},
+      {{{0.5, 2.},
+        {0.5, 2.},
+        {-1., 1.},
+        {-1., 1.},
+        {-1., 1.},
+        {-1., 1.},
+        {-1., 1.},
+        {-1., 1.},
+        {-1., 1.}}},
+      DataVector{3});
+  pypp::check_with_random_values<13>(
+      &apply_boundary_condition_linearized, "ApparentHorizon",
+      {"normal_dot_conformal_factor_gradient_correction",
+       "normal_dot_lapse_times_conformal_factor_gradient",
+       "shift_excess_correction"},
+      {{{0.5, 2.},
+        {0.5, 2.},
+        {-1., 1.},
+        {-1., 1.},
+        {-1., 1.},
+        {-1., 1.},
+        {-1., 1.},
+        {-1., 1.},
+        {0.5, 2.},
+        {0.5, 2.},
+        {-1., 1.},
+        {-1., 1.},
+        {-1., 1.}}},
+      DataVector{3});
+  pypp::check_with_random_values<11>(
+      &apply_boundary_condition_linearized_flat_cartesian, "ApparentHorizon",
+      {"normal_dot_conformal_factor_gradient_correction_flat_cartesian",
+       "normal_dot_lapse_times_conformal_factor_gradient",
+       "shift_excess_correction_flat_cartesian"},
+      {{{0.5, 2.},
+        {0.5, 2.},
+        {-1., 1.},
+        {-1., 1.},
+        {-1., 1.},
+        {-1., 1.},
+        {-1., 1.},
+        {-1., 1.},
+        {0.5, 2.},
+        {0.5, 2.},
+        {-1., 1.}}},
+      DataVector{3});
+}
+
+void test_consistency_with_kerr(const bool compute_expansion) {
+  INFO("Consistency with Kerr solution");
+  CAPTURE(compute_expansion);
+  const double mass = 1.;
+  const std::array<double, 3> center{{0., 0., 0.}};
+  const std::array<double, 3> dimensionless_spin{{0., 0., 0.8}};
+  const double horizon_kerrschild_radius =
+      mass * (1. + sqrt(1. - dot(dimensionless_spin, dimensionless_spin)));
+  CAPTURE(horizon_kerrschild_radius);
+  // Eq. (8) in https://arxiv.org/abs/1506.01689
+  std::array<double, 3> rotation =
+      -0.5 * dimensionless_spin / horizon_kerrschild_radius;
+  CAPTURE(rotation);
+  const Solutions::Kerr<> solution{mass, dimensionless_spin, {{0., 0., 0.}}};
+  const ApparentHorizon<Xcts::Geometry::Curved> kerr_horizon{
+      center, rotation, solution,
+      // Check with and without the negative-expansion condition. Either the
+      // expansion is _computed_ to be zero from the Kerr solution at the
+      // horizon, or it is just set to zero.
+      compute_expansion ? std::make_optional(solution) : std::nullopt};
+
+  // Set up a wedge with a Kerr-horizon-conforming inner surface
+  const Mesh<3> mesh{6, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto};
+  const size_t num_points = mesh.number_of_grid_points();
+  const domain::CoordinateMaps::Wedge<3> wedge_map{
+      horizon_kerrschild_radius,
+      2. * horizon_kerrschild_radius,
+      1.,
+      1.,
+      {},
+      false};
+  const domain::CoordinateMaps::KerrHorizonConforming horizon_map{
+      dimensionless_spin};
+  const auto coord_map =
+      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          wedge_map, horizon_map);
+  // Set up a mesh so we can numerically differentiate the Jacobian
+  const auto logical_coords = logical_coordinates(mesh);
+  const tnsr::I<DataVector, 3> inertial_coords = (*coord_map)(logical_coords);
+  const auto inv_jacobian = coord_map->inv_jacobian(logical_coords);
+  using inv_jac_tag =
+      domain::Tags::InverseJacobian<3, Frame::Logical, Frame::Inertial>;
+  Variables<tmpl::list<inv_jac_tag>> vars_to_derive{num_points};
+  get<inv_jac_tag>(vars_to_derive) = inv_jacobian;
+  const auto deriv_vars = partial_derivatives<tmpl::list<inv_jac_tag>>(
+      vars_to_derive, mesh, inv_jacobian);
+  const auto& deriv_inv_jac =
+      get<::Tags::deriv<inv_jac_tag, tmpl::size_t<3>, Frame::Inertial>>(
+          deriv_vars);
+  // Coords on the face
+  const auto direction = Direction<3>::lower_zeta();
+  const size_t slice_index = index_to_slice_at(mesh.extents(), direction);
+  const auto x = data_on_slice(inertial_coords, mesh.extents(),
+                               direction.dimension(), slice_index);
+  // Get background fields from the solution
+  const auto background_fields = solution.variables(
+      x,
+      tmpl::list<
+          Tags::InverseConformalMetric<DataVector, 3, Frame::Inertial>,
+          Tags::ConformalChristoffelSecondKind<DataVector, 3, Frame::Inertial>,
+          gr::Tags::TraceExtrinsicCurvature<DataVector>,
+          Tags::ShiftBackground<DataVector, 3, Frame::Inertial>,
+          Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<
+              DataVector, 3, Frame::Inertial>>{});
+  const auto& inv_conformal_metric =
+      get<Tags::InverseConformalMetric<DataVector, 3, Frame::Inertial>>(
+          background_fields);
+  // Set up the face normal on the horizon surface. It points _into_ the
+  // horizon because the computational domain fills the space outside of it
+  // and the normal always points away from the computational domain.
+  const Mesh<2> face_mesh = mesh.slice_away(direction.dimension());
+  const size_t face_num_points = face_mesh.number_of_grid_points();
+  auto face_normal = unnormalized_face_normal(face_mesh, *coord_map, direction);
+  const auto face_normal_magnitude =
+      magnitude(face_normal, inv_conformal_metric);
+  for (size_t d = 0; d < 3; ++d) {
+    face_normal.get(d) /= get(face_normal_magnitude);
+  }
+  tnsr::ij<DataVector, 3> deriv_unnormalized_face_normal{face_num_points};
+  const auto deriv_inv_jac_on_face = data_on_slice(
+      deriv_inv_jac, mesh.extents(), direction.dimension(), slice_index);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      deriv_unnormalized_face_normal.get(i, j) =
+          direction.sign() *
+          deriv_inv_jac_on_face.get(i, direction.dimension(), j);
+    }
+  }
+
+  // Retrieve the expected surface vars and fluxes from the solution
+  const auto surface_vars_expected =
+      variables_from_tagged_tuple(solution.variables(
+          x, tmpl::list<Tags::ConformalFactor<DataVector>,
+                        Tags::LapseTimesConformalFactor<DataVector>,
+                        Tags::ShiftExcess<DataVector, 3, Frame::Inertial>>{}));
+  const auto surface_fluxes_expected =
+      variables_from_tagged_tuple(solution.variables(
+          x,
+          tmpl::list<::Tags::Flux<Tags::ConformalFactor<DataVector>,
+                                  tmpl::size_t<3>, Frame::Inertial>,
+                     ::Tags::Flux<Tags::LapseTimesConformalFactor<DataVector>,
+                                  tmpl::size_t<3>, Frame::Inertial>,
+                     Tags::LongitudinalShiftExcess<DataVector, 3,
+                                                   Frame::Inertial>>{}));
+  Variables<tmpl::list<
+      ::Tags::NormalDotFlux<Tags::ConformalFactor<DataVector>>,
+      ::Tags::NormalDotFlux<Tags::LapseTimesConformalFactor<DataVector>>,
+      ::Tags::NormalDotFlux<Tags::ShiftExcess<DataVector, 3, Frame::Inertial>>>>
+      n_dot_surface_fluxes_expected{num_points};
+  normal_dot_flux(make_not_null(&n_dot_surface_fluxes_expected), face_normal,
+                  surface_fluxes_expected);
+  // Apply the boundary conditions, passing garbage for the data that the
+  // boundary conditions are expected to fill
+  auto surface_vars = surface_vars_expected;
+  auto n_dot_surface_fluxes = n_dot_surface_fluxes_expected;
+  get(get<::Tags::NormalDotFlux<Tags::ConformalFactor<DataVector>>>(
+      n_dot_surface_fluxes)) = std::numeric_limits<double>::signaling_NaN();
+  get<0>(get<Tags::ShiftExcess<DataVector, 3, Frame::Inertial>>(surface_vars)) =
+      std::numeric_limits<double>::signaling_NaN();
+  get<1>(get<Tags::ShiftExcess<DataVector, 3, Frame::Inertial>>(surface_vars)) =
+      std::numeric_limits<double>::signaling_NaN();
+  get<2>(get<Tags::ShiftExcess<DataVector, 3, Frame::Inertial>>(surface_vars)) =
+      std::numeric_limits<double>::signaling_NaN();
+  kerr_horizon.apply(
+      make_not_null(&get<Tags::ConformalFactor<DataVector>>(surface_vars)),
+      make_not_null(
+          &get<Tags::LapseTimesConformalFactor<DataVector>>(surface_vars)),
+      make_not_null(&get<Tags::ShiftExcess<DataVector, 3, Frame::Inertial>>(
+          surface_vars)),
+      make_not_null(
+          &get<::Tags::NormalDotFlux<Tags::ConformalFactor<DataVector>>>(
+              n_dot_surface_fluxes)),
+      make_not_null(&get<::Tags::NormalDotFlux<
+                        Tags::LapseTimesConformalFactor<DataVector>>>(
+          n_dot_surface_fluxes)),
+      make_not_null(&get<::Tags::NormalDotFlux<
+                        Tags::ShiftExcess<DataVector, 3, Frame::Inertial>>>(
+          n_dot_surface_fluxes)),
+      face_normal, deriv_unnormalized_face_normal, face_normal_magnitude, x,
+      get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(background_fields),
+      get<Tags::ShiftBackground<DataVector, 3, Frame::Inertial>>(
+          background_fields),
+      get<Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<
+          DataVector, 3, Frame::Inertial>>(background_fields),
+      get<Tags::InverseConformalMetric<DataVector, 3, Frame::Inertial>>(
+          background_fields),
+      get<Tags::ConformalChristoffelSecondKind<DataVector, 3, Frame::Inertial>>(
+          background_fields));
+  // Check the result.
+  CHECK_VARIABLES_APPROX(surface_vars, surface_vars_expected);
+  CHECK_VARIABLES_APPROX(n_dot_surface_fluxes, n_dot_surface_fluxes_expected);
+}
+
+void test_parse_errors() {
+  CHECK_THROWS_WITH(
+      ApparentHorizon<Xcts::Geometry::Curved>(
+          {{0., 1., 2.}},
+          {{0.1, 0.2, 0.3}},
+          {{2.3, {{0.4, 0.5, 0.6}}, {{0.5, 0., 0.}}}},
+          std::nullopt,
+          Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::Contains("The Kerr solution supplied to the 'Lapse' "
+                                "option has a non-zero 'Center'."));
+  CHECK_THROWS_WITH(
+      ApparentHorizon<Xcts::Geometry::Curved>(
+          {{0., 1., 2.}},
+          {{0.1, 0.2, 0.3}},
+          std::nullopt,
+          {{2.3, {{0.4, 0.5, 0.6}}, {{0.5, 0., 0.}}}},
+          Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::Contains(
+          "The Kerr solution supplied to the 'NegativeExpansion' "
+          "option has a non-zero 'Center'."));
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Xcts.BoundaryConditions.ApparentHorizon",
+                  "[Unit][Elliptic]") {
+  test_creation({{1., 2., 3.}}, {{0.1, 0.2, 0.3}}, std::nullopt, std::nullopt,
+                "ApparentHorizon:\n"
+                "  Center: [1., 2., 3.]\n"
+                "  Rotation: [0.1, 0.2, 0.3]\n"
+                "  Lapse: Auto\n"
+                "  NegativeExpansion: None\n");
+  test_creation({{1., 2., 3.}}, {{0.1, 0.2, 0.3}},
+                {{2.3, {{0.4, 0.5, 0.6}}, {{0., 0., 0.}}}},
+                {{3.4, {{0.3, 0.2, 0.1}}, {{0., 0., 0.}}}},
+                "ApparentHorizon:\n"
+                "  Center: [1., 2., 3.]\n"
+                "  Rotation: [0.1, 0.2, 0.3]\n"
+                "  Lapse:\n"
+                "    Mass: 2.3\n"
+                "    Spin: [0.4, 0.5, 0.6]\n"
+                "    Center: [0., 0., 0.]\n"
+                "  NegativeExpansion:\n"
+                "    Mass: 3.4\n"
+                "    Spin: [0.3, 0.2, 0.1]\n"
+                "    Center: [0., 0., 0.]\n");
+  test_parse_errors();
+  test_with_random_values();
+  test_consistency_with_kerr(false);
+  test_consistency_with_kerr(true);
+}
+
+}  // namespace Xcts::BoundaryConditions


### PR DESCRIPTION
## Proposed changes

Quasi-equilibrium apparent-horizon boundary conditions for XCTS solves.

- [x] The first commit is from #2667 (doesn't really matter which PR merges that one).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
