### PR TITLE
Add GeneralizedHarmonic: Christoffel

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/Christoffel.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Christoffel.hpp
@@ -45,6 +45,35 @@ tnsr::abb<DataType, SpatialDim, Frame, Index> christoffel_first_kind(
     const tnsr::abb<DataType, SpatialDim, Frame, Index>& d_metric) noexcept;
 // @}
 
+// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes Christoffel symbol of the second kind from derivative of
+ * metric and the inverse metric.
+ *
+ * \details Computes Christoffel symbol \f$\Gamma^a_{bc}\f$ as:
+ * \f$ \Gamma^d_{ab} = \frac{1}{2} g^{cd} (\partial_a g_{bc} + \partial_b g_{ac}
+ *  -  \partial_c g_{ab}) \f$
+ * where \f$g_{bc}\f$ is either a spatial or spacetime metric.
+ *
+ * Avoids the extra memory allocation that occurs by computing the
+ * Christoffel symbol of the first kind and then raising the index.
+ */
+template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
+void christoffel_second_kind(
+    const gsl::not_null<tnsr::Abb<DataType, SpatialDim, Frame, Index>*>
+        christoffel,
+    const tnsr::abb<DataType, SpatialDim, Frame, Index>& d_metric,
+    const tnsr::AA<DataType, SpatialDim, Frame, Index>&
+        inverse_metric) noexcept;
+
+template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
+auto christoffel_second_kind(
+    const tnsr::abb<DataType, SpatialDim, Frame, Index>& d_metric,
+    const tnsr::AA<DataType, SpatialDim, Frame, Index>& inverse_metric) noexcept
+    -> tnsr::Abb<DataType, SpatialDim, Frame, Index>;
+// @}
+
 namespace Tags {
 /// Compute item for spatial Christoffel symbols of the first kind
 /// \f$\Gamma_{ijk}\f$ computed from the first derivative of the

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/CMakeLists.txt
@@ -4,6 +4,7 @@
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  Christoffel.cpp
   CovariantDerivOfExtrinsicCurvature.cpp
   DerivSpatialMetric.cpp
   ExtrinsicCurvature.cpp
@@ -27,6 +28,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Christoffel.hpp
   ConstraintGammas.hpp
   CovariantDerivOfExtrinsicCurvature.hpp
   DerivSpatialMetric.hpp

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Christoffel.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Christoffel.cpp
@@ -1,0 +1,74 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Christoffel.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace GeneralizedHarmonic {
+template <size_t SpatialDim, typename Frame, typename DataType>
+void christoffel_second_kind(
+    const gsl::not_null<tnsr::Ijj<DataType, SpatialDim, Frame>*> christoffel,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::II<DataType, SpatialDim, Frame>& inv_metric) noexcept {
+  destructive_resize_components(christoffel, get_size(*phi.begin()));
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = i; j < SpatialDim; ++j) {
+      for (size_t m = 0; m < SpatialDim; ++m) {
+        christoffel->get(m, i, j) =
+            0.5 * inv_metric.get(m, 0) *
+            (phi.get(i, j + 1, 1) + phi.get(j, i + 1, 1) -
+             phi.get(0, i + 1, j + 1));
+        for (size_t k = 1; k < SpatialDim; ++k) {
+          christoffel->get(m, i, j) +=
+              0.5 * inv_metric.get(m, k) *
+              (phi.get(i, j + 1, k + 1) + phi.get(j, i + 1, k + 1) -
+               phi.get(k, i + 1, j + 1));
+        }
+      }
+    }
+  }
+}
+template <size_t SpatialDim, typename Frame, typename DataType>
+auto christoffel_second_kind(
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::II<DataType, SpatialDim, Frame>& inv_metric) noexcept
+    -> tnsr::Ijj<DataType, SpatialDim, Frame> {
+  tnsr::Ijj<DataType, SpatialDim, Frame> christoffel(
+      get_size(get<0, 0, 0>(phi)));
+  christoffel_second_kind(make_not_null(&christoffel), phi, inv_metric);
+  return christoffel;
+}
+}  // namespace GeneralizedHarmonic
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                               \
+  template void GeneralizedHarmonic::christoffel_second_kind(              \
+      const gsl::not_null<tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>*> \
+          christoffel,                                                     \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,           \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                 \
+          inv_metric) noexcept;                                            \
+  template tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>                  \
+  GeneralizedHarmonic::christoffel_second_kind(                            \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,           \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                 \
+          inv_metric) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
+                        (Frame::Grid, Frame::Inertial,
+                         Frame::Spherical<Frame::Inertial>,
+                         Frame::Spherical<Frame::Grid>))
+
+#undef DIM
+#undef DTYPE
+#undef FRAME
+#undef INSTANTIATE

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Christoffel.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Christoffel.hpp
@@ -1,0 +1,42 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace GeneralizedHarmonic {
+// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes spatial Christoffel symbol of the 2nd kind from the
+ * the generalized harmonic spatial derivative variable and the
+ * inverse spatial metric.
+ *
+ * \details
+ * If \f$ \Phi_{kab} \f$ is the generalized harmonic spatial derivative
+ * variable \f$ \Phi_{kab} = \partial_k \psi_{ab}\f$ and \f$\gamma^{ij}\f$
+ * is the inverse spatial metric, the Christoffel symbols are
+ * \f[
+ *   \Gamma^m_{ij} = \frac{1}{2}\gamma^{mk}(\Phi_{ijk}+\Phi_{jik}-\Phi_{kij}).
+ * \f]
+ *
+ * In the not_null version, no memory allocations are performed if the
+ * output tensor already has the correct size.
+ *
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+void christoffel_second_kind(
+    const gsl::not_null<tnsr::Ijj<DataType, SpatialDim, Frame>*> christoffel,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::II<DataType, SpatialDim, Frame>& inv_metric) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+auto christoffel_second_kind(
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::II<DataType, SpatialDim, Frame>& inv_metric) noexcept
+    -> tnsr::Ijj<DataType, SpatialDim, Frame>;
+}  // namespace GeneralizedHarmonic

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Christoffel.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Christoffel.cpp
@@ -173,6 +173,20 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.Christoffel",
       raise_or_lower_first_index(expected_spacetime_christoffel_first_kind,
                                  inverse_spacetime_metric);
 
