### PR TITLE
Add visit and return phase change, and interface helpers

### DIFF
--- a/src/Parallel/PhaseControl/CMakeLists.txt
+++ b/src/Parallel/PhaseControl/CMakeLists.txt
@@ -5,6 +5,7 @@ spectre_target_headers(
   Parallel
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  ExecutePhaseChange.hpp
   PhaseChange.hpp
   PhaseControlTags.hpp
   )

--- a/src/Parallel/PhaseControl/CMakeLists.txt
+++ b/src/Parallel/PhaseControl/CMakeLists.txt
@@ -8,4 +8,5 @@ spectre_target_headers(
   ExecutePhaseChange.hpp
   PhaseChange.hpp
   PhaseControlTags.hpp
+  VisitAndReturn.hpp
   )

--- a/src/Parallel/PhaseControl/ExecutePhaseChange.hpp
+++ b/src/Parallel/PhaseControl/ExecutePhaseChange.hpp
@@ -1,0 +1,190 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <tuple>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Parallel/AlgorithmMetafunctions.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Main.hpp"
+#include "Parallel/PhaseControl/PhaseChange.hpp"
+#include "Parallel/PhaseControl/PhaseControlTags.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace PhaseControl {
+namespace Actions {
+
+/*!
+ * \ingroup ActionsGroup
+ * \brief Check if any triggers are activated, and perform phase changes as
+ * needed.
+ *
+ * This action is intended to be executed on every component that repeatedly
+ * runs iterable actions that would need to halt during a phase change. This
+ * action sends data to the Main chare via a reduction.
+ *
+ * This action iterates over the `Tags::PhaseChangeAndTriggers`, sending
+ * reduction data for the phase decision for each triggered `PhaseChange`, then
+ * halts the algorithm execution so that the `Main` chare can make a phase
+ * decision if any were triggered.
+ *
+ * Uses:
+ * - GlobalCache: `Tags::PhaseChangeAndTriggers`
+ * - DataBox: As specified by the `PhaseChange` option-created objects.
+ *   - `PhaseChange` objects are permitted to perform mutations on the
+ *     \ref DataBoxGroup "DataBox" to store persistent state information.
+ */
+template <typename PhaseChangeRegistrars, typename TriggerRegistrars>
+struct ExecutePhaseChange {
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTags>&&, Parallel::AlgorithmExecution> apply(
+      db::DataBox<DbTags>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index, const ActionList /*meta*/,
+      const ParallelComponent* const /*component*/) noexcept {
+    const auto& phase_change_and_triggers = Parallel::get<
+        Tags::PhaseChangeAndTriggers<PhaseChangeRegistrars, TriggerRegistrars>>(
+        cache);
+    bool should_halt = false;
+    for (const auto& [trigger, phase_changes] : phase_change_and_triggers) {
+      if (trigger->is_triggered(box)) {
+        for (const auto& phase_change : phase_changes) {
+          phase_change->template contribute_phase_data<ParallelComponent>(
+              make_not_null(&box), cache, array_index);
+        }
+        should_halt = true;
+      }
+    }
+    // if we halt, we need to make sure that the Main chare knows that it is
+    // because we are requesting phase change arbitration, regardless of what
+    // data was actually sent to make that decision.
+    if (should_halt) {
+      if constexpr (std::is_same_v<typename ParallelComponent::chare_type,
+                    Parallel::Algorithms::Array>) {
+        Parallel::contribute_to_phase_change_reduction<ParallelComponent>(
+            tuples::TaggedTuple<TagsAndCombines::UsePhaseChangeArbitration>{
+                true},
+            cache, array_index);
+      } else {
+        Parallel::contribute_to_phase_change_reduction<ParallelComponent>(
+            tuples::TaggedTuple<TagsAndCombines::UsePhaseChangeArbitration>{
+                true},
+            cache);
+      }
+    }
+    return {std::move(box), should_halt
+                                ? Parallel::AlgorithmExecution::Halt
+                                : Parallel::AlgorithmExecution::Continue};
+  }
+};
+}  // namespace Actions
+
+/*!
+ * \brief Use the runtime data aggregated in `phase_change_decision_data` to
+ * decide which phase to execute next.
+ *
+ * \details This function will iterate through each of the option-created pairs
+ * of `PhaseChange`s, and obtain from each a
+ * `std::optional<std::pair<Metavariables::Phase,
+ * PhaseControl::ArbitrationStrategy>`. Any `std::nullopt` is skipped. If all
+ * `PhaseChange`s provide `std::nullopt`, the phase will either keep its
+ * current value (if the halt was caused by one of the triggers associated with
+ * an  option-created `PhaseChange`), or this function will return a
+ * `std::nullopt` as well (otherwise), indicating that the phase should proceed
+ * according to other information, such as global ordering.
+ *
+ * In the case of a `PhaseControl::ArbitrationStrategy::RunPhaseImmediately`,
+ * the first such return value is immediately run, and no further `PhaseChange`s
+ * are queried for their input.
+ *
+ * \note There can be cases where multiple triggers activate, and/or multiple
+ * `PhaseChange` objects have data in a state for which they would request a
+ * specific phase. When multiple phases are requested, arbitration will
+ * proceed in order of appearance in the `PhaseChangeAndTriggers`, determined
+ * from the input file options. Therefore, if that order of execution is
+ * important for the logic of the executable, the input file ordering and
+ * `ArbitrationStrategy` must be chosen carefully.
+ */
+template <typename PhaseChangeRegistrars, typename TriggerRegistrars,
+          typename... DecisionTags, typename Metavariables>
+typename std::optional<typename Metavariables::Phase> arbitrate_phase_change(
+    const gsl::not_null<tuples::TaggedTuple<DecisionTags...>*>
+        phase_change_decision_data,
+    typename Metavariables::Phase current_phase,
+    const Parallel::GlobalCache<Metavariables>& cache) noexcept {
+  const auto& phase_change_and_triggers = Parallel::get<
+      Tags::PhaseChangeAndTriggers<PhaseChangeRegistrars, TriggerRegistrars>>(
+      cache);
+  bool phase_chosen = false;
+  for (const auto& [trigger, phase_changes] : phase_change_and_triggers) {
+    // avoid unused variable warning
+    (void)trigger;
+    for (const auto& phase_change : phase_changes) {
+      const auto phase_result = phase_change->arbitrate_phase_change(
+          phase_change_decision_data, current_phase, cache);
+      if (phase_result.has_value()) {
+        if (phase_result.value().second ==
+            ArbitrationStrategy::RunPhaseImmediately) {
+          tuples::get<TagsAndCombines::UsePhaseChangeArbitration>(
+              *phase_change_decision_data) = false;
+          return phase_result.value().first;
+        }
+        current_phase = phase_result.value().first;
+        phase_chosen = true;
+      }
+    }
+  }
+  if (tuples::get<TagsAndCombines::UsePhaseChangeArbitration>(
+          *phase_change_decision_data) == false and
+      not phase_chosen) {
+    return std::nullopt;
+  }
+  // if no phase change object suggests a specific phase, return to execution
+  // in the current phase.
+  tuples::get<TagsAndCombines::UsePhaseChangeArbitration>(
+      *phase_change_decision_data) = false;
+  return current_phase;
+}
+
+/*!
+ * \brief Initialize the Main chare's `phase_change_decision_data` for the
+ * option-selected `PhaseChange`s.
+ *
+ * \details This struct provides a convenient method of specifying the
+ * initialization of the `phase_change_decision_data`. To instruct the Main
+ * chare to use this initialization routine, define the type alias in the
+ * `Metavariables`:
+ * ```
+ * using initialize_phase_data =
+ *   PhaseControl::InitializePhaseChangeDecisionData<
+ *       phase_change_registrars, trigger_registrars>;
+ * ```
+ */
+template <typename PhaseChangeRegistrars, typename TriggerRegistrars>
+struct InitializePhaseChangeDecisionData {
+  template <typename... DecisionTags, typename Metavariables>
+  static void apply(
+      const gsl::not_null<tuples::TaggedTuple<DecisionTags...>*>
+          phase_change_decision_data,
+      const Parallel::GlobalCache<Metavariables>& cache) noexcept {
+    tuples::get<TagsAndCombines::UsePhaseChangeArbitration>(
+        *phase_change_decision_data) = false;
+    const auto& phase_change_and_triggers = Parallel::get<
+        Tags::PhaseChangeAndTriggers<PhaseChangeRegistrars, TriggerRegistrars>>(
+        cache);
+    for (const auto& [trigger, phase_changes] : phase_change_and_triggers) {
+      // avoid unused variable warning
+      (void)trigger;
+      for (const auto& phase_change : phase_changes) {
+        phase_change->initialize_phase_data(phase_change_decision_data);
+      }
+    }
+  }
+};
+}  // namespace PhaseControl

