### PR TITLE
Add Kerr horizon conforming map

### DIFF
--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -26,6 +26,7 @@ spectre_target_sources(
   FocallyLiftedSide.cpp
   Frustum.cpp
   Identity.cpp
+  KerrHorizonConforming.cpp
   Rotation.cpp
   SpecialMobius.cpp
   Wedge.cpp
@@ -56,6 +57,7 @@ spectre_target_headers(
   FocallyLiftedSide.hpp
   Frustum.hpp
   Identity.hpp
+  KerrHorizonConforming.hpp
   MapInstantiationMacros.hpp
   ProductMaps.hpp
   ProductMaps.tpp

--- a/src/Domain/CoordinateMaps/KerrHorizonConforming.cpp
+++ b/src/Domain/CoordinateMaps/KerrHorizonConforming.cpp
@@ -1,0 +1,197 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/KerrHorizonConforming.hpp"
+
+#include <array>
+#include <cstddef>
+#include <optional>
+
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
+
+namespace domain::CoordinateMaps {
+
+KerrHorizonConforming::KerrHorizonConforming(std::array<double, 3> spin)
+    : spin_(spin), spin_mag_sq_(dot(spin, spin)) {}
+
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, 3> KerrHorizonConforming::operator()(
+    const std::array<T, 3>& source_coords) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  std::array<ReturnType, 3> result{};
+  ReturnType& stretch_fac = get<2>(result);
+  stretch_factor_square(make_not_null(&stretch_fac), source_coords);
+  stretch_fac = sqrt(stretch_fac);
+  for (size_t i = 0; i < 3; ++i) {
+    gsl::at(result, i) = gsl::at(source_coords, i) * stretch_fac;
+  }
+  return result;
+}
+
+std::optional<std::array<double, 3>> KerrHorizonConforming::inverse(
+    const std::array<double, 3>& target_coords) const noexcept {
+  const auto coords_mag_sq = dot(target_coords, target_coords);
+  const auto coords_sq_min_spin_sq = coords_mag_sq - spin_mag_sq_;
+  const auto coords_dot_spin = dot(target_coords, spin_);
+  const auto fac = (coords_sq_min_spin_sq +
+                    sqrt(coords_sq_min_spin_sq * coords_sq_min_spin_sq +
+                         4. * square(coords_dot_spin))) /
+                   (2. * coords_mag_sq);
+  // this is the way it was written in spec, but I dont think `fac` can
+  // ever be smaller than 0
+  return fac >= 0.
+             ? std::optional<std::array<double, 3>>(target_coords * sqrt(fac))
+             : std::nullopt;
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
+KerrHorizonConforming::jacobian(
+    const std::array<T, 3>& source_coords) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+
+  tnsr::Ij<ReturnType, 3, Frame::NoFrame> jac(
+      get_size(dereference_wrapper(source_coords[0])));
+
+  // use allocations from `jac` for auxiliaries
+  ReturnType& fac = get<0, 0>(jac);
+  ReturnType& source_coords_sq = get<0, 1>(jac);
+  ReturnType& coords_dot_spin = get<0, 2>(jac);
+  ReturnType& subexpr_1 = get<1, 0>(jac);
+  ReturnType& subexpr_2 = get<1, 1>(jac);
+
+  std::array<ReturnType, 3> dfac_dx{};
+  if constexpr (std::is_same_v<ReturnType, DataVector>) {
+    dfac_dx[0].set_data_ref(&get<2, 0>(jac));
+    dfac_dx[1].set_data_ref(&get<2, 1>(jac));
+    dfac_dx[2].set_data_ref(&get<2, 2>(jac));
+  }
+
+  stretch_factor_square(make_not_null(&fac), source_coords);
+  source_coords_sq = dot(source_coords, source_coords);
+  coords_dot_spin = dot(source_coords, spin_);
+  subexpr_1 = 4. * source_coords_sq * (1. - fac);
+  subexpr_2 = 2. * fac * coords_dot_spin;
+
+  for (size_t i = 0; i < 3; ++i) {
+    gsl::at(dfac_dx, i) = subexpr_1 * gsl::at(source_coords, i) +
+                          2. * spin_mag_sq_ * gsl::at(source_coords, i) -
+                          subexpr_2 * gsl::at(spin_, i);
+  }
+  dfac_dx = dfac_dx / (square(source_coords_sq) + square(coords_dot_spin));
+
+  const ReturnType sqrt_fac = sqrt(fac);
+
+  // not mathematically a part of `dfac_dx` but can be absorbed to avoid
+  // allocation for temporary
+  dfac_dx = dfac_dx / (2. * sqrt_fac);
+
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      jac.get(i, j) = gsl::at(dfac_dx, j) * gsl::at(source_coords, i);
+    }
+    jac.get(i, i) += sqrt_fac;
+  }
+  return jac;
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
+KerrHorizonConforming::inv_jacobian(
+    const std::array<T, 3>& source_coords) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+
+  tnsr::Ij<ReturnType, 3, Frame::NoFrame> inv_jac(
+      get_size(dereference_wrapper(source_coords[0])));
+
+  ReturnType& mapped_mag_sq = get<0, 0>(inv_jac);
+  ReturnType& mapped_mag = get<0, 1>(inv_jac);
+  ReturnType& mapped_dot_spin = get<0, 2>(inv_jac);
+  ReturnType& mapped_sq_min_spin_sq = get<1, 0>(inv_jac);
+  ReturnType& r = get<1, 1>(inv_jac);
+  ReturnType& fac = get<1, 2>(inv_jac);
+  std::array<ReturnType, 3> dr_dx{};
+  if constexpr (std::is_same_v<ReturnType, DataVector>) {
+    dr_dx[0].set_data_ref(&get<2, 0>(inv_jac));
+    dr_dx[1].set_data_ref(&get<2, 1>(inv_jac));
+    dr_dx[2].set_data_ref(&get<2, 2>(inv_jac));
+  }
+
+  auto mapped = operator()(source_coords);
+
+  mapped_mag_sq = dot(mapped, mapped);
+  mapped_mag = sqrt(mapped_mag_sq);
+  mapped_dot_spin = dot(mapped, spin_);
+  mapped_sq_min_spin_sq = mapped_mag_sq - spin_mag_sq_;
+  r = sqrt(0.5 * (mapped_sq_min_spin_sq + sqrt(square(mapped_sq_min_spin_sq) +
+                                               4 * square(mapped_dot_spin))));
+  fac = 1. / (2. * cube(r) - mapped_sq_min_spin_sq * r);
+
+  for (size_t i = 0; i < 3; ++i) {
+    gsl::at(dr_dx, i) =
+        (square(r) * mapped.at(i) + mapped_dot_spin * gsl::at(spin_, i)) * fac;
+  }
+
+  // normalized from this point
+  mapped = mapped / mapped_mag;
+  const ReturnType r_by_mapped = r / mapped_mag;
+
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      inv_jac.get(i, j) = gsl::at(dr_dx, j) * gsl::at(mapped, i) -
+                          r_by_mapped * gsl::at(mapped, i) * gsl::at(mapped, j);
+    }
+    inv_jac.get(i, i) += r_by_mapped;
+  }
+  return inv_jac;
+}
+
+template <typename T>
+void KerrHorizonConforming::stretch_factor_square(
+    const gsl::not_null<tt::remove_cvref_wrap_t<T>*> result,
+    const std::array<T, 3>& source_coords) const noexcept {
+  auto& source_coords_sq = *result;
+  source_coords_sq = dot(source_coords, source_coords);
+  *result =
+      source_coords_sq * (source_coords_sq + spin_mag_sq_) /
+      (source_coords_sq * source_coords_sq + square(dot(source_coords, spin_)));
+}
+
+void KerrHorizonConforming::pup(PUP::er& p) {
+  p | spin_;
+  p | spin_mag_sq_;
+}
+
+bool operator==(const KerrHorizonConforming& lhs,
+                const KerrHorizonConforming& rhs) noexcept {
+  return lhs.spin_ == rhs.spin_;
+}
+
+bool operator!=(const KerrHorizonConforming& lhs,
+                const KerrHorizonConforming& rhs) noexcept {
+  return not(lhs == rhs);
+}
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define INSTANTIATE(_, data)                                                 \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>               \
+  KerrHorizonConforming::operator()(                                         \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;       \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame> \
+  KerrHorizonConforming::jacobian(                                           \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;       \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame> \
+  KerrHorizonConforming::inv_jacobian(                                       \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
+                                      std::reference_wrapper<const double>,
+                                      std::reference_wrapper<const DataVector>))
+#undef DTYPE
+#undef INSTANTIATE
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/KerrHorizonConforming.hpp
+++ b/src/Domain/CoordinateMaps/KerrHorizonConforming.hpp
@@ -1,0 +1,112 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <optional>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
+
+namespace domain::CoordinateMaps {
+
+/*!
+ * \brief Distorts cartesian coordinates \f$x^i\f$ such that a coordinate sphere
+ * \f$\delta_{ij}x^ix^j=C\f$ is mapped to an ellipsoid of constant
+ * Kerr-Schild radius \f$r=C\f$.
+ *
+ * The Kerr-Schild radius \f$r\f$ is defined as the largest positive
+ * root of
+ *
+ *  \f{equation*}{
+ *  r^4 - r^2 (x^2 - a^2) - (\vec{a}\cdot \vec{x})^2 = 0.
+ *  \f}
+ *
+ * In this equation, \f$\vec{x}\f$ are the coordinates of the (distorted)
+ * surface, and \f$\vec{a}=\vec{S}/M\f$ is the spin-parameter of the black hole.
+ * This is equivalent to the implicit definition of \f$r\f$ in Eq. (47) of
+ * \cite Lovelace2008tw. The black hole is assumed to be at the origin.
+ *
+ * \details Given a spin vector \f$\vec{a}\f$, we define the Kerr-Schild radius:
+ *
+ * \f{equation}{r(\vec{x}) = \sqrt{\frac{x^2 - a^2 + \sqrt{(x^2 -
+ * a^2)^2 + 4 (\vec{x} \cdot \vec{a})^2}}{2}} \f}
+ *
+ * We also define the auxiliary variable:
+ *
+ * \f{equation}{s(\vec{x}) = \frac{x^2(x^2 + a^2)}{x^4 + (\vec{x}
+ * \cdot \vec{a})^2} \f}
+ *
+ * The map is then given by:
+ *
+ * \f{equation}{\vec{x}(\vec{\xi}) = \vec{\xi} \sqrt{s(\vec{\xi})} \f}
+ *
+ * The inverse map is given by:
+ * \f{equation}{\vec{\xi}(\vec{x}) = \vec{x} \frac{r(\vec{x})}{|\vec{x}|}
+ * \f}
+ *
+ * The jacobian is:
+ * \f{equation}{ \frac{\partial \xi^i}{\partial x^j} =
+ * \delta_{ij} \sqrt{s(\vec{\xi})} +
+ * \frac{\xi_j}{2 \sqrt{s(\vec{\xi})}} \frac{4\xi^2(1 -
+ * s(\vec{\xi})) \xi_j + 2a^2\xi_i + 2 s(\vec{\xi})
+ * (\vec{\xi} \cdot \vec{a}) a_i}{\xi^4 + (\vec{\xi} \cdot
+ * \vec{a})^2} \f}
+ *
+ * The inverse jacobian is:
+ * \f{equation}{\frac{\partial x^i}{\partial \xi^j} =
+ * \delta_{ij}\frac{r(\vec{x})}{|\vec{x}|}
+ * + \frac{r(\vec{x})^2 x_i + (\vec{x} \cdot \vec{a})a_i}{2r(\vec{x})^3
+ * - r(\vec{x}) (x^2 - a^2)}\frac{x_j}{|\vec{x}|} - \frac{r(\vec{x})
+ * x_i x_j}{x^3} \f}
+ */
+class KerrHorizonConforming {
+ public:
+  KerrHorizonConforming() = default;
+  static constexpr size_t dim = 3;
+  /*!
+   * constructs a Kerr horizon conforming map.
+   * \param spin : the dimensionless spin
+   */
+  explicit KerrHorizonConforming(std::array<double, 3> spin);
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  std::optional<std::array<double, 3>> inverse(
+      const std::array<double, 3>& target_coords) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> jacobian(
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> inv_jacobian(
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  bool is_identity() const noexcept {
+    return spin_ == std::array<double, 3>{0., 0., 0.};
+  }
+
+  friend bool operator==(const KerrHorizonConforming& lhs,
+                         const KerrHorizonConforming& rhs) noexcept;
+
+  void pup(PUP::er& p);
+
+ private:
+  template <typename T>
+  void stretch_factor_square(
+      const gsl::not_null<tt::remove_cvref_wrap_t<T>*> result,
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  std::array<double, 3> spin_;
+  double spin_mag_sq_;
+};
+bool operator!=(const KerrHorizonConforming& lhs,
+                const KerrHorizonConforming& rhs) noexcept;
+
+}  // namespace domain::CoordinateMaps

--- a/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
@@ -17,6 +17,7 @@ set(LIBRARY_SOURCES
   Test_Equiangular.cpp
   Test_Frustum.cpp
   Test_Identity.cpp
+  Test_KerrHorizonConforming.cpp
   Test_ProductMaps.cpp
   Test_Rotation.cpp
   Test_SpecialMobius.cpp

--- a/tests/Unit/Domain/CoordinateMaps/Test_KerrHorizonConforming.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_KerrHorizonConforming.cpp
@@ -1,0 +1,81 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/CoordinateMaps/KerrHorizonConforming.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
+
+namespace {
+
+void test_map_helpers(const gsl::not_null<std::mt19937*> generator) {
+  std::uniform_real_distribution spin_dist{-1. / sqrt(3), 1. / sqrt(3)};
+  const auto spin =
+      make_with_random_values<std::array<double, 3>>(generator, spin_dist, 3);
+  const domain::CoordinateMaps::KerrHorizonConforming map(spin);
+  std::uniform_real_distribution point_dist{-10., 10.};
+  const auto random_point =
+      make_with_random_values<std::array<double, 3>>(generator, point_dist, 3);
+  test_serialization(map);
+  test_coordinate_map_argument_types(map, random_point);
+  test_inverse_map(map, random_point);
+  test_jacobian(map, random_point);
+  test_inv_jacobian(map, random_point);
+}
+
+void test_no_spin(const gsl::not_null<std::mt19937*> generator) {
+  const std::array<double, 3> spin{0., 0., 0.};
+  std::uniform_real_distribution dist{-10., 10.};
+  const auto coords =
+      make_with_random_values<std::array<double, 3>>(generator, dist, 3);
+  const auto map = domain::CoordinateMaps::KerrHorizonConforming(spin);
+  const auto res = map(coords);
+  CHECK_ITERABLE_APPROX(coords, res);
+}
+
+void test_random_spin(const gsl::not_null<std::mt19937*> generator) {
+  std::uniform_real_distribution spin_dist{-1. / sqrt(3), 1. / sqrt(3)};
+  const auto spin =
+      make_with_random_values<std::array<double, 3>>(generator, spin_dist, 3);
+  // test coordinates on unit sphere
+  std::uniform_real_distribution point_dist{-10., 10.};
+  const size_t number_of_points = 1000;
+  auto coords = make_with_random_values<std::array<DataVector, 3>>(
+      generator, point_dist, number_of_points);
+  coords = coords / magnitude(coords);
+
+  const auto map = domain::CoordinateMaps::KerrHorizonConforming(spin);
+  const auto mapped_coords = map(coords);
+
+  const DataVector coords_sq_min_spin_sq =
+      dot(mapped_coords, mapped_coords) - dot(spin, spin);
+
+  // explicit expression for Kerr-Schild radius r
+  DataVector r = coords_sq_min_spin_sq +
+                 sqrt(coords_sq_min_spin_sq * coords_sq_min_spin_sq +
+                      4 * dot(mapped_coords, spin) * dot(mapped_coords, spin));
+  r = sqrt(r / 2.);
+
+  for (const auto& val : r) {
+    CHECK(val == approx(1.));
+  }
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.KerrHorizonConforming",
+                  "[Domain][Unit]") {
+  MAKE_GENERATOR(generator);
+  test_map_helpers(make_not_null(&generator));
+  test_no_spin(make_not_null(&generator));
+  test_random_spin(make_not_null(&generator));
+}


### PR DESCRIPTION
## Proposed changes
Adds the horizon conforming map as needed for the Moncrief Fishbone initial data. 
It assumes that the black hole has the coordinate origin at its center as it did for spec though this can be changed.

~~depends on #3114~~ (merged) 
<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
