### PR TITLE
Add hydro tag LorentzFactorTimesSpatialVelocity

### DIFF
--- a/src/PointwiseFunctions/Hydro/Tags.hpp
+++ b/src/PointwiseFunctions/Hydro/Tags.hpp
@@ -180,6 +180,12 @@ struct LowerSpatialFourVelocity : db::SimpleTag {
   using type = tnsr::i<DataType, Dim, Fr>;
 };
 
+/// The Lorentz factor \f$W\f$ times the spatial velocity \f$v^i\f$.
+template <typename DataType, size_t Dim, typename Fr>
+struct LorentzFactorTimesSpatialVelocity : db::SimpleTag {
+  using type = tnsr::I<DataType, Dim, Fr>;
+};
+
 /// The vector \f$J^i\f$ in \f$\dot{M} = -\int J^i s_i d^2S\f$,
 /// representing the mass flux through a surface with normal \f$s_i\f$.
 ///

--- a/src/PointwiseFunctions/Hydro/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/Hydro/TagsDeclarations.hpp
@@ -62,6 +62,8 @@ template <typename DataType>
 struct SpecificInternalEnergy;
 template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
 struct LowerSpatialFourVelocity;
+template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
+struct LorentzFactorTimesSpatialVelocity;
 }  // namespace Tags
 /// \endcond
 

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_Tags.cpp
@@ -78,5 +78,9 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Hydro.Tags", "[Unit][Hydro]") {
       hydro::Tags::LowerSpatialFourVelocity<DataVector, 3, Frame::Logical>>(
       "LowerSpatialFourVelocity");
   TestHelpers::db::test_simple_tag<
+      hydro::Tags::LorentzFactorTimesSpatialVelocity<DataVector, 3,
+                                                     Frame::Logical>>(
+      "LorentzFactorTimesSpatialVelocity");
+  TestHelpers::db::test_simple_tag<
       hydro::Tags::MassFlux<DataVector, 3, Frame::Logical>>("Logical_MassFlux");
 }


### PR DESCRIPTION
## Proposed changes

This is useful for reconstruction since it's `gamma^{ij} u_i` and so allows reconstructing the velocity in a way that guarantees the Lorentz factor is physical, but without having to compute `u_i` always on the DG and subcell grids.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
