### PR TITLE
Restrict Variables subitems to Tags::Variables

### DIFF
--- a/src/Evolution/DgSubcell/Tags/Inactive.hpp
+++ b/src/Evolution/DgSubcell/Tags/Inactive.hpp
@@ -25,10 +25,16 @@ struct Inactive : db::PrefixTag, db::SimpleTag {
   using type = typename tag::type;
 };
 
-/// \copydoc Inactive
+/// \cond
+// This tag currently exposes its constituents as subitems. Possible
+// compile-time optimization: Remove this template specialization and use
+// `Inactive<VariablesTag<tmpl::list<Tag1, Tag2>>>` instead of the individual
+// `Inactive<Tag1>`.
 template <typename TagList>
-struct Inactive<::Tags::Variables<TagList>> : db::PrefixTag, db::SimpleTag {
+struct Inactive<::Tags::Variables<TagList>>
+    : ::Tags::Variables<db::wrap_tags_in<Inactive, TagList>> {
   using tag = ::Tags::Variables<TagList>;
   using type = Variables<db::wrap_tags_in<Inactive, TagList>>;
 };
+/// \endcond
 }  // namespace evolution::dg::subcell::Tags

--- a/src/Evolution/DgSubcell/Tags/OnSubcells.hpp
+++ b/src/Evolution/DgSubcell/Tags/OnSubcells.hpp
@@ -26,9 +26,13 @@ struct OnSubcells : db::PrefixTag, db::SimpleTag {
 };
 
 /// \cond
+// This tag currently exposes its constituents as subitems. Possible
+// compile-time optimization: Remove this template specialization and use
+// `OnSubcells<VariablesTag<tmpl::list<Tag1, Tag2>>>` instead of the individual
+// `OnSubcells<Tag1>`.
 template <typename TagList>
-struct OnSubcells<::Tags::Variables<TagList>> : db::PrefixTag,
-                                                   db::SimpleTag {
+struct OnSubcells<::Tags::Variables<TagList>>
+    : ::Tags::Variables<db::wrap_tags_in<OnSubcells, TagList>> {
  private:
   using wrapped_tags_list = db::wrap_tags_in<OnSubcells, TagList>;
 

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -896,10 +896,8 @@ void multiply_variables_by_two(
 }  // namespace
 
 namespace test_databox_tags {
-struct MultiplyScalarByTwo : db::SimpleTag {
-  using type = Variables<
-      tmpl::list<test_databox_tags::ScalarTag2, test_databox_tags::VectorTag2>>;
-};
+using MultiplyScalarByTwo = ::Tags::Variables<
+    tmpl::list<test_databox_tags::ScalarTag2, test_databox_tags::VectorTag2>>;
 
 struct MultiplyScalarByTwoCompute : MultiplyScalarByTwo, db::ComputeTag {
   using base = MultiplyScalarByTwo;
@@ -942,10 +940,8 @@ struct DivideScalarByThreeCompute : DivideScalarByThree, db::ComputeTag {
   using argument_tags = tmpl::list<test_databox_tags::MultiplyScalarByThree>;
 };
 
-struct DivideScalarByTwo : db::SimpleTag {
-  using type = Variables<
-      tmpl::list<test_databox_tags::VectorTag3, test_databox_tags::ScalarTag3>>;
-};
+using DivideScalarByTwo = ::Tags::Variables<
+    tmpl::list<test_databox_tags::VectorTag3, test_databox_tags::ScalarTag3>>;
 
 struct DivideScalarByTwoCompute : DivideScalarByTwo, db::ComputeTag {
   using base = DivideScalarByTwo;
@@ -955,10 +951,8 @@ struct DivideScalarByTwoCompute : DivideScalarByTwo, db::ComputeTag {
   using argument_tags = tmpl::list<test_databox_tags::DivideScalarByThree>;
 };
 
-struct MultiplyVariablesByTwo : db::SimpleTag {
-  using type = Variables<
-      tmpl::list<test_databox_tags::ScalarTag4, test_databox_tags::VectorTag4>>;
-};
+using MultiplyVariablesByTwo = ::Tags::Variables<
+    tmpl::list<test_databox_tags::ScalarTag4, test_databox_tags::VectorTag4>>;
 
 struct MultiplyVariablesByTwoCompute : MultiplyVariablesByTwo, db::ComputeTag {
   using base = MultiplyVariablesByTwo;

--- a/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
@@ -92,12 +92,12 @@ SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Tags",
       evolution::dg::subcell::Tags::Inactive<Var1>>("Inactive(Var1)");
   TestHelpers::db::test_simple_tag<evolution::dg::subcell::Tags::Inactive<
       ::Tags::Variables<tmpl::list<Var1, Var2>>>>(
-      "Inactive(Variables(Var1,Var2))");
+      "Variables(Inactive(Var1),Inactive(Var2))");
   TestHelpers::db::test_simple_tag<
       evolution::dg::subcell::Tags::OnSubcells<Var1>>("OnSubcells(Var1)");
   TestHelpers::db::test_simple_tag<evolution::dg::subcell::Tags::OnSubcells<
       ::Tags::Variables<tmpl::list<Var1, Var2>>>>(
-      "OnSubcells(Variables(Var1,Var2))");
+      "Variables(OnSubcells(Var1),OnSubcells(Var2))");
   TestHelpers::db::test_simple_tag<
       evolution::dg::subcell::Tags::SubcellOptions>("SubcellOptions");
   TestHelpers::db::test_simple_tag<

--- a/tests/Unit/Evolution/Test_ComputeTags.cpp
+++ b/tests/Unit/Evolution/Test_ComputeTags.cpp
@@ -52,7 +52,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.ComputeTags", "[Unit][Evolution]") {
           1, AnalyticSolutionTag, tmpl::list<FieldTag>>>>(
       std::move(inertial_coords), AnalyticSolution{}, current_time);
   const DataVector expected{2., 4., 6., 8.};
-  CHECK_ITERABLE_APPROX(get(get<::Tags::Analytic<FieldTag>>(box)), expected);
+  CHECK_ITERABLE_APPROX(get(get<::Tags::Analytic<FieldTag>>(
+                            get<::Tags::AnalyticSolutionsBase>(box))),
+                        expected);
 
   TestHelpers::db::test_compute_tag<evolution::Tags::AnalyticCompute<
       1, AnalyticSolutionTag, tmpl::list<FieldTag>>>("AnalyticSolutions");


### PR DESCRIPTION
## Proposed changes

Tags other than `::Tags::Variables` will not automatically expose their `Variables` constituents as subitems to avoid inflating the size of the DataBox. Closes #3229.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
