### PR TITLE
Notify components of phase change before starting LB phase

### DIFF
--- a/src/Parallel/Main.ci
+++ b/src/Parallel/Main.ci
@@ -21,6 +21,7 @@ module Main {
             reduction_data);
 
     entry void execute_next_phase();
+    entry void start_load_balance();
   }
 
   namespace detail {


### PR DESCRIPTION
## Proposed changes

Tweaks how we trigger load balancing with Charm++, for compatibility with the (upcoming) checkpointing feature.

This PR delays the Charm++ call that starts LB, by adding a new round-trip communication that ensures every parallel component is notified that the phase is LB. This way, when components (de)serialize, they can do so in a phase-dependent manner.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
