### PR TITLE
Constraint-preserving boundary terms for VZero (GH)

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.cpp
@@ -7,6 +7,7 @@
 #include <array>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/LeviCivitaIterator.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
@@ -41,6 +42,65 @@ void constraint_preserving_bjorhus_corrections_dt_v_psi(
     }
   }
 }
+
+template <size_t VolumeDim, typename DataType>
+void constraint_preserving_bjorhus_corrections_dt_v_zero(
+    const gsl::not_null<tnsr::iaa<DataType, VolumeDim, Frame::Inertial>*>
+        bc_dt_v_zero,
+    const tnsr::I<DataType, VolumeDim, Frame::Inertial>&
+        unit_interface_normal_vector,
+    const tnsr::iaa<DataType, VolumeDim, Frame::Inertial>&
+        four_index_constraint,
+    const std::array<DataType, 4>& char_speeds) noexcept {
+  if (UNLIKELY(get_size(get<0, 0, 0>(*bc_dt_v_zero)) !=
+               get_size(get<0>(unit_interface_normal_vector)))) {
+    *bc_dt_v_zero = tnsr::iaa<DataType, VolumeDim, Frame::Inertial>{
+        get_size(get<0>(unit_interface_normal_vector))};
+  }
+  std::fill(bc_dt_v_zero->begin(), bc_dt_v_zero->end(), 0.);
+
+  if (LIKELY(VolumeDim == 3)) {
+    for (size_t a = 0; a <= VolumeDim; ++a) {
+      for (size_t b = a; b <= VolumeDim; ++b) {
+        // Lets say this term is T2_{iab} := - n_l \beta^l n^j C_{jiab}.
+        // But we store D_{iab} = LeviCivita^{ijk} dphi_{jkab},
+        // and C_{ijab} = LeviCivita^{kij} D_{kab}
+        // where D is `four_index_constraint`.
+        // therefore, T2_{iab} =  char_speed<VZero> n^j C_{jiab}
+        // (since char_speed<VZero> = - n_l \beta^l), and therefore:
+        // T2_{iab} = char_speed<VZero> n^j LeviCivita^{ikj} D_{kab}.
+        // Let LeviCivitaIterator be indexed by
+        // it[0] <--> i,
+        // it[1] <--> j,
+        // it[2] <--> k, then
+        // T2_{it[0], ab} += char_speed<VZero> n^it[2] it.sign() D_{it[1], ab};
+        for (LeviCivitaIterator<VolumeDim> it; it; ++it) {
+          bc_dt_v_zero->get(it[0], a, b) +=
+              it.sign() * char_speeds[1] *
+              unit_interface_normal_vector.get(it[2]) *
+              four_index_constraint.get(it[1], a, b);
+        }
+      }
+    }
+  } else if (LIKELY(VolumeDim == 2)) {
+    for (size_t a = 0; a <= VolumeDim; ++a) {
+      for (size_t b = a; b <= VolumeDim; ++b) {
+        // Lets say this term is T2_{kab} := - n_l \beta^l n^j C_{jkab}.
+        // In 2+1 spacetime, we store the four index constraint to
+        // be D_{1ab} = C_{12ab}, C_{2ab} = C_{21ab}. Therefore,
+        // T_{kab} = -n_l \beta^l (n^1 C_{1kab} + n^2 C_{2kab}), i.e.
+        // T_{1ab} = -n_l \beta^l n^2 D_{2ab}, T_{2ab} = -n_l \beta^l n^1
+        // D_{1ab}.
+        bc_dt_v_zero->get(0, a, b) +=
+            char_speeds[1] * (unit_interface_normal_vector.get(1) *
+                              four_index_constraint.get(1, a, b));
+        bc_dt_v_zero->get(1, a, b) +=
+            char_speeds[1] * (unit_interface_normal_vector.get(0) *
+                              four_index_constraint.get(0, a, b));
+      }
+    }
+  }
+}
 }  // namespace GeneralizedHarmonic::BoundaryConditions::Bjorhus
 
 // Explicit Instantiations
