### PR TITLE
Instantiate Fastflow and its dependents for Frame::Grid.

### DIFF
--- a/src/ApparentHorizons/FastFlow.cpp
+++ b/src/ApparentHorizons/FastFlow.cpp
@@ -23,6 +23,7 @@
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 // IWYU pragma: no_forward_declare Tensor
@@ -354,13 +355,17 @@ FastFlow::FlowType Options::create_from_yaml<FastFlow::FlowType>::create<void>(
                                         "one of Jacobi, Curvature, Fast.");
 }
 
-template size_t FastFlow::current_l_mesh(
-    const Strahlkorper<Frame::Inertial>& strahlkorper) const noexcept;
-
-template std::pair<FastFlow::Status, FastFlow::IterInfo>
-FastFlow::iterate_horizon_finder<Frame::Inertial>(
-    const gsl::not_null<Strahlkorper<Frame::Inertial>*> current_strahlkorper,
-    const tnsr::II<DataVector, 3, Frame::Inertial>& upper_spatial_metric,
-    const tnsr::ii<DataVector, 3, Frame::Inertial>& extrinsic_curvature,
-    const tnsr::Ijj<DataVector, 3, Frame::Inertial>&
-        christoffel_2nd_kind) noexcept;
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define INSTANTIATE(_, data)                                                \
+  template size_t FastFlow::current_l_mesh(                                 \
+      const Strahlkorper<FRAME(data)>& strahlkorper) const noexcept;        \
+  template std::pair<FastFlow::Status, FastFlow::IterInfo>                  \
+  FastFlow::iterate_horizon_finder<FRAME(data)>(                            \
+      const gsl::not_null<Strahlkorper<FRAME(data)>*> current_strahlkorper, \
+      const tnsr::II<DataVector, 3, FRAME(data)>& upper_spatial_metric,     \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& extrinsic_curvature,      \
+      const tnsr::Ijj<DataVector, 3, FRAME(data)>&                          \
+          christoffel_2nd_kind) noexcept;
+GENERATE_INSTANTIATIONS(INSTANTIATE, (Frame::Grid, Frame::Inertial))
+#undef INSTANTIATE
+#undef FRAME

--- a/src/ApparentHorizons/Strahlkorper.cpp
+++ b/src/ApparentHorizons/Strahlkorper.cpp
@@ -143,3 +143,4 @@ bool Strahlkorper<Frame>::point_is_contained(
 }
 
 template class Strahlkorper<Frame::Inertial>;
+template class Strahlkorper<Frame::Grid>;

--- a/src/ApparentHorizons/StrahlkorperGr.cpp
+++ b/src/ApparentHorizons/StrahlkorperGr.cpp
@@ -22,6 +22,7 @@
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
@@ -812,146 +813,141 @@ double christodoulou_mass(const double dimensionful_spin_magnitude,
 }
 }  // namespace StrahlkorperGr
 
