### PR TITLE
Print backtrace on floating point exception

### DIFF
--- a/src/Utilities/ErrorHandling/FloatingPointExceptions.cpp
+++ b/src/Utilities/ErrorHandling/FloatingPointExceptions.cpp
@@ -3,7 +3,7 @@
 
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 
-#include "Utilities/System/Abort.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 
 #include <csignal>
 
@@ -20,7 +20,7 @@ auto old_mask = _mm_getcsr();
 #endif
 
 [[noreturn]] void fpe_signal_handler(int /*signal*/) {
-  sys::abort("Floating point exception!");  // LCOV_EXCL_LINE
+  ERROR("Floating point exception!");
 }
 }  // namespace
 


### PR DESCRIPTION
## Proposed changes

Exactly what the title says, because "FPE happened" is just not the best error message :)

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
