### PR TITLE
Subcell: add ability reconstruct neighbor fluxes, AO-WENO(5,3)

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -64,6 +64,19 @@
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@article{Balsara2016780,
+  title =   {An efficient class of WENO schemes with adaptive order},
+  journal = {Journal of Computational Physics},
+  volume =  326,
+  pages =   {780-804},
+  year =    2016,
+  issn =    {0021-9991},
+  doi =     {10.1016/j.jcp.2016.09.009},
+  url =     {https://www.sciencedirect.com/science/article/pii/S0021999116304211},
+  author =  {Dinshaw S. Balsara and Sudip Garain and Chi-Wang Shu}
+}
+
+
 @article{Barkett2019uae,
       author         = "Barkett, Kevin and Moxon, Jordan and Scheel, Mark A. and
                         Szilágyi, Béla",
@@ -182,6 +195,22 @@
       primaryClass   = "gr-qc",
       SLACcitation   = "%%CITATION = GR-QC/9801070;%%"
 }
+
+@article{Borges20083191,
+  title =   {An improved weighted essentially non-oscillatory scheme for
+             hyperbolic conservation laws},
+  journal = {Journal of Computational Physics},
+  volume =  227,
+  number =  6,
+  pages =   {3191-3211},
+  year =    2008,
+  issn =    {0021-9991},
+  doi =     {10.1016/j.jcp.2007.11.038},
+  url =   {https://www.sciencedirect.com/science/article/pii/S0021999107005232},
+  author = {Rafael Borges and Monique Carmona and Bruno Costa and Wai Sun
+                  Don},
+}
+
 
 @article{Boyle:2015nqa,
   author =       "Boyle, Michael",

--- a/src/NumericalAlgorithms/FiniteDifference/AoWeno.cpp
+++ b/src/NumericalAlgorithms/FiniteDifference/AoWeno.cpp
@@ -1,0 +1,54 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/FiniteDifference/AoWeno.hpp"
+
+#include <array>
+
+#include "NumericalAlgorithms/FiniteDifference/Reconstruct.tpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace fd::reconstruction {
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define NONLINEAR_WEIGHT_EXPONENT(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATION(r, data)                                                 \
+  template void                                                                \
+  reconstruct<AoWeno53Reconstructor<NONLINEAR_WEIGHT_EXPONENT(data)>>(         \
+      gsl::not_null<std::array<gsl::span<double>, DIM(data)>*>                 \
+          reconstructed_upper_side_of_face_vars,                               \
+      gsl::not_null<std::array<gsl::span<double>, DIM(data)>*>                 \
+          reconstructed_lower_side_of_face_vars,                               \
+      const gsl::span<const double>& volume_vars,                              \
+      const DirectionMap<DIM(data), gsl::span<const double>>& ghost_cell_vars, \
+      const Index<DIM(data)>& volume_extents,                                  \
+      const size_t number_of_variables, const double& gamma_hi,                \
+      const double& gamma_lo, const double& epsilon) noexcept;
+
+namespace detail {
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (2, 4, 6, 8, 10, 12))
+}  // namespace detail
+
+#undef INSTANTIATION
+
+#define SIDE(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATION(r, data)                                                 \
+  template void reconstruct_neighbor<                                          \
+      SIDE(data),                                                              \
+      detail::AoWeno53Reconstructor<NONLINEAR_WEIGHT_EXPONENT(data)>>(         \
+      gsl::not_null<DataVector*> face_data, const DataVector& volume_data,     \
+      const DataVector& neighbor_data, const Index<DIM(data)>& volume_extents, \
+      const Index<DIM(data)>& ghost_data_extents,                              \
+      const Direction<DIM(data)>& direction_to_reconstruct,                    \
+      const double& gamma_hi, const double& gamma_lo,                          \
+      const double& epsilon) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (2, 4, 6, 8, 10, 12),
+                        (Side::Upper, Side::Lower))
+
+#undef INSTANTIATION
+#undef SIDE
+#undef NONLINEAR_WEIGHT_EXPONENT
+#undef DIM
+}  // namespace fd::reconstruction

--- a/src/NumericalAlgorithms/FiniteDifference/AoWeno.cpp
+++ b/src/NumericalAlgorithms/FiniteDifference/AoWeno.cpp
@@ -6,10 +6,106 @@
 #include <array>
 
 #include "NumericalAlgorithms/FiniteDifference/Reconstruct.tpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
 namespace fd::reconstruction {
+template <size_t Dim>
+std::tuple<
+    void (*)(gsl::not_null<std::array<gsl::span<double>, Dim>*>,
+             gsl::not_null<std::array<gsl::span<double>, Dim>*>,
+             const gsl::span<const double>&,
+             const DirectionMap<Dim, gsl::span<const double>>&,
+             const Index<Dim>&, size_t, double, double, double) noexcept,
+    void (*)(gsl::not_null<DataVector*>, const DataVector&, const DataVector&,
+             const Index<Dim>&, const Index<Dim>&, const Direction<Dim>&,
+             const double&, const double&, const double&) noexcept,
+    void (*)(gsl::not_null<DataVector*>, const DataVector&, const DataVector&,
+             const Index<Dim>&, const Index<Dim>&, const Direction<Dim>&,
+             const double&, const double&, const double&) noexcept>
+aoweno_53_function_pointers(const size_t nonlinear_weight_exponent) noexcept {
+  switch (nonlinear_weight_exponent) {
+    case 2:
+      return {&aoweno_53<2, Dim>,
+              &::fd::reconstruction::reconstruct_neighbor<
+                  Side::Lower,
+                  ::fd::reconstruction::detail::AoWeno53Reconstructor<2>, Dim>,
+              &::fd::reconstruction::reconstruct_neighbor<
+                  Side::Upper,
+                  ::fd::reconstruction::detail::AoWeno53Reconstructor<2>, Dim>};
+    case 4:
+      return {&aoweno_53<4, Dim>,
+              &::fd::reconstruction::reconstruct_neighbor<
+                  Side::Lower,
+                  ::fd::reconstruction::detail::AoWeno53Reconstructor<4>, Dim>,
+              &::fd::reconstruction::reconstruct_neighbor<
+                  Side::Upper,
+                  ::fd::reconstruction::detail::AoWeno53Reconstructor<4>, Dim>};
+    case 6:
+      return {&aoweno_53<6, Dim>,
+              &::fd::reconstruction::reconstruct_neighbor<
+                  Side::Lower,
+                  ::fd::reconstruction::detail::AoWeno53Reconstructor<6>, Dim>,
+              &::fd::reconstruction::reconstruct_neighbor<
+                  Side::Upper,
+                  ::fd::reconstruction::detail::AoWeno53Reconstructor<6>, Dim>};
+    case 8:
+      return {&aoweno_53<8, Dim>,
+              &::fd::reconstruction::reconstruct_neighbor<
+                  Side::Lower,
+                  ::fd::reconstruction::detail::AoWeno53Reconstructor<8>, Dim>,
+              &::fd::reconstruction::reconstruct_neighbor<
+                  Side::Upper,
+                  ::fd::reconstruction::detail::AoWeno53Reconstructor<8>, Dim>};
+    case 10:
+      return {
+          &aoweno_53<10, Dim>,
+          &::fd::reconstruction::reconstruct_neighbor<
+              Side::Lower,
+              ::fd::reconstruction::detail::AoWeno53Reconstructor<10>, Dim>,
+          &::fd::reconstruction::reconstruct_neighbor<
+              Side::Upper,
+              ::fd::reconstruction::detail::AoWeno53Reconstructor<10>, Dim>};
+    case 12:
+      return {
+          &aoweno_53<12, Dim>,
+          &::fd::reconstruction::reconstruct_neighbor<
+              Side::Lower,
+              ::fd::reconstruction::detail::AoWeno53Reconstructor<12>, Dim>,
+          &::fd::reconstruction::reconstruct_neighbor<
+              Side::Upper,
+              ::fd::reconstruction::detail::AoWeno53Reconstructor<12>, Dim>};
+    default:
+      ERROR("Unsupported nonlinear weight exponent "
+            << nonlinear_weight_exponent << " only have 2,4,6,8,10,12 allowed");
+  };
+}
+
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data)                                           \
+  template std::tuple<                                                   \
+      void (*)(gsl::not_null<std::array<gsl::span<double>, DIM(data)>*>, \
+               gsl::not_null<std::array<gsl::span<double>, DIM(data)>*>, \
+               const gsl::span<const double>&,                           \
+               const DirectionMap<DIM(data), gsl::span<const double>>&,  \
+               const Index<DIM(data)>&, size_t, double, double,          \
+               double) noexcept,                                         \
+      void (*)(gsl::not_null<DataVector*>, const DataVector&,            \
+               const DataVector&, const Index<DIM(data)>&,               \
+               const Index<DIM(data)>&, const Direction<DIM(data)>&,     \
+               const double&, const double&, const double&) noexcept,    \
+      void (*)(gsl::not_null<DataVector*>, const DataVector&,            \
+               const DataVector&, const Index<DIM(data)>&,               \
+               const Index<DIM(data)>&, const Direction<DIM(data)>&,     \
+               const double&, const double&, const double&) noexcept>    \
+  aoweno_53_function_pointers(                                           \
+      const size_t nonlinear_weight_exponent) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+
 #define NONLINEAR_WEIGHT_EXPONENT(data) BOOST_PP_TUPLE_ELEM(1, data)
 
 #define INSTANTIATION(r, data)                                                 \

--- a/src/NumericalAlgorithms/FiniteDifference/AoWeno.hpp
+++ b/src/NumericalAlgorithms/FiniteDifference/AoWeno.hpp
@@ -336,4 +336,29 @@ void aoweno_53(
       reconstructed_lower_side_of_face_vars, volume_vars, ghost_cell_vars,
       volume_extents, number_of_variables, gamma_hi, gamma_lo, epsilon);
 }