-template void StrahlkorperGr::unit_normal_one_form<Frame::Inertial>(
-    const gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*> result,
-    const tnsr::i<DataVector, 3, Frame::Inertial>& normal_one_form,
-    const DataVector& one_over_one_form_magnitude) noexcept;
-template tnsr::i<DataVector, 3, Frame::Inertial>
-StrahlkorperGr::unit_normal_one_form<Frame::Inertial>(
-    const tnsr::i<DataVector, 3, Frame::Inertial>& normal_one_form,
-    const DataVector& one_over_one_form_magnitude) noexcept;
-
-template void StrahlkorperGr::grad_unit_normal_one_form<Frame::Inertial>(
-    gsl::not_null<tnsr::ii<DataVector, 3, Frame::Inertial>*> result,
-    const tnsr::i<DataVector, 3, Frame::Inertial>& r_hat,
-    const DataVector& radius,
-    const tnsr::i<DataVector, 3, Frame::Inertial>& unit_normal_one_form,
-    const tnsr::ii<DataVector, 3, Frame::Inertial>& d2x_radius,
-    const DataVector& one_over_one_form_magnitude,
-    const tnsr::Ijj<DataVector, 3, Frame::Inertial>&
-        christoffel_2nd_kind) noexcept;
-template tnsr::ii<DataVector, 3, Frame::Inertial>
-StrahlkorperGr::grad_unit_normal_one_form<Frame::Inertial>(
-    const tnsr::i<DataVector, 3, Frame::Inertial>& r_hat,
-    const DataVector& radius,
-    const tnsr::i<DataVector, 3, Frame::Inertial>& unit_normal_one_form,
-    const tnsr::ii<DataVector, 3, Frame::Inertial>& d2x_radius,
-    const DataVector& one_over_one_form_magnitude,
-    const tnsr::Ijj<DataVector, 3, Frame::Inertial>&
-        christoffel_2nd_kind) noexcept;
-
-template void StrahlkorperGr::inverse_surface_metric<Frame::Inertial>(
-    const gsl::not_null<tnsr::II<DataVector, 3, Frame::Inertial>*> result,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& unit_normal_vector,
-    const tnsr::II<DataVector, 3, Frame::Inertial>&
-        upper_spatial_metric) noexcept;
-template tnsr::II<DataVector, 3, Frame::Inertial>
-StrahlkorperGr::inverse_surface_metric<Frame::Inertial>(
-    const tnsr::I<DataVector, 3, Frame::Inertial>& unit_normal_vector,
-    const tnsr::II<DataVector, 3, Frame::Inertial>&
-        upper_spatial_metric) noexcept;
-
-template void StrahlkorperGr::expansion<Frame::Inertial>(
-    const gsl::not_null<Scalar<DataVector>*> result,
-    const tnsr::ii<DataVector, 3, Frame::Inertial>& grad_normal,
-    const tnsr::II<DataVector, 3, Frame::Inertial>& inverse_surface_metric,
-    const tnsr::ii<DataVector, 3, Frame::Inertial>&
-        extrinsic_curvature) noexcept;
-template Scalar<DataVector> StrahlkorperGr::expansion<Frame::Inertial>(
-    const tnsr::ii<DataVector, 3, Frame::Inertial>& grad_normal,
-    const tnsr::II<DataVector, 3, Frame::Inertial>& inverse_surface_metric,
-    const tnsr::ii<DataVector, 3, Frame::Inertial>&
-        extrinsic_curvature) noexcept;
-
-template void StrahlkorperGr::extrinsic_curvature<Frame::Inertial>(
-    const gsl::not_null<tnsr::ii<DataVector, 3, Frame::Inertial>*> result,
-    const tnsr::ii<DataVector, 3, Frame::Inertial>& grad_normal,
-    const tnsr::i<DataVector, 3, Frame::Inertial>& unit_normal_one_form,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& unit_normal_vector) noexcept;
-template tnsr::ii<DataVector, 3, Frame::Inertial>
-StrahlkorperGr::extrinsic_curvature<Frame::Inertial>(
-    const tnsr::ii<DataVector, 3, Frame::Inertial>& grad_normal,
-    const tnsr::i<DataVector, 3, Frame::Inertial>& unit_normal_one_form,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& unit_normal_vector) noexcept;
-
-template void StrahlkorperGr::ricci_scalar<Frame::Inertial>(
-    const gsl::not_null<Scalar<DataVector>*> result,
-    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_ricci_tensor,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& unit_normal_vector,
-    const tnsr::ii<DataVector, 3, Frame::Inertial>& extrinsic_curvature,
-    const tnsr::II<DataVector, 3, Frame::Inertial>&
-        upper_spatial_metric) noexcept;
-template Scalar<DataVector> StrahlkorperGr::ricci_scalar<Frame::Inertial>(
-    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_ricci_tensor,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& unit_normal_vector,
-    const tnsr::ii<DataVector, 3, Frame::Inertial>& extrinsic_curvature,
-    const tnsr::II<DataVector, 3, Frame::Inertial>&
-        upper_spatial_metric) noexcept;
-
-template void StrahlkorperGr::area_element<Frame::Inertial>(
-    const gsl::not_null<Scalar<DataVector>*> result,
-    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
-    const StrahlkorperTags::aliases::Jacobian<Frame::Inertial>& jacobian,
-    const tnsr::i<DataVector, 3, Frame::Inertial>& normal_one_form,
-    const DataVector& radius,
-    const tnsr::i<DataVector, 3, Frame::Inertial>& r_hat) noexcept;
-template Scalar<DataVector> StrahlkorperGr::area_element<Frame::Inertial>(
-    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
-    const StrahlkorperTags::aliases::Jacobian<Frame::Inertial>& jacobian,
-    const tnsr::i<DataVector, 3, Frame::Inertial>& normal_one_form,
-    const DataVector& radius,
-    const tnsr::i<DataVector, 3, Frame::Inertial>& r_hat) noexcept;
-
-template void StrahlkorperGr::euclidean_area_element<Frame::Inertial>(
-    const gsl::not_null<Scalar<DataVector>*> result,
-    const StrahlkorperTags::aliases::Jacobian<Frame::Inertial>& jacobian,
-    const tnsr::i<DataVector, 3, Frame::Inertial>& normal_one_form,
-    const DataVector& radius,
-    const tnsr::i<DataVector, 3, Frame::Inertial>& r_hat) noexcept;
-template Scalar<DataVector>
-StrahlkorperGr::euclidean_area_element<Frame::Inertial>(
-    const StrahlkorperTags::aliases::Jacobian<Frame::Inertial>& jacobian,
-    const tnsr::i<DataVector, 3, Frame::Inertial>& normal_one_form,
-    const DataVector& radius,
-    const tnsr::i<DataVector, 3, Frame::Inertial>& r_hat) noexcept;
-
-template double StrahlkorperGr::surface_integral_of_scalar(
-    const Scalar<DataVector>& area_element, const Scalar<DataVector>& scalar,
-    const Strahlkorper<Frame::Inertial>& strahlkorper) noexcept;
-
-template
-double StrahlkorperGr::euclidean_surface_integral_of_vector(
-    const Scalar<DataVector>& area_element,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& vector,
-    const tnsr::i<DataVector, 3, Frame::Inertial>& normal_one_form,
-    const Strahlkorper<Frame::Inertial>& strahlkorper) noexcept;
-
-template void StrahlkorperGr::spin_function<Frame::Inertial>(
-    const gsl::not_null<Scalar<DataVector>*> result,
-    const StrahlkorperTags::aliases::Jacobian<Frame::Inertial>& tangents,
-    const Strahlkorper<Frame::Inertial>& strahlkorper,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& unit_normal_vector,
-    const Scalar<DataVector>& area_element,
-    const tnsr::ii<DataVector, 3, Frame::Inertial>&
-        extrinsic_curvature) noexcept;
-template Scalar<DataVector> StrahlkorperGr::spin_function<Frame::Inertial>(
-    const StrahlkorperTags::aliases::Jacobian<Frame::Inertial>& tangents,
-    const Strahlkorper<Frame::Inertial>& strahlkorper,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& unit_normal_vector,
-    const Scalar<DataVector>& area_element,
-    const tnsr::ii<DataVector, 3, Frame::Inertial>&
-        extrinsic_curvature) noexcept;
-
-template double StrahlkorperGr::dimensionful_spin_magnitude<Frame::Inertial>(
-    const Scalar<DataVector>& ricci_scalar,
-    const Scalar<DataVector>& spin_function,
-    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
-    const StrahlkorperTags::aliases::Jacobian<Frame::Inertial>& tangents,
-    const YlmSpherepack& ylm, const Scalar<DataVector>& area_element) noexcept;
-
-template std::array<double, 3> StrahlkorperGr::spin_vector<Frame::Inertial>(
-    const double spin_magnitude, const Scalar<DataVector>& area_element,
-    const Scalar<DataVector>& radius,
-    const tnsr::i<DataVector, 3, Frame::Inertial>& r_hat,
-    const Scalar<DataVector>& ricci_scalar,
-    const Scalar<DataVector>& spin_function, const YlmSpherepack& ylm) noexcept;
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define INSTANTIATE(_, data)                                                   \
+  template void StrahlkorperGr::unit_normal_one_form<FRAME(data)>(             \
+      const gsl::not_null<tnsr::i<DataVector, 3, FRAME(data)>*> result,        \
+      const tnsr::i<DataVector, 3, FRAME(data)>& normal_one_form,              \
+      const DataVector& one_over_one_form_magnitude) noexcept;                 \
+  template tnsr::i<DataVector, 3, FRAME(data)>                                 \
+  StrahlkorperGr::unit_normal_one_form<FRAME(data)>(                           \
+      const tnsr::i<DataVector, 3, FRAME(data)>& normal_one_form,              \
+      const DataVector& one_over_one_form_magnitude) noexcept;                 \
+  template void StrahlkorperGr::grad_unit_normal_one_form<FRAME(data)>(        \
+      gsl::not_null<tnsr::ii<DataVector, 3, FRAME(data)>*> result,             \
+      const tnsr::i<DataVector, 3, FRAME(data)>& r_hat,                        \
+      const DataVector& radius,                                                \
+      const tnsr::i<DataVector, 3, FRAME(data)>& unit_normal_one_form,         \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& d2x_radius,                  \
+      const DataVector& one_over_one_form_magnitude,                           \
+      const tnsr::Ijj<DataVector, 3, FRAME(data)>&                             \
+          christoffel_2nd_kind) noexcept;                                      \
+  template tnsr::ii<DataVector, 3, FRAME(data)>                                \
+  StrahlkorperGr::grad_unit_normal_one_form<FRAME(data)>(                      \
+      const tnsr::i<DataVector, 3, FRAME(data)>& r_hat,                        \
+      const DataVector& radius,                                                \
+      const tnsr::i<DataVector, 3, FRAME(data)>& unit_normal_one_form,         \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& d2x_radius,                  \
+      const DataVector& one_over_one_form_magnitude,                           \
+      const tnsr::Ijj<DataVector, 3, FRAME(data)>&                             \
+          christoffel_2nd_kind) noexcept;                                      \
+  template void StrahlkorperGr::inverse_surface_metric<FRAME(data)>(           \
+      const gsl::not_null<tnsr::II<DataVector, 3, FRAME(data)>*> result,       \
+      const tnsr::I<DataVector, 3, FRAME(data)>& unit_normal_vector,           \
+      const tnsr::II<DataVector, 3, FRAME(data)>&                              \
+          upper_spatial_metric) noexcept;                                      \
+  template tnsr::II<DataVector, 3, FRAME(data)>                                \
+  StrahlkorperGr::inverse_surface_metric<FRAME(data)>(                         \
+      const tnsr::I<DataVector, 3, FRAME(data)>& unit_normal_vector,           \
+      const tnsr::II<DataVector, 3, FRAME(data)>&                              \
+          upper_spatial_metric) noexcept;                                      \
+  template void StrahlkorperGr::expansion<FRAME(data)>(                        \
+      const gsl::not_null<Scalar<DataVector>*> result,                         \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& grad_normal,                 \
+      const tnsr::II<DataVector, 3, FRAME(data)>& inverse_surface_metric,      \
+      const tnsr::ii<DataVector, 3, FRAME(data)>&                              \
+          extrinsic_curvature) noexcept;                                       \
+  template Scalar<DataVector> StrahlkorperGr::expansion<FRAME(data)>(          \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& grad_normal,                 \
+      const tnsr::II<DataVector, 3, FRAME(data)>& inverse_surface_metric,      \
+      const tnsr::ii<DataVector, 3, FRAME(data)>&                              \
+          extrinsic_curvature) noexcept;                                       \
+  template void StrahlkorperGr::extrinsic_curvature<FRAME(data)>(              \
+      const gsl::not_null<tnsr::ii<DataVector, 3, FRAME(data)>*> result,       \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& grad_normal,                 \
+      const tnsr::i<DataVector, 3, FRAME(data)>& unit_normal_one_form,         \
+      const tnsr::I<DataVector, 3, FRAME(data)>& unit_normal_vector) noexcept; \
+  template tnsr::ii<DataVector, 3, FRAME(data)>                                \
+  StrahlkorperGr::extrinsic_curvature<FRAME(data)>(                            \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& grad_normal,                 \
+      const tnsr::i<DataVector, 3, FRAME(data)>& unit_normal_one_form,         \
+      const tnsr::I<DataVector, 3, FRAME(data)>& unit_normal_vector) noexcept; \
+  template void StrahlkorperGr::ricci_scalar<FRAME(data)>(                     \
+      const gsl::not_null<Scalar<DataVector>*> result,                         \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& spatial_ricci_tensor,        \
+      const tnsr::I<DataVector, 3, FRAME(data)>& unit_normal_vector,           \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& extrinsic_curvature,         \
+      const tnsr::II<DataVector, 3, FRAME(data)>&                              \
+          upper_spatial_metric) noexcept;                                      \
+  template Scalar<DataVector> StrahlkorperGr::ricci_scalar<FRAME(data)>(       \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& spatial_ricci_tensor,        \
+      const tnsr::I<DataVector, 3, FRAME(data)>& unit_normal_vector,           \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& extrinsic_curvature,         \
+      const tnsr::II<DataVector, 3, FRAME(data)>&                              \
+          upper_spatial_metric) noexcept;                                      \
+  template void StrahlkorperGr::area_element<FRAME(data)>(                     \
+      const gsl::not_null<Scalar<DataVector>*> result,                         \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& spatial_metric,              \
+      const StrahlkorperTags::aliases::Jacobian<FRAME(data)>& jacobian,        \
+      const tnsr::i<DataVector, 3, FRAME(data)>& normal_one_form,              \
+      const DataVector& radius,                                                \
+      const tnsr::i<DataVector, 3, FRAME(data)>& r_hat) noexcept;              \
+  template Scalar<DataVector> StrahlkorperGr::area_element<FRAME(data)>(       \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& spatial_metric,              \
+      const StrahlkorperTags::aliases::Jacobian<FRAME(data)>& jacobian,        \
+      const tnsr::i<DataVector, 3, FRAME(data)>& normal_one_form,              \
+      const DataVector& radius,                                                \
+      const tnsr::i<DataVector, 3, FRAME(data)>& r_hat) noexcept;              \
+  template void StrahlkorperGr::euclidean_area_element<FRAME(data)>(           \
+      const gsl::not_null<Scalar<DataVector>*> result,                         \
+      const StrahlkorperTags::aliases::Jacobian<FRAME(data)>& jacobian,        \
+      const tnsr::i<DataVector, 3, FRAME(data)>& normal_one_form,              \
+      const DataVector& radius,                                                \
+      const tnsr::i<DataVector, 3, FRAME(data)>& r_hat) noexcept;              \
+  template Scalar<DataVector>                                                  \
+  StrahlkorperGr::euclidean_area_element<FRAME(data)>(                         \
+      const StrahlkorperTags::aliases::Jacobian<FRAME(data)>& jacobian,        \
+      const tnsr::i<DataVector, 3, FRAME(data)>& normal_one_form,              \
+      const DataVector& radius,                                                \
+      const tnsr::i<DataVector, 3, FRAME(data)>& r_hat) noexcept;              \
+  template double StrahlkorperGr::surface_integral_of_scalar(                  \
+      const Scalar<DataVector>& area_element,                                  \
+      const Scalar<DataVector>& scalar,                                        \
+      const Strahlkorper<FRAME(data)>& strahlkorper) noexcept;                 \
+  template double StrahlkorperGr::euclidean_surface_integral_of_vector(        \
+      const Scalar<DataVector>& area_element,                                  \
+      const tnsr::I<DataVector, 3, FRAME(data)>& vector,                       \
+      const tnsr::i<DataVector, 3, FRAME(data)>& normal_one_form,              \
+      const Strahlkorper<FRAME(data)>& strahlkorper) noexcept;                 \
+  template void StrahlkorperGr::spin_function<FRAME(data)>(                    \
+      const gsl::not_null<Scalar<DataVector>*> result,                         \
+      const StrahlkorperTags::aliases::Jacobian<FRAME(data)>& tangents,        \
+      const Strahlkorper<FRAME(data)>& strahlkorper,                           \
+      const tnsr::I<DataVector, 3, FRAME(data)>& unit_normal_vector,           \
+      const Scalar<DataVector>& area_element,                                  \
+      const tnsr::ii<DataVector, 3, FRAME(data)>&                              \
+          extrinsic_curvature) noexcept;                                       \
+  template Scalar<DataVector> StrahlkorperGr::spin_function<FRAME(data)>(      \
+      const StrahlkorperTags::aliases::Jacobian<FRAME(data)>& tangents,        \
+      const Strahlkorper<FRAME(data)>& strahlkorper,                           \
+      const tnsr::I<DataVector, 3, FRAME(data)>& unit_normal_vector,           \
+      const Scalar<DataVector>& area_element,                                  \
+      const tnsr::ii<DataVector, 3, FRAME(data)>&                              \
+          extrinsic_curvature) noexcept;                                       \
+  template double StrahlkorperGr::dimensionful_spin_magnitude<FRAME(data)>(    \
+      const Scalar<DataVector>& ricci_scalar,                                  \
+      const Scalar<DataVector>& spin_function,                                 \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& spatial_metric,              \
+      const StrahlkorperTags::aliases::Jacobian<FRAME(data)>& tangents,        \
+      const YlmSpherepack& ylm,                                                \
+      const Scalar<DataVector>& area_element) noexcept;                        \
+  template std::array<double, 3> StrahlkorperGr::spin_vector<FRAME(data)>(     \
+      const double spin_magnitude, const Scalar<DataVector>& area_element,     \
+      const Scalar<DataVector>& radius,                                        \
+      const tnsr::i<DataVector, 3, FRAME(data)>& r_hat,                        \
+      const Scalar<DataVector>& ricci_scalar,                                  \
+      const Scalar<DataVector>& spin_function,                                 \
+      const YlmSpherepack& ylm) noexcept;
+GENERATE_INSTANTIATIONS(INSTANTIATE, (Frame::Grid, Frame::Inertial))
+#undef INSTANTIATE
+#undef FRAME

