### PR TITLE
Add scotch dependency

### DIFF
--- a/cmake/FindCharm.cmake
+++ b/cmake/FindCharm.cmake
@@ -97,6 +97,24 @@ if("${CHARM_EVERYLB}" STREQUAL "CHARM_EVERYLB-NOTFOUND")
     "Make sure you have built the LIBS target when building charm++")
 endif()
 
+option(USE_SCOTCH_LB "Use the charm++ ScotchLB module" OFF)
+
+if (USE_SCOTCH_LB)
+   find_library(CHARM_SCOTCHLB
+     NAMES moduleScotchLB
+     HINTS ${CHARM_LIBRARIES}
+     NO_DEFAULT_PATH
+     )
+
+   if("${CHARM_SCOTCHLB}" STREQUAL "CHARM_SCOTCHLB-NOTFOUND")
+     message(SEND_ERROR "Could not find charm module ScotchLB, "
+    "but building with cmake flag USE_SCOTCH_LB. Either be sure "
+    "to build Charm++ with ScotchLB support (it is an independent "
+    "Charm++ target), or build spectre without USE_SCOTCH_LB enabled")
+endif()
+
+endif ()
+
 find_program(CHARM_COMPILER
   NAMES charmc
   PATH_SUFFIXES bin

--- a/cmake/SetupCharm.cmake
+++ b/cmake/SetupCharm.cmake
@@ -26,9 +26,15 @@ endif(NOT TARGET Charmxx)
 # will call your normal compiler, set at charm++ installation time internally.
 # Note: The -pthread is necessary with Charm v6.10 to get linking working
 #       with GCC
+if (USE_SCOTCH_LB)
+  set(SCOTCH_LB_FLAG "-module ScotchLB")
+else()
+  set(SCOTCH_LB_FLAG "")
+endif()
+
 string(
     REGEX REPLACE "<CMAKE_CXX_COMPILER>"
-    "${CHARM_COMPILER} -pthread -module EveryLB -no-charmrun"
+    "${CHARM_COMPILER} -pthread -module EveryLB ${SCOTCH_LB_FLAG} -no-charmrun"
     CMAKE_CXX_LINK_EXECUTABLE "${CMAKE_CXX_LINK_EXECUTABLE}")
 
 # When building for trace analysis the PAPI counters passed to charmc

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -67,6 +67,8 @@ environment differently, read on!
 * [Clang-Tidy](http://clang.llvm.org/extra/clang-tidy/) — to "lint" C++ code
 * [Cppcheck](http://cppcheck.sourceforge.net/) — to analyze C++ code
 * [yapf](https://github.com/google/yapf) 0.29.0 - to format python code
+* [Scotch](https://gitlab.inria.fr/scotch/scotch) - to build the `ScotchLB`
+  graph partition based load balancer in charm++.
 
 ## Using Docker to obtain a SpECTRE environment
 


### PR DESCRIPTION
## Proposed changes

Adds the Scotch library as an optional dependency, and depending on a CMake flag, links in the `ScotchLB` module from charm.
Scotch is a particularly nice graph-partition library and seems to give pretty good results for large communication graphs in test problems

This also adds the support for the new build option for Caltech HPC; that build procedure can then be used as a rough guide for installation on other systems

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->
To use Scotch, follow a build procedure similar to that in the Caltech HPC environment file, and supply the `-D USE_SCOTCH_LB=ON` cmake flag.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
