### PR TITLE
Add ComputeTag to set tags using AnalyticData

### DIFF
--- a/src/Evolution/ComputeTags.hpp
+++ b/src/Evolution/ComputeTags.hpp
@@ -39,6 +39,29 @@ struct AnalyticCompute : ::Tags::AnalyticSolutions<AnalyticFieldsTagList>,
   }
 };
 
+/*!
+ * \brief Use the `AnalyticDataTag` to compute the analytic data for the
+ * tags in `AnalyticFieldsTagList`.
+ */
+template <size_t Dim, typename AnalyticDataTag, typename AnalyticFieldsTagList>
+struct AnalyticDataCompute : ::Tags::AnalyticSolutions<AnalyticFieldsTagList>,
+                             db::ComputeTag {
+  using base = ::Tags::AnalyticSolutions<AnalyticFieldsTagList>;
+  using return_type = typename base::type;
+  using argument_tags =
+      tmpl::list<AnalyticDataTag,
+                 domain::Tags::Coordinates<Dim, Frame::Inertial>>;
+  static void function(const gsl::not_null<return_type*> analytic_data,
+                       const db::detail::const_item_type<AnalyticDataTag>&
+                           analytic_data_computer,
+                       const tnsr::I<DataVector, Dim, Frame::Inertial>&
+                           inertial_coords) noexcept {
+    *analytic_data =
+        variables_from_tagged_tuple(analytic_data_computer.variables(
+            inertial_coords, AnalyticFieldsTagList{}));
+  }
+};
+
 // @{
 /*!
  * \brief For each `Tag` in `TagsList`, compute its difference from the

--- a/tests/Unit/Evolution/Test_ComputeTags.cpp
+++ b/tests/Unit/Evolution/Test_ComputeTags.cpp
@@ -41,21 +41,51 @@ struct AnalyticSolutionTag : db::SimpleTag {
   using type = AnalyticSolution;
 };
 
+struct AnalyticData {
+  static tuples::TaggedTuple<FieldTag> variables(
+      const tnsr::I<DataVector, 1>& x,
+      const tmpl::list<FieldTag> /*meta*/) noexcept {
+    return {Scalar<DataVector>{1. * get<0>(x)}};
+  }
+  void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
+};
+
+struct AnalyticDataTag : db::SimpleTag {
+  using type = AnalyticData;
+};
+
 }  // namespace
 SPECTRE_TEST_CASE("Unit.Evolution.ComputeTags", "[Unit][Evolution]") {
-  tnsr::I<DataVector, 1, Frame::Inertial> inertial_coords{{{{1., 2., 3., 4.}}}};
   const double current_time = 2.;
-  const auto box = db::create<
-      db::AddSimpleTags<domain::Tags::Coordinates<1, Frame::Inertial>,
-                        AnalyticSolutionTag, Tags::Time>,
-      db::AddComputeTags<evolution::Tags::AnalyticCompute<
-          1, AnalyticSolutionTag, tmpl::list<FieldTag>>>>(
-      std::move(inertial_coords), AnalyticSolution{}, current_time);
-  const DataVector expected{2., 4., 6., 8.};
-  CHECK_ITERABLE_APPROX(get(get<::Tags::Analytic<FieldTag>>(box)), expected);
+  {
+    tnsr::I<DataVector, 1, Frame::Inertial> inertial_coords{
+        {{{1., 2., 3., 4.}}}};
+    const auto box = db::create<
+        db::AddSimpleTags<domain::Tags::Coordinates<1, Frame::Inertial>,
+                          AnalyticSolutionTag, Tags::Time>,
+        db::AddComputeTags<evolution::Tags::AnalyticCompute<
+            1, AnalyticSolutionTag, tmpl::list<FieldTag>>>>(
+        std::move(inertial_coords), AnalyticSolution{}, current_time);
+    const DataVector expected{2., 4., 6., 8.};
+    CHECK_ITERABLE_APPROX(get(get<::Tags::Analytic<FieldTag>>(box)), expected);
+  }
+  {
+    tnsr::I<DataVector, 1, Frame::Inertial> inertial_coords{
+        {{{3., 5., 7., 9.}}}};
+    const auto box = db::create<
+        db::AddSimpleTags<domain::Tags::Coordinates<1, Frame::Inertial>,
+                          AnalyticDataTag>,
+        db::AddComputeTags<evolution::Tags::AnalyticDataCompute<
+            1, AnalyticDataTag, tmpl::list<FieldTag>>>>(
+        std::move(inertial_coords), AnalyticData{});
+    const DataVector expected{3., 5., 7., 9.};
+    CHECK_ITERABLE_APPROX(get(get<::Tags::Analytic<FieldTag>>(box)), expected);
+  }
 
   TestHelpers::db::test_compute_tag<evolution::Tags::AnalyticCompute<
       1, AnalyticSolutionTag, tmpl::list<FieldTag>>>("AnalyticSolutions");
+  TestHelpers::db::test_compute_tag<evolution::Tags::AnalyticDataCompute<
+      1, AnalyticDataTag, tmpl::list<FieldTag>>>("AnalyticSolutions");
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.ComputeTags.Errors",


### PR DESCRIPTION
## Proposed changes

This PR adds a compute tag to compute analytic data for given variables in order to use it to initialize an evolution. Its similar to another tag that currently does the same with analytic solutions, with the key difference that analytic data is time independent.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
