### PR TITLE
Allow reference tags to list multiple arguments

### DIFF
--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -214,6 +214,10 @@ class DataBox<tmpl::list<Tags...>> : private detail::Item<Tags>... {
   using compute_item_tags =
       tmpl::filter<immutable_item_tags, db::is_compute_tag<tmpl::_1>>;
 
+  /// A list of all the reference tags
+  using reference_item_tags =
+      tmpl::filter<immutable_item_tags, db::is_reference_tag<tmpl::_1>>;
+
   /// \cond HIDDEN_SYMBOLS
   /*!
    * \note the default constructor is only used for serialization
@@ -390,6 +394,8 @@ std::string DataBox<tmpl::list<Tags...>>::print_types() const {
      << pretty_type::get_name<mutable_subitem_tags>() << ";\n";
   os << "using compute_item_tags = "
      << pretty_type::get_name<compute_item_tags>() << ";\n";
+  os << "using reference_item_tags = "
+     << pretty_type::get_name<reference_item_tags>() << ";\n";
   os << "using edge_list = " << pretty_type::get_name<edge_list>() << ";\n";
   return os.str();
 }

--- a/src/DataStructures/DataBox/ObservationBox.hpp
+++ b/src/DataStructures/DataBox/ObservationBox.hpp
@@ -74,6 +74,9 @@ class ObservationBox<tmpl::list<ComputeTags...>, DataBoxType>
   void evaluate_compute_item(
       tmpl::list<ArgumentTags...> /*meta*/) const;
 
+  template <typename ReferenceTag, typename... ArgumentTags>
+  const auto& get_reference_item(tmpl::list<ArgumentTags...> /*meta*/) const;
+
   const DataBoxType* databox_ = nullptr;
 };
 
