### PR TITLE
AddTemporalIdsToInterpolationTarget now works with time-dependent maps

### DIFF
--- a/src/Domain/FunctionsOfTime/Tags.hpp
+++ b/src/Domain/FunctionsOfTime/Tags.hpp
@@ -16,6 +16,7 @@
 #include "Domain/FunctionsOfTime/ReadSpecThirdOrderPiecewisePolynomial.hpp"
 #include "Domain/OptionTags.hpp"
 #include "Options/Options.hpp"
+#include "Utilities/StdHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits/CreateHasStaticMemberVariable.hpp"
 
@@ -94,15 +95,13 @@ struct FunctionsOfTime : db::SimpleTag {
         // an element with key==spectre_name; this action only
         // mutates the value associated with that key
         if (functions_of_time.count(spectre_name) == 0) {
-          std::vector<std::string> keys_in_functions_of_time{
-              keys_of(functions_of_time)};
           ERROR("Trying to import data for key "
                 << spectre_name
                 << "in FunctionsOfTime, but FunctionsOfTime does not "
                    "contain that key. This might happen if the option "
                    "FunctionOfTimeNameMap is not specified correctly. Keys "
                    "contained in FunctionsOfTime: "
-                << keys_in_functions_of_time << "\n");
+                << keys_of(functions_of_time) << "\n");
         }
         auto* piecewise_polynomial = dynamic_cast<
             domain::FunctionsOfTime::PiecewisePolynomial<max_deriv>*>(

--- a/src/NumericalAlgorithms/Interpolation/Actions/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Interpolation/Actions/CMakeLists.txt
@@ -11,4 +11,5 @@ spectre_target_headers(
   InterpolationTargetSendPoints.hpp
   InterpolationTargetVarsFromElement.hpp
   SendPointsToInterpolator.hpp
+  VerifyTemporalIdsAndSendPoints.hpp
   )

--- a/src/NumericalAlgorithms/Interpolation/Actions/SendPointsToInterpolator.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Actions/SendPointsToInterpolator.hpp
@@ -43,7 +43,7 @@ struct SendPointsToInterpolator {
                     const ArrayIndex& /*array_index*/,
                     const TemporalId& temporal_id) noexcept {
     auto coords = InterpolationTarget_detail::block_logical_coords<
-        InterpolationTargetTag>(box, tmpl::type_<Metavariables>{}, temporal_id);
+        InterpolationTargetTag>(box, cache, temporal_id);
     InterpolationTarget_detail::set_up_interpolation<InterpolationTargetTag>(
         make_not_null(&box), temporal_id, coords);
     auto& receiver_proxy =

--- a/src/NumericalAlgorithms/Interpolation/Actions/VerifyTemporalIdsAndSendPoints.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Actions/VerifyTemporalIdsAndSendPoints.hpp
@@ -1,0 +1,266 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
+#include "NumericalAlgorithms/Interpolation/Tags.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace intrp::Actions {
+
+template <typename InterpolationTargetTag>
+struct VerifyTemporalIdsAndSendPoints;
+
+namespace detail {
+template <typename InterpolationTargetTag, typename ParallelComponent,
+          typename DbTags, typename Metavariables>
+void verify_temporal_ids_and_send_points_time_independent(
+    const gsl::not_null<db::DataBox<DbTags>*> box,
+    Parallel::GlobalCache<Metavariables>& cache) noexcept {
+  using TemporalId = typename Metavariables::temporal_id::type;
+
+  // Move all PendingTemporalIds to TemporalIds, provided
+  // that they are not already there, and fill new_temporal_ids
+  // with the temporal_ids that were so moved.
+  std::vector<TemporalId> new_temporal_ids{};
+  db::mutate_apply<tmpl::list<Tags::TemporalIds<TemporalId>,
+                              Tags::PendingTemporalIds<TemporalId>>,
+                   tmpl::list<Tags::CompletedTemporalIds<TemporalId>>>(
+      [&new_temporal_ids](
+          const gsl::not_null<std::deque<TemporalId>*> ids,
+          const gsl::not_null<std::deque<TemporalId>*> pending_ids,
+          const std::deque<TemporalId>& completed_ids) noexcept {
+        for (auto& id : *pending_ids) {
+          if (std::find(completed_ids.begin(), completed_ids.end(), id) ==
+                  completed_ids.end() and
+              std::find(ids->begin(), ids->end(), id) == ids->end()) {
+            ids->push_back(id);
+            new_temporal_ids.push_back(id);
+          }
+        }
+        pending_ids->clear();
+      },
+      box);
+  if (InterpolationTargetTag::compute_target_points::is_sequential::value) {
+    // Sequential: start interpolation only for the first new_temporal_id.
+    if (not new_temporal_ids.empty()) {
+      auto& my_proxy =
+          Parallel::get_parallel_component<ParallelComponent>(cache);
+      Parallel::simple_action<
+          Actions::SendPointsToInterpolator<InterpolationTargetTag>>(
+          my_proxy, new_temporal_ids.front());
+    }
+  } else {
+    // Non-sequential: start interpolation for all new_temporal_ids.
+    auto& my_proxy = Parallel::get_parallel_component<ParallelComponent>(cache);
+    for (const auto& id : new_temporal_ids) {
+      Parallel::simple_action<
+          Actions::SendPointsToInterpolator<InterpolationTargetTag>>(my_proxy,
+                                                                     id);
+    }
+  }
+}
+
+template <typename InterpolationTargetTag, typename ParallelComponent,
+          typename DbTags, typename Metavariables>
+void verify_temporal_ids_and_send_points_time_dependent(
+    const gsl::not_null<db::DataBox<DbTags>*> box,
+    Parallel::GlobalCache<Metavariables>& cache) noexcept {
+  using TemporalId = typename Metavariables::temporal_id::type;
+
+  const auto& pending_temporal_ids =
+      db::get<Tags::PendingTemporalIds<TemporalId>>(*box);
+  if (pending_temporal_ids.empty()) {
+    return; // Nothing to do if there are no pending temporal_ids.
+  }
+
+  auto& this_proxy = Parallel::get_parallel_component<ParallelComponent>(cache);
+  double min_expiration_time = std::numeric_limits<double>::max();
+  const bool at_least_one_pending_temporal_id_is_ready =
+      ::Parallel::mutable_cache_item_is_ready<domain::Tags::FunctionsOfTime>(
+          cache,
+          [&this_proxy, &pending_temporal_ids, &min_expiration_time](
+              const std::unordered_map<
+                  std::string,
+                  std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+                  functions_of_time) -> std::unique_ptr<Parallel::Callback> {
+            min_expiration_time =
+                std::min_element(functions_of_time.begin(),
+                                 functions_of_time.end(),
+                                 [](const auto& a, const auto& b) {
+                                   return a.second->time_bounds()[1] <
+                                          b.second->time_bounds()[1];
+                                 })
+                    ->second->time_bounds()[1];
+            for (const auto& pending_id : pending_temporal_ids) {
+              if (pending_id.step_time().value() <= min_expiration_time) {
+                // Success: at least one pending_temporal_id is ok.
+                return std::unique_ptr<Parallel::Callback>{};
+              }
+            }
+            // Failure: none of the pending_temporal_ids are ok.
+            return std::unique_ptr<Parallel::Callback>(
+                new Parallel::SimpleActionCallback<
+                    VerifyTemporalIdsAndSendPoints<InterpolationTargetTag>,
+                    decltype(this_proxy)>(this_proxy));
+          });
+
+  if (not at_least_one_pending_temporal_id_is_ready) {
+    // A callback has been set so that VerifyTemporalIdsAndSendPoints will
+    // be called by MutableGlobalCache when domain::Tags::FunctionsOfTime
+    // is updated.  So we can exit now.
+    return;
+  }
+
+  // Move up-to-date PendingTemporalIds to TemporalIds, provided
+  // that they are not already there, and fill new_temporal_ids
+  // with the temporal_ids that were so moved.
+  std::vector<TemporalId> new_temporal_ids{};
+  db::mutate_apply<tmpl::list<Tags::TemporalIds<TemporalId>,
+                              Tags::PendingTemporalIds<TemporalId>>,
+                   tmpl::list<Tags::CompletedTemporalIds<TemporalId>>>(
+      [&min_expiration_time, &new_temporal_ids](
+          const gsl::not_null<std::deque<TemporalId>*> ids,
+          const gsl::not_null<std::deque<TemporalId>*> pending_ids,
+          const std::deque<TemporalId>& completed_ids) noexcept {
+        for (auto it = pending_ids->begin(); it != pending_ids->end();) {
+          if (it->step_time().value() <= min_expiration_time and
+              std::find(completed_ids.begin(), completed_ids.end(), *it) ==
+                  completed_ids.end() and
+              std::find(ids->begin(), ids->end(), *it) == ids->end()) {
+            ids->push_back(*it);
+            new_temporal_ids.push_back(*it);
+            it = pending_ids->erase(it);
+          } else {
+            ++it;
+          }
+        }
+      },
+      box);
+
+  if (InterpolationTargetTag::compute_target_points::is_sequential::value) {
+    // Sequential: start interpolation only for the first new_temporal_id.
+    if (not new_temporal_ids.empty()) {
+      auto& my_proxy =
+          Parallel::get_parallel_component<ParallelComponent>(cache);
+      Parallel::simple_action<
+          Actions::SendPointsToInterpolator<InterpolationTargetTag>>(
+          my_proxy, new_temporal_ids.front());
+    }
+  } else {
+    // Non-sequential: start interpolation for all new_temporal_ids.
+    auto& my_proxy = Parallel::get_parallel_component<ParallelComponent>(cache);
+    for (const auto& id : new_temporal_ids) {
+      Parallel::simple_action<
+          Actions::SendPointsToInterpolator<InterpolationTargetTag>>(my_proxy,
+                                                                     id);
+    }
+    // If there are still pending temporal_ids, call
+    // VerifyTemporalIdsAndSendPoints again, so that those pending
+    // temporal_ids can be waited for.
+    if (not db::get<Tags::PendingTemporalIds<TemporalId>>(*box).empty()) {
+      Parallel::simple_action<
+          VerifyTemporalIdsAndSendPoints<InterpolationTargetTag>>(my_proxy);
+    }
+  }
+}
+}  // namespace detail
+
+/// \ingroup ActionsGroup
+/// \brief Sends points to an Interpolator for verified temporal_ids.
+///
+/// VerifyTemporalIdsAndSendPoints is invoked on an InterpolationTarget.
+///
+/// In more detail, does the following:
+/// - If any map is time-dependent:
+///   - Moves verified PendingTemporalIds to TemporalIds, where
+///     verified means that the FunctionsOfTime in the GlobalCache
+///     are up-to-date for that TemporalId.  If no PendingTemporalIds are
+///     moved, then VerifyTemporalIdsAndSendPoints sets itself as a
+///     callback in the GlobalCache so that it is called again when the
+///     FunctionsOfTime are mutated.
+///   - If the InterpolationTarget is sequential, invokes
+///     intrp::Actions::SendPointsToInterpolator for the first TemporalId.
+///     (when interpolation is complete,
+///      intrp::Actions::InterpolationTargetReceiveVars will begin interpolation
+///     on the next TemporalId)
+///   - If the InterpolationTarget is not sequential, invokes
+///     intrp::Actions::SendPointsToInterpolator for all valid TemporalIds,
+///     and then if PendingTemporalIds is non-empty it invokes itself.
+///
+/// - If all maps are time-independent:
+///   - Moves all PendingTemporalIds to TemporalIds
+///   - If the InterpolationTarget is sequential, invokes
+///     intrp::Actions::SendPointsToInterpolator for the first TemporalId.
+///     (when interpolation is complete,
+///      intrp::Actions::InterpolationTargetReceiveVars will begin interpolation
+///     on the next TemporalId)
+///   - If the InterpolationTarget is not sequential, invokes
+///     intrp::Actions::SendPointsToInterpolator for all TemporalIds.
+///
+/// Uses:
+/// - DataBox:
+///   - `intrp::Tags::PendingTeporalIds`
+///   - `intrp::Tags::TeporalIds`
+///
+/// DataBox changes:
+/// - Adds: nothing
+/// - Removes: nothing
+/// - Modifies:
+///   - `intrp::Tags::PendingTeporalIds`
+///   - `intrp::Tags::TeporalIds`
+///
+/// For requirements on InterpolationTargetTag, see InterpolationTarget
+template <typename InterpolationTargetTag>
+struct VerifyTemporalIdsAndSendPoints {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex,
+            Requires<tmpl::list_contains_v<
+                DbTags,
+                Tags::TemporalIds<typename Metavariables::temporal_id::type>>> =
+                nullptr>
+  static void apply(db::DataBox<DbTags>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/) noexcept {
+    if constexpr (std::is_same_v<typename InterpolationTargetTag::
+                                     compute_target_points::frame,
+                                 ::Frame::Grid>) {
+      detail::verify_temporal_ids_and_send_points_time_independent<
+          InterpolationTargetTag, ParallelComponent>(make_not_null(&box),
+                                                     cache);
+    } else {
+      if (InterpolationTarget_detail::maps_are_time_dependent<
+              InterpolationTargetTag>(box, tmpl::type_<Metavariables>{})) {
+        if constexpr (InterpolationTarget_detail::
+                          cache_contains_functions_of_time<
+                              Metavariables>::value) {
+          detail::verify_temporal_ids_and_send_points_time_dependent<
+              InterpolationTargetTag, ParallelComponent>(make_not_null(&box),
+                                                         cache);
+        } else {
+          // We error here because the maps are time-dependent, yet
+          // the cache does not contain FunctionsOfTime.  It would be
+          // nice to make this a compile-time error; however, we want
+          // the code to compile for the completely time-independent
+          // case where there are no FunctionsOfTime in the cache at
+          // all.  Unfortunately, checking whether the maps are
+          // time-dependent is currently not constexpr.
+          ERROR(
+              "There is a time-dependent CoordinateMap in at least one "
+              "of the Blocks, but FunctionsOfTime are not in the "
+              "GlobalCache.  If you intend to use a time-dependent "
+              "CoordinateMap, please add FunctionsOfTime to the GlobalCache.");
+        }
+      } else {
+        detail::verify_temporal_ids_and_send_points_time_independent<
+            InterpolationTargetTag, ParallelComponent>(make_not_null(&box),
+                                                       cache);
+      }
+    }
+  }
+};
+}  // namespace intrp::Actions

--- a/src/NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp
@@ -100,6 +100,7 @@ struct compute_target_points_tags<
 /// - Adds:
 ///   - `Tags::IndicesOfFilledInterpPoints<TemporalId>`
 ///   - `Tags::IndicesOfInvalidInterpPoints<TemporalId>`
+///   - `Tags::PendingTemporalIds<TemporalId>`
 ///   - `Tags::TemporalIds<TemporalId>`
 ///   - `Tags::CompletedTemporalIds<TemporalId>`
 ///   - `Tags::InterpolatedVars<InterpolationTargetTag,TemporalId>`
@@ -119,7 +120,7 @@ struct InitializeInterpolationTarget {
   using return_tag_list_initial = tmpl::list<
       Tags::IndicesOfFilledInterpPoints<TemporalId>,
       Tags::IndicesOfInvalidInterpPoints<TemporalId>,
-      Tags::TemporalIds<TemporalId>,
+      Tags::PendingTemporalIds<TemporalId>, Tags::TemporalIds<TemporalId>,
       Tags::CompletedTemporalIds<TemporalId>,
       Tags::InterpolatedVars<InterpolationTargetTag, TemporalId>,
       ::Tags::Variables<

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTarget.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTarget.hpp
@@ -237,26 +237,6 @@ namespace intrp {
 /// `intrp::Events::Interpolate` to trigger interpolation for new
 /// `temporal_id`s. Its logic is as follows, in pseudocode:
 ///
-/// ###### Current logic:
-///
-/// ```
-/// Add passed-in temporal_ids to TemporalIds
-/// if (sequential) {
-///   if (TemporalIds was empty before it was appended above) {
-///     call block_logical_coordinates and begin interpolating for the
-///     first temporal_id
-///   } else {
-///     Do nothing, because there is already a sequential interpolation in
-///     progress.
-///   }
-/// } else { // not sequential
-///    call block_logical_coordinates and begin interpolating for
-///    all newly-added TemporalIds.
-/// }
-///```
-///
-/// ###### New logic:
-///
 /// ```
 /// Add passed-in temporal_ids to PendingTemporalIds
 /// if (sequential) {

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
@@ -147,6 +147,7 @@ struct ApparentHorizon {
                               logging::Tags::Verbosity<InterpolationTargetTag>>,
                    StrahlkorperTags::compute_items_tags<Frame>>;
   using is_sequential = std::true_type;
+  using frame = Frame;
 
   using simple_tags =
       tmpl::push_back<StrahlkorperTags::items_tags<Frame>, ::ah::Tags::FastFlow,

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetDetail.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetDetail.hpp
@@ -14,8 +14,10 @@
 #include "DataStructures/VariablesTag.hpp"
 #include "Domain/BlockLogicalCoordinates.hpp"
 #include "Domain/Tags.hpp"
+#include "Domain/TagsTimeDependent.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
 #include "Utilities/Requires.hpp"
@@ -267,6 +269,13 @@ bool have_data_at_all_points(const db::DataBox<DbTags>& box,
           .number_of_grid_points();
   return (invalid_size + filled_size == interp_size);
 }
+
+/// Is domain::Tags::FunctionsOfTime in the mutable global cache?
+/// Result is either std::true_type or std::false_type.
+template <typename Metavariables>
+using cache_contains_functions_of_time =
+    tmpl::found<Parallel::get_mutable_global_cache_tags<Metavariables>,
+                std::is_same<tmpl::_1, domain::Tags::FunctionsOfTime>>;
 
 /// Tells an InterpolationTarget that it should interpolate at
 /// the supplied temporal_ids.  Changes the InterpolationTarget's DataBox

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetDetail.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetDetail.hpp
@@ -18,6 +18,7 @@
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Utilities/Algorithm.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
 #include "Utilities/Requires.hpp"
@@ -276,6 +277,20 @@ template <typename Metavariables>
 using cache_contains_functions_of_time =
     tmpl::found<Parallel::get_mutable_global_cache_tags<Metavariables>,
                 std::is_same<tmpl::_1, domain::Tags::FunctionsOfTime>>;
+
+/// Returns true if at least one Block in the Domain has
+/// time-dependent maps.
+template <typename InterpolationTargetTag, typename DbTags,
+          typename Metavariables>
+bool maps_are_time_dependent(
+    const db::DataBox<DbTags>& box,
+    const tmpl::type_<Metavariables>& /*meta*/) noexcept {
+  const auto& domain =
+      db::get<domain::Tags::Domain<Metavariables::volume_dim>>(box);
+  return alg::any_of(domain.blocks(), [](const auto& block) noexcept {
+    return block.is_time_dependent();
+  });
+}
 
 /// Tells an InterpolationTarget that it should interpolate at
 /// the supplied temporal_ids.  Changes the InterpolationTarget's DataBox

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp
@@ -158,6 +158,7 @@ struct KerrHorizon {
       tmpl::append<StrahlkorperTags::items_tags<Frame>,
                    StrahlkorperTags::compute_items_tags<Frame>>;
   using is_sequential = std::false_type;
+  using frame = Frame;
 
   using simple_tags = typename StrahlkorperTags::items_tags<Frame>;
   using compute_tags = typename StrahlkorperTags::compute_items_tags<Frame>;
@@ -181,27 +182,23 @@ struct KerrHorizon {
   }
 
   template <typename Metavariables, typename DbTags, typename TemporalId>
-  static tnsr::I<DataVector, 3, ::Frame::Inertial> points(
+  static tnsr::I<DataVector, 3, Frame> points(
       const db::DataBox<DbTags>& box,
       const tmpl::type_<Metavariables>& /*meta*/,
       const TemporalId& /*temporal_id*/) noexcept {
-    // In the future, when we add support for multiple Frames,
-    // the code that transforms coordinates from the Strahlkorper Frame
-    // to Frame::Inertial will go here.  That transformation
-    // may depend on `temporal_id`.
     const auto& kerr_horizon =
         db::get<Tags::KerrHorizon<InterpolationTargetTag>>(box);
     if (kerr_horizon.theta_varies_fastest_memory_layout) {
-      return db::get<StrahlkorperTags::CartesianCoords<::Frame::Inertial>>(box);
+      return db::get<StrahlkorperTags::CartesianCoords<Frame>>(box);
     } else {
       const auto& strahlkorper =
-          db::get<StrahlkorperTags::Strahlkorper<::Frame::Inertial>>(box);
+          db::get<StrahlkorperTags::Strahlkorper<Frame>>(box);
       const auto& coords =
-          db::get<StrahlkorperTags::CartesianCoords<::Frame::Inertial>>(box);
+          db::get<StrahlkorperTags::CartesianCoords<Frame>>(box);
       const auto physical_extents =
           strahlkorper.ylm_spherepack().physical_extents();
       auto transposed_coords =
-          tnsr::I<DataVector, 3, ::Frame::Inertial>(get<0>(coords).size());
+          tnsr::I<DataVector, 3, Frame>(get<0>(coords).size());
       for (size_t i = 0; i < 3; ++i) {
         transpose(make_not_null(&transposed_coords.get(i)), coords.get(i),
                   physical_extents[0], physical_extents[1]);
@@ -210,10 +207,10 @@ struct KerrHorizon {
     }
   }
   template <typename Metavariables, typename DbTags>
-  static tnsr::I<DataVector, 3, ::Frame::Inertial> points(
+  static tnsr::I<DataVector, 3, Frame> points(
       const db::DataBox<DbTags>& box,
       const tmpl::type_<Metavariables>& /*meta*/) noexcept {
-    return db::get<StrahlkorperTags::CartesianCoords<::Frame::Inertial>>(box);
+    return db::get<StrahlkorperTags::CartesianCoords<Frame>>(box);
   }
 };
 

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp
@@ -124,6 +124,7 @@ struct LineSegment {
   using const_global_cache_tags =
       tmpl::list<Tags::LineSegment<InterpolationTargetTag, VolumeDim>>;
   using is_sequential = std::false_type;
+  using frame = Frame::Inertial;
 
   template <typename Metavariables, typename DbTags>
   static tnsr::I<DataVector, VolumeDim, Frame::Inertial> points(

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
@@ -191,6 +191,7 @@ struct WedgeSectionTorus {
   using const_global_cache_tags =
       tmpl::list<Tags::WedgeSectionTorus<InterpolationTargetTag>>;
   using is_sequential = std::false_type;
+  using frame = Frame::Inertial;
 
   template <typename Metavariables, typename DbTags>
   static tnsr::I<DataVector, 3, Frame::Inertial> points(

--- a/src/NumericalAlgorithms/Interpolation/Tags.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Tags.hpp
@@ -57,6 +57,15 @@ struct IndicesOfInvalidInterpPoints : db::SimpleTag {
   using type = std::unordered_map<TemporalId, std::unordered_set<size_t>>;
 };
 
+/// `temporal_id`s that have been flagged to interpolate on, but that
+/// have not yet been added to Tags::TemporalIds.  A `temporal_id` is
+/// pending if the `FunctionOfTime`s are not up to date for the time
+/// associated with the `temporal_id`.
+template <typename TemporalId>
+struct PendingTemporalIds : db::SimpleTag {
+  using type = std::deque<TemporalId>;
+};
+
 /// `temporal_id`s on which to interpolate.
 template <typename TemporalId>
 struct TemporalIds : db::SimpleTag {

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
@@ -5,14 +5,19 @@
 
 #include <cstddef>
 #include <deque>
+#include <memory>
 #include <unordered_set>
 #include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
+#include "Domain/Creators/Brick.hpp"
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/Shell.hpp"
+#include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/TimeDependence/UniformTranslation.hpp"
 #include "Domain/Domain.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
 #include "Domain/Tags.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "NumericalAlgorithms/Interpolation/AddTemporalIdsToInterpolationTarget.hpp"  // IWYU pragma: keep
@@ -39,6 +44,8 @@ template <typename TemporalId>
 struct IndicesOfFilledInterpPoints;
 template <typename TemporalId>
 struct TemporalIds;
+template <typename TemporalId>
+struct PendingTemporalIds;
 }  // namespace intrp::Tags
 namespace Parallel {
 template <typename Metavariables>
@@ -63,8 +70,8 @@ struct MockSendPointsToInterpolator {
     db::mutate<::intrp::Tags::IndicesOfFilledInterpPoints<TemporalId>>(
         make_not_null(&box),
         [&temporal_id](
-            const gsl::not_null<std::unordered_map<TemporalId,
-                                                   std::unordered_set<size_t>>*>
+            const gsl::not_null<
+                std::unordered_map<TemporalId, std::unordered_set<size_t>>*>
                 indices) noexcept {
           (*indices)[temporal_id].insert((*indices)[temporal_id].size() + 1);
         });
@@ -77,6 +84,10 @@ struct mock_interpolation_target {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
   using const_global_cache_tags = tmpl::list<domain::Tags::Domain<3>>;
+  using mutable_global_cache_tags =
+      tmpl::conditional_t<metavariables::use_time_dependent_maps,
+                          tmpl::list<domain::Tags::FunctionsOfTime>,
+                          tmpl::list<>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -93,9 +104,10 @@ struct mock_interpolation_target {
 template <typename IsSequential>
 struct MockComputeTargetPoints {
   using is_sequential = IsSequential;
+  using frame = ::Frame::Inertial;
 };
 
-template <typename IsSequential>
+template <typename IsSequential, typename IsTimeDependent>
 struct MockMetavariables {
   struct InterpolationTargetA {
     using vars_to_interpolate_to_target =
@@ -103,7 +115,9 @@ struct MockMetavariables {
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points = MockComputeTargetPoints<IsSequential>;
   };
+  static constexpr bool use_time_dependent_maps = IsTimeDependent::value;
   using temporal_id = ::Tags::TimeStepId;
+  static constexpr size_t volume_dim = 3;
 
   using component_list = tmpl::list<
       mock_interpolation_target<MockMetavariables, InterpolationTargetA>>;
@@ -112,7 +126,7 @@ struct MockMetavariables {
 
 template <typename IsSequential>
 void test_add_temporal_ids() {
-  using metavars = MockMetavariables<IsSequential>;
+  using metavars = MockMetavariables<IsSequential, std::false_type>;
   using temporal_id_type = typename metavars::temporal_id::type;
   using target_component =
       mock_interpolation_target<metavars,
@@ -129,6 +143,11 @@ void test_add_temporal_ids() {
   }
   ActionTesting::set_phase(make_not_null(&runner), metavars::Phase::Testing);
 
+  // Both PendingTemporalIds and TemporalIds should be initially empty.
+  CHECK(ActionTesting::get_databox_tag<
+            target_component,
+            ::intrp::Tags::PendingTemporalIds<temporal_id_type>>(runner, 0)
+            .empty());
   CHECK(ActionTesting::get_databox_tag<
             target_component, ::intrp::Tags::TemporalIds<temporal_id_type>>(
             runner, 0)
@@ -139,34 +158,90 @@ void test_add_temporal_ids() {
       TimeStepId(true, 0, Time(slab, 0)),
       TimeStepId(true, 0, Time(slab, Rational(1, 3)))};
 
-  runner.template simple_action<
+  ActionTesting::simple_action<
       target_component, ::intrp::Actions::AddTemporalIdsToInterpolationTarget<
                             typename metavars::InterpolationTargetA>>(
-      0, temporal_ids);
+      make_not_null(&runner), 0, temporal_ids);
 
+  // TemporalIds should still be empty, but PendingTemporalIds should
+  // have been filled.
+  CHECK(ActionTesting::get_databox_tag<
+            target_component,
+            ::intrp::Tags::PendingTemporalIds<temporal_id_type>>(runner, 0) ==
+        std::deque<TimeStepId>(temporal_ids.begin(), temporal_ids.end()));
+  CHECK(ActionTesting::get_databox_tag<
+            target_component, ::intrp::Tags::TemporalIds<temporal_id_type>>(
+            runner, 0)
+            .empty());
+
+  // Should be only one queued simple action: VerifyTemporalIdsAndSendPoints
+  CHECK(ActionTesting::number_of_queued_simple_actions<target_component>(
+            runner, 0) == 1);
+
+  // Add the same temporal_ids again, which should do nothing...
+  ActionTesting::simple_action<
+      target_component, ::intrp::Actions::AddTemporalIdsToInterpolationTarget<
+                            typename metavars::InterpolationTargetA>>(
+      make_not_null(&runner), 0, temporal_ids);
+  // ...and check that it indeed did nothing.
+  CHECK(ActionTesting::get_databox_tag<
+            target_component,
+            ::intrp::Tags::PendingTemporalIds<temporal_id_type>>(runner, 0) ==
+        std::deque<TimeStepId>(temporal_ids.begin(), temporal_ids.end()));
+  CHECK(ActionTesting::get_databox_tag<
+            target_component, ::intrp::Tags::TemporalIds<temporal_id_type>>(
+            runner, 0)
+            .empty());
+
+  // At this point, there should be only one queued simple action,
+  // VerifyTemporalIdsAndSendPoints, and triggering this action
+  // should move the PendingTemporalIds to TemporalIds and invoke
+  // other simple actions.
+  CHECK(ActionTesting::number_of_queued_simple_actions<target_component>(
+            runner, 0) == 1);
+  ActionTesting::invoke_queued_simple_action<target_component>(
+      make_not_null(&runner), 0);
+
+  // Now the PendingTemporalIds should be empty, and the
+  // TemporalIds should contain the two IDs.
   CHECK(ActionTesting::get_databox_tag<
             target_component, ::intrp::Tags::TemporalIds<temporal_id_type>>(
             runner, 0) ==
         std::deque<TimeStepId>(temporal_ids.begin(), temporal_ids.end()));
+  CHECK(ActionTesting::get_databox_tag<
+            target_component,
+            ::intrp::Tags::PendingTemporalIds<temporal_id_type>>(runner, 0)
+            .empty());
 
-  // Add the same temporal_ids again, which should do nothing...
-  runner.template simple_action<
+  // Add the same temporal_ids yet again, which should do nothing...
+  ActionTesting::simple_action<
       target_component, ::intrp::Actions::AddTemporalIdsToInterpolationTarget<
                             typename metavars::InterpolationTargetA>>(
-      0, temporal_ids);
+      make_not_null(&runner), 0, temporal_ids);
   // ...and check that it indeed did nothing.
   CHECK(ActionTesting::get_databox_tag<
             target_component, ::intrp::Tags::TemporalIds<temporal_id_type>>(
             runner, 0) ==
         std::deque<TimeStepId>(temporal_ids.begin(), temporal_ids.end()));
+  CHECK(ActionTesting::get_databox_tag<
+            target_component,
+            ::intrp::Tags::PendingTemporalIds<temporal_id_type>>(runner, 0)
+            .empty());
 
   if (IsSequential::value) {
     // Only one simple action should be queued, for the first temporal_id.
-    runner.template invoke_queued_simple_action<target_component>(0);
+    CHECK(ActionTesting::number_of_queued_simple_actions<target_component>(
+              runner, 0) == 1);
+    ActionTesting::invoke_queued_simple_action<target_component>(
+        make_not_null(&runner), 0);
   } else {
     // Two simple actions should be queued, one for each temporal_id.
-    runner.template invoke_queued_simple_action<target_component>(0);
-    runner.template invoke_queued_simple_action<target_component>(0);
+    CHECK(ActionTesting::number_of_queued_simple_actions<target_component>(
+              runner, 0) == 2);
+    ActionTesting::invoke_queued_simple_action<target_component>(
+        make_not_null(&runner), 0);
+    ActionTesting::invoke_queued_simple_action<target_component>(
+        make_not_null(&runner), 0);
   }
 
   // Check that MockSendPointsToInterpolator was called.
@@ -186,23 +261,35 @@ void test_add_temporal_ids() {
               .size() == 1);
   }
 
+  // Check that there are no queued simple actions.
+  CHECK(
+      ActionTesting::is_simple_action_queue_empty<target_component>(runner, 0));
+
   // Call again.
   // If sequential, it should not call MockSendPointsToInterpolator this time.
   // Otherwise it should call MockSendPointsToInterpolator twice.
   const std::vector<TimeStepId> temporal_ids_2 = {
       TimeStepId(true, 0, Time(slab, Rational(2, 3))),
       TimeStepId(true, 0, Time(slab, Rational(3, 3)))};
-  runner.template simple_action<
+  ActionTesting::simple_action<
       target_component, ::intrp::Actions::AddTemporalIdsToInterpolationTarget<
                             typename metavars::InterpolationTargetA>>(
-      0, temporal_ids_2);
+      make_not_null(&runner), 0, temporal_ids_2);
 
   if (not IsSequential::value) {
-    // For non-sequential, there should be two queued_simple_actions,
+    // For non-sequential, there should be only one queued simple action,
+    // VerifyTemporalIdsAndSendPoints.
+    CHECK(ActionTesting::number_of_queued_simple_actions<target_component>(
+              runner, 0) == 1);
+    ActionTesting::invoke_queued_simple_action<target_component>(
+        make_not_null(&runner), 0);
+
+    // Now there should be two queued_simple_actions,
     // each of which will call MockSendPointsToInterpolator for one of the
     // new temporal_ids.
     for (size_t i = 0; i < 2; ++i) {
-      runner.template invoke_queued_simple_action<target_component>(0);
+      ActionTesting::invoke_queued_simple_action<target_component>(
+          make_not_null(&runner), 0);
       CHECK(ActionTesting::get_databox_tag<
                 target_component,
                 ::intrp::Tags::IndicesOfFilledInterpPoints<temporal_id_type>>(
@@ -213,12 +300,331 @@ void test_add_temporal_ids() {
   }
 
   // Check that there are no queued simple actions.
-  CHECK(runner.template is_simple_action_queue_empty<target_component>(0));
+  CHECK(
+      ActionTesting::is_simple_action_queue_empty<target_component>(runner, 0));
 }
+
+// For updating the expiration time in the FunctionOfTimes.
+template <size_t Multiplier>
+struct MyFunctionOfTimeUpdater {
+  static void apply(gsl::not_null<typename domain::Tags::FunctionsOfTime::type*>
+                        functions_of_time) {
+    for (auto& name_and_function_of_time : *functions_of_time) {
+      auto* function_of_time =
+          dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<2>*>(
+              name_and_function_of_time.second.get());
+      REQUIRE(function_of_time != nullptr);
+      function_of_time->reset_expiration_time(0.5 * Multiplier);
+    }
+  }
+};
+
+template <typename IsSequential>
+void test_add_temporal_ids_time_dependent() {
+  using metavars = MockMetavariables<IsSequential, std::true_type>;
+  using temporal_id_type = typename metavars::temporal_id::type;
+  using target_component =
+      mock_interpolation_target<metavars,
+                                typename metavars::InterpolationTargetA>;
+
+  const double expiration_time = 0.1;
+  // Create a Domain with time-dependence. For this test we don't care
+  // what the Domain actually is, we care only that it has time-dependence.
+  const auto domain_creator = domain::creators::Brick(
+      {{-1.2, 3.0, 2.5}}, {{0.8, 5.0, 3.0}}, {{1, 1, 1}}, {{5, 4, 3}},
+      {{false, false, false}},
+      std::make_unique<
+          domain::creators::time_dependence::UniformTranslation<3>>(
+          0.0, expiration_time, std::array<double, 3>({{0.1, 0.2, 0.3}})));
+
+  ActionTesting::MockRuntimeSystem<metavars> runner{
+      {domain_creator.create_domain()}, {domain_creator.functions_of_time()}};
+  ActionTesting::emplace_component<target_component>(&runner, 0);
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::next_action<target_component>(make_not_null(&runner), 0);
+  }
+  ActionTesting::set_phase(make_not_null(&runner), metavars::Phase::Testing);
+
+  // Both PendingTemporalIds and TemporalIds should be initially empty.
+  CHECK(ActionTesting::get_databox_tag<
+            target_component,
+            ::intrp::Tags::PendingTemporalIds<temporal_id_type>>(runner, 0)
+            .empty());
+  CHECK(ActionTesting::get_databox_tag<
+            target_component, ::intrp::Tags::TemporalIds<temporal_id_type>>(
+            runner, 0)
+            .empty());
+
+  // Two of the temporal_ids are before the expiration_time, the
+  // others are afterwards.  Later we will update the FunctionOfTimes
+  // so that the later temporal_ids become valid.
+  Slab slab(0.0, 1.0);
+  const std::vector<TimeStepId> temporal_ids = {
+      TimeStepId(true, 0, Time(slab, 0)),
+      TimeStepId(true, 0, Time(slab, Rational(1, 20))),
+      TimeStepId(true, 0, Time(slab, Rational(1, 4))),
+      TimeStepId(true, 0, Time(slab, Rational(1, 3))),
+      TimeStepId(true, 0, Time(slab, Rational(2, 3))),
+      TimeStepId(true, 0, Time(slab, Rational(3, 4)))};
+
+  ActionTesting::simple_action<
+      target_component, ::intrp::Actions::AddTemporalIdsToInterpolationTarget<
+                            typename metavars::InterpolationTargetA>>(
+      make_not_null(&runner), 0, temporal_ids);
+
+  // TemporalIds should still be empty, but PendingTemporalIds should
+  // have been filled.
+  CHECK(ActionTesting::get_databox_tag<
+            target_component,
+            ::intrp::Tags::PendingTemporalIds<temporal_id_type>>(runner, 0) ==
+        std::deque<TimeStepId>(temporal_ids.begin(), temporal_ids.end()));
+  CHECK(ActionTesting::get_databox_tag<
+            target_component, ::intrp::Tags::TemporalIds<temporal_id_type>>(
+            runner, 0)
+            .empty());
+
+  // Should be only one queued simple action: VerifyTemporalIdsAndSendPoints
+  CHECK(ActionTesting::number_of_queued_simple_actions<target_component>(
+            runner, 0) == 1);
+
+  // Add the same temporal_ids again, which should do nothing...
+  ActionTesting::simple_action<
+      target_component, ::intrp::Actions::AddTemporalIdsToInterpolationTarget<
+                            typename metavars::InterpolationTargetA>>(
+      make_not_null(&runner), 0, temporal_ids);
+  // ...and check that it indeed did nothing.
+  CHECK(ActionTesting::get_databox_tag<
+            target_component,
+            ::intrp::Tags::PendingTemporalIds<temporal_id_type>>(runner, 0) ==
+        std::deque<TimeStepId>(temporal_ids.begin(), temporal_ids.end()));
+  CHECK(ActionTesting::get_databox_tag<
+            target_component, ::intrp::Tags::TemporalIds<temporal_id_type>>(
+            runner, 0)
+            .empty());
+
+  // At this point, there should still be only one queued simple
+  // action, VerifyTemporalIdsAndSendPoints.
+  CHECK(ActionTesting::number_of_queued_simple_actions<target_component>(
+            runner, 0) == 1);
+
+  // Now invoke VerifyTemporalIdsAndSendPoints.
+  ActionTesting::invoke_queued_simple_action<target_component>(
+      make_not_null(&runner), 0);
+
+  // Two of the temporal_ids are before the expiration_time, but the
+  // other temporal_ids are after the expiration_time.  So only the
+  // first two temporal_id should have been moved from
+  // PendingTemporalIds to TemporalIds.
+  CHECK(ActionTesting::get_databox_tag<
+            target_component, ::intrp::Tags::TemporalIds<temporal_id_type>>(
+            runner, 0) ==
+        std::deque<TimeStepId>({temporal_ids[0], temporal_ids[1]}));
+  CHECK(ActionTesting::get_databox_tag<
+            target_component,
+            ::intrp::Tags::PendingTemporalIds<temporal_id_type>>(runner, 0) ==
+        std::deque<TimeStepId>({temporal_ids[2], temporal_ids[3],
+                                temporal_ids[4], temporal_ids[5]}));
+
+  if (IsSequential::value) {
+    // Only one simple action should be queued,
+    // MockSendPointsToInterpolator for the first temporal_id.
+    CHECK(ActionTesting::number_of_queued_simple_actions<target_component>(
+              runner, 0) == 1);
+  } else {
+    // Three simple actions should be queued,
+    // MockSendPointsToInterpolator for each of the first two
+    // temporal_ids, and VerifyTemporalIdsAndSendPoints because there
+    // are remaining temporal_ids that are still pending.
+    CHECK(ActionTesting::number_of_queued_simple_actions<target_component>(
+              runner, 0) == 3);
+  }
+
+  // Add the same temporal_ids yet again, which should do nothing...
+  ActionTesting::simple_action<
+      target_component, ::intrp::Actions::AddTemporalIdsToInterpolationTarget<
+                            typename metavars::InterpolationTargetA>>(
+      make_not_null(&runner), 0, temporal_ids);
+  // ...and check that it indeed did nothing. That is, check that the
+  // TemporalIds and PendingTemporalIds and the number of queued actions are as
+  // before.
+  CHECK(ActionTesting::get_databox_tag<
+            target_component, ::intrp::Tags::TemporalIds<temporal_id_type>>(
+            runner, 0) ==
+        std::deque<TimeStepId>({temporal_ids[0], temporal_ids[1]}));
+  CHECK(ActionTesting::get_databox_tag<
+            target_component,
+            ::intrp::Tags::PendingTemporalIds<temporal_id_type>>(runner, 0) ==
+        std::deque<TimeStepId>({temporal_ids[2], temporal_ids[3],
+                                temporal_ids[4], temporal_ids[5]}));
+  if (IsSequential::value) {
+    CHECK(ActionTesting::number_of_queued_simple_actions<target_component>(
+              runner, 0) == 1);
+  } else {
+    CHECK(ActionTesting::number_of_queued_simple_actions<target_component>(
+              runner, 0) == 3);
+  }
+
+  // Now call all of the queued actions, so that we are now waiting on
+  // the FunctionOfTime to update.
+  if (IsSequential::value) {
+    ActionTesting::invoke_queued_simple_action<target_component>(
+        make_not_null(&runner), 0);
+  } else {
+    ActionTesting::invoke_queued_simple_action<target_component>(
+        make_not_null(&runner), 0);
+    ActionTesting::invoke_queued_simple_action<target_component>(
+        make_not_null(&runner), 0);
+    ActionTesting::invoke_queued_simple_action<target_component>(
+        make_not_null(&runner), 0);
+  }
+
+  // Check that MockSendPointsToInterpolator was called for the first
+  // temporal_id.
+  CHECK(ActionTesting::get_databox_tag<
+            target_component,
+            ::intrp::Tags::IndicesOfFilledInterpPoints<temporal_id_type>>(
+            runner, 0)
+            .at(temporal_ids[0])
+            .size() == 1);
+  if (not IsSequential::value) {
+    // Check that MockSendPointsToInterpolator was called for the second
+    // temporal_id, in the non-sequential case.
+    CHECK(ActionTesting::get_databox_tag<
+              target_component,
+              ::intrp::Tags::IndicesOfFilledInterpPoints<temporal_id_type>>(
+              runner, 0)
+              .at(temporal_ids[1])
+              .size() == 1);
+  }
+
+  // Check that there are no queued simple actions.
+  CHECK(
+      ActionTesting::is_simple_action_queue_empty<target_component>(runner, 0));
+
+  // So now mutate the FunctionsOfTime.  For the non-sequential case,
+  // there should be a callback waiting on a modification of the
+  // FunctionOfTimes in the GlobalCache.  For the sequential case,
+  // there should be no callback because the next interpolation is
+  // started when the previous interpolation is finished
+  // (and that code is not included in this test).
+  auto& cache = ActionTesting::cache<target_component>(runner, 0_st);
+  Parallel::mutate<domain::Tags::FunctionsOfTime, MyFunctionOfTimeUpdater<1>>(
+      cache);
+
+  if (IsSequential::value) {
+    // Check that there are no queued simple actions.
+    CHECK(ActionTesting::is_simple_action_queue_empty<target_component>(runner,
+                                                                        0));
+  } else {
+    // The callback should have queued a single simple action,
+    // VerifyTemporalIdsAndSendPoints.
+    CHECK(ActionTesting::number_of_queued_simple_actions<target_component>(
+              runner, 0) == 1);
+
+    ActionTesting::invoke_queued_simple_action<target_component>(
+        make_not_null(&runner), 0);
+
+    // The first 4 temporal_ids should now be in TemporalIds,
+    // and the last 2 should be in PendingTemporalIds.
+    CHECK(ActionTesting::get_databox_tag<
+              target_component, ::intrp::Tags::TemporalIds<temporal_id_type>>(
+              runner, 0) ==
+          std::deque<TimeStepId>({temporal_ids[0], temporal_ids[1],
+                                  temporal_ids[2], temporal_ids[3]}));
+    CHECK(ActionTesting::get_databox_tag<
+              target_component,
+              ::intrp::Tags::PendingTemporalIds<temporal_id_type>>(runner, 0) ==
+          std::deque<TimeStepId>({temporal_ids[4], temporal_ids[5]}));
+
+    // Now there should be three queued simple actions.  One is
+    // VerifyTemporalIdsAndSendPoints, which was invoked by the last
+    // invocation of VerifyTemporalIdsAndSendPoints because there are
+    // still pending temporal_ids.
+    // The other two are MockSendPointsToInterpolator for each
+    // of the newly-added temporal_ids.
+    CHECK(ActionTesting::number_of_queued_simple_actions<target_component>(
+              runner, 0) == 3);
+
+    // Invoke the first two simple actions (the ones that call
+    // MockSendPointsToInterpolator), and verify that
+    // MockSendPointsToInterpolator was indeed called for the
+    // temporal_ids.
+    for (size_t i = 0; i < 2; ++i) {
+      ActionTesting::invoke_queued_simple_action<target_component>(
+          make_not_null(&runner), 0);
+      CHECK(ActionTesting::get_databox_tag<
+                target_component,
+                ::intrp::Tags::IndicesOfFilledInterpPoints<temporal_id_type>>(
+                runner, 0)
+                .at(temporal_ids[i + 2])
+                .size() == 1);
+    }
+  }
+
+  // Earlier in this test we mutated the FunctionsOfTime when there were
+  // no more simple_actions in the queue.  Now we mutate the
+  // FunctionsOfTime while there is still (for the nonsequential case) a
+  // VerifyTemporalIdsAndSendPoints queued.
+  Parallel::mutate<domain::Tags::FunctionsOfTime, MyFunctionOfTimeUpdater<2>>(
+      cache);
+
+  if (IsSequential::value) {
+    // Check that there are no queued simple actions.
+    CHECK(ActionTesting::is_simple_action_queue_empty<target_component>(runner,
+                                                                        0));
+  } else {
+    // There should still be a single simple action in the queue,
+    // VerifyTemporalIdsAndSendPoints, because there was no callback.
+    CHECK(ActionTesting::number_of_queued_simple_actions<target_component>(
+              runner, 0) == 1);
+
+    ActionTesting::invoke_queued_simple_action<target_component>(
+        make_not_null(&runner), 0);
+
+    // All temporal_ids should now be in TemporalIds,
+    // and none should be in PendingTemporalIds.
+    CHECK(ActionTesting::get_databox_tag<
+              target_component, ::intrp::Tags::TemporalIds<temporal_id_type>>(
+              runner, 0) ==
+          std::deque<TimeStepId>(temporal_ids.begin(), temporal_ids.end()));
+    CHECK(ActionTesting::get_databox_tag<
+              target_component,
+              ::intrp::Tags::PendingTemporalIds<temporal_id_type>>(runner, 0)
+              .empty());
+
+    // Now there should be two queued simple actions, the
+    // MockSendPointsToInterpolator ones.
+    CHECK(ActionTesting::number_of_queued_simple_actions<target_component>(
+              runner, 0) == 2);
+
+    // Invoke the two simple actions, and verify that
+    // MockSendPointsToInterpolator was indeed called for the
+    // temporal_ids.
+    for (size_t i = 0; i < 2; ++i) {
+      ActionTesting::invoke_queued_simple_action<target_component>(
+          make_not_null(&runner), 0);
+      CHECK(ActionTesting::get_databox_tag<
+                target_component,
+                ::intrp::Tags::IndicesOfFilledInterpPoints<temporal_id_type>>(
+                runner, 0)
+                .at(temporal_ids[i + 4])
+                .size() == 1);
+    }
+  }
+
+  // Check that there are no queued simple actions.
+  CHECK(
+      ActionTesting::is_simple_action_queue_empty<target_component>(runner, 0));
+}
+
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.AddTemporalIds",
                   "[Unit]") {
   domain::creators::register_derived_with_charm();
+  domain::creators::time_dependence::register_derived_with_charm();
+  domain::FunctionsOfTime::register_derived_with_charm();
   test_add_temporal_ids<std::true_type>();
   test_add_temporal_ids<std::false_type>();
+  test_add_temporal_ids_time_dependent<std::true_type>();
+  test_add_temporal_ids_time_dependent<std::false_type>();
 }
 }  // namespace

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
@@ -320,6 +320,7 @@ void test_interpolation_target_receive_vars() noexcept {
       {std::unordered_map<temporal_id_type, std::unordered_set<size_t>>{},
        std::unordered_map<temporal_id_type, std::unordered_set<size_t>>{
            invalid_indices},
+       std::deque<temporal_id_type>{},
        std::deque<temporal_id_type>{first_temporal_id, second_temporal_id},
        std::deque<temporal_id_type>{},
        std::unordered_map<temporal_id_type,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetVarsFromElement.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetVarsFromElement.cpp
@@ -160,6 +160,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.TargetVarsFromElement",
       {std::unordered_map<temporal_id_type, std::unordered_set<size_t>>{},
        std::unordered_map<temporal_id_type, std::unordered_set<size_t>>{},
        std::deque<temporal_id_type>{}, std::deque<temporal_id_type>{},
+       std::deque<temporal_id_type>{},
        std::unordered_map<temporal_id_type,
                           Variables<typename metavars::InterpolationTargetA::
                                         vars_to_interpolate_to_target>>{},


### PR DESCRIPTION
## Proposed changes
There are multiple commits in this PR. Most of them do small things:
 - Add 'frame' type alias to InterpolationTargets
 - Add a new tag PendingTemporalIds to the DataBox of InterpolationTarget
 - Adds new functions to InterpolationTargetDetail, for determining when maps are time-dependent.
And then some make larger changes
 - Add intrp::Actions::VerifyTemporalIdsAndSendPoints (as described in the documentation)
 - Update AddTemporalIdsToInterpolationTarget, and its test, to work with time-dependent maps.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
