### PR TITLE
Add SphericalCompression TimeDependence

### DIFF
--- a/src/Domain/Creators/TimeDependence/CMakeLists.txt
+++ b/src/Domain/Creators/TimeDependence/CMakeLists.txt
@@ -12,6 +12,7 @@ spectre_target_sources(
   CubicScale.cpp
   None.cpp
   RegisterDerivedWithCharm.cpp
+  SphericalCompression.cpp
   UniformRotationAboutZAxis.cpp
   UniformTranslation.cpp
   )
@@ -26,6 +27,7 @@ spectre_target_headers(
   GenerateCoordinateMap.hpp
   None.hpp
   RegisterDerivedWithCharm.hpp
+  SphericalCompression.hpp
   TimeDependence.hpp
   UniformRotationAboutZAxis.hpp
   UniformTranslation.hpp

--- a/src/Domain/Creators/TimeDependence/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/Creators/TimeDependence/RegisterDerivedWithCharm.cpp
@@ -16,6 +16,7 @@
 #include "Domain/Creators/TimeDependence/Composition.tpp"
 #include "Domain/Creators/TimeDependence/CubicScale.hpp"
 #include "Domain/Creators/TimeDependence/None.hpp"
+#include "Domain/Creators/TimeDependence/SphericalCompression.hpp"
 #include "Domain/Creators/TimeDependence/TimeDependence.hpp"
 #include "Domain/Creators/TimeDependence/UniformRotationAboutZAxis.hpp"
 #include "Domain/Creators/TimeDependence/UniformTranslation.hpp"

--- a/src/Domain/Creators/TimeDependence/SphericalCompression.cpp
+++ b/src/Domain/Creators/TimeDependence/SphericalCompression.cpp
@@ -1,0 +1,129 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Creators/TimeDependence/SphericalCompression.hpp"
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <ostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/MapInstantiationMacros.hpp"
+#include "Domain/Creators/TimeDependence/TimeDependence.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace domain {
+namespace creators::time_dependence {
+
+SphericalCompression::SphericalCompression(
+    const double initial_time,
+    const std::optional<double> initial_expiration_delta_t,
+    const double min_radius, const double max_radius,
+    const std::array<double, 3> center, const double initial_value,
+    const double initial_velocity, const double initial_acceleration,
+    std::string function_of_time_name, const Options::Context& context)
+    : initial_time_(initial_time),
+      initial_expiration_delta_t_(initial_expiration_delta_t),
+      min_radius_(min_radius),
+      max_radius_(max_radius),
+      center_(center),
+      initial_value_(initial_value),
+      initial_velocity_(initial_velocity),
+      initial_acceleration_(initial_acceleration),
+      function_of_time_name_(std::move(function_of_time_name)) {
+  if (min_radius >= max_radius) {
+    PARSE_ERROR(context,
+                "Tried to create a SphericalCompression TimeDependence, but "
+                "the minimum radius ("
+                    << min_radius << ") is not less than the maximum radius ("
+                    << max_radius << ")");
+  }
+}
+
+std::unique_ptr<TimeDependence<3>> SphericalCompression::get_clone()
+    const noexcept {
+  return std::make_unique<SphericalCompression>(
+      initial_time_, initial_expiration_delta_t_, min_radius_, max_radius_,
+      center_, initial_value_, initial_velocity_, initial_acceleration_,
+      function_of_time_name_);
+}
+
+std::vector<
+    std::unique_ptr<domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, 3>>>
+SphericalCompression::block_maps(
+    const size_t number_of_blocks) const noexcept {
+  ASSERT(number_of_blocks > 0,
+         "Must have at least one block on which to create a map.");
+  std::vector<std::unique_ptr<
+      domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, 3>>>
+      result{number_of_blocks};
+  result[0] = std::make_unique<MapForComposition>(map_for_composition());
+  for (size_t i = 1; i < number_of_blocks; ++i) {
+    result[i] = result[0]->get_clone();
+  }
+  return result;
+}
+
+std::unordered_map<std::string,
+                   std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+SphericalCompression::functions_of_time() const noexcept {
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      result{};
+  result[function_of_time_name_] =
+      std::make_unique<FunctionsOfTime::PiecewisePolynomial<3>>(
+          initial_time_,
+          std::array<DataVector, 4>{{{initial_value_},
+                                     {initial_velocity_},
+                                     {initial_acceleration_},
+                                     {0.0}}},
+          initial_expiration_delta_t_
+              ? initial_time_ + *initial_expiration_delta_t_
+              : std::numeric_limits<double>::max());
+  return result;
+}
+
+auto SphericalCompression::map_for_composition() const noexcept
+    -> MapForComposition {
+  return MapForComposition{SphericalCompressionMap{
+      function_of_time_name_, min_radius_, max_radius_, center_}};
+}
+
+bool operator==(const SphericalCompression& lhs,
+                const SphericalCompression& rhs) noexcept {
+  return lhs.initial_time_ == rhs.initial_time_ and
+         lhs.initial_expiration_delta_t_ == rhs.initial_expiration_delta_t_ and
+         lhs.min_radius_ == rhs.min_radius_ and
+         lhs.max_radius_ == rhs.max_radius_ and lhs.center_ == rhs.center_ and
+         lhs.initial_value_ == rhs.initial_value_ and
+         lhs.initial_velocity_ == rhs.initial_velocity_ and
+         lhs.initial_acceleration_ == rhs.initial_acceleration_ and
+         lhs.function_of_time_name_ == rhs.function_of_time_name_;
+}
+
+bool operator!=(const SphericalCompression& lhs,
+                const SphericalCompression& rhs) noexcept {
+  return not(lhs == rhs);
+}
+}  // namespace creators::time_dependence
+
+using SphericalCompressionMap3d =
+    CoordinateMaps::TimeDependent::SphericalCompression<false>;
+
+INSTANTIATE_MAPS_FUNCTIONS(((SphericalCompressionMap3d)), (Frame::Grid),
+                           (Frame::Inertial), (double, DataVector))
+
+}  // namespace domain

