### PR TITLE
Add Rusanov boundary correction to ScalarAdvection

### DIFF
--- a/src/Evolution/Systems/ScalarAdvection/BoundaryCorrections/BoundaryCorrection.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/BoundaryCorrections/BoundaryCorrection.hpp
@@ -1,0 +1,44 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <pup.h>
+
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// Boundary corrections/numerical fluxes
+namespace ScalarAdvection::BoundaryCorrections {
+/// \cond
+template <size_t Dim>
+class Rusanov;
+/// \endcond
+
+/*!
+ * \brief The base class used to create boundary corrections from input files
+ * and store them in the global cache.
+ */
+template <size_t Dim>
+class BoundaryCorrection : public PUP::able {
+ public:
+  BoundaryCorrection() = default;
+  BoundaryCorrection(const BoundaryCorrection&) = default;
+  BoundaryCorrection& operator=(const BoundaryCorrection&) = default;
+  BoundaryCorrection(BoundaryCorrection&&) = default;
+  BoundaryCorrection& operator=(BoundaryCorrection&&) = default;
+  ~BoundaryCorrection() override = default;
+
+  /// \cond
+  explicit BoundaryCorrection(CkMigrateMessage* msg) noexcept
+      : PUP::able(msg) {}
+  WRAPPED_PUPable_abstract(BoundaryCorrection<Dim>);  // NOLINT
+  /// \endcond
+
+  using creatable_classes = tmpl::list<Rusanov<Dim>>;
+
+  virtual std::unique_ptr<BoundaryCorrection<Dim>> get_clone()
+      const noexcept = 0;
+};
+}  // namespace ScalarAdvection::BoundaryCorrections

--- a/src/Evolution/Systems/ScalarAdvection/BoundaryCorrections/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarAdvection/BoundaryCorrections/CMakeLists.txt
@@ -4,10 +4,16 @@
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  RegisterDerived.cpp
+  Rusanov.cpp
   )
 
 spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  BoundaryCorrection.hpp
+  Factory.hpp
+  RegisterDerived.hpp
+  Rusanov.hpp
   )

--- a/src/Evolution/Systems/ScalarAdvection/BoundaryCorrections/Factory.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/BoundaryCorrections/Factory.hpp
@@ -1,0 +1,7 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/Systems/ScalarAdvection/BoundaryCorrections/BoundaryCorrection.hpp"
+#include "Evolution/Systems/ScalarAdvection/BoundaryCorrections/Rusanov.hpp"

--- a/src/Evolution/Systems/ScalarAdvection/BoundaryCorrections/RegisterDerived.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/BoundaryCorrections/RegisterDerived.cpp
@@ -1,0 +1,12 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarAdvection/BoundaryCorrections/Factory.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+
+namespace ScalarAdvection::BoundaryCorrections {
+void register_derived_with_charm() noexcept {
+  Parallel::register_derived_classes_with_charm<BoundaryCorrection<1>>();
+  Parallel::register_derived_classes_with_charm<BoundaryCorrection<2>>();
+}
+}  // namespace ScalarAdvection::BoundaryCorrections

--- a/src/Evolution/Systems/ScalarAdvection/BoundaryCorrections/RegisterDerived.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/BoundaryCorrections/RegisterDerived.hpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace ScalarAdvection::BoundaryCorrections {
+void register_derived_with_charm() noexcept;
+}  // namespace ScalarAdvection::BoundaryCorrections