--- a/src/ApparentHorizons/Tags.cpp
+++ b/src/ApparentHorizons/Tags.cpp
@@ -10,6 +10,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
@@ -257,17 +258,20 @@ void TangentsCompute<Frame>::function(
 
 }  // namespace StrahlkorperTags
 
-namespace StrahlkorperTags {
-template struct ThetaPhiCompute<Frame::Inertial>;
-template struct RhatCompute<Frame::Inertial>;
-template struct JacobianCompute<Frame::Inertial>;
-template struct InvJacobianCompute<Frame::Inertial>;
-template struct InvHessianCompute<Frame::Inertial>;
-template struct RadiusCompute<Frame::Inertial>;
-template struct CartesianCoordsCompute<Frame::Inertial>;
-template struct DxRadiusCompute<Frame::Inertial>;
-template struct D2xRadiusCompute<Frame::Inertial>;
-template struct LaplacianRadiusCompute<Frame::Inertial>;
-template struct NormalOneFormCompute<Frame::Inertial>;
-template struct TangentsCompute<Frame::Inertial>;
-}  // namespace StrahlkorperTags
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define INSTANTIATE(_, data)                                             \
+  template struct StrahlkorperTags::ThetaPhiCompute<FRAME(data)>;        \
+  template struct StrahlkorperTags::RhatCompute<FRAME(data)>;            \
+  template struct StrahlkorperTags::JacobianCompute<FRAME(data)>;        \
+  template struct StrahlkorperTags::InvJacobianCompute<FRAME(data)>;     \
+  template struct StrahlkorperTags::InvHessianCompute<FRAME(data)>;      \
+  template struct StrahlkorperTags::RadiusCompute<FRAME(data)>;          \
+  template struct StrahlkorperTags::CartesianCoordsCompute<FRAME(data)>; \
+  template struct StrahlkorperTags::DxRadiusCompute<FRAME(data)>;        \
+  template struct StrahlkorperTags::D2xRadiusCompute<FRAME(data)>;       \
+  template struct StrahlkorperTags::LaplacianRadiusCompute<FRAME(data)>; \
+  template struct StrahlkorperTags::NormalOneFormCompute<FRAME(data)>;   \
+  template struct StrahlkorperTags::TangentsCompute<FRAME(data)>;
+GENERATE_INSTANTIATIONS(INSTANTIATE, (Frame::Grid, Frame::Inertial))
+#undef INSTANTIATE
+#undef FRAME

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.cpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.cpp
@@ -50,7 +50,7 @@ bool operator!=(const ApparentHorizon<Frame>& lhs,
                            const ApparentHorizon<FRAME(data)>& rhs) noexcept; \
   template bool operator!=(const ApparentHorizon<FRAME(data)>& lhs,           \
                            const ApparentHorizon<FRAME(data)>& rhs) noexcept;
