### PR TITLE
Export GCC_HOME in ocean_gcc.sh spectre_run_cmake

### DIFF
--- a/support/Environments/ocean_gcc.sh
+++ b/support/Environments/ocean_gcc.sh
@@ -69,6 +69,7 @@ spectre_run_cmake() {
         return 1
     fi
     spectre_load_modules
+    export GCC_HOME=/opt/ohpc/pub/compiler/gcc/7.3.0/bin
     cmake -D CHARM_ROOT=$CHARM_ROOT \
           -D CMAKE_BUILD_TYPE=Release \
           -D CMAKE_C_COMPILER=gcc \


### PR DESCRIPTION
## Proposed changes

This PR adds what I believe is a missing export for `GCC_HOME` in the `ocean_gcc.sh` environment. Sourcing the file as it currently is and attempting to run `spectre_run_cmake` produces an error for the `gfortran` path:

```
CMake Error at CMakeLists.txt:13 (project):
  The CMAKE_Fortran_COMPILER:

    /gfortran

  is not a full path to an existing compiler tool.

  Tell CMake where to find the compiler by setting either the environment
  variable "FC" or the CMake cache entry CMAKE_Fortran_COMPILER to the full
  path to the compiler, or to the compiler name if it is in the PATH.
```

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
