### PR TITLE
Subcell: add class to store neighbor data for reconstruction and RDMP TCI

### DIFF
--- a/src/Evolution/DgSubcell/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/CMakeLists.txt
@@ -13,6 +13,7 @@ spectre_target_headers(
   DgSubcell.hpp
   Matrices.hpp
   Mesh.hpp
+  NeighborData.hpp
   PerssonTci.hpp
   Projection.hpp
   Reconstruction.hpp
@@ -26,6 +27,7 @@ spectre_target_sources(
   ActiveGrid.cpp
   Matrices.cpp
   Mesh.cpp
+  NeighborData.cpp
   PerssonTci.cpp
   Projection.cpp
   Reconstruction.cpp

--- a/src/Evolution/DgSubcell/NeighborData.cpp
+++ b/src/Evolution/DgSubcell/NeighborData.cpp
@@ -1,0 +1,39 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/DgSubcell/NeighborData.hpp"
+
+#include <ostream>
+#include <pup.h>
+#include <pup_stl.h>
+
+#include "Utilities/StdHelpers.hpp"
+
+namespace evolution::dg::subcell {
+void pup(PUP::er& p, NeighborData& nhbr_data) noexcept {  // NOLINT
+  p | nhbr_data.data_for_reconstruction;
+  p | nhbr_data.max_variables_values;
+  p | nhbr_data.min_variables_values;
+}
+
+void operator|(PUP::er& p, NeighborData& nhbr_data) noexcept {  // NOLINT
+  pup(p, nhbr_data);
+}
+
+bool operator==(const NeighborData& lhs, const NeighborData& rhs) noexcept {
+  return lhs.data_for_reconstruction == rhs.data_for_reconstruction and
+         lhs.max_variables_values == rhs.max_variables_values and
+         lhs.min_variables_values == rhs.min_variables_values;
+}
+
+bool operator!=(const NeighborData& lhs, const NeighborData& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+std::ostream& operator<<(std::ostream& os, const NeighborData& t) noexcept {
+  using ::operator<<;
+  return os << t.data_for_reconstruction << '\n'
+            << t.max_variables_values << '\n'
+            << t.min_variables_values;
+}
+}  // namespace evolution::dg::subcell

--- a/src/Evolution/DgSubcell/NeighborData.hpp
+++ b/src/Evolution/DgSubcell/NeighborData.hpp
@@ -1,0 +1,39 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <iosfwd>
+#include <vector>
+
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/ElementId.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace evolution::dg::subcell {
+/// Holds neighbor data needed for the TCI and reconstruction.
+///
+/// The `max_variables_values` and `min_variables_values` are used for the
+/// relaxed discrete maximum principle troubled-cell indicator.
+struct NeighborData {
+  std::vector<double> data_for_reconstruction{};
+  std::vector<double> max_variables_values{};
+  std::vector<double> min_variables_values{};
+};
+
+void pup(PUP::er& p, NeighborData& nhbr_data) noexcept;  // NOLINT
+
+void operator|(PUP::er& p, NeighborData& nhbr_data) noexcept;  // NOLINT
+
+bool operator==(const NeighborData& lhs, const NeighborData& rhs) noexcept;
+
+bool operator!=(const NeighborData& lhs, const NeighborData& rhs) noexcept;
+
+std::ostream& operator<<(std::ostream& os, const NeighborData& t) noexcept;
+}  // namespace evolution::dg::subcell

--- a/src/Evolution/DgSubcell/Tags/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/Tags/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_headers(
   Coordinates.hpp
   Inactive.hpp
   Mesh.hpp
+  NeighborData.hpp
   SubcellOptions.hpp
   Tags.hpp
   TciGridHistory.hpp

--- a/src/Evolution/DgSubcell/Tags/NeighborData.hpp
+++ b/src/Evolution/DgSubcell/Tags/NeighborData.hpp
@@ -1,0 +1,31 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/functional/hash.hpp>
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/FixedHashMap.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/MaxNumberOfNeighbors.hpp"
+#include "Evolution/DgSubcell/NeighborData.hpp"
+
+namespace evolution::dg::subcell::Tags {
+/// The neighbor data for reconstruction and the RDMP troubled-cell indicator.
+///
+/// This also holds the self-information for the RDMP at the time level `t^n`
+/// (the candidate is at `t^{n+1}`), with id `ElementId::external_boundary_id`
+/// and `Direction::lower_xi()` as the (arbitrary and meaningless)
+/// direction.
+template <size_t Dim>
+struct NeighborDataForReconstructionAndRdmpTci : db::SimpleTag {
+  using type =
+      FixedHashMap<maximum_number_of_neighbors(Dim) + 1,
+                   std::pair<Direction<Dim>, ElementId<Dim>>, NeighborData,
+                   boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>;
+};
+}  // namespace evolution::dg::subcell::Tags

--- a/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
+++ b/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_ActiveGrid.cpp
   Test_Matrices.cpp
   Test_Mesh.cpp
+  Test_NeighborData.cpp
   Test_PerssonTci.cpp
   Test_Projection.cpp
   Test_Reconstruction.cpp

--- a/tests/Unit/Evolution/DgSubcell/Test_NeighborData.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_NeighborData.cpp
@@ -1,0 +1,76 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Evolution/DgSubcell/NeighborData.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace evolution::dg::subcell {
+namespace {
+void test() noexcept {
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<double> dist{-100.0, 100.0};
+  std::vector<double> slice_data(10);
+  std::vector<double> max_vars(10);
+  std::vector<double> min_vars(10);
+  fill_with_random_values(make_not_null(&slice_data), make_not_null(&gen),
+                          make_not_null(&dist));
+  fill_with_random_values(make_not_null(&max_vars), make_not_null(&gen),
+                          make_not_null(&dist));
+  fill_with_random_values(make_not_null(&min_vars), make_not_null(&gen),
+                          make_not_null(&dist));
+
+  const NeighborData nhbr_data{slice_data, max_vars, min_vars};
+
+  // test equivalence
+  {
+    // clang-tidy: intentional copy
+    const auto nhbr_data2 = nhbr_data;  // NOLINT
+    CHECK(nhbr_data == nhbr_data2);
+    CHECK_FALSE(nhbr_data != nhbr_data2);
+  }
+  {
+    auto nhbr_data2 = nhbr_data;
+    nhbr_data2.data_for_reconstruction[0] = 200.0;
+    CHECK_FALSE(nhbr_data2 == nhbr_data);
+    CHECK(nhbr_data2 != nhbr_data);
+  }
+  {
+    auto nhbr_data2 = nhbr_data;
+    nhbr_data2.max_variables_values[0] = 200.0;
+    CHECK_FALSE(nhbr_data2 == nhbr_data);
+    CHECK(nhbr_data2 != nhbr_data);
+  }
+  {
+    auto nhbr_data2 = nhbr_data;
+    nhbr_data2.min_variables_values[0] = 200.0;
+    CHECK_FALSE(nhbr_data2 == nhbr_data);
+    CHECK(nhbr_data2 != nhbr_data);
+  }
+
+  // Test stream operator
+  CHECK(get_output(nhbr_data) ==
+        get_output(nhbr_data.data_for_reconstruction) + '\n' +
+            get_output(nhbr_data.max_variables_values) + '\n' +
+            get_output(nhbr_data.min_variables_values));
+
+  // Test serialization
+  test_serialization(nhbr_data);
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Subcell.NeighborData", "[Evolution][Unit]") {
+  test();
+}
+}  // namespace
+}  // namespace evolution::dg::subcell

--- a/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
@@ -13,6 +13,7 @@
 #include "Evolution/DgSubcell/Tags/Coordinates.hpp"
 #include "Evolution/DgSubcell/Tags/Inactive.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/NeighborData.hpp"
 #include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
 #include "Evolution/DgSubcell/Tags/TciGridHistory.hpp"
 #include "Evolution/DgSubcell/Tags/TciStatus.hpp"
@@ -36,6 +37,9 @@ template <size_t Dim>
 void test() {
   TestHelpers::db::test_simple_tag<evolution::dg::subcell::Tags::Mesh<Dim>>(
       "Subcell(Mesh)");
+  TestHelpers::db::test_simple_tag<
+      evolution::dg::subcell::Tags::NeighborDataForReconstructionAndRdmpTci<
+          Dim>>("NeighborDataForReconstructionAndRdmpTci");
   TestHelpers::db::test_simple_tag<
       evolution::dg::subcell::Tags::Coordinates<Dim, Frame::Logical>>(
       "LogicalCoordinates");


### PR DESCRIPTION
## Proposed changes

- Add a class that stores neighbor data for reconstruction on the subcells as well as data from the neighbor for the RDMP
- Add a tag for the neighbor data

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
