### PR TITLE
Add radial partitioning check and improve help strings

### DIFF
--- a/src/Domain/Creators/Shell.cpp
+++ b/src/Domain/Creators/Shell.cpp
@@ -3,6 +3,7 @@
 
 #include "Domain/Creators/Shell.hpp"
 
+#include <algorithm>
 #include <memory>
 #include <utility>
 
@@ -84,14 +85,14 @@ Shell::Shell(
     PARSE_ERROR(context,
                 "Cannot have periodic boundary conditions with a shell");
   }
-  if (not std::is_sorted(radial_partitioning_.begin(),
-                         radial_partitioning_.end())) {
-    PARSE_ERROR(context,
-                "Specify radial partitioning in ascending order. Specified "
-                "radial partitioning is: "
-                    << get_output(radial_partitioning_));
-  }
   if (not radial_partitioning_.empty()) {
+    if (not std::is_sorted(radial_partitioning_.begin(),
+                           radial_partitioning_.end())) {
+      PARSE_ERROR(context,
+                  "Specify radial partitioning in ascending order. Specified "
+                  "radial partitioning is: "
+                      << get_output(radial_partitioning_));
+    }
     if (radial_partitioning_.front() <= inner_radius_) {
       PARSE_ERROR(
           context,
@@ -103,6 +104,12 @@ Shell::Shell(
           context,
           "Last radial partition must be smaller than outer radius, but is: "
               << outer_radius_);
+    }
+    const auto duplicate = std::adjacent_find(radial_partitioning_.begin(),
+                                              radial_partitioning_.end());
+    if (duplicate != radial_partitioning_.end()) {
+      PARSE_ERROR(context, "Radial partitioning contains duplicate element: "
+                               << *duplicate);
     }
   }
   if (radial_distribution_.size() != number_of_layers_) {

--- a/src/Domain/Creators/Shell.hpp
+++ b/src/Domain/Creators/Shell.hpp
@@ -94,18 +94,18 @@ class Shell : public DomainCreator<3> {
     using type = std::vector<double>;
     static constexpr Options::String help = {
         "Radial coordinates of the boundaries splitting the shell "
-        "between InnerRadius and OuterRadius. This should be used if "
-        "boundaries need to be set at specific radii. If the number but not "
-        "the specific locations of the boundaries are important, use "
-        "InitialRefinement instead."};
+        "between InnerRadius and OuterRadius. They must be given in ascending "
+        "order. This should be used if boundaries need to be set at specific "
+        "radii. If the number but not the specific locations of the boundaries "
+        "are important, use InitialRefinement instead."};
   };
 
   struct RadialDistribution {
     using type = std::vector<domain::CoordinateMaps::Distribution>;
     static constexpr Options::String help = {
         "Select the radial distribution of grid points in each spherical "
-        "shell. The 'RadialPartitioning' determines the "
-        "number of shells."};
+        "shell. The possible values are `Linear` and `Logarithmic`. There must "
+        "be N+1 radial distributions specified for N radial partitions."};
     static size_t lower_bound_on_size() noexcept { return 1; }
   };
 


### PR DESCRIPTION
## Proposed changes
adds a check that there are duplicate radial partitionings specified in the Shell setup. 

Improves the help strings for `RadialPartitioning` and `RadialDistribution`

Fixes #3233
<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
