### PR TITLE
Add tags and initialization action for AMR flags

### DIFF
--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -18,6 +18,11 @@
  */
 
 /*!
+ * \defgroup AmrGroup Adaptive Mesh Refinement
+ * \brief Functions and classes specific to hp-adaptive mesh refinement.
+ */
+
+/*!
  * \defgroup AnalyticDataGroup Analytic Data
  * \brief Analytic data used to specify (for example) initial data to the
  * equations implemented in \ref EvolutionSystemsGroup.

--- a/src/Domain/Amr/Amr.hpp
+++ b/src/Domain/Amr/Amr.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+/// \ingroup AmrGroup
+/// \brief Items for adaptive mesh refinement
+namespace amr {
+/// \brief Domain-dependent items for adaptive mesh refinement
+namespace domain {}  // namespace domain
+}  // namespace amr

--- a/src/Domain/Amr/CMakeLists.txt
+++ b/src/Domain/Amr/CMakeLists.txt
@@ -31,3 +31,5 @@ target_link_libraries(
   ErrorHandling
   Utilities
   )
+
+add_subdirectory(Tags)

--- a/src/Domain/Amr/CMakeLists.txt
+++ b/src/Domain/Amr/CMakeLists.txt
@@ -17,6 +17,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Amr.hpp
   Flag.hpp
   Helpers.hpp
   UpdateAmrDecision.hpp

--- a/src/Domain/Amr/Flag.cpp
+++ b/src/Domain/Amr/Flag.cpp
@@ -6,7 +6,7 @@
 
 #include <ostream>
 
-namespace amr {
+namespace amr::domain {
 
 std::ostream& operator<<(std::ostream& os, const Flag& flag) {
   switch (flag) {
@@ -33,4 +33,4 @@ std::ostream& operator<<(std::ostream& os, const Flag& flag) {
   }
   return os;
 }
-}  // namespace amr
+}  // namespace amr::domain

--- a/src/Domain/Amr/Flag.hpp
+++ b/src/Domain/Amr/Flag.hpp
@@ -8,11 +8,9 @@
 
 #include <iosfwd>
 
-/// \ingroup ComputationalDomainGroup
-/// Items for adaptive mesh refinement
-namespace amr {
+namespace amr::domain {
 
-/// \ingroup ComputationalDomainGroup
+/// \ingroup AmrGroup
 /// \brief Flags that represent decisions about mesh refinement
 ///
 /// In order to support anisotropic mesh refinement, a flag is specified for
@@ -28,4 +26,4 @@ enum class Flag {
 
 /// Output operator for a Flag.
 std::ostream& operator<<(std::ostream& os, const Flag& flag);
-}  // namespace amr
+}  // namespace amr::domain

--- a/src/Domain/Amr/Helpers.cpp
+++ b/src/Domain/Amr/Helpers.cpp
@@ -11,20 +11,19 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-namespace amr {
+namespace amr::domain {
 template <size_t VolumeDim>
 std::array<size_t, VolumeDim> desired_refinement_levels(
-    const ElementId<VolumeDim>& id,
-    const std::array<amr::Flag, VolumeDim>& flags) {
+    const ElementId<VolumeDim>& id, const std::array<Flag, VolumeDim>& flags) {
   std::array<size_t, VolumeDim> result{};
 
   for (size_t d = 0; d < VolumeDim; ++d) {
-    ASSERT(amr::Flag::Undefined != gsl::at(flags, d),
-           "Undefined amr::Flag in dimension " << d);
+    ASSERT(Flag::Undefined != gsl::at(flags, d),
+           "Undefined Flag in dimension " << d);
     gsl::at(result, d) = id.segment_id(d).refinement_level();
-    if (amr::Flag::Join == gsl::at(flags, d)) {
+    if (Flag::Join == gsl::at(flags, d)) {
       --gsl::at(result, d);
-    } else if (amr::Flag::Split == gsl::at(flags, d)) {
+    } else if (Flag::Split == gsl::at(flags, d)) {
       ++gsl::at(result, d);
     }
   }
@@ -34,20 +33,20 @@ std::array<size_t, VolumeDim> desired_refinement_levels(
 template <size_t VolumeDim>
 std::array<size_t, VolumeDim> desired_refinement_levels_of_neighbor(
     const ElementId<VolumeDim>& neighbor_id,
-    const std::array<amr::Flag, VolumeDim>& neighbor_flags,
+    const std::array<Flag, VolumeDim>& neighbor_flags,
     const OrientationMap<VolumeDim>& orientation) {
   if (orientation.is_aligned()) {
     return desired_refinement_levels(neighbor_id, neighbor_flags);
   }
   std::array<size_t, VolumeDim> result{};
   for (size_t d = 0; d < VolumeDim; ++d) {
-    ASSERT(amr::Flag::Undefined != gsl::at(neighbor_flags, d),
-           "Undefined amr::Flag in dimension " << d);
+    ASSERT(Flag::Undefined != gsl::at(neighbor_flags, d),
+           "Undefined Flag in dimension " << d);
     const size_t mapped_dim = orientation(d);
     gsl::at(result, d) = neighbor_id.segment_id(mapped_dim).refinement_level();
-    if (amr::Flag::Join == gsl::at(neighbor_flags, mapped_dim)) {
+    if (Flag::Join == gsl::at(neighbor_flags, mapped_dim)) {
       --gsl::at(result, d);
-    } else if (amr::Flag::Split == gsl::at(neighbor_flags, mapped_dim)) {
+    } else if (Flag::Split == gsl::at(neighbor_flags, mapped_dim)) {
       ++gsl::at(result, d);
     }
   }
@@ -65,10 +64,12 @@ bool has_potential_sibling(const ElementId<VolumeDim>& element_id,
 
 #define INSTANTIATE(_, data)                                                   \
   template std::array<size_t, DIM(data)> desired_refinement_levels<DIM(data)>( \
-      const ElementId<DIM(data)>&, const std::array<amr::Flag, DIM(data)>&);   \
+      const ElementId<DIM(data)>&,                                             \
+      const std::array<Flag, DIM(data)>&);                                     \
   template std::array<size_t, DIM(data)>                                       \
   desired_refinement_levels_of_neighbor<DIM(data)>(                            \
-      const ElementId<DIM(data)>&, const std::array<amr::Flag, DIM(data)>&,    \
+      const ElementId<DIM(data)>&,                                             \
+      const std::array<Flag, DIM(data)>&,                                      \
       const OrientationMap<DIM(data)>&);                                       \
   template bool has_potential_sibling(const ElementId<DIM(data)>& element_id,  \
                                       const Direction<DIM(data)>& direction);
@@ -77,4 +78,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #undef DIM
 #undef INSTANTIATE
-}  // namespace amr
+}  // namespace amr::domain

--- a/src/Domain/Amr/Helpers.hpp
+++ b/src/Domain/Amr/Helpers.hpp
@@ -22,16 +22,15 @@ template <size_t VolumeDim>
 class OrientationMap;
 /// \endcond
 
-namespace amr {
-/// \ingroup ComputationalDomainGroup
+namespace amr::domain {
+/// \ingroup AmrGroup
 /// \brief Computes the desired refinement level of the Element with ElementId
 /// `id` given the desired amr::Flag%s `flags`
 template <size_t VolumeDim>
 std::array<size_t, VolumeDim> desired_refinement_levels(
-    const ElementId<VolumeDim>& id,
-    const std::array<amr::Flag, VolumeDim>& flags);
+    const ElementId<VolumeDim>& id, const std::array<Flag, VolumeDim>& flags);
 
-/// \ingroup ComputationalDomainGroup
+/// \ingroup AmrGroup
 /// \brief Computes the desired refinement level of a neighboring Element with
 /// ElementId `neighbor_id` given its desired amr::Flag%s `neighbor_flags`
 /// taking into account the OrientationMap `orientation` of the neighbor
@@ -41,13 +40,13 @@ std::array<size_t, VolumeDim> desired_refinement_levels(
 template <size_t VolumeDim>
 std::array<size_t, VolumeDim> desired_refinement_levels_of_neighbor(
     const ElementId<VolumeDim>& neighbor_id,
-    const std::array<amr::Flag, VolumeDim>& neighbor_flags,
+    const std::array<Flag, VolumeDim>& neighbor_flags,
     const OrientationMap<VolumeDim>& orientation);
 
-/// \ingroup ComputationalDomainGroup
+/// \ingroup AmrGroup
 /// \brief Whether or not the Element with `element_id` can have a sibling
 /// in the given `direction`
 template <size_t VolumeDim>
 bool has_potential_sibling(const ElementId<VolumeDim>& element_id,
                            const Direction<VolumeDim>& direction);
-}  // namespace amr
+}  // namespace amr::domain

--- a/src/Domain/Amr/Tags/CMakeLists.txt
+++ b/src/Domain/Amr/Tags/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY Amr)
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Flags.hpp
+  NeighborFlags.hpp
+  Tags.hpp
+  )

--- a/src/Domain/Amr/Tags/Flags.hpp
+++ b/src/Domain/Amr/Tags/Flags.hpp
@@ -1,0 +1,19 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Domain/Amr/Flag.hpp"
+
+namespace amr::domain::Tags {
+/// amr::domain::Flag%s for an Element.
+template <size_t VolumeDim>
+struct Flags : db::SimpleTag {
+  using type = std::array<amr::domain::Flag, VolumeDim>;
+};
+
+}  // namespace amr::domain::Tags

--- a/src/Domain/Amr/Tags/NeighborFlags.hpp
+++ b/src/Domain/Amr/Tags/NeighborFlags.hpp
@@ -1,0 +1,26 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <unordered_map>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Domain/Amr/Flag.hpp"
+
+/// \cond
+template <size_t VolumeDim>
+class ElementId;
+/// \endcond
+
+namespace amr::domain::Tags {
+/// amr::domain::Flag%s for the neighbors of an Element.
+template <size_t VolumeDim>
+struct NeighborFlags : db::SimpleTag {
+  using type = std::unordered_map<ElementId<VolumeDim>,
+                                  std::array<amr::domain::Flag, VolumeDim>>;
+};
+
+}  // namespace amr::domain::Tags

--- a/src/Domain/Amr/Tags/Tags.hpp
+++ b/src/Domain/Amr/Tags/Tags.hpp
@@ -1,0 +1,10 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+/// \ingroup AmrGroup
+namespace amr::domain {
+/// \brief %Tags for adaptive mesh refinement
+namespace Tags {}
+}  // namespace amr::domain

--- a/src/Domain/Amr/UpdateAmrDecision.hpp
+++ b/src/Domain/Amr/UpdateAmrDecision.hpp
@@ -21,8 +21,8 @@ template <size_t VolumeDim>
 class ElementId;
 /// \endcond
 
-namespace amr {
-/// \ingroup ComputationalDomainGroup
+namespace amr::domain {
+/// \ingroup AmrGroup
 /// \brief Updates the AMR decisions `my_current_amr_flags` of the Element
 /// `element` based on the AMR decisions `neighbor_amr_flags` of a neighbor
 /// Element with ElementId `neighbor_id`.
@@ -43,7 +43,7 @@ namespace amr {
 /// `element`.
 template <size_t VolumeDim>
 bool update_amr_decision(
-    gsl::not_null<std::array<amr::Flag, VolumeDim>*> my_current_amr_flags,
+    gsl::not_null<std::array<Flag, VolumeDim>*> my_current_amr_flags,
     const Element<VolumeDim>& element, const ElementId<VolumeDim>& neighbor_id,
-    const std::array<amr::Flag, VolumeDim>& neighbor_amr_flags);
-}  // namespace amr
+    const std::array<Flag, VolumeDim>& neighbor_amr_flags);
+}  // namespace amr::domain

--- a/src/ParallelAlgorithms/Amr/Actions/Actions.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/Actions.hpp
@@ -1,0 +1,10 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+/// \ingroup AmrGroup
+namespace amr {
+/// \brief %Actions for adaptive mesh refinement
+namespace Actions {}
+}  // namespace amr

--- a/src/ParallelAlgorithms/Amr/Actions/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Actions/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Actions.hpp
+  Initialization.hpp
+  Initialize.hpp
+  )

--- a/src/ParallelAlgorithms/Amr/Actions/Initialization.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/Initialization.hpp
@@ -1,0 +1,9 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace amr {
+/// \brief %Mutators used for initialization of adaptive mesh refinement
+namespace Initialization {}
+}  // namespace amr

--- a/src/ParallelAlgorithms/Amr/Actions/Initialize.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/Initialize.hpp
@@ -1,0 +1,51 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <unordered_map>
+
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Amr/Tags/Flags.hpp"
+#include "Domain/Amr/Tags/NeighborFlags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+template <size_t VolumeDim>
+class ElementId;
+/// \endcond
+
+namespace amr::Initialization {
+/*!
+ * \brief %Mutator meant to be used with
+ *  `Initialization::Actions::AddSimpleTags`to initialize flags used for
+ * adaptive mesh refinement
+ *
+ * DataBox:
+ * - Adds:
+ *   - `amr::domain::Tags::Flags<Dim>`
+ *   - `amr::domain::Tags::NeighborFlags<Dim>`
+ * - Removes: nothing
+ * - Modifies: nothing
+ *
+ */
+template <size_t Dim>
+struct Initialize {
+  using return_tags =
+    tmpl::list<amr::domain::Tags::Flags<Dim>,
+               amr::domain::Tags::NeighborFlags<Dim>>;
+  using argument_tags = tmpl::list<>;
+
+  static void apply(
+      const gsl::not_null<std::array<amr::domain::Flag, Dim>*> amr_flags,
+      const gsl::not_null<std::unordered_map<ElementId<Dim>,
+          std::array<amr::domain::Flag, Dim>>*> /*neighbor_flags*/) {
+    *amr_flags = make_array<Dim>(amr::domain::Flag::Undefined);
+    // default initialization of NeighborFlags is okay
+  }
+};
+}  // namespace amr::Initialization