@@ -57,6 +117,16 @@ void constraint_preserving_bjorhus_corrections_dt_v_psi(
               unit_interface_normal_vector,                         \
           const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>& \
               three_index_constraint,                               \
+          const std::array<DTYPE(data), 4>& char_speeds) noexcept;  \
+  template void GeneralizedHarmonic::BoundaryConditions::Bjorhus::  \
+      constraint_preserving_bjorhus_corrections_dt_v_zero(          \
+          const gsl::not_null<                                      \
+              tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>*>  \
+              bc_dt_v_zero,                                         \
+          const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>&   \
+              unit_interface_normal_vector,                         \
+          const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>& \
+              four_index_constraint,                                \
           const std::array<DTYPE(data), 4>& char_speeds) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (DataVector))

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.hpp
@@ -20,7 +20,6 @@ class not_null;
 namespace GeneralizedHarmonic::BoundaryConditions {
 /// \brief Detailed implementation of Bjorhus-type boundary corrections
 namespace Bjorhus {
-// @{
 /*!
  * \brief Computes the expression needed to set boundary conditions on the time
  * derivative of the characteristic field \f$v^{\psi}_{ab}\f$
@@ -46,6 +45,37 @@ void constraint_preserving_bjorhus_corrections_dt_v_psi(
     const tnsr::iaa<DataType, VolumeDim, Frame::Inertial>&
         three_index_constraint,
     const std::array<DataType, 4>& char_speeds) noexcept;
-// @}
+
+/*!
+ * \brief Computes the expression needed to set boundary conditions on the time
+ * derivative of the characteristic field \f$v^{0}_{iab}\f$
+ *
+ * \details In the Bjorhus scheme, the time derivatives of evolved variables are
+ * characteristic projected. A constraint-preserving correction term is added
+ * here to the resulting characteristic (time-derivative) field \f$v^0_{iab}\f$:
+ *
+ * \f{align}
+ * \Delta \partial_t v^{0}_{iab} = \lambda_{0} n^j C_{jiab}
+ * \f}
+ *
+ * where \f$n^i\f$ is the local unit normal to the external boundary,
+ * \f$C_{ijab} = \partial_i\Phi_{jab} - \partial_j\Phi_{iab}\f$ is the
+ * four-index constraint, and \f$\lambda_{0}\f$ is the characteristic speed of
+ * the field \f$v^0_{iab}\f$.
+ *
+ * \note In 3D, only the non-zero and unique components of the four-index
+ * constraint are stored, as \f$\hat{C}_{iab} = \epsilon_i^{jk} C_{jkab}\f$. In
+ * 2D the input expected here is \f$\hat{C}_{0ab} = C_{01ab}, \hat{C}_{1ab} =
+ * C_{10ab}\f$, and in 1D \f$\hat{C}_{0ab} = 0\f$.
+ */
+template <size_t VolumeDim, typename DataType>
+void constraint_preserving_bjorhus_corrections_dt_v_zero(
+    gsl::not_null<tnsr::iaa<DataType, VolumeDim, Frame::Inertial>*>
+        bc_dt_v_zero,
+    const tnsr::I<DataType, VolumeDim, Frame::Inertial>&
+        unit_interface_normal_vector,
+    const tnsr::iaa<DataType, VolumeDim, Frame::Inertial>&
+        four_index_constraint,
+    const std::array<DataType, 4>& char_speeds) noexcept;
 }  // namespace Bjorhus
 }  // namespace GeneralizedHarmonic::BoundaryConditions

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.py
@@ -1,6 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+import itertools as it
 import numpy as np
 
 
@@ -8,3 +9,29 @@ def constraint_preserving_bjorhus_corrections_dt_v_psi(
     unit_interface_normal_vector, three_index_constraint, char_speeds):
     return (char_speeds[0] * np.einsum(
         'i,iab->ab', unit_interface_normal_vector, three_index_constraint))
