### PR TITLE
Support "massive" elliptic DG operator

### DIFF
--- a/src/Elliptic/CMakeLists.txt
+++ b/src/Elliptic/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(
   Options
   INTERFACE
   DataStructures
+  DiscontinuousGalerkin
   Domain
   EventsAndTriggers
   LinearOperators

--- a/src/Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp
@@ -403,7 +403,8 @@ struct ReceiveMortarDataAndApplyOperator<
 
  public:
   using const_global_cache_tags =
-      tmpl::list<elliptic::dg::Tags::PenaltyParameter>;
+      tmpl::list<elliptic::dg::Tags::PenaltyParameter,
+                 elliptic::dg::Tags::Massive>;
   using inbox_tags = tmpl::list<mortar_data_inbox_tag>;
 
   template <typename DbTags, typename... InboxTags, typename Metavariables,
@@ -448,6 +449,8 @@ struct ReceiveMortarDataAndApplyOperator<
         db::get<domain::Tags::Mesh<Dim>>(box),
         db::get<domain::Tags::InverseJacobian<Dim, Frame::Logical,
                                               Frame::Inertial>>(box),
+        db::get<domain::Tags::DetInvJacobian<Frame::Logical, Frame::Inertial>>(
+            box),
         db::get<domain::Tags::Interface<
             domain::Tags::InternalDirections<Dim>,
             ::Tags::Magnitude<domain::Tags::UnnormalizedFaceNormal<Dim>>>>(box),
@@ -456,7 +459,8 @@ struct ReceiveMortarDataAndApplyOperator<
             ::Tags::Magnitude<domain::Tags::UnnormalizedFaceNormal<Dim>>>>(box),
         db::get<::Tags::Mortars<domain::Tags::Mesh<Dim - 1>, Dim>>(box),
         db::get<::Tags::Mortars<::Tags::MortarSize<Dim - 1>, Dim>>(box),
-        db::get<elliptic::dg::Tags::PenaltyParameter>(box), temporal_id,
+        db::get<elliptic::dg::Tags::PenaltyParameter>(box),
+        db::get<elliptic::dg::Tags::Massive>(box), temporal_id,
         std::forward_as_tuple(db::get<SourcesArgsTags>(box)...));
 
     return {std::move(box), Parallel::AlgorithmExecution::Continue};
@@ -536,7 +540,8 @@ struct ImposeInhomogeneousBoundaryConditionsOnSource<
 
  public:
   using const_global_cache_tags =
-      tmpl::list<elliptic::dg::Tags::PenaltyParameter>;
+      tmpl::list<elliptic::dg::Tags::PenaltyParameter,
+                 elliptic::dg::Tags::Massive>;
 
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ActionList, typename ParallelComponent>
@@ -587,6 +592,8 @@ struct ImposeInhomogeneousBoundaryConditionsOnSource<
         db::get<domain::Tags::Mesh<Dim>>(box),
         db::get<domain::Tags::InverseJacobian<Dim, Frame::Logical,
                                               Frame::Inertial>>(box),
+        db::get<domain::Tags::DetInvJacobian<Frame::Logical, Frame::Inertial>>(
+            box),
         db::get<domain::Tags::Interface<
             domain::Tags::BoundaryDirectionsInterior<Dim>,
             ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>>>(
@@ -597,7 +604,7 @@ struct ImposeInhomogeneousBoundaryConditionsOnSource<
         db::get<::Tags::Mortars<domain::Tags::Mesh<Dim - 1>, Dim>>(box),
         db::get<::Tags::Mortars<::Tags::MortarSize<Dim - 1>, Dim>>(box),
         db::get<elliptic::dg::Tags::PenaltyParameter>(box),
-        apply_boundary_condition,
+        db::get<elliptic::dg::Tags::Massive>(box), apply_boundary_condition,
         std::forward_as_tuple(db::get<FluxesArgsTags>(box)...),
         std::forward_as_tuple(db::get<SourcesArgsTags>(box)...),
         interface_apply<domain::Tags::InternalDirections<Dim>,

--- a/src/Elliptic/DiscontinuousGalerkin/Tags.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Tags.hpp
@@ -32,6 +32,15 @@ struct PenaltyParameter {
   using group = DiscontinuousGalerkin;
 };
 
+struct Massive {
+  using type = bool;
+  static constexpr Options::String help =
+      "Whether or not to multiply the DG operator with the mass matrix. "
+      "Massive DG operators can be easier to solve because they are symmetric, "
+      "or at least closer to symmetry";
+  using group = DiscontinuousGalerkin;
+};
+
 }  // namespace OptionTags
 
 /// DataBox tags related to elliptic discontinuous Galerkin schemes