+
+/*!
+ * \brief Returns function pointers to the `aoweno_53` function, lower neighbor
+ * reconstruction, and upper neighbor reconstruction.
+ *
+ * This is useful for controlling template parameters like the
+ * `NonlinearWeightExponent` from an input file by setting a function pointer.
+ * Note that the reason the reconstruction functions instead of say the
+ * `pointwise` member function is returned is to avoid function pointers inside
+ * tight loops.
+ */
+template <size_t Dim>
+std::tuple<
+    void (*)(gsl::not_null<std::array<gsl::span<double>, Dim>*>,
+             gsl::not_null<std::array<gsl::span<double>, Dim>*>,
+             const gsl::span<const double>&,
+             const DirectionMap<Dim, gsl::span<const double>>&,
+             const Index<Dim>&, size_t, double, double, double) noexcept,
+    void (*)(gsl::not_null<DataVector*>, const DataVector&, const DataVector&,
+             const Index<Dim>&, const Index<Dim>&, const Direction<Dim>&,
+             const double&, const double&, const double&) noexcept,
+    void (*)(gsl::not_null<DataVector*>, const DataVector&, const DataVector&,
+             const Index<Dim>&, const Index<Dim>&, const Direction<Dim>&,
+             const double&, const double&, const double&) noexcept>
+aoweno_53_function_pointers(size_t nonlinear_weight_exponent) noexcept;
 }  // namespace fd::reconstruction

