### PR TITLE
Subcell: Cartesian flux divergence, compute boundary terms

### DIFF
--- a/src/Evolution/DgSubcell/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ActiveGrid.hpp
+  CartesianFluxDivergence.hpp
   DgSubcell.hpp
   Matrices.hpp
   Mesh.hpp

--- a/src/Evolution/DgSubcell/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_headers(
   HEADERS
   ActiveGrid.hpp
   CartesianFluxDivergence.hpp
+  ComputeBoundaryTerms.hpp
   DgSubcell.hpp
   Matrices.hpp
   Mesh.hpp

--- a/src/Evolution/DgSubcell/CartesianFluxDivergence.hpp
+++ b/src/Evolution/DgSubcell/CartesianFluxDivergence.hpp
@@ -1,0 +1,89 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace evolution::dg::subcell {
+// @{
+/*!
+ * \brief Compute and add the 2nd-order flux divergence on a Cartesian mesh to
+ * the cell-centered time derivatives.
+ */
+void add_cartesian_flux_divergence(const gsl::not_null<DataVector*> dt_var,
+                                   const double one_over_delta,
+                                   const DataVector& inv_jacobian,
+                                   const DataVector& boundary_correction,
+                                   const Index<1>& subcell_extents,
+                                   const size_t dimension) noexcept {
+  (void)dimension;
+  ASSERT(dimension == 0, "dimension must be 0 but is " << dimension);
+  for (size_t i = 0; i < subcell_extents[0]; ++i) {
+    (*dt_var)[i] += one_over_delta * inv_jacobian[i] *
+                    (boundary_correction[i + 1] - boundary_correction[i]);
+  }
+}
+
+void add_cartesian_flux_divergence(const gsl::not_null<DataVector*> dt_var,
+                                   const double one_over_delta,
+                                   const DataVector& inv_jacobian,
+                                   const DataVector& boundary_correction,
+                                   const Index<2>& subcell_extents,
+                                   const size_t dimension) noexcept {
+  ASSERT(dimension == 0 or dimension == 1,
+         "dimension must be 0 or 1 but is " << dimension);
+  Index<2> subcell_face_extents = subcell_extents;
+  ++subcell_face_extents[dimension];
+  for (size_t j = 0; j < subcell_extents[1]; ++j) {
+    for (size_t i = 0; i < subcell_extents[0]; ++i) {
+      Index<2> index(i, j);
+      const size_t volume_index = collapsed_index(index, subcell_extents);
+      const size_t boundary_correction_lower_index =
+          collapsed_index(index, subcell_face_extents);
+      ++index[dimension];
+      const size_t boundary_correction_upper_index =
+          collapsed_index(index, subcell_face_extents);
+      (*dt_var)[volume_index] +=
+          one_over_delta * inv_jacobian[volume_index] *
+          (boundary_correction[boundary_correction_upper_index] -
+           boundary_correction[boundary_correction_lower_index]);
+    }
+  }
+}
+
+void add_cartesian_flux_divergence(const gsl::not_null<DataVector*> dt_var,
+                                   const double one_over_delta,
+                                   const DataVector& inv_jacobian,
+                                   const DataVector& boundary_correction,
+                                   const Index<3>& subcell_extents,
+                                   const size_t dimension) noexcept {
+  ASSERT(dimension == 0 or dimension == 1 or dimension == 2,
+         "dimension must be 0, 1, or 2 but is " << dimension);
+  Index<3> subcell_face_extents = subcell_extents;
+  ++subcell_face_extents[dimension];
+  for (size_t k = 0; k < subcell_extents[2]; ++k) {
+    for (size_t j = 0; j < subcell_extents[1]; ++j) {
+      for (size_t i = 0; i < subcell_extents[0]; ++i) {
+        Index<3> index(i, j, k);
+        const size_t volume_index = collapsed_index(index, subcell_extents);
+        const size_t boundary_correction_lower_index =
+            collapsed_index(index, subcell_face_extents);
+        ++index[dimension];
+        const size_t boundary_correction_upper_index =
+            collapsed_index(index, subcell_face_extents);
+        (*dt_var)[volume_index] +=
+            one_over_delta * inv_jacobian[volume_index] *
+            (boundary_correction[boundary_correction_upper_index] -
+             boundary_correction[boundary_correction_lower_index]);
+      }
+    }
+  }
+}
+// @}
+}  // namespace evolution::dg::subcell

--- a/src/Evolution/DgSubcell/ComputeBoundaryTerms.hpp
+++ b/src/Evolution/DgSubcell/ComputeBoundaryTerms.hpp
@@ -1,0 +1,44 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <ostream>
+
+#include "DataStructures/Variables.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace evolution::dg::subcell {
+template <typename... CorrectionTags, typename BoundaryCorrection,
+          typename... PackageFieldTags>
+void compute_boundary_terms(
+    const gsl::not_null<Variables<tmpl::list<CorrectionTags...>>*>
+        boundary_corrections_on_face,
+    const BoundaryCorrection& boundary_correction,
+    const Variables<tmpl::list<PackageFieldTags...>>& upper_packaged_data,
+    const Variables<tmpl::list<PackageFieldTags...>>&
+        lower_packaged_data) noexcept {
+  ASSERT(
+      upper_packaged_data.number_of_grid_points() ==
+          lower_packaged_data.number_of_grid_points(),
+      "The number of grid points must be the same for the upper packaged data ("
+          << upper_packaged_data.number_of_grid_points()
+          << ") and the lower packaged data ("
+          << lower_packaged_data.number_of_grid_points() << ')');
+  ASSERT(upper_packaged_data.number_of_grid_points() ==
+             boundary_corrections_on_face->number_of_grid_points(),
+         "The number of grid points must be the same for the packaged data ("
+             << upper_packaged_data.number_of_grid_points()
+             << ") and the boundary corrections on the faces ("
+             << boundary_corrections_on_face->number_of_grid_points() << ')');
+  boundary_correction.dg_boundary_terms(
+      make_not_null(&get<CorrectionTags>(*boundary_corrections_on_face))...,
+      get<PackageFieldTags>(upper_packaged_data)...,
+      get<PackageFieldTags>(lower_packaged_data)...,
+      // FD schemes are basically weak form FV scheme
+      ::dg::Formulation::WeakInertial);
+}
+}  // namespace evolution::dg::subcell

