### PR TITLE
Add functions to transform tensors to different frames.

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -24,6 +24,7 @@ spectre_target_sources(
   SpacetimeNormalVector.cpp
   SpatialMetric.cpp
   TimeDerivativeOfSpacetimeMetric.cpp
+  Transform.cpp
   WeylElectric.cpp
   WeylPropagating.cpp
   )
@@ -51,6 +52,7 @@ spectre_target_headers(
   Tags.hpp
   TagsDeclarations.hpp
   TimeDerivativeOfSpacetimeMetric.hpp
+  Transform.hpp
   WeylElectric.hpp
   WeylPropagating.hpp
   )

--- a/src/PointwiseFunctions/GeneralRelativity/Transform.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Transform.cpp
@@ -1,0 +1,140 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/GeneralRelativity/Transform.hpp"
+
+#include <limits>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace transform {
+
+template <size_t VolumeDim, typename SrcFrame, typename DestFrame>
+void to_different_frame(
+    const gsl::not_null<tnsr::ii<DataVector, VolumeDim, DestFrame>*> dest,
+    const tnsr::ii<DataVector, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataVector, VolumeDim, DestFrame, SrcFrame>&
+        jacobian) noexcept {
+  destructive_resize_components(dest, src.begin()->size());
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    for (size_t j = i; j < VolumeDim; ++j) {  // symmetry
+      // To avoid initializing to zero, split out k=0 here, and start
+      // k loop below at k=1.
+      dest->get(i, j) = jacobian.get(0, i) * jacobian.get(0, j) * src.get(0, 0);
+      for (size_t p = 1; p < VolumeDim; ++p) {
+        dest->get(i, j) +=
+            jacobian.get(0, i) * jacobian.get(p, j) * src.get(0, p);
+      }
+      for (size_t k = 1; k < VolumeDim; ++k) {
+        for (size_t p = 0; p < VolumeDim; ++p) {
+          dest->get(i, j) +=
+              jacobian.get(k, i) * jacobian.get(p, j) * src.get(k, p);
+        }
+      }
+    }
+  }
+}
+
+template <size_t VolumeDim, typename SrcFrame, typename DestFrame>
+auto to_different_frame(const tnsr::ii<DataVector, VolumeDim, SrcFrame>& src,
+                        const Jacobian<DataVector, VolumeDim, DestFrame,
+                                       SrcFrame>& jacobian) noexcept
+    -> tnsr::ii<DataVector, VolumeDim, DestFrame> {
+  auto dest = make_with_value<tnsr::ii<DataVector, VolumeDim, DestFrame>>(
+      src, std::numeric_limits<double>::signaling_NaN());
+  to_different_frame(make_not_null(&dest), src, jacobian);
+  return dest;
+}
+
+template <size_t VolumeDim, typename SrcFrame, typename DestFrame>
+void first_index_to_different_frame(
+    const gsl::not_null<tnsr::ijj<DataVector, VolumeDim, DestFrame>*> dest,
+    const Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1, 1>,
+                 index_list<SpatialIndex<VolumeDim, UpLo::Lo, SrcFrame>,
+                            SpatialIndex<VolumeDim, UpLo::Lo, DestFrame>,
+                            SpatialIndex<VolumeDim, UpLo::Lo, DestFrame>>>& src,
+    const Jacobian<DataVector, VolumeDim, DestFrame, SrcFrame>&
+        jacobian) noexcept {
+  destructive_resize_components(dest, src.begin()->size());
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    for (size_t j = i; j < VolumeDim; ++j) {  // symmetry
+      for (size_t k = 0; k < VolumeDim; ++k) {
+        dest->get(k, i, j) = jacobian.get(0, k) * src.get(0, i, j);
+        for (size_t p = 1; p < VolumeDim; ++p) {
+          dest->get(k, i, j) += jacobian.get(p, k) * src.get(p, i, j);
+        }
+      }
+    }
+  }
+}
+
+template <size_t VolumeDim, typename SrcFrame, typename DestFrame>
+auto first_index_to_different_frame(
+    const Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1, 1>,
+                 index_list<SpatialIndex<VolumeDim, UpLo::Lo, SrcFrame>,
+                            SpatialIndex<VolumeDim, UpLo::Lo, DestFrame>,
+                            SpatialIndex<VolumeDim, UpLo::Lo, DestFrame>>>& src,
+    const Jacobian<DataVector, VolumeDim, DestFrame, SrcFrame>&
+        jacobian) noexcept -> tnsr::ijj<DataVector, VolumeDim, DestFrame> {
+  auto dest = make_with_value<tnsr::ijj<DataVector, VolumeDim, DestFrame>>(
+      src, std::numeric_limits<double>::signaling_NaN());
+  first_index_to_different_frame(make_not_null(&dest), src, jacobian);
+  return dest;
+}
+
+}  // namespace transform
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define SRCFRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define DESTFRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                                  \
+  template void transform::to_different_frame(                                \
+      const gsl::not_null<tnsr::ii<DataVector, DIM(data), DESTFRAME(data)>*>  \
+          dest,                                                               \
+      const tnsr::ii<DataVector, DIM(data), SRCFRAME(data)>& src,             \
+      const Jacobian<DataVector, DIM(data), DESTFRAME(data), SRCFRAME(data)>& \
+          jacobian) noexcept;                                                 \
+  template auto transform::to_different_frame(                                \
+      const tnsr::ii<DataVector, DIM(data), SRCFRAME(data)>& src,             \
+      const Jacobian<DataVector, DIM(data), DESTFRAME(data), SRCFRAME(data)>& \
+          jacobian) noexcept                                                  \
+      ->tnsr::ii<DataVector, DIM(data), DESTFRAME(data)>;
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid),
+                        (Frame::Inertial))
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Inertial),
+                        (Frame::Grid))
+#undef INSTANTIATE
+
+#define INSTANTIATE(_, data)                                                  \
+  template void transform::first_index_to_different_frame(                    \
+      const gsl::not_null<tnsr::ijj<DataVector, DIM(data), DESTFRAME(data)>*> \
+          dest,                                                               \
+      const Tensor<                                                           \
+          DataVector, tmpl::integral_list<std::int32_t, 2, 1, 1>,             \
+          index_list<SpatialIndex<DIM(data), UpLo::Lo, SRCFRAME(data)>,       \
+                     SpatialIndex<DIM(data), UpLo::Lo, DESTFRAME(data)>,      \
+                     SpatialIndex<DIM(data), UpLo::Lo, DESTFRAME(data)>>>&    \
+          src,                                                                \
+      const Jacobian<DataVector, DIM(data), DESTFRAME(data), SRCFRAME(data)>& \
+          jacobian) noexcept;                                                 \
+  template auto transform::first_index_to_different_frame(                    \
+      const Tensor<                                                           \
+          DataVector, tmpl::integral_list<std::int32_t, 2, 1, 1>,             \
+          index_list<SpatialIndex<DIM(data), UpLo::Lo, SRCFRAME(data)>,       \
+                     SpatialIndex<DIM(data), UpLo::Lo, DESTFRAME(data)>,      \
+                     SpatialIndex<DIM(data), UpLo::Lo, DESTFRAME(data)>>>&    \
+          src,                                                                \
+      const Jacobian<DataVector, DIM(data), DESTFRAME(data), SRCFRAME(data)>& \
+          jacobian) noexcept                                                  \
+      ->tnsr::ijj<DataVector, DIM(data), DESTFRAME(data)>;
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Logical), (Frame::Grid))
+
+#undef DIM
+#undef SRCFRAME
+#undef DESTFRAME
+#undef INSTANTIATE

