### PR TITLE
Add finite difference reconstruction schemes: minmod and MC

### DIFF
--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -465,6 +465,11 @@
  */
 
 /*!
+ * \defgroup FiniteDifferenceGroup Finite Difference
+ * \brief Functions needed for (conservative) finite difference methods.
+ */
+
+/*!
  * \defgroup GeneralRelativityGroup General Relativity
  * \brief Contains functions used in General Relativistic simulations
  */

--- a/src/NumericalAlgorithms/CMakeLists.txt
+++ b/src/NumericalAlgorithms/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 add_subdirectory(Convergence)
 add_subdirectory(DiscontinuousGalerkin)
+add_subdirectory(FiniteDifference)
 add_subdirectory(Integration)
 add_subdirectory(Interpolation)
 add_subdirectory(LinearAlgebra)

--- a/src/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
+++ b/src/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   Minmod.cpp
+  MonotisedCentral.cpp
   )
 
 spectre_target_headers(
@@ -17,6 +18,7 @@ spectre_target_headers(
   HEADERS
   FiniteDifference.hpp
   Minmod.hpp
+  MonotisedCentral.hpp
   Reconstruct.hpp
   Reconstruct.tpp
   )

--- a/src/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
+++ b/src/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY FiniteDifference)
+
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  Minmod.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  FiniteDifference.hpp
+  Minmod.hpp
+  Reconstruct.hpp
+  Reconstruct.tpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  Utilities
+  PRIVATE
+  DataStructures
+  DomainStructure
+  ErrorHandling
+  )

--- a/src/NumericalAlgorithms/FiniteDifference/FiniteDifference.hpp
+++ b/src/NumericalAlgorithms/FiniteDifference/FiniteDifference.hpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+/// \ingroup FiniteDifferenceGroup
+/// \brief Functions and classes for finite difference methods.
+namespace fd {}

--- a/src/NumericalAlgorithms/FiniteDifference/Minmod.cpp
+++ b/src/NumericalAlgorithms/FiniteDifference/Minmod.cpp
@@ -1,0 +1,29 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/FiniteDifference/Minmod.hpp"
+
+#include <array>
+
+#include "NumericalAlgorithms/FiniteDifference/Reconstruct.tpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace fd::reconstruction::detail {
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data)                                                 \
+  template void reconstruct<MinmodReconstructor>(                              \
+      gsl::not_null<std::array<gsl::span<double>, DIM(data)>*>                 \
+          reconstructed_upper_side_of_face_vars,                               \
+      gsl::not_null<std::array<gsl::span<double>, DIM(data)>*>                 \
+          reconstructed_lower_side_of_face_vars,                               \
+      const gsl::span<const double>& volume_vars,                              \
+      const DirectionMap<DIM(data), gsl::span<const double>>& ghost_cell_vars, \
+      const Index<DIM(data)>& volume_extents,                                  \
+      const size_t number_of_variables) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATION
+}  // namespace fd::reconstruction::detail

--- a/src/NumericalAlgorithms/FiniteDifference/Minmod.hpp
+++ b/src/NumericalAlgorithms/FiniteDifference/Minmod.hpp
@@ -1,0 +1,93 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <utility>
+
+#include "NumericalAlgorithms/FiniteDifference/Reconstruct.hpp"
+#include "Utilities/ForceInline.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Math.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+template <size_t Dim>
+class Direction;
+template <size_t Dim>
+class Index;
+/// \endcond
+
+namespace fd::reconstruction {
+namespace detail {
+struct MinmodReconstructor {
+  SPECTRE_ALWAYS_INLINE static std::array<double, 2> pointwise(
+      const double* const q, const int stride) noexcept {
+    using std::min;
+    using std::abs;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    const double a = q[stride] - q[0];
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    const double b = q[0] - q[-stride];
+    const double slope = 0.5 * (sgn(a) + sgn(b)) * min(abs(a), abs(b));
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    return {{q[0] - 0.5 * slope, q[0] + 0.5 * slope}};
+  }
+
+  SPECTRE_ALWAYS_INLINE static constexpr size_t stencil_width() noexcept {
+    return 3;
+  }
+};
+}  // namespace detail
+
+/*!
+ * \ingroup FiniteDifferenceGroup
+ * \brief Performs minmod reconstruction on the `volume_vars` in each direction.
+ *
+ * On a 1d mesh with spacing \f$\Delta x\f$ we denote the solution at the
+ * \f$j\f$th point by \f$u_j\f$. The minmod reconstruction \cite RezzollaBook
+ * first computes:
+ *
+ * \f{align}
+ * \sigma_j\equiv \textrm{minmod}\left(\frac{u_j-u_{j-1}}{\Delta x},
+ *           \frac{u_{j+1}-u_j}{\Delta x}\right)
+ * \f}
+ *
+ * where
+ *
+ * \f{align}
+ *  \mathrm{minmod}(a,b)=
+ * \left\{
+ *   \begin{array}{ll}
+ *    \mathrm{sgn}(a)\min(\lvert a\rvert, \lvert b\rvert)
+ *      & \mathrm{if} \; \mathrm{sgn}(a)=\mathrm{sgn}(b) \\
+ *    0 & \mathrm{otherwise}
+ *   \end{array}\right.
+ * \f}
+ *
+ * The reconstructed solution \f$u_j(x)\f$ in the \f$j\f$th cell is given by
+ *
+ * \f{align}
+ * u_j(x)=u_j + \sigma_j (x-x_j),
+ * \f}
+ *
+ * where \f$x_j\f$ is the coordinate \f$x\f$ at the center of the cell.
+ */
+template <size_t Dim>
+void minmod(const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+                reconstructed_upper_side_of_face_vars,
+            const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+                reconstructed_lower_side_of_face_vars,
+            const gsl::span<const double>& volume_vars,
+            const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+            const Index<Dim>& volume_extents,
+            const size_t number_of_variables) noexcept {
+  detail::reconstruct<detail::MinmodReconstructor>(
+      reconstructed_upper_side_of_face_vars,
+      reconstructed_lower_side_of_face_vars, volume_vars, ghost_cell_vars,
+      volume_extents, number_of_variables);
+}
+}  // namespace fd::reconstruction

--- a/src/NumericalAlgorithms/FiniteDifference/MonotisedCentral.cpp
+++ b/src/NumericalAlgorithms/FiniteDifference/MonotisedCentral.cpp
@@ -1,0 +1,29 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/FiniteDifference/MonotisedCentral.hpp"
+
+#include <array>
+
+#include "NumericalAlgorithms/FiniteDifference/Reconstruct.tpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace fd::reconstruction::detail {
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data)                                                 \
+  template void reconstruct<MonotisedCentralReconstructor>(                    \
+      gsl::not_null<std::array<gsl::span<double>, DIM(data)>*>                 \
+          reconstructed_upper_side_of_face_vars,                               \
+      gsl::not_null<std::array<gsl::span<double>, DIM(data)>*>                 \
+          reconstructed_lower_side_of_face_vars,                               \
+      const gsl::span<const double>& volume_vars,                              \
+      const DirectionMap<DIM(data), gsl::span<const double>>& ghost_cell_vars, \
+      const Index<DIM(data)>& volume_extents,                                  \
+      const size_t number_of_variables) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATION
+}  // namespace fd::reconstruction::detail

