### PR TITLE
CylindricalEndcap: Keep proj point farther from invertibility cone.

### DIFF
--- a/src/Domain/CoordinateMaps/CylindricalEndcap.cpp
+++ b/src/Domain/CoordinateMaps/CylindricalEndcap.cpp
@@ -152,16 +152,6 @@ CylindricalEndcap::CylindricalEndcap(const std::array<double, 3>& center_one,
              << radius_one << ", radius_two = " << radius_two
              << ", dist_spheres = " << dist_spheres);
 
-  // Check if we are too close to singular.  We do this check
-  // separately from the earlier similar check because this check may
-  // be changed in the future based on further testing and further
-  // logic that may be added (for example we may want to change the
-  // 0.85 to some other number), but the previous check (without the
-  // 0.85) is a hard limit that should always be obeyed.
-  ASSERT(acos(abs(cos_alpha)) < abs(0.85 * asin(cos_theta)),
-         "Parameters are close to where the map becomes "
-         "non-invertible.  The map has not been tested for this case.");
-
   const double proj_radius_two_squared =
       square(center_two[0] - proj_center[0]) +
       square(center_two[1] - proj_center[1]) +
@@ -174,6 +164,24 @@ CylindricalEndcap::CylindricalEndcap(const std::array<double, 3>& center_one,
 
   if (dist_spheres + radius_two < radius_one) {
     // sphere_two is contained in sphere_one
+
+    // Check if we are too close to singular.  We do this check
+    // separately from the earlier similar check because this check
+    // may be changed in the future based on further testing and
+    // further logic that may be added (for example we may want to
+    // change the 0.85 to some other number), but the previous check
+    // (without the 0.85) is a hard limit that should always be
+    // obeyed.  We also use a different threshold for sphere_two
+    // contained inside sphere_one than we do for sphere_one contained
+    // inside sphere_two.
+    ASSERT(acos(abs(cos_alpha)) < abs(0.85 * asin(cos_theta)),
+           "Parameters are close to where the map becomes non-invertible. "
+           "acos(abs(cos_alpha)) = "
+               << acos(abs(cos_alpha)) << " and abs(asin(cos_theta)) = "
+               << abs(asin(cos_theta)) << ", so the ratio is "
+               << acos(abs(cos_alpha)) / abs(asin(cos_theta))
+               << ". The map has not been tested for this "
+                  "case.");
 
     // We keep this as a separate condition because we may change the
     // number 0.85 in the future if we ever have reason to do so.
@@ -197,6 +205,24 @@ CylindricalEndcap::CylindricalEndcap(const std::array<double, 3>& center_one,
                << proj_radius_two_squared - square(0.1 * radius_two));
   } else {
     // sphere_one is contained in sphere_two.
+
+    // Check if we are too close to singular.  We do this check
+    // separately from the earlier similar check because this check
+    // may be changed in the future based on further testing and
+    // further logic that may be added (for example we may want to
+    // change the 0.75 to some other number), but the previous check
+    // (without the 0.75) is a hard limit that should always be
+    // obeyed.  We also use a different threshold for sphere_two
+    // contained inside sphere_one than we do for sphere_one contained
+    // inside sphere_two.
+    ASSERT(acos(abs(cos_alpha)) < abs(0.75 * asin(cos_theta)),
+           "Parameters are close to where the map becomes non-invertible. "
+           "acos(abs(cos_alpha)) = "
+               << acos(abs(cos_alpha)) << " and abs(asin(cos_theta)) = "
+               << abs(asin(cos_theta)) << ", so the ratio is "
+               << acos(abs(cos_alpha)) / abs(asin(cos_theta))
+               << ". The map has not been tested for this "
+                  "case.");
 
     ASSERT(1.01 * (dist_spheres + radius_one) <= radius_two,
            "The map has been tested only for the case when "

--- a/tests/Unit/Domain/CoordinateMaps/Test_CylindricalEndcap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CylindricalEndcap.cpp
@@ -203,11 +203,11 @@ void test_cylindrical_endcap_sphere_two_large() {
     // We typically expect success on the first iteration or the first
     // few iterations if we get unlucky.  Let V_O be the volume of
     // cone_opening that is contained inside sphere_two.  If
-    // cone_regular (modulo a small buffer angle, the 0.85 below)
+    // cone_regular (modulo a small buffer angle, the 0.75 below)
     // contains V_O, then success is certain the first
     // time. Otherwise, the probability of success is roughly V_R/V_O,
     // where V_R is the volume of the portion of cone_regular (modulo
-    // a small buffer angle, the 0.85 below) that is contained inside
+    // a small buffer angle, the 0.75 below) that is contained inside
     // V_O.
 
     // Pick radius of the larger sphere to enclose the smaller one
@@ -249,9 +249,9 @@ void test_cylindrical_endcap_sphere_two_large() {
 
     // Now for the rejection.  We reject the point if it is outside
     // cone_opening, and we also reject the point if it is too close
-    // to cone_opening (using a factor 0.85 that is the same as the
+    // to cone_opening (using a factor 0.75 that is the same as the
     // factor in the ASSERTS in the CylindricalEndcap constructor).
-    const double alpha = 0.85 * cone_regular_opening_angle;
+    const double alpha = 0.75 * cone_regular_opening_angle;
 
     // If beta <= alpha, then there is no max distance, i.e.
     // all distances are ok.


### PR DESCRIPTION
## Proposed changes

This ensures that the map is farther from where it goes singular,
so that large roundoff errors do not occur.
Code is unchanged for sphere_two contained inside sphere_one.

Test succeeded with --repeat-until-fail 10000.

Fixes #3028

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