--- a/src/PointwiseFunctions/GeneralRelativity/Transform.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Transform.hpp
@@ -1,0 +1,100 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+class DataVector;
+/// \endcond
+
+/// Holds functions related to transforming between frames.
+namespace transform {
+//@{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * Transforms tensor to different frame.
+ *
+ * The formula for transforming \f$T_{ij}\f$ is
+ * \f{align}
+ *   T_{\bar{\imath}\bar{\jmath}} &= T_{ij}
+ *      \frac{\partial x^i}{\partial x^{\bar{\imath}}}
+ *      \frac{\partial x^j}{\partial x^{\bar{\jmath}}}
+ * \f}
+ * where \f$x^i\f$ are the source coordinates and
+ * \f$x^{\bar{\imath}}\f$ are the destination coordinates.
+ *
+ * Note that `Jacobian<DestFrame,SrcFrame>` is the same type as
+ * `InverseJacobian<SrcFrame,DestFrame>` and represents
+ * \f$\partial x^i/\partial x^{\bar{\jmath}}\f$.
+ *
+ * In principle `to_different_frame` can be extended/generalized to
+ * other tensor types if needed.
+ */
+template <size_t VolumeDim, typename SrcFrame, typename DestFrame>
+void to_different_frame(
+    const gsl::not_null<tnsr::ii<DataVector, VolumeDim, DestFrame>*> dest,
+    const tnsr::ii<DataVector, VolumeDim, SrcFrame>& src,
+    const Jacobian<DataVector, VolumeDim, DestFrame, SrcFrame>&
+        jacobian) noexcept;
+
+template <size_t VolumeDim, typename SrcFrame, typename DestFrame>
+auto to_different_frame(const tnsr::ii<DataVector, VolumeDim, SrcFrame>& src,
+                        const Jacobian<DataVector, VolumeDim, DestFrame,
+                                       SrcFrame>& jacobian) noexcept
+    -> tnsr::ii<DataVector, VolumeDim, DestFrame>;
+//@}
+
+//@{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * Transforms only the first index to different frame.
+ *
+ * Often used for derivatives: When representing derivatives as
+ * tensors, the first index is typically the derivative index.
+ * Numerical derivatives must be computed in the logical frame or
+ * sometimes the grid frame (independent of the frame of the tensor
+ * being differentiated), and then that derivative index must later
+ * be transformed into the same frame as the other indices of the
+ * tensor.
+ *
+ * The formula for transforming \f$T_{i\bar{\jmath}\bar{k}}\f$ is
+ * \f{align}
+ *   T_{\bar{\imath}\bar{\jmath}\bar{k}} &= T_{i\bar{\jmath}\bar{k}}
+ *      \frac{\partial x^i}{\partial x^{\bar{\imath}}},
+ * \f}
+ * where \f$x^i\f$ are the source coordinates and
+ * \f$x^{\bar{\imath}}\f$ are the destination coordinates.
+ *
+ * Note that `Jacobian<DestFrame,SrcFrame>` is the same type as
+ * `InverseJacobian<SrcFrame,DestFrame>` and represents
+ * \f$\partial x^i/\partial x^{\bar{\jmath}}\f$.
+ *
+ * In principle `first_index_to_different_frame` can be
+ * extended/generalized to other tensor types if needed.
+ */
+template <size_t VolumeDim, typename SrcFrame, typename DestFrame>
+void first_index_to_different_frame(
+    const gsl::not_null<tnsr::ijj<DataVector, VolumeDim, DestFrame>*> dest,
+    const Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1, 1>,
+                 index_list<SpatialIndex<VolumeDim, UpLo::Lo, SrcFrame>,
+                            SpatialIndex<VolumeDim, UpLo::Lo, DestFrame>,
+                            SpatialIndex<VolumeDim, UpLo::Lo, DestFrame>>>& src,
+    const Jacobian<DataVector, VolumeDim, DestFrame, SrcFrame>&
+        jacobian) noexcept;
+
+template <size_t VolumeDim, typename SrcFrame, typename DestFrame>
+auto first_index_to_different_frame(
+    const Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1, 1>,
+                 index_list<SpatialIndex<VolumeDim, UpLo::Lo, SrcFrame>,
+                            SpatialIndex<VolumeDim, UpLo::Lo, DestFrame>,
+                            SpatialIndex<VolumeDim, UpLo::Lo, DestFrame>>>& src,
+    const Jacobian<DataVector, VolumeDim, DestFrame, SrcFrame>&
+        jacobian) noexcept -> tnsr::ijj<DataVector, VolumeDim, DestFrame>;
+//@}
+}  // namespace transform

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBRARY_SOURCES
   Test_ProjectionOperators.cpp
   Test_Ricci.cpp
   Test_Tags.cpp
