### PR TITLE
Support anisotropic and inhomogeneous refinement in Cylinder

### DIFF
--- a/src/Domain/Creators/CMakeLists.txt
+++ b/src/Domain/Creators/CMakeLists.txt
@@ -13,6 +13,7 @@ spectre_target_sources(
   Brick.cpp
   Cylinder.cpp
   Disk.cpp
+  ExpandOverBlocks.cpp
   FrustalCloak.cpp
   Interval.cpp
   Rectangle.cpp
@@ -34,6 +35,7 @@ spectre_target_headers(
   Cylinder.hpp
   Disk.hpp
   DomainCreator.hpp
+  ExpandOverBlocks.hpp
   FrustalCloak.hpp
   Interval.hpp
   Rectangle.hpp

--- a/src/Domain/Creators/ExpandOverBlocks.cpp
+++ b/src/Domain/Creators/ExpandOverBlocks.cpp
@@ -1,0 +1,111 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Creators/ExpandOverBlocks.hpp"
+
+#include <array>
+#include <boost/algorithm/string/join.hpp>
+#include <cstddef>
+#include <exception>
+#include <string>
+#include <vector>
+
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace domain {
+
+template <typename T, size_t Dim>
+ExpandOverBlocks<T, Dim>::ExpandOverBlocks(size_t num_blocks) noexcept
+    : num_blocks_(num_blocks) {}
+
+template <typename T, size_t Dim>
+ExpandOverBlocks<T, Dim>::ExpandOverBlocks(
+    std::vector<std::string> block_names,
+    std::unordered_map<std::string, std::unordered_set<std::string>>
+        block_groups) noexcept
+    : num_blocks_(block_names.size()),
+      block_names_(std::move(block_names)),
+      block_groups_(std::move(block_groups)) {}
+
+template <typename T, size_t Dim>
+std::vector<std::array<T, Dim>> ExpandOverBlocks<T, Dim>::operator()(
+    const T& value) const {
+  return {num_blocks_, make_array<Dim>(value)};
+}
+
+template <typename T, size_t Dim>
+std::vector<std::array<T, Dim>> ExpandOverBlocks<T, Dim>::operator()(
+    const std::array<T, Dim>& value) const {
+  return {num_blocks_, value};
+}
+
+template <typename T, size_t Dim>
+std::vector<std::array<T, Dim>> ExpandOverBlocks<T, Dim>::operator()(
+    const std::vector<std::array<T, Dim>> value) const {
+  if (value.size() != num_blocks_) {
+    throw std::length_error{"You supplied " + std::to_string(value.size()) +
+                            " values, but the domain creator has " +
+                            std::to_string(num_blocks_) + " blocks."};
+  }
+  return value;
+}
+
+template <typename T, size_t Dim>
+std::vector<std::array<T, Dim>> ExpandOverBlocks<T, Dim>::operator()(
+    const std::unordered_map<std::string, std::array<T, Dim>>& value) const {
+  ASSERT(num_blocks_ == block_names_.size(),
+         "Construct 'ExpandOverBlocks' with block names to use the "
+         "map-over-block-names feature.");
+  // Expand group names
+  auto value_per_block = value;
+  for (const auto& [name, block_value] : value) {
+    const auto found_group = block_groups_.find(name);
+    if (found_group != block_groups_.end()) {
+      for (const auto& expanded_name : found_group->second) {
+        if (value_per_block.count(expanded_name) == 0) {
+          value_per_block[expanded_name] = block_value;
+        } else {
+          throw std::invalid_argument{
+              "Duplicate block name '" + expanded_name +
+              // NOLINTNEXTLINE(performance-inefficient-string-concatenation)
+              "' (expanded from '" + name + "')."};
+        }
+      }
+      value_per_block.erase(name);
+    }
+  }
+  if (value_per_block.size() != num_blocks_) {
+    throw std::length_error{
+        "You supplied " + std::to_string(value_per_block.size()) +
+        " values, but the domain creator has " + std::to_string(num_blocks_) +
+        " blocks: " + boost::algorithm::join(block_names_, ", ")};
+  }
+  std::vector<std::array<T, Dim>> result{};
+  for (const auto& block_name : block_names_) {
+    const auto found_value = value_per_block.find(block_name);
+    if (found_value != value_per_block.end()) {
+      result.push_back(found_value->second);
+    } else {
+      throw std::out_of_range{"Value for block '" + block_name +
+                              "' is missing. Did you misspell its name?"};
+    }
+  }
+  return result;
+}
+
+/// \cond
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define INSTANTIATE(_, data) \
+  template class ExpandOverBlocks<DTYPE(data), DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (size_t), (1, 2, 3))
+
+#undef DIM
+#undef DTYPE
+#undef INSTANTIATE
+/// \endcond
+
+}  // namespace domain

--- a/src/Domain/Creators/ExpandOverBlocks.hpp
+++ b/src/Domain/Creators/ExpandOverBlocks.hpp
@@ -1,0 +1,80 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace domain {
+/*!
+ * \brief Produce a distribution of type `T` over all blocks and dimensions in
+ * the domain, based on values `T` of variable isotropy and homogeneity.
+ *
+ * This class is useful to option-create values for e.g. the initial refinement
+ * level or initial number of grid points for domain creators. It can be used
+ * with `std::visit` and a `std::variant` with (a subset of) these types:
+ *
+ * - `T`: Repeat over all blocks and dimensions (isotropic and homogeneous).
+ * - `std::array<T, Dim>`: Repeat over all blocks (homogeneous).
+ * - `std::vector<std::array<T, Dim>>>`: Only check if the size matches the
+ *   number of blocks, throwing a `std::length_error` if it doesn't.
+ * - `std::unordered_map<std::string, std::array<T, Dim>>`: Map block names, or
+ *   names of block groups, to values. The map must cover all blocks once the
+ *   groups are expanded. To use this option you must pass the list of block
+ *   names and groups to the constructor.
+ *
+ * Note that the call-operators `throw` when they encounter errors, such as
+ * mismatches in the number of blocks. The exceptions can be used to output
+ * user-facing error messages in an option-parsing context.
+ *
+ * Here's an example for using this class:
+ *
+ * \snippet Test_ExpandOverBlocks.cpp expand_over_blocks_example
+ *
+ * Here's an example using block names and groups:
+ *
+ * \snippet Test_ExpandOverBlocks.cpp expand_over_blocks_named_example
+ *
+ * \tparam T The type distributed over the domain
+ * \tparam Dim The number of spatial dimensions
+ */
+template <typename T, size_t Dim>
+struct ExpandOverBlocks {
+  ExpandOverBlocks(size_t num_blocks) noexcept;
+  ExpandOverBlocks(
+      std::vector<std::string> block_names,
+      std::unordered_map<std::string, std::unordered_set<std::string>>
+          block_groups = {}) noexcept;
+
+  /// Repeat over all blocks and dimensions (isotropic and homogeneous)
+  std::vector<std::array<T, Dim>> operator()(const T& value) const;
+
+  /// Repeat over all blocks (homogeneous)
+  std::vector<std::array<T, Dim>> operator()(
+      const std::array<T, Dim>& value) const;
+
+  /// Only check if the size matches the number of blocks, throwing a
+  /// `std::length_error` if it doesn't
+  std::vector<std::array<T, Dim>> operator()(
+      std::vector<std::array<T, Dim>> value) const;
+
+  /// Map block names, or names of block groups, to values. The map must cover
+  /// all blocks once the groups are expanded. To use this option you must pass
+  /// the list of block names and groups to the constructor. Here's an example:
+  ///
+  /// \snippet Test_ExpandOverBlocks.cpp expand_over_blocks_named_example
+  std::vector<std::array<T, Dim>> operator()(
+      const std::unordered_map<std::string, std::array<T, Dim>>& value) const;
+
+ private:
+  size_t num_blocks_;
+  std::vector<std::string> block_names_;
+  std::unordered_map<std::string, std::unordered_set<std::string>>
+      block_groups_;
+};
+}  // namespace domain

--- a/tests/Unit/Domain/Creators/CMakeLists.txt
+++ b/tests/Unit/Domain/Creators/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBRARY_SOURCES
   Test_Brick.cpp
   Test_Cylinder.cpp
   Test_Disk.cpp
+  Test_ExpandOverBlocks.cpp
   Test_FrustalCloak.cpp
   Test_Interval.cpp
   Test_Rectangle.cpp

--- a/tests/Unit/Domain/Creators/Test_ExpandOverBlocks.cpp
+++ b/tests/Unit/Domain/Creators/Test_ExpandOverBlocks.cpp
@@ -1,0 +1,118 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <variant>
+#include <vector>
+
+#include "Domain/Creators/ExpandOverBlocks.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+
+namespace domain {
+template <typename T, size_t Dim>
+void test_expand_over_blocks(
+    const std::variant<T, std::array<T, Dim>, std::vector<std::array<T, Dim>>>&
+        input_value,
+    const size_t num_blocks,
+    const std::vector<std::array<T, Dim>>& expected_expanded_value) {
+  CHECK(std::visit(ExpandOverBlocks<T, Dim>{num_blocks}, input_value) ==
+        expected_expanded_value);
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.ExpandOverBlocks", "[Domain][Unit]") {
+  test_expand_over_blocks<size_t, 1>(size_t{2}, 3, {3, {2}});
+  test_expand_over_blocks<size_t, 1>(std::array<size_t, 1>{2}, 3, {3, {2}});
+  test_expand_over_blocks<size_t, 1>(
+      std::vector<std::array<size_t, 1>>{{2}, {3}, {4}}, 3, {{2}, {3}, {4}});
+  test_expand_over_blocks<size_t, 2>(size_t{2}, 3, {3, {2, 2}});
+  test_expand_over_blocks<size_t, 2>(std::array<size_t, 2>{2, 3}, 3,
+                                     {3, {2, 3}});
+  test_expand_over_blocks<size_t, 2>(
+      std::vector<std::array<size_t, 2>>{{2, 3}, {3, 4}, {4, 5}}, 3,
+      {{2, 3}, {3, 4}, {4, 5}});
+  test_expand_over_blocks<size_t, 3>(size_t{2}, 3, {3, {2, 2, 2}});
+  test_expand_over_blocks<size_t, 3>(std::array<size_t, 3>{2, 3, 4}, 3,
+                                     {3, {2, 3, 4}});
+  test_expand_over_blocks<size_t, 3>(
+      std::vector<std::array<size_t, 3>>{{2, 3, 4}, {3, 4, 5}, {4, 5, 6}}, 3,
+      {{2, 3, 4}, {3, 4, 5}, {4, 5, 6}});
+  CHECK_THROWS_WITH(
+      SINGLE_ARG(ExpandOverBlocks<size_t, 1>{3}(
+          std::vector<std::array<size_t, 1>>{{2}, {3}})),
+      Catch::Matchers::Contains(
+          "You supplied 2 values, but the domain creator has 3 blocks."));
+  {
+    // [expand_over_blocks_example]
+    static constexpr size_t Dim = 3;
+    const size_t num_blocks = 3;
+    // This is an example for a variant that represents the distribution of
+    // initial refinement levels, which might be parsed from options:
+    using InitialRefinementOptionType =
+        std::variant<size_t, std::array<size_t, Dim>,
+                     std::vector<std::array<size_t, Dim>>>;
+    // In this example the user specified a single number:
+    const InitialRefinementOptionType initial_refinement_from_options{
+        size_t{2}};
+    try {
+      // Invoke `ExpandOverBlocks`:
+      const auto initial_refinement =
+          std::visit(ExpandOverBlocks<size_t, Dim>{num_blocks},
+                     initial_refinement_from_options);
+      // Since a single number was specified, we expect the vector over blocks
+      // is homogeneously and isotropically filled with that number:
+      std::vector<std::array<size_t, Dim>> expected_initial_refinement{
+          num_blocks, {2, 2, 2}};
+      CHECK(initial_refinement == expected_initial_refinement);
+    } catch (const std::length_error& error) {
+      // This would be a `PARSE_ERROR` in an option-parsing context
+      ERROR("Invalid 'InitialRefinement': " << error.what());
+    }
+    // [expand_over_blocks_example]
+  }
+  {
+    // [expand_over_blocks_named_example]
+    static constexpr size_t Dim = 2;
+    // In this example we name the blocks, representing a cubed-sphere domain:
+    const std::vector<std::string> block_names{"InnerCube", "East", "North",
+                                               "West", "South"};
+    // The blocks can also be grouped:
+    const std::unordered_map<std::string, std::unordered_set<std::string>>
+        block_groups{{"Wedges", {"East", "North", "West", "South"}}};
+    // Now we can expand values over blocks by giving their names. This can also
+    // be used with a std::variant like in the other example.
+    ExpandOverBlocks<size_t, Dim> expand{block_names, block_groups};
+    CHECK(expand({{"West", {{3, 4}}},
+                  {"InnerCube", {{2, 3}}},
+                  {"South", {{3, 4}}},
+                  {"North", {{5, 6}}},
+                  {"East", {{1, 2}}}}) ==
+          std::vector<std::array<size_t, Dim>>{
+              {{2, 3}}, {{1, 2}}, {{5, 6}}, {{3, 4}}, {{3, 4}}});
+    // Instead of naming all blocks individually we can also name groups:
+    CHECK(expand({{"InnerCube", {{2, 3}}}, {"Wedges", {{3, 4}}}}) ==
+          std::vector<std::array<size_t, Dim>>{
+              {{2, 3}}, {{3, 4}}, {{3, 4}}, {{3, 4}}, {{3, 4}}});
+    // [expand_over_blocks_named_example]
+    CHECK_THROWS_WITH(expand({{"InnerCube", {{2, 3}}}, {"East", {{3, 4}}}}),
+                      Catch::Matchers::Contains(
+                          "You supplied 2 values, but the domain creator has 5 "
+                          "blocks: InnerCube, East, North, West, South"));
+    CHECK_THROWS_WITH(expand({{{"Wedges", {{3, 4}}}}}),
+                      Catch::Matchers::Contains(
+                          "You supplied 4 values, but the domain creator has 5 "
+                          "blocks: InnerCube, East, North, West, South"));
+    CHECK_THROWS_WITH(
+        expand({{"Wedges", {{3, 4}}}, {"East", {{3, 4}}}}),
+        Catch::Matchers::Contains(
+            "Duplicate block name 'East' (expanded from 'Wedges')."));
+    CHECK_THROWS_WITH(
+        expand({{"noblock", {{3, 4}}}, {"Wedges", {{3, 4}}}}),
+        Catch::Matchers::Contains("Value for block 'InnerCube' is missing. Did "
+                                  "you misspell its name?"));
+  }
+}
+
+}  // namespace domain


### PR DESCRIPTION
## Proposed changes

Support specifying the refinement and number of grid points for the `Cylinder` domain creator in the input file as one of these:
- A single number: Expand to all blocks and dimensions -> homogeneous and isotropic
- A `std::array<size_t, 3>`: Expand to all blocks -> homogeneous
- A `std::vector<std::array<size_t, 3>>`: Pass along mostly unmodified -> can be anisotropic and inhomogeneous

Use cases are mostly tests of AMR, and manually refining the grid while we don't have AMR yet.

Here's an example of a domain that I refined pretty much randomly:

<img width="744" alt="Bildschirmfoto 2021-03-22 um 22 18 00" src="https://user-images.githubusercontent.com/746230/112059775-9223bd80-8b5c-11eb-99fb-a0821fc5d7f6.png">


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
