### PR TITLE
Horizon finder can now fail gracefully

### DIFF
--- a/src/ApparentHorizons/FastFlow.cpp
+++ b/src/ApparentHorizons/FastFlow.cpp
@@ -318,6 +318,8 @@ std::ostream& operator<<(std::ostream& os,
       return os << "Failed: Negative radius";
     case FastFlow::Status::DivergenceError:
       return os << "Failed: Diverging";
+    case FastFlow::Status::InterpolationFailure:
+      return os << "Failed: Cannot interpolate onto surface";
     default:  // LCOV_EXCL_LINE
       // LCOV_EXCL_START
       ERROR("Need to add another case, don't understand value of 'status'");

--- a/src/ApparentHorizons/FastFlow.hpp
+++ b/src/ApparentHorizons/FastFlow.hpp
@@ -45,7 +45,8 @@ class FastFlow {
     // The following indicate errors.
     MaxIts = -1,
     NegativeRadius = -2,
-    DivergenceError = -3
+    DivergenceError = -3,
+    InterpolationFailure = -4
   };
 
   /// Holds information about an iteration of the algorithm.

--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -29,6 +29,13 @@ namespace ah::Tags {
 struct FastFlow : db::SimpleTag {
   using type = ::FastFlow;
 };
+/// Tag for holding the previously-found value of a Strahlkorper,
+/// which is saved for extrapolation for future initial guesses
+/// and for recovering the initial guess on failure of the algorithm.
+template <typename Frame>
+struct PreviousStrahlkorper : db::SimpleTag {
+  using type = ::Strahlkorper<Frame>;
+};
 }  // namespace ah::Tags
 
 /// \ingroup SurfacesGroup

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonicWithHorizon.hpp
@@ -16,6 +16,7 @@
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/RegisterDerived.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/RegisterDerivedWithCharm.hpp"
 #include "NumericalAlgorithms/Interpolation/AddTemporalIdsToInterpolationTarget.hpp"
+#include "NumericalAlgorithms/Interpolation/Callbacks/ErrorOnFailedApparentHorizon.hpp"
 #include "NumericalAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp"
 #include "NumericalAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp"
 #include "NumericalAlgorithms/Interpolation/CleanUpInterpolator.hpp"
@@ -75,6 +76,8 @@ struct EvolutionMetavars
         intrp::TargetPoints::ApparentHorizon<AhA, ::Frame::Inertial>;
     using post_interpolation_callback =
         intrp::callbacks::FindApparentHorizon<AhA, ::Frame::Inertial>;
+    using horizon_find_failure_callback =
+        intrp::callbacks::ErrorOnFailedApparentHorizon;
     using post_horizon_find_callback =
         intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, AhA, AhA>;
   };

--- a/src/NumericalAlgorithms/Interpolation/Callbacks/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Interpolation/Callbacks/CMakeLists.txt
@@ -6,6 +6,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Callbacks.hpp
+  ErrorOnFailedApparentHorizon.hpp
   FindApparentHorizon.hpp
   IgnoreFailedApparentHorizon.hpp
   ObserveTimeSeriesOnSurface.hpp

--- a/src/NumericalAlgorithms/Interpolation/Callbacks/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Interpolation/Callbacks/CMakeLists.txt
@@ -7,6 +7,7 @@ spectre_target_headers(
   HEADERS
   Callbacks.hpp
   FindApparentHorizon.hpp
+  IgnoreFailedApparentHorizon.hpp
   ObserveTimeSeriesOnSurface.hpp
   SendGhWorldtubeData.hpp
   )

--- a/src/NumericalAlgorithms/Interpolation/Callbacks/Callbacks.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Callbacks/Callbacks.hpp
@@ -8,5 +8,5 @@ namespace intrp {
  * \ingroup NumericalAlgorithmsGroup
  * \brief Contains callback functions called by `InterpolationTarget`s.
  */
-namespace callbacks;
+namespace callbacks {}
 }  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/Callbacks/ErrorOnFailedApparentHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Callbacks/ErrorOnFailedApparentHorizon.hpp
@@ -1,0 +1,37 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "ApparentHorizons/FastFlow.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/PrettyType.hpp"
+
+/// \cond
+namespace db {
+template <typename DbTags>
+class DataBox;
+}  // namespace db
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
+/// \endcond
+
+namespace intrp::callbacks {
+
+/// \brief Callback for a failed apparent horizon find that simply errors.
+struct ErrorOnFailedApparentHorizon {
+  template <typename InterpolationTargetTag, typename DbTags,
+            typename Metavariables, typename TemporalId>
+  static void apply(const db::DataBox<DbTags>& /*box*/,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const TemporalId& /*temporal_id*/,
+                    const FastFlow::Status failure_reason) noexcept {
+    ERROR("Apparent horizon finder "
+          << pretty_type::short_name<InterpolationTargetTag>()
+          << " failed, reason = " << failure_reason);
+  }
+};
+
+}  // namespace intrp::callbacks