--- a/src/NumericalAlgorithms/FiniteDifference/MonotisedCentral.hpp
+++ b/src/NumericalAlgorithms/FiniteDifference/MonotisedCentral.hpp
@@ -1,0 +1,98 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <utility>
+
+#include "NumericalAlgorithms/FiniteDifference/Reconstruct.hpp"
+#include "Utilities/ForceInline.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Math.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+template <size_t Dim>
+class Direction;
+template <size_t Dim>
+class Index;
+/// \endcond
+
+namespace fd::reconstruction {
+namespace detail {
+struct MonotisedCentralReconstructor {
+  SPECTRE_ALWAYS_INLINE static std::array<double, 2> pointwise(
+      const double* const q, const int stride) noexcept {
+    using std::abs;
+    using std::min;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    const double a = q[stride] - q[0];
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    const double b = q[0] - q[-stride];
+    const double slope = 0.5 * (sgn(a) + sgn(b)) *
+                         min(0.5 * abs(a + b), 2.0 * min(abs(a), abs(b)));
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    return {{q[0] - 0.5 * slope, q[0] + 0.5 * slope}};
+  }
+
+  SPECTRE_ALWAYS_INLINE static constexpr size_t stencil_width() noexcept {
+    return 3;
+  }
+};
+}  // namespace detail
+
+/*!
+ * \ingroup FiniteDifferenceGroup
+ * \brief Performs monotised central-difference reconstruction on the `vars` in
+ * each direction.
+ *
+ * On a 1d mesh with spacing \f$\Delta x\f$ we denote the solution at the
+ * \f$j\f$th point by \f$u_j\f$. The monotised central-difference reconstruction
+ * \cite RezzollaBook first computes:
+ *
+ * \f{align}
+ * \sigma_j\equiv \textrm{minmod}
+ *           \left(\frac{u_{j+1} - u_{j-1}}{2\Delta x},
+ *                 2\frac{u_j-u_{j-1}}{\Delta x},
+ *                 2\frac{u_{j+1}-u_j}{\Delta x}\right)
+ * \f}
+ *
+ * where
+ *
+ * \f{align}
+ *  \mathrm{minmod}(a,b,c)=
+ * \left\{
+ *   \begin{array}{ll}
+ *    \mathrm{sgn}(a)\min(\lvert a\rvert, \lvert b\rvert, \lvert c\rvert)
+ *      & \mathrm{if} \; \mathrm{sgn}(a)=\mathrm{sgn}(b)=\mathrm{sgn}(c) \\
+ *    0 & \mathrm{otherwise}
+ *   \end{array}\right.
+ * \f}
+ *
+ * The reconstructed solution \f$u_j(x)\f$ in the \f$j\f$th cell is given by
+ *
+ * \f{align}
+ * u_j(x)=u_j + \sigma_j (x-x_j)
+ * \f}
+ *
+ * where \f$x_j\f$ is the coordinate \f$x\f$ at the center of the cell.
+ */
+template <size_t Dim>
+void monotised_central(
+    const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+        reconstructed_upper_side_of_face_vars,
+    const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+        reconstructed_lower_side_of_face_vars,
+    const gsl::span<const double>& volume_vars,
+    const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+    const Index<Dim>& volume_extents,
+    const size_t number_of_variables) noexcept {
+  detail::reconstruct<detail::MonotisedCentralReconstructor>(
+      reconstructed_upper_side_of_face_vars,
+      reconstructed_lower_side_of_face_vars, volume_vars, ghost_cell_vars,
+      volume_extents, number_of_variables);
+}
+}  // namespace fd::reconstruction

--- a/src/NumericalAlgorithms/FiniteDifference/Reconstruct.hpp
+++ b/src/NumericalAlgorithms/FiniteDifference/Reconstruct.hpp
@@ -1,0 +1,104 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <utility>  // for std::pair
+
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+template <size_t Dim>
+class Direction;
+template <size_t Dim, typename T>
+class DirectionMap;
+template <size_t Dim>
+class Index;
+/// \endcond
+
+namespace fd {
+/*!
+ * \ingroup FiniteDifferenceGroup
+ * \brief Variable and flux vector splitting reconstruction schemes for finite
+ * difference methods.
+ *
+ * Implementations of reconstruction methods must call the function
+ * `fd::reconstruction::detail::reconstruct` to perform the reconstruction.
+ * This function performs the actual loops taking into account strides and ghost
+ * zones for the reconstruction method. The `reconstruct` function has the
+ * following signature:
+ *
+ * \code
+ * template <typename Reconstructor, typename... ArgsForReconstructor, size_t
+ *           Dim>
+ * void reconstruct(
+ *     const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+ *         reconstructed_upper_side_of_face_vars,
+ *     const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+ *         reconstructed_lower_side_of_face_vars,
+ *     const gsl::span<const double>& volume_vars,
+ *     const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+ *     const Index<Dim>& volume_extents, const size_t number_of_variables,
+ *     const ArgsForReconstructor&... args_for_reconstructor) noexcept;
+ * \endcode
+ *
+ * The type of reconstruction done is specified with the `Reconstructor`
+ * explicit template parameter. Parameters for the reconstruction scheme, such
+ * as the linear weights and the epsilon tolerance in a CWENO reconstruction
+ * scheme,  are forwarded along using the `args_for_reconstruction` parameter
+ * pack.
+ *
+ * `Reconstructor` classes must define:
+ * - a `static constexpr size_t stencil_width()` function that
+ *   returns the size of the stencil, e.g. 3 for minmod, and 5 for 5-point
+ *   reconstruction.
+ * - a
+ *   \code
+ *      SPECTRE_ALWAYS_INLINE static std::array<double, 2> pointwise(
+ *            const double* const u, const int stride)
+ *   \endcode
+ *   function that optionally takes the additional arguments.
+ *   The `u` are the cell-centered values to reconstruct. The value \f$u_i\f$ in
+ *   the current FD cell is located at `u[0]`, the value at neighbor cell
+ *   \f$u_{i+1}\f$ is at `u[stride]`, and the value at neighbor cell
+ *   \f$u_{i-1}\f$ is at `u[-stride]`. The returned values are the
+ *   reconstructed solution on the lower and upper side of the cell.
+ *
+ * \note Currently the stride is always one because we transpose the data before
+ * reconstruction. However, it may be faster to have a non-unit stride without
+ * the transpose. We have the `stride` parameter in the reconstruction schemes
+ * to make testing performance easier in the future.
+ *
+ * Here is an ASCII illustration of the names of various quantities and where in
+ * the cells they are:
+ *
+ * \code
+ *   reconstructed_upper_side_of_face_vars v
+ * reconstructed_lower_side_of_face_vars v
+ *   volume_vars (at the cell-center) v
+ *                               |    x   |
+ *                                ^ reconstructed_upper_side_of_face_vars
+ *                              ^ reconstructed_lower_side_of_face_vars
+ * \endcode
+ *
+ * Notice that the `reconstructed_upper_side_of_face_vars` are on the lower side
+ * of the cell, while the `reconstructed_lower_side_of_face_vars` are on the
+ * upper side of the cell.
+ */
+namespace reconstruction {
+namespace detail {
+template <typename Reconstructor, typename... ArgsForReconstructor, size_t Dim>
+void reconstruct(
+    const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+        reconstructed_upper_side_of_face_vars,
+    const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+        reconstructed_lower_side_of_face_vars,
+    const gsl::span<const double>& volume_vars,
+    const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+    const Index<Dim>& volume_extents, const size_t number_of_variables,
+    const ArgsForReconstructor&... args_for_reconstructor) noexcept;
+}  // namespace detail
+}  // namespace reconstruction
+}  // namespace fd

