### PR TITLE
Add Kerr solution to XCTS equations

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp
@@ -296,7 +296,6 @@ class KerrSchild : public MarkAsAnalyticSolution {
     return dimensionless_spin_;
   }
 
- private:
   struct internal_tags {
     template <typename DataType>
     using x_minus_center = ::Tags::TempI<0, 3, Frame::Inertial, DataType>;
@@ -545,6 +544,7 @@ class KerrSchild : public MarkAsAnalyticSolution {
     static constexpr double null_vector_0_ = -1.0;
   };
 
+ private:
   double mass_{std::numeric_limits<double>::signaling_NaN()};
   std::array<double, volume_dim> dimensionless_spin_ =
       make_array<volume_dim>(std::numeric_limits<double>::signaling_NaN());

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp
@@ -15,6 +15,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
 #include "Utilities/ForceInline.hpp"
+#include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -544,9 +545,11 @@ class KerrSchild : public MarkAsAnalyticSolution {
     static constexpr double null_vector_0_ = -1.0;
   };
 
-  double mass_{1.0};
-  std::array<double, volume_dim> dimensionless_spin_{{0.0, 0.0, 0.0}};
-  std::array<double, volume_dim> center_{{0.0, 0.0, 0.0}};
+  double mass_{std::numeric_limits<double>::signaling_NaN()};
+  std::array<double, volume_dim> dimensionless_spin_ =
+      make_array<volume_dim>(std::numeric_limits<double>::signaling_NaN());
+  std::array<double, volume_dim> center_ =
+      make_array<volume_dim>(std::numeric_limits<double>::signaling_NaN());
 };
 
 SPECTRE_ALWAYS_INLINE bool operator==(const KerrSchild& lhs,

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   ConstantDensityStar.cpp
+  Kerr.cpp
   Schwarzschild.cpp
   )
 
@@ -21,6 +22,7 @@ spectre_target_headers(
   CommonVariables.tpp
   ConstantDensityStar.hpp
   Flatness.hpp
+  Kerr.hpp
   Schwarzschild.hpp
   )
 
