### PR TITLE
Add option to output noninertial News

### DIFF
--- a/src/Evolution/Systems/Cce/AnalyticBoundaryDataManager.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticBoundaryDataManager.hpp
@@ -108,7 +108,10 @@ void AnalyticBoundaryDataManager::write_news(
   auto observer_proxy = Parallel::get_parallel_component<
       observers::ObserverWriter<Metavariables>>(
       cache)[static_cast<size_t>(Parallel::my_node(*my_proxy.ckLocal()))];
+  const std::string prefix =
+      generator_->use_noninertial_news() ? "Noninertial_" : "";
   Parallel::threaded_action<observers::ThreadedActions::WriteSimpleData>(
-      observer_proxy, file_legend, data_to_write, "/News_expected"s);
+      observer_proxy, file_legend, data_to_write,
+      "/News_" + prefix + "expected"s);
 }
 }  // namespace Cce

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp
@@ -125,6 +125,8 @@ struct WorldtubeData : public PUP::able {
     return std::make_unique<Cce::InitializeJ::InverseCubic>();
   };
 
+  virtual bool use_noninertial_news() const noexcept { return false; }
+
  protected:
   template <typename Tag>
   const auto& cache_or_compute(const size_t output_l_max,

--- a/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
@@ -142,9 +142,12 @@ struct CharacteristicEvolution {
                                  tmpl::bind<CalculateScriPlusValue, tmpl::_1>>>,
       tmpl::transform<
           typename metavariables::scri_values_to_observe,
-          tmpl::bind<Actions::InsertInterpolationScriData, tmpl::_1>>,
+          tmpl::bind<
+              Actions::InsertInterpolationScriData, tmpl::_1,
+              tmpl::pin<typename Metavariables::cce_boundary_component>>>,
       Actions::ScriObserveInterpolated<
-          observers::ObserverWriter<Metavariables>>>;
+          observers::ObserverWriter<Metavariables>,
+          typename Metavariables::cce_boundary_component>>;
 
   using record_time_stepper_data_and_step =
       tmpl::list<::Actions::RecordTimeStepperData<

--- a/src/Evolution/Systems/Cce/OptionTags.hpp
+++ b/src/Evolution/Systems/Cce/OptionTags.hpp
@@ -540,5 +540,21 @@ struct AnalyticBoundaryDataManager : db::SimpleTag {
                                               worldtube_data->get_clone());
   }
 };
+
+/// Represents whether the news should be provided at noninertial times.
+///
+/// \details Currently, this is only useful for analytic solutions for which the
+/// inertial-time news is difficult to compute.
+struct OutputNoninertialNews : db::SimpleTag {
+  using type = bool;
+  using option_tags =
+      tmpl::list<OptionTags::AnalyticSolution>;
+  static constexpr bool pass_metavariables = false;
+  static bool create_from_options(
+      const std::unique_ptr<Cce::Solutions::WorldtubeData>&
+          worldtube_data) noexcept {
+    return worldtube_data->use_noninertial_news();
+  }
+};
 }  // namespace Tags
 }  // namespace Cce

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
@@ -11,6 +11,11 @@
 #include "Evolution/Systems/Cce/Actions/InsertInterpolationScriData.hpp"
 #include "Evolution/Systems/Cce/Actions/ReceiveWorldtubeData.hpp"
 #include "Evolution/Systems/Cce/Actions/RequestBoundaryData.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/BouncingBlackHole.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/GaugeWave.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/RotatingSchwarzschild.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/TeukolskyWave.hpp"
 #include "Evolution/Systems/Cce/BoundaryData.hpp"
 #include "Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp"
 #include "Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp"
