### PR TITLE
Subcell: tags LowerSpatialFourVelocity, OnSubcells, OnSubcellFaces, SubcellSolver option group

### DIFF
--- a/src/Evolution/DgSubcell/Tags/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/Tags/CMakeLists.txt
@@ -15,6 +15,7 @@ spectre_target_headers(
   Mesh.hpp
   NeighborData.hpp
   SubcellOptions.hpp
+  SubcellSolver.hpp
   Tags.hpp
   TciGridHistory.hpp
   TciStatus.hpp

--- a/src/Evolution/DgSubcell/Tags/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/Tags/CMakeLists.txt
@@ -14,6 +14,7 @@ spectre_target_headers(
   Jacobians.hpp
   Mesh.hpp
   NeighborData.hpp
+  OnSubcells.hpp
   SubcellOptions.hpp
   SubcellSolver.hpp
   Tags.hpp

--- a/src/Evolution/DgSubcell/Tags/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/Tags/CMakeLists.txt
@@ -14,6 +14,7 @@ spectre_target_headers(
   Jacobians.hpp
   Mesh.hpp
   NeighborData.hpp
+  OnSubcellFaces.hpp
   OnSubcells.hpp
   SubcellOptions.hpp
   SubcellSolver.hpp

--- a/src/Evolution/DgSubcell/Tags/OnSubcellFaces.hpp
+++ b/src/Evolution/DgSubcell/Tags/OnSubcellFaces.hpp
@@ -1,0 +1,24 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/VariablesTag.hpp"
+
+/// \cond
+template <typename X, typename Symm, typename IndexList>
+class Tensor;
+template <typename TagsList>
+class Variables;
+/// \endcond
+
+namespace evolution::dg::subcell::Tags {
+/// Mark a tag as the being on the subcell faces
+template <typename Tag, size_t Dim>
+struct OnSubcellFaces : db::PrefixTag, db::SimpleTag {
+  using type = std::array<typename Tag::type, Dim>;
+  using tag = Tag;
+};
+}  // namespace evolution::dg::subcell::Tags

--- a/src/Evolution/DgSubcell/Tags/OnSubcells.hpp
+++ b/src/Evolution/DgSubcell/Tags/OnSubcells.hpp
@@ -1,0 +1,40 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/VariablesTag.hpp"
+
+/// \cond
+template <typename X, typename Symm, typename IndexList>
+class Tensor;
+template <typename TagsList>
+class Variables;
+/// \endcond
+
+namespace evolution::dg::subcell::Tags {
+/// Mark a tag as the being on the subcell grid
+template <typename Tag>
+struct OnSubcells : db::PrefixTag, db::SimpleTag {
+  static_assert(tt::is_a_v<Tensor, typename Tag::type>,
+                "A subcell tag must be either a Tensor or a Variables "
+                "currently, though this can be generalized if needed.");
+  using type = typename Tag::type;
+  using tag = Tag;
+};
+
+/// \cond
+template <typename TagList>
+struct OnSubcells<::Tags::Variables<TagList>> : db::PrefixTag,
+                                                   db::SimpleTag {
+ private:
+  using wrapped_tags_list = db::wrap_tags_in<OnSubcells, TagList>;
+
+ public:
+  using tag = ::Tags::Variables<TagList>;
+  using type = Variables<wrapped_tags_list>;
+};
+/// \endcond
+}  // namespace evolution::dg::subcell::Tags

--- a/src/Evolution/DgSubcell/Tags/SubcellSolver.hpp
+++ b/src/Evolution/DgSubcell/Tags/SubcellSolver.hpp
@@ -1,0 +1,29 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "NumericalAlgorithms/SpatialDiscretization/OptionTags.hpp"
+#include "Options/Options.hpp"
+
+namespace evolution::dg::subcell::OptionTags {
+/*!
+ * \brief Group holding options for controlling the subcell solver
+ * discretization.
+ *
+ * For example, this would hold the reconstruction scheme or order of the finite
+ * difference derivatives.
+ *
+ * \note The `SubcellSolverGroup` is a subgroup of
+ * `SpatialDiscretization::OptionTags::SpatialDiscretizationGroup`.
+ */
+struct SubcellSolverGroup {
+  static std::string name() noexcept { return "SubcellSolver"; }
+  static constexpr Options::String help{
+      "Options controlling the subcell solver spatial discretization "
+      "of the PDE system.\n\n"
+      "Contains options such as what reconstruction scheme to use or what "
+      "order of finite difference derivatives to apply."};
+  using group = SpatialDiscretization::OptionTags::SpatialDiscretizationGroup;
+};
+}  // namespace evolution::dg::subcell::OptionTags

--- a/src/PointwiseFunctions/Hydro/Tags.hpp
+++ b/src/PointwiseFunctions/Hydro/Tags.hpp
@@ -174,6 +174,12 @@ struct SpecificInternalEnergy : db::SimpleTag {
   using type = Scalar<DataType>;
 };
 
+/// The spatial components of the four-velocity one-form \f$u_i\f$.
+template <typename DataType, size_t Dim, typename Fr>
+struct LowerSpatialFourVelocity : db::SimpleTag {
+  using type = tnsr::i<DataType, Dim, Fr>;
+};
+
 /// The vector \f$J^i\f$ in \f$\dot{M} = -\int J^i s_i d^2S\f$,
 /// representing the mass flux through a surface with normal \f$s_i\f$.
 ///

--- a/src/PointwiseFunctions/Hydro/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/Hydro/TagsDeclarations.hpp
@@ -60,6 +60,8 @@ template <typename DataType>
 struct SpecificEnthalpy;
 template <typename DataType>
 struct SpecificInternalEnergy;
+template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
+struct LowerSpatialFourVelocity;
 }  // namespace Tags
 /// \endcond
 

--- a/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
@@ -16,6 +16,7 @@
 #include "Evolution/DgSubcell/Tags/Jacobians.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/NeighborData.hpp"
+#include "Evolution/DgSubcell/Tags/OnSubcellFaces.hpp"
 #include "Evolution/DgSubcell/Tags/OnSubcells.hpp"
 #include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
 #include "Evolution/DgSubcell/Tags/TciGridHistory.hpp"
@@ -53,6 +54,12 @@ void test() {
   TestHelpers::db::test_simple_tag<
       evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToGrid<Dim>>(
       "InverseJacobian(Logical,Grid)");
+  TestHelpers::db::test_simple_tag<
+      evolution::dg::subcell::Tags::OnSubcellFaces<Var1, Dim>>(
+      "OnSubcellFaces(Var1)");
+  TestHelpers::db::test_simple_tag<evolution::dg::subcell::Tags::OnSubcellFaces<
+      ::Tags::Variables<tmpl::list<Var1, Var2>>, Dim>>(
+      "OnSubcellFaces(Variables(Var1,Var2))");
 
   TestHelpers::db::test_compute_tag<
       evolution::dg::subcell::Tags::LogicalCoordinatesCompute<Dim>>(

--- a/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
@@ -16,6 +16,7 @@
 #include "Evolution/DgSubcell/Tags/Jacobians.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/NeighborData.hpp"
+#include "Evolution/DgSubcell/Tags/OnSubcells.hpp"
 #include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
 #include "Evolution/DgSubcell/Tags/TciGridHistory.hpp"
 #include "Evolution/DgSubcell/Tags/TciStatus.hpp"
@@ -85,6 +86,11 @@ SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Tags",
   TestHelpers::db::test_simple_tag<evolution::dg::subcell::Tags::Inactive<
       ::Tags::Variables<tmpl::list<Var1, Var2>>>>(
       "Inactive(Variables(Var1,Var2))");
+  TestHelpers::db::test_simple_tag<
+      evolution::dg::subcell::Tags::OnSubcells<Var1>>("OnSubcells(Var1)");
+  TestHelpers::db::test_simple_tag<evolution::dg::subcell::Tags::OnSubcells<
+      ::Tags::Variables<tmpl::list<Var1, Var2>>>>(
+      "OnSubcells(Variables(Var1,Var2))");
   TestHelpers::db::test_simple_tag<
       evolution::dg::subcell::Tags::SubcellOptions>("SubcellOptions");
   TestHelpers::db::test_simple_tag<

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_Tags.cpp
@@ -75,5 +75,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Hydro.Tags", "[Unit][Hydro]") {
       hydro::Tags::SpecificInternalEnergy<DataVector>>(
       "SpecificInternalEnergy");
   TestHelpers::db::test_simple_tag<
+      hydro::Tags::LowerSpatialFourVelocity<DataVector, 3, Frame::Logical>>(
+      "LowerSpatialFourVelocity");
+  TestHelpers::db::test_simple_tag<
       hydro::Tags::MassFlux<DataVector, 3, Frame::Logical>>("Logical_MassFlux");
 }


### PR DESCRIPTION
## Proposed changes

These are tags needed for doing GRMHD. The `OnSubcells` will be used to mark the analytic spacetime variables as being the ones on the subcells. We also need spacetime vars on the subcell faces.

The `LowerSpatialFourVelocity` (`u_i`) will be what we reconstruct since this is what SpEC and most other (M)HD codes do nowadays.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
