### PR TITLE
Switch elliptic executables to new compact DG operator

### DIFF
--- a/src/Elliptic/Executables/Elasticity/CMakeLists.txt
+++ b/src/Elliptic/Executables/Elasticity/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBS_TO_LINK
   DomainCreators
   Elasticity
   ElasticityAnalyticData
+  ElasticityBoundaryConditions
   ElasticityPointwiseFunctions
   ElasticitySolutions
   Elliptic

--- a/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
+++ b/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
@@ -11,12 +11,8 @@
 #include "Elliptic/Actions/InitializeAnalyticSolution.hpp"
 #include "Elliptic/Actions/InitializeFields.hpp"
 #include "Elliptic/Actions/InitializeFixedSources.hpp"
+#include "Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp"
 #include "Elliptic/DiscontinuousGalerkin/DgElementArray.hpp"
-#include "Elliptic/DiscontinuousGalerkin/ImposeBoundaryConditions.hpp"
-#include "Elliptic/DiscontinuousGalerkin/ImposeInhomogeneousBoundaryConditionsOnSource.hpp"
-#include "Elliptic/DiscontinuousGalerkin/InitializeFirstOrderOperator.hpp"
-#include "Elliptic/DiscontinuousGalerkin/NumericalFluxes/FirstOrderInternalPenalty.hpp"
-#include "Elliptic/FirstOrderOperator.hpp"
 #include "Elliptic/Systems/Elasticity/FirstOrderSystem.hpp"
 #include "Elliptic/Systems/Elasticity/Tags.hpp"
 #include "Elliptic/Tags.hpp"
@@ -25,7 +21,6 @@
 #include "IO/Observer/Helpers.hpp"
 #include "IO/Observer/ObserverComponent.hpp"
 #include "NumericalAlgorithms/Convergence/Tags.hpp"
-#include "NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/FirstOrderScheme.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
@@ -36,11 +31,7 @@
 #include "Parallel/Reduction.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
-#include "ParallelAlgorithms/DiscontinuousGalerkin/CollectDataForFluxes.hpp"
-#include "ParallelAlgorithms/DiscontinuousGalerkin/FluxCommunication.hpp"
 #include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeDomain.hpp"
-#include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeInterfaces.hpp"
-#include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeMortars.hpp"
 #include "ParallelAlgorithms/Events/ObserveErrorNorms.hpp"
 #include "ParallelAlgorithms/Events/ObserveFields.hpp"
 #include "ParallelAlgorithms/Events/ObserveVolumeIntegrals.hpp"
