### PR TITLE
Add radial partitioning to Shell domain

### DIFF
--- a/src/Domain/Creators/Python/Shell.cpp
+++ b/src/Domain/Creators/Python/Shell.cpp
@@ -12,19 +12,15 @@
 
 namespace py = pybind11;
 
-namespace domain {
-namespace creators {
-namespace py_bindings {
+namespace domain::creators::py_bindings {
+
 void bind_shell(py::module& m) {  // NOLINT
   py::class_<Shell, DomainCreator<3>>(m, "Shell")
-      .def(py::init<double, double, size_t, std::array<size_t, 2>, bool, double,
-                    bool>(),
+      .def(py::init<double, double, size_t, std::array<size_t, 2>, bool,
+                    double>(),
            py::arg("inner_radius"), py::arg("outer_radius"),
            py::arg("initial_refinement"),
            py::arg("initial_number_of_grid_points"),
-           py::arg("use_equiangular_map") = true, py::arg("aspect_ratio") = 1.,
-           py::arg("use_logarithmic_map") = false);
+           py::arg("use_equiangular_map") = true, py::arg("aspect_ratio") = 1.);
 }
-}  // namespace py_bindings
-}  // namespace creators
-}  // namespace domain
+}  // namespace domain::creators::py_bindings

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -148,20 +148,20 @@ enum class ShellWedges {
 /// The argument `aspect_ratio` sets the equatorial compression factor,
 /// used by the EquatorialCompression maps which get composed with the Wedges.
 /// This is done if `aspect_ratio` is set to something other than the default
-/// value of one. When the argument `use_logarithmic_map` is set to `true`,
-/// the radial gridpoints of the wedge map are set to be spaced logarithmically.
-/// The `number_of_layers` is used when the user wants to have multiple layers
-/// of Blocks in the radial direction.
+/// value of one. The `radial_partitioning` specifies the radial boundaries of
+/// sub-shells between `inner_radius` and `outer_radius`. Set the
+/// `radial_distribution` to select the radial distribution of grid points in
+/// the spherical shells.
 template <typename TargetFrame>
-auto sph_wedge_coordinate_maps(double inner_radius, double outer_radius,
-                               double inner_sphericity, double outer_sphericity,
-                               bool use_equiangular_map,
-                               double x_coord_of_shell_center = 0.0,
-                               bool use_half_wedges = false,
-                               double aspect_ratio = 1.0,
-                               bool use_logarithmic_map = false,
-                               ShellWedges which_wedges = ShellWedges::All,
-                               size_t number_of_layers = 1) noexcept
+auto sph_wedge_coordinate_maps(
+    double inner_radius, double outer_radius, double inner_sphericity,
+    double outer_sphericity, bool use_equiangular_map,
+    double x_coord_of_shell_center = 0.0, bool use_half_wedges = false,
+    double aspect_ratio = 1.0,
+    const std::vector<double>& radial_partitioning = {},
+    const std::vector<domain::CoordinateMaps::Distribution>&
+        radial_distribution = {domain::CoordinateMaps::Distribution::Linear},
+    ShellWedges which_wedges = ShellWedges::All) noexcept
     -> std::vector<std::unique_ptr<
         domain::CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>;
 

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -25,9 +25,9 @@ DomainCreator:
     InitialGridPoints: [5, 5]
     UseEquiangularMap: true
     AspectRatio: 1.0
-    UseLogarithmicMap: true
+    RadialPartitioning: []
+    RadialDistribution: [Logarithmic]
     WhichWedges: All
-    RadialBlockLayers: 1
     TimeDependence: None
     BoundaryConditions:
       InnerBoundary: DirichletAnalytic

--- a/tests/InputFiles/Xcts/Schwarzschild.yaml
+++ b/tests/InputFiles/Xcts/Schwarzschild.yaml
@@ -28,10 +28,10 @@ DomainCreator:
     InitialRefinement: 0
     InitialGridPoints: [5, 5]
     UseEquiangularMap: True
-    UseLogarithmicMap: True
     AspectRatio: 1.
     WhichWedges: All
-    RadialBlockLayers: 1
+    RadialPartitioning: []
+    RadialDistribution: [Logarithmic]
     TimeDependence: None
     BoundaryConditions:
       InnerBoundary:

--- a/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
@@ -261,11 +261,15 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
   // would make the test slower).
   if constexpr (IsTimeDependent::value) {
     const double expiration_time = 1.0;
+    std::vector<double> radial_partitioning{};
+    std::vector<domain::CoordinateMaps::Distribution> radial_distribution{
+        domain::CoordinateMaps::Distribution::Linear};
+
     domain_creator = std::make_unique<domain::creators::Shell>(
         1.9, 2.9, 1,
         std::array<size_t, 2>{grid_points_each_dimension,
                               grid_points_each_dimension},
-        false, 1.0, false, ShellWedges::All, 1,
+        false, 1.0, radial_partitioning, radial_distribution, ShellWedges::All,
         std::make_unique<
             domain::creators::time_dependence::UniformTranslation<3>>(
             0.0, expiration_time, std::array<double, 3>({{0.01, 0.02, 0.03}})));

--- a/tests/Unit/Domain/Creators/Python/Test_Shell.py
+++ b/tests/Unit/Domain/Creators/Python/Test_Shell.py
@@ -12,8 +12,7 @@ class TestShell(unittest.TestCase):
                       initial_refinement=1,
                       initial_number_of_grid_points=[3, 3],
                       use_equiangular_map=False,
-                      aspect_ratio=1.,
-                      use_logarithmic_map=False)
+                      aspect_ratio=1.)
         self.assertIsInstance(shell, DomainCreator3D)
 
 

