### PR TITLE
Add interpolator deregistration, Add load balancing to remaining executables

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -70,6 +70,9 @@
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/Algorithms/AlgorithmSingleton.hpp"
 #include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
+#include "Parallel/PhaseControl/PhaseControlTags.hpp"
+#include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/Reduction.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
@@ -244,18 +247,6 @@ struct EvolutionMetavars {
       observation_events,
       intrp::Events::Registrars::Interpolate<3, AhA, interpolator_source_vars>>;
 
-  // A tmpl::list of tags to be added to the GlobalCache by the
-  // metavariables
-  using const_global_cache_tags = tmpl::list<
-      analytic_solution_tag, normal_dot_numerical_flux, time_stepper_tag,
-      Tags::EventsAndTriggers<events, triggers>,
-      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma0<
-          volume_dim, frame>,
-      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma1<
-          volume_dim, frame>,
-      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma2<
-          volume_dim, frame>>;
-
   using observed_reduction_data_tags = observers::collect_reduction_data_tags<
       tmpl::push_back<typename Event<observation_events>::creatable_classes,
                       typename AhA::post_horizon_find_callback>>;
@@ -281,9 +272,44 @@ struct EvolutionMetavars {
     InitializeInitialDataDependentQuantities,
     InitializeTimeStepperHistory,
     Register,
+    LoadBalancing,
     Evolve,
     Exit
   };
+
+  static std::string phase_name(Phase phase) noexcept {
+    if (phase == Phase::LoadBalancing) {
+      return "LoadBalancing";
+    }
+    ERROR(
+        "Passed phase that should not be used in input file. Integer "
+        "corresponding to phase is: "
+        << static_cast<int>(phase));
+  }
+
+  using phase_changes = tmpl::list<PhaseControl::Registrars::VisitAndReturn<
+      EvolutionMetavars, Phase::LoadBalancing>>;
+
+  using initialize_phase_change_decision_data =
+      PhaseControl::InitializePhaseChangeDecisionData<phase_changes, triggers>;
+
+  using phase_change_tags_and_combines_list =
+      PhaseControl::get_phase_change_tags<phase_changes>;
+
+  using const_global_cache_tags = tmpl::list<
+      analytic_solution_tag, normal_dot_numerical_flux, time_stepper_tag,
+    Tags::EventsAndTriggers<events, triggers>,
+    GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma0<
+      volume_dim, frame>,
+    GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma1<
+      volume_dim, frame>,
+    GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma2<
+      volume_dim, frame>,
+    PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes, triggers>>;
+
+  using dg_registration_list =
+      tmpl::list<intrp::Actions::RegisterElementWithInterpolator,
+                 observers::Actions::RegisterEventsWithObservers>;
 
   using initialization_actions = tmpl::list<
       Actions::SetupDataBox,
@@ -340,6 +366,52 @@ struct EvolutionMetavars {
       GeneralizedHarmonic::Actions::InitializeConstraints<volume_dim>,
       Parallel::Actions::TerminatePhase>;
 
+  using dg_element_array = DgElementArray<
+      EvolutionMetavars,
+      tmpl::flatten<tmpl::list<
+          Parallel::PhaseActions<Phase, Phase::Initialization,
+                                 initialization_actions>,
+          tmpl::conditional_t<
+              evolution::is_numeric_initial_data_v<initial_data>,
+              tmpl::list<
+                  Parallel::PhaseActions<
+                      Phase, Phase::RegisterWithElementDataReader,
+                      tmpl::list<
+                          importers::Actions::RegisterWithElementDataReader,
+                          Parallel::Actions::TerminatePhase>>,
+                  Parallel::PhaseActions<
+                      Phase, Phase::ImportInitialData,
+                      tmpl::list<importers::Actions::ReadVolumeData<
+                                     evolution::OptionTags::NumericInitialData,
+                                     typename system::variables_tag::tags_list>,
+                                 importers::Actions::ReceiveVolumeData<
+                                     evolution::OptionTags::NumericInitialData,
+                                     typename system::variables_tag::tags_list>,
+                                 Parallel::Actions::TerminatePhase>>>,
+              tmpl::list<>>,
+          Parallel::PhaseActions<
+              Phase, Phase::InitializeInitialDataDependentQuantities,
+              initialize_initial_data_dependent_quantities_actions>,
+          Parallel::PhaseActions<
+              Phase, Phase::InitializeTimeStepperHistory,
+              SelfStart::self_start_procedure<step_actions, system>>,
+          Parallel::PhaseActions<Phase, Phase::Register,
+                                 tmpl::list<dg_registration_list,
+                                            Parallel::Actions::TerminatePhase>>,
+          Parallel::PhaseActions<
+              Phase, Phase::Evolve,
+              tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
+                         step_actions, Actions::AdvanceTime,
+                         PhaseControl::Actions::ExecutePhaseChange<
+                             phase_changes, triggers>>>>>>;
+
+  template <typename ParallelComponent>
+  struct registration_list {
+    using type = std::conditional_t<
+        std::is_same_v<ParallelComponent, dg_element_array>,
+      dg_registration_list, tmpl::list<>>;
+  };
+
   using component_list = tmpl::flatten<tmpl::list<
       observers::Observer<EvolutionMetavars>,
       observers::ObserverWriter<EvolutionMetavars>,
@@ -348,46 +420,7 @@ struct EvolutionMetavars {
       tmpl::conditional_t<evolution::is_numeric_initial_data_v<initial_data>,
                           importers::ElementDataReader<EvolutionMetavars>,
                           tmpl::list<>>,
-      DgElementArray<
-          EvolutionMetavars,
-          tmpl::flatten<tmpl::list<
-              Parallel::PhaseActions<Phase, Phase::Initialization,
-                                     initialization_actions>,
-              tmpl::conditional_t<
-                  evolution::is_numeric_initial_data_v<initial_data>,
-                  tmpl::list<
-                      Parallel::PhaseActions<
-                          Phase, Phase::RegisterWithElementDataReader,
-                          tmpl::list<
-                              importers::Actions::RegisterWithElementDataReader,
-                              Parallel::Actions::TerminatePhase>>,
-                      Parallel::PhaseActions<
-                          Phase, Phase::ImportInitialData,
-                          tmpl::list<
-                              importers::Actions::ReadVolumeData<
-                                  evolution::OptionTags::NumericInitialData,
-                                  typename system::variables_tag::tags_list>,
-                              importers::Actions::ReceiveVolumeData<
-                                  evolution::OptionTags::NumericInitialData,
-                                  typename system::variables_tag::tags_list>,
-                              Parallel::Actions::TerminatePhase>>>,
-                  tmpl::list<>>,
-              Parallel::PhaseActions<
-                  Phase, Phase::InitializeInitialDataDependentQuantities,
-                  initialize_initial_data_dependent_quantities_actions>,
-              Parallel::PhaseActions<
-                  Phase, Phase::InitializeTimeStepperHistory,
-                  SelfStart::self_start_procedure<step_actions, system>>,
-              Parallel::PhaseActions<
-                  Phase, Phase::Register,
-                  tmpl::list<intrp::Actions::RegisterElementWithInterpolator,
-                             observers::Actions::RegisterEventsWithObservers,
-                             Parallel::Actions::TerminatePhase>>,
-              Parallel::PhaseActions<
-                  Phase, Phase::Evolve,
-                  tmpl::list<Actions::RunEventsAndTriggers,
-                             Actions::ChangeSlabSize, step_actions,
-                             Actions::AdvanceTime>>>>>>>;
+      dg_element_array>>;
 
   static constexpr Options::String help{
       "Evolve a generalized harmonic analytic solution.\n\n"
@@ -396,11 +429,18 @@ struct EvolutionMetavars {
 
   template <typename... Tags>
   static Phase determine_next_phase(
-      const gsl::not_null<
-          tuples::TaggedTuple<Tags...>*> /*phase_change_decision_data*/,
+      const gsl::not_null<tuples::TaggedTuple<Tags...>*>
+          phase_change_decision_data,
       const Phase& current_phase,
-      const Parallel::CProxy_GlobalCache<
-          EvolutionMetavars>& /*cache_proxy*/) noexcept {
+      const Parallel::CProxy_GlobalCache<EvolutionMetavars>&
+          cache_proxy) noexcept {
+    const auto next_phase =
+        PhaseControl::arbitrate_phase_change<phase_changes, triggers>(
+            phase_change_decision_data, current_phase,
+            *(cache_proxy.ckLocalBranch()));
+    if (next_phase.has_value()) {
+      return next_phase.value();
+    }
     switch (current_phase) {
       case Phase::Initialization:
         return evolution::is_numeric_initial_data_v<initial_data>
@@ -448,7 +488,9 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &Parallel::register_derived_classes_with_charm<TimeSequence<std::uint64_t>>,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<
-        Trigger<metavariables::triggers>>};
+        Trigger<metavariables::triggers>>,
+    &Parallel::register_derived_classes_with_charm<
+        PhaseChange<metavariables::phase_changes>>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};

--- a/src/NumericalAlgorithms/Interpolation/InterpolatorRegisterElement.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolatorRegisterElement.hpp
@@ -41,10 +41,10 @@ namespace Actions {
 ///
 /// For requirements on Metavariables, see `InterpolationTarget`.
 struct RegisterElement {
-  template <
-      typename ParallelComponent, typename DbTags, typename Metavariables,
-      typename ArrayIndex,
-      Requires<tmpl::list_contains_v<DbTags, Tags::NumberOfElements>> = nullptr>
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex,
+            Requires<db::tag_is_retrievable_v<Tags::NumberOfElements,
+                                              db::DataBox<DbTags>>> = nullptr>
   static void apply(db::DataBox<DbTags>& box,
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/) noexcept {
@@ -52,6 +52,37 @@ struct RegisterElement {
         make_not_null(&box),
         [](const gsl::not_null<size_t*> num_elements) noexcept {
           ++(*num_elements);
+        });
+  }
+};
+
+/// \ingroup ActionsGroup
+/// \brief Invoked on the `Interpolator` ParallelComponent to deregister an
+/// element with the `Interpolator`.
+///
+/// This is called by `RegisterElementWithInterpolator` below.
+///
+/// Uses: nothing
+///
+/// DataBox changes:
+/// - Adds: nothing
+/// - Removes: nothing
+/// - Modifies:
+///   - `Tags::NumberOfElements`
+///
+/// For requirements on Metavariables, see `InterpolationTarget`.
+struct DeregisterElement {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex,
+            Requires<db::tag_is_retrievable_v<Tags::NumberOfElements,
+                                              db::DataBox<DbTags>>> = nullptr>
+  static void apply(db::DataBox<DbTags>& box,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/) noexcept {
+    db::mutate<Tags::NumberOfElements>(
+        make_not_null(&box),
+        [](const gsl::not_null<size_t*> num_elements) noexcept {
+          --(*num_elements);
         });
   }
 };
@@ -67,7 +98,52 @@ struct RegisterElement {
 /// - Removes: nothing
 /// - Modifies: nothing
 ///
+/// When this struct is used as an action, the `apply` function will perform the
+/// registration with the interpolator. However, this struct also offers the
+/// static member functions `perform_registration` and `perform_deregistration`
+/// that are needed for either registering when an element is added to a core
+/// outside of initialization or deregistering when an element is being
+/// eliminated from a core. The use of separate functions is necessary to
+/// provide an interface usable outside of iterable actions, e.g. in specialized
+/// `pup` functions.
 struct RegisterElementWithInterpolator {
+ private:
+  template <typename ParallelComponent, typename RegisterOrDeregisterAction,
+            typename Metavariables, typename ArrayIndex>
+  static void register_or_deregister_impl(
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/) noexcept {
+    auto& interpolator =
+        *Parallel::get_parallel_component<::intrp::Interpolator<Metavariables>>(
+             cache)
+             .ckLocalBranch();
+    Parallel::simple_action<RegisterOrDeregisterAction>(interpolator);
+  }
+
+ public:
+  // the registration functions do not use the DataBox argument, but need to
+  // keep it to conform to the interface used in the registration and
+  // deregistration procedure in Algorithm.hpp, which also supports registration
+  // and deregistration that does use the box.
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables, typename ArrayIndex>
+  static void perform_registration(const db::DataBox<DbTagList>& /*box*/,
+                                   Parallel::GlobalCache<Metavariables>& cache,
+                                   const ArrayIndex& array_index) noexcept {
+    register_or_deregister_impl<ParallelComponent, RegisterElement>(
+        cache, array_index);
+  }
+
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables, typename ArrayIndex>
+  static void perform_deregistration(
+      const db::DataBox<DbTagList>& /*box*/,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index) noexcept {
+    register_or_deregister_impl<ParallelComponent, DeregisterElement>(
+        cache, array_index);
+  }
+
   template <typename DbTagList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>
@@ -75,13 +151,9 @@ struct RegisterElementWithInterpolator {
       db::DataBox<DbTagList>& box,
       const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
       Parallel::GlobalCache<Metavariables>& cache,
-      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ArrayIndex& array_index, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) noexcept {
-    auto& interpolator =
-        *Parallel::get_parallel_component<::intrp::Interpolator<Metavariables>>(
-             cache)
-             .ckLocalBranch();
-    Parallel::simple_action<RegisterElement>(interpolator);
+    perform_registration<ParallelComponent>(box, cache, array_index);
     return {std::move(box)};
   }
 };

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -15,6 +15,8 @@ Evolution:
     AdamsBashforthN:
       Order: 1
 
+PhaseChangeAndTriggers:
+
 DomainCreator:
     Shell:
       InnerRadius: 1.9

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/CylindricalBlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/CylindricalBlastWave.yaml
@@ -9,6 +9,8 @@ Evolution:
   InitialTimeStep: 0.01
   TimeStepper: RungeKutta3
 
+PhaseChangeAndTriggers:
+
 DomainCreator:
   Brick:
     LowerBound: [-6.0, -6.0, -6.0]

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -21,6 +21,8 @@ Evolution:
   # InitialSlabSize is only needed for local time stepping
   # InitialSlabSize: 0.01
 
+PhaseChangeAndTriggers:
+
 DomainCreator:
   Brick:
     LowerBound: [10.5, 0.0, 0.0]

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
@@ -125,6 +125,34 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.RegisterElement",
   // No more queued simple actions.
   CHECK(runner.is_simple_action_queue_empty<interp_component>(0));
   CHECK(runner.is_simple_action_queue_empty<elem_component>(0));
+
+  {
+    INFO("Deregistration");
+    intrp::Actions::RegisterElementWithInterpolator::
+        template perform_deregistration<elem_component>(
+            ActionTesting::get_databox<elem_component, tmpl::list<>>(
+                make_not_null(&runner), 0_st),
+            ActionTesting::cache<elem_component>(runner, 0_st), 0_st);
+    ActionTesting::invoke_queued_simple_action<interp_component>(
+        make_not_null(&runner), 0);
+    // No more queued simple actions.
+    CHECK(runner.is_simple_action_queue_empty<interp_component>(0));
+    CHECK(runner.is_simple_action_queue_empty<elem_component>(0));
+
+    CHECK(ActionTesting::get_databox_tag<interp_component,
+          ::intrp::Tags::NumberOfElements>(
+               runner, 0) == 2);
+    runner.simple_action<interp_component, ::intrp::Actions::DeregisterElement>(
+        0);
+    CHECK(ActionTesting::get_databox_tag<interp_component,
+          ::intrp::Tags::NumberOfElements>(
+               runner, 0) == 1);
+    runner.simple_action<interp_component, ::intrp::Actions::DeregisterElement>(
+        0);
+    CHECK(ActionTesting::get_databox_tag<interp_component,
+                                         ::intrp::Tags::NumberOfElements>(
+              runner, 0) == 0);
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
## Proposed changes

Extends the deregistration/re-registration to the interpolator registration, and adds the load-balancing metavariables changes to GH and GRMHD, which use interpolators.

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->
Now all of the executables require input file .yamls to have a `PhaseChangeAndTriggers` entry
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Dependencies

- [x] #3045