### PR TITLE
Update parallelization docs on action types

### DIFF
--- a/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
@@ -153,14 +153,16 @@ struct nodegroup_check_first_result {
 };
 
 struct nodegroup_threaded_receive {
+  // [threaded_action_example]
   template <typename ParallelComponent, typename... DbTags,
-            typename Metavariables, typename ArrayIndex, typename NodeLock,
+            typename Metavariables, typename ArrayIndex,
             Requires<sizeof...(DbTags) == 3> = nullptr>
   static void apply(db::DataBox<tmpl::list<DbTags...>>& box,
                     Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/,
-                    const gsl::not_null<NodeLock*> node_lock,
+                    const gsl::not_null<Parallel::NodeLock*> node_lock,
                     const int& id_of_array) {
+    // [threaded_action_example]
     node_lock->lock();
     db::mutate<Tags::vector_of_array_indexs, Tags::total_receives_on_node>(
         make_not_null(&box),
@@ -217,9 +219,7 @@ struct reduce_to_nodegroup {
         *(Parallel::get_parallel_component<
               NodegroupParallelComponent<Metavariables>>(cache)
               .ckLocalBranch());
-    // [simple_action_with_args]
     Parallel::simple_action<nodegroup_receive>(local_nodegroup, array_index);
-    // [simple_action_with_args]
   }
 };
 

--- a/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
@@ -76,7 +76,6 @@ struct ProcessErrorNorms {
 };
 // [reduce_rms_action]
 
-// [custom_reduction_action]
 struct ProcessCustomReductionAction {
   template <typename ParallelComponent, typename DbTags, typename Metavariables,
             typename ArrayIndex>
@@ -99,7 +98,6 @@ struct ProcessCustomReductionAction {
                           8 * reduced_int * number_of_1d_array_elements}));
   }
 };
-// [custom_reduction_action]
 
 template <class Metavariables>
 struct SingletonParallelComponent {
@@ -160,7 +158,6 @@ struct ArrayReduce {
                                                          my_proxy, array_proxy);
     // [contribute_to_rms_reduction]
 
-    // [custom_contribute_to_reduction_example]
     std::unordered_map<std::string, int> my_send_map;
     my_send_map["unity"] = array_index;
     my_send_map["double"] = 2 * array_index;
@@ -216,12 +213,9 @@ struct ArrayReduce {
     Parallel::contribute_to_reduction<ProcessCustomReductionAction>(
         ReductionType{10, my_send_map, std::vector<int>{array_index, 10, -8}},
         my_proxy, singleton_proxy);
-    // [custom_contribute_to_reduction_example]
-    // [custom_contribute_to_broadcast_reduction]
     Parallel::contribute_to_reduction<ProcessCustomReductionAction>(
         ReductionType{10, my_send_map, std::vector<int>{array_index, 10, -8}},
         my_proxy, array_proxy);
-    // [custom_contribute_to_broadcast_reduction]
   }
 };
 


### PR DESCRIPTION
[Rendered](http://hosting.astro.cornell.edu/~wthrowe/spectre_action_doc_pr/dev_guide_parallelization_foundations.html)

## Proposed changes

This is mostly reorganization of the text, but also adds docs on threaded actions, which were missing, and covers the return type of iterable actions better.

Relates to #3110.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
