### PR TITLE
Avoid negative radii in SphericalCompression test

### DIFF
--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_SphericalCompression.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_SphericalCompression.cpp
@@ -227,7 +227,7 @@ void test_out_of_bounds_inverse(
       target_radius = max_radius + rad_dis(*generator) * min_radius +
                       std::numeric_limits<double>::epsilon();
     } else {
-      target_radius = min_radius - lambda_y - rad_dis(*generator) * min_radius -
+      target_radius = (min_radius - lambda_y) * (1.0 - rad_dis(*generator)) -
                       std::numeric_limits<double>::epsilon();
     }
   }


### PR DESCRIPTION
## Proposed changes

Fixes random test failure in the SphericalCompression test. I verified on clang-10 that the test passed 10k times without failure, whereas before the fix, it failed within 100 attempts. The failure was that when testing that the inverse map fails when a target radius is out of the expected bounds, sometimes the bad target radius was not only out of bounds but also negative. This caused the inverse to sometimes actually succeed when it should have failed.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
