### PR TITLE
Fix Doxygen grouping

### DIFF
--- a/src/ApparentHorizons/ComputeItems.hpp
+++ b/src/ApparentHorizons/ComputeItems.hpp
@@ -29,7 +29,7 @@ class DataVector;
 
 namespace ah {
 namespace Tags {
-// @{
+/// @{
 /// These ComputeItems are different from those used in
 /// GeneralizedHarmonic evolution because these live only on the
 /// intrp::Actions::ApparentHorizon DataBox, not in the volume
@@ -92,6 +92,6 @@ struct SpatialChristoffelSecondKindCompute
                                    gr::Tags::InverseSpatialMetric<Dim, Frame>>;
   using base = ::gr::Tags::SpatialChristoffelSecondKind<Dim, Frame>;
 };
-// }@
+/// @}
 }  // namespace Tags
 }  // namespace ah

--- a/src/ApparentHorizons/StrahlkorperGr.hpp
+++ b/src/ApparentHorizons/StrahlkorperGr.hpp
@@ -26,7 +26,7 @@ struct not_null;
 /// Contains functions that depend both on a Strahlkorper and a metric.
 namespace StrahlkorperGr {
 
-//@{
+/// @{
 /// \ingroup SurfacesGroup
 /// \brief Computes normalized unit normal one-form to a Strahlkorper.
 ///
@@ -45,9 +45,9 @@ template <typename Frame>
 tnsr::i<DataVector, 3, Frame> unit_normal_one_form(
     const tnsr::i<DataVector, 3, Frame>& normal_one_form,
     const DataVector& one_over_one_form_magnitude) noexcept;
-//@}
+/// @}
 
-//@{
+/// @{
 /// \ingroup SurfacesGroup
 /// \brief Computes 3-covariant gradient \f$D_i S_j\f$ of a
 /// Strahlkorper's normal.
@@ -83,9 +83,9 @@ tnsr::ii<DataVector, 3, Frame> grad_unit_normal_one_form(
     const tnsr::ii<DataVector, 3, Frame>& d2x_radius,
     const DataVector& one_over_one_form_magnitude,
     const tnsr::Ijj<DataVector, 3, Frame>& christoffel_2nd_kind) noexcept;
-//@}
+/// @}
 
-//@{
+/// @{
 /// \ingroup SurfacesGroup
 /// \brief Computes inverse 2-metric \f$g^{ij}-S^i S^j\f$ of a Strahlkorper.
 ///
@@ -107,9 +107,9 @@ template <typename Frame>
 tnsr::II<DataVector, 3, Frame> inverse_surface_metric(
     const tnsr::I<DataVector, 3, Frame>& unit_normal_vector,
     const tnsr::II<DataVector, 3, Frame>& upper_spatial_metric) noexcept;
-//@}
+/// @}
 
-//@{
+/// @{
 /// \ingroup SurfacesGroup
 /// \brief Expansion of a `Strahlkorper`. Should be zero on apparent horizons.
 ///
@@ -129,9 +129,9 @@ Scalar<DataVector> expansion(
     const tnsr::ii<DataVector, 3, Frame>& grad_normal,
     const tnsr::II<DataVector, 3, Frame>& inverse_surface_metric,
     const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature) noexcept;
-//@}
+/// @}
 
-//@{
+/// @{
 /*!
  * \ingroup SurfacesGroup
  * \brief Extrinsic curvature of a 2D `Strahlkorper` embedded in a 3D space.
@@ -162,9 +162,9 @@ tnsr::ii<DataVector, 3, Frame> extrinsic_curvature(
     const tnsr::ii<DataVector, 3, Frame>& grad_normal,
     const tnsr::i<DataVector, 3, Frame>& unit_normal_one_form,
     const tnsr::I<DataVector, 3, Frame>& unit_normal_vector) noexcept;
-//@}
+/// @}
 
-//@{
+/// @{
 /// \ingroup SurfacesGroup
 /// \brief Intrinsic Ricci scalar of a 2D `Strahlkorper`.
 ///
@@ -194,9 +194,9 @@ Scalar<DataVector> ricci_scalar(
     const tnsr::I<DataVector, 3, Frame>& unit_normal_vector,
     const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature,
     const tnsr::II<DataVector, 3, Frame>& upper_spatial_metric) noexcept;
-//@}
+/// @}
 
-//@{
+/// @{
 /*!
  * \ingroup SurfacesGroup
  * \brief Area element of a 2D `Strahlkorper`.
@@ -233,9 +233,9 @@ Scalar<DataVector> area_element(
     const tnsr::i<DataVector, 3, Frame>& normal_one_form,
     const Scalar<DataVector>& radius,
     const tnsr::i<DataVector, 3, Frame>& r_hat) noexcept;
-//@}
+/// @}
 
-//@{
+/// @{
 /*!
  * \ingroup SurfacesGroup
  * \brief Euclidean area element of a 2D `Strahlkorper`.
@@ -274,7 +274,7 @@ Scalar<DataVector> euclidean_area_element(
     const tnsr::i<DataVector, 3, Frame>& normal_one_form,
     const Scalar<DataVector>& radius,
     const tnsr::i<DataVector, 3, Frame>& r_hat) noexcept;
-//@}
+/// @}
 
 /*!
  * \ingroup SurfacesGroup
@@ -310,7 +310,7 @@ double euclidean_surface_integral_of_vector(
     const tnsr::i<DataVector, 3, Frame>& normal_one_form,
     const Strahlkorper<Frame>& strahlkorper) noexcept;
 
-//@{
+/// @{
 /*!
  * \ingroup SurfacesGroup
  * \brief Spin function of a 2D `Strahlkorper`.
@@ -360,7 +360,7 @@ Scalar<DataVector> spin_function(
     const tnsr::I<DataVector, 3, Frame>& unit_normal_vector,
     const Scalar<DataVector>& area_element,
     const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature) noexcept;
-//@}
+/// @}
 
 /*!
  * \ingroup SurfacesGroup

--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -41,7 +41,7 @@ struct Strahlkorper : db::SimpleTag {
   using type = ::Strahlkorper<Frame>;
 };
 
-// @{
+/// @{
 /// \f$(\theta,\phi)\f$ on the grid.
 /// Doesn't depend on the shape of the surface.
 template <typename Frame>
@@ -57,9 +57,9 @@ struct ThetaPhiCompute : ThetaPhi<Frame>, db::ComputeTag {
                        const ::Strahlkorper<Frame>& strahlkorper) noexcept;
   using argument_tags = tmpl::list<Strahlkorper<Frame>>;
 };
-// }@
+/// @}
 
-// @{
+/// @{
 /// `Rhat(i)` is \f$\hat{r}^i = x_i/\sqrt{x^2+y^2+z^2}\f$ on the grid.
 /// Doesn't depend on the shape of the surface.
 template <typename Frame>
@@ -75,9 +75,9 @@ struct RhatCompute : Rhat<Frame>, db::ComputeTag {
                        const aliases::ThetaPhi<Frame>& theta_phi) noexcept;
   using argument_tags = tmpl::list<ThetaPhi<Frame>>;
 };
-// }@
+/// @}
 
-// @{
+/// @{
 /// `Jacobian(i,0)` is \f$\frac{1}{r}\partial x^i/\partial\theta\f$,
 /// and `Jacobian(i,1)`
 /// is \f$\frac{1}{r\sin\theta}\partial x^i/\partial\phi\f$.
@@ -96,9 +96,9 @@ struct JacobianCompute : Jacobian<Frame>, db::ComputeTag {
                        const aliases::ThetaPhi<Frame>& theta_phi) noexcept;
   using argument_tags = tmpl::list<ThetaPhi<Frame>>;
 };
-// }@
+/// @}
 
-// @{
+/// @{
 /// `InvJacobian(0,i)` is \f$r\partial\theta/\partial x^i\f$,
 /// and `InvJacobian(1,i)` is \f$r\sin\theta\partial\phi/\partial x^i\f$.
 /// Here \f$r\f$ means \f$\sqrt{x^2+y^2+z^2}\f$.
@@ -116,9 +116,9 @@ struct InvJacobianCompute : InvJacobian<Frame>, db::ComputeTag {
                        const aliases::ThetaPhi<Frame>& theta_phi) noexcept;
   using argument_tags = tmpl::list<ThetaPhi<Frame>>;
 };
-// }@
+/// @}
 
-// @{
+/// @{
 /// `InvHessian(k,i,j)` is \f$\partial (J^{-1}){}^k_j/\partial x^i\f$,
 /// where \f$(J^{-1}){}^k_j\f$ is the inverse Jacobian.
 /// `InvHessian` is not symmetric because the Jacobians are Pfaffian.
@@ -136,9 +136,9 @@ struct InvHessianCompute : InvHessian<Frame>, db::ComputeTag {
                        const aliases::ThetaPhi<Frame>& theta_phi) noexcept;
   using argument_tags = tmpl::list<ThetaPhi<Frame>>;
 };
-// }@
+/// @}
 
-// @{
+/// @{
 /// (Euclidean) distance \f$r_{\rm surf}(\theta,\phi)\f$ from the center to each
 /// point of the surface.
 template <typename Frame>
@@ -154,9 +154,9 @@ struct RadiusCompute : Radius<Frame>, db::ComputeTag {
                        const ::Strahlkorper<Frame>& strahlkorper) noexcept;
   using argument_tags = tmpl::list<Strahlkorper<Frame>>;
 };
-// }@
+/// @}
 
-// @{
+/// @{
 /// `CartesianCoords(i)` is \f$x_{\rm surf}^i\f$,
 /// the vector of \f$(x,y,z)\f$ coordinates of each point
 /// on the surface.
@@ -176,9 +176,9 @@ struct CartesianCoordsCompute : CartesianCoords<Frame>, db::ComputeTag {
   using argument_tags =
       tmpl::list<Strahlkorper<Frame>, Radius<Frame>, Rhat<Frame>>;
 };
-// }@
+/// @}
 
-// @{
+/// @{
 /// `DxRadius(i)` is \f$\partial r_{\rm surf}/\partial x^i\f$.  Here
 /// \f$r_{\rm surf}=r_{\rm surf}(\theta,\phi)\f$ is the function
 /// describing the surface, which is considered a function of
@@ -201,9 +201,9 @@ struct DxRadiusCompute : DxRadius<Frame>, db::ComputeTag {
   using argument_tags =
       tmpl::list<Strahlkorper<Frame>, Radius<Frame>, InvJacobian<Frame>>;
 };
-// }@
+/// @}
 
-// @{
+/// @{
 /// `D2xRadius(i,j)` is
 /// \f$\partial^2 r_{\rm surf}/\partial x^i\partial x^j\f$. Here
 /// \f$r_{\rm surf}=r_{\rm surf}(\theta,\phi)\f$ is the function
@@ -228,9 +228,9 @@ struct D2xRadiusCompute : D2xRadius<Frame>, db::ComputeTag {
   using argument_tags = tmpl::list<Strahlkorper<Frame>, Radius<Frame>,
                                    InvJacobian<Frame>, InvHessian<Frame>>;
 };
-// }@
+/// @}
 
-// @{
+/// @{
 /// \f$\nabla^2 r_{\rm surf}\f$, the flat Laplacian of the surface.
 /// This is \f$\eta^{ij}\partial^2 r_{\rm surf}/\partial x^i\partial x^j\f$,
 /// where \f$r_{\rm surf}=r_{\rm surf}(\theta(x,y,z),\phi(x,y,z))\f$.
@@ -250,9 +250,9 @@ struct LaplacianRadiusCompute : LaplacianRadius<Frame>, db::ComputeTag {
   using argument_tags =
       tmpl::list<Strahlkorper<Frame>, Radius<Frame>, ThetaPhi<Frame>>;
 };
-// }@
+/// @}
 
-// @{
+/// @{
 /// `NormalOneForm(i)` is \f$s_i\f$, the (unnormalized) normal one-form
 /// to the surface, expressed in Cartesian components.
 /// This is computed by \f$x_i/r-\partial r_{\rm surf}/\partial x^i\f$,
@@ -276,7 +276,7 @@ struct NormalOneFormCompute : NormalOneForm<Frame>, db::ComputeTag {
                        const aliases::OneForm<Frame>& r_hat) noexcept;
   using argument_tags = tmpl::list<DxRadius<Frame>, Rhat<Frame>>;
 };
-// }@
+/// @}
 
 /// The OneOverOneFormMagnitude is the reciprocal of the magnitude of the
 /// one-form perpendicular to the horizon
@@ -402,7 +402,7 @@ struct MinRicciScalarCompute : MinRicciScalar, db::ComputeTag {
   using argument_tags = tmpl::list<RicciScalar>;
 };
 
-// @{
+/// @{
 /// `Tangents(i,j)` is \f$\partial x_{\rm surf}^i/\partial q^j\f$,
 /// where \f$x_{\rm surf}^i\f$ are the Cartesian coordinates of the
 /// surface (i.e. `CartesianCoords`) and are considered functions of
@@ -435,9 +435,9 @@ struct TangentsCompute : Tangents<Frame>, db::ComputeTag {
   using argument_tags = tmpl::list<Strahlkorper<Frame>, Radius<Frame>,
                                    Rhat<Frame>, Jacobian<Frame>>;
 };
-// }@
+/// @}
 
-// @{
+/// @{
 /// Computes the Euclidean area element on a Strahlkorper.
 /// Useful for flat space integrals.
 template <typename Frame>
@@ -460,9 +460,9 @@ struct EuclideanAreaElementCompute : EuclideanAreaElement<Frame>,
       StrahlkorperTags::Jacobian<Frame>, StrahlkorperTags::NormalOneForm<Frame>,
       StrahlkorperTags::Radius<Frame>, StrahlkorperTags::Rhat<Frame>>;
 };
-// }@
+/// @}
 
-// @{
+/// @{
 /// Computes the flat-space integral of a scalar over a Strahlkorper.
 template <typename IntegrandTag, typename Frame>
 struct EuclideanSurfaceIntegral : db::SimpleTag {
@@ -488,9 +488,9 @@ struct EuclideanSurfaceIntegralCompute
   using argument_tags = tmpl::list<EuclideanAreaElement<Frame>, IntegrandTag,
                                    StrahlkorperTags::Strahlkorper<Frame>>;
 };
-// }@
+/// @}
 
-// @{
+/// @{
 /// Computes the Euclidean-space integral of a vector over a
 /// Strahlkorper, \f$\oint V^i s_i (s_j s_k \delta^{jk})^{-1/2} d^2 S\f$,
 /// where \f$s_i\f$ is the Strahlkorper surface unit normal and
@@ -525,7 +525,7 @@ struct EuclideanSurfaceIntegralVectorCompute
                                    StrahlkorperTags::NormalOneForm<Frame>,
                                    StrahlkorperTags::Strahlkorper<Frame>>;
 };
-// }@
+/// @}
 
 template <typename Frame>
 using items_tags = tmpl::list<Strahlkorper<Frame>>;
@@ -547,7 +547,7 @@ namespace StrahlkorperGr {
 /// also need a metric.
 namespace Tags {
 
-// @{
+/// @{
 /// Computes the area element on a Strahlkorper. Useful for integrals.
 template <typename Frame>
 struct AreaElement : db::SimpleTag {
@@ -568,9 +568,9 @@ struct AreaElementCompute : AreaElement<Frame>, db::ComputeTag {
       StrahlkorperTags::NormalOneForm<Frame>, StrahlkorperTags::Radius<Frame>,
       StrahlkorperTags::Rhat<Frame>>;
 };
-// }@
+/// @}
 
-// @{
+/// @{
 /// Computes the integral of a scalar over a Strahlkorper.
 template <typename IntegrandTag, typename Frame>
 struct SurfaceIntegral : db::SimpleTag {
@@ -595,7 +595,7 @@ struct SurfaceIntegralCompute : SurfaceIntegral<IntegrandTag, Frame>,
   using argument_tags = tmpl::list<AreaElement<Frame>, IntegrandTag,
                                    StrahlkorperTags::Strahlkorper<Frame>>;
 };
-// }@
+/// @}
 
 /// Tag representing the surface area of a Strahlkorper
 struct Area : db::SimpleTag {

--- a/src/ApparentHorizons/YlmSpherepack.hpp
+++ b/src/ApparentHorizons/YlmSpherepack.hpp
@@ -103,7 +103,7 @@ class YlmSpherepack {
   /// the Ylm expansion.
   YlmSpherepack(size_t l_max, size_t m_max) noexcept;
 
-  ///@{
+  /// @{
   /// Static functions to return the correct sizes of vectors of
   /// collocation points and spectral coefficients for a given l_max
   /// and m_max.  Useful for allocating space without having to create
@@ -122,21 +122,21 @@ class YlmSpherepack {
       const size_t l_max, const size_t m_max) noexcept {
     return 2 * (l_max + 1) * (m_max + 1);
   }
-  ///@}
+  /// @}
 
-  ///@{
+  /// @{
   /// Sizes in physical and spectral space for this instance.
   size_t l_max() const noexcept { return l_max_; }
   size_t m_max() const noexcept { return m_max_; }
   size_t physical_size() const noexcept { return n_theta_ * n_phi_; }
   size_t spectral_size() const noexcept { return spectral_size_; }
-  ///@}
+  /// @}
 
   std::array<size_t, 2> physical_extents() const noexcept {
     return {{n_theta_, n_phi_}};
   }
 
-  ///@{
+  /// @{
   /// Collocation points theta and phi.
   ///
   /// The phi points are uniform in phi, with the first point
@@ -147,9 +147,9 @@ class YlmSpherepack {
   const std::vector<double>& theta_points() const noexcept;
   const std::vector<double>& phi_points() const noexcept;
   std::array<DataVector, 2> theta_phi_points() const noexcept;
-  ///@}
+  /// @}
 
-  ///@{
+  /// @{
   /// Spectral transformations.
   /// To act on a slice of the input and output arrays, specify strides
   /// and offsets.
@@ -169,9 +169,9 @@ class YlmSpherepack {
     spec_to_phys_impl(collocation_values, spectral_coefs, spectral_stride,
                       spectral_offset, physical_stride, physical_offset, false);
   };
-  ///@}
+  /// @}
 
-  ///@{
+  /// @{
   /// Spectral transformations where `collocation_values` and
   /// `spectral_coefs` are assumed to point to 3-dimensional arrays
   /// (I1 x S2 topology), and the transformations are done for all
@@ -190,9 +190,9 @@ class YlmSpherepack {
     spec_to_phys_impl(collocation_values, spectral_coefs, stride, 0, stride, 0,
                       true);
   };
-  ///@}
+  /// @}
 
-  ///@{
+  /// @{
   /// Simpler, less general interfaces to `phys_to_spec` and `spec_to_phys`.
   /// Acts on a slice of the input and returns a unit-stride result.
   DataVector phys_to_spec(const DataVector& collocation_values,
@@ -201,9 +201,9 @@ class YlmSpherepack {
   DataVector spec_to_phys(const DataVector& spectral_coefs,
                           size_t spectral_stride = 1,
                           size_t spectral_offset = 0) const noexcept;
-  ///@}
+  /// @}
 
-  ///@{
+  /// @{
   /// Simpler, less general interfaces to `phys_to_spec_all_offsets`
   /// and `spec_to_phys_all_offsets`.  Result has the same stride as
   /// the input.
@@ -211,7 +211,7 @@ class YlmSpherepack {
                                       size_t stride) const noexcept;
   DataVector spec_to_phys_all_offsets(const DataVector& spectral_coefs,
                                       size_t stride) const noexcept;
-  ///@}
+  /// @}
 
   /// Computes Pfaffian derivative (df/dtheta, csc(theta) df/dphi) at
   /// the collocation values.
@@ -239,7 +239,7 @@ class YlmSpherepack {
                              false);
   }
 
-  ///@{
+  /// @{
   /// Same as `gradient` but pointers are assumed to point to
   /// 3-dimensional arrays (I1 x S2 topology), and the gradient is
   /// done for all 'radial' points at once by internally looping
@@ -254,9 +254,9 @@ class YlmSpherepack {
       size_t stride = 1) const noexcept {
     gradient_from_coefs_impl(df, spectral_coefs, stride, 0, stride, 0, true);
   }
-  ///@}
+  /// @}
 
-  ///@{
+  /// @{
   /// Simpler, less general interfaces to `gradient`.
   /// Acts on a slice of the input and returns a unit-stride result.
   FirstDeriv gradient(const DataVector& collocation_values,
@@ -265,16 +265,16 @@ class YlmSpherepack {
   FirstDeriv gradient_from_coefs(const DataVector& spectral_coefs,
                                  size_t spectral_stride = 1,
                                  size_t spectral_offset = 0) const noexcept;
-  ///@}
+  /// @}
 
-  ///@{
+  /// @{
   /// Simpler, less general interfaces to `gradient_all_offsets`.
   /// Result has the same stride as the input.
   FirstDeriv gradient_all_offsets(const DataVector& collocation_values,
                                   size_t stride = 1) const noexcept;
   FirstDeriv gradient_from_coefs_all_offsets(const DataVector& spectral_coefs,
                                              size_t stride = 1) const noexcept;
-  ///@}
+  /// @}
 
   /// Computes Laplacian in physical space.
   /// To act on a slice of the input and output arrays, specify stride
@@ -297,7 +297,7 @@ class YlmSpherepack {
                                    size_t physical_stride = 1,
                                    size_t physical_offset = 0) const noexcept;
 
-  ///@{
+  /// @{
   /// Simpler, less general interfaces to `scalar_laplacian`.
   /// Acts on a slice of the input and returns a unit-stride result.
   DataVector scalar_laplacian(const DataVector& collocation_values,
@@ -306,7 +306,7 @@ class YlmSpherepack {
   DataVector scalar_laplacian_from_coefs(
       const DataVector& spectral_coefs, size_t spectral_stride = 1,
       size_t spectral_offset = 0) const noexcept;
-  ///@}
+  /// @}
 
   /// Computes Pfaffian first and second derivative in physical space.
   /// The first derivative is \f$df(i) = d_i f\f$, and the

--- a/src/DataStructures/ApplyMatrices.hpp
+++ b/src/DataStructures/ApplyMatrices.hpp
@@ -48,7 +48,7 @@ size_t result_size(const std::array<MatrixType, Dim>& matrices,
 }
 }  // namespace apply_matrices_detail
 
-// @{
+/// @{
 /// \ingroup NumericalAlgorithmsGroup
 /// \brief Multiply by matrices in each dimension
 ///
@@ -139,4 +139,4 @@ ResultType apply_matrices(const std::array<MatrixType, Dim>& matrices,
   apply_matrices(make_not_null(&result), matrices, u, extents);
   return result;
 }
-// @}
+/// @}

--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -49,7 +49,7 @@ template <typename TagsList>
 class DataBox;
 /// \endcond
 
-// @{
+/// @{
 /// \ingroup DataBoxGroup
 /// Equal to `true` if `Tag` can be retrieved from a `DataBox` of type
 /// `DataBoxType`.
@@ -60,7 +60,7 @@ using tag_is_retrievable = tmpl::any<typename DataBoxType::tags_list,
 template <typename Tag, typename DataBoxType>
 constexpr bool tag_is_retrievable_v =
     tag_is_retrievable<Tag, DataBoxType>::value;
-// @}
+/// @}
 
 namespace detail {
 template <typename Tag>
@@ -1089,7 +1089,7 @@ static constexpr auto apply(F&& f, const DataBox<BoxTags>& box,
 }
 }  // namespace detail
 
-// @{
+/// @{
 /*!
  * \ingroup DataBoxGroup
  * \brief Apply the invokable `f` with argument Tags `TagsList` from
@@ -1155,7 +1155,7 @@ SPECTRE_ALWAYS_INLINE constexpr auto apply(const DataBox<BoxTags>& box,
                                            Args&&... args) noexcept {
   return apply(F{}, box, std::forward<Args>(args)...);
 }
-// @}
+/// @}
 
 namespace detail {
 template <typename... ReturnTags, typename... ArgumentTags, typename F,
@@ -1203,7 +1203,7 @@ SPECTRE_ALWAYS_INLINE constexpr decltype(auto) mutate_apply(
 }
 }  // namespace detail
 
-// @{
+/// @{
 /*!
  * \ingroup DataBoxGroup
  * \brief Apply the invokable `f` mutating items `MutateTags` and taking as
@@ -1267,5 +1267,5 @@ SPECTRE_ALWAYS_INLINE constexpr decltype(auto) mutate_apply(
     const gsl::not_null<DataBox<BoxTags>*> box, Args&&... args) noexcept {
   return mutate_apply(F{}, box, std::forward<Args>(args)...);
 }
-// @}
+/// @}
 }  // namespace db

--- a/src/DataStructures/FixedHashMap.hpp
+++ b/src/DataStructures/FixedHashMap.hpp
@@ -127,7 +127,7 @@ class FixedHashMap {
 
   void clear() noexcept;
 
-  // @{
+  /// @{
   /// Inserts the element if it does not exists.
   std::pair<iterator, bool> insert(const value_type& value) noexcept {
     return insert(value_type(value));
@@ -141,8 +141,8 @@ class FixedHashMap {
   std::pair<iterator, bool> emplace(Args&&... args) noexcept {
     return insert(value_type(std::forward<Args>(args)...));
   }
-  // @}
-  // @{
+  /// @}
+  /// @{
   /// Inserts the element if it does not exists, otherwise assigns to it the new
   /// value.
   template <class M>
@@ -154,7 +154,7 @@ class FixedHashMap {
   std::pair<iterator, bool> insert_or_assign(key_type&& key, M&& obj) noexcept {
     return insert_or_assign_impl<true>(std::move(key), std::forward<M>(obj));
   }
-  // @}
+  /// @}
 
   iterator erase(const const_iterator& pos) noexcept;
   size_t erase(const key_type& key) noexcept;

--- a/src/DataStructures/GeneralIndexIterator.hpp
+++ b/src/DataStructures/GeneralIndexIterator.hpp
@@ -47,12 +47,12 @@ class GeneralIndexIterator {
   }
 
   /// Iterate over the coordinates of the current value.
-  //@{
+  /// @{
   iterator_type cbegin() const noexcept { return current_.cbegin(); }
   iterator_type cend() const noexcept { return current_.cend(); }
   iterator_type begin() const noexcept { return cbegin(); }
   iterator_type end() const noexcept { return cend(); }
-  //@}
+  /// @}
 
  private:
   Container ranges_;

--- a/src/DataStructures/IndexIterator.hpp
+++ b/src/DataStructures/IndexIterator.hpp
@@ -27,13 +27,13 @@ class IndexIterator {
   IndexIterator() = delete;
   /// \cond HIDDEN_SYMBOLS
   ~IndexIterator() = default;
-  // @{
+  /// @{
   /// No copy or move semantics
   IndexIterator(const IndexIterator<Dim>&) = delete;
   IndexIterator(IndexIterator<Dim>&&) = delete;
   IndexIterator<Dim>& operator=(const IndexIterator<Dim>&) = delete;
   IndexIterator<Dim>& operator=(IndexIterator<Dim>&&) = delete;
-  // @}
+  /// @}
   /// \endcond
 
   /// Returns false if the end of the Index iteration is reached

--- a/src/DataStructures/LeviCivitaIterator.hpp
+++ b/src/DataStructures/LeviCivitaIterator.hpp
@@ -36,13 +36,13 @@ class LeviCivitaIterator {
 
   /// \cond HIDDEN_SYMBOLS
   ~LeviCivitaIterator() = default;
-  // @{
+  /// @{
   /// No copy or move semantics
   LeviCivitaIterator(const LeviCivitaIterator<Dim>&) = delete;
   LeviCivitaIterator(LeviCivitaIterator<Dim>&&) = delete;
   LeviCivitaIterator<Dim>& operator=(const LeviCivitaIterator<Dim>&) = delete;
   LeviCivitaIterator<Dim>& operator=(LeviCivitaIterator<Dim>&&) = delete;
-  // @}
+  /// @}
   /// \endcond
 
   // Return false if the end of the loop is reached

--- a/src/DataStructures/SliceTensorToVariables.hpp
+++ b/src/DataStructures/SliceTensorToVariables.hpp
@@ -14,7 +14,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
-// @{
+/// @{
 /*!
  * \ingroup DataStructuresGroup
  * \brief Slices volume `Tensor`s into a `Variables`
@@ -64,4 +64,4 @@ Variables<tmpl::list<TagsToSlice...>> data_on_slice(
                                 sliced_dim, fixed_index, tensors...);
   return interface_vars;
 }
-// @}
+/// @}

--- a/src/DataStructures/SliceVariables.hpp
+++ b/src/DataStructures/SliceVariables.hpp
@@ -13,7 +13,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
-// @{
+/// @{
 /*!
  * \ingroup DataStructuresGroup
  * \brief Slices the data within `vars` to a codimension 1 slice. The
@@ -65,7 +65,7 @@ Variables<TagsList> data_on_slice(const Variables<TagsList>& vars,
                 sliced_dim, fixed_index);
   return interface_vars;
 }
-// @}
+/// @}
 
 /*!
  * \ingroup DataStructuresGroup

--- a/src/DataStructures/SpinWeighted.hpp
+++ b/src/DataStructures/SpinWeighted.hpp
@@ -8,7 +8,7 @@
 #include "Utilities/Requires.hpp"
 #include "Utilities/TypeTraits.hpp"
 
-// @{
+/// @{
 /*!
  * \ingroup DataStructuresGroup
  * \brief Make a spin-weighted type `T` with spin-weight `Spin`. Mathematical
@@ -211,7 +211,7 @@ struct SpinWeighted<T, Spin, true> {
  private:
   T data_;
 };
-// @}
+/// @}
 
 template <typename T, int Spin>
 void SpinWeighted<T, Spin, true>::pup(PUP::er& p) noexcept {
@@ -223,7 +223,7 @@ void SpinWeighted<T, Spin, false>::pup(PUP::er& p) noexcept {
   p | data_;
 }
 
-// @{
+/// @{
 /// \ingroup TypeTraitsGroup
 /// \ingroup DataStructuresGroup
 /// This is a `std::true_type` if the provided type is a `SpinWeighted` of any
@@ -233,12 +233,12 @@ struct is_any_spin_weighted : std::false_type {};
 
 template <typename T, int S>
 struct is_any_spin_weighted<SpinWeighted<T, S>> : std::true_type {};
-// @}
+/// @}
 
 template <typename T>
 constexpr bool is_any_spin_weighted_v = is_any_spin_weighted<T>::value;
 
-// @{
+/// @{
 /// \ingroup TypeTraitsGroup
 /// \ingroup DataStructuresGroup
 /// This is a `std::true_type` if the provided type `T` is a `SpinWeighted` of
@@ -249,13 +249,13 @@ struct is_spin_weighted_of : std::false_type {};
 template <typename InternalType, int S>
 struct is_spin_weighted_of<InternalType, SpinWeighted<InternalType, S>>
     : std::true_type {};
-// @}
+/// @}
 
 template <typename InternalType, typename T>
 constexpr bool is_spin_weighted_of_v =
     is_spin_weighted_of<InternalType, T>::value;
 
-// @{
+/// @{
 /// \ingroup TypeTraitsGroup
 /// \ingroup DataStructuresGroup
 /// This is a `std::true_type` if the provided type `T1` is a `SpinWeighted` and
@@ -268,13 +268,13 @@ template <typename T, int Spin1, int Spin2>
 struct is_spin_weighted_of_same_type<SpinWeighted<T, Spin1>,
                                      SpinWeighted<T, Spin2>> : std::true_type {
 };
-// @}
+/// @}
 
 template <typename T1, typename T2>
 constexpr bool is_spin_weighted_of_same_type_v =
     is_spin_weighted_of_same_type<T1, T2>::value;
 
-// {@
+/// @{
 /// \brief Add two spin-weighted quantities if the types are compatible and
 /// spins are the same. Un-weighted quantities are assumed to be spin 0.
 // These overloads are designed to allow SpinWeighted to wrap Blaze expression
@@ -315,9 +315,9 @@ operator+(const get_vector_element_type_t<T>& lhs,
           const SpinWeighted<T, 0>& rhs) noexcept {
   return {lhs + rhs.data()};
 }
-// @}
+/// @}
 
-// @{
+/// @{
 /// \brief Subtract two spin-weighted quantities if the types are compatible and
 /// spins are the same. Un-weighted quantities are assumed to be spin 0.
 // These overloads are designed to allow SpinWeighted to wrap Blaze expression
@@ -358,7 +358,7 @@ operator-(const get_vector_element_type_t<T>& lhs,
           const SpinWeighted<T, 0>& rhs) noexcept {
   return {lhs - rhs.data()};
 }
-// @}
+/// @}
 
 /// Negation operator preserves spin
 template <typename T, int Spin>
@@ -374,7 +374,7 @@ operator+(const SpinWeighted<T, Spin>& operand) noexcept {
   return {+operand.data()};
 }
 
-// @{
+/// @{
 /// \brief Multiply two spin-weighted quantities if the types are compatible and
 /// add the spins. Un-weighted quantities are assumed to be spin 0.
 // These overloads are designed to allow SpinWeighted to wrap Blaze expression
@@ -415,9 +415,9 @@ operator*(const get_vector_element_type_t<T>& lhs,
           const SpinWeighted<T, Spin>& rhs) noexcept {
   return {lhs * rhs.data()};
 }
-// @}
+/// @}
 
-// @{
+/// @{
 /// \brief Divide two spin-weighted quantities if the types are compatible and
 /// subtract the spins. Un-weighted quantities are assumed to be spin 0.
 // These overloads are designed to allow SpinWeighted to wrap Blaze expression
@@ -458,7 +458,7 @@ operator/(const get_vector_element_type_t<T>& lhs,
           const SpinWeighted<T, Spin>& rhs) noexcept {
   return {lhs / rhs.data()};
 }
-// @}
+/// @}
 
 /// conjugate the spin-weighted quantity, inverting the spin
 template <typename T, int Spin>
@@ -483,7 +483,7 @@ SPECTRE_ALWAYS_INLINE SpinWeighted<decltype(sqrt(std::declval<T>())), 0> sqrt(
   return {sqrt(value.data())};
 }
 
-// @{
+/// @{
 /// \brief Test equivalence of spin-weighted quantities if the types are
 /// compatible and spins are the same. Un-weighted quantities are assumed to
 /// be spin 0.
@@ -503,9 +503,9 @@ SPECTRE_ALWAYS_INLINE bool operator==(const T& lhs,
                                       const SpinWeighted<T, 0>& rhs) noexcept {
   return lhs == rhs.data();
 }
-// @}
+/// @}
 
-// @{
+/// @{
 /// \brief Test inequivalence of spin-weighted quantities if the types are
 /// compatible and spins are the same. Un-weighted quantities are assumed to be
 /// spin 0.
@@ -525,7 +525,7 @@ SPECTRE_ALWAYS_INLINE bool operator!=(const T& lhs,
                                       const SpinWeighted<T, 0>& rhs) noexcept {
   return not(lhs == rhs);
 }
-// @}
+/// @}
 
 /// \ingroup DataStructuresGroup
 /// Make the input `view` a `const` view of the const data `spin_weighted`, at

--- a/src/DataStructures/Tags/TempTensor.hpp
+++ b/src/DataStructures/Tags/TempTensor.hpp
@@ -25,7 +25,7 @@ struct TempTensor : db::SimpleTag {
   }
 };
 
-// @{
+/// @{
 /// \ingroup PeoGroup
 /// Variables Tags for temporary tensors inside a function.
 template <size_t N, typename DataType = DataVector>
@@ -124,5 +124,5 @@ using TempabC = TempTensor<N, tnsr::abC<DataType, SpatialDim, Fr>>;
 template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
           typename DataType = DataVector>
 using Tempijaa = TempTensor<N, tnsr::ijaa<DataType, SpatialDim, Fr>>;
-// @}
+/// @}
 }  // namespace Tags

--- a/src/DataStructures/Tensor/EagerMath/Determinant.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Determinant.hpp
@@ -127,7 +127,7 @@ struct DeterminantImpl<Symmetry<1, 1>, Index, Requires<Index::dim == 4>> {
 };
 }  // namespace detail
 
-//@{
+/// @{
 /*!
  * \ingroup TensorGroup
  * \brief Computes the determinant of a rank-2 Tensor `tensor`.
@@ -155,4 +155,4 @@ Scalar<T> determinant(
   determinant(make_not_null(&result), tensor);
   return result;
 }
-//@}
+/// @}

--- a/src/DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp
+++ b/src/DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp
@@ -346,7 +346,7 @@ struct DetAndInverseImpl<Symmetry<1, 1>, Index0, Index0,
 };
 }  // namespace determinant_and_inverse_detail
 
-// @{
+/// @{
 /*!
  * \ingroup TensorGroup
  * \brief Computes the determinant and inverse of a rank-2 Tensor.
@@ -407,9 +407,9 @@ auto determinant_and_inverse(
                                    make_not_null(&result.second), tensor);
   return result;
 }
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \ingroup TensorGroup
  * \brief Computes the determinant and inverse of a rank-2 Tensor.
@@ -467,4 +467,4 @@ auto determinant_and_inverse(
                                    make_not_null(&get<InvTag>(result)), tensor);
   return result;
 }
-// @}
+/// @}

--- a/src/DataStructures/Tensor/EagerMath/DotProduct.hpp
+++ b/src/DataStructures/Tensor/EagerMath/DotProduct.hpp
@@ -12,7 +12,7 @@
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
-// @{
+/// @{
 /*!
  * \ingroup TensorGroup
  * \brief Compute the Euclidean dot product of two vectors or one forms
@@ -40,9 +40,9 @@ Scalar<DataType> dot_product(
   ::dot_product(make_not_null(&dot_product), vector_a, vector_b);
   return dot_product;
 }
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \ingroup TensorGroup
  * \brief Compute the dot product of a vector and a one form
@@ -75,9 +75,9 @@ Scalar<DataType> dot_product(
   ::dot_product(make_not_null(&dot_product), vector_a, vector_b);
   return dot_product;
 }
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \ingroup TensorGroup
  * \brief Compute the dot_product of two vectors or one forms
@@ -119,4 +119,4 @@ Scalar<DataType> dot_product(
   ::dot_product(make_not_null(&dot_product), vector_a, vector_b, metric);
   return dot_product;
 }
-// @}
+/// @}

--- a/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
@@ -14,7 +14,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
-// @{
+/// @{
 /*!
  * \ingroup TensorGroup
  * \brief Compute the Euclidean magnitude of a rank-1 tensor
@@ -37,9 +37,9 @@ void magnitude(
   dot_product(magnitude, vector, vector);
   get(*magnitude) = sqrt(get(*magnitude));
 }
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \ingroup TensorGroup
  * \brief Compute the magnitude of a rank-1 tensor
@@ -69,9 +69,9 @@ void magnitude(
   dot_product(magnitude, vector, vector, metric);
   get(*magnitude) = sqrt(get(*magnitude));
 }
-// @}
+/// @}
 
-// @{
+/// @{
 /// \ingroup TensorGroup
 /// \brief Compute square root of the Euclidean magnitude of a rank-0 tensor
 ///
@@ -88,7 +88,7 @@ void sqrt_magnitude(const gsl::not_null<Scalar<DataType>*> sqrt_magnitude,
   destructive_resize_components(sqrt_magnitude, get_size(get(input)));
   get(*sqrt_magnitude) = sqrt(abs(get(input)));
 }
-// @}
+/// @}
 
 namespace Tags {
 /// \ingroup DataBoxTagsGroup

--- a/src/DataStructures/Tensor/EagerMath/Norms.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Norms.hpp
@@ -31,7 +31,7 @@ Scalar<DataType> pointwise_l2_norm_square(
 }
 }  // namespace L2Norm_detail
 
-// @{
+/// @{
 /*!
  * \ingroup TensorGroup
  * \brief Compute point-wise Euclidean \f$L^2\f$-norm of arbitrary Tensors.
@@ -63,7 +63,7 @@ void pointwise_l2_norm(
   destructive_resize_components(norm, get_size(tensor[0].size()));
   get(*norm) = sqrt(get(L2Norm_detail::pointwise_l2_norm_square(tensor)));
 }
-// @}
+/// @}
 
 /*!
  * \ingroup TensorGroup

--- a/src/DataStructures/Tensor/EagerMath/OrthonormalOneform.hpp
+++ b/src/DataStructures/Tensor/EagerMath/OrthonormalOneform.hpp
@@ -14,7 +14,7 @@ struct not_null;
 }  // namespace gsl
 /// \endcond
 
-// @{
+/// @{
 /*!
  * \ingroup TensorGroup
  *
@@ -40,9 +40,9 @@ template <typename DataType, size_t VolumeDim, typename Frame>
 tnsr::i<DataType, VolumeDim, Frame> orthonormal_oneform(
     const tnsr::i<DataType, VolumeDim, Frame>& unit_form,
     const tnsr::II<DataType, VolumeDim, Frame>& inv_spatial_metric) noexcept;
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \ingroup TensorGroup
  *
@@ -73,4 +73,4 @@ tnsr::i<DataType, 3, Frame> orthonormal_oneform(
     const tnsr::i<DataType, 3, Frame>& second_unit_form,
     const tnsr::ii<DataType, 3, Frame>& spatial_metric,
     const Scalar<DataType>& det_spatial_metric) noexcept;
-// @}
+/// @}

--- a/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
+++ b/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
@@ -138,7 +138,7 @@ SPECTRE_ALWAYS_INLINE auto operator+(
   return TensorExpressions::AddSub<T1, T2, Args1, Args2, 1>(~t1, ~t2);
 }
 
-// @{
+/// @{
 /// \ingroup TensorExpressionsGroup
 /// \brief Returns the tensor expression representing the sum of a tensor
 /// expression and a `double`
@@ -172,7 +172,7 @@ SPECTRE_ALWAYS_INLINE auto operator+(
     const TensorExpression<T, X, tmpl::list<>, tmpl::list<>, tmpl::list<>>& t) {
   return TensorExpressions::NumberAsExpression(number) + t;
 }
-// @}
+/// @}
 
 /*!
  * \ingroup TensorExpressionsGroup
@@ -191,7 +191,7 @@ SPECTRE_ALWAYS_INLINE auto operator-(
   return TensorExpressions::AddSub<T1, T2, Args1, Args2, -1>(~t1, ~t2);
 }
 
-// @{
+/// @{
 /// \ingroup TensorExpressionsGroup
 /// \brief Returns the tensor expression representing the difference of a tensor
 /// expression and a `double`
@@ -225,4 +225,4 @@ SPECTRE_ALWAYS_INLINE auto operator-(
     const TensorExpression<T, X, tmpl::list<>, tmpl::list<>, tmpl::list<>>& t) {
   return TensorExpressions::NumberAsExpression(number) - t;
 }
-// @}
+/// @}

--- a/src/DataStructures/Tensor/Expressions/Product.hpp
+++ b/src/DataStructures/Tensor/Expressions/Product.hpp
@@ -229,7 +229,7 @@ SPECTRE_ALWAYS_INLINE auto operator*(
       TensorExpressions::OuterProduct<T1, T2>(~t1, ~t2));
 }
 
-// @{
+/// @{
 /// \ingroup TensorExpressionsGroup
 /// \brief Returns the tensor expression representing the product of a tensor
 /// expression and a `double`
@@ -258,7 +258,7 @@ SPECTRE_ALWAYS_INLINE auto operator*(
                            ArgsList>& t) {
   return TensorExpressions::NumberAsExpression(number) * t;
 }
-// @}
+/// @}
 
 /// \ingroup TensorExpressionsGroup
 /// \brief Returns the tensor expression representing the quotient of a tensor

--- a/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
@@ -105,7 +105,7 @@ get_tensorindex_value_with_opposite_valence(const size_t i) noexcept {
   }
 }
 
-// @{
+/// @{
 /*!
  * \ingroup TensorExpressionsGroup
  * \brief The available TensorIndex's to use in a TensorExpression
@@ -137,7 +137,7 @@ static constexpr TensorIndex<spatial_sentinel + 2> ti_k{};
 static constexpr TensorIndex<upper_spatial_sentinel + 2> ti_K{};
 static constexpr TensorIndex<spatial_sentinel + 3> ti_l{};
 static constexpr TensorIndex<upper_spatial_sentinel + 3> ti_L{};
-// @}
+/// @}
 
 namespace tt {
 /*!
@@ -158,7 +158,7 @@ struct is_tensor_index<TensorIndex<I>> : std::true_type {};
 /// TensorExpression.
 struct Expression {};
 
-// @{
+/// @{
 /// \ingroup TensorExpressionsGroup
 /// \brief The base class all tensor expression implementations derive from
 ///
@@ -192,7 +192,7 @@ struct TensorExpression<Derived, DataType, Symm, tmpl::list<Indices...>,
 
   virtual ~TensorExpression() = 0;
 
-  // @{
+  /// @{
   /// Derived is casted down to the derived class. This is enabled by the
   /// [CRTP](https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern)
   ///
@@ -201,7 +201,7 @@ struct TensorExpression<Derived, DataType, Symm, tmpl::list<Indices...>,
   SPECTRE_ALWAYS_INLINE const auto& operator~() const noexcept {
       return static_cast<const Derived&>(*this);
   }
-  // @}
+  /// @}
 };
 
 template <typename Derived, typename DataType, typename Symm,
@@ -209,4 +209,4 @@ template <typename Derived, typename DataType, typename Symm,
           typename... Args>
 TensorExpression<Derived, DataType, Symm, tmpl::list<Indices...>,
                  ArgsList<Args...>>::~TensorExpression() = default;
-// @}
+/// @}

--- a/src/DataStructures/Tensor/IndexType.hpp
+++ b/src/DataStructures/Tensor/IndexType.hpp
@@ -201,7 +201,7 @@ using SpacetimeIndex =
     Tensor_detail::TensorIndexType<SpatialDim, Ul, Fr, IndexType::Spacetime>;
 
 namespace tt {
-// @{
+/// @{
 /// \ingroup TensorGroup TypeTraitsGroup
 /// Inherits from std::true_type if T is a \ref SpacetimeIndex
 /// "TensorIndexType"
@@ -217,7 +217,7 @@ struct is_tensor_index_type<
 /// \see is_tensor_index_type
 template <typename T>
 using is_tensor_index_type_t = typename is_tensor_index_type<T>::type;
-// @}
+/// @}
 }  // namespace tt
 
 /// \ingroup TensorGroup

--- a/src/DataStructures/Tensor/Slice.hpp
+++ b/src/DataStructures/Tensor/Slice.hpp
@@ -15,7 +15,7 @@
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
 
-// @{
+/// @{
 /*!
  * \ingroup DataStructuresGroup
  * \brief Slices the data within `volume_tensor` to a codimension 1 slice. The
@@ -96,4 +96,4 @@ std::optional<Tensor<VectorType, Structure...>> data_on_slice(
   }
   return std::nullopt;
 }
-// @}
+/// @}

--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -190,7 +190,7 @@ class Tensor<X, Symm, IndexList<Indices...>> {
   const_reverse_iterator rend() const noexcept { return data_.rend(); }
   const_reverse_iterator crend() const noexcept { return data_.rend(); }
 
-  // @{
+  /// @{
   /// Get data entry using an array representing a tensor index
   ///
   /// \details
@@ -207,8 +207,8 @@ class Tensor<X, Symm, IndexList<Indices...>> {
       const std::array<T, sizeof...(Indices)>& tensor_index) const noexcept {
     return gsl::at(data_, structure::get_storage_index(tensor_index));
   }
-  // @}
-  // @{
+  /// @}
+  /// @{
   /// Get data entry using a list of integers representing a tensor index
   ///
   /// \details
@@ -231,9 +231,9 @@ class Tensor<X, Symm, IndexList<Indices...>> {
         "the tensor");
     return gsl::at(data_, structure::get_storage_index(n...));
   }
-  // @}
+  /// @}
 
-  // @{
+  /// @{
   /// Retrieve the index `N...` by computing the storage index at compile time
   // clang-tidy: redundant declaration (bug in clang-tidy)
   template <int... N, typename... Args>
@@ -244,9 +244,9 @@ class Tensor<X, Symm, IndexList<Indices...>> {
   friend SPECTRE_ALWAYS_INLINE constexpr
       typename Tensor<Args...>::const_reference
       get(const Tensor<Args...>& t) noexcept;  // NOLINT
-  // @}
+                                               /// @}
 
-  // @{
+  /// @{
   /// Retrieve a TensorExpression object with the index structure passed in
   template <typename... TensorIndices>
   SPECTRE_ALWAYS_INLINE constexpr auto operator()(
@@ -271,9 +271,9 @@ class Tensor<X, Symm, IndexList<Indices...>> {
                   "types of the indices in the Tensor.");
     return TensorExpressions::contract(TE<tmpl::list<TensorIndices...>>{*this});
   }
-  // @}
+  /// @}
 
-  // @{
+  /// @{
   /// Return i'th component of storage vector
   constexpr reference operator[](const size_t storage_index) noexcept {
     return gsl::at(data_, storage_index);
@@ -282,7 +282,7 @@ class Tensor<X, Symm, IndexList<Indices...>> {
       noexcept {
     return gsl::at(data_, storage_index);
   }
-  // @}
+  /// @}
 
   /// Return the number of independent components of the Tensor
   ///
@@ -305,7 +305,7 @@ class Tensor<X, Symm, IndexList<Indices...>> {
     return sizeof...(Indices);
   }
 
-  // @{
+  /// @{
   /// Given an iterator or storage index, get the canonical tensor index.
   /// For scalars this is defined to be std::array<int, 1>{{0}}
   SPECTRE_ALWAYS_INLINE constexpr std::array<size_t, sizeof...(Indices)>
@@ -317,9 +317,9 @@ class Tensor<X, Symm, IndexList<Indices...>> {
   get_tensor_index(const size_t storage_index) noexcept {
     return structure::get_canonical_tensor_index(storage_index);
   }
-  // @}
+  /// @}
 
-  // @{
+  /// @{
   /// Get the storage index of the tensor index. Should only be used when
   /// optimizing code in which computing the storage index is a bottleneck.
   template <typename... N>
@@ -332,9 +332,9 @@ class Tensor<X, Symm, IndexList<Indices...>> {
       const std::array<I, sizeof...(Indices)>& tensor_index) noexcept {
     return structure::get_storage_index(tensor_index);
   }
-  // @}
+  /// @}
 
-  // @{
+  /// @{
   /// Given an iterator or storage index, get the multiplicity of an index
   ///
   /// \see TensorMetafunctions::compute_multiplicity
@@ -346,9 +346,9 @@ class Tensor<X, Symm, IndexList<Indices...>> {
       const size_t storage_index) noexcept {
     return structure::multiplicity(storage_index);
   }
-  // @}
+  /// @}
 
-  // @{
+  /// @{
   /// Get dimensionality of i'th tensor index
   ///
   /// \snippet Test_Tensor.cpp index_dim
@@ -360,26 +360,26 @@ class Tensor<X, Symm, IndexList<Indices...>> {
                   "retrieve the dimensionality.");
     return gsl::at(structure::dims(), i);
   }
-  // @}
+  /// @}
 
-  //@{
+  /// @{
   /// Return an array corresponding to the ::Symmetry of the Tensor
   SPECTRE_ALWAYS_INLINE static constexpr std::array<int, sizeof...(Indices)>
   symmetries() noexcept {
     return structure::symmetries();
   }
-  //@}
+  /// @}
 
-  //@{
+  /// @{
   /// Return array of the ::IndexType's (spatial or spacetime)
   SPECTRE_ALWAYS_INLINE static constexpr std::array<IndexType,
                                                     sizeof...(Indices)>
   index_types() noexcept {
     return structure::index_types();
   }
-  //@}
+  /// @}
 
-  //@{
+  /// @{
   /// Return array of dimensionality of each index
   ///
   /// \snippet Test_Tensor.cpp index_dim
@@ -388,24 +388,24 @@ class Tensor<X, Symm, IndexList<Indices...>> {
   index_dims() noexcept {
     return structure::dims();
   }
-  //@}
+  /// @}
 
-  //@{
+  /// @{
   /// Return array of the valence of each index (::UpLo)
   SPECTRE_ALWAYS_INLINE static constexpr std::array<UpLo, sizeof...(Indices)>
   index_valences() noexcept {
     return structure::index_valences();
   }
-  //@}
+  /// @}
 
-  //@{
+  /// @{
   /// Returns std::tuple of the ::Frame of each index
   SPECTRE_ALWAYS_INLINE static constexpr auto index_frames() noexcept {
     return Tensor_detail::Structure<Symm, Indices...>::index_frames();
   }
-  //@}
+  /// @}
 
-  //@{
+  /// @{
   /// \brief Given a tensor index, get the canonical label associated with the
   /// canonical \ref SpacetimeIndex "TensorIndexType"
   ///
@@ -421,9 +421,9 @@ class Tensor<X, Symm, IndexList<Indices...>> {
           make_array<rank()>(std::string(""))) noexcept {
     return structure::component_name(tensor_index, axis_labels);
   }
-  //@}
+  /// @}
 
-  ///@{
+  /// @{
   /// \brief Suffix to append to the tensor name that indicates the component
   ///
   /// The suffix is empty for scalars, otherwise it is an underscore followed by
@@ -451,7 +451,7 @@ class Tensor<X, Symm, IndexList<Indices...>> {
           make_array<rank()>(std::string(""))) noexcept {
     return component_suffix(get_tensor_index(storage_index), axis_labels);
   }
-  ///@}
+  /// @}
 
   /// Copy tensor data into an `std::vector<X>` along with the
   /// component names into a `std::vector<std::string>`

--- a/src/DataStructures/Transpose.hpp
+++ b/src/DataStructures/Transpose.hpp
@@ -37,7 +37,7 @@ void raw_transpose(const gsl::not_null<T*> result, const T* const data,
   }
 }
 
-// @{
+/// @{
 /// \ingroup NumericalAlgorithmsGroup
 /// \brief Function to compute transposed data.
 ///
@@ -98,4 +98,4 @@ T transpose(const U& u, const size_t chunk_size,
   transpose(make_not_null(&t), u, chunk_size, number_of_chunks);
   return t;
 }
-// @}
+/// @}

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -148,7 +148,7 @@ class Variables<tmpl::list<Tags...>> {
   Variables(const Variables& rhs) noexcept;
   Variables& operator=(const Variables& rhs) noexcept;
 
-  // @{
+  /// @{
   /// Copy and move semantics for wrapped variables
   template <typename... WrappedTags,
             Requires<tmpl2::flat_all<std::is_same<
@@ -172,20 +172,20 @@ class Variables<tmpl::list<Tags...>> {
                 db::remove_all_prefixes<Tags>>::value...>::value> = nullptr>
   Variables& operator=(
       const Variables<tmpl::list<WrappedTags...>>& rhs) noexcept;
-  // @}
+  /// @}
 
   /// \cond HIDDEN_SYMBOLS
   ~Variables() noexcept = default;
   /// \endcond
 
-  // @{
+  /// @{
   /// Initialize a Variables to the state it would have after calling
   /// the constructor with the same arguments.
   // this should be updated if we ever use a variables which has a `value_type`
   // larger than ~2 doubles in size.
   void initialize(size_t number_of_grid_points) noexcept;
   void initialize(size_t number_of_grid_points, value_type value) noexcept;
-  // @}
+  /// @}
 
   constexpr SPECTRE_ALWAYS_INLINE size_t
   number_of_grid_points() const noexcept {
@@ -197,11 +197,11 @@ class Variables<tmpl::list<Tags...>> {
     return size_;
   }
 
-  //{@
+  /// @{
   /// Access pointer to underlying data
   pointer data() noexcept { return variable_data_.data(); }
   const_pointer data() const noexcept { return variable_data_.data(); }
-  //@}
+  /// @}
 
   /// \cond HIDDEN_SYMBOLS
   /// Needed because of limitations and inconsistency between compiler
@@ -222,7 +222,7 @@ class Variables<tmpl::list<Tags...>> {
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p) noexcept;  // NOLINT
 
-  // @{
+  /// @{
   /// \brief Assign a subset of the `Tensor`s from another Variables or a
   /// tuples::TaggedTuple
   ///
@@ -245,7 +245,7 @@ class Variables<tmpl::list<Tags...>> {
     EXPAND_PACK_LEFT_TO_RIGHT(
         (get<SubsetOfTags>(*this) = get<SubsetOfTags>(vars)));
   }
-  // @}
+  /// @}
 
   /// Create a Variables from a subset of the `Tensor`s in this
   /// Variables
@@ -389,7 +389,7 @@ class Variables<tmpl::list<Tags...>> {
   }
 
  private:
-  //{@
+  /// @{
   /*!
    * \brief Subscript operator
    *
@@ -408,7 +408,7 @@ class Variables<tmpl::list<Tags...>> {
       const size_type i) const noexcept {
     return variable_data_[i];
   }
-  //@}
+  /// @}
 
   void add_reference_variable_data() noexcept;
 
@@ -646,7 +646,7 @@ void Variables<tmpl::list<Tags...>>::pup(PUP::er& p) noexcept {
 }
 /// \endcond
 
-// {@
+/// @{
 /*!
  * \ingroup DataStructuresGroup
  * \brief Return Tag::type pointing into the contiguous array
@@ -671,7 +671,7 @@ constexpr const typename Tag::type& get(const Variables<TagList>& v) noexcept {
                 "what Tags are available.");
   return tuples::get<Tag>(v.reference_variable_data_);
 }
-// @}
+/// @}
 
 template <typename... Tags>
 template <typename VT, bool VF>

--- a/src/DataStructures/VectorImpl.hpp
+++ b/src/DataStructures/VectorImpl.hpp
@@ -101,7 +101,7 @@ class VectorImpl
   using BaseType::end;
   using BaseType::size;
 
-  // @{
+  /// @{
   /// Upcast to `BaseType`
   /// \attention
   /// upcast should only be used when implementing a derived vector type, not in
@@ -110,7 +110,7 @@ class VectorImpl
     return static_cast<const BaseType&>(*this);
   }
   BaseType& operator*() noexcept { return static_cast<BaseType&>(*this); }
-  // @}
+  /// @}
 
   /// Create with the given size. In debug mode, the vector is initialized to
   /// 'NaN' by default. If not initialized to 'NaN', the memory is allocated but
@@ -182,7 +182,7 @@ class VectorImpl
 
   VectorImpl& operator=(const T& rhs) noexcept;
 
-  // @{
+  /// @{
   /// Set the VectorImpl to be a reference to another VectorImpl object
   void set_data_ref(gsl::not_null<VectorType*> rhs) noexcept {
     set_data_ref(rhs->data(), rhs->size());
@@ -197,7 +197,7 @@ class VectorImpl
     }
     owning_ = false;
   }
-  // @}
+  /// @}
 
   /*!
    * \brief A common operation for checking the size and resizing a memory
@@ -561,7 +561,7 @@ std::ostream& operator<<(std::ostream& os,
   };                                                                         \
   }  // namespace MakeWithValueImpls
 
-// {@
+/// @{
 /*!
  * \ingroup DataStructuresGroup
  * \ingroup TypeTraitsGroup
@@ -607,7 +607,7 @@ template <typename T, size_t S>
 struct get_vector_element_type<std::array<T, S>, false> {
   using type = typename get_vector_element_type<T>::type;
 };
-// @}
+/// @}
 
 template <typename T>
 using get_vector_element_type_t = typename get_vector_element_type<T>::type;

--- a/src/Domain/CoordinateMaps/CoordinateMap.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.hpp
@@ -78,7 +78,7 @@ class CoordinateMapBase : public PUP::able {
   /// Returns `true` if the Jacobian depends on time.
   virtual bool jacobian_is_time_dependent() const noexcept = 0;
 
-  // @{
+  /// @{
   /// Apply the `Maps` to the point(s) `source_point`
   virtual tnsr::I<double, Dim, TargetFrame> operator()(
       tnsr::I<double, Dim, SourceFrame> source_point,
@@ -100,9 +100,9 @@ class CoordinateMapBase : public PUP::able {
       std::string,
       std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
       noexcept = 0;
-  // @}
+  /// @}
 
-  // @{
+  /// @{
   /// Apply the inverse `Maps` to the point(s) `target_point`.
   /// The returned std::optional is invalid if the map is not invertible
   /// at `target_point`, or if `target_point` can be easily determined to not
@@ -122,9 +122,9 @@ class CoordinateMapBase : public PUP::able {
       std::string,
       std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
       noexcept = 0;
-  // @}
+  /// @}
 
-  // @{
+  /// @{
   /// Compute the inverse Jacobian of the `Maps` at the point(s)
   /// `source_point`
   virtual InverseJacobian<double, Dim, SourceFrame, TargetFrame> inv_jacobian(
@@ -148,9 +148,9 @@ class CoordinateMapBase : public PUP::able {
       std::string,
       std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
       noexcept = 0;
-  // @}
+  /// @}
 
-  // @{
+  /// @{
   /// Compute the Jacobian of the `Maps` at the point(s) `source_point`
   virtual Jacobian<double, Dim, SourceFrame, TargetFrame> jacobian(
       tnsr::I<double, Dim, SourceFrame> source_point,
@@ -172,9 +172,9 @@ class CoordinateMapBase : public PUP::able {
       std::string,
       std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
       noexcept = 0;
-  // @}
+  /// @}
 
-  // @{
+  /// @{
   /// Compute the mapped coordinates, frame velocity, Jacobian, and inverse
   /// Jacobian
   virtual std::tuple<tnsr::I<double, Dim, TargetFrame>,
@@ -205,7 +205,7 @@ class CoordinateMapBase : public PUP::able {
       std::string,
       std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{}) const
   noexcept = 0;
-  // @}
+  /// @}
 
  private:
   virtual bool is_equal_to(const CoordinateMapBase& other) const = 0;
@@ -284,7 +284,7 @@ class CoordinateMap
   /// Returns `true` if the Jacobian depends on time.
   bool jacobian_is_time_dependent() const noexcept override;
 
-  // @{
+  /// @{
   /// Apply the `Maps...` to the point(s) `source_point`
   constexpr tnsr::I<double, dim, TargetFrame> operator()(
       tnsr::I<double, dim, SourceFrame> source_point,
@@ -312,9 +312,9 @@ class CoordinateMap
     return call_impl(std::move(source_point), time, functions_of_time,
                      std::make_index_sequence<sizeof...(Maps)>{});
   }
-  // @}
+  /// @}
 
-  // @{
+  /// @{
   /// Apply the inverse `Maps...` to the point(s) `target_point`
   constexpr std::optional<tnsr::I<double, dim, SourceFrame>> inverse(
       tnsr::I<double, dim, TargetFrame> target_point,
@@ -329,9 +329,9 @@ class CoordinateMap
     return inverse_impl(std::move(target_point), time, functions_of_time,
                         std::make_index_sequence<sizeof...(Maps)>{});
   }
-  // @}
+  /// @}
 
-  // @{
+  /// @{
   /// Compute the inverse Jacobian of the `Maps...` at the point(s)
   /// `source_point`
   constexpr InverseJacobian<double, dim, SourceFrame, TargetFrame> inv_jacobian(
@@ -359,9 +359,9 @@ class CoordinateMap
       noexcept override {
     return inv_jacobian_impl(std::move(source_point), time, functions_of_time);
   }
-  // @}
+  /// @}
 
-  // @{
+  /// @{
   /// Compute the Jacobian of the `Maps...` at the point(s) `source_point`
   constexpr Jacobian<double, dim, SourceFrame, TargetFrame> jacobian(
       tnsr::I<double, dim, SourceFrame> source_point,
@@ -387,9 +387,9 @@ class CoordinateMap
       noexcept override {
     return jacobian_impl(std::move(source_point), time, functions_of_time);
   }
-  // @}
+  /// @}
 
-  // @{
+  /// @{
   /// Compute the mapped coordinates, frame velocity, Jacobian, and inverse
   /// Jacobian
   std::tuple<tnsr::I<double, dim, TargetFrame>,
@@ -426,7 +426,7 @@ class CoordinateMap
     return coords_frame_velocity_jacobians_impl(std::move(source_point), time,
                                                 functions_of_time);
   }
-  // @}
+  /// @}
 
   WRAPPED_PUPable_decl_base_template(  // NOLINT
       SINGLE_ARG(CoordinateMapBase<SourceFrame, TargetFrame, dim>),

--- a/src/Domain/CoordinateMaps/CoordinateMapHelpers.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMapHelpers.hpp
@@ -19,7 +19,7 @@
 
 namespace domain {
 namespace CoordinateMap_detail {
-// @{
+/// @{
 /// Call the map passing in the time and FunctionsOfTime if the map is
 /// time-dependent
 template <typename T, size_t Dim, typename Map>
@@ -99,9 +99,9 @@ auto apply_map(
       "The time must not be NaN for time-dependent maps.");
   return the_map(source_points, t, functions_of_time);
 }
-// @}
+/// @}
 
-// @{
+/// @{
 template <typename T, size_t Dim, typename Map>
 auto apply_inverse_map(
     const Map& the_map, const std::array<T, Dim>& target_points,
@@ -142,9 +142,9 @@ auto apply_inverse_map(
       "The time must not be NaN for time-dependent maps.");
   return the_map.inverse(target_points, t, functions_of_time);
 }
-// @}
+/// @}
 
-// @{
+/// @{
 /// Compute the frame velocity
 template <typename T, size_t Dim, typename Map>
 auto apply_frame_velocity(
@@ -179,9 +179,9 @@ auto apply_frame_velocity(
       "The time must not be NaN for time-dependent maps.");
   return the_map.frame_velocity(source_points, t, functions_of_time);
 }
-// @}
+/// @}
 
-// @{
+/// @{
 /// Compute the Jacobian
 template <typename T, size_t Dim, typename Map>
 auto apply_jacobian(
@@ -220,9 +220,9 @@ auto apply_jacobian(
   }
   return identity<Dim>(dereference_wrapper(source_points[0]));
 }
-// @}
+/// @}
 
-// @{
+/// @{
 /// Compute the Jacobian
 template <typename T, size_t Dim, typename Map>
 auto apply_inverse_jacobian(
@@ -261,6 +261,6 @@ auto apply_inverse_jacobian(
   }
   return identity<Dim>(dereference_wrapper(source_points[0]));
 }
-// @}
+/// @}
 }  // namespace CoordinateMap_detail
 }  // namespace domain

--- a/src/Domain/FaceNormal.hpp
+++ b/src/Domain/FaceNormal.hpp
@@ -36,7 +36,7 @@ template <size_t>
 class Mesh;
 /// \endcond
 
-// @{
+/// @{
 /*!
  * \ingroup ComputationalDomainGroup
  * \brief Compute the outward grid normal on a face of an Element
@@ -101,7 +101,7 @@ tnsr::i<DataVector, VolumeDim, Frame::Inertial> unnormalized_face_normal(
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time,
     const Direction<VolumeDim>& direction) noexcept;
-// @}
+/// @}
 
 namespace domain {
 namespace Tags {

--- a/src/Domain/InterfaceHelpers.hpp
+++ b/src/Domain/InterfaceHelpers.hpp
@@ -235,7 +235,7 @@ struct InterfaceApplyImpl<DirectionsTag, tmpl::list<ArgumentTags...>,
 
 }  // namespace InterfaceHelpers_detail
 
-// @{
+/// @{
 /*!
  * \brief Apply an invokable to the `box` on all interfaces given by the
  * `DirectionsTag`.
@@ -296,4 +296,4 @@ SPECTRE_ALWAYS_INLINE constexpr auto interface_apply(
                          get_volume_tags<InterfaceInvokable>>(
       InterfaceInvokable{}, box, std::forward<ExtraArgs>(extra_args)...);
 }
-// @}
+/// @}

--- a/src/Domain/LogicalCoordinates.hpp
+++ b/src/Domain/LogicalCoordinates.hpp
@@ -33,7 +33,7 @@ struct not_null;
 }  // namespace gsl
 /// \endcond
 
-// @{
+/// @{
 /*!
  * \ingroup ComputationalDomainGroup
  * \brief Compute the logical coordinates in an Element.
@@ -53,7 +53,7 @@ void logical_coordinates(
 template <size_t VolumeDim>
 tnsr::I<DataVector, VolumeDim, Frame::Logical> logical_coordinates(
     const Mesh<VolumeDim>& mesh) noexcept;
-// @}
+/// @}
 
 /*!
  * \ingroup ComputationalDomainGroup

--- a/src/Domain/MinimumGridSpacing.hpp
+++ b/src/Domain/MinimumGridSpacing.hpp
@@ -29,7 +29,7 @@ double minimum_grid_spacing(
 
 namespace domain {
 namespace Tags {
-// @{
+/// @{
 /// \ingroup ComputationalDomainGroup
 /// \ingroup DataBoxTagsGroup
 /// The minimum coordinate distance between grid points.
@@ -50,6 +50,6 @@ struct MinimumGridSpacingCompute : MinimumGridSpacing<Dim, Frame>,
   }
   using argument_tags = tmpl::list<Mesh<Dim>, Coordinates<Dim, Frame>>;
 };
-// @}
+/// @}
 }  // namespace Tags
 }  // namespace domain

--- a/src/Domain/SizeOfElement.hpp
+++ b/src/Domain/SizeOfElement.hpp
@@ -35,7 +35,7 @@ struct ElementMap;
 }  // namespace domain
 /// \endcond
 
-// @{
+/// @{
 /*!
  * \ingroup ComputationalDomainGroup
  * \brief Compute the inertial-coordinate size of an element along each of its
@@ -65,7 +65,7 @@ std::array<double, VolumeDim> size_of_element(
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) noexcept;
-// @}
+/// @}
 
 namespace domain {
 namespace Tags {

--- a/src/Domain/Structure/Direction.hpp
+++ b/src/Domain/Structure/Direction.hpp
@@ -55,7 +55,7 @@ class Direction {
   static const std::array<Direction<VolumeDim>, 2 * VolumeDim>&
   all_directions() noexcept;
 
-  // {@
+  /// @{
   /// Helper functions for creating specific Directions.
   /// These are labeled by the logical-coordinate names (Xi,Eta,Zeta).
   // Note: these are functions because they contain static_assert.
@@ -65,7 +65,7 @@ class Direction {
   static Direction<VolumeDim> upper_eta() noexcept;
   static Direction<VolumeDim> lower_zeta() noexcept;
   static Direction<VolumeDim> upper_zeta() noexcept;
-  // @}
+  /// @}
 
   /// Serialization for Charm++
   void pup(PUP::er& p) noexcept;  // NOLINT

--- a/src/Domain/Structure/Hypercube.hpp
+++ b/src/Domain/Structure/Hypercube.hpp
@@ -57,16 +57,16 @@ struct HypercubeElement {
   HypercubeElement(size_t dim_in_parent,
                    std::array<Side, HypercubeDim - 1> index) noexcept;
 
-  // @{
+  /// @{
   /// The parent hypercube's dimensions that this element shares
   const std::array<size_t, ElementDim>& dimensions_in_parent() const noexcept;
 
   template <size_t LocalElementDim = ElementDim,
             Requires<LocalElementDim == 1> = nullptr>
   size_t dimension_in_parent() const noexcept;
-  // @}
+  /// @}
 
-  // @{
+  /// @{
   /// Whether this element is located on the lower or upper side in those
   /// dimensions that it does not share with its parent hypercube
   const std::array<Side, HypercubeDim - ElementDim>& index() const noexcept;
@@ -78,7 +78,7 @@ struct HypercubeElement {
   const Side& side() const noexcept {
     return index_[0];
   }
-  // @}
+  /// @}
 
   bool operator==(const HypercubeElement& rhs) const noexcept {
     return dimensions_in_parent_ == rhs.dimensions_in_parent_ and

--- a/src/Domain/Structure/OrientationMapHelpers.hpp
+++ b/src/Domain/Structure/OrientationMapHelpers.hpp
@@ -47,7 +47,7 @@ std::vector<size_t> oriented_offset_on_slice(
 
 }  // namespace OrientationMapHelpers_detail
 
-// @{
+/// @{
 /// \ingroup ComputationalDomainGroup
 /// Orient variables to the data-storage order of a neighbor element with
 /// the given orientation.
@@ -109,9 +109,9 @@ Variables<TagsList> orient_variables_on_slice(
 
   return oriented_variables;
 }
-// }@
+/// @}
 
-// @{
+/// @{
 /// \ingroup ComputationalDomainGroup
 /// Orient data in a `std::vector<double>` representing one or more tensor
 /// components.
@@ -133,4 +133,4 @@ std::vector<double> orient_variables_on_slice(
     const std::vector<double>& variables_on_slice,
     const Index<VolumeDim - 1>& slice_extents, size_t sliced_dim,
     const OrientationMap<VolumeDim>& orientation_of_neighbor) noexcept;
-// }@
+/// @}

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -262,7 +262,7 @@ struct DetInvJacobianCompute : db::ComputeTag,
 /// Base tag for boundary data needed for updating the variables.
 struct VariablesBoundaryData : db::BaseTag {};
 
-// @{
+/// @{
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup
 /// The set of directions to neighboring Elements
@@ -286,8 +286,9 @@ struct InternalDirectionsCompute : InternalDirections<VolumeDim>,
     }
   }
 };
-// @}
+/// @}
 
+/// @{
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup
 /// The set of directions which correspond to external boundaries.
@@ -312,9 +313,9 @@ struct BoundaryDirectionsInteriorCompute
     *directions = element.external_boundaries();
   }
 };
-// @}
+/// @}
 
-// @{
+/// @{
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup
 /// The set of directions which correspond to external boundaries. To be used
@@ -339,7 +340,7 @@ struct BoundaryDirectionsExteriorCompute
     *directions = element.external_boundaries();
   }
 };
-// @}
+/// @}
 
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup

--- a/src/Elliptic/Actions/InitializeAnalyticSolution.hpp
+++ b/src/Elliptic/Actions/InitializeAnalyticSolution.hpp
@@ -28,7 +28,7 @@ struct Inertial;
 
 namespace elliptic::Actions {
 
-// @{
+/// @{
 /*!
  * \brief Place the analytic solution of the system fields in the DataBox.
  *
@@ -115,5 +115,5 @@ struct InitializeOptionalAnalyticSolution {
     return {std::move(box)};
   }
 };
-// @}
+/// @}
 }  // namespace elliptic::Actions

--- a/src/Elliptic/Systems/Xcts/Equations.hpp
+++ b/src/Elliptic/Systems/Xcts/Equations.hpp
@@ -206,7 +206,7 @@ void add_linearized_distortion_hamiltonian_and_lapse_sources(
  *
  * \see Xcts
  */
-//@{
+/// @{
 template <int ConformalMatterScale>
 void add_curved_momentum_sources(
     gsl::not_null<Scalar<DataVector>*> hamiltonian_constraint,
@@ -238,7 +238,7 @@ void add_flat_cartesian_momentum_sources(
     const tnsr::I<DataVector, 3>& lapse_times_conformal_factor_flux,
     const tnsr::II<DataVector, 3>&
         longitudinal_shift_minus_dt_conformal_metric) noexcept;
-//@}
+/// @}
 
 /// The linearization of `add_curved_momentum_sources`
 template <int ConformalMatterScale>

--- a/src/Elliptic/Utilities/ApplyAt.hpp
+++ b/src/Elliptic/Utilities/ApplyAt.hpp
@@ -82,7 +82,7 @@ SPECTRE_ALWAYS_INLINE decltype(auto) apply_at(
 
 }  // namespace detail
 
-// @{
+/// @{
 /*!
  * \brief Apply the invokable `f` with arguments from maps in the DataBox
  *
@@ -123,7 +123,7 @@ SPECTRE_ALWAYS_INLINE decltype(auto) apply_at(F&& f, const TaggedContainer& box,
       std::forward<F>(f), box, std::forward_as_tuple(map_key), ArgumentTags{},
       PassthroughArgumentTags{}, std::forward<Args>(args)...);
 }
-// @}
+/// @}
 
 namespace detail {
 
@@ -163,7 +163,7 @@ SPECTRE_ALWAYS_INLINE void mutate_apply_at(
 
 }  // namespace detail
 
-// @{
+/// @{
 /*!
  * \brief Apply the invokable `f` to mutate items in maps in the DataBox
  *
@@ -204,6 +204,6 @@ SPECTRE_ALWAYS_INLINE void mutate_apply_at(
       std::forward<F>(f), box, std::forward_as_tuple(map_key), MutateTags{},
       ArgumentTags{}, PassthroughTags{}, std::forward<Args>(args)...);
 }
-// @}
+/// @}
 
 }  // namespace elliptic::util

--- a/src/Evolution/ComputeTags.hpp
+++ b/src/Evolution/ComputeTags.hpp
@@ -39,7 +39,7 @@ struct AnalyticCompute : ::Tags::AnalyticSolutions<AnalyticFieldsTagList>,
   }
 };
 
-// @{
+/// @{
 /*!
  * \brief For each `Tag` in `TagsList`, compute its difference from the
  * analytic solution.
@@ -79,6 +79,6 @@ struct ErrorsCompute
     *errors -= analytic;
   }
 };
-// @}
+/// @}
 }  // namespace Tags
 }  // namespace evolution

--- a/src/Evolution/DgSubcell/CartesianFluxDivergence.hpp
+++ b/src/Evolution/DgSubcell/CartesianFluxDivergence.hpp
@@ -11,7 +11,7 @@
 #include "Utilities/Gsl.hpp"
 
 namespace evolution::dg::subcell {
-// @{
+/// @{
 /*!
  * \brief Compute and add the 2nd-order flux divergence on a Cartesian mesh to
  * the cell-centered time derivatives.
@@ -85,5 +85,5 @@ void add_cartesian_flux_divergence(const gsl::not_null<DataVector*> dt_var,
     }
   }
 }
-// @}
+/// @}
 }  // namespace evolution::dg::subcell

--- a/src/Evolution/DgSubcell/Projection.hpp
+++ b/src/Evolution/DgSubcell/Projection.hpp
@@ -26,7 +26,7 @@ void project_impl(gsl::span<double> subcell_u, gsl::span<const double> dg_u,
                   const Index<Dim>& subcell_extents) noexcept;
 }  // namespace detail
 
-// @{
+/// @{
 /*!
  * \ingroup DgSubcellGroup
  * \brief Project the variable `dg_u` onto the subcell grid with extents
@@ -74,5 +74,5 @@ Variables<TagList> project(const Variables<TagList>& dg_u,
   project(make_not_null(&subcell_u), dg_u, dg_mesh, subcell_extents);
   return subcell_u;
 }
-// @}
+/// @}
 }  // namespace evolution::dg::subcell::fd

--- a/src/Evolution/DgSubcell/Reconstruction.hpp
+++ b/src/Evolution/DgSubcell/Reconstruction.hpp
@@ -25,7 +25,7 @@ void reconstruct_impl(gsl::span<double> dg_u,
                       const Index<Dim>& subcell_extents) noexcept;
 }  // namespace detail
 
-// @{
+/// @{
 /*!
  * \ingroup DgSubcellGroup
  * \brief reconstruct the variable `subcell_u_times_projected_det_jac` onto the
@@ -81,5 +81,5 @@ Variables<TagList> reconstruct(const Variables<TagList>& subcell_u,
   reconstruct(make_not_null(&dg_u), subcell_u, dg_mesh, subcell_extents);
   return dg_u;
 }
-// @}
+/// @}
 }  // namespace evolution::dg::subcell::fd

--- a/src/Evolution/DgSubcell/TciStatus.hpp
+++ b/src/Evolution/DgSubcell/TciStatus.hpp
@@ -20,7 +20,7 @@ class not_null;
 /// \endcond
 
 namespace evolution::dg::subcell {
-// @{
+/// @{
 /// Set `status` to `1` if the cell is marked as needing subcell, otherwise set
 /// `status` to `0`. `status` has grid points on the currently active mesh.
 ///
@@ -46,5 +46,5 @@ Scalar<DataVector> tci_status(
     const Mesh<Dim>& dg_mesh, const Mesh<Dim>& subcell_mesh,
     subcell::ActiveGrid active_grid,
     const std::deque<subcell::ActiveGrid>& tci_history) noexcept;
-// @}
+/// @}
 }  // namespace evolution::dg::subcell

--- a/src/Evolution/DiscontinuousGalerkin/MortarData.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/MortarData.hpp
@@ -66,14 +66,14 @@ class MortarData {
    * neighboring elements have no a priori knowledge about what well be
    * received.
    */
-  //@{
+  /// @{
   void insert_local_mortar_data(TimeStepId time_step_id,
                                 Mesh<Dim - 1> local_interface_mesh,
                                 std::vector<double> local_mortar_vars) noexcept;
   void insert_neighbor_mortar_data(
       TimeStepId time_step_id, Mesh<Dim - 1> neighbor_interface_mesh,
       std::vector<double> neighbor_mortar_vars) noexcept;
-  //@}
+  /// @}
 
   /*!
    * \brief Insert the magnitude of the local face normal, the determinant

--- a/src/Evolution/Systems/Cce/IntegrandInputSteps.hpp
+++ b/src/Evolution/Systems/Cce/IntegrandInputSteps.hpp
@@ -195,7 +195,7 @@ using pre_computation_tags =
                Tags::EthEthbarRDividedByR, Tags::BondiK, Tags::OneMinusY,
                Tags::BondiR>;
 
-// @{
+/// @{
 /*!
  * \brief A typelist for the set of tags computed by the set of
  * template specializations of `ComputePreSwshDerivatives`.
@@ -221,9 +221,9 @@ struct pre_swsh_derivative_tags_to_compute_for {
 template <typename Tag>
 using pre_swsh_derivative_tags_to_compute_for_t =
     typename pre_swsh_derivative_tags_to_compute_for<Tag>::type;
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \brief A typelist for the set of tags computed by single spin-weighted
  * differentiation using utilities from the `Swsh` namespace.
@@ -236,9 +236,9 @@ struct single_swsh_derivative_tags_to_compute_for {
 template <typename Tag>
 using single_swsh_derivative_tags_to_compute_for_t =
     typename single_swsh_derivative_tags_to_compute_for<Tag>::type;
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \brief A typelist for the set of tags computed by multiple spin-weighted
  * differentiation using utilities from the `Swsh` namespace.
@@ -252,7 +252,7 @@ struct second_swsh_derivative_tags_to_compute_for {
 template <typename Tag>
 using second_swsh_derivative_tags_to_compute_for_t =
     typename second_swsh_derivative_tags_to_compute_for<Tag>::type;
-// @}
+/// @}
 
 /// Typelist of steps for `SwshDerivatives` mutations called on volume
 /// quantities needed for scri+ computations

--- a/src/Evolution/Systems/Cce/LinearSolve.hpp
+++ b/src/Evolution/Systems/Cce/LinearSolve.hpp
@@ -64,7 +64,7 @@ void transpose_to_reals_then_imags_radial_stripes(
     size_t number_of_radial_points, size_t number_of_angular_points) noexcept;
 }  // namespace detail
 
-// @{
+/// @{
 /*!
  * \brief Computational structs for evaluating the hypersurface integrals during
  * CCE evolution. These are compatible with use in `db::mutate_apply`.
@@ -193,5 +193,5 @@ struct RadialIntegrateBondi<BoundaryPrefix, Tags::BondiH> {
       const Scalar<SpinWeighted<ComplexDataVector, 0>>& one_minus_y,
       size_t l_max, size_t number_of_radial_points) noexcept;
 };
-// @}
+/// @}
 }  // namespace Cce

--- a/src/Evolution/Systems/CurvedScalarWave/Characteristics.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Characteristics.hpp
@@ -16,7 +16,7 @@
 #include "Utilities/TMPL.hpp"
 
 namespace CurvedScalarWave {
-// @{
+/// @{
 /*!
  * \brief Compute the characteristic speeds for the scalar wave system in curved
  * spacetime.
@@ -79,9 +79,9 @@ struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds<SpatialDim>,
                                       unit_normal_one_form);
   }
 };
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \brief Computes characteristic fields from evolved fields
  *
@@ -177,9 +177,9 @@ struct CharacteristicFieldsCompute : Tags::CharacteristicFields<SpatialDim>,
                                       psi, pi, phi, unit_normal_one_form);
   }
 };
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \brief For expressions used here to compute evolved fields from
  * characteristic ones, see \ref CharacteristicFieldsCompute.
@@ -225,7 +225,7 @@ struct EvolvedFieldsFromCharacteristicFieldsCompute
         result, gamma_2, v_psi, v_zero, v_plus, v_minus, unit_normal_one_form);
   }
 };
-// @}
+/// @}
 
 namespace Tags {
 /*!

--- a/src/Evolution/Systems/CurvedScalarWave/Constraints.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Constraints.hpp
@@ -17,7 +17,7 @@
 #include "Utilities/TMPL.hpp"
 
 namespace CurvedScalarWave {
-// @{
+/// @{
 /*!
  * \brief Computes the scalar-wave one-index constraint.
  *
@@ -35,9 +35,9 @@ void one_index_constraint(
     gsl::not_null<tnsr::i<DataVector, SpatialDim, Frame::Inertial>*> constraint,
     const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& d_psi,
     const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi) noexcept;
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \brief Computes the scalar-wave 2-index constraint.
  *
@@ -59,7 +59,7 @@ void two_index_constraint(
     gsl::not_null<tnsr::ij<DataVector, SpatialDim, Frame::Inertial>*>
         constraint,
     const tnsr::ij<DataVector, SpatialDim, Frame::Inertial>& d_phi) noexcept;
-// @}
+/// @}
 
 namespace Tags {
 /*!

--- a/src/Evolution/Systems/CurvedScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Tags.hpp
@@ -65,7 +65,7 @@ struct TwoIndexConstraint : db::SimpleTag {
   using type = tnsr::ij<DataVector, SpatialDim, Frame::Inertial>;
 };
 
-// @{
+/// @{
 /// \brief Tags corresponding to the characteristic fields of the
 /// scalar-wave system in curved spacetime.
 ///
@@ -84,7 +84,7 @@ struct VPlus : db::SimpleTag {
 struct VMinus : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
-// @}
+/// @}
 
 template <size_t Dim>
 struct CharacteristicSpeeds : db::SimpleTag {

--- a/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
@@ -28,7 +28,7 @@ struct Normalized;
 // IWYU pragma: no_forward_declare Tensor
 
 namespace GeneralizedHarmonic {
-// @{
+/// @{
 /*!
  * \brief Compute the characteristic speeds for the generalized harmonic system.
  *
@@ -90,9 +90,9 @@ struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds<Dim, Frame>,
     characteristic_speeds(result, gamma_1, lapse, shift, unit_normal_one_form);
   };
 };
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \brief Computes characteristic fields from evolved fields
  *
@@ -178,9 +178,9 @@ struct CharacteristicFieldsCompute : Tags::CharacteristicFields<Dim, Frame>,
       const tnsr::iaa<DataVector, Dim, Frame>&,
       const tnsr::i<DataVector, Dim, Frame>&) noexcept>(&characteristic_fields);
 };
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \brief For expressions used here to compute evolved fields from
  * characteristic ones, see \ref CharacteristicFieldsCompute.
@@ -228,7 +228,7 @@ struct EvolvedFieldsFromCharacteristicFieldsCompute
       const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept>(
       &evolved_fields_from_characteristic_fields);
 };
-// @}
+/// @}
 
 namespace Tags{
 struct LargestCharacteristicSpeed : db::SimpleTag {

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/DampingFunction.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/DampingFunction.hpp
@@ -60,7 +60,7 @@ class DampingFunction : public PUP::able {
 
   explicit DampingFunction(CkMigrateMessage* msg) noexcept : PUP::able(msg) {}
 
-  //@{
+  /// @{
   /// Returns the value of the function at the coordinate 'x'.
   virtual void operator()(
       const gsl::not_null<Scalar<double>*> value_at_x,
@@ -76,7 +76,7 @@ class DampingFunction : public PUP::able {
           std::string,
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
           functions_of_time) const noexcept = 0;
-  //@}
+  /// @}
 
   virtual auto get_clone() const noexcept
       -> std::unique_ptr<DampingFunction<VolumeDim, Fr>> = 0;

--- a/src/Evolution/Systems/GeneralizedHarmonic/Constraints.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Constraints.hpp
@@ -26,7 +26,7 @@ class not_null;
 /// \endcond
 
 namespace GeneralizedHarmonic {
-// @{
+/// @{
 /*!
  * \brief Computes the generalized-harmonic 3-index constraint.
  *
@@ -44,9 +44,9 @@ void three_index_constraint(
     gsl::not_null<tnsr::iaa<DataType, SpatialDim, Frame>*> constraint,
     const tnsr::iaa<DataType, SpatialDim, Frame>& d_spacetime_metric,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \brief Computes the generalized-harmonic gauge constraint.
  *
@@ -84,9 +84,9 @@ void gauge_constraint(
     const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
     const tnsr::aa<DataType, SpatialDim, Frame>& pi,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \brief Computes the generalized-harmonic 2-index constraint.
  *
@@ -151,9 +151,9 @@ void two_index_constraint(
     const Scalar<DataType>& gamma2,
     const tnsr::iaa<DataType, SpatialDim, Frame>&
         three_index_constraint) noexcept;
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \brief Computes the generalized-harmonic 4-index constraint.
  *
@@ -187,9 +187,9 @@ template <size_t SpatialDim, typename Frame, typename DataType>
 void four_index_constraint(
     gsl::not_null<tnsr::iaa<DataType, SpatialDim, Frame>*> constraint,
     const tnsr::ijaa<DataType, SpatialDim, Frame>& d_phi) noexcept;
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \brief Computes the generalized-harmonic F constraint.
  *
@@ -275,9 +275,9 @@ void f_constraint(
     const Scalar<DataType>& gamma2,
     const tnsr::iaa<DataType, SpatialDim, Frame>&
         three_index_constraint) noexcept;
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \brief Computes the generalized-harmonic (unnormalized) constraint energy.
  *
@@ -492,7 +492,7 @@ void constraint_energy(
     double two_index_constraint_multiplier = 1.0,
     double three_index_constraint_multiplier = 1.0,
     double four_index_constraint_multiplier = 1.0) noexcept;
-// @}
+/// @}
 
 namespace Tags {
 /*!

--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -98,7 +98,7 @@ struct SpacetimeDerivInitialGaugeH : db::SimpleTag {
   using type = tnsr::ab<DataVector, Dim, Frame>;
 };
 
-// @{
+/// @{
 /// \brief Tags corresponding to the characteristic fields of the generalized
 /// harmonic system.
 ///
@@ -120,7 +120,7 @@ template <size_t Dim, typename Frame>
 struct VMinus : db::SimpleTag {
   using type = tnsr::aa<DataVector, Dim, Frame>;
 };
-// @}
+/// @}
 
 template <size_t Dim, typename Frame>
 struct CharacteristicSpeeds : db::SimpleTag {

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.hpp
@@ -34,7 +34,7 @@ struct Normalized;
 namespace grmhd {
 namespace ValenciaDivClean {
 
-// @{
+/// @{
 /*!
  * \brief Compute the characteristic speeds for the Valencia formulation of
  * GRMHD with divergence cleaning.
@@ -120,7 +120,7 @@ void characteristic_speeds(
     const tnsr::i<DataVector, 3>& unit_normal,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
         equation_of_state) noexcept;
-// @}
+/// @}
 
 namespace Tags {
 /// \brief Compute the characteristic speeds for the Valencia formulation of

--- a/src/Evolution/Systems/NewtonianEuler/Characteristics.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Characteristics.hpp
@@ -32,7 +32,7 @@ class DataVector;
 
 namespace NewtonianEuler {
 
-// @{
+/// @{
 /*!
  * \brief Compute the characteristic speeds of NewtonianEuler system
  *
@@ -61,9 +61,9 @@ std::array<DataVector, Dim + 2> characteristic_speeds(
     const tnsr::I<DataVector, Dim>& velocity,
     const Scalar<DataVector>& sound_speed,
     const tnsr::i<DataVector, Dim>& normal) noexcept;
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \brief Compute the transform matrices between the conserved variables and
  * the characteristic variables of the NewtonianEuler system.
@@ -112,7 +112,7 @@ Matrix left_eigenvectors(const tnsr::I<double, Dim>& velocity,
                          const Scalar<double>& specific_enthalpy,
                          const Scalar<double>& kappa_over_density,
                          const tnsr::i<double, Dim>& unit_normal) noexcept;
-// @}
+/// @}
 
 namespace Tags {
 

--- a/src/Evolution/Systems/NewtonianEuler/InternalEnergyDensity.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/InternalEnergyDensity.hpp
@@ -14,7 +14,7 @@
 #include "Utilities/TMPL.hpp"
 
 namespace NewtonianEuler {
-//@{
+/// @{
 /*!
  * Compute the internal energy density, \f$\rho \epsilon\f$,
  * where \f$\rho\f$ is the mass density, and \f$\epsilon\f$ is the
@@ -30,7 +30,7 @@ template <typename DataType>
 Scalar<DataType> internal_energy_density(
     const Scalar<DataType>& mass_density,
     const Scalar<DataType>& specific_internal_energy) noexcept;
-//@}
+/// @}
 
 namespace Tags {
 /// Compute item for the internal energy density, \f$\rho \epsilon\f$.

--- a/src/Evolution/Systems/NewtonianEuler/KineticEnergyDensity.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/KineticEnergyDensity.hpp
@@ -14,7 +14,7 @@
 #include "Utilities/TMPL.hpp"
 
 namespace NewtonianEuler {
-//@{
+/// @{
 /*!
  * Compute the kinetic energy density, \f$\rho v^2/2\f$,
  * where \f$\rho\f$ is the mass density, and \f$v\f$ is the
@@ -30,7 +30,7 @@ template <typename DataType, size_t Dim, typename Fr>
 Scalar<DataType> kinetic_energy_density(
     const Scalar<DataType>& mass_density,
     const tnsr::I<DataType, Dim, Fr>& velocity) noexcept;
-//@}
+/// @}
 
 namespace Tags {
 /// Compute item for the kinetic energy density, \f$\rho v^2/2\f$.

--- a/src/Evolution/Systems/NewtonianEuler/Limiters/CharacteristicHelpers.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Limiters/CharacteristicHelpers.hpp
@@ -40,7 +40,7 @@ std::pair<Matrix, Matrix> right_and_left_eigenvectors(
         equation_of_state,
     const tnsr::i<double, VolumeDim>& unit_normal) noexcept;
 
-// @{
+/// @{
 /// \brief Compute characteristic fields from conserved fields
 ///
 /// Note that these functions apply the same transformation to every grid point
@@ -85,7 +85,7 @@ void characteristic_fields(
                                NewtonianEuler::Tags::MomentumDensity<VolumeDim>,
                                NewtonianEuler::Tags::EnergyDensity>>& cons_vars,
     const Matrix& left) noexcept;
-// @}
+/// @}
 
 /// \brief Compute conserved fields from characteristic fields
 ///

--- a/src/Evolution/Systems/NewtonianEuler/MachNumber.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/MachNumber.hpp
@@ -13,7 +13,7 @@
 #include "Utilities/TMPL.hpp"
 
 namespace NewtonianEuler {
-//@{
+/// @{
 /*!
  * Compute the local Mach number, \f$\text{Ma} = v/c_s\f$,
  * where \f$v\f$ is the magnitude of the velocity, and
@@ -27,7 +27,7 @@ void mach_number(gsl::not_null<Scalar<DataType>*> result,
 template <typename DataType, size_t Dim, typename Fr>
 Scalar<DataType> mach_number(const tnsr::I<DataType, Dim, Fr>& velocity,
                              const Scalar<DataType>& sound_speed) noexcept;
-//@}
+/// @}
 
 namespace Tags {
 /// Compute item for the local Mach number, \f$\text{Ma}\f$.

--- a/src/Evolution/Systems/NewtonianEuler/RamPressure.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/RamPressure.hpp
@@ -14,7 +14,7 @@
 #include "Utilities/TMPL.hpp"
 
 namespace NewtonianEuler {
-//@{
+/// @{
 /*!
  * Compute the ram pressure, \f$\rho v^i v^j\f$, where \f$\rho\f$ is the
  * mass density, and \f$v^i\f$ is the velocity.
@@ -28,7 +28,7 @@ template <typename DataType, size_t Dim, typename Fr>
 tnsr::II<DataType, Dim, Fr> ram_pressure(
     const Scalar<DataType>& mass_density,
     const tnsr::I<DataType, Dim, Fr>& velocity) noexcept;
-//@}
+/// @}
 
 namespace Tags {
 /// Compute item for the ram pressure, \f$\rho v^i v^j\f$.

--- a/src/Evolution/Systems/NewtonianEuler/SoundSpeedSquared.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/SoundSpeedSquared.hpp
@@ -14,7 +14,7 @@
 #include "Utilities/TMPL.hpp"
 
 namespace NewtonianEuler {
-//@{
+/// @{
 /*!
  * Compute the Newtonian sound speed squared
  * \f$c_s^2 = \chi + p\kappa / \rho^2\f$, where
@@ -37,7 +37,7 @@ Scalar<DataType> sound_speed_squared(
     const Scalar<DataType>& specific_internal_energy,
     const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
         equation_of_state) noexcept;
-//@}
+/// @}
 
 namespace Tags {
 /// Compute item for the sound speed \f$c_s\f$.

--- a/src/Evolution/Systems/NewtonianEuler/SpecificKineticEnergy.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/SpecificKineticEnergy.hpp
@@ -14,7 +14,7 @@
 #include "Utilities/TMPL.hpp"
 
 namespace NewtonianEuler {
-//@{
+/// @{
 /*!
  * Compute the specific kinetic energy, \f$v^2/2\f$,
  * where \f$v\f$ is the magnitude of the velocity.
@@ -27,7 +27,7 @@ void specific_kinetic_energy(
 template <typename DataType, size_t Dim, typename Fr>
 Scalar<DataType> specific_kinetic_energy(
     const tnsr::I<DataType, Dim, Fr>& velocity) noexcept;
-//@}
+/// @}
 
 namespace Tags {
 /// Compute item for the specific kinetic energy, \f$v^2/2\f$.

--- a/src/Evolution/Systems/NewtonianEuler/Tags.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Tags.hpp
@@ -85,7 +85,7 @@ struct CharacteristicSpeeds : db::SimpleTag {
   using type = std::array<DataVector, Dim + 2>;
 };
 
-// @{
+/// @{
 /// The characteristic fields of the NewtonianEuler system.
 struct VMinus : db::SimpleTag {
   using type = Scalar<DataVector>;
@@ -97,7 +97,7 @@ struct VMomentum : db::SimpleTag {
 struct VPlus : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
-// @}
+/// @}
 
 /// The internal energy density.
 template <typename DataType>

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/Characteristics.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/Characteristics.hpp
@@ -29,7 +29,7 @@ struct Normalized;
 namespace RelativisticEuler {
 namespace Valencia {
 
-// @{
+/// @{
 /*!
  * \brief Compute the characteristic speeds for the Valencia formulation
  * of the relativistic Euler system.
@@ -73,7 +73,7 @@ std::array<DataVector, Dim + 2> characteristic_speeds(
     const Scalar<DataVector>& spatial_velocity_squared,
     const Scalar<DataVector>& sound_speed_squared,
     const tnsr::i<DataVector, Dim>& normal) noexcept;
-// @}
+/// @}
 
 /*!
  * \brief Right eigenvectors of the Valencia formulation

--- a/src/Evolution/Systems/ScalarWave/Characteristics.hpp
+++ b/src/Evolution/Systems/ScalarWave/Characteristics.hpp
@@ -26,7 +26,7 @@ struct Normalized;
 /// \endcond
 
 namespace ScalarWave {
-// @{
+/// @{
 /*!
  * \brief Compute the characteristic speeds for the scalar wave system.
  *
@@ -78,9 +78,9 @@ struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds<Dim>,
   }
 };
 }  // namespace Tags
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \brief Computes characteristic fields from evolved fields
  *
@@ -169,9 +169,9 @@ struct CharacteristicFieldsCompute : Tags::CharacteristicFields<Dim>,
   };
 };
 }  // namespace Tags
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \brief Compute evolved fields from characteristic fields.
  *
@@ -238,5 +238,5 @@ struct ComputeLargestCharacteristicSpeed : LargestCharacteristicSpeed,
   }
 };
 }  // namespace Tags
-// @}
+/// @}
 }  // namespace ScalarWave

--- a/src/Evolution/Systems/ScalarWave/Constraints.hpp
+++ b/src/Evolution/Systems/ScalarWave/Constraints.hpp
@@ -18,7 +18,7 @@ class not_null;
 /// \endcond
 
 namespace ScalarWave {
-// @{
+/// @{
 /*!
  * \brief Compute the scalar-wave one-index constraint.
  *
@@ -36,9 +36,9 @@ void one_index_constraint(
     gsl::not_null<tnsr::i<DataVector, SpatialDim, Frame::Inertial>*> constraint,
     const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& d_psi,
     const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi) noexcept;
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \brief Compute the scalar-wave 2-index constraint.
  *
@@ -58,7 +58,7 @@ void two_index_constraint(
     gsl::not_null<tnsr::ij<DataVector, SpatialDim, Frame::Inertial>*>
         constraint,
     const tnsr::ij<DataVector, SpatialDim, Frame::Inertial>& d_phi) noexcept;
-// @}
+/// @}
 
 namespace Tags {
 /*!

--- a/src/Evolution/Systems/ScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/ScalarWave/Tags.hpp
@@ -60,7 +60,7 @@ struct TwoIndexConstraint : db::SimpleTag {
   using type = tnsr::ij<DataVector, Dim, Frame::Inertial>;
 };
 
-// @{
+/// @{
 /// \brief Tags corresponding to the characteristic fields of the flat-spacetime
 /// scalar-wave system.
 ///
@@ -83,7 +83,7 @@ struct VMinus : db::SimpleTag {
   using type = Scalar<DataVector>;
   static std::string name() noexcept { return "VMinus"; }
 };
-// @}
+/// @}
 
 template <size_t Dim>
 struct CharacteristicSpeeds : db::SimpleTag {

--- a/src/Evolution/TypeTraits.hpp
+++ b/src/Evolution/TypeTraits.hpp
@@ -35,7 +35,7 @@ template <typename T>
 constexpr bool is_analytic_solution_v =
     std::is_convertible_v<T*, MarkAsAnalyticSolution*>;
 
-// @{
+/// @{
 /// Helper metafunction that checks if the class `T` is marked as numeric
 /// initial data.
 template <typename T>
@@ -45,5 +45,5 @@ using is_numeric_initial_data =
 template <typename T>
 constexpr bool is_numeric_initial_data_v =
     tt::conforms_to_v<T, protocols::NumericInitialData>;
-// @}
+/// @}
 }  // namespace evolution

--- a/src/IO/Connectivity.hpp
+++ b/src/IO/Connectivity.hpp
@@ -46,7 +46,7 @@ struct CellInTopology {
   std::vector<size_t> bounding_indices{};
 };
 
-// @{
+/// @{
 /*!
  * \brief Compute the cells in the element.
  *
@@ -64,6 +64,6 @@ std::vector<CellInTopology> compute_cells(const Index<Dim>& extents) noexcept;
 
 std::vector<CellInTopology> compute_cells(
     const std::vector<size_t>& extents) noexcept;
-// @}
+/// @}
 }  // namespace detail
 }  // namespace vis

--- a/src/IO/H5/File.hpp
+++ b/src/IO/H5/File.hpp
@@ -77,14 +77,14 @@ class H5File {
   ~H5File();
   /// \endcond
 
-  // @{
+  /// @{
   /*!
    * \brief It does not make sense to copy an object referring to a file, only
    * to move it.
    */
   H5File(const H5File& /*rhs*/) = delete;
   H5File& operator=(const H5File& /*rhs*/) = delete;
-  // @}
+  /// @}
 
   /// \cond HIDDEN_SYMBOLS
   H5File(H5File&& rhs) noexcept;             // NOLINT
@@ -99,7 +99,7 @@ class H5File {
     return h5::get_group_names(file_id_, "/");
   }
 
-  // @{
+  /// @{
   /*!
    * \requires `ObjectType` is a valid h5::Object derived class, `path`
    * is a valid path in the HDF5 file
@@ -117,7 +117,7 @@ class H5File {
 
   template <typename ObjectType, typename... Args>
   const ObjectType& get(const std::string& path, Args&&... args) const;
-  // @}
+  /// @}
 
   /*!
    * \brief Insert an object into an H5 file.

--- a/src/IO/H5/OpenGroup.hpp
+++ b/src/IO/H5/OpenGroup.hpp
@@ -36,13 +36,13 @@ class OpenGroup {
   ~OpenGroup();
   /// \endcond
 
-  // @{
+  /// @{
   /// \cond HIDDEN_SYMBOLS
   /// Copying does not make sense since the group will then be closed twice.
   OpenGroup(const OpenGroup& /*rhs*/) = delete;
   OpenGroup& operator=(const OpenGroup& /*rhs*/) = delete;
   /// \endcond
-  // @}
+  /// @}
 
   OpenGroup(OpenGroup&& rhs) noexcept;             // NOLINT
   OpenGroup& operator=(OpenGroup&& rhs) noexcept;  // NOLINT

--- a/src/IO/Observer/TypeOfObservation.hpp
+++ b/src/IO/Observer/TypeOfObservation.hpp
@@ -24,7 +24,7 @@ enum class TypeOfObservation {
 
 std::ostream& operator<<(std::ostream& os, const TypeOfObservation& t) noexcept;
 
-// @{
+/// @{
 /// Inherits off of `std::true_type` if `T` has a member variable
 /// `RegisterWithObserver`
 template <class T, class = std::void_t<>>
@@ -39,5 +39,5 @@ struct has_register_with_observer<
 template <class T>
 constexpr bool has_register_with_observer_v =
     has_register_with_observer<T>::value;
-// @}
+/// @}
 }  // namespace observers

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/ApplyMassMatrix.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/ApplyMassMatrix.hpp
@@ -47,7 +47,7 @@ void apply_mass_matrix_impl(gsl::not_null<double*> data,
  * \note The mass-lumping is exact on Legendre-Gauss meshes, but omits a
  * correction term on Legendre-Gauss-Lobatto meshes.
  */
-// @{
+/// @{
 template <size_t Dim>
 void apply_mass_matrix(const gsl::not_null<DataVector*> data,
                        const Mesh<Dim>& mesh) noexcept {
@@ -72,6 +72,6 @@ void apply_mass_matrix(const gsl::not_null<Variables<TagsList>*> data,
     detail::apply_mass_matrix_impl(data->data() + i * num_points, mesh);
   }
 }
-// @}
+/// @}
 
 }  // namespace dg

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/LiftFlux.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/LiftFlux.hpp
@@ -17,7 +17,7 @@
 #include "Utilities/TMPL.hpp"
 
 namespace dg {
-// @{
+/// @{
 /// \ingroup DiscontinuousGalerkinGroup
 /// \brief Lifts the flux contribution from an interface to the volume.
 ///
@@ -73,5 +73,5 @@ auto lift_flux(Variables<tmpl::list<FluxTags...>> flux,
             std::move(magnitude_of_face_normal));
   return lifted_data;
 }
-// @}
+/// @}
 }  // namespace dg

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp
@@ -21,7 +21,7 @@
 // IWYU pragma: no_forward_declare Tags::Flux
 /// \endcond
 
