### PR TITLE
Add load balancing

### DIFF
--- a/cmake/ExecuteCheckOutputFilesAndClean.sh
+++ b/cmake/ExecuteCheckOutputFilesAndClean.sh
@@ -7,7 +7,7 @@
                     --input-file $2 --output-dir @CMAKE_BINARY_DIR@/$3
 mkdir @CMAKE_BINARY_DIR@/$3
 cd @CMAKE_BINARY_DIR@/$3
-@CMAKE_BINARY_DIR@/bin/$1 --input-file $2 &&
+@CMAKE_BINARY_DIR@/bin/$1 --input-file $2 ${4} &&
     @Python_EXECUTABLE@ @CMAKE_SOURCE_DIR@/tools/CheckOutputFiles.py \
      --input-file $2 --run-directory @CMAKE_BINARY_DIR@/$3 &&
 @Python_EXECUTABLE@ @CMAKE_SOURCE_DIR@/tools/CleanOutput.py -v \

--- a/cmake/SetupCharm.cmake
+++ b/cmake/SetupCharm.cmake
@@ -28,7 +28,7 @@ endif(NOT TARGET Charmxx)
 #       with GCC
 string(
     REGEX REPLACE "<CMAKE_CXX_COMPILER>"
-    "${CHARM_COMPILER} -pthread -module CommonLBs -no-charmrun"
+    "${CHARM_COMPILER} -pthread -module EveryLB -no-charmrun"
     CMAKE_CXX_LINK_EXECUTABLE "${CMAKE_CXX_LINK_EXECUTABLE}")
 
 # When building for trace analysis the PAPI counters passed to charmc

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -335,6 +335,9 @@ Follow these steps:
     The Charm++ build will be located in a new directory,
     `CHARM_DIR/ARCH_OPTS`, whose name may (or may not) have some of the options
     appended to the architecture.
+    In addition to the core `charm++` target, you will need to compile either
+    the `LIBS` target or the `everylb` target. This is needed so that we can
+    support the more sophisticated load balancers in SpECTRE executables.
   * On macOS 10.12 it is necessary to patch the STL implementation. Insert
     \code
     #ifndef _MACH_PORT_T