--- a/src/Domain/Creators/TimeDependence/SphericalCompression.hpp
+++ b/src/Domain/Creators/TimeDependence/SphericalCompression.hpp
@@ -1,0 +1,181 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/SphericalCompression.hpp"
+#include "Domain/Creators/TimeDependence/GenerateCoordinateMap.hpp"
+#include "Domain/Creators/TimeDependence/TimeDependence.hpp"
+#include "Options/Auto.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace domain {
+namespace FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace FunctionsOfTime
+namespace CoordinateMaps::TimeDependent {
+template <bool InertiorMap>
+class SphericalCompression;
+}  // namespace CoordinateMaps::TimeDependent
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+class CoordinateMap;
+}  // namespace domain
+
+namespace Frame {
+struct Grid;
+struct Inertial;
+}  // namespace Frame
+/// \endcond
+
+namespace domain::creators::time_dependence {
+/*!
+ * \brief A spherical compression about some center, as given by
+ * domain::CoordinateMaps::TimeDependent::SphericalCompression<false>.
+ *
+ * \details This TimeDependence is suitable for use on a spherical shell,
+ * where MinRadius and MaxRadius are the inner and outer radii of the shell,
+ * respectively.
+ */
+class SphericalCompression final : public TimeDependence<3> {
+ private:
+  using SphericalCompressionMap =
+      domain::CoordinateMaps::TimeDependent::SphericalCompression<false>;
+
+ public:
+  using maps_list =
+      tmpl::list<domain::CoordinateMap<Frame::Grid, Frame::Inertial,
+                                       SphericalCompressionMap>>;
+
+  static constexpr size_t mesh_dim = 3;
+
+  /// \brief The initial time of the function of time.
+  struct InitialTime {
+    using type = double;
+    static constexpr Options::String help = {
+        "The initial time of the function of time"};
+  };
+  /// \brief The time interval for updates of the functions of time.
+  struct InitialExpirationDeltaT {
+    using type = Options::Auto<double>;
+    static constexpr Options::String help = {
+        "The initial time interval for updates of the functions of time. If "
+        "Auto, then the functions of time do not expire, nor can they be "
+        "updated."};
+  };
+  /// \brief Minimum radius for the SphericalCompression map
+  struct MinRadius {
+    using type = double;
+    static constexpr Options::String help = {
+        "Min radius for SphericalCompression map."};
+  };
+  /// \brief Maximum radius for the SphericalCompression map
+  struct MaxRadius {
+    using type = double;
+    static constexpr Options::String help = {
+        "Max radius for SphericalCompression map."};
+  };
+  /// \brief Center for the SphericalCompression map
+  struct Center {
+    using type = std::array<double, 3>;
+    static constexpr Options::String help = {
+        "Center for the SphericalCompression map."};
+  };
+  /// \brief Initial value for function of time for the spherical compression
+  struct InitialValue {
+    using type = double;
+    static constexpr Options::String help = {
+        "Spherical compression value at initial time."};
+  };
+  /// \brief Initial radial velocity for the function of time for the spherical
+  /// compression
+  struct InitialVelocity {
+    using type = double;
+    static constexpr Options::String help = {
+        "Spherical compression initial radial velocity."};
+  };
+  /// \brief Initial radial acceleration for the function of time for the
+  /// spherical compression
+  struct InitialAcceleration {
+    using type = double;
+    static constexpr Options::String help = {
+        "Spherical compression initial radial acceleration."};
+  };
+  /// \brief The name of the functions of time to be added to the added to the
+  /// DataBox for the spherical compression
+  struct FunctionOfTimeName {
+    using type = std::string;
+    static constexpr Options::String help = {
+        "Names of SphericalCompression function of time."};
+  };
+
+  using MapForComposition =
+      detail::generate_coordinate_map_t<tmpl::list<SphericalCompressionMap>>;
+
+  using options = tmpl::list<InitialTime, InitialExpirationDeltaT, MinRadius,
+                             MaxRadius, Center, InitialValue, InitialVelocity,
+                             InitialAcceleration, FunctionOfTimeName>;
+
+  static constexpr Options::String help = {"A spherical compression."};
+
+  SphericalCompression() = default;
+  ~SphericalCompression() override = default;
+  SphericalCompression(const SphericalCompression&) = delete;
+  SphericalCompression(SphericalCompression&&) noexcept = default;
+  SphericalCompression& operator=(const SphericalCompression&) = delete;
+  SphericalCompression& operator=(SphericalCompression&&) noexcept = default;
+
+  SphericalCompression(double initial_time,
+                       std::optional<double> initial_expiration_delta_t,
+                       double min_radius, double max_radius,
+                       std::array<double, 3> center, double initial_value,
+                       double initial_velocity, double initial_acceleration,
+                       std::string function_of_time_name = "LambdaFactorA0",
+                       const Options::Context& context = {});
+
+  auto get_clone() const noexcept
+      -> std::unique_ptr<TimeDependence<mesh_dim>> override;
+
+  auto block_maps(size_t number_of_blocks) const noexcept
+      -> std::vector<std::unique_ptr<domain::CoordinateMapBase<
+          Frame::Grid, Frame::Inertial, mesh_dim>>> override;
+
+  auto functions_of_time() const noexcept -> std::unordered_map<
+      std::string,
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override;
+
+  /// Returns the map for each block to be used in a composition of
+  /// `TimeDependence`s.
+  MapForComposition map_for_composition() const noexcept;
+
+ private:
+  // NOLINTNEXTLINE(readability-redundant-declaration)
+  friend bool operator==(const SphericalCompression& lhs,
+                         const SphericalCompression& rhs) noexcept;
+
+  double initial_time_{std::numeric_limits<double>::signaling_NaN()};
+  std::optional<double> initial_expiration_delta_t_{};
+  double min_radius_{std::numeric_limits<double>::signaling_NaN()};
+  double max_radius_{std::numeric_limits<double>::signaling_NaN()};
+  std::array<double, 3> center_{};
+  double initial_value_{std::numeric_limits<double>::signaling_NaN()};
+  double initial_velocity_{std::numeric_limits<double>::signaling_NaN()};
+  double initial_acceleration_{std::numeric_limits<double>::signaling_NaN()};
+  std::string function_of_time_name_{};
+};
+
+bool operator!=(const SphericalCompression& lhs,
+                const SphericalCompression& rhs) noexcept;
+}  // namespace domain::creators::time_dependence

