### PR TITLE
GRMHD: add magnetized tov analytic data

### DIFF
--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -101,6 +101,12 @@ add_grmhd_executable(
   )
 
 add_grmhd_executable(
+  MagnetizedTovStar
+  grmhd::AnalyticData::MagnetizedTovStar
+  "${LIBS_TO_LINK}"
+  )
+
+add_grmhd_executable(
   OrszagTangVortex
   grmhd::AnalyticData::OrszagTangVortex
   "${LIBS_TO_LINK}"

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -92,6 +92,7 @@
 #include "PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.hpp"
 #include "PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.hpp"
 #include "PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.hpp"
 #include "PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.hpp"
 #include "PointwiseFunctions/AnalyticData/Tags.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.hpp"

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivCleanFwd.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivCleanFwd.hpp
@@ -31,6 +31,7 @@ class CylindricalBlastWave;
 class MagneticFieldLoop;
 class MagneticRotor;
 class MagnetizedFmDisk;
+class MagnetizedTovStar;
 class OrszagTangVortex;
 }  // namespace AnalyticData
 }  // namespace grmhd

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/CMakeLists.txt
@@ -13,6 +13,7 @@ spectre_target_sources(
   MagneticFieldLoop.cpp
   MagneticRotor.cpp
   MagnetizedFmDisk.cpp
+  MagnetizedTovStar.cpp
   OrszagTangVortex.cpp
   )
 
