### PR TITLE
Constraint-preserving boundary terms for VMinus (GH)

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -1245,6 +1245,19 @@
   url       = "{http://adsabs.harvard.edu/abs/2013rehy.book.....R}",
 }
 
+@article{Rinne2007ui,
+    author = "Rinne, Oliver and Lindblom, Lee and Scheel, Mark A.",
+    title = "{Testing outer boundary treatments for the Einstein equations}",
+    eprint = "0704.0782",
+    archivePrefix = "arXiv",
+    primaryClass = "gr-qc",
+    doi = "10.1088/0264-9381/24/16/006",
+    journal = "Class. Quant. Grav.",
+    volume = "24",
+    pages = "4053--4078",
+    year = "2007"
+}
+
 @book{Saad2003,
   title     = "Iterative Methods for Sparse Linear Systems: Second Edition",
   author    = "Saad, Yousef",

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.cpp
@@ -5,10 +5,18 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/LeviCivitaIterator.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/TempBuffer.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/CovariantDerivOfExtrinsicCurvature.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Ricci.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ProjectionOperators.hpp"
+#include "PointwiseFunctions/GeneralRelativity/WeylPropagating.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
@@ -101,32 +109,683 @@ void constraint_preserving_bjorhus_corrections_dt_v_zero(
     }
   }
 }
