### PR TITLE
Add needs_evolved_variables method to events

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp
@@ -177,6 +177,8 @@ class InterpolateWithoutInterpComponent<VolumeDim, InterpolationTargetTag,
         std::vector<std::vector<size_t>>({element_coord_holder.offsets}),
         time_id);
   }
+
+  bool needs_evolved_variables() const noexcept override { return true; }
 };
 
 /// \cond

--- a/src/NumericalAlgorithms/Interpolation/Interpolate.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Interpolate.hpp
@@ -121,6 +121,8 @@ class Interpolate<VolumeDim, InterpolationTargetTag, tmpl::list<Tensors...>,
         Actions::AddTemporalIdsToInterpolationTarget<InterpolationTargetTag>>(
         target, std::vector<TimeStepId>{time_id});
   }
+
+  bool needs_evolved_variables() const noexcept override { return true; }
 };
 
 /// \cond

--- a/src/ParallelAlgorithms/Events/ObserveErrorNorms.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveErrorNorms.hpp
@@ -203,6 +203,8 @@ class ObserveErrorNorms<ObservationValueTag, tmpl::list<Tensors...>,
             observers::ObservationKey(subfile_path_ + ".dat")};
   }
 
+  bool needs_evolved_variables() const noexcept override { return true; }
+
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) override {
     Event<EventRegistrars>::pup(p);

--- a/src/ParallelAlgorithms/Events/ObserveFields.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveFields.hpp
@@ -349,6 +349,8 @@ class ObserveFields<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
             observers::ObservationKey(subfile_path_ + ".vol")};
   }
 
+  bool needs_evolved_variables() const noexcept override { return true; }
+
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) noexcept override {
     Event<EventRegistrars>::pup(p);

--- a/src/ParallelAlgorithms/Events/ObserveTimeStep.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveTimeStep.hpp
@@ -204,6 +204,8 @@ class ObserveTimeStep : public Event<EventRegistrars> {
             observers::ObservationKey(subfile_path_ + ".dat")};
   }
 
+  bool needs_evolved_variables() const noexcept override { return false; }
+
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) override {
     Event<EventRegistrars>::pup(p);

--- a/src/ParallelAlgorithms/Events/ObserveVolumeIntegrals.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveVolumeIntegrals.hpp
@@ -180,6 +180,8 @@ class ObserveVolumeIntegrals<VolumeDim, ObservationValueTag,
             observers::ObservationKey(subfile_path_ + ".dat")};
   }
 
+  bool needs_evolved_variables() const noexcept override { return true; }
+
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) override {
     Event<EventRegistrars>::pup(p);

--- a/src/ParallelAlgorithms/EventsAndTriggers/Completion.hpp
+++ b/src/ParallelAlgorithms/EventsAndTriggers/Completion.hpp
@@ -40,6 +40,8 @@ class Completion : public Event<EventRegistrars> {
             .ckLocal();
     al_gore->set_terminate(true);
   }
+
+  bool needs_evolved_variables() const noexcept override { return false; }
 };
 
 /// \cond

--- a/src/ParallelAlgorithms/EventsAndTriggers/Event.hpp
+++ b/src/ParallelAlgorithms/EventsAndTriggers/Event.hpp
@@ -58,6 +58,12 @@ class Event : public PUP::able {
           db::apply(*event, box, cache, array_index, ComponentPointer{});
         });
   }
+
+  /// Whether the event uses anything depending on the
+  /// evolved_variables.  If this returns false, anything depending on
+  /// the evolved variables may have an incorrect value when the event
+  /// is run.
+  virtual bool needs_evolved_variables() const noexcept = 0;
 };
 
 #include "ParallelAlgorithms/EventsAndTriggers/Completion.hpp"

--- a/src/Time/Actions/ChangeSlabSize.hpp
+++ b/src/Time/Actions/ChangeSlabSize.hpp
@@ -329,6 +329,13 @@ class ChangeSlabSize : public Event<EventRegistrars> {
         component_proxy);
   }
 