--- a/src/Evolution/Systems/ScalarAdvection/BoundaryCorrections/Rusanov.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/BoundaryCorrections/Rusanov.cpp
@@ -1,0 +1,97 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarAdvection/BoundaryCorrections/Rusanov.hpp"
+
+#include <memory>
+#include <optional>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace ScalarAdvection::BoundaryCorrections {
+template <size_t Dim>
+Rusanov<Dim>::Rusanov(CkMigrateMessage* msg) noexcept
+    : BoundaryCorrection<Dim>(msg) {}
+
+template <size_t Dim>
+std::unique_ptr<BoundaryCorrection<Dim>> Rusanov<Dim>::get_clone()
+    const noexcept {
+  return std::make_unique<Rusanov>(*this);
+}
+
+template <size_t Dim>
+void Rusanov<Dim>::pup(PUP::er& p) {
+  BoundaryCorrection<Dim>::pup(p);
+}
+
+template <size_t Dim>
+double Rusanov<Dim>::dg_package_data(
+    const gsl::not_null<Scalar<DataVector>*> packaged_u,
+    const gsl::not_null<Scalar<DataVector>*> packaged_normal_dot_flux_u,
+    const gsl::not_null<Scalar<DataVector>*> packaged_abs_char_speed,
+    const Scalar<DataVector>& u,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& flux_u,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& velocity_field,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+    const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+    /*mesh_velocity*/,
+    const std::optional<Scalar<DataVector>>&
+        normal_dot_mesh_velocity) noexcept {
+  Scalar<DataVector>& normal_dot_velocity = *packaged_u;
+  dot_product(make_not_null(&normal_dot_velocity), velocity_field,
+              normal_covector);
+  if (normal_dot_mesh_velocity.has_value()) {
+    get(*packaged_abs_char_speed) =
+        abs(get(normal_dot_velocity) - get(*normal_dot_mesh_velocity));
+  } else {
+    get(*packaged_abs_char_speed) = abs(get(normal_dot_velocity));
+  }
+  *packaged_u = u;
+  normal_dot_flux(packaged_normal_dot_flux_u, normal_covector, flux_u);
+  return max(get(*packaged_abs_char_speed));
+}
+
+template <size_t Dim>
+void Rusanov<Dim>::dg_boundary_terms(
+    const gsl::not_null<Scalar<DataVector>*> boundary_correction_u,
+    const Scalar<DataVector>& u_int,
+    const Scalar<DataVector>& normal_dot_flux_u_int,
+    const Scalar<DataVector>& abs_char_speed_int,
+    const Scalar<DataVector>& u_ext,
+    const Scalar<DataVector>& normal_dot_flux_u_ext,
+    const Scalar<DataVector>& abs_char_speed_ext,
+    const dg::Formulation dg_formulation) noexcept {
+  if (dg_formulation == dg::Formulation::WeakInertial) {
+    get(*boundary_correction_u) =
+        0.5 * (get(normal_dot_flux_u_int) - get(normal_dot_flux_u_ext)) -
+        0.5 * max(get(abs_char_speed_int), get(abs_char_speed_ext)) *
+            (get(u_ext) - get(u_int));
+  } else {
+    get(*boundary_correction_u) =
+        -0.5 * (get(normal_dot_flux_u_int) + get(normal_dot_flux_u_ext)) -
+        0.5 * max(get(abs_char_speed_int), get(abs_char_speed_ext)) *
+            (get(u_ext) - get(u_int));
+  }
+}
+
+template <size_t Dim>
+// NOLINTNEXTLINE
+PUP::able::PUP_ID
+    ScalarAdvection::BoundaryCorrections::Rusanov<Dim>::my_PUP_ID = 0;
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(_, data) template class Rusanov<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
+
+#undef INSTANTIATION
+#undef DIM
+}  // namespace ScalarAdvection::BoundaryCorrections

