### PR TITLE
Subcell: Add TciOnFdGrid mutator for NewtonianEuler 

### DIFF
--- a/src/Evolution/Systems/NewtonianEuler/Subcell/CMakeLists.txt
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/CMakeLists.txt
@@ -6,6 +6,7 @@ spectre_target_sources(
   PRIVATE
   InitialDataTci.cpp
   TciOnDgGrid.cpp
+  TciOnFdGrid.cpp
   )
 
 spectre_target_headers(
@@ -15,4 +16,5 @@ spectre_target_headers(
   InitialDataTci.hpp
   Subcell.hpp
   TciOnDgGrid.hpp
+  TciOnFdGrid.hpp
   )

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnFdGrid.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnFdGrid.cpp
@@ -1,0 +1,90 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/NewtonianEuler/Subcell/TciOnFdGrid.hpp"
+
+#include <algorithm>
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/DgSubcell/PerssonTci.hpp"
+#include "Evolution/Systems/NewtonianEuler/PrimitiveFromConservative.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace NewtonianEuler::subcell {
+template <size_t Dim>
+template <size_t ThermodynamicDim>
+bool TciOnFdGrid<Dim>::apply(
+    const gsl::not_null<Variables<
+        tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>>*>
+        subcell_grid_prim_vars,
+    const Scalar<DataVector>& subcell_mass_density,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& subcell_momentum_density,
+    const Scalar<DataVector>& subcell_energy_density,
+    const Scalar<DataVector>& dg_mass_density,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& dg_momentum_density,
+    const Scalar<DataVector>& dg_energy_density,
+    const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
+    const Mesh<Dim>& dg_mesh, const double persson_exponent) noexcept {
+  constexpr double persson_tci_epsilon = 1.0e-18;
+  NewtonianEuler::PrimitiveFromConservative<Dim, ThermodynamicDim>::apply(
+      make_not_null(&get<MassDensity>(*subcell_grid_prim_vars)),
+      make_not_null(&get<Velocity>(*subcell_grid_prim_vars)),
+      make_not_null(&get<SpecificInternalEnergy>(*subcell_grid_prim_vars)),
+      make_not_null(&get<Pressure>(*subcell_grid_prim_vars)),
+      subcell_mass_density, subcell_momentum_density, subcell_energy_density,
+      eos);
+  Variables<tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>>
+      dg_grid_prim_vars{get(dg_energy_density).size()};
+  NewtonianEuler::PrimitiveFromConservative<Dim, ThermodynamicDim>::apply(
+      make_not_null(&get<MassDensity>(dg_grid_prim_vars)),
+      make_not_null(&get<Velocity>(dg_grid_prim_vars)),
+      make_not_null(&get<SpecificInternalEnergy>(dg_grid_prim_vars)),
+      make_not_null(&get<Pressure>(dg_grid_prim_vars)), dg_mass_density,
+      dg_momentum_density, dg_energy_density, eos);
+
+  using std::min;
+  return min(min(get(subcell_mass_density)), min(get(dg_mass_density))) <
+             min_density_allowed or
+         min(min(get(get<Pressure>(*subcell_grid_prim_vars))),
+             min(get(get<Pressure>(dg_grid_prim_vars)))) <
+             min_pressure_allowed or
+         evolution::dg::subcell::persson_tci(
+             dg_mass_density, dg_mesh, persson_exponent, persson_tci_epsilon) or
+         evolution::dg::subcell::persson_tci(get<Pressure>(dg_grid_prim_vars),
+                                             dg_mesh, persson_exponent,
+                                             persson_tci_epsilon);
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define INSTANTIATION(r, data) template class TciOnFdGrid<DIM(data)>;
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+#undef INSTANTIATION
+
+#define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define INSTANTIATION(r, data)                                               \
+  template bool TciOnFdGrid<DIM(data)>::apply<THERMO_DIM(data)>(             \
+      const gsl::not_null<Variables<tmpl::list<                              \
+          MassDensity, Velocity, SpecificInternalEnergy, Pressure>>*>        \
+          subcell_grid_prim_vars,                                            \
+      const Scalar<DataVector>& subcell_mass_density,                        \
+      const tnsr::I<DataVector, DIM(data), Frame::Inertial>&                 \
+          subcell_momentum_density,                                          \
+      const Scalar<DataVector>& subcell_energy_density,                      \
+      const Scalar<DataVector>& dg_mass_density,                             \
+      const tnsr::I<DataVector, DIM(data), Frame::Inertial>&                 \
+          dg_momentum_density,                                               \
+      const Scalar<DataVector>& dg_energy_density,                           \
+      const EquationsOfState::EquationOfState<false, THERMO_DIM(data)>& eos, \
+      const Mesh<DIM(data)>& dg_mesh, const double persson_exponent) noexcept;
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
+#undef INSTANTIATION
+#undef THERMO_DIM
+#undef DIM
+}  // namespace NewtonianEuler::subcell

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnFdGrid.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnFdGrid.hpp
@@ -1,0 +1,93 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+template <size_t Dim>
+class Mesh;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+template <typename TagsList>
+class Variables;
+/// \endcond
+
+namespace NewtonianEuler::subcell {
+/*!
+ * \brief Troubled-cell indicator applied to the finite difference subcell
+ * solution to check if the corresponding DG solution is admissible.
+ *
+ * Computes the primitive variables on the DG and subcell grids, mutating the
+ * subcell/active primitive variables in the DataBox. Then,
+ * - if the minimum density or pressure on either the DG or subcell mesh are
+ *   below \f$10^{-18}\f$, marks the element as troubled and returns. We check
+ *   both the FD and DG grids since when a discontinuity is inside the element
+ *   oscillations in the DG solution can result in negative values that aren't
+ *   present in the FD solution.
+ * - runs the Persson TCI on the density and pressure on the DG grid. The reason
+ *   for applying the Persson TCI to both the density and pressure is to flag
+ *   cells at contact discontinuities. The Persson TCI only works with
+ *   spectral-type methods and is a direct check of whether or not the DG
+ *   solution is a good representation of the underlying data.
+ *
+ * Please note that the TCI is run after the subcell solution has been
+ * reconstructed to the DG grid, and so `Inactive<Tag>` is the updated DG
+ * solution.
+ */
+template <size_t Dim>
+class TciOnFdGrid {
+ private:
+  using MassDensityCons = NewtonianEuler::Tags::MassDensityCons;
+  using EnergyDensity = NewtonianEuler::Tags::EnergyDensity;
+  using MomentumDensity = NewtonianEuler::Tags::MomentumDensity<Dim>;
+
+  using MassDensity = NewtonianEuler::Tags::MassDensity<DataVector>;
+  using Velocity = NewtonianEuler::Tags::Velocity<DataVector, Dim>;
+  using SpecificInternalEnergy =
+      NewtonianEuler::Tags::SpecificInternalEnergy<DataVector>;
+  using Pressure = NewtonianEuler::Tags::Pressure<DataVector>;
+
+  template <typename Tag>
+  using Inactive = evolution::dg::subcell::Tags::Inactive<Tag>;
+
+  static constexpr double min_density_allowed = 1.0e-18;
+  static constexpr double min_pressure_allowed = 1.0e-18;
+
+ public:
+  using return_tags = tmpl::list<::Tags::Variables<
+      tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>>>;
+  using argument_tags =
+      tmpl::list<MassDensityCons, MomentumDensity, EnergyDensity,
+                 Inactive<MassDensityCons>, Inactive<MomentumDensity>,
+                 Inactive<EnergyDensity>, hydro::Tags::EquationOfStateBase,
+                 domain::Tags::Mesh<Dim>>;
+
+  template <size_t ThermodynamicDim>
+  static bool apply(
+      gsl::not_null<Variables<
+          tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>>*>
+          subcell_grid_prim_vars,
+      const Scalar<DataVector>& subcell_mass_density,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& subcell_momentum_density,
+      const Scalar<DataVector>& subcell_energy_density,
+      const Scalar<DataVector>& dg_mass_density,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& dg_momentum_density,
+      const Scalar<DataVector>& dg_energy_density,
+      const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
+      const Mesh<Dim>& dg_mesh, double persson_exponent) noexcept;
+};
+}  // namespace NewtonianEuler::subcell

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBRARY_SOURCES
   BoundaryCorrections/Test_Rusanov.cpp
   Subcell/Test_InitialDataTci.cpp
   Subcell/Test_TciOnDgGrid.cpp
+  Subcell/Test_TciOnFdGrid.cpp
   Test_Characteristics.cpp
   Test_ConservativeFromPrimitive.cpp
   Test_Fluxes.cpp

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TciOnFdGrid.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TciOnFdGrid.cpp
@@ -1,0 +1,146 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <memory>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/Systems/NewtonianEuler/ConservativeFromPrimitive.hpp"
+#include "Evolution/Systems/NewtonianEuler/Subcell/TciOnFdGrid.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+
+namespace {
+template <typename Tag>
+using Inactive = evolution::dg::subcell::Tags::Inactive<Tag>;
+
+enum class TestThis {
+  AllGood,
+  SmallDensityDg,
+  SmallDensitySubcell,
+  SmallPressureDg,
+  SmallPressureSubcell,
+  PerssonDensity,
+  PerssonPressure
+};
+
+template <size_t Dim>
+void test(const TestThis test_this) {
+  CAPTURE(Dim);
+  using MassDensityCons = NewtonianEuler::Tags::MassDensityCons;
+  using EnergyDensity = NewtonianEuler::Tags::EnergyDensity;
+  using MomentumDensity = NewtonianEuler::Tags::MomentumDensity<Dim>;
+
+  using MassDensity = NewtonianEuler::Tags::MassDensity<DataVector>;
+  using Velocity = NewtonianEuler::Tags::Velocity<DataVector, Dim>;
+  using SpecificInternalEnergy =
+      NewtonianEuler::Tags::SpecificInternalEnergy<DataVector>;
+  using Pressure = NewtonianEuler::Tags::Pressure<DataVector>;
+
+  const Mesh<Dim> dg_mesh{5, Spectral::Basis::Legendre,
+                          Spectral::Quadrature::GaussLobatto};
+  const Mesh<Dim> subcell_mesh = evolution::dg::subcell::fd::mesh(dg_mesh);
+
+  using cons_tags = tmpl::list<MassDensityCons, MomentumDensity, EnergyDensity>;
+  using ConsVars = Variables<cons_tags>;
+  using prim_tags =
+      tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>;
+  using PrimVars = Variables<prim_tags>;
+  using inactive_cons_tags =
+      tmpl::list<Inactive<MassDensityCons>, Inactive<MomentumDensity>,
+                 Inactive<EnergyDensity>>;
+  using InactiveConsVars = Variables<inactive_cons_tags>;
+  using inactive_prim_tags =
+      tmpl::list<Inactive<MassDensity>, Inactive<Velocity>,
+                 Inactive<SpecificInternalEnergy>, Inactive<Pressure>>;
+  using InactivePrimVars = Variables<inactive_prim_tags>;
+
+  const double persson_exponent = 4.0;
+  std::unique_ptr<EquationsOfState::EquationOfState<false, 2>> eos =
+      std::make_unique<EquationsOfState::IdealFluid<false>>(5.0 / 3.0);
+  ConsVars subcell_cons{subcell_mesh.number_of_grid_points()};
+  PrimVars subcell_prims{subcell_mesh.number_of_grid_points(), 1.0e-7};
+  InactivePrimVars dg_prim{dg_mesh.number_of_grid_points(), 1.0e-7};
+  InactiveConsVars dg_cons{dg_mesh.number_of_grid_points()};
+
+  if (test_this == TestThis::SmallPressureDg) {
+    get(get<Inactive<Pressure>>(dg_prim))[dg_mesh.number_of_grid_points() / 2] =
+        0.1 * 1.0e-18;
+  } else if (test_this == TestThis::PerssonPressure) {
+    get(get<Inactive<Pressure>>(dg_prim))[dg_mesh.number_of_grid_points() / 2] =
+        1.0;
+  }
+
+  get<Inactive<SpecificInternalEnergy>>(dg_prim) =
+      eos->specific_internal_energy_from_density_and_pressure(
+          get<Inactive<MassDensity>>(dg_prim),
+          get<Inactive<Pressure>>(dg_prim));
+  NewtonianEuler::ConservativeFromPrimitive<Dim>::apply(
+      make_not_null(&get<Inactive<MassDensityCons>>(dg_cons)),
+      make_not_null(&get<Inactive<MomentumDensity>>(dg_cons)),
+      make_not_null(&get<Inactive<EnergyDensity>>(dg_cons)),
+      get<Inactive<MassDensity>>(dg_prim), get<Inactive<Velocity>>(dg_prim),
+      get<Inactive<SpecificInternalEnergy>>(dg_prim));
+
+  if (test_this == TestThis::SmallDensitySubcell) {
+    get(get<MassDensity>(
+        subcell_prims))[subcell_mesh.number_of_grid_points() / 2] =
+        0.1 * 1.0e-18;
+  } else if (test_this == TestThis::SmallPressureSubcell) {
+    get(get<Pressure>(
+        subcell_prims))[subcell_mesh.number_of_grid_points() / 2] =
+        0.1 * 1.0e-18;
+  } else if (test_this == TestThis::SmallDensityDg) {
+    get(get<Inactive<MassDensityCons>>(
+        dg_cons))[dg_mesh.number_of_grid_points() / 2] = 0.1 * 1.0e-18;
+  } else if (test_this == TestThis::PerssonDensity) {
+    get(get<Inactive<MassDensityCons>>(
+        dg_cons))[dg_mesh.number_of_grid_points() / 2] = 1.0e18;
+  }
+
+  get<SpecificInternalEnergy>(subcell_prims) =
+      eos->specific_internal_energy_from_density_and_pressure(
+          get<MassDensity>(subcell_prims), get<Pressure>(subcell_prims));
+
+  auto box = db::create<db::AddSimpleTags<
+      ::Tags::Variables<cons_tags>, ::Tags::Variables<prim_tags>,
+      Inactive<::Tags::Variables<cons_tags>>, ::domain::Tags::Mesh<Dim>,
+      hydro::Tags::EquationOfState<
+          std::unique_ptr<EquationsOfState::EquationOfState<false, 2>>>>>(
+      subcell_cons, subcell_prims, dg_cons, dg_mesh, std::move(eos));
+  db::mutate_apply<NewtonianEuler::ConservativeFromPrimitive<Dim>>(
+      make_not_null(&box));
+  const bool result =
+      db::mutate_apply<NewtonianEuler::subcell::TciOnFdGrid<Dim>>(
+          make_not_null(&box), persson_exponent);
+  if (test_this == TestThis::AllGood) {
+    CHECK_FALSE(result);
+  } else {
+    CHECK(result);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.NewtonianEuler.Subcell.TciOnFdGrid",
+                  "[Unit][Evolution]") {
+  for (const auto test_this :
+       {TestThis::AllGood, TestThis::SmallDensityDg,
+        TestThis::SmallDensitySubcell, TestThis::SmallPressureDg,
+        TestThis::SmallPressureSubcell, TestThis::PerssonDensity,
+        TestThis::PerssonPressure}) {
+    test<1>(test_this);
+    test<2>(test_this);
+    test<3>(test_this);
+  }
+}


### PR DESCRIPTION
## Proposed changes

Add the troubled-cell indicator on the FD grid for NewtonianEuler.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
