### PR TITLE
Subcell tags for the mesh, coordinates, and TCI status

### DIFF
--- a/src/Evolution/DgSubcell/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(
   ${LIBRARY}
   PUBLIC
   DataStructures
+  Domain
   Spectral
 
   PRIVATE

--- a/src/Evolution/DgSubcell/Tags/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/Tags/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_headers(
   Coordinates.hpp
   Inactive.hpp
   Mesh.hpp
+  Tags.hpp
   TciGridHistory.hpp
   TciStatus.hpp
   )

--- a/src/Evolution/DgSubcell/Tags/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/Tags/CMakeLists.txt
@@ -12,4 +12,5 @@ spectre_target_headers(
   Inactive.hpp
   Mesh.hpp
   TciGridHistory.hpp
+  TciStatus.hpp
   )

--- a/src/Evolution/DgSubcell/Tags/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/Tags/CMakeLists.txt
@@ -8,6 +8,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ActiveGrid.hpp
+  Coordinates.hpp
   Inactive.hpp
   Mesh.hpp
   TciGridHistory.hpp

--- a/src/Evolution/DgSubcell/Tags/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/Tags/CMakeLists.txt
@@ -9,5 +9,6 @@ spectre_target_headers(
   HEADERS
   ActiveGrid.hpp
   Inactive.hpp
+  Mesh.hpp
   TciGridHistory.hpp
   )

--- a/src/Evolution/DgSubcell/Tags/Coordinates.hpp
+++ b/src/Evolution/DgSubcell/Tags/Coordinates.hpp
@@ -1,0 +1,45 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Utilities/GetOutput.hpp"
+
+/// \cond
+class DataVector;
+template <size_t Dim>
+class Mesh;
+namespace gsl {
+template <typename>
+struct not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace evolution::dg::subcell::Tags {
+/// The coordinates in a given frame.
+template <size_t Dim, typename Frame>
+struct Coordinates : db::SimpleTag {
+  static std::string name() noexcept {
+    return get_output(Frame{}) + "Coordinates";
+  }
+  using type = tnsr::I<DataVector, Dim, Frame>;
+};
+
+/// The logical coordinates on the subcell grid
+template <size_t VolumeDim>
+struct LogicalCoordinatesCompute : Coordinates<VolumeDim, Frame::Logical>,
+                                   db::ComputeTag {
+  using base = Coordinates<VolumeDim, Frame::Logical>;
+  using return_type = typename base::type;
+  using argument_tags = tmpl::list<Mesh<VolumeDim>>;
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<return_type*>, const ::Mesh<VolumeDim>&) noexcept>(
+      &logical_coordinates<VolumeDim>);
+};
+}  // namespace evolution::dg::subcell::Tags

--- a/src/Evolution/DgSubcell/Tags/Mesh.hpp
+++ b/src/Evolution/DgSubcell/Tags/Mesh.hpp
@@ -1,0 +1,22 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+
+/// \cond
+template <size_t Dim>
+class Mesh;
+/// \endcond
+
+namespace evolution::dg::subcell::Tags {
+/// The mesh on the subcells
+template <size_t VolumeDim>
+struct Mesh : db::SimpleTag {
+  static std::string name() noexcept { return "Subcell(Mesh)"; }
+  using type = ::Mesh<VolumeDim>;
+};
+}  // namespace evolution::dg::subcell::Tags

--- a/src/Evolution/DgSubcell/Tags/Tags.hpp
+++ b/src/Evolution/DgSubcell/Tags/Tags.hpp
@@ -1,0 +1,19 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace evolution::dg::subcell {
+/// \ingroup DgSubcellGroup
+/// \brief Option tags for the DG-subcell solver
+namespace OptionTags {}
+/// \ingroup DgSubcellGroup
+/// \brief %Tags for the DG-subcell solver
+namespace Tags {}
+
+namespace fd {
+/// \ingroup DgSubcellGroup
+/// \brief %Tags for the DG-subcell finite difference solver
+namespace Tags {}
+}  // namespace fd
+}  // namespace evolution::dg::subcell

--- a/src/Evolution/DgSubcell/Tags/TciStatus.hpp
+++ b/src/Evolution/DgSubcell/Tags/TciStatus.hpp
@@ -1,0 +1,19 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+/// \cond
+class DataVector;
+/// \endcond
+
+namespace evolution::dg::subcell::Tags {
+/// Stores the status of the troubled cell indicator in the element as a
+/// `Scalar<DataVector>` so it can be observed.
+struct TciStatus : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+}  // namespace evolution::dg::subcell::Tags

--- a/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
+++ b/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
@@ -16,5 +16,15 @@ add_test_library(
   ${LIBRARY}
   "Evolution/DgSubcell/"
   "${LIBRARY_SOURCES}"
-  "DataStructures;DgSubcell;DgSubcellHelpers"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DataStructures
+  Domain
+  DgSubcell
+  DgSubcellHelpers
+  Spectral
   )

--- a/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
@@ -5,13 +5,18 @@
 
 #include <string>
 
-#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/VariablesTag.hpp"
+#include "Domain/LogicalCoordinates.hpp"
 #include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Tags/Coordinates.hpp"
 #include "Evolution/DgSubcell/Tags/Inactive.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/TciGridHistory.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
 
 /// \cond
 class DataVector;
@@ -29,6 +34,28 @@ template <size_t Dim>
 void test() {
   TestHelpers::db::test_simple_tag<evolution::dg::subcell::Tags::Mesh<Dim>>(
       "Subcell(Mesh)");
+  TestHelpers::db::test_simple_tag<
+      evolution::dg::subcell::Tags::Coordinates<Dim, Frame::Logical>>(
+      "LogicalCoordinates");
+  TestHelpers::db::test_simple_tag<
+      evolution::dg::subcell::Tags::Coordinates<Dim, Frame::Grid>>(
+      "GridCoordinates");
+  TestHelpers::db::test_simple_tag<
+      evolution::dg::subcell::Tags::Coordinates<Dim, Frame::Inertial>>(
+      "InertialCoordinates");
+
+  TestHelpers::db::test_compute_tag<
+      evolution::dg::subcell::Tags::LogicalCoordinatesCompute<Dim>>(
+      "LogicalCoordinates");
+  Mesh<Dim> subcell_mesh(5, Spectral::Basis::FiniteDifference,
+                         Spectral::Quadrature::CellCentered);
+  const auto logical_coords_box = db::create<
+      db::AddSimpleTags<evolution::dg::subcell::Tags::Mesh<Dim>>,
+      db::AddComputeTags<
+          evolution::dg::subcell::Tags::LogicalCoordinatesCompute<Dim>>>(
+      subcell_mesh);
+  CHECK(db::get<evolution::dg::subcell::Tags::Coordinates<Dim, Frame::Logical>>(
+            logical_coords_box) == logical_coordinates(subcell_mesh));
 }
 }  // namespace
 

