### PR TITLE
Add a safe way to mutably access a DataBox item

### DIFF
--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -2684,6 +2684,37 @@ void test_serialization() noexcept {
   serialization_compute_items_of_base_tags();
   serialization_of_pointers();
 }
+
+void test_get_mutable_reference() noexcept {
+  INFO("test get_mutable_reference");
+  // Make sure the presence of tags that could not be extracted
+  // doesn't prevent the function from working on other tags.
+  auto box = db::create<db::AddSimpleTags<test_databox_tags::Tag0,
+                                          test_databox_tags::Tag2, Parent<0>>,
+                        db::AddComputeTags<test_databox_tags::Tag4Compute>>(
+      3.14, "Original string"s,
+      std::make_pair(Boxed<int>(std::make_shared<int>(5)),
+                     Boxed<double>(std::make_shared<double>(3.5))));
+
+  decltype(auto) ref =
+      db::get_mutable_reference<test_databox_tags::Tag2>(make_not_null(&box));
+  static_assert(std::is_same_v<decltype(ref), std::string&>);
+  decltype(auto) base_ref =
+      db::get_mutable_reference<test_databox_tags::Tag2Base>(
+          make_not_null(&box));
+  static_assert(std::is_same_v<decltype(base_ref), std::string&>);
+  CHECK(&ref == &base_ref);
+  ref = "New string";
+  CHECK(db::get<test_databox_tags::Tag2Base>(box) == "New string");
+
+  // These should all fail to compile:
+  // db::get_mutable_reference<test_databox_tags::Tag0>(make_not_null(&box));
+  // db::get_mutable_reference<test_databox_tags::Tag4>(make_not_null(&box));
+  // db::get_mutable_reference<test_databox_tags::Tag4Compute>(
+  //     make_not_null(&box));
+  // db::get_mutable_reference<Parent<0>>(make_not_null(&box));
+  // db::get_mutable_reference<First<0>>(make_not_null(&box));
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.DataStructures.DataBox", "[Unit][DataStructures]") {
@@ -2705,6 +2736,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox", "[Unit][DataStructures]") {
   test_with_tagged_tuple();
   test_serialization();
   test_reference_item();
+  test_get_mutable_reference();
 }
 
 // Test`tag_is_retrievable_v`

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -2676,7 +2676,6 @@ void test_reference_item() noexcept {
         std::vector<double>{8.7, 93.2, 84.7});
   CHECK(get<test_databox_tags::Tag2>(box) == "My Sample String"s);
 }
-}  // namespace
 
 void test_serialization() noexcept {
   serialization_non_subitem_simple_items();
@@ -2685,6 +2684,7 @@ void test_serialization() noexcept {
   serialization_compute_items_of_base_tags();
   serialization_of_pointers();
 }
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.DataStructures.DataBox", "[Unit][DataStructures]") {
   test_databox();


### PR DESCRIPTION
## Proposed changes

This idea was discussed somewhere, but, unfortunately, I cannot remember where or who was involved.
Basically, the feature is restricted to cases where the DataBox is being used purely as a container for an object, without any relevant compute tags or similar.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
