### PR TITLE
Use charm inline method instead of eliding charm

### DIFF
--- a/cmake/SetupCharmModuleFunctions.cmake
+++ b/cmake/SetupCharmModuleFunctions.cmake
@@ -16,6 +16,7 @@ function(add_charm_module MODULE)
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${MODULE}.ci
     COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/${MODULE}.ci ${MODULE}.ci
     COMMAND ${CHARM_COMPILER} -no-charmrun ${MODULE}.ci
+    COMMAND ${CMAKE_SOURCE_DIR}/tools/patch_charm_modules.sh ${MODULE} ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR} `pwd`
     )
   add_custom_target(
     module_${MODULE}

--- a/src/Parallel/Algorithms/AlgorithmArray.ci
+++ b/src/Parallel/Algorithms/AlgorithmArray.ci
@@ -4,6 +4,7 @@
 module AlgorithmArray {
   include "Utilities/TaggedTuple.hpp";
   include "Parallel/GlobalCache.decl.h";
+  include "Parallel/MaxInlineMethodsReached.hpp";
 
   // note: the array index here is a hack to use our own types in the chare
   // array index. The way the ci file is parsed as of charm++ 6.10.2 is such
@@ -24,24 +25,36 @@ module AlgorithmArray {
             typename ParallelComponent::initialization_tags>
             initialization_items);
 
+    // Ordinarily, indiscriminate use of [inline] has the danger of arbitrarily
+    // deep recursive function calls, which then exceed the stack limits of the
+    // machine that it is running on and errors. We modify the charm definition
+    // of this function (via a patch in tools/CharmModulePatches) to switch to
+    // message-passing when the recursive depth is high, using
+    // Parallel::detail::max_inline_methods_reached() in
+    // MaxInlineMethodsReached.hpp. This allows us to inline up to a set limit
+    // (improving performance) and support load-balancing and debug
+    // instrumentation performed during charm entry method calls, while being
+    // certain to avoid stack overflows.
+
     template <typename Action, typename... Args>
-    entry void simple_action(std::tuple<Args...> & args);
+    entry [inline] void simple_action(std::tuple<Args...> & args);
 
     template <typename Action>
-    entry void simple_action();
+    entry [inline] void simple_action();
 
     template <typename Action, typename Arg>
     entry[reductiontarget] void reduction_action(Arg arg);
 
-    entry void perform_algorithm();
+    entry [inline] void perform_algorithm();
 
-    entry void perform_algorithm(bool);
+    entry [inline] void perform_algorithm(bool);
 
     entry void start_phase(typename ParallelComponent::metavariables::Phase);
 
     template <typename ReceiveTag, typename ReceiveData_t>
-    entry void receive_data(typename ReceiveTag::temporal_id&, ReceiveData_t&,
-                            bool enable_if_disabled = false);
+    entry [inline] void receive_data(typename ReceiveTag::temporal_id&,
+                                    ReceiveData_t&,
+                                    bool enable_if_disabled = false);
 
     entry void set_terminate(bool);
   }

--- a/src/Parallel/CMakeLists.txt
+++ b/src/Parallel/CMakeLists.txt
@@ -32,6 +32,7 @@ spectre_target_headers(
   InitializationFunctions.hpp
   Invoke.hpp
   Main.hpp
+  MaxInlineMethodsReached.hpp
   NodeLock.hpp
   ParallelComponentHelpers.hpp
   PhaseDependentActionList.hpp

--- a/src/Parallel/MaxInlineMethodsReached.hpp
+++ b/src/Parallel/MaxInlineMethodsReached.hpp
@@ -1,0 +1,24 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <utility>
+
+namespace Parallel::detail {
+
+// Allow 64 inline entry method calls before we fall back to Charm++. This is
+// done to avoid blowing the stack.
+inline bool max_inline_entry_methods_reached() noexcept {
+  thread_local size_t approx_stack_depth = 0;
+#ifndef SPECTRE_PROFILING
+  approx_stack_depth++;
+  if (approx_stack_depth < 64) {
+    return false;
+  }
+  approx_stack_depth = 0;
+#endif
+  return true;
+}
+}  // namespace Parallel::detail

--- a/tests/Unit/Parallel/Test_AlgorithmCore.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmCore.cpp
@@ -518,7 +518,7 @@ struct finalize {
     SPECTRE_PARALLEL_REQUIRE(db::get<TemporalId>(box) ==
                              TestAlgorithmArrayInstance{4});
     SPECTRE_PARALLEL_REQUIRE(db::get<CountActionsCalled>(box) == 13);
-    SPECTRE_PARALLEL_REQUIRE(db::get<Int1>(box) == 5);
+    SPECTRE_PARALLEL_REQUIRE(db::get<Int1>(box) == 10);
   }
 };
 }  // namespace receive_data_test