--- a/src/Evolution/Systems/ScalarAdvection/BoundaryCorrections/Rusanov.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/BoundaryCorrections/Rusanov.hpp
@@ -1,0 +1,111 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <pup.h>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/ScalarAdvection/BoundaryCorrections/BoundaryCorrection.hpp"
+#include "Evolution/Systems/ScalarAdvection/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ScalarAdvection {
+namespace BoundaryCorrections {
+/*!
+ * \brief A Rusanov/local Lax-Friedrichs Riemann solver
+ *
+ * Let \f$U\f$ be the evolved scalar variable, \f$F^i\f$ the corresponding
+ * fluxes, and \f$n_i\f$ be the outward directed unit normal to the interface.
+ * Denoting \f$F := n_i F^i\f$, the %Rusanov boundary correction is
+ *
+ * \f{align*}
+ * G_\text{Rusanov} = \frac{F_\text{int} - F_\text{ext}}{2} -
+ * \frac{\text{max}\left(|\lambda_\text{int}|,
+ * |\lambda_\text{ext}|\right)}{2} \left(U_\text{ext} - U_\text{int}\right),
+ * \f}
+ *
+ * where "int" and "ext" stand for interior and exterior, and
+ * \f$\lambda\f$ is the characteristic/signal speed. The minus sign in
+ * front of the \f$F_{\text{ext}}\f$ is necessary because the outward directed
+ * normal of the neighboring element has the opposite sign, i.e.
+ * \f$n_i^{\text{ext}}=-n_i^{\text{int}}\f$.
+ *
+ * For the ScalarAdvection system, \f$\lambda\f$ is given as
+ *
+ * \f{align*}
+ * \lambda = |v| = \sqrt{v^iv_i}
+ * \f}
+ *
+ * where \f$v^i\f$ is the advection velocity field.
+ *
+ * \note In the strong form the `dg_boundary_terms` function returns
+ * \f$G - F_\text{int}\f$
+ */
+template <size_t Dim>
+class Rusanov final : public BoundaryCorrection<Dim> {
+ private:
+  struct AbsCharSpeed : db::SimpleTag {
+    using type = Scalar<DataVector>;
+  };
+
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help = {
+      "Computes the Rusanov or local Lax-Friedrichs boundary correction term "
+      "for the ScalarAdvection system."};
+
+  Rusanov() = default;
+  Rusanov(const Rusanov&) = default;
+  Rusanov& operator=(const Rusanov&) = default;
+  Rusanov(Rusanov&&) = default;
+  Rusanov& operator=(Rusanov&&) = default;
+  ~Rusanov() override = default;
+
+  /// \cond
+  explicit Rusanov(CkMigrateMessage* msg) noexcept;
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Rusanov);  // NOLINT
+  /// \endcond
+  void pup(PUP::er& p) override;  // NOLINT
+
+  std::unique_ptr<BoundaryCorrection<Dim>> get_clone() const noexcept override;
+
+  using dg_package_field_tags =
+      tmpl::list<Tags::U, ::Tags::NormalDotFlux<Tags::U>, AbsCharSpeed>;
+  using dg_package_data_temporary_tags = tmpl::list<Tags::VelocityField<Dim>>;
+  using dg_package_data_volume_tags = tmpl::list<>;
+
+  static double dg_package_data(
+      gsl::not_null<Scalar<DataVector>*> packaged_u,
+      gsl::not_null<Scalar<DataVector>*> packaged_normal_dot_flux_u,
+      gsl::not_null<Scalar<DataVector>*> packaged_abs_char_speed,
+      const Scalar<DataVector>& u,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& flux_u,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& velocity_field,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+          mesh_velocity,
+      const std::optional<Scalar<DataVector>>&
+          normal_dot_mesh_velocity) noexcept;
+
+  static void dg_boundary_terms(
+      gsl::not_null<Scalar<DataVector>*> boundary_correction_u,
+      const Scalar<DataVector>& u_int,
+      const Scalar<DataVector>& normal_dot_flux_u_int,
+      const Scalar<DataVector>& abs_char_speed_int,
+      const Scalar<DataVector>& u_ext,
+      const Scalar<DataVector>& normal_dot_flux_u_ext,
+      const Scalar<DataVector>& abs_char_speed_ext,
+      dg::Formulation dg_formulation) noexcept;
+};
+}  // namespace BoundaryCorrections
+}  // namespace ScalarAdvection

