### PR TITLE
(De)registration during serialization

### DIFF
--- a/src/Domain/Creators/TimeDependence/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/Creators/TimeDependence/RegisterDerivedWithCharm.cpp
@@ -7,6 +7,7 @@
 
 #include "Domain/CoordinateMaps/TimeDependent/CubicScale.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/TimeDependent/Translation.hpp"
 #include "Domain/Creators/TimeDependence/Composition.hpp"
 #include "Domain/Creators/TimeDependence/Composition.tpp"

--- a/src/IO/Observer/Actions/ObserverRegistration.hpp
+++ b/src/IO/Observer/Actions/ObserverRegistration.hpp
@@ -80,6 +80,66 @@ struct RegisterVolumeContributorWithObserverWriter {
   }
 };
 
+/// \brief Deregister an `ArrayComponentId` with a specific
+/// `ObservationIdRegistrationKey` that will no longer call
+/// `observers::ThreadedActions::ContributeVolumeData`
+///
+/// Should be invoked on ObserverWriter by the component that was previously
+/// registered with
+/// `observers::Actions::RegisterVolumeContributorWithObserverWriter`
+struct DeregisterVolumeContributorWithObserverWriter {
+ public:
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables, typename ArrayIndex>
+  static void apply(db::DataBox<DbTagsList>& box,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const observers::ObservationKey& observation_key,
+                    const ArrayComponentId& id_of_caller) noexcept {
+    if constexpr (tmpl::list_contains_v<
+                      DbTagsList, Tags::ExpectedContributorsForObservations>) {
+      db::mutate<Tags::ExpectedContributorsForObservations>(
+          make_not_null(&box),
+          [&id_of_caller, &observation_key](
+              const gsl::not_null<std::unordered_map<
+                  ObservationKey, std::unordered_set<ArrayComponentId>>*>
+                  volume_observers_registered) noexcept {
+            if (UNLIKELY(volume_observers_registered->find(observation_key) ==
+                         volume_observers_registered->end())) {
+              ERROR(
+                  "Trying to deregister a component associated with an "
+                  "unregistered observation key: "
+                  << observation_key);
+            }
+
+            if (UNLIKELY(
+                    volume_observers_registered->at(observation_key)
+                        .find(id_of_caller) ==
+                    volume_observers_registered->at(observation_key).end())) {
+              ERROR("Trying to deregister an unregistered component: "
+                    << id_of_caller);
+            }
+
+            volume_observers_registered->at(observation_key)
+                .erase(id_of_caller);
+            if (UNLIKELY(
+                    volume_observers_registered->at(observation_key).size() ==
+                    0)) {
+              volume_observers_registered->erase(observation_key);
+            }
+          });
+    } else {
+      (void)box;
+      (void)observation_key;
+      (void)id_of_caller;
+      ERROR(
+          "Could not find tag "
+          "observers::Tags::ExpectedContributorsForObservations in the "
+          "DataBox.");
+    }
+  }
+};
+
 /*!
  * \brief Register a node with the node that writes the reduction data to disk.
  */
@@ -112,16 +172,76 @@ struct RegisterReductionNodeWithWritingNode {
               (*reduction_observers_registered_nodes)[observation_key] =
                   std::set<size_t>{};
             }
