### PR TITLE
Subcell: Add action TciAndSwitchToDg

### DIFF
--- a/src/Evolution/DgSubcell/Actions/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/Actions/CMakeLists.txt
@@ -12,4 +12,5 @@ spectre_target_headers(
   Labels.hpp
   SelectNumericalMethod.hpp
   TciAndRollback.hpp
+  TciAndSwitchToDg.hpp
   )

--- a/src/Evolution/DgSubcell/Actions/TciAndSwitchToDg.hpp
+++ b/src/Evolution/DgSubcell/Actions/TciAndSwitchToDg.hpp
@@ -1,0 +1,308 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <deque>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/NeighborData.hpp"
+#include "Evolution/DgSubcell/RdmpTci.hpp"
+#include "Evolution/DgSubcell/Reconstruction.hpp"
+#include "Evolution/DgSubcell/SubcellOptions.hpp"
+#include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Tags/DidRollback.hpp"
+#include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/NeighborData.hpp"
+#include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
+#include "Evolution/DgSubcell/Tags/TciGridHistory.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Time/History.hpp"
+#include "Time/Tags.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
+namespace tuples {
+template <typename...>
+class TaggedTuple;
+}  // namespace tuples
+/// \endcond
+
+namespace evolution::dg::subcell::Actions {
+/*!
+ * \brief Run the troubled-cell indicator on the subcell solution to see if it
+ * is safe to switch back to DG.
+ *
+ * In terms of the DG-subcell/FD hybrid solver, this action is run after the FD
+ * step has calculated the solution at \f$t^{n+1}\f$. At this point we check if
+ * the FD solution at the new time \f$t^{n+1}\f$ is representable on the DG
+ * grid.
+ *
+ * The algorithm proceeds as follows:
+ * 1. If we are using a substep time integrator and are not at the end of a
+ *    step, or we are in the self-starting stage of a multistep method, or the
+ *    `subcell_options.always_use_subcells() == true`, then we do not run any
+ *    TCI or try to go back to DG. We need to avoid reconstructing (in the sense
+ *    of the inverse of projecting the DG solution to the subcells) the time
+ *    stepper history if there are shocks present in the history, and for
+ *    substep methods this is most easily handled by only switching back at the
+ *    end of a full time step. During the self-start phase of the multistep time
+ *    integrators we integrate over the same region of time at increasingly
+ *    higher order, which means if we were on subcell "previously" (since we use
+ *    a forward-in-time self-start method the time history is actually in the
+ *    future of the current step) then we will very likely need to again switch
+ *    to subcell.
+ * 2. Reconstruct the subcell solution to the DG grid.
+ * 3. Run the relaxed discrete maximum principle (RDMP) troubled-cell indicator
+ *    (TCI), checking both the subcell solution at \f$t^{n+1}\f$ and the
+ *    reconstructed DG solution at \f$t^{n+1}\f$ to make sure they are
+ *    admissible.
+ * 4. If the RDMP TCI marked the DG solution as admissible, run the
+ *    user-specified mutator TCI `TciMutator`.
+ * 5. If the cell is not troubled, and the time integrator type is substep or
+ *    the TCI history indicates the entire history for the multistep method is
+ *    free of discontinuities, then we can switch back to DG. Switching back to
+ *    DG requires swapping the active and inactive evolved variables,
+ *    reconstructing the time stepper history, marking the active grid as
+ *    `ActiveGrid::Dg`, and clearing the subcell neighbor data.
+ * 6. If we are not using a substep method, then record the TCI decision in the
+ *    `subcell::Tags::TciGridHistory`.
+ *
+ * \note Unlike `Actions::TciAndRollback`, this action does _not_ jump back to
+ * `Labels::BeginDg`. This is because users may add actions after a time step
+ * has been completed. In that sense, it may be more proper to actually check
+ * the TCI and switch back to DG at the start of the step rather than the end.
+ *
+ * \note This action always sets `subcell::Tags::DidRollback` to `false` at the
+ * very beginning since this action is called after an FD step has completed.
+ *
+ * GlobalCache:
+ * - Uses:
+ *   - `subcell::Tags::SubcellOptions`
+ *
+ * DataBox:
+ * - Uses:
+ *   - `domain::Tags::Mesh<Dim>`
+ *   - `subcell::Tags::Mesh<Dim>`
+ *   - `Tags::TimeStepId`
+ *   - `subcell::Tags::ActiveGrid`
+ *   - `subcell::Tags::NeighborDataForReconstructionAndRdmpTci<Dim>`
+ *   - `subcell::Tags::TciGridHistory`
+ * - Adds: nothing
+ * - Removes: nothing
+ * - Modifies:
+ *   - `subcell::Tags::Inactive<System::variables_tag>`
+ *   - `System::variables_tag` if the cell is not troubled
+ *   - `Tags::HistoryEvolvedVariables` if the cell is not troubled
+ *   - `subcell::Tags::ActiveGrid` if the cell is not troubled
+ *   - `subcell::Tags::DidRollback` sets to `false`
+ *   - `subcell::Tags::NeighborDataForReconstructionAndRdmpTci<Dim>`
+ *     if the cell is not troubled
+ *   - `subcell::Tags::TciGridHistory` if the time stepper is a multistep method
+ */
+template <typename TciMutator>
+struct TciAndSwitchToDg {
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent, size_t Dim = Metavariables::volume_dim>
+  static std::tuple<db::DataBox<DbTags>&&> apply(
+      db::DataBox<DbTags>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    static_assert(
+        tmpl::count_if<
+            ActionList,
+            std::is_same<tmpl::_1, tmpl::pin<TciAndSwitchToDg>>>::value == 1,
+        "Must have the TciAndSwitchToDg action exactly once in the action list "
+        "of a phase.");
+
+    db::mutate<subcell::Tags::DidRollback>(
+        make_not_null(&box),
+        [](const gsl::not_null<bool*> did_rollback) noexcept {
+          *did_rollback = false;
+        });
+
+    const TimeStepId& time_step_id = db::get<::Tags::TimeStepId>(box);
+    const SubcellOptions& subcell_options = db::get<Tags::SubcellOptions>(box);
+    if (time_step_id.substep() != 0 or
+        UNLIKELY(time_step_id.slab_number() < 0) or
+        UNLIKELY(subcell_options.always_use_subcells())) {
+      // The first condition is that for substep time integrators we only allow
+      // switching back to DG on step boundaries. This is the easiest way to
+      // avoid having a shock in the time stepper history, since there is no
+      // history at step boundaries.
+      //
+      // The second condition is that if we are in the self-start procedure of
+      // the time stepper, and we don't want to switch from subcell back to DG
+      // during self-start since we integrate over the same temporal region at
+      // increasingly higher order.
+      //
+      // The third condition is that the user has requested we always do
+      // subcell, so effectively a finite difference/volume code.
+      return {std::move(box)};
+    }
+
+    using variables_tag = typename Metavariables::system::variables_tag;
+
+    ASSERT(db::get<Tags::ActiveGrid>(box) == ActiveGrid::Subcell,
+           "Must be using subcells when calling TciAndSwitchToDg action.");
+    const Mesh<Dim>& dg_mesh = db::get<::domain::Tags::Mesh<Dim>>(box);
+    const Mesh<Dim>& subcell_mesh = db::get<subcell::Tags::Mesh<Dim>>(box);
+
+    db::mutate<Tags::Inactive<variables_tag>>(
+        make_not_null(&box),
+        [&dg_mesh, &subcell_mesh](const auto inactive_vars_ptr,
+                                  const auto& active_vars) noexcept {
+          // Note: strictly speaking, to be conservative this should reconstruct
+          // uJ instead of u.
+          fd::reconstruct(inactive_vars_ptr, active_vars, dg_mesh,
+                          subcell_mesh.extents());
+        },
+        db::get<variables_tag>(box));
+
+    // Run RDMP TCI since no user info beyond the input file options are needed
+    // for that.
+    const std::pair self_id{Direction<Dim>::lower_xi(),
+                            ElementId<Dim>::external_boundary_id()};
+    ASSERT(
+        db::get<Tags::NeighborDataForReconstructionAndRdmpTci<Dim>>(box).count(
+            self_id) != 0,
+        "The self ID is not in the NeighborData but should have been added "
+        "before TciAndSwitchToDg was called.");
+    const NeighborData& self_neighbor_data =
+        db::get<Tags::NeighborDataForReconstructionAndRdmpTci<Dim>>(box).at(
+            self_id);
+
+    // Note: we assume the max/min over all neighbors and ourselves at the past
+    // time step has been collected into
+    // `self_neighbor_data.max/min_variables_values`
+    bool cell_is_troubled =
+        rdmp_tci(db::get<variables_tag>(box),
+                 db::get<Tags::Inactive<variables_tag>>(box),
+                 self_neighbor_data.max_variables_values,
+                 self_neighbor_data.min_variables_values,
+                 subcell_options.rdmp_delta0(), subcell_options.rdmp_epsilon());
+
+    // If the RDMP TCI marked the candidate as acceptable, check with the
+    // user-specified TCI, since that could be stricter. We pass in the Persson
+    // exponent with one added in order to avoid flip-flopping between DG and
+    // subcell. That is, `persson_exponent+1.0` is stricter than
+    // `persson_exponent`.
+    if (not cell_is_troubled) {
+      cell_is_troubled = db::mutate_apply<TciMutator>(
+          make_not_null(&box), subcell_options.persson_exponent() + 1.0);
+    }
+
+    // If the cell is not troubled, then we _might_ be able to switch back to
+    // DG. This depends on the type of time stepper we are using:
+    // - ADER: Not yet implemented, but here the TCI history is irrelevant
+    //         because it is a one-step scheme, so we can always switch.
+    // - Multistep: the TCI must have marked the entire evolved variable history
+    //              as free of shocks. In practice for LMMs this means the TCI
+    //              history is as long as the evolved variables history and that
+    //              the entire TCI history is `ActiveGrid::Dg`.
+    // - Substep: the easiest is to restrict switching back to DG to step
+    //            boundaries where there is no history.
+    const auto& time_stepper = db::get<::Tags::TimeStepper<>>(box);
+    const bool is_substep_method = time_stepper.number_of_substeps() != 1;
+    ASSERT(time_stepper.number_of_substeps() != 0,
+           "Don't know how to handle a time stepper with zero substeps. This "
+           "might be totally fine, but the case should be thought about.");
+    if (const auto& tci_history = db::get<subcell::Tags::TciGridHistory>(box);
+        not cell_is_troubled and
+        (is_substep_method or
+         (tci_history.size() == time_stepper.order() and
+          alg::all_of(tci_history, [](const ActiveGrid tci_decision) noexcept {
+            return tci_decision == ActiveGrid::Dg;
+          })))) {
+      db::mutate<variables_tag, Tags::Inactive<variables_tag>,
+                 ::Tags::HistoryEvolvedVariables<variables_tag>,
+                 Tags::ActiveGrid,
+                 subcell::Tags::NeighborDataForReconstructionAndRdmpTci<Dim>,
+                 evolution::dg::subcell::Tags::TciGridHistory>(
+          make_not_null(&box),
+          [&dg_mesh, &subcell_mesh](
+              const auto active_vars_ptr, const auto inactive_vars_ptr,
+              const auto active_history_ptr,
+              const gsl::not_null<ActiveGrid*> active_grid_ptr,
+              const auto subcell_neighbor_data_ptr,
+              const gsl::not_null<
+                  std::deque<evolution::dg::subcell::ActiveGrid>*>
+                  tci_grid_history_ptr) noexcept {
+            using std::swap;
+            swap(*active_vars_ptr, *inactive_vars_ptr);
+
+            // Reconstruct the DG solution for each time in the time stepper
+            // history
+            using dt_variables_tag =
+                db::add_tag_prefix<::Tags::dt, variables_tag>;
+            TimeSteppers::History<typename variables_tag::type,
+                                  typename dt_variables_tag::type>
+                dg_history{active_history_ptr->integration_order()};
+            const auto end_it = active_history_ptr->end();
+            for (auto it = active_history_ptr->begin(); it != end_it; ++it) {
+              dg_history.insert(
+                  it.time_step_id(),
+                  fd::reconstruct(it.value(), dg_mesh, subcell_mesh.extents()),
+                  fd::reconstruct(it.derivative(), dg_mesh,
+                                  subcell_mesh.extents()));
+            }
+            *active_history_ptr = std::move(dg_history);
+            *active_grid_ptr = ActiveGrid::Dg;
+
+            // Clear the neighbor data needed for subcell reconstruction since
+            // we have now completed the time step.
+            subcell_neighbor_data_ptr->clear();
+
+            // Clear the TCI grid history since we don't need to use it when on
+            // the DG grid.
+            tci_grid_history_ptr->clear();
+          });
+      return {std::move(box)};
+    }
+
+    if (not is_substep_method) {
+      // For multistep methods we need to record the TCI decision history.
+      // We track the TCI decision, not which grid we are on because for
+      // multistep methods we need the discontinuity to clear the entire
+      // history before we can switch back to DG.
+      db::mutate<evolution::dg::subcell::Tags::TciGridHistory>(
+          make_not_null(&box),
+          [cell_is_troubled,
+           &time_stepper](const gsl::not_null<
+                          std::deque<evolution::dg::subcell::ActiveGrid>*>
+                              tci_grid_history) noexcept {
+            tci_grid_history->push_front(cell_is_troubled ? ActiveGrid::Subcell
+                                                          : ActiveGrid::Dg);
+            if (tci_grid_history->size() > time_stepper.order()) {
+              tci_grid_history->pop_back();
+            }
+          });
+    }
+    return {std::move(box)};
+  }
+};
+}  // namespace evolution::dg::subcell::Actions

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndSwitchToDg.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndSwitchToDg.cpp
@@ -1,0 +1,386 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <boost/functional/hash.hpp>
+#include <cstddef>
+#include <deque>
+#include <memory>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/FixedHashMap.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/MaxNumberOfNeighbors.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/Actions/TciAndSwitchToDg.hpp"
+#include "Evolution/DgSubcell/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "Evolution/DgSubcell/NeighborData.hpp"
+#include "Evolution/DgSubcell/Reconstruction.hpp"
+#include "Evolution/DgSubcell/SubcellOptions.hpp"
+#include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Tags/DidRollback.hpp"
+#include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/NeighborData.hpp"
+#include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
+#include "Evolution/DgSubcell/Tags/TciGridHistory.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "Time/History.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Time/TimeSteppers/AdamsBashforthN.hpp"
+#include "Time/TimeSteppers/RungeKutta3.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+struct Var1 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct System {
+  static constexpr size_t volume_dim = Dim;
+  using variables_tag = Tags::Variables<tmpl::list<Var1>>;
+};
+
+template <size_t Dim, typename Metavariables>
+struct component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+
+  using initial_tags = tmpl::list<
+      ::Tags::TimeStepId, domain::Tags::Mesh<Dim>,
+      evolution::dg::subcell::Tags::Mesh<Dim>,
+      evolution::dg::subcell::Tags::ActiveGrid,
+      evolution::dg::subcell::Tags::DidRollback,
+      evolution::dg::subcell::Tags::NeighborDataForReconstructionAndRdmpTci<
+          Dim>,
+      evolution::dg::subcell::Tags::TciGridHistory,
+      Tags::Variables<tmpl::list<Var1>>,
+      evolution::dg::subcell::Tags::Inactive<Tags::Variables<tmpl::list<Var1>>>,
+      Tags::HistoryEvolvedVariables<Tags::Variables<tmpl::list<Var1>>>,
+      Tags::TimeStepper<TimeStepper>>;
+
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      typename Metavariables::Phase, Metavariables::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<initial_tags>,
+                 evolution::dg::subcell::Actions::TciAndSwitchToDg<
+                     typename Metavariables::TciOnSubcellGrid>>>>;
+};
+
+template <size_t Dim>
+struct Metavariables {
+  static constexpr size_t volume_dim = Dim;
+  using component_list = tmpl::list<component<Dim, Metavariables>>;
+  using system = System<Dim>;
+  using analytic_variables_tags = typename system::variables_tag::tags_list;
+  using const_global_cache_tags =
+      tmpl::list<evolution::dg::subcell::Tags::SubcellOptions>;
+  enum class Phase { Initialization, Exit };
+
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+  static bool rdmp_fails;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+  static bool tci_fails;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+  static bool tci_invoked;
+
+  struct TciOnSubcellGrid {
+    using return_tags = tmpl::list<>;
+    using argument_tags =
+        tmpl::list<evolution::dg::subcell::Tags::Inactive<
+                       Tags::Variables<tmpl::list<Var1>>>,
+                   Tags::Variables<tmpl::list<Var1>>, domain::Tags::Mesh<Dim>>;
+
+    static bool apply(
+        const Variables<
+            tmpl::list<evolution::dg::subcell::Tags::Inactive<Var1>>>& dg_vars,
+        const Variables<tmpl::list<Var1>>& subcell_vars,
+        const Mesh<Dim>& dg_mesh, const double persson_exponent) noexcept {
+      Variables<tmpl::list<evolution::dg::subcell::Tags::Inactive<Var1>>>
+          reconstructed_dg_vars{dg_vars.number_of_grid_points()};
+      evolution::dg::subcell::fd::reconstruct(
+          make_not_null(&reconstructed_dg_vars), subcell_vars, dg_mesh,
+          evolution::dg::subcell::fd::mesh(dg_mesh).extents());
+      CHECK(reconstructed_dg_vars == dg_vars);
+      CHECK(approx(persson_exponent) == 5.0);  // Should be subcell_opts + 1
+      tci_invoked = true;
+      return tci_fails;
+    }
+  };
+};
+
+template <size_t Dim>
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+bool Metavariables<Dim>::rdmp_fails = false;
+template <size_t Dim>
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+bool Metavariables<Dim>::tci_fails = false;
+template <size_t Dim>
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+bool Metavariables<Dim>::tci_invoked = false;
+
+std::unique_ptr<TimeStepper> make_time_stepper(
+    const bool multistep_time_stepper) {
+  if (multistep_time_stepper) {
+    return std::make_unique<TimeSteppers::AdamsBashforthN>(2);
+  } else {
+    return std::make_unique<TimeSteppers::RungeKutta3>();
+  }
+}
+
+template <size_t Dim>
+void test_impl(const bool multistep_time_stepper, const bool rdmp_fails,
+               const bool tci_fails, const bool always_use_subcell,
+               const bool self_starting, const bool in_substep) {
+  CAPTURE(Dim);
+  CAPTURE(multistep_time_stepper);
+  CAPTURE(rdmp_fails);
+  CAPTURE(tci_fails);
+  CAPTURE(always_use_subcell);
+  CAPTURE(self_starting);
+  CAPTURE(in_substep);
+  if (in_substep and multistep_time_stepper) {
+    ERROR("Can't both be taking a substep and using a multistep time stepper");
+  }
+
+  using metavars = Metavariables<Dim>;
+  metavars::rdmp_fails = rdmp_fails;
+  metavars::tci_fails = tci_fails;
+  metavars::tci_invoked = false;
+
+  using comp = component<Dim, metavars>;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
+  MockRuntimeSystem runner{{evolution::dg::subcell::SubcellOptions{
+      1.0e-3, 1.0e-4, 2.0e-3, 2.0e-4, 4.0, 4.0, always_use_subcell}}};
+
+  TimeStepId time_step_id{true, self_starting ? -1 : 1,
+                          Time{Slab{1.0, 2.0}, {0, 10}}};
+  if (in_substep) {
+    // We are in the middle of a time step with a substep method, so update
+    // time_step_id to signal it is in a substep.
+    time_step_id = TimeStepId{true, 1, Time{Slab{1.0, 2.0}, {0, 10}}, 1,
+                              Time{Slab{1.0, 2.0}, {1, 10}}};
+  }
+  const Mesh<Dim> dg_mesh{5, Spectral::Basis::Legendre,
+                          Spectral::Quadrature::GaussLobatto};
+  const Mesh<Dim> subcell_mesh = evolution::dg::subcell::fd::mesh(dg_mesh);
+  const evolution::dg::subcell::ActiveGrid active_grid =
+      evolution::dg::subcell::ActiveGrid::Subcell;
+  const std::unique_ptr<TimeStepper> time_stepper =
+      make_time_stepper(multistep_time_stepper);
+
+  FixedHashMap<maximum_number_of_neighbors(Dim) + 1,
+               std::pair<Direction<Dim>, ElementId<Dim>>,
+               evolution::dg::subcell::NeighborData,
+               boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>
+      neighbor_data{};
+  const std::pair self_id{Direction<Dim>::lower_xi(),
+                          ElementId<Dim>::external_boundary_id()};
+  neighbor_data[self_id] = {};
+  // max and min of +-2 at last time level means reconstructed vars will be in
+  // limit
+  neighbor_data[self_id].max_variables_values.push_back(2.0);
+  neighbor_data[self_id].min_variables_values.push_back(-2.0);
+  std::deque<evolution::dg::subcell::ActiveGrid> tci_grid_history{};
+  for (size_t i = 0; i < time_stepper->order(); ++i) {
+    tci_grid_history.push_back(evolution::dg::subcell::ActiveGrid::Dg);
+  }
+
+  using evolved_vars_tags = tmpl::list<Var1>;
+  Variables<evolved_vars_tags> evolved_vars{
+      subcell_mesh.number_of_grid_points()};
+  // Set Var1 to the logical coords, since those are linear
+  get(get<Var1>(evolved_vars)) = get<0>(logical_coordinates(subcell_mesh));
+  if (rdmp_fails) {
+    get(get<Var1>(evolved_vars))[0] = 100.0;
+  }
+  const Variables<tmpl::list<evolution::dg::subcell::Tags::Inactive<Var1>>>
+      inactive_evolved_vars{dg_mesh.number_of_grid_points(), 1.0};
+  TimeSteppers::History<
+      Variables<evolved_vars_tags>,
+      Variables<db::wrap_tags_in<Tags::dt, evolved_vars_tags>>>
+      time_stepper_history{};
+  for (size_t i = 0; i < time_stepper->order(); ++i) {
+    Variables<evolved_vars_tags> vars{subcell_mesh.number_of_grid_points()};
+    get(get<Var1>(vars)) =
+        (i + 2.0) * get<0>(logical_coordinates(subcell_mesh));
+    Variables<db::wrap_tags_in<Tags::dt, evolved_vars_tags>> dt_vars{
+        subcell_mesh.number_of_grid_points()};
+    get(get<Tags::dt<Var1>>(dt_vars)) =
+        (i + 20.0) * get<0>(logical_coordinates(subcell_mesh));
+    time_stepper_history.insert(
+        {true, 1, Time{Slab{1.0, 2.0}, {static_cast<int>(5 - i), 10}}}, vars,
+        dt_vars);
+  }
+
+  ActionTesting::emplace_array_component_and_initialize<comp>(
+      &runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0}, 0,
+      {time_step_id, dg_mesh, subcell_mesh, active_grid, true, neighbor_data,
+       tci_grid_history, evolved_vars, inactive_evolved_vars,
+       time_stepper_history, make_time_stepper(multistep_time_stepper)});
+
+  // Invoke the TciAndSwitchToDg action on the runner
+  ActionTesting::next_action<comp>(make_not_null(&runner), 0);
+
+  const auto active_grid_from_box =
+      ActionTesting::get_databox_tag<comp,
+                                     evolution::dg::subcell::Tags::ActiveGrid>(
+          runner, 0);
+  const auto& inactive_vars_from_box =
+      ActionTesting::get_databox_tag<comp,
+                                     evolution::dg::subcell::Tags::Inactive<
+                                         Tags::Variables<evolved_vars_tags>>>(
+          runner, 0);
+  const auto& active_vars_from_box =
+      ActionTesting::get_databox_tag<comp, Tags::Variables<evolved_vars_tags>>(
+          runner, 0);
+  const auto& time_stepper_history_from_box =
+      ActionTesting::get_databox_tag<comp, Tags::HistoryEvolvedVariables<>>(
+          runner, 0);
+  const auto& tci_grid_history_from_box = ActionTesting::get_databox_tag<
+      comp, evolution::dg::subcell::Tags::TciGridHistory>(runner, 0);
+  const auto& neighbor_data_from_box = ActionTesting::get_databox_tag<
+      comp, evolution::dg::subcell::Tags::
+                NeighborDataForReconstructionAndRdmpTci<Dim>>(runner, 0);
+
+  // true if the TCI wasn't invoked at all because we are always using subcell,
+  // doing self-start, or took a substep.
+  const bool avoid_tci =
+      always_use_subcell or self_starting or time_step_id.substep() != 0;
+
+  CHECK_FALSE(ActionTesting::get_databox_tag<
+              comp, evolution::dg::subcell::Tags::DidRollback>(runner, 0));
+
+  if (rdmp_fails or avoid_tci) {
+    // If the RDMP decided the cell is troubled, we shouldn't be checking the
+    // user-specified TCI
+    CHECK_FALSE(metavars::tci_invoked);
+  }
+
+  // Check ActiveGrid
+  if (avoid_tci or rdmp_fails or tci_fails) {
+    CHECK(active_grid_from_box == evolution::dg::subcell::ActiveGrid::Subcell);
+
+  } else {
+    CHECK(active_grid_from_box == evolution::dg::subcell::ActiveGrid::Dg);
+  }
+
+  if (avoid_tci) {
+    // Should not have reconstructed DG variables
+    CHECK(inactive_vars_from_box == inactive_evolved_vars);
+  } else {
+    auto reconstructed_dg_vars = inactive_evolved_vars;
+    evolution::dg::subcell::fd::reconstruct(
+        make_not_null(&reconstructed_dg_vars), evolved_vars, dg_mesh,
+        subcell_mesh.extents());
+    if (active_grid_from_box == evolution::dg::subcell::ActiveGrid::Subcell) {
+      CHECK(reconstructed_dg_vars == inactive_vars_from_box);
+    } else {
+      // Do swap because types are different
+      auto reconstructed_active_vars = evolved_vars;
+      swap(reconstructed_dg_vars, reconstructed_active_vars);
+      CHECK(reconstructed_active_vars == active_vars_from_box);
+    }
+  }
+
+  if (active_grid_from_box == evolution::dg::subcell::ActiveGrid::Dg) {
+    for (auto expected_it = time_stepper_history.cbegin(),
+              box_it = time_stepper_history_from_box.cbegin();
+         expected_it != time_stepper_history.end(); ++expected_it, ++box_it) {
+      CHECK(expected_it.time_step_id() == box_it.time_step_id());
+      CHECK(evolution::dg::subcell::fd::reconstruct(
+                expected_it.value(), dg_mesh, subcell_mesh.extents()) ==
+            box_it.value());
+      CHECK(evolution::dg::subcell::fd::reconstruct(
+                expected_it.derivative(), dg_mesh, subcell_mesh.extents()) ==
+            box_it.derivative());
+    }
+    CHECK(neighbor_data_from_box.empty());
+    CHECK(tci_grid_history_from_box.empty());
+  } else {
+    // TCI failed
+    for (auto expected_it = time_stepper_history.cbegin(),
+              box_it = time_stepper_history_from_box.cbegin();
+         expected_it != time_stepper_history.end(); ++expected_it, ++box_it) {
+      CHECK(expected_it.time_step_id() == box_it.time_step_id());
+      CHECK(expected_it.value() == box_it.value());
+      CHECK(expected_it.derivative() == box_it.derivative());
+    }
+    CHECK(neighbor_data_from_box.size() == 1);
+    CHECK(neighbor_data_from_box.count(self_id) == 1);
+    if (avoid_tci) {
+      CHECK(tci_grid_history_from_box.front() ==
+            evolution::dg::subcell::ActiveGrid::Dg);
+    } else if (multistep_time_stepper) {
+      CHECK(tci_grid_history_from_box.front() ==
+            evolution::dg::subcell::ActiveGrid::Subcell);
+    } else {
+      // substep time steppers don't need to keep track of the history right now
+      // because we restrict subcell to DG changes only on step boundaries.
+      CHECK(tci_grid_history_from_box.front() ==
+            evolution::dg::subcell::ActiveGrid::Dg);
+    }
+    if (multistep_time_stepper) {
+      CHECK(tci_grid_history_from_box.size() == time_stepper->order());
+    }
+  }
+}
+
+template <size_t Dim>
+void test() {
+  for (const bool use_multistep_time_stepper : {true, false}) {
+    for (const bool rdmp_fails : {true, false}) {
+      for (const bool tci_fails : {false, true}) {
+        for (const bool always_use_subcell : {false, true}) {
+          for (const bool self_starting : {false, true}) {
+            test_impl<Dim>(use_multistep_time_stepper, rdmp_fails, tci_fails,
+                           always_use_subcell, self_starting, false);
+            if (not use_multistep_time_stepper) {
+              test_impl<Dim>(use_multistep_time_stepper, rdmp_fails, tci_fails,
+                             always_use_subcell, self_starting, true);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Actions.TciAndSwitchToDg",
+                  "[Evolution][Unit]") {
+  // 1. check that if we are in self-start nothing happens. This can be done by
+  //    verifying that the Inactive vars are untouched.
+  // 2. check if substep != 0, nothing happens. Check Inactive vars untouched.
+  // 3. Check if always_use_subcells, inactive vars are untouched.
+  // 4. Check if RDMP gets triggered, then tci_mutator is not called, and we
+  //    stay on subcell
+  // 5. Check if RDMP is not triggered, but tci_mutator is, we stay on subcell
+  // 6. check if RDMP & TCI not triggered, switch to DG.
+  Parallel::register_derived_classes_with_charm<TimeStepper>();
+  test<1>();
+  test<2>();
+  test<3>();
+}
+}  // namespace

--- a/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
+++ b/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Actions/Test_Initialize.cpp
   Actions/Test_SelectNumericalMethod.cpp
   Actions/Test_TciAndRollback.cpp
+  Actions/Test_TciAndSwitchToDg.cpp
   Events/Test_ObserveFields.cpp
   Test_ActiveGrid.cpp
   Test_CartesianFluxDivergence.cpp


### PR DESCRIPTION
## Proposed changes

Add an action that runs the TCI on the subcell grid and then decides whether or not to switch back to DG. The decision making process is a bit tedious because we ultimately need to support substep, multistep, one high-order one-step (ADER) methods

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