+
+
+def constraint_preserving_bjorhus_corrections_dt_v_zero(
+    unit_interface_normal_vector, four_index_constraint, char_speeds):
+    spatial_dim = len(unit_interface_normal_vector)
+    result = np.zeros([spatial_dim, 1 + spatial_dim, 1 + spatial_dim])
+
+    if spatial_dim == 2:
+        result[0, :, :] += char_speeds[1] * unit_interface_normal_vector[
+            1] * four_index_constraint[1, :, :]
+        result[1, :, :] += char_speeds[1] * unit_interface_normal_vector[
+            0] * four_index_constraint[0, :, :]
+    elif spatial_dim == 3:
+
+        def is_even(sequence):
+            count = 0
+            for i, n in enumerate(sequence, start=1):
+                count += sum(n > num for num in sequence[i:])
+            return not count % 2
+
+        for p in it.permutations(np.arange(len(unit_interface_normal_vector))):
+            sgn = 1 if is_even(p) else -1
+            result[p[0], :, :] += (sgn * char_speeds[1] *
+                                   unit_interface_normal_vector[p[2]] *
+                                   four_index_constraint[p[1], :, :])
+    return result

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_BjorhusImpl.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_BjorhusImpl.cpp
@@ -12,6 +12,7 @@
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/Side.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Constraints.hpp"
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
@@ -164,6 +165,175 @@ void test_constraint_preserving_bjorhus_v_psi_vs_spec_3d(
   // Compare values returned by BC action vs those from SpEC
   CHECK_ITERABLE_APPROX(local_bc_dt_v_psi, spec_bc_dt_v_psi);
 }