@@ -49,6 +58,16 @@ struct PenaltyParameter : db::SimpleTag {
   static double create_from_options(const double value) noexcept {
     return value;
   }
+};
+
+/// Whether or not to multiply the DG operator with the mass matrix. Massive DG
+/// operators can be easier to solve because they are symmetric, or at least
+/// closer to symmetry.
+struct Massive : db::SimpleTag {
+  using type = bool;
+  static constexpr bool pass_metavariables = false;
+  using option_tags = tmpl::list<OptionTags::Massive>;
+  static bool create_from_options(const bool value) noexcept { return value; }
 };
 
 }  // namespace Tags

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/ApplyMassMatrix.cpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/ApplyMassMatrix.cpp
@@ -1,0 +1,61 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/DiscontinuousGalerkin/ApplyMassMatrix.hpp"
+
+#include <cstddef>
+
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace dg::detail {
+
+template <>
+void apply_mass_matrix_impl<1>(const gsl::not_null<double*> data,
+                               const Mesh<1>& mesh) noexcept {
+  const size_t x_size = mesh.extents(0);
+  const auto& w_x = Spectral::quadrature_weights(mesh);
+  for (size_t i = 0; i < x_size; ++i) {
+    data.get()[i] *= w_x[i];
+  }
+}
+
+template <>
+void apply_mass_matrix_impl<2>(const gsl::not_null<double*> data,
+                               const Mesh<2>& mesh) noexcept {
+  const size_t x_size = mesh.extents(0);
+  const size_t y_size = mesh.extents(1);
+  const auto& w_x = Spectral::quadrature_weights(mesh.slice_through(0));
+  const auto& w_y = Spectral::quadrature_weights(mesh.slice_through(1));
+  for (size_t j = 0; j < y_size; ++j) {
+    const size_t offset = j * x_size;
+    for (size_t i = 0; i < x_size; ++i) {
+      data.get()[offset + i] *= w_x[i] * w_y[j];
+    }
+  }
+}
+
+template <>
+void apply_mass_matrix_impl<3>(const gsl::not_null<double*> data,
+                               const Mesh<3>& mesh) noexcept {
+  const size_t x_size = mesh.extents(0);
+  const size_t y_size = mesh.extents(1);
+  const size_t z_size = mesh.extents(2);
+  const auto& w_x = Spectral::quadrature_weights(mesh.slice_through(0));
+  const auto& w_y = Spectral::quadrature_weights(mesh.slice_through(1));
+  const auto& w_z = Spectral::quadrature_weights(mesh.slice_through(2));
+  for (size_t k = 0; k < z_size; ++k) {
+    const size_t offset_z = k * y_size * x_size;
+    for (size_t j = 0; j < y_size; ++j) {
+      const double w_yz = w_y[j] * w_z[k];
+      const size_t offset = x_size * j + offset_z;
+      for (size_t i = 0; i < x_size; ++i) {
+        data.get()[offset + i] *= w_x[i] * w_yz;
+      }
+    }
+  }
+}
+
+}  // namespace dg::detail

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/ApplyMassMatrix.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/ApplyMassMatrix.hpp
@@ -1,0 +1,77 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Variables.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace dg {
+
+namespace detail {
+template <size_t Dim>
+void apply_mass_matrix_impl(gsl::not_null<double*> data,
+                            const Mesh<Dim>& mesh) noexcept;
+}  // namespace detail
+
+/*!
+ * \brief Apply the DG mass matrix to the data, in the diagonal mass-matrix
+ * approximation ("mass-lumping")
+ *
+ * The DG mass matrix is:
+ *
+ * \f{equation}
+ * M_{pq} = \int_{\Omega_k} \psi_p(\xi) \psi_q(\xi) \mathrm{d}V
+ * \f}
+ *
+ * where \f$\psi_p(\xi)\f$ are the basis functions on the element
+ * \f$\Omega_k\f$. In the diagonal mass-matrix approximation ("mass-lumping") we
+ * evaluate the integral directly on the collocation points, i.e. with a Gauss
+ * or Gauss-Lobatto quadrature determined by the element mesh. Then it reduces
+ * to:
+ *
+ * \f{equation}
+ * M_{pq} \approx \delta_{pq} \prod_{i=1}^d w_{p_i}
+ * \f}
+ *
+ * where \f$d\f$ is the spatial dimension and \f$w_{p_i}\f$ are the quadrature
+ * weights in dimension \f$i\f$. To apply the mass matrix in coordinates
+ * different than logical, or to account for a curved background metric, the
+ * data can be pre-multiplied with the Jacobian determinant and/or a metric
+ * determinant.
+ *
+ * \note The mass-lumping is exact on Legendre-Gauss meshes, but omits a
+ * correction term on Legendre-Gauss-Lobatto meshes.
+ */
+// @{
+template <size_t Dim>
+void apply_mass_matrix(const gsl::not_null<DataVector*> data,
+                       const Mesh<Dim>& mesh) noexcept {
+  ASSERT(data->size() == mesh.number_of_grid_points(),
+         "The DataVector has size " << data->size() << ", but expected size "
+                                    << mesh.number_of_grid_points()
+                                    << " on the given mesh.");
+  detail::apply_mass_matrix_impl(data->data(), mesh);
+}
+
+template <size_t Dim, typename TagsList>
+void apply_mass_matrix(const gsl::not_null<Variables<TagsList>*> data,
+                       const Mesh<Dim>& mesh) noexcept {
+  const size_t num_points = data->number_of_grid_points();
+  ASSERT(num_points == mesh.number_of_grid_points(),
+         "The Variables data has "
+             << num_points << " grid points, but expected "
+             << mesh.number_of_grid_points() << " on the given mesh.");
+  constexpr size_t num_comps =
+      Variables<TagsList>::number_of_independent_components;
+  for (size_t i = 0; i < num_comps; ++i) {
+    detail::apply_mass_matrix_impl(data->data() + i * num_points, mesh);
+  }
+}
+// @}
+
+}  // namespace dg

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
@@ -8,6 +8,7 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  ApplyMassMatrix.cpp
   Formulation.cpp
   MetricIdentityJacobian.cpp
   MortarHelpers.cpp