--- a/src/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY ParallelAmr)
+
+add_spectre_library(${LIBRARY} INTERFACE)
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE
+  Amr
+  DataStructures
+  Initialization
+  Utilities
+  )
+
+add_subdirectory(Actions)

--- a/src/ParallelAlgorithms/CMakeLists.txt
+++ b/src/ParallelAlgorithms/CMakeLists.txt
@@ -2,6 +2,7 @@
 # See LICENSE.txt for details.
 
 add_subdirectory(Actions)
+add_subdirectory(Amr)
 add_subdirectory(Events)
 add_subdirectory(EventsAndTriggers)
 add_subdirectory(Initialization)

--- a/tests/Unit/Domain/Amr/CMakeLists.txt
+++ b/tests/Unit/Domain/Amr/CMakeLists.txt
@@ -14,5 +14,5 @@ add_test_library(
   ${LIBRARY}
   "Domain/Amr"
   "${LIBRARY_SOURCES}"
-  "Amr;Utilities"
+  "Amr;DomainStructure;Utilities"
   )

--- a/tests/Unit/Domain/Amr/CMakeLists.txt
+++ b/tests/Unit/Domain/Amr/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_Amr")
 set(LIBRARY_SOURCES
   Test_Flag.cpp
   Test_Helpers.cpp
+  Test_Tags.cpp
   Test_UpdateAmrDecision.cpp
   )
 

