### PR TITLE
Add using_subcell type trait

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -13,6 +13,7 @@ spectre_target_headers(
   MortarTags.hpp
   NormalVectorTags.hpp
   ProjectToBoundary.hpp
+  UsingSubcell.hpp
   )
 
 spectre_target_sources(

--- a/src/Evolution/DiscontinuousGalerkin/UsingSubcell.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/UsingSubcell.hpp
@@ -1,0 +1,36 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <type_traits>
+
+namespace evolution::dg {
+/*!
+ * \brief If `Metavars` has a `SubcellOptions` member struct and
+ * `SubcellOptions::subcell_enabled` is `true` then inherits from
+ * `std::true_type`, otherwise inherits from `std::false_type`.
+ *
+ * \note This check is intentionally not inside the `DgSubcell` library so that
+ * executables that do not use subcell do not need to link against it.
+ */
+template <typename Metavars, typename = std::void_t<>>
+struct using_subcell : std::false_type {};
+
+/// \cond
+template <typename Metavars>
+struct using_subcell<Metavars, std::void_t<typename Metavars::SubcellOptions>>
+    : std::bool_constant<Metavars::SubcellOptions::subcell_enabled> {};
+/// \endcond
+
+/*!
+ * \brief If `Metavars` has a `SubcellOptions` member struct and
+ * `SubcellOptions::subcell_enabled` is `true` then is `true`, otherwise
+ * `false`.
+ *
+ * \note This check is intentionally not inside the `DgSubcell` library so that
+ * executables that do not use subcell do not need to link against it.
+ */
+template <typename Metavars>
+constexpr bool using_subcell_v = using_subcell<Metavars>::value;
+}  // namespace evolution::dg

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -20,6 +20,7 @@ set(LIBRARY_SOURCES
   Test_MortarTags.cpp
   Test_NormalVectorTags.cpp
   Test_ProjectToBoundary.cpp
+  Test_UsingSubcell.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_UsingSubcell.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_UsingSubcell.cpp
@@ -1,0 +1,27 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Evolution/DiscontinuousGalerkin/UsingSubcell.hpp"
+
+namespace {
+template <bool SubcellEnabled>
+struct MetavarsSubcell {
+  struct SubcellOptions {
+    static constexpr bool subcell_enabled = SubcellEnabled;
+  };
+};
+
+struct MetavarsNoSubcell {};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.DG.UsingSubcell", "[Unit][Evolution]") {
+  static_assert(not evolution::dg::using_subcell_v<MetavarsNoSubcell>);
+  static_assert(not evolution::dg::using_subcell_v<MetavarsSubcell<false>>);
+  static_assert(evolution::dg::using_subcell_v<MetavarsSubcell<true>>);
+
+  CHECK(not evolution::dg::using_subcell_v<MetavarsNoSubcell>);
+  CHECK(not evolution::dg::using_subcell_v<MetavarsSubcell<false>>);
+  CHECK(evolution::dg::using_subcell_v<MetavarsSubcell<true>>);
+}


### PR DESCRIPTION
## Proposed changes

Adds a type trait that can be used to check if we are using subcell. This is not part of the `DgSubcell` library so that not all executables will need to link against `DgSubcell`

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