--- a/src/Domain/Creators/TimeDependence/TimeDependence.hpp
+++ b/src/Domain/Creators/TimeDependence/TimeDependence.hpp
@@ -25,13 +25,12 @@ struct Grid;
 struct Inertial;
 }  // namespace Frame
 
-namespace domain {
-namespace creators {
-namespace time_dependence {
+namespace domain::creators::time_dependence {
 template <size_t MeshDim>
 class CubicScale;
 template <size_t MeshDim>
 class None;
+class SphericalCompression;
 template <size_t MeshDim>
 class UniformRotationAboutZAxis;
 template <size_t MeshDim>
@@ -40,13 +39,10 @@ template <typename TimeDependenceCompTag0, typename... TimeDependenceCompTags>
 class Composition;
 template <typename TimeDep, size_t Suffix>
 struct TimeDependenceCompositionTag;
-}  // namespace time_dependence
-}  // namespace creators
-}  // namespace domain
+}  // namespace domain::creators::time_dependence
 /// \endcond
 
-namespace domain {
-namespace creators {
+namespace domain::creators {
 /// \ingroup ComputationalDomainGroup
 /// \brief Classes and functions for adding time dependence to a domain.
 namespace time_dependence {
@@ -62,7 +58,7 @@ struct TimeDependence {
   using creatable_classes_1d = tmpl::list<>;
   using creatable_classes_2d = tmpl::list<UniformRotationAboutZAxis<2>>;
   using creatable_classes_3d = tmpl::list<
-      UniformRotationAboutZAxis<3>,
+      SphericalCompression, UniformRotationAboutZAxis<3>,
       Composition<
           TimeDependenceCompositionTag<CubicScale<3>,
                                        std::numeric_limits<size_t>::max()>,
@@ -111,8 +107,7 @@ struct TimeDependence {
 template <size_t MeshDim>
 TimeDependence<MeshDim>::~TimeDependence() = default;
 }  // namespace time_dependence
-}  // namespace creators
-}  // namespace domain
+}  // namespace creators::namespace domain
 
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
@@ -121,5 +116,6 @@ TimeDependence<MeshDim>::~TimeDependence() = default;
 #include "Domain/Creators/TimeDependence/Composition.hpp"
 #include "Domain/Creators/TimeDependence/CubicScale.hpp"
 #include "Domain/Creators/TimeDependence/None.hpp"
+#include "Domain/Creators/TimeDependence/SphericalCompression.hpp"
 #include "Domain/Creators/TimeDependence/UniformRotationAboutZAxis.hpp"
 #include "Domain/Creators/TimeDependence/UniformTranslation.hpp"

--- a/tests/Unit/Domain/Creators/TimeDependence/CMakeLists.txt
+++ b/tests/Unit/Domain/Creators/TimeDependence/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_Composition.cpp
   Test_CubicScale.cpp
   Test_None.cpp
+  Test_SphericalCompression.cpp
   Test_UniformRotationAboutZAxis.cpp
   Test_UniformTranslation.cpp
   )

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_SphericalCompression.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_SphericalCompression.cpp
@@ -1,0 +1,242 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+#include <random>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/Creators/TimeDependence/SphericalCompression.hpp"
+#include "Domain/Creators/TimeDependence/TimeDependence.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/Domain/Creators/TimeDependence/TestHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace domain::creators::time_dependence {
+
+namespace {
+using SphericalCompressionMap =
+    domain::CoordinateMaps::TimeDependent::SphericalCompression<false>;
+
+using ConcreteMap = domain::CoordinateMap<Frame::Grid, Frame::Inertial,
+                                          SphericalCompressionMap>;
+
+ConcreteMap create_coord_map(const std::string& f_of_t_name,
+                             const double min_radius, const double max_radius,
+                             const std::array<double, 3>& center) {
+  return ConcreteMap{
+      {SphericalCompressionMap{f_of_t_name, min_radius, max_radius, center}}};
+}
+
+void test(const std::unique_ptr<TimeDependence<3>>& time_dep_unique_ptr,
+          const double initial_time, const std::string& f_of_t_name,
+          const double min_radius, const double max_radius,
+          const std::array<double, 3>& center) noexcept {
+  MAKE_GENERATOR(gen);
+  CAPTURE(initial_time);
+  CAPTURE(f_of_t_name);
+  CAPTURE(min_radius);
+  CAPTURE(max_radius);
+  CAPTURE(center);
+
+  CHECK_FALSE(time_dep_unique_ptr->is_none());
+
+  // We downcast to the expected derived class to make sure that factory
+  // creation worked correctly. In order to maximize code reuse this check is
+  // done here as opposed to separately elsewhere.
+  const auto* const time_dep =
+      dynamic_cast<const SphericalCompression*>(time_dep_unique_ptr.get());
+  REQUIRE(time_dep != nullptr);
+
+  // Test coordinate maps
+  UniformCustomDistribution<size_t> dist_size_t{1, 10};
+  const size_t num_blocks = dist_size_t(gen);
+  CAPTURE(num_blocks);
+
+  const auto expected_block_map =
+      create_coord_map(f_of_t_name, min_radius, max_radius, center);
+
+  const auto block_maps = time_dep_unique_ptr->block_maps(num_blocks);
+  for (const auto& block_map_unique_ptr : block_maps) {
+    const auto* const block_map =
+        dynamic_cast<const ConcreteMap*>(block_map_unique_ptr.get());
+    REQUIRE(block_map != nullptr);
+    CHECK(*block_map == expected_block_map);
+  }
+
+  // Test functions of time
+  const auto functions_of_time = time_dep_unique_ptr->functions_of_time();
+  REQUIRE(functions_of_time.size() == 1);
+
+  // Test map for composition
+  CHECK(time_dep->map_for_composition() == expected_block_map);
+
+  // For a random point at a random time check that the values agree. This is to
+  // check that the internals were assigned the correct function of times.
+  // The points are are drawn from the positive x/y/z quadrant in a that
+  // guarantees that they are in the region where the map is valid (min_radius
+  // <= radius <= max_radius), provided that min_radius is sufficiently small
+  // compared to max_radius. This could be generalized, but in practice,
+  // this map will not be used in cases where min_radius and max_radius
+  // are very close to each other.
+  TIME_DEPENDENCE_GENERATE_COORDS(make_not_null(&gen), 3, min_radius * 1.001,
+                                  max_radius * 0.5);
+
+  for (const auto& block_map : block_maps) {
+    // We've checked equivalence above
+    // (CHECK(*block_map == expected_block_map);), but have sometimes been
+    // burned by incorrect operator== implementations so we check that the
+    // mappings behave as expected.
+    const double time_offset = dist(gen) + 1.2;
+    CHECK_ITERABLE_APPROX(
+        expected_block_map(grid_coords_dv, initial_time + time_offset,
+                           functions_of_time),
+        (*block_map)(grid_coords_dv, initial_time + time_offset,
+                     functions_of_time));
+    CHECK_ITERABLE_APPROX(
+        expected_block_map(grid_coords_double, initial_time + time_offset,
+                           functions_of_time),
+        (*block_map)(grid_coords_double, initial_time + time_offset,
+                     functions_of_time));
+
+    CHECK_ITERABLE_APPROX(
+        *expected_block_map.inverse(inertial_coords_double,
+                                    initial_time + time_offset,
+                                    functions_of_time),
+        *block_map->inverse(inertial_coords_double, initial_time + time_offset,
+                            functions_of_time));
+
+    CHECK_ITERABLE_APPROX(
+        expected_block_map.inv_jacobian(
+            grid_coords_dv, initial_time + time_offset, functions_of_time),
+        block_map->inv_jacobian(grid_coords_dv, initial_time + time_offset,
+                                functions_of_time));
+    CHECK_ITERABLE_APPROX(
+        expected_block_map.inv_jacobian(
+            grid_coords_double, initial_time + time_offset, functions_of_time),
+        block_map->inv_jacobian(grid_coords_double, initial_time + time_offset,
+                                functions_of_time));
+
+    CHECK_ITERABLE_APPROX(
+        expected_block_map.jacobian(grid_coords_dv, initial_time + time_offset,
+                                    functions_of_time),
+        block_map->jacobian(grid_coords_dv, initial_time + time_offset,
+                            functions_of_time));
+    CHECK_ITERABLE_APPROX(
+        expected_block_map.jacobian(
+            grid_coords_double, initial_time + time_offset, functions_of_time),
+        block_map->jacobian(grid_coords_double, initial_time + time_offset,
+                            functions_of_time));
+  }
+}
+
+void test_equivalence() noexcept {
+  SphericalCompression sc0{
+      1.0, 2.5, 0.4, 4.0, {{-0.2, 1.3, 2.4}}, 3.5, -4.6, 5.7, "LambdaFactorA0"};
+  SphericalCompression sc1{
+      1.0, 2.6, 0.4, 4.0, {{-0.2, 1.3, 2.4}}, 3.5, -4.6, 5.7, "LambdaFactorA0"};
+  SphericalCompression sc2{
+      1.0, 2.5, 0.3, 4.0, {{-0.2, 1.3, 2.4}}, 3.5, -4.6, 5.7, "LambdaFactorA0"};
+  SphericalCompression sc3{
+      1.0, 2.5, 0.4, 4.1, {{-0.2, 1.3, 2.4}}, 3.5, -4.6, 5.7, "LambdaFactorA0"};
+  SphericalCompression sc4{
+      1.0, 2.5, 0.4, 4.0, {{0.2, 1.3, 2.4}}, 3.5, -4.6, 5.7, "LambdaFactorA0"};
+  SphericalCompression sc5{
+      1.0, 2.5, 0.4, 4.0, {{-0.2, 1.3, 2.4}}, 3.8, -4.6, 5.7, "LambdaFactorA0"};
+  SphericalCompression sc6{
+      1.0, 2.5, 0.4, 4.0, {{-0.2, 1.3, 2.4}}, 3.5, 4.6, 5.7, "LambdaFactorA0"};
+  SphericalCompression sc7{
+      1.0, 2.5, 0.4, 4.0, {{-0.2, 1.3, 2.4}}, 3.5, -4.6, 5.9, "LambdaFactorA0"};
+  SphericalCompression sc8{
+      1.0, 2.5, 0.4, 4.0, {{-0.2, 1.3, 2.4}}, 3.5, -4.6, 5.7, "LambdaFactorB0"};
+
+  CHECK(sc0 == sc0);
+  CHECK_FALSE(sc0 != sc0);
+  CHECK(sc0 != sc1);
+  CHECK_FALSE(sc0 == sc1);
+  CHECK(sc0 != sc2);
+  CHECK_FALSE(sc0 == sc2);
+  CHECK(sc0 != sc3);
+  CHECK_FALSE(sc0 == sc3);
+  CHECK(sc0 != sc4);
+  CHECK_FALSE(sc0 == sc4);
+  CHECK(sc0 != sc5);
+  CHECK_FALSE(sc0 == sc5);
+  CHECK(sc0 != sc6);
+  CHECK_FALSE(sc0 == sc6);
+  CHECK(sc0 != sc7);
+  CHECK_FALSE(sc0 == sc7);
+  CHECK(sc0 != sc8);
+  CHECK_FALSE(sc0 == sc8);
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.SphericalCompression",
+                  "[Domain][Unit]") {
+  constexpr double initial_time{1.3};
+  constexpr double update_delta_t{11.0};
+  constexpr double min_radius{0.4};
+  constexpr double max_radius{4.0};
+  const std::array<double, 3> center{{-0.02, 0.013, 0.024}};
+  constexpr double initial_value{1.0};
+  constexpr double initial_velocity{-0.1};
+  constexpr double initial_acceleration{0.01};
+  const std::string f_of_t_name{"LambdaFactorA0"};
+
+  const std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
+      time_dep = std::make_unique<SphericalCompression>(
+          initial_time, update_delta_t, min_radius, max_radius, center,
+          initial_value, initial_velocity, initial_acceleration, f_of_t_name);
+  test(time_dep, initial_time, f_of_t_name, min_radius, max_radius, center);
+  test(time_dep->get_clone(), initial_time, f_of_t_name, min_radius, max_radius,
+       center);
+
+  test(TestHelpers::test_creation<std::unique_ptr<TimeDependence<3>>>(
+           "SphericalCompression:\n"
+           "  InitialTime: 1.3\n"
+           "  InitialExpirationDeltaT: 11.0\n"
+           "  MinRadius: 0.4\n"
+           "  MaxRadius: 4.0\n"
+           "  Center: [-0.02, 0.013, 0.024]\n"
+           "  InitialValue: 1.0\n"
+           "  InitialVelocity: -0.1\n"
+           "  InitialAcceleration: 0.01\n"
+           "  FunctionOfTimeName: LambdaFactorA0\n"),
+       initial_time, f_of_t_name, min_radius, max_radius, center);
+
+  test_equivalence();
+}
+
+// [[OutputRegex, Tried to create a SphericalCompression TimeDependence]]
+SPECTRE_TEST_CASE(
+    "Unit.Domain.Creators.TimeDependence.SphericalCompression.ErrorTest",
+    "[Domain][Unit]") {
+  ERROR_TEST();
+  TestHelpers::test_creation<std::unique_ptr<TimeDependence<3>>>(
+      "SphericalCompression:\n"
+      "  InitialTime: 1.3\n"
+      "  InitialExpirationDeltaT: Auto\n"
+      "  MinRadius: 4.0\n"
+      "  MaxRadius: 0.4\n"
+      "  Center: [-0.01, 0.02, 0.01]\n"
+      "  InitialValue: 3.5\n"
+      "  InitialVelocity: -4.6\n"
+      "  InitialAcceleration: 5.7\n"
+      "  FunctionOfTimeName: LambdaFactorA0\n");
+}
+}  // namespace
+
+}  // namespace domain::creators::time_dependence


### PR DESCRIPTION
## Proposed changes

This PR adds a TimeDependence for the SphericalCompression time-dependent map, so that it can be used on a spherical shell for single-BH runs. Previously, it only worked hard-coded into the BBH domain, but this will let it work with a shell (provided the map's min and max radii are the inner and outer shell radii, respectively). 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
