### PR TITLE
Subcell: Add NewtonianEuler AO-WENO(5,3) reconstruction

### DIFF
--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/AoWeno.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/AoWeno.cpp
@@ -1,0 +1,213 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/NewtonianEuler/FiniteDifference/AoWeno.hpp"
+
+#include <array>
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/FixedHashMap.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/MaxNumberOfNeighbors.hpp"
+#include "Evolution/DgSubcell/NeighborData.hpp"
+#include "Evolution/Systems/NewtonianEuler/ConservativeFromPrimitive.hpp"
+#include "Evolution/Systems/NewtonianEuler/FiniteDifference/ReconstructWork.tpp"
+#include "NumericalAlgorithms/FiniteDifference/AoWeno.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace NewtonianEuler::fd {
+template <size_t Dim>
+AoWeno53Prim<Dim>::AoWeno53Prim(const double gamma_hi, const double gamma_lo,
+                                const double epsilon,
+                                const size_t nonlinear_weight_exponent) noexcept
+    : gamma_hi_(gamma_hi),
+      gamma_lo_(gamma_lo),
+      epsilon_(epsilon),
+      nonlinear_weight_exponent_(nonlinear_weight_exponent) {
+  std::tie(reconstruct_, reconstruct_lower_neighbor_,
+           reconstruct_upper_neighbor_) =
+      ::fd::reconstruction::aoweno_53_function_pointers<Dim>(
+          nonlinear_weight_exponent_);
+}
+
+template <size_t Dim>
+AoWeno53Prim<Dim>::AoWeno53Prim(CkMigrateMessage* const msg) noexcept
+    : Reconstructor<Dim>(msg) {}
+
+template <size_t Dim>
+std::unique_ptr<Reconstructor<Dim>> AoWeno53Prim<Dim>::get_clone()
+    const noexcept {
+  return std::make_unique<AoWeno53Prim>(*this);
+}
+
+template <size_t Dim>
+void AoWeno53Prim<Dim>::pup(PUP::er& p) {
+  Reconstructor<Dim>::pup(p);
+  p | gamma_hi_;
+  p | gamma_lo_;
+  p | epsilon_;
+  p | nonlinear_weight_exponent_;
+  if (p.isUnpacking()) {
+    std::tie(reconstruct_, reconstruct_lower_neighbor_,
+             reconstruct_upper_neighbor_) =
+        ::fd::reconstruction::aoweno_53_function_pointers<Dim>(
+            nonlinear_weight_exponent_);
+  }
+}
+
+template <size_t Dim>
+// NOLINTNEXTLINE
+PUP::able::PUP_ID AoWeno53Prim<Dim>::my_PUP_ID = 0;
+
+template <size_t Dim>
+template <size_t ThermodynamicDim, typename TagsList>
+void AoWeno53Prim<Dim>::reconstruct(
+    const gsl::not_null<std::array<Variables<TagsList>, Dim>*>
+        vars_on_lower_face,
+    const gsl::not_null<std::array<Variables<TagsList>, Dim>*>
+        vars_on_upper_face,
+    const Variables<prims_tags>& volume_prims,
+    const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
+    const Element<Dim>& element,
+    const FixedHashMap<maximum_number_of_neighbors(Dim) + 1,
+                       std::pair<Direction<Dim>, ElementId<Dim>>,
+                       evolution::dg::subcell::NeighborData,
+                       boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
+        neighbor_data,
+    const Mesh<Dim>& subcell_mesh) const noexcept {
+  reconstruct_prims_work(
+      vars_on_lower_face, vars_on_upper_face,
+      [this](auto upper_face_vars_ptr, auto lower_face_vars_ptr,
+             const auto& volume_vars, const auto& ghost_cell_vars,
+             const auto& subcell_extents, const size_t number_of_variables) {
+        reconstruct_(upper_face_vars_ptr, lower_face_vars_ptr, volume_vars,
+                     ghost_cell_vars, subcell_extents, number_of_variables,
+                     gamma_hi_, gamma_lo_, epsilon_);
+      },
+      volume_prims, eos, element, neighbor_data, subcell_mesh,
+      ghost_zone_size());
+}
+
+template <size_t Dim>
+template <size_t ThermodynamicDim, typename TagsList>
+void AoWeno53Prim<Dim>::reconstruct_fd_neighbor(
+    const gsl::not_null<Variables<TagsList>*> vars_on_face,
+    const Variables<prims_tags>& subcell_volume_prims,
+    const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
+    const Element<Dim>& element,
+    const FixedHashMap<maximum_number_of_neighbors(Dim) + 1,
+                       std::pair<Direction<Dim>, ElementId<Dim>>,
+                       evolution::dg::subcell::NeighborData,
+                       boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
+        neighbor_data,
+    const Mesh<Dim>& subcell_mesh,
+    const Direction<Dim> direction_to_reconstruct) const noexcept {
+  reconstruct_fd_neighbor_work(
+      vars_on_face,
+      [this](const auto tensor_component_on_face_ptr,
+             const auto& tensor_component_volume,
+             const auto& tensor_component_neighbor,
+             const Index<Dim>& subcell_extents,
+             const Index<Dim>& ghost_data_extents,
+             const Direction<Dim>& local_direction_to_reconstruct) noexcept {
+        reconstruct_lower_neighbor_(
+            tensor_component_on_face_ptr, tensor_component_volume,
+            tensor_component_neighbor, subcell_extents, ghost_data_extents,
+            local_direction_to_reconstruct, gamma_hi_, gamma_lo_, epsilon_);
+      },
+      [this](const auto tensor_component_on_face_ptr,
+             const auto& tensor_component_volume,
+             const auto& tensor_component_neighbor,
+             const Index<Dim>& subcell_extents,
+             const Index<Dim>& ghost_data_extents,
+             const Direction<Dim>& local_direction_to_reconstruct) noexcept {
+        reconstruct_upper_neighbor_(
+            tensor_component_on_face_ptr, tensor_component_volume,
+            tensor_component_neighbor, subcell_extents, ghost_data_extents,
+            local_direction_to_reconstruct, gamma_hi_, gamma_lo_, epsilon_);
+      },
+      subcell_volume_prims, eos, element, neighbor_data, subcell_mesh,
+      direction_to_reconstruct, ghost_zone_size());
+}
+
+template <size_t Dim>
+bool operator==(const AoWeno53Prim<Dim>& lhs,
+                const AoWeno53Prim<Dim>& rhs) noexcept {
+  // Don't check function pointers since they are set from
+  // nonlinear_weight_exponent_
+  return lhs.gamma_hi_ == rhs.gamma_hi_ and lhs.gamma_lo_ == rhs.gamma_lo_ and
+         lhs.epsilon_ == rhs.epsilon_ and
+         lhs.nonlinear_weight_exponent_ == rhs.nonlinear_weight_exponent_;
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define TAGS_LIST(data)                                                   \
+  tmpl::list<Tags::MassDensityCons, Tags::MomentumDensity<DIM(data)>,     \
+             Tags::EnergyDensity, Tags::MassDensity<DataVector>,          \
+             Tags::Velocity<DataVector, DIM(data)>,                       \
+             Tags::SpecificInternalEnergy<DataVector>,                    \
+             Tags::Pressure<DataVector>,                                  \
+             ::Tags::Flux<Tags::MassDensityCons, tmpl::size_t<DIM(data)>, \
+                          Frame::Inertial>,                               \
+             ::Tags::Flux<Tags::MomentumDensity<DIM(data)>,               \
+                          tmpl::size_t<DIM(data)>, Frame::Inertial>,      \
+             ::Tags::Flux<Tags::EnergyDensity, tmpl::size_t<DIM(data)>,   \
+                          Frame::Inertial>>
+
+#define INSTANTIATION(r, data)                                 \
+  template class AoWeno53Prim<DIM(data)>;                      \
+  template bool operator==(const AoWeno53Prim<DIM(data)>& lhs, \
+                           const AoWeno53Prim<DIM(data)>& rhs) noexcept;
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+#undef INSTANTIATION
+
+#define INSTANTIATION(r, data)                                                 \
+  template void AoWeno53Prim<DIM(data)>::reconstruct(                          \
+      gsl::not_null<std::array<Variables<TAGS_LIST(data)>, DIM(data)>*>        \
+          vars_on_lower_face,                                                  \
+      gsl::not_null<std::array<Variables<TAGS_LIST(data)>, DIM(data)>*>        \
+          vars_on_upper_face,                                                  \
+      const Variables<prims_tags>& volume_prims,                               \
+      const EquationsOfState::EquationOfState<false, THERMO_DIM(data)>& eos,   \
+      const Element<DIM(data)>& element,                                       \
+      const FixedHashMap<                                                      \
+          maximum_number_of_neighbors(DIM(data)) + 1,                          \
+          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>,               \
+          evolution::dg::subcell::NeighborData,                                \
+          boost::hash<std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>>>& \
+          neighbor_data,                                                       \
+      const Mesh<DIM(data)>& subcell_mesh) const noexcept;                     \
+  template void AoWeno53Prim<DIM(data)>::reconstruct_fd_neighbor(              \
+      gsl::not_null<Variables<TAGS_LIST(data)>*> vars_on_face,                 \
+      const Variables<prims_tags>& subcell_volume_prims,                       \
+      const EquationsOfState::EquationOfState<false, THERMO_DIM(data)>& eos,   \
+      const Element<DIM(data)>& element,                                       \
+      const FixedHashMap<                                                      \
+          maximum_number_of_neighbors(DIM(data)) + 1,                          \
+          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>,               \
+          evolution::dg::subcell::NeighborData,                                \
+          boost::hash<std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>>>& \
+          neighbor_data,                                                       \
+      const Mesh<DIM(data)>& subcell_mesh,                                     \
+      const Direction<DIM(data)> direction_to_reconstruct) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
+
+#undef INSTANTIATION
+#undef TAGS_LIST
+#undef THERMO_DIM
+#undef DIM
+}  // namespace NewtonianEuler::fd

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/AoWeno.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/AoWeno.hpp
@@ -1,0 +1,173 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <boost/functional/hash.hpp>
+#include <cstddef>
+#include <limits>
+#include <memory>
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/FixedHashMap.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/Structure/MaxNumberOfNeighbors.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/NeighborData.hpp"
+#include "Evolution/Systems/NewtonianEuler/FiniteDifference/Reconstructor.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+
+namespace NewtonianEuler::fd {
+/*!
+ * \brief Adaptive-order WENO reconstruction hybridizing orders 5 and 3. See
+ * ::fd::reconstruction::aoweno_53() for details.
+ */
+template <size_t Dim>
+class AoWeno53Prim : public Reconstructor<Dim> {
+ private:
+  // Conservative vars tags
+  using MassDensityCons = Tags::MassDensityCons;
+  using EnergyDensity = Tags::EnergyDensity;
+  using MomentumDensity = Tags::MomentumDensity<Dim>;
+
+  // Primitive vars tags
+  using MassDensity = Tags::MassDensity<DataVector>;
+  using Velocity = Tags::Velocity<DataVector, Dim>;
+  using SpecificInternalEnergy = Tags::SpecificInternalEnergy<DataVector>;
+  using Pressure = Tags::Pressure<DataVector>;
+
+  using prims_tags =
+      tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>;
+  using cons_tags = tmpl::list<MassDensityCons, MomentumDensity, EnergyDensity>;
+  using flux_tags = db::wrap_tags_in<::Tags::Flux, cons_tags, tmpl::size_t<Dim>,
+                                     Frame::Inertial>;
+  using prim_tags_for_reconstruction =
+      tmpl::list<MassDensity, Velocity, Pressure>;
+
+ public:
+  struct GammaHi {
+    using type = double;
+    static constexpr Options::String help = {
+        "The linear weight for the 5th-order stencil."};
+  };
+  struct GammaLo {
+    using type = double;
+    static constexpr Options::String help = {
+        "The linear weight for the central 3rd-order stencil."};
+  };
+  struct Epsilon {
+    using type = double;
+    static constexpr Options::String help = {
+        "The parameter added to the oscillation indicators to avoid division "
+        "by zero"};
+  };
+  struct NonlinearWeightExponent {
+    using type = size_t;
+    static constexpr Options::String help = {
+        "The exponent q to which the oscillation indicators are raised"};
+  };
+
+  using options =
+      tmpl::list<GammaHi, GammaLo, Epsilon, NonlinearWeightExponent>;
+  static constexpr Options::String help{
+      "Monotised central reconstruction scheme using primitive variables."};
+
+  AoWeno53Prim() = default;
+  AoWeno53Prim(AoWeno53Prim&&) noexcept = default;
+  AoWeno53Prim& operator=(AoWeno53Prim&&) noexcept = default;
+  AoWeno53Prim(const AoWeno53Prim&) = default;
+  AoWeno53Prim& operator=(const AoWeno53Prim&) = default;
+  ~AoWeno53Prim() override = default;
+
+  AoWeno53Prim(double gamma_hi, double gamma_lo, double epsilon,
+               size_t nonlinear_weight_exponent) noexcept;
+
+  explicit AoWeno53Prim(CkMigrateMessage* msg) noexcept;
+
+  WRAPPED_PUPable_decl_base_template(Reconstructor<Dim>, AoWeno53Prim);
+
+  auto get_clone() const noexcept
+      -> std::unique_ptr<Reconstructor<Dim>> override;
+
+  void pup(PUP::er& p) override;
+
+  size_t ghost_zone_size() const noexcept override { return 3; }
+
+  using reconstruction_argument_tags =
+      tmpl::list<::Tags::Variables<prims_tags>,
+                 hydro::Tags::EquationOfStateBase, domain::Tags::Element<Dim>,
+                 evolution::dg::subcell::Tags::
+                     NeighborDataForReconstructionAndRdmpTci<Dim>,
+                 evolution::dg::subcell::Tags::Mesh<Dim>>;
+
+  template <size_t ThermodynamicDim, typename TagsList>
+  void reconstruct(
+      gsl::not_null<std::array<Variables<TagsList>, Dim>*> vars_on_lower_face,
+      gsl::not_null<std::array<Variables<TagsList>, Dim>*> vars_on_upper_face,
+      const Variables<prims_tags>& volume_prims,
+      const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
+      const Element<Dim>& element,
+      const FixedHashMap<
+          maximum_number_of_neighbors(Dim) + 1,
+          std::pair<Direction<Dim>, ElementId<Dim>>,
+          evolution::dg::subcell::NeighborData,
+          boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
+          neighbor_data,
+      const Mesh<Dim>& subcell_mesh) const noexcept;
+
+  /// Called by an element doing DG when the neighbor is doing subcell.
+  template <size_t ThermodynamicDim, typename TagsList>
+  void reconstruct_fd_neighbor(
+      gsl::not_null<Variables<TagsList>*> vars_on_face,
+      const Variables<prims_tags>& subcell_volume_prims,
+      const EquationsOfState::EquationOfState<false, ThermodynamicDim>& eos,
+      const Element<Dim>& element,
+      const FixedHashMap<
+          maximum_number_of_neighbors(Dim) + 1,
+          std::pair<Direction<Dim>, ElementId<Dim>>,
+          evolution::dg::subcell::NeighborData,
+          boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>&
+          neighbor_data,
+      const Mesh<Dim>& subcell_mesh,
+      const Direction<Dim> direction_to_reconstruct) const noexcept;
+
+ private:
+  template <size_t LocalDim>
+  // NOLINTNEXTLINE(readability-redundant-declaration)
+  friend bool operator==(const AoWeno53Prim<LocalDim>& lhs,
+                         const AoWeno53Prim<LocalDim>& rhs) noexcept;
+
+  double gamma_hi_ = std::numeric_limits<double>::signaling_NaN();
+  double gamma_lo_ = std::numeric_limits<double>::signaling_NaN();
+  double epsilon_ = std::numeric_limits<double>::signaling_NaN();
+  size_t nonlinear_weight_exponent_ = 0;
+
+  void (*reconstruct_)(gsl::not_null<std::array<gsl::span<double>, Dim>*>,
+                       gsl::not_null<std::array<gsl::span<double>, Dim>*>,
+                       const gsl::span<const double>&,
+                       const DirectionMap<Dim, gsl::span<const double>>&,
+                       const Index<Dim>&, size_t, double, double,
+                       double) noexcept;
+  void (*reconstruct_lower_neighbor_)(gsl::not_null<DataVector*>,
+                                      const DataVector&, const DataVector&,
+                                      const Index<Dim>&, const Index<Dim>&,
+                                      const Direction<Dim>&, const double&,
+                                      const double&, const double&) noexcept;
+  void (*reconstruct_upper_neighbor_)(gsl::not_null<DataVector*>,
+                                      const DataVector&, const DataVector&,
+                                      const Index<Dim>&, const Index<Dim>&,
+                                      const Direction<Dim>&, const double&,
+                                      const double&, const double&) noexcept;
+};
+
+template <size_t Dim>
+bool operator!=(const AoWeno53Prim<Dim>& lhs,
+                const AoWeno53Prim<Dim>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+}  // namespace NewtonianEuler::fd

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/CMakeLists.txt
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/CMakeLists.txt
@@ -20,4 +20,5 @@ spectre_target_headers(
   ReconstructWork.tpp
   Reconstructor.hpp
   RegisterDerivedWithCharm.hpp
+  Tag.hpp
   )

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/CMakeLists.txt
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/CMakeLists.txt
@@ -4,6 +4,7 @@
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  AoWeno.cpp
   MonotisedCentral.cpp
   Reconstructor.cpp
   RegisterDerivedWithCharm.cpp
@@ -13,6 +14,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  AoWeno.hpp
   Factory.hpp
   FiniteDifference.hpp
   MonotisedCentral.hpp

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/Factory.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/Factory.hpp
@@ -3,5 +3,6 @@
 
 #pragma once
 
+#include "Evolution/Systems/NewtonianEuler/FiniteDifference/AoWeno.hpp"
 #include "Evolution/Systems/NewtonianEuler/FiniteDifference/MonotisedCentral.hpp"
 #include "Evolution/Systems/NewtonianEuler/FiniteDifference/Reconstructor.hpp"

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/MonotisedCentral.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/MonotisedCentral.hpp
@@ -139,4 +139,16 @@ class MonotisedCentralPrim : public Reconstructor<Dim> {
       const Mesh<Dim>& subcell_mesh,
       const Direction<Dim> direction_to_reconstruct) const noexcept;
 };
