### PR TITLE
Fix a missing include in build system

### DIFF
--- a/cmake/SetupPypp.cmake
+++ b/cmake/SetupPypp.cmake
@@ -21,6 +21,7 @@ file(APPEND
   )
 
 # Also check that SciPy is installed
+include(FindPythonModule)
 find_python_module(scipy TRUE)
 
 add_library(Python::NumPy INTERFACE IMPORTED)


### PR DESCRIPTION
## Proposed changes

This fixes a bug where cmake fails when Doxygen is not installed, since
`SetupDoxygen` provided the missing include.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