@@ -122,7 +125,7 @@ const auto& ObservationBox<tmpl::list<ComputeTags...>, DataBoxType>::get()
       using item_tag = db::detail::first_matching_tag<compute_item_tags, Tag>;
       if constexpr (db::detail::Item<item_tag>::item_type ==
                     db::detail::ItemType::Reference) {
-        return item_tag::get(get<typename item_tag::parent_tag>());
+        return get_reference_item<item_tag>(typename item_tag::argument_tags{});
       } else {
         if (not get_item<item_tag>().evaluated()) {
           evaluate_compute_item<item_tag>(typename item_tag::argument_tags{});
@@ -142,6 +145,14 @@ template <typename ComputeTag, typename... ArgumentTags>
 void ObservationBox<tmpl::list<ComputeTags...>, DataBoxType>::
     evaluate_compute_item(tmpl::list<ArgumentTags...> /*meta*/) const {
   get_item<ComputeTag>().evaluate(get<ArgumentTags>()...);
+}
+
+template <typename DataBoxType, typename... ComputeTags>
+template <typename ReferenceTag, typename... ArgumentTags>
+const auto&
+ObservationBox<tmpl::list<ComputeTags...>, DataBoxType>::get_reference_item(
+    tmpl::list<ArgumentTags...> /*meta*/) const {
+  return ReferenceTag::get(get<ArgumentTags>()...);
 }
 
 template <typename ComputeTagsList, typename DataBoxType>

--- a/src/DataStructures/DataBox/SubitemTag.hpp
+++ b/src/DataStructures/DataBox/SubitemTag.hpp
@@ -21,11 +21,11 @@ struct Subitem;
 template <typename Tag, typename ParentTag, typename>
 struct Subitem : Tag, db::ReferenceTag {
   using base = Tag;
-  using parent_tag = ParentTag;
-  static const auto& get(const typename parent_tag::type& parent_value) {
-    return ::db::Subitems<parent_tag>::template create_compute_item<base>(
+  using argument_tags = tmpl::list<ParentTag>;
+  static const auto& get(
+      const typename ParentTag::type& parent_value) {
+    return ::db::Subitems<ParentTag>::template create_compute_item<base>(
         parent_value);
   }
-  using argument_tags = tmpl::list<parent_tag>;
 };
 }  // namespace Tags

--- a/src/DataStructures/DataBox/Tag.hpp
+++ b/src/DataStructures/DataBox/Tag.hpp
@@ -168,11 +168,9 @@ struct ComputeTag {};
  * \derivedrequires
  * - type alias `base` that is the simple tag from which the reference tag is
  *   derived
- * - type alias `parent_tag` that is the tag for the item from which the
- *   reference item is retrieved
- * - static function `get` that, given the item fetched by `parent_tag`, returns
- *   a const reference to the sub-item
- * - type alias `argument_tags` that is `tmpl::list<parent_tag>`
+ * - type alias `argument_tags` that lists tags needed to evaluate `get`
+ * - static function `get` that, given the items fetched by `argument_tags`,
+ *   returns a const reference to the sub-item
  *
  * A reference tag may optionally specify a static `std::string name()` method
  * to override the default name produced by db::tag_name.

--- a/src/Parallel/GlobalCache.hpp
+++ b/src/Parallel/GlobalCache.hpp
@@ -972,28 +972,24 @@ template <class CacheTag>
 struct FromGlobalCache : CacheTag, db::ReferenceTag {
   static_assert(db::is_simple_tag_v<CacheTag>);
   using base = CacheTag;
-  using parent_tag = GlobalCache;
+  using argument_tags = tmpl::list<GlobalCache>;
 
   template <class Metavariables>
   static const auto& get(
       const Parallel::GlobalCache<Metavariables>* const& cache) {
     return Parallel::get<CacheTag>(*cache);
   }
-
-  using argument_tags = tmpl::list<parent_tag>;
 };
 
 template <typename Metavariables>
 struct ResourceInfoReference : ResourceInfo<Metavariables>, db::ReferenceTag {
   using base = ResourceInfo<Metavariables>;
-  using parent_tag = GlobalCache;
+  using argument_tags = tmpl::list<GlobalCache>;
 
   static const auto& get(
       const Parallel::GlobalCache<Metavariables>* const& cache) {
     return cache->get_resource_info();
   }
-
-  using argument_tags = tmpl::list<parent_tag>;
 };
 }  // namespace Tags
 }  // namespace Parallel

--- a/tests/Unit/DataStructures/DataBox/CMakeLists.txt
+++ b/tests/Unit/DataStructures/DataBox/CMakeLists.txt
@@ -19,5 +19,13 @@ add_test_library(
   ${LIBRARY}
   "DataStructures/DataBox"
   "${LIBRARY_SOURCES}"
-  "DataStructures;ErrorHandling;Utilities"
+  ""
   )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DataStructures
+  ErrorHandling
+  Utilities
+)

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -2592,33 +2592,79 @@ struct TaggedTuple : db::SimpleTag {
 template <typename Tag, typename ParentTag>
 struct FromTaggedTuple : Tag, db::ReferenceTag {
   using base = Tag;
-  using parent_tag = ParentTag;
+  using argument_tags = tmpl::list<ParentTag>;
 
-  static const auto& get(const typename parent_tag::type& tagged_tuple) {
+  static const auto& get(const typename ParentTag::type& tagged_tuple) {
     return tuples::get<Tag>(tagged_tuple);
   }
-
-  using argument_tags = tmpl::list<parent_tag>;
 };
 // [databox_reference_tag_example]
+
+// The following is an overcomplicated tag setup to test the dependency
+// resolution of compute tags and reference tags. We shouldn't do this sort of
+// "tag programming" in source code. The test setup is this:
+struct SwitchTag : db::SimpleTag {
+  using type = bool;
+};
+
+struct Var0 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+struct Tag0OrVar0 : db::SimpleTag {
+  using type = double;
+};
+
+struct Tag0OrVar0Reference : Tag0OrVar0, db::ReferenceTag {
+  using base = Tag0OrVar0;
+  using argument_tags = tmpl::list<SwitchTag, Tag0, Var0>;
+
+  static const double& get(const bool& switch_value, const double& tag0_value,
+                           const Scalar<DataVector>& var0_value) {
+    if (switch_value) {
+      return tag0_value;
+    } else {
+      return ::get(var0_value)[0];
+    }
+  }
+};
+
+struct Tag0OrVar0TimesTwo : db::SimpleTag  {
+  using type = double;
+};
+
+struct Tag0OrVar0TimesTwoCompute : Tag0OrVar0TimesTwo,
+                                db::ComputeTag {
+  using base = Tag0OrVar0TimesTwo;
+  using return_type = double;
+  using argument_tags = tmpl::list<Tag0OrVar0>;
+  static constexpr auto function = multiply_by_two;
+};
+
 }  // namespace test_databox_tags
 
 void test_reference_item() {
   INFO("test reference item");
-  using tuple_tag = test_databox_tags::TaggedTuple<test_databox_tags::Tag0,
-                                                   test_databox_tags::Tag1,
-                                                   test_databox_tags::Tag2>;
-  auto box =
-      db::create<db::AddSimpleTags<tuple_tag>,
-                 db::AddComputeTags<test_databox_tags::FromTaggedTuple<
-                                        test_databox_tags::Tag0, tuple_tag>,
-                                    test_databox_tags::FromTaggedTuple<
-                                        test_databox_tags::Tag1, tuple_tag>,
-                                    test_databox_tags::FromTaggedTuple<
-                                        test_databox_tags::Tag2, tuple_tag>>>(
-          tuples::TaggedTuple<test_databox_tags::Tag0, test_databox_tags::Tag1,
-                              test_databox_tags::Tag2>{
-              3.14, std::vector<double>{8.7, 93.2, 84.7}, "My Sample String"s});
+  using tuple_tag = test_databox_tags::TaggedTuple<
+      test_databox_tags::Tag0, test_databox_tags::Tag1, test_databox_tags::Tag2,
+      test_databox_tags::Tag4>;
+  using vars_tag = Tags::Variables<tmpl::list<test_databox_tags::Var0>>;
+  auto box = db::create<
+      db::AddSimpleTags<tuple_tag, vars_tag, test_databox_tags::SwitchTag>,
+      db::AddComputeTags<test_databox_tags::FromTaggedTuple<
+                             test_databox_tags::Tag0, tuple_tag>,
+                         test_databox_tags::FromTaggedTuple<
+                             test_databox_tags::Tag1, tuple_tag>,
+                         test_databox_tags::FromTaggedTuple<
+                             test_databox_tags::Tag2, tuple_tag>,
+                         test_databox_tags::FromTaggedTuple<
+                             test_databox_tags::Tag4, tuple_tag>,
+                         test_databox_tags::Tag0OrVar0Reference,
+                         test_databox_tags::Tag0OrVar0TimesTwoCompute>>(
+      tuples::TaggedTuple<test_databox_tags::Tag0, test_databox_tags::Tag1,
+                          test_databox_tags::Tag2, test_databox_tags::Tag4>{
+          3.14, std::vector<double>{8.7, 93.2, 84.7}, "My Sample String"s, 1.},
+      Variables<tmpl::list<test_databox_tags::Var0>>{1, 1.}, true);
   const auto& tagged_tuple = get<tuple_tag>(box);
   CHECK(get<test_databox_tags::Tag0>(tagged_tuple) == 3.14);
   CHECK(get<test_databox_tags::Tag1>(tagged_tuple) ==
@@ -2628,6 +2674,25 @@ void test_reference_item() {
   CHECK(get<test_databox_tags::Tag1>(box) ==
         std::vector<double>{8.7, 93.2, 84.7});
   CHECK(get<test_databox_tags::Tag2>(box) == "My Sample String"s);
+  // Checking dependency resolution of reference tags and compute tags
+  CHECK(get<test_databox_tags::SwitchTag>(box));
+  CHECK(get<test_databox_tags::Tag0OrVar0>(box) == 3.14);
+  CHECK(get<test_databox_tags::Tag0OrVar0TimesTwo>(box) == 2. * 3.14);
+  db::mutate<tuple_tag>(make_not_null(&box), [](const auto tuple) {
+    get<test_databox_tags::Tag0>(*tuple) = 4.5;
+  });
+  CHECK(get<test_databox_tags::Tag0OrVar0TimesTwo>(box) == 9.);
+  db::mutate<test_databox_tags::SwitchTag>(
+      make_not_null(&box),
+      [](const gsl::not_null<bool*> switch_value) { *switch_value = false; });
+  CHECK(get<test_databox_tags::Tag0OrVar0>(box) == 1.);
+  CHECK(get<test_databox_tags::Tag0OrVar0TimesTwo>(box) == 2.);
+  db::mutate<test_databox_tags::Var0>(
+      make_not_null(&box),
+      [](const gsl::not_null<Scalar<DataVector>*> var0_value) {
+        get(*var0_value) = 0.5;
+      });
+  CHECK(get<test_databox_tags::Tag0OrVar0TimesTwo>(box) == 1.);
 }
 
 void test_get_mutable_reference() {

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -184,6 +184,16 @@ struct PointerToSumCompute : PointerToSum, db::ComputeTag {
   }
   using argument_tags = tmpl::list<PointerToCounter, PointerToCounterBase>;
 };
+
+struct Tag0Ref : db::SimpleTag {
+  using type = double;
+};
+
+struct Tag0Reference : Tag0Ref, db::ReferenceTag {
+  using base = Tag0Ref;
+  using argument_tags = tmpl::list<Tag0>;
+  static const double& get(const double& tag0_value) { return tag0_value; }
+};
 }  // namespace test_databox_tags
 
 void test_databox() {
@@ -2656,7 +2666,8 @@ void test_output() {
       db::AddSimpleTags<test_databox_tags::Tag0, test_databox_tags::Tag1,
                         test_databox_tags::Tag2>,
       db::AddComputeTags<test_databox_tags::Tag4Compute,
-                         test_databox_tags::Tag5Compute>>(
+                         test_databox_tags::Tag5Compute,
+                         test_databox_tags::Tag0Reference>>(
       3.14, std::vector<double>{8.7, 93.2, 84.7}, "My Sample String"s);
   std::string output_types = box.print_types();
   std::string expected_types =
@@ -2666,13 +2677,16 @@ void test_output() {
       "namespace)::test_databox_tags::Tag1, (anonymous "
       "namespace)::test_databox_tags::Tag2, (anonymous "
       "namespace)::test_databox_tags::Tag4Compute, (anonymous "
-      "namespace)::test_databox_tags::Tag5Compute>;\n"
+      "namespace)::test_databox_tags::Tag5Compute, (anonymous "
+      "namespace)::test_databox_tags::Tag0Reference>;\n"
       "using immutable_item_tags "
       "= brigand::list<(anonymous namespace)::test_databox_tags::Tag4Compute, "
-      "(anonymous namespace)::test_databox_tags::Tag5Compute>;\n"
+      "(anonymous namespace)::test_databox_tags::Tag5Compute, (anonymous "
+      "namespace)::test_databox_tags::Tag0Reference>;\n"
       "using immutable_item_creation_tags = brigand::list<(anonymous "
       "namespace)::test_databox_tags::Tag4Compute, (anonymous "
-      "namespace)::test_databox_tags::Tag5Compute>;\n"
+      "namespace)::test_databox_tags::Tag5Compute, (anonymous "
+      "namespace)::test_databox_tags::Tag0Reference>;\n"
       "using mutable_item_tags = brigand::list<(anonymous "
       "namespace)::test_databox_tags::Tag0, (anonymous "
       "namespace)::test_databox_tags::Tag1, (anonymous "
@@ -2681,6 +2695,8 @@ void test_output() {
       "using compute_item_tags = brigand::list<(anonymous "
       "namespace)::test_databox_tags::Tag4Compute, (anonymous "
       "namespace)::test_databox_tags::Tag5Compute>;\n"
+      "using reference_item_tags = brigand::list<(anonymous "
+      "namespace)::test_databox_tags::Tag0Reference>;\n"
       "using edge_list = "
       "brigand::list<brigand::edge<(anonymous "
       "namespace)::test_databox_tags::Tag0, (anonymous "
@@ -2691,6 +2707,9 @@ void test_output() {
       "brigand::integral_constant<int, 1> >, brigand::edge<(anonymous "
       "namespace)::test_databox_tags::Tag4Compute, (anonymous "
       "namespace)::test_databox_tags::Tag5Compute, "
+      "brigand::integral_constant<int, 1> >, brigand::edge<(anonymous "
+      "namespace)::test_databox_tags::Tag0, (anonymous "
+      "namespace)::test_databox_tags::Tag0Reference, "
       "brigand::integral_constant<int, 1> > >;\n";
   CHECK(output_types == expected_types);
 
@@ -2716,7 +2735,11 @@ void test_output() {
       "----------\n"
       "Name:  (anonymous namespace)::test_databox_tags::Tag5Compute\n"
       "Type:  std::string\n"
-      "Value: My Sample String6.28\n";
+      "Value: My Sample String6.28\n"
+      "----------\n"
+      "Name:  (anonymous namespace)::test_databox_tags::Tag0Reference\n"
+      "Type:  double\n"
+      "Value: 3.14\n";
   CHECK(output_items == expected_items);
   std::ostringstream os;
   os << box;

--- a/tests/Unit/Helpers/DataStructures/DataBox/TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/DataBox/TestHelpers.hpp
@@ -25,8 +25,6 @@ CREATE_HAS_TYPE_ALIAS(argument_tags)
 CREATE_HAS_TYPE_ALIAS_V(argument_tags)
 CREATE_HAS_TYPE_ALIAS(base)
 CREATE_HAS_TYPE_ALIAS_V(base)
-CREATE_HAS_TYPE_ALIAS(parent_tag)
-CREATE_HAS_TYPE_ALIAS_V(parent_tag)
 CREATE_HAS_TYPE_ALIAS(return_type)
 CREATE_HAS_TYPE_ALIAS_V(return_type)
 CREATE_HAS_TYPE_ALIAS(tag)
@@ -90,11 +88,8 @@ void test_reference_tag(const std::string& expected_name) {
                 "A reference tag must be derived from db::ReferenceTag");
   static_assert(detail::has_argument_tags_v<Tag>);
   static_assert(detail::has_base_v<Tag>);
-  static_assert(detail::has_parent_tag_v<Tag>);
   static_assert(::db::is_simple_tag_v<typename Tag::base>,
                 "The base type alias of a reference tag must be a simple tag.");
-  static_assert(std::is_same_v<typename Tag::parent_tag,
-                               tmpl::front<typename Tag::argument_tags>>);
   detail::check_tag_name<Tag>(expected_name);
 }
 

--- a/tests/Unit/Helpers/DataStructures/DataBox/TestTags.hpp
+++ b/tests/Unit/Helpers/DataStructures/DataBox/TestTags.hpp
@@ -51,16 +51,14 @@ struct ParentTag : ::db::SimpleTag {
 
 struct SimpleReference : Simple, ::db::ReferenceTag {
   using base = Simple;
-  using parent_tag = ParentTag;
-  static const auto& get(const typename parent_tag::type& /* parent_value */);
-  using argument_tags = tmpl::list<parent_tag>;
+  using argument_tags = tmpl::list<ParentTag>;
+  static const auto& get(const typename ParentTag::type& /* parent_value */);
 };
 
 struct SimpleWithBaseReference : SimpleWithBase, ::db::ReferenceTag {
   using base = SimpleWithBase;
-  using parent_tag = ParentTag;
-  static const auto& get(const typename parent_tag::type& /* parent_value */);
-  using argument_tags = tmpl::list<parent_tag>;
+  using argument_tags = tmpl::list<ParentTag>;
+  static const auto& get(const typename ParentTag::type& /* parent_value */);
 };
 
 template <typename Tag>


### PR DESCRIPTION
## Proposed changes

Remove `parent_tag`s and use `argument_tag`s instead. This removes the restriction that reference tags can only have a single argument. My use case for this is to store an elastic constitutive relation _per block_ in the global cache and reference the correct one in the element's DataBox, which needs both the global cache tag and the element ID.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
