### PR TITLE
Make Symmetry doc match implementation and prohibit antisymmetries

### DIFF
--- a/src/DataStructures/Tensor/Symmetry.hpp
+++ b/src/DataStructures/Tensor/Symmetry.hpp
@@ -55,6 +55,8 @@ struct SymmetryImpl;
 template <size_t... Is, std::int32_t... Ss>
 struct SymmetryImpl<std::index_sequence<Is...>,
                     tmpl::integral_list<std::int32_t, Ss...>> {
+  static_assert((... and (Ss > 0)),
+                "Symmetry values must be positive integers.");
   static constexpr cpp20::array<int, sizeof...(Is)> t =
       symmetry(std::array<int, sizeof...(Is)>{{Ss...}});
   using type = tmpl::integral_list<std::int32_t, t[Is]...>;
@@ -66,13 +68,10 @@ struct SymmetryImpl<std::index_sequence<Is...>,
 ///
 /// \details
 /// Compute the canonical symmetry typelist given a set of integers, T. The
-/// resulting typelist is in descending order of the absolute value of the
-/// integers. For example, the result of `Symmetry<1, 2, 3>` is
-/// `integral_list<int32_t, 3, 2, 1>`. Anti-symmetries can be denoted with a
-/// minus sign on either _or_ both indices. That is, `Symmetry<-1, 2, 1>` is
-/// anti-symmetric in the first and last index and is the same as `Symmetry<-1,
-/// 2, -1>`. Note: two minus signs are still anti-symmetric because it
-/// simplifies the algorithm used to compute the canonical form of the symmetry.
+/// resulting typelist is in ascending order of the integers, from right to
+/// left. For example, the result of `Symmetry<1, 2, 1, 3>` is
+/// `integral_list<int32_t, 2, 3, 2, 1>`. Anti-symmetries are not currently
+/// supported.
 ///
 /// \tparam T the integers denoting the symmetry of the Tensor
 template <std::int32_t... T>

--- a/tests/Unit/DataStructures/Tensor/Test_Tensor.cpp
+++ b/tests/Unit/DataStructures/Tensor/Test_Tensor.cpp
@@ -55,6 +55,12 @@ static_assert(
     "Failed testing Symmetry");
 static_assert(std::is_same_v<Symmetry<4>, tmpl::integral_list<std::int32_t, 1>>,
               "Failed testing Symmetry");
+static_assert(std::is_same_v<Symmetry<1, 2, 1, 3>,
+                             tmpl::integral_list<std::int32_t, 2, 3, 2, 1>>,
+              "Failed testing Symmetry");
+static_assert(std::is_same_v<Symmetry<5, 3, 1, 1, 5>,
+                             tmpl::integral_list<std::int32_t, 1, 3, 2, 2, 1>>,
+              "Failed testing Symmetry");
 
 // Test prepend_spacetime_index and prepend_spatial_index
 static_assert(std::is_same_v<tnsr::aB<double, 3, Frame::Grid>,


### PR DESCRIPTION
## Proposed changes

This PR updates the documentation of the `Symmetry` metafunction to match the behavior of the implementation, adds 2 new test cases to demonstrate the behavior, and prohibits antisymmetries (using `-1` to denote an antisymmetry) since (i) the underlying `symmetry` implementation does not currently preserve them and (ii) they aren't currently supported by or used in  other SpECTRE code.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
