### PR TITLE
Add new WriteCheckpoint phase

### DIFF
--- a/src/Parallel/AlgorithmMetafunctions.hpp
+++ b/src/Parallel/AlgorithmMetafunctions.hpp
@@ -162,6 +162,8 @@ struct build_databox_types<
 CREATE_IS_CALLABLE(is_ready)
 CREATE_HAS_STATIC_MEMBER_VARIABLE(LoadBalancing)
 CREATE_HAS_STATIC_MEMBER_VARIABLE_V(LoadBalancing)
+CREATE_HAS_STATIC_MEMBER_VARIABLE(WriteCheckpoint)
+CREATE_HAS_STATIC_MEMBER_VARIABLE_V(WriteCheckpoint)
 
 // for checking the DataBox return of an iterable action
 template <typename FirstIterableActionType>

--- a/src/Parallel/CharmRegistration.hpp
+++ b/src/Parallel/CharmRegistration.hpp
@@ -157,8 +157,8 @@ struct RegisterParallelComponent : RegistrationHelper {
       return;  // LCOV_EXCL_LINE
     }
     done_registration = true;
-    ckindex::__register(get_template_parameters_as_string<algorithm>().c_str(),
-                        sizeof(algorithm));
+    static const std::string parallel_component_name = name();
+    ckindex::__register(parallel_component_name.c_str(), sizeof(algorithm));
   }
 
   bool is_registering_chare() const noexcept override { return true; }
@@ -205,8 +205,8 @@ struct RegisterChare : RegistrationHelper {
       return;  // LCOV_EXCL_LINE
     }
     done_registration = true;
-    CkIndex::__register(get_template_parameters_as_string<Chare>().c_str(),
-                        sizeof(Chare));
+    static const std::string chare_name = name();
+    CkIndex::__register(chare_name.c_str(), sizeof(Chare));
   }
 
   bool is_registering_chare() const noexcept override { return true; }

