### PR TITLE
Print contents of an uncaught exception.

### DIFF
--- a/src/Parallel/CMakeLists.txt
+++ b/src/Parallel/CMakeLists.txt
@@ -11,6 +11,7 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  InitializationFunctions.cpp
   NodeLock.cpp
   )
 

--- a/src/Parallel/InitializationFunctions.cpp
+++ b/src/Parallel/InitializationFunctions.cpp
@@ -1,0 +1,28 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Parallel/InitializationFunctions.hpp"
+
+#include <exception>
+
+#include "Utilities/ErrorHandling/Error.hpp"
+
+void setup_error_handling() {
+  std::set_terminate([]() {
+    std::exception_ptr exception = std::current_exception();
+    if (exception) {
+      try {
+        std::rethrow_exception(exception);
+      } catch (std::exception& ex) {
+        ERROR("Terminated due to an uncaught exception: " << ex.what());
+      } catch (...) {
+        ERROR("Terminated due to unknown exception\n");
+      }
+    } else {
+      ERROR(
+          "Terminate was called for an unknown reason (not an uncaught "
+          "exception), calling Charm++'s abort function to properly "
+          "terminate execution.");
+    }
+  });
+}

--- a/src/Parallel/InitializationFunctions.hpp
+++ b/src/Parallel/InitializationFunctions.hpp
@@ -7,10 +7,4 @@
 
 #include "Utilities/ErrorHandling/Error.hpp"
 
-inline void setup_error_handling() {
-  std::set_terminate([]() {
-    ERROR(
-        "Terminate was called, calling Charm++'s abort function to properly "
-        "terminate execution.");
-  });
-}
+void setup_error_handling();

--- a/tests/Unit/RunTests.cpp
+++ b/tests/Unit/RunTests.cpp
@@ -16,6 +16,7 @@
 
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Informer/InfoFromBuild.hpp"
+#include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Printf.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/System/Abort.hpp"
@@ -23,7 +24,7 @@
 #include "tests/Unit/RunTestsRegister.hpp"
 
 RunTests::RunTests(CkArgMsg* msg) {
-  std::set_terminate([]() { sys::abort("Called terminate. Aborting..."); });
+  setup_error_handling();
   register_run_tests_libs();
   Parallel::printf("%s", info_from_build().c_str());
   enable_floating_point_exceptions();


### PR DESCRIPTION
## Proposed changes

I think Blaze throws exceptions for errors, and while implementing subcell I've had size mismatches a number of times. Not printing the message in uncaught exceptions basically made it so that I had no idea why the code died. Now at least the exception message is printed.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
