### PR TITLE
Add Charm++ section reductions

### DIFF
--- a/src/Parallel/Algorithms/AlgorithmArrayDeclarations.hpp
+++ b/src/Parallel/Algorithms/AlgorithmArrayDeclarations.hpp
@@ -25,6 +25,8 @@ namespace Algorithms {
  * - `ckindex`: A charm++ chare index object. Useful for obtaining entry
  *   method indices that are needed for creating callbacks. See
  *   https://charm.readthedocs.io/en/latest/charm++/manual.html#creating-a-ckcallback-object
+ * - `cproxy_section`: The charm++ section proxy class. See
+ *   https://charm.readthedocs.io/en/latest/charm++/manual.html?#sections-subsets-of-a-chare-array-group
  */
 struct Array {
   template <typename ParallelComponent,
@@ -46,6 +48,10 @@ struct Array {
             typename SpectreArrayIndex>
   using ckindex = CkIndex_AlgorithmArray<ParallelComponent,
                                          SpectreArrayIndex>;
+
+  template <typename ParallelComponent, typename SpectreArrayIndex>
+  using cproxy_section =
+      CProxySection_AlgorithmArray<ParallelComponent, SpectreArrayIndex>;
 };
 }  // namespace Algorithms
 }  // namespace Parallel

--- a/src/Parallel/Algorithms/AlgorithmGroupDeclarations.hpp
+++ b/src/Parallel/Algorithms/AlgorithmGroupDeclarations.hpp
@@ -25,6 +25,8 @@ namespace Algorithms {
  * - `ckindex`: A charm++ chare index object. Useful for obtaining entry
  *   method indices that are needed for creating callbacks. See
  *   https://charm.readthedocs.io/en/latest/charm++/manual.html#creating-a-ckcallback-object
+ * - `cproxy_section`: The charm++ section proxy class. See
+ *   https://charm.readthedocs.io/en/latest/charm++/manual.html?#sections-subsets-of-a-chare-array-group
  */
 struct Group {
   template <typename ParallelComponent,
@@ -46,6 +48,10 @@ struct Group {
             typename SpectreArrayIndex>
   using ckindex = CkIndex_AlgorithmGroup<ParallelComponent,
                                          SpectreArrayIndex>;
+
+  template <typename ParallelComponent, typename SpectreArrayIndex>
+  using cproxy_section =
+      CProxySection_AlgorithmGroup<ParallelComponent, SpectreArrayIndex>;
 };
 }  // namespace Algorithms
 }  // namespace Parallel

--- a/src/Parallel/Algorithms/AlgorithmNodegroupDeclarations.hpp
+++ b/src/Parallel/Algorithms/AlgorithmNodegroupDeclarations.hpp
@@ -25,6 +25,8 @@ namespace Algorithms {
  * - `ckindex`: A charm++ chare index object. Useful for obtaining entry
  *   method indices that are needed for creating callbacks. See
  *   https://charm.readthedocs.io/en/latest/charm++/manual.html#creating-a-ckcallback-object
+ * - `cproxy_section`: The charm++ section proxy class. See
+ *   https://charm.readthedocs.io/en/latest/charm++/manual.html?#sections-subsets-of-a-chare-array-group
  */
 struct Nodegroup {
   template <typename ParallelComponent,
@@ -46,6 +48,10 @@ struct Nodegroup {
             typename SpectreArrayIndex>
   using ckindex = CkIndex_AlgorithmNodegroup<ParallelComponent,
                                              SpectreArrayIndex>;
+
+  template <typename ParallelComponent, typename SpectreArrayIndex>
+  using cproxy_section =
+      CProxySection_AlgorithmNodegroup<ParallelComponent, SpectreArrayIndex>;
 };
 }  // namespace Algorithms
 }  // namespace Parallel

--- a/src/Parallel/Algorithms/AlgorithmSingletonDeclarations.hpp
+++ b/src/Parallel/Algorithms/AlgorithmSingletonDeclarations.hpp
@@ -46,6 +46,9 @@ struct Singleton {
             typename SpectreArrayIndex>
   using ckindex = CkIndex_AlgorithmSingleton<ParallelComponent,
                                              SpectreArrayIndex>;
+
+  template <typename ParallelComponent, typename SpectreArrayIndex>
+  using cproxy_section = void;
 };
 }  // namespace Algorithms
 }  // namespace Parallel