--- a/tools/CharmModulePatches/src/Parallel/Algorithms/AlgorithmArray.def.h.patch
+++ b/tools/CharmModulePatches/src/Parallel/Algorithms/AlgorithmArray.def.h.patch
@@ -1,0 +1,49 @@
+Distributed under the MIT License.
+See LICENSE.txt for details.
+--- AlgorithmArray.def.h	2021-04-01 14:42:23.928094971 -0700
++++ alterations/AlgorithmArray.def.h	2021-04-01 14:44:19.599096051 -0700
+@@ -310,7 +310,7 @@
+ {
+   ckCheck();
+   AlgorithmArray <ParallelComponent, SpectreArrayIndex>  *obj = ckLocal();
+-  if (obj) {
++  if (obj != nullptr and not Parallel::detail::max_inline_entry_methods_reached()) {
+     _TRACE_BEGIN_EXECUTE_DETAILED(0,ForArrayEltMsg,(CkIndex_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::template idx_simple_action_marshall2<Action, Args...>()),CkMyPe(), 0, ((CkArrayIndex&)ckGetIndex()).getProjectionID(), obj);
+ #if CMK_LBDB_ON
+     LDObjHandle objHandle;
+@@ -360,7 +360,7 @@
+ {
+   ckCheck();
+   AlgorithmArray <ParallelComponent, SpectreArrayIndex>  *obj = ckLocal();
+-  if (obj) {
++  if (obj != nullptr and not Parallel::detail::max_inline_entry_methods_reached()) {
+     _TRACE_BEGIN_EXECUTE_DETAILED(0,ForArrayEltMsg,(CkIndex_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::template idx_simple_action_void<Action>()),CkMyPe(), 0, ((CkArrayIndex&)ckGetIndex()).getProjectionID(), obj);
+ #if CMK_LBDB_ON
+     LDObjHandle objHandle;
+@@ -442,7 +442,7 @@
+ {
+   ckCheck();
+   AlgorithmArray <ParallelComponent, SpectreArrayIndex>  *obj = ckLocal();
+-  if (obj) {
++  if (obj != nullptr and not Parallel::detail::max_inline_entry_methods_reached()) {
+     _TRACE_BEGIN_EXECUTE_DETAILED(0,ForArrayEltMsg,(CkIndex_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::idx_perform_algorithm_void()),CkMyPe(), 0, ((CkArrayIndex&)ckGetIndex()).getProjectionID(), obj);
+ #if CMK_LBDB_ON
+     LDObjHandle objHandle;
+@@ -479,7 +479,7 @@
+ {
+   ckCheck();
+   AlgorithmArray <ParallelComponent, SpectreArrayIndex>  *obj = ckLocal();
+-  if (obj) {
++  if (obj != nullptr and not Parallel::detail::max_inline_entry_methods_reached()) {
+     _TRACE_BEGIN_EXECUTE_DETAILED(0,ForArrayEltMsg,(CkIndex_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::idx_perform_algorithm_marshall6()),CkMyPe(), 0, ((CkArrayIndex&)ckGetIndex()).getProjectionID(), obj);
+ #if CMK_LBDB_ON
+     LDObjHandle objHandle;
+@@ -557,7 +557,7 @@
+ {
+   ckCheck();
+   AlgorithmArray <ParallelComponent, SpectreArrayIndex>  *obj = ckLocal();
+-  if (obj) {
++  if (obj != nullptr and not Parallel::detail::max_inline_entry_methods_reached()) {
+     _TRACE_BEGIN_EXECUTE_DETAILED(0,ForArrayEltMsg,(CkIndex_AlgorithmArray <ParallelComponent, SpectreArrayIndex> ::template idx_receive_data_marshall8<ReceiveTag, ReceiveData_t>()),CkMyPe(), 0, ((CkArrayIndex&)ckGetIndex()).getProjectionID(), obj);
+ #if CMK_LBDB_ON
+     LDObjHandle objHandle;

--- a/tools/CheckFiles.sh
+++ b/tools/CheckFiles.sh
@@ -214,6 +214,7 @@ if ! find . \
      ! -name '*.patch' \
      ! -name '*.pyc' \
      ! -path '*/__pycache__/*' \
+     ! -path './tools/charm_module_patchs/*' \
      ! -name '*~' \
      ! -name deploy_key.enc \
      -print0 \

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -194,6 +194,7 @@ long_lines() {
               '.html$' \
               '.json$' \
               '.min.js$' \
+              '.patch' \
               '.travis.yml$' \
               'CMakeLists.txt$' \
               'Doxyfile.in$' \
@@ -279,7 +280,7 @@ standard_checks+=(boost_none)
 
 # Check for files containing tabs
 tabs() {
-    whitelist "$1" '.h5' '.png' &&
+    whitelist "$1" '.h5' '.png' '.patch' &&
     staged_grep -q -F $'\t' "$1"
 }
 tabs_report() {

--- a/tools/patch_charm_modules.sh
+++ b/tools/patch_charm_modules.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env -S bash -e
+
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Applies any patches that are present in $3/tools/CharmModulePatches/ to
+# their corresponding .def.h and decl.h files in the charm module outputs.
+# This is used to override default charm behavior with custom versions or to
+# patch bugs
+
+if [ "$#" -ne 4 ]; then
+    echo "Usage: patch_charm_modules.sh module_name path_to_current_source_dir\
+ path_to_source_root_dir path_to_current_build_dir"
+    exit 1
+fi
+
+PATCH_PREFIX=$3/tools/CharmModulePatches${2#"$3"}
+DEF_PATCH_FILENAME="$PATCH_PREFIX"/$1.def.h.patch
+DECL_PATCH_FILENAME="$PATCH_PREFIX"/$1.decl.h.patch
+
+if [ -f "$DEF_PATCH_FILENAME" ]; then
+    patch -u $4/$1.def.h -i $DEF_PATCH_FILENAME
+fi
+
+if [ -f "$DECL_PATCH_FILENAME" ]; then
+    patch -u $4/$1.decl.h -i $DECL_PATCH_FILENAME
+fi


### PR DESCRIPTION
This allows the charm load measurements to track the inlined methods, which
enables useful measurements by projections, and should improve load balancing
performance.

I've elected to perform the post-processing of the charm-generated files by putting patch files in the repository and applying them with a script in cmake rather than (for instance), creating a regex replacement script. This is a bit more verbose in terms of the repo changes, but I think it's considerably safer. When the charm files change due to ci modifications or charm version changes, this should force us to regenerate the patch files, which is better because I'm not certain about how these files will evolve in the future.

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
