### PR TITLE
Enable cleanup on CCE input file tests

### DIFF
--- a/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
@@ -4,6 +4,8 @@
 # Executable: AnalyticTestCharacteristicExtract
 # Check: parse;execute_check_output
 # Timeout: 10
+# ExpectedOutput:
+#   CharacteristicExtractVolume0.h5
 # OutputFileChecks:
 #   - Label: "check_news"
 #     Subfile: "/News.dat"

--- a/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
@@ -4,6 +4,8 @@
 # Executable: AnalyticTestCharacteristicExtract
 # Check: parse;execute_check_output
 # Timeout: 10
+# ExpectedOutput:
+#   CharacteristicExtractVolume0.h5
 # OutputFileChecks:
 #   - Label: "check_news"
 #     Subfile: "/News.dat"

--- a/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
@@ -4,6 +4,8 @@
 # Executable: AnalyticTestCharacteristicExtract
 # Check: parse;execute_check_output
 # Timeout: 10
+# ExpectedOutput:
+#   CharacteristicExtractVolume0.h5
 # OutputFileChecks:
 #   - Label: "check_news"
 #     Subfile: "/News.dat"

--- a/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
@@ -4,6 +4,8 @@
 # Executable: AnalyticTestCharacteristicExtract
 # Check: parse;execute_check_output
 # Timeout: 10
+# ExpectedOutput:
+#   CharacteristicExtractVolume0.h5
 # OutputFileChecks:
 #   - Label: "check_news"
 #     Subfile: "/News.dat"

--- a/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
@@ -4,6 +4,8 @@
 # Executable: AnalyticTestCharacteristicExtract
 # Check: parse;execute_check_output
 # Timeout: 10
+# ExpectedOutput:
+#   CharacteristicExtractVolume0.h5
 # OutputFileChecks:
 #   - Label: "check_news"
 #     Subfile: "/News.dat"


### PR DESCRIPTION
## Proposed changes

Previously, the CCE `execute_check_output` tests didn't provide enough information to the scripts to perform the cleanup of their output files correctly -- this fixes that.

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