--- a/tests/Unit/Domain/Amr/Test_Flag.cpp
+++ b/tests/Unit/Domain/Amr/Test_Flag.cpp
@@ -9,10 +9,12 @@
 #include "Utilities/GetOutput.hpp"
 
 SPECTRE_TEST_CASE("Unit.Domain.Amr.Flag", "[Domain][Unit]") {
-  CHECK(get_output(amr::Flag::Undefined) == "Undefined");
-  CHECK(get_output(amr::Flag::Join) == "Join");
-  CHECK(get_output(amr::Flag::DecreaseResolution) == "DecreaseResolution");
-  CHECK(get_output(amr::Flag::DoNothing) == "DoNothing");
-  CHECK(get_output(amr::Flag::IncreaseResolution) == "IncreaseResolution");
-  CHECK(get_output(amr::Flag::Split) == "Split");
+  CHECK(get_output(amr::domain::Flag::Undefined) == "Undefined");
+  CHECK(get_output(amr::domain::Flag::Join) == "Join");
+  CHECK(get_output(amr::domain::Flag::DecreaseResolution) ==
+        "DecreaseResolution");
+  CHECK(get_output(amr::domain::Flag::DoNothing) == "DoNothing");
+  CHECK(get_output(amr::domain::Flag::IncreaseResolution) ==
+        "IncreaseResolution");
+  CHECK(get_output(amr::domain::Flag::Split) == "Split");
 }