--- a/src/Parallel/PhaseControl/VisitAndReturn.hpp
+++ b/src/Parallel/PhaseControl/VisitAndReturn.hpp
@@ -1,0 +1,201 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <optional>
+#include <pup.h>
+#include <string>
+#include <utility>
+#include <type_traits>
+
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Main.hpp"
+#include "Parallel/PhaseControl/PhaseChange.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace PhaseControl {
+template <typename Metavariables, typename Metavariables::Phase TargetPhase,
+          typename PhaseChangeRegistrars>
+class VisitAndReturn;
+
+namespace Registrars {
+template <typename Metavariables, typename Metavariables::Phase TargetPhase>
+struct VisitAndReturn {
+  template <typename PhaseChangeRegistrars>
+  using f = ::PhaseControl::VisitAndReturn<Metavariables, TargetPhase,
+                                                 PhaseChangeRegistrars>;
+};
+}  // namespace Registrars
+/// \endcond
+
+namespace Tags {
+/// Storage in the phase change decision tuple so that the Main chare can record
+/// the phase to return to after a temporary phase.
+///
+/// \note This tag is not intended to participate in any of the reduction
+/// procedures, so will error if the combine method is called.
+template <auto Phase>
+struct ReturnPhase {
+  using type = std::optional<decltype(Phase)>;
+
+  struct combine_method {
+    std::optional<decltype(Phase)> operator()(
+        const std::optional<decltype(Phase)> /*first_phase*/,
+        const std::optional<decltype(Phase)>& /*second_phase*/) noexcept {
+      ERROR(
+          "The return phase should only be altered by the phase change "
+          "arbitration in the Main chare, so no reduction data should be "
+          "provided.");
+    }
+  };
+
+  using main_combine_method = combine_method;
+};
+
+/// Stores whether the phase in question has been requested.
+///
+/// Combinations are performed via `funcl::Or`, as the phase in question should
+/// be chosen if any component requests the jump.
+template <auto Phase>
+struct TemporaryPhaseRequested {
+  using type = bool;
+
+  using combine_method = funcl::Or<>;
+  using main_combine_method = funcl::Or<>;
+};
+}  // namespace Tags
+
+/*!
+ * \brief Phase control object for temporarily visiting `TargetPhase`, until the
+ * algorithm halts again, then returning to the original phase.
+ *
+ * The motivation for this type of procedure is e.g. load balancing,
+ * checkpointing, and other maintenance tasks that should be performed
+ * periodically during a lengthy evolution.
+ * Once triggered, this will cause a change to `TargetPhase`, but store the
+ * current phase to resume execution when the tasks in `TargetPhase` are
+ * completed.
+ *
+ * Any parallel component can participate in the associated phase change
+ * reduction data contribution, and if any component requests the temporary
+ * phase, it will execute.
+ *
+ * To determine which specialization of this template is requested from the
+ * input file, the `Metavariables` must define a `phase_name(Phase)` static
+ * member function that returns a string for each phase that will be used in
+ * `VisitAndReturn`s.
+ *
+ * \note  If multiple such methods are specified (with different
+ * `TargetPhase`s), then the order of phase jumps depends on their order in the
+ * list.
+ * - If multiple `VisitAndReturn`s trigger simultaneously, then they will visit
+ *   in sequence specified by the input file: first going to the first
+ *   `TargetPhase` until that phase resolves, then immediately entering the
+ *   second `TargetPhase` (without yet returning to the original phase), then
+ *   finally returning to the original phase.
+ * - If a `VisitAndReturn` is triggered in a phase that is already a
+ *   `TargetPhase` of another `VisitAndReturn`, it will be executed, and
+ *   following completion, control will return to the original phase from before
+ *   the first `VisitAndReturn`.
+ */
+template <typename Metavariables, typename Metavariables::Phase TargetPhase,
+          typename PhaseChangeRegistrars = tmpl::list<
+              Registrars::VisitAndReturn<Metavariables, TargetPhase>>>
+struct VisitAndReturn : public PhaseChange<PhaseChangeRegistrars> {
+  /// \cond
+  VisitAndReturn() = default;
+  explicit VisitAndReturn(CkMigrateMessage* /*unused*/) noexcept {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(VisitAndReturn);  // NOLINT
+  /// \endcond
+
+  static std::string name() noexcept {
+    return "VisitAndReturn(" + Metavariables::phase_name(TargetPhase) +
+           ")";
+  }
+  using options = tmpl::list<>;
+  static constexpr Options::String help{
+      "Temporarily jump to the phase given by `TargetPhase`, returning to the "
+      "previously executing phase when complete."};
+
+  using argument_tags = tmpl::list<>;
+  using return_tags = tmpl::list<>;
+
+  using phase_change_tags_and_combines =
+      tmpl::list<Tags::ReturnPhase<TargetPhase>,
+                 Tags::TemporaryPhaseRequested<TargetPhase>>;
+
+  template <typename LocalMetavariables>
+  using participating_components = typename LocalMetavariables::component_list;
+
+  template <typename... DecisionTags>
+  void initialize_phase_data_impl(
+      const gsl::not_null<tuples::TaggedTuple<DecisionTags...>*>
+          phase_change_decision_data) const noexcept {
+    tuples::get<Tags::ReturnPhase<TargetPhase>>(*phase_change_decision_data) =
+        std::nullopt;
+    tuples::get<Tags::TemporaryPhaseRequested<TargetPhase>>(
+        *phase_change_decision_data) = false;
+  }
+
+  template <typename ParallelComponent, typename ArrayIndex>
+  void contribute_phase_data_impl(
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index) const noexcept {
+    if constexpr (std::is_same_v<typename ParallelComponent::chare_type,
+                                 Parallel::Algorithms::Array>) {
+      Parallel::contribute_to_phase_change_reduction<ParallelComponent>(
+          tuples::TaggedTuple<Tags::TemporaryPhaseRequested<TargetPhase>>{true},
+          cache, array_index);
+    } else {
+      Parallel::contribute_to_phase_change_reduction<ParallelComponent>(
+          tuples::TaggedTuple<Tags::TemporaryPhaseRequested<TargetPhase>>{true},
+          cache);
+    }
+  }
+
+  template <typename... DecisionTags>
+  typename std::optional<
+      std::pair<typename Metavariables::Phase, ArbitrationStrategy>>
+  arbitrate_phase_change_impl(
+      const gsl::not_null<tuples::TaggedTuple<DecisionTags...>*>
+          phase_change_decision_data,
+      const typename Metavariables::Phase current_phase,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/) const noexcept {
+    auto& return_phase = tuples::get<Tags::ReturnPhase<TargetPhase>>(
+        *phase_change_decision_data);
+    if (return_phase.has_value()) {
+      const auto result = return_phase;
+      return_phase.reset();
+      return std::make_pair(result.value(),
+                            ArbitrationStrategy::PermitAdditionalJumps);
+    }
+    auto& temporary_phase_requested =
+        tuples::get<Tags::TemporaryPhaseRequested<TargetPhase>>(
+            *phase_change_decision_data);
+    if (temporary_phase_requested) {
+      return_phase = current_phase;
+      temporary_phase_requested = false;
+      return std::make_pair(TargetPhase,
+                            ArbitrationStrategy::RunPhaseImmediately);
+    }
+    return std::nullopt;
+  }
+
+  void pup(PUP::er& /*p*/) noexcept override {}
+};
+}  // namespace PhaseControl
+
+/// \cond
+template <typename Metavariables, typename Metavariables::Phase TargetPhase,
+          typename PhaseChangeRegistrars>
+PUP::able::PUP_ID PhaseControl::VisitAndReturn<
+    Metavariables, TargetPhase, PhaseChangeRegistrars>::my_PUP_ID = 0;
+/// \endcond

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -41,6 +41,7 @@ add_algorithm_test(Test_AlgorithmLocalSyncAction)
 add_algorithm_test(Test_AlgorithmNestedApply1)
 add_algorithm_test(Test_AlgorithmNestedApply2)
 add_algorithm_test(Test_AlgorithmParallel)
