### PR TITLE
Auto-publish releases on Zenodo

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -134,7 +134,8 @@ jobs:
             --github-token ${{ secrets.GITHUB_TOKEN }}
           python3 .github/scripts/Release.py publish -vv --check-only \
             --zenodo-token ${{ secrets.ZENODO_READONLY_TOKEN }} \
-            --github-token ${{ secrets.GITHUB_TOKEN }}
+            --github-token ${{ secrets.GITHUB_TOKEN }} \
+            --auto-publish
       - name: Check release notes
         run: |
           python3 tools/CompileReleaseNotes.py -vv -o release_notes.md \
@@ -614,16 +615,14 @@ jobs:
           release_name: Release ${{ env.RELEASE_VERSION }}
           body_path: >-
             ${{ steps.release-notes.outputs.download-path }}/release_notes.md
-      # This action currently doesn't publish the Zenodo record automatically.
-      # Instead it prints a link to the website where we can go and hit the
-      # "Publish" button when everything looks correct. Once we're convinced the
-      # automation works well enough we can add the `--auto-publish` flag to
-      # the command below.
+      # Publish the Zenodo record. Once published, the record can't be deleted
+      # anymore and editing is limited.
       - name: Publish to Zenodo
         run: |
           python3 .github/scripts/Release.py publish -vv \
             --zenodo-token ${{ secrets.ZENODO_PUBLISH_TOKEN }} \
-            --github-token ${{ secrets.GITHUB_TOKEN }}
+            --github-token ${{ secrets.GITHUB_TOKEN }} \
+            --auto-publish
 
   arch_datastructures_tests:
     name: Archs


### PR DESCRIPTION
## Proposed changes

The release workflow has been working fine, so this commit enables auto-publishing the Zenodo record without manually going to the Zenodo website to click a button.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
