### PR TITLE
Add GH+MHD BoundaryCorrection

### DIFF
--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -151,8 +151,7 @@ struct EvolutionMetavars {
           evolution::is_analytic_solution_v<initial_data>,
       "initial_data must be either an analytic_data or an analytic_solution");
   using equation_of_state_type = typename initial_data::equation_of_state_type;
-  using system = grmhd::ValenciaDivClean::System<equation_of_state_type>;
-  static constexpr size_t thermodynamic_dim = system::thermodynamic_dim;
+  using system = grmhd::ValenciaDivClean::System;
   using temporal_id = Tags::TimeStepId;
   static constexpr bool local_time_stepping = false;
   using initial_data_tag =
@@ -290,7 +289,7 @@ struct EvolutionMetavars {
           domain::Tags::Coordinates<3, Frame::Logical>>,
       Initialization::Actions::TimeStepperHistory<EvolutionMetavars>,
       VariableFixing::Actions::FixVariables<
-          VariableFixing::FixToAtmosphere<volume_dim, thermodynamic_dim>>,
+          VariableFixing::FixToAtmosphere<volume_dim>>,
       Actions::UpdateConservatives,
       tmpl::conditional_t<
           evolution::is_analytic_solution_v<initial_data>,
@@ -324,14 +323,13 @@ struct EvolutionMetavars {
 
           Parallel::PhaseActions<
               Phase, Phase::Evolve,
-              tmpl::list<
-                  VariableFixing::Actions::FixVariables<
-                      VariableFixing::FixToAtmosphere<volume_dim,
-                                                      thermodynamic_dim>>,
-                  Actions::UpdateConservatives, Actions::RunEventsAndTriggers,
-                  Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
-                  PhaseControl::Actions::ExecutePhaseChange<phase_changes,
-                                                            triggers>>>>>;
+              tmpl::list<VariableFixing::Actions::FixVariables<
+                             VariableFixing::FixToAtmosphere<volume_dim>>,
+                         Actions::UpdateConservatives,
+                         Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
+                         step_actions, Actions::AdvanceTime,
+                         PhaseControl::Actions::ExecutePhaseChange<
+                             phase_changes, triggers>>>>>;
 
   template <typename ParallelComponent>
   struct registration_list {

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -119,10 +119,7 @@ struct EvolutionMetavars {
 
   using equation_of_state_type = typename initial_data::equation_of_state_type;
 
-  using system =
-      RelativisticEuler::Valencia::System<Dim, equation_of_state_type>;
-
-  static constexpr size_t thermodynamic_dim = system::thermodynamic_dim;
+  using system = RelativisticEuler::Valencia::System<Dim>;
 
   using temporal_id = Tags::TimeStepId;
   static constexpr bool local_time_stepping = false;
@@ -244,7 +241,7 @@ struct EvolutionMetavars {
           domain::Tags::Coordinates<Dim, Frame::Logical>>,
       Initialization::Actions::TimeStepperHistory<EvolutionMetavars>,
       VariableFixing::Actions::FixVariables<
-          VariableFixing::FixToAtmosphere<volume_dim, thermodynamic_dim>>,
+          VariableFixing::FixToAtmosphere<volume_dim>>,
       Initialization::Actions::AddComputeTags<
           tmpl::list<hydro::Tags::SoundSpeedSquaredCompute<DataVector>>>,
       Actions::UpdateConservatives,
@@ -276,14 +273,13 @@ struct EvolutionMetavars {
 
           Parallel::PhaseActions<
               Phase, Phase::Evolve,
-              tmpl::list<
-                  VariableFixing::Actions::FixVariables<
-                      VariableFixing::FixToAtmosphere<volume_dim,
-                                                      thermodynamic_dim>>,
-                  Actions::UpdateConservatives, Actions::RunEventsAndTriggers,
-                  Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
-                  PhaseControl::Actions::ExecutePhaseChange<phase_changes,
-                                                            triggers>>>>>;
+              tmpl::list<VariableFixing::Actions::FixVariables<
+                             VariableFixing::FixToAtmosphere<volume_dim>>,
+                         Actions::UpdateConservatives,
+                         Actions::RunEventsAndTriggers, Actions::ChangeSlabSize,
+                         step_actions, Actions::AdvanceTime,
+                         PhaseControl::Actions::ExecutePhaseChange<
+                             phase_changes, triggers>>>>>;
 
   template <typename ParallelComponent>
   struct registration_list {

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/UpwindPenalty.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/UpwindPenalty.hpp
@@ -223,6 +223,7 @@ class UpwindPenalty final : public BoundaryCorrection<Dim> {
       ::GeneralizedHarmonic::ConstraintDamping::Tags::ConstraintGamma2,
       gr::Tags::Lapse<DataVector>,
       gr::Tags::Shift<Dim, Frame::Inertial, DataVector>>;
+  using dg_package_data_primitive_tags = tmpl::list<>;
   using dg_package_data_volume_tags = tmpl::list<>;
 
   double dg_package_data(

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/BoundaryCorrection.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/BoundaryCorrection.hpp
@@ -1,0 +1,62 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/BoundaryCorrection.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/BoundaryCorrection.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// Boundary corrections/numerical fluxes
+namespace grmhd::GhValenciaDivClean::BoundaryCorrections {
+/// \cond
+template <typename DerivedGhCorrection, typename DerivedValenciaCorrection>
+class ProductOfCorrections;
+/// \endcond
+
+namespace detail {
+template <typename GhList, typename ValenciaList>
+struct AllProductCorrections;
+
+template <typename GhList, typename... ValenciaCorrections>
+struct AllProductCorrections<GhList, tmpl::list<ValenciaCorrections...>> {
+  using type = tmpl::flatten<tmpl::list<
+      tmpl::transform<GhList, tmpl::bind<ProductOfCorrections, tmpl::_1,
+                                         tmpl::pin<ValenciaCorrections>>>...>>;
+};
+}  // namespace detail
+
+/*!
+ * \brief The base class used to make boundary corrections factory createable so
+ * they can be specified in the input file.
+ */
+class BoundaryCorrection : public PUP::able {
+ public:
+  BoundaryCorrection() = default;
+  BoundaryCorrection(const BoundaryCorrection&) = default;
+  BoundaryCorrection& operator=(const BoundaryCorrection&) = default;
+  BoundaryCorrection(BoundaryCorrection&&) = default;
+  BoundaryCorrection& operator=(BoundaryCorrection&&) = default;
+  ~BoundaryCorrection() override = default;
+
+  /// \cond
+  explicit BoundaryCorrection(CkMigrateMessage* msg) noexcept
+      : PUP::able(msg) {}
+  WRAPPED_PUPable_abstract(BoundaryCorrection);  // NOLINT
+  /// \endcond
+
+  using creatable_classes = typename detail::AllProductCorrections<
+      typename GeneralizedHarmonic::BoundaryCorrections::BoundaryCorrection<
+          3_st>::creatable_classes,
+      typename grmhd::ValenciaDivClean::BoundaryCorrections::
+          BoundaryCorrection::creatable_classes>::type;
+
+  virtual std::unique_ptr<BoundaryCorrection> get_clone() const noexcept = 0;
+};
+}  // namespace grmhd::GhValenciaDivClean::BoundaryCorrections

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  RegisterDerived.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  BoundaryCorrection.hpp
+  ProductOfCorrections.hpp
+  Factory.hpp
+  RegisterDerived.hpp
+  )

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/Factory.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/Factory.hpp
@@ -1,0 +1,7 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/BoundaryCorrection.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/ProductOfCorrections.hpp"

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/ProductOfCorrections.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/ProductOfCorrections.hpp
@@ -1,0 +1,255 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/Factory.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/BoundaryCorrection.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/Tags.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Factory.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace grmhd::GhValenciaDivClean::BoundaryCorrections {
+namespace detail {
+template <typename DerivedGhCorrection, typename DerivedValenciaCorrection,
+          typename GhPackageFieldTagList, typename ValenciaPackageFieldTagList,
+          typename GhEvolvedTagList, typename ValenciaEvolvedTags,
+          typename GhFluxTagList, typename ValenciaFluxTagList,
+          typename GhTempTagList, typename ValenciaTempTagList,
+          typename DeduplicatedTempTags, typename GhPrimTagList,
+          typename ValenicaPrimTagList, typename GhVolumeTagList,
+          typename ValenciaVolumeTagList>
+struct ProductOfCorrectionsImpl;
+
+template <typename DerivedGhCorrection, typename DerivedValenciaCorrection,
+          typename... GhPackageFieldTags, typename... ValenciaPackageFieldTags,
+          typename... GhEvolvedTags, typename... ValenciaEvolvedTags,
+          typename... GhFluxTags, typename... ValenciaFluxTags,
+          typename... GhTempTags, typename... ValenciaTempTags,
+          typename... DeduplicatedTempTags, typename... GhPrimTags,
+          typename... ValenciaPrimTags, typename... GhVolumeTags,
+          typename... ValenciaVolumeTags>
+struct ProductOfCorrectionsImpl<
+    DerivedGhCorrection, DerivedValenciaCorrection,
+    tmpl::list<GhPackageFieldTags...>, tmpl::list<ValenciaPackageFieldTags...>,
+    tmpl::list<GhEvolvedTags...>, tmpl::list<ValenciaEvolvedTags...>,
+    tmpl::list<GhFluxTags...>, tmpl::list<ValenciaFluxTags...>,
+    tmpl::list<GhTempTags...>, tmpl::list<ValenciaTempTags...>,
+    tmpl::list<DeduplicatedTempTags...>, tmpl::list<GhPrimTags...>,
+    tmpl::list<ValenciaPrimTags...>, tmpl::list<GhVolumeTags...>,
+    tmpl::list<ValenciaVolumeTags...>> {
+  static double dg_package_data(
+      const gsl::not_null<
+          typename GhPackageFieldTags::type*>... gh_packaged_fields,
+      const gsl::not_null<
+          typename ValenciaPackageFieldTags::type*>... valencia_packaged_fields,
+
+      const typename GhEvolvedTags::type&... gh_variables,
+      const typename ValenciaEvolvedTags::type&... valencia_variables,
+
+      const typename GhFluxTags::type&... gh_fluxes,
+      const typename ValenciaFluxTags::type&... valencia_fluxes,
+
+      const typename DeduplicatedTempTags::type&... temporaries,
+
+      const typename GhPrimTags::type&... gh_primitives,
+      const typename ValenciaPrimTags::type&... valencia_primitives,
+
+      const tnsr::i<DataVector, 3, Frame::Inertial>& normal_covector,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& normal_vector,
+      const std::optional<tnsr::I<DataVector, 3, Frame::Inertial>>&
+          mesh_velocity,
+      const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,
+
+      const typename GhVolumeTags::type&... gh_volume_quantities,
+      const typename ValenciaVolumeTags::type&... valencia_volume_quantities,
+
+      const DerivedGhCorrection& gh_correction,
+      const DerivedValenciaCorrection& valencia_correction) noexcept {
+    tuples::TaggedTuple<
+        Tags::detail::TemporaryReference<DeduplicatedTempTags>...>
+        shuffle_refs{temporaries...};
+    return std::max(
+        gh_correction.dg_package_data(
+            gh_packaged_fields..., gh_variables..., gh_fluxes...,
+            tuples::get<Tags::detail::TemporaryReference<GhTempTags>>(
+                shuffle_refs)...,
+            gh_primitives..., normal_covector, normal_vector, mesh_velocity,
+            normal_dot_mesh_velocity, gh_volume_quantities...),
+        valencia_correction.dg_package_data(
+            valencia_packaged_fields..., valencia_variables...,
+            valencia_fluxes...,
+            tuples::get<Tags::detail::TemporaryReference<ValenciaTempTags>>(
+                shuffle_refs)...,
+            valencia_primitives..., normal_covector, normal_vector,
+            mesh_velocity, normal_dot_mesh_velocity,
+            valencia_volume_quantities...));
+  }
+
+  static void dg_boundary_terms(
+      const gsl::not_null<
+          typename GhEvolvedTags::type*>... gh_boundary_corrections,
+      const gsl::not_null<
+          typename ValenciaEvolvedTags::type*>... valencia_boundary_corrections,
+
+      const typename GhPackageFieldTags::type&... gh_internal_packaged_fields,
+      const typename ValenciaPackageFieldTags::
+          type&... valencia_internal_packaged_fields,
+
+      const typename GhPackageFieldTags::type&... gh_external_packaged_fields,
+      const typename ValenciaPackageFieldTags::
+          type&... valencia_external_packaged_fields,
+      const dg::Formulation dg_formulation,
+
+      const DerivedGhCorrection& gh_correction,
+      const DerivedValenciaCorrection& valencia_correction) noexcept {
+    gh_correction.dg_boundary_terms(
+        gh_boundary_corrections..., gh_internal_packaged_fields...,
+        gh_external_packaged_fields..., dg_formulation);
+    valencia_correction.dg_boundary_terms(
+        valencia_boundary_corrections..., valencia_internal_packaged_fields...,
+        valencia_external_packaged_fields..., dg_formulation);
+  }
+};
+}  // namespace detail
+
+/*!
+ * \brief Apply a boundary condition to the combined Generalized Harmonic (GH)
+ * and Valencia GRMHD system using boundary corrections defined separately for
+ * the GH and Valencia systems.
+ *
+ * \details The implementation of this boundary correction applies the
+ * `DerivedGhCorrection` followed by the `DerivedValenciaCorrection`. It is
+ * anticipated that the systems are sufficiently independent that the order of
+ * application is inconsequential.
+ */
+template <typename DerivedGhCorrection, typename DerivedValenciaCorrection>
+class ProductOfCorrections : public BoundaryCorrection {
+ public:
+  using dg_package_field_tags =
+      tmpl::append<typename DerivedGhCorrection::dg_package_field_tags,
+                   typename DerivedValenciaCorrection::dg_package_field_tags>;
+
+  using dg_package_data_temporary_tags = tmpl::remove_duplicates<tmpl::append<
+      typename DerivedGhCorrection::dg_package_data_temporary_tags,
+      typename DerivedValenciaCorrection::dg_package_data_temporary_tags>>;
+
+  using dg_package_data_primitive_tags =
+      typename DerivedValenciaCorrection::dg_package_data_primitive_tags;
+
+  using dg_package_data_volume_tags = tmpl::append<
+      typename DerivedGhCorrection::dg_package_data_volume_tags,
+      typename DerivedValenciaCorrection::dg_package_data_volume_tags>;
+
+  using derived_product_correction_impl = detail::ProductOfCorrectionsImpl<
+      DerivedGhCorrection, DerivedValenciaCorrection,
+      typename DerivedGhCorrection::dg_package_field_tags,
+      typename DerivedValenciaCorrection::dg_package_field_tags,
+      typename GeneralizedHarmonic::System<3_st>::variables_tag::tags_list,
+      typename grmhd::ValenciaDivClean::System::variables_tag::tags_list,
+      db::wrap_tags_in<
+          ::Tags::Flux,
+          typename GeneralizedHarmonic::System<3_st>::flux_variables,
+          tmpl::size_t<3_st>, Frame::Inertial>,
+      db::wrap_tags_in<::Tags::Flux,
+                       typename grmhd::ValenciaDivClean::System::flux_variables,
+                       tmpl::size_t<3_st>, Frame::Inertial>,
+      typename DerivedGhCorrection::dg_package_data_temporary_tags,
+      typename DerivedValenciaCorrection::dg_package_data_temporary_tags,
+      dg_package_data_temporary_tags, tmpl::list<>,
+      typename DerivedValenciaCorrection::dg_package_data_primitive_tags,
+      typename DerivedGhCorrection::dg_package_data_volume_tags,
+      typename DerivedValenciaCorrection::dg_package_data_volume_tags>;
+
+  static std::string name() noexcept {
+    return "Product" + Options::name<DerivedGhCorrection>() + "And" +
+           Options::name<DerivedValenciaCorrection>();
+  }
+
+  struct GhCorrection {
+    using type = DerivedGhCorrection;
+    static std::string name() noexcept {
+      return Options::name<DerivedGhCorrection>();
+    }
+    static constexpr Options::String help{
+        "The Generalized Harmonic part of the product boundary condition"};
+  };
+  struct ValenciaCorrection {
+    using type = DerivedValenciaCorrection;
+    static std::string name() noexcept {
+      return Options::name<DerivedValenciaCorrection>();
+    }
+    static constexpr Options::String help{
+        "The Valencia part of the product boundary condition"};
+  };
+
+  using options = tmpl::list<GhCorrection, ValenciaCorrection>;
+
+  static constexpr Options::String help = {
+      "Direct product of a GH and ValenciaDivClean GRMHD boundary correction. "
+      "See the documentation for the two individual boundary corrections for "
+      "further details."};
+
+  ProductOfCorrections() = default;
+  ProductOfCorrections(DerivedGhCorrection gh_correction,
+                       DerivedValenciaCorrection valencia_correction) noexcept
+      : derived_gh_correction_{gh_correction},
+        derived_valencia_correction_{valencia_correction} {}
+  ProductOfCorrections(const ProductOfCorrections&) = default;
+  ProductOfCorrections& operator=(const ProductOfCorrections&) = default;
+  ProductOfCorrections(ProductOfCorrections&&) = default;
+  ProductOfCorrections& operator=(ProductOfCorrections&&) = default;
+  ~ProductOfCorrections() override = default;
+
+  /// \cond
+  explicit ProductOfCorrections(CkMigrateMessage* msg) noexcept
+      : BoundaryCorrection(msg) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(ProductOfCorrections);  // NOLINT
+  /// \endcond
+  void pup(PUP::er& p) noexcept override {
+    p | derived_gh_correction_;
+    p | derived_valencia_correction_;
+    BoundaryCorrection::pup(p);
+  }
+
+  std::unique_ptr<BoundaryCorrection> get_clone() const noexcept override {
+    return std::make_unique<ProductOfCorrections>(*this);
+  }
+
+  template <typename... Args>
+  double dg_package_data(Args&&... args) const noexcept {
+    return derived_product_correction_impl::dg_package_data(
+        std::forward<Args>(args)..., derived_gh_correction_,
+        derived_valencia_correction_);
+  }
+
+  template <typename... Args>
+  void dg_boundary_terms(Args&&... args) const noexcept {
+    derived_product_correction_impl::dg_boundary_terms(
+        std::forward<Args>(args)..., derived_gh_correction_,
+        derived_valencia_correction_);
+  }
+
+ private:
+  DerivedGhCorrection derived_gh_correction_;
+  DerivedValenciaCorrection derived_valencia_correction_;
+};
+
+/// \cond
+template <typename DerivedGhCorrection, typename DerivedValenciaCorrection>
+PUP::able::PUP_ID ProductOfCorrections<DerivedGhCorrection,
+                                       DerivedValenciaCorrection>::my_PUP_ID =
+    0;  // NOLINT
+/// \endcond
+}  // namespace grmhd::GhValenciaDivClean::BoundaryCorrections

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/RegisterDerived.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/RegisterDerived.cpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/Factory.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+
+namespace grmhd::GhValenciaDivClean::BoundaryCorrections {
+void register_derived_with_charm() noexcept {
+  Parallel::register_derived_classes_with_charm<BoundaryCorrection>();
+}
+}  // namespace grmhd::GhValenciaDivClean::BoundaryCorrections

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/RegisterDerived.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/RegisterDerived.hpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace grmhd::GhValenciaDivClean::BoundaryCorrections {
+void register_derived_with_charm() noexcept;
+}  // namespace grmhd::GhValenciaDivClean::BoundaryCorrections

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
@@ -27,3 +27,5 @@ target_link_libraries(
   DataStructures
   GeneralRelativity
   )
+
+add_subdirectory(BoundaryCorrections)

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/System.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/System.hpp
@@ -3,10 +3,70 @@
 
 #pragma once
 
+#include <cstddef>
+
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/BoundaryCorrection.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/TimeDerivativeTerms.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Sources.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/TimeDerivativeTerms.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
 namespace grmhd {
 
 /// Namespace associated with utilities for the combined Generalized Harmonic
 /// and Valencia formulation of ideal GRMHD with divergence cleaning systems.
 namespace GhValenciaDivClean {
+struct System {
+  using boundary_correction_base = BoundaryCorrections::BoundaryCorrection;
+  static constexpr bool has_primitive_and_conservative_vars = true;
+  static constexpr size_t volume_dim = 3;
+  using grmhd_system = grmhd::ValenciaDivClean::System;
+  using gh_system = GeneralizedHarmonic::System<3_st>;
+
+  using variables_tag = ::Tags::Variables<
+      tmpl::append<typename gh_system::variables_tag::tags_list,
+                   typename grmhd_system::variables_tag::tags_list>>;
+  using flux_variables = tmpl::append<typename gh_system::flux_variables,
+                                      typename grmhd_system::flux_variables>;
+  using gradient_variables =
+      tmpl::append<typename gh_system::gradient_variables,
+                   typename grmhd_system::gradient_variables>;
+  using gradient_tags = gradient_variables;
+  using sourced_variables = typename grmhd_system::sourced_variables;
+
+  using primitive_variables_tag =
+      typename grmhd_system::primitive_variables_tag;
+  using spacetime_variables_tag =
+      typename grmhd_system::spacetime_variables_tag;
+
+  using compute_volume_time_derivative_terms = TimeDerivativeTerms;
+  using volume_fluxes = typename grmhd_system::volume_fluxes;
+  using volume_sources = typename grmhd_system::volume_sources;
+
+  using conservative_from_primitive =
+      typename grmhd_system::conservative_from_primitive;
+  template <typename OrderedListOfPrimitiveRecoverySchemes>
+  using primitive_from_conservative =
+      typename grmhd_system::template primitive_from_conservative<
+          OrderedListOfPrimitiveRecoverySchemes>;
+
+  using compute_largest_characteristic_speed =
+      gh_system::compute_largest_characteristic_speed;
+
+  using inverse_spatial_metric_tag =
+      typename gh_system::inverse_spatial_metric_tag;
+};
 }  // namespace GhValenciaDivClean
 }  // namespace grmhd

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/TimeDerivativeTerms.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/TimeDerivativeTerms.hpp
@@ -178,15 +178,12 @@ struct TimeDerivativeTermsImpl<
  * can be explicitly inlined here to reduce memory pressure and the number of
  * compute tags.
  */
-template <typename EquationOfStateType>
 struct TimeDerivativeTerms {
-  using valencia_dt_tags =
-      db::wrap_tags_in<::Tags::dt,
-                       typename grmhd::ValenciaDivClean::System<
-                           EquationOfStateType>::variables_tag::tags_list>;
+  using valencia_dt_tags = db::wrap_tags_in<
+      ::Tags::dt,
+      typename grmhd::ValenciaDivClean::System::variables_tag::tags_list>;
   using valencia_flux_tags = tmpl::transform<
-      typename grmhd::ValenciaDivClean::System<
-          EquationOfStateType>::flux_variables,
+      typename grmhd::ValenciaDivClean::System::flux_variables,
       tmpl::bind<::Tags::Flux, tmpl::_1, tmpl::pin<tmpl::size_t<3_st>>,
                  tmpl::pin<Frame::Inertial>>>;
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
@@ -34,30 +34,28 @@
 
 namespace grmhd::ValenciaDivClean {
 
-template <typename OrderedListOfPrimitiveRecoverySchemes,
-          size_t ThermodynamicDim>
-void PrimitiveFromConservative<OrderedListOfPrimitiveRecoverySchemes,
-                               ThermodynamicDim>::
-    apply(const gsl::not_null<Scalar<DataVector>*> rest_mass_density,
-          const gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
-          const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
-              spatial_velocity,
-          const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
-              magnetic_field,
-          const gsl::not_null<Scalar<DataVector>*> divergence_cleaning_field,
-          const gsl::not_null<Scalar<DataVector>*> lorentz_factor,
-          const gsl::not_null<Scalar<DataVector>*> pressure,
-          const gsl::not_null<Scalar<DataVector>*> specific_enthalpy,
-          const Scalar<DataVector>& tilde_d,
-          const Scalar<DataVector>& tilde_tau,
-          const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
-          const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
-          const Scalar<DataVector>& tilde_phi,
-          const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
-          const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
-          const Scalar<DataVector>& sqrt_det_spatial_metric,
-          const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
-              equation_of_state) noexcept {
+template <typename OrderedListOfPrimitiveRecoverySchemes>
+template <size_t ThermodynamicDim>
+void PrimitiveFromConservative<OrderedListOfPrimitiveRecoverySchemes>::apply(
+    const gsl::not_null<Scalar<DataVector>*> rest_mass_density,
+    const gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        spatial_velocity,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        magnetic_field,
+    const gsl::not_null<Scalar<DataVector>*> divergence_cleaning_field,
+    const gsl::not_null<Scalar<DataVector>*> lorentz_factor,
+    const gsl::not_null<Scalar<DataVector>*> pressure,
+    const gsl::not_null<Scalar<DataVector>*> specific_enthalpy,
+    const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
+    const Scalar<DataVector>& tilde_phi,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+    const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+        equation_of_state) noexcept {
   get(*divergence_cleaning_field) =
       get(tilde_phi) / get(sqrt_det_spatial_metric);
   for (size_t i = 0; i < 3; ++i) {
@@ -176,13 +174,47 @@ void PrimitiveFromConservative<OrderedListOfPrimitiveRecoverySchemes,
 #define RECOVERY(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define THERMODIM(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATION(_, data)                                        \
-  template struct grmhd::ValenciaDivClean::PrimitiveFromConservative< \
-      RECOVERY(data), THERMODIM(data)>;
+#define INSTANTIATION(_, data)                                                 \
+  template struct grmhd::ValenciaDivClean::PrimitiveFromConservative<RECOVERY( \
+      data)>;
 
 using NewmanHamlinThenPalenzuelaEtAl = tmpl::list<
     grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin,
     grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::PalenzuelaEtAl>;
+
+GENERATE_INSTANTIATIONS(
+    INSTANTIATION,
+    (tmpl::list<
+         grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin>,
+     tmpl::list<
+         grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::PalenzuelaEtAl>,
+     NewmanHamlinThenPalenzuelaEtAl))
+
+#undef INSTANTIATION
+
+#define INSTANTIATION(_, data)                                                \
+  template void grmhd::ValenciaDivClean::                                     \
+      PrimitiveFromConservative<RECOVERY(data)>::apply<THERMODIM(data)>(      \
+          const gsl::not_null<Scalar<DataVector>*> rest_mass_density,         \
+          const gsl::not_null<Scalar<DataVector>*> specific_internal_energy,  \
+          const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>       \
+              spatial_velocity,                                               \
+          const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>       \
+              magnetic_field,                                                 \
+          const gsl::not_null<Scalar<DataVector>*> divergence_cleaning_field, \
+          const gsl::not_null<Scalar<DataVector>*> lorentz_factor,            \
+          const gsl::not_null<Scalar<DataVector>*> pressure,                  \
+          const gsl::not_null<Scalar<DataVector>*> specific_enthalpy,         \
+          const Scalar<DataVector>& tilde_d,                                  \
+          const Scalar<DataVector>& tilde_tau,                                \
+          const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,             \
+          const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,             \
+          const Scalar<DataVector>& tilde_phi,                                \
+          const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,     \
+          const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric, \
+          const Scalar<DataVector>& sqrt_det_spatial_metric,                  \
+          const EquationsOfState::EquationOfState<true, THERMODIM(data)>&     \
+              equation_of_state) noexcept;
 
 GENERATE_INSTANTIATIONS(
     INSTANTIATION,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp
@@ -41,8 +41,7 @@ namespace ValenciaDivClean {
  * (http://iopscience.iop.org/article/10.3847/1538-4357/aabcc5/meta)
  * compares several inversion methods.
  */
-template <typename OrderedListOfPrimitiveRecoverySchemes,
-          size_t ThermodynamicDim>
+template <typename OrderedListOfPrimitiveRecoverySchemes>
 struct PrimitiveFromConservative {
   using return_tags =
       tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
@@ -64,6 +63,7 @@ struct PrimitiveFromConservative {
                  gr::Tags::SqrtDetSpatialMetric<>,
                  hydro::Tags::EquationOfStateBase>;
 
+  template <size_t ThermodynamicDim>
   static void apply(
       gsl::not_null<Scalar<DataVector>*> rest_mass_density,
       gsl::not_null<Scalar<DataVector>*> specific_internal_energy,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp
@@ -33,13 +33,10 @@ namespace grmhd {
 /// (http://iopscience.iop.org/article/10.1088/0264-9381/31/1/015005)
 namespace ValenciaDivClean {
 
-template <typename EquationOfStateType>
 struct System {
   static constexpr bool is_in_flux_conservative_form = true;
   static constexpr bool has_primitive_and_conservative_vars = true;
   static constexpr size_t volume_dim = 3;
-  static constexpr size_t thermodynamic_dim =
-      EquationOfStateType::thermodynamic_dim;
 
   using boundary_conditions_base = BoundaryConditions::BoundaryCondition;
   using boundary_correction_base = BoundaryCorrections::BoundaryCorrection;
@@ -66,8 +63,7 @@ struct System {
   using conservative_from_primitive = ConservativeFromPrimitive;
   template <typename OrderedListOfPrimitiveRecoverySchemes>
   using primitive_from_conservative =
-      PrimitiveFromConservative<OrderedListOfPrimitiveRecoverySchemes,
-                                thermodynamic_dim>;
+      PrimitiveFromConservative<OrderedListOfPrimitiveRecoverySchemes>;
 
   using compute_largest_characteristic_speed =
       Tags::ComputeLargestCharacteristicSpeed;

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/VolumeTermsInstantiation.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/VolumeTermsInstantiation.cpp
@@ -7,41 +7,29 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/TimeDerivativeTerms.hpp"
 
-namespace {
-// The system is currently templated on the equation of state, but it's only
-// used in code that will be removed and that we don't care about. Even the
-// dependence on the thermodynamic dimension can probably be removed. In either
-// case, we don't care about the thermodynamic dimension for the explicit
-// instantiation either.
-struct DummyEquationOfStateType {
-  static constexpr size_t thermodynamic_dim = 1;
-};
-}  // namespace
-
 namespace evolution::dg::Actions::detail {
 template void volume_terms<::grmhd::ValenciaDivClean::TimeDerivativeTerms>(
     const gsl::not_null<Variables<db::wrap_tags_in<
-        ::Tags::dt, typename ::grmhd::ValenciaDivClean::System<
-                        DummyEquationOfStateType>::variables_tag::tags_list>>*>
+        ::Tags::dt,
+        typename ::grmhd::ValenciaDivClean::System::variables_tag::tags_list>>*>
         dt_vars_ptr,
-    const gsl::not_null<Variables<
-        db::wrap_tags_in<::Tags::Flux,
-                         typename ::grmhd::ValenciaDivClean::System<
-                             DummyEquationOfStateType>::flux_variables,
-                         tmpl::size_t<3>, Frame::Inertial>>*>
+    const gsl::not_null<Variables<db::wrap_tags_in<
+        ::Tags::Flux,
+        typename ::grmhd::ValenciaDivClean::System::flux_variables,
+        tmpl::size_t<3>, Frame::Inertial>>*>
         volume_fluxes,
-    const gsl::not_null<Variables<
-        db::wrap_tags_in<::Tags::deriv,
-                         typename ::grmhd::ValenciaDivClean::System<
-                             DummyEquationOfStateType>::gradient_variables,
-                         tmpl::size_t<3>, Frame::Inertial>>*>
+    const gsl::not_null<Variables<db::wrap_tags_in<
+        ::Tags::deriv,
+        typename ::grmhd::ValenciaDivClean::System::gradient_variables,
+        tmpl::size_t<3>, Frame::Inertial>>*>
         partial_derivs,
-    const gsl::not_null<Variables<
-        typename ::grmhd::ValenciaDivClean::System<DummyEquationOfStateType>::
-            compute_volume_time_derivative_terms::temporary_tags>*>
+    const gsl::not_null<
+        Variables<typename ::grmhd::ValenciaDivClean::System::
+                      compute_volume_time_derivative_terms::temporary_tags>*>
         temporaries,
-    const Variables<typename ::grmhd::ValenciaDivClean::System<
-        DummyEquationOfStateType>::variables_tag::tags_list>& evolved_vars,
+    const Variables<
+        typename ::grmhd::ValenciaDivClean::System::variables_tag::tags_list>&
+        evolved_vars,
     const ::dg::Formulation dg_formulation, const Mesh<3>& mesh,
     [[maybe_unused]] const tnsr::I<DataVector, 3, Frame::Inertial>&
         inertial_coordinates,

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/PrimitiveFromConservative.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/PrimitiveFromConservative.cpp
@@ -74,8 +74,9 @@ class FunctionOfZ {
 };
 }  // namespace
 
-template <size_t ThermodynamicDim, size_t Dim>
-void PrimitiveFromConservative<ThermodynamicDim, Dim>::apply(
+template <size_t Dim>
+template <size_t ThermodynamicDim>
+void PrimitiveFromConservative<Dim>::apply(
     const gsl::not_null<Scalar<DataVector>*> rest_mass_density,
     const gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
     const gsl::not_null<Scalar<DataVector>*> lorentz_factor,
@@ -145,7 +146,28 @@ void PrimitiveFromConservative<ThermodynamicDim, Dim>::apply(
 #define THERMODIM(data) BOOST_PP_TUPLE_ELEM(1, data)
 
 #define INSTANTIATION(_, data) \
-  template class PrimitiveFromConservative<THERMODIM(data), DIM(data)>;
+  template class PrimitiveFromConservative<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+
+#define INSTANTIATION(_, data)                                                \
+  template void PrimitiveFromConservative<DIM(data)>::apply<THERMODIM(data)>( \
+      const gsl::not_null<Scalar<DataVector>*> rest_mass_density,             \
+      const gsl::not_null<Scalar<DataVector>*> specific_internal_energy,      \
+      const gsl::not_null<Scalar<DataVector>*> lorentz_factor,                \
+      const gsl::not_null<Scalar<DataVector>*> specific_enthalpy,             \
+      const gsl::not_null<Scalar<DataVector>*> pressure,                      \
+      const gsl::not_null<tnsr::I<DataVector, DIM(data), Frame::Inertial>*>   \
+          spatial_velocity,                                                   \
+      const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau, \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& tilde_s,         \
+      const tnsr::II<DataVector, DIM(data), Frame::Inertial>&                 \
+          inv_spatial_metric,                                                 \
+      const Scalar<DataVector>& sqrt_det_spatial_metric,                      \
+      const EquationsOfState::EquationOfState<true, THERMODIM(data)>&         \
+          equation_of_state) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
 

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/PrimitiveFromConservative.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/PrimitiveFromConservative.hpp
@@ -59,7 +59,7 @@ namespace Valencia {
  * \todo The method also will make corrections if physical bounds are violated,
  * see the paper for details.
  */
-template <size_t ThermodynamicDim, size_t Dim>
+template <size_t Dim>
 struct PrimitiveFromConservative {
   using return_tags =
       tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
@@ -77,6 +77,7 @@ struct PrimitiveFromConservative {
                  gr::Tags::SqrtDetSpatialMetric<>,
                  hydro::Tags::EquationOfStateBase>;
 
+  template <size_t ThermodynamicDim>
   static void apply(
       gsl::not_null<Scalar<DataVector>*> rest_mass_density,
       gsl::not_null<Scalar<DataVector>*> specific_internal_energy,

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/System.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/System.hpp
@@ -27,13 +27,11 @@ namespace RelativisticEuler {
 /// Zanotti or http://iopscience.iop.org/article/10.1086/303604
 namespace Valencia {
 
-template <size_t Dim, typename EquationOfStateType>
+template <size_t Dim>
 struct System {
   static constexpr bool is_in_flux_conservative_form = true;
   static constexpr bool has_primitive_and_conservative_vars = true;
   static constexpr size_t volume_dim = Dim;
-  static constexpr size_t thermodynamic_dim =
-      EquationOfStateType::thermodynamic_dim;
 
   using boundary_conditions_base = BoundaryConditions::BoundaryCondition<Dim>;
   using boundary_correction_base = BoundaryCorrections::BoundaryCorrection<Dim>;
@@ -60,8 +58,7 @@ struct System {
   using volume_sources = ComputeSources<Dim>;
 
   using conservative_from_primitive = ConservativeFromPrimitive<Dim>;
-  using primitive_from_conservative =
-      PrimitiveFromConservative<thermodynamic_dim, Dim>;
+  using primitive_from_conservative = PrimitiveFromConservative<Dim>;
 
   using inverse_spatial_metric_tag =
       gr::Tags::InverseSpatialMetric<volume_dim, Frame::Inertial, DataVector>;

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/VolumeTermsInstantiation.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/VolumeTermsInstantiation.cpp
@@ -8,21 +8,9 @@
 #include "Evolution/Systems/RelativisticEuler/Valencia/TimeDerivativeTerms.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
-namespace {
-// The system is currently templated on the equation of state, but it's only
-// used in code that will be removed and that we don't care about. Even the
-// dependence on the thermodynamic dimension can probably be removed. In either
-// case, we don't care about the thermodynamic dimension for the explicit
-// instantiation either.
-struct DummyEquationOfStateType {
-  static constexpr size_t thermodynamic_dim = 1;
-};
-}  // namespace
-
 namespace evolution::dg::Actions::detail {
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
-#define SYSTEM(data) \
-  ::RelativisticEuler::Valencia::System<DIM(data), DummyEquationOfStateType>
+#define SYSTEM(data) ::RelativisticEuler::Valencia::System<DIM(data)>
 
 #define INSTANTIATION(r, data)                                                 \
   template void                                                                \

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/Test_ProductOfCorrections.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/Test_ProductOfCorrections.cpp
@@ -1,0 +1,291 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <optional>
+#include <string>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/BoundaryCorrection.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/ProductOfCorrections.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/System.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+template <typename DerivedCorrection, typename PackagedFieldTagList,
+          typename EvolvedTagList, typename FluxTagList, typename TempTagList,
+          typename PrimTagList, typename VolumeTagList>
+struct ComputeBoundaryCorrectionHelperImpl;
+
+template <typename DerivedCorrection, typename... PackagedFieldTags,
+          typename... EvolvedTags, typename... FluxTags, typename... TempTags,
+          typename... PrimTags, typename... VolumeTags>
+struct ComputeBoundaryCorrectionHelperImpl<
+    DerivedCorrection, tmpl::list<PackagedFieldTags...>,
+    tmpl::list<EvolvedTags...>, tmpl::list<FluxTags...>,
+    tmpl::list<TempTags...>, tmpl::list<PrimTags...>,
+    tmpl::list<VolumeTags...>> {
+  template <typename PackagedVariables, typename EvolvedVariables,
+            typename FluxVariables, typename TempVariables,
+            typename PrimVariables, typename VolumeVariables>
+  static double dg_package_data(
+      const gsl::not_null<PackagedVariables*> packaged_variables,
+      const EvolvedVariables& evolved_variables,
+      const FluxVariables& flux_variables, const TempVariables& temp_variables,
+      const PrimVariables& prim_variables,
+      const VolumeVariables& volume_variables,
+      const tnsr::i<DataVector, 3, Frame::Inertial>& normal_covector,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& normal_vector,
+      const std::optional<tnsr::I<DataVector, 3, Frame::Inertial>>&
+          mesh_velocity,
+      const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,
+      const DerivedCorrection& derived_correction) noexcept {
+    return derived_correction.dg_package_data(
+        make_not_null(&get<PackagedFieldTags>(*packaged_variables))...,
+        get<EvolvedTags>(evolved_variables)...,
+        get<FluxTags>(flux_variables)..., get<TempTags>(temp_variables)...,
+        get<PrimTags>(prim_variables)..., normal_covector, normal_vector,
+        mesh_velocity, normal_dot_mesh_velocity,
+        get<VolumeTags>(volume_variables)...);
+  }
+
+  template <typename EvolvedVariables, typename PackagedVariables>
+  static void dg_boundary_terms(
+      const gsl::not_null<EvolvedVariables*> boundary_corrections,
+      const PackagedVariables& internal_packaged_fields,
+      const PackagedVariables& external_packaged_fields,
+      dg::Formulation dg_formulation,
+      const DerivedCorrection& derived_correction) noexcept {
+    derived_correction.dg_boundary_terms(
+        make_not_null(&get<EvolvedTags>(*boundary_corrections))...,
+        get<PackagedFieldTags>(internal_packaged_fields)...,
+        get<PackagedFieldTags>(external_packaged_fields)..., dg_formulation);
+  }
+};
+
+template <typename DerivedCorrection, typename EvolvedTagList,
+          typename FluxTagList>
+using ComputeBoundaryCorrectionHelper = ComputeBoundaryCorrectionHelperImpl<
+    DerivedCorrection, typename DerivedCorrection::dg_package_field_tags,
+    EvolvedTagList, FluxTagList,
+    typename DerivedCorrection::dg_package_data_temporary_tags,
+    typename DerivedCorrection::dg_package_data_primitive_tags,
+    typename DerivedCorrection::dg_package_data_volume_tags>;
+
+template <typename DerivedGhCorrection, typename DerivedValenciaCorrection>
+void test_boundary_correction_combination(
+    const DerivedGhCorrection& derived_gh_correction,
+    const DerivedValenciaCorrection& derived_valencia_correction,
+    const grmhd::GhValenciaDivClean::BoundaryCorrections::ProductOfCorrections<
+        DerivedGhCorrection, DerivedValenciaCorrection>&
+        derived_product_correction,
+    const dg::Formulation formulation) noexcept {
+  using gh_variables_tags =
+      typename GeneralizedHarmonic::System<3_st>::variables_tag::tags_list;
+  using valencia_variables_tags =
+      typename grmhd::ValenciaDivClean::System::variables_tag::tags_list;
+  using evolved_variables_type =
+      Variables<tmpl::append<gh_variables_tags, valencia_variables_tags>>;
+
+  using derived_product_correction_type =
+      grmhd::GhValenciaDivClean::BoundaryCorrections::ProductOfCorrections<
+          DerivedGhCorrection, DerivedValenciaCorrection>;
+
+  using packaged_variables_type = Variables<
+      typename derived_product_correction_type::dg_package_field_tags>;
+
+  using gh_flux_tags = db::wrap_tags_in<
+      ::Tags::Flux, typename GeneralizedHarmonic::System<3_st>::flux_variables,
+      tmpl::size_t<3_st>, Frame::Inertial>;
+  using valencia_flux_tags =
+      db::wrap_tags_in<::Tags::Flux,
+                       typename grmhd::ValenciaDivClean::System::flux_variables,
+                       tmpl::size_t<3_st>, Frame::Inertial>;
+  using flux_variables_type =
+      Variables<tmpl::append<gh_flux_tags, valencia_flux_tags>>;
+
+  using temporary_variables_type = Variables<
+      typename derived_product_correction_type::dg_package_data_temporary_tags>;
+  using primitive_variables_type = Variables<
+      typename derived_product_correction_type::dg_package_data_primitive_tags>;
+  using volume_variables_type = Variables<
+      typename derived_product_correction_type::dg_package_data_volume_tags>;
+
+  const size_t element_size = 10_st;
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> dist(0.1, 1.0);
+
+  packaged_variables_type expected_packaged_variables{element_size};
+  packaged_variables_type packaged_variables{element_size};
+
+  const auto evolved_variables =
+      make_with_random_values<evolved_variables_type>(
+          make_not_null(&gen), make_not_null(&dist), element_size);
+  const auto flux_variables = make_with_random_values<flux_variables_type>(
+      make_not_null(&gen), make_not_null(&dist), element_size);
+  primitive_variables_type prim_variables{element_size};
+  if constexpr (tmpl::size<typename derived_product_correction_type::
+                               dg_package_data_primitive_tags>::value > 0) {
+    fill_with_random_values(make_not_null(&prim_variables), make_not_null(&gen),
+                            make_not_null(&dist));
+  }
+  const auto temporary_variables =
+      make_with_random_values<temporary_variables_type>(
+          make_not_null(&gen), make_not_null(&dist), element_size);
+  volume_variables_type volume_variables{element_size};
+  if constexpr (tmpl::size<typename derived_product_correction_type::
+                               dg_package_data_volume_tags>::value > 0) {
+    fill_with_random_values(make_not_null(&volume_variables),
+                            make_not_null(&gen), make_not_null(&dist));
+  }
+
+  const auto normal_covector =
+      make_with_random_values<tnsr::i<DataVector, 3, Frame::Inertial>>(
+          make_not_null(&gen), make_not_null(&dist), element_size);
+  const auto normal_vector =
+      make_with_random_values<tnsr::I<DataVector, 3, Frame::Inertial>>(
+          make_not_null(&gen), make_not_null(&dist), element_size);
+  const auto mesh_velocity =
+      make_with_random_values<tnsr::I<DataVector, 3, Frame::Inertial>>(
+          make_not_null(&gen), make_not_null(&dist), element_size);
+  const auto normal_dot_mesh_velocity =
+      make_with_random_values<Scalar<DataVector>>(
+          make_not_null(&gen), make_not_null(&dist), element_size);
+
+  double expected_package_gh_result =
+      ComputeBoundaryCorrectionHelper<DerivedGhCorrection, gh_variables_tags,
+                                      gh_flux_tags>::
+          dg_package_data(make_not_null(&expected_packaged_variables),
+                          evolved_variables, flux_variables,
+                          temporary_variables, prim_variables, volume_variables,
+                          normal_covector, normal_vector, mesh_velocity,
+                          normal_dot_mesh_velocity, derived_gh_correction);
+  double expected_package_valencia_result = ComputeBoundaryCorrectionHelper<
+      DerivedValenciaCorrection, valencia_variables_tags, valencia_flux_tags>::
+      dg_package_data(make_not_null(&expected_packaged_variables),
+                      evolved_variables, flux_variables, temporary_variables,
+                      prim_variables, volume_variables, normal_covector,
+                      normal_vector, mesh_velocity, normal_dot_mesh_velocity,
+                      derived_valencia_correction);
+
+  double package_combined_result = ComputeBoundaryCorrectionHelper<
+      derived_product_correction_type,
+      tmpl::append<gh_variables_tags, valencia_variables_tags>,
+      tmpl::append<gh_flux_tags, valencia_flux_tags>>::
+      dg_package_data(make_not_null(&packaged_variables), evolved_variables,
+                      flux_variables, temporary_variables, prim_variables,
+                      volume_variables, normal_covector, normal_vector,
+                      mesh_velocity, normal_dot_mesh_velocity,
+                      derived_product_correction);
+  CHECK(approx(SINGLE_ARG(std::max(expected_package_gh_result,
+                                   expected_package_valencia_result))) ==
+        package_combined_result);
+  CHECK_VARIABLES_APPROX(packaged_variables, expected_packaged_variables);
+
+  auto serialized_and_deserialized_correction =
+      serialize_and_deserialize(derived_product_correction);
+
+  package_combined_result = ComputeBoundaryCorrectionHelper<
+      derived_product_correction_type,
+      tmpl::append<gh_variables_tags, valencia_variables_tags>,
+      tmpl::append<gh_flux_tags, valencia_flux_tags>>::
+      dg_package_data(make_not_null(&packaged_variables), evolved_variables,
+                      flux_variables, temporary_variables, prim_variables,
+                      volume_variables, normal_covector, normal_vector,
+                      mesh_velocity, normal_dot_mesh_velocity,
+                      serialized_and_deserialized_correction);
+  CHECK(approx(SINGLE_ARG(std::max(expected_package_gh_result,
+                                   expected_package_valencia_result))) ==
+        package_combined_result);
+  CHECK_VARIABLES_APPROX(packaged_variables, expected_packaged_variables);
+
+  const auto external_packaged_fields =
+      make_with_random_values<packaged_variables_type>(
+          make_not_null(&gen), make_not_null(&dist), element_size);
+  const auto internal_packaged_fields =
+      make_with_random_values<packaged_variables_type>(
+          make_not_null(&gen), make_not_null(&dist), element_size);
+
+  evolved_variables_type expected_boundary_correction{element_size};
+  evolved_variables_type boundary_correction{element_size};
+  ComputeBoundaryCorrectionHelper<DerivedGhCorrection, gh_variables_tags,
+                                  gh_flux_tags>::
+      dg_boundary_terms(make_not_null(&expected_boundary_correction),
+                        internal_packaged_fields, external_packaged_fields,
+                        formulation, derived_gh_correction);
+  ComputeBoundaryCorrectionHelper<DerivedValenciaCorrection,
+                                  valencia_variables_tags, valencia_flux_tags>::
+      dg_boundary_terms(make_not_null(&expected_boundary_correction),
+                        internal_packaged_fields, external_packaged_fields,
+                        formulation, derived_valencia_correction);
+
+  ComputeBoundaryCorrectionHelper<
+      derived_product_correction_type,
+      tmpl::append<gh_variables_tags, valencia_variables_tags>,
+      tmpl::append<gh_flux_tags, valencia_flux_tags>>::
+      dg_boundary_terms(make_not_null(&boundary_correction),
+                        internal_packaged_fields, external_packaged_fields,
+                        formulation, derived_product_correction);
+  CHECK_VARIABLES_APPROX(boundary_correction, expected_boundary_correction);
+
+  ComputeBoundaryCorrectionHelper<
+      derived_product_correction_type,
+      tmpl::append<gh_variables_tags, valencia_variables_tags>,
+      tmpl::append<gh_flux_tags, valencia_flux_tags>>::
+      dg_boundary_terms(make_not_null(&boundary_correction),
+                        internal_packaged_fields, external_packaged_fields,
+                        formulation, serialized_and_deserialized_correction);
+  CHECK_VARIABLES_APPROX(boundary_correction, expected_boundary_correction);
+
+  PUPable_reg(SINGLE_ARG(
+      grmhd::GhValenciaDivClean::BoundaryCorrections::ProductOfCorrections<
+          DerivedGhCorrection, DerivedValenciaCorrection>));
+
+  TestHelpers::evolution::dg::test_boundary_correction_conservation<
+      grmhd::GhValenciaDivClean::System>(
+      make_not_null(&gen), derived_product_correction,
+      Mesh<2>{5, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, {},
+      {});
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.GhValenciaDivClean.ProductOfCorrections",
+    "[Unit][Evolution]") {
+  // scoped to separate out each product combination
+  {
+    INFO("Product correction UpwindPenalty and Rusanov");
+    grmhd::ValenciaDivClean::BoundaryCorrections::Rusanov valencia_correction{};
+    GeneralizedHarmonic::BoundaryCorrections::UpwindPenalty<3_st>
+        gh_correction{};
+    TestHelpers::test_creation<std::unique_ptr<
+        grmhd::GhValenciaDivClean::BoundaryCorrections::BoundaryCorrection>>(
+        "ProductUpwindPenaltyAndRusanov:\n"
+        "  UpwindPenalty:\n"
+        "  Rusanov:");
+    grmhd::GhValenciaDivClean::BoundaryCorrections::ProductOfCorrections<
+        GeneralizedHarmonic::BoundaryCorrections::UpwindPenalty<3_st>,
+        grmhd::ValenciaDivClean::BoundaryCorrections::Rusanov>
+        product_boundary_correction{gh_correction, valencia_correction};
+    for (const auto formulation :
+         {dg::Formulation::StrongInertial, dg::Formulation::WeakInertial}) {
+      test_boundary_correction_combination<
+          GeneralizedHarmonic::BoundaryCorrections::UpwindPenalty<3_st>,
+          grmhd::ValenciaDivClean::BoundaryCorrections::Rusanov>(
+          gh_correction, valencia_correction, product_boundary_correction,
+          formulation);
+    }
+  }
+}

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_GhValenciaDivClean")
 
 set(LIBRARY_SOURCES
+  BoundaryCorrections/Test_ProductOfCorrections.cpp
   Test_Tags.cpp
   Test_StressEnergy.cpp
   Test_TimeDerivativeTerms.cpp

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Test_TimeDerivativeTerms.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Test_TimeDerivativeTerms.cpp
@@ -16,7 +16,6 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/TimeDerivativeTerms.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
-#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace {
@@ -54,46 +53,42 @@ struct ComputeVolumeTimeDerivativeTermsHelper<
 SPECTRE_TEST_CASE(
     "Unit.Evolution.Systems.GhValenciaDivClean.TimeDerivativeTerms",
     "[Unit][Evolution]") {
-  using equation_of_state_type = EquationsOfState::IdealFluid<true>;
   using gh_variables_tags =
       typename GeneralizedHarmonic::System<3_st>::variables_tag::tags_list;
-  using valencia_variables_tags = typename grmhd::ValenciaDivClean::System<
-      equation_of_state_type>::variables_tag::tags_list;
+  using valencia_variables_tags =
+      typename grmhd::ValenciaDivClean::System::variables_tag::tags_list;
 
-  using gh_dt_variables_tags = grmhd::GhValenciaDivClean::TimeDerivativeTerms<
-      equation_of_state_type>::gh_dt_tags;
+  using gh_dt_variables_tags =
+      grmhd::GhValenciaDivClean::TimeDerivativeTerms::gh_dt_tags;
   using valencia_dt_variables_tags =
-      grmhd::GhValenciaDivClean::TimeDerivativeTerms<
-          equation_of_state_type>::valencia_dt_tags;
+      grmhd::GhValenciaDivClean::TimeDerivativeTerms::valencia_dt_tags;
   using dt_variables_type =
       Variables<tmpl::append<gh_dt_variables_tags, valencia_dt_variables_tags>>;
 
   using gh_flux_tags = tmpl::list<>;
-  using valencia_flux_tags = grmhd::GhValenciaDivClean::TimeDerivativeTerms<
-      equation_of_state_type>::valencia_flux_tags;
+  using valencia_flux_tags =
+      grmhd::GhValenciaDivClean::TimeDerivativeTerms::valencia_flux_tags;
   using flux_variables_type =
       Variables<tmpl::append<gh_flux_tags, valencia_flux_tags>>;
 
-  using gh_temp_tags = grmhd::GhValenciaDivClean::TimeDerivativeTerms<
-      equation_of_state_type>::gh_temp_tags;
-  using valencia_temp_tags = grmhd::GhValenciaDivClean::TimeDerivativeTerms<
-      equation_of_state_type>::valencia_temp_tags;
-  using temp_variables_type =
-      Variables<typename grmhd::GhValenciaDivClean::TimeDerivativeTerms<
-          equation_of_state_type>::temporary_tags>;
+  using gh_temp_tags =
+      grmhd::GhValenciaDivClean::TimeDerivativeTerms::gh_temp_tags;
+  using valencia_temp_tags =
+      grmhd::GhValenciaDivClean::TimeDerivativeTerms::valencia_temp_tags;
+  using temp_variables_type = Variables<
+      typename grmhd::GhValenciaDivClean::TimeDerivativeTerms::temporary_tags>;
 
   using gh_gradient_tags = tmpl::transform<
-      grmhd::GhValenciaDivClean::TimeDerivativeTerms<
-          equation_of_state_type>::gh_gradient_tags,
+      grmhd::GhValenciaDivClean::TimeDerivativeTerms::gh_gradient_tags,
       tmpl::bind<::Tags::deriv, tmpl::_1, tmpl::pin<tmpl::size_t<3_st>>,
                  tmpl::pin<Frame::Inertial>>>;
   using valencia_gradient_tags = tmpl::list<>;
   using gradient_variables_type = Variables<gh_gradient_tags>;
 
-  using gh_arg_tags = grmhd::GhValenciaDivClean::TimeDerivativeTerms<
-      equation_of_state_type>::gh_arg_tags;
-  using valencia_arg_tags = grmhd::GhValenciaDivClean::TimeDerivativeTerms<
-      equation_of_state_type>::valencia_arg_tags;
+  using gh_arg_tags =
+      grmhd::GhValenciaDivClean::TimeDerivativeTerms::gh_arg_tags;
+  using valencia_arg_tags =
+      grmhd::GhValenciaDivClean::TimeDerivativeTerms::valencia_arg_tags;
   using all_valencia_arg_tags =
       typename grmhd::ValenciaDivClean::TimeDerivativeTerms::argument_tags;
   using arg_variables_type = tuples::tagged_tuple_from_typelist<
@@ -220,8 +215,8 @@ SPECTRE_TEST_CASE(
       get<gr::Tags::Lapse<>>(expected_temp_variables));
 
   ComputeVolumeTimeDerivativeTermsHelper<
-      grmhd::GhValenciaDivClean::TimeDerivativeTerms<equation_of_state_type>,
-      3_st, tmpl::append<gh_variables_tags, valencia_variables_tags>,
+      grmhd::GhValenciaDivClean::TimeDerivativeTerms, 3_st,
+      tmpl::append<gh_variables_tags, valencia_variables_tags>,
       typename flux_variables_type::tags_list,
       typename temp_variables_type::tags_list,
       typename gradient_variables_type::tags_list,

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Test_DirichletAnalytic.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Test_DirichletAnalytic.cpp
@@ -112,8 +112,7 @@ void test_soln() {
   helpers::test_boundary_condition_with_python<
       grmhd::ValenciaDivClean::BoundaryConditions::DirichletAnalytic,
       grmhd::ValenciaDivClean::BoundaryConditions::BoundaryCondition,
-      grmhd::ValenciaDivClean::System<
-          typename grmhd::Solutions::SmoothFlow::equation_of_state_type>,
+      grmhd::ValenciaDivClean::System,
       tmpl::list<grmhd::ValenciaDivClean::BoundaryCorrections::Rusanov>,
       tmpl::list<ConvertSmoothFlow>>(
       make_not_null(&gen),
@@ -168,8 +167,7 @@ void test_data() {
   helpers::test_boundary_condition_with_python<
       grmhd::ValenciaDivClean::BoundaryConditions::DirichletAnalytic,
       grmhd::ValenciaDivClean::BoundaryConditions::BoundaryCondition,
-      grmhd::ValenciaDivClean::System<
-          typename grmhd::AnalyticData::MagneticRotor::equation_of_state_type>,
+      grmhd::ValenciaDivClean::System,
       tmpl::list<grmhd::ValenciaDivClean::BoundaryCorrections::Rusanov>,
       tmpl::list<ConvertMagneticRotor>>(
       make_not_null(&gen),

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Test_Rusanov.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Test_Rusanov.cpp
@@ -25,10 +25,7 @@ SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.Rusanov", "[Unit][GrMhd]") {
       "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections"};
   MAKE_GENERATOR(gen);
 
-  // need some equation of state. Rusanov doesn't care about it since the max
-  // speed is set by the speed of light.
-  using system =
-      grmhd::ValenciaDivClean::System<EquationsOfState::IdealFluid<true>>;
+  using system = grmhd::ValenciaDivClean::System;
 
   TestHelpers::evolution::dg::test_boundary_correction_conservation<system>(
       make_not_null(&gen),

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_PrimitiveFromConservative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_PrimitiveFromConservative.cpp
@@ -108,19 +108,16 @@ void test_primitive_from_conservative_random(
   // not nan
   Scalar<DataVector> pressure(number_of_points, 0.0);
   Scalar<DataVector> specific_enthalpy(number_of_points);
-  grmhd::ValenciaDivClean::PrimitiveFromConservative<
-      OrderedListOfPrimitiveRecoverySchemes,
-      ThermodynamicDim>::apply(make_not_null(&rest_mass_density),
-                               make_not_null(&specific_internal_energy),
-                               make_not_null(&spatial_velocity),
-                               make_not_null(&magnetic_field),
-                               make_not_null(&divergence_cleaning_field),
-                               make_not_null(&lorentz_factor),
-                               make_not_null(&pressure),
-                               make_not_null(&specific_enthalpy), tilde_d,
-                               tilde_tau, tilde_s, tilde_b, tilde_phi,
-                               spatial_metric, inv_spatial_metric,
-                               sqrt_det_spatial_metric, equation_of_state);
+  grmhd::ValenciaDivClean::
+      PrimitiveFromConservative<OrderedListOfPrimitiveRecoverySchemes>::apply(
+          make_not_null(&rest_mass_density),
+          make_not_null(&specific_internal_energy),
+          make_not_null(&spatial_velocity), make_not_null(&magnetic_field),
+          make_not_null(&divergence_cleaning_field),
+          make_not_null(&lorentz_factor), make_not_null(&pressure),
+          make_not_null(&specific_enthalpy), tilde_d, tilde_tau, tilde_s,
+          tilde_b, tilde_phi, spatial_metric, inv_spatial_metric,
+          sqrt_det_spatial_metric, equation_of_state);
 
   Approx larger_approx =
       Approx::custom().epsilon(std::numeric_limits<double>::epsilon() * 1.e8);
@@ -204,17 +201,16 @@ void test_primitive_from_conservative_known(
   Scalar<DataVector> pressure(number_of_points, 0.0);
   Scalar<DataVector> specific_enthalpy(number_of_points);
   EquationsOfState::IdealFluid<true> ideal_fluid(4.0 / 3.0);
-  grmhd::ValenciaDivClean::PrimitiveFromConservative<
-      OrderedListOfPrimitiveRecoverySchemes,
-      2>::apply(make_not_null(&rest_mass_density),
-                make_not_null(&specific_internal_energy),
-                make_not_null(&spatial_velocity),
-                make_not_null(&magnetic_field),
-                make_not_null(&divergence_cleaning_field),
-                make_not_null(&lorentz_factor), make_not_null(&pressure),
-                make_not_null(&specific_enthalpy), tilde_d, tilde_tau, tilde_s,
-                tilde_b, tilde_phi, spatial_metric, inv_spatial_metric,
-                sqrt_det_spatial_metric, ideal_fluid);
+  grmhd::ValenciaDivClean::
+      PrimitiveFromConservative<OrderedListOfPrimitiveRecoverySchemes>::apply(
+          make_not_null(&rest_mass_density),
+          make_not_null(&specific_internal_energy),
+          make_not_null(&spatial_velocity), make_not_null(&magnetic_field),
+          make_not_null(&divergence_cleaning_field),
+          make_not_null(&lorentz_factor), make_not_null(&pressure),
+          make_not_null(&specific_enthalpy), tilde_d, tilde_tau, tilde_s,
+          tilde_b, tilde_phi, spatial_metric, inv_spatial_metric,
+          sqrt_det_spatial_metric, ideal_fluid);
 
   CHECK_ITERABLE_APPROX(expected_rest_mass_density, rest_mass_density);
   CHECK_ITERABLE_APPROX(expected_specific_internal_energy,

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/Test_DirichletAnalytic.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/Test_DirichletAnalytic.cpp
@@ -75,9 +75,7 @@ void test() {
   helpers::test_boundary_condition_with_python<
       RelativisticEuler::Valencia::BoundaryConditions::DirichletAnalytic<Dim>,
       RelativisticEuler::Valencia::BoundaryConditions::BoundaryCondition<Dim>,
-      RelativisticEuler::Valencia::System<
-          Dim, typename RelativisticEuler::Solutions::SmoothFlow<
-                   Dim>::equation_of_state_type>,
+      RelativisticEuler::Valencia::System<Dim>,
       tmpl::list<
           RelativisticEuler::Valencia::BoundaryCorrections::Rusanov<Dim>>,
       tmpl::list<ConvertSmoothFlow<Dim>>>(

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/BoundaryCorrections/Test_Rusanov.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/BoundaryCorrections/Test_Rusanov.cpp
@@ -88,14 +88,14 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts,
              std::array<double, 2>{{-0.1, 0.1}}};
 
   helpers::test_boundary_correction_conservation<
-      RelativisticEuler::Valencia::System<Dim, EosType>>(
+      RelativisticEuler::Valencia::System<Dim>>(
       gen, RelativisticEuler::Valencia::BoundaryCorrections::Rusanov<Dim>{},
       Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
                     Spectral::Quadrature::Gauss},
       volume_data, ranges);
 
   helpers::test_boundary_correction_with_python<
-      RelativisticEuler::Valencia::System<Dim, EosType>,
+      RelativisticEuler::Valencia::System<Dim>,
       tmpl::list<ConvertPolytropic, ConvertIdeal>>(
       gen,
       "Evolution.Systems.RelativisticEuler.Valencia.BoundaryCorrections."
@@ -117,7 +117,7 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts,
                           BoundaryCorrection<Dim>>>("Rusanov:");
 
   helpers::test_boundary_correction_with_python<
-      RelativisticEuler::Valencia::System<Dim, EosType>,
+      RelativisticEuler::Valencia::System<Dim>,
       tmpl::list<ConvertPolytropic, ConvertIdeal>>(
       gen,
       "Evolution.Systems.RelativisticEuler.Valencia.BoundaryCorrections."

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_PrimitiveFromConservative.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_PrimitiveFromConservative.cpp
@@ -89,15 +89,12 @@ void test_primitive_from_conservative(
   auto spatial_velocity =
       make_with_value<tnsr::I<DataVector, Dim>>(used_for_size, 0.0);
 
-  RelativisticEuler::Valencia::PrimitiveFromConservative<
-      ThermodynamicDim, Dim>::apply(make_not_null(&rest_mass_density),
-                                    make_not_null(&specific_internal_energy),
-                                    make_not_null(&lorentz_factor),
-                                    make_not_null(&specific_enthalpy),
-                                    make_not_null(&pressure),
-                                    make_not_null(&spatial_velocity), tilde_d,
-                                    tilde_tau, tilde_s, inv_spatial_metric,
-                                    sqrt_det_spatial_metric, equation_of_state);
+  RelativisticEuler::Valencia::PrimitiveFromConservative<Dim>::apply(
+      make_not_null(&rest_mass_density),
+      make_not_null(&specific_internal_energy), make_not_null(&lorentz_factor),
+      make_not_null(&specific_enthalpy), make_not_null(&pressure),
+      make_not_null(&spatial_velocity), tilde_d, tilde_tau, tilde_s,
+      inv_spatial_metric, sqrt_det_spatial_metric, equation_of_state);
 
   Approx larger_approx =
       Approx::custom().epsilon(std::numeric_limits<double>::epsilon() * 1.e7);


### PR DESCRIPTION
## Proposed changes

Adds a `BoundaryCorrection` struct and derived class representing the 'product' of the GRMHD (ValenciaDivClean) and GH systems -- it performs some template manipulations and just calls the respective corrections in sequence.

### Upgrade instructions
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Dependencies

- [x] #3134 

