### PR TITLE
Utilites for spacetime quantities on 2-surfaces

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -12,6 +12,7 @@ spectre_target_sources(
   DerivativesOfSpacetimeMetric.cpp
   ExtrinsicCurvature.cpp
   IndexManipulation.cpp
+  InterfaceNullNormal.cpp
   InverseSpacetimeMetric.cpp
   KerrSchildCoords.cpp
   Lapse.cpp
@@ -36,6 +37,7 @@ spectre_target_headers(
   DetAndInverseSpatialMetric.hpp
   ExtrinsicCurvature.hpp
   IndexManipulation.hpp
+  InterfaceNullNormal.hpp
   InverseSpacetimeMetric.hpp
   KerrSchildCoords.hpp
   Lapse.hpp

--- a/src/PointwiseFunctions/GeneralRelativity/InterfaceNullNormal.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/InterfaceNullNormal.cpp
@@ -1,0 +1,132 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/GeneralRelativity/InterfaceNullNormal.hpp"
+
+#include <cmath>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+namespace gr {
+template <size_t VolumeDim, typename Frame, typename DataType>
+tnsr::a<DataType, VolumeDim, Frame> interface_null_normal(
+    const tnsr::a<DataType, VolumeDim, Frame>& spacetime_normal_one_form,
+    const tnsr::i<DataType, VolumeDim, Frame>& interface_unit_normal_one_form,
+    const double sign) noexcept {
+  ASSERT((sign == 1.) or (sign == -1.),
+         "Calculation of interface null normal accepts only +1/-1 to indicate "
+         "whether the outgoing/incoming normal is needed.");
+  tnsr::a<DataType, VolumeDim, Frame> null_one_form(
+      get_size(get<0>(spacetime_normal_one_form)));
+  interface_null_normal(make_not_null(&null_one_form),
+                        spacetime_normal_one_form,
+                        interface_unit_normal_one_form, sign);
+  return null_one_form;
+}
+
+template <size_t VolumeDim, typename Frame, typename DataType>
+void interface_null_normal(
+    gsl::not_null<tnsr::a<DataType, VolumeDim, Frame>*> null_one_form,
+    const tnsr::a<DataType, VolumeDim, Frame>& spacetime_normal_one_form,
+    const tnsr::i<DataType, VolumeDim, Frame>& interface_unit_normal_one_form,
+    const double sign) noexcept {
+  ASSERT((sign == 1.) or (sign == -1.),
+         "Calculation of interface null normal accepts only +1/-1 to indicate "
+         "whether the outgoing/incoming normal is needed.");
+  destructive_resize_components(null_one_form,
+                                get_size(get<0>(spacetime_normal_one_form)));
+
+  const double one_by_sqrt_2 = 1. / sqrt(2.);
+  get<0>(*null_one_form) = one_by_sqrt_2 * get<0>(spacetime_normal_one_form);
+  for (size_t a = 1; a < VolumeDim + 1; ++a) {
+    null_one_form->get(a) =
+        one_by_sqrt_2 * (spacetime_normal_one_form.get(a) +
+                         sign * interface_unit_normal_one_form.get(a - 1));
+  }
+}
+
+template <size_t VolumeDim, typename Frame, typename DataType>
+tnsr::A<DataType, VolumeDim, Frame> interface_null_normal(
+    const tnsr::A<DataType, VolumeDim, Frame>& spacetime_normal_vector,
+    const tnsr::I<DataType, VolumeDim, Frame>& interface_unit_normal_vector,
+    const double sign) noexcept {
+  ASSERT((sign == 1.) or (sign == -1.),
+         "Calculation of interface null normal accepts only +1/-1 to indicate "
+         "whether the outgoing/incoming normal is needed.");
+  tnsr::A<DataType, VolumeDim, Frame> null_vector(
+      get_size(get<0>(spacetime_normal_vector)));
+  interface_null_normal(make_not_null(&null_vector), spacetime_normal_vector,
+                        interface_unit_normal_vector, sign);
+  return null_vector;
+}
+
+template <size_t VolumeDim, typename Frame, typename DataType>
+void interface_null_normal(
+    gsl::not_null<tnsr::A<DataType, VolumeDim, Frame>*> null_vector,
+    const tnsr::A<DataType, VolumeDim, Frame>& spacetime_normal_vector,
+    const tnsr::I<DataType, VolumeDim, Frame>& interface_unit_normal_vector,
+    const double sign) noexcept {
+  ASSERT((sign == 1.) or (sign == -1.),
+         "Calculation of interface null normal accepts only +1/-1 to indicate "
+         "whether the outgoing/incoming normal is needed.");
+  destructive_resize_components(null_vector,
+                                get_size(get<0>(spacetime_normal_vector)));
+
+  const double one_by_sqrt_2 = 1. / sqrt(2.);
+  get<0>(*null_vector) = one_by_sqrt_2 * get<0>(spacetime_normal_vector);
+  for (size_t a = 1; a < VolumeDim + 1; ++a) {
+    null_vector->get(a) =
+        one_by_sqrt_2 * (spacetime_normal_vector.get(a) +
+                         sign * interface_unit_normal_vector.get(a - 1));
+  }
+}
+}  // namespace gr
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                             \
+  template tnsr::a<DTYPE(data), DIM(data), FRAME(data)>                  \
+  gr::interface_null_normal(                                             \
+      const tnsr::a<DTYPE(data), DIM(data), FRAME(data)>&                \
+          spacetime_normal_one_form,                                     \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&                \
+          interface_unit_normal_one_form,                                \
+      const double sign) noexcept;                                       \
+  template void gr::interface_null_normal(                               \
+      const gsl::not_null<tnsr::a<DTYPE(data), DIM(data), FRAME(data)>*> \
+          null_one_form,                                                 \
+      const tnsr::a<DTYPE(data), DIM(data), FRAME(data)>&                \
+          spacetime_normal_one_form,                                     \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&                \
+          interface_unit_normal_one_form,                                \
+      const double sign) noexcept;                                       \
+  template tnsr::A<DTYPE(data), DIM(data), FRAME(data)>                  \
+  gr::interface_null_normal(                                             \
+      const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                \
+          spacetime_normal_vector,                                       \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>&                \
+          interface_unit_normal_vector,                                  \
+      const double sign) noexcept;                                       \
+  template void gr::interface_null_normal(                               \
+      const gsl::not_null<tnsr::A<DTYPE(data), DIM(data), FRAME(data)>*> \
+          null_vector,                                                   \
+      const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                \
+          spacetime_normal_vector,                                       \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>&                \
+          interface_unit_normal_vector,                                  \
+      const double sign) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
+                        (Frame::Grid, Frame::Inertial))
+
+#undef DIM
+#undef DTYPE
+#undef FRAME
+#undef INSTANTIATE
+/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/InterfaceNullNormal.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/InterfaceNullNormal.hpp
@@ -1,0 +1,77 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+/// \cond
+namespace gsl {
+template <typename>
+struct not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace gr {
+// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute null normal one-form to the boundary of a closed
+ * region in a spatial slice of spacetime.
+ *
+ * \details Consider an \f$n-1\f$-dimensional boundary \f$S\f$ of a closed
+ * region in an \f$n\f$-dimensional spatial hypersurface \f$\Sigma\f$. Let
+ * \f$s^a\f$ be the unit spacelike vector orthogonal to \f$S\f$ in \f$\Sigma\f$,
+ * and \f$n^a\f$ be the timelike unit vector orthogonal to \f$\Sigma\f$.
+ * This function returns the null one-form that is outgoing/incoming on \f$S\f$:
+ *
+ * \f{align*}
+ * k_a = \frac{1}{\sqrt{2}}\left(n_a \pm s_a\right).
+ * \f}
+ */
+template <size_t VolumeDim, typename Frame, typename DataType>
+tnsr::a<DataType, VolumeDim, Frame> interface_null_normal(
+    const tnsr::a<DataType, VolumeDim, Frame>& spacetime_normal_one_form,
+    const tnsr::i<DataType, VolumeDim, Frame>& interface_unit_normal_one_form,
+    const double sign) noexcept;
+
+template <size_t VolumeDim, typename Frame, typename DataType>
+void interface_null_normal(
+    gsl::not_null<tnsr::a<DataType, VolumeDim, Frame>*> null_one_form,
+    const tnsr::a<DataType, VolumeDim, Frame>& spacetime_normal_one_form,
+    const tnsr::i<DataType, VolumeDim, Frame>& interface_unit_normal_one_form,
+    const double sign) noexcept;
+// @}
+
+// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute null normal vector to the boundary of a closed
+ * region in a spatial slice of spacetime.
+ *
+ * \details Consider an \f$n-1\f$-dimensional boundary \f$S\f$ of a closed
+ * region in an \f$n\f$-dimensional spatial hypersurface \f$\Sigma\f$. Let
+ * \f$s^a\f$ be the unit spacelike vector orthogonal to \f$S\f$ in \f$\Sigma\f$,
+ * and \f$n^a\f$ be the timelike unit vector orthogonal to \f$\Sigma\f$.
+ * This function returns the null vector that is outgoing/ingoing on \f$S\f$:
+ *
+ * \f{align*}
+ * k^a = \frac{1}{\sqrt{2}}\left(n^a \pm s^a\right).
+ * \f}
+ */
+template <size_t VolumeDim, typename Frame, typename DataType>
+tnsr::A<DataType, VolumeDim, Frame> interface_null_normal(
+    const tnsr::A<DataType, VolumeDim, Frame>& spacetime_normal_vector,
+    const tnsr::I<DataType, VolumeDim, Frame>& interface_unit_normal_vector,
+    const double sign) noexcept;
+
+template <size_t VolumeDim, typename Frame, typename DataType>
+void interface_null_normal(
+    gsl::not_null<tnsr::A<DataType, VolumeDim, Frame>*> null_vector,
+    const tnsr::A<DataType, VolumeDim, Frame>& spacetime_normal_vector,
+    const tnsr::I<DataType, VolumeDim, Frame>& interface_unit_normal_vector,
+    const double sign) noexcept;
+// @}
+}  // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/ProjectionOperators.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ProjectionOperators.cpp
@@ -96,49 +96,230 @@ void transverse_projection_operator(
     projection_tensor->get(i, i) += 1.;
   }
 }
