### PR TITLE
Add two-mesh relaxed DMP troubled cell indicator

### DIFF
--- a/src/Evolution/DgSubcell/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/CMakeLists.txt
@@ -15,6 +15,7 @@ spectre_target_headers(
   Mesh.hpp
   Projection.hpp
   Reconstruction.hpp
+  TwoMeshRdmpTci.hpp
   )
 
 spectre_target_sources(

--- a/src/Evolution/DgSubcell/TwoMeshRdmpTci.hpp
+++ b/src/Evolution/DgSubcell/TwoMeshRdmpTci.hpp
@@ -1,0 +1,83 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+
+#include "DataStructures/Variables.hpp"
+#include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace evolution::dg::subcell {
+/*!
+ * \brief Troubled cell indicator using a relaxed discrete maximum principle,
+ * comparing the solution on two grids at the same point in time.
+ *
+ * Checks that the subcell solution \f$\underline{u}\f$ and the DG solution
+ * \f$u\f$ satisfy
+ *
+ * \f{align*}{
+ * \min(u)-\delta \le \underline{u} \le \max(u)+\delta
+ * \f}
+ *
+ * where
+ *
+ * \f{align*}{
+ * \delta = \max\left[\delta_0, \epsilon(\max(u) - \min(u))\right]
+ * \f}
+ *
+ * where \f$\delta_0\f$ and \f$\epsilon\f$ are constants controlling the maximum
+ * absolute and relative change allowed when projecting the DG solution to the
+ * subcell grid. We currently specify one value of \f$\delta_0\f$ and
+ * \f$\epsilon\f$ for all variables, but this could be generalized to choosing
+ * the allowed variation in a variable-specific manner.
+ */
+template <typename... EvolvedVarsTags>
+bool two_mesh_rdmp_tci(
+    const Variables<tmpl::list<EvolvedVarsTags...>>& dg_evolved_vars,
+    const Variables<tmpl::list<Tags::Inactive<EvolvedVarsTags>...>>&
+        subcell_evolved_vars,
+    const double rdmp_delta0, const double rdmp_epsilon) noexcept {
+  ASSERT(rdmp_delta0 > 0.0, "The RDMP delta0 parameter must be positive.");
+  ASSERT(rdmp_epsilon > 0.0, "The RDMP epsilon parameter must be positive.");
+  bool cell_is_troubled = false;
+  tmpl::for_each<tmpl::list<EvolvedVarsTags...>>(
+      [&cell_is_troubled, &dg_evolved_vars, rdmp_delta0, rdmp_epsilon,
+       &subcell_evolved_vars](auto tag_v) noexcept {
+        if (cell_is_troubled) {
+          return;
+        }
+
+        using tag = tmpl::type_from<decltype(tag_v)>;
+        using inactive_tag = Tags::Inactive<tag>;
+        const auto& dg_var = get<tag>(dg_evolved_vars);
+        const auto& subcell_var = get<inactive_tag>(subcell_evolved_vars);
+
+        for (auto dg_it = dg_var.begin(), subcell_it = subcell_var.begin();
+             dg_it != dg_var.end() and subcell_it != subcell_var.end();
+             (void)++dg_it, (void)++subcell_it) {
+          ASSERT(not cell_is_troubled,
+                 "If a cell has already been marked as troubled during the "
+                 "two mesh RDMP TCI, we should not be continuing to check "
+                 "other variables.");
+          using std::max;
+          using std::min;
+
+          const double max_dg = max(*dg_it);
+          const double min_dg = min(*dg_it);
+          const double max_subcell = max(*subcell_it);
+          const double min_subcell = min(*subcell_it);
+          const double delta =
+              max(rdmp_delta0, rdmp_epsilon * (max_dg - min_dg));
+          cell_is_troubled =
+              max_subcell > max_dg + delta or min_subcell < min_dg - delta;
+          if (cell_is_troubled) {
+            return;
+          }
+        }
+      });
+  return cell_is_troubled;
+}
+}  // namespace evolution::dg::subcell

--- a/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
+++ b/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
   Test_Projection.cpp
   Test_Reconstruction.cpp
   Test_Tags.cpp
