### PR TITLE
Subcell: tags DidRollback and caching Jacobians

### DIFF
--- a/src/Evolution/DgSubcell/Tags/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/Tags/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_headers(
   Coordinates.hpp
   DidRollback.hpp
   Inactive.hpp
+  Jacobians.hpp
   Mesh.hpp
   NeighborData.hpp
   SubcellOptions.hpp

--- a/src/Evolution/DgSubcell/Tags/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/Tags/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_headers(
   HEADERS
   ActiveGrid.hpp
   Coordinates.hpp
+  DidRollback.hpp
   Inactive.hpp
   Mesh.hpp
   NeighborData.hpp

--- a/src/Evolution/DgSubcell/Tags/DidRollback.hpp
+++ b/src/Evolution/DgSubcell/Tags/DidRollback.hpp
@@ -1,0 +1,19 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/Tag.hpp"
+
+namespace evolution::dg::subcell::Tags {
+/// \brief Tag indicating whether we are retrying a step after a rollback of a
+/// failed DG step
+///
+/// Set to `true` by the DG scheme when the predicted step failed and a rollback
+/// is performed. The subcell solver checks the tag, and uses the DG boundary
+/// data if a rollback occurred in order to maintain conservation. The subcell
+/// solver then sets `DidRollback` to `false`.
+struct DidRollback : db::SimpleTag {
+  using type = bool;
+};
+}  // namespace evolution::dg::subcell::Tags

--- a/src/Evolution/DgSubcell/Tags/Jacobians.hpp
+++ b/src/Evolution/DgSubcell/Tags/Jacobians.hpp
@@ -1,0 +1,39 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+namespace evolution::dg::subcell::fd::Tags {
+/// \brief The inverse Jacobian from the logical frame to the grid frame at the
+/// cell centers.
+///
+/// Specifically, \f$\partial x^{\bar{i}} / \partial x^i\f$, where \f$\bar{i}\f$
+/// denotes the logical frame and \f$i\f$ denotes the grid frame.
+///
+/// \note stored as a `std::optional` so we can reset it when switching to DG
+/// and reduce the memory footprint.
+template <size_t Dim>
+struct InverseJacobianLogicalToGrid : db::SimpleTag {
+  static std::string name() noexcept { return "InverseJacobian(Logical,Grid)"; }
+  using type = std::optional<
+      ::InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Grid>>;
+};
+
+/// \brief The determinant of the inverse Jacobian from the logical frame to the
+/// grid frame at the cell centers.
+///
+/// \note stored as a `std::optional` so we can reset it when switching to DG
+/// and reduce the memory footprint.
+struct DetInverseJacobianLogicalToGrid : db::SimpleTag {
+  static std::string name() noexcept {
+    return "Det(InverseJacobian(Logical,Grid))";
+  }
+  using type = std::optional<Scalar<DataVector>>;
+};
+}  // namespace evolution::dg::subcell::fd::Tags

--- a/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
@@ -13,6 +13,7 @@
 #include "Evolution/DgSubcell/Tags/Coordinates.hpp"
 #include "Evolution/DgSubcell/Tags/DidRollback.hpp"
 #include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/DgSubcell/Tags/Jacobians.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/NeighborData.hpp"
 #include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
@@ -50,6 +51,9 @@ void test() {
   TestHelpers::db::test_simple_tag<
       evolution::dg::subcell::Tags::Coordinates<Dim, Frame::Inertial>>(
       "InertialCoordinates");
+  TestHelpers::db::test_simple_tag<
+      evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToGrid<Dim>>(
+      "InverseJacobian(Logical,Grid)");
 
   TestHelpers::db::test_compute_tag<
       evolution::dg::subcell::Tags::LogicalCoordinatesCompute<Dim>>(
@@ -73,6 +77,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Tags",
                   "[Evolution][Unit]") {
   TestHelpers::db::test_simple_tag<evolution::dg::subcell::Tags::ActiveGrid>(
       "ActiveGrid");
+  TestHelpers::db::test_simple_tag<
+      evolution::dg::subcell::fd::Tags::DetInverseJacobianLogicalToGrid>(
+      "Det(InverseJacobian(Logical,Grid))");
   TestHelpers::db::test_simple_tag<evolution::dg::subcell::Tags::DidRollback>(
       "DidRollback");
   TestHelpers::db::test_simple_tag<

--- a/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
@@ -11,6 +11,7 @@
 #include "Domain/LogicalCoordinates.hpp"
 #include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/Tags/Coordinates.hpp"
+#include "Evolution/DgSubcell/Tags/DidRollback.hpp"
 #include "Evolution/DgSubcell/Tags/Inactive.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/NeighborData.hpp"
@@ -72,6 +73,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Tags",
                   "[Evolution][Unit]") {
   TestHelpers::db::test_simple_tag<evolution::dg::subcell::Tags::ActiveGrid>(
       "ActiveGrid");
+  TestHelpers::db::test_simple_tag<evolution::dg::subcell::Tags::DidRollback>(
+      "DidRollback");
   TestHelpers::db::test_simple_tag<
       evolution::dg::subcell::Tags::Inactive<Var1>>("Inactive(Var1)");
   TestHelpers::db::test_simple_tag<evolution::dg::subcell::Tags::Inactive<


### PR DESCRIPTION
## Proposed changes

- Add a tag `DidRollback` that is used so the subcell solver can determine if a DG step was attempted and failed
- Add tags for the cell-centered inverse Jacobian and determinant from logical to the grid frame

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
