### PR TITLE
Fix random unit test failures in computation of covD(ex curv)

### DIFF
--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
@@ -642,7 +642,7 @@ void test_cov_deriv_extrinsic_curvature(
           &::GeneralizedHarmonic::covariant_deriv_of_extrinsic_curvature<
               SpatialDim, Frame, DataType>),
       "GeneralRelativity.ComputeGhQuantities",
-      "covariant_deriv_extrinsic_curvture", {{{-10., 10.}}}, used_for_size);
+      "covariant_deriv_extrinsic_curvture", {{{-1., 1.}}}, used_for_size);
 }
 
 }  // namespace


### PR DESCRIPTION
## Proposed changes

This should fix failures reported in #3011 . Tensor magnitudes were getting large enough to cause disparities at the second last significant figure checked by the unit test.

Fix #3011 


### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
