### PR TITLE
Cmake files and installation docs for Arpack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ include(CheckBrokenArray0)
 include(SetupBlas)
 include(SetupLapack)
 include(SetupLIBXSMM)
+include(SetupArpack)
 
 include(SetupBlaze)
 include(SetupBrigand)

--- a/cmake/FindArpack.cmake
+++ b/cmake/FindArpack.cmake
@@ -1,0 +1,20 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+if(NOT ARPACK_ROOT)
+  # Need to set to empty to avoid warnings with --warn-uninitialized
+  set(ARPACK_ROOT "")
+  set(ARPACK_ROOT $ENV{ARPACK_ROOT})
+endif()
+
+find_library(ARPACK_LIBRARIES
+  NAMES arpack
+  PATH_SUFFIXES lib64 lib
+  HINTS ${ARPACK_ROOT})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  Arpack
+  FOUND_VAR ARPACK_FOUND
+  REQUIRED_VARS ARPACK_LIBRARIES
+  )

--- a/cmake/SetupArpack.cmake
+++ b/cmake/SetupArpack.cmake
@@ -1,0 +1,21 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+find_package(Arpack REQUIRED)
+
+add_library(Arpack INTERFACE IMPORTED)
+
+message(STATUS "Arpack libs: " ${ARPACK_LIBRARIES})
+
+file(APPEND
+  "${CMAKE_BINARY_DIR}/BuildInfo.txt"
+  "ARPACK_LIBRARIES: ${ARPACK_LIBRARIES}\n"
+  )
+
+set_property(TARGET Arpack
+  APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${ARPACK_LIBRARIES})
+
+set_property(
+  GLOBAL APPEND PROPERTY SPECTRE_THIRD_PARTY_LIBS
+  Arpack
+  )

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -69,6 +69,7 @@ all of these dependencies.
 * [HDF5](https://support.hdfgroup.org/HDF5/) (non-mpi version on macOS)
 * [jemalloc](https://github.com/jemalloc/jemalloc)
 * LAPACK
+* [Arpack](https://github.com/opencollab/arpack-ng)
 * [libsharp](https://github.com/Libsharp/libsharp) should be built with
   support disabled for openmp and mpi, as we want all of our parallelism to
   be accomplished via Charm++.

--- a/docs/Installation/InstallationOnClusters.md
+++ b/docs/Installation/InstallationOnClusters.md
@@ -85,5 +85,4 @@ shell.
 
 ## Ocean at Fullerton
 
-Follow the general instructions, using `ocean` for `SYSTEM_TO_RUN_ON`,
-you do not need to install any dependencies, so you can skip steps 5 and 6.
+Follow the general instructions, using `ocean` for `SYSTEM_TO_RUN_ON`.

--- a/support/Environments/caltech_hpc_gcc.sh
+++ b/support/Environments/caltech_hpc_gcc.sh
@@ -287,6 +287,36 @@ setenv JEMALLOC_HOME $dep_dir/jemalloc/
 prepend-path CMAKE_PREFIX_PATH "$dep_dir/jemalloc/"
 EOF
     fi
+    cd $dep_dir
+
+    if [ -f $dep_dir/arpack/lib64/libarpack.a ]; then
+        echo "arpack is already set up"
+    else
+        echo "Installing arpack..."
+        wget https://github.com/opencollab/arpack-ng/archive/refs/tags/3.8.0.tar.gz
+        tar -xzf 3.8.0.tar.gz
+        mv arpack-ng-3.8.0 arpack-build
+        cd $dep_dir/arpack-build
+        mkdir build
+        cd build
+        cmake -D CMAKE_BUILD_TYPE=Release \
+              -D CMAKE_C_COMPILER=gcc \
+              -D BUILD_SHARED_LIBS=OFF \
+              -D CMAKE_INSTALL_PREFIX=$dep_dir/arpack ..
+        make -j4
+        make install
+        cd $dep_dir
+        rm 3.8.0.tar.gz
+        rm -r arpack-build
+        echo "Installed arpack into $dep_dir/arpack"
+        cat >$dep_dir/modules/arpack <<EOF
+#%Module1.0
+prepend-path LIBRARY_PATH "$dep_dir/arpack/lib64"
+prepend-path LD_LIBRARY_PATH "$dep_dir/arpack/lib64"
+prepend-path CPATH "$dep_dir/arpack/include"
+prepend-path CMAKE_PREFIX_PATH "$dep_dir/arpack/"
+EOF
+    fi
 
     cd $start_dir
 
@@ -312,6 +342,7 @@ spectre_unload_modules() {
     module unload catch
     module unload brigand
     module unload blaze
+    module unload arpack
 
     spectre_unload_sys_modules
 }
@@ -319,6 +350,7 @@ spectre_unload_modules() {
 spectre_load_modules() {
     spectre_load_sys_modules
 
+    module load arpack
     module load blaze
     module load brigand
     module load catch

--- a/support/Environments/expanse_gcc.sh
+++ b/support/Environments/expanse_gcc.sh
@@ -311,6 +311,35 @@ setenv JEMALLOC_HOME $dep_dir/jemalloc/
 prepend-path CMAKE_PREFIX_PATH "$dep_dir/jemalloc/"
 EOF
     fi
+    cd $dep_dir
+
+    if [ -f $dep_dir/arpack/lib64/libarpack.a ]; then
+        echo "arpack is already set up"
+    else
+        echo "Installing arpack..."
+        wget https://github.com/opencollab/arpack-ng/archive/refs/tags/3.8.0.tar.gz
+        tar -xzf 3.8.0.tar.gz
+        mv arpack-ng-3.8.0 arpack-build
+        cd $dep_dir/arpack-build
+        mkdir build
+        cd build
+        cmake -D CMAKE_BUILD_TYPE=Release \
+              -D CMAKE_C_COMPILER=gcc \
+              -D CMAKE_INSTALL_PREFIX=$dep_dir/arpack ..
+        make -j4
+        make install
+        cd $dep_dir
+        rm 3.8.0.tar.gz
+        rm -r arpack-build
+        echo "Installed arpack into $dep_dir/arpack"
+        cat >$dep_dir/modules/arpack <<EOF
+#%Module1.0
+prepend-path LIBRARY_PATH "$dep_dir/arpack/lib64"
+prepend-path LD_LIBRARY_PATH "$dep_dir/arpack/lib64"
+prepend-path CPATH "$dep_dir/arpack/include"
+prepend-path CMAKE_PREFIX_PATH "$dep_dir/arpack/"
+EOF
+    fi
 
     cd $start_dir
 
@@ -338,6 +367,7 @@ spectre_unload_modules() {
     module unload catch
     module unload brigand
     module unload blaze
+    module unload arpack
 
     spectre_unload_sys_modules
 }
@@ -345,6 +375,7 @@ spectre_unload_modules() {
 spectre_load_modules() {
     spectre_load_sys_modules
 
+    module load arpack
     module load blaze
     module load brigand
     module load catch

--- a/support/Environments/wheeler_clang.sh
+++ b/support/Environments/wheeler_clang.sh
@@ -33,6 +33,7 @@ spectre_unload_modules() {
     module unload charm/7.0.0-intelmpi-smp
     module unload python/anaconda3-2019.10
     module unload pybind11/2.6.1
+    module unload arpack/3.8.0
 }
 
 spectre_load_modules() {
@@ -56,6 +57,7 @@ spectre_load_modules() {
     module load charm/7.0.0-intelmpi-smp
     module load python/anaconda3-2019.10
     module load pybind11/2.6.1
+    module load arpack/3.8.0
 }
 
 spectre_run_cmake() {

--- a/support/Environments/wheeler_gcc.sh
+++ b/support/Environments/wheeler_gcc.sh
@@ -28,6 +28,7 @@ spectre_unload_modules() {
     module unload charm/7.0.0-intelmpi-smp
     module unload python/anaconda3-2019.10
     module unload pybind11/2.6.1
+    module unload arpack/3.8.0
 }
 
 spectre_load_modules() {
@@ -51,6 +52,7 @@ spectre_load_modules() {
     module load charm/7.0.0-intelmpi-smp
     module load python/anaconda3-2019.10
     module load pybind11/2.6.1
+    module load arpack/3.8.0
 }
 
 spectre_run_cmake() {


### PR DESCRIPTION
## Proposed changes

This PR contains shell scripts to install Arpack on clusters and cmake files to find and link it. 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

#### For container users
 #3323 has been merged so the new containers already have Arpack installed, the end user only needs to pull the latest image.

#### For cluster users
Run spectre_setup_modules. All the shell files have been updated to install Arpack automatically and everything should just work. (Installation shell scripts have been updated for expanse, wheeler and CaltechHPC in this PR. Users of other clusters please make the relevant changes and open a PR for your cluster.)

#### For unix users
Install Arpack using your package manager.
                           **OR**
Build Arpack from source following the installation instructions given at https://github.com/opencollab/arpack-ng, and set the env variable ARPACK_ROOT to the installation directory.

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
