### PR TITLE
Fix failure in CylindricalSide

### DIFF
--- a/src/Domain/CoordinateMaps/CylindricalSide.cpp
+++ b/src/Domain/CoordinateMaps/CylindricalSide.cpp
@@ -90,10 +90,15 @@ CylindricalSide::CylindricalSide(const std::array<double, 3>& center_one,
          "proj_center is contained inside z_lower and z_upper: "
              << z_lower << " " << proj_center[2] << " " << z_upper);
 
-  ASSERT(center_one[2] - z_lower <= 0.95 * radius_one and
-             z_upper - center_one[2] <= 0.95 * radius_one,
+  ASSERT(center_one[2] - z_lower <= 0.92 * radius_one and
+             z_upper - center_one[2] <= 0.92 * radius_one,
          "CylindricalSide: The map has been tested only when z_lower and "
          "z_upper are sufficently far from the edge of sphere_one");
+
+  ASSERT(center_one[2] - z_lower >= 0.01 * radius_one and
+             z_upper - center_one[2] >= 0.01 * radius_one,
+         "CylindricalSide: The map has been tested only when z_lower and "
+         "z_upper are sufficently far from the center of sphere_one");
 
   if (dist_spheres + radius_two < radius_one) {
     ASSERT(center_one[2] - z_lower >= 0.2 * radius_one and

--- a/tests/Unit/Domain/CoordinateMaps/Test_CylindricalSide.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CylindricalSide.cpp
@@ -49,12 +49,13 @@ void test_cylindrical_side_sphere_two_encloses_sphere_one() {
   const std::array<double, 2> z_planes =
       [&gen, &unit_dis, &center_one, &radius_one ]() noexcept {
     // Make sure each z_plane intersects sphere_one in two locations;
-    // to do this, ensure that each plane is no closer than 5% of the
-    // radius to the min/max z-extents of sphere_one.
+    // to do this, ensure that each plane is no closer than 8% of the
+    // radius to the min/max z-extents of sphere_one and no closer than
+    // 1% of the radius to the center.
     const double z_plane_1 =
-        center_one[2] - (0.95 * unit_dis(gen)) * radius_one;
+        center_one[2] - (0.01 + 0.91 * unit_dis(gen)) * radius_one;
     const double z_plane_2 =
-        center_one[2] + (0.95 * unit_dis(gen)) * radius_one;
+        center_one[2] + (0.01 + 0.91 * unit_dis(gen)) * radius_one;
     return std::array<double, 2>{z_plane_1, z_plane_2};
   }
   ();
@@ -102,7 +103,7 @@ void test_cylindrical_side_sphere_one_encloses_sphere_two() {
   CAPTURE(radius_one);
 
   // Make sure each z_plane intersects sphere_one in two locations;
-  // to do this, ensure that each plane is no closer than 5% of the
+  // to do this, ensure that each plane is no closer than 8% of the
   // radius to the min/max z-extents of sphere_one.
   // Also make sure that each z_plane is not more than 20% away from
   // the center of sphere_one (because we need to fit sphere_two between
@@ -110,9 +111,9 @@ void test_cylindrical_side_sphere_one_encloses_sphere_two() {
   const std::array<double, 2> z_planes =
       [&gen, &unit_dis, &center_one, &radius_one ]() noexcept {
     const double z_plane_1 =
-        center_one[2] - (0.2 + 0.75 * unit_dis(gen)) * radius_one;
+        center_one[2] - (0.2 + 0.72 * unit_dis(gen)) * radius_one;
     const double z_plane_2 =
-        center_one[2] + (0.2 + 0.75 * unit_dis(gen)) * radius_one;
+        center_one[2] + (0.2 + 0.72 * unit_dis(gen)) * radius_one;
     return std::array<double, 2>{z_plane_1, z_plane_2};
   }
   ();

--- a/tests/Unit/Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -410,7 +410,9 @@ void test_inverse_map(const Map& map,
                       const std::array<T, Map::dim>& test_point) noexcept {
   INFO("Test inverse map");
   CAPTURE(test_point);
-  CHECK_ITERABLE_APPROX(test_point, map.inverse(map(test_point)).value());
+  const auto expected_test_point = map.inverse(map(test_point));
+  REQUIRE(expected_test_point.has_value());
+  CHECK_ITERABLE_APPROX(test_point, expected_test_point.value());
 }
 
 template <typename Map, typename T>
@@ -420,10 +422,12 @@ void test_inverse_map(
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) noexcept {
-  CHECK_ITERABLE_APPROX(
-      test_point, map.inverse(map(test_point, time, functions_of_time), time,
-                              functions_of_time)
-                      .value());
+  INFO("Test inverse map time dependent");
+  CAPTURE(test_point);
+  const auto expected_test_point = map.inverse(
+      map(test_point, time, functions_of_time), time, functions_of_time);
+  REQUIRE(expected_test_point.has_value());
+  CHECK_ITERABLE_APPROX(test_point, expected_test_point.value());
 }
 // @}
 


### PR DESCRIPTION
## Proposed changes

Two commits: one fixes #3169 (I ran 20,000 times on my machine without a failure)
The other allows more information to get printed on test failures where inverse maps
return invalid std::optionals.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