+  bool needs_evolved_variables() const noexcept override {
+    // This depends on the chosen StepChoosers, but they don't have a
+    // way to report this information so we just return true to be
+    // safe.
+    return true;
+  }
+
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) noexcept override {
     Event<EventRegistrars>::pup(p);

--- a/tests/Unit/IO/Observers/Test_RegisterEvents.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterEvents.cpp
@@ -25,6 +25,7 @@
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/EventsAndTriggers.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Registration.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -58,6 +59,10 @@ class SomeEvent : public Event<EventRegistrars> {
   get_observation_type_and_key_for_registration() const noexcept {
     return {observers::TypeOfObservation::Reduction,
             observers::ObservationKey(subfile_path_ + ".dat")};
+  }
+
+  bool needs_evolved_variables() const noexcept override {
+    ERROR("Should not be called");
   }
 
   // NOLINTNEXTLINE(google-runtime-references)

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateEvent.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateEvent.cpp
@@ -217,6 +217,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.InterpolateEvent",
                              metavars::InterpolatorTargetA,
                              metavars::interpolator_source_vars> event{};
 
+  CHECK(event.needs_evolved_variables());
   event.run(box, ActionTesting::cache<elem_component>(runner, array_index),
             array_index, std::add_pointer_t<elem_component>{});
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateWithoutInterpComponent.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateWithoutInterpComponent.cpp
@@ -59,6 +59,8 @@ struct initialize_elements_and_queue_simple_actions {
         tmpl::list<InterpolateOnElementTestHelpers::Tags::TestSolution>>
         event{};
 
+    CHECK(event.needs_evolved_variables());
+
     // Run event on all elements.
     for (const auto& element_id : element_ids) {
       // 1. Get vars and mesh

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveErrorNorms.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveErrorNorms.cpp
@@ -331,6 +331,8 @@ void test_observe(const std::unique_ptr<ObserveEvent> observe,
     ++num_tensors_observed;
   });
   CHECK(results.errors.size() == num_tensors_observed);
+
+  CHECK(observe->needs_evolved_variables());
 }
 
 template <typename System, bool HasAnalyticSolutions>

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
@@ -426,6 +426,8 @@ void test_observe(
         });
   }
   CHECK(results.in_received_tensor_data.size() == num_components_observed);
+
+  CHECK(observe->needs_evolved_variables());
 }
 
 template <typename System, bool AlwaysHasAnalyticSolutions = true>

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStep.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStep.cpp
@@ -238,6 +238,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.ObserveTimeStep", "[Unit][Evolution]") {
   for (const bool print_to_terminal : {true, false}) {
     const Events::ObserveTimeStep<Metavariables> observer("time_step_subfile",
                                                           print_to_terminal);
+    CHECK(not observer.needs_evolved_variables());
     test_observe(observer, false);
     test_observe(observer, true);
     test_observe(serialize_and_deserialize(observer), false);

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
@@ -252,6 +252,8 @@ void test_observe(const std::unique_ptr<ObserveEvent> observe) noexcept {
   CHECK(results.volume == expected_volume);
   CHECK(results.volume_integrals.size() == num_tensor_components);
   CHECK(results.volume_integrals == expected_volume_integrals);
+
+  CHECK(observe->needs_evolved_variables());
 }
 }  // namespace
 

--- a/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_EventsAndTriggers.cpp
+++ b/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_EventsAndTriggers.cpp
@@ -87,7 +87,11 @@ void check_trigger(const bool expected, const std::string& trigger_string) {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.EventsAndTriggers", "[Unit][Evolution]") {
-  TestHelpers::test_factory_creation<Event<tmpl::list<>>>("Completion");
+  {
+    const auto completion =
+        TestHelpers::test_factory_creation<Event<tmpl::list<>>>("Completion");
+    CHECK(not completion->needs_evolved_variables());
+  }
 
   check_trigger(true, "Always");
   check_trigger(false, "Not: Always");


### PR DESCRIPTION
Not used with EventsAndTriggers (which always has the evolved
variables available), but will allow avoiding unnecessary dense output
when running events in that context.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
