### PR TITLE
Add time derivative and volume terms to ScalarAdvection

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/VolumeTermsImpl.tpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/VolumeTermsImpl.tpp
@@ -12,6 +12,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/MetricIdentityJacobian.hpp"
 #include "NumericalAlgorithms/LinearOperators/Divergence.hpp"

--- a/src/Evolution/Systems/ScalarAdvection/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarAdvection/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   Characteristics.cpp
   Fluxes.cpp
+  TimeDerivativeTerms.cpp
   )
 
 spectre_target_headers(
@@ -20,6 +21,7 @@ spectre_target_headers(
   Fluxes.hpp
   System.hpp
   Tags.hpp
+  TimeDerivativeTerms.hpp
   )
 
 target_link_libraries(

--- a/src/Evolution/Systems/ScalarAdvection/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarAdvection/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_sources(
   Characteristics.cpp
   Fluxes.cpp
   TimeDerivativeTerms.cpp
+  VolumeTermsInstantiation.cpp
   )
 
 spectre_target_headers(

--- a/src/Evolution/Systems/ScalarAdvection/System.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/System.hpp
@@ -10,6 +10,7 @@
 #include "Evolution/Systems/ScalarAdvection/Characteristics.hpp"
 #include "Evolution/Systems/ScalarAdvection/Fluxes.hpp"
 #include "Evolution/Systems/ScalarAdvection/Tags.hpp"
+#include "Evolution/Systems/ScalarAdvection/TimeDerivativeTerms.hpp"
 #include "Utilities/TMPL.hpp"
 
 /*!
@@ -36,6 +37,8 @@ struct System {
   using flux_variables = tmpl::list<Tags::U>;
   using gradient_variables = tmpl::list<>;
   using sourced_variables = tmpl::list<>;
+
+  using compute_volume_time_derivative_terms = TimeDerivativeTerms<Dim>;
 
   using volume_fluxes = Fluxes<Dim>;
 

--- a/src/Evolution/Systems/ScalarAdvection/TimeDerivativeTerms.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/TimeDerivativeTerms.cpp
@@ -1,0 +1,34 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarAdvection/TimeDerivativeTerms.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/ScalarAdvection/Fluxes.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace ScalarAdvection {
+
+template <size_t Dim>
+void TimeDerivativeTerms<Dim>::apply(
+    gsl::not_null<Scalar<DataVector>*> /*non_flux_terms_dt_vars*/,
+    gsl::not_null<tnsr::I<DataVector, Dim>*> flux, const Scalar<DataVector>& u,
+    const tnsr::I<DataVector, Dim>& velocity_field) noexcept {
+  Fluxes<Dim>::apply(flux, u, velocity_field);
+}
+
+}  // namespace ScalarAdvection
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data) \
+  template class ScalarAdvection::TimeDerivativeTerms<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2))
+
+#undef DIM
+#undef INSTANTIATE

--- a/src/Evolution/Systems/ScalarAdvection/TimeDerivativeTerms.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/TimeDerivativeTerms.hpp
@@ -1,0 +1,37 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/ScalarAdvection/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ScalarAdvection {
+/// Computes the time derivative terms needed for the ScalarAdvection system,
+/// which are just the fluxes.
+template <size_t Dim>
+struct TimeDerivativeTerms {
+  using temporary_tags = tmpl::list<>;
+  using argument_tags = tmpl::list<Tags::U, Tags::VelocityField<Dim>>;
+
+  static void apply(
+      // Time derivatives returned by reference. No source terms or
+      // nonconservative products, so not used. All the tags in the
+      // variables_tag in the system struct.
+      gsl::not_null<Scalar<DataVector>*> /*non_flux_terms_dt_vars*/,
+
+      // Fluxes returned by reference. Listed in the system struct as
+      // flux_variables.
+      gsl::not_null<tnsr::I<DataVector, Dim>*> flux,
+
+      // Arguments listed in argument_tags above
+      const Scalar<DataVector>& u,
+      const tnsr::I<DataVector, Dim>& velocity_field) noexcept;
+};
+}  // namespace ScalarAdvection