--- a/src/NumericalAlgorithms/FiniteDifference/Reconstruct.tpp
+++ b/src/NumericalAlgorithms/FiniteDifference/Reconstruct.tpp
@@ -1,0 +1,278 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "NumericalAlgorithms/FiniteDifference/Reconstruct.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/Index.hpp"
+#include "DataStructures/StripeIterator.hpp"
+#include "DataStructures/Transpose.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace fd::reconstruction::detail {
+template <typename Reconstructor, typename... ArgsForReconstructor, size_t Dim>
+void reconstruct_impl(
+    const gsl::not_null<gsl::span<double>*> recons_upper,
+    const gsl::not_null<gsl::span<double>*> recons_lower,
+    const gsl::span<const double>& volume_vars,
+    const gsl::span<const double>& lower_ghost_data,
+    const gsl::span<const double>& upper_ghost_data,
+    const Index<Dim>& volume_extents, const size_t number_of_variables,
+    const ArgsForReconstructor&... args_for_reconstructor) noexcept {
+  constexpr size_t stencil_width = Reconstructor::stencil_width();
+  ASSERT(stencil_width % 2 == 1, "The stencil with should be odd but got "
+                                     << stencil_width
+                                     << " for the reconstructor.");
+  const size_t ghost_zone_for_stencil = (stencil_width - 1) / 2;
+  // Assume we send one extra ghost cell so we can reconstruct our neighbor's
+  // external data.
+  const size_t ghost_pts_in_neighbor_data = ghost_zone_for_stencil + 1;
+
+  const size_t number_of_stripes =
+      volume_extents.slice_away(0).product() * number_of_variables;
+
+  std::array<double, stencil_width> q{};
+  for (size_t slice = 0; slice < number_of_stripes; ++slice) {
+    const size_t vars_slice_offset = slice * volume_extents[0];
+    const size_t vars_neighbor_slice_offset =
+        slice * ghost_pts_in_neighbor_data;
+    const size_t recons_slice_offset = (volume_extents[0] + 1) * slice;
+
+    // Deal with lower ghost data.
+    //
+    // There's one extra reconstruction for the upper face of the neighbor
+    for (size_t j = 0; j < ghost_pts_in_neighbor_data; ++j) {
+      q[j] = lower_ghost_data[vars_neighbor_slice_offset + j];
+    }
+    for (size_t j = ghost_pts_in_neighbor_data, k = 0; j < stencil_width;
+         ++j, ++k) {
+      gsl::at(q, j) = volume_vars[vars_slice_offset + k];
+    }
+    (*recons_lower)[recons_slice_offset] = Reconstructor::pointwise(
+        q.data() + ghost_zone_for_stencil, 1, args_for_reconstructor...)[1];
+
+    for (size_t i = 0; i < ghost_zone_for_stencil; ++i) {
+      // offset comes from accounting for the 1 extra point in our ghost
+      // cells plus how far away from the boundary we are reconstructing.
+      for (size_t j = 0, offset = vars_neighbor_slice_offset +
+                                  ghost_pts_in_neighbor_data -
+                                  (ghost_zone_for_stencil - i);
+           j < ghost_zone_for_stencil - i; ++j) {
+        q[j] = lower_ghost_data[offset + j];
+      }
+      for (size_t j = ghost_zone_for_stencil - i, k = 0; j < stencil_width;
+           ++j, ++k) {
+        gsl::at(q, j) = volume_vars[vars_slice_offset + k];
+      }
+      const auto [upper_side_of_face, lower_side_of_face] =
+          Reconstructor::pointwise(q.data() + ghost_zone_for_stencil, 1,
+                                   args_for_reconstructor...);
+      (*recons_upper)[recons_slice_offset + i] = upper_side_of_face;
+      (*recons_lower)[recons_slice_offset + 1 + i] = lower_side_of_face;
+    }
+
+    // Reconstruct in the bulk
+    const size_t slice_end = volume_extents[0] - ghost_zone_for_stencil;
+    for (size_t vars_index = vars_slice_offset + ghost_zone_for_stencil,
+                i = ghost_zone_for_stencil;
+         i < slice_end; ++vars_index, ++i) {
+      // Note: we keep the `stride` here because we may want to
+      // experiment/support non-unit strides in the bulk in the future. For
+      // cells where the reconstruction needs boundary data we copy into a
+      // `std::array` buffer, which means we always have unit stride.
+      constexpr int stride = 1;
+      const auto [upper_side_of_face, lower_side_of_face] =
+          Reconstructor::pointwise(&volume_vars[vars_index], stride,
+                                   args_for_reconstructor...);
+      (*recons_upper)[recons_slice_offset + i] = upper_side_of_face;
+      (*recons_lower)[recons_slice_offset + 1 + i] = lower_side_of_face;
+    }
+
+    // Reconstruct using upper neighbor data
+    for (size_t i = 0; i < ghost_zone_for_stencil; ++i) {
+      // offset comes from accounting for the 1 extra point in our ghost
+      // cells plus how far away from the boundary we are reconstructing.
+      //
+      // Note:
+      // - q has size stencil_width
+      // - we need to copy over (stencil_width - 1 - i) from the volume
+      // - we need to copy (i + 1) from the neighbor
+      //
+      // Here is an example of a case with stencil_width 5:
+      //
+      //  Interior points| Neighbor points
+      // x x x x x x x x | o o o
+      //             ^
+      //         c c c c | c
+      //  c = points used for reconstruction
+      size_t j = 0;
+      for (size_t k =
+               vars_slice_offset + volume_extents[0] - (stencil_width - 1 - i);
+           j < stencil_width - 1 - i; ++j, ++k) {
+        gsl::at(q, j) = volume_vars[k];
+      }
+      for (size_t k = 0; j < stencil_width; ++j, ++k) {
+        gsl::at(q, j) = upper_ghost_data[vars_neighbor_slice_offset + k];
+      }
+
+      const auto [upper_side_of_face, lower_side_of_face] =
+          Reconstructor::pointwise(q.data() + ghost_zone_for_stencil, 1,
+                                   args_for_reconstructor...);
+      (*recons_upper)[recons_slice_offset + slice_end + i] = upper_side_of_face;
+      (*recons_lower)[recons_slice_offset + slice_end + i + 1] =
+          lower_side_of_face;
+    }
+
+    // Reconstruct the upper side of the last face, this is what the
+    // neighbor would've reconstructed.
+    for (size_t j = 0; j < ghost_zone_for_stencil; ++j) {
+      gsl::at(q, j) = volume_vars[vars_slice_offset + volume_extents[0] -
+                                  ghost_zone_for_stencil + j];
+    }
+    for (size_t j = ghost_zone_for_stencil, k = 0; j < stencil_width;
+         ++j, ++k) {
+      gsl::at(q, j) = upper_ghost_data[vars_neighbor_slice_offset + k];
+    }
+    (*recons_upper)[recons_slice_offset + volume_extents[0]] =
+        Reconstructor::pointwise(q.data() + ghost_zone_for_stencil, 1,
+                                 args_for_reconstructor...)[0];
+  }  // for slices
+}
+
+template <typename Reconstructor, typename... ArgsForReconstructor, size_t Dim>
+void reconstruct(
+    const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+        reconstructed_upper_side_of_face_vars,
+    const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+        reconstructed_lower_side_of_face_vars,
+    const gsl::span<const double>& volume_vars,
+    const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+    const Index<Dim>& volume_extents, const size_t number_of_variables,
+    const ArgsForReconstructor&... args_for_reconstructor) noexcept {
+#ifdef SPECTRE_DEBUG
+  ASSERT(volume_extents == Index<Dim>(volume_extents[0]),
+         "The extents must be isotropic, but got " << volume_extents);
+  const size_t number_of_points = volume_extents.product();
+  for (size_t i = 0; i < Dim; ++i) {
+    const size_t expected_pts =
+        number_of_points / volume_extents[i] * (volume_extents[i] + 1);
+    const size_t upper_num_pts =
+        gsl::at(*reconstructed_upper_side_of_face_vars, i).size() /
+        number_of_variables;
+    ASSERT(upper_num_pts == expected_pts,
+           "Incorrect number of points for "
+           "reconstructed_upper_side_of_face_vars in direction "
+               << i << ". Has " << upper_num_pts << " Expected "
+               << expected_pts);
+    const size_t lower_num_pts =
+        gsl::at(*reconstructed_lower_side_of_face_vars, i).size() /
+        number_of_variables;
+    ASSERT(lower_num_pts == expected_pts,
+           "Incorrect number of points for "
+           "reconstructed_lower_side_of_face_vars in direction "
+               << i << ". Has " << lower_num_pts << " Expected "
+               << expected_pts);
+  }
+#endif  // SPECTRE_DEBUG
+
+  ASSERT(ghost_cell_vars.contains(Direction<Dim>::lower_xi()),
+         "Couldn't find lower ghost data in lower-xi");
+  ASSERT(ghost_cell_vars.contains(Direction<Dim>::upper_xi()),
+         "Couldn't find upper ghost data in upper-xi");
+  reconstruct_impl<Reconstructor>(
+      make_not_null(&(*reconstructed_upper_side_of_face_vars)[0]),
+      make_not_null(&(*reconstructed_lower_side_of_face_vars)[0]), volume_vars,
+      ghost_cell_vars.at(Direction<Dim>::lower_xi()),
+      ghost_cell_vars.at(Direction<Dim>::upper_xi()), volume_extents,
+      number_of_variables, args_for_reconstructor...);
+
+  if constexpr (Dim > 1) {
+    // We transpose from (x,y,z,vars) ordering to (y,z,vars,x) ordering
+    // Might not be the most efficient (unclear), but easiest.
+    // We use a single large buffer for both the y and z reconstruction
+    // to reduce the number of memory allocations and improve data locality.
+    const auto& lower_ghost = ghost_cell_vars.at(Direction<Dim>::lower_eta());
+    const auto& upper_ghost = ghost_cell_vars.at(Direction<Dim>::upper_eta());
+    std::vector<double> buffer(
+        volume_vars.size() + lower_ghost.size() + upper_ghost.size() +
+        2 * (*reconstructed_upper_side_of_face_vars)[1].size());
+    raw_transpose(make_not_null(buffer.data()), volume_vars.data(),
+                  volume_extents[0], volume_vars.size() / volume_extents[0]);
+    raw_transpose(make_not_null(buffer.data() + volume_vars.size()),
+                  lower_ghost.data(), volume_extents[0],
+                  lower_ghost.size() / volume_extents[0]);
+    raw_transpose(
+        make_not_null(buffer.data() + volume_vars.size() + lower_ghost.size()),
+        upper_ghost.data(), volume_extents[0],
+        upper_ghost.size() / volume_extents[0]);
+
+    // Note: assumes isotropic extents
+    const size_t recons_offset_in_buffer =
+        volume_vars.size() + lower_ghost.size() + upper_ghost.size();
+    const size_t recons_size =
+        (*reconstructed_upper_side_of_face_vars)[1].size();
+    gsl::span<double> recons_upper_view =
+        gsl::make_span(buffer.data() + recons_offset_in_buffer, recons_size);
+    gsl::span<double> recons_lower_view = gsl::make_span(
+        buffer.data() + recons_offset_in_buffer + recons_size, recons_size);
+    reconstruct_impl<Reconstructor>(
+        make_not_null(&recons_upper_view), make_not_null(&recons_lower_view),
+        gsl::make_span(buffer),
+        gsl::make_span(buffer.data() + volume_vars.size(), lower_ghost.size()),
+        gsl::make_span(buffer.data() + volume_vars.size() + lower_ghost.size(),
+                       upper_ghost.size()),
+        volume_extents, number_of_variables, args_for_reconstructor...);
+    // Transpose result back
+    raw_transpose(
+        make_not_null((*reconstructed_upper_side_of_face_vars)[1].data()),
+        recons_upper_view.data(), recons_upper_view.size() / volume_extents[0],
+        volume_extents[0]);
+    raw_transpose(
+        make_not_null((*reconstructed_lower_side_of_face_vars)[1].data()),
+        recons_lower_view.data(), recons_lower_view.size() / volume_extents[0],
+        volume_extents[0]);
+
+    if constexpr (Dim > 2) {
+      size_t chunk_size = volume_extents[0] * volume_extents[1];
+      size_t number_of_volume_chunks = volume_vars.size() / chunk_size;
+      size_t number_of_neighbor_chunks =
+          ghost_cell_vars.at(Direction<Dim>::lower_zeta()).size() / chunk_size;
+
+      raw_transpose(make_not_null(buffer.data()), volume_vars.data(),
+                    chunk_size, number_of_volume_chunks);
+      raw_transpose(make_not_null(buffer.data() + volume_vars.size()),
+                    ghost_cell_vars.at(Direction<Dim>::lower_zeta()).data(),
+                    chunk_size, number_of_neighbor_chunks);
+      raw_transpose(make_not_null(buffer.data() + volume_vars.size() +
+                                  lower_ghost.size()),
+                    ghost_cell_vars.at(Direction<Dim>::upper_zeta()).data(),
+                    chunk_size, number_of_neighbor_chunks);
+
+      reconstruct_impl<Reconstructor>(
+          make_not_null(&recons_upper_view), make_not_null(&recons_lower_view),
+          gsl::make_span(buffer),
+          gsl::make_span(buffer.data() + volume_vars.size(),
+                         lower_ghost.size()),
+          gsl::make_span(
+              buffer.data() + volume_vars.size() + lower_ghost.size(),
+              upper_ghost.size()),
+          volume_extents, number_of_variables, args_for_reconstructor...);
+      // Transpose result back
+      raw_transpose(
+          make_not_null((*reconstructed_upper_side_of_face_vars)[2].data()),
+          recons_upper_view.data(), recons_upper_view.size() / chunk_size,
+          chunk_size);
+      raw_transpose(
+          make_not_null((*reconstructed_lower_side_of_face_vars)[2].data()),
+          recons_lower_view.data(), recons_lower_view.size() / chunk_size,
+          chunk_size);
+    }
+  }
+}
+}  // namespace fd::reconstruction::detail