--- a/src/Parallel/CMakeLists.txt
+++ b/src/Parallel/CMakeLists.txt
@@ -43,6 +43,7 @@ spectre_target_headers(
   Reduction.hpp
   ReductionDeclare.hpp
   RegisterDerivedClassesWithCharm.hpp
+  Section.hpp
   Serialize.hpp
   SimpleActionVisitation.hpp
   TypeTraits.hpp

--- a/src/Parallel/CMakeLists.txt
+++ b/src/Parallel/CMakeLists.txt
@@ -64,6 +64,7 @@ target_link_libraries(
 
 add_dependencies(
   ${LIBRARY}
+  module_GlobalCache
   module_Main          # GlobalCache module depends on Main module
   )
 

--- a/src/Parallel/CMakeLists.txt
+++ b/src/Parallel/CMakeLists.txt
@@ -13,6 +13,7 @@ spectre_target_sources(
   PRIVATE
   InitializationFunctions.cpp
   NodeLock.cpp
+  Reduction.cpp
   )
 
 spectre_target_headers(

--- a/src/Parallel/ParallelComponentHelpers.hpp
+++ b/src/Parallel/ParallelComponentHelpers.hpp
@@ -355,6 +355,9 @@ struct charm_types_with_parameters {
           ParallelComponent, Args...>;
   using ckindex = typename ParallelComponent::chare_type::template ckindex<
       ParallelComponent, Args...>;
+  using cproxy_section =
+      typename ParallelComponent::chare_type::template cproxy_section<
+          ParallelComponent, Args...>;
 };
 /// \endcond
 }  // namespace Parallel

--- a/src/Parallel/Reduction.cpp
+++ b/src/Parallel/Reduction.cpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Parallel/Reduction.hpp"
+
+namespace Parallel {
+NoSection& no_section() noexcept {
+  static NoSection local_no_section{};
+  return local_no_section;
+}
+}  // namespace Parallel

--- a/src/Parallel/Section.hpp
+++ b/src/Parallel/Section.hpp
@@ -1,0 +1,97 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <charm++.h>
+#include <optional>
+#include <pup.h>
+
+#include "Parallel/ParallelComponentHelpers.hpp"
+
+namespace Parallel {
+
+/*!
+ * \brief A subset of chares in a parallel component
+ *
+ * The section is identified at compile time by the parallel component and a
+ * `SectionIdTag`. The `SectionIdTag` describes the quantity that partitions the
+ * chares into one or more sections. For example, the `SectionIdTag` could be
+ * the block ID in the computational domain, so elements are partitioned per
+ * block. Chares can be a member of multiple sections.
+ *
+ * - [Details on sections in the Charm++
+ *   documentation](https://charm.readthedocs.io/en/latest/charm++/manual.html#sections-subsets-of-a-chare-array-group)
+ *
+ * Here's an example how to work with sections in an array parallel component:
+ *
+ * \snippet Test_SectionReductions.cpp sections_example
+ *
+ * \warning The Charm++ documentation indicates some [creation order
+ * restrictions](https://charm.readthedocs.io/en/latest/charm++/manual.html#creation-order-restrictions)
+ * for sections that may become relevant if we encounter issues with race
+ * conditions in the future.
+ */
+template <typename ParallelComponent, typename SectionIdTag>
+struct Section {
+ private:
+  using chare_type = typename ParallelComponent::chare_type;
+  using charm_type = charm_types_with_parameters<
+      ParallelComponent,
+      typename get_array_index<chare_type>::template f<ParallelComponent>>;
+  using IdType = typename SectionIdTag::type;
+
+ public:
+  using parallel_component = ParallelComponent;
+  using cproxy_section = typename charm_type::cproxy_section;
+  using section_id_tag = SectionIdTag;
+
+  Section(IdType id, cproxy_section proxy) noexcept
+      : id_(id), proxy_(std::move(proxy)), cookie_(proxy_.ckGetSectionInfo()) {}
+
+  Section() = default;
+  Section(Section&& rhs) = default;
+  Section& operator=(Section&& rhs) = default;
+  // The copy constructors currently copy the cookie as well. This seems to work
+  // fine, but if issues come up with updating the cookie we can consider
+  // re-creating it when copying the section to each element.
+  Section(const Section&) = default;
+  Section& operator=(const Section&) = default;
+  ~Section() = default;
+
+  /// The section ID corresponding to the `SectionIdTag`
+  const IdType& id() const noexcept { return id_; }
+
+  // @{
+  /// The Charm++ section proxy
+  const cproxy_section& proxy() const noexcept { return proxy_; }
+  cproxy_section& proxy() noexcept { return proxy_; }
+  // @}
+
+  /*!
+   * \brief The Charm++ section cookie that keeps track of reductions
+   *
+   * The section cookie must be stored on each element and updated when
+   * performing reductions. For details on Charm++ sections and section
+   * reductions see:
+   * https://charm.readthedocs.io/en/latest/charm++/manual.html?#sections-subsets-of-a-chare-array-group
+   */
+  // @{
+  const CkSectionInfo& cookie() const noexcept { return cookie_; }
+  CkSectionInfo& cookie() noexcept { return cookie_; }
+  // @}
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) noexcept {
+    p | id_;
+    p | proxy_;
+    p | cookie_;
+  }
+
+ private:
+  IdType id_{};
+  cproxy_section proxy_{};
+  CkSectionInfo cookie_{};
+};
+
+}  // namespace Parallel

--- a/src/Parallel/Tags/CMakeLists.txt
+++ b/src/Parallel/Tags/CMakeLists.txt
@@ -6,4 +6,5 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Metavariables.hpp
+  Section.hpp
   )

