### PR TITLE
Allow different boundary conditions on bases and mantle of cylinder

### DIFF
--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -27,15 +27,21 @@ DomainCreator:
     OuterRadius: 0.6
     LowerBound: 0
     UpperBound: 0.3
-    IsPeriodicInZ: False
     InitialRefinement: 0
     InitialGridPoints: [3, 3, 4]
     UseEquiangularMap: True
     RadialPartitioning: []
     HeightPartitioning: []
-    BoundaryCondition:
-      AnalyticSolution:
-        Displacement: Dirichlet
+    BoundaryConditions:
+      Lower:
+        AnalyticSolution:
+          Displacement: Dirichlet
+      Upper:
+        AnalyticSolution:
+          Displacement: Dirichlet
+      Mantle:
+        AnalyticSolution:
+          Displacement: Dirichlet
 
 NumericalFlux:
   InternalPenalty:


### PR DESCRIPTION
## Proposed changes

Extend boundary condition support for the Cylinder domain creator to allow for different boundary conditions on each base (in upper/lower z-direction) and on the mantle (in radial direction). Also add support for boundary conditions when the cylinder is partitioned radially and along its height into extra blocks.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