--- a/src/NumericalAlgorithms/FiniteDifference/AoWeno.hpp
+++ b/src/NumericalAlgorithms/FiniteDifference/AoWeno.hpp
@@ -1,0 +1,339 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <utility>
+
+#include "NumericalAlgorithms/FiniteDifference/Reconstruct.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ForceInline.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Math.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+template <size_t Dim>
+class Direction;
+template <size_t Dim>
+class Index;
+/// \endcond
+
+namespace fd::reconstruction {
+namespace detail {
+template <size_t NonlinearWeightExponent>
+struct AoWeno53Reconstructor {
+  SPECTRE_ALWAYS_INLINE static std::array<double, 2> pointwise(
+      const double* const u, const int stride, const double gamma_hi,
+      const double gamma_lo, const double epsilon) noexcept {
+    ASSERT(gamma_hi <= 1.0 and gamma_hi >= 0.0,
+           "gamma_hi must be in [0.0, 1.0] but is " << gamma_hi);
+    ASSERT(gamma_lo <= 1.0 and gamma_lo >= 0.0,
+           "gamma_lo must be in [0.0, 1.0] but is " << gamma_lo);
+    ASSERT(epsilon > 0.0,
+           "epsilon must be greater than zero but is " << epsilon);
+
+    const std::array moments_sr3_1{
+        1.041666666666666 * u[0] - 0.08333333333333333 * u[-stride] +
+            0.04166666666666666 * u[-2 * stride],
+        0.5 * u[-2 * stride] - 2.0 * u[-stride] + 1.5 * u[0],
+        0.5 * u[-2 * stride] - u[-stride] + 0.5 * u[0]};
+    const std::array moments_sr3_2{0.04166666666666666 * u[stride] +
+                                       0.9166666666666666 * u[0] +
+                                       0.04166666666666666 * u[-stride],
+                                   0.5 * (u[stride] - u[-stride]),
+                                   0.5 * u[-stride] - u[0] + 0.5 * u[stride]};
+    const std::array moments_sr3_3{
+        0.04166666666666666 * u[2 * stride] - 0.08333333333333333 * u[stride] +
+            1.04166666666666666 * u[0],
+        -1.5 * u[0] + 2.0 * u[stride] - 0.5 * u[2 * stride],
+        0.5 * u[0] - u[stride] + 0.5 * u[2 * stride]};
+    const std::array moments_sr5{-2.95138888888888881e-03 * u[-2 * stride] +
+                                     5.34722222222222196e-02 * u[-stride] +
+                                     8.98958333333333304e-01 * u[0] +
+                                     5.34722222222222196e-02 * u[stride] +
+                                     -2.95138888888888881e-03 * u[2 * stride],
+                                 7.08333333333333315e-02 * u[-2 * stride] +
+                                     -6.41666666666666718e-01 * u[-stride] +
+                                     6.41666666666666718e-01 * u[stride] +
+                                     -7.08333333333333315e-02 * u[2 * stride],
+                                 -3.27380952380952397e-02 * u[-2 * stride] +
+                                     6.30952380952380931e-01 * u[-stride] +
+                                     -1.19642857142857140e+00 * u[0] +
+                                     6.30952380952380931e-01 * u[stride] +
+                                     -3.27380952380952397e-02 * u[2 * stride],
+                                 -8.33333333333333287e-02 * u[-2 * stride] +
+                                     1.66666666666666657e-01 * u[-stride] +
+                                     -1.66666666666666657e-01 * u[stride] +
+                                     8.33333333333333287e-02 * u[2 * stride],
+                                 4.16666666666666644e-02 * u[-2 * stride] +
+                                     -1.66666666666666657e-01 * u[-stride] +
+                                     2.50000000000000000e-01 * u[0] +
+                                     -1.66666666666666657e-01 * u[stride] +
+                                     4.16666666666666644e-02 * u[2 * stride]};
+
+    // These are the "first alternative" oscillation indicators
+    constexpr double beta_r3_factor = 37.0 / 3.0;
+    const std::array beta_r3{
+        square(moments_sr3_1[1]) + beta_r3_factor * square(moments_sr3_1[2]),
+        square(moments_sr3_2[1]) + beta_r3_factor * square(moments_sr3_2[2]),
+        square(moments_sr3_3[1]) + beta_r3_factor * square(moments_sr3_3[2])};
+    const double beta_sr5 = square(moments_sr5[1]) +
+                            61.0 / 5.0 * moments_sr5[1] * moments_sr5[3] +
+                            37.0 / 3.0 * square(moments_sr5[2]) +
+                            1538.0 / 7.0 * moments_sr5[2] * moments_sr5[4] +
+                            8973.0 / 50.0 * square(moments_sr5[3]) +
+                            167158.0 / 49.0 * square(moments_sr5[4]);
+
+    // Compute linear and normalized nonlinear weights
+    const std::array linear_weights{
+        gamma_hi, 0.5 * (1.0 - gamma_hi) * (1.0 - gamma_lo),
+        (1.0 - gamma_hi) * gamma_lo, 0.5 * (1.0 - gamma_hi) * (1.0 - gamma_lo)};
+    std::array nonlinear_weights{
+        linear_weights[0] / pow<NonlinearWeightExponent>(beta_sr5 + epsilon),
+        linear_weights[1] / pow<NonlinearWeightExponent>(beta_r3[0] + epsilon),
+        linear_weights[2] / pow<NonlinearWeightExponent>(beta_r3[1] + epsilon),
+        linear_weights[3] / pow<NonlinearWeightExponent>(beta_r3[2] + epsilon)};
+    const double normalization = nonlinear_weights[0] + nonlinear_weights[1] +
+                                 nonlinear_weights[2] + nonlinear_weights[3];
+    for (double& nw : nonlinear_weights) {
+      nw /= normalization;
+    }
+
+    const std::array<double, 5> moments{
+        {nonlinear_weights[0] / linear_weights[0] *
+                 (moments_sr5[0] - linear_weights[1] * moments_sr3_1[0] -
+                  linear_weights[2] * moments_sr3_2[0] -
+                  linear_weights[3] * moments_sr3_3[0]) +
+             nonlinear_weights[1] * moments_sr3_1[0] +
+             nonlinear_weights[2] * moments_sr3_2[0] +
+             nonlinear_weights[3] * moments_sr3_3[0],
+         nonlinear_weights[0] / linear_weights[0] *
+                 (moments_sr5[1] - linear_weights[1] * moments_sr3_1[1] -
+                  linear_weights[2] * moments_sr3_2[1] -
+                  linear_weights[3] * moments_sr3_3[1]) +
+             nonlinear_weights[1] * moments_sr3_1[1] +
+             nonlinear_weights[2] * moments_sr3_2[1] +
+             nonlinear_weights[3] * moments_sr3_3[1],
+         nonlinear_weights[0] / linear_weights[0] *
+                 (moments_sr5[2] - linear_weights[1] * moments_sr3_1[2] -
+                  linear_weights[2] * moments_sr3_2[2] -
+                  linear_weights[3] * moments_sr3_3[2]) +
+             nonlinear_weights[1] * moments_sr3_1[2] +
+             nonlinear_weights[2] * moments_sr3_2[2] +
+             nonlinear_weights[3] * moments_sr3_3[2],
+         nonlinear_weights[0] / linear_weights[0] * moments_sr5[3],
+         nonlinear_weights[0] / linear_weights[0] * moments_sr5[4]}};
+
+    // The polynomial values (excluding the L_0(x)) at the lower/upper faces.
+    // The polynomials are (x in [-0.5,0.5]):
+    // L0(x)=1.0 (not in array)
+    // L1(x)=x
+    // L2(x)=x^2-1/12
+    // L3(x)=x^3 - (3/20) x
+    // L4(x)=x^4 - (3/14) x^2 + 3/560
+    const std::array polys_at_plus_half{0.5, 0.16666666666666666, 0.05,
+                                        0.014285714285714289};
+
+    return {{moments[0] - polys_at_plus_half[0] * moments[1] +
+                 polys_at_plus_half[1] * moments[2] -
+                 polys_at_plus_half[2] * moments[3] +
+                 polys_at_plus_half[3] * moments[4],
+             moments[0] + polys_at_plus_half[0] * moments[1] +
+                 polys_at_plus_half[1] * moments[2] +
+                 polys_at_plus_half[2] * moments[3] +
+                 polys_at_plus_half[3] * moments[4]}};
+  }
+
+  SPECTRE_ALWAYS_INLINE static constexpr size_t stencil_width() noexcept {
+    return 5;
+  }
+};
+}  // namespace detail
+
+/*!
+ * \ingroup FiniteDifferenceGroup
+ * \brief Performs an adaptive order (AO) WENO reconstruction using a single 5th
+ * order stencil and a 3rd-order CWENO scheme.
+ *
+ * The AO-WENO(5,3) scheme is based on the scheme presented in
+ * \cite Balsara2016780 but adjusted to do reconstruction on variables instead
+ * of fluxes. The Legendre basis functions on the domain \f$\xi\in[-1/2,1/2]\f$
+ * are given by:
+ *
+ * \f{align*}{
+ * L_0(\xi) &= 1 \\
+ * L_1(\xi) &= \xi \\
+ * L_2(\xi) &= \xi^2-\frac{1}{12} \\
+ * L_3(\xi) &= \xi^3 - \frac{3}{20} \xi \\
+ * L_4(\xi) &= \xi^4 - \frac{3}{14} \xi^2 + \frac{3}{560}
+ * \f}
+ *
+ * The oscillation indicators are given by
+ *
+ * \f{align*}{
+ * \beta_l = \sum_{k=1}^{p}\sum_{m=1}^{p}\sigma_{km} u_{k,l} u_{m,l}
+ * \f}
+ *
+ * where \f$p\f$ is the maximum degree of the basis function used for the
+ * stencil \f$l\f$, and
+ *
+ * \f{align*}{
+ * \sigma_{km}=\sum_{i=1}^{p}\int_{-1/2}^{1/2}
+ * \frac{d^i L_k(\xi)}{d\xi^i}\frac{d^i L_m(\xi)}{d\xi^i}d\xi
+ * \f}
+ *
+ * We write the 3rd-order reconstructed polynomial \f$P^{r3}_l(\xi)\f$
+ * associated with the stencil \f$S^{r3}_l\f$ as
+ *
+ * \f{align*}{
+ * P^{r3}_l(\xi) = u_0 +u_{\xi} L_1(\xi) + u_{\xi 2} L_2(\xi)
+ * \f}
+ *
+ * For the stencil \f$S^{r3}_1\f$ we get
+ *
+ * \f{align*}{
+ *  u_0 &= \frac{25}{24} u_{j} -\frac{1}{12} u_{j-1} + \frac{1}{24} u_{j-2} \\
+ *  u_{\xi} &= \frac{1}{2}u_{j-2} - 2 u_{j-1} + \frac{3}{2} u_j \\
+ *  u_{\xi2} &= \frac{1}{2} u_{j-2} - u_{j-1} + \frac{1}{2} u_j
+ * \f}
+ *
+ * For the stencil \f$S^{r3}_2\f$ we get
+ *
+ * \f{align*}{
+ *  u_0 &= \frac{1}{24} u_{j-1} + \frac{11}{12} u_{j} + \frac{1}{24} u_{j+1} \\
+ *  u_{\xi} &= \frac{1}{2}(u_{j+1} - u_{j-1}) \\
+ *  u_{\xi2} &= \frac{1}{2} u_{j-1} - u_{j} + \frac{1}{2} u_{j+1}
+ * \f}
+ *
+ * For the stencil \f$S^{r3}_3\f$ we get
+ *
+ * \f{align*}{
+ *  u_0 &= \frac{25}{24} u_{j} -\frac{1}{12} u_{j+1} + \frac{1}{24} u_{j+2} \\
+ *  u_{\xi} &= -\frac{1}{2}u_{j+2} + 2 u_{j+1} - \frac{3}{2} u_j \\
+ *  u_{\xi2} &= \frac{1}{2} u_{j+2} - u_{j+1} + \frac{1}{2} u_j
+ * \f}
+ *
+ * The oscillation indicator for the 3rd-order stencils is given by
+ *
+ * \f{align*}{
+ *  \beta^{r3}_l = \left(u_{\xi}\right)^2+\frac{13}{3}\left(u_{\xi2}\right)^2
+ * \f}
+ *
+ * We write the 5th-order reconstructed polynomial \f$P^{r5}(\xi)\f$ as
+ *
+ * \f{align*}{
+ * P^{r5}_l(\xi) = u_0 +u_{\xi} L_1(\xi) + u_{\xi 2} L_2(\xi)
+ *  + u_{\xi3} L_3(\xi) + u_{\xi4} L_4(\xi)
+ * \f}
+ *
+ * with
+ *
+ * \f{align*}{
+ * u_0 &= -\frac{17}{5760} u_{j-2} + \frac{77}{1440} u_{j-1} +
+ *        \frac{863}{960} u_{j} + \frac{77}{1440} u_{j+1} -
+ *        \frac{17}{5760} u_{j+2} \\
+ * u_{\xi} &= \frac{17}{240} u_{j-2} - \frac{77}{120} u_{j-1} +
+ *           \frac{77}{120} u_{j+1} - \frac{17}{240} u_{j+2} \\
+ * u_{\xi2} &= -\frac{11}{336} u_{j-2} + \frac{53}{84} u_{j-1} -
+ *            \frac{67}{56} u_{j} + \frac{53}{84} u_{j+1} -
+ *            \frac{11}{336} u_{j+2} \\
+ * u_{\xi3} &= -\frac{1}{12} u_{j-2} + \frac{1}{6} u_{j-1}
+ *            -\frac{1}{6} u_{j+1} + \frac{1}{12} u_{j+2} \\
+ * u_{\xi4} &= \frac{1}{24} u_{j-2} -\frac{1}{6} u_{j-1}
+ *           +\frac{1}{4} u_{j} - \frac{1}{6}u_{j+1}+\frac{1}{24}u_{j+2}
+ * \f}
+ *
+ * The oscillation indicator is given by
+ *
+ * \f{align*}{
+ *  \beta^{r5}&=\left(u_{\xi}+\frac{1}{10}u_{\xi3}\right)^2 \\
+ *             &+\frac{13}{3}\left(u_{\xi2}+\frac{123}{455}u_{\xi4}\right)^2\\
+ *             &+\frac{781}{20}(u_{\xi3})^2+\frac{1421461}{2275}(u_{\xi4})^2
+ * \f}
+ *
+ * There are two linear weights \f$\gamma_{\mathrm{hi}}\f$ and
+ * \f$\gamma_{\mathrm{lo}}\f$. \f$\gamma_{\mathrm{hi}}\f$ controls how much of
+ * the 5th-order stencil is used in smooth regions, while
+ * \f$\gamma_{\mathrm{lo}}\f$ controls the linear weight of the central
+ * 3rd-order stencil. For larger \f$\gamma_{\mathrm{lo}}\f$, the 3rd-order
+ * method is more centrally weighted. The linear weights for the stencils
+ * are given by
+ *
+ * \f{align*}{
+ *  \gamma^{r5}&=\gamma_{\mathrm{hi}} \\
+ *  \gamma^{r3}_1& = (1-\gamma_{\mathrm{hi}})(1-\gamma_{\mathrm{lo}})/2 \\
+ *  \gamma^{r3}_2& = (1-\gamma_{\mathrm{hi}})\gamma_{\mathrm{lo}} \\
+ *  \gamma^{r3}_3& = (1-\gamma_{\mathrm{hi}})(1-\gamma_{\mathrm{lo}})/2
+ * \f}
+ *
+ * We use the standard nonlinear weights instead of the "Z" weights of
+ * \cite Borges20083191
+ *
+ * \f{align*}{
+ *  w^{r5}&=\frac{\gamma^{r5}}{(\beta^{r5}+\epsilon)^q} \\
+ *  w^{r3}_l&=\frac{\gamma^{r3}_l}{(\beta^{r3}_l+\epsilon)^q}
+ * \f}
+ *
+ * where \f$\epsilon\f$ is a small number used to avoid division by zero. The
+ * normalized nonlinear weights are denoted by \f$\bar{w}^{r5}\f$ and
+ * \f$\bar{w}_l^{r3}\f$. The final reconstructed polynomial \f$P(\xi)\f$ is
+ * given by
+ *
+ * \f{align*}{
+ *  P(\xi)&=\frac{\bar{w}^{r5}}{\gamma^{r5}}
+ *   \left(P^{r5}(\xi)-\gamma^{r3}_1P^{r3}_1(\xi)
+ *         -\gamma^{r3}_2P^{r3}_2(\xi)-\gamma^{r3}_3P^{r3}_3(\xi)\right) \\
+ *  &+\bar{w}^{r3}_1P^{r3}_1(\xi)+\bar{w}^{r3}_2P^{r3}_2(\xi)
+ *  +\bar{w}^{r3}_3P^{r3}_3(\xi)
+ * \f}
+ *
+ * The weights \f$\gamma_{\mathrm{hi}}\f$ and \f$\gamma_{\mathrm{lo}}\f$
+ * are typically chosen to be in the range \f$[0.85,0.95]\f$.
+ *
+ * ### First alternative oscillation indicators
+ *
+ * Instead of integrating over just the cell, we can instead integrate the basis
+ * functions over the entire fit interval, \f$[-5/2,5/2]\f$. Using this interval
+ * for the \f$S^{r3}_l\f$ and the \f$S^{r5}\f$ stencils we get
+ *
+ * \f{align*}{
+ *  \beta^{r3}_l&=(u_{\xi})^2 + \frac{37}{3} (u_{\xi2})^2 \\
+ *  \beta^{r5}  &=\left(u_{\xi}+\frac{61}{10}u_{\xi3}\right)^2
+ *   + \frac{569}{4}u_{\xi3}^2 \\
+ *  &+ \frac{1}{8190742}\left(5383 u_{\xi2} + 167158 u_{\xi4}\right)^2
+ *  +\frac{4410763}{501474}(u_{\xi2})^2 \\
+ * &=u_{\xi}^2 + \frac{61}{5}u_{\xi}u_{\xi3} + \frac{37}{3}u_{\xi2}^2
+ *  + \frac{1538}{7}u_{\xi2}u_{\xi4} \\
+ * &+ \frac{8973}{50}u_{\xi3}^2 + \frac{167158}{49}u_{\xi4}^2
+ * \f}
+ *
+ * Note that the indicator is manifestly non-negative, a required property of
+ * oscillation indicators. These indicators weight high modes more, which means
+ * the scheme is more sensitive to high-frequency features in the solution.
+ *
+ * \note currently it is the alternative indicators that are used. However, an
+ * option to control which are used can readily be added, probably best done
+ * as a template parameter with `if constexpr` to avoid conditionals inside
+ * tight loops.
+ */
+template <size_t NonlinearWeightExponent, size_t Dim>
+void aoweno_53(
+    const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+        reconstructed_upper_side_of_face_vars,
+    const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+        reconstructed_lower_side_of_face_vars,
+    const gsl::span<const double>& volume_vars,
+    const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+    const Index<Dim>& volume_extents, const size_t number_of_variables,
+    const double gamma_hi, const double gamma_lo,
+    const double epsilon) noexcept {
+  detail::reconstruct<detail::AoWeno53Reconstructor<NonlinearWeightExponent>>(
+      reconstructed_upper_side_of_face_vars,
+      reconstructed_lower_side_of_face_vars, volume_vars, ghost_cell_vars,
+      volume_extents, number_of_variables, gamma_hi, gamma_lo, epsilon);
+}
+}  // namespace fd::reconstruction

