### PR TITLE
Fix vector comparison

### DIFF
--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -413,19 +413,19 @@ class Variables<tmpl::list<Tags...>> {
   void add_reference_variable_data() noexcept;
 
   friend bool operator==(const Variables& lhs, const Variables& rhs) noexcept {
-    return lhs.variable_data_ == rhs.variable_data_;
+    return blaze::equal<blaze::strict>(lhs.variable_data_, rhs.variable_data_);
   }
 
   template <typename VT, bool TF>
   friend bool operator==(const Variables& lhs,
                          const blaze::DenseVector<VT, TF>& rhs) noexcept {
-    return lhs.variable_data_ == *rhs;
+    return blaze::equal<blaze::strict>(lhs.variable_data_, *rhs);
   }
 
   template <typename VT, bool TF>
   friend bool operator==(const blaze::DenseVector<VT, TF>& lhs,
                          const Variables& rhs) noexcept {
-    return *lhs == rhs.variable_data_;
+    return blaze::equal<blaze::strict>(*lhs, rhs.variable_data_);
   }
 
   template <class FriendTags>

--- a/tests/Unit/DataStructures/Test_ApplyMatrices.cpp
+++ b/tests/Unit/DataStructures/Test_ApplyMatrices.cpp
@@ -146,10 +146,11 @@ struct CheckApply<LocalScalarTag, LocalTensorTag, Dim, Dim> {
       expected_t0[i + get(get<LocalScalarTag>(expected)).size()] =
           2.0 * expected_t0[i];
     }
-    CHECK(apply_matrices(ref_matrices, t0, source_mesh.extents()) ==
-          expected_t0);
-    CHECK(apply_matrices<DataType>(ref_matrices, t0, source_mesh.extents()) ==
-          expected_t0);
+    CHECK_ITERABLE_APPROX(
+        apply_matrices(ref_matrices, t0, source_mesh.extents()), expected_t0);
+    CHECK_ITERABLE_APPROX(
+        apply_matrices<DataType>(ref_matrices, t0, source_mesh.extents()),
+        expected_t0);
   }
 };
 