-// @}
+
+template <size_t VolumeDim, typename Frame, typename DataType>
+tnsr::AA<DataType, VolumeDim, Frame> transverse_projection_operator(
+    const tnsr::AA<DataType, VolumeDim, Frame>& inverse_spacetime_metric,
+    const tnsr::A<DataType, VolumeDim, Frame>& spacetime_normal_vector,
+    const tnsr::I<DataType, VolumeDim, Frame>&
+        interface_unit_normal_vector) noexcept {
+  tnsr::AA<DataType, VolumeDim, Frame> projection_tensor(
+      get_size(get<0>(spacetime_normal_vector)));
+  transverse_projection_operator(
+      make_not_null(&projection_tensor), inverse_spacetime_metric,
+      spacetime_normal_vector, interface_unit_normal_vector);
+  return projection_tensor;
+}
+
+template <size_t VolumeDim, typename Frame, typename DataType>
+void transverse_projection_operator(
+    const gsl::not_null<tnsr::AA<DataType, VolumeDim, Frame>*>
+        projection_tensor,
+    const tnsr::AA<DataType, VolumeDim, Frame>& inverse_spacetime_metric,
+    const tnsr::A<DataType, VolumeDim, Frame>& spacetime_normal_vector,
+    const tnsr::I<DataType, VolumeDim, Frame>&
+        interface_unit_normal_vector) noexcept {
+  destructive_resize_components(projection_tensor,
+                                get_size(get<0>(spacetime_normal_vector)));
+
+  for (size_t a = 0, b = 0; b < VolumeDim + 1; ++b) {
+    projection_tensor->get(a, b) =
+        inverse_spacetime_metric.get(a, b) +
+        spacetime_normal_vector.get(a) * spacetime_normal_vector.get(b);
+  }
+  for (size_t a = 1; a < VolumeDim + 1; ++a) {
+    for (size_t b = a; b < VolumeDim + 1; ++b) {
+      projection_tensor->get(a, b) =
+          inverse_spacetime_metric.get(a, b) +
+          spacetime_normal_vector.get(a) * spacetime_normal_vector.get(b) -
+          interface_unit_normal_vector.get(a - 1) *
+              interface_unit_normal_vector.get(b - 1);
+    }
+  }
+}
+
+template <size_t VolumeDim, typename Frame, typename DataType>
+tnsr::aa<DataType, VolumeDim, Frame> transverse_projection_operator(
+    const tnsr::aa<DataType, VolumeDim, Frame>& spacetime_metric,
+    const tnsr::a<DataType, VolumeDim, Frame>& spacetime_normal_one_form,
+    const tnsr::i<DataType, VolumeDim, Frame>&
+        interface_unit_normal_one_form) noexcept {
+  tnsr::aa<DataType, VolumeDim, Frame> projection_tensor(
+      get_size(get<0>(spacetime_normal_one_form)));
+  transverse_projection_operator(make_not_null(&projection_tensor),
+                                 spacetime_metric, spacetime_normal_one_form,
+                                 interface_unit_normal_one_form);
+  return projection_tensor;
+}
+
+template <size_t VolumeDim, typename Frame, typename DataType>
+void transverse_projection_operator(
+    const gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame>*>
+        projection_tensor,
+    const tnsr::aa<DataType, VolumeDim, Frame>& spacetime_metric,
+    const tnsr::a<DataType, VolumeDim, Frame>& spacetime_normal_one_form,
+    const tnsr::i<DataType, VolumeDim, Frame>&
+        interface_unit_normal_one_form) noexcept {
+  destructive_resize_components(projection_tensor,
+                                get_size(get<0>(spacetime_normal_one_form)));
+
+  for (size_t a = 0, b = 0; b < VolumeDim + 1; ++b) {
+    projection_tensor->get(a, b) =
+        spacetime_metric.get(a, b) +
+        spacetime_normal_one_form.get(a) * spacetime_normal_one_form.get(b);
+  }
+  for (size_t a = 1; a < VolumeDim + 1; ++a) {
+    for (size_t b = a; b < VolumeDim + 1; ++b) {
+      projection_tensor->get(a, b) =
+          spacetime_metric.get(a, b) +
+          spacetime_normal_one_form.get(a) * spacetime_normal_one_form.get(b) -
+          interface_unit_normal_one_form.get(a - 1) *
+              interface_unit_normal_one_form.get(b - 1);
+    }
+  }
+}
+
+template <size_t VolumeDim, typename Frame, typename DataType>
+tnsr::Ab<DataType, VolumeDim, Frame> transverse_projection_operator(
+    const tnsr::A<DataType, VolumeDim, Frame>& spacetime_normal_vector,
+    const tnsr::a<DataType, VolumeDim, Frame>& spacetime_normal_one_form,
+    const tnsr::I<DataType, VolumeDim, Frame>& interface_unit_normal_vector,
+    const tnsr::i<DataType, VolumeDim, Frame>&
+        interface_unit_normal_one_form) noexcept {
+  tnsr::Ab<DataType, VolumeDim, Frame> projection_tensor(
+      get_size(get<0>(spacetime_normal_vector)));
+  transverse_projection_operator(
+      make_not_null(&projection_tensor), spacetime_normal_vector,
+      spacetime_normal_one_form, interface_unit_normal_vector,
+      interface_unit_normal_one_form);
+  return projection_tensor;
+}
+
+template <size_t VolumeDim, typename Frame, typename DataType>
+void transverse_projection_operator(
+    const gsl::not_null<tnsr::Ab<DataType, VolumeDim, Frame>*>
+        projection_tensor,
+    const tnsr::A<DataType, VolumeDim, Frame>& spacetime_normal_vector,
+    const tnsr::a<DataType, VolumeDim, Frame>& spacetime_normal_one_form,
+    const tnsr::I<DataType, VolumeDim, Frame>& interface_unit_normal_vector,
+    const tnsr::i<DataType, VolumeDim, Frame>&
+        interface_unit_normal_one_form) noexcept {
+  destructive_resize_components(projection_tensor,
+                                get_size(get<0>(spacetime_normal_vector)));
+
+  for (size_t a = 0, b = 0; b < VolumeDim + 1; ++b) {
+    projection_tensor->get(a, b) =
+        spacetime_normal_vector.get(a) * spacetime_normal_one_form.get(b);
+    projection_tensor->get(b, a) =
+        spacetime_normal_vector.get(b) * spacetime_normal_one_form.get(a);
+  }
+  get<0, 0>(*projection_tensor) += 1.;
+
+  for (size_t a = 1; a < VolumeDim + 1; ++a) {
+    for (size_t b = 1; b < VolumeDim + 1; ++b) {
+      projection_tensor->get(a, b) =
+          spacetime_normal_vector.get(a) * spacetime_normal_one_form.get(b) -
+          interface_unit_normal_vector.get(a - 1) *
+              interface_unit_normal_one_form.get(b - 1);
+    }
+    projection_tensor->get(a, a) += 1.;
+  }
+}
 }  // namespace gr
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
 
