### PR TITLE
Move factory information to the metavariables

### DIFF
--- a/docs/DevGuide/OptionParsing.md
+++ b/docs/DevGuide/OptionParsing.md
@@ -84,13 +84,22 @@ Example:
 
 The factory interface creates an object of type
 `std::unique_ptr<Base>` containing a pointer to some class derived
-from `Base`.  The base class must define a type alias listing the
-derived classes that can be created.
-\code{cpp}
- using creatable_classes = tmpl::list<Derived1, ...>;
-\endcode
-The requested derived class is created in the same way as an
-explicitly constructible class.
+from `Base`.  The list of creatable derived classes is specified in
+the `factory_creation` struct in the metavariables, which must contain
+a `factory_classes` type alias that is a `tmpl::map` from base classes
+to lists of derived classes:
+\snippet Test_Factory.cpp factory_creation
+
+When a `std::unique_ptr<Base>` is requested, the factory will expect a
+single YAML argument specifying the name of the class (as given by a
+static `name()` function or, lacking that, the actual class name).  If
+the derived class takes no arguments, the name can be given as a YAML
+string, otherwise it must be given as a single key-value pair, with
+the key the name of the class.  The value portion of this pair is then
+used to create the requested derived class in the same way as an
+explicitly constructible class.  Examples:
+\snippet Test_Factory.cpp factory_without_arguments
+\snippet Test_Factory.cpp factory_with_arguments
 
 \anchor custom-parsing
 ## Custom parsing

--- a/src/Domain/Creators/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/Creators/RegisterDerivedWithCharm.cpp
@@ -68,6 +68,6 @@ void register_derived_with_charm() {
   using maps_to_register =
       tmpl::remove_duplicates<tmpl::append<all_maps, maps_to_grid>>;
 
-  Parallel::register_classes_in_list<maps_to_register>();
+  Parallel::register_classes_with_charm(maps_to_register{});
 }
 }  // namespace domain::creators

--- a/src/Domain/Creators/TimeDependence/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/Creators/TimeDependence/RegisterDerivedWithCharm.cpp
@@ -38,7 +38,7 @@ void register_maps_with_charm() noexcept {
           domain::CoordinateMap<Frame::Grid, Frame::Inertial,
                                 CoordinateMaps::Identity<Dim>>>>>;
 
-  Parallel::register_classes_in_list<maps_to_register>();
+  Parallel::register_classes_with_charm(maps_to_register{});
 }
 }  // namespace
 

--- a/src/Domain/FunctionsOfTime/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/FunctionsOfTime/RegisterDerivedWithCharm.cpp
@@ -15,11 +15,10 @@
 namespace domain {
 namespace FunctionsOfTime {
 void register_derived_with_charm() noexcept {
-  using to_register = tmpl::list<FunctionsOfTime::PiecewisePolynomial<2>,
-                                 FunctionsOfTime::PiecewisePolynomial<3>,
-                                 FunctionsOfTime::PiecewisePolynomial<4>,
-                                 FunctionsOfTime::SettleToConstant>;
-  Parallel::register_classes_in_list<to_register>();
+  Parallel::register_classes_with_charm<FunctionsOfTime::PiecewisePolynomial<2>,
+                                        FunctionsOfTime::PiecewisePolynomial<3>,
+                                        FunctionsOfTime::PiecewisePolynomial<4>,
+                                        FunctionsOfTime::SettleToConstant>();
 }
 }  // namespace FunctionsOfTime
 }  // namespace domain

--- a/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
+++ b/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
@@ -62,6 +62,12 @@
 #include "Utilities/Functional.hpp"
 #include "Utilities/TMPL.hpp"
 
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
 namespace SolveElasticity::OptionTags {
 struct LinearSolverGroup {
   static std::string name() noexcept { return "LinearSolver"; }
@@ -265,6 +271,9 @@ struct Metavariables {
             "value?");
     }
   }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{

--- a/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
@@ -58,6 +58,12 @@
 #include "Utilities/Functional.hpp"
 #include "Utilities/TMPL.hpp"
 
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
 namespace SolvePoisson::OptionTags {
 struct LinearSolverGroup {
   static std::string name() noexcept { return "LinearSolver"; }
@@ -249,6 +255,9 @@ struct Metavariables {
             "value?");
     }
   }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -90,6 +90,9 @@
 namespace Frame {
 struct Inertial;
 }  // namespace Frame
+namespace PUP {
+class er;
+}  // namespace PUP
 namespace Parallel {
 template <typename Metavariables>
 class CProxy_GlobalCache;
@@ -292,6 +295,9 @@ struct EvolutionMetavars {
             "value?");
     }
   }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -38,6 +38,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/LocalLaxFriedrichs.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "Options/Options.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
@@ -75,6 +76,7 @@
 #include "Time/StepChoosers/PreventRapidIncrease.hpp"  // IWYU pragma: keep
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/StepChoosers/StepToTimes.hpp"
+#include "Time/StepControllers/Factory.hpp"
 #include "Time/StepControllers/StepController.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSequence.hpp"
@@ -82,6 +84,7 @@
 #include "Time/Triggers/TimeTriggers.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 // IWYU pragma: no_include <pup.h>
@@ -157,6 +160,12 @@ struct EvolutionMetavars {
 
   using observed_reduction_data_tags = observers::collect_reduction_data_tags<
       typename Event<events>::creatable_classes>;
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<StepController, StepControllers::standard_step_controllers>>;
+  };
 
   using step_actions = tmpl::flatten<tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
@@ -314,13 +323,13 @@ static const std::vector<void (*)()> charm_init_node_funcs{
         StepChooser<metavariables::slab_choosers>>,
     &Parallel::register_derived_classes_with_charm<
         StepChooser<metavariables::step_choosers>>,
-    &Parallel::register_derived_classes_with_charm<StepController>,
     &Parallel::register_derived_classes_with_charm<TimeSequence<double>>,
     &Parallel::register_derived_classes_with_charm<TimeSequence<std::uint64_t>>,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<
         Trigger<metavariables::triggers>>,
     &Parallel::register_derived_classes_with_charm<
-        PhaseChange<metavariables::phase_changes>>};
+        PhaseChange<metavariables::phase_changes>>,
+    &Parallel::register_factory_classes_with_charm<metavariables>};
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};

--- a/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
+++ b/src/Evolution/Executables/Cce/CharacteristicExtract.hpp
@@ -37,6 +37,12 @@
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
 template <template <typename> class BoundaryComponent>
 struct EvolutionMetavars {
   using system = Cce::System;
@@ -125,6 +131,9 @@ struct EvolutionMetavars {
       return Phase::Exit;
     }
   }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -129,6 +129,9 @@ namespace Frame {
 // IWYU pragma: no_forward_declare MathFunction
 struct Inertial;
 }  // namespace Frame
+namespace PUP {
+class er;
+}  // namespace PUP
 namespace Parallel {
 template <typename Metavariables>
 class CProxy_GlobalCache;
@@ -468,6 +471,9 @@ struct EvolutionMetavars {
             "value?");
     }
   }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -66,6 +66,7 @@
 #include "NumericalAlgorithms/Interpolation/Tags.hpp"
 #include "NumericalAlgorithms/Interpolation/TryToInterpolate.hpp"
 #include "Options/Options.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/Algorithms/AlgorithmSingleton.hpp"
@@ -113,6 +114,7 @@
 #include "Time/StepChoosers/PreventRapidIncrease.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/StepChoosers/StepToTimes.hpp"
+#include "Time/StepControllers/Factory.hpp"
 #include "Time/StepControllers/StepController.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSequence.hpp"
@@ -122,6 +124,7 @@
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/Functional.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -253,6 +256,12 @@ struct EvolutionMetavars {
   using observed_reduction_data_tags = observers::collect_reduction_data_tags<
       tmpl::push_back<typename Event<observation_events>::creatable_classes,
                       typename AhA::post_horizon_find_callback>>;
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<StepController, StepControllers::standard_step_controllers>>;
+  };
 
   using step_actions = tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
@@ -489,14 +498,14 @@ static const std::vector<void (*)()> charm_init_node_funcs{
         StepChooser<metavariables::slab_choosers>>,
     &Parallel::register_derived_classes_with_charm<
         StepChooser<metavariables::step_choosers>>,
-    &Parallel::register_derived_classes_with_charm<StepController>,
     &Parallel::register_derived_classes_with_charm<TimeSequence<double>>,
     &Parallel::register_derived_classes_with_charm<TimeSequence<std::uint64_t>>,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<
         Trigger<metavariables::triggers>>,
     &Parallel::register_derived_classes_with_charm<
-        PhaseChange<metavariables::phase_changes>>};
+        PhaseChange<metavariables::phase_changes>>,
+    &Parallel::register_factory_classes_with_charm<metavariables>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -62,6 +62,7 @@
 #include "NumericalAlgorithms/Interpolation/Tags.hpp"
 #include "NumericalAlgorithms/Interpolation/TryToInterpolate.hpp"
 #include "Options/Options.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/Algorithms/AlgorithmSingleton.hpp"
@@ -115,6 +116,7 @@
 #include "Time/StepChoosers/PreventRapidIncrease.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/StepChoosers/StepToTimes.hpp"
+#include "Time/StepControllers/Factory.hpp"
 #include "Time/StepControllers/StepController.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSequence.hpp"
@@ -123,6 +125,7 @@
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/Functional.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -238,6 +241,12 @@ struct EvolutionMetavars {
       observers::collect_reduction_data_tags<tmpl::push_back<
           typename Event<observation_events>::creatable_classes,
           typename InterpolationTargetTags::post_interpolation_callback...>>;
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<StepController, StepControllers::standard_step_controllers>>;
+  };
 
   using step_actions = tmpl::flatten<tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
@@ -456,14 +465,14 @@ static const std::vector<void (*)()> charm_init_node_funcs{
         StepChooser<metavariables::slab_choosers>>,
     &Parallel::register_derived_classes_with_charm<
         StepChooser<metavariables::step_choosers>>,
-    &Parallel::register_derived_classes_with_charm<StepController>,
     &Parallel::register_derived_classes_with_charm<TimeSequence<double>>,
     &Parallel::register_derived_classes_with_charm<TimeSequence<std::uint64_t>>,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<
         Trigger<metavariables::triggers>>,
     &Parallel::register_derived_classes_with_charm<
-        PhaseChange<metavariables::phase_changes>>};
+        PhaseChange<metavariables::phase_changes>>,
+    &Parallel::register_factory_classes_with_charm<metavariables>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -129,6 +129,9 @@
 namespace Frame {
 struct Inertial;
 }  // namespace Frame
+namespace PUP {
+class er;
+}  // namespace PUP
 namespace Parallel {
 template <typename Metavariables>
 class CProxy_GlobalCache;
@@ -411,6 +414,9 @@ struct EvolutionMetavars {
             "value?");
     }
   }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 struct KerrHorizon {

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -93,6 +93,9 @@
 namespace Frame {
 struct Inertial;
 }  // namespace Frame
+namespace PUP {
+class er;
+}  // namespace PUP
 namespace Parallel {
 template <typename Metavariables>
 class CProxy_GlobalCache;
@@ -324,6 +327,9 @@ struct EvolutionMetavars {
             "value?");
     }
   }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -41,6 +41,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "Options/Options.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/InitializationFunctions.hpp"
@@ -79,6 +80,7 @@
 #include "Time/StepChoosers/PreventRapidIncrease.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/StepChoosers/StepToTimes.hpp"
+#include "Time/StepControllers/Factory.hpp"
 #include "Time/StepControllers/StepController.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSequence.hpp"
@@ -87,6 +89,7 @@
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/Functional.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -182,6 +185,12 @@ struct EvolutionMetavars {
 
   using observed_reduction_data_tags = observers::collect_reduction_data_tags<
       typename Event<events>::creatable_classes>;
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<StepController, StepControllers::standard_step_controllers>>;
+  };
 
   using step_actions = tmpl::flatten<tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
@@ -346,14 +355,14 @@ static const std::vector<void (*)()> charm_init_node_funcs{
         StepChooser<metavariables::slab_choosers>>,
     &Parallel::register_derived_classes_with_charm<
         StepChooser<metavariables::step_choosers>>,
-    &Parallel::register_derived_classes_with_charm<StepController>,
     &Parallel::register_derived_classes_with_charm<TimeSequence<double>>,
     &Parallel::register_derived_classes_with_charm<TimeSequence<std::uint64_t>>,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<
         Trigger<metavariables::triggers>>,
     &Parallel::register_derived_classes_with_charm<
-        PhaseChange<metavariables::phase_changes>>};
+        PhaseChange<metavariables::phase_changes>>,
+    &Parallel::register_factory_classes_with_charm<metavariables>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -42,6 +42,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/LocalLaxFriedrichs.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "Options/Options.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/InitializationFunctions.hpp"
@@ -81,6 +82,7 @@
 #include "Time/StepChoosers/PreventRapidIncrease.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/StepChoosers/StepToTimes.hpp"
+#include "Time/StepControllers/Factory.hpp"
 #include "Time/StepControllers/StepController.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSequence.hpp"
@@ -89,6 +91,7 @@
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/Functional.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -183,6 +186,12 @@ struct EvolutionMetavars {
 
   using observed_reduction_data_tags = observers::collect_reduction_data_tags<
       typename Event<events>::creatable_classes>;
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<StepController, StepControllers::standard_step_controllers>>;
+  };
 
   using step_actions = tmpl::flatten<tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
@@ -365,14 +374,14 @@ static const std::vector<void (*)()> charm_init_node_funcs{
         StepChooser<metavariables::slab_choosers>>,
     &Parallel::register_derived_classes_with_charm<
         StepChooser<metavariables::step_choosers>>,
-    &Parallel::register_derived_classes_with_charm<StepController>,
     &Parallel::register_derived_classes_with_charm<TimeSequence<double>>,
     &Parallel::register_derived_classes_with_charm<TimeSequence<std::uint64_t>>,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<
         Trigger<metavariables::triggers>>,
     &Parallel::register_derived_classes_with_charm<
-        PhaseChange<metavariables::phase_changes>>};
+        PhaseChange<metavariables::phase_changes>>,
+    &Parallel::register_factory_classes_with_charm<metavariables>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -95,6 +95,9 @@
 namespace Frame {
 struct Inertial;
 }  // namespace Frame
+namespace PUP {
+class er;
+}  // namespace PUP
 namespace Parallel {
 template <typename Metavariables>
 class CProxy_GlobalCache;
@@ -345,6 +348,9 @@ struct EvolutionMetavars {
             "value?");
     }
   }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -94,6 +94,9 @@
 namespace Frame {
 struct Inertial;
 }  // namespace Frame
+namespace PUP {
+class er;
+}  // namespace PUP
 namespace Parallel {
 template <typename Metavariables>
 class CProxy_GlobalCache;
@@ -362,6 +365,9 @@ struct EvolutionMetavars {
             "value?");
     }
   }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -41,6 +41,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/LocalLaxFriedrichs.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "Options/Options.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/InitializationFunctions.hpp"
@@ -80,6 +81,7 @@
 #include "Time/StepChoosers/PreventRapidIncrease.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/StepChoosers/StepToTimes.hpp"
+#include "Time/StepControllers/Factory.hpp"
 #include "Time/StepControllers/StepController.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSequence.hpp"
@@ -88,6 +90,7 @@
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/Functional.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -192,6 +195,12 @@ struct EvolutionMetavars {
 
   using observed_reduction_data_tags = observers::collect_reduction_data_tags<
       typename Event<events>::creatable_classes>;
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<StepController, StepControllers::standard_step_controllers>>;
+  };
 
   using step_actions = tmpl::flatten<tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
@@ -382,14 +391,14 @@ static const std::vector<void (*)()> charm_init_node_funcs{
         StepChooser<metavariables::slab_choosers>>,
     &Parallel::register_derived_classes_with_charm<
         StepChooser<metavariables::step_choosers>>,
-    &Parallel::register_derived_classes_with_charm<StepController>,
     &Parallel::register_derived_classes_with_charm<TimeSequence<double>>,
     &Parallel::register_derived_classes_with_charm<TimeSequence<std::uint64_t>>,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<
         Trigger<metavariables::triggers>>,
     &Parallel::register_derived_classes_with_charm<
-        PhaseChange<metavariables::phase_changes>>};
+        PhaseChange<metavariables::phase_changes>>,
+    &Parallel::register_factory_classes_with_charm<metavariables>};
 
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -94,6 +94,9 @@ namespace Parallel {
 template <typename Metavariables>
 class CProxy_GlobalCache;
 }  // namespace Parallel
+namespace PUP {
+class er;
+}  // namespace PUP
 /// \endcond
 
 template <size_t Dim, typename InitialData>
@@ -288,6 +291,9 @@ struct EvolutionMetavars {
             "value?");
     }
   }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -306,7 +306,6 @@ static const std::vector<void (*)()> charm_init_node_funcs{
         StepChooser<metavariables::slab_choosers>>,
     &Parallel::register_derived_classes_with_charm<
         StepChooser<metavariables::step_choosers>>,
-    &ScalarWave::BoundaryCorrections::register_derived_with_charm,
     &Parallel::register_derived_classes_with_charm<StepController>,
     &Parallel::register_derived_classes_with_charm<TimeSequence<double>>,
     &Parallel::register_derived_classes_with_charm<TimeSequence<std::uint64_t>>,

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/RegisterDerivedWithCharm.cpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/RegisterDerivedWithCharm.cpp
@@ -11,7 +11,6 @@
 
 namespace Burgers::BoundaryConditions {
 void register_derived_with_charm() noexcept {
-  Parallel::register_classes_in_list<
-      typename BoundaryCondition::creatable_classes>();
+  Parallel::register_derived_classes_with_charm<BoundaryCondition>();
 }
 }  // namespace Burgers::BoundaryConditions

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/RegisterDerivedWithCharm.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/RegisterDerivedWithCharm.cpp
@@ -9,11 +9,8 @@
 
 namespace GeneralizedHarmonic::BoundaryConditions {
 void register_derived_with_charm() noexcept {
-  Parallel::register_classes_in_list<
-      typename BoundaryCondition<1>::creatable_classes>();
-  Parallel::register_classes_in_list<
-      typename BoundaryCondition<2>::creatable_classes>();
-  Parallel::register_classes_in_list<
-      typename BoundaryCondition<3>::creatable_classes>();
+  Parallel::register_derived_classes_with_charm<BoundaryCondition<1>>();
+  Parallel::register_derived_classes_with_charm<BoundaryCondition<2>>();
+  Parallel::register_derived_classes_with_charm<BoundaryCondition<3>>();
 }
 }  // namespace GeneralizedHarmonic::BoundaryConditions

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/RegisterDerivedWithCharm.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/RegisterDerivedWithCharm.cpp
@@ -15,8 +15,7 @@ namespace GeneralizedHarmonic::ConstraintDamping {
 namespace {
 template <size_t Dim, typename Fr>
 void register_damping_functions_with_charm() noexcept {
-  Parallel::register_classes_in_list<
-      typename DampingFunction<Dim, Fr>::creatable_classes>();
+  Parallel::register_derived_classes_with_charm<DampingFunction<Dim, Fr>>();
 }
 }  // namespace
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/RegisterDerivedWithCharm.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/RegisterDerivedWithCharm.cpp
@@ -9,7 +9,6 @@
 
 namespace grmhd::ValenciaDivClean::BoundaryConditions {
 void register_derived_with_charm() noexcept {
-  Parallel::register_classes_in_list<
-      typename BoundaryCondition::creatable_classes>();
+  Parallel::register_derived_classes_with_charm<BoundaryCondition>();
 }
 }  // namespace grmhd::ValenciaDivClean::BoundaryConditions

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/RegisterDerivedWithCharm.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/RegisterDerivedWithCharm.cpp
@@ -9,11 +9,8 @@
 
 namespace NewtonianEuler::BoundaryConditions {
 void register_derived_with_charm() noexcept {
-  Parallel::register_classes_in_list<
-      typename BoundaryCondition<1>::creatable_classes>();
-  Parallel::register_classes_in_list<
-      typename BoundaryCondition<2>::creatable_classes>();
-  Parallel::register_classes_in_list<
-      typename BoundaryCondition<3>::creatable_classes>();
+  Parallel::register_derived_classes_with_charm<BoundaryCondition<1>>();
+  Parallel::register_derived_classes_with_charm<BoundaryCondition<2>>();
+  Parallel::register_derived_classes_with_charm<BoundaryCondition<3>>();
 }
 }  // namespace NewtonianEuler::BoundaryConditions

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/RegisterDerivedWithCharm.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/RegisterDerivedWithCharm.cpp
@@ -9,11 +9,8 @@
 
 namespace RelativisticEuler::Valencia::BoundaryConditions {
 void register_derived_with_charm() noexcept {
-  Parallel::register_classes_in_list<
-      typename BoundaryCondition<1>::creatable_classes>();
-  Parallel::register_classes_in_list<
-      typename BoundaryCondition<2>::creatable_classes>();
-  Parallel::register_classes_in_list<
-      typename BoundaryCondition<3>::creatable_classes>();
+  Parallel::register_derived_classes_with_charm<BoundaryCondition<1>>();
+  Parallel::register_derived_classes_with_charm<BoundaryCondition<2>>();
+  Parallel::register_derived_classes_with_charm<BoundaryCondition<3>>();
 }
 }  // namespace RelativisticEuler::Valencia::BoundaryConditions

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/RegisterDerivedWithCharm.cpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/RegisterDerivedWithCharm.cpp
@@ -11,11 +11,8 @@
 
 namespace ScalarWave::BoundaryConditions {
 void register_derived_with_charm() noexcept {
-  Parallel::register_classes_in_list<
-      typename BoundaryCondition<1>::creatable_classes>();
-  Parallel::register_classes_in_list<
-      typename BoundaryCondition<2>::creatable_classes>();
-  Parallel::register_classes_in_list<
-      typename BoundaryCondition<3>::creatable_classes>();
+  Parallel::register_derived_classes_with_charm<BoundaryCondition<1>>();
+  Parallel::register_derived_classes_with_charm<BoundaryCondition<2>>();
+  Parallel::register_derived_classes_with_charm<BoundaryCondition<3>>();
 }
 }  // namespace ScalarWave::BoundaryConditions

--- a/src/Executables/Examples/HelloWorld/SingletonHelloWorld.hpp
+++ b/src/Executables/Examples/HelloWorld/SingletonHelloWorld.hpp
@@ -18,6 +18,10 @@
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/System/ParallelInfo.hpp"
 #include "Utilities/TMPL.hpp"
+
+namespace PUP {
+class er;
+}  // namespace PUP
 /// [executable_example_includes]
 
 /// [executable_example_options]
@@ -101,6 +105,9 @@ struct Metavars {
     return current_phase == Phase::Initialization ? Phase::Execute
                                                   : Phase::Exit;
   }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 /// [executable_example_metavariables]
 

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -255,6 +255,9 @@ struct Metavariables {
         ERROR("Unknown type of phase.");
     }
   }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{

--- a/src/Options/CMakeLists.txt
+++ b/src/Options/CMakeLists.txt
@@ -32,3 +32,5 @@ target_link_libraries(
   Utilities
   YamlCpp
   )
+
+add_subdirectory(Protocols)

--- a/src/Options/Factory.hpp
+++ b/src/Options/Factory.hpp
@@ -15,7 +15,9 @@
 #include <yaml-cpp/yaml.h>
 
 #include "Options/Options.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/StdHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -51,16 +53,41 @@ struct print_derived {
   }
 };
 