-// @{
+/// @{
 /*!
  * \brief Contract a surface normal covector with the first index of a flux
  * tensor or variables
@@ -66,7 +66,7 @@ auto normal_dot_flux(
   });
   return result;
 }
-// @}
+/// @}
 
 namespace Tags {
 

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/NumericalFluxHelpers.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/NumericalFluxHelpers.hpp
@@ -57,7 +57,7 @@ void normal_dot_numerical_fluxes_impl(
 }
 }  // namespace detail
 
-// @{
+/// @{
 /// Helper function to unpack arguments when invoking the numerical flux
 template <typename NumericalFluxType, typename... AllFieldTags,
           typename... AllExtraTags, typename... Args>
@@ -116,7 +116,7 @@ void normal_dot_numerical_fluxes(
       typename NumericalFluxType::package_field_tags{},
       typename NumericalFluxType::package_extra_tags{}, n_dot_num_fluxes...);
 }
-// @}
+/// @}
 
 }  // namespace NumericalFluxes
 }  // namespace dg

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/SimpleMortarData.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/SimpleMortarData.hpp
@@ -34,17 +34,17 @@ class SimpleMortarData {
 
   /// These functions do nothing.  They exist for compatibility with
   /// BoundaryHistory.
-  //@{
+  /// @{
   size_t integration_order() const noexcept { return 0; }
   void integration_order(const size_t /*integration_order*/) noexcept {}