--- a/tests/Unit/Domain/Amr/Test_Helpers.cpp
+++ b/tests/Unit/Domain/Amr/Test_Helpers.cpp
@@ -19,43 +19,50 @@
 namespace {
 void test_desired_refinement_levels() {
   ElementId<1> element_id_1d{0, {{SegmentId(2, 3)}}};
-  CHECK(amr::desired_refinement_levels(element_id_1d, {{amr::Flag::Split}}) ==
+  CHECK(amr::domain::desired_refinement_levels(element_id_1d,
+                                               {{amr::domain::Flag::Split}}) ==
         std::array<size_t, 1>{{3}});
-  CHECK(
-      amr::desired_refinement_levels(element_id_1d, {{amr::Flag::DoNothing}}) ==
-      std::array<size_t, 1>{{2}});
-  CHECK(amr::desired_refinement_levels(element_id_1d, {{amr::Flag::Join}}) ==
+  CHECK(amr::domain::desired_refinement_levels(
+            element_id_1d, {{amr::domain::Flag::DoNothing}}) ==
+        std::array<size_t, 1>{{2}});
+  CHECK(amr::domain::desired_refinement_levels(element_id_1d,
+                                               {{amr::domain::Flag::Join}}) ==
         std::array<size_t, 1>{{1}});
 
   ElementId<2> element_id_2d{1, {{SegmentId(3, 5), SegmentId(1, 1)}}};
-  CHECK(amr::desired_refinement_levels(element_id_2d,
-                                       {{amr::Flag::Split, amr::Flag::Join}}) ==
+  CHECK(amr::domain::desired_refinement_levels(
+            element_id_2d,
+            {{amr::domain::Flag::Split, amr::domain::Flag::Join}}) ==
         std::array<size_t, 2>{{4, 0}});
-  CHECK(amr::desired_refinement_levels(
-            element_id_2d, {{amr::Flag::Join, amr::Flag::DoNothing}}) ==
+  CHECK(amr::domain::desired_refinement_levels(
+            element_id_2d,
+            {{amr::domain::Flag::Join, amr::domain::Flag::DoNothing}}) ==
         std::array<size_t, 2>{{2, 1}});
-  CHECK(amr::desired_refinement_levels(element_id_2d,
-                                       {{amr::Flag::Join, amr::Flag::Join}}) ==
+  CHECK(amr::domain::desired_refinement_levels(
+            element_id_2d,
+            {{amr::domain::Flag::Join, amr::domain::Flag::Join}}) ==
         std::array<size_t, 2>{{2, 0}});
-  CHECK(amr::desired_refinement_levels(
-            element_id_2d, {{amr::Flag::DoNothing, amr::Flag::Split}}) ==
+  CHECK(amr::domain::desired_refinement_levels(
+            element_id_2d,
+            {{amr::domain::Flag::DoNothing, amr::domain::Flag::Split}}) ==
         std::array<size_t, 2>{{3, 2}});
-  CHECK(amr::desired_refinement_levels(
-            element_id_2d, {{amr::Flag::DoNothing, amr::Flag::DoNothing}}) ==
+  CHECK(amr::domain::desired_refinement_levels(
+            element_id_2d,
+            {{amr::domain::Flag::DoNothing, amr::domain::Flag::DoNothing}}) ==
         std::array<size_t, 2>{{3, 1}});
 
   ElementId<3> element_id_3d{
       7, {{SegmentId(5, 15), SegmentId(2, 0), SegmentId(4, 6)}}};
-  CHECK(amr::desired_refinement_levels(
-            element_id_3d,
-            {{amr::Flag::Split, amr::Flag::Join, amr::Flag::DoNothing}}) ==
+  CHECK(amr::domain::desired_refinement_levels(
+            element_id_3d, {{amr::domain::Flag::Split, amr::domain::Flag::Join,
+                             amr::domain::Flag::DoNothing}}) ==
         std::array<size_t, 3>{{6, 1, 4}});
 }
 
 template <size_t VolumeDim>
 void check_desired_refinement_levels_of_neighbor(
     const ElementId<VolumeDim>& neighbor_id,
-    const std::array<amr::Flag, VolumeDim>& neighbor_flags) {
+    const std::array<amr::domain::Flag, VolumeDim>& neighbor_flags) {
   for (OrientationMapIterator<VolumeDim> orientation{}; orientation;
        ++orientation) {
     const auto desired_levels_my_frame = desired_refinement_levels_of_neighbor(
@@ -72,59 +79,68 @@ void check_desired_refinement_levels_of_neighbor(
 void test_desired_refinement_levels_of_neighbor() {
   ElementId<1> neighbor_id_1d{0, {{SegmentId(2, 3)}}};
   check_desired_refinement_levels_of_neighbor(neighbor_id_1d,
-                                              {{amr::Flag::Split}});
+                                              {{amr::domain::Flag::Split}});
   check_desired_refinement_levels_of_neighbor(neighbor_id_1d,
-                                              {{amr::Flag::DoNothing}});
+                                              {{amr::domain::Flag::DoNothing}});
   check_desired_refinement_levels_of_neighbor(neighbor_id_1d,
-                                              {{amr::Flag::Join}});
+                                              {{amr::domain::Flag::Join}});
 
   ElementId<2> neighbor_id_2d{1, {{SegmentId(3, 0), SegmentId(1, 1)}}};
   check_desired_refinement_levels_of_neighbor(
-      neighbor_id_2d, {{amr::Flag::Split, amr::Flag::Join}});
+      neighbor_id_2d, {{amr::domain::Flag::Split, amr::domain::Flag::Join}});
   check_desired_refinement_levels_of_neighbor(
-      neighbor_id_2d, {{amr::Flag::Join, amr::Flag::DoNothing}});
+      neighbor_id_2d,
+      {{amr::domain::Flag::Join, amr::domain::Flag::DoNothing}});
   check_desired_refinement_levels_of_neighbor(
-      neighbor_id_2d, {{amr::Flag::Join, amr::Flag::Join}});
+      neighbor_id_2d, {{amr::domain::Flag::Join, amr::domain::Flag::Join}});
   check_desired_refinement_levels_of_neighbor(
-      neighbor_id_2d, {{amr::Flag::DoNothing, amr::Flag::Split}});
+      neighbor_id_2d,
+      {{amr::domain::Flag::DoNothing, amr::domain::Flag::Split}});
   check_desired_refinement_levels_of_neighbor(
-      neighbor_id_2d, {{amr::Flag::DoNothing, amr::Flag::DoNothing}});
+      neighbor_id_2d,
+      {{amr::domain::Flag::DoNothing, amr::domain::Flag::DoNothing}});
 
   ElementId<3> neighbor_id_3d{
       7, {{SegmentId(5, 31), SegmentId(2, 0), SegmentId(4, 15)}}};
   check_desired_refinement_levels_of_neighbor(
-      neighbor_id_3d,
-      {{amr::Flag::Split, amr::Flag::Join, amr::Flag::DoNothing}});
+      neighbor_id_3d, {{amr::domain::Flag::Split, amr::domain::Flag::Join,
+                        amr::domain::Flag::DoNothing}});
   check_desired_refinement_levels_of_neighbor(
-      neighbor_id_3d,
-      {{amr::Flag::Join, amr::Flag::DoNothing, amr::Flag::Split}});
+      neighbor_id_3d, {{amr::domain::Flag::Join, amr::domain::Flag::DoNothing,
+                        amr::domain::Flag::Split}});
 }
 
 void test_has_potential_sibling() {
   ElementId<1> element_id_1d{0, {{SegmentId(2, 3)}}};
-  CHECK(amr::has_potential_sibling(element_id_1d, Direction<1>::lower_xi()));
-  CHECK_FALSE(
-      amr::has_potential_sibling(element_id_1d, Direction<1>::upper_xi()));
+  CHECK(amr::domain::has_potential_sibling(element_id_1d,
+                                           Direction<1>::lower_xi()));
+  CHECK_FALSE(amr::domain::has_potential_sibling(element_id_1d,
+                                                 Direction<1>::upper_xi()));
 
   ElementId<2> element_id_2d{0, {{SegmentId(3, 0), SegmentId{1, 1}}}};
-  CHECK(amr::has_potential_sibling(element_id_2d, Direction<2>::upper_xi()));
-  CHECK(amr::has_potential_sibling(element_id_2d, Direction<2>::lower_eta()));
-  CHECK_FALSE(
-      amr::has_potential_sibling(element_id_2d, Direction<2>::lower_xi()));
-  CHECK_FALSE(
-      amr::has_potential_sibling(element_id_2d, Direction<2>::upper_eta()));
+  CHECK(amr::domain::has_potential_sibling(element_id_2d,
+                                           Direction<2>::upper_xi()));
+  CHECK(amr::domain::has_potential_sibling(element_id_2d,
+                                           Direction<2>::lower_eta()));
+  CHECK_FALSE(amr::domain::has_potential_sibling(element_id_2d,
+                                                 Direction<2>::lower_xi()));
+  CHECK_FALSE(amr::domain::has_potential_sibling(element_id_2d,
+                                                 Direction<2>::upper_eta()));
 
   ElementId<3> element_id_3d{
       7, {{SegmentId(5, 31), SegmentId(2, 0), SegmentId(4, 15)}}};
-  CHECK(amr::has_potential_sibling(element_id_3d, Direction<3>::lower_xi()));
-  CHECK(amr::has_potential_sibling(element_id_3d, Direction<3>::upper_eta()));
-  CHECK(amr::has_potential_sibling(element_id_3d, Direction<3>::lower_zeta()));
-  CHECK_FALSE(
-      amr::has_potential_sibling(element_id_3d, Direction<3>::upper_xi()));
-  CHECK_FALSE(
-      amr::has_potential_sibling(element_id_3d, Direction<3>::lower_eta()));
-  CHECK_FALSE(
-      amr::has_potential_sibling(element_id_3d, Direction<3>::upper_zeta()));
+  CHECK(amr::domain::has_potential_sibling(element_id_3d,
+                                           Direction<3>::lower_xi()));
+  CHECK(amr::domain::has_potential_sibling(element_id_3d,
+                                           Direction<3>::upper_eta()));
+  CHECK(amr::domain::has_potential_sibling(element_id_3d,
+                                           Direction<3>::lower_zeta()));
+  CHECK_FALSE(amr::domain::has_potential_sibling(element_id_3d,
+                                                 Direction<3>::upper_xi()));
+  CHECK_FALSE(amr::domain::has_potential_sibling(element_id_3d,
+                                                 Direction<3>::lower_eta()));
+  CHECK_FALSE(amr::domain::has_potential_sibling(element_id_3d,
+                                                 Direction<3>::upper_zeta()));
 }
 }  // namespace
 
@@ -134,25 +150,25 @@ SPECTRE_TEST_CASE("Unit.Domain.Amr.Helpers", "[Domain][Unit]") {
   test_has_potential_sibling();
 }
 
-// [[OutputRegex, Undefined amr::Flag in dimension]]
+// [[OutputRegex, Undefined Flag in dimension]]
 [[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Amr.Helpers.BadFlag",
                                "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  auto bad_flag =
-      amr::desired_refinement_levels(ElementId<1>{0}, {{amr::Flag::Undefined}});
+  auto bad_flag = amr::domain::desired_refinement_levels(
+      ElementId<1>{0}, {{amr::domain::Flag::Undefined}});
   static_cast<void>(bad_flag);
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
-// [[OutputRegex, Undefined amr::Flag in dimension]]
+// [[OutputRegex, Undefined Flag in dimension]]
 [[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Amr.Helpers.BadFlag2",
                                "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  auto bad_flag = amr::desired_refinement_levels_of_neighbor(
-      ElementId<1>{0}, {{amr::Flag::Undefined}},
+  auto bad_flag = amr::domain::desired_refinement_levels_of_neighbor(
+      ElementId<1>{0}, {{amr::domain::Flag::Undefined}},
       OrientationMap<1>{{{Direction<1>::lower_xi()}}});
   static_cast<void>(bad_flag);
   ERROR("Failed to trigger ASSERT in an assertion test");

--- a/tests/Unit/Domain/Amr/Test_Tags.cpp
+++ b/tests/Unit/Domain/Amr/Test_Tags.cpp
@@ -1,0 +1,23 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Domain/Amr/Tags/Flags.hpp"
+#include "Domain/Amr/Tags/NeighborFlags.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+
+namespace {
+template <size_t Dim>
+void test() {
+  TestHelpers::db::test_simple_tag<amr::domain::Tags::Flags<Dim>>("Flags");
+  TestHelpers::db::test_simple_tag<amr::domain::Tags::NeighborFlags<Dim>>(
+      "NeighborFlags");
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Amr.Tags", "[Domain][Unit]") {
+  test<1>();
+  test<2>();
+  test<3>();
+}

--- a/tests/Unit/Domain/Amr/Test_UpdateAmrDecision.cpp
+++ b/tests/Unit/Domain/Amr/Test_UpdateAmrDecision.cpp
@@ -28,41 +28,45 @@ namespace {
 
 template <size_t VolumeDim>
 void check_amr_decision_is_unchanged(
-    std::array<amr::Flag, VolumeDim> my_initial_amr_flags,
+    std::array<amr::domain::Flag, VolumeDim> my_initial_amr_flags,
     const Element<VolumeDim>& element, const ElementId<VolumeDim>& neighbor_id,
-    const std::array<amr::Flag, VolumeDim>& neighbor_amr_flags) {
+    const std::array<amr::domain::Flag, VolumeDim>&
+        neighbor_amr_flags) {
   const auto expected_updated_flags = my_initial_amr_flags;
   std::stringstream os;
   os << neighbor_amr_flags;
   INFO(os.str());
-  CHECK_FALSE(amr::update_amr_decision(make_not_null(&my_initial_amr_flags),
-                                       element, neighbor_id,
-                                       neighbor_amr_flags));
+  CHECK_FALSE(amr::domain::update_amr_decision(
+      make_not_null(&my_initial_amr_flags), element, neighbor_id,
+      neighbor_amr_flags));
   CHECK(expected_updated_flags == my_initial_amr_flags);
 }
 
 template <size_t VolumeDim>
 void check_amr_decision_is_changed(
-    std::array<amr::Flag, VolumeDim> my_initial_amr_flags,
+    std::array<amr::domain::Flag, VolumeDim> my_initial_amr_flags,
     const Element<VolumeDim>& element, const ElementId<VolumeDim>& neighbor_id,
-    const std::array<amr::Flag, VolumeDim>& neighbor_amr_flags,
-    const std::array<amr::Flag, VolumeDim>& expected_updated_flags) {
+    const std::array<amr::domain::Flag, VolumeDim>& neighbor_amr_flags,
+    const std::array<amr::domain::Flag, VolumeDim>&
+        expected_updated_flags) {
   std::stringstream os;
   os << my_initial_amr_flags << " " << neighbor_amr_flags;
   INFO(os.str());
-  CHECK(amr::update_amr_decision(make_not_null(&my_initial_amr_flags), element,
-                                 neighbor_id, neighbor_amr_flags));
+  CHECK(amr::domain::update_amr_decision(make_not_null(&my_initial_amr_flags),
+                                         element, neighbor_id,
+                                         neighbor_amr_flags));
   CHECK(expected_updated_flags == my_initial_amr_flags);
 }
 
 template <size_t VolumeDim>
-using changed_flags_t = std::map<std::pair<std::array<amr::Flag, VolumeDim>,
-                                           std::array<amr::Flag, VolumeDim>>,
-                                 std::array<amr::Flag, VolumeDim>>;
+using changed_flags_t =
+    std::map<std::pair<std::array<amr::domain::Flag, VolumeDim>,
+                       std::array<amr::domain::Flag, VolumeDim>>,
+             std::array<amr::domain::Flag, VolumeDim>>;
 template <size_t VolumeDim>
 void check_update_amr_decision(
     const Element<VolumeDim>& element, const ElementId<VolumeDim>& neighbor_id,
-    const std::vector<std::array<amr::Flag, VolumeDim>>& all_flags,
+    const std::vector<std::array<amr::domain::Flag, VolumeDim>>& all_flags,
     const changed_flags_t<VolumeDim>& changed_flags) {
   for (const auto& my_flags : all_flags) {
     for (const auto& neighbor_flags : all_flags) {
@@ -122,10 +126,11 @@ Element<2> make_element(
 }
 
 void test_update_amr_decision_1d() {
-  const std::array<amr::Flag, 1> split{{amr::Flag::Split}};
-  const std::array<amr::Flag, 1> join{{amr::Flag::Join}};
-  const std::array<amr::Flag, 1> stay{{amr::Flag::DoNothing}};
-  const std::vector<std::array<amr::Flag, 1>> all_flags{split, join, stay};
+  const std::array<amr::domain::Flag, 1> split{{amr::domain::Flag::Split}};
+  const std::array<amr::domain::Flag, 1> join{{amr::domain::Flag::Join}};
+  const std::array<amr::domain::Flag, 1> stay{{amr::domain::Flag::DoNothing}};
+  const std::vector<std::array<amr::domain::Flag, 1>> all_flags{split, join,
+                                                                stay};
 
   const SegmentId x_segment{3, 5};
   const SegmentId x_cousin{3, 6};
@@ -164,25 +169,26 @@ void test_update_amr_decision_1d() {
 }
 
 void test_update_amr_decision_2d() {
-  const std::array<amr::Flag, 2> split_split{
-      {amr::Flag::Split, amr::Flag::Split}};
-  const std::array<amr::Flag, 2> join_split{
-      {amr::Flag::Join, amr::Flag::Split}};
-  const std::array<amr::Flag, 2> stay_split{
-      {amr::Flag::DoNothing, amr::Flag::Split}};
-  const std::array<amr::Flag, 2> split_stay{
-      {amr::Flag::Split, amr::Flag::DoNothing}};
-  const std::array<amr::Flag, 2> join_stay{
-      {amr::Flag::Join, amr::Flag::DoNothing}};
-  const std::array<amr::Flag, 2> stay_stay{
-      {amr::Flag::DoNothing, amr::Flag::DoNothing}};
-  const std::array<amr::Flag, 2> split_join{
-      {amr::Flag::Split, amr::Flag::Join}};
-  const std::array<amr::Flag, 2> join_join{{amr::Flag::Join, amr::Flag::Join}};
-  const std::array<amr::Flag, 2> stay_join{
-      {amr::Flag::DoNothing, amr::Flag::Join}};
+  const std::array<amr::domain::Flag, 2> split_split{
+      {amr::domain::Flag::Split, amr::domain::Flag::Split}};
+  const std::array<amr::domain::Flag, 2> join_split{
+      {amr::domain::Flag::Join, amr::domain::Flag::Split}};
+  const std::array<amr::domain::Flag, 2> stay_split{
+      {amr::domain::Flag::DoNothing, amr::domain::Flag::Split}};
+  const std::array<amr::domain::Flag, 2> split_stay{
+      {amr::domain::Flag::Split, amr::domain::Flag::DoNothing}};
+  const std::array<amr::domain::Flag, 2> join_stay{
+      {amr::domain::Flag::Join, amr::domain::Flag::DoNothing}};
+  const std::array<amr::domain::Flag, 2> stay_stay{
+      {amr::domain::Flag::DoNothing, amr::domain::Flag::DoNothing}};
+  const std::array<amr::domain::Flag, 2> split_join{
+      {amr::domain::Flag::Split, amr::domain::Flag::Join}};
+  const std::array<amr::domain::Flag, 2> join_join{
+      {amr::domain::Flag::Join, amr::domain::Flag::Join}};
+  const std::array<amr::domain::Flag, 2> stay_join{
+      {amr::domain::Flag::DoNothing, amr::domain::Flag::Join}};
 
-  const std::vector<std::array<amr::Flag, 2>> all_flags{
+  const std::vector<std::array<amr::domain::Flag, 2>> all_flags{
       split_split, join_split, stay_split, split_stay, join_stay,
       stay_stay,   split_join, join_join,  stay_join};
 

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_Initialize.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_Initialize.cpp
@@ -1,0 +1,39 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <unordered_map>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Amr/Tags/Flags.hpp"
+#include "Domain/Amr/Tags/NeighborFlags.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "ParallelAlgorithms/Amr/Actions/Initialize.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace {
+template <size_t Dim>
+void test() {
+  auto box = db::create<db::AddSimpleTags<amr::domain::Tags::Flags<Dim>,
+                        amr::domain::Tags::NeighborFlags<Dim>>>(
+      std::array<amr::domain::Flag, Dim>{},
+      std::unordered_map<ElementId<Dim>,
+                         std::array<amr::domain::Flag, Dim>>{});
+  db::mutate_apply<amr::Initialization::Initialize<Dim>>(make_not_null(&box));
+  CHECK(db::get<amr::domain::Tags::Flags<Dim>>(box) ==
+        make_array<Dim>(amr::domain::Flag::Undefined));
+  CHECK(db::get<amr::domain::Tags::NeighborFlags<Dim>>(box).empty());
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ParallelAmr.Actions.Initialize",
+                  "[ParallelAlgorithms][Unit]") {
+  test<1>();
+  test<2>();
+  test<3>();
+}

--- a/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_ParallelAmr")
+
+set(LIBRARY_SOURCES
+  Actions/Test_Initialize.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "ParallelAlgorithms/Amr"
+  "${LIBRARY_SOURCES}"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  Amr
+  DomainStructure
+  Utilities
+  )

--- a/tests/Unit/ParallelAlgorithms/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/CMakeLists.txt
@@ -2,6 +2,7 @@
 # See LICENSE.txt for details.
 
 add_subdirectory(Actions)
+add_subdirectory(Amr)
 add_subdirectory(Events)
 add_subdirectory(EventsAndTriggers)
 add_subdirectory(Initialization)


### PR DESCRIPTION
## Proposed changes

- Move `amr` namespace within `domain` namespace
- Add tags for items meant to hold the AMR decisions of an Element and the neighbors of an Element
- Add an initialization action to initialize those items in the Element's DataBox

