### PR TITLE
Forbid cmake commands using literal library names

### DIFF
--- a/src/DataStructures/DataBox/CMakeLists.txt
+++ b/src/DataStructures/DataBox/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  DataStructures
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   DataBox.hpp

--- a/src/DataStructures/Tags/CMakeLists.txt
+++ b/src/DataStructures/Tags/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  DataStructures
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   TempTensor.hpp

--- a/src/DataStructures/Tensor/CMakeLists.txt
+++ b/src/DataStructures/Tensor/CMakeLists.txt
@@ -2,13 +2,13 @@
 # See LICENSE.txt for details.
 
 spectre_target_sources(
-  DataStructures
+  ${LIBRARY}
   PRIVATE
   TensorData.cpp
   )
 
 spectre_target_headers(
-  DataStructures
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Identity.hpp

--- a/src/DataStructures/Tensor/EagerMath/CMakeLists.txt
+++ b/src/DataStructures/Tensor/EagerMath/CMakeLists.txt
@@ -2,13 +2,13 @@
 # See LICENSE.txt for details.
 
 spectre_target_sources(
-  DataStructures
+  ${LIBRARY}
   PRIVATE
   OrthonormalOneform.cpp
   )
 
 spectre_target_headers(
-  DataStructures
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   CrossProduct.hpp

--- a/src/DataStructures/Tensor/Expressions/CMakeLists.txt
+++ b/src/DataStructures/Tensor/Expressions/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  DataStructures
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   AddSubtract.hpp

--- a/src/Domain/CoordinateMaps/TimeDependent/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/TimeDependent/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_sources(
-  CoordinateMaps
+  ${LIBRARY}
   PRIVATE
   CubicScale.cpp
   Rotation.cpp
@@ -11,7 +11,7 @@ spectre_target_sources(
   )
 
 spectre_target_headers(
-  CoordinateMaps
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   CubicScale.hpp

--- a/src/Elliptic/Actions/CMakeLists.txt
+++ b/src/Elliptic/Actions/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  Elliptic
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   InitializeAnalyticSolution.hpp

--- a/src/Elliptic/BoundaryConditions/CMakeLists.txt
+++ b/src/Elliptic/BoundaryConditions/CMakeLists.txt
@@ -2,13 +2,13 @@
 # See LICENSE.txt for details.
 
 spectre_target_sources(
-  Elliptic
+  ${LIBRARY}
   PRIVATE
   BoundaryConditionType.cpp
   )
 
 spectre_target_headers(
-  Elliptic
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   AnalyticSolution.hpp

--- a/src/Elliptic/DiscontinuousGalerkin/NumericalFluxes/CMakeLists.txt
+++ b/src/Elliptic/DiscontinuousGalerkin/NumericalFluxes/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  EllipticDg
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   FirstOrderInternalPenalty.hpp

--- a/src/Elliptic/Triggers/CMakeLists.txt
+++ b/src/Elliptic/Triggers/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  Elliptic
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   EveryNIterations.hpp

--- a/src/Elliptic/Utilities/CMakeLists.txt
+++ b/src/Elliptic/Utilities/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  Elliptic
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ApplyAt.hpp

--- a/src/Evolution/Actions/CMakeLists.txt
+++ b/src/Evolution/Actions/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  Evolution
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   AddMeshVelocityNonconservative.hpp

--- a/src/Evolution/Conservative/CMakeLists.txt
+++ b/src/Evolution/Conservative/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  Evolution
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ConservativeDuDt.hpp

--- a/src/Evolution/DiscontinuousGalerkin/Actions/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  Evolution
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ApplyBoundaryCorrections.hpp

--- a/src/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  Evolution
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   DgElementArray.hpp
@@ -17,7 +17,7 @@ spectre_target_headers(
   )
 
 spectre_target_sources(
-  Evolution
+  ${LIBRARY}
   PRIVATE
   InterpolateFromBoundary.cpp
   LiftFromBoundary.cpp

--- a/src/Evolution/DiscontinuousGalerkin/Initialization/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/Initialization/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  Evolution
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Mortars.hpp
@@ -10,7 +10,7 @@ spectre_target_headers(
   )
 
 spectre_target_sources(
-  Evolution
+  ${LIBRARY}
   PRIVATE
   Mortars.cpp
   )

--- a/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
@@ -1,6 +1,17 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+function(add_generalized_harmonic_executable
+    INITIAL_DATA_NAME INITIAL_DATA BOUNDARY_CONDITIONS LIBS_TO_LINK)
+  add_spectre_parallel_executable(
+    "EvolveGh${INITIAL_DATA_NAME}"
+    EvolveGeneralizedHarmonic
+    Evolution/Executables/GeneralizedHarmonic
+    "EvolutionMetavars<${INITIAL_DATA}, ${BOUNDARY_CONDITIONS}>"
+    "${LIBS_TO_LINK}"
+    )
+endfunction(add_generalized_harmonic_executable)
+
 set(LIBS_TO_LINK
   ApparentHorizons
   CoordinateMaps
@@ -23,36 +34,16 @@ set(LIBS_TO_LINK
   Utilities
   )
 
-function(add_generalized_harmonic_executable
-    INITIAL_DATA_NAME INITIAL_DATA BOUNDARY_CONDITIONS)
-  add_spectre_parallel_executable(
-    "EvolveGh${INITIAL_DATA_NAME}"
-    EvolveGeneralizedHarmonic
-    Evolution/Executables/GeneralizedHarmonic
-    "EvolutionMetavars<${INITIAL_DATA}, ${BOUNDARY_CONDITIONS}>"
-    "${LIBS_TO_LINK}"
-    )
-endfunction(add_generalized_harmonic_executable)
-
 add_generalized_harmonic_executable(
   KerrSchild
   GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::KerrSchild>
   GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::KerrSchild>
+  "${LIBS_TO_LINK};GeneralRelativitySolutions"
 )
-target_link_libraries(
-  EvolveGhKerrSchild
-  PRIVATE
-  GeneralRelativitySolutions
-  )
 
 add_generalized_harmonic_executable(
   KerrSchildNumericInitialData
   evolution::NumericInitialData
   GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::KerrSchild>
+  "${LIBS_TO_LINK};GeneralRelativitySolutions;Importers"
 )
-target_link_libraries(
-  EvolveGhKerrSchildNumericInitialData
-  PRIVATE
-  GeneralRelativitySolutions
-  Importers
-  )

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -1,6 +1,16 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+function(add_grmhd_executable INITIAL_DATA_NAME INITIAL_DATA LIBS_TO_LINK)
+  add_spectre_parallel_executable(
+    "EvolveValenciaDivClean${INITIAL_DATA_NAME}"
+    EvolveValenciaDivClean
+    Evolution/Executables/GrMhd/ValenciaDivClean
+    "EvolutionMetavars<${INITIAL_DATA}>"
+    "${LIBS_TO_LINK}"
+    )
+endfunction(add_grmhd_executable)
+
 set(LIBS_TO_LINK
   CoordinateMaps
   DiscontinuousGalerkin
@@ -23,78 +33,74 @@ set(LIBS_TO_LINK
   ValenciaDivClean
   )
 
-function(add_grmhd_executable INITIAL_DATA_NAME INITIAL_DATA)
-  add_spectre_parallel_executable(
-    "EvolveValenciaDivClean${INITIAL_DATA_NAME}"
-    EvolveValenciaDivClean
-    Evolution/Executables/GrMhd/ValenciaDivClean
-    "EvolutionMetavars<${INITIAL_DATA}>"
-    "${LIBS_TO_LINK}"
-    )
-endfunction(add_grmhd_executable)
-
 add_grmhd_executable(
   FishboneMoncriefDisk
   RelativisticEuler::Solutions::FishboneMoncriefDisk,KerrHorizon
-  )
-target_link_libraries(
-  EvolveValenciaDivCleanFishboneMoncriefDisk
-  PUBLIC
-  ApparentHorizons
-  Interpolation
+  "${LIBS_TO_LINK};ApparentHorizons;Interpolation"
   )
 
 add_grmhd_executable(
   TovStar
   RelativisticEuler::Solutions::TovStar<gr::Solutions::TovSolution>
+  "${LIBS_TO_LINK}"
   )
 
 add_grmhd_executable(
   AlfvenWave
   grmhd::Solutions::AlfvenWave
+  "${LIBS_TO_LINK}"
   )
 
 add_grmhd_executable(
   BondiMichel
   grmhd::Solutions::BondiMichel
+  "${LIBS_TO_LINK}"
   )
 
 add_grmhd_executable(
   KomissarovShock
   grmhd::Solutions::KomissarovShock
+  "${LIBS_TO_LINK}"
   )
 
 add_grmhd_executable(
   SmoothFlow
   grmhd::Solutions::SmoothFlow
+  "${LIBS_TO_LINK}"
   )
 
 add_grmhd_executable(
   BondiHoyleAccretion
   grmhd::AnalyticData::BondiHoyleAccretion
+  "${LIBS_TO_LINK}"
   )
 
 add_grmhd_executable(
   CylindricalBlastWave
   grmhd::AnalyticData::CylindricalBlastWave
+  "${LIBS_TO_LINK}"
   )
 
 add_grmhd_executable(
   MagneticFieldLoop
   grmhd::AnalyticData::MagneticFieldLoop
+  "${LIBS_TO_LINK}"
   )
 
 add_grmhd_executable(
   MagneticRotor
   grmhd::AnalyticData::MagneticRotor
+  "${LIBS_TO_LINK}"
   )
 
 add_grmhd_executable(
   MagnetizedFmDisk
   grmhd::AnalyticData::MagnetizedFmDisk
+  "${LIBS_TO_LINK}"
   )
 
 add_grmhd_executable(
   OrszagTangVortex
   grmhd::AnalyticData::OrszagTangVortex
+  "${LIBS_TO_LINK}"
   )

--- a/src/Evolution/Initialization/CMakeLists.txt
+++ b/src/Evolution/Initialization/CMakeLists.txt
@@ -2,13 +2,13 @@
 # See LICENSE.txt for details.
 
 spectre_target_sources(
-  Evolution
+  ${LIBRARY}
   PRIVATE
   DgDomain.cpp
   )
 
 spectre_target_headers(
-  Evolution
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ConservativeSystem.hpp

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/CMakeLists.txt
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_sources(
-  Burgers
+  ${LIBRARY}
   PRIVATE
   BoundaryCondition.cpp
   Dirichlet.cpp
@@ -12,7 +12,7 @@ spectre_target_sources(
   )
 
 spectre_target_headers(
-  Burgers
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   BoundaryCondition.hpp

--- a/src/Evolution/Systems/Burgers/BoundaryCorrections/CMakeLists.txt
+++ b/src/Evolution/Systems/Burgers/BoundaryCorrections/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 
 spectre_target_sources(
-  Burgers
+  ${LIBRARY}
   PRIVATE
   RegisterDerived.cpp
   Hll.cpp
@@ -11,7 +11,7 @@ spectre_target_sources(
   )
 
 spectre_target_headers(
-  Burgers
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   BoundaryCorrection.hpp

--- a/src/Evolution/Systems/Cce/Actions/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/Actions/CMakeLists.txt
@@ -2,13 +2,13 @@
 # See LICENSE.txt for details.
 
 spectre_target_sources(
-  Cce
+  ${LIBRARY}
   PRIVATE
   ScriObserveInterpolated.cpp
   )
 
 spectre_target_headers(
-  Cce
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   BoundaryComputeAndSendToEvolution.hpp

--- a/src/Evolution/Systems/Cce/Components/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/Components/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  Cce
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   CharacteristicEvolution.hpp

--- a/src/Evolution/Systems/Cce/Initialize/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/Initialize/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_sources(
-  Cce
+  ${LIBRARY}
   PRIVATE
   InitializeJ.cpp
   InverseCubic.cpp
@@ -11,7 +11,7 @@ spectre_target_sources(
   )
 
 spectre_target_headers(
-  Cce
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   InitializeJ.hpp

--- a/src/Evolution/Systems/Cce/InterfaceManagers/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/InterfaceManagers/CMakeLists.txt
@@ -2,14 +2,14 @@
 # See LICENSE.txt for details.
 
 spectre_target_sources(
-  Cce
+  ${LIBRARY}
   PRIVATE
   GhLocalTimeStepping.cpp
   GhLockstep.cpp
   )
 
 spectre_target_headers(
-  Cce
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   GhInterfaceManager.hpp

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_sources(
-  GeneralizedHarmonic
+  ${LIBRARY}
   PRIVATE
   BoundaryCondition.cpp
   DirichletAnalytic.cpp
@@ -10,7 +10,7 @@ spectre_target_sources(
   )
 
 spectre_target_headers(
-  GeneralizedHarmonic
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   BoundaryCondition.hpp

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/CMakeLists.txt
@@ -2,14 +2,14 @@
 # See LICENSE.txt for details.
 
 spectre_target_sources(
-  GeneralizedHarmonic
+  ${LIBRARY}
   PRIVATE
   RegisterDerived.cpp
   UpwindPenalty.cpp
   )
 
 spectre_target_headers(
-  GeneralizedHarmonic
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   BoundaryCorrection.hpp

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_sources(
-  ValenciaDivClean
+  ${LIBRARY}
   PRIVATE
   BoundaryCondition.cpp
   DirichletAnalytic.cpp
@@ -10,7 +10,7 @@ spectre_target_sources(
   )
 
 spectre_target_headers(
-  ValenciaDivClean
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   BoundaryCondition.hpp

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/CMakeLists.txt
@@ -3,14 +3,14 @@
 # See LICENSE.txt for details.
 
 spectre_target_sources(
-  ValenciaDivClean
+  ${LIBRARY}
   PRIVATE
   RegisterDerived.cpp
   Rusanov.cpp
   )
 
 spectre_target_headers(
-  ValenciaDivClean
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   BoundaryCorrection.hpp

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/CMakeLists.txt
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_sources(
-  NewtonianEuler
+  ${LIBRARY}
   PRIVATE
   BoundaryCondition.cpp
   DirichletAnalytic.cpp
@@ -10,7 +10,7 @@ spectre_target_sources(
   )
 
 spectre_target_headers(
-  NewtonianEuler
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   BoundaryCondition.hpp

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/CMakeLists.txt
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_sources(
-  NewtonianEuler
+  ${LIBRARY}
   PRIVATE
   Hll.cpp
   RegisterDerived.cpp
@@ -10,7 +10,7 @@ spectre_target_sources(
   )
 
 spectre_target_headers(
-  NewtonianEuler
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   BoundaryCorrection.hpp

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/BoundaryCorrections/CMakeLists.txt
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/BoundaryCorrections/CMakeLists.txt
@@ -2,13 +2,13 @@
 # See LICENSE.txt for details.
 
 spectre_target_sources(
-  M1Grey
+  ${LIBRARY}
   PRIVATE
   Rusanov.cpp
   )
 
 spectre_target_headers(
-  M1Grey
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   BoundaryCorrection.hpp

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/CMakeLists.txt
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_sources(
-  Valencia
+  ${LIBRARY}
   PRIVATE
   BoundaryCondition.cpp
   DirichletAnalytic.cpp
@@ -10,7 +10,7 @@ spectre_target_sources(
   )
 
 spectre_target_headers(
-  Valencia
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   BoundaryCondition.hpp

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryCorrections/CMakeLists.txt
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryCorrections/CMakeLists.txt
@@ -2,14 +2,14 @@
 # See LICENSE.txt for details.
 
 spectre_target_sources(
-  Valencia
+  ${LIBRARY}
   PRIVATE
   RegisterDerived.cpp
   Rusanov.cpp
   )
 
 spectre_target_headers(
-  Valencia
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   BoundaryCorrection.hpp

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_sources(
-  ScalarWave
+  ${LIBRARY}
   PRIVATE
   BoundaryCondition.cpp
   ConstraintPreservingSphericalRadiation.cpp
@@ -12,7 +12,7 @@ spectre_target_sources(
   )
 
 spectre_target_headers(
-  ScalarWave
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   BoundaryCondition.hpp

--- a/src/Evolution/Systems/ScalarWave/BoundaryCorrections/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarWave/BoundaryCorrections/CMakeLists.txt
@@ -2,14 +2,14 @@
 # See LICENSE.txt for details.
 
 spectre_target_sources(
-  ScalarWave
+  ${LIBRARY}
   PRIVATE
   RegisterDerived.cpp
   UpwindPenalty.cpp
   )
 
 spectre_target_headers(
-  ScalarWave
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   BoundaryCorrection.hpp

--- a/src/IO/H5/CMakeLists.txt
+++ b/src/IO/H5/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_sources(
-  IO
+  ${LIBRARY}
   PRIVATE
   AccessType.cpp
   Dat.cpp
@@ -18,7 +18,7 @@ spectre_target_sources(
   )
 
 spectre_target_headers(
-  IO
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   AccessType.hpp

--- a/src/IO/Importers/Actions/CMakeLists.txt
+++ b/src/IO/Importers/Actions/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  Importers
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ReadVolumeData.hpp

--- a/src/IO/Observer/Actions/CMakeLists.txt
+++ b/src/IO/Observer/Actions/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  IO
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   GetLockPointer.hpp

--- a/src/IO/Observer/CMakeLists.txt
+++ b/src/IO/Observer/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_sources(
-  IO
+  ${LIBRARY}
   PRIVATE
   ArrayComponentId.cpp
   ObservationId.cpp
@@ -10,7 +10,7 @@ spectre_target_sources(
   )
 
 spectre_target_headers(
-  IO
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ArrayComponentId.hpp

--- a/src/IO/Observer/Protocols/CMakeLists.txt
+++ b/src/IO/Observer/Protocols/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  IO
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ReductionDataFormatter.hpp

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/CMakeLists.txt
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  DiscontinuousGalerkin
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ComputeNonconservativeBoundaryFluxes.hpp

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/CMakeLists.txt
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  DiscontinuousGalerkin
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   BoundaryData.hpp

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/CMakeLists.txt
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  DiscontinuousGalerkin
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Hll.hpp

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags/CMakeLists.txt
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags/CMakeLists.txt
@@ -2,13 +2,13 @@
 # See LICENSE.txt for details.
 
 spectre_target_sources(
-  DiscontinuousGalerkin
+  ${LIBRARY}
   PRIVATE
   Formulation.cpp
   )
 
 spectre_target_headers(
-  DiscontinuousGalerkin
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Formulation.hpp

--- a/src/NumericalAlgorithms/Interpolation/Actions/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Interpolation/Actions/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  Interpolation
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ElementInitInterpPoints.hpp

--- a/src/NumericalAlgorithms/Interpolation/Callbacks/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Interpolation/Callbacks/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  Interpolation
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Callbacks.hpp

--- a/src/NumericalAlgorithms/Interpolation/Events/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Interpolation/Events/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  Interpolation
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   InterpolateWithoutInterpComponent.hpp

--- a/src/Parallel/Actions/CMakeLists.txt
+++ b/src/Parallel/Actions/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  Parallel
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Goto.hpp

--- a/src/Parallel/PhaseControl/CMakeLists.txt
+++ b/src/Parallel/PhaseControl/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  Parallel
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ExecutePhaseChange.hpp

--- a/src/ParallelAlgorithms/EventsAndTriggers/Actions/CMakeLists.txt
+++ b/src/ParallelAlgorithms/EventsAndTriggers/Actions/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  EventsAndTriggers
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   RunEventsAndTriggers.hpp

--- a/src/ParallelAlgorithms/Initialization/Actions/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Initialization/Actions/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  Initialization
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   AddComputeTags.hpp

--- a/src/ParallelAlgorithms/LinearSolver/Actions/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/Actions/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  ParallelLinearSolver
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   MakeIdentityIfSkipped.hpp

--- a/src/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/AsynchronousSolvers/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  ParallelLinearSolver
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ElementActions.hpp

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  ParallelLinearSolver
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ConjugateGradient.hpp

--- a/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/Tags/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/ConjugateGradient/Tags/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  ParallelLinearSolver
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   InboxTags.hpp

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  ParallelLinearSolver
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ElementActions.hpp

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/Tags/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/Tags/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  ParallelLinearSolver
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   InboxTags.hpp

--- a/src/ParallelAlgorithms/LinearSolver/Richardson/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/Richardson/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  ParallelLinearSolver
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Richardson.hpp

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/Actions/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/Actions/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  ParallelSchwarz
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   CommunicateOverlapFields.hpp

--- a/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/CMakeLists.txt
+++ b/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/CMakeLists.txt
@@ -2,13 +2,13 @@
 # See LICENSE.txt for details.
 
 spectre_target_sources(
-  ParallelNonlinearSolver
+  ${LIBRARY}
   PRIVATE
   LineSearch.cpp
   )
 
 spectre_target_headers(
-  ParallelNonlinearSolver
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ElementActions.hpp

--- a/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/Tags/CMakeLists.txt
+++ b/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/Tags/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  ParallelNonlinearSolver
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   InboxTags.hpp

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_sources(
-  GeneralRelativity
+  ${LIBRARY}
   PRIVATE
   CovariantDerivOfExtrinsicCurvature.cpp
   DerivSpatialMetric.cpp
@@ -24,7 +24,7 @@ spectre_target_sources(
   )
 
 spectre_target_headers(
-  GeneralRelativity
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ConstraintGammas.hpp

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_sources(
-  Hydro
+  ${LIBRARY}
   PRIVATE
   DarkEnergyFluid.cpp
   IdealFluid.cpp
@@ -10,7 +10,7 @@ spectre_target_sources(
   )
 
 spectre_target_headers(
-  Hydro
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   DarkEnergyFluid.hpp

--- a/src/Time/Actions/CMakeLists.txt
+++ b/src/Time/Actions/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  Time
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   AdvanceTime.hpp

--- a/src/Time/StepChoosers/CMakeLists.txt
+++ b/src/Time/StepChoosers/CMakeLists.txt
@@ -2,13 +2,13 @@
 # See LICENSE.txt for details.
 
 spectre_target_sources(
-  Time
+  ${LIBRARY}
   PRIVATE
   Constant.cpp
   )
 
 spectre_target_headers(
-  Time
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ByBlock.hpp

--- a/src/Time/StepControllers/CMakeLists.txt
+++ b/src/Time/StepControllers/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_sources(
-  Time
+  ${LIBRARY}
   PRIVATE
   BinaryFraction.cpp
   FullSlab.cpp
@@ -11,7 +11,7 @@ spectre_target_sources(
   )
 
 spectre_target_headers(
-  Time
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   BinaryFraction.hpp

--- a/src/Time/TimeSteppers/CMakeLists.txt
+++ b/src/Time/TimeSteppers/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_sources(
-  Time
+  ${LIBRARY}
   PRIVATE
   AdamsBashforthN.cpp
   DormandPrince5.cpp
@@ -11,7 +11,7 @@ spectre_target_sources(
   )
 
 spectre_target_headers(
-  Time
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   AdamsBashforthN.hpp

--- a/src/Time/Triggers/CMakeLists.txt
+++ b/src/Time/Triggers/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  Time
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   NearTimes.hpp

--- a/src/Utilities/TypeTraits/CMakeLists.txt
+++ b/src/Utilities/TypeTraits/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 spectre_target_headers(
-  Utilities
+  ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ArraySize.hpp

--- a/tests/Unit/Elliptic/Systems/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/CMakeLists.txt
@@ -15,7 +15,7 @@ add_test_library(
   )
 
 target_link_libraries(
-  Test_EllipticSystems
+  ${LIBRARY}
   PRIVATE
   EllipticSystems
   )

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Actions/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Actions/CMakeLists.txt
@@ -16,7 +16,7 @@ add_test_library(
   )
 
 target_link_libraries(
-  Test_ParallelSchwarzActions
+  ${LIBRARY}
   PRIVATE
   Convergence
   DataStructures

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
@@ -17,7 +17,7 @@ add_test_library(
   )
 
 target_link_libraries(
-  Test_XctsSolutions
+  ${LIBRARY}
   PRIVATE
   DataStructures
   Utilities

--- a/tools/CheckFiles.sh
+++ b/tools/CheckFiles.sh
@@ -204,7 +204,7 @@ if [ "$1" = --test ] ; then
 fi
 
 # Exclude files that are generated, out of our control, etc.
-if ! find . \
+find . \
      -type f \
      ! -path './.git/*' \
      ! -path './build*' \
@@ -219,8 +219,3 @@ if ! find . \
      ! -name deploy_key.enc \
      -print0 \
         | run_checks "${standard_checks[@]}" "${ci_checks[@]}"
-then
-    echo "This script can be run locally from any source dir using:"
-    echo "SPECTRE_ROOT/tools/CheckFiles.sh"
-    exit 1
-fi


### PR DESCRIPTION
Using library names in individual commands is error-prone when
CMakeLists.txt files are used as templates for new directories.

This would have caught the error fixed in #2966, as well as the one in #2983 (not yet merged).

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
