### PR TITLE
Make alg::min_element and alg::max_element constexpr

### DIFF
--- a/src/Utilities/Algorithm.hpp
+++ b/src/Utilities/Algorithm.hpp
@@ -324,7 +324,7 @@ decltype(auto) equal(const Container& lhs, const Container2& rhs,
 
 /// Convenience wrapper around std::max_element
 template <class Container>
-decltype(auto) max_element(const Container& c) {
+constexpr decltype(auto) max_element(const Container& c) {
   using std::begin;
   using std::end;
   return std::max_element(begin(c), end(c));
@@ -332,7 +332,7 @@ decltype(auto) max_element(const Container& c) {
 
 /// Convenience wrapper around std::max_element
 template <class Container, class Compare>
-decltype(auto) max_element(const Container& c, Compare&& comp) {
+constexpr decltype(auto) max_element(const Container& c, Compare&& comp) {
   using std::begin;
   using std::end;
   return std::max_element(begin(c), end(c), std::forward<Compare>(comp));
@@ -340,7 +340,7 @@ decltype(auto) max_element(const Container& c, Compare&& comp) {
 
 /// Convenience wrapper around std::min_element
 template <class Container>
-decltype(auto) min_element(const Container& c) {
+constexpr decltype(auto) min_element(const Container& c) {
   using std::begin;
   using std::end;
   return std::min_element(begin(c), end(c));
@@ -348,7 +348,7 @@ decltype(auto) min_element(const Container& c) {
 
 /// Convenience wrapper around std::min_element
 template <class Container, class Compare>
-decltype(auto) min_element(const Container& c, Compare&& comp) {
+constexpr decltype(auto) min_element(const Container& c, Compare&& comp) {
   using std::begin;
   using std::end;
   return std::min_element(begin(c), end(c), std::forward<Compare>(comp));


### PR DESCRIPTION
## Proposed changes

This updates `alg::min_element` and `alg::max_element` to be `constexpr` since `std::min_element` and `std::max_element` are `constexpr` as of C++17 ([std::min_element](https://en.cppreference.com/w/cpp/algorithm/min_element), [std::max_element](https://en.cppreference.com/w/cpp/algorithm/max_element)).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
