### PR TITLE
Support log and inverse radial distributions of grid points in Cylinder

### DIFF
--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -15,6 +15,7 @@ spectre_target_sources(
   CylindricalFlatSide.cpp
   CylindricalSide.cpp
   DiscreteRotation.cpp
+  Distribution.cpp
   EquatorialCompression.cpp
   Equiangular.cpp
   FocallyLiftedEndcap.cpp
@@ -44,6 +45,7 @@ spectre_target_headers(
   CylindricalFlatSide.hpp
   CylindricalSide.hpp
   DiscreteRotation.hpp
+  Distribution.hpp
   EquatorialCompression.hpp
   Equiangular.hpp
   FocallyLiftedEndcap.hpp

--- a/src/Domain/CoordinateMaps/Distribution.cpp
+++ b/src/Domain/CoordinateMaps/Distribution.cpp
@@ -1,0 +1,45 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/Distribution.hpp"
+
+#include <ostream>
+#include <string>
+
+#include "Options/Options.hpp"
+#include "Options/ParseOptions.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+
+namespace domain::CoordinateMaps {
+
+std::ostream& operator<<(std::ostream& os,
+                         const Distribution distribution) noexcept {
+  switch (distribution) {
+    case Distribution::Linear:
+      return os << "Linear";
+    case Distribution::Logarithmic:
+      return os << "Logarithmic";
+    case Distribution::Inverse:
+      return os << "Inverse";
+    default:
+      ERROR("Unknown domain::CoordinateMaps::Distribution type");
+  }
+}
+
+}  // namespace domain::CoordinateMaps
+
+template <>
+domain::CoordinateMaps::Distribution
+Options::create_from_yaml<domain::CoordinateMaps::Distribution>::create<void>(
+    const Options::Option& options) {
+  const auto distribution = options.parse_as<std::string>();
+  if (distribution == "Linear") {
+    return domain::CoordinateMaps::Distribution::Linear;
+  } else if (distribution == "Logarithmic") {
+    return domain::CoordinateMaps::Distribution::Logarithmic;
+  } else if (distribution == "Inverse") {
+    return domain::CoordinateMaps::Distribution::Inverse;
+  }
+  PARSE_ERROR(options.context(),
+              "Distribution must be 'Linear', 'Logarithmic' or 'Inverse'");
+}

--- a/src/Domain/CoordinateMaps/Distribution.hpp
+++ b/src/Domain/CoordinateMaps/Distribution.hpp
@@ -1,0 +1,42 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <ostream>
+
+/// \cond
+namespace Options {
+class Option;
+template <typename T>
+struct create_from_yaml;
+}  // namespace Options
+/// \endcond
+
+namespace domain::CoordinateMaps {
+
+/*!
+ * \brief Distribution of grid points in one dimension
+ *
+ * Used to select a distribution of grid points in the input file.
+ *
+ * \see domain::CoordinateMaps::Wedge
+ */
+enum class Distribution { Linear, Logarithmic, Inverse };
+
+std::ostream& operator<<(std::ostream& os, Distribution distribution) noexcept;
+
+}  // namespace domain::CoordinateMaps
+
+template <>
+struct Options::create_from_yaml<domain::CoordinateMaps::Distribution> {
+  template <typename Metavariables>
+  static domain::CoordinateMaps::Distribution create(
+      const Options::Option& options) {
+    return create<void>(options);
+  }
+};
+template <>
+domain::CoordinateMaps::Distribution
+Options::create_from_yaml<domain::CoordinateMaps::Distribution>::create<void>(
+    const Options::Option& options);

--- a/src/Domain/CoordinateMaps/Wedge.hpp
+++ b/src/Domain/CoordinateMaps/Wedge.hpp
@@ -9,6 +9,7 @@
 #include <optional>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
 
@@ -18,8 +19,7 @@ class er;
 }  // namespace PUP
 /// \endcond
 
-namespace domain {
-namespace CoordinateMaps {
+namespace domain::CoordinateMaps {
 
 namespace detail {
 // This mapping can be deleted once the 2D and 3D wedges are oriented the same
@@ -242,6 +242,14 @@ struct WedgeCoordOrientation<3> {
  *
  *  The jacobian simplifies similarly.
  *
+ *  Alternatively, an inverse radial distribution can be chosen where the linear
+ *  interpolation is:
+ *
+ *  \f[
+ *  \frac{1}{r} = \frac{R_\mathrm{inner} + R_\mathrm{outer}}{2 R_\mathrm{inner}
+ *  R_\mathrm{outer}} + \frac{R_\mathrm{inner} - R_\mathrm{outer}}{2
+ *  R_\mathrm{inner} R_\mathrm{outer}} \zeta
+ *  \f]
  */
 template <size_t Dim>
 class Wedge {
@@ -285,15 +293,15 @@ class Wedge {
    * intermediate map applied. In all cases, the logical points returned by the
    * inverse map will lie in the range [-1,1] in each dimension. Half wedges are
    * currently only useful in constructing domains for binary systems.
-   * \param with_logarithmic_map Determines whether to apply an exponential
-   * function mapping to the "sphere factor", the effect of which is to
-   * distribute the radial gridpoints logarithmically in physical space.
+   * \param radial_distribution Determines how to distribute grid points along
+   * the radial direction. For wedges that are not exactly spherical, only
+   * `Distribution::Linear` is currently supported.
    */
   Wedge(double radius_inner, double radius_outer, double sphericity_inner,
         double sphericity_outer, OrientationMap<Dim> orientation_of_wedge,
         bool with_equiangular_map,
         WedgeHalves halves_to_use = WedgeHalves::Both,
-        bool with_logarithmic_map = false) noexcept;
+        Distribution radial_distribution = Distribution::Linear) noexcept;
 
   Wedge() = default;
   ~Wedge() = default;
@@ -360,7 +368,7 @@ class Wedge {
   OrientationMap<Dim> orientation_of_wedge_{};
   bool with_equiangular_map_ = false;
   WedgeHalves halves_to_use_ = WedgeHalves::Both;
-  bool with_logarithmic_map_ = false;
+  Distribution radial_distribution_ = Distribution::Linear;
   double scaled_frustum_zero_{std::numeric_limits<double>::signaling_NaN()};
   double sphere_zero_{std::numeric_limits<double>::signaling_NaN()};
   double scaled_frustum_rate_{std::numeric_limits<double>::signaling_NaN()};
@@ -369,5 +377,4 @@ class Wedge {
 
 template <size_t Dim>
 bool operator!=(const Wedge<Dim>& lhs, const Wedge<Dim>& rhs) noexcept;
-}  // namespace CoordinateMaps
-}  // namespace domain
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/Creators/Cylinder.hpp
+++ b/src/Domain/Creators/Cylinder.hpp
@@ -11,6 +11,7 @@
 
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Domain/BoundaryConditions/GetBoundaryConditionsBase.hpp"
+#include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Domain.hpp"
 #include "Options/Options.hpp"
@@ -137,6 +138,16 @@ class Cylinder : public DomainCreator<3> {
         "between LowerBound and UpperBound."};
   };
 
+  struct RadialDistribution {
+    using type = std::vector<domain::CoordinateMaps::Distribution>;
+    static constexpr Options::String help = {
+        "Select the radial distribution of grid points in each cylindrical "
+        "shell. The innermost shell must have a 'Linear' distribution because "
+        "it changes in circularity. The 'RadialPartitioning' determines the "
+        "number of shells."};
+    static size_t lower_bound_on_size() noexcept { return 1; }
+  };
+
   struct BoundaryConditions {
     static constexpr Options::String help =
         "Options for the boundary conditions";
@@ -190,7 +201,7 @@ class Cylinder : public DomainCreator<3> {
                       typename Metavariables::system>>>,
           tmpl::list<IsPeriodicInZ>>,
       tmpl::list<InitialRefinement, InitialGridPoints, UseEquiangularMap,
-                 RadialPartitioning, HeightPartitioning>>;
+                 RadialPartitioning, HeightPartitioning, RadialDistribution>>;
 
   static constexpr Options::String help{
       "Creates a right circular Cylinder with a square prism surrounded by \n"
@@ -221,6 +232,8 @@ class Cylinder : public DomainCreator<3> {
       const typename InitialRefinement::type& initial_number_of_grid_points,
       bool use_equiangular_map, std::vector<double> radial_partitioning = {},
       std::vector<double> height_partitioning = {},
+      std::vector<domain::CoordinateMaps::Distribution> radial_distribution =
+          {domain::CoordinateMaps::Distribution::Linear},
       const Options::Context& context = {});
 
   Cylinder(
@@ -236,6 +249,8 @@ class Cylinder : public DomainCreator<3> {
       const typename InitialRefinement::type& initial_number_of_grid_points,
       bool use_equiangular_map, std::vector<double> radial_partitioning = {},
       std::vector<double> height_partitioning = {},
+      std::vector<domain::CoordinateMaps::Distribution> radial_distribution =
+          {domain::CoordinateMaps::Distribution::Linear},
       const Options::Context& context = {});
 
   Cylinder() = default;
@@ -263,6 +278,7 @@ class Cylinder : public DomainCreator<3> {
   bool use_equiangular_map_{false};
   std::vector<double> radial_partitioning_{};
   std::vector<double> height_partitioning_{};
+  std::vector<domain::CoordinateMaps::Distribution> radial_distribution_{};
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
       lower_boundary_condition_{};
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -247,6 +247,7 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const noexcept {
       cyl_wedge_coord_map_surrounding_blocks(
           cylinder_inner_radius, cylinder_outer_radius, cylinder_lower_bound_z,
           cylinder_upper_bound_z, false, 0.0, {}, {},
+          {domain::CoordinateMaps::Distribution::Linear},
           CylindricalDomainParityFlip::z_direction);
 
   enum class AddBoundaryCondition { none, inner, outer };
@@ -386,7 +387,8 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const noexcept {
       cyl_wedge_coord_map_surrounding_blocks(
           cylindrical_shell_inner_radius, cylindrical_shell_outer_radius,
           cylindrical_shell_lower_bound_z, cylindrical_shell_upper_bound_z,
-          false, 1.0, {}, {}, CylindricalDomainParityFlip::z_direction);
+          false, 1.0, {}, {}, {domain::CoordinateMaps::Distribution::Linear},
+          CylindricalDomainParityFlip::z_direction);
 
   // Lambda that takes a CylindricalSide map and a DiscreteRotation
   // map, composes it with the logical-to-cylinder maps, and adds it

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -17,6 +17,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
+#include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/CoordinateMaps/EquatorialCompression.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/Frustum.hpp"
@@ -625,6 +626,9 @@ sph_wedge_coordinate_maps(const double inner_radius, const double outer_radius,
   using Wedge3DMap = domain::CoordinateMaps::Wedge<3>;
   using Halves = Wedge3DMap::WedgeHalves;
   std::vector<Wedge3DMap> wedges_for_all_layers{};
+  const auto radial_distribution =
+      use_logarithmic_map ? domain::CoordinateMaps::Distribution::Logarithmic
+                          : domain::CoordinateMaps::Distribution::Linear;
 
   // Set up layers:
   const double delta_zeta = 2.0 / number_of_layers;
@@ -652,27 +656,27 @@ sph_wedge_coordinate_maps(const double inner_radius, const double outer_radius,
         wedges_for_this_layer.emplace_back(
             inner_radius_layer_i, outer_radius_layer_i, inner_sphericity,
             outer_sphericity, gsl::at(wedge_orientations, face_j),
-            use_equiangular_map, Halves::Both, use_logarithmic_map);
+            use_equiangular_map, Halves::Both, radial_distribution);
       }
     } else {
       for (size_t i = 0; i < 4; i++) {
         wedges_for_this_layer.emplace_back(
             inner_radius_layer_i, outer_radius_layer_i, inner_sphericity,
             outer_sphericity, gsl::at(wedge_orientations, i),
-            use_equiangular_map, Halves::LowerOnly, use_logarithmic_map);
+            use_equiangular_map, Halves::LowerOnly, radial_distribution);
         wedges_for_this_layer.emplace_back(
             inner_radius_layer_i, outer_radius_layer_i, inner_sphericity,
             outer_sphericity, gsl::at(wedge_orientations, i),
-            use_equiangular_map, Halves::UpperOnly, use_logarithmic_map);
+            use_equiangular_map, Halves::UpperOnly, radial_distribution);
       }
       wedges_for_this_layer.emplace_back(
           inner_radius_layer_i, outer_radius_layer_i, inner_sphericity,
           outer_sphericity, gsl::at(wedge_orientations, 4), use_equiangular_map,
-          Halves::Both, use_logarithmic_map);
+          Halves::Both, radial_distribution);
       wedges_for_this_layer.emplace_back(
           inner_radius_layer_i, outer_radius_layer_i, inner_sphericity,
           outer_sphericity, gsl::at(wedge_orientations, 5), use_equiangular_map,
-          Halves::Both, use_logarithmic_map);
+          Halves::Both, radial_distribution);
     }
     for (const auto& wedge : wedges_for_this_layer) {
       wedges_for_all_layers.push_back(wedge);

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -16,6 +16,7 @@
 #include "DataStructures/Index.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/Side.hpp"
 #include "Utilities/ConstantExpressions.hpp"
@@ -227,12 +228,20 @@ std::vector<std::array<size_t, 8>> corners_for_biradially_layered_domains(
 /// specifies the z-boundaries, splitting the cylinder into stacked
 /// 3-dimensional disks. The circularity of the shell wedges changes from 0 to 1
 /// within the innermost sub-shell.
+///
+/// Set the `radial_distribution` to select the radial distribution of grid
+/// points in the cylindrical shells. The innermost shell must have
+/// `domain::CoordinateMaps::Distribution::Linear` because it changes the
+/// circularity.
 template <typename TargetFrame>
 auto cyl_wedge_coordinate_maps(
     double inner_radius, double outer_radius, double lower_bound,
     double upper_bound, bool use_equiangular_map,
     const std::vector<double>& radial_partitioning = {},
-    const std::vector<double>& height_partitioning = {}) noexcept
+    const std::vector<double>& height_partitioning = {},
+    const std::vector<domain::CoordinateMaps::Distribution>&
+        radial_distribution =
+            {domain::CoordinateMaps::Distribution::Linear}) noexcept
     -> std::vector<std::unique_ptr<
         domain::CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>;
 
@@ -287,6 +296,8 @@ auto cyl_wedge_coord_map_surrounding_blocks(
     double upper_bound, bool use_equiangular_map, double inner_circularity,
     const std::vector<double>& radial_partitioning = {},
     const std::vector<double>& height_partitioning = {},
+    const std::vector<domain::CoordinateMaps::Distribution>&
+        radial_distribution = {domain::CoordinateMaps::Distribution::Linear},
     CylindricalDomainParityFlip parity_flip =
         CylindricalDomainParityFlip::none) noexcept
     -> std::vector<domain::CoordinateMaps::ProductOf2Maps<

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -32,6 +32,7 @@ DomainCreator:
     UseEquiangularMap: True
     RadialPartitioning: []
     HeightPartitioning: []
+    RadialDistribution: [Linear]
     BoundaryConditions:
       Lower:
         AnalyticSolution:

--- a/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBRARY_SOURCES
   Test_CylindricalFlatSide.cpp
   Test_CylindricalSide.cpp
   Test_DiscreteRotation.cpp
+  Test_Distribution.cpp
   Test_EquatorialCompression.cpp
   Test_Equiangular.cpp
   Test_Frustum.cpp

--- a/tests/Unit/Domain/CoordinateMaps/Test_Distribution.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Distribution.cpp
@@ -1,0 +1,26 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "Domain/CoordinateMaps/Distribution.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Utilities/GetOutput.hpp"
+
+namespace domain::CoordinateMaps {
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Distribution", "[Domain][Unit]") {
+  CHECK(get_output(Distribution::Linear) == "Linear");
+  CHECK(get_output(Distribution::Logarithmic) == "Logarithmic");
+  CHECK(get_output(Distribution::Inverse) == "Inverse");
+  CHECK(TestHelpers::test_creation<Distribution>("Linear") ==
+        Distribution::Linear);
+  CHECK(TestHelpers::test_creation<Distribution>("Logarithmic") ==
+        Distribution::Logarithmic);
+  CHECK(TestHelpers::test_creation<Distribution>("Inverse") ==
+        Distribution::Inverse);
+}
+
+}  // namespace domain::CoordinateMaps

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
@@ -9,6 +9,7 @@
 #include <random>
 
 #include "DataStructures/Tensor/EagerMath/Determinant.hpp"
+#include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/CoordinateMaps/Wedge.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
@@ -133,13 +134,20 @@ void test_wedge2d_all_orientations(const bool with_equiangular_map) {
     CAPTURE(orientation);
     for (const auto& halves : possible_halves) {
       CAPTURE(halves);
-      for (const auto with_logarithmic_map : {false, true}) {
-        CAPTURE(with_logarithmic_map);
-        test_suite_for_map_on_unit_cube(
-            Wedge2D{inner_radius, outer_radius,
-                    with_logarithmic_map ? 1.0 : inner_circularity,
-                    with_logarithmic_map ? 1.0 : outer_circularity, orientation,
-                    with_equiangular_map, halves, with_logarithmic_map});
+      for (const auto radial_distribution :
+           {CoordinateMaps::Distribution::Linear,
+            CoordinateMaps::Distribution::Logarithmic,
+            CoordinateMaps::Distribution::Inverse}) {
+        CAPTURE(radial_distribution);
+        test_suite_for_map_on_unit_cube(Wedge2D{
+            inner_radius, outer_radius,
+            radial_distribution == CoordinateMaps::Distribution::Linear
+                ? inner_circularity
+                : 1.0,
+            radial_distribution == CoordinateMaps::Distribution::Linear
+                ? outer_circularity
+                : 1.0,
+            orientation, with_equiangular_map, halves, radial_distribution});
       }
     }
   }

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
@@ -8,6 +8,7 @@
 #include <optional>
 #include <random>
 
+#include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/CoordinateMaps/Wedge.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Framework/TestHelpers.hpp"
@@ -45,13 +46,20 @@ void test_wedge3d_all_directions() {
       CAPTURE(orientation);
       for (const auto& with_equiangular_map : {true, false}) {
         CAPTURE(with_equiangular_map);
-        for (const auto& with_logarithmic_map : {true, false}) {
-          CAPTURE(with_logarithmic_map);
-          const Wedge3D wedge_map(inner_radius, outer_radius,
-                                  with_logarithmic_map ? 1.0 : inner_sphericity,
-                                  with_logarithmic_map ? 1.0 : outer_sphericity,
-                                  orientation, with_equiangular_map, halves,
-                                  with_logarithmic_map);
+        for (const auto radial_distribution :
+             {CoordinateMaps::Distribution::Linear,
+              CoordinateMaps::Distribution::Logarithmic,
+              CoordinateMaps::Distribution::Inverse}) {
+          CAPTURE(radial_distribution);
+          const Wedge3D wedge_map(
+              inner_radius, outer_radius,
+              radial_distribution == CoordinateMaps::Distribution::Linear
+                  ? inner_sphericity
+                  : 1.0,
+              radial_distribution == CoordinateMaps::Distribution::Linear
+                  ? outer_sphericity
+                  : 1.0,
+              orientation, with_equiangular_map, halves, radial_distribution);
           test_suite_for_map_on_unit_cube(wedge_map);
         }
       }
@@ -72,33 +80,38 @@ void test_wedge3d_alignment() {
 
   for (const auto& with_equiangular_map : {true, false}) {
     CAPTURE(with_equiangular_map);
-    for (const auto& with_logarithmic_map : {true, false}) {
-      CAPTURE(with_logarithmic_map);
-      const double inner_sphericity = with_logarithmic_map ? 1.0 : 0.0;
+    for (const auto radial_distribution :
+         {CoordinateMaps::Distribution::Linear,
+          CoordinateMaps::Distribution::Logarithmic,
+          CoordinateMaps::Distribution::Inverse}) {
+      CAPTURE(radial_distribution);
+      const double inner_sphericity =
+          radial_distribution == CoordinateMaps::Distribution::Linear ? 0.0
+                                                                      : 1.0;
       const Wedge3D map_upper_zeta(inner_r, outer_r, inner_sphericity, 1.0,
                                    wedge_directions[0], with_equiangular_map,
                                    WedgeHalves::Both,
-                                   with_logarithmic_map);  // Upper Z wedge
+                                   radial_distribution);  // Upper Z wedge
       const Wedge3D map_upper_eta(inner_r, outer_r, inner_sphericity, 1.0,
                                   wedge_directions[2], with_equiangular_map,
                                   WedgeHalves::Both,
-                                  with_logarithmic_map);  // Upper Y wedge
+                                  radial_distribution);  // Upper Y wedge
       const Wedge3D map_upper_xi(inner_r, outer_r, inner_sphericity, 1.0,
                                  wedge_directions[4], with_equiangular_map,
                                  WedgeHalves::Both,
-                                 with_logarithmic_map);  // Upper X Wedge
+                                 radial_distribution);  // Upper X Wedge
       const Wedge3D map_lower_zeta(inner_r, outer_r, inner_sphericity, 1.0,
                                    wedge_directions[1], with_equiangular_map,
                                    WedgeHalves::Both,
-                                   with_logarithmic_map);  // Lower Z wedge
+                                   radial_distribution);  // Lower Z wedge
       const Wedge3D map_lower_eta(inner_r, outer_r, inner_sphericity, 1.0,
                                   wedge_directions[3], with_equiangular_map,
                                   WedgeHalves::Both,
-                                  with_logarithmic_map);  // Lower Y wedge
+                                  radial_distribution);  // Lower Y wedge
       const Wedge3D map_lower_xi(inner_r, outer_r, inner_sphericity, 1.0,
                                  wedge_directions[5], with_equiangular_map,
                                  WedgeHalves::Both,
-                                 with_logarithmic_map);  // Lower X wedge
+                                 radial_distribution);  // Lower X wedge
       const std::array<double, 3> lowest_corner{{-1.0, -1.0, -1.0}};
       const std::array<double, 3> along_xi{{1.0, -1.0, -1.0}};
       const std::array<double, 3> along_eta{{-1.0, 1.0, -1.0}};
@@ -204,33 +217,38 @@ void test_wedge3d_random_radii() {
   const auto wedge_directions = all_wedge_directions();
   for (const auto& with_equiangular_map : {true, false}) {
     CAPTURE(with_equiangular_map);
-    for (const auto& with_logarithmic_map : {true, false}) {
-      CAPTURE(with_logarithmic_map);
-      const double inner_sphericity = with_logarithmic_map ? 1.0 : 0.0;
+    for (const auto radial_distribution :
+         {CoordinateMaps::Distribution::Linear,
+          CoordinateMaps::Distribution::Logarithmic,
+          CoordinateMaps::Distribution::Inverse}) {
+      CAPTURE(radial_distribution);
+      const double inner_sphericity =
+          radial_distribution == CoordinateMaps::Distribution::Linear ? 0.0
+                                                                      : 1.0;
       const Wedge3D map_lower_xi(random_inner_radius_lower_xi,
                                  random_outer_radius_lower_xi, inner_sphericity,
                                  1.0, wedge_directions[5], with_equiangular_map,
-                                 WedgeHalves::Both, with_logarithmic_map);
+                                 WedgeHalves::Both, radial_distribution);
       const Wedge3D map_lower_eta(
           random_inner_radius_lower_eta, random_outer_radius_lower_eta,
           inner_sphericity, 1.0, wedge_directions[3], with_equiangular_map,
-          WedgeHalves::Both, with_logarithmic_map);
+          WedgeHalves::Both, radial_distribution);
       const Wedge3D map_lower_zeta(
           random_inner_radius_lower_zeta, random_outer_radius_lower_zeta,
           inner_sphericity, 1.0, wedge_directions[1], with_equiangular_map,
-          WedgeHalves::Both, with_logarithmic_map);
+          WedgeHalves::Both, radial_distribution);
       const Wedge3D map_upper_xi(random_inner_radius_upper_xi,
                                  random_outer_radius_upper_xi, inner_sphericity,
                                  1.0, wedge_directions[4], with_equiangular_map,
-                                 WedgeHalves::Both, with_logarithmic_map);
+                                 WedgeHalves::Both, radial_distribution);
       const Wedge3D map_upper_eta(
           random_inner_radius_upper_eta, random_outer_radius_upper_eta,
           inner_sphericity, 1.0, wedge_directions[2], with_equiangular_map,
-          WedgeHalves::Both, with_logarithmic_map);
+          WedgeHalves::Both, radial_distribution);
       const Wedge3D map_upper_zeta(
           random_inner_radius_upper_zeta, random_outer_radius_upper_zeta,
           inner_sphericity, 1.0, wedge_directions[0], with_equiangular_map,
-          WedgeHalves::Both, with_logarithmic_map);
+          WedgeHalves::Both, radial_distribution);
       CHECK(map_lower_xi(outer_corner)[0] ==
             approx(-random_outer_radius_lower_xi / sqrt(3.0)));
       CHECK(map_lower_eta(outer_corner)[1] ==
@@ -253,7 +271,7 @@ void test_wedge3d_random_radii() {
       CAPTURE(random_outer_face);
       CAPTURE(random_inner_face);
 
-      if (not with_logarithmic_map) {
+      if (radial_distribution == CoordinateMaps::Distribution::Linear) {
         CHECK(map_lower_xi(random_inner_face)[0] ==
               approx(-random_inner_radius_lower_xi / sqrt(3.0)));
         CHECK(map_lower_eta(random_inner_face)[1] ==
@@ -379,13 +397,15 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Map", "[Domain][Unit]") {
 #endif
 }
 
-// [[OutputRegex, The logarithmic map is only supported for spherical wedges.]]
+// [[OutputRegex, Only the 'Linear' radial distribution is supported for
+// non-spherical wedges.]]
 [[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.LogarithmicMap",
                                "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  auto failed_wedge3d = Wedge3D(0.2, 4.0, 0.8, 0.9, OrientationMap<3>{}, true,
-                                Wedge3D::WedgeHalves::Both, true);
+  auto failed_wedge3d = Wedge3D(
+      0.2, 4.0, 0.8, 0.9, OrientationMap<3>{}, true, Wedge3D::WedgeHalves::Both,
+      domain::CoordinateMaps::Distribution::Logarithmic);
   static_cast<void>(failed_wedge3d);
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif

--- a/tests/Unit/Domain/Creators/Test_Shell.cpp
+++ b/tests/Unit/Domain/Creators/Test_Shell.cpp
@@ -200,36 +200,39 @@ void test_shell_construction(
   CHECK(shell.initial_refinement_levels() == expected_refinement_level);
   using Wedge3DMap = CoordinateMaps::Wedge<3>;
   using Halves = Wedge3DMap::WedgeHalves;
+  const auto radial_distribution =
+      use_logarithmic_map ? domain::CoordinateMaps::Distribution::Logarithmic
+                          : domain::CoordinateMaps::Distribution::Linear;
   if (aspect_ratio == 1.0) {
     auto vector_of_maps = make_vector_coordinate_map_base<Frame::Logical,
                                                           Frame::Inertial>(
         Wedge3DMap{inner_radius, outer_radius, 1.0, 1.0, OrientationMap<3>{},
-                   use_equiangular_map, Halves::Both, use_logarithmic_map},
+                   use_equiangular_map, Halves::Both, radial_distribution},
         Wedge3DMap{inner_radius, outer_radius, 1.0, 1.0,
                    OrientationMap<3>{std::array<Direction<3>, 3>{
                        {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
                         Direction<3>::lower_zeta()}}},
-                   use_equiangular_map, Halves::Both, use_logarithmic_map},
+                   use_equiangular_map, Halves::Both, radial_distribution},
         Wedge3DMap{inner_radius, outer_radius, 1.0, 1.0,
                    OrientationMap<3>{std::array<Direction<3>, 3>{
                        {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
                         Direction<3>::lower_eta()}}},
-                   use_equiangular_map, Halves::Both, use_logarithmic_map},
+                   use_equiangular_map, Halves::Both, radial_distribution},
         Wedge3DMap{inner_radius, outer_radius, 1.0, 1.0,
                    OrientationMap<3>{std::array<Direction<3>, 3>{
                        {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
                         Direction<3>::upper_eta()}}},
-                   use_equiangular_map, Halves::Both, use_logarithmic_map},
+                   use_equiangular_map, Halves::Both, radial_distribution},
         Wedge3DMap{inner_radius, outer_radius, 1.0, 1.0,
                    OrientationMap<3>{std::array<Direction<3>, 3>{
                        {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
                         Direction<3>::upper_eta()}}},
-                   use_equiangular_map, Halves::Both, use_logarithmic_map},
+                   use_equiangular_map, Halves::Both, radial_distribution},
         Wedge3DMap{inner_radius, outer_radius, 1.0, 1.0,
                    OrientationMap<3>{std::array<Direction<3>, 3>{
                        {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
                         Direction<3>::upper_eta()}}},
-                   use_equiangular_map, Halves::Both, use_logarithmic_map});
+                   use_equiangular_map, Halves::Both, radial_distribution});
     if (UNLIKELY(which_wedges == ShellWedges::FourOnEquator)) {
       vector_of_maps.erase(vector_of_maps.begin(), vector_of_maps.begin() + 2);
     } else if (UNLIKELY(which_wedges == ShellWedges::OneAlongMinusX)) {
@@ -269,14 +272,14 @@ void test_shell_construction(
         make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
             Wedge3DMap{inner_radius, outer_radius, 1.0, 1.0,
                        OrientationMap<3>{}, use_equiangular_map, Halves::Both,
-                       use_logarithmic_map},
+                       radial_distribution},
             compression, translation),
         make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
             Wedge3DMap{inner_radius, outer_radius, 1.0, 1.0,
                        OrientationMap<3>{std::array<Direction<3>, 3>{
                            {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
                             Direction<3>::lower_zeta()}}},
-                       use_equiangular_map, Halves::Both, use_logarithmic_map},
+                       use_equiangular_map, Halves::Both, radial_distribution},
             compression, translation),
         make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
             Wedge3DMap{
@@ -284,7 +287,7 @@ void test_shell_construction(
                 OrientationMap<3>{std::array<Direction<3>, 3>{
                     {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
                      Direction<3>::lower_eta()}}},
-                use_equiangular_map, Halves::Both, use_logarithmic_map},
+                use_equiangular_map, Halves::Both, radial_distribution},
             compression, translation),
         make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
             Wedge3DMap{
@@ -292,7 +295,7 @@ void test_shell_construction(
                 OrientationMap<3>{std::array<Direction<3>, 3>{
                     {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
                      Direction<3>::upper_eta()}}},
-                use_equiangular_map, Halves::Both, use_logarithmic_map},
+                use_equiangular_map, Halves::Both, radial_distribution},
             compression, translation),
         make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
             Wedge3DMap{
@@ -300,7 +303,7 @@ void test_shell_construction(
                 OrientationMap<3>{std::array<Direction<3>, 3>{
                     {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
                      Direction<3>::upper_eta()}}},
-                use_equiangular_map, Halves::Both, use_logarithmic_map},
+                use_equiangular_map, Halves::Both, radial_distribution},
             compression, translation),
         make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
             Wedge3DMap{
@@ -308,7 +311,7 @@ void test_shell_construction(
                 OrientationMap<3>{std::array<Direction<3>, 3>{
                     {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
                      Direction<3>::upper_eta()}}},
-                use_equiangular_map, Halves::Both, use_logarithmic_map},
+                use_equiangular_map, Halves::Both, radial_distribution},
             compression, translation));
     if (UNLIKELY(which_wedges == ShellWedges::FourOnEquator)) {
       vector_of_maps.erase(vector_of_maps.begin(), vector_of_maps.begin() + 2);


### PR DESCRIPTION
## Proposed changes

Add linear, logarithmic and inverse radial distributions of grid points to `Wedge`, and use it for the `Cylinder`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
If you construct `Wedge`s with the `use_logarithmic_map` option, change the boolean to `domain::CoordinateMaps::Distribution::Logarithmic`.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
