### PR TITLE
Subcell: Add function to correct packaged data for conservation

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -303,6 +303,19 @@
   year   = "1939"
 }
 
+@article{CHEN2016604,
+  title =   {A fifth-order finite difference scheme for hyperbolic
+             equations on block-adaptive curvilinear grids},
+  journal = {Journal of Computational Physics},
+  volume =  305,
+  pages =   {604-621},
+  year =    2016,
+  issn =    {0021-9991},
+  doi =     {10.1016/j.jcp.2015.11.003},
+  url =   {https://www.sciencedirect.com/science/article/pii/S0021999115007378},
+  author = {Yuxi Chen and Gábor Tóth and Tamas I. Gombosi},
+}
+
 @article{CLAIN20114028,
   title   = {A high-order finite volume method for systems of conservation
              laws—Multi-dimensional Optimal Order Detection (MOOD)},

--- a/src/Evolution/DgSubcell/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/CMakeLists.txt
@@ -12,6 +12,7 @@ spectre_target_headers(
   ActiveGrid.hpp
   CartesianFluxDivergence.hpp
   ComputeBoundaryTerms.hpp
+  CorrectPackagedData.hpp
   DgSubcell.hpp
   Matrices.hpp
   Mesh.hpp

--- a/src/Evolution/DgSubcell/CorrectPackagedData.hpp
+++ b/src/Evolution/DgSubcell/CorrectPackagedData.hpp
@@ -1,0 +1,185 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <boost/functional/hash.hpp>
+#include <cstddef>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/SliceIterator.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Evolution/DgSubcell/Projection.hpp"
+#include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace evolution::dg::subcell {
+/*!
+ * \brief Project the DG package data to the subcells. Data received from a
+ * neighboring element doing DG is always projected, while the data we sent to
+ * our neighbors before doing a rollback from DG to subcell is only projected if
+ * `OverwriteInternalMortarData` is `true`.
+ *
+ * In order for the hybrid DG-FD/FV scheme to be conservative between elements
+ * using DG and elements using subcell, the boundary terms must be the same on
+ * both elements. In practice this means the boundary corrections \f$G+D\f$ must
+ * be computed on the same grid. Consider the element doing subcell which
+ * receives data from an element doing DG. In this case the DG element's
+ * ingredients going into \f$G+D\f$ are projected to the subcells and then
+ * \f$G+D\f$ are computed on the subcells. Similarly, for strict conservation
+ * the element doing DG must first project the data it sent to the neighbor to
+ * the subcells, then compute \f$G+D\f$ on the subcells, and finally reconstrct
+ * \f$G+D\f$ back to the DG grid before lifting \f$G+D\f$ to the volume.
+ *
+ * This function updates the `packaged_data` (ingredients into \f$G+D\f$)
+ * received by an element doing subcell by projecting the neighbor's DG data
+ * onto the subcells. Note that this is only half of what is required for strict
+ * conservation, the DG element must also compute \f$G+D\f$ on the subcells.
+ * Note that we currently do not perform the other half of the correction
+ * needed to be strictly conservative.
+ *
+ * If we are retaking a time step after the DG step failed then maintaining
+ * conservation requires additional care. If `OverwriteInternalMortarData` is
+ * `true` then the local (the element switching from DG to subcell) ingredients
+ * into \f$G+D\f$ are projected and overwrite the data computed from
+ * the FD reconstruction to the interface. However, even this is insufficient to
+ * guarantee conservation. To guarantee conservation (which we do not currently
+ * do) the correction \f$G+D\f$ must be computed on the DG grid and then
+ * projected to the subcells.
+ *
+ * Note that our practical experience shows that since the DG-subcell hybrid
+ * scheme switches to the subcell solver _before_ the local solution contains
+ * discontinuities, strict conservation is not necessary between DG and FD/FV
+ * regions. This was also observed with a block-adaptive finite difference AMR
+ * code \cite CHEN2016604
+ */
+template <bool OverwriteInternalMortarData, size_t Dim,
+          typename DgPackageFieldTags>
+void correct_package_data(
+    const gsl::not_null<Variables<DgPackageFieldTags>*> lower_packaged_data,
+    const gsl::not_null<Variables<DgPackageFieldTags>*> upper_packaged_data,
+    const size_t logical_dimension_to_operate_in, const Element<Dim>& element,
+    const Mesh<Dim>& subcell_volume_mesh,
+    const std::unordered_map<
+        std::pair<Direction<Dim>, ElementId<Dim>>,
+        evolution::dg::MortarData<Dim>,
+        boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
+        mortar_data) noexcept {
+  const Direction<Dim> upper_direction{logical_dimension_to_operate_in,
+                                       Side::Upper};
+  const Direction<Dim> lower_direction{logical_dimension_to_operate_in,
+                                       Side::Lower};
+  const bool has_upper_neighbor = element.neighbors().contains(upper_direction);
+  const bool has_lower_neighbor = element.neighbors().contains(lower_direction);
+  const std::pair upper_mortar_id =
+      has_upper_neighbor
+          ? std::pair{upper_direction,
+                      *element.neighbors().at(upper_direction).begin()}
+          : std::pair<Direction<Dim>, ElementId<Dim>>{};
+  const std::pair lower_mortar_id =
+      has_lower_neighbor
+          ? std::pair{lower_direction,
+                      *element.neighbors().at(lower_direction).begin()}
+          : std::pair<Direction<Dim>, ElementId<Dim>>{};
+
+  Index<Dim> subcell_extents_with_faces = subcell_volume_mesh.extents();
+  ++subcell_extents_with_faces[logical_dimension_to_operate_in];
+  const Mesh<Dim - 1>& subcell_face_mesh =
+      subcell_volume_mesh.slice_away(logical_dimension_to_operate_in);
+
+  const auto project_dg_data_to_subcells =
+      [logical_dimension_to_operate_in, &subcell_extents_with_faces,
+       &subcell_face_mesh](const gsl::not_null<Variables<DgPackageFieldTags>*>
+                               subcell_packaged_data,
+                           const size_t subcell_index,
+                           const Mesh<Dim - 1>& neighbor_face_mesh,
+                           const std::vector<double>& neighbor_data) noexcept {
+        const double* slice_data = neighbor_data.data();
+        // Warning: projected_data can't be inside the `if constexpr` since that
+        // would lead to a dangling pointer.
+        std::vector<double> projected_data{};
+        if constexpr (Dim > 1) {
+          projected_data.resize(
+              Variables<DgPackageFieldTags>::number_of_independent_components *
+              subcell_face_mesh.number_of_grid_points());
+          evolution::dg::subcell::fd::detail::project_impl(
+              gsl::make_span(projected_data.data(), projected_data.size()),
+              gsl::make_span(neighbor_data.data(), neighbor_data.size()),
+              neighbor_face_mesh, subcell_face_mesh.extents());
+          slice_data = projected_data.data();
+        } else {
+          (void)subcell_face_mesh;
+          (void)projected_data;
+        }
+        const size_t volume_grid_points = subcell_extents_with_faces.product();
+        const size_t slice_grid_points =
+            subcell_extents_with_faces
+                .slice_away(logical_dimension_to_operate_in)
+                .product();
+        double* const volume_data = subcell_packaged_data->data();
+        for (SliceIterator si(subcell_extents_with_faces,
+                              logical_dimension_to_operate_in, subcell_index);
+             si; ++si) {
+          for (size_t i = 0;
+               i <
+               Variables<DgPackageFieldTags>::number_of_independent_components;
+               ++i) {
+            // clang-tidy: do not use pointer arithmetic
+            volume_data[si.volume_offset() +
+                        i * volume_grid_points] =  // NOLINT
+                slice_data[si.slice_offset() +
+                           i * slice_grid_points];  // NOLINT
+          }
+        }
+      };
+
+  // Project DG data to the subcells
+  if (auto neighbor_mortar_data_it = mortar_data.find(upper_mortar_id);
+      has_upper_neighbor and neighbor_mortar_data_it != mortar_data.end()) {
+    if (neighbor_mortar_data_it->second.neighbor_mortar_data().has_value()) {
+      project_dg_data_to_subcells(
+          upper_packaged_data,
+          subcell_extents_with_faces[logical_dimension_to_operate_in] - 1,
+          neighbor_mortar_data_it->second.neighbor_mortar_data()->first,
+          neighbor_mortar_data_it->second.neighbor_mortar_data()->second);
+    }
+    if constexpr (OverwriteInternalMortarData) {
+      if (neighbor_mortar_data_it->second.local_mortar_data().has_value()) {
+        project_dg_data_to_subcells(
+            lower_packaged_data,
+            subcell_extents_with_faces[logical_dimension_to_operate_in] - 1,
+            neighbor_mortar_data_it->second.local_mortar_data()->first,
+            neighbor_mortar_data_it->second.local_mortar_data()->second);
+      }
+    }
+  }
+  if (auto neighbor_mortar_data_it = mortar_data.find(lower_mortar_id);
+      has_lower_neighbor and neighbor_mortar_data_it != mortar_data.end()) {
+    if (neighbor_mortar_data_it->second.neighbor_mortar_data().has_value()) {
+      project_dg_data_to_subcells(
+          lower_packaged_data, 0,
+          neighbor_mortar_data_it->second.neighbor_mortar_data()->first,
+          neighbor_mortar_data_it->second.neighbor_mortar_data()->second);
+    }
+    if constexpr (OverwriteInternalMortarData) {
+      if (neighbor_mortar_data_it->second.local_mortar_data().has_value()) {
+        project_dg_data_to_subcells(
+            upper_packaged_data, 0,
+            neighbor_mortar_data_it->second.local_mortar_data()->first,
+            neighbor_mortar_data_it->second.local_mortar_data()->second);
+      }
+    }
+  }
+}
+}  // namespace evolution::dg::subcell

--- a/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
+++ b/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
@@ -14,6 +14,7 @@ set(LIBRARY_SOURCES
   Test_ActiveGrid.cpp
   Test_CartesianFluxDivergence.cpp
   Test_ComputeBoundaryTerms.cpp
+  Test_CorrectPackagedData.cpp
   Test_Matrices.cpp
   Test_Mesh.cpp
   Test_NeighborData.cpp

--- a/tests/Unit/Evolution/DgSubcell/Test_CorrectPackagedData.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_CorrectPackagedData.cpp
@@ -1,0 +1,247 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <boost/functional/hash.hpp>
+#include <cstddef>
+#include <numeric>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/SliceIterator.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Evolution/DgSubcell/CorrectPackagedData.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "Evolution/DgSubcell/Projection.hpp"
+#include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct Var1 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct Var2 : db::SimpleTag {
+  using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
+};
+
+template <size_t Dim>
+void test() {
+  CAPTURE(Dim);
+  using Vars = Variables<tmpl::list<Var1, Var2<Dim>>>;
+  const Mesh<Dim> volume_dg_mesh{5, Spectral::Basis::Legendre,
+                                 Spectral::Quadrature::GaussLobatto};
+  const Mesh<Dim> volume_subcell_mesh =
+      evolution::dg::subcell::fd::mesh(volume_dg_mesh);
+  DirectionMap<Dim, Neighbors<Dim>> neighbors{};
+  for (size_t i = 0; i < 2 * Dim; ++i) {
+    neighbors[gsl::at(Direction<Dim>::all_directions(), i)] =
+        Neighbors<Dim>{{ElementId<Dim>{i + 1, {}}}, {}};
+  }
+  const Element<Dim> element{ElementId<Dim>{0, {}}, neighbors};
+  const TimeStepId time_step_id{true, 1, Time{Slab{1.1, 4.4}, {3, 10}}};
+
+  CAPTURE(volume_dg_mesh);
+  CAPTURE(volume_subcell_mesh);
+  for (size_t direction_to_check = 0; direction_to_check < Dim;
+       ++direction_to_check) {
+    CAPTURE(direction_to_check);
+    Index<Dim> volume_face_extents = volume_subcell_mesh.extents();
+    ++volume_face_extents[direction_to_check];
+    Vars lower_packaged_data{volume_face_extents.product()};
+    Vars upper_packaged_data{volume_face_extents.product()};
+    const size_t number_of_independent_components = Variables<
+        tmpl::list<Var1, Var2<Dim>>>::number_of_independent_components;
+    const auto set_volume_data = [&lower_packaged_data,
+                                  &upper_packaged_data]() {
+      std::iota(lower_packaged_data.data(),
+                lower_packaged_data.data() + lower_packaged_data.size(), 1.0);
+      std::iota(upper_packaged_data.data(),
+                upper_packaged_data.data() + upper_packaged_data.size(),
+                1.0 + upper_packaged_data.size());
+    };
+    set_volume_data();
+    // Save a copy of the lower/upper data so we can compare points in the
+    // volume/away from the interfaces.
+    const Vars interior_lower_packaged_data = lower_packaged_data;
+    const Vars interior_upper_packaged_data = upper_packaged_data;
+
+    std::unordered_map<std::pair<Direction<Dim>, ElementId<Dim>>,
+                       evolution::dg::MortarData<Dim>,
+                       boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>
+        mortar_data{};
+    const Direction<Dim> upper{direction_to_check, Side::Upper};
+    const Direction<Dim> lower{direction_to_check, Side::Lower};
+    const std::pair upper_neighbor{upper,
+                                   *element.neighbors().at(upper).begin()};
+    const std::pair lower_neighbor{lower,
+                                   *element.neighbors().at(lower).begin()};
+    evolution::dg::MortarData<Dim>& upper_mortar_data =
+        mortar_data[upper_neighbor] = {};
+    evolution::dg::MortarData<Dim>& lower_mortar_data =
+        mortar_data[lower_neighbor] = {};
+
+    const Mesh<Dim - 1> dg_face_mesh =
+        volume_dg_mesh.slice_away(direction_to_check);
+    std::vector<double> upper_neighbor_data(
+        number_of_independent_components *
+        dg_face_mesh.number_of_grid_points());
+    std::iota(upper_neighbor_data.begin(), upper_neighbor_data.end(),
+              1.0 + 2.0 * upper_packaged_data.size());
+    std::vector<double> lower_neighbor_data(
+        number_of_independent_components *
+        dg_face_mesh.number_of_grid_points());
+    std::iota(
+        lower_neighbor_data.begin(), lower_neighbor_data.end(),
+        1.0 + 2.0 * upper_packaged_data.size() + upper_neighbor_data.size());
+
+    upper_mortar_data.insert_neighbor_mortar_data(time_step_id, dg_face_mesh,
+                                                  upper_neighbor_data);
+    lower_mortar_data.insert_neighbor_mortar_data(time_step_id, dg_face_mesh,
+                                                  lower_neighbor_data);
+
+    // Check with only remote data
+    evolution::dg::subcell::correct_package_data<false>(
+        make_not_null(&lower_packaged_data),
+        make_not_null(&upper_packaged_data), direction_to_check, element,
+        volume_subcell_mesh, mortar_data);
+
+    const size_t volume_grid_points = volume_face_extents.product();
+    const size_t slice_grid_points =
+        volume_face_extents.slice_away(direction_to_check).product();
+    const Mesh<Dim - 1> subcell_face_mesh =
+        volume_subcell_mesh.slice_away(direction_to_check);
+    const auto perform_face_check = [&dg_face_mesh, direction_to_check,
+                                     slice_grid_points, &subcell_face_mesh,
+                                     &volume_face_extents, volume_grid_points](
+                                        const auto& face_dg_data,
+                                        const auto& volume_packaged_data,
+                                        const size_t subcell_index) {
+      Vars face_vars_data{dg_face_mesh.number_of_grid_points()};
+      std::copy(face_dg_data.begin(), face_dg_data.end(),
+                face_vars_data.data());
+      if constexpr (Dim > 1) {
+        face_vars_data = evolution::dg::subcell::fd::project(
+            face_vars_data, dg_face_mesh, subcell_face_mesh.extents());
+      } else {
+        (void)subcell_face_mesh;
+      }
+      for (SliceIterator si(volume_face_extents, direction_to_check,
+                            subcell_index);
+           si; ++si) {
+        CAPTURE(si.volume_offset());
+        CAPTURE(si.slice_offset());
+        for (size_t i = 0; i < number_of_independent_components; ++i) {
+          CAPTURE(i);
+          CHECK(volume_packaged_data
+                    .data()[i * volume_grid_points + si.volume_offset()] ==
+                approx(face_vars_data
+                           .data()[i * slice_grid_points + si.slice_offset()]));
+        }
+      }
+    };
+    const auto perform_interior_check =
+        [direction_to_check, &volume_face_extents, volume_grid_points](
+            const auto& expected_volume_packaged_data,
+            const auto& volume_packaged_data, const size_t start_index,
+            const size_t one_past_end_index) {
+          for (size_t slice_index = start_index;
+               slice_index < one_past_end_index; ++slice_index) {
+            for (SliceIterator si(volume_face_extents, direction_to_check,
+                                  slice_index);
+                 si; ++si) {
+              for (size_t i = 0; i < number_of_independent_components; ++i) {
+                CHECK(volume_packaged_data.data()[i * volume_grid_points +
+                                                  si.volume_offset()] ==
+                      approx(expected_volume_packaged_data
+                                 .data()[i * volume_grid_points +
+                                         si.volume_offset()]));
+              }
+            }
+          }
+        };
+
+    perform_face_check(upper_neighbor_data, upper_packaged_data,
+                       volume_face_extents[direction_to_check] - 1);
+    perform_face_check(lower_neighbor_data, lower_packaged_data, 0);
+    perform_interior_check(interior_upper_packaged_data, upper_packaged_data, 0,
+                           volume_face_extents[direction_to_check] - 1);
+    perform_interior_check(interior_lower_packaged_data, lower_packaged_data, 1,
+                           volume_face_extents[direction_to_check]);
+
+    // Reset volume data and then check that we can project both local and
+    // remote data (note the `true` template parameter to
+    // `correct_package_data`)
+    set_volume_data();
+
+    std::vector<double> upper_local_data(number_of_independent_components *
+                                         dg_face_mesh.number_of_grid_points());
+    std::iota(upper_local_data.begin(), upper_local_data.end(), 1.0e6);
+    std::vector<double> lower_local_data(number_of_independent_components *
+                                         dg_face_mesh.number_of_grid_points());
+    std::iota(lower_local_data.begin(), lower_local_data.end(), 1.0e7);
+    upper_mortar_data.insert_local_mortar_data(time_step_id, dg_face_mesh,
+                                               upper_local_data);
+    lower_mortar_data.insert_local_mortar_data(time_step_id, dg_face_mesh,
+                                               lower_local_data);
+
+    evolution::dg::subcell::correct_package_data<true>(
+        make_not_null(&lower_packaged_data),
+        make_not_null(&upper_packaged_data), direction_to_check, element,
+        volume_subcell_mesh, mortar_data);
+
+    perform_face_check(upper_neighbor_data, upper_packaged_data,
+                       volume_face_extents[direction_to_check] - 1);
+    perform_face_check(lower_neighbor_data, lower_packaged_data, 0);
+    perform_face_check(upper_local_data, lower_packaged_data,
+                       volume_face_extents[direction_to_check] - 1);
+    perform_face_check(lower_local_data, upper_packaged_data, 0);
+
+    perform_interior_check(interior_upper_packaged_data, upper_packaged_data, 1,
+                           volume_face_extents[direction_to_check] - 1);
+    perform_interior_check(interior_lower_packaged_data, lower_packaged_data, 1,
+                           volume_face_extents[direction_to_check] - 1);
+
+    // Check that if the local data is in the map but not requested to be
+    // overwritten then we don't overwrite it.
+    set_volume_data();
+
+    evolution::dg::subcell::correct_package_data<false>(
+        make_not_null(&lower_packaged_data),
+        make_not_null(&upper_packaged_data), direction_to_check, element,
+        volume_subcell_mesh, mortar_data);
+
+    perform_face_check(upper_neighbor_data, upper_packaged_data,
+                       volume_face_extents[direction_to_check] - 1);
+    perform_face_check(lower_neighbor_data, lower_packaged_data, 0);
+
+    perform_interior_check(interior_upper_packaged_data, upper_packaged_data, 0,
+                           volume_face_extents[direction_to_check] - 1);
+    perform_interior_check(interior_lower_packaged_data, lower_packaged_data, 1,
+                           volume_face_extents[direction_to_check]);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Subcell.CorrectPackagedData",
+                  "[Evolution][Unit]") {
+  test<1>();
+  test<2>();
+  test<3>();
+}


### PR DESCRIPTION
## Proposed changes

Add a function that overwrites the packaged data computed by reconstruction with the data sent from neighboring elements and optionally, if the step is being retaken, with the DG data sent to the neighboring elements. This doesn't quite get us to strict conservation, the remaining part is computing the boundary corrections on the DG elements on the subcell interface and then reconstructing that back to the element.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