+add_algorithm_test(Test_AlgorithmPhaseControl)
 add_algorithm_test(Test_PhaseChangeMain)
 add_algorithm_test(Test_AlgorithmNodelock)
 add_algorithm_test(Test_AlgorithmReduction)
@@ -178,6 +179,7 @@ add_algorithm_test_with_balancing("AlgorithmParallelWithBalancing"
   "AlgorithmParallel" "Objects migrating: 14")
 
 add_algorithm_test_with_input_file("AlgorithmGlobalCache" "Unit/Parallel")
+add_algorithm_test_with_input_file("AlgorithmPhaseControl" "Unit/Parallel")
 
 # Tests that do not require their own Chare setup and can work with the
 # unit tests

--- a/tests/Unit/Parallel/PhaseControl/CMakeLists.txt
+++ b/tests/Unit/Parallel/PhaseControl/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_ExecutePhaseChange.cpp
   Test_PhaseChange.cpp
   Test_PhaseControlTags.cpp
+  Test_VisitAndReturn.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Parallel/PhaseControl/CMakeLists.txt
+++ b/tests/Unit/Parallel/PhaseControl/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_PhaseControl")
 
 set(LIBRARY_SOURCES
+  Test_ExecutePhaseChange.cpp
   Test_PhaseChange.cpp
   Test_PhaseControlTags.cpp
   )

