### PR TITLE
Add lld to docker image.

### DIFF
--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -41,6 +41,7 @@ RUN apt-get update -y \
                           libgsl0-dev \
                           clang-8 clang-9 \
                           clang-10 clang-format-10 clang-tidy-10 \
+                          lld \
                           wget libncurses-dev \
                           lcov cppcheck \
                           libboost-dev libboost-program-options-dev \
@@ -81,7 +82,7 @@ RUN apt-get update -y \
 RUN add-apt-repository universe \
     && apt-get update -y \
     && apt-get install -y curl python2 python2-dev \
-    && curl https://bootstrap.pypa.io/2.7/get-pip.py --output get-pip.py \
+    && curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py \
     && python2 get-pip.py && rm get-pip.py \
     && apt-get install -y python3-pip python-is-python3 \
     && pip3 --no-cache-dir install -U pip \


### PR DESCRIPTION
## Proposed changes

Adds ld.lld to the docker image.

Also, changes the URL for get-pip.py; the old one no longer worked.

The image is in DockerHub under sxscollaboration/spectrebuildenv_experimental:latest
I can push to sxscollaboration/spectrebuildenv:latest after this PR is reviewed.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
