### PR TITLE
Add ability to specify ranges for random numbers in boundary corrections test helper

### DIFF
--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_BoundaryCorrectionsHelper.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_BoundaryCorrectionsHelper.cpp
@@ -283,7 +283,8 @@ void test_impl() {
       System<Dim, CurvedBackground>>(
       correction, face_mesh,
       tuples::TaggedTuple<Tags::VolumeDouble<VolumeDoubleType>>{
-          VolumeDoubleType{2.3}});
+          VolumeDoubleType{2.3}},
+      tuples::TaggedTuple<>{});
   const std::string curved_suffix =
       CurvedBackground ? std::string{"_curved"} : std::string{""};
   TestHelpers::evolution::dg::test_boundary_correction_with_python<
@@ -297,7 +298,8 @@ void test_impl() {
       {{"dg_boundary_terms_var1", "dg_boundary_terms_var2"}}, correction,
       face_mesh,
       tuples::TaggedTuple<Tags::VolumeDouble<VolumeDoubleType>>{
-          VolumeDoubleType{2.3}});
+          VolumeDoubleType{2.3}},
+      tuples::TaggedTuple<>{});
 }
 
 template <size_t Dim>

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_BoundaryCorrectionsHelper.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_BoundaryCorrectionsHelper.cpp
@@ -274,22 +274,24 @@ template <size_t Dim, typename VolumeDoubleType>
 PUP::able::PUP_ID Correction<Dim, VolumeDoubleType>::my_PUP_ID = 0;
 
 template <size_t Dim, bool CurvedBackground, typename VolumeDoubleType>
