### PR TITLE
Make CSW::ComputeLargestCharSpeed a compute tag

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/Characteristics.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Characteristics.cpp
@@ -151,18 +151,21 @@ evolved_fields_from_characteristic_fields(
   return evolved_fields;
 }
 
+namespace Tags {
 template <size_t SpatialDim>
-double ComputeLargestCharacteristicSpeed<SpatialDim>::apply(
-    const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
+void ComputeLargestCharacteristicSpeed<SpatialDim>::function(
+    const gsl::not_null<double*> max_speed, const Scalar<DataVector>& gamma_1,
+    const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, SpatialDim, Frame::Inertial>& shift,
     const tnsr::ii<DataVector, SpatialDim, Frame::Inertial>&
         spatial_metric) noexcept {
   const auto shift_magnitude = magnitude(shift, spatial_metric);
-  return std::max(
-      max(abs(1. + get(gamma_1)) * get(shift_magnitude)),  // v(VPsi)
-      max(get(shift_magnitude) +
-          abs(get(lapse))));  // v(VZero), v(VPlus),v(VMinus)
+  *max_speed =
+      std::max(max(abs(1. + get(gamma_1)) * get(shift_magnitude)),  // v(VPsi)
+               max(get(shift_magnitude) +
+                   abs(get(lapse))));  // v(VZero), v(VPlus),v(VMinus)
 }
+}  // namespace Tags
 }  // namespace CurvedScalarWave
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
@@ -225,8 +228,8 @@ double ComputeLargestCharacteristicSpeed<SpatialDim>::apply(
           unit_normal_one_form) noexcept;                                     \
   template struct CurvedScalarWave::                                          \
       EvolvedFieldsFromCharacteristicFieldsCompute<DIM(data)>;                \
-  template struct CurvedScalarWave::ComputeLargestCharacteristicSpeed<DIM(    \
-      data)>;
+  template struct CurvedScalarWave::Tags::ComputeLargestCharacteristicSpeed<  \
+      DIM(data)>;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 

--- a/src/Evolution/Systems/CurvedScalarWave/Characteristics.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Characteristics.hpp
@@ -227,6 +227,7 @@ struct EvolvedFieldsFromCharacteristicFieldsCompute
 };
 // @}
 
+namespace Tags {
 /*!
  * \brief Computes the largest magnitude of the characteristic speeds.
  *
@@ -243,15 +244,20 @@ struct EvolvedFieldsFromCharacteristicFieldsCompute
  * N_i},\, \sqrt{N^i N_i}+\vert N\vert) \f$.
  */
 template <size_t SpatialDim>
-struct ComputeLargestCharacteristicSpeed {
+struct ComputeLargestCharacteristicSpeed : LargestCharacteristicSpeed,
+                                           db::ComputeTag {
   using argument_tags = tmpl::list<
       Tags::ConstraintGamma1, gr::Tags::Lapse<DataVector>,
       gr::Tags::Shift<SpatialDim, Frame::Inertial, DataVector>,
       gr::Tags::SpatialMetric<SpatialDim, Frame::Inertial, DataVector>>;
-  static double apply(
-      const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
+  using return_type = double;
+  using base = LargestCharacteristicSpeed;
+  static void function(
+      const gsl::not_null<double*> max_speed, const Scalar<DataVector>& gamma_1,
+      const Scalar<DataVector>& lapse,
       const tnsr::I<DataVector, SpatialDim, Frame::Inertial>& shift,
       const tnsr::ii<DataVector, SpatialDim, Frame::Inertial>&
           spatial_metric) noexcept;
 };
+}  // namespace Tags
 }  // namespace CurvedScalarWave

--- a/src/Evolution/Systems/CurvedScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Tags.hpp
@@ -91,6 +91,10 @@ struct CharacteristicSpeeds : db::SimpleTag {
   using type = std::array<DataVector, 4>;
 };
 
+struct LargestCharacteristicSpeed : db::SimpleTag {
+  using type = double;
+};
+
 template <size_t Dim>
 struct CharacteristicFields : db::SimpleTag {
   using type = Variables<tmpl::list<VPsi, VZero<Dim>, VPlus, VMinus>>;

--- a/src/Evolution/Systems/CurvedScalarWave/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/TagsDeclarations.hpp
@@ -26,6 +26,7 @@ struct VMinus;
 
 template <size_t Dim>
 struct CharacteristicSpeeds;
+struct LargestCharacteristicSpeed;
 template <size_t Dim>
 struct CharacteristicFields;
 template <size_t Dim>


### PR DESCRIPTION
## Proposed changes

Convert the struct `CurvedScalarWave::ComputeLargestCharacteristicSpeed` to a proper compute tag so that it can be used in an executable for the system.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