--- a/src/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
+++ b/src/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
@@ -8,6 +8,7 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  AoWeno.cpp
   Minmod.cpp
   MonotisedCentral.cpp
   )
@@ -16,6 +17,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  AoWeno.hpp
   FiniteDifference.hpp
   Minmod.hpp
   MonotisedCentral.hpp

--- a/src/NumericalAlgorithms/FiniteDifference/Minmod.cpp
+++ b/src/NumericalAlgorithms/FiniteDifference/Minmod.cpp
@@ -8,7 +8,8 @@
 #include "NumericalAlgorithms/FiniteDifference/Reconstruct.tpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
-namespace fd::reconstruction::detail {
+// NOLINTNEXTLINE(modernize-concat-nested-namespaces)
+namespace fd::reconstruction {
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATION(r, data)                                                 \
@@ -22,8 +23,25 @@ namespace fd::reconstruction::detail {
       const Index<DIM(data)>& volume_extents,                                  \
       const size_t number_of_variables) noexcept;
 
+namespace detail {
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+}  // namespace detail
 
-#undef DIM
+
 #undef INSTANTIATION
-}  // namespace fd::reconstruction::detail
+
+#define SIDE(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATION(r, data)                                                 \
+  template void reconstruct_neighbor<SIDE(data), detail::MinmodReconstructor>( \
+      gsl::not_null<DataVector*> face_data, const DataVector& volume_data,     \
+      const DataVector& neighbor_data, const Index<DIM(data)>& volume_extents, \
+      const Index<DIM(data)>& ghost_data_extents,                              \
+      const Direction<DIM(data)>& direction_to_reconstruct) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (Side::Upper, Side::Lower))
+
+#undef INSTANTIATION
+#undef SIDE
+#undef DIM
+}  // namespace fd::reconstruction