--- a/tests/Unit/Domain/Creators/Test_Shell.cpp
+++ b/tests/Unit/Domain/Creators/Test_Shell.cpp
@@ -415,9 +415,9 @@ void test_shell_boundaries() {
         grid_points_r_angular,
         use_equiangular_map,
         1.0,
-        false,
+        {},
+        {domain::CoordinateMaps::Distribution::Linear},
         ShellWedges::All,
-        1,
         std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>{},
         create_inner_boundary_condition(),
         create_outer_boundary_condition()};
@@ -462,10 +462,10 @@ void test_shell_factory_equiangular() {
         "  InitialGridPoints: [2,3]\n"
         "  UseEquiangularMap: true\n"
         "  AspectRatio: 1.0\n"
-        "  UseLogarithmicMap: false\n"
+        "  RadialPartitioning: []\n"
+        "  RadialDistribution: [Linear]\n"
         "  WhichWedges: All\n"
-        "  TimeDependence: None\n"
-        "  RadialBlockLayers: 1\n" +
+        "  TimeDependence: None\n" +
         (expected_boundary_conditions.empty() ? std::string{}
                                               : boundary_conditions_string()));
     const double inner_radius = 1.0;
@@ -500,7 +500,8 @@ void test_shell_factory_equiangular_time_dependent() {
         "  InitialGridPoints: [2,3]\n"
         "  UseEquiangularMap: true\n"
         "  AspectRatio: 1.0\n"
-        "  UseLogarithmicMap: false\n"
+        "  RadialPartitioning: []\n"
+        "  RadialDistribution: [Linear]\n"
         "  WhichWedges: All\n"
         "  TimeDependence:\n"
         "    UniformTranslation:\n"
@@ -509,8 +510,7 @@ void test_shell_factory_equiangular_time_dependent() {
         "      Velocity: [2.3, -0.3, 1.2]\n"
         "      FunctionOfTimeNames: [TranslationX,"
         "                            TranslationY,"
-        "                            TranslationZ]\n"
-        "  RadialBlockLayers: 1\n" +
+        "                            TranslationZ]\n" +
         (expected_boundary_conditions.empty() ? std::string{}
                                               : boundary_conditions_string()));
     const double inner_radius = 1.0;
@@ -577,10 +577,10 @@ void test_shell_factory_equidistant() {
         "  InitialGridPoints: [2,3]\n"
         "  UseEquiangularMap: false\n"
         "  AspectRatio: 1.0\n"
-        "  UseLogarithmicMap: false\n"
+        "  RadialPartitioning: []\n"
+        "  RadialDistribution: [Linear]\n"
         "  WhichWedges: All\n"
-        "  TimeDependence: None\n"
-        "  RadialBlockLayers: 1\n" +
+        "  TimeDependence: None\n" +
         (expected_boundary_conditions.empty() ? std::string{}
                                               : boundary_conditions_string()));
     const double inner_radius = 1.0;
@@ -620,9 +620,9 @@ void test_shell_boundaries_aspect_ratio() {
       grid_points_r_angular,
       false,
       aspect_ratio,
-      false,
+      {},
+      {domain::CoordinateMaps::Distribution::Linear},
       ShellWedges::All,
-      1,
       std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>{},
       create_inner_boundary_condition(),
       create_outer_boundary_condition()};
@@ -652,10 +652,10 @@ void test_shell_factory_aspect_ratio() {
         "  InitialGridPoints: [2,3]\n"
         "  UseEquiangularMap: false\n"
         "  AspectRatio: 2.0        \n"
-        "  UseLogarithmicMap: false\n"
+        "  RadialPartitioning: []\n"
+        "  RadialDistribution: [Linear]\n"
         "  WhichWedges: All\n"
-        "  TimeDependence: None\n"
-        "  RadialBlockLayers: 1\n" +
+        "  TimeDependence: None\n" +
         (expected_boundary_conditions.empty() ? std::string{}
                                               : boundary_conditions_string()));
     const double inner_radius = 1.0;
@@ -681,10 +681,17 @@ void test_shell_boundaries_logarithmic_map() {
   const std::array<size_t, 2> grid_points_r_angular{{4, 4}};
   const double aspect_ratio = 1.0;
   const bool use_logarithmic_map = true;
+  const std::vector<domain::CoordinateMaps::Distribution> radial_distribution{
+      domain::CoordinateMaps::Distribution::Logarithmic};
 
-  const creators::Shell shell{
-      inner_radius, outer_radius, refinement_level,   grid_points_r_angular,
-      false,        aspect_ratio, use_logarithmic_map};
+  const creators::Shell shell{inner_radius,
+                              outer_radius,
+                              refinement_level,
+                              grid_points_r_angular,
+                              false,
+                              aspect_ratio,
+                              {},
+                              radial_distribution};
   test_physical_separation(shell.create_domain().blocks());
   test_shell_construction(
       shell, inner_radius, outer_radius, false, grid_points_r_angular,
@@ -697,9 +704,9 @@ void test_shell_boundaries_logarithmic_map() {
       grid_points_r_angular,
       false,
       aspect_ratio,
-      use_logarithmic_map,
+      {},
+      radial_distribution,
       ShellWedges::All,
-      1,
       std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>{},
       create_inner_boundary_condition(),
       create_outer_boundary_condition()};
@@ -713,7 +720,7 @@ void test_shell_boundaries_logarithmic_map() {
   CHECK_THROWS_WITH(
       creators::Shell(
           inner_radius, outer_radius, refinement_level, grid_points_r_angular,
-          false, aspect_ratio, use_logarithmic_map, ShellWedges::All, 1,
+          false, aspect_ratio, {}, radial_distribution, ShellWedges::All,
           std::unique_ptr<
               domain::creators::time_dependence::TimeDependence<3>>{},
           std::make_unique<TestHelpers::domain::BoundaryConditions::
@@ -722,34 +729,34 @@ void test_shell_boundaries_logarithmic_map() {
       Catch::Matchers::Contains(
           "Cannot have periodic boundary conditions with a shell"));
   CHECK_THROWS_WITH(
-      creators::Shell(inner_radius, outer_radius, refinement_level,
-                      grid_points_r_angular, false, aspect_ratio,
-                      use_logarithmic_map, ShellWedges::All, 1,
-                      std::unique_ptr<
-                      domain::creators::time_dependence::TimeDependence<3>>{},
-                      create_inner_boundary_condition(),
-                      std::make_unique<TestHelpers::domain::BoundaryConditions::
-                                           TestPeriodicBoundaryCondition<3>>(),
-                      Options::Context{false, {}, 1, 1}),
+      creators::Shell(
+          inner_radius, outer_radius, refinement_level, grid_points_r_angular,
+          false, aspect_ratio, {}, radial_distribution, ShellWedges::All,
+          std::unique_ptr<
+              domain::creators::time_dependence::TimeDependence<3>>{},
+          create_inner_boundary_condition(),
+          std::make_unique<TestHelpers::domain::BoundaryConditions::
+                               TestPeriodicBoundaryCondition<3>>(),
+          Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "Cannot have periodic boundary conditions with a shell"));
   CHECK_THROWS_WITH(
-      creators::Shell(inner_radius, outer_radius, refinement_level,
-                      grid_points_r_angular, false, aspect_ratio,
-                      use_logarithmic_map, ShellWedges::All, 1,
-                      std::unique_ptr<
-                      domain::creators::time_dependence::TimeDependence<3>>{},
-                      create_inner_boundary_condition(),
-                      std::make_unique<TestHelpers::domain::BoundaryConditions::
-                                           TestNoneBoundaryCondition<3>>(),
-                      Options::Context{false, {}, 1, 1}),
+      creators::Shell(
+          inner_radius, outer_radius, refinement_level, grid_points_r_angular,
+          false, aspect_ratio, {}, radial_distribution, ShellWedges::All,
+          std::unique_ptr<
+              domain::creators::time_dependence::TimeDependence<3>>{},
+          create_inner_boundary_condition(),
+          std::make_unique<TestHelpers::domain::BoundaryConditions::
+                               TestNoneBoundaryCondition<3>>(),
+          Options::Context{false, {}, 1, 1}),
       Catch::Matchers::Contains(
           "None boundary condition is not supported. If you would like "
           "an outflow boundary condition, you must use that."));
   CHECK_THROWS_WITH(
       creators::Shell(
           inner_radius, outer_radius, refinement_level, grid_points_r_angular,
-          false, aspect_ratio, use_logarithmic_map, ShellWedges::All, 1,
+          false, aspect_ratio, {}, radial_distribution, ShellWedges::All,
           std::unique_ptr<
               domain::creators::time_dependence::TimeDependence<3>>{},
           std::make_unique<TestHelpers::domain::BoundaryConditions::
@@ -778,10 +785,10 @@ void test_shell_factory_logarithmic_map() {
         "  InitialGridPoints: [2,3]\n"
         "  UseEquiangularMap: false\n"
         "  AspectRatio: 2.0        \n"
-        "  UseLogarithmicMap: true\n"
+        "  RadialPartitioning: []\n"
+        "  RadialDistribution: [Logarithmic]\n"
         "  WhichWedges: All\n"
-        "  TimeDependence: None\n"
-        "  RadialBlockLayers: 1\n" +
+        "  TimeDependence: None\n" +
         (expected_boundary_conditions.empty() ? std::string{}
                                               : boundary_conditions_string()));
     const double inner_radius = 1.0;
@@ -800,22 +807,22 @@ void test_shell_factory_logarithmic_map() {
   helper(create_boundary_conditions(1, ShellWedges::All), std::true_type{});
 
   INFO("Test with multiple radial layers");
-  const auto shell = TestHelpers::test_option_tag<
-      domain::OptionTags::DomainCreator<3>,
-      TestHelpers::domain::BoundaryConditions::
-          MetavariablesWithBoundaryConditions<3>>(
-      "Shell:\n"
-      "  InnerRadius: 1\n"
-      "  OuterRadius: 3\n"
-      "  InitialRefinement: 2\n"
-      "  InitialGridPoints: [2,3]\n"
-      "  UseEquiangularMap: false\n"
-      "  AspectRatio: 2.0        \n"
-      "  UseLogarithmicMap: true\n"
-      "  WhichWedges: All\n"
-      "  TimeDependence: None\n"
-      "  RadialBlockLayers: 3\n" +
-      boundary_conditions_string());
+  const auto shell =
+      TestHelpers::test_option_tag<domain::OptionTags::DomainCreator<3>,
+                                   TestHelpers::domain::BoundaryConditions::
+                                       MetavariablesWithBoundaryConditions<3>>(
+          "Shell:\n"
+          "  InnerRadius: 1\n"
+          "  OuterRadius: 3\n"
+          "  InitialRefinement: 2\n"
+          "  InitialGridPoints: [2,3]\n"
+          "  UseEquiangularMap: false\n"
+          "  AspectRatio: 2.0        \n"
+          "  RadialPartitioning: [1.5, 2.5]\n"
+          "  RadialDistribution: [Logarithmic, Logarithmic, Logarithmic]\n"
+          "  WhichWedges: All\n"
+          "  TimeDependence: None\n" +
+          boundary_conditions_string());
   const Domain<3> multiple_layers_domain = shell->create_domain();
   const auto expected_boundary_conditions =
       create_boundary_conditions(3, ShellWedges::All);
@@ -859,10 +866,10 @@ void test_shell_factory_wedges_four_on_equator() {
       "  InitialGridPoints: [2,3]\n"
       "  UseEquiangularMap: false\n"
       "  AspectRatio: 2.0        \n"
-      "  UseLogarithmicMap: true\n"
+      "  RadialPartitioning: []\n"
+      "  RadialDistribution: [Logarithmic]\n"
       "  WhichWedges: FourOnEquator\n"
-      "  TimeDependence: None\n"
-      "  RadialBlockLayers: 1\n");
+      "  TimeDependence: None\n");
   const double inner_radius = 1.0;
   const double outer_radius = 3.0;
   const size_t refinement_level = 2;
@@ -889,10 +896,10 @@ void test_shell_factory_wedges_one_along_minus_x() {
       "  InitialGridPoints: [2,3]\n"
       "  UseEquiangularMap: true\n"
       "  AspectRatio: 2.7        \n"
-      "  UseLogarithmicMap: false\n"
+      "  RadialPartitioning: []\n"
+      "  RadialDistribution: [Linear]\n"
       "  WhichWedges: OneAlongMinusX \n"
-      "  TimeDependence: None\n"
-      "  RadialBlockLayers: 1\n");
+      "  TimeDependence: None\n");
   const double inner_radius = 2.0;
   const double outer_radius = 3.0;
   const size_t refinement_level = 2;
@@ -950,13 +957,30 @@ void test_radial_block_layers(const double inner_radius,
   }
   x_on_element_boundary[number_of_divisions] = outer_radius;
 
+  std::vector<double> radial_partitions(radial_block_layers - 1);
+  for (size_t i = 1; i < radial_block_layers; ++i) {
+    const double delta =
+        static_cast<double>(i) / static_cast<double>(radial_block_layers);
+    if (use_logarithmic_map) {
+      radial_partitions[i - 1] =
+          inner_radius * pow(outer_radius / inner_radius, delta);
+    } else {
+      radial_partitions[i - 1] =
+          inner_radius + delta * (outer_radius - inner_radius);
+    }
+  }
+
   const auto zero = make_with_value<DataVector>(x_in_block_interior, 0.0);
   tnsr::I<DataVector, 3, Frame::Inertial> interior_inertial_coords{
       {{-x_in_block_interior, zero, zero}}};
+  const std::vector<domain::CoordinateMaps::Distribution> radial_distribution(
+      radial_block_layers,
+      use_logarithmic_map ? domain::CoordinateMaps::Distribution::Logarithmic
+                          : domain::CoordinateMaps::Distribution::Linear);
   const creators::Shell shell{
       inner_radius,          outer_radius,        refinement_level,
       grid_points_r_angular, use_equiangular_map, aspect_ratio,
-      use_logarithmic_map,   which_wedges,        radial_block_layers};
+      radial_partitions,     radial_distribution, which_wedges};
   auto domain = shell.create_domain();
   const auto blogical_coords =
       block_logical_coordinates(domain, interior_inertial_coords);

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -305,13 +305,13 @@ void test_wedge_map_generation_against_domain_helpers(
   const double x_coord_of_shell_center = 0.1;
   const bool use_half_wedges = true;
   const double aspect_ratio = 1.0;
-  const bool use_logarithmic_map = true;
+  const std::vector<domain::CoordinateMaps::Distribution> radial_distribution{
+      domain::CoordinateMaps::Distribution::Logarithmic};
   const ShellWedges which_wedges = ShellWedges::FourOnEquator;
-  const size_t number_of_layers = 3;
   static_cast<void>(sph_wedge_coordinate_maps<Frame::Inertial>(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
       use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
-      aspect_ratio, use_logarithmic_map, which_wedges, number_of_layers));
+      aspect_ratio, {}, radial_distribution, which_wedges));
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
@@ -330,13 +330,16 @@ void test_wedge_map_generation_against_domain_helpers(
   const double x_coord_of_shell_center = 0.1;
   const bool use_half_wedges = true;
   const double aspect_ratio = 1.0;
-  const bool use_logarithmic_map = true;
+  std::vector<double> radial_partitioning{1., 1.5};
+  const std::vector<domain::CoordinateMaps::Distribution> radial_distribution{
+      domain::CoordinateMaps::Distribution::Logarithmic,
+      domain::CoordinateMaps::Distribution::Logarithmic,
+      domain::CoordinateMaps::Distribution::Logarithmic};
   const ShellWedges which_wedges = ShellWedges::All;
-  const size_t number_of_layers = 3;
   static_cast<void>(sph_wedge_coordinate_maps<Frame::Inertial>(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
       use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
-      aspect_ratio, use_logarithmic_map, which_wedges, number_of_layers));
+      aspect_ratio, radial_partitioning, radial_distribution, which_wedges));
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }


### PR DESCRIPTION
## Proposed changes
Changes the `Shell` domain to use radial partitioning analogously to the `Cylinder` domain. This way the exact radial position of the radial partitions can be set in the input file.
<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
The option parsing arguments for `Shell` has changed.  Example:
Old:
```
Shell:
   InnerRadius: 1.
   OuterRadius: 2.
   UseLogarithmicMap: false
   RadialBlockLayers: 2
```
New:
```
Shell:
    InnerRadius: 1.
    OuterRadius: 2.
    RadialPartitioning: [1.5]
    RadialDistribution: [Linear, Linear]
```

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
