### PR TITLE
Make ElementId support up to 2^24 blocks and 2^8 grid indices

### DIFF
--- a/src/Domain/Structure/ElementId.cpp
+++ b/src/Domain/Structure/ElementId.cpp
@@ -109,7 +109,7 @@ ElementId<VolumeDim> ElementId<VolumeDim>::external_boundary_id() noexcept {
   // unlikely we will ever get to that large of a refinement.
   return ElementId<VolumeDim>(
       two_to_the(ElementId::block_id_bits) - 1,
-      make_array<VolumeDim>(SegmentId(ElementId::max_refinement_level, 0)));
+      make_array<VolumeDim>(SegmentId(ElementId::max_refinement_level - 1, 0)));
 }
 
 template <size_t VolumeDim>

--- a/src/Domain/Structure/SegmentId.cpp
+++ b/src/Domain/Structure/SegmentId.cpp
@@ -12,7 +12,7 @@
 
 SegmentId::SegmentId(const size_t refinement_level, const size_t index) noexcept
     : refinement_level_(refinement_level), index_(index) {
-  ASSERT(refinement_level <= max_refinement_level,
+  ASSERT(refinement_level < max_refinement_level,
          "Refinement level out of bounds: " << refinement_level);
   ASSERT(index < two_to_the(refinement_level),
          "index = " << index << ", refinement_level = " << refinement_level);

--- a/src/Domain/Structure/SegmentId.cpp
+++ b/src/Domain/Structure/SegmentId.cpp
@@ -11,46 +11,17 @@
 #include "Utilities/ErrorHandling/Assert.hpp"
 
 SegmentId::SegmentId(const size_t refinement_level, const size_t index) noexcept
-    : block_id_(0),
-      refinement_level_(refinement_level),
-      index_(index),
-      grid_index_(0) {
+    : refinement_level_(refinement_level), index_(index) {
   ASSERT(refinement_level <= max_refinement_level,
          "Refinement level out of bounds: " << refinement_level);
   ASSERT(index < two_to_the(refinement_level),
          "index = " << index << ", refinement_level = " << refinement_level);
 }
 
-SegmentId::SegmentId(const size_t block_id, const size_t refinement_level,
-                     const size_t index, const size_t grid_index) noexcept
-    : block_id_(block_id),
-      refinement_level_(refinement_level),
-      index_(index),
-      grid_index_(grid_index) {
-  ASSERT(block_id < two_to_the(block_id_bits),
-         "Block id out of bounds: " << block_id << "\nMaximum value is: "
-                                    << two_to_the(block_id_bits) - 1);
-  ASSERT(refinement_level <= max_refinement_level,
-         "Refinement level out of bounds: " << refinement_level
-                                            << "\nMaximum value is: "
-                                            << max_refinement_level);
-  ASSERT(index < two_to_the(refinement_level),
-         "index = " << index << ", refinement_level = " << refinement_level);
-  ASSERT(grid_index < two_to_the(grid_index_bits),
-         "Grid index out of bounds: " << grid_index << "\nMaximum value is: "
-                                      << two_to_the(grid_index_bits) - 1);
+void SegmentId::pup(PUP::er& p) noexcept {
+  p | refinement_level_;
+  p | index_;
 }
-
-// Because `ElementId` is built up of `VolumeDim` `SegmentId`s, and `ElementId`
-// is used as a Charm++ index, `ElementId` has the following restrictions:
-// - `ElementId` must satisfy `std::is_pod`
-// - `ElementId` must not be larger than the size of three `int`s, i.e.
-//   `sizeof(ElementId) <= 3 * sizeof(int)`
-// which means `SegmentId` must be the size of an `int` and satisfy
-// `std::is_pod`.
-static_assert(std::is_pod<SegmentId>::value, "SegmentId is not POD");
-static_assert(sizeof(SegmentId) == sizeof(int),
-              "SegmentId does not fit in an int");
 
 std::ostream& operator<<(std::ostream& os, const SegmentId& id) noexcept {
   os << 'L' << id.refinement_level() << 'I' << id.index();

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementCenteredSubdomainData.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementCenteredSubdomainData.hpp
@@ -229,8 +229,8 @@ std::vector<OverlapId<Dim>> ordered_overlap_ids(
                 return lhs.second.block_id() < rhs.second.block_id();
               }
               for (size_t d = 0; d < Dim; ++d) {
-                const auto& lhs_segment_id = lhs.second.segment_ids().at(d);
-                const auto& rhs_segment_id = rhs.second.segment_ids().at(d);
+                const auto lhs_segment_id = lhs.second.segment_ids().at(d);
+                const auto rhs_segment_id = rhs.second.segment_ids().at(d);
                 if (lhs_segment_id.refinement_level() !=
                     rhs_segment_id.refinement_level()) {
                   return lhs_segment_id.refinement_level() <

--- a/tests/Unit/Domain/Structure/Test_ElementId.cpp
+++ b/tests/Unit/Domain/Structure/Test_ElementId.cpp
@@ -136,7 +136,7 @@ void test_element_id() {
   CHECK(ElementId<3>::external_boundary_id().block_id() ==
         two_to_the(ElementId<3>::block_id_bits) - 1);
   CHECK(ElementId<3>::external_boundary_id().segment_ids() ==
-        make_array<3>(SegmentId(ElementId<3>::max_refinement_level, 0)));
+        make_array<3>(SegmentId(ElementId<3>::max_refinement_level - 1, 0)));
   CHECK(ElementId<3>::external_boundary_id().grid_index() == 0);
 }
 

--- a/tests/Unit/Domain/Structure/Test_ElementId.cpp
+++ b/tests/Unit/Domain/Structure/Test_ElementId.cpp
@@ -134,9 +134,9 @@ void test_element_id() {
   CHECK(get_output(element_six) == "[B4,(L0I0,L0I0,L0I0),G1]");
 
   CHECK(ElementId<3>::external_boundary_id().block_id() ==
-        two_to_the(SegmentId::block_id_bits) - 1);
+        two_to_the(ElementId<3>::block_id_bits) - 1);
   CHECK(ElementId<3>::external_boundary_id().segment_ids() ==
-        make_array<3>(SegmentId(SegmentId::max_refinement_level, 0)));
+        make_array<3>(SegmentId(ElementId<3>::max_refinement_level, 0)));
   CHECK(ElementId<3>::external_boundary_id().grid_index() == 0);
 }
 
@@ -145,10 +145,12 @@ void test_serialization() noexcept {
   constexpr size_t volume_dim = VolumeDim;
   const ElementId<volume_dim> unused_id(0);
   const auto initial_ref_levels = make_array<volume_dim>(1_st);
-  for (size_t block_id = 0; block_id < two_to_the(SegmentId::block_id_bits);
-       ++block_id) {
+  // We restrict the test to 2^7 blocks and 2^grid_index_bits-2 grid indices so
+  // it finishes in a reasonable amount of time.
+  for (size_t block_id = 0; block_id < two_to_the(7_st); ++block_id) {
     for (size_t grid_index = 0;
-         grid_index < two_to_the(SegmentId::grid_index_bits); ++grid_index) {
+         grid_index < two_to_the(ElementId<VolumeDim>::grid_index_bits - 2);
+         ++grid_index) {
       const std::vector<ElementId<volume_dim>> element_ids =
           initial_element_ids(block_id, initial_ref_levels, grid_index);
       for (const auto element_id : element_ids) {
@@ -186,7 +188,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.ElementId", "[Domain][Unit]") {
                                "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  auto failed_element_id = ElementId<1>(two_to_the(SegmentId::block_id_bits));
+  auto failed_element_id =
+      ElementId<1>(two_to_the(ElementId<1>::block_id_bits));
   static_cast<void>(failed_element_id);
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
@@ -198,7 +201,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.ElementId", "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   auto failed_element_id =
-      ElementId<1>(0, {{{0, 0}}}, two_to_the(SegmentId::grid_index_bits));
+      ElementId<1>(0, {{{0, 0}}}, two_to_the(ElementId<1>::grid_index_bits));
   static_cast<void>(failed_element_id);
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif


### PR DESCRIPTION
## Proposed changes

While 2^24 is a ridiculously large number, our previous number of 128 was rather low. If I want to run a 3d simulation with 50^3 elements I need 25^3=15625 blocks at lev 1. Our current ability to control refinement only be a factor of 2 makes resolution in 3d basically impossible since doubling the resolution amounts to 16x longer simulations.

Previously SegmentId was the size of 1 int and used bit fields to store its refinement level and index (where along the interval it is). The SegmentId also store the block ID and the grid index, which in 3d resulted in us wasting quite a few bits for duplicate info. By having ElementId store all bits (hard-coded for 3d) we can pack things more densely and take advantage of the extra space to support having more blocks.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
