### PR TITLE
Add function to slice data on subcells

### DIFF
--- a/src/Evolution/DgSubcell/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/CMakeLists.txt
@@ -18,6 +18,7 @@ spectre_target_headers(
   Projection.hpp
   RdmpTci.hpp
   Reconstruction.hpp
+  SliceData.hpp
   SubcellOptions.hpp
   TciStatus.hpp
   TwoMeshRdmpTci.hpp
@@ -33,6 +34,7 @@ spectre_target_sources(
   PerssonTci.cpp
   Projection.cpp
   Reconstruction.cpp
+  SliceData.cpp
   SubcellOptions.cpp
   TciStatus.cpp
   )

--- a/src/Evolution/DgSubcell/SliceData.cpp
+++ b/src/Evolution/DgSubcell/SliceData.cpp
@@ -1,0 +1,133 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/DgSubcell/SliceData.hpp"
+
+#include <array>
+#include <cstddef>
+#include <vector>
+
+#include "DataStructures/Index.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Side.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace evolution::dg::subcell::detail {
+namespace {
+template <size_t Dim>
+void copy_data(gsl::not_null<std::vector<double>*> sliced_subcell_vars,
+               const gsl::span<const double>& volume_subcell_vars,
+               size_t component_offset, size_t component_offset_volume,
+               const std::array<size_t, Dim>& lower_bounds,
+               const std::array<size_t, Dim>& upper_bounds,
+               const Index<Dim>& volume_extents) noexcept;
+
+template <>
+void copy_data(const gsl::not_null<std::vector<double>*> sliced_subcell_vars,
+               const gsl::span<const double>& volume_subcell_vars,
+               const size_t component_offset,
+               const size_t component_offset_volume,
+               const std::array<size_t, 1>& lower_bounds,
+               const std::array<size_t, 1>& upper_bounds,
+               const Index<1>& /*volume_extents*/) noexcept {
+  for (size_t i = lower_bounds[0], index = 0; i < upper_bounds[0];
+       ++i, ++index) {
+    (*sliced_subcell_vars)[component_offset + index] =
+        volume_subcell_vars[component_offset_volume + i];
+  }
+}
+
+template <>
+void copy_data(const gsl::not_null<std::vector<double>*> sliced_subcell_vars,
+               const gsl::span<const double>& volume_subcell_vars,
+               const size_t component_offset,
+               const size_t component_offset_volume,
+               const std::array<size_t, 2>& lower_bounds,
+               const std::array<size_t, 2>& upper_bounds,
+               const Index<2>& volume_extents) noexcept {
+  for (size_t j = lower_bounds[1], index = 0; j < upper_bounds[1]; ++j) {
+    for (size_t i = lower_bounds[0]; i < upper_bounds[0]; ++i, ++index) {
+      (*sliced_subcell_vars)[component_offset + index] =
+          volume_subcell_vars[component_offset_volume + i +
+                              j * volume_extents[0]];
+    }
+  }
+}
+
+template <>
+void copy_data(const gsl::not_null<std::vector<double>*> sliced_subcell_vars,
+               const gsl::span<const double>& volume_subcell_vars,
+               const size_t component_offset,
+               const size_t component_offset_volume,
+               const std::array<size_t, 3>& lower_bounds,
+               const std::array<size_t, 3>& upper_bounds,
+               const Index<3>& volume_extents) noexcept {
+  for (size_t k = lower_bounds[2], index = 0; k < upper_bounds[2]; ++k) {
+    for (size_t j = lower_bounds[1]; j < upper_bounds[1]; ++j) {
+      for (size_t i = lower_bounds[0]; i < upper_bounds[0]; ++i, ++index) {
+        (*sliced_subcell_vars)[component_offset + index] =
+            volume_subcell_vars[component_offset_volume + i +
+                                volume_extents[0] *
+                                    (j + k * volume_extents[1])];
+      }
+    }
+  }
+}
+}  // namespace
+
+template <size_t Dim>
+DirectionMap<Dim, std::vector<double>> slice_data_impl(
+    const gsl::span<const double>& volume_subcell_vars,
+    const Index<Dim>& subcell_extents, const size_t number_of_ghost_points,
+    const DirectionMap<Dim, bool>& directions_to_slice) noexcept {
+  const size_t num_pts = subcell_extents.product();
+  const size_t number_of_components = volume_subcell_vars.size() / num_pts;
+  std::array<size_t, Dim> result_grid_points{};
+  for (size_t d = 0; d < Dim; ++d) {
+    gsl::at(result_grid_points, d) =
+        number_of_ghost_points * subcell_extents.slice_away(d).product();
+  }
+  DirectionMap<Dim, std::vector<double>> result{};
+  for (const auto& [dir, should_slice] : directions_to_slice) {
+    if (should_slice) {
+      result[dir] = std::vector<double>(
+          gsl::at(result_grid_points, dir.dimension()) * number_of_components);
+    }
+  }
+
+  for (size_t component_index = 0; component_index < number_of_components;
+       ++component_index) {
+    const size_t component_offset_volume = component_index * num_pts;
+    for (auto& [direction, sliced_data] : result) {
+      const size_t component_offset_result =
+          gsl::at(result_grid_points, direction.dimension()) * component_index;
+      std::array<size_t, Dim> lower_bounds =
+          make_array<Dim>(static_cast<size_t>(0));
+      std::array<size_t, Dim> upper_bounds = subcell_extents.indices();
+      if (direction.side() == Side::Lower) {
+        gsl::at(upper_bounds, direction.dimension()) = number_of_ghost_points;
+      } else {
+        gsl::at(lower_bounds, direction.dimension()) =
+            gsl::at(upper_bounds, direction.dimension()) -
+            number_of_ghost_points;
+      }
+      copy_data(&sliced_data, volume_subcell_vars, component_offset_result,
+                component_offset_volume, lower_bounds, upper_bounds,
+                subcell_extents);
+    }
+  }
+  return result;
+}
+
+template DirectionMap<1, std::vector<double>> slice_data_impl(
+    const gsl::span<const double>&, const Index<1>&, const size_t,
+    const DirectionMap<1, bool>&) noexcept;
+template DirectionMap<2, std::vector<double>> slice_data_impl(
+    const gsl::span<const double>&, const Index<2>&, const size_t,
+    const DirectionMap<2, bool>&) noexcept;
+template DirectionMap<3, std::vector<double>> slice_data_impl(
+    const gsl::span<const double>&, const Index<3>&, const size_t,
+    const DirectionMap<3, bool>&) noexcept;
+}  // namespace evolution::dg::subcell::detail

