### PR TITLE
Add subcell action labels and select method action

### DIFF
--- a/src/Evolution/DgSubcell/Actions/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/Actions/CMakeLists.txt
@@ -10,4 +10,5 @@ spectre_target_headers(
   Actions.hpp
   Initialize.hpp
   Labels.hpp
+  SelectNumericalMethod.hpp
   )

--- a/src/Evolution/DgSubcell/Actions/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/Actions/CMakeLists.txt
@@ -9,4 +9,5 @@ spectre_target_headers(
   HEADERS
   Actions.hpp
   Initialize.hpp
+  Labels.hpp
   )

--- a/src/Evolution/DgSubcell/Actions/Labels.hpp
+++ b/src/Evolution/DgSubcell/Actions/Labels.hpp
@@ -1,0 +1,21 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace evolution::dg::subcell::Actions {
+/// Labels used to navigate the action list when using a DG-subcell scheme
+namespace Labels {
+/// Label marking the start of the unlimited DG solver
+struct BeginDg {};
+/// Label marking the end of the `step_actions`, i.e. the end of both the
+/// unlimited DG solver and the subcell solver.
+struct EndOfSolvers {};
+/// Label marking the start of the subcell solver
+struct BeginSubcell {};
+/// Label marking the part of the subcell solver that the unlimited DG solver
+/// jumps to after rolling back the unlimited DG step because it was
+/// inadmissible.
+struct BeginSubcellAfterDgRollback {};
+}  // namespace Labels
+}  // namespace evolution::dg::subcell::Actions

--- a/src/Evolution/DgSubcell/Actions/SelectNumericalMethod.hpp
+++ b/src/Evolution/DgSubcell/Actions/SelectNumericalMethod.hpp
@@ -1,0 +1,69 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Evolution/DgSubcell/Actions/Labels.hpp"
+#include "Evolution/DgSubcell/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
+#include "Parallel/Actions/Goto.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
+namespace tuples {
+template <typename...>
+class TaggedTuple;
+}  // namespace tuples
+/// \endcond
+
+namespace evolution::dg::subcell::Actions {
+/*!
+ * \brief Goes to `Labels::BeginDg` or `Labels::BeginSubcell` depending on
+ * whether the active grid is `Dg` or `Subcell`.
+ *
+ * GlobalCache: nothing
+ *
+ * DataBox:
+ * - Uses:
+ *   - `subcell::Tags::ActiveGrid`
+ */
+struct SelectNumericalMethod {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&, bool, size_t> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    // Note: we jump to the `Label+1` because the label actions don't do
+    // anything anyway
+    if (db::get<Tags::ActiveGrid>(box) == subcell::ActiveGrid::Dg) {
+      const size_t dg_index =
+          tmpl::index_of<ActionList, ::Actions::Label<Labels::BeginDg>>::value +
+          1;
+      return {std::move(box), false, dg_index};
+    } else if (db::get<Tags::ActiveGrid>(box) == subcell::ActiveGrid::Subcell) {
+      const size_t subcell_index =
+          tmpl::index_of<ActionList,
+                         ::Actions::Label<Labels::BeginSubcell>>::value +
+          1;
+      return {std::move(box), false, subcell_index};
+    }
+    ERROR(
+        "Only know DG and subcell active grids for selecting the numerical "
+        "method.");
+  }
+};
+}  // namespace evolution::dg::subcell::Actions

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_SelectNumericalMethod.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_SelectNumericalMethod.cpp
@@ -1,0 +1,72 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "Evolution/DgSubcell/Actions/Labels.hpp"
+#include "Evolution/DgSubcell/Actions/SelectNumericalMethod.hpp"
+#include "Evolution/DgSubcell/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Parallel/Actions/Goto.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+// Use Actions::Label<DummyLabel> actions to space out the action list so we can
+// check that SelectNumericalMethod is jumping to the right locations.
+template <size_t Index>
+struct DummyLabel {};
+
+template <typename Metavariables>
+struct component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using const_global_cache_tag_list = tmpl::list<>;
+
+  using initial_tags = tmpl::list<evolution::dg::subcell::Tags::ActiveGrid>;
+
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      tmpl::list<
+          ActionTesting::InitializeDataBox<initial_tags>,
+          evolution::dg::subcell::Actions::SelectNumericalMethod,
+          Actions::Label<DummyLabel<0>>,
+          Actions::Label<evolution::dg::subcell::Actions::Labels::BeginDg>,
+          Actions::Label<DummyLabel<1>>,
+          Actions::Label<evolution::dg::subcell::Actions::Labels::BeginSubcell>,
+          Actions::Label<DummyLabel<2>>>>>;
+};
+
+struct Metavariables {
+  using component_list = tmpl::list<component<Metavariables>>;
+  enum class Phase { Initialization, Exit };
+};
+
+void test(const evolution::dg::subcell::ActiveGrid active_grid) {
+  CAPTURE(active_grid);
+  using metavars = Metavariables;
+  using comp = component<metavars>;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
+  MockRuntimeSystem runner{{}};
+  ActionTesting::emplace_array_component_and_initialize<comp>(
+      &runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0}, 0,
+      {active_grid});
+
+  // Invoke the SelectNumericalMethod action on the runner
+  ActionTesting::next_action<comp>(make_not_null(&runner), 0);
+  // SelectNumericalMethod jumps to `index_of<Label>+1`
+  const size_t expected_next_action_index =
+      (active_grid == evolution::dg::subcell::ActiveGrid::Dg ? 4 : 6);
+  CHECK(ActionTesting::get_next_action_index<comp>(runner, 0) ==
+        expected_next_action_index);
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Actions.SelectNumericalMethod",
+                  "[Evolution][Unit]") {
+  test(evolution::dg::subcell::ActiveGrid::Dg);
+  test(evolution::dg::subcell::ActiveGrid::Subcell);
+}
+}  // namespace

--- a/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
+++ b/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_DgSubcell")
 
 set(LIBRARY_SOURCES
   Actions/Test_Initialize.cpp
+  Actions/Test_SelectNumericalMethod.cpp
   Test_ActiveGrid.cpp
   Test_Matrices.cpp
   Test_Mesh.cpp
@@ -34,5 +35,6 @@ target_link_libraries(
   Domain
   DgSubcell
   DgSubcellHelpers
+  Parallel
   Spectral
   )


### PR DESCRIPTION
## Proposed changes

- Add labels that are used to select whether we use DG or subcell
- Add action that jumps to the DG or subcell label by checking `Tags::ActiveGrid`

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