-template <typename BaseClass>
+template <typename CreatableClasses>
 std::string help_derived() noexcept {
   return "Known Ids:\n" +
-         tmpl::for_each<typename BaseClass::creatable_classes>(
+         tmpl::for_each<CreatableClasses>(
              Factory_detail::print_derived{})
              .value;
 }
 
+// This is for handling legacy code that still uses creatable_classes.
+// It should be inlined once everything is converted.
+template <typename BaseClass, typename Metavariables, typename = std::void_t<>>
+struct get_creatable_classes {
+  using factory_creation = typename Metavariables::factory_creation;
+  // This assertion is normally done in tests, but the executable
+  // metavariables don't have tests, so we do it here.
+  static_assert(tt::assert_conforms_to<factory_creation,
+                                       Options::protocols::FactoryCreation>);
+  using type = tmpl::at<typename factory_creation::factory_classes, BaseClass>;
+};
+
+template <typename BaseClass, typename Metavariables>
+struct get_creatable_classes<
+  BaseClass, Metavariables,
+  std::void_t<typename BaseClass::creatable_classes>> {
+  using type = typename BaseClass::creatable_classes;
+};
+
 template <typename BaseClass, typename Metavariables>
 std::unique_ptr<BaseClass> create(const Option& options) {
+  using creatable_classes =
+      typename get_creatable_classes<BaseClass, Metavariables>::type;
+  static_assert(not std::is_same_v<creatable_classes, tmpl::no_such_type_>,
+                "List of creatable derived types for this class is missing "
+                "from Metavariables::factory_classes.");
+
   const auto& node = options.node();
   Option derived_opts(options.context());
   derived_opts.append_context("While operating factory for " +
@@ -78,7 +105,8 @@ std::unique_ptr<BaseClass> create(const Option& options) {
     derived_opts.set_node(node.begin()->second);
   } else if (node.IsNull()) {
     PARSE_ERROR(derived_opts.context(),
-                "Expected a class to create:\n" << help_derived<BaseClass>());
+                "Expected a class to create:\n"
+                << help_derived<creatable_classes>());
   } else {
     PARSE_ERROR(derived_opts.context(),
                 "Expected a class or a class with options, got:\n"
@@ -86,7 +114,7 @@ std::unique_ptr<BaseClass> create(const Option& options) {
   }
 
   std::unique_ptr<BaseClass> result;
-  tmpl::for_each<typename BaseClass::creatable_classes>(
+  tmpl::for_each<creatable_classes>(
       [&id, &derived_opts, &result](auto derived_v) {
         using Derived = tmpl::type_from<decltype(derived_v)>;
         if (name<Derived>() == id) {
@@ -99,7 +127,8 @@ std::unique_ptr<BaseClass> create(const Option& options) {
     return result;
   }
   PARSE_ERROR(derived_opts.context(),
-              "Unknown Id '" << id << "'\n" << help_derived<BaseClass>());
+              "Unknown Id '" << id << "'\n"
+              << help_derived<creatable_classes>());
 }
 }  // namespace Factory_detail
 

--- a/src/Options/Protocols/CMakeLists.txt
+++ b/src/Options/Protocols/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  FactoryCreation.hpp
+  )

--- a/src/Options/Protocols/FactoryCreation.hpp
+++ b/src/Options/Protocols/FactoryCreation.hpp
@@ -1,0 +1,49 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <type_traits>
+
+#include "Utilities/TMPL.hpp"
+
+namespace Options::protocols {
+/*!
+ * \brief Compile-time information for factory-creation
+ *
+ * A class conforming to this protocol is placed in the metavariables
+ * to provide information on the set of derived classes for each
+ * factory-creatable base class.  The conforming class must provide
+ * the following type aliases:
+ *
+ * - `factory_classes`: A `tmpl::map` from the base class to the list
+ *   of derived classes. List all derived classes that should be
+ *   factory-creatable, e.g. through input-file options.
+ *
+ * Here's an example for a class conforming to this protocol:
+ *
+ * \snippet Test_Factory.cpp factory_creation
+ */
+struct FactoryCreation {
+  template <typename ConformingType>
+  struct test {
+    using factory_classes = typename ConformingType::factory_classes;
+
+    template <typename BaseClass, typename DerivedClass>
+    struct factory_class_is_derived_from_base_class : std::true_type {
+      static_assert(std::is_base_of_v<BaseClass, DerivedClass>,
+                    "FactoryCreation protocol: The first template argument to "
+                    "this struct is not a base class of the second.");
+    };
+
+    using all_classes_are_derived_classes = tmpl::all<
+        factory_classes,
+        tmpl::bind<
+            tmpl::all, tmpl::bind<tmpl::back, tmpl::_1>,
+            tmpl::defer<factory_class_is_derived_from_base_class<
+                tmpl::bind<tmpl::front, tmpl::parent<tmpl::_1>>, tmpl::_1>>>>;
+
+    static_assert(all_classes_are_derived_classes::value);
+  };
+};
+}  // namespace Options::protocols

--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -30,6 +30,7 @@
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/PupStlCpp11.hpp"
 #include "Parallel/SimpleActionVisitation.hpp"
+#include "Parallel/Tags/Metavariables.hpp"
 #include "Parallel/TypeTraits.hpp"
 #include "Utilities/BoostHelpers.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
@@ -584,6 +585,7 @@ class AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>
 
   using all_cache_tags = get_const_global_cache_tags<metavariables>;
   using initial_databox = db::compute_databox_type<tmpl::flatten<tmpl::list<
+      Tags::MetavariablesImpl<metavariables>,
       Tags::GlobalCacheImpl<metavariables>,
       typename ParallelComponent::initialization_tags,
       db::wrap_tags_in<Tags::FromGlobalCache, all_cache_tags>>>>;
@@ -643,10 +645,12 @@ AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>::
   global_cache_ = global_cache_proxy.ckLocalBranch();
   box_ = db::create<
       db::AddSimpleTags<tmpl::flatten<
-          tmpl::list<Tags::GlobalCacheImpl<metavariables>,
+          tmpl::list<Tags::MetavariablesImpl<metavariables>,
+                     Tags::GlobalCacheImpl<metavariables>,
                      typename ParallelComponent::initialization_tags>>>,
       db::AddComputeTags<
           db::wrap_tags_in<Tags::FromGlobalCache, all_cache_tags>>>(
+          metavariables{},
           global_cache_,
       std::move(get<InitializationTags>(initialization_items))...);
 }

--- a/src/Parallel/CMakeLists.txt
+++ b/src/Parallel/CMakeLists.txt
@@ -68,3 +68,4 @@ add_dependencies(
 add_subdirectory(Actions)
 add_subdirectory(Algorithms)
 add_subdirectory(PhaseControl)
+add_subdirectory(Tags)

--- a/src/Parallel/PhaseControl/PhaseChange.hpp
+++ b/src/Parallel/PhaseControl/PhaseChange.hpp
@@ -14,6 +14,7 @@
 #include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
 #include "Utilities/FakeVirtual.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/Registration.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 

--- a/src/Parallel/RegisterDerivedClassesWithCharm.hpp
+++ b/src/Parallel/RegisterDerivedClassesWithCharm.hpp
@@ -13,22 +13,26 @@
 #include "Utilities/TMPL.hpp"
 
 namespace Parallel {
-/// Register the classes in `ListOfClassesToRegister` with the serialization
-/// framework.
-template <typename ListOfClassesToRegister>
-void register_classes_in_list() noexcept {
-  tmpl::for_each<ListOfClassesToRegister>([](auto class_v) noexcept {
+/// Register specified classes.  This function can either take classes
+/// to register as template arguments or take a `tmpl::list` of
+/// classes as a function argument.
+template <typename... Registrants>
+void register_classes_with_charm(
+    const tmpl::list<Registrants...> /*meta*/ = {}) noexcept {
+  const auto helper = [](auto class_v) noexcept {
     using class_to_register = typename decltype(class_v)::type;
     // We use PUPable_reg2 because this takes as a second argument the name of
     // the class as a `const char*`, while PUPable_reg converts the argument
     // verbatim to a string using the `#` preprocessor operator.
     PUPable_reg2(class_to_register, typeid(class_to_register).name());
-  });
+  };
+  (void)helper;
+  EXPAND_PACK_LEFT_TO_RIGHT(helper(tmpl::type_<Registrants>{}));
 }
 
 /// Register derived classes of the `Base` class
 template <typename Base>
 void register_derived_classes_with_charm() noexcept {
-  register_classes_in_list<typename Base::creatable_classes>();
+  register_classes_with_charm(typename Base::creatable_classes{});
 }
 }  // namespace Parallel

--- a/src/Parallel/RegisterDerivedClassesWithCharm.hpp
+++ b/src/Parallel/RegisterDerivedClassesWithCharm.hpp
@@ -35,4 +35,12 @@ template <typename Base>
 void register_derived_classes_with_charm() noexcept {
   register_classes_with_charm(typename Base::creatable_classes{});
 }
+
+/// Register all classes in Metavariables::factory_classes
+template <typename Metavariables>
+void register_factory_classes_with_charm() noexcept {
+  register_classes_with_charm(
+      tmpl::flatten<tmpl::values_as_sequence<
+          typename Metavariables::factory_creation::factory_classes>>{});
+}
 }  // namespace Parallel

--- a/src/Parallel/Tags/CMakeLists.txt
+++ b/src/Parallel/Tags/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Metavariables.hpp
+  )

--- a/src/Parallel/Tags/Metavariables.hpp
+++ b/src/Parallel/Tags/Metavariables.hpp
@@ -1,0 +1,19 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/Tag.hpp"
+
+namespace Parallel::Tags {
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ParallelGroup
+/// Tag to retrieve the `Metavariables` from the DataBox.
+struct Metavariables : db::BaseTag {};
+
+template <typename Metavars>
+struct MetavariablesImpl : Metavariables, db::SimpleTag {
+  using base = Metavariables;
+  using type = Metavars;
+};
+}  // namespace Parallel::Tags

--- a/src/Time/StepControllers/CMakeLists.txt
+++ b/src/Time/StepControllers/CMakeLists.txt
@@ -15,6 +15,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   BinaryFraction.hpp
+  Factory.hpp
   FullSlab.hpp
   SimpleTimes.hpp
   SplitRemaining.hpp

--- a/src/Time/StepControllers/Factory.hpp
+++ b/src/Time/StepControllers/Factory.hpp
@@ -1,0 +1,12 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Time/StepControllers/BinaryFraction.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace StepControllers {
+/// Typelist of standard StepControllers
+using standard_step_controllers = tmpl::list<BinaryFraction>;
+}  // namespace Triggers

--- a/src/Time/StepControllers/StepController.hpp
+++ b/src/Time/StepControllers/StepController.hpp
@@ -15,12 +15,7 @@
 /// \ingroup TimeSteppersGroup
 ///
 /// Holds all the StepControllers
-namespace StepControllers {
-class BinaryFraction;  // IWYU pragma: keep
-class FullSlab;  // IWYU pragma: keep
-class SimpleTimes;  // IWYU pragma: keep
-class SplitRemaining;  // IWYU pragma: keep
-}  // namespace StepControllers
+namespace StepControllers {}
 
 /// \ingroup TimeSteppersGroup
 ///
@@ -29,12 +24,6 @@ class SplitRemaining;  // IWYU pragma: keep
 /// slab requirements.
 class StepController : public PUP::able {
  public:
-  using creatable_classes = tmpl::list<
-    StepControllers::BinaryFraction,
-    StepControllers::FullSlab,
-    StepControllers::SimpleTimes,
-    StepControllers::SplitRemaining>;
-
   /// \cond HIDDEN_SYMBOLS
   WRAPPED_PUPable_abstract(StepController);  // NOLINT
   /// \endcond
@@ -42,8 +31,3 @@ class StepController : public PUP::able {
   virtual TimeDelta choose_step(const Time& time,
                                 double desired_step) const noexcept = 0;
 };
-
-#include "Time/StepControllers/BinaryFraction.hpp"  // IWYU pragma: keep
-#include "Time/StepControllers/FullSlab.hpp"  // IWYU pragma: keep
-#include "Time/StepControllers/SimpleTimes.hpp"  // IWYU pragma: keep
-#include "Time/StepControllers/SplitRemaining.hpp"  // IWYU pragma: keep

--- a/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
+++ b/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
@@ -47,8 +47,8 @@ void test_aligned_blocks(
     const creators::AlignedLattice<VolumeDim>& aligned_lattice,
     const std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>&
         expected_boundary_condition) noexcept {
-  Parallel::register_classes_in_list<
-      typename creators::AlignedLattice<VolumeDim>::maps_list>();
+  Parallel::register_classes_with_charm(
+      typename creators::AlignedLattice<VolumeDim>::maps_list{});
 
   const auto test_impl = [&expected_boundary_condition,
                           &aligned_lattice](const auto& domain) {

--- a/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
+++ b/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
@@ -89,8 +89,9 @@ template <size_t VolumeDim>
 auto make_domain_creator(const std::string& opt_string,
                          const bool use_boundary_condition) {
   if (use_boundary_condition) {
-    return TestHelpers::test_factory_creation<
-        DomainCreator<VolumeDim>, domain::OptionTags::DomainCreator<VolumeDim>,
+    return TestHelpers::test_creation<
+        std::unique_ptr<DomainCreator<VolumeDim>>,
+        domain::OptionTags::DomainCreator<VolumeDim>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithBoundaryConditions<VolumeDim>>(
         opt_string + std::string{"  BoundaryCondition:\n"
@@ -98,8 +99,9 @@ auto make_domain_creator(const std::string& opt_string,
                                  "      Direction: upper-xi\n"
                                  "      BlockId: 100\n"});
   } else {
-    return TestHelpers::test_factory_creation<
-        DomainCreator<VolumeDim>, domain::OptionTags::DomainCreator<VolumeDim>,
+    return TestHelpers::test_creation<
+        std::unique_ptr<DomainCreator<VolumeDim>>,
+        domain::OptionTags::DomainCreator<VolumeDim>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithoutBoundaryConditions<VolumeDim>>(opt_string);
   }
@@ -212,8 +214,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
                         expected_boundary_condition_3d);
   }
 
-  const auto domain_creator_2d_periodic = TestHelpers::test_factory_creation<
-      DomainCreator<2>, domain::OptionTags::DomainCreator<2>,
+  const auto domain_creator_2d_periodic = TestHelpers::test_creation<
+      std::unique_ptr<DomainCreator<2>>, domain::OptionTags::DomainCreator<2>,
       TestHelpers::domain::BoundaryConditions::
           MetavariablesWithoutBoundaryConditions<2>>(
       "AlignedLattice:\n"
@@ -229,8 +231,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
           domain_creator_2d_periodic.get());
   test_aligned_blocks(*aligned_blocks_creator_2d_periodic, nullptr);
 
-  const auto domain_creator_3d_periodic = TestHelpers::test_factory_creation<
-      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+  const auto domain_creator_3d_periodic = TestHelpers::test_creation<
+      std::unique_ptr<DomainCreator<3>>, domain::OptionTags::DomainCreator<3>,
       TestHelpers::domain::BoundaryConditions::
           MetavariablesWithoutBoundaryConditions<3>>(
       "AlignedLattice:\n"
@@ -251,8 +253,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
     // 23 23 67
     // 23 45 67
     // 23 XX 45
-    const auto refined_domain = TestHelpers::test_factory_creation<
-        DomainCreator<2>, domain::OptionTags::DomainCreator<2>,
+    const auto refined_domain = TestHelpers::test_creation<
+        std::unique_ptr<DomainCreator<2>>, domain::OptionTags::DomainCreator<2>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithoutBoundaryConditions<2>>(
         "AlignedLattice:\n"
@@ -303,8 +305,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
     // 25 25 46
     // 25 35 46
     // 25 XX 35
-    const auto refined_domain = TestHelpers::test_factory_creation<
-        DomainCreator<2>, domain::OptionTags::DomainCreator<2>,
+    const auto refined_domain = TestHelpers::test_creation<
+        std::unique_ptr<DomainCreator<2>>, domain::OptionTags::DomainCreator<2>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithoutBoundaryConditions<2>>(
         "AlignedLattice:\n"

--- a/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
+++ b/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
@@ -89,8 +89,7 @@ template <size_t VolumeDim>
 auto make_domain_creator(const std::string& opt_string,
                          const bool use_boundary_condition) {
   if (use_boundary_condition) {
-    return TestHelpers::test_creation<
-        std::unique_ptr<DomainCreator<VolumeDim>>,
+    return TestHelpers::test_option_tag<
         domain::OptionTags::DomainCreator<VolumeDim>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithBoundaryConditions<VolumeDim>>(
@@ -99,8 +98,7 @@ auto make_domain_creator(const std::string& opt_string,
                                  "      Direction: upper-xi\n"
                                  "      BlockId: 100\n"});
   } else {
-    return TestHelpers::test_creation<
-        std::unique_ptr<DomainCreator<VolumeDim>>,
+    return TestHelpers::test_option_tag<
         domain::OptionTags::DomainCreator<VolumeDim>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithoutBoundaryConditions<VolumeDim>>(opt_string);
@@ -214,8 +212,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
                         expected_boundary_condition_3d);
   }
 
-  const auto domain_creator_2d_periodic = TestHelpers::test_creation<
-      std::unique_ptr<DomainCreator<2>>, domain::OptionTags::DomainCreator<2>,
+  const auto domain_creator_2d_periodic = TestHelpers::test_option_tag<
+      domain::OptionTags::DomainCreator<2>,
       TestHelpers::domain::BoundaryConditions::
           MetavariablesWithoutBoundaryConditions<2>>(
       "AlignedLattice:\n"
@@ -231,8 +229,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
           domain_creator_2d_periodic.get());
   test_aligned_blocks(*aligned_blocks_creator_2d_periodic, nullptr);
 
-  const auto domain_creator_3d_periodic = TestHelpers::test_creation<
-      std::unique_ptr<DomainCreator<3>>, domain::OptionTags::DomainCreator<3>,
+  const auto domain_creator_3d_periodic = TestHelpers::test_option_tag<
+      domain::OptionTags::DomainCreator<3>,
       TestHelpers::domain::BoundaryConditions::
           MetavariablesWithoutBoundaryConditions<3>>(
       "AlignedLattice:\n"
@@ -253,8 +251,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
     // 23 23 67
     // 23 45 67
     // 23 XX 45
-    const auto refined_domain = TestHelpers::test_creation<
-        std::unique_ptr<DomainCreator<2>>, domain::OptionTags::DomainCreator<2>,
+    const auto refined_domain = TestHelpers::test_option_tag<
+        domain::OptionTags::DomainCreator<2>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithoutBoundaryConditions<2>>(
         "AlignedLattice:\n"
@@ -305,8 +303,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
     // 25 25 46
     // 25 35 46
     // 25 XX 35
-    const auto refined_domain = TestHelpers::test_creation<
-        std::unique_ptr<DomainCreator<2>>, domain::OptionTags::DomainCreator<2>,
+    const auto refined_domain = TestHelpers::test_option_tag<
+        domain::OptionTags::DomainCreator<2>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithoutBoundaryConditions<2>>(
         "AlignedLattice:\n"

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -418,14 +418,16 @@ std::string create_option_string(const bool excise_A, const bool excise_B,
 void test_bbh_time_dependent_factory(const bool with_boundary_conditions) {
   const auto binary_compact_object = [&with_boundary_conditions]() {
     if (with_boundary_conditions) {
-      return TestHelpers::test_factory_creation<
-          DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      return TestHelpers::test_creation<
+          std::unique_ptr<DomainCreator<3>>,
+          domain::OptionTags::DomainCreator<3>,
           TestHelpers::domain::BoundaryConditions::
               MetavariablesWithBoundaryConditions<3>>(create_option_string(
           true, true, true, false, 0, 0, 0, with_boundary_conditions));
     } else {
-      return TestHelpers::test_factory_creation<
-          DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      return TestHelpers::test_creation<
+          std::unique_ptr<DomainCreator<3>>,
+          domain::OptionTags::DomainCreator<3>,
           TestHelpers::domain::BoundaryConditions::
               MetavariablesWithoutBoundaryConditions<3>>(create_option_string(
           true, true, true, false, 0, 0, 0, with_boundary_conditions));
@@ -494,13 +496,15 @@ void test_binary_factory() {
     const auto binary_compact_object = [&opt_string,
                                         &with_boundary_conditions]() {
       if (with_boundary_conditions) {
-        return TestHelpers::test_factory_creation<
-            DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+        return TestHelpers::test_creation<
+            std::unique_ptr<DomainCreator<3>>,
+            domain::OptionTags::DomainCreator<3>,
             TestHelpers::domain::BoundaryConditions::
                 MetavariablesWithBoundaryConditions<3>>(opt_string);
       } else {
-        return TestHelpers::test_factory_creation<
-            DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+        return TestHelpers::test_creation<
+            std::unique_ptr<DomainCreator<3>>,
+            domain::OptionTags::DomainCreator<3>,
             TestHelpers::domain::BoundaryConditions::
                 MetavariablesWithoutBoundaryConditions<3>>(opt_string);
       }

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -418,15 +418,13 @@ std::string create_option_string(const bool excise_A, const bool excise_B,
 void test_bbh_time_dependent_factory(const bool with_boundary_conditions) {
   const auto binary_compact_object = [&with_boundary_conditions]() {
     if (with_boundary_conditions) {
-      return TestHelpers::test_creation<
-          std::unique_ptr<DomainCreator<3>>,
+      return TestHelpers::test_option_tag<
           domain::OptionTags::DomainCreator<3>,
           TestHelpers::domain::BoundaryConditions::
               MetavariablesWithBoundaryConditions<3>>(create_option_string(
           true, true, true, false, 0, 0, 0, with_boundary_conditions));
     } else {
-      return TestHelpers::test_creation<
-          std::unique_ptr<DomainCreator<3>>,
+      return TestHelpers::test_option_tag<
           domain::OptionTags::DomainCreator<3>,
           TestHelpers::domain::BoundaryConditions::
               MetavariablesWithoutBoundaryConditions<3>>(create_option_string(
@@ -496,14 +494,12 @@ void test_binary_factory() {
     const auto binary_compact_object = [&opt_string,
                                         &with_boundary_conditions]() {
       if (with_boundary_conditions) {
-        return TestHelpers::test_creation<
-            std::unique_ptr<DomainCreator<3>>,
+        return TestHelpers::test_option_tag<
             domain::OptionTags::DomainCreator<3>,
             TestHelpers::domain::BoundaryConditions::
                 MetavariablesWithBoundaryConditions<3>>(opt_string);
       } else {
-        return TestHelpers::test_creation<
-            std::unique_ptr<DomainCreator<3>>,
+        return TestHelpers::test_option_tag<
             domain::OptionTags::DomainCreator<3>,
             TestHelpers::domain::BoundaryConditions::
                 MetavariablesWithoutBoundaryConditions<3>>(opt_string);

--- a/tests/Unit/Domain/Creators/Test_Brick.cpp
+++ b/tests/Unit/Domain/Creators/Test_Brick.cpp
@@ -303,8 +303,8 @@ void test_brick_factory() {
       "      BlockId: 2\n"};
   {
     INFO("Brick factory time independent, no boundary condition");
-    const auto domain_creator = TestHelpers::test_creation<
-        std::unique_ptr<DomainCreator<3>>, domain::OptionTags::DomainCreator<3>,
+    const auto domain_creator = TestHelpers::test_option_tag<
+        domain::OptionTags::DomainCreator<3>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithoutBoundaryConditions<3>>(
         "Brick:\n"
@@ -329,8 +329,8 @@ void test_brick_factory() {
   }
   {
     INFO("Brick factory time independent, with boundary condition");
-    const auto domain_creator = TestHelpers::test_creation<
-        std::unique_ptr<DomainCreator<3>>, domain::OptionTags::DomainCreator<3>,
+    const auto domain_creator = TestHelpers::test_option_tag<
+        domain::OptionTags::DomainCreator<3>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithBoundaryConditions<3>>(
         "Brick:\n"
@@ -355,8 +355,8 @@ void test_brick_factory() {
   }
   {
     INFO("Brick factory time dependent");
-    const auto domain_creator = TestHelpers::test_creation<
-        std::unique_ptr<DomainCreator<3>>, domain::OptionTags::DomainCreator<3>,
+    const auto domain_creator = TestHelpers::test_option_tag<
+        domain::OptionTags::DomainCreator<3>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithoutBoundaryConditions<3>>(
         "Brick:\n"
@@ -404,8 +404,8 @@ void test_brick_factory() {
   }
   {
     INFO("Brick factory time dependent");
-    const auto domain_creator = TestHelpers::test_creation<
-        std::unique_ptr<DomainCreator<3>>, domain::OptionTags::DomainCreator<3>,
+    const auto domain_creator = TestHelpers::test_option_tag<
+        domain::OptionTags::DomainCreator<3>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithBoundaryConditions<3>>(
         "Brick:\n"

--- a/tests/Unit/Domain/Creators/Test_Brick.cpp
+++ b/tests/Unit/Domain/Creators/Test_Brick.cpp
@@ -303,8 +303,8 @@ void test_brick_factory() {
       "      BlockId: 2\n"};
   {
     INFO("Brick factory time independent, no boundary condition");
-    const auto domain_creator = TestHelpers::test_factory_creation<
-        DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+    const auto domain_creator = TestHelpers::test_creation<
+        std::unique_ptr<DomainCreator<3>>, domain::OptionTags::DomainCreator<3>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithoutBoundaryConditions<3>>(
         "Brick:\n"
@@ -329,8 +329,8 @@ void test_brick_factory() {
   }
   {
     INFO("Brick factory time independent, with boundary condition");
-    const auto domain_creator = TestHelpers::test_factory_creation<
-        DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+    const auto domain_creator = TestHelpers::test_creation<
+        std::unique_ptr<DomainCreator<3>>, domain::OptionTags::DomainCreator<3>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithBoundaryConditions<3>>(
         "Brick:\n"
@@ -355,8 +355,8 @@ void test_brick_factory() {
   }
   {
     INFO("Brick factory time dependent");
-    const auto domain_creator = TestHelpers::test_factory_creation<
-        DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+    const auto domain_creator = TestHelpers::test_creation<
+        std::unique_ptr<DomainCreator<3>>, domain::OptionTags::DomainCreator<3>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithoutBoundaryConditions<3>>(
         "Brick:\n"
@@ -404,8 +404,8 @@ void test_brick_factory() {
   }
   {
     INFO("Brick factory time dependent");
-    const auto domain_creator = TestHelpers::test_factory_creation<
-        DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+    const auto domain_creator = TestHelpers::test_creation<
+        std::unique_ptr<DomainCreator<3>>, domain::OptionTags::DomainCreator<3>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithBoundaryConditions<3>>(
         "Brick:\n"

--- a/tests/Unit/Domain/Creators/Test_Cylinder.cpp
+++ b/tests/Unit/Domain/Creators/Test_Cylinder.cpp
@@ -257,7 +257,8 @@ void test_cylinder_construction(
 
   test_initial_domain(domain, cylinder.initial_refinement_levels());
 
-  Parallel::register_classes_in_list<typename creators::Cylinder::maps_list>();
+  Parallel::register_classes_with_charm(
+      typename creators::Cylinder::maps_list{});
   test_serialization(domain);
 }
 
@@ -815,7 +816,8 @@ void test_refined_cylinder_boundaries(const bool use_equiangular_map) {
 
   test_initial_domain(domain, refined_cylinder.initial_refinement_levels());
 
-  Parallel::register_classes_in_list<typename creators::Cylinder::maps_list>();
+  Parallel::register_classes_with_charm(
+      typename creators::Cylinder::maps_list{});
   test_serialization(domain);
 }
 
@@ -1217,7 +1219,8 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
 
   test_initial_domain(domain, refined_cylinder.initial_refinement_levels());
 
-  Parallel::register_classes_in_list<typename creators::Cylinder::maps_list>();
+  Parallel::register_classes_with_charm(
+      typename creators::Cylinder::maps_list{});
   test_serialization(domain);
 }
 

--- a/tests/Unit/Domain/Creators/Test_Cylinder.cpp
+++ b/tests/Unit/Domain/Creators/Test_Cylinder.cpp
@@ -339,13 +339,15 @@ void test_cylinder_no_refinement() {
         const auto cylinder_factory = [&opt_string,
                                        with_boundary_conditions]() {
           if (with_boundary_conditions) {
-            return TestHelpers::test_factory_creation<
-                DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+            return TestHelpers::test_creation<
+                std::unique_ptr<DomainCreator<3>>,
+                domain::OptionTags::DomainCreator<3>,
                 TestHelpers::domain::BoundaryConditions::
                     MetavariablesWithBoundaryConditions<3>>(opt_string);
           } else {
-            return TestHelpers::test_factory_creation<
-                DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+            return TestHelpers::test_creation<
+                std::unique_ptr<DomainCreator<3>>,
+                domain::OptionTags::DomainCreator<3>,
                 TestHelpers::domain::BoundaryConditions::
                     MetavariablesWithoutBoundaryConditions<3>>(opt_string);
           }

--- a/tests/Unit/Domain/Creators/Test_Cylinder.cpp
+++ b/tests/Unit/Domain/Creators/Test_Cylinder.cpp
@@ -339,14 +339,12 @@ void test_cylinder_no_refinement() {
         const auto cylinder_factory = [&opt_string,
                                        with_boundary_conditions]() {
           if (with_boundary_conditions) {
-            return TestHelpers::test_creation<
-                std::unique_ptr<DomainCreator<3>>,
+            return TestHelpers::test_option_tag<
                 domain::OptionTags::DomainCreator<3>,
                 TestHelpers::domain::BoundaryConditions::
                     MetavariablesWithBoundaryConditions<3>>(opt_string);
           } else {
-            return TestHelpers::test_creation<
-                std::unique_ptr<DomainCreator<3>>,
+            return TestHelpers::test_option_tag<
                 domain::OptionTags::DomainCreator<3>,
                 TestHelpers::domain::BoundaryConditions::
                     MetavariablesWithoutBoundaryConditions<3>>(opt_string);

--- a/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
@@ -314,14 +314,16 @@ std::string create_option_string(const bool add_time_dependence,
 void test_bbh_time_dependent_factory(const bool with_boundary_conditions) {
   const auto binary_compact_object = [&with_boundary_conditions]() {
     if (with_boundary_conditions) {
-      return TestHelpers::test_factory_creation<
-          DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      return TestHelpers::test_creation<
+          std::unique_ptr<DomainCreator<3>>,
+          domain::OptionTags::DomainCreator<3>,
           TestHelpers::domain::BoundaryConditions::
               MetavariablesWithBoundaryConditions<3>>(
           create_option_string(true, with_boundary_conditions));
     } else {
-      return TestHelpers::test_factory_creation<
-          DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+      return TestHelpers::test_creation<
+          std::unique_ptr<DomainCreator<3>>,
+          domain::OptionTags::DomainCreator<3>,
           TestHelpers::domain::BoundaryConditions::
               MetavariablesWithoutBoundaryConditions<3>>(
           create_option_string(true, with_boundary_conditions));
@@ -390,13 +392,15 @@ void test_binary_factory() {
     const auto binary_compact_object = [&opt_string,
                                         &with_boundary_conditions]() {
       if (with_boundary_conditions) {
-        return TestHelpers::test_factory_creation<
-            DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+        return TestHelpers::test_creation<
+            std::unique_ptr<DomainCreator<3>>,
+            domain::OptionTags::DomainCreator<3>,
             TestHelpers::domain::BoundaryConditions::
                 MetavariablesWithBoundaryConditions<3>>(opt_string);
       } else {
-        return TestHelpers::test_factory_creation<
-            DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+        return TestHelpers::test_creation<
+            std::unique_ptr<DomainCreator<3>>,
+            domain::OptionTags::DomainCreator<3>,
             TestHelpers::domain::BoundaryConditions::
                 MetavariablesWithoutBoundaryConditions<3>>(opt_string);
       }

--- a/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
@@ -314,15 +314,13 @@ std::string create_option_string(const bool add_time_dependence,
 void test_bbh_time_dependent_factory(const bool with_boundary_conditions) {
   const auto binary_compact_object = [&with_boundary_conditions]() {
     if (with_boundary_conditions) {
-      return TestHelpers::test_creation<
-          std::unique_ptr<DomainCreator<3>>,
+      return TestHelpers::test_option_tag<
           domain::OptionTags::DomainCreator<3>,
           TestHelpers::domain::BoundaryConditions::
               MetavariablesWithBoundaryConditions<3>>(
           create_option_string(true, with_boundary_conditions));
     } else {
-      return TestHelpers::test_creation<
-          std::unique_ptr<DomainCreator<3>>,
+      return TestHelpers::test_option_tag<
           domain::OptionTags::DomainCreator<3>,
           TestHelpers::domain::BoundaryConditions::
               MetavariablesWithoutBoundaryConditions<3>>(
@@ -392,14 +390,12 @@ void test_binary_factory() {
     const auto binary_compact_object = [&opt_string,
                                         &with_boundary_conditions]() {
       if (with_boundary_conditions) {
-        return TestHelpers::test_creation<
-            std::unique_ptr<DomainCreator<3>>,
+        return TestHelpers::test_option_tag<
             domain::OptionTags::DomainCreator<3>,
             TestHelpers::domain::BoundaryConditions::
                 MetavariablesWithBoundaryConditions<3>>(opt_string);
       } else {
-        return TestHelpers::test_creation<
-            std::unique_ptr<DomainCreator<3>>,
+        return TestHelpers::test_option_tag<
             domain::OptionTags::DomainCreator<3>,
             TestHelpers::domain::BoundaryConditions::
                 MetavariablesWithoutBoundaryConditions<3>>(opt_string);

--- a/tests/Unit/Domain/Creators/Test_Disk.cpp
+++ b/tests/Unit/Domain/Creators/Test_Disk.cpp
@@ -136,7 +136,7 @@ void test_disk_construction(
 
   test_initial_domain(domain, disk.initial_refinement_levels());
 
-  Parallel::register_classes_in_list<typename creators::Disk::maps_list>();
+  Parallel::register_classes_with_charm(typename creators::Disk::maps_list{});
   test_serialization(domain);
 }
 

--- a/tests/Unit/Domain/Creators/Test_Disk.cpp
+++ b/tests/Unit/Domain/Creators/Test_Disk.cpp
@@ -189,8 +189,8 @@ void test_disk_boundaries_equiangular() {
 
 void test_disk_factory_equiangular() {
   INFO("Disk factory equiangular");
-  const auto disk = TestHelpers::test_factory_creation<
-      DomainCreator<2>, domain::OptionTags::DomainCreator<2>,
+  const auto disk = TestHelpers::test_creation<
+      std::unique_ptr<DomainCreator<2>>, domain::OptionTags::DomainCreator<2>,
       TestHelpers::domain::BoundaryConditions::
           MetavariablesWithoutBoundaryConditions<2>>(
       "Disk:\n"
@@ -208,8 +208,8 @@ void test_disk_factory_equiangular() {
                          inner_radius, outer_radius, grid_points,
                          {5, make_array<2>(refinement_level)}, true);
 
-  const auto disk_boundary_conditions = TestHelpers::test_factory_creation<
-      DomainCreator<2>, domain::OptionTags::DomainCreator<2>,
+  const auto disk_boundary_conditions = TestHelpers::test_creation<
+      std::unique_ptr<DomainCreator<2>>, domain::OptionTags::DomainCreator<2>,
       TestHelpers::domain::BoundaryConditions::
           MetavariablesWithBoundaryConditions<2>>(
       "Disk:\n"
@@ -270,8 +270,8 @@ void test_disk_boundaries_equidistant() {
 
 void test_disk_factory_equidistant() {
   INFO("Disk factory equidistant");
-  const auto disk = TestHelpers::test_factory_creation<
-      DomainCreator<2>, domain::OptionTags::DomainCreator<2>,
+  const auto disk = TestHelpers::test_creation<
+      std::unique_ptr<DomainCreator<2>>, domain::OptionTags::DomainCreator<2>,
       TestHelpers::domain::BoundaryConditions::
           MetavariablesWithoutBoundaryConditions<2>>(
       "Disk:\n"
@@ -289,8 +289,8 @@ void test_disk_factory_equidistant() {
                          inner_radius, outer_radius, grid_points,
                          {5, make_array<2>(refinement_level)}, false);
 
-  const auto disk_boundary_conditions = TestHelpers::test_factory_creation<
-      DomainCreator<2>, domain::OptionTags::DomainCreator<2>,
+  const auto disk_boundary_conditions = TestHelpers::test_creation<
+      std::unique_ptr<DomainCreator<2>>, domain::OptionTags::DomainCreator<2>,
       TestHelpers::domain::BoundaryConditions::
           MetavariablesWithBoundaryConditions<2>>(
       "Disk:\n"

--- a/tests/Unit/Domain/Creators/Test_Disk.cpp
+++ b/tests/Unit/Domain/Creators/Test_Disk.cpp
@@ -189,8 +189,8 @@ void test_disk_boundaries_equiangular() {
 
 void test_disk_factory_equiangular() {
   INFO("Disk factory equiangular");
-  const auto disk = TestHelpers::test_creation<
-      std::unique_ptr<DomainCreator<2>>, domain::OptionTags::DomainCreator<2>,
+  const auto disk = TestHelpers::test_option_tag<
+      domain::OptionTags::DomainCreator<2>,
       TestHelpers::domain::BoundaryConditions::
           MetavariablesWithoutBoundaryConditions<2>>(
       "Disk:\n"
@@ -208,8 +208,8 @@ void test_disk_factory_equiangular() {
                          inner_radius, outer_radius, grid_points,
                          {5, make_array<2>(refinement_level)}, true);
 
-  const auto disk_boundary_conditions = TestHelpers::test_creation<
-      std::unique_ptr<DomainCreator<2>>, domain::OptionTags::DomainCreator<2>,
+  const auto disk_boundary_conditions = TestHelpers::test_option_tag<
+      domain::OptionTags::DomainCreator<2>,
       TestHelpers::domain::BoundaryConditions::
           MetavariablesWithBoundaryConditions<2>>(
       "Disk:\n"
@@ -270,8 +270,8 @@ void test_disk_boundaries_equidistant() {
 
 void test_disk_factory_equidistant() {
   INFO("Disk factory equidistant");
-  const auto disk = TestHelpers::test_creation<
-      std::unique_ptr<DomainCreator<2>>, domain::OptionTags::DomainCreator<2>,
+  const auto disk = TestHelpers::test_option_tag<
+      domain::OptionTags::DomainCreator<2>,
       TestHelpers::domain::BoundaryConditions::
           MetavariablesWithoutBoundaryConditions<2>>(
       "Disk:\n"
@@ -289,8 +289,8 @@ void test_disk_factory_equidistant() {
                          inner_radius, outer_radius, grid_points,
                          {5, make_array<2>(refinement_level)}, false);
 
-  const auto disk_boundary_conditions = TestHelpers::test_creation<
-      std::unique_ptr<DomainCreator<2>>, domain::OptionTags::DomainCreator<2>,
+  const auto disk_boundary_conditions = TestHelpers::test_option_tag<
+      domain::OptionTags::DomainCreator<2>,
       TestHelpers::domain::BoundaryConditions::
           MetavariablesWithBoundaryConditions<2>>(
       "Disk:\n"

--- a/tests/Unit/Domain/Creators/Test_FrustalCloak.cpp
+++ b/tests/Unit/Domain/Creators/Test_FrustalCloak.cpp
@@ -59,8 +59,8 @@ auto create_boundary_conditions() {
 void test_frustal_cloak_construction(
     const domain::creators::FrustalCloak& frustal_cloak,
     const BoundaryCondVector& expected_external_boundary_conditions) {
-  Parallel::register_classes_in_list<
-      typename domain::creators::FrustalCloak::maps_list>();
+  Parallel::register_classes_with_charm(
+      typename domain::creators::FrustalCloak::maps_list{});
 
   const auto test_impl = [&expected_external_boundary_conditions,
                           &frustal_cloak](const auto& domain) {

--- a/tests/Unit/Domain/Creators/Test_FrustalCloak.cpp
+++ b/tests/Unit/Domain/Creators/Test_FrustalCloak.cpp
@@ -107,13 +107,15 @@ void test_factory() {
                                              : ""}};
     const auto frustal_cloak = [&opt_string, &with_boundary_conditions]() {
       if (with_boundary_conditions) {
-        return TestHelpers::test_factory_creation<
-            DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+        return TestHelpers::test_creation<
+            std::unique_ptr<DomainCreator<3>>,
+            domain::OptionTags::DomainCreator<3>,
             TestHelpers::domain::BoundaryConditions::
                 MetavariablesWithBoundaryConditions<3>>(opt_string);
       } else {
-        return TestHelpers::test_factory_creation<
-            DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+        return TestHelpers::test_creation<
+            std::unique_ptr<DomainCreator<3>>,
+            domain::OptionTags::DomainCreator<3>,
             TestHelpers::domain::BoundaryConditions::
                 MetavariablesWithoutBoundaryConditions<3>>(opt_string);
       }

--- a/tests/Unit/Domain/Creators/Test_FrustalCloak.cpp
+++ b/tests/Unit/Domain/Creators/Test_FrustalCloak.cpp
@@ -107,14 +107,12 @@ void test_factory() {
                                              : ""}};
     const auto frustal_cloak = [&opt_string, &with_boundary_conditions]() {
       if (with_boundary_conditions) {
-        return TestHelpers::test_creation<
-            std::unique_ptr<DomainCreator<3>>,
+        return TestHelpers::test_option_tag<
             domain::OptionTags::DomainCreator<3>,
             TestHelpers::domain::BoundaryConditions::
                 MetavariablesWithBoundaryConditions<3>>(opt_string);
       } else {
-        return TestHelpers::test_creation<
-            std::unique_ptr<DomainCreator<3>>,
+        return TestHelpers::test_option_tag<
             domain::OptionTags::DomainCreator<3>,
             TestHelpers::domain::BoundaryConditions::
                 MetavariablesWithoutBoundaryConditions<3>>(opt_string);

--- a/tests/Unit/Domain/Creators/Test_Interval.cpp
+++ b/tests/Unit/Domain/Creators/Test_Interval.cpp
@@ -228,8 +228,8 @@ void test_interval_factory() {
        {Direction<1>::upper_xi(), {0, {}}}}};
   {
     INFO("Interval factory time independent, no boundary condition");
-    const auto domain_creator = TestHelpers::test_factory_creation<
-        DomainCreator<1>, domain::OptionTags::DomainCreator<1>,
+    const auto domain_creator = TestHelpers::test_creation<
+        std::unique_ptr<DomainCreator<1>>, domain::OptionTags::DomainCreator<1>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithoutBoundaryConditions<1>>(
         "Interval:\n"
@@ -246,8 +246,8 @@ void test_interval_factory() {
   }
   {
     INFO("Interval factory time independent, with boundary condition");
-    const auto domain_creator = TestHelpers::test_factory_creation<
-        DomainCreator<1>, domain::OptionTags::DomainCreator<1>,
+    const auto domain_creator = TestHelpers::test_creation<
+        std::unique_ptr<DomainCreator<1>>, domain::OptionTags::DomainCreator<1>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithBoundaryConditions<1>>(
         "Interval:\n"
@@ -273,8 +273,8 @@ void test_interval_factory() {
   }
   {
     INFO("Interval factory time dependent, no boundary condition");
-    const auto domain_creator = TestHelpers::test_factory_creation<
-        DomainCreator<1>, domain::OptionTags::DomainCreator<1>,
+    const auto domain_creator = TestHelpers::test_creation<
+        std::unique_ptr<DomainCreator<1>>, domain::OptionTags::DomainCreator<1>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithoutBoundaryConditions<1>>(
         "Interval:\n"
@@ -305,8 +305,8 @@ void test_interval_factory() {
   }
   {
     INFO("Interval factory time dependent, with boundary condition");
-    const auto domain_creator = TestHelpers::test_factory_creation<
-        DomainCreator<1>, domain::OptionTags::DomainCreator<1>,
+    const auto domain_creator = TestHelpers::test_creation<
+        std::unique_ptr<DomainCreator<1>>, domain::OptionTags::DomainCreator<1>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithBoundaryConditions<1>>(
         "Interval:\n"

--- a/tests/Unit/Domain/Creators/Test_Interval.cpp
+++ b/tests/Unit/Domain/Creators/Test_Interval.cpp
@@ -228,8 +228,8 @@ void test_interval_factory() {
        {Direction<1>::upper_xi(), {0, {}}}}};
   {
     INFO("Interval factory time independent, no boundary condition");
-    const auto domain_creator = TestHelpers::test_creation<
-        std::unique_ptr<DomainCreator<1>>, domain::OptionTags::DomainCreator<1>,
+    const auto domain_creator = TestHelpers::test_option_tag<
+        domain::OptionTags::DomainCreator<1>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithoutBoundaryConditions<1>>(
         "Interval:\n"
@@ -246,8 +246,8 @@ void test_interval_factory() {
   }
   {
     INFO("Interval factory time independent, with boundary condition");
-    const auto domain_creator = TestHelpers::test_creation<
-        std::unique_ptr<DomainCreator<1>>, domain::OptionTags::DomainCreator<1>,
+    const auto domain_creator = TestHelpers::test_option_tag<
+        domain::OptionTags::DomainCreator<1>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithBoundaryConditions<1>>(
         "Interval:\n"
@@ -273,8 +273,8 @@ void test_interval_factory() {
   }
   {
     INFO("Interval factory time dependent, no boundary condition");
-    const auto domain_creator = TestHelpers::test_creation<
-        std::unique_ptr<DomainCreator<1>>, domain::OptionTags::DomainCreator<1>,
+    const auto domain_creator = TestHelpers::test_option_tag<
+        domain::OptionTags::DomainCreator<1>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithoutBoundaryConditions<1>>(
         "Interval:\n"
@@ -305,8 +305,8 @@ void test_interval_factory() {
   }
   {
     INFO("Interval factory time dependent, with boundary condition");
-    const auto domain_creator = TestHelpers::test_creation<
-        std::unique_ptr<DomainCreator<1>>, domain::OptionTags::DomainCreator<1>,
+    const auto domain_creator = TestHelpers::test_option_tag<
+        domain::OptionTags::DomainCreator<1>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithBoundaryConditions<1>>(
         "Interval:\n"

--- a/tests/Unit/Domain/Creators/Test_Rectangle.cpp
+++ b/tests/Unit/Domain/Creators/Test_Rectangle.cpp
@@ -229,8 +229,8 @@ void test_rectangle_factory() {
 
   {
     INFO("Rectangle factory time independent, no boundary condition");
-    const auto domain_creator = TestHelpers::test_creation<
-        std::unique_ptr<DomainCreator<2>>, domain::OptionTags::DomainCreator<2>,
+    const auto domain_creator = TestHelpers::test_option_tag<
+        domain::OptionTags::DomainCreator<2>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithoutBoundaryConditions<2>>(
         "Rectangle:\n"
@@ -250,8 +250,8 @@ void test_rectangle_factory() {
   }
   {
     INFO("Rectangle factory time independent, with boundary condition");
-    const auto domain_creator = TestHelpers::test_creation<
-        std::unique_ptr<DomainCreator<2>>, domain::OptionTags::DomainCreator<2>,
+    const auto domain_creator = TestHelpers::test_option_tag<
+        domain::OptionTags::DomainCreator<2>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithBoundaryConditions<2>>(
         "Rectangle:\n"
@@ -276,8 +276,8 @@ void test_rectangle_factory() {
   }
   {
     INFO("Rectangle factory time dependent");
-    const auto domain_creator = TestHelpers::test_creation<
-        std::unique_ptr<DomainCreator<2>>, domain::OptionTags::DomainCreator<2>,
+    const auto domain_creator = TestHelpers::test_option_tag<
+        domain::OptionTags::DomainCreator<2>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithoutBoundaryConditions<2>>(
         "Rectangle:\n"
@@ -315,8 +315,8 @@ void test_rectangle_factory() {
   }
   {
     INFO("Rectangle factory time dependent, with boundary conditions");
-    const auto domain_creator = TestHelpers::test_creation<
-        std::unique_ptr<DomainCreator<2>>, domain::OptionTags::DomainCreator<2>,
+    const auto domain_creator = TestHelpers::test_option_tag<
+        domain::OptionTags::DomainCreator<2>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithBoundaryConditions<2>>(
         "Rectangle:\n"

--- a/tests/Unit/Domain/Creators/Test_Rectangle.cpp
+++ b/tests/Unit/Domain/Creators/Test_Rectangle.cpp
@@ -229,8 +229,8 @@ void test_rectangle_factory() {
 
   {
     INFO("Rectangle factory time independent, no boundary condition");
-    const auto domain_creator = TestHelpers::test_factory_creation<
-        DomainCreator<2>, domain::OptionTags::DomainCreator<2>,
+    const auto domain_creator = TestHelpers::test_creation<
+        std::unique_ptr<DomainCreator<2>>, domain::OptionTags::DomainCreator<2>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithoutBoundaryConditions<2>>(
         "Rectangle:\n"
@@ -250,8 +250,8 @@ void test_rectangle_factory() {
   }
   {
     INFO("Rectangle factory time independent, with boundary condition");
-    const auto domain_creator = TestHelpers::test_factory_creation<
-        DomainCreator<2>, domain::OptionTags::DomainCreator<2>,
+    const auto domain_creator = TestHelpers::test_creation<
+        std::unique_ptr<DomainCreator<2>>, domain::OptionTags::DomainCreator<2>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithBoundaryConditions<2>>(
         "Rectangle:\n"
@@ -276,8 +276,8 @@ void test_rectangle_factory() {
   }
   {
     INFO("Rectangle factory time dependent");
-    const auto domain_creator = TestHelpers::test_factory_creation<
-        DomainCreator<2>, domain::OptionTags::DomainCreator<2>,
+    const auto domain_creator = TestHelpers::test_creation<
+        std::unique_ptr<DomainCreator<2>>, domain::OptionTags::DomainCreator<2>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithoutBoundaryConditions<2>>(
         "Rectangle:\n"
@@ -315,8 +315,8 @@ void test_rectangle_factory() {
   }
   {
     INFO("Rectangle factory time dependent, with boundary conditions");
-    const auto domain_creator = TestHelpers::test_factory_creation<
-        DomainCreator<2>, domain::OptionTags::DomainCreator<2>,
+    const auto domain_creator = TestHelpers::test_creation<
+        std::unique_ptr<DomainCreator<2>>, domain::OptionTags::DomainCreator<2>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithBoundaryConditions<2>>(
         "Rectangle:\n"

--- a/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
@@ -158,8 +158,8 @@ void test_rotated_bricks_construction(
                            expected_boundary_conditions);
   test_initial_domain(domain, rotated_bricks.initial_refinement_levels());
 
-  Parallel::register_classes_in_list<
-      typename domain::creators::RotatedBricks::maps_list>();
+  Parallel::register_classes_with_charm(
+      typename domain::creators::RotatedBricks::maps_list{});
   test_serialization(domain);
 }
 

--- a/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
@@ -399,14 +399,12 @@ void test_rotated_bricks_factory() {
                         : "  IsPeriodicIn: [false, false, false]\n"}};
     const auto domain_creator = [&opt_string, with_boundary_conditions]() {
       if (with_boundary_conditions) {
-        return TestHelpers::test_creation<
-            std::unique_ptr<DomainCreator<3>>,
+        return TestHelpers::test_option_tag<
             domain::OptionTags::DomainCreator<3>,
             TestHelpers::domain::BoundaryConditions::
                 MetavariablesWithBoundaryConditions<3>>(opt_string);
       } else {
-        return TestHelpers::test_creation<
-            std::unique_ptr<DomainCreator<3>>,
+        return TestHelpers::test_option_tag<
             domain::OptionTags::DomainCreator<3>,
             TestHelpers::domain::BoundaryConditions::
                 MetavariablesWithoutBoundaryConditions<3>>(opt_string);

--- a/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
@@ -399,13 +399,15 @@ void test_rotated_bricks_factory() {
                         : "  IsPeriodicIn: [false, false, false]\n"}};
     const auto domain_creator = [&opt_string, with_boundary_conditions]() {
       if (with_boundary_conditions) {
-        return TestHelpers::test_factory_creation<
-            DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+        return TestHelpers::test_creation<
+            std::unique_ptr<DomainCreator<3>>,
+            domain::OptionTags::DomainCreator<3>,
             TestHelpers::domain::BoundaryConditions::
                 MetavariablesWithBoundaryConditions<3>>(opt_string);
       } else {
-        return TestHelpers::test_factory_creation<
-            DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+        return TestHelpers::test_creation<
+            std::unique_ptr<DomainCreator<3>>,
+            domain::OptionTags::DomainCreator<3>,
             TestHelpers::domain::BoundaryConditions::
                 MetavariablesWithoutBoundaryConditions<3>>(opt_string);
       }

--- a/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
@@ -67,8 +67,8 @@ void test_rotated_intervals_construction(
       0.0, {}, {}, expected_boundary_conditions);
   test_initial_domain(domain, rotated_intervals.initial_refinement_levels());
 
-  Parallel::register_classes_in_list<
-      typename domain::creators::RotatedIntervals::maps_list>();
+  Parallel::register_classes_with_charm(
+      typename domain::creators::RotatedIntervals::maps_list{});
   test_serialization(domain);
 }
 

--- a/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
@@ -221,8 +221,8 @@ void test_rotated_intervals_factory() {
       std::array<Direction<1>, 1>{{Direction<1>::lower_xi()}}};
   {
     INFO("Rotated intervals factory, no boundary condition");
-    const auto domain_creator = TestHelpers::test_factory_creation<
-        DomainCreator<1>, domain::OptionTags::DomainCreator<1>,
+    const auto domain_creator = TestHelpers::test_creation<
+        std::unique_ptr<DomainCreator<1>>, domain::OptionTags::DomainCreator<1>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithoutBoundaryConditions<1>>(
         "RotatedIntervals:\n"
@@ -246,8 +246,8 @@ void test_rotated_intervals_factory() {
   }
   {
     INFO("Rotated intervals factory, with boundary condition");
-    const auto domain_creator = TestHelpers::test_factory_creation<
-        DomainCreator<1>, domain::OptionTags::DomainCreator<1>,
+    const auto domain_creator = TestHelpers::test_creation<
+        std::unique_ptr<DomainCreator<1>>, domain::OptionTags::DomainCreator<1>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithBoundaryConditions<1>>(
         "RotatedIntervals:\n"

--- a/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
@@ -221,8 +221,8 @@ void test_rotated_intervals_factory() {
       std::array<Direction<1>, 1>{{Direction<1>::lower_xi()}}};
   {
     INFO("Rotated intervals factory, no boundary condition");
-    const auto domain_creator = TestHelpers::test_creation<
-        std::unique_ptr<DomainCreator<1>>, domain::OptionTags::DomainCreator<1>,
+    const auto domain_creator = TestHelpers::test_option_tag<
+        domain::OptionTags::DomainCreator<1>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithoutBoundaryConditions<1>>(
         "RotatedIntervals:\n"
@@ -246,8 +246,8 @@ void test_rotated_intervals_factory() {
   }
   {
     INFO("Rotated intervals factory, with boundary condition");
-    const auto domain_creator = TestHelpers::test_creation<
-        std::unique_ptr<DomainCreator<1>>, domain::OptionTags::DomainCreator<1>,
+    const auto domain_creator = TestHelpers::test_option_tag<
+        domain::OptionTags::DomainCreator<1>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithBoundaryConditions<1>>(
         "RotatedIntervals:\n"

--- a/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
@@ -90,8 +90,8 @@ void test_rotated_rectangles_construction(
                            expected_boundary_conditions);
   test_initial_domain(domain, rotated_rectangles.initial_refinement_levels());
 
-  Parallel::register_classes_in_list<
-      typename domain::creators::RotatedRectangles::maps_list>();
+  Parallel::register_classes_with_charm(
+      typename domain::creators::RotatedRectangles::maps_list{});
   test_serialization(domain);
 }
 

--- a/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
@@ -287,8 +287,8 @@ void test_rotated_rectangles_factory() {
 
   {
     INFO("No boundary condition");
-    const auto domain_creator = TestHelpers::test_factory_creation<
-        DomainCreator<2>, domain::OptionTags::DomainCreator<2>,
+    const auto domain_creator = TestHelpers::test_creation<
+        std::unique_ptr<DomainCreator<2>>, domain::OptionTags::DomainCreator<2>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithoutBoundaryConditions<2>>(
         "RotatedRectangles:\n"
@@ -324,8 +324,8 @@ void test_rotated_rectangles_factory() {
     const std::vector<DirectionMap<
         2, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
         expected_boundary_conditions = create_boundary_conditions();
-    const auto domain_creator = TestHelpers::test_factory_creation<
-        DomainCreator<2>, domain::OptionTags::DomainCreator<2>,
+    const auto domain_creator = TestHelpers::test_creation<
+        std::unique_ptr<DomainCreator<2>>, domain::OptionTags::DomainCreator<2>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithBoundaryConditions<2>>(
         "RotatedRectangles:\n"

--- a/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
@@ -287,8 +287,8 @@ void test_rotated_rectangles_factory() {
 
   {
     INFO("No boundary condition");
-    const auto domain_creator = TestHelpers::test_creation<
-        std::unique_ptr<DomainCreator<2>>, domain::OptionTags::DomainCreator<2>,
+    const auto domain_creator = TestHelpers::test_option_tag<
+        domain::OptionTags::DomainCreator<2>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithoutBoundaryConditions<2>>(
         "RotatedRectangles:\n"
@@ -324,8 +324,8 @@ void test_rotated_rectangles_factory() {
     const std::vector<DirectionMap<
         2, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
         expected_boundary_conditions = create_boundary_conditions();
-    const auto domain_creator = TestHelpers::test_creation<
-        std::unique_ptr<DomainCreator<2>>, domain::OptionTags::DomainCreator<2>,
+    const auto domain_creator = TestHelpers::test_option_tag<
+        domain::OptionTags::DomainCreator<2>,
         TestHelpers::domain::BoundaryConditions::
             MetavariablesWithBoundaryConditions<2>>(
         "RotatedRectangles:\n"

--- a/tests/Unit/Domain/Creators/Test_Shell.cpp
+++ b/tests/Unit/Domain/Creators/Test_Shell.cpp
@@ -395,8 +395,8 @@ void test_shell_factory_equiangular() {
   INFO("Shell factory equiangular");
   const auto helper = [](const auto expected_boundary_conditions,
                          auto use_boundary_condition) {
-    const auto shell = TestHelpers::test_creation<
-        std::unique_ptr<DomainCreator<3>>, domain::OptionTags::DomainCreator<3>,
+    const auto shell = TestHelpers::test_option_tag<
+        domain::OptionTags::DomainCreator<3>,
         tmpl::conditional_t<decltype(use_boundary_condition)::value,
                             TestHelpers::domain::BoundaryConditions::
                                 MetavariablesWithBoundaryConditions<3>,
@@ -432,8 +432,8 @@ void test_shell_factory_equidistant() {
   INFO("Shell factory equidistant");
   const auto helper = [](const auto expected_boundary_conditions,
                          auto use_boundary_condition) {
-    const auto shell = TestHelpers::test_creation<
-        std::unique_ptr<DomainCreator<3>>, domain::OptionTags::DomainCreator<3>,
+    const auto shell = TestHelpers::test_option_tag<
+        domain::OptionTags::DomainCreator<3>,
         tmpl::conditional_t<decltype(use_boundary_condition)::value,
                             TestHelpers::domain::BoundaryConditions::
                                 MetavariablesWithBoundaryConditions<3>,
@@ -504,8 +504,8 @@ void test_shell_factory_aspect_ratio() {
   INFO("Shell factory aspect ratio");
   const auto helper = [](const auto expected_boundary_conditions,
                          auto use_boundary_condition) {
-    const auto shell = TestHelpers::test_creation<
-        std::unique_ptr<DomainCreator<3>>, domain::OptionTags::DomainCreator<3>,
+    const auto shell = TestHelpers::test_option_tag<
+        domain::OptionTags::DomainCreator<3>,
         tmpl::conditional_t<decltype(use_boundary_condition)::value,
                             TestHelpers::domain::BoundaryConditions::
                                 MetavariablesWithBoundaryConditions<3>,
@@ -620,8 +620,8 @@ void test_shell_factory_logarithmic_map() {
   INFO("Shell factory logarithmic map");
   const auto helper = [](const auto expected_boundary_conditions,
                          auto use_boundary_condition) {
-    const auto shell = TestHelpers::test_creation<
-        std::unique_ptr<DomainCreator<3>>, domain::OptionTags::DomainCreator<3>,
+    const auto shell = TestHelpers::test_option_tag<
+        domain::OptionTags::DomainCreator<3>,
         tmpl::conditional_t<decltype(use_boundary_condition)::value,
                             TestHelpers::domain::BoundaryConditions::
                                 MetavariablesWithBoundaryConditions<3>,
@@ -655,8 +655,8 @@ void test_shell_factory_logarithmic_map() {
   helper(create_boundary_conditions(1, ShellWedges::All), std::true_type{});
 
   INFO("Test with multiple radial layers");
-  const auto shell = TestHelpers::test_creation<
-      std::unique_ptr<DomainCreator<3>>, domain::OptionTags::DomainCreator<3>,
+  const auto shell = TestHelpers::test_option_tag<
+      domain::OptionTags::DomainCreator<3>,
       TestHelpers::domain::BoundaryConditions::
           MetavariablesWithBoundaryConditions<3>>(
       "Shell:\n"
@@ -702,8 +702,8 @@ void test_shell_factory_logarithmic_map() {
 
 void test_shell_factory_wedges_four_on_equator() {
   INFO("Shell factory wedges four on equator");
-  const auto shell = TestHelpers::test_creation<
-      std::unique_ptr<DomainCreator<3>>, domain::OptionTags::DomainCreator<3>,
+  const auto shell = TestHelpers::test_option_tag<
+      domain::OptionTags::DomainCreator<3>,
       TestHelpers::domain::BoundaryConditions::
           MetavariablesWithoutBoundaryConditions<3>>(
       "Shell:\n"
@@ -731,8 +731,8 @@ void test_shell_factory_wedges_four_on_equator() {
 
 void test_shell_factory_wedges_one_along_minus_x() {
   INFO("Shell factory wedges one along minus x");
-  const auto shell = TestHelpers::test_creation<
-      std::unique_ptr<DomainCreator<3>>, domain::OptionTags::DomainCreator<3>,
+  const auto shell = TestHelpers::test_option_tag<
+      domain::OptionTags::DomainCreator<3>,
       TestHelpers::domain::BoundaryConditions::
           MetavariablesWithoutBoundaryConditions<3>>(
       "Shell:\n"

--- a/tests/Unit/Domain/Creators/Test_Shell.cpp
+++ b/tests/Unit/Domain/Creators/Test_Shell.cpp
@@ -395,8 +395,8 @@ void test_shell_factory_equiangular() {
   INFO("Shell factory equiangular");
   const auto helper = [](const auto expected_boundary_conditions,
                          auto use_boundary_condition) {
-    const auto shell = TestHelpers::test_factory_creation<
-        DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+    const auto shell = TestHelpers::test_creation<
+        std::unique_ptr<DomainCreator<3>>, domain::OptionTags::DomainCreator<3>,
         tmpl::conditional_t<decltype(use_boundary_condition)::value,
                             TestHelpers::domain::BoundaryConditions::
                                 MetavariablesWithBoundaryConditions<3>,
@@ -432,8 +432,8 @@ void test_shell_factory_equidistant() {
   INFO("Shell factory equidistant");
   const auto helper = [](const auto expected_boundary_conditions,
                          auto use_boundary_condition) {
-    const auto shell = TestHelpers::test_factory_creation<
-        DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+    const auto shell = TestHelpers::test_creation<
+        std::unique_ptr<DomainCreator<3>>, domain::OptionTags::DomainCreator<3>,
         tmpl::conditional_t<decltype(use_boundary_condition)::value,
                             TestHelpers::domain::BoundaryConditions::
                                 MetavariablesWithBoundaryConditions<3>,
@@ -504,8 +504,8 @@ void test_shell_factory_aspect_ratio() {
   INFO("Shell factory aspect ratio");
   const auto helper = [](const auto expected_boundary_conditions,
                          auto use_boundary_condition) {
-    const auto shell = TestHelpers::test_factory_creation<
-        DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+    const auto shell = TestHelpers::test_creation<
+        std::unique_ptr<DomainCreator<3>>, domain::OptionTags::DomainCreator<3>,
         tmpl::conditional_t<decltype(use_boundary_condition)::value,
                             TestHelpers::domain::BoundaryConditions::
                                 MetavariablesWithBoundaryConditions<3>,
@@ -620,8 +620,8 @@ void test_shell_factory_logarithmic_map() {
   INFO("Shell factory logarithmic map");
   const auto helper = [](const auto expected_boundary_conditions,
                          auto use_boundary_condition) {
-    const auto shell = TestHelpers::test_factory_creation<
-        DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+    const auto shell = TestHelpers::test_creation<
+        std::unique_ptr<DomainCreator<3>>, domain::OptionTags::DomainCreator<3>,
         tmpl::conditional_t<decltype(use_boundary_condition)::value,
                             TestHelpers::domain::BoundaryConditions::
                                 MetavariablesWithBoundaryConditions<3>,
@@ -655,8 +655,8 @@ void test_shell_factory_logarithmic_map() {
   helper(create_boundary_conditions(1, ShellWedges::All), std::true_type{});
 
   INFO("Test with multiple radial layers");
-  const auto shell = TestHelpers::test_factory_creation<
-      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+  const auto shell = TestHelpers::test_creation<
+      std::unique_ptr<DomainCreator<3>>, domain::OptionTags::DomainCreator<3>,
       TestHelpers::domain::BoundaryConditions::
           MetavariablesWithBoundaryConditions<3>>(
       "Shell:\n"
@@ -702,8 +702,8 @@ void test_shell_factory_logarithmic_map() {
 
 void test_shell_factory_wedges_four_on_equator() {
   INFO("Shell factory wedges four on equator");
-  const auto shell = TestHelpers::test_factory_creation<
-      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+  const auto shell = TestHelpers::test_creation<
+      std::unique_ptr<DomainCreator<3>>, domain::OptionTags::DomainCreator<3>,
       TestHelpers::domain::BoundaryConditions::
           MetavariablesWithoutBoundaryConditions<3>>(
       "Shell:\n"
@@ -731,8 +731,8 @@ void test_shell_factory_wedges_four_on_equator() {
 
 void test_shell_factory_wedges_one_along_minus_x() {
   INFO("Shell factory wedges one along minus x");
-  const auto shell = TestHelpers::test_factory_creation<
-      DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+  const auto shell = TestHelpers::test_creation<
+      std::unique_ptr<DomainCreator<3>>, domain::OptionTags::DomainCreator<3>,
       TestHelpers::domain::BoundaryConditions::
           MetavariablesWithoutBoundaryConditions<3>>(
       "Shell:\n"

--- a/tests/Unit/Domain/Creators/Test_Shell.cpp
+++ b/tests/Unit/Domain/Creators/Test_Shell.cpp
@@ -104,8 +104,8 @@ void test_shell_construction(
     const std::vector<DirectionMap<
         3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>&
         expected_boundary_conditions = {}) {
-  Parallel::register_classes_in_list<
-      typename domain::creators::Shell::maps_list>();
+  Parallel::register_classes_with_charm(
+      typename domain::creators::Shell::maps_list{});
   const auto domain = shell.create_domain();
   const OrientationMap<3> aligned_orientation{};
   const OrientationMap<3> quarter_turn_ccw_about_zeta(

--- a/tests/Unit/Domain/Creators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/Test_Sphere.cpp
@@ -296,8 +296,8 @@ void test_sphere_factory_equiangular() {
   INFO("Sphere factory equiangular");
   const auto helper = [](const auto expected_boundary_conditions,
                          auto use_boundary_condition) {
-    const auto sphere = TestHelpers::test_creation<
-        std::unique_ptr<DomainCreator<3>>, domain::OptionTags::DomainCreator<3>,
+    const auto sphere = TestHelpers::test_option_tag<
+        domain::OptionTags::DomainCreator<3>,
         tmpl::conditional_t<decltype(use_boundary_condition)::value,
                             TestHelpers::domain::BoundaryConditions::
                                 MetavariablesWithBoundaryConditions<3>,
@@ -354,8 +354,8 @@ void test_sphere_factory_equidistant() {
   INFO("Sphere factory equidistant");
   const auto helper = [](const auto expected_boundary_conditions,
                          auto use_boundary_condition) {
-    const auto sphere = TestHelpers::test_creation<
-        std::unique_ptr<DomainCreator<3>>, domain::OptionTags::DomainCreator<3>,
+    const auto sphere = TestHelpers::test_option_tag<
+        domain::OptionTags::DomainCreator<3>,
         tmpl::conditional_t<decltype(use_boundary_condition)::value,
                             TestHelpers::domain::BoundaryConditions::
                                 MetavariablesWithBoundaryConditions<3>,

--- a/tests/Unit/Domain/Creators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/Test_Sphere.cpp
@@ -296,8 +296,8 @@ void test_sphere_factory_equiangular() {
   INFO("Sphere factory equiangular");
   const auto helper = [](const auto expected_boundary_conditions,
                          auto use_boundary_condition) {
-    const auto sphere = TestHelpers::test_factory_creation<
-        DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+    const auto sphere = TestHelpers::test_creation<
+        std::unique_ptr<DomainCreator<3>>, domain::OptionTags::DomainCreator<3>,
         tmpl::conditional_t<decltype(use_boundary_condition)::value,
                             TestHelpers::domain::BoundaryConditions::
                                 MetavariablesWithBoundaryConditions<3>,
@@ -354,8 +354,8 @@ void test_sphere_factory_equidistant() {
   INFO("Sphere factory equidistant");
   const auto helper = [](const auto expected_boundary_conditions,
                          auto use_boundary_condition) {
-    const auto sphere = TestHelpers::test_factory_creation<
-        DomainCreator<3>, domain::OptionTags::DomainCreator<3>,
+    const auto sphere = TestHelpers::test_creation<
+        std::unique_ptr<DomainCreator<3>>, domain::OptionTags::DomainCreator<3>,
         tmpl::conditional_t<decltype(use_boundary_condition)::value,
                             TestHelpers::domain::BoundaryConditions::
                                 MetavariablesWithBoundaryConditions<3>,

--- a/tests/Unit/Domain/Creators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/Test_Sphere.cpp
@@ -241,8 +241,8 @@ void test_sphere_construction(
   test_initial_domain(domain, sphere.initial_refinement_levels());
   test_initial_domain(domain_no_corners, sphere.initial_refinement_levels());
 
-  Parallel::register_classes_in_list<
-      typename domain::creators::Sphere::maps_list>();
+  Parallel::register_classes_with_charm(
+      typename domain::creators::Sphere::maps_list{});
 
   test_serialization(domain);
   test_serialization(domain_no_corners);

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_CubicScale.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_CubicScale.cpp
@@ -168,17 +168,18 @@ void test() noexcept {
   test_impl(time_dep->get_clone(), initial_time, update_delta_t, outer_boundary,
             initial_expansion, velocity, acceleration, f_of_t_names);
 
-  test_impl(TestHelpers::test_factory_creation<TimeDependence<MeshDim>>(
-                "CubicScale:\n"
-                "  InitialTime: 1.3\n"
-                "  InitialExpirationDeltaT: 2.5\n"
-                "  OuterBoundary: 10.4\n"
-                "  InitialExpansion: [1.0, 1.0]\n"
-                "  Velocity: [-0.1, 0.0]\n"
-                "  Acceleration: [0.0, 0.0]\n"
-                "  FunctionOfTimeNames: [Expansion0, Expansion1]\n"),
-            initial_time, update_delta_t, outer_boundary, initial_expansion,
-            velocity, acceleration, f_of_t_names);
+  test_impl(
+      TestHelpers::test_creation<std::unique_ptr<TimeDependence<MeshDim>>>(
+          "CubicScale:\n"
+          "  InitialTime: 1.3\n"
+          "  InitialExpirationDeltaT: 2.5\n"
+          "  OuterBoundary: 10.4\n"
+          "  InitialExpansion: [1.0, 1.0]\n"
+          "  Velocity: [-0.1, 0.0]\n"
+          "  Acceleration: [0.0, 0.0]\n"
+          "  FunctionOfTimeNames: [Expansion0, Expansion1]\n"),
+      initial_time, update_delta_t, outer_boundary, initial_expansion, velocity,
+      acceleration, f_of_t_names);
 
   INFO("Check equivalence operators");
   CubicScale<MeshDim> cubic_scale0{

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_None.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_None.cpp
@@ -31,7 +31,8 @@ void test() noexcept {
   CHECK(time_dep_clone != nullptr);
 
   const std::unique_ptr<TimeDependence<MeshDim>> time_dep_factory =
-      TestHelpers::test_factory_creation<TimeDependence<MeshDim>>("None\n");
+      TestHelpers::test_creation<std::unique_ptr<TimeDependence<MeshDim>>>(
+          "None\n");
   CHECK(time_dep_factory != nullptr);
 
   CHECK(None<MeshDim>{} == None<MeshDim>{});

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_UniformRotationAboutZAxis.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_UniformRotationAboutZAxis.cpp
@@ -198,7 +198,7 @@ SPECTRE_TEST_CASE(
     test(time_dep, initial_time, f_of_t_name);
     test(time_dep->get_clone(), initial_time, f_of_t_name);
 
-    test(TestHelpers::test_factory_creation<TimeDependence<2>>(
+    test(TestHelpers::test_creation<std::unique_ptr<TimeDependence<2>>>(
              "UniformRotationAboutZAxis:\n"
              "  InitialTime: 1.3\n"
              "  InitialExpirationDeltaT: 2.5\n"
@@ -215,7 +215,7 @@ SPECTRE_TEST_CASE(
     test(time_dep, initial_time, f_of_t_name);
     test(time_dep->get_clone(), initial_time, f_of_t_name);
 
-    test(TestHelpers::test_factory_creation<TimeDependence<3>>(
+    test(TestHelpers::test_creation<std::unique_ptr<TimeDependence<3>>>(
              "UniformRotationAboutZAxis:\n"
              "  InitialTime: 1.3\n"
              "  InitialExpirationDeltaT: Auto\n"

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_UniformTranslation.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_UniformTranslation.cpp
@@ -296,7 +296,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.UniformTranslation",
     test(time_dep, initial_time, f_of_t_names);
     test(time_dep->get_clone(), initial_time, f_of_t_names);
 
-    test(TestHelpers::test_factory_creation<TimeDependence<1>>(
+    test(TestHelpers::test_creation<std::unique_ptr<TimeDependence<1>>>(
              "UniformTranslation:\n"
              "  InitialTime: 1.3\n"
              "  InitialExpirationDeltaT: 2.5\n"
@@ -316,7 +316,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.UniformTranslation",
     test(time_dep, initial_time, f_of_t_names);
     test(time_dep->get_clone(), initial_time, f_of_t_names);
 
-    test(TestHelpers::test_factory_creation<TimeDependence<2>>(
+    test(TestHelpers::test_creation<std::unique_ptr<TimeDependence<2>>>(
              "UniformTranslation:\n"
              "  InitialTime: 1.3\n"
              "  InitialExpirationDeltaT: 2.5\n"
@@ -336,7 +336,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.UniformTranslation",
     test(time_dep, initial_time, f_of_t_names);
     test(time_dep->get_clone(), initial_time, f_of_t_names);
 
-    test(TestHelpers::test_factory_creation<TimeDependence<3>>(
+    test(TestHelpers::test_creation<std::unique_ptr<TimeDependence<3>>>(
              "UniformTranslation:\n"
              "  InitialTime: 1.3\n"
              "  InitialExpirationDeltaT: Auto\n"

--- a/tests/Unit/Domain/FunctionsOfTime/Test_ReadSpecThirdOrderPiecewisePolynomial.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_ReadSpecThirdOrderPiecewisePolynomial.cpp
@@ -195,39 +195,36 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.ReadSpecPiecewisePolynomial",
       {"Unity", "Unity"},
       {"RotationAngle", "RotationAngle"}};
 
-  const auto& created_domain_creator =
-      TestHelpers::test_creation<std::unique_ptr<::DomainCreator<3>>,
-                                 domain::OptionTags::DomainCreator<3>,
-                                 TestHelpers::domain::BoundaryConditions::
-                                     MetavariablesWithoutBoundaryConditions<3>>(
-          "Brick:\n"
-          "  LowerBound: [-4.0, -5.0, -6.0]\n"
-          "  UpperBound: [6.0, 5.0, 4.0]\n"
-          "  IsPeriodicIn: [false, false, false]\n"
-          "  InitialRefinement: [0, 0, 0]\n"
-          "  InitialGridPoints: [5, 5, 5]\n"
-          "  TimeDependence:\n"
-          "    Composition:\n"
-          "      CubicScale:\n"
-          "        CubicScale:\n"
-          "            InitialTime: 0.0\n"
-          "            InitialExpirationDeltaT: 0.2\n"
-          "            InitialExpansion: [1.0, 1.0]\n"
-          "            Velocity: [0.0, 0.0]\n"
-          "            Acceleration: [0.0, 0.0]\n"
-          "            OuterBoundary: 839.661030811156\n"
-          "            FunctionOfTimeNames: [\"ExpansionFactor\", \"Unity\"]\n"
-          "      UniformRotationAboutZAxis:\n"
-          "        UniformRotationAboutZAxis:\n"
-          "          InitialTime: 0.0\n"
-          "          InitialExpirationDeltaT: 0.2\n"
-          "          AngularVelocity: 0.0\n"
-          "          FunctionOfTimeName: \"RotationAngle\"\n");
-  const auto& created_function_of_time_file = TestHelpers::test_creation<
-      std::optional<std::string>,
+  const auto created_domain_creator = TestHelpers::test_option_tag<
+      domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithoutBoundaryConditions<3>>(
+      "Brick:\n"
+      "  LowerBound: [-4.0, -5.0, -6.0]\n"
+      "  UpperBound: [6.0, 5.0, 4.0]\n"
+      "  IsPeriodicIn: [false, false, false]\n"
+      "  InitialRefinement: [0, 0, 0]\n"
+      "  InitialGridPoints: [5, 5, 5]\n"
+      "  TimeDependence:\n"
+      "    Composition:\n"
+      "      CubicScale:\n"
+      "        CubicScale:\n"
+      "            InitialTime: 0.0\n"
+      "            InitialExpirationDeltaT: 0.2\n"
+      "            InitialExpansion: [1.0, 1.0]\n"
+      "            Velocity: [0.0, 0.0]\n"
+      "            Acceleration: [0.0, 0.0]\n"
+      "            OuterBoundary: 839.661030811156\n"
+      "            FunctionOfTimeNames: [\"ExpansionFactor\", \"Unity\"]\n"
+      "      UniformRotationAboutZAxis:\n"
+      "        UniformRotationAboutZAxis:\n"
+      "          InitialTime: 0.0\n"
+      "          InitialExpirationDeltaT: 0.2\n"
+      "          AngularVelocity: 0.0\n"
+      "          FunctionOfTimeName: \"RotationAngle\"\n");
+  const auto created_function_of_time_file = TestHelpers::test_option_tag<
       domain::FunctionsOfTime::OptionTags::FunctionOfTimeFile>(test_filename);
-  const auto& created_function_of_time_name_map = TestHelpers::test_creation<
-      std::optional<std::map<std::string, std::string>>,
+  const auto created_function_of_time_name_map = TestHelpers::test_option_tag<
       domain::FunctionsOfTime::OptionTags::FunctionOfTimeNameMap>(
       "{ExpansionFactor: ExpansionFactor, Unity: Unity, RotationAngle: "
       "RotationAngle}");
@@ -289,9 +286,8 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.ReadSpecPiecewisePolynomial",
   check_read_functions_of_time(functions_of_time, expected_functions);
 
   // Read the file again, but this time, only override one FunctionOfTime
-  const auto& created_function_of_time_name_map_expansion =
-      TestHelpers::test_creation<
-          std::optional<std::map<std::string, std::string>>,
+  const auto created_function_of_time_name_map_expansion =
+      TestHelpers::test_option_tag<
           domain::FunctionsOfTime::OptionTags::FunctionOfTimeNameMap>(
           "{ExpansionFactor: ExpansionFactor}");
   const auto& functions_of_time_expansion =

--- a/tests/Unit/Elliptic/BoundaryConditions/Test_AnalyticSolution.cpp
+++ b/tests/Unit/Elliptic/BoundaryConditions/Test_AnalyticSolution.cpp
@@ -57,8 +57,8 @@ void test_analytic_solution() noexcept {
   CAPTURE(Dim);
   // Test factory-creation
   using Registrar = Registrars::AnalyticSolution<System<Dim>>;
-  const auto boundary_condition_base = TestHelpers::test_factory_creation<
-      BoundaryCondition<Dim, tmpl::list<Registrar>>>(
+  const auto boundary_condition_base = TestHelpers::test_creation<
+      std::unique_ptr<BoundaryCondition<Dim, tmpl::list<Registrar>>>>(
       "AnalyticSolution:\n"
       "  Field1: Dirichlet\n"
       "  Field2: Neumann");

--- a/tests/Unit/Elliptic/BoundaryConditions/Test_BoundaryCondition.cpp
+++ b/tests/Unit/Elliptic/BoundaryConditions/Test_BoundaryCondition.cpp
@@ -110,8 +110,9 @@ PUP::able::PUP_ID TestBoundaryCondition<Registrars>::my_PUP_ID = 0;
 SPECTRE_TEST_CASE("Unit.Elliptic.BoundaryConditions.Base", "[Unit][Elliptic]") {
   using BoundaryConditionType = TestBoundaryCondition<>;
   // Factory-create a boundary condition and cast down to derived class
-  const auto boundary_condition_base = TestHelpers::test_factory_creation<
-      BoundaryCondition<1, tmpl::list<TestRegistrar>>>("TestBoundaryCondition");
+  const auto boundary_condition_base = TestHelpers::test_creation<
+      std::unique_ptr<BoundaryCondition<1, tmpl::list<TestRegistrar>>>>(
+          "TestBoundaryCondition");
   const auto& boundary_condition =
       dynamic_cast<const BoundaryConditionType&>(*boundary_condition_base);
 

--- a/tests/Unit/Elliptic/Systems/Elasticity/BoundaryConditions/Test_LaserBeam.cpp
+++ b/tests/Unit/Elliptic/Systems/Elasticity/BoundaryConditions/Test_LaserBeam.cpp
@@ -61,9 +61,9 @@ void apply_boundary_condition(
 SPECTRE_TEST_CASE("Unit.Elasticity.BoundaryConditions.LaserBeam",
                   "[Unit][Elliptic]") {
   // Test factory-creation
-  const auto created = TestHelpers::test_factory_creation<
-      elliptic::BoundaryConditions::BoundaryCondition<
-          3, tmpl::list<Registrars::LaserBeam>>>(
+  const auto created = TestHelpers::test_creation<
+      std::unique_ptr<elliptic::BoundaryConditions::BoundaryCondition<
+          3, tmpl::list<Registrars::LaserBeam>>>>(
       "LaserBeam:\n"
       "  BeamWidth: 2.");
 

--- a/tests/Unit/Elliptic/Systems/Elasticity/BoundaryConditions/Test_Zero.cpp
+++ b/tests/Unit/Elliptic/Systems/Elasticity/BoundaryConditions/Test_Zero.cpp
@@ -27,12 +27,12 @@ SPECTRE_TEST_CASE("Unit.Elasticity.BoundaryConditions.Zero",
       Registrars::Zero<2, elliptic::BoundaryConditionType::Dirichlet>;
   using registrar_free =
       Registrars::Zero<2, elliptic::BoundaryConditionType::Neumann>;
-  const auto created_fixed = TestHelpers::test_factory_creation<
-      elliptic::BoundaryConditions::BoundaryCondition<
-          2, tmpl::list<registrar_fixed>>>("Fixed");
-  const auto created_free = TestHelpers::test_factory_creation<
-      elliptic::BoundaryConditions::BoundaryCondition<
-          2, tmpl::list<registrar_free>>>("Free");
+  const auto created_fixed = TestHelpers::test_creation<
+      std::unique_ptr<elliptic::BoundaryConditions::BoundaryCondition<
+          2, tmpl::list<registrar_fixed>>>>("Fixed");
+  const auto created_free = TestHelpers::test_creation<
+      std::unique_ptr<elliptic::BoundaryConditions::BoundaryCondition<
+          2, tmpl::list<registrar_free>>>>("Free");
 
   // Test semantics
   using Fixed =

--- a/tests/Unit/Elliptic/Systems/Poisson/BoundaryConditions/Test_Robin.cpp
+++ b/tests/Unit/Elliptic/Systems/Poisson/BoundaryConditions/Test_Robin.cpp
@@ -52,9 +52,9 @@ void apply_neumann_boundary_condition(
 SPECTRE_TEST_CASE("Unit.Elasticity.BoundaryConditions.Robin",
                   "[Unit][Elliptic]") {
   // Test factory-creation
-  const auto created = TestHelpers::test_factory_creation<
-      elliptic::BoundaryConditions::BoundaryCondition<
-          1, tmpl::list<Registrars::Robin<1>>>>(
+  const auto created = TestHelpers::test_creation<
+      std::unique_ptr<elliptic::BoundaryConditions::BoundaryCondition<
+          1, tmpl::list<Registrars::Robin<1>>>>>(
       "Robin:\n"
       "  DirichletWeight: 2.\n"
       "  NeumannWeight: 3.\n"

--- a/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_Flatness.cpp
+++ b/tests/Unit/Elliptic/Systems/Xcts/BoundaryConditions/Test_Flatness.cpp
@@ -75,9 +75,9 @@ void test_flatness(const Flatness<>& boundary_condition) {
 
 SPECTRE_TEST_CASE("Unit.Xcts.BoundaryConditions.Flatness", "[Unit][Elliptic]") {
   // Test factory-creation
-  const auto created = TestHelpers::test_factory_creation<
-      elliptic::BoundaryConditions::BoundaryCondition<
-          3, tmpl::list<Registrars::Flatness>>>("Flatness");
+  const auto created = TestHelpers::test_creation<
+      std::unique_ptr<elliptic::BoundaryConditions::BoundaryCondition<
+          3, tmpl::list<Registrars::Flatness>>>>("Flatness");
   REQUIRE(dynamic_cast<const Flatness<>*>(created.get()) != nullptr);
   const auto& boundary_condition = dynamic_cast<const Flatness<>&>(*created);
   {

--- a/tests/Unit/Elliptic/Triggers/Test_EveryNIterations.cpp
+++ b/tests/Unit/Elliptic/Triggers/Test_EveryNIterations.cpp
@@ -31,7 +31,7 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Triggers.EveryNIterations",
       elliptic::Triggers::Registrars::EveryNIterations<IterationIdTag>>>;
   Parallel::register_derived_classes_with_charm<TriggerType>();
 
-  const auto trigger = TestHelpers::test_factory_creation<TriggerType>(
+  const auto trigger = TestHelpers::test_creation<std::unique_ptr<TriggerType>>(
       "EveryNIterations:\n"
       "  N: 3\n"
       "  Offset: 5");

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
@@ -282,19 +282,19 @@ void test(const bool always_use_subcell, const bool interior_element) {
 
 SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Actions.Initialize",
                   "[Evolution][Unit]") {
-  Parallel::register_classes_in_list<
-      tmpl::list<domain::CoordinateMap<Frame::Logical, Frame::Grid,
-                                       domain::CoordinateMaps::Identity<1>>,
-                 domain::CoordinateMap<Frame::Logical, Frame::Grid,
-                                       domain::CoordinateMaps::Identity<2>>,
-                 domain::CoordinateMap<Frame::Logical, Frame::Grid,
-                                       domain::CoordinateMaps::Identity<3>>,
-                 domain::CoordinateMap<Frame::Grid, Frame::Inertial,
-                                       domain::CoordinateMaps::Identity<1>>,
-                 domain::CoordinateMap<Frame::Grid, Frame::Inertial,
-                                       domain::CoordinateMaps::Identity<2>>,
-                 domain::CoordinateMap<Frame::Grid, Frame::Inertial,
-                                       domain::CoordinateMaps::Identity<3>>>>();
+  Parallel::register_classes_with_charm<
+      domain::CoordinateMap<Frame::Logical, Frame::Grid,
+                            domain::CoordinateMaps::Identity<1>>,
+      domain::CoordinateMap<Frame::Logical, Frame::Grid,
+                            domain::CoordinateMaps::Identity<2>>,
+      domain::CoordinateMap<Frame::Logical, Frame::Grid,
+                            domain::CoordinateMaps::Identity<3>>,
+      domain::CoordinateMap<Frame::Grid, Frame::Inertial,
+                            domain::CoordinateMaps::Identity<1>>,
+      domain::CoordinateMap<Frame::Grid, Frame::Inertial,
+                            domain::CoordinateMaps::Identity<2>>,
+      domain::CoordinateMap<Frame::Grid, Frame::Inertial,
+                            domain::CoordinateMaps::Identity<3>>>();
   for (const bool always_use_subcell : {false, true}) {
     for (const bool interior_element : {false, true}) {
       test<1, true>(always_use_subcell, interior_element);

--- a/tests/Unit/Evolution/DgSubcell/Test_SubcellOptions.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_SubcellOptions.cpp
@@ -60,7 +60,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Subcell.SubcellOptions",
   CHECK(options == deserialized_options);
 
   CHECK(options ==
-        TestHelpers::test_creation<SubcellOptions, OptionTags::SubcellOptions>(
+        TestHelpers::test_option_tag<OptionTags::SubcellOptions>(
             "InitialData:\n"
             "  RdmpDelta0: 1.0e-3\n"
             "  RdmpEpsilon: 1.0e-4\n"

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_QuadratureTag.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_QuadratureTag.cpp
@@ -14,10 +14,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.Initialization.QuadratureTag",
                   "[Unit][Evolution]") {
   TestHelpers::db::test_simple_tag<evolution::dg::Tags::Quadrature>(
       "Quadrature");
-  CHECK(TestHelpers::test_creation<Spectral::Quadrature,
-                                   evolution::dg::OptionTags::Quadrature>(
+  CHECK(TestHelpers::test_option_tag<evolution::dg::OptionTags::Quadrature>(
             "Gauss") == Spectral::Quadrature::Gauss);
-  CHECK(TestHelpers::test_creation<Spectral::Quadrature,
-                                   evolution::dg::OptionTags::Quadrature>(
+  CHECK(TestHelpers::test_option_tag<evolution::dg::OptionTags::Quadrature>(
             "GaussLobatto") == Spectral::Quadrature::GaussLobatto);
 }

--- a/tests/Unit/Evolution/Initialization/Test_SetVariables.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_SetVariables.cpp
@@ -283,22 +283,22 @@ void test_analytic_data() noexcept {
 SPECTRE_TEST_CASE("Unit.Evolution.Initialization.SetVariables",
                   "[Unit][Evolution][Actions]") {
   domain::FunctionsOfTime::register_derived_with_charm();
-  Parallel::register_classes_in_list<
-      tmpl::list<domain::CoordinateMap<Frame::Logical, Frame::Grid,
-                                       domain::CoordinateMaps::Identity<1>>,
-                 domain::CoordinateMap<Frame::Logical, Frame::Grid,
-                                       domain::CoordinateMaps::Identity<2>>,
-                 domain::CoordinateMap<Frame::Logical, Frame::Grid,
-                                       domain::CoordinateMaps::Identity<3>>,
-                 domain::CoordinateMap<
-                     Frame::Grid, Frame::Inertial,
-                     domain::CoordinateMaps::TimeDependent::CubicScale<1>>,
-                 domain::CoordinateMap<
-                     Frame::Grid, Frame::Inertial,
-                     domain::CoordinateMaps::TimeDependent::CubicScale<2>>,
-                 domain::CoordinateMap<
-                     Frame::Grid, Frame::Inertial,
-                     domain::CoordinateMaps::TimeDependent::CubicScale<3>>>>();
+  Parallel::register_classes_with_charm<
+      domain::CoordinateMap<Frame::Logical, Frame::Grid,
+                            domain::CoordinateMaps::Identity<1>>,
+      domain::CoordinateMap<Frame::Logical, Frame::Grid,
+                            domain::CoordinateMaps::Identity<2>>,
+      domain::CoordinateMap<Frame::Logical, Frame::Grid,
+                            domain::CoordinateMaps::Identity<3>>,
+      domain::CoordinateMap<
+          Frame::Grid, Frame::Inertial,
+          domain::CoordinateMaps::TimeDependent::CubicScale<1>>,
+      domain::CoordinateMap<
+          Frame::Grid, Frame::Inertial,
+          domain::CoordinateMaps::TimeDependent::CubicScale<2>>,
+      domain::CoordinateMap<
+          Frame::Grid, Frame::Inertial,
+          domain::CoordinateMaps::TimeDependent::CubicScale<3>>>();
 
   // Test setting variables from analytic solution
   test_analytic_solution<1, false>();

--- a/tests/Unit/Evolution/Systems/Burgers/BoundaryConditions/Test_Outflow.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/BoundaryConditions/Test_Outflow.cpp
@@ -27,8 +27,9 @@ SPECTRE_TEST_CASE("Unit.Burgers.BoundaryConditions.Outflow",
       "Evolution/Systems/Burgers/BoundaryConditions/"};
   MAKE_GENERATOR(gen);
   const std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-      boundary_condition = TestHelpers::test_factory_creation<
-          Burgers::BoundaryConditions::BoundaryCondition>("Outflow:\n");
+      boundary_condition = TestHelpers::test_creation<
+          std::unique_ptr<Burgers::BoundaryConditions::BoundaryCondition>>(
+          "Outflow:\n");
 
   helpers::test_boundary_condition_with_python<
       Burgers::BoundaryConditions::Outflow,

--- a/tests/Unit/Evolution/Systems/Burgers/BoundaryCorrections/Test_Hll.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/BoundaryCorrections/Test_Hll.cpp
@@ -37,8 +37,9 @@ SPECTRE_TEST_CASE("Unit.Burgers.Hll", "[Unit][Burgers]") {
       Mesh<0>{1, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {},
       {});
 
-  const auto Hll = TestHelpers::test_factory_creation<
-      Burgers::BoundaryCorrections::BoundaryCorrection>("Hll:");
+  const auto Hll = TestHelpers::test_creation<
+      std::unique_ptr<Burgers::BoundaryCorrections::BoundaryCorrection>>(
+      "Hll:");
 
   TestHelpers::evolution::dg::test_boundary_correction_with_python<
       Burgers::System>(

--- a/tests/Unit/Evolution/Systems/Burgers/BoundaryCorrections/Test_Rusanov.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/BoundaryCorrections/Test_Rusanov.cpp
@@ -37,8 +37,9 @@ SPECTRE_TEST_CASE("Unit.Burgers.Rusanov", "[Unit][Burgers]") {
       Mesh<0>{1, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {},
       {});
 
-  const auto rusanov = TestHelpers::test_factory_creation<
-      Burgers::BoundaryCorrections::BoundaryCorrection>("Rusanov:");
+  const auto rusanov = TestHelpers::test_creation<
+      std::unique_ptr<Burgers::BoundaryCorrections::BoundaryCorrection>>(
+      "Rusanov:");
 
   TestHelpers::evolution::dg::test_boundary_correction_with_python<
       Burgers::System>(

--- a/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
@@ -77,69 +77,54 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
   TestHelpers::db::test_simple_tag<Cce::Tags::OutputNoninertialNews>(
       "OutputNoninertialNews");
 
-  CHECK(TestHelpers::test_creation<size_t, Cce::OptionTags::LMax>("8") == 8_st);
-  CHECK(TestHelpers::test_creation<size_t, Cce::OptionTags::FilterLMax>("7") ==
-        7_st);
-  CHECK(TestHelpers::test_creation<double, Cce::OptionTags::RadialFilterAlpha>(
+  CHECK(TestHelpers::test_option_tag<Cce::OptionTags::LMax>("8") == 8_st);
+  CHECK(TestHelpers::test_option_tag<Cce::OptionTags::FilterLMax>("7") == 7_st);
+  CHECK(TestHelpers::test_option_tag<Cce::OptionTags::RadialFilterAlpha>(
             "32.5") == 32.5);
-  CHECK(TestHelpers::test_creation<size_t,
-                                   Cce::OptionTags::RadialFilterHalfPower>(
+  CHECK(TestHelpers::test_option_tag<Cce::OptionTags::RadialFilterHalfPower>(
             "20") == 20_st);
-  CHECK(TestHelpers::test_creation<size_t, Cce::OptionTags::ObservationLMax>(
-            "6") == 6_st);
-  CHECK(
-      TestHelpers::test_creation<size_t, Cce::OptionTags::NumberOfRadialPoints>(
-          "3") == 3_st);
-  CHECK(TestHelpers::test_creation<double, Cce::OptionTags::ExtractionRadius>(
+  CHECK(TestHelpers::test_option_tag<Cce::OptionTags::ObservationLMax>("6") ==
+        6_st);
+  CHECK(TestHelpers::test_option_tag<Cce::OptionTags::NumberOfRadialPoints>(
+            "3") == 3_st);
+  CHECK(TestHelpers::test_option_tag<Cce::OptionTags::ExtractionRadius>(
             "100.0") == 100.0);
-  CHECK(TestHelpers::test_creation<std::optional<double>,
-                                   Cce::OptionTags::ExtractionRadius>(
-            "100.0") == std::optional<double>{100.0});
 
-  CHECK(TestHelpers::test_creation<std::optional<double>,
-                                   Cce::OptionTags::EndTime>("4.0") ==
-        std::optional<double>{4.0});
-  CHECK(TestHelpers::test_creation<std::optional<double>,
-                                   Cce::OptionTags::EndTime>("Auto") ==
-        std::optional<double>{});
-  CHECK(TestHelpers::test_creation<std::optional<double>,
-                                   Cce::OptionTags::StartTime>("2.0") ==
-        std::optional<double>{2.0});
-  CHECK(TestHelpers::test_creation<std::optional<double>,
-                                   Cce::OptionTags::StartTime>("Auto") ==
-        std::optional<double>{});
-  CHECK(TestHelpers::test_creation<double, Cce::OptionTags::TargetStepSize>(
-            "0.5") == 0.5);
-  CHECK(TestHelpers::test_creation<std::string,
-                                   Cce::OptionTags::BoundaryDataFilename>(
+  CHECK(TestHelpers::test_option_tag<Cce::OptionTags::EndTime>("4.0") ==
+        Options::Auto<double>{4.0});
+  CHECK(TestHelpers::test_option_tag<Cce::OptionTags::EndTime>("Auto") ==
+        Options::Auto<double>{});
+  CHECK(TestHelpers::test_option_tag<Cce::OptionTags::StartTime>("2.0") ==
+        Options::Auto<double>{2.0});
+  CHECK(TestHelpers::test_option_tag<Cce::OptionTags::StartTime>("Auto") ==
+        Options::Auto<double>{});
+  CHECK(TestHelpers::test_option_tag<Cce::OptionTags::TargetStepSize>("0.5") ==
+        0.5);
+  CHECK(TestHelpers::test_option_tag<Cce::OptionTags::BoundaryDataFilename>(
             "OptionTagsCceR0100.h5") == "OptionTagsCceR0100.h5");
-  CHECK(TestHelpers::test_creation<size_t, Cce::OptionTags::H5LookaheadTimes>(
-            "5") == 5_st);
-  CHECK(TestHelpers::test_creation<size_t,
-                                   Cce::OptionTags::ScriInterpolationOrder>(
+  CHECK(TestHelpers::test_option_tag<Cce::OptionTags::H5LookaheadTimes>("5") ==
+        5_st);
+  CHECK(TestHelpers::test_option_tag<Cce::OptionTags::ScriInterpolationOrder>(
             "4") == 4_st);
 
-  auto option_created_lockstep_interface_manager = TestHelpers::test_creation<
-      std::unique_ptr<Cce::InterfaceManagers::GhInterfaceManager>,
-      Cce::OptionTags::GhInterfaceManager>("GhLockstep");
+  auto option_created_lockstep_interface_manager =
+      TestHelpers::test_option_tag<Cce::OptionTags::GhInterfaceManager>(
+          "GhLockstep");
   CHECK(std::is_same_v<
         decltype(option_created_lockstep_interface_manager),
         std::unique_ptr<Cce::InterfaceManagers::GhInterfaceManager>>);
 
-  CHECK(TestHelpers::test_creation<size_t, Cce::OptionTags::ScriOutputDensity>(
-            "6") == 6_st);
+  CHECK(TestHelpers::test_option_tag<Cce::OptionTags::ScriOutputDensity>("6") ==
+        6_st);
 
-  TestHelpers::test_creation<std::unique_ptr<::Cce::InitializeJ::InitializeJ>,
-                             Cce::OptionTags::InitializeJ>("InverseCubic");
-  TestHelpers::test_creation<std::unique_ptr<::Cce::Solutions::WorldtubeData>,
-                             Cce::OptionTags::AnalyticSolution>(
+  TestHelpers::test_option_tag<Cce::OptionTags::InitializeJ>("InverseCubic");
+  TestHelpers::test_option_tag<Cce::OptionTags::AnalyticSolution>(
       "BouncingBlackHole:\n"
       "  Period: 40.0\n"
       "  ExtractionRadius: 30.0\n"
       "  Mass: 1.0\n"
       "  Amplitude: 2.0");
-  TestHelpers::test_creation<std::unique_ptr<::Cce::Solutions::WorldtubeData>,
-                             Cce::OptionTags::AnalyticSolution>(
+  TestHelpers::test_option_tag<Cce::OptionTags::AnalyticSolution>(
       "GaugeWave:\n"
       "  ExtractionRadius: 40.0\n"
       "  Mass: 1.0\n"
@@ -147,20 +132,17 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
       "  Amplitude: 0.1\n"
       "  PeakTime: 50.0\n"
       "  Duration: 10.0");
-  TestHelpers::test_creation<std::unique_ptr<::Cce::Solutions::WorldtubeData>,
-                             Cce::OptionTags::AnalyticSolution>(
+  TestHelpers::test_option_tag<Cce::OptionTags::AnalyticSolution>(
       "LinearizedBondiSachs:\n"
       "  ExtractionRadius: 40.0\n"
       "  InitialModes: [[0.20, 0.10], [0.08, 0.04]]\n"
       "  Frequency: 0.2");
-  TestHelpers::test_creation<std::unique_ptr<::Cce::Solutions::WorldtubeData>,
-                             Cce::OptionTags::AnalyticSolution>(
+  TestHelpers::test_option_tag<Cce::OptionTags::AnalyticSolution>(
       "RotatingSchwarzschild:\n"
       "  ExtractionRadius: 20.0\n"
       "  Mass: 1.0\n"
       "  Frequency: 0.0");
-  TestHelpers::test_creation<std::unique_ptr<::Cce::Solutions::WorldtubeData>,
-                             Cce::OptionTags::AnalyticSolution>(
+  TestHelpers::test_option_tag<Cce::OptionTags::AnalyticSolution>(
       "TeukolskyWave:\n"
       "  ExtractionRadius: 40.0\n"
       "  Amplitude: 0.1\n"

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/Test_UpwindPenalty.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/Test_UpwindPenalty.cpp
@@ -46,8 +46,8 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts) {
                     Spectral::Quadrature::Gauss},
       {}, {});
 
-  const auto upwind_penalty = TestHelpers::test_factory_creation<
-      GeneralizedHarmonic::BoundaryCorrections::BoundaryCorrection<Dim>>(
+  const auto upwind_penalty = TestHelpers::test_creation<std::unique_ptr<
+      GeneralizedHarmonic::BoundaryCorrections::BoundaryCorrection<Dim>>>(
       "UpwindPenalty:");
 
   TestHelpers::evolution::dg::test_boundary_correction_with_python<

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Test_GaussianPlusConstant.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Test_GaussianPlusConstant.cpp
@@ -85,8 +85,9 @@ SPECTRE_TEST_CASE(
     });
   });
 
-  TestHelpers::test_factory_creation<GeneralizedHarmonic::ConstraintDamping::
-                                         DampingFunction<1, Frame::Inertial>>(
+  TestHelpers::test_creation<
+      std::unique_ptr<GeneralizedHarmonic::ConstraintDamping::DampingFunction<
+          1, Frame::Inertial>>>(
       "GaussianPlusConstant:\n"
       "  Constant: 4.0\n"
       "  Amplitude: 3.0\n"
@@ -108,15 +109,14 @@ SPECTRE_TEST_CASE(
           "Width: 1.5\n"
           "Center: [1.1, -2.2, 3.3]");
   CHECK(created_gauss_plus_const == gauss_plus_const_3d);
-  const auto created_gauss_gh_damping_function =
-      TestHelpers::test_factory_creation<
-          GeneralizedHarmonic::ConstraintDamping::DampingFunction<
-              3, Frame::Inertial>>(
-          "GaussianPlusConstant:\n"
-          "  Constant: 5.0\n"
-          "  Amplitude: 4.0\n"
-          "  Width: 1.5\n"
-          "  Center: [1.1, -2.2, 3.3]");
+  const auto created_gauss_gh_damping_function = TestHelpers::test_creation<
+      std::unique_ptr<GeneralizedHarmonic::ConstraintDamping::DampingFunction<
+          3, Frame::Inertial>>>(
+      "GaussianPlusConstant:\n"
+      "  Constant: 5.0\n"
+      "  Amplitude: 4.0\n"
+      "  Width: 1.5\n"
+      "  Center: [1.1, -2.2, 3.3]");
 
   test_serialization(gauss_plus_const_3d);
 }

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Test_TimeDependentTripleGaussian.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Test_TimeDependentTripleGaussian.cpp
@@ -142,9 +142,9 @@ SPECTRE_TEST_CASE(
       "FunctionOfTimeForScaling: ExpansionFactor");
   CHECK(created_triple_gauss == triple_gauss_3d);
   const auto created_triple_gauss_gh_damping_function =
-      TestHelpers::test_factory_creation<
-          GeneralizedHarmonic::ConstraintDamping::DampingFunction<3,
-                                                                  Frame::Grid>>(
+      TestHelpers::test_creation<
+          std::unique_ptr<GeneralizedHarmonic::ConstraintDamping::
+                              DampingFunction<3, Frame::Grid>>>(
           "TimeDependentTripleGaussian:\n"
           "  Constant: 5.0\n"
           "  Gaussian1:\n"

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_InitializeDampedHarmonic.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_InitializeDampedHarmonic.cpp
@@ -397,8 +397,7 @@ void test_create_from_options() noexcept {
         "      RollOnTimeWindow : 100.\n";
   }
 
-  auto created = TestHelpers::test_creation<
-      GeneralizedHarmonic::gauges::DhGaugeParameters<UseRollon>,
+  auto created = TestHelpers::test_option_tag<
       GeneralizedHarmonic::gauges::OptionTags::DhGaugeParameters<UseRollon>>(
       options);
 

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Test_Rusanov.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Test_Rusanov.cpp
@@ -53,8 +53,8 @@ SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.Rusanov", "[Unit][GrMhd]") {
       Mesh<2>{5, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {},
       {});
 
-  const auto rusanov = TestHelpers::test_factory_creation<
-      grmhd::ValenciaDivClean::BoundaryCorrections::BoundaryCorrection>(
+  const auto rusanov = TestHelpers::test_creation<std::unique_ptr<
+      grmhd::ValenciaDivClean::BoundaryCorrections::BoundaryCorrection>>(
       "Rusanov:");
 
   TestHelpers::evolution::dg::test_boundary_correction_with_python<system>(

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Test_Hll.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Test_Hll.cpp
@@ -115,8 +115,8 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts,
                     Spectral::Quadrature::Gauss},
       volume_data, ranges);
 
-  const auto hll = TestHelpers::test_factory_creation<
-      NewtonianEuler::BoundaryCorrections::BoundaryCorrection<Dim>>("Hll:");
+  const auto hll = TestHelpers::test_creation<std::unique_ptr<
+      NewtonianEuler::BoundaryCorrections::BoundaryCorrection<Dim>>>("Hll:");
 
   helpers::test_boundary_correction_with_python<
       NewtonianEuler::System<Dim, EosType, DummyInitialData>,

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Test_Hllc.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Test_Hllc.cpp
@@ -117,8 +117,8 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts,
                     Spectral::Quadrature::Gauss},
       volume_data, ranges);
 
-  const auto hllc = TestHelpers::test_factory_creation<
-      NewtonianEuler::BoundaryCorrections::BoundaryCorrection<Dim>>("Hllc:");
+  const auto hllc = TestHelpers::test_creation<std::unique_ptr<
+      NewtonianEuler::BoundaryCorrections::BoundaryCorrection<Dim>>>("Hllc:");
 
   helpers::test_boundary_correction_with_python<
       NewtonianEuler::System<Dim, EosType, DummyInitialData>,

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Test_Rusanov.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Test_Rusanov.cpp
@@ -115,8 +115,9 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts,
                     Spectral::Quadrature::Gauss},
       volume_data, ranges);
 
-  const auto rusanov = TestHelpers::test_factory_creation<
-      NewtonianEuler::BoundaryCorrections::BoundaryCorrection<Dim>>("Rusanov:");
+  const auto rusanov = TestHelpers::test_creation<std::unique_ptr<
+      NewtonianEuler::BoundaryCorrections::BoundaryCorrection<Dim>>>(
+      "Rusanov:");
 
   helpers::test_boundary_correction_with_python<
       NewtonianEuler::System<Dim, EosType, DummyInitialData>,

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/BoundaryCorrections/Test_Rusanov.cpp
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/BoundaryCorrections/Test_Rusanov.cpp
@@ -49,10 +49,10 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts) {
       Mesh<2>{num_pts, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss},
       {}, {});
 
-  const auto rusanov_from_factory = TestHelpers::test_factory_creation<
+  const auto rusanov_from_factory = TestHelpers::test_creation<std::unique_ptr<
       RadiationTransport::M1Grey::BoundaryCorrections::BoundaryCorrection<
           neutrinos::ElectronNeutrinos<1>,
-          neutrinos::ElectronAntiNeutrinos<1>>>("Rusanov:");
+          neutrinos::ElectronAntiNeutrinos<1>>>>("Rusanov:");
 
   helpers::test_boundary_correction_with_python<system>(
       gen, "Rusanov",

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/BoundaryCorrections/Test_Rusanov.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/BoundaryCorrections/Test_Rusanov.cpp
@@ -112,9 +112,9 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts,
                     Spectral::Quadrature::Gauss},
       volume_data, ranges);
 
-  const auto rusanov = TestHelpers::test_factory_creation<
-      RelativisticEuler::Valencia::BoundaryCorrections::BoundaryCorrection<
-          Dim>>("Rusanov:");
+  const auto rusanov = TestHelpers::test_creation<
+      std::unique_ptr<RelativisticEuler::Valencia::BoundaryCorrections::
+                          BoundaryCorrection<Dim>>>("Rusanov:");
 
   helpers::test_boundary_correction_with_python<
       RelativisticEuler::Valencia::System<Dim, EosType>,

--- a/tests/Unit/Evolution/Systems/ScalarWave/BoundaryCorrections/Test_UpwindPenalty.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/BoundaryCorrections/Test_UpwindPenalty.cpp
@@ -45,8 +45,8 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts) {
                     Spectral::Quadrature::Gauss},
       {}, {});
 
-  const auto upwind_penalty = TestHelpers::test_factory_creation<
-      ScalarWave::BoundaryCorrections::BoundaryCorrection<Dim>>(
+  const auto upwind_penalty = TestHelpers::test_creation<std::unique_ptr<
+      ScalarWave::BoundaryCorrections::BoundaryCorrection<Dim>>>(
       "UpwindPenalty:");
 
   TestHelpers::evolution::dg::test_boundary_correction_with_python<

--- a/tests/Unit/Evolution/Test_BoundaryCorrectionTags.cpp
+++ b/tests/Unit/Evolution/Test_BoundaryCorrectionTags.cpp
@@ -54,8 +54,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.BoundaryCorrectionTags",
                   "[Unit][Evolution]") {
   TestHelpers::db::test_simple_tag<evolution::Tags::BoundaryCorrection<System>>(
       "BoundaryCorrection");
-  const auto boundary_correction = TestHelpers::test_creation<
-      std::unique_ptr<BoundaryCorrectionBase>,
+  const auto boundary_correction = TestHelpers::test_option_tag<
       evolution::OptionTags::BoundaryCorrection<System>>("BoundaryCorrection");
   CHECK(dynamic_cast<const BoundaryCorrection*>(boundary_correction.get()) !=
         nullptr);

--- a/tests/Unit/Evolution/Test_BoundaryCorrectionTags.cpp
+++ b/tests/Unit/Evolution/Test_BoundaryCorrectionTags.cpp
@@ -54,8 +54,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.BoundaryCorrectionTags",
                   "[Unit][Evolution]") {
   TestHelpers::db::test_simple_tag<evolution::Tags::BoundaryCorrection<System>>(
       "BoundaryCorrection");
-  const auto boundary_correction = TestHelpers::test_factory_creation<
-      BoundaryCorrectionBase,
+  const auto boundary_correction = TestHelpers::test_creation<
+      std::unique_ptr<BoundaryCorrectionBase>,
       evolution::OptionTags::BoundaryCorrection<System>>("BoundaryCorrection");
   CHECK(dynamic_cast<const BoundaryCorrection*>(boundary_correction.get()) !=
         nullptr);

--- a/tests/Unit/Framework/MockDistributedObject.hpp
+++ b/tests/Unit/Framework/MockDistributedObject.hpp
@@ -25,6 +25,7 @@
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/SimpleActionVisitation.hpp"
+#include "Parallel/Tags/Metavariables.hpp"
 #include "Utilities/BoostHelpers.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
@@ -352,6 +353,7 @@ class MockDistributedObject {
   using initialization_tags =
       typename detail::get_initialization_tags_from_component<Component>::type;
   using initial_tags = tmpl::flatten<tmpl::list<
+      Parallel::Tags::MetavariablesImpl<metavariables>,
       Parallel::Tags::GlobalCacheImpl<metavariables>, initialization_tags,
       db::wrap_tags_in<Parallel::Tags::FromGlobalCache, all_cache_tags>>>;
   using initial_databox = db::compute_databox_type<initial_tags>;
@@ -394,10 +396,11 @@ class MockDistributedObject {
         inboxes_(inboxes) {
     box_ = detail::ForwardAllOptionsToDataBox<initialization_tags>::apply(
         db::create<
-            db::AddSimpleTags<Parallel::Tags::GlobalCacheImpl<metavariables>>,
+            db::AddSimpleTags<Parallel::Tags::MetavariablesImpl<metavariables>,
+                              Parallel::Tags::GlobalCacheImpl<metavariables>>,
             db::AddComputeTags<db::wrap_tags_in<Parallel::Tags::FromGlobalCache,
                                                 all_cache_tags>>>(
-            global_cache_),
+            metavariables{}, global_cache_),
         std::forward<Options>(opts)...);
   }
 

--- a/tests/Unit/Framework/TestCreation.hpp
+++ b/tests/Unit/Framework/TestCreation.hpp
@@ -35,8 +35,7 @@ struct AddGroups<Tag, std::void_t<typename Tag::group>> {
 }  // namespace TestCreation_detail
 
 /// \ingroup TestingFrameworkGroup
-/// The default option tag for `TestHelpers::test_creation()`, and
-/// `TestHelpers::test_factory_creation()`.
+/// The default option tag for `TestHelpers::test_creation()`.
 template <typename T>
 struct TestCreationOpt {
   using type = T;
@@ -71,30 +70,5 @@ T test_creation(const std::string& construction_string) noexcept {
   options.parse(
       TestCreation_detail::AddGroups<OptionTag>::apply(construction_string));
   return options.template get<OptionTag, Metavariables>();
-}
-
-/// \ingroup TestingFrameworkGroup
-/// Construct a factory object from a given string.
-///
-/// The string must contain the name of the option (specifically, the struct
-/// being created from options, which is the name of the struct). Note that it
-/// is not the name of the base class, but the name of the derived class that
-/// must be given. For example, to create a `BaseClass*` pointing to a derived
-/// class of type `size_t_argument_base` with an option tag name `SizeT` the
-/// following would be used:
-///
-/// \snippet Test_TestCreation.cpp size_t_argument_base
-///
-/// Option tags can be tested by passing them as the second template parameter.
-/// If the metavariables are required to create the class then the metavariables
-/// must be passed as the third template parameter. The default option tag is
-/// `TestCreationOpt<std::unique_ptr<BaseClass>>`.
-template <typename BaseClass,
-          typename OptionTag = TestCreationOpt<std::unique_ptr<BaseClass>>,
-          typename Metavariables = NoSuchType>
-std::unique_ptr<BaseClass> test_factory_creation(
-    const std::string& construction_string) noexcept {
-  return TestHelpers::test_creation<std::unique_ptr<BaseClass>, OptionTag,
-                                    Metavariables>(construction_string);
 }
 }  // namespace TestHelpers

--- a/tests/Unit/Framework/Tests/Test_TestCreation.cpp
+++ b/tests/Unit/Framework/Tests/Test_TestCreation.cpp
@@ -44,6 +44,7 @@ Color Options::create_from_yaml<Color>::create<void>(
 }
 
 namespace {
+// [class_without_metavariables]
 struct ClassWithoutMetavariables {
   struct SizeT {
     using type = size_t;
@@ -59,6 +60,7 @@ struct ClassWithoutMetavariables {
 
   size_t value{0};
 };
+// [class_without_metavariables]
 
 struct ClassWithMetavariables {
   struct SizeT {
@@ -121,114 +123,97 @@ struct Metavars {
   static constexpr size_t value_multiplier = ValueMultiplier;
 };
 
+// [class_without_metavariables_tag]
+struct ExampleTag {
+  using type = ClassWithoutMetavariables;
+  static constexpr Options::String help = {"help"};
+  using group = OptionGroup1;
+};
+// [class_without_metavariables_tag]
+
 void test_test_creation() {
   // Test creation of fundamentals
   CHECK(TestHelpers::test_creation<double>("1.846") == 1.846);
-  CHECK(
-      TestHelpers::test_creation<double, TestHelpers::TestCreationOpt<double>>(
-          "1.846") == 1.846);
-  CHECK(TestHelpers::test_creation<double, NoGroup<double>>("1.846") == 1.846);
-  CHECK(TestHelpers::test_creation<double, OneGroup<double>>("1.846") == 1.846);
-  CHECK(TestHelpers::test_creation<double, TwoGroup<double>>("1.846") == 1.846);
+  CHECK(TestHelpers::test_option_tag<NoGroup<double>>("1.846") == 1.846);
+  CHECK(TestHelpers::test_option_tag<OneGroup<double>>("1.846") == 1.846);
+  CHECK(TestHelpers::test_option_tag<TwoGroup<double>>("1.846") == 1.846);
 
   // Test class that doesn't need metavariables when not passing metavariables
-  // [size_t_argument]
+  // [class_without_metavariables_create]
   CHECK(
       TestHelpers::test_creation<ClassWithoutMetavariables>("SizeT: 7").value ==
       7);
-  // [size_t_argument]
+  // [class_without_metavariables_create]
+  // [class_without_metavariables_create_tag]
+  CHECK(TestHelpers::test_option_tag<ExampleTag>("SizeT: 7").value == 7);
+  // [class_without_metavariables_create_tag]
 
-  CHECK(
-      TestHelpers::test_creation<ClassWithoutMetavariables,
-                                 NoGroup<ClassWithoutMetavariables>>("SizeT: 4")
-          .value == 4);
-  CHECK(TestHelpers::test_creation<ClassWithoutMetavariables,
-                                   OneGroup<ClassWithoutMetavariables>>(
+  CHECK(TestHelpers::test_option_tag<NoGroup<ClassWithoutMetavariables>>(
+            "SizeT: 4")
+            .value == 4);
+  CHECK(TestHelpers::test_option_tag<OneGroup<ClassWithoutMetavariables>>(
             "SizeT: 5")
             .value == 5);
-  CHECK(TestHelpers::test_creation<ClassWithoutMetavariables,
-                                   TwoGroup<ClassWithoutMetavariables>>(
+  CHECK(TestHelpers::test_option_tag<TwoGroup<ClassWithoutMetavariables>>(
             "SizeT: 6")
             .value == 6);
 
   // Test class that doesn't need metavariables but passing metavariables
-  CHECK(
-      TestHelpers::test_creation<
-          ClassWithoutMetavariables,
-          TestHelpers::TestCreationOpt<ClassWithoutMetavariables>, Metavars<3>>(
-          "SizeT: 8")
-          .value == 8);
-  CHECK(TestHelpers::test_creation<ClassWithoutMetavariables,
-                                   NoGroup<ClassWithoutMetavariables>,
-                                   Metavars<4>>("SizeT: 9")
+  CHECK(TestHelpers::test_creation<ClassWithoutMetavariables, Metavars<3>>(
+            "SizeT: 8")
+            .value == 8);
+  CHECK(TestHelpers::test_option_tag<NoGroup<ClassWithoutMetavariables>,
+                                     Metavars<4>>("SizeT: 9")
             .value == 9);
-  CHECK(TestHelpers::test_creation<ClassWithoutMetavariables,
-                                   OneGroup<ClassWithoutMetavariables>,
-                                   Metavars<5>>("SizeT: 10")
+  CHECK(TestHelpers::test_option_tag<OneGroup<ClassWithoutMetavariables>,
+                                     Metavars<5>>("SizeT: 10")
             .value == 10);
-  CHECK(TestHelpers::test_creation<ClassWithoutMetavariables,
-                                   TwoGroup<ClassWithoutMetavariables>,
-                                   Metavars<6>>("SizeT: 11")
+  CHECK(TestHelpers::test_option_tag<TwoGroup<ClassWithoutMetavariables>,
+                                     Metavars<6>>("SizeT: 11")
             .value == 11);
 
   // Test class that uses metavariables but not passing metavariables
-  CHECK(TestHelpers::test_creation<
-            ClassWithMetavariables,
-            TestHelpers::TestCreationOpt<ClassWithMetavariables>>("SizeT: 4")
-            .value == std::numeric_limits<size_t>::max());
-  CHECK(TestHelpers::test_creation<ClassWithMetavariables,
-                                   NoGroup<ClassWithMetavariables>>("SizeT: 4")
-            .value == std::numeric_limits<size_t>::max());
-  CHECK(TestHelpers::test_creation<ClassWithMetavariables,
-                                   OneGroup<ClassWithMetavariables>>("SizeT: 4")
-            .value == std::numeric_limits<size_t>::max());
-  CHECK(TestHelpers::test_creation<ClassWithMetavariables,
-                                   TwoGroup<ClassWithMetavariables>>("SizeT: 4")
-            .value == std::numeric_limits<size_t>::max());
+  CHECK(
+      TestHelpers::test_option_tag<NoGroup<ClassWithMetavariables>>("SizeT: 4")
+          .value == std::numeric_limits<size_t>::max());
+  CHECK(
+      TestHelpers::test_option_tag<OneGroup<ClassWithMetavariables>>("SizeT: 4")
+          .value == std::numeric_limits<size_t>::max());
+  CHECK(
+      TestHelpers::test_option_tag<TwoGroup<ClassWithMetavariables>>("SizeT: 4")
+          .value == std::numeric_limits<size_t>::max());
 
   // Test class that uses metavariables but passing metavariables
-  CHECK(TestHelpers::test_creation<
-            ClassWithMetavariables,
-            TestHelpers::TestCreationOpt<ClassWithMetavariables>, Metavars<3>>(
+  CHECK(TestHelpers::test_creation<ClassWithMetavariables, Metavars<3>>(
             "SizeT: 4")
             .value == 12);
-  CHECK(
-      TestHelpers::test_creation<ClassWithMetavariables,
-                                 NoGroup<ClassWithMetavariables>, Metavars<4>>(
-          "SizeT: 4")
-          .value == 16);
-  CHECK(
-      TestHelpers::test_creation<ClassWithMetavariables,
-                                 OneGroup<ClassWithMetavariables>, Metavars<5>>(
-          "SizeT: 4")
-          .value == 20);
-  CHECK(
-      TestHelpers::test_creation<ClassWithMetavariables,
-                                 TwoGroup<ClassWithMetavariables>, Metavars<6>>(
-          "SizeT: 4")
-          .value == 24);
+  CHECK(TestHelpers::test_option_tag<NoGroup<ClassWithMetavariables>,
+                                     Metavars<4>>("SizeT: 4")
+            .value == 16);
+  CHECK(TestHelpers::test_option_tag<OneGroup<ClassWithMetavariables>,
+                                     Metavars<5>>("SizeT: 4")
+            .value == 20);
+  CHECK(TestHelpers::test_option_tag<TwoGroup<ClassWithMetavariables>,
+                                     Metavars<6>>("SizeT: 4")
+            .value == 24);
 }
 
 void test_test_enum_creation() {
-  // [enum_purple]
   CHECK(TestHelpers::test_creation<Color>("Purple") == Color::Purple);
-  // [enum_purple]
-  CHECK(TestHelpers::test_creation<Color, TestHelpers::TestCreationOpt<Color>>(
-            "Purple") == Color::Purple);
-  CHECK(TestHelpers::test_creation<Color, NoGroup<Color>>("Purple") ==
+  CHECK(TestHelpers::test_option_tag<NoGroup<Color>>("Purple") ==
         Color::Purple);
-  CHECK(TestHelpers::test_creation<Color, OneGroup<Color>>("Purple") ==
+  CHECK(TestHelpers::test_option_tag<OneGroup<Color>>("Purple") ==
         Color::Purple);
-  CHECK(TestHelpers::test_creation<Color, TwoGroup<Color>>("Purple") ==
+  CHECK(TestHelpers::test_option_tag<TwoGroup<Color>>("Purple") ==
         Color::Purple);
-  CHECK(TestHelpers::test_creation<Color, TestHelpers::TestCreationOpt<Color>,
-                                   Metavars<3>>("Purple") == Color::Purple);
-  CHECK(TestHelpers::test_creation<Color, NoGroup<Color>, Metavars<3>>(
-            "Purple") == Color::Purple);
-  CHECK(TestHelpers::test_creation<Color, OneGroup<Color>, Metavars<3>>(
-            "Purple") == Color::Purple);
-  CHECK(TestHelpers::test_creation<Color, TwoGroup<Color>, Metavars<3>>(
-            "Purple") == Color::Purple);
+  CHECK(TestHelpers::test_creation<Color, Metavars<3>>("Purple") ==
+        Color::Purple);
+  CHECK(TestHelpers::test_option_tag<NoGroup<Color>, Metavars<3>>("Purple") ==
+        Color::Purple);
+  CHECK(TestHelpers::test_option_tag<OneGroup<Color>, Metavars<3>>("Purple") ==
+        Color::Purple);
+  CHECK(TestHelpers::test_option_tag<TwoGroup<Color>, Metavars<3>>("Purple") ==
+        Color::Purple);
 }
 
 SPECTRE_TEST_CASE("Unit.TestCreation", "[Unit]") {

--- a/tests/Unit/Framework/Tests/Test_TestCreation.cpp
+++ b/tests/Unit/Framework/Tests/Test_TestCreation.cpp
@@ -131,6 +131,40 @@ struct ExampleTag {
 };
 // [class_without_metavariables_tag]
 
+struct BaseClass {
+  BaseClass() = default;
+  BaseClass(const BaseClass&) = delete;
+  BaseClass& operator=(const BaseClass&) = delete;
+  BaseClass(BaseClass&&) = default;
+  BaseClass& operator=(BaseClass&&) = default;
+  virtual ~BaseClass() = default;
+
+  virtual size_t get_value() const = 0;
+};
+
+struct DerivedClass : BaseClass {
+  struct SizeT {
+    using type = size_t;
+    static constexpr Options::String help = {"SizeT help"};
+  };
+
+  using options = tmpl::list<SizeT>;
+  static constexpr Options::String help = {"Help"};
+
+  explicit DerivedClass(const size_t in_value) : value(in_value) {}
+
+  DerivedClass() = default;
+  DerivedClass(const DerivedClass&) = delete;
+  DerivedClass& operator=(const DerivedClass&) = delete;
+  DerivedClass(DerivedClass&&) = default;
+  DerivedClass& operator=(DerivedClass&&) = default;
+  ~DerivedClass() override = default;
+
+  size_t get_value() const override { return value; }
+
+  size_t value{0};
+};
+
 void test_test_creation() {
   // Test creation of fundamentals
   CHECK(TestHelpers::test_creation<double>("1.846") == 1.846);
@@ -198,6 +232,15 @@ void test_test_creation() {
             .value == 24);
 }
 
+void test_test_factory_creation() {
+  // [test_factory_creation]
+  CHECK(TestHelpers::test_factory_creation<BaseClass, DerivedClass>(
+            "DerivedClass:\n"
+            "  SizeT: 5")
+            ->get_value() == 5);
+  // [test_factory_creation]
+}
+
 void test_test_enum_creation() {
   CHECK(TestHelpers::test_creation<Color>("Purple") == Color::Purple);
   CHECK(TestHelpers::test_option_tag<NoGroup<Color>>("Purple") ==
@@ -218,6 +261,7 @@ void test_test_enum_creation() {
 
 SPECTRE_TEST_CASE("Unit.TestCreation", "[Unit]") {
   test_test_creation();
+  test_test_factory_creation();
   test_test_enum_creation();
 }
 }  // namespace

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -61,6 +61,8 @@
 #include "Time/Slab.hpp"
 #include "Time/StepChoosers/Constant.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
+#include "Time/StepControllers/SplitRemaining.hpp"
+#include "Time/StepControllers/StepController.hpp"
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
 #include "Time/TimeStepId.hpp"

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -958,8 +958,8 @@ void test_impl(const Spectral::Quadrature quadrature,
                                  LocalTimeStepping, UseMovingMesh, HasPrims>;
   Parallel::register_derived_classes_with_charm<
       StepChooser<typename metavars::step_choosers>>();
-  Parallel::register_derived_classes_with_charm<StepController>();
   Parallel::register_derived_classes_with_charm<TimeStepper>();
+  Parallel::register_classes_with_charm<StepControllers::SplitRemaining>();
 
   using system = typename metavars::system;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp
@@ -562,7 +562,7 @@ void test_boundary_condition_with_python(
                        Frame::Inertial>;
   const std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
       boundary_condition =
-          TestHelpers::test_factory_creation<BoundaryConditionBase>(
+          TestHelpers::test_creation<std::unique_ptr<BoundaryConditionBase>>(
               factory_string);
 
   REQUIRE_FALSE(
@@ -610,7 +610,8 @@ template <typename BoundaryCondition, typename BoundaryConditionBase>
 void test_periodic_condition(const std::string& factory_string) {
   PUPable_reg(BoundaryCondition);
   const auto boundary_condition =
-      TestHelpers::test_factory_creation<BoundaryConditionBase>(factory_string);
+      TestHelpers::test_creation<std::unique_ptr<BoundaryConditionBase>>(
+          factory_string);
   REQUIRE(typeid(*boundary_condition.get()) == typeid(BoundaryCondition));
   const auto bc_clone = boundary_condition->get_clone();
   CHECK(domain::BoundaryConditions::is_periodic(bc_clone));

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
@@ -44,6 +44,12 @@
 #include "Utilities/System/ParallelInfo.hpp"
 #include "Utilities/TMPL.hpp"
 
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
 struct ScalarFieldTag : db::SimpleTag {
   using type = Scalar<DataVector>;
   static std::string name() noexcept { return "ScalarField"; }
@@ -382,6 +388,9 @@ struct Metavariables {
         return Phase::Exit;
     }
   }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 /// [metavars]
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Tags/Test_Formulation.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Tags/Test_Formulation.cpp
@@ -13,10 +13,8 @@
 SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Tags.Formulation",
                   "[Unit][Evolution]") {
   TestHelpers::db::test_simple_tag<dg::Tags::Formulation>("Formulation");
-  CHECK(
-      TestHelpers::test_creation<dg::Formulation, dg::OptionTags::Formulation>(
-          "StrongInertial") == dg::Formulation::StrongInertial);
-  CHECK(
-      TestHelpers::test_creation<dg::Formulation, dg::OptionTags::Formulation>(
-          "WeakInertial") == dg::Formulation::WeakInertial);
+  CHECK(TestHelpers::test_option_tag<dg::OptionTags::Formulation>(
+            "StrongInertial") == dg::Formulation::StrongInertial);
+  CHECK(TestHelpers::test_option_tag<dg::OptionTags::Formulation>(
+            "WeakInertial") == dg::Formulation::WeakInertial);
 }

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_SpanInterpolators.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_SpanInterpolators.cpp
@@ -99,7 +99,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolation.SpanInterpolators",
 
     // verify the the construction from options is successful
     const auto option_created_linear_interpolator =
-        TestHelpers::test_factory_creation<intrp::SpanInterpolator>(
+        TestHelpers::test_creation<std::unique_ptr<intrp::SpanInterpolator>>(
             "LinearSpanInterpolator");
     test_interpolator_approximate_fidelity<DataVector>(
         make_not_null(&gen), *option_created_linear_interpolator,
@@ -133,7 +133,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolation.SpanInterpolators",
 
     // verify the the construction from options is successful
     const auto option_created_cubic_interpolator =
-        TestHelpers::test_factory_creation<intrp::SpanInterpolator>(
+        TestHelpers::test_creation<std::unique_ptr<intrp::SpanInterpolator>>(
             "CubicSpanInterpolator");
     test_interpolator_approximate_fidelity<DataVector>(
         make_not_null(&gen), *option_created_cubic_interpolator,
@@ -167,7 +167,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolation.SpanInterpolators",
 
     // verify the the construction from options is successful
     const auto option_created_barycentric_interpolator =
-        TestHelpers::test_factory_creation<intrp::SpanInterpolator>(
+        TestHelpers::test_creation<std::unique_ptr<intrp::SpanInterpolator>>(
             "BarycentricRationalSpanInterpolator:\n"
             "  MinOrder: 5\n"
             "  MaxOrder: 6");

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Test_Gmres.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Test_Gmres.cpp
@@ -376,7 +376,7 @@ SPECTRE_TEST_CASE("Unit.LinearSolver.Serial.Gmres",
           tmpl::list<Registrars::Gmres<DenseVector<double>>>;
       using LinearSolverFactory = LinearSolver<LinearSolverRegistrars>;
       const auto solver =
-          TestHelpers::test_factory_creation<LinearSolverFactory>(
+          TestHelpers::test_creation<std::unique_ptr<LinearSolverFactory>>(
               "Gmres:\n"
               "  ConvergenceCriteria:\n"
               "    MaxIterations: 2\n"

--- a/tests/Unit/Options/Test_Factory.cpp
+++ b/tests/Unit/Options/Test_Factory.cpp
@@ -40,7 +40,7 @@ class OptionTest {
   OptionTest& operator=(OptionTest&&) = default;
   virtual ~OptionTest() = default;
 
-  virtual std::string name() const = 0;
+  virtual std::string derived_name() const = 0;
 };
 
 class Test1 : public OptionTest {
@@ -49,7 +49,7 @@ class Test1 : public OptionTest {
   static constexpr Options::String help = {"A derived class"};
   Test1() = default;
 
-  std::string name() const override { return "Test1"; }
+  std::string derived_name() const override { return "Test1"; }
 };
 // [factory_example]
 
@@ -59,7 +59,7 @@ class Test2 : public OptionTest {
   static constexpr Options::String help = {""};
   Test2() = default;
 
-  std::string name() const override { return "Test2"; }
+  std::string derived_name() const override { return "Test2"; }
 };
 
 class TestWithArg : public OptionTest {
@@ -73,7 +73,9 @@ class TestWithArg : public OptionTest {
   TestWithArg() = default;
   explicit TestWithArg(std::string arg) : arg_(std::move(arg)) {}
 
-  std::string name() const override { return "TestWithArg(" + arg_ + ")"; }
+  std::string derived_name() const override {
+    return "TestWithArg(" + arg_ + ")";
+  }
 
  private:
   std::string arg_;
@@ -94,7 +96,9 @@ class TestWithArg2 : public OptionTest {
   TestWithArg2() = default;
   explicit TestWithArg2(std::string arg) : arg_(std::move(arg)) {}
 
-  std::string name() const override { return "TestWithArg2(" + arg_ + ")"; }
+  std::string derived_name() const override {
+    return "TestWithArg2(" + arg_ + ")";
+  }
 
  private:
   std::string arg_;
@@ -129,7 +133,7 @@ struct TestWithMetavars : OptionTest {
                             Metavariables /*meta*/)
       : arg_(std::move(arg)), valid_(Metavariables::valid) {}
 
-  std::string name() const override {
+  std::string derived_name() const override {
     return "TestWithArg(" + arg_ + ")" +
            (valid_ ? std::string{"yes"} : std::string{"no"});
   }
@@ -144,7 +148,7 @@ void test_factory() {
   opts.parse("OptionType: Test2");
   // must pass metavars because TestWithMetavars is a derived class in
   // `creatable_classes`
-  CHECK(opts.get<OptionType, Metavars<true>>()->name() == "Test2");
+  CHECK(opts.get<OptionType, Metavars<true>>()->derived_name() == "Test2");
 }
 
 void test_factory_with_colon() {
@@ -154,7 +158,7 @@ void test_factory_with_colon() {
       "  Test2:");
   // must pass metavars because TestWithMetavars is a derived class in
   // `creatable_classes`
-  CHECK(opts.get<OptionType, Metavars<true>>()->name() == "Test2");
+  CHECK(opts.get<OptionType, Metavars<true>>()->derived_name() == "Test2");
 }
 
 void test_factory_with_arg() {
@@ -165,7 +169,8 @@ void test_factory_with_arg() {
       "    Arg: stuff");
   // must pass metavars because TestWithMetavars is a derived class in
   // `creatable_classes`
-  CHECK(opts.get<OptionType, Metavars<true>>()->name() == "TestWithArg(stuff)");
+  CHECK(opts.get<OptionType, Metavars<true>>()->derived_name() ==
+        "TestWithArg(stuff)");
 }
 
 void test_factory_with_name_function() {
@@ -176,7 +181,7 @@ void test_factory_with_name_function() {
       "    ThisIsArg: stuff");
   // must pass metavars because TestWithMetavars is a derived class in
   // `creatable_classes`
-  CHECK(opts.get<OptionType, Metavars<true>>()->name() ==
+  CHECK(opts.get<OptionType, Metavars<true>>()->derived_name() ==
         "TestWithArg2(stuff)");
 }
 
@@ -188,18 +193,18 @@ void test_factory_with_metavars() {
       "    Arg: stuff");
   // must pass metavars because TestWithMetavars is a derived class in
   // `creatable_classes`
-  CHECK(opts.get<OptionType, Metavars<true>>()->name() ==
+  CHECK(opts.get<OptionType, Metavars<true>>()->derived_name() ==
         "TestWithArg(stuff)yes");
   // must pass metavars because TestWithMetavars is a derived class in
   // `creatable_classes`
-  CHECK(opts.get<OptionType, Metavars<false>>()->name() ==
+  CHECK(opts.get<OptionType, Metavars<false>>()->derived_name() ==
         "TestWithArg(stuff)no");
   auto result_true = opts.apply<tmpl::list<OptionType>, Metavars<true>>(
       [&](auto arg) { return arg; });
-  CHECK(result_true->name() == "TestWithArg(stuff)yes");
+  CHECK(result_true->derived_name() == "TestWithArg(stuff)yes");
   auto result_false = opts.apply<tmpl::list<OptionType>, Metavars<false>>(
       [&](auto arg) { return arg; });
-  CHECK(result_false->name() == "TestWithArg(stuff)no");
+  CHECK(result_false->derived_name() == "TestWithArg(stuff)no");
 }
 
 void test_factory_object_vector() {
@@ -209,9 +214,9 @@ void test_factory_object_vector() {
   // `creatable_classes`
   const auto& arg = opts.get<Vector, Metavars<true>>();
   CHECK(arg.size() == 3);
-  CHECK(arg[0]->name() == "Test1");
-  CHECK(arg[1]->name() == "Test2");
-  CHECK(arg[2]->name() == "Test1");
+  CHECK(arg[0]->derived_name() == "Test1");
+  CHECK(arg[1]->derived_name() == "Test2");
+  CHECK(arg[2]->derived_name() == "Test1");
 }
 
 void test_factory_object_map() {
@@ -225,9 +230,9 @@ void test_factory_object_map() {
   // `creatable_classes`
   const auto& arg = opts.get<Map, Metavars<true>>();
   CHECK(arg.size() == 3);
-  CHECK(arg.at("A")->name() == "Test1");
-  CHECK(arg.at("B")->name() == "Test2");
-  CHECK(arg.at("C")->name() == "Test1");
+  CHECK(arg.at("A")->derived_name() == "Test1");
+  CHECK(arg.at("B")->derived_name() == "Test2");
+  CHECK(arg.at("C")->derived_name() == "Test1");
 }
 }  // namespace
 
@@ -285,5 +290,5 @@ SPECTRE_TEST_CASE("Unit.Options.Factory.missing_arg", "[Unit][Options]") {
   Options::Parser<tmpl::list<OptionType>> opts("");
   opts.parse("OptionType:\n"
              "  TestWithArg:");
-  CHECK(opts.get<OptionType, Metavars<true>>()->name() == "TestWithArg(stuff)");
+  opts.get<OptionType, Metavars<true>>();
 }

--- a/tests/Unit/Options/Test_Factory.cpp
+++ b/tests/Unit/Options/Test_Factory.cpp
@@ -81,15 +81,16 @@ class TestWithArg : public OptionTest {
   std::string arg_;
 };
 
-// Same as TestWithArg, except there is an TestWithArg2::Arg::name() that
-// returns something other than "Arg" to test that Arg is named in the
-// input file using Options::name rather than pretty_type::short_name
+// Same as TestWithArg, except there is an TestWithArg2::name() that
+// returns something other than "TestWithArg2Arg" to test that class
+// is named in the input file using Options::name rather than
+// pretty_type::short_name
 class TestWithArg2 : public OptionTest {
  public:
+  static std::string name() noexcept { return "ThisIsArg"; }
   struct Arg {
     using type = std::string;
     static constexpr Options::String help = {"halp"};
-    static std::string name() noexcept { return "ThisIsArg"; }
   };
   using options = tmpl::list<Arg>;
   static constexpr Options::String help = {""};
@@ -177,8 +178,8 @@ void test_factory_with_name_function() {
   Options::Parser<tmpl::list<OptionType>> opts("");
   opts.parse(
       "OptionType:\n"
-      "  TestWithArg2:\n"
-      "    ThisIsArg: stuff");
+      "  ThisIsArg:\n"
+      "    Arg: stuff");
   // must pass metavars because TestWithMetavars is a derived class in
   // `creatable_classes`
   CHECK(opts.get<OptionType, Metavars<true>>()->derived_name() ==

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -196,6 +196,8 @@ set(LIBRARY_SOURCES
   Test_TypeTraits.cpp
   )
 
+add_subdirectory(Tags)
+
 add_test_library(
   ${LIBRARY}
   "Parallel"

--- a/tests/Unit/Parallel/PhaseControl/Test_PhaseChange.cpp
+++ b/tests/Unit/Parallel/PhaseControl/Test_PhaseChange.cpp
@@ -156,8 +156,8 @@ SPECTRE_TEST_CASE("Unit.Parallel.PhaseControl.PhaseChange",
           std::numeric_limits<double>::signaling_NaN(), -5);
   tuples::TaggedTuple<Tags::Request> phase_change_decision_data{true};
 
-  auto phase_change = TestHelpers::test_factory_creation<
-      PhaseChange<tmpl::list<Registrars::TestPhaseChange>>>(
+  auto phase_change = TestHelpers::test_creation<
+      std::unique_ptr<PhaseChange<tmpl::list<Registrars::TestPhaseChange>>>>(
       "TestPhaseChange:\n"
       "  Factor: 3");
 

--- a/tests/Unit/Parallel/PhaseControl/Test_PhaseControlTags.cpp
+++ b/tests/Unit/Parallel/PhaseControl/Test_PhaseControlTags.cpp
@@ -103,9 +103,7 @@ SPECTRE_TEST_CASE("Unit.Parallel.PhaseControl.PhaseControlTags",
       PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes, triggers>>(
       "PhaseChangeAndTriggers");
 
-  const auto created_phase_changes = TestHelpers::test_creation<
-      typename PhaseControl::OptionTags::PhaseChangeAndTriggers<phase_changes,
-                                                                triggers>::type,
+  const auto created_phase_changes = TestHelpers::test_option_tag<
       PhaseControl::OptionTags::PhaseChangeAndTriggers<phase_changes,
                                                        triggers>>(
       " - - Slabs:\n"

--- a/tests/Unit/Parallel/PhaseControl/Test_VisitAndReturn.cpp
+++ b/tests/Unit/Parallel/PhaseControl/Test_VisitAndReturn.cpp
@@ -45,9 +45,7 @@ SPECTRE_TEST_CASE("Unit.Parallel.PhaseControl.VisitAndReturn",
   using triggers = tmpl::list<>;
   Parallel::GlobalCache<Metavariables> cache{};
 
-  const auto created_phase_changes = TestHelpers::test_creation<
-      typename PhaseControl::OptionTags::PhaseChangeAndTriggers<phase_changes,
-                                                                triggers>::type,
+  const auto created_phase_changes = TestHelpers::test_option_tag<
       PhaseControl::OptionTags::PhaseChangeAndTriggers<phase_changes,
                                                        triggers>>(
       " - - Always:\n"

--- a/tests/Unit/Parallel/Tags/CMakeLists.txt
+++ b/tests/Unit/Parallel/Tags/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY_SOURCES
+  ${LIBRARY_SOURCES}
+  Tags/Test_Metavariables.cpp
+  PARENT_SCOPE)

--- a/tests/Unit/Parallel/Tags/Test_Metavariables.cpp
+++ b/tests/Unit/Parallel/Tags/Test_Metavariables.cpp
@@ -1,0 +1,20 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Parallel/Tags/Metavariables.hpp"
+
+namespace {
+struct TestMetavariables;
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Parallel.Tags.Metavariables", "[Unit][Parallel]") {
+  TestHelpers::db::test_base_tag<Parallel::Tags::Metavariables>(
+      "Metavariables");
+  TestHelpers::db::test_simple_tag<
+      Parallel::Tags::MetavariablesImpl<TestMetavariables>>("Metavariables");
+}

--- a/tests/Unit/Parallel/Test_AlgorithmBadBoxApply.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmBadBoxApply.cpp
@@ -17,6 +17,9 @@
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
+namespace PUP {
+class er;
+}  // namespace PUP
 namespace db {
 template <typename TagsList>
 class DataBox;
@@ -77,6 +80,9 @@ struct TestMetavariables {
     }
     return Phase::Exit;
   }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{

--- a/tests/Unit/Parallel/Test_AlgorithmCore.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmCore.cpp
@@ -732,6 +732,9 @@ struct TestMetavariables {
     return Phase::Exit;
   }
   // [determine_next_phase_example]
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 // [charm_init_funcs_example]

--- a/tests/Unit/Parallel/Test_AlgorithmGlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmGlobalCache.cpp
@@ -26,6 +26,10 @@
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
+namespace PUP {
+class er;
+}  // namespace PUP
+
 template <class Metavariables>
 struct MutateCacheComponent;
 template <class Metavariables>
@@ -337,6 +341,9 @@ struct TestMetavariables {
 
     return Phase::Exit;
   }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{

--- a/tests/Unit/Parallel/Test_AlgorithmLocalSyncAction.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmLocalSyncAction.cpp
@@ -30,6 +30,10 @@
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
+namespace PUP {
+class er;
+}  // namespace PUP
+
 namespace LocalSyncActionTest {
 template <class Metavariables>
 struct NodegroupComponent;
@@ -257,6 +261,9 @@ struct TestMetavariables {
     }
     return Phase::Exit;
   }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{

--- a/tests/Unit/Parallel/Test_AlgorithmNestedApply1.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNestedApply1.cpp
@@ -15,6 +15,9 @@
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/TMPL.hpp"
 
+namespace PUP {
+class er;
+}  // namespace PUP
 namespace db {
 template <typename TagsList>
 class DataBox;
@@ -77,6 +80,9 @@ struct TestMetavariables {
     }
     return Phase::Exit;
   }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{

--- a/tests/Unit/Parallel/Test_AlgorithmNestedApply2.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNestedApply2.cpp
@@ -15,6 +15,9 @@
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/TMPL.hpp"
 
+namespace PUP {
+class er;
+}  // namespace PUP
 namespace db {
 template <typename TagsList>
 class DataBox;
@@ -81,6 +84,9 @@ struct TestMetavariables {
     }
     return Phase::Exit;
   }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{

--- a/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
@@ -34,6 +34,9 @@ static constexpr int number_of_1d_array_elements_per_core = 10;
 
 struct TestMetavariables;
 
+namespace PUP {
+class er;
+}  // namespace PUP
 namespace db {
 template <typename TagsList>
 class DataBox;
@@ -103,10 +106,11 @@ struct nodegroup_initialize {
 };
 
 struct nodegroup_receive {
-  template <typename ParallelComponent, typename... DbTags,
-            typename Metavariables, typename ArrayIndex,
-            Requires<sizeof...(DbTags) == 3> = nullptr>
-  static void apply(db::DataBox<tmpl::list<DbTags...>>& box,
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex,
+            Requires<db::tag_is_retrievable_v<Tags::vector_of_array_indexs,
+                                              db::DataBox<DbTags>>> = nullptr>
+  static void apply(db::DataBox<DbTags>& box,
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/, const int& id_of_array) {
     static_assert(std::is_same_v<ParallelComponent,
@@ -129,10 +133,11 @@ struct nodegroup_receive {
 };
 
 struct nodegroup_check_first_result {
-  template <typename ParallelComponent, typename... DbTags,
-            typename Metavariables, typename ArrayIndex,
-            Requires<sizeof...(DbTags) == 3> = nullptr>
-  static void apply(db::DataBox<tmpl::list<DbTags...>>& box,
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex,
+            Requires<db::tag_is_retrievable_v<Tags::vector_of_array_indexs,
+                                              db::DataBox<DbTags>>> = nullptr>
+  static void apply(db::DataBox<DbTags>& box,
                     Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/) {
     static_assert(std::is_same_v<ParallelComponent,
@@ -154,10 +159,11 @@ struct nodegroup_check_first_result {
 
 struct nodegroup_threaded_receive {
   // [threaded_action_example]
-  template <typename ParallelComponent, typename... DbTags,
-            typename Metavariables, typename ArrayIndex,
-            Requires<sizeof...(DbTags) == 3> = nullptr>
-  static void apply(db::DataBox<tmpl::list<DbTags...>>& box,
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex,
+            Requires<db::tag_is_retrievable_v<Tags::vector_of_array_indexs,
+                                              db::DataBox<DbTags>>> = nullptr>
+  static void apply(db::DataBox<DbTags>& box,
                     Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/,
                     const gsl::not_null<Parallel::NodeLock*> node_lock,
@@ -182,10 +188,11 @@ struct nodegroup_threaded_receive {
 };
 
 struct nodegroup_check_threaded_result {
-  template <typename ParallelComponent, typename... DbTags,
-            typename Metavariables, typename ArrayIndex,
-            Requires<sizeof...(DbTags) == 3> = nullptr>
-  static void apply(db::DataBox<tmpl::list<DbTags...>>& box,
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex,
+            Requires<db::tag_is_retrievable_v<Tags::vector_of_array_indexs,
+                                              db::DataBox<DbTags>>> = nullptr>
+  static void apply(db::DataBox<DbTags>& box,
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/) {
     static_assert(std::is_same_v<ParallelComponent,
@@ -372,6 +379,9 @@ struct TestMetavariables {
 
     return Phase::Exit;
   }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{

--- a/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
@@ -35,6 +35,9 @@
 
 static constexpr int number_of_1d_array_elements = 14;
 
+namespace PUP {
+class er;
+}  // namespace PUP
 namespace db {
 template <typename TagsList>
 class DataBox;
@@ -663,6 +666,9 @@ struct TestMetavariables {
 
     return Phase::Exit;
   }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 // [charm_include_example]

--- a/tests/Unit/Parallel/Test_AlgorithmPhaseControl.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmPhaseControl.cpp
@@ -514,6 +514,9 @@ struct TestMetavariables {
 
     return Phase::Exit;
   }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 // [charm_init_funcs_example]

--- a/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
@@ -32,6 +32,9 @@
 #include "Utilities/System/ParallelInfo.hpp"
 #include "Utilities/TMPL.hpp"
 
+namespace PUP {
+class er;
+}  // namespace PUP
 namespace db {
 template <typename TagsList>
 class DataBox;
@@ -278,6 +281,9 @@ struct TestMetavariables {
     return current_phase == Phase::Initialization ? Phase::CallArrayReduce
                                                   : Phase::Exit;
   }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{

--- a/tests/Unit/Parallel/Test_GlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_GlobalCache.cpp
@@ -479,7 +479,7 @@ template <typename Metavariables>
 Test_GlobalCache<Metavariables>::Test_GlobalCache(CkArgMsg*
                                                   /*msg*/) noexcept {
   // Register the pup functions.
-  Parallel::register_classes_in_list<tmpl::list<Triangle, Square, Arthropod>>();
+  Parallel::register_classes_with_charm<Triangle, Square, Arthropod>();
 
   // Call the single core test before doing anything else.
   run_single_core_test();

--- a/tests/Unit/Parallel/Test_PhaseChangeMain.cpp
+++ b/tests/Unit/Parallel/Test_PhaseChangeMain.cpp
@@ -28,6 +28,10 @@
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
+namespace PUP {
+class er;
+}  // namespace PUP
+
 namespace PhaseChangeTest {
 template <class Metavariables>
 struct ArrayComponent;
@@ -261,6 +265,9 @@ struct TestMetavariables {
 
     return Phase::Exit;
   }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveErrorNorms.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveErrorNorms.cpp
@@ -347,9 +347,10 @@ void test_system(const bool has_analytic_solutions) noexcept {
   using EventType = Event<tmpl::list<dg::Events::Registrars::ObserveErrorNorms<
       ObservationTimeTag, typename System::vars_for_test>>>;
   Parallel::register_derived_classes_with_charm<EventType>();
-  const auto factory_event = TestHelpers::test_factory_creation<EventType>(
-      "ObserveErrorNorms:\n"
-      "  SubfileName: reduction0");
+  const auto factory_event =
+      TestHelpers::test_creation<std::unique_ptr<EventType>>(
+          "ObserveErrorNorms:\n"
+          "  SubfileName: reduction0");
   auto serialized_event = serialize_and_deserialize(factory_event);
   test_observe<System, HasAnalyticSolutions>(std::move(serialized_event),
                                              has_analytic_solutions);

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
@@ -452,7 +452,7 @@ void test_system(
   const std::string creation_string =
       System::creation_string_for_test + mesh_creation_string;
   const auto factory_event =
-      TestHelpers::test_factory_creation<EventType>(creation_string);
+      TestHelpers::test_creation<std::unique_ptr<EventType>>(creation_string);
   auto serialized_event = serialize_and_deserialize(factory_event);
   test_observe<System, AlwaysHasAnalyticSolutions>(
       std::move(serialized_event), interpolating_mesh, has_analytic_solutions);

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStep.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStep.cpp
@@ -244,7 +244,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.ObserveTimeStep", "[Unit][Evolution]") {
     test_observe(serialize_and_deserialize(observer), false);
     test_observe(serialize_and_deserialize(observer), true);
 
-    const auto event = TestHelpers::test_factory_creation<EventType>(
+    const auto event = TestHelpers::test_creation<std::unique_ptr<EventType>>(
         "ObserveTimeStep:\n"
         "  SubfileName: time_step_subfile\n"
         "  PrintTimeToTerminal: " +

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveVolumeIntegrals.cpp
@@ -273,9 +273,10 @@ void test_observe_system() noexcept {
         Event<tmpl::list<dg::Events::Registrars::ObserveVolumeIntegrals<
             VolumeDim, ObservationTimeTag, vars_for_test>>>;
     Parallel::register_derived_classes_with_charm<EventType>();
-    const auto factory_event = TestHelpers::test_factory_creation<EventType>(
-        "ObserveVolumeIntegrals:\n"
-        "  SubfileName: volume_integrals");
+    const auto factory_event =
+        TestHelpers::test_creation<std::unique_ptr<EventType>>(
+            "ObserveVolumeIntegrals:\n"
+            "  SubfileName: volume_integrals");
     auto serialized_event = serialize_and_deserialize(factory_event);
     test_observe<VolumeDim>(std::move(serialized_event));
   }

--- a/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_EventsAndTriggers.cpp
+++ b/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_EventsAndTriggers.cpp
@@ -72,7 +72,8 @@ void run_events_and_triggers(const EventsAndTriggersType& events_and_triggers,
 void check_trigger(const bool expected, const std::string& trigger_string) {
   // Test factory
   std::unique_ptr<Trigger<tmpl::list<>>> trigger =
-      TestHelpers::test_factory_creation<Trigger<tmpl::list<>>>(trigger_string);
+      TestHelpers::test_creation<std::unique_ptr<Trigger<tmpl::list<>>>>(
+          trigger_string);
 
   EventsAndTriggersType::Storage events_and_triggers_map;
   events_and_triggers_map.emplace(
@@ -89,7 +90,8 @@ void check_trigger(const bool expected, const std::string& trigger_string) {
 SPECTRE_TEST_CASE("Unit.Evolution.EventsAndTriggers", "[Unit][Evolution]") {
   {
     const auto completion =
-        TestHelpers::test_factory_creation<Event<tmpl::list<>>>("Completion");
+        TestHelpers::test_creation<std::unique_ptr<Event<tmpl::list<>>>>(
+            "Completion");
     CHECK(not completion->needs_evolved_variables());
   }
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.cpp
@@ -12,6 +12,10 @@
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/TMPL.hpp"
 
+namespace PUP {
+class er;
+}  // namespace PUP
+
 namespace helpers = LinearSolverAlgorithmTestHelpers;
 
 namespace {
@@ -37,6 +41,9 @@ struct Metavariables {
   using Phase = helpers::Phase;
   static constexpr auto determine_next_phase =
       helpers::determine_next_phase<Metavariables>;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 }  // namespace

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.cpp
@@ -15,6 +15,10 @@
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/TMPL.hpp"
 
+namespace PUP {
+class er;
+}  // namespace PUP
+
 namespace helpers = LinearSolverAlgorithmTestHelpers;
 namespace helpers_distributed = DistributedLinearSolverAlgorithmTestHelpers;
 
@@ -45,6 +49,9 @@ struct Metavariables {
   static constexpr bool ignore_unrecognized_command_line_options = false;
   static constexpr auto determine_next_phase =
       helpers::determine_next_phase<Metavariables>;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 }  // namespace

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.cpp
@@ -15,6 +15,10 @@
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/TMPL.hpp"
 
+namespace PUP {
+class er;
+}  // namespace PUP
+
 namespace helpers = LinearSolverAlgorithmTestHelpers;
 namespace helpers_distributed = DistributedLinearSolverAlgorithmTestHelpers;
 
@@ -45,6 +49,9 @@ struct Metavariables {
   static constexpr bool ignore_unrecognized_command_line_options = false;
   static constexpr auto determine_next_phase =
       helpers::determine_next_phase<Metavariables>;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 }  // namespace

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresPreconditionedAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresPreconditionedAlgorithm.cpp
@@ -16,6 +16,10 @@
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/TMPL.hpp"
 
+namespace PUP {
+class er;
+}  // namespace PUP
+
 namespace helpers = LinearSolverAlgorithmTestHelpers;
 namespace helpers_distributed = DistributedLinearSolverAlgorithmTestHelpers;
 
@@ -53,6 +57,9 @@ struct Metavariables {
   static constexpr bool ignore_unrecognized_command_line_options = false;
   static constexpr auto determine_next_phase =
       helpers::determine_next_phase<Metavariables>;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 }  // namespace

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.cpp
@@ -12,6 +12,10 @@
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/TMPL.hpp"
 
+namespace PUP {
+class er;
+}  // namespace PUP
+
 namespace helpers = LinearSolverAlgorithmTestHelpers;
 
 namespace {
@@ -37,6 +41,9 @@ struct Metavariables {
   using Phase = helpers::Phase;
   static constexpr auto determine_next_phase =
       helpers::determine_next_phase<Metavariables>;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 }  // namespace

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresPreconditionedAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_GmresPreconditionedAlgorithm.cpp
@@ -13,6 +13,10 @@
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/TMPL.hpp"
 
+namespace PUP {
+class er;
+}  // namespace PUP
+
 namespace helpers = LinearSolverAlgorithmTestHelpers;
 
 namespace {
@@ -44,6 +48,9 @@ struct Metavariables {
   using Phase = helpers::Phase;
   static constexpr auto determine_next_phase =
       helpers::determine_next_phase<Metavariables>;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 }  // namespace

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/Test_DistributedRichardsonAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/Test_DistributedRichardsonAlgorithm.cpp
@@ -15,6 +15,10 @@
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/TMPL.hpp"
 
+namespace PUP {
+class er;
+}  // namespace PUP
+
 namespace helpers = LinearSolverAlgorithmTestHelpers;
 namespace helpers_distributed = DistributedLinearSolverAlgorithmTestHelpers;
 
@@ -44,6 +48,9 @@ struct Metavariables {
   static constexpr bool ignore_unrecognized_command_line_options = false;
   static constexpr auto determine_next_phase =
       helpers::determine_next_phase<Metavariables>;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 }  // namespace

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/Test_RichardsonAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Richardson/Test_RichardsonAlgorithm.cpp
@@ -12,6 +12,10 @@
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/TMPL.hpp"
 
+namespace PUP {
+class er;
+}  // namespace PUP
+
 namespace helpers = LinearSolverAlgorithmTestHelpers;
 
 namespace {
@@ -37,6 +41,9 @@ struct Metavariables {
   using Phase = helpers::Phase;
   static constexpr auto determine_next_phase =
       helpers::determine_next_phase<Metavariables>;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 }  // namespace

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.cpp
@@ -32,6 +32,10 @@
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
 
+namespace PUP {
+class er;
+}  // namespace PUP
+
 namespace helpers = LinearSolverAlgorithmTestHelpers;
 namespace helpers_distributed = DistributedLinearSolverAlgorithmTestHelpers;
 
@@ -183,6 +187,9 @@ struct Metavariables {
   static constexpr bool ignore_unrecognized_command_line_options = false;
   static constexpr auto determine_next_phase =
       helpers::determine_next_phase<Metavariables>;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 }  // namespace

--- a/tests/Unit/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/Test_NewtonRaphsonAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/Test_NewtonRaphsonAlgorithm.cpp
@@ -14,6 +14,10 @@
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/TMPL.hpp"
 
+namespace PUP {
+class er;
+}  // namespace PUP
+
 namespace helpers = TestHelpers::NonlinearSolver;
 
 namespace {
@@ -90,6 +94,9 @@ struct Metavariables {
   using Phase = helpers::Phase;
   static constexpr auto determine_next_phase =
       helpers::determine_next_phase<Metavariables>;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
 };
 
 }  // namespace

--- a/tests/Unit/PointwiseFunctions/AnalyticData/Xcts/Test_Binary.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/Xcts/Test_Binary.cpp
@@ -53,9 +53,9 @@ void test_data(const std::array<double, 2>& x_coords,
                const std::array<double, 2>& masses,
                const std::string& py_functions_suffix,
                const std::string& options_string) {
-  const auto created = TestHelpers::test_factory_creation<
+  const auto created = TestHelpers::test_creation<std::unique_ptr<
       ::AnalyticData<3, tmpl::list<Registrars::Binary<tmpl::list<
-                            Xcts::Solutions::Registrars::Schwarzschild>>>>>(
+                            Xcts::Solutions::Registrars::Schwarzschild>>>>>>(
       options_string);
   REQUIRE(dynamic_cast<const Binary<
               tmpl::list<Xcts::Solutions::Registrars::Schwarzschild>>*>(

--- a/tests/Unit/PointwiseFunctions/AnalyticData/Xcts/Test_Binary.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/Xcts/Test_Binary.cpp
@@ -96,8 +96,7 @@ void test_data(const std::array<double, 2>& x_coords,
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticData.Xcts.Binary",
                   "[PointwiseFunctions][Unit]") {
-  Parallel::register_classes_in_list<
-      tmpl::list<Xcts::Solutions::Schwarzschild<>>>();
+  Parallel::register_classes_with_charm<Xcts::Solutions::Schwarzschild<>>();
   pypp::SetupLocalPythonEnvironment local_python_env{
       "PointwiseFunctions/AnalyticData/Xcts"};
   test_data<tmpl::list<Xcts::Solutions::Registrars::Schwarzschild>>(

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_Flatness.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_Flatness.cpp
@@ -21,9 +21,9 @@ namespace Xcts::Solutions {
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Xcts.Flatness",
                   "[PointwiseFunctions][Unit]") {
-  const auto created =
-      TestHelpers::test_factory_creation<Xcts::Solutions::AnalyticSolution<
-          tmpl::list<Xcts::Solutions::Registrars::Flatness>>>("Flatness");
+  const auto created = TestHelpers::test_creation<
+      std::unique_ptr<Xcts::Solutions::AnalyticSolution<
+          tmpl::list<Xcts::Solutions::Registrars::Flatness>>>>("Flatness");
   REQUIRE(dynamic_cast<const Flatness<>*>(created.get()) != nullptr);
   const auto& solution = dynamic_cast<const Flatness<>&>(*created);
   {

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_Kerr.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_Kerr.cpp
@@ -37,9 +37,9 @@ void test_solution(const double mass, const std::array<double, 3> spin,
   CAPTURE(mass);
   CAPTURE(spin);
   CAPTURE(center);
-  const auto created =
-      TestHelpers::test_factory_creation<Xcts::Solutions::AnalyticSolution<
-          tmpl::list<Xcts::Solutions::Registrars::Kerr>>>(options_string);
+  const auto created = TestHelpers::test_creation<
+      std::unique_ptr<Xcts::Solutions::AnalyticSolution<
+          tmpl::list<Xcts::Solutions::Registrars::Kerr>>>>(options_string);
   REQUIRE(dynamic_cast<const Kerr<>*>(created.get()) != nullptr);
   const auto& solution = dynamic_cast<const Kerr<>&>(*created);
   {

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_Schwarzschild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Xcts/Test_Schwarzschild.cpp
@@ -108,10 +108,10 @@ void test_solution(const double mass,
                    const std::string& options_string) {
   CAPTURE(mass);
   CAPTURE(coords);
-  const auto created =
-      TestHelpers::test_factory_creation<Xcts::Solutions::AnalyticSolution<
-          tmpl::list<Xcts::Solutions::Registrars::Schwarzschild>>>(
-          options_string);
+  const auto created = TestHelpers::test_creation<
+      std::unique_ptr<Xcts::Solutions::AnalyticSolution<
+          tmpl::list<Xcts::Solutions::Registrars::Schwarzschild>>>>(
+      options_string);
   REQUIRE(dynamic_cast<const Schwarzschild<>*>(created.get()) != nullptr);
   const auto& solution = dynamic_cast<const Schwarzschild<>&>(*created);
   {

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_DarkEnergyFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_DarkEnergyFluid.cpp
@@ -38,23 +38,27 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.DarkEnergyFluid",
                                        1.0 / 3.0);
 
   TestHelpers::EquationsOfState::check(
-      TestHelpers::test_factory_creation<EoS::EquationOfState<true, 2>>(
+      TestHelpers::test_creation<
+          std::unique_ptr<EoS::EquationOfState<true, 2>>>(
           {"DarkEnergyFluid:\n"
            "  ParameterW: 1.0\n"}),
       "dark_energy_fluid", d_for_size, 1.0);
   TestHelpers::EquationsOfState::check(
-      TestHelpers::test_factory_creation<EoS::EquationOfState<true, 2>>(
+      TestHelpers::test_creation<
+          std::unique_ptr<EoS::EquationOfState<true, 2>>>(
           {"DarkEnergyFluid:\n"
            "  ParameterW: 0.3333333333333333\n"}),
       "dark_energy_fluid", d_for_size, 1.0 / 3.0);
 
   TestHelpers::EquationsOfState::check(
-      TestHelpers::test_factory_creation<EoS::EquationOfState<true, 2>>(
+      TestHelpers::test_creation<
+          std::unique_ptr<EoS::EquationOfState<true, 2>>>(
           {"DarkEnergyFluid:\n"
            "  ParameterW: 1.0\n"}),
       "dark_energy_fluid", dv_for_size, 1.0);
   TestHelpers::EquationsOfState::check(
-      TestHelpers::test_factory_creation<EoS::EquationOfState<true, 2>>(
+      TestHelpers::test_creation<
+          std::unique_ptr<EoS::EquationOfState<true, 2>>>(
           {"DarkEnergyFluid:\n"
            "  ParameterW: 0.3333333333333333\n"}),
       "dark_energy_fluid", dv_for_size, 1.0 / 3.0);

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_IdealFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_IdealFluid.cpp
@@ -37,23 +37,27 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.IdealFluid",
                                        "ideal_fluid", dv_for_size, 4.0 / 3.0);
 
   TestHelpers::EquationsOfState::check(
-      TestHelpers::test_factory_creation<EoS::EquationOfState<true, 2>>(
+      TestHelpers::test_creation<
+          std::unique_ptr<EoS::EquationOfState<true, 2>>>(
           {"IdealFluid:\n"
            "  AdiabaticIndex: 1.6666666666666667\n"}),
       "ideal_fluid", d_for_size, 5.0 / 3.0);
   TestHelpers::EquationsOfState::check(
-      TestHelpers::test_factory_creation<EoS::EquationOfState<true, 2>>(
+      TestHelpers::test_creation<
+          std::unique_ptr<EoS::EquationOfState<true, 2>>>(
           {"IdealFluid:\n"
            "  AdiabaticIndex: 1.3333333333333333\n"}),
       "ideal_fluid", dv_for_size, 4.0 / 3.0);
 
   TestHelpers::EquationsOfState::check(
-      TestHelpers::test_factory_creation<EoS::EquationOfState<false, 2>>(
+      TestHelpers::test_creation<
+          std::unique_ptr<EoS::EquationOfState<false, 2>>>(
           {"IdealFluid:\n"
            "  AdiabaticIndex: 1.6666666666666667\n"}),
       "ideal_fluid", d_for_size, 5.0 / 3.0);
   TestHelpers::EquationsOfState::check(
-      TestHelpers::test_factory_creation<EoS::EquationOfState<false, 2>>(
+      TestHelpers::test_creation<
+          std::unique_ptr<EoS::EquationOfState<false, 2>>>(
           {"IdealFluid:\n"
            "  AdiabaticIndex: 1.3333333333333333\n"}),
       "ideal_fluid", dv_for_size, 4.0 / 3.0);

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_PolytropicFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_PolytropicFluid.cpp
@@ -37,26 +37,30 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.PolytropicFluid",
                                        "polytropic", dv_for_size, 117.0, 1.12);
 
   TestHelpers::EquationsOfState::check(
-      TestHelpers::test_factory_creation<EoS::EquationOfState<true, 1>>(
+      TestHelpers::test_creation<
+          std::unique_ptr<EoS::EquationOfState<true, 1>>>(
           {"PolytropicFluid:\n"
            "  PolytropicConstant: 100.0\n"
            "  PolytropicExponent: 2.0\n"}),
       "polytropic", d_for_size, 100.0, 2.0);
   TestHelpers::EquationsOfState::check(
-      TestHelpers::test_factory_creation<EoS::EquationOfState<true, 1>>(
+      TestHelpers::test_creation<
+          std::unique_ptr<EoS::EquationOfState<true, 1>>>(
           {"PolytropicFluid:\n"
            "  PolytropicConstant: 134.0\n"
            "  PolytropicExponent: 1.5\n"}),
       "polytropic", dv_for_size, 134.0, 1.5);
 
   TestHelpers::EquationsOfState::check(
-      TestHelpers::test_factory_creation<EoS::EquationOfState<false, 1>>(
+      TestHelpers::test_creation<
+          std::unique_ptr<EoS::EquationOfState<false, 1>>>(
           {"PolytropicFluid:\n"
            "  PolytropicConstant: 121.0\n"
            "  PolytropicExponent: 1.2\n"}),
       "polytropic", d_for_size, 121.0, 1.2);
   TestHelpers::EquationsOfState::check(
-      TestHelpers::test_factory_creation<EoS::EquationOfState<false, 1>>(
+      TestHelpers::test_creation<
+          std::unique_ptr<EoS::EquationOfState<false, 1>>>(
           {"PolytropicFluid:\n"
            "  PolytropicConstant: 117.0\n"
            "  PolytropicExponent: 1.12\n"}),

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_Gaussian.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_Gaussian.cpp
@@ -78,7 +78,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Gaussian",
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Gaussian.Factory",
                   "[PointwiseFunctions][Unit]") {
-  TestHelpers::test_factory_creation<MathFunction<1, Frame::Inertial>>(
+  TestHelpers::test_creation<std::unique_ptr<MathFunction<1, Frame::Inertial>>>(
       "Gaussian:\n"
       "  Amplitude: 3\n"
       "  Width: 2\n"
@@ -95,10 +95,10 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Gaussian.Factory",
           "Width: 1.5\n"
           "Center: [1.1, -2.2, 3.3]");
   CHECK(created_gauss == gauss_3d);
-  const auto created_gauss_mathfunction =
-      TestHelpers::test_factory_creation<MathFunction<3, Frame::Inertial>>(
-          "Gaussian:\n"
-          "  Amplitude: 4.0\n"
-          "  Width: 1.5\n"
-          "  Center: [1.1, -2.2, 3.3]");
+  const auto created_gauss_mathfunction = TestHelpers::test_creation<
+      std::unique_ptr<MathFunction<3, Frame::Inertial>>>(
+      "Gaussian:\n"
+      "  Amplitude: 4.0\n"
+      "  Width: 1.5\n"
+      "  Center: [1.1, -2.2, 3.3]");
 }

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_PowX.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_PowX.cpp
@@ -58,9 +58,9 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.PowX",
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.PowX.Factory",
                   "[PointwiseFunctions][Unit]") {
-  TestHelpers::test_factory_creation<MathFunction<1, Frame::Inertial>>(
+  TestHelpers::test_creation<std::unique_ptr<MathFunction<1, Frame::Inertial>>>(
       "PowX:\n    Power: 3");
-  TestHelpers::test_factory_creation<MathFunction<1, Frame::Inertial>>(
+  TestHelpers::test_creation<std::unique_ptr<MathFunction<1, Frame::Inertial>>>(
       "PowX:\n    Power: 3");
   // Catch requires us to have at least one CHECK in each test
   // The Unit.PointwiseFunctions.MathFunctions.PowX.Factory does not need to

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_Sinusoid.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_Sinusoid.cpp
@@ -67,12 +67,12 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Sinusoid",
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Sinusoid.Factory",
                   "[PointwiseFunctions][Unit]") {
-  TestHelpers::test_factory_creation<MathFunction<1, Frame::Inertial>>(
+  TestHelpers::test_creation<std::unique_ptr<MathFunction<1, Frame::Inertial>>>(
       "Sinusoid:\n"
       "  Amplitude: 3\n"
       "  Wavenumber: 2\n"
       "  Phase: -9");
-  TestHelpers::test_factory_creation<MathFunction<1, Frame::Inertial>>(
+  TestHelpers::test_creation<std::unique_ptr<MathFunction<1, Frame::Inertial>>>(
       "Sinusoid:\n"
       "  Amplitude: 3\n"
       "  Wavenumber: 2\n"

--- a/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
+++ b/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
@@ -121,7 +121,7 @@ void check(const bool time_runs_forward,
 SPECTRE_TEST_CASE("Unit.Time.Actions.ChangeStepSize", "[Unit][Time][Actions]") {
   Parallel::register_derived_classes_with_charm<TimeStepper>();
   Parallel::register_derived_classes_with_charm<StepChooser<step_choosers>>();
-  Parallel::register_derived_classes_with_charm<StepController>();
+  Parallel::register_classes_with_charm<StepControllers::BinaryFraction>();
   const Slab slab(-5., -2.);
   const double slab_length = slab.duration().value();
   check(true, std::make_unique<TimeSteppers::AdamsBashforthN>(1),

--- a/tests/Unit/Time/StepChoosers/Test_ByBlock.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_ByBlock.cpp
@@ -62,7 +62,7 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ByBlock", "[Unit][Time]") {
           std::make_pair(expected, true));
   }
 
-  TestHelpers::test_factory_creation<StepChooserType>(
+  TestHelpers::test_creation<std::unique_ptr<StepChooserType>>(
       "ByBlock:\n"
       "  Sizes: [1.0, 2.0]");
 }

--- a/tests/Unit/Time/StepChoosers/Test_Cfl.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_Cfl.cpp
@@ -118,7 +118,7 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.Cfl", "[Unit][Time]") {
   CHECK(get_suggestion(1, 1., 2., {0., 2., 3., 5.}).first == approx(0.5));
   CHECK(get_suggestion(1, 1., 1., {0., 2., 2.5, 5.}).first == approx(0.5));
 
-  TestHelpers::test_factory_creation<StepChooserType>(
+  TestHelpers::test_creation<std::unique_ptr<StepChooserType>>(
       "Cfl:\n"
       "  SafetyFactor: 5.0");
 }

--- a/tests/Unit/Time/StepChoosers/Test_Constant.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_Constant.cpp
@@ -49,12 +49,13 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.Constant", "[Unit][Time]") {
             ->desired_step(make_not_null(&box), current_step, cache) ==
         std::make_pair(5.4, true));
 
-  TestHelpers::test_factory_creation<StepChooserType>("Constant: 5.4");
+  TestHelpers::test_creation<std::unique_ptr<StepChooserType>>("Constant: 5.4");
 }
 
 // [[OutputRegex, Requested step magnitude should be positive]]
 SPECTRE_TEST_CASE("Unit.Time.StepChoosers.Constant.bad_create",
                   "[Unit][Time]") {
   ERROR_TEST();
-  TestHelpers::test_factory_creation<StepChooserType>("Constant: -5.4");
+  TestHelpers::test_creation<std::unique_ptr<StepChooserType>>(
+      "Constant: -5.4");
 }

--- a/tests/Unit/Time/StepChoosers/Test_ErrorControl.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_ErrorControl.cpp
@@ -248,16 +248,16 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.ErrorControl", "[Unit][Time]") {
     }
   }
   // test option creation
-  TestHelpers::test_factory_creation<
-      StepChoosers::ErrorControl<EvolvedVariablesTag>>(
+  TestHelpers::test_creation<
+      std::unique_ptr<StepChoosers::ErrorControl<EvolvedVariablesTag>>>(
       "ErrorControl:\n"
       "  SafetyFactor: 0.95\n"
       "  AbsoluteTolerance: 1.0e-5\n"
       "  RelativeTolerance: 1.0e-4\n"
       "  MaxFactor: 2.1\n"
       "  MinFactor: 0.5");
-  TestHelpers::test_factory_creation<
-      StepChoosers::ErrorControl<EvolvedVariablesTag, ErrorControlSelecter>>(
+  TestHelpers::test_creation<std::unique_ptr<
+      StepChoosers::ErrorControl<EvolvedVariablesTag, ErrorControlSelecter>>>(
       "ErrorControl(SelectorLabel):\n"
       "  SafetyFactor: 0.95\n"
       "  AbsoluteTolerance: 1.0e-5\n"

--- a/tests/Unit/Time/StepChoosers/Test_Increase.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_Increase.cpp
@@ -55,7 +55,7 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.Increase", "[Unit][Time]") {
   check(std::numeric_limits<double>::infinity(),
         std::numeric_limits<double>::infinity());
 
-  TestHelpers::test_factory_creation<StepChooserType>(
+  TestHelpers::test_creation<std::unique_ptr<StepChooserType>>(
       "Increase:\n"
       "  Factor: 5.0");
 }

--- a/tests/Unit/Time/StepChoosers/Test_PreventRapidIncrease.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_PreventRapidIncrease.cpp
@@ -154,5 +154,6 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.PreventRapidIncrease",
   // Cause roundoff errors
   check_case(-1, {{1, 3}, {2, 3}, {3, 3}});
 
-  TestHelpers::test_factory_creation<StepChooserType>("PreventRapidIncrease");
+  TestHelpers::test_creation<std::unique_ptr<StepChooserType>>(
+      "PreventRapidIncrease");
 }

--- a/tests/Unit/Time/StepChoosers/Test_StepToTimes.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_StepToTimes.cpp
@@ -132,7 +132,7 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.StepToTimes", "[Unit][Time]") {
   check_rounding(1.0e5, 1.0e5);
   check_rounding(-1.0e5, 1.0e5);
 
-  TestHelpers::test_factory_creation<StepChooserType>(
+  TestHelpers::test_creation<std::unique_ptr<StepChooserType>>(
       "StepToTimes:\n"
       "  Times:\n"
       "    Specified:\n"

--- a/tests/Unit/Time/StepControllers/Test_BinaryFraction.cpp
+++ b/tests/Unit/Time/StepControllers/Test_BinaryFraction.cpp
@@ -34,7 +34,8 @@ SPECTRE_TEST_CASE("Unit.Time.StepControllers.BinaryFraction", "[Unit][Time]") {
   };
   check(StepControllers::BinaryFraction{});
   check(*serialize_and_deserialize(
-      TestHelpers::test_factory_creation<StepController>("BinaryFraction")));
+      TestHelpers::test_creation<std::unique_ptr<StepController>>(
+          "BinaryFraction")));
 }
 
 // [[OutputRegex, Not at a binary-fraction time within slab]]

--- a/tests/Unit/Time/StepControllers/Test_BinaryFraction.cpp
+++ b/tests/Unit/Time/StepControllers/Test_BinaryFraction.cpp
@@ -16,7 +16,7 @@
 #include "Utilities/ErrorHandling/Error.hpp"
 
 SPECTRE_TEST_CASE("Unit.Time.StepControllers.BinaryFraction", "[Unit][Time]") {
-  Parallel::register_derived_classes_with_charm<StepController>();
+  Parallel::register_classes_with_charm<StepControllers::BinaryFraction>();
   const auto check = [](const auto& bf) noexcept {
     const Slab slab(1., 4.);
     CHECK(bf.choose_step(slab.start(), 4.) == slab.duration());
@@ -34,8 +34,8 @@ SPECTRE_TEST_CASE("Unit.Time.StepControllers.BinaryFraction", "[Unit][Time]") {
   };
   check(StepControllers::BinaryFraction{});
   check(*serialize_and_deserialize(
-      TestHelpers::test_creation<std::unique_ptr<StepController>>(
-          "BinaryFraction")));
+      TestHelpers::test_factory_creation<
+          StepController, StepControllers::BinaryFraction>("BinaryFraction")));
 }
 
 // [[OutputRegex, Not at a binary-fraction time within slab]]

--- a/tests/Unit/Time/StepControllers/Test_FullSlab.cpp
+++ b/tests/Unit/Time/StepControllers/Test_FullSlab.cpp
@@ -31,5 +31,5 @@ SPECTRE_TEST_CASE("Unit.Time.StepControllers.FullSlab", "[Unit][Time]") {
   };
   check(StepControllers::FullSlab{});
   check(*serialize_and_deserialize(
-      TestHelpers::test_factory_creation<StepController>("FullSlab")));
+      TestHelpers::test_creation<std::unique_ptr<StepController>>("FullSlab")));
 }

--- a/tests/Unit/Time/StepControllers/Test_FullSlab.cpp
+++ b/tests/Unit/Time/StepControllers/Test_FullSlab.cpp
@@ -15,7 +15,7 @@
 #include "Time/Time.hpp"
 
 SPECTRE_TEST_CASE("Unit.Time.StepControllers.FullSlab", "[Unit][Time]") {
-  Parallel::register_derived_classes_with_charm<StepController>();
+  Parallel::register_classes_with_charm<StepControllers::FullSlab>();
   const auto check = [](const auto& fs) noexcept {
     const Slab slab(1., 4.);
     CHECK(fs.choose_step(slab.start(), 4.) == slab.duration());
@@ -31,5 +31,6 @@ SPECTRE_TEST_CASE("Unit.Time.StepControllers.FullSlab", "[Unit][Time]") {
   };
   check(StepControllers::FullSlab{});
   check(*serialize_and_deserialize(
-      TestHelpers::test_creation<std::unique_ptr<StepController>>("FullSlab")));
+      TestHelpers::test_factory_creation<
+          StepController, StepControllers::FullSlab>("FullSlab")));
 }

--- a/tests/Unit/Time/StepControllers/Test_SimpleTimes.cpp
+++ b/tests/Unit/Time/StepControllers/Test_SimpleTimes.cpp
@@ -41,5 +41,6 @@ SPECTRE_TEST_CASE("Unit.Time.StepControllers.SimpleTimes", "[Unit][Time]") {
   };
   check(StepControllers::SimpleTimes{});
   check(*serialize_and_deserialize(
-      TestHelpers::test_factory_creation<StepController>("SimpleTimes")));
+      TestHelpers::test_creation<std::unique_ptr<StepController>>(
+          "SimpleTimes")));
 }

--- a/tests/Unit/Time/StepControllers/Test_SimpleTimes.cpp
+++ b/tests/Unit/Time/StepControllers/Test_SimpleTimes.cpp
@@ -17,7 +17,7 @@
 // IWYU pragma: no_include "Utilities/Rational.hpp"
 
 SPECTRE_TEST_CASE("Unit.Time.StepControllers.SimpleTimes", "[Unit][Time]") {
-  Parallel::register_derived_classes_with_charm<StepController>();
+  Parallel::register_classes_with_charm<StepControllers::SimpleTimes>();
   const auto check = [](const auto& st) noexcept {
     const Slab slab(1., 4.);
     CHECK(st.choose_step(slab.start(), 4.) == slab.duration());
@@ -41,6 +41,6 @@ SPECTRE_TEST_CASE("Unit.Time.StepControllers.SimpleTimes", "[Unit][Time]") {
   };
   check(StepControllers::SimpleTimes{});
   check(*serialize_and_deserialize(
-      TestHelpers::test_creation<std::unique_ptr<StepController>>(
-          "SimpleTimes")));
+      TestHelpers::test_factory_creation<
+          StepController, StepControllers::SimpleTimes>("SimpleTimes")));
 }

--- a/tests/Unit/Time/StepControllers/Test_SplitRemaining.cpp
+++ b/tests/Unit/Time/StepControllers/Test_SplitRemaining.cpp
@@ -35,5 +35,6 @@ SPECTRE_TEST_CASE("Unit.Time.StepControllers.SplitRemaining", "[Unit][Time]") {
   };
   check(StepControllers::SplitRemaining{});
   check(*serialize_and_deserialize(
-      TestHelpers::test_factory_creation<StepController>("SplitRemaining")));
+      TestHelpers::test_creation<std::unique_ptr<StepController>>(
+          "SplitRemaining")));
 }

--- a/tests/Unit/Time/StepControllers/Test_SplitRemaining.cpp
+++ b/tests/Unit/Time/StepControllers/Test_SplitRemaining.cpp
@@ -15,7 +15,7 @@
 #include "Time/Time.hpp"
 
 SPECTRE_TEST_CASE("Unit.Time.StepControllers.SplitRemaining", "[Unit][Time]") {
-  Parallel::register_derived_classes_with_charm<StepController>();
+  Parallel::register_classes_with_charm<StepControllers::SplitRemaining>();
   const auto check = [](const auto& sr) noexcept {
     const Slab slab(1., 4.);
     CHECK(sr.choose_step(slab.start(), 4.) == slab.duration());
@@ -35,6 +35,6 @@ SPECTRE_TEST_CASE("Unit.Time.StepControllers.SplitRemaining", "[Unit][Time]") {
   };
   check(StepControllers::SplitRemaining{});
   check(*serialize_and_deserialize(
-      TestHelpers::test_creation<std::unique_ptr<StepController>>(
-          "SplitRemaining")));
+      TestHelpers::test_factory_creation<
+          StepController, StepControllers::SplitRemaining>("SplitRemaining")));
 }

--- a/tests/Unit/Time/Test_TimeSequence.cpp
+++ b/tests/Unit/Time/Test_TimeSequence.cpp
@@ -19,11 +19,11 @@ namespace {
 void test_evenly_spaced() noexcept {
   {
     const TimeSequences::EvenlySpaced<std::uint64_t> constructed(3, 5);
-    const auto factory =
-        TestHelpers::test_factory_creation<TimeSequence<std::uint64_t>>(
-            "EvenlySpaced:\n"
-            "  Interval: 3\n"
-            "  Offset: 5\n");
+    const auto factory = TestHelpers::test_creation<
+        std::unique_ptr<TimeSequence<std::uint64_t>>>(
+        "EvenlySpaced:\n"
+        "  Interval: 3\n"
+        "  Offset: 5\n");
     const auto check = [&constructed, &factory](
                            const std::uint64_t arg,
                            const std::uint64_t result) noexcept {
@@ -49,7 +49,7 @@ void test_evenly_spaced() noexcept {
   {
     const TimeSequences::EvenlySpaced<double> constructed(3.75, 4.0625);
     const auto factory =
-        TestHelpers::test_factory_creation<TimeSequence<double>>(
+        TestHelpers::test_creation<std::unique_ptr<TimeSequence<double>>>(
             "EvenlySpaced:\n"
             "  Interval: 3.75\n"
             "  Offset: 4.0625\n");
@@ -73,10 +73,10 @@ void test_specified() noexcept {
     using Result = std::array<std::optional<std::uint64_t>, 3>;
     const TimeSequences::Specified<std::uint64_t> constructed(
         {4, 8, 0, 4, 4, 3, 4});
-    const auto factory =
-        TestHelpers::test_factory_creation<TimeSequence<std::uint64_t>>(
-            "Specified:\n"
-            "  Values: [4, 8, 0, 4, 4, 3, 4]\n");
+    const auto factory = TestHelpers::test_creation<
+        std::unique_ptr<TimeSequence<std::uint64_t>>>(
+        "Specified:\n"
+        "  Values: [4, 8, 0, 4, 4, 3, 4]\n");
     const auto check = [&constructed, &factory](
                            const std::uint64_t arg,
                            const Result& expected) noexcept {
@@ -113,7 +113,7 @@ void test_specified() noexcept {
     const TimeSequences::Specified<double> constructed(
         {-5.1, 7.2, -2.3, 0.0, -5.1, -5.1, 3.4, 4.5});
     const auto factory =
-        TestHelpers::test_factory_creation<TimeSequence<double>>(
+        TestHelpers::test_creation<std::unique_ptr<TimeSequence<double>>>(
             "Specified:\n"
             "  Values: [-5.1, 7.2, -2.3, 0.0, -5.1, -5.1, 3.4, 4.5]\n");
     const auto check = [&constructed, &factory](

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
@@ -75,10 +75,10 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN", "[Unit][Time]") {
   CHECK_FALSE(can_change(end, start, mid));
   CHECK_FALSE(can_change(end, mid, start));
 
-  TestHelpers::test_factory_creation<TimeStepper>(
+  TestHelpers::test_creation<std::unique_ptr<TimeStepper>>(
       "AdamsBashforthN:\n"
       "  Order: 3");
-  TestHelpers::test_factory_creation<LtsTimeStepper>(
+  TestHelpers::test_creation<std::unique_ptr<LtsTimeStepper>>(
       "AdamsBashforthN:\n"
       "  Order: 3");
 

--- a/tests/Unit/Time/TimeSteppers/Test_DormandPrince5.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_DormandPrince5.cpp
@@ -29,7 +29,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.DormandPrince5", "[Unit][Time]") {
   CHECK(stepper.order() == 5_st);
   CHECK(stepper.error_estimate_order() == 4_st);
 
-  TestHelpers::test_factory_creation<TimeStepper>("DormandPrince5");
+  TestHelpers::test_creation<std::unique_ptr<TimeStepper>>("DormandPrince5");
   test_serialization(stepper);
   test_serialization_via_base<TimeStepper, TimeSteppers::DormandPrince5>();
   // test operator !=

--- a/tests/Unit/Time/TimeSteppers/Test_RungeKutta3.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_RungeKutta3.cpp
@@ -29,7 +29,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3", "[Unit][Time]") {
   CHECK(stepper.order() == 3_st);
   CHECK(stepper.error_estimate_order() == 2_st);
 
-  TestHelpers::test_factory_creation<TimeStepper>("RungeKutta3");
+  TestHelpers::test_creation<std::unique_ptr<TimeStepper>>("RungeKutta3");
   test_serialization(stepper);
   test_serialization_via_base<TimeStepper, TimeSteppers::RungeKutta3>();
   // test operator !=

--- a/tests/Unit/Time/TimeSteppers/Test_RungeKutta4.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_RungeKutta4.cpp
@@ -29,7 +29,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta4", "[Unit][Time]") {
   CHECK(stepper.order() == 4_st);
   CHECK(stepper.error_estimate_order() == 3_st);
 
-  TestHelpers::test_factory_creation<TimeStepper>("RungeKutta4");
+  TestHelpers::test_creation<std::unique_ptr<TimeStepper>>("RungeKutta4");
   test_serialization(stepper);
   test_serialization_via_base<TimeStepper, TimeSteppers::RungeKutta4>();
   // test operator !=

--- a/tests/Unit/Time/Triggers/Test_NearTimes.cpp
+++ b/tests/Unit/Time/Triggers/Test_NearTimes.cpp
@@ -103,7 +103,7 @@ SPECTRE_TEST_CASE("Unit.Time.Triggers.NearTimes", "[Unit][Time]") {
   check(5.0, 3.0, {1.0, 9.0}, Direction::Before, false);
   check(5.0, 3.0, {1.0, 9.0}, Direction::After, false);
 
-  TestHelpers::test_factory_creation<TriggerType>(
+  TestHelpers::test_creation<std::unique_ptr<TriggerType>>(
       "NearTimes:\n"
       "  Times:\n"
       "    Specified:\n"

--- a/tests/Unit/Time/Triggers/Test_SlabCompares.cpp
+++ b/tests/Unit/Time/Triggers/Test_SlabCompares.cpp
@@ -22,7 +22,7 @@ SPECTRE_TEST_CASE("Unit.Time.Triggers.SlabCompares", "[Unit][Time]") {
   using TriggerType = Trigger<tmpl::list<Triggers::Registrars::SlabCompares>>;
   Parallel::register_derived_classes_with_charm<TriggerType>();
 
-  const auto trigger = TestHelpers::test_factory_creation<TriggerType>(
+  const auto trigger = TestHelpers::test_creation<std::unique_ptr<TriggerType>>(
       "SlabCompares:\n"
       "  Comparison: GreaterThan\n"
       "  Value: 3");

--- a/tests/Unit/Time/Triggers/Test_Slabs.cpp
+++ b/tests/Unit/Time/Triggers/Test_Slabs.cpp
@@ -26,7 +26,7 @@ SPECTRE_TEST_CASE("Unit.Time.Triggers.Slabs", "[Unit][Time]") {
   Parallel::register_derived_classes_with_charm<TriggerType>();
   Parallel::register_derived_classes_with_charm<TimeSequence<std::uint64_t>>();
 
-  const auto trigger = TestHelpers::test_factory_creation<TriggerType>(
+  const auto trigger = TestHelpers::test_creation<std::unique_ptr<TriggerType>>(
       "Slabs:\n"
       "  Specified:\n"
       "    Values: [3, 6, 8]");

--- a/tests/Unit/Time/Triggers/Test_TimeCompares.cpp
+++ b/tests/Unit/Time/Triggers/Test_TimeCompares.cpp
@@ -20,7 +20,7 @@ SPECTRE_TEST_CASE("Unit.Time.Triggers.TimeCompares", "[Unit][Time]") {
   using TriggerType = Trigger<tmpl::list<Triggers::Registrars::TimeCompares>>;
   Parallel::register_derived_classes_with_charm<TriggerType>();
 
-  const auto trigger = TestHelpers::test_factory_creation<TriggerType>(
+  const auto trigger = TestHelpers::test_creation<std::unique_ptr<TriggerType>>(
       "TimeCompares:\n"
       "  Comparison: GreaterThan\n"
       "  Value: 3.5");

--- a/tests/Unit/Time/Triggers/Test_Times.cpp
+++ b/tests/Unit/Time/Triggers/Test_Times.cpp
@@ -70,7 +70,7 @@ SPECTRE_TEST_CASE("Unit.Time.Triggers.Times", "[Unit][Time]") {
   check(inaccurate_1, 1.0, {1.0}, false);
   check(inaccurate_1, 1.0e5, {1.0}, true);
 
-  TestHelpers::test_factory_creation<TriggerType>(
+  TestHelpers::test_creation<std::unique_ptr<TriggerType>>(
       "Times:\n"
       "  Specified:\n"
       "    Values: [2.0, 1.0, 3.0, 2.0]");

--- a/tests/Unit/Utilities/Test_Registration.cpp
+++ b/tests/Unit/Utilities/Test_Registration.cpp
@@ -89,12 +89,12 @@ SPECTRE_TEST_CASE("Unit.Utilities.Registration", "[Unit][Utilities]") {
       Base<tmpl::list<Registrars::Derived1, Registrars::Derived2<double>,
                       Registrars::Derived3<4>>>;
   // [registrar_use]
-  CHECK(TestHelpers::test_factory_creation<ConcreteBase>("Derived1")->func() ==
-        1);
-  CHECK(TestHelpers::test_factory_creation<ConcreteBase>("Derived2")->func() ==
-        2);
-  CHECK(TestHelpers::test_factory_creation<ConcreteBase>("Derived3")->func() ==
-        4);
+  CHECK(TestHelpers::test_creation<std::unique_ptr<ConcreteBase>>("Derived1")
+            ->func() == 1);
+  CHECK(TestHelpers::test_creation<std::unique_ptr<ConcreteBase>>("Derived2")
+            ->func() == 2);
+  CHECK(TestHelpers::test_creation<std::unique_ptr<ConcreteBase>>("Derived3")
+            ->func() == 4);
 
   // Test standalone derived classes
   CHECK(Derived1<>{}.func() == 1);


### PR DESCRIPTION
## Proposed changes

This moves the lists of derived classes from base classes into the metavariables, as discussed in #2953.  

This shows the infrastructure and converts three base classes: StepController, Trigger, and StepChooser.  The last of those is probably the most complicated case in the repo, and the base class has been split into two specializations.

A few design notes:
* Things using `call_with_derived_type` need the list of classes now.  Most of them already had the DataBox, so I put the Metavariables in there.
* The option-parser testing functions have been rearranged (and I haven't written the new docs yet), mostly to make it easier to pass metavariables, which is necessary more often now.  
  * The new `test_creation` is the same as the old `test_creation`, but with the second template argument (the tag override) removed.
  * The `test_option_tag` function is the same as the old `test_creation` but with the first template argument removed (as it can be inferred from the second argument).
  * The new `test_factory_creation` is a helper for the case where you know factory should be creating one specific type, generating appropriate metavariables for you.

My proposal is to merge the infrastructure changes first (diff currently 131,+804,-667, mostly churn from test_creation), and then do the base classes in separate PRs.  This should minimize rebase conflicts and get the size of the PRs down somewhat.

Ping @nilsleiffischer and @nilsdeppe from earlier discussions.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
The available factory-creatable types for some base classes (currently just StepController) are now specified in a `factory_creation` struct in the metavariables.  See one of the standard executables for an example.  More base classes will be converted to this new method over time.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
