### PR TITLE
Fix git info in InfoAtLink and simplify it

### DIFF
--- a/cmake/SetupBuildInfo.cmake
+++ b/cmake/SetupBuildInfo.cmake
@@ -1,10 +1,6 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-configure_file(
-  ${CMAKE_SOURCE_DIR}/src/Informer/InfoAtLink.cpp
-  ${CMAKE_BINARY_DIR}/Informer/InfoAtLink.cpp
-  )
 # Configure info from build to give access to unit test path,
 # SpECTRE version, etc. (things known at CMake time)
 configure_file(

--- a/cmake/SpectreGetGitHash.cmake
+++ b/cmake/SpectreGetGitHash.cmake
@@ -2,7 +2,9 @@
 # See LICENSE.txt for details.
 
 set(GIT_HASH "")
+set(GIT_BRANCH_COMMAND "")
 set(GIT_BRANCH "")
+set(GIT_DESCRIPTION_COMMAND "")
 set(GIT_DESCRIPTION "")
 
 if(EXISTS ${CMAKE_SOURCE_DIR}/.git)
@@ -15,15 +17,17 @@ if(EXISTS ${CMAKE_SOURCE_DIR}/.git)
       OUTPUT_VARIABLE GIT_HASH
       OUTPUT_STRIP_TRAILING_WHITESPACE
       )
+    set(GIT_BRANCH_COMMAND "${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD")
     execute_process(
-      COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
+      COMMAND bash -c "${GIT_BRANCH_COMMAND}"
       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
       OUTPUT_VARIABLE GIT_BRANCH
       OUTPUT_STRIP_TRAILING_WHITESPACE
       )