+
+namespace detail {
+template <size_t VolumeDim, typename DataType>
+void add_gauge_sommerfeld_terms_to_dt_v_minus(
+    const gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame::Inertial>*>
+        bc_dt_v_minus,
+    const Scalar<DataType>& gamma2,
+    const tnsr::I<DataType, VolumeDim, Frame::Inertial>& inertial_coords,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>& incoming_null_one_form,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>& outgoing_null_one_form,
+    const tnsr::A<DataType, VolumeDim, Frame::Inertial>& incoming_null_vector,
+    const tnsr::A<DataType, VolumeDim, Frame::Inertial>& outgoing_null_vector,
+    const tnsr::Ab<DataType, VolumeDim, Frame::Inertial>& projection_Ab,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>&
+        char_projected_rhs_dt_v_psi) noexcept {
+  // gauge_bc_coeff below is hard-coded here to its default value in SpEC
+  constexpr double gauge_bc_coeff = 1.;
+
+  DataType inertial_radius_or_scalar_factor(get_size(get<0>(inertial_coords)),
+                                            0.);
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    inertial_radius_or_scalar_factor += square(inertial_coords.get(i));
+  }
+  inertial_radius_or_scalar_factor =
+      get(gamma2) - (gauge_bc_coeff / sqrt(inertial_radius_or_scalar_factor));
+
+  for (size_t a = 0; a <= VolumeDim; ++a) {
+    for (size_t b = a; b <= VolumeDim; ++b) {
+      for (size_t c = 0; c <= VolumeDim; ++c) {
+        for (size_t d = 0; d <= VolumeDim; ++d) {
+          bc_dt_v_minus->get(a, b) +=
+              (incoming_null_one_form.get(a) * projection_Ab.get(c, b) *
+                   outgoing_null_vector.get(d) +
+               incoming_null_one_form.get(b) * projection_Ab.get(c, a) *
+                   outgoing_null_vector.get(d) -
+               (incoming_null_one_form.get(a) * outgoing_null_one_form.get(b) *
+                    incoming_null_vector.get(c) * outgoing_null_vector.get(d) +
+                incoming_null_one_form.get(b) * outgoing_null_one_form.get(a) *
+                    incoming_null_vector.get(c) * outgoing_null_vector.get(d) +
+                incoming_null_one_form.get(a) * incoming_null_one_form.get(b) *
+                    outgoing_null_vector.get(c) *
+                    outgoing_null_vector.get(d))) *
+              inertial_radius_or_scalar_factor *
+              char_projected_rhs_dt_v_psi.get(c, d);
+        }
+      }
+    }
+  }
+}
+
+template <size_t VolumeDim, typename DataType>
+void add_constraint_dependent_terms_to_dt_v_minus(
+    const gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame::Inertial>*>
+        bc_dt_v_minus,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>& outgoing_null_one_form,
+    const tnsr::A<DataType, VolumeDim, Frame::Inertial>& incoming_null_vector,
+    const tnsr::A<DataType, VolumeDim, Frame::Inertial>& outgoing_null_vector,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>& projection_ab,
+    const tnsr::Ab<DataType, VolumeDim, Frame::Inertial>& projection_Ab,
+    const tnsr::AA<DataType, VolumeDim, Frame::Inertial>& projection_AB,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>&
+        constraint_char_zero_plus,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>&
+        constraint_char_zero_minus,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>&
+        char_projected_rhs_dt_v_minus,
+    const std::array<DataType, 4>& char_speeds) noexcept {
+  constexpr double mu = 0.;  // hard-coded value from SpEC Bbh input file Mu = 0
+  const double one_by_sqrt_2 = 1. / sqrt(2.);
+
+  // Add corrections c.f. Eq (64) of gr-qc/0512093
+  for (size_t a = 0; a <= VolumeDim; ++a) {
+    for (size_t b = a; b <= VolumeDim; ++b) {
+      for (size_t c = 0; c <= VolumeDim; ++c) {
+        for (size_t d = 0; d <= VolumeDim; ++d) {
+          bc_dt_v_minus->get(a, b) +=
+              0.5 *
+              (2. * incoming_null_vector.get(c) * incoming_null_vector.get(d) *
+                   outgoing_null_one_form.get(a) *
+                   outgoing_null_one_form.get(b) -
+               incoming_null_vector.get(c) * projection_Ab.get(d, a) *
+                   outgoing_null_one_form.get(b) -
+               incoming_null_vector.get(c) * projection_Ab.get(d, b) *
+                   outgoing_null_one_form.get(a) -
+               incoming_null_vector.get(d) * projection_Ab.get(c, a) *
+                   outgoing_null_one_form.get(b) -
+               incoming_null_vector.get(d) * projection_Ab.get(c, b) *
+                   outgoing_null_one_form.get(a) +
+               projection_AB.get(c, d) * projection_ab.get(a, b)) *
+              char_projected_rhs_dt_v_minus.get(c, d);
+        }
+      }
+      if constexpr (mu == 0.) {
+        for (size_t c = 0; c <= VolumeDim; ++c) {
+          bc_dt_v_minus->get(a, b) +=
+              one_by_sqrt_2 * char_speeds[3] *
+              constraint_char_zero_minus.get(c) *
+              (outgoing_null_one_form.get(a) * outgoing_null_one_form.get(b) *
+                   incoming_null_vector.get(c) +
+               projection_ab.get(a, b) * outgoing_null_vector.get(c) -
+               projection_Ab.get(c, b) * outgoing_null_one_form.get(a) -
+               projection_Ab.get(c, a) * outgoing_null_one_form.get(b));
+        }
+      } else {
+        for (size_t c = 0; c <= VolumeDim; ++c) {
+          bc_dt_v_minus->get(a, b) +=
+              one_by_sqrt_2 * char_speeds[3] *
+              (constraint_char_zero_minus.get(c) -
+               mu * constraint_char_zero_plus.get(c)) *
+              (outgoing_null_one_form.get(a) * outgoing_null_one_form.get(b) *
+                   incoming_null_vector.get(c) +
+               projection_ab.get(a, b) * outgoing_null_vector.get(c) -
+               projection_Ab.get(c, b) * outgoing_null_one_form.get(a) -
+               projection_Ab.get(c, a) * outgoing_null_one_form.get(b));
+        }
+      }
+    }
+  }
+}
+
+template <size_t VolumeDim, typename DataType>
+void add_physical_terms_to_dt_v_minus(
+    const gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame::Inertial>*>
+        bc_dt_v_minus,
+    const Scalar<DataType>& gamma2,
+    const tnsr::i<DataType, VolumeDim, Frame::Inertial>&
+        unit_interface_normal_one_form,
+    const tnsr::I<DataType, VolumeDim, Frame::Inertial>&
+        unit_interface_normal_vector,
+    const tnsr::A<DataType, VolumeDim, Frame::Inertial>&
+        spacetime_unit_normal_vector,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>& projection_ab,
+    const tnsr::Ab<DataType, VolumeDim, Frame::Inertial>& projection_Ab,
+    const tnsr::AA<DataType, VolumeDim, Frame::Inertial>& projection_AB,
+    const tnsr::II<DataType, VolumeDim, Frame::Inertial>&
+        inverse_spatial_metric,
+    const tnsr::ii<DataType, VolumeDim, Frame::Inertial>& extrinsic_curvature,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>& spacetime_metric,
+    const tnsr::AA<DataType, VolumeDim, Frame::Inertial>&
+        inverse_spacetime_metric,
+    const tnsr::iaa<DataType, VolumeDim, Frame::Inertial>&
+        three_index_constraint,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>&
+        char_projected_rhs_dt_v_minus,
+    const tnsr::iaa<DataType, VolumeDim, Frame::Inertial>& phi,
+    const tnsr::ijaa<DataType, VolumeDim, Frame::Inertial>& d_phi,
+    const tnsr::iaa<DataType, VolumeDim, Frame::Inertial>& d_pi,
+    const std::array<DataType, 4>& char_speeds) noexcept {
+  // hard-coded value from SpEC Bbh input file Mu = MuPhys = 0
+  constexpr double mu_phys = 0.;
+  constexpr bool adjust_phys_using_c4 = true;
+  constexpr bool gamma2_in_phys = true;
+
+  // In what follows, we follow Kidder, Scheel & Teukolsky (2001)
+  // https://arxiv.org/pdf/gr-qc/0105031.pdf.
+  TempBuffer<tmpl::list<::Tags::Tempaa<0, VolumeDim, Frame::Inertial, DataType>,
+                        ::Tags::Tempaa<1, VolumeDim, Frame::Inertial, DataType>,
+                        ::Tags::TempScalar<0, DataType>>>
+      u3_buffer(get_size(get<0>(unit_interface_normal_vector)), 0.);
+  auto& U3p =
+      get<::Tags::Tempaa<0, VolumeDim, Frame::Inertial, DataType>>(u3_buffer);
+  auto& U3m =
+      get<::Tags::Tempaa<1, VolumeDim, Frame::Inertial, DataType>>(u3_buffer);
+
+  {
+    TempBuffer<
+        tmpl::list<::Tags::Tempijj<0, VolumeDim, Frame::Inertial, DataType>,
+                   // cov deriv of Kij
+                   ::Tags::Tempijj<1, VolumeDim, Frame::Inertial, DataType>,
+                   // spatial Ricci
+                   ::Tags::Tempii<0, VolumeDim, Frame::Inertial, DataType>,
+                   // spatial projection operators P_ij, P^ij, and P^i_j
+                   ::Tags::TempII<0, VolumeDim, Frame::Inertial, DataType>,
+                   ::Tags::Tempii<1, VolumeDim, Frame::Inertial, DataType>,
+                   ::Tags::TempIj<0, VolumeDim, Frame::Inertial, DataType>,
+                   // weyl propagating modes
+                   ::Tags::Tempii<2, VolumeDim, Frame::Inertial, DataType>,
+                   ::Tags::Tempii<3, VolumeDim, Frame::Inertial, DataType>,
+                   ::Tags::Tempii<4, VolumeDim, Frame::Inertial, DataType>>>
+        local_buffer(get_size(get<0>(unit_interface_normal_vector)), 0.);
+
+    auto& spatial_phi =
+        get<::Tags::Tempijj<0, VolumeDim, Frame::Inertial, DataType>>(
+            local_buffer);
+    auto& cov_deriv_ex_curv =
+        get<::Tags::Tempijj<1, VolumeDim, Frame::Inertial, DataType>>(
+            local_buffer);
+    auto& ricci_3 =
+        get<::Tags::Tempii<0, VolumeDim, Frame::Inertial, DataType>>(
+            local_buffer);
+    auto& spatial_projection_IJ =
+        get<::Tags::TempII<0, VolumeDim, Frame::Inertial, DataType>>(
+            local_buffer);
+    auto& spatial_projection_ij =
+        get<::Tags::Tempii<1, VolumeDim, Frame::Inertial, DataType>>(
+            local_buffer);
+    auto& spatial_projection_Ij =
+        get<::Tags::TempIj<0, VolumeDim, Frame::Inertial, DataType>>(
+            local_buffer);
+    auto weyl_prop_minus =
+        get<::Tags::Tempii<2, VolumeDim, Frame::Inertial, DataType>>(
+            local_buffer);
+    auto& spatial_metric =
+        get<::Tags::Tempii<3, VolumeDim, Frame::Inertial, DataType>>(
+            local_buffer);
+
+    // D_(k,i,j) = (1/2) \partial_k g_(ij) and its derivative
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      for (size_t j = i; j < VolumeDim; ++j) {
+        for (size_t k = 0; k < VolumeDim; ++k) {
+          spatial_phi.get(k, i, j) = phi.get(k, i + 1, j + 1);
+        }
+      }
+    }
+
+    // Compute covariant deriv of extrinsic curvature
+    GeneralizedHarmonic::covariant_deriv_of_extrinsic_curvature(
+        make_not_null(&cov_deriv_ex_curv), extrinsic_curvature,
+        spacetime_unit_normal_vector,
+        raise_or_lower_first_index(gr::christoffel_first_kind(spatial_phi),
+                                   inverse_spatial_metric),
+        inverse_spacetime_metric, phi, d_pi, d_phi);
+
+    // Compute spatial Ricci tensor
+    GeneralizedHarmonic::spatial_ricci_tensor(make_not_null(&ricci_3), phi,
+                                              d_phi, inverse_spatial_metric);
+
+    if (adjust_phys_using_c4) {
+      // This adds 4-index constraint terms to 3Ricci so as to cancel
+      // out normal derivatives from the final expression for U8.
+      // It is much easier to add them here than to recalculate U8
+      // from scratch.
+
+      // Add some 4-index constraint terms to 3Ricci.
+      for (size_t i = 0; i < VolumeDim; ++i) {
+        for (size_t j = i; j < VolumeDim; ++j) {
+          for (size_t k = 0; k < VolumeDim; ++k) {
+            for (size_t l = 0; l < VolumeDim; ++l) {
+              ricci_3.get(i, j) += 0.25 * inverse_spatial_metric.get(k, l) *
+                                   (d_phi.get(i, k, 1 + l, 1 + j) -
+                                    d_phi.get(k, i, 1 + l, 1 + j) +
+                                    d_phi.get(j, k, 1 + l, 1 + i) -
+                                    d_phi.get(k, j, 1 + l, 1 + i));
+            }
+          }
+        }
+      }
+
+      // Add more 4-index constraint terms to 3Ricci
+      // These compensate for some of the cov_deriv_ex_curv terms.
+      for (size_t i = 0; i < VolumeDim; ++i) {
+        for (size_t j = i; j < VolumeDim; ++j) {
+          for (size_t a = 0; a <= VolumeDim; ++a) {
+            for (size_t k = 0; k < VolumeDim; ++k) {
+              ricci_3.get(i, j) +=
+                  0.5 * unit_interface_normal_vector.get(k) *
+                  spacetime_unit_normal_vector.get(a) *
+                  (d_phi.get(i, k, j + 1, a) - d_phi.get(k, i, j + 1, a) +
+                   d_phi.get(j, k, i + 1, a) - d_phi.get(k, j, i + 1, a));
+            }
+          }
+        }
+      }
+    }
+
+    // Make spatial projection operators
+    for (size_t j = 0; j < VolumeDim; ++j) {
+      for (size_t k = j; k < VolumeDim; ++k) {
+        spatial_metric.get(j, k) = spacetime_metric.get(1 + j, 1 + k);
+      }
+    }
+    gr::transverse_projection_operator(make_not_null(&spatial_projection_IJ),
+                                       inverse_spatial_metric,
+                                       unit_interface_normal_vector);
+    gr::transverse_projection_operator(make_not_null(&spatial_projection_ij),
+                                       spatial_metric,
+                                       unit_interface_normal_one_form);
+    gr::transverse_projection_operator(make_not_null(&spatial_projection_Ij),
+                                       unit_interface_normal_vector,
+                                       unit_interface_normal_one_form);
+
+    // Weyl propagating mode
+    gr::weyl_propagating(make_not_null(&weyl_prop_minus), ricci_3,
+                         extrinsic_curvature, inverse_spatial_metric,
+                         cov_deriv_ex_curv, unit_interface_normal_vector,
+                         spatial_projection_IJ, spatial_projection_ij,
+                         spatial_projection_Ij, -1);
+
+    if constexpr (mu_phys == 0.) {
+      // No need to compute U3p or weyl_prop_plus in this case
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          for (size_t i = 0; i < VolumeDim; ++i) {
+            for (size_t j = 0; j < VolumeDim; ++j) {
+              U3m.get(a, b) += 2. * projection_Ab.get(i + 1, a) *
+                               projection_Ab.get(j + 1, b) *
+                               weyl_prop_minus.get(i, j);
+            }
+          }
+        }
+      }
+    } else {
+      auto& weyl_prop_plus =
+          get<::Tags::Tempii<3, VolumeDim, Frame::Inertial, DataType>>(
+              local_buffer);
+      gr::weyl_propagating(make_not_null(&weyl_prop_plus), ricci_3,
+                           extrinsic_curvature, inverse_spatial_metric,
+                           cov_deriv_ex_curv, unit_interface_normal_vector,
+                           spatial_projection_IJ, spatial_projection_ij,
+                           spatial_projection_Ij, 1);
+
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          for (size_t i = 0; i < VolumeDim; ++i) {
+            for (size_t j = 0; j < VolumeDim; ++j) {
+              U3p.get(a, b) += 2. * projection_Ab.get(i + 1, a) *
+                               projection_Ab.get(j + 1, b) *
+                               weyl_prop_plus.get(i, j);
+              U3m.get(a, b) += 2. * projection_Ab.get(i + 1, a) *
+                               projection_Ab.get(j + 1, b) *
+                               weyl_prop_minus.get(i, j);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Add physical boundary corrections
+  if (gamma2_in_phys) {
+    auto& normal_dot_three_index_constraint_gamma2 =
+        get(get<::Tags::TempScalar<0, DataType>>(u3_buffer));
+
+    for (size_t a = 0; a <= VolumeDim; ++a) {
+      for (size_t b = a; b <= VolumeDim; ++b) {
+        for (size_t c = 0; c <= VolumeDim; ++c) {
+          for (size_t d = 0; d <= VolumeDim; ++d) {
+            normal_dot_three_index_constraint_gamma2 =
+                get<0>(unit_interface_normal_vector) *
+                three_index_constraint.get(0, c, d);
+            for (size_t i = 1; i < VolumeDim; ++i) {
+              normal_dot_three_index_constraint_gamma2 +=
+                  unit_interface_normal_vector.get(i) *
+                  three_index_constraint.get(i, c, d);
+            }
+            normal_dot_three_index_constraint_gamma2 *= get(gamma2);
+
+            if constexpr (mu_phys == 0.) {
+              bc_dt_v_minus->get(a, b) +=
+                  (projection_Ab.get(c, a) * projection_Ab.get(d, b) -
+                   0.5 * projection_ab.get(a, b) * projection_AB.get(c, d)) *
+                  (char_projected_rhs_dt_v_minus.get(c, d) +
+                   char_speeds[3] * (U3m.get(c, d) -
+                                     normal_dot_three_index_constraint_gamma2));
+            } else {
+              bc_dt_v_minus->get(a, b) +=
+                  (projection_Ab.get(c, a) * projection_Ab.get(d, b) -
+                   0.5 * projection_ab.get(a, b) * projection_AB.get(c, d)) *
+                  (char_projected_rhs_dt_v_minus.get(c, d) +
+                   char_speeds[3] * (U3m.get(c, d) -
+                                     normal_dot_three_index_constraint_gamma2 -
+                                     mu_phys * U3p.get(c, d)));
+            }
+          }
+        }
+      }
+    }
+  } else {
+    for (size_t a = 0; a <= VolumeDim; ++a) {
+      for (size_t b = a; b <= VolumeDim; ++b) {
+        for (size_t c = 0; c <= VolumeDim; ++c) {
+          for (size_t d = 0; d <= VolumeDim; ++d) {
+            if constexpr (mu_phys == 0.) {
+              (projection_Ab.get(c, a) * projection_Ab.get(d, b) -
+               0.5 * projection_ab.get(a, b) * projection_AB.get(c, d)) *
+                  (char_projected_rhs_dt_v_minus.get(c, d) +
+                   char_speeds[3] * (U3m.get(c, d)));
+            } else {
+              bc_dt_v_minus->get(a, b) +=
+                  (projection_Ab.get(c, a) * projection_Ab.get(d, b) -
+                   0.5 * projection_ab.get(a, b) * projection_AB.get(c, d)) *
+                  (char_projected_rhs_dt_v_minus.get(c, d) +
+                   char_speeds[3] * (U3m.get(c, d) - mu_phys * U3p.get(c, d)));
+            }
+          }
+        }
+      }
+    }
+  }
+}
+}  // namespace detail
+
+template <size_t VolumeDim, typename DataType>
+void constraint_preserving_bjorhus_corrections_dt_v_minus(
+    const gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame::Inertial>*>
+        bc_dt_v_minus,
+    const Scalar<DataType>& gamma2,
+    const tnsr::I<DataType, VolumeDim, Frame::Inertial>& inertial_coords,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>& incoming_null_one_form,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>& outgoing_null_one_form,
+    const tnsr::A<DataType, VolumeDim, Frame::Inertial>& incoming_null_vector,
+    const tnsr::A<DataType, VolumeDim, Frame::Inertial>& outgoing_null_vector,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>& projection_ab,
+    const tnsr::Ab<DataType, VolumeDim, Frame::Inertial>& projection_Ab,
+    const tnsr::AA<DataType, VolumeDim, Frame::Inertial>& projection_AB,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>&
+        char_projected_rhs_dt_v_psi,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>&
+        char_projected_rhs_dt_v_minus,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>&
+        constraint_char_zero_plus,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>&
+        constraint_char_zero_minus,
+    const std::array<DataType, 4>& char_speeds) noexcept {
+  destructive_resize_components(bc_dt_v_minus, get_size(get(gamma2)));
+  for (size_t a = 0; a <= VolumeDim; ++a) {
+    for (size_t b = a; b <= VolumeDim; ++b) {
+      bc_dt_v_minus->get(a, b) = -char_projected_rhs_dt_v_minus.get(a, b);
+    }
+  }
+  detail::add_constraint_dependent_terms_to_dt_v_minus(
+      bc_dt_v_minus, outgoing_null_one_form, incoming_null_vector,
+      outgoing_null_vector, projection_ab, projection_Ab, projection_AB,
+      constraint_char_zero_plus, constraint_char_zero_minus,
+      char_projected_rhs_dt_v_minus, char_speeds);
+  detail::add_gauge_sommerfeld_terms_to_dt_v_minus(
+      bc_dt_v_minus, gamma2, inertial_coords, incoming_null_one_form,
+      outgoing_null_one_form, incoming_null_vector, outgoing_null_vector,
+      projection_Ab, char_projected_rhs_dt_v_psi);
+}
+
+template <size_t VolumeDim, typename DataType>
+void constraint_preserving_physical_bjorhus_corrections_dt_v_minus(
+    const gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame::Inertial>*>
+        bc_dt_v_minus,
+    const Scalar<DataType>& gamma2,
+    const tnsr::I<DataType, VolumeDim, Frame::Inertial>& inertial_coords,
+    const tnsr::i<DataType, VolumeDim, Frame::Inertial>&
+        unit_interface_normal_one_form,
+    const tnsr::I<DataType, VolumeDim, Frame::Inertial>&
+        unit_interface_normal_vector,
+    const tnsr::A<DataType, VolumeDim, Frame::Inertial>&
+        spacetime_unit_normal_vector,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>& incoming_null_one_form,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>& outgoing_null_one_form,
+    const tnsr::A<DataType, VolumeDim, Frame::Inertial>& incoming_null_vector,
+    const tnsr::A<DataType, VolumeDim, Frame::Inertial>& outgoing_null_vector,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>& projection_ab,
+    const tnsr::Ab<DataType, VolumeDim, Frame::Inertial>& projection_Ab,
+    const tnsr::AA<DataType, VolumeDim, Frame::Inertial>& projection_AB,
+    const tnsr::II<DataType, VolumeDim, Frame::Inertial>&
+        inverse_spatial_metric,
+    const tnsr::ii<DataType, VolumeDim, Frame::Inertial>& extrinsic_curvature,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>& spacetime_metric,
+    const tnsr::AA<DataType, VolumeDim, Frame::Inertial>&
+        inverse_spacetime_metric,
+    const tnsr::iaa<DataType, VolumeDim, Frame::Inertial>&
+        three_index_constraint,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>&
+        char_projected_rhs_dt_v_psi,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>&
+        char_projected_rhs_dt_v_minus,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>&
+        constraint_char_zero_plus,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>&
+        constraint_char_zero_minus,
+    const tnsr::iaa<DataType, VolumeDim, Frame::Inertial>& phi,
+    const tnsr::ijaa<DataType, VolumeDim, Frame::Inertial>& d_phi,
+    const tnsr::iaa<DataType, VolumeDim, Frame::Inertial>& d_pi,
+    const std::array<DataType, 4>& char_speeds) noexcept {
+  destructive_resize_components(bc_dt_v_minus, get_size(get(gamma2)));
+  for (size_t a = 0; a <= VolumeDim; ++a) {
+    for (size_t b = a; b <= VolumeDim; ++b) {
+      bc_dt_v_minus->get(a, b) = -char_projected_rhs_dt_v_minus.get(a, b);
+    }
+  }
+  detail::add_constraint_dependent_terms_to_dt_v_minus(
+      bc_dt_v_minus, outgoing_null_one_form, incoming_null_vector,
+      outgoing_null_vector, projection_ab, projection_Ab, projection_AB,
+      constraint_char_zero_plus, constraint_char_zero_minus,
+      char_projected_rhs_dt_v_minus, char_speeds);
+  detail::add_physical_terms_to_dt_v_minus(
+      bc_dt_v_minus, gamma2, unit_interface_normal_one_form,
+      unit_interface_normal_vector, spacetime_unit_normal_vector, projection_ab,
+      projection_Ab, projection_AB, inverse_spatial_metric, extrinsic_curvature,
+      spacetime_metric, inverse_spacetime_metric, three_index_constraint,
+      char_projected_rhs_dt_v_minus, phi, d_phi, d_pi, char_speeds);
+  detail::add_gauge_sommerfeld_terms_to_dt_v_minus(
+      bc_dt_v_minus, gamma2, inertial_coords, incoming_null_one_form,
+      outgoing_null_one_form, incoming_null_vector, outgoing_null_vector,
+      projection_Ab, char_projected_rhs_dt_v_psi);
+}
 }  // namespace GeneralizedHarmonic::BoundaryConditions::Bjorhus
 
 // Explicit Instantiations
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATE(_, data)                                        \
-  template void GeneralizedHarmonic::BoundaryConditions::Bjorhus::  \
-      constraint_preserving_bjorhus_corrections_dt_v_psi(           \
-          const gsl::not_null<                                      \
-              tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>*>   \
-              bc_dt_v_psi,                                          \
-          const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>&   \
-              unit_interface_normal_vector,                         \
-          const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>& \
-              three_index_constraint,                               \
-          const std::array<DTYPE(data), 4>& char_speeds) noexcept;  \
-  template void GeneralizedHarmonic::BoundaryConditions::Bjorhus::  \
-      constraint_preserving_bjorhus_corrections_dt_v_zero(          \
-          const gsl::not_null<                                      \
-              tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>*>  \
-              bc_dt_v_zero,                                         \
-          const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>&   \
-              unit_interface_normal_vector,                         \
-          const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>& \
-              four_index_constraint,                                \
+#define INSTANTIATE(_, data)                                                \
+  template void GeneralizedHarmonic::BoundaryConditions::Bjorhus::          \
+      constraint_preserving_bjorhus_corrections_dt_v_psi(                   \
+          const gsl::not_null<                                              \
+              tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>*>           \
+              bc_dt_v_psi,                                                  \
+          const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              unit_interface_normal_vector,                                 \
+          const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>&         \
+              three_index_constraint,                                       \
+          const std::array<DTYPE(data), 4>& char_speeds) noexcept;          \
+  template void GeneralizedHarmonic::BoundaryConditions::Bjorhus::          \
+      constraint_preserving_bjorhus_corrections_dt_v_zero(                  \
+          const gsl::not_null<                                              \
+              tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>*>          \
+              bc_dt_v_zero,                                                 \
+          const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              unit_interface_normal_vector,                                 \
+          const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>&         \
+              four_index_constraint,                                        \
+          const std::array<DTYPE(data), 4>& char_speeds) noexcept;          \
+  template void GeneralizedHarmonic::BoundaryConditions::Bjorhus::detail::  \
+      add_gauge_sommerfeld_terms_to_dt_v_minus(                             \
+          const gsl::not_null<                                              \
+              tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>*>           \
+              bc_dt_v_minus,                                                \
+          const Scalar<DTYPE(data)>& gamma2,                                \
+          const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              inertial_coords,                                              \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              incoming_null_one_form,                                       \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              outgoing_null_one_form,                                       \
+          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              incoming_null_vector,                                         \
+          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              outgoing_null_vector,                                         \
+          const tnsr::Ab<DTYPE(data), DIM(data), Frame::Inertial>&          \
+              projection_Ab,                                                \
+          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&          \
+              char_projected_rhs_dt_v_psi) noexcept;                        \
+  template void GeneralizedHarmonic::BoundaryConditions::Bjorhus::detail::  \
+      add_constraint_dependent_terms_to_dt_v_minus(                         \
+          const gsl::not_null<                                              \
+              tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>*>           \
+              bc_dt_v_minus,                                                \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              outgoing_null_one_form,                                       \
+          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              incoming_null_vector,                                         \
+          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              outgoing_null_vector,                                         \
+          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&          \
+              projection_ab,                                                \
+          const tnsr::Ab<DTYPE(data), DIM(data), Frame::Inertial>&          \
+              projection_Ab,                                                \
+          const tnsr::AA<DTYPE(data), DIM(data), Frame::Inertial>&          \
+              projection_AB,                                                \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              constraint_char_zero_plus,                                    \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              constraint_char_zero_minus,                                   \
+          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&          \
+              char_projected_rhs_dt_v_minus,                                \
+          const std::array<DTYPE(data), 4>& char_speeds) noexcept;          \
+  template void GeneralizedHarmonic::BoundaryConditions::Bjorhus::detail::  \
+      add_physical_terms_to_dt_v_minus(                                     \
+          const gsl::not_null<                                              \
+              tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>*>           \
+              bc_dt_v_minus,                                                \
+          const Scalar<DTYPE(data)>& gamma2,                                \
+          const tnsr::i<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              unit_interface_normal_one_form,                               \
+          const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              unit_interface_normal_vector,                                 \
+          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              spacetime_unit_normal_vector,                                 \
+          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&          \
+              projection_ab,                                                \
+          const tnsr::Ab<DTYPE(data), DIM(data), Frame::Inertial>&          \
+              projection_Ab,                                                \
+          const tnsr::AA<DTYPE(data), DIM(data), Frame::Inertial>&          \
+              projection_AB,                                                \
+          const tnsr::II<DTYPE(data), DIM(data), Frame::Inertial>&          \
+              inverse_spatial_metric,                                       \
+          const tnsr::ii<DTYPE(data), DIM(data), Frame::Inertial>&          \
+              extrinsic_curvature,                                          \
+          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&          \
+              spacetime_metric,                                             \
+          const tnsr::AA<DTYPE(data), DIM(data), Frame::Inertial>&          \
+              inverse_spacetime_metric,                                     \
+          const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>&         \
+              three_index_constraint,                                       \
+          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&          \
+              char_projected_rhs_dt_v_minus,                                \
+          const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>& phi,    \
+          const tnsr::ijaa<DTYPE(data), DIM(data), Frame::Inertial>& d_phi, \
+          const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>& d_pi,   \
+          const std::array<DTYPE(data), 4>& char_speeds) noexcept;          \
+  template void GeneralizedHarmonic::BoundaryConditions::Bjorhus::          \
+      constraint_preserving_bjorhus_corrections_dt_v_minus(                 \
+          const gsl::not_null<                                              \
+              tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>*>           \
+              bc_dt_v_minus,                                                \
+          const Scalar<DTYPE(data)>& gamma2,                                \
+          const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              inertial_coords,                                              \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              incoming_null_one_form,                                       \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              outgoing_null_one_form,                                       \
+          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              incoming_null_vector,                                         \
+          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              outgoing_null_vector,                                         \
+          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&          \
+              projection_ab,                                                \
+          const tnsr::Ab<DTYPE(data), DIM(data), Frame::Inertial>&          \
+              projection_Ab,                                                \
+          const tnsr::AA<DTYPE(data), DIM(data), Frame::Inertial>&          \
+              projection_AB,                                                \
+          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&          \
+              char_projected_rhs_dt_v_psi,                                  \
+          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&          \
+              char_projected_rhs_dt_v_minus,                                \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              constraint_char_zero_plus,                                    \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              constraint_char_zero_minus,                                   \
+          const std::array<DTYPE(data), 4>& char_speeds) noexcept;          \
+  template void GeneralizedHarmonic::BoundaryConditions::Bjorhus::          \
+      constraint_preserving_physical_bjorhus_corrections_dt_v_minus(        \
+          const gsl::not_null<                                              \
+              tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>*>           \
+              bc_dt_v_minus,                                                \
+          const Scalar<DTYPE(data)>& gamma2,                                \
+          const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              inertial_coords,                                              \
+          const tnsr::i<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              unit_interface_normal_one_form,                               \
+          const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              unit_interface_normal_vector,                                 \
+          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              spacetime_unit_normal_vector,                                 \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              incoming_null_one_form,                                       \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              outgoing_null_one_form,                                       \
+          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              incoming_null_vector,                                         \
+          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              outgoing_null_vector,                                         \
+          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&          \
+              projection_ab,                                                \
+          const tnsr::Ab<DTYPE(data), DIM(data), Frame::Inertial>&          \
+              projection_Ab,                                                \
+          const tnsr::AA<DTYPE(data), DIM(data), Frame::Inertial>&          \
+              projection_AB,                                                \
+          const tnsr::II<DTYPE(data), DIM(data), Frame::Inertial>&          \
+              inverse_spatial_metric,                                       \
+          const tnsr::ii<DTYPE(data), DIM(data), Frame::Inertial>&          \
+              extrinsic_curvature,                                          \
+          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&          \
+              spacetime_metric,                                             \
+          const tnsr::AA<DTYPE(data), DIM(data), Frame::Inertial>&          \
+              inverse_spacetime_metric,                                     \
+          const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>&         \
+              three_index_constraint,                                       \
+          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&          \
+              char_projected_rhs_dt_v_psi,                                  \
+          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&          \
+              char_projected_rhs_dt_v_minus,                                \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              constraint_char_zero_plus,                                    \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&           \
+              constraint_char_zero_minus,                                   \
+          const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>& phi,    \
+          const tnsr::ijaa<DTYPE(data), DIM(data), Frame::Inertial>& d_phi, \
+          const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>& d_pi,   \
           const std::array<DTYPE(data), 4>& char_speeds) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (DataVector))

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.hpp
@@ -77,5 +77,222 @@ void constraint_preserving_bjorhus_corrections_dt_v_zero(
     const tnsr::iaa<DataType, VolumeDim, Frame::Inertial>&
         four_index_constraint,
     const std::array<DataType, 4>& char_speeds) noexcept;
