### PR TITLE
Add tags and functions to compute char speeds for GhValencia

### DIFF
--- a/src/Evolution/Systems/GrMhd/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+add_subdirectory(GhValenciaDivClean)
 add_subdirectory(ValenciaDivClean)

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY GhValenciaDivClean)
+
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  Characteristics.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Characteristics.hpp
+  Tags.hpp
+  TagsDeclarations.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  DataStructures
+  GeneralRelativity
+  Valencia
+  )

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Characteristics.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Characteristics.cpp
@@ -1,0 +1,141 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/Characteristics.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.hpp"
+#include "Evolution/Systems/RelativisticEuler/Valencia/Characteristics.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/Tags.hpp"              // IWYU pragma: keep
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+// IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
+// IWYU pragma: no_forward_declare Tensor
+
+namespace grmhd::GhValenciaDivClean {
+template <size_t ThermodynamicDim>
+void characteristic_speeds(
+    const gsl::not_null<std::array<DataVector, 13>*> char_speeds,
+    const Scalar<DataVector>& rest_mass_density,
+    const Scalar<DataVector>& specific_internal_energy,
+    const Scalar<DataVector>& specific_enthalpy,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,
+    const Scalar<DataVector>& lorentz_factor,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& magnetic_field,
+    const Scalar<DataVector>& lapse, const tnsr::I<DataVector, 3>& shift,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+    const tnsr::i<DataVector, 3>& unit_normal,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+        equation_of_state,
+    const Scalar<DataVector>& gh_constraint_gamma1) noexcept {
+  const size_t num_grid_points = get(lapse).size();
+  auto& achar_speeds = *char_speeds;
+  for (size_t idx = 0; idx < 13; ++idx) {
+    if (achar_speeds.at(idx).size() != num_grid_points) {
+      achar_speeds.at(idx) = DataVector(num_grid_points);
+    }
+  }
+
+  const auto char_speeds_valencia =
+      grmhd::ValenciaDivClean::characteristic_speeds(
+          rest_mass_density, specific_internal_energy, specific_enthalpy,
+          spatial_velocity, lorentz_factor, magnetic_field, lapse, shift,
+          spatial_metric, unit_normal, equation_of_state);
+  for (size_t idx = 0; idx < 9; ++idx) {
+    char_speeds->at(idx) = char_speeds_valencia.at(idx);
+  }
+
+  const auto char_speeds_gh =
+      GeneralizedHarmonic::characteristic_speeds<3, Frame::Inertial>(
+          gh_constraint_gamma1, lapse, shift, unit_normal);
+  for (size_t idx = 0; idx < 4; ++idx) {
+    char_speeds->at(9 + idx) = char_speeds_gh.at(idx);
+  }
+}
+
+template <size_t ThermodynamicDim>
+std::array<DataVector, 13> characteristic_speeds(
+    const Scalar<DataVector>& rest_mass_density,
+    const Scalar<DataVector>& specific_internal_energy,
+    const Scalar<DataVector>& specific_enthalpy,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,
+    const Scalar<DataVector>& lorentz_factor,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& magnetic_field,
+    const Scalar<DataVector>& lapse, const tnsr::I<DataVector, 3>& shift,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+    const tnsr::i<DataVector, 3>& unit_normal,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+        equation_of_state,
+    const Scalar<DataVector>& gh_constraint_gamma1) noexcept {
+  auto char_speeds = make_with_value<typename Tags::CharacteristicSpeeds::type>(
+      get(lapse), 0.);
+  characteristic_speeds(make_not_null(&char_speeds), rest_mass_density,
+                        specific_internal_energy, specific_enthalpy,
+                        spatial_velocity, lorentz_factor, magnetic_field, lapse,
+                        shift, spatial_metric, unit_normal, equation_of_state,
+                        gh_constraint_gamma1);
+  return char_speeds;
+}
+
+void Tags::ComputeLargestCharacteristicSpeed::function(
+    const gsl::not_null<double*> speed,
+    const Scalar<DataVector>& gh_constraint_gamma1,
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric) noexcept {
+  double max_gh_speed = std::numeric_limits<double>::signaling_NaN();
+  GeneralizedHarmonic::Tags::ComputeLargestCharacteristicSpeed<
+      3, Frame::Inertial>::function(make_not_null(&max_gh_speed),
+                                    gh_constraint_gamma1, lapse, shift,
+                                    spatial_metric);
+  // note: the 1.0 is an approximation valid only in flat spacetime. For
+  // better CFL estimates, this should be updated to calculate the
+  // characteristic speed based on the lapse and shift.
+  *speed = std::max(max_gh_speed, 1.0);
+}
+
+#define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data)                                              \
+  template std::array<DataVector, 13> characteristic_speeds<GET_DIM(data)>( \
+      const Scalar<DataVector>& rest_mass_density,                          \
+      const Scalar<DataVector>& specific_internal_energy,                   \
+      const Scalar<DataVector>& specific_enthalpy,                          \
+      const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,      \
+      const Scalar<DataVector>& lorentz_factor,                             \
+      const tnsr::I<DataVector, 3, Frame::Inertial>& magnetic_field,        \
+      const Scalar<DataVector>& lapse, const tnsr::I<DataVector, 3>& shift, \
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,       \
+      const tnsr::i<DataVector, 3>& unit_normal,                            \
+      const EquationsOfState::EquationOfState<true, GET_DIM(data)>&         \
+          equation_of_state,                                                \
+      const Scalar<DataVector>& gh_constraint_gamma1) noexcept;             \
+  template void characteristic_speeds<GET_DIM(data)>(                       \
+      const gsl::not_null<std::array<DataVector, 13>*> char_speeds,         \
+      const Scalar<DataVector>& rest_mass_density,                          \
+      const Scalar<DataVector>& specific_internal_energy,                   \
+      const Scalar<DataVector>& specific_enthalpy,                          \
+      const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,      \
+      const Scalar<DataVector>& lorentz_factor,                             \
+      const tnsr::I<DataVector, 3, Frame::Inertial>& magnetic_field,        \
+      const Scalar<DataVector>& lapse, const tnsr::I<DataVector, 3>& shift, \
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,       \
+      const tnsr::i<DataVector, 3>& unit_normal,                            \
+      const EquationsOfState::EquationOfState<true, GET_DIM(data)>&         \
+          equation_of_state,                                                \
+      const Scalar<DataVector>& gh_constraint_gamma1) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
+
+#undef GET_DIM
+#undef INSTANTIATION
+}  // namespace grmhd::GhValenciaDivClean

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Characteristics.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Characteristics.hpp
@@ -1,0 +1,149 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"  // IWYU pragma: keep
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+// IWYU pragma: no_include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+// IWYU pragma: no_include "PointwiseFunctions/Hydro/Tags.hpp"
+
+/// \cond
+class DataVector;
+namespace Tags {
+template <typename Tag>
+struct Normalized;
+}  // namespace Tags
+/// \endcond
+
+// IWYU pragma:  no_forward_declare EquationsOfState::EquationOfState
+// IWYU pragma:  no_forward_declare EquationsOfSTate::IdealFluid
+// IWYU pragma: no_forward_declare Tensor
+
+namespace grmhd {
+namespace GhValenciaDivClean {
+
+// @{
+/*!
+ * \brief Compute the characteristic speeds for the Valencia formulation of
+ * GRMHD with divergence cleaning with a dynamical spacetime evolved in the
+ * Generalized Harmonic formulation.
+ */
+template <size_t ThermodynamicDim>
+std::array<DataVector, 13> characteristic_speeds(
+    const Scalar<DataVector>& rest_mass_density,
+    const Scalar<DataVector>& specific_internal_energy,
+    const Scalar<DataVector>& specific_enthalpy,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,
+    const Scalar<DataVector>& lorentz_factor,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& magnetic_field,
+    const Scalar<DataVector>& lapse, const tnsr::I<DataVector, 3>& shift,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+    const tnsr::i<DataVector, 3>& unit_normal,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+        equation_of_state,
+    const Scalar<DataVector>& gh_constraint_gamma1) noexcept;
+
+template <size_t ThermodynamicDim>
+void characteristic_speeds(
+    const gsl::not_null<std::array<DataVector, 13>*> char_speeds,
+    const Scalar<DataVector>& rest_mass_density,
+    const Scalar<DataVector>& specific_internal_energy,
+    const Scalar<DataVector>& specific_enthalpy,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,
+    const Scalar<DataVector>& lorentz_factor,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& magnetic_field,
+    const Scalar<DataVector>& lapse, const tnsr::I<DataVector, 3>& shift,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+    const tnsr::i<DataVector, 3>& unit_normal,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+        equation_of_state,
+    const Scalar<DataVector>& gh_constraint_gamma1) noexcept;
+// @}
+
+namespace Tags {
+/*!
+ * \brief Compute the characteristic speeds for the Valencia formulation of
+ * GRMHD with divergence cleaning with a dynamical spacetime evolved in the
+ * Generalized Harmonic formulation.
+ *
+ * \details see grmhd::GhValenciaDivClean::characteristic_speeds
+ */
+template <typename EquationOfStateType>
+struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds,
+                                     db::ComputeTag {
+  using base = Tags::CharacteristicSpeeds;
+  using argument_tags = tmpl::list<
+      hydro::Tags::RestMassDensity<DataVector>,
+      hydro::Tags::SpecificInternalEnergy<DataVector>,
+      hydro::Tags::SpecificEnthalpy<DataVector>,
+      hydro::Tags::SpatialVelocity<DataVector, 3>,
+      hydro::Tags::LorentzFactor<DataVector>,
+      hydro::Tags::MagneticField<DataVector, 3>, gr::Tags::Lapse<>,
+      gr::Tags::Shift<3>, gr::Tags::SpatialMetric<3>,
+      ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<3>>,
+      hydro::Tags::EquationOfState<EquationOfStateType>,
+      GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1>;
+
+  using volume_tags =
+      tmpl::list<hydro::Tags::EquationOfState<EquationOfStateType>>;
+
+  using return_type = std::array<DataVector, 13>;
+
+  static constexpr void function(
+      const gsl::not_null<return_type*> result,
+      const Scalar<DataVector>& rest_mass_density,
+      const Scalar<DataVector>& specific_internal_energy,
+      const Scalar<DataVector>& specific_enthalpy,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,
+      const Scalar<DataVector>& lorentz_factor,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& magnetic_field,
+      const Scalar<DataVector>& lapse, const tnsr::I<DataVector, 3>& shift,
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+      const tnsr::i<DataVector, 3>& unit_normal,
+      const EquationsOfState::EquationOfState<
+          true, EquationOfStateType::thermodynamic_dim>& equation_of_state,
+      const Scalar<DataVector>& gh_constraint_gamma1) noexcept {
+    characteristic_speeds<EquationOfStateType::thermodynamic_dim>(
+        result, rest_mass_density, specific_internal_energy, specific_enthalpy,
+        spatial_velocity, lorentz_factor, magnetic_field, lapse, shift,
+        spatial_metric, unit_normal, equation_of_state, gh_constraint_gamma1);
+  }
+};
+
+struct ComputeLargestCharacteristicSpeed : LargestCharacteristicSpeed,
+                                           db::ComputeTag {
+  using base = LargestCharacteristicSpeed;
+  using type = typename base::type;
+  using argument_tags = tmpl::list<
+      ::GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma1,
+      gr::Tags::Lapse<DataVector>,
+      gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+      gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>;
+
+  using return_type = double;
+
+  static void function(
+      const gsl::not_null<double*> speed,
+      const Scalar<DataVector>& gh_constraint_gamma1,
+      const Scalar<DataVector>& lapse,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric) noexcept;
+};
+}  // namespace Tags
+}  // namespace GhValenciaDivClean
+}  // namespace grmhd

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Tags.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Tags.hpp
@@ -1,0 +1,34 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/TagsDeclarations.hpp"
+#include "Evolution/Tags.hpp"
+
+/// \cond
+class DataVector;
+/// \endcond
+
+namespace grmhd {
+namespace GhValenciaDivClean {
+/// %Tags for the Valencia formulation of the ideal GRMHD equations
+/// with divergence cleaning.
+namespace Tags {
+
+/// The characteristic speeds
+struct CharacteristicSpeeds : db::SimpleTag {
+  using type = std::array<DataVector, 13>;
+};
+
+/// The largest characteristic speed at any point
+struct LargestCharacteristicSpeed : db::SimpleTag {
+  using type = double;
+};
+}  // namespace Tags
+}  // namespace GhValenciaDivClean
+}  // namespace grmhd

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/TagsDeclarations.hpp
@@ -1,0 +1,21 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/IndexType.hpp"
+
+/// \cond
+class DataVector;
+
+namespace grmhd {
+namespace GhValenciaDivClean {
+namespace Tags {
+struct CharacteristicSpeeds;
+struct LargestCharacteristicSpeed;
+}  // namespace Tags
+}  // namespace GhValenciaDivClean
+}  // namespace grmhd
+/// \endcond

