### PR TITLE
Add Kastaun et al GRMHD primitive recovery scheme

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -827,6 +827,22 @@
   doi     = "10.1007/s10915-006-9105-9",
   url     = "https://doi.org/10.1007/s10915-006-9105-9"
 }
+@article{Kastaun2020uxr,
+  author =       "Kastaun, Wolfgang and Kalinani, Jay Vijay and Ciolfi,
+                  Riccardo",
+  title =        "{Robust Recovery of Primitive Variables in Relativistic Ideal
+                  Magnetohydrodynamics}",
+  eprint =       "2005.01821",
+  archivePrefix ="arXiv",
+  primaryClass = "gr-qc",
+  doi =          "10.1103/PhysRevD.103.023018",
+  url =          "https://doi.org/10.1103/PhysRevD.103.023018",
+  journal =      "Phys. Rev. D",
+  volume =       103,
+  number =       2,
+  pages =        023018,
+  year =         2021
+}
 
 @article{Kidder2001tz,
   author        = "Kidder, Lawrence E. and Scheel, Mark A. and

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -12,6 +12,7 @@ spectre_target_sources(
   ConservativeFromPrimitive.cpp
   FixConservatives.cpp
   Fluxes.cpp
+  KastaunEtAl.cpp
   NewmanHamlin.cpp
   PalenzuelaEtAl.cpp
   PrimitiveFromConservative.cpp
@@ -28,6 +29,7 @@ spectre_target_headers(
   ConservativeFromPrimitive.hpp
   FixConservatives.hpp
   Fluxes.hpp
+  KastaunEtAl.hpp
   NewmanHamlin.hpp
   PalenzuelaEtAl.hpp
   PrimitiveFromConservative.hpp

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.cpp
@@ -1,0 +1,351 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.hpp"
+
+#include <cmath>
+#include <exception>
+#include <limits>
+#include <optional>
+#include <stdexcept>
+#include <utility>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveRecoveryData.hpp"
+#include "NumericalAlgorithms/RootFinding/TOMS748.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes {
+
+namespace {
+
+// Equation (26)
+double compute_x(const double mu, const double b_squared) noexcept {
+  return 1.0 / (1.0 + mu * b_squared);
+}
+
+// Equation (38)
+double compute_r_bar_squared(const double mu, const double x,
+                             const double r_squared,
+                             const double r_dot_b_squared) noexcept {
+  return x * (r_squared * x + mu * (1.0 + x) * r_dot_b_squared);
+}
+
+// Equations (33) and (32)
+double compute_v_0_squared(const double r_squared, const double h_0) noexcept {
+  const double z_0_squared = r_squared / square(h_0);
+  return z_0_squared / (1.0 + z_0_squared);
+}
+
+struct Primitives {
+  const double rest_mass_density;
+  const double lorentz_factor;
+  const double pressure;
+  const double specific_internal_energy;
+  const double q_bar;
+  const double r_bar_squared;
+};
+
+// Function to tighten master function bracket in corner case discussed in
+// Appendix A when Equation (41) produces a rest mass density outside the
+// valid range of the EOS
+class CornerCaseFunction {
+ public:
+  CornerCaseFunction(const double w_target, const double r_squared,
+                     const double b_squared,
+                     const double r_dot_b_squared) noexcept
+      : v_squared_target_(1.0 - 1.0 / square(w_target)),
+        r_squared_(r_squared),
+        b_squared_(b_squared),
+        r_dot_b_squared_(r_dot_b_squared) {}
+
+  double operator()(const double mu) const noexcept {
+    const double x = compute_x(mu, b_squared_);
+    const double r_bar_squared =
+        compute_r_bar_squared(mu, x, r_squared_, r_dot_b_squared_);
+    // v = mu*r_bar, see text after Equation (31)
+    // target is v satisfying W(mu) = D/ rho_{min/max}
+    return square(mu) * r_bar_squared - v_squared_target_;
+  }
+
+ private:
+  const double v_squared_target_;
+  const double r_squared_;
+  const double b_squared_;
+  const double r_dot_b_squared_;
+};
+
+// Function whose root is upper bracket of master function, see Sec. II.F
+class AuxiliaryFunction {
+ public:
+  AuxiliaryFunction(const double h_0, const double r_squared,
+                    const double b_squared,
+                    const double r_dot_b_squared) noexcept
+      : h_0_(h_0),
+        r_squared_(r_squared),
+        b_squared_(b_squared),
+        r_dot_b_squared_(r_dot_b_squared) {}
+
+  double operator()(double mu) const noexcept {
+    const double x = compute_x(mu, b_squared_);
+    const double r_bar_squared =
+        compute_r_bar_squared(mu, x, r_squared_, r_dot_b_squared_);
+    // Equation (49)
+    return mu * sqrt(square(h_0_) + r_bar_squared) - 1.0;
+  }
+
+ private:
+  const double h_0_;
+  const double r_squared_;
+  const double b_squared_;
+  const double r_dot_b_squared_;
+};
+
+// Master function, see Equation (44) in Sec. II.E
+template <size_t ThermodynamicDim>
+class FunctionOfMu {
+ public:
+  FunctionOfMu(const double total_energy_density,
+               const double momentum_density_squared,
+               const double momentum_density_dot_magnetic_field,
+               const double magnetic_field_squared,
+               const double rest_mass_density_times_lorentz_factor,
+               const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+                   equation_of_state) noexcept
+      : q_(total_energy_density / rest_mass_density_times_lorentz_factor - 1.0),
+        r_squared_(momentum_density_squared /
+                   square(rest_mass_density_times_lorentz_factor)),
+        b_squared_(magnetic_field_squared /
+                   rest_mass_density_times_lorentz_factor),
+        r_dot_b_squared_(square(momentum_density_dot_magnetic_field) /
+                         cube(rest_mass_density_times_lorentz_factor)),
+        rest_mass_density_times_lorentz_factor_(
+            rest_mass_density_times_lorentz_factor),
+        equation_of_state_(equation_of_state),
+        h_0_(equation_of_state_.specific_enthalpy_lower_bound()),
+        v_0_squared_(compute_v_0_squared(r_squared_, h_0_)) {}
+
+  std::pair<double, double> root_bracket(
+      double rest_mass_density_times_lorentz_factor, double absolute_tolerance,
+      double relative_tolerance, size_t max_iterations) const;
+
+  Primitives primitives(double mu) const noexcept;
+
+  double operator()(const double mu) const noexcept;
+
+ private:
+  const double q_;
+  const double r_squared_;
+  const double b_squared_;
+  const double r_dot_b_squared_;
+  const double rest_mass_density_times_lorentz_factor_;
+  const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+      equation_of_state_;
+  const double h_0_;
+  const double v_0_squared_;
+};
+
+template <size_t ThermodynamicDim>
+std::pair<double, double> FunctionOfMu<ThermodynamicDim>::root_bracket(
+    const double rest_mass_density_times_lorentz_factor,
+    const double absolute_tolerance, const double relative_tolerance,
+    const size_t max_iterations) const {
+  // see text between Equations (49) and (50) and after Equation (54)
+  double lower_bound = 0.0;
+  double upper_bound =
+      0.0 == h_0_ ? std::numeric_limits<double>::max() : 1.0 / h_0_;
+  if (r_squared_ < square(h_0_)) {
+    // need to solve auxiliary function to determine mu_+ which will
+    // be the upper bound for the master function bracket
+    const auto auxiliary_function =
+        AuxiliaryFunction{h_0_, r_squared_, b_squared_, r_dot_b_squared_};
+    upper_bound =
+        // NOLINTNEXTLINE(clang-analyzer-core)
+        RootFinder::toms748(auxiliary_function, lower_bound, upper_bound,
+                            absolute_tolerance, relative_tolerance,
+                            max_iterations);
+  }
+
+  // Determine if the corner case discussed in Appendix A occurs where the
+  // mass density is outside the valid range of the EOS
+  const double rho_min = equation_of_state_.rest_mass_density_lower_bound();
+  const double rho_max = equation_of_state_.rest_mass_density_upper_bound();
+
+  // If this is triggering, the most likely cause is that the density cutoff
+  // for atmosphere is smaller than the minimum density of the EOS, i.e. this
+  // point should have been flagged as atmosphere
+  if (rest_mass_density_times_lorentz_factor < rho_min) {
+    throw std::runtime_error("Density too small for EOS");
+  }
+
+  const double mu_b = upper_bound;
+  const double x = compute_x(mu_b, b_squared_);
+  const double r_bar_squared =
+      compute_r_bar_squared(mu_b, x, r_squared_, r_dot_b_squared_);
+  // Equation (40)
+  const double v_hat_squared =
+      std::min(square(mu_b) * r_bar_squared, v_0_squared_);
+  const double w_hat = 1.0 / sqrt(1.0 - v_hat_squared);
+
+  // If this is being triggered, the only possible recourse would be
+  // to limit the rest mass density to the maximum value allowed by the
+  // EOS.  This seems questionable, so it is treated as an inversion failure.
+  // The exception should be caught by the try-catch in apply() which will
+  // return std::nullopt
+  if (rest_mass_density_times_lorentz_factor / w_hat > rho_max) {
+    throw std::runtime_error("Density too big for EOS");
+  }
+
+  if (rest_mass_density_times_lorentz_factor / w_hat < rho_min) {
+    // adjust lower bound
+    const auto corner_case_function =
+        CornerCaseFunction{rest_mass_density_times_lorentz_factor / rho_max,
+                           r_squared_, b_squared_, r_dot_b_squared_};
+    lower_bound = std::max(
+        lower_bound, RootFinder::toms748(corner_case_function, lower_bound,
+                                         upper_bound, absolute_tolerance,
+                                         relative_tolerance, max_iterations));
+  }
+
+  if (rho_max < rest_mass_density_times_lorentz_factor) {
+    // adjust upper bound
+    const auto corner_case_function =
+        CornerCaseFunction{rest_mass_density_times_lorentz_factor / rho_min,
+                           r_squared_, b_squared_, r_dot_b_squared_};
+    upper_bound = std::min(
+        upper_bound, RootFinder::toms748(corner_case_function, lower_bound,
+                                         upper_bound, absolute_tolerance,
+                                         relative_tolerance, max_iterations));
+  }
+
+  return {lower_bound, upper_bound};
+}
+
+template <size_t ThermodynamicDim>
+Primitives FunctionOfMu<ThermodynamicDim>::primitives(const double mu) const
+    noexcept {
+  // Equation (26)
+  const double x = compute_x(mu, b_squared_);
+  // Equations(38)
+  const double r_bar_squared =
+      compute_r_bar_squared(mu, x, r_squared_, r_dot_b_squared_);
+  // Equation (40)
+  const double v_hat_squared =
+      std::min(square(mu) * r_bar_squared, v_0_squared_);
+  const double w_hat = 1.0 / sqrt(1.0 - v_hat_squared);
+  // Equation (41) with bounds from Equation (5)
+  const double rho_hat =
+      std::clamp(rest_mass_density_times_lorentz_factor_ / w_hat,
+                 equation_of_state_.rest_mass_density_lower_bound(),
+                 equation_of_state_.rest_mass_density_upper_bound());
+  // Equations (39) and (25)
+  const double q_bar =
+      q_ - 0.5 * b_squared_ -
+      0.5 * square(mu * x) * (r_squared_ * b_squared_ - r_dot_b_squared_);
+  // Equation (42) with bounds from Equation (6)
+  const double epsilon_hat = std::clamp(
+      w_hat * (q_bar - mu * r_bar_squared) +
+          v_hat_squared * square(w_hat) / (1.0 + w_hat),
+      equation_of_state_.specific_internal_energy_lower_bound(rho_hat),
+      equation_of_state_.specific_internal_energy_upper_bound(rho_hat));
+  // Pressure from EOS
+  double p_hat = std::numeric_limits<double>::signaling_NaN();
+  if constexpr (ThermodynamicDim == 1) {
+    p_hat =
+        get(equation_of_state_.pressure_from_density(Scalar<double>(rho_hat)));
+  } else if constexpr (ThermodynamicDim == 2) {
+    p_hat = get(equation_of_state_.pressure_from_density_and_energy(
+        Scalar<double>(rho_hat), Scalar<double>(epsilon_hat)));
+  }
+  return Primitives{rho_hat, w_hat, p_hat, epsilon_hat, q_bar, r_bar_squared};
+}
+
+template <size_t ThermodynamicDim>
+double FunctionOfMu<ThermodynamicDim>::operator()(const double mu) const
+    noexcept {
+  const auto [rho_hat, w_hat, p_hat, epsilon_hat, q_bar, r_bar_squared] =
+      primitives(mu);
+  // Equation (43)
+  const double a_hat = p_hat / (rho_hat * (1.0 + epsilon_hat));
+  const double h_hat = (1.0 + epsilon_hat) * (1.0 + a_hat);
+  // Equations (46) - (48)
+  const double nu_hat = std::max(
+      h_hat / w_hat, (1.0 + a_hat) * (1.0 + q_bar - mu * r_bar_squared));
+  // Equations (44) - (45)
+  return mu - 1.0 / (nu_hat + mu * r_bar_squared);
+}
+}  // namespace
+
+template <size_t ThermodynamicDim>
+std::optional<PrimitiveRecoveryData> KastaunEtAl::apply(
+    const double /*initial_guess_pressure*/, const double total_energy_density,
+    const double momentum_density_squared,
+    const double momentum_density_dot_magnetic_field,
+    const double magnetic_field_squared,
+    const double rest_mass_density_times_lorentz_factor,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+        equation_of_state) noexcept {
+  // Master function see Equation (44)
+  const auto f_of_mu =
+      FunctionOfMu<ThermodynamicDim>{total_energy_density,
+                                     momentum_density_squared,
+                                     momentum_density_dot_magnetic_field,
+                                     magnetic_field_squared,
+                                     rest_mass_density_times_lorentz_factor,
+                                     equation_of_state};
+
+  // mu is 1 / (h W) see Equation (26)
+  double one_over_specific_enthalpy_times_lorentz_factor =
+      std::numeric_limits<double>::signaling_NaN();
+  try {
+    // Bracket for master function, see Sec. II.F
+    const auto [lower_bound, upper_bound] = f_of_mu.root_bracket(
+        rest_mass_density_times_lorentz_factor, absolute_tolerance_,
+        relative_tolerance_, max_iterations_);
+
+    // Try to recover primitves
+    one_over_specific_enthalpy_times_lorentz_factor =
+        // NOLINTNEXTLINE(clang-analyzer-core)
+        RootFinder::toms748(f_of_mu, lower_bound, upper_bound,
+                            absolute_tolerance_, relative_tolerance_,
+                            max_iterations_);
+  } catch (std::exception& exception) {
+    return std::nullopt;
+  }
+
+  const auto [rest_mass_density, lorentz_factor, pressure,
+              specific_internal_energy, q_bar, r_bar_squared] =
+      f_of_mu.primitives(one_over_specific_enthalpy_times_lorentz_factor);
+
+  (void)(specific_internal_energy);
+  (void)(q_bar);
+  (void)(r_bar_squared);
+
+  return PrimitiveRecoveryData{
+      rest_mass_density, lorentz_factor, pressure,
+      rest_mass_density_times_lorentz_factor /
+          one_over_specific_enthalpy_times_lorentz_factor};
+}
+}  // namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes
+
+#define THERMODIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define INSTANTIATION(_, data)                                                \
+  template std::optional<grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::  \
+                             PrimitiveRecoveryData>                           \
+  grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl::apply<      \
+      THERMODIM(data)>(                                                       \
+      const double initial_guess_pressure, const double total_energy_density, \
+      const double momentum_density_squared,                                  \
+      const double momentum_density_dot_magnetic_field,                       \
+      const double magnetic_field_squared,                                    \
+      const double rest_mass_density_times_lorentz_factor,                    \
+      const EquationsOfState::EquationOfState<true, THERMODIM(data)>&         \
+          equation_of_state) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
+
+#undef INSTANTIATION
+#undef THERMODIM

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.hpp
@@ -1,0 +1,72 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <limits>
+#include <optional>
+#include <string>
+
+/// \cond
+namespace EquationsOfState {
+template <bool, size_t>
+class EquationOfState;
+}  // namespace EquationsOfState
+/// \endcond
+
+namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes {
+
+/// \cond
+struct PrimitiveRecoveryData;
+/// \endcond
+
+/*!
+ * \brief Compute the primitive variables from the conservative variables using
+ * the scheme of \cite Kastaun2020uxr.
+ *
+ * In the notation of the Kastaun paper, `total_energy_density` is \f$D
+ * (1+q)\f$, `momentum_density_squared` is \f$r^2 D^2\f$,
+ * `momentum_density_dot_magnetic_field` is \f$t D^{\frac{3}{2}}\f$,
+ * `magnetic_field_squared` is \f$s D\f$, and
+ * `rest_mass_density_times_lorentz_factor` is \f$D\f$.
+ * Furthermore, the returned `PrimitiveRecoveryData.rho_h_w_squared` is \f$x
+ * D\f$.
+ *
+ * In terms of the conservative variables (in our notation):
+ * \f{align*}
+ * q = & \frac{{\tilde \tau}}{{\tilde D}} \\
+ * r = & \frac{\gamma^{kl} {\tilde S}_k {\tilde S}_l}{{\tilde D}^2} \\
+ * t^2 = & \frac{({\tilde B}^k {\tilde S}_k)^2}{{\tilde D}^3 \sqrt{\gamma}} \\
+ * s = & \frac{\gamma_{kl} {\tilde B}^k {\tilde B}^l}{{\tilde D}\sqrt{\gamma}}
+ * \f}
+ *
+ * where the conserved variables \f${\tilde D}\f$, \f${\tilde S}_i\f$,
+ * \f${\tilde \tau}\f$, and \f${\tilde B}^i\f$ are a generalized mass-energy
+ * density, momentum density, specific internal energy density, and magnetic
+ * field, and \f$\gamma\f$ and \f$\gamma^{kl}\f$ are the determinant and inverse
+ * of the spatial metric \f$\gamma_{kl}\f$.
+ *
+ * \note This scheme does not use the initial guess for the pressure.
+ */
+class KastaunEtAl {
+ public:
+  template <size_t ThermodynamicDim>
+  static std::optional<PrimitiveRecoveryData> apply(
+      double initial_guess_pressure, double total_energy_density,
+      double momentum_density_squared,
+      double momentum_density_dot_magnetic_field, double magnetic_field_squared,
+      double rest_mass_density_times_lorentz_factor,
+      const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+          equation_of_state) noexcept;
+
+  static const std::string name() noexcept { return "KastaunEtAl"; }
+
+ private:
+  static constexpr size_t max_iterations_ = 100;
+  static constexpr double absolute_tolerance_ =
+      10.0 * std::numeric_limits<double>::epsilon();
+  static constexpr double relative_tolerance_ =
+      10.0 * std::numeric_limits<double>::epsilon();
+};
+}  // namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
@@ -13,6 +13,7 @@
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp"  // IWYU pragma: keep
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.hpp"  // IWYU pragma: keep
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveRecoveryData.hpp"
@@ -231,6 +232,8 @@ GENERATE_INSTANTIATIONS(
 GENERATE_INSTANTIATIONS(
     INSTANTIATION,
     (tmpl::list<
+         grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl>,
+     tmpl::list<
          grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin>,
      tmpl::list<
          grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::PalenzuelaEtAl>,

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.cpp
@@ -15,8 +15,8 @@ template <bool IsRelativistic>
 DarkEnergyFluid<IsRelativistic>::DarkEnergyFluid(
     const double parameter_w) noexcept
     : parameter_w_(parameter_w) {
-  if (parameter_w_ <= 0.0) {
-    ERROR("The w(z) parameter must be positive.");
+  if (parameter_w_ <= 0.0 or parameter_w_ > 1.0) {
+    ERROR("The w(z) parameter must be positive, but less than one");
   }
 }
 

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.hpp
@@ -48,6 +48,8 @@ class DarkEnergyFluid : public EquationOfState<IsRelativistic, 2> {
   struct ParameterW {
     using type = double;
     static constexpr Options::String help = {"Parameter w(z)"};
+    static double lower_bound() noexcept { return 0.0; }
+    static double upper_bound() noexcept { return 1.0; }
   };
 
   static constexpr Options::String help = {
@@ -72,6 +74,31 @@ class DarkEnergyFluid : public EquationOfState<IsRelativistic, 2> {
 
   WRAPPED_PUPable_decl_base_template(  // NOLINT
       SINGLE_ARG(EquationOfState<IsRelativistic, 2>), DarkEnergyFluid);
+
+  /// The lower bound of the rest mass density that is valid for this EOS
+  double rest_mass_density_lower_bound() const noexcept override { return 0.0; }
+
+  /// The upper bound of the rest mass density that is valid for this EOS
+  double rest_mass_density_upper_bound() const noexcept override {
+    return std::numeric_limits<double>::max();
+  }
+
+  /// The lower bound of the specific internal energy that is valid for this EOS
+  /// at the given rest mass density \f$\rho\f$
+  double specific_internal_energy_lower_bound(
+      const double /* rest_mass_density */) const noexcept override {
+    return -1.0;
+  }
+
+  /// The upper bound of the specific internal energy that is valid for this EOS
+  /// at the given rest mass density \f$\rho\f$
+  double specific_internal_energy_upper_bound(
+      const double /* rest_mass_density */) const noexcept override {
+    return std::numeric_limits<double>::max();
+  }
+
+  /// The lower bound of the specific enthalpy that is valid for this EOS
+  double specific_enthalpy_lower_bound() const noexcept override { return 0.0; }
 
  private:
   EQUATION_OF_STATE_FORWARD_DECLARE_MEMBER_IMPLS(2)

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp
@@ -157,6 +157,25 @@ class EquationOfState<IsRelativistic, 1>
       const Scalar<double>& /*rest_mass_density*/) const noexcept = 0;
   virtual Scalar<DataVector> kappa_times_p_over_rho_squared_from_density(
       const Scalar<DataVector>& /*rest_mass_density*/) const noexcept = 0;
+
+  /// The lower bound of the rest mass density that is valid for this EOS
+  virtual double rest_mass_density_lower_bound() const noexcept = 0;
+
+  /// The upper bound of the rest mass density that is valid for this EOS
+  virtual double rest_mass_density_upper_bound() const noexcept = 0;
+
+  /// The lower bound of the specific internal energy that is valid for this EOS
+  /// at the given rest mass density \f$\rho\f$
+  virtual double specific_internal_energy_lower_bound(
+      const double rest_mass_density) const noexcept = 0;
+
+  /// The upper bound of the specific internal energy that is valid for this EOS
+  /// at the given rest mass density \f$\rho\f$
+  virtual double specific_internal_energy_upper_bound(
+      const double rest_mass_density) const noexcept = 0;
+
+  /// The lower bound of the specific enthalpy that is valid for this EOS
+  virtual double specific_enthalpy_lower_bound() const noexcept = 0;
 };
 
 /*!
@@ -229,7 +248,7 @@ class EquationOfState<IsRelativistic, 2>
   // @{
   /*!
    * Computes the specific internal energy \f$\epsilon\f$ from the rest mass
-   * density \f$\rho\f$ and the pressure \f$pn\f$.
+   * density \f$\rho\f$ and the pressure \f$p\f$.
    */
   virtual Scalar<double> specific_internal_energy_from_density_and_pressure(
       const Scalar<double>& /*rest_mass_density*/,
@@ -275,6 +294,25 @@ class EquationOfState<IsRelativistic, 2>
       const Scalar<DataVector>& /*specific_internal_energy*/) const
       noexcept = 0;
   // @}
+
+  /// The lower bound of the rest mass density that is valid for this EOS
+  virtual double rest_mass_density_lower_bound() const noexcept = 0;
+
+  /// The upper bound of the rest mass density that is valid for this EOS
+  virtual double rest_mass_density_upper_bound() const noexcept = 0;
+
+  /// The lower bound of the specific internal energy that is valid for this EOS
+  /// at the given rest mass density \f$\rho\f$
+  virtual double specific_internal_energy_lower_bound(
+      const double rest_mass_density) const noexcept = 0;
+
+  /// The upper bound of the specific internal energy that is valid for this EOS
+  /// at the given rest mass density \f$\rho\f$
+  virtual double specific_internal_energy_upper_bound(
+      const double rest_mass_density) const noexcept = 0;
+
+  /// The lower bound of the specific enthalpy that is valid for this EOS
+  virtual double specific_enthalpy_lower_bound() const noexcept = 0;
 };
 }  // namespace EquationsOfState
 

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.cpp
@@ -3,6 +3,8 @@
 
 #include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
 
+#include <limits>
+
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/ConstantExpressions.hpp"
@@ -104,6 +106,18 @@ Scalar<DataType> IdealFluid<IsRelativistic>::
         const Scalar<DataType>& specific_internal_energy) const noexcept {
   return Scalar<DataType>{square(adiabatic_index_ - 1.0) *
                           get(specific_internal_energy)};
+}
+
+template <bool IsRelativistic>
+double IdealFluid<IsRelativistic>::specific_internal_energy_upper_bound(
+    const double /* rest_mass_density */) const noexcept {
+  // this bound comes from the dominant energy condition which implies
+  // that the pressure is bounded by the total energy density,
+  // i.e. p < e = rho * (1 + eps)
+  if (IsRelativistic and adiabatic_index_ > 2.0) {
+    return 1.0 / (adiabatic_index_ - 2.0);
+  }
+  return std::numeric_limits<double>::max();
 }
 }  // namespace EquationsOfState
 

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp
@@ -69,6 +69,31 @@ class IdealFluid : public EquationOfState<IsRelativistic, 2> {
   WRAPPED_PUPable_decl_base_template(  // NOLINT
       SINGLE_ARG(EquationOfState<IsRelativistic, 2>), IdealFluid);
 
+  /// The lower bound of the rest mass density that is valid for this EOS
+  double rest_mass_density_lower_bound() const noexcept override { return 0.0; }
+
+  /// The upper bound of the rest mass density that is valid for this EOS
+  double rest_mass_density_upper_bound() const noexcept override {
+    return std::numeric_limits<double>::max();
+  }
+
+  /// The lower bound of the specific internal energy that is valid for this EOS
+  /// at the given rest mass density \f$\rho\f$
+  double specific_internal_energy_lower_bound(
+      const double /* rest_mass_density */) const noexcept override {
+    return 0.0;
+  }
+
+  /// The upper bound of the specific internal energy that is valid for this EOS
+  /// at the given rest mass density \f$\rho\f$
+  double specific_internal_energy_upper_bound(double rest_mass_density) const
+      noexcept override;
+
+  /// The lower bound of the specific enthalpy that is valid for this EOS
+  double specific_enthalpy_lower_bound() const noexcept override {
+    return IsRelativistic ? 1.0 : 0.0;
+  }
+
  private:
   EQUATION_OF_STATE_FORWARD_DECLARE_MEMBER_IMPLS(2)
 

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.cpp
@@ -3,6 +3,9 @@
 
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
 
+#include <cmath>
+#include <limits>
+
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/MakeWithValue.hpp"
@@ -106,6 +109,20 @@ Scalar<DataType> PolytropicFluid<IsRelativistic>::
     kappa_times_p_over_rho_squared_from_density_impl(
         const Scalar<DataType>& rest_mass_density) const noexcept {
   return make_with_value<Scalar<DataType>>(get(rest_mass_density), 0.0);
+}
+
+template <bool IsRelativistic>
+double PolytropicFluid<IsRelativistic>::rest_mass_density_upper_bound() const
+    noexcept {
+  // this bound comes from the dominant energy condition which implies
+  // that the pressure is bounded by the total energy density,
+  // i.e. p < e = rho * (1 + eps)
+  if (IsRelativistic and polytropic_exponent_ > 2.0) {
+    return pow((polytropic_exponent_ - 1.0) /
+                   (polytropic_constant_ * (polytropic_exponent_ - 2.0)),
+               1.0 / (polytropic_exponent_ - 1.0));
+  }
+  return std::numeric_limits<double>::max();
 }
 }  // namespace EquationsOfState
 

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp
@@ -77,6 +77,31 @@ class PolytropicFluid : public EquationOfState<IsRelativistic, 1> {
   WRAPPED_PUPable_decl_base_template(  // NOLINT
       SINGLE_ARG(EquationOfState<IsRelativistic, 1>), PolytropicFluid);
 
+  /// The lower bound of the rest mass density that is valid for this EOS
+  double rest_mass_density_lower_bound() const noexcept override { return 0.0; }
+
+  /// The upper bound of the rest mass density that is valid for this EOS
+  double rest_mass_density_upper_bound() const noexcept override;
+
+  /// The lower bound of the specific internal energy that is valid for this EOS
+  /// at the given rest mass density \f$\rho\f$
+  double specific_internal_energy_lower_bound(
+      const double /* rest_mass_density */) const noexcept override {
+    return 0.0;
+  }
+
+  /// The upper bound of the specific internal energy that is valid for this EOS
+  /// at the given rest mass density \f$\rho\f$
+  double specific_internal_energy_upper_bound(
+      const double /* rest_mass_density */) const noexcept override {
+    return std::numeric_limits<double>::max();
+  }
+
+  /// The lower bound of the specific enthalpy that is valid for this EOS
+  double specific_enthalpy_lower_bound() const noexcept override {
+    return IsRelativistic ? 1.0 : 0.0;
+  }
+
  private:
   EQUATION_OF_STATE_FORWARD_DECLARE_MEMBER_IMPLS(1)
 

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_PrimitiveFromConservative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_PrimitiveFromConservative.cpp
@@ -12,6 +12,9 @@
 #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PalenzuelaEtAl.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/PointwiseFunctions/GeneralRelativity/TestHelpers.hpp"
@@ -28,6 +31,7 @@
 // IWYU pragma: no_forward_declare Tensor
 
 namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes {
+class KastaunEtAl;
 class NewmanHamlin;
 class PalenzuelaEtAl;
 }  // namespace grmhd::ValenciaDivClean::PrimitiveRecoverySchemes
@@ -236,6 +240,8 @@ SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.PrimitiveFromConservative",
   test_primitive_from_conservative_known<tmpl::list<
       grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::PalenzuelaEtAl>>(dv);
   test_primitive_from_conservative_known<tmpl::list<
+      grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl>>(dv);
+  test_primitive_from_conservative_known<tmpl::list<
       grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin>>(dv);
   test_primitive_from_conservative_random<
       tmpl::list<
@@ -252,5 +258,13 @@ SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.PrimitiveFromConservative",
   test_primitive_from_conservative_random<
       tmpl::list<
           grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::PalenzuelaEtAl>,
+      2>(&generator, ideal_fluid, dv);
+  test_primitive_from_conservative_random<
+      tmpl::list<
+          grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl>,
+      1>(&generator, polytropic_fluid, dv);
+  test_primitive_from_conservative_random<
+      tmpl::list<
+          grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl>,
       2>(&generator, ideal_fluid, dv);
 }

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_DarkEnergyFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_DarkEnergyFluid.cpp
@@ -12,9 +12,20 @@
 #include "Framework/TestCreation.hpp"
 #include "Helpers/PointwiseFunctions/Hydro/EquationsOfState/TestHelpers.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 
-// IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
+namespace {
+void check_bounds() noexcept {
+  const auto eos = EquationsOfState::DarkEnergyFluid<true>{1.0};
+  CHECK(0.0 == eos.rest_mass_density_lower_bound());
+  CHECK(-1.0 == eos.specific_internal_energy_lower_bound(1.0));
+  CHECK(0.0 == eos.specific_enthalpy_lower_bound());
+  const double max_double = std::numeric_limits<double>::max();
+  CHECK(max_double == eos.rest_mass_density_upper_bound());
+  CHECK(max_double == eos.specific_internal_energy_upper_bound(1.0));
+}
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.DarkEnergyFluid",
                   "[Unit][EquationsOfState]") {
@@ -62,4 +73,6 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.DarkEnergyFluid",
           {"DarkEnergyFluid:\n"
            "  ParameterW: 0.3333333333333333\n"}),
       "dark_energy_fluid", dv_for_size, 1.0 / 3.0);
+
+  check_bounds();
 }

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_IdealFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_IdealFluid.cpp
@@ -5,16 +5,57 @@
 
 #include <limits>
 #include <pup.h>
+#include <random>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
 #include "Helpers/PointwiseFunctions/Hydro/EquationsOfState/TestHelpers.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
 
-// IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
+namespace {
+// check that pressure equals energy density at upper bound of specific
+// internal energy for adiabatic index > 2
+void check_dominant_energy_condition_at_bound() noexcept {
+  const auto seed = std::random_device{}();
+  MAKE_GENERATOR(generator, seed);
+  CAPTURE(seed);
+  auto distribution = std::uniform_real_distribution<>{2.0, 3.0};
+  const double adiabatic_index = distribution(generator);
+  const double rest_mass_density = distribution(generator);
+  const auto eos = EquationsOfState::IdealFluid<true>{adiabatic_index};
+  const double specific_internal_energy =
+      eos.specific_internal_energy_upper_bound(rest_mass_density);
+  const double pressure = get(eos.pressure_from_density_and_energy(
+      Scalar<double>{rest_mass_density},
+      Scalar<double>{specific_internal_energy}));
+  const double energy_density =
+      rest_mass_density * (1.0 + specific_internal_energy);
+  CAPTURE(rest_mass_density);
+  CAPTURE(specific_internal_energy);
+  CHECK(approx(pressure) == energy_density);
+}
+
+template <bool IsRelativistic>
+void check_bounds() noexcept {
+  const auto eos = EquationsOfState::IdealFluid<IsRelativistic>{1.5};
+  CHECK(0.0 == eos.rest_mass_density_lower_bound());
+  CHECK(0.0 == eos.specific_internal_energy_lower_bound(1.0));
+  if constexpr (IsRelativistic) {
+    CHECK(1.0 == eos.specific_enthalpy_lower_bound());
+  } else {
+    CHECK(0.0 == eos.specific_enthalpy_lower_bound());
+  }
+  const double max_double = std::numeric_limits<double>::max();
+  CHECK(max_double == eos.rest_mass_density_upper_bound());
+  CHECK(max_double == eos.specific_internal_energy_upper_bound(1.0));
+}
+
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.IdealFluid",
                   "[Unit][EquationsOfState]") {
@@ -61,4 +102,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.IdealFluid",
           {"IdealFluid:\n"
            "  AdiabaticIndex: 1.3333333333333333\n"}),
       "ideal_fluid", dv_for_size, 4.0 / 3.0);
+
+  check_bounds<true>();
+  check_bounds<false>();
+  check_dominant_energy_condition_at_bound();
 }


### PR DESCRIPTION
## Proposed changes

Add GRMHD primitive recovery scheme from Kastaun et al (2021)

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->

This is a new primitive recovery scheme.  
To enable it in a GRMHD executable, add `grmhd::ValenciaDivClean::KastaunEtAl` to the `ordered_list_of_primitive_recovery_schemes` in the metavariables.

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