+
+/// @{
+/*!
+ * \brief Computes the expression needed to set boundary conditions on the time
+ * derivative of the characteristic field \f$v^{-}_{ab}\f$
+ *
+ * \details In the Bjorhus scheme, the time derivatives of evolved variables are
+ * characteristic projected. Constraint-preserving correction terms
+ * \f$T^{\mathrm C}_{ab}\f$, Sommerfeld condition terms for gauge degrees of
+ * freedom \f$T^{\mathrm G}_{ab}\f$, and terms constraining physical degrees of
+ * freedom \f$T^{\mathrm P}_{ab}\f$ are added here to the resulting
+ * characteristic (time-derivative) field:
+ *
+ * \f{align}
+ * \Delta \partial_t v^{-}_{ab} = T^{\mathrm C}_{ab} + T^{\mathrm G}_{ab}
+ *                              + T^{\mathrm P}_{ab}.
+ * \f}
+ *
+ * These terms are given by Eq. (64) of \cite Lindblom2005qh :
+ *
+ * \f{eqnarray}
+ * T^{\mathrm C}_{ab} &=& \frac{1}{2}
+ *      \left(2 k^c k^d l_a l_b - k^c l_b P^d_a - k^c l_a P^d_b - k^d l_b P^c_a
+ *            - k^d l_a P^c_b + P^{cd} P_{ab}\right) \partial_t v^{-}_{cd}\\
+ *     &&+ \frac{1}{\sqrt{2}} \lambda_{-}c^{\hat{0}-}_c \left(l_a l_b k^c +
+ *          P_{ab} l^c - P^c_b l_a - P^c_a l_b \right) \nonumber
+ * \f}
+ *
+ * where \f$l^a (l_a)\f$ is the outgoing null vector (one-form), \f$k^a (k_a)\f$
+ * is the incoming null vector (one-form), \f$P_{ab}, P^{ab}, P^a_b\f$ are
+ * spacetime projection operators defined in `transverse_projection_operator()`,
+ * \f$\partial_t v^{-}_{ab}\f$ is the characteristic projected time derivative
+ * of evolved variables (corresponding to the \f$v^{-}\f$ field), and
+ * \f$c^{\hat{0}\pm}_a\f$ are characteristic modes of the constraint evolution
+ * system:
+ *
+ * \f{align}\nonumber
+ * c^{\hat{0}\pm}_a = F_a \mp n^k C_{ka},
+ * \f}
+ *
+ * where \f$F_a\f$ is the generalized-harmonic (GH) F constraint [Eq. (43) of
+ * \cite Lindblom2005qh], \f$C_{ka}\f$ is the GH 2-index constraint [Eq. (44)
+ * of \cite Lindblom2005qh], and \f$n^k\f$ is the unit spatial normal to the
+ * outer boundary. Boundary correction terms that prevent strong reflections of
+ * gauge perturbations are given by Eq. (25) of \cite Rinne2007ui :
+ *
+ * \f{align}
+ * T^{\mathrm G}_{ab} =
+ *     \left(k_a P^c_b l^d + k_b P^c_a l^d -
+ *          \left(k_a l_b k^c l^d + k_b l_a k_c l^d + k_a k_b l^c l^d
+ *          \right) \right) \left(\gamma_2 - \frac{1}{r}
+ *                          \right) \partial_t v^{\psi}_{cd}
+ * \f}
+ *
+ * where \f$r\f$ is the radial coordinate at the outer boundary, which is
+ * assumed to be spherical, \f$\gamma_2\f$ is a GH constraint damping parameter,
+ * and \f$\partial_t v^{\psi}_{ab}\f$ is the characteristic projected time
+ * derivative of evolved variables (corresponding to the \f$v^{\psi}\f$ field).
+ * Finally, we constrain physical degrees of freedom using corrections from
+ * Eq. (68) of \cite Lindblom2005qh :
+ *
+ * \f{align}
+ * T^{\mathrm P}_{ab} = \left( P^c_a P^d_b - \frac{1}{2} P_{ab} P^{cd} \right)
+ *     \left(\partial_t v^{-}_{cd} + \lambda_{-}
+ *           \left(U^{3-}_{cd} - \gamma_2 n^i C_{icd}\right)\right),
+ * \f}
+ *
+ * where \f$C_{icd}\f$ is the GH 3-index constraint [c.f. Eq. (26) of
+ * \cite Lindblom2005qh, see also `three_index_constraint()`], and
+ *
+ * \f{align}\nonumber
+ * U^{3-}_{ab} = 2 P^i_a P^j_b U^{8-}_{ij}
+ * \f}
+ *
+ * is the inward propagating characteristic mode of the Weyl tensor evolution
+ * \f$U^{8-}_{ab}\f$ [c.f. Eq. 75 of \cite Kidder2004rw ] projected onto the
+ * outer boundary using the spatial-spacetime projection operators \f$P^i_a\f$.
+ * Note that (A) the covariant derivative of extrinsic curvature needed to
+ * get the Weyl propagating modes is calculated substituting the evolved
+ * variable \f$\Phi_{iab}\f$ for spatial derivatives of the spacetime metric;
+ * and (B) the spatial Ricci tensor used in the same calculation is also
+ * calculated using the same substituion, and also includes corrections
+ * proportional to the GH 4-index constraint \f$C_{ijab}\f$ [c.f. Eq. (45) of
+ * \cite Lindblom2005qh , see also `four_index_constraint()`]:
+ *
+ * \f{align}\nonumber
+ * R_{ij} \rightarrow R_{ij} + C_{(iklj)} + \frac{1}{2} n^k q^a C_{(ikj)a},
+ * \f}
+ *
+ * where \f$q^a\f$ is the future-directed spacetime normal vector.
+ */
+template <size_t VolumeDim, typename DataType>
+void constraint_preserving_bjorhus_corrections_dt_v_minus(
+    gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame::Inertial>*>
+        bc_dt_v_minus,
+    const Scalar<DataType>& gamma2,
+    const tnsr::I<DataType, VolumeDim, Frame::Inertial>& inertial_coords,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>& incoming_null_one_form,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>& outgoing_null_one_form,
+    const tnsr::A<DataType, VolumeDim, Frame::Inertial>& incoming_null_vector,
+    const tnsr::A<DataType, VolumeDim, Frame::Inertial>& outgoing_null_vector,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>& projection_ab,
+    const tnsr::Ab<DataType, VolumeDim, Frame::Inertial>& projection_Ab,
+    const tnsr::AA<DataType, VolumeDim, Frame::Inertial>& projection_AB,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>&
+        char_projected_rhs_dt_v_psi,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>&
+        char_projected_rhs_dt_v_minus,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>&
+        constraint_char_zero_plus,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>&
+        constraint_char_zero_minus,
+    const std::array<DataType, 4>& char_speeds) noexcept;
+
+template <size_t VolumeDim, typename DataType>
+void constraint_preserving_physical_bjorhus_corrections_dt_v_minus(
+    gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame::Inertial>*>
+        bc_dt_v_minus,
+    const Scalar<DataType>& gamma2,
+    const tnsr::I<DataType, VolumeDim, Frame::Inertial>& inertial_coords,
+    const tnsr::i<DataType, VolumeDim, Frame::Inertial>&
+        unit_interface_normal_one_form,
+    const tnsr::I<DataType, VolumeDim, Frame::Inertial>&
+        unit_interface_normal_vector,
+    const tnsr::A<DataType, VolumeDim, Frame::Inertial>&
+        spacetime_unit_normal_vector,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>& incoming_null_one_form,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>& outgoing_null_one_form,
+    const tnsr::A<DataType, VolumeDim, Frame::Inertial>& incoming_null_vector,
+    const tnsr::A<DataType, VolumeDim, Frame::Inertial>& outgoing_null_vector,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>& projection_ab,
+    const tnsr::Ab<DataType, VolumeDim, Frame::Inertial>& projection_Ab,
+    const tnsr::AA<DataType, VolumeDim, Frame::Inertial>& projection_AB,
+    const tnsr::II<DataType, VolumeDim, Frame::Inertial>&
+        inverse_spatial_metric,
+    const tnsr::ii<DataType, VolumeDim, Frame::Inertial>& extrinsic_curvature,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>& spacetime_metric,
+    const tnsr::AA<DataType, VolumeDim, Frame::Inertial>&
+        inverse_spacetime_metric,
+    const tnsr::iaa<DataType, VolumeDim, Frame::Inertial>&
+        three_index_constraint,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>&
+        char_projected_rhs_dt_v_psi,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>&
+        char_projected_rhs_dt_v_minus,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>&
+        constraint_char_zero_plus,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>&
+        constraint_char_zero_minus,
+    const tnsr::iaa<DataType, VolumeDim, Frame::Inertial>& phi,
+    const tnsr::ijaa<DataType, VolumeDim, Frame::Inertial>& d_phi,
+    const tnsr::iaa<DataType, VolumeDim, Frame::Inertial>& d_pi,
+    const std::array<DataType, 4>& char_speeds) noexcept;
+/// @}
+
+namespace detail {
+template <size_t VolumeDim, typename DataType>
+void add_gauge_sommerfeld_terms_to_dt_v_minus(
+    const gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame::Inertial>*>
+        bc_dt_v_minus,
+    const Scalar<DataType>& gamma2,
+    const tnsr::I<DataType, VolumeDim, Frame::Inertial>& inertial_coords,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>& incoming_null_one_form,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>& outgoing_null_one_form,
+    const tnsr::A<DataType, VolumeDim, Frame::Inertial>& incoming_null_vector,
+    const tnsr::A<DataType, VolumeDim, Frame::Inertial>& outgoing_null_vector,
+    const tnsr::Ab<DataType, VolumeDim, Frame::Inertial>& projection_Ab,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>&
+        char_projected_rhs_dt_v_psi) noexcept;
+
+template <size_t VolumeDim, typename DataType>
+void add_constraint_dependent_terms_to_dt_v_minus(
+    const gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame::Inertial>*>
+        bc_dt_v_minus,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>& outgoing_null_one_form,
+    const tnsr::A<DataType, VolumeDim, Frame::Inertial>& incoming_null_vector,
+    const tnsr::A<DataType, VolumeDim, Frame::Inertial>& outgoing_null_vector,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>& projection_ab,
+    const tnsr::Ab<DataType, VolumeDim, Frame::Inertial>& projection_Ab,
+    const tnsr::AA<DataType, VolumeDim, Frame::Inertial>& projection_AB,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>&
+        constraint_char_zero_plus,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>&
+        constraint_char_zero_minus,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>&
+        char_projected_rhs_dt_v_minus,
+    const std::array<DataType, 4>& char_speeds) noexcept;
+
+template <size_t VolumeDim, typename DataType>
+void add_physical_terms_to_dt_v_minus(
+    const gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame::Inertial>*>
+        bc_dt_v_minus,
+    const Scalar<DataType>& gamma2,
+    const tnsr::i<DataType, VolumeDim, Frame::Inertial>&
+        unit_interface_normal_one_form,
+    const tnsr::I<DataType, VolumeDim, Frame::Inertial>&
+        unit_interface_normal_vector,
+    const tnsr::A<DataType, VolumeDim, Frame::Inertial>&
+        spacetime_unit_normal_vector,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>& projection_ab,
+    const tnsr::Ab<DataType, VolumeDim, Frame::Inertial>& projection_Ab,
+    const tnsr::AA<DataType, VolumeDim, Frame::Inertial>& projection_AB,
+    const tnsr::II<DataType, VolumeDim, Frame::Inertial>&
+        inverse_spatial_metric,
+    const tnsr::ii<DataType, VolumeDim, Frame::Inertial>& extrinsic_curvature,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>& spacetime_metric,
+    const tnsr::AA<DataType, VolumeDim, Frame::Inertial>&
+        inverse_spacetime_metric,
+    const tnsr::iaa<DataType, VolumeDim, Frame::Inertial>&
+        three_index_constraint,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>&
+        char_projected_rhs_dt_v_minus,
+    const tnsr::iaa<DataType, VolumeDim, Frame::Inertial>& phi,
+    const tnsr::ijaa<DataType, VolumeDim, Frame::Inertial>& d_phi,
+    const tnsr::iaa<DataType, VolumeDim, Frame::Inertial>& d_pi,
+    const std::array<DataType, 4>& char_speeds) noexcept;
+}  // namespace detail
 }  // namespace Bjorhus
 }  // namespace GeneralizedHarmonic::BoundaryConditions

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.py
@@ -4,6 +4,11 @@
 import itertools as it
 import numpy as np
 
