### PR TITLE
Subcell GRMHD: add VariablesNeededFixing tag and TCI options

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/CMakeLists.txt
@@ -1,9 +1,16 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  TciOptions.cpp
+  )
+
 spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Subcell.hpp
+  TciOptions.hpp
   )

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOptions.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOptions.cpp
@@ -1,0 +1,14 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOptions.hpp"
+
+#include <pup.h>
+
+namespace grmhd::ValenciaDivClean::subcell {
+void TciOptions::pup(PUP::er& p) noexcept {
+  p | minimum_rest_mass_density_times_lorentz_factor;
+  p | atmosphere_density;
+  p | safety_factor_for_magnetic_field;
+}
+}  // namespace grmhd::ValenciaDivClean::subcell

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOptions.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOptions.hpp
@@ -1,0 +1,92 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags/OptionsGroup.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace grmhd::ValenciaDivClean::subcell {
+/*!
+ * \brief Class holding options using by the GRMHD-specific parts of the
+ * troubled-cell indicator.
+ */
+struct TciOptions {
+  /// \brief Minimum value of rest-mass density times Lorentz factor before we
+  /// switch to subcell. Used to identify places where the density has suddenly
+  /// become negative
+  struct MinimumValueOfD {
+    using type = double;
+    static type lower_bound() noexcept { return 0.0; }
+    static constexpr Options::String help = {
+        "Minimum value of rest-mass density times Lorentz factor before we "
+        "switch to subcell."};
+  };
+  /// \brief The density cutoff where if the maximum value of the density in the
+  /// DG element is below this value we skip primitive recovery and treat the
+  /// cell as atmosphere.
+  struct AtmosphereDensity {
+    using type = double;
+    static type lower_bound() noexcept { return 0.0; }
+    static constexpr Options::String help = {
+        "The density cutoff where if the maximum value of the density in the "
+        "DG element is below this value we skip primitive recovery and treat "
+        "the cell as atmosphere."};
+  };
+  /// \brief Safety factor \f$\epsilon_B\f$.
+  ///
+  /// See the documentation for TciOnDgGrid for details on what this parameter
+  /// controls.
+  struct SafetyFactorForB {
+    using type = double;
+    static type lower_bound() noexcept { return 0.0; }
+    static constexpr Options::String help = {
+        "Safety factor for magnetic field bound."};
+  };
+
+  using options =
+      tmpl::list<MinimumValueOfD, AtmosphereDensity, SafetyFactorForB>;
+  static constexpr Options::String help = {
+      "Options for the troubled-cell indicator."};
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) noexcept;
+
+  double minimum_rest_mass_density_times_lorentz_factor{
+      std::numeric_limits<double>::signaling_NaN()};
+  double atmosphere_density{std::numeric_limits<double>::signaling_NaN()};
+  double safety_factor_for_magnetic_field{
+      std::numeric_limits<double>::signaling_NaN()};
+};
+
+namespace OptionTags {
+struct TciOptions {
+  using type = subcell::TciOptions;
+  static constexpr Options::String help = "GRMHD-specific options for the TCI.";
+  using group = ::dg::OptionTags::DiscontinuousGalerkinGroup;
+};
+}  // namespace OptionTags
+
+namespace Tags {
+struct TciOptions : db::SimpleTag {
+  using type = subcell::TciOptions;
+
+  using option_tags = tmpl::list<OptionTags::TciOptions>;
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& tci_options) noexcept {
+    return tci_options;
+  }
+};
+}  // namespace Tags
+}  // namespace grmhd::ValenciaDivClean::subcell

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp
@@ -56,6 +56,12 @@ struct TildePhi : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 
+/// \brief Set to `true` if the variables needed fixing.
+///
+/// Used in DG-subcell hybrid scheme evolutions.
+struct VariablesNeededFixing : db::SimpleTag {
+  using type = bool;
+};
 }  // namespace Tags
 
 namespace OptionTags {

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBRARY_SOURCES
   Test_Fluxes.cpp
   Test_PrimitiveFromConservative.cpp
   Test_Sources.cpp
+  Test_Tags.cpp
   Test_TimeDerivativeTerms.cpp
   Test_ValenciaDivClean.cpp
   )

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   BoundaryConditions/Test_DirichletAnalytic.cpp
   BoundaryConditions/Test_Periodic.cpp
   BoundaryCorrections/Test_Rusanov.cpp
+  Subcell/Test_TciOptions.cpp
   Test_Characteristics.cpp
   Test_ConservativeFromPrimitive.cpp
   Test_FixConservatives.cpp

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOptions.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOptions.cpp
@@ -1,0 +1,21 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOptions.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.Subcell.TciOptions",
+                  "[Unit][GrMhd]") {
+  const auto tci_options_from_opts = TestHelpers::test_option_tag<
+      grmhd::ValenciaDivClean::subcell::OptionTags::TciOptions>(
+      "MinimumValueOfD: 1.0e-18\n"
+      "AtmosphereDensity: 1.1e-12\n"
+      "SafetyFactorForB: 1.0e-12\n");
+  const auto tci_options = serialize_and_deserialize(tci_options_from_opts);
+  CHECK(tci_options.minimum_rest_mass_density_times_lorentz_factor == 1.0e-18);
+  CHECK(tci_options.atmosphere_density == 1.1e-12);
+  CHECK(tci_options.safety_factor_for_magnetic_field == 1.0e-12);
+}

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Tags.cpp
@@ -1,0 +1,16 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.ValenciaDivClean.Tags",
+                  "[Unit][Evolution]") {
+  TestHelpers::db::test_simple_tag<
+      grmhd::ValenciaDivClean::Tags::VariablesNeededFixing>(
+          "VariablesNeededFixing");
+}


### PR DESCRIPTION
## Proposed changes

- The `VariablesNeededFixing` is used when on the subcells to tell the TCI if the solution was bad and we shouldn't go back to DG. 
- And `TciOptions` struct that houses the system-specific TCI options. At some point it might be worth revisiting the input file layout for all the subcell code, but I think that's best done after we can do evolutions and know what features we need.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