-#define INSTANTIATE(_, data)                                               \
-  template tnsr::II<DTYPE(data), DIM(data), FRAME(data)>                   \
-  gr::transverse_projection_operator(                                      \
-      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                 \
-          inverse_spatial_metric,                                          \
-      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>&                  \
-          normal_vector) noexcept;                                         \
-  template tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>                   \
-  gr::transverse_projection_operator(                                      \
-      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& spatial_metric, \
-      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&                  \
-          normal_one_form) noexcept;                                       \
-  template tnsr::Ij<DTYPE(data), DIM(data), FRAME(data)>                   \
-  gr::transverse_projection_operator(                                      \
-      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& normal_vector,   \
-      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&                  \
-          normal_one_form) noexcept;                                       \
-  template void gr::transverse_projection_operator(                        \
-      const gsl::not_null<tnsr::II<DTYPE(data), DIM(data), FRAME(data)>*>  \
-          projection_tensor,                                               \
-      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                 \
-          inverse_spatial_metric,                                          \
-      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>&                  \
-          normal_vector) noexcept;                                         \
-  template void gr::transverse_projection_operator(                        \
-      const gsl::not_null<tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>*>  \
-          projection_tensor,                                               \
-      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& spatial_metric, \
-      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&                  \
-          normal_one_form) noexcept;                                       \
-  template void gr::transverse_projection_operator(                        \
-      const gsl::not_null<tnsr::Ij<DTYPE(data), DIM(data), FRAME(data)>*>  \
-          projection_tensor,                                               \
-      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& normal_vector,   \
-      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&                  \
-          normal_one_form) noexcept;
+#define INSTANTIATE(_, data)                                                 \
+  template tnsr::II<DTYPE(data), DIM(data), FRAME(data)>                     \
+  gr::transverse_projection_operator(                                        \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                   \
+          inverse_spatial_metric,                                            \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          normal_vector) noexcept;                                           \
+  template tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>                     \
+  gr::transverse_projection_operator(                                        \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& spatial_metric,   \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          normal_one_form) noexcept;                                         \
+  template tnsr::Ij<DTYPE(data), DIM(data), FRAME(data)>                     \
+  gr::transverse_projection_operator(                                        \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& normal_vector,     \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          normal_one_form) noexcept;                                         \
+  template void gr::transverse_projection_operator(                          \
+      const gsl::not_null<tnsr::II<DTYPE(data), DIM(data), FRAME(data)>*>    \
+          projection_tensor,                                                 \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                   \
+          inverse_spatial_metric,                                            \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          normal_vector) noexcept;                                           \
+  template void gr::transverse_projection_operator(                          \
+      const gsl::not_null<tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>*>    \
+          projection_tensor,                                                 \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& spatial_metric,   \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          normal_one_form) noexcept;                                         \
+  template void gr::transverse_projection_operator(                          \
+      const gsl::not_null<tnsr::Ij<DTYPE(data), DIM(data), FRAME(data)>*>    \
+          projection_tensor,                                                 \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& normal_vector,     \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          normal_one_form) noexcept;                                         \
+  template tnsr::AA<DTYPE(data), DIM(data), FRAME(data)>                     \
+  gr::transverse_projection_operator(                                        \
+      const tnsr::AA<DTYPE(data), DIM(data), FRAME(data)>&                   \
+          inverse_spacetime_metric,                                          \
+      const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          spacetime_normal_vector,                                           \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          interface_unit_normal_vector) noexcept;                            \
+  template tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>                     \
+  gr::transverse_projection_operator(                                        \
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& spacetime_metric, \
+      const tnsr::a<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          spacetime_normal_one_form,                                         \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          interface_unit_normal_one_form) noexcept;                          \
+  template tnsr::Ab<DTYPE(data), DIM(data), FRAME(data)>                     \
+  gr::transverse_projection_operator(                                        \
+      const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          spacetime_normal_vector,                                           \
+      const tnsr::a<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          spacetime_normal_one_form,                                         \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          interface_unit_normal_vector,                                      \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          interface_unit_normal_one_form) noexcept;                          \
+  template void gr::transverse_projection_operator(                          \
+      const gsl::not_null<tnsr::AA<DTYPE(data), DIM(data), FRAME(data)>*>    \
+          projection_tensor,                                                 \
+      const tnsr::AA<DTYPE(data), DIM(data), FRAME(data)>&                   \
+          inverse_spacetime_metric,                                          \
+      const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          spacetime_normal_vector,                                           \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          interface_unit_normal_vector) noexcept;                            \
+  template void gr::transverse_projection_operator(                          \
+      const gsl::not_null<tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>*>    \
+          projection_tensor,                                                 \
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& spacetime_metric, \
+      const tnsr::a<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          spacetime_normal_one_form,                                         \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          interface_unit_normal_one_form) noexcept;                          \
+  template void gr::transverse_projection_operator(                          \
+      const gsl::not_null<tnsr::Ab<DTYPE(data), DIM(data), FRAME(data)>*>    \
+          projection_tensor,                                                 \
+      const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          spacetime_normal_vector,                                           \
+      const tnsr::a<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          spacetime_normal_one_form,                                         \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          interface_unit_normal_vector,                                      \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          interface_unit_normal_one_form) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
                         (Frame::Grid, Frame::Inertial))