-void test_impl() {
+void test_impl(const gsl::not_null<std::mt19937*> gen) {
   PUPable_reg(SINGLE_ARG(Correction<Dim, VolumeDoubleType>));
   const Correction<Dim, VolumeDoubleType> correction{};
   const Mesh<Dim - 1> face_mesh{Dim * Dim, Spectral::Basis::Legendre,
                                 Spectral::Quadrature::Gauss};
+
   TestHelpers::evolution::dg::test_boundary_correction_conservation<
       System<Dim, CurvedBackground>>(
-      correction, face_mesh,
+      gen, correction, face_mesh,
       tuples::TaggedTuple<Tags::VolumeDouble<VolumeDoubleType>>{
           VolumeDoubleType{2.3}},
       tuples::TaggedTuple<>{});
+
   const std::string curved_suffix =
       CurvedBackground ? std::string{"_curved"} : std::string{""};
   TestHelpers::evolution::dg::test_boundary_correction_with_python<
       System<Dim, CurvedBackground>, tmpl::list<VolumeDoubleConversion>>(
-      "BoundaryCorrectionsHelper",
+      gen, "BoundaryCorrectionsHelper",
       {{"dg_package_data_var1" + curved_suffix,
         "dg_package_data_var1_normal_dot_flux" + curved_suffix,
         "dg_package_data_var2" + curved_suffix,
@@ -303,12 +305,12 @@ void test_impl() {
 }
 
 template <size_t Dim>
-void test() {
-  test_impl<Dim, false, double>();
-  test_impl<Dim, false, VolumeDouble>();
+void test(const gsl::not_null<std::mt19937*> gen) {
+  test_impl<Dim, false, double>(gen);
+  test_impl<Dim, false, VolumeDouble>(gen);
 
-  test_impl<Dim, true, double>();
-  test_impl<Dim, true, VolumeDouble>();
+  test_impl<Dim, true, double>(gen);
+  test_impl<Dim, true, VolumeDouble>(gen);
 }
 }  // namespace
 
@@ -316,7 +318,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.BoundaryCorrectionsHelper",
                   "[Unit][Evolution]") {
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/DiscontinuousGalerkin/"};
-  test<1>();
-  test<2>();
-  test<3>();
+  MAKE_GENERATOR(gen);
+
+  test<1>(make_not_null(&gen));
+  test<2>(make_not_null(&gen));
+  test<3>(make_not_null(&gen));
 }

--- a/tests/Unit/Evolution/Systems/Burgers/BoundaryCorrections/Test_Hll.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/BoundaryCorrections/Test_Hll.cpp
@@ -24,7 +24,8 @@ SPECTRE_TEST_CASE("Unit.Burgers.Hll", "[Unit][Burgers]") {
   TestHelpers::evolution::dg::test_boundary_correction_conservation<
       Burgers::System>(
       Burgers::BoundaryCorrections::Hll{},
-      Mesh<0>{1, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {});
+      Mesh<0>{1, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {},
+      {});
 
   TestHelpers::evolution::dg::test_boundary_correction_with_python<
       Burgers::System>(
@@ -32,7 +33,8 @@ SPECTRE_TEST_CASE("Unit.Burgers.Hll", "[Unit][Burgers]") {
       {{"dg_package_data_u", "dg_package_data_normal_dot_flux",
         "dg_package_data_char_speed"}},
       {{"dg_boundary_terms_u"}}, Burgers::BoundaryCorrections::Hll{},
-      Mesh<0>{1, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {});
+      Mesh<0>{1, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {},
+      {});
 
   const auto Hll = TestHelpers::test_factory_creation<
       Burgers::BoundaryCorrections::BoundaryCorrection>("Hll:");
@@ -44,5 +46,6 @@ SPECTRE_TEST_CASE("Unit.Burgers.Hll", "[Unit][Burgers]") {
         "dg_package_data_char_speed"}},
       {{"dg_boundary_terms_u"}},
       dynamic_cast<const Burgers::BoundaryCorrections::Hll&>(*Hll),
-      Mesh<0>{1, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {});
+      Mesh<0>{1, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {},
+      {});
 }

--- a/tests/Unit/Evolution/Systems/Burgers/BoundaryCorrections/Test_Hll.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/BoundaryCorrections/Test_Hll.cpp
@@ -20,16 +20,17 @@ SPECTRE_TEST_CASE("Unit.Burgers.Hll", "[Unit][Burgers]") {
   PUPable_reg(Burgers::BoundaryCorrections::Hll);
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/Burgers/BoundaryCorrections"};
+  MAKE_GENERATOR(gen);
 
   TestHelpers::evolution::dg::test_boundary_correction_conservation<
       Burgers::System>(
-      Burgers::BoundaryCorrections::Hll{},
+      make_not_null(&gen), Burgers::BoundaryCorrections::Hll{},
       Mesh<0>{1, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {},
       {});
 
   TestHelpers::evolution::dg::test_boundary_correction_with_python<
       Burgers::System>(
-      "Hll",
+      make_not_null(&gen), "Hll",
       {{"dg_package_data_u", "dg_package_data_normal_dot_flux",
         "dg_package_data_char_speed"}},
       {{"dg_boundary_terms_u"}}, Burgers::BoundaryCorrections::Hll{},
@@ -41,7 +42,7 @@ SPECTRE_TEST_CASE("Unit.Burgers.Hll", "[Unit][Burgers]") {
 
   TestHelpers::evolution::dg::test_boundary_correction_with_python<
       Burgers::System>(
-      "Hll",
+      make_not_null(&gen), "Hll",
       {{"dg_package_data_u", "dg_package_data_normal_dot_flux",
         "dg_package_data_char_speed"}},
       {{"dg_boundary_terms_u"}},

--- a/tests/Unit/Evolution/Systems/Burgers/BoundaryCorrections/Test_Rusanov.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/BoundaryCorrections/Test_Rusanov.cpp
@@ -20,16 +20,17 @@ SPECTRE_TEST_CASE("Unit.Burgers.Rusanov", "[Unit][Burgers]") {
   PUPable_reg(Burgers::BoundaryCorrections::Rusanov);
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/Burgers/BoundaryCorrections"};
+  MAKE_GENERATOR(gen);
 
   TestHelpers::evolution::dg::test_boundary_correction_conservation<
       Burgers::System>(
-      Burgers::BoundaryCorrections::Rusanov{},
+      make_not_null(&gen), Burgers::BoundaryCorrections::Rusanov{},
       Mesh<0>{1, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {},
       {});
 
   TestHelpers::evolution::dg::test_boundary_correction_with_python<
       Burgers::System>(
-      "Rusanov",
+      make_not_null(&gen), "Rusanov",
       {{"dg_package_data_u", "dg_package_data_normal_dot_flux",
         "dg_package_data_abs_char_speed"}},
       {{"dg_boundary_terms_u"}}, Burgers::BoundaryCorrections::Rusanov{},
@@ -41,7 +42,7 @@ SPECTRE_TEST_CASE("Unit.Burgers.Rusanov", "[Unit][Burgers]") {
 
   TestHelpers::evolution::dg::test_boundary_correction_with_python<
       Burgers::System>(
-      "Rusanov",
+      make_not_null(&gen), "Rusanov",
       {{"dg_package_data_u", "dg_package_data_normal_dot_flux",
         "dg_package_data_abs_char_speed"}},
       {{"dg_boundary_terms_u"}},

--- a/tests/Unit/Evolution/Systems/Burgers/BoundaryCorrections/Test_Rusanov.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/BoundaryCorrections/Test_Rusanov.cpp
@@ -24,7 +24,8 @@ SPECTRE_TEST_CASE("Unit.Burgers.Rusanov", "[Unit][Burgers]") {
   TestHelpers::evolution::dg::test_boundary_correction_conservation<
       Burgers::System>(
       Burgers::BoundaryCorrections::Rusanov{},
-      Mesh<0>{1, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {});
+      Mesh<0>{1, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {},
+      {});
 
   TestHelpers::evolution::dg::test_boundary_correction_with_python<
       Burgers::System>(
@@ -32,7 +33,8 @@ SPECTRE_TEST_CASE("Unit.Burgers.Rusanov", "[Unit][Burgers]") {
       {{"dg_package_data_u", "dg_package_data_normal_dot_flux",
         "dg_package_data_abs_char_speed"}},
       {{"dg_boundary_terms_u"}}, Burgers::BoundaryCorrections::Rusanov{},
-      Mesh<0>{1, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {});
+      Mesh<0>{1, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {},
+      {});
 
   const auto rusanov = TestHelpers::test_factory_creation<
       Burgers::BoundaryCorrections::BoundaryCorrection>("Rusanov:");
@@ -44,5 +46,6 @@ SPECTRE_TEST_CASE("Unit.Burgers.Rusanov", "[Unit][Burgers]") {
         "dg_package_data_abs_char_speed"}},
       {{"dg_boundary_terms_u"}},
       dynamic_cast<const Burgers::BoundaryCorrections::Rusanov&>(*rusanov),
-      Mesh<0>{1, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {});
+      Mesh<0>{1, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {},
+      {});
 }

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_DirichletAnalytic.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_DirichletAnalytic.cpp
@@ -12,6 +12,7 @@
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/Range.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugeWave.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/Test_UpwindPenalty.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/Test_UpwindPenalty.cpp
@@ -18,18 +18,19 @@
 
 namespace {
 template <size_t Dim>
-void test(const size_t num_pts) {
+void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts) {
   PUPable_reg(GeneralizedHarmonic::BoundaryCorrections::UpwindPenalty<Dim>);
+
   TestHelpers::evolution::dg::test_boundary_correction_conservation<
       GeneralizedHarmonic::System<Dim>>(
-      GeneralizedHarmonic::BoundaryCorrections::UpwindPenalty<Dim>{},
+      gen, GeneralizedHarmonic::BoundaryCorrections::UpwindPenalty<Dim>{},
       Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
                     Spectral::Quadrature::Gauss},
       {}, {});
 
   TestHelpers::evolution::dg::test_boundary_correction_with_python<
       GeneralizedHarmonic::System<Dim>>(
-      "UpwindPenalty",
+      gen, "UpwindPenalty",
       {{"dg_package_data_char_speed_v_spacetime_metric",
         "dg_package_data_char_speed_v_zero",
         "dg_package_data_char_speed_v_plus",
@@ -51,7 +52,7 @@ void test(const size_t num_pts) {
 
   TestHelpers::evolution::dg::test_boundary_correction_with_python<
       GeneralizedHarmonic::System<Dim>>(
-      "UpwindPenalty",
+      gen, "UpwindPenalty",
       {{"dg_package_data_char_speed_v_spacetime_metric",
         "dg_package_data_char_speed_v_zero",
         "dg_package_data_char_speed_v_plus",
@@ -75,7 +76,9 @@ SPECTRE_TEST_CASE("Unit.GeneralizedHarmonic.UpwindPenalty",
                   "[Unit][Evolution]") {
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections"};
-  test<1>(1);
-  test<2>(5);
-  test<3>(5);
+  MAKE_GENERATOR(gen);
+
+  test<1>(make_not_null(&gen), 1);
+  test<2>(make_not_null(&gen), 5);
+  test<3>(make_not_null(&gen), 5);
 }

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/Test_UpwindPenalty.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/Test_UpwindPenalty.cpp
@@ -25,7 +25,7 @@ void test(const size_t num_pts) {
       GeneralizedHarmonic::BoundaryCorrections::UpwindPenalty<Dim>{},
       Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
                     Spectral::Quadrature::Gauss},
-      {});
+      {}, {});
 
   TestHelpers::evolution::dg::test_boundary_correction_with_python<
       GeneralizedHarmonic::System<Dim>>(
@@ -43,7 +43,7 @@ void test(const size_t num_pts) {
       GeneralizedHarmonic::BoundaryCorrections::UpwindPenalty<Dim>{},
       Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
                     Spectral::Quadrature::Gauss},
-      {});
+      {}, {});
 
   const auto upwind_penalty = TestHelpers::test_factory_creation<
       GeneralizedHarmonic::BoundaryCorrections::BoundaryCorrection<Dim>>(
@@ -63,12 +63,11 @@ void test(const size_t num_pts) {
       {{"dg_boundary_terms_spacetime_metric", "dg_boundary_terms_pi",
         "dg_boundary_terms_phi"}},
       dynamic_cast<
-          const
-          GeneralizedHarmonic::BoundaryCorrections::UpwindPenalty<Dim>&>(
+          const GeneralizedHarmonic::BoundaryCorrections::UpwindPenalty<Dim>&>(
           *upwind_penalty),
       Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
                     Spectral::Quadrature::Gauss},
-      {});
+      {}, {});
 }
 }  // namespace
 

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Test_Rusanov.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Test_Rusanov.cpp
@@ -30,7 +30,8 @@ SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.Rusanov", "[Unit][GrMhd]") {
 
   TestHelpers::evolution::dg::test_boundary_correction_conservation<system>(
       grmhd::ValenciaDivClean::BoundaryCorrections::Rusanov{},
-      Mesh<2>{5, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {});
+      Mesh<2>{5, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {},
+      {});
 
   TestHelpers::evolution::dg::test_boundary_correction_with_python<system>(
       "Rusanov",
@@ -46,7 +47,8 @@ SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.Rusanov", "[Unit][GrMhd]") {
         "dg_boundary_terms_tilde_s", "dg_boundary_terms_tilde_b",
         "dg_boundary_terms_tilde_phi"}},
       grmhd::ValenciaDivClean::BoundaryCorrections::Rusanov{},
-      Mesh<2>{5, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {});
+      Mesh<2>{5, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {},
+      {});
 
   const auto rusanov = TestHelpers::test_factory_creation<
       grmhd::ValenciaDivClean::BoundaryCorrections::BoundaryCorrection>(
@@ -68,5 +70,6 @@ SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.Rusanov", "[Unit][GrMhd]") {
       dynamic_cast<
           const grmhd::ValenciaDivClean::BoundaryCorrections::Rusanov&>(
           *rusanov),
-      Mesh<2>{5, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {});
+      Mesh<2>{5, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {},
+      {});
 }

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Test_Rusanov.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Test_Rusanov.cpp
@@ -23,18 +23,21 @@ SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.Rusanov", "[Unit][GrMhd]") {
   PUPable_reg(grmhd::ValenciaDivClean::BoundaryCorrections::Rusanov);
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections"};
+  MAKE_GENERATOR(gen);
+
   // need some equation of state. Rusanov doesn't care about it since the max
   // speed is set by the speed of light.
   using system =
       grmhd::ValenciaDivClean::System<EquationsOfState::IdealFluid<true>>;
 
   TestHelpers::evolution::dg::test_boundary_correction_conservation<system>(
+      make_not_null(&gen),
       grmhd::ValenciaDivClean::BoundaryCorrections::Rusanov{},
       Mesh<2>{5, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {},
       {});
 
   TestHelpers::evolution::dg::test_boundary_correction_with_python<system>(
-      "Rusanov",
+      make_not_null(&gen), "Rusanov",
       {{"dg_package_data_tilde_d", "dg_package_data_tilde_tau",
         "dg_package_data_tilde_s", "dg_package_data_tilde_b",
         "dg_package_data_tilde_phi", "dg_package_data_normal_dot_flux_tilde_d",
@@ -55,7 +58,7 @@ SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.Rusanov", "[Unit][GrMhd]") {
       "Rusanov:");
 
   TestHelpers::evolution::dg::test_boundary_correction_with_python<system>(
-      "Rusanov",
+      make_not_null(&gen), "Rusanov",
       {{"dg_package_data_tilde_d", "dg_package_data_tilde_tau",
         "dg_package_data_tilde_s", "dg_package_data_tilde_b",
         "dg_package_data_tilde_phi", "dg_package_data_normal_dot_flux_tilde_d",

--- a/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/Test_DirichletAnalytic.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/Test_DirichletAnalytic.cpp
@@ -12,6 +12,7 @@
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/Range.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"
 #include "PointwiseFunctions/MathFunctions/Gaussian.hpp"

--- a/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/Test_SphericalRadiation.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/Test_SphericalRadiation.cpp
@@ -12,6 +12,7 @@
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/Range.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "Time/Tags.hpp"
 #include "Utilities/Gsl.hpp"

--- a/tests/Unit/Evolution/Systems/ScalarWave/BoundaryCorrections/Test_UpwindPenalty.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/BoundaryCorrections/Test_UpwindPenalty.cpp
@@ -26,7 +26,7 @@ void test(const size_t num_pts) {
       ScalarWave::BoundaryCorrections::UpwindPenalty<Dim>{},
       Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
                     Spectral::Quadrature::Gauss},
-      {});
+      {}, {});
 
   TestHelpers::evolution::dg::test_boundary_correction_with_python<
       ScalarWave::System<Dim>>(
@@ -43,7 +43,7 @@ void test(const size_t num_pts) {
       ScalarWave::BoundaryCorrections::UpwindPenalty<Dim>{},
       Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
                     Spectral::Quadrature::Gauss},
-      {});
+      {}, {});
 
   const auto upwind_penalty = TestHelpers::test_factory_creation<
       ScalarWave::BoundaryCorrections::BoundaryCorrection<Dim>>(
@@ -65,7 +65,7 @@ void test(const size_t num_pts) {
           *upwind_penalty),
       Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
                     Spectral::Quadrature::Gauss},
-      {});
+      {}, {});
 }
 }  // namespace
 

--- a/tests/Unit/Evolution/Systems/ScalarWave/BoundaryCorrections/Test_UpwindPenalty.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/BoundaryCorrections/Test_UpwindPenalty.cpp
@@ -19,18 +19,18 @@
 
 namespace {
 template <size_t Dim>
-void test(const size_t num_pts) {
+void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts) {
   PUPable_reg(ScalarWave::BoundaryCorrections::UpwindPenalty<Dim>);
   TestHelpers::evolution::dg::test_boundary_correction_conservation<
       ScalarWave::System<Dim>>(
-      ScalarWave::BoundaryCorrections::UpwindPenalty<Dim>{},
+      gen, ScalarWave::BoundaryCorrections::UpwindPenalty<Dim>{},
       Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
                     Spectral::Quadrature::Gauss},
       {}, {});
 
   TestHelpers::evolution::dg::test_boundary_correction_with_python<
       ScalarWave::System<Dim>>(
-      "UpwindPenalty",
+      gen, "UpwindPenalty",
       {{"dg_package_data_char_speed_v_psi", "dg_package_data_char_speed_v_zero",
         "dg_package_data_char_speed_v_plus",
         "dg_package_data_char_speed_v_minus",
@@ -51,7 +51,7 @@ void test(const size_t num_pts) {
 
   TestHelpers::evolution::dg::test_boundary_correction_with_python<
       ScalarWave::System<Dim>>(
-      "UpwindPenalty",
+      gen, "UpwindPenalty",
       {{"dg_package_data_char_speed_v_psi", "dg_package_data_char_speed_v_zero",
         "dg_package_data_char_speed_v_plus",
         "dg_package_data_char_speed_v_minus",
@@ -72,7 +72,9 @@ void test(const size_t num_pts) {
 SPECTRE_TEST_CASE("Unit.ScalarWave.UpwindPenalty", "[Unit][Evolution]") {
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/ScalarWave/BoundaryCorrections"};
-  test<1>(1);
-  test<2>(5);
-  test<3>(5);
+  MAKE_GENERATOR(gen);
+
+  test<1>(make_not_null(&gen), 1);
+  test<2>(make_not_null(&gen), 5);
+  test<3>(make_not_null(&gen), 5);
 }

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp
@@ -33,6 +33,7 @@
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/Evolution/DiscontinuousGalerkin/NormalVectors.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/Range.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/NoSuchType.hpp"
@@ -69,14 +70,6 @@ template <typename BoundaryCorrection = NoSuchType>
 struct PythonFunctionForErrorMessage {
   using boundary_correction = BoundaryCorrection;
   using type = std::string;
-};
-
-/// Tag for a `TaggedTuple` that holds the range of validity for the variable
-/// associated with `Tag`.
-template <typename Tag>
-struct Range {
-  using tag = Tag;
-  using type = std::array<double, 2>;
 };
 }  // namespace Tags
 

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp
@@ -247,12 +247,13 @@ void test_boundary_condition_with_python_impl(
 
   std::uniform_real_distribution<> dist(-1., 1.);
 
+  // Fill all fields with random values in [-1,1), then, for each tag with a
+  // specified range, overwrite with new random values in [min,max)
   Variables<tmpl::remove_duplicates<
       tmpl::append<bcondition_interior_tags, inverse_spatial_metric_list>>>
       interior_face_fields{number_of_points_on_face};
   fill_with_random_values(make_not_null(&interior_face_fields), generator,
                           make_not_null(&dist));
-
   tmpl::for_each<tmpl::list<RangeTags...>>([&generator, &interior_face_fields,
                                             &ranges](auto tag_v) {
     using tag = tmpl::type_from<decltype(tag_v)>;

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp
@@ -23,6 +23,7 @@
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/Evolution/DiscontinuousGalerkin/NormalVectors.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/Range.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Utilities/Gsl.hpp"
@@ -135,10 +136,11 @@ void call_dg_boundary_terms(
 }
 
 template <typename System, typename BoundaryCorrection, size_t FaceDim,
-          typename... VolumeTags>
+          typename... VolumeTags, typename... RangeTags>
 void test_boundary_correction_conservation_impl(
     const BoundaryCorrection& correction_in, const Mesh<FaceDim>& face_mesh,
     const tuples::TaggedTuple<VolumeTags...>& volume_data,
+    const tuples::TaggedTuple<Tags::Range<RangeTags>...>& ranges,
     const bool use_moving_mesh, const ::dg::Formulation dg_formulation,
     const ZeroOnSmoothSolution zero_on_smooth_solution) {
   CAPTURE(use_moving_mesh);
@@ -192,8 +194,7 @@ void test_boundary_correction_conservation_impl(
       "listed in the system as being primitive variables");
 
   MAKE_GENERATOR(gen);
-  std::uniform_real_distribution<> dist(0.0, 1.0);
-  std::uniform_real_distribution<> pos_neg_dist(-1.0, 1.0);
+  std::uniform_real_distribution<> dist(-1.0, 1.0);
   DataVector used_for_size{face_mesh.number_of_grid_points()};
 
   std::optional<tnsr::I<DataVector, FaceDim + 1, Frame::Inertial>>
@@ -214,21 +215,40 @@ void test_boundary_correction_conservation_impl(
                          curved_background>::template f<System>>>,
       face_tags>;
 
+  // Fill all fields with random values in [-1,1), then, for each tag with a
+  // specified range, overwrite with new random values in [min,max)
   Variables<dg_package_field_tags> interior_package_data{used_for_size.size()};
   auto interior_fields_on_face =
       make_with_random_values<Variables<face_tags_with_curved_background>>(
           make_not_null(&gen), make_not_null(&dist), used_for_size);
+  tmpl::for_each<tmpl::list<RangeTags...>>([&gen, &interior_fields_on_face,
+                                            &ranges](auto tag_v) {
+    using tag = tmpl::type_from<decltype(tag_v)>;
+    const std::array<double, 2>& range = tuples::get<Tags::Range<tag>>(ranges);
+    std::uniform_real_distribution<> local_dist(range[0], range[1]);
+    fill_with_random_values(make_not_null(&get<tag>(interior_fields_on_face)),
+                            make_not_null(&gen), make_not_null(&local_dist));
+  });
 
+  // Same as above but now for external data
   Variables<dg_package_field_tags> exterior_package_data{used_for_size.size()};
   auto exterior_fields_on_face =
       make_with_random_values<Variables<face_tags_with_curved_background>>(
           make_not_null(&gen), make_not_null(&dist), used_for_size);
+  tmpl::for_each<tmpl::list<RangeTags...>>([&gen, &exterior_fields_on_face,
+                                            &ranges](auto tag_v) {
+    using tag = tmpl::type_from<decltype(tag_v)>;
+    const std::array<double, 2>& range = tuples::get<Tags::Range<tag>>(ranges);
+    std::uniform_real_distribution<> local_dist(range[0], range[1]);
+    fill_with_random_values(make_not_null(&get<tag>(exterior_fields_on_face)),
+                            make_not_null(&gen), make_not_null(&local_dist));
+  });
 
   // Compute the interior and exterior normal vectors so they are pointing in
   // opposite directions.
   auto interior_unit_normal_covector = make_with_random_values<
       tnsr::i<DataVector, FaceDim + 1, Frame::Inertial>>(
-      make_not_null(&gen), make_not_null(&pos_neg_dist), used_for_size);
+      make_not_null(&gen), make_not_null(&dist), used_for_size);
   tnsr::I<DataVector, FaceDim + 1, Frame::Inertial>
       interior_unit_normal_vector{};
 
@@ -438,18 +458,19 @@ void test_boundary_correction_conservation_impl(
  * smooth solutions the strong-form correction is zero.
  */
 template <typename System, typename BoundaryCorrection, size_t FaceDim,
-          typename... VolumeTags>
+          typename... VolumeTags, typename... RangeTags>
 void test_boundary_correction_conservation(
     const BoundaryCorrection& correction, const Mesh<FaceDim>& face_mesh,
     const tuples::TaggedTuple<VolumeTags...>& volume_data,
+    const tuples::TaggedTuple<Tags::Range<RangeTags>...>& ranges,
     const ZeroOnSmoothSolution zero_on_smooth_solution =
         ZeroOnSmoothSolution::Yes) {
   for (const auto use_moving_mesh : {true, false}) {
     for (const auto& dg_formulation :
          {::dg::Formulation::StrongInertial, ::dg::Formulation::WeakInertial}) {
       detail::test_boundary_correction_conservation_impl<System>(
-          correction, face_mesh, volume_data, use_moving_mesh, dg_formulation,
-          zero_on_smooth_solution);
+          correction, face_mesh, volume_data, ranges, use_moving_mesh,
+          dg_formulation, zero_on_smooth_solution);
     }
   }
 }
@@ -457,7 +478,8 @@ void test_boundary_correction_conservation(
 namespace detail {
 template <typename System, typename ConversionClassList, typename VariablesTags,
           typename BoundaryCorrection, size_t FaceDim, typename... FaceTags,
-          typename... VolumeTags, typename... DgPackageDataTags>
+          typename... VolumeTags, typename... RangeTags,
+          typename... DgPackageDataTags>
 void test_with_python(
     const std::string& python_module,
     const std::array<
@@ -468,6 +490,7 @@ void test_with_python(
         python_dg_boundary_terms_functions,
     const BoundaryCorrection& correction, const Mesh<FaceDim>& face_mesh,
     const tuples::TaggedTuple<VolumeTags...>& volume_data,
+    const tuples::TaggedTuple<Tags::Range<RangeTags>...>& ranges,
     const bool use_moving_mesh, const ::dg::Formulation dg_formulation,
     const double epsilon, tmpl::list<FaceTags...> /*meta*/,
     tmpl::list<DgPackageDataTags...> /*meta*/) {
@@ -481,7 +504,7 @@ void test_with_python(
       typename BoundaryCorrection::dg_package_field_tags;
 
   MAKE_GENERATOR(gen);
-  std::uniform_real_distribution<> dist(0.0, 1.0);
+  std::uniform_real_distribution<> dist(-1.0, 1.0);
   DataVector used_for_size{face_mesh.number_of_grid_points()};
 
   using face_tags = tmpl::list<FaceTags...>;
@@ -493,9 +516,39 @@ void test_with_python(
                              curved_background>::template f<System>>>,
       face_tags>;
 
+  // Sanity check: we apply the same ranges to the random inputs of the
+  // `dg_package_data` function and the `dg_boundary_terms` function. So
+  // first we check that each range tag appears in at least one of these
+  // function's arguments.
+  using range_tags_list = tmpl::list<RangeTags...>;
+  using ranges_for_dg_boundary_terms_only =
+      tmpl::list_difference<range_tags_list, face_tags_with_curved_background>;
+  using ranges_unused = tmpl::list_difference<ranges_for_dg_boundary_terms_only,
+                                              dg_package_field_tags>;
+  static_assert(std::is_same_v<tmpl::list<>, ranges_unused>,
+                "Received Tags::Range for Tags that are neither arguments to "
+                "dg_package_data nor dg_boundary_terms");
+
+  // Fill all fields with random values in [-1,1), then, for each tag with a
+  // specified range, overwrite with new random values in [min,max)
   auto fields_on_face =
       make_with_random_values<Variables<face_tags_with_curved_background>>(
           make_not_null(&gen), make_not_null(&dist), used_for_size);
+  tmpl::for_each<tmpl::list<RangeTags...>>([&gen, &fields_on_face,
+                                            &ranges](auto tag_v) {
+    using tag = tmpl::type_from<decltype(tag_v)>;
+    // If this range tag is for an argument to dg_boundary_terms only, don't try
+    // to extract it from this Variables
+    if constexpr (tmpl::list_contains_v<face_tags_with_curved_background,
+                                        tag>) {
+      const std::array<double, 2>& range =
+          tuples::get<Tags::Range<tag>>(ranges);
+      std::uniform_real_distribution<> local_dist(range[0], range[1]);
+      fill_with_random_values(make_not_null(&get<tag>(fields_on_face)),
+                              make_not_null(&gen), make_not_null(&local_dist));
+    }
+  });
+
   auto unit_normal_covector = make_with_random_values<
       tnsr::i<DataVector, FaceDim + 1, Frame::Inertial>>(
       make_not_null(&gen), make_not_null(&dist), used_for_size);
@@ -600,12 +653,41 @@ void test_with_python(
       });
 
   // Now we need to check the dg_boundary_terms function.
-  const auto interior_package_data =
+  // Fill all fields with random values in [-1,1), then, for each tag with a
+  // specified range, overwrite with new random values in [min,max)
+  auto interior_package_data =
       make_with_random_values<Variables<dg_package_field_tags>>(
           make_not_null(&gen), make_not_null(&dist), used_for_size);
-  const auto exterior_package_data =
+  tmpl::for_each<tmpl::list<RangeTags...>>([&gen, &interior_package_data,
+                                            &ranges](auto tag_v) {
+    using tag = tmpl::type_from<decltype(tag_v)>;
+    // If this range tag is for an argument to dg_package_data only, don't try
+    // to extract it from this Variables
+    if constexpr (tmpl::list_contains_v<dg_package_field_tags, tag>) {
+      const std::array<double, 2>& range =
+          tuples::get<Tags::Range<tag>>(ranges);
+      std::uniform_real_distribution<> local_dist(range[0], range[1]);
+      fill_with_random_values(make_not_null(&get<tag>(interior_package_data)),
+                              make_not_null(&gen), make_not_null(&local_dist));
+    }
+  });
+
+  // Same as above but for exterior data
+  auto exterior_package_data =
       make_with_random_values<Variables<dg_package_field_tags>>(
           make_not_null(&gen), make_not_null(&dist), used_for_size);
+  tmpl::for_each<tmpl::list<RangeTags...>>([&gen, &exterior_package_data,
+                                            &ranges](auto tag_v) {
+    using tag = tmpl::type_from<decltype(tag_v)>;
+    if constexpr (tmpl::list_contains_v<dg_package_field_tags, tag>) {
+      const std::array<double, 2>& range =
+          tuples::get<Tags::Range<tag>>(ranges);
+      std::uniform_real_distribution<> local_dist(range[0], range[1]);
+      fill_with_random_values(make_not_null(&get<tag>(exterior_package_data)),
+                              make_not_null(&gen), make_not_null(&local_dist));
+    }
+  });
+
   // We don't need to prefix the VariablesTags with anything because we are not
   // interacting with any code that cares about what the tags are, just that the
   // types matched the evolved variables.
@@ -685,9 +767,18 @@ void test_with_python(
  * - The arguments to the python functions for computing the boundary
  *   corrections are the same as the arguments for the C++ `dg_boundary_terms`
  *   function, excluding the `gsl::not_null` arguments.
+ * - `ranges` is a `TaggedTuple` of
+ *   `TestHelpers::evolution::dg::Tags::Range<tag>` specifying a custom range in
+ *   which to generate the random values. This can be used for ensuring that
+ *   positive quantities are randomly generated on the interval
+ *   `[lower_bound,upper_bound)`, choosing `lower_bound` to be `0` or some small
+ *   number. The default interval if a tag is not listed is `[-1,1)`. The range
+ *   is used for setting the random inputs to `dg_package_data` and
+ *   `dg_boundary_terms`.
  */
 template <typename System, typename ConversionClassList = tmpl::list<>,
-          typename BoundaryCorrection, size_t FaceDim, typename... VolumeTags>
+          typename BoundaryCorrection, size_t FaceDim, typename... VolumeTags,
+          typename... RangeTags>
 void test_boundary_correction_with_python(
     const std::string& python_module,
     const std::array<
@@ -700,6 +791,7 @@ void test_boundary_correction_with_python(
         python_dg_boundary_terms_functions,
     const BoundaryCorrection& correction, const Mesh<FaceDim>& face_mesh,
     const tuples::TaggedTuple<VolumeTags...>& volume_data,
+    const tuples::TaggedTuple<Tags::Range<RangeTags>...>& ranges,
     const double epsilon = 1.0e-12) {
   static_assert(std::is_final_v<std::decay_t<BoundaryCorrection>>,
                 "All boundary correction classes must be marked `final`.");
@@ -719,7 +811,7 @@ void test_boundary_correction_with_python(
       detail::test_with_python<System, ConversionClassList, variables_tags>(
           python_module, python_dg_package_data_functions,
           python_dg_boundary_terms_functions, correction, face_mesh,
-          volume_data, use_moving_mesh, dg_formulation, epsilon,
+          volume_data, ranges, use_moving_mesh, dg_formulation, epsilon,
           tmpl::append<variables_tags, flux_tags, package_temporary_tags,
                        package_primitive_tags>{},
           typename BoundaryCorrection::dg_package_field_tags{});

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp
@@ -493,7 +493,6 @@ void test_with_python(
                              curved_background>::template f<System>>>,
       face_tags>;
 
-  Variables<dg_package_field_tags> package_data{used_for_size.size()};
   auto fields_on_face =
       make_with_random_values<Variables<face_tags_with_curved_background>>(
           make_not_null(&gen), make_not_null(&dist), used_for_size);
@@ -532,6 +531,7 @@ void test_with_python(
   }
 
   // Call C++ implementation of dg_package_data
+  Variables<dg_package_field_tags> package_data{used_for_size.size()};
   if constexpr (curved_background) {
     call_dg_package_data(make_not_null(&package_data), correction,
                          fields_on_face, volume_data, unit_normal_covector,

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp
@@ -193,18 +193,6 @@ void test_boundary_correction_conservation_impl(
       "There are primitive tags needed by the boundary correction that are not "
       "listed in the system as being primitive variables");
 
-  MAKE_GENERATOR(gen);
-  std::uniform_real_distribution<> dist(-1.0, 1.0);
-  DataVector used_for_size{face_mesh.number_of_grid_points()};
-
-  std::optional<tnsr::I<DataVector, FaceDim + 1, Frame::Inertial>>
-      mesh_velocity{};
-  if (use_moving_mesh) {
-    mesh_velocity = make_with_random_values<
-        tnsr::I<DataVector, FaceDim + 1, Frame::Inertial>>(
-        make_not_null(&gen), make_not_null(&dist), used_for_size);
-  }
-
   using face_tags =
       tmpl::append<variables_tags, flux_tags, package_temporary_tags,
                    package_primitive_tags>;
@@ -214,6 +202,10 @@ void test_boundary_correction_conservation_impl(
           face_tags, typename detail::inverse_spatial_metric_tag<
                          curved_background>::template f<System>>>,
       face_tags>;
+
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> dist(-1.0, 1.0);
+  DataVector used_for_size{face_mesh.number_of_grid_points()};
 
   // Fill all fields with random values in [-1,1), then, for each tag with a
   // specified range, overwrite with new random values in [min,max)
@@ -296,6 +288,14 @@ void test_boundary_correction_conservation_impl(
         make_not_null(&exterior_unit_normal_covector),
         make_not_null(&exterior_unit_normal_vector),
         get<inv_spatial_metric>(exterior_fields_on_face));
+  }
+
+  std::optional<tnsr::I<DataVector, FaceDim + 1, Frame::Inertial>>
+      mesh_velocity{};
+  if (use_moving_mesh) {
+    mesh_velocity = make_with_random_values<
+        tnsr::I<DataVector, FaceDim + 1, Frame::Inertial>>(
+        make_not_null(&gen), make_not_null(&dist), used_for_size);
   }
 
   if constexpr (curved_background) {
@@ -503,10 +503,6 @@ void test_with_python(
   using dg_package_field_tags =
       typename BoundaryCorrection::dg_package_field_tags;
 
-  MAKE_GENERATOR(gen);
-  std::uniform_real_distribution<> dist(-1.0, 1.0);
-  DataVector used_for_size{face_mesh.number_of_grid_points()};
-
   using face_tags = tmpl::list<FaceTags...>;
   using face_tags_with_curved_background = tmpl::conditional_t<
       curved_background,
@@ -528,6 +524,10 @@ void test_with_python(
   static_assert(std::is_same_v<tmpl::list<>, ranges_unused>,
                 "Received Tags::Range for Tags that are neither arguments to "
                 "dg_package_data nor dg_boundary_terms");
+
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> dist(-1.0, 1.0);
+  DataVector used_for_size{face_mesh.number_of_grid_points()};
 
   // Fill all fields with random values in [-1,1), then, for each tag with a
   // specified range, overwrite with new random values in [min,max)

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp
@@ -136,7 +136,7 @@ void call_dg_boundary_terms(
 
 template <typename System, typename BoundaryCorrection, size_t FaceDim,
           typename... VolumeTags>
-void test_boundary_correction_impl(
+void test_boundary_correction_conservation_impl(
     const BoundaryCorrection& correction_in, const Mesh<FaceDim>& face_mesh,
     const tuples::TaggedTuple<VolumeTags...>& volume_data,
     const bool use_moving_mesh, const ::dg::Formulation dg_formulation,
@@ -447,7 +447,7 @@ void test_boundary_correction_conservation(
   for (const auto use_moving_mesh : {true, false}) {
     for (const auto& dg_formulation :
          {::dg::Formulation::StrongInertial, ::dg::Formulation::WeakInertial}) {
-      detail::test_boundary_correction_impl<System>(
+      detail::test_boundary_correction_conservation_impl<System>(
           correction, face_mesh, volume_data, use_moving_mesh, dg_formulation,
           zero_on_smooth_solution);
     }

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Range.hpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Range.hpp
@@ -1,0 +1,18 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+
+namespace TestHelpers::evolution::dg::Tags {
+
+/// Tag for a `TaggedTuple` that holds the range of validity for the variable
+/// associated with `Tag`.
+template <typename Tag>
+struct Range {
+  using tag = Tag;
+  using type = std::array<double, 2>;
+};
+
+}  // namespace TestHelpers::evolution::dg::Tags


### PR DESCRIPTION
## Proposed changes

Depends on #2967 

Primary change:
- enable calls to the generic boundary correction test functions to specify the [min,max) interval from which to generate random numbers for each Tag. By default, any Tag will be drawn from [-1,1), but the new feature enables specifying an arbitrary interval.

Also:
- various smaller cleanups to increase legibility and/or consistency with boundary conditions test helper

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