--- a/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
+++ b/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Actions/Test_Initialize.cpp
   Actions/Test_SelectNumericalMethod.cpp
   Test_ActiveGrid.cpp
+  Test_CartesianFluxDivergence.cpp
   Test_Matrices.cpp
   Test_Mesh.cpp
   Test_NeighborData.cpp

--- a/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
+++ b/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Actions/Test_SelectNumericalMethod.cpp
   Test_ActiveGrid.cpp
   Test_CartesianFluxDivergence.cpp
+  Test_ComputeBoundaryTerms.cpp
   Test_Matrices.cpp
   Test_Mesh.cpp
   Test_NeighborData.cpp

--- a/tests/Unit/Evolution/DgSubcell/Test_CartesianFluxDivergence.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_CartesianFluxDivergence.cpp
@@ -1,0 +1,55 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Evolution/DgSubcell/CartesianFluxDivergence.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace {
+template <size_t Dim>
+void test() {
+  const size_t num_pts_1d = 5;
+  const Index<Dim> subcell_extents{num_pts_1d};
+  for (size_t d = 0; d < Dim; ++d) {
+    CAPTURE(d);
+    auto extents = make_array<Dim>(num_pts_1d);
+    ++gsl::at(extents, d);
+    const auto basis = make_array<Dim>(Spectral::Basis::FiniteDifference);
+    auto quadrature = make_array<Dim>(Spectral::Quadrature::CellCentered);
+    gsl::at(quadrature, d) = Spectral::Quadrature::FaceCentered;
+    const Mesh<Dim> subcell_face_mesh{extents, basis, quadrature};
+
+    DataVector dt_var{subcell_extents.product(), 1.2};
+    const DataVector inv_jacobian{subcell_extents.product(), 5.0};
+    const auto logical_coords = logical_coordinates(subcell_face_mesh);
+    const double one_over_delta =
+        1.0 / (get<0>(logical_coords)[1] - get<0>(logical_coords)[0]);
+    const DataVector boundary_correction = 3.0 * logical_coords.get(d);
+    evolution::dg::subcell::add_cartesian_flux_divergence(
+        make_not_null(&dt_var), one_over_delta, inv_jacobian,
+        boundary_correction, subcell_extents, d);
+    const DataVector expected_dt_var{subcell_extents.product(),
+                                     inv_jacobian[0] * 3.0 + 1.2};
+    CHECK_ITERABLE_APPROX(dt_var, expected_dt_var);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Subcell.FD.CartesianFluxDivergence",
+                  "[Evolution][Unit]") {
+  test<1>();
+  test<2>();
+  test<3>();
+}

--- a/tests/Unit/Evolution/DgSubcell/Test_ComputeBoundaryTerms.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_ComputeBoundaryTerms.cpp
@@ -1,0 +1,49 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/DgSubcell/ComputeBoundaryTerms.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+struct Var1 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+class BoundaryCorrection {
+ public:
+  explicit BoundaryCorrection(const double multiply) noexcept
+      : multiply_(multiply) {}
+  void dg_boundary_terms(
+      const gsl::not_null<Scalar<DataVector>*> correction_var1,
+      const Scalar<DataVector>& upper_var1,
+      const Scalar<DataVector>& lower_var1,
+      const dg::Formulation dg_formulation) const noexcept {
+    get(*correction_var1) = get(upper_var1) + multiply_ * get(lower_var1);
+    CHECK(dg_formulation == dg::Formulation::WeakInertial);
+  }
+
+ private:
+  double multiply_ = std::numeric_limits<double>::signaling_NaN();
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Subcell.ComputeBoundaryTerms",
+                  "[Evolution][Unit]") {
+  const BoundaryCorrection correction{5.0};
+  const size_t num_pts = 5;
+  Variables<tmpl::list<Var1>> corrections{num_pts};
+  Variables<tmpl::list<Var1>> upper{num_pts, 1.3};
+  Variables<tmpl::list<Var1>> lower{num_pts, 7.0};
+  evolution::dg::subcell::compute_boundary_terms(make_not_null(&corrections),
+                                                 correction, upper, lower);
+  Variables<tmpl::list<Var1>> expected_corrections{num_pts, 1.3 + 5.0 * 7.0};
+  CHECK_VARIABLES_APPROX(corrections, expected_corrections);
+}


### PR DESCRIPTION
## Proposed changes

- Add a function that computes the flux divergence on a time-independent Cartesian grid
- Add a function to do pack expansion and all `dg_boundary_terms` for the subcell solver

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