--- a/src/PointwiseFunctions/GeneralRelativity/ProjectionOperators.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ProjectionOperators.hpp
@@ -80,4 +80,103 @@ void transverse_projection_operator(
     const tnsr::I<DataType, VolumeDim, Frame>& normal_vector,
     const tnsr::i<DataType, VolumeDim, Frame>& normal_one_form) noexcept;
 // @}
+
+// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute spacetime projection operator onto an interface
+ *
+ * \details Consider an \f$n-1\f$-dimensional surface \f$S\f$ in an
+ * \f$n\f$-dimensional spatial hypersurface \f$\Sigma\f$. Let \f$s_a\f$
+ * be the unit spacelike one-form orthogonal to \f$S\f$ in \f$\Sigma\f$,
+ * and \f$n_a\f$ be the timelike unit vector orthogonal to \f$\Sigma\f$.
+ * This function returns the projection operator onto \f$S\f$ for
+ * \f$n+1\f$ dimensional quantities:
+ *
+ * \f{align*}
+ * P_{ab} = \psi_{ab} + n_a n_b - s_a s_b.
+ * \f}
+ */
+template <size_t VolumeDim, typename Frame, typename DataType>
+tnsr::aa<DataType, VolumeDim, Frame> transverse_projection_operator(
+    const tnsr::aa<DataType, VolumeDim, Frame>& spacetime_metric,
+    const tnsr::a<DataType, VolumeDim, Frame>& spacetime_normal_one_form,
+    const tnsr::i<DataType, VolumeDim, Frame>&
+        interface_unit_normal_one_form) noexcept;
+
+template <size_t VolumeDim, typename Frame, typename DataType>
+void transverse_projection_operator(
+    gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame>*> projection_tensor,
+    const tnsr::aa<DataType, VolumeDim, Frame>& spacetime_metric,
+    const tnsr::a<DataType, VolumeDim, Frame>& spacetime_normal_one_form,
+    const tnsr::i<DataType, VolumeDim, Frame>&
+        interface_unit_normal_one_form) noexcept;
+// @}
+
+// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute spacetime projection operator onto an interface
+ *
+ * \details Consider an \f$n-1\f$-dimensional surface \f$S\f$ in an
+ * \f$n\f$-dimensional spatial hypersurface \f$\Sigma\f$. Let \f$s^a\f$
+ * be the unit spacelike vector orthogonal to \f$S\f$ in \f$\Sigma\f$,
+ * and \f$n^a\f$ be the timelike unit vector orthogonal to \f$\Sigma\f$.
+ * This function returns the projection operator onto \f$S\f$ for
+ * \f$n+1\f$ dimensional quantities:
+ *
+ * \f{align*}
+ * P^{ab} = \psi^{ab} + n^a n^b - s^a s^b.
+ * \f}
+ */
+template <size_t VolumeDim, typename Frame, typename DataType>
+tnsr::AA<DataType, VolumeDim, Frame> transverse_projection_operator(
+    const tnsr::AA<DataType, VolumeDim, Frame>& inverse_spacetime_metric,
+    const tnsr::A<DataType, VolumeDim, Frame>& spacetime_normal_vector,
+    const tnsr::I<DataType, VolumeDim, Frame>&
+        interface_unit_normal_vector) noexcept;
+
+template <size_t VolumeDim, typename Frame, typename DataType>
+void transverse_projection_operator(
+    gsl::not_null<tnsr::AA<DataType, VolumeDim, Frame>*> projection_tensor,
+    const tnsr::AA<DataType, VolumeDim, Frame>& inverse_spacetime_metric,
+    const tnsr::A<DataType, VolumeDim, Frame>& spacetime_normal_vector,
+    const tnsr::I<DataType, VolumeDim, Frame>&
+        interface_unit_normal_vector) noexcept;
+// @}
+
+// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute spacetime projection operator onto an interface
+ *
+ * \details Consider an \f$n-1\f$-dimensional surface \f$S\f$ in an
+ * \f$n\f$-dimensional spatial hypersurface \f$\Sigma\f$. Let \f$s^a\f$
+ * \f$(s_a)\f$ be the unit spacelike vector (one-form) orthogonal
+ * to \f$S\f$ in \f$\Sigma\f$, and \f$n^a\f$ \f$(n_a)\f$ be the timelike
+ * unit vector (one-form) orthogonal to \f$\Sigma\f$. This function
+ * returns the projection operator onto \f$S\f$ for \f$n+1\f$ dimensional
+ * quantities:
+ *
+ * \f{align*}
+ * P^a_b = \delta^a_b + n^a n_b - s^a s_b.
+ * \f}
+ */
+template <size_t VolumeDim, typename Frame, typename DataType>
+tnsr::Ab<DataType, VolumeDim, Frame> transverse_projection_operator(
+    const tnsr::A<DataType, VolumeDim, Frame>& spacetime_normal_vector,
+    const tnsr::a<DataType, VolumeDim, Frame>& spacetime_normal_one_form,
+    const tnsr::I<DataType, VolumeDim, Frame>& interface_unit_normal_vector,
+    const tnsr::i<DataType, VolumeDim, Frame>&
+        interface_unit_normal_one_form) noexcept;
+
+template <size_t VolumeDim, typename Frame, typename DataType>
+void transverse_projection_operator(
+    gsl::not_null<tnsr::Ab<DataType, VolumeDim, Frame>*> projection_tensor,
+    const tnsr::A<DataType, VolumeDim, Frame>& spacetime_normal_vector,
+    const tnsr::a<DataType, VolumeDim, Frame>& spacetime_normal_one_form,
+    const tnsr::I<DataType, VolumeDim, Frame>& interface_unit_normal_vector,
+    const tnsr::i<DataType, VolumeDim, Frame>&
+        interface_unit_normal_one_form) noexcept;
+// @}
 }  // namespace gr

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_ComputeGhQuantities.cpp
   Test_ComputeSpacetimeQuantities.cpp
   Test_IndexManipulation.cpp
