### PR TITLE
Add walltime output

### DIFF
--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStep.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStep.cpp
@@ -88,6 +88,15 @@ struct MockContributeReductionData {
       *results = {observation_id, subfile_name, reduction_names,
                   std::move(reduction_data), formatter.has_value()};
     }
+
+    if (formatter.has_value()) {
+      const auto formatted_msg = (*formatter)(
+        0.123, 3, 1.560, 3.141, 2.7818, 1023.3, 9.32, 4.148
+      );
+      CHECK(formatted_msg ==
+        "Simulation time: 0.123000s\n"
+        "  Wall time: 9.320000s (min) - 4.148000s (max)");
+    }
   }
 };
 
@@ -227,6 +236,8 @@ void test_observe(const Observer& observer,
   CHECK(std::get<4>(reduction_data.data()) == expected_max_step);
   CHECK(results->reduction_names[5] == "Effective time step");
   CHECK(std::get<5>(reduction_data.data()) == approx(expected_effective_step));
+  CHECK(results->reduction_names[6] == "Minimum Walltime");
+  CHECK(results->reduction_names[7] == "Maximum Walltime");
 }
 }  // namespace
 


### PR DESCRIPTION
## Proposed changes

This PR simply outputs the minimum and maximum walltime
on top of the simulation time when using the `ObserveTimeStep`
event and the `PrintTimeToTerminal `option is true.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