--- a/src/Evolution/DgSubcell/SliceData.hpp
+++ b/src/Evolution/DgSubcell/SliceData.hpp
@@ -1,0 +1,53 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include "DataStructures/Variables.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+template <size_t Dim, typename T>
+class DirectionMap;
+template <size_t Dim>
+class Index;
+/// \endcond
+
+namespace evolution::dg::subcell {
+namespace detail {
+template <size_t Dim>
+DirectionMap<Dim, std::vector<double>> slice_data_impl(
+    const gsl::span<const double>& volume_subcell_vars,
+    const Index<Dim>& subcell_extents, size_t number_of_ghost_points,
+    const DirectionMap<Dim, bool>& directions_to_slice) noexcept;
+}  // namespace detail
+
+/*!
+ * \brief Slice the subcell variables needed for neighbors to perform
+ * reconstruction.
+ *
+ * Note that we slice to a grid that is against the boundary of the element but
+ * is several ghost points deep. This is in contrast to the slicing used in the
+ * DG method which is to the boundary of the element only.
+ *
+ * The `number_of_ghost_points` will depend on the number of neighboring points
+ * the reconstruction method needs that is used on the subcell. The
+ * `directions_to_slice` determines in which directions data is sliced.
+ * Generally this will be the directions in which the element has neighbors.
+ *
+ * The data always has the same ordering as the volume data (tags have the same
+ * ordering, grid points are x-varies-fastest).
+ */
+template <size_t Dim, typename TagList>
+DirectionMap<Dim, std::vector<double>> slice_data(
+    const Variables<TagList>& volume_subcell_vars,
+    const Index<Dim>& subcell_extents, const size_t number_of_ghost_points,
+    const DirectionMap<Dim, bool>& directions_to_slice) noexcept {
+  return detail::slice_data_impl(
+      gsl::make_span(volume_subcell_vars.data(), volume_subcell_vars.size()),
+      subcell_extents, number_of_ghost_points, directions_to_slice);
+}
+}  // namespace evolution::dg::subcell

--- a/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
+++ b/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBRARY_SOURCES
   Test_Projection.cpp
   Test_RdmpTci.cpp
   Test_Reconstruction.cpp
+  Test_SliceData.cpp
   Test_SubcellOptions.cpp
   Test_Tags.cpp
   Test_TciStatus.cpp

