### PR TITLE
Compute AddSub symmetry using operand symmetries and index orders

### DIFF
--- a/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
+++ b/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_Expressions")
 
 set(LIBRARY_SOURCES
+  Test_AddSubSymmetry.cpp
   Test_AddSubtract.cpp
   Test_Contract.cpp
   Test_Evaluate.cpp

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubSymmetry.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubSymmetry.cpp
@@ -1,0 +1,237 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+#include <type_traits>
+
+#include "DataStructures/Tensor/Symmetry.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+template <auto&... TensorIndices>
+using make_tensorindex_list =
+    tmpl::list<std::decay_t<decltype(TensorIndices)>...>;
+
+void test_impl_consistency() {
+  const std::string error_msg =
+      "Symmetry and AddSubSymmetry are no longer using the same canonical "
+      "form. You must update the implementation for "
+      "TensorExpressions::detail::get_addsub_symm to use the same canonical "
+      "form as Symmetry and update the expected result symmetries for the unit "
+      "test cases in this file.";
+
+  if (not std::is_same_v<Symmetry<>, tmpl::integral_list<std::int32_t>>) {
+    ERROR(error_msg);
+  }
+  if (not std::is_same_v<Symmetry<4>, tmpl::integral_list<std::int32_t, 1>>) {
+    ERROR(error_msg);
+  }
+  if (not std::is_same_v<Symmetry<1, 2>,
+                         tmpl::integral_list<std::int32_t, 2, 1>>) {
+    ERROR(error_msg);
+  }
+  if (not std::is_same_v<Symmetry<3, 5>,
+                         tmpl::integral_list<std::int32_t, 2, 1>>) {
+    ERROR(error_msg);
+  }
+  if (not std::is_same_v<Symmetry<2, 2, 2>,
+                         tmpl::integral_list<std::int32_t, 1, 1, 1>>) {
+    ERROR(error_msg);
+  }
+  if (not std::is_same_v<Symmetry<8, 4, 5, 5, 8>,
+                         tmpl::integral_list<std::int32_t, 1, 3, 2, 2, 1>>) {
+    ERROR(error_msg);
+  }
+}
+
+void test_rank0() {
+  using symm = Symmetry<>;
+  using tensorindex_list = make_tensorindex_list<>;
+
+  CHECK(
+      std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+                         symm, symm, tensorindex_list, tensorindex_list>::type,
+                     tmpl::integral_list<std::int32_t>>);
+}
+
+void test_rank1() {
+  using symm = Symmetry<1>;
+  using tensorindex_list = make_tensorindex_list<ti_a>;
+
+  CHECK(
+      std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+                         symm, symm, tensorindex_list, tensorindex_list>::type,
+                     tmpl::integral_list<std::int32_t, 1>>);
+}
+
+void test_rank2() {
+  using symmetric_symm = Symmetry<1, 1>;
+  using asymmetric_symm = Symmetry<2, 1>;
+  using tensorindex_list_ij = make_tensorindex_list<ti_i, ti_j>;
+  using tensorindex_list_ji = make_tensorindex_list<ti_j, ti_i>;
+
+  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+                           symmetric_symm, symmetric_symm, tensorindex_list_ij,
+                           tensorindex_list_ij>::type,
+                       tmpl::integral_list<std::int32_t, 1, 1>>);
+
+  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+                           symmetric_symm, symmetric_symm, tensorindex_list_ij,
+                           tensorindex_list_ji>::type,
+                       tmpl::integral_list<std::int32_t, 1, 1>>);
+
+  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+                           asymmetric_symm, symmetric_symm, tensorindex_list_ij,
+                           tensorindex_list_ij>::type,
+                       tmpl::integral_list<std::int32_t, 2, 1>>);
+
+  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+                           asymmetric_symm, symmetric_symm, tensorindex_list_ij,
+                           tensorindex_list_ji>::type,
+                       tmpl::integral_list<std::int32_t, 2, 1>>);
+
+  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+                           symmetric_symm, asymmetric_symm, tensorindex_list_ij,
+                           tensorindex_list_ij>::type,
+                       tmpl::integral_list<std::int32_t, 2, 1>>);
+
+  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+                           symmetric_symm, asymmetric_symm, tensorindex_list_ij,
+                           tensorindex_list_ji>::type,
+                       tmpl::integral_list<std::int32_t, 2, 1>>);
+}
+
+void test_rank3() {
+  using symm_111 = Symmetry<1, 1, 1>;
+  using symm_121 = Symmetry<1, 2, 1>;
+  using symm_211 = Symmetry<2, 1, 1>;
+  using symm_221 = Symmetry<2, 2, 1>;
+  using symm_321 = Symmetry<3, 2, 1>;
+
+  using tensorindex_list_abc = make_tensorindex_list<ti_a, ti_b, ti_c>;
+  using tensorindex_list_acb = make_tensorindex_list<ti_a, ti_c, ti_b>;
+  using tensorindex_list_bac = make_tensorindex_list<ti_b, ti_a, ti_c>;
+  using tensorindex_list_bca = make_tensorindex_list<ti_b, ti_c, ti_a>;
+  using tensorindex_list_cab = make_tensorindex_list<ti_c, ti_a, ti_b>;
+  using tensorindex_list_cba = make_tensorindex_list<ti_c, ti_b, ti_a>;
+
+  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+                           symm_111, symm_121, tensorindex_list_abc,
+                           tensorindex_list_bca>::type,
+                       tmpl::integral_list<std::int32_t, 2, 2, 1>>);
+
+  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+                           symm_121, symm_111, tensorindex_list_abc,
+                           tensorindex_list_bca>::type,
+                       tmpl::integral_list<std::int32_t, 1, 2, 1>>);
+
+  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+                           symm_111, symm_221, tensorindex_list_abc,
+                           tensorindex_list_acb>::type,
+                       tmpl::integral_list<std::int32_t, 1, 2, 1>>);
+
+  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+                           symm_221, symm_111, tensorindex_list_abc,
+                           tensorindex_list_acb>::type,
+                       tmpl::integral_list<std::int32_t, 2, 2, 1>>);
+
+  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+                           symm_121, symm_221, tensorindex_list_abc,
+                           tensorindex_list_cab>::type,
+                       tmpl::integral_list<std::int32_t, 1, 2, 1>>);
+
+  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+                           symm_221, symm_121, tensorindex_list_abc,
+                           tensorindex_list_cab>::type,
+                       tmpl::integral_list<std::int32_t, 3, 2, 1>>);
+
+  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+                           symm_221, symm_121, tensorindex_list_cab,
+                           tensorindex_list_abc>::type,
+                       tmpl::integral_list<std::int32_t, 2, 2, 1>>);
+
+  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+                           symm_121, symm_221, tensorindex_list_cab,
+                           tensorindex_list_abc>::type,
+                       tmpl::integral_list<std::int32_t, 3, 2, 1>>);
+
+  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+                           symm_121, symm_221, tensorindex_list_abc,
+                           tensorindex_list_acb>::type,
+                       tmpl::integral_list<std::int32_t, 1, 2, 1>>);
+
+  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+                           symm_221, symm_121, tensorindex_list_abc,
+                           tensorindex_list_acb>::type,
+                       tmpl::integral_list<std::int32_t, 2, 2, 1>>);
+
+  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+                           symm_111, symm_321, tensorindex_list_abc,
+                           tensorindex_list_bac>::type,
+                       tmpl::integral_list<std::int32_t, 3, 2, 1>>);
+
+  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+                           symm_321, symm_111, tensorindex_list_abc,
+                           tensorindex_list_bac>::type,
+                       tmpl::integral_list<std::int32_t, 3, 2, 1>>);
+
+  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+                           symm_211, symm_321, tensorindex_list_abc,
+                           tensorindex_list_cba>::type,
+                       tmpl::integral_list<std::int32_t, 3, 2, 1>>);
+
+  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+                           symm_321, symm_211, tensorindex_list_abc,
+                           tensorindex_list_cba>::type,
+                       tmpl::integral_list<std::int32_t, 3, 2, 1>>);
+}
+
+void test_high_rank() {
+  using tensorindex_list = make_tensorindex_list<ti_a, ti_b, ti_c, ti_d, ti_e>;
+
+  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+                           Symmetry<2, 1, 1, 1, 1>, Symmetry<3, 2, 2, 1, 1>,
+                           tensorindex_list, tensorindex_list>::type,
+                       tmpl::integral_list<std::int32_t, 3, 2, 2, 1, 1>>);
+
+  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+                           Symmetry<3, 2, 2, 1, 1>, Symmetry<2, 1, 1, 1, 1>,
+                           tensorindex_list, tensorindex_list>::type,
+                       tmpl::integral_list<std::int32_t, 3, 2, 2, 1, 1>>);
+
+  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+                           Symmetry<1, 1, 2, 1, 1>, Symmetry<4, 3, 1, 2, 1>,
+                           tensorindex_list, tensorindex_list>::type,
+                       tmpl::integral_list<std::int32_t, 5, 4, 3, 2, 1>>);
+
+  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+                           Symmetry<4, 3, 1, 2, 1>, Symmetry<1, 1, 2, 1, 1>,
+                           tensorindex_list, tensorindex_list>::type,
+                       tmpl::integral_list<std::int32_t, 5, 4, 3, 2, 1>>);
+
+  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+                           Symmetry<1, 2, 2, 2, 1>, Symmetry<1, 2, 1, 1, 1>,
+                           tensorindex_list, tensorindex_list>::type,
+                       tmpl::integral_list<std::int32_t, 1, 3, 2, 2, 1>>);
+
+  CHECK(std::is_same_v<typename TensorExpressions::detail::AddSubSymmetry<
+                           Symmetry<1, 2, 1, 1, 1>, Symmetry<1, 2, 2, 2, 1>,
+                           tensorindex_list, tensorindex_list>::type,
+                       tmpl::integral_list<std::int32_t, 1, 3, 2, 2, 1>>);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubSymmetry",
+                  "[DataStructures][Unit]") {
+  test_impl_consistency();
+  test_rank0();
+  test_rank1();
+  test_rank2();
+  test_rank3();
+  test_high_rank();
+}

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubtract.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_AddSubtract.cpp
@@ -124,12 +124,22 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
       Hll{};
   std::iota(Hll.begin(), Hll.end(), 0.0);
   // [use_tensor_index]