+import PointwiseFunctions.GeneralRelativity.Christoffel as ch
+import PointwiseFunctions.GeneralRelativity.ComputeGhQuantities as gh
+import PointwiseFunctions.GeneralRelativity.ProjectionOperators as proj
+import PointwiseFunctions.GeneralRelativity.WeylPropagating as wp
+
 
 def constraint_preserving_bjorhus_corrections_dt_v_psi(
     unit_interface_normal_vector, three_index_constraint, char_speeds):
@@ -35,3 +40,182 @@ def constraint_preserving_bjorhus_corrections_dt_v_zero(
                                    unit_interface_normal_vector[p[2]] *
                                    four_index_constraint[p[1], :, :])
     return result
+
+
+def add_gauge_sommerfeld_terms_to_dt_v_minus(
+    gamma2, inertial_coords, incoming_null_one_form, outgoing_null_one_form,
+    incoming_null_vector, outgoing_null_vector, projection_Ab,
+    char_projected_rhs_dt_v_psi):
+    gauge_bc_coeff = 1.
+    inertial_radius = np.sum(inertial_coords**2)**0.5
+    prefac = (gamma2 - gauge_bc_coeff / inertial_radius)
+
+    t1_ = np.einsum('a,cb,d,cd->ab', incoming_null_one_form, projection_Ab,
+                    outgoing_null_vector, char_projected_rhs_dt_v_psi)
+    t2_ = np.einsum('b,ca,d,cd->ab', incoming_null_one_form, projection_Ab,
+                    outgoing_null_vector, char_projected_rhs_dt_v_psi)
+    t3_ = np.einsum('a,b,c,d,cd->ab', incoming_null_one_form,
+                    outgoing_null_one_form, incoming_null_vector,
+                    outgoing_null_vector, char_projected_rhs_dt_v_psi)
+    t4_ = np.einsum('b,a,c,d,cd->ab', incoming_null_one_form,
+                    outgoing_null_one_form, incoming_null_vector,
+                    outgoing_null_vector, char_projected_rhs_dt_v_psi)
+    t5_ = np.einsum('a,b,c,d,cd->ab', incoming_null_one_form,
+                    incoming_null_one_form, outgoing_null_vector,
+                    outgoing_null_vector, char_projected_rhs_dt_v_psi)
+    return prefac * (t1_ + t2_ - t3_ - t4_ - t5_)
+
+
+def add_constraint_dependent_terms_to_dt_v_minus(
+    incoming_null_one_form, outgoing_null_one_form, incoming_null_vector,
+    outgoing_null_vector, projection_ab, projection_Ab, projection_AB,
+    constraint_char_zero_plus, constraint_char_zero_minus,
+    char_projected_rhs_dt_v_minus, char_speeds):
+    mu = 0.0  # hard-coded value from SpEC Bbh input file Mu = 0
+
+    t1_ = np.einsum('c,d,a,b,cd->ab', incoming_null_vector,
+                    incoming_null_vector, outgoing_null_one_form,
+                    outgoing_null_one_form, char_projected_rhs_dt_v_minus)
+    t2_ = np.einsum('c,da,b,cd->ab', incoming_null_vector, projection_Ab,
+                    outgoing_null_one_form, char_projected_rhs_dt_v_minus)
+    t3_ = np.einsum('c,db,a,cd->ab', incoming_null_vector, projection_Ab,
+                    outgoing_null_one_form, char_projected_rhs_dt_v_minus)
+    t4_ = np.einsum('d,ca,b,cd->ab', incoming_null_vector, projection_Ab,
+                    outgoing_null_one_form, char_projected_rhs_dt_v_minus)
+    t5_ = np.einsum('d,cb,a,cd->ab', incoming_null_vector, projection_Ab,
+                    outgoing_null_one_form, char_projected_rhs_dt_v_minus)
+    t6_ = np.einsum('cd,ab,cd->ab', projection_AB, projection_ab,
+                    char_projected_rhs_dt_v_minus)
+
+    common_term = np.sqrt(0.5) * char_speeds[3] * (
+        constraint_char_zero_minus - mu * constraint_char_zero_plus)
+    t7_ = np.einsum('a,b,c,c->ab', outgoing_null_one_form,
+                    outgoing_null_one_form, incoming_null_vector, common_term)
+    t8_ = np.einsum('ab,c,c->ab', projection_ab, outgoing_null_vector,
+                    common_term)
+    t9_ = np.einsum('cb,a,c->ab', projection_Ab, outgoing_null_one_form,
+                    common_term)
+    t10_ = np.einsum('ca,b,c->ab', projection_Ab, outgoing_null_one_form,
+                     common_term)
+    return (0.5 * (2.0 * t1_ - t2_ - t3_ - t4_ - t5_ + t6_) +
+            (t7_ + t8_ - t9_ - t10_))
+
+
+def add_physical_dof_terms_to_dt_v_minus(
+    gamma2, unit_interface_normal_one_form, unit_interface_normal_vector,
+    spacetime_unit_normal_vector, projection_ab, projection_Ab, projection_AB,
+    inverse_spatial_metric, extrinsic_curvature, spacetime_metric,
+    inverse_spacetime_metric, three_index_constraint,
+    char_projected_rhs_dt_v_minus, phi, d_phi, d_pi, char_speeds):
+    mu_phys = 0
+    adjust_phys_using_c4 = True
+    gamma2_in_phys = True
+    # calculate weyl propagating modes
+    #       cov deriv of Kij
+    #       calculate ricci3
+    #       adjust_phys_using_c4
+    #       calculate projection operators
+    spatial_christoffel_1st_kind = ch.christoffel_first_kind(phi[:, 1:, 1:])
+    spatial_christoffel_second_kind = np.einsum('ij,jkl->ikl',
+                                                inverse_spatial_metric,
+                                                spatial_christoffel_1st_kind)
+    cov_d_Kij = gh.covariant_deriv_extrinsic_curvture(
+        extrinsic_curvature, spacetime_unit_normal_vector,
+        spatial_christoffel_second_kind, inverse_spacetime_metric, phi, d_pi,
+        d_phi)
+    ricci3 = gh.gh_spatial_ricci_tensor(phi, d_phi, inverse_spatial_metric)
+    if adjust_phys_using_c4:
+        ricci3 = ricci3 + 0.25 * (
+            np.einsum('kl,iklj->ij', inverse_spatial_metric, d_phi[:, :, 1:,
+                                                                   1:]) -
+            np.einsum('kl,kilj->ij', inverse_spatial_metric, d_phi[:, :, 1:,
+                                                                   1:]) +
+            np.einsum('kl,jkli->ij', inverse_spatial_metric, d_phi[:, :, 1:,
+                                                                   1:]) - np.
+            einsum('kl,kjli->ij', inverse_spatial_metric, d_phi[:, :, 1:, 1:]))
+        ricci3 = ricci3 + 0.5 * (
+            np.einsum('k,a,ikja->ij', unit_interface_normal_vector,
+                      spacetime_unit_normal_vector, d_phi[:, :, 1:, :]) -
+            np.einsum('k,a,kija->ij', unit_interface_normal_vector,
+                      spacetime_unit_normal_vector, d_phi[:, :, 1:, :]) +
+            np.einsum('k,a,jkia->ij', unit_interface_normal_vector,
+                      spacetime_unit_normal_vector, d_phi[:, :, 1:, :]) -
+            np.einsum('k,a,kjia->ij', unit_interface_normal_vector,
+                      spacetime_unit_normal_vector, d_phi[:, :, 1:, :]))
+    spatial_proj_IJ = proj.transverse_projection_operator(
+        inverse_spatial_metric, unit_interface_normal_vector)
+    spatial_proj_ij = proj.transverse_projection_operator(
+        spacetime_metric[1:, 1:], unit_interface_normal_one_form)
+    spatial_proj_Ij =\
+        proj.transverse_projection_operator_mixed_from_spatial_input(
+            unit_interface_normal_vector, unit_interface_normal_one_form)
+    weyl_prop_plus = wp.weyl_propagating_mode_plus(
+        ricci3, extrinsic_curvature, inverse_spatial_metric, cov_d_Kij,
+        unit_interface_normal_vector, spatial_proj_IJ, spatial_proj_ij,
+        spatial_proj_Ij)
+    weyl_prop_minus = wp.weyl_propagating_mode_minus(
+        ricci3, extrinsic_curvature, inverse_spatial_metric, cov_d_Kij,
+        unit_interface_normal_vector, spatial_proj_IJ, spatial_proj_ij,
+        spatial_proj_Ij)
+    # calculate U3+ U3-
+    U3_plus = 2 * np.einsum('ia,jb,ij->ab', projection_Ab[1:, :],
+                            projection_Ab[1:, :], weyl_prop_plus)
+    U3_minus = 2 * np.einsum('ia,jb,ij->ab', projection_Ab[1:, :],
+                             projection_Ab[1:, :], weyl_prop_minus)
+    # calculate corrections
+    tmp_ = char_speeds[3] * (U3_minus - mu_phys * U3_plus)
+    if gamma2_in_phys:
+        tmp_ = tmp_ - char_speeds[3] * gamma2 * np.einsum(
+            'i,iab->ab', unit_interface_normal_vector, three_index_constraint)
+
+    t1_ = np.einsum('ac,bd,ab->cd', projection_Ab, projection_Ab,
+                    char_projected_rhs_dt_v_minus + tmp_)
+    t2_ = -0.5 * np.einsum('ab,cd,ab->cd', projection_AB, projection_ab,
+                           char_projected_rhs_dt_v_minus + tmp_)
+    return t1_ + t2_
+
+
+def constraint_preserving_bjorhus_corrections_dt_v_minus(
+    gamma2, inertial_coords, incoming_null_one_form, outgoing_null_one_form,
+    incoming_null_vector, outgoing_null_vector, projection_ab, projection_Ab,
+    projection_AB, char_projected_rhs_dt_v_psi, char_projected_rhs_dt_v_minus,
+    constraint_char_zero_plus, constraint_char_zero_minus, char_speeds):
+    return add_constraint_dependent_terms_to_dt_v_minus(
+        incoming_null_one_form, outgoing_null_one_form, incoming_null_vector,
+        outgoing_null_vector, projection_ab, projection_Ab, projection_AB,
+        constraint_char_zero_plus, constraint_char_zero_minus,
+        char_projected_rhs_dt_v_minus,
+        char_speeds) + add_gauge_sommerfeld_terms_to_dt_v_minus(
+            gamma2, inertial_coords, incoming_null_one_form,
+            outgoing_null_one_form, incoming_null_vector, outgoing_null_vector,
+            projection_Ab,
+            char_projected_rhs_dt_v_psi) - char_projected_rhs_dt_v_minus
+
+
+def constraint_preserving_physical_bjorhus_corrections_dt_v_minus(
+    gamma2, inertial_coords, unit_interface_normal_one_form,
+    unit_interface_normal_vector, spacetime_unit_normal_vector,
+    incoming_null_one_form, outgoing_null_one_form, incoming_null_vector,
+    outgoing_null_vector, projection_ab, projection_Ab, projection_AB,
+    inverse_spatial_metric, extrinsic_curvature, spacetime_metric,
+    inverse_spacetime_metric, three_index_constraint,
+    char_projected_rhs_dt_v_psi, char_projected_rhs_dt_v_minus,
+    constraint_char_zero_plus, constraint_char_zero_minus, phi, d_phi, d_pi,
+    char_speeds):
+    return add_constraint_dependent_terms_to_dt_v_minus(
+        incoming_null_one_form, outgoing_null_one_form, incoming_null_vector,
+        outgoing_null_vector, projection_ab, projection_Ab, projection_AB,
+        constraint_char_zero_plus, constraint_char_zero_minus,
+        char_projected_rhs_dt_v_minus,
+        char_speeds) + add_physical_dof_terms_to_dt_v_minus(
+            gamma2, unit_interface_normal_one_form,
+            unit_interface_normal_vector, spacetime_unit_normal_vector,
+            projection_ab, projection_Ab, projection_AB,
+            inverse_spatial_metric, extrinsic_curvature, spacetime_metric,
+            inverse_spacetime_metric, three_index_constraint,
+            char_projected_rhs_dt_v_minus, phi, d_phi, d_pi,
+            char_speeds) + add_gauge_sommerfeld_terms_to_dt_v_minus(
+                gamma2, inertial_coords, incoming_null_one_form,
+                outgoing_null_one_form, incoming_null_vector,
+                outgoing_null_vector, projection_Ab,
+                char_projected_rhs_dt_v_psi) - char_projected_rhs_dt_v_minus

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_BjorhusImpl.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_BjorhusImpl.cpp
@@ -4,6 +4,7 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <array>
+#include <cmath>
 #include <cstddef>
 #include <limits>
 
