### PR TITLE
Loosen tolerance in RelativisticEuler cons2prim

### DIFF
--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_PrimitiveFromConservative.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_PrimitiveFromConservative.cpp
@@ -100,7 +100,7 @@ void test_primitive_from_conservative(
                                     sqrt_det_spatial_metric, equation_of_state);
 
   Approx larger_approx =
-      Approx::custom().epsilon(std::numeric_limits<double>::epsilon() * 1.e6);
+      Approx::custom().epsilon(std::numeric_limits<double>::epsilon() * 1.e7);
   CHECK_ITERABLE_CUSTOM_APPROX(expected_rest_mass_density, rest_mass_density,
                                larger_approx);
   CHECK_ITERABLE_CUSTOM_APPROX(expected_specific_internal_energy,


### PR DESCRIPTION
## Proposed changes

Depending on the parameters, the results are only accurate to ~1e-9 it seems.

Fixes #1765 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
