### PR TITLE
Add ObserveNorms event to observe norms of any tensor in the DataBox

### DIFF
--- a/src/ParallelAlgorithms/Events/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Events/CMakeLists.txt
@@ -12,6 +12,7 @@ spectre_target_headers(
   Factory.hpp
   ObserveErrorNorms.hpp
   ObserveFields.hpp
+  ObserveNorms.hpp
   ObserveTimeStep.hpp
   ObserveVolumeIntegrals.hpp
   )

--- a/src/ParallelAlgorithms/Events/ObserveNorms.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveNorms.hpp
@@ -1,0 +1,381 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <limits>
+#include <pup.h>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/TagName.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "IO/Observer/Helpers.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/ReductionActions.hpp"
+#include "IO/Observer/TypeOfObservation.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/ArrayIndex.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Reduction.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/Numeric.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Events {
+/// \cond
+template <typename ObservableTensorTagsList>
+class ObserveNorms;
+/// \endcond
+
+/*!
+ * \brief Compute norms of tensors in the DataBox and write them to disk.
+ *
+ * The L2 norm is computed as the RMS, so
+ *
+ * \f{align*}{
+ * L_2(u)=\sqrt{\frac{1}{N}\sum_{i=0}^{N} u_i^2}
+ * \f}
+ *
+ * where \f$N\f$ is the number of grid points.
+ *
+ * The norm can be taken for each individual component, or summed over
+ * components. For the max/min it is then the max/min over all components, while
+ * for the L2 norm we have (for a 3d vector, 2d and 1d are similar)
+ *
+ * \f{align*}{
+ * L_2(v^k)=\sqrt{\frac{1}{N}\sum_{i=0}^{N} \left[(v^x_i)^2 + (v^y_i)^2
+ *          + (v^z_i)^2\right]}
+ * \f}
+ *
+ * Here is an example of an input file:
+ *
+ * \snippet Test_ObserveNorms.cpp input_file_examples
+ */
+template <typename... ObservableTensorTags>
+class ObserveNorms<tmpl::list<ObservableTensorTags...>> : public Event {
+ private:
+  struct ObserveTensor {
+    static constexpr Options::String help = {
+        "The tensor to reduce, and how to reduce it."};
+
+    struct Name {
+      using type = std::string;
+      static constexpr Options::String help = {
+          "The name of the tensor to observe."};
+    };
+    struct NormType {
+      using type = std::string;
+      static constexpr Options::String help = {
+          "The type of norm to use. Must be one of Max, Min, or L2Norm."};
+    };
+    struct Components {
+      using type = std::string;
+      static constexpr Options::String help = {
+          "How to handle tensor components. Must be Individual or Sum."};
+    };
+
+    using options = tmpl::list<Name, NormType, Components>;
+
+    ObserveTensor() = default;
+
+    ObserveTensor(std::string in_tensor, std::string in_norm_type,
+                  std::string in_components,
+                  const Options::Context& context = {});
+
+    std::string tensor{};
+    std::string norm_type{};
+    std::string components{};
+  };
+
+  template <typename Functional>
+  struct ElementWiseBinary {
+    std::vector<double> operator()(
+        const std::vector<double>& t0,
+        const std::vector<double>& t1) const noexcept {
+      ASSERT(t0.size() == t1.size(),
+             "Size must be the same but got t0: " << t0.size()
+                                                  << " and t1: " << t1.size());
+      std::vector<double> result(t0.size());
+      for (size_t i = 0; i < t0.size(); ++i) {
+        result[i] = Functional{}(t0[i], t1[i]);
+      }
+      return result;
+    }
+
+    std::vector<double> operator()(const std::vector<double>& t0,
+                                   const double t1) const noexcept {
+      // This overload is needed for the L2 norm
+      std::vector<double> result(t0.size());
+      for (size_t i = 0; i < t0.size(); ++i) {
+        result[i] = Functional{}(t0[i], t1);
+      }
+      return result;
+    }
+  };
+
+  using ReductionData = tmpl::wrap<
+      tmpl::list<Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
+                 Parallel::ReductionDatum<size_t, funcl::Plus<>>,
+                 Parallel::ReductionDatum<std::vector<double>,
+                                          ElementWiseBinary<funcl::Max<>>>,
+                 Parallel::ReductionDatum<std::vector<double>,
+                                          ElementWiseBinary<funcl::Min<>>>,
+                 Parallel::ReductionDatum<
+                     std::vector<double>, ElementWiseBinary<funcl::Plus<>>,
+                     ElementWiseBinary<funcl::Sqrt<funcl::Divides<>>>,
+                     std::index_sequence<1>>>,
+      Parallel::ReductionData>;
+
+ public:
+  /// The name of the subfile inside the HDF5 file
+  struct SubfileName {
+    using type = std::string;
+    static constexpr Options::String help = {
+        "The name of the subfile inside the HDF5 file without an extension and "
+        "without a preceding '/'."};
+  };
+  /// The tensor to observe and how to do the reduction
+  struct TensorsToObserve {
+    using type = std::vector<ObserveTensor>;
+    static constexpr Options::String help = {
+        "List specifying each tensor to observe and how it is reduced."};
+  };
+
+  /// \cond
+  explicit ObserveNorms(CkMigrateMessage* msg) noexcept;
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(ObserveNorms);  // NOLINT
+  /// \endcond
+
+  using options = tmpl::list<SubfileName, TensorsToObserve>;
+
+  static constexpr Options::String help =
+      "Observe norms of tensors in the DataBox.\n"
+      "\n"
+      "Writes reduction quantities:\n"
+      " * Time\n"
+      " * NumberOfPoints = total number of points in the domain\n"
+      " * Max values\n"
+      " * Min values\n"
+      " * L2-norm values\n";
+
+  ObserveNorms() = default;
+
+  ObserveNorms(const std::string& subfile_name,
+               const std::vector<ObserveTensor>& observe_tensors) noexcept;
+
+  using observed_reduction_data_tags =
+      observers::make_reduction_data_tags<tmpl::list<ReductionData>>;
+
+  using argument_tags = tmpl::list<::Tags::Time, ::Tags::DataBox>;
+
+  template <typename DbTagsList, typename Metavariables, typename ArrayIndex,
+            typename ParallelComponent>
+  void operator()(const double& time, const db::DataBox<DbTagsList>& box,
+                  Parallel::GlobalCache<Metavariables>& cache,
+                  const ArrayIndex& array_index,
+                  const ParallelComponent* const /*meta*/) const noexcept;
+
+  using observation_registration_tags = tmpl::list<>;
+
+  std::pair<observers::TypeOfObservation, observers::ObservationKey>
+  get_observation_type_and_key_for_registration() const noexcept {
+    return {observers::TypeOfObservation::Reduction,
+            observers::ObservationKey(subfile_path_ + ".dat")};
+  }
+
+  bool needs_evolved_variables() const noexcept override { return true; }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override;
+
+ private:
+  std::string subfile_path_;
+  std::vector<std::string> tensor_names_{};
+  std::vector<std::string> tensor_norm_types_{};
+  std::vector<std::string> tensor_components_{};
+};
+
+/// \cond
+template <typename... ObservableTensorTags>
+ObserveNorms<tmpl::list<ObservableTensorTags...>>::ObserveNorms(
+    CkMigrateMessage* msg) noexcept
+    : Event(msg) {}
+
+template <typename... ObservableTensorTags>
+ObserveNorms<tmpl::list<ObservableTensorTags...>>::ObserveNorms(
+    const std::string& subfile_name,
+    const std::vector<ObserveTensor>& observe_tensors) noexcept
+    : subfile_path_("/" + subfile_name) {
+  tensor_names_.reserve(observe_tensors.size());
+  tensor_norm_types_.reserve(observe_tensors.size());
+  tensor_components_.reserve(observe_tensors.size());
+  for (const auto& observe_tensor : observe_tensors) {
+    tensor_names_.push_back(observe_tensor.tensor);
+    tensor_norm_types_.push_back(observe_tensor.norm_type);
+    tensor_components_.push_back(observe_tensor.components);
+  }
+}
+
+template <typename... ObservableTensorTags>
+ObserveNorms<tmpl::list<ObservableTensorTags...>>::ObserveTensor::ObserveTensor(
+    std::string in_tensor, std::string in_norm_type, std::string in_components,
+    const Options::Context& context)
+    : tensor(std::move(in_tensor)),
+      norm_type(std::move(in_norm_type)),
+      components(std::move(in_components)) {
+  if (((tensor != db::tag_name<ObservableTensorTags>()) and ...)) {
+    PARSE_ERROR(
+        context, "Tensor '"
+                     << tensor << "' is not known. Known tensors are: "
+                     << ((db::tag_name<ObservableTensorTags>() + ",") + ...));
+  }
+  if (norm_type != "Max" and norm_type != "Min" and norm_type != "L2Norm") {
+    PARSE_ERROR(context, "NormType must be one of Max, Min, or L2Norm, not "
+                             << norm_type);
+  }
+  if (components != "Individual" and components != "Sum") {
+    PARSE_ERROR(context,
+                "Components must be Individual or Sum, not " << components);
+  }
+}
+
+template <typename... ObservableTensorTags>
+template <typename DbTagsList, typename Metavariables, typename ArrayIndex,
+          typename ParallelComponent>
+void ObserveNorms<tmpl::list<ObservableTensorTags...>>::operator()(
+    const double& time, const db::DataBox<DbTagsList>& box,
+    Parallel::GlobalCache<Metavariables>& cache, const ArrayIndex& array_index,
+    const ParallelComponent* const /*meta*/) const noexcept {
+  using tensor_tags = tmpl::list<ObservableTensorTags...>;
+  static_assert((db::tag_is_retrievable_v<ObservableTensorTags,
+                                          db::DataBox<DbTagsList>> and
+                 ...),
+                "Not all ObservableTensorTags were found in the DataBox.");
+
+  std::unordered_map<std::string,
+                     std::pair<std::vector<double>, std::vector<std::string>>>
+      norm_values_and_names{};
+  size_t number_of_points = 0;
+
+  // Loop over ObservableTensorTags and see if it was requested to be observed.
+  // This approach allows us to delay evaluating any compute tags until they're
+  // actually needed for observing.
+  tmpl::for_each<tensor_tags>([this, &box, &norm_values_and_names,
+                               &number_of_points](auto tag_v) noexcept {
+    using tag = tmpl::type_from<decltype(tag_v)>;
+    const std::string tensor_name = db::tag_name<tag>();
+    for (size_t i = 0; i < tensor_names_.size(); ++i) {
+      if (tensor_name == tensor_names_[i]) {
+        auto& [values, names] = norm_values_and_names[tensor_norm_types_[i]];
+        const auto [component_names, components] =
+            db::get<tag>(box).get_vector_of_data();
+        if (number_of_points != 0 and
+            components[0].size() != number_of_points) {
+          ERROR("The number of grid points previously was "
+                << number_of_points << " but changed to "
+                << components[0].size()
+                << ". This means you're computing norms of tensors over "
+                   "different grids, which will give the wrong answer for "
+                   "norms that use the grid points. The tensor is: "
+                << tensor_name);
+        }
+        number_of_points = components[0].size();
+
+        if (tensor_components_[i] == "Individual") {
+          for (size_t storage_index = 0; storage_index < component_names.size();
+               ++storage_index) {
+            if (tensor_norm_types_[i] == "Max") {
+              values.push_back(max(components[storage_index]));
+            } else if (tensor_norm_types_[i] == "Min") {
+              values.push_back(min(components[storage_index]));
+            } else if (tensor_norm_types_[i] == "L2Norm") {
+              values.push_back(
+                  alg::accumulate(square(components[storage_index]), 0.0));
+            }
+            names.push_back(
+                tensor_norm_types_[i] + "(" +
+                (component_names.size() == 1
+                     ? tensor_name
+                     : (tensor_name + "_" + component_names[storage_index])) +
+                ")");
+          }
+        } else if (tensor_components_[i] == "Sum") {
+          double value = 0.0;
+          if (tensor_norm_types_[i] == "Max") {
+            value = std::numeric_limits<double>::min();
+          } else if (tensor_norm_types_[i] == "Min") {
+            value = std::numeric_limits<double>::max();
+          }
+          for (size_t storage_index = 0; storage_index < component_names.size();
+               ++storage_index) {
+            if (tensor_norm_types_[i] == "Max") {
+              value = std::max(value, max(components[storage_index]));
+            } else if (tensor_norm_types_[i] == "Min") {
+              value = std::min(value, min(components[storage_index]));
+            } else if (tensor_norm_types_[i] == "L2Norm") {
+              value += alg::accumulate(square(components[storage_index]), 0.0);
+            }
+          }
+
+          names.push_back(tensor_norm_types_[i] + "(" + tensor_name + ")");
+          values.push_back(value);
+        }
+      }
+    }
+  });
+
+  // Concatenate the legend info together.
+  std::vector<std::string> legend{"Time", "NumberOfPoints"};
+  legend.insert(legend.end(), norm_values_and_names["Max"].second.begin(),
+                norm_values_and_names["Max"].second.end());
+  legend.insert(legend.end(), norm_values_and_names["Min"].second.begin(),
+                norm_values_and_names["Min"].second.end());
+  legend.insert(legend.end(), norm_values_and_names["L2Norm"].second.begin(),
+                norm_values_and_names["L2Norm"].second.end());
+
+  // Send data to reduction observer
+  auto& local_observer =
+      *Parallel::get_parallel_component<observers::Observer<Metavariables>>(
+           cache)
+           .ckLocalBranch();
+
+  Parallel::simple_action<observers::Actions::ContributeReductionData>(
+      local_observer, observers::ObservationId(time, subfile_path_ + ".dat"),
+      observers::ArrayComponentId{
+          std::add_pointer_t<ParallelComponent>{nullptr},
+          Parallel::ArrayIndex<ArrayIndex>(array_index)},
+      subfile_path_, std::move(legend),
+      ReductionData{time, number_of_points,
+                    std::move(norm_values_and_names["Max"].first),
+                    std::move(norm_values_and_names["Min"].first),
+                    std::move(norm_values_and_names["L2Norm"].first)});
+}
+
+template <typename... ObservableTensorTags>
+void ObserveNorms<tmpl::list<ObservableTensorTags...>>::pup(PUP::er& p) {
+  Event::pup(p);
+  p | subfile_path_;
+  p | tensor_names_;
+  p | tensor_norm_types_;
+  p | tensor_components_;
+}
+
+template <typename... ObservableTensorTags>
+PUP::able::PUP_ID ObserveNorms<tmpl::list<ObservableTensorTags...>>::my_PUP_ID =
+    0;  // NOLINT
+/// \endcond
+}  // namespace Events

