### PR TITLE
Temporarily disable charm inlining

### DIFF
--- a/src/Parallel/Algorithms/AlgorithmArray.ci
+++ b/src/Parallel/Algorithms/AlgorithmArray.ci
@@ -36,25 +36,35 @@ module AlgorithmArray {
     // instrumentation performed during charm entry method calls, while being
     // certain to avoid stack overflows.
 
+    // The charm [inline] flag has been temporarily removed from the following
+    // entry methods:
+    // - `simple action` (both overloads)
+    // - `perform_algorithm` (both overloads)
+    // - `receive_data`
+    // The [inline] has been removed because of a charm bug that causes inlined
+    // entry methods to not be instrumented for load-balancing.
+    // Once the charm fix is published and we have updated our support, the
+    // [inline] flag should be restored to the listed entry methods.
+    // Related charm pull request: https://github.com/UIUC-PPL/charm/pull/3352
+
     template <typename Action, typename... Args>
-    entry [inline] void simple_action(std::tuple<Args...> & args);
+    entry void simple_action(std::tuple<Args...> & args);
 
     template <typename Action>
-    entry [inline] void simple_action();
+    entry void simple_action();
 
     template <typename Action, typename Arg>
     entry[reductiontarget] void reduction_action(Arg arg);
 
-    entry [inline] void perform_algorithm();
+    entry void perform_algorithm();
 
-    entry [inline] void perform_algorithm(bool);
+    entry void perform_algorithm(bool);
 
     entry void start_phase(typename ParallelComponent::metavariables::Phase);
 
     template <typename ReceiveTag, typename ReceiveData_t>
-    entry [inline] void receive_data(typename ReceiveTag::temporal_id&,
-                                    ReceiveData_t&,
-                                    bool enable_if_disabled = false);
+    entry void receive_data(typename ReceiveTag::temporal_id&, ReceiveData_t&,
+                            bool enable_if_disabled = false);
 
     entry void set_terminate(bool);
   }

--- a/tools/CharmModulePatches/src/Parallel/Algorithms/AlgorithmArray.def.h.patch.unused
+++ b/tools/CharmModulePatches/src/Parallel/Algorithms/AlgorithmArray.def.h.patch.unused
@@ -1,5 +1,12 @@
 Distributed under the MIT License.
 See LICENSE.txt for details.
+This patch is currently unused because we have disabled charm inlining due to a
+Charm bug that causes inlined functions to not be instrumented for communication
+aware load balancers.
+This file should be renamed to `AlgorithmArray.def.h.patch` when re-enabling
+charm inlining, once the bug fix is applied to charm and we update to the
+appropriately fixed version.
+Related charm pull request: https://github.com/UIUC-PPL/charm/pull/3352
 --- AlgorithmArray.def.h	2021-04-01 14:42:23.928094971 -0700
 +++ alterations/AlgorithmArray.def.h	2021-04-01 14:44:19.599096051 -0700
 @@ -310,7 +310,7 @@


### PR DESCRIPTION
## Proposed changes

Because the instrumentation for communication-based balancers is not currently operating correctly for [inline] entry methods (https://github.com/UIUC-PPL/charm/pull/3352), I think it's better to ensure that the balancers work efficiently. This temporarily disables the charm inlining, and should be reverted as soon as we can propagate the charm changes necessary to have inline methods that are instrumented for the communication-based balancing.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
