### PR TITLE
Allow writing volume data at single precision

### DIFF
--- a/src/DataStructures/CMakeLists.txt
+++ b/src/DataStructures/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   ApplyMatrices.cpp
   DynamicBuffer.cpp
+  FloatingPointType.cpp
   Index.cpp
   IndexIterator.cpp
   LeviCivitaIterator.cpp
@@ -33,6 +34,7 @@ spectre_target_headers(
   DiagonalModalOperator.hpp
   DynamicBuffer.hpp
   FixedHashMap.hpp
+  FloatingPointType.hpp
   GeneralIndexIterator.hpp
   IdPair.hpp
   Index.hpp

--- a/src/DataStructures/FloatingPointType.cpp
+++ b/src/DataStructures/FloatingPointType.cpp
@@ -1,0 +1,40 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "DataStructures/FloatingPointType.hpp"
+
+#include <ostream>
+#include <string>
+
+#include "Options/Options.hpp"
+#include "Options/ParseOptions.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GetOutput.hpp"
+
+std::ostream& operator<<(std::ostream& os,
+                         const FloatingPointType& t) noexcept {
+  switch (t) {
+    case FloatingPointType::Float:
+      return os << "Float";
+    case FloatingPointType::Double:
+      return os << "Double";
+    default:
+      ERROR("Unknown floating point type, must be Float or Double");
+  }
+}
+
+template <>
+FloatingPointType Options::create_from_yaml<FloatingPointType>::create<void>(
+    const Options::Option& options) {
+  const auto type_read = options.parse_as<std::string>();
+  if (type_read == get_output(FloatingPointType::Float)) {
+    return FloatingPointType::Float;
+  } else if (type_read == get_output(FloatingPointType::Double)) {
+    return FloatingPointType::Double;
+  }
+  PARSE_ERROR(options.context(),
+              "Failed to convert \""
+                  << type_read << "\" to FloatingPointType. Must be one of '"
+                  << get_output(FloatingPointType::Float) << "' or '"
+                  << get_output(FloatingPointType::Double) << "'.");
+}

--- a/src/DataStructures/FloatingPointType.hpp
+++ b/src/DataStructures/FloatingPointType.hpp
@@ -1,0 +1,37 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <iosfwd>
+
+/// \cond
+namespace Options {
+class Option;
+template <typename T>
+struct create_from_yaml;
+}  // namespace Options
+/// \endcond
+
+/// \ingroup DataStructuresGroup
+/// \brief Which floating point type to use
+///
+/// An example use-case is for specifying in an input file to what precision
+/// data is written to disk, since most simulations will not have full double
+/// precision accuracy on volume data and we don't need all digits to visualize
+/// the data.
+enum FloatingPointType { Float, Double };
+
+std::ostream& operator<<(std::ostream& os, const FloatingPointType& t) noexcept;
+
+template <>
+struct Options::create_from_yaml<FloatingPointType> {
+  template <typename Metavariables>
+  static FloatingPointType create(const Options::Option& options) {
+    return create<void>(options);
+  }
+};
+
+template <>
+FloatingPointType Options::create_from_yaml<FloatingPointType>::create<void>(
+    const Options::Option& options);

--- a/src/DataStructures/Tensor/TensorData.cpp
+++ b/src/DataStructures/Tensor/TensorData.cpp
@@ -6,6 +6,15 @@
 #include <ostream>
 #include <pup.h>
 #include <pup_stl.h>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+
+TensorComponent::TensorComponent(std::string n, DataVector d) noexcept
+    : name(std::move(n)), data(std::move(d)) {}
 
 void TensorComponent::pup(PUP::er& p) noexcept {
   p | name;
@@ -26,10 +35,24 @@ bool operator!=(const TensorComponent& lhs,
   return not(lhs == rhs);
 }
 
+ExtentsAndTensorVolumeData::ExtentsAndTensorVolumeData(
+    std::vector<size_t> extents_in,
+    std::vector<TensorComponent> components) noexcept
+    : extents(std::move(extents_in)),
+      tensor_components(std::move(components)) {}
+
 void ExtentsAndTensorVolumeData::pup(PUP::er& p) noexcept {
   p | extents;
   p | tensor_components;
 }
+
+ElementVolumeData::ElementVolumeData(
+    std::vector<size_t> extents_in, std::vector<TensorComponent> components,
+    std::vector<Spectral::Basis> basis_in,
+    std::vector<Spectral::Quadrature> quadrature_in) noexcept
+    : ExtentsAndTensorVolumeData(std::move(extents_in), std::move(components)),
+      basis(std::move(basis_in)),
+      quadrature(std::move(quadrature_in)) {}
 
 void ElementVolumeData::pup(PUP::er& p) noexcept {
   ExtentsAndTensorVolumeData::pup(p);

--- a/src/DataStructures/Tensor/TensorData.hpp
+++ b/src/DataStructures/Tensor/TensorData.hpp
@@ -7,6 +7,7 @@
 #include <iosfwd>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "DataStructures/DataVector.hpp"
@@ -28,11 +29,12 @@ class er;
  */
 struct TensorComponent {
   TensorComponent() = default;
-  TensorComponent(std::string n, DataVector d) noexcept;
+  TensorComponent(std::string in_name, DataVector in_data) noexcept;
+  TensorComponent(std::string in_name, std::vector<float> in_data) noexcept;
 
   void pup(PUP::er& p) noexcept;  // NOLINT
   std::string name{};
-  DataVector data{};
+  std::variant<DataVector, std::vector<float>> data{};
 };
 
 std::ostream& operator<<(std::ostream& os, const TensorComponent& t) noexcept;

--- a/src/DataStructures/Tensor/TensorData.hpp
+++ b/src/DataStructures/Tensor/TensorData.hpp
@@ -28,8 +28,7 @@ class er;
  */
 struct TensorComponent {
   TensorComponent() = default;
-  TensorComponent(std::string n, DataVector d) noexcept
-      : name(std::move(n)), data(std::move(d)) {}
+  TensorComponent(std::string n, DataVector d) noexcept;
 
   void pup(PUP::er& p) noexcept;  // NOLINT
   std::string name{};
@@ -57,9 +56,7 @@ bool operator!=(const TensorComponent& lhs,
 struct ExtentsAndTensorVolumeData {
   ExtentsAndTensorVolumeData() = default;
   ExtentsAndTensorVolumeData(std::vector<size_t> extents_in,
-                             std::vector<TensorComponent> components) noexcept
-      : extents(std::move(extents_in)),
-        tensor_components(std::move(components)) {}
+                             std::vector<TensorComponent> components) noexcept;
 
   void pup(PUP::er& p) noexcept;  // NOLINT
   std::vector<size_t> extents{};
@@ -76,11 +73,7 @@ struct ElementVolumeData : ExtentsAndTensorVolumeData {
   ElementVolumeData(std::vector<size_t> extents_in,
                     std::vector<TensorComponent> components,
                     std::vector<Spectral::Basis> basis_in,
-                    std::vector<Spectral::Quadrature> quadrature_in) noexcept
-      : ExtentsAndTensorVolumeData(std::move(extents_in),
-                                   std::move(components)),
-        basis(std::move(basis_in)),
-        quadrature(std::move(quadrature_in)) {};
+                    std::vector<Spectral::Quadrature> quadrature_in) noexcept;
 
   void pup(PUP::er& p) noexcept;  // NOLINT
   std::vector<Spectral::Basis> basis{};

--- a/src/Evolution/DgSubcell/Events/ObserveFields.hpp
+++ b/src/Evolution/DgSubcell/Events/ObserveFields.hpp
@@ -138,10 +138,7 @@ class ObserveFields<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
       " * Tensors listed in Tensors template parameter\n"
       " * Error(*) = errors in AnalyticSolutionTensors\n"
       "            = value - analytic solution\n"
-      "\n"
-      "Warning: Currently, only one volume observation event can be\n"
-      "triggered at a given time.  Causing multiple events to run at once\n"
-      "will produce unpredictable results.";
+      "\n";
 
   ObserveFields() = default;
 

--- a/src/IO/H5/Helpers.cpp
+++ b/src/IO/H5/Helpers.cpp
@@ -528,7 +528,7 @@ template Index<3> read_extents<3>(const hid_t group_id,
       const std::string& name) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE_WRITE_DATA,
-                        (double, int, unsigned int, long, unsigned long,
+                        (float, double, int, unsigned int, long, unsigned long,
                          long long, unsigned long long, char))
 
 #define INSTANTIATE_ATTRIBUTE(_, DATA)                                 \
@@ -551,7 +551,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_ATTRIBUTE,
       const hid_t group_id, const std::string& dataset_name) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE_READ_SCALAR,
-                        (double, int, unsigned int, long, unsigned long,
+                        (float, double, int, unsigned int, long, unsigned long,
                          long long, unsigned long long, char),
                         (0))
 
@@ -561,7 +561,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATE_READ_SCALAR,
       const hid_t group_id, const std::string& dataset_name) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE_READ_VECTOR,
-                        (double, int, unsigned int, long, unsigned long,
+                        (float, double, int, unsigned int, long, unsigned long,
                          long long, unsigned long long, char),
                         (1))
 

--- a/src/IO/H5/Helpers.cpp
+++ b/src/IO/H5/Helpers.cpp
@@ -368,8 +368,8 @@ std::vector<std::string> read_rank1_attribute<std::string>(
   CHECK_H5(dataspace_id,
            "Failed to open dataspace for attribute '" << name << "'");
   // Get the size of the strings
-  hsize_t legend_dims[1];
-  CHECK_H5(H5Sget_simple_extent_dims(dataspace_id, legend_dims, nullptr),
+  std::array<hsize_t, 1> legend_dims{};
+  CHECK_H5(H5Sget_simple_extent_dims(dataspace_id, legend_dims.data(), nullptr),
            "Failed to get size of strings");
   // Read the strings as arrays of characters
   std::vector<char*> temp(legend_dims[0]);

--- a/src/IO/H5/Type.hpp
+++ b/src/IO/H5/Type.hpp
@@ -28,6 +28,10 @@ template <typename T>
 SPECTRE_ALWAYS_INLINE hid_t h5_type();
 /// \cond HIDDEN_SYMBOLS
 template <>
+SPECTRE_ALWAYS_INLINE hid_t h5_type<float>() {
+  return H5T_NATIVE_FLOAT;  // LCOV_EXCL_LINE
+}
+template <>
 SPECTRE_ALWAYS_INLINE hid_t h5_type<double>() {
   return H5T_NATIVE_DOUBLE;  // LCOV_EXCL_LINE
 }

--- a/src/ParallelAlgorithms/Events/ObserveFields.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveFields.hpp
@@ -133,11 +133,7 @@ class ObserveFields<VolumeDim, ObservationValueTag, tmpl::list<Tensors...>,
       " * InertialCoordinates\n"
       " * Tensors listed in Tensors template parameter\n"
       " * Error(*) = errors in AnalyticSolutionTensors\n"
-      "            = value - analytic solution\n"
-      "\n"
-      "Warning: Currently, only one volume observation event can be\n"
-      "triggered at a given time.  Causing multiple events to run at once\n"
-      "will produce unpredictable results.";
+      "            = value - analytic solution\n";
 
   ObserveFields() = default;
 

--- a/src/Visualization/Python/GenerateXdmf.py
+++ b/src/Visualization/Python/GenerateXdmf.py
@@ -263,7 +263,8 @@ def parse_args():
     parser.add_argument(
         '--file-prefix',
         required=True,
-        help="The common prefix of the H5 volume files to load")
+        help="The common prefix of the H5 volume files to load, excluding "
+        "the node number integer(s)")
     parser.add_argument(
         '--output',
         '-o',

--- a/tests/InputFiles/Elasticity/BentBeam.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam.yaml
@@ -66,3 +66,5 @@ EventsAndTriggers:
           - Displacement
           - PotentialEnergyDensity
         InterpolateToMesh: None
+        CoordinatesFloatingPointType: Double
+        FloatingPointTypes: [Double]

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -84,3 +84,5 @@ EventsAndTriggers:
           - Displacement
           - PotentialEnergyDensity
         InterpolateToMesh: None
+        CoordinatesFloatingPointType: Double
+        FloatingPointTypes: [Double]

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave.yaml
@@ -93,6 +93,8 @@ EventsAndTriggers:
           - PointwiseL2Norm(ThreeIndexConstraint)
           - PointwiseL2Norm(FourIndexConstraint)
         InterpolateToMesh: None
+        CoordinatesFloatingPointType: Double
+        FloatingPointTypes: [Double]
   ? Slabs:
       Specified:
         Values: [2]

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -104,6 +104,8 @@ EventsAndTriggers:
           - PointwiseL2Norm(ThreeIndexConstraint)
           - PointwiseL2Norm(FourIndexConstraint)
         InterpolateToMesh: None
+        CoordinatesFloatingPointType: Double
+        FloatingPointTypes: [Double]
   ? Slabs:
       EvenlySpaced:
         Interval: 5

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -61,3 +61,5 @@ EventsAndTriggers:
         SubfileName: VolumeData
         VariablesToObserve: [Field]
         InterpolateToMesh: None
+        CoordinatesFloatingPointType: Double
+        FloatingPointTypes: [Double]

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -57,3 +57,5 @@ EventsAndTriggers:
         SubfileName: VolumeData
         VariablesToObserve: [Field]
         InterpolateToMesh: None
+        CoordinatesFloatingPointType: Double
+        FloatingPointTypes: [Double]

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -57,3 +57,5 @@ EventsAndTriggers:
         SubfileName: VolumeData
         VariablesToObserve: [Field]
         InterpolateToMesh: None
+        CoordinatesFloatingPointType: Double
+        FloatingPointTypes: [Double]

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -84,6 +84,8 @@ EventsAndTriggers:
         SubfileName: VolumePsiPiPhiEvery50Slabs
         VariablesToObserve: ["Psi", "Pi", "Phi"]
         InterpolateToMesh: None
+        CoordinatesFloatingPointType: Double
+        FloatingPointTypes: [Double, Float, Float]
 # [observe_event_trigger]
 
 Observers:

--- a/tests/InputFiles/Xcts/Schwarzschild.yaml
+++ b/tests/InputFiles/Xcts/Schwarzschild.yaml
@@ -86,3 +86,5 @@ EventsAndTriggers:
           - LapseTimesConformalFactor
           - ShiftExcess
         InterpolateToMesh: None
+        CoordinatesFloatingPointType: Double
+        FloatingPointTypes: [Double]

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -21,6 +21,7 @@ set(LIBRARY_SOURCES
   Test_DiagonalModalOperator.cpp
   Test_DynamicBuffer.cpp
   Test_FixedHashMap.cpp
+  Test_FloatingPointType.cpp
   Test_GeneralIndexIterator.cpp
   Test_IdPair.cpp
   Test_Index.cpp

--- a/tests/Unit/DataStructures/Tensor/Test_TensorData.cpp
+++ b/tests/Unit/DataStructures/Tensor/Test_TensorData.cpp
@@ -13,10 +13,12 @@
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
 
-SPECTRE_TEST_CASE("Unit.DataStructures.TensorData", "[Unit]") {
-  TensorComponent tc0("T_x", DataVector{8.9, 7.6, -3.4, 9.0});
-  TensorComponent tc1("T_y", DataVector{8.9, 7.6, -3.4, 9.0});
-  TensorComponent tc2("T_x", DataVector{8.9, 7.6, -3.4, 9.1});
+namespace {
+template <typename DataType>
+void test() {
+  TensorComponent tc0("T_x", DataType{8.9, 7.6, -3.4, 9.0});
+  TensorComponent tc1("T_y", DataType{8.9, 7.6, -3.4, 9.0});
+  TensorComponent tc2("T_x", DataType{8.9, 7.6, -3.4, 9.1});
   CHECK(get_output(tc0) == "(T_x, (8.9,7.6,-3.4,9))");
   CHECK(tc0 == tc0);
   CHECK(tc0 != tc1);
@@ -28,4 +30,10 @@ SPECTRE_TEST_CASE("Unit.DataStructures.TensorData", "[Unit]") {
   const auto after = serialize_and_deserialize(etvd0);
   CHECK(after.extents == etvd0.extents);
   CHECK(after.tensor_components == etvd0.tensor_components);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.TensorData", "[Unit]") {
+  test<DataVector>();
+  test<std::vector<float>>();
 }

--- a/tests/Unit/DataStructures/Test_FloatingPointType.cpp
+++ b/tests/Unit/DataStructures/Test_FloatingPointType.cpp
@@ -1,0 +1,29 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "DataStructures/FloatingPointType.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+template <FloatingPointType FloatType>
+void test_construct_from_options() noexcept {
+  const auto created =
+      TestHelpers::test_creation<FloatingPointType>(get_output(FloatType));
+  CHECK(created == FloatType);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.FloatingPointType",
+                  "[Unit][DataStructures]") {
+  CHECK(get_output(FloatingPointType::Float) == "Float");
+  CHECK(get_output(FloatingPointType::Double) == "Double");
+
+  test_construct_from_options<FloatingPointType::Float>();
+  test_construct_from_options<FloatingPointType::Double>();
+}

--- a/tests/Unit/Evolution/DgSubcell/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Events/Test_ObserveFields.cpp
@@ -238,15 +238,21 @@ void test_observe(
           const std::string& component, const DataVector& expected) noexcept {
         CAPTURE(*tensor_data);
         CAPTURE(component);
+        const DataVector interpolated_expected =
+            interpolant.interpolate(expected);
         const auto it =
             alg::find_if(*tensor_data, [name = element_name + "/" + component](
                                            const TensorComponent& tc) noexcept {
               return tc.name == name;
             });
         CHECK(it != tensor_data->end());
-        if (it != tensor_data->end()) {
-          CHECK(std::get<DataVector>(it->data) ==
-                interpolant.interpolate(expected));
+        if (component.substr(0, 6) == "Tensor" or
+            component.substr(6, 7) == "Tensor2") {
+          CHECK(std::get<std::vector<float>>(it->data) ==
+                std::vector<float>{interpolated_expected.begin(),
+                                   interpolated_expected.end()});
+        } else {
+          CHECK(std::get<DataVector>(it->data) == interpolated_expected);
         }
         ++num_components_observed;
       };

--- a/tests/Unit/Evolution/DgSubcell/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Events/Test_ObserveFields.cpp
@@ -245,7 +245,8 @@ void test_observe(
             });
         CHECK(it != tensor_data->end());
         if (it != tensor_data->end()) {
-          CHECK(it->data == interpolant.interpolate(expected));
+          CHECK(std::get<DataVector>(it->data) ==
+                interpolant.interpolate(expected));
         }
         ++num_components_observed;
       };

--- a/tests/Unit/Helpers/ParallelAlgorithms/Events/ObserveFields.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Events/ObserveFields.hpp
@@ -13,6 +13,7 @@
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/FloatingPointType.hpp"
 #include "DataStructures/Index.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
@@ -177,10 +178,16 @@ struct ScalarSystem {
   static constexpr auto creation_string_for_test =
       "ObserveFields:\n"
       "  SubfileName: element_data\n"
-      "  VariablesToObserve: [Scalar]\n";
+      "  CoordinatesFloatingPointType: Double\n"
+      "  VariablesToObserve: [Scalar]\n"
+      "  FloatingPointTypes: [Double]\n";
   static ObserveEvent make_test_object(
       const std::optional<Mesh<volume_dim>>& interpolating_mesh) noexcept {
-    return ObserveEvent{"element_data", {"Scalar"}, interpolating_mesh};
+    return ObserveEvent{"element_data",
+                        FloatingPointType::Double,
+                        {FloatingPointType::Double},
+                        {"Scalar"},
+                        interpolating_mesh};
   }
 };
 
@@ -274,11 +281,15 @@ struct ComplicatedSystem {
   static constexpr auto creation_string_for_test =
       "ObserveFields:\n"
       "  SubfileName: element_data\n"
-      "  VariablesToObserve: [Scalar, Vector, Tensor, Tensor2]\n";
+      "  CoordinatesFloatingPointType: Double\n"
+      "  VariablesToObserve: [Scalar, Vector, Tensor, Tensor2]\n"
+      "  FloatingPointTypes: [Double, Double, Float, Float]\n";
 
   static ObserveEvent make_test_object(
       const std::optional<Mesh<volume_dim>>& interpolating_mesh) noexcept {
-    return ObserveEvent("element_data",
+    return ObserveEvent("element_data", FloatingPointType::Double,
+                        {FloatingPointType::Double, FloatingPointType::Double,
+                         FloatingPointType::Float, FloatingPointType::Float},
                         {"Scalar", "Vector", "Tensor", "Tensor2"},
                         interpolating_mesh);
   }

--- a/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
@@ -249,7 +249,7 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.VolumeObserver", "[Unit][Observers]") {
                               std::get<0>(volume_data_fakes)[1]} ==
           read_extents[i]);
     for (const auto& tensor_component : std::get<1>(volume_data_fakes)) {
-      CHECK(tensor_component.data ==
+      CHECK(std::get<DataVector>(tensor_component.data) ==
             DataVector(
                 &(read_tensor_data[tensor_component.name][points_processed]),
                 stride));

--- a/tests/Unit/IO/Test_VolumeData.cpp
+++ b/tests/Unit/IO/Test_VolumeData.cpp
@@ -23,7 +23,18 @@
 #include "Utilities/MakeString.hpp"
 #include "Utilities/Numeric.hpp"
 
-SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData", "[Unit][IO][H5]") {
+namespace {
+template <typename T>
+T multiply(const double obs_value, const T& component) noexcept {
+  T result = component;
+  for (auto& t : result) {
+    t *= obs_value;
+  }
+  return result;
+}
+
+template <typename DataType>
+void test() {
   const std::string h5_file_name("Unit.IO.H5.VolumeData.h5");
   const uint32_t version_number = 4;
   if (file_system::check_if_file_exists(h5_file_name)) {
@@ -31,7 +42,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData", "[Unit][IO][H5]") {
   }
 
   h5::H5File<h5::AccessType::ReadWrite> my_file(h5_file_name);
-  const std::vector<DataVector> tensor_components_and_coords{
+  const std::vector<DataType> tensor_components_and_coords{
       {8.9, 7.6, 3.9, 2.1, 18.9, 17.6, 13.9, 12.1},
       {0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0},
       {0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0},
@@ -60,52 +71,52 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData", "[Unit][IO][H5]") {
           observation_id, observation_value,
           std::vector<ElementVolumeData>{
               {{2, 2, 2},
-               {TensorComponent{
-                    first_grid + "/S",
-                    observation_value * tensor_components_and_coords[0]},
-                TensorComponent{
-                    first_grid + "/x-coord",
-                    observation_value * tensor_components_and_coords[1]},
-                TensorComponent{
-                    first_grid + "/y-coord",
-                    observation_value * tensor_components_and_coords[2]},
-                TensorComponent{
-                    first_grid + "/z-coord",
-                    observation_value * tensor_components_and_coords[3]},
-                TensorComponent{
-                    first_grid + "/T_x",
-                    observation_value * tensor_components_and_coords[4]},
-                TensorComponent{
-                    first_grid + "/T_y",
-                    observation_value * tensor_components_and_coords[5]},
-                TensorComponent{
-                    first_grid + "/T_z",
-                    observation_value * tensor_components_and_coords[6]}},
+               {TensorComponent{first_grid + "/S",
+                                multiply(observation_value,
+                                         tensor_components_and_coords[0])},
+                TensorComponent{first_grid + "/x-coord",
+                                multiply(observation_value,
+                                         tensor_components_and_coords[1])},
+                TensorComponent{first_grid + "/y-coord",
+                                multiply(observation_value,
+                                         tensor_components_and_coords[2])},
+                TensorComponent{first_grid + "/z-coord",
+                                multiply(observation_value,
+                                         tensor_components_and_coords[3])},
+                TensorComponent{first_grid + "/T_x",
+                                multiply(observation_value,
+                                         tensor_components_and_coords[4])},
+                TensorComponent{first_grid + "/T_y",
+                                multiply(observation_value,
+                                         tensor_components_and_coords[5])},
+                TensorComponent{first_grid + "/T_z",
+                                multiply(observation_value,
+                                         tensor_components_and_coords[6])}},
                bases.front(),
                quadratures.front()},
               // Second Element Data
               {{2, 2, 2},
-               {TensorComponent{
-                    last_grid + "/S",
-                    observation_value * tensor_components_and_coords[1]},
-                TensorComponent{
-                    last_grid + "/x-coord",
-                    observation_value * tensor_components_and_coords[0]},
-                TensorComponent{
-                    last_grid + "/y-coord",
-                    observation_value * tensor_components_and_coords[5]},
-                TensorComponent{
-                    last_grid + "/z-coord",
-                    observation_value * tensor_components_and_coords[3]},
-                TensorComponent{
-                    last_grid + "/T_x",
-                    observation_value * tensor_components_and_coords[6]},
-                TensorComponent{
-                    last_grid + "/T_y",
-                    observation_value * tensor_components_and_coords[4]},
-                TensorComponent{
-                    last_grid + "/T_z",
-                    observation_value * tensor_components_and_coords[2]}},
+               {TensorComponent{last_grid + "/S",
+                                multiply(observation_value,
+                                         tensor_components_and_coords[1])},
+                TensorComponent{last_grid + "/x-coord",
+                                multiply(observation_value,
+                                         tensor_components_and_coords[0])},
+                TensorComponent{last_grid + "/y-coord",
+                                multiply(observation_value,
+                                         tensor_components_and_coords[5])},
+                TensorComponent{last_grid + "/z-coord",
+                                multiply(observation_value,
+                                         tensor_components_and_coords[3])},
+                TensorComponent{last_grid + "/T_x",
+                                multiply(observation_value,
+                                         tensor_components_and_coords[6])},
+                TensorComponent{last_grid + "/T_y",
+                                multiply(observation_value,
+                                         tensor_components_and_coords[4])},
+                TensorComponent{last_grid + "/T_z",
+                                multiply(observation_value,
+                                         tensor_components_and_coords[2])}},
                bases.back(),
                quadratures.back()}});
     };
@@ -218,13 +229,13 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData", "[Unit][IO][H5]") {
       }
       return read_points;
     }();
-    // Given a DataVector, corresponding to contiguous data read out of a
+    // Given a DataType, corresponding to contiguous data read out of a
     // file, find the data which was written by the grid whose extents are
     // found at position `grid_index` in the vector of extents.
     const auto get_grid_data = [&element_num_points, &read_points_by_element](
                                    DataVector all_data,
                                    const size_t grid_index) {
-      DataVector result(element_num_points[grid_index]);
+      DataType result(element_num_points[grid_index]);
       // clang-tidy: do not use pointer arithmetic
       std::copy(&all_data[read_points_by_element[grid_index]],
                 &all_data[read_points_by_element[grid_index]] +  // NOLINT
@@ -245,8 +256,8 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData", "[Unit][IO][H5]") {
         CHECK(get_grid_data(
                   volume_file.get_tensor_component(observation_id, component),
                   grid_positions[j]) ==
-              observation_value *
-                  tensor_components_and_coords[grid_data_orders[j][i]]);
+              multiply(observation_value,
+                       tensor_components_and_coords[grid_data_orders[j][i]]));
       }
     }
   };
@@ -275,6 +286,12 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData", "[Unit][IO][H5]") {
     file_system::rm(h5_file_name, true);
   }
 }
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData", "[Unit][IO][H5]") {
+  test<DataVector>();
+  test<std::vector<float>>();
+}
 
 // [[OutputRegex, The expected format of the tensor component names is
 // 'GROUP_NAME/COMPONENT_NAME' but could not find a '/' in]]
@@ -292,7 +309,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData", "[Unit][IO][H5]") {
       my_file.insert<h5::VolumeData>("/element_data", version_number);
   volume_file.write_volume_data(100, 10.0,
                                 {{{2},
-                                  {TensorComponent{"S", {1.0, 2.0}}},
+                                  {TensorComponent{"S", DataVector{1.0, 2.0}}},
                                   {Spectral::Basis::Legendre},
                                   {Spectral::Quadrature::Gauss}}});
   ERROR("Failed to trigger ASSERT in an assertion test");
@@ -316,12 +333,12 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData.ComponentFormat1",
   h5::H5File<h5::AccessType::ReadWrite> my_file(h5_file_name);
   auto& volume_file =
       my_file.insert<h5::VolumeData>("/element_data", version_number);
-  volume_file.write_volume_data(
-      100, 10.0,
-      {{{2},
-        {TensorComponent{"A/S", {1.0, 2.0}}, TensorComponent{"S", {1.0, 2.0}}},
-        {Spectral::Basis::Legendre},
-        {Spectral::Quadrature::Gauss}}});
+  volume_file.write_volume_data(100, 10.0,
+                                {{{2},
+                                  {TensorComponent{"A/S", DataVector{1.0, 2.0}},
+                                   TensorComponent{"S", DataVector{1.0, 2.0}}},
+                                  {Spectral::Basis::Legendre},
+                                  {Spectral::Quadrature::Gauss}}});
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
   // clang-format off
@@ -343,12 +360,13 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData.ComponentFormat1",
   h5::H5File<h5::AccessType::ReadWrite> my_file(h5_file_name);
   auto& volume_file =
       my_file.insert<h5::VolumeData>("/element_data", version_number);
-  volume_file.write_volume_data(100, 10.0,
-                                {{{2},
-                                  {TensorComponent{"A/S", {1.0, 2.0}},
-                                   TensorComponent{"A/S", {1.0, 2.0}}},
-                                  {Spectral::Basis::Legendre},
-                                  {Spectral::Quadrature::Gauss}}});
+  volume_file.write_volume_data(
+      100, 10.0,
+      {{{2},
+        {TensorComponent{"A/S", DataVector{1.0, 2.0}},
+         TensorComponent{"A/S", DataVector{1.0, 2.0}}},
+        {Spectral::Basis::Legendre},
+        {Spectral::Quadrature::Gauss}}});
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
   // clang-format off
@@ -357,6 +375,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData.ComponentFormat1",
 // [[OutputRegex, No observation with value]]
 SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData.FindNoObservationId",
                   "[Unit][IO][H5]") {
+  // clang-format on
   ERROR_TEST();
   const std::string h5_file_name(
       "Unit.IO.H5.VolumeData.FindNoObservationId.h5");
@@ -369,8 +388,9 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData.FindNoObservationId",
       h5_file.insert<h5::VolumeData>("/element_data", version_number);
   volume_file.write_volume_data(
       100, 10.0,
-      {
-       {{2}, {TensorComponent{"A/S", {1.0, 2.0}}},{Spectral::Basis::Legendre},
+      {{{2},
+        {TensorComponent{"A/S", DataVector{1.0, 2.0}}},
+        {Spectral::Basis::Legendre},
         {Spectral::Quadrature::Gauss}}});
   volume_file.find_observation_id(11.0);
 }

--- a/tests/Unit/IO/Test_VolumeData.cpp
+++ b/tests/Unit/IO/Test_VolumeData.cpp
@@ -233,7 +233,7 @@ void test() {
     // file, find the data which was written by the grid whose extents are
     // found at position `grid_index` in the vector of extents.
     const auto get_grid_data = [&element_num_points, &read_points_by_element](
-                                   DataVector all_data,
+                                   const DataVector& all_data,
                                    const size_t grid_index) {
       DataType result(element_num_points[grid_index]);
       // clang-tidy: do not use pointer arithmetic

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
@@ -179,7 +179,8 @@ void test_observe(
             });
         CHECK(it != tensor_data->end());
         if (it != tensor_data->end()) {
-          CHECK(it->data == interpolant.interpolate(expected));
+          CHECK(std::get<DataVector>(it->data) ==
+                interpolant.interpolate(expected));
         }
         ++num_components_observed;
       };

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
@@ -17,6 +17,7 @@
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/FloatingPointType.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Tensor/TensorData.hpp"
 #include "DataStructures/Variables.hpp"
@@ -77,9 +78,9 @@ void test_observe(
     const std::optional<Mesh<System::volume_dim>>& interpolating_mesh,
     const bool has_analytic_solutions) noexcept {
   using metavariables = Metavariables<System, AlwaysHasAnalyticSolutions>;
+  constexpr size_t volume_dim = System::volume_dim;
   using element_component = ElementComponent<metavariables>;
   using observer_component = MockObserverComponent<metavariables>;
-  static constexpr auto volume_dim = System::volume_dim;
   using coordinates_tag =
       domain::Tags::Coordinates<volume_dim, Frame::Inertial>;
 
@@ -166,24 +167,31 @@ void test_observe(
   // gcc 6.4.0 gets confused if we try to capture tensor_data by
   // reference and fails to compile because it wants it to be
   // non-const, so we capture a pointer instead.
-  const auto check_component =
-      [&element_name, &num_components_observed,
-       tensor_data = &results.in_received_tensor_data, &interpolant](
-          const std::string& component, const DataVector& expected) noexcept {
-        CAPTURE(*tensor_data);
-        CAPTURE(component);
-        const auto it =
-            alg::find_if(*tensor_data, [name = element_name + "/" + component](
-                                           const TensorComponent& tc) noexcept {
-              return tc.name == name;
-            });
-        CHECK(it != tensor_data->end());
-        if (it != tensor_data->end()) {
-          CHECK(std::get<DataVector>(it->data) ==
-                interpolant.interpolate(expected));
-        }
-        ++num_components_observed;
-      };
+  const auto check_component = [&element_name, &num_components_observed,
+                                tensor_data = &results.in_received_tensor_data,
+                                &interpolant](
+                                   const std::string& component,
+                                   const DataVector& expected) noexcept {
+    CAPTURE(*tensor_data);
+    CAPTURE(component);
+    const DataVector interpolated_expected = interpolant.interpolate(expected);
+    const auto it = alg::find_if(
+        *tensor_data,
+        [name = element_name + "/" + component](
+            const TensorComponent& tc) noexcept { return tc.name == name; });
+    CHECK(it != tensor_data->end());
+    if (it != tensor_data->end()) {
+      if (component.substr(0, 6) == "Tensor" or
+          component.substr(6, 7) == "Tensor2") {
+        CHECK(std::get<std::vector<float>>(it->data) ==
+              std::vector<float>{interpolated_expected.begin(),
+                                 interpolated_expected.end()});
+      } else {
+        CHECK(std::get<DataVector>(it->data) == interpolated_expected);
+      }
+    }
+    ++num_components_observed;
+  };
   for (size_t i = 0; i < volume_dim; ++i) {
     check_component(
         std::string("InertialCoordinates_") + gsl::at({'x', 'y', 'z'}, i),
@@ -364,8 +372,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.dG.ObserveFields.bad_field",
   TestHelpers::test_creation<
       typename ScalarSystem<dg::Events::ObserveFields>::ObserveEvent>(
       "SubfileName: VolumeData\n"
+      "CoordinatesFloatingPointType: Double\n"
       "VariablesToObserve: [NotAVar]\n"
-      "InterpolateToMesh: None");
+      "FloatingPointTypes: [Double]\n"
+      "InterpolateToMesh: None\n");
 }
 
 // [[OutputRegex, Scalar specified multiple times]]
@@ -375,6 +385,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.dG.ObserveFields.repeated_field",
   TestHelpers::test_creation<
       typename ScalarSystem<dg::Events::ObserveFields>::ObserveEvent>(
       "SubfileName: VolumeData\n"
+      "CoordinatesFloatingPointType: Double\n"
       "VariablesToObserve: [Scalar, Scalar]\n"
-      "InterpolateToMesh: None");
+      "FloatingPointTypes: [Double]\n"
+      "InterpolateToMesh: None\n");
 }


### PR DESCRIPTION
## Proposed changes

Most 3d simulations aren't even accurate to single precision, so writing the volume data at single precision just saves a factor of 2 in disk space usage. With the changes here, users can control whether to write volume data at double or single precision.

Enabling HDF5 compression also helps reduce file size but there's some importer code that uses otherwise untested features that seems to break that I need to fix before I can submit a PR for volume data compression.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
