### PR TITLE
Make ErrorNorms optionally subtract analyic solution

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -208,16 +208,18 @@ struct EvolutionMetavars {
             Event,
             tmpl::flatten<tmpl::list<
                 Events::Completion,
-                dg::Events::field_observations<volume_dim, Tags::Time,
-                                               observe_fields,
-                                               analytic_solution_fields>,
+                dg::Events::field_observations<
+                    volume_dim, Tags::Time, observe_fields,
+                    tmpl::conditional_t<
+                        evolution::is_numeric_initial_data_v<initial_data>,
+                        tmpl::list<>, analytic_solution_fields>>,
                 Events::time_events<EvolutionMetavars>,
                 intrp::Events::Interpolate<3, AhA, interpolator_source_vars>>>>,
         tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
                    StepChoosers::standard_step_choosers<system>>,
-        tmpl::pair<StepChooser<StepChooserUse::Slab>,
-                   StepChoosers::standard_slab_choosers<system,
-                                                        local_time_stepping>>,
+        tmpl::pair<
+            StepChooser<StepChooserUse::Slab>,
+            StepChoosers::standard_slab_choosers<system, local_time_stepping>>,
         tmpl::pair<StepController, StepControllers::standard_step_controllers>,
         tmpl::pair<Trigger, tmpl::append<Triggers::logical_triggers,
                                          Triggers::time_triggers>>>;

--- a/src/ParallelAlgorithms/Events/Factory.hpp
+++ b/src/ParallelAlgorithms/Events/Factory.hpp
@@ -18,8 +18,8 @@ template <size_t VolumeDim, typename TimeTag, typename Fields,
 using field_observations = tmpl::flatten<tmpl::list<
     ObserveFields<VolumeDim, TimeTag, Fields, SolutionFields>,
     tmpl::conditional_t<std::is_same_v<SolutionFields, tmpl::list<>>,
-                        tmpl::list<>,
-                        ObserveErrorNorms<TimeTag, SolutionFields>>>>;
+                        ObserveErrorNorms<TimeTag, false, Fields>,
+                        ObserveErrorNorms<TimeTag, true, SolutionFields>>>>;
 }  // namespace dg::Events
 
 namespace Events {


### PR DESCRIPTION
## Proposed changes

This PR adds a boolean template parameter to `ObserveErrorNorms`. If true, `ObserveErrorNorms` subtracts the analytic solution and then computes the norm; if false, `ObserveErrorNorms` does not subtract the analytic solution before computing the norm. The former is appropriate behavior when observing a list of fields that have corresponding analytic solutions, while the latter is appropriate when observing a list of fields that do not have corresponding analytic solutions (such as constraints in an evolution of numeric initial data).

Currently, `field_observations` calls `ObserveErrorNorms` (subtracting the analytic solution) if passed analytic solution tensors and does nothing if not passed analytic solution tensors. This PR replaces the "do nothing" behavior with a call to `ObserveErrorNorms` that does not subtract the analytic solution.

Finally, this PR invokes this new `field_observations` behavior in EvolveGeneralizedHarmonic when reading in numeric initial data.

Note: the same behavior could have been achieved by i) never subtracting the analytic solution in `ObserveErrorNorms`, and ii) instead adding `Error<Tensor>` tags for each tensor that you want to compare with an analytic solution. I decided to give this approach a shot to avoid adding so many additional tags to the DataBox.

### Upgrade instructions

Calls to `ObserveErrorNorms` now have a template parameter that controls whether or not the analytic solution is subtracted when computing the norm. If not passed a list of analytic solution tensors, `field_observations` will call `ObserveErrorNorms` to compute norms without subtracting an analytic solution, instead of doing nothing.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