+  Test_TwoMeshRdmpTci.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Evolution/DgSubcell/Test_TwoMeshRdmpTci.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_TwoMeshRdmpTci.cpp
@@ -1,0 +1,123 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Evolution/DgSubcell/Projection.hpp"
+#include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/DgSubcell/TwoMeshRdmpTci.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+namespace Tags {
+struct Scalar : db::SimpleTag {
+  using type = ::Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct Vector : db::SimpleTag {
+  using type = tnsr::I<DataVector, Dim>;
+};
+}  // namespace Tags
+
+template <size_t Dim>
+DataVector soln(const tnsr::I<DataVector, Dim, Frame::Logical>& coords,
+                const bool add_discontinuity) noexcept {
+  DataVector result =
+      Spectral::compute_basis_function_value<Spectral::Basis::Legendre>(
+          1, get<0>(coords));
+  for (size_t d = 1; d < Dim; ++d) {
+    result += Spectral::compute_basis_function_value<Spectral::Basis::Legendre>(
+        1, coords.get(d));
+  }
+
+  if (add_discontinuity) {
+    const double max_value = max(abs(result));
+    for (size_t i = 0; i < result.size() / 2; ++i) {
+      result[i] += 10.0 * max_value;
+    }
+  }
+  return result;
+}
+
+template <size_t Dim>
+void test_two_mesh_rdmp_impl(const size_t num_pts_1d,
+                             const size_t tensor_component_to_modify,
+                             const double rdmp_delta0,
+                             const double rdmp_epsilon,
+                             const bool expected_tci_triggered) noexcept {
+  CAPTURE(Dim);
+  CAPTURE(num_pts_1d);
+  CAPTURE(tensor_component_to_modify);
+  CAPTURE(rdmp_delta0);
+  CAPTURE(rdmp_epsilon);
+  CAPTURE(expected_tci_triggered);
+  const Mesh<Dim> dg_mesh{num_pts_1d, Spectral::Basis::Legendre,
+                          Spectral::Quadrature::GaussLobatto};
+  const Mesh<Dim> subcell_mesh{2 * num_pts_1d - 1,
+                               Spectral::Basis::FiniteDifference,
+                               Spectral::Quadrature::FaceCentered};
+  const auto logical_coords = logical_coordinates(dg_mesh);
+
+  Variables<tmpl::list<Tags::Scalar, Tags::Vector<Dim>>> dg_vars(
+      dg_mesh.number_of_grid_points());
+  get(get<Tags::Scalar>(dg_vars)) =
+      soln(logical_coords, tensor_component_to_modify == 0);
+  for (size_t d = 0; d < Dim; ++d) {
+    get<Tags::Vector<Dim>>(dg_vars).get(d) =
+        (d + 0.3) * soln(logical_coords, tensor_component_to_modify == d + 1);
+  }
+
+  const Variables<
+      tmpl::list<evolution::dg::subcell::Tags::Inactive<Tags::Scalar>,
+                 evolution::dg::subcell::Tags::Inactive<Tags::Vector<Dim>>>>
+      subcell_vars{evolution::dg::subcell::fd::project(dg_vars, dg_mesh,
+                                                       subcell_mesh.extents())};
+
+  CHECK(evolution::dg::subcell::two_mesh_rdmp_tci(dg_vars, subcell_vars,
+                                                  rdmp_delta0, rdmp_epsilon) ==
+        expected_tci_triggered);
+}
+
+template <size_t Dim>
+void test_two_mesh_rdmp() noexcept {
+  // We lower the maximum number of 1d points in 3d in order to reduce total
+  // test runtime.
+  const size_t maximum_number_of_points_1d =
+      Dim == 3 ? 7
+               : Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+  for (size_t num_pts_1d = 4; num_pts_1d < maximum_number_of_points_1d;
+       ++num_pts_1d) {
+    test_two_mesh_rdmp_impl<Dim>(num_pts_1d, 0, 1.0e-4, 1.0e-3, true);
+    test_two_mesh_rdmp_impl<Dim>(num_pts_1d, 0, 1.0e-4, 1.0e3, false);
+    test_two_mesh_rdmp_impl<Dim>(num_pts_1d, std::numeric_limits<size_t>::max(),
+                                 1.0e-4, 1.0e-3, false);
+
+    // Modify tensor components
+    for (size_t i = 1; i < Dim + 1; ++i) {
+      test_two_mesh_rdmp_impl<Dim>(num_pts_1d, i, 1.0e-4, 1.0e-3, true);
+      test_two_mesh_rdmp_impl<Dim>(num_pts_1d, i, 1.0e-4, 1.0e3, false);
+    }
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Tci.TwoMeshRdmp",
+                  "[Evolution][Unit]") {
+  test_two_mesh_rdmp<1>();
+  test_two_mesh_rdmp<2>();
+  test_two_mesh_rdmp<3>();
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

The TCI is used on the initial data, comparing the solution projected to the subcells to the solution we started with on DG. If they differ too much the cell is marked as troubled. Applying TCIs to the initial data allows us to ensure the initial data does contain discontinuities.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