--- a/src/Parallel/Main.ci
+++ b/src/Parallel/Main.ci
@@ -22,6 +22,7 @@ module Main {
 
     entry void execute_next_phase();
     entry void start_load_balance();
+    entry void start_write_checkpoint();
   }
 
   namespace detail {

--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -9,6 +9,8 @@
 #include <boost/program_options.hpp>
 #include <charm++.h>
 #include <initializer_list>
+#include <pup.h>
+#include <regex>
 #include <string>
 #include <type_traits>
 
@@ -24,6 +26,7 @@
 #include "Parallel/Reduction.hpp"
 #include "Parallel/TypeTraits.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/FileSystem.hpp"
 #include "Utilities/Formaline.hpp"
 #include "Utilities/Overloader.hpp"
 #include "Utilities/System/Exit.hpp"
@@ -92,6 +95,12 @@ class Main : public CBase_Main<Metavariables> {
   /// used as the callback after a quiescence detection.
   void start_load_balance() noexcept;
 
+  /// Place the Charm++ call that starts writing a checkpoint
+  ///
+  /// \details This call is wrapped within an entry method so that it may be
+  /// used as the callback after a quiescence detection.
+  void start_write_checkpoint() noexcept;
+
   /// Reduction target for data used in phase change decisions.
   ///
   /// It is required that the `Parallel::ReductionData` holds a single
@@ -103,6 +112,19 @@ class Main : public CBase_Main<Metavariables> {
           reduction_data) noexcept;
 
  private:
+  // Return the dir name for the next Charm++ checkpoint as well as the pieces
+  // from which the name is built up: the basename and the padding. This is a
+  // "detail" function so that these pieces can be defined in one place only.
+  std::tuple<std::string, std::string, size_t> checkpoint_dir_basename_pad()
+      const noexcept;
+
+  // Return the dir name for the next Charm++ checkpoint; check and error if
+  // this name already exists and writing the checkpoint would be unsafe.
+  std::string checkpoint_dir() const noexcept;
+
+  // Check if future checkpoint dirs are available; error if any already exist.
+  void check_future_checkpoint_dirs_available() const noexcept;
+
   template <typename ParallelComponent>
   using parallel_component_options =
       Parallel::get_option_tags<typename ParallelComponent::initialization_tags,
@@ -131,6 +153,7 @@ class Main : public CBase_Main<Metavariables> {
   // Metavariables
   tuples::tagged_tuple_from_typelist<phase_change_tags_and_combines_list>
       phase_change_decision_data_;
+  size_t checkpoint_dir_counter_ = 0_st;
 };
 
 namespace detail {
@@ -335,6 +358,21 @@ Main<Metavariables>::Main(CkArgMsg* msg) noexcept {
         // program would have started.
         Parallel::printf("\nNo options to check!\n");
       }
+
+      // Include a check that the checkpoint dirs are available for writing as
+      // part of checking the option parsing. Doing these checks together helps
+      // catch more user errors before running the executable 'for real'.
+      //
+      // Note we don't do this check at the beginning of the Main chare
+      // constructor because we don't _always_ want to error if checkpoint dirs
+      // already exist. For example, running the executable with flags like
+      // `--help` or `--dump-source-tree-as` should succeed even if checkpoints
+      // were previously written.
+      if constexpr (Algorithm_detail::has_WriteCheckpoint_v<
+                        typename Metavariables::Phase>) {
+        check_future_checkpoint_dirs_available();
+      }
+
       sys::exit();
     }
 
@@ -346,6 +384,11 @@ Main<Metavariables>::Main(CkArgMsg* msg) noexcept {
     Parallel::printf("\nOption parsing completed.\n");
   } catch (const bpo::error& e) {
     ERROR(e.what());
+  }
+
+  if constexpr (Algorithm_detail::has_WriteCheckpoint_v<
+                    typename Metavariables::Phase>) {
+    check_future_checkpoint_dirs_available();
   }
 
   mutable_global_cache_proxy_ = CProxy_MutableGlobalCache<Metavariables>::ckNew(
@@ -488,6 +531,41 @@ void Main<Metavariables>::pup(PUP::er& p) noexcept {  // NOLINT
   // options will be held in various code objects that will themselves be
   // serialized.
   p | phase_change_decision_data_;
+
+  p | checkpoint_dir_counter_;
+  if constexpr (Algorithm_detail::has_WriteCheckpoint_v<
+                    typename Metavariables::Phase>) {
+    if (p.isUnpacking()) {
+      check_future_checkpoint_dirs_available();
+    }
+  }
+
+  // For now we only support restarts on the same hardware configuration (same
+  // number of nodes and same procs per node) used when writing the checkpoint.
+  // We check this by adding counters to the pup stream.
+  if (p.isUnpacking()) {
+    int previous_nodes = 0;
+    int previous_procs = 0;
+    p | previous_nodes;
+    p | previous_procs;
+    if (previous_nodes != sys::number_of_nodes() or
+        previous_procs != sys::number_of_procs()) {
+      ERROR(
+          "Must restart on the same hardware configuration used when writing "
+          "the checkpoint.\n"
+          "Checkpoint written with "
+          << previous_nodes << " nodes, " << previous_procs
+          << " procs.\n"
+             "Restarted with "
+          << sys::number_of_nodes() << " nodes, " << sys::number_of_procs()
+          << " procs.");
+    }
+  } else {
+    int current_nodes = sys::number_of_nodes();
+    int current_procs = sys::number_of_procs();
+    p | current_nodes;
+    p | current_procs;
+  }
 }
 
 template <typename Metavariables>
@@ -555,6 +633,15 @@ void Main<Metavariables>::execute_next_phase() noexcept {
       return;
     }
   }
+  if constexpr (Algorithm_detail::has_WriteCheckpoint_v<
+                    typename Metavariables::Phase>) {
+    if (current_phase_ == Metavariables::Phase::WriteCheckpoint) {
+      CkStartQD(
+          CkCallback(CkIndex_Main<Metavariables>::start_write_checkpoint(),
+                     this->thisProxy));
+      return;
+    }
+  }
 
   // The general case simply returns to execute_next_phase
   CkStartQD(CkCallback(CkIndex_Main<Metavariables>::execute_next_phase(),
@@ -566,6 +653,15 @@ void Main<Metavariables>::start_load_balance() noexcept {
   at_sync_indicator_proxy_.IndicateAtSync();
   // No need for a callback to return to execute_next_phase: this is done by
   // ResumeFromSync instead.
+}
+
+template <typename Metavariables>
+void Main<Metavariables>::start_write_checkpoint() noexcept {
+  const std::string dir = checkpoint_dir();
+  checkpoint_dir_counter_++;
+  CkStartCheckpoint(
+      dir.c_str(), CkCallback(CkIndex_Main<Metavariables>::execute_next_phase(),
+                              this->thisProxy));
 }
 
 template <typename Metavariables>
@@ -671,6 +767,62 @@ void contribute_to_phase_change_reduction(
         "reduction.");
   }
 }
+
+template <typename Metavariables>
+std::tuple<std::string, std::string, size_t>
+Main<Metavariables>::checkpoint_dir_basename_pad() const noexcept {
+  const std::string basename = "SpectreCheckpoint";
+  constexpr size_t pad = 6;
+
+  const std::string counter = std::to_string(checkpoint_dir_counter_);
+  const std::string padded_counter =
+      std::string(pad - counter.size(), '0').append(counter);
+  const std::string checkpoint_dir = basename + padded_counter;
+  return std::make_tuple(checkpoint_dir, basename, pad);
+}
+
+template <typename Metavariables>
+std::string Main<Metavariables>::checkpoint_dir() const noexcept {
+  const auto [checkpoint_dir, basename, pad] = checkpoint_dir_basename_pad();
+  (void)basename;
+  (void)pad;
+  if (file_system::check_if_dir_exists(checkpoint_dir)) {
+    ERROR("Can't write checkpoint: dir " + checkpoint_dir + " already exists!");
+  }
+  return checkpoint_dir;
+}
+
+template <typename Metavariables>
+void Main<Metavariables>::check_future_checkpoint_dirs_available()
+    const noexcept {
+  // Can't lambda-capture from structured binding in clang-11
+  std::string checkpoint_dir;
+  std::string basename;
+  size_t pad;
+  std::tie(checkpoint_dir, basename, pad) = checkpoint_dir_basename_pad();
+
+  // Find existing files with names that match the checkpoint dir name pattern
+  const auto all_files = file_system::ls();
+  const std::regex re(basename + "[0-9]{" + std::to_string(pad) + "}");
+  std::vector<std::string> checkpoint_files;
+  std::copy_if(
+      all_files.begin(), all_files.end(), std::back_inserter(checkpoint_files),
+      [&re](const std::string& s) noexcept { return std::regex_match(s, re); });
+
+  // Using string comparison of filenames, check that all the files we found
+  // are from older checkpoints, but not from future checkpoints
+  const bool found_older_checkpoints_only =
+      std::all_of(checkpoint_files.begin(), checkpoint_files.end(),
+                  [&checkpoint_dir](const std::string& s) noexcept {
+                    return s < checkpoint_dir;
+                  });
+  if (not found_older_checkpoints_only) {
+    ERROR(
+        "Can't start run: found checkpoints that may be overwritten!\n"
+        "Dirs from " << checkpoint_dir << " onward must not exist.\n");
+  }
+}
+
 /// @}
 }  // namespace Parallel
 

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -44,6 +44,7 @@ add_algorithm_test(Test_AlgorithmNodelock)
 add_algorithm_test(Test_AlgorithmParallel)
 add_algorithm_test(Test_AlgorithmPhaseControl)
 add_algorithm_test(Test_AlgorithmReduction)
+add_algorithm_test(Test_CheckpointRestart)
 add_algorithm_test(Test_GlobalCache)
 add_algorithm_test(Test_PhaseChangeMain)
 add_algorithm_test(Test_SectionReductions)
@@ -155,6 +156,33 @@ function(add_algorithm_test_with_balancing TEST_NAME EXECUTABLE_NAME REGEX_TO_MA
   endif()
 endfunction()
 
+# Run TEST_NAME twice: first with no command-line args, then with the
+# `+restart SpectreCheckpoint0` command-line arg to restart from a Charm++
+# checkpoint named `SpectreCheckpoint0`. The checkpoint file is then deleted
+# to avoid it getting in the way of future test invocations (which would try
+# to overwrite the prior checkpoint file and error).
+function(add_algorithm_test_with_restart_from_checkpoint TEST_NAME)
+  # Executable writes checkpoint file into the dir where it runs:
+  set(CHECKPOINT
+    "${CMAKE_BINARY_DIR}/tests/Unit/Parallel/SpectreCheckpoint000000")
+  add_test(
+    NAME "\"Unit.Parallel.${TEST_NAME}\""
+    COMMAND
+    ${SHELL_EXECUTABLE}
+    -c
+    "rm -rf ${CHECKPOINT} \
+    && ${CMAKE_BINARY_DIR}/bin/Test_${TEST_NAME} 2>&1 \
+    && ${CMAKE_BINARY_DIR}/bin/Test_${TEST_NAME} +restart ${CHECKPOINT} 2>&1 \
+    && rm -rf ${CHECKPOINT}"
+    )
+  set_tests_properties(
+    "\"Unit.Parallel.${TEST_NAME}\""
+    PROPERTIES
+    TIMEOUT 10
+    LABELS "unit"
+    ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
+endfunction()
+
 add_algorithm_test(
   "AlgorithmBadBoxApply"
   "Cannot call apply function of 'error_size_zero' with DataBox \
@@ -184,6 +212,8 @@ add_algorithm_test_with_balancing("AlgorithmParallelWithBalancing"
 
 add_algorithm_test_with_input_file("AlgorithmGlobalCache" "Unit/Parallel")
 add_algorithm_test_with_input_file("AlgorithmPhaseControl" "Unit/Parallel")
+
+add_algorithm_test_with_restart_from_checkpoint("CheckpointRestart")
 
 # Tests that do not require their own Chare setup and can work with the
 # unit tests

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -34,18 +34,18 @@ function(add_algorithm_test EXECUTABLE_NAME)
   add_dependencies(unit-tests ${EXECUTABLE_NAME})
 endfunction()
 
-add_algorithm_test(Test_AlgorithmCore)
 add_algorithm_test(Test_AlgorithmBadBoxApply)
+add_algorithm_test(Test_AlgorithmCore)
 add_algorithm_test(Test_AlgorithmGlobalCache)
 add_algorithm_test(Test_AlgorithmLocalSyncAction)
 add_algorithm_test(Test_AlgorithmNestedApply1)
 add_algorithm_test(Test_AlgorithmNestedApply2)
+add_algorithm_test(Test_AlgorithmNodelock)
 add_algorithm_test(Test_AlgorithmParallel)
 add_algorithm_test(Test_AlgorithmPhaseControl)
-add_algorithm_test(Test_PhaseChangeMain)
-add_algorithm_test(Test_AlgorithmNodelock)
 add_algorithm_test(Test_AlgorithmReduction)
 add_algorithm_test(Test_GlobalCache)
+add_algorithm_test(Test_PhaseChangeMain)
 add_algorithm_test(Test_SectionReductions)
 
 # Test GlobalCache
@@ -155,11 +155,11 @@ function(add_algorithm_test_with_balancing TEST_NAME EXECUTABLE_NAME REGEX_TO_MA
   endif()
 endfunction()
 
-add_algorithm_test("AlgorithmCore" "")
 add_algorithm_test(
   "AlgorithmBadBoxApply"
   "Cannot call apply function of 'error_size_zero' with DataBox \
 type 'db::DataBox<brigand::list<")
+add_algorithm_test("AlgorithmCore" "")
 add_algorithm_test("AlgorithmLocalSyncAction" "")
 add_algorithm_test(
   "AlgorithmNestedApply1"
@@ -171,13 +171,14 @@ add_algorithm_test(
   "Already performing an Action and cannot execute additional Actions \
 from inside of an Action. This is only possible if the simple_action \
 function is not invoked via a proxy, which we do not allow.")
-add_algorithm_test("AlgorithmParallel" "")
-add_algorithm_test("PhaseChangeMain" "")
-add_algorithm_test("AlgorithmReduction" "")
 add_algorithm_test("AlgorithmNodelock" "")
+add_algorithm_test("AlgorithmParallel" "")
+add_algorithm_test("AlgorithmReduction" "")
 add_algorithm_test("GlobalCache" "")
+add_algorithm_test("PhaseChangeMain" "")
 add_algorithm_test("SectionReductions"
   "Element 0 received reduction: Counted 2 odd elements.")
+
 add_algorithm_test_with_balancing("AlgorithmParallelWithBalancing"
   "AlgorithmParallel" "Objects migrating: 14")
 

--- a/tests/Unit/Parallel/Test_CheckpointRestart.cpp
+++ b/tests/Unit/Parallel/Test_CheckpointRestart.cpp
@@ -1,0 +1,294 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#define CATCH_CONFIG_RUNNER
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+#include <tuple>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/Algorithms/AlgorithmArray.hpp"
+#include "Parallel/Algorithms/AlgorithmGroup.hpp"
+#include "Parallel/Algorithms/AlgorithmNodegroup.hpp"
+#include "Parallel/Algorithms/AlgorithmSingleton.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/InboxInserters.hpp"
+#include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/Main.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
+#include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MemoryHelpers.hpp"
+#include "Utilities/System/ParallelInfo.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace PUP {
+class er;
+}  // namespace PUP
+
+namespace CheckpointTest {
+namespace Tags {
+struct Log : db::SimpleTag {
+  using type = std::string;
+};
+}  // namespace Tags
+
+struct InitializeLog {
+  using simple_tags = tmpl::list<Tags::Log>;
+
+  template <typename... DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<tmpl::list<DbTags...>>&&, bool> apply(
+      db::DataBox<tmpl::list<DbTags...>>& box,
+      tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& array_index, ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    const std::string component_name =
+        pretty_type::short_name<ParallelComponent>() + " " +
+        std::to_string(static_cast<int>(array_index));
+    Initialization::mutate_assign<simple_tags>(
+        make_not_null(&box),
+        component_name + " invoked action InitializeLog\n");
+    return {std::move(box), true};
+  }
+};
+
+struct MutateLog {
+  template <typename... DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<tmpl::list<DbTags...>>&&, bool> apply(
+      db::DataBox<tmpl::list<DbTags...>>& box,
+      tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& array_index, ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    db::mutate<Tags::Log>(
+        make_not_null(&box),
+        [&array_index](const gsl::not_null<std::string*> log) noexcept {
+          const std::string component_name =
+              pretty_type::short_name<ParallelComponent>() + " " +
+              std::to_string(static_cast<int>(array_index));
+          log->append(component_name + " invoked action MutateLog\n");
+        });
+    return {std::move(box), true};
+  }
+};
+
+struct CheckLog {
+  template <typename... DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static std::tuple<db::DataBox<tmpl::list<DbTags...>>&&, bool> apply(
+      db::DataBox<tmpl::list<DbTags...>>& box,
+      tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& array_index, ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    const std::string& log = db::get<Tags::Log>(box);
+    const std::string component_name =
+        pretty_type::short_name<ParallelComponent>() + " " +
+        std::to_string(static_cast<int>(array_index));
+    const std::string expected_log =
+        component_name + " invoked action InitializeLog\n" + component_name +
+        " invoked action MutateLog\n";
+    SPECTRE_PARALLEL_REQUIRE(log == expected_log);
+    return {std::move(box), true};
+  }
+};
+
+template <class Metavariables>
+struct ArrayComponent {
+  using chare_type = Parallel::Algorithms::Array;
+  using metavariables = Metavariables;
+  using array_index = int;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Initialization,
+                             tmpl::list<Actions::SetupDataBox, InitializeLog>>,
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::MutateDatabox,
+                             tmpl::list<MutateLog>>,
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::CheckDatabox,
+                             tmpl::list<CheckLog>>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+
+  static void allocate_array(
+      Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
+      const tuples::tagged_tuple_from_typelist<initialization_tags>&
+      /*initialization_items*/) noexcept {
+    auto& local_cache = *(global_cache.ckLocalBranch());
+    auto& array_proxy =
+        Parallel::get_parallel_component<ArrayComponent>(local_cache);
+
+    for (int i = 0, which_proc = 0, number_of_procs = sys::number_of_procs();
+         i < 2; ++i) {
+      array_proxy[i].insert(global_cache, {}, which_proc);
+      which_proc = which_proc + 1 == number_of_procs ? 0 : which_proc + 1;
+    }
+    array_proxy.doneInserting();
+  }
+
+  static void execute_next_phase(
+      const typename Metavariables::Phase next_phase,
+      const Parallel::CProxy_GlobalCache<Metavariables>& global_cache) {
+    auto& local_cache = *(global_cache.ckLocalBranch());
+    Parallel::get_parallel_component<ArrayComponent>(local_cache)
+        .start_phase(next_phase);
+  }
+};
+
+template <class Metavariables>
+struct GroupComponent {
+  using chare_type = Parallel::Algorithms::Group;
+  using metavariables = Metavariables;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Initialization,
+                             tmpl::list<Actions::SetupDataBox, InitializeLog>>,
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::MutateDatabox,
+                             tmpl::list<MutateLog>>,
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::CheckDatabox,
+                             tmpl::list<CheckLog>>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+
+  static void execute_next_phase(
+      const typename Metavariables::Phase next_phase,
+      const Parallel::CProxy_GlobalCache<Metavariables>& global_cache) {
+    auto& local_cache = *(global_cache.ckLocalBranch());
+    Parallel::get_parallel_component<GroupComponent>(local_cache)
+        .start_phase(next_phase);
+  }
+};
+
+template <class Metavariables>
+struct NodegroupComponent {
+  using chare_type = Parallel::Algorithms::Nodegroup;
+  using metavariables = Metavariables;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Initialization,
+                             tmpl::list<Actions::SetupDataBox, InitializeLog>>,
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::MutateDatabox,
+                             tmpl::list<MutateLog>>,
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::CheckDatabox,
+                             tmpl::list<CheckLog>>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+
+  static void execute_next_phase(
+      const typename Metavariables::Phase next_phase,
+      const Parallel::CProxy_GlobalCache<Metavariables>& global_cache) {
+    auto& local_cache = *(global_cache.ckLocalBranch());
+    Parallel::get_parallel_component<NodegroupComponent>(local_cache)
+        .start_phase(next_phase);
+  }
+};
+
+template <class Metavariables>
+struct SingletonComponent {
+  using chare_type = Parallel::Algorithms::Singleton;
+  using metavariables = Metavariables;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::Initialization,
+                             tmpl::list<Actions::SetupDataBox, InitializeLog>>,
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::MutateDatabox,
+                             tmpl::list<MutateLog>>,
+      Parallel::PhaseActions<typename Metavariables::Phase,
+                             Metavariables::Phase::CheckDatabox,
+                             tmpl::list<CheckLog>>>;
+  using initialization_tags = Parallel::get_initialization_tags<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+
+  static void execute_next_phase(
+      const typename Metavariables::Phase next_phase,
+      const Parallel::CProxy_GlobalCache<Metavariables>& global_cache) {
+    auto& local_cache = *(global_cache.ckLocalBranch());
+    Parallel::get_parallel_component<SingletonComponent>(local_cache)
+        .start_phase(next_phase);
+  }
+};
+}  // namespace CheckpointTest
+
+struct TestMetavariables {
+  using component_list =
+      tmpl::list<CheckpointTest::ArrayComponent<TestMetavariables>,
+                 CheckpointTest::GroupComponent<TestMetavariables>,
+                 CheckpointTest::NodegroupComponent<TestMetavariables>,
+                 CheckpointTest::SingletonComponent<TestMetavariables>>;
+
+  static constexpr Options::String help = "";
+
+  enum class Phase {
+    Initialization,
+    MutateDatabox,
+    WriteCheckpoint,
+    CheckDatabox,
+    Exit
+  };
+
+  using phase_change_tags_and_combines_list = tmpl::list<>;
+  struct initialize_phase_change_decision_data {
+    static void apply(
+        const gsl::not_null<
+            tuples::TaggedTuple<>*> /*phase_change_decision_data*/,
+        const Parallel::GlobalCache<TestMetavariables>& /*cache*/) noexcept {}
+  };
+
+  template <typename... Tags>
+  static Phase determine_next_phase(
+      const gsl::not_null<tuples::TaggedTuple<Tags...>*>
+      /*phase_change_decision_data*/,
+      const Phase& current_phase,
+      const Parallel::CProxy_GlobalCache<
+          TestMetavariables>& /*cache_proxy*/) noexcept {
+    switch (current_phase) {
+      case Phase::Initialization:
+        return Phase::MutateDatabox;
+      case Phase::MutateDatabox:
+        return Phase::WriteCheckpoint;
+      case Phase::WriteCheckpoint:
+        return Phase::CheckDatabox;
+      case Phase::CheckDatabox:
+        return Phase::Exit;
+      default:
+        ERROR("Unknown Phase...");
+    }
+    return Phase::Exit;
+  }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
+};
+
+static const std::vector<void (*)()> charm_init_node_funcs{
+    &setup_error_handling, &setup_memory_allocation_failure_reporting};
+static const std::vector<void (*)()> charm_init_proc_funcs{
+    &enable_floating_point_exceptions};
+
+using charmxx_main_component = Parallel::Main<TestMetavariables>;
+
+#include "Parallel/CharmMain.tpp"  // IWYU pragma: keep

--- a/tests/Unit/Parallel/Test_GlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_GlobalCache.cpp
@@ -260,18 +260,6 @@ void TestArrayChare<Metavariables>::run_test_one() noexcept {
                            global_cache_proxy_.ckLocalBranch());
 
   // test the serialization of the caches
-  auto& serialized_and_deserialized_local_cache =
-      *serialize_and_deserialize(global_cache_proxy_.ckLocalBranch());
-  SPECTRE_PARALLEL_REQUIRE(
-      "Nobody" == Parallel::get<name>(serialized_and_deserialized_local_cache));
-  SPECTRE_PARALLEL_REQUIRE(
-      178 == Parallel::get<age>(serialized_and_deserialized_local_cache));
-  SPECTRE_PARALLEL_REQUIRE(
-      2.2 == Parallel::get<height>(serialized_and_deserialized_local_cache));
-  SPECTRE_PARALLEL_REQUIRE(4 == Parallel::get<shape_of_nametag>(
-                                    serialized_and_deserialized_local_cache)
-                                    .number_of_sides());
-
   Parallel::GlobalCache<TestMetavariables>
       serialized_and_deserialized_global_cache{};
   serialize_and_deserialize(


### PR DESCRIPTION
## Proposed changes

Adds support for a new execution phase `WriteCheckpoint` that does exactly what it says.

The new `WriteCheckpoint` phase is ready to use, though it is not yet added into any executables. Users can add a `VisitAndReturn(WriteCheckpoint)` phase control in current executables to write checkpoints every N slabs. A followup PR will add a phase control using wallclock time that will be better suited to typical checkpointing needs, and at that point it will make more sense to add the WriteCheckpoint phase into our executables by default.

The checkpoints are written in directories `SpectreCheckpointN`, and the executable can be restarting by calling `MySpectreExec +restart SpectreCheckpointN`.

Current limitations:
- checkpoints do not currently allow for parameters to change, only for the run to continue past wallclock limits
- restarts from checkpoints must currently use the same hardware config (total procs & procs per node) as the original run was using when writing the checkpoint

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
