### PR TITLE
Add analytic data for a plane wave in Minkowski background

### DIFF
--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   PlaneWave3DKerrSchild.cpp
+  PlaneWaveMinkowski.cpp
   RegularSphericalWave3DKerrSchild.cpp
   )
 

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/CMakeLists.txt
@@ -18,8 +18,6 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   AnalyticData.hpp
-  PlaneWave3DKerrSchild.hpp
-  RegularSphericalWave3DKerrSchild.hpp
   ScalarWaveGr.hpp
   ScalarWaveGr.tpp
   )

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/PlaneWave3DKerrSchild.cpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/PlaneWave3DKerrSchild.cpp
@@ -1,7 +1,9 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include "PointwiseFunctions/AnalyticData/CurvedWaveEquation/PlaneWave3DKerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveGr.tpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"
 
 namespace CurvedScalarWave ::AnalyticData {
 template class ScalarWaveGr<ScalarWave::Solutions::PlaneWave<3>,

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/PlaneWave3DKerrSchild.hpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/PlaneWave3DKerrSchild.hpp
@@ -1,9 +1,0 @@
-// Distributed under the MIT License.
-// See LICENSE.txt for details.
-
-#pragma once
-
-#include "PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveGr.tpp"
-
-#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
-#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/PlaneWaveMinkowski.cpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/PlaneWaveMinkowski.cpp
@@ -1,0 +1,27 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveGr.tpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"
+
+namespace CurvedScalarWave::AnalyticData {
+#define FUNCS_DECL(dim)                                                 \
+  template class ScalarWaveGr<ScalarWave::Solutions::PlaneWave<dim>,    \
+                              gr::Solutions::Minkowski<dim>>;           \
+  template bool operator==(                                             \
+      const ScalarWaveGr<ScalarWave::Solutions::PlaneWave<dim>,         \
+                         gr::Solutions::Minkowski<dim>>& lhs,           \
+      const ScalarWaveGr<ScalarWave::Solutions::PlaneWave<dim>,         \
+                         gr::Solutions::Minkowski<dim>>& rhs) noexcept; \
+  template bool operator!=(                                             \
+      const ScalarWaveGr<ScalarWave::Solutions::PlaneWave<dim>,         \
+                         gr::Solutions::Minkowski<dim>>& lhs,           \
+      const ScalarWaveGr<ScalarWave::Solutions::PlaneWave<dim>,         \
+                         gr::Solutions::Minkowski<dim>>& rhs) noexcept;
+
+FUNCS_DECL(1)
+FUNCS_DECL(2)
+FUNCS_DECL(3)
+#undef FUNCS_DECL
+}  // namespace CurvedScalarWave::AnalyticData

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/RegularSphericalWave3DKerrSchild.cpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/RegularSphericalWave3DKerrSchild.cpp
@@ -1,7 +1,9 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include "PointwiseFunctions/AnalyticData/CurvedWaveEquation/RegularSphericalWave3DKerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveGr.tpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp"
 
 namespace CurvedScalarWave ::AnalyticData {
 template class ScalarWaveGr<ScalarWave::Solutions::RegularSphericalWave,

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/RegularSphericalWave3DKerrSchild.hpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/RegularSphericalWave3DKerrSchild.hpp
@@ -1,9 +1,0 @@
-// Distributed under the MIT License.
-// See LICENSE.txt for details.
-
-#pragma once
-
-#include "PointwiseFunctions/AnalyticData/CurvedWaveEquation/ScalarWaveGr.tpp"
-
-#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
-#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp"


### PR DESCRIPTION
## Proposed changes

Add analytic data class for a plane wave propagating in Minkowski spacetime. This specialization will provide initial data for the curved scalar-wave system to produce evolutions that can be compared directly with the flat scalar-wave system.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.