+
+// Test boundary conditions on dt<VZero>
+void test_constraint_preserving_bjorhus_v_zero_vs_spec_3d(
+    const size_t grid_size_each_dimension) noexcept {
+  // Setup grid
+  Mesh<VolumeDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+  const Direction<VolumeDim> direction(1, Side::Upper);  // +y direction
+  const size_t slice_grid_points =
+      mesh.extents().slice_away(direction.dimension()).product();
+
+  // Populate various tensors needed to compute BcDtVZero
+  tnsr::iaa<DataVector, VolumeDim, frame> local_four_index_constraint(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+  tnsr::I<DataVector, VolumeDim, frame> local_unit_interface_normal_vector(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+  std::array<DataVector, 4> local_char_speeds{
+      DataVector(slice_grid_points,
+                 std::numeric_limits<double>::signaling_NaN()),
+      DataVector(slice_grid_points,
+                 std::numeric_limits<double>::signaling_NaN()),
+      DataVector(slice_grid_points,
+                 std::numeric_limits<double>::signaling_NaN()),
+      DataVector(slice_grid_points,
+                 std::numeric_limits<double>::signaling_NaN())};
+  // Allocate memory for output
+  tnsr::iaa<DataVector, VolumeDim, frame> local_bc_dt_v_zero(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+
+  {
+    // Setting the 4-index constraint:
+    // initialize dPhi (with same values as for SpEC) and compute C4 from it
+    auto local_dphi = make_with_value<tnsr::ijaa<DataVector, VolumeDim, frame>>(
+        local_unit_interface_normal_vector,
+        std::numeric_limits<double>::signaling_NaN());
+    for (size_t a = 0; a <= VolumeDim; ++a) {
+      for (size_t b = 0; b <= VolumeDim; ++b) {
+        for (size_t i = 0; i < slice_grid_points; ++i) {
+          local_dphi.get(0, 0, a, b)[i] = 3.;
+          local_dphi.get(0, 1, a, b)[i] = 5.;
+          local_dphi.get(0, 2, a, b)[i] = 7.;
+          local_dphi.get(1, 0, a, b)[i] = 59.;
+          local_dphi.get(1, 1, a, b)[i] = 61.;
+          local_dphi.get(1, 2, a, b)[i] = 67.;
+          local_dphi.get(2, 0, a, b)[i] = 73.;
+          local_dphi.get(2, 1, a, b)[i] = 79.;
+          local_dphi.get(2, 2, a, b)[i] = 83.;
+        }
+      }
+    }
+    // C4_{iab} = LeviCivita^{ijk} dphi_{jkab}
+    local_four_index_constraint =
+        GeneralizedHarmonic::four_index_constraint(local_dphi);
+
+    // Setting unit_interface_normal_Vector
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      get<0>(local_unit_interface_normal_vector)[i] = -1.;
+      get<1>(local_unit_interface_normal_vector)[i] = 1.;
+      get<2>(local_unit_interface_normal_vector)[i] = 1.;
+    }
+    // Setting char speeds
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      local_char_speeds.at(0)[i] = -0.3;
+      local_char_speeds.at(1)[i] = -0.1;
+    }
+
+    // Compute rhs value
+    GeneralizedHarmonic::BoundaryConditions::Bjorhus::
+        constraint_preserving_bjorhus_corrections_dt_v_zero(
+            make_not_null(&local_bc_dt_v_zero),
+            local_unit_interface_normal_vector, local_four_index_constraint,
+            local_char_speeds);
+    // Setting local_Rhs
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          local_bc_dt_v_zero.get(0, a, b)[i] += 91.;
+          local_bc_dt_v_zero.get(1, a, b)[i] += 97.;
+          local_bc_dt_v_zero.get(2, a, b)[i] += 101.;
+        }
+      }
+    }
+  }
+  // Initialize with values from SpEC
+  auto spec_bc_dt_v_zero =
+      make_with_value<tnsr::iaa<DataVector, VolumeDim, frame>>(
+          local_bc_dt_v_zero, std::numeric_limits<double>::signaling_NaN());
+
+  for (size_t i = 0; i < slice_grid_points; ++i) {
+    for (size_t a = 0; a <= VolumeDim; ++a) {
+      spec_bc_dt_v_zero.get(0, 0, a)[i] = 79.;
+      spec_bc_dt_v_zero.get(1, 0, a)[i] = 90.4;
+      spec_bc_dt_v_zero.get(2, 0, a)[i] = 95.6;
+    }
+    for (size_t a = 1; a <= VolumeDim; ++a) {
+      spec_bc_dt_v_zero.get(0, 1, a)[i] = 79.;
+      spec_bc_dt_v_zero.get(1, 1, a)[i] = 90.4;
+      spec_bc_dt_v_zero.get(2, 1, a)[i] = 95.6;
+    }
+
+    get<0, 2, 2>(spec_bc_dt_v_zero)[i] = 79.;
+    get<0, 2, 3>(spec_bc_dt_v_zero)[i] = 79.;
+    get<1, 2, 2>(spec_bc_dt_v_zero)[i] = 90.4;
+    get<1, 2, 3>(spec_bc_dt_v_zero)[i] = 90.4;
+    get<2, 2, 2>(spec_bc_dt_v_zero)[i] = 95.6;
+    get<2, 2, 3>(spec_bc_dt_v_zero)[i] = 95.6;
+
+    get<0, 3, 3>(spec_bc_dt_v_zero)[i] = 79.;
+    get<1, 3, 3>(spec_bc_dt_v_zero)[i] = 90.4;
+    get<2, 3, 3>(spec_bc_dt_v_zero)[i] = 95.6;
+  }
+
+  // Compare values returned by BC action vs those from SpEC
+  CHECK_ITERABLE_APPROX(local_bc_dt_v_zero, spec_bc_dt_v_zero);
+
+  // Test for another set of values
+  {
+    // Setting unit_interface_normal_Vector
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      get<0>(local_unit_interface_normal_vector)[i] = -1.;
+      get<1>(local_unit_interface_normal_vector)[i] = 0.;
+      get<2>(local_unit_interface_normal_vector)[i] = 0.;
+    }
+    // Compute rhs value
+    GeneralizedHarmonic::BoundaryConditions::Bjorhus::
+        constraint_preserving_bjorhus_corrections_dt_v_zero(
+            make_not_null(&local_bc_dt_v_zero),
+            local_unit_interface_normal_vector, local_four_index_constraint,
+            local_char_speeds);
+    // Setting local_Rhs
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          local_bc_dt_v_zero.get(0, a, b)[i] += 91.;
+          local_bc_dt_v_zero.get(1, a, b)[i] += 97.;
+          local_bc_dt_v_zero.get(2, a, b)[i] += 101.;
+        }
+      }
+    }
+  }
+
+  // Initialize with values from SpEC
+  for (size_t i = 0; i < slice_grid_points; ++i) {
+    for (size_t a = 0; a <= VolumeDim; ++a) {
+      spec_bc_dt_v_zero.get(0, 0, a)[i] = 91.;
+      spec_bc_dt_v_zero.get(1, 0, a)[i] = 91.6;
+      spec_bc_dt_v_zero.get(2, 0, a)[i] = 94.4;
+    }
+    for (size_t a = 1; a <= VolumeDim; ++a) {
+      spec_bc_dt_v_zero.get(0, 1, a)[i] = 91.;
+      spec_bc_dt_v_zero.get(1, 1, a)[i] = 91.6;
+      spec_bc_dt_v_zero.get(2, 1, a)[i] = 94.4;
+    }
+
+    get<0, 2, 2>(spec_bc_dt_v_zero)[i] = 91.;
+    get<0, 2, 3>(spec_bc_dt_v_zero)[i] = 91.;
+    get<1, 2, 2>(spec_bc_dt_v_zero)[i] = 91.6;
+    get<1, 2, 3>(spec_bc_dt_v_zero)[i] = 91.6;
+    get<2, 2, 2>(spec_bc_dt_v_zero)[i] = 94.4;
+    get<2, 2, 3>(spec_bc_dt_v_zero)[i] = 94.4;
+
+    get<0, 3, 3>(spec_bc_dt_v_zero)[i] = 91.;
+    get<1, 3, 3>(spec_bc_dt_v_zero)[i] = 91.6;
+    get<2, 3, 3>(spec_bc_dt_v_zero)[i] = 94.4;
+  }
+
+  // Compare values returned by BC action vs those from SpEC
+  CHECK_ITERABLE_APPROX(local_bc_dt_v_zero, spec_bc_dt_v_zero);
+}
 }  // namespace
 
 // Python tests