--- a/src/Evolution/Systems/ScalarAdvection/System.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/System.hpp
@@ -7,6 +7,7 @@
 
 #include "DataStructures/VariablesTag.hpp"
 #include "Evolution/Systems/ScalarAdvection/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/ScalarAdvection/BoundaryCorrections/BoundaryCorrection.hpp"
 #include "Evolution/Systems/ScalarAdvection/Characteristics.hpp"
 #include "Evolution/Systems/ScalarAdvection/Fluxes.hpp"
 #include "Evolution/Systems/ScalarAdvection/Tags.hpp"
@@ -32,6 +33,7 @@ struct System {
   static constexpr size_t volume_dim = Dim;
 
   using boundary_conditions_base = BoundaryConditions::BoundaryCondition<Dim>;
+  using boundary_correction_base = BoundaryCorrections::BoundaryCorrection<Dim>;
 
   using variables_tag = ::Tags::Variables<tmpl::list<Tags::U>>;
   using flux_variables = tmpl::list<Tags::U>;

--- a/src/Evolution/Systems/ScalarAdvection/TimeDerivativeTerms.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/TimeDerivativeTerms.cpp
@@ -15,9 +15,12 @@ namespace ScalarAdvection {
 
 template <size_t Dim>
 void TimeDerivativeTerms<Dim>::apply(
-    gsl::not_null<Scalar<DataVector>*> /*non_flux_terms_dt_vars*/,
-    gsl::not_null<tnsr::I<DataVector, Dim>*> flux, const Scalar<DataVector>& u,
+    const gsl::not_null<Scalar<DataVector>*> /*non_flux_terms_dt_vars*/,
+    const gsl::not_null<tnsr::I<DataVector, Dim>*> temp_velocity_field,
+    const gsl::not_null<tnsr::I<DataVector, Dim>*> flux,
+    const Scalar<DataVector>& u,
     const tnsr::I<DataVector, Dim>& velocity_field) noexcept {
+  *temp_velocity_field = velocity_field;
   Fluxes<Dim>::apply(flux, u, velocity_field);
 }
 

--- a/src/Evolution/Systems/ScalarAdvection/TimeDerivativeTerms.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/TimeDerivativeTerms.hpp
@@ -17,7 +17,7 @@ namespace ScalarAdvection {
 /// which are just the fluxes.
 template <size_t Dim>
 struct TimeDerivativeTerms {
-  using temporary_tags = tmpl::list<>;
+  using temporary_tags = tmpl::list<Tags::VelocityField<Dim>>;
   using argument_tags = tmpl::list<Tags::U, Tags::VelocityField<Dim>>;
 
   static void apply(
@@ -25,6 +25,7 @@ struct TimeDerivativeTerms {
       // nonconservative products, so not used. All the tags in the
       // variables_tag in the system struct.
       gsl::not_null<Scalar<DataVector>*> /*non_flux_terms_dt_vars*/,
+      gsl::not_null<tnsr::I<DataVector, Dim>*> temp_velocity_field,
 
       // Fluxes returned by reference. Listed in the system struct as
       // flux_variables.

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/BoundaryCorrections/Rusanov.py
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/BoundaryCorrections/Rusanov.py
@@ -1,0 +1,40 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def dg_package_data_u(u, flux_u, velocity_field, normal_covector,
+                      mesh_velocity, normal_dot_mesh_velocity):
+    return u
+
+
+def dg_package_data_normal_dot_flux_u(u, flux_u, velocity_field,
+                                      normal_covector, mesh_velocity,
+                                      normal_dot_mesh_velocity):
+    return np.einsum("i,i", flux_u, normal_covector)
+
+
+def dg_package_data_abs_char_speed(u, flux_u, velocity_field, normal_covector,
+                                   mesh_velocity, normal_dot_mesh_velocity):
+    normal_dot_velocity = np.einsum("i,i", velocity_field, normal_covector)
+    if normal_dot_mesh_velocity is None:
+        return np.abs(normal_dot_velocity)
+    else:
+        return np.abs(normal_dot_velocity - normal_dot_mesh_velocity)
+
+
+def dg_boundary_terms_u(interior_u, interior_normal_dot_flux_u,
+                        interior_abs_char_speed, exterior_u,
+                        exterior_normal_dot_flux_u, exterior_abs_char_speed,
+                        use_strong_form):
+    if use_strong_form:
+        return -0.5 * (interior_normal_dot_flux_u +
+                       exterior_normal_dot_flux_u) - 0.5 * np.maximum(
+                           interior_abs_char_speed,
+                           exterior_abs_char_speed) * (exterior_u - interior_u)
+    else:
+        return 0.5 * (interior_normal_dot_flux_u -
+                      exterior_normal_dot_flux_u) - 0.5 * np.maximum(
+                          interior_abs_char_speed,
+                          exterior_abs_char_speed) * (exterior_u - interior_u)

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/BoundaryCorrections/Test_Rusanov.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/BoundaryCorrections/Test_Rusanov.cpp
@@ -1,0 +1,71 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "Evolution/Systems/ScalarAdvection/BoundaryCorrections/Factory.hpp"
+#include "Evolution/Systems/ScalarAdvection/BoundaryCorrections/Rusanov.hpp"
+#include "Evolution/Systems/ScalarAdvection/System.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/Range.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace helpers = TestHelpers::evolution::dg;
+
+namespace {
+
+template <size_t Dim>
+void test_rusanov(const gsl::not_null<std::mt19937*> gen,
+                  const size_t num_pts) {
+  helpers::test_boundary_correction_conservation<ScalarAdvection::System<Dim>>(
+      gen, ScalarAdvection::BoundaryCorrections::Rusanov<Dim>{},
+      Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
+                    Spectral::Quadrature::Gauss},
+      {}, {});
+
+  helpers::test_boundary_correction_with_python<ScalarAdvection::System<Dim>>(
+      gen, "Rusanov",
+      {{"dg_package_data_u", "dg_package_data_normal_dot_flux_u",
+        "dg_package_data_abs_char_speed"}},
+      {{"dg_boundary_terms_u"}},
+      ScalarAdvection::BoundaryCorrections::Rusanov<Dim>{},
+      Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
+                    Spectral::Quadrature::Gauss},
+      {}, {});
+
+  const auto rusanov = TestHelpers::test_creation<std::unique_ptr<
+      ScalarAdvection::BoundaryCorrections::BoundaryCorrection<Dim>>>(
+      "Rusanov:");
+
+  helpers::test_boundary_correction_with_python<ScalarAdvection::System<Dim>>(
+      gen, "Rusanov",
+      {{"dg_package_data_u", "dg_package_data_normal_dot_flux_u",
+        "dg_package_data_abs_char_speed"}},
+      {{"dg_boundary_terms_u"}},
+      dynamic_cast<const ScalarAdvection::BoundaryCorrections::Rusanov<Dim>&>(
+          *rusanov),
+      Mesh<Dim - 1>{num_pts, Spectral::Basis::Legendre,
+                    Spectral::Quadrature::Gauss},
+      {}, {});
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ScalarAdvection.BoundaryCorrections.Rusanov",
+                  "[Unit][Evolution]") {
+  PUPable_reg(ScalarAdvection::BoundaryCorrections::Rusanov<1>);
+  PUPable_reg(ScalarAdvection::BoundaryCorrections::Rusanov<2>);
+
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/ScalarAdvection/BoundaryCorrections"};
+  MAKE_GENERATOR(gen);
+
+  test_rusanov<1>(make_not_null(&gen), 5);
+  test_rusanov<2>(make_not_null(&gen), 5);
+}

--- a/tests/Unit/Evolution/Systems/ScalarAdvection/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarAdvection/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY Test_ScalarAdvection)
 
 set(LIBRARY_SOURCES
   BoundaryConditions/Test_Periodic.cpp
+  BoundaryCorrections/Test_Rusanov.cpp
   Test_Characteristics.cpp
   Test_Fluxes.cpp
   Test_Tags.cpp


### PR DESCRIPTION
## Proposed changes

- Set advection velocity field as a temporary tag (Dependent on #3149)
- Add Rusanov boundary correction

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
