### PR TITLE
Fix source frame in CoordinateMap tag, take coordinates tag as template parameter for MappedCoordinates

### DIFF
--- a/src/Domain/CoordinateMaps/Tags.hpp
+++ b/src/Domain/CoordinateMaps/Tags.hpp
@@ -30,7 +30,7 @@ template <size_t VolumeDim, typename SourceFrame, typename TargetFrame>
 struct CoordinateMap : db::SimpleTag {
 static constexpr size_t dim = VolumeDim;
   using target_frame = TargetFrame;
-  using source_frame = Frame::Logical;
+  using source_frame = SourceFrame;
 
   static std::string name() noexcept {
     return "CoordinateMap(" + get_output(SourceFrame{}) + "," +

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -138,11 +138,12 @@ struct Coordinates : db::SimpleTag {
 /// \ingroup ComputationalDomainGroup
 /// The coordinates in the target frame of `MapTag`. The `SourceCoordsTag`'s
 /// frame must be the source frame of `MapTag`
-template <class MapTag, class SourceCoordsTag>
+template <class MapTag, class SourceCoordsTag,
+          template <size_t, class> class CoordinatesTag = Coordinates>
 struct MappedCoordinates
-    : Coordinates<MapTag::dim, typename MapTag::target_frame>,
+    : CoordinatesTag<MapTag::dim, typename MapTag::target_frame>,
       db::ComputeTag {
-  using base = Coordinates<MapTag::dim, typename MapTag::target_frame>;
+  using base = CoordinatesTag<MapTag::dim, typename MapTag::target_frame>;
   using return_type = typename base::type;
   using argument_tags = tmpl::list<MapTag, SourceCoordsTag>;
   static constexpr auto function(


### PR DESCRIPTION
## Proposed changes

- The source frame doesn't need to be the `Logical` coordinates
- For subcell we either need to make some of the `Domain` tags dependent on the numerical scheme to compute the logical coordinates correctly, or we allow specifying the `Coordinates` tag, and have subcell use its own `Coordinates` tag. Currently I'm opting for the latter.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
