### PR TITLE
Add DimensionfulSpinVectorTag and change RadiusCompute to type Scalar<DataVector>

### DIFF
--- a/src/ApparentHorizons/FastFlow.cpp
+++ b/src/ApparentHorizons/FastFlow.cpp
@@ -108,7 +108,8 @@ FastFlow::iterate_horizon_finder(
 
   // Get minimum radius.
   const auto& radius = db::get<StrahlkorperTags::Radius<Frame>>(box);
-  const auto r_minmax = std::minmax_element(radius.begin(), radius.end());
+  const auto r_minmax =
+      std::minmax_element(get(radius).begin(), get(radius).end());
   const auto r_min = *r_minmax.first;
   const auto r_max = *r_minmax.second;
 
@@ -148,7 +149,7 @@ FastFlow::iterate_horizon_finder(
     case FlowType::Fast: {
       weighted_residual *= fast_flow_weight<Frame>(
           one_form_magnitude, db::get<StrahlkorperTags::Rhat<Frame>>(box),
-          db::get<StrahlkorperTags::Radius<Frame>>(box),
+          get(db::get<StrahlkorperTags::Radius<Frame>>(box)),
           inverse_surface_metric);
     } break;
     default:  // LCOV_EXCL_LINE

--- a/src/ApparentHorizons/StrahlkorperGr.hpp
+++ b/src/ApparentHorizons/StrahlkorperGr.hpp
@@ -68,7 +68,8 @@ tnsr::i<DataVector, 3, Frame> unit_normal_one_form(
 template <typename Frame>
 void grad_unit_normal_one_form(
     gsl::not_null<tnsr::ii<DataVector, 3, Frame>*> result,
-    const tnsr::i<DataVector, 3, Frame>& r_hat, const DataVector& radius,
+    const tnsr::i<DataVector, 3, Frame>& r_hat,
+    const Scalar<DataVector>& radius,
     const tnsr::i<DataVector, 3, Frame>& unit_normal_one_form,
     const tnsr::ii<DataVector, 3, Frame>& d2x_radius,
     const DataVector& one_over_one_form_magnitude,
@@ -76,7 +77,8 @@ void grad_unit_normal_one_form(
 
 template <typename Frame>
 tnsr::ii<DataVector, 3, Frame> grad_unit_normal_one_form(
-    const tnsr::i<DataVector, 3, Frame>& r_hat, const DataVector& radius,
+    const tnsr::i<DataVector, 3, Frame>& r_hat,
+    const Scalar<DataVector>& radius,
     const tnsr::i<DataVector, 3, Frame>& unit_normal_one_form,
     const tnsr::ii<DataVector, 3, Frame>& d2x_radius,
     const DataVector& one_over_one_form_magnitude,
@@ -221,7 +223,7 @@ void area_element(gsl::not_null<Scalar<DataVector>*> result,
                   const tnsr::ii<DataVector, 3, Frame>& spatial_metric,
                   const StrahlkorperTags::aliases::Jacobian<Frame>& jacobian,
                   const tnsr::i<DataVector, 3, Frame>& normal_one_form,
-                  const DataVector& radius,
+                  const Scalar<DataVector>& radius,
                   const tnsr::i<DataVector, 3, Frame>& r_hat) noexcept;
 
 template <typename Frame>
@@ -229,7 +231,7 @@ Scalar<DataVector> area_element(
     const tnsr::ii<DataVector, 3, Frame>& spatial_metric,
     const StrahlkorperTags::aliases::Jacobian<Frame>& jacobian,
     const tnsr::i<DataVector, 3, Frame>& normal_one_form,
-    const DataVector& radius,
+    const Scalar<DataVector>& radius,
     const tnsr::i<DataVector, 3, Frame>& r_hat) noexcept;
 //@}
 
@@ -263,14 +265,14 @@ void euclidean_area_element(
     gsl::not_null<Scalar<DataVector>*> result,
     const StrahlkorperTags::aliases::Jacobian<Frame>& jacobian,
     const tnsr::i<DataVector, 3, Frame>& normal_one_form,
-    const DataVector& radius,
+    const Scalar<DataVector>& radius,
     const tnsr::i<DataVector, 3, Frame>& r_hat) noexcept;
 
 template <typename Frame>
 Scalar<DataVector> euclidean_area_element(
     const StrahlkorperTags::aliases::Jacobian<Frame>& jacobian,
     const tnsr::i<DataVector, 3, Frame>& normal_one_form,
-    const DataVector& radius,
+    const Scalar<DataVector>& radius,
     const tnsr::i<DataVector, 3, Frame>& r_hat) noexcept;
 //@}
 
@@ -429,14 +431,24 @@ double dimensionful_spin_magnitude(
  * moment vanishes. Also note that \f$x^i - x^i_0\f$ is
  * is the product of `StrahlkorperTags::Rhat` and `StrahlkorperTags::Radius`.
  */
+
 template <typename Frame>
-std::array<double, 3> spin_vector(double spin_magnitude,
-                                  const Scalar<DataVector>& area_element,
-                                  const Scalar<DataVector>& radius,
-                                  const tnsr::i<DataVector, 3, Frame>& r_hat,
-                                  const Scalar<DataVector>& ricci_scalar,
-                                  const Scalar<DataVector>& spin_function,
-                                  const YlmSpherepack& ylm) noexcept;
+void spin_vector(const gsl::not_null<std::array<double, 3>*> result,
+                 double spin_magnitude, const Scalar<DataVector>& area_element,
+                 const Scalar<DataVector>& radius,
+                 const tnsr::i<DataVector, 3, Frame>& r_hat,
+                 const Scalar<DataVector>& ricci_scalar,
+                 const Scalar<DataVector>& spin_function,
+                 const Strahlkorper<Frame>& strahlkorper) noexcept;
+
+template <typename Frame>
+std::array<double, 3> spin_vector(
+    double spin_magnitude, const Scalar<DataVector>& area_element,
+    const Scalar<DataVector>& radius,
+    const tnsr::i<DataVector, 3, Frame>& r_hat,
+    const Scalar<DataVector>& ricci_scalar,
+    const Scalar<DataVector>& spin_function,
+    const Strahlkorper<Frame>& strahlkorper) noexcept;
 
 /*!
  * \ingroup SurfacesGroup

--- a/src/ApparentHorizons/TagsDeclarations.hpp
+++ b/src/ApparentHorizons/TagsDeclarations.hpp
@@ -53,6 +53,10 @@ struct MaxRicciScalar;
 struct MaxRicciScalarCompute;
 struct MinRicciScalar;
 struct MinRicciScalarCompute;
+template <typename Frame>
+struct DimensionfulSpinVector;
+template <typename Frame>
+struct DimensionfulSpinVectorCompute;
 
 }  // namespace StrahlkorperTags
 

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
@@ -188,7 +188,7 @@ struct ApparentHorizon {
     auto& theta_phi =
         get<::Tags::Tempi<0, 2, ::Frame::Spherical<Frame>>>(temp_buffer);
     auto& r_hat = get<::Tags::Tempi<1, 3, Frame>>(temp_buffer);
-    auto& radius = get(get<::Tags::TempScalar<2>>(temp_buffer));
+    auto& radius = get<::Tags::TempScalar<2>>(temp_buffer);
     StrahlkorperTags::ThetaPhiCompute<Frame>::function(
         make_not_null(&theta_phi), prolonged_strahlkorper);
     StrahlkorperTags::RhatCompute<Frame>::function(make_not_null(&r_hat),

--- a/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
@@ -102,7 +102,7 @@ struct TestSchwarzschildHorizon {
                     const typename Metavariables::temporal_id::
                         type& /*temporal_id*/) noexcept {
     const auto& horizon_radius =
-        get<StrahlkorperTags::Radius<Frame::Inertial>>(box);
+        get(get<StrahlkorperTags::Radius<Frame::Inertial>>(box));
     const auto expected_radius =
         make_with_value<DataVector>(horizon_radius, 2.0);
     // We don't choose many grid points (for speed of test), so we
@@ -142,7 +142,7 @@ struct TestKerrHorizon {
         strahlkorper.ylm_spherepack().theta_phi_points(), 1.1,
         {{0.12, 0.23, 0.45}});
     const auto& horizon_radius =
-        get<StrahlkorperTags::Radius<Frame::Inertial>>(box);
+        get(get<StrahlkorperTags::Radius<Frame::Inertial>>(box));
     // The accuracy is not great because I use only a few grid points
     // to speed up the test.
     Approx custom_approx = Approx::custom().epsilon(1.e-3).scale(1.0);

--- a/tests/Unit/ApparentHorizons/Test_FastFlow.cpp
+++ b/tests/Unit/ApparentHorizons/Test_FastFlow.cpp
@@ -197,7 +197,8 @@ void test_schwarzschild(FastFlow::Flow::type type_of_flow,
         db::AddComputeTags<
             StrahlkorperTags::compute_items_tags<Frame::Inertial>>>(
         strahlkorper);
-    const auto& rad = db::get<StrahlkorperTags::Radius<Frame::Inertial>>(box);
+    const auto& rad =
+        get(db::get<StrahlkorperTags::Radius<Frame::Inertial>>(box));
     const auto r_minmax = std::minmax_element(rad.begin(), rad.end());
     Approx custom_approx = Approx::custom().epsilon(1.e-11);
     CHECK(*r_minmax.first == custom_approx(2.0));

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
@@ -767,10 +767,9 @@ void test_spin_vector(
       horizon_radius_with_spin_on_z_axis, ylm_with_spin_on_z_axis, ylm, mass,
       dimensionless_spin);
 
-  const auto spin_vector =
-      StrahlkorperGr::spin_vector(magnitude(dimensionless_spin), area_element,
-                                  Scalar<DataVector>{std::move(radius)}, r_hat,
-                                  ricci_scalar, spin_function, ylm);
+  const auto spin_vector = StrahlkorperGr::spin_vector(
+      magnitude(dimensionless_spin), area_element, std::move(radius), r_hat,
+      ricci_scalar, spin_function, strahlkorper);
 
   CHECK_ITERABLE_APPROX(spin_vector, dimensionless_spin);
 }


### PR DESCRIPTION
## Proposed changes

The DimensionfulSpinVectorTag and DimensionfulSpinVectorTagCompute calculate the dimensionful spin angular momentum vector of a Strahlkorper.

Change the RadiusCompute to a type Scalar DataVector in Tags.hpp. 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
