### PR TITLE
Adds time dependence to InterpolationTargetReceiveVars

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/InterpolationTarget.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTarget.hpp
@@ -265,18 +265,6 @@ namespace intrp {
 /// `temporal_id`.  For the sequential case, it needs to start
 /// interpolating for the next `temporal_id`.  The logic is, in pseudocode:
 ///
-/// ###### Current logic:
-///
-///```
-/// if (sequential) {
-///   if (TemporalIds is not empty) {
-///     call block_logical_coordinates and interpolate for next temporal_id
-///   }
-/// }
-///```
-///
-/// ###### New logic:
-///
 ///```
 /// if (sequential) {
 ///   if (TemporalIds is not empty) {


### PR DESCRIPTION
## Proposed changes

This is a step towards having the horizon finder work in multiple frames.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