--- a/src/NumericalAlgorithms/Spectral/Spectral.cpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.cpp
@@ -534,10 +534,15 @@ decltype(auto) get_spectral_quantity_for_mesh(F&& f,
               std::integral_constant<Basis, Basis::FiniteDifference>{},
               std::integral_constant<Quadrature, Quadrature::CellCentered>{},
               num_points);
+        case Quadrature::FaceCentered:
+          return f(
+              std::integral_constant<Basis, Basis::FiniteDifference>{},
+              std::integral_constant<Quadrature, Quadrature::FaceCentered>{},
+              num_points);
         default:
           ERROR(
-              "Only CellCentered is supported for finite difference "
-              "quadrature.");
+              "Only CellCentered and FaceCentered are supported for finite "
+              "difference quadrature.");
       }
     default:
       ERROR("Missing basis case for spectral quantity. The missing basis is: "

--- a/tests/Unit/Helpers/NumericalAlgorithms/FiniteDifference/Exact.hpp
+++ b/tests/Unit/Helpers/NumericalAlgorithms/FiniteDifference/Exact.hpp
@@ -1,0 +1,175 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Evolution/DgSubcell/SliceData.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace TestHelpers::fd::reconstruction {
+/*!
+ * \brief Test that the reconstruction procedure can exactly reconstruct
+ * polynomials of degree equal to the degree of the basis.
+ *
+ * For example, for a minmod, MC, or other second-order TVD limiter, we must be
+ * able to reconstruct linear functions exactly. For a third-order WENO scheme,
+ * we must be able to reconstruct quadratic functions exactly. This is done
+ * by setting up the function
+ *
+ * \f{align}{
+ *  u=\sum_{i=1}^p x^p + y^p + z^p
+ * \f}
+ *
+ * where \f$(x,y,z)=(\xi,\eta+4,\zeta+8)\f$ and \f$\xi,\eta,\zeta\f$ are the
+ * logical coordinates. The translation is done to catch subtle bugs that may
+ * arise from indexing in the wrong dimension.
+ */
+template <size_t Dim, typename F>
+void test_reconstruction_is_exact_if_in_basis(const size_t max_degree,
+                                              const size_t points_per_dimension,
+                                              const size_t stencil_width,
+                                              const F& invoke_recons) {
+  const size_t number_of_vars = 2;  // arbitrary, 2 is "cheap but not trivial"
+
+  const Mesh<Dim> mesh{points_per_dimension, Spectral::Basis::FiniteDifference,
+                       Spectral::Quadrature::CellCentered};
+  auto logical_coords = logical_coordinates(mesh);
+  // Make the logical coordinates different in each direction
+  for (size_t i = 1; i < Dim; ++i) {
+    logical_coords.get(i) += 4.0 * i;
+  }
+
+  // Compute polynomial on cell centers in FD cluster of points
+  const auto set_polynomial = [max_degree](
+                                  const gsl::not_null<DataVector*> var1_ptr,
+                                  const gsl::not_null<DataVector*> var2_ptr,
+                                  const auto& local_logical_coords) {
+    *var1_ptr = 0.0;
+    *var2_ptr = 100.0;  // some constant offset to distinguish the var values
+    for (size_t degree = 1; degree <= max_degree; ++degree) {
+      for (size_t i = 0; i < Dim; ++i) {
+        *var1_ptr += pow(local_logical_coords.get(i), degree);
+        if (number_of_vars == 2) {
+          *var2_ptr += pow(local_logical_coords.get(i), degree);
+        }
+      }
+    }
+  };
+  std::vector<double> volume_vars(mesh.number_of_grid_points() * number_of_vars,
+                                  0.0);
+  DataVector var1(volume_vars.data(), mesh.number_of_grid_points());
+  DataVector var2(volume_vars.data() + mesh.number_of_grid_points(),  // NOLINT
+                  mesh.number_of_grid_points());
+  set_polynomial(&var1, &var2, logical_coords);
+
+  // Compute the polynomial at the cell center for the neighbor data that we
+  // "received".
+  //
+  // We do this by computing the solution in our entire neighbor, then using
+  // slice_data to get the subset of points that are needed.
+  DirectionMap<Dim, std::vector<double>> neighbor_data{};
+  for (const auto& direction : Direction<Dim>::all_directions()) {
+    auto neighbor_logical_coords = logical_coords;
+    neighbor_logical_coords.get(direction.dimension()) +=
+        direction.sign() * 2.0;
+    std::vector<double> neighbor_vars(
+        mesh.number_of_grid_points() * number_of_vars, 0.0);
+    DataVector neighbor_var1(neighbor_vars.data(),
+                             mesh.number_of_grid_points());
+    DataVector neighbor_var2(
+        neighbor_vars.data() + mesh.number_of_grid_points(),  // NOLINT
+        mesh.number_of_grid_points());
+    set_polynomial(&neighbor_var1, &neighbor_var2, neighbor_logical_coords);
+
+    DirectionMap<Dim, bool> directions_to_slice{};
+    directions_to_slice[direction.opposite()] = true;
+    const auto sliced_data = evolution::dg::subcell::detail::slice_data_impl(
+        gsl::make_span(neighbor_vars.data(), neighbor_vars.size()),
+        mesh.extents(), (stencil_width - 1) / 2 + 1, directions_to_slice);
+    REQUIRE(sliced_data.size() == 1);
+    REQUIRE(sliced_data.contains(direction.opposite()));
+    neighbor_data[direction] = sliced_data.at(direction.opposite());
+  }
+
+  // Note: reconstructed_num_pts assumes isotropic extents
+  const size_t reconstructed_num_pts =
+      (mesh.extents(0) + 1) * mesh.slice_away(0).number_of_grid_points();
+  std::array<std::vector<double>, Dim> reconstructed_upper_side_of_face_vars =
+      make_array<Dim>(
+          std::vector<double>(reconstructed_num_pts * number_of_vars));
+  std::array<std::vector<double>, Dim> reconstructed_lower_side_of_face_vars =
+      make_array<Dim>(
+          std::vector<double>(reconstructed_num_pts * number_of_vars));
+
+  std::array<gsl::span<double>, Dim> recons_upper_side_of_face{};
+  std::array<gsl::span<double>, Dim> recons_lower_side_of_face{};
+  for (size_t i = 0; i < Dim; ++i) {
+    auto& upper = gsl::at(reconstructed_upper_side_of_face_vars, i);
+    auto& lower = gsl::at(reconstructed_lower_side_of_face_vars, i);
+    gsl::at(recons_upper_side_of_face, i) =
+        gsl::make_span(upper.data(), upper.size());
+    gsl::at(recons_lower_side_of_face, i) =
+        gsl::make_span(lower.data(), lower.size());
+  }
+
+  DirectionMap<Dim, gsl::span<const double>> ghost_cell_vars{};
+  for (const auto& [direction, data] : neighbor_data) {
+    ghost_cell_vars[direction] = gsl::make_span(data.data(), data.size());
+  }
+
+  invoke_recons(make_not_null(&recons_upper_side_of_face),
+                make_not_null(&recons_lower_side_of_face),
+                gsl::make_span(volume_vars.data(), volume_vars.size()),
+                ghost_cell_vars, mesh.extents(), number_of_vars);
+
+  for (size_t dim = 0; dim < Dim; ++dim) {
+    CAPTURE(dim);
+    // Since the reconstruction is to the same physical points the values should
+    // be the same if the polynomial is representable in the basis of the
+    // reconstructor.
+
+    CHECK_ITERABLE_APPROX(gsl::at(reconstructed_upper_side_of_face_vars, dim),
+                          gsl::at(reconstructed_lower_side_of_face_vars, dim));
+
+    // Compare to analytic solution on the faces.
+    const auto basis = make_array<Dim>(Spectral::Basis::FiniteDifference);
+    auto quadrature = make_array<Dim>(Spectral::Quadrature::CellCentered);
+    auto extents = make_array<Dim>(points_per_dimension);
+    gsl::at(extents, dim) = points_per_dimension + 1;
+    gsl::at(quadrature, dim) = Spectral::Quadrature::FaceCentered;
+    const Mesh<Dim> face_centered_mesh{extents, basis, quadrature};
+    auto logical_coords_face_centered = logical_coordinates(face_centered_mesh);
+    for (size_t i = 1; i < Dim; ++i) {
+      logical_coords_face_centered.get(i) =
+          logical_coords_face_centered.get(i) + 4.0 * i;
+    }
+
+    std::vector<double> expected_volume_vars(
+        face_centered_mesh.number_of_grid_points() * number_of_vars, 0.0);
+    DataVector expected_var1(expected_volume_vars.data(),
+                             face_centered_mesh.number_of_grid_points());
+    DataVector expected_var2(
+        expected_volume_vars.data() +
+            face_centered_mesh.number_of_grid_points(),  // NOLINT
+        face_centered_mesh.number_of_grid_points());
+    set_polynomial(&expected_var1, &expected_var2,
+                   logical_coords_face_centered);
+    CHECK_ITERABLE_APPROX(gsl::at(reconstructed_upper_side_of_face_vars, dim),
+                          expected_volume_vars);
+  }
+}
+}  // namespace TestHelpers::fd::reconstruction

--- a/tests/Unit/Helpers/NumericalAlgorithms/FiniteDifference/Python.hpp
+++ b/tests/Unit/Helpers/NumericalAlgorithms/FiniteDifference/Python.hpp
@@ -1,0 +1,227 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "DataStructures/Index.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Side.hpp"
+#include "Framework/Pypp.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace TestHelpers::fd::reconstruction {
+/*!
+ * \brief Compare the output of reconstruction done once in python and once in
+ * C++.
+ *
+ * - `extents` The extents are the volume extents of the subcell grid in a
+ * DG-subcell scheme. In general, this should be the size of the reconstruction
+ * stencil plus one or larger to provide a good test.
+ * - `stencil_width` the width of the reconstruction stencil. For example, for
+ * minmod or MC this would be 3, for 5-point 5th-order WENO this would
+ * be 5, and for three three-point stencil CWENO this would be 5 as well.
+ * -`python_test_file` the file in which the python function to compare the
+ * output result is defined in.
+ * - `python_function` the python function whose output will be compared to
+ * - `recons_function` an invokable (usually a lambda) that has the following
+ * signature:
+ * \code{.cpp}
+ *  (const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+ *              reconstructed_upper_side_of_face_vars,
+ *  const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+ *              reconstructed_lower_side_of_face_vars,
+ *  const gsl::span<const double>& volume_vars,
+ *  const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+ *  const Index<Dim>& volume_extents, const size_t number_of_variables)
+ * \endcode
+ */
+template <size_t Dim, typename ReconsFunction>
+void test_with_python(const Index<Dim>& extents, const size_t stencil_width,
+                      const std::string& python_test_file,
+                      const std::string& python_function,
+                      const ReconsFunction& recons_function) {
+  CAPTURE(extents);
+  CAPTURE(Dim);
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> dist(-1.0, 1.0);
+
+  const size_t ghost_zone_size = (stencil_width - 1) / 2;
+  const size_t ghost_cells_from_neighbor = ghost_zone_size + 1;
+  Index<Dim> extents_with_ghosts = extents;
+  for (size_t i = 0; i < Dim; ++i) {
+    // 2 because we extend in both upper and lower direction.
+    extents_with_ghosts[i] += 2 * ghost_cells_from_neighbor;
+  }
+  const size_t number_of_vars = 1;
+  std::vector<double> vars_with_ghosts(extents_with_ghosts.product() *
+                                       number_of_vars);
+  fill_with_random_values(make_not_null(&vars_with_ghosts), make_not_null(&gen),
+                          make_not_null(&dist));
+  // Copy out interior and neighbor data since that's what we will be passing
+  // to the C++ implementation.
+  const auto in_volume = [ghost_cells_from_neighbor, extents](
+                             const auto& idx, const size_t dim) {
+    return idx >= ghost_cells_from_neighbor and
+           idx < extents[dim] + ghost_cells_from_neighbor;
+  };
+  const auto in_upper_neighbor = [ghost_cells_from_neighbor, extents](
+                                     const auto& idx, const size_t dim) {
+    return idx >= extents[dim] + ghost_cells_from_neighbor;
+  };
+  const auto in_lower_neighbor = [ghost_cells_from_neighbor](const auto& idx) {
+    return idx < ghost_cells_from_neighbor;
+  };
+
+  DirectionMap<Dim, std::vector<double>> ghost_cells{};
+  for (const auto& direction : Direction<Dim>::all_directions()) {
+    ghost_cells[direction] = std::vector<double>{};
+  }
+  std::vector<double> volume_vars(extents.product() * number_of_vars);
+  for (size_t k = 0; k < (Dim > 2 ? extents_with_ghosts[2] : 1); ++k) {
+    for (size_t j = 0; j < (Dim > 1 ? extents_with_ghosts[1] : 1); ++j) {
+      for (size_t i = 0; i < extents_with_ghosts[0]; ++i) {
+        if constexpr (Dim > 1) {
+          // Check if we are in a Voronoi neighbor (ignore then)
+          std::vector<bool> has_neighbor(Dim);
+          has_neighbor.at(0) = in_lower_neighbor(i) or in_upper_neighbor(i, 0);
+          has_neighbor.at(1) = in_lower_neighbor(j) or in_upper_neighbor(j, 1);
+          if constexpr (Dim > 2) {
+            has_neighbor.at(2) =
+                in_lower_neighbor(k) or in_upper_neighbor(k, 2);
+          }
+          if (std::count(has_neighbor.begin(), has_neighbor.end(), true) >= 2) {
+            continue;
+          }
+        }
+
+        std::array volume_with_ghost_indices{i, j, k};
+        Index<Dim> volume_with_ghosts_index{};
+        for (size_t d = 0; d < Dim; ++d) {
+          volume_with_ghosts_index[d] = gsl::at(volume_with_ghost_indices, d);
+        }
+
+        // If in volume, copy over...
+        if (in_volume(i, 0) and
+            (Dim == 1 or (in_volume(j, 1) and (Dim == 2 or in_volume(k, 2))))) {
+          Index<Dim> volume_index{};
+          for (size_t d = 0; d < Dim; ++d) {
+            volume_index[d] = gsl::at(volume_with_ghost_indices, d) -
+                              (extents_with_ghosts[d] - extents[d]) / 2;
+          }
+
+          volume_vars[collapsed_index(volume_index, extents)] =
+              vars_with_ghosts[collapsed_index(volume_with_ghosts_index,
+                                               extents_with_ghosts)];
+        } else {
+          // We are dealing with something in the neighbor data. We need to
+          // identify which neighbor and then set.
+          Side side = Side::Lower;
+          size_t dimension = 0;
+          if (in_upper_neighbor(i, 0)) {
+            side = Side::Upper;
+          }
+          if (Dim > 1 and in_lower_neighbor(j)) {
+            dimension = 1;
+          }
+          if (Dim > 1 and in_upper_neighbor(j, 1)) {
+            side = Side::Upper;
+            dimension = 1;
+          }
+          if (Dim > 2 and in_lower_neighbor(k)) {
+            dimension = 2;
+          }
+          if (Dim > 2 and in_upper_neighbor(k, 2)) {
+            side = Side::Upper;
+            dimension = 2;
+          }
+
+          const Direction<Dim> direction{dimension, side};
+          ghost_cells.at(direction).push_back(vars_with_ghosts[collapsed_index(
+              volume_with_ghosts_index, extents_with_ghosts)]);
+        }
+      }
+    }
+  }
+
+  const size_t reconstructed_num_pts =
+      (extents[0] + 1) * extents.slice_away(0).product();
+  std::array<std::vector<double>, Dim> reconstructed_upper_side_of_face_vars =
+      make_array<Dim>(
+          std::vector<double>(reconstructed_num_pts * number_of_vars));
+  std::array<std::vector<double>, Dim> reconstructed_lower_side_of_face_vars =
+      make_array<Dim>(
+          std::vector<double>(reconstructed_num_pts * number_of_vars));
+
+  std::array<gsl::span<double>, Dim> recons_upper_side_of_face{};
+  std::array<gsl::span<double>, Dim> recons_lower_side_of_face{};
+  for (size_t i = 0; i < Dim; ++i) {
+    auto& upper = gsl::at(reconstructed_upper_side_of_face_vars, i);
+    auto& lower = gsl::at(reconstructed_lower_side_of_face_vars, i);
+    gsl::at(recons_upper_side_of_face, i) =
+        gsl::make_span(upper.data(), upper.size());
+    gsl::at(recons_lower_side_of_face, i) =
+        gsl::make_span(lower.data(), lower.size());
+  }
+
+  DirectionMap<Dim, gsl::span<const double>> ghost_cell_vars{};
+  for (const auto& [direction, data] : ghost_cells) {
+    ghost_cell_vars[direction] = gsl::make_span(data.data(), data.size());
+  }
+
+  recons_function(make_not_null(&recons_upper_side_of_face),
+                  make_not_null(&recons_lower_side_of_face),
+                  gsl::make_span(volume_vars), ghost_cell_vars, extents,
+                  number_of_vars);
+
+  const std::vector<size_t> extents_with_ghosts_vector(
+      extents_with_ghosts.begin(), extents_with_ghosts.end());
+  const std::vector<size_t> ghost_zones(Dim, ghost_zone_size);
+  for (size_t var_index = 0; var_index < number_of_vars; ++var_index) {
+    CAPTURE(var_index);
+    const std::vector<double> var(
+        vars_with_ghosts.begin() +
+            static_cast<std::ptrdiff_t>(var_index *
+                                        extents_with_ghosts.product()),
+        vars_with_ghosts.begin() +
+            static_cast<std::ptrdiff_t>((var_index + 1) *
+                                        extents_with_ghosts.product()));
+    const auto result =
+        pypp::call<std::vector<std::vector<std::vector<double>>>>(
+            python_test_file, python_function, var, extents_with_ghosts_vector,
+            Dim);
+
+    const std::vector<std::vector<double>>& python_recons_on_lower = result[0];
+    const std::vector<std::vector<double>>& python_recons_on_upper = result[1];
+    for (size_t d = 0; d < Dim; ++d) {
+      CAPTURE(d);
+      const std::vector<double> recons_upper_side_this_var(
+          gsl::at(recons_upper_side_of_face, d).begin() +
+              var_index * reconstructed_num_pts,
+          gsl::at(recons_upper_side_of_face, d).begin() +
+              (var_index + 1) * reconstructed_num_pts);
+      CHECK_ITERABLE_APPROX(recons_upper_side_this_var,
+                            python_recons_on_upper[d]);
+
+      const std::vector<double> recons_lower_side_this_var(
+          gsl::at(recons_lower_side_of_face, d).begin() +
+              var_index * reconstructed_num_pts,
+          gsl::at(recons_lower_side_of_face, d).begin() +
+              (var_index + 1) * reconstructed_num_pts);
+      CHECK_ITERABLE_APPROX(recons_lower_side_this_var,
+                            python_recons_on_lower[d]);
+    }
+  }
+}
+}  // namespace TestHelpers::fd::reconstruction