@@ -30,6 +35,42 @@
 
 namespace Cce {
 namespace {
+
+std::unordered_map<std::string, std::vector<double>> written_modes;
+struct MockWriteSimpleData {
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables, typename ArrayIndex>
+  static void apply(const db::DataBox<DbTagsList>& /*box*/,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const gsl::not_null<Parallel::NodeLock*> /*node_lock*/,
+                    const std::vector<std::string>& /*file_legend*/,
+                    const std::vector<double>& data_row,
+                    const std::string& subfile_name) noexcept {
+    written_modes[subfile_name] = data_row;
+  }
+};
+
+struct RotatingSchwarzschildWithNoninertialNews
+    : public Cce::Solutions::RotatingSchwarzschild {
+  using Cce::Solutions::RotatingSchwarzschild::RotatingSchwarzschild;
+  // ignore warning for unused | operator
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+  WRAPPED_PUPable_decl_template(RotatingSchwarzschildWithNoninertialNews);
+#pragma GCC diagnostic pop
+  bool use_noninertial_news() const noexcept override { return true; }
+
+  std::unique_ptr<Cce::Solutions::WorldtubeData> get_clone()
+      const noexcept override {
+    return std::make_unique<RotatingSchwarzschildWithNoninertialNews>(*this);
+  }
+  void pup(PUP::er& p) noexcept override {
+    Cce::Solutions::RotatingSchwarzschild::pup(p);
+  }
+};
+
+PUP::able::PUP_ID RotatingSchwarzschildWithNoninertialNews::my_PUP_ID = 0;
 
 struct SetRandomBoundaryValues {
   template <typename DbTags, typename... InboxTags, typename Metavariables,
@@ -69,7 +110,33 @@ struct SetRandomBoundaryValues {
 };
 
 template <typename Metavariables>
-struct mock_characteristic_evolution {
+struct MockObserver {
+  using component_being_mocked = observers::ObserverWriter<Metavariables>;
+  using replace_these_threaded_actions =
+      tmpl::list<observers::ThreadedActions::WriteSimpleData>;
+  using with_these_threaded_actions = tmpl::list<MockWriteSimpleData>;
+
+  using const_global_cache_tags = tmpl::list<Tags::ObservationLMax>;
+  using initialize_action_list =
+      tmpl::list<::Actions::SetupDataBox,
+                 observers::Actions::InitializeWriter<Metavariables>>;
+  using initialization_tags =
+      Parallel::get_initialization_tags<initialize_action_list>;
+
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Initialization,
+                             initialize_action_list>,
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Evolve, tmpl::list<>>>;
+};
+
+template <typename Metavariables>
+struct MockCharacteristicEvolution {
   using component_being_mocked = CharacteristicEvolution<Metavariables>;
   using replace_these_simple_actions = tmpl::list<>;
   using with_these_simple_actions = tmpl::list<>;
@@ -81,13 +148,14 @@ struct mock_characteristic_evolution {
           typename Metavariables::evolved_coordinates_variables_tag,
           typename Metavariables::evolved_swsh_tag>,
       Actions::InitializeCharacteristicEvolutionScri<
-          typename Metavariables::scri_values_to_observe, NoSuchType>,
+          typename Metavariables::scri_values_to_observe,
+          typename Metavariables::cce_boundary_component>,
       Initialization::Actions::RemoveOptionsAndTerminatePhase>;
   using initialization_tags =
       Parallel::get_initialization_tags<initialize_action_list>;
 
   using metavariables = Metavariables;
-  using chare_type = ActionTesting::MockArrayChare;
+  using chare_type = ActionTesting::MockSingletonChare;
   using array_index = size_t;
 
   using simple_tags = tmpl::list<>;
@@ -99,9 +167,11 @@ struct mock_characteristic_evolution {
           typename Metavariables::Phase, Metavariables::Phase::Evolve,
           tmpl::list<
               SetRandomBoundaryValues,
-              tmpl::transform<typename Metavariables::scri_values_to_observe,
-                              tmpl::bind<Actions::InsertInterpolationScriData,
-                                         tmpl::_1>>>>>;
+              tmpl::transform<
+                  typename Metavariables::scri_values_to_observe,
+                  tmpl::bind<Actions::InsertInterpolationScriData, tmpl::_1,
+                             tmpl::pin<typename Metavariables::
+                                           cce_boundary_component>>>>>>;
 };
 
 struct test_metavariables {
@@ -155,8 +225,13 @@ struct test_metavariables {
                              Cce::Tags::ScriPlus<Cce::Tags::Psi4>>>,
                          Cce::Tags::ScriPlusFactor<Cce::Tags::Psi4>>>;
 
+  using observed_reduction_data_tags = tmpl::list<>;
+  using cce_boundary_component =
+      Cce::AnalyticWorldtubeBoundary<test_metavariables>;
+
   using component_list =
-      tmpl::list<mock_characteristic_evolution<test_metavariables>>;
+      tmpl::list<MockCharacteristicEvolution<test_metavariables>,
+                 MockObserver<test_metavariables>>;
   enum class Phase { Initialization, Evolve, Exit };
 };
 }  // namespace
@@ -165,7 +240,12 @@ SPECTRE_TEST_CASE(
     "Unit.Evolution.Systems.Cce.Actions.InsertInterpolationScriData",
     "[Unit][Cce]") {
   Parallel::register_derived_classes_with_charm<TimeStepper>();
-  using evolution_component = mock_characteristic_evolution<test_metavariables>;
+  Parallel::register_derived_classes_with_charm<
+      Cce::Solutions::WorldtubeData>();
+  PUPable_reg2(RotatingSchwarzschildWithNoninertialNews,
+               typeid(RotatingSchwarzschildWithNoninertialNews).name());
+  using evolution_component = MockCharacteristicEvolution<test_metavariables>;
+  using observation_component = MockObserver<test_metavariables>;
   MAKE_GENERATOR(gen);
   UniformCustomDistribution<double> value_dist{0.1, 0.5};
 
@@ -177,15 +257,25 @@ SPECTRE_TEST_CASE(
   const double start_time = value_dist(gen);
   const double target_step_size = 0.01 * value_dist(gen);
   const size_t buffer_size = 5;
+  const double extraction_radius = 100.0;
 
+  const RotatingSchwarzschildWithNoninertialNews analytic_solution{
+      extraction_radius, 1.0, 0.05};
+  const AnalyticBoundaryDataManager analytic_manager{
+      l_max, extraction_radius, analytic_solution.get_clone()};
   ActionTesting::MockRuntimeSystem<test_metavariables> runner{
-      {start_time, l_max, number_of_radial_points,
-       std::make_unique<::TimeSteppers::RungeKutta3>(), scri_output_density}};
+      {start_time, l_max, l_max, number_of_radial_points,
+       std::make_unique<::TimeSteppers::RungeKutta3>(), scri_output_density,
+       true}};
 
   runner.set_phase(test_metavariables::Phase::Initialization);
+  // Serialize and deserialize to get around the lack of implicit copy
+  // constructor.
   ActionTesting::emplace_component<evolution_component>(
-      &runner, 0, target_step_size, buffer_size);
-
+      &runner, 0, target_step_size, buffer_size,
+      serialize_and_deserialize(analytic_manager));
+  ActionTesting::emplace_component<MockObserver<test_metavariables>>(&runner,
+                                                                      0);
   // the initialization actions
   for (size_t i = 0; i < 5; ++i) {
     ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
@@ -233,5 +323,28 @@ SPECTRE_TEST_CASE(
       runner, 0);
   CHECK(multiplies_du_interpolator.number_of_data_points() == 1);
   CHECK(multiplies_du_interpolator.number_of_target_times() == 5);
+
+  // check the output news against the news provided by the analytic solution
+  ActionTesting::invoke_queued_threaded_action<observation_component>(
+      make_not_null(&runner), 0);
+  ActionTesting::invoke_queued_threaded_action<observation_component>(
+      make_not_null(&runner), 0);
+  const ComplexModalVector analytic_news_modes =
+      Spectral::Swsh::libsharp_to_goldberg_modes(
+          Spectral::Swsh::swsh_transform(
+              l_max, 1,
+              get(get<Tags::News>(analytic_solution.variables(
+                  l_max, start_time, tmpl::list<Tags::News>{})))),
+          l_max)
+          .data();
+  CHECK(written_modes["/News_Noninertial"].size() == 2 * square(l_max + 1) + 1);
+  CHECK(written_modes["/News_Noninertial"][0] == start_time);
+  CHECK(written_modes["/News_Noninertial_expected"][0] == start_time);
+  for (size_t i = 0; i < square(l_max + 1); ++i) {
+    CHECK(written_modes["/News_Noninertial_expected"][2 * i + 1] ==
+          real(analytic_news_modes[i]));
+    CHECK(written_modes["/News_Noninertial_expected"][2 * i + 2] ==
+          imag(analytic_news_modes[i]));
+  }
 }
 }  // namespace Cce

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
@@ -144,8 +144,12 @@ struct mock_characteristic_evolution {
           tmpl::list<
               tmpl::transform<
                   typename Metavariables::scri_values_to_observe,
-                  tmpl::bind<Actions::InsertInterpolationScriData, tmpl::_1>>,
-              Actions::ScriObserveInterpolated<mock_observer<Metavariables>>,
+                  tmpl::bind<Actions::InsertInterpolationScriData, tmpl::_1,
+                             tmpl::pin<typename Metavariables::
+                                           cce_boundary_component>>>,
+              Actions::ScriObserveInterpolated<
+                  mock_observer<Metavariables>,
+                  typename Metavariables::cce_boundary_component>,
               ::Actions::AdvanceTime>>>;
 };
 
@@ -259,7 +263,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.ScriObserveInterpolated",
 
   ActionTesting::MockRuntimeSystem<test_metavariables> runner{
       {start_time, filename, l_max, l_max, number_of_radial_points,
-       std::make_unique<::TimeSteppers::RungeKutta3>(), scri_output_density}};
+       std::make_unique<::TimeSteppers::RungeKutta3>(), scri_output_density,
+       false}};
 
   runner.set_phase(test_metavariables::Phase::Initialization);
   // Serialize and deserialize to get around the lack of implicit copy

--- a/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
@@ -74,6 +74,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
   TestHelpers::db::test_simple_tag<Cce::Tags::InitializeJ>("InitializeJ");
   TestHelpers::db::test_simple_tag<Cce::Tags::AnalyticInitializeJ>(
       "AnalyticInitializeJ");
+  TestHelpers::db::test_simple_tag<Cce::Tags::OutputNoninertialNews>(
+      "OutputNoninertialNews");
 
   CHECK(TestHelpers::test_creation<size_t, Cce::OptionTags::LMax>("8") == 8_st);
   CHECK(TestHelpers::test_creation<size_t, Cce::OptionTags::FilterLMax>("7") ==


### PR DESCRIPTION
## Proposed changes

Permits outputting the noninertial news for comparison in CCE analytic tests -- sometimes the noninertial news is tractable to compute an expected value for, but the inertial news would be too complicated.

Split out from #2610

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