+  Test_Transform.cpp
   Test_WeylElectric.cpp
   Test_WeylPropagating.cpp
   )

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Transform.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Transform.cpp
@@ -1,0 +1,87 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Transform.hpp"
+
+namespace {
+template <size_t Dim, typename SrcFrame, typename DestFrame, typename DataType>
+void test_transform_to_different_frame(const DataType& used_for_size) {
+  tnsr::ii<DataType, Dim, DestFrame> (*f)(
+      const tnsr::ii<DataType, Dim, SrcFrame>&,
+      const ::Jacobian<DataType, Dim, DestFrame, SrcFrame>&) =
+      transform::to_different_frame<Dim, SrcFrame, DestFrame>;
+  pypp::check_with_random_values<1>(f, "Transform", "to_different_frame",
+                                    {{{-10., 10.}}}, used_for_size);
+
+  // Transform src->dest and then dest->src and ensure we recover
+  // what we started with.
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> interval_dis(-1.0, 1.0);
+  std::uniform_real_distribution<> interval_dis_small(-0.1, 0.1);
+  const auto nn_generator = make_not_null(&gen);
+  const auto nn_interval_dis = make_not_null(&interval_dis);
+  const auto nn_interval_dis_small = make_not_null(&interval_dis_small);
+
+  const auto src_tensor =
+      make_with_random_values<tnsr::ii<DataType, Dim, SrcFrame>>(
+          nn_generator, nn_interval_dis, used_for_size);
+  const auto jacobian = [&]() {
+    auto jacobian_l =
+        make_with_random_values<::Jacobian<DataType, Dim, DestFrame, SrcFrame>>(
+            nn_generator, nn_interval_dis_small, used_for_size);
+    // Ensure an invertible Jacobian by making the diagonal
+    // elements 1+small, and all other elements small.
+    for (size_t i = 0; i < Dim; ++i) {
+      jacobian_l.get(i, i) += 1.0;
+    }
+    return jacobian_l;
+  }();
+
+  const auto dest_tensor = transform::to_different_frame(src_tensor, jacobian);
+  const auto expected_src_tensor = transform::to_different_frame(
+      dest_tensor, determinant_and_inverse(jacobian).second);
+  CHECK_ITERABLE_APPROX(expected_src_tensor, src_tensor);
+}
+
+  template <size_t Dim, typename SrcFrame, typename DestFrame,
+            typename DataType>
+  void test_transform_first_index_to_different_frame(
+      const DataType& used_for_size) {
+    tnsr::ijj<DataType, Dim, DestFrame> (*f)(
+        const Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1, 1>,
+                     index_list<SpatialIndex<Dim, UpLo::Lo, SrcFrame>,
+                                SpatialIndex<Dim, UpLo::Lo, DestFrame>,
+                                SpatialIndex<Dim, UpLo::Lo, DestFrame>>>&,
+        const ::Jacobian<DataType, Dim, DestFrame, SrcFrame>&) =
+        transform::first_index_to_different_frame<Dim, SrcFrame, DestFrame>;
+    pypp::check_with_random_values<1>(f, "Transform",
+                                      "first_index_to_different_frame",
+                                      {{{-10., 10.}}}, used_for_size);
+  }
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.Transform",
+                  "[PointwiseFunctions][Unit]") {
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "PointwiseFunctions/GeneralRelativity/");
+  const DataVector dv(5);
+  test_transform_to_different_frame<1, Frame::Grid, Frame::Inertial>(dv);
+  test_transform_to_different_frame<2, Frame::Grid, Frame::Inertial>(dv);
+  test_transform_to_different_frame<3, Frame::Grid, Frame::Inertial>(dv);
+  test_transform_first_index_to_different_frame<1, Frame::Logical, Frame::Grid>(
+      dv);
+  test_transform_first_index_to_different_frame<2, Frame::Logical, Frame::Grid>(
+      dv);
+  test_transform_first_index_to_different_frame<3, Frame::Logical, Frame::Grid>(
+      dv);
+}

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Transform.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Transform.py
@@ -1,0 +1,14 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def to_different_frame(src, jacobian):
+    # Jacobian here is d^x_src/d^x_dest
+    return np.einsum("ab,ac,bd", src, jacobian, jacobian)
+
+
+def first_index_to_different_frame(src, jacobian):
+    # Jacobian here is d^x_src/d^x_dest
+    return np.einsum("abc,ad->dbc", src, jacobian)


### PR DESCRIPTION
## Proposed changes

Add functions to transform tensors to different frames.  Will be used by AH finder, and will probably be useful elsewhere.

The not_null versions of these functions do no memory allocations.
### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
