### PR TITLE
Fix CylindricalEndcap test

### DIFF
--- a/src/Domain/CoordinateMaps/CylindricalEndcap.cpp
+++ b/src/Domain/CoordinateMaps/CylindricalEndcap.cpp
@@ -124,7 +124,8 @@ CylindricalEndcap::CylindricalEndcap(const std::array<double, 3>& center_one,
          "case where proj_center is at larger z than the z_plane. "
          "The map may still be invertible, but further "
          "testing would be needed to ensure that jacobians are not "
-         "ill-conditioned.");
+         "ill-conditioned. Here z_plane = "
+             << z_plane << " and proj_center[2] = " << proj_center[2]);
 
   ASSERT(abs(cos_theta) <= 0.95,
          "z_plane is too far from the center of sphere_one. "


### PR DESCRIPTION
## Proposed changes

Fixes #3230
    
The problem was that for certain (very unlikely) choices of random numbers, the test tried to construct a map with bad parameters.
    
The error was unlikely because for it to occur, the vector from center_one to center_two (both centers are randomly chosen in 3d) had to be nearly aligned wth the plus z-direction, and the (randomly chosen) value of radius_one had to be near its minimum allowed value, and the (randomly chosen) value of radius_two had to be near its maximum allowed value, and the (randomly chosen) value of z_plane had to be near its minimum allowed value, and the (randomly chosen) projection point had to be in a certain range.

Now the max and min allowed values of a few of these randomly chosen parameters have been changed to ensure that the error cannot occur.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