--- a/tests/Unit/DataStructures/Test_SpinWeighted.cpp
+++ b/tests/Unit/DataStructures/Test_SpinWeighted.cpp
@@ -183,7 +183,6 @@ void test_spinweights() {
 
 using SpinWeightedTypePairs =
     tmpl::list<tmpl::list<std::complex<double>, double>,
-               tmpl::list<ComplexDataVector, double>,
                tmpl::list<ComplexDataVector, std::complex<double>>>;
 
 SPECTRE_TEST_CASE("Unit.DataStructures.SpinWeighted",

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -318,6 +318,15 @@ void test_variables_math() noexcept {
 
   // Test math +, -, *, /
   const TestVariablesType vars{num_points, value_in_variables};
+  const TestVariablesType close{num_points,
+                                value_in_variables * (1.0 + 1.0e-14)};
+  CHECK(close != vars);
+  CHECK_FALSE(close == vars);
+  CHECK_VARIABLES_APPROX(close, vars);
+  const TestVariablesType equivalent{num_points, value_in_variables};
+  CHECK(equivalent == vars);
+  CHECK_FALSE(equivalent != vars);
+
   TestVariablesType expected{num_points, rand_vals.at(0) * value_in_variables};
   CHECK_VARIABLES_APPROX(expected, rand_vals[0] * vars);
   expected = TestVariablesType{num_points, value_in_variables * rand_vals[0]};

--- a/tests/Unit/Evolution/Conservative/Test_ConservativeDuDt.cpp
+++ b/tests/Unit/Evolution/Conservative/Test_ConservativeDuDt.cpp
@@ -255,11 +255,11 @@ void test(const Mesh<Dim>& mesh,
                                   DgFormulation>::apply(make_not_null(&dt_vars),
                                                         mesh, inverse_jacobian,
                                                         fluxes, sources);
-  CHECK(get(get<Tags::dt<Var1>>(dt_vars)) ==
-        -get(get<Tags::div<Flux1>>(expected_div_fluxes)));
+  CHECK_ITERABLE_APPROX(get(get<Tags::dt<Var1>>(dt_vars)),
+                        -get(get<Tags::div<Flux1>>(expected_div_fluxes)));
   for (size_t i = 0; i < Dim; ++i) {
-    CHECK(get<Tags::dt<Var2<Dim>>>(dt_vars).get(i) ==
-          -get<Tags::div<Flux2>>(expected_div_fluxes).get(i));
+    CHECK_ITERABLE_APPROX(get<Tags::dt<Var2<Dim>>>(dt_vars).get(i),
+                          -get<Tags::div<Flux2>>(expected_div_fluxes).get(i));
   }
 
   // Test with Tags::Source<Var1>
@@ -269,12 +269,12 @@ void test(const Mesh<Dim>& mesh,
                                   DgFormulation>::apply(make_not_null(&dt_vars),
                                                         mesh, inverse_jacobian,
                                                         fluxes, sources);
-  CHECK(get(get<Tags::dt<Var1>>(dt_vars)) ==
-        -get(get<Tags::div<Flux1>>(expected_div_fluxes)) +
-            get(get<Tags::Source<Var1>>(sources)));
+  CHECK_ITERABLE_APPROX(get(get<Tags::dt<Var1>>(dt_vars)),
+                        -get(get<Tags::div<Flux1>>(expected_div_fluxes)) +
+                            get(get<Tags::Source<Var1>>(sources)));
   for (size_t i = 0; i < Dim; ++i) {
-    CHECK(get<Tags::dt<Var2<Dim>>>(dt_vars).get(i) ==
-          -get<Tags::div<Flux2>>(expected_div_fluxes).get(i));
+    CHECK_ITERABLE_APPROX(get<Tags::dt<Var2<Dim>>>(dt_vars).get(i),
+                          -get<Tags::div<Flux2>>(expected_div_fluxes).get(i));
   }
 
   // Test with Tags::Source<Var2>
@@ -287,12 +287,12 @@ void test(const Mesh<Dim>& mesh,
                                   DgFormulation>::apply(make_not_null(&dt_vars),
                                                         mesh, inverse_jacobian,
                                                         fluxes, sources);
-  CHECK(get(get<Tags::dt<Var1>>(dt_vars)) ==
+  CHECK_ITERABLE_APPROX(get(get<Tags::dt<Var1>>(dt_vars)),
         -get(get<Tags::div<Flux1>>(expected_div_fluxes)));
   for (size_t i = 0; i < Dim; ++i) {
-    CHECK(get<Tags::dt<Var2<Dim>>>(dt_vars).get(i) ==
-          -get<Tags::div<Flux2>>(expected_div_fluxes).get(i) +
-              get<Tags::Source<Var2<Dim>>>(sources).get(i));
+    CHECK_ITERABLE_APPROX(get<Tags::dt<Var2<Dim>>>(dt_vars).get(i),
+                          -get<Tags::div<Flux2>>(expected_div_fluxes).get(i) +
+                              get<Tags::Source<Var2<Dim>>>(sources).get(i));
   }
 
   // Test with both sources
@@ -300,13 +300,13 @@ void test(const Mesh<Dim>& mesh,
                                   DgFormulation>::apply(make_not_null(&dt_vars),
                                                         mesh, inverse_jacobian,
                                                         fluxes, sources);
-  CHECK(get(get<Tags::dt<Var1>>(dt_vars)) ==
-        -get(get<Tags::div<Flux1>>(expected_div_fluxes)) +
-            get(get<Tags::Source<Var1>>(sources)));
+  CHECK_ITERABLE_APPROX(get(get<Tags::dt<Var1>>(dt_vars)),
+                        -get(get<Tags::div<Flux1>>(expected_div_fluxes)) +
+                            get(get<Tags::Source<Var1>>(sources)));
   for (size_t i = 0; i < Dim; ++i) {
-    CHECK(get<Tags::dt<Var2<Dim>>>(dt_vars).get(i) ==
-          -get<Tags::div<Flux2>>(expected_div_fluxes).get(i) +
-              get<Tags::Source<Var2<Dim>>>(sources).get(i));
+    CHECK_ITERABLE_APPROX(get<Tags::dt<Var2<Dim>>>(dt_vars).get(i),
+                          -get<Tags::div<Flux2>>(expected_div_fluxes).get(i) +
+                              get<Tags::Source<Var2<Dim>>>(sources).get(i));
   }
 }
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Krivodonova.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Krivodonova.cpp
@@ -83,13 +83,15 @@ void test_package_data(const size_t order) noexcept {
                              mesh, {});
     ModalVector expected0(mesh.number_of_grid_points(), 0.0);
     expected0[mesh.number_of_grid_points() - 1] = 1.0;
-    CHECK(get(get<::Tags::Modal<ScalarTag<0>>>(
-              packaged_data.modal_volume_data)) == expected0);
+    CHECK_ITERABLE_APPROX(
+        get(get<::Tags::Modal<ScalarTag<0>>>(packaged_data.modal_volume_data)),
+        expected0);
     ModalVector expected1(mesh.number_of_grid_points(), 0.0);
     expected1[mesh.number_of_grid_points() - 1] = 1.0;
     expected1[mesh.number_of_grid_points() - 2] = 2.0;
-    CHECK(get<0>(get<::Tags::Modal<VectorTag<1, 0>>>(
-              packaged_data.modal_volume_data)) == expected1);
+    CHECK_ITERABLE_APPROX(SINGLE_ARG(get<0>(get<::Tags::Modal<VectorTag<1, 0>>>(
+                              packaged_data.modal_volume_data))),
+                          expected1);
   }
   // test reorienting
   {
@@ -98,13 +100,15 @@ void test_package_data(const size_t order) noexcept {
         {{{Direction<1>::upper_xi()}}, {{Direction<1>::lower_xi()}}});
     ModalVector expected0(mesh.number_of_grid_points(), 0.0);
     expected0[0] = 1.0;
-    CHECK(get(get<::Tags::Modal<ScalarTag<0>>>(
-              packaged_data.modal_volume_data)) == expected0);
+    CHECK_ITERABLE_APPROX(
+        get(get<::Tags::Modal<ScalarTag<0>>>(packaged_data.modal_volume_data)),
+        expected0);
     ModalVector expected1(mesh.number_of_grid_points(), 0.0);
     expected1[0] = 1.0;
     expected1[1] = 2.0;
-    CHECK(get<0>(get<::Tags::Modal<VectorTag<1, 0>>>(
-              packaged_data.modal_volume_data)) == expected1);
+    CHECK_ITERABLE_APPROX(SINGLE_ARG(get<0>(get<::Tags::Modal<VectorTag<1, 0>>>(
+                              packaged_data.modal_volume_data))),
+                          expected1);
   }
 }
 
@@ -1017,12 +1021,14 @@ void test_package_data() noexcept {
   {
     krivodonova.package_data(make_not_null(&packaged_data), tensor0, tensor1,
                              mesh, {});
-    CHECK(get(get<::Tags::Modal<ScalarTag<0>>>(
-              packaged_data.modal_volume_data)) == neighbor_modes);
+    CHECK_ITERABLE_APPROX(
+        get(get<::Tags::Modal<ScalarTag<0>>>(packaged_data.modal_volume_data)),
+        neighbor_modes);
     for (size_t d = 0; d < dim; ++d) {
-      CHECK(
-          get<::Tags::Modal<VectorTag<dim, 0>>>(packaged_data.modal_volume_data)
-              .get(d) == ModalVector((d + 2.0) * neighbor_modes));
+      CHECK_ITERABLE_APPROX(SINGLE_ARG(get<::Tags::Modal<VectorTag<dim, 0>>>(
+                                           packaged_data.modal_volume_data)
+                                           .get(d)),
+                            ModalVector((d + 2.0) * neighbor_modes));
     }
   }
   // test reorienting
@@ -1035,12 +1041,14 @@ void test_package_data() noexcept {
     const ModalVector expected_modes{
         0.0, 6.0, 12.0, 18.0, 2.0, 8.0, 14.0, 20.0, 4.0, 10.0, 16.0, 22.0,
         1.0, 7.0, 13.0, 19.0, 3.0, 9.0, 15.0, 21.0, 5.0, 11.0, 17.0, 23.0};
-    CHECK(get(get<::Tags::Modal<ScalarTag<0>>>(
-              packaged_data.modal_volume_data)) == expected_modes);
+    CHECK_ITERABLE_APPROX(
+        get(get<::Tags::Modal<ScalarTag<0>>>(packaged_data.modal_volume_data)),
+        expected_modes);
     for (size_t d = 0; d < dim; ++d) {
-      CHECK(
-          get<::Tags::Modal<VectorTag<dim, 0>>>(packaged_data.modal_volume_data)
-              .get(d) == ModalVector((d + 2.0) * expected_modes));
+      CHECK_ITERABLE_APPROX(SINGLE_ARG(get<::Tags::Modal<VectorTag<dim, 0>>>(
+                                           packaged_data.modal_volume_data)
+                                           .get(d)),
+                            ModalVector((d + 2.0) * expected_modes));
     }
   }
 }

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_ProjectToBoundary.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_ProjectToBoundary.cpp
@@ -93,44 +93,50 @@ void test(const Spectral::Quadrature quadrature) {
         face_mesh.number_of_grid_points(), 0.0};
     evolution::dg::project_tensors_to_boundary<tmpl::list<Var2>>(
         make_not_null(&face_values), volume_data, volume_mesh, direction);
-    CHECK(get<Var1>(face_values) == expected_var1);
-    CHECK(get<Var2>(face_values) == get<Var2>(expected_face_values));
-    CHECK(get<Var3>(face_values) == expected_var3);
+    CHECK_ITERABLE_APPROX(get<Var1>(face_values), expected_var1);
+    CHECK_ITERABLE_APPROX(get<Var2>(face_values),
+                          get<Var2>(expected_face_values));
+    CHECK_ITERABLE_APPROX(get<Var3>(face_values), expected_var3);
 
     evolution::dg::project_tensors_to_boundary<tmpl::list<Var3>>(
         make_not_null(&face_values), volume_data, volume_mesh, direction);
-    CHECK(get<Var1>(face_values) == expected_var1);
-    CHECK(get<Var2>(face_values) == get<Var2>(expected_face_values));
-    CHECK(get<Var3>(face_values) == get<Var3>(expected_face_values));
+    CHECK_ITERABLE_APPROX(get<Var1>(face_values), expected_var1);
+    CHECK_ITERABLE_APPROX(get<Var2>(face_values),
+                          get<Var2>(expected_face_values));
+    CHECK_ITERABLE_APPROX(get<Var3>(face_values),
+                          get<Var3>(expected_face_values));
 
     face_values.initialize(face_mesh.number_of_grid_points(), 0.0);
     evolution::dg::project_tensors_to_boundary<tmpl::list<Var2, Var3>>(
         make_not_null(&face_values), volume_data, volume_mesh, direction);
-    CHECK(get<Var1>(face_values) == expected_var1);
-    CHECK(get<Var2>(face_values) == get<Var2>(expected_face_values));
-    CHECK(get<Var3>(face_values) == get<Var3>(expected_face_values));
+    CHECK_ITERABLE_APPROX(get<Var1>(face_values), expected_var1);
+    CHECK_ITERABLE_APPROX(get<Var2>(face_values),
+                          get<Var2>(expected_face_values));
+    CHECK_ITERABLE_APPROX(get<Var3>(face_values),
+                          get<Var3>(expected_face_values));
 
     Variables<tmpl::list<Var1, Var2, Var3>> face_values_contiguous_project{
         face_mesh.number_of_grid_points(), 0.0};
     evolution::dg::project_contiguous_data_to_boundary(
         make_not_null(&face_values_contiguous_project), volume_data,
         volume_mesh, direction);
-    CHECK(get<Var1>(face_values_contiguous_project) == expected_var1);
-    CHECK(get<Var2>(face_values_contiguous_project) ==
-          get<Var2>(expected_face_values));
-    CHECK(get<Var3>(face_values_contiguous_project) ==
-          get<Var3>(expected_face_values));
+    CHECK_ITERABLE_APPROX(get<Var1>(face_values_contiguous_project),
+                          expected_var1);
+    CHECK_ITERABLE_APPROX(get<Var2>(face_values_contiguous_project),
+                          get<Var2>(expected_face_values));
+    CHECK_ITERABLE_APPROX(get<Var3>(face_values_contiguous_project),
+                          get<Var3>(expected_face_values));
 
     Scalar<DataVector> var3_face{face_mesh.number_of_grid_points()};
     evolution::dg::project_tensor_to_boundary(
         make_not_null(&var3_face), var3_volume, volume_mesh, direction);
-    CHECK(var3_face == get<Var3>(expected_face_values));
+    CHECK_ITERABLE_APPROX(var3_face, get<Var3>(expected_face_values));
 
     tnsr::I<DataVector, 2, Frame::Inertial> var2_face{
         face_mesh.number_of_grid_points()};
     evolution::dg::project_tensor_to_boundary(
         make_not_null(&var2_face), var2_volume, volume_mesh, direction);
-    CHECK(var2_face == get<Var2>(expected_face_values));
+    CHECK_ITERABLE_APPROX(var2_face, get<Var2>(expected_face_values));
   }
 }
 }  // namespace

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_UpwindPenaltyCorrection.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_UpwindPenaltyCorrection.cpp
@@ -169,7 +169,7 @@ void test_upwind_flux_random() noexcept {
       CurvedScalarWave::CurvedScalarWave_detail::weight_char_fields<Dim>(
           char_fields_int, char_speeds_minus_one, char_fields_ext,
           char_speeds_minus_one);
-  CHECK(weighted_char_fields_minus_one == -1. * char_fields_ext);
+  CHECK_VARIABLES_APPROX(-1. * char_fields_ext, weighted_char_fields_minus_one);
 
   // Check scaling by 5 instead of 1
   const auto weighted_char_fields_minus_five =
@@ -179,8 +179,9 @@ void test_upwind_flux_random() noexcept {
   const auto weighted_char_fields_five =
       CurvedScalarWave::CurvedScalarWave_detail::weight_char_fields<Dim>(
           char_fields_int, char_speeds_five, char_fields_ext, char_speeds_five);
-  CHECK(weighted_char_fields_minus_five == -5. * char_fields_ext);
-  CHECK(weighted_char_fields_five == 5. * char_fields_int);
+  CHECK_VARIABLES_APPROX(weighted_char_fields_minus_five,
+                         -5. * char_fields_ext);
+  CHECK_VARIABLES_APPROX(weighted_char_fields_five, 5. * char_fields_int);
 
   // Check that if the same fields are given for the interior and exterior
   // (except that the normal vector gets multiplied by -1.0) that the

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/NumericalFluxes/Test_Hllc.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/NumericalFluxes/Test_Hllc.cpp
@@ -147,9 +147,11 @@ void apply_hllc(
       hllc_flux{}, packaged_data_int, packaged_data_ext,
       n_dot_num_f_mass_density, n_dot_num_f_momentum_density,
       n_dot_num_f_energy_density);
-  CHECK(*n_dot_num_f_mass_density == n_dot_f_mass_density_int);
-  CHECK(*n_dot_num_f_momentum_density == n_dot_f_momentum_density_int);
-  CHECK(*n_dot_num_f_energy_density == n_dot_f_energy_density_int);
+  CHECK_ITERABLE_APPROX(*n_dot_num_f_mass_density, n_dot_f_mass_density_int);
+  CHECK_ITERABLE_APPROX(*n_dot_num_f_momentum_density,
+                        n_dot_f_momentum_density_int);
+  CHECK_ITERABLE_APPROX(*n_dot_num_f_energy_density,
+                        n_dot_f_energy_density_int);
 
   // Now package different exterior data.
   packaged_data_ext = TestHelpers::NumericalFluxes::get_packaged_data(
@@ -179,12 +181,13 @@ void apply_hllc(
       make_not_null(&minus_n_dot_num_f_mass_density),
       make_not_null(&minus_n_dot_num_f_momentum_density),
       make_not_null(&minus_n_dot_num_f_energy_density));
-  CHECK(get(*n_dot_num_f_mass_density) == -get(minus_n_dot_num_f_mass_density));
-  CHECK(get(*n_dot_num_f_energy_density) ==
-        -get(minus_n_dot_num_f_energy_density));
+  CHECK_ITERABLE_APPROX(get(*n_dot_num_f_mass_density),
+                        -get(minus_n_dot_num_f_mass_density));
+  CHECK_ITERABLE_APPROX(get(*n_dot_num_f_energy_density),
+                        -get(minus_n_dot_num_f_energy_density));
   for (size_t i = 0; i < Dim; ++i) {
-    CHECK(n_dot_num_f_momentum_density->get(i) ==
-          -minus_n_dot_num_f_momentum_density.get(i));
+    CHECK_ITERABLE_APPROX(n_dot_num_f_momentum_density->get(i),
+                          -minus_n_dot_num_f_momentum_density.get(i));
   }
 }
 

--- a/tests/Unit/Helpers/DataStructures/VectorImplTestHelper.hpp
+++ b/tests/Unit/Helpers/DataStructures/VectorImplTestHelper.hpp
@@ -77,6 +77,44 @@ void vector_test_construct_and_assign(
   CHECK(gsl::at(initializer_list_constructed, 0) == generated_value2);
   CHECK(gsl::at(initializer_list_constructed, 1) == generated_value3);
 
+  // check equality operators do not perform approximate comparison
+  CHECK(SINGLE_ARG(
+      initializer_list_constructed ==
+      VectorType{
+          {static_cast<typename VectorType::value_type>(generated_value2),
+           static_cast<typename VectorType::value_type>(generated_value3)}}));
+  CHECK_FALSE(SINGLE_ARG(
+      initializer_list_constructed !=
+      VectorType{
+          {static_cast<typename VectorType::value_type>(generated_value2),
+           static_cast<typename VectorType::value_type>(generated_value3)}}));
+  const VectorType close = (1.0 + 1.0e-14) * initializer_list_constructed;
+  CHECK(initializer_list_constructed != close);
+  CHECK_FALSE(initializer_list_constructed == close);
+  CHECK_ITERABLE_APPROX(initializer_list_constructed, close);
+
+  CHECK(
+      initializer_list_constructed !=
+      (initializer_list_constructed + 1.0e-11 * initializer_list_constructed));
+  CHECK_FALSE(
+      initializer_list_constructed ==
+      (initializer_list_constructed + 1.0e-11 * initializer_list_constructed));
+  CHECK(initializer_list_constructed !=
+        static_cast<typename VectorType::value_type>(generated_value2));
+  CHECK(static_cast<typename VectorType::value_type>(generated_value2) !=
+        initializer_list_constructed);
+  CHECK_FALSE(initializer_list_constructed ==
+              static_cast<typename VectorType::value_type>(generated_value2));
+  CHECK_FALSE(static_cast<typename VectorType::value_type>(generated_value2) ==
+              initializer_list_constructed);
+
+  CHECK(
+      (initializer_list_constructed - 1.0e-11 * initializer_list_constructed) !=
+      (initializer_list_constructed + 1.0e-11 * initializer_list_constructed));
+  CHECK_FALSE(
+      (initializer_list_constructed - 1.0e-11 * initializer_list_constructed) ==
+      (initializer_list_constructed + 1.0e-11 * initializer_list_constructed));
+
   // NOLINTNEXTLINE(modernize-avoid-c-arrays)
   typename VectorType::value_type raw_ptr[2] = {generated_value2,
                                                 generated_value3};

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -1334,11 +1334,13 @@ void test_impl(const Spectral::Quadrature quadrature,
     get(get<::Tags::dt<Var1>>(expected_dt_evolved_vars)) += 5.0;
   }
 
-  CHECK(ActionTesting::get_databox_tag<
-            component<metavars>,
-            db::add_tag_prefix<::Tags::dt,
-                               typename metavars::system::variables_tag>>(
-            runner, self_id) == expected_dt_evolved_vars);
+  CHECK_VARIABLES_APPROX(
+      SINGLE_ARG(ActionTesting::get_databox_tag<
+                 component<metavars>,
+                 db::add_tag_prefix<::Tags::dt,
+                                    typename metavars::system::variables_tag>>(
+          runner, self_id)),
+      expected_dt_evolved_vars);
 
   const auto mortar_id_east =
       std::make_pair(Direction<Dim>::upper_xi(), east_id);

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp
@@ -376,7 +376,8 @@ void test_boundary_correction_conservation_impl(
     });
     {
       INFO("Check weak and strong boundary terms match.");
-      CHECK(boundary_corrections == expected_boundary_corrections);
+      CHECK_VARIABLES_APPROX(boundary_corrections,
+                             expected_boundary_corrections);
     }
 
     if (zero_on_smooth_solution == ZeroOnSmoothSolution::Yes) {

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_FiniteDifference.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_FiniteDifference.cpp
@@ -13,9 +13,11 @@
 namespace Spectral {
 SPECTRE_TEST_CASE("Unit.Numerical.Spectral.Fd.Points",
                   "[NumericalAlgorithms][Spectral][Unit]") {
-  CHECK(
-      DataVector{-2.0 / 3.0, 0.0, 2.0 / 3.0} ==
-      collocation_points<Basis::FiniteDifference, Quadrature::CellCentered>(3));
+  CHECK_ITERABLE_APPROX(
+      SINGLE_ARG(DataVector{-2.0 / 3.0, 0.0, 2.0 / 3.0}),
+      SINGLE_ARG(
+          collocation_points<Basis::FiniteDifference, Quadrature::CellCentered>(
+              3)));
   CHECK(
       DataVector{-0.75, -0.25, 0.25, 0.75} ==
       collocation_points<Basis::FiniteDifference, Quadrature::CellCentered>(4));
@@ -25,9 +27,11 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.Fd.Points",
   CHECK(
       DataVector{-1.0, 0.0, 1.0} ==
       collocation_points<Basis::FiniteDifference, Quadrature::FaceCentered>(3));
-  CHECK(
-      DataVector{-1.0, -1.0 / 3.0, 1.0 / 3.0, 1.0} ==
-      collocation_points<Basis::FiniteDifference, Quadrature::FaceCentered>(4));
+  CHECK_ITERABLE_APPROX(
+      SINGLE_ARG(DataVector{-1.0, -1.0 / 3.0, 1.0 / 3.0, 1.0}),
+      SINGLE_ARG(
+          collocation_points<Basis::FiniteDifference, Quadrature::FaceCentered>(
+              4)));
   CHECK(get_output(Quadrature::FaceCentered) == "FaceCentered");
 }
 }  // namespace Spectral

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
@@ -484,8 +484,8 @@ void test_shift_deriv_functions_analytic(
   CHECK_ITERABLE_APPROX(dt_shift_expected, dt_shift);
   CHECK_ITERABLE_APPROX(d_shift_expected, d_shift);
   CHECK_ITERABLE_APPROX(d4_norm_of_shift_expected, d4_norm_shift);
-  CHECK(get(shift_dot_dt_lower_shift_expected) ==
-        get(shift_dot_dt_lower_shift));
+  CHECK_ITERABLE_APPROX(get(shift_dot_dt_lower_shift_expected),
+                        get(shift_dot_dt_lower_shift));
 }
 
 // Test computation of derivs of spatial metric by comparing to Kerr-Schild
@@ -831,16 +831,20 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.GhQuantities",
           GeneralizedHarmonic::Tags::DerivLapseCompute<3, Frame::Inertial>,
           GeneralizedHarmonic::Tags::DerivShiftCompute<3, Frame::Inertial>>>(
       lapse, spacetime_normal_vector, inverse_spacetime_metric, expected_phi);
-  CHECK(
-      db::get<
-          ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
-                        tmpl::size_t<3>, Frame::Inertial>>(box) ==
+  CHECK_ITERABLE_APPROX(
+      SINGLE_ARG(db::get<::Tags::deriv<
+                     gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+                     tmpl::size_t<3>, Frame::Inertial>>(box)),
       expected_deriv_spatial_metric);
-  CHECK(db::get<::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,
-                              Frame::Inertial>>(box) == expected_deriv_lapse);
-  CHECK(db::get<::Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
-                              tmpl::size_t<3>, Frame::Inertial>>(box) ==
-        expected_deriv_shift);
+  CHECK_ITERABLE_APPROX(
+      SINGLE_ARG(db::get<::Tags::deriv<gr::Tags::Lapse<DataVector>,
+                                       tmpl::size_t<3>, Frame::Inertial>>(box)),
+      expected_deriv_lapse);
+  CHECK_ITERABLE_APPROX(
+      SINGLE_ARG(
+          db::get<::Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+                                tmpl::size_t<3>, Frame::Inertial>>(box)),
+      expected_deriv_shift);
 
   const auto other_box = db::create<
       db::AddSimpleTags<
@@ -859,14 +863,19 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.GhQuantities",
                                                            Frame::Inertial>>>(
       lapse, shift, spacetime_normal_vector, inverse_spacetime_metric,
       inverse_spatial_metric, expected_phi, expected_pi);
-  CHECK(
-      db::get<
-          ::Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>>(
-          other_box) == expected_dt_spatial_metric);
-  CHECK(db::get<::Tags::dt<gr::Tags::Lapse<DataVector>>>(other_box) ==
-        expected_dt_lapse);
-  CHECK(db::get<::Tags::dt<gr::Tags::Shift<3, Frame::Inertial, DataVector>>>(
-            other_box) == expected_dt_shift);
+  CHECK_ITERABLE_APPROX(
+      SINGLE_ARG(db::get<::Tags::dt<
+                     gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>>(
+          other_box)),
+      expected_dt_spatial_metric);
+  CHECK_ITERABLE_APPROX(
+      SINGLE_ARG(db::get<::Tags::dt<gr::Tags::Lapse<DataVector>>>(other_box)),
+      expected_dt_lapse);
+  CHECK_ITERABLE_APPROX(
+      SINGLE_ARG(
+          db::get<::Tags::dt<gr::Tags::Shift<3, Frame::Inertial, DataVector>>>(
+              other_box)),
+      expected_dt_shift);
 
   const auto ghvars_box = db::create<
       db::AddSimpleTags<

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -322,8 +322,11 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
       db::AddComputeTags<
           gr::Tags::SpacetimeMetricCompute<3, Frame::Inertial, DataVector>>>(
       expected_spatial_metric, expected_lapse, expected_shift);
-  CHECK(db::get<gr::Tags::SpacetimeMetric<3, Frame::Inertial, DataVector>>(
-            second_box) == expected_spacetime_metric);
+  CHECK_ITERABLE_APPROX(
+      SINGLE_ARG(
+          db::get<gr::Tags::SpacetimeMetric<3, Frame::Inertial, DataVector>>(
+              second_box)),
+      expected_spacetime_metric);
 
   // Now let's put the temporal and spatial derivatives of lapse, shift, and
   // spatial metric into the databox and test that we can assemple the


### PR DESCRIPTION
## Proposed changes

Fixes #2978.

It turns out, there were a number of places where we mistakenly used the == in tests. I have changed all such instances to `CHECK...APPROX` as appropriate.

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->
Be sure to use `==` on `Variables` and vectors only where you actually mean strict (bitwise) equality. Otherwise, use `CHECK...APPROX` in tests.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
