### PR TITLE
Add interpolation of Gauss points to GL points for Bjorhus boundary conditions

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -7,6 +7,7 @@ spectre_target_headers(
   HEADERS
   DgElementArray.hpp
   InboxTags.hpp
+  InterpolateFromBoundary.hpp
   LiftFromBoundary.hpp
   MortarData.hpp
   MortarTags.hpp
@@ -17,6 +18,7 @@ spectre_target_headers(
 spectre_target_sources(
   Evolution
   PRIVATE
+  InterpolateFromBoundary.cpp
   LiftFromBoundary.cpp
   MortarData.cpp
   )

--- a/src/Evolution/DiscontinuousGalerkin/InterpolateFromBoundary.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/InterpolateFromBoundary.cpp
@@ -1,0 +1,98 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/DiscontinuousGalerkin/InterpolateFromBoundary.hpp"
+
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/StripeIterator.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace evolution::dg::detail {
+namespace {
+// We use a separate function in the  xi direction to avoid the expensive
+// SliceIterator
+void interpolate_dt_terms_gauss_points_impl_xi_dir(
+    const gsl::not_null<double*> volume_dt_vars,
+    const size_t num_independent_components, const size_t num_volume_pts,
+    const size_t num_boundary_pts,
+    const gsl::span<const double>& dt_corrections,
+    const DataVector& boundary_interpolation_term) noexcept {
+  DataVector volume_dt_vars_view{};
+  for (size_t component_index = 0; component_index < num_independent_components;
+       ++component_index) {
+    const size_t stripe_size = num_volume_pts / num_boundary_pts;
+    for (size_t boundary_index = 0; boundary_index < num_boundary_pts;
+         ++boundary_index) {
+      volume_dt_vars_view.set_data_ref(volume_dt_vars.get() +
+                                           component_index * num_volume_pts +
+                                           boundary_index * stripe_size,
+                                       stripe_size);
+      volume_dt_vars_view +=
+          boundary_interpolation_term *
+          dt_corrections[component_index * num_boundary_pts + boundary_index];
+    }
+  }
+}
+}  // namespace
+
+template <size_t Dim>
+void interpolate_dt_terms_gauss_points_impl(
+    const gsl::not_null<double*> volume_dt_vars,
+    const size_t num_independent_components, const Mesh<Dim>& volume_mesh,
+    const size_t dimension, const size_t num_boundary_pts,
+    const gsl::span<const double>& dt_corrections,
+    const DataVector& boundary_interpolation_term) noexcept {
+  const size_t num_volume_pts = volume_mesh.number_of_grid_points();
+  if (dimension == 0) {
+    interpolate_dt_terms_gauss_points_impl_xi_dir(
+        volume_dt_vars, num_independent_components, num_volume_pts,
+        num_boundary_pts, dt_corrections, boundary_interpolation_term);
+    return;
+  }
+
+  // Developer note: A potential optimization is to re-order (not transpose!)
+  // the volume time derivative for all variables before lifting, so that the
+  // lifting can be done using vectorized math and DataVectors as views. It
+  // would need to be tested whether that actually increases performance.
+  // Another alternative would be to use a SIMD library, such as nsimd or xsimd.
+
+  const size_t stripe_size = volume_mesh.extents(dimension);
+  size_t boundary_index = 0;
+  for (StripeIterator si{volume_mesh.extents(), dimension}; si;
+       (void)++si, (void)++boundary_index) {
+    // Loop over each stripe in this logical direction. This is effectively
+    // looping over each boundary grid point.
+    for (size_t component_index = 0;
+         component_index < num_independent_components; ++component_index) {
+      for (size_t index_on_stripe = 0; index_on_stripe < stripe_size;
+           ++index_on_stripe) {
+        const size_t volume_index = si.offset() + si.stride() * index_on_stripe;
+        volume_dt_vars.get()[component_index * num_volume_pts + volume_index] +=
+            boundary_interpolation_term[index_on_stripe] *
+            dt_corrections[component_index * num_boundary_pts + boundary_index];
+      }
+    }
+  }
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(r, data)                                                 \
+  template void interpolate_dt_terms_gauss_points_impl(                      \
+      gsl::not_null<double*> volume_dt_vars,                                 \
+      size_t num_independent_components, const Mesh<DIM(data)>& volume_mesh, \
+      size_t dimension, size_t num_boundary_pts,                             \
+      const gsl::span<const double>& dt_corrections,                         \
+      const DataVector& boundary_interpolation_term) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+#undef DIM
+}  // namespace evolution::dg::detail

--- a/src/Evolution/DiscontinuousGalerkin/InterpolateFromBoundary.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/InterpolateFromBoundary.hpp
@@ -1,0 +1,71 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Side.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace evolution::dg {
+namespace detail {
+template <size_t Dim>
+void interpolate_dt_terms_gauss_points_impl(
+    gsl::not_null<double*> volume_dt_vars, size_t num_independent_components,
+    const Mesh<Dim>& volume_mesh, size_t dimension, size_t num_boundary_pts,
+    const gsl::span<const double>& dt_corrections,
+    const DataVector& boundary_interpolation_term) noexcept;
+}  // namespace detail
+
+/*!
+ * \brief Interpolate the Bjorhus/time derivative corrections to the volume time
+ * derivatives in the specified direction.
+ *
+ * The general interpolation term (for the \f$+\xi\f$-dimension) is:
+ *
+ * \f{align*}{
+ *   \partial_t u_{\alpha\breve{\imath}\breve{\jmath}\breve{k}}=\cdots
+ *   +\ell^{\mathrm{Gauss-Lobatto}}_{N}
+ *    \left(\xi_{\breve{\imath}}^{\mathrm{Gauss}}\right)
+ *    \partial_t u^{\mathrm{BC}}_{\alpha\breve{\jmath}\breve{k}},
+ * \f}
+ *
+ * where \f$\breve{\imath}\f$, \f$\breve{\jmath}\f$, and \f$\breve{k}\f$ are
+ * indices in the logical \f$\xi\f$, \f$\eta\f$, and \f$\zeta\f$ dimensions.
+ * \f$\partial_t u^{\mathrm{BC}}\f$ is the time derivative correction, and
+ * the  function Spectral::boundary_interpolation_term() is used to compute and
+ * cache the terms from the lifting terms.
+ */
+template <size_t Dim, typename DtTagsList>
+void interpolate_dt_terms_gauss_points(
+    const gsl::not_null<Variables<DtTagsList>*> dt_vars,
+    const Mesh<Dim>& volume_mesh, const Direction<Dim>& direction,
+    const Variables<DtTagsList>& dt_corrections) noexcept {
+  ASSERT(std::all_of(volume_mesh.quadrature().begin(),
+                     volume_mesh.quadrature().end(),
+                     [](const Spectral::Quadrature quadrature) noexcept {
+                       return quadrature == Spectral::Quadrature::Gauss;
+                     }),
+         "Must use Gauss points in all directions but got the mesh: "
+             << volume_mesh);
+  const Mesh<Dim - 1> boundary_mesh =
+      volume_mesh.slice_away(direction.dimension());
+  const Mesh<1> volume_stripe_mesh =
+      volume_mesh.slice_through(direction.dimension());
+  const size_t num_boundary_grid_points = boundary_mesh.number_of_grid_points();
+  detail::interpolate_dt_terms_gauss_points_impl(
+      make_not_null(dt_vars->data()), dt_vars->number_of_independent_components,
+      volume_mesh, direction.dimension(), num_boundary_grid_points,
+      gsl::make_span(dt_corrections.data(), dt_corrections.size()),
+      direction.side() == Side::Upper
+          ? Spectral::boundary_interpolation_term(volume_stripe_mesh).second
+          : Spectral::boundary_interpolation_term(volume_stripe_mesh).first);
+}
+}  // namespace evolution::dg

--- a/src/NumericalAlgorithms/Spectral/Spectral.hpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.hpp
@@ -447,6 +447,40 @@ const std::pair<Matrix, Matrix>& boundary_interpolation_matrices(
 
 // @{
 /*!
+ * \brief Interpolates values from the boundary into the volume, which is needed
+ * when applying time derivative or Bjorhus-type boundary conditions in a
+ * discontinuous Galerkin scheme using Gauss points.
+ *
+ * Assumes that the logical coordinates are \f$[-1, 1]\f$.
+ * The interpolation is done by assuming the time derivative correction is zero
+ * on interior nodes. With a nodal Lagrange polynomial basis this means that
+ * only the \f$\ell^{\mathrm{Gauss-Lobatto}}_{0}\f$ and
+ * \f$\ell^{\mathrm{Gauss-Lobatto}}_{N}\f$ polynomials/basis functions
+ * contribute to the correction. In order to interpolate the correction from the
+ * nodes at the boundary, the Gauss-Lobatto Lagrange polynomials  must be
+ * evaluated at the Gauss grid points. The returned pair of `DataVector`s stores
+ *
+ * \f{align*}{
+ *   &\ell^{\mathrm{Gauss-Lobatto}}_{0}(\xi_j^{\mathrm{Gauss}}), \\
+ *   &\ell^{\mathrm{Gauss-Lobatto}}_{N}(\xi_j^{\mathrm{Gauss}}).
+ * \f}
+ *
+ * This is a different correction from lifting. Lifting is done using the mass
+ * matrix, which is an integral over the basis functions, while here we use
+ * interpolation.
+ *
+ * \warning This can only be called with Gauss points.
+ */
+const std::pair<DataVector, DataVector>& boundary_interpolation_term(
+    const Mesh<1>& mesh) noexcept;
+
+template <Basis BasisType, Quadrature QuadratureType>
+const std::pair<DataVector, DataVector>& boundary_interpolation_term(
+    size_t num_points) noexcept;
+// @}
+
+// @{
+/*!
  * \brief Terms used during the lifting portion of a discontinuous Galerkin
  * scheme when using Gauss points.
  *

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBRARY_SOURCES
   Initialization/Test_QuadratureTag.cpp
   Test_BoundaryCorrectionsHelper.cpp
   Test_InboxTags.cpp
+  Test_InterpolateFromBoundary.cpp
   Test_LiftFromBoundary.cpp
   Test_MortarData.cpp
   Test_MortarTags.cpp

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InterpolateFromBoundary.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InterpolateFromBoundary.cpp
@@ -1,0 +1,91 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/SliceIterator.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Evolution/DiscontinuousGalerkin/InterpolateFromBoundary.hpp"
+#include "NumericalAlgorithms/Interpolation/RegularGridInterpolant.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct Var1 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct Var2 : db::SimpleTag {
+  using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
+};
+
+template <size_t Dim>
+void test(const double eps) {
+  using dt_variables_tags = tmpl::list<Tags::dt<Var1>, Tags::dt<Var2<Dim>>>;
+  Mesh<Dim> volume_mesh{8, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::Gauss};
+  Mesh<Dim> volume_mesh_gl{8, Spectral::Basis::Legendre,
+                           Spectral::Quadrature::GaussLobatto};
+  CAPTURE(Dim);
+  CAPTURE(volume_mesh);
+  const double correction_value = 2.0e-3;
+
+  for (const auto& direction : Direction<Dim>::all_directions()) {
+    CAPTURE(direction);
+    Variables<dt_variables_tags> volume_dt{volume_mesh.number_of_grid_points(),
+                                           3.0};
+
+    Variables<dt_variables_tags> volume_dt_correction_gl{
+        volume_mesh_gl.number_of_grid_points(), 0.0};
+    for (SliceIterator si(volume_mesh.extents(), direction.dimension(),
+                          direction.side() == Side::Upper
+                              ? volume_mesh.extents(direction.dimension()) - 1
+                              : 0);
+         si; ++si) {
+      get(get<Tags::dt<Var1>>(volume_dt_correction_gl))[si.volume_offset()] =
+          correction_value;
+      for (size_t i = 0; i < Dim; ++i) {
+        get<Tags::dt<Var2<Dim>>>(volume_dt_correction_gl)
+            .get(i)[si.volume_offset()] = correction_value * (i + 2.0);
+      }
+    }
+    const Variables<dt_variables_tags> volume_dt_correction_gauss =
+        intrp::RegularGrid<Dim>{volume_mesh_gl, volume_mesh}.interpolate(
+            volume_dt_correction_gl);
+
+    const Variables<dt_variables_tags> expected_volume_dt_gauss =
+        volume_dt + volume_dt_correction_gauss;
+
+    Variables<dt_variables_tags> dt_correction_on_boundary{
+        volume_mesh.slice_away(direction.dimension()).number_of_grid_points(),
+        correction_value};
+    for (size_t i = 0; i < Dim; ++i) {
+      get<Tags::dt<Var2<Dim>>>(dt_correction_on_boundary).get(i) *= (2.0 + i);
+    }
+    evolution::dg::interpolate_dt_terms_gauss_points(make_not_null(&volume_dt),
+                                                     volume_mesh, direction,
+                                                     dt_correction_on_boundary);
+
+    Approx local_approx = Approx::custom().epsilon(eps).scale(1.0);
+    CHECK_ITERABLE_CUSTOM_APPROX(get<Tags::dt<Var1>>(volume_dt),
+                                 get<Tags::dt<Var1>>(expected_volume_dt_gauss),
+                                 local_approx);
+    CHECK_ITERABLE_CUSTOM_APPROX(
+        get<Tags::dt<Var2<Dim>>>(volume_dt),
+        get<Tags::dt<Var2<Dim>>>(expected_volume_dt_gauss), local_approx);
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.DG.InterpolateDtCorrection",
+                  "[Unit][Evolution]") {
+  test<1>(1.0e-14);
+  test<2>(1.0e-14);
+  test<3>(1.0e-14);
+}
+}  // namespace

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
@@ -520,6 +520,17 @@ void test_gauss_points_boundary_interpolation_and_lifting() noexcept {
       CHECK_ITERABLE_APPROX(DataVector{lift_lagrange_upper / quad_weights},
                             lifting_terms.second);
     }
+
+    const std::pair<DataVector, DataVector>& interp_terms =
+        Spectral::boundary_interpolation_term(local_mesh);
+    const Matrix interp_to_gauss_matrix = Spectral::interpolation_matrix(
+        Mesh<1>{n == 1 ? 2 : n, BasisType, Spectral::Quadrature::GaussLobatto},
+        Spectral::collocation_points<BasisType, QuadratureType>(n));
+
+    for (size_t i = 0; i < n; ++i) {
+      CHECK(approx(interp_terms.first[i]) == interp_to_gauss_matrix(i, 0));
+      CHECK(approx(interp_terms.second[i]) == interp_to_gauss_matrix(i, n - 1));
+    }
   }
 }
 }  // namespace


### PR DESCRIPTION
## Proposed changes

I don't know how to do Bjorhus boundary conditions when using Gauss points other than to interpolation the boundary time derivative correction to the Gauss points from a Gauss-Lobatto grid. This PR adds the interpolation functions and matrix calculations.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