-  auto Gll = TensorExpressions::evaluate<ti_a, ti_b>(All(ti_a, ti_b) +
-                                                     Hll(ti_a, ti_b));
-  auto Gll2 = TensorExpressions::evaluate<ti_a, ti_b>(All(ti_a, ti_b) +
-                                                      Hll(ti_b, ti_a));
-  auto Gll3 = TensorExpressions::evaluate<ti_a, ti_b>(
-      All(ti_a, ti_b) + Hll(ti_b, ti_a) + All(ti_b, ti_a) - Hll(ti_b, ti_a));
+  const Tensor<double, Symmetry<2, 1>,
+               index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
+      Gll = TensorExpressions::evaluate<ti_a, ti_b>(All(ti_a, ti_b) +
+                                                    Hll(ti_a, ti_b));
+  const Tensor<double, Symmetry<2, 1>,
+               index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
+      Gll2 = TensorExpressions::evaluate<ti_a, ti_b>(All(ti_a, ti_b) +
+                                                     Hll(ti_b, ti_a));
+  const Tensor<double, Symmetry<2, 1>,
+               index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
+      Gll3 = TensorExpressions::evaluate<ti_a, ti_b>(
+          All(ti_a, ti_b) + Hll(ti_b, ti_a) + All(ti_b, ti_a) -
+          Hll(ti_b, ti_a));
   // [use_tensor_index]
   for (int i = 0; i < 4; ++i) {
     for (int j = 0; j < 4; ++j) {
@@ -151,19 +161,57 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
                     SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
       Hlll{};
   std::iota(Hlll.begin(), Hlll.end(), 0.0);
-  auto Glll = TensorExpressions::evaluate<ti_a, ti_b, ti_c>(
-      Alll(ti_a, ti_b, ti_c) + Hlll(ti_a, ti_b, ti_c));
-  auto Glll2 = TensorExpressions::evaluate<ti_a, ti_b, ti_c>(
-      Alll(ti_a, ti_b, ti_c) + Hlll(ti_b, ti_a, ti_c));
-  auto Glll3 = TensorExpressions::evaluate<ti_a, ti_b, ti_c>(
-      Alll(ti_a, ti_b, ti_c) + Hlll(ti_b, ti_a, ti_c) + Alll(ti_b, ti_a, ti_c) -
-      Hlll(ti_b, ti_a, ti_c));
+  Tensor<double, Symmetry<2, 1, 1>,
+         index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
+      Rlll{};
+  std::iota(Rlll.begin(), Rlll.end(), 0.0);
+
+  const Tensor<double, Symmetry<3, 2, 1>,
+               index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
+      Glll = TensorExpressions::evaluate<ti_a, ti_b, ti_c>(
+          Alll(ti_a, ti_b, ti_c) + Hlll(ti_a, ti_b, ti_c));
+  const Tensor<double, Symmetry<3, 2, 1>,
+               index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
+      Glll2 = TensorExpressions::evaluate<ti_a, ti_b, ti_c>(
+          Alll(ti_a, ti_b, ti_c) + Hlll(ti_b, ti_a, ti_c));
+  const Tensor<double, Symmetry<3, 2, 1>,
+               index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
+      Glll3 = TensorExpressions::evaluate<ti_a, ti_b, ti_c>(
+          Alll(ti_a, ti_b, ti_c) + Hlll(ti_b, ti_a, ti_c) +
+          Alll(ti_b, ti_a, ti_c) - Hlll(ti_b, ti_a, ti_c));
+  // testing LHS symmetry is nonsymmetric when RHS operands do not have
+  // symmetries in common
+  const Tensor<double, Symmetry<3, 2, 1>,
+               index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
+      Glll4 = TensorExpressions::evaluate<ti_a, ti_b, ti_c>(
+          Alll(ti_b, ti_c, ti_a) + Rlll(ti_c, ti_a, ti_b));
+  // testing LHS symmetry preserves shared RHS symmetry when RHS operands have
+  // symmetries in common
+  const Tensor<double, Symmetry<2, 1, 1>,
+               index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                          SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>
+      Glll5 = TensorExpressions::evaluate<ti_a, ti_b, ti_c>(
+          Alll(ti_b, ti_c, ti_a) - Rlll(ti_a, ti_c, ti_b));
+
   for (int i = 0; i < 4; ++i) {
     for (int j = 0; j < 4; ++j) {
       for (int k = 0; k < 4; ++k) {
         CHECK(Glll.get(i, j, k) == Alll.get(i, j, k) + Hlll.get(i, j, k));
         CHECK(Glll2.get(i, j, k) == Alll.get(i, j, k) + Hlll.get(j, i, k));
         CHECK(Glll3.get(i, j, k) == 2.0 * Alll.get(i, j, k));
+        CHECK(Glll4.get(i, j, k) == Alll.get(j, k, i) + Rlll.get(k, i, j));
+        CHECK(Glll5.get(i, j, k) == Alll.get(j, k, i) - Rlll.get(i, k, j));
       }
     }
   }


### PR DESCRIPTION
## Proposed changes

This PR concerns the symmetry of `AddSub` expressions. `AddSub` expressions represent the addition or subtraction of two tensor expressions, and its symmetry represents the symmetry of the tensor resulting from adding/subtracting the two operands. This PR fixes and tests the computation of this symmetry by accounting for the symmetries and differences in the generic index orders of the two operands. The rule used by the fix: the symmetry of the result (`AddSub`'s symmetry) contains symmetries iff those symmetries are present in both operands.

See **Further comments** for an example test case that currently computes the resultant symmetry incorrectly. `Test_AddSubSymmetry.cpp` directly tests the underlying implementation of the fix and the two new test cases added to `Test_AddSubtract.cpp` test the fix at a higher level with two real tensor expressions. These last two test cases are similar in principle to the example in **Further comments**.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

**Motivating example**
Equation:
- written: `L_abc = R_abc - S_abc`
- code:
```
auto L = TensorExpressions::evaluate<ti_a, ti_b, ti_c>(R(ti_a, ti_b, ti_c) - S(ti_a, ti_b, ti_c));
```
`R` symmetry: `[2, 2, 1]` --> a and b are symmetric
`S` symmetry: `[2, 1, 1]` --> b and c are symmetric

Regardless of the LHS index order, the resultant tensor's symmetry should be asymmetric (`[3, 2, 1]`). However, the current code just takes the maximum between `R` and `S`' symmetry values at each position (which is then canonicalized by `Symmetry`). So, the current code will say the symmetry of the result is `[2, 2, 1]`, implying a symmetry between the first two indices of the first operand (i.e. regardless of LHS index order, `AddSub` is incorrectly saying the result's `a` and `b` indices are symmetric).

This PR fixes this by taking index order into account and looking for symmetries that the two operands have in common. With the fix, the resultant symmetry only contains symmetries shared by the two operands.