--- a/tests/Unit/NumericalAlgorithms/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 add_subdirectory(Convergence)
 add_subdirectory(DiscontinuousGalerkin)
+add_subdirectory(FiniteDifference)
 add_subdirectory(Integration)
 add_subdirectory(Interpolation)
 add_subdirectory(LinearAlgebra)

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_FiniteDifference")
 
 set(LIBRARY_SOURCES
   Test_Minmod.cpp
+  Test_MonotisedCentral.cpp
   )
 
 add_test_library(

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_FiniteDifference")
+
+set(LIBRARY_SOURCES
+  Test_Minmod.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "NumericalAlgorithms/FiniteDifference/"
+  "${LIBRARY_SOURCES}"
+  ""
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  CoordinateMaps
+  DataStructures
+  Domain
+  FiniteDifference
+  ErrorHandling
+  Utilities
+  )

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/Minmod.py
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/Minmod.py
@@ -1,0 +1,34 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import Reconstruction
+
+
+def test_minmod(u, extents, dim):
+    def minmod(a, b):
+        if a * b <= 0.0:
+            return 0.0
+        if abs(a) < abs(b):
+            return a
+        return b
+
+    def compute_face_values(recons_upper_of_cell, recons_lower_of_cell, v, i,
+                            j, k, dim_to_recons):
+        if dim_to_recons == 0:
+            slope = minmod(v[i, j, k] - v[i - 1, j, k],
+                           v[i + 1, j, k] - v[i, j, k])
+            recons_lower_of_cell.append(v[i, j, k] - 0.5 * slope)
+            recons_upper_of_cell.append(v[i, j, k] + 0.5 * slope)
+        if dim_to_recons == 1:
+            slope = minmod(v[i, j, k] - v[i, j - 1, k],
+                           v[i, j + 1, k] - v[i, j, k])
+            recons_lower_of_cell.append(v[i, j, k] - 0.5 * slope)
+            recons_upper_of_cell.append(v[i, j, k] + 0.5 * slope)
+        if dim_to_recons == 2:
+            slope = minmod(v[i, j, k] - v[i, j, k - 1],
+                           v[i, j, k + 1] - v[i, j, k])
+            recons_lower_of_cell.append(v[i, j, k] - 0.5 * slope)
+            recons_upper_of_cell.append(v[i, j, k] + 0.5 * slope)
+
+    return Reconstruction.reconstruct(u, extents, dim, [1, 1, 1],
+                                      compute_face_values)

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/MonotisedCentral.py
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/MonotisedCentral.py
@@ -1,0 +1,34 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import Reconstruction
+
+
+def test_monotised_central(u, extents, dim):
+    def monotised_central(a, b):
+        sign = lambda x: -1 if x < 0 else 1
+        sign_a = sign(a)
+        sign_b = sign(b)
+        return 0.5 * (sign_a + sign_b) * min(0.5 * abs(a + b),
+                                             min(2.0 * abs(a), 2.0 * abs(b)))
+
+    def compute_face_values(recons_upper_of_cell, recons_lower_of_cell, v, i,
+                            j, k, dim_to_recons):
+        if dim_to_recons == 0:
+            slope = monotised_central(v[i, j, k] - v[i - 1, j, k],
+                                      v[i + 1, j, k] - v[i, j, k])
+            recons_lower_of_cell.append(v[i, j, k] - 0.5 * slope)
+            recons_upper_of_cell.append(v[i, j, k] + 0.5 * slope)
+        if dim_to_recons == 1:
+            slope = monotised_central(v[i, j, k] - v[i, j - 1, k],
+                                      v[i, j + 1, k] - v[i, j, k])
+            recons_lower_of_cell.append(v[i, j, k] - 0.5 * slope)
+            recons_upper_of_cell.append(v[i, j, k] + 0.5 * slope)
+        if dim_to_recons == 2:
+            slope = monotised_central(v[i, j, k] - v[i, j, k - 1],
+                                      v[i, j, k + 1] - v[i, j, k])
+            recons_lower_of_cell.append(v[i, j, k] - 0.5 * slope)
+            recons_upper_of_cell.append(v[i, j, k] + 0.5 * slope)
+
+    return Reconstruction.reconstruct(u, extents, dim, [1, 1, 1],
+                                      compute_face_values)

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/Reconstruction.py
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/Reconstruction.py
@@ -1,0 +1,74 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def reconstruct(u, extents, dim, ghost_zones, func):
+    # Need to push back extra vars to get test to be generic.
+    number_of_dims = len(extents)
+    if len(extents) < 3:
+        for i in range(len(extents), 3):
+            extents.append(1)
+
+    u = np.reshape(np.copy(np.asarray(u)), extents, order='F')
+    recons_x_lower_face = []
+    recons_x_upper_face = []
+    # Reconstruction in x
+    for k in range(ghost_zones[2] + 1, extents[2] - ghost_zones[2] -
+                   1) if number_of_dims > 2 else range(1):
+        for j in range(ghost_zones[1] + 1, extents[1] - ghost_zones[1] -
+                       1) if number_of_dims > 1 else range(1):
+            recons_upper_of_cell = []
+            recons_lower_of_cell = []
+            for i in range(ghost_zones[0], extents[0] - ghost_zones[0]):
+                func(recons_upper_of_cell, recons_lower_of_cell, u, i, j, k, 0)
+            # By deleting the first entry in lower_of_cell and the last
+            # entry of upper_of_cell we convert to the face-based indices
+            recons_lower_of_cell.pop(0)
+            recons_upper_of_cell.pop(-1)
+            recons_x_lower_face = recons_x_lower_face + recons_upper_of_cell
+            recons_x_upper_face = recons_x_upper_face + recons_lower_of_cell
+
+    if dim == 1:
+        return [[recons_x_lower_face], [recons_x_upper_face]]
+
+    # Reconstruction in y
+    recons_y_lower_face = []
+    recons_y_upper_face = []
+    for k in range(ghost_zones[2] + 1, extents[2] - ghost_zones[2] -
+                   1) if number_of_dims > 2 else range(1):
+        recons_upper_of_cell = []
+        recons_lower_of_cell = []
+        for j in range(ghost_zones[1], extents[1] - ghost_zones[1]):
+            for i in range(ghost_zones[0] + 1,
+                           extents[0] - ghost_zones[0] - 1):
+                func(recons_upper_of_cell, recons_lower_of_cell, u, i, j, k, 1)
+        # By deleting the first entry in lower_of_cell and the last
+        # entry of upper_of_cell we convert to the face-based indices
+        for i in range(ghost_zones[0] + 1, extents[0] - ghost_zones[0] - 1):
+            recons_lower_of_cell.pop(0)
+            recons_upper_of_cell.pop(-1)
+        recons_y_lower_face = recons_y_lower_face + recons_upper_of_cell
+        recons_y_upper_face = recons_y_upper_face + recons_lower_of_cell
+    if dim == 2:
+        return [[recons_x_lower_face, recons_y_lower_face],
+                [recons_x_upper_face, recons_y_upper_face]]
+
+    # Reconstruction in z
+    recons_z_lower_face = []
+    recons_z_upper_face = []
+    for k in range(ghost_zones[2], extents[2] - ghost_zones[2]):
+        for j in range(ghost_zones[1] + 1, extents[1] - ghost_zones[1] - 1):
+            for i in range(ghost_zones[0] + 1,
+                           extents[0] - ghost_zones[0] - 1):
+                func(recons_z_lower_face, recons_z_upper_face, u, i, j, k, 2)
+    # By deleting the first entry in lower_of_cell and the last
+    # entry of upper_of_cell we convert to the face-based indices
+    for j in range(ghost_zones[1] + 1, extents[1] - ghost_zones[1] - 1):
+        for i in range(ghost_zones[0] + 1, extents[0] - ghost_zones[0] - 1):
+            recons_z_upper_face.pop(0)
+            recons_z_lower_face.pop(-1)
+
+    return [[recons_x_lower_face, recons_y_lower_face, recons_z_lower_face],
+            [recons_x_upper_face, recons_y_upper_face, recons_z_upper_face]]

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_Minmod.cpp
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_Minmod.cpp
@@ -1,0 +1,48 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/Index.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Framework/Pypp.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/NumericalAlgorithms/FiniteDifference/Exact.hpp"
+#include "Helpers/NumericalAlgorithms/FiniteDifference/Python.hpp"
+#include "NumericalAlgorithms/FiniteDifference/Minmod.hpp"
+
+namespace {
+
+template <size_t Dim>
+void test() {
+  const auto recons =
+      [](const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+             reconstructed_upper_side_of_face_vars,
+         const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+             reconstructed_lower_side_of_face_vars,
+         const gsl::span<const double>& volume_vars,
+         const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+         const Index<Dim>& volume_extents, const size_t number_of_variables) {
+        fd::reconstruction::minmod(reconstructed_upper_side_of_face_vars,
+                                   reconstructed_lower_side_of_face_vars,
+                                   volume_vars, ghost_cell_vars, volume_extents,
+                                   number_of_variables);
+      };
+  TestHelpers::fd::reconstruction::test_reconstruction_is_exact_if_in_basis<
+      Dim>(1, 4, 3, recons);
+  TestHelpers::fd::reconstruction::test_with_python(Index<Dim>{4}, 3, "Minmod",
+                                                    "test_minmod", recons);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.FiniteDifference.Minmod",
+                  "[Unit][NumericalAlgorithms]") {
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "NumericalAlgorithms/FiniteDifference/");
+  test<1>();
+  test<2>();
+  test<3>();
+}

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_MonotisedCentral.cpp
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_MonotisedCentral.cpp
@@ -1,0 +1,48 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/Index.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Framework/Pypp.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/NumericalAlgorithms/FiniteDifference/Exact.hpp"
+#include "Helpers/NumericalAlgorithms/FiniteDifference/Python.hpp"
+#include "NumericalAlgorithms/FiniteDifference/MonotisedCentral.hpp"
+
+namespace {
+
+template <size_t Dim>
+void test() {
+  const auto recons =
+      [](const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+             reconstructed_upper_side_of_face_vars,
+         const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+             reconstructed_lower_side_of_face_vars,
+         const gsl::span<const double>& volume_vars,
+         const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+         const Index<Dim>& volume_extents, const size_t number_of_variables) {
+        fd::reconstruction::monotised_central(
+            reconstructed_upper_side_of_face_vars,
+            reconstructed_lower_side_of_face_vars, volume_vars, ghost_cell_vars,
+            volume_extents, number_of_variables);
+      };
+  TestHelpers::fd::reconstruction::test_reconstruction_is_exact_if_in_basis<
+      Dim>(1, 4, 3, recons);
+  TestHelpers::fd::reconstruction::test_with_python(
+      Index<Dim>{4}, 3, "MonotisedCentral", "test_monotised_central", recons);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.FiniteDifference.MonotisedCentral",
+                  "[Unit][NumericalAlgorithms]") {
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "NumericalAlgorithms/FiniteDifference/");
+  test<1>();
+  test<2>();
+  test<3>();
+}

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/__init__.py
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/__init__.py
@@ -1,0 +1,2 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.


### PR DESCRIPTION
## Proposed changes

- Allow getting the face-centered collocation points because these are useful to have for testing the reconstruction schemes
- add the generic reconstruction function and minmod reconstruction. The generic function will be applicable to all reconstruction done on a uniform (in terms of refinement, the map can be non-trivial) Cartesian mesh. 
- Add monotised central reconstruction to give a second example of a reconstruction scheme (plus it's a bit better than minmod)

The way I've structured the code should mean that additional reconstruction schemes will only need ~200 lines to be implemented since all the looping code is shared between the different schemes.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