--- a/tests/Unit/Evolution/Systems/GrMhd/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+add_subdirectory(GhValenciaDivClean)
 add_subdirectory(ValenciaDivClean)

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_GhValenciaDivClean")
+
+set(LIBRARY_SOURCES
+  Test_Characteristics.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "Evolution/Systems/GrMhd/GhValenciaDivClean"
+  "${LIBRARY_SOURCES}"
+  "DomainHelpers;Framework;GeneralRelativityHelpers;HydroHelpers;ValenciaDivClean;GhValenciaDivClean"
+  )

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/TestFunctions.py
@@ -1,0 +1,34 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+from Evolution.Systems.GeneralizedHarmonic.TestFunctions import (
+    char_speed_upsi, char_speed_uzero, char_speed_uplus, char_speed_uminus)
+from Evolution.Systems.GrMhd.ValenciaDivClean.TestFunctions import\
+    characteristic_speeds as char_speeds_mhd
+
+
+# Functions for testing Characteristics.cpp
+def characteristic_speeds(lapse, shift, spatial_velocity,
+                          spatial_velocity_sqrd, sound_speed_sqrd,
+                          alfven_speed_sqrd, normal_oneform,
+                          gh_constraint_gamma1):
+    return list(
+        np.append(
+            char_speeds_mhd(lapse, shift, spatial_velocity,
+                            spatial_velocity_sqrd, sound_speed_sqrd,
+                            alfven_speed_sqrd, normal_oneform),
+            np.array([
+                char_speed_upsi(gh_constraint_gamma1, lapse, shift,
+                                normal_oneform),
+                char_speed_uzero(gh_constraint_gamma1, lapse, shift,
+                                 normal_oneform),
+                char_speed_uplus(gh_constraint_gamma1, lapse, shift,
+                                 normal_oneform),
+                char_speed_uminus(gh_constraint_gamma1, lapse, shift,
+                                  normal_oneform)
+            ])))
+
+
+# End functions for testing Characteristics.cpp

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Test_Characteristics.cpp
@@ -1,0 +1,113 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/Characteristics.hpp"
+#include "Framework/Pypp.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Helpers/Domain/DomainTestHelpers.hpp"
+#include "Helpers/PointwiseFunctions/GeneralRelativity/TestHelpers.hpp"
+#include "Helpers/PointwiseFunctions/Hydro/TestHelpers.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"  // IWYU pragma: keep
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+
+// IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
+// IWYU pragma: no_forward_declare Tensor
+
+namespace {
+void test_with_normal_along_coordinate_axes(
+    const DataVector& used_for_size) noexcept {
+  MAKE_GENERATOR(generator);
+  namespace helper = TestHelpers::hydro;
+  namespace gr_helper = TestHelpers::gr;
+  const auto nn_gen = make_not_null(&generator);
+  const auto rest_mass_density = helper::random_density(nn_gen, used_for_size);
+  EquationsOfState::PolytropicFluid<true> eos(0.001, 4.0 / 3.0);
+  const auto specific_internal_energy =
+      eos.specific_internal_energy_from_density(rest_mass_density);
+  const auto specific_enthalpy =
+      eos.specific_enthalpy_from_density(rest_mass_density);
+
+  const auto lapse = gr_helper::random_lapse(nn_gen, used_for_size);
+  const auto shift = gr_helper::random_shift<3>(nn_gen, used_for_size);
+  const auto spatial_metric =
+      gr_helper::random_spatial_metric<3>(nn_gen, used_for_size);
+  const auto lorentz_factor =
+      helper::random_lorentz_factor(nn_gen, used_for_size);
+  const auto gh_gamma1 = gr_helper::random_lapse(nn_gen, used_for_size);
+  const auto spatial_velocity =
+      helper::random_velocity(nn_gen, lorentz_factor, spatial_metric);
+  const auto spatial_velocity_squared =
+      dot_product(spatial_velocity, spatial_velocity, spatial_metric);
+
+  const auto magnetic_field = helper::random_magnetic_field(
+      nn_gen, eos.pressure_from_density(rest_mass_density), spatial_metric);
+  const auto magnetic_field_squared =
+      dot_product(magnetic_field, magnetic_field, spatial_metric);
+  const auto magnetic_field_dot_spatial_velocity =
+      dot_product(spatial_velocity, magnetic_field, spatial_metric);
+  const DataVector comoving_magnetic_field_squared =
+      get(magnetic_field_squared) / square(get(lorentz_factor)) +
+      square(get(magnetic_field_dot_spatial_velocity));
+  Scalar<DataVector> alfven_speed_squared{
+      comoving_magnetic_field_squared /
+      (comoving_magnetic_field_squared +
+       get(rest_mass_density) * get(specific_enthalpy))};
+  Scalar<DataVector> sound_speed_squared{
+      (get(eos.chi_from_density(rest_mass_density)) +
+       get(eos.kappa_times_p_over_rho_squared_from_density(
+           rest_mass_density))) /
+      get(specific_enthalpy)};
+
+  for (const auto& direction : Direction<3>::all_directions()) {
+    const auto normal = unit_basis_form(
+        direction, determinant_and_inverse(spatial_metric).second);
+    const auto& eos_base =
+        static_cast<const EquationsOfState::EquationOfState<true, 1>&>(eos);
+    Approx custom_approx = Approx::custom().epsilon(1.e-10);
+
+    CHECK_ITERABLE_CUSTOM_APPROX(
+        grmhd::GhValenciaDivClean::characteristic_speeds(
+            rest_mass_density, specific_internal_energy, specific_enthalpy,
+            spatial_velocity, lorentz_factor, magnetic_field, lapse, shift,
+            spatial_metric, normal, eos_base, gh_gamma1),
+        (pypp::call<std::array<DataVector, 13>>(
+            "Evolution.Systems.GrMhd.GhValenciaDivClean.TestFunctions",
+            "characteristic_speeds", lapse, shift, spatial_velocity,
+            spatial_velocity_squared, sound_speed_squared, alfven_speed_squared,
+            normal, gh_gamma1)),
+        custom_approx);
+  }
+}
+
+struct SomeEosType {
+  static constexpr size_t thermodynamic_dim = 3;
+};
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.GrMhd.GhValenciaDivClean.Characteristics",
+    "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{""};
+
+  TestHelpers::db::test_compute_tag<
+      grmhd::GhValenciaDivClean::Tags::CharacteristicSpeedsCompute<
+          SomeEosType>>("CharacteristicSpeeds");
+
+  // Test with aligned normals to check the code works
+  // with vector components being 0.
+  const DataVector dv(5);
+  test_with_normal_along_coordinate_axes(dv);
+}

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/__init__.py
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/__init__.py
@@ -1,0 +1,2 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.


### PR DESCRIPTION
## Proposed changes

Add functions to compute characteristic speeds of the valencia divergence cleaning evolution system in a dynamical spacetime evolved using the generalized harmonic formulation.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.