+    set(GIT_DESCRIPTION_COMMAND "${GIT_EXECUTABLE} describe \
+--always --first-parent --match 'v[0-9]*' HEAD")
     execute_process(
-      COMMAND ${GIT_EXECUTABLE} describe
-        --always --first-parent --match "v[0-9]*" HEAD
+      COMMAND bash -c "${GIT_DESCRIPTION_COMMAND}"
       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
       OUTPUT_VARIABLE GIT_DESCRIPTION
       OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/src/Informer/CMakeLists.txt
+++ b/src/Informer/CMakeLists.txt
@@ -36,7 +36,11 @@ spectre_target_headers(
 # can be deferred until we link an executable.
 target_link_options(
   ${LIBRARY}
-  PUBLIC "$<$<PLATFORM_ID:Darwin>:-Wl,-U,_info_from_build>")
+  PUBLIC
+  "$<$<PLATFORM_ID:Darwin>:-Wl,-U,_git_branch>"
+  "$<$<PLATFORM_ID:Darwin>:-Wl,-U,_git_description>"
+  "$<$<PLATFORM_ID:Darwin>:-Wl,-U,_link_date>"
+  )
 
 target_link_libraries(
   ${LIBRARY}

--- a/src/Informer/InfoAtCompile.cpp
+++ b/src/Informer/InfoAtCompile.cpp
@@ -1,7 +1,13 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+// This file is configured into the build directory by CMake and compiled as
+// part of the build system. It exposes information from CMake to C++.
+
 #include "@CMAKE_SOURCE_DIR@/src/Informer/InfoFromBuild.hpp"
+
+#include <sstream>
+#include <string>
 
 std::string spectre_version() { return std::string("@SPECTRE_VERSION@"); }
 
@@ -11,4 +17,17 @@ std::string unit_test_build_path() noexcept {
 
 std::string unit_test_src_path() noexcept {
   return "@CMAKE_SOURCE_DIR@/tests/Unit/";
+}
+
+std::string info_from_build() noexcept {
+  std::ostringstream os;
+  os << "SpECTRE Build Information:\n";
+  os << "Version:                      " << spectre_version() << "\n";
+  os << "Compiled on host:             @HOSTNAME@\n";
+  os << "Compiled in directory:        @CMAKE_BINARY_DIR@\n";
+  os << "Source directory is:          @CMAKE_SOURCE_DIR@\n";
+  os << "Compiled on git branch:       " << git_branch() << "\n";
+  os << "Compiled on git revision:     " << git_description() << "\n";
+  os << "Linked on:                    " << link_date() << "\n";
+  return os.str();
 }

--- a/src/Informer/InfoAtLink.cpp
+++ b/src/Informer/InfoAtLink.cpp
@@ -1,12 +1,15 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include "@CMAKE_SOURCE_DIR@/src/Informer/InfoFromBuild.hpp"
+// This file is compiled into every executable at link time, so the information
+// that these functions provide reflects the time the executable was linked
+// instead of the time that CMake was last run.
+
+#include "Informer/InfoFromBuild.hpp"
 
 #include <boost/preprocessor.hpp>
-#include <sstream>
+#include <string>
 
-namespace {
 std::string link_date() { return std::string(__TIMESTAMP__); }
 
 std::string git_description() {
@@ -14,20 +17,3 @@ std::string git_description() {
 }
 
 std::string git_branch() { return std::string(BOOST_PP_STRINGIZE(GIT_BRANCH)); }
-}  // namespace
-
-std::string info_from_build() {
-  static const std::string info = [] {
-    std::ostringstream os;
-    os << "SpECTRE Build Information:\n";
-    os << "Version:                      " << spectre_version() << "\n";
-    os << "Compiled on host:             @HOSTNAME@\n";
-    os << "Compiled in directory:        @CMAKE_BINARY_DIR@\n";
-    os << "Source directory is:          @CMAKE_SOURCE_DIR@\n";
-    os << "Compiled on git branch:       " << git_branch() << "\n";
-    os << "Compiled on git revision:     " << git_description() << "\n";
-    os << "Linked on:                    " << link_date() << "\n";
-    return os.str();
-  }();
-  return info;
-}

--- a/src/Informer/InfoFromBuild.hpp
+++ b/src/Informer/InfoFromBuild.hpp
@@ -15,18 +15,34 @@
  * The information returned by this function is invaluable for identifying
  * the version of the code used in a simulation, as well as which host, the
  * date the code was compiled, and the time of linkage.
- *
- * We declare the function `extern "C"` so its symbol is not mangled and we can
- * ignore that it is undefined until link time (see `CMakeLists.txt`). Note that
- * the `std::string` return type is not compatible with C, but that's OK as long
- * as we're not calling or defining the function in C. See Microsoft's C4190:
- * https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4190
  */
+std::string info_from_build() noexcept;
+
+// We declare these functions `extern "C"` so their symbols are not mangled and
+// we can ignore that they are undefined until link time (see `CMakeLists.txt`).
+// Note that the `std::string` return type is not compatible with C, but that's
+// OK as long as we're not calling or defining the functions in C. See
+// Microsoft's C4190:
+// https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4190
 #if defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wreturn-type-c-linkage"
 #endif  // defined(__clang__)
-extern "C" std::string info_from_build();
+/*!
+ * \ingroup LoggingGroup
+ * \brief The time and date the executable was linked
+ */
+extern "C" std::string link_date();
+/*!
+ * \ingroup LoggingGroup
+ * \brief The git description at the time the executable was linked
+ */
+extern "C" std::string git_description();
+/*!
+ * \ingroup LoggingGroup
+ * \brief The git branch at the time the executable was linked
+ */
+extern "C" std::string git_branch();
 #if defined(__clang__)
 #pragma GCC diagnostic pop
 #endif  // defined(__clang__)

--- a/src/PythonBindings/InfoAtLink.cpp
+++ b/src/PythonBindings/InfoAtLink.cpp
@@ -5,4 +5,8 @@
 
 #include <string>
 
-std::string info_from_build() { return "build_info"; }
+std::string link_date() { return "Unavailable in Python bindings"; }
+
+std::string git_description() { return "Unavailable in Python bindings"; }
+
+std::string git_branch() { return "Unavailable in Python bindings"; }

--- a/tools/WrapExecutableLinker.sh
+++ b/tools/WrapExecutableLinker.sh
@@ -7,13 +7,13 @@ temp_files=()
 trap 'rm -r "${temp_files[@]}"' EXIT
 
 pushd @CMAKE_SOURCE_DIR@ >/dev/null
-git_description="@GIT_DESCRIPTION@"
-git_branch="@GIT_BRANCH@"
-if [ -z "$git_description" ]; then
-    git_description="NOT_IN_GIT_REPO"
+git_description="@GIT_DESCRIPTION_COMMAND@"
+git_branch="@GIT_BRANCH_COMMAND@"
+if [ ! -z "${git_description}" ]; then
+    git_description=`${git_description}`
 fi
-if [ -z "$git_branch" ]; then
-    git_branch="NOT_IN_GIT_REPO"
+if [ ! -z "${git_branch}" ]; then
+    git_branch=`${git_branch}`
 fi
 popd >/dev/null
 

--- a/tools/WrapExecutableLinker.sh
+++ b/tools/WrapExecutableLinker.sh
@@ -36,7 +36,7 @@ let ++oindex
 InfoAtLink_file=@CMAKE_BINARY_DIR@/tmp/\
 $(basename "${!oindex}")_InfoAtLink.cpp
 temp_files+=("${InfoAtLink_file}")
-cp @CMAKE_BINARY_DIR@/Informer/InfoAtLink.cpp "${InfoAtLink_file}"
+cp @CMAKE_SOURCE_DIR@/src/Informer/InfoAtLink.cpp "${InfoAtLink_file}"
 
 # - Formaline through the linker doesn't work on macOS and since we won't
 #   be doing production runs on macOS we disable it.
@@ -46,11 +46,11 @@ if [ -f @CMAKE_BINARY_DIR@/tmp/Formaline.sh ]; then
     . @CMAKE_BINARY_DIR@/tmp/Formaline.sh $(basename "${!oindex}")
     temp_files+=("${formaline_output}" "${formaline_object_output}")
     "$@" -DGIT_DESCRIPTION=$git_description -DGIT_BRANCH=$git_branch \
-         -I@Boost_INCLUDE_DIRS@ "${InfoAtLink_file}" "${formaline_output}" \
-         ${formaline_object_output}
+         -I@CMAKE_SOURCE_DIR@/src -I@Boost_INCLUDE_DIRS@ "${InfoAtLink_file}" \
+         "${formaline_output}" ${formaline_object_output}
 else
     "$@" -DGIT_DESCRIPTION=$git_description -DGIT_BRANCH=$git_branch \
-         -I@Boost_INCLUDE_DIRS@ "${InfoAtLink_file}"
+         -I@CMAKE_SOURCE_DIR@/src -I@Boost_INCLUDE_DIRS@ "${InfoAtLink_file}"
 fi
 
 if @WRAP_EXECUTABLE_LINKER_USE_STUB_OBJECT_FILES@; then


### PR DESCRIPTION
## Proposed changes

- Determine the git branch and description at the time an executable is linked, instead of using the info from CMake. The info from CMake can be wrong when switching branches doesn't require CMake to re-configure. This was an oversight on my part in #2673.
- Move the `info_from_build` function to `InfoAtCompile.cpp`. Now the `InfoAtLink.cpp` file doesn't depend on functions defined elsewhere anymore, and also doesn't need to be configured by CMake anymore.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