@@ -26,6 +27,7 @@ spectre_target_headers(
   MagneticFieldLoop.hpp
   MagneticRotor.hpp
   MagnetizedFmDisk.hpp
+  MagnetizedTovStar.hpp
   OrszagTangVortex.hpp
   )
 

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.cpp
@@ -1,0 +1,131 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <ostream>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace grmhd::AnalyticData {
+MagnetizedTovStar::MagnetizedTovStar(
+    const double central_rest_mass_density, const double polytropic_constant,
+    const double polytropic_exponent, const size_t pressure_exponent,
+    const double cutoff_pressure_fraction,
+    const double vector_potential_amplitude) noexcept
+    : tov_star(central_rest_mass_density, polytropic_constant,
+               polytropic_exponent),
+      pressure_exponent_(pressure_exponent),
+      cutoff_pressure_(cutoff_pressure_fraction *
+                       get(equation_of_state().pressure_from_density(
+                           Scalar<double>{central_rest_mass_density}))),
+      vector_potential_amplitude_(vector_potential_amplitude) {}
+
+void MagnetizedTovStar::pup(PUP::er& p) noexcept {
+  tov_star::pup(p);
+  p | pressure_exponent_;
+  p | cutoff_pressure_;
+  p | vector_potential_amplitude_;
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>>
+MagnetizedTovStar::variables(
+    const tnsr::I<DataType, 3>& coords,
+    tmpl::list<
+        hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>> /*meta*/,
+    const RadialVariables<DataType>& radial_vars) const noexcept {
+  const size_t num_pts = get_size(get<0>(coords));
+  auto magnetic_field =
+      make_with_value<tnsr::I<DataType, 3, Frame::Inertial>>(num_pts, 0.0);
+  using std::max;
+  const auto sqrt_det_spatial_metric =
+      get<gr::Tags::SqrtDetSpatialMetric<DataType>>(variables(
+          coords, tmpl::list<gr::Tags::SqrtDetSpatialMetric<DataType>>{},
+          radial_vars));
+  for (size_t i = 0; i < num_pts; ++i) {
+    const double pressure = get_element(get(radial_vars.pressure), i);
+    if (LIKELY(get_element(radial_vars.radial_coordinate, i) > 1.0e-16)) {
+      if (pressure < cutoff_pressure_) {
+        continue;
+      }
+
+      const double x = get_element(get<0>(coords), i);
+      const double y = get_element(get<1>(coords), i);
+      const double z = get_element(get<2>(coords), i);
+      const double radius = get_element(radial_vars.radial_coordinate, i);
+      const double dr_pressure = get_element(radial_vars.dr_pressure, i);
+      const double pressure_term =
+          pow(pressure - cutoff_pressure_, pressure_exponent_);
+      const double deriv_pressure_term =
+          pressure_exponent_ *
+          pow(pressure - cutoff_pressure_,
+              static_cast<int>(pressure_exponent_) - 1) *
+          dr_pressure;
+
+      get_element(get<0>(magnetic_field), i) =
+          x * z / radius * deriv_pressure_term;
+
+      get_element(get<1>(magnetic_field), i) =
+          y * z / radius * deriv_pressure_term;
+
+      get_element(get<2>(magnetic_field), i) =
+          (-2.0 * pressure_term +
+           (square(x) + square(y)) / radius * deriv_pressure_term);
+    } else {
+      get_element(get<2>(magnetic_field), i) =
+          (-2.0 * pow(pressure - cutoff_pressure_, pressure_exponent_));
+    }
+  }
+  for (size_t i = 0; i < 3; ++i) {
+    magnetic_field.get(i) *=
+        vector_potential_amplitude_ / get(sqrt_det_spatial_metric);
+  }
+  return magnetic_field;
+}
+
+bool operator==(const MagnetizedTovStar& lhs,
+                const MagnetizedTovStar& rhs) noexcept {
+  return static_cast<const typename MagnetizedTovStar::tov_star&>(lhs) ==
+             static_cast<const typename MagnetizedTovStar::tov_star&>(rhs) and
+         lhs.pressure_exponent_ == rhs.pressure_exponent_ and
+         lhs.cutoff_pressure_ == rhs.cutoff_pressure_ and
+         lhs.vector_potential_amplitude_ == rhs.vector_potential_amplitude_;
+}
+
+bool operator!=(const MagnetizedTovStar& lhs,
+                const MagnetizedTovStar& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                            \
+  template tuples::TaggedTuple<                                         \
+      hydro::Tags::MagneticField<DTYPE(data), 3, Frame::Inertial>>      \
+  MagnetizedTovStar::variables(                                         \
+      const tnsr::I<DTYPE(data), 3>& coords,                            \
+      tmpl::list<hydro::Tags::MagneticField<DTYPE(data), 3,             \
+                                            Frame::Inertial>> /*meta*/, \
+      const RadialVariables<DTYPE(data)>& radial_vars) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
+
+#undef INSTANTIATE
+#undef DTYPE
+}  // namespace grmhd::AnalyticData

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.hpp
@@ -1,0 +1,234 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Tov.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace PUP {
+class er;  // IWYU pragma: keep
+}  // namespace PUP
+/// \endcond
+
+namespace grmhd::AnalyticData {
+/*!
+ * \brief Magnetized TOV star initial data, where metric terms only account for
+ * the hydrodynamics not the magnetic fields.
+ *
+ * Superposes a poloidal magnetic field on top of a TOV solution where the
+ * vector potential has the form
+ *
+ * \f{align*}{
+ *  A_{\phi} = A_b \varpi^2 \max(p-p_{\mathrm{cut}}, 0)^{n_s}
+ * \f}
+ *
+ * where \f$A_b\f$ controls the amplitude of the magnetic field,
+ * \f$\varpi^2=x^2+y^2=r^2-z^2\f$ is the cylindrical radius,
+ * \f$n_s\f$ controls the degree of differentiability, and
+ * \f$p_{\mathrm{cut}}\f$ controls the pressure cutoff below which the magnetic
+ * field is zero.
+ *
+ * In Cartesian coordinates the vector potential is:
+ *
+ * \f{align*}{
+ *   A_x&=-\frac{y}{\varpi^2}A_\phi, \\
+ *   A_y&=\frac{x}{\varpi^2}A_\phi, \\
+ *   A_z&=0,
+ * \f}
+ *
+ * For the poloidal field this means
+ *
+ * \f{align*}{
+ *   A_x &= -y A_b\max(p-p_{\mathrm{cut}}, 0)^{n_s}, \\
+ *   A_y &= x A_b\max(p-p_{\mathrm{cut}}, 0)^{n_s}.
+ * \f}
+ *
+ * The magnetic field is computed from the vector potential as
+ *
+ * \f{align*}{
+ *   B^i&=n_a\epsilon^{aijk}\partial_jA_k \\
+ *      &=-\frac{1}{\sqrt{\gamma}}[ijk]\partial_j A_k,
+ * \f}
+ *
+ * where \f$[ijk]\f$ is the total anti-symmetric symbol. This means that
+ *
+ * \f{align*}{
+ *   B^x&=\frac{1}{\sqrt{\gamma}} (\partial_z A_y-\partial_y A_z), \\
+ *   B^y&=\frac{1}{\sqrt{\gamma}} (\partial_x A_z - \partial_z A_x), \\
+ *   B^z&=\frac{1}{\sqrt{\gamma}} (\partial_y A_x - \partial_x A_y).
+ * \f}
+ *
+ * Focusing on the region where the field is non-zero we have:
+ *
+ * \f{align*}{
+ *   \partial_x A_y
+ *   &= A_b(p-p_{\mathrm{cut}})^{n_s}+
+ *     \frac{x^2}{r}A_bn_s(p-p_{\mathrm{cut}})^{n_s-1}\partial_r p \\
+ *   \partial_y A_x
+ *   &= -A_b(p-p_{\mathrm{cut}})^{n_s}-
+ *     \frac{y^2}{r}A_bn_s(p-p_{\mathrm{cut}})^{n_s-1}\partial_r p \\
+ *   \partial_z A_x
+ *   &= -\frac{yz}{r}A_bn_s(p-p_{\mathrm{cut}})^{n_s-1}\partial_rp \\
+ *   \partial_z A_y
+ *   &= \frac{xz}{r}A_bn_s(p-p_{\mathrm{cut}})^{n_s-1}\partial_rp
+ * \f}
+ *
+ * The magnetic field is given by:
+ *
+ * \f{align*}{
+ *   B^x&=\frac{1}{\sqrt{\gamma}}\frac{xz}{r}
+ *        A_bn_s(p-p_{\mathrm{cut}})^{n_s-1}\partial_rp \\
+ *   B^y&=\frac{1}{\sqrt{\gamma}}\frac{yz}{r}
+ *        A_bn_s(p-p_{\mathrm{cut}})^{n_s-1}\partial_rp \\
+ *   B^z&=-\frac{A_b}{\sqrt{\gamma}}\left[
+ *        2(p-p_{\mathrm{cut}})^{n_s} \phantom{\frac{a}{b}}\right. \\
+ *      &\left.+\frac{x^2+y^2}{r}
+ *        n_s(p-p_{\mathrm{cut}})^{n_s-1}\partial_r p
+ *        \right]
+ * \f}
+ *
+ * Taking the small-\f$r\f$ limit gives the \f$r=0\f$ magnetic field:
+ *
+ * \f{align*}{
+ *   B^x&=0, \\
+ *   B^y&=0, \\
+ *   B^z&=-\frac{A_b}{\sqrt{\gamma}}
+ *        2(p-p_{\mathrm{cut}})^{n_s}.
+ * \f}
+ *
+ * While the amplitude \f$A_b\f$ is specified in the code, it is more natural
+ * to work with the magnetic field strength, which is given by \f$\sqrt{b^2}\f$
+ * (where \f$b^a\f$ is the comoving magnetic field), and in CGS units is
+ *
+ * \f{align*}{
+ *  |B_{\mathrm{CGS}}|&= \sqrt{4 \pi b^2}
+ *   \left(\frac{c^2}{G M_\odot}\right) \left(\frac{c}{\sqrt{4 \pi \epsilon_0
+ *    G}}\right) \\
+ *   &= \sqrt{b^2} \times 8.352\times10^{19}\mathrm{G} \,.
+ * \f}
+ *
+ * We now give values used for standard tests of magnetized stars.
+ * - \f$\rho_c(0)=1.28\times10^{-3}\f$
+ * - \f$K=100\f$
+ * - \f$\Gamma=2\f$
+ * - %Domain \f$[-20,20]^3\f$
+ * - Units \f$M=M_\odot\f$
+ * - A target final time 20ms means \f$20\times10^{-3}/(5\times10^{-6})=4000M\f$
+ * - The mass of the star is \f$1.4M_{\odot}\f$
+ *
+ * Parameters for desired magnetic field strength:
+ * - For \f$n_s=0\f$ and \f$p_{\mathrm{cut}}=0.04p_{\max}\f$ setting
+ *   \f$A_b=6\times10^{-5}\f$ yields a maximum mganetic field strength of
+ *   \f$1.002\times10^{16}G\f$.
+ * - For \f$n_s=1\f$ and \f$p_{\mathrm{cut}}=0.04p_{\max}\f$ setting
+ *   \f$A_b=0.4\f$ yields a maximum mganetic field strength of
+ *   \f$1.05\times10^{16}G\f$.
+ * - For \f$n_s=2\f$ and \f$p_{\mathrm{cut}}=0.04p_{\max}\f$ setting
+ *   \f$A_b=2500\f$ yields a maximum mganetic field strength of
+ *   \f$1.03\times10^{16}G\f$.
+ * - For \f$n_s=3\f$ and \f$p_{\mathrm{cut}}=0.04p_{\max}\f$ setting
+ *   \f$A_b=1.65\times10^{7}\f$ yields a maximum mganetic field strength of
+ *   \f$1.07\times10^{16}G\f$.
+ *
+ * Note that the magnetic field strength goes as \f$A_b\f$ so any desired value
+ * can be achieved by a linear scaling.
+ */
+class MagnetizedTovStar : public MarkAsAnalyticData,
+                          private RelativisticEuler::Solutions::TovStar<
+                              gr::Solutions::TovSolution> {
+ private:
+  using tov_star =
+      RelativisticEuler::Solutions::TovStar<gr::Solutions::TovSolution>;
+
+ public:
+  struct PressureExponent {
+    using type = size_t;
+    static constexpr Options::String help = {
+        "The exponent n_s controlling the smoothness of the field"};
+  };
+
+  struct VectorPotentialAmplitude {
+    using type = double;
+    static constexpr Options::String help = {
+        "The amplitude A_b of the phi-component of the vector potential. This "
+        "controls the magnetic field strength."};
+    static type lower_bound() { return 0.0; }
+  };
+
+  struct CutoffPressureFraction {
+    using type = double;
+    static constexpr Options::String help = {
+        "The fraction of the central pressure below which there is no magnetic "
+        "field. p_cut = Fraction * p_max."};
+    static type lower_bound() { return 0.0; }
+    static type upper_bound() { return 1.0; }
+  };
+
+  using options =
+      tmpl::push_back<tov_star::options, PressureExponent,
+                      CutoffPressureFraction, VectorPotentialAmplitude>;
+
+  static constexpr Options::String help = {
+      "Magnetized TOV star in areal coordinates."};
+
+  MagnetizedTovStar() = default;
+  MagnetizedTovStar(const MagnetizedTovStar& /*rhs*/) = delete;
+  MagnetizedTovStar& operator=(const MagnetizedTovStar& /*rhs*/) = delete;
+  MagnetizedTovStar(MagnetizedTovStar&& /*rhs*/) noexcept = default;
+  MagnetizedTovStar& operator=(MagnetizedTovStar&& /*rhs*/) noexcept = default;
+  ~MagnetizedTovStar() = default;
+
+  MagnetizedTovStar(double central_rest_mass_density,
+                    double polytropic_constant, double polytropic_exponent,
+                    size_t pressure_exponent, double cutoff_pressure_fraction,
+                    double vector_potential_amplitude) noexcept;
+
+  // Overload the variables function from the base class.
+  using tov_star::equation_of_state;
+  using tov_star::equation_of_state_type;
+  using tov_star::variables;
+
+  /// Retrieve a collection of variables at `(x)`
+  template <typename DataType, typename... Tags>
+  tuples::TaggedTuple<Tags...> variables(
+      const tnsr::I<DataType, 3>& x,
+      tmpl::list<Tags...> /*meta*/) const noexcept {
+    auto radial_vars =
+        radial_tov_solution().radial_variables(equation_of_state(), x);
+    return {get<Tags>(variables(x, tmpl::list<Tags>{}, radial_vars))...};
+  }
+
+  void pup(PUP::er& p) noexcept;  //  NOLINT
+
+ private:
+  friend bool operator==(const MagnetizedTovStar& lhs,
+                         const MagnetizedTovStar& rhs) noexcept;
+
+  template <typename DataType>
+  tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>>
+  variables(const tnsr::I<DataType, 3>& coords,
+            tmpl::list<hydro::Tags::MagneticField<DataType, 3,
+                                                  Frame::Inertial>> /*meta*/,
+            const RadialVariables<DataType>& radial_vars) const noexcept;
+
+  size_t pressure_exponent_ = std::numeric_limits<size_t>::max();
+  double cutoff_pressure_ = std::numeric_limits<double>::signaling_NaN();
+  double vector_potential_amplitude_ =
+      std::numeric_limits<double>::signaling_NaN();
+};
+
+bool operator!=(const MagnetizedTovStar& lhs,
+                const MagnetizedTovStar& rhs) noexcept;
+}  // namespace grmhd::AnalyticData

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp
@@ -83,6 +83,7 @@ class TovStar : public MarkAsAnalyticSolution {
               make_with_value<Scalar<DataType>>(radial_coordinate, 0.0)),
           specific_enthalpy(
               make_with_value<Scalar<DataType>>(radial_coordinate, 0.0)),
+          dr_pressure(make_with_value<DataType>(radial_coordinate, 0.0)),
           metric_time_potential(
               make_with_value<DataType>(radial_coordinate, 0.0)),
           dr_metric_time_potential(
@@ -100,6 +101,7 @@ class TovStar : public MarkAsAnalyticSolution {
     Scalar<DataType> pressure{};
     Scalar<DataType> specific_internal_energy{};
     Scalar<DataType> specific_enthalpy{};
+    DataType dr_pressure{};
     DataType metric_time_potential{};
     DataType dr_metric_time_potential{};
     DataType metric_radial_potential{};

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp
@@ -173,11 +173,7 @@ class TovStar : public MarkAsAnalyticSolution {
     return equation_of_state_;
   }
 
- private:
-  template <typename LocalRadialSolution>
-  friend bool operator==(const TovStar<LocalRadialSolution>& lhs,
-                         const TovStar<LocalRadialSolution>& rhs) noexcept;
-
+ protected:
   const RadialSolution& radial_tov_solution() const noexcept;
 
   template <typename DataType>
@@ -237,6 +233,11 @@ class TovStar : public MarkAsAnalyticSolution {
   BOOST_PP_LIST_FOR_EACH(FUNC_DECL, _, MY_LIST)
 #undef MY_LIST
 #undef FUNC_DECL
+
+ private:
+  template <typename LocalRadialSolution>
+  friend bool operator==(const TovStar<LocalRadialSolution>& lhs,
+                         const TovStar<LocalRadialSolution>& rhs) noexcept;
 
   double central_rest_mass_density_ =
       std::numeric_limits<double>::signaling_NaN();

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   Test_MagneticFieldLoop.cpp
   Test_MagneticRotor.cpp
   Test_MagnetizedFmDisk.cpp
+  Test_MagnetizedTovStar.cpp
   Test_OrszagTangVortex.cpp
   )
 

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagnetizedTovStar.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagnetizedTovStar.cpp
@@ -1,0 +1,94 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Domain/LogicalCoordinates.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticData.GrMhd.MagTovStar",
+                  "[Unit][PointwiseFunctions]") {
+  const auto mag_tov_opts =
+      TestHelpers::test_creation<grmhd::AnalyticData::MagnetizedTovStar>(
+          "CentralDensity: 1.28e-3\n"
+          "PolytropicConstant: 100.0\n"
+          "PolytropicExponent: 2.0\n"
+          "PressureExponent: 2\n"
+          "VectorPotentialAmplitude: 2500\n"
+          "CutoffPressureFraction: 0.04\n");
+  const RelativisticEuler::Solutions::TovStar<gr::Solutions::TovSolution> tov{
+      1.28e-3, 100.0, 2.0};
+  const auto mag_tov = serialize_and_deserialize(mag_tov_opts);
+  CHECK(mag_tov == grmhd::AnalyticData::MagnetizedTovStar(1.28e-3, 100.0, 2.0,
+                                                          2, 0.04, 2500.0));
+  CHECK(mag_tov != grmhd::AnalyticData::MagnetizedTovStar(2.28e-3, 100.0, 2.0,
+                                                          2, 0.04, 2500.0));
+  CHECK(mag_tov != grmhd::AnalyticData::MagnetizedTovStar(1.28e-3, 200.0, 2.0,
+                                                          2, 0.04, 2500.0));
+  CHECK(mag_tov != grmhd::AnalyticData::MagnetizedTovStar(1.28e-3, 100.0, 3.0,
+                                                          2, 0.04, 2500.0));
+  CHECK(mag_tov != grmhd::AnalyticData::MagnetizedTovStar(1.28e-3, 100.0, 2.0,
+                                                          3, 0.04, 2500.0));
+  CHECK(mag_tov != grmhd::AnalyticData::MagnetizedTovStar(1.28e-3, 100.0, 2.0,
+                                                          2, 0.05, 2500.0));
+  CHECK(mag_tov != grmhd::AnalyticData::MagnetizedTovStar(1.28e-3, 100.0, 2.0,
+                                                          2, 0.04, 3500.0));
+
+  std::unique_ptr<EquationsOfState::EquationOfState<true, 1>> eos =
+      std::make_unique<EquationsOfState::PolytropicFluid<true>>(100.0, 2.0);
+
+  const gr::Solutions::TovSolution tov_soln{*eos, 1.28e-3};
+  const Mesh<3> mesh{{{5, 5, 5}},
+                     {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+                       Spectral::Basis::Legendre}},
+                     {{Spectral::Quadrature::Gauss, Spectral::Quadrature::Gauss,
+                       Spectral::Quadrature::Gauss}}};
+  const auto log_coords = logical_coordinates(mesh);
+
+  tnsr::I<DataVector, 3, Frame::Inertial> in_coords{
+      mesh.number_of_grid_points(), 0.0};
+  const double scale = 1.0e-2;
+  in_coords.get(0) = scale * (log_coords.get(0) + 1.1);
+  InverseJacobian<DataVector, 3, Frame::Logical, Frame::Inertial> inv_jac{
+      mesh.number_of_grid_points(), 0.0};
+  for (size_t i = 0; i < 3; ++i) {
+    inv_jac.get(i, i) = 1.0 / scale;
+  }
+
+  // Check that the non-magnetic field tags match the unmagnetized solution.
+  using tov_tags =
+      tmpl::remove<tmpl::append<hydro::grmhd_tags<DataVector>,
+                                gr::tags_for_hydro<3, DataVector>>,
+                   hydro::Tags::MagneticField<DataVector, 3, Frame::Inertial>>;
+  tmpl::for_each<tov_tags>(
+      [tov_values = tov.variables(in_coords, 0.0, tov_tags{}),
+       mag_tov_values =
+           mag_tov.variables(in_coords, tov_tags{})](auto tag_v) noexcept {
+        using tag = tmpl::type_from<decltype(tag_v)>;
+        CHECK_ITERABLE_APPROX(get<tag>(mag_tov_values), get<tag>(tov_values));
+      });
+
+  // Verify that the resulting magnetic field has (approximately) vanishing
+  // covariant divergence
+  const auto b_field =
+      get<hydro::Tags::MagneticField<DataVector, 3, Frame::Inertial>>(
+          mag_tov.variables(in_coords, tmpl::list<hydro::Tags::MagneticField<
+                                           DataVector, 3, Frame::Inertial>>{}));
+  const auto sqrt_det_spatial_metric =
+      get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(mag_tov.variables(
+          in_coords, tmpl::list<gr::Tags::SqrtDetSpatialMetric<DataVector>>{}));
+  auto tilde_b = b_field;
+  for (size_t i = 0; i < 3; ++i) {
+    tilde_b.get(i) *= get(sqrt_det_spatial_metric);
+  }
+
+  const auto div_tilde_b = divergence(tilde_b, mesh, inv_jac);
+  CHECK(max(abs(get(div_tilde_b))) < 1.0e-14);
+}


### PR DESCRIPTION
## Proposed changes

Add analytic data of a magnetized TOV star with vector potential:
```
A_\phi=A_b \varpi^2 max(p-p_{cutoff}, 0)^n
```
This is a very common configuration in the literature also used in BNS mergers.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
