### PR TITLE
Add comment explaining charm inline oddities

### DIFF
--- a/src/Parallel/Invoke.hpp
+++ b/src/Parallel/Invoke.hpp
@@ -32,6 +32,16 @@ template <typename ReceiveTag, typename Proxy, typename ReceiveDataType>
 void receive_data(Proxy&& proxy, typename ReceiveTag::temporal_id temporal_id,
                   ReceiveDataType&& receive_data,
                   const bool enable_if_disabled = false) noexcept {
+  // Both branches of this if statement call into the charm proxy system, but
+  // because we specify [inline] for array chares, we must specify the
+  // `ReceiveDataType` explicitly in the template arguments when dispatching to
+  // array chares.
+  // This is required because of inconsistent overloads in the generated charm++
+  // files when [inline] is specified vs when it is not. The [inline] version
+  // generates a function signature with template parameters associated with
+  // each function argument, ensuring a redundant template parameter for the
+  // `ReceiveDataType`. Then, that template parameter cannot be inferred so must
+  // be explicitly specified.
   if constexpr (detail::has_ckLocal_method<std::decay_t<Proxy>>::value) {
     proxy.template receive_data<ReceiveTag, std::decay_t<ReceiveDataType>>(
         std::move(temporal_id), std::forward<ReceiveDataType>(receive_data),


### PR DESCRIPTION
## Proposed changes

Adds a bit of (hopefully helpful) information about the weird charm call needed in `invoke.hpp`

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