@@ -17,6 +18,7 @@
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
@@ -334,6 +336,742 @@ void test_constraint_preserving_bjorhus_v_zero_vs_spec_3d(
   // Compare values returned by BC action vs those from SpEC
   CHECK_ITERABLE_APPROX(local_bc_dt_v_zero, spec_bc_dt_v_zero);
 }
+
+void test_constraint_preserving_physical_bjorhus_v_minus_vs_spec_3d(
+    const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& /* upper_bound */) noexcept {
+  // Setup grid
+  Mesh<VolumeDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+  // Setup coordinates
+  const Direction<VolumeDim> direction(1, Side::Upper);  // +y direction
+  const size_t slice_grid_points =
+      mesh.extents().slice_away(direction.dimension()).product();
+  const auto inertial_coords = [&slice_grid_points, &lower_bound]() {
+    tnsr::I<DataVector, VolumeDim, frame> tmp(slice_grid_points, 0.);
+    // +y direction
+    get<1>(tmp) = 0.5;
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      for (size_t j = 0; j < VolumeDim; ++j) {
+        get<0>(tmp)[i * VolumeDim + j] =
+            lower_bound[0] + 0.5 * static_cast<double>(i);
+        get<2>(tmp)[i * VolumeDim + j] =
+            lower_bound[2] + 0.5 * static_cast<double>(j);
+      }
+    }
+    return tmp;
+  }();
+
+  // Populate various tensors needed to compute BcDtVMinus as done in SpEC
+  tnsr::I<DataVector, VolumeDim, frame> local_unit_interface_normal_vector(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+  tnsr::I<DataVector, VolumeDim, frame> local_inertial_coords(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+  const auto& local_inertial_coords_x = get<0>(local_inertial_coords);
+  const auto& local_inertial_coords_y = get<1>(local_inertial_coords);
+  const auto& local_inertial_coords_z = get<2>(local_inertial_coords);
+  Scalar<DataVector> local_constraint_gamma2(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+
+  // timelike and spacelike SPACETIME vectors, l^a and k^a
+  tnsr::a<DataVector, VolumeDim, frame> local_outgoing_null_one_form(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+  tnsr::a<DataVector, VolumeDim, frame> local_incoming_null_one_form(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+
+  // timelike and spacelike SPACETIME oneforms, l_a and k_a
+  tnsr::A<DataVector, VolumeDim, frame> local_outgoing_null_vector(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+  tnsr::A<DataVector, VolumeDim, frame> local_incoming_null_vector(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+
+  // spacetime projection operator P_ab, P^ab, and P^a_b
+  tnsr::AA<DataVector, VolumeDim, frame> local_projection_AB(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+  tnsr::aa<DataVector, VolumeDim, frame> local_projection_ab(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+  tnsr::Ab<DataVector, VolumeDim, frame> local_projection_Ab(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+
+  // constraint characteristics
+  tnsr::a<DataVector, VolumeDim, frame> local_constraint_char_zero_minus(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+  tnsr::a<DataVector, VolumeDim, frame> local_constraint_char_zero_plus(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+
+  // RhsVSpacetimeMetric and RhsVMinus
+  tnsr::aa<DataVector, VolumeDim, frame> local_char_projected_rhs_dt_v_psi(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+  tnsr::aa<DataVector, VolumeDim, frame> local_char_projected_rhs_dt_v_minus(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+
+  // Vars
+  tnsr::aa<DataVector, VolumeDim, frame> local_pi(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+  tnsr::iaa<DataVector, VolumeDim, frame> local_phi(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+
+  // Char speeds
+  std::array<DataVector, 4> local_char_speeds{
+      DataVector(slice_grid_points,
+                 std::numeric_limits<double>::signaling_NaN()),
+      DataVector(slice_grid_points,
+                 std::numeric_limits<double>::signaling_NaN()),
+      DataVector(slice_grid_points,
+                 std::numeric_limits<double>::signaling_NaN()),
+      DataVector(slice_grid_points,
+                 std::numeric_limits<double>::signaling_NaN())};
+
+  // interface normal one form
+  tnsr::i<DataVector, VolumeDim, frame> local_unit_interface_normal_one_form(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+
+  // spacetime unit normal vec
+  tnsr::A<DataVector, VolumeDim, frame> local_spacetime_unit_normal_vector(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+
+  // metrics
+  tnsr::II<DataVector, VolumeDim, frame> local_inverse_spatial_metric(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+  tnsr::aa<DataVector, VolumeDim, frame> local_spacetime_metric(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+  tnsr::AA<DataVector, VolumeDim, frame> local_inverse_spacetime_metric(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+
+  // extrinsic curvature
+  tnsr::ii<DataVector, VolumeDim, frame> local_extrinsic_curvature(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+
+  // deriv of pi and phi
+  tnsr::iaa<DataVector, VolumeDim, frame> local_d_pi(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+  tnsr::ijaa<DataVector, VolumeDim, frame> local_d_phi(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+
+  // 3-index constraint
+  tnsr::iaa<DataVector, VolumeDim, frame> local_three_index_constraint(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+
+  {
+    // Setting coords
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      local_inertial_coords.get(i) = inertial_coords.get(i);
+    }
+
+    // Setting local_unit_interface_normal_one_form
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      local_unit_interface_normal_one_form.get(0)[i] = -1.;
+      local_unit_interface_normal_one_form.get(1)[i] = 1.;
+      local_unit_interface_normal_one_form.get(2)[i] = 1.;
+    }
+    // Setting local_spacetime_unit_normal_vector
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      local_spacetime_unit_normal_vector.get(0)[i] = -1.;
+      local_spacetime_unit_normal_vector.get(1)[i] = -3.;
+      local_spacetime_unit_normal_vector.get(2)[i] = -5.;
+      local_spacetime_unit_normal_vector.get(3)[i] = -7.;
+    }
+    // Setting local_inverse_spatial_metric
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      for (size_t j = 0; j < VolumeDim; ++j) {
+        local_inverse_spatial_metric.get(0, j)[i] = 41.;
+        local_inverse_spatial_metric.get(1, j)[i] = 43.;
+        local_inverse_spatial_metric.get(2, j)[i] = 47.;
+      }
+    }
+    // Setting local_spacetime_metric
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        local_spacetime_metric.get(0, a)[i] = 257.;
+        local_spacetime_metric.get(1, a)[i] = 263.;
+        local_spacetime_metric.get(2, a)[i] = 269.;
+        local_spacetime_metric.get(3, a)[i] = 271.;
+      }
+    }
+    // Setting local_inverse_spacetime_metric
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        local_inverse_spacetime_metric.get(0, a)[i] =
+            -277.;  // needs to be < 0 for lapse
+        local_inverse_spacetime_metric.get(1, a)[i] = 281.;
+        local_inverse_spacetime_metric.get(2, a)[i] = 283.;
+        local_inverse_spacetime_metric.get(3, a)[i] = 293.;
+      }
+    }
+    // Setting local_extrinsic_curvature
+    // ONLY ON THE +Y AXIS (Y = +0.5)
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      std::array<double, 9> spec_vals{};
+      bool not_initialized = true;
+
+      if ((local_inertial_coords_x[i] == 299. or
+           local_inertial_coords_x[i] == 299.5 or
+           local_inertial_coords_x[i] == 300.) and
+          local_inertial_coords_y[i] == 0.5 and
+          (local_inertial_coords_z[i] == -0.5 or
+           local_inertial_coords_z[i] == 0. or
+           local_inertial_coords_z[i] == 0.5)) {
+        spec_vals = {{200.2198037251189, 266.7930716334918, 333.3663395418648,
+                      266.7930716334918, 333.3663395418648, 399.9396074502377,
+                      333.3663395418648, 399.9396074502377, 466.5128753586106}};
+        not_initialized = false;
+      }
+
+      if (not_initialized) {
+        ERROR("Not checking the correct face, coordinates not recognized");
+      }
+      for (size_t j = 0; j < VolumeDim; ++j) {
+        for (size_t k = 0; k < VolumeDim; ++k) {
+          local_extrinsic_curvature.get(j, k)[i] =
+              gsl::at(spec_vals, j * (0 + VolumeDim) + k);
+        }
+      }
+    }
+
+    // Setting local_d_phi
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = 0; b <= VolumeDim; ++b) {
+          local_d_pi.get(0, a, b)[i] = 1.;
+          local_d_phi.get(0, 0, a, b)[i] = 3.;
+          local_d_phi.get(0, 1, a, b)[i] = 5.;
+          local_d_phi.get(0, 2, a, b)[i] = 7.;
+          local_d_pi.get(1, a, b)[i] = 53.;
+          local_d_phi.get(1, 0, a, b)[i] = 59.;
+          local_d_phi.get(1, 1, a, b)[i] = 61.;
+          local_d_phi.get(1, 2, a, b)[i] = 67.;
+          local_d_pi.get(2, a, b)[i] = 71.;
+          local_d_phi.get(2, 0, a, b)[i] = 73.;
+          local_d_phi.get(2, 1, a, b)[i] = 79.;
+          local_d_phi.get(2, 2, a, b)[i] = 83.;
+        }
+      }
+    }
+    // Setting 3idxConstraint
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = 0; b <= VolumeDim; ++b) {
+          local_three_index_constraint.get(0, a, b)[i] = 11. - 3.;
+          local_three_index_constraint.get(1, a, b)[i] = 13. - 5.;
+          local_three_index_constraint.get(2, a, b)[i] = 17. - 7.;
+        }
+      }
+    }
+
+    // Setting constraint_gamma2
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      get(local_constraint_gamma2)[i] = 113.;
+    }
+    // Note: explicit division by sqrt(2) below for the computation of ui, uI,
+    // vi, vI are left as-is to remind us that SpEC uses these null vectors
+    // and one forms without normalization by sqrt(2).
+    // Setting incoming null one_form: ui
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      local_incoming_null_one_form.get(0)[i] = -2. / sqrt(2.);
+      local_incoming_null_one_form.get(1)[i] = 5. / sqrt(2.);
+      local_incoming_null_one_form.get(2)[i] = 3. / sqrt(2.);
+      local_incoming_null_one_form.get(3)[i] = 7. / sqrt(2.);
+    }
+    // Setting incoming null vector: uI
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      local_incoming_null_vector.get(0)[i] = -1. / sqrt(2.);
+      local_incoming_null_vector.get(1)[i] = 13. / sqrt(2.);
+      local_incoming_null_vector.get(2)[i] = 17. / sqrt(2.);
+      local_incoming_null_vector.get(3)[i] = 19. / sqrt(2.);
+    }
+    // Setting outgoing null one_form: vi
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      local_outgoing_null_one_form.get(0)[i] = -1. / sqrt(2.);
+      local_outgoing_null_one_form.get(1)[i] = 3. / sqrt(2.);
+      local_outgoing_null_one_form.get(2)[i] = 2. / sqrt(2.);
+      local_outgoing_null_one_form.get(3)[i] = 5. / sqrt(2.);
+    }
+    // Setting outgoing null vector: vI
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      local_outgoing_null_vector.get(0)[i] = -1. / sqrt(2.);
+      local_outgoing_null_vector.get(1)[i] = 2. / sqrt(2.);
+      local_outgoing_null_vector.get(2)[i] = 3. / sqrt(2.);
+      local_outgoing_null_vector.get(3)[i] = 5. / sqrt(2.);
+    }
+    // Setting projection Ab
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        local_projection_Ab.get(0, a)[i] = 233.;
+        local_projection_Ab.get(1, a)[i] = 239.;
+        local_projection_Ab.get(2, a)[i] = 241.;
+        local_projection_Ab.get(3, a)[i] = 251.;
+      }
+    }
+    // Setting projection ab
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        local_projection_ab.get(0, a)[i] = 379.;
+        local_projection_ab.get(1, a)[i] = 383.;
+        local_projection_ab.get(2, a)[i] = 389.;
+        local_projection_ab.get(3, a)[i] = 397.;
+      }
+    }
+    // Setting projection AB
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        local_projection_AB.get(0, a)[i] = 353.;
+        local_projection_AB.get(1, a)[i] = 359.;
+        local_projection_AB.get(2, a)[i] = 367.;
+        local_projection_AB.get(3, a)[i] = 373.;
+      }
+    }
+    // Setting local_RhsVSpacetimeMetric
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        local_char_projected_rhs_dt_v_psi.get(0, a)[i] = 23.;
+        local_char_projected_rhs_dt_v_psi.get(1, a)[i] = 29.;
+        local_char_projected_rhs_dt_v_psi.get(2, a)[i] = 31.;
+        local_char_projected_rhs_dt_v_psi.get(3, a)[i] = 37.;
+      }
+    }
+    // Setting RhsVMinus
+    for (size_t i = 0; i < get<0>(local_inertial_coords).size(); ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        local_char_projected_rhs_dt_v_minus.get(0, a)[i] = 331.;
+        local_char_projected_rhs_dt_v_minus.get(1, a)[i] = 337.;
+        local_char_projected_rhs_dt_v_minus.get(2, a)[i] = 347.;
+        local_char_projected_rhs_dt_v_minus.get(3, a)[i] = 349.;
+      }
+    }
+
+    // Setting unit_interface_normal_Vector
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      get<0>(local_unit_interface_normal_vector)[i] = -1.;
+      get<1>(local_unit_interface_normal_vector)[i] = 1.;
+      get<2>(local_unit_interface_normal_vector)[i] = 1.;
+    }
+    // Setting pi AND phi
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = 0; b <= VolumeDim; ++b) {
+          local_pi.get(a, b)[i] = 1.;
+          local_phi.get(0, a, b)[i] = 3.;
+          local_phi.get(1, a, b)[i] = 5.;
+          local_phi.get(2, a, b)[i] = 7.;
+        }
+      }
+    }
+    // Setting char speeds
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      local_char_speeds.at(0)[i] = -0.3;
+      local_char_speeds.at(1)[i] = -0.1;
+      local_char_speeds.at(3)[i] = -0.2;
+    }
+    // Setting constraint_char_zero_plus AND constraint_char_zero_minus
+    // ONLY ON THE +Y AXIS (Y = +0.5)
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      std::array<double, 4> spec_vals{};
+      std::array<double, 4> spec_vals2{};
+      bool not_initialized = true;
+
+      if (local_inertial_coords_x[i] == 299. and
+          local_inertial_coords_y[i] == 0.5 and
+          local_inertial_coords_z[i] == -0.5) {
+        spec_vals = {{3722388974.799386, -16680127.68747905, -22991565.68745775,
+                      -29394198.68743645}};
+        spec_vals2 = {{3866802572.424386, -19802442.06247905,
+                       -19496408.06245775, -19257249.06243645}};
+        not_initialized = false;
+      }
+      if (local_inertial_coords_x[i] == 299.5 and
+          local_inertial_coords_y[i] == 0.5 and
+          local_inertial_coords_z[i] == -0.5) {
+        spec_vals = {{1718287695.133032, -35082292.16184025, -44420849.32723039,
+                      -53850596.45928719}};
+        spec_vals2 = {{1866652790.548975, -38170999.90741873,
+                       -40892085.07280888, -43680040.20486567}};
+        not_initialized = false;
+      }
+      if (local_inertial_coords_x[i] == 300. and
+          local_inertial_coords_y[i] == 0.5 and
+          local_inertial_coords_z[i] == -0.5) {
+        spec_vals = {{1718299060.415949, -35082089.27527188, -44420613.14790046,
+                      -53850326.98725116}};
+        spec_vals2 = {{1866664134.129611, -38170797.39904065,
+                       -40891849.27166924, -43679771.11101994}};
+        not_initialized = false;
+      }
+      if (local_inertial_coords_x[i] == 299. and
+          local_inertial_coords_y[i] == 0.5 and
+          local_inertial_coords_z[i] == 0.) {
+        spec_vals = {{1718276282.501221, -35082495.89577083, -44421086.49296889,
+                      -53850867.05677793}};
+        spec_vals2 = {{1866641399.709844, -38171203.26157932,
+                       -40892321.85877737, -43680310.4225864}};
+        not_initialized = false;
+      }
+      if (local_inertial_coords_x[i] == 299.5 and
+          local_inertial_coords_y[i] == 0.5 and
+          local_inertial_coords_z[i] == 0.) {
+        spec_vals = {{1718287685.660846, -35082292.33093269, -44420849.52407002,
+                      -53850596.68387395}};
+        spec_vals2 = {{1866652781.094877, -38171000.07619599,
+                       -40892085.26933331, -43680040.42913724}};
+        not_initialized = false;
+      }
+      if (local_inertial_coords_x[i] == 300. and
+          local_inertial_coords_y[i] == 0.5 and
+          local_inertial_coords_z[i] == 0.) {
+        spec_vals = {{1718299050.990844, -35082089.44352208, -44420613.34375966,
+                      -53850327.21071925}};
+        spec_vals2 = {{1866664124.722503, -38170797.56697725,
+                       -40891849.46721483, -43679771.33417442}};
+        not_initialized = false;
+      }
+      if (local_inertial_coords_x[i] == 299. and
+          local_inertial_coords_y[i] == 0.5 and
+          local_inertial_coords_z[i] == 0.5) {
+        spec_vals = {{1718276292.082241, -35082495.72473276, -44421086.29386414,
+                      -53850866.82960649}};
+        spec_vals2 = {{1866641409.272568, -38171203.09086005,
+                       -40892321.65999144, -43680310.19573379}};
+        not_initialized = false;
+      }
+      if (local_inertial_coords_x[i] == 299.5 and
+          local_inertial_coords_y[i] == 0.5 and
+          local_inertial_coords_z[i] == 0.5) {
+        spec_vals = {{1718287695.194063, -35082292.16074976, -44420849.32596073,
+                      -53850596.45783833}};
+        spec_vals2 = {{1866652790.609889, -38170999.90633029,
+                       -40892085.07154126, -43680040.20341886}};
+        not_initialized = false;
+      }
+      if (local_inertial_coords_x[i] == 300. and
+          local_inertial_coords_y[i] == 0.5 and
+          local_inertial_coords_z[i] == 0.5) {
+        spec_vals = {{1718299060.476573, -35082089.27418864, -44420613.14663924,
+                      -53850326.98581193}};
+        spec_vals2 = {{1866664134.190119, -38170797.39795944,
+                       -40891849.27041004, -43679771.10958273}};
+        not_initialized = false;
+      }
+      if (not_initialized) {
+        ERROR("Not checking the correct face, coordinates not recognized");
+      }
+      for (size_t j = 0; j <= VolumeDim; ++j) {
+        local_constraint_char_zero_plus.get(j)[i] = gsl::at(spec_vals, j);
+        local_constraint_char_zero_minus.get(j)[i] = gsl::at(spec_vals2, j);
+      }
+    }
+  }
+
+  // Memory for output
+  tnsr::aa<DataVector, VolumeDim, frame> local_bc_dt_v_minus(
+      slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+
+  {
+    // Compute the new boundary corrections for dt<vminus>
+    GeneralizedHarmonic::BoundaryConditions::Bjorhus::
+        constraint_preserving_bjorhus_corrections_dt_v_minus(
+            make_not_null(&local_bc_dt_v_minus), local_constraint_gamma2,
+            local_inertial_coords, local_incoming_null_one_form,
+            local_outgoing_null_one_form, local_incoming_null_vector,
+            local_outgoing_null_vector, local_projection_ab,
+            local_projection_Ab, local_projection_AB,
+            local_char_projected_rhs_dt_v_psi,
+            local_char_projected_rhs_dt_v_minus,
+            local_constraint_char_zero_plus, local_constraint_char_zero_minus,
+            local_char_speeds);
+    // Add in the current boundary value to get corrected values for dt<vminus>
+    for (size_t a = 0; a <= VolumeDim; ++a) {
+      for (size_t b = a; b <= VolumeDim; ++b) {
+        local_bc_dt_v_minus.get(a, b) +=
+            local_char_projected_rhs_dt_v_minus.get(a, b);
+      }
+    }
+
+    // Initialize with values from SpEC
+    tnsr::aa<DataVector, VolumeDim, frame> spec_bc_dt_v_minus(
+        slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      std::array<double, 16> spec_vals{};
+      bool not_initialized = true;
+
+      if (local_inertial_coords_x[i] == 299. and
+          local_inertial_coords_y[i] == 0.5 and
+          local_inertial_coords_z[i] == -0.5) {
+        spec_vals = {{-22857869555.93848, 330934979077.5689, 242482973593.2169,
+                      507808643438.4713, 330934979077.5689, 690190606335.8783,
+                      600780523621.8837, 868984678067.689, 242482973593.2169,
+                      600780523621.8837, 514052337348.0055, 781537245156.9633,
+                      507808643438.4713, 868984678067.689, 781537245156.9633,
+                      1054439575483.625}};
+        not_initialized = false;
+      }
+      if (local_inertial_coords_x[i] == 299.5 and
+          local_inertial_coords_y[i] == 0.5 and
+          local_inertial_coords_z[i] == -0.5) {
+        spec_vals = {{6085210488.394159, 167380193629.8459, 127052654518.3203,
+                      248004925243.5957, 167380193629.8459, 332680231531.8318,
+                      291581334988.8124, 414851930920.4022, 127052654518.3203,
+                      291581334988.8124, 252051387928.7005, 374742777072.0203,
+                      248004925243.5957, 414851930920.4022, 374742777072.0203,
+                      501009779843.9042}};
+        not_initialized = false;
+      }
+      if (local_inertial_coords_x[i] == 300. and
+          local_inertial_coords_y[i] == 0.5 and
+          local_inertial_coords_z[i] == -0.5) {
+        spec_vals = {{6084984067.712499, 167381093626.4053, 127053272910.3827,
+                      248006388447.6548, 167381093626.4053, 332682261170.2852,
+                      291583083105.2007, 414854523601.7003, 127053272910.3827,
+                      291583083105.2007, 252052859833.8237, 374745093603.8436,
+                      248006388447.6548, 414854523601.7003, 374745093603.8436,
+                      501012947925.7576}};
+        not_initialized = false;
+      }
+      if (local_inertial_coords_x[i] == 299. and
+          local_inertial_coords_y[i] == 0.5 and
+          local_inertial_coords_z[i] == 0.) {
+        spec_vals = {{6085437853.704128, 167379289884.4027, 127052033550.7529,
+                      248003455943.9015, 167379289884.4027, 332678193437.6569,
+                      291579579589.7132, 414849327437.366, 127052033550.7529,
+                      291579579589.7132, 252049909891.7733, 374740450889.0901,
+                      248003455943.9015, 414849327437.366, 374740450889.0901,
+                      501006598562.8735}};
+        not_initialized = false;
+      }
+      if (local_inertial_coords_x[i] == 299.5 and
+          local_inertial_coords_y[i] == 0.5 and
+          local_inertial_coords_z[i] == 0.) {
+        spec_vals = {{6085210677.100476, 167380192879.7604, 127052654002.9328,
+                      248004924024.1152, 167380192879.7604, 332680229840.2671,
+                      291581333531.8772, 414851928759.5795, 127052654002.9328,
+                      291581333531.8772, 252051386701.9684, 374742775141.3494,
+                      248004924024.1152, 414851928759.5795, 374742775141.3494,
+                      501009777203.5247}};
+        not_initialized = false;
+      }
+      if (local_inertial_coords_x[i] == 300. and
+          local_inertial_coords_y[i] == 0.5 and
+          local_inertial_coords_z[i] == 0.) {
+        spec_vals = {{6084984255.479748, 167381092880.0475, 127053272397.5563,
+                      248006387234.2355, 167381092880.0475, 332682259487.1282,
+                      291583081655.5068, 414854521451.6181, 127053272397.5563,
+                      291583081655.5068, 252052858613.1887, 374745091682.769,
+                      248006387234.2355, 414854521451.6181, 374745091682.769,
+                      501012945298.5021}};
+        not_initialized = false;
+      }
+      if (local_inertial_coords_x[i] == 299. and
+          local_inertial_coords_y[i] == 0.5 and
+          local_inertial_coords_z[i] == 0.5) {
+        spec_vals = {{6085437662.827703, 167379290643.1056, 127052034072.0609,
+                      248003457177.3931, 167379290643.1056, 332678195148.6575,
+                      291579581063.3884, 414849329623.0162, 127052034072.0609,
+                      291579581063.3884, 252049911132.6, 374740452841.9442,
+                      248003457177.3931, 414849329623.0162, 374740452841.9442,
+                      501006601233.5914}};
+        not_initialized = false;
+      }
+      if (local_inertial_coords_x[i] == 299.5 and
+          local_inertial_coords_y[i] == 0.5 and
+          local_inertial_coords_z[i] == 0.5) {
+        spec_vals = {{6085210487.177534, 167380193634.6784, 127052654521.6405,
+                      248004925251.4529, 167380193634.6784, 332680231542.7307,
+                      291581334998.1996, 414851930934.3248, 127052654521.6405,
+                      291581334998.1996, 252051387936.6043, 374742777084.4599,
+                      248004925251.4529, 414851930934.3248, 374742777084.4599,
+                      501009779860.9169}};
+        not_initialized = false;
+      }
+      if (local_inertial_coords_x[i] == 300. and
+          local_inertial_coords_y[i] == 0.5 and
+          local_inertial_coords_z[i] == 0.5) {
+        spec_vals = {{6084984066.503965, 167381093631.2057, 127053272913.6808,
+                      248006388455.4596, 167381093631.2057, 332682261181.1116,
+                      291583083114.5252, 414854523615.53, 127053272913.6808,
+                      291583083114.5252, 252052859841.6748, 374745093616.2003,
+                      248006388455.4596, 414854523615.53, 374745093616.2003,
+                      501012947942.6568}};
+        not_initialized = false;
+      }
+      if (not_initialized) {
+        ERROR("Not checking the correct face, coordinates not recognized");
+      }
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          spec_bc_dt_v_minus.get(a, b)[i] =
+              gsl::at(spec_vals, a * (1 + VolumeDim) + b);
+        }
+      }
+    }
+
+    // Compare values returned by BC action vs those from SpEC
+    CHECK_ITERABLE_APPROX(local_bc_dt_v_minus, spec_bc_dt_v_minus);
+  }
+
+  {  // Compute the new boundary corrections for dt<vminus>
+    GeneralizedHarmonic::BoundaryConditions::Bjorhus::
+        constraint_preserving_physical_bjorhus_corrections_dt_v_minus(
+            make_not_null(&local_bc_dt_v_minus), local_constraint_gamma2,
+            local_inertial_coords, local_unit_interface_normal_one_form,
+            local_unit_interface_normal_vector,
+            local_spacetime_unit_normal_vector, local_incoming_null_one_form,
+            local_outgoing_null_one_form, local_incoming_null_vector,
+            local_outgoing_null_vector, local_projection_ab,
+            local_projection_Ab, local_projection_AB,
+            local_inverse_spatial_metric, local_extrinsic_curvature,
+            local_spacetime_metric, local_inverse_spacetime_metric,
+            local_three_index_constraint, local_char_projected_rhs_dt_v_psi,
+            local_char_projected_rhs_dt_v_minus,
+            local_constraint_char_zero_plus, local_constraint_char_zero_minus,
+            local_phi, local_d_phi, local_d_pi, local_char_speeds);
+    // Add in the current boundary value to get corrected values for dt<vminus>
+    for (size_t a = 0; a <= VolumeDim; ++a) {
+      for (size_t b = a; b <= VolumeDim; ++b) {
+        local_bc_dt_v_minus.get(a, b) +=
+            local_char_projected_rhs_dt_v_minus.get(a, b);
+      }
+    }
+
+    // Initialize with values from SpEC
+    tnsr::aa<DataVector, VolumeDim, frame> spec_bc_dt_v_minus(
+        slice_grid_points, std::numeric_limits<double>::signaling_NaN());
+
+    for (size_t i = 0; i < slice_grid_points; ++i) {
+      std::array<double, 16> spec_vals{};
+      bool not_initialized = true;
+
+      if (local_inertial_coords_x[i] == 299. and
+          local_inertial_coords_y[i] == 0.5 and
+          local_inertial_coords_z[i] == -0.5) {
+        spec_vals = {{7.122948293721196e+19, 7.122948329100482e+19,
+                      7.122948320255282e+19, 7.122948346787851e+19,
+                      7.122948329100482e+19, 7.639071460057165e+19,
+                      7.639071451116156e+19, 7.639071477936572e+19,
+                      7.122948320255282e+19, 7.639071451116156e+19,
+                      8.413256084990011e+19, 8.413256111738503e+19,
+                      7.122948346787851e+19, 7.639071477936572e+19,
+                      8.413256111738503e+19, 9.445502329090969e+19}};
+        not_initialized = false;
+      }
+      if (local_inertial_coords_x[i] == 299.5 and
+          local_inertial_coords_y[i] == 0.5 and
+          local_inertial_coords_z[i] == -0.5) {
+        spec_vals = {{7.122948296615504e+19, 7.122948312745003e+19,
+                      7.122948308712251e+19, 7.122948320807479e+19,
+                      7.122948312745003e+19, 7.639071424306128e+19,
+                      7.639071420196236e+19, 7.639071432523298e+19,
+                      7.122948308712251e+19, 7.639071420196236e+19,
+                      8.413256058789916e+19, 8.413256071059056e+19,
+                      7.122948320807479e+19, 7.639071432523298e+19,
+                      8.413256071059056e+19, 9.445502273747989e+19}};
+        not_initialized = false;
+      }
+      if (local_inertial_coords_x[i] == 300. and
+          local_inertial_coords_y[i] == 0.5 and
+          local_inertial_coords_z[i] == -0.5) {
+        spec_vals = {{7.122948296615481e+19, 7.122948312745094e+19,
+                      7.122948308712312e+19, 7.122948320807626e+19,
+                      7.122948312745094e+19, 7.639071424306332e+19,
+                      7.639071420196412e+19, 7.639071432523558e+19,
+                      7.122948308712312e+19, 7.639071420196412e+19,
+                      8.413256058790063e+19, 8.413256071059287e+19,
+                      7.122948320807626e+19, 7.639071432523558e+19,
+                      8.413256071059287e+19, 9.445502273748306e+19}};
+        not_initialized = false;
+      }
+      if (local_inertial_coords_x[i] == 299. and
+          local_inertial_coords_y[i] == 0.5 and
+          local_inertial_coords_z[i] == 0.) {
+        spec_vals = {{7.122948296615527e+19, 7.122948312744913e+19,
+                      7.122948308712188e+19, 7.122948320807332e+19,
+                      7.122948312744913e+19, 7.639071424305924e+19,
+                      7.639071420196061e+19, 7.639071432523037e+19,
+                      7.122948308712188e+19, 7.639071420196061e+19,
+                      8.413256058789768e+19, 8.413256071058824e+19,
+                      7.122948320807332e+19, 7.639071432523037e+19,
+                      8.413256071058824e+19, 9.445502273747671e+19}};
+        not_initialized = false;
+      }
+      if (local_inertial_coords_x[i] == 299.5 and
+          local_inertial_coords_y[i] == 0.5 and
+          local_inertial_coords_z[i] == 0.) {
+        spec_vals = {{7.122948296615504e+19, 7.122948312745003e+19,
+                      7.122948308712251e+19, 7.122948320807479e+19,
+                      7.122948312745003e+19, 7.639071424306128e+19,
+                      7.639071420196236e+19, 7.639071432523298e+19,
+                      7.122948308712251e+19, 7.639071420196236e+19,
+                      8.413256058789916e+19, 8.413256071059056e+19,
+                      7.122948320807479e+19, 7.639071432523298e+19,
+                      8.413256071059056e+19, 9.445502273747989e+19}};
+        not_initialized = false;
+      }
+      if (local_inertial_coords_x[i] == 300. and
+          local_inertial_coords_y[i] == 0.5 and
+          local_inertial_coords_z[i] == 0.) {
+        spec_vals = {{7.122948296615482e+19, 7.122948312745094e+19,
+                      7.122948308712312e+19, 7.122948320807626e+19,
+                      7.122948312745094e+19, 7.63907142430633e+19,
+                      7.63907142019641e+19, 7.639071432523556e+19,
+                      7.122948308712312e+19, 7.63907142019641e+19,
+                      8.413256058790063e+19, 8.413256071059287e+19,
+                      7.122948320807626e+19, 7.639071432523556e+19,
+                      8.413256071059287e+19, 9.445502273748306e+19}};
+        not_initialized = false;
+      }
+      if (local_inertial_coords_x[i] == 299. and
+          local_inertial_coords_y[i] == 0.5 and
+          local_inertial_coords_z[i] == 0.5) {
+        spec_vals = {{7.122948296615527e+19, 7.122948312744913e+19,
+                      7.122948308712188e+19, 7.122948320807332e+19,
+                      7.122948312744913e+19, 7.639071424305924e+19,
+                      7.639071420196061e+19, 7.639071432523039e+19,
+                      7.122948308712188e+19, 7.639071420196061e+19,
+                      8.413256058789768e+19, 8.413256071058824e+19,
+                      7.122948320807332e+19, 7.639071432523039e+19,
+                      8.413256071058824e+19, 9.445502273747671e+19}};
+        not_initialized = false;
+      }
+      if (local_inertial_coords_x[i] == 299.5 and
+          local_inertial_coords_y[i] == 0.5 and
+          local_inertial_coords_z[i] == 0.5) {
+        spec_vals = {{7.122948296615504e+19, 7.122948312745003e+19,
+                      7.122948308712251e+19, 7.122948320807479e+19,
+                      7.122948312745003e+19, 7.639071424306128e+19,
+                      7.639071420196236e+19, 7.639071432523298e+19,
+                      7.122948308712251e+19, 7.639071420196236e+19,
+                      8.413256058789916e+19, 8.413256071059056e+19,
+                      7.122948320807479e+19, 7.639071432523298e+19,
+                      8.413256071059056e+19, 9.445502273747989e+19}};
+        not_initialized = false;
+      }
+      if (local_inertial_coords_x[i] == 300. and
+          local_inertial_coords_y[i] == 0.5 and
+          local_inertial_coords_z[i] == 0.5) {
+        spec_vals = {{7.122948296615481e+19, 7.122948312745094e+19,
+                      7.122948308712312e+19, 7.122948320807626e+19,
+                      7.122948312745094e+19, 7.639071424306332e+19,
+                      7.639071420196412e+19, 7.639071432523558e+19,
+                      7.122948308712312e+19, 7.639071420196412e+19,
+                      8.413256058790063e+19, 8.413256071059287e+19,
+                      7.122948320807626e+19, 7.639071432523558e+19,
+                      8.413256071059287e+19, 9.445502273748306e+19}};
+        not_initialized = false;
+      }
+      if (not_initialized) {
+        ERROR("Not checking the correct face, coordinates not recognized");
+      }
+      for (size_t a = 0; a <= VolumeDim; ++a) {
+        for (size_t b = a; b <= VolumeDim; ++b) {
+          spec_bc_dt_v_minus.get(a, b)[i] =
+              gsl::at(spec_vals, a * (1 + VolumeDim) + b);
+        }
+      }
+    }
+
+    // Compare values returned by BC action vs those from SpEC
+    CHECK_ITERABLE_APPROX(local_bc_dt_v_minus, spec_bc_dt_v_minus);
+  }
+}
 }  // namespace
 
 // Python tests