-GENERATE_INSTANTIATIONS(INSTANTIATE, (::Frame::Inertial))
+GENERATE_INSTANTIATIONS(INSTANTIATE, (::Frame::Inertial, ::Frame::Grid))
 
 #undef FRAME
 #undef INSTANTIATE

--- a/src/PointwiseFunctions/GeneralRelativity/Christoffel.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Christoffel.cpp
@@ -59,7 +59,8 @@ tnsr::abb<DataType, SpatialDim, Frame, Index> christoffel_first_kind(
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
                         (Frame::Grid, Frame::Inertial,
-                         Frame::Spherical<Frame::Inertial>),
+                         Frame::Spherical<Frame::Inertial>,
+                         Frame::Spherical<Frame::Grid>),
                         (IndexType::Spatial, IndexType::Spacetime))
 
 #undef DIM

--- a/src/PointwiseFunctions/GeneralRelativity/IndexManipulation.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/IndexManipulation.cpp
@@ -139,7 +139,8 @@ void trace(
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
                         (Frame::Grid, Frame::Inertial,
-                         Frame::Spherical<Frame::Inertial>),
+                         Frame::Spherical<Frame::Inertial>,
+                         Frame::Spherical<Frame::Grid>),
                         (SpatialIndex, SpacetimeIndex), (UpLo::Lo, UpLo::Up),
                         (UpLo::Lo, UpLo::Up))
 


### PR DESCRIPTION
## Proposed changes

Fastflow and things it depends on are instantiated only for Frame::Inertial.
If we want to find horizons in the grid frame, they need to be instantiated for Frame::Grid,
which is what this PR does.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