@@ -57,6 +48,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/Elasticity/Zero.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "PointwiseFunctions/Elasticity/PotentialEnergy.hpp"
+#include "PointwiseFunctions/Elasticity/Strain.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/Functional.hpp"
@@ -95,60 +87,54 @@ struct Metavariables {
   using background_tag = elliptic::Tags::Background<
       Elasticity::AnalyticData::AnalyticData<Dim, background_registrars>>;
 
-  // List the possible initial guesses. We currently only support the trivial
-  // "zero" initial guess. This will be generalized ASAP.
+  // List the possible initial guesses
   using initial_guess_registrars =
-      tmpl::list<Elasticity::Solutions::Registrars::Zero<Dim>>;
+      tmpl::append<tmpl::list<Elasticity::Solutions::Registrars::Zero<Dim>>,
+                   analytic_solution_registrars>;
   using initial_guess_tag = elliptic::Tags::InitialGuess<
       ::AnalyticData<Dim, initial_guess_registrars>>;
 
   static constexpr Options::String help{
       "Find the solution to a linear elasticity problem."};
 
-  using fluxes_computer_tag =
-      elliptic::Tags::FluxesComputer<typename system::fluxes_computer>;
-
-  // Only Dirichlet boundary conditions are currently supported, and they are
-  // are all imposed by analytic solutions right now. This will be generalized
-  // ASAP and this alias deleted.
-  using analytic_solution_tag = background_tag;
+  // These are the fields we solve for
+  using fields_tag = ::Tags::Variables<typename system::primal_fields>;
+  // These are the fixed sources, i.e. the RHS of the equations
+  using fixed_sources_tag = db::add_tag_prefix<::Tags::FixedSource, fields_tag>;
+  // This is the linear operator applied to the fields. We'll only use it to
+  // apply the operator to the initial guess, so an optimization would be to
+  // re-use the `operator_applied_to_vars_tag` below. This optimization needs a
+  // few minor changes to the parallel linear solver algorithm.
+  using operator_applied_to_fields_tag =
+      db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, fields_tag>;
 
   // The linear solver algorithm. We must use GMRES since the operator is
-  // not positive-definite for the first-order system.
+  // not guaranteed to be symmetric. It can be made symmetric by multiplying by
+  // the DG mass matrix.
   using linear_solver =
-      LinearSolver::gmres::Gmres<Metavariables, typename system::fields_tag,
+      LinearSolver::gmres::Gmres<Metavariables, fields_tag,
                                  SolveElasticity::OptionTags::GmresGroup,
                                  false>;
   using linear_solver_iteration_id =
       Convergence::Tags::IterationId<typename linear_solver::options_group>;
   // For the GMRES linear solver we need to apply the DG operator to its
   // internal "operand" in every iteration of the algorithm.
-  using linear_operand_tag = db::add_tag_prefix<LinearSolver::Tags::Operand,
-                                                typename system::fields_tag>;
-  using primal_variables = db::wrap_tags_in<LinearSolver::Tags::Operand,
-                                            typename system::primal_fields>;
-  using auxiliary_variables =
-      db::wrap_tags_in<LinearSolver::Tags::Operand,
-                       typename system::auxiliary_fields>;
-
-  // Parse numerical flux parameters from the input file to store in the cache.
-  using normal_dot_numerical_flux = Tags::NumericalFlux<
-      elliptic::dg::NumericalFluxes::FirstOrderInternalPenalty<
-          volume_dim, fluxes_computer_tag, primal_variables,
-          auxiliary_variables>>;
-  // Specify the DG boundary scheme. We use the strong first-order scheme here
-  // that only requires us to compute normals dotted into the first-order
-  // fluxes.
-  using boundary_scheme = dg::FirstOrderScheme::FirstOrderScheme<
-      volume_dim, linear_operand_tag,
-      db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo,
-                         linear_operand_tag>,
-      normal_dot_numerical_flux, linear_solver_iteration_id>;
+  using vars_tag = typename linear_solver::operand_tag;
+  using operator_applied_to_vars_tag =
+      db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, vars_tag>;
+  // We'll buffer the corresponding fluxes in this tag, but won't actually need
+  // to access them outside applying the operator
+  using fluxes_vars_tag =
+      ::Tags::Variables<db::wrap_tags_in<LinearSolver::Tags::Operand,
+                                         typename system::primal_fluxes>>;
 
   // Collect events and triggers
   // (public for use by the Charm++ registration code)
-  using observe_fields = typename system::fields_tag::tags_list;
-  using analytic_solution_fields = observe_fields;
+  using analytic_solution_fields = typename system::primal_fields;
+  using observe_fields = tmpl::append<
+      analytic_solution_fields,
+      tmpl::list<Elasticity::Tags::Strain<volume_dim>,
+                 Elasticity::Tags::PotentialEnergyDensity<volume_dim>>>;
   using events = tmpl::list<
       dg::Events::Registrars::ObserveFields<
           volume_dim, linear_solver_iteration_id, observe_fields,
@@ -163,8 +149,7 @@ struct Metavariables {
 
   // Collect all items to store in the cache.
   using const_global_cache_tags =
-      tmpl::list<background_tag, initial_guess_tag, fluxes_computer_tag,
-                 normal_dot_numerical_flux,
+      tmpl::list<background_tag, initial_guess_tag,
                  Tags::EventsAndTriggers<events, triggers>>;
 
   // Collect all reduction tags for observers
@@ -177,45 +162,31 @@ struct Metavariables {
 
   using initialization_actions = tmpl::list<
       Actions::SetupDataBox, dg::Actions::InitializeDomain<volume_dim>,
-      dg::Actions::InitializeInterfaces<
-          system, dg::Initialization::slice_tags_to_face<>,
-          dg::Initialization::slice_tags_to_exterior<>,
-          dg::Initialization::face_compute_tags<
-              domain::Tags::BoundaryCoordinates<volume_dim>>,
-          dg::Initialization::exterior_compute_tags<>, false, false>,
       typename linear_solver::initialize_element,
       elliptic::Actions::InitializeFields<system, initial_guess_tag>,
       elliptic::Actions::InitializeFixedSources<system, background_tag>,
       Initialization::Actions::AddComputeTags<tmpl::list<
           Elasticity::Tags::ConstitutiveRelationReference<volume_dim,
                                                           background_tag>,
+          Elasticity::Tags::StrainCompute<volume_dim>,
           Elasticity::Tags::PotentialEnergyDensityCompute<volume_dim>>>,
       elliptic::Actions::InitializeOptionalAnalyticSolution<
-          background_tag, analytic_solution_fields,
+          background_tag,
+          tmpl::append<typename system::primal_fields,
+                       typename system::primal_fluxes>,
           Elasticity::Solutions::AnalyticSolution<Dim, background_registrars>>,
+      elliptic::dg::Actions::initialize_operator<system>,
       elliptic::dg::Actions::ImposeInhomogeneousBoundaryConditionsOnSource<
-          Metavariables>,
-      dg::Actions::InitializeMortars<boundary_scheme>,
-      elliptic::dg::Actions::InitializeFirstOrderOperator<
-          volume_dim, typename system::fluxes_computer,
-          typename system::sources_computer, linear_operand_tag,
-          primal_variables, auxiliary_variables>,
+          system, fixed_sources_tag>,
+      // Apply the DG operator to the initial guess
+      elliptic::dg::Actions::apply_operator<
+          system, true, linear_solver_iteration_id, fields_tag, fluxes_vars_tag,
+          operator_applied_to_fields_tag, vars_tag, fluxes_vars_tag>,
       Initialization::Actions::RemoveOptionsAndTerminatePhase>;
 
-  using build_linear_operator_actions = tmpl::list<
-      dg::Actions::CollectDataForFluxes<
-          boundary_scheme, domain::Tags::InternalDirections<volume_dim>>,
-      dg::Actions::SendDataForFluxes<boundary_scheme>,
-      Actions::MutateApply<elliptic::FirstOrderOperator<
-          volume_dim, LinearSolver::Tags::OperatorAppliedTo,
-          linear_operand_tag>>,
-      elliptic::dg::Actions::ImposeHomogeneousDirichletBoundaryConditions<
-          linear_operand_tag, primal_variables>,
-      dg::Actions::CollectDataForFluxes<
-          boundary_scheme,
-          domain::Tags::BoundaryDirectionsInterior<volume_dim>>,
-      dg::Actions::ReceiveDataForFluxes<boundary_scheme>,
-      Actions::MutateApply<boundary_scheme>>;
+  using build_linear_operator_actions = elliptic::dg::Actions::apply_operator<
+      system, true, linear_solver_iteration_id, vars_tag, fluxes_vars_tag,
+      operator_applied_to_vars_tag>;
 
   using register_actions =
       tmpl::list<observers::Actions::RegisterEventsWithObservers,

--- a/src/Elliptic/Executables/Poisson/CMakeLists.txt
+++ b/src/Elliptic/Executables/Poisson/CMakeLists.txt
@@ -17,6 +17,7 @@ set(LIBS_TO_LINK
   Parallel
   ParallelLinearSolver
   Poisson
+  PoissonBoundaryConditions
   PoissonSolutions
   Utilities
   )

--- a/src/Elliptic/Systems/Elasticity/Equations.cpp
+++ b/src/Elliptic/Systems/Elasticity/Equations.cpp
@@ -19,7 +19,7 @@ namespace Elasticity {
 
 template <size_t Dim>
 void primal_fluxes(
-    const gsl::not_null<tnsr::IJ<DataVector, Dim>*> flux_for_displacement,
+    const gsl::not_null<tnsr::II<DataVector, Dim>*> flux_for_displacement,
     const tnsr::ii<DataVector, Dim>& strain,
     const ConstitutiveRelations::ConstitutiveRelation<Dim>&
         constitutive_relation,
@@ -97,7 +97,7 @@ void add_curved_auxiliary_sources(
 
 template <size_t Dim>
 void Fluxes<Dim>::apply(
-    const gsl::not_null<tnsr::IJ<DataVector, Dim>*> flux_for_displacement,
+    const gsl::not_null<tnsr::II<DataVector, Dim>*> flux_for_displacement,
     const ConstitutiveRelations::ConstitutiveRelation<Dim>&
         constitutive_relation,
     const tnsr::I<DataVector, Dim>& coordinates,
@@ -121,7 +121,7 @@ void Sources<Dim>::apply(
     const gsl::not_null<
         tnsr::I<DataVector, Dim>*> /*equation_for_displacement*/,
     const tnsr::I<DataVector, Dim>& /*displacement*/,
-    const tnsr::IJ<DataVector, Dim>& /*minus_stress*/) noexcept {}
+    const tnsr::II<DataVector, Dim>& /*minus_stress*/) noexcept {}
 
 template <size_t Dim>
 void Sources<Dim>::apply(
@@ -134,7 +134,7 @@ void Sources<Dim>::apply(
 
 #define INSTANTIATE(_, data)                                             \
   template void Elasticity::primal_fluxes<DIM(data)>(                    \
-      gsl::not_null<tnsr::IJ<DataVector, DIM(data)>*>,                   \
+      gsl::not_null<tnsr::II<DataVector, DIM(data)>*>,                   \
       const tnsr::ii<DataVector, DIM(data)>&,                            \
       const Elasticity::ConstitutiveRelations::ConstitutiveRelation<DIM( \
           data)>&,                                                       \

--- a/src/Elliptic/Systems/Elasticity/Equations.hpp
+++ b/src/Elliptic/Systems/Elasticity/Equations.hpp
@@ -34,7 +34,7 @@ namespace Elasticity {
  */
 template <size_t Dim>
 void primal_fluxes(
-    gsl::not_null<tnsr::IJ<DataVector, Dim>*> flux_for_displacement,
+    gsl::not_null<tnsr::II<DataVector, Dim>*> flux_for_displacement,
     const tnsr::ii<DataVector, Dim>& strain,
     const ConstitutiveRelations::ConstitutiveRelation<Dim>&
         constitutive_relation,
@@ -106,7 +106,7 @@ struct Fluxes {
                  domain::Tags::Coordinates<Dim, Frame::Inertial>>;
   using volume_tags = tmpl::list<Tags::ConstitutiveRelation<Dim>>;
   static void apply(
-      gsl::not_null<tnsr::IJ<DataVector, Dim>*> flux_for_displacement,
+      gsl::not_null<tnsr::II<DataVector, Dim>*> flux_for_displacement,
       const ConstitutiveRelations::ConstitutiveRelation<Dim>&
           constitutive_relation,
       const tnsr::I<DataVector, Dim>& coordinates,
@@ -131,7 +131,7 @@ struct Sources {
   static void apply(
       gsl::not_null<tnsr::I<DataVector, Dim>*> equation_for_displacement,
       const tnsr::I<DataVector, Dim>& displacement,
-      const tnsr::IJ<DataVector, Dim>& minus_stress) noexcept;
+      const tnsr::II<DataVector, Dim>& minus_stress) noexcept;
   static void apply(
       gsl::not_null<tnsr::ii<DataVector, Dim>*> equation_for_strain,
       const tnsr::I<DataVector, Dim>& displacement) noexcept;

--- a/src/Elliptic/Systems/Elasticity/FirstOrderSystem.hpp
+++ b/src/Elliptic/Systems/Elasticity/FirstOrderSystem.hpp
@@ -7,10 +7,11 @@
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
-#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
-#include "DataStructures/VariablesTag.hpp"
 #include "Elliptic/BoundaryConditions/AnalyticSolution.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryConditionType.hpp"
+#include "Elliptic/Systems/Elasticity/BoundaryConditions/LaserBeam.hpp"
+#include "Elliptic/Systems/Elasticity/BoundaryConditions/Zero.hpp"
 #include "Elliptic/Systems/Elasticity/Equations.hpp"
 #include "Elliptic/Systems/Elasticity/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
@@ -55,6 +56,7 @@ struct FirstOrderSystem {
  private:
   using displacement = Tags::Displacement<Dim>;
   using strain = Tags::Strain<Dim>;
+  using minus_stress = Tags::MinusStress<Dim>;
 
  public:
   static constexpr size_t volume_dim = Dim;
@@ -62,13 +64,9 @@ struct FirstOrderSystem {
   // The physical fields to solve for
   using primal_fields = tmpl::list<displacement>;
   using auxiliary_fields = tmpl::list<strain>;
-  using fields_tag =
-      ::Tags::Variables<tmpl::append<primal_fields, auxiliary_fields>>;
 
-  // Tags for the first-order fluxes. We can use the symmetric stress here as an
-  // optimization once the DG operator supports fluxes with symmetries.
-  using primal_fluxes = tmpl::list<
-      ::Tags::Flux<displacement, tmpl::size_t<Dim>, Frame::Inertial>>;
+  // Tags for the first-order fluxes
+  using primal_fluxes = tmpl::list<minus_stress>;
   using auxiliary_fluxes =
       tmpl::list<::Tags::Flux<strain, tmpl::size_t<Dim>, Frame::Inertial>>;
 
@@ -84,12 +82,17 @@ struct FirstOrderSystem {
   // factory-created from this base class.
   using boundary_conditions_base =
       elliptic::BoundaryConditions::BoundaryCondition<
-          Dim, tmpl::list<elliptic::BoundaryConditions::Registrars::
-                              AnalyticSolution<FirstOrderSystem>>>;
-
-  // The tag of the operator to compute magnitudes on the manifold, e.g. to
-  // normalize vectors on the faces of an element
-  template <typename Tag>
-  using magnitude_tag = ::Tags::EuclideanMagnitude<Tag>;
+          Dim,
+          tmpl::append<
+              tmpl::list<elliptic::BoundaryConditions::Registrars::
+                             AnalyticSolution<FirstOrderSystem>,
+                         BoundaryConditions::Registrars::Zero<
+                             Dim, elliptic::BoundaryConditionType::Dirichlet>,
+                         BoundaryConditions::Registrars::Zero<
+                             Dim, elliptic::BoundaryConditionType::Neumann>>,
+              tmpl::conditional_t<
+                  Dim == 3,
+                  tmpl::list<BoundaryConditions::Registrars::LaserBeam>,
+                  tmpl::list<>>>>;
 };
 }  // namespace Elasticity

--- a/src/Elliptic/Systems/Poisson/FirstOrderSystem.hpp
+++ b/src/Elliptic/Systems/Poisson/FirstOrderSystem.hpp
@@ -10,10 +10,9 @@
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
-#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
-#include "DataStructures/VariablesTag.hpp"
 #include "Elliptic/BoundaryConditions/AnalyticSolution.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/Systems/Poisson/BoundaryConditions/Robin.hpp"
 #include "Elliptic/Systems/Poisson/Equations.hpp"
 #include "Elliptic/Systems/Poisson/Geometry.hpp"
 #include "Elliptic/Systems/Poisson/Tags.hpp"
@@ -87,8 +86,6 @@ struct FirstOrderSystem {
   // The physical fields to solve for
   using primal_fields = tmpl::list<field>;
   using auxiliary_fields = tmpl::list<field_gradient>;
-  using fields_tag =
-      ::Tags::Variables<tmpl::append<primal_fields, auxiliary_fields>>;
 
   // Tags for the first-order fluxes. We just use the standard `Flux` prefix
   // because the fluxes don't have symmetries and we don't need to give them a
@@ -118,14 +115,7 @@ struct FirstOrderSystem {
   using boundary_conditions_base =
       elliptic::BoundaryConditions::BoundaryCondition<
           Dim, tmpl::list<elliptic::BoundaryConditions::Registrars::
-                              AnalyticSolution<FirstOrderSystem>>>;
-
-  // The tag of the operator to compute magnitudes on the manifold, e.g. to
-  // normalize vectors on the faces of an element
-  template <typename Tag>
-  using magnitude_tag =
-      tmpl::conditional_t<BackgroundGeometry == Geometry::FlatCartesian,
-                          ::Tags::EuclideanMagnitude<Tag>,
-                          ::Tags::NonEuclideanMagnitude<Tag, inv_metric_tag>>;
+                              AnalyticSolution<FirstOrderSystem>,
+                          Poisson::BoundaryConditions::Registrars::Robin<Dim>>>;
 };
 }  // namespace Poisson

--- a/tests/InputFiles/Elasticity/BentBeam.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam.yaml
@@ -2,10 +2,16 @@
 # See LICENSE.txt for details.
 
 # Executable: SolveElasticity2D
-# Check: parse;execute
+# Check: parse;execute_check_output
 # ExpectedOutput:
 #   ElasticBentBeam2DReductions.h5
 #   ElasticBentBeam2DVolume0.h5
+# OutputFileChecks:
+#   - Label: Discretization error
+#     Subfile: /ErrorNorms.dat
+#     FileGlob: ElasticBentBeam2DReductions.h5
+#     SkipColumns: [0, 1]
+#     AbsoluteTolerance: 1.e-8
 
 Background:
   BentBeam:
@@ -24,15 +30,15 @@ DomainCreator:
   Rectangle:
     LowerBound: [-1., -0.5]
     UpperBound: [1., 0.5]
-    InitialRefinement: [2, 1]
+    InitialRefinement: [1, 0]
     InitialGridPoints: [3, 3]
     TimeDependence: None
     BoundaryCondition:
       AnalyticSolution:
         Displacement: Dirichlet
 
-NumericalFlux:
-  InternalPenalty:
+Discretization:
+  DiscontinuousGalerkin:
     PenaltyParameter: 1.
 
 Observers:
@@ -42,18 +48,20 @@ Observers:
 LinearSolver:
   GMRES:
     ConvergenceCriteria:
-      MaxIterations: 1
-      AbsoluteResidual: 0.
-      RelativeResidual: 0.
+      MaxIterations: 9
+      RelativeResidual: 1.e-8
+      AbsoluteResidual: 1.e-14
     Verbosity: Verbose
 
 EventsAndTriggers:
   ? EveryNIterations:
       N: 1
-      Offset: 0
+      Offset: 9
   : - ObserveErrorNorms:
-        SubfileName: "element_data"
+        SubfileName: ErrorNorms
     - ObserveFields:
-        SubfileName: "element_data"
-        VariablesToObserve: [Displacement, Strain]
+        SubfileName: VolumeData
+        VariablesToObserve:
+          - Displacement
+          - PotentialEnergyDensity
         InterpolateToMesh: None

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -6,6 +6,12 @@
 # ExpectedOutput:
 #   ElasticHalfSpaceMirrorReductions.h5
 #   ElasticHalfSpaceMirrorVolume0.h5
+# OutputFileChecks:
+#   - Label: Discretization error
+#     Subfile: /ErrorNorms.dat
+#     FileGlob: ElasticHalfSpaceMirrorReductions.h5
+#     SkipColumns: [0, 1]
+#     AbsoluteTolerance: 1.e-3
 
 Background:
   HalfSpaceMirror:
@@ -43,9 +49,9 @@ DomainCreator:
         AnalyticSolution:
           Displacement: Dirichlet
 
-NumericalFlux:
-  InternalPenalty:
-    PenaltyParameter: 1
+Discretization:
+  DiscontinuousGalerkin:
+    PenaltyParameter: 1.
 
 Observers:
   VolumeFileName: "ElasticHalfSpaceMirrorVolume"
@@ -54,23 +60,25 @@ Observers:
 LinearSolver:
   GMRES:
     ConvergenceCriteria:
-      MaxIterations: 1
-      RelativeResidual: 1e-8
-      AbsoluteResidual: 1e-12
+      MaxIterations: 22
+      RelativeResidual: 1.e-4
+      AbsoluteResidual: 1.e-12
     Verbosity: Verbose
 
 EventsAndTriggers:
   ? EveryNIterations:
       N: 1
-      Offset: 0
+      Offset: 22
   : - ObserveErrorNorms:
         SubfileName: ErrorNorms
     - ObserveVolumeIntegrals:
         SubfileName: VolumeIntegrals
   ? EveryNIterations:
-      N: 10
+      N: 2
       Offset: 0
   : - ObserveFields:
         SubfileName: VolumeData
-        VariablesToObserve: [Displacement, Strain]
+        VariablesToObserve:
+          - Displacement
+          - PotentialEnergyDensity
         InterpolateToMesh: None

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -8,10 +8,10 @@
 #   PoissonProductOfSinusoids1DVolume0.h5
 # OutputFileChecks:
 #   - Label: Discretization error
-#     Subfile: /Errors.dat
+#     Subfile: /ErrorNorms.dat
 #     FileGlob: PoissonProductOfSinusoids1DReductions.h5
-#     SkipColumns: [0, 1, 3]
-#     AbsoluteTolerance: 0.02
+#     SkipColumns: [0, 1]
+#     AbsoluteTolerance: 0.004
 
 Background:
   ProductOfSinusoids:
@@ -22,10 +22,10 @@ InitialGuess:
 
 DomainCreator:
   Interval:
-    LowerBound: [0]
+    LowerBound: [-1.570796326794896]
     UpperBound: [3.141592653589793]
     InitialRefinement: [1]
-    InitialGridPoints: [3]
+    InitialGridPoints: [4]
     TimeDependence: None
     BoundaryConditions:
       LowerBoundary:
@@ -33,10 +33,10 @@ DomainCreator:
           Field: Dirichlet
       UpperBoundary:
         AnalyticSolution:
-          Field: Dirichlet
+          Field: Neumann
 
-NumericalFlux:
-  InternalPenalty:
+Discretization:
+  DiscontinuousGalerkin:
     PenaltyParameter: 1.
 
 Observers:
@@ -45,18 +45,18 @@ Observers:
 
 LinearSolver:
   ConvergenceCriteria:
-    MaxIterations: 7
-    AbsoluteResidual: 1e-10
-    RelativeResidual: 1e-10
+    MaxIterations: 8
+    RelativeResidual: 1.e-10
+    AbsoluteResidual: 1.e-10
   Verbosity: Verbose
 
 EventsAndTriggers:
   ? EveryNIterations:
       N: 1
-      Offset: 6
+      Offset: 8
   : - ObserveErrorNorms:
-        SubfileName: Errors
+        SubfileName: ErrorNorms
     - ObserveFields:
         SubfileName: VolumeData
-        VariablesToObserve: [Field, deriv(Field)]
+        VariablesToObserve: [Field]
         InterpolateToMesh: None

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -2,10 +2,16 @@
 # See LICENSE.txt for details.
 
 # Executable: SolvePoisson2D
-# Check: parse;execute
+# Check: parse;execute_check_output
 # ExpectedOutput:
 #   PoissonProductOfSinusoids2DReductions.h5
 #   PoissonProductOfSinusoids2DVolume0.h5
+# OutputFileChecks:
+#   - Label: Discretization error
+#     Subfile: /ErrorNorms.dat
+#     FileGlob: PoissonProductOfSinusoids2DReductions.h5
+#     SkipColumns: [0, 1]
+#     AbsoluteTolerance: 0.007
 
 Background:
   ProductOfSinusoids:
@@ -16,17 +22,17 @@ InitialGuess:
 
 DomainCreator:
   Rectangle:
-    LowerBound: [0, 0]
-    UpperBound: [3.141592653589793, 3.141592653589793]
-    InitialRefinement: [1, 1]
-    InitialGridPoints: [3, 3]
+    LowerBound: [-1.570796326794896, 0.]
+    UpperBound: [3.141592653589793, 1.570796326794896]
+    InitialRefinement: [1, 0]
+    InitialGridPoints: [4, 3]
     TimeDependence: None
     BoundaryCondition:
       AnalyticSolution:
         Field: Dirichlet
 
-NumericalFlux:
-  InternalPenalty:
+Discretization:
+  DiscontinuousGalerkin:
     PenaltyParameter: 1.
 
 Observers:
@@ -35,18 +41,18 @@ Observers:
 
 LinearSolver:
   ConvergenceCriteria:
-    MaxIterations: 1
-    AbsoluteResidual: 0
-    RelativeResidual: 0
+    MaxIterations: 23
+    RelativeResidual: 1.e-10
+    AbsoluteResidual: 1.e-10
   Verbosity: Verbose
 
 EventsAndTriggers:
   ? EveryNIterations:
       N: 1
-      Offset: 0
+      Offset: 23
   : - ObserveErrorNorms:
-        SubfileName: Errors
+        SubfileName: ErrorNorms
     - ObserveFields:
         SubfileName: VolumeData
-        VariablesToObserve: [Field, deriv(Field)]
+        VariablesToObserve: [Field]
         InterpolateToMesh: None

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -2,10 +2,16 @@
 # See LICENSE.txt for details.
 
 # Executable: SolvePoisson3D
-# Check: parse;execute
+# Check: parse;execute_check_output
 # ExpectedOutput:
 #   PoissonProductOfSinusoids3DReductions.h5
 #   PoissonProductOfSinusoids3DVolume0.h5
+# OutputFileChecks:
+#   - Label: Discretization error
+#     Subfile: /ErrorNorms.dat
+#     FileGlob: PoissonProductOfSinusoids3DReductions.h5
+#     SkipColumns: [0, 1]
+#     AbsoluteTolerance: 0.004
 
 Background:
   ProductOfSinusoids:
@@ -16,17 +22,17 @@ InitialGuess:
 
 DomainCreator:
   Brick:
-    LowerBound: [0, 0, 0]
-    UpperBound: [3.141592653589793, 3.141592653589793, 3.141592653589793]
-    InitialRefinement: [1, 1, 1]
-    InitialGridPoints: [2, 2, 2]
+    LowerBound: [-1.570796326794896, 0., 0.]
+    UpperBound: [3.141592653589793, 1.570796326794896, 3.141592653589793]
+    InitialRefinement: [1, 0, 0]
+    InitialGridPoints: [4, 3, 5]
     TimeDependence: None
     BoundaryCondition:
       AnalyticSolution:
         Field: Dirichlet
 
-NumericalFlux:
-  InternalPenalty:
+Discretization:
+  DiscontinuousGalerkin:
     PenaltyParameter: 1.
 
 Observers:
@@ -35,18 +41,18 @@ Observers:
 
 LinearSolver:
   ConvergenceCriteria:
-    MaxIterations: 1
-    AbsoluteResidual: 0
-    RelativeResidual: 0
+    MaxIterations: 29
+    RelativeResidual: 1.e-6
+    AbsoluteResidual: 1.e-6
   Verbosity: Verbose
 
 EventsAndTriggers:
   ? EveryNIterations:
       N: 1
-      Offset: 0
+      Offset: 29
   : - ObserveErrorNorms:
-        SubfileName: Errors
+        SubfileName: ErrorNorms
     - ObserveFields:
         SubfileName: VolumeData
-        VariablesToObserve: [Field, deriv(Field)]
+        VariablesToObserve: [Field]
         InterpolateToMesh: None

--- a/tests/Unit/Elliptic/Actions/Test_InitializeFields.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeFields.cpp
@@ -35,22 +35,16 @@ struct ScalarFieldTag : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 
-struct AuxiliaryFieldTag : db::SimpleTag {
-  using type = tnsr::i<DataVector, 1>;
-};
-
 struct System {
-  using fields_tag =
-      Tags::Variables<tmpl::list<ScalarFieldTag, AuxiliaryFieldTag>>;
+  using primal_fields = tmpl::list<ScalarFieldTag>;
 };
 
 struct InitialGuess {
-  static tuples::TaggedTuple<ScalarFieldTag, AuxiliaryFieldTag> variables(
+  static tuples::TaggedTuple<ScalarFieldTag> variables(
       const tnsr::I<DataVector, 1>& x,
-      tmpl::list<ScalarFieldTag, AuxiliaryFieldTag> /*meta*/) noexcept {
+      tmpl::list<ScalarFieldTag> /*meta*/) noexcept {
     Scalar<DataVector> scalar_field{2. * get<0>(x)};
-    tnsr::i<DataVector, 1> aux_field{3. * get<0>(x)};
-    return {std::move(scalar_field), std::move(aux_field)};
+    return {std::move(scalar_field)};
   }
   // NOLINTNEXTLINE
   void pup(PUP::er& /*p*/) noexcept {}
@@ -118,5 +112,4 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeFields",
   const auto& inertial_coords =
       get_tag(domain::Tags::Coordinates<1, Frame::Inertial>{});
   CHECK(get(get_tag(ScalarFieldTag{})) == 2. * get<0>(inertial_coords));
-  CHECK(get<0>(get_tag(AuxiliaryFieldTag{})) == 3. * get<0>(inertial_coords));
 }

--- a/tests/Unit/Elliptic/Actions/Test_InitializeFixedSources.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeFixedSources.cpp
@@ -32,7 +32,6 @@ struct ScalarFieldTag : db::SimpleTag {
 };
 
 struct System {
-  using fields_tag = Tags::Variables<tmpl::list<ScalarFieldTag>>;
   using primal_fields = tmpl::list<ScalarFieldTag>;
 };
 

--- a/tests/Unit/Elliptic/Systems/Elasticity/Test_Equations.cpp
+++ b/tests/Unit/Elliptic/Systems/Elasticity/Test_Equations.cpp
@@ -30,7 +30,7 @@ template <size_t Dim>
 void primal_fluxes(
     // This wrapper function is needed to construct a constitutive relation for
     // the random values of its parameters.
-    const gsl::not_null<tnsr::IJ<DataVector, Dim, Frame::Inertial>*>
+    const gsl::not_null<tnsr::II<DataVector, Dim, Frame::Inertial>*>
         flux_for_displacement,
     const tnsr::ii<DataVector, Dim, Frame::Inertial>& strain,
     const tnsr::I<DataVector, Dim>& coordinates, const double bulk_modulus,
@@ -66,8 +66,7 @@ template <size_t Dim>
 void test_computers(const DataVector& used_for_size) {
   using field_tag = Elasticity::Tags::Displacement<Dim>;
   using auxiliary_field_tag = Elasticity::Tags::Strain<Dim>;
-  using field_flux_tag =
-      ::Tags::Flux<field_tag, tmpl::size_t<Dim>, Frame::Inertial>;
+  using field_flux_tag = Elasticity::Tags::MinusStress<Dim>;
   using auxiliary_flux_tag =
       ::Tags::Flux<auxiliary_field_tag, tmpl::size_t<Dim>, Frame::Inertial>;
   using field_source_tag = ::Tags::Source<field_tag>;
@@ -87,7 +86,7 @@ void test_computers(const DataVector& used_for_size) {
         constitutive_relation_tag, coordinates_tag>>(
         tnsr::I<DataVector, Dim>{num_points, 1.},
         tnsr::ii<DataVector, Dim>{num_points, 2.},
-        tnsr::IJ<DataVector, Dim>{num_points,
+        tnsr::II<DataVector, Dim>{num_points,
                                   std::numeric_limits<double>::signaling_NaN()},
         tnsr::Ijj<DataVector, Dim>{
             num_points, std::numeric_limits<double>::signaling_NaN()},
@@ -99,7 +98,7 @@ void test_computers(const DataVector& used_for_size) {
 
     db::mutate_apply<tmpl::list<field_flux_tag>, argument_tags>(
         fluxes_computer, make_not_null(&box), get<auxiliary_field_tag>(box));
-    auto expected_field_flux = tnsr::IJ<DataVector, Dim>{
+    auto expected_field_flux = tnsr::II<DataVector, Dim>{
         num_points, std::numeric_limits<double>::signaling_NaN()};
     Elasticity::primal_fluxes(
         make_not_null(&expected_field_flux), get<auxiliary_field_tag>(box),
@@ -132,7 +131,7 @@ void test_computers(const DataVector& used_for_size) {
         sources_computer, make_not_null(&box),
         tnsr::I<DataVector, Dim>{num_points,
                                  std::numeric_limits<double>::signaling_NaN()},
-        tnsr::IJ<DataVector, Dim>{
+        tnsr::II<DataVector, Dim>{
             num_points, std::numeric_limits<double>::signaling_NaN()});
     auto expected_field_source = tnsr::I<DataVector, Dim>{num_points, 0.};
     auto expected_auxiliary_source = tnsr::ii<DataVector, Dim>{num_points, 0.};


### PR DESCRIPTION
## Proposed changes

This switch enables a range of features:

- The executables don't need to explicitly solve for the auxiliary variables anymore with the new DG operator. This means they solve a lot faster.
- The executables support arbitrary boundary conditions. A selection of boundary conditions is already enabled, and more can be implemented.
- The executables support arbitrary initial guesses. They can currently choose a trivial inital guess (`Zero`) or an analytic solution, and more can be implemented.
- The elasticity executables can use the symmetric stress as flux, further reducing memory usage and computational cost.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
