### PR TITLE
Add PrimsAfterRollback mutator to NewtonianEuler

### DIFF
--- a/src/Evolution/Systems/NewtonianEuler/Subcell/CMakeLists.txt
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/CMakeLists.txt
@@ -5,6 +5,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   InitialDataTci.cpp
+  PrimsAfterRollback.cpp
   ResizeAndComputePrimitives.cpp
   TciOnDgGrid.cpp
   TciOnFdGrid.cpp
@@ -15,6 +16,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   InitialDataTci.hpp
+  PrimsAfterRollback.hpp
   ResizeAndComputePrimitives.hpp
   Subcell.hpp
   TciOnDgGrid.hpp

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/PrimsAfterRollback.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/PrimsAfterRollback.cpp
@@ -1,0 +1,67 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/NewtonianEuler/Subcell/PrimsAfterRollback.hpp"
+
+#include <algorithm>
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/NewtonianEuler/PrimitiveFromConservative.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace NewtonianEuler::subcell {
+template <size_t Dim>
+template <size_t ThermodynamicDim>
+void PrimsAfterRollback<Dim>::apply(
+    const gsl::not_null<Variables<
+        tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>>*>
+        prim_vars,
+    const bool did_rollback, const Mesh<Dim>& subcell_mesh,
+    const Scalar<DataVector>& mass_density_cons,
+    const tnsr::I<DataVector, Dim>& momentum_density,
+    const Scalar<DataVector>& energy_density,
+    const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
+        equation_of_state) noexcept {
+  if (did_rollback) {
+    const size_t num_grid_points = subcell_mesh.number_of_grid_points();
+    if (prim_vars->number_of_grid_points() != num_grid_points) {
+      prim_vars->initialize(num_grid_points);
+    }
+    NewtonianEuler::PrimitiveFromConservative<Dim, ThermodynamicDim>::apply(
+        make_not_null(&get<MassDensity>(*prim_vars)),
+        make_not_null(&get<Velocity>(*prim_vars)),
+        make_not_null(&get<SpecificInternalEnergy>(*prim_vars)),
+        make_not_null(&get<Pressure>(*prim_vars)), mass_density_cons,
+        momentum_density, energy_density, equation_of_state);
+  }
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define INSTANTIATION(r, data) template class PrimsAfterRollback<DIM(data)>;
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+#undef INSTANTIATION
+
+#define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define INSTANTIATION(r, data)                                                \
+  template void PrimsAfterRollback<DIM(data)>::apply<THERMO_DIM(data)>(       \
+      gsl::not_null<Variables<tmpl::list<MassDensity, Velocity,               \
+                                         SpecificInternalEnergy, Pressure>>*> \
+          prim_vars,                                                          \
+      bool did_rollback, const Mesh<DIM(data)>& subcell_mesh,                 \
+      const Scalar<DataVector>& mass_density_cons,                            \
+      const tnsr::I<DataVector, DIM(data)>& momentum_density,                 \
+      const Scalar<DataVector>& energy_density,                               \
+      const EquationsOfState::EquationOfState<false, THERMO_DIM(data)>&       \
+          equation_of_state) noexcept;
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))
+#undef INSTANTIATION
+#undef THERMO_DIM
+#undef DIM
+}  // namespace NewtonianEuler::subcell

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/PrimsAfterRollback.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/PrimsAfterRollback.hpp
@@ -1,0 +1,73 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/Tags/DidRollback.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace EquationsOfState {
+template <bool IsRelativistic, size_t ThermodynamicDim>
+class EquationOfState;
+}  // namespace EquationsOfState
+template <size_t Dim>
+class Mesh;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+template <typename TagsList>
+class Variables;
+/// \endcond
+
+namespace NewtonianEuler::subcell {
+/*!
+ * \brief Mutator that resizes the primitive variables to the subcell mesh and
+ * computes the primitives, but only if
+ * `evolution::dg::subcell::Tags::DidRollback` is `true`.
+ *
+ * In the DG-subcell `step_actions` list this will normally be called using the
+ * `::Actions::MutateApply` action right after the
+ * `evolution::dg::subcell::Actions::Labels::BeginSubcellAfterDgRollback` label.
+ */
+template <size_t Dim>
+struct PrimsAfterRollback {
+ private:
+  using MassDensity = NewtonianEuler::Tags::MassDensity<DataVector>;
+  using Velocity = NewtonianEuler::Tags::Velocity<DataVector, Dim>;
+  using SpecificInternalEnergy =
+      NewtonianEuler::Tags::SpecificInternalEnergy<DataVector>;
+  using Pressure = NewtonianEuler::Tags::Pressure<DataVector>;
+
+ public:
+  using return_tags = tmpl::list<::Tags::Variables<
+      tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>>>;
+  using argument_tags =
+      tmpl::list<evolution::dg::subcell::Tags::DidRollback,
+                 evolution::dg::subcell::Tags::Mesh<Dim>, Tags::MassDensityCons,
+                 Tags::MomentumDensity<Dim>, Tags::EnergyDensity,
+                 hydro::Tags::EquationOfStateBase>;
+
+  template <size_t ThermodynamicDim>
+  static void apply(
+      gsl::not_null<Variables<
+          tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>>*>
+          prim_vars,
+      bool did_rollback, const Mesh<Dim>& subcell_mesh,
+      const Scalar<DataVector>& mass_density_cons,
+      const tnsr::I<DataVector, Dim>& momentum_density,
+      const Scalar<DataVector>& energy_density,
+      const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
+          equation_of_state) noexcept;
+};
+}  // namespace NewtonianEuler::subcell

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBRARY_SOURCES
   FiniteDifference/Test_MonotisedCentral.cpp
   FiniteDifference/Test_Tag.cpp
   Subcell/Test_InitialDataTci.cpp
