### PR TITLE
Include factor of dimension in CFL calculation

### DIFF
--- a/src/Time/StepChoosers/Cfl.hpp
+++ b/src/Time/StepChoosers/Cfl.hpp
@@ -83,7 +83,7 @@ class Cfl : public StepChooser<StepChooserRegistrars> {
     const double time_stepper_stability_factor = time_stepper.stable_step();
 
     const double step_size = safety_factor_ * time_stepper_stability_factor *
-                             minimum_grid_spacing / speed;
+                             minimum_grid_spacing / (speed * Dim);
     // Reject the step if the CFL condition is violated.
     return std::make_pair(step_size, last_step_magnitude <= step_size);
   }


### PR DESCRIPTION
## Proposed changes

It is my understanding that the CFL step size estimate should be proportional to 1/Dim, and that such factor is not included in either the characteristic speed calculation or the grid spacing calculation, so I think it should be present in the CFL calculation itself.

I do invite corrections, though, if my understanding is mistaken.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
The `SafetyFactor` option to the `Cfl` step chooser has changed its meaning.  To maintain the same behavior, multiply the value in the input file by the spatial dimension of the evolution.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