--- a/src/NumericalAlgorithms/FiniteDifference/MonotisedCentral.cpp
+++ b/src/NumericalAlgorithms/FiniteDifference/MonotisedCentral.cpp
@@ -8,7 +8,8 @@
 #include "NumericalAlgorithms/FiniteDifference/Reconstruct.tpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
-namespace fd::reconstruction::detail {
+// NOLINTNEXTLINE(modernize-concat-nested-namespaces)
+namespace fd::reconstruction {
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATION(r, data)                                                 \
@@ -22,8 +23,25 @@ namespace fd::reconstruction::detail {
       const Index<DIM(data)>& volume_extents,                                  \
       const size_t number_of_variables) noexcept;
 
+namespace detail {
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+}  // namespace detail
 
-#undef DIM
 #undef INSTANTIATION
-}  // namespace fd::reconstruction::detail
+
+#define SIDE(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATION(r, data)                                                 \
+  template void                                                                \
+  reconstruct_neighbor<SIDE(data), detail::MonotisedCentralReconstructor>(     \
+      gsl::not_null<DataVector*> face_data, const DataVector& volume_data,     \
+      const DataVector& neighbor_data, const Index<DIM(data)>& volume_extents, \
+      const Index<DIM(data)>& ghost_data_extents,                              \
+      const Direction<DIM(data)>& direction_to_reconstruct) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (Side::Upper, Side::Lower))
+
+#undef INSTANTIATION
+#undef SIDE
+#undef DIM
+}  // namespace fd::reconstruction

