### PR TITLE
Improve atmosphere treatment

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -1160,6 +1160,25 @@
   year =         "2014"
 }
 
+@article{Muhlberger2014pja,
+  author =       "Muhlberger, Curran D. and Nouri, Fatemeh Hossein and Duez,
+                  Matthew D. and Foucart, Francois and Kidder, Lawrence E. and
+                  Ott, Christian D. and Scheel, Mark A. and Szil\'agyi, B\'ela
+                  and Teukolsky, Saul A.",
+  title =        "{Magnetic effects on the low-T/|W| instability in
+                  differentially rotating neutron stars}",
+  eprint =       "1405.2144",
+  archivePrefix ="arXiv",
+  primaryClass = "astro-ph.HE",
+  doi =          "10.1103/PhysRevD.90.104014",
+  url = {https://journals.aps.org/prd/abstract/10.1103/PhysRevD.90.104014},
+  journal =      "Phys. Rev. D",
+  volume =       90,
+  number =       10,
+  pages =        104014,
+  year =         2014
+}
+
 @book{NumericalRecipes,
   author    = "Press, William~H. and Teukolsky, Saul~A. and
                Vetterling, William~T. and Flannery, Brian~P.",

--- a/src/Evolution/VariableFixing/CMakeLists.txt
+++ b/src/Evolution/VariableFixing/CMakeLists.txt
@@ -28,5 +28,8 @@ target_link_libraries(
   ${LIBRARY}
   PUBLIC
   DataStructures
+  GeneralRelativity
+  Hydro
   Options
+  Utilities
   )

--- a/src/Evolution/VariableFixing/FixToAtmosphere.cpp
+++ b/src/Evolution/VariableFixing/FixToAtmosphere.cpp
@@ -19,15 +19,32 @@ namespace VariableFixing {
 template <size_t Dim>
 FixToAtmosphere<Dim>::FixToAtmosphere(const double density_of_atmosphere,
                                       const double density_cutoff,
+                                      const double transition_density_cutoff,
+                                      const double max_velocity_magnitude,
                                       const Options::Context& context)
     : density_of_atmosphere_(density_of_atmosphere),
-      density_cutoff_(density_cutoff) {
+      density_cutoff_(density_cutoff),
+      transition_density_cutoff_(transition_density_cutoff),
+      max_velocity_magnitude_(max_velocity_magnitude) {
   if (density_of_atmosphere_ > density_cutoff_) {
     PARSE_ERROR(context, "The cutoff density ("
                              << density_cutoff_
                              << ") must be greater than or equal to the "
                                 "density value in the atmosphere ("
                              << density_of_atmosphere_ << ')');
+  }
+  if (transition_density_cutoff_ < density_of_atmosphere_ or
+      transition_density_cutoff_ > 10.0 * density_of_atmosphere_) {
+    PARSE_ERROR(context, "The transition density must be in ["
+                             << density_of_atmosphere_ << ", "
+                             << 10 * density_of_atmosphere_ << "], but is "
+                             << transition_density_cutoff_);
+  }
+  if (transition_density_cutoff_ <= density_cutoff_) {
+    PARSE_ERROR(context, "The transition density cutoff ("
+                             << transition_density_cutoff_
+                             << ") must be bigger than the density cutoff ("
+                             << density_cutoff_ << ")");
   }
 }
 
@@ -36,6 +53,8 @@ template <size_t Dim>
 void FixToAtmosphere<Dim>::pup(PUP::er& p) noexcept {  // NOLINT
   p | density_of_atmosphere_;
   p | density_cutoff_;
+  p | transition_density_cutoff_;
+  p | max_velocity_magnitude_;
 }
 
 template <size_t Dim>
@@ -48,6 +67,7 @@ void FixToAtmosphere<Dim>::call_impl(
     const gsl::not_null<Scalar<DataVector>*> lorentz_factor,
     const gsl::not_null<Scalar<DataVector>*> pressure,
     const gsl::not_null<Scalar<DataVector>*> specific_enthalpy,
+    const tnsr::ii<DataVector, Dim, Frame::Inertial>& spatial_metric,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
         equation_of_state) const noexcept {
   for (size_t i = 0; i < rest_mass_density->get().size(); i++) {
@@ -77,6 +97,33 @@ void FixToAtmosphere<Dim>::call_impl(
             get(equation_of_state.specific_enthalpy_from_density_and_energy(
                 atmosphere_density, atmosphere_energy));
       }
+    } else if (UNLIKELY(rest_mass_density->get()[i] <
+                        transition_density_cutoff_)) {
+      double magnitude_of_velocity = 0.0;
+      for (size_t j = 0; j < Dim; ++j) {
+        magnitude_of_velocity += spatial_velocity->get(j)[i] *
+                                 spatial_velocity->get(j)[i] *
+                                 spatial_metric.get(j, j)[i];
+        for (size_t k = j + 1; k < Dim; ++k) {
+          magnitude_of_velocity += 2.0 * spatial_velocity->get(j)[i] *
+                                   spatial_velocity->get(k)[i] *
+                                   spatial_metric.get(j, k)[i];
+        }
+      }
+      magnitude_of_velocity = sqrt(magnitude_of_velocity);
+      const double scale_factor =
+          (get(*rest_mass_density)[i] - density_cutoff_) /
+          (transition_density_cutoff_ - density_cutoff_);
+      if (const double max_mag_of_velocity =
+              scale_factor * max_velocity_magnitude_;
+          magnitude_of_velocity > max_mag_of_velocity) {
+        for (size_t j = 0; j < Dim; ++j) {
+          spatial_velocity->get(j)[i] *=
+              max_mag_of_velocity / magnitude_of_velocity;
+        }
+        get(*lorentz_factor)[i] =
+            1.0 / sqrt(1.0 - max_mag_of_velocity * max_mag_of_velocity);
+      }
     }
   }
 }
@@ -85,7 +132,9 @@ template <size_t Dim>
 bool operator==(const FixToAtmosphere<Dim>& lhs,
                 const FixToAtmosphere<Dim>& rhs) noexcept {
   return lhs.density_of_atmosphere_ == rhs.density_of_atmosphere_ and
-         lhs.density_cutoff_ == rhs.density_cutoff_;
+         lhs.density_cutoff_ == rhs.density_cutoff_ and
+         lhs.transition_density_cutoff_ == rhs.transition_density_cutoff_ and
+         lhs.max_velocity_magnitude_ == rhs.max_velocity_magnitude_;
 }
 
 template <size_t Dim>
@@ -108,16 +157,17 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
 #undef INSTANTIATION
 
-#define INSTANTIATION(r, data)                                              \
-  template void FixToAtmosphere<DIM(data)>::call_impl(                      \
-      const gsl::not_null<Scalar<DataVector>*> rest_mass_density,           \
-      const gsl::not_null<Scalar<DataVector>*> specific_internal_energy,    \
-      const gsl::not_null<tnsr::I<DataVector, DIM(data), Frame::Inertial>*> \
-          spatial_velocity,                                                 \
-      const gsl::not_null<Scalar<DataVector>*> lorentz_factor,              \
-      const gsl::not_null<Scalar<DataVector>*> pressure,                    \
-      const gsl::not_null<Scalar<DataVector>*> specific_enthalpy,           \
-      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>&      \
+#define INSTANTIATION(r, data)                                                \
+  template void FixToAtmosphere<DIM(data)>::call_impl(                        \
+      const gsl::not_null<Scalar<DataVector>*> rest_mass_density,             \
+      const gsl::not_null<Scalar<DataVector>*> specific_internal_energy,      \
+      const gsl::not_null<tnsr::I<DataVector, DIM(data), Frame::Inertial>*>   \
+          spatial_velocity,                                                   \
+      const gsl::not_null<Scalar<DataVector>*> lorentz_factor,                \
+      const gsl::not_null<Scalar<DataVector>*> pressure,                      \
+      const gsl::not_null<Scalar<DataVector>*> specific_enthalpy,             \
+      const tnsr::ii<DataVector, DIM(data), Frame::Inertial>& spatial_metric, \
+      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>&        \
           equation_of_state) const noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (1, 2))

--- a/src/Evolution/VariableFixing/FixToAtmosphere.cpp
+++ b/src/Evolution/VariableFixing/FixToAtmosphere.cpp
@@ -59,7 +59,7 @@ void FixToAtmosphere<Dim>::pup(PUP::er& p) noexcept {  // NOLINT
 
 template <size_t Dim>
 template <size_t ThermodynamicDim>
-void FixToAtmosphere<Dim>::call_impl(
+void FixToAtmosphere<Dim>::operator()(
     const gsl::not_null<Scalar<DataVector>*> rest_mass_density,
     const gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
     const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
@@ -158,7 +158,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 #undef INSTANTIATION
 
 #define INSTANTIATION(r, data)                                                \
-  template void FixToAtmosphere<DIM(data)>::call_impl(                        \
+  template void FixToAtmosphere<DIM(data)>::operator()(                       \
       const gsl::not_null<Scalar<DataVector>*> rest_mass_density,             \
       const gsl::not_null<Scalar<DataVector>*> specific_internal_energy,      \
       const gsl::not_null<tnsr::I<DataVector, DIM(data), Frame::Inertial>*>   \

--- a/src/Evolution/VariableFixing/FixToAtmosphere.hpp
+++ b/src/Evolution/VariableFixing/FixToAtmosphere.hpp
@@ -155,6 +155,24 @@ class FixToAtmosphere {
       equation_of_state) const noexcept;
 
  private:
+  template <size_t ThermodynamicDim>
+  void set_density_to_atmosphere(
+      gsl::not_null<Scalar<DataVector>*> rest_mass_density,
+      gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
+      gsl::not_null<Scalar<DataVector>*> pressure,
+      gsl::not_null<Scalar<DataVector>*> specific_enthalpy,
+      const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+          equation_of_state,
+      size_t grid_index) const noexcept;
+
+  void set_to_magnetic_free_transition(
+      gsl::not_null<Scalar<DataVector>*> rest_mass_density,
+      gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+          spatial_velocity,
+      gsl::not_null<Scalar<DataVector>*> lorentz_factor,
+      const tnsr::ii<DataVector, Dim, Frame::Inertial>& spatial_metric,
+      size_t grid_index) const noexcept;
+
   template <size_t SpatialDim>
   // NOLINTNEXTLINE(readability-redundant-declaration)
   friend bool operator==(const FixToAtmosphere<SpatialDim>& lhs,

--- a/src/Evolution/VariableFixing/FixToAtmosphere.hpp
+++ b/src/Evolution/VariableFixing/FixToAtmosphere.hpp
@@ -152,26 +152,9 @@ class FixToAtmosphere {
       gsl::not_null<Scalar<DataVector>*> specific_enthalpy,
       const tnsr::ii<DataVector, Dim, Frame::Inertial>& spatial_metric,
       const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
-          equation_of_state) const noexcept {
-    call_impl(rest_mass_density, specific_internal_energy, spatial_velocity,
-              lorentz_factor, pressure, specific_enthalpy, spatial_metric,
-              equation_of_state);
-  }
+      equation_of_state) const noexcept;
 
  private:
-  template <size_t ThermodynamicDim>
-  void call_impl(
-      gsl::not_null<Scalar<DataVector>*> rest_mass_density,
-      gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
-      gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
-          spatial_velocity,
-      gsl::not_null<Scalar<DataVector>*> lorentz_factor,
-      gsl::not_null<Scalar<DataVector>*> pressure,
-      gsl::not_null<Scalar<DataVector>*> specific_enthalpy,
-      const tnsr::ii<DataVector, Dim, Frame::Inertial>& spatial_metric,
-      const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
-          equation_of_state) const noexcept;
-
   template <size_t SpatialDim>
   // NOLINTNEXTLINE(readability-redundant-declaration)
   friend bool operator==(const FixToAtmosphere<SpatialDim>& lhs,

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/CylindricalBlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/CylindricalBlastWave.yaml
@@ -60,6 +60,8 @@ VariableFixing:
   FixToAtmosphere:
     DensityOfAtmosphere: 1.0e-12
     DensityCutoff: 1.0e-12
+    TransitionDensityCutoff: 1.0e-11
+    MaxVelocityMagnitude: 1.0e-4
 
 Observers:
   VolumeFileName: "ValenciaDivCleanBlastWaveVolume"

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -69,6 +69,8 @@ VariableFixing:
   FixToAtmosphere:
     DensityOfAtmosphere: 1.0e-12
     DensityCutoff: 1.0e-12
+    TransitionDensityCutoff: 1.0e-11
+    MaxVelocityMagnitude: 1.0e-4
 
 EventsAndTriggers:
   ? Slabs:

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow1D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow1D.yaml
@@ -54,6 +54,8 @@ VariableFixing:
   FixToAtmosphere:
     DensityOfAtmosphere: 1.e-12
     DensityCutoff: 1.2e-12
+    TransitionDensityCutoff: 1.0e-11
+    MaxVelocityMagnitude: 1.0e-4
 
 EventsAndTriggers:
   # ? Slabs:

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow2D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow2D.yaml
@@ -52,6 +52,8 @@ VariableFixing:
   FixToAtmosphere:
     DensityOfAtmosphere: 1.e-12
     DensityCutoff: 1.2e-12
+    TransitionDensityCutoff: 1.0e-11
+    MaxVelocityMagnitude: 1.0e-4
 
 EventsAndTriggers:
   # ? Slabs:

--- a/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow3D.yaml
+++ b/tests/InputFiles/RelativisticEuler/Valencia/SmoothFlow3D.yaml
@@ -52,6 +52,8 @@ VariableFixing:
   FixToAtmosphere:
     DensityOfAtmosphere: 1.e-12
     DensityCutoff: 1.2e-12
+    TransitionDensityCutoff: 1.0e-11
+    MaxVelocityMagnitude: 1.0e-4
 
 EventsAndTriggers:
   # ? Slabs:

--- a/tests/Unit/Evolution/VariableFixing/Test_FixToAtmosphere.cpp
+++ b/tests/Unit/Evolution/VariableFixing/Test_FixToAtmosphere.cpp
@@ -24,32 +24,48 @@ void test_variable_fixer(
     const VariableFixing::FixToAtmosphere<Dim>& variable_fixer,
     const EquationsOfState::EquationOfState<true, 1>&
         equation_of_state) noexcept {
-  Scalar<DataVector> density{DataVector{2.e-12, 2.e-11}};
+  // 2.e-12 -> below cutoff, velocity goes to zero
+  // 2.e-11 -> above cutoff, no changes
+  // 4.e-12 -> density unchanged, velocity restricted
+  Scalar<DataVector> density{DataVector{2.e-12, 2.e-11, 4.e-12}};
   auto pressure = equation_of_state.pressure_from_density(density);
   auto specific_enthalpy =
       equation_of_state.specific_enthalpy_from_density(density);
   auto specific_internal_energy =
       equation_of_state.specific_internal_energy_from_density(density);
 
-  Scalar<DataVector> lorentz_factor{DataVector{5.0 / 3.0, 1.25}};
+  Scalar<DataVector> lorentz_factor{
+      DataVector{5.0 / 3.0, 1.25, 1.8898223650461359}};
   auto spatial_velocity =
       make_with_value<tnsr::I<DataVector, Dim, Frame::Inertial>>(density, 0.0);
-  spatial_velocity.get(0) = DataVector{0.8, 0.6};
+  spatial_velocity.get(0) = DataVector{0.8, 0.6, 0.6};
+  auto spatial_metric =
+      make_with_value<tnsr::ii<DataVector, Dim, Frame::Inertial>>(density, 0.0);
+  for (size_t i = 0; i < Dim; ++i) {
+    spatial_metric.get(i, i) = 2.0;
+  }
   variable_fixer(&density, &specific_internal_energy, &spatial_velocity,
-                 &lorentz_factor, &pressure, &specific_enthalpy,
+                 &lorentz_factor, &pressure, &specific_enthalpy, spatial_metric,
                  equation_of_state);
 
-  Scalar<DataVector> expected_density{DataVector{1.e-12, 2.e-11}};
+  Scalar<DataVector> expected_density{DataVector{1.e-12, 2.e-11, 4.e-12}};
   auto expected_pressure =
       equation_of_state.pressure_from_density(expected_density);
   auto expected_specific_enthalpy =
       equation_of_state.specific_enthalpy_from_density(expected_density);
   auto expected_specific_internal_energy =
       equation_of_state.specific_internal_energy_from_density(expected_density);
-  Scalar<DataVector> expected_lorentz_factor{DataVector{1.0, 1.25}};
+  Scalar<DataVector> expected_lorentz_factor{
+      DataVector{1.0, 1.25, 1.0000000001020408}};
   auto expected_spatial_velocity =
       make_with_value<tnsr::I<DataVector, Dim, Frame::Inertial>>(density, 0.0);
   expected_spatial_velocity.get(0)[1] = 0.6;
+  // The [2] component of the expected velocity is:
+  //     velocity *= max_velocity_magnitude_ * (rho - rho_cut) /
+  //                 (trans_rho - rho_cut) / |v^i|
+  expected_spatial_velocity.get(0)[2] = 0.6 * (4.e-12 - 3.e-12) /
+                                        (1.e-11 - 3.e-12) * 1.e-4 /
+                                        sqrt(0.6 * 0.6 * 2.0);
 
   CHECK_ITERABLE_APPROX(density, expected_density);
   CHECK_ITERABLE_APPROX(pressure, expected_pressure);
@@ -64,33 +80,47 @@ template <size_t Dim>
 void test_variable_fixer(
     const VariableFixing::FixToAtmosphere<Dim>& variable_fixer,
     const EquationsOfState::EquationOfState<true, 2>& equation_of_state) {
-  Scalar<DataVector> density{DataVector{2.e-12, 2.e-11}};
-  Scalar<DataVector> specific_internal_energy{DataVector{2.0, 3.0}};
+  Scalar<DataVector> density{DataVector{2.e-12, 2.e-11, 4.e-12}};
+  Scalar<DataVector> specific_internal_energy{DataVector{2.0, 3.0, 3.0}};
   auto pressure = equation_of_state.pressure_from_density_and_energy(
       density, specific_internal_energy);
   auto specific_enthalpy =
       equation_of_state.specific_enthalpy_from_density_and_energy(
           density, specific_internal_energy);
 
-  Scalar<DataVector> lorentz_factor{DataVector{5.0 / 3.0, 1.25}};
+  Scalar<DataVector> lorentz_factor{
+      DataVector{5.0 / 3.0, 1.25, 1.8898223650461359}};
   auto spatial_velocity =
       make_with_value<tnsr::I<DataVector, Dim, Frame::Inertial>>(density, 0.0);
-  spatial_velocity.get(0) = DataVector{0.8, 0.6};
+  spatial_velocity.get(0) = DataVector{0.8, 0.6, 0.6};
+  auto spatial_metric =
+      make_with_value<tnsr::ii<DataVector, Dim, Frame::Inertial>>(density, 0.0);
+  for (size_t i = 0; i < Dim; ++i) {
+    spatial_metric.get(i, i) = 2.0;
+  }
   variable_fixer(&density, &specific_internal_energy, &spatial_velocity,
-                 &lorentz_factor, &pressure, &specific_enthalpy,
+                 &lorentz_factor, &pressure, &specific_enthalpy, spatial_metric,
                  equation_of_state);
 
-  Scalar<DataVector> expected_density{DataVector{1.e-12, 2.e-11}};
-  Scalar<DataVector> expected_specific_internal_energy{DataVector{0.0, 3.0}};
+  Scalar<DataVector> expected_density{DataVector{1.e-12, 2.e-11, 4.e-12}};
+  Scalar<DataVector> expected_specific_internal_energy{
+      DataVector{0.0, 3.0, 3.0}};
   auto expected_pressure = equation_of_state.pressure_from_density_and_energy(
       expected_density, expected_specific_internal_energy);
   auto expected_specific_enthalpy =
       equation_of_state.specific_enthalpy_from_density_and_energy(
           expected_density, expected_specific_internal_energy);
-  Scalar<DataVector> expected_lorentz_factor{DataVector{1.0, 1.25}};
+  Scalar<DataVector> expected_lorentz_factor{
+      DataVector{1.0, 1.25, 1.0000000001020408}};
   auto expected_spatial_velocity =
       make_with_value<tnsr::I<DataVector, Dim, Frame::Inertial>>(density, 0.0);
   expected_spatial_velocity.get(0)[1] = 0.6;
+  // The [2] component of the expected velocity is:
+  //     velocity *= max_velocity_magnitude_ * (rho - rho_cut) /
+  //                 (trans_rho - rho_cut) / |v^i|
+  expected_spatial_velocity.get(0)[2] = 0.6 * (4.e-12 - 3.e-12) /
+                                        (1.e-11 - 3.e-12) * 1.e-4 /
+                                        sqrt(0.6 * 0.6 * 2.0);
 
   CHECK_ITERABLE_APPROX(density, expected_density);
   CHECK_ITERABLE_APPROX(pressure, expected_pressure);
@@ -104,7 +134,8 @@ void test_variable_fixer(
 template <size_t Dim>
 void test_variable_fixer() noexcept {
   // Test for representative 1-d equation of state
-  VariableFixing::FixToAtmosphere<Dim> variable_fixer{1.e-12, 1.e-11};
+  VariableFixing::FixToAtmosphere<Dim> variable_fixer{1.e-12, 3.e-12, 1.e-11,
+                                                      1.e-4};
   EquationsOfState::PolytropicFluid<true> polytrope{1.0, 2.0};
   test_variable_fixer<Dim>(variable_fixer, polytrope);
   test_serialization(variable_fixer);
@@ -112,7 +143,9 @@ void test_variable_fixer() noexcept {
   const auto fixer_from_options =
       TestHelpers::test_creation<VariableFixing::FixToAtmosphere<Dim>>(
           "DensityOfAtmosphere: 1.0e-12\n"
-          "DensityCutoff: 1.0e-11\n");
+          "DensityCutoff: 3.0e-12\n"
+          "TransitionDensityCutoff: 1.0e-11\n"
+          "MaxVelocityMagnitude: 1.0e-4\n");
   test_variable_fixer(fixer_from_options, polytrope);
 
   // Test for representative 2-d equation of state


### PR DESCRIPTION
## Proposed changes

SpEC has a gradual transition from atmosphere velocities to unlimited velocities. This adds such a gradual change to our atmosphere treatment.

Slightly different restrictions are needed when magnetic fields are present, but that will be added in a followup PR.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
