### PR TITLE
Tweak relative tolerance in ErrorControl test

### DIFF
--- a/tests/Unit/Time/StepChoosers/Test_ErrorControl.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_ErrorControl.cpp
@@ -177,17 +177,17 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ErrorControl", "[Unit][Time]") {
     {
       INFO("Test error control step fixed by relative tolerance");
       const StepChoosers::ErrorControl<EvolvedVariablesTag> error_control{
-          0.0, 5.0e-4, 2.0, 0.5, 0.95};
+          0.0, 3.0e-4, 2.0, 0.5, 0.95};
       std::optional<double> previous_step_error;
       const auto first_result =
           get_suggestion(make_not_null(&previous_step_error), error_control,
                          step_values, step_errors, 1.0, stepper_order);
-      // manually calculated in the special case in question: only absolute
+      // manually calculated in the special case in question: only relative
       // errors constrained
       const double expected_linf_error =
           max(flattened_step_errors /
               (flattened_step_values + flattened_step_errors)) /
-          5.0e-4;
+          3.0e-4;
       CHECK(approx(first_result.first) ==
             0.95 / pow(expected_linf_error, 1.0 / stepper_order));
       CHECK(first_result.second);
@@ -198,7 +198,7 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ErrorControl", "[Unit][Time]") {
       const double new_expected_linf_error =
           max(1.2 * flattened_step_errors /
               (flattened_step_values + 1.2 * flattened_step_errors)) /
-          5.0e-4;
+          3.0e-4;
       CHECK(approx(second_result.first) ==
             0.95 * first_result.first /
                 (pow(pow(new_expected_linf_error, 1.0 / stepper_order), 0.7) *


### PR DESCRIPTION
This avoids hitting the maximum factor and causing the special case formulas to be incorrect

previously, this failed within a few hundred attempts, now runs for 10^4 without failure.

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
