### PR TITLE
Doxygen-ignore cpp files

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -89,8 +89,9 @@ INPUT = @SPECTRE_DOXYGEN_GROUPS@ \
 # Add tutorials directory
 INPUT += @PROJECT_SOURCE_DIR@/docs
 
-FILE_PATTERNS          = *.cpp \
-                         *.hpp \
+# We don't parse cpp files because Doxygen has trouble with some template
+# expressions and we place documentation in header files anyway.
+FILE_PATTERNS          = *.hpp \
                          *.md
 
 RECURSIVE              = YES

--- a/src/ApparentHorizons/ChangeCenterOfStrahlkorper.cpp
+++ b/src/ApparentHorizons/ChangeCenterOfStrahlkorper.cpp
@@ -141,7 +141,6 @@ void change_expansion_center_of_strahlkorper_to_physical(
   }
   ERROR("Too many iterations in change_expansion_center_of_strahlkorper");
 }
-/// \cond
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                         \
@@ -155,4 +154,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (::Frame::Inertial))
 
 #undef INSTANTIATE
 #undef FRAME
-/// \endcond

--- a/src/ApparentHorizons/Strahlkorper.cpp
+++ b/src/ApparentHorizons/Strahlkorper.cpp
@@ -12,11 +12,9 @@
 #include "ApparentHorizons/SpherepackIterator.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
-/// \cond
 namespace Frame {
 struct Inertial;
 }  // namespace Frame
-/// \endcond
 
 template <typename Frame>
 Strahlkorper<Frame>::Strahlkorper(const size_t l_max, const size_t m_max,

--- a/src/ApparentHorizons/StrahlkorperGr.cpp
+++ b/src/ApparentHorizons/StrahlkorperGr.cpp
@@ -31,7 +31,6 @@
 // IWYU pragma: no_forward_declare Strahlkorper
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 // Functions used by StrahlkorperGr::dimensionful_spin_magnitude
 namespace {
 // Find the 2D surface metric by inserting the tangents \f$\partial_\theta\f$
@@ -956,4 +955,3 @@ template std::array<double, 3> StrahlkorperGr::spin_vector<Frame::Inertial>(
     const tnsr::i<DataVector, 3, Frame::Inertial>& r_hat,
     const Scalar<DataVector>& ricci_scalar,
     const Scalar<DataVector>& spin_function, const YlmSpherepack& ylm) noexcept;
-/// \endcond

--- a/src/ApparentHorizons/Tags.cpp
+++ b/src/ApparentHorizons/Tags.cpp
@@ -13,7 +13,6 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-/// \cond
 namespace StrahlkorperTags {
 
 template <typename Frame>
@@ -272,4 +271,3 @@ template struct LaplacianRadiusCompute<Frame::Inertial>;
 template struct NormalOneFormCompute<Frame::Inertial>;
 template struct TangentsCompute<Frame::Inertial>;
 }  // namespace StrahlkorperTags
-/// \endcond

--- a/src/ApparentHorizons/YlmSpherepack.cpp
+++ b/src/ApparentHorizons/YlmSpherepack.cpp
@@ -182,7 +182,6 @@ DataVector YlmSpherepack::spec_to_phys_all_offsets(
   return result;
 }
 
-/// \cond DOXYGEN_FAILS_TO_PARSE_THIS
 void YlmSpherepack::gradient(
     const std::array<double*, 2>& df,
     const gsl::not_null<const double*> collocation_values,
@@ -194,9 +193,7 @@ void YlmSpherepack::gradient(
                            physical_offset, false);
   memory_pool_.free(f_k);
 }
-/// \endcond
 
-/// \cond DOXYGEN_FAILS_TO_PARSE_THIS
 void YlmSpherepack::gradient_all_offsets(
     const std::array<double*, 2>& df,
     const gsl::not_null<const double*> collocation_values,
@@ -208,7 +205,6 @@ void YlmSpherepack::gradient_all_offsets(
   gradient_from_coefs_impl(df, f_k.data(), spectral_stride, 0, stride, 0, true);
   memory_pool_.free(f_k);
 }
-/// \endcond
 
 void YlmSpherepack::gradient_from_coefs_impl(
     const std::array<double*, 2>& df,
@@ -306,7 +302,6 @@ YlmSpherepack::FirstDeriv YlmSpherepack::gradient_from_coefs_all_offsets(
   return result;
 }
 
-/// \cond DOXYGEN_FAILS_TO_PARSE_THIS
 void YlmSpherepack::scalar_laplacian(
     const gsl::not_null<double*> scalar_laplacian,
     const gsl::not_null<const double*> collocation_values,
@@ -318,9 +313,7 @@ void YlmSpherepack::scalar_laplacian(
                               physical_stride, physical_offset);
   memory_pool_.free(f_k);
 }
-/// \endcond
 
-/// \cond DOXYGEN_FAILS_TO_PARSE_THIS
 void YlmSpherepack::scalar_laplacian_from_coefs(
     const gsl::not_null<double*> scalar_laplacian,
     const gsl::not_null<const double*> spectral_coefs,
@@ -347,7 +340,6 @@ void YlmSpherepack::scalar_laplacian_from_coefs(
   }
   memory_pool_.free(work);
 }
-/// \endcond
 
 DataVector YlmSpherepack::scalar_laplacian(const DataVector& collocation_values,
                                            const size_t physical_stride,
@@ -672,7 +664,6 @@ YlmSpherepack::InterpolationInfo YlmSpherepack::set_up_interpolation_info(
   return interpolation_info;
 }
 
-/// \cond DOXYGEN_FAILS_TO_PARSE_THIS
 void YlmSpherepack::interpolate(
     const gsl::not_null<std::vector<double>*> result,
     const gsl::not_null<const double*> collocation_values,
@@ -687,7 +678,6 @@ void YlmSpherepack::interpolate(
   interpolate_from_coefs(result, f_k, interpolation_info);
   memory_pool_.free(f_k);
 }
-/// \endcond
 
 template <typename T>
 void YlmSpherepack::interpolate_from_coefs(

--- a/src/ApparentHorizons/YlmSpherepackHelper.cpp
+++ b/src/ApparentHorizons/YlmSpherepackHelper.cpp
@@ -37,7 +37,6 @@ void MemoryPool::free(const std::vector<double>& to_be_freed) noexcept {
   ERROR("Attempt to free temp that was never allocated.");
 }
 
-/// \cond DOXYGEN_FAILS_TO_PARSE_THIS
 void MemoryPool::free(const gsl::not_null<double*> to_be_freed) noexcept {
   for (auto& elem : memory_pool_) {
     if (elem.storage.data() == to_be_freed) {
@@ -47,6 +46,5 @@ void MemoryPool::free(const gsl::not_null<double*> to_be_freed) noexcept {
   }
   ERROR("Attempt to free temp that was never allocated.");
 }
-/// \endcond
 
 }  // namespace YlmSpherepack_detail

--- a/src/ControlSystem/Averager.cpp
+++ b/src/ControlSystem/Averager.cpp
@@ -194,6 +194,4 @@ std::array<DataVector, DerivOrder + 1> Averager<DerivOrder>::get_derivs() const
 }
 
 // explicit instantiations
-/// \cond
 template class Averager<2>;
-/// \endcond

--- a/src/ControlSystem/Controller.cpp
+++ b/src/ControlSystem/Controller.cpp
@@ -74,6 +74,4 @@ DataVector Controller<DerivOrder>::operator()(
 }
 
 // explicit instantiations
-/// \cond
 template class Controller<2>;
-/// \endcond

--- a/src/ControlSystem/FunctionOfTimeUpdater.cpp
+++ b/src/ControlSystem/FunctionOfTimeUpdater.cpp
@@ -48,6 +48,4 @@ void FunctionOfTimeUpdater<DerivOrder>::modify(
   }
 }
 
-/// \cond
 template class FunctionOfTimeUpdater<2>;
-/// \endcond

--- a/src/DataStructures/Index.cpp
+++ b/src/DataStructures/Index.cpp
@@ -9,7 +9,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
 
-/// \cond HIDDEN_SYMBOLS
 template <size_t Dim>
 void Index<Dim>::pup(PUP::er& p) noexcept {
   p | indices_;
@@ -46,4 +45,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (0, 1, 2, 3, 4))
 #undef DIM
 #undef GEN_OP
 #undef INSTANTIATE
-/// \endcond

--- a/src/DataStructures/IndexIterator.cpp
+++ b/src/DataStructures/IndexIterator.cpp
@@ -29,7 +29,6 @@ IndexIterator<Dim>& IndexIterator<Dim>::operator++() {
   return *this;
 }
 
-/// \cond
 template <>
 IndexIterator<0>& IndexIterator<0>::operator++() {
   valid_ = false;
@@ -41,4 +40,3 @@ template class IndexIterator<1>;
 template class IndexIterator<2>;
 template class IndexIterator<3>;
 template class IndexIterator<4>;
-/// \endcond

--- a/src/DataStructures/SliceIterator.cpp
+++ b/src/DataStructures/SliceIterator.cpp
@@ -103,7 +103,6 @@ volume_and_slice_indices(const Index<VolumeDim>& extents) noexcept {
   return {std::move(indices_buffer), std::move(volume_and_slice_indices)};
 }
 
-/// \cond HIDDEN_SYMBOLS
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define INSTANTIATION(r, data)                                                 \
   template SliceIterator::SliceIterator(const Index<DIM(data)>&, const size_t, \
@@ -120,4 +119,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef DIM
 #undef INSTANTIATION
-/// \endcond

--- a/src/DataStructures/StripeIterator.cpp
+++ b/src/DataStructures/StripeIterator.cpp
@@ -20,8 +20,6 @@ StripeIterator::StripeIterator(const Index<Dim>& extents,
       stride_count_(0),
       jump_((extents[stripe_dim] - 1) * stride_) {}
 
-/// \cond HIDDEN_SYMBOLS
 template StripeIterator::StripeIterator(const Index<1>&, const size_t);
 template StripeIterator::StripeIterator(const Index<2>&, const size_t);
 template StripeIterator::StripeIterator(const Index<3>&, const size_t);
-/// \endcond

--- a/src/DataStructures/Tensor/EagerMath/OrthonormalOneform.cpp
+++ b/src/DataStructures/Tensor/EagerMath/OrthonormalOneform.cpp
@@ -12,7 +12,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 template <typename DataType, size_t VolumeDim, typename Frame>
 void orthonormal_oneform(
     const gsl::not_null<tnsr::i<DataType, VolumeDim, Frame>*> orthonormal_form,
@@ -123,4 +122,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_SECOND_FORM, (double, DataVector),
 #undef DIM
 #undef FRAME
 #undef DTYPE
-/// \endcond

--- a/src/Domain/Amr/Helpers.cpp
+++ b/src/Domain/Amr/Helpers.cpp
@@ -63,7 +63,6 @@ bool has_potential_sibling(const ElementId<VolumeDim>& element_id,
              .side_of_sibling();
 }
 
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                   \
@@ -82,5 +81,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #undef DIM
 #undef INSTANTIATE
-/// \endcond
 }  // namespace amr

--- a/src/Domain/Amr/UpdateAmrDecision.cpp
+++ b/src/Domain/Amr/UpdateAmrDecision.cpp
@@ -102,7 +102,6 @@ bool update_amr_decision(
   return my_amr_decision_changed;
 }
 
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                 \
@@ -117,5 +116,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #undef DIM
 #undef INSTANTIATE
-/// \endcond
 }  // namespace amr

--- a/src/Domain/BlockLogicalCoordinates.cpp
+++ b/src/Domain/BlockLogicalCoordinates.cpp
@@ -127,7 +127,6 @@ std::vector<block_logical_coord_holder<Dim>> block_logical_coordinates(
 }
 
 // Explicit instantiations
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 
@@ -144,4 +143,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
 #undef FRAME
 #undef DIM
 #undef INSTANTIATE
-/// \endcond

--- a/src/Domain/CoordinateMaps/Affine.cpp
+++ b/src/Domain/CoordinateMaps/Affine.cpp
@@ -76,7 +76,6 @@ bool operator==(const CoordinateMaps::Affine& lhs,
 }
 
 // Explicit instantiations
-/// \cond
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                  \
@@ -94,5 +93,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
                                       std::reference_wrapper<const DataVector>))
 #undef DTYPE
 #undef INSTANTIATE
-/// \endcond
 }  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/BulgedCube.cpp
+++ b/src/Domain/CoordinateMaps/BulgedCube.cpp
@@ -292,7 +292,6 @@ bool operator!=(const BulgedCube& lhs, const BulgedCube& rhs) noexcept {
 }
 
 // Explicit instantiations
-/// \cond
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                  \
@@ -311,5 +310,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
 
 #undef DTYPE
 #undef INSTANTIATE
-/// \endcond
 }  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/CylindricalEndcap.cpp
+++ b/src/Domain/CoordinateMaps/CylindricalEndcap.cpp
@@ -292,7 +292,6 @@ bool operator!=(const CylindricalEndcap& lhs,
 }
 
 // Explicit instantiations
-/// \cond
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                   \
@@ -312,6 +311,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
 
 #undef DTYPE
 #undef INSTANTIATE
-/// \endcond
 
 }  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/CylindricalFlatEndcap.cpp
+++ b/src/Domain/CoordinateMaps/CylindricalFlatEndcap.cpp
@@ -100,7 +100,6 @@ bool operator!=(const CylindricalFlatEndcap& lhs,
 }
 
 // Explicit instantiations
-/// \cond
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                 \
@@ -120,6 +119,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
 
 #undef DTYPE
 #undef INSTANTIATE
-/// \endcond
 
 }  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/CylindricalFlatSide.cpp
+++ b/src/Domain/CoordinateMaps/CylindricalFlatSide.cpp
@@ -111,7 +111,6 @@ bool operator!=(const CylindricalFlatSide& lhs,
 }
 
 // Explicit instantiations
-/// \cond
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                 \
@@ -131,6 +130,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
 
 #undef DTYPE
 #undef INSTANTIATE
-/// \endcond
 
 }  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/CylindricalSide.cpp
+++ b/src/Domain/CoordinateMaps/CylindricalSide.cpp
@@ -141,7 +141,6 @@ bool operator!=(const CylindricalSide& lhs,
 }
 
 // Explicit instantiations
-/// \cond
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                   \
@@ -161,6 +160,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
 
 #undef DTYPE
 #undef INSTANTIATE
-/// \endcond
 
 }  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/DiscreteRotation.cpp
+++ b/src/Domain/CoordinateMaps/DiscreteRotation.cpp
@@ -88,7 +88,6 @@ template class DiscreteRotation<2>;
 template class DiscreteRotation<3>;
 
 // Explicit instantiations
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 
@@ -112,5 +111,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
 
 #undef DTYPE
 #undef INSTANTIATE
-/// \endcond
 }  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/EquatorialCompression.cpp
+++ b/src/Domain/CoordinateMaps/EquatorialCompression.cpp
@@ -163,7 +163,6 @@ bool operator!=(const EquatorialCompression& lhs,
 }
 
 // Explicit instantiations
-/// \cond
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                 \
@@ -182,5 +181,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
                                       std::reference_wrapper<const DataVector>))
 #undef DTYPE
 #undef INSTANTIATE
-/// \endcond
 }  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/Equiangular.cpp
+++ b/src/Domain/CoordinateMaps/Equiangular.cpp
@@ -104,7 +104,6 @@ bool operator==(const CoordinateMaps::Equiangular& lhs,
 }
 
 // Explicit instantiations
-/// \cond
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                  \
@@ -123,5 +122,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
 
 #undef DTYPE
 #undef INSTANTIATE
-/// \endcond
 }  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/FocallyLiftedEndcap.cpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedEndcap.cpp
@@ -360,7 +360,6 @@ bool operator!=(const Endcap& lhs, const Endcap& rhs) noexcept {
   return not(lhs == rhs);
 }
 // Explicit instantiations
-/// \cond
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                  \
@@ -406,6 +405,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
 
 #undef INSTANTIATE
 #undef DTYPE
-/// \endcond
 
 }  // namespace domain::CoordinateMaps::FocallyLiftedInnerMaps

--- a/src/Domain/CoordinateMaps/FocallyLiftedFlatEndcap.cpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedFlatEndcap.cpp
@@ -196,7 +196,6 @@ bool operator!=(const FlatEndcap& lhs, const FlatEndcap& rhs) noexcept {
   return not(lhs == rhs);
 }
 // Explicit instantiations
-/// \cond
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                  \
@@ -242,5 +241,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
 
 #undef INSTANTIATE
 #undef DTYPE
-/// \endcond
 }  // namespace domain::CoordinateMaps::FocallyLiftedInnerMaps

--- a/src/Domain/CoordinateMaps/FocallyLiftedFlatSide.cpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedFlatSide.cpp
@@ -255,7 +255,6 @@ bool operator!=(const FlatSide& lhs, const FlatSide& rhs) noexcept {
   return not(lhs == rhs);
 }
 // Explicit instantiations
-/// \cond
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                  \
@@ -301,5 +300,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
 
 #undef INSTANTIATE
 #undef DTYPE
-/// \endcond
 }  // namespace domain::CoordinateMaps::FocallyLiftedInnerMaps

--- a/src/Domain/CoordinateMaps/FocallyLiftedMap.cpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedMap.cpp
@@ -359,7 +359,6 @@ bool operator==(const FocallyLiftedMap<InnerMap>& lhs,
 }
 
 // Explicit instantiations
-/// \cond
 #define IMAP(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                  \
@@ -401,6 +400,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATE,
 #undef INSTANTIATE
 #undef DTYPE
 #undef IMAP
-/// \endcond
 
 }  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/FocallyLiftedMapHelpers.cpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedMapHelpers.cpp
@@ -231,7 +231,6 @@ void d_scale_factor_d_src_point(
 }
 
 // Explicit instantiations
-/// \cond
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                              \
@@ -254,6 +253,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
                                       std::reference_wrapper<const DataVector>))
 #undef INSTANTIATE
 #undef DTYPE
-/// \endcond
 
 }  // namespace domain::CoordinateMaps::FocallyLiftedMapHelpers

--- a/src/Domain/CoordinateMaps/FocallyLiftedSide.cpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedSide.cpp
@@ -262,7 +262,6 @@ bool operator!=(const Side& lhs, const Side& rhs) noexcept {
   return not(lhs == rhs);
 }
 // Explicit instantiations
-/// \cond
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                  \
@@ -308,6 +307,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
 
 #undef INSTANTIATE
 #undef DTYPE
-/// \endcond
 
 }  // namespace domain::CoordinateMaps::FocallyLiftedInnerMaps

--- a/src/Domain/CoordinateMaps/Frustum.cpp
+++ b/src/Domain/CoordinateMaps/Frustum.cpp
@@ -288,7 +288,6 @@ bool operator!=(const Frustum& lhs, const Frustum& rhs) noexcept {
 }
 
 // Explicit instantiations
-/// \cond
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                  \
@@ -306,5 +305,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
                                       std::reference_wrapper<const DataVector>))
 #undef DTYPE
 #undef INSTANTIATE
-/// \endcond
 }  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/Identity.cpp
+++ b/src/Domain/CoordinateMaps/Identity.cpp
@@ -44,7 +44,6 @@ template class Identity<2>;
 template class Identity<3>;
 
 // Explicit instantiations
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 
@@ -69,6 +68,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
 #undef DIM
 #undef DTYPE
 #undef INSTANTIATE
-/// \endcond
 
 }  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/Rotation.cpp
+++ b/src/Domain/CoordinateMaps/Rotation.cpp
@@ -198,7 +198,6 @@ bool operator!=(const Rotation<3>& lhs, const Rotation<3>& rhs) noexcept {
   return not(lhs == rhs);
 }
 // Explicit instantiations
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 
@@ -222,6 +221,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3),
 #undef DIM
 #undef DTYPE
 #undef INSTANTIATE
-/// \endcond
 
 }  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/SpecialMobius.cpp
+++ b/src/Domain/CoordinateMaps/SpecialMobius.cpp
@@ -119,7 +119,6 @@ bool operator!=(const SpecialMobius& lhs, const SpecialMobius& rhs) noexcept {
 }
 
 // Explicit instantiations
-/// \cond
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                   \
@@ -138,5 +137,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
 
 #undef DTYPE
 #undef INSTANTIATE
-/// \endcond
 }  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/TimeDependent/CubicScale.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/CubicScale.cpp
@@ -406,7 +406,6 @@ bool operator==(const CubicScale<Dim>& lhs,
 }
 
 // Explicit instantiations
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                 \
@@ -463,5 +462,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
 #undef DIM
 #undef DTYPE
 #undef INSTANTIATE
-/// \endcond
 }  // namespace domain::CoordinateMaps::TimeDependent

--- a/src/Domain/CoordinateMaps/TimeDependent/Rotation.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Rotation.cpp
@@ -169,7 +169,6 @@ bool operator!=(const Rotation<2>& lhs, const Rotation<2>& rhs) noexcept {
   return not(lhs == rhs);
 }
 
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 
@@ -213,6 +212,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (2),
 #undef DIM
 #undef DTYPE
 #undef INSTANTIATE
-/// \endcond
 
 }  // namespace domain::CoordinateMaps::TimeDependent

--- a/src/Domain/CoordinateMaps/TimeDependent/SphericalCompression.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/SphericalCompression.cpp
@@ -292,7 +292,6 @@ void SphericalCompression<InteriorMap>::pup(PUP::er& p) noexcept {
   p | center_;
 }
 
-/// \cond
 #define INTERIOR_MAP(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 
@@ -351,6 +350,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (true, false))
 #undef INTERIOR_MAP
 #undef INSTANTIATE
 
-/// \endcond
 
 }  // namespace domain::CoordinateMaps::TimeDependent

--- a/src/Domain/CoordinateMaps/TimeDependent/Translation.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Translation.cpp
@@ -87,7 +87,6 @@ bool operator==(const Translation& lhs, const Translation& rhs) noexcept {
 }
 
 // Explicit instantiations
-/// \cond
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                 \
@@ -117,5 +116,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
                                       std::reference_wrapper<const DataVector>))
 #undef DTYPE
 #undef INSTANTIATE
-/// \endcond
 }  // namespace domain::CoordinateMaps::TimeDependent

--- a/src/Domain/CoordinateMaps/Wedge.cpp
+++ b/src/Domain/CoordinateMaps/Wedge.cpp
@@ -443,7 +443,6 @@ bool operator!=(const Wedge<Dim>& lhs, const Wedge<Dim>& rhs) noexcept {
 }
 
 // Explicit instantiations
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 
@@ -477,5 +476,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_DTYPE, (2, 3),
 #undef DTYPE
 #undef INSTANTIATE_DIM
 #undef INSTANTIATE_DTYPE
-/// \endcond
 }  // namespace domain::CoordinateMaps

--- a/src/Domain/CreateInitialElement.cpp
+++ b/src/Domain/CreateInitialElement.cpp
@@ -179,7 +179,6 @@ Element<VolumeDim> create_initial_element(
 }
 }  // namespace domain::Initialization
 
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                 \
@@ -192,4 +191,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #undef DIM
 #undef INSTANTIATE
-/// \endcond

--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -30,11 +30,9 @@
 #include "Domain/Structure/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Utilities/MakeArray.hpp"
 
-/// \cond
 namespace Frame {
 struct Logical;
 }  // namespace Frame
-/// \endcond
 
 namespace domain::creators {
 

--- a/src/Domain/Creators/Brick.cpp
+++ b/src/Domain/Creators/Brick.cpp
@@ -22,12 +22,10 @@
 #include "Domain/DomainHelpers.hpp"
 #include "Domain/Structure/BlockNeighbor.hpp"  // IWYU pragma: keep
 
-/// \cond
 namespace Frame {
 struct Logical;
 struct Inertial;
 }  // namespace Frame
-/// \endcond
 
 namespace domain::creators {
 Brick::Brick(

--- a/src/Domain/Creators/Disk.cpp
+++ b/src/Domain/Creators/Disk.cpp
@@ -22,12 +22,10 @@
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Utilities/MakeArray.hpp"
 
-/// \cond
 namespace Frame {
 struct Inertial;
 struct Logical;
 }  // namespace Frame
-/// \endcond
 
 namespace domain::creators {
 Disk::Disk(typename InnerRadius::type inner_radius,

--- a/src/Domain/Creators/ExpandOverBlocks.cpp
+++ b/src/Domain/Creators/ExpandOverBlocks.cpp
@@ -95,7 +95,6 @@ std::vector<std::array<T, Dim>> ExpandOverBlocks<T, Dim>::operator()(
   return result;
 }
 
-/// \cond
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define INSTANTIATE(_, data) \
@@ -106,6 +105,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (size_t), (1, 2, 3))
 #undef DIM
 #undef DTYPE
 #undef INSTANTIATE
-/// \endcond
 
 }  // namespace domain

--- a/src/Domain/Creators/FrustalCloak.cpp
+++ b/src/Domain/Creators/FrustalCloak.cpp
@@ -17,7 +17,6 @@
 #include "Domain/Structure/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Utilities/MakeArray.hpp"
 
-/// \cond
 namespace Frame {
 struct Inertial;
 struct Logical;
@@ -26,7 +25,6 @@ namespace domain {
 template <typename, typename, size_t>
 class CoordinateMapBase;
 }  // namespace domain
-/// \endcond
 
 namespace domain::creators {
 FrustalCloak::FrustalCloak(

--- a/src/Domain/Creators/Interval.cpp
+++ b/src/Domain/Creators/Interval.cpp
@@ -20,12 +20,10 @@
 #include "Domain/DomainHelpers.hpp"
 #include "Domain/Structure/BlockNeighbor.hpp"  // IWYU pragma: keep
 
-/// \cond
 namespace Frame {
 struct Inertial;
 struct Logical;
 }  // namespace Frame
-/// \endcond
 
 namespace domain::creators {
 Interval::Interval(

--- a/src/Domain/Creators/Rectangle.cpp
+++ b/src/Domain/Creators/Rectangle.cpp
@@ -23,12 +23,10 @@
 #include "Domain/Structure/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Utilities/ErrorHandling/Assert.hpp"
 
-/// \cond
 namespace Frame {
 struct Inertial;
 struct Logical;
 }  // namespace Frame
-/// \endcond
 
 namespace domain::creators {
 Rectangle::Rectangle(

--- a/src/Domain/Creators/Shell.cpp
+++ b/src/Domain/Creators/Shell.cpp
@@ -16,12 +16,10 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
 
-/// \cond
 namespace Frame {
 struct Inertial;
 struct Logical;
 }  // namespace Frame
-/// \endcond
 
 namespace domain::creators {
 Shell::Shell(typename InnerRadius::type inner_radius,

--- a/src/Domain/Creators/Sphere.cpp
+++ b/src/Domain/Creators/Sphere.cpp
@@ -22,12 +22,10 @@
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/MakeArray.hpp"
 
-/// \cond
 namespace Frame {
 struct Inertial;  // IWYU pragma: keep
 struct Logical;   // IWYU pragma: keep
 }  // namespace Frame
-/// \endcond
 
 namespace domain::creators {
 Sphere::Sphere(typename InnerRadius::type inner_radius,

--- a/src/Domain/Creators/TimeDependence/CompositionCubicScaleAndUniformRotationAboutZAxis.cpp
+++ b/src/Domain/Creators/TimeDependence/CompositionCubicScaleAndUniformRotationAboutZAxis.cpp
@@ -12,7 +12,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 
 namespace domain::creators::time_dependence {
-/// \cond
 
 #define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
@@ -28,5 +27,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (2, 3))
 #undef GET_DIM
 #undef INSTANTIATION
 
-/// \endcond
 }  // namespace domain::creators::time_dependence

--- a/src/Domain/Creators/TimeDependence/None.cpp
+++ b/src/Domain/Creators/TimeDependence/None.cpp
@@ -50,7 +50,6 @@ bool operator!=(const None<Dim>& lhs, const None<Dim>& rhs) noexcept {
   return not(lhs == rhs);
 }
 
-/// \cond
 
 #define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
@@ -65,5 +64,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef GET_DIM
 #undef INSTANTIATION
-/// \endcond
 }  // namespace domain::creators::time_dependence

--- a/src/Domain/Creators/TimeDependence/UniformRotationAboutZAxis.cpp
+++ b/src/Domain/Creators/TimeDependence/UniformRotationAboutZAxis.cpp
@@ -82,7 +82,6 @@ UniformRotationAboutZAxis<MeshDim>::functions_of_time() const noexcept {
   return result;
 }
 
-/// \cond
 template <>
 auto UniformRotationAboutZAxis<2>::map_for_composition() const noexcept
     -> MapForComposition {
@@ -132,7 +131,6 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (2, 3))
 
 #undef GET_DIM
 #undef INSTANTIATION
-/// \endcond
 }  // namespace creators::time_dependence
 
 using Identity = CoordinateMaps::Identity<1>;

--- a/src/Domain/Creators/TimeDependence/UniformTranslation.cpp
+++ b/src/Domain/Creators/TimeDependence/UniformTranslation.cpp
@@ -104,7 +104,6 @@ UniformTranslation<MeshDim>::functions_of_time() const noexcept {
   return result;
 }
 
-/// \cond
 template <>
 auto UniformTranslation<1>::map_for_composition() const noexcept
     -> MapForComposition {
@@ -182,7 +181,6 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef GET_DIM
 #undef INSTANTIATION
-/// \endcond
 }  // namespace creators::time_dependence
 
 using Translation = CoordinateMaps::TimeDependent::Translation;

--- a/src/Domain/Domain.cpp
+++ b/src/Domain/Domain.cpp
@@ -133,7 +133,6 @@ void Domain<VolumeDim>::pup(PUP::er& p) noexcept {
   p | blocks_;
 }
 
-/// \cond HIDDEN_SYMBOLS
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define INSTANTIATE(_, data)                                       \
@@ -150,7 +149,6 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 #undef DIM
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond
 
 // Some compilers (clang 3.9.1) don't instantiate the default argument
 // to the second Domain constructor.

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -1374,7 +1374,6 @@ cyl_wedge_coordinate_maps(
     const std::vector<double>& radial_partitioning,
     const std::vector<double>& height_partitioning) noexcept;
 // Explicit instantiations
-/// \cond
 using Affine2d =
     domain::CoordinateMaps::ProductOf2Maps<domain::CoordinateMaps::Affine,
                                            domain::CoordinateMaps::Affine>;
@@ -1471,4 +1470,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1_st, 2_st, 3_st))
 #undef DIM
 #undef DTYPE
 #undef INSTANTIATE
-/// \endcond

--- a/src/Domain/ElementLogicalCoordinates.cpp
+++ b/src/Domain/ElementLogicalCoordinates.cpp
@@ -103,7 +103,6 @@ element_logical_coordinates(const std::vector<ElementId<Dim>>& element_ids,
   return result;
 }
 
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                        \
@@ -118,4 +117,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #undef DIM
 #undef INSTANTIATE
-/// \endcond

--- a/src/Domain/ElementMap.cpp
+++ b/src/Domain/ElementMap.cpp
@@ -8,7 +8,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/OptimizerHacks.hpp"
 
-/// \cond
 template <size_t Dim, typename TargetFrame>
 ElementMap<Dim, TargetFrame>::ElementMap(
     ElementId<Dim> element_id,
@@ -80,4 +79,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3),
 #undef GET_DIM
 #undef GET_FRAME
 #undef INSTANTIATION
-/// \endcond

--- a/src/Domain/FunctionsOfTime/PiecewisePolynomial.cpp
+++ b/src/Domain/FunctionsOfTime/PiecewisePolynomial.cpp
@@ -215,7 +215,6 @@ bool operator!=(const PiecewisePolynomial<MaxDeriv>& lhs,
 
 // do explicit instantiation of MaxDeriv = {2,3,4}
 // along with all combinations of MaxDerivReturned = {0,...,MaxDeriv}
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DIMRETURNED(data) BOOST_PP_TUPLE_ELEM(1, data)
 
@@ -244,5 +243,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (4), (0, 1, 2, 3, 4))
 #undef DIM
 #undef DIMRETURNED
 #undef INSTANTIATE
-/// \endcond
 }  // namespace domain::FunctionsOfTime

--- a/src/Domain/FunctionsOfTime/SettleToConstant.cpp
+++ b/src/Domain/FunctionsOfTime/SettleToConstant.cpp
@@ -78,7 +78,6 @@ bool operator!=(const SettleToConstant& lhs,
   return not(lhs == rhs);
 }
 
-/// \cond
 PUP::able::PUP_ID SettleToConstant::my_PUP_ID = 0;  // NOLINT
 
 #define DERIV(data) BOOST_PP_TUPLE_ELEM(0, data)
@@ -91,6 +90,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (0, 1, 2))
 
 #undef DERIV
 #undef INSTANTIATE
-/// \endcond
 }  // namespace FunctionsOfTime
 }  // namespace domain

--- a/src/Domain/FunctionsOfTime/SettleToConstant.cpp
+++ b/src/Domain/FunctionsOfTime/SettleToConstant.cpp
@@ -10,8 +10,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
 
-namespace domain {
-namespace FunctionsOfTime {
+namespace domain::FunctionsOfTime {
 SettleToConstant::SettleToConstant(
     const std::array<DataVector, 3>& initial_func_and_derivs,
     const double match_time, const double decay_time) noexcept
@@ -90,5 +89,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (0, 1, 2))
 
 #undef DERIV
 #undef INSTANTIATE
-}  // namespace FunctionsOfTime
-}  // namespace domain
+}  // namespace domain::FunctionsOfTime

--- a/src/Domain/LogicalCoordinates.cpp
+++ b/src/Domain/LogicalCoordinates.cpp
@@ -1,9 +1,6 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-/// \file
-/// Defines functions logical_coordinates and interface_logical_coordinates
-
 #include "Domain/LogicalCoordinates.hpp"
 
 #include <array>

--- a/src/Domain/Structure/CreateInitialMesh.cpp
+++ b/src/Domain/Structure/CreateInitialMesh.cpp
@@ -30,7 +30,6 @@ Mesh<Dim> create_initial_mesh(
 }
 }  // namespace domain::Initialization
 
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                              \
@@ -44,4 +43,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #undef DIM
 #undef INSTANTIATE
-/// \endcond

--- a/src/Domain/Structure/Direction.cpp
+++ b/src/Domain/Structure/Direction.cpp
@@ -10,7 +10,6 @@
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
-/// \cond
 template <size_t VolumeDim>
 void Direction<VolumeDim>::pup(PUP::er& p) noexcept {
   p | axis_;
@@ -76,4 +75,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef GET_DIM
 #undef INSTANTIATION
-/// \endcond

--- a/src/Domain/Structure/Direction.hpp
+++ b/src/Domain/Structure/Direction.hpp
@@ -84,6 +84,7 @@ std::ostream& operator<<(std::ostream& os,
 // INLINE DEFINITIONS
 //##############################################################################
 
+/// \cond
 // clang-tidy: redundant declaration false positive. Needs to be here because of
 // the Axis enum, otherwise won't compile.
 template <size_t VolumeDim>
@@ -143,7 +144,6 @@ inline Direction<VolumeDim> Direction<VolumeDim>::opposite() const noexcept {
   return Direction<VolumeDim>(axis_, ::opposite(side_));
 }
 
-/// \cond NEVER
 template <>
 inline const std::array<Direction<1>, 2>&
 Direction<1>::all_directions() noexcept {

--- a/src/Domain/Structure/Hypercube.cpp
+++ b/src/Domain/Structure/Hypercube.cpp
@@ -213,7 +213,6 @@ bool operator!=(
   return not(lhs == rhs);
 }
 
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define INSTANTIATE(ELEMENT_DIM, HYPERCUBE_DIM)                              \
   template struct HypercubeElement<ELEMENT_DIM, HYPERCUBE_DIM>;              \
@@ -253,4 +252,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_CELL, (3))
 #undef INSTANTIATE_EDGE
 #undef INSTANTIATE_FACE
 #undef INSTANTIATE_CELL
-/// \endcond

--- a/src/Elliptic/BoundaryConditions/BoundaryConditionType.cpp
+++ b/src/Elliptic/BoundaryConditions/BoundaryConditionType.cpp
@@ -10,7 +10,6 @@
 #include "Options/ParseOptions.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 
-/// \cond
 namespace elliptic {
 std::ostream& operator<<(
     std::ostream& os,
@@ -42,4 +41,3 @@ Options::create_from_yaml<elliptic::BoundaryConditionType>::create<void>(
                   << "\" to elliptic::BoundaryConditionType. Must be "
                      "either 'Dirichlet' or 'Neumann'.");
 }
-/// \endcond

--- a/src/Elliptic/Systems/Elasticity/Equations.cpp
+++ b/src/Elliptic/Systems/Elasticity/Equations.cpp
@@ -95,7 +95,6 @@ void add_curved_auxiliary_sources(
   }
 }
 
-/// \cond
 template <size_t Dim>
 void Fluxes<Dim>::apply(
     const gsl::not_null<tnsr::IJ<DataVector, Dim>*> flux_for_displacement,
@@ -128,7 +127,6 @@ template <size_t Dim>
 void Sources<Dim>::apply(
     const gsl::not_null<tnsr::ii<DataVector, Dim>*> /*equation_for_strain*/,
     const tnsr::I<DataVector, Dim>& /*displacement*/) noexcept {}
-/// \endcond
 
 }  // namespace Elasticity
 

--- a/src/Elliptic/Systems/Poisson/Equations.cpp
+++ b/src/Elliptic/Systems/Poisson/Equations.cpp
@@ -51,7 +51,6 @@ void auxiliary_fluxes(
   }
 }
 
-/// \cond
 template <size_t Dim>
 void Fluxes<Dim, Geometry::FlatCartesian>::apply(
     const gsl::not_null<tnsr::I<DataVector, Dim>*> flux_for_field,
@@ -109,7 +108,6 @@ void Sources<Dim, Geometry::Curved>::apply(
         tnsr::i<DataVector, Dim>*> /*equation_for_field_gradient*/,
     const tnsr::i<DataVector, Dim>& /*christoffel_contracted*/,
     const Scalar<DataVector>& /*field*/) noexcept {}
-/// \endcond
 
 }  // namespace Poisson
 

--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/Flatness.cpp
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/Flatness.cpp
@@ -10,7 +10,6 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace Xcts::BoundaryConditions::detail {
 
 void FlatnessImpl::apply(
@@ -92,4 +91,3 @@ bool operator!=(const FlatnessImpl& lhs, const FlatnessImpl& rhs) noexcept {
 }
 
 }  // namespace Xcts::BoundaryConditions::detail
-/// \endcond

--- a/src/Evolution/DgSubcell/Matrices.cpp
+++ b/src/Evolution/DgSubcell/Matrices.cpp
@@ -21,7 +21,6 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Numeric.hpp"  // IWYU pragma: keep
 
-/// \cond
 namespace evolution::dg::subcell::fd {
 template <Spectral::Quadrature QuadratureType, size_t NumDgGridPoints1d,
           size_t Dim>
@@ -361,4 +360,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef GET_DIM
 #undef INSTANTIATION
 }  // namespace evolution::dg::subcell::fd
-/// \endcond

--- a/src/Evolution/DgSubcell/Projection.cpp
+++ b/src/Evolution/DgSubcell/Projection.cpp
@@ -14,7 +14,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace evolution::dg::subcell::fd {
 namespace detail {
 template <size_t Dim>
@@ -67,4 +66,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef INSTANTIATION
 #undef DIM
 }  // namespace evolution::dg::subcell::fd
-/// \endcond

--- a/src/Evolution/DgSubcell/Reconstruction.cpp
+++ b/src/Evolution/DgSubcell/Reconstruction.cpp
@@ -14,7 +14,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace evolution::dg::subcell::fd {
 namespace detail {
 template <size_t Dim>
@@ -73,4 +72,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef INSTANTIATION
 #undef DIM
 }  // namespace evolution::dg::subcell::fd
-/// \endcond

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/Dirichlet.cpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/Dirichlet.cpp
@@ -13,7 +13,6 @@
 #include "Evolution/Systems/Burgers/Fluxes.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace Burgers::BoundaryConditions {
 Dirichlet::Dirichlet(const double u_value) noexcept : u_value_(u_value) {}
 
@@ -45,4 +44,3 @@ std::optional<std::string> Dirichlet::dg_ghost(
 // NOLINTNEXTLINE
 PUP::able::PUP_ID Dirichlet::my_PUP_ID = 0;
 }  // namespace Burgers::BoundaryConditions
-/// \endcond

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/DirichletAnalytic.cpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/DirichletAnalytic.cpp
@@ -11,7 +11,6 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/Systems/Burgers/Fluxes.hpp"
 
-/// \cond
 namespace Burgers::BoundaryConditions {
 DirichletAnalytic::DirichletAnalytic(CkMigrateMessage* const msg) noexcept
     : BoundaryCondition(msg) {}
@@ -31,5 +30,4 @@ void DirichletAnalytic::flux_impl(
 
 // NOLINTNEXTLINE
 PUP::able::PUP_ID DirichletAnalytic::my_PUP_ID = 0;
-/// \endcond
 }  // namespace Burgers::BoundaryConditions

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/Outflow.cpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/Outflow.cpp
@@ -45,8 +45,6 @@ std::optional<std::string> Outflow::dg_outflow(
   return std::nullopt;
 }
 
-/// \cond
 // NOLINTNEXTLINE
 PUP::able::PUP_ID Outflow::my_PUP_ID = 0;
-/// \endcond
 }  // namespace Burgers::BoundaryConditions

--- a/src/Evolution/Systems/Burgers/BoundaryCorrections/Hll.cpp
+++ b/src/Evolution/Systems/Burgers/BoundaryCorrections/Hll.cpp
@@ -15,7 +15,6 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace Burgers::BoundaryCorrections {
 Hll::Hll(CkMigrateMessage* msg) noexcept : BoundaryCorrection(msg) {}
 
@@ -76,4 +75,3 @@ void Hll::dg_boundary_terms(
 
 // NOLINTNEXTLINE
 PUP::able::PUP_ID Burgers::BoundaryCorrections::Hll::my_PUP_ID = 0;
-/// \endcond

--- a/src/Evolution/Systems/Burgers/BoundaryCorrections/Rusanov.cpp
+++ b/src/Evolution/Systems/Burgers/BoundaryCorrections/Rusanov.cpp
@@ -13,7 +13,6 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace Burgers::BoundaryCorrections {
 Rusanov::Rusanov(CkMigrateMessage* msg) noexcept : BoundaryCorrection(msg) {}
 
@@ -70,4 +69,3 @@ void Rusanov::dg_boundary_terms(
 
 // NOLINTNEXTLINE
 PUP::able::PUP_ID Burgers::BoundaryCorrections::Rusanov::my_PUP_ID = 0;
-/// \endcond

--- a/src/Evolution/Systems/Burgers/Characteristics.cpp
+++ b/src/Evolution/Systems/Burgers/Characteristics.cpp
@@ -12,7 +12,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace Burgers::Tags {
 void CharacteristicSpeedsCompute::function(
     const gsl::not_null<return_type*> result,
@@ -31,4 +30,3 @@ void ComputeLargestCharacteristicSpeed::function(
   *speed = max(abs(get(u)));
 }
 }  // namespace Burgers::Tags
-/// \endcond

--- a/src/Evolution/Systems/Burgers/Fluxes.cpp
+++ b/src/Evolution/Systems/Burgers/Fluxes.cpp
@@ -13,11 +13,9 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace Burgers {
 void Fluxes::apply(const gsl::not_null<tnsr::I<DataVector, 1>*> flux,
                    const Scalar<DataVector>& u) noexcept {
   get<0>(*flux) = 0.5 * square(get(u));
 }
 }  // namespace Burgers
-/// \endcond

--- a/src/Evolution/Systems/Burgers/TimeDerivativeTerms.cpp
+++ b/src/Evolution/Systems/Burgers/TimeDerivativeTerms.cpp
@@ -7,7 +7,6 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace Burgers {
 void TimeDerivativeTerms::apply(
     const gsl::not_null<Scalar<DataVector>*> /*non_flux_terms_dt_vars*/,
@@ -16,4 +15,3 @@ void TimeDerivativeTerms::apply(
   get<0>(*flux_u) = 0.5 * square(get(u));
 }
 }  // namespace Burgers
-/// \endcond

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/BouncingBlackHole.cpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/BouncingBlackHole.cpp
@@ -18,9 +18,7 @@
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
-namespace Cce {
-namespace Solutions {
-
+namespace Cce::Solutions {
 
 BouncingBlackHole::BouncingBlackHole(const double amplitude,
                                      const double extraction_radius,
@@ -315,5 +313,4 @@ void BouncingBlackHole::pup(PUP::er& p) noexcept {
 }
 
 PUP::able::PUP_ID BouncingBlackHole::my_PUP_ID = 0;
-}  // namespace Solutions
-}  // namespace Cce
+}  // namespace Cce::Solutions

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/BouncingBlackHole.cpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/BouncingBlackHole.cpp
@@ -21,7 +21,6 @@
 namespace Cce {
 namespace Solutions {
 
-/// \cond
 
 BouncingBlackHole::BouncingBlackHole(const double amplitude,
                                      const double extraction_radius,
@@ -316,6 +315,5 @@ void BouncingBlackHole::pup(PUP::er& p) noexcept {
 }
 
 PUP::able::PUP_ID BouncingBlackHole::my_PUP_ID = 0;
-/// \endcond
 }  // namespace Solutions
 }  // namespace Cce

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/GaugeWave.cpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/GaugeWave.cpp
@@ -24,7 +24,6 @@
 
 namespace Cce::Solutions {
 
-/// \cond
 GaugeWave::GaugeWave(const double extraction_radius, const double mass,
                      const double frequency, const double amplitude,
                      const double peak_time, const double duration) noexcept
@@ -210,5 +209,4 @@ void GaugeWave::pup(PUP::er& p) noexcept {
 }
 
 PUP::able::PUP_ID GaugeWave::my_PUP_ID = 0;
-/// \endcond
 }  // namespace Cce::Solutions

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.cpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.cpp
@@ -23,7 +23,6 @@
 #include "Utilities/TMPL.hpp"
 
 namespace Cce::Solutions {
-/// \cond
 namespace LinearizedBondiSachs_detail {
 namespace InitializeJ {
 LinearizedBondiSachs::LinearizedBondiSachs(
@@ -617,5 +616,4 @@ void LinearizedBondiSachs::pup(PUP::er& p) noexcept {
 }
 
 PUP::able::PUP_ID LinearizedBondiSachs::my_PUP_ID = 0;
-/// \endcond
 }  // namespace Cce::Solutions

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/RotatingSchwarzschild.cpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/RotatingSchwarzschild.cpp
@@ -20,7 +20,6 @@
 
 namespace Cce::Solutions {
 
-/// \cond
 RotatingSchwarzschild::RotatingSchwarzschild(const double extraction_radius,
                                              const double mass,
                                              const double frequency) noexcept
@@ -120,5 +119,4 @@ void RotatingSchwarzschild::pup(PUP::er& p) noexcept {
 }
 
 PUP::able::PUP_ID RotatingSchwarzschild::my_PUP_ID = 0;
-/// \endcond
 }  // namespace Cce::Solutions

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/SphericalMetricData.cpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/SphericalMetricData.cpp
@@ -26,7 +26,6 @@
 
 namespace Cce::Solutions {
 
-/// \cond
 
 void SphericalMetricData::variables_impl(
     const gsl::not_null<tnsr::aa<DataVector, 3>*> spacetime_metric,
@@ -389,5 +388,4 @@ void SphericalMetricData::dr_jacobian(
 
 void SphericalMetricData::pup(PUP::er& p) noexcept { WorldtubeData::pup(p); }
 
-/// \endcond
 }  // namespace Cce::Solutions

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/TeukolskyWave.cpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/TeukolskyWave.cpp
@@ -24,7 +24,6 @@
 
 namespace Cce::Solutions {
 
-/// \cond
 TeukolskyWave::TeukolskyWave(const double extraction_radius,
                              const double amplitude,
                              const double duration) noexcept
@@ -321,5 +320,4 @@ void TeukolskyWave::pup(PUP::er& p) noexcept {
 }
 
 PUP::able::PUP_ID TeukolskyWave::my_PUP_ID = 0;
-/// \endcond
 }  // namespace Cce::Solutions

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.cpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.cpp
@@ -28,7 +28,6 @@
 
 namespace Cce::Solutions {
 
-/// \cond
 void WorldtubeData::variables_impl(
     const gsl::not_null<tnsr::i<DataVector, 3>*> cartesian_coordinates,
     const size_t output_l_max, double /*time*/,
@@ -279,5 +278,4 @@ void WorldtubeData::pup(PUP::er& p) noexcept {
   }
 }
 
-/// \endcond
 }  // namespace Cce::Solutions

--- a/src/Evolution/Systems/Cce/Equations.cpp
+++ b/src/Evolution/Systems/Cce/Equations.cpp
@@ -25,7 +25,6 @@
 
 namespace Cce {
 // suppresses doxygen problems with these functions
-/// \cond
 
 void ComputeBondiIntegrand<Tags::Integrand<Tags::BondiBeta>>::apply_impl(
     const gsl::not_null<SpinWeighted<ComplexDataVector, 0>*> integrand_for_beta,
@@ -270,5 +269,4 @@ void ComputeBondiIntegrand<Tags::LinearFactorForConjugate<Tags::BondiH>>::
                    j * (conj(j) * dy_j + j * conj(dy_j)) / (1.0 + j * conj(j)));
   *linear_factor_for_conjugate_h = j * (*script_djbar);
 }
-/// \endcond
 }  // namespace Cce

--- a/src/Evolution/Systems/Cce/GaugeTransformBoundaryData.cpp
+++ b/src/Evolution/Systems/Cce/GaugeTransformBoundaryData.cpp
@@ -13,7 +13,6 @@
 #include "NumericalAlgorithms/Spectral/SwshDerivatives.hpp"
 #include "NumericalAlgorithms/Spectral/SwshInterpolation.hpp"
 
-/// \cond
 
 namespace Cce {
 
@@ -694,4 +693,3 @@ void InitializeGauge::apply(
 
 }  // namespace Cce
 
-/// \endcond

--- a/src/Evolution/Systems/Cce/Initialize/InverseCubic.cpp
+++ b/src/Evolution/Systems/Cce/Initialize/InverseCubic.cpp
@@ -77,7 +77,5 @@ void InverseCubic::operator()(
 
 void InverseCubic::pup(PUP::er& /*p*/) noexcept {}
 
-/// \cond
 PUP::able::PUP_ID InverseCubic::my_PUP_ID = 0;
-/// \endcond
 }  // namespace Cce::InitializeJ

--- a/src/Evolution/Systems/Cce/Initialize/NoIncomingRadiation.cpp
+++ b/src/Evolution/Systems/Cce/Initialize/NoIncomingRadiation.cpp
@@ -170,8 +170,6 @@ void NoIncomingRadiation::pup(PUP::er& p) noexcept {
   p | max_iterations_;
 }
 
-/// \cond
 PUP::able::PUP_ID NoIncomingRadiation::my_PUP_ID = 0;
-/// \endcond
 }  // namespace InitializeJ
 }  // namespace Cce

--- a/src/Evolution/Systems/Cce/Initialize/NoIncomingRadiation.cpp
+++ b/src/Evolution/Systems/Cce/Initialize/NoIncomingRadiation.cpp
@@ -23,8 +23,7 @@
 #include "Utilities/MakeString.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace Cce {
-namespace InitializeJ {
+namespace Cce::InitializeJ {
 namespace detail {
 
 void radial_evolve_psi0_condition(
@@ -171,5 +170,4 @@ void NoIncomingRadiation::pup(PUP::er& p) noexcept {
 }
 
 PUP::able::PUP_ID NoIncomingRadiation::my_PUP_ID = 0;
-}  // namespace InitializeJ
-}  // namespace Cce
+}  // namespace Cce::InitializeJ

--- a/src/Evolution/Systems/Cce/Initialize/ZeroNonSmooth.cpp
+++ b/src/Evolution/Systems/Cce/Initialize/ZeroNonSmooth.cpp
@@ -16,8 +16,7 @@
 #include "Utilities/MakeString.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace Cce {
-namespace InitializeJ {
+namespace Cce::InitializeJ {
 
 ZeroNonSmooth::ZeroNonSmooth(const double angular_coordinate_tolerance,
                              const size_t max_iterations,
@@ -84,5 +83,4 @@ void ZeroNonSmooth::pup(PUP::er& p) noexcept {
 }
 
 PUP::able::PUP_ID ZeroNonSmooth::my_PUP_ID = 0;
-}  // namespace InitializeJ
-}  // namespace Cce
+}  // namespace Cce::InitializeJ

--- a/src/Evolution/Systems/Cce/Initialize/ZeroNonSmooth.cpp
+++ b/src/Evolution/Systems/Cce/Initialize/ZeroNonSmooth.cpp
@@ -83,8 +83,6 @@ void ZeroNonSmooth::pup(PUP::er& p) noexcept {
   p | max_iterations_;
 }
 
-/// \cond
 PUP::able::PUP_ID ZeroNonSmooth::my_PUP_ID = 0;
-/// \endcond
 }  // namespace InitializeJ
 }  // namespace Cce

--- a/src/Evolution/Systems/Cce/InterfaceManagers/GhLocalTimeStepping.cpp
+++ b/src/Evolution/Systems/Cce/InterfaceManagers/GhLocalTimeStepping.cpp
@@ -202,7 +202,5 @@ void GhLocalTimeStepping::pup(PUP::er& p) noexcept {
   p | time_stepper_;
 }
 
-/// \cond
 PUP::able::PUP_ID GhLocalTimeStepping::my_PUP_ID = 0;
-/// \endcond
 }  // namespace Cce::InterfaceManagers

--- a/src/Evolution/Systems/Cce/InterfaceManagers/GhLockstep.cpp
+++ b/src/Evolution/Systems/Cce/InterfaceManagers/GhLockstep.cpp
@@ -51,7 +51,5 @@ auto GhLockstep::retrieve_and_remove_first_ready_gh_data() noexcept
 
 void GhLockstep::pup(PUP::er& p) noexcept { p | provided_data_; }
 
-/// \cond
 PUP::able::PUP_ID GhLockstep::my_PUP_ID = 0;
-/// \endcond
 }  // namespace Cce::InterfaceManagers

--- a/src/Evolution/Systems/Cce/WorldtubeBufferUpdater.cpp
+++ b/src/Evolution/Systems/Cce/WorldtubeBufferUpdater.cpp
@@ -446,8 +446,6 @@ void BondiWorldtubeH5BufferUpdater::pup(PUP::er& p) noexcept {
   }
 }
 
-/// \cond
 PUP::able::PUP_ID MetricWorldtubeH5BufferUpdater::my_PUP_ID = 0;
 PUP::able::PUP_ID BondiWorldtubeH5BufferUpdater::my_PUP_ID = 0;
-/// \endcond
 }  // namespace Cce

--- a/src/Evolution/Systems/Cce/WorldtubeDataManager.cpp
+++ b/src/Evolution/Systems/Cce/WorldtubeDataManager.cpp
@@ -449,8 +449,6 @@ void BondiWorldtubeDataManager::pup(PUP::er& p) noexcept {
   }
 }
 
-/// \cond
 PUP::able::PUP_ID MetricWorldtubeDataManager::my_PUP_ID = 0;
 PUP::able::PUP_ID BondiWorldtubeDataManager::my_PUP_ID = 0;
-/// \endcond
 }  // namespace Cce

--- a/src/Evolution/Systems/CurvedScalarWave/Constraints.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Constraints.cpp
@@ -72,7 +72,6 @@ void two_index_constraint(
 }  // namespace CurvedScalarWave
 
 // Explicit Instantiations
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                  \
@@ -95,4 +94,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #undef DIM
 #undef INSTANTIATE
-/// \endcond

--- a/src/Evolution/Systems/CurvedScalarWave/Constraints.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Constraints.cpp
@@ -34,7 +34,8 @@ void one_index_constraint(
   }
   // Declare iterators for d_psi and phi outside the for loop,
   // because they are const but constraint is not
-  auto d_psi_it = d_psi.cbegin(), phi_it = phi.cbegin();
+  auto d_psi_it = d_psi.cbegin();
+  auto phi_it = phi.cbegin();
 
   for (auto constraint_it = (*constraint).begin();
        constraint_it != (*constraint).end();

--- a/src/Evolution/Systems/CurvedScalarWave/Equations.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Equations.cpp
@@ -18,7 +18,6 @@ template <typename X, typename Symm, typename IndexList>
 class Tensor;
 
 namespace CurvedScalarWave {
-/// \cond
 template <size_t Dim>
 void ComputeNormalDotFluxes<Dim>::apply(
     const gsl::not_null<Scalar<DataVector>*> pi_normal_dot_flux,
@@ -56,7 +55,6 @@ void ComputeNormalDotFluxes<Dim>::apply(
         shift_dot_normal * phi.get(i);
   }
 }
-/// \endcond
 }  // namespace CurvedScalarWave
 // Generate explicit instantiations of partial_derivatives function as well as
 // all other functions in Equations.cpp

--- a/src/Evolution/Systems/CurvedScalarWave/TimeDerivative.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/TimeDerivative.cpp
@@ -15,7 +15,6 @@
 #include "Utilities/TMPL.hpp"
 
 namespace CurvedScalarWave {
-/// \cond
 template <size_t Dim>
 void TimeDerivative<Dim>::apply(
     const gsl::not_null<Scalar<DataVector>*> dt_pi,
@@ -66,7 +65,6 @@ void TimeDerivative<Dim>::apply(
     }
   }
 }
-/// \endcond
 }  // namespace CurvedScalarWave
 // Generate explicit instantiations of partial_derivatives function as well as
 // all other functions in Equations.cpp

--- a/src/Evolution/Systems/CurvedScalarWave/UpwindPenaltyCorrection.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/UpwindPenaltyCorrection.cpp
@@ -83,7 +83,6 @@ Variables<char_field_tags<Dim>> weight_char_fields(
 }
 }  // namespace CurvedScalarWave_detail
 
-/// \cond
 template <size_t Dim>
 void UpwindPenaltyCorrection<Dim>::package_data(
     const gsl::not_null<Scalar<DataVector>*> packaged_pi,
@@ -173,7 +172,6 @@ void UpwindPenaltyCorrection<Dim>::operator()(
   *pi_normal_dot_numerical_flux = get<Pi>(weighted_evolved_fields);
   *phi_normal_dot_numerical_flux = get<Phi<Dim>>(weighted_evolved_fields);
 }
-/// \endcond
 }  // namespace CurvedScalarWave
 
 // Generate explicit instantiations

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BoundaryCondition.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BoundaryCondition.cpp
@@ -8,7 +8,6 @@
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
-/// \cond
 namespace GeneralizedHarmonic::BoundaryConditions {
 template <size_t Dim>
 BoundaryCondition<Dim>::BoundaryCondition(CkMigrateMessage* const msg) noexcept
@@ -28,4 +27,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef INSTANTIATION
 #undef DIM
 }  // namespace GeneralizedHarmonic::BoundaryConditions
-/// \endcond

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletAnalytic.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletAnalytic.cpp
@@ -12,7 +12,6 @@
 #include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
-/// \cond
 namespace GeneralizedHarmonic::BoundaryConditions {
 template <size_t Dim>
 DirichletAnalytic<Dim>::DirichletAnalytic(CkMigrateMessage* const msg) noexcept
@@ -55,4 +54,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef INSTANTIATION
 #undef DIM
 }  // namespace GeneralizedHarmonic::BoundaryConditions
-/// \endcond

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/UpwindPenalty.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/UpwindPenalty.cpp
@@ -17,7 +17,6 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"  // IWYU pragma: keep
 
-/// \cond
 namespace GeneralizedHarmonic::BoundaryCorrections {
 template <size_t Dim>
 UpwindPenalty<Dim>::UpwindPenalty(CkMigrateMessage* msg) noexcept
@@ -289,4 +288,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef INSTANTIATION
 #undef DIM
 }  // namespace GeneralizedHarmonic::BoundaryCorrections
-/// \endcond

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/GaussianPlusConstant.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/GaussianPlusConstant.cpp
@@ -19,19 +19,15 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace domain::FunctionsOfTime {
 class FunctionOfTime;
 }  // namespace domain::FunctionsOfTime
-/// \endcond
 
 namespace GeneralizedHarmonic::ConstraintDamping {
-/// \cond
 template <size_t VolumeDim, typename Fr>
 GaussianPlusConstant<VolumeDim, Fr>::GaussianPlusConstant(
     CkMigrateMessage* msg) noexcept
     : DampingFunction<VolumeDim, Fr>(msg) {}
-/// \endcond
 
 template <size_t VolumeDim, typename Fr>
 GaussianPlusConstant<VolumeDim, Fr>::GaussianPlusConstant(
@@ -92,7 +88,6 @@ auto GaussianPlusConstant<VolumeDim, Fr>::get_clone() const noexcept
 }
 }  // namespace GeneralizedHarmonic::ConstraintDamping
 
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define INSTANTIATE(_, data)                                                  \
@@ -137,4 +132,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial),
 #undef DTYPE
 #undef INSTANTIATE
 
-/// \endcond

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TimeDependentTripleGaussian.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TimeDependentTripleGaussian.cpp
@@ -132,7 +132,5 @@ bool operator!=(const TimeDependentTripleGaussian& lhs,
   return not(lhs == rhs);
 }
 }  // namespace GeneralizedHarmonic::ConstraintDamping
-/// \cond
 PUP::able::PUP_ID GeneralizedHarmonic::ConstraintDamping::
     TimeDependentTripleGaussian::my_PUP_ID = 0;  // NOLINT
-/// \endcond

--- a/src/Evolution/Systems/GeneralizedHarmonic/Constraints.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Constraints.cpp
@@ -1307,7 +1307,6 @@ void constraint_energy(
 }  // namespace GeneralizedHarmonic
 
 // Explicit Instantiations
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
@@ -1482,4 +1481,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_ONLY_3D, (3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/Evolution/Systems/GeneralizedHarmonic/Equations.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Equations.cpp
@@ -12,7 +12,6 @@
 #include "Utilities/Gsl.hpp"
 
 namespace GeneralizedHarmonic {
-/// \cond
 template <size_t Dim>
 void ComputeNormalDotFluxes<Dim>::apply(
     const gsl::not_null<tnsr::aa<DataVector, Dim>*>
@@ -37,7 +36,6 @@ void ComputeNormalDotFluxes<Dim>::apply(
     (*phi_normal_dot_flux)[storage_index] = 0.0;
   }
 }
-/// \endcond
 }  // namespace GeneralizedHarmonic
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
@@ -48,4 +46,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #undef INSTANTIATE
 #undef DIM
-/// \endcond

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
@@ -32,7 +32,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace GeneralizedHarmonic::gauges {
 namespace DampedHarmonicGauge_detail {
 // Roll-on function for the damped harmonic gauge.
@@ -505,5 +504,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_DV_FUNC, (1, 2, 3), (DataVector),
 #undef DTYPE_SCAL
 #undef INSTANTIATE_DV_FUNC
 #undef INSTANTIATE_SCALAR_FUNC
-/// \endcond
 }  // namespace GeneralizedHarmonic::gauges

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedWaveHelpers.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedWaveHelpers.cpp
@@ -20,7 +20,6 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
-/// \cond
 namespace GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail {
 template <size_t SpatialDim, typename Frame, typename DataType>
 void spatial_weight_function(const gsl::not_null<Scalar<DataType>*> weight,
@@ -312,4 +311,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
 #undef DTYPE
 #undef DIM
 }  // namespace GeneralizedHarmonic::gauges::DampedHarmonicGauge_detail
-/// \endcond

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DhGaugeParameters.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DhGaugeParameters.cpp
@@ -7,7 +7,6 @@
 #include <pup.h>
 #include <pup_stl.h>
 
-/// \cond
 GeneralizedHarmonic::gauges::DhGaugeParameters<true>::DhGaugeParameters(
     const double start, const double window, const double width,
     const std::array<double, 3>& amps, const std::array<int, 3>& exps)
@@ -39,4 +38,3 @@ void GeneralizedHarmonic::gauges::DhGaugeParameters<false>::pup(
   p | amplitudes;
   p | exponents;
 }
-/// \endcond

--- a/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.cpp
@@ -23,7 +23,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace GeneralizedHarmonic {
 template <size_t Dim>
 void TimeDerivative<Dim>::apply(
@@ -355,4 +354,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #undef INSTANTIATE
 #undef DIM
-/// \endcond

--- a/src/Evolution/Systems/GeneralizedHarmonic/UpwindPenaltyCorrection.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/UpwindPenaltyCorrection.cpp
@@ -14,7 +14,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace GeneralizedHarmonic {
 template <size_t Dim>
 void UpwindPenaltyCorrection<Dim>::package_data(
@@ -207,4 +206,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef INSTANTIATION
 #undef DIM
 }  // namespace GeneralizedHarmonic
-/// \endcond

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/BoundaryCondition.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/BoundaryCondition.cpp
@@ -8,7 +8,6 @@
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
-/// \cond
 namespace grmhd::ValenciaDivClean::BoundaryConditions {
 BoundaryCondition::BoundaryCondition(CkMigrateMessage* const msg) noexcept
     : domain::BoundaryConditions::BoundaryCondition(msg) {}
@@ -17,4 +16,3 @@ void BoundaryCondition::pup(PUP::er& p) {
   domain::BoundaryConditions::BoundaryCondition::pup(p);
 }
 }  // namespace grmhd::ValenciaDivClean::BoundaryConditions
-/// \endcond

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/DirichletAnalytic.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/DirichletAnalytic.cpp
@@ -9,7 +9,6 @@
 
 #include "Utilities/GenerateInstantiations.hpp"
 
-/// \cond
 namespace grmhd::ValenciaDivClean::BoundaryConditions {
 DirichletAnalytic::DirichletAnalytic(CkMigrateMessage* const msg) noexcept
     : BoundaryCondition(msg) {}
@@ -24,4 +23,3 @@ void DirichletAnalytic::pup(PUP::er& p) { BoundaryCondition::pup(p); }
 // NOLINTNEXTLINE
 PUP::able::PUP_ID DirichletAnalytic::my_PUP_ID = 0;
 }  // namespace grmhd::ValenciaDivClean::BoundaryConditions
-/// \endcond

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Rusanov.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Rusanov.cpp
@@ -15,7 +15,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace grmhd::ValenciaDivClean::BoundaryCorrections {
 Rusanov::Rusanov(CkMigrateMessage* /*unused*/) noexcept {}
 
@@ -201,4 +200,3 @@ void Rusanov::dg_boundary_terms(
 // NOLINTNEXTLINE
 PUP::able::PUP_ID Rusanov::my_PUP_ID = 0;
 }  // namespace grmhd::ValenciaDivClean::BoundaryCorrections
-/// \endcond

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.cpp
@@ -20,7 +20,6 @@
 // IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 
 namespace {
 void compute_characteristic_speeds(
@@ -237,4 +236,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
 #undef GET_DIM
 #undef INSTANTIATION
 }  // namespace grmhd::ValenciaDivClean
-/// \endcond

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.cpp
@@ -20,7 +20,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace grmhd::ValenciaDivClean {
 
 void ConservativeFromPrimitive::apply(
@@ -102,4 +101,3 @@ void ConservativeFromPrimitive::apply(
 }
 
 }  // namespace grmhd::ValenciaDivClean
-/// \endcond

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.cpp
@@ -54,7 +54,6 @@ class FunctionOfLorentzFactor {
 };
 }  // namespace
 
-/// \cond
 namespace grmhd::ValenciaDivClean {
 FixConservatives::FixConservatives(
     const double minimum_rest_mass_density_times_lorentz_factor,
@@ -247,4 +246,3 @@ bool operator!=(const FixConservatives& lhs,
   return not(lhs == rhs);
 }
 }  // namespace grmhd::ValenciaDivClean
-/// \endcond

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.cpp
@@ -21,7 +21,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace grmhd::ValenciaDivClean {
 namespace detail {
 void fluxes_impl(
@@ -150,4 +149,3 @@ void ComputeFluxes::apply(
                       shift, inv_spatial_metric, spatial_velocity);
 }
 }  // namespace grmhd::ValenciaDivClean
-/// \endcond

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.cpp
@@ -16,7 +16,6 @@
 
 // IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
 
-/// \cond
 namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes {
 
 template <size_t ThermodynamicDim>
@@ -189,4 +188,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
 
 #undef INSTANTIATION
 #undef THERMODIM
-/// \endcond

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.cpp
@@ -15,7 +15,6 @@
 
 // IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
 
-/// \cond
 namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes {
 
 namespace {
@@ -167,4 +166,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
 
 #undef INSTANTIATION
 #undef THERMODIM
-/// \endcond

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
@@ -32,7 +32,6 @@
 // IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace grmhd::ValenciaDivClean {
 
 template <typename OrderedListOfPrimitiveRecoverySchemes,
@@ -197,4 +196,3 @@ GENERATE_INSTANTIATIONS(
 #undef INSTANTIATION
 #undef THERMODIM
 #undef RECOVERY
-/// \endcond

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Sources.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Sources.cpp
@@ -21,7 +21,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace {
 void densitized_stress(
     const gsl::not_null<tnsr::II<DataVector, 3, Frame::Inertial>*> result,
@@ -263,4 +262,3 @@ void ComputeSources::apply(
       constraint_damping_parameter);
 }
 }  // namespace grmhd::ValenciaDivClean
-/// \endcond

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/TimeDerivativeTerms.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/TimeDerivativeTerms.cpp
@@ -17,7 +17,6 @@
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace grmhd::ValenciaDivClean {
 namespace detail {
 void fluxes_impl(
@@ -208,4 +207,3 @@ void TimeDerivativeTerms::apply(
       constraint_damping_parameter);
 }
 }  // namespace grmhd::ValenciaDivClean
-/// \endcond

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/BoundaryCondition.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/BoundaryCondition.cpp
@@ -8,7 +8,6 @@
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
-/// \cond
 namespace NewtonianEuler::BoundaryConditions {
 template <size_t Dim>
 BoundaryCondition<Dim>::BoundaryCondition(CkMigrateMessage* const msg) noexcept
@@ -28,4 +27,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef INSTANTIATION
 #undef DIM
 }  // namespace NewtonianEuler::BoundaryConditions
-/// \endcond

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/DirichletAnalytic.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/DirichletAnalytic.cpp
@@ -10,7 +10,6 @@
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
-/// \cond
 namespace NewtonianEuler::BoundaryConditions {
 template <size_t Dim>
 DirichletAnalytic<Dim>::DirichletAnalytic(CkMigrateMessage* const msg) noexcept
@@ -40,4 +39,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef INSTANTIATION
 #undef DIM
 }  // namespace NewtonianEuler::BoundaryConditions
-/// \endcond

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Hll.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Hll.cpp
@@ -19,7 +19,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace NewtonianEuler::BoundaryCorrections {
 template <size_t Dim>
 Hll<Dim>::Hll(CkMigrateMessage* msg) noexcept : BoundaryCorrection<Dim>(msg) {}
@@ -264,4 +263,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
 #undef THERMODIM
 #undef DIM
 }  // namespace NewtonianEuler::BoundaryCorrections
-/// \endcond

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Rusanov.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Rusanov.cpp
@@ -16,7 +16,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace NewtonianEuler::BoundaryCorrections {
 template <size_t Dim>
 Rusanov<Dim>::Rusanov(CkMigrateMessage* msg) noexcept
@@ -223,4 +222,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
 #undef THERMODIM
 #undef DIM
 }  // namespace NewtonianEuler::BoundaryCorrections
-/// \endcond

--- a/src/Evolution/Systems/NewtonianEuler/Characteristics.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Characteristics.cpp
@@ -20,7 +20,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace NewtonianEuler {
 
 template <size_t Dim>
@@ -406,4 +405,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #undef DIM
 #undef INSTANTIATE
-/// \endcond

--- a/src/Evolution/Systems/NewtonianEuler/ConservativeFromPrimitive.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/ConservativeFromPrimitive.cpp
@@ -13,7 +13,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace NewtonianEuler {
 
 template <size_t Dim>
@@ -46,4 +45,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #undef DIM
 #undef INSTANTIATE
-/// \endcond

--- a/src/Evolution/Systems/NewtonianEuler/Fluxes.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Fluxes.cpp
@@ -12,7 +12,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace NewtonianEuler {
 namespace detail {
 template <size_t Dim>
@@ -74,4 +73,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #undef DIM
 #undef INSTANTIATE
-/// \endcond

--- a/src/Evolution/Systems/NewtonianEuler/InternalEnergyDensity.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/InternalEnergyDensity.cpp
@@ -8,7 +8,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace NewtonianEuler {
 template <typename DataType>
 void internal_energy_density(
@@ -45,4 +44,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
 #undef INSTANTIATE
 #undef DTYPE
 }  // namespace NewtonianEuler
-/// \endcond

--- a/src/Evolution/Systems/NewtonianEuler/KineticEnergyDensity.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/KineticEnergyDensity.cpp
@@ -9,7 +9,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace NewtonianEuler {
 template <typename DataType, size_t Dim, typename Fr>
 void kinetic_energy_density(
@@ -47,4 +46,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector), (1, 2, 3))
 #undef DIM
 #undef DTYPE
 }  // namespace NewtonianEuler
-/// \endcond

--- a/src/Evolution/Systems/NewtonianEuler/MachNumber.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/MachNumber.cpp
@@ -10,7 +10,6 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-/// \cond
 namespace NewtonianEuler {
 template <typename DataType, size_t Dim, typename Fr>
 void mach_number(const gsl::not_null<Scalar<DataType>*> result,
@@ -45,4 +44,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector), (1, 2, 3))
 #undef DIM
 #undef DTYPE
 }  // namespace NewtonianEuler
-/// \endcond

--- a/src/Evolution/Systems/NewtonianEuler/NumericalFluxes/Hllc.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/NumericalFluxes/Hllc.cpp
@@ -21,7 +21,6 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-/// \cond
 namespace NewtonianEuler::NumericalFluxes {
 
 template <size_t Dim, typename Frame>
@@ -218,4 +217,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Inertial))
 #undef FRAME
 #undef INSTANTIATE
 }  // namespace NewtonianEuler::NumericalFluxes
-/// \endcond

--- a/src/Evolution/Systems/NewtonianEuler/PrimitiveFromConservative.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/PrimitiveFromConservative.cpp
@@ -16,7 +16,6 @@
 // IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace NewtonianEuler {
 
 template <size_t Dim, size_t ThermodynamicDim>
@@ -64,4 +63,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (1, 2))
 #undef DIM
 #undef THERMO_DIM
 #undef INSTANTIATE
-/// \endcond

--- a/src/Evolution/Systems/NewtonianEuler/RamPressure.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/RamPressure.cpp
@@ -8,7 +8,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace NewtonianEuler {
 template <typename DataType, size_t Dim, typename Fr>
 void ram_pressure(const gsl::not_null<tnsr::II<DataType, Dim, Fr>*> result,
@@ -49,4 +48,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector), (1, 2, 3))
 #undef DIM
 #undef DTYPE
 }  // namespace NewtonianEuler
-/// \endcond

--- a/src/Evolution/Systems/NewtonianEuler/SoundSpeedSquared.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/SoundSpeedSquared.cpp
@@ -10,7 +10,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace NewtonianEuler {
 template <typename DataType, size_t ThermodynamicDim>
 void sound_speed_squared(
@@ -69,4 +68,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector), (1, 2))
 #undef THERMO_DIM
 #undef DTYPE
 }  // namespace NewtonianEuler
-/// \endcond

--- a/src/Evolution/Systems/NewtonianEuler/Sources/VortexPerturbation.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Sources/VortexPerturbation.cpp
@@ -21,7 +21,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace NewtonianEuler::Sources {
 template <>
 void VortexPerturbation<2>::apply() const noexcept {}
@@ -88,4 +87,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3))
 #undef INSTANTIATE
 #undef DIM
 }  // namespace NewtonianEuler::Sources
-/// \endcond

--- a/src/Evolution/Systems/NewtonianEuler/SpecificKineticEnergy.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/SpecificKineticEnergy.cpp
@@ -10,7 +10,6 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-/// \cond
 namespace NewtonianEuler {
 template <typename DataType, size_t Dim, typename Fr>
 void specific_kinetic_energy(
@@ -44,4 +43,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector), (1, 2, 3))
 #undef DIM
 #undef DTYPE
 }  // namespace NewtonianEuler
-/// \endcond

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/BoundaryCorrections/Rusanov.cpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/BoundaryCorrections/Rusanov.cpp
@@ -15,7 +15,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace RadiationTransport::M1Grey::BoundaryCorrections::Rusanov_detail {
 
 void dg_package_data_impl(
@@ -89,4 +88,3 @@ void dg_boundary_terms_impl(
 }
 
 }  // namespace RadiationTransport::M1Grey::BoundaryCorrections::Rusanov_detail
-/// \endcond

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/M1Closure.cpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/M1Closure.cpp
@@ -32,7 +32,7 @@ struct MomentumSquared {
 };
 /// \endcond
 
-/// Minerbo (maximum entropy) closure for the M1 scheme
+// Minerbo (maximum entropy) closure for the M1 scheme
 double minerbo_closure_function(const double zeta) noexcept {
   return 1.0 / 3.0 +
          square(zeta) * (0.4 - 2.0 / 15.0 * zeta + 0.4 * square(zeta));

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/M1Closure.cpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/M1Closure.cpp
@@ -23,14 +23,12 @@
 // IWYU pragma: no_forward_declare Tensor
 
 namespace {
-/// \cond
 struct MomentumUp {
   using type = tnsr::I<DataVector, 3, Frame::Inertial>;
 };
 struct MomentumSquared {
   using type = Scalar<DataVector>;
 };
-/// \endcond
 
 // Minerbo (maximum entropy) closure for the M1 scheme
 double minerbo_closure_function(const double zeta) noexcept {

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/M1HydroCoupling.cpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/M1HydroCoupling.cpp
@@ -22,7 +22,6 @@
 // IWYU pragma: no_forward_declare Tensor
 
 namespace {
-/// \cond
 struct densitized_eta_minus_kappaJ {
   using type = Scalar<DataVector>;
 };
@@ -30,7 +29,6 @@ struct densitized_eta_minus_kappaJ {
 struct kappaT_lapse {
   using type = Scalar<DataVector>;
 };
-/// \endcond
 }  // namespace
 
 namespace RadiationTransport::M1Grey::detail {

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/BoundaryCondition.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/BoundaryCondition.cpp
@@ -8,7 +8,6 @@
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
-/// \cond
 namespace RelativisticEuler::Valencia::BoundaryConditions {
 template <size_t Dim>
 BoundaryCondition<Dim>::BoundaryCondition(CkMigrateMessage* const msg) noexcept
@@ -28,4 +27,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef INSTANTIATION
 #undef DIM
 }  // namespace RelativisticEuler::Valencia::BoundaryConditions
-/// \endcond

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/DirichletAnalytic.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/DirichletAnalytic.cpp
@@ -10,7 +10,6 @@
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
-/// \cond
 namespace RelativisticEuler::Valencia::BoundaryConditions {
 template <size_t Dim>
 DirichletAnalytic<Dim>::DirichletAnalytic(CkMigrateMessage* const msg) noexcept
@@ -40,4 +39,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef INSTANTIATION
 #undef DIM
 }  // namespace RelativisticEuler::Valencia::BoundaryConditions
-/// \endcond

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryCorrections/Rusanov.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryCorrections/Rusanov.cpp
@@ -17,7 +17,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace RelativisticEuler::Valencia::BoundaryCorrections {
 template <size_t Dim>
 Rusanov<Dim>::Rusanov(CkMigrateMessage* msg) noexcept
@@ -248,4 +247,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
 #undef DIM
 
 }  // namespace RelativisticEuler::Valencia::BoundaryCorrections
-/// \endcond

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/Characteristics.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/Characteristics.cpp
@@ -18,7 +18,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace RelativisticEuler::Valencia {
 
 template <size_t Dim>
@@ -385,4 +384,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #undef DIM
 #undef INSTANTIATE
-/// \endcond

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/ConservativeFromPrimitive.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/ConservativeFromPrimitive.cpp
@@ -13,7 +13,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace RelativisticEuler::Valencia {
 
 template <size_t Dim>
@@ -67,4 +66,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef INSTANTIATION
 #undef DIM
 }  // namespace RelativisticEuler::Valencia
-/// \endcond

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/FixConservatives.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/FixConservatives.cpp
@@ -17,7 +17,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/TMPL.hpp"
 
-/// \cond
 namespace RelativisticEuler::Valencia {
 
 template <size_t Dim>
@@ -135,4 +134,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_CLASS, (1, 2, 3))
 #undef INSTANTIATE_CLASS
 #undef DIM
 }  // namespace RelativisticEuler::Valencia
-/// \endcond

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/Fluxes.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/Fluxes.cpp
@@ -14,7 +14,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace RelativisticEuler::Valencia {
 namespace detail {
 template <size_t Dim>
@@ -96,4 +95,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef DIM
 
 }  // namespace RelativisticEuler::Valencia
-/// \endcond

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/PrimitiveFromConservative.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/PrimitiveFromConservative.cpp
@@ -18,7 +18,6 @@
 
 // IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
 
-/// \cond
 namespace RelativisticEuler::Valencia {
 
 namespace {
@@ -154,4 +153,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
 #undef THERMODIM
 #undef DIM
 }  // namespace RelativisticEuler::Valencia
-/// \endcond

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/Sources.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/Sources.cpp
@@ -13,7 +13,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace {
 template <size_t Dim>
 void densitized_stress(
@@ -149,4 +148,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef DIM
 
 }  // namespace RelativisticEuler::Valencia
-/// \endcond

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/TimeDerivativeTerms.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/TimeDerivativeTerms.cpp
@@ -12,7 +12,6 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
-/// \cond
 namespace RelativisticEuler::Valencia {
 namespace detail {
 template <size_t Dim>
@@ -124,4 +123,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 #undef INSTANTIATE
 #undef DIM
 }  // namespace RelativisticEuler::Valencia
-/// \endcond

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/BoundaryCondition.cpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/BoundaryCondition.cpp
@@ -8,7 +8,6 @@
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
-/// \cond
 namespace ScalarWave::BoundaryConditions {
 template <size_t Dim>
 BoundaryCondition<Dim>::BoundaryCondition(CkMigrateMessage* const msg) noexcept
@@ -28,4 +27,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef INSTANTIATION
 #undef DIM
 }  // namespace ScalarWave::BoundaryConditions
-/// \endcond

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.cpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.cpp
@@ -14,7 +14,6 @@
 #include "Options/ParseOptions.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
-/// \cond
 namespace ScalarWave::BoundaryConditions {
 namespace detail {
 ConstraintPreservingSphericalRadiationType
@@ -175,4 +174,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef INSTANTIATION
 #undef DIM
 }  // namespace ScalarWave::BoundaryConditions
-/// \endcond

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/DirichletAnalytic.cpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/DirichletAnalytic.cpp
@@ -9,7 +9,6 @@
 
 #include "Utilities/GenerateInstantiations.hpp"
 
-/// \cond
 namespace ScalarWave::BoundaryConditions {
 template <size_t Dim>
 DirichletAnalytic<Dim>::DirichletAnalytic(CkMigrateMessage* const msg) noexcept
@@ -39,4 +38,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef INSTANTIATION
 #undef DIM
 }  // namespace ScalarWave::BoundaryConditions
-/// \endcond

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/SphericalRadiation.cpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/SphericalRadiation.cpp
@@ -18,7 +18,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace ScalarWave::BoundaryConditions {
 namespace detail {
 SphericalRadiationType convert_spherical_radiation_type_from_yaml(
@@ -121,4 +120,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef INSTANTIATION
 #undef DIM
 }  // namespace ScalarWave::BoundaryConditions
-/// \endcond

--- a/src/Evolution/Systems/ScalarWave/BoundaryCorrections/UpwindPenalty.cpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryCorrections/UpwindPenalty.cpp
@@ -16,7 +16,6 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"  // IWYU pragma: keep
 
-/// \cond
 namespace ScalarWave::BoundaryCorrections {
 template <size_t Dim>
 UpwindPenalty<Dim>::UpwindPenalty(CkMigrateMessage* msg) noexcept
@@ -220,4 +219,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef INSTANTIATION
 #undef DIM
 }  // namespace ScalarWave::BoundaryCorrections
-/// \endcond

--- a/src/Evolution/Systems/ScalarWave/Constraints.cpp
+++ b/src/Evolution/Systems/ScalarWave/Constraints.cpp
@@ -65,7 +65,6 @@ void two_index_constraint(
 }  // namespace ScalarWave
 
 // Explicit Instantiations
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                  \
@@ -88,4 +87,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #undef DIM
 #undef INSTANTIATE
-/// \endcond

--- a/src/Evolution/Systems/ScalarWave/Equations.cpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.cpp
@@ -13,7 +13,6 @@
 #include "Utilities/TMPL.hpp"
 
 namespace ScalarWave {
-/// \cond
 template <size_t Dim>
 void ComputeNormalDotFluxes<Dim>::apply(
     const gsl::not_null<Scalar<DataVector>*> pi_normal_dot_flux,
@@ -30,7 +29,6 @@ void ComputeNormalDotFluxes<Dim>::apply(
     phi_normal_dot_flux->get(i) = 0.0;
   }
 }
-/// \endcond
 }  // namespace ScalarWave
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)

--- a/src/Evolution/Systems/ScalarWave/TimeDerivative.cpp
+++ b/src/Evolution/Systems/ScalarWave/TimeDerivative.cpp
@@ -10,7 +10,6 @@
 #include "Utilities/Gsl.hpp"
 
 namespace ScalarWave {
-/// \cond
 template <size_t Dim>
 void TimeDerivative<Dim>::apply(
     const gsl::not_null<Scalar<DataVector>*> dt_pi,
@@ -47,5 +46,4 @@ void TimeDerivative<Dim>::apply(
 template class TimeDerivative<1>;
 template class TimeDerivative<2>;
 template class TimeDerivative<3>;
-/// \endcond
 }  // namespace ScalarWave

--- a/src/Evolution/Systems/ScalarWave/UpwindPenaltyCorrection.cpp
+++ b/src/Evolution/Systems/ScalarWave/UpwindPenaltyCorrection.cpp
@@ -16,7 +16,6 @@
 #include "Utilities/Gsl.hpp"   // IWYU pragma: keep
 #include "Utilities/TMPL.hpp"  // IWYU pragma: keep
 
-/// \cond
 namespace ScalarWave {
 template <size_t Dim>
 void UpwindPenaltyCorrection<Dim>::package_data(
@@ -175,4 +174,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef INSTANTIATION
 #undef DIM
 }  // namespace ScalarWave
-/// \endcond

--- a/src/Executables/ParallelInfo/ParallelInfo.cpp
+++ b/src/Executables/ParallelInfo/ParallelInfo.cpp
@@ -15,7 +15,6 @@
 #include "Utilities/System/Exit.hpp"
 #include "Utilities/System/ParallelInfo.hpp"
 
-/// \cond HIDDEN_SYMBOLS
 ParallelInfo::ParallelInfo(CkArgMsg* msg) {
   // clang-tidy: do not use pointer arithmetic
   Parallel::printf("Executing '%s' using %d processors.\n",
@@ -96,7 +95,6 @@ NodeGroupReporter::NodeGroupReporter(const CkCallback& cb_end_report) {
   print_info();
   this->contribute(cb_end_report);
 }
-/// \endcond
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Weffc++"

--- a/src/IO/H5/Dat.cpp
+++ b/src/IO/H5/Dat.cpp
@@ -23,10 +23,8 @@
 // IWYU pragma: no_include "DataStructures/Index.hpp"
 
 namespace {
-/*!
- * Given a vector of contiguous data and an array giving the dimensions of the
- * matrix returns a `vector<vector<T>>` representing the matrix.
- */
+// Given a vector of contiguous data and an array giving the dimensions of the
+// matrix returns a `vector<vector<T>>` representing the matrix.
 Matrix vector_to_matrix(const std::vector<double>& raw_data,
                         const std::array<hsize_t, 2>& size) {
   Matrix temp(size[0], size[1]);

--- a/src/IO/H5/Dat.cpp
+++ b/src/IO/H5/Dat.cpp
@@ -38,7 +38,6 @@ Matrix vector_to_matrix(const std::vector<double>& raw_data,
 }  // namespace
 
 namespace h5 {
-/// \cond HIDDEN_SYMBOLS
 Dat::Dat(const bool exists, detail::OpenGroup&& group, const hid_t location,
          const std::string& name, std::vector<std::string> legend,
          const uint32_t version)
@@ -103,7 +102,6 @@ Dat::Dat(const bool exists, detail::OpenGroup&& group, const hid_t location,
 }
 
 Dat::~Dat() { CHECK_H5(H5Dclose(dataset_id_), "Failed to close dataset"); }
-/// \endcond HIDDEN_SYMBOLS
 
 void Dat::append_impl(const hsize_t number_of_rows,
                       const std::vector<double>& data) {

--- a/src/IO/H5/File.cpp
+++ b/src/IO/H5/File.cpp
@@ -61,7 +61,6 @@ H5File<Access_t>::H5File(std::string file_name, bool append_to_file)
   }
 }
 
-/// \cond
 template <AccessType Access_t>
 H5File<Access_t>::H5File(H5File&& rhs) noexcept {
   file_name_ = std::move(rhs.file_name_);
@@ -100,7 +99,6 @@ void H5File<AccessType::ReadWrite>::insert_source_archive() noexcept {
 }
 template <>
 void H5File<AccessType::ReadOnly>::insert_source_archive() noexcept {}
-/// \endcond
 }  // namespace h5
 
 template class h5::H5File<h5::AccessType::ReadOnly>;

--- a/src/IO/H5/Header.cpp
+++ b/src/IO/H5/Header.cpp
@@ -15,7 +15,6 @@
 #include "Utilities/StdHelpers.hpp"
 
 namespace h5 {
-/// \cond HIDDEN_SYMOLS
 Header::Header(const bool exists, detail::OpenGroup&& group,
                const hid_t location, const std::string& name)
     : group_(std::move(group)) {
@@ -69,5 +68,4 @@ const std::string Header::printenv_delimiter_{
     "############### printenv ###############\n"};
 const std::string Header::library_versions_delimiter_{
     "############### library versions ###############\n"};
-/// \endcond
 }  // namespace h5

--- a/src/IO/H5/OpenGroup.cpp
+++ b/src/IO/H5/OpenGroup.cpp
@@ -62,7 +62,6 @@ OpenGroup::OpenGroup(hid_t file_id, const std::string& group_name,
   group_id_ = group_id;
 }
 
-/// \cond HIDDEN_SYMBOLS
 OpenGroup::OpenGroup(OpenGroup&& rhs) noexcept {
   group_path_ = std::move(rhs.group_path_);
   // clang-tidy: moving trivial type has no effect: might change in future
@@ -96,5 +95,4 @@ OpenGroup::~OpenGroup() {
     group_id_ = -1;
   }
 }
-/// \endcond
 }  // namespace h5::detail

--- a/src/IO/H5/SourceArchive.cpp
+++ b/src/IO/H5/SourceArchive.cpp
@@ -12,7 +12,6 @@
 #include "Utilities/Formaline.hpp"
 
 namespace h5 {
-/// \cond HIDDEN_SYMOLS
 SourceArchive::SourceArchive(const bool exists, detail::OpenGroup&& group,
                              const hid_t location,
                              const std::string& name) noexcept
@@ -26,5 +25,4 @@ SourceArchive::SourceArchive(const bool exists, detail::OpenGroup&& group,
                name + extension());
   }
 }
-/// \endcond
 }  // namespace h5

--- a/src/IO/H5/StellarCollapseEos.cpp
+++ b/src/IO/H5/StellarCollapseEos.cpp
@@ -11,7 +11,6 @@
 #include "IO/H5/Helpers.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 
-/// \cond
 namespace h5 {
 StellarCollapseEos::StellarCollapseEos(bool exists, detail::OpenGroup&& group,
                                        const hid_t /*location*/,
@@ -49,4 +48,3 @@ template int StellarCollapseEos::get_scalar_dataset(
     const std::string& dataset_name) const noexcept;
 
 }  // namespace h5
-/// \endcond

--- a/src/IO/H5/Version.cpp
+++ b/src/IO/H5/Version.cpp
@@ -8,7 +8,6 @@
 #include "Helpers.hpp"
 
 namespace h5 {
-/// \cond HIDDEN_SYMOLS
 Version::Version(bool exists, detail::OpenGroup&& group, hid_t location,
                  std::string name, const uint32_t version)
     : version_([&exists, &location, &version, &name]() {
@@ -32,5 +31,4 @@ Version::Version(bool exists, detail::OpenGroup&& group, hid_t location,
       }()),
       group_(std::move(group)) {}
 
-/// \endcond
 }  // namespace h5

--- a/src/IO/H5/VolumeData.cpp
+++ b/src/IO/H5/VolumeData.cpp
@@ -30,7 +30,6 @@
 #include "Utilities/MakeString.hpp"
 #include "Utilities/Numeric.hpp"
 
-/// \cond HIDDEN_SYMBOLS
 namespace h5 {
 namespace {
 // Append the element extents and connectevity to the total extents and
@@ -415,4 +414,3 @@ std::vector<std::vector<std::string>> VolumeData::get_quadratures(
 }
 
 }  // namespace h5
-/// \endcond HIDDEN_SYMBOLS

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Formulation.cpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Formulation.cpp
@@ -22,7 +22,6 @@ std::ostream& operator<<(std::ostream& os, const Formulation t) noexcept {
 }
 }  // namespace dg
 
-/// \cond
 template <>
 dg::Formulation Options::create_from_yaml<dg::Formulation>::create<void>(
     const Options::Option& options) {
@@ -37,4 +36,3 @@ dg::Formulation Options::create_from_yaml<dg::Formulation>::create<void>(
                                      << "\" to dg::Formulation. Must be one "
                                         "of StrongInertial or WeakInertial.");
 }
-/// \endcond

--- a/src/NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.cpp
+++ b/src/NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.cpp
@@ -33,7 +33,5 @@ double BarycentricRationalSpanInterpolator::interpolate(
   return interpolant(target_point);
 }
 
-/// \cond
 PUP::able::PUP_ID intrp::BarycentricRationalSpanInterpolator::my_PUP_ID = 0;
-/// \endcond
 }  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/CubicSpanInterpolator.cpp
+++ b/src/NumericalAlgorithms/Interpolation/CubicSpanInterpolator.cpp
@@ -50,7 +50,5 @@ std::complex<double> CubicSpanInterpolator::interpolate(
   return interpolate_impl(source_points, values, target_point);
 }
 
-/// \cond
 PUP::able::PUP_ID intrp::CubicSpanInterpolator::my_PUP_ID = 0;
-/// \endcond
 }  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.cpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.cpp
@@ -7,11 +7,9 @@
 
 #include "Utilities/GenerateInstantiations.hpp"
 
-/// \cond
 namespace Frame {
 struct Inertial;
 }  // namespace Frame
-/// \endcond
 
 namespace intrp::OptionHolders {
 template <typename Frame>
@@ -44,7 +42,6 @@ bool operator!=(const ApparentHorizon<Frame>& lhs,
 }
 
 // Explicit instantiations
-/// \cond
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                  \
@@ -57,5 +54,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (::Frame::Inertial))
 
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond
 }  // namespace intrp::OptionHolders

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.cpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.cpp
@@ -5,8 +5,7 @@
 
 #include "Utilities/GenerateInstantiations.hpp"
 
-namespace intrp {
-namespace OptionHolders {
+namespace intrp::OptionHolders {
 
 template <size_t VolumeDim>
 LineSegment<VolumeDim>::LineSegment(std::array<double, VolumeDim> begin_in,
@@ -51,5 +50,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 #undef DIM
 #undef INSTANTIATE
 
-}  // namespace OptionHolders
-}  // namespace intrp
+}  // namespace intrp::OptionHolders

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.cpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.cpp
@@ -37,7 +37,6 @@ bool operator!=(const LineSegment<VolumeDim>& lhs,
   return not(lhs == rhs);
 }
 
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                        \
@@ -51,7 +50,6 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #undef DIM
 #undef INSTANTIATE
-/// \endcond
 
 }  // namespace OptionHolders
 }  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/LinearSpanInterpolator.cpp
+++ b/src/NumericalAlgorithms/Interpolation/LinearSpanInterpolator.cpp
@@ -34,7 +34,5 @@ std::complex<double> LinearSpanInterpolator::interpolate(
   return interpolate_impl(source_points, values, target_point);
 }
 
-/// \cond
 PUP::able::PUP_ID intrp::LinearSpanInterpolator::my_PUP_ID = 0;
-/// \endcond
 }  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/RegularGridInterpolant.cpp
+++ b/src/NumericalAlgorithms/Interpolation/RegularGridInterpolant.cpp
@@ -83,7 +83,6 @@ bool operator!=(const RegularGrid<Dim>& lhs,
   return not(lhs == rhs);
 }
 
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                        \
@@ -97,6 +96,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #undef DIM
 #undef INSTANTIATE
-/// \endcond
 
 }  // namespace intrp

--- a/src/NumericalAlgorithms/LinearOperators/DefiniteIntegral.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/DefiniteIntegral.cpp
@@ -12,7 +12,6 @@
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 
-/// \cond
 // The 2D and 3D definite integrals have been optimized and are up to 2x faster
 // than the previous implementation. The main differences are
 //
@@ -118,4 +117,3 @@ double definite_integral<3>(const DataVector& integrand,
   }
   return result;
 }
-/// \endcond

--- a/src/NumericalAlgorithms/LinearOperators/ExponentialFilter.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/ExponentialFilter.cpp
@@ -11,7 +11,6 @@
 #include "Utilities/Literals.hpp"
 #include "Utilities/StaticCache.hpp"
 
-/// \cond HIDDEN_SYMBOLS
 namespace Filters {
 
 template <size_t FilterIndex>
@@ -78,4 +77,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (0, 1, 2, 3, 4, 5, 6, 7, 8, 9))
 #undef INSTANTIATE
 
 }  // namespace Filters
-/// \endcond

--- a/src/NumericalAlgorithms/RootFinding/QuadraticEquation.cpp
+++ b/src/NumericalAlgorithms/RootFinding/QuadraticEquation.cpp
@@ -144,7 +144,6 @@ struct root_between_values_impl<DataVector> {
 }  // namespace detail
 
 // Explicit instantiations
-/// \cond
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                               \
@@ -159,4 +158,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
 
 #undef DTYPE
 #undef INSTANTIATE
-/// \endcond

--- a/src/NumericalAlgorithms/Spectral/Chebyshev.cpp
+++ b/src/NumericalAlgorithms/Spectral/Chebyshev.cpp
@@ -90,7 +90,7 @@ compute_collocation_points_and_weights<Basis::Chebyshev, Quadrature::Gauss>(
   DataVector x(num_points);
   DataVector w(num_points, M_PI / num_points);
   for (size_t j = 0; j < num_points; j++) {
-    x[j] = -cos(M_PI_2 * (2 * j + 1) / (poly_degree + 1));
+    x[j] = -cos(M_PI_2 * (2. * j + 1.) / (poly_degree + 1.));
   }
   return std::make_pair(std::move(x), std::move(w));
 }
@@ -129,7 +129,8 @@ Matrix spectral_indefinite_integral_matrix<Basis::Chebyshev>(
   }
   if (LIKELY(num_points > 2)) {
     indef_int(1, 2) = -0.5;
-    indef_int(num_points - 1, num_points - 2) = 1.0 / (2.0 * (num_points - 1));
+    indef_int(num_points - 1, num_points - 2) =
+        1.0 / (2.0 * (num_points - 1.0));
   }
   for (size_t i = 2; i < num_points - 1; ++i) {
     indef_int(i, i - 1) = 1.0 / (2.0 * i);

--- a/src/NumericalAlgorithms/Spectral/Chebyshev.cpp
+++ b/src/NumericalAlgorithms/Spectral/Chebyshev.cpp
@@ -49,7 +49,6 @@ T compute_basis_function_value_impl(const size_t k, const T& x) noexcept {
 }
 }  // namespace
 
-/// \cond
 template <>
 DataVector compute_basis_function_value<Basis::Chebyshev>(
     const size_t k, const DataVector& x) noexcept {
@@ -77,11 +76,9 @@ double compute_basis_function_normalization_square<Basis::Chebyshev>(
     return M_PI_2;
   }
 }
-/// \endcond
 
 // Algorithm to compute Chebyshev-Gauss quadrature
 
-/// \cond
 template <>
 std::pair<DataVector, DataVector>
 compute_collocation_points_and_weights<Basis::Chebyshev, Quadrature::Gauss>(
@@ -97,11 +94,9 @@ compute_collocation_points_and_weights<Basis::Chebyshev, Quadrature::Gauss>(
   }
   return std::make_pair(std::move(x), std::move(w));
 }
-/// \endcond
 
 // Algorithm to compute Chebyshev-Gauss-Lobatto quadrature
 
-/// \cond
 template <>
 std::pair<DataVector, DataVector> compute_collocation_points_and_weights<
     Basis::Chebyshev, Quadrature::GaussLobatto>(
@@ -151,6 +146,5 @@ Matrix spectral_indefinite_integral_matrix<Basis::Chebyshev>(
   }
   return constant * indef_int;
 }
-/// \endcond
 
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/Legendre.cpp
+++ b/src/NumericalAlgorithms/Spectral/Legendre.cpp
@@ -175,16 +175,18 @@ EvaluateQandL::EvaluateQandL(const size_t poly_degree,
   double L_prime_n_minus_1 = 1.;
   double L_n = std::numeric_limits<double>::signaling_NaN();
   for (size_t k = 2; k <= poly_degree; k++) {
-    L_n = ((2 * k - 1) * x * L_n_minus_1 - (k - 1) * L_n_minus_2) / k;
-    const double L_prime_n = L_prime_n_minus_2 + (2 * k - 1) * L_n_minus_1;
+    L_n = ((2. * k - 1.) * x * L_n_minus_1 - (k - 1.) * L_n_minus_2) / k;
+    const double L_prime_n = L_prime_n_minus_2 + (2. * k - 1.) * L_n_minus_1;
     L_n_minus_2 = L_n_minus_1;
     L_n_minus_1 = L_n;
     L_prime_n_minus_2 = L_prime_n_minus_1;
     L_prime_n_minus_1 = L_prime_n;
   }
   const size_t k = poly_degree + 1;
-  const double L_n_plus_1 = ((2 * k - 1) * x * L_n - (k - 1) * L_n_minus_2) / k;
-  const double L_prime_n_plus_1 = L_prime_n_minus_2 + (2 * k - 1) * L_n_minus_1;
+  const double L_n_plus_1 =
+      ((2. * k - 1.) * x * L_n - (k - 1.) * L_n_minus_2) / k;
+  const double L_prime_n_plus_1 =
+      L_prime_n_minus_2 + (2. * k - 1.) * L_n_minus_1;
   q = L_n_plus_1 - L_n_minus_2;
   q_prime = L_prime_n_plus_1 - L_prime_n_minus_2;
   L = L_n;
@@ -212,7 +214,7 @@ std::pair<DataVector, DataVector> compute_collocation_points_and_weights<
     default:
       x[0] = -1.;
       x[poly_degree] = 1.;
-      w[0] = w[poly_degree] = 2. / (poly_degree * (poly_degree + 1));
+      w[0] = w[poly_degree] = 2. / (poly_degree * (poly_degree + 1.));
       auto newton_raphson_step = [poly_degree](double logical_coord) noexcept {
         const EvaluateQandL q_and_L(poly_degree, logical_coord);
         return std::make_pair(q_and_L.q, q_and_L.q_prime);
@@ -229,13 +231,13 @@ std::pair<DataVector, DataVector> compute_collocation_points_and_weights<
         x[j] = logical_coord;
         x[poly_degree - j] = -logical_coord;
         w[j] = w[poly_degree - j] =
-            2. / (poly_degree * (poly_degree + 1) * square(q_and_L.L));
+            2. / (poly_degree * (poly_degree + 1.) * square(q_and_L.L));
       }
       if (poly_degree % 2 == 0) {
         const EvaluateQandL q_and_L(poly_degree, 0.);
         x[poly_degree / 2] = 0.;
         w[poly_degree / 2] =
-            2. / (poly_degree * (poly_degree + 1) * square(q_and_L.L));
+            2. / (poly_degree * (poly_degree + 1.) * square(q_and_L.L));
       }
       break;
   }
@@ -256,7 +258,7 @@ Matrix spectral_indefinite_integral_matrix<Basis::Legendre>(
   }
   if (LIKELY(num_points > 1)) {
     indef_int(num_points - 1, num_points - 2) =
-        1.0 / (2.0 * (num_points - 1) - 1.0);
+        1.0 / (2.0 * (num_points - 1.0) - 1.0);
   }
 
   // Matrix that ensures that BC at left of interval is 0.0

--- a/src/NumericalAlgorithms/Spectral/Legendre.cpp
+++ b/src/NumericalAlgorithms/Spectral/Legendre.cpp
@@ -45,7 +45,6 @@ T compute_basis_function_value_impl(const size_t k, const T& x) noexcept {
 }
 }  // namespace
 
-/// \cond
 template <>
 DataVector compute_basis_function_value<Basis::Legendre>(
     const size_t k, const DataVector& x) noexcept {
@@ -69,7 +68,6 @@ double compute_basis_function_normalization_square<Basis::Legendre>(
     const size_t k) noexcept {
   return 2. / (2. * k + 1.);
 }
-/// \endcond
 
 // Algorithms to compute Legendre-Gauss quadrature
 
@@ -105,7 +103,6 @@ LegendrePolynomialAndDerivative::LegendrePolynomialAndDerivative(
 
 }  // namespace
 
-/// \cond
 template <>
 std::pair<DataVector, DataVector>
 compute_collocation_points_and_weights<Basis::Legendre, Quadrature::Gauss>(
@@ -155,7 +152,6 @@ compute_collocation_points_and_weights<Basis::Legendre, Quadrature::Gauss>(
   }
   return std::make_pair(std::move(x), std::move(w));
 }
-/// \endcond
 
 // Algorithms to compute Legendre-Gauss-Lobatto quadrature
 
@@ -196,7 +192,6 @@ EvaluateQandL::EvaluateQandL(const size_t poly_degree,
 
 }  // namespace
 
-/// \cond
 template <>
 std::pair<DataVector, DataVector> compute_collocation_points_and_weights<
     Basis::Legendre, Quadrature::GaussLobatto>(
@@ -274,6 +269,5 @@ Matrix spectral_indefinite_integral_matrix<Basis::Legendre>(
   }
   return constant * indef_int;
 }
-/// \endcond
 
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/Mesh.cpp
+++ b/src/NumericalAlgorithms/Spectral/Mesh.cpp
@@ -66,7 +66,6 @@ std::array<Mesh<1>, Dim> Mesh<Dim>::slices() const noexcept {
   return result;
 }
 
-/// \cond HIDDEN_SYMBOLS
 template <size_t Dim>
 void Mesh<Dim>::pup(PUP::er& p) noexcept {
   p | extents_;
@@ -134,4 +133,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_SLICE_AWAY, (1, 2, 3))
 #undef GEN_OP
 #undef INSTANTIATE_MESH
 #undef INSTANTIATE_SLICE_AWAY
-/// \endcond

--- a/src/NumericalAlgorithms/Spectral/Spectral.cpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.cpp
@@ -295,7 +295,6 @@ const DataVector& quadrature_weights(const size_t num_points) noexcept {
       QuadratureWeightsGenerator<BasisType, QuadratureType>>(num_points);
 }
 
-/// \cond
 // clang-tidy: Macro arguments should be in parentheses, but we want to append
 // template parameters here.
 #define PRECOMPUTED_SPECTRAL_QUANTITY(function_name, return_type,      \
@@ -322,7 +321,6 @@ PRECOMPUTED_SPECTRAL_QUANTITY(linear_filter_matrix, Matrix,
                               LinearFilterMatrixGenerator)
 
 #undef PRECOMPUTED_SPECTRAL_QUANTITY
-/// \endcond
 
 template <Basis BasisType, Quadrature QuadratureType, typename T>
 Matrix interpolation_matrix(const size_t num_points,
@@ -549,7 +547,6 @@ decltype(auto) get_spectral_quantity_for_mesh(F&& f,
 
 }  // namespace
 
-/// \cond
 // clang-tidy: Macro arguments should be in parentheses, but we want to append
 // template parameters here.
 #define SPECTRAL_QUANTITY_FOR_MESH(function_name, return_type)           \
@@ -573,7 +570,6 @@ SPECTRAL_QUANTITY_FOR_MESH(nodal_to_modal_matrix, Matrix)
 SPECTRAL_QUANTITY_FOR_MESH(linear_filter_matrix, Matrix)
 
 #undef SPECTRAL_QUANTITY_FOR_MESH
-/// \endcond
 
 template <typename T>
 Matrix interpolation_matrix(const Mesh<1>& mesh,
@@ -590,7 +586,6 @@ Matrix interpolation_matrix(const Mesh<1>& mesh,
 
 }  // namespace Spectral
 
-/// \cond HIDDEN_SYMBOLS
 #define BASIS(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define QUAD(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define INSTANTIATE(_, data)                                                  \
@@ -645,9 +640,7 @@ template const DataVector& Spectral::collocation_points<
 template const DataVector& Spectral::quadrature_weights<
     Spectral::Basis::FiniteDifference, Spectral::Quadrature::FaceCentered>(
     size_t) noexcept;
-/// \endcond
 
-/// \cond
 template <>
 Spectral::Quadrature
 Options::create_from_yaml<Spectral::Quadrature>::create<void>(
@@ -686,4 +679,3 @@ Spectral::Basis Options::create_from_yaml<Spectral::Basis>::create<void>(
                   << "\" to Spectral::Basis. Must be one "
                      "of Chebyshev, Legendre, or FiniteDifference.");
 }
-/// \endcond

--- a/src/NumericalAlgorithms/Spectral/SwshInterpolation.cpp
+++ b/src/NumericalAlgorithms/Spectral/SwshInterpolation.cpp
@@ -299,7 +299,7 @@ struct ClenshawRecurrenceConstants {
     }
   }
 
-  /// Serialization for Charm++.
+  // Serialization for Charm++.
   void pup(PUP::er& p) noexcept {  // NOLINT
     p | alpha_prefactor;
     p | alpha_constant;

--- a/src/NumericalAlgorithms/Spectral/SwshInterpolation.cpp
+++ b/src/NumericalAlgorithms/Spectral/SwshInterpolation.cpp
@@ -25,7 +25,6 @@
 #include "Utilities/StaticCache.hpp"
 #include "Utilities/TMPL.hpp"
 
-/// \cond
 
 namespace Spectral::Swsh {
 
@@ -671,4 +670,3 @@ GENERATE_INSTANTIATIONS(INTERPOLATION_INSTANTIATION, (-2, -1, 0, 1, 2))
 #undef GET_SPIN
 
 }  // namespace Spectral::Swsh
-/// \endcond

--- a/src/Options/ParseOptions.hpp
+++ b/src/Options/ParseOptions.hpp
@@ -922,6 +922,7 @@ struct create_from_yaml<std::variant<T...>> {
 };
 }  // namespace Options
 
+/// \cond
 template <typename T, typename Metavariables>
 struct YAML::convert<Options::Options_detail::CreateWrapper<T, Metavariables>> {
   static bool decode(
@@ -936,5 +937,6 @@ struct YAML::convert<Options::Options_detail::CreateWrapper<T, Metavariables>> {
     return true;
   }
 };
+/// \endcond
 
 #include "Options/Factory.hpp"

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/OverlapHelpers.cpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/OverlapHelpers.cpp
@@ -165,7 +165,6 @@ void add_overlap_data_impl(double* volume_data, const double* overlap_data,
 
 }  // namespace detail
 
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define INSTANTIATE(r, data)                                                  \
   template size_t overlap_num_points(const Index<DIM(data)>&, size_t,         \
@@ -183,6 +182,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #undef DIM
 #undef INSTANTIATE
-/// \endcond
 
 }  // namespace LinearSolver::Schwarz

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/Weighting.cpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/Weighting.cpp
@@ -201,7 +201,6 @@ Scalar<DataVector> intruding_weight(
   return weight;
 }
 
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define INSTANTIATE(r, data)                                                \
   template void element_weight(                                             \
@@ -231,6 +230,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #undef DIM
 #undef INSTANTIATE
-/// \endcond
 
 }  // namespace LinearSolver::Schwarz

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/PlaneWave3DKerrSchild.cpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/PlaneWave3DKerrSchild.cpp
@@ -3,7 +3,6 @@
 
 #include "PointwiseFunctions/AnalyticData/CurvedWaveEquation/PlaneWave3DKerrSchild.hpp"
 
-/// \cond
 namespace CurvedScalarWave ::AnalyticData {
 template class ScalarWaveGr<ScalarWave::Solutions::PlaneWave<3>,
                             gr::Solutions::KerrSchild>;
@@ -18,4 +17,3 @@ template bool operator!=(
     const ScalarWaveGr<ScalarWave::Solutions::PlaneWave<3>,
                        gr::Solutions::KerrSchild>& rhs) noexcept;
 }  // namespace CurvedScalarWave::AnalyticData
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/RegularSphericalWave3DKerrSchild.cpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/RegularSphericalWave3DKerrSchild.cpp
@@ -3,7 +3,6 @@
 
 #include "PointwiseFunctions/AnalyticData/CurvedWaveEquation/RegularSphericalWave3DKerrSchild.hpp"
 
-/// \cond
 namespace CurvedScalarWave ::AnalyticData {
 template class ScalarWaveGr<ScalarWave::Solutions::RegularSphericalWave,
                             gr::Solutions::KerrSchild>;
@@ -18,4 +17,3 @@ template bool operator!=(
     const ScalarWaveGr<ScalarWave::Solutions::RegularSphericalWave,
                        gr::Solutions::KerrSchild>& rhs) noexcept;
 }  // namespace CurvedScalarWave::AnalyticData
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.cpp
@@ -15,7 +15,6 @@
 
 // IWYU pragma:  no_include "DataStructures/Tensor/TypeAliases.hpp"
 
-/// \cond
 namespace grmhd {
 namespace AnalyticData {
 
@@ -241,4 +240,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_VECTORS, (double, DataVector),
 
 }  // namespace AnalyticData
 }  // namespace grmhd
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.cpp
@@ -15,8 +15,7 @@
 
 // IWYU pragma:  no_include "DataStructures/Tensor/TypeAliases.hpp"
 
-namespace grmhd {
-namespace AnalyticData {
+namespace grmhd::AnalyticData {
 
 BondiHoyleAccretion::BondiHoyleAccretion(
     const double bh_mass, const double bh_dimless_spin,
@@ -238,5 +237,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_VECTORS, (double, DataVector),
 #undef INSTANTIATE_SCALARS
 #undef INSTANTIATE_VECTORS
 
-}  // namespace AnalyticData
-}  // namespace grmhd
+}  // namespace grmhd::AnalyticData

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/CylindricalBlastWave.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/CylindricalBlastWave.cpp
@@ -49,7 +49,6 @@ Scalar<DataType> compute_piecewise(const tnsr::I<DataType, 3>& x,
 }
 }  // namespace
 
-/// \cond
 namespace grmhd::AnalyticData {
 
 CylindricalBlastWave::CylindricalBlastWave(
@@ -220,4 +219,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_VECTORS, (double, DataVector),
 #undef INSTANTIATE_SCALARS
 #undef INSTANTIATE_VECTORS
 }  // namespace grmhd::AnalyticData
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.cpp
@@ -23,7 +23,6 @@
 
 // IWYU pragma: no_include <complex>
 
-/// \cond
 namespace grmhd::AnalyticData {
 
 MagneticFieldLoop::MagneticFieldLoop(
@@ -220,4 +219,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_VECTORS, (double, DataVector),
 #undef INSTANTIATE_SCALARS
 #undef INSTANTIATE_VECTORS
 }  // namespace grmhd::AnalyticData
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.cpp
@@ -34,7 +34,6 @@ Scalar<DataType> compute_piecewise(const tnsr::I<DataType, 3>& x,
 }
 }  // namespace
 
-/// \cond
 namespace grmhd::AnalyticData {
 
 MagneticRotor::MagneticRotor(
@@ -209,4 +208,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_VECTORS, (double, DataVector),
 #undef INSTANTIATE_SCALARS
 #undef INSTANTIATE_VECTORS
 }  // namespace grmhd::AnalyticData
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.cpp
@@ -24,7 +24,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace grmhd::AnalyticData {
 
 MagnetizedFmDisk::MagnetizedFmDisk(
@@ -261,4 +260,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector), (true, false))
 #undef NEED_SPACETIME
 #undef INSTANTIATE
 }  // namespace grmhd::AnalyticData
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.cpp
@@ -14,8 +14,7 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-namespace grmhd {
-namespace AnalyticData {
+namespace grmhd::AnalyticData {
 
 OrszagTangVortex::OrszagTangVortex() = default;
 
@@ -149,5 +148,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_VECTORS, (double, DataVector),
 #undef INSTANTIATE_SCALARS
 #undef INSTANTIATE_VECTORS
 
-}  // namespace AnalyticData
-}  // namespace grmhd
+}  // namespace grmhd::AnalyticData

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.cpp
@@ -14,7 +14,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-/// \cond
 namespace grmhd {
 namespace AnalyticData {
 
@@ -152,4 +151,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_VECTORS, (double, DataVector),
 
 }  // namespace AnalyticData
 }  // namespace grmhd
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticData/NewtonianEuler/KhInstability.cpp
+++ b/src/PointwiseFunctions/AnalyticData/NewtonianEuler/KhInstability.cpp
@@ -17,7 +17,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-/// \cond
 namespace NewtonianEuler::AnalyticData {
 
 template <size_t Dim>
@@ -204,4 +203,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_VELOCITY, (2, 3), (double, DataVector),
 #undef DTYPE
 #undef DIM
 }  // namespace NewtonianEuler::AnalyticData
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticData/NewtonianEuler/SodExplosion.cpp
+++ b/src/PointwiseFunctions/AnalyticData/NewtonianEuler/SodExplosion.cpp
@@ -16,7 +16,6 @@
 #include "Utilities/Math.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 
-/// \cond
 namespace NewtonianEuler::AnalyticData {
 template <size_t Dim>
 SodExplosion<Dim>::SodExplosion(const double initial_radius,
@@ -155,4 +154,3 @@ template bool operator!=(const SodExplosion<2>& lhs,
 template bool operator!=(const SodExplosion<3>& lhs,
                          const SodExplosion<3>& rhs) noexcept;
 }  // namespace NewtonianEuler::AnalyticData
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.cpp
@@ -14,7 +14,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-/// \cond
 namespace Elasticity::Solutions::detail {
 
 template <typename DataType>
@@ -86,4 +85,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (DataVector))
 #undef INSTANTIATE
 
 }  // namespace Elasticity::Solutions::detail
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.cpp
@@ -21,7 +21,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-/// \cond
 namespace Elasticity::Solutions::detail {
 
 namespace {
@@ -226,4 +225,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (DataVector))
 #undef INSTANTIATE
 
 }  // namespace Elasticity::Solutions::detail
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugeWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugeWave.cpp
@@ -16,7 +16,6 @@
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 
-/// \cond
 namespace {
 // compute gauge wave H
 template <typename DataType, size_t Dim>
@@ -361,4 +360,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 #undef DIM
 }  // namespace Solutions
 }  // namespace gr
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugeWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugeWave.cpp
@@ -36,8 +36,7 @@ DataType gauge_wave_deriv_h(const tnsr::I<DataType, Dim>& x, const double t,
 }
 }  // namespace
 
-namespace gr {
-namespace Solutions {
+namespace gr::Solutions {
 template <size_t Dim>
 GaugeWave<Dim>::GaugeWave(const double amplitude, const double wavelength,
                           const Options::Context& context)
@@ -358,5 +357,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 #undef INSTANTIATE
 #undef DTYPE
 #undef DIM
-}  // namespace Solutions
-}  // namespace gr
+}  // namespace gr::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.cpp
@@ -19,7 +19,6 @@
 #include "Utilities/StdArrayHelpers.hpp"
 #include "Utilities/StdHelpers.hpp"
 
-/// \cond
 namespace gr::Solutions {
 
 KerrSchild::KerrSchild(const double mass,
@@ -552,4 +551,3 @@ template class KerrSchild::IntermediateVars<double>;
 template class KerrSchild::IntermediateComputer<DataVector>;
 template class KerrSchild::IntermediateComputer<double>;
 }  // namespace gr::Solutions
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.cpp
@@ -11,7 +11,6 @@
 
 // IWYU pragma: no_forward_declare ::Tags::deriv
 
-/// \cond
 namespace gr {
 namespace Solutions {
 
@@ -260,4 +259,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector))
 #undef DIM
 #undef DTYPE
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.cpp
@@ -11,8 +11,7 @@
 
 // IWYU pragma: no_forward_declare ::Tags::deriv
 
-namespace gr {
-namespace Solutions {
+namespace gr::Solutions {
 
 template <size_t Dim>
 template <typename DataType>
@@ -161,8 +160,7 @@ Minkowski<Dim>::variables(
     const noexcept {
   return {make_with_value<Scalar<DataType>>(x, 0.)};
 }
-}  // namespace Solutions
-}  // namespace gr
+}  // namespace gr::Solutions
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.cpp
@@ -15,7 +15,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 // IWYU pragma: no_forward_declare ::Tags::deriv
 
-/// \cond
 namespace GeneralizedHarmonic::Solutions {
 // Preprocessor logic to avoid defining variables() functions for
 // tags other than the three the wrapper adds (i.e., other than
@@ -302,4 +301,3 @@ GENERATE_INSTANTIATIONS(
 #undef DIM
 #undef STYPE
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.cpp
@@ -21,7 +21,6 @@
 
 // IWYU pragma:  no_include "DataStructures/Tensor/TypeAliases.hpp"
 
-/// \cond
 namespace grmhd::Solutions {
 
 AlfvenWave::AlfvenWave(
@@ -252,4 +251,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_VECTORS, (double, DataVector),
 #undef INSTANTIATE_SCALARS
 #undef INSTANTIATE_VECTORS
 }  // namespace grmhd::Solutions
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.cpp
@@ -17,8 +17,8 @@
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
-namespace grmhd {
-namespace Solutions {
+
+namespace grmhd::Solutions {
 
 BondiMichel::BondiMichel(const double mass, const double sonic_radius,
                          const double sonic_density,
@@ -370,5 +370,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
 
 #undef DTYPE
 #undef INSTANTIATE
-}  // namespace Solutions
-}  // namespace grmhd
+}  // namespace grmhd::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.cpp
@@ -17,7 +17,6 @@
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
-/// \cond
 namespace grmhd {
 namespace Solutions {
 
@@ -373,4 +372,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
 #undef INSTANTIATE
 }  // namespace Solutions
 }  // namespace grmhd
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.cpp
@@ -42,7 +42,6 @@ tnsr::I<DataType, 3> compute_piecewise_vector(
 }
 }  // namespace
 
-/// \cond
 namespace grmhd::Solutions {
 
 KomissarovShock::KomissarovShock(
@@ -215,4 +214,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_VECTORS, (double, DataVector),
 #undef INSTANTIATE_SCALARS
 #undef INSTANTIATE_VECTORS
 }  // namespace grmhd::Solutions
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.cpp
@@ -11,8 +11,7 @@
 
 // IWYU pragma:  no_include "DataStructures/Tensor/TypeAliases.hpp"
 
-namespace grmhd {
-namespace Solutions {
+namespace grmhd::Solutions {
 
 SmoothFlow::SmoothFlow(const std::array<double, 3>& mean_velocity,
                        const std::array<double, 3>& wavevector,
@@ -79,5 +78,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_VECTORS, (double, DataVector),
 #undef TAG
 #undef INSTANTIATE_SCALARS
 #undef INSTANTIATE_VECTORS
-}  // namespace Solutions
-}  // namespace grmhd
+}  // namespace grmhd::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.cpp
@@ -11,7 +11,6 @@
 
 // IWYU pragma:  no_include "DataStructures/Tensor/TypeAliases.hpp"
 
-/// \cond
 namespace grmhd {
 namespace Solutions {
 
@@ -82,4 +81,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_VECTORS, (double, DataVector),
 #undef INSTANTIATE_VECTORS
 }  // namespace Solutions
 }  // namespace grmhd
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/Hydro/SmoothFlow.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Hydro/SmoothFlow.cpp
@@ -17,7 +17,6 @@
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/Numeric.hpp"
 
-/// \cond
 namespace hydro::Solutions {
 
 template <size_t Dim, bool IsRelativistic>
@@ -216,4 +215,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_VECTORS, (1, 2, 3), (true, false),
 #undef INSTANTIATE_LORENTZ_FACTOR
 #undef INSTANTIATE_VECTORS
 }  // namespace hydro::Solutions
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.cpp
@@ -21,7 +21,6 @@
 
 // IWYU pragma: no_include <complex>
 
-/// \cond
 namespace NewtonianEuler::Solutions {
 
 template <size_t Dim>
@@ -215,4 +214,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_VELOCITY, (2, 3), (double, DataVector),
 #undef INSTANTIATE_VELOCITY
 
 }  // namespace NewtonianEuler::Solutions
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/RiemannProblem.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/RiemannProblem.cpp
@@ -73,7 +73,6 @@ struct FunctionOfPressureAndData {
 
 }  // namespace
 
-/// \cond
 namespace NewtonianEuler::Solutions {
 
 template <size_t Dim>
@@ -536,4 +535,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_VELOCITY, (1, 2, 3), (double, DataVector),
 #undef INSTANTIATE_VELOCITY
 
 }  // namespace NewtonianEuler::Solutions
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/SmoothFlow.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/SmoothFlow.cpp
@@ -17,7 +17,6 @@
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/Numeric.hpp"
 
-/// \cond
 namespace NewtonianEuler::Solutions {
 
 template <size_t Dim>
@@ -65,4 +64,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_CLASS, (1, 2, 3))
 #undef INSTANTIATE_CLASS
 #undef DIM
 }  // namespace NewtonianEuler::Solutions
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/Lorentzian.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/Lorentzian.cpp
@@ -15,7 +15,6 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-/// \cond
 namespace Poisson::Solutions::detail {
 
 template <typename DataType, size_t Dim>
@@ -72,4 +71,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (DataVector), (3))
 #undef INSTANTIATE
 
 }  // namespace Poisson::Solutions::detail
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.cpp
@@ -16,7 +16,6 @@
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/Math.hpp"
 
-/// \cond
 namespace Poisson::Solutions::detail {
 
 template <typename DataType, size_t Dim>
@@ -111,4 +110,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (DataVector), (1, 2))
 #undef INSTANTIATE
 
 }  // namespace Poisson::Solutions::detail
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.cpp
@@ -15,7 +15,6 @@
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 
-/// \cond
 namespace Poisson::Solutions::detail {
 
 template <typename DataType, size_t Dim>
@@ -82,4 +81,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (DataVector), (1, 2, 3))
 #undef INSTANTIATE
 
 }  // namespace Poisson::Solutions::detail
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/ConstantM1.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/ConstantM1.cpp
@@ -19,7 +19,6 @@
 // IWYU pragma:  no_include "DataStructures/Tensor/TypeAliases.hpp"
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace RadiationTransport::M1Grey::Solutions {
 
 ConstantM1::ConstantM1(const std::array<double, 3>& mean_velocity,
@@ -195,4 +194,3 @@ GENERATE_INSTANTIATIONS(
 #undef GENERATE_LIST
 
 }  // namespace RadiationTransport::M1Grey::Solutions
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.cpp
@@ -25,7 +25,6 @@
 // functions
 // IWYU pragma: no_include <complex>
 
-/// \cond
 namespace RelativisticEuler {
 namespace Solutions {
 
@@ -409,4 +408,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
 #undef INSTANTIATE
 }  // namespace Solutions
 }  // namespace RelativisticEuler
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.cpp
@@ -25,8 +25,7 @@
 // functions
 // IWYU pragma: no_include <complex>
 
-namespace RelativisticEuler {
-namespace Solutions {
+namespace RelativisticEuler::Solutions {
 
 FishboneMoncriefDisk::FishboneMoncriefDisk(
     const double bh_mass, const double bh_dimless_spin,
@@ -406,5 +405,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
 #undef DTYPE
 #undef NEED_SPACETIME
 #undef INSTANTIATE
-}  // namespace Solutions
-}  // namespace RelativisticEuler
+}  // namespace RelativisticEuler::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.cpp
@@ -17,7 +17,6 @@
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/Numeric.hpp"
 
-/// \cond
 namespace RelativisticEuler::Solutions {
 
 template <size_t Dim>
@@ -67,4 +66,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_CLASS, (1, 2, 3))
 #undef INSTANTIATE_CLASS
 #undef DIM
 }  // namespace RelativisticEuler::Solutions
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.cpp
@@ -134,7 +134,6 @@ T PlaneWave<Dim>::u(const tnsr::I<T, Dim>& x, const double t) const noexcept {
 
 }  // namespace ScalarWave::Solutions
 
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 
@@ -174,4 +173,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector))
 template class ScalarWave::Solutions::PlaneWave<1>;
 template class ScalarWave::Solutions::PlaneWave<2>;
 template class ScalarWave::Solutions::PlaneWave<3>;
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/ConstantDensityStar.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/ConstantDensityStar.cpp
@@ -66,7 +66,6 @@ Scalar<DataVector> compute_piecewise(const Scalar<DataVector>& r,
 
 }  // namespace
 
-/// \cond
 namespace Xcts::Solutions {
 
 ConstantDensityStar::ConstantDensityStar(const double density,
@@ -203,4 +202,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
 #undef INSTANTIATE
 
 }  // namespace Xcts::Solutions
-/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.cpp
@@ -22,7 +22,6 @@
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace Xcts::Solutions {
 
 std::ostream& operator<<(std::ostream& os,
@@ -280,4 +279,3 @@ template class Xcts::AnalyticData::CommonVariables<
     DataVector, typename Xcts::Solutions::detail::SchwarzschildVariables<
                     DataVector>::Cache>;
 
-/// \endcond

--- a/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/ConstitutiveRelation.cpp
+++ b/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/ConstitutiveRelation.cpp
@@ -10,7 +10,6 @@
 
 namespace Elasticity::ConstitutiveRelations {
 
-/// \cond
 template <size_t Dim>
 void ConstitutiveRelation<Dim>::stress(
     const gsl::not_null<tnsr::IJ<DataVector, Dim>*> stress,
@@ -33,6 +32,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3))
 
 #undef DIM
 #undef INSTANTIATE
-/// \endcond
 
 }  // namespace Elasticity::ConstitutiveRelations

--- a/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/CubicCrystal.cpp
+++ b/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/CubicCrystal.cpp
@@ -58,9 +58,7 @@ double CubicCrystal::poisson_ratio() const noexcept {
   return 1. / (1. + (c_11_ / c_12_));
 }
 
-/// \cond
 PUP::able::PUP_ID CubicCrystal::my_PUP_ID = 0;
-/// \endcond
 
 void CubicCrystal::pup(PUP::er& p) noexcept {
   p | c_11_;

--- a/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.cpp
+++ b/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.cpp
@@ -106,7 +106,6 @@ bool operator!=(const IsotropicHomogeneous<Dim>& lhs,
   return not(lhs == rhs);
 }
 
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                \
@@ -123,6 +122,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3))
 #undef DIM
 #undef INSTANTIATE
 
-/// \endcond
 
 }  // namespace Elasticity::ConstitutiveRelations

--- a/src/PointwiseFunctions/Elasticity/PotentialEnergy.cpp
+++ b/src/PointwiseFunctions/Elasticity/PotentialEnergy.cpp
@@ -50,7 +50,6 @@ Scalar<DataVector> potential_energy_density(
   return result;
 }
 
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                        \
@@ -70,6 +69,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3))
 
 #undef DIM
 #undef INSTANTIATE
-/// \endcond
 
 }  // namespace Elasticity

--- a/src/PointwiseFunctions/Elasticity/Strain.cpp
+++ b/src/PointwiseFunctions/Elasticity/Strain.cpp
@@ -79,7 +79,6 @@ void strain(const gsl::not_null<tnsr::ii<DataVector, Dim>*> strain,
   Elasticity::strain(strain, displacement_gradient);
 }
 
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 
@@ -108,6 +107,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_DTYPE, (2, 3), (double, DataVector))
 
 #undef DIM
 #undef INSTANTIATE
-/// \endcond
 
 }  // namespace Elasticity

--- a/src/PointwiseFunctions/GeneralRelativity/Christoffel.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Christoffel.cpp
@@ -8,7 +8,6 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-/// \cond
 namespace gr {
 template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
 void christoffel_first_kind(
@@ -68,4 +67,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef FRAME
 #undef INDEXTYPE
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/DerivativesOfSpacetimeMetric.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/DerivativesOfSpacetimeMetric.cpp
@@ -8,7 +8,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace gr {
 template <size_t Dim, typename Frame, typename DataType>
 tnsr::abb<DataType, Dim, Frame> derivatives_of_spacetime_metric(
@@ -134,4 +133,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/ExtrinsicCurvature.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ExtrinsicCurvature.cpp
@@ -12,7 +12,6 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-/// \cond
 namespace gr {
 
 template <size_t SpatialDim, typename Frame, typename DataType>
@@ -89,4 +88,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/CovariantDerivOfExtrinsicCurvature.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/CovariantDerivOfExtrinsicCurvature.cpp
@@ -12,7 +12,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace GeneralizedHarmonic {
 template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::ijj<DataType, SpatialDim, Frame> covariant_deriv_of_extrinsic_curvature(
@@ -137,4 +136,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/DerivSpatialMetric.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/DerivSpatialMetric.cpp
@@ -13,7 +13,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace GeneralizedHarmonic {
 template <size_t SpatialDim, typename Frame, typename DataType>
 void deriv_spatial_metric(
@@ -64,4 +63,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ExtrinsicCurvature.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ExtrinsicCurvature.cpp
@@ -13,7 +13,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace GeneralizedHarmonic {
 template <size_t SpatialDim, typename Frame, typename DataType>
 void extrinsic_curvature(
@@ -76,4 +75,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/GaugeSource.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/GaugeSource.cpp
@@ -13,7 +13,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace GeneralizedHarmonic {
 template <size_t SpatialDim, typename Frame, typename DataType>
 void gauge_source(
@@ -117,4 +116,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Phi.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Phi.cpp
@@ -12,7 +12,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace GeneralizedHarmonic {
 template <size_t SpatialDim, typename Frame, typename DataType>
 void phi(const gsl::not_null<tnsr::iaa<DataType, SpatialDim, Frame>*> phi,
@@ -100,4 +99,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Pi.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Pi.cpp
@@ -12,7 +12,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace GeneralizedHarmonic {
 template <size_t SpatialDim, typename Frame, typename DataType>
 void pi(const gsl::not_null<tnsr::aa<DataType, SpatialDim, Frame>*> pi,
@@ -105,4 +104,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Ricci.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Ricci.cpp
@@ -14,7 +14,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace GeneralizedHarmonic {
 template <size_t VolumeDim, typename Frame, typename DataType>
 void spatial_ricci_tensor(
@@ -166,4 +165,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpacetimeDerivOfDetSpatialMetric.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpacetimeDerivOfDetSpatialMetric.cpp
@@ -17,7 +17,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace GeneralizedHarmonic {
 namespace {
 template <size_t SpatialDim, typename Frame, typename DataType>
@@ -142,4 +141,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpacetimeDerivOfNormOfShift.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpacetimeDerivOfNormOfShift.cpp
@@ -20,7 +20,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace GeneralizedHarmonic {
 namespace {
 template <size_t SpatialDim, typename Frame, typename DataType>
@@ -174,4 +173,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpacetimeDerivativeOfSpacetimeMetric.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpacetimeDerivativeOfSpacetimeMetric.cpp
@@ -13,7 +13,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace GeneralizedHarmonic {
 template <size_t SpatialDim, typename Frame, typename DataType>
 void spacetime_derivative_of_spacetime_metric(
@@ -56,4 +55,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfLapse.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfLapse.cpp
@@ -13,7 +13,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace GeneralizedHarmonic {
 template <size_t SpatialDim, typename Frame, typename DataType>
 void spatial_deriv_of_lapse(
@@ -78,4 +77,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfShift.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfShift.cpp
@@ -13,7 +13,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace GeneralizedHarmonic {
 
 template <size_t SpatialDim, typename Frame, typename DataType>
@@ -92,4 +91,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfLapse.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfLapse.cpp
@@ -13,7 +13,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace GeneralizedHarmonic {
 template <size_t SpatialDim, typename Frame, typename DataType>
 void time_deriv_of_lapse(
@@ -89,4 +88,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfLowerShift.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfLowerShift.cpp
@@ -19,7 +19,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace GeneralizedHarmonic {
 namespace {
 template <size_t SpatialDim, typename Frame, typename DataType>
@@ -139,4 +138,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfShift.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfShift.cpp
@@ -13,7 +13,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace GeneralizedHarmonic {
 template <size_t SpatialDim, typename Frame, typename DataType>
 void time_deriv_of_shift(
@@ -99,4 +98,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfSpatialMetric.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfSpatialMetric.cpp
@@ -13,7 +13,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace GeneralizedHarmonic {
 template <size_t SpatialDim, typename Frame, typename DataType>
 void time_deriv_of_spatial_metric(
@@ -78,4 +77,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivativeOfSpacetimeMetric.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivativeOfSpacetimeMetric.cpp
@@ -13,7 +13,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace GeneralizedHarmonic {
 template <size_t SpatialDim, typename Frame, typename DataType>
 void time_derivative_of_spacetime_metric(
@@ -74,4 +73,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/IndexManipulation.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/IndexManipulation.cpp
@@ -8,7 +8,6 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
-/// \cond
 template <typename X, typename Symm, typename IndexList>
 class Tensor;
 
@@ -182,4 +181,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE2, (1, 2, 3), (double, DataVector),
 #undef INDEXTYPE0
 #undef INDEX0
 #undef INSTANTIATE2
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/InterfaceNullNormal.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/InterfaceNullNormal.cpp
@@ -10,7 +10,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace gr {
 template <size_t VolumeDim, typename Frame, typename DataType>
 tnsr::a<DataType, VolumeDim, Frame> interface_null_normal(
@@ -129,4 +128,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/InverseSpacetimeMetric.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/InverseSpacetimeMetric.cpp
@@ -12,7 +12,6 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-/// \cond
 namespace gr {
 template <size_t Dim, typename Frame, typename DataType>
 tnsr::AA<DataType, Dim, Frame> inverse_spacetime_metric(
@@ -75,4 +74,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/KerrSchildCoords.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/KerrSchildCoords.cpp
@@ -18,7 +18,6 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-/// \cond
 namespace gr {
 
 KerrSchildCoords::KerrSchildCoords(const double bh_mass,
@@ -147,4 +146,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
 #undef INSTANTIATE
 
 }  // namespace gr
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/Lapse.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Lapse.cpp
@@ -12,7 +12,6 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-/// \cond
 namespace gr {
 template <size_t SpatialDim, typename Frame, typename DataType>
 Scalar<DataType> lapse(
@@ -59,4 +58,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/ProjectionOperators.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ProjectionOperators.cpp
@@ -8,7 +8,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace gr {
 template <size_t VolumeDim, typename Frame, typename DataType>
 tnsr::II<DataType, VolumeDim, Frame> transverse_projection_operator(
@@ -328,4 +327,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/Ricci.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Ricci.cpp
@@ -9,7 +9,6 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-/// \cond
 namespace gr {
 template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
 void ricci_tensor(
@@ -83,4 +82,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef FRAME
 #undef INDEXTYPE
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/Shift.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Shift.cpp
@@ -12,7 +12,6 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-/// \cond
 namespace gr {
 template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::I<DataType, SpatialDim, Frame> shift(
@@ -65,4 +64,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/SpacetimeMetric.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/SpacetimeMetric.cpp
@@ -10,7 +10,6 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-/// \cond
 namespace gr {
 template <size_t Dim, typename Frame, typename DataType>
 void spacetime_metric(
@@ -81,4 +80,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/SpacetimeNormalOneForm.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/SpacetimeNormalOneForm.cpp
@@ -12,7 +12,6 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-/// \cond
 namespace gr {
 template <size_t SpatialDim, typename Frame, typename DataType>
 void spacetime_normal_one_form(
@@ -53,4 +52,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.cpp
@@ -12,7 +12,6 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-/// \cond
 namespace gr {
 template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::A<DataType, SpatialDim, Frame> spacetime_normal_vector(
@@ -62,4 +61,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/SpatialMetric.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/SpatialMetric.cpp
@@ -12,7 +12,6 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-/// \cond
 namespace gr {
 template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::ii<DataType, SpatialDim, Frame> spatial_metric(
@@ -58,4 +57,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/TimeDerivativeOfSpacetimeMetric.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/TimeDerivativeOfSpacetimeMetric.cpp
@@ -12,7 +12,6 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-/// \cond
 namespace gr {
 template <size_t SpatialDim, typename Frame, typename DataType>
 void time_derivative_of_spacetime_metric(
@@ -97,4 +96,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/WeylElectric.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/WeylElectric.cpp
@@ -10,7 +10,6 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-/// \cond
 namespace gr {
 template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::ii<DataType, SpatialDim, Frame> weyl_electric(
@@ -130,4 +129,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/WeylPropagating.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/WeylPropagating.cpp
@@ -16,7 +16,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace gr {
 template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::ii<DataType, SpatialDim, Frame> weyl_propagating(
@@ -141,4 +140,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.cpp
@@ -10,7 +10,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace EquationsOfState {
 template <bool IsRelativistic>
 DarkEnergyFluid<IsRelativistic>::DarkEnergyFluid(
@@ -98,4 +97,3 @@ Scalar<DataType> DarkEnergyFluid<IsRelativistic>::
 }  // namespace EquationsOfState
 
 template class EquationsOfState::DarkEnergyFluid<true>;
-/// \endcond

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.cpp
@@ -9,7 +9,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace EquationsOfState {
 template <bool IsRelativistic>
 IdealFluid<IsRelativistic>::IdealFluid(const double adiabatic_index) noexcept
@@ -110,4 +109,3 @@ Scalar<DataType> IdealFluid<IsRelativistic>::
 
 template class EquationsOfState::IdealFluid<true>;
 template class EquationsOfState::IdealFluid<false>;
-/// \endcond

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.cpp
@@ -9,7 +9,6 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace EquationsOfState {
 template <bool IsRelativistic>
 PolytropicFluid<IsRelativistic>::PolytropicFluid(
@@ -112,4 +111,3 @@ Scalar<DataType> PolytropicFluid<IsRelativistic>::
 
 template class EquationsOfState::PolytropicFluid<true>;
 template class EquationsOfState::PolytropicFluid<false>;
-/// \endcond

--- a/src/PointwiseFunctions/Hydro/LorentzFactor.cpp
+++ b/src/PointwiseFunctions/Hydro/LorentzFactor.cpp
@@ -11,7 +11,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace hydro {
 template <typename DataType>
 void lorentz_factor(const gsl::not_null<Scalar<DataType>*> result,
@@ -82,4 +81,3 @@ template Scalar<double> lorentz_factor(
 #undef FRAME
 #undef INSTANTIATE
 }  // namespace hydro
-/// \endcond

--- a/src/PointwiseFunctions/Hydro/MassFlux.cpp
+++ b/src/PointwiseFunctions/Hydro/MassFlux.cpp
@@ -10,7 +10,6 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-/// \cond
 namespace hydro {
 
 template <typename DataType, size_t Dim, typename Frame>
@@ -71,4 +70,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
 #undef FRAME
 #undef INSTANTIATE
 }  // namespace hydro
-/// \endcond

--- a/src/PointwiseFunctions/Hydro/SoundSpeedSquared.cpp
+++ b/src/PointwiseFunctions/Hydro/SoundSpeedSquared.cpp
@@ -12,7 +12,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace hydro {
 
 template <typename DataType, size_t ThermodynamicDim>
@@ -78,4 +77,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector), (1, 2))
 #undef THERMO_DIM
 #undef INSTANTIATE
 }  // namespace hydro
-/// \endcond

--- a/src/PointwiseFunctions/Hydro/SpecificEnthalpy.cpp
+++ b/src/PointwiseFunctions/Hydro/SpecificEnthalpy.cpp
@@ -9,7 +9,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace hydro {
 template <typename DataType>
 void relativistic_specific_enthalpy(
@@ -51,4 +50,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
 #undef DTYPE
 #undef INSTANTIATE
 }  // namespace hydro
-/// \endcond

--- a/src/PointwiseFunctions/MathFunctions/Gaussian.cpp
+++ b/src/PointwiseFunctions/MathFunctions/Gaussian.cpp
@@ -263,7 +263,6 @@ void Gaussian<VolumeDim, Fr>::pup(PUP::er& p) {
 }
 }  // namespace MathFunctions
 
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define INSTANTIATE(_, data)                                          \
@@ -347,4 +346,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (Frame::Grid, Frame::Inertial),
 #undef FRAME
 #undef INSTANTIATE
 
-/// \endcond

--- a/src/PointwiseFunctions/MathFunctions/PowX.cpp
+++ b/src/PointwiseFunctions/MathFunctions/PowX.cpp
@@ -86,7 +86,6 @@ void PowX<1, Fr>::pup(PUP::er& p) {
   p | power_;
 }
 
-/// \cond
 template MathFunctions::PowX<1, Frame::Grid>::PowX(const int power) noexcept;
 template MathFunctions::PowX<1, Frame::Inertial>::PowX(
     const int power) noexcept;
@@ -125,5 +124,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (Frame::Grid, Frame::Inertial),
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond
 }  // namespace MathFunctions

--- a/src/PointwiseFunctions/MathFunctions/Sinusoid.cpp
+++ b/src/PointwiseFunctions/MathFunctions/Sinusoid.cpp
@@ -87,7 +87,6 @@ void Sinusoid<1, Fr>::pup(PUP::er& p) {
 }
 }  // namespace MathFunctions
 
-/// \cond
 template MathFunctions::Sinusoid<1, Frame::Grid>::Sinusoid(
     const double amplitude, const double wavenumber,
     const double phase) noexcept;
@@ -128,4 +127,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (Frame::Grid, Frame::Inertial),
 #undef FRAME
 #undef INSTANTIATE
 
-/// \endcond

--- a/src/PointwiseFunctions/MathFunctions/TensorProduct.cpp
+++ b/src/PointwiseFunctions/MathFunctions/TensorProduct.cpp
@@ -75,7 +75,6 @@ tnsr::ii<T, Dim> TensorProduct<Dim>::second_derivatives(
 
 }  // namespace MathFunctions
 
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 
@@ -108,4 +107,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 #undef DIM
 #undef DTYPE
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/SpecialRelativity/LorentzBoostMatrix.cpp
+++ b/src/PointwiseFunctions/SpecialRelativity/LorentzBoostMatrix.cpp
@@ -61,7 +61,6 @@ void lorentz_boost_matrix(
 }  // namespace sr
 
 // Explicit Instantiations
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                \
@@ -79,4 +78,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 #undef DTYPE
 #undef FRAME
 #undef INSTANTIATE
-/// \endcond

--- a/src/PointwiseFunctions/Xcts/LongitudinalOperator.cpp
+++ b/src/PointwiseFunctions/Xcts/LongitudinalOperator.cpp
@@ -13,7 +13,6 @@
 
 namespace Xcts {
 
-/// \cond
 template <typename DataType>
 void longitudinal_operator(const gsl::not_null<tnsr::II<DataType, 3>*> result,
                            const tnsr::ii<DataType, 3>& strain,
@@ -82,6 +81,5 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
 
 #undef DTYPE
 #undef INSTANTIATE
-/// \endcond
 
 }  // namespace Xcts

--- a/src/PythonBindings/CharmCompatibility.cpp
+++ b/src/PythonBindings/CharmCompatibility.cpp
@@ -15,7 +15,6 @@
 // linked is non-trivial since Charm++ generally wants you to use their `charmc`
 // script, but we want to avoid that.
 
-/// \cond
 
 __attribute__ ((format (printf, 1, 2)))
 // NOLINTNEXTLINE(cert-dcl50-cpp)
@@ -172,4 +171,3 @@ void pup_bytes(pup_er /*p*/, void* /*ptr*/, size_t /*nBytes*/) {
 
 #pragma GCC diagnostic pop
 
-/// \endcond

--- a/src/Time/TimeSequence.cpp
+++ b/src/Time/TimeSequence.cpp
@@ -50,10 +50,8 @@ void EvenlySpaced<T>::pup(PUP::er& p) noexcept {
   p | offset_;
 }
 
-/// \cond
 template <typename T>
 PUP::able::PUP_ID EvenlySpaced<T>::my_PUP_ID = 0;  // NOLINT
-/// \endcond
 
 template <typename T>
 Specified<T>::Specified(std::vector<T> values) noexcept
@@ -90,10 +88,8 @@ void Specified<T>::pup(PUP::er& p) noexcept {
   p | values_;
 }
 
-/// \cond
 template <typename T>
 PUP::able::PUP_ID Specified<T>::my_PUP_ID = 0;  // NOLINT
-/// \endcond
 
 // For time values
 template class EvenlySpaced<double>;

--- a/src/Time/TimeSteppers/AdamsBashforthN.cpp
+++ b/src/Time/TimeSteppers/AdamsBashforthN.cpp
@@ -148,7 +148,5 @@ bool operator!=(const AdamsBashforthN& lhs,
 }
 }  // namespace TimeSteppers
 
-/// \cond
 PUP::able::PUP_ID TimeSteppers::AdamsBashforthN::my_PUP_ID =  // NOLINT
     0;
-/// \endcond

--- a/src/Time/TimeSteppers/DormandPrince5.cpp
+++ b/src/Time/TimeSteppers/DormandPrince5.cpp
@@ -100,7 +100,5 @@ const std::array<Time::rational_t, 6> DormandPrince5::c_ = {
     {{1, 5}, {3, 10}, {4, 5}, {8, 9}, {1, 1}, {1, 1}}};
 }  // namespace TimeSteppers
 
-/// \cond
 PUP::able::PUP_ID TimeSteppers::DormandPrince5::my_PUP_ID =  // NOLINT
     0;
-/// \endcond

--- a/src/Time/TimeSteppers/RungeKutta3.cpp
+++ b/src/Time/TimeSteppers/RungeKutta3.cpp
@@ -60,7 +60,5 @@ TimeStepId RungeKutta3::next_time_id_for_error(
 }
 }  // namespace TimeSteppers
 
-/// \cond
 PUP::able::PUP_ID TimeSteppers::RungeKutta3::my_PUP_ID =  // NOLINT
     0;
-/// \endcond

--- a/src/Time/TimeSteppers/RungeKutta4.cpp
+++ b/src/Time/TimeSteppers/RungeKutta4.cpp
@@ -108,7 +108,5 @@ TimeStepId RungeKutta4::next_time_id_for_error(
 }
 }  // namespace TimeSteppers
 
-/// \cond
 PUP::able::PUP_ID TimeSteppers::RungeKutta4::my_PUP_ID =  // NOLINT
     0;
-/// \endcond

--- a/src/Utilities/TMPL.hpp
+++ b/src/Utilities/TMPL.hpp
@@ -24,6 +24,7 @@
 #include "Utilities/TmplDigraph.hpp"  // IWYU pragma: export
 
 namespace brigand {
+/// \cond
 namespace detail {
 template <bool b, typename O, typename L, std::size_t I, typename R,
           typename U = void>
@@ -65,6 +66,7 @@ struct call_replace_at_impl
     : replace_at_impl<(I::value > 15), brigand::clear<L>, L, I::value + 1, R> {
 };
 }  // namespace detail
+/// \endcond
 
 namespace lazy {
 template <typename L, typename I, typename R>

--- a/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
@@ -66,7 +66,6 @@
 #include "Utilities/TaggedTuple.hpp"
 
 // IWYU pragma: no_forward_declare Tensor
-/// \cond
 namespace Parallel {
 template <typename Metavariables>
 class GlobalCache;
@@ -87,7 +86,6 @@ namespace db {
 template <typename TagsList>
 class DataBox;
 }  // namespace db
-/// \endcond
 
 namespace {
 

--- a/tests/Unit/ApparentHorizons/Test_ChangeCenterOfStrahlkorper.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ChangeCenterOfStrahlkorper.cpp
@@ -13,11 +13,9 @@
 #include "Framework/TestHelpers.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace Frame {
 struct Inertial;
 }  // namespace Frame
-/// \endcond
 
 namespace {
 

--- a/tests/Unit/ApparentHorizons/Test_SpherepackIterator.cpp
+++ b/tests/Unit/ApparentHorizons/Test_SpherepackIterator.cpp
@@ -23,7 +23,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.SpherepackIterator",
                                           50,  55,  60,  65,  70, 95, 110,
                                           115, 125, 130, 140, 145};
 
-  /// [spherepack_iterator_example]
+  // [spherepack_iterator_example]
   const size_t l_max = 4;
   const size_t m_max = 2;
   const size_t stride = 5;
@@ -43,7 +43,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.SpherepackIterator",
     CHECK(iter.m() == test_m[i]);
     CHECK(iter() == test_index[i]);
   }
-  /// [spherepack_iterator_example]
+  // [spherepack_iterator_example]
   CHECK(iter.l_max() == 4);
   CHECK(iter.m_max() == 2);
   CHECK(iter.n_th() == 5);

--- a/tests/Unit/ApparentHorizons/Test_Strahlkorper.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Strahlkorper.cpp
@@ -21,11 +21,9 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
-/// \cond
 namespace Frame {
 struct Inertial;
 }  // namespace Frame
-/// \endcond
 
 namespace {
 

--- a/tests/Unit/ArchitectureVectorization/TestArchitectureVectorization.cpp
+++ b/tests/Unit/ArchitectureVectorization/TestArchitectureVectorization.cpp
@@ -31,4 +31,4 @@ RunTests::RunTests(CkArgMsg* msg) {
   sys::abort("A catch test has failed.");
 }
 
-#include "tests/Unit/RunTests.def.h"  /// IWYU pragma: keep
+#include "tests/Unit/RunTests.def.h"

--- a/tests/Unit/DataStructures/DataBox/Test_BaseTags.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_BaseTags.cpp
@@ -20,7 +20,7 @@
 
 namespace {
 namespace TestTags {
-/// [vector_base_definitions]
+// [vector_base_definitions]
 template <int I>
 struct VectorBase : db::BaseTag {};
 
@@ -28,9 +28,9 @@ template <int I>
 struct Vector : db::SimpleTag, VectorBase<I> {
   using type = std::vector<double>;
 };
-/// [vector_base_definitions]
+// [vector_base_definitions]
 
-/// [array_base_definitions]
+// [array_base_definitions]
 template <int I>
 struct ArrayBase : db::BaseTag {};
 
@@ -38,9 +38,9 @@ template <int I, size_t Size = 3>
 struct Array : db::SimpleTag, ArrayBase<I> {
   using type = std::array<int, Size>;
 };
-/// [array_base_definitions]
+// [array_base_definitions]
 
-/// [compute_template_base_tags]
+// [compute_template_base_tags]
 template <int I, int VectorBaseIndex = 0, int... VectorBaseExtraIndices>
 struct ArrayCompute : Array<I, sizeof...(VectorBaseExtraIndices) == 0
                                    ? 3
@@ -68,7 +68,7 @@ struct ArrayCompute : Array<I, sizeof...(VectorBaseExtraIndices) == 0
   using argument_tags = tmpl::list<VectorBase<VectorBaseIndex>,
                                    VectorBase<VectorBaseExtraIndices>...>;
 };
-/// [compute_template_base_tags]
+// [compute_template_base_tags]
 }  // namespace TestTags
 
 void test_non_subitems() {
@@ -78,7 +78,7 @@ void test_non_subitems() {
   // - using a base tag as the argument in a compute item
   // - `get`ing a compute item by base tag
   // - `get`ing a compute item by its simple tag
-  /// [base_simple_and_compute_mutate]
+  // [base_simple_and_compute_mutate]
   auto box = db::create<db::AddSimpleTags<TestTags::Vector<0>>,
                         db::AddComputeTags<TestTags::ArrayCompute<0>>>(
       std::vector<double>{-10.0, 10.0});
@@ -106,7 +106,7 @@ void test_non_subitems() {
   CHECK(db::get<TestTags::Array<0>>(box) == std::array<int, 3>{{2, 101, -8}});
   CHECK(db::get<TestTags::ArrayCompute<0>>(box) ==
         std::array<int, 3>{{2, 101, -8}});
-  /// [base_simple_and_compute_mutate]
+  // [base_simple_and_compute_mutate]
 
   // - adding compute item that uses a base tag as its argument
   auto box2 = db::create_from<db::RemoveTags<>, db::AddSimpleTags<>,
@@ -156,7 +156,7 @@ void test_non_subitems() {
         std::vector<double>{408.8, -73.2});
 
   // - removing a compute item and its dependencies by the base tags
-  /// [remove_using_base]
+  // [remove_using_base]
   const auto& box6 = db::create_from<
       db::RemoveTags<TestTags::VectorBase<1>, TestTags::VectorBase<2>,
                      TestTags::ArrayBase<1>>>(
@@ -168,7 +168,7 @@ void test_non_subitems() {
                      db::AddComputeTags<TestTags::ArrayCompute<0>>>(
               std::vector<double>{101.8, 10.0}),
           std::vector<double>{-7.1, 8.9}, std::vector<double>{408.8, -73.2}));
-  /// [remove_using_base]
+  // [remove_using_base]
   CHECK(db::get<TestTags::VectorBase<0>>(box6) ==
         std::vector<double>{101.8, 10.0});
   CHECK(db::get<TestTags::ArrayBase<0>>(box6) ==

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -58,11 +58,11 @@ void append_word(const gsl::not_null<std::string*> result,
 }
 
 namespace test_databox_tags {
-/// [databox_tag_example]
+// [databox_tag_example]
 struct Tag0 : db::SimpleTag {
   using type = double;
 };
-/// [databox_tag_example]
+// [databox_tag_example]
 struct Tag1 : db::SimpleTag {
   using type = std::vector<double>;
 };
@@ -110,7 +110,7 @@ struct Tag6Compute : Tag6, db::ComputeTag {
   using argument_tags = tmpl::list<Tag2Base>;
 };
 
-/// [compute_item_tag_function]
+// [compute_item_tag_function]
 struct Lambda0 : db::SimpleTag {
   using type = double;
 };
@@ -124,13 +124,13 @@ struct Lambda0Compute : Lambda0, db::ComputeTag {
   }
   using argument_tags = tmpl::list<Tag0>;
 };
-/// [compute_item_tag_function]
+// [compute_item_tag_function]
 
 struct Lambda1 : db::SimpleTag {
   using type = double;
 };
 
-/// [compute_item_tag_no_tags]
+// [compute_item_tag_no_tags]
 struct Lambda1Compute : Lambda1, db::ComputeTag {
   using base = Lambda1;
   using return_type = double;
@@ -139,9 +139,9 @@ struct Lambda1Compute : Lambda1, db::ComputeTag {
   }
   using argument_tags = tmpl::list<>;
 };
-/// [compute_item_tag_no_tags]
+// [compute_item_tag_no_tags]
 
-/// [databox_prefix_tag_example]
+// [databox_prefix_tag_example]
 template <typename Tag>
 struct TagPrefix : db::PrefixTag, db::SimpleTag {
   using type = typename Tag::type;
@@ -150,7 +150,7 @@ struct TagPrefix : db::PrefixTag, db::SimpleTag {
     return "TagPrefix(" + db::tag_name<Tag>() + ")";
   }
 };
-/// [databox_prefix_tag_example]
+// [databox_prefix_tag_example]
 
 struct PointerBase : db::BaseTag {};
 
@@ -229,7 +229,7 @@ static_assert(std::is_same<decltype(db::create_from<db::RemoveTags<>>(Box_t{})),
 void test_databox() noexcept {
   INFO("test databox");
   const auto create_original_box = []() {
-    /// [create_databox]
+    // [create_databox]
     auto original_box = db::create<
         db::AddSimpleTags<test_databox_tags::Tag0, test_databox_tags::Tag1,
                           test_databox_tags::Tag2>,
@@ -238,7 +238,7 @@ void test_databox() noexcept {
                            test_databox_tags::Lambda0Compute,
                            test_databox_tags::Lambda1Compute>>(
         3.14, std::vector<double>{8.7, 93.2, 84.7}, "My Sample String"s);
-    /// [create_databox]
+    // [create_databox]
     return original_box;
   };
   {
@@ -255,9 +255,9 @@ void test_databox() noexcept {
                            test_databox_tags::Lambda1Compute>>>>>::value,
         "Failed to create original_box");
 
-    /// [using_db_get]
+    // [using_db_get]
     const auto& tag0 = db::get<test_databox_tags::Tag0>(original_box);
-    /// [using_db_get]
+    // [using_db_get]
     CHECK(tag0 == 3.14);
     // Check retrieving chained compute item result
     CHECK(db::get<test_databox_tags::Tag5>(original_box) ==
@@ -275,23 +275,23 @@ void test_databox() noexcept {
     CHECK(db::get<test_databox_tags::Lambda0>(box) == 3.0 * 3.14);
   }
   {
-    /// [create_from_remove]
+    // [create_from_remove]
     auto original_box = create_original_box();
     const auto& box = db::create_from<db::RemoveTags<test_databox_tags::Tag1>>(
         std::move(original_box));
-    /// [create_from_remove]
+    // [create_from_remove]
     CHECK(db::get<test_databox_tags::Tag2>(box) == "My Sample String"s);
     CHECK(db::get<test_databox_tags::Tag5>(box) == "My Sample String6.28"s);
     CHECK(db::get<test_databox_tags::Lambda0>(box) == 3.0 * 3.14);
   }
   {
-    /// [create_from_add_item]
+    // [create_from_add_item]
     auto original_box = create_original_box();
     const auto& box =
         db::create_from<db::RemoveTags<>,
                         db::AddSimpleTags<test_databox_tags::Tag3>>(
             std::move(original_box), "Yet another test string"s);
-    /// [create_from_add_item]
+    // [create_from_add_item]
     CHECK(db::get<test_databox_tags::Tag3>(box) == "Yet another test string"s);
     CHECK(db::get<test_databox_tags::Tag2>(box) == "My Sample String"s);
     // Check retrieving compute item result
@@ -299,7 +299,7 @@ void test_databox() noexcept {
     CHECK(db::get<test_databox_tags::Lambda0>(box) == 3.0 * 3.14);
   }
   {
-    /// [create_from_add_compute_item]
+    // [create_from_add_compute_item]
     auto simple_box = db::create<
         db::AddSimpleTags<test_databox_tags::Tag0, test_databox_tags::Tag1,
                           test_databox_tags::Tag2>>(
@@ -308,7 +308,7 @@ void test_databox() noexcept {
         db::create_from<db::RemoveTags<>, db::AddSimpleTags<>,
                         db::AddComputeTags<test_databox_tags::Tag4Compute>>(
             std::move(simple_box));
-    /// [create_from_add_compute_item]
+    // [create_from_add_compute_item]
     CHECK(db::get<test_databox_tags::Tag2>(box) == "My Sample String"s);
     // Check retrieving compute item result
     CHECK(db::get<test_databox_tags::Tag4>(box) == 6.28);
@@ -454,13 +454,13 @@ void test_get_databox() noexcept {
       3.14, std::vector<double>{8.7, 93.2, 84.7}, "My Sample String"s);
   CHECK(std::addressof(original_box) ==
         std::addressof(db::get<Tags::DataBox>(original_box)));
-  /// [databox_self_tag_example]
+  // [databox_self_tag_example]
   auto check_result_no_args = [](const auto& box) {
     CHECK(db::get<test_databox_tags::Tag2>(box) == "My Sample String"s);
     CHECK(db::get<test_databox_tags::Tag5>(box) == "My Sample String6.28"s);
   };
   db::apply<tmpl::list<Tags::DataBox>>(check_result_no_args, original_box);
-  /// [databox_self_tag_example]
+  // [databox_self_tag_example]
 }
 }  // namespace
 
@@ -497,7 +497,7 @@ void test_mutate() noexcept {
       3.14, std::vector<double>{8.7, 93.2, 84.7}, "My Sample String"s,
       std::make_unique<int>(3));
   CHECK(approx(db::get<test_databox_tags::Tag4>(original_box)) == 3.14 * 2.0);
-  /// [databox_mutate_example]
+  // [databox_mutate_example]
   db::mutate<test_databox_tags::Tag0, test_databox_tags::Tag1>(
       make_not_null(&original_box),
       [](const gsl::not_null<double*> tag0,
@@ -510,7 +510,7 @@ void test_mutate() noexcept {
       db::get<test_databox_tags::Tag4>(original_box));
   CHECK(10.32 == db::get<test_databox_tags::Tag0>(original_box));
   CHECK(837.2 == db::get<test_databox_tags::Tag1>(original_box)[0]);
-  /// [databox_mutate_example]
+  // [databox_mutate_example]
   CHECK(approx(db::get<test_databox_tags::Tag4>(original_box)) == 10.32 * 2.0);
 
   auto result = db::mutate<test_databox_tags::Tag0>(
@@ -630,7 +630,7 @@ void test_apply() noexcept {
   db::apply<tmpl::list<test_databox_tags::Tag2Base, test_databox_tags::Tag5>>(
       check_result_no_args, original_box);
 
-  /// [apply_example]
+  // [apply_example]
   auto check_result_args = [](const std::string& sample_string,
                               const auto& computed_string, const auto& vector) {
     CHECK(sample_string == "My Sample String"s);
@@ -640,11 +640,11 @@ void test_apply() noexcept {
   db::apply<tmpl::list<test_databox_tags::Tag2, test_databox_tags::Tag5>>(
       check_result_args, original_box,
       db::get<test_databox_tags::Tag1>(original_box));
-  /// [apply_example]
+  // [apply_example]
 
   db::apply<tmpl::list<>>(NonCopyableFunctor{}, original_box);
 
-  /// [apply_struct_example]
+  // [apply_struct_example]
   struct ApplyCallable {
     static void apply(const std::string& sample_string,
                       const std::string& computed_string,
@@ -657,11 +657,11 @@ void test_apply() noexcept {
   db::apply<tmpl::list<test_databox_tags::Tag2, test_databox_tags::Tag5>>(
       ApplyCallable{}, original_box,
       db::get<test_databox_tags::Tag1>(original_box));
-  /// [apply_struct_example]
+  // [apply_struct_example]
   db::apply<tmpl::list<test_databox_tags::Tag2Base, test_databox_tags::Tag5>>(
       ApplyCallable{}, original_box,
       db::get<test_databox_tags::Tag1>(original_box));
-  /// [apply_stateless_struct_example]
+  // [apply_stateless_struct_example]
   struct StatelessApplyCallable {
     using argument_tags =
         tmpl::list<test_databox_tags::Tag2, test_databox_tags::Tag5>;
@@ -675,7 +675,7 @@ void test_apply() noexcept {
   };
   db::apply<StatelessApplyCallable>(
       original_box, db::get<test_databox_tags::Tag1>(original_box));
-  /// [apply_stateless_struct_example]
+  // [apply_stateless_struct_example]
   db::apply(StatelessApplyCallable{}, original_box,
             db::get<test_databox_tags::Tag1>(original_box));
 
@@ -1235,7 +1235,7 @@ void test_variables_extra_reset() noexcept {
   CHECK(db::get<ExtraResetTags::CheckReset>(box) == 0);
 }
 
-/// [mutate_apply_struct_definition_example]
+// [mutate_apply_struct_definition_example]
 struct TestDataboxMutateApply {
   // delete copy semantics just to make sure it works. Not necessary in general.
   TestDataboxMutateApply() = default;
@@ -1261,7 +1261,7 @@ struct TestDataboxMutateApply {
     CHECK(tag2 == "My Sample String"s);
   }
 };
-/// [mutate_apply_struct_definition_example]
+// [mutate_apply_struct_definition_example]
 
 struct TestDataboxMutateApplyBase {
   using return_tags = tmpl::list<test_databox_tags::ScalarTag>;
@@ -1326,9 +1326,9 @@ void test_mutate_apply() noexcept {
 
   {
     INFO("Apply function or lambda");
-    /// [mutate_apply_struct_example_stateful]
+    // [mutate_apply_struct_example_stateful]
     db::mutate_apply(TestDataboxMutateApply{}, make_not_null(&box));
-    /// [mutate_apply_struct_example_stateful]
+    // [mutate_apply_struct_example_stateful]
     db::mutate_apply(TestDataboxMutateApplyBase{}, make_not_null(&box));
 
     CHECK(approx(db::get<test_databox_tags::Tag4>(box)) == 3.14 * 2.0);
@@ -1341,7 +1341,7 @@ void test_mutate_apply() noexcept {
           Scalar<DataVector>(DataVector(2, 12.)));
     CHECK(db::get<test_databox_tags::VectorTag2>(box) ==
           (tnsr::I<DataVector, 3>(DataVector(2, 2.))));
-    /// [mutate_apply_lambda_example]
+    // [mutate_apply_lambda_example]
     db::mutate_apply<
         tmpl::list<test_databox_tags::ScalarTag, test_databox_tags::VectorTag>,
         tmpl::list<test_databox_tags::Tag2>>(
@@ -1355,7 +1355,7 @@ void test_mutate_apply() noexcept {
           CHECK(tag2 == "My Sample String"s);
         },
         make_not_null(&box));
-    /// [mutate_apply_lambda_example]
+    // [mutate_apply_lambda_example]
     db::mutate_apply<tmpl::list<test_databox_tags::ScalarTag>,
                      tmpl::list<test_databox_tags::Tag2Base>>(
         [](const gsl::not_null<Scalar<DataVector>*> scalar,
@@ -1417,9 +1417,9 @@ void test_mutate_apply() noexcept {
 
   {
     INFO("Stateless struct with tags lists");
-    /// [mutate_apply_struct_example_stateless]
+    // [mutate_apply_struct_example_stateless]
     db::mutate_apply<TestDataboxMutateApply>(make_not_null(&box));
-    /// [mutate_apply_struct_example_stateless]
+    // [mutate_apply_struct_example_stateless]
     CHECK(approx(db::get<test_databox_tags::Tag4>(box)) == 3.14 * 2.0);
     CHECK(db::get<test_databox_tags::ScalarTag>(box) ==
           Scalar<DataVector>(DataVector(2, 48.)));
@@ -1505,7 +1505,7 @@ void multiply_by_two_mutate(const gsl::not_null<std::vector<double>*> t,
   }
 }
 
-/// [databox_mutating_compute_item_function]
+// [databox_mutating_compute_item_function]
 void mutate_variables(
     const gsl::not_null<Variables<tmpl::list<test_databox_tags::ScalarTag,
                                              test_databox_tags::VectorTag>>*>
@@ -1523,7 +1523,7 @@ void mutate_variables(
     p = 3.0 * value;
   }
 }
-/// [databox_mutating_compute_item_function]
+// [databox_mutating_compute_item_function]
 
 namespace test_databox_tags {
 struct MutateTag0 : db::SimpleTag {
@@ -1542,7 +1542,7 @@ struct MutateVariables : db::SimpleTag {
       tmpl::list<test_databox_tags::ScalarTag, test_databox_tags::VectorTag>>;
 };
 
-/// [databox_mutating_compute_item_tag]
+// [databox_mutating_compute_item_tag]
 struct MutateVariablesCompute : MutateVariables, db::ComputeTag {
   using base = MutateVariables;
   static constexpr auto function = mutate_variables;
@@ -1550,7 +1550,7 @@ struct MutateVariablesCompute : MutateVariables, db::ComputeTag {
       tmpl::list<test_databox_tags::ScalarTag, test_databox_tags::VectorTag>>;
   using argument_tags = tmpl::list<Tag0>;
 };
-/// [databox_mutating_compute_item_tag]
+// [databox_mutating_compute_item_tag]
 }  // namespace test_databox_tags
 
 void test_mutating_compute_item() noexcept {
@@ -1710,10 +1710,10 @@ void test_data_on_slice_single() noexcept {
     }
   }
   CHECK(
-      /// [data_on_slice]
+      // [data_on_slice]
       db::data_on_slice(box, extents, 0, x_offset,
                         tmpl::list<DataBoxTest_detail::vector>{})
-      /// [data_on_slice]
+      // [data_on_slice]
       == expected_vars_sliced_in_x);
   CHECK(db::data_on_slice(box, extents, 1, y_offset,
                           tmpl::list<DataBoxTest_detail::vector>{}) ==
@@ -2008,7 +2008,7 @@ struct OverloadType : db::SimpleTag {
   using type = double;
 };
 
-/// [overload_compute_tag_type]
+// [overload_compute_tag_type]
 template <typename ArgumentTag>
 struct OverloadTypeCompute : OverloadType<ArgumentTag>, db::ComputeTag {
   using base = OverloadType<ArgumentTag>;
@@ -2024,14 +2024,14 @@ struct OverloadTypeCompute : OverloadType<ArgumentTag>, db::ComputeTag {
   }
   using argument_tags = tmpl::list<ArgumentTag>;
 };
-/// [overload_compute_tag_type]
+// [overload_compute_tag_type]
 
 template <typename ArgumentTag0, typename ArgumentTag1 = void>
 struct OverloadNumberOfArgs : db::SimpleTag {
   using type = double;
 };
 
-/// [overload_compute_tag_number_of_args]
+// [overload_compute_tag_number_of_args]
 template <typename ArgumentTag0, typename ArgumentTag1 = void>
 struct OverloadNumberOfArgsCompute
     : OverloadNumberOfArgs<ArgumentTag0, ArgumentTag1>,
@@ -2054,14 +2054,14 @@ struct OverloadNumberOfArgsCompute
                           tmpl::list<ArgumentTag0>,
                           tmpl::list<ArgumentTag0, ArgumentTag1>>;
 };
-/// [overload_compute_tag_number_of_args]
+// [overload_compute_tag_number_of_args]
 
 template <typename ArgumentTag>
 struct Template : db::SimpleTag {
   using type = typename ArgumentTag::type;
 };
 
-/// [overload_compute_tag_template]
+// [overload_compute_tag_template]
 template <typename ArgumentTag>
 struct TemplateCompute : Template<ArgumentTag>, db::ComputeTag {
   using base = Template<ArgumentTag>;
@@ -2075,7 +2075,7 @@ struct TemplateCompute : Template<ArgumentTag>, db::ComputeTag {
 
   using argument_tags = tmpl::list<ArgumentTag>;
 };
-/// [overload_compute_tag_template]
+// [overload_compute_tag_template]
 }  // namespace test_databox_tags
 
 void test_overload_compute_tags() noexcept {
@@ -2630,7 +2630,7 @@ void serialization_of_pointers() noexcept {
 }
 
 namespace test_databox_tags {
-/// [databox_reference_tag_example]
+// [databox_reference_tag_example]
 template <typename... Tags>
 struct TaggedTuple : db::SimpleTag {
   using type = tuples::TaggedTuple<Tags...>;
@@ -2647,7 +2647,7 @@ struct FromTaggedTuple : Tag, db::ReferenceTag {
 
   using argument_tags = tmpl::list<parent_tag>;
 };
-/// [databox_reference_tag_example]
+// [databox_reference_tag_example]
 }  // namespace test_databox_tags
 
 void test_reference_item() noexcept {

--- a/tests/Unit/DataStructures/DataBox/Test_DataBoxDocumentation.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBoxDocumentation.cpp
@@ -24,7 +24,7 @@ class DataBox;
 // clang-format off
 namespace {
 double working_without_databoxes_1() noexcept {
-/// [working_without_databoxes_small_program_1]
+// [working_without_databoxes_small_program_1]
 // Set up variables:
 const double velocity = 4.0;
 const double radius = 2.0;
@@ -35,24 +35,24 @@ const double volume = 10.0;
 const double mass = density * volume;
 const double acceleration = velocity * velocity / radius;
 return mass * acceleration;
-/// [working_without_databoxes_small_program_1]
+// [working_without_databoxes_small_program_1]
 }
 
-/// [working_without_databoxes_mass_compute]
+// [working_without_databoxes_mass_compute]
 double mass_compute(const double density, const double volume) noexcept {
   return density * volume;
 }
-/// [working_without_databoxes_mass_compute]
+// [working_without_databoxes_mass_compute]
 
-/// [working_without_databoxes_accel_compute]
+// [working_without_databoxes_accel_compute]
 double acceleration_compute(
     const double velocity, const double radius) noexcept {
   return velocity * velocity / radius;
 }
-/// [working_without_databoxes_accel_compute]
+// [working_without_databoxes_accel_compute]
 
 double working_without_databoxes_2() noexcept {
-/// [working_without_databoxes_small_program_2]
+// [working_without_databoxes_small_program_2]
 // Set up variables:
 const double velocity = 4.0;
 const double radius = 2.0;
@@ -63,30 +63,30 @@ const double volume = 10.0;
 const double mass = mass_compute(density, volume);
 const double acceleration = acceleration_compute(velocity, radius);
 return mass * acceleration;
-/// [working_without_databoxes_small_program_2]
+// [working_without_databoxes_small_program_2]
 }
 
-/// [working_without_databoxes_force_compute]
+// [working_without_databoxes_force_compute]
 double force_compute(const double velocity, const double radius,
                      const double density, const double volume) noexcept {
   const double mass = mass_compute(density, volume);
   const double acceleration = acceleration_compute(velocity, radius);
   return mass *  acceleration;
 }
-/// [working_without_databoxes_force_compute]
+// [working_without_databoxes_force_compute]
 
 void failed_acceleration() noexcept {
-/// [working_without_databoxes_failed_accel]
+// [working_without_databoxes_failed_accel]
 const double velocity = 4.0;
 const double radius = 2.0;
 const double acceleration = acceleration_compute(velocity, radius);
 const double failed_acceleration = acceleration_compute(radius, velocity);
-/// [working_without_databoxes_failed_accel]
+// [working_without_databoxes_failed_accel]
   CHECK(not(acceleration == failed_acceleration));
 }
 
 double std_map_databox_1() noexcept {
-/// [std_map_databox_small_program_1]
+// [std_map_databox_small_program_1]
 // Set up variables:
 const double velocity = 4.0;
 const double radius = 2.0;
@@ -99,34 +99,34 @@ naive_databox["Velocity"] = velocity;
 naive_databox["Radius"] = radius;
 naive_databox["Density"] = density;
 naive_databox["Volume"] = volume;
-/// [std_map_databox_small_program_1]
+// [std_map_databox_small_program_1]
   return naive_databox["Density"] * naive_databox["Volume"] *
          naive_databox["Velocity"] * naive_databox["Velocity"] /
          naive_databox["Radius"];
 }
 
-/// [std_map_databox_mass_compute]
+// [std_map_databox_mass_compute]
 double mass_compute(const std::map<std::string, double>& box) noexcept {
   return box.at("Density") * box.at("Volume");
 }
-/// [std_map_databox_mass_compute]
+// [std_map_databox_mass_compute]
 
-/// [std_map_databox_accel_compute]
+// [std_map_databox_accel_compute]
 double acceleration_compute(const std::map<std::string, double>& box) noexcept {
   return box.at("Velocity") * box.at("Velocity") / box.at("Radius");
 }
-/// [std_map_databox_accel_compute]
+// [std_map_databox_accel_compute]
 
-/// [std_map_databox_force_compute]
+// [std_map_databox_force_compute]
 double force_compute(const std::map<std::string, double>& box) noexcept {
   const double mass = mass_compute(box);
   const double acceleration = acceleration_compute(box);
   return mass * acceleration;
 }
-/// [std_map_databox_force_compute]
+// [std_map_databox_force_compute]
 
 double std_map_databox_2() noexcept {
-/// [std_map_databox_small_program_2]
+// [std_map_databox_small_program_2]
 // Set up variables:
 const double velocity = 4.0;
 const double radius = 2.0;
@@ -142,39 +142,39 @@ naive_databox["Volume"] = volume;
 
 // Use variables:
 return force_compute(naive_databox);
-/// [std_map_databox_small_program_2]
+// [std_map_databox_small_program_2]
 }
 
 bool std_tuple_databox_example() noexcept {
-/// [std_tuple_databox_1]
+// [std_tuple_databox_1]
 std::tuple<double, size_t, bool> sophomore_databox =
   std::make_tuple(1.2, 8, true);
-/// [std_tuple_databox_1]
+// [std_tuple_databox_1]
 
-/// [std_tuple_databox_2]
+// [std_tuple_databox_2]
 const bool bool_quantity = std::get<bool>(sophomore_databox);
 // value obtained is `true`
-/// [std_tuple_databox_2]
+// [std_tuple_databox_2]
 return bool_quantity;
 }
 
 namespace sophomore {
-/// [std_tuple_tags]
+// [std_tuple_tags]
 struct Velocity{};
 struct Radius{};
 struct Density{};
 struct Volume{};
-/// [std_tuple_tags]
+// [std_tuple_tags]
 
 double std_tuple_databox_1() noexcept {
-/// [std_tuple_small_program_1]
+// [std_tuple_small_program_1]
 std::tuple<std::pair<Velocity,double>,
            std::pair<Radius, double>, std::pair<Density, double>,
            std::pair<Volume, double>> sophomore_databox =
   std::make_tuple(std::make_pair(Velocity{}, 4.0),
                   std::make_pair(Radius{}, 2.0), std::make_pair(Density{}, 0.5),
                   std::make_pair(Volume{}, 10.0));
-/// [std_tuple_small_program_1]
+// [std_tuple_small_program_1]
   return std::get<std::pair<Density, double>>(sophomore_databox).second *
          std::get<std::pair<Volume, double>>(sophomore_databox).second *
          std::get<std::pair<Velocity, double>>(sophomore_databox).second *
@@ -182,34 +182,34 @@ std::tuple<std::pair<Velocity,double>,
          std::get<std::pair<Radius, double>>(sophomore_databox).second;
 }
 
-/// [std_tuple_mass_compute]
+// [std_tuple_mass_compute]
 template<typename... Pairs>
 double mass_compute(const std::tuple<Pairs...>& box) noexcept {
   return std::get<std::pair<Density, double>>(box).second *
          std::get<std::pair<Volume, double>>(box).second;
 }
-/// [std_tuple_mass_compute]
+// [std_tuple_mass_compute]
 
-/// [std_tuple_acceleration_compute]
+// [std_tuple_acceleration_compute]
 template<typename... Pairs>
 double acceleration_compute(const std::tuple<Pairs...>& box) noexcept {
   return std::get<std::pair<Velocity, double>>(box).second *
          std::get<std::pair<Velocity, double>>(box).second /
          std::get<std::pair<Radius, double>>(box).second;
 }
-/// [std_tuple_acceleration_compute]
+// [std_tuple_acceleration_compute]
 
-/// [std_tuple_force_compute]
+// [std_tuple_force_compute]
 template<typename... Pairs>
 double force_compute(const std::tuple<Pairs...>& box) noexcept {
   const double mass = mass_compute(box);
   const double acceleration = acceleration_compute(box);
   return mass * acceleration;
 }
-/// [std_tuple_force_compute]
+// [std_tuple_force_compute]
 
 double std_tuple_databox_2() noexcept {
-/// [std_tuple_small_program_2]
+// [std_tuple_small_program_2]
 std::tuple<std::pair<Velocity,double>,
            std::pair<Radius, double>, std::pair<Density, double>,
            std::pair<Volume, double>> sophomore_databox =
@@ -217,13 +217,13 @@ std::tuple<std::pair<Velocity,double>,
                   std::make_pair(Radius{}, 2.0), std::make_pair(Density{}, 0.5),
                   std::make_pair(Volume{}, 10.0));
 
-/// [std_tuple_small_program_2]
+// [std_tuple_small_program_2]
   return force_compute(sophomore_databox);
 }
 } // namespace sophomore
 
 namespace junior {
-/// [tagged_tuple_tags]
+// [tagged_tuple_tags]
 struct Velocity {
   using type = double;
 };
@@ -236,13 +236,13 @@ struct Density {
 struct Volume {
   using type = double;
 };
-/// [tagged_tuple_tags]
+// [tagged_tuple_tags]
 
 double tagged_tuple_databox_1() noexcept {
-/// [tagged_tuple_databox_1]
+// [tagged_tuple_databox_1]
 tuples::TaggedTuple<Velocity, Radius, Density, Volume> junior_databox{
   4.0, 2.0, 0.5, 10.0};
-/// [tagged_tuple_databox_1]
+// [tagged_tuple_databox_1]
   return tuples::get<Density>(junior_databox) *
          tuples::get<Volume>(junior_databox) *
          tuples::get<Velocity>(junior_databox) *
@@ -250,33 +250,33 @@ tuples::TaggedTuple<Velocity, Radius, Density, Volume> junior_databox{
          tuples::get<Radius>(junior_databox);
 }
 
-/// [tagged_tuple_mass_compute]
+// [tagged_tuple_mass_compute]
 template<typename... Tags>
 double mass_compute(const tuples::TaggedTuple<Tags...>& box) noexcept {
   return tuples::get<Density>(box) * tuples::get<Volume>(box);
 }
-/// [tagged_tuple_mass_compute]
+// [tagged_tuple_mass_compute]
 
-/// [tagged_tuple_acceleration_compute]
+// [tagged_tuple_acceleration_compute]
 template<typename... Tags>
 double acceleration_compute(const tuples::TaggedTuple<Tags...>& box) noexcept {
   return tuples::get<Velocity>(box) * tuples::get<Velocity>(box) /
          tuples::get<Radius>(box);
 }
-/// [tagged_tuple_acceleration_compute]
+// [tagged_tuple_acceleration_compute]
 
-/// [tagged_tuple_force_compute]
+// [tagged_tuple_force_compute]
 template<typename... Tags>
 double force_compute(const tuples::TaggedTuple<Tags...>& box) noexcept {
   const double mass = mass_compute(box);
   const double acceleration = acceleration_compute(box);
   return mass * acceleration;
 }
-/// [tagged_tuple_force_compute]
+// [tagged_tuple_force_compute]
 } // namespace junior
 
 namespace proper{
-/// [proper_databox_tags]
+// [proper_databox_tags]
 struct Velocity : db::SimpleTag {
   using type = double;
 };
@@ -292,17 +292,17 @@ struct Volume : db::SimpleTag {
 struct Mass : db::SimpleTag {
   using type = double;
 };
-/// [proper_databox_tags]
+// [proper_databox_tags]
 
 double refined_databox_1() noexcept {
-/// [refined_databox]
+// [refined_databox]
 const auto refined_databox = db::create<
     db::AddSimpleTags<
       Velocity, Radius, Density, Volume>>(4.0, 2.0, 0.5, 10.0);
-/// [refined_databox]
-/// [refined_databox_get]
+// [refined_databox]
+// [refined_databox_get]
 const double velocity = db::get<Velocity>(refined_databox);
-/// [refined_databox_get]
+// [refined_databox_get]
 const double radius = db::get<Radius>(refined_databox);
 const double density = db::get<Density>(refined_databox);
 const double volume = db::get<Volume>(refined_databox);
@@ -313,14 +313,14 @@ void mass_from_density_and_volume(const gsl::not_null<double*> result,
   const double density, const double volume) noexcept {
   *result = density * volume;
 }
-/// [compute_tags]
+// [compute_tags]
 struct MassCompute : db::ComputeTag, Mass {
   using base = Mass;
   using return_type = double;
   static constexpr auto function = &mass_from_density_and_volume;
   using argument_tags = tmpl::list<Density, Volume>;
 };
-/// [compute_tags]
+// [compute_tags]
 
 void acceleration_from_velocity_and_radius(const gsl::not_null<double*> result,
   const double velocity, const double radius) noexcept {
@@ -338,7 +338,7 @@ struct AccelerationCompute : db::ComputeTag, Acceleration {
   using argument_tags = tmpl::list<Velocity, Radius>;
 };
 
-/// [compute_tags_force_compute]
+// [compute_tags_force_compute]
 struct Force : db::SimpleTag {
   using type = double;
 };
@@ -351,10 +351,10 @@ struct ForceCompute : db::ComputeTag, Force {
     *result = mass * acceleration; }
   using argument_tags = tmpl::list<Mass, Acceleration>;
 };
-/// [compute_tags_force_compute]
+// [compute_tags_force_compute]
 } // namespace proper
 
-/// [mutate_tags]
+// [mutate_tags]
 struct Time : db::SimpleTag {
   using type = double;
 };
@@ -370,9 +370,9 @@ struct EarthGravity : db::SimpleTag {
 struct FallingSpeed : db::SimpleTag {
   using type = double;
 };
-/// [mutate_tags]
+// [mutate_tags]
 
-/// [intended_mutation]
+// [intended_mutation]
 struct IntendedMutation {
   static void apply(const gsl::not_null<double*> time,
      const gsl::not_null<double*> falling_speed,
@@ -382,9 +382,9 @@ struct IntendedMutation {
     *falling_speed += time_step * earth_gravity;
   }
 };
-/// [intended_mutation]
+// [intended_mutation]
 
-/// [intended_mutation2]
+// [intended_mutation2]
 struct IntendedMutation2 {
   using return_tags = tmpl::list<Time, FallingSpeed>;
   using argument_tags = tmpl::list<TimeStep, EarthGravity>;
@@ -397,9 +397,9 @@ struct IntendedMutation2 {
     *falling_speed += time_step * earth_gravity;
   }
 };
-/// [intended_mutation2]
+// [intended_mutation2]
 
-/// [my_first_action]
+// [my_first_action]
 template <typename Mutator>
 struct MyFirstAction{
   template<typename DbTagsList>
@@ -409,7 +409,7 @@ struct MyFirstAction{
     db::mutate_apply<Mutator>(time_dependent_databox);
   }
 };
-/// [my_first_action]
+// [my_first_action]
 
 } // namespace
 // clang-format on
@@ -470,7 +470,7 @@ const auto refined_databox = db::create<
                                               volume);
 CHECK(force == db::get<proper::Force>(refined_databox));
 
-/// [time_dep_databox]
+// [time_dep_databox]
 auto time_dependent_databox = db::create<
     db::AddSimpleTags<
       Time, TimeStep, EarthGravity, FallingSpeed>>(0.0, 0.1, -9.8, -10.0);
@@ -487,31 +487,31 @@ db::mutate_apply<
     *falling_speed += time_step * earth_gravity;
   },
   make_not_null(&time_dependent_databox));
-/// [time_dep_databox]
+// [time_dep_databox]
 CHECK(0.0 + 0.1 == approx(db::get<Time>(time_dependent_databox)));
 CHECK(-10.0 + 0.1 * -9.8 ==
   approx(db::get<FallingSpeed>(time_dependent_databox)));
 
-/// [time_dep_databox2]
+// [time_dep_databox2]
 db::mutate_apply<
   tmpl::list<Time, FallingSpeed>,
   tmpl::list<TimeStep, EarthGravity>>(
     IntendedMutation{}, make_not_null(&time_dependent_databox));
-/// [time_dep_databox2]
+// [time_dep_databox2]
 CHECK(0.0 + 0.2 == approx(db::get<Time>(time_dependent_databox)));
 CHECK(-10.0 + 0.2 * -9.8 ==
   approx(db::get<FallingSpeed>(time_dependent_databox)));
 
-/// [time_dep_databox3]
+// [time_dep_databox3]
 db::mutate_apply<IntendedMutation2>(make_not_null(&time_dependent_databox));
-/// [time_dep_databox3]
+// [time_dep_databox3]
 CHECK(0.0 + 0.3 == approx(db::get<Time>(time_dependent_databox)));
 CHECK(-10.0 + 0.3 * -9.8 ==
   approx(db::get<FallingSpeed>(time_dependent_databox)));
 
-/// [time_dep_databox4]
+// [time_dep_databox4]
 MyFirstAction<IntendedMutation2>::apply(make_not_null(&time_dependent_databox));
-/// [time_dep_databox4]
+// [time_dep_databox4]
 CHECK(0.0 + 0.4 == approx(db::get<Time>(time_dependent_databox)));
 CHECK(-10.0 + 0.4 * -9.8 ==
   approx(db::get<FallingSpeed>(time_dependent_databox)));

--- a/tests/Unit/DataStructures/DataBox/Test_DataBoxPrefixes.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBoxPrefixes.cpp
@@ -27,34 +27,34 @@ struct TensorTag : db::SimpleTag {
 
 SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.Prefixes",
                   "[Unit][DataStructures]") {
-  /// [dt_name]
+  // [dt_name]
   TestHelpers::db::test_prefix_tag<Tags::dt<Tag>>("dt(Tag)");
-  /// [dt_name]
+  // [dt_name]
   using Dim = tmpl::size_t<2>;
   using Frame = Frame::Inertial;
   using VariablesTag = Tags::Variables<tmpl::list<TensorTag>>;
-  /// [flux_name]
+  // [flux_name]
   TestHelpers::db::test_prefix_tag<Tags::Flux<TensorTag, Dim, Frame>>(
       "Flux(TensorTag)");
   TestHelpers::db::test_prefix_tag<Tags::Flux<VariablesTag, Dim, Frame>>(
       "Flux(Variables(TensorTag))");
-  /// [flux_name]
-  /// [source_name]
+  // [flux_name]
+  // [source_name]
   TestHelpers::db::test_prefix_tag<Tags::Source<Tag>>("Source(Tag)");
-  /// [source_name]
+  // [source_name]
   TestHelpers::db::test_prefix_tag<Tags::FixedSource<Tag>>("FixedSource(Tag)");
-  /// [initial_name]
+  // [initial_name]
   TestHelpers::db::test_prefix_tag<Tags::Initial<Tag>>("Initial(Tag)");
-  /// [initial_name]
-  /// [normal_dot_flux_name]
+  // [initial_name]
+  // [normal_dot_flux_name]
   TestHelpers::db::test_prefix_tag<Tags::NormalDotFlux<Tag>>(
       "NormalDotFlux(Tag)");
-  /// [normal_dot_flux_name]
-  /// [normal_dot_numerical_flux_name]
+  // [normal_dot_flux_name]
+  // [normal_dot_numerical_flux_name]
   TestHelpers::db::test_prefix_tag<Tags::NormalDotNumericalFlux<Tag>>(
       "NormalDotNumericalFlux(Tag)");
-  /// [normal_dot_numerical_flux_name]
-  /// [next_name]
+  // [normal_dot_numerical_flux_name]
+  // [next_name]
   TestHelpers::db::test_prefix_tag<Tags::Next<Tag>>("Next(Tag)");
-  /// [next_name]
+  // [next_name]
 }

--- a/tests/Unit/DataStructures/DataBox/Test_TestHelpers.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_TestHelpers.cpp
@@ -47,7 +47,7 @@ struct RedundantName : db::SimpleTag {
 };
 }  // namespace
 
-/// [[OutputRegex, Do not define name for Tag]]
+// [[OutputRegex, Do not define name for Tag]]
 SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.TestHelpers.redundant_name",
                   "[Unit][DataStructures]") {
   ERROR_TEST();

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubtract.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubtract.cpp
@@ -121,14 +121,14 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
                     SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
       Hll{};
   std::iota(Hll.begin(), Hll.end(), 0.0);
-  /// [use_tensor_index]
+  // [use_tensor_index]
   auto Gll = TensorExpressions::evaluate<ti_a, ti_b>(All(ti_a, ti_b) +
                                                      Hll(ti_a, ti_b));
   auto Gll2 = TensorExpressions::evaluate<ti_a, ti_b>(All(ti_a, ti_b) +
                                                       Hll(ti_b, ti_a));
   auto Gll3 = TensorExpressions::evaluate<ti_a, ti_b>(
       All(ti_a, ti_b) + Hll(ti_b, ti_a) + All(ti_b, ti_a) - Hll(ti_b, ti_a));
-  /// [use_tensor_index]
+  // [use_tensor_index]
   for (int i = 0; i < 4; ++i) {
     for (int j = 0; j < 4; ++j) {
       CHECK(Gll.get(i, j) == All.get(i, j) + Hll.get(i, j));

--- a/tests/Unit/DataStructures/Tensor/Test_Tensor.cpp
+++ b/tests/Unit/DataStructures/Tensor/Test_Tensor.cpp
@@ -28,14 +28,14 @@
 #include "Utilities/TypeTraits.hpp"
 // IWYU pragma: no_forward_declare Tensor
 
-/// [change_up_lo]
+// [change_up_lo]
 using Index = SpatialIndex<3, UpLo::Lo, Frame::Grid>;
 using UpIndex = change_index_up_lo<Index>;
 static_assert(std::is_same_v<UpIndex, SpatialIndex<3, UpLo::Up, Frame::Grid>>,
               "Failed testing change_index_up_lo");
-/// [change_up_lo]
+// [change_up_lo]
 
-/// [is_frame_physical]
+// [is_frame_physical]
 static_assert(not Frame::is_frame_physical_v<Frame::Logical>,
               "Failed testing Frame::is_frame_physical");
 static_assert(not Frame::is_frame_physical_v<Frame::Distorted>,
@@ -44,7 +44,7 @@ static_assert(not Frame::is_frame_physical_v<Frame::Grid>,
               "Failed testing Frame::is_frame_physical");
 static_assert(Frame::is_frame_physical_v<Frame::Inertial>,
               "Failed testing Frame::is_frame_physical");
-/// [is_frame_physical]
+// [is_frame_physical]
 
 // Test Symmetry metafunction
 static_assert(
@@ -223,33 +223,33 @@ static_assert(check_construction.rank() == 4, "Wrong structure");
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.ComponentNames",
                   "[DataStructures][Unit]") {
-  /// [spatial_vector]
+  // [spatial_vector]
   tnsr::I<double, 3, Frame::Grid> spatial_vector3{};
-  /// [spatial_vector]
+  // [spatial_vector]
   CHECK(spatial_vector3.component_name(std::array<size_t, 1>{{0}}) == "x");
   CHECK(spatial_vector3.component_name(std::array<size_t, 1>{{1}}) == "y");
   CHECK(spatial_vector3.component_name(std::array<size_t, 1>{{2}}) == "z");
 
-  /// [spacetime_vector]
+  // [spacetime_vector]
   tnsr::A<double, 3, Frame::Grid> spacetime_vector3{};
-  /// [spacetime_vector]
+  // [spacetime_vector]
   CHECK(spacetime_vector3.component_name(std::array<size_t, 1>{{0}}) == "t");
   CHECK(spacetime_vector3.component_name(std::array<size_t, 1>{{1}}) == "x");
   CHECK(spacetime_vector3.component_name(std::array<size_t, 1>{{2}}) == "y");
   CHECK(spacetime_vector3.component_name(std::array<size_t, 1>{{3}}) == "z");
 
-  /// [scalar]
+  // [scalar]
   Tensor<double> scalar{};
-  /// [scalar]
+  // [scalar]
   CHECK(scalar.component_name() == "Scalar");
 
-  /// [rank_3_122]
+  // [rank_3_122]
   Tensor<double, Symmetry<1, 2, 2>,
          index_list<SpacetimeIndex<1, UpLo::Lo, Frame::Grid>,
                     SpatialIndex<1, UpLo::Lo, Frame::Grid>,
                     SpatialIndex<1, UpLo::Lo, Frame::Grid>>>
       tensor_1{};
-  /// [rank_3_122]
+  // [rank_3_122]
   CHECK(tensor_1.component_name(std::array<size_t, 3>{{0, 0, 0}}) == "txx");
   CHECK(tensor_1.component_name(std::array<size_t, 3>{{1, 0, 0}}) == "xxx");
 
@@ -516,7 +516,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.RankAndSize",
   }
 
   {
-    /// [index_dim]
+    // [index_dim]
     using T = Tensor<double, Symmetry<1, 2, 3>,
                      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Inertial>,
                                 SpatialIndex<1, UpLo::Up, Frame::Inertial>,
@@ -529,7 +529,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.RankAndSize",
     CHECK(T::index_dim(1) == 1);
     CHECK(T::index_dim(2) == 2);
     CHECK(T::index_dims() == std::array<size_t, 3>{{3, 1, 2}});
-    /// [index_dim]
+    // [index_dim]
   }
 
   Tensor<double, Symmetry<3>,
@@ -1340,11 +1340,11 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.GetVectorOfData",
                   "[Unit][DataStructures]") {
   // NOTE: This test depends on the implementation of serialize and Tensor,
   // but that is inevitable without making the test more complicated.
-  /// [init_vector]
+  // [init_vector]
   tnsr::I<DataVector, 3, Frame::Grid> tensor_data_vector{
       {{{1., 2., 3.}, {4., 5., 6.}, {7., 8., 9.}}}};
   Scalar<DataVector> scalar_data_vector{{{{1., 2., 3.}}}};
-  /// [init_vector]
+  // [init_vector]
   CHECK(std::make_pair(std::vector<std::string>{"x", "y", "z"},
                        std::vector<DataVector>{
                            {1., 2., 3.}, {4., 5., 6.}, {7., 8., 9.}}) ==
@@ -1364,7 +1364,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.GetVectorOfData",
         scalar.get_vector_of_data());
 }
 
-/// [example_spectre_test_case]
+// [example_spectre_test_case]
 SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Frames",
                   "[Unit][DataStructures]") {
   CHECK("Logical" == get_output(Frame::Logical{}));
@@ -1373,7 +1373,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Frames",
   CHECK("Distorted" == get_output(Frame::Distorted{}));
   CHECK("NoFrame" == get_output(Frame::NoFrame{}));
 }
-/// [example_spectre_test_case]
+// [example_spectre_test_case]
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.MakeWithValue",
                   "[Unit][DataStructures]") {

--- a/tests/Unit/DataStructures/Test_CachedTempBuffer.cpp
+++ b/tests/Unit/DataStructures/Test_CachedTempBuffer.cpp
@@ -46,13 +46,13 @@ struct Count {
 template <typename DataType>
 struct Computer;
 
-/// [alias]
+// [alias]
 template <typename DataType>
 using Cache =
     CachedTempBuffer<Computer<DataType>, Tags::Scalar1<DataType>,
                      Tags::Scalar2<DataType>, Tags::Vector1<DataType>,
                      Tags::Vector2<DataType>>;
-/// [alias]
+// [alias]
 
 template <typename DataType>
 using Counter = tuples::TaggedTuple<
@@ -72,11 +72,11 @@ class Computer {
     get(*scalar1) = 7.0;
   }
 
-  /// [compute_func]
+  // [compute_func]
   void operator()(const gsl::not_null<Scalar<DataType>*> scalar2,
                   const gsl::not_null<Cache<DataType>*> cache,
                   Tags::Scalar2<DataType> /*meta*/) const noexcept {
-    /// [compute_func]
+    // [compute_func]
     ++get<Tags::Count<Tags::Scalar2<DataType>>>(*counter_);
     const auto& vector1 = cache->get_var(Tags::Vector1<DataType>{});
 

--- a/tests/Unit/DataStructures/Test_ComplexDataVector.cpp
+++ b/tests/Unit/DataStructures/Test_ComplexDataVector.cpp
@@ -51,14 +51,14 @@ void test_complex_data_vector_math() noexcept {
   TestHelpers::VectorImpl::test_functions_with_vector_arguments<
       TestHelpers::VectorImpl::TestKind::Normal, ComplexDataVector>(unary_ops);
 
-  /// [test_vector_math_usage]
+  // [test_vector_math_usage]
   const auto real_unary_ops = std::make_tuple(
       std::make_tuple(funcl::Real<>{}, std::make_tuple(generic)),
       std::make_tuple(funcl::Imag<>{}, std::make_tuple(generic)));
 
   TestHelpers::VectorImpl::test_functions_with_vector_arguments<
       TestHelpers::VectorImpl::TestKind::Normal, DataVector>(real_unary_ops);
-  /// [test_vector_math_usage]
+  // [test_vector_math_usage]
 
   // Note that the binary operations have been moved to
   // `Test_ComplexDataVectorBinaryOperations.cpp` in an effort to better

--- a/tests/Unit/DataStructures/Test_ComplexDataVectorAsserts.cpp
+++ b/tests/Unit/DataStructures/Test_ComplexDataVectorAsserts.cpp
@@ -1,9 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-/// \file
-/// These error tests are in a separate file so `Test_ComplexDataVector.cpp` can
-/// be compiled into `TestArchitectureVectorization`
+// These error tests are in a separate file so `Test_ComplexDataVector.cpp` can
+// be compiled into `TestArchitectureVectorization`
 
 #include "Framework/TestingFramework.hpp"
 

--- a/tests/Unit/DataStructures/Test_DataVector.cpp
+++ b/tests/Unit/DataStructures/Test_DataVector.cpp
@@ -20,7 +20,7 @@
 // IWYU pragma: no_include <algorithm>
 
 void test_data_vector_unary_math() noexcept {
-  /// [test_functions_with_vector_arguments_example]
+  // [test_functions_with_vector_arguments_example]
   const TestHelpers::VectorImpl::Bound generic{{-100.0, 100.0}};
   const TestHelpers::VectorImpl::Bound mone_one{{-1.0, 1.0}};
   const TestHelpers::VectorImpl::Bound gt_one{{1.0, 100.0}};
@@ -58,7 +58,7 @@ void test_data_vector_unary_math() noexcept {
 
   TestHelpers::VectorImpl::test_functions_with_vector_arguments<
       TestHelpers::VectorImpl::TestKind::Normal, DataVector>(unary_ops);
-  /// [test_functions_with_vector_arguments_example]
+  // [test_functions_with_vector_arguments_example]
 
   // Note that the binary operations have been moved to
   // `Test_DataVectorBinaryOperations.cpp` in an effort to better parallelize

--- a/tests/Unit/DataStructures/Test_DataVectorAsserts.cpp
+++ b/tests/Unit/DataStructures/Test_DataVectorAsserts.cpp
@@ -1,9 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-/// \file
-/// These error tests are in a separate file so `Test_DataVector.cpp` can be
-/// compiled into `TestArchitectureVectorization`
+// These error tests are in a separate file so `Test_DataVector.cpp` can be
+// compiled into `TestArchitectureVectorization`
 
 #include "Framework/TestingFramework.hpp"
 

--- a/tests/Unit/DataStructures/Test_DenseMatrixAsserts.cpp
+++ b/tests/Unit/DataStructures/Test_DenseMatrixAsserts.cpp
@@ -1,9 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-/// \file
-/// These error tests are in a separate file so `Test_DenseMatrix.cpp` can be
-/// compiled into `TestArchitectureVectorization`
+// These error tests are in a separate file so `Test_DenseMatrix.cpp` can be
+// compiled into `TestArchitectureVectorization`
 
 #include "Framework/TestingFramework.hpp"
 

--- a/tests/Unit/DataStructures/Test_IndexIterator.cpp
+++ b/tests/Unit/DataStructures/Test_IndexIterator.cpp
@@ -11,13 +11,13 @@
 
 SPECTRE_TEST_CASE("Unit.DataStructures.IndexIterator",
                   "[DataStructures][Unit]") {
-  /// [index_iterator_example]
+  // [index_iterator_example]
   Index<3> elements(1, 2, 3);
   for (IndexIterator<3> index_it(elements); index_it; ++index_it) {
     // Use the index iterator to do something super awesome
     CHECK(Index<3>(-1, -1, -1) != *index_it);
   }
-  /// [index_iterator_example]
+  // [index_iterator_example]
 
   IndexIterator<3> index_iterator(elements);
   auto check_next = [&index_iterator,

--- a/tests/Unit/DataStructures/Test_LeviCivitaIterator.cpp
+++ b/tests/Unit/DataStructures/Test_LeviCivitaIterator.cpp
@@ -91,7 +91,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.LeviCivitaIterator",
   CHECK(i == 24);
 
   // Demonstrate using the iterator to compute a cross product
-  /// [levi_civita_iterator_example]
+  // [levi_civita_iterator_example]
   const std::array<double, 3> vector_a = {{2.0, 3.0, 4.0}};
   const std::array<double, 3> vector_b = {{7.0, 6.0, 5.0}};
   const std::array<double, 3> a_cross_b_expected = {{-9.0, 18.0, -9.0}};
@@ -102,5 +102,5 @@ SPECTRE_TEST_CASE("Unit.DataStructures.LeviCivitaIterator",
         it.sign() * gsl::at(vector_a, it[1]) * gsl::at(vector_b, it[2]);
   }
   CHECK_ITERABLE_APPROX(a_cross_b, a_cross_b_expected);
-  /// [levi_civita_iterator_example]
+  // [levi_civita_iterator_example]
 }

--- a/tests/Unit/DataStructures/Test_SpinWeighted.cpp
+++ b/tests/Unit/DataStructures/Test_SpinWeighted.cpp
@@ -221,7 +221,6 @@ SPECTRE_TEST_CASE("Unit.DataStructures.SpinWeighted",
   CHECK(destructive_resize_check.size() == destructive_resize_copy.size() + 1);
 }
 
-/// \cond HIDDEN_SYMBOLS
 // A macro which will static_assert fail when LHSTYPE OP RHSTYPE succeeds during
 // SFINAE. Used to make sure we can't violate spin addition rules.
 // clang-tidy: wants parens around macro argument, but that breaks macro
@@ -245,5 +244,4 @@ CHECK_TYPE_OPERATION_FAIL(spin_check_3, +,
                           decltype(std::declval<SpinZero>() *
                                    std::declval<SpinTwo>()),
                           SpinOne);
-/// \endcond
 }  // namespace

--- a/tests/Unit/DataStructures/Test_Transpose.cpp
+++ b/tests/Unit/DataStructures/Test_Transpose.cpp
@@ -36,7 +36,7 @@ using one_var = tmpl::list<Var1<Dim>>;
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Transpose", "[DataStructures][Unit]") {
   // clang-format off
-  /// [transpose_matrix]
+  // [transpose_matrix]
   const DataVector matrix{ 1.,  2.,  3.,
                            4.,  5.,  6.,
                            7.,  8.,  9.,
@@ -44,7 +44,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Transpose", "[DataStructures][Unit]") {
   CHECK(transpose(matrix, 3, 4) == DataVector{1.,  4.,  7., 10.,
                                               2.,  5.,  8., 11.,
                                               3.,  6.,  9., 12.});
-  /// [transpose_matrix]
+  // [transpose_matrix]
   // clang-format on
 
   DataVector transposed_matrix(12);
@@ -52,7 +52,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Transpose", "[DataStructures][Unit]") {
   CHECK(transposed_matrix ==
         DataVector{1., 4., 7., 10., 2., 5., 8., 11., 3., 6., 9., 12.});
 
-  /// [return_transpose_example]
+  // [return_transpose_example]
   const size_t chunk_size = 8;
   const size_t number_of_chunks = 2;
   const size_t n_pts = chunk_size * number_of_chunks;
@@ -68,7 +68,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Transpose", "[DataStructures][Unit]") {
             transposed_data[j + number_of_chunks * i]);
     }
   }
-  /// [return_transpose_example]
+  // [return_transpose_example]
   std::fill(transposed_data.begin(), transposed_data.end(), 0.0);
   DataVector ref_to_data;
   ref_to_data.set_data_ref(&data);
@@ -87,7 +87,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Transpose", "[DataStructures][Unit]") {
     }
   }
 
-  /// [transpose_by_not_null_example]
+  // [transpose_by_not_null_example]
   const size_t chunk_size_vars = 8;
   const size_t n_grid_pts = 2 * chunk_size_vars;
   Variables<two_vars<2>> variables(n_grid_pts, 0.);
@@ -106,9 +106,9 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Transpose", "[DataStructures][Unit]") {
             transposed_vars.data()[j + number_of_chunks_vars * i]);  // NOLINT
     }
   }
-  /// [transpose_by_not_null_example]
+  // [transpose_by_not_null_example]
 
-  /// [partial_transpose_example]
+  // [partial_transpose_example]
   Variables<one_var<2>> partial_vars(n_grid_pts, 0.);
   get<Var1<2>>(partial_vars) = get<Var1<2>>(variables);
   Variables<one_var<2>> partial_transpose(n_grid_pts, 0.);
@@ -126,7 +126,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Transpose", "[DataStructures][Unit]") {
             partial_vars.data()[i + chunk_size_vars * j]);    // NOLINT
     }
   }
-  /// [partial_transpose_example]
+  // [partial_transpose_example]
 
   const auto another_partial_transpose =
       transpose<Variables<two_vars<2>>, Variables<one_var<2>>>(

--- a/tests/Unit/DataStructures/Test_VectorImpl.cpp
+++ b/tests/Unit/DataStructures/Test_VectorImpl.cpp
@@ -12,7 +12,7 @@
 #include "DataStructures/VectorImpl.hpp"  // IWYU pragma: keep
 #include "Utilities/TypeTraits.hpp"
 
-/// [get_vector_element_type_example]
+// [get_vector_element_type_example]
 static_assert(std::is_same_v<get_vector_element_type_t<DataVector>, double>,
               "Failed testing type trait get_vector_element_type");
 
@@ -26,7 +26,7 @@ static_assert(std::is_same_v<get_vector_element_type_t<std::complex<double>*>,
 
 static_assert(std::is_same_v<get_vector_element_type_t<DataVector&>, double>,
               "Failed testing type trait get_vector_element_type");
-/// [get_vector_element_type_example]
+// [get_vector_element_type_example]
 
 static_assert(is_derived_of_vector_impl_v<DataVector>,
               "Failed testing type trait is_derived_of_vector_impl");

--- a/tests/Unit/Domain/CoordinateMaps/Test_TimeDependentHelpers.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_TimeDependentHelpers.cpp
@@ -15,11 +15,9 @@
 
 class DataVector;
 
-namespace domain {
-namespace FunctionsOfTime {
+namespace domain::FunctionsOfTime {
 class FunctionOfTime;
-}  // namespace FunctionsOfTime
-}  // namespace domain
+}  // namespace domain::FunctionsOfTime
 
 namespace {
 template <size_t Dim>

--- a/tests/Unit/Domain/CoordinateMaps/Test_TimeDependentHelpers.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_TimeDependentHelpers.cpp
@@ -13,7 +13,6 @@
 #include "Domain/CoordinateMaps/TimeDependentHelpers.hpp"
 #include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
 
-/// \cond
 class DataVector;
 
 namespace domain {
@@ -21,7 +20,6 @@ namespace FunctionsOfTime {
 class FunctionOfTime;
 }  // namespace FunctionsOfTime
 }  // namespace domain
-/// \endcond
 
 namespace {
 template <size_t Dim>

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -1480,7 +1480,7 @@ void test_maps_for_rectilinear_domains() noexcept {
     CHECK(*equiangular_maps_2d[i] == *expected_equiangular_maps_2d[i]);
   }
 
-  /// [show_maps_for_rectilinear_domains]
+  // [show_maps_for_rectilinear_domains]
   const std::vector<
       std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>>
       affine_maps_3d = maps_for_rectilinear_domains<Frame::Inertial>(
@@ -1488,7 +1488,7 @@ void test_maps_for_rectilinear_domains() noexcept {
           std::array<std::vector<double>, 3>{
               {{0.0, 0.5, 2.0}, {0.0, 1.0, 2.0}, {-0.4, 0.3}}},
           {Index<3>{}}, {}, false);
-  /// [show_maps_for_rectilinear_domains]
+  // [show_maps_for_rectilinear_domains]
   const auto expected_affine_maps_3d =
       make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
           Affine3D{Affine{-1., 1., 0.0, 0.5}, Affine{-1., 1., 0.0, 1.0},

--- a/tests/Unit/Domain/Test_FaceNormal.cpp
+++ b/tests/Unit/Domain/Test_FaceNormal.cpp
@@ -203,13 +203,13 @@ void check_time_dependent(
 
 void test_face_normal_coordinate_map() {
   INFO("Test coordinate map");
-  /// [face_normal_example]
+  // [face_normal_example]
   const Mesh<0> mesh_0d;
   const auto map_1d = make_coordinate_map<Frame::Logical, Frame::Grid>(
       CoordinateMaps::Affine(-1.0, 1.0, -3.0, 7.0));
   const auto normal_1d_lower =
       unnormalized_face_normal(mesh_0d, map_1d, Direction<1>::lower_xi());
-  /// [face_normal_example]
+  // [face_normal_example]
 
   CHECK(normal_1d_lower.get(0) == DataVector(1, -0.2));
 

--- a/tests/Unit/Domain/Test_InterfaceHelpers.cpp
+++ b/tests/Unit/Domain/Test_InterfaceHelpers.cpp
@@ -24,7 +24,7 @@ struct SomeVolumeArgument : VolumeArgumentBase, db::SimpleTag {
   static std::string name() noexcept { return "SomeVolumeArgument"; }
 };
 
-/// [interface_invokable_example]
+// [interface_invokable_example]
 struct ComputeSomethingOnInterface {
   using argument_tags = tmpl::list<SomeNumber, SomeVolumeArgument>;
   using volume_tags = tmpl::list<SomeVolumeArgument>;
@@ -34,7 +34,7 @@ struct ComputeSomethingOnInterface {
     return factor * some_number_on_interface + volume_argument;
   }
 };
-/// [interface_invokable_example]
+// [interface_invokable_example]
 
 struct ComputeWithTemplateParameters {
   using argument_tags = tmpl::list<SomeNumber>;
@@ -67,7 +67,7 @@ void test_interface_apply(
                                    SomeVolumeArgument>>(
           element, directions, number_on_interfaces, 1.);
   // Test applying a function to the interface and give an example
-  /// [interface_apply_example]
+  // [interface_apply_example]
   const auto computed_number_on_interfaces =
       interface_apply<DirectionsTag, tmpl::list<SomeNumber, SomeVolumeArgument>,
                       tmpl::list<SomeVolumeArgument>>(
@@ -84,7 +84,7 @@ void test_interface_apply(
         computed_number_on_interfaces.at(direction_and_expected_result.first) ==
         direction_and_expected_result.second);
   }
-  /// [interface_apply_example]
+  // [interface_apply_example]
 
   // Test volume base tag
   const auto computed_numbers_with_base_tag =
@@ -98,10 +98,10 @@ void test_interface_apply(
   CHECK(computed_numbers_with_base_tag == computed_number_on_interfaces);
 
   // Test overload that takes a stateless invokable
-  /// [interface_apply_example_stateless]
+  // [interface_apply_example_stateless]
   const auto computed_numbers_with_struct =
       interface_apply<DirectionsTag, ComputeSomethingOnInterface>(box, 2.);
-  /// [interface_apply_example_stateless]
+  // [interface_apply_example_stateless]
   CHECK(computed_numbers_with_struct == computed_number_on_interfaces);
 
   {

--- a/tests/Unit/Domain/Test_LogicalCoordinates.cpp
+++ b/tests/Unit/Domain/Test_LogicalCoordinates.cpp
@@ -34,7 +34,7 @@ SPECTRE_TEST_CASE("Unit.Domain.LogicalCoordinates", "[Domain][Unit]") {
   const Mesh<2> mesh_2d{
       {{2, 3}}, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto};
 
-  /// [logical_coordinates_example]
+  // [logical_coordinates_example]
   const Mesh<3> mesh_3d{{{5, 3, 2}},
                         Spectral::Basis::Legendre,
                         Spectral::Quadrature::GaussLobatto};
@@ -47,7 +47,7 @@ SPECTRE_TEST_CASE("Unit.Domain.LogicalCoordinates", "[Domain][Unit]") {
       Affine3d{x_map, y_map, z_map});
 
   const auto x_3d = map_3d(logical_coordinates(mesh_3d));
-  /// [logical_coordinates_example]
+  // [logical_coordinates_example]
 
   const auto map_1d = make_coordinate_map<Frame::Logical, Frame::Grid>(
       CoordinateMaps::Affine{x_map});
@@ -263,13 +263,13 @@ SPECTRE_TEST_CASE("Unit.Domain.InterfaceLogicalCoordinates", "[Domain][Unit]") {
   CHECK(x_3d_ub_eta[2][7] == 74.0);
   CHECK(x_3d_ub_eta[2][9] == 74.0);
 
-  /// [interface_logical_coordinates_example]
+  // [interface_logical_coordinates_example]
   const Mesh<2> mesh_3d_zbdry{
       {{5, 3}}, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto};
 
   const auto x_3d_lb_zeta = map_3d(
       interface_logical_coordinates(mesh_3d_zbdry, Direction<3>::lower_zeta()));
-  /// [interface_logical_coordinates_example]
+  // [interface_logical_coordinates_example]
 
   CHECK(x_3d_lb_zeta[0][0] == -3.0);
   CHECK(x_3d_lb_zeta[0][2] == 2.0);

--- a/tests/Unit/Elliptic/BoundaryConditions/Test_BoundaryCondition.cpp
+++ b/tests/Unit/Elliptic/BoundaryConditions/Test_BoundaryCondition.cpp
@@ -75,12 +75,12 @@ class TestBoundaryCondition : public BoundaryCondition<1, Registrars> {
       tmpl::list<ArgumentTag, VolumeArgumentTag, NonlinearArgumentTag>;
   using volume_tags = tmpl::list<VolumeArgumentTag>;
 
-  /// [example_poisson_fields]
+  // [example_poisson_fields]
   static void apply(const gsl::not_null<Scalar<DataVector>*> field,
                     const gsl::not_null<Scalar<DataVector>*> n_dot_flux,
                     const int arg_on_face, const bool arg_from_volume,
                     const int arg_nonlinear) noexcept {
-    /// [example_poisson_fields]
+    // [example_poisson_fields]
     CHECK(arg_on_face == 1);
     CHECK(arg_from_volume);
     CHECK(arg_nonlinear == 2);

--- a/tests/Unit/ErrorHandling/Test_AssertAndError.cpp
+++ b/tests/Unit/ErrorHandling/Test_AssertAndError.cpp
@@ -6,7 +6,7 @@
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 
-/// [assertion_test_example]
+// [assertion_test_example]
 // [[OutputRegex, Testing assert]]
 [[noreturn]] SPECTRE_TEST_CASE("Unit.ErrorHandling.Assert",
                                "[Unit][ErrorHandling]") {
@@ -16,13 +16,13 @@
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
-/// [assertion_test_example]
+// [assertion_test_example]
 
-/// [error_test_example]
+// [error_test_example]
 // [[OutputRegex, Testing error]]
 [[noreturn]] SPECTRE_TEST_CASE("Unit.ErrorHandling.Error",
                                "[Unit][ErrorHandling]") {
   ERROR_TEST();
   ERROR("Testing error");
 }
-/// [error_test_example]
+// [error_test_example]

--- a/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
@@ -23,9 +23,7 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 
-/// \cond
 class DataVector;
-/// \endcond
 
 namespace {
 struct Var1 : db::SimpleTag {

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
@@ -81,11 +81,9 @@ struct BoundaryTerms final : public BoundaryCorrection<Dim> {
     using type = Scalar<DataVector>;
   };
 
-  /// \cond
   explicit BoundaryTerms(CkMigrateMessage* /*unused*/) noexcept {}
   using PUP::able::register_constructor;
   WRAPPED_PUPable_decl_template(BoundaryTerms);  // NOLINT
-  /// \endcond
   BoundaryTerms() = default;
   BoundaryTerms(const BoundaryTerms&) = default;
   BoundaryTerms& operator=(const BoundaryTerms&) = default;

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_BoundaryConditions.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_BoundaryConditions.cpp
@@ -127,11 +127,9 @@ struct BoundaryTerms final
     using type = Scalar<DataVector>;
   };
 
-  /// \cond
   explicit BoundaryTerms(CkMigrateMessage* /*unused*/) noexcept {}
   using PUP::able::register_constructor;
   WRAPPED_PUPable_decl_template(BoundaryTerms);  // NOLINT
-  /// \endcond
   BoundaryTerms(const bool mesh_is_moving, const double sign_of_normal)
       : mesh_is_moving_(mesh_is_moving), sign_of_normal_(sign_of_normal) {}
   BoundaryTerms() = default;

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_BoundaryCorrectionsHelper.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_BoundaryCorrectionsHelper.cpp
@@ -105,12 +105,10 @@ struct CorrectionBase : public PUP::able {
 
   explicit CorrectionBase(CkMigrateMessage* msg) noexcept : PUP::able(msg) {}
 
-  /// \cond
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
   WRAPPED_PUPable_abstract(CorrectionBase);  // NOLINT
 #pragma GCC diagnostic pop
-  /// \endcond
 
   virtual std::unique_ptr<CorrectionBase> get_clone() const noexcept = 0;
 };
@@ -141,11 +139,9 @@ struct Correction final : public CorrectionBase {
     return std::make_unique<Correction>(*this);
   }
 
-  /// \cond
   explicit Correction(CkMigrateMessage* msg) noexcept : CorrectionBase(msg) {}
   using PUP::able::register_constructor;
   WRAPPED_PUPable_decl_template(Correction);  // NOLINT
-  /// \endcond
   void pup(PUP::er& p) override { CorrectionBase::pup(p); }
 
   double dg_package_data(

--- a/tests/Unit/Evolution/Systems/Cce/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_Tags.cpp
@@ -11,9 +11,7 @@
 #include "Evolution/Systems/Cce/WorldtubeBufferUpdater.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 
-/// \cond
 class ComplexDataVector;
-/// \endcond
 namespace {
 struct SomeTag {
   using type = Scalar<SpinWeighted<ComplexDataVector, 0>>;

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/Test_UpwindPenalty.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/Test_UpwindPenalty.cpp
@@ -1,4 +1,4 @@
-//// Distributed under the MIT License.
+// Distributed under the MIT License.
 // See LICENSE.txt for details.
 
 #include "Framework/TestingFramework.hpp"

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Test_M1Closure.cpp
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Test_M1Closure.cpp
@@ -19,7 +19,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
-/// Test M1 closure function
+// Test M1 closure function
 SPECTRE_TEST_CASE("Evolution.Systems.RadiationTransport.M1Grey.M1Closure",
                   "[Unit][M1Grey]") {
   const DataVector used_for_size(5);

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Test_Tags.cpp
@@ -11,7 +11,7 @@
 #include "Evolution/Systems/RadiationTransport/Tags.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 
-/// Test tags used in M1Grey code
+// Test tags used in M1Grey code
 SPECTRE_TEST_CASE("Evolution.Systems.RadiationTransport.M1Grey.Tags",
                   "[Unit][M1Grey]") {
   // (1) Tags for neutrino species

--- a/tests/Unit/Framework/SetupLocalPythonEnvironment.cpp
+++ b/tests/Unit/Framework/SetupLocalPythonEnvironment.cpp
@@ -20,7 +20,6 @@
 #include "Informer/InfoFromBuild.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 
-/// \cond
 namespace pypp {
 SetupLocalPythonEnvironment::SetupLocalPythonEnvironment(
     const std::string &cur_dir_relative_to_unit_test_path) {
@@ -82,4 +81,3 @@ void SetupLocalPythonEnvironment::finalize_env() {
 bool SetupLocalPythonEnvironment::initialized = false;
 bool SetupLocalPythonEnvironment::finalized = false;
 }  // namespace pypp
-/// \endcond

--- a/tests/Unit/Framework/Tests/Test_ActionTesting.cpp
+++ b/tests/Unit/Framework/Tests/Test_ActionTesting.cpp
@@ -35,7 +35,7 @@ struct simple_action_c_mock;
 struct threaded_action_b;
 struct threaded_action_b_mock;
 
-/// [tags for const global cache]
+// [tags for const global cache]
 struct ValueTag : db::SimpleTag {
   using type = int;
   static std::string name() noexcept { return "ValueTag"; }
@@ -45,7 +45,7 @@ struct PassedToB : db::SimpleTag {
   using type = double;
   static std::string name() noexcept { return "PassedToB"; }
 };
-/// [tags for const global cache]
+// [tags for const global cache]
 
 template <typename Metavariables>
 struct component_for_simple_action_mock {
@@ -60,17 +60,17 @@ struct component_for_simple_action_mock {
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Testing, tmpl::list<>>>;
 
-  /// [simple action replace]
+  // [simple action replace]
   using replace_these_simple_actions =
       tmpl::list<simple_action_a, simple_action_c, threaded_action_b>;
   using with_these_simple_actions =
       tmpl::list<simple_action_a_mock, simple_action_c_mock,
                  threaded_action_b_mock>;
-  /// [simple action replace]
-  /// [threaded action replace]
+  // [simple action replace]
+  // [threaded action replace]
   using replace_these_threaded_actions = tmpl::list<threaded_action_b>;
   using with_these_threaded_actions = tmpl::list<threaded_action_b_mock>;
-  /// [threaded action replace]
+  // [threaded action replace]
 };
 
 struct simple_action_a_mock {
@@ -188,9 +188,9 @@ struct SimpleActionMockMetavariables {
 struct MockMetavariablesWithGlobalCacheTags {
   using component_list = tmpl::list<
       component_for_simple_action_mock<MockMetavariablesWithGlobalCacheTags>>;
-  /// [const global cache metavars]
+  // [const global cache metavars]
   using const_global_cache_tags = tmpl::list<ValueTag, PassedToB>;
-  /// [const global cache metavars]
+  // [const global cache metavars]
 
   enum class Phase { Initialization, Testing, Exit };
 };
@@ -199,13 +199,13 @@ void test_mock_runtime_system_constructors() {
   using metavars = MockMetavariablesWithGlobalCacheTags;
   using component = component_for_simple_action_mock<metavars>;
   // Test whether we can construct with tagged tuples in different orders.
-  /// [constructor const global cache tags known]
+  // [constructor const global cache tags known]
   ActionTesting::MockRuntimeSystem<metavars> runner1{{3, 7.0}};
-  /// [constructor const global cache tags known]
-  /// [constructor const global cache tags unknown]
+  // [constructor const global cache tags known]
+  // [constructor const global cache tags unknown]
   ActionTesting::MockRuntimeSystem<metavars> runner2{
       tuples::TaggedTuple<PassedToB, ValueTag>{7.0, 3}};
-  /// [constructor const global cache tags unknown]
+  // [constructor const global cache tags unknown]
   ActionTesting::emplace_component<component>(&runner1, 0);
   ActionTesting::emplace_component<component>(&runner2, 0);
   const auto& cache1 = ActionTesting::cache<component>(runner1, 0_st);
@@ -223,12 +223,12 @@ SPECTRE_TEST_CASE("Unit.ActionTesting.MockSimpleAction", "[Unit]") {
       component_for_simple_action_mock<metavars>>(&runner, 0, {0, -1});
   ActionTesting::set_phase(make_not_null(&runner), metavars::Phase::Testing);
 
-  /// [get databox]
+  // [get databox]
   const auto& box =
       ActionTesting::get_databox<component_for_simple_action_mock<metavars>,
                                  db::AddSimpleTags<ValueTag, PassedToB>>(runner,
                                                                          0);
-  /// [get databox]
+  // [get databox]
   CHECK(db::get<PassedToB>(box) == -1);
   runner.simple_action<component_for_simple_action_mock<metavars>,
                        simple_action_b>(0, 0);
@@ -239,20 +239,20 @@ SPECTRE_TEST_CASE("Unit.ActionTesting.MockSimpleAction", "[Unit]") {
           0);
   CHECK(db::get<PassedToB>(box) == 0);
   CHECK(db::get<ValueTag>(box) == 11);
-  /// [invoke simple action]
+  // [invoke simple action]
   ActionTesting::simple_action<component_for_simple_action_mock<metavars>,
                                simple_action_b>(make_not_null(&runner), 0, 2);
-  /// [invoke simple action]
+  // [invoke simple action]
   REQUIRE(not
-          /// [simple action queue empty]
+          // [simple action queue empty]
           ActionTesting::is_simple_action_queue_empty<
               component_for_simple_action_mock<metavars>>(runner, 0)
-          /// [simple action queue empty]
+          // [simple action queue empty]
   );
-  /// [invoke queued simple action]
+  // [invoke queued simple action]
   ActionTesting::invoke_queued_simple_action<
       component_for_simple_action_mock<metavars>>(make_not_null(&runner), 0);
-  /// [invoke queued simple action]
+  // [invoke queued simple action]
   CHECK(db::get<PassedToB>(box) == 2);
   CHECK(db::get<ValueTag>(box) == 25);
   runner.simple_action<component_for_simple_action_mock<metavars>,
@@ -277,10 +277,10 @@ SPECTRE_TEST_CASE("Unit.ActionTesting.MockSimpleAction", "[Unit]") {
   CHECK(db::get<PassedToB>(box) == 3);
   CHECK(db::get<ValueTag>(box) == 25);
 
-  /// [invoke threaded action]
+  // [invoke threaded action]
   ActionTesting::threaded_action<component_for_simple_action_mock<metavars>,
                                  threaded_action_a>(make_not_null(&runner), 0);
-  /// [invoke threaded action]
+  // [invoke threaded action]
   CHECK(db::get<ValueTag>(box) == 35);
 
   ActionTesting::threaded_action<component_for_simple_action_mock<metavars>,
@@ -358,9 +358,9 @@ SPECTRE_TEST_CASE("Unit.ActionTesting.IsRetrievable", "[Unit]") {
   // Runs Action0
   runner.next_action<component>(0);
   CHECK(
-      /// [tag is retrievable]
+      // [tag is retrievable]
       ActionTesting::tag_is_retrievable<component, DummyTimeTag>(runner, 0)
-      /// [tag is retrievable]
+      // [tag is retrievable]
   );
   CHECK(ActionTesting::get_databox_tag<component, DummyTimeTag>(runner, 0) ==
         6);
@@ -429,15 +429,15 @@ SPECTRE_TEST_CASE("Unit.ActionTesting.GetInboxTags", "[Unit]") {
             .empty());
   ActionTesting::next_action<component>(make_not_null(&runner), 0);
   CHECK(
-      /// [const get inbox tags]
+      // [const get inbox tags]
       ActionTesting::get_inbox_tag<component, Tags::ValueTag>(runner, 0).at(1)
-      /// [const get inbox tags]
+      // [const get inbox tags]
       == 23);
-  /// [get inbox tags]
+  // [get inbox tags]
   ActionTesting::get_inbox_tag<component, Tags::ValueTag>(
       make_not_null(&runner), 0)
       .clear();
-  /// [get inbox tags]
+  // [get inbox tags]
   CHECK(ActionTesting::get_inbox_tag<component, Tags::ValueTag>(
             make_not_null(&runner), 0)
             .empty());
@@ -466,7 +466,7 @@ struct ComponentA {
 template <typename Metavariables>
 struct ComponentB;
 
-/// [mock component b]
+// [mock component b]
 template <typename Metavariables>
 struct ComponentBMock {
   using metavariables = Metavariables;
@@ -484,7 +484,7 @@ struct ComponentBMock {
       Parallel::PhaseActions<typename Metavariables::Phase,
                              Metavariables::Phase::Testing, tmpl::list<>>>;
 };
-/// [mock component b]
+// [mock component b]
 
 struct ActionCalledOnComponentB {
   template <typename ParallelComponent, typename DbTagsList,
@@ -499,7 +499,7 @@ struct ActionCalledOnComponentB {
   }
 };
 
-/// [action call component b]
+// [action call component b]
 struct CallActionOnComponentB {
   template <typename ParallelComponent, typename DbTagsList,
             typename Metavariables, typename ArrayIndex>
@@ -510,7 +510,7 @@ struct CallActionOnComponentB {
         Parallel::get_parallel_component<ComponentB<Metavariables>>(cache));
   }
 };
-/// [action call component b]
+// [action call component b]
 
 struct Metavariables {
   using component_list =
@@ -526,24 +526,24 @@ SPECTRE_TEST_CASE("Unit.ActionTesting.MockComponent", "[Unit]") {
 
   ActionTesting::MockRuntimeSystem<metavars> runner{{}};
   ActionTesting::emplace_component<component_a>(&runner, 0);
-  /// [initialize component b]
+  // [initialize component b]
   ActionTesting::emplace_component_and_initialize<
       ComponentBMock<Metavariables>>(&runner, 0, {0});
-  /// [initialize component b]
+  // [initialize component b]
 
   ActionTesting::set_phase(make_not_null(&runner), metavars::Phase::Testing);
   CHECK(ActionTesting::get_databox_tag<component_b_mock, ValueTag>(runner, 0) ==
         0);
   ActionTesting::simple_action<component_a, CallActionOnComponentB>(
       make_not_null(&runner), 0);
-  /// [component b mock checks]
+  // [component b mock checks]
   CHECK(not ActionTesting::is_simple_action_queue_empty<component_b_mock>(
       runner, 0));
   ActionTesting::invoke_queued_simple_action<component_b_mock>(
       make_not_null(&runner), 0);
   CHECK(ActionTesting::get_databox_tag<component_b_mock, ValueTag>(runner, 0) ==
         5);
-  /// [component b mock checks]
+  // [component b mock checks]
 }
 }  // namespace TestComponentMocking
 

--- a/tests/Unit/Framework/Tests/Test_Pypp.cpp
+++ b/tests/Unit/Framework/Tests/Test_Pypp.cpp
@@ -31,7 +31,7 @@
 // IWYU pragma: no_forward_declare Tensor
 
 namespace {
-/// [convert_arbitrary_a]
+// [convert_arbitrary_a]
 struct ClassForConversionTest {
   double a_;
   double b_;
@@ -57,9 +57,9 @@ struct ConvertClassForConservionTestA {
     return 1;
   }
 };
-/// [convert_arbitrary_a]
+// [convert_arbitrary_a]
 
-/// [convert_arbitrary_b]
+// [convert_arbitrary_b]
 struct ConvertClassForConservionTestB {
   using unpacked_container = double;
   using packed_container = ClassForConversionTest;
@@ -80,7 +80,7 @@ struct ConvertClassForConservionTestB {
     return 1;
   }
 };
-/// [convert_arbitrary_b]
+// [convert_arbitrary_b]
 
 void test_none() {
   pypp::call<pypp::None>("PyppPyTests", "test_none");
@@ -99,10 +99,10 @@ void test_std_string() {
 }
 
 void test_int() {
-  /// [pypp_int_test]
+  // [pypp_int_test]
   const auto ret = pypp::call<long>("PyppPyTests", "test_numeric", 3, 4);
   CHECK(ret == 3 * 4);
-  /// [pypp_int_test]
+  // [pypp_int_test]
   CHECK_THROWS(pypp::call<double>("PyppPyTests", "test_numeric", 3, 4));
   CHECK_THROWS(pypp::call<void*>("PyppPyTests", "test_numeric", 3, 4));
   CHECK_THROWS(pypp::call<long>("PyppPyTests", "test_none"));
@@ -133,13 +133,13 @@ void test_double() {
 }
 
 void test_std_vector() {
-  /// [pypp_vector_test]
+  // [pypp_vector_test]
   const auto ret = pypp::call<std::vector<double>>(
       "PyppPyTests", "test_vector", std::vector<double>{1.3, 4.9},
       std::vector<double>{4.2, 6.8});
   CHECK(approx(ret[0]) == 1.3 * 4.2);
   CHECK(approx(ret[1]) == 4.9 * 6.8);
-  /// [pypp_vector_test]
+  // [pypp_vector_test]
   CHECK_THROWS(pypp::call<std::string>("PyppPyTests", "test_vector",
                                        std::vector<double>{1.3, 4.9},
                                        std::vector<double>{4.2, 6.8}));
@@ -441,10 +441,10 @@ void test_einsum(const T& used_for_size) {
     }
     return tnsr;
   }();
-  /// [einsum_example]
+  // [einsum_example]
   const auto tensor_from_python = pypp::call<tnsr::i<T, 3>>(
       "PyppPyTests", "test_einsum", scalar, vector, tnsr_ia, tnsr_AA, tnsr_iaa);
-  /// [einsum_example]
+  // [einsum_example]
   CHECK_ITERABLE_CUSTOM_APPROX(expected, tensor_from_python,
                                approx.epsilon(2.0e-13));
 }
@@ -496,12 +496,12 @@ void test_optional() {
 void test_custom_conversion() {
   const Scalar<DataVector> t{DataVector{5, 2.5}};
   {
-    /// [convert_arbitrary_a_call]
+    // [convert_arbitrary_a_call]
     const auto result = pypp::call<Scalar<DataVector>,
                                    tmpl::list<ConvertClassForConservionTestA>>(
         "PyppPyTests", "custom_conversion", t,
         ClassForConversionTest{2.0, 3.0});
-    /// [convert_arbitrary_a_call]
+    // [convert_arbitrary_a_call]
     CHECK(DataVector{5, 5.0} == get(result));
   }
   {

--- a/tests/Unit/Framework/Tests/Test_PyppRandomValues.cpp
+++ b/tests/Unit/Framework/Tests/Test_PyppRandomValues.cpp
@@ -360,12 +360,12 @@ void test_free(const T& value) {
       &check_double_not_null1<T>, "PyppPyTests",
       {"check_double_not_null1_result0", "check_double_not_null1_result1"},
       {{{-10.0, 10.0}}}, value);
-  /// [cxx_two_not_null]
+  // [cxx_two_not_null]
   pypp::check_with_random_values<2>(
       &check_double_not_null2<T>, "PyppPyTests",
       {"check_double_not_null2_result0", "check_double_not_null2_result1"},
       {{{0.0, 10.0}, {-10.0, 0.0}}}, value);
-  /// [cxx_two_not_null]
+  // [cxx_two_not_null]
 
   pypp::check_with_random_values<1>(&check_by_value0<T>, "PyppPyTests",
                                     "check_by_value0", {{{-10.0, 10.0}}},

--- a/tests/Unit/Framework/Tests/Test_TestCreation.cpp
+++ b/tests/Unit/Framework/Tests/Test_TestCreation.cpp
@@ -212,11 +212,11 @@ void test_test_creation() {
   CHECK(TestHelpers::test_creation<double, TwoGroup<double>>("1.846") == 1.846);
 
   // Test class that doesn't need metavariables when not passing metavariables
-  /// [size_t_argument]
+  // [size_t_argument]
   CHECK(
       TestHelpers::test_creation<ClassWithoutMetavariables>("SizeT: 7").value ==
       7);
-  /// [size_t_argument]
+  // [size_t_argument]
 
   CHECK(
       TestHelpers::test_creation<ClassWithoutMetavariables,
@@ -292,12 +292,12 @@ void test_test_creation() {
 void test_test_factory_creation() {
   // Test derived class that doesn't need metavariables when not passing
   // metavariables
-  /// [size_t_argument_base]
+  // [size_t_argument_base]
   CHECK(TestHelpers::test_factory_creation<BaseClass>(
             "DerivedClassWithoutMetavariables:\n"
             "  SizeT: 5")
             ->get_value() == 5);
-  /// [size_t_argument_base]
+  // [size_t_argument_base]
   CHECK(TestHelpers::test_factory_creation<BaseClass,
                                            NoGroup<std::unique_ptr<BaseClass>>>(
             "DerivedClassWithoutMetavariables:\n"
@@ -389,9 +389,9 @@ void test_test_factory_creation() {
 }
 
 void test_test_enum_creation() {
-  /// [enum_purple]
+  // [enum_purple]
   CHECK(TestHelpers::test_creation<Color>("Purple") == Color::Purple);
-  /// [enum_purple]
+  // [enum_purple]
   CHECK(TestHelpers::test_creation<Color, TestHelpers::TestCreationOpt<Color>>(
             "Purple") == Color::Purple);
   CHECK(TestHelpers::test_creation<Color, NoGroup<Color>>("Purple") ==

--- a/tests/Unit/Framework/Tests/Test_TestingFramework.cpp
+++ b/tests/Unit/Framework/Tests/Test_TestingFramework.cpp
@@ -8,10 +8,10 @@
 #include "Utilities/System/Abort.hpp"
 
 SPECTRE_TEST_CASE("Unit.TestingFramework.Approx", "[Unit]") {
-  /// [approx_test]
+  // [approx_test]
   CHECK(1.0 == approx(1.0 + 1e-15));
   CHECK(1.0 != approx(1.0 + 1e-13));
-  /// [approx_test]
+  // [approx_test]
   // also check numbers that are not order unity, but do not include in example
   CHECK(1e-10 == approx(1e-10 + 1e-25).scale(1e-10));
   CHECK(1e-10 == approx(1e-10 + 1e-23));
@@ -19,19 +19,19 @@ SPECTRE_TEST_CASE("Unit.TestingFramework.Approx", "[Unit]") {
   CHECK(1e+10 == approx(1e+10 + 1e-5));
   CHECK(1e+10 != approx(1e+10 + 1e-3));
 
-  /// [approx_default]
+  // [approx_default]
   CHECK(sin(M_PI / 4.0) == approx(cos(M_PI / 4.0)));
-  /// [approx_default]
-  /// [approx_single_custom]
+  // [approx_default]
+  // [approx_single_custom]
   // This check needs tolerance 1e-12 for X reason.
   CHECK(1.0 == approx(1.0 + 5e-13).epsilon(1e-12));
-  /// [approx_single_custom]
-  /// [approx_new_custom]
+  // [approx_single_custom]
+  // [approx_new_custom]
   // The checks in this test need tolerance 1e-12 for X reason.
   Approx my_approx = Approx::custom().epsilon(1e-12);
   CHECK(1.0 == my_approx(1.0 + 5e-13));
   CHECK(1.0 != my_approx(1.0 + 5e-12));
-  /// [approx_new_custom]
+  // [approx_new_custom]
 }
 
 // [[OutputRegex, I failed]]

--- a/tests/Unit/Helpers/ApparentHorizons/StrahlkorperGrTestHelpers.cpp
+++ b/tests/Unit/Helpers/ApparentHorizons/StrahlkorperGrTestHelpers.cpp
@@ -123,7 +123,7 @@ Scalar<DataType> horizon_ricci_scalar(
 
   // Get the ricci scalar for a Kerr black hole with spin in the +z direction
   // but same mass and spin magnitude
-  const auto ricci_scalar_with_spin_on_z_axis = horizon_ricci_scalar(
+  auto ricci_scalar_with_spin_on_z_axis = horizon_ricci_scalar(
       horizon_radius_with_spin_on_z_axis, mass, spin_magnitude);
 
   // Is the spin aligned? If so, just return the aligned-spin scalar curvature

--- a/tests/Unit/Helpers/ApparentHorizons/StrahlkorperGrTestHelpers.cpp
+++ b/tests/Unit/Helpers/ApparentHorizons/StrahlkorperGrTestHelpers.cpp
@@ -17,7 +17,6 @@
 #include "Utilities/StdArrayHelpers.hpp"
 
 // IWYU pragma: no_forward_declare Tensor
-/// \cond
 namespace TestHelpers {
 namespace Schwarzschild {
 
@@ -224,4 +223,3 @@ template Scalar<DataVector> TestHelpers::Kerr::horizon_ricci_scalar(
     const Scalar<DataVector>& horizon_radius_with_spin_on_z_axis,
     const YlmSpherepack& ylm_with_spin_on_z_axis, const YlmSpherepack& ylm,
     const double mass, const std::array<double, 3>& spin) noexcept;
-/// \endcond

--- a/tests/Unit/Helpers/ControlSystem/FoTUpdater_Helper.cpp
+++ b/tests/Unit/Helpers/ControlSystem/FoTUpdater_Helper.cpp
@@ -8,8 +8,7 @@
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Utilities/Gsl.hpp"
 
-namespace TestHelpers {
-namespace ControlErrors {
+namespace TestHelpers::ControlErrors {
 
 template <size_t DerivOrder>
 Translation<DerivOrder>::Translation(DataVector target_coords) noexcept
@@ -23,7 +22,6 @@ void Translation<DerivOrder>::operator()(
   const DataVector q = coords - target_coords_ - f_of_t.func(time)[0];
   updater->measure(time, q);
 }
-}  // namespace ControlErrors
-}  // namespace TestHelpers
+}  // namespace TestHelpers::ControlErrors
 
 template class TestHelpers::ControlErrors::Translation<2>;

--- a/tests/Unit/Helpers/ControlSystem/FoTUpdater_Helper.cpp
+++ b/tests/Unit/Helpers/ControlSystem/FoTUpdater_Helper.cpp
@@ -26,6 +26,4 @@ void Translation<DerivOrder>::operator()(
 }  // namespace ControlErrors
 }  // namespace TestHelpers
 
-/// \cond
 template class TestHelpers::ControlErrors::Translation<2>;
-/// \endcond

--- a/tests/Unit/Helpers/DataStructures/RandomUnitNormal.cpp
+++ b/tests/Unit/Helpers/DataStructures/RandomUnitNormal.cpp
@@ -14,7 +14,6 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-/// \cond
 template <typename DataType>
 tnsr::I<DataType, 1> random_unit_normal(
     const gsl::not_null<std::mt19937*> generator,
@@ -81,4 +80,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (double, DataVector), (1, 2, 3))
 #undef INSTANTIATION
 #undef DIM
 #undef DTYPE
-/// \endcond

--- a/tests/Unit/Helpers/Domain/BoundaryConditions/BoundaryCondition.cpp
+++ b/tests/Unit/Helpers/Domain/BoundaryConditions/BoundaryCondition.cpp
@@ -11,7 +11,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-/// \cond
 namespace TestHelpers::domain::BoundaryConditions {
 template <size_t Dim>
 BoundaryConditionBase<Dim>::BoundaryConditionBase(
@@ -116,4 +115,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef DIM
 #undef INSTANTIATION
 }  // namespace TestHelpers::domain::BoundaryConditions
-/// \endcond

--- a/tests/Unit/Helpers/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Helpers/Domain/DomainTestHelpers.cpp
@@ -531,7 +531,6 @@ tnsr::i<DataType, SpatialDim> unit_basis_form(
   return basis_form;
 }
 
-/// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                          \
@@ -597,4 +596,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_BASIS_VECTOR, (1, 2, 3),
 #undef DIM
 #undef DTYPE
 #undef INSTANTIATE_BASIS_VECTOR
-/// \endcond

--- a/tests/Unit/Helpers/PointwiseFunctions/Hydro/TestHelpers.cpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/Hydro/TestHelpers.cpp
@@ -16,7 +16,6 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-/// \cond
 namespace TestHelpers {
 namespace hydro {
 template <typename DataType>
@@ -157,4 +156,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_TENSORS, (double, DataVector), (1, 2, 3))
 #undef DTYPE
 }  // namespace hydro
 }  // namespace TestHelpers
-/// \endcond

--- a/tests/Unit/Helpers/PointwiseFunctions/Hydro/TestHelpers.cpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/Hydro/TestHelpers.cpp
@@ -16,8 +16,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-namespace TestHelpers {
-namespace hydro {
+namespace TestHelpers::hydro {
 template <typename DataType>
 Scalar<DataType> random_density(const gsl::not_null<std::mt19937*> generator,
                                 const DataType& used_for_size) noexcept {
@@ -154,5 +153,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_TENSORS, (double, DataVector), (1, 2, 3))
 #undef INSTANTIATE_TENSORS
 #undef DIM
 #undef DTYPE
-}  // namespace hydro
-}  // namespace TestHelpers
+}  // namespace TestHelpers::hydro

--- a/tests/Unit/IO/Observers/Test_RegisterEvents.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterEvents.cpp
@@ -47,11 +47,9 @@ class SomeEvent : public Event<EventRegistrars> {
   explicit SomeEvent(std::string subfile_path) noexcept
       : subfile_path_(std::move(subfile_path)) {}
 
-  /// \cond
   explicit SomeEvent(CkMigrateMessage* /*unused*/) noexcept {}
   using PUP::able::register_constructor;
   WRAPPED_PUPable_decl_template(SomeEvent);  // NOLINT
-  /// \endcond
 
   using observation_registration_tags = tmpl::list<>;
   std::pair<observers::TypeOfObservation, observers::ObservationKey>

--- a/tests/Unit/IO/Test_H5.cpp
+++ b/tests/Unit/IO/Test_H5.cpp
@@ -54,11 +54,11 @@ SPECTRE_TEST_CASE("Unit.IO.H5.File", "[Unit][IO][H5]") {
   if (file_system::check_if_file_exists(h5_file_name)) {
     file_system::rm(h5_file_name, true);
   }
-  /// [h5file_readwrite_get_header]
+  // [h5file_readwrite_get_header]
   h5::H5File<h5::AccessType::ReadWrite> my_file0(h5_file_name);
   // Check that the header was written correctly
   const std::string header = my_file0.get<h5::Header>("/header").get_header();
-  /// [h5file_readwrite_get_header]
+  // [h5file_readwrite_get_header]
   my_file0.close_current_object();
 
   const auto check_header = [&h5_file_name](const auto& my_file) noexcept {
@@ -180,14 +180,14 @@ SPECTRE_TEST_CASE("Unit.IO.H5.FileErrorCannotAppendReadOnly",
   h5::H5File<h5::AccessType::ReadOnly> my_file(file_name, true);
 }
 
-/// [willfail_example_for_dev_doc]
+// [willfail_example_for_dev_doc]
 // [[OutputRegex, File './Unit.IO.H5.FileErrorExists.h5' already exists and we
 // are not allowed to append. To reduce the risk of accidental deletion you must
 // explicitly delete the file first using the file_system library in
 // SpECTRE or through your shell.]]
 SPECTRE_TEST_CASE("Unit.IO.H5.FileErrorExists", "[Unit][IO][H5]") {
   ERROR_TEST();
-  /// [willfail_example_for_dev_doc]
+  // [willfail_example_for_dev_doc]
   std::string file_name = "./Unit.IO.H5.FileErrorExists.h5";
   if (file_system::check_if_file_exists(file_name)) {
     file_system::rm(file_name, true);
@@ -196,9 +196,9 @@ SPECTRE_TEST_CASE("Unit.IO.H5.FileErrorExists", "[Unit][IO][H5]") {
   // pure virtual method called
   // terminate called recursively
   {
-    /// [h5file_readwrite_file]
+    // [h5file_readwrite_file]
     h5::H5File<h5::AccessType::ReadWrite> my_file(file_name);
-    /// [h5file_readwrite_file]
+    // [h5file_readwrite_file]
   }
   h5::H5File<h5::AccessType::ReadWrite> my_file_2(file_name);
 }
@@ -241,16 +241,16 @@ SPECTRE_TEST_CASE("Unit.IO.H5.Version", "[Unit][IO][H5]") {
     file_system::rm(h5_file_name, true);
   }
   {
-    /// [h5file_write_version]
+    // [h5file_write_version]
     h5::H5File<h5::AccessType::ReadWrite> my_file(h5_file_name);
     my_file.insert<h5::Version>("/the_version", version_number);
-    /// [h5file_write_version]
+    // [h5file_write_version]
   }
 
   h5::H5File<h5::AccessType::ReadOnly> my_file(h5_file_name);
-  /// [h5file_read_version]
+  // [h5file_read_version]
   const auto& const_version = my_file.get<h5::Version>("/the_version");
-  /// [h5file_read_version]
+  // [h5file_read_version]
   CHECK(version_number == const_version.get_version());
   auto& version = my_file.get<h5::Version>("/the_version");
   CHECK(version_number == version.get_version());
@@ -306,7 +306,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.Dat", "[Unit][IO][H5]") {
   std::array<hsize_t, 2> size_of_data{{4, 4}};
   CHECK(error_file.get_dimensions() == size_of_data);
 
-  /// [h5dat_get_data]
+  // [h5dat_get_data]
   const Matrix data_in_dat_file = []() {
     Matrix result(4, 4);
     result(0, 0) = 0.0;
@@ -328,7 +328,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.Dat", "[Unit][IO][H5]") {
     return result;
   }();
   CHECK(error_file.get_data() == data_in_dat_file);
-  /// [h5dat_get_data]
+  // [h5dat_get_data]
 
   {
     const auto subset = error_file.get_data_subset({1, 2}, 1, 2);
@@ -343,7 +343,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.Dat", "[Unit][IO][H5]") {
     CHECK(subset == answer);
   }
   {
-    /// [h5dat_get_subset]
+    // [h5dat_get_subset]
     const auto subset = error_file.get_data_subset({1, 3}, 1, 3);
     const Matrix answer = []() {
       Matrix result(3, 2);
@@ -356,7 +356,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.Dat", "[Unit][IO][H5]") {
       return result;
     }();
     CHECK(subset == answer);
-    /// [h5dat_get_subset]
+    // [h5dat_get_subset]
   }
   {
     const auto subset = error_file.get_data_subset({0, 3}, 0, 2);
@@ -629,7 +629,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.contains_attribute_false", "[Unit][IO][H5]") {
   CHECK_H5(H5Fclose(file_id), "Failed to close file: '" << h5_file_name << "'");
 }
 
-/// [[OutputRegex, Failed HDF5 operation: Failed to open dataset 'no_dataset']]
+// [[OutputRegex, Failed HDF5 operation: Failed to open dataset 'no_dataset']]
 SPECTRE_TEST_CASE("Unit.IO.H5.read_data_error", "[Unit][IO][H5]") {
   ERROR_TEST();
   const std::string file_name("Unit.IO.H5.read_data_error.h5");

--- a/tests/Unit/IO/Test_VolumeData.cpp
+++ b/tests/Unit/IO/Test_VolumeData.cpp
@@ -257,12 +257,12 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData", "[Unit][IO][H5]") {
   {
     INFO("offset_and_length_for_grid");
     const size_t observation_id = observation_ids.front();
-    /// [find_offset]
+    // [find_offset]
     const auto all_grid_names = volume_file.get_grid_names(observation_id);
     const auto all_extents = volume_file.get_extents(observation_id);
     const auto first_grid_offset_and_length = h5::offset_and_length_for_grid(
         grid_names.front(), all_grid_names, all_extents);
-    /// [find_offset]
+    // [find_offset]
     CHECK(first_grid_offset_and_length.first == 0);
     CHECK(first_grid_offset_and_length.second == 8);
     const auto last_grid_offset_and_length = h5::offset_and_length_for_grid(

--- a/tests/Unit/NumericalAlgorithms/Integration/Test_GslQuadAdaptive.cpp
+++ b/tests/Unit/NumericalAlgorithms/Integration/Test_GslQuadAdaptive.cpp
@@ -11,12 +11,12 @@
 #include "NumericalAlgorithms/Integration/GslQuadAdaptive.hpp"
 
 namespace {
-/// [integrated_function]
+// [integrated_function]
 double gaussian(const double x, const double mean,
                 const double factor) noexcept {
   return 2. * factor / sqrt(M_PI) * exp(-square(x - mean));
 }
-/// [integrated_function]
+// [integrated_function]
 
 double integrable_singularity(const double x, const double factor) noexcept {
   return factor * cos(sqrt(abs(x))) / sqrt(abs(x));
@@ -33,7 +33,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.Integration.GslQuadAdaptive",
   {
     INFO("StandardGaussKronrod");
     // Construct the integration and give an example
-    /// [integration_example]
+    // [integration_example]
     const integration::GslQuadAdaptive<
         integration::GslIntegralType::StandardGaussKronrod>
         integration{20};
@@ -44,7 +44,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.Integration.GslQuadAdaptive",
     const auto result = integration(
         [&mean, &factor](const double x) { return gaussian(x, mean, factor); },
         lower_boundary, upper_boundary, absolute_tolerance, 4);
-    /// [integration_example]
+    // [integration_example]
     CHECK(result == custom_approx(factor * erf(upper_boundary - mean) -
                                   factor * erf(lower_boundary - mean)));
     CHECK_THROWS(integration(

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
@@ -32,7 +32,6 @@
 
 // IWYU pragma: no_include <boost/variant/get.hpp>
 
-/// \cond
 class DataVector;
 namespace intrp::Tags {
 template <typename TemporalId>
@@ -44,7 +43,6 @@ namespace Parallel {
 template <typename Metavariables>
 class GlobalCache;
 }  // namespace Parallel
-/// \endcond
 
 namespace {
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_CleanUpInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_CleanUpInterpolator.cpp
@@ -28,14 +28,12 @@
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
-/// \cond
 // IWYU pragma: no_forward_declare ActionTesting::InitializeDataBox
 class DataVector;
 template <size_t VolumeDim>
 class ElementId;
 namespace intrp {
 }  // namespace intrp
-/// \endcond
 
 namespace {
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_CubicSpline.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_CubicSpline.cpp
@@ -19,7 +19,8 @@ void test_cubic_spline(const F& function, const double lower_bound,
                        const double tolerance_interior) noexcept {
   // Construct random points between lower and upper bound to interpolate
   // through. Always include the bounds in the x-values.
-  std::vector<double> x_values(size), y_values(size);
+  std::vector<double> x_values(size);
+  std::vector<double> y_values(size);
   const double delta_x = (upper_bound - lower_bound) / size;
   MAKE_GENERATOR(gen);
   std::uniform_real_distribution<> dist(0., delta_x);
@@ -76,8 +77,8 @@ void test_cubic_spline(const F& function, const double lower_bound,
     // Since this is a cubic spline interpolation, boundary effects should be
     // confined to the outer three interpolation points.
     const double boundary_fraction = 0.3;
-    if (i > 10 * size * boundary_fraction and
-        i < 10 * size * (1. - boundary_fraction)) {
+    if (i > 10. * size * boundary_fraction and
+        i < 10. * size * (1. - boundary_fraction)) {
       CHECK(interpolated_y_value == custom_approx_interior(y_value));
       if (error >= max_error_interior) {
         max_error_interior = error;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_CubicSpline.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_CubicSpline.cpp
@@ -37,13 +37,13 @@ void test_cubic_spline(const F& function, const double lower_bound,
       Approx::custom().epsilon(tolerance_interior).scale(1.);
 
   // Construct the interpolant and give an example
-  /// [interpolate_example]
+  // [interpolate_example]
   intrp::CubicSpline interpolant{x_values, y_values};
   const double x_to_interpolate_to =
       lower_bound + (upper_bound - lower_bound) / 2.;
   CHECK(interpolant(x_to_interpolate_to) ==
         custom_approx_interior(function(x_to_interpolate_to)));
-  /// [interpolate_example]
+  // [interpolate_example]
 
   // Check that the interpolation is exact at the datapoints
   for (const auto& x_value : x_values) {

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
@@ -26,9 +26,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
-/// \cond
 class DataVector;
-/// \endcond
 
 namespace {
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolator.cpp
@@ -21,9 +21,7 @@
 
 // IWYU pragma: no_include <boost/variant/get.hpp>
 
-/// \cond
 class DataVector;
-/// \endcond
 
 namespace {
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateEvent.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolateEvent.cpp
@@ -36,7 +36,6 @@
 // "DataStructures/DataBox/Prefixes.hpp", IWYU tells me to remove it.
 // If I remove it, IWYU tells me to include it.
 
-/// \cond
 class DataVector;
 namespace Parallel {
 template <typename Metavariables>
@@ -49,7 +48,6 @@ class DataBox;
 namespace intrp::Actions {
 struct InterpolatorReceiveVolumeData;
 }  // namespace intrp::Actions
-/// \endcond
 
 namespace {
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
@@ -39,7 +39,6 @@
 
 // IWYU pragma: no_include <boost/variant/get.hpp>
 
-/// \cond
 // IWYU pragma: no_forward_declare ActionTesting::InitializeDataBox
 // IWYU pragma: no_forward_declare Tensor
 // IWYU pragma: no_forward_declare Variables
@@ -64,7 +63,6 @@ struct TemporalIds;
 template <typename TemporalId>
 struct CompletedTemporalIds;
 }  // namespace intrp::Tags
-/// \endcond
 
 namespace {
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetVarsFromElement.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetVarsFromElement.cpp
@@ -24,12 +24,10 @@
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/Rational.hpp"
 
-/// \cond
 namespace Parallel {
 template <typename Metavariables>
 class GlobalCache;
 }  // namespace Parallel
-/// \endcond
 
 namespace {
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
@@ -43,7 +43,6 @@
 
 // IWYU pragma: no_include <boost/variant/get.hpp>
 
-/// \cond
 namespace intrp::Actions {
 template <typename InterpolationTargetTag>
 struct InterpolationTargetReceiveVars;
@@ -66,7 +65,6 @@ namespace Tags {
 template <typename TagsList>
 struct Variables;
 }  // namespace Tags
-/// \endcond
 
 namespace {
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
@@ -57,7 +57,6 @@
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
-/// \cond
 // IWYU pragma: no_forward_declare ActionTesting::InitializeDataBox
 // IWYU pragma: no_forward_declare Tensor
 namespace intrp::Actions {
@@ -82,7 +81,6 @@ struct TemporalIds;
 template <typename TemporalId>
 struct VolumeVarsInfo;
 }  // namespace intrp::Tags
-/// \endcond
 
 namespace {
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
@@ -18,12 +18,10 @@
 
 // IWYU pragma: no_include <boost/variant/get.hpp>
 
-/// \cond
 class DataVector;
 namespace intrp::Tags {
 struct NumberOfElements;
 }  // namespace intrp::Tags
-/// \endcond
 
 namespace {
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
@@ -73,14 +73,12 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace StrahlkorperGr::Tags {
 template <typename Frame>
 struct AreaElement;
 template <typename IntegrandTag, typename Frame>
 struct SurfaceIntegral;
 }  // namespace StrahlkorperGr::Tags
-/// \endcond
 
 namespace {
 // Simple DataBoxItems for test.

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
@@ -56,7 +56,6 @@
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
-/// \cond
 // IWYU pragma: no_forward_declare db::DataBox
 // IWYU pragma: no_forward_declare Tensor
 namespace Parallel {
@@ -67,7 +66,6 @@ namespace StrahlkorperTags {
 template <typename Frame>
 struct Strahlkorper;
 }  // namespace StrahlkorperTags
-/// \endcond
 
 namespace {
 // Simple DataBoxItems for test.

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Filtering.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Filtering.cpp
@@ -66,7 +66,7 @@ struct Component {
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
-      /// [action_list_example]
+      // [action_list_example]
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Testing,
           tmpl::conditional_t<
@@ -78,7 +78,7 @@ struct Component {
               tmpl::list<dg::Actions::Filter<
                   Filters::Exponential<0>,
                   tmpl::list<Tags::VectorVar<dim>, Tags::ScalarVar>>>>>>;
-  /// [action_list_example]
+  // [action_list_example]
 };
 
 template <size_t Dim, bool FilterIndividually>

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Test_Gmres.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Test_Gmres.cpp
@@ -37,7 +37,7 @@ struct SomePrefix : db::PrefixTag {
 SPECTRE_TEST_CASE("Unit.LinearSolver.Serial.Gmres",
                   "[Unit][NumericalAlgorithms][LinearSolver]") {
   {
-    /// [gmres_example]
+    // [gmres_example]
     INFO("Solve a symmetric 2x2 matrix");
     DenseMatrix<double> matrix(2, 2);
     matrix(0, 0) = 4.;
@@ -73,7 +73,7 @@ SPECTRE_TEST_CASE("Unit.LinearSolver.Serial.Gmres",
     for (size_t i = 1; i < has_converged.num_iterations(); ++i) {
       CHECK(recorded_residuals[i] <= recorded_residuals[i - 1]);
     }
-    /// [gmres_example]
+    // [gmres_example]
     {
       INFO("Check that a solved system terminates early");
       const auto second_has_converged =

--- a/tests/Unit/NumericalAlgorithms/OdeIntegration/Test_OdeIntegration.cpp
+++ b/tests/Unit/NumericalAlgorithms/OdeIntegration/Test_OdeIntegration.cpp
@@ -14,19 +14,19 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.OdeIntegration",
                   "[Unit][NumericalAlgorithms]") {
 
   // explicit stepper for an array of fundamental types
-  /// [explicit_fundamental_array_system]
+  // [explicit_fundamental_array_system]
   const auto oscillatory_array_system = [](const std::array<double, 2>& state,
                                            std::array<double, 2>& dt_state,
                                            const double /*time*/) noexcept {
     dt_state[0] = state[1];
     dt_state[1] = -state[0];
   };
-  /// [explicit_fundamental_array_system]
-  /// [explicit_fundamental_stepper_construction]
+  // [explicit_fundamental_array_system]
+  // [explicit_fundamental_stepper_construction]
   boost::numeric::odeint::runge_kutta4<std::array<double, 2>>
       fixed_array_stepper;
-  /// [explicit_fundamental_stepper_construction]
-  /// [explicit_fundamental_stepper_use]
+  // [explicit_fundamental_stepper_construction]
+  // [explicit_fundamental_stepper_use]
   const double fixed_step = 0.001;
   std::array<double, 2> fixed_step_array_state{{1.0, 0.0}};
   for (size_t i = 0; i < 1000; ++i) {
@@ -36,16 +36,16 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.OdeIntegration",
                                 fixed_step_array_state, i * fixed_step,
                                 fixed_step);
   }
-  /// [explicit_fundamental_stepper_use]
+  // [explicit_fundamental_stepper_use]
 
   // dense output stepper for a fundamental type
-  /// [dense_output_fundamental_system]
+  // [dense_output_fundamental_system]
   const auto quadratic_system = [](const double /*state*/, double& dt_state,
                                    const double time) noexcept {
     dt_state = 2.0 * time;
   };
-  /// [dense_output_fundamental_system]
-  /// [dense_output_fundamental_construction]
+  // [dense_output_fundamental_system]
+  // [dense_output_fundamental_construction]
   boost::numeric::odeint::dense_output_runge_kutta<
       boost::numeric::odeint::controlled_runge_kutta<
           boost::numeric::odeint::runge_kutta_dopri5<double>>>
@@ -53,8 +53,8 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.OdeIntegration",
           1.0e-12, 1.0e-12,
           boost::numeric::odeint::runge_kutta_dopri5<double>{});
   dense_fundamental_stepper.initialize(1.0, 1.0, 0.01);
-  /// [dense_output_fundamental_construction]
-  /// [dense_output_fundamental_stepper_use]
+  // [dense_output_fundamental_construction]
+  // [dense_output_fundamental_stepper_use]
   std::pair<double, double> step_range =
       dense_fundamental_stepper.do_step(quadratic_system);
   double state_output;
@@ -65,9 +65,9 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.OdeIntegration",
     dense_fundamental_stepper.calc_state(1.0 + 0.01 * square(i), state_output);
     CHECK(approx(state_output) == square(1.0 + 0.01 * square(i)));
   }
-  /// [dense_output_fundamental_stepper_use]
+  // [dense_output_fundamental_stepper_use]
   // dense output stepper for an array of SpECTRE vectors
-  /// [dense_output_vector_stepper]
+  // [dense_output_vector_stepper]
   const auto oscillatory_vector_system =
       [](const std::array<DataVector, 2>& state,
          std::array<DataVector, 2>& dt_state, const double /*time*/) noexcept {
@@ -101,5 +101,5 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.OdeIntegration",
             -(0.1 * j + 0.1) * sin(0.01 * i));
     }
   }
-  /// [dense_output_vector_stepper]
+  // [dense_output_vector_stepper]
 }

--- a/tests/Unit/NumericalAlgorithms/OdeIntegration/Test_OdeIntegration.cpp
+++ b/tests/Unit/NumericalAlgorithms/OdeIntegration/Test_OdeIntegration.cpp
@@ -12,7 +12,6 @@
 
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.OdeIntegration",
                   "[Unit][NumericalAlgorithms]") {
-
   // explicit stepper for an array of fundamental types
   // [explicit_fundamental_array_system]
   const auto oscillatory_array_system = [](const std::array<double, 2>& state,

--- a/tests/Unit/NumericalAlgorithms/RootFinding/Test_NewtonRaphson.cpp
+++ b/tests/Unit/NumericalAlgorithms/RootFinding/Test_NewtonRaphson.cpp
@@ -28,7 +28,7 @@ struct FuncAndDeriv {
 };
 
 void test_simple() noexcept {
-  /// [double_newton_raphson_root_find]
+  // [double_newton_raphson_root_find]
   const size_t digits = 8;
   const double correct = sqrt(2.);
   const double guess = 1.5;
@@ -39,7 +39,7 @@ void test_simple() noexcept {
   };
   const auto root_from_lambda = RootFinder::newton_raphson(
       func_and_deriv_lambda, guess, lower, upper, digits);
-  /// [double_newton_raphson_root_find]
+  // [double_newton_raphson_root_find]
   const auto root_from_free = RootFinder::newton_raphson(
       func_and_deriv_free, guess, lower, upper, digits);
   const FuncAndDeriv func_and_deriv_functor{};
@@ -74,7 +74,7 @@ void test_bounds() noexcept {
 }
 
 void test_datavector() noexcept {
-  /// [datavector_newton_raphson_root_find]
+  // [datavector_newton_raphson_root_find]
   const size_t digits = 8;
   const DataVector guess{1.6, 1.9, -1.6, -1.9};
   const DataVector lower{sqrt(2.), sqrt(2.), -2., -3.};
@@ -88,7 +88,7 @@ void test_datavector() noexcept {
 
   const auto root = RootFinder::newton_raphson(func_and_deriv_lambda, guess,
                                                lower, upper, digits);
-  /// [datavector_newton_raphson_root_find]
+  // [datavector_newton_raphson_root_find]
 
   const DataVector correct{sqrt(2.), 2., -sqrt(2.), -2.};
 

--- a/tests/Unit/NumericalAlgorithms/RootFinding/Test_TOMS748.cpp
+++ b/tests/Unit/NumericalAlgorithms/RootFinding/Test_TOMS748.cpp
@@ -42,7 +42,7 @@ void test_simple() noexcept {
 }
 
 void test_bounds() noexcept {
-  /// [double_root_find]
+  // [double_root_find]
   const double abs_tol = 1e-15;
   const double rel_tol = 1e-15;
   const double upper = 2.0;
@@ -50,7 +50,7 @@ void test_bounds() noexcept {
   const auto f_lambda = [](double x) { return 2.0 - square(x); };
 
   auto root = RootFinder::toms748(f_lambda, lower, upper, abs_tol, rel_tol);
-  /// [double_root_find]
+  // [double_root_find]
 
   CHECK(std::abs(root - sqrt(2.0)) < abs_tol);
   CHECK(std::abs(root - sqrt(2.0)) / sqrt(2.0) < rel_tol);
@@ -95,7 +95,7 @@ void test_bounds() noexcept {
 }
 
 void test_datavector() noexcept {
-  /// [datavector_root_find]
+  // [datavector_root_find]
   const double abs_tol = 1e-15;
   const double rel_tol = 1e-15;
   const DataVector upper{2.0, 3.0, -sqrt(2.0) + abs_tol, -sqrt(2.0)};
@@ -108,7 +108,7 @@ void test_datavector() noexcept {
 
   const auto root_no_function_values =
       RootFinder::toms748(f_lambda, lower, upper, abs_tol, rel_tol);
-  /// [datavector_root_find]
+  // [datavector_root_find]
 
   auto check_root = [&abs_tol,&rel_tol](const DataVector& root) noexcept {
     CHECK(std::abs(root[0] - sqrt(2.0)) < abs_tol);

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
@@ -455,14 +455,14 @@ void test_spectral_quantities_for_mesh_impl(const Mesh<1>& slice) {
 }
 
 void test_spectral_quantities_for_mesh() {
-  /// [get_points_for_mesh]
+  // [get_points_for_mesh]
   const Mesh<2> mesh2d{
       {{3, 4}},
       {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
       {{Spectral::Quadrature::Gauss, Spectral::Quadrature::GaussLobatto}}};
   const auto collocation_points_in_first_dim =
       Spectral::collocation_points(mesh2d.slice_through(0));
-  /// [get_points_for_mesh]
+  // [get_points_for_mesh]
   test_spectral_quantities_for_mesh_impl<Spectral::Basis::Legendre,
                                          Spectral::Quadrature::Gauss>(
       mesh2d.slice_through(0));

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTags.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTags.cpp
@@ -57,7 +57,7 @@ static_assert(
         Derivative<Spin2TestTag, EthEthbar>>,
     "failed testing SwshTransform");
 
-/// [get_tags_with_spin]
+// [get_tags_with_spin]
 using TestVarTagList = tmpl::list<SpinMinus1TestTag, SpinMinus1TestTag,
                                   AnotherSpinMinus1TestTag, Spin2TestTag>;
 
@@ -77,9 +77,9 @@ static_assert(
                    tmpl::list<Derivative<AnotherSpinMinus1TestTag, EthEth>,
                               Derivative<Spin2TestTag, Ethbar>>>,
     "failed testing get_tags_with_spin");
-/// [get_tags_with_spin]
+// [get_tags_with_spin]
 
-/// [get_prefix_tags_that_wrap_tags_with_spin]
+// [get_prefix_tags_that_wrap_tags_with_spin]
 using WrappedTagList = tmpl::list<Derivative<SpinMinus1TestTag, Eth>,
                                   Derivative<SpinMinus1TestTag, EthEthbar>,
                                   Derivative<AnotherSpinMinus1TestTag, EthEth>,
@@ -90,7 +90,7 @@ static_assert(
                               Derivative<SpinMinus1TestTag, EthEthbar>,
                               Derivative<AnotherSpinMinus1TestTag, EthEth>>>,
     "failed testing get_wrapped_tags_with_spin_from_prefix_tag_list");
-/// [get_prefix_tags_that_wrap_tags_with_spin]
+// [get_prefix_tags_that_wrap_tags_with_spin]
 
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.Tags",
                   "[Unit][NumericalAlgorithms]") {

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTags.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTags.cpp
@@ -17,10 +17,8 @@
 // IWYU pragma: no_forward_declare SpinWeighted
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 class ComplexDataVector;
 class ComplexModalVector;
-/// \endcond
 
 namespace Spectral::Swsh::Tags {
 namespace {

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTransform.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTransform.cpp
@@ -46,7 +46,7 @@ using TestDerivativeTagList =
                Tags::Derivative<TestTag<1, -1>, Tags::EthEthbar>,
                Tags::Derivative<TestTag<0, 2>, Tags::EthbarEthbar>>;
 
-/// [make_transform_list]
+// [make_transform_list]
 using ExpectedInverseTransforms = tmpl::list<
     SwshTransform<tmpl::list<Tags::Derivative<TestTag<0, -1>, Tags::EthEthbar>,
                              Tags::Derivative<TestTag<1, -1>, Tags::EthEthbar>>,
@@ -61,9 +61,9 @@ static_assert(
                                        TestDerivativeTagList>,
                    ExpectedInverseTransforms>,
     "failed testing make_transform_list");
-/// [make_transform_list]
+// [make_transform_list]
 
-/// [make_transform_from_derivative_tags]
+// [make_transform_from_derivative_tags]
 using ExpectedTransforms =
     tmpl::list<SwshTransform<tmpl::list<TestTag<0, -1>, TestTag<1, -1>>,
                              ComplexRepresentation::Interleaved>,
@@ -75,7 +75,7 @@ static_assert(std::is_same_v<make_transform_list_from_derivative_tags<
                                  TestDerivativeTagList>,
                              ExpectedTransforms>,
               "failed testing make_transform_list_from_derivative_tags");
-/// [make_transform_from_derivative_tags]
+// [make_transform_from_derivative_tags]
 
 template <ComplexRepresentation Representation, int S>
 void test_transform_and_inverse_transform() noexcept {

--- a/tests/Unit/Options/Test_Auto.cpp
+++ b/tests/Unit/Options/Test_Auto.cpp
@@ -117,7 +117,7 @@ void test_parsing() noexcept {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif  // defined(__GNUC__) && !defined(__clang__) && __GNUC__ => 8 && __GNUC__ < 11
-/// [example_class]
+// [example_class]
 class ExampleClass {
  public:
   ExampleClass() = default;
@@ -144,7 +144,7 @@ class ExampleClass {
   int value{};
   std::optional<double> optional_value{};
 };
-/// [example_class]
+// [example_class]
 #if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 8 && __GNUC__ < 11
 #pragma GCC diagnostic pop
 #endif  // defined(__GNUC__) && !defined(__clang__) && __GNUC__ => 8 && __GNUC__ < 11
@@ -166,7 +166,7 @@ class NonCopyableArgument {
 };
 
 void test_use_as_option() noexcept {
-  /// [example_create]
+  // [example_create]
   const auto example1 = TestHelpers::test_creation<ExampleClass>(
       "AutoArg: 7\n"
       "OptionalArg: 10.");
@@ -177,7 +177,7 @@ void test_use_as_option() noexcept {
       "OptionalArg: None");
   CHECK(example2.value == -12);
   CHECK(example2.optional_value == std::nullopt);
-  /// [example_create]
+  // [example_create]
 
   // Make sure this compiles.
   TestHelpers::test_creation<NonCopyableArgument>("AutoArg: Auto");

--- a/tests/Unit/Options/Test_CustomTypeConstruction.cpp
+++ b/tests/Unit/Options/Test_CustomTypeConstruction.cpp
@@ -11,7 +11,7 @@
 #include "Utilities/TMPL.hpp"
 
 namespace {
-/// [class_creation_example]
+// [class_creation_example]
 class CreateFromOptions {
  public:
   struct CfoOption {
@@ -45,9 +45,9 @@ const char* const input_file_text = R"(
 Cfo:
   CfoOption: foo
 )";
-/// [class_creation_example]
+// [class_creation_example]
 
-/// [class_creation_example_with_metavariables]
+// [class_creation_example_with_metavariables]
 class CreateFromOptionsWithMetavariables {
  public:
   template <typename Metavariables>
@@ -87,7 +87,7 @@ const char* const input_file_text_with_metavariables = R"(
 CfoWithMetavariables:
   MetaName: MetaString
 )";
-/// [class_creation_example_with_metavariables]
+// [class_creation_example_with_metavariables]
 
 struct CreateFromOptionsAggregate {
   struct CfoOption {
@@ -153,7 +153,7 @@ SPECTRE_TEST_CASE("Unit.Options.CustomType.custom_error", "[Unit][Options]") {
   opts.get<Cfo>();
 }
 
-/// [enum_creation_example]
+// [enum_creation_example]
 namespace {
 enum class CreateFromOptionsAnimal { Cat, Dog };
 
@@ -178,7 +178,7 @@ struct Options::create_from_yaml<CreateFromOptionsAnimal> {
                 "CreateFromOptionsAnimal must be 'Cat' or 'Dog'");
   }
 };
-/// [enum_creation_example]
+// [enum_creation_example]
 
 SPECTRE_TEST_CASE("Unit.Options.CustomType.specialized", "[Unit][Options]") {
   Options::Parser<tmpl::list<CfoAnimal>> opts("");
@@ -186,7 +186,7 @@ SPECTRE_TEST_CASE("Unit.Options.CustomType.specialized", "[Unit][Options]") {
   CHECK(opts.get<CfoAnimal>() == CreateFromOptionsAnimal::Cat);
 }
 
-/// [enum_void_creation_header_example]
+// [enum_void_creation_header_example]
 namespace {
 enum class CreateFromOptionsExoticAnimal { MexicanWalkingFish, Platypus };
 
@@ -207,9 +207,9 @@ template <>
 CreateFromOptionsExoticAnimal
 Options::create_from_yaml<CreateFromOptionsExoticAnimal>::create<void>(
     const Options::Option& options);
-/// [enum_void_creation_header_example]
+// [enum_void_creation_header_example]
 
-/// [enum_void_creation_cpp_example]
+// [enum_void_creation_cpp_example]
 template <>
 CreateFromOptionsExoticAnimal
 Options::create_from_yaml<CreateFromOptionsExoticAnimal>::create<void>(
@@ -225,7 +225,7 @@ Options::create_from_yaml<CreateFromOptionsExoticAnimal>::create<void>(
               "CreateFromOptionsExoticAnimal must be 'MexicanWalkingFish' or "
               "'Platypus'");
 }
-/// [enum_void_creation_cpp_example]
+// [enum_void_creation_cpp_example]
 
 SPECTRE_TEST_CASE("Unit.Options.CustomType.specialized_void",
                   "[Unit][Options]") {

--- a/tests/Unit/Options/Test_Factory.cpp
+++ b/tests/Unit/Options/Test_Factory.cpp
@@ -22,7 +22,7 @@ class TestWithArg;
 class TestWithArg2;
 struct TestWithMetavars;
 
-/// [factory_example]
+// [factory_example]
 struct OptionType {
   using type = std::unique_ptr<OptionTest>;
   static constexpr Options::String help = {"The type of OptionTest"};
@@ -51,7 +51,7 @@ class Test1 : public OptionTest {
 
   std::string name() const override { return "Test1"; }
 };
-/// [factory_example]
+// [factory_example]
 
 class Test2 : public OptionTest {
  public:

--- a/tests/Unit/Options/Test_Options.cpp
+++ b/tests/Unit/Options/Test_Options.cpp
@@ -181,7 +181,7 @@ SPECTRE_TEST_CASE("Unit.Options.NamedSimple.invalid", "[Unit][Options]") {
 }
 
 namespace {
-/// [options_example_group]
+// [options_example_group]
 struct Group {
   static constexpr Options::String help = {"Group halp"};
 };
@@ -191,7 +191,7 @@ struct GroupedTag {
   static constexpr Options::String help = {"Tag halp"};
   using group = Group;
 };
-/// [options_example_group]
+// [options_example_group]
 
 struct OuterGroup {
   static constexpr Options::String help = {"Outer group halp"};
@@ -261,7 +261,7 @@ SPECTRE_TEST_CASE("Unit.Options.Grouped.missing_inner_group",
   opts.get<InnerGroupedTag>();
 }
 
-/// [options_example_scalar_struct]
+// [options_example_scalar_struct]
 struct Bounded {
   using type = int;
   static constexpr Options::String help = {
@@ -271,7 +271,7 @@ struct Bounded {
   static type lower_bound() noexcept { return 2; }
   static type upper_bound() noexcept { return 10; }
 };
-/// [options_example_scalar_struct]
+// [options_example_scalar_struct]
 
 void test_options_suggested_followed() {
   Options::Parser<tmpl::list<Bounded>> opts("Overall help text");
@@ -280,11 +280,11 @@ void test_options_suggested_followed() {
 }
 
 void test_options_suggested_not_followed() {
-  /// [options_example_scalar_parse]
+  // [options_example_scalar_parse]
   Options::Parser<tmpl::list<Bounded>> opts("Overall help text");
   opts.parse("Bounded: 3");
   CHECK(opts.get<Bounded>() == 3);
-  /// [options_example_scalar_parse]
+  // [options_example_scalar_parse]
 }
 
 // [[OutputRegex, In string:.*While parsing option Bounded:.At line 1 column
@@ -357,7 +357,7 @@ SPECTRE_TEST_CASE("Unit.Options.NamedBadSuggestion", "[Unit][Options]") {
   opts.get<NamedBadSuggestion>();
 }
 
-/// [options_example_vector_struct]
+// [options_example_vector_struct]
 struct VectorOption {
   using type = std::vector<int>;
   static constexpr Options::String help = {"A vector with length limits"};
@@ -368,7 +368,7 @@ struct VectorOption {
   static size_t lower_bound_on_size() { return 2; }
   static size_t upper_bound_on_size() { return 5; }
 };
-/// [options_example_vector_struct]
+// [options_example_vector_struct]
 
 // [[OutputRegex, In string:.*While parsing option Vector:.At line 1 column
 // 9:.Value must have at least 2 entries, but 1 were given.]]
@@ -996,7 +996,7 @@ struct Alternatives {
   static constexpr Options::String help = "halp";
   Alternatives() = default;
 
-/// [alternatives]
+// [alternatives]
   using options = tmpl::list<
       A, Options::Alternatives<tmpl::list<B>, tmpl::list<C>, tmpl::list<D, E>>,
       F>;
@@ -1006,7 +1006,7 @@ struct Alternatives {
       : a_(a), c_(c), f_(std::move(f)) {}
   Alternatives(double a, std::vector<int> d, bool e, std::string f)
       : a_(a), d_(std::move(d)), e_(e), f_(std::move(f)) {}
-/// [alternatives]
+// [alternatives]
 
   double a_{-1.0};
   int b_{-1};

--- a/tests/Unit/Options/Test_Options.cpp
+++ b/tests/Unit/Options/Test_Options.cpp
@@ -996,7 +996,7 @@ struct Alternatives {
   static constexpr Options::String help = "halp";
   Alternatives() = default;
 
-// [alternatives]
+  // [alternatives]
   using options = tmpl::list<
       A, Options::Alternatives<tmpl::list<B>, tmpl::list<C>, tmpl::list<D, E>>,
       F>;
@@ -1006,7 +1006,7 @@ struct Alternatives {
       : a_(a), c_(c), f_(std::move(f)) {}
   Alternatives(double a, std::vector<int> d, bool e, std::string f)
       : a_(a), d_(std::move(d)), e_(e), f_(std::move(f)) {}
-// [alternatives]
+  // [alternatives]
 
   double a_{-1.0};
   int b_{-1};

--- a/tests/Unit/Parallel/Actions/Test_Goto.cpp
+++ b/tests/Unit/Parallel/Actions/Test_Goto.cpp
@@ -53,7 +53,7 @@ struct Increment {
   }
 };
 
-/// [component]
+// [component]
 template <typename Metavariables>
 struct Component {
   using metavariables = Metavariables;
@@ -80,18 +80,18 @@ struct Component {
                              Metavariables::Phase::TestRepeatUntil,
                              repeat_until_phase_action_list>>;
 };
-/// [component]
+// [component]
 
-/// [metavariables]
+// [metavariables]
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
 
   enum class Phase { Initialization, TestGoto, TestRepeatUntil, Exit };
 };
-/// [metavariables]
+// [metavariables]
 }  // namespace
 
-/// [test case]
+// [test case]
 SPECTRE_TEST_CASE("Unit.Parallel.GotoAction", "[Unit][Parallel][Actions]") {
   using component = Component<Metavariables>;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
@@ -132,4 +132,4 @@ SPECTRE_TEST_CASE("Unit.Parallel.GotoAction", "[Unit][Parallel][Actions]") {
   // condition is already fulfilled at the start.
   CHECK(ActionTesting::get_databox_tag<component, Counter>(runner, 0) == 2);
 }
-/// [test case]
+// [test case]

--- a/tests/Unit/Parallel/Actions/Test_SetupDataBox.cpp
+++ b/tests/Unit/Parallel/Actions/Test_SetupDataBox.cpp
@@ -42,7 +42,7 @@ struct SquareVectorCompute : SquareVectorTag, db::ComputeTag {
   using base = SquareVectorTag;
 };
 
-/// [initialization_action]
+// [initialization_action]
 struct InitializationAction {
   using simple_tags = tmpl::list<CounterTag, VectorTag>;
   using compute_tags = tmpl::list<SquareVectorCompute>;
@@ -60,7 +60,7 @@ struct InitializationAction {
     return {std::move(box)};
   }
 };
-/// [initialization_action]
+// [initialization_action]
 
 struct MutateAction {
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,

--- a/tests/Unit/Parallel/Actions/Test_TerminatePhase.cpp
+++ b/tests/Unit/Parallel/Actions/Test_TerminatePhase.cpp
@@ -8,7 +8,7 @@
 #include "Utilities/TMPL.hpp"
 
 namespace {
-/// [component]
+// [component]
 template <typename Metavariables>
 struct Component {
   using metavariables = Metavariables;
@@ -18,17 +18,17 @@ struct Component {
       typename Metavariables::Phase, Metavariables::Phase::Testing,
       tmpl::list<Parallel::Actions::TerminatePhase>>>;
 };
-/// [component]
+// [component]
 
-/// [metavariables]
+// [metavariables]
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
   enum class Phase { Initialization, Testing, Exit };
 };
-/// [metavariables]
+// [metavariables]
 }  // namespace
 
-/// [test case]
+// [test case]
 SPECTRE_TEST_CASE("Unit.Parallel.Actions.TerminatePhase",
                   "[Unit][Parallel][Actions]") {
   using component = Component<Metavariables>;
@@ -43,4 +43,4 @@ SPECTRE_TEST_CASE("Unit.Parallel.Actions.TerminatePhase",
   ActionTesting::next_action<component>(make_not_null(&runner), 0);
   CHECK(ActionTesting::get_terminate<component>(runner, 0));
 }
-/// [test case]
+// [test case]

--- a/tests/Unit/Parallel/PhaseControl/Test_ExecutePhaseChange.cpp
+++ b/tests/Unit/Parallel/PhaseControl/Test_ExecutePhaseChange.cpp
@@ -38,12 +38,10 @@ template <PhaseControl::ArbitrationStrategy Strategy, size_t Index,
           typename PhaseChangeRegistrars =
               tmpl::list<Registrars::TestPhaseChange<Strategy, Index>>>
 struct TestPhaseChange : public PhaseChange<PhaseChangeRegistrars> {
-  /// \cond
   TestPhaseChange() = default;
   explicit TestPhaseChange(CkMigrateMessage* /*unused*/) noexcept {}
   using PUP::able::register_constructor;
   WRAPPED_PUPable_decl_template(TestPhaseChange);  // NOLINT
-  /// \endcond
   static std::string name() noexcept {
     if constexpr (Strategy ==
                   PhaseControl::ArbitrationStrategy::RunPhaseImmediately) {

--- a/tests/Unit/Parallel/PhaseControl/Test_PhaseChange.cpp
+++ b/tests/Unit/Parallel/PhaseControl/Test_PhaseChange.cpp
@@ -73,12 +73,10 @@ bool contributed = false;
 template <typename PhaseChangeRegistrars =
               tmpl::list<Registrars::TestPhaseChange>>
 struct TestPhaseChange : public PhaseChange<PhaseChangeRegistrars> {
-  /// \cond
   TestPhaseChange() = default;
   explicit TestPhaseChange(CkMigrateMessage* /*unused*/) noexcept {}
   using PUP::able::register_constructor;
   WRAPPED_PUPable_decl_template(TestPhaseChange);  // NOLINT
-  /// \endcond
 
   struct Factor {
     using type = int;

--- a/tests/Unit/Parallel/Test_AlgorithmCore.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmCore.cpp
@@ -432,12 +432,11 @@ struct add_int0_from_receive {
   // [is_ready_example]
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex>
-  static bool is_ready(
-      const db::DataBox<DbTags>& box,
-      const tuples::TaggedTuple<InboxTags...>& inboxes,
-      const Parallel::GlobalCache<Metavariables>& /*cache*/,
-      const ArrayIndex& /*array_index*/) noexcept
-      // [is_ready_example]
+  static bool is_ready(const db::DataBox<DbTags>& box,
+                       const tuples::TaggedTuple<InboxTags...>& inboxes,
+                       const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                       const ArrayIndex& /*array_index*/) noexcept
+  // [is_ready_example]
   {
     const auto& inbox = tuples::get<IntReceiveTag>(inboxes);
     // The const_cast in this function is purely for testing purposes, this is

--- a/tests/Unit/Parallel/Test_AlgorithmCore.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmCore.cpp
@@ -122,7 +122,7 @@ struct increment_count_actions_called {
 };
 
 struct no_op {
-  /// [apply_iterative]
+  // [apply_iterative]
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>
@@ -132,7 +132,7 @@ struct no_op {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept
-  /// [apply_iterative]
+  // [apply_iterative]
   {
     static_assert(
         std::is_same_v<ParallelComponent, NoOpsComponent<TestMetavariables>>,
@@ -214,10 +214,10 @@ struct NoOpsComponent {
       const typename Metavariables::Phase next_phase,
       const Parallel::CProxy_GlobalCache<Metavariables>& global_cache) {
     auto& local_cache = *(global_cache.ckLocalBranch());
-    /// [start_phase]
+    // [start_phase]
     Parallel::get_parallel_component<NoOpsComponent>(local_cache)
         .start_phase(next_phase);
-    /// [start_phase]
+    // [start_phase]
     if (next_phase == Metavariables::Phase::NoOpsFinish) {
       Parallel::simple_action<no_op_test::finalize>(
           Parallel::get_parallel_component<NoOpsComponent>(local_cache));
@@ -381,10 +381,10 @@ struct MutateComponent {
       Parallel::simple_action<add_remove_test::test_args>(
           Parallel::get_parallel_component<MutateComponent>(local_cache),
           4.82937, std::vector<double>{3.2, -8.4, 7.5});
-      /// [simple_action_call]
+      // [simple_action_call]
       Parallel::simple_action<add_remove_test::finalize>(
           Parallel::get_parallel_component<MutateComponent>(local_cache));
-      /// [simple_action_call]
+      // [simple_action_call]
     }
   }
 };
@@ -394,13 +394,13 @@ struct MutateComponent {
 //////////////////////////////////////////////////////////////////////
 
 namespace receive_data_test {
-/// [int receive tag insert]
+// [int receive tag insert]
 struct IntReceiveTag
     : public Parallel::InboxInserters::MemberInsert<IntReceiveTag> {
   using temporal_id = TestAlgorithmArrayInstance;
   using type = std::unordered_map<temporal_id, std::unordered_multiset<int>>;
 };
-/// [int receive tag insert]
+// [int receive tag insert]
 
 struct add_int0_from_receive {
   using inbox_tags = tmpl::list<IntReceiveTag>;
@@ -429,7 +429,7 @@ struct add_int0_from_receive {
         ++a >= 5);
   }
 
-  /// [is_ready_example]
+  // [is_ready_example]
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex>
   static bool is_ready(
@@ -437,7 +437,7 @@ struct add_int0_from_receive {
       const tuples::TaggedTuple<InboxTags...>& inboxes,
       const Parallel::GlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/) noexcept
-      /// [is_ready_example]
+      // [is_ready_example]
   {
     const auto& inbox = tuples::get<IntReceiveTag>(inboxes);
     // The const_cast in this function is purely for testing purposes, this is
@@ -504,7 +504,7 @@ struct initialize {
 
 struct finalize {
   using inbox_tags = tmpl::list<IntReceiveTag>;
-  /// [requires_action]
+  // [requires_action]
   template <typename ParallelComponent, typename... DbTags,
             typename Metavariables, typename ArrayIndex,
             Requires<tmpl2::flat_any_v<
@@ -512,7 +512,7 @@ struct finalize {
   static void apply(db::DataBox<tmpl::list<DbTags...>>& box,
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/) noexcept {
-    /// [requires_action]
+    // [requires_action]
     SPECTRE_PARALLEL_REQUIRE(db::get<TemporalId>(box) ==
                              TestAlgorithmArrayInstance{4});
     SPECTRE_PARALLEL_REQUIRE(db::get<CountActionsCalled>(box) == 13);
@@ -599,11 +599,11 @@ struct iterate_increment_int0 {
     }
 
     SPECTRE_PARALLEL_REQUIRE(db::get<Int0>(box) == max_int0_value);
-    /// [out_of_order_action]
+    // [out_of_order_action]
     return std::tuple<decltype(std::move(box)), bool, size_t>(
         std::move(box), true,
         tmpl::index_of<ActionList, iterate_increment_int0>::value + 1);
-    /// [out_of_order_action]
+    // [out_of_order_action]
   }
 };
 
@@ -663,14 +663,14 @@ struct AnyOrderComponent {
 };
 
 struct TestMetavariables {
-  /// [component_list_example]
+  // [component_list_example]
   using component_list = tmpl::list<NoOpsComponent<TestMetavariables>,
                                     MutateComponent<TestMetavariables>,
                                     ReceiveComponent<TestMetavariables>,
                                     AnyOrderComponent<TestMetavariables>>;
-  /// [component_list_example]
+  // [component_list_example]
 
-  /// [help_string_example]
+  // [help_string_example]
   static constexpr Options::String help =
       "An executable for testing the core functionality of the Algorithm. "
       "Actions that do not perform any operations (no-ops), invoking simple "
@@ -679,9 +679,9 @@ struct TestMetavariables {
       "out-of-order execution of Actions are all tested. All tests are run "
       "just by running the executable, no input file or command line arguments "
       "are required";
-  /// [help_string_example]
+  // [help_string_example]
 
-  /// [determine_next_phase_example]
+  // [determine_next_phase_example]
   enum class Phase {
     Initialization,
     NoOpsStart,
@@ -729,19 +729,19 @@ struct TestMetavariables {
 
     return Phase::Exit;
   }
-  /// [determine_next_phase_example]
+  // [determine_next_phase_example]
 };
 
-/// [charm_init_funcs_example]
+// [charm_init_funcs_example]
 static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling};
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};
-/// [charm_init_funcs_example]
+// [charm_init_funcs_example]
 
-/// [charm_main_example]
+// [charm_main_example]
 using charmxx_main_component = Parallel::Main<TestMetavariables>;
-/// [charm_main_example]
+// [charm_main_example]
 
 // [[OutputRegex, AlgorithmImpl has been constructed with a nullptr]]
 SPECTRE_TEST_CASE("Unit.Parallel.Algorithm.NullptrConstructError",

--- a/tests/Unit/Parallel/Test_AlgorithmCore.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmCore.cpp
@@ -71,9 +71,7 @@ struct hash<TestAlgorithmArrayInstance> {
 };
 }  // namespace std
 
-/// \cond
 struct ElementId {};
-/// \endcond
 
 struct CountActionsCalled : db::SimpleTag {
   static std::string name() noexcept { return "CountActionsCalled"; }

--- a/tests/Unit/Parallel/Test_AlgorithmGlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmGlobalCache.cpp
@@ -55,7 +55,7 @@ struct VectorOfDoubles : db::SimpleTag {
 }  // namespace Tags
 
 // Functions to be passed into GlobalCache::mutate
-/// [mutate_global_cache_item_mutator]
+// [mutate_global_cache_item_mutator]
 namespace MutationFunctions {
 struct add_stored_double {
   static void apply(const gsl::not_null<std::vector<double>*> data,
@@ -64,7 +64,7 @@ struct add_stored_double {
   }
 };
 }  // namespace MutationFunctions
-/// [mutate_global_cache_item_mutator]
+// [mutate_global_cache_item_mutator]
 
 namespace Actions {
 struct initialize {
@@ -89,11 +89,11 @@ struct add_new_stored_double {
   static void apply(db::DataBox<tmpl::list<DbTags...>>& /*box*/,
                     Parallel::GlobalCache<Metavariables>& cache,
                     const ArrayIndex& /*array_index*/) noexcept {
-    /// [mutate_global_cache_item]
+    // [mutate_global_cache_item]
     Parallel::mutate<Tags::VectorOfDoubles,
                      MutationFunctions::add_stored_double>(cache.thisProxy,
                                                            42.0);
-    /// [mutate_global_cache_item]
+    // [mutate_global_cache_item]
   }
 };
 
@@ -165,14 +165,14 @@ struct use_stored_double {
                     const ParallelComponent* const /*meta*/) noexcept {
     ++number_of_calls_to_use_stored_double_apply;
     const std::vector<double> expected_result{42.0};
-    /// [retrieve_mutable_cache_item]
+    // [retrieve_mutable_cache_item]
     SPECTRE_PARALLEL_REQUIRE(Parallel::get<Tags::VectorOfDoubles>(cache) ==
                              expected_result);
-    /// [retrieve_mutable_cache_item]
+    // [retrieve_mutable_cache_item]
     return std::tuple<db::DataBox<DbTags>&&, bool>(std::move(box), true);
   }
 
-  /// [check_mutable_cache_item_is_ready]
+  // [check_mutable_cache_item_is_ready]
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex>
   static bool is_ready(const db::DataBox<DbTags>& /*box*/,
@@ -192,7 +192,7 @@ struct use_stored_double {
                      : std::unique_ptr<Parallel::Callback>{};
         });
   }
-  /// [check_mutable_cache_item_is_ready]
+  // [check_mutable_cache_item_is_ready]
 };
 }  // namespace Actions
 

--- a/tests/Unit/Parallel/Test_AlgorithmLocalSyncAction.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmLocalSyncAction.cpp
@@ -59,7 +59,7 @@ struct InitializeNodegroup {
   }
 };
 
-/// [synchronous_action_example]
+// [synchronous_action_example]
 struct SyncGetPointerFromNodegroup {
   using return_type = size_t*;
   template <typename ParallelComponent, typename DbTagsList>
@@ -88,7 +88,7 @@ struct SyncGetPointerFromNodegroup {
     }
   }
 };
-/// [synchronous_action_example]
+// [synchronous_action_example]
 
 struct SyncGetConstRefFromNodegroup {
   using return_type = const size_t&;
@@ -148,12 +148,12 @@ struct TestSyncActionIncrement {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    /// [synchronous_action_invocation_example]
+    // [synchronous_action_invocation_example]
     size_t* step_number =
         Parallel::local_synchronous_action<SyncGetPointerFromNodegroup>(
             Parallel::get_parallel_component<NodegroupComponent<Metavariables>>(
                 cache));
-    /// [synchronous_action_invocation_example]
+    // [synchronous_action_invocation_example]
     Parallel::local_synchronous_action<IncrementNodegroupStep>(
         Parallel::get_parallel_component<NodegroupComponent<Metavariables>>(
             cache));

--- a/tests/Unit/Parallel/Test_AlgorithmNestedApply1.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNestedApply1.cpp
@@ -26,12 +26,12 @@ struct error_call_single_action_from_action {
   static void apply(db::DataBox<tmpl::list<DbTags...>>& /*box*/,
                     const Parallel::GlobalCache<Metavariables>& cache,
                     const ArrayIndex& /*array_index*/) {
-    /// [bad_recursive_call]
+    // [bad_recursive_call]
     auto& local_parallel_component =
         *Parallel::get_parallel_component<ParallelComponent>(cache).ckLocal();
     Parallel::simple_action<error_call_single_action_from_action>(
         local_parallel_component);
-    /// [bad_recursive_call]
+    // [bad_recursive_call]
   }
 };
 

--- a/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
@@ -217,9 +217,9 @@ struct reduce_to_nodegroup {
         *(Parallel::get_parallel_component<
               NodegroupParallelComponent<Metavariables>>(cache)
               .ckLocalBranch());
-    /// [simple_action_with_args]
+    // [simple_action_with_args]
     Parallel::simple_action<nodegroup_receive>(local_nodegroup, array_index);
-    /// [simple_action_with_args]
+    // [simple_action_with_args]
   }
 };
 

--- a/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
@@ -81,7 +81,7 @@ struct UnpackCounter : db::SimpleTag {
   using type = AlgorithmParallel_detail::UnpackCounter;
 };
 
-/// [int_receive_tag]
+// [int_receive_tag]
 struct IntReceiveTag {
   using temporal_id = int;
   using type = std::unordered_map<temporal_id, std::unordered_multiset<int>>;
@@ -93,7 +93,7 @@ struct IntReceiveTag {
     (*inbox)[temporal_id_v].insert(std::forward<ReceiveDataType>(data));
   }
 };
-/// [int_receive_tag]
+// [int_receive_tag]
 }  // namespace Tags
 
 struct TestMetavariables;
@@ -133,9 +133,9 @@ struct RestartMe {
 };
 
 struct CountReceives {
-  /// [int_receive_tag_list]
+  // [int_receive_tag_list]
   using inbox_tags = tmpl::list<Tags::IntReceiveTag>;
-  /// [int_receive_tag_list]
+  // [int_receive_tag_list]
 
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
@@ -162,7 +162,7 @@ struct CountReceives {
     // We do not do a broadcast so that we can check inline entry methods on
     // array work. We pass "true" as the second argument to start the
     // algorithm up again on the arrays
-    /// [call_on_indexed_array]
+    // [call_on_indexed_array]
     auto& array_parallel_component =
         Parallel::get_parallel_component<ArrayParallelComponent<Metavariables>>(
             cache);
@@ -170,13 +170,13 @@ struct CountReceives {
       Parallel::receive_data<Tags::IntReceiveTag>(array_parallel_component[i],
                                                   0, 101, true);
     }
-    /// [call_on_indexed_array]
-    /// [return_with_termination]
+    // [call_on_indexed_array]
+    // [return_with_termination]
     return std::tuple<db::DataBox<DbTags>&&, bool>(std::move(box), true);
-    /// [return_with_termination]
+    // [return_with_termination]
   }
 
-  /// [int_receive_tag_is_ready]
+  // [int_receive_tag_is_ready]
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex>
   static bool is_ready(
@@ -187,7 +187,7 @@ struct CountReceives {
     auto& int_receives = tuples::get<Tags::IntReceiveTag>(inboxes);
     return int_receives.size() == 70;
   }
-  /// [int_receive_tag_is_ready]
+  // [int_receive_tag_is_ready]
 };
 }  // namespace SingletonActions
 
@@ -250,14 +250,14 @@ struct AddIntValue10 {
     auto& int_receives = tuples::get<Tags::IntReceiveTag>(inboxes);
     SPECTRE_PARALLEL_REQUIRE(int_receives.empty() or int_receives.size() == 1);
     if (int_receives.size() == 1) {
-      /// [broadcast_to_group]
+      // [broadcast_to_group]
       auto& group_parallel_component = Parallel::get_parallel_component<
           GroupParallelComponent<Metavariables>>(cache);
       Parallel::receive_data<Tags::IntReceiveTag>(
           group_parallel_component,
           db::get<Tags::CountActionsCalled>(box) + 100 * array_index,
           db::get<Tags::CountActionsCalled>(box));
-      /// [broadcast_to_group]
+      // [broadcast_to_group]
     }
     db::mutate<Tags::CountActionsCalled>(
         make_not_null(&box),
@@ -315,9 +315,9 @@ struct IncrementInt0 {
         });
     db::mutate<Tags::Int0>(make_not_null(&box),
                            [](const gsl::not_null<int*> int0) { ++*int0; });
-    /// [return_forward_as_tuple]
+    // [return_forward_as_tuple]
     return std::forward_as_tuple(std::move(box));
-    /// [return_forward_as_tuple]
+    // [return_forward_as_tuple]
   }
 };
 
@@ -376,12 +376,12 @@ struct SendToSingleton {
     auto& singleton_parallel_component = Parallel::get_parallel_component<
         SingletonParallelComponent<Metavariables>>(cache);
     // Send CountActionsCalled to the SingletonParallelComponent several times
-    /// [receive_broadcast]
+    // [receive_broadcast]
     Parallel::receive_data<Tags::IntReceiveTag>(
         singleton_parallel_component,
         db::get<Tags::CountActionsCalled>(box) + 1000 * array_index,
         db::get<Tags::CountActionsCalled>(box), true);
-    /// [receive_broadcast]
+    // [receive_broadcast]
     return std::forward_as_tuple(std::move(box));
   }
 };
@@ -516,7 +516,7 @@ struct Initialize {
 
 }  // namespace NodegroupActions
 
-/// [singleton_parallel_component]
+// [singleton_parallel_component]
 template <class Metavariables>
 struct SingletonParallelComponent {
   using chare_type = Parallel::Algorithms::Singleton;
@@ -540,9 +540,9 @@ struct SingletonParallelComponent {
     }
   }
 };
-/// [singleton_parallel_component]
+// [singleton_parallel_component]
 
-/// [array_parallel_component]
+// [array_parallel_component]
 template <class Metavariables>
 struct ArrayParallelComponent {
   using chare_type = Parallel::Algorithms::Array;
@@ -590,7 +590,7 @@ struct ArrayParallelComponent {
     }
   }
 };
-/// [array_parallel_component]
+// [array_parallel_component]
 
 template <class Metavariables>
 struct GroupParallelComponent {
@@ -665,7 +665,7 @@ struct TestMetavariables {
   }
 };
 
-/// [charm_include_example]
+// [charm_include_example]
 static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &disable_openblas_multithreading};
 static const std::vector<void (*)()> charm_init_proc_funcs{
@@ -674,4 +674,4 @@ static const std::vector<void (*)()> charm_init_proc_funcs{
 using charmxx_main_component = Parallel::Main<TestMetavariables>;
 
 #include "Parallel/CharmMain.tpp"  // IWYU pragma: keep
-/// [charm_include_example]
+// [charm_include_example]

--- a/tests/Unit/Parallel/Test_AlgorithmPhaseControl.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmPhaseControl.cpp
@@ -83,12 +83,10 @@ struct ComponentBeta;
 template <typename TriggerRegistrars =
               tmpl::list<Registrars::TempPhaseATrigger>>
 struct TempPhaseATrigger : public Trigger<TriggerRegistrars> {
-  /// \cond
   TempPhaseATrigger() = default;
   explicit TempPhaseATrigger(CkMigrateMessage* /*unused*/) noexcept {}
   using PUP::able::register_constructor;
   WRAPPED_PUPable_decl_template(TempPhaseATrigger);  // NOLINT
-  /// \endcond
 
   static constexpr Options::String help{
     "Trigger for going to TempPhaseA."};
@@ -104,12 +102,10 @@ struct TempPhaseATrigger : public Trigger<TriggerRegistrars> {
 template <typename TriggerRegistrars =
               tmpl::list<Registrars::TempPhaseBTrigger>>
 struct TempPhaseBTrigger : public Trigger<TriggerRegistrars> {
-  /// \cond
   TempPhaseBTrigger() = default;
   explicit TempPhaseBTrigger(CkMigrateMessage* /*unused*/) noexcept {}
   using PUP::able::register_constructor;
   WRAPPED_PUPable_decl_template(TempPhaseBTrigger);  // NOLINT
-  /// \endcond
 
   static constexpr Options::String help{"Trigger for going to TempPhaseB."};
   using options = tmpl::list<>;

--- a/tests/Unit/Parallel/Test_AlgorithmPhaseControl.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmPhaseControl.cpp
@@ -516,7 +516,7 @@ struct TestMetavariables {
   }
 };
 
-/// [charm_init_funcs_example]
+// [charm_init_funcs_example]
 static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling,
     &Parallel::register_derived_classes_with_charm<
@@ -525,10 +525,10 @@ static const std::vector<void (*)()> charm_init_node_funcs{
         Trigger<TestMetavariables::phase_changes>>};
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};
-/// [charm_init_funcs_example]
+// [charm_init_funcs_example]
 
-/// [charm_main_example]
+// [charm_main_example]
 using charmxx_main_component = Parallel::Main<TestMetavariables>;
-/// [charm_main_example]
+// [charm_main_example]
 
 #include "Parallel/CharmMain.tpp"  // IWYU pragma: keep

--- a/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
@@ -44,7 +44,7 @@ struct TestMetavariables;
 // correctly.
 static constexpr int number_of_1d_array_elements = 46;
 
-/// [reduce_sum_int_action]
+// [reduce_sum_int_action]
 struct ProcessReducedSumOfInts {
   template <typename ParallelComponent, typename DbTags, typename Metavariables,
             typename ArrayIndex>
@@ -57,9 +57,9 @@ struct ProcessReducedSumOfInts {
                              value);
   }
 };
-/// [reduce_sum_int_action]
+// [reduce_sum_int_action]
 
-/// [reduce_rms_action]
+// [reduce_rms_action]
 struct ProcessErrorNorms {
   template <typename ParallelComponent, typename DbTags, typename Metavariables,
             typename ArrayIndex>
@@ -74,9 +74,9 @@ struct ProcessErrorNorms {
         error_v, sqrt(number_of_1d_array_elements * square(1.0e-4) / points)));
   }
 };
-/// [reduce_rms_action]
+// [reduce_rms_action]
 
-/// [custom_reduction_action]
+// [custom_reduction_action]
 struct ProcessCustomReductionAction {
   template <typename ParallelComponent, typename DbTags, typename Metavariables,
             typename ArrayIndex>
@@ -99,7 +99,7 @@ struct ProcessCustomReductionAction {
                           8 * reduced_int * number_of_1d_array_elements}));
   }
 };
-/// [custom_reduction_action]
+// [custom_reduction_action]
 
 template <class Metavariables>
 struct SingletonParallelComponent {
@@ -138,18 +138,18 @@ struct ArrayReduce {
             cache);
     const auto& singleton_proxy = Parallel::get_parallel_component<
         SingletonParallelComponent<Metavariables>>(cache);
-    /// [contribute_to_reduction_example]
+    // [contribute_to_reduction_example]
     Parallel::ReductionData<Parallel::ReductionDatum<int, funcl::Plus<>>>
         my_send_int{array_index};
     Parallel::contribute_to_reduction<ProcessReducedSumOfInts>(
         my_send_int, my_proxy, singleton_proxy);
-    /// [contribute_to_reduction_example]
-    /// [contribute_to_broadcast_reduction]
+    // [contribute_to_reduction_example]
+    // [contribute_to_broadcast_reduction]
     Parallel::contribute_to_reduction<ProcessReducedSumOfInts>(
         my_send_int, my_proxy, array_proxy);
-    /// [contribute_to_broadcast_reduction]
+    // [contribute_to_broadcast_reduction]
 
-    /// [contribute_to_rms_reduction]
+    // [contribute_to_rms_reduction]
     using RmsRed = Parallel::ReductionDatum<double, funcl::Plus<>,
                                             funcl::Sqrt<funcl::Divides<>>,
                                             std::index_sequence<0>>;
@@ -158,9 +158,9 @@ struct ArrayReduce {
         error_reduction{3, square(1.0e-3), square(1.0e-4)};
     Parallel::contribute_to_reduction<ProcessErrorNorms>(error_reduction,
                                                          my_proxy, array_proxy);
-    /// [contribute_to_rms_reduction]
+    // [contribute_to_rms_reduction]
 
-    /// [custom_contribute_to_reduction_example]
+    // [custom_contribute_to_reduction_example]
     std::unordered_map<std::string, int> my_send_map;
     my_send_map["unity"] = array_index;
     my_send_map["double"] = 2 * array_index;
@@ -216,12 +216,12 @@ struct ArrayReduce {
     Parallel::contribute_to_reduction<ProcessCustomReductionAction>(
         ReductionType{10, my_send_map, std::vector<int>{array_index, 10, -8}},
         my_proxy, singleton_proxy);
-    /// [custom_contribute_to_reduction_example]
-    /// [custom_contribute_to_broadcast_reduction]
+    // [custom_contribute_to_reduction_example]
+    // [custom_contribute_to_broadcast_reduction]
     Parallel::contribute_to_reduction<ProcessCustomReductionAction>(
         ReductionType{10, my_send_map, std::vector<int>{array_index, 10, -8}},
         my_proxy, array_proxy);
-    /// [custom_contribute_to_broadcast_reduction]
+    // [custom_contribute_to_broadcast_reduction]
   }
 };
 

--- a/tests/Unit/Parallel/Test_GlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_GlobalCache.cpp
@@ -219,10 +219,8 @@ struct TestMetavariables {
 // PerformAlgorithmCallback because they can be mocked.
 class UseCkCallbackAsCallback : public Parallel::Callback {
  public:
-  /// \cond
   explicit UseCkCallbackAsCallback(CkMigrateMessage* /*unused*/) noexcept {}
   WRAPPED_PUPable_decl(UseCkCallbackAsCallback);
-  /// \endcond
   explicit UseCkCallbackAsCallback(const CkCallback& callback)
       : callback_(callback) {}
   void invoke() noexcept override { callback_.send(nullptr); }
@@ -554,14 +552,12 @@ SPECTRE_TEST_CASE("Unit.Parallel.MutableGlobalCache.NullptrConstructError",
 
 // --------- registration stuff below -------
 
-/// \cond
 PUPable_def(UseCkCallbackAsCallback)
 // clang-tidy: possibly throwing constructor static storage
 // clang-tidy: false positive: redundant declaration
 PUP::able::PUP_ID Triangle::my_PUP_ID = 0;   // NOLINT
 PUP::able::PUP_ID Square::my_PUP_ID = 0;     // NOLINT
 PUP::able::PUP_ID Arthropod::my_PUP_ID = 0;  // NOLINT
-/// \endcond
 
 static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling};

--- a/tests/Unit/Parallel/Test_InboxInserters.cpp
+++ b/tests/Unit/Parallel/Test_InboxInserters.cpp
@@ -41,34 +41,34 @@ struct PushbackCounter : db::SimpleTag {
   using type = size_t;
 };
 
-/// [map tag]
+// [map tag]
 struct MapTag : public Parallel::InboxInserters::Map<MapTag> {
   using temporal_id = size_t;
   using type = std::unordered_map<temporal_id, std::unordered_map<int, int>>;
 };
-/// [map tag]
+// [map tag]
 
-/// [member insert tag]
+// [member insert tag]
 struct MemberInsertTag
     : public Parallel::InboxInserters::MemberInsert<MemberInsertTag> {
   using temporal_id = size_t;
   using type = std::unordered_map<temporal_id, std::unordered_multiset<int>>;
 };
-/// [member insert tag]
+// [member insert tag]
 
-/// [value tag]
+// [value tag]
 struct ValueTag : public Parallel::InboxInserters::Value<ValueTag> {
   using temporal_id = size_t;
   using type = std::unordered_map<temporal_id, int>;
 };
-/// [value tag]
+// [value tag]
 
-/// [pushback tag]
+// [pushback tag]
 struct PushbackTag : public Parallel::InboxInserters::Pushback<PushbackTag> {
   using temporal_id = size_t;
   using type = std::unordered_map<temporal_id, std::vector<int>>;
 };
-/// [pushback tag]
+// [pushback tag]
 }  // namespace Tags
 
 namespace Actions {

--- a/tests/Unit/Parallel/Test_Parallel.cpp
+++ b/tests/Unit/Parallel/Test_Parallel.cpp
@@ -40,7 +40,7 @@ std::ostream& operator<<(std::ostream& os, const TestEnum& t) noexcept {
 
 }  // namespace
 
-/// [output_test_example]
+// [output_test_example]
 // [[OutputRegex, -100 3000000000 1.0000000000000000000e\+00 \(0,4,8,-7\) test 1
 // 2 3 abf a o e u Value 2]]
 SPECTRE_TEST_CASE("Unit.Parallel.printf", "[Unit][Parallel]") {
@@ -61,7 +61,7 @@ SPECTRE_TEST_CASE("Unit.Parallel.printf", "[Unit][Parallel]") {
   // clang-tidy doesn't want delete on anything without gsl::owner<>.
   delete[] c_string1; // NOLINT
 }
-/// [output_test_example]
+// [output_test_example]
 
 SPECTRE_TEST_CASE("Unit.Parallel.NodeAndPes", "[Unit][Parallel]") {
   CHECK(1 == sys::number_of_procs());

--- a/tests/Unit/Parallel/Test_PupStlCpp11.cpp
+++ b/tests/Unit/Parallel/Test_PupStlCpp11.cpp
@@ -101,8 +101,6 @@ SPECTRE_TEST_CASE("Unit.Serialization.PupStlCpp11", "[Serialization][Unit]") {
   }
 }
 
-/// \cond
 // clang-tidy: possibly throwing constructor static storage
 // clang-tidy: false positive: redundant declaration
 PUP::able::PUP_ID Test_Classes::DerivedInPupStlCpp11::my_PUP_ID = 0;  // NOLINT
-/// \endcond

--- a/tests/Unit/Parallel/Test_PupStlCpp11.cpp
+++ b/tests/Unit/Parallel/Test_PupStlCpp11.cpp
@@ -56,7 +56,7 @@ struct DerivedInPupStlCpp11 : public Base {
 }  // namespace Test_Classes
 
 SPECTRE_TEST_CASE("Unit.Serialization.PupStlCpp11", "[Serialization][Unit]") {
-  /// [example_serialize_comparable]
+  // [example_serialize_comparable]
   {
     INFO("tuple");
     std::unordered_map<std::string, double> um;
@@ -67,15 +67,15 @@ SPECTRE_TEST_CASE("Unit.Serialization.PupStlCpp11", "[Serialization][Unit]") {
                                           2, 0.57, "blah", std::move(um));
     test_serialization(test_tuple);
   }
-  /// [example_serialize_comparable]
-  /// [example_serialize_derived]
+  // [example_serialize_comparable]
+  // [example_serialize_derived]
   {
     INFO("unique_ptr.abstract_base");
     test_serialization_via_base<Test_Classes::Base,
                                 Test_Classes::DerivedInPupStlCpp11>(
                                     std::vector<double>{-1, 12.3, -7, 8});
   }
-  /// [example_serialize_derived]
+  // [example_serialize_derived]
   {
     // note the `serialize_and_deserialize` utilities don't work here because
     // atomic specifically has no copy constructor -- it must be serialized

--- a/tests/Unit/Parallel/Test_TypeTraits.cpp
+++ b/tests/Unit/Parallel/Test_TypeTraits.cpp
@@ -85,7 +85,7 @@ static_assert(not Parallel::is_node_group_proxy<group_proxy>::value,
 static_assert(Parallel::is_node_group_proxy<nodegroup_proxy>::value,
               "Failed testing type trait is_node_group_proxy");
 
-/// [has_pup_member_example]
+// [has_pup_member_example]
 static_assert(Parallel::has_pup_member<PupableClass>::value,
               "Failed testing type trait has_pup_member");
 static_assert(Parallel::has_pup_member_t<PupableClass>::value,
@@ -94,9 +94,9 @@ static_assert(Parallel::has_pup_member_v<PupableClass>,
               "Failed testing type trait has_pup_member");
 static_assert(not Parallel::has_pup_member<NonpupableClass>::value,
               "Failed testing type trait has_pup_member");
-/// [has_pup_member_example]
+// [has_pup_member_example]
 
-/// [is_pupable_example]
+// [is_pupable_example]
 static_assert(Parallel::is_pupable<PupableClass>::value,
               "Failed testing type trait is_pupable");
 static_assert(Parallel::is_pupable_t<PupableClass>::value,
@@ -105,4 +105,4 @@ static_assert(Parallel::is_pupable_v<PupableClass>,
               "Failed testing type trait is_pupable");
 static_assert(not Parallel::is_pupable<NonpupableClass>::value,
               "Failed testing type trait is_pupable");
-/// [is_pupable_example]
+// [is_pupable_example]

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_HasReceivedFromAllMortars.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_HasReceivedFromAllMortars.cpp
@@ -17,12 +17,12 @@
 
 namespace {
 
-/// [inbox_example]
+// [inbox_example]
 template <size_t Dim>
 struct InboxTag {
   using type = std::unordered_map<int, dg::MortarMap<Dim, double>>;
 };
-/// [inbox_example]
+// [inbox_example]
 
 template <size_t Dim>
 using InboxType = tmpl::type_from<InboxTag<Dim>>;

--- a/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_RemoveOptionsAndTerminatePhase.cpp
+++ b/tests/Unit/ParallelAlgorithms/Initialization/Actions/Test_RemoveOptionsAndTerminatePhase.cpp
@@ -108,11 +108,11 @@ struct Component {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
 
-  /// [actions]
+  // [actions]
   using initialization_actions =
       tmpl::list<Action0, Action1,
                  Initialization::Actions::RemoveOptionsAndTerminatePhase>;
-  /// [actions]
+  // [actions]
 
   using phase_dependent_action_list =
       tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_OverlapHelpers.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_OverlapHelpers.cpp
@@ -183,7 +183,7 @@ SPECTRE_TEST_CASE("Unit.ParallelSchwarz.OverlapHelpers",
     INFO("Overlap iterator");
     {
       // Give an example to include in the docs
-      /// [overlap_iterator]
+      // [overlap_iterator]
       // Overlap region:
       // + - - - + -xi->
       // | X X O |
@@ -204,7 +204,7 @@ SPECTRE_TEST_CASE("Unit.ParallelSchwarz.OverlapHelpers",
         ++i;
       }
       CHECK(i == expected_volume_offsets.size());
-      /// [overlap_iterator]
+      // [overlap_iterator]
     }
     // Overlap region: [X X O] -xi->
     test_overlap_iterator(Index<1>{3}, 2, Direction<1>::lower_xi(), {{0, 1}});

--- a/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/Test_ScalarWaveGr.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/CurvedWaveEquation/Test_ScalarWaveGr.cpp
@@ -370,7 +370,7 @@ SPECTRE_TEST_CASE("Unit.AnalyticData.CurvedWaveEquation.ScalarWaveGr",
   }
 }
 
-/// Check restrictions on input options below
+// Check restrictions on input options below
 
 // [[OutputRegex, Mass must be non-negative]]
 SPECTRE_TEST_CASE("Unit.AnalyticData.CurvedWaveEquation.ScalarWaveGrMass",

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Test_Tags.cpp
@@ -25,10 +25,10 @@ SPECTRE_TEST_CASE("Unit.AnalyticSolutions.Tags", "[Unit][PointwiseFunctions]") {
       "BoundaryConditionBase");
   TestHelpers::db::test_simple_tag<Tags::BoundaryCondition<DummyType>>(
       "BoundaryCondition");
-  /// [analytic_name]
+  // [analytic_name]
   TestHelpers::db::test_prefix_tag<Tags::Analytic<DummyTag>>(
       "Analytic(DummyTag)");
-  /// [analytic_name]
+  // [analytic_name]
   TestHelpers::db::test_prefix_tag<Tags::Error<DummyTag>>("Error(DummyTag)");
   TestHelpers::db::test_base_tag<Tags::AnalyticSolutionsBase>(
       "AnalyticSolutionsBase");

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Christoffel.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Christoffel.cpp
@@ -30,14 +30,12 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
-/// \cond
 namespace Tags {
 template <typename Tag, typename Dim, typename Frame, typename>
 struct deriv;
 }  // namespace Tags
 template <typename X, typename Symm, typename IndexList>
 class Tensor;
-/// \endcond
 
 namespace {
 template <size_t Dim, IndexType Index, typename DataType>

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
@@ -72,12 +72,10 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace Tags {
 template <typename Tag, typename Dim, typename Frame, typename>
 struct deriv;
 }  // namespace Tags
-/// \endcond
 
 namespace {
 using Affine = domain::CoordinateMaps::Affine;

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -38,12 +38,10 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-/// \cond
 namespace Tags {
 template <typename Tag, typename Dim, typename Frame, typename>
 struct deriv;
 }  // namespace Tags
-/// \endcond
 
 namespace {
 template <size_t Dim, typename DataType>

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_Tags.cpp
@@ -52,14 +52,14 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Hydro.Tags", "[Unit][Hydro]") {
       "RestMassDensity");
   TestHelpers::db::test_simple_tag<hydro::Tags::SoundSpeedSquared<DataVector>>(
       "SoundSpeedSquared");
-  /// [prefix_example]
+  // [prefix_example]
   TestHelpers::db::test_simple_tag<
       hydro::Tags::SpatialVelocity<DataVector, 3, Frame::Grid>>(
       "Grid_SpatialVelocity");
   TestHelpers::db::test_simple_tag<
       hydro::Tags::SpatialVelocityOneForm<DataVector, 3, Frame::Logical>>(
       "Logical_SpatialVelocityOneForm");
-  /// [prefix_example]
+  // [prefix_example]
   TestHelpers::db::test_simple_tag<hydro::Tags::SpatialVelocitySquared<double>>(
       "SpatialVelocitySquared");
   TestHelpers::db::test_simple_tag<

--- a/tests/Unit/RunSingleTest/RunSingleTest.cpp
+++ b/tests/Unit/RunSingleTest/RunSingleTest.cpp
@@ -36,7 +36,7 @@ RunTests::RunTests(CkArgMsg* msg) {
   sys::abort("A catch test has failed.");
 }
 
-#include "tests/Unit/RunTests.def.h"  /// IWYU pragma: keep
+#include "tests/Unit/RunTests.def.h"
 
 // Needed for tests that use the GlobalCache since it registers itself with
 // Charm++. However, since Parallel/CharmMain.tpp isn't included in the RunTests

--- a/tests/Unit/RunSingleTest/RunSingleTest.cpp
+++ b/tests/Unit/RunSingleTest/RunSingleTest.cpp
@@ -44,9 +44,7 @@ RunTests::RunTests(CkArgMsg* msg) {
 // queued for registration.
 namespace Parallel::charmxx {
 class RegistrationHelper;
-/// \cond
 std::unique_ptr<RegistrationHelper>* charm_register_list = nullptr;
 size_t charm_register_list_capacity = 0;
 size_t charm_register_list_size = 0;
-/// \endcond
 }  // namespace Parallel::charmxx

--- a/tests/Unit/RunTests.cpp
+++ b/tests/Unit/RunTests.cpp
@@ -51,9 +51,7 @@ RunTests::RunTests(CkArgMsg* msg) {
 // queued for registration.
 namespace Parallel::charmxx {
 class RegistrationHelper;
-/// \cond
 std::unique_ptr<RegistrationHelper>* charm_register_list = nullptr;
 size_t charm_register_list_capacity = 0;
 size_t charm_register_list_size = 0;
-/// \endcond
 }  // namespace Parallel::charmxx

--- a/tests/Unit/RunTests.cpp
+++ b/tests/Unit/RunTests.cpp
@@ -43,7 +43,7 @@ RunTests::RunTests(CkArgMsg* msg) {
   sys::abort("A catch test has failed.");
 }
 
-#include "tests/Unit/RunTests.def.h"  /// IWYU pragma: keep
+#include "tests/Unit/RunTests.def.h"
 
 // Needed for tests that use the GlobalCache since it registers itself with
 // Charm++. However, since Parallel/CharmMain.tpp isn't included in the RunTests

--- a/tests/Unit/Time/Actions/Test_ChangeSlabSize.cpp
+++ b/tests/Unit/Time/Actions/Test_ChangeSlabSize.cpp
@@ -28,7 +28,6 @@
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
-/// \cond
 // IWYU pragma: no_forward_declare ActionTesting::InitializeDataBox
 namespace Tags {
 template <typename Tag>
@@ -36,7 +35,6 @@ struct Next;
 template <typename Tag>
 struct dt;
 }  // namespace Tags
-/// \endcond
 
 namespace {
 struct Var : db::SimpleTag {

--- a/tests/Unit/Time/Test_Time.cpp
+++ b/tests/Unit/Time/Test_Time.cpp
@@ -301,7 +301,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
 #pragma GCC diagnostic ignored "-Wunused-comparison"
 #endif
 
-/// [example_of_error_test]
+// [example_of_error_test]
 // [[OutputRegex, Out of range slab fraction]]
 [[noreturn]] SPECTRE_TEST_CASE("Unit.Time.Time.Init.0", "[Unit][Time]") {
   ASSERTION_TEST();
@@ -310,7 +310,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
-/// [example_of_error_test]
+// [example_of_error_test]
 
 // [[OutputRegex, Out of range slab fraction]]
 [[noreturn]] SPECTRE_TEST_CASE("Unit.Time.Time.Init.1", "[Unit][Time]") {

--- a/tests/Unit/Utilities/Test_CachedFunction.cpp
+++ b/tests/Unit/Utilities/Test_CachedFunction.cpp
@@ -27,14 +27,14 @@ SPECTRE_TEST_CASE("Unit.Utilities.CachedFunction", "[Unit][Utilities]") {
     return a < b;
   };
 
-  /// [make_cached_function_example]
+  // [make_cached_function_example]
   auto cached = make_cached_function<const std::string&>(func);
 
   // Specifying all the arguments
   auto cached2 =
       make_cached_function<const std::string&, std::map, decltype(comparator)>(
           func, std::move(comparator));
-  /// [make_cached_function_example]
+  // [make_cached_function_example]
 
   static_assert(std::is_same_v<decltype(cached)::input, std::string>,
                 "Wrong input type");

--- a/tests/Unit/Utilities/Test_ContainerHelpers.cpp
+++ b/tests/Unit/Utilities/Test_ContainerHelpers.cpp
@@ -14,7 +14,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 
-/// [get_element_example_indexing_callable]
+// [get_element_example_indexing_callable]
 struct ArrayOfArraysIndexFunctor {
   template <size_t OuterArraySize, size_t InnerArraySize, typename T>
   T& operator()(std::array<std::array<T, InnerArraySize>, OuterArraySize>&
@@ -24,9 +24,9 @@ struct ArrayOfArraysIndexFunctor {
         .at(index / OuterArraySize);
   }
 };
-/// [get_element_example_indexing_callable]
+// [get_element_example_indexing_callable]
 
-/// [get_size_example_size_callable]
+// [get_size_example_size_callable]
 struct ArrayOfArraysSizeFunctor {
   template <size_t OuterArraySize, size_t InnerArraySize, typename T>
   size_t operator()(
@@ -35,7 +35,7 @@ struct ArrayOfArraysSizeFunctor {
     return OuterArraySize * InnerArraySize;
   }
 };
-/// [get_size_example_size_callable]
+// [get_size_example_size_callable]
 
 namespace {
 struct HalfDataVectorSize {

--- a/tests/Unit/Utilities/Test_FakeVirtual.cpp
+++ b/tests/Unit/Utilities/Test_FakeVirtual.cpp
@@ -14,7 +14,7 @@
 
 namespace {
 
-/// [fake_virtual_example]
+// [fake_virtual_example]
 DEFINE_FAKE_VIRTUAL(fv)
 
 class Derived;
@@ -46,7 +46,7 @@ class Derived : public Base::Inherit {
     return x + 3;
   }
 };
-/// [fake_virtual_example]
+// [fake_virtual_example]
 
 std::string called_func;
 std::vector<std::string> called_types;

--- a/tests/Unit/Utilities/Test_FileSystem.cpp
+++ b/tests/Unit/Utilities/Test_FileSystem.cpp
@@ -10,7 +10,7 @@
 
 SPECTRE_TEST_CASE("Unit.Utilities.FileSystem.get_parent_path",
                   "[Unit][Utilities]") {
-  /// [get_parent_path]
+  // [get_parent_path]
   CHECK("/test/path/to/dir"s ==
         file_system::get_parent_path("/test/path/to/dir/dummy.txt"));
   CHECK("/test/path/to"s == file_system::get_parent_path("/test/path/to/dir/"));
@@ -22,12 +22,12 @@ SPECTRE_TEST_CASE("Unit.Utilities.FileSystem.get_parent_path",
   CHECK("."s == file_system::get_parent_path("usr"));
   CHECK("."s == file_system::get_parent_path(".."));
   CHECK("."s == file_system::get_parent_path(""));
-  /// [get_parent_path]
+  // [get_parent_path]
 }
 
 SPECTRE_TEST_CASE("Unit.Utilities.FileSystem.get_file_name",
                   "[Unit][Utilities]") {
-  /// [get_file_name]
+  // [get_file_name]
   CHECK("dummy.txt"s ==
         file_system::get_file_name("/test/path/to/dir/dummy.txt"));
   CHECK(".dummy.txt"s ==
@@ -37,7 +37,7 @@ SPECTRE_TEST_CASE("Unit.Utilities.FileSystem.get_file_name",
   CHECK(".dummy.txt"s == file_system::get_file_name(".dummy.txt"));
   CHECK("dummy.txt"s == file_system::get_file_name("dummy.txt"));
   CHECK(".dummy"s == file_system::get_file_name(".dummy"));
-  /// [get_file_name]
+  // [get_file_name]
 }
 
 // [[OutputRegex, Failed to find a file in the given path: '/']]

--- a/tests/Unit/Utilities/Test_Functional.cpp
+++ b/tests/Unit/Utilities/Test_Functional.cpp
@@ -199,17 +199,17 @@ void test_functional_against_function(
   }
 }
 
-/// [using_sinusoid]
+// [using_sinusoid]
 using Sinusoid = funcl::Multiplies<
     funcl::Identity,
     funcl::Sin<funcl::Plus<funcl::Identity, funcl::Multiplies<>>>>;
-///[using_sinusoid]
+// [using_sinusoid]
 
-/// [using_gaussian]
+// [using_gaussian]
 using GaussianExp =
     funcl::Negate<funcl::Square<funcl::Minus<Identity, Literal<5, double>>>>;
 using Gaussian = funcl::Exp<GaussianExp>;
-/// [using_gaussian]
+// [using_gaussian]
 
 void test_get_argument() noexcept {
   CHECK(GetArgument<1>{}(-2) == -2);

--- a/tests/Unit/Utilities/Test_MakeString.cpp
+++ b/tests/Unit/Utilities/Test_MakeString.cpp
@@ -11,10 +11,10 @@
 #include "Utilities/StdHelpers.hpp"
 
 SPECTRE_TEST_CASE("Unit.Utilities.MakeString", "[Unit][Utilities]") {
-  /// [make_string]
+  // [make_string]
   std::array<int, 3> arr{{2, 3, 4}};
   const std::string t = MakeString{} << "Test" << 2 << arr << "Done";
-  /// [make_string]
+  // [make_string]
   const std::string expected = "Test2" + get_output(arr) + "Done";
   CHECK(t == expected);
   CHECK(get_output(MakeString{} << "Test" << 2 << arr << "Done") == expected);

--- a/tests/Unit/Utilities/Test_MakeVector.cpp
+++ b/tests/Unit/Utilities/Test_MakeVector.cpp
@@ -16,7 +16,7 @@ SPECTRE_TEST_CASE("Unit.Utilities.MakeVector", "[Unit][Utilities]") {
           double>::value,
       "Unit Test Failure: Incorrect type from make_vector.");
 
-  /// [make_vector_example]
+  // [make_vector_example]
   auto vector = make_vector(3.2, 4.3, 5.4, 6.5, 7.8);
   CHECK(vector == (std::vector<double>{{3.2, 4.3, 5.4, 6.5, 7.8}}));
 
@@ -31,5 +31,5 @@ SPECTRE_TEST_CASE("Unit.Utilities.MakeVector", "[Unit][Utilities]") {
 
   auto vector_explicit_type = make_vector<double>(1, 2, 3);
   CHECK(vector_explicit_type == (std::vector<double>{1.,2.,3.}));
-  /// [make_vector_example]
+  // [make_vector_example]
 }

--- a/tests/Unit/Utilities/Test_Overloader.cpp
+++ b/tests/Unit/Utilities/Test_Overloader.cpp
@@ -7,7 +7,7 @@
 #include "Utilities/TypeTraits.hpp"
 
 namespace {
-/// [overloader_example]
+// [overloader_example]
 struct my_type1 {
   int func(int a) { return 2 * a; }
 };
@@ -45,7 +45,7 @@ void caller() {
   func(my_type1{});
   func(my_type2{});
 }
-/// [overloader_example]
+// [overloader_example]
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Utilities.Overloader", "[Unit][Utilities]") {

--- a/tests/Unit/Utilities/Test_ProtocolHelpers.cpp
+++ b/tests/Unit/Utilities/Test_ProtocolHelpers.cpp
@@ -14,7 +14,7 @@ namespace {
 
 /// [named_protocol]
 namespace protocols {
-/*!
+/*
  * \brief Has a name.
  *
  * Requires the class has these member functions:

--- a/tests/Unit/Utilities/Test_ProtocolHelpers.cpp
+++ b/tests/Unit/Utilities/Test_ProtocolHelpers.cpp
@@ -12,7 +12,7 @@
 
 namespace {
 
-/// [named_protocol]
+// [named_protocol]
 namespace protocols {
 /*
  * \brief Has a name.
@@ -31,9 +31,9 @@ struct Named {
   };
 };
 }  // namespace protocols
-/// [named_protocol]
+// [named_protocol]
 
-/// [named_conformance]
+// [named_conformance]
 class Person : public tt::ConformsTo<protocols::Named> {
  public:
   // Function required to conform to the protocol
@@ -48,9 +48,9 @@ class Person : public tt::ConformsTo<protocols::Named> {
   Person(std::string first_name, std::string last_name)
       : first_name_(std::move(first_name)), last_name_(std::move(last_name)) {}
 };
-/// [named_conformance]
+// [named_conformance]
 
-/// [using_named_protocol]
+// [using_named_protocol]
 template <typename NamedThing>
 std::string greet(const NamedThing& named_thing) {
   // Make sure the template parameter conforms to the protocol
@@ -58,9 +58,9 @@ std::string greet(const NamedThing& named_thing) {
   // Now we can rely on the interface that the protocol defines
   return "Hello, " + named_thing.name() + "!";
 }
-/// [using_named_protocol]
+// [using_named_protocol]
 
-/// [protocol_sfinae]
+// [protocol_sfinae]
 template <typename Thing,
           Requires<not tt::conforms_to_v<Thing, protocols::Named>> = nullptr>
 std::string greet_anything(const Thing& /*anything*/) {
@@ -71,7 +71,7 @@ template <typename NamedThing,
 std::string greet_anything(const NamedThing& named_thing) {
   return greet(named_thing);
 }
-/// [protocol_sfinae]
+// [protocol_sfinae]
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Utilities.ProtocolHelpers", "[Utilities][Unit]") {
@@ -82,13 +82,13 @@ SPECTRE_TEST_CASE("Unit.Utilities.ProtocolHelpers", "[Utilities][Unit]") {
 }
 
 // Test tt::conforms_to metafunction
-/// [conforms_to]
+// [conforms_to]
 // SFINAE-friendly version:
 constexpr bool person_class_is_named =
     tt::conforms_to_v<Person, protocols::Named>;
 // Assert-friendly version with more diagnostics:
 static_assert(tt::assert_conforms_to<Person, protocols::Named>);
-/// [conforms_to]
+// [conforms_to]
 static_assert(person_class_is_named,
               "The 'Person' class does not conform to the 'Named' protocol.");
 
@@ -108,7 +108,7 @@ static_assert(tt::conforms_to_v<DerivedConformingClass, protocols::Named>,
 // Give examples about protocol antipatterns
 namespace {
 namespace protocols {
-/// [named_antipattern]
+// [named_antipattern]
 // Don't do this. Protocols should not have template parameters.
 template <typename NameType>
 struct NamedAntipattern {
@@ -120,8 +120,8 @@ struct NamedAntipattern {
                   "The 'name' function must return a 'NameType'.");
   };
 };
-/// [named_antipattern]
-/// [named_with_type]
+// [named_antipattern]
+// [named_with_type]
 // Instead, do this.
 struct NamedWithType {
   template <typename ConformingType>
@@ -134,24 +134,24 @@ struct NamedWithType {
                   "The 'name' function must return a 'NameType'.");
   };
 };
-/// [named_with_type]
+// [named_with_type]
 }  // namespace protocols
-/// [person_with_name_type]
+// [person_with_name_type]
 struct PersonWithNameType : tt::ConformsTo<protocols::NamedWithType> {
   using NameType = std::string;
   std::string name() const;
 };
-/// [person_with_name_type]
-/// [example_check_name_type]
+// [person_with_name_type]
+// [example_check_name_type]
 static_assert(
     tt::assert_conforms_to<PersonWithNameType, protocols::NamedWithType>);
 static_assert(
     std::is_same_v<typename PersonWithNameType::NameType, std::string>,
     "The `NameType` isn't a `std::string`!");
-/// [example_check_name_type]
+// [example_check_name_type]
 }  // namespace
 
 // Give an example how protocol consumers should test protocol conformance
-/// [test_protocol_conformance]
+// [test_protocol_conformance]
 static_assert(tt::assert_conforms_to<Person, protocols::Named>);
-/// [test_protocol_conformance]
+// [test_protocol_conformance]

--- a/tests/Unit/Utilities/Test_Registration.cpp
+++ b/tests/Unit/Utilities/Test_Registration.cpp
@@ -11,7 +11,7 @@
 #include "Utilities/TMPL.hpp"
 
 namespace {
-/// [registrar_structure]
+// [registrar_structure]
 template <typename Registrars>
 class Base {
  public:
@@ -40,9 +40,9 @@ class Derived1 : public Base<Registrars> {
   using options = tmpl::list<>;
   int func() const noexcept override { return 1; }
 };
-/// [registrar_structure]
+// [registrar_structure]
 
-/// [registrar]
+// [registrar]
 template <typename SomeArg, typename Registrars>
 class Derived2;
 
@@ -59,9 +59,9 @@ class Derived2 : public Base<Registrars> {
   using options = tmpl::list<>;
   int func() const noexcept override { return 2; }
 };
-/// [registrar]
+// [registrar]
 
-/// [custom_registrar]
+// [custom_registrar]
 template <int N, typename Registrars>
 class Derived3;
 
@@ -80,15 +80,15 @@ class Derived3 : public Base<Registrars> {
   using options = tmpl::list<>;
   int func() const noexcept override { return N; }
 };
-/// [custom_registrar]
+// [custom_registrar]
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Utilities.Registration", "[Unit][Utilities]") {
-  /// [registrar_use]
+  // [registrar_use]
   using ConcreteBase =
       Base<tmpl::list<Registrars::Derived1, Registrars::Derived2<double>,
                       Registrars::Derived3<4>>>;
-  /// [registrar_use]
+  // [registrar_use]
   CHECK(TestHelpers::test_factory_creation<ConcreteBase>("Derived1")->func() ==
         1);
   CHECK(TestHelpers::test_factory_creation<ConcreteBase>("Derived2")->func() ==

--- a/tests/Unit/Utilities/Test_Requires.cpp
+++ b/tests/Unit/Utilities/Test_Requires.cpp
@@ -11,19 +11,19 @@
 #include "Utilities/TypeTraits/IsA.hpp"
 
 namespace {
-/// [function_definitions]
-/// [foo_definition]
+// [function_definitions]
+// [foo_definition]
 template <typename T, Requires<tt::is_a_v<std::vector, T>> = nullptr>
 std::string foo(const T& /*unused*/) {
   return "vector";
 }
-/// [foo_definition]
+// [foo_definition]
 
 template <typename T, Requires<tt::is_a_v<std::list, T>> = nullptr>
 std::string foo(const T& /*unused*/) {
   return "list";
 }
-/// [function_definitions]
+// [function_definitions]
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Utilities.Requires", "[Unit][Utilities]") {

--- a/tests/Unit/Utilities/Test_StaticCache.cpp
+++ b/tests/Unit/Utilities/Test_StaticCache.cpp
@@ -47,13 +47,13 @@ std::ostream& operator<<(std::ostream& os, Animal t) noexcept {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Utilities.StaticCache", "[Utilities][Unit]") {
-  /// [static_cache]
+  // [static_cache]
   const static auto cache =
       make_static_cache<CacheRange<0_st, 3_st>, CacheRange<3_st, 5_st>>(
           [](const size_t a, const size_t b) noexcept { return a + b; });
   CHECK(cache(0, 3) == 3);  // smallest entry
   CHECK(cache(2, 4) == 6);  // largest entry
-  /// [static_cache]
+  // [static_cache]
 
   std::vector<std::pair<size_t, size_t>> calls;
   const auto cache2 =
@@ -98,11 +98,11 @@ SPECTRE_TEST_CASE("Unit.Utilities.StaticCache", "[Utilities][Unit]") {
   CHECK(small_cache() == 5);
   CHECK(small_calls == 1);
 
-  /// [static_cache_no_args]
+  // [static_cache_no_args]
   const auto simple_small_cache =
       make_static_cache([]() noexcept { return size_t{10}; });
   CHECK(simple_small_cache() == 10);
-  /// [static_cache_no_args]
+  // [static_cache_no_args]
 
   // check enum caching functionality
   const auto enum_generator_tuple =
@@ -136,12 +136,12 @@ SPECTRE_TEST_CASE("Unit.Utilities.StaticCache", "[Utilities][Unit]") {
                                value);
     };
   };
-  /// [static_cache_with_enum]
+  // [static_cache_with_enum]
   const auto simple_enum_cache = make_static_cache<
       CacheEnumeration<Color, Color::Red, Color::Green, Color::Purple>>([
   ](const Color color) noexcept { return std::string{MakeString{} << color}; });
   CHECK(simple_enum_cache(Color::Red) == "Red");
-  /// [static_cache_with_enum]
+  // [static_cache_with_enum]
 
   const auto int_cache = make_static_cache<CacheRange<-5, 10>>(
       [](const int val) noexcept { return pow<3>(val); });
@@ -166,7 +166,7 @@ SPECTRE_TEST_CASE("Unit.Utilities.StaticCache", "[Utilities][Unit]") {
           std::make_tuple(3, static_cast<size_t>(color) + 1, 4));
   }
 
-  /// [static_cache_with_enum_and_numeric]
+  // [static_cache_with_enum_and_numeric]
   const auto simple_enum_size_t_enum_cache = make_static_cache<
       CacheEnumeration<Color, Color::Red, Color::Green, Color::Purple>,
       CacheRange<3_st, 5_st>,
@@ -179,7 +179,7 @@ SPECTRE_TEST_CASE("Unit.Utilities.StaticCache", "[Utilities][Unit]") {
         "Red3Labradoodle");
   CHECK(simple_enum_size_t_enum_cache(Color::Purple, 4, Animal::Poodle) ==
         "Purple4Poodle");
-  /// [static_cache_with_enum_and_numeric]
+  // [static_cache_with_enum_and_numeric]
   const auto enum_size_t_enum_cache = make_static_cache<
       CacheEnumeration<Color, Color::Red, Color::Green, Color::Purple>,
       CacheRange<3_st, 5_st>,

--- a/tests/Unit/Utilities/Test_TMPL.cpp
+++ b/tests/Unit/Utilities/Test_TMPL.cpp
@@ -11,7 +11,7 @@
 #include "Utilities/TypeTraits.hpp"
 
 namespace {
-/// [expand_pack_example]
+// [expand_pack_example]
 template <typename... Elements, size_t... Is>
 void transform(const std::tuple<Elements...>& tupull,
                std::tuple<Elements...>& out_tupull,
@@ -31,7 +31,7 @@ void test_expand_pack() noexcept {
   CHECK(std::get<1>(my_tupull_output) == 5.4);
   CHECK(std::get<2>(my_tupull_output) == 16.4f);
 }
-/// [expand_pack_example]
+// [expand_pack_example]
 
 template <typename>
 struct Templated {};
@@ -77,7 +77,7 @@ void test_get_first_argument() noexcept {
   CHECK('7' == get_first_argument(a3, a1, a2, a0));
 }
 
-/// [expand_pack_left_to_right]
+// [expand_pack_left_to_right]
 template <typename... Ts>
 void test_expand_pack_left_to_right(const size_t expected,
                                     tmpl::list<Ts...> /*meta*/) {
@@ -86,7 +86,7 @@ void test_expand_pack_left_to_right(const size_t expected,
   EXPAND_PACK_LEFT_TO_RIGHT(lambda(Ts{}));
   CHECK(sum == expected);
 }
-/// [expand_pack_left_to_right]
+// [expand_pack_left_to_right]
 
 static_assert(tmpl::as_pack<tmpl::list<tmpl::size_t<1>, tmpl::size_t<2>,
                                        tmpl::size_t<3>>>([](auto... args) {
@@ -94,13 +94,13 @@ static_assert(tmpl::as_pack<tmpl::list<tmpl::size_t<1>, tmpl::size_t<2>,
               }) == 6);
 
 void test_as_pack() noexcept {
-  /// [as_pack]
+  // [as_pack]
   using List = tmpl::list<tmpl::size_t<1>, tmpl::size_t<2>, tmpl::size_t<3>>;
   const size_t result = tmpl::as_pack<List>([](auto... args) {
     return (... + tmpl::type_from<decltype(args)>::value);
   });
   CHECK(result == 6);
-  /// [as_pack]
+  // [as_pack]
 }
 }  // namespace
 

--- a/tests/Unit/Utilities/Test_TaggedTuple.cpp
+++ b/tests/Unit/Utilities/Test_TaggedTuple.cpp
@@ -48,7 +48,7 @@ struct not_streamable_tag {
   using type = not_streamable;
 };
 
-/// [expand_tuple_example_function]
+// [expand_tuple_example_function]
 struct FirstArg {
   using type = int;
 };
@@ -58,14 +58,14 @@ struct SecondArg {
 double test_function(const int first_arg, const double second_arg) {
   return static_cast<double>(first_arg) + second_arg;
 }
-/// [expand_tuple_example_function]
+// [expand_tuple_example_function]
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Utilities.TaggedTuple", "[Utilities][Unit]") {
-  /// [construction_example]
+  // [construction_example]
   tuples::TaggedTuple<name, age, email, parents, not_streamable_tag> test(
       "bla", 17, "bla@bla.bla", std::vector<std::string>{"Mom", "Dad"}, 0);
-  /// [construction_example]
+  // [construction_example]
   static_assert(tuples::TaggedTuple<name, age, email>::size() == 3,
                 "Failed to test size of TaggedTuple");
   {
@@ -74,11 +74,11 @@ SPECTRE_TEST_CASE("Unit.Utilities.TaggedTuple", "[Utilities][Unit]") {
     CHECK(ss.str() == "(bla, 17, bla@bla.bla, (Mom,Dad), NOT STREAMABLE)");
   }
   CHECK(test.size() == 5);
-  /// [get_example]
+  // [get_example]
   CHECK("bla" == tuples::get<name>(test));
   CHECK(17 == tuples::get<age>(test));
   CHECK("bla@bla.bla" == tuples::get<email>(test));
-  /// [get_example]
+  // [get_example]
   auto& name_temp = tuples::get<name>(test);
   name_temp = "Dennis";
   CHECK(tuples::get<name>(test) == "Dennis");
@@ -112,11 +112,11 @@ SPECTRE_TEST_CASE("Unit.Utilities.TaggedTuple", "[Utilities][Unit]") {
             "Eamonn", 17, "bla@bla.bla", std::vector<std::string>{"Mom", "Dad"},
             0});
 
-  /// [reorder_example]
+  // [reorder_example]
   const auto test4 = tuples::reorder<
       tuples::TaggedTuple<email, not_streamable_tag, parents, age, name>>(
       std::move(test));
-  /// [reorder_example]
+  // [reorder_example]
   CHECK(test4 ==
         tuples::TaggedTuple<email, not_streamable_tag, parents, age, name>{
             "bla@bla.bla", 0, std::vector<std::string>{"Mom", "Dad"}, 17,
@@ -124,14 +124,14 @@ SPECTRE_TEST_CASE("Unit.Utilities.TaggedTuple", "[Utilities][Unit]") {
 
   {
     INFO("Expand tuple");
-    /// [expand_tuple_example]
+    // [expand_tuple_example]
     const double extra_factor = 3.;
     const double result = tuples::apply(
         [&extra_factor](const auto&... expanded_args) {
           return extra_factor * test_function(expanded_args...);
         },
         tuples::TaggedTuple<FirstArg, SecondArg>{1, 2.});
-    /// [expand_tuple_example]
+    // [expand_tuple_example]
     CHECK(result == 9.);
     CHECK(1 == tuples::apply<tmpl::list<FirstArg>>(
                    [](const int arg) { return arg; },

--- a/tests/Unit/Utilities/Test_Tuple.cpp
+++ b/tests/Unit/Utilities/Test_Tuple.cpp
@@ -11,7 +11,7 @@
 #include "Utilities/Tuple.hpp"
 
 namespace {
-/// [tuple_fold_struct_defn]
+// [tuple_fold_struct_defn]
 template <typename T>
 struct tuple_fold_plus {
   T value = 0.0;
@@ -20,21 +20,21 @@ struct tuple_fold_plus {
     value += element;
   }
 };
-/// [tuple_fold_struct_defn]
+// [tuple_fold_struct_defn]
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Utilities.tuple_fold", "[Utilities][Unit]") {
   {
-    /// [tuple_fold_lambda]
+    // [tuple_fold_lambda]
     const auto my_tupull = std::make_tuple(2, 7, -3.8, 20.9);
     double sum_value = 0.0;
     tuple_fold(my_tupull,
                [](const auto& element, double& state) { state += element; },
                sum_value);
     CHECK(sum_value == approx(26.1));
-    /// [tuple_fold_lambda]
+    // [tuple_fold_lambda]
 
-    /// [tuple_counted_fold_lambda]
+    // [tuple_counted_fold_lambda]
     sum_value = 0.0;
     tuple_counted_fold(my_tupull,
                        [](const auto& element, size_t index, double& state) {
@@ -44,15 +44,15 @@ SPECTRE_TEST_CASE("Unit.Utilities.tuple_fold", "[Utilities][Unit]") {
                        },
                        sum_value);
     CHECK(sum_value == approx(19.1));
-    /// [tuple_counted_fold_lambda]
+    // [tuple_counted_fold_lambda]
   }
   {
-    /// [tuple_fold_struct]
+    // [tuple_fold_struct]
     const auto my_tupull = std::make_tuple(2, 7, -3.8, 20.9);
     tuple_fold_plus<double> sum_value{};
     tuple_fold(my_tupull, sum_value);
     CHECK(sum_value.value == approx(26.1));
-    /// [tuple_fold_struct]
+    // [tuple_fold_struct]
   }
   {
     // Check passing rvalue to tuple_fold and tuple_counted_fold works
@@ -177,7 +177,7 @@ SPECTRE_TEST_CASE("Unit.Utilities.tuple_fold", "[Utilities][Unit]") {
 }
 
 namespace {
-/// [tuple_transform_negate]
+// [tuple_transform_negate]
 struct negate {
   template <typename T, typename Index, typename S>
   void operator()(const T& element, Index /*index*/,
@@ -185,7 +185,7 @@ struct negate {
     std::get<Index::value>(second_tuple_element) = -element;
   }
 };
-/// [tuple_transform_negate]
+// [tuple_transform_negate]
 struct negate_if_sum_less {
   template <typename T, typename Index, typename S>
   void operator()(const T& element, Index /*index*/, S& second_tuple_element,
@@ -205,7 +205,7 @@ struct negate_if_sum_less {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Utilities.tuple_transform", "[Utilities][Unit]") {
-  /// [tuple_transform]
+  // [tuple_transform]
   const auto my_tupull = std::make_tuple(2, 7, -3.8, 20.9);
   std::decay_t<decltype(my_tupull)> out_tupull;
   tuple_transform(my_tupull,
@@ -219,7 +219,7 @@ SPECTRE_TEST_CASE("Unit.Utilities.tuple_transform", "[Utilities][Unit]") {
   CHECK(std::get<1>(out_tupull) == -7);
   CHECK(std::get<2>(out_tupull) == 3.8);
   CHECK(std::get<3>(out_tupull) == -20.9);
-  /// [tuple_transform]
+  // [tuple_transform]
 
   // Check iterating left-to-right and right-to-left, and also passing in rvalue
   // and const lvalue references

--- a/tests/Unit/Utilities/TypeTraits/Test_ArraySize.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_ArraySize.cpp
@@ -5,11 +5,9 @@
 
 #include "Utilities/TypeTraits/ArraySize.hpp"
 
-/// \cond
 namespace {
 class A {};
 }  // namespace
-/// \endcond
 
 /// [array_size_example]
 static_assert(tt::array_size<std::array<double, 3>>::value == 3,

--- a/tests/Unit/Utilities/TypeTraits/Test_ArraySize.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_ArraySize.cpp
@@ -9,9 +9,9 @@ namespace {
 class A {};
 }  // namespace
 
-/// [array_size_example]
+// [array_size_example]
 static_assert(tt::array_size<std::array<double, 3>>::value == 3,
               "Failed testing type trait array_size");
 static_assert(tt::array_size<std::array<A, 4>>::value == 4,
               "Failed testing type trait array_size");
-/// [array_size_example]
+// [array_size_example]

--- a/tests/Unit/Utilities/TypeTraits/Test_CreateHasStaticMemberVariable.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_CreateHasStaticMemberVariable.cpp
@@ -6,7 +6,7 @@
 #include "Utilities/TypeTraits/CreateHasStaticMemberVariable.hpp"
 
 namespace {
-/// [CREATE_HAS_EXAMPLE]
+// [CREATE_HAS_EXAMPLE]
 CREATE_HAS_STATIC_MEMBER_VARIABLE(foo)
 CREATE_HAS_STATIC_MEMBER_VARIABLE_V(foo)
 CREATE_HAS_STATIC_MEMBER_VARIABLE(foobar)
@@ -26,6 +26,6 @@ static_assert(not has_foobar_v<testing_create_has_static_member_variable>,
 static_assert(
     not has_foobar_v<testing_create_has_static_member_variable, size_t>,
     "Failed testing CREATE_HAS_STATIC_MEMBER_VARIABLE");
-/// [CREATE_HAS_EXAMPLE]
+// [CREATE_HAS_EXAMPLE]
 
 }  // namespace

--- a/tests/Unit/Utilities/TypeTraits/Test_CreateHasTypeAlias.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_CreateHasTypeAlias.cpp
@@ -4,7 +4,7 @@
 #include "Utilities/TypeTraits/CreateHasTypeAlias.hpp"
 
 namespace {
-/// [CREATE_HAS_TYPE_ALIAS]
+// [CREATE_HAS_TYPE_ALIAS]
 CREATE_HAS_TYPE_ALIAS(foo_alias)
 CREATE_HAS_TYPE_ALIAS_V(foo_alias)
 CREATE_HAS_TYPE_ALIAS(foobar_alias)
@@ -23,5 +23,5 @@ static_assert(not has_foobar_alias_v<testing_create_has_type_alias>,
               "Failed testing CREATE_HAS_TYPE_ALIAS");
 static_assert(not has_foobar_alias_v<testing_create_has_type_alias, int>,
               "Failed testing CREATE_HAS_TYPE_ALIAS");
-/// [CREATE_HAS_TYPE_ALIAS]
+// [CREATE_HAS_TYPE_ALIAS]
 }  // namespace

--- a/tests/Unit/Utilities/TypeTraits/Test_CreateIsCallable.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_CreateIsCallable.cpp
@@ -6,7 +6,7 @@
 #include "Utilities/TypeTraits/CreateIsCallable.hpp"
 
 namespace {
-/// [CREATE_IS_CALLABLE_EXAMPLE]
+// [CREATE_IS_CALLABLE_EXAMPLE]
 CREATE_IS_CALLABLE(foo)
 CREATE_IS_CALLABLE_V(foo)
 CREATE_IS_CALLABLE_R_V(foo)
@@ -30,5 +30,5 @@ static_assert(not is_foo_callable_r_v<int, bar, int, double>,
               "Failed testing CREATE_IS_CALLABLE");
 static_assert(not is_foobar_callable_v<bar, int, double>,
               "Failed testing CREATE_IS_CALLABLE");
-/// [CREATE_IS_CALLABLE_EXAMPLE]
+// [CREATE_IS_CALLABLE_EXAMPLE]
 }  // namespace

--- a/tests/Unit/Utilities/TypeTraits/Test_GetFundamentalType.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_GetFundamentalType.cpp
@@ -8,7 +8,7 @@
 #include "Utilities/TypeTraits.hpp"
 #include "Utilities/TypeTraits/GetFundamentalType.hpp"
 
-/// [get_fundamental_type]
+// [get_fundamental_type]
 static_assert(
     std::is_same_v<
         typename tt::get_fundamental_type<std::array<double, 2>>::type, double>,
@@ -20,4 +20,4 @@ static_assert(
     "Failed testing get_fundamental_type");
 static_assert(std::is_same_v<typename tt::get_fundamental_type_t<int>, int>,
               "Failed testing get_fundamental_type");
-/// [get_fundamental_type]
+// [get_fundamental_type]

--- a/tests/Unit/Utilities/TypeTraits/Test_HasEquivalence.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_HasEquivalence.cpp
@@ -3,7 +3,6 @@
 
 #include "Utilities/TypeTraits/HasEquivalence.hpp"
 
-/// \cond
 namespace {
 class A {};
 }  // namespace
@@ -13,7 +12,6 @@ class C {};
 
 bool operator==(const C&, const C&);
 }  // namespace TestHelpers
-/// \endcond
 
 /// [has_equivalence_example]
 static_assert(not tt::has_equivalence<A>::value,

--- a/tests/Unit/Utilities/TypeTraits/Test_HasEquivalence.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_HasEquivalence.cpp
@@ -13,7 +13,7 @@ class C {};
 bool operator==(const C&, const C&);
 }  // namespace TestHelpers
 
-/// [has_equivalence_example]
+// [has_equivalence_example]
 static_assert(not tt::has_equivalence<A>::value,
               "Failed testing type trait has_equivalence");
 static_assert(tt::has_equivalence<TestHelpers::C>::value,
@@ -22,4 +22,4 @@ static_assert(tt::has_equivalence_t<TestHelpers::C>::value,
               "Failed testing type trait has_equivalence");
 static_assert(tt::has_equivalence_v<TestHelpers::C>,
               "Failed testing type trait has_equivalence");
-/// [has_equivalence_example]
+// [has_equivalence_example]

--- a/tests/Unit/Utilities/TypeTraits/Test_HasInequivalence.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_HasInequivalence.cpp
@@ -13,7 +13,7 @@ class C {};
 bool operator!=(const C&, const C&);
 }  // namespace TestHelpers
 
-/// [has_inequivalence_example]
+// [has_inequivalence_example]
 static_assert(not tt::has_inequivalence<A>::value,
               "Failed testing type trait has_inequivalence");
 static_assert(tt::has_inequivalence<TestHelpers::C>::value,
@@ -22,4 +22,4 @@ static_assert(tt::has_inequivalence_t<TestHelpers::C>::value,
               "Failed testing type trait has_inequivalence");
 static_assert(tt::has_inequivalence_v<TestHelpers::C>,
               "Failed testing type trait has_inequivalence");
-/// [has_inequivalence_example]
+// [has_inequivalence_example]

--- a/tests/Unit/Utilities/TypeTraits/Test_HasInequivalence.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_HasInequivalence.cpp
@@ -3,7 +3,6 @@
 
 #include "Utilities/TypeTraits/HasInequivalence.hpp"
 
-/// \cond
 namespace {
 class A {};
 }  // namespace
@@ -13,7 +12,6 @@ class C {};
 
 bool operator!=(const C&, const C&);
 }  // namespace TestHelpers
-/// \endcond
 
 /// [has_inequivalence_example]
 static_assert(not tt::has_inequivalence<A>::value,

--- a/tests/Unit/Utilities/TypeTraits/Test_IsA.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_IsA.cpp
@@ -17,13 +17,11 @@
 
 #include "Utilities/TypeTraits/IsA.hpp"
 
-/// \cond
 namespace {
 class A;
 class C;
 class D;
 } // namespace
-/// \endcond
 
 /// [is_a_example]
 static_assert(tt::is_a<std::vector, std::vector<double>>::value,

--- a/tests/Unit/Utilities/TypeTraits/Test_IsA.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_IsA.cpp
@@ -23,7 +23,7 @@ class C;
 class D;
 } // namespace
 
-/// [is_a_example]
+// [is_a_example]
 static_assert(tt::is_a<std::vector, std::vector<double>>::value,
               "Failed testing type trait is_a<vector>");
 static_assert(not tt::is_a_t<std::vector, double>::value,
@@ -182,4 +182,4 @@ static_assert(tt::is_a<std::shared_future,
               "Failed testing type trait is_a<shared_future>");
 static_assert(not tt::is_a<std::shared_future, std::future<double>>::value,
               "Failed testing type trait is_a<shared_future>");
-/// [is_a_example]
+// [is_a_example]

--- a/tests/Unit/Utilities/TypeTraits/Test_IsCallable.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_IsCallable.cpp
@@ -3,7 +3,6 @@
 
 #include "Utilities/TypeTraits/IsCallable.hpp"
 
-/// \cond
 namespace {
 class A {
  public:
@@ -17,7 +16,6 @@ class B {
   }
 };
 }  // namespace
-/// \endcond
 
 /// [is_callable_example]
 static_assert(not tt::is_callable<A, int, double>::value,

--- a/tests/Unit/Utilities/TypeTraits/Test_IsCallable.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_IsCallable.cpp
@@ -17,7 +17,7 @@ class B {
 };
 }  // namespace
 
-/// [is_callable_example]
+// [is_callable_example]
 static_assert(not tt::is_callable<A, int, double>::value,
               "Failed testing type trait is_callable");
 static_assert(not tt::is_callable<A, int>::value,
@@ -32,4 +32,4 @@ static_assert(tt::is_callable_v<B, int, double>,
               "Failed testing type trait is_callable");
 static_assert(not tt::is_callable<B>::value,
               "Failed testing type trait is_callable");
-/// [is_callable_example]
+// [is_callable_example]

--- a/tests/Unit/Utilities/TypeTraits/Test_IsComplexOfFundamental.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_IsComplexOfFundamental.cpp
@@ -8,7 +8,7 @@
 
 class DataVector;
 
-/// [is_complex_of_fundamental]
+// [is_complex_of_fundamental]
 static_assert(tt::is_complex_of_fundamental_v<std::complex<double>>,
               "Failed testing is_complex_of_fundamental");
 static_assert(tt::is_complex_of_fundamental_v<std::complex<int>>,
@@ -19,7 +19,7 @@ static_assert(not tt::is_complex_of_fundamental_v<std::complex<DataVector>>,
               "Failed testing is_complex_of_fundamental");
 static_assert(not tt::is_complex_of_fundamental_v<DataVector>,
               "Failed testing is_complex_of_fundamental");
-/// [is_complex_of_fundamental]
+// [is_complex_of_fundamental]
 
 static_assert(tt::is_complex_or_fundamental_v<std::complex<double>>,
               "Failed testing is_complex_of_fundamental");

--- a/tests/Unit/Utilities/TypeTraits/Test_IsComplexOfFundamental.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_IsComplexOfFundamental.cpp
@@ -6,9 +6,7 @@
 #include "Utilities/TypeTraits.hpp"
 #include "Utilities/TypeTraits/IsComplexOfFundamental.hpp"
 
-/// \cond
 class DataVector;
-/// \endcond
 
 /// [is_complex_of_fundamental]
 static_assert(tt::is_complex_of_fundamental_v<std::complex<double>>,

--- a/tests/Unit/Utilities/TypeTraits/Test_IsInteger.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_IsInteger.cpp
@@ -3,7 +3,7 @@
 
 #include "Utilities/TypeTraits/IsInteger.hpp"
 
-/// [is_integer_example]
+// [is_integer_example]
 static_assert(tt::is_integer<short>::value,
               "Failed testing type trait is_integer");
 static_assert(tt::is_integer_v<unsigned short>,
@@ -22,4 +22,4 @@ static_assert(not tt::is_integer_v<bool>,
               "Failed testing type trait is_integer");
 static_assert(not tt::is_integer_v<char>,
               "Failed testing type trait is_integer");
-/// [is_integer_example]
+// [is_integer_example]

--- a/tests/Unit/Utilities/TypeTraits/Test_IsIterable.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_IsIterable.cpp
@@ -5,7 +5,7 @@
 
 #include "Utilities/TypeTraits/IsIterable.hpp"
 
-/// [is_iterable_example]
+// [is_iterable_example]
 static_assert(tt::is_iterable<std::vector<double>>::value,
               "Failed testing type trait is_iterable");
 static_assert(tt::is_iterable_t<std::vector<double>>::value,
@@ -14,5 +14,5 @@ static_assert(tt::is_iterable_v<std::vector<double>>,
               "Failed testing type trait is_iterable");
 static_assert(not tt::is_iterable<double>::value,
               "Failed testing type trait is_iterable");
-/// [is_iterable_example]
+// [is_iterable_example]
 

--- a/tests/Unit/Utilities/TypeTraits/Test_IsIterable.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_IsIterable.cpp
@@ -15,4 +15,3 @@ static_assert(tt::is_iterable_v<std::vector<double>>,
 static_assert(not tt::is_iterable<double>::value,
               "Failed testing type trait is_iterable");
 // [is_iterable_example]
-

--- a/tests/Unit/Utilities/TypeTraits/Test_IsMaplike.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_IsMaplike.cpp
@@ -12,7 +12,7 @@ class C {};
 class D {};
 }  // namespace
 
-/// [is_maplike_example]
+// [is_maplike_example]
 static_assert(tt::is_maplike<std::unordered_map<int, double>>::value,
               "Failed testing type trait is_maplike");
 static_assert(tt::is_maplike_t<std::unordered_map<int, double>>::value,
@@ -25,4 +25,4 @@ static_assert(not tt::is_maplike<std::vector<C>>::value,
               "Failed testing type trait is_maplike");
 static_assert(not tt::is_maplike<D>::value,
               "Failed testing type trait is_maplike");
-/// [is_maplike_example]
+// [is_maplike_example]

--- a/tests/Unit/Utilities/TypeTraits/Test_IsMaplike.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_IsMaplike.cpp
@@ -7,12 +7,10 @@
 
 #include "Utilities/TypeTraits/IsMaplike.hpp"
 
-/// \cond
 namespace {
 class C {};
 class D {};
 }  // namespace
-/// \endcond
 
 /// [is_maplike_example]
 static_assert(tt::is_maplike<std::unordered_map<int, double>>::value,

--- a/tests/Unit/Utilities/TypeTraits/Test_IsStdArray.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_IsStdArray.cpp
@@ -9,7 +9,7 @@ namespace {
 class D;
 }  // namespace
 
-/// [is_std_array_example]
+// [is_std_array_example]
 static_assert(tt::is_std_array<std::array<double, 3>>::value,
               "Failed testing type trait is_std_array");
 static_assert(tt::is_std_array_t<std::array<double, 3>>::value,
@@ -20,4 +20,4 @@ static_assert(not tt::is_std_array<double>::value,
               "Failed testing type trait is_std_array");
 static_assert(tt::is_std_array<std::array<D, 10>>::value,
               "Failed testing type trait is_std_array");
-/// [is_std_array_example]
+// [is_std_array_example]

--- a/tests/Unit/Utilities/TypeTraits/Test_IsStdArray.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_IsStdArray.cpp
@@ -5,11 +5,9 @@
 
 #include "Utilities/TypeTraits/IsStdArrayOfSize.hpp"
 
-/// \cond
 namespace {
 class D;
 }  // namespace
-/// \endcond
 
 /// [is_std_array_example]
 static_assert(tt::is_std_array<std::array<double, 3>>::value,

--- a/tests/Unit/Utilities/TypeTraits/Test_IsStdArrayOfSize.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_IsStdArrayOfSize.cpp
@@ -5,11 +5,9 @@
 
 #include "Utilities/TypeTraits/IsStdArrayOfSize.hpp"
 
-/// \cond
 namespace {
 class D;
 }  // namespace
-/// \endcond
 
 /// [is_std_array_of_size_example]
 static_assert(tt::is_std_array_of_size<3, std::array<double, 3>>::value,

--- a/tests/Unit/Utilities/TypeTraits/Test_IsStdArrayOfSize.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_IsStdArrayOfSize.cpp
@@ -9,7 +9,7 @@ namespace {
 class D;
 }  // namespace
 
-/// [is_std_array_of_size_example]
+// [is_std_array_of_size_example]
 static_assert(tt::is_std_array_of_size<3, std::array<double, 3>>::value,
               "Failed testing type trait is_std_array_of_size");
 static_assert(tt::is_std_array_of_size_t<3, std::array<double, 3>>::value,
@@ -22,4 +22,4 @@ static_assert(not tt::is_std_array_of_size<2, std::array<double, 3>>::value,
               "Failed testing type trait is_std_array_of_size");
 static_assert(tt::is_std_array_of_size<10, std::array<D, 10>>::value,
               "Failed testing type trait is_std_array_of_size");
-/// [is_std_array_of_size_example]
+// [is_std_array_of_size_example]

--- a/tests/Unit/Utilities/TypeTraits/Test_IsStreamable.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_IsStreamable.cpp
@@ -6,7 +6,6 @@
 
 #include "Utilities/TypeTraits/IsStreamable.hpp"
 
-/// \cond
 namespace {
 class A {};
 
@@ -18,7 +17,6 @@ class D {};
 
 std::ostream& operator<<(std::ostream& os, const D&) noexcept;
 }  // namespace TestHelpers
-/// \endcond
 
 /// [is_streamable_example]
 static_assert(not tt::is_streamable<std::ostream, C>::value,

--- a/tests/Unit/Utilities/TypeTraits/Test_IsStreamable.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_IsStreamable.cpp
@@ -18,7 +18,7 @@ class D {};
 std::ostream& operator<<(std::ostream& os, const D&) noexcept;
 }  // namespace TestHelpers
 
-/// [is_streamable_example]
+// [is_streamable_example]
 static_assert(not tt::is_streamable<std::ostream, C>::value,
               "Failed testing type trait is_streamable");
 static_assert(not tt::is_streamable_t<std::ostream, C>::value,
@@ -31,4 +31,4 @@ static_assert(tt::is_streamable<std::ostream, TestHelpers::D>::value,
               "Failed testing type trait is_streamable");
 static_assert(tt::is_streamable_v<std::ostream, std::vector<TestHelpers::D>>,
               "Failed testing type trait is_streamable");
-/// [is_streamable_example]
+// [is_streamable_example]

--- a/tests/Unit/Utilities/TypeTraits/Test_RemoveReferenceWrapper.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_RemoveReferenceWrapper.cpp
@@ -142,4 +142,3 @@ static_assert(
         int>,
     "Failed testing remove_cvref_wrap");
 // [remove_cvref_wrap]
-

--- a/tests/Unit/Utilities/TypeTraits/Test_RemoveReferenceWrapper.cpp
+++ b/tests/Unit/Utilities/TypeTraits/Test_RemoveReferenceWrapper.cpp
@@ -10,7 +10,7 @@ namespace {
 class A;
 }  // namespace
 
-/// [remove_reference_wrapper_example]
+// [remove_reference_wrapper_example]
 static_assert(
     std::is_same_v<const double, tt::remove_reference_wrapper_t<
                                      std::reference_wrapper<const double>>>,
@@ -82,9 +82,9 @@ static_assert(std::is_same_v<
                   const A, tt::remove_reference_wrapper_t<
                                const volatile std::reference_wrapper<const A>>>,
               "Failed testing remove_reference_wrapper");
-/// [remove_reference_wrapper_example]
+// [remove_reference_wrapper_example]
 
-/// [remove_cvref_wrap]
+// [remove_cvref_wrap]
 static_assert(std::is_same_v<tt::remove_cvref_wrap_t<int>, int>,
               "Failed testing remove_cvref_wrap");
 static_assert(std::is_same_v<tt::remove_cvref_wrap_t<int&>, int>,
@@ -141,5 +141,5 @@ static_assert(
         tt::remove_cvref_wrap_t<const volatile std::reference_wrapper<int>>,
         int>,
     "Failed testing remove_cvref_wrap");
-/// [remove_cvref_wrap]
+// [remove_cvref_wrap]
 

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -581,6 +581,27 @@ prevent_cpp_includes_test() {
 }
 standard_checks+=(prevent_cpp_includes)
 
+# Check for Doxygen-comments in cpp files. We don't parse cpp files with
+# Doxygen, so they shouldn't contain Doxygen-formatting.
+prevent_cpp_doxygen() {
+    [[ $1 =~ \.cpp$ ]] && staged_grep -q '/// \|/\*\!' "$1"
+}
+prevent_cpp_doxygen_report() {
+    echo "Found Doxygen-formatting in cpp file:"
+    pretty_grep '/// \|/\*\!' "$@"
+    echo "Doxygen-formatting only has an effect in header files."
+    echo "Use standard C++ comments in cpp files."
+}
+prevent_cpp_doxygen_test() {
+    test_check fail foo.cpp '/// Dox.'$'\n'
+    test_check fail foo.cpp '/*! Dox.'$'\n'
+    test_check fail foo.cpp '/*!'$'\n'' * Dox.'$'\n'
+    test_check pass foo.cpp '// Dox.'$'\n'
+    test_check pass foo.cpp '/* Dox.'$'\n'
+    test_check pass foo.cpp '/*'$'\n'' * Dox.'$'\n'
+}
+standard_checks+=(prevent_cpp_doxygen)
+
 # Prevent editing RunSingleTest files. We may need to occasionally update these
 # files, but it's at least less than once a year.
 #


### PR DESCRIPTION
## Proposed changes

- All our documentation is in header files, so this PR just removes cpp files from the Doxygen input altogether. Parsing cpp files with Doxygen has been a nuisance because Doxygen has trouble with some template expressions. The change means we don't have to `/// \cond` problematic code in cpp files anymore (though we still have to do it in header files).
- Also adds a file check that cpp files contain no Doxygen formatting. We have been checking this in code review so far.
- Deletes all Doxygen-formatting from cpp files (including the `/// \cond`s) so the file check passes. We could leave the `/// \cond`s in the code (it's a separate commit so I can easily drop it), but then we can't add the file check.

Closes #3050.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
- You don't have to Doxygen-ignore problematic code in cpp files anymore using `/// \cond`-comments (though you may still have to do so in header files).
- For Doxygen `\snippet`s write `// [snippet_name]`, not `/// [snippet_name]`.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
