### PR TITLE
Fix circular dependency for Parallel/PhaseControl

### DIFF
--- a/src/Evolution/Executables/Burgers/CMakeLists.txt
+++ b/src/Evolution/Executables/Burgers/CMakeLists.txt
@@ -15,6 +15,7 @@ set(LIBS_TO_LINK
   LinearOperators
   Options
   Parallel
+  PhaseControl
   Time
   Utilities
   )

--- a/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Executables/GeneralizedHarmonic/CMakeLists.txt
@@ -31,6 +31,7 @@ set(LIBS_TO_LINK
   MathFunctions
   Options
   Parallel
+  PhaseControl
   Time
   Utilities
   )

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -29,6 +29,7 @@ set(LIBS_TO_LINK
   RelativisticEulerSolutions
   Options
   Parallel
+  PhaseControl
   Time
   Utilities
   ValenciaDivClean

--- a/src/Evolution/Executables/NewtonianEuler/CMakeLists.txt
+++ b/src/Evolution/Executables/NewtonianEuler/CMakeLists.txt
@@ -52,6 +52,7 @@ set(LIBS_TO_LINK
   NewtonianEulerSources
   Options
   Parallel
+  PhaseControl
   Time
   Utilities
   )

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/CMakeLists.txt
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/CMakeLists.txt
@@ -18,6 +18,7 @@ set(LIBS_TO_LINK
   M1GreySolutions
   Options
   Parallel
+  PhaseControl
   Time
   Utilities
   )

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/CMakeLists.txt
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/CMakeLists.txt
@@ -18,6 +18,7 @@ set(LIBS_TO_LINK
   Time
   Options
   Parallel
+  PhaseControl
   Utilities
   Valencia
   )

--- a/src/Evolution/Executables/ScalarWave/CMakeLists.txt
+++ b/src/Evolution/Executables/ScalarWave/CMakeLists.txt
@@ -16,6 +16,7 @@ set(LIBS_TO_LINK
   Time
   Options
   Parallel
+  PhaseControl
   Utilities
   WaveEquationSolutions
   )

--- a/src/Parallel/CMakeLists.txt
+++ b/src/Parallel/CMakeLists.txt
@@ -37,6 +37,7 @@ spectre_target_headers(
   MaxInlineMethodsReached.hpp
   NodeLock.hpp
   ParallelComponentHelpers.hpp
+  PhaseControlReductionHelpers.hpp
   PhaseDependentActionList.hpp
   Printf.hpp
   PupStlCpp11.hpp
@@ -55,7 +56,6 @@ target_link_libraries(
   INTERFACE
   Boost::boost
   DataStructures
-  EventsAndTriggers
   Informer
   Options
   PUBLIC

--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -19,7 +19,7 @@
 #include "Parallel/CreateFromOptions.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
-#include "Parallel/PhaseControl/PhaseControlTags.hpp"
+#include "Parallel/PhaseControlReductionHelpers.hpp"
 #include "Parallel/Printf.hpp"
 #include "Parallel/Reduction.hpp"
 #include "Parallel/TypeTraits.hpp"

--- a/src/Parallel/PhaseControl/CMakeLists.txt
+++ b/src/Parallel/PhaseControl/CMakeLists.txt
@@ -1,6 +1,10 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+set(LIBRARY PhaseControl)
+
+add_spectre_library(${LIBRARY} INTERFACE)
+
 spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
@@ -9,4 +13,14 @@ spectre_target_headers(
   PhaseChange.hpp
   PhaseControlTags.hpp
   VisitAndReturn.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE
+  DataStructures
+  EventsAndTriggers
+  Options
+  Parallel
+  Utilities
   )

--- a/src/Parallel/PhaseControl/PhaseControlTags.hpp
+++ b/src/Parallel/PhaseControl/PhaseControlTags.hpp
@@ -5,92 +5,20 @@
 
 #include <memory>
 #include <type_traits>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
-#include "Parallel/PhaseControl/PhaseChange.hpp"
-#include "Parallel/Reduction.hpp"
 #include "Parallel/Serialize.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
 #include "Utilities/Registration.hpp"
 #include "Utilities/TMPL.hpp"
-#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+template <typename PhaseChangeRegistrars>
+struct PhaseChange;
+/// \endcond
 
 namespace PhaseControl {
-
-/// A type for denoting a piece of data for deciding a phase change.
-///
-/// `Tag` is intended to be a tag (with a type) for indexing a
-/// `tuples::TaggedTuple`, and `CombineMethod` is intended to be a
-/// `Parallel::ReductionDatum`-compatible invokable for combining the `type` of
-/// the `Tag`. The `MainCombineMethod` is provided to give flexibility for a
-/// different method of combination at the top level of the hierarchy (so, in
-/// the case of phase control reductions, performed by the main chare to combine
-/// reductions from different chares)
-template <typename Tag, typename CombineMethod,
-          typename MainCombineMethod = CombineMethod>
-struct TagAndCombine : Tag {
-  using tag = Tag;
-  using combine_method = CombineMethod;
-  using main_combine_method = MainCombineMethod;
-};
-
-/// A flexible combine invokable that combines into a `tuples::TaggedTuple` a
-/// new `tuples::TaggedTuple`, and combines according to type aliases
-/// `combination_method`s that are required to be defined in each tag.
-struct TaggedTupleCombine {
-  template <typename... Tags>
-  tuples::TaggedTuple<Tags...> operator()(
-      tuples::TaggedTuple<Tags...> current_state,
-      const tuples::TaggedTuple<Tags...>& element) {
-    tmpl::for_each<tmpl::list<Tags...>>(
-        [&current_state, &element](auto tag_v) noexcept {
-          using tag = typename decltype(tag_v)::type;
-          tuples::get<tag>(current_state) = typename tag::combine_method{}(
-              tuples::get<tag>(current_state), tuples::get<tag>(element));
-        });
-    return current_state;
-  }
-};
-
-/// A flexible combine invokable that combines into a `tuples::TaggedTuple` a
-/// new `tuples::TaggedTuple` with a subset of the original tags, and combines
-/// according to type aliases `main_combine_method`s that are required to be
-/// defined in each tag.
-///
-/// \note This is _not_ usable with charm++ reductions; it mutates the current
-/// state in-place. This is constructed for the use-case where the main chare
-/// stores a persistent data structure and combines reduction data as it arrives
-/// from the other chares.
-struct TaggedTupleMainCombine {
-  template <typename... CurrentTags, typename... CombineTags>
-  static void apply(
-      const gsl::not_null<tuples::TaggedTuple<CurrentTags...>*> current_state,
-      const tuples::TaggedTuple<CombineTags...>& element) {
-    tmpl::for_each<tmpl::list<CombineTags...>>(
-        [&current_state, &element](auto tag_v) noexcept {
-          using tag = typename decltype(tag_v)::type;
-          tuples::get<tag>(*current_state) =
-              typename tag::main_combine_method{}(
-                  tuples::get<tag>(*current_state), tuples::get<tag>(element));
-        });
-  }
-};
-
-/// A `Parallel::ReductionData` with a single `Parallel::ReductionDatum` for a
-/// given tagged tuple type determined by `TagsPresent`, and performs the
-/// combine according to `TagsAndCombines`, which must be a `tmpl::list` of
-/// `PhaseControl::TagAndCombine`s.
-///
-/// Each tag in the `TagsAndCombinesPresent` may either be a `TagsAndCombines`
-/// or otherise define all three type traits `type`, `combine_method`, and
-/// `main_combine_method`.
-template <typename TagsAndCombinesPresent, typename TagsAndCombines>
-using reduction_data = Parallel::ReductionData<Parallel::ReductionDatum<
-    tuples::tagged_tuple_from_typelist<TagsAndCombinesPresent>,
-    TaggedTupleCombine>>;
-
 namespace OptionTags {
 /// Option tag for the collection of triggers that indicate synchronization
 /// points at which phase changes should be considered, and the associated

--- a/src/Parallel/PhaseControlReductionHelpers.hpp
+++ b/src/Parallel/PhaseControlReductionHelpers.hpp
@@ -1,0 +1,84 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Parallel/Reduction.hpp"
+#include "Parallel/Serialize.hpp"
+#include "Utilities/Registration.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace PhaseControl {
+
+/// A type for denoting a piece of data for deciding a phase change.
+///
+/// `Tag` is intended to be a tag (with a type) for indexing a
+/// `tuples::TaggedTuple`, and `CombineMethod` is intended to be a
+/// `Parallel::ReductionDatum`-compatible invokable for combining the `type` of
+/// the `Tag`. The `MainCombineMethod` is provided to give flexibility for a
+/// different method of combination at the top level of the hierarchy (so, in
+/// the case of phase control reductions, performed by the main chare to combine
+/// reductions from different chares)
+template <typename Tag, typename CombineMethod,
+          typename MainCombineMethod = CombineMethod>
+struct TagAndCombine : Tag {
+  using tag = Tag;
+  using combine_method = CombineMethod;
+  using main_combine_method = MainCombineMethod;
+};
+
+/// A flexible combine invokable that combines into a `tuples::TaggedTuple` a
+/// new `tuples::TaggedTuple`, and combines according to type aliases
+/// `combination_method`s that are required to be defined in each tag.
+struct TaggedTupleCombine {
+  template <typename... Tags>
+  tuples::TaggedTuple<Tags...> operator()(
+      tuples::TaggedTuple<Tags...> current_state,
+      const tuples::TaggedTuple<Tags...>& element) {
+    tmpl::for_each<tmpl::list<Tags...>>(
+        [&current_state, &element](auto tag_v) noexcept {
+          using tag = typename decltype(tag_v)::type;
+          tuples::get<tag>(current_state) = typename tag::combine_method{}(
+              tuples::get<tag>(current_state), tuples::get<tag>(element));
+        });
+    return current_state;
+  }
+};
+
+/// A flexible combine invokable that combines into a `tuples::TaggedTuple` a
+/// new `tuples::TaggedTuple` with a subset of the original tags, and combines
+/// according to type aliases `main_combine_method`s that are required to be
+/// defined in each tag.
+///
+/// \note This is _not_ usable with charm++ reductions; it mutates the current
+/// state in-place. This is constructed for the use-case where the main chare
+/// stores a persistent data structure and combines reduction data as it arrives
+/// from the other chares.
+struct TaggedTupleMainCombine {
+  template <typename... CurrentTags, typename... CombineTags>
+  static void apply(
+      const gsl::not_null<tuples::TaggedTuple<CurrentTags...>*> current_state,
+      const tuples::TaggedTuple<CombineTags...>& element) {
+    tmpl::for_each<tmpl::list<CombineTags...>>([&current_state,
+                                                &element](auto tag_v) noexcept {
+      using tag = typename decltype(tag_v)::type;
+      tuples::get<tag>(*current_state) = typename tag::main_combine_method{}(
+          tuples::get<tag>(*current_state), tuples::get<tag>(element));
+    });
+  }
+};
+
+/// A `Parallel::ReductionData` with a single `Parallel::ReductionDatum` for a
+/// given tagged tuple type determined by `TagsPresent`, and performs the
+/// combine according to `TagsAndCombines`, which must be a `tmpl::list` of
+/// `PhaseControl::TagAndCombine`s.
+///
+/// Each tag in the `TagsAndCombinesPresent` may either be a `TagsAndCombines`
+/// or otherise define all three type traits `type`, `combine_method`, and
+/// `main_combine_method`.
+template <typename TagsAndCombinesPresent, typename TagsAndCombines>
+using reduction_data = Parallel::ReductionData<Parallel::ReductionDatum<
+    tuples::tagged_tuple_from_typelist<TagsAndCombinesPresent>,
+    TaggedTupleCombine>>;
+}  // namespace PhaseControl

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -27,6 +27,7 @@ function(add_algorithm_test EXECUTABLE_NAME)
     Informer
     Options
     Parallel
+    PhaseControl
     SystemUtilities
     Utilities
     )

--- a/tests/Unit/Parallel/PhaseControl/CMakeLists.txt
+++ b/tests/Unit/Parallel/PhaseControl/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(
   DataStructures
   Options
   Parallel
+  PhaseControl
   Time
   Utilities
   )

--- a/tests/Unit/Parallel/Test_PhaseChangeMain.cpp
+++ b/tests/Unit/Parallel/Test_PhaseChangeMain.cpp
@@ -20,6 +20,7 @@
 #include "Parallel/Main.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/PhaseControl/PhaseControlTags.hpp"
+#include "Parallel/PhaseControlReductionHelpers.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"


### PR DESCRIPTION
## Proposed changes

Fixes #3163 by creating a new library for the `PhaseControl` directory, and moving the tags to `Parallel`

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->
Includes will need to be updated to `Parallel/PhaseControlTags.hpp`, and anything that uses the `PhaseControl` features likely needs to link the `PhaseControl` library.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
