### PR TITLE
Generalize spec reader to nth order polynomials

### DIFF
--- a/src/Domain/FunctionsOfTime/CMakeLists.txt
+++ b/src/Domain/FunctionsOfTime/CMakeLists.txt
@@ -9,7 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   PiecewisePolynomial.cpp
-  ReadSpecThirdOrderPiecewisePolynomial.cpp
+  ReadSpecPiecewisePolynomial.cpp
   RegisterDerivedWithCharm.cpp
   SettleToConstant.cpp
   )
@@ -21,7 +21,7 @@ spectre_target_headers(
   FunctionOfTime.hpp
   OptionTags.hpp
   PiecewisePolynomial.hpp
-  ReadSpecThirdOrderPiecewisePolynomial.hpp
+  ReadSpecPiecewisePolynomial.hpp
   RegisterDerivedWithCharm.hpp
   SettleToConstant.hpp
   Tags.hpp

--- a/src/Domain/FunctionsOfTime/ReadSpecPiecewisePolynomial.hpp
+++ b/src/Domain/FunctionsOfTime/ReadSpecPiecewisePolynomial.hpp
@@ -39,9 +39,10 @@ class PiecewisePolynomial;
 /// that we will read in with this action will always be 3rd-order
 /// piecewise polynomials.
 ///
-void read_spec_third_order_piecewise_polynomial(
+template <size_t MaxDeriv>
+void read_spec_piecewise_polynomial(
     gsl::not_null<std::unordered_map<
-        std::string, domain::FunctionsOfTime::PiecewisePolynomial<3>>*>
+        std::string, domain::FunctionsOfTime::PiecewisePolynomial<MaxDeriv>>*>
         spec_functions_of_time,
     const std::string& file_name,
     const std::map<std::string, std::string>& dataset_name_map) noexcept;

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -149,6 +149,10 @@ struct GeneralizedHarmonicDefaults {
   static constexpr bool use_damped_harmonic_rollon = true;
   using temporal_id = Tags::TimeStepId;
   static constexpr bool local_time_stepping = false;
+  // Set override_functions_of_time to true to override the
+  // 2nd or 3rd order piecewise polynomial functions of time using
+  // `read_spec_piecewise_polynomial()`
+  static constexpr bool override_functions_of_time = false;
 
   using normal_dot_numerical_flux = Tags::NumericalFlux<
     GeneralizedHarmonic::UpwindPenaltyCorrection<volume_dim>>;
@@ -317,7 +321,8 @@ struct GeneralizedHarmonicTemplateBase<
   using initialization_actions = tmpl::list<
       Actions::SetupDataBox,
       Initialization::Actions::TimeAndTimeStep<derived_metavars>,
-      evolution::dg::Initialization::Domain<volume_dim>,
+      evolution::dg::Initialization::Domain<volume_dim,
+                                            override_functions_of_time>,
       Initialization::Actions::NonconservativeSystem<system>,
       std::conditional_t<
           evolution::is_numeric_initial_data_v<initial_data>, tmpl::list<>,

--- a/src/Evolution/Initialization/DgDomain.hpp
+++ b/src/Evolution/Initialization/DgDomain.hpp
@@ -79,7 +79,7 @@ namespace Initialization {
  * mechanism, so `Actions::SetupDataBox` must be present in the `Initialization`
  * phase action list prior to this action.
  * \note If OverrideCubicFunctionsOfTime == true, then cubic functions
- * of time are overriden via `read_spec_third_order_piecewise_polynomial()`
+ * of time are overriden via `read_spec_piecewise_polynomial()`
  */
 template <size_t Dim, bool OverrideCubicFunctionsOfTime = false>
 struct Domain {

--- a/tests/Unit/Domain/FunctionsOfTime/CMakeLists.txt
+++ b/tests/Unit/Domain/FunctionsOfTime/CMakeLists.txt
@@ -5,7 +5,7 @@ set(LIBRARY "Test_FunctionsOfTime")
 
 set(LIBRARY_SOURCES
   Test_PiecewisePolynomial.cpp
-  Test_ReadSpecThirdOrderPiecewisePolynomial.cpp
+  Test_ReadSpecPiecewisePolynomial.cpp
   Test_SettleToConstant.cpp
   Test_Tags.cpp
   )

--- a/tests/Unit/Domain/FunctionsOfTime/Test_ReadSpecPiecewisePolynomial.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_ReadSpecPiecewisePolynomial.cpp
@@ -17,7 +17,7 @@
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/OptionTags.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
-#include "Domain/FunctionsOfTime/ReadSpecThirdOrderPiecewisePolynomial.hpp"
+#include "Domain/FunctionsOfTime/ReadSpecPiecewisePolynomial.hpp"
 #include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
 #include "Domain/FunctionsOfTime/Tags.hpp"
 #include "Domain/OptionTags.hpp"
@@ -107,13 +107,13 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.ReadSpecPiecewisePolynomial",
 
   const std::array<DataVector, 4> initial_rotation{
       {{{2.0}}, {{-0.1}}, {{-0.02}}, {{-0.003}}}};
-  const std::array<DataVector, number_of_times - 1> next_rotation_third_deriv{
+  const std::array<DataVector, number_of_times - 1> next_rotation_fourth_deriv{
       {{{-0.5}}, {{-0.75}}}};
   domain::FunctionsOfTime::PiecewisePolynomial<3> rotation(
       expected_times[0], initial_rotation, expected_times[0]);
-  rotation.update(expected_times[1], {{next_rotation_third_deriv[0]}},
+  rotation.update(expected_times[1], {{next_rotation_fourth_deriv[0]}},
                   expected_times[1]);
-  rotation.update(expected_times[2], {{next_rotation_third_deriv[1]}},
+  rotation.update(expected_times[2], {{next_rotation_fourth_deriv[1]}},
                   expected_times[2]);
   const std::array<std::array<DataVector, 3>, number_of_times - 1>&
       rotation_func_and_2_derivs_next{
@@ -149,12 +149,12 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.ReadSpecPiecewisePolynomial",
        rotation_func_and_2_derivs_next[0][0][0],
        rotation_func_and_2_derivs_next[0][1][0],
        rotation_func_and_2_derivs_next[0][2][0],
-       next_rotation_third_deriv[0][0]},
+       next_rotation_fourth_deriv[0][0]},
       {expected_times[2], expected_times[2], 1.0, 3.0, 1.0,
        rotation_func_and_2_derivs_next[1][0][0],
        rotation_func_and_2_derivs_next[1][1][0],
        rotation_func_and_2_derivs_next[1][2][0],
-       next_rotation_third_deriv[1][0]}};
+       next_rotation_fourth_deriv[1][0]}};
   const std::vector<std::string> rotation_legend{
       "Time", "TLastUpdate", "Nc",    "DerivOrder", "Version",
       "Phi",  "dPhi",        "d2Phi", "d3Phi"};
@@ -332,13 +332,13 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.ReadSpecPolyNonmonotonic",
 
   const std::array<DataVector, 4> initial_rotation{
       {{{2.0}}, {{-0.1}}, {{-0.02}}, {{-0.003}}}};
-  const std::array<DataVector, number_of_times - 1> next_rotation_third_deriv{
+  const std::array<DataVector, number_of_times - 1> next_rotation_fourth_deriv{
       {{{-0.5}}, {{-0.75}}}};
   domain::FunctionsOfTime::PiecewisePolynomial<3> rotation(
       expected_times[0], initial_rotation, expected_times[0]);
-  rotation.update(expected_times[1], {{next_rotation_third_deriv[0]}},
+  rotation.update(expected_times[1], {{next_rotation_fourth_deriv[0]}},
                   expected_times[1]);
-  rotation.update(expected_times[2], {{next_rotation_third_deriv[1]}},
+  rotation.update(expected_times[2], {{next_rotation_fourth_deriv[1]}},
                   expected_times[2]);
   const std::array<std::array<DataVector, 3>, number_of_times - 1>&
       rotation_func_and_2_derivs_next{
@@ -353,12 +353,12 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.ReadSpecPolyNonmonotonic",
        rotation_func_and_2_derivs_next[0][0][0],
        rotation_func_and_2_derivs_next[0][1][0],
        rotation_func_and_2_derivs_next[0][2][0],
-       next_rotation_third_deriv[0][0]},
+       next_rotation_fourth_deriv[0][0]},
       {expected_times[1], expected_times[1], 1.0, 3.0, 1.0,
        rotation_func_and_2_derivs_next[1][0][0],
        rotation_func_and_2_derivs_next[1][1][0],
        rotation_func_and_2_derivs_next[1][2][0],
-       next_rotation_third_deriv[1][0]}};
+       next_rotation_fourth_deriv[1][0]}};
   const std::vector<std::string> rotation_legend{
       "Time", "TLastUpdate", "Nc",    "DerivOrder", "Version",
       "Phi",  "dPhi",        "d2Phi", "d3Phi"};
@@ -371,7 +371,7 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.ReadSpecPolyNonmonotonic",
       spec_functions_of_time{};
   // Attempt to read in the file: will trigger error that file contains
   // a non-monotonic time step
-  domain::FunctionsOfTime::read_spec_third_order_piecewise_polynomial(
+  domain::FunctionsOfTime::read_spec_piecewise_polynomial(
       make_not_null(&spec_functions_of_time), test_filename, test_name_map);
 }
 
@@ -380,7 +380,7 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.ReadSpecPolyCols234Const",
                   "[Unit][Evolution][Actions]") {
   ERROR_TEST();
   // Each row in the SpEC data read by
-  // read_spec_third_order_piecewise_polynomial() should have the same values in
+  // read_spec_piecewise_polynomial() should have the same values in
   // column 2 (number of components), column 3 (max deriv order), or column 4
   // (version). This test checks that an appropriate ERROR() triggers if one of
   // these (randomly chosen) is not satisfied.
@@ -450,73 +450,6 @@ SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.ReadSpecPolyCols234Const",
       spec_functions_of_time{};
   // Attempt to read in the file: will trigger error that column 2, 3, or 4
   // should be constant, but one isn't
-  domain::FunctionsOfTime::read_spec_third_order_piecewise_polynomial(
-      make_not_null(&spec_functions_of_time), test_filename, test_name_map);
-}
-
-// [[OutputRegex, Deriv order in.*should be 3, not]]
-SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.ReadSpecPolyDerivOrder",
-                  "[Unit][Evolution][Actions]") {
-  ERROR_TEST();
-
-  // Create a temporary file with test data to read in
-  // First, check if the file exists, and delete it if so
-  const std::string test_filename{"TestSpecFuncOfTimeDataDerivOrder.h5"};
-  const std::map<std::string, std::string> test_name_map{
-      {{"RotationAngle", "RotationAngle"}}};
-  constexpr uint32_t version_number = 4;
-  if (file_system::check_if_file_exists(test_filename)) {
-    file_system::rm(test_filename, true);
-  }
-
-  h5::H5File<h5::AccessType::ReadWrite> test_file(test_filename);
-
-  constexpr size_t number_of_times = 3;
-  const std::array<double, number_of_times> expected_times{{0.0, 0.1, 0.2}};
-  const std::string expected_name{"RotationAngle"};
-
-  const std::array<DataVector, 4> initial_rotation{
-      {{{2.0}}, {{-0.1}}, {{-0.02}}, {{-0.003}}}};
-  const std::array<DataVector, number_of_times - 1> next_rotation_third_deriv{
-      {{{-0.5}}, {{-0.75}}}};
-  domain::FunctionsOfTime::PiecewisePolynomial<3> rotation(
-      expected_times[0], initial_rotation, expected_times[0]);
-  rotation.update(expected_times[1], {{next_rotation_third_deriv[0]}},
-                  expected_times[1]);
-  rotation.update(expected_times[2], {{next_rotation_third_deriv[1]}},
-                  expected_times[2]);
-  const std::array<std::array<DataVector, 3>, number_of_times - 1>&
-      rotation_func_and_2_derivs_next{
-          {rotation.func_and_2_derivs(expected_times[1]),
-           rotation.func_and_2_derivs(expected_times[2])}};
-
-  // The max derivative order is here set to 2.0 instead of 3.0, as required
-  const std::vector<std::vector<double>> test_rotation{
-      {expected_times[0], expected_times[0], 1.0, 2.0, 1.0,
-       initial_rotation[0][0], initial_rotation[1][0], initial_rotation[2][0],
-       initial_rotation[3][0]},
-      {expected_times[1], expected_times[1], 1.0, 2.0, 1.0,
-       rotation_func_and_2_derivs_next[0][0][0],
-       rotation_func_and_2_derivs_next[0][1][0],
-       rotation_func_and_2_derivs_next[0][2][0],
-       next_rotation_third_deriv[0][0]},
-      {expected_times[2], expected_times[2], 1.0, 2.0, 1.0,
-       rotation_func_and_2_derivs_next[1][0][0],
-       rotation_func_and_2_derivs_next[1][1][0],
-       rotation_func_and_2_derivs_next[1][2][0],
-       next_rotation_third_deriv[1][0]}};
-  const std::vector<std::string> rotation_legend{
-      "Time", "TLastUpdate", "Nc",    "DerivOrder", "Version",
-      "Phi",  "dPhi",        "d2Phi", "d3Phi"};
-  auto& rotation_file = test_file.insert<h5::Dat>(
-      "/" + expected_name, rotation_legend, version_number);
-  rotation_file.append(test_rotation);
-
-  std::unordered_map<std::string,
-                     domain::FunctionsOfTime::PiecewisePolynomial<3>>
-      spec_functions_of_time{};
-  // Attempt to read in the file: will trigger error that file contains
-  // a max deriv order other than 3
-  domain::FunctionsOfTime::read_spec_third_order_piecewise_polynomial(
+  domain::FunctionsOfTime::read_spec_piecewise_polynomial(
       make_not_null(&spec_functions_of_time), test_filename, test_name_map);
 }

--- a/tests/Unit/Domain/FunctionsOfTime/Test_Tags.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_Tags.cpp
@@ -14,7 +14,7 @@ namespace domain {
 template <bool Override>
 struct Metavariables {
   static constexpr size_t volume_dim = 3;
-  static constexpr bool override_cubic_functions_of_time = Override;
+  static constexpr bool override_functions_of_time = Override;
 };
 
 SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.Tags", "[Domain][Unit]") {


### PR DESCRIPTION
## Proposed changes

We eventually want to no longer rely on the spec function of time reader; instead of getting control system data from spec, we want to use spectre's own control system. But until that control system is ready, reading in spec control system data is necessary for running binary black holes with spectre.

This PR updates the spec piecewise-polynomial function of time reader to in principle support deriv orders other than three, since some spec control systems use 2nd order instead of 3rd order. This code generalizes to arbitrary derivative order where practical, but in one place it requires either second or third order piecewise polynomials, with a comment saying that we can expand this in the future if necessary. Since we hope to make this whole reader obsolete eventually, I don't think it's worth doing that now.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