--- a/tests/Unit/Evolution/DgSubcell/Test_SliceData.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_SliceData.cpp
@@ -1,0 +1,158 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <numeric>
+#include <vector>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/SliceIterator.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Evolution/DgSubcell/SliceData.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace evolution::dg::subcell {
+namespace {
+namespace Tags {
+struct Scalar : db::SimpleTag {
+  using type = ::Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct Vector : db::SimpleTag {
+  using type = tnsr::I<DataVector, Dim>;
+};
+}  // namespace Tags
+
+template <size_t Dim>
+void check_slice(
+    const Index<Dim>& volume_extents, const Index<Dim>& slice_extents,
+    const Direction<Dim>& direction, const size_t fixed_index,
+    const size_t ghost_slice, const size_t component_index,
+    const Variables<tmpl::list<Tags::Scalar, Tags::Vector<Dim>>>& volume_vars,
+    const DirectionMap<Dim, std::vector<double>>& sliced_data) noexcept {
+  const size_t volume_offset = component_index * volume_extents.product();
+  const size_t slice_offset = component_index * slice_extents.product();
+  CAPTURE(volume_offset);
+  CAPTURE(slice_offset);
+
+  for (SliceIterator
+           volume_it(volume_extents, direction.dimension(), fixed_index),
+       slice_it(slice_extents, direction.dimension(), ghost_slice);
+       volume_it; ++volume_it, ++slice_it) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    CHECK(*(volume_vars.data() + volume_offset + volume_it.volume_offset()) ==
+          sliced_data.at(direction)[slice_offset + slice_it.volume_offset()]);
+  }
+}
+
+template <>
+void check_slice<1>(
+    const Index<1>& volume_extents, const Index<1>& slice_extents,
+    const Direction<1>& direction, const size_t fixed_index,
+    const size_t ghost_slice, const size_t component_index,
+    const Variables<tmpl::list<Tags::Scalar, Tags::Vector<1>>>& volume_vars,
+    const DirectionMap<1, std::vector<double>>& sliced_data) noexcept {
+  const size_t volume_offset = component_index * volume_extents.product();
+  const size_t slice_offset = component_index * slice_extents.product();
+  CAPTURE(volume_offset);
+  CAPTURE(slice_offset);
+  for (SliceIterator volume_it(volume_extents, direction.dimension(),
+                               fixed_index);
+       volume_it; ++volume_it) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    CHECK(*(volume_vars.data() + volume_offset + volume_it.volume_offset()) ==
+          sliced_data.at(direction)[slice_offset + ghost_slice]);
+  }
+}
+
+template <size_t Dim>
+void test_slice_data(const std::optional<size_t> do_not_slice_in_direction) {
+  CAPTURE(do_not_slice_in_direction.value_or(-1));
+  for (size_t number_of_ghost_points = 1; number_of_ghost_points < 5;
+       ++number_of_ghost_points) {
+    for (size_t num_pts_1d = 5; num_pts_1d < 7; ++num_pts_1d) {
+      const Index<Dim> extents{num_pts_1d};
+      Variables<tmpl::list<Tags::Scalar, Tags::Vector<Dim>>> volume_vars{
+          extents.product()};
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      std::iota(volume_vars.data(), volume_vars.data() + volume_vars.size(),
+                0.0);
+
+      DirectionMap<Dim, bool> directions_to_slice{};
+      for (const auto& direction : Direction<Dim>::all_directions()) {
+        directions_to_slice[direction] = true;
+      }
+
+      if (do_not_slice_in_direction.has_value()) {
+        directions_to_slice[gsl::at(Direction<Dim>::all_directions(),
+                                    *do_not_slice_in_direction)] = false;
+      }
+
+      const auto sliced_data = subcell::slice_data(
+          volume_vars, extents, number_of_ghost_points, directions_to_slice);
+      for (const auto& direction : Direction<Dim>::all_directions()) {
+        CAPTURE(direction);
+        if (directions_to_slice.count(direction) == 1 and
+            directions_to_slice.at(direction)) {
+          REQUIRE(sliced_data.count(direction) == 1);
+          Index<Dim> subcell_slice_extents = extents;
+          subcell_slice_extents[direction.dimension()] = number_of_ghost_points;
+
+          for (size_t component_index = 0;
+               component_index < volume_vars.number_of_independent_components;
+               ++component_index) {
+            for (size_t ghost_slice = 0; ghost_slice < number_of_ghost_points;
+                 ++ghost_slice) {
+              const size_t fixed_index = direction.side() == Side::Lower
+                                             ? ghost_slice
+                                             : extents[direction.dimension()] +
+                                                   ghost_slice -
+                                                   number_of_ghost_points;
+              CAPTURE(number_of_ghost_points);
+              CAPTURE(num_pts_1d);
+              CAPTURE(direction);
+              CAPTURE(component_index);
+              CAPTURE(ghost_slice);
+              CAPTURE(fixed_index);
+              CAPTURE(volume_vars);
+              CAPTURE(subcell_slice_extents);
+              CAPTURE(sliced_data.at(direction));
+              check_slice(extents, subcell_slice_extents, direction,
+                          fixed_index, ghost_slice, component_index,
+                          volume_vars, sliced_data);
+            }
+          }
+        } else {
+          CHECK(sliced_data.count(direction) == 0);
+        }
+      }
+    }
+  }
+}
+
+template <size_t Dim>
+void test() {
+  CAPTURE(Dim);
+  test_slice_data<Dim>(std::nullopt);
+  for (size_t i = 0; i < 2 * Dim; ++i) {
+    test_slice_data<Dim>(i);
+  }
+}
+
+// [[TimeOut, 8]]
+SPECTRE_TEST_CASE("Unit.Evolution.Subcell.SliceData", "[Evolution][Unit]") {
+  test<1>();
+  test<2>();
+  test<3>();
+}
+}  // namespace
+}  // namespace evolution::dg::subcell


### PR DESCRIPTION
## Proposed changes

Add a function that slices data on the subcells to send for reconstruction to the neighboring elements

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
