### PR TITLE
Fix MagneticRotor documentation

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -1376,6 +1376,23 @@
   url      = "http://cdsads.u-strasbg.fr/abs/1999JCoPh.150..199Y",
 }
 
+@article{Zanotti2016efficient,
+  title =        {Efficient conservative ADER schemes based on WENO
+                  reconstruction and space-time predictor in primitive
+                  variables},
+  author =       {Zanotti, Olindo and Dumbser, Michael},
+  journal =      {Computational astrophysics and cosmology},
+  volume =       3,
+  number =       1,
+  pages =        {1--32},
+  year =         2016,
+  publisher =    {SpringerOpen},
+  doi = "10.1186/s40668-015-0014-x",
+  eprint         = "1511.04728",
+  archivePrefix  = "arXiv",
+  url = "https://arxiv.org/abs/1511.04728"
+}
+
 @article{Zhong2013,
   author   = "Zhong, Xinghui and Shu, Chi-Wang",
   title    = "A simple weighted essentially nonoscillatory limiter for

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.hpp
@@ -42,18 +42,26 @@ namespace AnalyticData {
  * magnetic braking will slow down the rotor, while dragging the magnetic field
  * lines.
  *
- * The standard test setup is done on a unit cube with the following values
- * given for the options:
+ * The standard test setup is done on a unit cube \f$[-0.5,0.5]^3\f$ with the
+ * following values given for the options:
  * -  RotorRadius: 0.1
  * -  RotorDensity: 10.0
  * -  BackgroundDensity: 1.0
  * -  Pressure: 1.0
  * -  AngularVelocity: 9.95
- * -  MagneticField: [3.54490770181103205, 0.0, 0.0]
+ * -  MagneticField: [1.0, 0.0, 0.0]
  * -  AdiabaticIndex: 1.66666666666666667
  *
- * The magnetic field in the disk should rotate by about 90 degrees by t = 0.4.
+ * Note that \cite Zanotti2016efficient uses different parameters,
+ * -  RotorRadius: 0.1
+ * -  RotorDensity: 10.0
+ * -  BackgroundDensity: 1.0
+ * -  Pressure: 1.0
+ * -  AngularVelocity: 9.3
+ * -  MagneticField: [1.0, 0.0, 0.0]
+ * -  AdiabaticIndex: 1.333333333333333
  *
+ * The magnetic field in the disk should rotate by about 90 degrees by t = 0.4.
  */
 class MagneticRotor : public MarkAsAnalyticData {
  public:


### PR DESCRIPTION
## Proposed changes

The documentation didn't give the domain size and gave the incorrect magnetic field value to reproduce the results from the cited paper. Additionally, some authors have decided to use slightly different values, so the added dox points this out.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
