### PR TITLE
Add SphericalHarmonic basis

### DIFF
--- a/src/NumericalAlgorithms/Spectral/Mesh.hpp
+++ b/src/NumericalAlgorithms/Spectral/Mesh.hpp
@@ -12,6 +12,7 @@
 #include "DataStructures/Index.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Options/Options.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TypeTraits.hpp"  // IWYU pragma: keep
@@ -96,6 +97,8 @@ class Mesh {
   Mesh(const size_t isotropic_extents, const Spectral::Basis basis,
        const Spectral::Quadrature quadrature) noexcept
       : extents_(isotropic_extents) {
+    ASSERT(basis != Spectral::Basis::SphericalHarmonic,
+           "SphericalHarmonic is not a valid basis for the Mesh");
     bases_.fill(basis);
     quadratures_.fill(quadrature);
   }
@@ -113,6 +116,8 @@ class Mesh {
   Mesh(std::array<size_t, Dim> extents, const Spectral::Basis basis,
        const Spectral::Quadrature quadrature) noexcept
       : extents_(std::move(extents)) {
+    ASSERT(basis != Spectral::Basis::SphericalHarmonic,
+           "SphericalHarmonic is not a valid basis for the Mesh");
     bases_.fill(basis);
     quadratures_.fill(quadrature);
   }
@@ -129,9 +134,13 @@ class Mesh {
    */
   Mesh(std::array<size_t, Dim> extents, std::array<Spectral::Basis, Dim> bases,
        std::array<Spectral::Quadrature, Dim> quadratures) noexcept
-      : extents_(std::move(extents)),
-        bases_(std::move(bases)),
-        quadratures_(std::move(quadratures)) {}
+      : extents_(std::move(extents)), quadratures_(std::move(quadratures)) {
+    for (auto it = bases.begin(); it != bases.end(); it++) {
+      ASSERT(*it != Spectral::Basis::SphericalHarmonic,
+             "SphericalHarmonic is not a valid basis for the Mesh");
+    }
+    bases_ = std::move(bases);
+  }
 
   /*!
    * \brief The number of grid points in each dimension of the grid.

--- a/src/NumericalAlgorithms/Spectral/Spectral.cpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.cpp
@@ -32,6 +32,8 @@ std::ostream& operator<<(std::ostream& os, const Basis& basis) noexcept {
       return os << "Chebyshev";
     case Basis::FiniteDifference:
       return os << "FiniteDifference";
+    case Basis::SphericalHarmonic:
+      return os << "SphericalHarmonic";
     default:
       ERROR("Invalid basis");
   }
@@ -677,6 +679,8 @@ Spectral::Basis Options::create_from_yaml<Spectral::Basis>::create<void>(
     return Spectral::Basis::Legendre;
   } else if ("FiniteDifference" == type_read) {
     return Spectral::Basis::FiniteDifference;
+  } else if ("SphericalHarmonic" == type_read) {
+    return Spectral::Basis::SphericalHarmonic;
   }
   PARSE_ERROR(options.context(),
               "Failed to convert \""

--- a/src/NumericalAlgorithms/Spectral/Spectral.hpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.hpp
@@ -67,7 +67,7 @@ namespace Spectral {
  * discontinuous solutions, hence none of those are defined for the
  * `FiniteDifference` basis.
  */
-enum class Basis { Chebyshev, Legendre, FiniteDifference };
+enum class Basis { Chebyshev, Legendre, FiniteDifference, SphericalHarmonic };
 
 /// \cond HIDDEN_SYMBOLS
 std::ostream& operator<<(std::ostream& os, const Basis& basis) noexcept;

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Mesh.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Mesh.cpp
@@ -320,6 +320,32 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.Mesh",
 #endif
 }
 
+// [[OutputRegex, SphericalHarmonic is not a valid basis for the Mesh]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.NumericalAlgorithms.Spectral.Mesh.InvalidBasis",
+    "[NumericalAlgorithms][Spectral][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  const Mesh<1> mesh1d{2, Spectral::Basis::SphericalHarmonic,
+                       Spectral::Quadrature::GaussLobatto};
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, SphericalHarmonic is not a valid basis for the Mesh]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.NumericalAlgorithms.Spectral.Mesh.InvalidBases",
+    "[NumericalAlgorithms][Spectral][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  const Mesh<2> mesh2d{
+      {{2, 2}},
+      {{Spectral::Basis::SphericalHarmonic, Spectral::Basis::Legendre}},
+      {{Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss}}};
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
 // [[OutputRegex, Failed to convert ".*" to Spectral::Basis.]]
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.Mesh.WrongBasis",
                   "[NumericalAlgorithms][Spectral][Unit]") {


### PR DESCRIPTION
## Proposed changes

Adds SphericalHarmonic as a basis to be used for generating the connectivity for S2 topology (apparent horizon connectivity).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