-  //@}
+  /// @}
 
   /// Add a value.  This function must be called once between calls to
   /// extract.
-  //@{
+  /// @{
   void local_insert(TemporalId temporal_id, LocalVars vars) noexcept;
   void remote_insert(TemporalId temporal_id, RemoteVars vars) noexcept;
-  //@}
+  /// @}
 
   /// Return the inserted data and reset the state to empty.
   std::pair<LocalVars, RemoteVars> extract() noexcept;

--- a/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp
+++ b/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp
@@ -38,7 +38,7 @@ class Irregular {
   /// Serialization for Charm++
   void pup(PUP::er& p) noexcept;  // NOLINT
 
-  //@{
+  /// @{
   /// Performs the interpolation on a `Variables` with grid points corresponding
   /// to the `Mesh<Dim>` specified in the constructor.
   /// The result is a `Variables` whose internal `DataVector` goes over the
@@ -50,7 +50,7 @@ class Irregular {
   template <typename TagsList>
   Variables<TagsList> interpolate(const Variables<TagsList>& vars) const
       noexcept;
-  //@}
+  /// @}
 
  private:
   friend bool operator==(const Irregular& lhs, const Irregular& rhs) noexcept {

--- a/src/NumericalAlgorithms/Interpolation/RegularGridInterpolant.hpp
+++ b/src/NumericalAlgorithms/Interpolation/RegularGridInterpolant.hpp
@@ -62,7 +62,7 @@ class RegularGrid {
   // clang-tidy: no runtime references
   void pup(PUP::er& p) noexcept;  // NOLINT
 
-  //@{
+  /// @{
   /// \brief Interpolate a Variables onto the target points.
   template <typename TagsList>
   void interpolate(gsl::not_null<Variables<TagsList>*> result,
@@ -70,9 +70,9 @@ class RegularGrid {
   template <typename TagsList>
   Variables<TagsList> interpolate(
       const Variables<TagsList>& vars) const noexcept;
-  //@}
+  /// @}
 
-  //@{
+  /// @{
   /// \brief Interpolate a DataVector onto the target points.
   ///
   /// \note When interpolating multiple tensors, the Variables interface is more
@@ -82,7 +82,7 @@ class RegularGrid {
   void interpolate(gsl::not_null<DataVector*> result,
                    const DataVector& input) const noexcept;
   DataVector interpolate(const DataVector& input) const noexcept;
-  //@}
+  /// @}
 
   /// \brief Return the internally-stored matrices that interpolate from the
   /// source grid to the target grid.

--- a/src/NumericalAlgorithms/LinearOperators/CoefficientTransforms.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/CoefficientTransforms.hpp
@@ -22,7 +22,7 @@ class not_null;
 }  // namespace gsl
 /// \endcond
 
-// @{
+/// @{
 /*!
  * \ingroup SpectralGroup
  * \brief Compute the modal coefficients from the nodal coefficients
@@ -51,9 +51,9 @@ template <size_t Dim>
 ComplexModalVector to_modal_coefficients(
     const ComplexDataVector& nodal_coefficients,
     const Mesh<Dim>& mesh) noexcept;
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \ingroup SpectralGroup
  * \brief Compute the nodal coefficients from the modal coefficients
@@ -81,4 +81,4 @@ template <size_t Dim>
 ComplexDataVector to_nodal_coefficients(
     const ComplexModalVector& modal_coefficients,
     const Mesh<Dim>& mesh) noexcept;
-// @}
+/// @}

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
@@ -53,7 +53,7 @@ struct div<Tag, Requires<tt::is_a_v<Tensor, typename Tag::type>>>
 /// \endcond
 }  // namespace Tags
 
-// @{
+/// @{
 /// \ingroup NumericalAlgorithmsGroup
 /// \brief Compute the (Euclidean) divergence of fluxes
 template <typename FluxTags, size_t Dim, typename DerivativeFrame>
@@ -70,9 +70,9 @@ void divergence(
     const Variables<tmpl::list<FluxTags...>>& F, const Mesh<Dim>& mesh,
     const InverseJacobian<DataVector, Dim, Frame::Logical, DerivativeFrame>&
         inverse_jacobian) noexcept;
-// @}
+/// @}
 
-// @{
+/// @{
 /// \ingroup NumericalAlgorithmsGroup
 /// \brief Compute the divergence of the vector `input`
 template <size_t Dim, typename DerivativeFrame>
@@ -89,7 +89,7 @@ void divergence(
     const Mesh<Dim>& mesh,
     const InverseJacobian<DataVector, Dim, Frame::Logical, DerivativeFrame>&
         inverse_jacobian) noexcept;
-// @}
+/// @}
 
 namespace Tags {
 /*!

--- a/src/NumericalAlgorithms/LinearOperators/IndefiniteIntegral.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/IndefiniteIntegral.hpp
@@ -14,7 +14,7 @@ class not_null;
 }  // namespace gsl
 /// \endcond
 
-// @{
+/// @{
 /*!
  * \ingroup NumericalAlgorithmsGroup
  * \brief Compute the indefinite integral of a function in the
@@ -41,4 +41,4 @@ template <size_t Dim, typename VectorType>
 VectorType indefinite_integral(const VectorType& integrand,
                                const Mesh<Dim>& mesh,
                                size_t dim_to_integrate) noexcept;
-// @}
+/// @}

--- a/src/NumericalAlgorithms/LinearOperators/Linearize.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Linearize.hpp
@@ -18,7 +18,7 @@ class not_null;
 }  // namespace gsl
 /// \endcond
 
-// @{
+/// @{
 /*!
  * \ingroup NumericalAlgorithmsGroup
  * \brief Truncate u to a linear function in each dimension.
@@ -33,9 +33,9 @@ void linearize(gsl::not_null<DataVector*> result, const DataVector& u,
                const Mesh<Dim>& mesh) noexcept;
 template <size_t Dim>
 DataVector linearize(const DataVector& u, const Mesh<Dim>& mesh) noexcept;
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \ingroup NumericalAlgorithmsGroup
  * \brief Truncate u to a linear function in the given dimension.
@@ -55,4 +55,4 @@ void linearize(gsl::not_null<DataVector*> result, const DataVector& u,
 template <size_t Dim>
 DataVector linearize(const DataVector& u, const Mesh<Dim>& mesh,
                      size_t d) noexcept;
-// @}
+/// @}

--- a/src/NumericalAlgorithms/LinearOperators/MeanValue.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/MeanValue.hpp
@@ -48,7 +48,7 @@ double mean_value(const DataVector& f, const Mesh<Dim>& mesh) noexcept {
   return definite_integral(f, mesh) / two_to_the(Dim);
 }
 
-// @{
+/// @{
 /*!
  * \ingroup NumericalAlgorithmsGroup
  * \brief Compute the mean value of a function over a boundary of a manifold.
@@ -96,4 +96,4 @@ double mean_value_on_boundary(
     gsl::not_null<DataVector*> /*boundary_buffer*/,
     gsl::span<std::pair<size_t, size_t>> /*volume_and_slice_indices*/,
     const DataVector& f, const Mesh<1>& mesh, size_t d, Side side) noexcept;
-// @}
+/// @}

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
@@ -86,7 +86,7 @@ struct spacetime_deriv<Tag, Dim, Frame,
 
 }  // namespace Tags
 
-// @{
+/// @{
 /// \ingroup NumericalAlgorithmsGroup
 /// \brief Compute the partial derivatives of each variable with respect to
 /// the logical coordinate.
@@ -108,9 +108,9 @@ template <typename DerivativeTags, typename VariableTags, size_t Dim>
 auto logical_partial_derivatives(const Variables<VariableTags>& u,
                                  const Mesh<Dim>& mesh) noexcept
     -> std::array<Variables<DerivativeTags>, Dim>;
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \ingroup NumericalAlgorithmsGroup
  * \brief Computes the logical partial derivative of a tensor, prepending the
@@ -150,9 +150,9 @@ auto logical_partial_derivative(
     const Mesh<Dim>& mesh) noexcept
     -> TensorMetafunctions::prepend_spatial_index<
         Tensor<DataVector, SymmList, IndexList>, Dim, UpLo::Lo, Frame::Logical>;
-// @}
+/// @}
 
-// @{
+/// @{
 /// \ingroup NumericalAlgorithmsGroup
 /// \brief Compute the partial derivatives of each variable with respect to
 /// the coordinates of `DerivativeFrame`.
@@ -192,7 +192,7 @@ auto partial_derivatives(
         inverse_jacobian) noexcept
     -> Variables<db::wrap_tags_in<Tags::deriv, DerivativeTags,
                                   tmpl::size_t<Dim>, DerivativeFrame>>;
-// @}
+/// @}
 
 namespace Tags {
 

--- a/src/NumericalAlgorithms/LinearSolver/Lapack.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Lapack.hpp
@@ -12,7 +12,7 @@ class Matrix;
 
 /// LAPACK wrappers
 namespace lapack {
-// @{
+/// @{
 /*!
  * \ingroup LinearSolverGroup
  * \brief Wrapper for LAPACK dgesv, which solves the general linear equation
@@ -80,5 +80,5 @@ int general_matrix_linear_solve(gsl::not_null<DataVector*> solution,
                                 const Matrix& matrix_operator,
                                 const DataVector& rhs,
                                 int number_of_rhs = 0) noexcept;
-// @}
+/// @}
 }  // namespace lapack

--- a/src/NumericalAlgorithms/LinearSolver/LinearSolver.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/LinearSolver.hpp
@@ -174,7 +174,7 @@ class PreconditionedLinearSolver : public LinearSolver<LinearSolverRegistrars> {
     }
   }
 
-  // @{
+  /// @{
   /// Access to the preconditioner. Check `has_preconditioner()` before calling
   /// this function. Calling this function when `has_preconditioner()` returns
   /// `false` is an error.

--- a/src/NumericalAlgorithms/RootFinding/GslMultiRoot.hpp
+++ b/src/NumericalAlgorithms/RootFinding/GslMultiRoot.hpp
@@ -339,7 +339,7 @@ void print_rootfinding_parameters(Method method, double absolute_tolerance,
                                   StoppingCondition condition) noexcept;
 }  // namespace gsl_multiroot_detail
 
-// @{
+/// @{
 /*!
  * \ingroup NumericalAlgorithmsGroup
  * \brief A multidimensional root finder supporting Newton and Hybrid
@@ -478,5 +478,5 @@ std::array<double, Dim> gsl_multiroot(
       &gsl_multiroot_fsolver_set, &gsl_multiroot_fsolver_iterate,
       &gsl_multiroot_fsolver_free);
 }
-// @}
+/// @}
 }  // namespace RootFinder

--- a/src/NumericalAlgorithms/Spectral/Spectral.hpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.hpp
@@ -424,7 +424,7 @@ template <typename T>
 Matrix interpolation_matrix(const Mesh<1>& mesh,
                             const T& target_points) noexcept;
 
-// @{
+/// @{
 /*!
  * \brief Matrices that interpolate to the lower and upper boundaries of the
  * element.
@@ -443,9 +443,9 @@ const std::pair<Matrix, Matrix>& boundary_interpolation_matrices(
 template <Basis BasisType, Quadrature QuadratureType>
 const std::pair<Matrix, Matrix>& boundary_interpolation_matrices(
     size_t num_points) noexcept;
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \brief Interpolates values from the boundary into the volume, which is needed
  * when applying time derivative or Bjorhus-type boundary conditions in a
@@ -477,9 +477,9 @@ const std::pair<DataVector, DataVector>& boundary_interpolation_term(
 template <Basis BasisType, Quadrature QuadratureType>
 const std::pair<DataVector, DataVector>& boundary_interpolation_term(
     size_t num_points) noexcept;
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \brief Terms used during the lifting portion of a discontinuous Galerkin
  * scheme when using Gauss points.
@@ -500,7 +500,7 @@ const std::pair<DataVector, DataVector>& boundary_lifting_term(
 template <Basis BasisType, Quadrature QuadratureType>
 const std::pair<DataVector, DataVector>& boundary_lifting_term(
     size_t num_points) noexcept;
-// @}
+/// @}
 
 /*!
  * \brief %Matrix used to transform from the spectral coefficients (modes) of a

--- a/src/NumericalAlgorithms/Spectral/SwshCoefficients.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshCoefficients.hpp
@@ -254,7 +254,7 @@ class CoefficientsMetadata {
       return pre_decrement;
     }
 
-    // @{
+    /// @{
     /// (In)Equivalence checks the object as well as the l and m current
     /// position.
     bool operator==(const CoefficientsIndexIterator& rhs) const noexcept {
@@ -263,7 +263,7 @@ class CoefficientsMetadata {
     bool operator!=(const CoefficientsIndexIterator& rhs) const noexcept {
       return not(*this == rhs);
     }
-    // @}
+    /// @}
 
    private:
     size_t m_;
@@ -293,7 +293,7 @@ class CoefficientsMetadata {
     return size_of_libsharp_coefficient_vector(l_max_);
   }
 
-  // @{
+  /// @{
   /// \brief Get a bidirectional iterator to the start of the series of modes.
   CoefficientsMetadata::CoefficientsIndexIterator begin() const noexcept {
     return CoefficientsIndexIterator(l_max_, 0, 0);
@@ -301,9 +301,9 @@ class CoefficientsMetadata {
   CoefficientsMetadata::CoefficientsIndexIterator cbegin() const noexcept {
     return begin();
   }
-  // @}
+  /// @}
 
-  // @{
+  /// @{
   /// \brief Get a bidirectional iterator to the end of the series of modes.
   CoefficientsMetadata::CoefficientsIndexIterator end() const noexcept {
     return CoefficientsIndexIterator(l_max_, l_max_ + 1, l_max_ + 1);
@@ -311,7 +311,7 @@ class CoefficientsMetadata {
   CoefficientsMetadata::CoefficientsIndexIterator cend() const noexcept {
     return end();
   }
-  // @}
+  /// @}
 
  private:
   std::unique_ptr<sharp_alm_info, detail::DestroySharpAlm> alm_info_;
@@ -331,7 +331,7 @@ class CoefficientsMetadata {
  */
 const CoefficientsMetadata& cached_coefficients_metadata(size_t l_max) noexcept;
 
-// @{
+/// @{
 /*!
  * \ingroup SwshGroup
  * \brief Compute the mode coefficient for the convention of
@@ -363,7 +363,7 @@ std::complex<double> libsharp_mode_to_goldberg_minus_m(
     const LibsharpCoefficientInfo& coefficient_info,
     const SpinWeighted<ComplexModalVector, Spin>& libsharp_modes,
     size_t radial_offset) noexcept;
-// @}
+/// @}
 
 /*!
  * \ingroup SwshGroup
@@ -441,7 +441,7 @@ void goldberg_modes_to_libsharp_modes_single_pair(
     size_t radial_offset, std::complex<double> goldberg_plus_m_mode_value,
     std::complex<double> goldberg_minus_m_mode_value) noexcept;
 
-// @{
+/// @{
 /*!
  * \ingroup SwshGroup
  * \brief Compute the set of Goldberg Spin-weighted spherical harmonic modes (in
@@ -461,9 +461,9 @@ template <int Spin>
 SpinWeighted<ComplexModalVector, Spin> libsharp_to_goldberg_modes(
     const SpinWeighted<ComplexModalVector, Spin>& libsharp_modes,
     size_t l_max) noexcept;
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \ingroup SwshGroup
  * \brief Compute the set of libsharp-compatible spin-weighted spherical
@@ -486,7 +486,7 @@ template <int Spin>
 SpinWeighted<ComplexModalVector, Spin> goldberg_to_libsharp_modes(
     const SpinWeighted<ComplexModalVector, Spin>& goldberg_modes,
     size_t l_max) noexcept;
-// @}
+/// @}
 
 /*!
  * \ingroup SwshGroup

--- a/src/NumericalAlgorithms/Spectral/SwshCollocation.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshCollocation.hpp
@@ -140,7 +140,7 @@ class CollocationMetadata {
       return CollocationConstIterator(collocation_, index_--);
     }
 
-    // @{
+    /// @{
     /// (In)Equivalence checks both the object and index for the iterator
     bool operator==(const CollocationConstIterator& rhs) const noexcept {
       return index_ == rhs.index_ and collocation_ == rhs.collocation_;
@@ -148,7 +148,7 @@ class CollocationMetadata {
     bool operator!=(const CollocationConstIterator& rhs) const noexcept {
       return not(*this == rhs);
     }
-    // @}
+    /// @}
 
    private:
     size_t index_;
@@ -198,7 +198,7 @@ class CollocationMetadata {
     return (l_max_ + 1) * (2 * l_max_ + 1);
   }
 
-  // @{
+  /// @{
   /// Get a bidirectional iterator to the start of the grid. `operator*` for
   /// that iterator gives a `LibsharpCollocationPoint` with members `offset`,
   /// `theta`, and `phi`
@@ -210,8 +210,8 @@ class CollocationMetadata {
       noexcept {
     return begin();
   }
-  // @}
-  // @{
+  /// @}
+  /// @{
   /// Get a bidirectional iterator to the end of the grid. `operator*` for
   /// that iterator gives a `LibsharpCollocationPoint` with members `offset`,
   /// `theta`, and `phi`
@@ -223,7 +223,7 @@ class CollocationMetadata {
       noexcept {
     return end();
   }
-  // @}
+  /// @}
 
  private:
   // an extra pointer layer is required for the peculiar way that libsharp

--- a/src/NumericalAlgorithms/Spectral/SwshFiltering.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshFiltering.hpp
@@ -16,7 +16,7 @@
 
 namespace Spectral {
 namespace Swsh {
-// @{
+/// @{
 /*!
  * \ingroup SwshGroup
  * \brief Filter a volume collocation set in the form of consecutive
@@ -53,8 +53,8 @@ void filter_swsh_volume_quantity(
     gsl::not_null<SpinWeighted<ComplexDataVector, Spin>*> to_filter,
     size_t l_max, size_t limit_l, double exponential_alpha,
     size_t exponential_half_power) noexcept;
-// @}
-// @{
+/// @}
+/// @{
 /*!
  * \ingroup SwshGroup
  * \brief Filter a libsharp-compatible set of collocation points on a spherical
@@ -75,6 +75,6 @@ template <int Spin>
 void filter_swsh_boundary_quantity(
     gsl::not_null<SpinWeighted<ComplexDataVector, Spin>*> to_filter,
     size_t l_max, size_t limit_l) noexcept;
-// @}
+/// @}
 }  // namespace Swsh
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/SwshTransform.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshTransform.hpp
@@ -728,7 +728,7 @@ struct make_inverse_transform_list_impl<MinSpin, Representation, TagList,
 };
 }  // namespace detail
 
-// @{
+/// @{
 /// \ingroup SwshGroup
 /// \brief Assemble a `tmpl::list` of `SwshTransform`s or
 /// `InverseSwshTransform`s given a list of tags `TagList` that need to be
@@ -753,7 +753,7 @@ using make_inverse_transform_list =
     typename detail::make_inverse_transform_list_impl<
         -2, Representation, TagList,
         decltype(std::make_integer_sequence<int, 5>{})>::type;
-// @}
+/// @}
 
 /// \ingroup SwshGroup
 /// \brief Assemble a `tmpl::list` of `SwshTransform`s given a list of

--- a/src/Options/ParseOptions.hpp
+++ b/src/Options/ParseOptions.hpp
@@ -205,13 +205,13 @@ class Parser {
   /// can be overridden by a new parsed value.  Newly parsed options
   /// replace the previous values.  Any tags not appearing in the new
   /// input are left unchanged.
-  //@{
+  /// @{
   template <typename OverlayOptions>
   void overlay(std::string options) noexcept;
 
   template <typename OverlayOptions>
   void overlay_file(const std::string& file_name) noexcept;
-  //@}
+  /// @}
 
   /// Get the value of the specified option
   ///

--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -285,7 +285,7 @@ class AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>
                                    std::forward<Args>(args)...);
   }
 
-  // @{
+  /// @{
   /// Call an Action on a local nodegroup requiring the Action to handle thread
   /// safety.
   ///
@@ -316,7 +316,7 @@ class AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>
         static_cast<const array_index&>(array_index_),
         make_not_null(&node_lock_));
   }
-  // @}
+  /// @}
 
   /// \brief Receive data and store it in the Inbox, and try to continue
   /// executing the algorithm
@@ -329,7 +329,7 @@ class AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>
                     ReceiveDataType&& t,
                     bool enable_if_disabled = false) noexcept;
 
-  // @{
+  /// @{
   /// Start evaluating the algorithm until it is stopped by an action.
   constexpr void perform_algorithm() noexcept;
 
@@ -339,7 +339,7 @@ class AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>
     }
     perform_algorithm();
   }
-  // @}
+  /// @}
 
   void start_phase(const PhaseType next_phase) noexcept {
     // terminate should be true since we exited a phase previously.
@@ -371,7 +371,7 @@ class AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>
   /// Check if an algorithm should continue being evaluated
   constexpr bool get_terminate() const noexcept { return terminate_; }
 
-  // {@
+  /// @{
   /// Wrappers for charm++ informational functions.
 
   /// Number of processing elements
@@ -415,7 +415,7 @@ class AlgorithmImpl<ParallelComponent, tmpl::list<PhaseDepActionListsPack...>>
   inline int local_rank_of(const int proc_index) const noexcept {
     return sys::local_rank_of(proc_index);
   }
-  // @}
+  /// @}
 
  private:
   template <typename ThisVariant, typename... Variants>

--- a/src/Parallel/GlobalCache.hpp
+++ b/src/Parallel/GlobalCache.hpp
@@ -523,7 +523,7 @@ void GlobalCache<Metavariables>::pup(PUP::er& p) noexcept {
 #pragma GCC diagnostic pop
 #endif  // defined(__GNUC__) && !defined(__clang__)
 
-// @{
+/// @{
 /// \ingroup ParallelGroup
 /// \brief Access the Charm++ proxy associated with a ParallelComponent
 ///
@@ -552,9 +552,9 @@ auto get_parallel_component(const GlobalCache<Metavariables>& cache) noexcept
           typename Metavariables::component_list, ParallelComponentTag>>>>(
       cache.parallel_components_);
 }
-// @}
+/// @}
 
-// @{
+/// @{
 /// \ingroup ParallelGroup
 /// \brief Access data in the cache
 ///

--- a/src/Parallel/Invoke.hpp
+++ b/src/Parallel/Invoke.hpp
@@ -53,7 +53,7 @@ void receive_data(Proxy&& proxy, typename ReceiveTag::temporal_id temporal_id,
   }
 }
 
-// @{
+/// @{
 /*!
  * \ingroup ParallelGroup
  * \brief Invoke a simple action on `proxy`
@@ -69,7 +69,7 @@ void simple_action(Proxy&& proxy, Arg0&& arg0, Args&&... args) noexcept {
       std::tuple<std::decay_t<Arg0>, std::decay_t<Args>...>(
           std::forward<Arg0>(arg0), std::forward<Args>(args)...));
 }
-// @}
+/// @}
 
 /*!
  * \ingroup ParallelGroup
@@ -82,7 +82,7 @@ decltype(auto) local_synchronous_action(Proxy&& proxy,
       std::forward<Args>(args)...);
 }
 
-// @{
+/// @{
 /*!
  * \ingroup ParallelGroup
  * \brief Invoke a threaded action on `proxy`, where the proxy must be a
@@ -99,5 +99,5 @@ void threaded_action(Proxy&& proxy, Arg0&& arg0, Args&&... args) noexcept {
       std::tuple<std::decay_t<Arg0>, std::decay_t<Args>...>(
           std::forward<Arg0>(arg0), std::forward<Args>(args)...));
 }
-// @}
+/// @}
 }  // namespace Parallel

--- a/src/Parallel/Reduction.hpp
+++ b/src/Parallel/Reduction.hpp
@@ -240,10 +240,10 @@ void ReductionData<ReductionDatum<Ts, InvokeCombines, InvokeFinals,
 /// Can be used instead of a `Parallel::Section` when no section is desired.
 ///
 /// \see Parallel::contribute_to_reduction
-// @{
+/// @{
 struct NoSection {};
 NoSection& no_section() noexcept;
-// @}
+/// @}
 
 /*!
  * \ingroup ParallelGroup

--- a/src/Parallel/Section.hpp
+++ b/src/Parallel/Section.hpp
@@ -62,11 +62,11 @@ struct Section {
   /// The section ID corresponding to the `SectionIdTag`
   const IdType& id() const noexcept { return id_; }
 
-  // @{
+  /// @{
   /// The Charm++ section proxy
   const cproxy_section& proxy() const noexcept { return proxy_; }
   cproxy_section& proxy() noexcept { return proxy_; }
-  // @}
+  /// @}
 
   /*!
    * \brief The Charm++ section cookie that keeps track of reductions
@@ -76,10 +76,10 @@ struct Section {
    * reductions see:
    * https://charm.readthedocs.io/en/latest/charm++/manual.html?#sections-subsets-of-a-chare-array-group
    */
-  // @{
+  /// @{
   const CkSectionInfo& cookie() const noexcept { return cookie_; }
   CkSectionInfo& cookie() noexcept { return cookie_; }
-  // @}
+  /// @}
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) noexcept {

--- a/src/Parallel/TypeTraits.hpp
+++ b/src/Parallel/TypeTraits.hpp
@@ -46,7 +46,7 @@ struct is_bound_array<T, std::void_t<typename T::bind_to>> : std::true_type {
                 "Can only bind to an array chare");
 };
 
-// @{
+/// @{
 /// \ingroup ParallelGroup
 /// \brief Check if `T` has a `pup` member function
 ///
@@ -92,9 +92,9 @@ constexpr bool has_pup_member_v = has_pup_member<T>::value;
 /// \see has_pup_member
 template <typename T>
 using has_pup_member_t = typename has_pup_member<T>::type;
-// @}
+/// @}
 
-// @{
+/// @{
 /// \ingroup ParallelGroup
 /// \brief Check if type `T` has operator| defined for Charm++ serialization
 ///
@@ -140,6 +140,6 @@ constexpr bool is_pupable_v = is_pupable<T>::value;
 /// \see is_pupable
 template <typename T>
 using is_pupable_t = typename is_pupable<T>::type;
-// @}
+/// @}
 
 } // namespace Parallel

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/OverlapHelpers.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/OverlapHelpers.hpp
@@ -133,7 +133,7 @@ class OverlapIterator {
   size_t overlap_offset_ = std::numeric_limits<size_t>::max();
 };
 
-// @{
+/// @{
 /// The part of the tensor data that lies within the overlap region
 template <size_t Dim, typename DataType, typename... TensorStructure>
 void data_on_overlap(const gsl::not_null<Tensor<DataType, TensorStructure...>*>
@@ -210,7 +210,7 @@ Variables<TagsList> data_on_overlap(const Variables<TagsList>& volume_data,
                   overlap_extent, direction);
   return overlap_data;
 }
-// @}
+/// @}
 
 namespace detail {
 template <size_t Dim>
@@ -246,7 +246,7 @@ void add_overlap_data(
                                 direction);
 }
 
-// @{
+/// @{
 /// Extend the overlap data to the full mesh by filling it with zeros outside
 /// the overlap region
 template <size_t Dim, typename ExtendedTagsList, typename OverlapTagsList>
@@ -269,6 +269,6 @@ Variables<TagsList> extended_overlap_data(
                         volume_extents, overlap_extent, direction);
   return extended_data;
 }
-// @}
+/// @}
 
 }  // namespace LinearSolver::Schwarz

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/Weighting.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/Weighting.hpp
@@ -48,7 +48,7 @@ namespace LinearSolver::Schwarz {
 DataVector extruding_weight(const DataVector& logical_coords, double width,
                             const Side& side) noexcept;
 
-// @{
+/// @{
 /*!
  * \brief Weights for data on the central element of an element-centered
  * subdomain
@@ -75,7 +75,7 @@ Scalar<DataVector> element_weight(
     const tnsr::I<DataVector, Dim, Frame::Logical>& logical_coords,
     const std::array<double, Dim>& overlap_widths,
     const std::unordered_set<Direction<Dim>>& external_boundaries) noexcept;
-// @}
+/// @}
 
 /*!
  * \brief Weights for the intruding solution of a neighboring element-centered
@@ -88,7 +88,7 @@ Scalar<DataVector> element_weight(
 DataVector intruding_weight(const DataVector& logical_coords, double width,
                             const Side& side) noexcept;
 
-// @{
+/// @{
 /*!
  * \brief Weights for data on overlap regions intruding into an element-centered
  * subdomain
@@ -126,6 +126,6 @@ Scalar<DataVector> intruding_weight(
     const std::array<double, Dim>& overlap_widths,
     size_t num_intruding_overlaps,
     const std::unordered_set<Direction<Dim>>& external_boundaries) noexcept;
-// @}
+/// @}
 
 }  // namespace LinearSolver::Schwarz

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/BlastWave.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/BlastWave.hpp
@@ -147,7 +147,7 @@ class BlastWave : public MarkAsAnalyticData, public AnalyticDataBase {
 
   explicit BlastWave(CkMigrateMessage* /*unused*/) noexcept {}
 
-  // @{
+  /// @{
   /// Retrieve the GRMHD variables at a given position.
   template <typename DataType>
   auto variables(const tnsr::I<DataType, 3>& x,
@@ -197,7 +197,7 @@ class BlastWave : public MarkAsAnalyticData, public AnalyticDataBase {
                  tmpl::list<hydro::Tags::SpecificEnthalpy<DataType>> /*meta*/)
       const noexcept
       -> tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DataType>>;
-  // @}
+  /// @}
 
   /// Retrieve a collection of hydrodynamic variables at position x
   template <typename DataType, typename... Tags>

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.hpp
@@ -150,7 +150,7 @@ class BondiHoyleAccretion : public MarkAsAnalyticData, public AnalyticDataBase {
                       double polytropic_constant,
                       double polytropic_exponent) noexcept;
 
-  // @{
+  /// @{
   /// Retrieve hydro variable at `x`
   template <typename DataType>
   auto variables(
@@ -200,7 +200,7 @@ class BondiHoyleAccretion : public MarkAsAnalyticData, public AnalyticDataBase {
       const tnsr::I<DataType, 3>& x,
       tmpl::list<hydro::Tags::SpecificEnthalpy<DataType>> /*meta*/) const
       noexcept -> tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DataType>>;
-  // @}
+  /// @}
 
   /// Retrieve a collection of hydro variables at `x`
   template <typename DataType, typename... Tags>

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.hpp
@@ -137,7 +137,7 @@ class MagneticFieldLoop : public MarkAsAnalyticData, public AnalyticDataBase {
 
   explicit MagneticFieldLoop(CkMigrateMessage* /*unused*/) noexcept {}
 
-  // @{
+  /// @{
   /// Retrieve the GRMHD variables at a given position.
   template <typename DataType>
   auto variables(
@@ -187,7 +187,7 @@ class MagneticFieldLoop : public MarkAsAnalyticData, public AnalyticDataBase {
       const tnsr::I<DataType, 3>& x,
       tmpl::list<hydro::Tags::SpecificEnthalpy<DataType>> /*meta*/) const
       noexcept -> tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DataType>>;
-  // @}
+  /// @}
 
   /// Retrieve a collection of hydrodynamic variables at position x
   template <typename DataType, typename... Tags>

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.hpp
@@ -135,7 +135,7 @@ class MagneticRotor : public MarkAsAnalyticData, public AnalyticDataBase {
 
   explicit MagneticRotor(CkMigrateMessage* /*unused*/) noexcept {}
 
-  // @{
+  /// @{
   /// Retrieve the GRMHD variables at a given position.
   template <typename DataType>
   auto variables(
@@ -185,7 +185,7 @@ class MagneticRotor : public MarkAsAnalyticData, public AnalyticDataBase {
       const tnsr::I<DataType, 3>& x,
       tmpl::list<hydro::Tags::SpecificEnthalpy<DataType>> /*meta*/) const
       noexcept -> tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DataType>>;
-  // @}
+  /// @}
 
   /// Retrieve a collection of hydrodynamic variables at position x
   template <typename DataType, typename... Tags>

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.hpp
@@ -144,7 +144,7 @@ class MagnetizedFmDisk
   using fm_disk::equation_of_state_type;
   using fm_disk::variables;
 
-  // @{
+  /// @{
   /// The grmhd variables in Cartesian Kerr-Schild coordinates at `(x, t)`
   ///
   /// \note The functions are optimized for retrieving the hydro variables
@@ -190,7 +190,7 @@ class MagnetizedFmDisk
                           std::numeric_limits<size_t>::max());
     return variables(x, tmpl::list<Tag>{}, intermediate_vars, 0);
   }
-  // @}
+  /// @}
 
   // clang-tidy: no runtime references
   void pup(PUP::er& /*p*/) noexcept;  //  NOLINT

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.hpp
@@ -68,7 +68,7 @@ class OrszagTangVortex : public MarkAsAnalyticData {
 
   OrszagTangVortex();
 
-  // @{
+  /// @{
   /// Retrieve hydro variable at `x`
   template <typename DataType>
   auto variables(
@@ -118,7 +118,7 @@ class OrszagTangVortex : public MarkAsAnalyticData {
       const tnsr::I<DataType, 3>& x,
       tmpl::list<hydro::Tags::SpecificEnthalpy<DataType>> /*meta*/) const
       noexcept -> tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DataType>>;
-  // @}
+  /// @}
 
   /// Retrieve a collection of hydro variables at `x`
   template <typename DataType, typename... Tags>

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/RiemannProblem.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/RiemannProblem.hpp
@@ -215,7 +215,7 @@ class RiemannProblem : public MarkAsAnalyticData {
 
   explicit RiemannProblem(CkMigrateMessage* /*unused*/) noexcept;
 
-  // @{
+  /// @{
   /// Retrieve the GRMHD variables at a given position.
   template <typename DataType>
   auto variables(const tnsr::I<DataType, 3>& x,
@@ -277,7 +277,7 @@ class RiemannProblem : public MarkAsAnalyticData {
       tmpl::list<gr::Tags::Shift<3, Frame::Inertial, DataType>> /*meta*/)
       const noexcept
       -> tuples::TaggedTuple<gr::Tags::Shift<3, Frame::Inertial, DataType>>;
-  // @}
+  /// @}
 
   /// Retrieve a collection of hydrodynamic variables at position x
   template <typename DataType, typename... Tags>

--- a/src/PointwiseFunctions/AnalyticData/NewtonianEuler/KhInstability.hpp
+++ b/src/PointwiseFunctions/AnalyticData/NewtonianEuler/KhInstability.hpp
@@ -214,7 +214,7 @@ class KhInstability : public MarkAsAnalyticData {
   void pup(PUP::er& /*p*/) noexcept;  //  NOLINT
 
  private:
-  // @{
+  /// @{
   /// Retrieve hydro variable at `x`
   template <typename DataType>
   auto variables(const tnsr::I<DataType, Dim, Frame::Inertial>& x,
@@ -240,7 +240,7 @@ class KhInstability : public MarkAsAnalyticData {
                  tmpl::list<Tags::Pressure<DataType>> /*meta*/
                  ) const noexcept
       -> tuples::TaggedTuple<Tags::Pressure<DataType>>;
-  // @}
+  /// @}
 
   template <size_t SpatialDim>
   friend bool

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.hpp
@@ -156,7 +156,7 @@ class AlfvenWave : public AnalyticSolution, public MarkAsAnalyticSolution {
              const std::array<double, 3>& background_magnetic_field,
              const std::array<double, 3>& wave_magnetic_field) noexcept;
 
-  // @{
+  /// @{
   /// Retrieve hydro variable at `(x, t)`
   template <typename DataType>
   auto variables(
@@ -206,7 +206,7 @@ class AlfvenWave : public AnalyticSolution, public MarkAsAnalyticSolution {
       const tnsr::I<DataType, 3>& x, double t,
       tmpl::list<hydro::Tags::SpecificEnthalpy<DataType>> /*meta*/) const
       noexcept -> tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DataType>>;
-  // @}
+  /// @}
 
   /// Retrieve a collection of hydro variables at `(x, t)`
   template <typename DataType, typename... Tags>

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.hpp
@@ -133,7 +133,7 @@ class KomissarovShock : public AnalyticSolution, public MarkAsAnalyticSolution {
 
   explicit KomissarovShock(CkMigrateMessage* /*unused*/) noexcept {}
 
-  // @{
+  /// @{
   /// Retrieve the GRMHD variables at a given position.
   template <typename DataType>
   auto variables(
@@ -183,7 +183,7 @@ class KomissarovShock : public AnalyticSolution, public MarkAsAnalyticSolution {
       const tnsr::I<DataType, 3>& x, double t,
       tmpl::list<hydro::Tags::SpecificEnthalpy<DataType>> /*meta*/) const
       noexcept -> tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DataType>>;
-  // @}
+  /// @}
 
   /// Retrieve a collection of hydrodynamic variables at position x
   template <typename DataType, typename... Tags>

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.hpp
@@ -64,7 +64,7 @@ class SmoothFlow : virtual public MarkAsAnalyticSolution,
   // Overload the variables function from the base class.
   using smooth_flow::variables;
 
-  // @{
+  /// @{
   /// Retrieve hydro variable at `(x, t)`
   template <typename DataType>
   auto variables(
@@ -78,7 +78,7 @@ class SmoothFlow : virtual public MarkAsAnalyticSolution,
       tmpl::list<hydro::Tags::DivergenceCleaningField<DataType>> /*meta*/) const
       noexcept
       -> tuples::TaggedTuple<hydro::Tags::DivergenceCleaningField<DataType>>;
-  // @}
+  /// @}
 
   /// Retrieve a collection of hydro variables at `(x, t)`
   template <typename DataType, typename... Tags>

--- a/src/PointwiseFunctions/AnalyticSolutions/Hydro/SmoothFlow.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Hydro/SmoothFlow.hpp
@@ -110,7 +110,7 @@ class SmoothFlow : virtual public MarkAsAnalyticSolution {
              const std::array<double, Dim>& wavevector, double pressure,
              double adiabatic_index, double perturbation_size) noexcept;
 
-  // @{
+  /// @{
   /// Retrieve hydro variable at `(x, t)`
   template <typename DataType>
   auto variables(const tnsr::I<DataType, Dim>& x, double t,
@@ -150,7 +150,7 @@ class SmoothFlow : virtual public MarkAsAnalyticSolution {
                  tmpl::list<hydro::Tags::SpecificEnthalpy<DataType>> /*meta*/)
       const noexcept
       -> tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DataType>>;
-  // @}
+  /// @}
 
   const EquationsOfState::IdealFluid<IsRelativistic>& equation_of_state()
       const noexcept {

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.hpp
@@ -195,7 +195,7 @@ class IsentropicVortex : public MarkAsAnalyticSolution {
   void pup(PUP::er& /*p*/) noexcept;  //  NOLINT
 
  private:
-  // @{
+  /// @{
   /// Retrieve hydro variable at `(x, t)`
   template <typename DataType>
   auto variables(tmpl::list<Tags::MassDensity<DataType>> /*meta*/,
@@ -217,7 +217,7 @@ class IsentropicVortex : public MarkAsAnalyticSolution {
   auto variables(tmpl::list<Tags::Pressure<DataType>> /*meta*/,
                  const IntermediateVariables<DataType>& vars) const noexcept
       -> tuples::TaggedTuple<Tags::Pressure<DataType>>;
-  // @}
+  /// @}
 
   // Intermediate variables needed to compute the primitives
   template <typename DataType>

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/RiemannProblem.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/RiemannProblem.hpp
@@ -287,7 +287,7 @@ class RiemannProblem : public MarkAsAnalyticSolution {
   }
 
  private:
-  // @{
+  /// @{
   /// Retrieve hydro variable at `(x, t)`
   template <typename DataType>
   auto variables(const tnsr::I<DataType, Dim, Frame::Inertial>& x_shifted,
@@ -314,7 +314,7 @@ class RiemannProblem : public MarkAsAnalyticSolution {
                  tmpl::list<Tags::SpecificInternalEnergy<DataType>> /*meta*/,
                  const Wave& left, const Wave& right) const noexcept
       -> tuples::TaggedTuple<Tags::SpecificInternalEnergy<DataType>>;
-  // @}
+  /// @}
 
   // Any of the two waves propagating on each side of the contact discontinuity.
   // Depending on whether p_* is larger or smaller

--- a/src/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/ConstantM1.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/ConstantM1.hpp
@@ -68,7 +68,7 @@ class ConstantM1 : public MarkAsAnalyticSolution {
 
   explicit ConstantM1(CkMigrateMessage* /*unused*/) noexcept {}
 
-  // @{
+  /// @{
   /// Retrieve fluid and neutrino variables at `(x, t)`
   template <typename NeutrinoSpecies>
   auto variables(const tnsr::I<DataVector, 3>& x, double t,
@@ -117,7 +117,7 @@ class ConstantM1 : public MarkAsAnalyticSolution {
       tmpl::list<hydro::Tags::SpatialVelocity<DataVector, 3>> /*meta*/) const
       noexcept
       -> tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataVector, 3>>;
-  // @}
+  /// @}
 
   /// Retrieve a collection of fluid and neutrino variables at `(x, t)`
   template <typename... Tags>

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
@@ -250,7 +250,7 @@ class FishboneMoncriefDisk : public MarkAsAnalyticSolution,
     return T::value;
   }
 
-  // @{
+  /// @{
   /// The fluid variables in Cartesian Kerr-Schild coordinates at `(x, t)`
   ///
   /// \note The functions are optimized for retrieving the hydro variables
@@ -296,7 +296,7 @@ class FishboneMoncriefDisk : public MarkAsAnalyticSolution,
                           std::numeric_limits<size_t>::max());
     return variables(x, tmpl::list<Tag>{}, intermediate_vars, 0);
   }
-  // @}
+  /// @}
 
   // clang-tidy: no runtime references
   void pup(PUP::er& /*p*/) noexcept;  //  NOLINT

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/ConstantDensityStar.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/ConstantDensityStar.hpp
@@ -119,7 +119,7 @@ class ConstantDensityStar {
   double density() const noexcept { return density_; }
   double radius() const noexcept { return radius_; }
 
-  // @{
+  /// @{
   /// Retrieve variable at coordinates `x`
   template <typename DataType>
   auto variables(
@@ -154,7 +154,7 @@ class ConstantDensityStar {
   auto variables(const tnsr::I<DataType, 3, Frame::Inertial>& x,
                  tmpl::list<gr::Tags::EnergyDensity<DataType>> /*meta*/) const
       noexcept -> tuples::TaggedTuple<gr::Tags::EnergyDensity<DataType>>;
-  // @}
+  /// @}
 
   /// Retrieve a collection of variables at coordinates `x`
   template <typename DataType, typename... Tags>

--- a/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/ConstitutiveRelation.hpp
+++ b/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/ConstitutiveRelation.hpp
@@ -68,7 +68,7 @@ class ConstitutiveRelation : public PUP::able {
 
   WRAPPED_PUPable_abstract(ConstitutiveRelation);  // NOLINT
 
-  // @{
+  /// @{
   /// The constitutive relation that characterizes the elastic properties of a
   /// material
   virtual void stress(gsl::not_null<tnsr::II<DataVector, Dim>*> stress,
@@ -81,7 +81,7 @@ class ConstitutiveRelation : public PUP::able {
   void stress(gsl::not_null<tnsr::IJ<DataVector, Dim>*> stress,
               const tnsr::ii<DataVector, Dim>& strain,
               const tnsr::I<DataVector, Dim>& x) const noexcept;
-  // @}
+  /// @}
 };
 
 }  // namespace ConstitutiveRelations

--- a/src/PointwiseFunctions/Elasticity/PotentialEnergy.hpp
+++ b/src/PointwiseFunctions/Elasticity/PotentialEnergy.hpp
@@ -14,7 +14,7 @@
 
 namespace Elasticity {
 
-// @{
+/// @{
 /*!
  * \brief The potential energy density \f$U=-\frac{1}{2}S_{ij}T^{ij}\f$ stored
  * in the deformation of the elastic material (see Eq. (11.25) in
@@ -41,7 +41,7 @@ Scalar<DataVector> potential_energy_density(
     const tnsr::I<DataVector, Dim>& coordinates,
     const ConstitutiveRelations::ConstitutiveRelation<Dim>&
         constitutive_relation) noexcept;
-// @}
+/// @}
 
 namespace Tags {
 

--- a/src/PointwiseFunctions/GeneralRelativity/Christoffel.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Christoffel.hpp
@@ -24,7 +24,7 @@ class not_null;
 /// \endcond
 
 namespace gr {
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes Christoffel symbol of the first kind from derivative of
@@ -43,9 +43,9 @@ void christoffel_first_kind(
 template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
 tnsr::abb<DataType, SpatialDim, Frame, Index> christoffel_first_kind(
     const tnsr::abb<DataType, SpatialDim, Frame, Index>& d_metric) noexcept;
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes Christoffel symbol of the second kind from derivative of
@@ -72,7 +72,7 @@ auto christoffel_second_kind(
     const tnsr::abb<DataType, SpatialDim, Frame, Index>& d_metric,
     const tnsr::AA<DataType, SpatialDim, Frame, Index>& inverse_metric) noexcept
     -> tnsr::Abb<DataType, SpatialDim, Frame, Index>;
-// @}
+/// @}
 
 namespace Tags {
 /// Compute item for spatial Christoffel symbols of the first kind

--- a/src/PointwiseFunctions/GeneralRelativity/DerivativesOfSpacetimeMetric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/DerivativesOfSpacetimeMetric.hpp
@@ -21,7 +21,7 @@
 /// \ingroup GeneralRelativityGroup
 /// Holds functions related to general relativity.
 namespace gr {
-//@{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes spacetime derivative of spacetime metric from spatial metric,
@@ -64,7 +64,7 @@ tnsr::abb<DataType, SpatialDim, Frame> derivatives_of_spacetime_metric(
     const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
     const tnsr::ijj<DataType, SpatialDim, Frame>&
         deriv_spatial_metric) noexcept;
-//@}
+/// @}
 
 namespace Tags {
 /*!

--- a/src/PointwiseFunctions/GeneralRelativity/ExtrinsicCurvature.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ExtrinsicCurvature.hpp
@@ -23,7 +23,7 @@
 /// \ingroup GeneralRelativityGroup
 /// Holds functions related to general relativity.
 namespace gr {
-//@{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief  Computes extrinsic curvature from metric and derivatives.
@@ -58,5 +58,5 @@ void extrinsic_curvature(
     const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
     const tnsr::ijj<DataType, SpatialDim, Frame>&
         deriv_spatial_metric) noexcept;
-//@}
+/// @}
 }  // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Christoffel.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Christoffel.hpp
@@ -9,7 +9,7 @@
 #include "Utilities/Gsl.hpp"
 
 namespace GeneralizedHarmonic {
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes spatial Christoffel symbol of the 2nd kind from the
@@ -39,4 +39,5 @@ auto christoffel_second_kind(
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
     const tnsr::II<DataType, SpatialDim, Frame>& inv_metric) noexcept
     -> tnsr::Ijj<DataType, SpatialDim, Frame>;
+/// @}
 }  // namespace GeneralizedHarmonic

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/DerivSpatialMetric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/DerivSpatialMetric.hpp
@@ -31,7 +31,7 @@ class Tensor;
 /// \endcond
 
 namespace GeneralizedHarmonic {
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes spatial derivatives of the spatial metric from
@@ -54,7 +54,7 @@ void deriv_spatial_metric(
 template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::ijj<DataType, SpatialDim, Frame> deriv_spatial_metric(
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
-// @}
+/// @}
 
 namespace Tags {
 /*!

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ExtrinsicCurvature.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ExtrinsicCurvature.hpp
@@ -31,7 +31,7 @@ class Tensor;
 /// \endcond
 
 namespace GeneralizedHarmonic {
-//@{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes extrinsic curvature from generalized harmonic variables
@@ -57,7 +57,7 @@ tnsr::ii<DataType, SpatialDim, Frame> extrinsic_curvature(
     const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
     const tnsr::aa<DataType, SpatialDim, Frame>& pi,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
-//@}
+/// @}
 
 namespace Tags {
 /*!

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/GaugeSource.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/GaugeSource.hpp
@@ -31,7 +31,7 @@ class Tensor;
 /// \endcond
 
 namespace GeneralizedHarmonic {
-//@{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief  Computes generalized harmonic gauge source function.
@@ -69,7 +69,7 @@ tnsr::a<DataType, SpatialDim, Frame> gauge_source(
     const Scalar<DataType>& trace_extrinsic_curvature,
     const tnsr::i<DataType, SpatialDim, Frame>&
         trace_christoffel_last_indices) noexcept;
-//@}
+/// @}
 
 namespace Tags {
 /*!

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Phi.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Phi.hpp
@@ -30,7 +30,7 @@ class Tensor;
 /// \endcond
 
 namespace GeneralizedHarmonic {
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes the auxiliary variable \f$\Phi_{iab}\f$ used by the
@@ -67,7 +67,7 @@ tnsr::iaa<DataType, SpatialDim, Frame> phi(
     const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
     const tnsr::ijj<DataType, SpatialDim, Frame>&
         deriv_spatial_metric) noexcept;
-// @}
+/// @}
 
 namespace Tags {
 /*!

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Pi.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Pi.hpp
@@ -30,7 +30,7 @@ class Tensor;
 /// \endcond
 
 namespace GeneralizedHarmonic {
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes the conjugate momentum \f$\Pi_{ab}\f$ of the spacetime metric
@@ -68,7 +68,7 @@ tnsr::aa<DataType, SpatialDim, Frame> pi(
     const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
     const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
-// @}
+/// @}
 
 namespace Tags {
 /*!

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Ricci.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Ricci.hpp
@@ -20,7 +20,7 @@ struct not_null;
 /// \endcond
 
 namespace GeneralizedHarmonic {
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Compute spatial Ricci tensor using evolved variables and
@@ -129,5 +129,5 @@ tnsr::ii<DataType, VolumeDim, Frame> spatial_ricci_tensor(
     const tnsr::ijaa<DataType, VolumeDim, Frame>& deriv_phi,
     const tnsr::II<DataType, VolumeDim, Frame>&
         inverse_spatial_metric) noexcept;
-// @}
+/// @}
 }  // namespace GeneralizedHarmonic

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpacetimeDerivOfDetSpatialMetric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpacetimeDerivOfDetSpatialMetric.hpp
@@ -31,7 +31,7 @@ class Tensor;
 /// \endcond
 
 namespace GeneralizedHarmonic {
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes spacetime derivatives of the determinant of spatial metric,
@@ -54,5 +54,5 @@ tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_det_spatial_metric(
     const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
     const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
-// @}
+/// @}
 }  // namespace GeneralizedHarmonic

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpacetimeDerivOfNormOfShift.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpacetimeDerivOfNormOfShift.hpp
@@ -31,7 +31,7 @@ class Tensor;
 /// \endcond
 
 namespace GeneralizedHarmonic {
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes spacetime derivatives of the norm of the shift vector.
@@ -64,5 +64,5 @@ tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_norm_of_shift(
     const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
     const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept;
-// @}
+/// @}
 }  // namespace GeneralizedHarmonic

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfLapse.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfLapse.hpp
@@ -31,7 +31,7 @@ class Tensor;
 /// \endcond
 
 namespace GeneralizedHarmonic {
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes spatial derivatives of lapse (N) from the generalized
@@ -68,7 +68,7 @@ tnsr::i<DataType, SpatialDim, Frame> spatial_deriv_of_lapse(
     const Scalar<DataType>& lapse,
     const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
-// @}
+/// @}
 
 namespace Tags {
 /*!

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfShift.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfShift.hpp
@@ -31,7 +31,7 @@ class Tensor;
 /// \endcond
 
 namespace GeneralizedHarmonic {
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes spatial derivatives of the shift vector from
@@ -68,7 +68,7 @@ tnsr::iJ<DataType, SpatialDim, Frame> spatial_deriv_of_shift(
     const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
     const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
-// @}
+/// @}
 
 namespace Tags {
 /*!

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfLapse.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfLapse.hpp
@@ -31,7 +31,7 @@ class Tensor;
 /// \endcond
 
 namespace GeneralizedHarmonic {
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes time derivative of lapse (N) from the generalized
@@ -76,7 +76,7 @@ Scalar<DataType> time_deriv_of_lapse(
     const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
     const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept;
-// @}
+/// @}
 
 namespace Tags {
 /*!

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfLowerShift.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfLowerShift.hpp
@@ -31,7 +31,7 @@ class Tensor;
 /// \endcond
 
 namespace GeneralizedHarmonic {
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes time derivative of index lowered shift from generalized
@@ -62,5 +62,5 @@ tnsr::i<DataType, SpatialDim, Frame> time_deriv_of_lower_shift(
     const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
     const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept;
-// @}
+/// @}
 }  // namespace GeneralizedHarmonic

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfShift.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfShift.hpp
@@ -31,7 +31,7 @@ class Tensor;
 /// \endcond
 
 namespace GeneralizedHarmonic {
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes time derivative of the shift vector from
@@ -67,7 +67,7 @@ tnsr::I<DataType, SpatialDim, Frame> time_deriv_of_shift(
     const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
     const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept;
-// @}
+/// @}
 
 namespace Tags {
 /*!

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfSpatialMetric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivOfSpatialMetric.hpp
@@ -31,7 +31,7 @@ class Tensor;
 /// \endcond
 
 namespace GeneralizedHarmonic {
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes time derivative of the spatial metric.
@@ -64,7 +64,7 @@ tnsr::ii<DataType, SpatialDim, Frame> time_deriv_of_spatial_metric(
     const tnsr::I<DataType, SpatialDim, Frame>& shift,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
     const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept;
-// @}
+/// @}
 
 namespace Tags {
 /*!

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivativeOfSpacetimeMetric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/TimeDerivativeOfSpacetimeMetric.hpp
@@ -31,7 +31,7 @@ class Tensor;
 /// \endcond
 
 namespace GeneralizedHarmonic {
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes the time derivative of the spacetime metric from the
@@ -58,5 +58,5 @@ tnsr::aa<DataType, SpatialDim, Frame> time_derivative_of_spacetime_metric(
     const tnsr::I<DataType, SpatialDim, Frame>& shift,
     const tnsr::aa<DataType, SpatialDim, Frame>& pi,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
-//@}
+/// @}
 }  // namespace GeneralizedHarmonic

--- a/src/PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp
@@ -10,7 +10,7 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Raises or lowers the first index of a rank 3 tensor which is symmetric
@@ -53,9 +53,9 @@ raise_or_lower_first_index(
   raise_or_lower_first_index(make_not_null(&result), tensor, metric);
   return result;
 }
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Raises or lowers the index of a rank 1 tensor.
@@ -91,9 +91,9 @@ raise_or_lower_index(
   raise_or_lower_index(make_not_null(&result), tensor, metric);
   return result;
 }
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes trace of a rank 3 tensor, which is symmetric in its last two
@@ -128,9 +128,9 @@ Tensor<DataType, Symmetry<1>, index_list<Index0>> trace_last_indices(
   trace_last_indices(make_not_null(&trace_of_tensor), tensor, metric);
   return trace_of_tensor;
 }
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes trace of a rank-2 symmetric tensor.
@@ -155,4 +155,4 @@ Scalar<DataType> trace(
   ::trace(make_not_null(&trace), tensor, metric);
   return trace;
 }
-// @}
+/// @}

--- a/src/PointwiseFunctions/GeneralRelativity/InterfaceNullNormal.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/InterfaceNullNormal.hpp
@@ -15,7 +15,7 @@ struct not_null;
 /// \endcond
 
 namespace gr {
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Compute null normal one-form to the boundary of a closed
@@ -43,9 +43,9 @@ void interface_null_normal(
     const tnsr::a<DataType, VolumeDim, Frame>& spacetime_normal_one_form,
     const tnsr::i<DataType, VolumeDim, Frame>& interface_unit_normal_one_form,
     const double sign) noexcept;
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Compute null normal vector to the boundary of a closed
@@ -73,5 +73,5 @@ void interface_null_normal(
     const tnsr::A<DataType, VolumeDim, Frame>& spacetime_normal_vector,
     const tnsr::I<DataType, VolumeDim, Frame>& interface_unit_normal_vector,
     const double sign) noexcept;
-// @}
+/// @}
 }  // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/InverseSpacetimeMetric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/InverseSpacetimeMetric.hpp
@@ -23,7 +23,7 @@
 /// \ingroup GeneralRelativityGroup
 /// Holds functions related to general relativity.
 namespace gr {
-//@{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Compute inverse spacetime metric from inverse spatial metric, lapse
@@ -53,7 +53,7 @@ tnsr::AA<DataType, SpatialDim, Frame> inverse_spacetime_metric(
     const tnsr::I<DataType, SpatialDim, Frame>& shift,
     const tnsr::II<DataType, SpatialDim, Frame>&
         inverse_spatial_metric) noexcept;
-//@}
+/// @}
 
 namespace Tags {
 /*!

--- a/src/PointwiseFunctions/GeneralRelativity/Lapse.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Lapse.hpp
@@ -23,7 +23,7 @@
 /// \ingroup GeneralRelativityGroup
 /// Holds functions related to general relativity.
 namespace gr {
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Compute lapse from shift and spacetime metric
@@ -46,7 +46,7 @@ void lapse(
     gsl::not_null<Scalar<DataType>*> lapse,
     const tnsr::I<DataType, SpatialDim, Frame>& shift,
     const tnsr::aa<DataType, SpatialDim, Frame>& spacetime_metric) noexcept;
-// @}
+/// @}
 
 namespace Tags {
 /*!

--- a/src/PointwiseFunctions/GeneralRelativity/ProjectionOperators.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ProjectionOperators.hpp
@@ -17,7 +17,7 @@ struct not_null;
 
 namespace gr {
 
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Compute projection operator onto an interface
@@ -37,9 +37,9 @@ void transverse_projection_operator(
     gsl::not_null<tnsr::II<DataType, VolumeDim, Frame>*> projection_tensor,
     const tnsr::II<DataType, VolumeDim, Frame>& inverse_spatial_metric,
     const tnsr::I<DataType, VolumeDim, Frame>& normal_vector) noexcept;
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Compute projection operator onto an interface
@@ -58,9 +58,9 @@ void transverse_projection_operator(
     gsl::not_null<tnsr::ii<DataType, VolumeDim, Frame>*> projection_tensor,
     const tnsr::ii<DataType, VolumeDim, Frame>& spatial_metric,
     const tnsr::i<DataType, VolumeDim, Frame>& normal_one_form) noexcept;
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Compute projection operator onto an interface
@@ -79,9 +79,9 @@ void transverse_projection_operator(
     gsl::not_null<tnsr::Ij<DataType, VolumeDim, Frame>*> projection_tensor,
     const tnsr::I<DataType, VolumeDim, Frame>& normal_vector,
     const tnsr::i<DataType, VolumeDim, Frame>& normal_one_form) noexcept;
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Compute spacetime projection operator onto an interface
@@ -111,9 +111,9 @@ void transverse_projection_operator(
     const tnsr::a<DataType, VolumeDim, Frame>& spacetime_normal_one_form,
     const tnsr::i<DataType, VolumeDim, Frame>&
         interface_unit_normal_one_form) noexcept;
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Compute spacetime projection operator onto an interface
@@ -143,9 +143,9 @@ void transverse_projection_operator(
     const tnsr::A<DataType, VolumeDim, Frame>& spacetime_normal_vector,
     const tnsr::I<DataType, VolumeDim, Frame>&
         interface_unit_normal_vector) noexcept;
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Compute spacetime projection operator onto an interface
@@ -178,5 +178,5 @@ void transverse_projection_operator(
     const tnsr::I<DataType, VolumeDim, Frame>& interface_unit_normal_vector,
     const tnsr::i<DataType, VolumeDim, Frame>&
         interface_unit_normal_one_form) noexcept;
-// @}
+/// @}
 }  // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/Ricci.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Ricci.hpp
@@ -21,7 +21,7 @@ struct not_null;
 
 namespace gr {
 
-//@{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes Ricci tensor from the (spatial or spacetime)
@@ -45,7 +45,7 @@ tnsr::aa<DataType, SpatialDim, Frame, Index> ricci_tensor(
     const tnsr::Abb<DataType, SpatialDim, Frame, Index>& christoffel_2nd_kind,
     const tnsr::aBcc<DataType, SpatialDim, Frame, Index>&
         d_christoffel_2nd_kind) noexcept;
-//@}
+/// @}
 
 namespace Tags {
 /// Compute item for spatial Ricci tensor \f$R_{ij}\f$

--- a/src/PointwiseFunctions/GeneralRelativity/Shift.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Shift.hpp
@@ -23,7 +23,7 @@
 /// \ingroup GeneralRelativityGroup
 /// Holds functions related to general relativity.
 namespace gr {
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Compute shift from spacetime metric and inverse spatial metric.
@@ -47,7 +47,7 @@ void shift(gsl::not_null<tnsr::I<DataType, SpatialDim, Frame>*> shift,
            const tnsr::aa<DataType, SpatialDim, Frame>& spacetime_metric,
            const tnsr::II<DataType, SpatialDim, Frame>&
                inverse_spatial_metric) noexcept;
-// @}
+/// @}
 
 namespace Tags {
 /*!

--- a/src/PointwiseFunctions/GeneralRelativity/SpacetimeMetric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/SpacetimeMetric.hpp
@@ -19,7 +19,7 @@
 #include "Utilities/TaggedTuple.hpp"
 
 namespace gr {
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes the spacetime metric from the spatial metric, lapse, and
@@ -44,7 +44,7 @@ tnsr::aa<DataType, SpatialDim, Frame> spacetime_metric(
     const Scalar<DataType>& lapse,
     const tnsr::I<DataType, SpatialDim, Frame>& shift,
     const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric) noexcept;
-// @}
+/// @}
 
 namespace Tags {
 /*!

--- a/src/PointwiseFunctions/GeneralRelativity/SpacetimeNormalOneForm.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/SpacetimeNormalOneForm.hpp
@@ -23,7 +23,7 @@
 /// \ingroup GeneralRelativityGroup
 /// Holds functions related to general relativity.
 namespace gr {
-//@{
+/// @{
 /*!
  * \brief Computes spacetime normal one-form from lapse.
  *
@@ -40,7 +40,7 @@ void spacetime_normal_one_form(
 template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::a<DataType, SpatialDim, Frame> spacetime_normal_one_form(
     const Scalar<DataType>& lapse) noexcept;
-//@}
+/// @}
 
 namespace Tags {
 /*!

--- a/src/PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp
@@ -23,7 +23,7 @@
 /// \ingroup GeneralRelativityGroup
 /// Holds functions related to general relativity.
 namespace gr {
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief  Computes spacetime normal vector from lapse and shift.
@@ -43,7 +43,7 @@ void spacetime_normal_vector(
         spacetime_normal_vector,
     const Scalar<DataType>& lapse,
     const tnsr::I<DataType, SpatialDim, Frame>& shift) noexcept;
-// @}
+/// @}
 
 namespace Tags {
 /*!

--- a/src/PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp
@@ -23,7 +23,7 @@
 /// \ingroup GeneralRelativityGroup
 /// Holds functions related to general relativity.
 namespace gr {
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Compute spatial metric from spacetime metric.
@@ -37,7 +37,7 @@ template <size_t SpatialDim, typename Frame, typename DataType>
 void spatial_metric(
     gsl::not_null<tnsr::ii<DataType, SpatialDim, Frame>*> spatial_metric,
     const tnsr::aa<DataType, SpatialDim, Frame>& spacetime_metric) noexcept;
-// @}
+/// @}
 
 namespace Tags {
 /*!

--- a/src/PointwiseFunctions/GeneralRelativity/TimeDerivativeOfSpacetimeMetric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/TimeDerivativeOfSpacetimeMetric.hpp
@@ -23,7 +23,7 @@
 /// \ingroup GeneralRelativityGroup
 /// Holds functions related to general relativity.
 namespace gr {
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes the time derivative of the spacetime metric from spatial
@@ -59,6 +59,6 @@ tnsr::aa<DataType, SpatialDim, Frame> time_derivative_of_spacetime_metric(
     const tnsr::I<DataType, SpatialDim, Frame>& dt_shift,
     const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
     const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric) noexcept;
-//@}
+/// @}
 namespace Tags {}  // namespace Tags
 }  // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/WeylElectric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/WeylElectric.hpp
@@ -18,7 +18,7 @@ struct not_null;
 
 namespace gr {
 
-//@(
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes the electric part of the Weyl tensor in vacuum.
@@ -46,9 +46,9 @@ void weyl_electric(
     const tnsr::ii<DataType, SpatialDim, Frame>& extrinsic_curvature,
     const tnsr::II<DataType, SpatialDim, Frame>&
         inverse_spatial_metric) noexcept;
-//@}
+/// @}
 
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes the scalar \f$E_{ij} E^{ij}\f$ from the electric
@@ -74,7 +74,7 @@ void weyl_electric_scalar(
     const tnsr::ii<DataType, SpatialDim, Frame>& weyl_electric,
     const tnsr::II<DataType, SpatialDim, Frame>&
         inverse_spatial_metric) noexcept;
-// @}
+/// @}
 
 namespace Tags {
 /// Compute item for the electric part of the weyl tensor in vacuum

--- a/src/PointwiseFunctions/GeneralRelativity/WeylPropagating.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/WeylPropagating.hpp
@@ -15,7 +15,7 @@ struct not_null;
 /// \endcond
 
 namespace gr {
-// @{
+/// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes the propagating modes of the Weyl tensor
@@ -68,5 +68,5 @@ void weyl_propagating(
     const tnsr::ii<DataType, SpatialDim, Frame>& projection_ij,
     const tnsr::Ij<DataType, SpatialDim, Frame>& projection_Ij,
     const double sign) noexcept;
-// @}
+/// @}
 }  // namespace gr

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp
@@ -88,7 +88,7 @@ class EquationOfState<IsRelativistic, 1>
 
   WRAPPED_PUPable_abstract(EquationOfState);  // NOLINT
 
-  // @{
+  /// @{
   /*!
    * Computes the pressure \f$p\f$ from the rest mass density \f$\rho\f$.
    */
@@ -96,9 +96,9 @@ class EquationOfState<IsRelativistic, 1>
       const Scalar<double>& /*rest_mass_density*/) const noexcept = 0;
   virtual Scalar<DataVector> pressure_from_density(
       const Scalar<DataVector>& /*rest_mass_density*/) const noexcept = 0;
-  // @}
+  /// @}
 
-  // @{
+  /// @{
   /*!
    * Computes the rest mass density \f$\rho\f$ from the specific enthalpy
    * \f$h\f$.
@@ -107,9 +107,9 @@ class EquationOfState<IsRelativistic, 1>
       const Scalar<double>& /*specific_enthalpy*/) const noexcept = 0;
   virtual Scalar<DataVector> rest_mass_density_from_enthalpy(
       const Scalar<DataVector>& /*specific_enthalpy*/) const noexcept = 0;
-  // @}
+  /// @}
 
-  // @{
+  /// @{
   /*!
    * Computes the specific enthalpy \f$h\f$ from the rest mass density
    * \f$\rho\f$.
@@ -118,9 +118,9 @@ class EquationOfState<IsRelativistic, 1>
       const Scalar<double>& /*rest_mass_density*/) const noexcept = 0;
   virtual Scalar<DataVector> specific_enthalpy_from_density(
       const Scalar<DataVector>& /*rest_mass_density*/) const noexcept = 0;
-  // @}
+  /// @}
 
-  // @{
+  /// @{
   /*!
    * Computes the specific internal energy \f$\epsilon\f$ from the rest mass
    * density \f$\rho\f$.
@@ -129,9 +129,9 @@ class EquationOfState<IsRelativistic, 1>
       const Scalar<double>& /*rest_mass_density*/) const noexcept = 0;
   virtual Scalar<DataVector> specific_internal_energy_from_density(
       const Scalar<DataVector>& /*rest_mass_density*/) const noexcept = 0;
-  // @}
+  /// @}
 
-  // @{
+  /// @{
   /*!
    * Computes \f$\chi=\partial p / \partial \rho\f$ from \f$\rho\f$, where
    * \f$p\f$ is the pressure and \f$\rho\f$ is the rest mass density.
@@ -140,9 +140,9 @@ class EquationOfState<IsRelativistic, 1>
       const Scalar<double>& /*rest_mass_density*/) const noexcept = 0;
   virtual Scalar<DataVector> chi_from_density(
       const Scalar<DataVector>& /*rest_mass_density*/) const noexcept = 0;
-  // @}
+  /// @}
 
-  // @{
+  /// @{
   /*!
    * Computes \f$\kappa p/\rho^2=(p/\rho^2)\partial p / \partial \epsilon\f$
    * from \f$\rho\f$, where \f$p\f$ is the pressure, \f$\rho\f$ is the rest mass
@@ -204,7 +204,7 @@ class EquationOfState<IsRelativistic, 2>
 
   WRAPPED_PUPable_abstract(EquationOfState);  // NOLINT
 
-  // @{
+  /// @{
   /*!
    * Computes the pressure \f$p\f$ from the rest mass density \f$\rho\f$ and the
    * specific internal energy \f$\epsilon\f$.
@@ -216,9 +216,9 @@ class EquationOfState<IsRelativistic, 2>
       const Scalar<DataVector>& /*rest_mass_density*/,
       const Scalar<DataVector>& /*specific_internal_energy*/) const
       noexcept = 0;
-  // @}
+  /// @}
 
-  // @{
+  /// @{
   /*!
    * Computes the pressure \f$p\f$ from the rest mass density \f$\rho\f$ and the
    * specific enthalpy \f$h\f$.
@@ -229,9 +229,9 @@ class EquationOfState<IsRelativistic, 2>
   virtual Scalar<DataVector> pressure_from_density_and_enthalpy(
       const Scalar<DataVector>& /*rest_mass_density*/,
       const Scalar<DataVector>& /*specific_enthalpy*/) const noexcept = 0;
-  // @}
+  /// @}
 
-  // @{
+  /// @{
   /*!
    * Computes the specific enthalpy \f$h\f$ from the rest mass density
    * \f$\rho\f$ and the specific internal energy \f$\epsilon\f$.
@@ -243,9 +243,9 @@ class EquationOfState<IsRelativistic, 2>
       const Scalar<DataVector>& /*rest_mass_density*/,
       const Scalar<DataVector>& /*specific_internal_energy*/) const
       noexcept = 0;
-  // @}
+  /// @}
 
-  // @{
+  /// @{
   /*!
    * Computes the specific internal energy \f$\epsilon\f$ from the rest mass
    * density \f$\rho\f$ and the pressure \f$p\f$.
@@ -256,9 +256,9 @@ class EquationOfState<IsRelativistic, 2>
   virtual Scalar<DataVector> specific_internal_energy_from_density_and_pressure(
       const Scalar<DataVector>& /*rest_mass_density*/,
       const Scalar<DataVector>& /*pressure*/) const noexcept = 0;
-  // @}
+  /// @}
 
-  // @{
+  /// @{
   /*!
    * Computes \f$\chi=\partial p / \partial \rho\f$ from the \f$\rho\f$ and
    * \f$\epsilon\f$, where \f$p\f$ is the pressure, \f$\rho\f$ is the rest mass
@@ -271,9 +271,9 @@ class EquationOfState<IsRelativistic, 2>
       const Scalar<DataVector>& /*rest_mass_density*/,
       const Scalar<DataVector>& /*specific_internal_energy*/) const
       noexcept = 0;
-  // @}
+  /// @}
 
-  // @{
+  /// @{
   /*!
    * Computes \f$\kappa p/\rho^2=(p/\rho^2)\partial p / \partial \epsilon\f$
    * from \f$\rho\f$ and \f$\epsilon\f$, where \f$p\f$ is the pressure,
@@ -293,7 +293,7 @@ class EquationOfState<IsRelativistic, 2>
       const Scalar<DataVector>& /*rest_mass_density*/,
       const Scalar<DataVector>& /*specific_internal_energy*/) const
       noexcept = 0;
-  // @}
+  /// @}
 
   /// The lower bound of the rest mass density that is valid for this EOS
   virtual double rest_mass_density_lower_bound() const noexcept = 0;

--- a/src/PointwiseFunctions/Hydro/LorentzFactor.hpp
+++ b/src/PointwiseFunctions/Hydro/LorentzFactor.hpp
@@ -18,7 +18,7 @@ struct not_null;
 /// \endcond
 
 namespace hydro {
-// @{
+/// @{
 /// Computes the Lorentz factor \f$W=1/\sqrt{1 - v^i v_i}\f$
 template <typename DataType, size_t Dim, typename Frame>
 void lorentz_factor(
@@ -38,7 +38,7 @@ void lorentz_factor(gsl::not_null<Scalar<DataType>*> result,
 template <typename DataType>
 Scalar<DataType> lorentz_factor(
     const Scalar<DataType>& spatial_velocity_squared) noexcept;
-// @}
+/// @}
 
 namespace Tags {
 /// Compute item for Lorentz factor \f$W\f$.

--- a/src/PointwiseFunctions/Hydro/MassFlux.hpp
+++ b/src/PointwiseFunctions/Hydro/MassFlux.hpp
@@ -26,7 +26,7 @@ struct not_null;
 /// \endcond
 
 namespace hydro {
-//@{
+/// @{
 /// Computes the vector \f$J^i\f$ in \f$\dot{M} = -\int J^i s_i d^2S\f$,
 /// representing the mass flux through a surface with normal \f$s_i\f$.
 ///
@@ -60,7 +60,7 @@ tnsr::I<DataType, Dim, Frame> mass_flux(
     const Scalar<DataType>& lorentz_factor, const Scalar<DataType>& lapse,
     const tnsr::I<DataType, Dim, Frame>& shift,
     const Scalar<DataType>& sqrt_det_spatial_metric) noexcept;
-//@}
+/// @}
 
 namespace Tags {
 /// Compute item for mass flux vector \f$J^i\f$.

--- a/src/PointwiseFunctions/Hydro/SoundSpeedSquared.hpp
+++ b/src/PointwiseFunctions/Hydro/SoundSpeedSquared.hpp
@@ -19,7 +19,7 @@ class EquationOfState;
 /// \endcond
 
 namespace hydro {
-//@{
+/// @{
 /*!
  * \ingroup EquationsOfStateGroup
  * \brief Computes the relativistic sound speed squared
@@ -48,7 +48,7 @@ Scalar<DataType> sound_speed_squared(
     const Scalar<DataType>& specific_enthalpy,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
         equation_of_state) noexcept;
-//@}
+/// @}
 
 namespace Tags {
 /// Compute item for the sound speed squared \f$c_s^2\f$.

--- a/src/PointwiseFunctions/Hydro/SpecificEnthalpy.hpp
+++ b/src/PointwiseFunctions/Hydro/SpecificEnthalpy.hpp
@@ -16,7 +16,7 @@ struct not_null;
 /// \endcond
 
 namespace hydro {
-//@{
+/// @{
 /*!
  * \ingroup EquationsOfStateGroup
  * \brief Computes the relativistic specific enthalpy \f$h\f$ as:
@@ -36,7 +36,7 @@ Scalar<DataType> relativistic_specific_enthalpy(
     const Scalar<DataType>& rest_mass_density,
     const Scalar<DataType>& specific_internal_energy,
     const Scalar<DataType>& pressure) noexcept;
-//@}
+/// @}
 
 namespace Tags {
 /// Compute item for the relativistic specific enthalpy \f$h\f$.

--- a/src/PointwiseFunctions/MathFunctions/MathFunction.hpp
+++ b/src/PointwiseFunctions/MathFunctions/MathFunction.hpp
@@ -52,37 +52,37 @@ class MathFunction : public PUP::able {
   MathFunction& operator=(MathFunction&& /*rhs*/) noexcept = default;
   ~MathFunction() override = default;
 
-  //@{
+  /// @{
   /// Returns the value of the function at the coordinate 'x'.
   virtual Scalar<double> operator()(
       const tnsr::I<double, VolumeDim, Fr>& x) const noexcept = 0;
   virtual Scalar<DataVector> operator()(
       const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept = 0;
-  //@}
+  /// @}
 
-  //@{
+  /// @{
   /// Returns the first partial derivatives of the function at 'x'.
   virtual tnsr::i<double, VolumeDim, Fr> first_deriv(
       const tnsr::I<double, VolumeDim, Fr>& x) const noexcept = 0;
   virtual tnsr::i<DataVector, VolumeDim, Fr> first_deriv(
       const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept = 0;
-  //@}
+  /// @}
 
-  //@{
+  /// @{
   /// Returns the second partial derivatives of the function at 'x'.
   virtual tnsr::ii<double, VolumeDim, Fr> second_deriv(
       const tnsr::I<double, VolumeDim, Fr>& x) const noexcept = 0;
   virtual tnsr::ii<DataVector, VolumeDim, Fr> second_deriv(
       const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept = 0;
-  //@}
+  /// @}
 
-  //@{
+  /// @{
   /// Returns the third partial derivatives of the function at 'x'.
   virtual tnsr::iii<double, VolumeDim, Fr> third_deriv(
       const tnsr::I<double, VolumeDim, Fr>& x) const noexcept = 0;
   virtual tnsr::iii<DataVector, VolumeDim, Fr> third_deriv(
       const tnsr::I<DataVector, VolumeDim, Fr>& x) const noexcept = 0;
-  //@}
+  /// @}
 };
 
 /*!

--- a/src/PointwiseFunctions/SpecialRelativity/LorentzBoostMatrix.hpp
+++ b/src/PointwiseFunctions/SpecialRelativity/LorentzBoostMatrix.hpp
@@ -18,7 +18,7 @@ class not_null;
 /// \ingroup SpecialRelativityGroup
 /// Holds functions related to special relativity.
 namespace sr {
-// @{
+/// @{
 /*!
  * \ingroup SpecialRelativityGroup
  * \brief Computes the matrix for a Lorentz boost from a single
@@ -53,5 +53,5 @@ template <size_t SpatialDim>
 void lorentz_boost_matrix(
     gsl::not_null<tnsr::Ab<double, SpatialDim, Frame::NoFrame>*> boost_matrix,
     const tnsr::I<double, SpatialDim, Frame::NoFrame>& velocity) noexcept;
-// @}
+/// @}
 }  // namespace sr

--- a/src/Time/BoundaryHistory.hpp
+++ b/src/Time/BoundaryHistory.hpp
@@ -52,26 +52,26 @@ class BoundaryHistory {
 
   /// The current order of integration.  This should match the value
   /// in the History.
-  //@{
+  /// @{
   size_t integration_order() const noexcept { return integration_order_; }
   void integration_order(const size_t integration_order) noexcept {
     integration_order_ = integration_order;
   }
-  //@}
+  /// @}
 
   /// Add a new value to the end of the history of the indicated side.
-  //@{
+  /// @{
   void local_insert(const TimeStepId& time_id, LocalVars vars) noexcept {
     local_data_.emplace_back(time_id.substep_time(), std::move(vars));
   }
   void remote_insert(const TimeStepId& time_id, RemoteVars vars) noexcept {
     remote_data_.emplace_back(time_id.substep_time(), std::move(vars));
   }
-  //@}
+  /// @}
 
   /// Add a new value to the front of the history of the indicated
   /// side.  This is often convenient for setting initial data.
-  //@{
+  /// @{
   void local_insert_initial(const TimeStepId& time_id,
                             LocalVars vars) noexcept {
     local_data_.emplace_front(time_id.substep_time(), std::move(vars));
@@ -80,23 +80,23 @@ class BoundaryHistory {
                              RemoteVars vars) noexcept {
     remote_data_.emplace_front(time_id.substep_time(), std::move(vars));
   }
-  //@}
+  /// @}
 
   /// Mark all data before the passed point in history on the
   /// indicated side as unneeded so it can be removed.  Calling this
   /// directly should not often be necessary, as it is handled
   /// internally by the time steppers.
-  //@{
+  /// @{
   void local_mark_unneeded(const local_iterator& first_needed) noexcept {
     mark_unneeded<0>(make_not_null(&local_data_), first_needed);
   }
   void remote_mark_unneeded(const remote_iterator& first_needed) noexcept {
     mark_unneeded<1>(make_not_null(&remote_data_), first_needed);
   }
-  //@}
+  /// @}
 
   /// Access to the sequence of times on the indicated side.
-  //@{
+  /// @{
   local_iterator local_begin() const noexcept {
     return local_iterator(local_data_.begin(), std::get<0>);
   }
@@ -113,7 +113,7 @@ class BoundaryHistory {
 
   size_t local_size() const noexcept { return local_data_.size(); }
   size_t remote_size() const noexcept { return remote_data_.size(); }
-  //@}
+  /// @}
 
   /// Look up the stored local data at the `time_id`. It is an error to request
   /// data at a `time_id` that has not been inserted yet.

--- a/src/Time/EvolutionOrdering.hpp
+++ b/src/Time/EvolutionOrdering.hpp
@@ -15,7 +15,7 @@
 ///
 /// This should only be used through the named aliases, but provides
 /// the documentation of the members.
-//@{
+/// @{
 template <typename T, template <typename> typename Comparator>
 struct evolution_comparator {
   bool time_runs_forward = true;
@@ -65,7 +65,7 @@ struct evolution_comparator<void, Comparator> {
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) noexcept { p | time_runs_forward; }
 };
-//@}
+/// @}
 
 /// \ingroup TimeGroup
 /// Ordering functors that reverse their order when time runs

--- a/src/Time/History.hpp
+++ b/src/Time/History.hpp
@@ -58,10 +58,10 @@ class History {
   void insert_initial(TimeStepId time_step_id, DerivVars deriv) noexcept;
 
   /// The most recent value of the integrated variables.
-  //@{
+  /// @{
   Vars& most_recent_value() noexcept { return most_recent_value_; }
   const Vars& most_recent_value() const noexcept { return most_recent_value_; }
-  //@}
+  /// @}
 
   /// Mark all data before the passed point in history as unneeded so
   /// it can be removed.  Calling this directly should not often be
@@ -71,7 +71,7 @@ class History {
   /// These iterators directly return the Time of the past values.
   /// The derivative data can be accessed through the iterators using
   /// HistoryIterator::derivative().
-  //@{
+  /// @{
   const_iterator begin() const noexcept {
     return data_.begin() +
            static_cast<typename decltype(data_.begin())::difference_type>(
@@ -80,7 +80,7 @@ class History {
   const_iterator end() const noexcept { return data_.end(); }
   const_iterator cbegin() const noexcept { return begin(); }
   const_iterator cend() const noexcept { return end(); }
-  //@}
+  /// @}
 
   size_type size() const noexcept { return capacity() - first_needed_entry_; }
   size_type capacity() const noexcept { return data_.size(); }
@@ -88,7 +88,7 @@ class History {
 
   /// These return the past times.  The other data can be accessed
   /// through HistoryIterator methods.
-  //@{
+  /// @{
   const_reference operator[](size_type n) const noexcept {
     return *(begin() + static_cast<difference_type>(n));
   }
@@ -97,16 +97,16 @@ class History {
   const_reference back() const noexcept {
     return std::get<0>(data_.back()).substep_time();
   }
-  //@}
+  /// @}
 
   /// Get or set the current order of integration.  TimeSteppers may
   /// impose restrictions on the valid values.
-  //@{
+  /// @{
   size_t integration_order() const noexcept { return integration_order_; }
   void integration_order(const size_t integration_order) noexcept {
     integration_order_ = integration_order;
   }
-  //@}
+  /// @}
 
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p) noexcept {  // NOLINT

--- a/src/Time/Slab.hpp
+++ b/src/Time/Slab.hpp
@@ -93,13 +93,13 @@ bool operator!=(const Slab& a, const Slab& b) noexcept;
 /// Slab comparison operators give the time ordering.  Overlapping
 /// unequal slabs should not be compared (and will trigger an
 /// assertion).
-//@{
+/// @{
 // NOLINTNEXTLINE(readability-redundant-declaration) redeclared for docs
 bool operator<(const Slab& a, const Slab& b) noexcept;
 bool operator>(const Slab& a, const Slab& b) noexcept;
 bool operator<=(const Slab& a, const Slab& b) noexcept;
 bool operator>=(const Slab& a, const Slab& b) noexcept;
-//@}
+/// @}
 
 std::ostream& operator<<(std::ostream& os, const Slab& s) noexcept;
 

--- a/src/Utilities/Algorithm.hpp
+++ b/src/Utilities/Algorithm.hpp
@@ -284,7 +284,7 @@ constexpr bool found_if_not(const Container& c,
          end(c);
 }
 
-// @{
+/// @{
 /// Convenience wrapper around std::for_each, returns the result of
 /// `std::for_each(begin(c), end(c), f)`.
 template <class Container, class UnaryFunction>
@@ -300,7 +300,7 @@ decltype(auto) for_each(Container& c, UnaryFunction&& f) {
   using std::end;
   return std::for_each(begin(c), end(c), std::forward<UnaryFunction>(f));
 }
-// @}
+/// @}
 
 /// Convenience wrapper around std::equal, assumes containers `lhs` has at least
 /// as many elements as `rhs`.

--- a/src/Utilities/Blas.hpp
+++ b/src/Utilities/Blas.hpp
@@ -65,7 +65,7 @@ inline double ddot_(const size_t& N, const double* X, const size_t& INCX,
                             gsl::narrow_cast<int>(INCY));
 }
 
-// @{
+/// @{
 /*!
  * \ingroup UtilitiesGroup
  * \brief Perform a matrix-matrix multiplication
@@ -143,9 +143,9 @@ inline void dgemm_<true>(const char& TRANSA, const char& TRANSB,
                 C, &ldc);
 }
 #endif  // ifndef SPECTRE_DEBUG
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \ingroup UtilitiesGroup
  * \brief Perform a matrix-vector multiplication
@@ -186,4 +186,4 @@ inline void dgemv_(const char& TRANS, const size_t& M, const size_t& N,
                       gsl::narrow_cast<int>(INCX), BETA, Y,
                       gsl::narrow_cast<int>(INCY));
 }
-//@}
+/// @}

--- a/src/Utilities/ConstantExpressions.hpp
+++ b/src/Utilities/ConstantExpressions.hpp
@@ -209,7 +209,7 @@ struct CompareByMagnitude {
 ///
 /// Magnitude is determined by constexpr_abs.  In case of a tie,
 /// returns the leftmost of the tied values.
-//@{
+/// @{
 template <typename T>
 constexpr const T& max_by_magnitude(const T& a, const T& b) {
   return std::max(a, b, ConstantExpressions_detail::CompareByMagnitude{});
@@ -220,14 +220,14 @@ constexpr T max_by_magnitude(std::initializer_list<T> ilist) {
   return std::max(std::move(ilist),
                   ConstantExpressions_detail::CompareByMagnitude{});
 }
-//@}
+/// @}
 
 /// \ingroup ConstantExpressionsGroup
 /// \brief Return the argument with the smallest magnitude
 ///
 /// Magnitude is determined by constexpr_abs.  In case of a tie,
 /// returns the leftmost of the tied values.
-//@{
+/// @{
 template <typename T>
 constexpr const T& min_by_magnitude(const T& a, const T& b) {
   return std::min(a, b, ConstantExpressions_detail::CompareByMagnitude{});
@@ -238,7 +238,7 @@ constexpr T min_by_magnitude(std::initializer_list<T> ilist) {
   return std::min(std::move(ilist),
                   ConstantExpressions_detail::CompareByMagnitude{});
 }
-//@}
+/// @}
 
 /// \ingroup ConstantExpressionsGroup
 /// \brief Returns `f(ic<0>{}) + f(ic<1>{}) + ... + f(ic<NumTerms-1>{})`

--- a/src/Utilities/FractionUtilities.hpp
+++ b/src/Utilities/FractionUtilities.hpp
@@ -14,7 +14,7 @@
 
 /// Type trait to check if a type looks like a fraction (specifically,
 /// if it has numerator and denominator methods)
-//@{
+/// @{
 template <typename T, typename = std::void_t<>>
 struct is_fraction : std::false_type {};
 template <typename T>
@@ -24,7 +24,7 @@ struct is_fraction<T, std::void_t<decltype(std::declval<T>().numerator()),
 
 template <typename T>
 constexpr bool is_fraction_v = is_fraction<T>::value;
-//@}
+/// @}
 
 /// \ingroup UtilitiesGroup
 /// \brief Compute the continued fraction representation of a number

--- a/src/Utilities/Gsl.hpp
+++ b/src/Utilities/Gsl.hpp
@@ -115,7 +115,7 @@ SPECTRE_ALWAYS_INLINE T narrow(U u) {
   return t;
 }
 
-// @{
+/// @{
 /*!
  * \ingroup UtilitiesGroup
  * \brief Retrieve a entry from a container, with checks in Debug mode that
@@ -140,7 +140,7 @@ SPECTRE_ALWAYS_INLINE constexpr const T& at(std::initializer_list<T> cont,
   Expects(index >= 0 and index < narrow_cast<Size>(cont.size()));
   return *(cont.begin() + index);
 }
-// @}
+/// @}
 
 namespace detail {
 template <class T>
@@ -794,7 +794,7 @@ constexpr bool operator>=(span<ElementType, Extent> l,
   return !(l < r);
 }
 
-// @{
+/// @{
 /// \ingroup UtilitiesGroup
 /// Utility function for creating spans
 template <class ElementType>
@@ -835,7 +835,7 @@ template <class Ptr>
 constexpr span<typename Ptr::element_type> make_span(Ptr& cont) {
   return span<typename Ptr::element_type>(cont);
 }
-// @}
+/// @}
 
 // Specialization of gsl::at for span
 template <class ElementType, std::ptrdiff_t Extent>

--- a/src/Utilities/MakeSignalingNan.hpp
+++ b/src/Utilities/MakeSignalingNan.hpp
@@ -5,7 +5,7 @@
 
 #include <limits>
 
-// @{
+/// @{
 /// \ingroup UtilitiesGroup
 /// \brief Returns an appropriate signaling NaN for fundamantal or multi-field
 /// types (such as `std::complex`).
@@ -24,4 +24,4 @@ template <typename T>
 T make_signaling_NaN() noexcept {
   return make_signaling_NaN(static_cast<T>(0));
 }
-// @}
+/// @}

--- a/src/Utilities/PrintHelpers.hpp
+++ b/src/Utilities/PrintHelpers.hpp
@@ -42,7 +42,7 @@ void sequence_print_helper(std::ostream& out, ForwardIt&& begin,
       [](std::ostream& os, const ForwardIt& it) noexcept { os << *it; });
 }
 
-//@{
+/// @{
 /*!
  * \ingroup UtilitiesGroup
  * Like sequence_print_helper, but sorts the string representations.
@@ -67,4 +67,4 @@ void unordered_print_helper(std::ostream& out, ForwardIt&& begin,
       out, std::forward<ForwardIt>(begin), std::forward<ForwardIt>(end),
       [](std::ostream& os, const ForwardIt& it) noexcept { os << *it; });
 }
-//@}
+/// @}

--- a/src/Utilities/ProtocolHelpers.hpp
+++ b/src/Utilities/ProtocolHelpers.hpp
@@ -24,7 +24,7 @@ struct ConformsTo {};
 // Note that std::is_convertible is used in the following type aliases as it
 // will not match private base classes (unlike std::is_base_of)
 
-// @{
+/// @{
 /*!
  * \ingroup ProtocolsGroup
  * \brief Checks if the `ConformingType` conforms to the `Protocol`.
@@ -47,7 +47,7 @@ using conforms_to =
 template <typename ConformingType, typename Protocol>
 constexpr bool conforms_to_v =
     std::is_convertible_v<ConformingType*, ConformsTo<Protocol>*>;
-// @}
+/// @}
 
 namespace detail {
 

--- a/src/Utilities/StdArrayHelpers.hpp
+++ b/src/Utilities/StdArrayHelpers.hpp
@@ -139,7 +139,7 @@ inline constexpr std::array<T, Dim + 1> prepend(const std::array<T, Dim>& a,
   return result;
 }
 
-//@{
+/// @{
 /// \ingroup UtilitiesGroup
 /// \brief Euclidean magnitude of the elements of the array.
 ///
@@ -164,8 +164,8 @@ template <typename T>
 decltype(auto) magnitude(const std::array<T, 3>& a) noexcept {
   return sqrt(a[0] * a[0] + a[1] * a[1] + a[2] * a[2]);
 }
-//@}
-//@{
+/// @}
+/// @{
 /// \ingroup UtilitiesGroup
 /// \brief Dot product between two arrays
 ///
@@ -190,7 +190,7 @@ decltype(auto) dot(const std::array<T, 3>& first,
                    const std::array<R, 3>& second) {
   return first[0] * second[0] + first[1] * second[1] + first[2] * second[2];
 }
-//@}
+/// @}
 
 namespace std_array_helpers_detail {
 template <typename T, size_t Dim, typename F, size_t... Indices>

--- a/src/Utilities/TaggedTuple.hpp
+++ b/src/Utilities/TaggedTuple.hpp
@@ -519,7 +519,7 @@ struct tuple_size<const volatile TaggedTuple<Tags...>>
     : tuple_size<TaggedTuple<Tags...>> {};
 
 // C++17 Draft 23.5.3.7 Element access
-// @{
+/// @{
 /*!
  * \ingroup UtilitiesGroup
  * \brief Retrieve the element of `Tag` in the TaggedTuple
@@ -568,7 +568,7 @@ inline constexpr typename Tag::type&& get(TaggedTuple<Tags...>&& t) noexcept {
   return static_cast<typename Tag::type&&>(
       static_cast<tuples_detail::TaggedTupleLeaf<Tag>&&>(t).get());
 }
-// @}
+/// @}
 
 // C++17 Draft 23.5.3.8 Relational operators
 namespace tuples_detail {
@@ -785,7 +785,7 @@ constexpr decltype(auto) apply_impl(F&& f, const TaggedTuple<Tags...>& t,
 
 }  // namespace TaggedTuple_detail
 
-// @{
+/// @{
 /*!
  * \ingroup UtilitiesGroup
  * \brief Invoke `f` with the `ApplyTags` taken from `t` expanded in a parameter
@@ -813,6 +813,6 @@ constexpr decltype(auto) apply(F&& f, const TaggedTuple<Tags...>& t) {
   return TaggedTuple_detail::apply_impl(
       std::forward<F>(f), t, typename TaggedTuple<Tags...>::tags_list{});
 }
-// @}
+/// @}
 
 }  // namespace tuples

--- a/src/Utilities/Tuple.hpp
+++ b/src/Utilities/Tuple.hpp
@@ -75,7 +75,7 @@ constexpr inline void tuple_transform_impl(
 }
 }  // namespace tuple_impl_detail
 
-// @{
+/// @{
 /*!
  * \ingroup UtilitiesGroup
  * \brief Perform a fold over a std::tuple
@@ -137,7 +137,7 @@ constexpr inline void tuple_counted_fold(
       tuple, std::forward<N_aryOp>(op),
       std::make_index_sequence<sizeof...(Elements)>{}, args...);
 }
-// @}
+/// @}
 
 /*!
  * \ingroup UtilitiesGroup

--- a/src/Utilities/TypeTraits/ArraySize.hpp
+++ b/src/Utilities/TypeTraits/ArraySize.hpp
@@ -14,7 +14,7 @@ std::integral_constant<std::size_t, N> array_size_impl(
     const std::array<T, N>& /*array*/);
 }  // namespace TypeTraits_detail
 
-// @{
+/// @{
 /// \ingroup TypeTraitsGroup
 /// \brief Get the size of a std::array as a std::integral_constant
 ///
@@ -44,5 +44,5 @@ std::integral_constant<std::size_t, N> array_size_impl(
 template <typename Array>
 using array_size =
     decltype(TypeTraits_detail::array_size_impl(std::declval<const Array&>()));
-// @}
+/// @}
 }  // namespace tt

--- a/src/Utilities/TypeTraits/CanBeCopyConstructed.hpp
+++ b/src/Utilities/TypeTraits/CanBeCopyConstructed.hpp
@@ -6,7 +6,7 @@
 #include <type_traits>
 
 namespace tt {
-// @{
+/// @{
 /*!
  * \ingroup TypeTraitsGroup
  * \brief Check if `T` is copy constructible
@@ -30,5 +30,5 @@ struct can_be_copy_constructed<T, std::void_t<typename T::value_type>>
 
 template <typename T>
 constexpr bool can_be_copy_constructed_v = can_be_copy_constructed<T>::value;
-// @}
+/// @}
 }  // namespace tt

--- a/src/Utilities/TypeTraits/CreateHasStaticMemberVariable.hpp
+++ b/src/Utilities/TypeTraits/CreateHasStaticMemberVariable.hpp
@@ -7,7 +7,7 @@
 
 #include "Utilities/NoSuchType.hpp"
 
-// @{
+/// @{
 /*!
  * \ingroup TypeTraitsGroup
  * \brief Generate a type trait to check if a class has a `static constexpr`
@@ -44,4 +44,4 @@
   template <typename CheckingType, typename VariableType = NoSuchType*****> \
   static constexpr const bool has_##CONSTEXPR_NAME##_v =                    \
       has_##CONSTEXPR_NAME<CheckingType, VariableType>::value;
-// @}
+/// @}

--- a/src/Utilities/TypeTraits/CreateHasTypeAlias.hpp
+++ b/src/Utilities/TypeTraits/CreateHasTypeAlias.hpp
@@ -7,7 +7,7 @@
 
 #include "Utilities/NoSuchType.hpp"
 
-// @{
+/// @{
 /*!
  * \ingroup TypeTraitsGroup
  * \brief Generate a type trait to check if a class has a type alias with a
@@ -40,4 +40,4 @@
   template <typename CheckingType, typename AliasType = NoSuchType*****> \
   static constexpr const bool has_##ALIAS_NAME##_v =                     \
       has_##ALIAS_NAME<CheckingType, AliasType>::value;
-// @}
+/// @}

--- a/src/Utilities/TypeTraits/CreateIsCallable.hpp
+++ b/src/Utilities/TypeTraits/CreateIsCallable.hpp
@@ -5,6 +5,7 @@
 
 #include <type_traits>
 
+/// @{
 /*!
  * \ingroup TypeTraitsGroup
  * \brief Generate a type trait to check if a class has a member function that
@@ -68,4 +69,4 @@
   template <typename T, typename... Args>                     \
   static constexpr const bool is_##METHOD_NAME##_callable_v = \
       is_##METHOD_NAME##_callable<T, Args...>::value;
-// @}
+/// @}

--- a/src/Utilities/TypeTraits/GetFundamentalType.hpp
+++ b/src/Utilities/TypeTraits/GetFundamentalType.hpp
@@ -9,7 +9,7 @@
 #include "Utilities/TMPL.hpp"
 
 namespace tt {
-// @{
+/// @{
 /// \ingroup TypeTraitsGroup
 /// \brief Extracts the fundamental type for a container
 ///
@@ -35,5 +35,5 @@ struct get_fundamental_type<T, std::void_t<typename T::value_type>> {
 
 template <typename T>
 using get_fundamental_type_t = typename get_fundamental_type<T>::type;
-// @}
+/// @}
 }  // namespace tt

--- a/src/Utilities/TypeTraits/HasEquivalence.hpp
+++ b/src/Utilities/TypeTraits/HasEquivalence.hpp
@@ -6,7 +6,7 @@
 #include <type_traits>
 
 namespace tt {
-// @{
+/// @{
 /// \ingroup TypeTraitsGroup
 /// \brief Check if type `T` has operator== defined.
 ///
@@ -54,5 +54,5 @@ constexpr bool has_equivalence_v = has_equivalence<T>::value;
 /// \see has_equivalence
 template <typename T>
 using has_equivalence_t = typename has_equivalence<T>::type;
-// @}
+/// @}
 }  // namespace tt

--- a/src/Utilities/TypeTraits/HasInequivalence.hpp
+++ b/src/Utilities/TypeTraits/HasInequivalence.hpp
@@ -6,7 +6,7 @@
 #include <type_traits>
 
 namespace tt {
-// @{
+/// @{
 /// \ingroup TypeTraitsGroup
 /// \brief Check if type `T` has operator!= defined.
 ///
@@ -54,5 +54,5 @@ constexpr bool has_inequivalence_v = has_inequivalence<T>::value;
 /// \see has_inequivalence
 template <typename T>
 using has_inequivalence_t = typename has_inequivalence<T>::type;
-// @}
+/// @}
 }  // namespace tt

--- a/src/Utilities/TypeTraits/IsA.hpp
+++ b/src/Utilities/TypeTraits/IsA.hpp
@@ -6,7 +6,7 @@
 #include <type_traits>
 
 namespace tt {
-// @{
+/// @{
 /// \ingroup TypeTraitsGroup
 /// \brief Check if type `T` is a template specialization of `U`
 ///
@@ -52,7 +52,7 @@ constexpr bool is_a_v = is_a<U, Args...>::value;
 /// \see is_a
 template <template <typename...> class U, typename... Args>
 using is_a_t = typename is_a<U, Args...>::type;
-// @}
+/// @}
 
 namespace detail {
 template <template <typename> class U>

--- a/src/Utilities/TypeTraits/IsCallable.hpp
+++ b/src/Utilities/TypeTraits/IsCallable.hpp
@@ -6,7 +6,7 @@
 #include <type_traits>
 
 namespace tt {
-// @{
+/// @{
 /// \ingroup TypeTraitsGroup
 /// \brief Check if a type `T` is callable, i.e. `T(Args...)` is evaluable.
 ///
@@ -69,5 +69,5 @@ constexpr bool is_callable_v = is_callable<T, Args...>::value;
 /// \see is_callable
 template <typename T, typename... Args>
 using is_callable_t = typename is_callable<T, Args...>::type;
-// @}
+/// @}
 }  // namespace tt

--- a/src/Utilities/TypeTraits/IsComplexOfFundamental.hpp
+++ b/src/Utilities/TypeTraits/IsComplexOfFundamental.hpp
@@ -7,7 +7,7 @@
 #include <type_traits>
 
 namespace tt {
-// @{
+/// @{
 /// \ingroup TypeTraitsGroup
 /// \brief Determines if a type `T` is a `std::complex` of a fundamental type,
 /// is a `std::true_type` if so, and otherwise is a `std::false_type`
@@ -24,7 +24,7 @@ struct is_complex_of_fundamental<std::complex<T>,
                                  std::bool_constant<std::is_fundamental_v<T>>>
     : std::true_type {};
 /// \endcond
-// @}
+/// @}
 
 template <typename T>
 constexpr bool is_complex_of_fundamental_v =

--- a/src/Utilities/TypeTraits/IsInteger.hpp
+++ b/src/Utilities/TypeTraits/IsInteger.hpp
@@ -6,7 +6,7 @@
 #include <type_traits>
 
 namespace tt {
-// @{
+/// @{
 /*!
  * \ingroup TypeTraitsGroup
  * \brief Check if `I` is an integer type (non-bool, non-character), unlike
@@ -61,5 +61,5 @@ struct is_integer<unsigned long long> : std::true_type {};
 /// \see is_integer
 template <typename T>
 constexpr bool is_integer_v = is_integer<T>::value;
-// @}
+/// @}
 }  // namespace tt

--- a/src/Utilities/TypeTraits/IsIterable.hpp
+++ b/src/Utilities/TypeTraits/IsIterable.hpp
@@ -6,7 +6,7 @@
 #include <type_traits>
 
 namespace tt {
-// @{
+/// @{
 /// \ingroup TypeTraitsGroup
 /// \brief Check if type T has a begin() and end() function
 ///
@@ -53,5 +53,5 @@ constexpr bool is_iterable_v = is_iterable<T>::value;
 /// \see is_iterable
 template <typename T>
 using is_iterable_t = typename is_iterable<T>::type;
-// @}
+/// @}
 }  // namespace tt

--- a/src/Utilities/TypeTraits/IsMaplike.hpp
+++ b/src/Utilities/TypeTraits/IsMaplike.hpp
@@ -9,7 +9,7 @@
 #include "Utilities/TypeTraits/IsIterable.hpp"
 
 namespace tt {
-// @{
+/// @{
 /// \ingroup TypeTraitsGroup
 /// \brief Check if type `T` is like a std::map or std::unordored_map
 ///
@@ -62,5 +62,5 @@ constexpr bool is_maplike_v = is_maplike<T>::value;
 /// \see is_maplike
 template <typename T>
 using is_maplike_t = typename is_maplike<T>::type;
-// @}
+/// @}
 }  // namespace tt

--- a/src/Utilities/TypeTraits/IsStdArray.hpp
+++ b/src/Utilities/TypeTraits/IsStdArray.hpp
@@ -7,7 +7,7 @@
 #include <type_traits>
 
 namespace tt {
-// @{
+/// @{
 /// \ingroup TypeTraitsGroup
 /// \brief Check if type T is a std::array
 ///
@@ -53,5 +53,5 @@ constexpr bool is_std_array_v = is_std_array<T>::value;
 /// \see is_std_array
 template <typename T>
 using is_std_array_t = typename is_std_array<T>::type;
-// @}
+/// @}
 }  // namespace tt

--- a/src/Utilities/TypeTraits/IsStdArrayOfSize.hpp
+++ b/src/Utilities/TypeTraits/IsStdArrayOfSize.hpp
@@ -8,7 +8,7 @@
 #include <type_traits>
 
 namespace tt {
-// @{
+/// @{
 /// \ingroup TypeTraitsGroup
 /// \brief Check if type T is a std::array of a given size
 ///
@@ -54,5 +54,5 @@ constexpr bool is_std_array_of_size_v = is_std_array_of_size<N, T>::value;
 /// \see is_std_array_of_size
 template <size_t N, typename T>
 using is_std_array_of_size_t = typename is_std_array_of_size<N, T>::type;
-// @}
+/// @}
 }  // namespace tt

--- a/src/Utilities/TypeTraits/IsStreamable.hpp
+++ b/src/Utilities/TypeTraits/IsStreamable.hpp
@@ -9,7 +9,7 @@
 #include "Utilities/StlStreamDeclarations.hpp"
 
 namespace tt {
-// @{
+/// @{
 /// \ingroup TypeTraitsGroup
 /// \brief Check if type `T` has operator<<(`S`, `T`) defined.
 ///
@@ -60,5 +60,5 @@ constexpr bool is_streamable_v = is_streamable<S, T>::value;
 /// \see is_streamable
 template <typename S, typename T>
 using is_streamable_t = typename is_streamable<S, T>::type;
-// @}
+/// @}
 }  // namespace tt

--- a/src/Utilities/TypeTraits/RemoveReferenceWrapper.hpp
+++ b/src/Utilities/TypeTraits/RemoveReferenceWrapper.hpp
@@ -8,7 +8,7 @@
 #include "Utilities/TypeTraits.hpp"
 
 namespace tt {
-// @{
+/// @{
 /*!
  * \ingroup TypeTraitsGroup
  * \brief Gets the underlying type if the type is a std::reference_wrapper,
@@ -55,9 +55,9 @@ struct remove_reference_wrapper<const volatile std::reference_wrapper<T>> {
 
 template <typename T>
 using remove_reference_wrapper_t = typename remove_reference_wrapper<T>::type;
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \ingroup TypeTraitsGroup
  * \brief Removes std::reference_wrapper, references, and cv qualifiers.
@@ -73,5 +73,5 @@ struct remove_cvref_wrap {
 
 template <typename T>
 using remove_cvref_wrap_t = typename remove_cvref_wrap<T>::type;
-// @}
+/// @}
 }  // namespace tt

--- a/src/Utilities/VectorAlgebra.hpp
+++ b/src/Utilities/VectorAlgebra.hpp
@@ -6,7 +6,7 @@
 #include "Utilities/Blaze.hpp"
 #include "Utilities/Gsl.hpp"
 
-// @{
+/// @{
 /// \ingroup UtilitiesGroup
 /// \brief Computes the outer product between two vectors.
 /// \details For vectors \f$A\f$ and \f$B\f$, the resulting outer product is
@@ -35,9 +35,9 @@ ResultVectorType outer_product(const LhsVectorType& lhs,
   outer_product(make_not_null(&result), lhs, rhs);
   return result;
 }
-// @}
+/// @}
 
-// @{
+/// @{
 /// \ingroup UtilitiesGroup
 /// \brief Creates or fills a vector with data from `to_repeat` copied
 /// `times_to_repeat`  times in sequence.
@@ -71,4 +71,4 @@ VectorType create_vector_of_n_copies(
   fill_with_n_copies(make_not_null(&result), to_copy, times_to_copy);
   return result;
 }
-// @}
+/// @}

--- a/tests/Unit/Framework/MockDistributedObject.hpp
+++ b/tests/Unit/Framework/MockDistributedObject.hpp
@@ -431,7 +431,7 @@ class MockDistributedObject {
     return number_of_actions;
   }
 
-  // @{
+  /// @{
   /// Returns the DataBox with the tags set from the GlobalCache and the
   /// tags in `AdditionalTagsList`. If the DataBox type is incorrect
   /// `std::terminate` is called.
@@ -448,7 +448,7 @@ class MockDistributedObject {
         tmpl::flatten<tmpl::list<initial_tags, AdditionalTagsList>>>;
     return boost::get<box_type>(box_);
   }
-  // @}
+  /// @}
 
   /// Walks through the variant of DataBoxes and retrieves the tag from the
   /// current one, if the current DataBox has the tag. If the current DataBox
@@ -468,12 +468,12 @@ class MockDistributedObject {
     return tag_is_retrievable_visitation<Tag>(box_);
   }
 
-  // @{
+  /// @{
   /// Returns the `boost::variant` of DataBoxes.
   auto& get_variant_box() noexcept { return box_; }
 
   const auto& get_variant_box() const noexcept { return box_; }
-  // @}
+  /// @}
 
   /// Force the next action invoked to be the `next_action_id`th action in the
   /// current phase.
@@ -654,7 +654,7 @@ class MockDistributedObject {
     return *global_cache_;
   }
 
-  // {@
+  /// @{
   /// Wrappers for charm++ informational functions.
 
   /// Number of processing elements
@@ -684,7 +684,7 @@ class MockDistributedObject {
 
   /// The local index for the given processing element on its node.
   int local_rank_of(int proc_index) const noexcept;
-  // @}
+  /// @}
 
  private:
   template <typename Action, typename... Args, size_t... Is>

--- a/tests/Unit/Framework/MockRuntimeSystem.hpp
+++ b/tests/Unit/Framework/MockRuntimeSystem.hpp
@@ -489,7 +489,7 @@ class MockRuntimeSystem {
         std::forward<Options>(opts)...);
   }
 
-  // @{
+  /// @{
   /// Invoke the simple action `Action` on the `Component` labeled by
   /// `array_index` immediately.
   template <typename Component, typename Action, typename Arg0,
@@ -511,9 +511,9 @@ class MockRuntimeSystem {
         .at(array_index)
         .template simple_action<Action>(true);
   }
-  // @}
+  /// @}
 
-  // @{
+  /// @{
   /// Invoke the threaded action `Action` on the `Component` labeled by
   /// `array_index` immediately.
   template <typename Component, typename Action, typename Arg0,
@@ -535,7 +535,7 @@ class MockRuntimeSystem {
         .at(array_index)
         .template threaded_action<Action>(true);
   }
-  // @}
+  /// @}
 
   /// Return true if there are no queued simple actions on the
   /// `Component` labeled by `array_index`.
@@ -671,7 +671,7 @@ class MockRuntimeSystem {
         .next_action_if_ready();
   }
 
-  // @{
+  /// @{
   /// Access the inboxes for a given component.
   template <typename Component>
   auto inboxes() noexcept -> std::unordered_map<
@@ -688,7 +688,7 @@ class MockRuntimeSystem {
           typename MockDistributedObject<Component>::inbox_tags_list>>& {
     return tuples::get<InboxesTag<Component>>(inboxes_);
   }
-  // @}
+  /// @}
 
   /// Find the set of array indices on Component where the specified
   /// inbox is not empty.

--- a/tests/Unit/Framework/MockRuntimeSystemFreeFunctions.hpp
+++ b/tests/Unit/Framework/MockRuntimeSystemFreeFunctions.hpp
@@ -187,7 +187,7 @@ void emplace_nodegroup_component_and_initialize(
       initial_values, std::forward<Options>(opts)...);
 }
 
-// @{
+/// @{
 /// Retrieves the DataBox with tags `TagsList` (omitting the `GlobalCache`
 /// and `add_from_options` tags) from the parallel component `Component` with
 /// index `array_index`.
@@ -207,7 +207,7 @@ auto& get_databox(const gsl::not_null<MockRuntimeSystem<Metavariables>*> runner,
       .at(array_index)
       .template get_databox<TagsList>();
 }
-// @}
+/// @}
 
 /// Get the index in the action list of the next action.
 template <typename Component, typename Metavariables>
@@ -229,7 +229,7 @@ const auto& get_databox_tag(
       .template get_databox_tag<Tag>();
 }
 
-// @{
+/// @{
 /// Returns the `InboxTag` from the parallel component `Component` with array
 /// index `array_index`.
 template <typename Component, typename InboxTag, typename Metavariables>
@@ -247,7 +247,7 @@ auto& get_inbox_tag(
   return tuples::get<InboxTag>(
       runner->template inboxes<Component>().at(array_index));
 }
-// @}
+/// @}
 
 /// Returns `true` if the current DataBox of `Component` with index
 /// `array_index` contains the tag `Tag`. If the tag is not contained, returns

--- a/tests/Unit/Helpers/DataStructures/MakeWithRandomValues.hpp
+++ b/tests/Unit/Helpers/DataStructures/MakeWithRandomValues.hpp
@@ -107,7 +107,7 @@ struct FillWithRandomValuesImpl<Variables<tmpl::list<Tags...>>,
 /// \endcond
 }  // namespace TestHelpers_detail
 
-// {@
+/// @{
 /// \ingroup TestingFrameworkGroup
 ///
 /// \brief A uniform distribution function object which redirects appropriately
@@ -156,7 +156,7 @@ class UniformCustomDistribution<bool> {
     return static_cast<bool>(gen() % 2);
   }
 };
-// @}
+/// @}
 
 /// \ingroup TestingFrameworkGroup
 /// \brief Fill an existing data structure with random values
@@ -170,7 +170,7 @@ void fill_with_random_values(
                                                          distribution);
 }
 
-// @{
+/// @{
 /// \ingroup TestingFrameworkGroup
 /// \brief Make a data structure and fill it with random values
 ///
@@ -209,7 +209,7 @@ ReturnType make_with_random_values(
   return make_with_random_values<ReturnType>(
       generator, make_not_null(&distribution), used_for_size);
 }
-// @}
+/// @}
 
 /// \ingroup TestingFrameworkGroup
 /// \brief Make a fixed-size data structure and fill with random values

--- a/tests/Unit/Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -93,7 +93,7 @@ void check_if_map_is_identity(const Map& map) noexcept {
   CHECK(map.is_identity());
 }
 
-// @{
+/// @{
 /*!
  * \ingroup TestingFrameworkGroup
  * \brief Given a Map `map`, checks that the jacobian gives expected results
@@ -145,9 +145,9 @@ void test_jacobian(
     }
   }
 }
-// @}
+/// @}
 
-// @{
+/// @{
 /*!
  * \ingroup TestingFrameworkGroup
  * \brief Given a Map `map`, checks that the inverse jacobian and jacobian
@@ -218,7 +218,7 @@ void test_inv_jacobian(
     }
   }
 }
-// @}
+/// @}
 
 /*!
  * \ingroup TestingFrameworkGroup
@@ -400,7 +400,7 @@ void test_coordinate_map_argument_types(
                  args...);
 }
 
-// @{
+/// @{
 /*!
  * \ingroup TestingFrameworkGroup
  * \brief Given a Map `map`, checks that the inverse map gives expected results
@@ -429,7 +429,7 @@ void test_inverse_map(
   REQUIRE(expected_test_point.has_value());
   CHECK_ITERABLE_APPROX(test_point, expected_test_point.value());
 }
-// @}
+/// @}
 
 /*!
  * \ingroup TestingFrameworkGroup

--- a/tests/Unit/Helpers/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TestHelpers.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TestHelpers.hpp
@@ -112,7 +112,7 @@ void check_impl(
   helper(serialize_and_deserialize(in_gh_damping_function));
 }
 }  // namespace detail
-// @{
+/// @{
 /*!
  * \ingroup TestingFrameworkGroup
  * \brief Test a DampingFunction by comparing to python functions
@@ -166,5 +166,5 @@ void check(DampingFunctionType in_gh_damping_function,
       python_function_prefix, used_for_size, random_value_bounds,
       function_of_time_names, member_args...);
 }
-// @}
+/// @}
 }  // namespace TestHelpers::GeneralizedHarmonic::ConstraintDamping

--- a/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/FirstOrderEllipticSolutionsTestHelpers.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/FirstOrderEllipticSolutionsTestHelpers.hpp
@@ -135,7 +135,7 @@ void verify_solution_impl(
 /// \ingroup TestingFrameworkGroup
 /// Test that the `solution` numerically solves the `System` on the given grid
 /// for the given tolerance
-// @{
+/// @{
 template <typename System, typename SolutionType, typename... Maps,
           typename... FluxesArgs, typename... SourcesArgs>
 void verify_solution(
@@ -183,7 +183,7 @@ void verify_solution(
       tuples::apply<typename System::sources_computer::argument_tags>(
           get_items, background_fields));
 }
-// @}
+/// @}
 
 /*!
  * \ingroup TestingFrameworkGroup

--- a/tests/Unit/Helpers/PointwiseFunctions/Hydro/EquationsOfState/TestHelpers.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/Hydro/EquationsOfState/TestHelpers.hpp
@@ -178,7 +178,7 @@ void check_impl(
 }
 }  // namespace detail
 
-// @{
+/// @{
 /*!
  * \ingroup TestingFrameworkGroup
  * \brief Test an equation of state by comparing to python functions
@@ -213,6 +213,6 @@ void check(EosType in_eos, const std::string& python_function_prefix,
                          std::make_unique<EosType>(std::move(in_eos))),
                      python_function_prefix, used_for_size, member_args...);
 }
-// @}
+/// @}
 }  // namespace EquationsOfState
 }  // namespace TestHelpers

--- a/tests/Unit/Helpers/PointwiseFunctions/MathFunctions/TestHelpers.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/MathFunctions/TestHelpers.hpp
@@ -119,7 +119,7 @@ void check_impl(
   }
 }
 }  // namespace detail
-// @{
+/// @{
 /*!
  * \ingroup TestingFrameworkGroup
  * \brief Test a MathFunction by comparing to python functions
@@ -160,6 +160,6 @@ void check(MathFunctionType in_math_function,
       python_function_prefix, used_for_size, random_value_bounds,
       member_args...);
 }
-// @}
+/// @}
 }  // namespace MathFunctions
 }  // namespace TestHelpers

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -666,6 +666,33 @@ check_throws_test() {
 }
 standard_checks+=(check_throws)
 
+# Check for typos similar to Doxygen groups
+check_dox_groups() {
+    is_c++ "$1" && staged_grep -E "^\s*//+\s*[\{\}\(\)]*@[\{\}\(\)]*" "$1" \
+            | grep -v -E "(^\s*/// @\{|^\s*/// @\})"
+}
+check_dox_groups_report() {
+    echo "Found a likely typo similar to a valid doxygen grouping"
+    echo "Use balanced /// @{ and /// @} (on their own lines) to"\
+         " create doxygen groups"
+    pretty_grep -E "^\s*//+\s*[\{\}\(\)]*@[\{\}\(\)]*" "$1" | \
+        grep -v -E "(/// @{|/// @})"
+}
+check_dox_groups_test() {
+    test_check pass foo.hpp '/// @{'
+    test_check pass foo.hpp '/// @}'
+    test_check pass foo.txt '// @('
+    test_check fail foo.hpp '// @{'
+    test_check fail foo.hpp '// @}'
+    test_check fail foo.hpp '//@{'
+    test_check fail foo.hpp '//@}'
+    test_check fail foo.hpp '// {@'
+    test_check fail foo.hpp '// }@'
+    test_check fail foo.hpp '///@('
+    test_check fail foo.hpp '///@)'
+}
+standard_checks+=(check_dox_groups)
+
 # Prevent editing RunSingleTest files. We may need to occasionally update these
 # files, but it's at least less than once a year.
 #


### PR DESCRIPTION
## Proposed changes

These grouping symbols are broken in a lot of places -- I'm not sure whether the doxygen syntax changed at some point, but most of our 'grouped' documentation doesn't render with all of the functions in the groups.
This updates all of the grouping symbols to a version that I've verified works in the container, and adds a check for common typos.

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->
Any incorrect doxygen grouping symbols (e.g. `// @{`) will have to be updated to the correct versions (e.g. `/// @{`).
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