-            if (UNLIKELY(
-                    reduction_observers_registered_nodes->at(observation_key)
-                        .find(caller_node_id) !=
-                    reduction_observers_registered_nodes->at(observation_key)
-                        .end())) {
+            auto& registered_nodes_for_key =
+                reduction_observers_registered_nodes->at(observation_key);
+            if (UNLIKELY(registered_nodes_for_key.find(caller_node_id) !=
+                         registered_nodes_for_key.end())) {
               ERROR("Already registered node "
                     << caller_node_id << " for reduction observations.");
             }
-            reduction_observers_registered_nodes->at(observation_key)
-                .insert(caller_node_id);
+            registered_nodes_for_key.insert(caller_node_id);
+          });
+    } else {
+      (void)box;
+      (void)observation_key;
+      (void)caller_node_id;
+      ERROR(
+          "Do not have tag "
+          "observers::Tags::NodesExpectedToContributeReductions "
+          "in the DataBox. This means components are registering for "
+          "reductions before initialization is complete.");
+    }
+  }
+};
+
+/*!
+ * \brief Deregister a node with the node that writes the reduction data to
+ * disk.
+ */
+struct DeregisterReductionNodeWithWritingNode {
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables, typename ArrayIndex>
+  static void apply(db::DataBox<DbTagsList>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const observers::ObservationKey& observation_key,
+                    const size_t caller_node_id) noexcept {
+    if constexpr (tmpl::list_contains_v<
+                      DbTagsList, Tags::NodesExpectedToContributeReductions>) {
+      auto& my_proxy =
+          Parallel::get_parallel_component<ParallelComponent>(cache);
+      const auto node_id =
+          static_cast<size_t>(Parallel::my_node(*my_proxy.ckLocalBranch()));
+      ASSERT(node_id == 0,
+             "Only node zero, not node "
+                 << node_id
+                 << " should deregister other nodes in the reduction");
+
+      db::mutate<Tags::NodesExpectedToContributeReductions>(
+          make_not_null(&box),
+          [&caller_node_id, &observation_key](
+              const gsl::not_null<
+                  std::unordered_map<ObservationKey, std::set<size_t>>*>
+                  reduction_observers_registered_nodes) noexcept {
+            if (UNLIKELY(reduction_observers_registered_nodes->find(
+                             observation_key) ==
+                         reduction_observers_registered_nodes->end())) {
+              ERROR(
+                  "Trying to deregister a node associated with an unregistered "
+                  "observation key: "
+                  << observation_key);
+            }
+            auto& registered_nodes_for_key =
+                reduction_observers_registered_nodes->at(observation_key);
+            if (UNLIKELY(registered_nodes_for_key.find(caller_node_id) ==
+                         registered_nodes_for_key.end())) {
+              ERROR("Trying to deregister an unregistered node: "
+                    << caller_node_id);
+            }
+            registered_nodes_for_key.erase(caller_node_id);
+            if (UNLIKELY(registered_nodes_for_key.size() == 0)) {
+              reduction_observers_registered_nodes->erase(observation_key);
+            }
           });
     } else {
       (void)box;
@@ -185,6 +305,74 @@ struct RegisterReductionContributorWithObserverWriter {
               ERROR("Trying to insert a Observer component more than once: "
                     << id_of_caller
                     << " with observation key: " << observation_key);
+            }
+          });
+    } else {
+      (void)box;
+      (void)cache;
+      (void)observation_key;
+      (void)id_of_caller;
+      ERROR(
+          "Could not find tag "
+          "observers::Tags::ExpectedContributorsForObservations in the "
+          "DataBox.");
+    }
+  }
+};
+
+/// \brief Deregister an `ArrayComponentId` that will no longer call
+/// `observers::ThreadedActions::WriteReductionData` or
+/// `observers::ThreadedActions::ContributeReductionData` for a specific
+/// `ObservationIdRegistrationKey`
+///
+/// Should be invoked on ObserverWriter by the component that was previously
+/// registered by
+/// `observers::Actions::RegisterReductionContributorWithObserverWriter`.
+struct DeregisterReductionContributorWithObserverWriter {
+ public:
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables, typename ArrayIndex>
+  static void apply(db::DataBox<DbTagsList>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const observers::ObservationKey& observation_key,
+                    const ArrayComponentId& id_of_caller) noexcept {
+    if constexpr (tmpl::list_contains_v<
+                      DbTagsList, Tags::ExpectedContributorsForObservations>) {
+      auto& my_proxy =
+          Parallel::get_parallel_component<ParallelComponent>(cache);
+      const auto node_id =
+          static_cast<size_t>(Parallel::my_node(*my_proxy.ckLocalBranch()));
+      db::mutate<Tags::ExpectedContributorsForObservations>(
+          make_not_null(&box),
+          [&cache, &id_of_caller, &node_id, &observation_key](
+              const gsl::not_null<std::unordered_map<
+                  ObservationKey, std::unordered_set<ArrayComponentId>>*>
+                  reduction_observers_registered) noexcept {
+            if (UNLIKELY(
+                    reduction_observers_registered->find(observation_key) ==
+                    reduction_observers_registered->end())) {
+              ERROR(
+                  "Trying to deregister a component associated with an "
+                  "unregistered observation key: "
+                  << observation_key);
+            }
+            auto& contributors_for_key =
+                reduction_observers_registered->at(observation_key);
+            if (UNLIKELY(contributors_for_key.find(id_of_caller) ==
+                         contributors_for_key.end())) {
+              ERROR("Trying to deregister an unregistered component: "
+                    << id_of_caller
+                    << " with observation key: " << observation_key);
+            }
+            contributors_for_key.erase(id_of_caller);
+            if (UNLIKELY(contributors_for_key.size() == 0)) {
+              Parallel::simple_action<
+                  Actions::DeregisterReductionNodeWithWritingNode>(
+                  Parallel::get_parallel_component<
+                      ObserverWriter<Metavariables>>(cache)[0],
+                  observation_key, node_id);
+              reduction_observers_registered->erase(observation_key);
             }
           });
     } else {
@@ -281,6 +469,95 @@ struct RegisterContributorWithObserver {
           "observers::Tags::ExpectedContributorsForObservations when the "
           "action "
           "RegisterContributorWithObserver is called.");
+    }
+  }
+};
+
+/*!
+ * \brief Deregister the `ArrayComponentId` that will no longer send the data to
+ * the observer for the given `ObservationIdRegistrationKey`
+ *
+ * Should be invoked on the `Observer` by the component that was previously
+ * registered with `observers::Actions::RegisterContributorWithObserver`.
+ */
+struct DeregisterContributorWithObserver {
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables, typename ArrayIndex>
+  static void apply(db::DataBox<DbTagList>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& array_index,
+                    const observers::ObservationKey& observation_key,
+                    const observers::ArrayComponentId& component_id,
+                    const TypeOfObservation& type_of_observation) noexcept {
+    if constexpr (tmpl::list_contains_v<
+                      DbTagList,
+                      observers::Tags::ExpectedContributorsForObservations>) {
+      bool all_array_components_have_been_deregistered = false;
+      db::mutate<observers::Tags::ExpectedContributorsForObservations>(
+          make_not_null(&box),
+          [&component_id, &observation_key,
+           &all_array_components_have_been_deregistered](
+              const gsl::not_null<std::unordered_map<
+                  ObservationKey, std::unordered_set<ArrayComponentId>>*>
+                  array_component_ids) noexcept {
+            if (UNLIKELY(array_component_ids->find(observation_key) ==
+                         array_component_ids->end())) {
+              ERROR(
+                  "Trying to deregister a component associated with an "
+                  "unregistered observation key: "
+                  << observation_key);
+            }
+            auto& component_ids_for_key =
+                array_component_ids->at(observation_key);
+            if (UNLIKELY(component_ids_for_key.find(component_id) ==
+                         array_component_ids->at(observation_key).end())) {
+              ERROR("Trying to deregister an unregistered component: "
+                    << component_id
+                    << " with observation key: " << observation_key);
+            }
+            component_ids_for_key.erase(component_id);
+            if (UNLIKELY(component_ids_for_key.size() == 0)) {
+              array_component_ids->erase(observation_key);
+              all_array_components_have_been_deregistered = true;
+            }
+          });
+
+      if (not all_array_components_have_been_deregistered) {
+        // Only deregister with the observer writer if this deregistration
+        // removes the last component for the provided `observation_key`.
+        return;
+      }
+
+      auto& observer_writer =
+          *Parallel::get_parallel_component<
+               observers::ObserverWriter<Metavariables>>(cache)
+               .ckLocalBranch();
+
+      switch (type_of_observation) {
+        case TypeOfObservation::Reduction:
+          Parallel::simple_action<
+              Actions::DeregisterReductionContributorWithObserverWriter>(
+              observer_writer, observation_key,
+              ArrayComponentId{std::add_pointer_t<ParallelComponent>{nullptr},
+                               Parallel::ArrayIndex<ArrayIndex>(array_index)});
+          return;
+        case TypeOfObservation::Volume:
+          Parallel::simple_action<
+              Actions::DeregisterVolumeContributorWithObserverWriter>(
+              observer_writer, observation_key,
+              ArrayComponentId{std::add_pointer_t<ParallelComponent>{nullptr},
+                               Parallel::ArrayIndex<ArrayIndex>(array_index)});
+          return;
+        default:
+          ERROR(
+              "Attempting to deregister an unknown TypeOfObservation. "
+              "Should be one of 'Reduction' or 'Volume'");
+      };
+    } else {
+      ERROR(
+          "The DataBox must contain the tag "
+          "observers::Tags::ExpectedContributorsForObservations when the "
+          "action DeregisterContributorWithObserver is called.");
     }
   }
 };

