### PR TITLE
Constraint-preserving boundary terms for VSpacetimeMetric

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.cpp
@@ -1,0 +1,68 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.hpp"
+
+#include <algorithm>
+#include <array>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace GeneralizedHarmonic::BoundaryConditions::Bjorhus {
+template <size_t VolumeDim, typename DataType>
+void constraint_preserving_bjorhus_corrections_dt_v_psi(
+    const gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame::Inertial>*>
+        bc_dt_v_psi,
+    const tnsr::I<DataType, VolumeDim, Frame::Inertial>&
+        unit_interface_normal_vector,
+    const tnsr::iaa<DataType, VolumeDim, Frame::Inertial>&
+        three_index_constraint,
+    const std::array<DataType, 4>& char_speeds) noexcept {
+  if (UNLIKELY(get_size(get<0, 0>(*bc_dt_v_psi)) !=
+               get_size(get<0>(unit_interface_normal_vector)))) {
+    *bc_dt_v_psi = tnsr::aa<DataType, VolumeDim, Frame::Inertial>{
+        get_size(get<0>(unit_interface_normal_vector))};
+  }
+  for (size_t a = 0; a <= VolumeDim; ++a) {
+    for (size_t b = a; b <= VolumeDim; ++b) {
+      bc_dt_v_psi->get(a, b) = char_speeds[0] *
+                               unit_interface_normal_vector.get(0) *
+                               three_index_constraint.get(0, a, b);
+      for (size_t i = 1; i < VolumeDim; ++i) {
+        bc_dt_v_psi->get(a, b) += char_speeds[0] *
+                                  unit_interface_normal_vector.get(i) *
+                                  three_index_constraint.get(i, a, b);
+      }
+    }
+  }
+}
+}  // namespace GeneralizedHarmonic::BoundaryConditions::Bjorhus
+
+// Explicit Instantiations
+/// \cond
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                        \
+  template void GeneralizedHarmonic::BoundaryConditions::Bjorhus::  \
+      constraint_preserving_bjorhus_corrections_dt_v_psi(           \
+          const gsl::not_null<                                      \
+              tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>*>   \
+              bc_dt_v_psi,                                          \
+          const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>&   \
+              unit_interface_normal_vector,                         \
+          const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>& \
+              three_index_constraint,                               \
+          const std::array<DTYPE(data), 4>& char_speeds) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (DataVector))
+
+#undef INSTANTIATE
+#undef DTYPE
+#undef DIM
+/// \endcond

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.hpp
@@ -1,0 +1,51 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+
+/// \cond
+class DataVector;
+namespace gsl {
+template <class T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace GeneralizedHarmonic::BoundaryConditions {
+/// \brief Detailed implementation of Bjorhus-type boundary corrections
+namespace Bjorhus {
+// @{
+/*!
+ * \brief Computes the expression needed to set boundary conditions on the time
+ * derivative of the characteristic field \f$v^{\psi}_{ab}\f$
+ *
+ * \details In the Bjorhus scheme, the time derivatives of evolved variables are
+ * characteristic projected. A constraint-preserving correction term is added
+ * here to the resulting characteristic (time-derivative) field:
+ *
+ * \f{align}
+ * \Delta \partial_t v^{\psi}_{ab} = \lambda_{\psi} n^i C_{iab}
+ * \f}
+ *
+ * where \f$n^i\f$ is the local unit normal to the external boundary,
+ * \f$C_{iab} = \partial_i \psi_{ab} - \Phi_{iab}\f$ is the three-index
+ * constraint, and \f$\lambda_{\psi}\f$ is the characteristic speed of the field
+ * \f$v^{\psi}_{ab}\f$.
+ */
+template <size_t VolumeDim, typename DataType>
+void constraint_preserving_bjorhus_corrections_dt_v_psi(
+    gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame::Inertial>*> bc_dt_v_psi,
+    const tnsr::I<DataType, VolumeDim, Frame::Inertial>&
+        unit_interface_normal_vector,
+    const tnsr::iaa<DataType, VolumeDim, Frame::Inertial>&
+        three_index_constraint,
+    const std::array<DataType, 4>& char_speeds) noexcept;
+// @}
+}  // namespace Bjorhus
+}  // namespace GeneralizedHarmonic::BoundaryConditions

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/CMakeLists.txt
@@ -4,6 +4,7 @@
 spectre_target_sources(
   GeneralizedHarmonic
   PRIVATE
+  BjorhusImpl.cpp
   BoundaryCondition.cpp
   DirichletAnalytic.cpp
   RegisterDerivedWithCharm.cpp
@@ -13,6 +14,7 @@ spectre_target_headers(
   GeneralizedHarmonic
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  BjorhusImpl.hpp
   BoundaryCondition.hpp
   DirichletAnalytic.hpp
   Factory.hpp

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.py
@@ -1,0 +1,10 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def constraint_preserving_bjorhus_corrections_dt_v_psi(
+    unit_interface_normal_vector, three_index_constraint, char_speeds):
+    return (char_speeds[0] * np.einsum(
+        'i,iab->ab', unit_interface_normal_vector, three_index_constraint))

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_BjorhusImpl.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_BjorhusImpl.cpp
@@ -1,0 +1,216 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Side.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+using frame = Frame::Inertial;
+constexpr size_t VolumeDim = 3;
+
+// Test boundary conditions on dt<VSpacetimeMetric> in 3D against SpEC
+void test_constraint_preserving_bjorhus_v_psi_vs_spec_3d(
+    const size_t grid_size_each_dimension) noexcept {
+  // Setup grid
+  Mesh<VolumeDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+  const Direction<VolumeDim> direction(1, Side::Upper);  // +y direction
+  const size_t slice_grid_points =
+      mesh.extents().slice_away(direction.dimension()).product();
+
+  // Populate various tensors needed to compute BcDtVSpacetimeMetric
+  tnsr::iaa<DataVector, VolumeDim, frame> local_three_index_constraint(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+  tnsr::I<DataVector, VolumeDim, frame> local_unit_interface_normal_vector(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+  std::array<DataVector, 4> local_char_speeds{
+      DataVector(slice_grid_points,
+                 std::numeric_limits<double>::signaling_NaN()),
+      DataVector(slice_grid_points,
+                 std::numeric_limits<double>::signaling_NaN()),
+      DataVector(slice_grid_points,
+                 std::numeric_limits<double>::signaling_NaN()),
+      DataVector(slice_grid_points,
+                 std::numeric_limits<double>::signaling_NaN())};
+  // Allocate memory for output
+  tnsr::aa<DataVector, VolumeDim, frame> local_bc_dt_v_psi(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+
+  {
+    // Setting the 3-index constraint
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = 0; b <= VolumeDim; ++b) {
+          // In SpEC, this constraint is explicitly computed using
+          // d_i psi_ab and phi_iab as inputs. The explicit subtractions
+          // below are here to remind us what values those two input
+          // tensors were set to in SpEC to get the desired BC in this test.
+          local_three_index_constraint.get(0, a, b)[i] = 11. - 3.;
+          local_three_index_constraint.get(1, a, b)[i] = 13. - 5.;
+          local_three_index_constraint.get(2, a, b)[i] = 17. - 7.;
+        }
+      }
+    }
+    // Setting unit_interface_normal_Vector
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      get<0>(local_unit_interface_normal_vector)[i] = -1.;
+      get<1>(local_unit_interface_normal_vector)[i] = 0.;
+      get<2>(local_unit_interface_normal_vector)[i] = 0.;
+    }
+    // Setting char speeds
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      local_char_speeds.at(0)[i] = -0.3;
+      local_char_speeds.at(1)[i] = -0.1;
+    }
+
+    // Compute rhs value
+    GeneralizedHarmonic::BoundaryConditions::Bjorhus::
+        constraint_preserving_bjorhus_corrections_dt_v_psi(
+            make_not_null(&local_bc_dt_v_psi),
+            local_unit_interface_normal_vector, local_three_index_constraint,
+            local_char_speeds);
+    // Setting local_RhsVSpacetimeMetric
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        local_bc_dt_v_psi.get(0, a)[i] += 23.;
+      }
+      for (size_t a = 1; a <= VolumeDim; ++a) {
+        local_bc_dt_v_psi.get(1, a)[i] += 29.;
+      }
+      for (size_t a = 2; a <= VolumeDim; ++a) {
+        local_bc_dt_v_psi.get(2, a)[i] += 31.;
+      }
+      local_bc_dt_v_psi.get(3, 3)[i] += 37.;
+    }
+  }
+  // Initialize with values from SpEC
+  auto spec_bc_dt_v_psi =
+      make_with_value<tnsr::aa<DataVector, VolumeDim, frame>>(
+          local_bc_dt_v_psi, std::numeric_limits<double>::signaling_NaN());
+
+  for (size_t i = 0; i < slice_grid_points; ++i) {
+    for (size_t a = 0; a <= VolumeDim; ++a) {
+      spec_bc_dt_v_psi.get(0, a)[i] = 25.4;
+    }
+    get<1, 1>(spec_bc_dt_v_psi)[i] = 31.4;
+    get<1, 2>(spec_bc_dt_v_psi)[i] = 31.4;
+    get<1, 3>(spec_bc_dt_v_psi)[i] = 31.4;
+    get<2, 2>(spec_bc_dt_v_psi)[i] = 33.4;
+    get<2, 3>(spec_bc_dt_v_psi)[i] = 33.4;
+    get<3, 3>(spec_bc_dt_v_psi)[i] = 39.4;
+  }
+
+  // Compare values returned by BC action vs those from SpEC
+  CHECK_ITERABLE_APPROX(local_bc_dt_v_psi, spec_bc_dt_v_psi);
+
+  // Test for another set of values
+  {
+    // Setting unit_interface_normal_Vector
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      get<0>(local_unit_interface_normal_vector)[i] = -1.;
+      get<1>(local_unit_interface_normal_vector)[i] = 1.;
+      get<2>(local_unit_interface_normal_vector)[i] = 1.;
+    }
+    // Compute rhs value
+    GeneralizedHarmonic::BoundaryConditions::Bjorhus::
+        constraint_preserving_bjorhus_corrections_dt_v_psi(
+            make_not_null(&local_bc_dt_v_psi),
+            local_unit_interface_normal_vector, local_three_index_constraint,
+            local_char_speeds);
+    // Setting local_RhsVSpacetimeMetric
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        local_bc_dt_v_psi.get(0, a)[i] += 23.;
+      }
+      for (size_t a = 1; a <= VolumeDim; ++a) {
+        local_bc_dt_v_psi.get(1, a)[i] += 29.;
+      }
+      for (size_t a = 2; a <= VolumeDim; ++a) {
+        local_bc_dt_v_psi.get(2, a)[i] += 31.;
+      }
+      local_bc_dt_v_psi.get(3, 3)[i] += 37.;
+    }
+  }
+
+  // Initialize with values from SpEC
+  for (size_t i = 0; i < slice_grid_points; ++i) {
+    for (size_t a = 0; a <= VolumeDim; ++a) {
+      spec_bc_dt_v_psi.get(0, a)[i] = 20.;
+    }
+    get<1, 1>(spec_bc_dt_v_psi)[i] = 26.;
+    get<1, 2>(spec_bc_dt_v_psi)[i] = 26.;
+    get<1, 3>(spec_bc_dt_v_psi)[i] = 26.;
+    get<2, 2>(spec_bc_dt_v_psi)[i] = 28.;
+    get<2, 3>(spec_bc_dt_v_psi)[i] = 28.;
+    get<3, 3>(spec_bc_dt_v_psi)[i] = 34.;
+  }
+
+  // Compare values returned by BC action vs those from SpEC
+  CHECK_ITERABLE_APPROX(local_bc_dt_v_psi, spec_bc_dt_v_psi);
+}
+}  // namespace
+
+// Python tests
+namespace {
+template <size_t VolumeDim>
+tnsr::aa<DataVector, VolumeDim, Frame::Inertial> wrapper_func_v_psi(
+    const tnsr::I<DataVector, VolumeDim, Frame::Inertial>&
+        interface_normal_vector,
+    const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>&
+        three_index_constraint,
+    const tnsr::a<DataVector, 3, Frame::Inertial>& char_speeds) {
+  std::array<DataVector, 4> char_speed_array{
+      {get<0>(char_speeds), get<1>(char_speeds), get<2>(char_speeds),
+       get<3>(char_speeds)}};
+  auto dt_v_psi =
+      make_with_value<tnsr::aa<DataVector, VolumeDim, Frame::Inertial>>(
+          interface_normal_vector, 0.);
+  GeneralizedHarmonic::BoundaryConditions::Bjorhus::
+      constraint_preserving_bjorhus_corrections_dt_v_psi<VolumeDim, DataVector>(
+          make_not_null(&dt_v_psi), interface_normal_vector,
+          three_index_constraint, char_speed_array);
+  return dt_v_psi;
+}
+
+template <size_t VolumeDim>
+void test_constraint_preserving_bjorhus_corrections_dt_v_psi(
+    const size_t grid_size_each_dimension) noexcept {
+  pypp::check_with_random_values<1>(
+      &wrapper_func_v_psi<VolumeDim>,
+      "Evolution.Systems.GeneralizedHarmonic.BoundaryConditions.Bjorhus",
+      "constraint_preserving_bjorhus_corrections_dt_v_psi", {{{-1., 1.}}},
+      DataVector(grid_size_each_dimension));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.BCBjorhus.VPsi",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{""};
+
+  // Piece-wise tests with SpEC output
+  const size_t grid_size = 3;
+
+  // Python tests
+  test_constraint_preserving_bjorhus_corrections_dt_v_psi<1>(grid_size);
+  test_constraint_preserving_bjorhus_corrections_dt_v_psi<2>(grid_size);
+  test_constraint_preserving_bjorhus_corrections_dt_v_psi<3>(grid_size);
+
+  // Piece-wise tests with SpEC output in 3D
+  test_constraint_preserving_bjorhus_v_psi_vs_spec_3d(grid_size);
+}

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory(ConstraintDamping)
 set(LIBRARY "Test_GeneralizedHarmonic")
 
 set(LIBRARY_SOURCES
+  BoundaryConditions/Test_BjorhusImpl.cpp
   BoundaryConditions/Test_DirichletAnalytic.cpp
   BoundaryConditions/Test_Periodic.cpp
   BoundaryCorrections/Test_UpwindPenalty.cpp


### PR DESCRIPTION
## Proposed changes

This PR adds free functions that calculate Bjorhus-type corrections to the characteristic-projected time-derivatives of the evolved GH variables, that damp out constraint violations at the external boundary. 


### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
