### PR TITLE
Add boundary conditions for radiation transport system

### DIFF
--- a/src/Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/BoundaryCondition.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/BoundaryCondition.hpp
@@ -6,6 +6,7 @@
 #include <pup.h>
 
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -21,7 +22,10 @@ namespace RadiationTransport::M1Grey::BoundaryConditions {
 template <typename... NeutrinoSpecies>
 class BoundaryCondition : public domain::BoundaryConditions::BoundaryCondition {
  public:
-  using creatable_classes = tmpl::list<DirichletAnalytic<NeutrinoSpecies...>>;
+  using creatable_classes =
+      tmpl::list<DirichletAnalytic<NeutrinoSpecies...>,
+                 domain::BoundaryConditions::Periodic<
+                     BoundaryCondition<NeutrinoSpecies...>>>;
 
   BoundaryCondition() = default;
   BoundaryCondition(BoundaryCondition&&) noexcept = default;

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/BoundaryCondition.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/BoundaryCondition.hpp
@@ -1,0 +1,40 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pup.h>
+
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace RadiationTransport::M1Grey::BoundaryConditions {
+template <typename... NeutrinoSpecies>
+class DirichletAnalytic;
+}  // namespace RadiationTransport::M1Grey::BoundaryConditions
+/// \endcond
+
+/// \brief Boundary conditions for the M1Grey radiation transport system
+namespace RadiationTransport::M1Grey::BoundaryConditions {
+/// \brief The base class off of which all boundary conditions must inherit
+template <typename... NeutrinoSpecies>
+class BoundaryCondition : public domain::BoundaryConditions::BoundaryCondition {
+ public:
+  using creatable_classes = tmpl::list<DirichletAnalytic<NeutrinoSpecies...>>;
+
+  BoundaryCondition() = default;
+  BoundaryCondition(BoundaryCondition&&) noexcept = default;
+  BoundaryCondition& operator=(BoundaryCondition&&) noexcept = default;
+  BoundaryCondition(const BoundaryCondition&) = default;
+  BoundaryCondition& operator=(const BoundaryCondition&) = default;
+  ~BoundaryCondition() override = default;
+
+  explicit BoundaryCondition(CkMigrateMessage* const msg) noexcept
+      : domain::BoundaryConditions::BoundaryCondition(msg) {}
+
+  void pup(PUP::er& p) override {
+    domain::BoundaryConditions::BoundaryCondition::pup(p);
+  }
+};
+}  // namespace RadiationTransport::M1Grey::BoundaryConditions

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/CMakeLists.txt
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  M1Grey
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  BoundaryCondition.hpp
+  DirichletAnalytic.hpp
+  Factory.hpp
+  )

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/DirichletAnalytic.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/DirichletAnalytic.hpp
@@ -1,0 +1,212 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <pup.h>
+#include <string>
+#include <type_traits>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/RadiationTransport/M1Grey/Fluxes.hpp"
+#include "Evolution/Systems/RadiationTransport/M1Grey/M1Closure.hpp"
+#include "Evolution/Systems/RadiationTransport/M1Grey/Tags.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/AnalyticData/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace domain::Tags {
+template <size_t Dim, typename Frame>
+struct Coordinates;
+}  // namespace domain::Tags
+/// \endcond
+
+namespace RadiationTransport::M1Grey::BoundaryConditions {
+/*!
+ * \brief Sets Dirichlet boundary conditions using the analytic solution or
+ * analytic data.
+ */
+template <typename... NeutrinoSpecies>
+class DirichletAnalytic final : public BoundaryCondition<NeutrinoSpecies...> {
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help{
+      "DirichletAnalytic boundary conditions using either analytic solution or "
+      "analytic data."};
+  static std::string name() noexcept { return "DirichletAnalytic"; }
+
+  DirichletAnalytic() = default;
+  DirichletAnalytic(DirichletAnalytic&&) noexcept = default;
+  DirichletAnalytic& operator=(DirichletAnalytic&&) noexcept = default;
+  DirichletAnalytic(const DirichletAnalytic&) = default;
+  DirichletAnalytic& operator=(const DirichletAnalytic&) = default;
+  ~DirichletAnalytic() override = default;
+
+  explicit DirichletAnalytic(CkMigrateMessage* msg) noexcept
+      : BoundaryCondition<NeutrinoSpecies...>(msg) {}
+
+  WRAPPED_PUPable_decl_base_template(
+      domain::BoundaryConditions::BoundaryCondition, DirichletAnalytic);
+
+  auto get_clone() const noexcept -> std::unique_ptr<
+      domain::BoundaryConditions::BoundaryCondition> override {
+    return std::make_unique<DirichletAnalytic>(*this);
+  }
+
+  static constexpr evolution::BoundaryConditions::Type bc_type =
+      evolution::BoundaryConditions::Type::Ghost;
+
+  void pup(PUP::er& p) override {
+    BoundaryCondition<NeutrinoSpecies...>::pup(p);
+  }
+
+  using dg_interior_evolved_variables_tags = tmpl::list<>;
+  using dg_interior_temporary_tags =
+      tmpl::list<domain::Tags::Coordinates<3, Frame::Inertial>>;
+  using dg_interior_primitive_variables_tags = tmpl::list<>;
+  using dg_gridless_tags =
+      tmpl::list<::Tags::Time, ::Tags::AnalyticSolutionOrData>;
+
+  template <typename AnalyticSolutionOrData>
+  std::optional<std::string> dg_ghost(
+      const gsl::not_null<typename Tags::TildeE<
+          Frame::Inertial, NeutrinoSpecies>::type*>... tilde_e,
+      const gsl::not_null<typename Tags::TildeS<
+          Frame::Inertial, NeutrinoSpecies>::type*>... tilde_s,
+
+      const gsl::not_null<typename ::Tags::Flux<
+          Tags::TildeE<Frame::Inertial, NeutrinoSpecies>, tmpl::size_t<3>,
+          Frame::Inertial>::type*>... flux_tilde_e,
+      const gsl::not_null<typename ::Tags::Flux<
+          Tags::TildeS<Frame::Inertial, NeutrinoSpecies>, tmpl::size_t<3>,
+          Frame::Inertial>::type*>... flux_tilde_s,
+
+      const std::optional<
+          tnsr::I<DataVector, 3, Frame::Inertial>>& /*face_mesh_velocity*/,
+      const tnsr::i<DataVector, 3, Frame::Inertial>& /*normal_covector*/,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& /*normal_vector*/,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& coords, const double time,
+      const AnalyticSolutionOrData& analytic_solution_or_data) const noexcept {
+    auto boundary_values = [&analytic_solution_or_data, &coords,
+                            &time]() noexcept {
+      if constexpr (std::is_base_of_v<MarkAsAnalyticSolution,
+                                      AnalyticSolutionOrData>) {
+        return analytic_solution_or_data.variables(
+            coords, time,
+            tmpl::list<Tags::TildeE<Frame::Inertial, NeutrinoSpecies>...,
+                       Tags::TildeS<Frame::Inertial, NeutrinoSpecies>...,
+                       hydro::Tags::LorentzFactor<DataVector>,
+                       hydro::Tags::SpatialVelocity<DataVector, 3>,
+                       gr::Tags::Lapse<>, gr::Tags::Shift<3>,
+                       gr::Tags::SpatialMetric<3>,
+                       gr::Tags::InverseSpatialMetric<3>>{});
+
+      } else {
+        (void)time;
+        return analytic_solution_or_data.variables(
+            coords,
+            tmpl::list<Tags::TildeE<Frame::Inertial, NeutrinoSpecies>...,
+                       Tags::TildeS<Frame::Inertial, NeutrinoSpecies>...,
+                       hydro::Tags::LorentzFactor<DataVector>,
+                       hydro::Tags::SpatialVelocity<DataVector, 3>,
+                       gr::Tags::Lapse<>, gr::Tags::Shift<3>,
+                       gr::Tags::SpatialMetric<3>,
+                       gr::Tags::InverseSpatialMetric<3>>{});
+      }
+    }();
+
+    // Allocate the temporary tensors outside the loop over species
+    const auto& lapse = get<gr::Tags::Lapse<>>(boundary_values);
+    Variables<tmpl::list<::Tags::TempScalar<0>, ::Tags::TempII<0, 3>,
+                         ::Tags::TempScalar<1>, ::Tags::TempScalar<2>,
+                         ::Tags::Tempi<0, 3>, ::Tags::TempI<0, 3>>>
+        buffer(get(lapse).size());
+
+    const auto assign_boundary_values_for_neutrino_species =
+        [&boundary_values, &lapse, &buffer](
+            const gsl::not_null<Scalar<DataVector>*> local_tilde_e,
+            const gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*>
+                local_tilde_s,
+            const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+                local_flux_tilde_e,
+            const gsl::not_null<tnsr::Ij<DataVector, 3, Frame::Inertial>*>
+                local_flux_tilde_s,
+            auto species_v) noexcept {
+          using species = decltype(species_v);
+          using tilde_e_tag = Tags::TildeE<Frame::Inertial, species>;
+          using tilde_s_tag = Tags::TildeS<Frame::Inertial, species>;
+          *local_tilde_e = get<tilde_e_tag>(boundary_values);
+          *local_tilde_s = get<tilde_s_tag>(boundary_values);
+
+          // Compute pressure tensor tilde_p from the M1Closure
+          const auto& fluid_velocity =
+              get<hydro::Tags::SpatialVelocity<DataVector, 3>>(boundary_values);
+          const auto& fluid_lorentz_factor =
+              get<hydro::Tags::LorentzFactor<DataVector>>(boundary_values);
+          const auto& shift = get<gr::Tags::Shift<3>>(boundary_values);
+          const auto& spatial_metric =
+              get<gr::Tags::SpatialMetric<3>>(boundary_values);
+          const auto& inv_spatial_metric =
+              get<gr::Tags::InverseSpatialMetric<3>>(boundary_values);
+          auto& closure_factor = get<::Tags::TempScalar<0>>(buffer);
+          // The M1Closure reads in values from `closure_factor` as an initial
+          // guess. We need to specify some value (else code fails in DEBUG
+          // mode when the temp Variables are initialized with NaNs)... for now
+          // we use 0 because it's easy, but improvements may be possible.
+          get(closure_factor) = 0.;
+          auto& pressure_tensor = get<::Tags::TempII<0, 3>>(buffer);
+          auto& comoving_energy_density = get<::Tags::TempScalar<1>>(buffer);
+          auto& comoving_momentum_density_normal =
+              get<::Tags::TempScalar<2>>(buffer);
+          auto& comoving_momentum_density_spatial =
+              get<::Tags::Tempi<0, 3>>(buffer);
+          detail::compute_closure_impl(
+              make_not_null(&closure_factor), make_not_null(&pressure_tensor),
+              make_not_null(&comoving_energy_density),
+              make_not_null(&comoving_momentum_density_normal),
+              make_not_null(&comoving_momentum_density_spatial), *local_tilde_e,
+              *local_tilde_s, fluid_velocity, fluid_lorentz_factor,
+              spatial_metric, inv_spatial_metric);
+          // Store det of metric in (otherwise unused) comoving_energy_density
+          get(comoving_energy_density) = get(determinant(spatial_metric));
+          for (auto& component : pressure_tensor) {
+            component *= get(comoving_energy_density);
+          }
+          const auto& tilde_p = pressure_tensor;
+
+          auto& tilde_s_M = get<::Tags::TempI<0, 3>>(buffer);
+          detail::compute_fluxes_impl(local_flux_tilde_e, local_flux_tilde_s,
+                                      &tilde_s_M, *local_tilde_e,
+                                      *local_tilde_s, tilde_p, lapse, shift,
+                                      spatial_metric, inv_spatial_metric);
+          return '0';
+        };
+
+    expand_pack(assign_boundary_values_for_neutrino_species(
+        tilde_e, tilde_s, flux_tilde_e, flux_tilde_s, NeutrinoSpecies{})...);
+    return {};
+  }
+};
+
+/// \cond
+template <typename... NeutrinoSpecies>
+// NOLINTNEXTLINE
+PUP::able::PUP_ID DirichletAnalytic<NeutrinoSpecies...>::my_PUP_ID = 0;
+/// \endcond
+
+}  // namespace RadiationTransport::M1Grey::BoundaryConditions

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/Factory.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/Factory.hpp
@@ -1,0 +1,7 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/DirichletAnalytic.hpp"

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/BoundaryCorrections/CMakeLists.txt
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/BoundaryCorrections/CMakeLists.txt
@@ -12,5 +12,6 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   BoundaryCorrection.hpp
+  Factory.hpp
   Rusanov.hpp
   )

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/BoundaryCorrections/Factory.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/BoundaryCorrections/Factory.hpp
@@ -1,0 +1,7 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/Systems/RadiationTransport/M1Grey/BoundaryCorrections/BoundaryCorrection.hpp"
+#include "Evolution/Systems/RadiationTransport/M1Grey/BoundaryCorrections/Rusanov.hpp"

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/CMakeLists.txt
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/CMakeLists.txt
@@ -39,4 +39,5 @@ target_link_libraries(
   INTERFACE Utilities
   )
 
