### PR TITLE
Include TensorExpression interface in Tensor.hpp and clean up TensorExpression includes

### DIFF
--- a/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
+++ b/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
@@ -6,16 +6,17 @@
 
 #pragma once
 
-#include <algorithm>
 #include <array>
 #include <cstddef>
+#include <type_traits>
+#include <utility>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Expressions/NumberAsExpression.hpp"
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
-#include "Utilities/Requires.hpp"
+#include "Utilities/ForceInline.hpp"
 #include "Utilities/TMPL.hpp"
-#include "Utilities/TypeTraits.hpp"
+
 /// \cond
 namespace TensorExpressions {
 template <typename T1, typename T2, typename ArgsList1, typename ArgsList2,

--- a/src/DataStructures/Tensor/Expressions/Contract.hpp
+++ b/src/DataStructures/Tensor/Expressions/Contract.hpp
@@ -9,10 +9,14 @@
 
 #include <array>
 #include <cstddef>
+#include <limits>
+#include <type_traits>
 #include <utility>
 
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Symmetry.hpp"
+#include "Utilities/ForceInline.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
 /*!

--- a/src/DataStructures/Tensor/Expressions/Evaluate.hpp
+++ b/src/DataStructures/Tensor/Expressions/Evaluate.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <array>
 #include <type_traits>
 
 #include "DataStructures/Tensor/Expressions/LhsTensorSymmAndIndices.hpp"
@@ -14,6 +15,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace TensorExpressions {
 

--- a/src/DataStructures/Tensor/Expressions/LhsTensorSymmAndIndices.hpp
+++ b/src/DataStructures/Tensor/Expressions/LhsTensorSymmAndIndices.hpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cstddef>
+#include <iterator>
 #include <utility>
 
 #include "DataStructures/Tensor/Structure.hpp"

--- a/src/DataStructures/Tensor/Expressions/Product.hpp
+++ b/src/DataStructures/Tensor/Expressions/Product.hpp
@@ -8,12 +8,17 @@
 
 #include <array>
 #include <cstddef>
+#include <iterator>
+#include <type_traits>
+#include <utility>
 
 #include "DataStructures/Tensor/Expressions/Contract.hpp"
 #include "DataStructures/Tensor/Expressions/NumberAsExpression.hpp"
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Symmetry.hpp"
 #include "Utilities/Algorithm.hpp"
+#include "Utilities/ForceInline.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace TensorExpressions {

--- a/src/DataStructures/Tensor/Expressions/SquareRoot.hpp
+++ b/src/DataStructures/Tensor/Expressions/SquareRoot.hpp
@@ -4,7 +4,10 @@
 #pragma once
 
 #include <array>
+#include <cmath>
 #include <cstddef>
+#include <type_traits>
+#include <utility>
 
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "Utilities/ForceInline.hpp"

--- a/src/DataStructures/Tensor/Expressions/TensorAsExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorAsExpression.hpp
@@ -8,16 +8,15 @@
 
 #include <array>
 #include <cstddef>
+#include <iterator>
+#include <type_traits>
 
-#include "DataStructures/Tensor/Expressions/LhsTensorSymmAndIndices.hpp"
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
-#include "DataStructures/Tensor/Symmetry.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/Algorithm.hpp"
-#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ForceInline.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
-#include "Utilities/TypeTraits/IsA.hpp"
 
 namespace TensorExpressions {
 /// \ingroup TensorExpressionsGroup

--- a/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
@@ -7,8 +7,9 @@
 
 #pragma once
 
-#include <array>
+#include <cassert>
 #include <cstddef>
+#include <type_traits>
 
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "Utilities/ForceInline.hpp"

--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -15,7 +15,13 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/ModalVector.hpp"
 #include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Tensor/Expressions/AddSubtract.hpp"
 #include "DataStructures/Tensor/Expressions/Contract.hpp"
+#include "DataStructures/Tensor/Expressions/Evaluate.hpp"
+#include "DataStructures/Tensor/Expressions/LhsTensorSymmAndIndices.hpp"
+#include "DataStructures/Tensor/Expressions/NumberAsExpression.hpp"
+#include "DataStructures/Tensor/Expressions/Product.hpp"
+#include "DataStructures/Tensor/Expressions/SquareRoot.hpp"
 #include "DataStructures/Tensor/Expressions/TensorAsExpression.hpp"
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
@@ -32,6 +38,8 @@
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
 #include "Utilities/TypeTraits/IsStreamable.hpp"
+// Not all the TensorExpression includes are necessary, but we include them so
+// that Tensor.hpp provides a uniform interface to Tensors and TensorExpressions
 
 /// \cond
 template <typename X, typename Symm = Symmetry<>,

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubtract.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubtract.cpp
@@ -8,9 +8,6 @@
 #include <numeric>
 
 #include "DataStructures/DataVector.hpp"
-#include "DataStructures/Tensor/Expressions/AddSubtract.hpp"
-#include "DataStructures/Tensor/Expressions/Evaluate.hpp"
-#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/MakeWithValue.hpp"
 

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubtract.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubtract.cpp
@@ -3,12 +3,17 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <climits>
 #include <cstddef>
 #include <iterator>
 #include <numeric>
+#include <type_traits>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Symmetry.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
 namespace {

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Contract.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Contract.cpp
@@ -3,14 +3,18 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <array>
+#include <climits>
 #include <cstddef>
 #include <iterator>
 #include <numeric>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Symmetry.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
-#include "Utilities/Requires.hpp"
 
 namespace {
 template <typename... Ts>

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Contract.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Contract.cpp
@@ -8,9 +8,6 @@
 #include <numeric>
 
 #include "DataStructures/DataVector.hpp"
-#include "DataStructures/Tensor/Expressions/Contract.hpp"
-#include "DataStructures/Tensor/Expressions/Evaluate.hpp"
-#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/Requires.hpp"

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Evaluate.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Evaluate.cpp
@@ -3,9 +3,13 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <type_traits>
+
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Expressions/Evaluate.hpp"
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Symmetry.hpp"
 #include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank0TestHelpers.hpp"
 #include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank1TestHelpers.hpp"
 #include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank2TestHelpers.hpp"

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_MixedOperations.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_MixedOperations.cpp
@@ -9,10 +9,6 @@
 #include <type_traits>
 
 #include "DataStructures/Tags/TempTensor.hpp"
-#include "DataStructures/Tensor/Expressions/AddSubtract.hpp"
-#include "DataStructures/Tensor/Expressions/Evaluate.hpp"
-#include "DataStructures/Tensor/Expressions/Product.hpp"
-#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Utilities/Gsl.hpp"

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_MixedOperations.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_MixedOperations.cpp
@@ -3,12 +3,16 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <climits>
 #include <cstddef>
 #include <iterator>
 #include <numeric>
 #include <type_traits>
 
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Symmetry.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Utilities/Gsl.hpp"

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Product.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Product.cpp
@@ -7,9 +7,6 @@
 #include <iterator>
 #include <numeric>
 
-#include "DataStructures/Tensor/Expressions/Evaluate.hpp"
-#include "DataStructures/Tensor/Expressions/Product.hpp"
-#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/MakeWithValue.hpp"
 

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Product.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Product.cpp
@@ -3,12 +3,19 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <climits>
 #include <cstddef>
 #include <iterator>
 #include <numeric>
+#include <type_traits>
 
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Symmetry.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace {
 template <typename... Ts>

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_ProductHighRankIntermediate.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_ProductHighRankIntermediate.cpp
@@ -7,9 +7,6 @@
 #include <iterator>
 #include <numeric>
 
-#include "DataStructures/Tensor/Expressions/Evaluate.hpp"
-#include "DataStructures/Tensor/Expressions/Product.hpp"
-#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/MakeWithValue.hpp"
 

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_ProductHighRankIntermediate.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_ProductHighRankIntermediate.cpp
@@ -3,12 +3,19 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <climits>
 #include <cstddef>
 #include <iterator>
 #include <numeric>
+#include <type_traits>
 
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Symmetry.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace {
 template <typename... Ts>

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_SquareRoot.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_SquareRoot.cpp
@@ -3,12 +3,17 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <climits>
 #include <cstddef>
 #include <iterator>
 #include <numeric>
+#include <type_traits>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Symmetry.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
 namespace {

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_SquareRoot.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_SquareRoot.cpp
@@ -8,10 +8,6 @@
 #include <numeric>
 
 #include "DataStructures/DataVector.hpp"
-#include "DataStructures/Tensor/Expressions/Evaluate.hpp"
-#include "DataStructures/Tensor/Expressions/Product.hpp"
-#include "DataStructures/Tensor/Expressions/SquareRoot.hpp"
-#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/MakeWithValue.hpp"
 

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank0TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank0TestHelpers.hpp
@@ -6,8 +6,6 @@
 #include <type_traits>
 
 #include "DataStructures/Tags/TempTensor.hpp"
-#include "DataStructures/Tensor/Expressions/Evaluate.hpp"
-#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Utilities/Gsl.hpp"

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank0TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank0TestHelpers.hpp
@@ -9,6 +9,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace TestHelpers::TensorExpressions {
 

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank1TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank1TestHelpers.hpp
@@ -9,8 +9,6 @@
 #include <type_traits>
 
 #include "DataStructures/Tags/TempTensor.hpp"
-#include "DataStructures/Tensor/Expressions/Evaluate.hpp"
-#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Utilities/GenerateInstantiations.hpp"

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank1TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank1TestHelpers.hpp
@@ -9,6 +9,8 @@
 #include <type_traits>
 
 #include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Symmetry.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Utilities/GenerateInstantiations.hpp"

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank2TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank2TestHelpers.hpp
@@ -9,8 +9,6 @@
 #include <type_traits>
 
 #include "DataStructures/Tags/TempTensor.hpp"
-#include "DataStructures/Tensor/Expressions/Evaluate.hpp"
-#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Utilities/GenerateInstantiations.hpp"

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank2TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank2TestHelpers.hpp
@@ -9,6 +9,8 @@
 #include <type_traits>
 
 #include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Symmetry.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Utilities/GenerateInstantiations.hpp"

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank3TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank3TestHelpers.hpp
@@ -4,16 +4,18 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <iterator>
 #include <numeric>
 #include <type_traits>
 
 #include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Symmetry.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
-#include "Utilities/Literals.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace TestHelpers::TensorExpressions {

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank3TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank3TestHelpers.hpp
@@ -9,8 +9,6 @@
 #include <type_traits>
 
 #include "DataStructures/Tags/TempTensor.hpp"
-#include "DataStructures/Tensor/Expressions/Evaluate.hpp"
-#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Utilities/GenerateInstantiations.hpp"

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank4TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank4TestHelpers.hpp
@@ -4,11 +4,13 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <iterator>
 #include <numeric>
 #include <type_traits>
 
 #include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/Symmetry.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Utilities/Gsl.hpp"

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank4TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank4TestHelpers.hpp
@@ -9,8 +9,6 @@
 #include <type_traits>
 
 #include "DataStructures/Tags/TempTensor.hpp"
-#include "DataStructures/Tensor/Expressions/Evaluate.hpp"
-#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Utilities/Gsl.hpp"

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorAsExpressionRank0TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorAsExpressionRank0TestHelpers.hpp
@@ -5,7 +5,6 @@
 
 #include <cstddef>
 
-#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 
 namespace TestHelpers::TensorExpressions {

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorAsExpressionRank0TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorAsExpressionRank0TestHelpers.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 
 #include "DataStructures/Tensor/Tensor.hpp"

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorAsExpressionRank1TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorAsExpressionRank1TestHelpers.hpp
@@ -3,11 +3,13 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <iterator>
 #include <numeric>
 
 #include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Symmetry.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 
 namespace TestHelpers::TensorExpressions {

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorAsExpressionRank1TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorAsExpressionRank1TestHelpers.hpp
@@ -7,7 +7,6 @@
 #include <iterator>
 #include <numeric>
 
-#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorAsExpressionRank2TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorAsExpressionRank2TestHelpers.hpp
@@ -3,11 +3,13 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <iterator>
 #include <numeric>
 
 #include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Symmetry.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 
 namespace TestHelpers::TensorExpressions {

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorAsExpressionRank2TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorAsExpressionRank2TestHelpers.hpp
@@ -7,7 +7,6 @@
 #include <iterator>
 #include <numeric>
 
-#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorAsExpressionRank3TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorAsExpressionRank3TestHelpers.hpp
@@ -3,11 +3,13 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <iterator>
 #include <numeric>
 
 #include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Symmetry.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 
 namespace TestHelpers::TensorExpressions {

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorAsExpressionRank3TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorAsExpressionRank3TestHelpers.hpp
@@ -7,7 +7,6 @@
 #include <iterator>
 #include <numeric>
 
-#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorAsExpressionRank4TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorAsExpressionRank4TestHelpers.hpp
@@ -3,11 +3,13 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <iterator>
 #include <numeric>
 
 #include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Symmetry.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 
 namespace TestHelpers::TensorExpressions {

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorAsExpressionRank4TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TensorAsExpressionRank4TestHelpers.hpp
@@ -7,7 +7,6 @@
 #include <iterator>
 #include <numeric>
 
-#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 


### PR DESCRIPTION
## Proposed changes

This PR adds to `Tensor.hpp` the `include`s necessary for interfacing with `TensorExpression`s - everything that's needed to write a tensor equation with `TensorExpression`s. As evidence that the `include`s appear to work properly, this PR also updates the `TensorExpression` tests that write tensor equations to simply include `Tensor.hpp` in lieu of including individual `DataStructures/Tensor/Expressions/....hpp` files for the generic indices, operations, and `evaluate`.

The motivation for this change is to have `#include DataStructures/Tensor/Tensor.hpp` provide all the ingredients necessary for writing a tensor equation with `TensorExpression`s:
- the generic indices (`TensorIndex`s)
- the operations (`+`, `-`, `*`, `/`, `sqrt`)
- the evaluation (`evaluate`) 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
