### PR TITLE
Subcell: Prep GRMHD, var fixers return bool, add subcell dir to GRMHD, return status in recovery

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -56,3 +56,4 @@ target_link_libraries(
 add_subdirectory(BoundaryConditions)
 add_subdirectory(BoundaryCorrections)
 add_subdirectory(FiniteDifference)
+add_subdirectory(Subcell)

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.hpp
@@ -118,7 +118,8 @@ class FixConservatives {
                  gr::Tags::SpatialMetric<3>, gr::Tags::InverseSpatialMetric<3>,
                  gr::Tags::SqrtDetSpatialMetric<>>;
 
-  void operator()(
+  /// Returns `true` if any variables were fixed.
+  bool operator()(
       gsl::not_null<Scalar<DataVector>*> tilde_d,
       gsl::not_null<Scalar<DataVector>*> tilde_tau,
       gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*> tilde_s,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp
@@ -40,8 +40,12 @@ namespace ValenciaDivClean {
  * [Siegel {\em et al}, The Astrophysical Journal 859:71(2018)]
  * (http://iopscience.iop.org/article/10.3847/1538-4357/aabcc5/meta)
  * compares several inversion methods.
+ *
+ * If `ErrorOnFailure` is `false` then the returned `bool` will be `false` if
+ * recovery failed and `true` if it succeeded.
  */
-template <typename OrderedListOfPrimitiveRecoverySchemes>
+template <typename OrderedListOfPrimitiveRecoverySchemes,
+          bool ErrorOnFailure = true>
 struct PrimitiveFromConservative {
   using return_tags =
       tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
@@ -64,7 +68,7 @@ struct PrimitiveFromConservative {
                  hydro::Tags::EquationOfStateBase>;
 
   template <size_t ThermodynamicDim>
-  static void apply(
+  static bool apply(
       gsl::not_null<Scalar<DataVector>*> rest_mass_density,
       gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
       gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> spatial_velocity,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Subcell.hpp
+  )

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Subcell.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Subcell.hpp
@@ -1,0 +1,9 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace grmhd::ValenciaDivClean {
+/// \brief Code required by the DG-subcell/FD hybrid solver.
+namespace subcell {}
+}  // namespace grmhd::ValenciaDivClean

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_FixConservatives.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_FixConservatives.cpp
@@ -59,8 +59,8 @@ void test_variable_fixer(
     inv_spatial_metric.get(d, d) = get(sqrt_det_spatial_metric);
   }
 
-  variable_fixer(&tilde_d, &tilde_tau, &tilde_s, tilde_b, spatial_metric,
-                 inv_spatial_metric, sqrt_det_spatial_metric);
+  CHECK(variable_fixer(&tilde_d, &tilde_tau, &tilde_s, tilde_b, spatial_metric,
+                       inv_spatial_metric, sqrt_det_spatial_metric));
 
   CHECK_ITERABLE_APPROX(tilde_d, expected_tilde_d);
   CHECK_ITERABLE_APPROX(tilde_tau, expected_tilde_tau);


### PR DESCRIPTION
## Proposed changes

- Adds `ValenciadivClean/Subcell` directory. This is where things like the system-specific TCI will live.
- Make the GRMHD variable fixer return whether or not it fixed the conservative variables. We will use having to fix the conserved variables as a method of preventing returning to DG when we are on subcells. That is, if the FD solution needed fixing, there's no way the DG solution will work.
- Add ability for prim recovery schemes to return whether or not the recovered the vars. This is needed because with DG-subcell we will use failed prim recovery while on DG as a TCI and switch to subcell then.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
