### PR TITLE
Add ExportTimeDependentCoordinates3D

### DIFF
--- a/src/Executables/ExportCoordinates/CMakeLists.txt
+++ b/src/Executables/ExportCoordinates/CMakeLists.txt
@@ -18,7 +18,7 @@ add_spectre_parallel_executable(
   ExportCoordinates1D
   ExportCoordinates
   Executables/ExportCoordinates
-  Metavariables<1>
+  Metavariables<1,false>
   "${LIBS_TO_LINK}"
   )
 
@@ -26,7 +26,7 @@ add_spectre_parallel_executable(
   ExportCoordinates2D
   ExportCoordinates
   Executables/ExportCoordinates
-  Metavariables<2>
+  Metavariables<2,false>
   "${LIBS_TO_LINK}"
   )
 
@@ -34,6 +34,14 @@ add_spectre_parallel_executable(
   ExportCoordinates3D
   ExportCoordinates
   Executables/ExportCoordinates
-  Metavariables<3>
+  Metavariables<3,false>
+  "${LIBS_TO_LINK}"
+  )
+
+add_spectre_parallel_executable(
+  ExportTimeDependentCoordinates3D
+  ExportCoordinates
+  Executables/ExportCoordinates
+  Metavariables<3,true>
   "${LIBS_TO_LINK}"
   )

--- a/src/Executables/ExportCoordinates/ExportCoordinatesFwd.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinatesFwd.hpp
@@ -6,6 +6,6 @@
 #include <cstddef>
 
 /// \cond
-template <size_t Dim>
+template <size_t Dim, bool EnableTimeDependence>
 struct Metavariables;
 /// \endcond

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -1,0 +1,75 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: ExportTimeDependentCoordinates3D
+# Check: parse;execute
+# ExpectedOutput:
+#   ExportTimeDependentCoordinates3DVolume0.h5
+
+DomainCreator:
+  # Parameters are chosen for an equal-mass, non-spinning binary black hole
+  # using superposed-Kerr-Schild initial data created with the
+  # Spectral Einstein Code (SpEC). The time-dependent maps are given
+  # arbitrary time-dependence.
+  BinaryCompactObject:
+    ObjectA:
+      InnerRadius: 0.4409
+      OuterRadius: 6.0
+      XCoord: -10.0
+      ExciseInterior: true
+      UseLogarithmicMap: false
+      AdditionToRadialRefinementLevel: 1
+    ObjectB:
+      InnerRadius: 0.4409
+      OuterRadius: 6.0
+      XCoord: 10.0
+      ExciseInterior: true
+      UseLogarithmicMap: false
+      AdditionToRadialRefinementLevel: 1
+    EnvelopingCube:
+      Radius: 100.0
+    OuterSphere:
+      Radius: 590.0
+      UseLogarithmicMap: false
+      AdditionToRadialRefinementLevel: 0
+    InitialRefinement: 0
+    InitialGridPoints: 3
+    UseProjectiveMap: true
+    TimeDependentMaps:
+      InitialTime: 0.0
+      InitialExpirationDeltaT: Auto
+      ExpansionMap:
+        OuterBoundary: 590.0
+        InitialExpansion: [1.0, 1.0]
+        InitialExpansionVelocity: [0.01, 0.02]
+        FunctionOfTimeNames: ['ExpansionFactor',  'Unity']
+      RotationAboutZAxisMap:
+        InitialRotationAngle: 0.0
+        InitialAngularVelocity: 0.0
+        FunctionOfTimeName: RotationAngle
+      SizeMap:
+        InitialValues: [0.0, 0.0]
+        InitialVelocities: [-0.1, -0.1]
+        InitialAccelerations: [-0.2, -0.2]
+        FunctionOfTimeNames: ['LambdaFactorA0',  'LambdaFactorB0']
+
+SpatialDiscretization:
+  DiscontinuousGalerkin:
+    Quadrature: GaussLobatto
+
+Evolution:
+  InitialTime: 0.0
+  InitialTimeStep: 0.01
+  TimeStepper:
+    AdamsBashforthN:
+      Order: 1
+
+EventsAndTriggers:
+  ? TimeCompares:
+      Comparison: GreaterThanOrEqualTo
+      Value: 0.08
+  : - Completion
+
+Observers:
+  VolumeFileName: "ExportTimeDependentCoordinates3DVolume"
+  ReductionFileName: "ExportTimeDependentCoordinates3DReductions"


### PR DESCRIPTION
## Proposed changes

This PR adds a new variant of `ExportCoordinates` family of executables: `ExportTimeDependentCoordinates3D`. This variant will enable time-dependent maps in the domain (currently, `BinaryCompactObject` is the only domain that supports this).

This executable is necessary for inspecting time-dependent domains, to ensure that they are behaving properly. It is also used as part of interpolating initial data for binary black holes from SpEC (to ensure the target coordinates for interpolation are in the inertial frame).

Note that because only `BinaryCompactObject` currently supports this, and `BinaryCompactObject` only uses three spatial dimensions, this PR does not add the necessary code to `CMakeLists.txt` to compile `ExportTimeDependentCoordinates1D` or `ExportTimeDependentCoordinates2D`, since there is no domain that could be used to test it.


### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
