### PR TITLE
Add DynamicBuffer

### DIFF
--- a/src/DataStructures/CMakeLists.txt
+++ b/src/DataStructures/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   ApplyMatrices.cpp
+  DynamicBuffer.cpp
   Index.cpp
   IndexIterator.cpp
   LeviCivitaIterator.cpp
@@ -30,6 +31,7 @@ spectre_target_headers(
   DenseMatrix.hpp
   DenseVector.hpp
   DiagonalModalOperator.hpp
+  DynamicBuffer.hpp
   FixedHashMap.hpp
   GeneralIndexIterator.hpp
   IdPair.hpp

--- a/src/DataStructures/DynamicBuffer.cpp
+++ b/src/DataStructures/DynamicBuffer.cpp
@@ -1,0 +1,113 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "DataStructures/DynamicBuffer.hpp"
+
+#include <pup_stl.h>
+
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+template <typename T>
+DynamicBuffer<T>::DynamicBuffer(const size_t number_of_vectors,
+                                const size_t number_of_grid_points) noexcept
+    : number_of_grid_points_(number_of_grid_points), data_(number_of_vectors) {
+  if constexpr (is_data_vector_type) {
+    buffer_.resize(number_of_vectors * number_of_grid_points);
+    set_references();
+  } else {
+    static_assert(
+        std::is_fundamental_v<T>,
+        "T was found to be neither a DataVector nor a fundamental type. "
+        "`DynamicBuffer` is not implemented yet for complex numbers.");
+    if (number_of_grid_points != 1) {
+      ERROR(
+          "DynamicBuffer must have number_of_grid_points == 1 when T is a "
+          "fundamental type but has number_of_grid_points = "
+          << number_of_grid_points_);
+    }
+  }
+}
+
+template <typename T>
+DynamicBuffer<T>::DynamicBuffer(const DynamicBuffer<T>& other) noexcept
+    : number_of_grid_points_(other.number_of_grid_points_) {
+  if constexpr (is_data_vector_type) {
+    data_.resize(other.size());
+    buffer_ = other.buffer_;
+    set_references();
+  } else {
+    data_ = other.data_;
+  }
+}
+
+template <typename T>
+DynamicBuffer<T>& DynamicBuffer<T>::operator=(
+    const DynamicBuffer& other) noexcept {
+  if (this == &other) {
+    return *this;
+  }
+  number_of_grid_points_ = other.number_of_grid_points_;
+  if constexpr (is_data_vector_type) {
+    data_.resize(other.size());
+    buffer_ = other.buffer_;
+    set_references();
+  } else {
+    data_ = other.data_;
+  }
+  return *this;
+}
+
+template <typename T>
+void DynamicBuffer<T>::pup(PUP::er& p) noexcept {
+  p | number_of_grid_points_;
+  p | buffer_;
+  if constexpr (is_data_vector_type) {
+    if (p.isUnpacking()) {
+      data_.resize(buffer_.size() / number_of_grid_points_);
+      set_references();
+    }
+  } else {
+    p | data_;
+  }
+}
+
+template <typename T>
+void DynamicBuffer<T>::set_references() noexcept {
+  if constexpr (is_data_vector_type) {
+    for (size_t i = 0; i < size(); ++i) {
+      data_[i].set_data_ref(&buffer_[number_of_grid_points_ * i],
+                            number_of_grid_points_);
+    }
+  }
+}
+
+template <typename T>
+bool operator==(const DynamicBuffer<T>& lhs,
+                const DynamicBuffer<T>& rhs) noexcept {
+  return lhs.data_ == rhs.data_ and
+         lhs.number_of_grid_points_ == rhs.number_of_grid_points_;
+}
+
+template <typename T>
+bool operator!=(const DynamicBuffer<T>& lhs,
+                const DynamicBuffer<T>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+/// \cond HIDDEN_SYMBOLS
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define GEN_OP(op, type)                                    \
+  template bool operator op(const DynamicBuffer<type>& lhs, \
+                            const DynamicBuffer<type>& rhs) noexcept;
+#define INSTANTIATE(_, data)                 \
+  template class DynamicBuffer<DTYPE(data)>; \
+  GEN_OP(==, DTYPE(data))                    \
+  GEN_OP(!=, DTYPE(data))
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
+
+#undef DTYPE
+#undef GEN_OP
+#undef INSTANTIATE
+/// \endcond

--- a/src/DataStructures/DynamicBuffer.hpp
+++ b/src/DataStructures/DynamicBuffer.hpp
@@ -1,0 +1,92 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <type_traits>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "Utilities/TypeTraits/GetFundamentalType.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+/**
+ * \ingroup DataStructuresGroup
+ *
+ * \brief A dynamically sized vector of `DataVector`s. For convenience it can
+ * also be instantiated for fundamental types.
+ *
+ * \details This class is useful when one wants to create a `std::vector<T>`
+ * with a size that is unknown at compile time. It allocates all `DataVector`s
+ * in a single memory chunk rather than allocating each individually. If the
+ * size of the vector is known at compile time, a `TempBuffer` object should be
+ * used instead.
+ *
+ * If needed it should be fairly straightforward to generalize to
+ * `ComplexDataVector`.
+ */
+template <typename T>
+class DynamicBuffer {
+ public:
+  static constexpr bool is_data_vector_type =
+      std::is_base_of_v<VectorImpl<tt::get_fundamental_type_t<T>, T>, T>;
+
+  DynamicBuffer() = default;
+
+  /*!
+   * Constructs a `DynamicBuffer`. The `number_of_vectors` corresponds to the
+   * number of `DataVector`s which are saved inside, each of which has size
+   * `number_of_grid_points`. `number_of_grid_points` has to be 1 if T is a
+   * fundamental type.
+   */
+  DynamicBuffer(size_t number_of_vectors,
+                size_t number_of_grid_points) noexcept;
+  ~DynamicBuffer() = default;
+  DynamicBuffer(DynamicBuffer&& other) = default;
+  DynamicBuffer& operator=(DynamicBuffer&& other) = default;
+
+  DynamicBuffer(const DynamicBuffer& other) noexcept;
+
+  DynamicBuffer& operator=(const DynamicBuffer& other) noexcept;
+
+  T& operator[](size_t index) noexcept { return data_[index]; }
+  T& at(size_t index) noexcept { return data_.at(index); }
+  const T& operator[](size_t index) const noexcept { return data_[index]; }
+  const T& at(size_t index) const noexcept { return data_.at(index); }
+
+  auto begin() noexcept { return data_.begin(); }
+  auto end() noexcept { return data_.end(); }
+  auto begin() const noexcept { return data_.begin(); }
+  auto end() const noexcept { return data_.end(); }
+
+  size_t size() const noexcept { return data_.size(); }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) noexcept;
+
+ private:
+  // sets data references for all `data_` into `buffer_`
+  void set_references() noexcept;
+
+  template <typename LocalT>
+  // NOLINTNEXTLINE(readability-redundant-declaration)
+  friend bool operator==(const DynamicBuffer<LocalT>& lhs,
+                         const DynamicBuffer<LocalT>& rhs) noexcept;
+
+  size_t number_of_grid_points_;
+  // vector of non-owning DataVectors pointing into `buffer_`. In case of
+  // fundamental type T the data is saved in `data_` directly.
+  std::vector<T> data_;
+  // memory buffer for all DataVectors. Unused in case of fundamental type T.
+  std::vector<double> buffer_;
+};
+
+template <typename T>
+bool operator!=(const DynamicBuffer<T>& lhs,
+                const DynamicBuffer<T>& rhs) noexcept;

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -19,6 +19,7 @@ set(LIBRARY_SOURCES
   Test_DenseMatrixAsserts.cpp
   Test_DenseVector.cpp
   Test_DiagonalModalOperator.cpp
+  Test_DynamicBuffer.cpp
   Test_FixedHashMap.cpp
   Test_GeneralIndexIterator.cpp
   Test_IdPair.cpp

--- a/tests/Unit/DataStructures/Test_DynamicBuffer.cpp
+++ b/tests/Unit/DataStructures/Test_DynamicBuffer.cpp
@@ -1,0 +1,133 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <random>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/DynamicBuffer.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TypeTraits/IsIterable.hpp"
+
+namespace {
+
+template <typename T>
+void check_results(const DynamicBuffer<T>& dynamic_buffer,
+                   const std::vector<T>& expected) {
+  CHECK(dynamic_buffer.size() == expected.size());
+
+  for (size_t i = 0; i < dynamic_buffer.size(); ++i) {
+    CHECK(dynamic_buffer[i] == expected[i]);
+    CHECK(dynamic_buffer.at(i) == expected[i]);
+  }
+
+  size_t i = 0;
+  for (auto it = dynamic_buffer.begin(); it != dynamic_buffer.end();
+       ++it, ++i) {
+    CHECK(*it == expected[i]);
+  }
+
+  i = 0;
+  for (const auto& val : dynamic_buffer) {
+    CHECK(val == expected[i]);
+    ++i;
+  }
+}
+
+template <typename T>
+std::vector<T> create_random_data(const gsl::not_null<std::mt19937*> gen,
+                                  const size_t number_of_vectors,
+                                  const size_t number_of_grid_points) {
+  auto value_distribution = std::uniform_real_distribution(
+      std::numeric_limits<double>::min(), std::numeric_limits<double>::max());
+
+  std::vector<T> res(number_of_vectors);
+  for (size_t i = 0; i < number_of_vectors; ++i) {
+    res[i] = make_with_random_values<T>(gen, value_distribution,
+                                        number_of_grid_points);
+  }
+  return res;
+}
+
+template <typename T>
+void test_dynamic_buffer() {
+  MAKE_GENERATOR(gen);
+  auto size_distribution = std::uniform_int_distribution(1, 10);
+  auto number_of_grid_points = static_cast<size_t>(size_distribution(gen));
+  const auto number_of_vectors = static_cast<size_t>(size_distribution(gen));
+  if constexpr (std::is_same_v<double, T>) {
+    number_of_grid_points = 1;
+  }
+
+  CAPTURE(number_of_grid_points);
+  CAPTURE(number_of_vectors);
+
+  const auto expected = create_random_data<T>(
+      make_not_null(&gen), number_of_vectors, number_of_grid_points);
+
+  DynamicBuffer<T> dynamic_buffer(number_of_vectors, number_of_grid_points);
+
+  for (size_t i = 0; i < number_of_vectors; ++i) {
+    dynamic_buffer.at(i) = expected.at(i);
+  }
+
+  dynamic_buffer = serialize_and_deserialize(dynamic_buffer);
+  check_results(dynamic_buffer, expected);
+
+  test_copy_semantics(dynamic_buffer);
+  auto dynamic_buffer_for_move = dynamic_buffer;
+  test_move_semantics(std::move(dynamic_buffer_for_move), dynamic_buffer);
+
+  DynamicBuffer<T> dynamic_buffer_copied(dynamic_buffer);
+  DynamicBuffer<T> dynamic_buffer_assigned;
+  dynamic_buffer_assigned = dynamic_buffer;
+
+  if constexpr (tt::is_iterable_v<T>) {
+    auto copied_it = dynamic_buffer_copied.begin();
+    auto assigned_it = dynamic_buffer_assigned.begin();
+    // check that the new buffers don't point to the same data storage location
+    for (auto it = dynamic_buffer.begin(); it != dynamic_buffer.end();
+         ++it, ++copied_it, ++assigned_it) {
+      // first `DataVector` of dynamic_buffer
+      const auto first_data_vector = *it;
+
+      // underlying C array
+      const auto array = first_data_vector.data();
+
+      // address of first element
+      const auto address = &*array;
+
+      // analogously for copied DynamicBuffers
+      CHECK(&*((*copied_it).data()) != address);
+      CHECK(&*((*assigned_it).data()) != address);
+    }
+    CHECK(copied_it == dynamic_buffer_copied.end());
+    CHECK(assigned_it == dynamic_buffer_assigned.end());
+  }
+
+  DynamicBuffer<T> dynamic_buffer_moved = std::move(dynamic_buffer);
+
+  dynamic_buffer_copied = serialize_and_deserialize(dynamic_buffer_copied);
+  dynamic_buffer_assigned = serialize_and_deserialize(dynamic_buffer_assigned);
+  dynamic_buffer_moved = serialize_and_deserialize(dynamic_buffer_moved);
+
+  check_results(dynamic_buffer_copied, expected);
+  check_results(dynamic_buffer_assigned, expected);
+  check_results(dynamic_buffer_moved, expected);
+}
+
+}  // namespace
+SPECTRE_TEST_CASE("Unit.DataStructures.DynamicBuffer",
+                  "[DataStructures][Unit]") {
+  for (size_t i = 0; i < 20; ++i) {
+    test_dynamic_buffer<DataVector>();
+    test_dynamic_buffer<double>();
+  }
+}


### PR DESCRIPTION
## Proposed changes
Adds `DynamicBuffer`, a class that acts as a `std::vector<DataVector>` but allocates all  `DataVector`s in a single chunk. This will be needed to reduce allocations in `YlmSpherepack`.
<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