+  Subcell/Test_PrimsAfterRollback.cpp
   Subcell/Test_ResizeAndComputePrimitives.cpp
   Subcell/Test_TciOnDgGrid.cpp
   Subcell/Test_TciOnFdGrid.cpp

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_PrimsAfterRollback.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_PrimsAfterRollback.cpp
@@ -1,0 +1,108 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <random>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "Evolution/DgSubcell/Projection.hpp"
+#include "Evolution/DgSubcell/Tags/DidRollback.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/Systems/NewtonianEuler/PrimitiveFromConservative.hpp"
+#include "Evolution/Systems/NewtonianEuler/Subcell/PrimsAfterRollback.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+
+namespace {
+template <size_t Dim>
+void test(const gsl::not_null<std::mt19937*> gen,
+          const gsl::not_null<std::uniform_real_distribution<>*> dist,
+          const bool did_rollback) {
+  using MassDensityCons = NewtonianEuler::Tags::MassDensityCons;
+  using EnergyDensity = NewtonianEuler::Tags::EnergyDensity;
+  using MomentumDensity = NewtonianEuler::Tags::MomentumDensity<Dim>;
+
+  using MassDensity = NewtonianEuler::Tags::MassDensity<DataVector>;
+  using Velocity = NewtonianEuler::Tags::Velocity<DataVector, Dim>;
+  using SpecificInternalEnergy =
+      NewtonianEuler::Tags::SpecificInternalEnergy<DataVector>;
+  using Pressure = NewtonianEuler::Tags::Pressure<DataVector>;
+
+  using cons_tags = tmpl::list<MassDensityCons, MomentumDensity, EnergyDensity>;
+  using ConsVars = Variables<cons_tags>;
+  using prim_tags =
+      tmpl::list<MassDensity, Velocity, SpecificInternalEnergy, Pressure>;
+  using PrimVars = Variables<prim_tags>;
+
+  const Mesh<Dim> dg_mesh{5, Spectral::Basis::Legendre,
+                          Spectral::Quadrature::GaussLobatto};
+  const Mesh<Dim> subcell_mesh = evolution::dg::subcell::fd::mesh(dg_mesh);
+
+  auto cons_vars = make_with_random_values<ConsVars>(
+      gen, dist, subcell_mesh.number_of_grid_points());
+  PrimVars expected_prim_vars{};
+
+  std::unique_ptr<EquationsOfState::EquationOfState<false, 1>> eos =
+      std::make_unique<EquationsOfState::PolytropicFluid<false>>(1.4,
+                                                                 5.0 / 3.0);
+
+  auto box = db::create<db::AddSimpleTags<
+      evolution::dg::subcell::Tags::DidRollback, ::Tags::Variables<cons_tags>,
+      ::Tags::Variables<prim_tags>, ::domain::Tags::Mesh<Dim>,
+      evolution::dg::subcell::Tags::Mesh<Dim>,
+      hydro::Tags::EquationOfState<
+          std::unique_ptr<EquationsOfState::EquationOfState<false, 1>>>>>(
+      did_rollback, cons_vars, expected_prim_vars, dg_mesh, subcell_mesh,
+      std::move(eos));
+
+  db::mutate_apply<NewtonianEuler::subcell::PrimsAfterRollback<Dim>>(
+      make_not_null(&box));
+
+  if (did_rollback) {
+    REQUIRE(
+        db::get<::Tags::Variables<prim_tags>>(box).number_of_grid_points() ==
+        cons_vars.number_of_grid_points());
+    expected_prim_vars.initialize(cons_vars.number_of_grid_points());
+    NewtonianEuler::PrimitiveFromConservative<Dim, 1>::apply(
+        make_not_null(&get<MassDensity>(expected_prim_vars)),
+        make_not_null(&get<Velocity>(expected_prim_vars)),
+        make_not_null(&get<SpecificInternalEnergy>(expected_prim_vars)),
+        make_not_null(&get<Pressure>(expected_prim_vars)),
+        get<MassDensityCons>(cons_vars), get<MomentumDensity>(cons_vars),
+        get<EnergyDensity>(cons_vars),
+        db::get<hydro::Tags::EquationOfStateBase>(box));
+    CHECK_VARIABLES_APPROX(db::get<::Tags::Variables<prim_tags>>(box),
+                           expected_prim_vars);
+  } else {
+    CHECK(db::get<::Tags::Variables<prim_tags>>(box).number_of_grid_points() ==
+          0);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.NewtonianEuler.Subcell.PrimsAfterRollback",
+    "[Unit][Evolution]") {
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> dist(0.1, 1.0);
+  for (const bool did_rollback : {true, false}) {
+    test<1>(make_not_null(&gen), make_not_null(&dist), did_rollback);
+    test<2>(make_not_null(&gen), make_not_null(&dist), did_rollback);
+    test<3>(make_not_null(&gen), make_not_null(&dist), did_rollback);
+  }
+}


### PR DESCRIPTION
## Proposed changes

Mutator that computes the primitives on the subcells after a rollback from DG was done.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
