### PR TITLE
Factor out TensorExpression Product stress test into own own test file

### DIFF
--- a/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
+++ b/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   Test_Evaluate.cpp
   Test_MixedOperations.cpp
   Test_Product.cpp
+  Test_ProductHighRankIntermediate.cpp
   Test_SquareRoot.cpp
   Test_TensorAsExpression.cpp
   Test_TensorExpressions.cpp

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Product.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Product.cpp
@@ -1128,76 +1128,6 @@ void test_three_term_inner_outer_product(
   }
 }
 
-// \brief Test the product of three rank 4 tensors involving both inner and
-// outer products of indices is correctly evaluated
-//
-// \details
-// The product case tested is:
-// - \f$L^{c}{}_{dkl} = R_{ijb}{}^{a} * (S_{da}{}^{BC} * T^{j}{}_{kl}{}^{i})\f$
-//
-// This is intended as a stress test for TensorContract and OuterProduct.
-//
-// \tparam DataType the type of data being stored in the product operands
-template <typename DataType>
-void test_high_rank_intermediate(const DataType& used_for_size) noexcept {
-  using frame = Frame::Inertial;
-  using A_index = SpacetimeIndex<3, UpLo::Up, frame>;
-  using a_index = SpacetimeIndex<3, UpLo::Lo, frame>;
-  using B_index = SpacetimeIndex<3, UpLo::Up, frame>;
-  using b_index = SpacetimeIndex<3, UpLo::Lo, frame>;
-  using C_index = B_index;
-  using d_index = SpacetimeIndex<3, UpLo::Lo, frame>;
-  using I_index = SpatialIndex<3, UpLo::Up, frame>;
-  using i_index = SpatialIndex<3, UpLo::Lo, frame>;
-  using J_index = SpatialIndex<3, UpLo::Up, frame>;
-  using j_index = i_index;
-  using k_index = SpatialIndex<3, UpLo::Lo, frame>;
-  using l_index = SpatialIndex<3, UpLo::Lo, frame>;
-
-  Tensor<DataType, Symmetry<3, 3, 2, 1>,
-         index_list<i_index, j_index, b_index, A_index>>
-      R(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&R));
-  Tensor<DataType, Symmetry<3, 2, 1, 1>,
-         index_list<d_index, a_index, B_index, C_index>>
-      S(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&S));
-  Tensor<DataType, Symmetry<4, 3, 2, 1>,
-         index_list<J_index, k_index, l_index, I_index>>
-      T(used_for_size);
-  assign_unique_values_to_tensor(make_not_null(&T));
-
-  // \f$L^{c}{}_{dkl} = R_{ijb}{}^{a} * (S_{da}{}^{BC} * T^{j}{}_{kl}{}^{i})\f$
-  const Tensor<DataType, Symmetry<4, 3, 2, 1>,
-               index_list<C_index, d_index, k_index, l_index>>
-      actual_result = TensorExpressions::evaluate<ti_C, ti_d, ti_k, ti_l>(
-          R(ti_i, ti_j, ti_b, ti_A) *
-          (S(ti_d, ti_a, ti_B, ti_C) * T(ti_J, ti_k, ti_l, ti_I)));
-
-  for (size_t c = 0; c < C_index::dim; c++) {
-    for (size_t d = 0; d < d_index::dim; d++) {
-      for (size_t k = 0; k < k_index::dim; k++) {
-        for (size_t l = 0; l < l_index::dim; l++) {
-          DataType expected_product_component =
-              make_with_value<DataType>(used_for_size, 0.0);
-          for (size_t i = 0; i < i_index::dim; i++) {
-            for (size_t j = 0; j < j_index::dim; j++) {
-              for (size_t b = 0; b < b_index::dim; b++) {
-                for (size_t a = 0; a < a_index::dim; a++) {
-                  expected_product_component +=
-                      R.get(i, j, b, a) * S.get(d, a, b, c) * T.get(j, k, l, i);
-                }
-              }
-            }
-          }
-          CHECK_ITERABLE_APPROX(actual_result.get(c, d, k, l),
-                                expected_product_component);
-        }
-      }
-    }
-  }
-}
-
 template <typename DataType>
 void test_products(const DataType& used_for_size) noexcept {
   // Test evaluation of outer products
@@ -1214,7 +1144,6 @@ void test_products(const DataType& used_for_size) noexcept {
   // Test evaluation of expressions involving both inner and outer products
   test_two_term_inner_outer_product(used_for_size);
   test_three_term_inner_outer_product(used_for_size);
-  test_high_rank_intermediate(used_for_size);
 }
 }  // namespace
 

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_ProductHighRankIntermediate.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_ProductHighRankIntermediate.cpp
@@ -1,0 +1,113 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <iterator>
+#include <numeric>
+
+#include "DataStructures/Tensor/Expressions/Evaluate.hpp"
+#include "DataStructures/Tensor/Expressions/Product.hpp"
+#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace {
+template <typename... Ts>
+void assign_unique_values_to_tensor(
+    gsl::not_null<Tensor<double, Ts...>*> tensor) noexcept {
+  std::iota(tensor->begin(), tensor->end(), 0.0);
+}
+
+template <typename... Ts>
+void assign_unique_values_to_tensor(
+    gsl::not_null<Tensor<DataVector, Ts...>*> tensor) noexcept {
+  double value = 0.0;
+  for (auto index_it = tensor->begin(); index_it != tensor->end(); index_it++) {
+    for (auto vector_it = index_it->begin(); vector_it != index_it->end();
+         vector_it++) {
+      *vector_it = value;
+      value += 1.0;
+    }
+  }
+}
+
+// \brief Test the product of three rank 4 tensors involving both inner and
+// outer products of indices is correctly evaluated
+//
+// \details
+// The product case tested is:
+// - \f$L^{c}{}_{dkl} = R_{ijb}{}^{a} * (S_{da}{}^{BC} * T^{j}{}_{kl}{}^{i})\f$
+//
+// This is intended as a stress test for TensorContract and OuterProduct.
+//
+// \tparam DataType the type of data being stored in the product operands
+template <typename DataType>
+void test_high_rank_intermediate(const DataType& used_for_size) noexcept {
+  using frame = Frame::Inertial;
+  using A_index = SpacetimeIndex<3, UpLo::Up, frame>;
+  using a_index = SpacetimeIndex<3, UpLo::Lo, frame>;
+  using B_index = SpacetimeIndex<3, UpLo::Up, frame>;
+  using b_index = SpacetimeIndex<3, UpLo::Lo, frame>;
+  using C_index = B_index;
+  using d_index = SpacetimeIndex<3, UpLo::Lo, frame>;
+  using I_index = SpatialIndex<3, UpLo::Up, frame>;
+  using i_index = SpatialIndex<3, UpLo::Lo, frame>;
+  using J_index = SpatialIndex<3, UpLo::Up, frame>;
+  using j_index = i_index;
+  using k_index = SpatialIndex<3, UpLo::Lo, frame>;
+  using l_index = SpatialIndex<3, UpLo::Lo, frame>;
+
+  Tensor<DataType, Symmetry<3, 3, 2, 1>,
+         index_list<i_index, j_index, b_index, A_index>>
+      R(used_for_size);
+  assign_unique_values_to_tensor(make_not_null(&R));
+  Tensor<DataType, Symmetry<3, 2, 1, 1>,
+         index_list<d_index, a_index, B_index, C_index>>
+      S(used_for_size);
+  assign_unique_values_to_tensor(make_not_null(&S));
+  Tensor<DataType, Symmetry<4, 3, 2, 1>,
+         index_list<J_index, k_index, l_index, I_index>>
+      T(used_for_size);
+  assign_unique_values_to_tensor(make_not_null(&T));
+
+  // \f$L^{c}{}_{dkl} = R_{ijb}{}^{a} * (S_{da}{}^{BC} * T^{j}{}_{kl}{}^{i})\f$
+  const Tensor<DataType, Symmetry<4, 3, 2, 1>,
+               index_list<C_index, d_index, k_index, l_index>>
+      actual_result = TensorExpressions::evaluate<ti_C, ti_d, ti_k, ti_l>(
+          R(ti_i, ti_j, ti_b, ti_A) *
+          (S(ti_d, ti_a, ti_B, ti_C) * T(ti_J, ti_k, ti_l, ti_I)));
+
+  for (size_t c = 0; c < C_index::dim; c++) {
+    for (size_t d = 0; d < d_index::dim; d++) {
+      for (size_t k = 0; k < k_index::dim; k++) {
+        for (size_t l = 0; l < l_index::dim; l++) {
+          DataType expected_product_component =
+              make_with_value<DataType>(used_for_size, 0.0);
+          for (size_t i = 0; i < i_index::dim; i++) {
+            for (size_t j = 0; j < j_index::dim; j++) {
+              for (size_t b = 0; b < b_index::dim; b++) {
+                for (size_t a = 0; a < a_index::dim; a++) {
+                  expected_product_component +=
+                      R.get(i, j, b, a) * S.get(d, a, b, c) * T.get(j, k, l, i);
+                }
+              }
+            }
+          }
+          CHECK_ITERABLE_APPROX(actual_result.get(c, d, k, l),
+                                expected_product_component);
+        }
+      }
+    }
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.DataStructures.Tensor.Expression.ProductHighRankIntermediate",
+    "[DataStructures][Unit]") {
+  test_high_rank_intermediate(std::numeric_limits<double>::signaling_NaN());
+  test_high_rank_intermediate(
+      DataVector(5, std::numeric_limits<double>::signaling_NaN()));
+}


### PR DESCRIPTION
## Proposed changes

This PR factors out a `TensorExpression` product test case that is intended to be a stress test for `TensorContract` and `OuterProduct` into its own test file.

Recently, a couple CI gcc-8 builds are showing that compilation of the `Test_Expressions` target, which includes the unit tests for `TensorExpression`s, is being killed:
- [Example build output](https://github.com/sxs-collaboration/spectre/runs/2151735227?check_suite_focus=true)
- [Another example build output](https://github.com/sxs-collaboration/spectre/pull/3006/checks?check_run_id=2144529994)

One believed possible cause of this is that the test case being factored out of `Test_Product.cpp` may be overwhelming the CI build. Evidence that suggests that this test case may be the cause of the build compilation being killed is that, when compiling this test case's expression locally with gcc-7 (gcc version on CSUF's ocean), the variable assignment tracking limit is reached and gcc retries compiling without `-fvar-tracking-assignments` to successfully compile.

The underlying cause of this limit being reached still needs to be investigated, identified, and addressed, but this PR is meant to reduce the overall memory usage and time for compiling `Test_Product.cpp` by factoring out this hefty test case into its own `cpp` file that is compiled individually to see if that temporarily fixes the CI builds in question.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
