### PR TITLE
Improve EveryLB instructions

### DIFF
--- a/cmake/FindCharm.cmake
+++ b/cmake/FindCharm.cmake
@@ -53,6 +53,17 @@ find_library(CHARM_LIBCK
     PATH_SUFFIXES lib
     HINTS ${CHARM_ROOT} ENV CHARM_ROOT
 )
+find_library(CHARM_EVERYLB
+    NAMES libmoduleEveryLB.a
+    PATH_SUFFIXES lib64 lib
+    HINTS ${CHARM_ROOT} ENV CHARM_ROOT
+)
+
+if("${CHARM_EVERYLB}" STREQUAL "CHARM_EVERYLB-NOTFOUND")
+  message(SEND_ERROR "Could not find charm module EveryLB."
+    "Make sure you have built the LIBS target when building charm++")
+endif()
+
 get_filename_component(CHARM_LIBRARIES ${CHARM_LIBCK} DIRECTORY)
 
 find_program(CHARM_COMPILER
@@ -80,4 +91,5 @@ mark_as_advanced(
     CHARM_PATCH_VERSION
     CHARM_VERSION
     CHARM_LIBRARIES
+    CHARM_EVERYLB
 )

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -327,7 +327,7 @@ Follow these steps:
   * In `CHARM_DIR`, run
     `git checkout v6.10.2` to switch to a supported, stable release of Charm++.
   * Charm++ is compiled by running
-    `./build charm++ ARCH OPTIONS`.
+    `./build LIBS ARCH OPTIONS`.
     To figure out the correct target architecture and options, you can simply
     run `./build`; the script will then ask you questions to guide you towards
     the correct settings (see notes below for additional details).


### PR DESCRIPTION
## Proposed changes

Adjusts documentation and adds a required lib so that cmake fails when the everylb module isn't built, rather than giving mysterious linker errors.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