+  // Compute Christoffel symbol of the 2nd kind in two different ways
+  // (the direct one, which we are testing here, and the one already
+  // tested independently, which uses christoffel_first_kind) and make
+  // sure we get the same result.
+  const auto spatial_christoffel_second_kind_test =
+      gr::christoffel_second_kind(deriv_spatial_metric, inverse_spatial_metric);
+  CHECK_ITERABLE_APPROX(expected_spatial_christoffel_second_kind,
+                        spatial_christoffel_second_kind_test);
+  const auto spacetime_christoffel_second_kind_test =
+      gr::christoffel_second_kind(derivatives_of_spacetime_metric,
+                                  inverse_spacetime_metric);
+  CHECK_ITERABLE_APPROX(expected_spacetime_christoffel_second_kind,
+                        spacetime_christoffel_second_kind_test);
+
   const auto box = db::create<
       db::AddSimpleTags<
           gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>,

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
@@ -39,6 +39,7 @@
 #include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
 #include "PointwiseFunctions/GeneralRelativity/DerivativesOfSpacetimeMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/ExtrinsicCurvature.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Christoffel.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ConstraintGammas.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/CovariantDerivOfExtrinsicCurvature.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/DerivSpatialMetric.hpp"
@@ -188,6 +189,18 @@ void test_compute_extrinsic_curvature_and_deriv_metric(const T& used_for_size) {
 
   CHECK_ITERABLE_APPROX(extrinsic_curvature, extrinsic_curvature_test);
   CHECK_ITERABLE_APPROX(deriv_spatial_metric, deriv_spatial_metric_test);
+
+  // Compute Christoffel symbol of the 2nd kind in two different ways
+  // (the gr one already tested independently) and make sure we get
+  // the same result.
+  const auto inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  const auto christoffel_second_kind =
+      GeneralizedHarmonic::christoffel_second_kind(phi, inverse_spatial_metric);
+  const auto christoffel_second_kind_test = raise_or_lower_first_index(
+      gr::christoffel_first_kind(deriv_spatial_metric), inverse_spatial_metric);
+
+  CHECK_ITERABLE_APPROX(christoffel_second_kind, christoffel_second_kind_test);
 }
 
 template <typename DataType, size_t SpatialDim, typename Frame>


### PR DESCRIPTION
## Proposed changes

Computes Christoffel symbol of the 2nd kind without
memory allocations.  Versions added that take Gh variables and that take derivs of metric.

### Upgrade instructions


### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