+  Test_InterfaceNullNormal.cpp
   Test_KerrSchildCoords.cpp
   Test_ProjectionOperators.cpp
   Test_Ricci.cpp

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/InterfaceNullNormal.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/InterfaceNullNormal.py
@@ -1,0 +1,18 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def interface_outgoing_null_normal(spacetime_normal_vector_or_one_form,
+                                   interface_normal_vector_or_one_form):
+    result = (2.**-0.5) * spacetime_normal_vector_or_one_form
+    result[1:] = result[1:] + (2.**-0.5) * interface_normal_vector_or_one_form
+    return result
+
+
+def interface_incoming_null_normal(spacetime_normal_vector_or_one_form,
+                                   interface_normal_vector_or_one_form):
+    result = (2.**-0.5) * spacetime_normal_vector_or_one_form
+    result[1:] = result[1:] - (2.**-0.5) * interface_normal_vector_or_one_form
+    return result

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/ProjectionOperators.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/ProjectionOperators.py
@@ -19,3 +19,25 @@ def transverse_projection_operator_mixed_from_spatial_input(
     normal_vector, normal_one_form):
     return (np.eye(np.shape(normal_vector)[0]) -
             np.einsum('i,j->ij', normal_vector, normal_one_form))
+
+
+def projection_operator_transverse_to_interface(
+    spacetime_metric_or_its_inverse, normal_vector_or_one_form,
+    interface_normal_vector_or_one_form):
+    interface_normal = np.zeros(1 + len(interface_normal_vector_or_one_form))
+    interface_normal[1:] = interface_normal_vector_or_one_form
+    return (spacetime_metric_or_its_inverse + np.einsum(
+        'i,j->ij', normal_vector_or_one_form, normal_vector_or_one_form) -
+            np.einsum('i,j->ij', interface_normal, interface_normal))
+
+
+def projection_operator_transverse_to_interface_mixed(
+    normal_vector, normal_one_form, interface_normal_vector,
+    interface_normal_one_form):
+    interface_normal_vec = np.zeros(1 + len(interface_normal_vector))
+    interface_normal_1form = np.zeros(1 + len(interface_normal_one_form))
+    interface_normal_vec[1:] = interface_normal_vector
+    interface_normal_1form[1:] = interface_normal_one_form
+    return (np.eye(np.shape(normal_vector)[0]) +
+            np.einsum('i,j->ij', normal_vector, normal_one_form) -
+            np.einsum('i,j->ij', interface_normal_vec, interface_normal_1form))

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_InterfaceNullNormal.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_InterfaceNullNormal.cpp
@@ -1,0 +1,93 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "PointwiseFunctions/GeneralRelativity/InterfaceNullNormal.hpp"
+
+namespace {
+template <size_t SpatialDim, typename DataType>
+tnsr::A<DataType, SpatialDim, Frame::Inertial>
+interface_outgoing_null_normal_one_form(
+    const tnsr::A<DataType, SpatialDim, Frame::Inertial>&
+        spacetime_normal_one_form,
+    const tnsr::I<DataType, SpatialDim, Frame::Inertial>&
+        interface_normal_one_form) noexcept {
+  return gr::interface_null_normal<SpatialDim, Frame::Inertial, DataType>(
+      spacetime_normal_one_form, interface_normal_one_form, 1.);
+}
+template <size_t SpatialDim, typename DataType>
+tnsr::A<DataType, SpatialDim, Frame::Inertial>
+interface_incoming_null_normal_one_form(
+    const tnsr::A<DataType, SpatialDim, Frame::Inertial>&
+        spacetime_normal_one_form,
+    const tnsr::I<DataType, SpatialDim, Frame::Inertial>&
+        interface_normal_one_form) noexcept {
+  return gr::interface_null_normal<SpatialDim, Frame::Inertial, DataType>(
+      spacetime_normal_one_form, interface_normal_one_form, -1.);
+}
+template <size_t SpatialDim, typename DataType>
+tnsr::A<DataType, SpatialDim, Frame::Inertial>
+interface_outgoing_null_normal_vector(
+    const tnsr::A<DataType, SpatialDim, Frame::Inertial>&
+        spacetime_normal_vector,
+    const tnsr::I<DataType, SpatialDim, Frame::Inertial>&
+        interface_normal_vector) noexcept {
+  return gr::interface_null_normal<SpatialDim, Frame::Inertial, DataType>(
+      spacetime_normal_vector, interface_normal_vector, 1.);
+}
+template <size_t SpatialDim, typename DataType>
+tnsr::A<DataType, SpatialDim, Frame::Inertial>
+interface_incoming_null_normal_vector(
+    const tnsr::A<DataType, SpatialDim, Frame::Inertial>&
+        spacetime_normal_vector,
+    const tnsr::I<DataType, SpatialDim, Frame::Inertial>&
+        interface_normal_vector) noexcept {
+  return gr::interface_null_normal<SpatialDim, Frame::Inertial, DataType>(
+      spacetime_normal_vector, interface_normal_vector, -1.);
+}
+
+template <size_t SpatialDim, typename DataType>
+void test_interface_null_normals(const DataType& used_for_size) {
+  {
+    auto* f = &interface_outgoing_null_normal_one_form<SpatialDim, DataType>;
+    pypp::check_with_random_values<1>(f, "InterfaceNullNormal",
+                                      "interface_outgoing_null_normal",
+                                      {{{-1., 1.}}}, used_for_size);
+  }
+  {
+    auto* f = &interface_outgoing_null_normal_vector<SpatialDim, DataType>;
+    pypp::check_with_random_values<1>(f, "InterfaceNullNormal",
+                                      "interface_outgoing_null_normal",
+                                      {{{-1., 1.}}}, used_for_size);
+  }
+  {
+    auto* f = &interface_incoming_null_normal_one_form<SpatialDim, DataType>;
+    pypp::check_with_random_values<1>(f, "InterfaceNullNormal",
+                                      "interface_incoming_null_normal",
+                                      {{{-1., 1.}}}, used_for_size);
+  }
+  {
+    auto* f = &interface_incoming_null_normal_vector<SpatialDim, DataType>;
+    pypp::check_with_random_values<1>(f, "InterfaceNullNormal",
+                                      "interface_incoming_null_normal",
+                                      {{{-1., 1.}}}, used_for_size);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.IntfcNullNormals",
+                  "[PointwiseFunctions][Unit]") {
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "PointwiseFunctions/GeneralRelativity/");
+
+  GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
+
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_interface_null_normals, (1, 2, 3));
+}

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ProjectionOperators.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ProjectionOperators.cpp
@@ -61,6 +61,44 @@ void test_projection_operator(const DataType& used_for_size) {
         "transverse_projection_operator_mixed_from_spatial_input",
         {{{-1., 1.}}}, used_for_size);
   }