--- a/src/NumericalAlgorithms/FiniteDifference/Reconstruct.hpp
+++ b/src/NumericalAlgorithms/FiniteDifference/Reconstruct.hpp
@@ -7,9 +7,11 @@
 #include <cstddef>
 #include <utility>  // for std::pair
 
+#include "Domain/Structure/Side.hpp"
 #include "Utilities/Gsl.hpp"
 
 /// \cond
+class DataVector;
 template <size_t Dim>
 class Direction;
 template <size_t Dim, typename T>
@@ -89,7 +91,7 @@ namespace fd {
  */
 namespace reconstruction {
 namespace detail {
-template <typename Reconstructor, typename... ArgsForReconstructor, size_t Dim>
+template <typename Reconstructor, size_t Dim, typename... ArgsForReconstructor>
 void reconstruct(
     const gsl::not_null<std::array<gsl::span<double>, Dim>*>
         reconstructed_upper_side_of_face_vars,
@@ -100,5 +102,31 @@ void reconstruct(
     const Index<Dim>& volume_extents, const size_t number_of_variables,
     const ArgsForReconstructor&... args_for_reconstructor) noexcept;
 }  // namespace detail
+
+/*!
+ * \ingroup FiniteDifferenceGroup
+ * \brief In a given direction, reconstruct the cells in the neighboring Element
+ * (or cluster of cells) nearest to the shared boundary between the current and
+ * neighboring Element (or cluster of cells).
+ *
+ * This is needed if one is sending reconstruction and flux data separately, or
+ * if one is using DG-FD hybrid schemes. Below is an ASCII diagram of what is
+ * reconstructed.
+ *
+ * ```
+ *  Self      |  Neighbor
+ *  x x x x x | o o o
+ *            ^+
+ *            Reconstruct to right/+ side of the interface
+ * ```
+ */
+template <Side LowerOrUpperSide, typename Reconstructor, size_t Dim,
+          typename... ArgsForReconstructor>
+void reconstruct_neighbor(
+    gsl::not_null<DataVector*> face_data, const DataVector& volume_data,
+    const DataVector& neighbor_data, const Index<Dim>& volume_extents,
+    const Index<Dim>& ghost_data_extents,
+    const Direction<Dim>& direction_to_reconstruct,
+    const ArgsForReconstructor&... args_for_reconstructor) noexcept;
 }  // namespace reconstruction
 }  // namespace fd

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/AoWeno53.py
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/AoWeno53.py
@@ -1,0 +1,146 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+import Reconstruction
+
+
+def test_aoweno53(u, extents, dim):
+    gamma_hi = 0.85
+    gamma_lo = 0.999
+    epsilon = 1.0e-12
+    exponent = 8
+
+    def aoweno53(q):
+        j = 2
+        moments_sr3_1 = [
+            1.041666666666666 * q[j] - 0.08333333333333333 * q[j - 1] +
+            0.04166666666666666 * q[j - 2],
+            0.5 * q[j - 2] - 2.0 * q[j - 1] + 1.5 * q[j],
+            0.5 * q[j - 2] - q[j - 1] + 0.5 * q[j]
+        ]
+        moments_sr3_2 = [
+            0.04166666666666666 * q[j + 1] + 0.9166666666666666 * q[j] +
+            0.04166666666666666 * q[j - 1], 0.5 * (q[j + 1] - q[j - 1]),
+            0.5 * q[j - 1] - q[j] + 0.5 * q[j + 1]
+        ]
+        moments_sr3_3 = [
+            0.04166666666666666 * q[j + 2] - 0.08333333333333333 * q[j + 1] +
+            1.04166666666666666 * q[j],
+            -1.5 * q[j] + 2.0 * q[j + 1] - 0.5 * q[j + 2],
+            0.5 * q[j] - q[j + 1] + 0.5 * q[j + 2]
+        ]
+        moments_sr5 = [
+            -2.95138888888888881e-03 * q[j - 2] +
+            5.34722222222222196e-02 * q[j - 1] +
+            8.98958333333333304e-01 * q[j] +
+            5.34722222222222196e-02 * q[j + 1] +
+            -2.95138888888888881e-03 * q[j + 2],
+            7.08333333333333315e-02 * q[j - 2] +
+            -6.41666666666666718e-01 * q[j - 1] +
+            6.41666666666666718e-01 * q[j + 1] +
+            -7.08333333333333315e-02 * q[j + 2],
+            -3.27380952380952397e-02 * q[j - 2] +
+            6.30952380952380931e-01 * q[j - 1] +
+            -1.19642857142857140e+00 * q[j] +
+            6.30952380952380931e-01 * q[j + 1] +
+            -3.27380952380952397e-02 * q[j + 2],
+            -8.33333333333333287e-02 * q[j - 2] +
+            1.66666666666666657e-01 * q[j - 1] +
+            -1.66666666666666657e-01 * q[j + 1] +
+            8.33333333333333287e-02 * q[j + 2],
+            4.16666666666666644e-02 * q[j - 2] +
+            -1.66666666666666657e-01 * q[j - 1] +
+            2.50000000000000000e-01 * q[j] +
+            -1.66666666666666657e-01 * q[j + 1] +
+            4.16666666666666644e-02 * q[j + 2]
+        ]
+
+        beta_r3_1 = moments_sr3_1[1]**2 + 37.0 / 3.0 * moments_sr3_1[2]**2
+        beta_r3_2 = moments_sr3_2[1]**2 + 37.0 / 3.0 * moments_sr3_2[2]**2
+        beta_r3_3 = moments_sr3_3[1]**2 + 37.0 / 3.0 * moments_sr3_3[2]**2
+        beta_sr5 = (moments_sr5[1]**2 +
+                    61.0 / 5.0 * moments_sr5[1] * moments_sr5[3] +
+                    37.0 / 3.0 * moments_sr5[2]**2 +
+                    1538.0 / 7.0 * moments_sr5[2] * moments_sr5[4] +
+                    8973.0 / 50.0 * moments_sr5[3]**2 +
+                    167158.0 / 49.0 * moments_sr5[4]**2)
+
+        linear_weights = [
+            gamma_hi, 0.5 * (1.0 - gamma_hi) * (1.0 - gamma_lo),
+            (1.0 - gamma_hi) * gamma_lo,
+            0.5 * (1.0 - gamma_hi) * (1.0 - gamma_lo)
+        ]
+        nonlinear_weights = np.asarray([
+            linear_weights[0] / (beta_sr5 + epsilon)**exponent,
+            linear_weights[1] / (beta_r3_1 + epsilon)**exponent,
+            linear_weights[2] / (beta_r3_2 + epsilon)**exponent,
+            linear_weights[3] / (beta_r3_3 + epsilon)**exponent
+        ])
+        normalization = np.sum(nonlinear_weights)
+        nonlinear_weights = nonlinear_weights / normalization
+
+        moments = np.asarray([
+            nonlinear_weights[0] / linear_weights[0] *
+            (moments_sr5[0] - linear_weights[1] * moments_sr3_1[0] -
+             linear_weights[2] * moments_sr3_2[0] -
+             linear_weights[3] * moments_sr3_3[0]) +
+            nonlinear_weights[1] * moments_sr3_1[0] +
+            nonlinear_weights[2] * moments_sr3_2[0] +
+            nonlinear_weights[3] * moments_sr3_3[0],
+            nonlinear_weights[0] / linear_weights[0] *
+            (moments_sr5[1] - linear_weights[1] * moments_sr3_1[1] -
+             linear_weights[2] * moments_sr3_2[1] -
+             linear_weights[3] * moments_sr3_3[1]) +
+            nonlinear_weights[1] * moments_sr3_1[1] +
+            nonlinear_weights[2] * moments_sr3_2[1] +
+            nonlinear_weights[3] * moments_sr3_3[1],
+            nonlinear_weights[0] / linear_weights[0] *
+            (moments_sr5[2] - linear_weights[1] * moments_sr3_1[2] -
+             linear_weights[2] * moments_sr3_2[2] -
+             linear_weights[3] * moments_sr3_3[2]) +
+            nonlinear_weights[1] * moments_sr3_1[2] +
+            nonlinear_weights[2] * moments_sr3_2[2] +
+            nonlinear_weights[3] * moments_sr3_3[2],
+            nonlinear_weights[0] / linear_weights[0] * moments_sr5[3],
+            nonlinear_weights[0] / linear_weights[0] * moments_sr5[4]
+        ])
+
+        polys_at_plus_half = np.asarray(
+            [1.0, 0.5, 0.16666666666666666, 0.05, 0.014285714285714289])
+        polys_at_minus_half = np.asarray(
+            [1.0, -0.5, 0.16666666666666666, -0.05, 0.014285714285714289])
+        return [
+            np.sum(moments * polys_at_minus_half),
+            np.sum(moments * polys_at_plus_half)
+        ]
+
+    def compute_face_values(recons_upper_of_cell, recons_lower_of_cell, v, i,
+                            j, k, dim_to_recons):
+        if dim_to_recons == 0:
+            lower, upper = aoweno53(
+                np.asarray([
+                    v[i - 2, j, k], v[i - 1, j, k], v[i, j, k], v[i + 1, j, k],
+                    v[i + 2, j, k]
+                ]))
+            recons_lower_of_cell.append(lower)
+            recons_upper_of_cell.append(upper)
+        if dim_to_recons == 1:
+            lower, upper = aoweno53(
+                np.asarray([
+                    v[i, j - 2, k], v[i, j - 1, k], v[i, j, k], v[i, j + 1, k],
+                    v[i, j + 2, k]
+                ]))
+            recons_lower_of_cell.append(lower)
+            recons_upper_of_cell.append(upper)
+        if dim_to_recons == 2:
+            lower, upper = aoweno53(
+                np.asarray([
+                    v[i, j, k - 2], v[i, j, k - 1], v[i, j, k], v[i, j, k + 1],
+                    v[i, j, k + 2]
+                ]))
+            recons_lower_of_cell.append(lower)
+            recons_upper_of_cell.append(upper)
+
+    return Reconstruction.reconstruct(u, extents, dim, [2, 2, 2],
+                                      compute_face_values)

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_FiniteDifference")
 set(LIBRARY_SOURCES
   Test_Minmod.cpp
   Test_MonotisedCentral.cpp
+  Test_AoWeno53.cpp
   )
 
 add_test_library(

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_AoWeno53.cpp
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_AoWeno53.cpp
@@ -1,0 +1,125 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/Index.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Framework/Pypp.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/NumericalAlgorithms/FiniteDifference/Exact.hpp"
+#include "Helpers/NumericalAlgorithms/FiniteDifference/Python.hpp"
+#include "NumericalAlgorithms/FiniteDifference/AoWeno.hpp"
+
+namespace {
+
+template <size_t Dim>
+void test() {
+  const auto recons =
+      [](const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+             reconstructed_upper_side_of_face_vars,
+         const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+             reconstructed_lower_side_of_face_vars,
+         const gsl::span<const double>& volume_vars,
+         const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+         const Index<Dim>& volume_extents, const size_t number_of_variables) {
+        const double gamma_hi = 0.85;
+        const double gamma_lo = 0.999;
+        const double epsilon = 1.0e-12;
+        fd::reconstruction::aoweno_53<8>(
+            reconstructed_upper_side_of_face_vars,
+            reconstructed_lower_side_of_face_vars, volume_vars, ghost_cell_vars,
+            volume_extents, number_of_variables, gamma_hi, gamma_lo, epsilon);
+      };
+  const auto recons_neighbor_data = [](const gsl::not_null<DataVector*>
+                                           face_data,
+                                       const DataVector& volume_data,
+                                       const DataVector& neighbor_data,
+                                       const Index<Dim>& volume_extents,
+                                       const Index<Dim>& ghost_data_extents,
+                                       const Direction<Dim>&
+                                           direction_to_reconstruct) {
+    const double gamma_hi = 0.85;
+    const double gamma_lo = 0.999;
+    const double epsilon = 1.0e-12;
+    if (direction_to_reconstruct.side() == Side::Upper) {
+      fd::reconstruction::reconstruct_neighbor<
+          Side::Upper, fd::reconstruction::detail::AoWeno53Reconstructor<8>>(
+          face_data, volume_data, neighbor_data, volume_extents,
+          ghost_data_extents, direction_to_reconstruct, gamma_hi, gamma_lo,
+          epsilon);
+    }
+    if (direction_to_reconstruct.side() == Side::Lower) {
+      fd::reconstruction::reconstruct_neighbor<
+          Side::Lower, fd::reconstruction::detail::AoWeno53Reconstructor<8>>(
+          face_data, volume_data, neighbor_data, volume_extents,
+          ghost_data_extents, direction_to_reconstruct, gamma_hi, gamma_lo,
+          epsilon);
+    }
+  };
+
+  TestHelpers::fd::reconstruction::test_reconstruction_is_exact_if_in_basis<
+      Dim>(2, 8, 5, recons, recons_neighbor_data);
+  TestHelpers::fd::reconstruction::test_with_python(
+      Index<Dim>{8}, 5, "AoWeno53", "test_aoweno53", recons,
+      recons_neighbor_data);
+
+  // Check the 5th order reconstruction is exact
+  const auto recons_5th_order_only =
+      [](const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+             reconstructed_upper_side_of_face_vars,
+         const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+             reconstructed_lower_side_of_face_vars,
+         const gsl::span<const double>& volume_vars,
+         const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+         const Index<Dim>& volume_extents, const size_t number_of_variables) {
+        const double gamma_hi = 1.0;
+        const double gamma_lo = 0.999;
+        const double epsilon = 1.0e-12;
+        fd::reconstruction::aoweno_53<8>(
+            reconstructed_upper_side_of_face_vars,
+            reconstructed_lower_side_of_face_vars, volume_vars, ghost_cell_vars,
+            volume_extents, number_of_variables, gamma_hi, gamma_lo, epsilon);
+      };
+  const auto recons_neighbor_data_5th_order_only =
+      [](const gsl::not_null<DataVector*> face_data,
+         const DataVector& volume_data, const DataVector& neighbor_data,
+         const Index<Dim>& volume_extents, const Index<Dim>& ghost_data_extents,
+         const Direction<Dim>& direction_to_reconstruct) {
+        const double gamma_hi = 1.0;
+        const double gamma_lo = 0.999;
+        const double epsilon = 1.0e-12;
+        if (direction_to_reconstruct.side() == Side::Upper) {
+          fd::reconstruction::reconstruct_neighbor<
+              Side::Upper,
+              fd::reconstruction::detail::AoWeno53Reconstructor<8>>(
+              face_data, volume_data, neighbor_data, volume_extents,
+              ghost_data_extents, direction_to_reconstruct, gamma_hi, gamma_lo,
+              epsilon);
+        }
+        if (direction_to_reconstruct.side() == Side::Lower) {
+          fd::reconstruction::reconstruct_neighbor<
+              Side::Lower,
+              fd::reconstruction::detail::AoWeno53Reconstructor<8>>(
+              face_data, volume_data, neighbor_data, volume_extents,
+              ghost_data_extents, direction_to_reconstruct, gamma_hi, gamma_lo,
+              epsilon);
+        }
+      };
+
+  TestHelpers::fd::reconstruction::test_reconstruction_is_exact_if_in_basis<
+      Dim>(4, 8, 5, recons_5th_order_only, recons_neighbor_data_5th_order_only);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.FiniteDifference.AoWeno53",
+                  "[Unit][NumericalAlgorithms]") {
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "NumericalAlgorithms/FiniteDifference/");
+  test<1>();
+  test<2>();
+  test<3>();
+}

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_Minmod.cpp
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_Minmod.cpp
@@ -31,10 +31,28 @@ void test() {
                                    volume_vars, ghost_cell_vars, volume_extents,
                                    number_of_variables);
       };
+  const auto recons_neighbor_data =
+      [](const gsl::not_null<DataVector*> face_data,
+         const DataVector& volume_data, const DataVector& neighbor_data,
+         const Index<Dim>& volume_extents, const Index<Dim>& ghost_data_extents,
+         const Direction<Dim>& direction_to_reconstruct) {
+        if (direction_to_reconstruct.side() == Side::Upper) {
+          fd::reconstruction::reconstruct_neighbor<
+              Side::Upper, fd::reconstruction::detail::MinmodReconstructor>(
+              face_data, volume_data, neighbor_data, volume_extents,
+              ghost_data_extents, direction_to_reconstruct);
+        }
+        if (direction_to_reconstruct.side() == Side::Lower) {
+          fd::reconstruction::reconstruct_neighbor<
+              Side::Lower, fd::reconstruction::detail::MinmodReconstructor>(
+              face_data, volume_data, neighbor_data, volume_extents,
+              ghost_data_extents, direction_to_reconstruct);
+        }
+      };
   TestHelpers::fd::reconstruction::test_reconstruction_is_exact_if_in_basis<
-      Dim>(1, 4, 3, recons);
-  TestHelpers::fd::reconstruction::test_with_python(Index<Dim>{4}, 3, "Minmod",
-                                                    "test_minmod", recons);
+      Dim>(1, 4, 3, recons, recons_neighbor_data);
+  TestHelpers::fd::reconstruction::test_with_python(
+      Index<Dim>{4}, 3, "Minmod", "test_minmod", recons, recons_neighbor_data);
 }
 }  // namespace
 

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_MonotisedCentral.cpp
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_MonotisedCentral.cpp
@@ -31,10 +31,31 @@ void test() {
             reconstructed_lower_side_of_face_vars, volume_vars, ghost_cell_vars,
             volume_extents, number_of_variables);
       };
