### PR TITLE
Remove use of env -S

### DIFF
--- a/tools/patch_charm_modules.sh
+++ b/tools/patch_charm_modules.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S bash -e
+#!/usr/bin/env bash
 
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
@@ -7,6 +7,8 @@
 # their corresponding .def.h and decl.h files in the charm module outputs.
 # This is used to override default charm behavior with custom versions or to
 # patch bugs
+
+set -e
 
 if [ "$#" -ne 4 ]; then
     echo "Usage: patch_charm_modules.sh module_name path_to_current_source_dir\


### PR DESCRIPTION
The -S option is new in coreutils 8.30 (mid 2018), which is too new to
rely on.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