--- a/src/Evolution/Systems/ScalarAdvection/VolumeTermsInstantiation.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/VolumeTermsInstantiation.cpp
@@ -1,0 +1,54 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/VolumeTermsImpl.tpp"
+#include "Evolution/Systems/ScalarAdvection/System.hpp"
+#include "Evolution/Systems/ScalarAdvection/TimeDerivativeTerms.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace evolution::dg::Actions::detail {
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data)                                                \
+  template void                                                               \
+  volume_terms<::ScalarAdvection::TimeDerivativeTerms<DIM(data)>>(            \
+      const gsl::not_null<Variables<db::wrap_tags_in<                         \
+          ::Tags::dt, typename ::ScalarAdvection::System<DIM(                 \
+                          data)>::variables_tag::tags_list>>*>                \
+          dt_vars_ptr,                                                        \
+      const gsl::not_null<Variables<db::wrap_tags_in<                         \
+          ::Tags::Flux,                                                       \
+          typename ::ScalarAdvection::System<DIM(data)>::flux_variables,      \
+          tmpl::size_t<DIM(data)>, Frame::Inertial>>*>                        \
+          volume_fluxes,                                                      \
+      const gsl::not_null<Variables<db::wrap_tags_in<                         \
+          ::Tags::deriv,                                                      \
+          typename ::ScalarAdvection::System<DIM(data)>::gradient_variables,  \
+          tmpl::size_t<DIM(data)>, Frame::Inertial>>*>                        \
+          partial_derivs,                                                     \
+      const gsl::not_null<Variables<typename ::ScalarAdvection::System<DIM(   \
+          data)>::compute_volume_time_derivative_terms::temporary_tags>*>     \
+          temporaries,                                                        \
+      const Variables<typename ::ScalarAdvection::System<DIM(                 \
+          data)>::variables_tag::tags_list>& evolved_vars,                    \
+      const ::dg::Formulation dg_formulation, const Mesh<DIM(data)>& mesh,    \
+      [[maybe_unused]] const tnsr::I<DataVector, DIM(data), Frame::Inertial>& \
+          inertial_coordinates,                                               \
+      const InverseJacobian<DataVector, DIM(data), Frame::Logical,            \
+                            Frame::Inertial>&                                 \
+          logical_to_inertial_inverse_jacobian,                               \
+      [[maybe_unused]] const Scalar<DataVector>* const det_inverse_jacobian,  \
+      const std::optional<tnsr::I<DataVector, DIM(data), Frame::Inertial>>&   \
+          mesh_velocity,                                                      \
+      const std::optional<Scalar<DataVector>>& div_mesh_velocity,             \
+      const Scalar<DataVector>& u,                                            \
+      const tnsr::I<DataVector, DIM(data), Frame::Inertial>&                  \
+          velocity_field) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
+
+#undef INSTANTIATION
+#undef DIM
+}  // namespace evolution::dg::Actions::detail

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_Characteristics.cpp
   Test_Fluxes.cpp
   Test_Tags.cpp
+  Test_TimeDerivativeTerms.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/Test_TimeDerivativeTerms.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/Test_TimeDerivativeTerms.cpp
@@ -1,0 +1,62 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/ScalarAdvection/Tags.hpp"
+#include "Evolution/Systems/ScalarAdvection/TimeDerivativeTerms.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+
+template <size_t Dim>
+void test_time_derivative(const gsl::not_null<std::mt19937*> generator,
+                          const size_t number_of_pts) {
+  // create datavectors to store computed values of dudt and flux
+  Scalar<DataVector> dudt{number_of_pts, 0.0};
+  tnsr::I<DataVector, Dim, Frame::Inertial> flux(number_of_pts);
+
+  // generate random u and velocity field
+  std::uniform_real_distribution<> distribution(-1.0, 1.0);
+  const auto u = make_with_random_values<Scalar<DataVector>>(
+      generator, make_not_null(&distribution), dudt);
+  const auto velocity =
+      make_with_random_values<tnsr::I<DataVector, Dim, Frame::Inertial>>(
+          generator, make_not_null(&distribution), dudt);
+
+  // evaluate dudt and flux
+  ScalarAdvection::TimeDerivativeTerms<Dim>::apply(&dudt, &flux, u, velocity);
+
+  // expected values of dudt and flux. note that dudt_expected is set to be
+  // equal to the original value of dudt (which is 0.0 here), since we have no
+  // source terms and the TimeDerivativeTerms::apply function should not make
+  // any change on dudt argument.
+  const Scalar<DataVector> dudt_expected{number_of_pts, 0.0};
+  const tnsr::I<DataVector, Dim, Frame::Inertial> flux_expected{
+      pypp::call<tnsr::I<DataVector, Dim, Frame::Inertial>>(
+          "TestFunctions", "compute_flux", u, velocity)};
+
+  // check values
+  CHECK_ITERABLE_APPROX(dudt, dudt_expected);
+  CHECK_ITERABLE_APPROX(flux, flux_expected);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarAdvection.TimeDerivative",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/ScalarAdvection"};
+  MAKE_GENERATOR(gen);
+
+  test_time_derivative<1>(make_not_null(&gen), 2);
+  test_time_derivative<2>(make_not_null(&gen), 5);
+}


### PR DESCRIPTION
## Proposed changes

- Add time derivative terms to the ScalarAdvection system
- Add volume terms instantiation of ScalarAdvection system, along with fixing include error

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
