### PR TITLE
Small cleanups to the boundary conditions and corrections

### DIFF
--- a/src/Evolution/Systems/Burgers/BoundaryConditions/DirichletAnalytic.hpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/DirichletAnalytic.hpp
@@ -42,7 +42,6 @@ class DirichletAnalytic final : public BoundaryCondition {
   static constexpr Options::String help{
       "DirichletAnalytic boundary conditions setting the value of U to "
       "the analytic solution or analytic data."};
-  static std::string name() noexcept { return "DirichletAnalytic"; }
 
   DirichletAnalytic() = default;
   DirichletAnalytic(DirichletAnalytic&&) noexcept = default;

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/Outflow.hpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/Outflow.hpp
@@ -27,7 +27,6 @@ class Outflow final : public BoundaryCondition {
   static constexpr Options::String help{
       "Outflow boundary condition that only verifies the characteristic speeds "
       "are all directed out of the domain."};
-  static std::string name() noexcept { return "Outflow"; }
 
   Outflow() = default;
   Outflow(Outflow&&) noexcept = default;

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletAnalytic.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletAnalytic.hpp
@@ -46,7 +46,6 @@ class DirichletAnalytic final : public BoundaryCondition<Dim> {
       "DirichletAnalytic boundary conditions setting the value of the "
       "spacetime metric and its derivatives Phi and Pi to the analytic "
       "solution or analytic data."};
-  static std::string name() noexcept { return "DirichletAnalytic"; }
 
   DirichletAnalytic() = default;
   DirichletAnalytic(DirichletAnalytic&&) noexcept = default;

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/UpwindPenalty.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/UpwindPenalty.cpp
@@ -9,10 +9,10 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
-#include "NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"  // IWYU pragma: keep

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/DirichletAnalytic.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/DirichletAnalytic.hpp
@@ -45,7 +45,6 @@ class DirichletAnalytic final : public BoundaryCondition {
   static constexpr Options::String help{
       "DirichletAnalytic boundary conditions using either analytic solution or "
       "analytic data."};
-  static std::string name() noexcept { return "DirichletAnalytic"; }
 
   DirichletAnalytic() = default;
   DirichletAnalytic(DirichletAnalytic&&) noexcept = default;

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Rusanov.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Rusanov.cpp
@@ -84,23 +84,16 @@ double Rusanov::dg_package_data(
   *packaged_tilde_b = tilde_b;
   *packaged_tilde_phi = tilde_phi;
 
-  dot_product(packaged_normal_dot_flux_tilde_d, flux_tilde_d, normal_covector);
-  dot_product(packaged_normal_dot_flux_tilde_tau, flux_tilde_tau,
-              normal_covector);
-  dot_product(packaged_normal_dot_flux_tilde_phi, flux_tilde_phi,
-              normal_covector);
-  for (size_t i = 0; i < 3; ++i) {
-    packaged_normal_dot_flux_tilde_s->get(i) =
-        get<0>(normal_covector) * flux_tilde_s.get(0, i);
-    packaged_normal_dot_flux_tilde_b->get(i) =
-        get<0>(normal_covector) * flux_tilde_b.get(0, i);
-    for (size_t j = 1; j < 3; ++j) {
-      packaged_normal_dot_flux_tilde_s->get(i) +=
-          normal_covector.get(j) * flux_tilde_s.get(j, i);
-      packaged_normal_dot_flux_tilde_b->get(i) +=
-          normal_covector.get(j) * flux_tilde_b.get(j, i);
-    }
-  }
+  normal_dot_flux(packaged_normal_dot_flux_tilde_d, normal_covector,
+                  flux_tilde_d);
+  normal_dot_flux(packaged_normal_dot_flux_tilde_tau, normal_covector,
+                  flux_tilde_tau);
+  normal_dot_flux(packaged_normal_dot_flux_tilde_s, normal_covector,
+                  flux_tilde_s);
+  normal_dot_flux(packaged_normal_dot_flux_tilde_b, normal_covector,
+                  flux_tilde_b);
+  normal_dot_flux(packaged_normal_dot_flux_tilde_phi, normal_covector,
+                  flux_tilde_phi);
 
   return max(get(*packaged_abs_char_speed));
 }

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/DirichletAnalytic.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/DirichletAnalytic.hpp
@@ -45,7 +45,6 @@ class DirichletAnalytic final : public BoundaryCondition<Dim> {
   static constexpr Options::String help{
       "DirichletAnalytic boundary conditions using either analytic solution or "
       "analytic data."};
-  static std::string name() noexcept { return "DirichletAnalytic"; }
 
   DirichletAnalytic() = default;
   DirichletAnalytic(DirichletAnalytic&&) noexcept = default;

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Hll.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Hll.cpp
@@ -98,18 +98,12 @@ double Hll<Dim>::dg_package_data(
   *packaged_momentum_density = momentum_density;
   *packaged_energy_density = energy_density;
 
-  dot_product(packaged_normal_dot_flux_mass_density, flux_mass_density,
-              normal_covector);
-  for (size_t i = 0; i < Dim; ++i) {
-    packaged_normal_dot_flux_momentum_density->get(i) =
-        get<0>(normal_covector) * flux_momentum_density.get(0, i);
-    for (size_t j = 1; j < Dim; ++j) {
-      packaged_normal_dot_flux_momentum_density->get(i) +=
-          normal_covector.get(j) * flux_momentum_density.get(j, i);
-    }
-  }
-  dot_product(packaged_normal_dot_flux_energy_density, flux_energy_density,
-              normal_covector);
+  normal_dot_flux(packaged_normal_dot_flux_mass_density, normal_covector,
+                  flux_mass_density);
+  normal_dot_flux(packaged_normal_dot_flux_momentum_density, normal_covector,
+                  flux_momentum_density);
+  normal_dot_flux(packaged_normal_dot_flux_energy_density, normal_covector,
+                  flux_energy_density);
 
   return fmax(max(get(*packaged_largest_outgoing_char_speed)),
               -min(get(*packaged_largest_ingoing_char_speed)));

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Hllc.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Hllc.cpp
@@ -119,18 +119,12 @@ double Hllc<Dim>::dg_package_data(
   *packaged_energy_density = energy_density;
   *packaged_interface_unit_normal = normal_covector;
 
-  dot_product(packaged_normal_dot_flux_mass_density, flux_mass_density,
-              normal_covector);
-  for (size_t i = 0; i < Dim; ++i) {
-    packaged_normal_dot_flux_momentum_density->get(i) =
-        get<0>(normal_covector) * flux_momentum_density.get(0, i);
-    for (size_t j = 1; j < Dim; ++j) {
-      packaged_normal_dot_flux_momentum_density->get(i) +=
-          normal_covector.get(j) * flux_momentum_density.get(j, i);
-    }
-  }
-  dot_product(packaged_normal_dot_flux_energy_density, flux_energy_density,
-              normal_covector);
+  normal_dot_flux(packaged_normal_dot_flux_mass_density, normal_covector,
+                  flux_mass_density);
+  normal_dot_flux(packaged_normal_dot_flux_momentum_density, normal_covector,
+                  flux_momentum_density);
+  normal_dot_flux(packaged_normal_dot_flux_energy_density, normal_covector,
+                  flux_energy_density);
 
   return fmax(max(get(*packaged_largest_outgoing_char_speed)),
               -min(get(*packaged_largest_ingoing_char_speed)));

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Rusanov.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Rusanov.cpp
@@ -89,18 +89,12 @@ double Rusanov<Dim>::dg_package_data(
   *packaged_momentum_density = momentum_density;
   *packaged_energy_density = energy_density;
 
-  dot_product(packaged_normal_dot_flux_mass_density, flux_mass_density,
-              normal_covector);
-  for (size_t i = 0; i < Dim; ++i) {
-    packaged_normal_dot_flux_momentum_density->get(i) =
-        get<0>(normal_covector) * flux_momentum_density.get(0, i);
-    for (size_t j = 1; j < Dim; ++j) {
-      packaged_normal_dot_flux_momentum_density->get(i) +=
-          normal_covector.get(j) * flux_momentum_density.get(j, i);
-    }
-  }
-  dot_product(packaged_normal_dot_flux_energy_density, flux_energy_density,
-              normal_covector);
+  normal_dot_flux(packaged_normal_dot_flux_mass_density, normal_covector,
+                  flux_mass_density);
+  normal_dot_flux(packaged_normal_dot_flux_momentum_density, normal_covector,
+                  flux_momentum_density);
+  normal_dot_flux(packaged_normal_dot_flux_energy_density, normal_covector,
+                  flux_energy_density);
 
   return max(get(*packaged_abs_char_speed));
 }

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/DirichletAnalytic.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/DirichletAnalytic.hpp
@@ -55,7 +55,6 @@ class DirichletAnalytic<tmpl::list<NeutrinoSpecies...>> final
   static constexpr Options::String help{
       "DirichletAnalytic boundary conditions using either analytic solution or "
       "analytic data."};
-  static std::string name() noexcept { return "DirichletAnalytic"; }
 
   DirichletAnalytic() = default;
   DirichletAnalytic(DirichletAnalytic&&) noexcept = default;

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/BoundaryCorrections/Rusanov.cpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/BoundaryCorrections/Rusanov.cpp
@@ -37,15 +37,10 @@ void dg_package_data_impl(
   *packaged_tilde_e = tilde_e;
   *packaged_tilde_s = tilde_s;
 
-  dot_product(packaged_normal_dot_flux_tilde_e, flux_tilde_e, normal_covector);
-  for (size_t i = 0; i < 3; ++i) {
-    packaged_normal_dot_flux_tilde_s->get(i) =
-        get<0>(normal_covector) * flux_tilde_s.get(0, i);
-    for (size_t j = 1; j < 3; ++j) {
-      packaged_normal_dot_flux_tilde_s->get(i) +=
-          normal_covector.get(j) * flux_tilde_s.get(j, i);
-    }
-  }
+  normal_dot_flux(packaged_normal_dot_flux_tilde_e, normal_covector,
+                  flux_tilde_e);
+  normal_dot_flux(packaged_normal_dot_flux_tilde_s, normal_covector,
+                  flux_tilde_s);
 }
 
 void dg_boundary_terms_impl(

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/DirichletAnalytic.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryConditions/DirichletAnalytic.hpp
@@ -45,7 +45,6 @@ class DirichletAnalytic final : public BoundaryCondition<Dim> {
   static constexpr Options::String help{
       "DirichletAnalytic boundary conditions using either analytic solution or "
       "analytic data."};
-  static std::string name() noexcept { return "DirichletAnalytic"; }
 
   DirichletAnalytic() = default;
   DirichletAnalytic(DirichletAnalytic&&) noexcept = default;

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryCorrections/Rusanov.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/BoundaryCorrections/Rusanov.cpp
@@ -114,17 +114,12 @@ double Rusanov<Dim>::dg_package_data(
   *packaged_tilde_tau = tilde_tau;
   *packaged_tilde_s = tilde_s;
 
-  dot_product(packaged_normal_dot_flux_tilde_d, flux_tilde_d, normal_covector);
-  dot_product(packaged_normal_dot_flux_tilde_tau, flux_tilde_tau,
-              normal_covector);
-  for (size_t i = 0; i < Dim; ++i) {
-    packaged_normal_dot_flux_tilde_s->get(i) =
-        get<0>(normal_covector) * flux_tilde_s.get(0, i);
-    for (size_t j = 1; j < Dim; ++j) {
-      packaged_normal_dot_flux_tilde_s->get(i) +=
-          normal_covector.get(j) * flux_tilde_s.get(j, i);
-    }
-  }
+  normal_dot_flux(packaged_normal_dot_flux_tilde_d, normal_covector,
+                  flux_tilde_d);
+  normal_dot_flux(packaged_normal_dot_flux_tilde_tau, normal_covector,
+                  flux_tilde_tau);
+  normal_dot_flux(packaged_normal_dot_flux_tilde_s, normal_covector,
+                  flux_tilde_s);
 
   return max(get(*packaged_abs_char_speed));
 }

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/DirichletAnalytic.hpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/DirichletAnalytic.hpp
@@ -43,7 +43,6 @@ class DirichletAnalytic final : public BoundaryCondition<Dim> {
   static constexpr Options::String help{
       "DirichletAnalytic boundary conditions setting the value of Psi, Phi, "
       "and Pi to the analytic solution or analytic data."};
-  static std::string name() noexcept { return "DirichletAnalytic"; }
 
   DirichletAnalytic() = default;
   DirichletAnalytic(DirichletAnalytic&&) noexcept = default;

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/SphericalRadiation.hpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/SphericalRadiation.hpp
@@ -92,7 +92,6 @@ class SphericalRadiation final : public BoundaryCondition<Dim> {
       "Spherical radiation boundary conditions setting the value of Psi, Phi, "
       "and Pi either using the Sommerfeld or first-order Bayliss-Turkel "
       "method."};
-  static std::string name() noexcept { return "SphericalRadiation"; }
 
   SphericalRadiation() = default;
   SphericalRadiation(detail::SphericalRadiationType type) noexcept;

--- a/src/Evolution/Systems/ScalarWave/BoundaryCorrections/UpwindPenalty.cpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryCorrections/UpwindPenalty.cpp
@@ -9,9 +9,10 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
-#include "NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"  // IWYU pragma: keep

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp
@@ -28,7 +28,7 @@
  *
  * \details
  * Returns \f$n_i F^i_{j\ldots}\f$, where the flux tensor \f$F\f$ must have an
- * upper spatial first index and may have arbitray extra indices.
+ * upper spatial first index and may have arbitrary extra indices.
  */
 template <size_t VolumeDim, typename Fr, typename Symm,
           typename... RemainingIndices,

--- a/tests/Unit/Evolution/Systems/Burgers/BoundaryCorrections/Test_Hll.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/BoundaryCorrections/Test_Hll.cpp
@@ -16,7 +16,7 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 
-SPECTRE_TEST_CASE("Unit.Burgers.Hll", "[Unit][Burgers]") {
+SPECTRE_TEST_CASE("Unit.Burgers.BoundaryCorrections.Hll", "[Unit][Burgers]") {
   PUPable_reg(Burgers::BoundaryCorrections::Hll);
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/Burgers/BoundaryCorrections"};

--- a/tests/Unit/Evolution/Systems/Burgers/BoundaryCorrections/Test_Rusanov.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/BoundaryCorrections/Test_Rusanov.cpp
@@ -16,7 +16,8 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 
-SPECTRE_TEST_CASE("Unit.Burgers.Rusanov", "[Unit][Burgers]") {
+SPECTRE_TEST_CASE("Unit.Burgers.BoundaryCorrections.Rusanov",
+                  "[Unit][Burgers]") {
   PUPable_reg(Burgers::BoundaryCorrections::Rusanov);
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/Burgers/BoundaryCorrections"};

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/Test_UpwindPenalty.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/Test_UpwindPenalty.cpp
@@ -72,7 +72,7 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts) {
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.GeneralizedHarmonic.UpwindPenalty",
+SPECTRE_TEST_CASE("Unit.GeneralizedHarmonic.BoundaryCorrections.UpwindPenalty",
                   "[Unit][Evolution]") {
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections"};

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/Test_ProductOfCorrections.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/Test_ProductOfCorrections.cpp
@@ -262,7 +262,7 @@ void test_boundary_correction_combination(
 }  // namespace
 
 SPECTRE_TEST_CASE(
-    "Unit.Evolution.Systems.GhValenciaDivClean.ProductOfCorrections",
+    "Unit.GhValenciaDivClean.BoundaryCorrections.ProductOfCorrections",
     "[Unit][Evolution]") {
   // scoped to separate out each product combination
   {

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Test_Rusanov.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Test_Rusanov.cpp
@@ -19,7 +19,8 @@
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
-SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.Rusanov", "[Unit][GrMhd]") {
+SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.BoundaryCorrections.Rusanov",
+                  "[Unit][GrMhd]") {
   PUPable_reg(grmhd::ValenciaDivClean::BoundaryCorrections::Rusanov);
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections"};

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Test_Hll.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Test_Hll.cpp
@@ -138,7 +138,8 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts,
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.NewtonianEuler.Hll", "[Unit][Evolution]") {
+SPECTRE_TEST_CASE("Unit.NewtonianEuler.BoundaryCorrections.Hll",
+                  "[Unit][Evolution]") {
   PUPable_reg(NewtonianEuler::BoundaryCorrections::Hll<1>);
   PUPable_reg(NewtonianEuler::BoundaryCorrections::Hll<2>);
   PUPable_reg(NewtonianEuler::BoundaryCorrections::Hll<3>);

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Test_Hllc.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Test_Hllc.cpp
@@ -143,7 +143,8 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts,
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.NewtonianEuler.Hllc", "[Unit][Evolution]") {
+SPECTRE_TEST_CASE("Unit.NewtonianEuler.BoundaryCorrections.Hllc",
+                  "[Unit][Evolution]") {
   PUPable_reg(NewtonianEuler::BoundaryCorrections::Hllc<1>);
   PUPable_reg(NewtonianEuler::BoundaryCorrections::Hllc<2>);
   PUPable_reg(NewtonianEuler::BoundaryCorrections::Hllc<3>);

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Test_Rusanov.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Test_Rusanov.cpp
@@ -139,7 +139,8 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts,
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.NewtonianEuler.Rusanov", "[Unit][Evolution]") {
+SPECTRE_TEST_CASE("Unit.NewtonianEuler.BoundaryCorrections.Rusanov",
+                  "[Unit][Evolution]") {
   PUPable_reg(NewtonianEuler::BoundaryCorrections::Rusanov<1>);
   PUPable_reg(NewtonianEuler::BoundaryCorrections::Rusanov<2>);
   PUPable_reg(NewtonianEuler::BoundaryCorrections::Rusanov<3>);

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/BoundaryCorrections/Test_Rusanov.cpp
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/BoundaryCorrections/Test_Rusanov.cpp
@@ -70,7 +70,7 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts) {
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.RadiationTransport.M1Grey.Rusanov",
+SPECTRE_TEST_CASE("Unit.RadiationTransport.M1Grey.BoundaryCorrections.Rusanov",
                   "[Unit][Evolution]") {
   using neutrino_species = tmpl::list<neutrinos::ElectronNeutrinos<1>,
                                       neutrinos::ElectronAntiNeutrinos<1>>;

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/BoundaryCorrections/Test_Rusanov.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/BoundaryCorrections/Test_Rusanov.cpp
@@ -137,7 +137,7 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts,
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.RelativisticEuler.Valencia.Rusanov",
+SPECTRE_TEST_CASE("Unit.RelativisticEuler.Valencia.BoundaryCorrections.Rusanov",
                   "[Unit][Evolution]") {
   PUPable_reg(RelativisticEuler::Valencia::BoundaryCorrections::Rusanov<1>);
   PUPable_reg(RelativisticEuler::Valencia::BoundaryCorrections::Rusanov<2>);

--- a/tests/Unit/Evolution/Systems/ScalarWave/BoundaryCorrections/Test_UpwindPenalty.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/BoundaryCorrections/Test_UpwindPenalty.cpp
@@ -69,7 +69,8 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts) {
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.ScalarWave.UpwindPenalty", "[Unit][Evolution]") {
+SPECTRE_TEST_CASE("Unit.ScalarWave.BoundaryCorrections.UpwindPenalty",
+                  "[Unit][Evolution]") {
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/ScalarWave/BoundaryCorrections"};
   MAKE_GENERATOR(gen);


### PR DESCRIPTION
## Proposed changes

- improve documentation and sanity checks of `ranges` in bdry corr test helper
- use `normal_dot_flux` when computing normal dot flux
- improve consistency of bdry corr test names
- remove unused `name()` functions in bdry conds

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
