### PR TITLE
Disallow step changes when slab number is negative

### DIFF
--- a/src/Time/Actions/SelfStartActions.hpp
+++ b/src/Time/Actions/SelfStartActions.hpp
@@ -411,6 +411,16 @@ struct Cleanup {
             *tag_value = std::decay_t<decltype(*tag_value)>{};
           });
         });
+    ASSERT(
+        db::get<::Tags::HistoryEvolvedVariables<>>(box).integration_order() ==
+            db::get<::Tags::TimeStepper<>>(box).order(),
+        "Volume history order is: "
+            << db::get<::Tags::HistoryEvolvedVariables<>>(box)
+                   .integration_order()
+            << " but time stepper requires order: "
+            << db::get<::Tags::TimeStepper<>>(box).order()
+            << ". This may indicate that the step size has varied during "
+               "self-start, which should not be permitted.");
     return std::make_tuple(std::move(box));
   }
 };

--- a/src/Time/CMakeLists.txt
+++ b/src/Time/CMakeLists.txt
@@ -8,6 +8,7 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  SelfStart.cpp
   Slab.cpp
   Time.cpp
   TimeSequence.cpp
@@ -22,6 +23,7 @@ spectre_target_headers(
   BoundaryHistory.hpp
   EvolutionOrdering.hpp
   History.hpp
+  SelfStart.hpp
   Slab.hpp
   Tags.hpp
   TakeStep.hpp

--- a/src/Time/SelfStart.cpp
+++ b/src/Time/SelfStart.cpp
@@ -1,0 +1,12 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Time/SelfStart.hpp"
+
+#include "Time/TimeStepId.hpp"
+
+namespace SelfStart {
+bool is_self_starting(const TimeStepId& time_id) noexcept {
+  return time_id.slab_number() < 0;
+}
+}  // namespace SelfStart

--- a/src/Time/SelfStart.hpp
+++ b/src/Time/SelfStart.hpp
@@ -1,0 +1,15 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Time/TimeStepId.hpp"
+
+namespace SelfStart {
+/// Reports whether the `time_id` is during self start
+///
+/// This currently assumes that the slab number of the `time_id` will be
+/// negative if and only if self-start is in progress. If self start is
+/// modified to alter that behavior, this utility must also be modified.
+bool is_self_starting(const TimeStepId& time_id) noexcept;
+}  // namespace SelfStart

--- a/src/Time/TimeSteppers/AdamsBashforthN.hpp
+++ b/src/Time/TimeSteppers/AdamsBashforthN.hpp
@@ -22,6 +22,7 @@
 #include "Options/Options.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "Time/EvolutionOrdering.hpp"
+#include "Time/SelfStart.hpp"
 #include "Time/Time.hpp"
 #include "Time/TimeStepId.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"  // IWYU pragma: keep
@@ -759,9 +760,10 @@ bool AdamsBashforthN::can_change_step_size(
   // evolution until the self-start history has been replaced with
   // "real" values.
   const evolution_less<Time> less{time_id.time_runs_forward()};
-  return history.size() == 0 or
-         (less(history.back(), time_id.step_time()) and
-          std::is_sorted(history.begin(), history.end(), less));
+  return not ::SelfStart::is_self_starting(time_id) and
+         (history.size() == 0 or
+          (less(history.back(), time_id.step_time()) and
+           std::is_sorted(history.begin(), history.end(), less)));
 }
 
 template <typename Iterator, typename Delta>

--- a/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
@@ -30,13 +30,13 @@ Evolution:
         SafetyFactor: 0.2
 
 DomainCreator:
-  Interval:
+  RotatedIntervals:
     LowerBound: [0.0]
+    Midpoint: [3.14159]
     UpperBound: [6.283185307179586]
     IsPeriodicIn: [true]
-    InitialRefinement: [2]
-    InitialGridPoints: [7]
-    TimeDependence: None
+    InitialRefinement: [1]
+    InitialGridPoints: [[7, 3]]
 
 SpatialDiscretization:
   DiscontinuousGalerkin:

--- a/tests/Unit/Time/CMakeLists.txt
+++ b/tests/Unit/Time/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_Time")
 set(LIBRARY_SOURCES
   Test_EvolutionOrdering.cpp
   Test_History.cpp
+  Test_SelfStart.cpp
   Test_Slab.cpp
   Test_Tags.cpp
   Test_TakeStep.cpp

--- a/tests/Unit/Time/Test_SelfStart.cpp
+++ b/tests/Unit/Time/Test_SelfStart.cpp
@@ -1,0 +1,19 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Time/SelfStart.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeStepId.hpp"
+
+SPECTRE_TEST_CASE("Unit.Time.SelfStart", "[Unit][Time][Actions]") {
+  CHECK(SelfStart::is_self_starting(
+      TimeStepId{true, -1, Time{{0.0, 1.0}, {1, 5}}}));
+  CHECK(SelfStart::is_self_starting(
+      TimeStepId{true, -5, Time{{0.5, 0.6}, {4, 9}}}));
+  CHECK_FALSE(SelfStart::is_self_starting(
+      TimeStepId{true, 0, Time{{0.0, 1.0}, {1, 5}}}));
+  CHECK_FALSE(SelfStart::is_self_starting(
+      TimeStepId{true, 5, Time{{0.5, 0.6}, {4, 9}}}));
+}


### PR DESCRIPTION
## Proposed changes

There are some edge cases where the `can_change_step_size` check in `AdamsBashforthN` doesn't manage to identify self-start, and the step ends up changing, which causes surprising breaks when evolution starts.
This fix makes the assumption that self-start has negative slab numbers, which is true for the current implementation, but may need to be changed in future.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
