### PR TITLE
Compute boundary terms from package data in python tests

### DIFF
--- a/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Test_Hll.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Test_Hll.cpp
@@ -88,26 +88,14 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts,
       helpers::Tags::Range<NewtonianEuler::Tags::MassDensityCons>,
       helpers::Tags::Range<
           NewtonianEuler::Tags::SpecificInternalEnergy<DataVector>>>
-      ranges_for_conservation{std::array{1.0e-30, 1.0},
-                              std::array{1.0e-30, 1.0}};
+      ranges{std::array{1.0e-30, 1.0}, std::array{1.0e-30, 1.0}};
 
   helpers::test_boundary_correction_conservation<
       NewtonianEuler::System<Dim, EosType, DummyInitialData>>(
       gen, NewtonianEuler::BoundaryCorrections::Hll<Dim>{},
       Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
                     Spectral::Quadrature::Gauss},
-      volume_data, ranges_for_conservation);
-
-  const tuples::TaggedTuple<
-      helpers::Tags::Range<NewtonianEuler::Tags::MassDensityCons>,
-      helpers::Tags::Range<
-          NewtonianEuler::Tags::SpecificInternalEnergy<DataVector>>,
-      helpers::Tags::Range<typename NewtonianEuler::BoundaryCorrections::Hll<
-          Dim>::LargestOutgoingCharSpeed>,
-      helpers::Tags::Range<typename NewtonianEuler::BoundaryCorrections::Hll<
-          Dim>::LargestIngoingCharSpeed>>
-      ranges_for_python{std::array{1.0e-30, 1.0}, std::array{1.0e-30, 1.0},
-                        std::array{0.0, 1.0}, std::array{-1.0, 0.0}};
+      volume_data, ranges);
 
   helpers::test_boundary_correction_with_python<
       NewtonianEuler::System<Dim, EosType, DummyInitialData>,
@@ -125,7 +113,7 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts,
       NewtonianEuler::BoundaryCorrections::Hll<Dim>{},
       Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
                     Spectral::Quadrature::Gauss},
-      volume_data, ranges_for_python);
+      volume_data, ranges);
 
   const auto hll = TestHelpers::test_factory_creation<
       NewtonianEuler::BoundaryCorrections::BoundaryCorrection<Dim>>("Hll:");
@@ -146,7 +134,7 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts,
       dynamic_cast<const NewtonianEuler::BoundaryCorrections::Hll<Dim>&>(*hll),
       Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
                     Spectral::Quadrature::Gauss},
-      volume_data, ranges_for_python);
+      volume_data, ranges);
 }
 }  // namespace
 


### PR DESCRIPTION
## Proposed changes

This is necessary to end up with a (reasonably) consistent state for the
input. The specific case where this came up is having an ASSERT in the HLLC
solver that the contact speed is between the left and right speed. This is
violated if all numbers are just random. While presumably appropriate bounds
could be set, it seems better to just feed in more "physical" random values.

In the future we may want/need to add a way of restricting the input into the
package data function, e.g. by generating random cons/prims, and setting fluxes,
etc. all consistent from that state.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