--- a/tests/Unit/Parallel/PhaseControl/Test_ExecutePhaseChange.cpp
+++ b/tests/Unit/Parallel/PhaseControl/Test_ExecutePhaseChange.cpp
@@ -1,0 +1,304 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
+#include "Parallel/PhaseControl/PhaseChange.hpp"
+#include "Parallel/PhaseControl/PhaseControlTags.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+
+namespace TestTags {
+template <PhaseControl::ArbitrationStrategy, size_t Index>
+struct Request {
+  using type = bool;
+
+  using combine_method = funcl::Or<>;
+  using main_combine_method = funcl::Or<>;
+};
+}  // namespace TestTags
+
+template <PhaseControl::ArbitrationStrategy Strategy, size_t Index,
+          typename PhaseChangeRegistrars>
+struct TestPhaseChange;
+
+namespace Registrars {
+template <PhaseControl::ArbitrationStrategy Strategy, size_t Index>
+struct TestPhaseChange {
+  template <typename PhaseChangeRegistrars>
+  using f = ::TestPhaseChange<Strategy, Index, PhaseChangeRegistrars>;
+};
+}  // namespace Registrars
+
+template <PhaseControl::ArbitrationStrategy Strategy, size_t Index,
+          typename PhaseChangeRegistrars =
+              tmpl::list<Registrars::TestPhaseChange<Strategy, Index>>>
+struct TestPhaseChange : public PhaseChange<PhaseChangeRegistrars> {
+  /// \cond
+  TestPhaseChange() = default;
+  explicit TestPhaseChange(CkMigrateMessage* /*unused*/) noexcept {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(TestPhaseChange);  // NOLINT
+  /// \endcond
+  static std::string name() noexcept {
+    if constexpr (Strategy ==
+                  PhaseControl::ArbitrationStrategy::RunPhaseImmediately) {
+      if constexpr (Index == 0_st) {
+        return "TestPhaseChange(RunPhaseImmediately, 0)";
+      } else {
+        return "TestPhaseChange(RunPhaseImmediately, 1)";
+      }
+    } else {
+      if constexpr (Index == 0_st) {
+        return "TestPhaseChange(PermitAdditionalJumps, 0)";
+      } else if constexpr (Index == 1_st) {
+        return "TestPhaseChange(PermitAdditionalJumps, 1)";
+      } else {
+        return "TestPhaseChange(PermitAdditionalJumps, 2)";
+      }
+    }
+  }
+
+  using options = tmpl::list<>;
+  static constexpr Options::String help{"Phase change tester"};
+
+  using argument_tags = tmpl::list<>;
+  using return_tags = tmpl::list<>;
+
+  using phase_change_tags_and_combines =
+      tmpl::list<TestTags::Request<Strategy, Index>>;
+  template <typename Metavariables>
+  using participating_components = tmpl::list<>;
+
+  template <typename... DecisionTags>
+  void initialize_phase_data_impl(
+      const gsl::not_null<tuples::TaggedTuple<DecisionTags...>*>
+          phase_change_decision_data) const noexcept {
+    tuples::get<TestTags::Request<Strategy, Index>>(
+        *phase_change_decision_data) =
+        (Index % 2 == 0) xor
+        (Strategy == PhaseControl::ArbitrationStrategy::RunPhaseImmediately);
+  }
+
+  template <typename ParallelComponent, typename Metavariables,
+            typename ArrayIndex>
+  void contribute_phase_data_impl(
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/) const noexcept {}
+
+  template <typename... DecisionTags, typename Metavariables>
+  typename std::optional<std::pair<typename Metavariables::Phase,
+                                   PhaseControl::ArbitrationStrategy>>
+  arbitrate_phase_change_impl(
+      const gsl::not_null<tuples::TaggedTuple<DecisionTags...>*>
+          phase_change_decision_data,
+      const typename Metavariables::Phase /*current_phase*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/) const noexcept {
+    if (tuples::get<TestTags::Request<Strategy, Index>>(
+            *phase_change_decision_data)) {
+      tuples::get<TestTags::Request<Strategy, Index>>(
+          *phase_change_decision_data) = false;
+      // Choose a unique phase, all after the first phase, for each choice of
+      // the template parameters.
+      return std::make_pair(
+          static_cast<typename Metavariables::Phase>(
+              1_st + static_cast<size_t>(Strategy) + Index * 2_st),
+          Strategy);
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  void pup(PUP::er& /*p*/) noexcept override {}  // NOLINT
+};
+
+template <PhaseControl::ArbitrationStrategy Strategy, size_t Index,
+          typename PhaseChangeRegistrars>
+PUP::able::PUP_ID
+    TestPhaseChange<Strategy, Index, PhaseChangeRegistrars>::my_PUP_ID = 0;
+
+struct Metavariables {
+  using component_list = tmpl::list<>;
+  using phase_changes = tmpl::list<
+      Registrars::TestPhaseChange<
+          PhaseControl::ArbitrationStrategy::RunPhaseImmediately, 0_st>,
+      Registrars::TestPhaseChange<
+          PhaseControl::ArbitrationStrategy::RunPhaseImmediately, 1_st>,
+      Registrars::TestPhaseChange<
+          PhaseControl::ArbitrationStrategy::PermitAdditionalJumps, 0_st>,
+      Registrars::TestPhaseChange<
+          PhaseControl::ArbitrationStrategy::PermitAdditionalJumps, 1_st>,
+      Registrars::TestPhaseChange<
+          PhaseControl::ArbitrationStrategy::PermitAdditionalJumps, 2_st>>;
+  using const_global_cache_tags = tmpl::list<
+      PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes, tmpl::list<>>>;
+
+  enum class Phase { PhaseA, PhaseB, PhaseC, PhaseD, PhaseE, PhaseF, PhaseG };
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Parallel.PhaseControl.ExecutePhaseChange",
+                  "[Unit][Parallel]") {
+  // for a test of the `ExecutePhaseChange` action, see
+  // `tests/Unit/Parallel/Test_AlgorithmPhaseControl.hpp`. Currently, there is
+  // no way to test interactions with the `Main` chare via the action testing
+  // framework.
+  using phase_change_decision_data_type = tuples::TaggedTuple<
+      ::TestTags::Request<
+          PhaseControl::ArbitrationStrategy::RunPhaseImmediately, 0_st>,
+      ::TestTags::Request<
+          PhaseControl::ArbitrationStrategy::PermitAdditionalJumps, 0_st>,
+      ::TestTags::Request<
+          PhaseControl::ArbitrationStrategy::RunPhaseImmediately, 1_st>,
+      ::TestTags::Request<
+          PhaseControl::ArbitrationStrategy::PermitAdditionalJumps, 1_st>,
+      ::TestTags::Request<
+          PhaseControl::ArbitrationStrategy::PermitAdditionalJumps, 2_st>,
+      PhaseControl::TagsAndCombines::UsePhaseChangeArbitration>;
+
+  phase_change_decision_data_type phase_change_data{true, true, true,
+                                                    true, true, true};
+
+  std::vector<
+      std::unique_ptr<PhaseChange<typename Metavariables::phase_changes>>>
+      phase_change_vector;
+  phase_change_vector.reserve(5);
+  phase_change_vector.emplace_back(
+      std::make_unique<TestPhaseChange<
+          PhaseControl::ArbitrationStrategy::RunPhaseImmediately, 0_st,
+          typename Metavariables::phase_changes>>());
+  phase_change_vector.emplace_back(
+      std::make_unique<TestPhaseChange<
+          PhaseControl::ArbitrationStrategy::PermitAdditionalJumps, 0_st,
+          typename Metavariables::phase_changes>>());
+  phase_change_vector.emplace_back(
+      std::make_unique<TestPhaseChange<
+          PhaseControl::ArbitrationStrategy::RunPhaseImmediately, 1_st,
+          typename Metavariables::phase_changes>>());
+  phase_change_vector.emplace_back(
+      std::make_unique<TestPhaseChange<
+          PhaseControl::ArbitrationStrategy::PermitAdditionalJumps, 1_st,
+          typename Metavariables::phase_changes>>());
+  phase_change_vector.emplace_back(
+      std::make_unique<TestPhaseChange<
+          PhaseControl::ArbitrationStrategy::PermitAdditionalJumps, 2_st,
+          typename Metavariables::phase_changes>>());
+
+  using phase_change_and_triggers = PhaseControl::Tags::PhaseChangeAndTriggers<
+      typename Metavariables::phase_changes, tmpl::list<>>;
+  typename phase_change_and_triggers::type vector_of_triggers_and_phase_changes;
+  vector_of_triggers_and_phase_changes.emplace_back(
+      static_cast<std::unique_ptr<Trigger<tmpl::list<>>>>(
+          std::make_unique<Triggers::Always<tmpl::list<>>>()),
+      std::move(phase_change_vector));
+
+  Parallel::MutableGlobalCache<Metavariables> mutable_cache{};
+  Parallel::GlobalCache<Metavariables> global_cache{
+      tuples::TaggedTuple<phase_change_and_triggers>{
+          std::move(vector_of_triggers_and_phase_changes)},
+      &mutable_cache};
+
+  {
+    INFO("Initialize phase change decision data");
+    PhaseControl::InitializePhaseChangeDecisionData<
+        typename Metavariables::phase_changes,
+        tmpl::list<>>::apply(make_not_null(&phase_change_data), global_cache);
+    // checking against the formula:
+    // (Index % 2 == 0) xor
+    // (Strategy == PhaseControl::ArbitrationStrategy::RunPhaseImmediately)
+    CHECK(phase_change_data == phase_change_decision_data_type{
+                                   false, true, true, false, true, false});
+  }
+  {
+    INFO("Arbitrate based on phase change decision data");
+    // if used, the phase change objects correspond to phases:
+    // B, C, D, E, and G (in that order)
+    phase_change_data = phase_change_decision_data_type{false, false, false,
+                                                        false, false, false};
+    CHECK(SINGLE_ARG(PhaseControl::arbitrate_phase_change<
+                     typename Metavariables::phase_changes, tmpl::list<>>(
+              make_not_null(&phase_change_data), Metavariables::Phase::PhaseA,
+              global_cache)) == std::nullopt);
+    CHECK(phase_change_data == SINGLE_ARG(phase_change_decision_data_type{
+                                   false, false, false, false, false, false}));
+
+    phase_change_data = phase_change_decision_data_type{false, false, false,
+                                                        false, false, true};
+    CHECK(SINGLE_ARG(PhaseControl::arbitrate_phase_change<
+                     typename Metavariables::phase_changes, tmpl::list<>>(
+              make_not_null(&phase_change_data), Metavariables::Phase::PhaseA,
+              global_cache)) == Metavariables::Phase::PhaseA);
+    CHECK(phase_change_data == SINGLE_ARG(phase_change_decision_data_type{
+                                   false, false, false, false, false, false}));
+
+    phase_change_data =
+        phase_change_decision_data_type{true, false, true, true, false, true};
+    // test the versions that use `RunPhaseImmediately`, so the phase jumps to
+    // those phaases without evaluating the other phase change objects
+    CHECK(SINGLE_ARG(PhaseControl::arbitrate_phase_change<
+                     typename Metavariables::phase_changes, tmpl::list<>>(
+              make_not_null(&phase_change_data), Metavariables::Phase::PhaseA,
+              global_cache)) == Metavariables::Phase::PhaseB);
+    CHECK(phase_change_data == SINGLE_ARG(phase_change_decision_data_type{
+                                   false, false, true, true, false, false}));
+    phase_change_data =
+        phase_change_decision_data_type{true, false, true, true, false, true};
+    CHECK(SINGLE_ARG(PhaseControl::arbitrate_phase_change<
+                     typename Metavariables::phase_changes, tmpl::list<>>(
+              make_not_null(&phase_change_data), Metavariables::Phase::PhaseA,
+              global_cache)) == Metavariables::Phase::PhaseB);
+    CHECK(phase_change_data == SINGLE_ARG(phase_change_decision_data_type{
+                                   false, false, true, true, false, false}));
+    CHECK(SINGLE_ARG(PhaseControl::arbitrate_phase_change<
+                     typename Metavariables::phase_changes, tmpl::list<>>(
+              make_not_null(&phase_change_data), Metavariables::Phase::PhaseA,
+              global_cache)) == Metavariables::Phase::PhaseD);
+    CHECK(phase_change_data == SINGLE_ARG(phase_change_decision_data_type{
+                                   false, false, false, true, false, false}));
+    CHECK(SINGLE_ARG(PhaseControl::arbitrate_phase_change<
+                     typename Metavariables::phase_changes, tmpl::list<>>(
+              make_not_null(&phase_change_data), Metavariables::Phase::PhaseA,
+              global_cache)) == Metavariables::Phase::PhaseE);
+    CHECK(phase_change_data == SINGLE_ARG(phase_change_decision_data_type{
+                                   false, false, false, false, false, false}));
+
+    // test the versions that use `PermitAdditionalJumps`, so each are evaluated
+    // and the phase that is run is the last in the sequence, or the first
+    // `RunPhaseImmediately` that is encountered.
+    phase_change_data =
+        phase_change_decision_data_type{false, true, false, true, false, true};
+    CHECK(SINGLE_ARG(PhaseControl::arbitrate_phase_change<
+                     typename Metavariables::phase_changes, tmpl::list<>>(
+              make_not_null(&phase_change_data), Metavariables::Phase::PhaseA,
+              global_cache)) == Metavariables::Phase::PhaseE);
+    CHECK(phase_change_data == SINGLE_ARG(phase_change_decision_data_type{
+                                   false, false, false, false, false, false}));
+
+    phase_change_data =
+        phase_change_decision_data_type{false, true, false, true, true, true};
+    CHECK(SINGLE_ARG(PhaseControl::arbitrate_phase_change<
+                     typename Metavariables::phase_changes, tmpl::list<>>(
+              make_not_null(&phase_change_data), Metavariables::Phase::PhaseA,
+              global_cache)) == Metavariables::Phase::PhaseG);
+    CHECK(phase_change_data == SINGLE_ARG(phase_change_decision_data_type{
+                                   false, false, false, false, false, false}));
+
+    // check that the result is the same starting from any phase
+    for (size_t i = 0; i < 7; ++i) {
+      phase_change_data = phase_change_decision_data_type{false, true,  true,
+                                                          false, false, true};
+      CHECK(SINGLE_ARG(PhaseControl::arbitrate_phase_change<
+                       typename Metavariables::phase_changes, tmpl::list<>>(
+                make_not_null(&phase_change_data),
+                static_cast<typename Metavariables::Phase>(i), global_cache)) ==
+            Metavariables::Phase::PhaseD);
+      CHECK(phase_change_data ==
+            SINGLE_ARG(phase_change_decision_data_type{false, false, false,
+                                                       false, false, false}));
+    }
+  }
+}

--- a/tests/Unit/Parallel/PhaseControl/Test_VisitAndReturn.cpp
+++ b/tests/Unit/Parallel/PhaseControl/Test_VisitAndReturn.cpp
@@ -1,0 +1,169 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <optional>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/PhaseControl/PhaseControlTags.hpp"
+#include "Parallel/PhaseControl/VisitAndReturn.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+struct Metavariables {
+  using component_list = tmpl::list<>;
+
+  enum class Phase { PhaseA, PhaseB, PhaseC};
+
+  static std::string phase_name(Phase phase) noexcept {
+    if (phase == Phase::PhaseB) {
+      return "PhaseB";
+    }
+    if (phase == Phase::PhaseC) {
+      return "PhaseC";
+    }
+    ERROR("Specified phase not supported for phase change");
+  }
+};
+
+SPECTRE_TEST_CASE("Unit.Parallel.PhaseControl.VisitAndReturn",
+                  "[Unit][Parallel]") {
+  // note that the `contribute_phase_data_impl` function is currently untested
+  // in this unit test, because we do not have good support for reductions in
+  // the action testing framework. These are tested in the integration test
+  // `Parallel/Test_AlgorithmPhaseControl.cpp`
+  using phase_changes =
+      tmpl::list<PhaseControl::Registrars::VisitAndReturn<
+                     Metavariables, Metavariables::Phase::PhaseB>,
+                 PhaseControl::Registrars::VisitAndReturn<
+                     Metavariables, Metavariables::Phase::PhaseC>>;
+  using triggers = tmpl::list<>;
+  Parallel::GlobalCache<Metavariables> cache{};
+
+  const auto created_phase_changes = TestHelpers::test_creation<
+      typename PhaseControl::OptionTags::PhaseChangeAndTriggers<phase_changes,
+                                                                triggers>::type,
+      PhaseControl::OptionTags::PhaseChangeAndTriggers<phase_changes,
+                                                       triggers>>(
+      " - - Always:\n"
+      "   - - VisitAndReturn(PhaseB):\n"
+      "     - VisitAndReturn(PhaseC):");
+  using phase_change_decision_data_type = tuples::tagged_tuple_from_typelist<
+      PhaseControl::get_phase_change_tags<phase_changes>>;
+
+  phase_change_decision_data_type phase_change_decision_data{
+      Metavariables::Phase::PhaseA, true, Metavariables::Phase::PhaseA, true,
+      true};
+  const auto& first_phase_change = created_phase_changes[0].second[0];
+  const auto& second_phase_change = created_phase_changes[0].second[1];
+  {
+    INFO("Test initialize phase change decision data");
+    first_phase_change->initialize_phase_data(
+        make_not_null(&phase_change_decision_data));
+    // extra parens in the check prevent Catch from trying to stream the tuple
+    CHECK((phase_change_decision_data ==
+           phase_change_decision_data_type{
+               std::nullopt, false, Metavariables::Phase::PhaseA, true, true}));
+
+    second_phase_change->initialize_phase_data(
+        make_not_null(&phase_change_decision_data));
+    CHECK((phase_change_decision_data ==
+           phase_change_decision_data_type{std::nullopt, false, std::nullopt,
+                                           false, true}));
+
+    using first_phase_change_tuple_type = tuples::TaggedTuple<
+        PhaseControl::Tags::ReturnPhase<Metavariables::Phase::PhaseB>,
+        PhaseControl::Tags::TemporaryPhaseRequested<
+            Metavariables::Phase::PhaseB>>;
+    first_phase_change_tuple_type tuple_for_first_phase_change{
+        Metavariables::Phase::PhaseA, true};
+    PhaseControl::VisitAndReturn<Metavariables, Metavariables::Phase::PhaseB>{}
+        .initialize_phase_data_impl(
+            make_not_null(&tuple_for_first_phase_change));
+    CHECK((tuple_for_first_phase_change ==
+           first_phase_change_tuple_type{std::nullopt, false}));
+  }
+  {
+    INFO("Test arbitrate phase control");
+    // In this test, we trace through the set of states that occur when
+    // resolving two simultaneous phase requests. This is a superset of states
+    // that occur in a single phase request
+    phase_change_decision_data = phase_change_decision_data_type{
+        std::nullopt, true, std::nullopt, true, true};
+    auto decision_result = first_phase_change->arbitrate_phase_change(
+        make_not_null(&phase_change_decision_data),
+        Metavariables::Phase::PhaseC, cache);
+    // extra parens in the check prevent Catch from trying to stream the tuple
+    CHECK((decision_result ==
+           std::make_pair(
+               Metavariables::Phase::PhaseB,
+               PhaseControl::ArbitrationStrategy::RunPhaseImmediately)));
+    CHECK((phase_change_decision_data ==
+           phase_change_decision_data_type{Metavariables::Phase::PhaseC, false,
+                                           std::nullopt, true, true}));
+
+    // check a different starting phase
+    phase_change_decision_data = phase_change_decision_data_type{
+        std::nullopt, true, std::nullopt, true, true};
+    decision_result = first_phase_change->arbitrate_phase_change(
+        make_not_null(&phase_change_decision_data),
+        Metavariables::Phase::PhaseA, cache);
+    CHECK((decision_result ==
+           std::make_pair(
+               Metavariables::Phase::PhaseB,
+               PhaseControl::ArbitrationStrategy::RunPhaseImmediately)));
+    CHECK((phase_change_decision_data ==
+           phase_change_decision_data_type{Metavariables::Phase::PhaseA, false,
+                                           std::nullopt, true, true}));
+
+    decision_result = first_phase_change->arbitrate_phase_change(
+        make_not_null(&phase_change_decision_data),
+        Metavariables::Phase::PhaseB, cache);
+    CHECK((decision_result ==
+           std::make_pair(
+               Metavariables::Phase::PhaseA,
+               PhaseControl::ArbitrationStrategy::PermitAdditionalJumps)));
+    CHECK((phase_change_decision_data ==
+           phase_change_decision_data_type{std::nullopt, false, std::nullopt,
+                                           true, true}));
+
+    decision_result = second_phase_change->arbitrate_phase_change(
+        make_not_null(&phase_change_decision_data),
+        Metavariables::Phase::PhaseA, cache);
+    CHECK((decision_result ==
+           std::make_pair(
+               Metavariables::Phase::PhaseC,
+               PhaseControl::ArbitrationStrategy::RunPhaseImmediately)));
+    CHECK(
+        (phase_change_decision_data ==
+         phase_change_decision_data_type{
+             std::nullopt, false, Metavariables::Phase::PhaseA, false, true}));
+
+    decision_result =
+        PhaseControl::VisitAndReturn<Metavariables,
+                                     Metavariables::Phase::PhaseC>{}
+            .arbitrate_phase_change_impl(
+                make_not_null(&phase_change_decision_data),
+                Metavariables::Phase::PhaseC, cache);
+    CHECK((decision_result ==
+           std::make_pair(
+               Metavariables::Phase::PhaseA,
+               PhaseControl::ArbitrationStrategy::PermitAdditionalJumps)));
+    CHECK((phase_change_decision_data ==
+           phase_change_decision_data_type{std::nullopt, false, std::nullopt,
+                                           false, true}));
+
+    decision_result = second_phase_change->arbitrate_phase_change(
+        make_not_null(&phase_change_decision_data),
+        Metavariables::Phase::PhaseA, cache);
+    CHECK((decision_result == std::nullopt));
+    CHECK((phase_change_decision_data ==
+           phase_change_decision_data_type{std::nullopt, false, std::nullopt,
+                                           false, true}));
+  }
+}

