### PR TITLE
Support aggregate-initialization in option parsing

### DIFF
--- a/src/Options/ParseOptions.hpp
+++ b/src/Options/ParseOptions.hpp
@@ -848,7 +848,7 @@ T create_from_yaml<T>::create(const Option& options) {
                                                const Context&>{}) {
       return T(std::move(args)..., options.context());
     } else {
-      return T(std::move(args)...);
+      return T{std::move(args)...};
     }
   });
 }

--- a/tests/Unit/Options/Test_CustomTypeConstruction.cpp
+++ b/tests/Unit/Options/Test_CustomTypeConstruction.cpp
@@ -88,6 +88,27 @@ CfoWithMetavariables:
   MetaName: MetaString
 )";
 /// [class_creation_example_with_metavariables]
+
+struct CreateFromOptionsAggregate {
+  struct CfoOption {
+    using type = std::string;
+    static constexpr Options::String help = {"Option help text"};
+  };
+  static constexpr Options::String help = {"Class help text"};
+  using options = tmpl::list<CfoOption>;
+  // Define no constructors. The class can be aggregate-initialized.
+  std::string str{};
+};
+
+struct CfoAggregate {
+  using type = CreateFromOptionsAggregate;
+  static constexpr Options::String help = {"help"};
+};
+
+const char* const input_file_text_aggregate = R"(
+CfoAggregate:
+  CfoOption: MetaString
+)";
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Options.CustomType", "[Unit][Options]") {
@@ -103,6 +124,12 @@ SPECTRE_TEST_CASE("Unit.Options.CustomType", "[Unit][Options]") {
     opts.parse(input_file_text_with_metavariables);
     CHECK(opts.get<CfoWithMetavariables, Metavariables>().str_ == "MetaString");
     CHECK(opts.get<CfoWithMetavariables, Metavariables>().expected_);
+  }
+  {
+    INFO("Aggregate-initialization");
+    Options::Parser<tmpl::list<CfoAggregate>> opts("");
+    opts.parse(input_file_text_aggregate);
+    CHECK(opts.get<CfoAggregate>().str == "MetaString");
   }
 }
 


### PR DESCRIPTION
## Proposed changes

This allows constructing simple types without defining constructors.

A use case is #2964.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
