### PR TITLE
Add GH GaugeWave executable

### DIFF
--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -135,7 +135,7 @@ struct EvolutionMetavars {
                               dg::Events::field_observations<
                                   volume_dim, Tags::Time, observe_fields,
                                   analytic_solution_fields>,
-                              Events::time_events<EvolutionMetavars>>>>,
+                              Events::time_events<system>>>>,
         tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
                    StepChoosers::standard_step_choosers<system>>,
         tmpl::pair<StepChooser<StepChooserUse::Slab>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
@@ -5,15 +5,25 @@ function(add_generalized_harmonic_executable
     INITIAL_DATA_NAME INITIAL_DATA BOUNDARY_CONDITIONS LIBS_TO_LINK)
   add_spectre_parallel_executable(
     "EvolveGh${INITIAL_DATA_NAME}"
-    EvolveGeneralizedHarmonic
+    EvolveGeneralizedHarmonicWithHorizon
     Evolution/Executables/GeneralizedHarmonic
     "EvolutionMetavars<${INITIAL_DATA}, ${BOUNDARY_CONDITIONS}>"
     "${LIBS_TO_LINK}"
     )
 endfunction(add_generalized_harmonic_executable)
 
+function(add_generalized_harmonic_no_horizon_executable
+    INITIAL_DATA_NAME INITIAL_DATA BOUNDARY_CONDITIONS LIBS_TO_LINK)
+  add_spectre_parallel_executable(
+    "EvolveGh${INITIAL_DATA_NAME}"
+    EvolveGeneralizedHarmonic
+    Evolution/Executables/GeneralizedHarmonic
+    "EvolutionMetavars<${INITIAL_DATA}, ${BOUNDARY_CONDITIONS}>"
+    "${LIBS_TO_LINK}"
+    )
+endfunction(add_generalized_harmonic_no_horizon_executable)
+
 set(LIBS_TO_LINK
-  ApparentHorizons
   CoordinateMaps
   DiscontinuousGalerkin
   Domain
@@ -39,12 +49,27 @@ add_generalized_harmonic_executable(
   KerrSchild
   GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::KerrSchild>
   GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::KerrSchild>
-  "${LIBS_TO_LINK};GeneralRelativitySolutions"
+  "${LIBS_TO_LINK};ApparentHorizons;GeneralRelativitySolutions"
 )
 
 add_generalized_harmonic_executable(
   KerrSchildNumericInitialData
   evolution::NumericInitialData
   GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::KerrSchild>
+  "${LIBS_TO_LINK};ApparentHorizons;GeneralRelativitySolutions;Importers"
+)
+
+add_generalized_harmonic_no_horizon_executable(
+  GaugeWave
+  GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::GaugeWave<3>>
+  GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::GaugeWave<3>>
+  "${LIBS_TO_LINK};GeneralRelativitySolutions"
+)
+
+add_generalized_harmonic_no_horizon_executable(
+  GaugeWaveNumericInitialData
+  evolution::NumericInitialData
+  GeneralizedHarmonic::Solutions::WrappedGr<gr::Solutions::GaugeWave<3>>
   "${LIBS_TO_LINK};GeneralRelativitySolutions;Importers"
 )
+

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -3,413 +3,51 @@
 
 #pragma once
 
-#include <cstddef>
 #include <cstdint>
 #include <vector>
 
-#include "ApparentHorizons/ComputeItems.hpp"
-#include "ApparentHorizons/Tags.hpp"
-#include "DataStructures/DataBox/Tag.hpp"
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
 #include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
-#include "Domain/Tags.hpp"
-#include "Domain/TagsCharacteresticSpeeds.hpp"
-#include "Evolution/Actions/AddMeshVelocityNonconservative.hpp"
-#include "Evolution/ComputeTags.hpp"
-#include "Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp"
-#include "Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp"
-#include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"
-#include "Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp"
-#include "Evolution/DiscontinuousGalerkin/Initialization/QuadratureTag.hpp"
-#include "Evolution/Initialization/DgDomain.hpp"
-#include "Evolution/Initialization/Evolution.hpp"
-#include "Evolution/Initialization/NonconservativeSystem.hpp"
-#include "Evolution/Initialization/SetVariables.hpp"
-#include "Evolution/NumericInitialData.hpp"
-#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Factory.hpp"
+#include "Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/RegisterDerivedWithCharm.hpp"
-#include "Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/Factory.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/RegisterDerived.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/RegisterDerivedWithCharm.hpp"
-#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
-#include "Evolution/Systems/GeneralizedHarmonic/Equations.hpp"
-#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/InitializeDampedHarmonic.hpp"
-#include "Evolution/Systems/GeneralizedHarmonic/Initialize.hpp"
-#include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
-#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
-#include "Evolution/Systems/GeneralizedHarmonic/TimeDerivative.hpp"
-#include "Evolution/TypeTraits.hpp"
-#include "IO/Importers/Actions/ReadVolumeData.hpp"
-#include "IO/Importers/Actions/ReceiveVolumeData.hpp"
-#include "IO/Importers/Actions/RegisterWithElementDataReader.hpp"
-#include "IO/Importers/ElementDataReader.hpp"
-#include "IO/Observer/Actions/RegisterEvents.hpp"
-#include "IO/Observer/Helpers.hpp"
-#include "IO/Observer/ObserverComponent.hpp"
-#include "IO/Observer/Tags.hpp"
-#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
-#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
-#include "NumericalAlgorithms/Interpolation/AddTemporalIdsToInterpolationTarget.hpp"
-#include "NumericalAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp"
-#include "NumericalAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp"
-#include "NumericalAlgorithms/Interpolation/CleanUpInterpolator.hpp"
-#include "NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp"
-#include "NumericalAlgorithms/Interpolation/Interpolate.hpp"
-#include "NumericalAlgorithms/Interpolation/InterpolationTarget.hpp"
-#include "NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp"
-#include "NumericalAlgorithms/Interpolation/InterpolationTargetReceiveVars.hpp"
-#include "NumericalAlgorithms/Interpolation/Interpolator.hpp"
-#include "NumericalAlgorithms/Interpolation/InterpolatorReceivePoints.hpp"
-#include "NumericalAlgorithms/Interpolation/InterpolatorReceiveVolumeData.hpp"
-#include "NumericalAlgorithms/Interpolation/InterpolatorRegisterElement.hpp"
-#include "NumericalAlgorithms/Interpolation/Tags.hpp"
-#include "NumericalAlgorithms/Interpolation/TryToInterpolate.hpp"
 #include "Options/Options.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
-#include "Parallel/Actions/SetupDataBox.hpp"
-#include "Parallel/Actions/TerminatePhase.hpp"
-#include "Parallel/Algorithms/AlgorithmSingleton.hpp"
-#include "Parallel/InitializationFunctions.hpp"
-#include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/PhaseControl/PhaseControlTags.hpp"
-#include "Parallel/PhaseControl/VisitAndReturn.hpp"
-#include "Parallel/PhaseDependentActionList.hpp"
-#include "Parallel/Reduction.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
-#include "ParallelAlgorithms/Actions/MutateApply.hpp"
-#include "ParallelAlgorithms/Events/Factory.hpp"
-#include "ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp"
-#include "ParallelAlgorithms/EventsAndTriggers/Completion.hpp"
-#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
-#include "ParallelAlgorithms/EventsAndTriggers/EventsAndTriggers.hpp"
-#include "ParallelAlgorithms/EventsAndTriggers/LogicalTriggers.hpp"
-#include "ParallelAlgorithms/EventsAndTriggers/Tags.hpp"
-#include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
-#include "ParallelAlgorithms/Initialization/Actions/AddComputeTags.hpp"
-#include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
-#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
-#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.hpp"
-#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
-#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
-#include "PointwiseFunctions/GeneralRelativity/DetAndInverseSpatialMetric.hpp"
-#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ConstraintGammas.hpp"
-#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
-#include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
-#include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
-#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
-#include "Time/Actions/AdvanceTime.hpp"
-#include "Time/Actions/ChangeSlabSize.hpp"
-#include "Time/Actions/ChangeStepSize.hpp"
-#include "Time/Actions/RecordTimeStepperData.hpp"
-#include "Time/Actions/SelfStartActions.hpp"
-#include "Time/Actions/UpdateU.hpp"
-#include "Time/StepChoosers/Factory.hpp"
-#include "Time/StepChoosers/StepChooser.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugeWave.hpp"
 #include "Time/StepControllers/Factory.hpp"
-#include "Time/StepControllers/StepController.hpp"
-#include "Time/Tags.hpp"
-#include "Time/TimeSequence.hpp"
-#include "Time/TimeSteppers/TimeStepper.hpp"
-#include "Time/Triggers/TimeTriggers.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
-#include "Utilities/Functional.hpp"
-#include "Utilities/MemoryHelpers.hpp"
-#include "Utilities/ProtocolHelpers.hpp"
-#include "Utilities/TMPL.hpp"
-
-/// \cond
-namespace Frame {
-// IWYU pragma: no_forward_declare MathFunction
-struct Inertial;
-}  // namespace Frame
-namespace PUP {
-class er;
-}  // namespace PUP
-namespace Parallel {
-template <typename Metavariables>
-class CProxy_GlobalCache;
-}  // namespace Parallel
-/// \endcond
 
 // First template parameter specifies the source of the initial data, which
 // could be an analytic solution, analytic data, or imported numerical data.
 // Second template parameter specifies the analytic solution used when imposing
 // dirichlet boundary conditions or against which to compute error norms.
 template <typename InitialData, typename BoundaryConditions>
-struct EvolutionMetavars {
-  static constexpr size_t volume_dim = 3;
-  using frame = Frame::Inertial;
-  using system = GeneralizedHarmonic::System<volume_dim>;
-  static constexpr dg::Formulation dg_formulation =
-      dg::Formulation::StrongInertial;
-  static constexpr bool use_damped_harmonic_rollon = true;
-  // Set override_cubic_functions_of_time to true to override the cubic
-  // piecewise polynomial functions of time using
-  // `read_spec_third_order_piecewise_polynomial()`
-  static constexpr bool override_cubic_functions_of_time = false;
-  using temporal_id = Tags::TimeStepId;
-  static constexpr bool local_time_stepping = false;
-  using initial_data = InitialData;
-  using analytic_solution_tag = Tags::AnalyticSolution<BoundaryConditions>;
-
-  using time_stepper_tag = Tags::TimeStepper<
-      tmpl::conditional_t<local_time_stepping, LtsTimeStepper, TimeStepper>>;
-
-  using analytic_solution_fields = typename system::variables_tag::tags_list;
-  using observe_fields = tmpl::append<
-      tmpl::push_back<
-          analytic_solution_fields,
-          ::Tags::PointwiseL2Norm<
-              GeneralizedHarmonic::Tags::GaugeConstraint<volume_dim, frame>>,
-          ::Tags::PointwiseL2Norm<GeneralizedHarmonic::Tags::
-                                      ThreeIndexConstraint<volume_dim, frame>>>,
-      tmpl::conditional_t<volume_dim == 3,
-                          tmpl::list<::Tags::PointwiseL2Norm<
-                              GeneralizedHarmonic::Tags::FourIndexConstraint<
-                                  volume_dim, frame>>>,
-                          tmpl::list<>>>;
-
-  struct AhA {
-    using tags_to_observe =
-        tmpl::list<StrahlkorperGr::Tags::AreaCompute<frame>>;
-    using compute_items_on_source = tmpl::list<
-        gr::Tags::SpatialMetricCompute<volume_dim, frame, DataVector>,
-        ah::Tags::InverseSpatialMetricCompute<volume_dim, frame>,
-        ah::Tags::ExtrinsicCurvatureCompute<volume_dim, frame>,
-        ah::Tags::SpatialChristoffelSecondKindCompute<volume_dim, frame>>;
-    using vars_to_interpolate_to_target =
-        tmpl::list<gr::Tags::SpatialMetric<volume_dim, frame, DataVector>,
-                   gr::Tags::InverseSpatialMetric<volume_dim, frame>,
-                   gr::Tags::ExtrinsicCurvature<volume_dim, frame>,
-                   gr::Tags::SpatialChristoffelSecondKind<volume_dim, frame>>;
-    using compute_items_on_target = tmpl::append<
-        tmpl::list<StrahlkorperGr::Tags::AreaElementCompute<frame>>,
-        tags_to_observe>;
-    using compute_target_points =
-        intrp::TargetPoints::ApparentHorizon<AhA, ::Frame::Inertial>;
-    using post_interpolation_callback =
-        intrp::callbacks::FindApparentHorizon<AhA, ::Frame::Inertial>;
-    using post_horizon_find_callback =
-        intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, AhA, AhA>;
-  };
-  using interpolation_target_tags = tmpl::list<AhA>;
-  using interpolator_source_vars =
-      tmpl::list<gr::Tags::SpacetimeMetric<volume_dim, frame>,
-                 GeneralizedHarmonic::Tags::Pi<volume_dim, frame>,
-                 GeneralizedHarmonic::Tags::Phi<volume_dim, frame>>;
-
-  struct factory_creation
-      : tt::ConformsTo<Options::protocols::FactoryCreation> {
-    using factory_classes = tmpl::map<
-        tmpl::pair<
-            Event,
-            tmpl::flatten<tmpl::list<
-                Events::Completion,
-                dg::Events::field_observations<volume_dim, Tags::Time,
-                                               observe_fields,
-                                               analytic_solution_fields>,
-                Events::time_events<system>,
-                intrp::Events::Interpolate<3, AhA, interpolator_source_vars>>>>,
-        tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
-                   StepChoosers::standard_step_choosers<system>>,
-        tmpl::pair<StepChooser<StepChooserUse::Slab>,
-                   StepChoosers::standard_slab_choosers<system,
-                                                        local_time_stepping>>,
-        tmpl::pair<StepController, StepControllers::standard_step_controllers>,
-        tmpl::pair<Trigger, tmpl::append<Triggers::logical_triggers,
-                                         Triggers::time_triggers>>>;
-  };
-
+struct EvolutionMetavars
+    : public virtual GeneralizedHarmonicDefaults,
+      public GeneralizedHarmonicTemplateBase<
+          EvolutionMetavars<InitialData, BoundaryConditions>> {
+  using const_global_cache_tags =
+      typename GeneralizedHarmonicTemplateBase<EvolutionMetavars<
+          InitialData, BoundaryConditions>>::const_global_cache_tags;
   using observed_reduction_data_tags =
-      observers::collect_reduction_data_tags<tmpl::push_back<
-          tmpl::at<typename factory_creation::factory_classes, Event>,
-          typename AhA::post_horizon_find_callback>>;
-
-  using step_actions = tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<EvolutionMetavars>,
-      evolution::dg::Actions::ApplyBoundaryCorrections<EvolutionMetavars>,
-      tmpl::conditional_t<
-          local_time_stepping, tmpl::list<>,
-          tmpl::list<Actions::RecordTimeStepperData<>, Actions::UpdateU<>>>>;
-
-  enum class Phase {
-    Initialization,
-    RegisterWithElementDataReader,
-    ImportInitialData,
-    InitializeInitialDataDependentQuantities,
-    InitializeTimeStepperHistory,
-    Register,
-    LoadBalancing,
-    Evolve,
-    Exit
-  };
-
-  static std::string phase_name(Phase phase) noexcept {
-    if (phase == Phase::LoadBalancing) {
-      return "LoadBalancing";
-    }
-    ERROR(
-        "Passed phase that should not be used in input file. Integer "
-        "corresponding to phase is: "
-        << static_cast<int>(phase));
-  }
-
-  using phase_changes = tmpl::list<PhaseControl::Registrars::VisitAndReturn<
-      EvolutionMetavars, Phase::LoadBalancing>>;
-
-  using initialize_phase_change_decision_data =
-      PhaseControl::InitializePhaseChangeDecisionData<phase_changes>;
-
-  using phase_change_tags_and_combines_list =
-      PhaseControl::get_phase_change_tags<phase_changes>;
-
-  using const_global_cache_tags = tmpl::list<
-      analytic_solution_tag, time_stepper_tag, Tags::EventsAndTriggers,
-      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma0<
-          volume_dim, frame>,
-      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma1<
-          volume_dim, frame>,
-      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma2<
-          volume_dim, frame>,
-      PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes>>;
-
-  using dg_registration_list =
-      tmpl::list<intrp::Actions::RegisterElementWithInterpolator,
-                 observers::Actions::RegisterEventsWithObservers>;
-
-  using initialization_actions = tmpl::list<
-      Actions::SetupDataBox,
-      Initialization::Actions::TimeAndTimeStep<EvolutionMetavars>,
-      evolution::dg::Initialization::Domain<volume_dim,
-                                            override_cubic_functions_of_time>,
-      Initialization::Actions::NonconservativeSystem<system>,
-      tmpl::conditional_t<
-          evolution::is_numeric_initial_data_v<initial_data>, tmpl::list<>,
-          evolution::Initialization::Actions::SetVariables<
-              domain::Tags::Coordinates<volume_dim, Frame::Logical>>>,
-      Initialization::Actions::TimeStepperHistory<EvolutionMetavars>,
-      GeneralizedHarmonic::Actions::InitializeGhAnd3Plus1Variables<volume_dim>,
-      Initialization::Actions::AddComputeTags<tmpl::push_back<
-          StepChoosers::step_chooser_compute_tags<EvolutionMetavars>,
-          evolution::Tags::AnalyticCompute<volume_dim, analytic_solution_tag,
-                                           analytic_solution_fields>>>,
-      ::evolution::dg::Initialization::Mortars<volume_dim, system>,
-      Initialization::Actions::RemoveOptionsAndTerminatePhase>;
-
-  using initialize_initial_data_dependent_quantities_actions = tmpl::list<
-      GeneralizedHarmonic::gauges::Actions::InitializeDampedHarmonic<
-          volume_dim, use_damped_harmonic_rollon>,
-      GeneralizedHarmonic::Actions::InitializeConstraints<volume_dim>,
-      Parallel::Actions::TerminatePhase>;
-
-  using dg_element_array = DgElementArray<
-      EvolutionMetavars,
-      tmpl::flatten<tmpl::list<
-          Parallel::PhaseActions<Phase, Phase::Initialization,
-                                 initialization_actions>,
-          tmpl::conditional_t<
-              evolution::is_numeric_initial_data_v<initial_data>,
-              tmpl::list<
-                  Parallel::PhaseActions<
-                      Phase, Phase::RegisterWithElementDataReader,
-                      tmpl::list<
-                          importers::Actions::RegisterWithElementDataReader,
-                          Parallel::Actions::TerminatePhase>>,
-                  Parallel::PhaseActions<
-                      Phase, Phase::ImportInitialData,
-                      tmpl::list<importers::Actions::ReadVolumeData<
-                                     evolution::OptionTags::NumericInitialData,
-                                     typename system::variables_tag::tags_list>,
-                                 importers::Actions::ReceiveVolumeData<
-                                     evolution::OptionTags::NumericInitialData,
-                                     typename system::variables_tag::tags_list>,
-                                 Parallel::Actions::TerminatePhase>>>,
-              tmpl::list<>>,
-          Parallel::PhaseActions<
-              Phase, Phase::InitializeInitialDataDependentQuantities,
-              initialize_initial_data_dependent_quantities_actions>,
-          Parallel::PhaseActions<
-              Phase, Phase::InitializeTimeStepperHistory,
-              SelfStart::self_start_procedure<step_actions, system>>,
-          Parallel::PhaseActions<Phase, Phase::Register,
-                                 tmpl::list<dg_registration_list,
-                                            Parallel::Actions::TerminatePhase>>,
-          Parallel::PhaseActions<
-              Phase, Phase::Evolve,
-              tmpl::list<Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
-                         step_actions, Actions::AdvanceTime,
-                         PhaseControl::Actions::ExecutePhaseChange<
-                             phase_changes>>>>>>;
-
+      typename GeneralizedHarmonicTemplateBase<EvolutionMetavars<
+          InitialData, BoundaryConditions>>::observed_reduction_data_tags;
+  using component_list = typename GeneralizedHarmonicTemplateBase<
+      EvolutionMetavars<InitialData, BoundaryConditions>>::component_list;
   template <typename ParallelComponent>
-  struct registration_list {
-    using type = std::conditional_t<
-        std::is_same_v<ParallelComponent, dg_element_array>,
-      dg_registration_list, tmpl::list<>>;
-  };
-
-  using component_list = tmpl::flatten<tmpl::list<
-      observers::Observer<EvolutionMetavars>,
-      observers::ObserverWriter<EvolutionMetavars>,
-      intrp::Interpolator<EvolutionMetavars>,
-      intrp::InterpolationTarget<EvolutionMetavars, AhA>,
-      tmpl::conditional_t<evolution::is_numeric_initial_data_v<initial_data>,
-                          importers::ElementDataReader<EvolutionMetavars>,
-                          tmpl::list<>>,
-      dg_element_array>>;
+  using registration_list = typename GeneralizedHarmonicTemplateBase<
+      EvolutionMetavars<InitialData, BoundaryConditions>>::
+      template registration_list<ParallelComponent>;
 
   static constexpr Options::String help{
-      "Evolve a generalized harmonic analytic solution.\n\n"
-      "The analytic solution is: KerrSchild\n"
-      "The numerical flux is:    UpwindFlux\n"};
-
-  template <typename... Tags>
-  static Phase determine_next_phase(
-      const gsl::not_null<tuples::TaggedTuple<Tags...>*>
-          phase_change_decision_data,
-      const Phase& current_phase,
-      const Parallel::CProxy_GlobalCache<EvolutionMetavars>&
-          cache_proxy) noexcept {
-    const auto next_phase =
-        PhaseControl::arbitrate_phase_change<phase_changes>(
-            phase_change_decision_data, current_phase,
-            *(cache_proxy.ckLocalBranch()));
-    if (next_phase.has_value()) {
-      return next_phase.value();
-    }
-    switch (current_phase) {
-      case Phase::Initialization:
-        return evolution::is_numeric_initial_data_v<initial_data>
-                   ? Phase::RegisterWithElementDataReader
-                   : Phase::InitializeInitialDataDependentQuantities;
-      case Phase::RegisterWithElementDataReader:
-        return Phase::ImportInitialData;
-      case Phase::ImportInitialData:
-        return Phase::InitializeInitialDataDependentQuantities;
-      case Phase::InitializeInitialDataDependentQuantities:
-        return Phase::InitializeTimeStepperHistory;
-      case Phase::InitializeTimeStepperHistory:
-        return Phase::Register;
-      case Phase::Register:
-        return Phase::Evolve;
-      case Phase::Evolve:
-        return Phase::Exit;
-      case Phase::Exit:
-        ERROR(
-            "Should never call determine_next_phase with the current phase "
-            "being 'Exit'");
-      default:
-        ERROR(
-            "Unknown type of phase. Did you static_cast<Phase> an integral "
-            "value?");
-    }
-  }
-
-  // NOLINTNEXTLINE(google-runtime-references)
-  void pup(PUP::er& /*p*/) noexcept {}
+      "Evolve the Einstein field equations using the Generalized Harmonic "
+      "formulation\n"};
 };
 
 static const std::vector<void (*)()> charm_init_node_funcs{

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -211,7 +211,7 @@ struct EvolutionMetavars {
                 dg::Events::field_observations<volume_dim, Tags::Time,
                                                observe_fields,
                                                analytic_solution_fields>,
-                Events::time_events<EvolutionMetavars>,
+                Events::time_events<system>,
                 intrp::Events::Interpolate<3, AhA, interpolator_source_vars>>>>,
         tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
                    StepChoosers::standard_step_choosers<system>>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
@@ -1,0 +1,170 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "ApparentHorizons/ComputeItems.hpp"
+#include "ApparentHorizons/Tags.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/RegisterDerivedWithCharm.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/RegisterDerived.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/RegisterDerivedWithCharm.hpp"
+#include "NumericalAlgorithms/Interpolation/AddTemporalIdsToInterpolationTarget.hpp"
+#include "NumericalAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp"
+#include "NumericalAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp"
+#include "NumericalAlgorithms/Interpolation/CleanUpInterpolator.hpp"
+#include "NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp"
+#include "NumericalAlgorithms/Interpolation/Interpolate.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolationTarget.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolationTargetReceiveVars.hpp"
+#include "NumericalAlgorithms/Interpolation/Interpolator.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolatorReceivePoints.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolatorReceiveVolumeData.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolatorRegisterElement.hpp"
+#include "NumericalAlgorithms/Interpolation/Tags.hpp"
+#include "NumericalAlgorithms/Interpolation/TryToInterpolate.hpp"
+#include "Options/Options.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/PhaseControl/PhaseControlTags.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Tags.hpp"
+#include "Time/StepChoosers/Factory.hpp"
+#include "Time/StepControllers/Factory.hpp"
+#include "Utilities/Blas.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+
+// First template parameter specifies the source of the initial data, which
+// could be an analytic solution, analytic data, or imported numerical data.
+// Second template parameter specifies the analytic solution used when imposing
+// dirichlet boundary conditions or against which to compute error norms.
+template <typename InitialData, typename BoundaryConditions>
+struct EvolutionMetavars
+    : public virtual GeneralizedHarmonicDefaults,
+      public GeneralizedHarmonicTemplateBase<
+          EvolutionMetavars<InitialData, BoundaryConditions>> {
+  static constexpr Options::String help{
+      "Evolve the Einstein field equations using the Generalized Harmonic "
+      "formulation,\n"
+      "on a domain with a single horizon and corresponding excised region"};
+
+  struct AhA {
+    using tags_to_observe =
+        tmpl::list<StrahlkorperGr::Tags::AreaCompute<frame>>;
+    using compute_items_on_source = tmpl::list<
+        gr::Tags::SpatialMetricCompute<volume_dim, frame, DataVector>,
+        ah::Tags::InverseSpatialMetricCompute<volume_dim, frame>,
+        ah::Tags::ExtrinsicCurvatureCompute<volume_dim, frame>,
+        ah::Tags::SpatialChristoffelSecondKindCompute<volume_dim, frame>>;
+    using vars_to_interpolate_to_target =
+        tmpl::list<gr::Tags::SpatialMetric<volume_dim, frame, DataVector>,
+                   gr::Tags::InverseSpatialMetric<volume_dim, frame>,
+                   gr::Tags::ExtrinsicCurvature<volume_dim, frame>,
+                   gr::Tags::SpatialChristoffelSecondKind<volume_dim, frame>>;
+    using compute_items_on_target = tmpl::append<
+        tmpl::list<StrahlkorperGr::Tags::AreaElementCompute<frame>>,
+        tags_to_observe>;
+    using compute_target_points =
+        intrp::TargetPoints::ApparentHorizon<AhA, ::Frame::Inertial>;
+    using post_interpolation_callback =
+        intrp::callbacks::FindApparentHorizon<AhA, ::Frame::Inertial>;
+    using post_horizon_find_callback =
+        intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, AhA, AhA>;
+  };
+
+  using interpolation_target_tags = tmpl::list<AhA>;
+  using interpolator_source_vars =
+      tmpl::list<gr::Tags::SpacetimeMetric<volume_dim, frame>,
+                 GeneralizedHarmonic::Tags::Pi<volume_dim, frame>,
+                 GeneralizedHarmonic::Tags::Phi<volume_dim, frame>>;
+
+  using observe_fields = typename GeneralizedHarmonicTemplateBase<
+      EvolutionMetavars>::observe_fields;
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<
+            Event,
+            tmpl::flatten<tmpl::list<
+                Events::Completion,
+                dg::Events::field_observations<volume_dim, Tags::Time,
+                                               observe_fields,
+                                               analytic_solution_fields>,
+                Events::time_events<system>,
+                intrp::Events::Interpolate<3, AhA, interpolator_source_vars>>>>,
+        tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
+                   StepChoosers::standard_step_choosers<system>>,
+        tmpl::pair<
+            StepChooser<StepChooserUse::Slab>,
+            StepChoosers::standard_slab_choosers<system, local_time_stepping>>,
+        tmpl::pair<StepController, StepControllers::standard_step_controllers>,
+        tmpl::pair<Trigger, tmpl::append<Triggers::logical_triggers,
+                                         Triggers::time_triggers>>>;
+  };
+
+  using phase_changes = typename GeneralizedHarmonicTemplateBase<
+      EvolutionMetavars>::phase_changes;
+
+  using const_global_cache_tags = tmpl::list<
+      typename GeneralizedHarmonicTemplateBase<
+          EvolutionMetavars>::analytic_solution_tag,
+      time_stepper_tag, Tags::EventsAndTriggers,
+      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma0<
+          volume_dim, frame>,
+      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma1<
+          volume_dim, frame>,
+      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma2<
+          volume_dim, frame>,
+      PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes>>;
+
+  using observed_reduction_data_tags =
+      observers::collect_reduction_data_tags<tmpl::push_back<
+          tmpl::at<typename factory_creation::factory_classes, Event>,
+          typename AhA::post_horizon_find_callback>>;
+
+  using dg_registration_list =
+      tmpl::push_back<typename GeneralizedHarmonicTemplateBase<
+                          EvolutionMetavars>::dg_registration_list,
+                      intrp::Actions::RegisterElementWithInterpolator>;
+
+  template <typename ParallelComponent>
+  struct registration_list {
+    using type = std::conditional_t<
+        std::is_same_v<ParallelComponent,
+                       typename GeneralizedHarmonicTemplateBase<
+                           EvolutionMetavars>::gh_dg_element_array>,
+        dg_registration_list, tmpl::list<>>;
+  };
+
+  using component_list =
+      tmpl::push_back<typename GeneralizedHarmonicTemplateBase<
+                          EvolutionMetavars>::component_list,
+                      intrp::Interpolator<EvolutionMetavars>,
+                      intrp::InterpolationTarget<EvolutionMetavars, AhA>>;
+};
+
+static const std::vector<void (*)()> charm_init_node_funcs{
+    &setup_error_handling,
+    &disable_openblas_multithreading,
+    &domain::creators::time_dependence::register_derived_with_charm,
+    &domain::FunctionsOfTime::register_derived_with_charm,
+    &GeneralizedHarmonic::BoundaryConditions::register_derived_with_charm,
+    &GeneralizedHarmonic::BoundaryCorrections::register_derived_with_charm,
+    &domain::creators::register_derived_with_charm,
+    &GeneralizedHarmonic::ConstraintDamping::register_derived_with_charm,
+    &Parallel::register_derived_classes_with_charm<TimeSequence<double>>,
+    &Parallel::register_derived_classes_with_charm<TimeSequence<std::uint64_t>>,
+    &Parallel::register_derived_classes_with_charm<TimeStepper>,
+    &Parallel::register_derived_classes_with_charm<
+        PhaseChange<metavariables::phase_changes>>,
+    &Parallel::register_factory_classes_with_charm<metavariables>};
+
+static const std::vector<void (*)()> charm_init_proc_funcs{
+    &enable_floating_point_exceptions};

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizonFwd.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizonFwd.hpp
@@ -16,8 +16,7 @@ struct WrappedGr;
 }  // namespace GeneralizedHarmonic
 namespace gr {
 namespace Solutions {
-template <size_t Dim>
-struct GaugeWave;
+struct KerrSchild;
 }  // namespace Solutions
 }  // namespace gr
 namespace evolution {

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -1,0 +1,390 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include "ApparentHorizons/ComputeItems.hpp"
+#include "ApparentHorizons/Tags.hpp"
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/TagsCharacteresticSpeeds.hpp"
+#include "Evolution/Actions/AddMeshVelocityNonconservative.hpp"
+#include "Evolution/Actions/ComputeTimeDerivative.hpp"
+#include "Evolution/ComputeTags.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp"
+#include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"
+#include "Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp"
+#include "Evolution/Initialization/DgDomain.hpp"
+#include "Evolution/Initialization/DiscontinuousGalerkin.hpp"
+#include "Evolution/Initialization/Evolution.hpp"
+#include "Evolution/Initialization/NonconservativeSystem.hpp"
+#include "Evolution/Initialization/SetVariables.hpp"
+#include "Evolution/NumericInitialData.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/Factory.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Equations.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/InitializeDampedHarmonic.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Initialize.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/UpwindPenaltyCorrection.hpp"
+#include "Evolution/TypeTraits.hpp"
+#include "IO/Importers/Actions/ReadVolumeData.hpp"
+#include "IO/Importers/Actions/ReceiveVolumeData.hpp"
+#include "IO/Importers/Actions/RegisterWithElementDataReader.hpp"
+#include "IO/Importers/ElementDataReader.hpp"
+#include "IO/Observer/Actions/ObserverRegistration.hpp"
+#include "IO/Observer/Actions/RegisterEvents.hpp"
+#include "IO/Observer/Helpers.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/FirstOrderScheme.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/BoundarySchemes/FirstOrder/FirstOrderSchemeLts.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "NumericalAlgorithms/Interpolation/AddTemporalIdsToInterpolationTarget.hpp"
+#include "NumericalAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp"
+#include "NumericalAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp"
+#include "NumericalAlgorithms/Interpolation/CleanUpInterpolator.hpp"
+#include "NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp"
+#include "NumericalAlgorithms/Interpolation/Interpolate.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolationTarget.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolationTargetReceiveVars.hpp"
+#include "NumericalAlgorithms/Interpolation/Interpolator.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolatorReceivePoints.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolatorReceiveVolumeData.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolatorRegisterElement.hpp"
+#include "NumericalAlgorithms/Interpolation/Tags.hpp"
+#include "NumericalAlgorithms/Interpolation/TryToInterpolate.hpp"
+#include "Options/Options.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Actions/TerminatePhase.hpp"
+#include "Parallel/Algorithms/AlgorithmSingleton.hpp"
+#include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
+#include "Parallel/PhaseControl/PhaseControlTags.hpp"
+#include "Parallel/PhaseControl/VisitAndReturn.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "ParallelAlgorithms/Actions/MutateApply.hpp"
+#include "ParallelAlgorithms/DiscontinuousGalerkin/CollectDataForFluxes.hpp"
+#include "ParallelAlgorithms/DiscontinuousGalerkin/FluxCommunication.hpp"
+#include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeInterfaces.hpp"
+#include "ParallelAlgorithms/DiscontinuousGalerkin/InitializeMortars.hpp"
+#include "ParallelAlgorithms/Events/Factory.hpp"
+#include "ParallelAlgorithms/Events/ObserveErrorNorms.hpp"
+#include "ParallelAlgorithms/Events/ObserveFields.hpp"
+#include "ParallelAlgorithms/Events/ObserveTimeStep.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Completion.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/EventsAndTriggers.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/LogicalTriggers.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Tags.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
+#include "ParallelAlgorithms/Initialization/Actions/AddComputeTags.hpp"
+#include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/DetAndInverseSpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ConstraintGammas.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Actions/AdvanceTime.hpp"
+#include "Time/Actions/ChangeSlabSize.hpp"
+#include "Time/Actions/ChangeStepSize.hpp"
+#include "Time/Actions/RecordTimeStepperData.hpp"
+#include "Time/Actions/SelfStartActions.hpp"
+#include "Time/Actions/UpdateU.hpp"
+#include "Time/StepChoosers/Cfl.hpp"
+#include "Time/StepChoosers/Constant.hpp"
+#include "Time/StepChoosers/Factory.hpp"
+#include "Time/StepChoosers/Increase.hpp"
+#include "Time/StepChoosers/PreventRapidIncrease.hpp"
+#include "Time/StepChoosers/StepChooser.hpp"
+#include "Time/StepChoosers/StepToTimes.hpp"
+#include "Time/StepControllers/Factory.hpp"
+#include "Time/StepControllers/StepController.hpp"
+#include "Time/Tags.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Time/Triggers/TimeTriggers.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Frame {
+// IWYU pragma: no_forward_declare MathFunction
+struct Inertial;
+}  // namespace Frame
+namespace PUP {
+class er;
+}  // namespace PUP
+namespace Parallel {
+template <typename Metavariables>
+class CProxy_GlobalCache;
+}  // namespace Parallel
+/// \endcond
+
+struct GeneralizedHarmonicDefaults {
+  static constexpr size_t volume_dim = 3;
+  using frame = Frame::Inertial;
+  using system = GeneralizedHarmonic::System<volume_dim>;
+  static constexpr dg::Formulation dg_formulation =
+      dg::Formulation::StrongInertial;
+  static constexpr bool use_damped_harmonic_rollon = true;
+  using temporal_id = Tags::TimeStepId;
+  static constexpr bool local_time_stepping = false;
+
+  using normal_dot_numerical_flux = Tags::NumericalFlux<
+    GeneralizedHarmonic::UpwindPenaltyCorrection<volume_dim>>;
+
+  using time_stepper_tag = Tags::TimeStepper<
+      std::conditional_t<local_time_stepping, LtsTimeStepper, TimeStepper>>;
+  using analytic_solution_fields = typename system::variables_tag::tags_list;
+
+  struct ObservationType {};
+  using element_observation_type = ObservationType;
+
+  enum class Phase {
+    Initialization,
+    RegisterWithElementDataReader,
+    ImportInitialData,
+    InitializeInitialDataDependentQuantities,
+    InitializeTimeStepperHistory,
+    Register,
+    LoadBalancing,
+    Evolve,
+    Exit
+  };
+
+  static std::string phase_name(Phase phase) noexcept {
+    if (phase == Phase::LoadBalancing) {
+        return "LoadBalancing";
+      }
+      ERROR(
+          "Passed phase that should not be used in input file. Integer "
+          "corresponding to phase is: "
+          << static_cast<int>(phase));
+  }
+
+  using initialize_initial_data_dependent_quantities_actions = tmpl::list<
+      GeneralizedHarmonic::gauges::Actions::InitializeDampedHarmonic<
+          volume_dim, use_damped_harmonic_rollon>,
+      GeneralizedHarmonic::Actions::InitializeConstraints<volume_dim>,
+      Parallel::Actions::TerminatePhase>;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
+};
+
+template <typename EvolutionMetavarsDerived>
+struct GeneralizedHarmonicTemplateBase;
+
+template <template <typename, typename> class EvolutionMetavarsDerived,
+          typename InitialData, typename BoundaryConditions>
+struct GeneralizedHarmonicTemplateBase<
+    EvolutionMetavarsDerived<InitialData, BoundaryConditions>>
+    : public virtual GeneralizedHarmonicDefaults {
+  using derived_metavars =
+      EvolutionMetavarsDerived<InitialData, BoundaryConditions>;
+
+  using initial_data = InitialData;
+  using analytic_solution_tag = Tags::AnalyticSolution<BoundaryConditions>;
+
+  using observe_fields = tmpl::append<
+      tmpl::push_back<
+          analytic_solution_fields,
+          ::Tags::PointwiseL2Norm<
+              GeneralizedHarmonic::Tags::GaugeConstraint<volume_dim, frame>>,
+          ::Tags::PointwiseL2Norm<GeneralizedHarmonic::Tags::
+                                      ThreeIndexConstraint<volume_dim, frame>>>,
+      std::conditional_t<volume_dim == 3,
+                         tmpl::list<::Tags::PointwiseL2Norm<
+                             GeneralizedHarmonic::Tags::FourIndexConstraint<
+                                 volume_dim, frame>>>,
+                         tmpl::list<>>>;
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<Event, tmpl::flatten<tmpl::list<
+                              Events::Completion,
+                              dg::Events::field_observations<
+                                  volume_dim, Tags::Time, observe_fields,
+                                  analytic_solution_fields>,
+                              Events::time_events<system>>>>,
+        tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
+                   StepChoosers::standard_step_choosers<system>>,
+        tmpl::pair<
+            StepChooser<StepChooserUse::Slab>,
+            StepChoosers::standard_slab_choosers<system, local_time_stepping>>,
+        tmpl::pair<StepController, StepControllers::standard_step_controllers>,
+        tmpl::pair<Trigger, tmpl::append<Triggers::logical_triggers,
+                                         Triggers::time_triggers>>>;
+  };
+
+  using observed_reduction_data_tags =
+      observers::collect_reduction_data_tags<tmpl::push_back<
+          tmpl::at<typename factory_creation::factory_classes, Event>>>;
+
+  using phase_changes = tmpl::list<PhaseControl::Registrars::VisitAndReturn<
+      GeneralizedHarmonicTemplateBase, Phase::LoadBalancing>>;
+
+  using initialize_phase_change_decision_data =
+      PhaseControl::InitializePhaseChangeDecisionData<phase_changes>;
+
+  using phase_change_tags_and_combines_list =
+      PhaseControl::get_phase_change_tags<phase_changes>;
+
+  // A tmpl::list of tags to be added to the GlobalCache by the
+  // metavariables
+  using const_global_cache_tags = tmpl::list<
+      analytic_solution_tag, time_stepper_tag, Tags::EventsAndTriggers,
+      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma0<
+          volume_dim, frame>,
+      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma1<
+          volume_dim, frame>,
+      GeneralizedHarmonic::ConstraintDamping::Tags::DampingFunctionGamma2<
+          volume_dim, frame>,
+      PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes>>;
+
+  using dg_registration_list =
+      tmpl::list<observers::Actions::RegisterEventsWithObservers>;
+
+  template <typename... Tags>
+  static Phase determine_next_phase(
+      const gsl::not_null<tuples::TaggedTuple<Tags...>*>
+          phase_change_decision_data,
+      const Phase& current_phase,
+      const Parallel::CProxy_GlobalCache<derived_metavars>&
+          cache_proxy) noexcept {
+    const auto next_phase = PhaseControl::arbitrate_phase_change<phase_changes>(
+        phase_change_decision_data, current_phase,
+        *(cache_proxy.ckLocalBranch()));
+    if (next_phase.has_value()) {
+      return next_phase.value();
+    }
+    switch (current_phase) {
+      case Phase::Initialization:
+        return evolution::is_numeric_initial_data_v<initial_data>
+                   ? Phase::RegisterWithElementDataReader
+                   : Phase::InitializeInitialDataDependentQuantities;
+      case Phase::RegisterWithElementDataReader:
+        return Phase::ImportInitialData;
+      case Phase::ImportInitialData:
+        return Phase::InitializeInitialDataDependentQuantities;
+      case Phase::InitializeInitialDataDependentQuantities:
+        return Phase::InitializeTimeStepperHistory;
+      case Phase::InitializeTimeStepperHistory:
+        return Phase::Register;
+      case Phase::Register:
+        return Phase::Evolve;
+      case Phase::Evolve:
+        return Phase::Exit;
+      case Phase::Exit:
+        ERROR(
+            "Should never call determine_next_phase with the current phase "
+            "being 'Exit'");
+      default:
+        ERROR(
+            "Unknown type of phase. Did you static_cast<Phase> an integral "
+            "value?");
+    }
+  }
+
+  using step_actions = tmpl::list<
+      evolution::dg::Actions::ComputeTimeDerivative<derived_metavars>,
+      evolution::dg::Actions::ApplyBoundaryCorrections<derived_metavars>,
+      tmpl::conditional_t<
+          local_time_stepping, tmpl::list<>,
+          tmpl::list<Actions::RecordTimeStepperData<>, Actions::UpdateU<>>>>;
+
+  using initialization_actions = tmpl::list<
+      Actions::SetupDataBox,
+      Initialization::Actions::TimeAndTimeStep<derived_metavars>,
+      evolution::dg::Initialization::Domain<volume_dim>,
+      Initialization::Actions::NonconservativeSystem<system>,
+      std::conditional_t<
+          evolution::is_numeric_initial_data_v<initial_data>, tmpl::list<>,
+          evolution::Initialization::Actions::SetVariables<
+              domain::Tags::Coordinates<volume_dim, Frame::Logical>>>,
+      Initialization::Actions::TimeStepperHistory<derived_metavars>,
+      GeneralizedHarmonic::Actions::InitializeGhAnd3Plus1Variables<volume_dim>,
+      Initialization::Actions::AddComputeTags<tmpl::push_back<
+          StepChoosers::step_chooser_compute_tags<
+              GeneralizedHarmonicTemplateBase>,
+          evolution::Tags::AnalyticCompute<volume_dim, analytic_solution_tag,
+                                           analytic_solution_fields>>>,
+      ::evolution::dg::Initialization::Mortars<volume_dim, system>,
+      Initialization::Actions::RemoveOptionsAndTerminatePhase>;
+
+  using gh_dg_element_array = DgElementArray<
+      derived_metavars,
+      tmpl::flatten<tmpl::list<
+          Parallel::PhaseActions<Phase, Phase::Initialization,
+                                 initialization_actions>,
+          tmpl::conditional_t<
+              evolution::is_numeric_initial_data_v<initial_data>,
+              tmpl::list<
+                  Parallel::PhaseActions<
+                      Phase, Phase::RegisterWithElementDataReader,
+                      tmpl::list<
+                          importers::Actions::RegisterWithElementDataReader,
+                          Parallel::Actions::TerminatePhase>>,
+                  Parallel::PhaseActions<
+                      Phase, Phase::ImportInitialData,
+                      tmpl::list<importers::Actions::ReadVolumeData<
+                                     evolution::OptionTags::NumericInitialData,
+                                     typename system::variables_tag::tags_list>,
+                                 importers::Actions::ReceiveVolumeData<
+                                     evolution::OptionTags::NumericInitialData,
+                                     typename system::variables_tag::tags_list>,
+                                 Parallel::Actions::TerminatePhase>>>,
+              tmpl::list<>>,
+          Parallel::PhaseActions<
+              Phase, Phase::InitializeInitialDataDependentQuantities,
+              initialize_initial_data_dependent_quantities_actions>,
+          Parallel::PhaseActions<
+              Phase, Phase::InitializeTimeStepperHistory,
+              SelfStart::self_start_procedure<step_actions, system>>,
+          Parallel::PhaseActions<Phase, Phase::Register,
+                                 tmpl::list<dg_registration_list,
+                                            Parallel::Actions::TerminatePhase>>,
+          Parallel::PhaseActions<
+              Phase, Phase::Evolve,
+              tmpl::list<
+                  Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
+                  step_actions, Actions::AdvanceTime,
+                  PhaseControl::Actions::ExecutePhaseChange<phase_changes>>>>>>;
+
+  template <typename ParallelComponent>
+  struct registration_list {
+    using type = std::conditional_t<
+        std::is_same_v<ParallelComponent, gh_dg_element_array>,
+        dg_registration_list, tmpl::list<>>;
+  };
+
+  using component_list = tmpl::flatten<tmpl::list<
+      observers::Observer<derived_metavars>,
+      observers::ObserverWriter<derived_metavars>,
+      std::conditional_t<evolution::is_numeric_initial_data_v<initial_data>,
+                         importers::ElementDataReader<derived_metavars>,
+                         tmpl::list<>>,
+      gh_dg_element_array>>;
+};

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -199,7 +199,7 @@ struct EvolutionMetavars {
                     tmpl::conditional_t<
                         evolution::is_analytic_solution_v<initial_data>,
                         analytic_variables_tags, tmpl::list<>>>,
-                Events::time_events<EvolutionMetavars>,
+                Events::time_events<system>,
                 intrp::Events::Interpolate<3, InterpolationTargetTags,
                                            interpolator_source_vars>...>>>,
         tmpl::pair<StepChooser<StepChooserUse::LtsStep>,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -164,7 +164,7 @@ struct EvolutionMetavars {
                         evolution::is_analytic_solution_v<initial_data>,
                         typename system::primitive_variables_tag::tags_list,
                         tmpl::list<>>>,
-                Events::time_events<EvolutionMetavars>>>>,
+                Events::time_events<system>>>>,
         tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
                    StepChoosers::standard_step_choosers<system>>,
         tmpl::pair<StepChooser<StepChooserUse::Slab>,

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -148,7 +148,7 @@ struct EvolutionMetavars {
                     tmpl::conditional_t<
                         evolution::is_analytic_solution_v<initial_data>,
                         analytic_variables_tags, tmpl::list<>>>,
-                Events::time_events<EvolutionMetavars>>>>,
+                Events::time_events<system>>>>,
         tmpl::pair<
             StepChooser<StepChooserUse::LtsStep>,
             StepChoosers::standard_step_choosers<system, false>>,

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -156,7 +156,7 @@ struct EvolutionMetavars {
                     tmpl::conditional_t<
                         evolution::is_analytic_solution_v<initial_data>,
                         analytic_variables_tags, tmpl::list<>>>,
-                Events::time_events<EvolutionMetavars>>>>,
+                Events::time_events<system>>>>,
         tmpl::pair<
             StepChooser<StepChooserUse::LtsStep>,
             StepChoosers::standard_step_choosers<system, false>>,

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -128,7 +128,7 @@ struct EvolutionMetavars {
                               dg::Events::field_observations<
                                   volume_dim, Tags::Time, observe_fields,
                                   analytic_solution_fields>,
-                              Events::time_events<EvolutionMetavars>>>>,
+                              Events::time_events<system>>>>,
         tmpl::pair<
             StepChooser<StepChooserUse::LtsStep>,
             tmpl::push_back<

--- a/src/Parallel/PhaseControl/VisitAndReturn.hpp
+++ b/src/Parallel/PhaseControl/VisitAndReturn.hpp
@@ -145,9 +145,10 @@ struct VisitAndReturn : public PhaseChange<PhaseChangeRegistrars> {
         *phase_change_decision_data) = false;
   }
 
-  template <typename ParallelComponent, typename ArrayIndex>
+  template <typename ParallelComponent, typename ArrayIndex,
+            typename LocalMetavariables>
   void contribute_phase_data_impl(
-      Parallel::GlobalCache<Metavariables>& cache,
+      Parallel::GlobalCache<LocalMetavariables>& cache,
       const ArrayIndex& array_index) const noexcept {
     if constexpr (std::is_same_v<typename ParallelComponent::chare_type,
                                  Parallel::Algorithms::Array>) {
@@ -161,14 +162,15 @@ struct VisitAndReturn : public PhaseChange<PhaseChangeRegistrars> {
     }
   }
 
-  template <typename... DecisionTags>
+  template <typename... DecisionTags, typename LocalMetavariables>
   typename std::optional<
       std::pair<typename Metavariables::Phase, ArbitrationStrategy>>
   arbitrate_phase_change_impl(
       const gsl::not_null<tuples::TaggedTuple<DecisionTags...>*>
           phase_change_decision_data,
-      const typename Metavariables::Phase current_phase,
-      const Parallel::GlobalCache<Metavariables>& /*cache*/) const noexcept {
+      const typename LocalMetavariables::Phase current_phase,
+      const Parallel::GlobalCache<LocalMetavariables>& /*cache*/)
+      const noexcept {
     auto& return_phase = tuples::get<Tags::ReturnPhase<TargetPhase>>(
         *phase_change_decision_data);
     if (return_phase.has_value()) {

--- a/src/ParallelAlgorithms/Events/Factory.hpp
+++ b/src/ParallelAlgorithms/Events/Factory.hpp
@@ -23,7 +23,7 @@ using field_observations = tmpl::flatten<tmpl::list<
 }  // namespace dg::Events
 
 namespace Events {
-template <typename Metavars>
+template <typename System>
 using time_events =
-    tmpl::list<Events::ObserveTimeStep<Metavars>, Events::ChangeSlabSize>;
+    tmpl::list<Events::ObserveTimeStep<System>, Events::ChangeSlabSize>;
 }  // namespace Events

--- a/src/ParallelAlgorithms/Events/ObserveTimeStep.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveTimeStep.hpp
@@ -104,7 +104,7 @@ struct FormatTimeOutput
  * All values are reported as positive numbers, even for backwards
  * evolutions.
  */
-template <typename Metavariables>
+template <typename System>
 class ObserveTimeStep : public Event {
  private:
   using ReductionData = Events::detail::ObserveTimeStepReductionData;
@@ -158,16 +158,15 @@ class ObserveTimeStep : public Event {
   // We obtain the grid size from the variables, rather than the mesh,
   // so that this observer is not DG-specific.
   using argument_tags =
-      tmpl::list<Tags::Time, Tags::TimeStep,
-                 typename Metavariables::system::variables_tag>;
+      tmpl::list<Tags::Time, Tags::TimeStep, typename System::variables_tag>;
 
-  template <typename ArrayIndex, typename ParallelComponent>
-  void operator()(
-      const double& time, const TimeDelta& time_step,
-      const typename Metavariables::system::variables_tag::type& variables,
-      Parallel::GlobalCache<Metavariables>& cache,
-      const ArrayIndex& array_index,
-      const ParallelComponent* const /*meta*/) const noexcept {
+  template <typename ArrayIndex, typename ParallelComponent,
+            typename Metavariables>
+  void operator()(const double& time, const TimeDelta& time_step,
+                  const typename System::variables_tag::type& variables,
+                  Parallel::GlobalCache<Metavariables>& cache,
+                  const ArrayIndex& array_index,
+                  const ParallelComponent* const /*meta*/) const noexcept {
     const size_t number_of_grid_points = variables.number_of_grid_points();
     const double slab_size = time_step.slab().duration().value();
     const double step_size = abs(time_step.value());
@@ -217,13 +216,13 @@ class ObserveTimeStep : public Event {
   bool output_time_;
 };
 
-template <typename Metavariables>
-ObserveTimeStep<Metavariables>::ObserveTimeStep(const std::string& subfile_name,
+template <typename System>
+ObserveTimeStep<System>::ObserveTimeStep(const std::string& subfile_name,
                                                 const bool output_time) noexcept
     : subfile_path_("/" + subfile_name), output_time_(output_time) {}
 
 /// \cond
-template <typename Metavariables>
-PUP::able::PUP_ID ObserveTimeStep<Metavariables>::my_PUP_ID = 0;  // NOLINT
+template <typename System>
+PUP::able::PUP_ID ObserveTimeStep<System>::my_PUP_ID = 0;  // NOLINT
 /// \endcond
 }  // namespace Events

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave.yaml
@@ -1,0 +1,96 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: EvolveGhGaugeWave
+# Check: parse;execute
+# Timeout: 8
+# ExpectedOutput:
+#   GhGaugeWaveVolume0.h5
+#   GhGaugeWaveReductions.h5
+
+Evolution:
+  InitialTime: 0.0
+  InitialTimeStep: 0.0002
+  TimeStepper:
+    AdamsBashforthN:
+      Order: 3
+
+PhaseChangeAndTriggers:
+
+DomainCreator:
+  Brick:
+    LowerBound: [0.0, 0.0, 0.0]
+    UpperBound: [1.0, 1.0, 1.0]
+    InitialRefinement: [1, 1, 1]
+    InitialGridPoints: [5, 5, 5]
+    TimeDependence: None
+    BoundaryCondition: Periodic
+
+AnalyticSolution:
+  GaugeWave:
+    Amplitude: 0.1
+    Wavelength: 1.0
+
+EvolutionSystem:
+  GeneralizedHarmonic:
+    DhGaugeParameters:
+      RollOnStartTime: 100000.0
+      RollOnTimeWindow: 100.0
+      SpatialDecayWidth: 50.0
+      Amplitudes: [1.0, 1.0, 1.0]
+      Exponents: [4, 4, 4]
+    DampingFunctionGamma0:
+      GaussianPlusConstant:
+        Constant: 1.0
+        Amplitude: 0.0
+        Width: 1.0
+        Center: [0.0, 0.0, 0.0]
+    DampingFunctionGamma1:
+      GaussianPlusConstant:
+        Constant: -1.0
+        Amplitude: 0.0
+        Width: 1.0
+        Center: [0.0, 0.0, 0.0]
+    DampingFunctionGamma2:
+      GaussianPlusConstant:
+        Constant: 1.0
+        Amplitude: 0.0
+        Width: 1.0
+        Center: [0.0, 0.0, 0.0]
+
+SpatialDiscretization:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+    Quadrature: GaussLobatto
+  BoundaryCorrection:
+    UpwindPenalty:
+
+EventsAndTriggers:
+  ? Slabs:
+      EvenlySpaced:
+        Interval: 2
+        Offset: 0
+  : - ObserveErrorNorms:
+        SubfileName: Errors
+  ? Slabs:
+      EvenlySpaced:
+        Interval: 5
+        Offset: 0
+  : - ObserveFields:
+        SubfileName: VolumeData
+        VariablesToObserve:
+          - SpacetimeMetric
+          - Pi
+          - Phi
+          - PointwiseL2Norm(GaugeConstraint)
+          - PointwiseL2Norm(ThreeIndexConstraint)
+          - PointwiseL2Norm(FourIndexConstraint)
+        InterpolateToMesh: None
+  ? Slabs:
+      Specified:
+        Values: [2]
+  : - Completion
+
+Observers:
+  VolumeFileName: "GhGaugeWaveVolume"
+  ReductionFileName: "GhGaugeWaveReductions"

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStep.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStep.cpp
@@ -54,10 +54,10 @@ static_assert(
 
 template <typename Metavariables>
 struct MockContributeReductionData {
-  using ReductionData =
-      tmpl::wrap<tmpl::front<typename Events::ObserveTimeStep<
-                     Metavariables>::observed_reduction_data_tags>,
-                 Parallel::ReductionData>;
+  using ReductionData = tmpl::wrap<
+      tmpl::front<typename Events::ObserveTimeStep<
+          typename Metavariables::system>::observed_reduction_data_tags>,
+      Parallel::ReductionData>;
   struct Results {
     observers::ObservationId observation_id;
     std::string subfile_name;
@@ -154,8 +154,9 @@ struct Metavariables {
 
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
-    using factory_classes = tmpl::map<
-        tmpl::pair<Event, tmpl::list<Events::ObserveTimeStep<Metavariables>>>>;
+    using factory_classes = tmpl::map<tmpl::pair<
+        Event,
+        tmpl::list<Events::ObserveTimeStep<typename Metavariables::system>>>>;
   };
 
   enum class Phase { Initialization, Testing, Exit };
@@ -257,8 +258,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.ObserveTimeStep", "[Unit][Evolution]") {
   Parallel::register_factory_classes_with_charm<Metavariables>();
 
   for (const bool print_to_terminal : {true, false}) {
-    const Events::ObserveTimeStep<Metavariables> observer("time_step_subfile",
-                                                          print_to_terminal);
+    const Events::ObserveTimeStep<typename Metavariables::system> observer(
+        "time_step_subfile", print_to_terminal);
     CHECK(not observer.needs_evolved_variables());
     test_observe(observer, false);
     test_observe(observer, true);


### PR DESCRIPTION
## Proposed changes

Adds a second Generalized Harmonic metavariables file for cases with 0 horizons (and therefore no interpolator or horizon finder compiled in), and a cmake target and input file test for `GaugeWave`.
The code duplication between the metavariables is significant, so if it seems preferable to add more `conditional_t` branching logic to the existing executable to handle the case of no horizons, I can do that instead.

(note: based on modifications to the GeneralizedHarmonic system that @fmahebert shared from his tests)

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

I've also tested the resulting executable on a longer run in the container and verified that the result is appropriately gauge-wavey.