### PR TITLE
Subcell: Add TciOnDgGrid mutator for NewtonianEuler

### DIFF
--- a/src/Evolution/Systems/NewtonianEuler/Subcell/CMakeLists.txt
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/CMakeLists.txt
@@ -5,6 +5,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   InitialDataTci.cpp
+  TciOnDgGrid.cpp
   )
 
 spectre_target_headers(
@@ -13,4 +14,5 @@ spectre_target_headers(
   HEADERS
   InitialDataTci.hpp
   Subcell.hpp
+  TciOnDgGrid.hpp
   )

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnDgGrid.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnDgGrid.cpp
@@ -1,0 +1,67 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/NewtonianEuler/Subcell/TciOnDgGrid.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/DgSubcell/PerssonTci.hpp"
+#include "Evolution/Systems/NewtonianEuler/PrimitiveFromConservative.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace NewtonianEuler::subcell {
+template <size_t Dim>
+template <size_t ThermodynamicDim>
+bool TciOnDgGrid<Dim>::apply(
+    const gsl::not_null<Variables<
+        tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>>*>
+        dg_prim_vars,
+    const Scalar<DataVector>& mass_density,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& momentum_density,
+    const Scalar<DataVector>& energy_density,
+    const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
+    const Mesh<Dim>& dg_mesh, const double persson_exponent) noexcept {
+  NewtonianEuler::PrimitiveFromConservative<Dim, ThermodynamicDim>::apply(
+      make_not_null(&get<MassDensity>(*dg_prim_vars)),
+      make_not_null(&get<Velocity>(*dg_prim_vars)),
+      make_not_null(&get<SpecificInternalEnergy>(*dg_prim_vars)),
+      make_not_null(&get<Pressure>(*dg_prim_vars)), mass_density,
+      momentum_density, energy_density, eos);
+  constexpr double persson_tci_epsilon = 1.0e-18;
+  return min(get(mass_density)) < min_density_allowed or
+         min(get(get<Pressure>(*dg_prim_vars))) < min_pressure_allowed or
+         evolution::dg::subcell::persson_tci(
+             mass_density, dg_mesh, persson_exponent, persson_tci_epsilon) or
+         evolution::dg::subcell::persson_tci(get<Pressure>(*dg_prim_vars),
+                                             dg_mesh, persson_exponent,
+                                             persson_tci_epsilon);
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define INSTANTIATION(r, data) template class TciOnDgGrid<DIM(data)>;
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+#undef INSTANTIATION
+
+#define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define INSTANTIATION(r, data)                                                 \
+  template bool TciOnDgGrid<DIM(data)>::apply<THERMO_DIM(data)>(               \
+      const gsl::not_null<Variables<tmpl::list<                                \
+          MassDensity, Velocity, SpecificInternalEnergy, Pressure>>*>          \
+          dg_prim_vars,                                                        \
+      const Scalar<DataVector>& mass_density,                                  \
+      const tnsr::I<DataVector, DIM(data), Frame::Inertial>& momentum_density, \
+      const Scalar<DataVector>& energy_density,                                \
+      const EquationsOfState::EquationOfState<false, THERMO_DIM(data)>& eos,   \
+      const Mesh<DIM(data)>& dg_mesh, const double persson_exponent) noexcept;
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
+#undef INSTANTIATION
+#undef THERMO_DIM
+#undef DIM
+}  // namespace NewtonianEuler::subcell

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnDgGrid.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnDgGrid.hpp
@@ -1,0 +1,80 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace EquationsOfState {
+template <bool IsRelativistic, size_t ThermodynamicDim>
+class EquationOfState;
+}  // namespace EquationsOfState
+template <size_t Dim>
+class Mesh;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+template <typename T>
+class Variables;
+/// \endcond
+
+namespace NewtonianEuler::subcell {
+/*!
+ * \brief Troubled-cell indicator applied to the DG solution.
+ *
+ * Computes the primitive variables on the DG grid, mutating them in the
+ * DataBox. Then,
+ * - if the minimum density or pressure are below \f$10^{-18}\f$ (the arbitrary
+ *   threshold used to signal "negative" density and pressure), marks the
+ *   element as troubled and returns
+ * - runs the Persson TCI on the density and pressure. The reason for applying
+ *   the Persson TCI to both the density and pressure is to flag cells at
+ *   contact discontinuities.
+ */
+template <size_t Dim>
+class TciOnDgGrid {
+ private:
+  using MassDensityCons = NewtonianEuler::Tags::MassDensityCons;
+  using EnergyDensity = NewtonianEuler::Tags::EnergyDensity;
+  using MomentumDensity = NewtonianEuler::Tags::MomentumDensity<Dim>;
+
+  using MassDensity = NewtonianEuler::Tags::MassDensity<DataVector>;
+  using Velocity = NewtonianEuler::Tags::Velocity<DataVector, Dim>;
+  using SpecificInternalEnergy =
+      NewtonianEuler::Tags::SpecificInternalEnergy<DataVector>;
+  using Pressure = NewtonianEuler::Tags::Pressure<DataVector>;
+
+  static constexpr double min_density_allowed = 1.0e-18;
+  static constexpr double min_pressure_allowed = 1.0e-18;
+
+ public:
+  using return_tags = tmpl::list<::Tags::Variables<
+      tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>>>;
+  using argument_tags =
+      tmpl::list<MassDensityCons, MomentumDensity, EnergyDensity,
+                 hydro::Tags::EquationOfStateBase, domain::Tags::Mesh<Dim>>;
+
+  template <size_t ThermodynamicDim>
+  static bool apply(
+      const gsl::not_null<Variables<
+          tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>>*>
+          dg_prim_vars,
+      const Scalar<DataVector>& mass_density,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& momentum_density,
+      const Scalar<DataVector>& energy_density,
+      const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
+      const Mesh<Dim>& dg_mesh, const double persson_exponent) noexcept;
+};
+}  // namespace NewtonianEuler::subcell

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
   BoundaryCorrections/Test_Hllc.cpp
   BoundaryCorrections/Test_Rusanov.cpp
   Subcell/Test_InitialDataTci.cpp
+  Subcell/Test_TciOnDgGrid.cpp
   Test_Characteristics.cpp
   Test_ConservativeFromPrimitive.cpp
   Test_Fluxes.cpp

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TciOnDgGrid.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TciOnDgGrid.cpp
@@ -1,0 +1,102 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <memory>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Systems/NewtonianEuler/ConservativeFromPrimitive.hpp"
+#include "Evolution/Systems/NewtonianEuler/Subcell/TciOnDgGrid.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+
+namespace {
+enum class TestThis {
+  AllGood,
+  SmallDensity,
+  SmallPressure,
+  PerssonDensity,
+  PerssonPressure
+};
+
+template <size_t Dim>
+void test(const TestThis test_this) {
+  using MassDensityCons = NewtonianEuler::Tags::MassDensityCons;
+  using EnergyDensity = NewtonianEuler::Tags::EnergyDensity;
+  using MomentumDensity = NewtonianEuler::Tags::MomentumDensity<Dim>;
+
+  using MassDensity = NewtonianEuler::Tags::MassDensity<DataVector>;
+  using Velocity = NewtonianEuler::Tags::Velocity<DataVector, Dim>;
+  using SpecificInternalEnergy =
+      NewtonianEuler::Tags::SpecificInternalEnergy<DataVector>;
+  using Pressure = NewtonianEuler::Tags::Pressure<DataVector>;
+
+  const Mesh<Dim> dg_mesh{5, Spectral::Basis::Legendre,
+                          Spectral::Quadrature::GaussLobatto};
+
+  using cons_tags = tmpl::list<MassDensityCons, MomentumDensity, EnergyDensity>;
+  using ConsVars = Variables<cons_tags>;
+  using prim_tags =
+      tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>;
+  using PrimVars = Variables<prim_tags>;
+
+  const double persson_exponent = 4.0;
+  PrimVars dg_prims{dg_mesh.number_of_grid_points(), 1.0e-7};
+  std::unique_ptr<EquationsOfState::EquationOfState<false, 2>> eos =
+      std::make_unique<EquationsOfState::IdealFluid<false>>(5.0 / 3.0);
+  if (test_this == TestThis::SmallDensity) {
+    get(get<MassDensity>(dg_prims))[dg_mesh.number_of_grid_points() / 2] =
+        0.1 * 1.0e-18;
+  } else if (test_this == TestThis::SmallPressure) {
+    get(get<Pressure>(dg_prims))[dg_mesh.number_of_grid_points() / 2] =
+        0.1 * 1.0e-18;
+  } else if (test_this == TestThis::PerssonDensity) {
+    get(get<MassDensity>(dg_prims))[dg_mesh.number_of_grid_points() / 2] =
+        1.0e18;
+  } else if (test_this == TestThis::PerssonPressure) {
+    get(get<Pressure>(dg_prims))[dg_mesh.number_of_grid_points() / 2] = 1.0e18;
+  }
+
+  get<SpecificInternalEnergy>(dg_prims) =
+      eos->specific_internal_energy_from_density_and_pressure(
+          get<MassDensity>(dg_prims), get<Pressure>(dg_prims));
+
+  auto box = db::create<
+      db::AddSimpleTags<::Tags::Variables<cons_tags>,
+                        ::Tags::Variables<prim_tags>, ::domain::Tags::Mesh<Dim>,
+                        hydro::Tags::EquationOfState<std::unique_ptr<
+                            EquationsOfState::EquationOfState<false, 2>>>>>(
+      ConsVars{dg_mesh.number_of_grid_points()}, dg_prims, dg_mesh,
+      std::move(eos));
+  db::mutate_apply<NewtonianEuler::ConservativeFromPrimitive<Dim>>(
+      make_not_null(&box));
+  const bool result =
+      db::mutate_apply<NewtonianEuler::subcell::TciOnDgGrid<Dim>>(
+          make_not_null(&box), persson_exponent);
+  if (test_this == TestThis::AllGood) {
+    CHECK_FALSE(result);
+  } else {
+    CHECK(result);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.NewtonianEuler.Subcell.TciOnDgGrid",
+                  "[Unit][Evolution]") {
+  for (const auto test_this :
+       {TestThis::AllGood, TestThis::SmallDensity, TestThis::SmallPressure,
+        TestThis::PerssonDensity, TestThis::PerssonPressure}) {
+    test<1>(test_this);
+    test<2>(test_this);
+    test<3>(test_this);
+  }
+}


### PR DESCRIPTION
## Proposed changes

Add the troubled-cell indicator on the DG grid for NewtonianEuler.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
