### PR TITLE
Add higher-dim projection operators, child_size function for AMR

### DIFF
--- a/src/Domain/Structure/CMakeLists.txt
+++ b/src/Domain/Structure/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   BlockNeighbor.cpp
+  ChildSize.cpp
   CreateInitialMesh.cpp
   Direction.cpp
   Element.cpp
@@ -28,6 +29,7 @@ spectre_target_headers(
   HEADERS
   BlockId.hpp
   BlockNeighbor.hpp
+  ChildSize.hpp
   CreateInitialMesh.hpp
   Direction.hpp
   DirectionMap.hpp

--- a/src/Domain/Structure/ChildSize.cpp
+++ b/src/Domain/Structure/ChildSize.cpp
@@ -1,0 +1,30 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Structure/ChildSize.hpp"
+
+#include <ostream>
+#include <string>
+
+#include "Domain/Structure/SegmentId.hpp"
+#include "Domain/Structure/Side.hpp"
+#include "NumericalAlgorithms/Spectral/Projection.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+
+namespace domain {
+
+Spectral::ChildSize child_size(const SegmentId& child_segment_id,
+                               const SegmentId& parent_segment_id) noexcept {
+  if (child_segment_id == parent_segment_id) {
+    return Spectral::ChildSize::Full;
+  } else {
+    ASSERT(child_segment_id.id_of_parent() == parent_segment_id,
+           "Segment id '" << parent_segment_id << "' is not the parent of '"
+                          << child_segment_id << "'.");
+    return parent_segment_id.id_of_child(Side::Lower) == child_segment_id
+               ? Spectral::ChildSize::LowerHalf
+               : Spectral::ChildSize::UpperHalf;
+  }
+}
+
+}  // namespace domain

--- a/src/Domain/Structure/ChildSize.hpp
+++ b/src/Domain/Structure/ChildSize.hpp
@@ -1,0 +1,18 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Domain/Structure/SegmentId.hpp"
+#include "NumericalAlgorithms/Spectral/Projection.hpp"
+
+namespace domain {
+/*!
+ * \brief Size of a child segment relative to its parent
+ *
+ * Determines which part of the `parent_segment_id` is covered by the
+ * `child_segment_id`: The full segment, its lower half or its upper half.
+ */
+Spectral::ChildSize child_size(const SegmentId& child_segment_id,
+                               const SegmentId& parent_segment_id) noexcept;
+}

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
@@ -28,6 +28,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags/Formulation.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Time/Tags.hpp"
@@ -411,7 +412,8 @@ void ApplyBoundaryCorrections<Metavariables>::complete_time_step(
                &dt_boundary_correction_projected_onto_face, &face_mesh,
                &mortar_mesh, &mortar_size]() noexcept
               -> Variables<db::wrap_tags_in<::Tags::dt, variables_tags>>& {
-            if (::dg::needs_projection(face_mesh, mortar_mesh, mortar_size)) {
+            if (Spectral::needs_projection(face_mesh, mortar_mesh,
+                                           mortar_size)) {
               dt_boundary_correction_projected_onto_face =
                   ::dg::project_from_mortar(dt_boundary_correction_on_mortar,
                                             face_mesh, mortar_mesh,

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
@@ -595,7 +595,7 @@ void ComputeTimeDerivative<Metavariables>::
       // projecting, because in that case the face may touch more than one
       // mortar so we need to keep the data around.
       auto boundary_data_on_mortar =
-          ::dg::needs_projection(face_mesh, mortar_mesh, mortar_size)
+          Spectral::needs_projection(face_mesh, mortar_mesh, mortar_size)
               ? boundary_data_on_interfaces.at(direction).project_to_mortar(
                     face_mesh, mortar_mesh, mortar_size)
               : std::move(boundary_data_on_interfaces.at(direction));

--- a/src/Evolution/DiscontinuousGalerkin/Actions/InternalMortarDataImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/InternalMortarDataImpl.hpp
@@ -32,6 +32,7 @@
 #include "Evolution/DiscontinuousGalerkin/ProjectToBoundary.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeStepId.hpp"
 #include "Utilities/Gsl.hpp"
@@ -250,7 +251,7 @@ void internal_mortar_data_impl(
         // in-place when projecting, because in that case the face may
         // touch two mortars so we need to keep the data around.
         auto boundary_data_on_mortar =
-            ::dg::needs_projection(face_mesh, mortar_mesh, mortar_size)
+            Spectral::needs_projection(face_mesh, mortar_mesh, mortar_size)
                 // NOLINTNEXTLINE(bugprone-use-after-move)
                 ? ::dg::project_to_mortar(packaged_data, face_mesh, mortar_mesh,
                                           mortar_size)

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/BoundaryFlux.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/BoundaryFlux.hpp
@@ -17,6 +17,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/NumericalFluxHelpers.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Protocols.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/Requires.hpp"
@@ -80,7 +81,7 @@ Variables<typename NumericalFluxType::variables_tags> boundary_flux(
 
   // Project from the mortar back to the face if needed
   auto projected_fluxes =
-      needs_projection(face_mesh, mortar_mesh, mortar_size)
+      Spectral::needs_projection(face_mesh, mortar_mesh, mortar_size)
           ? project_from_mortar(normal_dot_numerical_fluxes, face_mesh,
                                 mortar_mesh, mortar_size)
           : std::move(normal_dot_numerical_fluxes);

--- a/src/NumericalAlgorithms/Spectral/Projection.cpp
+++ b/src/NumericalAlgorithms/Spectral/Projection.cpp
@@ -14,6 +14,7 @@
 #include "DataStructures/Matrix.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Algorithm.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
@@ -36,6 +37,16 @@ std::ostream& operator<<(std::ostream& os, ChildSize mortar_size) noexcept {
           "Invalid ChildSize. Expected one of: 'Full', 'UpperHalf', "
           "'LowerHalf'");
   }
+}
+
+template <size_t Dim>
+bool needs_projection(const Mesh<Dim>& mesh1, const Mesh<Dim>& mesh2,
+                      const std::array<ChildSize, Dim>& child_sizes) noexcept {
+  return mesh1 != mesh2 or
+         alg::any_of(child_sizes,
+                     [](const Spectral::MortarSize child_size) noexcept {
+                       return child_size != Spectral::ChildSize::Full;
+                     });
 }
 
 const Matrix& projection_matrix_child_to_parent(
@@ -354,6 +365,9 @@ projection_matrix_parent_to_child(
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define INSTANTIATE(r, data)                                                 \
+  template bool needs_projection(                                            \
+      const Mesh<DIM(data)>& mesh1, const Mesh<DIM(data)>& mesh2,            \
+      const std::array<ChildSize, DIM(data)>& child_sizes) noexcept;         \
   template std::array<std::reference_wrapper<const Matrix>, DIM(data)>       \
   projection_matrix_child_to_parent(                                         \
       const Mesh<DIM(data)>& child_mesh, const Mesh<DIM(data)>& parent_mesh, \

--- a/src/NumericalAlgorithms/Spectral/Projection.hpp
+++ b/src/NumericalAlgorithms/Spectral/Projection.hpp
@@ -4,10 +4,10 @@
 #pragma once
 
 #include <cstddef>
-
-#include "DataStructures/Matrix.hpp"  // IWYU pragma: keep
+#include <ostream>
 
 /// \cond
+class Matrix;
 template <size_t Dim>
 class Mesh;
 /// \endcond

--- a/src/NumericalAlgorithms/Spectral/Projection.hpp
+++ b/src/NumericalAlgorithms/Spectral/Projection.hpp
@@ -24,6 +24,15 @@ using MortarSize = ChildSize;
 
 std::ostream& operator<<(std::ostream& os, ChildSize mortar_size) noexcept;
 
+/// Determine whether data needs to be projected between a child mesh and its
+/// parent mesh. If no projection is necessary the data may be used as-is.
+/// Projection is necessary if the child is either p-refined or h-refined
+/// relative to its parent, or both. This operation is symmetric, i.e. it is
+/// irrelevant in which order the child and the parent mesh are passed in.
+template <size_t Dim>
+bool needs_projection(const Mesh<Dim>& mesh1, const Mesh<Dim>& mesh2,
+                      const std::array<ChildSize, Dim>& child_sizes) noexcept;
+
 /*!
  * \brief The projection matrix from a child mesh to its parent.
  *

--- a/src/NumericalAlgorithms/Spectral/Projection.hpp
+++ b/src/NumericalAlgorithms/Spectral/Projection.hpp
@@ -3,7 +3,9 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
+#include <functional>
 #include <ostream>
 
 /// \cond
@@ -55,11 +57,26 @@ const Matrix& projection_matrix_child_to_parent(const Mesh<1>& child_mesh,
                                                 const Mesh<1>& parent_mesh,
                                                 ChildSize size) noexcept;
 
+/// The projection matrix from a child mesh to its parent, in `Dim` dimensions.
+template <size_t Dim>
+std::array<std::reference_wrapper<const Matrix>, Dim>
+projection_matrix_child_to_parent(
+    const Mesh<Dim>& child_mesh, const Mesh<Dim>& parent_mesh,
+    const std::array<ChildSize, Dim>& child_sizes) noexcept;
+
 /// The projection matrix from a parent mesh to one of its children.
 ///
 /// \see projection_matrix_child_to_parent()
 const Matrix& projection_matrix_parent_to_child(const Mesh<1>& parent_mesh,
                                                 const Mesh<1>& child_mesh,
                                                 ChildSize size) noexcept;
+
+/// The projection matrix from a parent mesh to one of its children, in `Dim`
+/// dimensions
+template <size_t Dim>
+std::array<std::reference_wrapper<const Matrix>, Dim>
+projection_matrix_parent_to_child(
+    const Mesh<Dim>& parent_mesh, const Mesh<Dim>& child_mesh,
+    const std::array<ChildSize, Dim>& child_sizes) noexcept;
 
 }  // namespace Spectral

--- a/src/ParallelAlgorithms/DiscontinuousGalerkin/CollectDataForFluxes.hpp
+++ b/src/ParallelAlgorithms/DiscontinuousGalerkin/CollectDataForFluxes.hpp
@@ -120,7 +120,7 @@ struct CollectDataForFluxes<BoundaryScheme, domain::Tags::InternalDirections<
         // projecting, because in that case the face may touch two mortars so we
         // need to keep the data around.
         auto boundary_data_on_mortar =
-            dg::needs_projection(face_mesh, mortar_mesh, mortar_size)
+            Spectral::needs_projection(face_mesh, mortar_mesh, mortar_size)
                 ? boundary_data_on_interfaces.at(direction).project_to_mortar(
                       face_mesh, mortar_mesh, mortar_size)
                 : std::move(boundary_data_on_interfaces.at(direction));

--- a/tests/Unit/Domain/Structure/Test_ChildSize.cpp
+++ b/tests/Unit/Domain/Structure/Test_ChildSize.cpp
@@ -1,0 +1,29 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Domain/Structure/ChildSize.hpp"
+#include "Domain/Structure/SegmentId.hpp"
+#include "NumericalAlgorithms/Spectral/Projection.hpp"
+
+namespace domain {
+
+SPECTRE_TEST_CASE("Unit.Domain.Structure.ChildSize", "[Domain][Unit]") {
+  CHECK(child_size({0, 0}, {0, 0}) == Spectral::ChildSize::Full);
+  CHECK(child_size({1, 0}, {0, 0}) == Spectral::ChildSize::LowerHalf);
+  CHECK(child_size({1, 1}, {0, 0}) == Spectral::ChildSize::UpperHalf);
+  CHECK(child_size({1, 1}, {1, 1}) == Spectral::ChildSize::Full);
+}
+
+// [[OutputRegex, Segment id 'L1I0' is not the parent of 'L1I1'.]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Structure.ChildSize.Assert",
+                               "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  child_size({1, 1}, {1, 0});
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+}  // namespace domain

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
@@ -30,6 +30,7 @@
 #include "Helpers/Evolution/DiscontinuousGalerkin/Actions/SystemType.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags/Formulation.hpp"
+#include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
@@ -815,7 +816,7 @@ void test_impl(const Spectral::Quadrature quadrature,
         [&dt_boundary_correction_on_mortar,
          &dt_boundary_correction_projected_onto_face, &face_mesh, &mortar_mesh,
          &mortar_size]() noexcept -> Variables<dt_variables_tags>& {
-      if (::dg::needs_projection(face_mesh, mortar_mesh, mortar_size)) {
+      if (Spectral::needs_projection(face_mesh, mortar_mesh, mortar_size)) {
         dt_boundary_correction_projected_onto_face =
             ::dg::project_from_mortar(dt_boundary_correction_on_mortar,
                                       face_mesh, mortar_mesh, mortar_size);

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -52,6 +52,7 @@
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
 #include "NumericalAlgorithms/LinearOperators/WeakDivergence.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
@@ -1772,7 +1773,7 @@ void test_impl(const Spectral::Quadrature quadrature,
           const auto& mortar_mesh = mortar_meshes.at(mortar_id);
           const auto& mortar_size = mortar_sizes.at(mortar_id);
           auto boundary_data_on_mortar =
-              ::dg::needs_projection(face_mesh, mortar_mesh, mortar_size)
+              Spectral::needs_projection(face_mesh, mortar_mesh, mortar_size)
                   ? ::dg::project_to_mortar(packaged_data, face_mesh,
                                             mortar_mesh, mortar_size)
                   : std::move(packaged_data);

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MortarHelpers.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MortarHelpers.cpp
@@ -179,60 +179,6 @@ SPECTRE_TEST_CASE("Unit.DG.MortarHelpers.projections",
   using Spectral::MortarSize;
   const auto all_mortar_sizes = {MortarSize::Full, MortarSize::LowerHalf,
                                  MortarSize::UpperHalf};
-
-  {
-    INFO("needs_projection");
-    CHECK_FALSE(
-        dg::needs_projection(Mesh<0>{}, Mesh<0>{}, dg::MortarSize<0>{}));
-    CHECK_FALSE(
-        dg::needs_projection(Mesh<1>{3, Spectral::Basis::Legendre,
-                                     Spectral::Quadrature::GaussLobatto},
-                             Mesh<1>{3, Spectral::Basis::Legendre,
-                                     Spectral::Quadrature::GaussLobatto},
-                             dg::MortarSize<1>{{MortarSize::Full}}));
-    CHECK_FALSE(dg::needs_projection(
-        Mesh<2>{3, Spectral::Basis::Legendre,
-                Spectral::Quadrature::GaussLobatto},
-        Mesh<2>{3, Spectral::Basis::Legendre,
-                Spectral::Quadrature::GaussLobatto},
-        dg::MortarSize<2>{{MortarSize::Full, MortarSize::Full}}));
-    CHECK_FALSE(dg::needs_projection(
-        Mesh<3>{3, Spectral::Basis::Legendre,
-                Spectral::Quadrature::GaussLobatto},
-        Mesh<3>{3, Spectral::Basis::Legendre,
-                Spectral::Quadrature::GaussLobatto},
-        dg::MortarSize<3>{
-            {MortarSize::Full, MortarSize::Full, MortarSize::Full}}));
-    CHECK(dg::needs_projection(Mesh<1>{3, Spectral::Basis::Legendre,
-                                       Spectral::Quadrature::GaussLobatto},
-                               Mesh<1>{4, Spectral::Basis::Legendre,
-                                       Spectral::Quadrature::GaussLobatto},
-                               dg::MortarSize<1>{{MortarSize::Full}}));
-    CHECK(dg::needs_projection(
-        Mesh<1>{3, Spectral::Basis::Legendre,
-                Spectral::Quadrature::GaussLobatto},
-        Mesh<1>{3, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss},
-        dg::MortarSize<1>{{MortarSize::Full}}));
-    CHECK(dg::needs_projection(Mesh<1>{3, Spectral::Basis::Legendre,
-                                       Spectral::Quadrature::GaussLobatto},
-                               Mesh<1>{3, Spectral::Basis::Legendre,
-                                       Spectral::Quadrature::GaussLobatto},
-                               dg::MortarSize<1>{{MortarSize::LowerHalf}}));
-    CHECK(dg::needs_projection(
-        Mesh<2>{3, Spectral::Basis::Legendre,
-                Spectral::Quadrature::GaussLobatto},
-        Mesh<2>{3, Spectral::Basis::Legendre,
-                Spectral::Quadrature::GaussLobatto},
-        dg::MortarSize<2>{{MortarSize::Full, MortarSize::LowerHalf}}));
-    CHECK(dg::needs_projection(
-        Mesh<3>{3, Spectral::Basis::Legendre,
-                Spectral::Quadrature::GaussLobatto},
-        Mesh<3>{3, Spectral::Basis::Legendre,
-                Spectral::Quadrature::GaussLobatto},
-        dg::MortarSize<3>{
-            {MortarSize::Full, MortarSize::Full, MortarSize::UpperHalf}}));
-  }
-
   // Check 0D
   {
     Variables<tmpl::list<Var>> vars(1);

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Projection.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Projection.cpp
@@ -16,6 +16,7 @@
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/MakeArray.hpp"
 
+namespace Spectral {
 namespace {
 constexpr auto quadratures = {Spectral::Quadrature::Gauss,
                               Spectral::Quadrature::GaussLobatto};
@@ -35,6 +36,39 @@ void test_mortar_size() {
   CHECK(get_output(Spectral::MortarSize::Full) == "Full");
   CHECK(get_output(Spectral::MortarSize::UpperHalf) == "UpperHalf");
   CHECK(get_output(Spectral::MortarSize::LowerHalf) == "LowerHalf");
+}
+
+void test_needs_projection() {
+  INFO("Needs projection");
+  CHECK_FALSE(needs_projection<0>({}, {}, {}));
+  CHECK_FALSE(
+      needs_projection<1>({3, Basis::Legendre, Quadrature::GaussLobatto},
+                          {3, Basis::Legendre, Quadrature::GaussLobatto},
+                          make_array<1>(ChildSize::Full)));
+  CHECK_FALSE(
+      needs_projection<2>({3, Basis::Legendre, Quadrature::GaussLobatto},
+                          {3, Basis::Legendre, Quadrature::GaussLobatto},
+                          make_array<2>(ChildSize::Full)));
+  CHECK_FALSE(
+      needs_projection<3>({3, Basis::Legendre, Quadrature::GaussLobatto},
+                          {3, Basis::Legendre, Quadrature::GaussLobatto},
+                          make_array<3>(ChildSize::Full)));
+  CHECK(needs_projection<1>({3, Basis::Legendre, Quadrature::GaussLobatto},
+                            {4, Basis::Legendre, Quadrature::GaussLobatto},
+                            make_array<1>(ChildSize::Full)));
+  CHECK(needs_projection<1>({3, Basis::Legendre, Quadrature::GaussLobatto},
+                            {3, Basis::Legendre, Quadrature::Gauss},
+                            make_array<1>(ChildSize::Full)));
+  CHECK(needs_projection<1>({3, Basis::Legendre, Quadrature::GaussLobatto},
+                            {3, Basis::Legendre, Quadrature::GaussLobatto},
+                            {{ChildSize::LowerHalf}}));
+  CHECK(needs_projection<2>({3, Basis::Legendre, Quadrature::GaussLobatto},
+                            {3, Basis::Legendre, Quadrature::GaussLobatto},
+                            {{ChildSize::Full, ChildSize::LowerHalf}}));
+  CHECK(needs_projection<3>(
+      {3, Basis::Legendre, Quadrature::GaussLobatto},
+      {3, Basis::Legendre, Quadrature::GaussLobatto},
+      {{ChildSize::Full, ChildSize::Full, ChildSize::UpperHalf}}));
 }
 
 void test_p_mortar_to_element() {
@@ -364,6 +398,7 @@ void test_higher_dimensions() {
 SPECTRE_TEST_CASE("Unit.Numerical.Spectral.Projection",
                   "[NumericalAlgorithms][Spectral][Unit]") {
   test_mortar_size();
+  test_needs_projection();
   test_p_mortar_to_element();
   test_p_element_to_mortar();
   test_h_mortar_to_element();
@@ -372,3 +407,5 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.Projection",
   test_higher_dimensions<2>();
   test_higher_dimensions<3>();
 }
+
+}  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Projection.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Projection.cpp
@@ -35,12 +35,9 @@ void test_mortar_size() {
   CHECK(get_output(Spectral::MortarSize::UpperHalf) == "UpperHalf");
   CHECK(get_output(Spectral::MortarSize::LowerHalf) == "LowerHalf");
 }
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Numerical.Spectral.Projection.p.mortar_to_element",
-                  "[NumericalAlgorithms][Spectral][Unit]") {
-  test_mortar_size();
-
+void test_p_mortar_to_element() {
+  INFO("p - mortar to element");
   for (const auto& quadrature_dest : quadratures) {
     for (size_t num_points_dest = 2;
          num_points_dest <=
@@ -93,8 +90,8 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.Projection.p.mortar_to_element",
   }
 }
 
-SPECTRE_TEST_CASE("Unit.Numerical.Spectral.Projection.p.element_to_mortar",
-                  "[NumericalAlgorithms][Spectral][Unit]") {
+void test_p_element_to_mortar() {
+  INFO("p - element to mortar");
   for (const auto& quadrature_dest : quadratures) {
     for (size_t num_points_dest = 2;
          num_points_dest <=
@@ -131,7 +128,6 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.Projection.p.element_to_mortar",
   }
 }
 
-namespace {
 DataVector to_upper_half(const DataVector& p) noexcept {
   return 0.5 * (p + 1.);
 }
@@ -228,10 +224,9 @@ void check_mortar_to_element_projection(const Spectral::MortarSize mortar_size,
     }
   }
 }
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Numerical.Spectral.Projection.h.mortar_to_element",
-                  "[NumericalAlgorithms][Spectral][Unit]") {
+void test_h_mortar_to_element() {
+  INFO("h - mortar to element");
   for (const auto& quadrature_dest : quadratures) {
     for (size_t num_points_dest = 2;
          // We need one extra point to do the quadrature later.
@@ -262,8 +257,8 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.Projection.h.mortar_to_element",
   }
 }
 
-SPECTRE_TEST_CASE("Unit.Numerical.Spectral.Projection.h.element_to_mortar",
-                  "[NumericalAlgorithms][Spectral][Unit]") {
+void test_h_element_to_mortar() {
+  INFO("h - element to mortar");
   for (const auto& quadrature_dest : quadratures) {
     for (size_t num_points_dest = 2;
          num_points_dest <=
@@ -310,4 +305,15 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.Projection.h.element_to_mortar",
       }
     }
   }
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Numerical.Spectral.Projection",
+                  "[NumericalAlgorithms][Spectral][Unit]") {
+  test_mortar_size();
+  test_p_mortar_to_element();
+  test_p_element_to_mortar();
+  test_h_mortar_to_element();
+  test_h_element_to_mortar();
 }


### PR DESCRIPTION
## Proposed changes

These operators can be used to project data across AMR levels. They are essentially moved from `MortarHelpers`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
