### PR TITLE
Rename projection functions for use in AMR, add docs

### DIFF
--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp
@@ -97,8 +97,8 @@ Variables<Tags> project_to_mortar(const Variables<Tags>& vars,
     const auto& slice_size = gsl::at(mortar_size, i);
     if (slice_size != Spectral::MortarSize::Full or
         face_slice_mesh != mortar_slice_mesh) {
-      gsl::at(projection_matrices, i) = projection_matrix_element_to_mortar(
-          slice_size, mortar_slice_mesh, face_slice_mesh);
+      gsl::at(projection_matrices, i) = projection_matrix_parent_to_child(
+          face_slice_mesh, mortar_slice_mesh, slice_size);
     }
   }
   return apply_matrices(projection_matrices, vars, face_mesh.extents());
@@ -129,8 +129,8 @@ Variables<Tags> project_from_mortar(
     const auto& slice_size = gsl::at(mortar_size, i);
     if (slice_size != Spectral::MortarSize::Full or
         face_slice_mesh != mortar_slice_mesh) {
-      gsl::at(projection_matrices, i) = projection_matrix_mortar_to_element(
-          slice_size, face_slice_mesh, mortar_slice_mesh);
+      gsl::at(projection_matrices, i) = projection_matrix_child_to_parent(
+          mortar_slice_mesh, face_slice_mesh, slice_size);
     }
   }
   return apply_matrices(projection_matrices, vars, mortar_mesh.extents());

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/SimpleBoundaryData.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/SimpleBoundaryData.hpp
@@ -20,9 +20,6 @@ template <size_t Dim>
 struct Mesh;
 template <size_t Dim>
 struct OrientationMap;
-namespace Spectral {
-enum class MortarSize;
-}  // namespace Spectral
 /// \endcond
 
 namespace dg {
@@ -66,8 +63,7 @@ struct SimpleBoundaryData {
   template <size_t MortarDim>
   SimpleBoundaryData<FieldTags, ExtraDataTags> project_to_mortar(
       const Mesh<MortarDim>& face_mesh, const Mesh<MortarDim>& mortar_mesh,
-      const std::array<Spectral::MortarSize, MortarDim>& mortar_size) const
-      noexcept {
+      const MortarSize<MortarDim>& mortar_size) const noexcept {
     SimpleBoundaryData<FieldTags, ExtraDataTags> projected_data{};
     projected_data.field_data = dg::project_to_mortar(
         this->field_data, face_mesh, mortar_mesh, mortar_size);

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Projection.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Projection.cpp
@@ -58,8 +58,8 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.Projection.p.mortar_to_element",
               num_points_source, Spectral::Basis::Legendre, quadrature_source);
           CAPTURE(mesh_source);
           const auto& points_source = Spectral::collocation_points(mesh_source);
-          const auto& projection = projection_matrix_mortar_to_element(
-              Spectral::MortarSize::Full, mesh_dest, mesh_source);
+          const auto& projection = projection_matrix_child_to_parent(
+              mesh_source, mesh_dest, Spectral::MortarSize::Full);
           for (size_t test_order = 0;
                test_order < num_points_source;
                ++test_order) {
@@ -112,8 +112,8 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.Projection.p.element_to_mortar",
               num_points_source, Spectral::Basis::Legendre, quadrature_source);
           CAPTURE(mesh_source);
           const auto& points_source = Spectral::collocation_points(mesh_source);
-          const auto& projection = projection_matrix_element_to_mortar(
-              Spectral::MortarSize::Full, mesh_dest, mesh_source);
+          const auto& projection = projection_matrix_parent_to_child(
+              mesh_source, mesh_dest, Spectral::MortarSize::Full);
           for (size_t test_order = 0;
                test_order < num_points_source;
                ++test_order) {
@@ -155,8 +155,8 @@ void check_mortar_to_element_projection(const Spectral::MortarSize mortar_size,
   // _element indicates the coordinate system on the large interval.
   // _mortar indicates the coordinate system on one of the small intervals.
 
-  const auto& projection = projection_matrix_mortar_to_element(
-      mortar_size, mesh_element, mesh_self_mortar);
+  const auto& projection = projection_matrix_child_to_parent(
+      mesh_self_mortar, mesh_element, mortar_size);
 
   const size_t num_points_self_mortar = mesh_self_mortar.extents(0);
   const size_t num_points_element = mesh_element.extents(0);
@@ -290,16 +290,16 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.Projection.h.element_to_mortar",
             // The function is contained in the destination space, so
             // projection should not alter it.
             {
-              const auto& projection = projection_matrix_element_to_mortar(
-                  Spectral::MortarSize::UpperHalf, mesh_dest, mesh_source);
+              const auto& projection = projection_matrix_parent_to_child(
+                  mesh_source, mesh_dest, Spectral::MortarSize::UpperHalf);
               const DataVector projected_data =
                   apply_matrix(projection, source_data);
               CHECK_ITERABLE_APPROX(
                   projected_data, pow(to_upper_half(points_dest), test_order));
             }
             {
-              const auto& projection = projection_matrix_element_to_mortar(
-                  Spectral::MortarSize::LowerHalf, mesh_dest, mesh_source);
+              const auto& projection = projection_matrix_parent_to_child(
+                  mesh_source, mesh_dest, Spectral::MortarSize::LowerHalf);
               const DataVector projected_data =
                   apply_matrix(projection, source_data);
               CHECK_ITERABLE_APPROX(


### PR DESCRIPTION
## Proposed changes

- Refer to the two meshes as "child" and "parent" mesh instead of "mortar" and "element". I chose "child" and "parent" because those names are also used in `SegmentId` and `ElementId`.
- Add some more documentation
- Reorder arguments so they match the function names.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
- Rename `projection_matrix_mortar_to_element` -> `projection_matrix_child_to_parent` and `projection_matrix_element_to_mortar` -> `projection_matrix_parent_to_child`. Make sure to check the order of their arguments.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