@@ -17,6 +18,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  ApplyMassMatrix.hpp
   Formulation.hpp
   HasReceivedFromAllMortars.hpp
   LiftFlux.hpp
@@ -35,8 +37,10 @@ target_link_libraries(
   Boost::boost
   DataStructures
   DomainStructure
+  ErrorHandling
   Options
   Spectral
+  Utilities
   INTERFACE
   Domain
   )

--- a/src/NumericalAlgorithms/Spectral/Projection.hpp
+++ b/src/NumericalAlgorithms/Spectral/Projection.hpp
@@ -53,6 +53,18 @@ bool needs_projection(const Mesh<Dim>& mesh1, const Mesh<Dim>& mesh2,
  * sometimes referred to as a "restriction operator" and the
  * `projection_matrix_parent_to_child` as a "prolongation operator".
  *
+ * \par Massive quantities
+ * If the quantity that should be projected is not a function over the
+ * computational grid but a "massive" residual, i.e. a quantity
+ * \f$\int_{\Omega_k} f(x) \psi_p(x) \mathrm{d}V\f$ where \f$\psi_p\f$ are the
+ * basis functions on the mesh, then pass `true` for the parameter
+ * `operand_is_massive` (default is `false`). The restriction operator for this
+ * case is just the transpose of the prolongation operator, i.e. just an
+ * interpolation matrix transpose. Note that the "massive" residual already
+ * takes the difference in element size between parent and children into account
+ * by including a Jacobian in the volume element of the integral.
+ *
+ * \par Implementation details
  * The half-interval projections are based on an equation derived by
  * Saul.  This shows that the projection from the spectral basis for
  * the entire interval to the spectral basis for the upper half
@@ -62,16 +74,17 @@ bool needs_projection(const Mesh<Dim>& mesh1, const Mesh<Dim>& mesh2,
  * \binom{(j + k + n - 1)/2}{j} \frac{(k + n)!^2}{(2 k + n + 1)! n!}
  * \f}
  */
-const Matrix& projection_matrix_child_to_parent(const Mesh<1>& child_mesh,
-                                                const Mesh<1>& parent_mesh,
-                                                ChildSize size) noexcept;
+const Matrix& projection_matrix_child_to_parent(
+    const Mesh<1>& child_mesh, const Mesh<1>& parent_mesh, ChildSize size,
+    bool operand_is_massive = false) noexcept;
 
 /// The projection matrix from a child mesh to its parent, in `Dim` dimensions.
 template <size_t Dim>
 std::array<std::reference_wrapper<const Matrix>, Dim>
-projection_matrix_child_to_parent(
-    const Mesh<Dim>& child_mesh, const Mesh<Dim>& parent_mesh,
-    const std::array<ChildSize, Dim>& child_sizes) noexcept;
+projection_matrix_child_to_parent(const Mesh<Dim>& child_mesh,
+                                  const Mesh<Dim>& parent_mesh,
+                                  const std::array<ChildSize, Dim>& child_sizes,
+                                  bool operand_is_massive = false) noexcept;
 
 /// The projection matrix from a parent mesh to one of its children.
 ///

--- a/tests/InputFiles/Elasticity/BentBeam.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam.yaml
@@ -40,6 +40,7 @@ DomainCreator:
 Discretization:
   DiscontinuousGalerkin:
     PenaltyParameter: 1.
+    Massive: True
 
 Observers:
   VolumeFileName: "ElasticBentBeam2DVolume"

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -11,7 +11,7 @@
 #     Subfile: /ErrorNorms.dat
 #     FileGlob: ElasticHalfSpaceMirrorReductions.h5
 #     SkipColumns: [0, 1]
-#     AbsoluteTolerance: 1.e-3
+#     AbsoluteTolerance: 6.e-4
 
 Background:
   HalfSpaceMirror:
@@ -53,6 +53,7 @@ DomainCreator:
 Discretization:
   DiscontinuousGalerkin:
     PenaltyParameter: 1.
+    Massive: True
 
 Observers:
   VolumeFileName: "ElasticHalfSpaceMirrorVolume"
@@ -61,7 +62,7 @@ Observers:
 LinearSolver:
   GMRES:
     ConvergenceCriteria:
-      MaxIterations: 22
+      MaxIterations: 34
       RelativeResidual: 1.e-4
       AbsoluteResidual: 1.e-12
     Verbosity: Verbose
@@ -69,7 +70,7 @@ LinearSolver:
 EventsAndTriggers:
   ? EveryNIterations:
       N: 1
-      Offset: 22
+      Offset: 27
   : - ObserveErrorNorms:
         SubfileName: ErrorNorms
     - ObserveVolumeIntegrals:

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -38,6 +38,7 @@ DomainCreator:
 Discretization:
   DiscontinuousGalerkin:
     PenaltyParameter: 1.
+    Massive: True
 
 Observers:
   VolumeFileName: "PoissonProductOfSinusoids1DVolume"

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -34,6 +34,7 @@ DomainCreator:
 Discretization:
   DiscontinuousGalerkin:
     PenaltyParameter: 1.
+    Massive: True
 
 Observers:
   VolumeFileName: "PoissonProductOfSinusoids2DVolume"
@@ -41,7 +42,7 @@ Observers:
 
 LinearSolver:
   ConvergenceCriteria:
-    MaxIterations: 23
+    MaxIterations: 21
     RelativeResidual: 1.e-10
     AbsoluteResidual: 1.e-10
   Verbosity: Verbose
@@ -49,7 +50,7 @@ LinearSolver:
 EventsAndTriggers:
   ? EveryNIterations:
       N: 1
-      Offset: 23
+      Offset: 8
   : - ObserveErrorNorms:
         SubfileName: ErrorNorms
     - ObserveFields:

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -34,6 +34,7 @@ DomainCreator:
 Discretization:
   DiscontinuousGalerkin:
     PenaltyParameter: 1.
+    Massive: True
 
 Observers:
   VolumeFileName: "PoissonProductOfSinusoids3DVolume"
@@ -41,7 +42,7 @@ Observers:
 
 LinearSolver:
   ConvergenceCriteria:
-    MaxIterations: 29
+    MaxIterations: 22
     RelativeResidual: 1.e-6
     AbsoluteResidual: 1.e-6
   Verbosity: Verbose
@@ -49,7 +50,7 @@ LinearSolver:
 EventsAndTriggers:
   ? EveryNIterations:
       N: 1
-      Offset: 29
+      Offset: 9
   : - ObserveErrorNorms:
         SubfileName: ErrorNorms
     - ObserveFields:

--- a/tests/InputFiles/Xcts/Schwarzschild.yaml
+++ b/tests/InputFiles/Xcts/Schwarzschild.yaml
@@ -48,6 +48,7 @@ DomainCreator:
 Discretization:
   DiscontinuousGalerkin:
     PenaltyParameter: 1.
+    Massive: True
 
 Observers:
   VolumeFileName: "SchwarzschildVolume"
@@ -67,7 +68,7 @@ NonlinearSolver:
 LinearSolver:
   Gmres:
     ConvergenceCriteria:
-      MaxIterations: 100
+      MaxIterations: 65
       RelativeResidual: 1.e-3
       AbsoluteResidual: 1.e-12
     Verbosity: Quiet

--- a/tests/Unit/Elliptic/Actions/Test_InitializeFixedSources.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeFixedSources.cpp
@@ -19,6 +19,7 @@
 #include "Domain/Tags.hpp"
 #include "Elliptic/Actions/InitializeFixedSources.hpp"
 #include "Elliptic/DiscontinuousGalerkin/Actions/InitializeDomain.hpp"
+#include "Elliptic/DiscontinuousGalerkin/Tags.hpp"
 #include "Elliptic/Tags.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Parallel/Actions/SetupDataBox.hpp"
@@ -86,7 +87,10 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeFixedSources",
 
   using element_array = ElementArray<Metavariables>;
   ActionTesting::MockRuntimeSystem<Metavariables> runner{
-      {std::make_unique<Background>(), domain_creator.create_domain()}};
+      tuples::TaggedTuple<elliptic::Tags::Background<Background>,
+                          domain::Tags::Domain<1>, elliptic::dg::Tags::Massive>{
+          std::make_unique<Background>(), domain_creator.create_domain(),
+          false}};
   ActionTesting::emplace_component_and_initialize<element_array>(
       &runner, element_id,
       {domain_creator.initial_refinement_levels(),

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
@@ -8,6 +8,7 @@ add_subdirectory(Tags)
 set(LIBRARY "Test_NumericalDiscontinuousGalerkin")
 
 set(LIBRARY_SOURCES
+  Test_ApplyMassMatrix.cpp
   Test_Formulation.cpp
   Test_HasReceivedFromAllMortars.cpp
   Test_LiftFlux.cpp

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_ApplyMassMatrix.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_ApplyMassMatrix.cpp
@@ -1,0 +1,182 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/ApplyMatrices.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/EagerMath/Determinant.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/ApplyMassMatrix.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace dg {
+namespace {
+
+// This function computes the logical mass matrix exactly using the (normalized)
+// Vandermonde matrix: M = (V * V^T)^-1. We don't currently use this way of
+// computing the mass matrix in the DG code because it is cheaper to apply the
+// mass matrix as a pointwise multiplication over the grid.
+template <Spectral::Basis BasisType, Spectral::Quadrature QuadratureType>
+Matrix exact_logical_mass_matrix(const size_t num_points) noexcept {
+  auto normalized_vandermonde_matrix =
+      Spectral::modal_to_nodal_matrix<BasisType, QuadratureType>(num_points);
+  for (size_t j = 0; j < num_points; ++j) {
+    const double normalization = sqrt(
+        Spectral::compute_basis_function_normalization_square<BasisType>(j));
+    for (size_t i = 0; i < num_points; ++i) {
+      normalized_vandermonde_matrix(i, j) /= normalization;
+    }
+  }
+  return inv(normalized_vandermonde_matrix *
+             trans(normalized_vandermonde_matrix));
+}
+
+template <size_t Dim>
+std::array<Matrix, Dim> exact_logical_mass_matrix(
+    const Mesh<Dim>& mesh) noexcept {
+  std::array<Matrix, Dim> result{};
+  for (size_t d = 0; d < Dim; ++d) {
+    ASSERT(mesh.basis(d) == Spectral::Basis::Legendre,
+           "This function is currently only implemented for a Legendre basis.");
+    switch (mesh.quadrature(d)) {
+      case Spectral::Quadrature::Gauss: {
+        gsl::at(result, d) =
+            exact_logical_mass_matrix<Spectral::Basis::Legendre,
+                                      Spectral::Quadrature::Gauss>(
+                mesh.extents(d));
+        break;
+      }
+      case Spectral::Quadrature::GaussLobatto: {
+        gsl::at(result, d) =
+            exact_logical_mass_matrix<Spectral::Basis::Legendre,
+                                      Spectral::Quadrature::GaussLobatto>(
+                mesh.extents(d));
+        break;
+      }
+      default:
+        ERROR(
+            "This function is currently only implemented for Gauss and "
+            "Gauss-Lobatto quadrature.");
+    }
+  }
+  return result;
+}
+
+template <size_t Dim>
+void test_apply_mass_matrix(
+    const Mesh<Dim>& mesh, const DataVector& scalar_field,
+    const DataVector& expected_mass_matrix_times_scalar_field) noexcept {
+  const size_t num_grid_points = mesh.number_of_grid_points();
+  {
+    INFO("Test with DataVector");
+    auto result = scalar_field;
+    apply_mass_matrix(make_not_null(&result), mesh);
+    CHECK_ITERABLE_APPROX(result, expected_mass_matrix_times_scalar_field);
+  }
+  {
+    INFO("Test with Variables");
+    using tag1 = ::Tags::TempScalar<0>;
+    using tag2 = ::Tags::TempScalar<1>;
+    Variables<tmpl::list<tag1, tag2>> vars{num_grid_points};
+    get<tag1>(vars) = Scalar<DataVector>(scalar_field);
+    get<tag2>(vars) = Scalar<DataVector>(scalar_field);
+    apply_mass_matrix(make_not_null(&vars), mesh);
+    CHECK_ITERABLE_APPROX(get(get<tag1>(vars)),
+                          expected_mass_matrix_times_scalar_field);
+    CHECK_ITERABLE_APPROX(get(get<tag2>(vars)),
+                          expected_mass_matrix_times_scalar_field);
+  }
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Numerical.DiscontinuousGalerkin.ApplyMassMatrix",
+                  "[NumericalAlgorithms][Unit]") {
+  {
+    INFO("1D");
+    {
+      INFO("Gauss quadrature (exact)");
+      const Mesh<1> mesh{
+          {{4}}, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss};
+      const DataVector data{1., 2., 3., 4.};
+      const auto mass_matrix = exact_logical_mass_matrix(mesh);
+      const auto massive_data =
+          apply_matrices(mass_matrix, data, mesh.extents());
+      test_apply_mass_matrix(mesh, data, massive_data);
+    }
+    {
+      INFO("Gauss-Lobatto quadrature");
+      const Mesh<1> mesh{
+          {{4}}, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto};
+      test_apply_mass_matrix(mesh, {1., 2., 3., 4.},
+                             // Data divided by LGL quadrature weights
+                             DataVector{1., 10., 15., 4.} / 6.);
+    }
+  }
+  {
+    INFO("2D");
+    {
+      INFO("Gauss quadrature (exact)");
+      const Mesh<2> mesh{
+          {{4, 2}}, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss};
+      const DataVector data{1., 2., 3., 4., 5., 6., 7., 8.};
+      const auto mass_matrix = exact_logical_mass_matrix(mesh);
+      const auto massive_data =
+          apply_matrices(mass_matrix, data, mesh.extents());
+      test_apply_mass_matrix(mesh, data, massive_data);
+    }
+    {
+      INFO("Gauss-Lobatto quadrature");
+      const Mesh<2> mesh{{{4, 2}},
+                         Spectral::Basis::Legendre,
+                         Spectral::Quadrature::GaussLobatto};
+      test_apply_mass_matrix(
+          mesh, {1., 2., 3., 4., 5., 6., 7., 8.},
+          // Data divided by LGL quadrature weights
+          DataVector{1., 10., 15., 4., 5., 30., 35., 8.} / 6.);
+    }
+  }
+  {
+    INFO("3D");
+    {
+      INFO("Gauss quadrature (exact)");
+      const Mesh<3> mesh{
+          {{4, 2, 3}}, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss};
+      const DataVector data{1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,
+                            9.,  10., 11., 12., 13., 14., 15., 16.,
+                            17., 18., 19., 20., 21., 22., 23., 24.};
+      const auto mass_matrix = exact_logical_mass_matrix(mesh);
+      const auto massive_data =
+          apply_matrices(mass_matrix, data, mesh.extents());
+      test_apply_mass_matrix(mesh, data, massive_data);
+    }
+    {
+      INFO("Gauss-Lobatto quadrature");
+      const Mesh<3> mesh{{{4, 2, 3}},
+                         Spectral::Basis::Legendre,
+                         Spectral::Quadrature::GaussLobatto};
+      test_apply_mass_matrix(
+          mesh, {1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9.,  10., 11., 12.,
+                 13., 14., 15., 16., 17., 18., 19., 20., 21., 22., 23., 24.},
+          // Data divided by LGL quadrature weights
+          DataVector{1.,  10.,  15.,  4.,  5.,  30.,  35.,  8.,
+                     36., 200., 220., 48., 52., 280., 300., 64.,
+                     17., 90.,  95.,  20., 21., 110., 115., 24.} /
+              18.);
+    }
+  }
+}
+
+}  // namespace dg


### PR DESCRIPTION
## Proposed changes

Add the option to multiply the elliptic DG operator by the mass matrix. The "massive" operator can be easier to solve because it is symmetric, or at least closer to symmetry.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