--- a/src/Parallel/Tags/Section.hpp
+++ b/src/Parallel/Tags/Section.hpp
@@ -1,0 +1,42 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataBox/TagName.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/PupStlCpp17.hpp"
+#include "Parallel/Section.hpp"
+
+namespace Parallel::Tags {
+
+/*!
+ * \brief The `Parallel::Section<ParallelComponent, SectionIdTag>` that this
+ * element belongs to.
+ *
+ * The tag holds a `std::nullopt` if the element doesn't belong to a section of
+ * the `SectionIdTag`. For example, a section may describe a specific region in
+ * the computational domain and thus doesn't include all elements, so this tag
+ * would hold `std::nullopt` on the elements outside that region.
+ *
+ * \see Parallel::Section
+ */
+template <typename ParallelComponent, typename SectionIdTag>
+struct Section : db::SimpleTag {
+  static std::string name() noexcept {
+    return "Section(" + db::tag_name<SectionIdTag>() + ")";
+  }
+  using type =
+      std::optional<Parallel::Section<ParallelComponent, SectionIdTag>>;
+  // Allow default-constructing the tag so sections can be created and assigned
+  // to the tag in a parallel component's `allocate_array` function.
+  constexpr static bool pass_metavariables = false;
+  using option_tags = tmpl::list<>;
+  static type create_from_options() noexcept { return {}; };
+};
+
+}  // namespace Parallel::Tags

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -46,6 +46,7 @@ add_algorithm_test(Test_PhaseChangeMain)
 add_algorithm_test(Test_AlgorithmNodelock)
 add_algorithm_test(Test_AlgorithmReduction)
 add_algorithm_test(Test_GlobalCache)
+add_algorithm_test(Test_SectionReductions)
 
 # Test GlobalCache
 add_charm_module(Test_GlobalCache)
@@ -175,6 +176,8 @@ add_algorithm_test("PhaseChangeMain" "")
 add_algorithm_test("AlgorithmReduction" "")
 add_algorithm_test("AlgorithmNodelock" "")
 add_algorithm_test("GlobalCache" "")
+add_algorithm_test("SectionReductions"
+  "Element 0 received reduction: Counted 2 odd elements.")
 add_algorithm_test_with_balancing("AlgorithmParallelWithBalancing"
   "AlgorithmParallel" "Objects migrating: 14")
 

--- a/tests/Unit/Parallel/Tags/CMakeLists.txt
+++ b/tests/Unit/Parallel/Tags/CMakeLists.txt
@@ -4,4 +4,5 @@
 set(LIBRARY_SOURCES
   ${LIBRARY_SOURCES}
   Tags/Test_Metavariables.cpp
+  Tags/Test_Section.cpp
   PARENT_SCOPE)

