### PR TITLE
Fix missing dependencies

### DIFF
--- a/src/Elliptic/Systems/CMakeLists.txt
+++ b/src/Elliptic/Systems/CMakeLists.txt
@@ -12,6 +12,12 @@ spectre_target_headers(
   GetSourcesComputer.hpp
   )
 
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE
+  Utilities
+  )
+
 add_subdirectory(Elasticity)
 add_subdirectory(Poisson)
 add_subdirectory(Xcts)

--- a/src/Elliptic/Systems/GetSourcesComputer.hpp
+++ b/src/Elliptic/Systems/GetSourcesComputer.hpp
@@ -5,6 +5,8 @@
 
 #include <type_traits>
 
+#include "Utilities/TMPL.hpp"
+
 namespace elliptic {
 namespace detail {
 template <typename System, typename = std::void_t<>>

--- a/src/Parallel/CMakeLists.txt
+++ b/src/Parallel/CMakeLists.txt
@@ -59,6 +59,11 @@ target_link_libraries(
   Utilities
   )
 
+add_dependencies(
+  ${LIBRARY}
+  module_Main          # GlobalCache module depends on Main module
+  )
+
 add_subdirectory(Actions)
 add_subdirectory(Algorithms)
 add_subdirectory(PhaseControl)


### PR DESCRIPTION
## Proposed changes

Fix missing depenencies introduced in recent code changes.

### Further comments

Without these changes I am not able to compile SpECTRE with GCC 9.3.0.

`Parallel/GlobalCache` depends on `Main.decl.h`, but before it was not guaranteed that `Main.decl.h` was generated at the time GCC requested it.
