### PR TITLE
Subcell: add functions for the DG actions to call to support subcell

### DIFF
--- a/src/Evolution/DgSubcell/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/CMakeLists.txt
@@ -16,6 +16,7 @@ spectre_target_headers(
   Matrices.hpp
   Mesh.hpp
   NeighborData.hpp
+  NeighborReconstructedFaceSolution.hpp
   PerssonTci.hpp
   PrepareNeighborData.hpp
   Projection.hpp

--- a/src/Evolution/DgSubcell/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/CMakeLists.txt
@@ -17,6 +17,7 @@ spectre_target_headers(
   Mesh.hpp
   NeighborData.hpp
   PerssonTci.hpp
+  PrepareNeighborData.hpp
   Projection.hpp
   RdmpTci.hpp
   Reconstruction.hpp

--- a/src/Evolution/DgSubcell/NeighborReconstructedFaceSolution.hpp
+++ b/src/Evolution/DgSubcell/NeighborReconstructedFaceSolution.hpp
@@ -1,0 +1,172 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/functional/hash.hpp>
+#include <cstddef>
+#include <iterator>
+#include <optional>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/FixedHashMap.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/MaxNumberOfNeighbors.hpp"
+#include "Evolution/DgSubcell/NeighborData.hpp"
+#include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/NeighborData.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace evolution::dg::subcell {
+/*!
+ * \brief Invoked in directions where the neighbor is doing subcell, this
+ * function computes the neighbor data on the mortar via reconstruction on
+ * nearest neighbor subcells.
+ *
+ *
+ * The data needed for reconstruction is copied over into
+ * `subcell::Tags::NeighborDataForReconstructionAndRdmpTci`.
+ * Additionally, the max/min of the evolved variables from neighboring elements
+ * that is used for the relaxed discrete maximum principle troubled-cell
+ * indicator is combined with the data from the local element and stored in
+ * `subcell::Tags::NeighborDataForReconstructionAndRdmpTci`. We handle the RDMP
+ * data now because it is sent in the same buffer as the data for
+ * reconstruction.
+ *
+ * A list of all the directions that are doing subcell is created and then
+ * passed to the mutator
+ * `Metavariables::SubcellOptions::DgOuterCorrectionPackageData::apply`, which
+ * must return a
+ *
+ * \code
+ *  FixedHashMap<
+ *      maximum_number_of_neighbors(volume_dim),
+ *      std::pair<Direction<volume_dim>, ElementId<volume_dim>>,
+ *      std::vector<double>,
+ *      boost::hash<std::pair<Direction<volume_dim>, ElementId<volume_dim>>>>
+ * \endcode
+ *
+ * which holds the reconstructed `dg_packaged_data` on the face (stored in the
+ * `std::vector<double>`) for the boundary correction. A
+ * `std::vector<std::pair<Direction<volume_dim>, ElementId<volume_dim>>>`
+ * holding the list of mortars that need to be reconstructed to is passed in as
+ * the last argument to
+ * `Metavariables::SubcellOptions::DgOuterCorrectionPackageData::apply`.
+ */
+template <typename Metavariables, typename DbTagsList>
+void neighbor_reconstructed_face_solution(
+    const gsl::not_null<db::DataBox<DbTagsList>*> box,
+    const gsl::not_null<std::pair<
+        const TimeStepId,
+        FixedHashMap<
+            maximum_number_of_neighbors(Metavariables::volume_dim),
+            std::pair<Direction<Metavariables::volume_dim>,
+                      ElementId<Metavariables::volume_dim>>,
+            std::tuple<Mesh<Metavariables::volume_dim - 1>,
+                       std::optional<std::vector<double>>,
+                       std::optional<std::vector<double>>, ::TimeStepId>,
+            boost::hash<std::pair<Direction<Metavariables::volume_dim>,
+                                  ElementId<Metavariables::volume_dim>>>>>*>
+        received_temporal_id_and_data) noexcept {
+  constexpr size_t volume_dim = Metavariables::volume_dim;
+  db::mutate<
+      subcell::Tags::NeighborDataForReconstructionAndRdmpTci<volume_dim>>(
+      box, [&received_temporal_id_and_data](
+               const auto subcell_neighbor_data_ptr) noexcept {
+        subcell::NeighborData& self_neighbor_data =
+            subcell_neighbor_data_ptr->at(
+                std::pair{Direction<volume_dim>::lower_xi(),
+                          ElementId<volume_dim>::external_boundary_id()});
+        const size_t number_of_evolved_vars =
+            self_neighbor_data.max_variables_values.size();
+        for (auto& received_mortar_data :
+             received_temporal_id_and_data->second) {
+          const auto& mortar_id = received_mortar_data.first;
+          ASSERT(std::get<1>(received_mortar_data.second).has_value(),
+                 "The subcell mortar data was not sent at TimeStepId "
+                     << received_temporal_id_and_data->first
+                     << " with mortar id (" << mortar_id.first << ','
+                     << mortar_id.second << ")");
+          const std::vector<double>& neighbor_ghost_and_subcell_data =
+              *std::get<1>(received_mortar_data.second);
+          // Compute min and max over neighbors
+          const size_t offset_for_min =
+              neighbor_ghost_and_subcell_data.size() - number_of_evolved_vars;
+          const size_t offset_for_max = offset_for_min - number_of_evolved_vars;
+          for (size_t var_index = 0; var_index < number_of_evolved_vars;
+               ++var_index) {
+            self_neighbor_data.max_variables_values[var_index] = std::max(
+                self_neighbor_data.max_variables_values[var_index],
+                neighbor_ghost_and_subcell_data[offset_for_max + var_index]);
+            self_neighbor_data.min_variables_values[var_index] = std::min(
+                self_neighbor_data.min_variables_values[var_index],
+                neighbor_ghost_and_subcell_data[offset_for_min + var_index]);
+          }
+
+          ASSERT(subcell_neighbor_data_ptr->find(mortar_id) ==
+                     subcell_neighbor_data_ptr->end(),
+                 "The subcell neighbor data is already inserted. Direction: "
+                     << mortar_id.first
+                     << " with ElementId: " << mortar_id.second);
+          // Copy over the neighbor data for reconstruction. We need this
+          // since we might be doing a step unwind and the DG algorithm deletes
+          // the inbox data after lifting the fluxes to the volume.
+          subcell::NeighborData neighbor_data{};
+          // The std::prev avoids copying over the data for the RDMP TCI, which
+          // is both the maximum and minimum of each evolved variable, so
+          // `2*number_of_evolved_vars` components.
+          neighbor_data.data_for_reconstruction.insert(
+              neighbor_data.data_for_reconstruction.end(),
+              neighbor_ghost_and_subcell_data.begin(),
+              std::prev(
+                  neighbor_ghost_and_subcell_data.end(),
+                  2 * static_cast<std::ptrdiff_t>(number_of_evolved_vars)));
+          (*subcell_neighbor_data_ptr)[mortar_id] = std::move(neighbor_data);
+        }
+      });
+  std::vector<std::pair<Direction<volume_dim>, ElementId<volume_dim>>>
+      mortars_to_reconstruct_to{};
+  for (auto& received_mortar_data : received_temporal_id_and_data->second) {
+    const auto& mortar_id = received_mortar_data.first;
+    if (not std::get<2>(received_mortar_data.second).has_value()) {
+      mortars_to_reconstruct_to.push_back(mortar_id);
+    }
+  }
+  FixedHashMap<
+      maximum_number_of_neighbors(volume_dim),
+      std::pair<Direction<volume_dim>, ElementId<volume_dim>>,
+      std::vector<double>,
+      boost::hash<std::pair<Direction<volume_dim>, ElementId<volume_dim>>>>
+      neighbor_reconstructed_evolved_vars =
+          Metavariables::SubcellOptions::DgComputeSubcellNeighborPackagedData::
+              apply(*box, mortars_to_reconstruct_to);
+  ASSERT(neighbor_reconstructed_evolved_vars.size() ==
+             mortars_to_reconstruct_to.size(),
+         "Should have reconstructed "
+             << mortars_to_reconstruct_to.size() << " sides but reconstructed "
+             << neighbor_reconstructed_evolved_vars.size() << " sides.");
+  // Now copy over the packaged data _into_ the inbox in order to avoid having
+  // to make other changes to the DG algorithm (code in
+  // src/Evolution/DiscontinuousGalerkin)
+  for (auto& received_mortar_data : received_temporal_id_and_data->second) {
+    const auto& mortar_id = received_mortar_data.first;
+    if (not std::get<2>(received_mortar_data.second).has_value()) {
+      ASSERT(neighbor_reconstructed_evolved_vars.find(mortar_id) !=
+                 neighbor_reconstructed_evolved_vars.end(),
+             "Could not find mortar id (" << mortar_id.first << ','
+                                          << mortar_id.second
+                                          << ") in reconstructed data map.");
+      std::get<2>(received_mortar_data.second) =
+          std::move(neighbor_reconstructed_evolved_vars.at(mortar_id));
+    }
+  }
+}
+}  // namespace evolution::dg::subcell

--- a/src/Evolution/DgSubcell/PrepareNeighborData.hpp
+++ b/src/Evolution/DgSubcell/PrepareNeighborData.hpp
@@ -1,0 +1,148 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Index.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/OrientationMapHelpers.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/NeighborData.hpp"
+#include "Evolution/DgSubcell/RdmpTci.hpp"
+#include "Evolution/DgSubcell/SliceData.hpp"
+#include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/NeighborData.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace evolution::dg::subcell {
+/*!
+ * \brief Add local data for our and our neighbor's relaxed discrete maximum
+ * principle troubled-cell indicator, and compute and slice data needed for the
+ * neighbor cells.
+ *
+ * The local maximum and minimum of the evolved variables is added to
+ * `Tags::NeighborDataForReconstructionAndRdmpTci` for the RDMP TCI. Then the
+ * data needed by neighbor elements to do reconstruction on the FD grid is sent.
+ * The data to be sent is computed in the mutator
+ * `Metavariables::SubcellOptions::GhostDataToSlice`, which returns a
+ * `Variables` of the tensors to slice and send to the neighbors. Note that the
+ * `Tags::Inactive<variables_tag>` are already projected onto the subcells
+ * before this function is called. This is because the projection needs to be
+ * done anyway for the a posteriori TCI. That is, the evolved variables are
+ * projected at the end of the time step rather than the beginning, while this
+ * function is called at the beginning. The main reason for having the mutator
+ * `GhostDataToSlice` is to allow sending primitive or characteristic variables
+ * for reconstruction.
+ */
+template <typename Metavariables, typename DbTagsList>
+DirectionMap<Metavariables::volume_dim, std::vector<double>>
+prepare_neighbor_data(
+    const gsl::not_null<db::DataBox<DbTagsList>*> box) noexcept {
+  constexpr size_t volume_dim = Metavariables::volume_dim;
+  using variables_tag = typename Metavariables::system::variables_tag;
+  const std::pair self_id{Direction<volume_dim>::lower_xi(),
+                          ElementId<volume_dim>::external_boundary_id()};
+  db::mutate<
+      subcell::Tags::NeighborDataForReconstructionAndRdmpTci<volume_dim>>(
+      box,
+      [&self_id](const auto neighbor_data_ptr,
+                 std::pair<std::vector<double>, std::vector<double>>
+                     max_min_of_vars) noexcept {
+        subcell::NeighborData rdmp_data{};
+        rdmp_data.max_variables_values = std::move(max_min_of_vars.first);
+        rdmp_data.min_variables_values = std::move(max_min_of_vars.second);
+        (*neighbor_data_ptr)[self_id] = std::move(rdmp_data);
+      },
+      evolution::dg::subcell::rdmp_max_min(
+          db::get<variables_tag>(*box),
+          db::get<evolution::dg::subcell::Tags::Inactive<variables_tag>>(*box),
+          true));
+
+  const auto& element = db::get<::domain::Tags::Element<volume_dim>>(*box);
+  DirectionMap<volume_dim, std::vector<double>>
+      all_neighbor_data_for_reconstruction{};
+
+  DirectionMap<volume_dim, bool> directions_to_slice{};
+  for (const auto& [direction, neighbors_in_direction] : element.neighbors()) {
+    if (neighbors_in_direction.size() == 0) {
+      directions_to_slice[direction] = false;
+    } else {
+      directions_to_slice[direction] = true;
+    }
+  }
+
+  const size_t ghost_zone_size =
+      Metavariables::SubcellOptions::ghost_zone_size(*box);
+
+  // We can assume that the inactive tags are projected because if the TCI
+  // passed at the end of the last step, then as part of the RDMP it
+  // projected the data. We require the data be projected during
+  // initialization.
+  all_neighbor_data_for_reconstruction = subcell::slice_data(
+      db::mutate_apply(
+          typename Metavariables::SubcellOptions::GhostDataToSlice{}, box),
+      db::get<subcell::Tags::Mesh<volume_dim>>(*box).extents(), ghost_zone_size,
+      directions_to_slice);
+
+  ASSERT(
+      db::get<
+          subcell::Tags::NeighborDataForReconstructionAndRdmpTci<volume_dim>>(
+          *box)
+          .contains(self_id),
+      "The self info for the RDMP TCI should have been added to the neighbor "
+      "data tag but wasn't.");
+  const subcell::NeighborData& rdmp_data =
+      db::get<
+          subcell::Tags::NeighborDataForReconstructionAndRdmpTci<volume_dim>>(
+          *box)
+          .at(self_id);
+
+  for (const auto& [direction, neighbors] : element.neighbors()) {
+    const auto& orientation = neighbors.orientation();
+    const Mesh<volume_dim>& subcell_mesh =
+        db::get<subcell::Tags::Mesh<volume_dim>>(*box);
+    if (not orientation.is_aligned()) {
+      std::array<size_t, volume_dim> slice_extents{};
+      for (size_t d = 0; d < volume_dim; ++d) {
+        gsl::at(slice_extents, d) = subcell_mesh.extents(d);
+      }
+
+      gsl::at(slice_extents, direction.dimension()) = ghost_zone_size;
+
+      all_neighbor_data_for_reconstruction.at(direction) =
+          orient_variables(all_neighbor_data_for_reconstruction.at(direction),
+                           Index<volume_dim>{slice_extents}, orientation);
+    }
+
+    // Add the RDMP TCI data to what we will be sending.
+    // Note that this is added _after_ the reconstruction data has been
+    // re-oriented.
+    std::vector<double>& neighbor_subcell_data =
+        all_neighbor_data_for_reconstruction.at(direction);
+    neighbor_subcell_data.reserve(neighbor_subcell_data.size() +
+                                  rdmp_data.max_variables_values.size() +
+                                  rdmp_data.min_variables_values.size());
+    neighbor_subcell_data.insert(neighbor_subcell_data.end(),
+                                 rdmp_data.max_variables_values.begin(),
+                                 rdmp_data.max_variables_values.end());
+    neighbor_subcell_data.insert(neighbor_subcell_data.end(),
+                                 rdmp_data.min_variables_values.begin(),
+                                 rdmp_data.min_variables_values.end());
+  }
+
+  return all_neighbor_data_for_reconstruction;
+}
+}  // namespace evolution::dg::subcell