--- a/tests/Unit/Parallel/Tags/Test_Section.cpp
+++ b/tests/Unit/Parallel/Tags/Test_Section.cpp
@@ -1,0 +1,24 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Parallel/Tags/Section.hpp"
+
+namespace Parallel {
+namespace {
+struct ParallelComponent;
+struct SectionIdTag {
+  using type = int;
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Parallel.Tags.Section", "[Unit][Parallel]") {
+  TestHelpers::db::test_simple_tag<
+      Tags::Section<ParallelComponent, SectionIdTag>>("Section(SectionIdTag)");
+}
+
+}  // namespace Parallel

--- a/tests/Unit/Parallel/Test_SectionReductions.cpp
+++ b/tests/Unit/Parallel/Test_SectionReductions.cpp
@@ -1,0 +1,249 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#define CATCH_CONFIG_RUNNER
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <ostream>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/Actions/TerminatePhase.hpp"
+#include "Parallel/Algorithms/AlgorithmArray.hpp"
+#include "Parallel/ArrayIndex.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/Printf.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Parallel/Section.hpp"
+#include "Parallel/Tags/Section.hpp"
+#include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/System/ParallelInfo.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+
+// In this test we create a few array elements, partition them in sections based
+// on their index, and then count the elements in each section separately in a
+// reduction.
+
+enum class EvenOrOdd { Even, Odd };
+
+// These don't need to be DataBox tags because they aren't placed in the
+// DataBox. they are used to identify the section. Note that in many practical
+// applications the section ID tag _is_ placed in the DataBox nonetheless.
+struct EvenOrOddTag {
+  using type = EvenOrOdd;
+};
+struct IsFirstElementTag {
+  using type = bool;
+};
+
+template <typename ArraySectionIdTag>
+struct ReceiveCount;
+
+template <typename ArraySectionIdTag>
+struct Count {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ActionList, typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&> apply(
+      db::DataBox<DbTagsList>& box,
+      tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::GlobalCache<Metavariables>& cache, const int array_index,
+      const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    const bool section_id = [&array_index]() {
+      if constexpr (std::is_same_v<ArraySectionIdTag, EvenOrOddTag>) {
+        return array_index % 2 == 0;
+      } else {
+        return array_index == 0;
+      }
+    }();
+    // [section_reduction]
+    auto& array_section = db::get_mutable_reference<
+        Parallel::Tags::Section<ParallelComponent, ArraySectionIdTag>>(
+        make_not_null(&box));
+    if (array_section.has_value()) {
+      // We'll just count the elements in each section
+      Parallel::ReductionData<
+          Parallel::ReductionDatum<bool, funcl::AssertEqual<>>,
+          Parallel::ReductionDatum<size_t, funcl::Plus<>>>
+          reduction_data{section_id, 1};
+      // Reduce over the section and broadcast to the full array
+      auto& array_proxy =
+          Parallel::get_parallel_component<ParallelComponent>(cache);
+      Parallel::contribute_to_reduction<ReceiveCount<ArraySectionIdTag>>(
+          std::move(reduction_data), array_proxy[array_index], array_proxy,
+          make_not_null(&*array_section));
+    }
+    // [section_reduction]
+    return {std::move(box)};
+  }
+};
+
+template <typename ArraySectionIdTag>
+struct ReceiveCount {
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables>
+  static void apply(db::DataBox<DbTagsList>& /*box*/,
+                    Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const int array_index, const bool section_id,
+                    const size_t count) noexcept {
+    if constexpr (std::is_same_v<ArraySectionIdTag, EvenOrOddTag>) {
+      const bool is_even = section_id;
+      Parallel::printf(
+          "Element %d received reduction: Counted %zu %s elements.\n",
+          array_index, count, is_even ? "even" : "odd");
+      SPECTRE_PARALLEL_REQUIRE(count == (is_even ? 3 : 2));
+    } else {
+      const bool is_first_element = section_id;
+      Parallel::printf(
+          "Element %d received reduction: Counted %zu element in "
+          "'IsFirstElement' section.\n",
+          array_index, count);
+      SPECTRE_PARALLEL_REQUIRE(is_first_element);
+      SPECTRE_PARALLEL_REQUIRE(count == 1);
+    }
+  }
+};
+
+template <typename Metavariables>
+struct ArrayComponent {
+  using chare_type = Parallel::Algorithms::Array;
+  using metavariables = Metavariables;
+  using array_index = int;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Initialization,
+                             tmpl::list<>>,
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::TestReductions,
+          tmpl::list<Count<EvenOrOddTag>,
+                     // Test performing a reduction over another section
+                     Count<IsFirstElementTag>,
+                     // Test performing multiple reductions asynchronously
+                     Count<EvenOrOddTag>, Count<EvenOrOddTag>,
+                     Count<IsFirstElementTag>,
+                     Parallel::Actions::TerminatePhase>>>;
+
+  // [sections_example]
+  using array_allocation_tags = tmpl::list<
+      // The section proxy will be stored in each element's DataBox in this tag
+      // for convenient access
+      Parallel::Tags::Section<ArrayComponent, EvenOrOddTag>,
+      Parallel::Tags::Section<ArrayComponent, IsFirstElementTag>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>,
+      array_allocation_tags>;
+
+  static void allocate_array(
+      Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
+      tuples::tagged_tuple_from_typelist<initialization_tags>
+          initialization_items) noexcept {
+    auto& local_cache = *(global_cache.ckLocalBranch());
+    auto& array_proxy =
+        Parallel::get_parallel_component<ArrayComponent>(local_cache);
+
+    // Create sections from element IDs (the corresponding elements will be
+    // created below)
+    const size_t num_elements = 5;
+    std::vector<CkArrayIndex> even_elements{};
+    std::vector<CkArrayIndex> odd_elements{};
+    for (size_t i = 0; i < num_elements; ++i) {
+      (i % 2 == 0 ? even_elements : odd_elements)
+          .push_back(Parallel::ArrayIndex<int>(static_cast<int>(i)));
+    }
+    std::vector<CkArrayIndex> first_element{};
+    first_element.push_back(Parallel::ArrayIndex<int>(0));
+    using EvenOrOddSection = Parallel::Section<ArrayComponent, EvenOrOddTag>;
+    const EvenOrOddSection even_section{
+        EvenOrOdd::Even, EvenOrOddSection::cproxy_section::ckNew(
+                             array_proxy.ckGetArrayID(), even_elements.data(),
+                             even_elements.size())};
+    const EvenOrOddSection odd_section{
+        EvenOrOdd::Odd, EvenOrOddSection::cproxy_section::ckNew(
+                            array_proxy.ckGetArrayID(), odd_elements.data(),
+                            odd_elements.size())};
+    using IsFirstElementSection =
+        Parallel::Section<ArrayComponent, IsFirstElementTag>;
+    const IsFirstElementSection is_first_element_section{
+        true, IsFirstElementSection::cproxy_section::ckNew(
+                  array_proxy.ckGetArrayID(), first_element.data(),
+                  first_element.size())};
+
+    // Create array elements, copying the appropriate section proxy into their
+    // DataBox
+    const int number_of_procs = sys::number_of_procs();
+    for (size_t i = 0; i < 5; ++i) {
+      tuples::get<Parallel::Tags::Section<ArrayComponent, EvenOrOddTag>>(
+          initialization_items) = i % 2 == 0 ? even_section : odd_section;
+      tuples::get<Parallel::Tags::Section<ArrayComponent, IsFirstElementTag>>(
+          initialization_items) =
+          i == 0 ? std::make_optional(is_first_element_section) : std::nullopt;
+      array_proxy[static_cast<int>(i)].insert(
+          global_cache, initialization_items,
+          static_cast<int>(i) % number_of_procs);
+    }
+    array_proxy.doneInserting();
+  }
+  // [sections_example]
+
+  static void execute_next_phase(
+      const typename Metavariables::Phase next_phase,
+      const Parallel::CProxy_GlobalCache<Metavariables>& global_cache) {
+    auto& local_cache = *(global_cache.ckLocalBranch());
+    Parallel::get_parallel_component<ArrayComponent>(local_cache)
+        .start_phase(next_phase);
+  }
+};
+
+struct Metavariables {
+  using component_list = tmpl::list<ArrayComponent<Metavariables>>;
+
+  static constexpr Options::String help = "Test section reductions";
+
+  enum class Phase { Initialization, TestReductions, Exit };
+
+  template <typename... Tags>
+  static Phase determine_next_phase(
+      const gsl::not_null<tuples::TaggedTuple<Tags...>*>
+      /*phase_change_decision_data*/,
+      const Phase& current_phase,
+      const Parallel::CProxy_GlobalCache<
+          Metavariables>& /*cache_proxy*/) noexcept {
+    switch (current_phase) {
+      case Phase::Initialization:
+        return Phase::TestReductions;
+      case Phase::TestReductions:
+        return Phase::Exit;
+      case Phase::Exit:
+        ERROR(
+            "Should never call determine_next_phase with the current phase "
+            "being 'Exit'");
+      default:
+        ERROR("Unknown Phase...");
+    }
+  }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
+};
+
+}  // namespace
+
+static const std::vector<void (*)()> charm_init_node_funcs{
+    &setup_error_handling};
+static const std::vector<void (*)()> charm_init_proc_funcs{
+    &enable_floating_point_exceptions};
+
+using charmxx_main_component = Parallel::Main<Metavariables>;
+
+#include "Parallel/CharmMain.tpp"  // IWYU pragma: keep


### PR DESCRIPTION
## Proposed changes

Add support for Charm++ section reductions, i.e. reductions over a subset of chares in a parallel component.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