+  const auto recons_neighbor_data =
+      [](const gsl::not_null<DataVector*> face_data,
+         const DataVector& volume_data, const DataVector& neighbor_data,
+         const Index<Dim>& volume_extents, const Index<Dim>& ghost_data_extents,
+         const Direction<Dim>& direction_to_reconstruct) {
+        if (direction_to_reconstruct.side() == Side::Upper) {
+          fd::reconstruction::reconstruct_neighbor<
+              Side::Upper,
+              fd::reconstruction::detail::MonotisedCentralReconstructor>(
+              face_data, volume_data, neighbor_data, volume_extents,
+              ghost_data_extents, direction_to_reconstruct);
+        }
+        if (direction_to_reconstruct.side() == Side::Lower) {
+          fd::reconstruction::reconstruct_neighbor<
+              Side::Lower,
+              fd::reconstruction::detail::MonotisedCentralReconstructor>(
+              face_data, volume_data, neighbor_data, volume_extents,
+              ghost_data_extents, direction_to_reconstruct);
+        }
+      };
   TestHelpers::fd::reconstruction::test_reconstruction_is_exact_if_in_basis<
-      Dim>(1, 4, 3, recons);
+      Dim>(1, 4, 3, recons, recons_neighbor_data);
   TestHelpers::fd::reconstruction::test_with_python(
-      Index<Dim>{4}, 3, "MonotisedCentral", "test_monotised_central", recons);
+      Index<Dim>{4}, 3, "MonotisedCentral", "test_monotised_central", recons,
+      recons_neighbor_data);
 }
 }  // namespace
 


### PR DESCRIPTION
## Proposed changes

- When an element is doing subcell it only sends the FD solution that can be used for reconstruction, not the fluxes. In these cases a neighboring element running DG needs to reconstruct the neighbor's solution to the mortar and compute the `packaged_data`
- add AO-WENO(5,3) reconstruction. This tests that adding a wider stencil scheme works correctly, and is also useful because of the increased accuracy

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
