### PR TITLE
Remove an extra db::AddSimpleTags

### DIFF
--- a/tests/Unit/Evolution/EventsAndDenseTriggers/DenseTriggers/Test_Or.cpp
+++ b/tests/Unit/Evolution/EventsAndDenseTriggers/DenseTriggers/Test_Or.cpp
@@ -42,9 +42,9 @@ void check(const bool time_runs_forward, const bool expected_is_ready,
            const std::string& creation_string) noexcept {
   CAPTURE(creation_string);
   const auto box = db::create<db::AddSimpleTags<
-      db::AddSimpleTags<Parallel::Tags::MetavariablesImpl<Metavariables>>,
-      Tags::TimeStepId>>(Metavariables{}, TimeStepId(time_runs_forward, 0,
-                                                     Slab(0.0, 1.0).start()));
+      Parallel::Tags::MetavariablesImpl<Metavariables>, Tags::TimeStepId>>(
+      Metavariables{},
+      TimeStepId(time_runs_forward, 0, Slab(0.0, 1.0).start()));
   const auto trigger = serialize_and_deserialize(
       TestHelpers::test_creation<std::unique_ptr<DenseTrigger>, Metavariables>(
           creation_string));


### PR DESCRIPTION
This slipped through in one of my recent PRs.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
