### PR TITLE
Switch compute tags to simple tags for elliptic domain geometry

### DIFF
--- a/src/Domain/InterfaceHelpers.hpp
+++ b/src/Domain/InterfaceHelpers.hpp
@@ -37,6 +37,13 @@ struct make_interface_tag {
                                    domain::Tags::Interface<DirectionsTag, Tag>>;
 };
 
+template <typename TagsList, typename DirectionsTag,
+          typename VolumeTags = tmpl::list<>>
+using make_interface_tags =
+    tmpl::transform<TagsList,
+                    make_interface_tag<tmpl::_1, tmpl::pin<DirectionsTag>,
+                                       tmpl::pin<VolumeTags>>>;
+
 namespace InterfaceHelpers_detail {
 
 // Retrieve the `argument_tags` from the `InterfaceInvokable` and wrap them in

--- a/src/Elliptic/DiscontinuousGalerkin/Actions/InitializeDomain.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Actions/InitializeDomain.hpp
@@ -3,35 +3,27 @@
 
 #pragma once
 
-#include <array>
 #include <cstddef>
 #include <tuple>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
-#include "Domain/CreateInitialElement.hpp"
-#include "Domain/Domain.hpp"
-#include "Domain/ElementMap.hpp"
-#include "Domain/LogicalCoordinates.hpp"
-#include "Domain/MinimumGridSpacing.hpp"
-#include "Domain/Structure/CreateInitialMesh.hpp"
-#include "Domain/Structure/Element.hpp"
-#include "Domain/Structure/ElementId.hpp"
 #include "Domain/Tags.hpp"
-#include "NumericalAlgorithms/Spectral/Mesh.hpp"
-#include "Parallel/GlobalCache.hpp"
-#include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
-#include "Utilities/Requires.hpp"
+#include "Elliptic/DiscontinuousGalerkin/Initialization.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
-#include "Utilities/TaggedTuple.hpp"
 
 /// \cond
+namespace Parallel {
+template <typename Metavariables>
+struct GlobalCache;
+}  // namespace Parallel
+namespace tuples {
+template <typename... Tags>
+struct TaggedTuple;
+}  // namespace tuples
 template <size_t VolumeDim>
 class ElementId;
-namespace Frame {
-struct Inertial;
-}  // namespace Frame
 /// \endcond
 
 namespace elliptic::dg::Actions {
@@ -39,24 +31,19 @@ namespace elliptic::dg::Actions {
  * \ingroup InitializationGroup
  * \brief Initialize items related to the basic structure of the element
  *
- * GlobalCache:
- * - Uses:
- *   - `Tags::Domain<Dim, Frame::Inertial>`
  * DataBox:
  * - Uses:
- *   - `Tags::InitialExtents<Dim>`
+ *   - `domain::Tags::Domain<Dim, Frame::Inertial>`
+ *   - `domain::Tags::InitialExtents<Dim>`
+ *   - `domain::Tags::InitialRefinementLevels<Dim>`
  * - Adds:
- *   - `Tags::Mesh<Dim>`
- *   - `Tags::Element<Dim>`
- *   - `Tags::ElementMap<Dim, Frame::Inertial>`
- *   - `Tags::Coordinates<Dim, Frame::Logical>`
- *   - `Tags::Coordinates<Dim, Frame::Inertial>`
- *   - `Tags::InverseJacobianCompute<
- *   Tags::ElementMap<Dim>, Tags::Coordinates<Dim, Frame::Logical>>`
- *   - `Tags::DetInvJacobianCompute<Dim, Frame::Logical, Frame::Inertial>`
- *   - `Tags::MinimumGridSpacingCompute<Dim, Frame::Inertial>>`
- * - Removes: nothing
- * - Modifies: nothing
+ *   - `domain::Tags::Mesh<Dim>`
+ *   - `domain::Tags::Element<Dim>`
+ *   - `domain::Tags::ElementMap<Dim, Frame::Inertial>`
+ *   - `domain::Tags::Coordinates<Dim, Frame::Logical>`
+ *   - `domain::Tags::Coordinates<Dim, Frame::Inertial>`
+ *   - `domain::Tags::InverseJacobian<Dim, Frame::Logical, Frame::Inertial>`
+ *   - `domain::Tags::DetInvJacobian<Frame::Logical, Frame::Inertial>`
  *
  * \note This action relies on the `SetupDataBox` aggregated initialization
  * mechanism, so `Actions::SetupDataBox` must be present in the `Initialization`
@@ -64,55 +51,28 @@ namespace elliptic::dg::Actions {
  */
 template <size_t Dim>
 struct InitializeDomain {
+ private:
+  using InitializeGeometry = elliptic::dg::InitializeGeometry<Dim>;
+
+ public:
   using initialization_tags =
       tmpl::list<domain::Tags::InitialExtents<Dim>,
                  domain::Tags::InitialRefinementLevels<Dim>>;
+  using simple_tags = typename InitializeGeometry::return_tags;
+  using compute_tags = tmpl::list<>;
 
-  using simple_tags =
-      tmpl::list<domain::Tags::Mesh<Dim>, domain::Tags::Element<Dim>,
-                 domain::Tags::ElementMap<Dim>>;
-  using compute_tags = tmpl::append<db::AddComputeTags<
-      domain::Tags::LogicalCoordinates<Dim>,
-      domain ::Tags::MappedCoordinates<
-          domain::Tags::ElementMap<Dim>,
-          domain ::Tags::Coordinates<Dim, Frame::Logical>>,
-      domain ::Tags::InverseJacobianCompute<
-          domain ::Tags::ElementMap<Dim>,
-          domain::Tags::Coordinates<Dim, Frame::Logical>>,
-      domain::Tags::DetInvJacobianCompute<Dim, Frame::Logical, Frame::Inertial>,
-      domain::Tags::MinimumGridSpacingCompute<Dim, Frame::Inertial>>>;
-
-  template <typename DataBox, typename... InboxTags, typename Metavariables,
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ActionList, typename ParallelComponent>
-  static auto apply(DataBox& box,
-                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
-                    const ElementId<Dim>& element_id, const ActionList /*meta*/,
-                    const ParallelComponent* const /*meta*/) noexcept {
-    const auto& initial_extents =
-        db::get<domain::Tags::InitialExtents<Dim>>(box);
-    const auto& initial_refinement =
-        db::get<domain::Tags::InitialRefinementLevels<Dim>>(box);
-    const auto& domain = db::get<domain::Tags::Domain<Dim>>(box);
-
-    const auto& my_block = domain.blocks()[element_id.block_id()];
-    Mesh<Dim> mesh = domain::Initialization::create_initial_mesh(
-        initial_extents, element_id, Spectral::Quadrature::GaussLobatto);
-    Element<Dim> element = domain::Initialization::create_initial_element(
-        element_id, my_block, initial_refinement);
-    if (my_block.is_time_dependent()) {
-      ERROR(
-          "The version of the InitializeDomain action being used is for "
-          "elliptic systems which do not have any time-dependence but the "
-          "domain creator has set up the domain to have time-dependence.");
-    }
-    ElementMap<Dim, Frame::Inertial> element_map{
-        element_id, my_block.stationary_map().get_clone()};
-    ::Initialization::mutate_assign<simple_tags>(
-        make_not_null(&box), std::move(mesh), std::move(element),
-        std::move(element_map));
-
-    return std::make_tuple(std::move(box));
+  static std::tuple<db::DataBox<DbTagsList>&&> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ElementId<Dim>& element_id, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    db::mutate_apply<typename InitializeGeometry::return_tags,
+                     typename InitializeGeometry::argument_tags>(
+        InitializeGeometry{}, make_not_null(&box), element_id);
+    return {std::move(box)};
   }
 };
 }  // namespace elliptic::dg::Actions

--- a/src/Elliptic/DiscontinuousGalerkin/CMakeLists.txt
+++ b/src/Elliptic/DiscontinuousGalerkin/CMakeLists.txt
@@ -8,6 +8,7 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  Initialization.cpp
   Penalty.cpp
 )
 
@@ -17,6 +18,7 @@ spectre_target_headers(
   HEADERS
   DgElementArray.hpp
   DgOperator.hpp
+  Initialization.hpp
   Penalty.hpp
   Tags.hpp
   )
@@ -25,23 +27,23 @@ target_link_libraries(
   ${LIBRARY}
   PUBLIC
   DataStructures
+  Domain
+  DomainStructure
+  ErrorHandling
+  Spectral
+  Utilities
   INTERFACE
   Boost::boost
   DiscontinuousGalerkin
-  Domain
   DomainCreators
-  DomainStructure
   Elliptic
   EllipticSystems
-  ErrorHandling
   Initialization
   LinearOperators
   Options
   Parallel
   ParallelDg
-  Spectral
   SystemUtilities
-  Utilities
   )
 
 add_subdirectory(Actions)

--- a/src/Elliptic/DiscontinuousGalerkin/Initialization.cpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Initialization.cpp
@@ -1,0 +1,156 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Elliptic/DiscontinuousGalerkin/Initialization.hpp"
+
+#include <array>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/Tensor/EagerMath/Determinant.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CreateInitialElement.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Structure/CreateInitialMesh.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace elliptic::dg {
+
+template <size_t Dim>
+void InitializeGeometry<Dim>::operator()(
+    const gsl::not_null<Mesh<Dim>*> mesh,
+    const gsl::not_null<Element<Dim>*> element,
+    const gsl::not_null<ElementMap<Dim, Frame::Inertial>*> element_map,
+    const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Logical>*>
+        logical_coords,
+    const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+        inertial_coords,
+    const gsl::not_null<
+        InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>*>
+        inv_jacobian,
+    const gsl::not_null<Scalar<DataVector>*> det_inv_jacobian,
+    const std::vector<std::array<size_t, Dim>>& initial_extents,
+    const std::vector<std::array<size_t, Dim>>& initial_refinement,
+    const Domain<Dim>& domain,
+    const ElementId<Dim>& element_id) const noexcept {
+  // Mesh
+  const auto quadrature = Spectral::Quadrature::GaussLobatto;
+  *mesh = domain::Initialization::create_initial_mesh(initial_extents,
+                                                      element_id, quadrature);
+  // Element
+  const auto& block = domain.blocks()[element_id.block_id()];
+  if (block.is_time_dependent()) {
+    ERROR_NO_TRACE(
+        "The InitializeDomain action is for elliptic systems which do not have "
+        "any time-dependence, but the domain creator has set up the domain to "
+        "have time-dependence.");
+  }
+  *element = domain::Initialization::create_initial_element(element_id, block,
+                                                            initial_refinement);
+  // Element map
+  *element_map = ElementMap<Dim, Frame::Inertial>{
+      element_id, block.stationary_map().get_clone()};
+  // Coordinates
+  *logical_coords = logical_coordinates(*mesh);
+  *inertial_coords = element_map->operator()(*logical_coords);
+  // Jacobian
+  *inv_jacobian = element_map->inv_jacobian(*logical_coords);
+  *det_inv_jacobian = determinant(*inv_jacobian);
+}
+
+template <size_t Dim>
+void InitializeFacesAndMortars<Dim>::operator()(
+    const gsl::not_null<std::unordered_set<Direction<Dim>>*>
+        internal_directions,
+    const gsl::not_null<std::unordered_set<Direction<Dim>>*>
+        external_directions,
+    const gsl::not_null<std::unordered_map<Direction<Dim>, Direction<Dim>>*>
+        face_directions_internal,
+    const gsl::not_null<
+        std::unordered_map<Direction<Dim>, tnsr::I<DataVector, Dim>>*>
+        face_inertial_coords_internal,
+    const gsl::not_null<
+        std::unordered_map<Direction<Dim>, tnsr::i<DataVector, Dim>>*>
+        face_normals_internal,
+    const gsl::not_null<std::unordered_map<Direction<Dim>, Scalar<DataVector>>*>
+    /*face_normal_magnitudes_internal*/,
+    const gsl::not_null<std::unordered_map<Direction<Dim>, Direction<Dim>>*>
+        face_directions_external,
+    const gsl::not_null<
+        std::unordered_map<Direction<Dim>, tnsr::I<DataVector, Dim>>*>
+        face_inertial_coords_external,
+    const gsl::not_null<
+        std::unordered_map<Direction<Dim>, tnsr::i<DataVector, Dim>>*>
+        face_normals_external,
+    const gsl::not_null<std::unordered_map<Direction<Dim>, Scalar<DataVector>>*>
+    /*face_normal_magnitudes_external*/,
+    const gsl::not_null<::dg::MortarMap<Dim, Mesh<Dim - 1>>*> mortar_meshes,
+    const gsl::not_null<::dg::MortarMap<Dim, ::dg::MortarSize<Dim - 1>>*>
+        mortar_sizes,
+    const Mesh<Dim>& mesh, const Element<Dim>& element,
+    const ElementMap<Dim, Frame::Inertial>& element_map,
+    const std::vector<std::array<size_t, Dim>>& initial_extents)
+    const noexcept {
+  const Spectral::Quadrature quadrature = mesh.quadrature(0);
+  const auto& element_id = element.id();
+  *internal_directions = element.internal_boundaries();
+  *external_directions = element.external_boundaries();
+  // Internal faces and mortars
+  for (const auto& [direction, neighbors] : element.neighbors()) {
+    const auto face_mesh = mesh.slice_away(direction.dimension());
+    (*face_directions_internal)[direction] = direction;
+    // Possible optimization: Not all systems need the coordinates on internal
+    // faces.
+    (*face_inertial_coords_internal)[direction] = element_map.operator()(
+        interface_logical_coordinates(face_mesh, direction));
+    (*face_normals_internal)[direction] =
+        unnormalized_face_normal(face_mesh, element_map, direction);
+    const auto& orientation = neighbors.orientation();
+    for (const auto& neighbor_id : neighbors) {
+      const ::dg::MortarId<Dim> mortar_id{direction, neighbor_id};
+      // Geometry on this side of the mortar
+      mortar_meshes->emplace(
+          mortar_id, ::dg::mortar_mesh(
+                         face_mesh, domain::Initialization::create_initial_mesh(
+                                        initial_extents, neighbor_id,
+                                        quadrature, orientation)
+                                        .slice_away(direction.dimension())));
+      mortar_sizes->emplace(
+          mortar_id, ::dg::mortar_size(element_id, neighbor_id,
+                                       direction.dimension(), orientation));
+    }  // neighbors
+  }    // internal directions
+  // External faces and mortars
+  for (const auto& direction : element.external_boundaries()) {
+    const auto face_mesh = mesh.slice_away(direction.dimension());
+    (*face_directions_external)[direction] = direction;
+    (*face_inertial_coords_external)[direction] = element_map.operator()(
+        interface_logical_coordinates(face_mesh, direction));
+    (*face_normals_external)[direction] =
+        unnormalized_face_normal(face_mesh, element_map, direction);
+    const auto mortar_id =
+        std::make_pair(direction, ElementId<Dim>::external_boundary_id());
+    mortar_meshes->emplace(mortar_id, face_mesh);
+    mortar_sizes->emplace(mortar_id,
+                          make_array<Dim - 1>(Spectral::MortarSize::Full));
+  }  // external directions
+}
+
+template class InitializeGeometry<1>;
+template class InitializeGeometry<2>;
+template class InitializeGeometry<3>;
+template class InitializeFacesAndMortars<1>;
+template class InitializeFacesAndMortars<2>;
+template class InitializeFacesAndMortars<3>;
+
+}  // namespace elliptic::dg

--- a/src/Elliptic/DiscontinuousGalerkin/Initialization.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Initialization.hpp
@@ -1,0 +1,205 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/SliceVariables.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/IndexToSliceAt.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/DiscontinuousGalerkin/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace elliptic::dg {
+
+/// Initialize the background-independent geometry for the elliptic DG operator
+template <size_t Dim>
+struct InitializeGeometry {
+  using return_tags = tmpl::list<
+      domain::Tags::Mesh<Dim>, domain::Tags::Element<Dim>,
+      domain::Tags::ElementMap<Dim>,
+      domain::Tags::Coordinates<Dim, Frame::Logical>,
+      domain::Tags::Coordinates<Dim, Frame::Inertial>,
+      domain::Tags::InverseJacobian<Dim, Frame::Logical, Frame::Inertial>,
+      domain::Tags::DetInvJacobian<Frame::Logical, Frame::Inertial>>;
+  using argument_tags = tmpl::list<domain::Tags::InitialExtents<Dim>,
+                                   domain::Tags::InitialRefinementLevels<Dim>,
+                                   domain::Tags::Domain<Dim>>;
+  void operator()(
+      gsl::not_null<Mesh<Dim>*> mesh, gsl::not_null<Element<Dim>*> element,
+      gsl::not_null<ElementMap<Dim, Frame::Inertial>*> element_map,
+      gsl::not_null<tnsr::I<DataVector, Dim, Frame::Logical>*> logical_coords,
+      gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> inertial_coords,
+      gsl::not_null<
+          InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>*>
+          inv_jacobian,
+      gsl::not_null<Scalar<DataVector>*> det_inv_jacobian,
+      const std::vector<std::array<size_t, Dim>>& initial_extents,
+      const std::vector<std::array<size_t, Dim>>& initial_refinement,
+      const Domain<Dim>& domain,
+      const ElementId<Dim>& element_id) const noexcept;
+};
+
+/// Initialize the geometry on faces and mortars for the elliptic DG operator
+///
+/// Face normals are not yet normalized, and the face-normal magnitudes are not
+/// yet computed at all. Invoke `elliptic::dg::NormalizeFaceNormals` for this
+/// purpose, possibly preceded by `elliptic::dg::InitializeBackground` if the
+/// system has a background metric.
+template <size_t Dim>
+struct InitializeFacesAndMortars {
+ private:
+  // These quantities are currently stored on internal and external faces
+  // separately for compatibility with existing code
+  template <typename DirectionsTag>
+  using face_tags = tmpl::list<
+      domain::Tags::Interface<DirectionsTag, domain::Tags::Direction<Dim>>,
+      domain::Tags::Interface<DirectionsTag,
+                              domain::Tags::Coordinates<Dim, Frame::Inertial>>,
+      domain::Tags::Interface<
+          DirectionsTag,
+          ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>>,
+      domain::Tags::Interface<
+          DirectionsTag,
+          ::Tags::Magnitude<domain::Tags::UnnormalizedFaceNormal<Dim>>>>;
+
+ public:
+  using return_tags = tmpl::flatten<
+      tmpl::list<domain::Tags::InternalDirections<Dim>,
+                 domain::Tags::BoundaryDirectionsInterior<Dim>,
+                 face_tags<domain::Tags::InternalDirections<Dim>>,
+                 face_tags<domain::Tags::BoundaryDirectionsInterior<Dim>>,
+                 ::Tags::Mortars<domain::Tags::Mesh<Dim - 1>, Dim>,
+                 ::Tags::Mortars<::Tags::MortarSize<Dim - 1>, Dim>>>;
+  using argument_tags =
+      tmpl::list<domain::Tags::Mesh<Dim>, domain::Tags::Element<Dim>,
+                 domain::Tags::ElementMap<Dim>>;
+  void operator()(
+      gsl::not_null<std::unordered_set<Direction<Dim>>*> internal_directions,
+      gsl::not_null<std::unordered_set<Direction<Dim>>*> external_directions,
+      gsl::not_null<std::unordered_map<Direction<Dim>, Direction<Dim>>*>
+          face_directions_internal,
+      gsl::not_null<
+          std::unordered_map<Direction<Dim>, tnsr::I<DataVector, Dim>>*>
+          face_inertial_coords_internal,
+      gsl::not_null<
+          std::unordered_map<Direction<Dim>, tnsr::i<DataVector, Dim>>*>
+          face_normals_internal,
+      gsl::not_null<std::unordered_map<Direction<Dim>, Scalar<DataVector>>*>
+          face_normal_magnitudes_internal,
+      gsl::not_null<std::unordered_map<Direction<Dim>, Direction<Dim>>*>
+          face_directions_external,
+      gsl::not_null<
+          std::unordered_map<Direction<Dim>, tnsr::I<DataVector, Dim>>*>
+          face_inertial_coords_external,
+      gsl::not_null<
+          std::unordered_map<Direction<Dim>, tnsr::i<DataVector, Dim>>*>
+          face_normals_external,
+      gsl::not_null<std::unordered_map<Direction<Dim>, Scalar<DataVector>>*>
+          face_normal_magnitudes_external,
+      gsl::not_null<::dg::MortarMap<Dim, Mesh<Dim - 1>>*> mortar_meshes,
+      gsl::not_null<::dg::MortarMap<Dim, ::dg::MortarSize<Dim - 1>>*>
+          mortar_sizes,
+      const Mesh<Dim>& mesh, const Element<Dim>& element,
+      const ElementMap<Dim, Frame::Inertial>& element_map,
+      const std::vector<std::array<size_t, Dim>>& initial_extents)
+      const noexcept;
+};
+
+/// Initialize background quantities for the elliptic DG operator, possibly
+/// including the metric necessary for normalizing face normals
+template <size_t Dim, typename BackgroundFields>
+struct InitializeBackground {
+  using return_tags = tmpl::list<
+      ::Tags::Variables<BackgroundFields>,
+      domain::Tags::Interface<domain::Tags::InternalDirections<Dim>,
+                              ::Tags::Variables<BackgroundFields>>,
+      domain::Tags::Interface<domain::Tags::BoundaryDirectionsInterior<Dim>,
+                              ::Tags::Variables<BackgroundFields>>>;
+  using argument_tags = tmpl::list<
+      domain::Tags::Coordinates<Dim, Frame::Inertial>, domain::Tags::Mesh<Dim>,
+      domain::Tags::InverseJacobian<Dim, Frame::Logical, Frame::Inertial>,
+      domain::Tags::Element<Dim>>;
+
+  template <typename Background>
+  void operator()(
+      const gsl::not_null<Variables<BackgroundFields>*> background_fields,
+      const gsl::not_null<
+          std::unordered_map<Direction<Dim>, Variables<BackgroundFields>>*>
+          face_background_fields_internal,
+      const gsl::not_null<
+          std::unordered_map<Direction<Dim>, Variables<BackgroundFields>>*>
+          face_background_fields_external,
+      const tnsr::I<DataVector, Dim>& inertial_coords, const Mesh<Dim>& mesh,
+      const InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>&
+          inv_jacobian,
+      const Element<Dim>& element,
+      const Background& background) const noexcept {
+    *background_fields = variables_from_tagged_tuple(background.variables(
+        inertial_coords, mesh, inv_jacobian, BackgroundFields{}));
+    ASSERT(mesh.quadrature(0) == Spectral::Quadrature::GaussLobatto,
+           "Only Gauss-Lobatto quadrature is currently implemented for "
+           "slicing background fields to faces.");
+    for (const auto& direction : element.internal_boundaries()) {
+      // Possible optimization: Only the background fields in the
+      // System::fluxes_computer::argument_tags are needed on internal faces.
+      data_on_slice(
+          make_not_null(&(*face_background_fields_internal)[direction]),
+          *background_fields, mesh.extents(), direction.dimension(),
+          index_to_slice_at(mesh.extents(), direction));
+    }
+    for (const auto& direction : element.external_boundaries()) {
+      data_on_slice(
+          make_not_null(&(*face_background_fields_external)[direction]),
+          *background_fields, mesh.extents(), direction.dimension(),
+          index_to_slice_at(mesh.extents(), direction));
+    }
+  }
+};
+
+/// Normalize face normals, possibly using a background metric. Set
+/// `InvMetricTag` to `void` to normalize face normals with the Euclidean
+/// magnitude.
+template <size_t Dim, typename InvMetricTag>
+struct NormalizeFaceNormal {
+  using return_tags =
+      tmpl::list<::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>,
+                 ::Tags::Magnitude<domain::Tags::UnnormalizedFaceNormal<Dim>>>;
+  using argument_tags =
+      tmpl::conditional_t<std::is_same_v<InvMetricTag, void>, tmpl::list<>,
+                          tmpl::list<InvMetricTag>>;
+
+  template <typename... InvMetric>
+  void operator()(
+      const gsl::not_null<tnsr::i<DataVector, Dim>*> face_normal,
+      const gsl::not_null<Scalar<DataVector>*> face_normal_magnitude,
+      const InvMetric&... inv_metric) const noexcept {
+    magnitude(face_normal_magnitude, *face_normal, inv_metric...);
+    for (size_t d = 0; d < Dim; ++d) {
+      face_normal->get(d) /= get(*face_normal_magnitude);
+    }
+  }
+};
+
+}  // namespace elliptic::dg

--- a/src/Elliptic/Executables/Xcts/SolveXcts.hpp
+++ b/src/Elliptic/Executables/Xcts/SolveXcts.hpp
@@ -9,7 +9,6 @@
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Tags.hpp"
 #include "Elliptic/Actions/InitializeAnalyticSolution.hpp"
-#include "Elliptic/Actions/InitializeBackgroundFields.hpp"
 #include "Elliptic/Actions/InitializeFields.hpp"
 #include "Elliptic/Actions/InitializeFixedSources.hpp"
 #include "Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp"
@@ -186,12 +185,11 @@ struct Metavariables {
       typename linear_solver::initialize_element,
       elliptic::Actions::InitializeFields<system, initial_guess_tag>,
       elliptic::Actions::InitializeFixedSources<system, background_tag>,
-      elliptic::Actions::InitializeBackgroundFields<system, background_tag>,
       elliptic::Actions::InitializeOptionalAnalyticSolution<
           background_tag, analytic_solution_fields,
           Xcts::Solutions::AnalyticSolution<tmpl::append<
               analytic_solution_registrars, analytic_data_registrars>>>,
-      elliptic::dg::Actions::initialize_operator<system>,
+      elliptic::dg::Actions::initialize_operator<system, background_tag>,
       Initialization::Actions::RemoveOptionsAndTerminatePhase>;
 
   template <bool Linearized>

--- a/src/Elliptic/Utilities/ApplyAt.hpp
+++ b/src/Elliptic/Utilities/ApplyAt.hpp
@@ -54,7 +54,7 @@ struct unmap_arg<false, FirstMapKey, MapKeys...> {
       const gsl::not_null<T*> arg,
       const std::tuple<FirstMapKey, MapKeys...>& map_keys) noexcept {
     return unmap_arg<sizeof...(MapKeys) == 0, MapKeys...>::apply(
-        make_not_null(&arg->at(std::get<0>(map_keys))),
+        make_not_null(&arg->operator[](std::get<0>(map_keys))),
         tuple_tail<sizeof...(MapKeys)>(map_keys));
   }
 };

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/CMakeLists.txt
@@ -33,6 +33,8 @@ target_link_libraries(
   PoissonSolutions
   Spectral
   Utilities
+  Xcts
+  XctsSolutions
   )
 
 add_subdirectory(Actions)

--- a/tests/Unit/Elliptic/Utilities/Test_ApplyAt.cpp
+++ b/tests/Unit/Elliptic/Utilities/Test_ApplyAt.cpp
@@ -78,7 +78,6 @@ void test_mutate_apply_at() noexcept {
                     tmpl::list<NonMapTag>>(
         [](const gsl::not_null<std::string*> mutate_arg, const int arg0,
            const std::unordered_map<std::string, bool>& arg2) {
-          CHECK(*mutate_arg == "A");
           *mutate_arg = "B";
           CHECK(arg0 == 1);
           CHECK(arg2.at("key") == true);
@@ -110,7 +109,7 @@ void test_mutate_apply_at() noexcept {
   };
   check(db::create<
         db::AddSimpleTags<MapTag, NonMapTag, NestedMapTag, DirectionMapTag>>(
-      std::map<int, std::string>{{0, "A"}}, 1,
+      std::map<int, std::string>{}, 1,
       std::map<int, std::unordered_map<std::string, bool>>{
           {0, {{"key", true}}}},
       DirectionMap<1, bool>{{Direction<1>::lower_xi(), true}}));

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
@@ -14,7 +14,7 @@ add_test_library(
   ${LIBRARY}
   "ParallelAlgorithms/DiscontinuousGalerkin/"
   "${LIBRARY_SOURCES}"
-  "CoordinateMaps;DataStructures;Domain;DiscontinuousGalerkin;ErrorHandling;Utilities"
+  "CoordinateMaps;DataStructures;Domain;DiscontinuousGalerkin;EllipticDg;ErrorHandling;Utilities"
   )
 
 add_dependencies(


### PR DESCRIPTION
## Proposed changes

- Init all geometry-related tags for the elliptic DG operator in simple
  tags. The geometry doesn't change during the elliptic solve, so
  there's no need for compute tags.
- Init background fields along with the face normals, because the
  normalization depends on the background metric.
- The functions will be re-usable by the subdomain initializer (#3127)

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