--- a/src/NumericalAlgorithms/Interpolation/Callbacks/IgnoreFailedApparentHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Callbacks/IgnoreFailedApparentHorizon.hpp
@@ -1,0 +1,41 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "ApparentHorizons/FastFlow.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Informer/Tags.hpp"
+#include "Parallel/Printf.hpp"
+#include "Utilities/PrettyType.hpp"
+
+/// \cond
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
+/// \endcond
+
+namespace intrp::callbacks {
+
+/// \brief Callback for a failed apparent horizon find that prints a
+/// message (if sufficient Verbosity is enabled) but does not
+/// terminate the executable.
+struct IgnoreFailedApparentHorizon {
+  template <typename InterpolationTargetTag, typename DbTags,
+            typename Metavariables, typename TemporalId>
+  static void apply(const db::DataBox<DbTags>& box,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const TemporalId& /*temporal_id*/,
+                    const FastFlow::Status failure_reason) noexcept {
+    const auto& verbosity =
+        db::get<logging::Tags::Verbosity<InterpolationTargetTag>>(box);
+    if (verbosity > ::Verbosity::Quiet) {
+      Parallel::printf("Remark: Horizon finder %s failed, reason = %s\n",
+                       pretty_type::short_name<InterpolationTargetTag>(),
+                       failure_reason);
+    }
+  }
+};
+
+}  // namespace intrp::callbacks

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
@@ -144,14 +144,16 @@ struct ApparentHorizon {
   using initialization_tags =
       tmpl::append<StrahlkorperTags::items_tags<Frame>,
                    tmpl::list<::ah::Tags::FastFlow,
-                              logging::Tags::Verbosity<InterpolationTargetTag>>,
+                              logging::Tags::Verbosity<InterpolationTargetTag>,
+                              ::ah::Tags::PreviousStrahlkorper<Frame>>,
                    StrahlkorperTags::compute_items_tags<Frame>>;
   using is_sequential = std::true_type;
   using frame = Frame;
 
   using simple_tags =
       tmpl::push_back<StrahlkorperTags::items_tags<Frame>, ::ah::Tags::FastFlow,
-                      logging::Tags::Verbosity<InterpolationTargetTag>>;
+                      logging::Tags::Verbosity<InterpolationTargetTag>,
+                      ::ah::Tags::PreviousStrahlkorper<Frame>>;
   using compute_tags = typename StrahlkorperTags::compute_items_tags<Frame>;
 
   template <typename DbTags, typename Metavariables>
@@ -164,8 +166,10 @@ struct ApparentHorizon {
 
     // Put Strahlkorper and its ComputeItems, FastFlow,
     // and verbosity into a new DataBox.
+    // Put the initial guess also into PreviousStrahlkorper.
     Initialization::mutate_assign<simple_tags>(
-        box, options.initial_guess, options.fast_flow, options.verbosity);
+        box, options.initial_guess, options.fast_flow, options.verbosity,
+        options.initial_guess);
   }
 
   template <typename Metavariables, typename DbTags, typename TemporalId>

--- a/src/NumericalAlgorithms/Interpolation/Intrp.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Intrp.hpp
@@ -7,4 +7,4 @@
  * \ingroup NumericalAlgorithmsGroup
  * \brief Contains classes and functions for interpolation
  */
-namespace intrp;
+namespace intrp {}


### PR DESCRIPTION
## Proposed changes

Previously, failure of the horizon finder halted the code.  But for some horizons, such as AhC (the common horizon), the horizon doesn't exist for a large range of times that one might look for it, and this should not be an error.  For an AhC failure, the code should just continue on, and not print out any horizon finder output.

Now, there is a new type alias called `horizon_find_failure_callback` that can be specified inside the InterpolationTargetTag struct that is specified in the metavariables. That callback has an `apply` function that is called on failure.

There are two horizon_find_failure_callbacks: `ErrorOnFailedApparentHorizon`, which is what I put into EvolveGeneralizedHarmonic, and this errors on failure as before, and `IgnoreFailedApparentHorizon`, which prints a warning message that the horizon finder has failed and continues, restoring the Strahlkorper in the DataBox to its previous converged value (or the initial guess, if there is no previously converged value).

In the future it is easy to add more horizon_find_failure_callbacks.  For instance,  on failure of AhC one might want to print a warning if AhC has never been found before, but error if AhC has been found at earlier times but cannot be found at the current time; enough information is passed into `horizon_find_failure_callback` to do something like that.
### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

A type alias `horizon_find_failure_callback` must now be specified inside of each InterpolationTargetTag that also has a `post_horizon_find_callback`. 

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