--- a/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
@@ -14,6 +14,7 @@
 #include "Evolution/DgSubcell/Tags/Inactive.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/TciGridHistory.hpp"
+#include "Evolution/DgSubcell/Tags/TciStatus.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
@@ -70,6 +71,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Tags",
       "Inactive(Variables(Var1,Var2))");
   TestHelpers::db::test_simple_tag<
       evolution::dg::subcell::Tags::TciGridHistory>("TciGridHistory");
+  TestHelpers::db::test_simple_tag<evolution::dg::subcell::Tags::TciStatus>(
+      "TciStatus");
 
   test<1>();
   test<2>();

--- a/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
@@ -9,6 +9,7 @@
 #include "DataStructures/VariablesTag.hpp"
 #include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/TciGridHistory.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 
@@ -23,6 +24,12 @@ struct Var1 : db::SimpleTag {
 struct Var2 : db::SimpleTag {
   using type = tnsr::i<DataVector, 3, Frame::Inertial>;
 };
+
+template <size_t Dim>
+void test() {
+  TestHelpers::db::test_simple_tag<evolution::dg::subcell::Tags::Mesh<Dim>>(
+      "Subcell(Mesh)");
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Tags",
@@ -36,4 +43,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Tags",
       "Inactive(Variables(Var1,Var2))");
   TestHelpers::db::test_simple_tag<
       evolution::dg::subcell::Tags::TciGridHistory>("TciGridHistory");
+
+  test<1>();
+  test<2>();
+  test<3>();
 }


### PR DESCRIPTION
## Proposed changes

Exactly what the description says. I will be adding a compute tag for the TCI status in a followup PR so that it gets set automatically depending on the mesh.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