@@ -197,6 +367,37 @@ void test_constraint_preserving_bjorhus_corrections_dt_v_psi(
       "constraint_preserving_bjorhus_corrections_dt_v_psi", {{{-1., 1.}}},
       DataVector(grid_size_each_dimension));
 }
+
+template <size_t VolumeDim>
+tnsr::iaa<DataVector, VolumeDim, Frame::Inertial> wrapper_func_v_zero(
+    const tnsr::I<DataVector, VolumeDim, Frame::Inertial>&
+        interface_normal_vector,
+    const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>&
+        four_index_constraint,
+    const tnsr::a<DataVector, 3, Frame::Inertial>& char_speeds) {
+  std::array<DataVector, 4> char_speed_array{
+      get<0>(char_speeds), get<1>(char_speeds), get<2>(char_speeds),
+      get<3>(char_speeds)};
+  auto dt_v_zero =
+      make_with_value<tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>>(
+          get<0>(interface_normal_vector), 0.);
+  GeneralizedHarmonic::BoundaryConditions::Bjorhus::
+      constraint_preserving_bjorhus_corrections_dt_v_zero<VolumeDim,
+                                                          DataVector>(
+          make_not_null(&dt_v_zero), interface_normal_vector,
+          four_index_constraint, char_speed_array);
+  return dt_v_zero;
+}
+
+template <size_t VolumeDim>
+void test_constraint_preserving_bjorhus_corrections_dt_v_zero(
+    const size_t grid_size_each_dimension) noexcept {
+  pypp::check_with_random_values<1>(
+      &wrapper_func_v_zero<VolumeDim>,
+      "Evolution.Systems.GeneralizedHarmonic.BoundaryConditions.Bjorhus",
+      "constraint_preserving_bjorhus_corrections_dt_v_zero", {{{-1., 1.}}},
+      DataVector(grid_size_each_dimension));
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.BCBjorhus.VPsi",
@@ -213,4 +414,20 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.BCBjorhus.VPsi",
 
   // Piece-wise tests with SpEC output in 3D
   test_constraint_preserving_bjorhus_v_psi_vs_spec_3d(grid_size);
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.BCBjorhus.VZero",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{""};
+
+  // Piece-wise tests with SpEC output
+  const size_t grid_size = 3;
+
+  // Python tests
+  test_constraint_preserving_bjorhus_corrections_dt_v_zero<1>(grid_size);
+  test_constraint_preserving_bjorhus_corrections_dt_v_zero<2>(grid_size);
+  test_constraint_preserving_bjorhus_corrections_dt_v_zero<3>(grid_size);
+
+  // Piece-wise tests with SpEC output
+  test_constraint_preserving_bjorhus_v_zero_vs_spec_3d(grid_size);
 }


### PR DESCRIPTION
## Proposed changes

This PR adds free functions to compute Bjorhus-type corrections to the characteristic projected time derivatives of evolved GH variables, specifically the combination that corresponds to `VZero` after projection. These corrections damp out constraint violations at the external boundary.


### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
