### PR TITLE
Add ResizeAndComputePrimitives mutator to NewtonianEuler

### DIFF
--- a/src/Evolution/Systems/NewtonianEuler/Subcell/CMakeLists.txt
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/CMakeLists.txt
@@ -5,6 +5,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   InitialDataTci.cpp
+  ResizeAndComputePrimitives.cpp
   TciOnDgGrid.cpp
   TciOnFdGrid.cpp
   )
@@ -14,6 +15,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   InitialDataTci.hpp
+  ResizeAndComputePrimitives.hpp
   Subcell.hpp
   TciOnDgGrid.hpp
   TciOnFdGrid.hpp

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/ResizeAndComputePrimitives.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/ResizeAndComputePrimitives.cpp
@@ -1,0 +1,76 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/NewtonianEuler/Subcell/ResizeAndComputePrimitives.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/NewtonianEuler/PrimitiveFromConservative.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace NewtonianEuler::subcell {
+template <size_t Dim>
+template <size_t ThermodynamicDim>
+void ResizeAndComputePrims<Dim>::apply(
+    const gsl::not_null<Variables<
+        tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>>*>
+        prim_vars,
+    const evolution::dg::subcell::ActiveGrid active_grid,
+    const Mesh<Dim>& dg_mesh, const Mesh<Dim>& subcell_mesh,
+    const Scalar<DataVector>& mass_density_cons,
+    const tnsr::I<DataVector, Dim>& momentum_density,
+    const Scalar<DataVector>& energy_density,
+    const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
+        equation_of_state) noexcept {
+  const size_t num_grid_points =
+      (active_grid == evolution::dg::subcell::ActiveGrid::Dg ? dg_mesh
+                                                             : subcell_mesh)
+          .number_of_grid_points();
+  if (prim_vars->number_of_grid_points() != num_grid_points) {
+    ASSERT(active_grid == evolution::dg::subcell::ActiveGrid::Dg,
+           "ResizeAndComputePrims should only be resizing when switching from "
+           "subcell to DG");
+    prim_vars->initialize(num_grid_points);
+
+    // We only need to compute the prims if we switched to the DG grid because
+    // otherwise we computed the prims during the FD TCI.
+    NewtonianEuler::PrimitiveFromConservative<Dim, ThermodynamicDim>::apply(
+        make_not_null(&get<MassDensity>(*prim_vars)),
+        make_not_null(&get<Velocity>(*prim_vars)),
+        make_not_null(&get<SpecificInternalEnergy>(*prim_vars)),
+        make_not_null(&get<Pressure>(*prim_vars)), mass_density_cons,
+        momentum_density, energy_density, equation_of_state);
+  }
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define INSTANTIATION(r, data) template class ResizeAndComputePrims<DIM(data)>;
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+#undef INSTANTIATION
+
+#define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define INSTANTIATION(r, data)                                                \
+  template void ResizeAndComputePrims<DIM(data)>::apply<THERMO_DIM(data)>(    \
+      gsl::not_null<Variables<tmpl::list<MassDensity, Velocity,               \
+                                         SpecificInternalEnergy, Pressure>>*> \
+          prim_vars,                                                          \
+      evolution::dg::subcell::ActiveGrid active_grid,                         \
+      const Mesh<DIM(data)>& dg_mesh, const Mesh<DIM(data)>& subcell_mesh,    \
+      const Scalar<DataVector>& mass_density_cons,                            \
+      const tnsr::I<DataVector, DIM(data)>& momentum_density,                 \
+      const Scalar<DataVector>& energy_density,                               \
+      const EquationsOfState::EquationOfState<false, THERMO_DIM(data)>&       \
+          equation_of_state) noexcept;
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
+#undef INSTANTIATION
+#undef THERMO_DIM
+#undef DIM
+}  // namespace NewtonianEuler::subcell

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/ResizeAndComputePrimitives.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/ResizeAndComputePrimitives.hpp
@@ -1,0 +1,80 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace EquationsOfState {
+template <bool IsRelativistic, size_t ThermodynamicDim>
+class EquationOfState;
+}  // namespace EquationsOfState
+template <size_t Dim>
+class Mesh;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+template <typename TagsList>
+class Variables;
+/// \endcond
+
+namespace NewtonianEuler::subcell {
+/*!
+ * \brief Mutator that resizes the primitive variables to have the size of the
+ * active mesh and then computes the primitive variables on the active mesh.
+ *
+ * In the DG-subcell `step_actions` list this will normally be called using the
+ * `::Actions::MutateApply` action right after the
+ * `evolution::dg::subcell::Actions::TciAndSwitchToDg` action. We only need to
+ * compute the primitives if we switched to the DG grid because otherwise we
+ * computed the primitives during the FD TCI. After the primitive variables tag
+ * is resized for the DG grid, the primitives are computed directly on the DG
+ * grid from the reconstructed conserved variables, not via a reconstruction
+ * operation applied to the primitives.
+ */
+template <size_t Dim>
+struct ResizeAndComputePrims {
+ private:
+  using MassDensity = NewtonianEuler::Tags::MassDensity<DataVector>;
+  using Velocity = NewtonianEuler::Tags::Velocity<DataVector, Dim>;
+  using SpecificInternalEnergy =
+      NewtonianEuler::Tags::SpecificInternalEnergy<DataVector>;
+  using Pressure = NewtonianEuler::Tags::Pressure<DataVector>;
+
+ public:
+  using return_tags = tmpl::list<::Tags::Variables<
+      tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>>>;
+  using argument_tags =
+      tmpl::list<evolution::dg::subcell::Tags::ActiveGrid,
+                 domain::Tags::Mesh<Dim>,
+                 evolution::dg::subcell::Tags::Mesh<Dim>, Tags::MassDensityCons,
+                 Tags::MomentumDensity<Dim>, Tags::EnergyDensity,
+                 hydro::Tags::EquationOfStateBase>;
+
+  template <size_t ThermodynamicDim>
+  static void apply(
+      gsl::not_null<Variables<
+          tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>>*>
+          prim_vars,
+      evolution::dg::subcell::ActiveGrid active_grid, const Mesh<Dim>& dg_mesh,
+      const Mesh<Dim>& subcell_mesh,
+      const Scalar<DataVector>& mass_density_cons,
+      const tnsr::I<DataVector, Dim>& momentum_density,
+      const Scalar<DataVector>& energy_density,
+      const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
+          equation_of_state) noexcept;
+};
+}  // namespace NewtonianEuler::subcell

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBRARY_SOURCES
   FiniteDifference/Test_MonotisedCentral.cpp
   FiniteDifference/Test_Tag.cpp
   Subcell/Test_InitialDataTci.cpp
+  Subcell/Test_ResizeAndComputePrimitives.cpp
   Subcell/Test_TciOnDgGrid.cpp
   Subcell/Test_TciOnFdGrid.cpp
   Test_Characteristics.cpp

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_ResizeAndComputePrimitives.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_ResizeAndComputePrimitives.cpp
@@ -1,0 +1,110 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <random>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "Evolution/DgSubcell/Projection.hpp"
+#include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/Systems/NewtonianEuler/PrimitiveFromConservative.hpp"
+#include "Evolution/Systems/NewtonianEuler/Subcell/ResizeAndComputePrimitives.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+
+namespace {
+template <size_t Dim>
+void test(const gsl::not_null<std::mt19937*> gen,
+          const gsl::not_null<std::uniform_real_distribution<>*> dist,
+          const evolution::dg::subcell::ActiveGrid active_grid) {
+  using MassDensityCons = NewtonianEuler::Tags::MassDensityCons;
+  using EnergyDensity = NewtonianEuler::Tags::EnergyDensity;
+  using MomentumDensity = NewtonianEuler::Tags::MomentumDensity<Dim>;
+
+  using MassDensity = NewtonianEuler::Tags::MassDensity<DataVector>;
+  using Velocity = NewtonianEuler::Tags::Velocity<DataVector, Dim>;
+  using SpecificInternalEnergy =
+      NewtonianEuler::Tags::SpecificInternalEnergy<DataVector>;
+  using Pressure = NewtonianEuler::Tags::Pressure<DataVector>;
+
+  using cons_tags = tmpl::list<MassDensityCons, MomentumDensity, EnergyDensity>;
+  using ConsVars = Variables<cons_tags>;
+  using prim_tags =
+      tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>;
+  using PrimVars = Variables<prim_tags>;
+
+  const Mesh<Dim> dg_mesh{5, Spectral::Basis::Legendre,
+                          Spectral::Quadrature::GaussLobatto};
+  const Mesh<Dim> subcell_mesh = evolution::dg::subcell::fd::mesh(dg_mesh);
+
+  auto cons_vars = make_with_random_values<ConsVars>(
+      gen, dist,
+      active_grid == evolution::dg::subcell::ActiveGrid::Dg
+          ? dg_mesh.number_of_grid_points()
+          : subcell_mesh.number_of_grid_points());
+  PrimVars prim_vars{};
+  if (active_grid == evolution::dg::subcell::ActiveGrid::Subcell) {
+    prim_vars.initialize(subcell_mesh.number_of_grid_points(), 1.0);
+  }
+
+  std::unique_ptr<EquationsOfState::EquationOfState<false, 1>> eos =
+      std::make_unique<EquationsOfState::PolytropicFluid<false>>(1.4,
+                                                                 5.0 / 3.0);
+
+  auto box = db::create<db::AddSimpleTags<
+      evolution::dg::subcell::Tags::ActiveGrid, ::Tags::Variables<cons_tags>,
+      ::Tags::Variables<prim_tags>, ::domain::Tags::Mesh<Dim>,
+      evolution::dg::subcell::Tags::Mesh<Dim>,
+      hydro::Tags::EquationOfState<
+          std::unique_ptr<EquationsOfState::EquationOfState<false, 1>>>>>(
+      active_grid, cons_vars, prim_vars, dg_mesh, subcell_mesh, std::move(eos));
+
+  db::mutate_apply<NewtonianEuler::subcell::ResizeAndComputePrims<Dim>>(
+      make_not_null(&box));
+
+  REQUIRE(db::get<::Tags::Variables<prim_tags>>(box).number_of_grid_points() ==
+          cons_vars.number_of_grid_points());
+  if (active_grid == evolution::dg::subcell::ActiveGrid::Dg) {
+    prim_vars.initialize(cons_vars.number_of_grid_points());
+    NewtonianEuler::PrimitiveFromConservative<Dim, 1>::apply(
+        make_not_null(&get<MassDensity>(prim_vars)),
+        make_not_null(&get<Velocity>(prim_vars)),
+        make_not_null(&get<SpecificInternalEnergy>(prim_vars)),
+        make_not_null(&get<Pressure>(prim_vars)),
+        get<MassDensityCons>(cons_vars), get<MomentumDensity>(cons_vars),
+        get<EnergyDensity>(cons_vars),
+        db::get<hydro::Tags::EquationOfStateBase>(box));
+  }
+  CHECK_VARIABLES_APPROX(db::get<::Tags::Variables<prim_tags>>(box), prim_vars);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.NewtonianEuler.Subcell.ResizeAndComputePrims",
+    "[Unit][Evolution]") {
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> dist(0.1, 1.0);
+  for (const auto active_grid : {evolution::dg::subcell::ActiveGrid::Dg,
+                                 evolution::dg::subcell::ActiveGrid::Subcell}) {
+    test<1>(make_not_null(&gen), make_not_null(&dist), active_grid);
+    test<2>(make_not_null(&gen), make_not_null(&dist), active_grid);
+    test<3>(make_not_null(&gen), make_not_null(&dist), active_grid);
+  }
+}


### PR DESCRIPTION
## Proposed changes

Exactly what the title says. This is used to compute the prims after we've decided we can go back to DG.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