--- a/tests/Unit/Parallel/Test_AlgorithmPhaseControl.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmPhaseControl.cpp
@@ -1,0 +1,538 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+// Need CATCH_CONFIG_RUNNER to avoid linking errors with Catch2
+#define CATCH_CONFIG_RUNNER
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <functional>
+#include <pup.h>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/Actions/TerminatePhase.hpp"
+#include "Parallel/Algorithms/AlgorithmArray.hpp"
+#include "Parallel/Algorithms/AlgorithmNodegroup.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/InboxInserters.hpp"
+#include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Main.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
+#include "Parallel/PhaseControl/PhaseChange.hpp"
+#include "Parallel/PhaseControl/PhaseControlTags.hpp"
+#include "Parallel/PhaseControl/VisitAndReturn.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"  // IWYU pragma: keep
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace Actions {
+struct InitializePhaseRecord;
+struct RecordCurrentPhase;
+template <size_t phase>
+struct RecordPhaseIteration;
+template <typename ComponentToRestart>
+struct RestartMe;
+template <typename OtherComponent, size_t interval>
+struct TerminateAndRestart;
+struct Finalize;
+}  // namespace Actions
+
+namespace Tags {
+struct PhaseRecord : db::SimpleTag {
+  using type = std::string;
+};
+struct Step : db::SimpleTag {
+  using type = size_t;
+};
+}  // namespace Tags
+
+template <typename TriggerRegistrars>
+struct TempPhaseATrigger;
+
+template <typename TriggerRegistrars>
+struct TempPhaseBTrigger;
+
+namespace Registrars {
+using TempPhaseATrigger = Registration::Registrar<TempPhaseATrigger>;
+using TempPhaseBTrigger = Registration::Registrar<TempPhaseBTrigger>;
+}  // namespace Registrars
+
+template <typename Metavariables>
+struct ComponentAlpha;
+
+template <typename Metavariables>
+struct ComponentBeta;
+
+template <typename TriggerRegistrars =
+              tmpl::list<Registrars::TempPhaseATrigger>>
+struct TempPhaseATrigger : public Trigger<TriggerRegistrars> {
+  /// \cond
+  TempPhaseATrigger() = default;
+  explicit TempPhaseATrigger(CkMigrateMessage* /*unused*/) noexcept {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(TempPhaseATrigger);  // NOLINT
+  /// \endcond
+
+  static constexpr Options::String help{
+    "Trigger for going to TempPhaseA."};
+  using options = tmpl::list<>;
+
+  using argument_tags = tmpl::list<Tags::Step>;
+
+  bool operator()(const size_t step) const noexcept {
+    return step % 5 == 0;
+  }
+};
+
+template <typename TriggerRegistrars =
+              tmpl::list<Registrars::TempPhaseBTrigger>>
+struct TempPhaseBTrigger : public Trigger<TriggerRegistrars> {
+  /// \cond
+  TempPhaseBTrigger() = default;
+  explicit TempPhaseBTrigger(CkMigrateMessage* /*unused*/) noexcept {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(TempPhaseBTrigger);  // NOLINT
+  /// \endcond
+
+  static constexpr Options::String help{"Trigger for going to TempPhaseB."};
+  using options = tmpl::list<>;
+
+  using argument_tags = tmpl::list<Tags::Step>;
+
+  bool operator()(const size_t step) const noexcept {
+    return step % 3 == 0;
+  }
+};
+
+template <typename TriggerRegistrars>
+PUP::able::PUP_ID TempPhaseBTrigger<TriggerRegistrars>::my_PUP_ID = 0;
+template <typename TriggerRegistrars>
+PUP::able::PUP_ID TempPhaseATrigger<TriggerRegistrars>::my_PUP_ID = 0;
+
+template <typename Metavariables>
+struct ComponentAlpha {
+  using chare_type = Parallel::Algorithms::Array;
+  using metavariables = Metavariables;
+  using array_index = int;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Initialization,
+                             tmpl::list<Actions::InitializePhaseRecord,
+                                        Actions::RecordPhaseIteration<0_st>,
+                                        Parallel::Actions::TerminatePhase>>,
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::TempPhaseA,
+                             tmpl::list<Actions::RecordPhaseIteration<1_st>,
+                                        Parallel::Actions::TerminatePhase>>,
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::TempPhaseB,
+                             tmpl::list<Actions::RecordPhaseIteration<2_st>,
+                                        Parallel::Actions::TerminatePhase>>,
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Evolve,
+          tmpl::list<
+              Actions::RecordPhaseIteration<3_st>,
+              Actions::TerminateAndRestart<ComponentBeta<Metavariables>, 2_st>,
+              PhaseControl::Actions::ExecutePhaseChange<
+                  typename Metavariables::phase_changes,
+                  typename Metavariables::triggers>>>>;
+
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+
+  static void allocate_array(
+      Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
+      const tuples::tagged_tuple_from_typelist<initialization_tags>&
+      /*initialization_items*/) noexcept {
+    auto& local_cache = *(global_cache.ckLocalBranch());
+    auto& array_proxy =
+        Parallel::get_parallel_component<ComponentAlpha>(local_cache);
+
+    array_proxy[0].insert(global_cache, {}, 0);
+    array_proxy.doneInserting();
+  }
+
+  static void execute_next_phase(
+      const typename Metavariables::Phase next_phase,
+      const Parallel::CProxy_GlobalCache<Metavariables>& global_cache) {
+    auto& local_cache = *(global_cache.ckLocalBranch());
+    if (next_phase == Metavariables::Phase::Finalize) {
+      Parallel::simple_action<Actions::Finalize>(
+          Parallel::get_parallel_component<ComponentAlpha>(local_cache));
+    } else {
+      Parallel::get_parallel_component<ComponentAlpha>(local_cache)
+          .start_phase(next_phase);
+    }
+  }
+};
+
+template <typename Metavariables>
+struct ComponentBeta {
+  using chare_type = Parallel::Algorithms::Nodegroup;
+  using metavariables = Metavariables;
+  using array_index = size_t;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Initialization,
+                             tmpl::list<Actions::InitializePhaseRecord,
+                                        Actions::RecordPhaseIteration<0_st>,
+                                        Parallel::Actions::TerminatePhase>>,
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::TempPhaseA,
+                             tmpl::list<Actions::RecordPhaseIteration<1_st>,
+                                        Parallel::Actions::TerminatePhase>>,
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::TempPhaseB,
+                             tmpl::list<Actions::RecordPhaseIteration<2_st>,
+                                        Parallel::Actions::TerminatePhase>>,
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Evolve,
+          tmpl::list<
+              Actions::RecordPhaseIteration<3_st>,
+              Actions::TerminateAndRestart<ComponentAlpha<Metavariables>, 3_st>,
+              PhaseControl::Actions::ExecutePhaseChange<
+                  typename Metavariables::phase_changes,
+                  typename Metavariables::triggers>>>>;
+
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+
+  static void execute_next_phase(
+      const typename Metavariables::Phase next_phase,
+      const Parallel::CProxy_GlobalCache<Metavariables>& global_cache) {
+    auto& local_cache = *(global_cache.ckLocalBranch());
+    if (next_phase == Metavariables::Phase::Finalize) {
+      Parallel::simple_action<Actions::Finalize>(
+          Parallel::get_parallel_component<ComponentBeta>(local_cache));
+    } else {
+      Parallel::get_parallel_component<ComponentBeta>(local_cache)
+          .start_phase(next_phase);
+    }
+  }
+};
+
+namespace Actions {
+
+struct InitializePhaseRecord {
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTags>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    return std::make_tuple(
+        Initialization::merge_into_databox<
+            InitializePhaseRecord,
+            db::AddSimpleTags<Tags::PhaseRecord, Tags::Step>,
+            db::AddComputeTags<>, Initialization::MergePolicy::Overwrite>(
+            std::move(box), "", 0_st));
+  }
+};
+
+// iterable action called during phases
+template <size_t Phase>
+struct RecordPhaseIteration {
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTags>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    db::mutate<Tags::PhaseRecord>(
+        make_not_null(&box),
+        [](const gsl::not_null<std::string*> phase_log) noexcept {
+          *phase_log += "Running phase: " +
+                        Metavariables::phase_name(
+                            static_cast<typename Metavariables::Phase>(Phase)) +
+                        "\n";
+        });
+    if (static_cast<typename Metavariables::Phase>(Phase) ==
+        Metavariables::Phase::Evolve) {
+      db::mutate<Tags::Step>(
+          make_not_null(&box),
+          [](const gsl::not_null<size_t*> step) noexcept { ++(*step); });
+    }
+    return std::make_tuple(std::move(box));
+  }
+};
+
+template <typename ComponentToRestart>
+struct RestartMe {
+  template <typename ParallelComponent, typename... DbTags, typename ArrayIndex,
+            typename Metavariables>
+  static void apply(db::DataBox<tmpl::list<DbTags...>>& /*box*/,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/) noexcept {
+    Parallel::get_parallel_component<ComponentToRestart>(cache)
+        .perform_algorithm(true);
+  }
+};
+
+template <typename OtherComponent, size_t interval>
+struct TerminateAndRestart {
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTags>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    if (db::get<Tags::Step>(box) % interval == 0) {
+      if(db::get<Tags::Step>(box) <= 15) {
+        Parallel::simple_action<Actions::RestartMe<ParallelComponent>>(
+            Parallel::get_parallel_component<OtherComponent>(cache));
+
+        db::mutate<Tags::PhaseRecord>(
+            make_not_null(&box),
+            [](const gsl::not_null<std::string*> phase_log) noexcept {
+              *phase_log += "Terminate and Restart\n";
+            });
+        return std::make_tuple(std::move(box),
+                               Parallel::AlgorithmExecution::Pause);
+      } else {
+        db::mutate<Tags::PhaseRecord>(
+            make_not_null(&box),
+            [](const gsl::not_null<std::string*> phase_log) noexcept {
+              *phase_log += "Terminate Completion\n";
+            });
+        return std::make_tuple(std::move(box),
+                               Parallel::AlgorithmExecution::Halt);
+      }
+    }
+    return std::make_tuple(std::move(box),
+                           Parallel::AlgorithmExecution::Continue);
+  }
+};
+
+struct Finalize {
+  template <
+      typename ParallelComponent, typename DbTagsList, typename ArrayIndex,
+      typename Metavariables,
+      Requires<tmpl::list_contains_v<DbTagsList, Tags::PhaseRecord>> = nullptr>
+  static auto apply(const db::DataBox<DbTagsList>& box,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/) noexcept {
+    const std::string& log = db::get<Tags::PhaseRecord>(box);
+    SPECTRE_PARALLEL_REQUIRE(
+        log == Metavariables::expected_log(tmpl::type_<ParallelComponent>{}));
+  }
+
+  template <typename ParallelComponent, typename DbTagsList,
+            typename ArrayIndex, typename Metavariables,
+            Requires<not tmpl::list_contains_v<DbTagsList, Tags::PhaseRecord>> =
+                nullptr>
+  static auto apply(const db::DataBox<DbTagsList>& /*box*/,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/) noexcept {
+    SPECTRE_PARALLEL_REQUIRE(false);
+  }
+};
+}  // namespace Actions
+
+// two elements: alpha and beta
+// terminate and restart alpha on even time steps
+// terminate and restart beta on odd time steps divisible by 3
+// request sync actions on counts that are divisible by 5 or 7
+//
+// all events are recorded in a 'log' string that can be checked at the end.
+//
+// action request pattern:
+//   'alpha'    'beta'
+//  5:  none |   none
+//  7:   A   |   none
+// 10:  none |     B
+// 14:  none |  A and B
+struct TestMetavariables {
+  using component_list = tmpl::list<ComponentAlpha<TestMetavariables>,
+                                    ComponentBeta<TestMetavariables>>;
+
+  enum class Phase {
+    Initialization,
+    TempPhaseA,
+    TempPhaseB,
+    Evolve,
+    Finalize,
+    Exit
+  };
+
+  using triggers =
+      tmpl::list<Registrars::TempPhaseATrigger, Registrars::TempPhaseBTrigger>;
+  using phase_changes =
+      tmpl::list<PhaseControl::Registrars::VisitAndReturn<TestMetavariables,
+                                                          Phase::TempPhaseA>,
+                 PhaseControl::Registrars::VisitAndReturn<TestMetavariables,
+                                                          Phase::TempPhaseB>>;
+
+  using phase_change_tags_and_combines_list =
+      PhaseControl::get_phase_change_tags<phase_changes>;
+
+  using initialize_phase_change_decision_data =
+      PhaseControl::InitializePhaseChangeDecisionData<phase_changes, triggers>;
+
+  using const_global_cache_tags = tmpl::list<
+      PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes, triggers>>;
+
+  static std::string phase_name(const Phase phase) noexcept {
+    switch (phase) {
+      case Phase::Initialization:
+        return "Initialization";
+      case Phase::TempPhaseA:
+        return "TempPhaseA";
+      case Phase::TempPhaseB:
+        return "TempPhaseB";
+      case Phase::Evolve:
+        return "Evolve";
+      case Phase::Finalize:
+        return "Finalize";
+      case Phase::Exit:
+        return "Exit";
+      default:
+        ERROR("phase_name: Unknown phase");
+    }
+  }
+
+  static constexpr Options::String help =
+      "An executable for testing basic phase control flow.";
+
+  static std::string repeat(const std::string& input,
+                            const size_t times) noexcept {
+    std::string output;
+    for (size_t i = 0; i < times; ++i) {
+      output += input;
+    }
+    return output;
+  }
+
+  static std::string expected_log(
+      tmpl::type_<ComponentAlpha<TestMetavariables>> /*meta*/) noexcept {
+    return "Running phase: Initialization\n" +
+           repeat("Running phase: Evolve\n", 2_st) +
+           "Terminate and Restart\n"
+           "Running phase: Evolve\n"  // step 3 -> B
+           "Running phase: TempPhaseB\n"
+           "Running phase: Evolve\n"  // step 4
+           "Terminate and Restart\n"
+           "Running phase: Evolve\n"  // step 5 -> A
+           "Running phase: TempPhaseA\n"
+           "Running phase: Evolve\n"  // step 6 -> B
+           "Terminate and Restart\n"
+           "Running phase: TempPhaseB\n" +
+           repeat("Running phase: Evolve\n", 2_st) +  // step 7-8
+           "Terminate and Restart\n"
+           "Running phase: Evolve\n"  // step 9 -> B
+           "Running phase: TempPhaseB\n"
+           "Running phase: Evolve\n"  // step 10 -> A
+           "Terminate and Restart\n"
+           "Running phase: TempPhaseA\n" +
+           repeat("Running phase: Evolve\n", 2_st) +  // step 11-12 -> B
+           "Terminate and Restart\n"
+           "Running phase: TempPhaseB\n" +
+           repeat("Running phase: Evolve\n", 2_st) +  // step 13-14
+           "Terminate and Restart\n"
+           "Running phase: Evolve\n"  // step 15 -> B then A
+           "Running phase: TempPhaseA\n"
+           "Running phase: TempPhaseB\n"
+           "Running phase: Evolve\n"  // step 16
+           "Terminate Completion\n";
+  }
+
+  static std::string expected_log(
+      tmpl::type_<ComponentBeta<TestMetavariables>> /*meta*/) noexcept {
+    return "Running phase: Initialization\n" +
+           repeat("Running phase: Evolve\n", 3_st) +  // steps 1-3 -> B
+           "Terminate and Restart\n"
+           "Running phase: TempPhaseB\n" +
+           repeat("Running phase: Evolve\n", 2_st) +  // steps 4-5 -> A
+           "Running phase: TempPhaseA\n"
+           "Running phase: Evolve\n"  // step 6 -> B
+           "Terminate and Restart\n"
+           "Running phase: TempPhaseB\n" +
+           repeat("Running phase: Evolve\n", 3_st) +  // steps 8-9 -> B
+           "Terminate and Restart\n"
+           "Running phase: TempPhaseB\n"
+           "Running phase: Evolve\n"  // step 10 -> A
+           "Running phase: TempPhaseA\n" +
+           repeat("Running phase: Evolve\n", 2_st) +  // steps 11-12 -> B
+           "Terminate and Restart\n"
+           "Running phase: TempPhaseB\n" +
+           repeat("Running phase: Evolve\n", 3_st) +  // steps 13-15 -> A then B
+           "Terminate and Restart\n"
+           "Running phase: TempPhaseA\n"
+           "Running phase: TempPhaseB\n" +
+           repeat("Running phase: Evolve\n", 3_st) +  // steps 16-18
+           "Terminate Completion\n";
+  }
+
+  template <typename... Tags>
+  static Phase determine_next_phase(
+      const gsl::not_null<tuples::TaggedTuple<Tags...>*>
+          phase_change_decision_data,
+      const Phase& current_phase,
+      const Parallel::CProxy_GlobalCache<
+          TestMetavariables>& cache_proxy) noexcept {
+    const auto next_phase =
+        PhaseControl::arbitrate_phase_change<phase_changes, triggers>(
+            phase_change_decision_data, current_phase,
+            *(cache_proxy.ckLocalBranch()));
+    if (next_phase.has_value()) {
+      return next_phase.value();
+    }
+    switch (current_phase) {
+      case Phase::Initialization:
+        return Phase::Evolve;
+      case Phase::Evolve:
+        return Phase::Finalize;
+      case Phase::Finalize:
+      case Phase::Exit:
+        return Phase::Exit;
+      default:
+        ERROR("Unknown Phase...");
+    }
+
+    return Phase::Exit;
+  }
+};
+
+/// [charm_init_funcs_example]
+static const std::vector<void (*)()> charm_init_node_funcs{
+    &setup_error_handling,
+    &Parallel::register_derived_classes_with_charm<
+        Trigger<TestMetavariables::triggers>>,
+    &Parallel::register_derived_classes_with_charm<
+        Trigger<TestMetavariables::phase_changes>>};
+static const std::vector<void (*)()> charm_init_proc_funcs{
+    &enable_floating_point_exceptions};
+/// [charm_init_funcs_example]
+
+/// [charm_main_example]
+using charmxx_main_component = Parallel::Main<TestMetavariables>;
+/// [charm_main_example]
+
+#include "Parallel/CharmMain.tpp"  // IWYU pragma: keep

--- a/tests/Unit/Parallel/Test_AlgorithmPhaseControl.yaml
+++ b/tests/Unit/Parallel/Test_AlgorithmPhaseControl.yaml
@@ -1,0 +1,10 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# note that this is a vector of pairs, so has the peculiar '- -' for the
+# elements
+PhaseChangeAndTriggers:
+  - - TempPhaseATrigger:
+    - - VisitAndReturn(TempPhaseA)
+  - - TempPhaseBTrigger:
+    - - VisitAndReturn(TempPhaseB)


### PR DESCRIPTION
## Proposed changes

Adds some utilities for easily performing phase changes on both the side of the main chare and the component side, and adds the `VisitAndReturn` phase change that will be necessary for jumping to and from load-balancing and checkpointing phases.

As far as I know, the action and the `VisitAndReturn` phase change cannot be effectively tested with the action-testing framework (because they perform reductions directly to the main chare). These are currently tested with the `Test_AlgorithmPhaseControl.cpp` as a whole, but that's probably not a sustainable policy moving forward, because all of these PhaseChange objects will need to send reduction data to the Main chare, so I'd be glad to hear any creative suggestions for making the action-testing framework applicable to this case.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Dependencies

- [x] #2990