--- a/src/ParallelAlgorithms/EventsAndTriggers/Event.hpp
+++ b/src/ParallelAlgorithms/EventsAndTriggers/Event.hpp
@@ -28,6 +28,7 @@ class Event : public PUP::able {
 
  public:
   ~Event() override = default;
+  explicit Event(CkMigrateMessage* msg) noexcept : PUP::able(msg) {}
 
   WRAPPED_PUPable_abstract(Event);  // NOLINT
 

--- a/tests/Unit/ParallelAlgorithms/Events/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Events/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_ParallelAlgorithmsEvents")
 set(LIBRARY_SOURCES
   Test_ObserveErrorNorms.cpp
   Test_ObserveFields.cpp
+  Test_ObserveNorms.cpp
   Test_ObserveTimeStep.cpp
   Test_ObserveVolumeIntegrals.cpp
   )

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveNorms.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveNorms.cpp
@@ -1,0 +1,238 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "IO/Observer/Actions/RegisterEvents.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "Parallel/Tags/Metavariables.hpp"
+#include "ParallelAlgorithms/Events/ObserveNorms.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct Var0 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+struct Var1 : db::SimpleTag {
+  using type = tnsr::I<DataVector, 3, Frame::Inertial>;
+};
+
+struct MockContributeReductionData {
+  struct Results {
+    observers::ObservationId observation_id;
+    std::string subfile_name;
+    std::vector<std::string> reduction_names;
+    double time;
+    size_t number_of_grid_points;
+    std::vector<double> max_values;
+    std::vector<double> min_values;
+    std::vector<double> l2_norm_values;
+  };
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+  static Results results;
+
+  template <typename ParallelComponent, typename... DbTags,
+            typename Metavariables, typename ArrayIndex, typename... Ts>
+  static void apply(db::DataBox<tmpl::list<DbTags...>>& /*box*/,
+                    Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const observers::ObservationId& observation_id,
+                    observers::ArrayComponentId /*sender_array_id*/,
+                    const std::string& subfile_name,
+                    const std::vector<std::string>& reduction_names,
+                    Parallel::ReductionData<Ts...>&& reduction_data) noexcept {
+    reduction_data.finalize();
+    results.observation_id = observation_id;
+    results.subfile_name = subfile_name;
+    results.reduction_names = reduction_names;
+    results.time = std::get<0>(reduction_data.data());
+    results.number_of_grid_points = std::get<1>(reduction_data.data());
+    results.max_values = std::get<2>(reduction_data.data());
+    results.min_values = std::get<3>(reduction_data.data());
+    results.l2_norm_values = std::get<4>(reduction_data.data());
+  }
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+MockContributeReductionData::Results MockContributeReductionData::results{};
+
+template <typename Metavariables>
+struct ElementComponent {
+  using component_being_mocked = void;
+
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Initialization,
+                                        tmpl::list<>>>;
+};
+
+template <typename Metavariables>
+struct MockObserverComponent {
+  using component_being_mocked = observers::Observer<Metavariables>;
+  using replace_these_simple_actions =
+      tmpl::list<observers::Actions::ContributeReductionData>;
+  using with_these_simple_actions = tmpl::list<MockContributeReductionData>;
+
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockGroupChare;
+  using array_index = int;
+  using phase_dependent_action_list =
+      tmpl::list<Parallel::PhaseActions<typename Metavariables::Phase,
+                                        Metavariables::Phase::Initialization,
+                                        tmpl::list<>>>;
+};
+
+struct Metavariables {
+  using component_list = tmpl::list<ElementComponent<Metavariables>,
+                                    MockObserverComponent<Metavariables>>;
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<tmpl::pair<
+        Event, tmpl::list<Events::ObserveNorms<tmpl::list<Var0, Var1>>>>>;
+  };
+
+  enum class Phase { Initialization, Testing, Exit };
+};
+
+template <typename ObserveEvent>
+void test(const std::unique_ptr<ObserveEvent> observe) {
+  using metavariables = Metavariables;
+  using element_component = ElementComponent<metavariables>;
+  using observer_component = MockObserverComponent<metavariables>;
+  const typename element_component::array_index array_index(0);
+  const size_t num_points = 5;
+  const double observation_time = 2.0;
+  Variables<tmpl::list<Var0, Var1>> vars(num_points);
+  // Fill the variables with some data.  It doesn't matter much what,
+  // but integers are nice in that we don't have to worry about
+  // roundoff error.
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+  std::iota(vars.data(), vars.data() + vars.size(), 1.0);
+
+  ActionTesting::MockRuntimeSystem<metavariables> runner{{}};
+  ActionTesting::emplace_component<element_component>(make_not_null(&runner),
+                                                      0);
+  ActionTesting::emplace_group_component<observer_component>(&runner);
+
+  const auto box = db::create<db::AddSimpleTags<
+      Parallel::Tags::MetavariablesImpl<metavariables>, ::Tags::Time,
+      Tags::Variables<typename decltype(vars)::tags_list>>>(
+      metavariables{}, observation_time, vars);
+
+  const auto ids_to_register =
+      observers::get_registration_observation_type_and_key(*observe, box);
+  const observers::ObservationKey expected_observation_key_for_reg(
+      "/reduction0.dat");
+  CHECK(ids_to_register->first == observers::TypeOfObservation::Reduction);
+  CHECK(ids_to_register->second == expected_observation_key_for_reg);
+
+  observe->run(box,
+               ActionTesting::cache<element_component>(runner, array_index),
+               array_index, std::add_pointer_t<element_component>{});
+
+  // Process the data
+  runner.template invoke_queued_simple_action<observer_component>(0);
+  CHECK(runner.template is_simple_action_queue_empty<observer_component>(0));
+
+  const auto& results = MockContributeReductionData::results;
+  CHECK(results.observation_id.value() == observation_time);
+  CHECK(results.subfile_name == "/reduction0");
+  CHECK(results.reduction_names[0] == "Time");
+  CHECK(results.time == observation_time);
+  CHECK(results.reduction_names[1] == "NumberOfPoints");
+  CHECK(results.number_of_grid_points == num_points);
+  // Check max values
+  CHECK(results.reduction_names[2] == "Max(Var0)");
+  CHECK(results.reduction_names[3] == "Max(Var0)");
+  CHECK(results.max_values == std::vector<double>{5.0, 5.0});
+
+  // Check min values
+  CHECK(results.reduction_names[4] == "Min(Var1_x)");
+  CHECK(results.reduction_names[5] == "Min(Var1_y)");
+  CHECK(results.reduction_names[6] == "Min(Var1_z)");
+  CHECK(results.reduction_names[7] == "Min(Var1)");
+  CHECK(results.min_values == std::vector<double>{6.0, 11.0, 16.0, 6.0});
+
+  // Check L2 norms
+  CHECK(results.reduction_names[8] == "L2Norm(Var1)");
+  CHECK(results.reduction_names[9] == "L2Norm(Var1_x)");
+  CHECK(results.reduction_names[10] == "L2Norm(Var1_y)");
+  CHECK(results.reduction_names[11] == "L2Norm(Var1_z)");
+  CHECK(results.l2_norm_values[0] == approx(23.72762103540934575));
+  CHECK(results.l2_norm_values[1] == approx(8.12403840463596083));
+  CHECK(results.l2_norm_values[2] == approx(13.076696830622021));
+  CHECK(results.l2_norm_values[3] == approx(18.055470085267789));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.ObserveNorms", "[Unit][Evolution]") {
+  test(std::make_unique<Events::ObserveNorms<tmpl::list<Var0, Var1>>>(
+      Events::ObserveNorms<tmpl::list<Var0, Var1>>{
+          "reduction0",
+          {{"Var0", "Max", "Individual"},
+           {"Var1", "Min", "Individual"},
+           {"Var0", "Max", "Sum"},
+           {"Var1", "L2Norm", "Sum"},
+           {"Var1", "L2Norm", "Individual"},
+           {"Var1", "Min", "Sum"}}}));
+
+  INFO("create/serialize");
+  Parallel::register_factory_classes_with_charm<Metavariables>();
+  const auto factory_event =
+      TestHelpers::test_creation<std::unique_ptr<Event>, Metavariables>(
+          // [input_file_examples]
+          R"(
+ObserveNorms:
+  SubfileName: reduction0
+  TensorsToObserve:
+  - Name: Var0
+    NormType: Max
+    Components: Individual
+  - Name: Var1
+    NormType: Min
+    Components: Individual
+  - Name: Var0
+    NormType: Max
+    Components: Sum
+  - Name: Var1
+    NormType: L2Norm
+    Components: Sum
+  - Name: Var1
+    NormType: L2Norm
+    Components: Individual
+  - Name: Var1
+    NormType: Min
+    Components: Sum
+      )");
+  // [input_file_examples]
+  auto serialized_event = serialize_and_deserialize(factory_event);
+  test(std::move(serialized_event));
+}


### PR DESCRIPTION
## Proposed changes

Currently supports Max, Min, and L2Norm. More can be easily added as we need them.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