+
+template <size_t Dim>
+bool operator==(const MonotisedCentralPrim<Dim>& /*lhs*/,
+                const MonotisedCentralPrim<Dim>& /*rhs*/) noexcept {
+  return true;
+}
+
+template <size_t Dim>
+bool operator!=(const MonotisedCentralPrim<Dim>& lhs,
+                const MonotisedCentralPrim<Dim>& rhs) noexcept {
+  return not(lhs == rhs);
+}
 }  // namespace NewtonianEuler::fd

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/Reconstructor.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/Reconstructor.hpp
@@ -12,6 +12,8 @@
 namespace NewtonianEuler::fd {
 /// \cond
 template <size_t Dim>
+class AoWeno53Prim;
+template <size_t Dim>
 class MonotisedCentralPrim;
 /// \endcond
 
@@ -42,7 +44,8 @@ class Reconstructor : public PUP::able {
   WRAPPED_PUPable_abstract(Reconstructor<Dim>);  // NOLINT
   /// \endcond
 
-  using creatable_classes = tmpl::list<MonotisedCentralPrim<Dim>>;
+  using creatable_classes =
+      tmpl::list<AoWeno53Prim<Dim>, MonotisedCentralPrim<Dim>>;
 
   virtual std::unique_ptr<Reconstructor<Dim>> get_clone() const noexcept = 0;
 

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/Tag.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/Tag.hpp
@@ -1,0 +1,41 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Evolution/DgSubcell/Tags/SubcellSolver.hpp"
+#include "Evolution/Systems/NewtonianEuler/FiniteDifference/Reconstructor.hpp"
+#include "Options/Options.hpp"
+
+namespace NewtonianEuler::fd {
+/// Option tags for reconstruction
+namespace OptionTags {
+/// \brief Option tag for the reconstructor
+template <size_t Dim>
+struct Reconstructor {
+  using type = std::unique_ptr<fd::Reconstructor<Dim>>;
+
+  static constexpr Options::String help = {"The reconstruction scheme to use."};
+  using group = evolution::dg::subcell::OptionTags::SubcellSolverGroup;
+};
+}  // namespace OptionTags
+
+/// %Tags for reconstruction
+namespace Tags {
+/// \brief Tag for the reconstructor
+template <size_t Dim>
+struct Reconstructor : db::SimpleTag {
+  using type = std::unique_ptr<fd::Reconstructor<Dim>>;
+  using option_tags = tmpl::list<OptionTags::Reconstructor<Dim>>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& reconstructor) noexcept {
+    return reconstructor->get_clone();
+  }
+};
+}  // namespace Tags
+}  // namespace NewtonianEuler::fd

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
   BoundaryCorrections/Test_Hllc.cpp
   BoundaryCorrections/Test_Rusanov.cpp
   FiniteDifference/Test_MonotisedCentral.cpp
+  FiniteDifference/Test_Tag.cpp
   Subcell/Test_InitialDataTci.cpp
   Subcell/Test_TciOnDgGrid.cpp
   Test_Characteristics.cpp

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   BoundaryCorrections/Test_Hll.cpp
   BoundaryCorrections/Test_Hllc.cpp
   BoundaryCorrections/Test_Rusanov.cpp
+  FiniteDifference/Test_AoWeno.cpp
   FiniteDifference/Test_MonotisedCentral.cpp
   FiniteDifference/Test_Tag.cpp
   Subcell/Test_InitialDataTci.cpp

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/FiniteDifference/Test_AoWeno.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/FiniteDifference/Test_AoWeno.cpp
@@ -1,0 +1,52 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Evolution/Systems/NewtonianEuler/FiniteDifference/AoWeno.hpp"
+#include "Evolution/Systems/NewtonianEuler/FiniteDifference/Factory.hpp"
+#include "Evolution/Systems/NewtonianEuler/FiniteDifference/Tag.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Helpers/Evolution/Systems/NewtonianEuler/FiniteDifference/PrimReconstructor.hpp"
+
+namespace {
+template <size_t Dim>
+void test() {
+  namespace helpers = TestHelpers::NewtonianEuler::fd;
+  const NewtonianEuler::fd::AoWeno53Prim<Dim> aoweno_recons{0.85, 0.8, 1.0e-12,
+                                                            8};
+  helpers::test_prim_reconstructor<Dim>(5, aoweno_recons);
+
+  const auto aoweno_from_options_base = TestHelpers::test_factory_creation<
+      NewtonianEuler::fd::Reconstructor<Dim>,
+      NewtonianEuler::fd::OptionTags::Reconstructor<Dim>>(
+      "AoWeno53Prim:\n"
+      "  GammaHi: 0.85\n"
+      "  GammaLo: 0.8\n"
+      "  Epsilon: 1.0e-12\n"
+      "  NonlinearWeightExponent: 8\n");
+  auto* const aoweno_from_options =
+      dynamic_cast<const NewtonianEuler::fd::AoWeno53Prim<Dim>*>(
+          aoweno_from_options_base.get());
+  REQUIRE(aoweno_from_options != nullptr);
+  CHECK(*aoweno_from_options == aoweno_recons);
+
+  CHECK(aoweno_recons !=
+        NewtonianEuler::fd::AoWeno53Prim<Dim>(0.8, 0.8, 1.0e-12, 8));
+  CHECK(aoweno_recons !=
+        NewtonianEuler::fd::AoWeno53Prim<Dim>(0.85, 0.85, 1.0e-12, 8));
+  CHECK(aoweno_recons !=
+        NewtonianEuler::fd::AoWeno53Prim<Dim>(0.85, 0.8, 2.0e-12, 8));
+  CHECK(aoweno_recons !=
+        NewtonianEuler::fd::AoWeno53Prim<Dim>(0.85, 0.8, 1.0e-12, 6));
+  CHECK(aoweno_recons ==
+        NewtonianEuler::fd::AoWeno53Prim<Dim>(0.85, 0.8, 1.0e-12, 8));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.NewtonianEuler.Fd.AoWeno53Prim",
+                  "[Unit][Evolution]") {
+  test<1>();
+  test<2>();
+  test<3>();
+}

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/FiniteDifference/Test_MonotisedCentral.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/FiniteDifference/Test_MonotisedCentral.cpp
@@ -3,17 +3,34 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include "Evolution/Systems/NewtonianEuler/FiniteDifference/Factory.hpp"
 #include "Evolution/Systems/NewtonianEuler/FiniteDifference/MonotisedCentral.hpp"
+#include "Evolution/Systems/NewtonianEuler/FiniteDifference/Tag.hpp"
+#include "Framework/TestCreation.hpp"
 #include "Helpers/Evolution/Systems/NewtonianEuler/FiniteDifference/PrimReconstructor.hpp"
+
+namespace {
+template <size_t Dim>
+void test() {
+  namespace helpers = TestHelpers::NewtonianEuler::fd;
+  const NewtonianEuler::fd::MonotisedCentralPrim<Dim> mc_recons{};
+  helpers::test_prim_reconstructor<Dim>(5, mc_recons);
+  const auto mc_from_options_base = TestHelpers::test_factory_creation<
+      NewtonianEuler::fd::Reconstructor<Dim>,
+      NewtonianEuler::fd::OptionTags::Reconstructor<Dim>>(
+      "MonotisedCentralPrim:\n");
+  auto* const mc_from_options =
+      dynamic_cast<const NewtonianEuler::fd::MonotisedCentralPrim<Dim>*>(
+          mc_from_options_base.get());
+  REQUIRE(mc_from_options != nullptr);
+  CHECK(*mc_from_options == mc_recons);
+}
+}  // namespace
 
 SPECTRE_TEST_CASE(
     "Unit.Evolution.Systems.NewtonianEuler.Fd.MonotisedCentralPrim",
     "[Unit][Evolution]") {
-  namespace helpers = TestHelpers::NewtonianEuler::fd;
-  helpers::test_prim_reconstructor<1>(
-      5, NewtonianEuler::fd::MonotisedCentralPrim<1>{});
-  helpers::test_prim_reconstructor<2>(
-      5, NewtonianEuler::fd::MonotisedCentralPrim<2>{});
-  helpers::test_prim_reconstructor<3>(
-      5, NewtonianEuler::fd::MonotisedCentralPrim<3>{});
+  test<1>();
+  test<2>();
+  test<3>();
 }

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/FiniteDifference/Test_Tag.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/FiniteDifference/Test_Tag.cpp
@@ -1,0 +1,22 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Evolution/Systems/NewtonianEuler/FiniteDifference/Tag.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+
+namespace {
+template <size_t Dim>
+void test() {
+  TestHelpers::db::test_simple_tag<
+      NewtonianEuler::fd::Tags::Reconstructor<Dim>>("Reconstructor");
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.NewtonianEuler.Fd.Tag",
+                  "[Unit][Evolution]") {
+  test<1>();
+  test<2>();
+  test<3>();
+}


### PR DESCRIPTION
## Proposed changes

- Refactor MC reconstruction so it can be specified in the input file
- Add adaptive order WENO (5,3) reconstruction. This doesn't do anything fancy like positivity-preserving.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