--- a/src/Domain/Creators/TimeDependence/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/Creators/TimeDependence/RegisterDerivedWithCharm.cpp
@@ -5,6 +5,9 @@
 #include <memory>
 #include <pup.h>
 
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/CubicScale.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/ProductMaps.tpp"
@@ -28,9 +31,12 @@ struct get_maps {
 
 template <size_t Dim>
 void register_maps_with_charm() noexcept {
-  using maps_to_register = tmpl::remove_duplicates<tmpl::flatten<
-      tmpl::transform<typename TimeDependence<Dim>::creatable_classes,
-                      get_maps<tmpl::_1>>>>;
+  using maps_to_register =
+      tmpl::remove_duplicates<tmpl::flatten<tmpl::push_back<
+          tmpl::transform<typename TimeDependence<Dim>::creatable_classes,
+                          get_maps<tmpl::_1>>,
+          domain::CoordinateMap<Frame::Grid, Frame::Inertial,
+                                CoordinateMaps::Identity<Dim>>>>>;
 
   Parallel::register_classes_in_list<maps_to_register>();
 }

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -36,6 +36,9 @@
 #include "Options/Options.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
+#include "Parallel/PhaseControl/PhaseControlTags.hpp"
+#include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
@@ -163,10 +166,6 @@ struct EvolutionMetavars {
       Events::Registrars::ChangeSlabSize<slab_choosers>>>;
   using triggers = Triggers::time_triggers;
 
-  using const_global_cache_tags =
-      tmpl::list<initial_data_tag, normal_dot_numerical_flux, time_stepper_tag,
-                 Tags::EventsAndTriggers<events, triggers>>;
-
   using observed_reduction_data_tags = observers::collect_reduction_data_tags<
       typename Event<events>::creatable_classes>;
 
@@ -189,11 +188,39 @@ struct EvolutionMetavars {
 
   enum class Phase {
     Initialization,
+    LoadBalancing,
     RegisterWithObserver,
     InitializeTimeStepperHistory,
     Evolve,
     Exit
   };
+
+  static std::string phase_name(Phase phase) noexcept {
+    if (phase == Phase::LoadBalancing) {
+      return "LoadBalancing";
+    }
+    ERROR(
+        "Passed phase that should not be used in input file. Integer "
+        "corresponding to phase is: "
+        << static_cast<int>(phase));
+  }
+
+  using phase_changes = tmpl::list<PhaseControl::Registrars::VisitAndReturn<
+      EvolutionMetavars, Phase::LoadBalancing>>;
+
+  using initialize_phase_change_decision_data =
+      PhaseControl::InitializePhaseChangeDecisionData<phase_changes, triggers>;
+
+  using phase_change_tags_and_combines_list =
+      PhaseControl::get_phase_change_tags<phase_changes>;
+
+  using const_global_cache_tags = tmpl::list<
+      initial_data_tag, normal_dot_numerical_flux, time_stepper_tag,
+      Tags::EventsAndTriggers<events, triggers>,
+      PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes, triggers>>;
+
+  using dg_registration_list =
+      tmpl::list<observers::Actions::RegisterEventsWithObservers>;
 
   using initialization_actions = tmpl::list<
       Actions::SetupDataBox,
@@ -221,29 +248,39 @@ struct EvolutionMetavars {
       Initialization::Actions::Minmod<1>,
       Initialization::Actions::RemoveOptionsAndTerminatePhase>;
 
-  using component_list = tmpl::list<
-      observers::Observer<EvolutionMetavars>,
-      observers::ObserverWriter<EvolutionMetavars>,
-      DgElementArray<
-          EvolutionMetavars,
-          tmpl::list<
-              Parallel::PhaseActions<Phase, Phase::Initialization,
-                                     initialization_actions>,
+  using dg_element_array = DgElementArray<
+      EvolutionMetavars,
+      tmpl::list<
+          Parallel::PhaseActions<Phase, Phase::Initialization,
+                                 initialization_actions>,
 
-              Parallel::PhaseActions<
-                  Phase, Phase::RegisterWithObserver,
-                  tmpl::list<observers::Actions::RegisterEventsWithObservers,
-                             Parallel::Actions::TerminatePhase>>,
+          Parallel::PhaseActions<Phase, Phase::RegisterWithObserver,
+                                 tmpl::list<dg_registration_list,
+                                            Parallel::Actions::TerminatePhase>>,
 
-              Parallel::PhaseActions<
-                  Phase, Phase::InitializeTimeStepperHistory,
-                  SelfStart::self_start_procedure<step_actions, system>>,
+          Parallel::PhaseActions<
+              Phase, Phase::InitializeTimeStepperHistory,
+              SelfStart::self_start_procedure<step_actions, system>>,
 
-              Parallel::PhaseActions<
-                  Phase, Phase::Evolve,
-                  tmpl::list<Actions::RunEventsAndTriggers,
-                             Actions::ChangeSlabSize, step_actions,
-                             Actions::AdvanceTime>>>>>;
+          Parallel::PhaseActions<
+              Phase, Phase::Evolve,
+              tmpl::list<Actions::RunEventsAndTriggers,
+                         Actions::ChangeSlabSize, step_actions,
+                         Actions::AdvanceTime,
+                         PhaseControl::Actions::ExecutePhaseChange<
+                             phase_changes, triggers>>>>>;
+
+  template <typename ParallelComponent>
+  struct registration_list {
+    using type = std::conditional_t<
+        std::is_same_v<ParallelComponent, dg_element_array>,
+        dg_registration_list, tmpl::list<>>;
+  };
+
+  using component_list =
+      tmpl::list<observers::Observer<EvolutionMetavars>,
+                 observers::ObserverWriter<EvolutionMetavars>,
+                 dg_element_array>;
 
   static constexpr Options::String help{
       "Evolve the Burgers equation.\n\n"
@@ -252,11 +289,18 @@ struct EvolutionMetavars {
 
   template <typename... Tags>
   static Phase determine_next_phase(
-      const gsl::not_null<
-          tuples::TaggedTuple<Tags...>*> /*phase_change_decision_data*/,
+      const gsl::not_null<tuples::TaggedTuple<Tags...>*>
+          phase_change_decision_data,
       const Phase& current_phase,
-      const Parallel::CProxy_GlobalCache<
-          EvolutionMetavars>& /*cache_proxy*/) noexcept {
+      const Parallel::CProxy_GlobalCache<EvolutionMetavars>&
+          cache_proxy) noexcept {
+    const auto next_phase =
+        PhaseControl::arbitrate_phase_change<phase_changes, triggers>(
+            phase_change_decision_data, current_phase,
+            *(cache_proxy.ckLocalBranch()));
+    if (next_phase.has_value()) {
+      return next_phase.value();
+    }
     switch (current_phase) {
       case Phase::Initialization:
         return Phase::InitializeTimeStepperHistory;
@@ -279,7 +323,8 @@ struct EvolutionMetavars {
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{
-    &setup_error_handling, &disable_openblas_multithreading,
+    &setup_error_handling,
+    &disable_openblas_multithreading,
     &domain::creators::register_derived_with_charm,
     &domain::creators::time_dependence::register_derived_with_charm,
     &domain::FunctionsOfTime::register_derived_with_charm,
@@ -294,6 +339,8 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &Parallel::register_derived_classes_with_charm<TimeSequence<std::uint64_t>>,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<
-        Trigger<metavariables::triggers>>};
+        Trigger<metavariables::triggers>>,
+    &Parallel::register_derived_classes_with_charm<
+        PhaseChange<metavariables::phase_changes>>};
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -41,6 +41,9 @@
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
+#include "Parallel/PhaseControl/PhaseControlTags.hpp"
+#include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
@@ -216,9 +219,32 @@ struct EvolutionMetavars {
     Initialization,
     InitializeTimeStepperHistory,
     RegisterWithObserver,
+    LoadBalancing,
     Evolve,
     Exit
   };
+
+  static std::string phase_name(Phase phase) noexcept {
+    if (phase == Phase::LoadBalancing) {
+      return "LoadBalancing";
+    }
+    ERROR(
+        "Passed phase that should not be used in input file. Integer "
+        "corresponding to phase is: "
+        << static_cast<int>(phase));
+  }
+
+  using phase_changes = tmpl::list<PhaseControl::Registrars::VisitAndReturn<
+      EvolutionMetavars, Phase::LoadBalancing>>;
+
+  using initialize_phase_change_decision_data =
+      PhaseControl::InitializePhaseChangeDecisionData<phase_changes, triggers>;
+
+  using phase_change_tags_and_combines_list =
+      PhaseControl::get_phase_change_tags<phase_changes>;
+
+  using dg_registration_list =
+      tmpl::list<observers::Actions::RegisterEventsWithObservers>;
 
   using initialization_actions = tmpl::list<
       Actions::SetupDataBox,
@@ -255,47 +281,64 @@ struct EvolutionMetavars {
       Initialization::Actions::Minmod<Dim>,
       Initialization::Actions::RemoveOptionsAndTerminatePhase>;
 
-  using component_list = tmpl::list<
-      observers::Observer<EvolutionMetavars>,
-      observers::ObserverWriter<EvolutionMetavars>,
-      DgElementArray<
-          EvolutionMetavars,
-          tmpl::list<
-              Parallel::PhaseActions<Phase, Phase::Initialization,
-                                     initialization_actions>,
+  using dg_element_array = DgElementArray<
+      EvolutionMetavars,
+      tmpl::list<
+          Parallel::PhaseActions<Phase, Phase::Initialization,
+                                 initialization_actions>,
 
-              Parallel::PhaseActions<
-                  Phase, Phase::InitializeTimeStepperHistory,
-                  SelfStart::self_start_procedure<step_actions, system>>,
+          Parallel::PhaseActions<
+              Phase, Phase::InitializeTimeStepperHistory,
+              SelfStart::self_start_procedure<step_actions, system>>,
 
-              Parallel::PhaseActions<
-                  Phase, Phase::RegisterWithObserver,
-                  tmpl::list<observers::Actions::RegisterEventsWithObservers,
-                             Parallel::Actions::TerminatePhase>>,
+          Parallel::PhaseActions<Phase, Phase::RegisterWithObserver,
+                                 tmpl::list<dg_registration_list,
+                                            Parallel::Actions::TerminatePhase>>,
 
-              Parallel::PhaseActions<
-                  Phase, Phase::Evolve,
-                  tmpl::list<Actions::UpdateConservatives,
-                             Actions::RunEventsAndTriggers,
-                             Actions::ChangeSlabSize, step_actions,
-                             Actions::AdvanceTime>>>>>;
+          Parallel::PhaseActions<
+              Phase, Phase::Evolve,
+              tmpl::list<Actions::UpdateConservatives,
+                         Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
+                         step_actions, Actions::AdvanceTime,
+                         PhaseControl::Actions::ExecutePhaseChange<
+                             phase_changes, triggers>>>>>;
+
+  template <typename ParallelComponent>
+  struct registration_list {
+    using type =
+        std::conditional_t<std::is_same_v<ParallelComponent, dg_element_array>,
+                           dg_registration_list, tmpl::list<>>;
+  };
+
+  using component_list =
+      tmpl::list<observers::Observer<EvolutionMetavars>,
+                 observers::ObserverWriter<EvolutionMetavars>,
+                 dg_element_array>;
 
   using const_global_cache_tags = tmpl::list<
       initial_data_tag,
       tmpl::conditional_t<has_source_terms, source_term_tag, tmpl::list<>>,
       normal_dot_numerical_flux, time_stepper_tag,
-      Tags::EventsAndTriggers<events, triggers>>;
+      Tags::EventsAndTriggers<events, triggers>,
+      PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes, triggers>>;
 
   static constexpr Options::String help{
       "Evolve the Newtonian Euler system in conservative form.\n\n"};
 
   template <typename... Tags>
   static Phase determine_next_phase(
-      const gsl::not_null<
-          tuples::TaggedTuple<Tags...>*> /*phase_change_decision_data*/,
+      const gsl::not_null<tuples::TaggedTuple<Tags...>*>
+          phase_change_decision_data,
       const Phase& current_phase,
-      const Parallel::CProxy_GlobalCache<
-          EvolutionMetavars>& /*cache_proxy*/) noexcept {
+      const Parallel::CProxy_GlobalCache<EvolutionMetavars>&
+          cache_proxy) noexcept {
+    const auto next_phase =
+        PhaseControl::arbitrate_phase_change<phase_changes, triggers>(
+            phase_change_decision_data, current_phase,
+            *(cache_proxy.ckLocalBranch()));
+    if (next_phase.has_value()) {
+      return next_phase.value();
+    }
     switch (current_phase) {
       case Phase::Initialization:
         return Phase::InitializeTimeStepperHistory;
@@ -318,7 +361,8 @@ struct EvolutionMetavars {
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{
-    &setup_error_handling, &disable_openblas_multithreading,
+    &setup_error_handling,
+    &disable_openblas_multithreading,
     &domain::creators::register_derived_with_charm,
     &domain::creators::time_dependence::register_derived_with_charm,
     &domain::FunctionsOfTime::register_derived_with_charm,
@@ -333,7 +377,9 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &Parallel::register_derived_classes_with_charm<TimeSequence<std::uint64_t>>,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<
-        Trigger<metavariables::triggers>>};
+        Trigger<metavariables::triggers>>,
+    &Parallel::register_derived_classes_with_charm<
+        PhaseChange<metavariables::phase_changes>>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -45,6 +45,9 @@
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
+#include "Parallel/PhaseControl/PhaseControlTags.hpp"
+#include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
@@ -204,9 +207,32 @@ struct EvolutionMetavars {
     Initialization,
     InitializeTimeStepperHistory,
     RegisterWithObserver,
+    LoadBalancing,
     Evolve,
     Exit
   };
+
+  static std::string phase_name(Phase phase) noexcept {
+    if (phase == Phase::LoadBalancing) {
+      return "LoadBalancing";
+    }
+    ERROR(
+        "Passed phase that should not be used in input file. Integer "
+        "corresponding to phase is: "
+        << static_cast<int>(phase));
+  }
+
+  using phase_changes = tmpl::list<PhaseControl::Registrars::VisitAndReturn<
+      EvolutionMetavars, Phase::LoadBalancing>>;
+
+  using initialize_phase_change_decision_data =
+      PhaseControl::InitializePhaseChangeDecisionData<phase_changes, triggers>;
+
+  using phase_change_tags_and_combines_list =
+      PhaseControl::get_phase_change_tags<phase_changes>;
+
+  using dg_registration_list =
+      tmpl::list<observers::Actions::RegisterEventsWithObservers>;
 
   using initialization_actions = tmpl::list<
       Actions::SetupDataBox,
@@ -244,33 +270,43 @@ struct EvolutionMetavars {
       Initialization::Actions::Minmod<3>,
       Initialization::Actions::RemoveOptionsAndTerminatePhase>;
 
-  using component_list = tmpl::list<
-      observers::Observer<EvolutionMetavars>,
-      observers::ObserverWriter<EvolutionMetavars>,
-      DgElementArray<
-          EvolutionMetavars,
-          tmpl::list<
-              Parallel::PhaseActions<Phase, Phase::Initialization,
-                                     initialization_actions>,
+  using dg_element_array = DgElementArray<
+      EvolutionMetavars,
+      tmpl::list<
+          Parallel::PhaseActions<Phase, Phase::Initialization,
+                                 initialization_actions>,
 
-              Parallel::PhaseActions<
-                  Phase, Phase::InitializeTimeStepperHistory,
-                  SelfStart::self_start_procedure<step_actions, system>>,
+          Parallel::PhaseActions<
+              Phase, Phase::InitializeTimeStepperHistory,
+              SelfStart::self_start_procedure<step_actions, system>>,
 
-              Parallel::PhaseActions<
-                  Phase, Phase::RegisterWithObserver,
-                  tmpl::list<observers::Actions::RegisterEventsWithObservers,
-                             Parallel::Actions::TerminatePhase>>,
+          Parallel::PhaseActions<Phase, Phase::RegisterWithObserver,
+                                 tmpl::list<dg_registration_list,
+                                            Parallel::Actions::TerminatePhase>>,
 
-              Parallel::PhaseActions<
-                  Phase, Phase::Evolve,
-                  tmpl::list<Actions::RunEventsAndTriggers,
-                             Actions::ChangeSlabSize, step_actions,
-                             Actions::AdvanceTime>>>>>;
+          Parallel::PhaseActions<
+              Phase, Phase::Evolve,
+              tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
+                         step_actions, Actions::AdvanceTime,
+                         PhaseControl::Actions::ExecutePhaseChange<
+                             phase_changes, triggers>>>>>;
 
-  using const_global_cache_tags =
-      tmpl::list<initial_data_tag, normal_dot_numerical_flux, time_stepper_tag,
-                 Tags::EventsAndTriggers<events, triggers>>;
+  template <typename ParallelComponent>
+  struct registration_list {
+    using type =
+        std::conditional_t<std::is_same_v<ParallelComponent, dg_element_array>,
+                           dg_registration_list, tmpl::list<>>;
+  };
+
+  using component_list =
+      tmpl::list<observers::Observer<EvolutionMetavars>,
+                 observers::ObserverWriter<EvolutionMetavars>,
+                 dg_element_array>;
+
+  using const_global_cache_tags = tmpl::list<
+      initial_data_tag, normal_dot_numerical_flux, time_stepper_tag,
+      Tags::EventsAndTriggers<events, triggers>,
+      PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes, triggers>>;
 
   static constexpr Options::String help{
       "Evolve the M1Grey system (without coupling to hydro).\n\n"};
@@ -278,10 +314,17 @@ struct EvolutionMetavars {
   template <typename... Tags>
   static Phase determine_next_phase(
       const gsl::not_null<
-          tuples::TaggedTuple<Tags...>*> /*phase_change_decision_data*/,
+      tuples::TaggedTuple<Tags...>*> phase_change_decision_data,
       const Phase& current_phase,
       const Parallel::CProxy_GlobalCache<
-          EvolutionMetavars>& /*cache_proxy*/) noexcept {
+      EvolutionMetavars>& cache_proxy) noexcept {
+    const auto next_phase =
+        PhaseControl::arbitrate_phase_change<phase_changes, triggers>(
+            phase_change_decision_data, current_phase,
+            *(cache_proxy.ckLocalBranch()));
+    if (next_phase.has_value()) {
+      return next_phase.value();
+    }
     switch (current_phase) {
       case Phase::Initialization:
         return Phase::InitializeTimeStepperHistory;
@@ -304,7 +347,8 @@ struct EvolutionMetavars {
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{
-    &setup_error_handling, &disable_openblas_multithreading,
+    &setup_error_handling,
+    &disable_openblas_multithreading,
     &domain::creators::register_derived_with_charm,
     &domain::creators::time_dependence::register_derived_with_charm,
     &domain::FunctionsOfTime::register_derived_with_charm,
@@ -319,7 +363,9 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &Parallel::register_derived_classes_with_charm<TimeSequence<std::uint64_t>>,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<
-        Trigger<metavariables::triggers>>};
+        Trigger<metavariables::triggers>>,
+    &Parallel::register_derived_classes_with_charm<
+        PhaseChange<metavariables::phase_changes>>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -44,6 +44,9 @@
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
+#include "Parallel/PhaseControl/PhaseControlTags.hpp"
+#include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
@@ -214,9 +217,32 @@ struct EvolutionMetavars {
     Initialization,
     InitializeTimeStepperHistory,
     RegisterWithObserver,
+    LoadBalancing,
     Evolve,
     Exit
   };
+
+  static std::string phase_name(Phase phase) noexcept {
+    if (phase == Phase::LoadBalancing) {
+      return "LoadBalancing";
+    }
+    ERROR(
+        "Passed phase that should not be used in input file. Integer "
+        "corresponding to phase is: "
+        << static_cast<int>(phase));
+  }
+
+  using phase_changes = tmpl::list<PhaseControl::Registrars::VisitAndReturn<
+      EvolutionMetavars, Phase::LoadBalancing>>;
+
+  using initialize_phase_change_decision_data =
+      PhaseControl::InitializePhaseChangeDecisionData<phase_changes, triggers>;
+
+  using phase_change_tags_and_combines_list =
+      PhaseControl::get_phase_change_tags<phase_changes>;
+
+  using dg_registration_list =
+      tmpl::list<observers::Actions::RegisterEventsWithObservers>;
 
   using initialization_actions = tmpl::list<
       Actions::SetupDataBox,
@@ -257,48 +283,65 @@ struct EvolutionMetavars {
       Initialization::Actions::Minmod<Dim>,
       Initialization::Actions::RemoveOptionsAndTerminatePhase>;
 
-  using component_list = tmpl::list<
-      observers::Observer<EvolutionMetavars>,
-      observers::ObserverWriter<EvolutionMetavars>,
-      DgElementArray<
-          EvolutionMetavars,
-          tmpl::list<
-              Parallel::PhaseActions<Phase, Phase::Initialization,
-                                     initialization_actions>,
+  using dg_element_array = DgElementArray<
+      EvolutionMetavars,
+      tmpl::list<
+          Parallel::PhaseActions<Phase, Phase::Initialization,
+                                 initialization_actions>,
 
-              Parallel::PhaseActions<
-                  Phase, Phase::InitializeTimeStepperHistory,
-                  SelfStart::self_start_procedure<step_actions, system>>,
+          Parallel::PhaseActions<
+              Phase, Phase::InitializeTimeStepperHistory,
+              SelfStart::self_start_procedure<step_actions, system>>,
 
-              Parallel::PhaseActions<
-                  Phase, Phase::RegisterWithObserver,
-                  tmpl::list<observers::Actions::RegisterEventsWithObservers,
-                             Parallel::Actions::TerminatePhase>>,
+          Parallel::PhaseActions<Phase, Phase::RegisterWithObserver,
+                                 tmpl::list<dg_registration_list,
+                                            Parallel::Actions::TerminatePhase>>,
 
-              Parallel::PhaseActions<
-                  Phase, Phase::Evolve,
-                  tmpl::list<VariableFixing::Actions::FixVariables<
-                                 VariableFixing::FixToAtmosphere<
-                                     volume_dim, thermodynamic_dim>>,
-                             Actions::UpdateConservatives,
-                             Actions::RunEventsAndTriggers,
-                             Actions::ChangeSlabSize, step_actions,
-                             Actions::AdvanceTime>>>>>;
+          Parallel::PhaseActions<
+              Phase, Phase::Evolve,
+              tmpl::list<
+                  VariableFixing::Actions::FixVariables<
+                      VariableFixing::FixToAtmosphere<volume_dim,
+                                                      thermodynamic_dim>>,
+                  Actions::UpdateConservatives, Actions::RunEventsAndTriggers,
+                  Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
+                  PhaseControl::Actions::ExecutePhaseChange<phase_changes,
+                                                            triggers>>>>>;
 
-  using const_global_cache_tags =
-      tmpl::list<initial_data_tag, normal_dot_numerical_flux, time_stepper_tag,
-                 Tags::EventsAndTriggers<events, triggers>>;
+  template <typename ParallelComponent>
+  struct registration_list {
+    using type =
+        std::conditional_t<std::is_same_v<ParallelComponent, dg_element_array>,
+      dg_registration_list, tmpl::list<>>;
+  };
+
+  using component_list =
+      tmpl::list<observers::Observer<EvolutionMetavars>,
+                 observers::ObserverWriter<EvolutionMetavars>,
+                 dg_element_array>;
+
+  using const_global_cache_tags = tmpl::list<
+      initial_data_tag, normal_dot_numerical_flux, time_stepper_tag,
+      Tags::EventsAndTriggers<events, triggers>,
+      PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes, triggers>>;
 
   static constexpr Options::String help{
       "Evolve the Valencia formulation of RelativisticEuler system.\n\n"};
 
   template <typename... Tags>
   static Phase determine_next_phase(
-      const gsl::not_null<
-          tuples::TaggedTuple<Tags...>*> /*phase_change_decision_data*/,
+      const gsl::not_null<tuples::TaggedTuple<Tags...>*>
+          phase_change_decision_data,
       const Phase& current_phase,
-      const Parallel::CProxy_GlobalCache<
-          EvolutionMetavars>& /*cache_proxy*/) noexcept {
+      const Parallel::CProxy_GlobalCache<EvolutionMetavars>&
+          cache_proxy) noexcept {
+    const auto next_phase =
+        PhaseControl::arbitrate_phase_change<phase_changes, triggers>(
+            phase_change_decision_data, current_phase,
+            *(cache_proxy.ckLocalBranch()));
+    if (next_phase.has_value()) {
+      return next_phase.value();
+    }
     switch (current_phase) {
       case Phase::Initialization:
         return Phase::InitializeTimeStepperHistory;
@@ -321,7 +364,8 @@ struct EvolutionMetavars {
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{
-    &setup_error_handling, &disable_openblas_multithreading,
+    &setup_error_handling,
+    &disable_openblas_multithreading,
     &domain::creators::register_derived_with_charm,
     &domain::creators::time_dependence::register_derived_with_charm,
     &domain::FunctionsOfTime::register_derived_with_charm,
@@ -336,7 +380,9 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &Parallel::register_derived_classes_with_charm<TimeSequence<std::uint64_t>>,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<
-        Trigger<metavariables::triggers>>};
+        Trigger<metavariables::triggers>>,
+    &Parallel::register_derived_classes_with_charm<
+        PhaseChange<metavariables::phase_changes>>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -39,6 +39,9 @@
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
+#include "Parallel/PhaseControl/PhaseControlTags.hpp"
+#include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/Reduction.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
@@ -158,12 +161,6 @@ struct EvolutionMetavars {
                  Events::Registrars::ChangeSlabSize<slab_choosers>>;
   using triggers = Triggers::time_triggers;
 
-  // A tmpl::list of tags to be added to the GlobalCache by the
-  // metavariables
-  using const_global_cache_tags =
-      tmpl::list<initial_data_tag, normal_dot_numerical_flux, time_stepper_tag,
-                 Tags::EventsAndTriggers<events, triggers>>;
-
   using observed_reduction_data_tags = observers::collect_reduction_data_tags<
       typename Event<events>::creatable_classes>;
 
@@ -197,9 +194,37 @@ struct EvolutionMetavars {
     Initialization,
     RegisterWithObserver,
     InitializeTimeStepperHistory,
+    LoadBalancing,
     Evolve,
     Exit
   };
+
+  static std::string phase_name(Phase phase) noexcept {
+    if (phase == Phase::LoadBalancing) {
+      return "LoadBalancing";
+    }
+    ERROR(
+        "Passed phase that should not be used in input file. Integer "
+        "corresponding to phase is: "
+        << static_cast<int>(phase));
+  }
+
+  using phase_changes = tmpl::list<PhaseControl::Registrars::VisitAndReturn<
+      EvolutionMetavars, Phase::LoadBalancing>>;
+
+  using initialize_phase_change_decision_data =
+      PhaseControl::InitializePhaseChangeDecisionData<phase_changes, triggers>;
+
+  using phase_change_tags_and_combines_list =
+      PhaseControl::get_phase_change_tags<phase_changes>;
+
+  using const_global_cache_tags = tmpl::list<
+      initial_data_tag, normal_dot_numerical_flux, time_stepper_tag,
+      Tags::EventsAndTriggers<events, triggers>,
+      PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes, triggers>>;
+
+  using dg_registration_list =
+      tmpl::list<observers::Actions::RegisterEventsWithObservers>;
 
   using initialization_actions = tmpl::list<
       Actions::SetupDataBox,
@@ -229,29 +254,38 @@ struct EvolutionMetavars {
       Initialization::Actions::DiscontinuousGalerkin<EvolutionMetavars>,
       Initialization::Actions::RemoveOptionsAndTerminatePhase>;
 
-  using component_list = tmpl::list<
-      observers::Observer<EvolutionMetavars>,
-      observers::ObserverWriter<EvolutionMetavars>,
-      DgElementArray<
-          EvolutionMetavars,
-          tmpl::list<
-              Parallel::PhaseActions<Phase, Phase::Initialization,
-                                     initialization_actions>,
+  using dg_element_array = DgElementArray<
+      EvolutionMetavars,
+      tmpl::list<
+          Parallel::PhaseActions<Phase, Phase::Initialization,
+                                 initialization_actions>,
 
-              Parallel::PhaseActions<
-                  Phase, Phase::InitializeTimeStepperHistory,
-                  SelfStart::self_start_procedure<step_actions, system>>,
+          Parallel::PhaseActions<
+              Phase, Phase::InitializeTimeStepperHistory,
+              SelfStart::self_start_procedure<step_actions, system>>,
 
-              Parallel::PhaseActions<
-                  Phase, Phase::RegisterWithObserver,
-                  tmpl::list<observers::Actions::RegisterEventsWithObservers,
-                             Parallel::Actions::TerminatePhase>>,
+          Parallel::PhaseActions<Phase, Phase::RegisterWithObserver,
+                                 tmpl::list<dg_registration_list,
+                                            Parallel::Actions::TerminatePhase>>,
 
-              Parallel::PhaseActions<
-                  Phase, Phase::Evolve,
-                  tmpl::list<Actions::RunEventsAndTriggers,
-                             Actions::ChangeSlabSize, step_actions,
-                             Actions::AdvanceTime>>>>>;
+          Parallel::PhaseActions<
+              Phase, Phase::Evolve,
+              tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
+                         step_actions, Actions::AdvanceTime,
+                         PhaseControl::Actions::ExecutePhaseChange<
+                             phase_changes, triggers>>>>>;
+
+  template <typename ParallelComponent>
+  struct registration_list {
+    using type =
+        std::conditional_t<std::is_same_v<ParallelComponent, dg_element_array>,
+      dg_registration_list, tmpl::list<>>;
+  };
+
+  using component_list =
+      tmpl::list<observers::Observer<EvolutionMetavars>,
+                 observers::ObserverWriter<EvolutionMetavars>,
+                 dg_element_array>;
 
   static constexpr Options::String help{
       "Evolve a Scalar Wave in Dim spatial dimension.\n\n"
@@ -259,11 +293,18 @@ struct EvolutionMetavars {
 
   template <typename... Tags>
   static Phase determine_next_phase(
-      const gsl::not_null<
-          tuples::TaggedTuple<Tags...>*> /*phase_change_decision_data*/,
+      const gsl::not_null<tuples::TaggedTuple<Tags...>*>
+          phase_change_decision_data,
       const Phase& current_phase,
-      const Parallel::CProxy_GlobalCache<
-          EvolutionMetavars>& /*cache_proxy*/) noexcept {
+      const Parallel::CProxy_GlobalCache<EvolutionMetavars>&
+          cache_proxy) noexcept {
+    const auto next_phase =
+        PhaseControl::arbitrate_phase_change<phase_changes, triggers>(
+            phase_change_decision_data, current_phase,
+            *(cache_proxy.ckLocalBranch()));
+    if (next_phase.has_value()) {
+      return next_phase.value();
+    }
     switch (current_phase) {
       case Phase::Initialization:
         return Phase::InitializeTimeStepperHistory;
@@ -286,7 +327,8 @@ struct EvolutionMetavars {
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{
-    &setup_error_handling, &disable_openblas_multithreading,
+    &setup_error_handling,
+    &disable_openblas_multithreading,
     &domain::creators::register_derived_with_charm,
     &domain::creators::time_dependence::register_derived_with_charm,
     &domain::FunctionsOfTime::register_derived_with_charm,
@@ -303,6 +345,9 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &Parallel::register_derived_classes_with_charm<TimeSequence<std::uint64_t>>,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<
-        Trigger<metavariables::triggers>>};
+        Trigger<metavariables::triggers>>,
+    &Parallel::register_derived_classes_with_charm<
+        PhaseChange<metavariables::phase_changes>>};
+
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};

--- a/src/IO/Observer/Actions/RegisterEvents.hpp
+++ b/src/IO/Observer/Actions/RegisterEvents.hpp
@@ -107,7 +107,8 @@ struct RegisterEventsWithObservers {
   template <typename ParallelComponent, typename RegisterOrDeregisterAction,
             typename DbTagList, typename Metavariables, typename ArrayIndex>
   static void register_or_deregister_impl(
-      db::DataBox<DbTagList>& box, Parallel::GlobalCache<Metavariables>& cache,
+      const db::DataBox<DbTagList>& box,
+      Parallel::GlobalCache<Metavariables>& cache,
       const ArrayIndex& array_index) noexcept {
     auto& observer =
         *Parallel::get_parallel_component<observers::Observer<Metavariables>>(
@@ -152,7 +153,7 @@ struct RegisterEventsWithObservers {
  public:
   template <typename ParallelComponent, typename DbTagList,
             typename Metavariables, typename ArrayIndex>
-  static void perform_registration(db::DataBox<DbTagList>& box,
+  static void perform_registration(const db::DataBox<DbTagList>& box,
                                    Parallel::GlobalCache<Metavariables>& cache,
                                    const ArrayIndex& array_index) noexcept {
     register_or_deregister_impl<ParallelComponent,
@@ -163,7 +164,8 @@ struct RegisterEventsWithObservers {
   template <typename ParallelComponent, typename DbTagList,
             typename Metavariables, typename ArrayIndex>
   static void perform_deregistration(
-      db::DataBox<DbTagList>& box, Parallel::GlobalCache<Metavariables>& cache,
+      const db::DataBox<DbTagList>& box,
+      Parallel::GlobalCache<Metavariables>& cache,
       const ArrayIndex& array_index) noexcept {
     register_or_deregister_impl<ParallelComponent,
                                 DeregisterContributorWithObserver>(box, cache,

--- a/src/IO/Observer/Actions/RegisterEvents.hpp
+++ b/src/IO/Observer/Actions/RegisterEvents.hpp
@@ -116,29 +116,36 @@ struct RegisterEventsWithObservers {
     std::vector<
         std::pair<observers::TypeOfObservation, observers::ObservationKey>>
         type_of_observation_and_observation_key_pairs;
-
-    const auto& triggers_and_events =
-        db::get<::Tags::EventsAndTriggersBase>(box);
-    for (const auto& trigger_and_events :
-         triggers_and_events.events_and_triggers()) {
-      for (const auto& event : trigger_and_events.second) {
-        if (auto obs_type_and_obs_key =
-                get_registration_observation_type_and_key(*event, box);
-            obs_type_and_obs_key.has_value()) {
-          type_of_observation_and_observation_key_pairs.push_back(
-              *obs_type_and_obs_key);
+    if constexpr (db::tag_is_retrievable_v<::Tags::EventsAndTriggersBase,
+                                           db::DataBox<DbTagList>>) {
+      const auto& triggers_and_events =
+          db::get<::Tags::EventsAndTriggersBase>(box);
+      for (const auto& trigger_and_events :
+           triggers_and_events.events_and_triggers()) {
+        for (const auto& event : trigger_and_events.second) {
+          if (auto obs_type_and_obs_key =
+                  get_registration_observation_type_and_key(*event, box);
+              obs_type_and_obs_key.has_value()) {
+            type_of_observation_and_observation_key_pairs.push_back(
+                *obs_type_and_obs_key);
+          }
         }
       }
-    }
 
-    for (const auto& [type_of_observation, observation_key] :
-         type_of_observation_and_observation_key_pairs) {
-      Parallel::simple_action<RegisterOrDeregisterAction>(
-          observer, observation_key,
-          observers::ArrayComponentId(
-              std::add_pointer_t<ParallelComponent>{nullptr},
-              Parallel::ArrayIndex<std::decay_t<ArrayIndex>>{array_index}),
-          type_of_observation);
+      for (const auto& [type_of_observation, observation_key] :
+           type_of_observation_and_observation_key_pairs) {
+        Parallel::simple_action<RegisterOrDeregisterAction>(
+            observer, observation_key,
+            observers::ArrayComponentId(
+                std::add_pointer_t<ParallelComponent>{nullptr},
+                Parallel::ArrayIndex<std::decay_t<ArrayIndex>>{array_index}),
+            type_of_observation);
+      }
+    } else {
+      ERROR(
+          "Cannot perform registration of events, "
+          "`::Tags::EventsAndTriggersBase` is not retrievable from the "
+          "DataBox");
     }
   }
 

--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -421,7 +421,8 @@ class AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>
               [this, &box](auto registration_v) noexcept {
                 using registration = typename decltype(registration_v)::type;
                 registration::template perform_deregistration<
-                    ParallelComponent>(box, *global_cache_, array_index_);
+                    ParallelComponent>(boost::get<ThisVariant>(box),
+                                       *global_cache_, array_index_);
               });
         }
         if (p.isUnpacking()) {
@@ -429,7 +430,7 @@ class AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>
               [this, &box](auto registration_v) noexcept {
                 using registration = typename decltype(registration_v)::type;
                 registration::template perform_registration<ParallelComponent>(
-                    box, *global_cache_, array_index_);
+                    boost::get<ThisVariant>(box), *global_cache_, array_index_);
               });
         }
         *already_visited = true;

--- a/src/Parallel/AlgorithmMetafunctions.hpp
+++ b/src/Parallel/AlgorithmMetafunctions.hpp
@@ -10,6 +10,7 @@
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
+#include "Utilities/TypeTraits/CreateHasStaticMemberVariable.hpp"
 #include "Utilities/TypeTraits/CreateIsCallable.hpp"
 
 namespace Parallel {
@@ -147,6 +148,8 @@ struct build_databox_types<
 };
 
 CREATE_IS_CALLABLE(is_ready)
+CREATE_HAS_STATIC_MEMBER_VARIABLE(LoadBalancing)
+CREATE_HAS_STATIC_MEMBER_VARIABLE_V(LoadBalancing)
 
 // for checking the DataBox return of an iterable action
 template <typename FirstIterableActionType>

--- a/src/Parallel/Main.ci
+++ b/src/Parallel/Main.ci
@@ -23,6 +23,13 @@ module Main {
     entry void execute_next_phase();
   }
 
-  }
+  namespace detail {
+  template <typename Metavariables>
+  array [1D] AtSyncIndicator {
+    entry AtSyncIndicator(CProxy_Main<Metavariables> main_proxy);
 
+    entry void IndicateAtSync();
+  }
+  }  // namespace detail
+  }  // namespace Parallel
 }

--- a/src/Parallel/PhaseControl/ExecutePhaseChange.hpp
+++ b/src/Parallel/PhaseControl/ExecutePhaseChange.hpp
@@ -36,6 +36,17 @@ namespace Actions {
  * - DataBox: As specified by the `PhaseChange` option-created objects.
  *   - `PhaseChange` objects are permitted to perform mutations on the
  *     \ref DataBoxGroup "DataBox" to store persistent state information.
+ *
+ * \warning This action should almost always be placed at the end of the action
+ * list for a given phase, because the record of the index through the action
+ * list will not be retained during a phase change. Therefore, to avoid
+ * unexpected behavior, the phase changes should happen at the end of a phase,
+ * so that if control returns to the same phase it may continue looping as
+ * usual.
+ * If this suggestion is ignored, the typical pathology is an infinite loop of
+ * repeatedly triggering a phase change, because the trigger is examined too
+ * early in the action list for any alteration to have occurred before being
+ * interrupted again for a phase change.
  */
 template <typename PhaseChangeRegistrars, typename TriggerRegistrars>
 struct ExecutePhaseChange {

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -17,6 +17,8 @@ Evolution:
     AdamsBashforthN:
       Order: 3
 
+PhaseChangeAndTriggers:
+
 DomainCreator:
   Interval:
     LowerBound: [-1.0]

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -2,6 +2,8 @@
 # See LICENSE.txt for details.
 
 # Executable: EvolveBurgersStep
+# CommandLineArgs: +balancer RandCentLB +p2
+# Timeout: 5
 # Check: parse;execute
 
 AnalyticSolution:
@@ -18,6 +20,11 @@ Evolution:
       Order: 3
 
 PhaseChangeAndTriggers:
+  - - Slabs:
+        EvenlySpaced:
+          Interval: 10
+          Offset: 0
+    - - VisitAndReturn(LoadBalancing)
 
 DomainCreator:
   Interval:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
@@ -10,6 +10,8 @@ Evolution:
   TimeStepper:
     RungeKutta3
 
+PhaseChangeAndTriggers:
+
 DomainCreator:
   Interval:
     LowerBound: [-0.25]

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
@@ -10,6 +10,8 @@ Evolution:
   TimeStepper:
     RungeKutta3
 
+PhaseChangeAndTriggers:
+
 DomainCreator:
   Rectangle:
     LowerBound: [-0.25, 0.0]

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
@@ -10,6 +10,8 @@ Evolution:
   TimeStepper:
     RungeKutta3
 
+PhaseChangeAndTriggers:
+
 DomainCreator:
   Brick:
     LowerBound: [-0.25, 0.0, 0.0]

--- a/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
+++ b/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
@@ -13,6 +13,8 @@ Evolution:
     AdamsBashforthN:
       Order: 3
 
+PhaseChangeAndTriggers:
+
 DomainCreator:
   Brick:
     LowerBound: [10.5, 0.0, 0.0]

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow1D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow1D.yaml
@@ -10,6 +10,8 @@ Evolution:
   TimeStepper:
     RungeKutta3
 
+PhaseChangeAndTriggers:
+
 DomainCreator:
   Interval:
     LowerBound: [0.0]

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow2D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow2D.yaml
@@ -10,6 +10,8 @@ Evolution:
   TimeStepper:
     RungeKutta3
 
+PhaseChangeAndTriggers:
+
 DomainCreator:
   Rectangle:
     LowerBound: [0.0, 0.0]

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow3D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow3D.yaml
@@ -10,6 +10,8 @@ Evolution:
   TimeStepper:
     RungeKutta3
 
+PhaseChangeAndTriggers:
+
 DomainCreator:
   Brick:
     LowerBound: [0.0, 0.0, 0.0]

--- a/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
@@ -14,6 +14,8 @@ AnalyticSolution:
         Wavenumber: 1.0
         Phase: 0.0
 
+PhaseChangeAndTriggers:
+
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.001

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -17,6 +17,8 @@ AnalyticSolution:
         Wavenumber: 1.0
         Phase: 0.0
 
+PhaseChangeAndTriggers:
+
 Evolution:
   InitialTime: &InitialTime
     0.0

--- a/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
@@ -14,6 +14,8 @@ AnalyticSolution:
         Wavenumber: 1.0
         Phase: 0.0
 
+PhaseChangeAndTriggers:
+
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.001

--- a/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
@@ -14,6 +14,8 @@ AnalyticSolution:
         Wavenumber: 1.0
         Phase: 0.0
 
+PhaseChangeAndTriggers:
+
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.001


### PR DESCRIPTION
## Proposed changes

Finishes adding the capability of load-balancing to the core parallelization infrastructure.
Also, enables load-balancing phase changes in all evolution executables that do not use the interpolation framework. Those executables that do use interpolation will be covered in a future PR that puts in the deregistration of elements with interpolation.

I also enable an input file test for Burgers that actually runs the load balancing so we have some verification that things don't immediately break with load-balancing enabled.

I have also done a longer run (with Burgers) to verify that observers are still stable with the load-balancing system operational, but it would probably be good for reviewers to double-check this with their favorite executable, because the charm++ load balancing has been known to have subtle side-effects in past experiments.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Many yaml files must now include a `PhaseChangeAndTriggers:` block. If you do not wish to enter the load balancing phase, the block may be left empty.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
