### PR TITLE
Add elastic strain function, used for XCTS longitudinal shift

### DIFF
--- a/src/PointwiseFunctions/Elasticity/Strain.hpp
+++ b/src/PointwiseFunctions/Elasticity/Strain.hpp
@@ -8,12 +8,34 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Tags.hpp"
 #include "Elliptic/Systems/Elasticity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
 
 namespace Elasticity {
 
 /*!
- * \brief The symmetric strain \f$S_{ij}=\nabla_{(i} \xi_{j)}\f$ in the elastic
- * material.
+ * \brief The symmetric strain \f$S_{ij} = \partial_{(i} \xi_{j)}\f$ on a flat
+ * background in Cartesian coordinates.
+ */
+template <typename DataType, size_t Dim>
+void strain(gsl::not_null<tnsr::ii<DataType, Dim>*> strain,
+            const tnsr::iJ<DataType, Dim>& deriv_displacement) noexcept;
+
+/*!
+ * \brief The symmetric strain \f$S_{ij} = \nabla_{(i} \gamma_{j)k} \xi^k =
+ * \partial_{(i} \gamma_{j)k} \xi^k - \Gamma_{kij} \xi^k\f$ on a
+ * background metric \f$\gamma_{ij}\f$.
+ */
+template <typename DataType, size_t Dim>
+void strain(gsl::not_null<tnsr::ii<DataType, Dim>*> strain,
+            const tnsr::iJ<DataType, Dim>& deriv_displacement,
+            const tnsr::ii<DataType, Dim>& metric,
+            const tnsr::ijj<DataType, Dim>& deriv_metric,
+            const tnsr::ijj<DataType, Dim>& christoffel_first_kind,
+            const tnsr::I<DataType, Dim>& displacement) noexcept;
+
+/*!
+ * \brief The symmetric strain \f$S_{ij} = \partial_{(i} \xi_{j)}\f$ on a flat
+ * background in Cartesian coordinates.
  *
  * Note that this function involves a numeric differentiation of the
  * displacement vector.

--- a/src/PointwiseFunctions/Xcts/LongitudinalOperator.hpp
+++ b/src/PointwiseFunctions/Xcts/LongitudinalOperator.hpp
@@ -32,6 +32,8 @@ namespace Xcts {
  * (L\beta)^{ij} = 2\left(\gamma^{ik}\gamma^{jl} -
  * \frac{1}{3} \gamma^{jk}\gamma^{kl}\right) B_{kl}
  * \f}
+ *
+ * Note that the strain can be computed with `Elasticity::strain`.
  */
 template <typename DataType>
 void longitudinal_operator(gsl::not_null<tnsr::II<DataType, 3>*> result,

--- a/tests/Unit/PointwiseFunctions/Elasticity/Strain.py
+++ b/tests/Unit/PointwiseFunctions/Elasticity/Strain.py
@@ -1,0 +1,23 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def strain_curved(deriv_displacement, metric, deriv_metric,
+                  christoffel_first_kind, displacement):
+    deriv_displacement_lo = (
+        np.einsum('jk,ik->ij', metric, deriv_displacement) +
+        np.einsum('k,ijk->ij', displacement, deriv_metric))
+    return (0.5 *
+            (deriv_displacement_lo + np.transpose(deriv_displacement_lo)) -
+            np.einsum('kij,k', christoffel_first_kind, displacement))
+
+
+def strain_flat(deriv_displacement):
+    dim = len(deriv_displacement)
+    return strain_curved(deriv_displacement,
+                         metric=np.identity(dim),
+                         deriv_metric=np.zeros((dim, dim, dim)),
+                         christoffel_first_kind=np.zeros((dim, dim, dim)),
+                         displacement=np.zeros((dim)))


### PR DESCRIPTION
## Proposed changes

This function computes the symmetric "strain" of a displacement vector field. It can be used to compute the "longitudinal shift" in an XCTS system.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