@@ -28,8 +30,10 @@ target_link_libraries(
   ${LIBRARY}
   PUBLIC
   DataStructures
+  ElasticityPointwiseFunctions
   ErrorHandling
   GeneralRelativity
+  GeneralRelativitySolutions
   Options
   Parallel
   Utilities

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Kerr.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Kerr.cpp
@@ -1,0 +1,261 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticSolutions/Xcts/Kerr.hpp"
+
+#include <algorithm>
+#include <cstddef>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Elliptic/Systems/Xcts/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Xcts/CommonVariables.tpp"
+#include "PointwiseFunctions/Elasticity/Strain.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/Xcts/LongitudinalOperator.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Xcts::Solutions::detail {
+
+template <typename DataType>
+void KerrVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::ii<DataType, Dim>*> conformal_metric,
+    const gsl::not_null<Cache*> cache,
+    Tags::ConformalMetric<DataType, Dim, Frame::Inertial> /*meta*/)
+    const noexcept {
+  const auto& conformal_factor =
+      cache->get_var(Xcts::Tags::ConformalFactor<DataType>{});
+  *conformal_metric = kerr_schild.get_var(
+      gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>{});
+  for (size_t i = 0; i < Dim; ++i) {
+    for (size_t j = 0; j <= i; ++j) {
+      conformal_metric->get(i, j) /= pow<4>(get(conformal_factor));
+    }
+  }
+}
+
+template <typename DataType>
+void KerrVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::II<DataType, Dim>*> inv_conformal_metric,
+    const gsl::not_null<Cache*> cache,
+    Tags::InverseConformalMetric<DataType, Dim, Frame::Inertial> /*meta*/)
+    const noexcept {
+  const auto& conformal_factor =
+      cache->get_var(Xcts::Tags::ConformalFactor<DataType>{});
+  *inv_conformal_metric = kerr_schild.get_var(
+      gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataType>{});
+  for (size_t i = 0; i < Dim; ++i) {
+    for (size_t j = 0; j <= i; ++j) {
+      inv_conformal_metric->get(i, j) *= pow<4>(get(conformal_factor));
+    }
+  }
+}
+
+template <typename DataType>
+void KerrVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::ijj<DataType, Dim>*> deriv_conformal_metric,
+    const gsl::not_null<Cache*> cache,
+    ::Tags::deriv<Tags::ConformalMetric<DataType, Dim, Frame::Inertial>,
+                  tmpl::size_t<Dim>, Frame::Inertial> /*meta*/) const noexcept {
+  const auto& conformal_factor =
+      cache->get_var(Xcts::Tags::ConformalFactor<DataType>{});
+  const auto& deriv_conformal_factor =
+      cache->get_var(::Tags::deriv<Xcts::Tags::ConformalFactor<DataType>,
+                                   tmpl::size_t<Dim>, Frame::Inertial>{});
+  const auto& conformal_metric = cache->get_var(
+      Xcts::Tags::ConformalMetric<DataType, Dim, Frame::Inertial>{});
+  *deriv_conformal_metric = kerr_schild.get_var(
+      ::Tags::deriv<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>,
+                    tmpl::size_t<Dim>, Frame::Inertial>{});
+  for (size_t i = 0; i < Dim; ++i) {
+    for (size_t j = 0; j < Dim; ++j) {
+      for (size_t k = 0; k <= j; ++k) {
+        deriv_conformal_metric->get(i, j, k) /= pow<4>(get(conformal_factor));
+        deriv_conformal_metric->get(i, j, k) -= 4. / get(conformal_factor) *
+                                                conformal_metric.get(j, k) *
+                                                deriv_conformal_factor.get(i);
+      }
+    }
+  }
+}
+
+template <typename DataType>
+void KerrVariables<DataType>::operator()(
+    const gsl::not_null<Scalar<DataType>*> trace_extrinsic_curvature,
+    const gsl::not_null<Cache*> /*cache*/,
+    gr::Tags::TraceExtrinsicCurvature<DataType> /*meta*/) const noexcept {
+  const auto& extrinsic_curvature = kerr_schild.get_var(
+      gr::Tags::ExtrinsicCurvature<Dim, Frame::Inertial, DataType>{});
+  const auto& inv_spatial_metric = kerr_schild.get_var(
+      gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataType>{});
+  trace(trace_extrinsic_curvature, extrinsic_curvature, inv_spatial_metric);
+}
+
+template <typename DataType>
+void KerrVariables<DataType>::operator()(
+    const gsl::not_null<Scalar<DataType>*> dt_trace_extrinsic_curvature,
+    const gsl::not_null<Cache*> /*cache*/,
+    ::Tags::dt<gr::Tags::TraceExtrinsicCurvature<DataType>> /*meta*/)
+    const noexcept {
+  get(*dt_trace_extrinsic_curvature) = 0.;
+}
+
+template <typename DataType>
+void KerrVariables<DataType>::operator()(
+    const gsl::not_null<Scalar<DataType>*> conformal_factor,
+    const gsl::not_null<Cache*> /*cache*/,
+    Tags::ConformalFactor<DataType> /*meta*/) const noexcept {
+  get(*conformal_factor) = 1.;
+}
+
+template <typename DataType>
+void KerrVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::i<DataType, Dim>*> conformal_factor_gradient,
+    const gsl::not_null<Cache*> /*cache*/,
+    ::Tags::deriv<Tags::ConformalFactor<DataType>, tmpl::size_t<Dim>,
+                  Frame::Inertial> /*meta*/) const noexcept {
+  std::fill(conformal_factor_gradient->begin(),
+            conformal_factor_gradient->end(), 0.);
+}
+
+template <typename DataType>
+void KerrVariables<DataType>::operator()(
+    const gsl::not_null<Scalar<DataType>*> lapse,
+    const gsl::not_null<Cache*> /*cache*/,
+    gr::Tags::Lapse<DataType> /*meta*/) const noexcept {
+  *lapse = kerr_schild.get_var(gr::Tags::Lapse<DataType>{});
+}
+
+template <typename DataType>
+void KerrVariables<DataType>::operator()(
+    const gsl::not_null<Scalar<DataType>*> lapse_times_conformal_factor,
+    const gsl::not_null<Cache*> cache,
+    Tags::LapseTimesConformalFactor<DataType> /*meta*/) const noexcept {
+  *lapse_times_conformal_factor = cache->get_var(gr::Tags::Lapse<DataType>{});
+  const auto& conformal_factor =
+      cache->get_var(Xcts::Tags::ConformalFactor<DataType>{});
+  get(*lapse_times_conformal_factor) *= get(conformal_factor);
+}
+
+template <typename DataType>
+void KerrVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::i<DataType, Dim>*>
+        lapse_times_conformal_factor_gradient,
+    const gsl::not_null<Cache*> cache,
+    ::Tags::deriv<Tags::LapseTimesConformalFactor<DataType>, tmpl::size_t<Dim>,
+                  Frame::Inertial> /*meta*/) const noexcept {
+  const auto& conformal_factor =
+      cache->get_var(Xcts::Tags::ConformalFactor<DataType>{});
+  const auto& deriv_conformal_factor =
+      cache->get_var(::Tags::deriv<Xcts::Tags::ConformalFactor<DataType>,
+                                   tmpl::size_t<Dim>, Frame::Inertial>{});
+  *lapse_times_conformal_factor_gradient =
+      kerr_schild.get_var(::Tags::deriv<gr::Tags::Lapse<DataType>,
+                                        tmpl::size_t<Dim>, Frame::Inertial>{});
+  const auto& lapse = kerr_schild.get_var(gr::Tags::Lapse<DataType>{});
+  for (size_t i = 0; i < Dim; ++i) {
+    lapse_times_conformal_factor_gradient->get(i) *= get(conformal_factor);
+    lapse_times_conformal_factor_gradient->get(i) +=
+        get(lapse) * deriv_conformal_factor.get(i);
+  }
+}
+
+template <typename DataType>
+void KerrVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::I<DataType, Dim>*> shift_background,
+    const gsl::not_null<Cache*> /*cache*/,
+    Tags::ShiftBackground<DataType, Dim, Frame::Inertial> /*meta*/)
+    const noexcept {
+  std::fill(shift_background->begin(), shift_background->end(), 0.);
+}
+
+template <typename DataType>
+void KerrVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::II<DataType, Dim, Frame::Inertial>*>
+        longitudinal_shift_background_minus_dt_conformal_metric,
+    const gsl::not_null<Cache*> /*cache*/,
+    Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<
+        DataType, Dim, Frame::Inertial> /*meta*/) const noexcept {
+  std::fill(longitudinal_shift_background_minus_dt_conformal_metric->begin(),
+            longitudinal_shift_background_minus_dt_conformal_metric->end(), 0.);
+}
+
+template <typename DataType>
+void KerrVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::I<DataType, Dim>*> shift_excess,
+    const gsl::not_null<Cache*> /*cache*/,
+    Tags::ShiftExcess<DataType, Dim, Frame::Inertial> /*meta*/) const noexcept {
+  *shift_excess =
+      kerr_schild.get_var(gr::Tags::Shift<Dim, Frame::Inertial, DataType>{});
+}
+
+template <typename DataType>
+void KerrVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::ii<DataType, Dim>*> shift_strain,
+    const gsl::not_null<Cache*> cache,
+    Tags::ShiftStrain<DataType, Dim, Frame::Inertial> /*meta*/) const noexcept {
+  const auto& shift =
+      kerr_schild.get_var(gr::Tags::Shift<Dim, Frame::Inertial, DataType>{});
+  const auto& deriv_shift = kerr_schild.get_var(
+      ::Tags::deriv<gr::Tags::Shift<Dim, Frame::Inertial, DataType>,
+                    tmpl::size_t<Dim>, Frame::Inertial>{});
+  const auto& conformal_metric = cache->get_var(
+      Xcts::Tags::ConformalMetric<DataType, Dim, Frame::Inertial>{});
+  const auto& deriv_conformal_metric = cache->get_var(
+      ::Tags::deriv<Xcts::Tags::ConformalMetric<DataType, Dim, Frame::Inertial>,
+                    tmpl::size_t<Dim>, Frame::Inertial>{});
+  const auto& conformal_christoffel_first_kind = cache->get_var(
+      Tags::ConformalChristoffelFirstKind<DataType, Dim, Frame::Inertial>{});
+  Elasticity::strain(shift_strain, deriv_shift, conformal_metric,
+                     deriv_conformal_metric, conformal_christoffel_first_kind,
+                     shift);
+}
+
+template <typename DataType>
+void KerrVariables<DataType>::operator()(
+    const gsl::not_null<Scalar<DataType>*> energy_density,
+    const gsl::not_null<Cache*> /*cache*/,
+    Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 0> /*meta*/)
+    const noexcept {
+  std::fill(energy_density->begin(), energy_density->end(), 0.);
+}
+
+template <typename DataType>
+void KerrVariables<DataType>::operator()(
+    const gsl::not_null<Scalar<DataType>*> stress_trace,
+    const gsl::not_null<Cache*> /*cache*/,
+    Tags::Conformal<gr::Tags::StressTrace<DataType>, 0> /*meta*/)
+    const noexcept {
+  std::fill(stress_trace->begin(), stress_trace->end(), 0.);
+}
+
+template <typename DataType>
+void KerrVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::I<DataType, Dim>*> momentum_density,
+    const gsl::not_null<Cache*> /*cache*/,
+    Tags::Conformal<gr::Tags::MomentumDensity<Dim, Frame::Inertial, DataType>,
+                    0> /*meta*/) const noexcept {
+  std::fill(momentum_density->begin(), momentum_density->end(), 0.);
+}
+
+template class KerrVariables<double>;
+template class KerrVariables<DataVector>;
+
+}  // namespace Xcts::Solutions::detail
+
+// Instantiate implementations for common variables
+template class Xcts::Solutions::CommonVariables<
+    double, typename Xcts::Solutions::detail::KerrVariables<double>::Cache>;
+template class Xcts::Solutions::CommonVariables<
+    DataVector,
+    typename Xcts::Solutions::detail::KerrVariables<DataVector>::Cache>;
+template class Xcts::AnalyticData::CommonVariables<
+    double, typename Xcts::Solutions::detail::KerrVariables<double>::Cache>;
+template class Xcts::AnalyticData::CommonVariables<
+    DataVector,
+    typename Xcts::Solutions::detail::KerrVariables<DataVector>::Cache>;

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Kerr.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Kerr.hpp
@@ -1,0 +1,234 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <pup.h>
+
+#include "DataStructures/CachedTempBuffer.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Elliptic/Systems/Xcts/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Xcts/AnalyticSolution.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Xcts/CommonVariables.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace Xcts::Solutions {
+namespace detail {
+
+template <typename DataType>
+struct KerrVariables;
+
+template <typename DataType>
+using KerrVariablesCache = cached_temp_buffer_from_typelist<
+    KerrVariables<DataType>,
+    tmpl::push_back<
+        common_tags<DataType>,
+        Tags::ConformalMetric<DataType, 3, Frame::Inertial>,
+        Tags::InverseConformalMetric<DataType, 3, Frame::Inertial>,
+        ::Tags::deriv<Tags::ConformalMetric<DataType, 3, Frame::Inertial>,
+                      tmpl::size_t<3>, Frame::Inertial>,
+        gr::Tags::TraceExtrinsicCurvature<DataType>,
+        ::Tags::dt<gr::Tags::TraceExtrinsicCurvature<DataType>>,
+        Tags::ConformalFactor<DataType>,
+        ::Tags::deriv<Tags::ConformalFactor<DataType>, tmpl::size_t<3>,
+                      Frame::Inertial>,
+        gr::Tags::Lapse<DataType>, Tags::LapseTimesConformalFactor<DataType>,
+        ::Tags::deriv<Tags::LapseTimesConformalFactor<DataType>,
+                      tmpl::size_t<3>, Frame::Inertial>,
+        Tags::ShiftBackground<DataType, 3, Frame::Inertial>,
+        Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<
+            DataType, 3, Frame::Inertial>,
+        Tags::ShiftExcess<DataType, 3, Frame::Inertial>,
+        Tags::ShiftStrain<DataType, 3, Frame::Inertial>,
+        Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 0>,
+        Tags::Conformal<gr::Tags::StressTrace<DataType>, 0>,
+        Tags::Conformal<gr::Tags::MomentumDensity<3, Frame::Inertial, DataType>,
+                        0>>>;
+
+template <typename DataType>
+struct KerrVariables : CommonVariables<DataType, KerrVariablesCache<DataType>> {
+  static constexpr size_t Dim = 3;
+  using Cache = KerrVariablesCache<DataType>;
+  using CommonVariables<DataType, KerrVariablesCache<DataType>>::operator();
+
+  const tnsr::I<DataType, Dim>& x;
+  mutable gr::Solutions::KerrSchild::IntermediateVars<DataType> kerr_schild;
+
+  void operator()(
+      gsl::not_null<tnsr::ii<DataType, Dim>*> conformal_metric,
+      gsl::not_null<Cache*> cache,
+      Tags::ConformalMetric<DataType, Dim, Frame::Inertial> /*meta*/)
+      const noexcept;
+  void operator()(
+      gsl::not_null<tnsr::II<DataType, Dim>*> inv_conformal_metric,
+      gsl::not_null<Cache*> cache,
+      Tags::InverseConformalMetric<DataType, Dim, Frame::Inertial> /*meta*/)
+      const noexcept;
+  void operator()(
+      gsl::not_null<tnsr::ijj<DataType, Dim>*> deriv_conformal_metric,
+      gsl::not_null<Cache*> cache,
+      ::Tags::deriv<Tags::ConformalMetric<DataType, Dim, Frame::Inertial>,
+                    tmpl::size_t<Dim>, Frame::Inertial> /*meta*/)
+      const noexcept;
+  void operator()(
+      gsl::not_null<Scalar<DataType>*> trace_extrinsic_curvature,
+      gsl::not_null<Cache*> cache,
+      gr::Tags::TraceExtrinsicCurvature<DataType> /*meta*/) const noexcept;
+  void operator()(
+      gsl::not_null<Scalar<DataType>*> dt_trace_extrinsic_curvature,
+      gsl::not_null<Cache*> cache,
+      ::Tags::dt<gr::Tags::TraceExtrinsicCurvature<DataType>> /*meta*/)
+      const noexcept;
+  void operator()(gsl::not_null<Scalar<DataType>*> conformal_factor,
+                  gsl::not_null<Cache*> cache,
+                  Tags::ConformalFactor<DataType> /*meta*/) const noexcept;
+  void operator()(
+      gsl::not_null<tnsr::i<DataType, Dim>*> conformal_factor_gradient,
+      gsl::not_null<Cache*> cache,
+      ::Tags::deriv<Xcts::Tags::ConformalFactor<DataType>, tmpl::size_t<Dim>,
+                    Frame::Inertial> /*meta*/) const noexcept;
+  void operator()(gsl::not_null<Scalar<DataType>*> lapse,
+                  gsl::not_null<Cache*> cache,
+                  gr::Tags::Lapse<DataType> /*meta*/) const noexcept;
+  void operator()(
+      gsl::not_null<Scalar<DataType>*> lapse_times_conformal_factor,
+      gsl::not_null<Cache*> cache,
+      Tags::LapseTimesConformalFactor<DataType> /*meta*/) const noexcept;
+  void operator()(gsl::not_null<tnsr::i<DataType, Dim>*>
+                      lapse_times_conformal_factor_gradient,
+                  gsl::not_null<Cache*> cache,
+                  ::Tags::deriv<Tags::LapseTimesConformalFactor<DataType>,
+                                tmpl::size_t<Dim>, Frame::Inertial> /*meta*/)
+      const noexcept;
+  void operator()(
+      gsl::not_null<tnsr::I<DataType, Dim>*> shift_background,
+      gsl::not_null<Cache*> cache,
+      Tags::ShiftBackground<DataType, Dim, Frame::Inertial> /*meta*/)
+      const noexcept;
+  void operator()(gsl::not_null<tnsr::II<DataType, Dim, Frame::Inertial>*>
+                      longitudinal_shift_background_minus_dt_conformal_metric,
+                  gsl::not_null<Cache*> cache,
+                  Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<
+                      DataType, Dim, Frame::Inertial> /*meta*/) const noexcept;
+  void operator()(gsl::not_null<tnsr::I<DataType, Dim>*> shift_excess,
+                  gsl::not_null<Cache*> cache,
+                  Tags::ShiftExcess<DataType, Dim, Frame::Inertial> /*meta*/)
+      const noexcept;
+  void operator()(gsl::not_null<tnsr::ii<DataType, Dim>*> shift_strain,
+                  gsl::not_null<Cache*> cache,
+                  Tags::ShiftStrain<DataType, Dim, Frame::Inertial> /*meta*/)
+      const noexcept;
+  void operator()(gsl::not_null<Scalar<DataType>*> energy_density,
+                  gsl::not_null<Cache*> cache,
+                  Tags::Conformal<gr::Tags::EnergyDensity<DataType>,
+                                  0> /*meta*/) const noexcept;
+  void operator()(gsl::not_null<Scalar<DataType>*> stress_trace,
+                  gsl::not_null<Cache*> cache,
+                  Tags::Conformal<gr::Tags::StressTrace<DataType>, 0> /*meta*/)
+      const noexcept;
+  void operator()(
+      gsl::not_null<tnsr::I<DataType, Dim>*> momentum_density,
+      gsl::not_null<Cache*> cache,
+      Tags::Conformal<gr::Tags::MomentumDensity<Dim, Frame::Inertial, DataType>,
+                      0> /*meta*/) const noexcept;
+};
+
+}  // namespace detail
+
+// The following implements the registration and factory-creation mechanism
+
+/// \cond
+template <typename Registrars>
+struct Kerr;
+
+namespace Registrars {
+struct Kerr {
+  template <typename Registrars>
+  using f = Solutions::Kerr<Registrars>;
+};
+}  // namespace Registrars
+/// \endcond
+
+/*!
+ * \brief Kerr spacetime in general relativity
+ *
+ * This class implements the Kerr solution to the XCTS equations. It is
+ * currently implemented in Kerr-Schild coordinates only and derives most
+ * quantities from the `gr::Solution::KerrSchild` class. It poses a
+ * non-conformally-flat problem to the XCTS equations.
+ *
+ * The conformal factor in this solution is set to \f$\psi=1\f$, so the
+ * conformal background-metric is the spatial Kerr metric. It is possible to
+ * choose a different \f$\psi\f$ so the solution is non-trivial in this
+ * variable, though that is probably only useful for testing and currently not
+ * implemented. It should be noted, however, that the combination of
+ * \f$\psi=1\f$ and apparent-horizon boundary conditions poses a hard problem to
+ * the nonlinear solver when starting at a flat initial guess. This is because
+ * the strongly-nonlinear boundary-conditions couple the variables in such a way
+ * that the solution is initially corrected away from \f$\psi=1\f$ and is then
+ * unable to recover. A conformal-factor profile such as \f$\psi=1 +
+ * \frac{M}{2r}\f$ (resembling isotropic coordinates) resolves this issue. In
+ * production solves this is not an issue because we choose a much better
+ * initial guess than flatness, such as a superposition of Kerr solutions for
+ * black-hole binary initial data.
+ */
+template <typename Registrars = tmpl::list<Solutions::Registrars::Kerr>>
+class Kerr : public AnalyticSolution<Registrars>,
+             public gr::Solutions::KerrSchild {
+ public:
+  using KerrSchild::KerrSchild;
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Kerr);
+
+  template <typename DataType, typename... RequestedTags>
+  tuples::TaggedTuple<RequestedTags...> variables(
+      const tnsr::I<DataType, 3, Frame::Inertial>& x,
+      tmpl::list<RequestedTags...> /*meta*/) const noexcept {
+    using VarsComputer = detail::KerrVariables<DataType>;
+    typename VarsComputer::Cache cache{
+        get_size(*x.begin()),
+        VarsComputer{
+            {{std::nullopt, std::nullopt}},
+            x,
+            gr::Solutions::KerrSchild::IntermediateVars<DataType>{*this, x}}};
+    return {cache.get_var(RequestedTags{})...};
+  }
+
+  template <typename DataType, typename... RequestedTags>
+  tuples::TaggedTuple<RequestedTags...> variables(
+      const tnsr::I<DataType, 3, Frame::Inertial>& x, const Mesh<3>& mesh,
+      const InverseJacobian<DataVector, 3, Frame::Logical, Frame::Inertial>&
+          inv_jacobian,
+      tmpl::list<RequestedTags...> /*meta*/) const noexcept {
+    using VarsComputer = detail::KerrVariables<DataType>;
+    typename VarsComputer::Cache cache{
+        get_size(*x.begin()),
+        VarsComputer{
+            {{mesh, inv_jacobian}},
+            x,
+            gr::Solutions::KerrSchild::IntermediateVars<DataType>{*this, x}}};
+    return {cache.get_var(RequestedTags{})...};
+  }
+
+  void pup(PUP::er& p) noexcept override {
+    gr::Solutions::KerrSchild::pup(p);
+    AnalyticSolution<Registrars>::pup(p);
+  }
+};
+
+/// \cond
+template <typename Registrars>
+PUP::able::PUP_ID Kerr<Registrars>::my_PUP_ID = 0;  // NOLINT
+/// \endcond
+
+}  // namespace Xcts::Solutions

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_XctsSolutions")
 set(LIBRARY_SOURCES
   Test_ConstantDensityStar.cpp
   Test_Flatness.cpp
+  Test_Kerr.cpp
   Test_Schwarzschild.cpp
   )
 
