### PR TITLE
Add GH+MHD TimeDerivativeTerms

### DIFF
--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
@@ -18,6 +18,7 @@ spectre_target_headers(
   System.hpp
   StressEnergy.hpp
   Tags.hpp
+  TimeDerivativeTerms.hpp
   )
 
 target_link_libraries(

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Tags.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Tags.hpp
@@ -12,6 +12,12 @@ namespace grmhd::GhValenciaDivClean {
 /// the Einstein field equations and the Valencia GRMHD formulation.
 namespace Tags {
 
+/// Represents the trace reversed stress-energy tensor of the matter in the MHD
+/// sector of the GRMHD system
+struct TraceReversedStressEnergy : db::SimpleTag {
+  using type = tnsr::aa<DataVector, 3>;
+};
+
 /// Represents the stress-energy tensor of the matter in the MHD sector of the
 /// GRMHD system
 struct StressEnergy : db::SimpleTag {

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Tags.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Tags.hpp
@@ -11,6 +11,15 @@ namespace grmhd::GhValenciaDivClean {
 /// %Tags for the combined system of the Generalized Harmonic formulation for
 /// the Einstein field equations and the Valencia GRMHD formulation.
 namespace Tags {
+namespace detail {
+// A const reference to another tag, used for rerouting arguments in the
+// combined system utilities
+template <typename Tag>
+struct TemporaryReference {
+  using tag = Tag;
+  using type = const typename Tag::type&;
+};
+}  // namespace detail
 
 /// Represents the trace reversed stress-energy tensor of the matter in the MHD
 /// sector of the GRMHD system

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/TimeDerivativeTerms.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/TimeDerivativeTerms.hpp
@@ -1,0 +1,224 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/TimeDerivative.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/StressEnergy.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/Tags.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/TimeDerivativeTerms.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace grmhd::GhValenciaDivClean {
+namespace detail {
+// Some temporary tags appear both in the GRMHD temporary list and the
+// GeneralizedHarmonic temporary list, so we wrap the GRMHD temporaries in this
+// prefix tag to avoid collisions in data structures used to store the
+// temporaries.
+template <typename Tag>
+struct ValenciaTempTag : db::SimpleTag, db::PrefixTag {
+  using tag = Tag;
+  using type = typename Tag::type;
+};
+
+template <typename GhDtTagList, typename ValenciaDtTagList,
+          typename ValenciaFluxTagList, typename GhTempTagList,
+          typename ValenciaTempTagList, typename GhGradientTagList,
+          typename GhArgTagList, typename ValenciaArgTagList,
+          typename ValenciaTimeDerivativeArgTagList>
+struct TimeDerivativeTermsImpl;
+
+template <typename... GhDtTags, typename... ValenciaDtTags,
+          typename... ValenciaFluxTags, typename... GhTempTags,
+          typename... ValenciaTempTags, typename... GhGradientTags,
+          typename... GhArgTags, typename... ValenciaArgTags,
+          typename... ValenciaTimeDerivativeArgTags>
+struct TimeDerivativeTermsImpl<
+    tmpl::list<GhDtTags...>, tmpl::list<ValenciaDtTags...>,
+    tmpl::list<ValenciaFluxTags...>, tmpl::list<GhTempTags...>,
+    tmpl::list<ValenciaTempTags...>, tmpl::list<GhGradientTags...>,
+    tmpl::list<GhArgTags...>, tmpl::list<ValenciaArgTags...>,
+    tmpl::list<ValenciaTimeDerivativeArgTags...>> {
+  static void apply(
+      const gsl::not_null<typename GhDtTags::type*>... gh_dts,
+      const gsl::not_null<typename ValenciaDtTags::type*>... valencia_dts,
+      const gsl::not_null<typename ValenciaFluxTags::type*>... valencia_fluxes,
+      const gsl::not_null<typename GhTempTags::type*>... gh_temporaries,
+      const gsl::not_null<
+          typename ValenciaTempTags::type*>... valencia_temporaries,
+      gsl::not_null<tnsr::aa<DataVector, 3_st>*> stress_energy,
+      gsl::not_null<tnsr::a<DataVector, 3_st>*> four_velocity_one_form,
+      gsl::not_null<tnsr::a<DataVector, 3_st>*>
+          comoving_magnetic_field_one_form,
+      const typename ::Tags::deriv<GhGradientTags, tmpl::size_t<3_st>,
+                                   Frame::Inertial>::type&... gh_gradients,
+      const typename GhArgTags::type&... gh_args,
+      const typename ValenciaArgTags::type&... valencia_args) noexcept {
+    GeneralizedHarmonic::TimeDerivative<3_st>::apply(
+        gh_dts..., gh_temporaries..., gh_gradients..., gh_args...);
+
+    // This is needed to be able to reuse temporary tags that the GH system
+    // computed already and pass them in as argument tags to the GRMHD system.
+    // Because the tag lists have order alterations from filtering the argument
+    // tags, we use a tagged tuple to reorder the references to the order
+    // expected by the GRMHD time derivative calculation.
+    tuples::TaggedTuple<Tags::detail::TemporaryReference<ValenciaArgTags>...,
+                        Tags::detail::TemporaryReference<ValenciaTempTags>...,
+                        Tags::detail::TemporaryReference<GhTempTags>...>
+    shuffle_refs(valencia_args..., *valencia_temporaries...,
+                 *gh_temporaries...);
+
+    grmhd::ValenciaDivClean::TimeDerivativeTerms::apply(
+        valencia_dts..., valencia_fluxes..., valencia_temporaries...,
+        tuples::get<
+            Tags::detail::TemporaryReference<ValenciaTimeDerivativeArgTags>>(
+            shuffle_refs)...);
+    dispatch_to_stress_energy_calculation(stress_energy, four_velocity_one_form,
+                                          comoving_magnetic_field_one_form,
+                                          gh_args..., shuffle_refs);
+    dispatch_to_add_stress_energy_term_to_dt_pi(gh_dts..., shuffle_refs,
+                                                *stress_energy);
+  }
+
+ private:
+  template <typename TupleType>
+  static void dispatch_to_add_stress_energy_term_to_dt_pi(
+      gsl::not_null<tnsr::aa<DataVector, 3_st>*> /*dt_spacetime_metric*/,
+      gsl::not_null<tnsr::aa<DataVector, 3_st>*> dt_pi,
+      gsl::not_null<tnsr::iaa<DataVector, 3_st>*> /*dt_phi*/,
+      const TupleType& args,
+      const tnsr::aa<DataVector, 3_st>& stress_energy) noexcept {
+    add_stress_energy_term_to_dt_pi(
+        dt_pi, stress_energy,
+        tuples::get<
+            Tags::detail::TemporaryReference<gr::Tags::Lapse<DataVector>>>(
+            args));
+  }
+
+  template <typename TupleType>
+  static void dispatch_to_stress_energy_calculation(
+      gsl::not_null<tnsr::aa<DataVector, 3_st>*> local_stress_energy,
+      gsl::not_null<tnsr::a<DataVector, 3_st>*> four_velocity_buffer_one_form,
+      gsl::not_null<tnsr::a<DataVector, 3_st>*>
+          comoving_magnetic_field_one_form,
+      const tnsr::aa<DataVector, 3_st>& spacetime_metric,
+      const tnsr::aa<DataVector, 3_st>& /*pi*/,
+      const tnsr::iaa<DataVector, 3_st>& /*phi*/,
+      const Scalar<DataVector>& /*gamma0*/,
+      const Scalar<DataVector>& /*gamma1*/,
+      const Scalar<DataVector>& /*gamma2*/,
+      const tnsr::a<DataVector, 3_st>& /*gauge_function*/,
+      const tnsr::ab<DataVector, 3_st>& /*spacetime_deriv_gauge_function*/,
+      const TupleType& args) noexcept {
+    trace_reversed_stress_energy(
+        local_stress_energy, four_velocity_buffer_one_form,
+        comoving_magnetic_field_one_form,
+        tuples::get<Tags::detail::TemporaryReference<
+            hydro::Tags::RestMassDensity<DataVector>>>(args),
+        tuples::get<Tags::detail::TemporaryReference<
+            hydro::Tags::SpecificEnthalpy<DataVector>>>(args),
+        tuples::get<Tags::detail::TemporaryReference<
+            ValenciaTempTag<hydro::Tags::SpatialVelocityOneForm<
+                DataVector, 3_st, Frame::Inertial>>>>(args),
+        tuples::get<Tags::detail::TemporaryReference<
+            ValenciaTempTag<hydro::Tags::MagneticFieldOneForm<
+                DataVector, 3_st, Frame::Inertial>>>>(args),
+        tuples::get<Tags::detail::TemporaryReference<
+            ValenciaTempTag<hydro::Tags::MagneticFieldSquared<DataVector>>>>(
+            args),
+        tuples::get<Tags::detail::TemporaryReference<ValenciaTempTag<
+            hydro::Tags::MagneticFieldDotSpatialVelocity<DataVector>>>>(args),
+        tuples::get<Tags::detail::TemporaryReference<
+            hydro::Tags::LorentzFactor<DataVector>>>(args),
+        tuples::get<Tags::detail::TemporaryReference<
+            ValenciaTempTag<grmhd::ValenciaDivClean::TimeDerivativeTerms::
+                                OneOverLorentzFactorSquared>>>(args),
+        tuples::get<Tags::detail::TemporaryReference<
+            hydro::Tags::Pressure<DataVector>>>(args),
+        spacetime_metric,
+        tuples::get<Tags::detail::TemporaryReference<
+            gr::Tags::Shift<3_st, Frame::Inertial, DataVector>>>(args),
+        tuples::get<
+            Tags::detail::TemporaryReference<gr::Tags::Lapse<DataVector>>>(
+            args));
+  }
+};
+}  // namespace detail
+
+/*!
+ * \brief Compute the RHS terms and flux values for both the Generalized
+ * Harmonic formulation of Einstein's equations and the Valencia formulation of
+ * the GRMHD equations with divergence cleaning.
+ *
+ * \details The bulk of the computations in this class dispatch to
+ * `GeneralizedHarmonic::TimeDerivative` and
+ * `grmhd::ValenciaDivClean::TimeDerivativeTerms` as a 'product system' -- each
+ * independently operating on its own subset of the supplied variable
+ * collections.
+ * The additional step is taken to compute the trace-reversed stress energy
+ * tensor associated with the GRMHD part of the system and add its contribution
+ * to the \f$\partial_t \Pi_{a b}\f$ variable in the Generalized Harmonic
+ * system, which is the only explicit coupling required to back-react the effect
+ * of matter on the spacetime solution.
+ *
+ * \note The MHD calculation reuses any spacetime quantities in its
+ * argument_tags that are computed by the GH time derivative. However, other
+ * quantities that aren't computed by the GH time derivative like the extrinsic
+ * curvature are currently still retrieved from the DataBox. Those calculations
+ * can be explicitly inlined here to reduce memory pressure and the number of
+ * compute tags.
+ */
+template <typename EquationOfStateType>
+struct TimeDerivativeTerms {
+  using valencia_dt_tags =
+      db::wrap_tags_in<::Tags::dt,
+                       typename grmhd::ValenciaDivClean::System<
+                           EquationOfStateType>::variables_tag::tags_list>;
+  using valencia_flux_tags = tmpl::transform<
+      typename grmhd::ValenciaDivClean::System<
+          EquationOfStateType>::flux_variables,
+      tmpl::bind<::Tags::Flux, tmpl::_1, tmpl::pin<tmpl::size_t<3_st>>,
+                 tmpl::pin<Frame::Inertial>>>;
+
+  using gh_dt_tags = db::wrap_tags_in<
+      ::Tags::dt,
+      typename GeneralizedHarmonic::System<3_st>::variables_tag::tags_list>;
+  using gh_temp_tags =
+      typename GeneralizedHarmonic::TimeDerivative<3_st>::temporary_tags;
+  using gh_gradient_tags =
+      typename GeneralizedHarmonic::System<3_st>::gradients_tags;
+  using gh_arg_tags =
+      typename GeneralizedHarmonic::TimeDerivative<3_st>::argument_tags;
+
+  using valencia_temp_tags = db::wrap_tags_in<
+      detail::ValenciaTempTag,
+      typename grmhd::ValenciaDivClean::TimeDerivativeTerms::temporary_tags>;
+  using valencia_arg_tags = tmpl::list_difference<
+      typename grmhd::ValenciaDivClean::TimeDerivativeTerms::argument_tags,
+      gh_temp_tags>;
+
+  using temporary_tags = tmpl::flatten<tmpl::list<
+      gh_temp_tags, valencia_temp_tags, Tags::TraceReversedStressEnergy,
+      Tags::FourVelocityOneForm, Tags::ComovingMagneticFieldOneForm>>;
+  using argument_tags = tmpl::append<gh_arg_tags, valencia_arg_tags>;
+
+  template <typename... Args>
+  static void apply(Args&&... args) noexcept {
+    detail::TimeDerivativeTermsImpl<
+        gh_dt_tags, valencia_dt_tags, valencia_flux_tags, gh_temp_tags,
+        valencia_temp_tags, gh_gradient_tags, gh_arg_tags, valencia_arg_tags,
+        typename grmhd::ValenciaDivClean::TimeDerivativeTerms::argument_tags>::
+        apply(std::forward<Args>(args)...);
+  }
+};
+}  // namespace grmhd::GhValenciaDivClean

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_GhValenciaDivClean")
 set(LIBRARY_SOURCES
   Test_Tags.cpp
   Test_StressEnergy.cpp
+  Test_TimeDerivativeTerms.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Test_Tags.cpp
@@ -11,6 +11,9 @@
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.GhValenciaDivClean.Tags",
                   "[Unit][Evolution]") {
   TestHelpers::db::test_simple_tag<
+      grmhd::GhValenciaDivClean::Tags::TraceReversedStressEnergy>(
+      "TraceReversedStressEnergy");
+  TestHelpers::db::test_simple_tag<
       grmhd::GhValenciaDivClean::Tags::StressEnergy>("StressEnergy");
   TestHelpers::db::test_simple_tag<
       grmhd::GhValenciaDivClean::Tags::ComovingMagneticField>(

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Test_TimeDerivativeTerms.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Test_TimeDerivativeTerms.cpp
@@ -1,0 +1,235 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/System.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/TimeDerivativeTerms.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/TimeDerivativeTerms.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+template <typename ComputeVolumeTimeDerivativeTerms, size_t Dim,
+          typename EvolvedTagList, typename FluxTagList, typename TempTagList,
+          typename GradientTagList, typename ArgTagList>
+struct ComputeVolumeTimeDerivativeTermsHelper;
+
+template <typename ComputeVolumeTimeDerivativeTerms, size_t Dim,
+          typename... EvolvedTags, typename... FluxTags, typename... TempTags,
+          typename... GradientTags, typename... ArgTags>
+struct ComputeVolumeTimeDerivativeTermsHelper<
+    ComputeVolumeTimeDerivativeTerms, Dim, tmpl::list<EvolvedTags...>,
+    tmpl::list<FluxTags...>, tmpl::list<TempTags...>,
+    tmpl::list<GradientTags...>, tmpl::list<ArgTags...>> {
+  template <typename EvolvedVariables, typename FluxVariables,
+            typename TemporaryVariables, typename GradientVariables,
+            typename ArgumentVariables>
+  static void apply(
+      const gsl::not_null<EvolvedVariables*> dt_vars_ptr,
+      [[maybe_unused]] const gsl::not_null<FluxVariables*> volume_fluxes,
+      const gsl::not_null<TemporaryVariables*> temporaries,
+      const GradientVariables& partial_derivs,
+      const ArgumentVariables& time_derivative_args) noexcept {
+    ComputeVolumeTimeDerivativeTerms::apply(
+        make_not_null(&get<::Tags::dt<EvolvedTags>>(*dt_vars_ptr))...,
+        make_not_null(&get<FluxTags>(*volume_fluxes))...,
+        make_not_null(&get<TempTags>(*temporaries))...,
+        get<GradientTags>(partial_derivs)...,
+        tuples::get<ArgTags>(time_derivative_args)...);
+  }
+};
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.GhValenciaDivClean.TimeDerivativeTerms",
+    "[Unit][Evolution]") {
+  using equation_of_state_type = EquationsOfState::IdealFluid<true>;
+  using gh_variables_tags =
+      typename GeneralizedHarmonic::System<3_st>::variables_tag::tags_list;
+  using valencia_variables_tags = typename grmhd::ValenciaDivClean::System<
+      equation_of_state_type>::variables_tag::tags_list;
+
+  using gh_dt_variables_tags = grmhd::GhValenciaDivClean::TimeDerivativeTerms<
+      equation_of_state_type>::gh_dt_tags;
+  using valencia_dt_variables_tags =
+      grmhd::GhValenciaDivClean::TimeDerivativeTerms<
+          equation_of_state_type>::valencia_dt_tags;
+  using dt_variables_type =
+      Variables<tmpl::append<gh_dt_variables_tags, valencia_dt_variables_tags>>;
+
+  using gh_flux_tags = tmpl::list<>;
+  using valencia_flux_tags = grmhd::GhValenciaDivClean::TimeDerivativeTerms<
+      equation_of_state_type>::valencia_flux_tags;
+  using flux_variables_type =
+      Variables<tmpl::append<gh_flux_tags, valencia_flux_tags>>;
+
+  using gh_temp_tags = grmhd::GhValenciaDivClean::TimeDerivativeTerms<
+      equation_of_state_type>::gh_temp_tags;
+  using valencia_temp_tags = grmhd::GhValenciaDivClean::TimeDerivativeTerms<
+      equation_of_state_type>::valencia_temp_tags;
+  using temp_variables_type =
+      Variables<typename grmhd::GhValenciaDivClean::TimeDerivativeTerms<
+          equation_of_state_type>::temporary_tags>;
+
+  using gh_gradient_tags = tmpl::transform<
+      grmhd::GhValenciaDivClean::TimeDerivativeTerms<
+          equation_of_state_type>::gh_gradient_tags,
+      tmpl::bind<::Tags::deriv, tmpl::_1, tmpl::pin<tmpl::size_t<3_st>>,
+                 tmpl::pin<Frame::Inertial>>>;
+  using valencia_gradient_tags = tmpl::list<>;
+  using gradient_variables_type = Variables<gh_gradient_tags>;
+
+  using gh_arg_tags = grmhd::GhValenciaDivClean::TimeDerivativeTerms<
+      equation_of_state_type>::gh_arg_tags;
+  using valencia_arg_tags = grmhd::GhValenciaDivClean::TimeDerivativeTerms<
+      equation_of_state_type>::valencia_arg_tags;
+  using all_valencia_arg_tags =
+      typename grmhd::ValenciaDivClean::TimeDerivativeTerms::argument_tags;
+  using arg_variables_type = tuples::tagged_tuple_from_typelist<
+      tmpl::append<gh_arg_tags, valencia_arg_tags>>;
+
+  const size_t element_size = 10_st;
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> dist(0.1, 1.0);
+
+  dt_variables_type expected_dt_variables{element_size};
+  dt_variables_type dt_variables{element_size};
+  // Because the tilde_d evolution equation has no source terms, the dt_tilde_d
+  // isn't set by the valencia div clean system, so we just set it arbitrarily
+  fill_with_random_values(
+      make_not_null(&get<::Tags::dt<grmhd::ValenciaDivClean::Tags::TildeD>>(
+          expected_dt_variables)),
+      make_not_null(&gen), make_not_null(&dist));
+  get<::Tags::dt<grmhd::ValenciaDivClean::Tags::TildeD>>(dt_variables) =
+      get<::Tags::dt<grmhd::ValenciaDivClean::Tags::TildeD>>(
+          expected_dt_variables);
+
+  flux_variables_type expected_flux_variables{element_size};
+  flux_variables_type flux_variables{element_size};
+
+  temp_variables_type temp_variables{element_size};
+  temp_variables_type expected_temp_variables{element_size};
+
+  const auto gradient_variables =
+      make_with_random_values<gradient_variables_type>(
+          make_not_null(&gen), make_not_null(&dist), element_size);
+  arg_variables_type arg_variables;
+  tmpl::for_each<tmpl::append<gh_arg_tags, valencia_arg_tags>>(
+      [&gen, &dist, &arg_variables](auto tag_v) noexcept {
+        using tag = typename decltype(tag_v)::type;
+        tuples::get<tag>(arg_variables) =
+            make_with_random_values<typename tag::type>(
+                make_not_null(&gen), make_not_null(&dist),
+                DataVector{element_size});
+      });
+
+  // ensure that the signature of the metric is correct
+  get<0, 0>(tuples::get<gr::Tags::SpacetimeMetric<3_st>>(arg_variables)) +=
+      -2.0;
+  for (size_t i = 0; i < 3; ++i) {
+    tuples::get<gr::Tags::SpacetimeMetric<3_st>>(arg_variables).get(i + 1, 0) *=
+        0.01;
+  }
+
+  ComputeVolumeTimeDerivativeTermsHelper<
+      GeneralizedHarmonic::TimeDerivative<3_st>, 3_st, gh_variables_tags,
+      gh_flux_tags, gh_temp_tags, gh_gradient_tags,
+      gh_arg_tags>::apply(make_not_null(&expected_dt_variables),
+                          make_not_null(&expected_flux_variables),
+                          make_not_null(&expected_temp_variables),
+                          gradient_variables, arg_variables);
+  // appropriately mimic the behavior of the `TimeDerivativeTerms`
+  // implementation wherein it uses the temporary tags from the Generalized
+  // Harmonic system that are applicable to the spacetime parts of the Valencia
+  // system.
+  tuples::tagged_tuple_from_typelist<all_valencia_arg_tags>
+      all_valencia_argument_variables{};
+
+  tmpl::for_each<all_valencia_arg_tags>(
+      [&arg_variables, &expected_temp_variables,
+       &all_valencia_argument_variables](const auto tag_v) noexcept {
+        using tag = typename decltype(tag_v)::type;
+        if constexpr (tmpl::list_contains_v<gh_temp_tags, tag>) {
+          tuples::get<tag>(all_valencia_argument_variables) =
+              get<tag>(expected_temp_variables);
+        } else {
+          tuples::get<tag>(all_valencia_argument_variables) =
+              tuples::get<tag>(arg_variables);
+        }
+      });
+
+  ComputeVolumeTimeDerivativeTermsHelper<
+      grmhd::ValenciaDivClean::TimeDerivativeTerms, 3_st,
+      valencia_variables_tags, valencia_flux_tags, valencia_temp_tags,
+      valencia_gradient_tags,
+      all_valencia_arg_tags>::apply(make_not_null(&expected_dt_variables),
+                                    make_not_null(&expected_flux_variables),
+                                    make_not_null(&expected_temp_variables),
+                                    gradient_variables,
+                                    all_valencia_argument_variables);
+
+  // compute the stress energy for the expected variables
+  grmhd::GhValenciaDivClean::trace_reversed_stress_energy(
+      make_not_null(
+          &get<grmhd::GhValenciaDivClean::Tags::TraceReversedStressEnergy>(
+              expected_temp_variables)),
+      make_not_null(&get<grmhd::GhValenciaDivClean::Tags::FourVelocityOneForm>(
+          expected_temp_variables)),
+      make_not_null(
+          &get<grmhd::GhValenciaDivClean::Tags::ComovingMagneticFieldOneForm>(
+              expected_temp_variables)),
+      tuples::get<hydro::Tags::RestMassDensity<DataVector>>(arg_variables),
+      tuples::get<hydro::Tags::SpecificEnthalpy<DataVector>>(arg_variables),
+      get<grmhd::GhValenciaDivClean::detail::ValenciaTempTag<
+          hydro::Tags::SpatialVelocityOneForm<DataVector, 3, Frame::Inertial>>>(
+          expected_temp_variables),
+      get<grmhd::GhValenciaDivClean::detail::ValenciaTempTag<
+          hydro::Tags::MagneticFieldOneForm<DataVector, 3>>>(
+          expected_temp_variables),
+      get<grmhd::GhValenciaDivClean::detail::ValenciaTempTag<
+          hydro::Tags::MagneticFieldSquared<DataVector>>>(
+          expected_temp_variables),
+      get<grmhd::GhValenciaDivClean::detail::ValenciaTempTag<
+          hydro::Tags::MagneticFieldDotSpatialVelocity<DataVector>>>(
+          expected_temp_variables),
+      tuples::get<hydro::Tags::LorentzFactor<DataVector>>(arg_variables),
+      get<grmhd::GhValenciaDivClean::detail::ValenciaTempTag<
+          typename grmhd::ValenciaDivClean::TimeDerivativeTerms::
+              OneOverLorentzFactorSquared>>(expected_temp_variables),
+      tuples::get<hydro::Tags::Pressure<DataVector>>(arg_variables),
+      tuples::get<gr::Tags::SpacetimeMetric<3_st>>(arg_variables),
+      get<gr::Tags::Shift<3_st>>(expected_temp_variables),
+      get<gr::Tags::Lapse<>>(expected_temp_variables));
+  // apply the correction to dt pi for the expected variables
+  grmhd::GhValenciaDivClean::add_stress_energy_term_to_dt_pi(
+      make_not_null(&get<::Tags::dt<GeneralizedHarmonic::Tags::Pi<3_st>>>(
+          expected_dt_variables)),
+      get<grmhd::GhValenciaDivClean::Tags::TraceReversedStressEnergy>(
+          expected_temp_variables),
+      get<gr::Tags::Lapse<>>(expected_temp_variables));
+
+  ComputeVolumeTimeDerivativeTermsHelper<
+      grmhd::GhValenciaDivClean::TimeDerivativeTerms<equation_of_state_type>,
+      3_st, tmpl::append<gh_variables_tags, valencia_variables_tags>,
+      typename flux_variables_type::tags_list,
+      typename temp_variables_type::tags_list,
+      typename gradient_variables_type::tags_list,
+      typename arg_variables_type::tags_list>::
+      apply(make_not_null(&dt_variables), make_not_null(&flux_variables),
+            make_not_null(&temp_variables), gradient_variables, arg_variables);
+
+  CHECK_VARIABLES_APPROX(dt_variables, expected_dt_variables);
+  CHECK_VARIABLES_APPROX(flux_variables, expected_flux_variables);
+  CHECK_VARIABLES_APPROX(temp_variables, expected_temp_variables);
+}


### PR DESCRIPTION
## Proposed changes

Adds the time derivative calculation for the `GhValenciaDivClean` system. The calculation just uses tag packs to dispatch to the two separate systems, except for a stress energy correction that is computed and applied to dt_pi

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Dependencies

- [x] #3083 