### PR TITLE
Add boundary conditions for RelativisticEuler

### DIFF
--- a/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/BoundaryCondition.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/BoundaryCondition.hpp
@@ -16,7 +16,7 @@ class DirichletAnalytic;
 }  // namespace NewtonianEuler::BoundaryConditions
 /// \endcond
 
-/// \brief Boundary conditions for the scalar wave system
+/// \brief Boundary conditions for the Newtonian Euler hydrodynamics system
 namespace NewtonianEuler::BoundaryConditions {
 /// \brief The base class off of which all boundary conditions must inherit
 template <size_t Dim>

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/BoundaryCondition.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/BoundaryCondition.cpp
@@ -1,0 +1,31 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/BoundaryCondition.hpp"
+
+#include <pup.h>
+
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+/// \cond
+namespace RelativisticEuler::Valencia::BoundaryConditions {
+template <size_t Dim>
+BoundaryCondition<Dim>::BoundaryCondition(CkMigrateMessage* const msg) noexcept
+    : domain::BoundaryConditions::BoundaryCondition(msg) {}
+
+template <size_t Dim>
+void BoundaryCondition<Dim>::pup(PUP::er& p) {
+  domain::BoundaryConditions::BoundaryCondition::pup(p);
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data) template class BoundaryCondition<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM
+}  // namespace RelativisticEuler::Valencia::BoundaryConditions
+/// \endcond

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/BoundaryCondition.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/BoundaryCondition.hpp
@@ -1,0 +1,36 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pup.h>
+
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace RelativisticEuler::Valencia::BoundaryConditions {
+template <size_t Dim>
+class DirichletAnalytic;
+}  // namespace RelativisticEuler::Valencia::BoundaryConditions
+/// \endcond
+
+/// \brief Boundary conditions for the relativistic Euler system
+namespace RelativisticEuler::Valencia::BoundaryConditions {
+/// \brief The base class off of which all boundary conditions must inherit
+template <size_t Dim>
+class BoundaryCondition : public domain::BoundaryConditions::BoundaryCondition {
+ public:
+  using creatable_classes = tmpl::list<DirichletAnalytic<Dim>>;
+
+  BoundaryCondition() = default;
+  BoundaryCondition(BoundaryCondition&&) noexcept = default;
+  BoundaryCondition& operator=(BoundaryCondition&&) noexcept = default;
+  BoundaryCondition(const BoundaryCondition&) = default;
+  BoundaryCondition& operator=(const BoundaryCondition&) = default;
+  ~BoundaryCondition() override = default;
+  explicit BoundaryCondition(CkMigrateMessage* msg) noexcept;
+
+  void pup(PUP::er& p) override;
+};
+}  // namespace RelativisticEuler::Valencia::BoundaryConditions

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/BoundaryCondition.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/BoundaryCondition.hpp
@@ -6,6 +6,7 @@
 #include <pup.h>
 
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -21,7 +22,9 @@ namespace RelativisticEuler::Valencia::BoundaryConditions {
 template <size_t Dim>
 class BoundaryCondition : public domain::BoundaryConditions::BoundaryCondition {
  public:
-  using creatable_classes = tmpl::list<DirichletAnalytic<Dim>>;
+  using creatable_classes =
+      tmpl::list<DirichletAnalytic<Dim>,
+                 domain::BoundaryConditions::Periodic<BoundaryCondition<Dim>>>;
 
   BoundaryCondition() = default;
   BoundaryCondition(BoundaryCondition&&) noexcept = default;

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/CMakeLists.txt
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_sources(
+  Valencia
+  PRIVATE
+  BoundaryCondition.cpp
+  DirichletAnalytic.cpp
+  RegisterDerivedWithCharm.cpp
+  )
+
+spectre_target_headers(
+  Valencia
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  BoundaryCondition.hpp
+  DirichletAnalytic.hpp
+  Factory.hpp
+  RegisterDerivedWithCharm.hpp
+  )

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/DirichletAnalytic.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/DirichletAnalytic.cpp
@@ -1,0 +1,43 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/DirichletAnalytic.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+/// \cond
+namespace RelativisticEuler::Valencia::BoundaryConditions {
+template <size_t Dim>
+DirichletAnalytic<Dim>::DirichletAnalytic(CkMigrateMessage* const msg) noexcept
+    : BoundaryCondition<Dim>(msg) {}
+
+template <size_t Dim>
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+DirichletAnalytic<Dim>::get_clone() const noexcept {
+  return std::make_unique<DirichletAnalytic>(*this);
+}
+
+template <size_t Dim>
+void DirichletAnalytic<Dim>::pup(PUP::er& p) {
+  BoundaryCondition<Dim>::pup(p);
+}
+
+template <size_t Dim>
+// NOLINTNEXTLINE
+PUP::able::PUP_ID DirichletAnalytic<Dim>::my_PUP_ID = 0;
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data) template class DirichletAnalytic<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM
+}  // namespace RelativisticEuler::Valencia::BoundaryConditions
+/// \endcond

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/DirichletAnalytic.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/DirichletAnalytic.hpp
@@ -1,0 +1,168 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <pup.h>
+#include <string>
+#include <type_traits>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/RelativisticEuler/Valencia/ConservativeFromPrimitive.hpp"
+#include "Evolution/Systems/RelativisticEuler/Valencia/Fluxes.hpp"
+#include "Evolution/Systems/RelativisticEuler/Valencia/Tags.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/AnalyticData/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace domain::Tags {
+template <size_t Dim, typename Frame>
+struct Coordinates;
+}  // namespace domain::Tags
+/// \endcond
+
+namespace RelativisticEuler::Valencia::BoundaryConditions {
+/*!
+ * \brief Sets Dirichlet boundary conditions using the analytic solution or
+ * analytic data.
+ */
+template <size_t Dim>
+class DirichletAnalytic final : public BoundaryCondition<Dim> {
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help{
+      "DirichletAnalytic boundary conditions using either analytic solution or "
+      "analytic data."};
+  static std::string name() noexcept { return "DirichletAnalytic"; }
+
+  DirichletAnalytic() = default;
+  DirichletAnalytic(DirichletAnalytic&&) noexcept = default;
+  DirichletAnalytic& operator=(DirichletAnalytic&&) noexcept = default;
+  DirichletAnalytic(const DirichletAnalytic&) = default;
+  DirichletAnalytic& operator=(const DirichletAnalytic&) = default;
+  ~DirichletAnalytic() override = default;
+
+  explicit DirichletAnalytic(CkMigrateMessage* msg) noexcept;
+
+  WRAPPED_PUPable_decl_base_template(
+      domain::BoundaryConditions::BoundaryCondition, DirichletAnalytic);
+
+  auto get_clone() const noexcept -> std::unique_ptr<
+      domain::BoundaryConditions::BoundaryCondition> override;
+
+  static constexpr evolution::BoundaryConditions::Type bc_type =
+      evolution::BoundaryConditions::Type::Ghost;
+
+  void pup(PUP::er& p) override;
+
+  using dg_interior_evolved_variables_tags = tmpl::list<>;
+  using dg_interior_temporary_tags =
+      tmpl::list<domain::Tags::Coordinates<Dim, Frame::Inertial>>;
+  using dg_interior_primitive_variables_tags = tmpl::list<>;
+  using dg_gridless_tags =
+      tmpl::list<::Tags::Time, ::Tags::AnalyticSolutionOrData>;
+
+  template <typename AnalyticSolutionOrData>
+  std::optional<std::string> dg_ghost(
+      const gsl::not_null<Scalar<DataVector>*> tilde_d,
+      const gsl::not_null<Scalar<DataVector>*> tilde_tau,
+      const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> tilde_s,
+
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+          flux_tilde_d,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+          flux_tilde_tau,
+      const gsl::not_null<tnsr::Ij<DataVector, Dim, Frame::Inertial>*>
+          flux_tilde_s,
+
+      const gsl::not_null<Scalar<DataVector>*> lapse,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> shift,
+      const gsl::not_null<tnsr::ii<DataVector, Dim, Frame::Inertial>*>
+          spatial_metric,
+      const gsl::not_null<Scalar<DataVector>*> rest_mass_density,
+      const gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
+      const gsl::not_null<Scalar<DataVector>*> specific_enthalpy,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+          spatial_velocity,
+
+      const std::optional<
+          tnsr::I<DataVector, Dim, Frame::Inertial>>& /*face_mesh_velocity*/,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& /*normal_covector*/,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& /*normal_vector*/,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& coords,
+      const double time,
+      const AnalyticSolutionOrData& analytic_solution_or_data) const noexcept {
+    auto boundary_values = [&analytic_solution_or_data, &coords,
+                            &time]() noexcept {
+      if constexpr (std::is_base_of_v<MarkAsAnalyticSolution,
+                                      AnalyticSolutionOrData>) {
+        return analytic_solution_or_data.variables(
+            coords, time,
+            tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
+                       hydro::Tags::SpecificInternalEnergy<DataVector>,
+                       hydro::Tags::SpecificEnthalpy<DataVector>,
+                       hydro::Tags::Pressure<DataVector>,
+                       hydro::Tags::SpatialVelocity<DataVector, Dim>,
+                       hydro::Tags::LorentzFactor<DataVector>,
+                       gr::Tags::SqrtDetSpatialMetric<>, gr::Tags::Lapse<>,
+                       gr::Tags::Shift<Dim>, gr::Tags::SpatialMetric<Dim>>{});
+      } else {
+        (void)time;
+        return analytic_solution_or_data.variables(
+            coords,
+            tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
+                       hydro::Tags::SpecificInternalEnergy<DataVector>,
+                       hydro::Tags::SpecificEnthalpy<DataVector>,
+                       hydro::Tags::Pressure<DataVector>,
+                       hydro::Tags::SpatialVelocity<DataVector, Dim>,
+                       hydro::Tags::LorentzFactor<DataVector>,
+                       gr::Tags::SqrtDetSpatialMetric<>, gr::Tags::Lapse<>,
+                       gr::Tags::Shift<Dim>, gr::Tags::SpatialMetric<Dim>>{});
+      }
+    }();
+
+    *lapse = get<gr::Tags::Lapse<>>(boundary_values);
+    *shift = get<gr::Tags::Shift<Dim>>(boundary_values);
+    *spatial_metric = get<gr::Tags::SpatialMetric<Dim>>(boundary_values);
+    *rest_mass_density =
+        get<hydro::Tags::RestMassDensity<DataVector>>(boundary_values);
+    *specific_internal_energy =
+        get<hydro::Tags::SpecificInternalEnergy<DataVector>>(boundary_values);
+    *specific_enthalpy =
+        get<hydro::Tags::SpecificEnthalpy<DataVector>>(boundary_values);
+    *spatial_velocity =
+        get<hydro::Tags::SpatialVelocity<DataVector, Dim>>(boundary_values);
+
+    const auto& pressure =
+        get<hydro::Tags::Pressure<DataVector>>(boundary_values);
+    const auto& lorentz_factor =
+        get<hydro::Tags::LorentzFactor<DataVector>>(boundary_values);
+    const auto& sqrt_det_spatial_metric =
+        get<gr::Tags::SqrtDetSpatialMetric<>>(boundary_values);
+
+    ConservativeFromPrimitive<Dim>::apply(
+        tilde_d, tilde_tau, tilde_s, *rest_mass_density,
+        *specific_internal_energy, *specific_enthalpy, pressure,
+        *spatial_velocity, lorentz_factor, sqrt_det_spatial_metric,
+        *spatial_metric);
+    ComputeFluxes<Dim>::apply(flux_tilde_d, flux_tilde_tau, flux_tilde_s,
+                              *tilde_d, *tilde_tau, *tilde_s, *lapse, *shift,
+                              sqrt_det_spatial_metric, pressure,
+                              *spatial_velocity);
+
+    return {};
+  }
+};
+}  // namespace RelativisticEuler::Valencia::BoundaryConditions

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/Factory.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/Factory.hpp
@@ -1,0 +1,7 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/DirichletAnalytic.hpp"

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/RegisterDerivedWithCharm.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/RegisterDerivedWithCharm.cpp
@@ -1,0 +1,19 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/RegisterDerivedWithCharm.hpp"
+
+#include "Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/DirichletAnalytic.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+
+namespace RelativisticEuler::Valencia::BoundaryConditions {
+void register_derived_with_charm() noexcept {
+  Parallel::register_classes_in_list<
+      typename BoundaryCondition<1>::creatable_classes>();
+  Parallel::register_classes_in_list<
+      typename BoundaryCondition<2>::creatable_classes>();
+  Parallel::register_classes_in_list<
+      typename BoundaryCondition<3>::creatable_classes>();
+}
+}  // namespace RelativisticEuler::Valencia::BoundaryConditions

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/RegisterDerivedWithCharm.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/RegisterDerivedWithCharm.hpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace RelativisticEuler::Valencia::BoundaryConditions {
+void register_derived_with_charm() noexcept;
+}  // namespace RelativisticEuler::Valencia::BoundaryConditions

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/CMakeLists.txt
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/CMakeLists.txt
@@ -46,4 +46,5 @@ target_link_libraries(
   VariableFixing
   )
 
+add_subdirectory(BoundaryConditions)
 add_subdirectory(BoundaryCorrections)

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/DirichletAnalytic.py
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/DirichletAnalytic.py
@@ -1,0 +1,222 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+import PointwiseFunctions.AnalyticSolutions.Hydro.SmoothFlow as hydro
+import Evolution.Systems.RelativisticEuler.Valencia.Fluxes as flux
+
+
+def soln_error(face_mesh_velocity, outward_directed_normal_covector,
+               outward_directed_normal_vector, coords, time, dim):
+    return None
+
+
+_soln_pressure = 1.0
+_soln_adiabatic_index = 5.0 / 3.0
+_soln_perturbation_size = 0.2
+
+
+def _soln_mean_velocity(dim):
+    mean_v = []
+    for i in range(0, dim):
+        mean_v.append(0.9 - i * 0.5)
+    return np.asarray(mean_v)
+
+
+def _soln_wave_vector(dim):
+    wave_vector = []
+    for i in range(0, dim):
+        wave_vector.append(0.1 + i)
+    return np.asarray(wave_vector)
+
+
+def soln_lapse(face_mesh_velocity, outward_directed_normal_covector,
+               outward_directed_normal_vector, coords, time, dim):
+    return 1.0
+
+
+def soln_shift(face_mesh_velocity, outward_directed_normal_covector,
+               outward_directed_normal_vector, coords, time, dim):
+    return np.zeros(dim)
+
+
+def soln_spatial_metric(face_mesh_velocity, outward_directed_normal_covector,
+                        outward_directed_normal_vector, coords, time, dim):
+    return np.identity(dim)
+
+
+def soln_rest_mass_density(face_mesh_velocity,
+                           outward_directed_normal_covector,
+                           outward_directed_normal_vector, coords, time, dim):
+    return hydro.rest_mass_density(coords, time, _soln_mean_velocity(dim),
+                                   _soln_wave_vector(dim), _soln_pressure,
+                                   _soln_adiabatic_index,
+                                   _soln_perturbation_size)
+
+
+def soln_specific_internal_energy(face_mesh_velocity,
+                                  outward_directed_normal_covector,
+                                  outward_directed_normal_vector, coords, time,
+                                  dim):
+    return hydro.specific_internal_energy(coords, time,
+                                          _soln_mean_velocity(dim),
+                                          _soln_wave_vector(dim),
+                                          _soln_pressure,
+                                          _soln_adiabatic_index,
+                                          _soln_perturbation_size)
+
+
+def soln_specific_enthalpy(face_mesh_velocity,
+                           outward_directed_normal_covector,
+                           outward_directed_normal_vector, coords, time, dim):
+    return hydro.specific_enthalpy_relativistic(coords, time,
+                                                _soln_mean_velocity(dim),
+                                                _soln_wave_vector(dim),
+                                                _soln_pressure,
+                                                _soln_adiabatic_index,
+                                                _soln_perturbation_size)
+
+
+def soln_spatial_velocity(face_mesh_velocity, outward_directed_normal_covector,
+                          outward_directed_normal_vector, coords, time, dim):
+    return hydro.spatial_velocity(coords, time, _soln_mean_velocity(dim),
+                                  _soln_wave_vector(dim), _soln_pressure,
+                                  _soln_adiabatic_index,
+                                  _soln_perturbation_size)
+
+
+def soln_tilde_d(face_mesh_velocity, outward_directed_normal_covector,
+                 outward_directed_normal_vector, coords, time, dim):
+    rho = soln_rest_mass_density(face_mesh_velocity,
+                                 outward_directed_normal_covector,
+                                 outward_directed_normal_vector, coords, time,
+                                 dim)
+    W = hydro.lorentz_factor(coords, time, _soln_mean_velocity(dim),
+                             _soln_wave_vector(dim), _soln_pressure,
+                             _soln_adiabatic_index, _soln_perturbation_size)
+    # for smooth flow, sqrt_det_spatial_metric = 1
+    return rho * W
+
+
+def soln_tilde_tau(face_mesh_velocity, outward_directed_normal_covector,
+                   outward_directed_normal_vector, coords, time, dim):
+    rho = soln_rest_mass_density(face_mesh_velocity,
+                                 outward_directed_normal_covector,
+                                 outward_directed_normal_vector, coords, time,
+                                 dim)
+    eps = soln_specific_internal_energy(face_mesh_velocity,
+                                        outward_directed_normal_covector,
+                                        outward_directed_normal_vector, coords,
+                                        time, dim)
+    v = soln_spatial_velocity(face_mesh_velocity,
+                              outward_directed_normal_covector,
+                              outward_directed_normal_vector, coords, time,
+                              dim)
+    v2 = v.dot(v)
+    W = hydro.lorentz_factor(coords, time, _soln_mean_velocity(dim),
+                             _soln_wave_vector(dim), _soln_pressure,
+                             _soln_adiabatic_index, _soln_perturbation_size)
+    # for smooth flow, sqrt_det_spatial_metric = 1
+    return W**2 * (rho * (eps + v2 * W / (W + 1.0)) + _soln_pressure * v2)
+
+
+def soln_tilde_s(face_mesh_velocity, outward_directed_normal_covector,
+                 outward_directed_normal_vector, coords, time, dim):
+    tilde_d = soln_tilde_d(face_mesh_velocity,
+                           outward_directed_normal_covector,
+                           outward_directed_normal_vector, coords, time, dim)
+    W = hydro.lorentz_factor(coords, time, _soln_mean_velocity(dim),
+                             _soln_wave_vector(dim), _soln_pressure,
+                             _soln_adiabatic_index, _soln_perturbation_size)
+    h = soln_specific_enthalpy(face_mesh_velocity,
+                               outward_directed_normal_covector,
+                               outward_directed_normal_vector, coords, time,
+                               dim)
+    # for smooth flow, metric = identity ==> v_lower = v_upper
+    v_lower = soln_spatial_velocity(face_mesh_velocity,
+                                    outward_directed_normal_covector,
+                                    outward_directed_normal_vector, coords,
+                                    time, dim)
+    return tilde_d * W * h * v_lower
+
+
+def soln_flux_tilde_d(face_mesh_velocity, outward_directed_normal_covector,
+                      outward_directed_normal_vector, coords, time, dim):
+    tilde_d = soln_tilde_d(face_mesh_velocity,
+                           outward_directed_normal_covector,
+                           outward_directed_normal_vector, coords, time, dim)
+    tilde_tau = soln_tilde_tau(face_mesh_velocity,
+                               outward_directed_normal_covector,
+                               outward_directed_normal_vector, coords, time,
+                               dim)
+    tilde_s = soln_tilde_s(face_mesh_velocity,
+                           outward_directed_normal_covector,
+                           outward_directed_normal_vector, coords, time, dim)
+    lapse = soln_lapse(face_mesh_velocity, outward_directed_normal_covector,
+                       outward_directed_normal_vector, coords, time, dim)
+    shift = soln_shift(face_mesh_velocity, outward_directed_normal_covector,
+                       outward_directed_normal_vector, coords, time, dim)
+    sqrt_det_spatial_metric = 1.0
+    pressure = _soln_pressure
+    spatial_velocity = soln_spatial_velocity(face_mesh_velocity,
+                                             outward_directed_normal_covector,
+                                             outward_directed_normal_vector,
+                                             coords, time, dim)
+    return flux.tilde_d_flux(tilde_d, tilde_tau, tilde_s, lapse, shift,
+                             sqrt_det_spatial_metric, pressure,
+                             spatial_velocity)
+
+
+def soln_flux_tilde_tau(face_mesh_velocity, outward_directed_normal_covector,
+                        outward_directed_normal_vector, coords, time, dim):
+    tilde_d = soln_tilde_d(face_mesh_velocity,
+                           outward_directed_normal_covector,
+                           outward_directed_normal_vector, coords, time, dim)
+    tilde_tau = soln_tilde_tau(face_mesh_velocity,
+                               outward_directed_normal_covector,
+                               outward_directed_normal_vector, coords, time,
+                               dim)
+    tilde_s = soln_tilde_s(face_mesh_velocity,
+                           outward_directed_normal_covector,
+                           outward_directed_normal_vector, coords, time, dim)
+    lapse = soln_lapse(face_mesh_velocity, outward_directed_normal_covector,
+                       outward_directed_normal_vector, coords, time, dim)
+    shift = soln_shift(face_mesh_velocity, outward_directed_normal_covector,
+                       outward_directed_normal_vector, coords, time, dim)
+    sqrt_det_spatial_metric = 1.0
+    pressure = _soln_pressure
+    spatial_velocity = soln_spatial_velocity(face_mesh_velocity,
+                                             outward_directed_normal_covector,
+                                             outward_directed_normal_vector,
+                                             coords, time, dim)
+    return flux.tilde_tau_flux(tilde_d, tilde_tau, tilde_s, lapse, shift,
+                               sqrt_det_spatial_metric, pressure,
+                               spatial_velocity)
+
+
+def soln_flux_tilde_s(face_mesh_velocity, outward_directed_normal_covector,
+                      outward_directed_normal_vector, coords, time, dim):
+    tilde_d = soln_tilde_d(face_mesh_velocity,
+                           outward_directed_normal_covector,
+                           outward_directed_normal_vector, coords, time, dim)
+    tilde_tau = soln_tilde_tau(face_mesh_velocity,
+                               outward_directed_normal_covector,
+                               outward_directed_normal_vector, coords, time,
+                               dim)
+    tilde_s = soln_tilde_s(face_mesh_velocity,
+                           outward_directed_normal_covector,
+                           outward_directed_normal_vector, coords, time, dim)
+    lapse = soln_lapse(face_mesh_velocity, outward_directed_normal_covector,
+                       outward_directed_normal_vector, coords, time, dim)
+    shift = soln_shift(face_mesh_velocity, outward_directed_normal_covector,
+                       outward_directed_normal_vector, coords, time, dim)
+    sqrt_det_spatial_metric = 1.0
+    pressure = _soln_pressure
+    spatial_velocity = soln_spatial_velocity(face_mesh_velocity,
+                                             outward_directed_normal_covector,
+                                             outward_directed_normal_vector,
+                                             coords, time, dim)
+    return flux.tilde_s_flux(tilde_d, tilde_tau, tilde_s, lapse, shift,
+                             sqrt_det_spatial_metric, pressure,
+                             spatial_velocity)

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/Test_DirichletAnalytic.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/Test_DirichletAnalytic.cpp
@@ -1,0 +1,138 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Index.hpp"
+#include "Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/DirichletAnalytic.hpp"
+#include "Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/RelativisticEuler/Valencia/BoundaryCorrections/Rusanov.hpp"
+#include "Evolution/Systems/RelativisticEuler/Valencia/System.hpp"
+#include "Evolution/Systems/RelativisticEuler/Valencia/Tags.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace helpers = TestHelpers::evolution::dg;
+
+namespace {
+template <size_t Dim>
+struct ConvertSmoothFlow {
+  using unpacked_container = int;
+  using packed_container = RelativisticEuler::Solutions::SmoothFlow<Dim>;
+  using packed_type = double;
+
+  static packed_container create_container() {
+    std::array<double, Dim> wave_vector{};
+    for (size_t i = 0; i < Dim; ++i) {
+      gsl::at(wave_vector, i) = 0.1 + i;
+    }
+    std::array<double, Dim> mean_velocity{};
+    for (size_t i = 0; i < Dim; ++i) {
+      gsl::at(mean_velocity, i) = 0.9 - i * 0.5;
+    }
+    const double pressure = 1.0;
+    const double adiabatic_index = 5.0 / 3.0;
+    const double perturbation_size = 0.2;
+    return {mean_velocity, wave_vector, pressure, adiabatic_index,
+            perturbation_size};
+  }
+
+  static inline unpacked_container unpack(
+      const packed_container& /*packed*/,
+      const size_t /*grid_point_index*/) noexcept {
+    // No way of getting the args from the boundary condition.
+    return Dim;
+  }
+
+  static inline void pack(const gsl::not_null<packed_container*> packed,
+                          const unpacked_container /*unpacked*/,
+                          const size_t /*grid_point_index*/) {
+    *packed = create_container();
+  }
+
+  static inline size_t get_size(const packed_container& /*packed*/) noexcept {
+    return 1;
+  }
+};
+
+template <size_t Dim>
+void test() {
+  CAPTURE(Dim);
+  MAKE_GENERATOR(gen);
+  const auto box_analytic_soln = db::create<db::AddSimpleTags<
+      Tags::Time,
+      Tags::AnalyticSolution<RelativisticEuler::Solutions::SmoothFlow<Dim>>>>(
+      0.5, ConvertSmoothFlow<Dim>::create_container());
+
+  helpers::test_boundary_condition_with_python<
+      RelativisticEuler::Valencia::BoundaryConditions::DirichletAnalytic<Dim>,
+      RelativisticEuler::Valencia::BoundaryConditions::BoundaryCondition<Dim>,
+      RelativisticEuler::Valencia::System<
+          Dim, typename RelativisticEuler::Solutions::SmoothFlow<
+                   Dim>::equation_of_state_type>,
+      tmpl::list<
+          RelativisticEuler::Valencia::BoundaryCorrections::Rusanov<Dim>>,
+      tmpl::list<ConvertSmoothFlow<Dim>>>(
+      make_not_null(&gen),
+      "Evolution.Systems.RelativisticEuler.Valencia.BoundaryConditions."
+      "DirichletAnalytic",
+      tuples::TaggedTuple<
+          helpers::Tags::PythonFunctionForErrorMessage<>,
+          helpers::Tags::PythonFunctionName<
+              RelativisticEuler::Valencia::Tags::TildeD>,
+          helpers::Tags::PythonFunctionName<
+              RelativisticEuler::Valencia::Tags::TildeTau>,
+          helpers::Tags::PythonFunctionName<
+              RelativisticEuler::Valencia::Tags::TildeS<Dim>>,
+
+          helpers::Tags::PythonFunctionName<
+              ::Tags::Flux<RelativisticEuler::Valencia::Tags::TildeD,
+                           tmpl::size_t<Dim>, Frame::Inertial>>,
+          helpers::Tags::PythonFunctionName<
+              ::Tags::Flux<RelativisticEuler::Valencia::Tags::TildeTau,
+                           tmpl::size_t<Dim>, Frame::Inertial>>,
+          helpers::Tags::PythonFunctionName<
+              ::Tags::Flux<RelativisticEuler::Valencia::Tags::TildeS<Dim>,
+                           tmpl::size_t<Dim>, Frame::Inertial>>,
+
+          helpers::Tags::PythonFunctionName<gr::Tags::Lapse<>>,
+          helpers::Tags::PythonFunctionName<gr::Tags::Shift<Dim>>,
+          helpers::Tags::PythonFunctionName<gr::Tags::SpatialMetric<Dim>>,
+          helpers::Tags::PythonFunctionName<
+              hydro::Tags::RestMassDensity<DataVector>>,
+          helpers::Tags::PythonFunctionName<
+              hydro::Tags::SpecificInternalEnergy<DataVector>>,
+          helpers::Tags::PythonFunctionName<
+              hydro::Tags::SpecificEnthalpy<DataVector>>,
+          helpers::Tags::PythonFunctionName<
+              hydro::Tags::SpatialVelocity<DataVector, Dim>>>{
+          "soln_error", "soln_tilde_d", "soln_tilde_tau", "soln_tilde_s",
+          "soln_flux_tilde_d", "soln_flux_tilde_tau", "soln_flux_tilde_s",
+          "soln_lapse", "soln_shift", "soln_spatial_metric",
+          "soln_rest_mass_density", "soln_specific_internal_energy",
+          "soln_specific_enthalpy", "soln_spatial_velocity"},
+      "DirichletAnalytic:\n", Index<Dim - 1>{Dim == 1 ? 1 : 5},
+      box_analytic_soln, tuples::TaggedTuple<>{});
+
+  // Note: Currently there is no analytic data for the
+  // RelativisticEuler::Valencia system. When that is implemented, a test should
+  // be added.
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.RelativisticEuler.Valencia.BoundaryConditions.DirichletAnalytic",
+    "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{""};
+  test<1>();
+  test<2>();
+  test<3>();
+}

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/Test_Periodic.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/Test_Periodic.cpp
@@ -1,0 +1,34 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "Domain/BoundaryConditions/Periodic.hpp"
+#include "Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/Factory.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp"
+
+namespace helpers = TestHelpers::evolution::dg;
+
+namespace {
+template <size_t Dim>
+void test() {
+  CAPTURE(Dim);
+  helpers::test_periodic_condition<
+      domain::BoundaryConditions::Periodic<
+          RelativisticEuler::Valencia::BoundaryConditions::BoundaryCondition<
+              Dim>>,
+      RelativisticEuler::Valencia::BoundaryConditions::BoundaryCondition<Dim>>(
+      "Periodic:\n");
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.RelativisticEuler.Valencia.BoundaryConditions.Periodic",
+                  "[Unit][Evolution]") {
+  test<1>();
+  test<2>();
+  test<3>();
+}

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/__init__.py
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/__init__.py
@@ -1,0 +1,2 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_Valencia")
 
 set(LIBRARY_SOURCES
   BoundaryConditions/Test_DirichletAnalytic.cpp
+  BoundaryConditions/Test_Periodic.cpp
   BoundaryCorrections/Test_Rusanov.cpp
   Test_Characteristics.cpp
   Test_ConservativeFromPrimitive.cpp

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_Valencia")
 
 set(LIBRARY_SOURCES
+  BoundaryConditions/Test_DirichletAnalytic.cpp
   BoundaryCorrections/Test_Rusanov.cpp
   Test_Characteristics.cpp
   Test_ConservativeFromPrimitive.cpp


### PR DESCRIPTION
## Proposed changes

Adds `DirichletAnalytic` and `Periodic` boundary conditions for `RelativisticEuler::Valencia`

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
