### PR TITLE
Add grid index to ElementId

### DIFF
--- a/src/Domain/CreateInitialElement.cpp
+++ b/src/Domain/CreateInitialElement.cpp
@@ -33,8 +33,9 @@ Element<VolumeDim> create_initial_element(
 
   // Declare two helper lambdas for setting the neighbors of an element
   const auto compute_element_neighbor_in_other_block =
-      [&block, &initial_refinement_levels, &neighbors_of_block, &segment_ids](
-          const Direction<VolumeDim>& direction) noexcept {
+      [&block, &initial_refinement_levels, &neighbors_of_block, &segment_ids,
+       grid_index = element_id.grid_index()](
+         const Direction<VolumeDim>& direction) noexcept {
     const auto& block_neighbor = neighbors_of_block.at(direction);
     const auto& orientation = block_neighbor.orientation();
     const auto direction_in_neighbor = orientation(direction);
@@ -122,7 +123,8 @@ Element<VolumeDim> create_initial_element(
           }
         }
       }
-      neighbor_ids.insert({block_neighbor.id(), segment_ids_of_neighbor});
+      neighbor_ids.insert(
+          {block_neighbor.id(), segment_ids_of_neighbor, grid_index});
     next_index:;
     }
     return std::make_pair(
@@ -143,7 +145,8 @@ Element<VolumeDim> create_initial_element(
         direction,
         Neighbors<VolumeDim>(
             {{ElementId<VolumeDim>{element_id.block_id(),
-                                   std::move(segment_ids_of_neighbor)}}},
+                                   std::move(segment_ids_of_neighbor),
+                                   element_id.grid_index()}}},
             OrientationMap<VolumeDim>{}));
   };
 