+
+  {
+    tnsr::AA<DataType, SpatialDim, Frame::Inertial> (*f)(
+        const tnsr::AA<DataType, SpatialDim, Frame::Inertial>&,
+        const tnsr::A<DataType, SpatialDim, Frame::Inertial>&,
+        const tnsr::I<DataType, SpatialDim, Frame::Inertial>&) =
+        &gr::transverse_projection_operator<SpatialDim, Frame::Inertial,
+                                            DataType>;
+    pypp::check_with_random_values<1>(
+        f, "ProjectionOperators", "projection_operator_transverse_to_interface",
+        {{{-1., 1.}}}, used_for_size);
+  }
+
+  {
+    tnsr::aa<DataType, SpatialDim, Frame::Inertial> (*f)(
+        const tnsr::aa<DataType, SpatialDim, Frame::Inertial>&,
+        const tnsr::a<DataType, SpatialDim, Frame::Inertial>&,
+        const tnsr::i<DataType, SpatialDim, Frame::Inertial>&) =
+        &gr::transverse_projection_operator<SpatialDim, Frame::Inertial,
+                                            DataType>;
+    pypp::check_with_random_values<1>(
+        f, "ProjectionOperators", "projection_operator_transverse_to_interface",
+        {{{-1., 1.}}}, used_for_size);
+  }
+
+  {
+    tnsr::Ab<DataType, SpatialDim, Frame::Inertial> (*f)(
+        const tnsr::A<DataType, SpatialDim, Frame::Inertial>&,
+        const tnsr::a<DataType, SpatialDim, Frame::Inertial>&,
+        const tnsr::I<DataType, SpatialDim, Frame::Inertial>&,
+        const tnsr::i<DataType, SpatialDim, Frame::Inertial>&) =
+        &gr::transverse_projection_operator<SpatialDim, Frame::Inertial,
+                                            DataType>;
+    pypp::check_with_random_values<1>(
+        f, "ProjectionOperators",
+        "projection_operator_transverse_to_interface_mixed", {{{-1., 1.}}},
+        used_for_size);
+  }
 }
 }  // namespace
 


### PR DESCRIPTION
## Proposed changes

This PR adds two sets of utilities:
1. functions to compute projection operators (for spacetime quantities) onto 2-surfaces in spatial slices,
2. functions to compute incoming and outgoing null normal vectors and one-forms on given interfaces.

These will be useful for applying external boundary conditions for the GH system.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