--- a/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
+++ b/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
@@ -15,6 +15,7 @@ set(LIBRARY_SOURCES
   Test_Matrices.cpp
   Test_Mesh.cpp
   Test_NeighborData.cpp
+  Test_NeighborReconstructedFaceSolution.cpp
   Test_PerssonTci.cpp
   Test_PrepareNeighborData.cpp
   Test_Projection.cpp

--- a/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
+++ b/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
@@ -16,6 +16,7 @@ set(LIBRARY_SOURCES
   Test_Mesh.cpp
   Test_NeighborData.cpp
   Test_PerssonTci.cpp
+  Test_PrepareNeighborData.cpp
   Test_Projection.cpp
   Test_RdmpTci.cpp
   Test_Reconstruction.cpp

--- a/tests/Unit/Evolution/DgSubcell/Test_NeighborReconstructedFaceSolution.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_NeighborReconstructedFaceSolution.cpp
@@ -1,0 +1,162 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <boost/functional/hash.hpp>
+#include <cstddef>
+#include <optional>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/FixedHashMap.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/MaxNumberOfNeighbors.hpp"
+#include "Evolution/DgSubcell/NeighborData.hpp"
+#include "Evolution/DgSubcell/NeighborReconstructedFaceSolution.hpp"
+#include "Evolution/DgSubcell/Tags/NeighborData.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct VolumeDouble : db::SimpleTag {
+  using type = double;
+};
+
+template <size_t Dim>
+using NeighborDataMap =
+    FixedHashMap<maximum_number_of_neighbors(Dim) + 1,
+                 std::pair<Direction<Dim>, ElementId<Dim>>,
+                 evolution::dg::subcell::NeighborData,
+                 boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>;
+template <size_t Dim>
+using NeighborReconstructionMap =
+    FixedHashMap<maximum_number_of_neighbors(Dim),
+                 std::pair<Direction<Dim>, ElementId<Dim>>, std::vector<double>,
+                 boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>;
+
+template <size_t Dim>
+using MortarData = std::tuple<Mesh<Dim - 1>, std::optional<std::vector<double>>,
+                              std::optional<std::vector<double>>, ::TimeStepId>;
+
+template <size_t Dim>
+using MortarDataMap =
+    FixedHashMap<maximum_number_of_neighbors(Dim),
+                 std::pair<Direction<Dim>, ElementId<Dim>>, MortarData<Dim>,
+                 boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>;
+
+template <size_t Dim>
+struct Metavariables {
+  static constexpr size_t volume_dim = Dim;
+  struct SubcellOptions {
+    struct DgComputeSubcellNeighborPackagedData {
+      template <typename DbTagsList>
+      static NeighborReconstructionMap<Dim> apply(
+          const db::DataBox<DbTagsList>& box,
+          const std::vector<
+              std::pair<Direction<volume_dim>, ElementId<volume_dim>>>&
+              mortars_to_reconstruct_to) noexcept {
+        const NeighborDataMap<Dim>& neighbor_data =
+            db::get<evolution::dg::subcell::Tags::
+                        NeighborDataForReconstructionAndRdmpTci<Dim>>(box);
+
+        // We just simply copy over the data sent since it doesn't actually
+        // matter what we fill the packaged data with in the test, just that
+        // this function is called and that we can retrieve the correct data
+        // from the stored NeighborData.
+        NeighborReconstructionMap<Dim> neighbor_package_data{};
+        for (const auto& mortar_id : mortars_to_reconstruct_to) {
+          neighbor_package_data[mortar_id] =
+              neighbor_data.at(mortar_id).data_for_reconstruction;
+        }
+        return neighbor_package_data;
+      }
+    };
+  };
+};
+
+template <size_t Dim>
+void test() {
+  CAPTURE(Dim);
+  using metavars = Metavariables<Dim>;
+  const std::pair self_id{Direction<Dim>::lower_xi(),
+                          ElementId<Dim>::external_boundary_id()};
+
+  // Local neighbor data only holds local max/min values of evolved vars.
+  evolution::dg::subcell::NeighborData local_neighbor_data{};
+  local_neighbor_data.max_variables_values = std::vector<double>{1.0, 2.0};
+  local_neighbor_data.min_variables_values = std::vector<double>{-2.0, 0.1};
+  NeighborDataMap<Dim> neighbor_data_map{};
+  neighbor_data_map[self_id] = std::move(local_neighbor_data);
+  auto box =
+      db::create<tmpl::list<evolution::dg::subcell::Tags::
+                                NeighborDataForReconstructionAndRdmpTci<Dim>,
+                            VolumeDouble>>(std::move(neighbor_data_map), 2.5);
+
+  std::pair<const TimeStepId, MortarDataMap<Dim>> mortar_data_from_neighbors{};
+  for (size_t d = 0; d < Dim; ++d) {
+    const Mesh<Dim - 1> dg_face_mesh{2 + 2 * Dim, Spectral::Basis::Legendre,
+                                     Spectral::Quadrature::GaussLobatto};
+    const Mesh<Dim - 1> fd_face_mesh{2 + 2 * Dim + 1,
+                                     Spectral::Basis::FiniteDifference,
+                                     Spectral::Quadrature::CellCentered};
+    std::vector<double> fd_recons_and_rdmp_data(2 * Dim + 1 + 4, 4.0);
+    std::vector<double> dg_recons_and_rdmp_data(2 * Dim + 1 + 4, 7.0);
+    for (size_t i = 0; i < 4; ++i) {
+      dg_recons_and_rdmp_data[2 * Dim + 1 + i] =
+          (i > 1 ? -1.0 : 1.0) * (d + 1.0) * 7.0 * (i + 5.0);
+      fd_recons_and_rdmp_data[2 * Dim + 1 + i] =
+          (i > 1 ? -1.0 : 1.0) * (d + 1.0) * 7.0 * (i + 50.0);
+    }
+    std::vector<double> dg_flux_data(2 * Dim + 1);
+    if (d % 2 == 0) {
+      mortar_data_from_neighbors.second[std::pair{
+          Direction<Dim>{d, Side::Upper}, ElementId<Dim>{2 * d}}] =
+          MortarData<Dim>{
+              dg_face_mesh, dg_recons_and_rdmp_data, dg_flux_data, {}};
+      mortar_data_from_neighbors.second[std::pair{
+          Direction<Dim>{d, Side::Lower}, ElementId<Dim>{2 * d + 1}}] =
+          MortarData<Dim>{
+              fd_face_mesh, fd_recons_and_rdmp_data, std::nullopt, {}};
+    } else {
+      mortar_data_from_neighbors.second[std::pair{
+          Direction<Dim>{d, Side::Lower}, ElementId<Dim>{2 * d}}] =
+          MortarData<Dim>{
+              dg_face_mesh, dg_recons_and_rdmp_data, dg_flux_data, {}};
+      mortar_data_from_neighbors.second[std::pair{
+          Direction<Dim>{d, Side::Upper}, ElementId<Dim>{2 * d + 1}}] =
+          MortarData<Dim>{
+              fd_face_mesh, fd_recons_and_rdmp_data, std::nullopt, {}};
+    }
+  }
+  evolution::dg::subcell::neighbor_reconstructed_face_solution<metavars>(
+      make_not_null(&box), make_not_null(&mortar_data_from_neighbors));
+  for (size_t d = 0; d < Dim; ++d) {
+    std::pair id{Direction<Dim>{d, Side::Lower}, ElementId<Dim>{2 * d + 1}};
+    if (d % 2 != 0) {
+      id = std::pair{Direction<Dim>{d, Side::Upper}, ElementId<Dim>{2 * d + 1}};
+    }
+    REQUIRE(std::get<1>(mortar_data_from_neighbors.second.at(id)).has_value());
+    REQUIRE(std::get<2>(mortar_data_from_neighbors.second.at(id)).has_value());
+    CHECK(*std::get<2>(mortar_data_from_neighbors.second.at(id)) ==
+          std::vector<double>{
+              std::get<1>(mortar_data_from_neighbors.second.at(id))->begin(),
+              std::prev(
+                  std::get<1>(mortar_data_from_neighbors.second.at(id))->end(),
+                  4)});
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Subcell.NeighborReconstructedFaceSolution",
+                  "[Evolution][Unit]") {
+  test<1>();
+  test<2>();
+  test<3>();
+}

--- a/tests/Unit/Evolution/DgSubcell/Test_PrepareNeighborData.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_PrepareNeighborData.cpp
@@ -1,0 +1,202 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <iterator>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Domain/Structure/OrientationMapHelpers.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "Evolution/DgSubcell/NeighborData.hpp"
+#include "Evolution/DgSubcell/PrepareNeighborData.hpp"
+#include "Evolution/DgSubcell/Projection.hpp"
+#include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/NeighborData.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct GhostZoneSize : db::SimpleTag {
+  using type = size_t;
+};
+
+struct Var1 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct Metavariables {
+  static constexpr size_t volume_dim = Dim;
+
+  struct system {
+    using variables_tag = ::Tags::Variables<tmpl::list<Var1>>;
+  };
+
+  struct SubcellOptions {
+    template <typename DbTagsList>
+    static size_t ghost_zone_size(const db::DataBox<DbTagsList>& box) {
+      return db::get<GhostZoneSize>(box);
+    }
+
+    struct GhostDataToSlice {
+      using return_tags = tmpl::list<>;
+      using argument_tags = tmpl::list<evolution::dg::subcell::Tags::Inactive<
+          typename system::variables_tag>>;
+      template <typename T>
+      static Variables<tmpl::list<evolution::dg::subcell::Tags::Inactive<Var1>>>
+      apply(const T& subcell_vars) noexcept {
+        T subcell_vars_to_send = subcell_vars;
+        get(get<evolution::dg::subcell::Tags::Inactive<Var1>>(
+            subcell_vars_to_send)) *= 2.0;
+        return subcell_vars_to_send;
+      }
+    };
+  };
+};
+
+template <size_t Dim>
+Element<Dim> create_element() {
+  DirectionMap<Dim, Neighbors<Dim>> neighbors{};
+  for (size_t i = 0; i < 2 * Dim; ++i) {
+    // only populate some directions with neighbors to test that we can handle
+    // that case correctly. This is needed for DG-subcell at external boundaries
+    if (i % 2 == 0) {
+      neighbors[gsl::at(Direction<Dim>::all_directions(), i)] =
+          Neighbors<Dim>{{ElementId<Dim>{i + 1, {}}}, {}};
+      if constexpr (Dim == 3) {
+        if (i == 2) {
+          neighbors[gsl::at(Direction<Dim>::all_directions(), i)] =
+              Neighbors<Dim>{
+                  {ElementId<Dim>{i + 1, {}}},
+                  OrientationMap<Dim>{std::array{
+                      Direction<Dim>::lower_xi(), Direction<Dim>::lower_eta(),
+                      Direction<Dim>::upper_zeta()}}};
+        }
+      }
+    }
+  }
+
+  return Element<Dim>{ElementId<Dim>{0, {}}, neighbors};
+}
+
+template <size_t Dim>
+std::vector<Direction<Dim>> expected_neighbor_directions() {
+  std::vector<Direction<Dim>> neighbor_directions{};
+  for (size_t i = 0; i < 2 * Dim; ++i) {
+    // only populate some directions with neighbors to test that we can handle
+    // that case correctly. This is needed for DG-subcell at external boundaries
+    if (i % 2 == 0) {
+      neighbor_directions.push_back(
+          gsl::at(Direction<Dim>::all_directions(), i));
+    }
+  }
+  return neighbor_directions;
+}
+
+template <size_t Dim>
+void test() {
+  using variables_tag = ::Tags::Variables<tmpl::list<Var1>>;
+  const Mesh<Dim> dg_mesh{5, Spectral::Basis::Legendre,
+                          Spectral::Quadrature::GaussLobatto};
+  const Mesh<Dim> subcell_mesh = evolution::dg::subcell::fd::mesh(dg_mesh);
+  const Element<Dim> element = create_element<Dim>();
+
+  Variables<tmpl::list<Var1>> vars{dg_mesh.number_of_grid_points(), 0.0};
+  get(get<Var1>(vars)) = get<0>(logical_coordinates(dg_mesh));
+  Variables<tmpl::list<evolution::dg::subcell::Tags::Inactive<Var1>>>
+      inactive_vars{subcell_mesh.number_of_grid_points()};
+  inactive_vars = evolution::dg::subcell::fd::project(vars, dg_mesh,
+                                                      subcell_mesh.extents());
+
+  const size_t ghost_zone_size = 2;
+  auto box = db::create<
+      tmpl::list<GhostZoneSize, evolution::dg::subcell::Tags::Mesh<Dim>,
+                 domain::Tags::Element<Dim>, variables_tag,
+                 evolution::dg::subcell::Tags::Inactive<variables_tag>,
+                 evolution::dg::subcell::Tags::
+                     NeighborDataForReconstructionAndRdmpTci<Dim>>>(
+      ghost_zone_size, subcell_mesh, element, vars, inactive_vars,
+      typename evolution::dg::subcell::Tags::
+          NeighborDataForReconstructionAndRdmpTci<Dim>::type{});
+  const auto data_for_neighbors =
+      evolution::dg::subcell::prepare_neighbor_data<Metavariables<Dim>>(
+          make_not_null(&box));
+
+  const std::pair self_id{Direction<Dim>::lower_xi(),
+                          ElementId<Dim>::external_boundary_id()};
+  const auto& local_neighbor_data =
+      db::get<evolution::dg::subcell::Tags::
+                  NeighborDataForReconstructionAndRdmpTci<Dim>>(box);
+  CHECK(local_neighbor_data.size() == 1);
+  REQUIRE(local_neighbor_data.contains(self_id) == 1);
+  CHECK_ITERABLE_APPROX(local_neighbor_data.at(self_id).min_variables_values,
+                        std::vector<double>{-1.0});
+  CHECK_ITERABLE_APPROX(local_neighbor_data.at(self_id).max_variables_values,
+                        std::vector<double>{1.0});
+
+  // Set all directions to false, enable the desired ones below
+  DirectionMap<Dim, bool> directions_to_slice{};
+  for (const auto& direction : Direction<Dim>::all_directions()) {
+    directions_to_slice[direction] = false;
+  }
+
+  REQUIRE(data_for_neighbors.size() == Dim);
+  const size_t num_ghost_points =
+      subcell_mesh.slice_away(0).number_of_grid_points() * ghost_zone_size;
+  for (const auto& direction : expected_neighbor_directions<Dim>()) {
+    REQUIRE(data_for_neighbors.contains(direction));
+    REQUIRE(data_for_neighbors.at(direction).size() == num_ghost_points + 2);
+    directions_to_slice[direction] = true;
+  }
+
+  // do same operation as GhostDataToSlice
+  get(get<evolution::dg::subcell::Tags::Inactive<Var1>>(inactive_vars)) *= 2.0;
+  auto expected_neighbor_data =
+      evolution::dg::subcell::slice_data(inactive_vars, subcell_mesh.extents(),
+                                         ghost_zone_size, directions_to_slice);
+  if constexpr (Dim == 3) {
+    const auto direction = expected_neighbor_directions<Dim>()[1];
+    Index<Dim> slice_extents = subcell_mesh.extents();
+    slice_extents[direction.dimension()] = ghost_zone_size;
+    expected_neighbor_data.at(direction) =
+        orient_variables(expected_neighbor_data.at(direction), slice_extents,
+                         element.neighbors().at(direction).orientation());
+  }
+
+  for (const auto& direction : expected_neighbor_directions<Dim>()) {
+    const auto& data_in_direction = data_for_neighbors.at(direction);
+    CHECK_ITERABLE_APPROX(
+        expected_neighbor_data.at(direction),
+        std::vector<double>(data_in_direction.begin(),
+                            std::prev(data_in_direction.end(), 2)));
+    CHECK(*std::prev(data_in_direction.end(), 2) == approx(1.0));
+    CHECK(*std::prev(data_in_direction.end(), 1) == approx(-1.0));
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Subcell.PrepareNeighborData",
+                  "[Evolution][Unit]") {
+  test<1>();
+  test<2>();
+  test<3>();
+}


### PR DESCRIPTION
## Proposed changes

The DG actions `ComputeTimeDerivative` and `ApplyBoundaryCorrections` need to be aware that subcell exists. However, the DG library doesn't depend on DG-subcell because we just forward declare the functions and hide them behind an `if constexpr (using_subcell)`. This means that non-subcell executables shouldn't need to link against DG-subcell.

Note that currently the DG-FD interface are not conservative. While making them be conservative wouldn't be too terribly difficult, so far I have no evidence that this actually matters since if we are doing DG the solution is smooth anyway.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
