### PR TITLE
Add error control step chooser

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -583,6 +583,15 @@
   primaryClass   = "gr-qc",
 }
 
+@book{Hairer1993,
+  address = {Berlin},
+  author = {Hairer, E. and N{\o}rsett, S.P. and Wanner, G.},
+  keywords = {imported},
+  publisher = {Springer},
+  title = {Solving Ordinary Differential Equations {I} Nonstiff problems},
+  year = 1993
+}
+
 @article{Handmer2014qha,
   author         = "Handmer, Casey J. and Szilagyi, B.",
   title          = "{Spectral Characteristic Evolution: A New Algorithm for

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -116,10 +116,9 @@ struct EvolutionMetavars {
   using limiter =
       Tags::Limiter<Limiters::Minmod<1, system::variables_tag::tags_list>>;
 
-  using step_choosers_common =
-      tmpl::list<StepChoosers::Registrars::Cfl<volume_dim, Frame::Inertial>,
-                 StepChoosers::Registrars::Constant,
-                 StepChoosers::Registrars::Increase>;
+  using step_choosers_common = tmpl::list<
+      StepChoosers::Registrars::Cfl<volume_dim, Frame::Inertial, system>,
+      StepChoosers::Registrars::Constant, StepChoosers::Registrars::Increase>;
   using step_choosers_for_step_only =
       tmpl::list<StepChoosers::Registrars::PreventRapidIncrease>;
   using step_choosers_for_slab_only =

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -216,6 +216,8 @@ struct EvolutionMetavars {
               tmpl::list<evolution::Tags::AnalyticCompute<
                   1, initial_data_tag, analytic_solution_fields>>>,
           tmpl::list<>>,
+      Initialization::Actions::AddComputeTags<
+          StepChoosers::step_chooser_compute_tags<EvolutionMetavars>>,
       dg::Actions::InitializeMortars<boundary_scheme>,
       Initialization::Actions::DiscontinuousGalerkin<EvolutionMetavars>,
       Initialization::Actions::Minmod<1>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -157,10 +157,9 @@ struct EvolutionMetavars {
   using normal_dot_numerical_flux = Tags::NumericalFlux<
       GeneralizedHarmonic::UpwindPenaltyCorrection<volume_dim>>;
 
-  using step_choosers_common =
-      tmpl::list<StepChoosers::Registrars::Cfl<volume_dim, Frame::Inertial>,
-                 StepChoosers::Registrars::Constant,
-                 StepChoosers::Registrars::Increase>;
+  using step_choosers_common = tmpl::list<
+      StepChoosers::Registrars::Cfl<volume_dim, Frame::Inertial, system>,
+      StepChoosers::Registrars::Constant, StepChoosers::Registrars::Increase>;
   using step_choosers_for_step_only =
       tmpl::list<StepChoosers::Registrars::PreventRapidIncrease>;
   using step_choosers_for_slab_only =

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -327,9 +327,10 @@ struct EvolutionMetavars {
               GeneralizedHarmonic::CharacteristicFieldsCompute<volume_dim,
                                                                frame>>,
           true, true>,
-      Initialization::Actions::AddComputeTags<
-          tmpl::list<evolution::Tags::AnalyticCompute<
-              volume_dim, analytic_solution_tag, analytic_solution_fields>>>,
+      Initialization::Actions::AddComputeTags<tmpl::push_back<
+          StepChoosers::step_chooser_compute_tags<EvolutionMetavars>,
+          evolution::Tags::AnalyticCompute<volume_dim, analytic_solution_tag,
+                                           analytic_solution_fields>>>,
       dg::Actions::InitializeMortars<boundary_scheme, true>,
       Initialization::Actions::DiscontinuousGalerkin<EvolutionMetavars>,
       Initialization::Actions::RemoveOptionsAndTerminatePhase>;

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -165,10 +165,9 @@ struct EvolutionMetavars {
                                      grmhd::ValenciaDivClean::Tags::TildeS<>,
                                      grmhd::ValenciaDivClean::Tags::TildeB<>>>>;
 
-  using step_choosers_common =
-      tmpl::list<StepChoosers::Registrars::Cfl<volume_dim, Frame::Inertial>,
-                 StepChoosers::Registrars::Constant,
-                 StepChoosers::Registrars::Increase>;
+  using step_choosers_common = tmpl::list<
+      StepChoosers::Registrars::Cfl<volume_dim, Frame::Inertial, system>,
+      StepChoosers::Registrars::Constant, StepChoosers::Registrars::Increase>;
   using step_choosers_for_step_only =
       tmpl::list<StepChoosers::Registrars::PreventRapidIncrease>;
   using step_choosers_for_slab_only =

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -292,6 +292,8 @@ struct EvolutionMetavars {
               tmpl::list<evolution::Tags::AnalyticCompute<
                   3, initial_data_tag, analytic_variables_tags>>>,
           tmpl::list<>>,
+      Initialization::Actions::AddComputeTags<
+          StepChoosers::step_chooser_compute_tags<EvolutionMetavars>>,
       dg::Actions::InitializeMortars<boundary_scheme>,
       Initialization::Actions::DiscontinuousGalerkin<EvolutionMetavars>,
       Initialization::Actions::Minmod<3>,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -250,6 +250,8 @@ struct EvolutionMetavars {
               tmpl::list<evolution::Tags::AnalyticCompute<
                   Dim, initial_data_tag, analytic_variables_tags>>>,
           tmpl::list<>>,
+      Initialization::Actions::AddComputeTags<
+          StepChoosers::step_chooser_compute_tags<EvolutionMetavars>>,
       dg::Actions::InitializeMortars<boundary_scheme>,
       Initialization::Actions::DiscontinuousGalerkin<EvolutionMetavars>,
       Initialization::Actions::Minmod<Dim>,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -143,10 +143,9 @@ struct EvolutionMetavars {
                       NewtonianEuler::Tags::MomentumDensity<Dim>,
                       NewtonianEuler::Tags::EnergyDensity>>>;
 
-  using step_choosers_common =
-      tmpl::list<StepChoosers::Registrars::Cfl<volume_dim, Frame::Inertial>,
-                 StepChoosers::Registrars::Constant,
-                 StepChoosers::Registrars::Increase>;
+  using step_choosers_common = tmpl::list<
+      StepChoosers::Registrars::Cfl<volume_dim, Frame::Inertial, system>,
+      StepChoosers::Registrars::Constant, StepChoosers::Registrars::Increase>;
   using step_choosers_for_step_only =
       tmpl::list<StepChoosers::Registrars::PreventRapidIncrease>;
   using step_choosers_for_slab_only =

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -239,6 +239,8 @@ struct EvolutionMetavars {
               tmpl::list<evolution::Tags::AnalyticCompute<
                   3, initial_data_tag, analytic_variables_tags>>>,
           tmpl::list<>>,
+      Initialization::Actions::AddComputeTags<
+          StepChoosers::step_chooser_compute_tags<EvolutionMetavars>>,
       dg::Actions::InitializeMortars<boundary_scheme>,
       Initialization::Actions::DiscontinuousGalerkin<EvolutionMetavars>,
       Initialization::Actions::Minmod<3>,

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -129,10 +129,9 @@ struct EvolutionMetavars {
   using limiter = Tags::Limiter<
       Limiters::Minmod<3, typename system::variables_tag::tags_list>>;
 
-  using step_choosers_common =
-      tmpl::list<//StepChoosers::Registrars::Cfl<volume_dim, Frame::Inertial>,
-                 StepChoosers::Registrars::Constant,
-                 StepChoosers::Registrars::Increase>;
+  using step_choosers_common = tmpl::list<
+      // StepChoosers::Registrars::Cfl<volume_dim, Frame::Inertial, system>,
+      StepChoosers::Registrars::Constant, StepChoosers::Registrars::Increase>;
   using step_choosers_for_step_only =
       tmpl::list<StepChoosers::Registrars::PreventRapidIncrease>;
   using step_choosers_for_slab_only =

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -252,6 +252,8 @@ struct EvolutionMetavars {
               tmpl::list<evolution::Tags::AnalyticCompute<
                   Dim, initial_data_tag, analytic_variables_tags>>>,
           tmpl::list<>>,
+      Initialization::Actions::AddComputeTags<
+          StepChoosers::step_chooser_compute_tags<EvolutionMetavars>>,
       dg::Actions::InitializeMortars<boundary_scheme>,
       Initialization::Actions::DiscontinuousGalerkin<EvolutionMetavars>,
       Initialization::Actions::Minmod<Dim>,

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -139,10 +139,9 @@ struct EvolutionMetavars {
                       RelativisticEuler::Valencia::Tags::TildeTau,
                       RelativisticEuler::Valencia::Tags::TildeS<Dim>>>>;
 
-  using step_choosers_common =
-      tmpl::list<//StepChoosers::Registrars::Cfl<volume_dim, Frame::Inertial>,
-                 StepChoosers::Registrars::Constant,
-                 StepChoosers::Registrars::Increase>;
+  using step_choosers_common = tmpl::list<
+      // StepChoosers::Registrars::Cfl<volume_dim, Frame::Inertial, system>,
+      StepChoosers::Registrars::Constant, StepChoosers::Registrars::Increase>;
   using step_choosers_for_step_only =
       tmpl::list<StepChoosers::Registrars::PreventRapidIncrease>;
   using step_choosers_for_slab_only =

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -222,9 +222,10 @@ struct EvolutionMetavars {
           dg::Initialization::exterior_compute_tags<
               ScalarWave::Tags::CharacteristicFieldsCompute<volume_dim>>,
           true, true>,
-      Initialization::Actions::AddComputeTags<
-          tmpl::list<evolution::Tags::AnalyticCompute<
-              Dim, initial_data_tag, analytic_solution_fields>>>,
+      Initialization::Actions::AddComputeTags<tmpl::push_back<
+          StepChoosers::step_chooser_compute_tags<EvolutionMetavars>,
+          evolution::Tags::AnalyticCompute<Dim, initial_data_tag,
+                                           analytic_solution_fields>>>,
       dg::Actions::InitializeMortars<boundary_scheme>,
       Initialization::Actions::DiscontinuousGalerkin<EvolutionMetavars>,
       Initialization::Actions::RemoveOptionsAndTerminatePhase>;

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -127,11 +127,10 @@ struct EvolutionMetavars {
           db::add_tag_prefix<::Tags::dt, typename system::variables_tag>,
           normal_dot_numerical_flux, Tags::TimeStepId>>;
 
-  using step_choosers_common =
-      tmpl::list<StepChoosers::Registrars::ByBlock<volume_dim>,
-                 StepChoosers::Registrars::Cfl<volume_dim, Frame::Inertial>,
-                 StepChoosers::Registrars::Constant,
-                 StepChoosers::Registrars::Increase>;
+  using step_choosers_common = tmpl::list<
+      StepChoosers::Registrars::ByBlock<volume_dim>,
+      StepChoosers::Registrars::Cfl<volume_dim, Frame::Inertial, system>,
+      StepChoosers::Registrars::Constant, StepChoosers::Registrars::Increase>;
   using step_choosers_for_step_only =
       tmpl::list<StepChoosers::Registrars::PreventRapidIncrease>;
   using step_choosers_for_slab_only =

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -83,9 +83,10 @@ struct TimeAndTimeStep {
                  Tags::InitialSlabSize<Metavariables::local_time_stepping>>;
 
   using simple_tags =
-      tmpl::list<::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>,
-                 ::Tags::Time, ::Tags::TimeStep,
-                 ::Tags::Next<::Tags::TimeStep>>;
+      tmpl::push_back<StepChoosers::step_chooser_simple_tags<Metavariables>,
+                      ::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>,
+                      ::Tags::Time, ::Tags::TimeStep,
+                      ::Tags::Next<::Tags::TimeStep>>;
   using compute_tags = tmpl::list<::Tags::SubstepTimeCompute>;
 
   template <

--- a/src/Evolution/Systems/Burgers/Characteristics.cpp
+++ b/src/Evolution/Systems/Burgers/Characteristics.cpp
@@ -13,8 +13,7 @@
 // IWYU pragma: no_forward_declare Tensor
 
 /// \cond
-namespace Burgers {
-namespace Tags {
+namespace Burgers::Tags {
 void CharacteristicSpeedsCompute::function(
     const gsl::not_null<return_type*> result,
     const Scalar<DataVector>& u,
@@ -25,11 +24,11 @@ void CharacteristicSpeedsCompute::function(
          << get(u).size() << " and " << get<0>(normal).size());
   gsl::at(*result, 0) = get<0>(normal)[0] > 0.0 ? get(u) : -get(u);
 }
-}  // namespace Tags
 
-double ComputeLargestCharacteristicSpeed::apply(
+void ComputeLargestCharacteristicSpeed::function(
+    const gsl::not_null<double*> speed,
     const Scalar<DataVector>& u) noexcept {
-  return max(abs(get(u)));
+  *speed = max(abs(get(u)));
 }
-}  // namespace Burgers
+}  // namespace Burgers::Tags
 /// \endcond

--- a/src/Evolution/Systems/Burgers/Characteristics.hpp
+++ b/src/Evolution/Systems/Burgers/Characteristics.hpp
@@ -23,8 +23,7 @@ struct U;
 }  // namespace Burgers
 /// \endcond
 
-namespace Burgers {
-namespace Tags {
+namespace Burgers::Tags {
 /// Computes the characteristic speeds
 struct CharacteristicSpeedsCompute : CharacteristicSpeeds, db::ComputeTag {
   using base = CharacteristicSpeeds;
@@ -35,10 +34,17 @@ struct CharacteristicSpeedsCompute : CharacteristicSpeeds, db::ComputeTag {
                        const Scalar<DataVector>& u,
                        const tnsr::i<DataVector, 1>& normal) noexcept;
 };
-}  // namespace Tags
 
-struct ComputeLargestCharacteristicSpeed {
-  using argument_tags = tmpl::list<Tags::U>;
-  static double apply(const Scalar<DataVector>& u) noexcept;
+struct LargestCharacteristicSpeed : db::SimpleTag {
+  using type = double;
 };
-}  // namespace Burgers
+
+struct ComputeLargestCharacteristicSpeed : LargestCharacteristicSpeed,
+                                           db::ComputeTag {
+  using argument_tags = tmpl::list<Tags::U>;
+  using return_type = double;
+  using base = LargestCharacteristicSpeed;
+  static void function(const gsl::not_null<double*> speed,
+                       const Scalar<DataVector>& u) noexcept;
+};
+}  // namespace Burgers::Tags

--- a/src/Evolution/Systems/Burgers/System.hpp
+++ b/src/Evolution/Systems/Burgers/System.hpp
@@ -34,7 +34,7 @@ struct System {
   using volume_fluxes = Fluxes;
 
   using compute_largest_characteristic_speed =
-      ComputeLargestCharacteristicSpeed;
+      Tags::ComputeLargestCharacteristicSpeed;
 
   using char_speeds_compute_tag = Tags::CharacteristicSpeedsCompute;
   using char_speeds_tag = Tags::CharacteristicSpeeds;

--- a/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.cpp
@@ -175,13 +175,14 @@ evolved_fields_from_characteristic_fields(
 }
 
 template <size_t Dim, typename Frame>
-double ComputeLargestCharacteristicSpeed<Dim, Frame>::apply(
+void Tags::ComputeLargestCharacteristicSpeed<Dim, Frame>::function(
+    const gsl::not_null<double*> speed,
     const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, Dim, Frame>& shift,
     const tnsr::ii<DataVector, Dim, Frame>& spatial_metric) noexcept {
   const auto shift_magnitude = magnitude(shift, spatial_metric);
-  return std::max(max(abs(1. + get(gamma_1)) * get(shift_magnitude)),
-                  max(get(shift_magnitude) + get(lapse)));
+  *speed = std::max(max(abs(1. + get(gamma_1)) * get(shift_magnitude)),
+                    max(get(shift_magnitude) + get(lapse)));
 }
 }  // namespace GeneralizedHarmonic
 
@@ -254,8 +255,8 @@ double ComputeLargestCharacteristicSpeed<Dim, Frame>::apply(
               unit_normal_one_form) noexcept;                               \
   template struct GeneralizedHarmonic::                                     \
       EvolvedFieldsFromCharacteristicFieldsCompute<DIM(data), FRAME(data)>; \
-  template struct GeneralizedHarmonic::ComputeLargestCharacteristicSpeed<   \
-      DIM(data), FRAME(data)>;
+  template struct GeneralizedHarmonic::Tags::                               \
+      ComputeLargestCharacteristicSpeed<DIM(data), FRAME(data)>;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3),
                         (Frame::Inertial, Frame::Grid))

--- a/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
@@ -230,18 +230,27 @@ struct EvolvedFieldsFromCharacteristicFieldsCompute
 };
 // @}
 
+namespace Tags{
+struct LargestCharacteristicSpeed : db::SimpleTag {
+  using type = double;
+};
 /*!
  * \brief Computes the largest magnitude of the characteristic speeds.
  */
 template <size_t Dim, typename Frame>
-struct ComputeLargestCharacteristicSpeed {
+struct ComputeLargestCharacteristicSpeed : db::ComputeTag,
+                                           LargestCharacteristicSpeed {
   using argument_tags = tmpl::list<
       ::GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1,
       gr::Tags::Lapse<DataVector>, gr::Tags::Shift<Dim, Frame, DataVector>,
       gr::Tags::SpatialMetric<Dim, Frame, DataVector>>;
-  static double apply(
-      const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
+  using return_type = double;
+  using base = LargestCharacteristicSpeed;
+  static void function(
+      const gsl::not_null<double*> speed, const Scalar<DataVector>& gamma_1,
+      const Scalar<DataVector>& lapse,
       const tnsr::I<DataVector, Dim, Frame>& shift,
       const tnsr::ii<DataVector, Dim, Frame>& spatial_metric) noexcept;
 };
+}  // namespace Tags
 }  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/System.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/System.hpp
@@ -44,7 +44,7 @@ struct System {
       CharacteristicSpeedsCompute<Dim, Frame::Inertial>;
   using char_speeds_tag = Tags::CharacteristicSpeeds<Dim, Frame::Inertial>;
   using compute_largest_characteristic_speed =
-      ComputeLargestCharacteristicSpeed<Dim, Frame::Inertial>;
+      Tags::ComputeLargestCharacteristicSpeed<Dim, Frame::Inertial>;
 
   template <typename Tag>
   using magnitude_tag = ::Tags::NonEuclideanMagnitude<

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.hpp
@@ -167,12 +167,23 @@ struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds,
         spatial_metric, unit_normal, equation_of_state);
   }
 };
-}  // namespace Tags
 
-struct ComputeLargestCharacteristicSpeed {
-  using argument_tags = tmpl::list<>;
-  static double apply() noexcept { return 1.0; }
+struct LargestCharacteristicSpeed : db::SimpleTag {
+  using type = double;
 };
 
+struct ComputeLargestCharacteristicSpeed : db::ComputeTag,
+                                           LargestCharacteristicSpeed {
+  using argument_tags = tmpl::list<>;
+  using return_type = double;
+  using base = LargestCharacteristicSpeed;
+  static void function(const gsl::not_null<double*> speed) noexcept {
+    // note: this is an approximation valid only in flat spacetime. For better
+    // CFL estimates, this should be updated to calculate the characteristic
+    // speed based on the lapse and shift.
+    *speed = 1.0;
+  }
+};
+}  // namespace Tags
 }  // namespace ValenciaDivClean
 }  // namespace grmhd

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp
@@ -69,7 +69,7 @@ struct System {
       Tags::CharacteristicSpeedsCompute<EquationOfStateType>;
   using char_speeds_tag = Tags::CharacteristicSpeeds;
   using compute_largest_characteristic_speed =
-      ComputeLargestCharacteristicSpeed;
+      Tags::ComputeLargestCharacteristicSpeed;
 
   template <typename Tag>
   using magnitude_tag = ::Tags::NonEuclideanMagnitude<

--- a/src/Evolution/Systems/NewtonianEuler/Characteristics.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Characteristics.cpp
@@ -399,7 +399,8 @@ Matrix left_eigenvectors<3>(const tnsr::I<double, 3>& velocity,
       const tnsr::I<DataVector, DIM(data)>& velocity,                          \
       const Scalar<DataVector>& sound_speed,                                   \
       const tnsr::i<DataVector, DIM(data)>& normal) noexcept;                  \
-  template struct NewtonianEuler::ComputeLargestCharacteristicSpeed<DIM(data)>;
+  template struct NewtonianEuler::Tags::ComputeLargestCharacteristicSpeed<DIM( \
+      data)>;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 

--- a/src/Evolution/Systems/NewtonianEuler/Characteristics.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Characteristics.hpp
@@ -133,17 +133,24 @@ struct CharacteristicSpeedsCompute : CharacteristicSpeeds<Dim>, db::ComputeTag {
     characteristic_speeds<Dim>(result, velocity, sound_speed, normal);
   }
 };
-}  // namespace Tags
 
-template <size_t Dim>
-struct ComputeLargestCharacteristicSpeed {
-  using argument_tags =
-      tmpl::list<Tags::Velocity<DataVector, Dim>, Tags::SoundSpeed<DataVector>>;
 
-  static double apply(const tnsr::I<DataVector, Dim>& velocity,
-                      const Scalar<DataVector>& sound_speed) noexcept {
-    return max(get(magnitude(velocity)) + get(sound_speed));
-  }
+struct LargestCharacteristicSpeed : db::SimpleTag {
+  using type = double;
 };
 
+template <size_t Dim>
+struct ComputeLargestCharacteristicSpeed : LargestCharacteristicSpeed,
+                                           db::ComputeTag {
+  using argument_tags =
+      tmpl::list<Tags::Velocity<DataVector, Dim>, Tags::SoundSpeed<DataVector>>;
+  using return_type = double;
+  using base = LargestCharacteristicSpeed;
+  static void function(const gsl::not_null<double*> speed,
+                       const tnsr::I<DataVector, Dim>& velocity,
+                       const Scalar<DataVector>& sound_speed) noexcept {
+    *speed = max(get(magnitude(velocity)) + get(sound_speed));
+  }
+};
+}  // namespace Tags
 }  // namespace NewtonianEuler

--- a/src/Evolution/Systems/NewtonianEuler/System.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/System.hpp
@@ -56,7 +56,7 @@ struct System {
   using char_speeds_compute_tag = Tags::CharacteristicSpeedsCompute<Dim>;
   using char_speeds_tag = Tags::CharacteristicSpeeds<Dim>;
   using compute_largest_characteristic_speed =
-      ComputeLargestCharacteristicSpeed<Dim>;
+      Tags::ComputeLargestCharacteristicSpeed<Dim>;
 
   template <typename Tag>
   using magnitude_tag = ::Tags::EuclideanMagnitude<Tag>;

--- a/src/Evolution/Systems/ScalarWave/Characteristics.hpp
+++ b/src/Evolution/Systems/ScalarWave/Characteristics.hpp
@@ -221,6 +221,22 @@ struct EvolvedFieldsFromCharacteristicFieldsCompute
                                               unit_normal_one_form);
   };
 };
+
+struct LargestCharacteristicSpeed : db::SimpleTag {
+  using type = double;
+};
+
+/// Compute the maximum magnitude of the characteristic speeds.
+struct ComputeLargestCharacteristicSpeed : LargestCharacteristicSpeed,
+                                           db::ComputeTag {
+  using argument_tags = tmpl::list<>;
+  using return_type = double;
+  using base = LargestCharacteristicSpeed;
+  SPECTRE_ALWAYS_INLINE static constexpr void function(
+      const gsl::not_null<double*> speed) noexcept {
+    *speed = 1.0;
+  }
+};
 }  // namespace Tags
 // @}
 }  // namespace ScalarWave

--- a/src/Evolution/Systems/ScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.hpp
@@ -35,10 +35,4 @@ struct ComputeNormalDotFluxes {
                     gsl::not_null<Scalar<DataVector>*> psi_normal_dot_flux,
                     const Scalar<DataVector>& pi) noexcept;
 };
-
-/// Compute the maximum magnitude of the characteristic speeds.
-struct ComputeLargestCharacteristicSpeed {
-  using argument_tags = tmpl::list<>;
-  SPECTRE_ALWAYS_INLINE static constexpr double apply() noexcept { return 1.0; }
-};
 }  // namespace ScalarWave

--- a/src/Evolution/Systems/ScalarWave/System.hpp
+++ b/src/Evolution/Systems/ScalarWave/System.hpp
@@ -49,7 +49,7 @@ struct System {
   using normal_dot_fluxes = ComputeNormalDotFluxes<Dim>;
 
   using compute_largest_characteristic_speed =
-      ComputeLargestCharacteristicSpeed;
+      Tags::ComputeLargestCharacteristicSpeed;
 
   using char_speeds_compute_tag = Tags::CharacteristicSpeedsCompute<Dim>;
   using char_speeds_tag = Tags::CharacteristicSpeeds<Dim>;

--- a/src/Time/Actions/ChangeSlabSize.hpp
+++ b/src/Time/Actions/ChangeSlabSize.hpp
@@ -308,12 +308,11 @@ class ChangeSlabSize : public Event<EventRegistrars> {
 
     double desired_slab_size = std::numeric_limits<double>::infinity();
     for (const auto& step_chooser : step_choosers_) {
-      desired_slab_size = std::min(
-          desired_slab_size,
-          step_chooser
-              ->desired_step(time_step_id.step_time().slab().duration().value(),
-                             box_for_step_choosers, cache)
-              .first);
+      desired_slab_size =
+          std::min(desired_slab_size,
+                   step_chooser->desired_slab(
+                       time_step_id.step_time().slab().duration().value(),
+                       box_for_step_choosers, cache));
     }
 
     const auto& component_proxy =

--- a/src/Time/Actions/ChangeStepSize.hpp
+++ b/src/Time/Actions/ChangeStepSize.hpp
@@ -72,6 +72,14 @@ bool change_step_size(
     desired_step = -desired_step;
   }
 
+  if (abs(desired_step / current_step.slab().duration().value()) < 1.0e-9) {
+    ERROR(
+        "Chosen step is extremely small; this can indicate a flaw in the a "
+        "step chooser, the grid, or a simualtion instability that an "
+        "error-based stepper is naively attempting to resolve. It is unlikely "
+        "that the simulation can proceed");
+  }
+
   const auto new_step =
       step_controller.choose_step(next_time_id.step_time(), desired_step);
   db::mutate<Tags::Next<Tags::TimeStep>>(

--- a/src/Time/Actions/ChangeStepSize.hpp
+++ b/src/Time/Actions/ChangeStepSize.hpp
@@ -64,7 +64,7 @@ bool change_step_size(
   bool step_accepted = true;
   for (const auto& step_chooser : step_choosers) {
     const auto [step_choice, step_choice_accepted] =
-        step_chooser->desired_step(last_step_size, *box, cache);
+        step_chooser->desired_step(box, last_step_size, cache);
     desired_step = std::min(desired_step, step_choice);
     step_accepted = step_accepted and step_choice_accepted;
   }

--- a/src/Time/StepChoosers/ByBlock.hpp
+++ b/src/Time/StepChoosers/ByBlock.hpp
@@ -67,7 +67,10 @@ class ByBlock : public StepChooser<StepChooserRegistrars> {
   explicit ByBlock(std::vector<double> sizes) noexcept
       : sizes_(std::move(sizes)) {}
 
+  static constexpr UsableFor usable_for = UsableFor::AnyStepChoice;
+
   using argument_tags = tmpl::list<domain::Tags::Element<Dim>>;
+  using return_tags = tmpl::list<>;
 
   template <typename Metavariables>
   std::pair<double, bool> operator()(

--- a/src/Time/StepChoosers/CMakeLists.txt
+++ b/src/Time/StepChoosers/CMakeLists.txt
@@ -14,6 +14,7 @@ spectre_target_headers(
   ByBlock.hpp
   Cfl.hpp
   Constant.hpp
+  ErrorControl.hpp
   Increase.hpp
   PreventRapidIncrease.hpp
   StepChooser.hpp

--- a/src/Time/StepChoosers/Cfl.hpp
+++ b/src/Time/StepChoosers/Cfl.hpp
@@ -30,21 +30,22 @@ struct MinimumGridSpacing;
 /// \endcond
 
 namespace StepChoosers {
-template <size_t Dim, typename Frame, typename StepChooserRegistrars>
+template <size_t Dim, typename Frame, typename System,
+          typename StepChooserRegistrars>
 class Cfl;
 
 namespace Registrars {
-template <size_t Dim, typename Frame>
+template <size_t Dim, typename Frame, typename System>
 struct Cfl {
   template <typename StepChooserRegistrars>
-  using f = StepChoosers::Cfl<Dim, Frame, StepChooserRegistrars>;
+  using f = StepChoosers::Cfl<Dim, Frame, System, StepChooserRegistrars>;
 };
 }  // namespace Registrars
 
 /// Suggests a step size based on the CFL stability criterion.
-template <size_t Dim, typename Frame,
+template <size_t Dim, typename Frame, typename System,
           typename StepChooserRegistrars =
-              tmpl::list<Registrars::Cfl<Dim, Frame>>>
+              tmpl::list<Registrars::Cfl<Dim, Frame, System>>>
 class Cfl : public StepChooser<StepChooserRegistrars> {
  public:
   /// \cond
@@ -67,23 +68,24 @@ class Cfl : public StepChooser<StepChooserRegistrars> {
   explicit Cfl(const double safety_factor) noexcept
       : safety_factor_(safety_factor) {}
 
-  using argument_tags = tmpl::list<domain::Tags::MinimumGridSpacing<Dim, Frame>,
-                                   Tags::DataBox, Tags::TimeStepper<>>;
-  using compute_tags =
-      tmpl::list<domain::Tags::MinimumGridSpacingCompute<Dim, Frame>>;
+  using argument_tags =
+      tmpl::list<domain::Tags::MinimumGridSpacing<Dim, Frame>,
+                 ::Tags::TimeStepper<>,
+                 typename System::compute_largest_characteristic_speed>;
+  using return_tags = tmpl::list<>;
 
-  template <typename Metavariables, typename DbTags>
+  using compute_tags =
+      tmpl::list<domain::Tags::MinimumGridSpacingCompute<Dim, Frame>,
+                 typename System::compute_largest_characteristic_speed>;
+
+  template <typename Metavariables>
   std::pair<double, bool> operator()(
-      const double minimum_grid_spacing, const db::DataBox<DbTags>& box,
+      const double minimum_grid_spacing,
       const typename Metavariables::time_stepper_tag::type::element_type&
           time_stepper,
-      const double last_step_magnitude,
+      const double speed, const double last_step_magnitude,
       const Parallel::GlobalCache<Metavariables>& /*cache*/) const noexcept {
-    using compute_largest_characteristic_speed =
-        typename Metavariables::system::compute_largest_characteristic_speed;
-    const double speed = db::apply<compute_largest_characteristic_speed>(box);
     const double time_stepper_stability_factor = time_stepper.stable_step();
-
     const double step_size = safety_factor_ * time_stepper_stability_factor *
                              minimum_grid_spacing / speed;
     // Reject the step if the CFL condition is violated.
@@ -98,8 +100,9 @@ class Cfl : public StepChooser<StepChooserRegistrars> {
 };
 
 /// \cond
-template <size_t Dim, typename Frame, typename StepChooserRegistrars>
-PUP::able::PUP_ID Cfl<Dim, Frame, StepChooserRegistrars>::my_PUP_ID =
+template <size_t Dim, typename Frame, typename System,
+          typename StepChooserRegistrars>
+PUP::able::PUP_ID Cfl<Dim, Frame, System, StepChooserRegistrars>::my_PUP_ID =
     0;  // NOLINT
 /// \endcond
 }  // namespace StepChoosers

--- a/src/Time/StepChoosers/Cfl.hpp
+++ b/src/Time/StepChoosers/Cfl.hpp
@@ -68,6 +68,8 @@ class Cfl : public StepChooser<StepChooserRegistrars> {
   explicit Cfl(const double safety_factor) noexcept
       : safety_factor_(safety_factor) {}
 
+  static constexpr UsableFor usable_for = UsableFor::AnyStepChoice;
+
   using argument_tags =
       tmpl::list<domain::Tags::MinimumGridSpacing<Dim, Frame>,
                  ::Tags::TimeStepper<>,

--- a/src/Time/StepChoosers/Cfl.hpp
+++ b/src/Time/StepChoosers/Cfl.hpp
@@ -69,6 +69,8 @@ class Cfl : public StepChooser<StepChooserRegistrars> {
 
   using argument_tags = tmpl::list<domain::Tags::MinimumGridSpacing<Dim, Frame>,
                                    Tags::DataBox, Tags::TimeStepper<>>;
+  using compute_tags =
+      tmpl::list<domain::Tags::MinimumGridSpacingCompute<Dim, Frame>>;
 
   template <typename Metavariables, typename DbTags>
   std::pair<double, bool> operator()(

--- a/src/Time/StepChoosers/Constant.hpp
+++ b/src/Time/StepChoosers/Constant.hpp
@@ -46,7 +46,10 @@ class Constant : public StepChooser<StepChooserRegistrars> {
     ASSERT(value_ > 0., "Requested step magnitude should be positive.");
   }
 
+  static constexpr UsableFor usable_for = UsableFor::AnyStepChoice;
+
   using argument_tags = tmpl::list<>;
+  using return_tags = tmpl::list<>;
 
   template <typename Metavariables>
   std::pair<double, bool> operator()(

--- a/src/Time/StepChoosers/ErrorControl.hpp
+++ b/src/Time/StepChoosers/ErrorControl.hpp
@@ -1,0 +1,347 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pup.h>
+#include <pup_stl.h>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Parallel/PupStlCpp17.hpp"
+#include "Time/StepChoosers/StepChooser.hpp"  // IWYU pragma: keep
+#include "Time/Tags.hpp"
+#include "Utilities/Registration.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits/IsIterable.hpp"
+
+/// \cond
+class Time;
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
+/// \endcond
+
+namespace StepChoosers {
+template <typename EvolvedType, typename ErrorControlSelector,
+          typename StepChooserRegistrars>
+class ErrorControl;
+
+namespace Registrars {
+template <typename EvolvedType, typename ErrorControlSelector = NoSuchType>
+using ErrorControl = Registration::Registrar<StepChoosers::ErrorControl,
+                                             EvolvedType, ErrorControlSelector>;
+}  // namespace Registrars
+
+namespace Tags {
+struct PreviousStepError : db::SimpleTag {
+  using type = std::optional<double>;
+};
+}  // namespace Tags
+
+/*!
+ * \brief Suggests a step size based on a target absolute and/or relative error
+ * measure.
+ *
+ * \details The suggested step is calculated via a simple specialization of the
+ * scheme suggested in \cite Hairer1993. We first compute the aggregated error
+ * measure from the stepper error:
+ *
+ * \f[
+ * E = \max_i(|E_i| / sc_i),
+ * \f]
+ *
+ * where \f$E_i\f$ is the ODE error reported for each individual grid point,
+ * reported by the time stepper, and \f$sc_i\f$ is the step control measure
+ * determined by the tolerances:
+ *
+ * \f[
+ * sc_i = Atol_i + \max(|y_i|,|y_i + E_i|) Rtol_i,
+ * \f]
+ *
+ * and \f$y_i\f$ is the value of the function at the current step at grid point
+ * \f$i\f$.
+ *
+ * When no previous record of previous error is available, the step has size:
+ *
+ * \f[
+ * h_{\text{new}} = h \cdot \min\left(F_{\text{max}},
+ * \max\left(F_{\text{min}},
+ * \frac{F_{\text{safety}}}{E^{1/(q + 1)}}\right)\right),
+ * \f]
+ *
+ * where \f$h_{\text{new}}\f$ is the new suggested step size \f$h\f$ is the
+ * previous step size, \f$F_{\text{max}}\f$ is the maximum factor by which we
+ * allow the step to increase, \f$F_{\text{min}}\f$ is the minimum factor by
+ * which we allow the step to decrease. \f$F_{\text{safety}}\f$ is the safety
+ * factor on the computed error -- this forces the step size slightly lower
+ * than we would naively compute so that the result of the step will likely be
+ * within the target error. \f$q\f$ is the order of the stepper error
+ * calculation. Intuitively, we should change the step less drastically for a
+ * higher order stepper.
+ *
+ * After the first error calculation, the error \f$E\f$ is recorded, and
+ * subsequent error calculations use a simple PI scheme suggested in
+ * \cite NumericalRecipes section 17.2.1:
+ *
+ * \f[
+ * h_{\text{new}} = h \cdot \min\left(F_{\text{max}},
+ * \max\left(F_{\text{min}},
+ * \frac{F_{\text{safety}}}{E^{0.7 / (q + 1)}
+ *  E_{\text{prev}}^{0.4 / (q + 1)}}\right)\right),
+ * \f]
+ *
+ * where \f$E_{\text{prev}}\f$ is the error computed in the previous step.
+ *
+ * \note The template parameter `ErrorControlSelector` is used to disambiguate
+ * in the input-file options between `ErrorControl` step choosers that are
+ * based on different variables. This is needed if multiple systems are evolved
+ * in the same executable. The name used for the input file includes
+ * `ErrorControlSelector::name()` if it is provided.
+ */
+template <
+    typename EvolvedVariableTag, typename ErrorControlSelector = NoSuchType,
+    typename StepChooserRegistrars = tmpl::list<
+        Registrars::ErrorControl<EvolvedVariableTag, ErrorControlSelector>>>
+class ErrorControl : public StepChooser<StepChooserRegistrars> {
+ public:
+  using evolved_variable_type = typename EvolvedVariableTag::type;
+  using error_variable_type =
+      typename db::add_tag_prefix<::Tags::StepperError,
+                                  EvolvedVariableTag>::type;
+
+  /// \cond
+  ErrorControl() = default;
+  explicit ErrorControl(CkMigrateMessage* /*unused*/) noexcept {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(ErrorControl);  // NOLINT
+  /// \endcond
+
+  static std::string name() noexcept {
+    if constexpr (std::is_same_v<ErrorControlSelector, NoSuchType>) {
+      return "ErrorControl";
+    } else {
+      return "ErrorControl(" + ErrorControlSelector::name() + ")";
+    }
+  }
+
+  struct AbsoluteTolerance {
+    using type = double;
+    static constexpr Options::String help{"Target absolute tolerance"};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+
+  struct RelativeTolerance {
+    using type = double;
+    static constexpr Options::String help{"Target relative tolerance"};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+
+  struct MaxFactor {
+    using type = double;
+    static constexpr Options::String help{
+        "Maximum factor to increase the step by"};
+    static type lower_bound() noexcept { return 1.0; }
+  };
+
+  struct MinFactor {
+    using type = double;
+    static constexpr Options::String help{
+        "Minimum factor to increase the step by"};
+    static type lower_bound() noexcept { return 0.0; }
+    static type upper_bound() noexcept { return 1.0; }
+  };
+
+  struct SafetyFactor {
+    using type = double;
+    static constexpr Options::String help{
+        "Extra factor to apply to step estimate; can be used to decrease step "
+        "size to improve step acceptance rate."};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+
+  static constexpr Options::String help{
+      "Chooses a step based on a target relative and absolute error tolerance"};
+  using options = tmpl::list<AbsoluteTolerance, RelativeTolerance, MaxFactor,
+                             MinFactor, SafetyFactor>;
+
+  ErrorControl(const double absolute_tolerance, const double relative_tolerance,
+               const double max_factor, const double min_factor,
+               const double safety_factor) noexcept
+      : absolute_tolerance_{absolute_tolerance},
+        relative_tolerance_{relative_tolerance},
+        max_factor_{max_factor},
+        min_factor_{min_factor},
+        safety_factor_{safety_factor} {}
+
+  static constexpr UsableFor usable_for = UsableFor::OnlyLtsStepChoice;
+
+  using argument_tags =
+      tmpl::list<::Tags::HistoryEvolvedVariables<EvolvedVariableTag>,
+                 db::add_tag_prefix<::Tags::StepperError, EvolvedVariableTag>,
+                 ::Tags::StepperErrorUpdated, ::Tags::TimeStepper<>>;
+
+  using return_tags = tmpl::list<Tags::PreviousStepError>;
+
+  using simple_tags = tmpl::list<Tags::PreviousStepError>;
+
+  template <typename Metavariables, typename History, typename TimeStepper>
+  std::pair<double, bool> operator()(
+      const gsl::not_null<std::optional<double>*> previous_step_error,
+      const History& history, const error_variable_type& error,
+      const bool& stepper_error_updated, const TimeStepper& stepper,
+      const double previous_step,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/) const noexcept {
+    // request that the step size not be changed if there isn't a new error
+    // estimate
+    if (not stepper_error_updated) {
+      return std::make_pair(std::numeric_limits<double>::infinity(), true);
+    }
+    const double l_inf_error =
+        error_calc_impl((history.end() - 1).value(), error);
+    double new_step;
+    if (not previous_step_error->has_value()) {
+      new_step = previous_step *
+                 std::clamp(safety_factor_ *
+                                pow(1.0 / std::max(l_inf_error, 1e-14),
+                                    1.0 / (stepper.error_estimate_order() + 1)),
+                            min_factor_, max_factor_);
+    } else {
+      // From simple advice from Numerical Recipes 17.2.1 regarding a heuristic
+      // for PI step control.
+      const double alpha_factor = 0.7 / (stepper.error_estimate_order() + 1);
+      const double beta_factor = 0.4 / (stepper.error_estimate_order() + 1);
+      new_step =
+          previous_step *
+          std::clamp(
+              safety_factor_ *
+                  pow(1.0 / std::max(l_inf_error, 1e-14), alpha_factor) *
+                  pow(1.0 / std::max(previous_step_error->value(), 1e-14),
+                      beta_factor),
+              min_factor_, max_factor_);
+    }
+    *previous_step_error = l_inf_error;
+    return std::make_pair(new_step, l_inf_error <= 1.0);
+  }
+
+  void pup(PUP::er& p) noexcept override {  // NOLINT
+    p | absolute_tolerance_;
+    p | relative_tolerance_;
+    p | min_factor_;
+    p | max_factor_;
+    p | safety_factor_;
+  }
+
+ private:
+  template <typename EvolvedType, typename ErrorType>
+  double error_calc_impl(const EvolvedType& values,
+                         const ErrorType& errors) const noexcept {
+    if constexpr (std::is_fundamental_v<std::remove_cv_t<EvolvedType>> or
+                  tt::is_complex_of_fundamental_v<
+                      std::remove_cv_t<EvolvedType>>) {
+      return std::abs(errors) /
+             (absolute_tolerance_ +
+              relative_tolerance_ *
+                  std::max(abs(values), abs(values + errors)));
+    } else if constexpr (tt::is_iterable_v<std::remove_cv_t<EvolvedType>>) {
+      double result = 0.0;
+      double recursive_call_result;
+      for (auto val_it = values.begin(), err_it = errors.begin();
+           val_it != values.end(); ++val_it, ++err_it) {
+        recursive_call_result = error_calc_impl(*val_it, *err_it);
+        if (recursive_call_result > result) {
+          result = recursive_call_result;
+        }
+      }
+      return result;
+    } else if constexpr (tt::is_a_v<Variables, std::remove_cv_t<EvolvedType>>) {
+      double result = 0.0;
+      double recursive_call_result;
+      tmpl::for_each<typename EvolvedType::tags_list>(
+          [this, &errors, &values, &recursive_call_result,
+           &result](auto tag_v) noexcept {
+            // clang erroneously warns that `this` is not used despite requiring
+            // it in the capture...
+            (void)this;
+            using tag = typename decltype(tag_v)::type;
+            recursive_call_result = error_calc_impl(
+                get<tag>(values), get<::Tags::StepperError<tag>>(errors));
+            if (recursive_call_result > result) {
+              result = recursive_call_result;
+            }
+          });
+      return result;
+    }
+  }
+
+  double absolute_tolerance_ = std::numeric_limits<double>::signaling_NaN();
+  double relative_tolerance_ = std::numeric_limits<double>::signaling_NaN();
+  double max_factor_ = std::numeric_limits<double>::signaling_NaN();
+  double min_factor_ = std::numeric_limits<double>::signaling_NaN();
+  double safety_factor_ = std::numeric_limits<double>::signaling_NaN();
+};
+/// \cond
+template <typename EvolvedVariableTag, typename ErrorControlSelector,
+          typename StepChooserRegistrars>
+PUP::able::PUP_ID ErrorControl<EvolvedVariableTag, ErrorControlSelector,
+                               StepChooserRegistrars>::my_PUP_ID = 0;  // NOLINT
+/// \endcond
+}  // namespace StepChoosers
+
+namespace Tags {
+/// Determines at runtime whether the `ErrorControl` step chooser has been
+/// selected.
+template <typename StepChooserRegistrars>
+struct IsUsingTimeSteppingErrorControl : IsUsingTimeSteppingErrorControlBase,
+                                         db::SimpleTag {
+  using type = bool;
+  template <typename Metavariables>
+  using option_tags = tmpl::flatten<tmpl::list<
+      tmpl::conditional_t<(tmpl::size<StepChooserRegistrars>::value > 0),
+                          ::OptionTags::StepChoosers<StepChooserRegistrars>,
+                          tmpl::list<>>>>;
+
+  static constexpr bool pass_metavariables = true;
+  template <typename Metavariables>
+  static bool create_from_options(
+      const std::vector<std::unique_ptr<::StepChooser<StepChooserRegistrars>>>&
+          step_choosers) noexcept {
+    bool is_using_error_control = false;
+    // unwraps the factory-created classes to determine whether any of the
+    // step choosers are the ErrorControl step chooser.
+    tmpl::for_each<
+        typename StepChooser<StepChooserRegistrars>::creatable_classes>(
+        [&is_using_error_control,
+         &step_choosers](auto step_chooser_type_v) noexcept {
+          if (is_using_error_control) {
+            return;
+          }
+          using step_chooser_type =
+              typename decltype(step_chooser_type_v)::type;
+          if constexpr (tt::is_a_v<::StepChoosers::ErrorControl,
+                                   step_chooser_type>) {
+            for (const auto& step_chooser : step_choosers) {
+              if (dynamic_cast<const step_chooser_type*>(&*step_chooser) !=
+                  nullptr) {
+                is_using_error_control = true;
+                return;
+              }
+            }
+          }
+        });
+    return is_using_error_control;
+  }
+};
+
+template <>
+struct IsUsingTimeSteppingErrorControl<tmpl::list<>>
+    : db::SimpleTag, ::Tags::IsUsingTimeSteppingErrorControlBase {
+  using type = bool;
+  using option_tags = tmpl::list<>;
+  static constexpr bool pass_metavariables = false;
+  static bool create_from_options() noexcept { return false; }
+};
+}  // namespace Tags

--- a/src/Time/StepChoosers/Increase.hpp
+++ b/src/Time/StepChoosers/Increase.hpp
@@ -52,7 +52,10 @@ class Increase : public StepChooser<StepChooserRegistrars> {
 
   explicit Increase(const double factor) noexcept : factor_(factor) {}
 
+  static constexpr UsableFor usable_for = UsableFor::AnyStepChoice;
+
   using argument_tags = tmpl::list<>;
+  using return_tags = tmpl::list<>;
 
   template <typename Metavariables>
   std::pair<double, bool> operator()(

--- a/src/Time/StepChoosers/PreventRapidIncrease.hpp
+++ b/src/Time/StepChoosers/PreventRapidIncrease.hpp
@@ -58,7 +58,10 @@ class PreventRapidIncrease : public StepChooser<StepChooserRegistrars> {
       "instabilities."};
   using options = tmpl::list<>;
 
-  using argument_tags = tmpl::list<Tags::HistoryEvolvedVariables<>>;
+  static constexpr UsableFor usable_for = UsableFor::AnyStepChoice;
+
+  using argument_tags = tmpl::list<::Tags::HistoryEvolvedVariables<>>;
+  using return_tags = tmpl::list<>;
 
   template <typename Metavariables, typename History>
   std::pair<double, bool> operator()(

--- a/src/Time/StepChoosers/StepChooser.hpp
+++ b/src/Time/StepChoosers/StepChooser.hpp
@@ -10,12 +10,16 @@
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/FakeVirtual.hpp"
 #include "Utilities/Registration.hpp"
+#include "Utilities/TypeTraits/CreateGetTypeAliasOrDefault.hpp"
+#include "Utilities/TypeTraits/CreateHasTypeAlias.hpp"
 
 /// \cond
 namespace Parallel {
 template <typename Metavariables>
 class GlobalCache;
 }  // namespace Parallel
+template <typename StepChooserRegistrars>
+class StepChooser;
 // IWYU pragma: no_forward_declare db::DataBox
 /// \endcond
 
@@ -28,6 +32,41 @@ namespace StepChoosers {
 /// These can be passed in a list to the template argument of
 /// StepChooser to choose which StepChoosers can be constructed.
 namespace Registrars {}
+
+namespace detail {
+CREATE_HAS_TYPE_ALIAS(slab_choosers)
+CREATE_HAS_TYPE_ALIAS_V(slab_choosers)
+CREATE_GET_TYPE_ALIAS_OR_DEFAULT(slab_choosers)
+CREATE_HAS_TYPE_ALIAS(step_choosers)
+CREATE_HAS_TYPE_ALIAS_V(step_choosers)
+CREATE_GET_TYPE_ALIAS_OR_DEFAULT(step_choosers)
+CREATE_HAS_TYPE_ALIAS(compute_tags)
+CREATE_HAS_TYPE_ALIAS_V(compute_tags)
+CREATE_GET_TYPE_ALIAS_OR_DEFAULT(compute_tags)
+CREATE_HAS_TYPE_ALIAS(simple_tags)
+CREATE_HAS_TYPE_ALIAS_V(simple_tags)
+CREATE_GET_TYPE_ALIAS_OR_DEFAULT(simple_tags)
+}  // namespace detail
+
+template <typename Metavariables>
+using step_chooser_compute_tags =
+    tmpl::remove_duplicates<tmpl::flatten<tmpl::transform<
+        typename StepChooser<tmpl::remove_duplicates<tmpl::append<
+            detail::get_step_choosers_or_default_t<Metavariables, tmpl::list<>>,
+            detail::get_slab_choosers_or_default_t<
+                Metavariables, tmpl::list<>>>>>::creatable_classes,
+        tmpl::bind<detail::get_compute_tags_or_default_t, tmpl::_1,
+                   tmpl::pin<tmpl::list<>>>>>>;
+
+template <typename Metavariables>
+using step_chooser_simple_tags =
+    tmpl::remove_duplicates<tmpl::flatten<tmpl::transform<
+        typename StepChooser<tmpl::remove_duplicates<tmpl::append<
+            detail::get_step_choosers_or_default_t<Metavariables, tmpl::list<>>,
+            detail::get_slab_choosers_or_default_t<
+                Metavariables, tmpl::list<>>>>>::creatable_classes,
+        tmpl::bind<detail::get_simple_tags_or_default_t, tmpl::_1,
+                   tmpl::pin<tmpl::list<>>>>>>;
 }  // namespace StepChoosers
 
 /// \ingroup TimeSteppersGroup

--- a/src/Time/StepChoosers/StepChooser.hpp
+++ b/src/Time/StepChoosers/StepChooser.hpp
@@ -21,6 +21,8 @@ class GlobalCache;
 template <typename StepChooserRegistrars>
 class StepChooser;
 // IWYU pragma: no_forward_declare db::DataBox
+template <typename StepChooserRegistrars>
+class StepChooser;
 /// \endcond
 
 /// \ingroup TimeSteppersGroup
@@ -47,6 +49,9 @@ CREATE_HAS_TYPE_ALIAS(simple_tags)
 CREATE_HAS_TYPE_ALIAS_V(simple_tags)
 CREATE_GET_TYPE_ALIAS_OR_DEFAULT(simple_tags)
 }  // namespace detail
+
+/// Designation for the context in which a step chooser may be used
+enum class UsableFor { OnlyLtsStepChoice, OnlySlabChoice, AnyStepChoice };
 
 template <typename Metavariables>
 using step_chooser_compute_tags =
@@ -78,6 +83,17 @@ using step_chooser_simple_tags =
 /// The step choosers valid for the integration being controlled are
 /// specified by passing a `tmpl::list` of the corresponding
 /// registrars.
+///
+/// Derived classes must specify the static member variable
+/// `StepChoosers::UsableFor usable_for`, indicating whether the chooser is
+/// usable as a step chooser, slab chooser, or both. If it is usable as a step
+/// chooser (`StepChoosers::UsableFor::OnlyLtsStepChoice` or
+/// `StepChoosers::UsableFor::AnyStepChoice`), it must specify type aliases
+/// `argument_tags` and `return_tags` for the arguments to the call operator. If
+/// it is usable only for slab choosing
+/// (`StepChoosers::UsableFor::OnlySlabChoice`), it need only specify
+/// `argument_tags`, as slab choosers are not permitted mutable access to the
+/// \ref DataBoxGroup "DataBox".
 template <typename StepChooserRegistrars>
 class StepChooser : public PUP::able {
  protected:
@@ -110,7 +126,8 @@ class StepChooser : public PUP::able {
   /// rejection).
   template <typename Metavariables, typename DbTags>
   std::pair<double, bool> desired_step(
-      const double last_step_magnitude, const db::DataBox<DbTags>& box,
+      const gsl::not_null<db::DataBox<DbTags>*> box,
+      const double last_step_magnitude,
       const Parallel::GlobalCache<Metavariables>& cache) const noexcept {
     ASSERT(last_step_magnitude > 0.,
            "Passed non-positive step magnitude: " << last_step_magnitude);
@@ -118,11 +135,54 @@ class StepChooser : public PUP::able {
         call_with_dynamic_type<std::pair<double, bool>, creatable_classes>(
             this, [&last_step_magnitude, &box,
                    &cache](const auto* const chooser) noexcept {
-              return db::apply(*chooser, box, last_step_magnitude, cache);
+              using chooser_type = typename std::decay_t<decltype(*chooser)>;
+              static_assert(chooser_type::usable_for ==
+                                    StepChoosers::UsableFor::AnyStepChoice or
+                                chooser_type::usable_for ==
+                                    StepChoosers::UsableFor::OnlyLtsStepChoice,
+                            "The chosen step chooser is not usable for a local "
+                            "time-stepping step choice.");
+              return db::mutate_apply<typename chooser_type::return_tags,
+                                      typename chooser_type::argument_tags>(
+                  *chooser, box, last_step_magnitude, cache);
             });
     ASSERT(
         result.first > 0.,
         "StepChoosers should always return positive values.  Got " << result);
     return result;
+  }
+
+  /// The `last_step_magnitude` parameter describes the slab size to be
+  /// adjusted; It may be infinite if the appropriate size cannot be determined.
+  ///
+  /// This function is distinct from `desired_step` because the slab change
+  /// decision must be callable from an event (so cannot store state information
+  /// in the \ref DataBoxGroup "DataBox"), and we do not have the capability to
+  /// reject a slab so this function returns only a `double` indicating the
+  /// desired slab size.
+  template <typename Metavariables, typename DbTags>
+  double desired_slab(
+      const double last_step_magnitude,
+      const db::DataBox<DbTags>& box,
+      const Parallel::GlobalCache<Metavariables>& cache) const noexcept {
+    ASSERT(last_step_magnitude > 0.,
+           "Passed non-positive step magnitude: " << last_step_magnitude);
+    const auto result = call_with_dynamic_type<
+        std::pair<double, bool>,
+        creatable_classes>(this, [&last_step_magnitude, &box,
+                                  &cache](const auto* const chooser) noexcept {
+          using chooser_type = typename std::decay_t<decltype(*chooser)>;
+          static_assert(chooser_type::usable_for ==
+                                StepChoosers::UsableFor::AnyStepChoice or
+                            chooser_type::usable_for ==
+                                StepChoosers::UsableFor::OnlySlabChoice,
+                        "The chosen step chooser is not usable for making a "
+                        "slab choice.");
+          return db::apply(*chooser, box, last_step_magnitude, cache);
+    });
+    ASSERT(
+        result.first > 0.,
+        "StepChoosers should always return positive values.  Got " << result);
+    return result.first;
   }
 };

--- a/src/Time/StepChoosers/StepToTimes.hpp
+++ b/src/Time/StepChoosers/StepToTimes.hpp
@@ -78,7 +78,10 @@ class StepToTimes : public StepChooser<StepChooserRegistrars> {
   explicit StepToTimes(std::unique_ptr<TimeSequence<double>> times) noexcept
       : times_(std::move(times)) {}
 
-  using argument_tags = tmpl::list<Tags::TimeStepId>;
+  static constexpr UsableFor usable_for = UsableFor::OnlySlabChoice;
+
+  using argument_tags = tmpl::list<::Tags::TimeStepId>;
+  using return_tags = tmpl::list<>;
 
   template <typename Metavariables>
   std::pair<double, bool> operator()(

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -105,6 +105,25 @@ struct HistoryEvolvedVariables : HistoryEvolvedVariables<>, db::SimpleTag {
 
 /// \ingroup DataBoxTagsGroup
 /// \ingroup TimeGroup
+/// \brief Tag for the stepper error measure.
+template <typename Tag>
+struct StepperError : db::PrefixTag, db::SimpleTag {
+  static std::string name() noexcept {
+    return "StepperError(" + db::tag_name<Tag>() + ")";
+  }
+  using type = typename Tag::type;
+  using tag = Tag;
+};
+
+/// \ingroup TimeGroup
+/// \brief Tag indicating whether the stepper error has been updated on the
+/// current step
+struct StepperErrorUpdated : db::SimpleTag {
+  using type = bool;
+};
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup TimeGroup
 /// Tag for TimeStepper boundary history
 template <typename LocalVars, typename RemoteVars, typename CouplingResult>
 struct BoundaryHistory : db::SimpleTag {
@@ -230,4 +249,9 @@ struct StepController : db::SimpleTag {
     return deserialize<type>(serialize<type>(step_controller).data());
   }
 };
+
+/// \ingroup TimeGroup
+/// \brief A tag that is true if the `ErrorControl` step chooser is one of the
+/// option-created `Event`s.
+struct IsUsingTimeSteppingErrorControlBase : db::BaseTag {};
 }  // namespace Tags

--- a/tests/Unit/Evolution/Systems/Burgers/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/Test_Characteristics.cpp
@@ -36,8 +36,14 @@ SPECTRE_TEST_CASE("Unit.Burgers.Characteristics", "[Unit][Burgers]") {
 
 SPECTRE_TEST_CASE("Unit.Burgers.ComputeLargestCharacteristicSpeed",
                   "[Unit][Burgers]") {
-  CHECK(Burgers::ComputeLargestCharacteristicSpeed::apply(
-            Scalar<DataVector>{{{{1., 2., 4., 3.}}}}) == 4.);
-  CHECK(Burgers::ComputeLargestCharacteristicSpeed::apply(
-            Scalar<DataVector>{{{{1., 2., 4., -5.}}}}) == 5.);
+  double largest_characteristic_speed =
+      std::numeric_limits<double>::signaling_NaN();
+  Burgers::Tags::ComputeLargestCharacteristicSpeed::function(
+      make_not_null(&largest_characteristic_speed),
+      Scalar<DataVector>{{{{1., 2., 4., 3.}}}});
+  CHECK(largest_characteristic_speed == 4.0);
+  Burgers::Tags::ComputeLargestCharacteristicSpeed::function(
+      make_not_null(&largest_characteristic_speed),
+      Scalar<DataVector>{{{{1., 2., 4., -5.}}}});
+  CHECK(largest_characteristic_speed == 5.0);
 }

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
@@ -583,9 +583,10 @@ void check_max_char_speed(const DataVector& used_for_size) noexcept {
   std::uniform_real_distribution<> gamma_1_dist(-5.0, 5.0);
   const auto gamma_1 = make_with_random_values<Scalar<DataVector>>(
       make_not_null(&gen), make_not_null(&gamma_1_dist), used_for_size);
-  const double max_char_speed =
-      GeneralizedHarmonic::ComputeLargestCharacteristicSpeed<
-          Dim, Frame::Inertial>::apply(gamma_1, lapse, shift, spatial_metric);
+  double max_char_speed = std::numeric_limits<double>::signaling_NaN();
+  GeneralizedHarmonic::Tags::ComputeLargestCharacteristicSpeed<
+      Dim, Frame::Inertial>::function(make_not_null(&max_char_speed), gamma_1,
+                                      lapse, shift, spatial_metric);
 
   double maximum_observed = -std::numeric_limits<double>::infinity();
   for (size_t i = 0; i < trials; ++i) {

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Characteristics.cpp
@@ -106,8 +106,11 @@ void test_largest_characteristic_speed(
       nn_generator, nn_distribution, used_for_size);
   const auto sound_speed = make_with_random_values<Scalar<DataVector>>(
       nn_generator, nn_distribution, used_for_size);
-  CHECK(NewtonianEuler::ComputeLargestCharacteristicSpeed<Dim>::apply(
-            velocity, sound_speed) ==
+  double largest_characteristic_speed =
+      std::numeric_limits<double>::signaling_NaN();
+  NewtonianEuler::Tags::ComputeLargestCharacteristicSpeed<Dim>::function(
+      make_not_null(&largest_characteristic_speed), velocity, sound_speed);
+  CHECK(largest_characteristic_speed ==
         max(get(sound_speed) + get(magnitude(velocity))));
 }
 

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Characteristics.cpp
@@ -395,4 +395,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave.Characteristics",
                                          lower_bound, upper_bound);
   test_evolved_from_characteristic_fields_analytic<3>(
       plane_wave_solution, grid_size, lower_bound, upper_bound);
+
+  double largest_characteristic_speed =
+      std::numeric_limits<double>::signaling_NaN();
+  ScalarWave::Tags::ComputeLargestCharacteristicSpeed::function(
+      make_not_null(&largest_characteristic_speed));
+  CHECK(largest_characteristic_speed == 1.0);
 }

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Equations.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Equations.cpp
@@ -89,6 +89,3 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave.NormalDotFluxes",
   check_normal_dot_fluxes<2>(3, time);
   check_normal_dot_fluxes<3>(3, time);
 }
-
-static_assert(1.0 == ScalarWave::ComputeLargestCharacteristicSpeed::apply(),
-              "Failed testing ScalarWave::ComputeLargestCharacteristicSpeed.");

--- a/tests/Unit/Time/StepChoosers/CMakeLists.txt
+++ b/tests/Unit/Time/StepChoosers/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY_SOURCES
   StepChoosers/Test_ByBlock.cpp
   StepChoosers/Test_Cfl.cpp
   StepChoosers/Test_Constant.cpp
+  StepChoosers/Test_ErrorControl.cpp
   StepChoosers/Test_Increase.cpp
   StepChoosers/Test_PreventRapidIncrease.cpp
   StepChoosers/Test_StepToTimes.cpp

--- a/tests/Unit/Time/StepChoosers/Test_ByBlock.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_ByBlock.cpp
@@ -45,19 +45,20 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ByBlock", "[Unit][Time]") {
   const Parallel::GlobalCache<Metavariables> cache{};
   for (size_t block = 0; block < 3; ++block) {
     const Element<volume_dim> element(ElementId<volume_dim>(block), {});
-    const auto box =
-        db::create<db::AddSimpleTags<domain::Tags::Element<volume_dim>>>(
-            element);
+    auto box = db::create<db::AddSimpleTags<domain::Tags::Element<volume_dim>>>(
+        element);
     const double expected = 0.5 * static_cast<double>(block + 5);
 
     CHECK(by_block(element, current_step, cache) ==
           std::make_pair(expected, true));
-    CHECK(by_block_base->desired_step(current_step, box, cache) ==
-          std::make_pair(expected, true));
+
+    CHECK(by_block_base->desired_step(make_not_null(&box), current_step,
+                                      cache) == std::make_pair(expected, true));
+    CHECK(by_block_base->desired_slab(current_step, box, cache) == expected);
     CHECK(serialize_and_deserialize(by_block)(element, current_step, cache) ==
           std::make_pair(expected, true));
     CHECK(serialize_and_deserialize(by_block_base)
-              ->desired_step(current_step, box, cache) ==
+              ->desired_step(make_not_null(&box), current_step, cache) ==
           std::make_pair(expected, true));
   }
 

--- a/tests/Unit/Time/StepChoosers/Test_Cfl.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_Cfl.cpp
@@ -31,12 +31,6 @@
 // IWYU pragma: no_include <pup.h>
 
 namespace {
-constexpr size_t dim = 1;
-using frame = Frame::Grid;
-using StepChooserType =
-    StepChooser<tmpl::list<StepChoosers::Registrars::Cfl<dim, frame>>>;
-using Cfl = StepChoosers::Cfl<dim, frame>;
-
 struct CharacteristicSpeed : db::SimpleTag {
   using type = double;
 };
@@ -46,12 +40,28 @@ struct Metavariables {
   using const_global_cache_tags = tmpl::list<>;
   using time_stepper_tag = Tags::TimeStepper<TimeStepper>;
   struct system {
-    struct compute_largest_characteristic_speed {
+    struct largest_characteristic_speed : db::SimpleTag {
+      using type = double;
+    };
+    struct compute_largest_characteristic_speed : db::ComputeTag,
+                                                  largest_characteristic_speed {
+      using base = largest_characteristic_speed;
       using argument_tags = tmpl::list<CharacteristicSpeed>;
-      static double apply(const double speed) noexcept { return speed; }
+      using return_type = double;
+      static void function(const gsl::not_null<double*> return_speed,
+                           const double& speed) noexcept {
+        *return_speed = speed;
+      }
     };
   };
 };
+
+
+constexpr size_t dim = 1;
+using frame = Frame::Grid;
+using StepChooserType = StepChooser<tmpl::list<
+    StepChoosers::Registrars::Cfl<dim, frame, typename Metavariables::system>>>;
+using Cfl = StepChoosers::Cfl<dim, frame, typename Metavariables::system>;
 
 std::pair<double, bool> get_suggestion(const size_t stepper_order,
                                        const double safety_factor,
@@ -62,7 +72,9 @@ std::pair<double, bool> get_suggestion(const size_t stepper_order,
       db::AddSimpleTags<
           CharacteristicSpeed, domain::Tags::Coordinates<dim, frame>,
           domain::Tags::Mesh<dim>, Tags::TimeStepper<TimeStepper>>,
-      db::AddComputeTags<domain::Tags::MinimumGridSpacingCompute<dim, frame>>>(
+      db::AddComputeTags<domain::Tags::MinimumGridSpacingCompute<dim, frame>,
+                         typename Metavariables::system::
+                             compute_largest_characteristic_speed>>(
       characteristic_speed, tnsr::I<DataVector, dim, frame>{{{coordinates}}},
       Mesh<dim>(coordinates.size(), Spectral::Basis::Legendre,
                 Spectral::Quadrature::GaussLobatto),
@@ -71,6 +83,9 @@ std::pair<double, bool> get_suggestion(const size_t stepper_order,
 
   const double grid_spacing =
       get<domain::Tags::MinimumGridSpacing<dim, frame>>(box);
+  const double speed =
+      get<typename Metavariables::system::compute_largest_characteristic_speed>(
+          box);
   const auto& time_stepper = get<Tags::TimeStepper<TimeStepper>>(box);
 
   const Cfl cfl{safety_factor};
@@ -78,13 +93,13 @@ std::pair<double, bool> get_suggestion(const size_t stepper_order,
 
   const double current_step = std::numeric_limits<double>::infinity();
   const auto result =
-      cfl(grid_spacing, box, time_stepper, current_step, cache);
+      cfl(grid_spacing, time_stepper, speed, current_step, cache);
   CHECK_FALSE(result.second);
   const auto accepted_step_result =
-      cfl(grid_spacing, box, time_stepper, result.first * 0.7, cache);
+      cfl(grid_spacing, time_stepper, speed, result.first * 0.7, cache);
   CHECK(accepted_step_result.second);
   CHECK(cfl_base->desired_step(current_step, box, cache) == result);
-  CHECK(serialize_and_deserialize(cfl)(grid_spacing, box, time_stepper,
+  CHECK(serialize_and_deserialize(cfl)(grid_spacing, time_stepper, speed,
                                        current_step, cache) == result);
   CHECK(serialize_and_deserialize(cfl_base)->desired_step(current_step, box,
                                                           cache) == result);

--- a/tests/Unit/Time/StepChoosers/Test_Constant.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_Constant.cpp
@@ -32,7 +32,7 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.Constant", "[Unit][Time]") {
   Parallel::register_derived_classes_with_charm<StepChooserType>();
 
   const Parallel::GlobalCache<Metavariables> cache{};
-  const auto box = db::create<db::AddSimpleTags<>>();
+  auto box = db::create<db::AddSimpleTags<>>();
 
   const Constant constant{5.4};
   const std::unique_ptr<StepChooserType> constant_base =
@@ -40,12 +40,13 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.Constant", "[Unit][Time]") {
 
   const double current_step = std::numeric_limits<double>::infinity();
   CHECK(constant(current_step, cache) == std::make_pair(5.4, true));
-  CHECK(constant_base->desired_step(current_step, box, cache) ==
+  CHECK(constant_base->desired_step(make_not_null(&box), current_step, cache) ==
         std::make_pair(5.4, true));
+  CHECK(constant_base->desired_slab(current_step, box, cache) == 5.4);
   CHECK(serialize_and_deserialize(constant)(current_step, cache) ==
         std::make_pair(5.4, true));
   CHECK(serialize_and_deserialize(constant_base)
-            ->desired_step(current_step, box, cache) ==
+            ->desired_step(make_not_null(&box), current_step, cache) ==
         std::make_pair(5.4, true));
 
   TestHelpers::test_factory_creation<StepChooserType>("Constant: 5.4");

--- a/tests/Unit/Time/StepChoosers/Test_ErrorControl.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_ErrorControl.cpp
@@ -1,0 +1,317 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Tags.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "Time/StepChoosers/Constant.hpp"
+#include "Time/StepChoosers/ErrorControl.hpp"
+#include "Time/StepChoosers/Increase.hpp"
+#include "Time/StepChoosers/PreventRapidIncrease.hpp"
+#include "Time/StepChoosers/StepChooser.hpp"
+#include "Time/Tags.hpp"
+#include "Time/TimeSteppers/AdamsBashforthN.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct EvolvedVar1 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+struct EvolvedVar2 : db::SimpleTag {
+  using type = tnsr::i<DataVector, 2>;
+};
+
+using EvolvedVariablesTag =
+    Tags::Variables<tmpl::list<EvolvedVar1, EvolvedVar2>>;
+
+struct ErrorControlSelecter {
+  static std::string name() {
+    return "SelectorLabel";
+  }
+};
+
+using StepChooserType = StepChooser<
+    tmpl::list<StepChoosers::Registrars::ErrorControl<EvolvedVariablesTag>>>;
+
+struct Metavariables {
+  using component_list = tmpl::list<>;
+};
+
+template <typename EvolvedTags, typename ErrorTags>
+std::pair<double, bool> get_suggestion(
+    const gsl::not_null<std::optional<double>*> previous_step_error,
+    const StepChoosers::ErrorControl<EvolvedVariablesTag>& error_control,
+    const Variables<EvolvedTags>& step_values,
+    const Variables<ErrorTags>& error, const double previous_step,
+    const size_t stepper_order) noexcept {
+  const Parallel::GlobalCache<Metavariables> cache{};
+  TimeSteppers::History<
+      Variables<EvolvedTags>,
+      typename db::add_tag_prefix<::Tags::dt, EvolvedVariablesTag>::type>
+      history{stepper_order};
+  history.insert(TimeStepId{true, 0, {{0.0, 1.0}, {0, 1}}}, step_values,
+                 0.1 * step_values);
+  auto box = db::create<
+      db::AddSimpleTags<
+          Tags::HistoryEvolvedVariables<EvolvedVariablesTag>,
+          db::add_tag_prefix<Tags::StepperError, EvolvedVariablesTag>,
+          Tags::StepperErrorUpdated, Tags::TimeStepper<TimeStepper>,
+          StepChoosers::Tags::PreviousStepError>,
+      db::AddComputeTags<>>(
+      std::move(history), error, false,
+      std::unique_ptr<TimeStepper>{
+          std::make_unique<TimeSteppers::AdamsBashforthN>(stepper_order)},
+      *previous_step_error);
+
+  const auto& time_stepper = get<Tags::TimeStepper<>>(box);
+  const std::unique_ptr<StepChooserType> error_control_base =
+      std::make_unique<StepChoosers::ErrorControl<EvolvedVariablesTag>>(
+          error_control);
+
+  // check that when the error is not declared updated, the step is accepted and
+  // the step is infinity.
+  CHECK(std::make_pair(std::numeric_limits<double>::infinity(), true) ==
+        error_control(
+            previous_step_error,
+            db::get<Tags::HistoryEvolvedVariables<EvolvedVariablesTag>>(box),
+            error, false, time_stepper, previous_step, cache));
+  CHECK(*previous_step_error ==
+        db::get<StepChoosers::Tags::PreviousStepError>(box));
+  CHECK(std::make_pair(std::numeric_limits<double>::infinity(), true) ==
+        error_control_base->desired_step(make_not_null(&box), previous_step,
+                                         cache));
+
+  db::mutate<Tags::StepperErrorUpdated>(
+      make_not_null(&box),
+      [](const gsl::not_null<bool*> stepper_updated) noexcept {
+        *stepper_updated = true;
+      });
+  const std::pair<double, bool> result = error_control(
+      previous_step_error,
+      db::get<Tags::HistoryEvolvedVariables<EvolvedVariablesTag>>(box), error,
+      true, time_stepper, previous_step, cache);
+  // reset the previous step error so we can reuse the former state on the next
+  // re-application
+  *previous_step_error = db::get<StepChoosers::Tags::PreviousStepError>(box);
+  CHECK(error_control_base->desired_step(make_not_null(&box), previous_step,
+                                         cache) == result);
+  db::mutate<StepChoosers::Tags::PreviousStepError>(
+      make_not_null(&box),
+      [previous_step_error](const gsl::not_null<std::optional<double>*>
+                                previous_step_error_from_box) noexcept {
+        *previous_step_error_from_box = *previous_step_error;
+      });
+  CHECK(serialize_and_deserialize(error_control)(
+            previous_step_error,
+            db::get<Tags::HistoryEvolvedVariables<EvolvedVariablesTag>>(box),
+            error, true, time_stepper, previous_step, cache) == result);
+  CHECK(serialize_and_deserialize(error_control_base)
+            ->desired_step(make_not_null(&box), previous_step, cache) ==
+        result);
+  return result;
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ErrorControl", "[Unit][Time]") {
+  Parallel::register_derived_classes_with_charm<StepChooserType>();
+
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> step_dist{1.0, 2.0};
+  Variables<tmpl::list<EvolvedVar1, EvolvedVar2>> step_values{5};
+  fill_with_random_values(make_not_null(&step_values),
+                          make_not_null(&generator), make_not_null(&step_dist));
+  const DataVector flattened_step_values{step_values.data(), 15};
+  std::uniform_real_distribution<> error_dist{1.0e-4, 2.0e-4};
+  Variables<tmpl::list<Tags::StepperError<EvolvedVar1>,
+                       Tags::StepperError<EvolvedVar2>>>
+      step_errors{5};
+  fill_with_random_values(make_not_null(&step_errors),
+                          make_not_null(&generator),
+                          make_not_null(&error_dist));
+  const DataVector flattened_step_errors{step_errors.data(), 15};
+  const std::vector<size_t> stepper_orders{2_st, 5_st};
+  for (size_t stepper_order : stepper_orders) {
+    CAPTURE(stepper_order);
+    {
+      INFO("Test error control step fixed by absolute tolerance");
+      const StepChoosers::ErrorControl<EvolvedVariablesTag> error_control{
+          5.0e-4, 0.0, 2.0, 0.5, 0.95};
+      std::optional<double> previous_step_error;
+      const auto first_result =
+          get_suggestion(make_not_null(&previous_step_error), error_control,
+                         step_values, step_errors, 1.0, stepper_order);
+      // manually calculated in the special case in question: only absolute
+      // errors constrained
+      const double expected_linf_error = max(flattened_step_errors) / 5.0e-4;
+      CHECK(approx(first_result.first) ==
+            0.95 / pow(expected_linf_error, 1.0 / stepper_order));
+      CHECK(first_result.second);
+      const auto second_result =
+          get_suggestion(make_not_null(&previous_step_error), error_control,
+                         step_values, decltype(step_errors){1.2 * step_errors},
+                         first_result.first, stepper_order);
+      CHECK(approx(second_result.first) ==
+            0.95 * first_result.first /
+                (pow(expected_linf_error, 1.1 / stepper_order) *
+                 pow(1.2, 0.7 / stepper_order)));
+      CHECK(second_result.first);
+    }
+    {
+      INFO("Test error control step fixed by relative tolerance");
+      const StepChoosers::ErrorControl<EvolvedVariablesTag> error_control{
+          0.0, 5.0e-4, 2.0, 0.5, 0.95};
+      std::optional<double> previous_step_error;
+      const auto first_result =
+          get_suggestion(make_not_null(&previous_step_error), error_control,
+                         step_values, step_errors, 1.0, stepper_order);
+      // manually calculated in the special case in question: only absolute
+      // errors constrained
+      const double expected_linf_error =
+          max(flattened_step_errors /
+              (flattened_step_values + flattened_step_errors)) /
+          5.0e-4;
+      CHECK(approx(first_result.first) ==
+            0.95 / pow(expected_linf_error, 1.0 / stepper_order));
+      CHECK(first_result.second);
+      const auto second_result =
+          get_suggestion(make_not_null(&previous_step_error), error_control,
+                         step_values, decltype(step_errors){1.2 * step_errors},
+                         first_result.first, stepper_order);
+      const double new_expected_linf_error =
+          max(1.2 * flattened_step_errors /
+              (flattened_step_values + 1.2 * flattened_step_errors)) /
+          5.0e-4;
+      CHECK(approx(second_result.first) ==
+            0.95 * first_result.first /
+                (pow(pow(new_expected_linf_error, 1.0 / stepper_order), 0.7) *
+                 pow(pow(expected_linf_error, 1.0 / stepper_order), 0.4)));
+      CHECK(second_result.first);
+    }
+    {
+      INFO("Test error control step failure");
+      const StepChoosers::ErrorControl<EvolvedVariablesTag> error_control{
+          4.0e-5, 4.0e-5, 2.0, 0.5, 0.95};
+      std::optional<double> previous_step_error;
+      const auto first_result =
+          get_suggestion(make_not_null(&previous_step_error), error_control,
+                         step_values, step_errors, 1.0, stepper_order);
+      // manually calculated in the special case in question: only absolute
+      // errors constrained
+      const double expected_linf_error =
+          max(flattened_step_errors /
+              (flattened_step_values + flattened_step_errors + 1.0)) /
+          4.0e-5;
+      CHECK(
+          approx(first_result.first) ==
+          std::max(0.95 / pow(expected_linf_error, 1.0 / stepper_order), 0.5));
+      CHECK_FALSE(first_result.second);
+    }
+    {
+      INFO("Test error control clamped minimum");
+      const StepChoosers::ErrorControl<EvolvedVariablesTag> error_control{
+          4.0e-5, 4.0e-5, 2.0, 0.9, 0.95};
+      std::optional<double> previous_step_error;
+      const auto first_result =
+          get_suggestion(make_not_null(&previous_step_error), error_control,
+                         step_values, step_errors, 1.0, stepper_order);
+      // manually calculated in the special case in question: only absolute
+      // errors constrained
+      CHECK(first_result.first == 0.9);
+    }
+    {
+      INFO("Test error control clamped minimum");
+      const StepChoosers::ErrorControl<EvolvedVariablesTag> error_control{
+          1.0e-1, 1.0e-1, 2.0, 0.5, 0.95};
+      std::optional<double> previous_step_error;
+      const auto first_result =
+          get_suggestion(make_not_null(&previous_step_error), error_control,
+                         step_values, step_errors, 1.0, stepper_order);
+      CHECK(first_result == std::make_pair(2.0, true));
+    }
+  }
+  // test option creation
+  TestHelpers::test_factory_creation<
+      StepChoosers::ErrorControl<EvolvedVariablesTag>>(
+      "ErrorControl:\n"
+      "  SafetyFactor: 0.95\n"
+      "  AbsoluteTolerance: 1.0e-5\n"
+      "  RelativeTolerance: 1.0e-4\n"
+      "  MaxFactor: 2.1\n"
+      "  MinFactor: 0.5");
+  TestHelpers::test_factory_creation<
+      StepChoosers::ErrorControl<EvolvedVariablesTag, ErrorControlSelecter>>(
+      "ErrorControl(SelectorLabel):\n"
+      "  SafetyFactor: 0.95\n"
+      "  AbsoluteTolerance: 1.0e-5\n"
+      "  RelativeTolerance: 1.0e-4\n"
+      "  MaxFactor: 2.1\n"
+      "  MinFactor: 0.5");
+
+  // Test `IsUsingTimeSteppingErrorControl` tag:
+  {
+    INFO("IsUsingTimeSteppingErrorControl tag test");
+    using step_choosers_with_error_control =
+        tmpl::list<StepChoosers::Registrars::Increase,
+                   StepChoosers::Registrars::Constant,
+                   StepChoosers::Registrars::ErrorControl<EvolvedVariablesTag>,
+                   StepChoosers::Registrars::PreventRapidIncrease>;
+    using step_choosers_without_error_control =
+        tmpl::list<StepChoosers::Registrars::Increase,
+                   StepChoosers::Registrars::Constant,
+                   StepChoosers::Registrars::PreventRapidIncrease>;
+    const auto step_choosers_collection_0 = TestHelpers::test_creation<
+        typename Tags::StepChoosers<step_choosers_with_error_control>::type>(
+        "- ErrorControl:\n"
+        "    SafetyFactor: 0.95\n"
+        "    AbsoluteTolerance: 1.0e-5\n"
+        "    RelativeTolerance: 1.0e-4\n"
+        "    MaxFactor: 2.1\n"
+        "    MinFactor: 0.5\n"
+        "- Increase:\n"
+        "    Factor: 2\n"
+        "- Constant: 0.5");
+    const auto step_choosers_collection_1 = TestHelpers::test_creation<
+        typename Tags::StepChoosers<step_choosers_with_error_control>::type>(
+        "- PreventRapidIncrease:\n"
+        "- Increase:\n"
+        "    Factor: 2\n"
+        "- Constant: 0.5");
+    const auto step_choosers_collection_2 = TestHelpers::test_creation<
+        typename Tags::StepChoosers<step_choosers_without_error_control>::type>(
+        "- PreventRapidIncrease:\n"
+        "- Increase:\n"
+        "    Factor: 2\n"
+        "- Constant: 0.5");
+    CHECK(Tags::IsUsingTimeSteppingErrorControl<
+          step_choosers_with_error_control>::
+              create_from_options<Metavariables>(step_choosers_collection_0));
+    CHECK_FALSE(
+        Tags::IsUsingTimeSteppingErrorControl<
+            step_choosers_with_error_control>::
+            create_from_options<Metavariables>(step_choosers_collection_1));
+    CHECK_FALSE(
+        Tags::IsUsingTimeSteppingErrorControl<
+            step_choosers_without_error_control>::
+            create_from_options<Metavariables>(step_choosers_collection_2));
+    CHECK_FALSE(Tags::IsUsingTimeSteppingErrorControl<
+                tmpl::list<>>::create_from_options());
+  }
+}

--- a/tests/Unit/Time/StepChoosers/Test_Increase.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_Increase.cpp
@@ -34,7 +34,7 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.Increase", "[Unit][Time]") {
   Parallel::register_derived_classes_with_charm<StepChooserType>();
 
   const Parallel::GlobalCache<Metavariables> cache{};
-  const auto box = db::create<db::AddSimpleTags<>>();
+  auto box = db::create<db::AddSimpleTags<>>();
   const auto check =
       [&box, &cache](const double step, const double expected) noexcept {
     const Increase increase{5.};
@@ -42,12 +42,13 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.Increase", "[Unit][Time]") {
         std::make_unique<Increase>(increase);
 
     CHECK(increase(step, cache) == std::make_pair(expected, true));
-    CHECK(increase_base->desired_step(step, box, cache) ==
+    CHECK(increase_base->desired_step(make_not_null(&box), step, cache) ==
           std::make_pair(expected, true));
+    CHECK(increase_base->desired_slab(step, box, cache) == expected);
     CHECK(serialize_and_deserialize(increase)(step, cache) ==
           std::make_pair(expected, true));
     CHECK(serialize_and_deserialize(increase_base)
-              ->desired_step(step, box, cache) ==
+              ->desired_step(make_not_null(&box), step, cache) ==
           std::make_pair(expected, true));
   };
   check(0.25, 1.25);

--- a/tests/Unit/Time/StepChoosers/Test_PreventRapidIncrease.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_PreventRapidIncrease.cpp
@@ -102,7 +102,7 @@ void check_case(const Frac& expected_frac,
     }
 
     const auto check = [&cache, &expected, &relax, &relax_base](
-        const auto& box, const Time& current_time) noexcept {
+                           auto box, const Time& current_time) noexcept {
       const auto& history = db::get<history_tag>(box);
       const double current_step =
           history.size() > 0 ? abs(current_time - history.back()).value()
@@ -110,12 +110,13 @@ void check_case(const Frac& expected_frac,
 
       CHECK(relax(history, current_step, cache) ==
             std::make_pair(expected, true));
-      CHECK(relax_base->desired_step(current_step, box, cache) ==
-            std::make_pair(expected, true));
+      CHECK(relax_base->desired_step(make_not_null(&box), current_step,
+                                     cache) == std::make_pair(expected, true));
+      CHECK(relax_base->desired_slab(current_step, box, cache) == expected);
       CHECK(serialize_and_deserialize(relax)(history, current_step, cache) ==
             std::make_pair(expected, true));
       CHECK(serialize_and_deserialize(relax_base)
-                ->desired_step(current_step, box, cache) ==
+                ->desired_step(make_not_null(&box), current_step, cache) ==
             std::make_pair(expected, true));
     };
 

--- a/tests/Unit/Time/StepChoosers/Test_StepToTimes.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_StepToTimes.cpp
@@ -56,7 +56,7 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.StepToTimes", "[Unit][Time]") {
               std::make_unique<Specified>(impl_times));
 
       const Parallel::GlobalCache<Metavariables> cache{};
-      const auto box = db::create<db::AddSimpleTags<Tags::TimeStepId>>(now_id);
+      auto box = db::create<db::AddSimpleTags<Tags::TimeStepId>>(now_id);
 
       const auto answer = step_to_times(now_id, step, cache);
       if (result == -1.0) {
@@ -64,13 +64,11 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.StepToTimes", "[Unit][Time]") {
       } else {
         CHECK(result == answer.first);
       }
-      CHECK(step_to_times_base->desired_step(step, box, cache) ==
-            std::make_pair(result, true));
+      CHECK(step_to_times_base->desired_slab(step, box, cache) == result);
       CHECK(serialize_and_deserialize(step_to_times)(now_id, step, cache) ==
             std::make_pair(result, true));
       CHECK(serialize_and_deserialize(step_to_times_base)
-                ->desired_step(step, box, cache) ==
-            std::make_pair(result, true));
+                ->desired_slab(step, box, cache) == result);
     };
     impl(TimeStepId(true, 0, Slab(now, now + 1.0).start()), times);
     alg::for_each(times, [](double& x) noexcept { return x = -x; });

--- a/tests/Unit/Time/Test_Tags.cpp
+++ b/tests/Unit/Time/Test_Tags.cpp
@@ -43,4 +43,10 @@ SPECTRE_TEST_CASE("Unit.Time.Tags", "[Unit][Time]") {
   TestHelpers::db::test_simple_tag<Tags::StepChoosers<DummyType>>(
       "StepChoosers");
   TestHelpers::db::test_simple_tag<Tags::StepController>("StepController");
+  TestHelpers::db::test_simple_tag<Tags::StepperError<DummyVariablesTag>>(
+      "StepperError(Variables(Scalar))");
+  TestHelpers::db::test_simple_tag<Tags::StepperErrorUpdated>(
+      "StepperErrorUpdated");
+  TestHelpers::db::test_base_tag<Tags::IsUsingTimeSteppingErrorControlBase>(
+      "IsUsingTimeSteppingErrorControlBase");
 }


### PR DESCRIPTION
## Proposed changes

To be most effective, the error control step chooser needs to store state information in the `DataBox` -- this ended up propagating a number of additional changes to the step choosers:
- The step and slab choice must be different because the slab choice must be callable from an event, and therefore can't save state. This is fine, because the error control step chooser shouldn't be used to choose slab anyway.
- The step choice cannot take the databox directly as an argument, so needs to specify all of the quantities that it uses as tags
- Because it previously used the databox to calculate the maximum characteristic speeds in-line in the CFL condition, that calculation must now be a compute tag rather than being usable in a `db::apply`
- For convenience, it is now desirable to aggregate all of the compute and simple tags needed by the step choosers so that they may be added to the databox by metafunctions according to the collection of step choosers chosen in the metavariables.

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->
Most executables should now add the simple and compute tags associated wtih the metavariables' `step_choosers` sometime during initialization. 
The `compute_largest_characteristic_speed` alias of most `System`s must now be a compute tag.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
