### PR TITLE
Add dot product between std::arrays

### DIFF
--- a/src/Utilities/StdArrayHelpers.hpp
+++ b/src/Utilities/StdArrayHelpers.hpp
@@ -165,6 +165,32 @@ decltype(auto) magnitude(const std::array<T, 3>& a) noexcept {
   return sqrt(a[0] * a[0] + a[1] * a[1] + a[2] * a[2]);
 }
 //@}
+//@{
+/// \ingroup UtilitiesGroup
+/// \brief Dot product between two arrays
+///
+/// \details This also works elementwise if T is a container and R is a float or
+/// the other way round. The return type will always be the same as the return
+/// type of the multiplication which may be a blaze expression template.
+
+template <typename T, typename R>
+decltype(auto) dot(const std::array<T, 1>& first,
+                   const std::array<R, 1>& second) {
+  return first[0] * second[0];
+}
+
+template <typename T, typename R>
+decltype(auto) dot(const std::array<T, 2>& first,
+                   const std::array<R, 2>& second) {
+  return first[0] * second[0] + first[1] * second[1];
+}
+
+template <typename T, typename R>
+decltype(auto) dot(const std::array<T, 3>& first,
+                   const std::array<R, 3>& second) {
+  return first[0] * second[0] + first[1] * second[1] + first[2] * second[2];
+}
+//@}
 
 namespace std_array_helpers_detail {
 template <typename T, size_t Dim, typename F, size_t... Indices>

--- a/tests/Unit/Utilities/Test_StdArrayHelpers.cpp
+++ b/tests/Unit/Utilities/Test_StdArrayHelpers.cpp
@@ -7,14 +7,16 @@
 #include <cstddef>
 #include <functional>
 
-#include "Utilities/Gsl.hpp"
-#include "Utilities/Literals.hpp"
 // We wish to explicitly test implicit type conversion when adding std::arrays
 // of different fundamentals, so we supress -Wsign-conversion.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #include "Utilities/StdArrayHelpers.hpp"
 #pragma GCC diagnostic pop
+
+#include "DataStructures/DataVector.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
 
 SPECTRE_TEST_CASE("Unit.Utilities.StdArrayHelpers.Arithmetic",
                   "[DataStructures][Unit]") {
@@ -93,6 +95,50 @@ SPECTRE_TEST_CASE("Unit.Utilities.StdArrayHelpers.Magnitude",
   CHECK(magnitude(p2) == approx(5.));
   const std::array<double, 3> p3{{-2., 10., 11.}};
   CHECK(magnitude(p3) == approx(15.));
+}
+
+SPECTRE_TEST_CASE("Unit.Utilities.StdArrayHelpers.Dot",
+                  "[DataStructures][Unit]") {
+  {
+    INFO("Testing 1D");
+    const std::array<double, 1> double_1{{-2.}};
+    const std::array<double, 1> double_2{{-3.}};
+    const std::array<DataVector, 1> dv_1{{{1., 2., 3.}}};
+    const std::array<DataVector, 1> dv_2{{{2., 4., 6.}}};
+
+    CHECK(dot(double_1, double_2) == approx(6.));
+    CHECK_ITERABLE_APPROX(dot(dv_1, dv_2), (DataVector{2., 8., 18.}));
+    CHECK_ITERABLE_APPROX(dot(dv_1, double_1), (DataVector{-2., -4., -6.}));
+    CHECK(dot(double_1, dv_1) == dot(dv_1, double_1));
+  }
+
+  {
+    INFO("Testing 2D");
+    const std::array<double, 2> double_1{{-2., -3.}};
+    const std::array<double, 2> double_2{{-3., -1.}};
+    const std::array<DataVector, 2> dv_1{{{1., 2., 3.}, {-1., -2., -3.}}};
+    const std::array<DataVector, 2> dv_2{{{2., 4., 6.}, {3., 6., 9.}}};
+
+    CHECK(dot(double_1, double_2) == approx(9.));
+    CHECK_ITERABLE_APPROX(dot(dv_1, dv_2), (DataVector{-1., -4., -9.}));
+    CHECK_ITERABLE_APPROX(dot(dv_1, double_1), (DataVector{1., 2., 3.}));
+    CHECK(dot(double_1, dv_1) == dot(dv_1, double_1));
+  }
+
+  {
+    INFO("Testing 3D");
+    const std::array<double, 3> double_1{{-2., 1., 4.}};
+    const std::array<double, 3> double_2{{-3., 2., 0.}};
+    const std::array<DataVector, 3> dv_1{
+        {{1., 2., 3.}, {-1., 2., 0.}, {-2., 1., 1.}}};
+    const std::array<DataVector, 3> dv_2{
+        {{1., 2., 3.}, {-3., -1., 2.}, {-4., 3., 1.}}};
+
+    CHECK(dot(double_1, double_2) == approx(8.));
+    CHECK_ITERABLE_APPROX(dot(dv_1, dv_2), (DataVector{12., 5., 10.}));
+    CHECK_ITERABLE_APPROX(dot(dv_1, double_1), (DataVector{-11., 2., -2.}));
+    CHECK(dot(double_1, dv_1) == dot(dv_1, double_1));
+  }
 }
 
 SPECTRE_TEST_CASE("Unit.Utilities.StdArrayHelpers.AllButSpecifiedElementOf",


### PR DESCRIPTION
## Proposed changes
adds the ability to compute the dot product between two arrays of `Datavector`s, two arrays of `double`s, or an array of `Datavector`s and an array of `double`s elementwise.
<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