--- a/src/Domain/Structure/InitialElementIds.cpp
+++ b/src/Domain/Structure/InitialElementIds.cpp
@@ -13,21 +13,21 @@
 
 template <>
 std::vector<ElementId<1>> initial_element_ids<1>(
-    const size_t block_id,
-    const std::array<size_t, 1> initial_ref_levs) noexcept {
+    const size_t block_id, const std::array<size_t, 1> initial_ref_levs,
+    const size_t grid_index) noexcept {
   std::vector<ElementId<1>> ids;
   ids.reserve(two_to_the(initial_ref_levs[0]));
   for (size_t x_i = 0; x_i < two_to_the(initial_ref_levs[0]); ++x_i) {
     SegmentId x_segment_id(initial_ref_levs[0], x_i);
-    ids.emplace_back(block_id, make_array<1>(x_segment_id));
+    ids.emplace_back(block_id, make_array<1>(x_segment_id), grid_index);
   }
   return ids;
 }
 
 template <>
 std::vector<ElementId<2>> initial_element_ids<2>(
-    const size_t block_id,
-    const std::array<size_t, 2> initial_ref_levs) noexcept {
+    const size_t block_id, const std::array<size_t, 2> initial_ref_levs,
+    const size_t grid_index) noexcept {
   std::vector<ElementId<2>> ids;
   ids.reserve(two_to_the(initial_ref_levs[0]) *
               two_to_the(initial_ref_levs[1]));
@@ -35,7 +35,8 @@ std::vector<ElementId<2>> initial_element_ids<2>(
     SegmentId x_segment_id(initial_ref_levs[0], x_i);
     for (size_t y_i = 0; y_i < two_to_the(initial_ref_levs[1]); ++y_i) {
       SegmentId y_segment_id(initial_ref_levs[1], y_i);
-      ids.emplace_back(block_id, make_array(x_segment_id, y_segment_id));
+      ids.emplace_back(block_id, make_array(x_segment_id, y_segment_id),
+                       grid_index);
     }
   }
   return ids;
@@ -43,8 +44,8 @@ std::vector<ElementId<2>> initial_element_ids<2>(
 
 template <>
 std::vector<ElementId<3>> initial_element_ids<3>(
-    const size_t block_id,
-    const std::array<size_t, 3> initial_ref_levs) noexcept {
+    const size_t block_id, const std::array<size_t, 3> initial_ref_levs,
+    const size_t grid_index) noexcept {
   std::vector<ElementId<3>> ids;
   ids.reserve(two_to_the(initial_ref_levs[0]) *
               two_to_the(initial_ref_levs[1]) *
@@ -56,7 +57,8 @@ std::vector<ElementId<3>> initial_element_ids<3>(
       for (size_t z_i = 0; z_i < two_to_the(initial_ref_levs[2]); ++z_i) {
         SegmentId z_segment_id(initial_ref_levs[2], z_i);
         ids.emplace_back(block_id,
-                         make_array(x_segment_id, y_segment_id, z_segment_id));
+                         make_array(x_segment_id, y_segment_id, z_segment_id),
+                         grid_index);
       }
     }
   }
@@ -65,13 +67,13 @@ std::vector<ElementId<3>> initial_element_ids<3>(
 
 template <size_t VolumeDim>
 std::vector<ElementId<VolumeDim>> initial_element_ids(
-    const std::vector<std::array<size_t, VolumeDim>>&
-        initial_refinement_levels) noexcept {
+    const std::vector<std::array<size_t, VolumeDim>>& initial_refinement_levels,
+    const size_t grid_index) noexcept {
   std::vector<ElementId<VolumeDim>> element_ids;
   for (size_t block_id = 0; block_id < initial_refinement_levels.size();
        ++block_id) {
-    auto ids_for_block =
-        initial_element_ids(block_id, initial_refinement_levels[block_id]);
+    auto ids_for_block = initial_element_ids(
+        block_id, initial_refinement_levels[block_id], grid_index);
     element_ids.reserve(element_ids.size() + ids_for_block.size());
     std::move(ids_for_block.begin(), ids_for_block.end(),
               std::back_inserter(element_ids));
@@ -85,7 +87,8 @@ std::vector<ElementId<VolumeDim>> initial_element_ids(
   template std::vector<ElementId<GET_DIM(data)>>            \
   initial_element_ids<GET_DIM(data)>(                       \
       const std::vector<std::array<size_t, GET_DIM(data)>>& \
-          initial_refinement_levels) noexcept;
+          initial_refinement_levels,                        \
+      size_t grid_index) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 

--- a/src/Domain/Structure/InitialElementIds.hpp
+++ b/src/Domain/Structure/InitialElementIds.hpp
@@ -16,11 +16,12 @@ class ElementId;
 /// \brief Create the `ElementId`s of the a single Block
 template <size_t VolumeDim>
 std::vector<ElementId<VolumeDim>> initial_element_ids(
-    size_t block_id, std::array<size_t, VolumeDim> initial_ref_levs) noexcept;
+    size_t block_id, std::array<size_t, VolumeDim> initial_ref_levs,
+    size_t grid_index = 0) noexcept;
 
 /// \ingroup ComputationalDomainGroup
 /// \brief Create the `ElementId`s of the initial computational domain.
 template <size_t VolumeDim>
 std::vector<ElementId<VolumeDim>> initial_element_ids(
-    const std::vector<std::array<size_t, VolumeDim>>&
-        initial_refinement_levels) noexcept;
+    const std::vector<std::array<size_t, VolumeDim>>& initial_refinement_levels,
+    size_t grid_index = 0) noexcept;

--- a/src/Domain/Structure/SegmentId.cpp
+++ b/src/Domain/Structure/SegmentId.cpp
@@ -11,7 +11,10 @@
 #include "Utilities/ErrorHandling/Assert.hpp"
 
 SegmentId::SegmentId(const size_t refinement_level, const size_t index) noexcept
-    : block_id_(0), refinement_level_(refinement_level), index_(index) {
+    : block_id_(0),
+      refinement_level_(refinement_level),
+      index_(index),
+      grid_index_(0) {
   ASSERT(refinement_level <= max_refinement_level,
          "Refinement level out of bounds: " << refinement_level);
   ASSERT(index < two_to_the(refinement_level),
@@ -19,8 +22,11 @@ SegmentId::SegmentId(const size_t refinement_level, const size_t index) noexcept
 }
 
 SegmentId::SegmentId(const size_t block_id, const size_t refinement_level,
-                     const size_t index) noexcept
-    : block_id_(block_id), refinement_level_(refinement_level), index_(index) {
+                     const size_t index, const size_t grid_index) noexcept
+    : block_id_(block_id),
+      refinement_level_(refinement_level),
+      index_(index),
+      grid_index_(grid_index) {
   ASSERT(block_id < two_to_the(block_id_bits),
          "Block id out of bounds: " << block_id << "\nMaximum value is: "
                                     << two_to_the(block_id_bits) - 1);
@@ -30,6 +36,9 @@ SegmentId::SegmentId(const size_t block_id, const size_t refinement_level,
                                             << max_refinement_level);
   ASSERT(index < two_to_the(refinement_level),
          "index = " << index << ", refinement_level = " << refinement_level);
+  ASSERT(grid_index < two_to_the(grid_index_bits),
+         "Grid index out of bounds: " << grid_index << "\nMaximum value is: "
+                                      << two_to_the(grid_index_bits) - 1);
 }
 
 // Because `ElementId` is built up of `VolumeDim` `SegmentId`s, and `ElementId`

--- a/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp
+++ b/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp
@@ -83,14 +83,12 @@ struct InitializeDomain {
       domain::Tags::DetInvJacobianCompute<Dim, Frame::Logical, Frame::Inertial>,
       domain::Tags::MinimumGridSpacingCompute<Dim, Frame::Inertial>>>;
 
-  template <
-      typename DataBox, typename... InboxTags, typename Metavariables,
-      typename ActionList, typename ParallelComponent>
+  template <typename DataBox, typename... InboxTags, typename Metavariables,
+            typename ActionList, typename ParallelComponent>
   static auto apply(DataBox& box,
                     const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
-                    const ElementId<Dim>& array_index,
-                    const ActionList /*meta*/,
+                    const ElementId<Dim>& element_id, const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
     const auto& initial_extents =
         db::get<domain::Tags::InitialExtents<Dim>>(box);
@@ -98,7 +96,6 @@ struct InitializeDomain {
         db::get<domain::Tags::InitialRefinementLevels<Dim>>(box);
     const auto& domain = db::get<domain::Tags::Domain<Dim>>(box);
 
-    const ElementId<Dim> element_id{array_index};
     const auto& my_block = domain.blocks()[element_id.block_id()];
     Mesh<Dim> mesh = domain::Initialization::create_initial_mesh(
         initial_extents, element_id, Spectral::Quadrature::GaussLobatto);

--- a/tests/Unit/Domain/Structure/Test_ElementId.cpp
+++ b/tests/Unit/Domain/Structure/Test_ElementId.cpp
@@ -25,11 +25,12 @@ namespace {
 template <size_t VolumeDim>
 void test_placement_new_and_hashing_impl(
     const size_t block1, const std::array<SegmentId, VolumeDim>& segments1,
-    const size_t block2, const std::array<SegmentId, VolumeDim>& segments2) {
+    const size_t grid1, const size_t block2,
+    const std::array<SegmentId, VolumeDim>& segments2, const size_t grid2) {
   using Hash = std::hash<ElementId<VolumeDim>>;
 
-  const ElementId<VolumeDim> id1(block1, segments1);
-  const ElementId<VolumeDim> id2(block2, segments2);
+  const ElementId<VolumeDim> id1(block1, segments1, grid1);
+  const ElementId<VolumeDim> id2(block2, segments2, grid2);
 
   ElementId<VolumeDim> test_id1{};
   ElementId<VolumeDim> test_id2{};
@@ -54,23 +55,28 @@ void test_placement_new_and_hashing_impl(
 void test_placement_new_and_hashing() {
   const std::array<size_t, 3> blocks{{0, 1, 4}};
   const std::array<SegmentId, 4> segments{{{0, 0}, {1, 0}, {1, 1}, {8, 4}}};
+  const std::array<size_t, 3> grids{{0, 1, 3}};
 
   for (const auto& block1 : blocks) {
     for (const auto& block2 : blocks) {
-      for (const auto& segment10 : segments) {
-        for (const auto& segment20 : segments) {
-          test_placement_new_and_hashing_impl<1>(block1, {{segment10}}, block2,
-                                                 {{segment20}});
-          for (const auto& segment11 : segments) {
-            for (const auto& segment21 : segments) {
-              test_placement_new_and_hashing_impl<2>(
-                  block1, {{segment10, segment11}}, block2,
-                  {{segment20, segment21}});
-              for (const auto& segment12 : segments) {
-                for (const auto& segment22 : segments) {
-                  test_placement_new_and_hashing_impl<3>(
-                      block1, {{segment10, segment11, segment12}}, block2,
-                      {{segment20, segment21, segment22}});
+      for (const auto& grid1 : grids) {
+        for (const auto& grid2 : grids) {
+          for (const auto& segment10 : segments) {
+            for (const auto& segment20 : segments) {
+              test_placement_new_and_hashing_impl<1>(
+                  block1, {{segment10}}, grid1, block2, {{segment20}}, grid2);
+              for (const auto& segment11 : segments) {
+                for (const auto& segment21 : segments) {
+                  test_placement_new_and_hashing_impl<2>(
+                      block1, {{segment10, segment11}}, grid1, block2,
+                      {{segment20, segment21}}, grid2);
+                  for (const auto& segment12 : segments) {
+                    for (const auto& segment22 : segments) {
+                      test_placement_new_and_hashing_impl<3>(
+                          block1, {{segment10, segment11, segment12}}, grid1,
+                          block2, {{segment20, segment21, segment22}}, grid2);
+                    }
+                  }
                 }
               }
             }
@@ -88,39 +94,50 @@ void test_element_id() {
   ElementId<3> block_2_3d(2, segment_ids);
   CHECK(block_2_3d.block_id() == 2);
   CHECK(block_2_3d.segment_ids() == segment_ids);
+  CHECK(block_2_3d.grid_index() == 0);
 
   // Test parent and child operations:
-  ElementId<3> id = block_2_3d;
-  for (size_t dim = 0; dim < 3; dim++) {
-    CHECK(id == id.id_of_child(dim, Side::Lower).id_of_parent(dim));
-    CHECK(id == id.id_of_child(dim, Side::Upper).id_of_parent(dim));
-    if (0 == gsl::at(id.segment_ids(), dim).index() % 2) {
-      CHECK(id == id.id_of_parent(dim).id_of_child(dim, Side::Lower));
-    } else {
-      CHECK(id == id.id_of_parent(dim).id_of_child(dim, Side::Upper));
+  const auto check_parent_and_child = [](const ElementId<3>& id) {
+    for (size_t dim = 0; dim < 3; dim++) {
+      CHECK(id == id.id_of_child(dim, Side::Lower).id_of_parent(dim));
+      CHECK(id == id.id_of_child(dim, Side::Upper).id_of_parent(dim));
+      if (0 == gsl::at(id.segment_ids(), dim).index() % 2) {
+        CHECK(id == id.id_of_parent(dim).id_of_child(dim, Side::Lower));
+      } else {
+        CHECK(id == id.id_of_parent(dim).id_of_child(dim, Side::Upper));
+      }
     }
-  }
+  };
+  check_parent_and_child(block_2_3d);
+  check_parent_and_child({3, segment_ids, 4});
 
   // Test equality operator:
   ElementId<3> element_one(1);
   ElementId<3> element_two(1);
   ElementId<3> element_three(2);
   ElementId<3> element_four(4);
+  ElementId<3> element_five(4, 0);
+  ElementId<3> element_six(4, 1);
   CHECK(element_one == element_two);
   CHECK(element_two != element_three);
   CHECK(element_two != element_four);
   CHECK(element_three != block_2_3d);
+  CHECK(element_five == element_four);
+  CHECK(element_six != element_four);
 
   // Test pup operations:
   test_serialization(element_one);
+  test_serialization(element_six);
 
   // Test output operator:
   CHECK(get_output(block_2_3d) == "[B2,(L2I3,L1I0,L1I1)]");
+  CHECK(get_output(element_six) == "[B4,(L0I0,L0I0,L0I0),G1]");
 
   CHECK(ElementId<3>::external_boundary_id().block_id() ==
         two_to_the(SegmentId::block_id_bits) - 1);
   CHECK(ElementId<3>::external_boundary_id().segment_ids() ==
         make_array<3>(SegmentId(SegmentId::max_refinement_level, 0)));
+  CHECK(ElementId<3>::external_boundary_id().grid_index() == 0);
 }
 
 template <size_t VolumeDim>
@@ -166,6 +183,18 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.ElementId", "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   auto failed_element_id = ElementId<1>(two_to_the(SegmentId::block_id_bits));
+  static_cast<void>(failed_element_id);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Grid index out of bounds]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Structure.ElementId.BadGridIndex",
+                               "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  auto failed_element_id =
+      ElementId<1>(0, {{{0, 0}}}, two_to_the(SegmentId::grid_index_bits));
   static_cast<void>(failed_element_id);
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif

--- a/tests/Unit/Domain/Structure/Test_ElementId.cpp
+++ b/tests/Unit/Domain/Structure/Test_ElementId.cpp
@@ -147,23 +147,27 @@ void test_serialization() noexcept {
   const auto initial_ref_levels = make_array<volume_dim>(1_st);
   for (size_t block_id = 0; block_id < two_to_the(SegmentId::block_id_bits);
        ++block_id) {
-    const std::vector<ElementId<volume_dim>> element_ids =
-        initial_element_ids(block_id, initial_ref_levels);
-    for (const auto element_id : element_ids) {
-      const auto serialized_id = serialize_and_deserialize(element_id);
-      CHECK(serialized_id == element_id);
-      // The following checks that ElementId can be used as a Charm array index
-      Parallel::ArrayIndex<ElementId<volume_dim>> array_index(element_id);
-      CHECK(element_id == array_index.get_index());
-      // now check pupping the ArrayIndex works...
-      const auto serialized_array_index =
-          serialize<Parallel::ArrayIndex<ElementId<volume_dim>>>(array_index);
-      PUP::fromMem reader(serialized_array_index.data());
-      Parallel::ArrayIndex<ElementId<volume_dim>> deserialized_array_index(
-          unused_id);
-      reader | deserialized_array_index;
-      CHECK(array_index == deserialized_array_index);
-      CHECK(element_id == deserialized_array_index.get_index());
+    for (size_t grid_index = 0;
+         grid_index < two_to_the(SegmentId::grid_index_bits); ++grid_index) {
+      const std::vector<ElementId<volume_dim>> element_ids =
+          initial_element_ids(block_id, initial_ref_levels, grid_index);
+      for (const auto element_id : element_ids) {
+        const auto serialized_id = serialize_and_deserialize(element_id);
+        CHECK(serialized_id == element_id);
+        // The following checks that ElementId can be used as a Charm array
+        // index
+        Parallel::ArrayIndex<ElementId<volume_dim>> array_index(element_id);
+        CHECK(element_id == array_index.get_index());
+        // now check pupping the ArrayIndex works...
+        const auto serialized_array_index =
+            serialize<Parallel::ArrayIndex<ElementId<volume_dim>>>(array_index);
+        PUP::fromMem reader(serialized_array_index.data());
+        Parallel::ArrayIndex<ElementId<volume_dim>> deserialized_array_index(
+            unused_id);
+        reader | deserialized_array_index;
+        CHECK(array_index == deserialized_array_index);
+        CHECK(element_id == deserialized_array_index.get_index());
+      }
     }
   }
 }

--- a/tests/Unit/Domain/Structure/Test_InitialElementIds.cpp
+++ b/tests/Unit/Domain/Structure/Test_InitialElementIds.cpp
@@ -18,8 +18,8 @@ namespace {
 template <size_t VolumeDim>
 void test_initial_element_ids(
     const std::vector<ElementId<VolumeDim>>& element_ids,
-    const std::vector<std::array<size_t, VolumeDim>>&
-        initial_refinement_levels) noexcept {
+    const std::vector<std::array<size_t, VolumeDim>>& initial_refinement_levels,
+    size_t grid_index) noexcept {
   size_t expected_number_of_elements = 0;
   for (const auto& initial_refinement_levels_of_block :
        initial_refinement_levels) {
@@ -36,6 +36,7 @@ void test_initial_element_ids(
   boost::rational<size_t> logical_volume_of_blocks(0);
   for (const auto& element_id : element_ids) {
     logical_volume_of_blocks += fraction_of_block_volume(element_id);
+    CHECK(element_id.grid_index() == grid_index);
   }
   CHECK(expected_logical_volume_of_blocks == logical_volume_of_blocks);
 }
@@ -45,15 +46,21 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.InitialElementIds", "[Domain][Unit]") {
   const std::vector<std::array<size_t, 1>> initial_refinement_levels_1d{{{2}},
                                                                         {{3}}};
   const auto element_ids_1d = initial_element_ids(initial_refinement_levels_1d);
-  test_initial_element_ids(element_ids_1d, initial_refinement_levels_1d);
+  test_initial_element_ids(element_ids_1d, initial_refinement_levels_1d, 0);
+  test_initial_element_ids(initial_element_ids(initial_refinement_levels_1d, 3),
+                           initial_refinement_levels_1d, 3);
 
   const std::vector<std::array<size_t, 2>> initial_refinement_levels_2d{
       {{2, 0}}, {{3, 1}}};
   const auto element_ids_2d = initial_element_ids(initial_refinement_levels_2d);
-  test_initial_element_ids(element_ids_2d, initial_refinement_levels_2d);
+  test_initial_element_ids(element_ids_2d, initial_refinement_levels_2d, 0);
+  test_initial_element_ids(initial_element_ids(initial_refinement_levels_2d, 3),
+                           initial_refinement_levels_2d, 3);
 
   const std::vector<std::array<size_t, 3>> initial_refinement_levels_3d{
       {{4, 2, 1}}, {{0, 3, 2}}};
   const auto element_ids_3d = initial_element_ids(initial_refinement_levels_3d);
-  test_initial_element_ids(element_ids_3d, initial_refinement_levels_3d);
+  test_initial_element_ids(element_ids_3d, initial_refinement_levels_3d, 0);
+  test_initial_element_ids(initial_element_ids(initial_refinement_levels_3d, 3),
+                           initial_refinement_levels_3d, 3);
 }

--- a/tests/Unit/Domain/Test_CreateInitialElement.cpp
+++ b/tests/Unit/Domain/Test_CreateInitialElement.cpp
@@ -485,5 +485,33 @@ SPECTRE_TEST_CASE("Unit.Domain.CreateInitialElement", "[Domain][Unit]") {
         Neighbors<2>{{ElementId<2>{0, {{SegmentId{2, 3}, SegmentId{3, 6}}}}},
                      aligned}}});
 
+  {
+    // element with a non-zero grid index
+    const size_t grid_index = 3;
+    test_create_initial_element(
+        ElementId<2>{0, {{SegmentId{2, 2}, SegmentId{3, 4}}}, grid_index},
+        test_block, refinement,
+        {{Direction<2>::upper_xi(),
+          Neighbors<2>{
+              {ElementId<2>{
+                  0, {{SegmentId{2, 3}, SegmentId{3, 4}}}, grid_index}},
+              aligned}},
+         {Direction<2>::lower_xi(),
+          Neighbors<2>{
+              {ElementId<2>{
+                  0, {{SegmentId{2, 1}, SegmentId{3, 4}}}, grid_index}},
+              aligned}},
+         {Direction<2>::upper_eta(),
+          Neighbors<2>{
+              {ElementId<2>{
+                  0, {{SegmentId{2, 2}, SegmentId{3, 5}}}, grid_index}},
+              aligned}},
+         {Direction<2>::lower_eta(),
+          Neighbors<2>{
+              {ElementId<2>{
+                  0, {{SegmentId{2, 2}, SegmentId{3, 3}}}, grid_index}},
+              aligned}}});
+  }
+
   test_h_refinement();
 }


### PR DESCRIPTION
## Proposed changes

Add a "grid index" to `ElementId` to identify elements across multiple grids. This allows the multigrid linear solver to allocate a hierarchy of grids.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