+add_subdirectory(BoundaryConditions)
 add_subdirectory(BoundaryCorrections)

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/DirichletAnalytic.py
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/DirichletAnalytic.py
@@ -1,0 +1,130 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+import PointwiseFunctions.AnalyticSolutions.RadiationTransport.M1Grey.\
+           TestFunctions as soln
+import Evolution.Systems.RadiationTransport.M1Grey.Fluxes as fluxes
+
+
+def soln_error(face_mesh_velocity, outward_directed_normal_covector,
+               outward_directed_normal_vector, coords, time, dim):
+    return None
+
+
+_soln_mean_velocity = np.array([0.1, 0.2, 0.3])
+_soln_comoving_energy_density = 0.4
+
+# There is no Python implementation of the M1Closure, so for now we hardcode
+# the pressure tensor with values obtained by running the C++ code run with
+# the same input parameters. This is hacky, because it couples the C++ and
+# Python implementations and makes the test less robust.
+_tilde_p_values_from_cxx = np.array(
+    [[0.13953488372093026, 0.012403100775193798, 0.018604651162790694],
+     [0.012403100775193798, 0.15813953488372096, 0.037209302325581388],
+     [0.018604651162790694, 0.037209302325581388, 0.18914728682170545]])
+
+
+def soln_tilde_e_nue(face_mesh_velocity, outward_directed_normal_covector,
+                     outward_directed_normal_vector, coords, time, dim):
+    return soln.constant_m1_tildeE(coords, time, _soln_mean_velocity,
+                                   _soln_comoving_energy_density)
+
+
+def soln_tilde_e_bar_nue(face_mesh_velocity, outward_directed_normal_covector,
+                         outward_directed_normal_vector, coords, time, dim):
+    return soln.constant_m1_tildeE(coords, time, _soln_mean_velocity,
+                                   _soln_comoving_energy_density)
+
+
+def soln_tilde_s_nue(face_mesh_velocity, outward_directed_normal_covector,
+                     outward_directed_normal_vector, coords, time, dim):
+    return soln.constant_m1_tildeS(coords, time, _soln_mean_velocity,
+                                   _soln_comoving_energy_density)
+
+
+def soln_tilde_s_bar_nue(face_mesh_velocity, outward_directed_normal_covector,
+                         outward_directed_normal_vector, coords, time, dim):
+    return soln.constant_m1_tildeS(coords, time, _soln_mean_velocity,
+                                   _soln_comoving_energy_density)
+
+
+def soln_flux_tilde_e_nue(face_mesh_velocity, outward_directed_normal_covector,
+                          outward_directed_normal_vector, coords, time, dim):
+    tilde_e = soln_tilde_e_nue(face_mesh_velocity,
+                               outward_directed_normal_covector,
+                               outward_directed_normal_vector, coords, time,
+                               dim)
+    tilde_s = soln_tilde_s_nue(face_mesh_velocity,
+                               outward_directed_normal_covector,
+                               outward_directed_normal_vector, coords, time,
+                               dim)
+    tilde_p = _tilde_p_values_from_cxx
+    lapse = 1.0
+    shift = np.array([0.0, 0.0, 0.0])
+    spatial_metric = np.identity(3)
+    inv_spatial_metric = np.identity(3)
+    return fluxes.tilde_e_flux(tilde_e, tilde_s, tilde_p, lapse, shift,
+                               spatial_metric, inv_spatial_metric)
+
+
+def soln_flux_tilde_e_bar_nue(face_mesh_velocity,
+                              outward_directed_normal_covector,
+                              outward_directed_normal_vector, coords, time,
+                              dim):
+    tilde_e = soln_tilde_e_bar_nue(face_mesh_velocity,
+                                   outward_directed_normal_covector,
+                                   outward_directed_normal_vector, coords,
+                                   time, dim)
+    tilde_s = soln_tilde_s_bar_nue(face_mesh_velocity,
+                                   outward_directed_normal_covector,
+                                   outward_directed_normal_vector, coords,
+                                   time, dim)
+    tilde_p = _tilde_p_values_from_cxx
+    lapse = 1.0
+    shift = np.array([0.0, 0.0, 0.0])
+    spatial_metric = np.identity(3)
+    inv_spatial_metric = np.identity(3)
+    return fluxes.tilde_e_flux(tilde_e, tilde_s, tilde_p, lapse, shift,
+                               spatial_metric, inv_spatial_metric)
+
+
+def soln_flux_tilde_s_nue(face_mesh_velocity, outward_directed_normal_covector,
+                          outward_directed_normal_vector, coords, time, dim):
+    tilde_e = soln_tilde_e_nue(face_mesh_velocity,
+                               outward_directed_normal_covector,
+                               outward_directed_normal_vector, coords, time,
+                               dim)
+    tilde_s = soln_tilde_s_nue(face_mesh_velocity,
+                               outward_directed_normal_covector,
+                               outward_directed_normal_vector, coords, time,
+                               dim)
+    tilde_p = _tilde_p_values_from_cxx
+    lapse = 1.0
+    shift = np.array([0.0, 0.0, 0.0])
+    spatial_metric = np.identity(3)
+    inv_spatial_metric = np.identity(3)
+    return fluxes.tilde_s_flux(tilde_e, tilde_s, tilde_p, lapse, shift,
+                               spatial_metric, inv_spatial_metric)
+
+
+def soln_flux_tilde_s_bar_nue(face_mesh_velocity,
+                              outward_directed_normal_covector,
+                              outward_directed_normal_vector, coords, time,
+                              dim):
+    tilde_e = soln_tilde_e_bar_nue(face_mesh_velocity,
+                                   outward_directed_normal_covector,
+                                   outward_directed_normal_vector, coords,
+                                   time, dim)
+    tilde_s = soln_tilde_s_bar_nue(face_mesh_velocity,
+                                   outward_directed_normal_covector,
+                                   outward_directed_normal_vector, coords,
+                                   time, dim)
+    tilde_p = _tilde_p_values_from_cxx
+    lapse = 1.0
+    shift = np.array([0.0, 0.0, 0.0])
+    spatial_metric = np.identity(3)
+    inv_spatial_metric = np.identity(3)
+    return fluxes.tilde_s_flux(tilde_e, tilde_s, tilde_p, lapse, shift,
+                               spatial_metric, inv_spatial_metric)

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/Test_DirichletAnalytic.cpp
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/Test_DirichletAnalytic.cpp
@@ -1,0 +1,129 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Index.hpp"
+#include "Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/DirichletAnalytic.hpp"
+#include "Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/RadiationTransport/M1Grey/BoundaryCorrections/Rusanov.hpp"
+#include "Evolution/Systems/RadiationTransport/M1Grey/System.hpp"
+#include "Evolution/Systems/RadiationTransport/M1Grey/Tags.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/ConstantM1.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace helpers = TestHelpers::evolution::dg;
+
+namespace {
+struct ConvertConstantM1 {
+  using unpacked_container = int;
+  using packed_container = RadiationTransport::M1Grey::Solutions::ConstantM1;
+  using packed_type = double;
+
+  static packed_container create_container() {
+    const std::array<double, 3> mean_velocity_{{0.1, 0.2, 0.3}};
+    const double comoving_energy_density = 0.4;
+    return {mean_velocity_, comoving_energy_density};
+  }
+
+  static inline unpacked_container unpack(
+      const packed_container& /*packed*/,
+      const size_t /*grid_point_index*/) noexcept {
+    // No way of getting the args from the boundary condition.
+    return 3;
+  }
+
+  static inline void pack(const gsl::not_null<packed_container*> packed,
+                          const unpacked_container /*unpacked*/,
+                          const size_t /*grid_point_index*/) {
+    *packed = create_container();
+  }
+
+  static inline size_t get_size(const packed_container& /*packed*/) noexcept {
+    return 1;
+  }
+};
+
+void test() {
+  MAKE_GENERATOR(gen);
+  const auto box_analytic_soln = db::create<db::AddSimpleTags<
+      Tags::Time, Tags::AnalyticSolution<
+                      RadiationTransport::M1Grey::Solutions::ConstantM1>>>(
+      0.5, ConvertConstantM1::create_container());
+
+  using system = RadiationTransport::M1Grey::System<tmpl::list<
+      neutrinos::ElectronNeutrinos<1>, neutrinos::ElectronAntiNeutrinos<1>>>;
+  using boundary_condition =
+      RadiationTransport::M1Grey::BoundaryConditions::BoundaryCondition<
+          neutrinos::ElectronNeutrinos<1>, neutrinos::ElectronAntiNeutrinos<1>>;
+  using dirichlet_analytic =
+      RadiationTransport::M1Grey::BoundaryConditions::DirichletAnalytic<
+          neutrinos::ElectronNeutrinos<1>, neutrinos::ElectronAntiNeutrinos<1>>;
+  using rusanov = RadiationTransport::M1Grey::BoundaryCorrections::Rusanov<
+      neutrinos::ElectronNeutrinos<1>, neutrinos::ElectronAntiNeutrinos<1>>;
+
+  using tilde_e_nue_tag =
+      RadiationTransport::M1Grey::Tags::TildeE<Frame::Inertial,
+                                               neutrinos::ElectronNeutrinos<1>>;
+  using tilde_e_bar_nue_tag = RadiationTransport::M1Grey::Tags::TildeE<
+      Frame::Inertial, neutrinos::ElectronAntiNeutrinos<1>>;
+  using tilde_s_nue_tag =
+      RadiationTransport::M1Grey::Tags::TildeS<Frame::Inertial,
+                                               neutrinos::ElectronNeutrinos<1>>;
+  using tilde_s_bar_nue_tag = RadiationTransport::M1Grey::Tags::TildeS<
+      Frame::Inertial, neutrinos::ElectronAntiNeutrinos<1>>;
+
+  helpers::test_boundary_condition_with_python<
+      dirichlet_analytic, boundary_condition, system, tmpl::list<rusanov>,
+      tmpl::list<ConvertConstantM1>>(
+      make_not_null(&gen),
+      "Evolution.Systems.RadiationTransport.M1Grey.BoundaryConditions."
+      "DirichletAnalytic",
+      tuples::TaggedTuple<
+          helpers::Tags::PythonFunctionForErrorMessage<>,
+          helpers::Tags::PythonFunctionName<tilde_e_nue_tag>,
+          helpers::Tags::PythonFunctionName<tilde_e_bar_nue_tag>,
+          helpers::Tags::PythonFunctionName<tilde_s_nue_tag>,
+          helpers::Tags::PythonFunctionName<tilde_s_bar_nue_tag>,
+
+          helpers::Tags::PythonFunctionName<
+              ::Tags::Flux<tilde_e_nue_tag, tmpl::size_t<3>, Frame::Inertial>>,
+          helpers::Tags::PythonFunctionName<::Tags::Flux<
+              tilde_e_bar_nue_tag, tmpl::size_t<3>, Frame::Inertial>>,
+          helpers::Tags::PythonFunctionName<
+              ::Tags::Flux<tilde_s_nue_tag, tmpl::size_t<3>, Frame::Inertial>>,
+          helpers::Tags::PythonFunctionName<::Tags::Flux<
+              tilde_s_bar_nue_tag, tmpl::size_t<3>, Frame::Inertial>>>{
+          "soln_error", "soln_tilde_e_nue", "soln_tilde_e_bar_nue",
+          "soln_tilde_s_nue", "soln_tilde_s_bar_nue", "soln_flux_tilde_e_nue",
+          "soln_flux_tilde_e_bar_nue", "soln_flux_tilde_s_nue",
+          "soln_flux_tilde_s_bar_nue"},
+      "DirichletAnalytic:\n", Index<2>{5}, box_analytic_soln,
+      tuples::TaggedTuple<>{});
+
+  // Note: Currently there is no analytic data for the
+  // RadiationTransport::M1Grey system. When that is implemented, a test should
+  // be added.
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.RadiationTransport.M1Grey.BoundaryConditions.DirichletAnalytic",
+    "[Unit][Evolution]") {
+  using dirichlet_analytic =
+      RadiationTransport::M1Grey::BoundaryConditions::DirichletAnalytic<
+          neutrinos::ElectronNeutrinos<1>, neutrinos::ElectronAntiNeutrinos<1>>;
+  PUPable_reg(dirichlet_analytic);
+  Parallel::register_derived_classes_with_charm<dirichlet_analytic>();
+
+  pypp::SetupLocalPythonEnvironment local_python_env{""};
+  test();
+}

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/Test_Periodic.cpp
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/Test_Periodic.cpp
@@ -1,0 +1,25 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "Domain/BoundaryConditions/Periodic.hpp"
+#include "Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/RadiationTransport/Tags.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp"
+
+namespace helpers = TestHelpers::evolution::dg;
+
+SPECTRE_TEST_CASE("Unit.RadiationTransport.M1Grey.BoundaryConditions.Periodic",
+                  "[Unit][Evolution]") {
+  using boundary_condition =
+      RadiationTransport::M1Grey::BoundaryConditions::BoundaryCondition<
+          neutrinos::ElectronNeutrinos<1>, neutrinos::ElectronAntiNeutrinos<1>>;
+  helpers::test_periodic_condition<
+      domain::BoundaryConditions::Periodic<boundary_condition>,
+      boundary_condition>("Periodic:\n");
+}

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/__init__.py
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/__init__.py
@@ -1,0 +1,2 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/BoundaryCorrections/Test_Rusanov.cpp
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/BoundaryCorrections/Test_Rusanov.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <string>
 
+#include "Evolution/Systems/RadiationTransport/M1Grey/BoundaryCorrections/Factory.hpp"
 #include "Evolution/Systems/RadiationTransport/M1Grey/BoundaryCorrections/Rusanov.hpp"
 #include "Evolution/Systems/RadiationTransport/M1Grey/System.hpp"
 #include "Evolution/Systems/RadiationTransport/Tags.hpp"

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_M1Grey")
 
 set(LIBRARY_SOURCES
+  BoundaryConditions/Test_DirichletAnalytic.cpp
   BoundaryCorrections/Test_Rusanov.cpp
   Test_Actions.cpp
   Test_Fluxes.cpp

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_M1Grey")
 
 set(LIBRARY_SOURCES
   BoundaryConditions/Test_DirichletAnalytic.cpp
+  BoundaryConditions/Test_Periodic.cpp
   BoundaryCorrections/Test_Rusanov.cpp
   Test_Actions.cpp
   Test_Fluxes.cpp

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/__init__.py
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/__init__.py
@@ -1,0 +1,2 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.

--- a/tests/Unit/Evolution/Systems/RadiationTransport/__init__.py
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/__init__.py
@@ -1,0 +1,2 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/__init__.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/__init__.py
@@ -1,0 +1,2 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RadiationTransport/__init__.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RadiationTransport/__init__.py
@@ -1,0 +1,2 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.


### PR DESCRIPTION
## Proposed changes

Adds `DirichletAnalytic` and `Periodic` boundary conditions for `RadiationTransport::M1Grey`

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