@@ -398,6 +1136,126 @@ void test_constraint_preserving_bjorhus_corrections_dt_v_zero(
       "constraint_preserving_bjorhus_corrections_dt_v_zero", {{{-1., 1.}}},
       DataVector(grid_size_each_dimension));
 }
+
+template <size_t VolumeDim>
+tnsr::aa<DataVector, VolumeDim, Frame::Inertial> wrapper_func_cp_v_minus(
+    const Scalar<DataVector>& gamma2,
+    const tnsr::I<DataVector, VolumeDim, Frame::Inertial>& inertial_coords,
+    const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+        incoming_null_one_form,
+    const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+        outgoing_null_one_form,
+    const tnsr::A<DataVector, VolumeDim, Frame::Inertial>& incoming_null_vector,
+    const tnsr::A<DataVector, VolumeDim, Frame::Inertial>& outgoing_null_vector,
+    const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>& projection_ab,
+    const tnsr::Ab<DataVector, VolumeDim, Frame::Inertial>& projection_Ab,
+    const tnsr::AA<DataVector, VolumeDim, Frame::Inertial>& projection_AB,
+    const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>&
+        char_projected_rhs_dt_v_psi,
+    const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>&
+        char_projected_rhs_dt_v_minus,
+    const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+        constraint_char_zero_plus,
+    const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+        constraint_char_zero_minus,
+    const tnsr::a<DataVector, 3, Frame::Inertial>& char_speeds) noexcept {
+  std::array<DataVector, 4> char_speed_array{
+      get<0>(char_speeds), get<1>(char_speeds), get<2>(char_speeds),
+      get<3>(char_speeds)};
+  auto dt_v_minus =
+      make_with_value<tnsr::aa<DataVector, VolumeDim, Frame::Inertial>>(
+          get(gamma2), 0.);
+  GeneralizedHarmonic::BoundaryConditions::Bjorhus::
+      constraint_preserving_bjorhus_corrections_dt_v_minus<VolumeDim,
+                                                           DataVector>(
+          make_not_null(&dt_v_minus), gamma2, inertial_coords,
+          incoming_null_one_form, outgoing_null_one_form, incoming_null_vector,
+          outgoing_null_vector, projection_ab, projection_Ab, projection_AB,
+          char_projected_rhs_dt_v_psi, char_projected_rhs_dt_v_minus,
+          constraint_char_zero_plus, constraint_char_zero_minus,
+          char_speed_array);
+  return dt_v_minus;
+}
+
+template <size_t VolumeDim>
+tnsr::aa<DataVector, VolumeDim, Frame::Inertial> wrapper_func_cpp_v_minus(
+    const Scalar<DataVector>& gamma2,
+    const tnsr::I<DataVector, VolumeDim, Frame::Inertial>& inertial_coords,
+    const tnsr::i<DataVector, VolumeDim, Frame::Inertial>&
+        unit_interface_normal_one_form,
+    const tnsr::I<DataVector, VolumeDim, Frame::Inertial>&
+        unit_interface_normal_vector,
+    const tnsr::A<DataVector, VolumeDim, Frame::Inertial>&
+        spacetime_unit_normal_vector,
+    const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+        incoming_null_one_form,
+    const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+        outgoing_null_one_form,
+    const tnsr::A<DataVector, VolumeDim, Frame::Inertial>& incoming_null_vector,
+    const tnsr::A<DataVector, VolumeDim, Frame::Inertial>& outgoing_null_vector,
+    const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>& projection_ab,
+    const tnsr::Ab<DataVector, VolumeDim, Frame::Inertial>& projection_Ab,
+    const tnsr::AA<DataVector, VolumeDim, Frame::Inertial>& projection_AB,
+    const tnsr::II<DataVector, VolumeDim, Frame::Inertial>&
+        inverse_spatial_metric,
+    const tnsr::ii<DataVector, VolumeDim, Frame::Inertial>& extrinsic_curvature,
+    const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>& spacetime_metric,
+    const tnsr::AA<DataVector, VolumeDim, Frame::Inertial>&
+        inverse_spacetime_metric,
+    const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>&
+        three_index_constraint,
+    const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>&
+        char_projected_rhs_dt_v_psi,
+    const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>&
+        char_projected_rhs_dt_v_minus,
+    const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+        constraint_char_zero_plus,
+    const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+        constraint_char_zero_minus,
+    const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>& phi,
+    const tnsr::ijaa<DataVector, VolumeDim, Frame::Inertial>& d_phi,
+    const tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>& d_pi,
+    const tnsr::a<DataVector, 3, Frame::Inertial>& char_speeds) noexcept {
+  std::array<DataVector, 4> char_speed_array{
+      get<0>(char_speeds), get<1>(char_speeds), get<2>(char_speeds),
+      get<3>(char_speeds)};
+  auto dt_v_minus =
+      make_with_value<tnsr::aa<DataVector, VolumeDim, Frame::Inertial>>(
+          get(gamma2), 0.);
+  GeneralizedHarmonic::BoundaryConditions::Bjorhus::
+      constraint_preserving_physical_bjorhus_corrections_dt_v_minus<VolumeDim,
+                                                                    DataVector>(
+          make_not_null(&dt_v_minus), gamma2, inertial_coords,
+          unit_interface_normal_one_form, unit_interface_normal_vector,
+          spacetime_unit_normal_vector, incoming_null_one_form,
+          outgoing_null_one_form, incoming_null_vector, outgoing_null_vector,
+          projection_ab, projection_Ab, projection_AB, inverse_spatial_metric,
+          extrinsic_curvature, spacetime_metric, inverse_spacetime_metric,
+          three_index_constraint, char_projected_rhs_dt_v_psi,
+          char_projected_rhs_dt_v_minus, constraint_char_zero_plus,
+          constraint_char_zero_minus, phi, d_phi, d_pi, char_speed_array);
+  return dt_v_minus;
+}
+
+template <size_t VolumeDim>
+void test_constraint_preserving_bjorhus_corrections_dt_v_minus(
+    const size_t grid_size_each_dimension) noexcept {
+  pypp::check_with_random_values<1>(
+      &wrapper_func_cp_v_minus<VolumeDim>,
+      "Evolution.Systems.GeneralizedHarmonic.BoundaryConditions.Bjorhus",
+      "constraint_preserving_bjorhus_corrections_dt_v_minus", {{{-1., 1.}}},
+      DataVector(grid_size_each_dimension));
+}
+
+template <size_t VolumeDim>
+void test_constraint_preserving_physical_bjorhus_corrections_dt_v_minus(
+    const size_t grid_size_each_dimension) noexcept {
+  pypp::check_with_random_values<1>(
+      &wrapper_func_cpp_v_minus<VolumeDim>,
+      "Evolution.Systems.GeneralizedHarmonic.BoundaryConditions.Bjorhus",
+      "constraint_preserving_physical_bjorhus_corrections_dt_v_minus",
+      {{{-1., 1.}}}, DataVector(grid_size_each_dimension));
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.BCBjorhus.VPsi",
@@ -430,4 +1288,29 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.BCBjorhus.VZero",
 
   // Piece-wise tests with SpEC output
   test_constraint_preserving_bjorhus_v_zero_vs_spec_3d(grid_size);
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.BCBjorhus.VMinus",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{""};
+
+  const size_t grid_size = 3;
+
+  // Python tests
+  test_constraint_preserving_bjorhus_corrections_dt_v_minus<1>(grid_size);
+  test_constraint_preserving_bjorhus_corrections_dt_v_minus<2>(grid_size);
+  test_constraint_preserving_bjorhus_corrections_dt_v_minus<3>(grid_size);
+  test_constraint_preserving_physical_bjorhus_corrections_dt_v_minus<1>(
+      grid_size);
+  test_constraint_preserving_physical_bjorhus_corrections_dt_v_minus<2>(
+      grid_size);
+  test_constraint_preserving_physical_bjorhus_corrections_dt_v_minus<3>(
+      grid_size);
+
+  // Piece-wise tests with SpEC output in 3D
+  const std::array<double, 3> lower_bound{{299., -0.5, -0.5}};
+  const std::array<double, 3> upper_bound{{300., 0.5, 0.5}};
+
+  test_constraint_preserving_physical_bjorhus_v_minus_vs_spec_3d(
+      grid_size, lower_bound, upper_bound);
 }

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_WeylPropagating.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_WeylPropagating.cpp
@@ -57,7 +57,7 @@ void test_weyl_propagating(const DataType& used_for_size) {
         const tnsr::ii<DataType, SpatialDim, Frame::Inertial>&,
         const tnsr::Ij<DataType, SpatialDim, Frame::Inertial>&) =
         &weyl_propagating_plus_wrapper<SpatialDim, Frame::Inertial, DataType>;
