### PR TITLE
Change wheeler openmpi module down to openmpi/2.0.0

### DIFF
--- a/support/Environments/wheeler_clang.sh
+++ b/support/Environments/wheeler_clang.sh
@@ -19,7 +19,7 @@ spectre_unload_modules() {
     module unload openblas/0.2.18
     module unload papi/5.5.1
     module unload yaml-cpp/master
-    module unload openmpi/2.0.1
+    module unload openmpi/2.0.0
     module unload cmake/3.18.2
     module unload ninja/1.10.0
     module unload doxygen/1.8.13
@@ -42,7 +42,7 @@ spectre_load_modules() {
     module load openblas/0.2.18
     module load papi/5.5.1
     module load yaml-cpp/master
-    module load openmpi/2.0.1
+    module load openmpi/2.0.0
     module load cmake/3.18.2
     module load ninja/1.10.0
     module load doxygen/1.8.13

--- a/support/Environments/wheeler_gcc.sh
+++ b/support/Environments/wheeler_gcc.sh
@@ -19,7 +19,7 @@ spectre_unload_modules() {
     module unload openblas/0.2.18
     module unload papi/5.5.1
     module unload yaml-cpp/master
-    module unload openmpi/2.0.1
+    module unload openmpi/2.0.0
     module unload cmake/3.18.2
     module unload ninja/1.10.0
     module unload doxygen/1.8.13
@@ -42,7 +42,7 @@ spectre_load_modules() {
     module load openblas/0.2.18
     module load papi/5.5.1
     module load yaml-cpp/master
-    module load openmpi/2.0.1
+    module load openmpi/2.0.0
     module load cmake/3.18.2
     module load ninja/1.10.0
     module load doxygen/1.8.13


### PR DESCRIPTION
wheeler's openmpi/2.0.1 module currently does not work correctly -- for now, I suggest just using 2.0.0. In the near future, I will test charm++ using non-openmpi options and likely switch it over to a different communications method, at which point we can drop the openmpi requirement from the environment.

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