@@ -19,7 +20,10 @@ add_test_library(
 target_link_libraries(
   ${LIBRARY}
   PRIVATE
+  CoordinateMaps
   DataStructures
+  Domain
+  Spectral
   Utilities
   Xcts
   XctsSolutions

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_Kerr.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_Kerr.cpp
@@ -1,0 +1,110 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+#include <tuple>
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Elliptic/Systems/Xcts/Tags.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Xcts/Kerr.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace Xcts::Solutions {
+namespace {
+
+void test_solution(const double mass, const std::array<double, 3> spin,
+                   const std::array<double, 3> center,
+                   const std::string& options_string) {
+  CAPTURE(mass);
+  CAPTURE(spin);
+  CAPTURE(center);
+  const auto created =
+      TestHelpers::test_factory_creation<Xcts::Solutions::AnalyticSolution<
+          tmpl::list<Xcts::Solutions::Registrars::Kerr>>>(options_string);
+  REQUIRE(dynamic_cast<const Kerr<>*>(created.get()) != nullptr);
+  const auto& solution = dynamic_cast<const Kerr<>&>(*created);
+  {
+    INFO("Properties");
+    CHECK(solution.mass() == mass);
+    CHECK(solution.dimensionless_spin() == spin);
+    CHECK(solution.center() == center);
+  }
+  {
+    INFO("Semantics");
+    test_serialization(solution);
+    test_copy_semantics(solution);
+    auto move_solution = solution;
+    test_move_semantics(std::move(move_solution), solution);
+  }
+  {
+    INFO("Verify the solution solves the XCTS system");
+    // Once the XCTS equations are implemented we will check here that the
+    // solution numerically solves the equations. That's both a rigorous test
+    // that the solution is correctly implemented, as well as a test of the XCTS
+    // system implementation. Until then we just call into the solution and
+    // probe a few variables.
+    const Mesh<3> mesh{12, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+    const size_t num_points = mesh.number_of_grid_points();
+    const double inner_radius = 2. * mass;
+    const double outer_radius = 5. * mass;
+    using AffineMap = domain::CoordinateMaps::Affine;
+    using AffineMap3D =
+        domain::CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
+    const domain::CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap3D>
+        coord_map{
+            {{-1., 1., inner_radius + center[0], outer_radius + center[0]},
+             {-1., 1., inner_radius + center[1], outer_radius + center[1]},
+             {-1., 1., inner_radius + center[2], outer_radius + center[2]}}};
+    const auto logical_coords = logical_coordinates(mesh);
+    const auto inertial_coords = coord_map(logical_coords);
+    const auto inv_jacobian = coord_map.inv_jacobian(logical_coords);
+    const auto vars = solution.variables(
+        inertial_coords, mesh, inv_jacobian,
+        tmpl::list<Tags::ConformalFactor<DataVector>,
+                   Tags::ShiftBackground<DataVector, 3, Frame::Inertial>>{});
+    CHECK_ITERABLE_APPROX(get(get<Tags::ConformalFactor<DataVector>>(vars)),
+                          DataVector(num_points, 1.));
+    for (size_t i = 0; i < 3; ++i) {
+      CHECK_ITERABLE_APPROX(
+          SINGLE_ARG(
+              get<Tags::ShiftBackground<DataVector, 3, Frame::Inertial>>(vars)
+                  .get(i)),
+          DataVector(num_points, 0.));
+    }
+  }
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Xcts.Kerr",
+                  "[PointwiseFunctions][Unit]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/AnalyticSolutions/Xcts"};
+  test_solution(0.43, {{0.1, 0.2, 0.3}}, {{1., 2., 3.}},
+                "Kerr:\n"
+                "  Mass: 0.43\n"
+                "  Spin: [0.1, 0.2, 0.3]\n"
+                "  Center: [1., 2., 3.]");
+}
+
+}  // namespace Xcts::Solutions


### PR DESCRIPTION
## Proposed changes

Use the existing Kerr solution to compute variables for the XCTS equations.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