-    pypp::check_with_random_values<1>(f, "WeylPropagating",
+    pypp::check_with_random_values<1>(f, "GeneralRelativity.WeylPropagating",
                                       "weyl_propagating_mode_plus",
                                       {{{-1., 1.}}}, used_for_size);
   }
@@ -72,7 +72,7 @@ void test_weyl_propagating(const DataType& used_for_size) {
         const tnsr::ii<DataType, SpatialDim, Frame::Inertial>&,
         const tnsr::Ij<DataType, SpatialDim, Frame::Inertial>&) =
         &weyl_propagating_minus_wrapper<SpatialDim, Frame::Inertial, DataType>;
-    pypp::check_with_random_values<1>(f, "WeylPropagating",
+    pypp::check_with_random_values<1>(f, "GeneralRelativity.WeylPropagating",
                                       "weyl_propagating_mode_minus",
                                       {{{-1., 1.}}}, used_for_size);
   }
@@ -81,8 +81,7 @@ void test_weyl_propagating(const DataType& used_for_size) {
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.WeylPropagating",
                   "[PointwiseFunctions][Unit]") {
-  pypp::SetupLocalPythonEnvironment local_python_env(
-      "PointwiseFunctions/GeneralRelativity/");
+  pypp::SetupLocalPythonEnvironment local_python_env("PointwiseFunctions/");
 
   GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
 

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/WeylPropagating.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/WeylPropagating.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 
-from WeylElectric import weyl_electric_tensor
+from .WeylElectric import weyl_electric_tensor
 
 
 def weyl_propagating_modes(ricci, extrinsic_curvature, inverse_spatial_metric,


### PR DESCRIPTION
## Proposed changes

This PR adds free functions to compute Bjorhus-type corrections to the characteristic projected time derivatives of evolved GH variables, specifically the combination that corresponds to `VMinus` after projection. These corrections damp out constraint violations at the external boundary.


### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.