### PR TITLE
Improve GRMHD FixConservatives, remove seconds as unit of simulation time

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.cpp
@@ -197,19 +197,27 @@ bool FixConservatives::operator()(
                        f_of_lorentz_factor, lower_bound_of_lorentz_factor,
                        upper_bound_of_lorentz_factor, 1.e-14, 1.e-14, 50));
       } catch (std::exception& exception) {
+        // clang-format makes the streamed text hard to read in code...
+        // clang-format off
         ERROR(
             "Failed to fix conserved variables because the root finder failed "
             "to find the lorentz factor.\n"
-            "  Upper bound: "
+            "  upper_bound = "
+            << std::scientific << std::setprecision(18)
             << upper_bound_of_lorentz_factor
-            << "\n  Lower bound: " << lower_bound_of_lorentz_factor
-            << "\n  s_tilde_squared: " << s_tilde_squared
-            << "\n  d_tilde: " << d_tilde << "\n  sqrt_det_g: " << sqrt_det_g
-            << "\n  tau_tilde: " << tau_tilde
-            << "\n  b_tilde_squared: " << b_tilde_squared
-            << "\n  s_tilde_squared: " << s_tilde_squared << "\n"
-            << "The message of the exception thrown by the root finder is:\n"
+            << "\n  lower_bound = " << lower_bound_of_lorentz_factor
+            << "\n  s_tilde_squared = " << s_tilde_squared
+            << "\n  d_tilde = " << d_tilde
+            << "\n  sqrt_det_g: " << sqrt_det_g
+            << "\n  tau_tilde = " << tau_tilde
+            << "\n  b_tilde_squared = " << b_tilde_squared
+            << "\n  b_squared_over_d = " << b_squared_over_d
+            << "\n  tau_over_d = " << tau_over_d
+            << "\n  normalized_s_dot_b = " << normalized_s_dot_b << "\n"
+            << "The message of the exception thrown by the root finder "
+               "is:\n"
             << exception.what());
+          // clang-format on
       }
 
       const double upper_bound_for_s_tilde_squared =

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.hpp
@@ -32,32 +32,70 @@ class DataVector;
 namespace grmhd {
 namespace ValenciaDivClean {
 
-/// \ingroup VariableFixingGroup
-/// \brief Fix conservative variables using method developed by Foucart.
-///
-/// Adjusts the conservative variables as follows:
-/// - Changes \f${\tilde D}\f$, the generalized mass-energy density, such
-///   that \f$D\f$, the product of the rest mass density \f$\rho\f$ and the
-///   Lorentz factor \f$W\f$, is set to value of the option `MinimumValueOfD`,
-///   whenever \f$D\f$ is below the value of the option `CutoffD`.
-/// - Increases \f${\tilde \tau}\f$, the generalized internal energy density,
-///   such that
-///   \f${\tilde B}^2 \leq 2 \sqrt{\gamma} (1 - \epsilon_B) {\tilde \tau}\f$,
-///   where \f${\tilde B}^i\f$ is the generalized magnetic field,
-///   \f$\gamma\f$ is the determinant of the spatial metric, and
-///   \f$\epsilon_B\f$ is the option `SafetyFactorForB`.
-/// - Decreases \f${\tilde S}_i\f$, the generalized momentum density, such that
-///   \f${\tilde S}^2 \leq (1 - \epsilon_S) {\tilde S}^2_{max}\f$, where
-///   \f$\epsilon_S\f$ is the option `SafetyFactorForS`, and
-///   \f${\tilde S}^2_{max}\f$ is a complicated function of the conservative
-///   variables which can only be found through root finding. There are
-///   sufficient conditions for a set of conservative variables to satisfy the
-///   inequality, which can be used to avoid root finding at most points.
-///
-/// \note The routine currently assumes the minimum specific enthalpy is one.
-///
-/// For more details see Appendix B from the [thesis of Francois
-/// Foucart](https://ecommons.cornell.edu/handle/1813/30652)
+/*!
+ * \ingroup VariableFixingGroup
+ * \brief Fix conservative variables using method developed by Foucart.
+ *
+ * Adjusts the conservative variables as follows:
+ * - Changes \f${\tilde D}\f$, the generalized mass-energy density, such
+ *   that \f$D\f$, the product of the rest mass density \f$\rho\f$ and the
+ *   Lorentz factor \f$W\f$, is set to value of the option `MinimumValueOfD`,
+ *   whenever \f$D\f$ is below the value of the option `CutoffD`.
+ * - Increases \f${\tilde \tau}\f$, the generalized internal energy density,
+ *   such that
+ *   \f${\tilde B}^2 \leq 2 \sqrt{\gamma} (1 - \epsilon_B) {\tilde \tau}\f$,
+ *   where \f${\tilde B}^i\f$ is the generalized magnetic field,
+ *   \f$\gamma\f$ is the determinant of the spatial metric, and
+ *   \f$\epsilon_B\f$ is the option `SafetyFactorForB`.
+ * - Decreases \f${\tilde S}_i\f$, the generalized momentum density, such that
+ *   \f${\tilde S}^2 \leq (1 - \epsilon_S) {\tilde S}^2_{max}\f$, where
+ *   \f$\epsilon_S\f$ is the option `SafetyFactorForS`, and
+ *   \f${\tilde S}^2_{max}\f$ is a complicated function of the conservative
+ *   variables which can only be found through root finding. There are
+ *   sufficient conditions for a set of conservative variables to satisfy the
+ *   inequality, which can be used to avoid root finding at most points.
+ *
+ * \note The routine currently assumes the minimum specific enthalpy is one.
+ *
+ * For more details see Appendix B from the [thesis of Francois
+ * Foucart](https://ecommons.cornell.edu/handle/1813/30652)
+ *
+ * You can plot the function whose root we are finding using:
+ *
+ * \code{.py}
+ *
+ * import numpy as np
+ * import matplotlib.pyplot as plt
+ *
+ * upper_bound = 1.000119047987896748e+00
+ * lower_bound = 1.000000000000000000e+00
+ * s_tilde_squared = 5.513009056734747750e-30
+ * d_tilde = 1.131468709980503465e-12
+ * sqrt_det_g: 1.131468709980503418e+00
+ * tau_tilde = 1.346990732914080573e-16
+ * b_tilde_squared = 3.048155733848927391e-16
+ * b_squared_over_d = 2.380959757934347320e-04
+ * tau_over_d = 1.190479878968363843e-04
+ * normalized_s_dot_b = -9.999999082462245337e-01
+ *
+ *
+ * def function_of_w(lorentz_factor):
+ *     return ((lorentz_factor + b_squared_over_d - tau_over_d - 1.0) *
+ *             (lorentz_factor**2 + b_squared_over_d * normalized_s_dot_b**2 *
+ *              (b_squared_over_d + 2.0 * lorentz_factor)) -
+ *             0.5 * b_squared_over_d -
+ *             0.5 * b_squared_over_d * normalized_s_dot_b**2 *
+ *             (lorentz_factor**2 - 1.0 +
+ *              2.0 * lorentz_factor * b_squared_over_d + b_squared_over_d**2))
+ *
+ *
+ * lorentz_factor = np.linspace(lower_bound, upper_bound, num=10000)
+ *
+ * plt.plot(lorentz_factor, function_of_w(lorentz_factor))
+ * plt.show()
+ *
+ * \endcode
+ */
 class FixConservatives {
  public:
   /// \brief Minimum value of rest-mass density times lorentz factor

--- a/src/ParallelAlgorithms/Events/ObserveTimeStep.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveTimeStep.hpp
@@ -80,7 +80,7 @@ struct FormatTimeOutput
       noexcept {
     std::stringstream ss;
     ss  << "Simulation time: " << std::to_string(time)
-        << "s\n  Wall time: " << std::to_string(min_wall_time)
+        << "\n  Wall time: " << std::to_string(min_wall_time)
         << "s (min) - "
         << std::to_string(max_wall_time) << "s (max)";
     return ss.str();

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStep.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStep.cpp
@@ -94,7 +94,7 @@ struct MockContributeReductionData {
         0.123, 3, 1.560, 3.141, 2.7818, 1023.3, 9.32, 4.148
       );
       CHECK(formatted_msg ==
-        "Simulation time: 0.123000s\n"
+        "Simulation time: 0.123000\n"
         "  Wall time: 9.320000s (min) - 4.148000s (max)");
     }
   }

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStep.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStep.cpp
@@ -64,6 +64,7 @@ struct MockContributeReductionData {
     bool formatter_is_set {};
   };
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static std::optional<Results> results;
 
   template <typename ParallelComponent, typename... DbTags, typename ArrayIndex,
@@ -102,6 +103,7 @@ struct MockContributeReductionData {
 
 template <typename Metavariables>
 std::optional<typename MockContributeReductionData<Metavariables>::Results>
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     MockContributeReductionData<Metavariables>::results{};
 
 template <typename Metavariables>


### PR DESCRIPTION
## Proposed changes

- have FixConservatives print enough info to actually be able to reproduce the failure
- handle W=1 errors that occasionally occur
- add plotting code to diagnose FixConservatives failures more easily
- remove "seconds" as unit of simulation time

@moxcodes this might be useful if you run into FixConservatives issues :)

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
