### PR TITLE
Have Options::Auto pass metavars along

### DIFF
--- a/src/Options/Auto.hpp
+++ b/src/Options/Auto.hpp
@@ -85,7 +85,7 @@ struct create_from_yaml<Auto<T, Label>> {
     } catch (...) {
       // The node failed to parse as a string.  It is not the AutoLabel.
     }
-    return Auto<T, Label>{options.parse_as<T>()};
+    return Auto<T, Label>{options.parse_as<T, Metavariables>()};
   }
 };
 }  // namespace Options


### PR DESCRIPTION
## Proposed changes

Pass metavars along when parsing `Options::Auto`. Found this when writing #2964.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