--- a/src/IO/Observer/Actions/RegisterWithObservers.hpp
+++ b/src/IO/Observer/Actions/RegisterWithObservers.hpp
@@ -34,9 +34,59 @@ namespace observers::Actions {
  * `ParallelComponent` and as function arguments a `db::DataBox` and the array
  * component index. The function must return a
  * `std::pair<observers::TypeOfObservation, observers::ObservationId>`
+ *
+ * When this struct is used as an action, the `apply` function will perform the
+ * registration with observers. However, this struct also offers the static
+ * member functions `perform_registriation` and `perform_deregistration` that
+ * are needed for either registering when an element is added to a core outside
+ * of initialization or deregistering when an element is being eliminated from a
+ * core. The use of separate functions is necessary to provide an interface
+ * usable outside of iterable actions, e.g. in specialized `pup` functions.
  */
 template <typename RegisterHelper>
 struct RegisterWithObservers {
+ private:
+  template <typename ParallelComponent, typename RegisterOrDeregisterAction,
+            typename DbTagList, typename Metavariables, typename ArrayIndex>
+  static void register_or_deregister_impl(
+      db::DataBox<DbTagList>& box, Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index) noexcept {
+    auto& observer =
+        *Parallel::get_parallel_component<observers::Observer<Metavariables>>(
+             cache)
+             .ckLocalBranch();
+    const auto [type_of_observation, observation_id] =
+        RegisterHelper::template register_info<ParallelComponent>(box,
+                                                                  array_index);
+
+    Parallel::simple_action<RegisterOrDeregisterAction>(
+        observer, observation_id,
+        observers::ArrayComponentId(
+            std::add_pointer_t<ParallelComponent>{nullptr},
+            Parallel::ArrayIndex<std::decay_t<ArrayIndex>>{array_index}),
+        type_of_observation);
+  }
+ public:
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables, typename ArrayIndex>
+  static void perform_registration(db::DataBox<DbTagList>& box,
+                                   Parallel::GlobalCache<Metavariables>& cache,
+                                   const ArrayIndex& array_index) noexcept {
+    register_or_deregister_impl<ParallelComponent,
+                                RegisterContributorWithObserver>(box, cache,
+                                                                 array_index);
+  }
+
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables, typename ArrayIndex>
+  static void perform_deregistration(
+      db::DataBox<DbTagList>& box, Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index) noexcept {
+    register_or_deregister_impl<ParallelComponent,
+                                DeregisterContributorWithObserver>(box, cache,
+                                                                   array_index);
+  }
+
   template <typename DbTagList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>
@@ -46,21 +96,7 @@ struct RegisterWithObservers {
       Parallel::GlobalCache<Metavariables>& cache,
       const ArrayIndex& array_index, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) noexcept {
-    auto& observer =
-        *Parallel::get_parallel_component<observers::Observer<Metavariables>>(
-             cache)
-             .ckLocalBranch();
-    const auto [type_of_observation, observation_id] =
-        RegisterHelper::template register_info<ParallelComponent>(box,
-                                                                  array_index);
-
-    Parallel::simple_action<
-        observers::Actions::RegisterContributorWithObserver>(
-        observer, observation_id,
-        observers::ArrayComponentId(
-            std::add_pointer_t<ParallelComponent>{nullptr},
-            Parallel::ArrayIndex<std::decay_t<ArrayIndex>>{array_index}),
-        type_of_observation);
+    perform_registration<ParallelComponent>(box, cache, array_index);
     return {std::move(box)};
   }
 };


### PR DESCRIPTION
## Proposed changes

Adds the ability to deregister from observers, and adds the framework of performing that deregistration and re-registration during serialization

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->
Any new registration structs should define the new `perform_registration` and `perform_deregistration` functions to conform to the interface expected by the `DgElementArray` pup. 
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
