### PR TITLE
Remove ANSI color strings so clang-format patch is valid

### DIFF
--- a/tools/Hooks/ClangFormat.py
+++ b/tools/Hooks/ClangFormat.py
@@ -65,6 +65,9 @@ if (int(clang_format_version.group(1)) < 4
 output = subprocess.check_output([git_executable, clang_format,
                                   "--diff"]).decode('ascii')
 
+ansi_color_code = re.compile(r'\x1B\[[0-9;]*m')
+output = ansi_color_code.sub('', output)
+
 if output not in [
         '\n', '', 'no modified files to format\n',
         'clang-format did not modify any files\n'


### PR DESCRIPTION
## Proposed changes

The git-clang-format githook writes a patch file that's invalid because it has ANSI color strings (at least on my system, I suspect in several cases...)
This strips the ANSI color strings and results in a patch file that can be applied as the instructions indicate --  I've verified it works locally, but that should be cross-checked on other systems, like mac.


### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
