### PR TITLE
Find horizon for time-dependent maps.

### DIFF
--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -28,6 +28,7 @@ DomainCreator:
       UseLogarithmicMap: true
       WhichWedges: All
       RadialBlockLayers: 1
+      TimeDependence: None
 
 AnalyticSolution:
   KerrSchild:


### PR DESCRIPTION
## Proposed changes

Test_ApparentHorizonFinder now works when finding horizons in the Inertial frame, for time-dependent maps.
Future PRs will add the ability for horizon finding in the Grid frame.

To make the test easier, we also add TimeDependence to the Shell DomainCreator.

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->

The Shell DomainCreator now takes a TimeDependence, and requires TimeDependence in the input file. Set it to `None` to add no time dependence.

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
