### PR TITLE
Add multigrid solver

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -278,6 +278,14 @@ eprint = {https://doi.org/10.1137/0916035}
       SLACcitation   = "%%CITATION = ARXIV:1904.04831;%%"
 }
 
+@article{Briggs2000jp,
+  title  = "A Multigrid Tutorial, Second Edition",
+  author = "Briggs, William L and Henson, Van Emden and McCormick, Steve F",
+  year   =  2000,
+  url    = "http://dx.doi.org/10.1137/1.9780898719505",
+  doi    = "10.1137/1.9780898719505"
+}
+
 @article{Brune2015,
   title          = "Composing Scalable Nonlinear Algebraic Solvers",
   volume         = "57",
@@ -619,6 +627,22 @@ eprint = {https://doi.org/10.1137/0916035}
   pages =        {297-316},
   doi =          {10.1086/305205},
   adsurl =       {https://ui.adsabs.harvard.edu/abs/1998ApJ...494..297F},
+}
+
+@article{Fortunato2019jl,
+  title     = "Efficient Operator-Coarsening Multigrid Schemes for Local
+               Discontinuous {Galerkin} Methods",
+  author    = "Fortunato, Daniel and Rycroft, Chris H and Saye, Robert",
+  journal   = "SIAM J. Sci. Comput.",
+  publisher = "Society for Industrial and Applied Mathematics",
+  volume    =  41,
+  number    =  6,
+  pages     = "A3913--A3937",
+  month     =  jan,
+  year      =  2019,
+  url       = "https://doi.org/10.1137/18M1206357",
+  issn      = "1064-8275",
+  doi       = "10.1137/18M1206357"
 }
 
 @article{Foucart2008qt,

--- a/src/Domain/Structure/ChildSize.cpp
+++ b/src/Domain/Structure/ChildSize.cpp
@@ -3,6 +3,8 @@
 
 #include "Domain/Structure/ChildSize.hpp"
 
+#include <array>
+#include <cstddef>
 #include <ostream>
 #include <string>
 
@@ -10,6 +12,8 @@
 #include "Domain/Structure/Side.hpp"
 #include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
 
 namespace domain {
 
@@ -26,5 +30,29 @@ Spectral::ChildSize child_size(const SegmentId& child_segment_id,
                : Spectral::ChildSize::UpperHalf;
   }
 }
+
+template <size_t Dim>
+std::array<Spectral::ChildSize, Dim> child_size(
+    const std::array<SegmentId, Dim>& child_segment_ids,
+    const std::array<SegmentId, Dim>& parent_segment_ids) noexcept {
+  std::array<Spectral::ChildSize, Dim> result{};
+  for (size_t d = 0; d < Dim; ++d) {
+    gsl::at(result, d) = child_size(gsl::at(child_segment_ids, d),
+                                    gsl::at(parent_segment_ids, d));
+  }
+  return result;
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                      \
+  template std::array<Spectral::ChildSize, DIM(data)> child_size( \
+      const std::array<SegmentId, DIM(data)>& child_segment_ids,  \
+      const std::array<SegmentId, DIM(data)>& parent_segment_ids) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+#undef DIM
 
 }  // namespace domain

--- a/src/Domain/Structure/ChildSize.hpp
+++ b/src/Domain/Structure/ChildSize.hpp
@@ -3,10 +3,14 @@
 
 #pragma once
 
+#include <array>
+#include <cstddef>
+
 #include "Domain/Structure/SegmentId.hpp"
 #include "NumericalAlgorithms/Spectral/Projection.hpp"
 
 namespace domain {
+/// @{
 /*!
  * \brief Size of a child segment relative to its parent
  *
@@ -15,4 +19,10 @@ namespace domain {
  */
 Spectral::ChildSize child_size(const SegmentId& child_segment_id,
                                const SegmentId& parent_segment_id) noexcept;
-}
+
+template <size_t Dim>
+std::array<Spectral::ChildSize, Dim> child_size(
+    const std::array<SegmentId, Dim>& child_segment_ids,
+    const std::array<SegmentId, Dim>& parent_segment_ids) noexcept;
+/// @}
+}  // namespace domain

--- a/src/IO/Observer/CMakeLists.txt
+++ b/src/IO/Observer/CMakeLists.txt
@@ -14,6 +14,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ArrayComponentId.hpp
+  GetSectionObservationKey.hpp
   Helpers.hpp
   Initialize.hpp
   ObservationId.hpp

--- a/src/IO/Observer/GetSectionObservationKey.hpp
+++ b/src/IO/Observer/GetSectionObservationKey.hpp
@@ -1,0 +1,30 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <type_traits>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "IO/Observer/Tags.hpp"
+
+namespace observers {
+
+/// Retrieve the `observers::Tags::ObservationKey<SectionIdTag>`, or the empty
+/// string if `SectionIdTag` is void. This is useful to support sections in
+/// parallel algorithms. The return value can be used to construct a subfile
+/// path for observations, and to skip observations on elements that are not
+/// part of a section (`std::nullopt`).
+template <typename SectionIdTag, typename DbTagsList>
+std::optional<std::string> get_section_observation_key(
+    [[maybe_unused]] const db::DataBox<DbTagsList>& box) noexcept {
+  if constexpr (std::is_same_v<SectionIdTag, void>) {
+    return "";
+  } else {
+    return db::get<observers::Tags::ObservationKey<SectionIdTag>>(box);
+  }
+}
+
+}  // namespace observers

--- a/src/IO/Observer/Tags.hpp
+++ b/src/IO/Observer/Tags.hpp
@@ -139,6 +139,27 @@ struct ReductionDataNames : db::SimpleTag {
 struct H5FileLock : db::SimpleTag {
   using type = Parallel::NodeLock;
 };
+
+/*!
+ * \brief A string identifying observations related to the `Tag`.
+ *
+ * For example, the `Tag` could refer to the block in the computational domain
+ * and the `ObservationKey` holds the name of the block, so reduction
+ * observations can be registered per-block. A value of `std::nullopt` means
+ * that the element doesn't participate in observations related to the `Tag`.
+ *
+ * This tag only provides a way to store and share the observation key related
+ * to the `Tag`. How it is used to construct composite observation keys or
+ * subfile paths is up to the code that performs the observations.
+ */
+template <typename Tag>
+struct ObservationKey : db::SimpleTag {
+  using type = std::optional<std::string>;
+  static std::string name() noexcept {
+    return "ObservationKey(" + Options::name<Tag>() + ")";
+  }
+};
+
 }  // namespace Tags
 
 /// \ingroup ObserversGroup

--- a/src/Parallel/CMakeLists.txt
+++ b/src/Parallel/CMakeLists.txt
@@ -28,6 +28,7 @@ spectre_target_headers(
   CharmPupable.hpp
   CharmRegistration.hpp
   CreateFromOptions.hpp
+  GetSection.hpp
   GlobalCache.hpp
   InboxInserters.hpp
   Info.hpp

--- a/src/Parallel/CMakeLists.txt
+++ b/src/Parallel/CMakeLists.txt
@@ -74,4 +74,5 @@ add_dependencies(
 add_subdirectory(Actions)
 add_subdirectory(Algorithms)
 add_subdirectory(PhaseControl)
+add_subdirectory(Protocols)
 add_subdirectory(Tags)

--- a/src/Parallel/GetSection.hpp
+++ b/src/Parallel/GetSection.hpp
@@ -1,0 +1,49 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <optional>
+#include <type_traits>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Parallel/Tags/Section.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Parallel {
+
+/*!
+ * \brief Retrieve the section that the element belongs to, or
+ * `Parallel::no_section()` if `SectionIdTag` is `void`.
+ *
+ * This function is useful to support sections in parallel algorithms. Specify
+ * the `SectionIdTag` template parameter to retrieve the associated section, or
+ * set it to `void` when the parallel algorithm runs over all elements of the
+ * parallel component. See `Parallel::Section` for details on sections.
+ *
+ * Only call this function on elements that are part of a section. In case not
+ * all elements are part of a section with the `SectionIdTag`, make sure to skip
+ * those elements before calling this function.
+ */
+template <typename ParallelComponent, typename SectionIdTag,
+          typename DbTagsList>
+auto& get_section([[maybe_unused]] const gsl::not_null<db::DataBox<DbTagsList>*>
+                      box) noexcept {
+  if constexpr (std::is_same_v<SectionIdTag, void>) {
+    return Parallel::no_section();
+  } else {
+    std::optional<Parallel::Section<ParallelComponent, SectionIdTag>>& section =
+        db::get_mutable_reference<
+            Parallel::Tags::Section<ParallelComponent, SectionIdTag>>(box);
+    ASSERT(section.has_value(),
+           "Call 'get_section' only on elements that belong to a section. This "
+           "is probably a bug, because the other elements should presumably be "
+           "skipped. The section is: "
+               << db::tag_name<SectionIdTag>());
+    return *section;
+  }
+}
+
+}  // namespace Parallel

--- a/src/Parallel/Protocols/ArrayElementsAllocator.hpp
+++ b/src/Parallel/Protocols/ArrayElementsAllocator.hpp
@@ -1,0 +1,36 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <type_traits>
+
+#include "Utilities/TMPL.hpp"
+
+namespace Parallel::protocols {
+/*!
+ * \brief Conforming types implement a strategy to create elements for array
+ * parallel components
+ *
+ * Conforming classes must provide the following type aliases:
+ *
+ * - `array_allocation_tags<ParallelComponent>`: A `tmpl::list` of tags that are
+ *   needed to perform the allocation. These tags will be parsed from input-file
+ *   options (see \ref dev_guide_parallelization_parallel_components). The array
+ *   parallel component will be passed in as a template parameter.
+ *
+ * Conforming classes must implement the following static member functions:
+ *
+ * - `apply<ParallelComponent>`: This function is responsible for creating the
+ *   array elements. It has the same signature as the `allocate_array` function
+ *   (see \ref dev_guide_parallelization_parallel_components), but takes the
+ *   array parallel component as an additional first template parameter.
+ *
+ * See `elliptic::DefaultElementsAllocator` for an example implementation of
+ * this protocol.
+ */
+struct ArrayElementsAllocator {
+  template <typename ConformingType>
+  struct test {};
+};
+}  // namespace Parallel::protocols

--- a/src/Parallel/Protocols/CMakeLists.txt
+++ b/src/Parallel/Protocols/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  ArrayElementsAllocator.hpp
+  )

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/ElementActions.hpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <limits>
+#include <optional>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -15,13 +16,17 @@
 #include "NumericalAlgorithms/Convergence/Tags.hpp"
 #include "NumericalAlgorithms/LinearSolver/InnerProduct.hpp"
 #include "Parallel/AlgorithmMetafunctions.hpp"
+#include "Parallel/GetSection.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Reduction.hpp"
+#include "Parallel/Tags/Section.hpp"
 #include "ParallelAlgorithms/LinearSolver/Gmres/ResidualMonitorActions.hpp"
 #include "ParallelAlgorithms/LinearSolver/Gmres/Tags/InboxTags.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Functional.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/Requires.hpp"
@@ -36,7 +41,10 @@ namespace LinearSolver::gmres::detail {
 template <typename Metavariables, typename FieldsTag, typename OptionsGroup>
 struct ResidualMonitor;
 template <typename FieldsTag, typename OptionsGroup, bool Preconditioned,
-          typename Label>
+          typename Label, typename ArraySectionIdTag>
+struct PrepareStep;
+template <typename FieldsTag, typename OptionsGroup, bool Preconditioned,
+          typename Label, typename ArraySectionIdTag>
 struct NormalizeOperandAndUpdateField;
 }  // namespace LinearSolver::gmres::detail
 /// \endcond
@@ -44,7 +52,7 @@ struct NormalizeOperandAndUpdateField;
 namespace LinearSolver::gmres::detail {
 
 template <typename FieldsTag, typename OptionsGroup, bool Preconditioned,
-          typename Label, typename SourceTag>
+          typename Label, typename SourceTag, typename ArraySectionIdTag>
 struct PrepareSolve {
  private:
   using fields_tag = FieldsTag;
@@ -67,14 +75,33 @@ struct PrepareSolve {
       Parallel::GlobalCache<Metavariables>& cache,
       const ArrayIndex& array_index, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) noexcept {
-    db::mutate<Convergence::Tags::IterationId<OptionsGroup>, operand_tag,
-               initial_fields_tag, basis_history_tag>(
+    db::mutate<Convergence::Tags::IterationId<OptionsGroup>>(
         make_not_null(&box),
-        [](const gsl::not_null<size_t*> iteration_id, const auto operand,
-           const auto initial_fields, const auto basis_history,
-           const auto& source, const auto& operator_applied_to_fields,
-           const auto& fields) noexcept {
+        [](const gsl::not_null<size_t*> iteration_id) noexcept {
           *iteration_id = 0;
+        });
+
+    // Skip the initial reduction on elements that are not part of the section
+    if constexpr (not std::is_same_v<ArraySectionIdTag, void>) {
+      if (not db::get<Parallel::Tags::Section<ParallelComponent,
+                                              ArraySectionIdTag>>(box)
+                  .has_value()) {
+        return {std::move(box)};
+      }
+    }
+
+    if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
+                 ::Verbosity::Debug)) {
+      Parallel::printf("%s %s: Prepare solve\n", get_output(array_index),
+                       Options::name<OptionsGroup>());
+    }
+
+    db::mutate<operand_tag, initial_fields_tag, basis_history_tag>(
+        make_not_null(&box),
+        [](const auto operand, const auto initial_fields,
+           const auto basis_history, const auto& source,
+           const auto& operator_applied_to_fields,
+           const auto& fields) noexcept {
           *operand = source - operator_applied_to_fields;
           *initial_fields = fields;
           *basis_history = typename basis_history_tag::type{};
@@ -82,6 +109,8 @@ struct PrepareSolve {
         get<source_tag>(box), get<operator_applied_to_fields_tag>(box),
         get<fields_tag>(box));
 
+    auto& section = Parallel::get_section<ParallelComponent, ArraySectionIdTag>(
+        make_not_null(&box));
     Parallel::contribute_to_reduction<InitializeResidualMagnitude<
         FieldsTag, OptionsGroup, ParallelComponent>>(
         Parallel::ReductionData<
@@ -89,7 +118,8 @@ struct PrepareSolve {
             inner_product(get<operand_tag>(box), get<operand_tag>(box))},
         Parallel::get_parallel_component<ParallelComponent>(cache)[array_index],
         Parallel::get_parallel_component<
-            ResidualMonitor<Metavariables, FieldsTag, OptionsGroup>>(cache));
+            ResidualMonitor<Metavariables, FieldsTag, OptionsGroup>>(cache),
+        make_not_null(&section));
 
     if constexpr (Preconditioned) {
       using preconditioned_operand_tag =
@@ -110,7 +140,7 @@ struct PrepareSolve {
 };
 
 template <typename FieldsTag, typename OptionsGroup, bool Preconditioned,
-          typename Label>
+          typename Label, typename ArraySectionIdTag>
 struct NormalizeInitialOperand {
  private:
   using fields_tag = FieldsTag;
@@ -120,6 +150,8 @@ struct NormalizeInitialOperand {
       LinearSolver::Tags::KrylovSubspaceBasis<operand_tag>;
 
  public:
+  using const_global_cache_tags =
+      tmpl::list<logging::Tags::Verbosity<OptionsGroup>>;
   using inbox_tags = tmpl::list<Tags::InitialOrthogonalization<OptionsGroup>>;
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
@@ -130,49 +162,82 @@ struct NormalizeInitialOperand {
   apply(db::DataBox<DbTagsList>& box,
         tuples::TaggedTuple<InboxTags...>& inboxes,
         const Parallel::GlobalCache<Metavariables>& /*cache*/,
-        const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+        const ArrayIndex& array_index, const ActionList /*meta*/,
         const ParallelComponent* const /*meta*/) noexcept {
+    const size_t iteration_id =
+        db::get<Convergence::Tags::IterationId<OptionsGroup>>(box);
     auto& inbox = get<Tags::InitialOrthogonalization<OptionsGroup>>(inboxes);
-    if (inbox.find(db::get<Convergence::Tags::IterationId<OptionsGroup>>(
-            box)) == inbox.end()) {
+    if (inbox.find(iteration_id) == inbox.end()) {
       return {std::move(box), Parallel::AlgorithmExecution::Retry,
               std::numeric_limits<size_t>::max()};
     }
 
-    auto received_data = std::move(
-        inbox
-            .extract(db::get<Convergence::Tags::IterationId<OptionsGroup>>(box))
-            .mapped());
+    auto received_data = std::move(inbox.extract(iteration_id).mapped());
     const double residual_magnitude = get<0>(received_data);
     auto& has_converged = get<1>(received_data);
-
-    db::mutate<operand_tag, basis_history_tag,
-               Convergence::Tags::HasConverged<OptionsGroup>>(
-        make_not_null(&box), [residual_magnitude, &has_converged](
-                                 const auto operand, const auto basis_history,
-                                 const gsl::not_null<Convergence::HasConverged*>
-                                     local_has_converged) noexcept {
-          *operand /= residual_magnitude;
-          basis_history->push_back(*operand);
+    db::mutate<Convergence::Tags::HasConverged<OptionsGroup>>(
+        make_not_null(&box),
+        [&has_converged](const gsl::not_null<Convergence::HasConverged*>
+                             local_has_converged) noexcept {
           *local_has_converged = std::move(has_converged);
         });
 
     // Skip steps entirely if the solve has already converged
     constexpr size_t step_end_index = tmpl::index_of<
-        ActionList, NormalizeOperandAndUpdateField<
-                        FieldsTag, OptionsGroup, Preconditioned, Label>>::value;
+        ActionList,
+        NormalizeOperandAndUpdateField<FieldsTag, OptionsGroup, Preconditioned,
+                                       Label, ArraySectionIdTag>>::value;
+    if (get<Convergence::Tags::HasConverged<OptionsGroup>>(box)) {
+      return {std::move(box), Parallel::AlgorithmExecution::Continue,
+              step_end_index + 1};
+    }
+
+    // Skip the solve entirely on elements that are not part of the section. To
+    // do so, we skip ahead to the `ApplyOperatorActions` action list between
+    // `PrepareStep` and `PerformStep`. Those actions need a chance to run even
+    // on elements that are not part of the section, because they may take part
+    // in preconditioning (see Multigrid preconditioner).
+    if constexpr (not std::is_same_v<ArraySectionIdTag, void>) {
+      if (not db::get<Parallel::Tags::Section<ParallelComponent,
+                                              ArraySectionIdTag>>(box)
+                  .has_value()) {
+        constexpr size_t prepare_step_index =
+            tmpl::index_of<ActionList,
+                           PrepareStep<FieldsTag, OptionsGroup, Preconditioned,
+                                       Label, ArraySectionIdTag>>::value;
+        return {std::move(box), Parallel::AlgorithmExecution::Continue,
+                prepare_step_index + 1};
+      }
+    }
+
+    if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
+                 ::Verbosity::Debug)) {
+      Parallel::printf("%s %s(%zu): Normalize initial operand\n",
+                       get_output(array_index), Options::name<OptionsGroup>(),
+                       iteration_id);
+    }
+
+    db::mutate<operand_tag, basis_history_tag>(
+        make_not_null(&box),
+        [residual_magnitude](const auto operand,
+                             const auto basis_history) noexcept {
+          *operand /= residual_magnitude;
+          basis_history->push_back(*operand);
+        });
+
     constexpr size_t this_action_index =
         tmpl::index_of<ActionList, NormalizeInitialOperand>::value;
     return {std::move(box), Parallel::AlgorithmExecution::Continue,
-            get<Convergence::Tags::HasConverged<OptionsGroup>>(box)
-                ? (step_end_index + 1)
-                : (this_action_index + 1)};
+            this_action_index + 1};
   }
 };
 
 template <typename FieldsTag, typename OptionsGroup, bool Preconditioned,
-          typename Label>
+          typename Label, typename ArraySectionIdTag>
 struct PrepareStep {
+  using const_global_cache_tags =
+      tmpl::list<logging::Tags::Verbosity<OptionsGroup>>;
+
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>
@@ -180,8 +245,16 @@ struct PrepareStep {
       db::DataBox<DbTagsList>& box,
       const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
       const Parallel::GlobalCache<Metavariables>& /*cache*/,
-      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ArrayIndex& array_index, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) noexcept {
+    const size_t iteration_id =
+        db::get<Convergence::Tags::IterationId<OptionsGroup>>(box);
+    if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
+                 ::Verbosity::Debug)) {
+      Parallel::printf("%s %s(%zu): Prepare step\n", get_output(array_index),
+                       Options::name<OptionsGroup>(), iteration_id);
+    }
+
     if constexpr (Preconditioned) {
       using fields_tag = FieldsTag;
       using operand_tag =
@@ -221,7 +294,7 @@ struct PrepareStep {
 };
 
 template <typename FieldsTag, typename OptionsGroup, bool Preconditioned,
-          typename Label>
+          typename Label, typename ArraySectionIdTag>
 struct PerformStep {
  private:
   using fields_tag = FieldsTag;
@@ -231,15 +304,42 @@ struct PerformStep {
       db::add_tag_prefix<LinearSolver::Tags::Preconditioned, operand_tag>;
 
  public:
+  using const_global_cache_tags =
+      tmpl::list<logging::Tags::Verbosity<OptionsGroup>>;
+
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>
-  static std::tuple<db::DataBox<DbTagsList>&&> apply(
-      db::DataBox<DbTagsList>& box,
-      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-      Parallel::GlobalCache<Metavariables>& cache,
-      const ArrayIndex& array_index, const ActionList /*meta*/,
-      const ParallelComponent* const /*meta*/) noexcept {
+  static std::tuple<db::DataBox<DbTagsList>&&, Parallel::AlgorithmExecution,
+                    size_t>
+  apply(db::DataBox<DbTagsList>& box,
+        const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+        Parallel::GlobalCache<Metavariables>& cache,
+        const ArrayIndex& array_index, const ActionList /*meta*/,
+        const ParallelComponent* const /*meta*/) noexcept {
+    // Skip to the end of the step on elements that are not part of the section
+    if constexpr (not std::is_same_v<ArraySectionIdTag, void>) {
+      if (not db::get<Parallel::Tags::Section<ParallelComponent,
+                                              ArraySectionIdTag>>(box)
+                  .has_value()) {
+        constexpr size_t step_end_index =
+            tmpl::index_of<ActionList,
+                           NormalizeOperandAndUpdateField<
+                               FieldsTag, OptionsGroup, Preconditioned, Label,
+                               ArraySectionIdTag>>::value;
+        return {std::move(box), Parallel::AlgorithmExecution::Continue,
+                step_end_index};
+      }
+    }
+
+    const size_t iteration_id =
+        db::get<Convergence::Tags::IterationId<OptionsGroup>>(box);
+    if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
+                 ::Verbosity::Debug)) {
+      Parallel::printf("%s %s(%zu): Perform step\n", get_output(array_index),
+                       Options::name<OptionsGroup>(), iteration_id);
+    }
+
     using operator_tag = db::add_tag_prefix<
         LinearSolver::Tags::OperatorAppliedTo,
         std::conditional_t<Preconditioned, preconditioned_operand_tag,
@@ -273,6 +373,8 @@ struct PerformStep {
         },
         get<operator_tag>(box));
 
+    auto& section = Parallel::get_section<ParallelComponent, ArraySectionIdTag>(
+        make_not_null(&box));
     Parallel::contribute_to_reduction<
         StoreOrthogonalization<FieldsTag, OptionsGroup, ParallelComponent>>(
         Parallel::ReductionData<
@@ -285,14 +387,18 @@ struct PerformStep {
                           get<operand_tag>(box))},
         Parallel::get_parallel_component<ParallelComponent>(cache)[array_index],
         Parallel::get_parallel_component<
-            ResidualMonitor<Metavariables, FieldsTag, OptionsGroup>>(cache));
+            ResidualMonitor<Metavariables, FieldsTag, OptionsGroup>>(cache),
+        make_not_null(&section));
 
-    return {std::move(box)};
+    constexpr size_t this_action_index =
+        tmpl::index_of<ActionList, PerformStep>::value;
+    return {std::move(box), Parallel::AlgorithmExecution::Continue,
+            this_action_index + 1};
   }
 };
 
 template <typename FieldsTag, typename OptionsGroup, bool Preconditioned,
-          typename Label>
+          typename Label, typename ArraySectionIdTag>
 struct OrthogonalizeOperand {
  private:
   using fields_tag = FieldsTag;
@@ -317,17 +423,16 @@ struct OrthogonalizeOperand {
         Parallel::GlobalCache<Metavariables>& cache,
         const ArrayIndex& array_index, const ActionList /*meta*/,
         const ParallelComponent* const /*meta*/) noexcept {
+    const size_t iteration_id =
+        db::get<Convergence::Tags::IterationId<OptionsGroup>>(box);
     auto& inbox = get<Tags::Orthogonalization<OptionsGroup>>(inboxes);
-    if (inbox.find(db::get<Convergence::Tags::IterationId<OptionsGroup>>(
-            box)) == inbox.end()) {
+    if (inbox.find(iteration_id) == inbox.end()) {
       return {std::move(box), Parallel::AlgorithmExecution::Retry,
               std::numeric_limits<size_t>::max()};
     }
 
-    const double orthogonalization = std::move(
-        inbox
-            .extract(db::get<Convergence::Tags::IterationId<OptionsGroup>>(box))
-            .mapped());
+    const double orthogonalization =
+        std::move(inbox.extract(iteration_id).mapped());
 
     db::mutate<operand_tag, orthogonalization_iteration_id_tag>(
         make_not_null(&box),
@@ -343,8 +448,6 @@ struct OrthogonalizeOperand {
 
     const auto& next_orthogonalization_iteration_id =
         get<orthogonalization_iteration_id_tag>(box);
-    const auto& iteration_id =
-        get<Convergence::Tags::IterationId<OptionsGroup>>(box);
     const bool orthogonalization_complete =
         next_orthogonalization_iteration_id == iteration_id + 1;
     const double local_orthogonalization =
@@ -354,6 +457,8 @@ struct OrthogonalizeOperand {
                                     next_orthogonalization_iteration_id),
                       get<operand_tag>(box));
 
+    auto& section = Parallel::get_section<ParallelComponent, ArraySectionIdTag>(
+        make_not_null(&box));
     Parallel::contribute_to_reduction<
         StoreOrthogonalization<FieldsTag, OptionsGroup, ParallelComponent>>(
         Parallel::ReductionData<
@@ -364,7 +469,8 @@ struct OrthogonalizeOperand {
             local_orthogonalization},
         Parallel::get_parallel_component<ParallelComponent>(cache)[array_index],
         Parallel::get_parallel_component<
-            ResidualMonitor<Metavariables, FieldsTag, OptionsGroup>>(cache));
+            ResidualMonitor<Metavariables, FieldsTag, OptionsGroup>>(cache),
+        make_not_null(&section));
 
     // Repeat this action until orthogonalization is complete
     constexpr size_t this_action_index =
@@ -376,7 +482,7 @@ struct OrthogonalizeOperand {
 };
 
 template <typename FieldsTag, typename OptionsGroup, bool Preconditioned,
-          typename Label>
+          typename Label, typename ArraySectionIdTag>
 struct NormalizeOperandAndUpdateField {
  private:
   using fields_tag = FieldsTag;
@@ -392,6 +498,8 @@ struct NormalizeOperandAndUpdateField {
           Preconditioned, preconditioned_operand_tag, operand_tag>>;
 
  public:
+  using const_global_cache_tags =
+      tmpl::list<logging::Tags::Verbosity<OptionsGroup>>;
   using inbox_tags = tmpl::list<Tags::FinalOrthogonalization<OptionsGroup>>;
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
@@ -402,32 +510,60 @@ struct NormalizeOperandAndUpdateField {
   apply(db::DataBox<DbTagsList>& box,
         tuples::TaggedTuple<InboxTags...>& inboxes,
         const Parallel::GlobalCache<Metavariables>& /*cache*/,
-        const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+        const ArrayIndex& array_index, const ActionList /*meta*/,
         const ParallelComponent* const /*meta*/) noexcept {
+    const size_t iteration_id =
+        db::get<Convergence::Tags::IterationId<OptionsGroup>>(box);
     auto& inbox = get<Tags::FinalOrthogonalization<OptionsGroup>>(inboxes);
-    if (inbox.find(db::get<Convergence::Tags::IterationId<OptionsGroup>>(
-            box)) == inbox.end()) {
+    if (inbox.find(iteration_id) == inbox.end()) {
       return {std::move(box), Parallel::AlgorithmExecution::Retry,
               std::numeric_limits<size_t>::max()};
     }
 
     // Retrieve reduction data from inbox
-    auto received_data = std::move(
-        inbox
-            .extract(db::get<Convergence::Tags::IterationId<OptionsGroup>>(box))
-            .mapped());
+    auto received_data = std::move(inbox.extract(iteration_id).mapped());
     const double normalization = get<0>(received_data);
     const auto& minres = get<1>(received_data);
     auto& has_converged = get<2>(received_data);
-
-    db::mutate<operand_tag, basis_history_tag, fields_tag,
-               Convergence::Tags::IterationId<OptionsGroup>,
-               Convergence::Tags::HasConverged<OptionsGroup>>(
+    db::mutate<Convergence::Tags::HasConverged<OptionsGroup>,
+               Convergence::Tags::IterationId<OptionsGroup>>(
         make_not_null(&box),
-        [normalization, &minres, &has_converged](
-            const auto operand, const auto basis_history, const auto field,
-            const gsl::not_null<size_t*> iteration_id,
+        [&has_converged](
             const gsl::not_null<Convergence::HasConverged*> local_has_converged,
+            const gsl::not_null<size_t*> local_iteration_id) noexcept {
+          *local_has_converged = std::move(has_converged);
+          ++(*local_iteration_id);
+        });
+
+    // Elements that are not part of the section jump directly to the
+    // `ApplyOperationActions` for the next step.`
+    constexpr size_t this_action_index =
+        tmpl::index_of<ActionList, NormalizeOperandAndUpdateField>::value;
+    constexpr size_t prepare_step_index =
+        tmpl::index_of<ActionList,
+                       PrepareStep<FieldsTag, OptionsGroup, Preconditioned,
+                                   Label, ArraySectionIdTag>>::value;
+    if constexpr (not std::is_same_v<ArraySectionIdTag, void>) {
+      if (not db::get<Parallel::Tags::Section<ParallelComponent,
+                                              ArraySectionIdTag>>(box)
+                  .has_value()) {
+        return {std::move(box), Parallel::AlgorithmExecution::Continue,
+                get<Convergence::Tags::HasConverged<OptionsGroup>>(box)
+                    ? (this_action_index + 1)
+                    : (prepare_step_index + 1)};
+      }
+    }
+
+    if (UNLIKELY(get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
+                 ::Verbosity::Debug)) {
+      Parallel::printf("%s %s(%zu): Complete step\n", get_output(array_index),
+                       Options::name<OptionsGroup>(), iteration_id);
+    }
+
+    db::mutate<operand_tag, basis_history_tag, fields_tag>(
+        make_not_null(&box),
+        [normalization, &minres](
+            const auto operand, const auto basis_history, const auto field,
             const auto& initial_field,
             const auto& preconditioned_basis_history) noexcept {
           // Avoid an FPE if the new operand norm is exactly zero. In that case
@@ -442,18 +578,11 @@ struct NormalizeOperandAndUpdateField {
           for (size_t i = 0; i < minres.size(); i++) {
             *field += minres[i] * gsl::at(preconditioned_basis_history, i);
           }
-          ++(*iteration_id);
-          *local_has_converged = std::move(has_converged);
         },
         get<initial_fields_tag>(box),
         get<preconditioned_basis_history_tag>(box));
 
     // Repeat steps until the solve has converged
-    constexpr size_t this_action_index =
-        tmpl::index_of<ActionList, NormalizeOperandAndUpdateField>::value;
-    constexpr size_t prepare_step_index =
-        tmpl::index_of<ActionList, PrepareStep<FieldsTag, OptionsGroup,
-                                               Preconditioned, Label>>::value;
     return {std::move(box), Parallel::AlgorithmExecution::Continue,
             get<Convergence::Tags::HasConverged<OptionsGroup>>(box)
                 ? (this_action_index + 1)

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/Actions/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/Actions/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  RestrictFields.hpp
+  )

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/Actions/RestrictFields.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/Actions/RestrictFields.hpp
@@ -1,0 +1,238 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <map>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include "DataStructures/ApplyMatrices.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/FixedHashMap.hpp"
+#include "Domain/Structure/ChildSize.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "IO/Logging/Tags.hpp"
+#include "IO/Logging/Verbosity.hpp"
+#include "IO/Observer/Tags.hpp"
+#include "NumericalAlgorithms/Convergence/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Projection.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/InboxInserters.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Printf.hpp"
+#include "ParallelAlgorithms/LinearSolver/Multigrid/Tags.hpp"
+#include "ParallelAlgorithms/LinearSolver/Tags.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+template <size_t Dim>
+struct ElementId;
+/// \endcond
+
+namespace LinearSolver::multigrid {
+
+template <size_t Dim, typename ReceiveTags>
+struct DataFromChildrenInboxTag
+    : public Parallel::InboxInserters::Map<
+          DataFromChildrenInboxTag<Dim, ReceiveTags>> {
+  using temporal_id = size_t;
+  using type =
+      std::map<temporal_id,
+               FixedHashMap<two_to_the(Dim), ElementId<Dim>,
+                            tuples::tagged_tuple_from_typelist<ReceiveTags>,
+                            boost::hash<ElementId<Dim>>>>;
+};
+
+/// Actions related to the Multigrid linear solver
+namespace Actions {
+/*!
+ * \brief Communicate and project the `FieldsTags` to the next-coarser grid
+ * in the multigrid hierarchy
+ *
+ * \tparam FieldsTags These tags will be communicated and projected. They can
+ * hold any type that works with `::apply_matrices` and supports addition, e.g.
+ * `Variables`.
+ * \tparam OptionsGroup The option group identifying the multigrid solver
+ * \tparam FieldsAreMassiveTag A boolean tag in the DataBox that indicates
+ * whether or not the `FieldsTags` have already been multiplied by the mass
+ * matrix. This setting influences the way the fields are projected. In
+ * particular, the mass matrix already includes a Jacobian factor, so the
+ * difference in size between the parent and the child element is already
+ * accounted for.
+ * \tparam ReceiveTags The projected fields will be stored in these tags
+ * (default: `FieldsTags`).
+ */
+template <typename FieldsTags, typename OptionsGroup,
+          typename FieldsAreMassiveTag, typename ReceiveTags = FieldsTags>
+struct SendFieldsToCoarserGrid;
+
+/// \cond
+template <typename... FieldsTags, typename OptionsGroup,
+          typename FieldsAreMassiveTag, typename... ReceiveTags>
+struct SendFieldsToCoarserGrid<tmpl::list<FieldsTags...>, OptionsGroup,
+                               FieldsAreMassiveTag,
+                               tmpl::list<ReceiveTags...>> {
+  using const_global_cache_tags =
+      tmpl::list<logging::Tags::Verbosity<OptionsGroup>>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            size_t Dim, typename ActionList, typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ElementId<Dim>& element_id, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    // Skip restriction on coarsest level
+    const auto& parent_id = db::get<Tags::ParentId<Dim>>(box);
+    if (not parent_id.has_value()) {
+      return {std::move(box)};
+    }
+
+    const size_t iteration_id =
+        db::get<Convergence::Tags::IterationId<OptionsGroup>>(box);
+    if (UNLIKELY(db::get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
+                 ::Verbosity::Debug)) {
+      Parallel::printf("%s %s(%zu): Send fields to coarser grid\n", element_id,
+                       Options::name<OptionsGroup>(), iteration_id);
+    }
+
+    // Restrict the fields to the coarser (parent) grid.
+    // We restrict before sending the data so the restriction operation is
+    // parellelized. The parent only needs to sum up all child contributions.
+    const auto& mesh = db::get<domain::Tags::Mesh<Dim>>(box);
+    const auto& parent_mesh = db::get<Tags::ParentMesh<Dim>>(box);
+    ASSERT(
+        parent_mesh.has_value(),
+        "Should have a parent mesh, because a parent ID is set. This element: "
+            << element_id << ", parent element: " << *parent_id);
+    const auto child_size =
+        domain::child_size(element_id.segment_ids(), parent_id->segment_ids());
+    bool massive = false;
+    if constexpr (not std::is_same_v<FieldsAreMassiveTag, void>) {
+      massive = db::get<FieldsAreMassiveTag>(box);
+    }
+    tuples::TaggedTuple<ReceiveTags...> restricted_fields{};
+    if (Spectral::needs_projection(mesh, *parent_mesh, child_size)) {
+      const auto restriction_operator =
+          Spectral::projection_matrix_child_to_parent(mesh, *parent_mesh,
+                                                      child_size, massive);
+      const auto restrict_fields = [&restricted_fields, &restriction_operator,
+                                    &mesh](const auto receive_tag_v,
+                                           const auto& fields) noexcept {
+        using receive_tag = std::decay_t<decltype(receive_tag_v)>;
+        get<receive_tag>(restricted_fields) = typename receive_tag::type(
+            apply_matrices(restriction_operator, fields, mesh.extents()));
+        return '0';
+      };
+      expand_pack(restrict_fields(ReceiveTags{}, db::get<FieldsTags>(box))...);
+    } else {
+      expand_pack(
+          (get<ReceiveTags>(restricted_fields) =
+               typename ReceiveTags::type(db::get<FieldsTags>(box)))...);
+    }
+
+    // Send restricted fields to the parent
+    auto& receiver_proxy =
+        Parallel::get_parallel_component<ParallelComponent>(cache);
+    Parallel::receive_data<
+        DataFromChildrenInboxTag<Dim, tmpl::list<ReceiveTags...>>>(
+        receiver_proxy[*parent_id], iteration_id,
+        std::make_pair(element_id, std::move(restricted_fields)));
+    return {std::move(box)};
+  }
+};
+/// \endcond
+
+/// Receive the `FieldsTags` communicated from the finer grid in the multigrid
+/// hierarchy.
+///
+/// \see LinearSolver::multigrid::Actions::SendFieldsToCoarserGrid
+template <size_t Dim, typename FieldsTags, typename OptionsGroup,
+          typename ReceiveTags = FieldsTags>
+struct ReceiveFieldsFromFinerGrid;
+
+/// \cond
+template <size_t Dim, typename FieldsTags, typename OptionsGroup,
+          typename... ReceiveTags>
+struct ReceiveFieldsFromFinerGrid<Dim, FieldsTags, OptionsGroup,
+                                  tmpl::list<ReceiveTags...>> {
+  using inbox_tags =
+      tmpl::list<DataFromChildrenInboxTag<Dim, tmpl::list<ReceiveTags...>>>;
+  using const_global_cache_tags =
+      tmpl::list<logging::Tags::Verbosity<OptionsGroup>>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ActionList, typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&, Parallel::AlgorithmExecution>
+  apply(db::DataBox<DbTagsList>& box,
+        tuples::TaggedTuple<InboxTags...>& inboxes,
+        const Parallel::GlobalCache<Metavariables>& /*cache*/,
+        const ElementId<Dim>& element_id, const ActionList /*meta*/,
+        const ParallelComponent* const /*meta*/) noexcept {
+    // Skip on finest grid
+    const auto& child_ids = db::get<Tags::ChildIds<Dim>>(box);
+    if (child_ids.empty()) {
+      return {std::move(box), Parallel::AlgorithmExecution::Continue};
+    }
+
+    // Wait for data from finer grid
+    const size_t iteration_id =
+        db::get<Convergence::Tags::IterationId<OptionsGroup>>(box);
+    auto& inbox =
+        tuples::get<DataFromChildrenInboxTag<Dim, tmpl::list<ReceiveTags...>>>(
+            inboxes);
+    const auto received_this_iteration = inbox.find(iteration_id);
+    if (received_this_iteration == inbox.end()) {
+      return {std::move(box), Parallel::AlgorithmExecution::Retry};
+    }
+    const auto& received_children_data = received_this_iteration->second;
+    for (const auto& child_id : child_ids) {
+      if (received_children_data.find(child_id) ==
+          received_children_data.end()) {
+        return {std::move(box), Parallel::AlgorithmExecution::Retry};
+      }
+    }
+    auto children_data = std::move(inbox.extract(iteration_id).mapped());
+
+    if (UNLIKELY(db::get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
+                 ::Verbosity::Debug)) {
+      Parallel::printf("%s %s(%zu): Receive fields from finer grid\n",
+                       element_id, Options::name<OptionsGroup>(), iteration_id);
+    }
+
+    // Assemble restricted data from children
+    const auto assemble_children_data =
+        [&children_data](const auto source, const auto receive_tag_v) noexcept {
+          using receive_tag = std::decay_t<decltype(receive_tag_v)>;
+          // Move the first child data directly into the buffer, then add the
+          // data from the remaining children.
+          auto child_id_and_data = children_data.begin();
+          *source = std::move(get<receive_tag>(child_id_and_data->second));
+          ++child_id_and_data;
+          while (child_id_and_data != children_data.end()) {
+            *source += get<receive_tag>(child_id_and_data->second);
+            ++child_id_and_data;
+          }
+          return '0';
+        };
+    expand_pack(db::mutate<ReceiveTags>(
+        make_not_null(&box), assemble_children_data, ReceiveTags{})...);
+
+    return {std::move(box), Parallel::AlgorithmExecution::Continue};
+  }
+};
+/// \endcond
+
+}  // namespace Actions
+}  // namespace LinearSolver::multigrid

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/CMakeLists.txt
@@ -17,13 +17,25 @@ spectre_target_headers(
   HEADERS
   Hierarchy.hpp
   Multigrid.hpp
+  Tags.hpp
   )
 
 target_link_libraries(
   ${LIBRARY}
   PUBLIC
   DomainStructure
-  PRIVATE
   ErrorHandling
   Utilities
+  INTERFACE
+  Convergence
+  DataStructures
+  Domain
+  Initialization
+  IO
+  Logging
+  Options
+  Parallel
+  ParallelLinearSolver
+  Spectral
+  SystemUtilities
   )

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/CMakeLists.txt
@@ -39,3 +39,5 @@ target_link_libraries(
   Spectral
   SystemUtilities
   )
+
+add_subdirectory(Actions)

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/CMakeLists.txt
@@ -15,9 +15,11 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  ElementActions.hpp
   ElementsAllocator.hpp
   Hierarchy.hpp
   Multigrid.hpp
+  ObserveVolumeData.hpp
   Tags.hpp
   )
 

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/CMakeLists.txt
@@ -15,6 +15,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  ElementsAllocator.hpp
   Hierarchy.hpp
   Multigrid.hpp
   Tags.hpp

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementActions.hpp
@@ -1,0 +1,415 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <map>
+#include <unordered_set>
+
+#include "DataStructures/ApplyMatrices.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/FixedHashMap.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "Domain/Structure/ChildSize.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "IO/Logging/Tags.hpp"
+#include "IO/Observer/Tags.hpp"
+#include "NumericalAlgorithms/Convergence/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Projection.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/InboxInserters.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Printf.hpp"
+#include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
+#include "ParallelAlgorithms/LinearSolver/Multigrid/Actions/RestrictFields.hpp"
+#include "ParallelAlgorithms/LinearSolver/Multigrid/Hierarchy.hpp"
+#include "ParallelAlgorithms/LinearSolver/Multigrid/Tags.hpp"
+#include "ParallelAlgorithms/LinearSolver/Tags.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace LinearSolver::multigrid::detail {
+
+/// \cond
+template <typename FieldsTag, typename OptionsGroup, typename SourceTag>
+struct SendCorrectionToFinerGrid;
+/// \endcond
+
+template <size_t Dim, typename FieldsTag, typename OptionsGroup,
+          typename SourceTag>
+struct InitializeElement {
+  using initialization_tags = tmpl::list<Tags::ChildrenRefinementLevels<Dim>,
+                                         Tags::ParentRefinementLevels<Dim>>;
+  using simple_tags =
+      tmpl::list<Tags::ParentId<Dim>, Tags::ChildIds<Dim>,
+                 Tags::ParentMesh<Dim>,
+                 observers::Tags::ObservationKey<Tags::MultigridLevel>,
+                 observers::Tags::ObservationKey<Tags::IsFinestGrid>,
+                 Tags::ObservationId<OptionsGroup>,
+                 Tags::VolumeDataForOutput<OptionsGroup, FieldsTag>>;
+  using compute_tags = tmpl::list<>;
+  using const_global_cache_tags =
+      tmpl::list<Tags::MaxLevels<OptionsGroup>,
+                 Tags::OutputVolumeData<OptionsGroup>>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ActionList, typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ElementId<Dim>& element_id, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    // Note: The following initialization code assumes that all elements in a
+    // block have the same p-refinement. This is true for initial domains, but
+    // will be broken by AMR.
+
+    const size_t multigrid_level = element_id.grid_index();
+    const bool is_finest_grid = multigrid_level == 0;
+    const bool is_coarsest_grid =
+        db::get<domain::Tags::InitialRefinementLevels<Dim>>(box) ==
+        db::get<Tags::ParentRefinementLevels<Dim>>(box);
+
+    std::optional<ElementId<Dim>> parent_id =
+        is_coarsest_grid ? std::nullopt
+                         : std::make_optional(multigrid::parent_id(element_id));
+    std::unordered_set<ElementId<Dim>> child_ids = multigrid::child_ids(
+        element_id, db::get<Tags::ChildrenRefinementLevels<Dim>>(
+                        box)[element_id.block_id()]);
+
+    const auto& mesh = db::get<domain::Tags::Mesh<Dim>>(box);
+    std::optional<Mesh<Dim>> parent_mesh =
+        is_coarsest_grid ? std::nullopt : std::make_optional(mesh);
+
+    auto observation_key_level = std::make_optional(
+        is_finest_grid ? std::string{""}
+                       : (std::string{"Level"} + get_output(multigrid_level)));
+    auto observation_key_is_finest_grid =
+        is_finest_grid ? std::make_optional(std::string{""}) : std::nullopt;
+
+    // Initialize volume data output
+    using VolumeDataVars =
+        typename Tags::VolumeDataForOutput<OptionsGroup, FieldsTag>::type;
+    VolumeDataVars volume_data{};
+    if (db::get<Tags::OutputVolumeData<OptionsGroup>>(box)) {
+      volume_data.initialize(mesh.number_of_grid_points());
+    }
+
+    Initialization::mutate_assign<simple_tags>(
+        make_not_null(&box), std::move(parent_id), std::move(child_ids),
+        std::move(parent_mesh), std::move(observation_key_level),
+        std::move(observation_key_is_finest_grid), size_t{0},
+        std::move(volume_data));
+    return {std::move(box)};
+  }
+};
+
+// These two actions communicate and project the residual from the finer grid to
+// the coarser grid, storing it in the `SourceTag` on the coarser grid.
+template <typename FieldsTag, typename OptionsGroup,
+          typename ResidualIsMassiveTag, typename SourceTag>
+using SendResidualToCoarserGrid = Actions::SendFieldsToCoarserGrid<
+    tmpl::list<db::add_tag_prefix<LinearSolver::Tags::Residual, FieldsTag>>,
+    OptionsGroup, ResidualIsMassiveTag, tmpl::list<SourceTag>>;
+
+template <size_t Dim, typename FieldsTag, typename OptionsGroup,
+          typename SourceTag>
+using ReceiveResidualFromFinerGrid = Actions::ReceiveFieldsFromFinerGrid<
+    Dim,
+    tmpl::list<db::add_tag_prefix<LinearSolver::Tags::Residual, FieldsTag>>,
+    OptionsGroup, tmpl::list<SourceTag>>;
+
+// Once the residual from the finer grid has been received and stored in the
+// `SourceTag`, this action prepares the pre-smoothing that will determine
+// an approximate solution on this grid. The pre-smoother is a separate
+// linear solver that runs independently after this action.
+template <typename FieldsTag, typename OptionsGroup, typename SourceTag>
+struct PreparePreSmoothing {
+ private:
+  using fields_tag = FieldsTag;
+  using operator_applied_to_fields_tag =
+      db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, fields_tag>;
+  using source_tag = SourceTag;
+
+ public:
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            size_t Dim, typename ActionList, typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&> apply(
+      db::DataBox<DbTagsList>& box,
+      tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ElementId<Dim>& element_id, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    const size_t iteration_id =
+        db::get<Convergence::Tags::IterationId<OptionsGroup>>(box);
+    if (UNLIKELY(db::get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
+                 ::Verbosity::Debug)) {
+      Parallel::printf("%s %s(%zu): Prepare pre-smoothing\n", element_id,
+                       Options::name<OptionsGroup>(), iteration_id);
+    }
+
+    // On coarser grids the smoother solves for a correction to the finer-grid
+    // fields, so we set its initial guess to zero. On the finest grid we smooth
+    // the fields directly, so there's nothing to prepare.
+    if (element_id.grid_index() > 0) {
+      db::mutate<fields_tag, operator_applied_to_fields_tag>(
+          make_not_null(&box),
+          [](const auto fields, const auto operator_applied_to_fields,
+             const auto& source) noexcept {
+            *fields = make_with_value<typename fields_tag::type>(source, 0.);
+            // We can set the linear operator applied to the initial fields to
+            // zero as well, since it's linear. This may save the smoother an
+            // operator application on coarser grids if it's optimized for this.
+            *operator_applied_to_fields =
+                make_with_value<typename operator_applied_to_fields_tag::type>(
+                    source, 0.);
+          },
+          db::get<source_tag>(box));
+    }
+
+    // Record pre-smoothing initial fields and source
+    if (db::get<Tags::OutputVolumeData<OptionsGroup>>(box)) {
+      db::mutate<Tags::VolumeDataForOutput<OptionsGroup, FieldsTag>>(
+          make_not_null(&box),
+          [](const auto volume_data, const auto& initial_fields,
+             const auto& source) noexcept {
+            volume_data->assign_subset(
+                Variables<db::wrap_tags_in<Tags::PreSmoothingInitial,
+                                           typename fields_tag::tags_list>>(
+                    initial_fields));
+            volume_data->assign_subset(
+                Variables<db::wrap_tags_in<Tags::PreSmoothingSource,
+                                           typename fields_tag::tags_list>>(
+                    source));
+          },
+          db::get<fields_tag>(box), db::get<source_tag>(box));
+    }
+
+    return {std::move(box)};
+  }
+};
+
+// Once the pre-smoothing is done, we skip the second smoothing step on the
+// coarsest grid, i.e. at the "tip" of the V-cycle.
+template <typename FieldsTag, typename OptionsGroup, typename SourceTag>
+struct SkipPostsmoothingAtBottom {
+ private:
+  using fields_tag = FieldsTag;
+  using residual_tag =
+      db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>;
+
+ public:
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            size_t Dim, typename ActionList, typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&, Parallel::AlgorithmExecution,
+                    size_t>
+  apply(db::DataBox<DbTagsList>& box,
+        const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+        const Parallel::GlobalCache<Metavariables>& /*cache*/,
+        const ElementId<Dim>& /*element_id*/, const ActionList /*meta*/,
+        const ParallelComponent* const /*meta*/) noexcept {
+    const bool is_coarsest_grid =
+        not db::get<Tags::ParentId<Dim>>(box).has_value();
+
+    // Record pre-smoothing result fields and residual
+    if (db::get<Tags::OutputVolumeData<OptionsGroup>>(box)) {
+      db::mutate<Tags::VolumeDataForOutput<OptionsGroup, FieldsTag>>(
+          make_not_null(&box),
+          [](const auto volume_data, const auto& result_fields,
+             const auto& residuals) noexcept {
+            volume_data->assign_subset(
+                Variables<db::wrap_tags_in<Tags::PreSmoothingResult,
+                                           typename fields_tag::tags_list>>(
+                    result_fields));
+            volume_data->assign_subset(
+                Variables<db::wrap_tags_in<Tags::PreSmoothingResidual,
+                                           typename fields_tag::tags_list>>(
+                    residuals));
+          },
+          db::get<fields_tag>(box), db::get<residual_tag>(box));
+    }
+
+    // Skip the second smoothing step on the coarsest grid
+    const size_t first_action_after_post_smoothing_index = tmpl::index_of<
+        ActionList,
+        SendCorrectionToFinerGrid<FieldsTag, OptionsGroup, SourceTag>>::value;
+    const size_t this_action_index =
+        tmpl::index_of<ActionList, SkipPostsmoothingAtBottom>::value;
+    return {std::move(box), Parallel::AlgorithmExecution::Continue,
+            is_coarsest_grid ? first_action_after_post_smoothing_index
+                             : (this_action_index + 1)};
+  }
+};
+
+template <typename FieldsTag>
+struct CorrectionInboxTag
+    : public Parallel::InboxInserters::Value<CorrectionInboxTag<FieldsTag>> {
+  using temporal_id = size_t;
+  using type = std::map<temporal_id, typename FieldsTag::type>;
+};
+
+// The next two actions communicate and project the coarse-grid correction, i.e.
+// the solution of the post-smoother, to the finer grid. The post-smoother on
+// finer grids runs after receiving this coarse-grid correction. Since the
+// post-smoother is skipped on the coarsest level, it directly sends the
+// solution of the pre-smoother to the finer grid, thus kicking off the
+// "ascending" branch of the V-cycle.
+template <typename FieldsTag, typename OptionsGroup, typename SourceTag>
+struct SendCorrectionToFinerGrid {
+ private:
+  using fields_tag = FieldsTag;
+  using residual_tag =
+      db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>;
+
+ public:
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            size_t Dim, typename ActionList, typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ElementId<Dim>& element_id, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    const auto& child_ids = db::get<Tags::ChildIds<Dim>>(box);
+
+    // Record post-smoothing result fields and residual
+    if (db::get<Tags::OutputVolumeData<OptionsGroup>>(box)) {
+      db::mutate<Tags::VolumeDataForOutput<OptionsGroup, FieldsTag>>(
+          make_not_null(&box),
+          [](const auto volume_data, const auto& result_fields,
+             const auto& residuals) noexcept {
+            volume_data->assign_subset(
+                Variables<db::wrap_tags_in<Tags::PostSmoothingResult,
+                                           typename fields_tag::tags_list>>(
+                    result_fields));
+            volume_data->assign_subset(
+                Variables<db::wrap_tags_in<Tags::PostSmoothingResidual,
+                                           typename fields_tag::tags_list>>(
+                    residuals));
+          },
+          db::get<fields_tag>(box), db::get<residual_tag>(box));
+    }
+
+    if (child_ids.empty()) {
+      return {std::move(box)};
+    }
+
+    const size_t iteration_id =
+        db::get<Convergence::Tags::IterationId<OptionsGroup>>(box);
+    if (UNLIKELY(db::get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
+                 ::Verbosity::Debug)) {
+      Parallel::printf("%s %s(%zu): Send correction to children\n", element_id,
+                       Options::name<OptionsGroup>(), iteration_id);
+    }
+
+    // Send a copy of the correction to all children
+    auto& receiver_proxy =
+        Parallel::get_parallel_component<ParallelComponent>(cache);
+    for (const auto& child_id : child_ids) {
+      auto coarse_grid_correction = db::get<fields_tag>(box);
+      Parallel::receive_data<CorrectionInboxTag<FieldsTag>>(
+          receiver_proxy[child_id], iteration_id,
+          std::move(coarse_grid_correction));
+    }
+    return {std::move(box)};
+  }
+};
+
+template <size_t Dim, typename FieldsTag, typename OptionsGroup,
+          typename SourceTag>
+struct ReceiveCorrectionFromCoarserGrid {
+ private:
+  using fields_tag = FieldsTag;
+  using source_tag = SourceTag;
+
+ public:
+  using inbox_tags = tmpl::list<CorrectionInboxTag<FieldsTag>>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ActionList, typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&, Parallel::AlgorithmExecution>
+  apply(db::DataBox<DbTagsList>& box,
+        tuples::TaggedTuple<InboxTags...>& inboxes,
+        const Parallel::GlobalCache<Metavariables>& /*cache*/,
+        const ElementId<Dim>& element_id, const ActionList /*meta*/,
+        const ParallelComponent* const /*meta*/) noexcept {
+    const auto& parent_id = db::get<Tags::ParentId<Dim>>(box);
+    // We should always have a `parent_id` at this point because we skip this
+    // part of the algorithm on the coarsest grid with the
+    // `SkipPostsmoothingAtBottom` action
+    ASSERT(parent_id.has_value(),
+           "Trying to receive data from parent but no parent is set on element "
+               << element_id << ".");
+    const size_t iteration_id =
+        db::get<Convergence::Tags::IterationId<OptionsGroup>>(box);
+
+    // Wait for data from coarser grid
+    auto& inbox = tuples::get<CorrectionInboxTag<FieldsTag>>(inboxes);
+    if (inbox.find(iteration_id) == inbox.end()) {
+      return {std::move(box), Parallel::AlgorithmExecution::Retry};
+    }
+    auto parent_correction = std::move(inbox.extract(iteration_id).mapped());
+
+    if (UNLIKELY(db::get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
+                 ::Verbosity::Debug)) {
+      Parallel::printf("%s %s(%zu): Prolongate correction from parent\n",
+                       element_id, Options::name<OptionsGroup>(), iteration_id);
+    }
+
+    // Apply prolongation operator
+    const auto& mesh = db::get<domain::Tags::Mesh<Dim>>(box);
+    const auto& parent_mesh = db::get<Tags::ParentMesh<Dim>>(box);
+    ASSERT(
+        parent_mesh.has_value(),
+        "Should have a parent mesh, because a parent ID is set. This element: "
+            << element_id << ", parent element: " << *parent_id);
+    const auto child_size =
+        domain::child_size(element_id.segment_ids(), parent_id->segment_ids());
+    const auto prolongated_parent_correction =
+        [&parent_correction, &parent_mesh, &mesh, &child_size]() noexcept {
+          if (Spectral::needs_projection(*parent_mesh, mesh, child_size)) {
+            const auto prolongation_operator =
+                Spectral::projection_matrix_parent_to_child(*parent_mesh, mesh,
+                                                            child_size);
+            return apply_matrices(prolongation_operator, parent_correction,
+                                  parent_mesh->extents());
+          } else {
+            return std::move(parent_correction);
+          }
+        }();
+
+    // Add correction to the solution on this grid
+    db::mutate<fields_tag>(
+        make_not_null(&box),
+        [&prolongated_parent_correction](const auto fields) noexcept {
+          *fields += prolongated_parent_correction;
+        });
+
+    // Record post-smoothing initial fields and source
+    if (db::get<Tags::OutputVolumeData<OptionsGroup>>(box)) {
+      db::mutate<Tags::VolumeDataForOutput<OptionsGroup, FieldsTag>>(
+          make_not_null(&box),
+          [](const auto volume_data, const auto& initial_fields,
+             const auto& source) noexcept {
+            volume_data->assign_subset(
+                Variables<db::wrap_tags_in<Tags::PostSmoothingInitial,
+                                           typename fields_tag::tags_list>>(
+                    initial_fields));
+            volume_data->assign_subset(
+                Variables<db::wrap_tags_in<Tags::PostSmoothingSource,
+                                           typename fields_tag::tags_list>>(
+                    source));
+          },
+          db::get<fields_tag>(box), db::get<source_tag>(box));
+    }
+
+    return {std::move(box), Parallel::AlgorithmExecution::Continue};
+  }
+};
+
+}  // namespace LinearSolver::multigrid::detail

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementsAllocator.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementsAllocator.hpp
@@ -162,8 +162,8 @@ struct ElementsAllocator
       const domain::BlockZCurveProcDistribution<Dim> element_distribution{
           static_cast<size_t>(number_of_procs), initial_refinement_levels};
       for (const auto& element_id : element_ids) {
-        const size_t target_proc = element_distribution.get_proc_for_element(
-            element_id.block_id(), element_id);
+        const size_t target_proc =
+            element_distribution.get_proc_for_element(element_id);
         element_array(element_id)
             .insert(global_cache, initialization_items, target_proc);
       }

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementsAllocator.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementsAllocator.hpp
@@ -1,0 +1,181 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <charm++.h>
+#include <cstddef>
+#include <optional>
+#include <vector>
+
+#include "Domain/ElementDistribution.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/Convergence/Tags.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/Printf.hpp"
+#include "Parallel/Protocols/ArrayElementsAllocator.hpp"
+#include "Parallel/Section.hpp"
+#include "Parallel/Serialize.hpp"
+#include "Parallel/Tags/Section.hpp"
+#include "ParallelAlgorithms/LinearSolver/Multigrid/Hierarchy.hpp"
+#include "ParallelAlgorithms/LinearSolver/Multigrid/Tags.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/System/ParallelInfo.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace LinearSolver::multigrid {
+
+/*!
+ * \brief A `Parallel::protocols::ArrayElementsAllocator` that creates array
+ * elements to cover the initial computational domain multiple times at
+ * different refinement levels, suitable for the
+ * `LinearSolver::multigrid::Multigrid` algorithm
+ *
+ * The `initial_element_ids` function and the option-created
+ * `domain::Tags::Domain` and `domain::Tags::InitialRefinementLevels` determine
+ * the initial set of element IDs in the domain. This is taken as the finest
+ * grid in the multigrid hierarchy. Coarser grids are determined by successively
+ * applying `LinearSolver::multigrid::coarsen`, up to
+ * `LinearSolver::multigrid::Tags::MaxLevels` grids.
+ *
+ * Array elements are created for all element IDs on all grids, meaning they all
+ * share the same parallel component, action list etc. Elements are connected to
+ * their neighbors _on the same grid_ by the
+ * `domain::Initialization::create_initial_element` function (this is
+ * independent of the multigrid code, the function is typically called in an
+ * initialization action). Elements are connected to their parent and children
+ * _across grids_ by the multigrid-tags set here and in the multigrid
+ * initialization actions (see `LinearSolver::multigrid::parent_id` and
+ * `LinearSolver::multigrid::child_ids`).
+ *
+ * This allocator also creates two sets of sections (see `Parallel::Section`):
+ * - `Parallel::Tags::Section<ElementArray,
+ *   LinearSolver::multigrid::Tags::MultigridLevel>`: One section per grid. All
+ *   elements are part of a section with this tag.
+ * - `Parallel::Tags::Section<ElementArray,
+ *   LinearSolver::multigrid::Tags::IsFinestGrid>`: A single section that holds
+ *   only the elements on the finest grid. Holds `std::nullopt` on all other
+ *   elements.
+ *
+ * The elements are distributed on processors using the
+ * `domain::BlockZCurveProcDistribution` for every grid independently.
+ */
+template <size_t Dim, typename OptionsGroup>
+struct ElementsAllocator
+    : tt::ConformsTo<Parallel::protocols::ArrayElementsAllocator> {
+  template <typename ElementArray>
+  using array_allocation_tags =
+      tmpl::list<domain::Tags::InitialRefinementLevels<Dim>,
+                 Tags::ChildrenRefinementLevels<Dim>,
+                 Tags::ParentRefinementLevels<Dim>,
+                 Parallel::Tags::Section<ElementArray, Tags::MultigridLevel>,
+                 Parallel::Tags::Section<ElementArray, Tags::IsFinestGrid>>;
+
+  template <typename ElementArray, typename Metavariables,
+            typename... InitializationTags>
+  static void apply(Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
+                    const tuples::TaggedTuple<InitializationTags...>&
+                        original_initialization_items) noexcept {
+    // Copy the initialization items so we can adjust them on each refinement
+    // level
+    auto initialization_items =
+        deserialize<tuples::TaggedTuple<InitializationTags...>>(
+            serialize<tuples::TaggedTuple<InitializationTags...>>(
+                original_initialization_items)
+                .data());
+    auto& local_cache = *(global_cache.ckLocalBranch());
+    auto& element_array =
+        Parallel::get_parallel_component<ElementArray>(local_cache);
+    const auto& domain = get<domain::Tags::Domain<Dim>>(local_cache);
+    auto& initial_refinement_levels =
+        get<domain::Tags::InitialRefinementLevels<Dim>>(initialization_items);
+    auto& children_refinement_levels =
+        get<Tags::ChildrenRefinementLevels<Dim>>(initialization_items);
+    auto& parent_refinement_levels =
+        get<Tags::ParentRefinementLevels<Dim>>(initialization_items);
+    std::optional<size_t> max_levels =
+        get<Tags::MaxLevels<OptionsGroup>>(local_cache);
+    if (max_levels == 0) {
+      ERROR_NO_TRACE(
+          "The 'MaxLevels' option includes the finest grid, so '0' is not a "
+          "valid value. Set the option to '1' to effectively disable "
+          "multigrid.");
+    }
+    const size_t num_iterations =
+        get<Convergence::Tags::Iterations<OptionsGroup>>(local_cache);
+    if (UNLIKELY(num_iterations == 0)) {
+      Parallel::printf(
+          "%s is disabled (zero iterations). Only creating a single grid.\n",
+          Options::name<OptionsGroup>());
+      max_levels = 1;
+    }
+    size_t multigrid_level = 0;
+    do {
+      // Store the current grid as child grid before coarsening it
+      children_refinement_levels = initial_refinement_levels;
+      initial_refinement_levels = parent_refinement_levels;
+      // Construct coarsened (parent) grid
+      if (not max_levels.has_value() or multigrid_level < *max_levels - 1) {
+        parent_refinement_levels =
+            LinearSolver::multigrid::coarsen(initial_refinement_levels);
+      }
+      // Create element IDs for all elements on this level
+      std::vector<ElementId<Dim>> element_ids{};
+      for (const auto& block : domain.blocks()) {
+        const std::vector<ElementId<Dim>> block_element_ids =
+            initial_element_ids(block.id(),
+                                initial_refinement_levels[block.id()],
+                                multigrid_level);
+        element_ids.insert(element_ids.begin(), block_element_ids.begin(),
+                           block_element_ids.end());
+      }
+      // Create an array section for this refinement level
+      std::vector<CkArrayIndex> array_indices(element_ids.size());
+      std::transform(
+          element_ids.begin(), element_ids.end(), array_indices.begin(),
+          [](const ElementId<Dim>& local_element_id) noexcept {
+            return Parallel::ArrayIndex<ElementId<Dim>>(local_element_id);
+          });
+      using MultigridLevelSection =
+          Parallel::Section<ElementArray, Tags::MultigridLevel>;
+      get<Parallel::Tags::Section<ElementArray, Tags::MultigridLevel>>(
+          initialization_items) = MultigridLevelSection{
+          multigrid_level, MultigridLevelSection::cproxy_section::ckNew(
+                               element_array.ckGetArrayID(),
+                               array_indices.data(), array_indices.size())};
+      using FinestGridSection =
+          Parallel::Section<ElementArray, Tags::IsFinestGrid>;
+      get<Parallel::Tags::Section<ElementArray, Tags::IsFinestGrid>>(
+          initialization_items) =
+          multigrid_level == 0
+              ? std::make_optional(FinestGridSection{
+                    true, FinestGridSection::cproxy_section::ckNew(
+                              element_array.ckGetArrayID(),
+                              array_indices.data(), array_indices.size())})
+              : std::nullopt;
+      // Create the elements for this refinement level and distribute them among
+      // processors
+      const int number_of_procs = sys::number_of_procs();
+      const domain::BlockZCurveProcDistribution<Dim> element_distribution{
+          static_cast<size_t>(number_of_procs), initial_refinement_levels};
+      for (const auto& element_id : element_ids) {
+        const size_t target_proc = element_distribution.get_proc_for_element(
+            element_id.block_id(), element_id);
+        element_array(element_id)
+            .insert(global_cache, initialization_items, target_proc);
+      }
+      Parallel::printf(
+          "%s level %zu has %zu elements in %zu blocks distributed on %d "
+          "procs.\n",
+          Options::name<OptionsGroup>(), multigrid_level, element_ids.size(),
+          domain.blocks().size(), number_of_procs);
+      ++multigrid_level;
+    } while (initial_refinement_levels != parent_refinement_levels);
+    element_array.doneInserting();
+  }
+};
+
+}  // namespace LinearSolver::multigrid

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/Multigrid.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/Multigrid.hpp
@@ -3,6 +3,154 @@
 
 #pragma once
 
-/// \ingroup LinearSolverGroup
+#include <cstddef>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "IO/Observer/Actions/RegisterWithObservers.hpp"
+#include "IO/Observer/Helpers.hpp"
+#include "ParallelAlgorithms/LinearSolver/AsynchronousSolvers/ElementActions.hpp"
+#include "ParallelAlgorithms/LinearSolver/Multigrid/ElementActions.hpp"
+#include "ParallelAlgorithms/LinearSolver/Multigrid/ObserveVolumeData.hpp"
+#include "Utilities/TMPL.hpp"
+
 /// Items related to the multigrid linear solver
-namespace LinearSolver::multigrid {}
+///
+/// \see `LinearSolver::multigrid::Multigrid`
+namespace LinearSolver::multigrid {
+
+/// A label indicating the pre-smoothing step in a V-cycle multigrid algorithm,
+/// i.e. the smoothing step before sending the residual to the coarser (parent)
+/// grid
+struct VcycleDownLabel {};
+
+/// A label indicating the post-smoothing step in a V-cycle multigrid algorithm,
+/// i.e. the smoothing step before sending the correction to the finer (child)
+/// grid
+struct VcycleUpLabel {};
+
+/*!
+ * \brief A V-cycle geometric multgrid solver for linear equations \f$Ax = b\f$
+ *
+ * This linear solver iteratively corrects an initial guess \f$x_0\f$ by
+ * restricting the residual \f$b - Ax\f$ to a series of coarser grids, solving
+ * for a correction on the coarser grids, and then prolongating (interpolating)
+ * the correction back to the finer grids. The solves on grids with different
+ * scales can very effectively solve large-scale modes in the solution, which
+ * Krylov-type linear solvers such as GMRES or Conjugate Gradients typically
+ * struggle with. Therefore, a multigrid solver can be an effective
+ * preconditioner for Krylov-type linear solvers (see
+ * `LinearSolver::gmres::Gmres` and `LinearSolver::cg::ConjugateGradient`). See
+ * \cite Briggs2000jp for an introduction to multigrid methods.
+ *
+ * \par Grid hierarchy
+ * This geometric multigrid solver relies on a strategy to coarsen the
+ * computational grid in a way that removes small-scale modes. We currently
+ * h-coarsen the domain, meaning that we create multigrid levels by successively
+ * combining two elements into one along every dimension of the grid. We only
+ * p-coarsen the grid in the sense that we choose the smaller of the two
+ * polynomial degrees when combining elements. This strategy follows
+ * \cite Vincent2019qpd. See `LinearSolver::multigrid::ElementsAllocator` and
+ * `LinearSolver::multigrid::coarsen` for the code that creates the multigrid
+ * hierarchy.
+ *
+ * \par Inter-mesh operators
+ * The algorithm relies on operations that project data between grids. Residuals
+ * are projected from finer to coarser grids ("restriction") and solutions are
+ * projected from coarser to finer grids ("prolongation"). We use the standard
+ * \f$L_2\f$-projections implemented in
+ * `Spectral::projection_matrix_child_to_parent` and
+ * `Spectral::projection_matrix_parent_to_child`, where "child" means the finer
+ * grid and "parent" means the coarser grid. Note that the residuals \f$b -
+ * Ax\f$ may or may not already include a mass matrix and Jacobian factors,
+ * depending on the implementation of the linear operator \f$A\f$. To account
+ * for this, provide a tag as the `ResidualIsMassiveTag` that holds a `bool`.
+ * See section 3 in \cite Fortunato2019jl for details on the inter-mesh
+ * operators.
+ *
+ * \par Smoother
+ * On every level of the grid hierarchy the multigrid solver relies on a
+ * "smoother" that performs an approximate linear solve on that level. The
+ * smoother can be any linear solver that solves the `smooth_fields_tag` for the
+ * source in the `smooth_source_tag`. Useful smoothers are asynchronous linear
+ * solvers that parallelize well, such as `LinearSolver::Schwarz::Schwarz`. The
+ * multigrid algorithm doesn't assume anything about the smoother, but requires
+ * only that the `PreSmootherActions` and the `PostSmootherActions` passed to
+ * `solve` leave the `smooth_fields_tag` in a state that represents an
+ * approximate solution to the `smooth_source_tag`, and that
+ * `db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo,
+ * smooth_fields_tag>` is left up-to-date as well. Here's an example of setting
+ * up a smoother for the multigrid solver:
+ *
+ * \snippet Test_MultigridAlgorithm.cpp setup_smoother
+ *
+ * The smoother can be used to construct an action list like this:
+ *
+ * \snippet Test_MultigridAlgorithm.cpp action_list
+ *
+ * \par Algorithm overview
+ * Every iteration of the multigrid algorithm performs a V-cycle over the grid
+ * hierarchy. One V-cycle consists of first "going down" the grid hierarchy,
+ * from the finest to successively coarser grids, smoothing on every level
+ * ("pre-smoothing"), and then "going up" the grid hierarchy again, smoothing on
+ * every level again ("post-smoothing"). When going down, the algorithm projects
+ * the remaining residual of the smoother to the next-coarser grid, setting it
+ * as the source for the smoother on the coarser grid. When going up again, the
+ * algorithm projects the solution of the smoother to the next-finer grid,
+ * adding it to the solution on the finer grid as a correction. The bottom-most
+ * coarsest grid (the "tip" of the V-cycle) skips the post-smoothing, so the
+ * result of the pre-smoother is immediately projected up to the finer grid. On
+ * the top-most finest grid (the "original" grid that represents the overall
+ * solution) the algorithm applies the smoothing and the corrections from the
+ * coarser grids directly to the solution fields.
+ */
+template <size_t Dim, typename FieldsTag, typename OptionsGroup,
+          typename ResidualIsMassiveTag,
+          typename SourceTag =
+              db::add_tag_prefix<::Tags::FixedSource, FieldsTag>>
+struct Multigrid {
+  using fields_tag = FieldsTag;
+  using options_group = OptionsGroup;
+  using source_tag = SourceTag;
+
+  using operand_tag = FieldsTag;
+
+  using smooth_source_tag = source_tag;
+  using smooth_fields_tag = fields_tag;
+
+  using component_list = tmpl::list<>;
+
+  using observed_reduction_data_tags = observers::make_reduction_data_tags<
+      tmpl::list<async_solvers::reduction_data>>;
+
+  using initialize_element = tmpl::list<
+      async_solvers::InitializeElement<FieldsTag, OptionsGroup, SourceTag>,
+      detail::InitializeElement<Dim, FieldsTag, OptionsGroup, SourceTag>>;
+
+  using register_element =
+      tmpl::list<async_solvers::RegisterElement<FieldsTag, OptionsGroup,
+                                                SourceTag, Tags::IsFinestGrid>,
+                 observers::Actions::RegisterWithObservers<
+                     detail::RegisterWithVolumeObserver<OptionsGroup>>>;
+
+  template <typename PreSmootherActions, typename PostSmootherActions,
+            typename Label = OptionsGroup>
+  using solve = tmpl::list<
+      async_solvers::PrepareSolve<FieldsTag, OptionsGroup, SourceTag, Label,
+                                  Tags::IsFinestGrid, false>,
+      detail::ReceiveResidualFromFinerGrid<Dim, FieldsTag, OptionsGroup,
+                                           SourceTag>,
+      detail::PreparePreSmoothing<FieldsTag, OptionsGroup, SourceTag>,
+      PreSmootherActions,
+      detail::SkipPostsmoothingAtBottom<FieldsTag, OptionsGroup, SourceTag>,
+      detail::SendResidualToCoarserGrid<FieldsTag, OptionsGroup,
+                                        ResidualIsMassiveTag, SourceTag>,
+      detail::ReceiveCorrectionFromCoarserGrid<Dim, FieldsTag, OptionsGroup,
+                                               SourceTag>,
+      PostSmootherActions,
+      detail::SendCorrectionToFinerGrid<FieldsTag, OptionsGroup, SourceTag>,
+      detail::ObserveVolumeData<FieldsTag, OptionsGroup, SourceTag>,
+      async_solvers::CompleteStep<FieldsTag, OptionsGroup, SourceTag, Label,
+                                  Tags::IsFinestGrid, false>>;
+};
+
+}  // namespace LinearSolver::multigrid

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/ObserveVolumeData.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/ObserveVolumeData.hpp
@@ -1,0 +1,128 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Tensor/TensorData.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/Tags.hpp"
+#include "IO/Observer/TypeOfObservation.hpp"
+#include "IO/Observer/VolumeActions.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "ParallelAlgorithms/LinearSolver/Multigrid/Tags.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace LinearSolver::multigrid::detail {
+
+template <typename OptionsGroup>
+struct RegisterWithVolumeObserver {
+  template <typename ParallelComponent, typename DbTagsList,
+            typename ArrayIndex>
+  static std::pair<observers::TypeOfObservation, observers::ObservationKey>
+  register_info(const db::DataBox<DbTagsList>& box,
+                const ArrayIndex& /*array_index*/) noexcept {
+    const std::string& level_observation_key =
+        *db::get<observers::Tags::ObservationKey<Tags::MultigridLevel>>(box);
+    const std::string subfile_path =
+        "/" + Options::name<OptionsGroup>() + level_observation_key;
+    return {observers::TypeOfObservation::Volume,
+            observers::ObservationKey(subfile_path)};
+  }
+};
+
+// Contribute the volume data recorded in the other actions to the observer at
+// the end of a step.
+template <typename FieldsTag, typename OptionsGroup, typename SourceTag>
+struct ObserveVolumeData {
+ private:
+  using volume_data_tag = Tags::VolumeDataForOutput<OptionsGroup, FieldsTag>;
+  using VolumeDataVars = typename volume_data_tag::type;
+
+ public:
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            size_t Dim, typename ActionList, typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ElementId<Dim>& element_id, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    if (not db::get<Tags::OutputVolumeData<OptionsGroup>>(box)) {
+      return {std::move(box)};
+    }
+    const auto& volume_data = db::get<volume_data_tag>(box);
+    const auto& observation_id =
+        db::get<Tags::ObservationId<OptionsGroup>>(box);
+    const auto& mesh = db::get<domain::Tags::Mesh<Dim>>(box);
+    const auto& inertial_coords =
+        db::get<domain::Tags::Coordinates<Dim, Frame::Inertial>>(box);
+    const std::string element_name = MakeString{} << element_id << '/';
+
+    // Collect tensor components to observe
+    std::vector<TensorComponent> components{};
+    components.reserve(inertial_coords.size() +
+                       VolumeDataVars::number_of_independent_components);
+    const auto record_tensor_components = [&components, &element_name](
+                                              const auto tensor_tag_v,
+                                              const auto& tensor) noexcept {
+      using tensor_tag = std::decay_t<decltype(tensor_tag_v)>;
+      for (size_t i = 0; i < tensor.size(); ++i) {
+        components.emplace_back(element_name + db::tag_name<tensor_tag>() +
+                                    tensor.component_suffix(i),
+                                tensor[i]);
+      }
+    };
+    record_tensor_components(domain::Tags::Coordinates<Dim, Frame::Inertial>{},
+                             inertial_coords);
+    tmpl::for_each<typename VolumeDataVars::tags_list>(
+        [&volume_data, &record_tensor_components](auto tag_v) noexcept {
+          using tag = tmpl::type_from<decltype(tag_v)>;
+          record_tensor_components(tag{}, get<tag>(volume_data));
+        });
+
+    // Contribute tensor components to observer
+    auto& local_observer =
+        *Parallel::get_parallel_component<observers::Observer<Metavariables>>(
+             cache)
+             .ckLocalBranch();
+    const auto& level_observation_key =
+        *db::get<observers::Tags::ObservationKey<Tags::MultigridLevel>>(box);
+    const std::string subfile_path =
+        "/" + Options::name<OptionsGroup>() + level_observation_key;
+    Parallel::simple_action<observers::Actions::ContributeVolumeData>(
+        local_observer, observers::ObservationId(observation_id, subfile_path),
+        subfile_path,
+        observers::ArrayComponentId(
+            std::add_pointer_t<ParallelComponent>{nullptr},
+            Parallel::ArrayIndex<ElementId<Dim>>(element_id)),
+        std::move(components), mesh.extents(), mesh.basis(), mesh.quadrature());
+
+    // Increment observation ID
+    db::mutate<Tags::ObservationId<OptionsGroup>>(
+        make_not_null(&box), [](const auto local_observation_id) noexcept {
+          ++(*local_observation_id);
+        });
+    return {std::move(box)};
+  }
+};
+
+}  // namespace LinearSolver::multigrid::detail

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/Tags.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/Tags.hpp
@@ -1,0 +1,206 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Options/Auto.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/PupStlCpp17.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace LinearSolver::multigrid {
+
+namespace OptionTags {
+
+template <typename OptionsGroup>
+struct MaxLevels {
+  using type = Options::Auto<size_t>;
+  static constexpr Options::String help =
+      "Maximum number of levels in the multigrid hierarchy. Includes the "
+      "finest grid, i.e. set to '1' to disable multigrids. Set to 'Auto' to "
+      "coarsen all the way up to single-element blocks.";
+  using group = OptionsGroup;
+};
+
+template <typename OptionsGroup>
+struct OutputVolumeData {
+  using type = bool;
+  static constexpr Options::String help =
+      "Record volume data for debugging purposes.";
+  using group = OptionsGroup;
+  static bool suggested_value() noexcept { return false; }
+};
+
+}  // namespace OptionTags
+
+/// DataBox tags for the `LinearSolver::multigrid::Multigrid` linear solver
+namespace Tags {
+
+/// Initial refinement of the next-finer (child) grid
+template <size_t Dim>
+struct ChildrenRefinementLevels : db::SimpleTag {
+ private:
+  using base = domain::Tags::InitialRefinementLevels<Dim>;
+
+ public:
+  using type = typename base::type;
+  static constexpr bool pass_metavariables = base::pass_metavariables;
+  using option_tags = typename base::option_tags;
+  static constexpr auto create_from_options = base::create_from_options;
+};
+
+/// Initial refinement of the next-coarser (parent) grid
+template <size_t Dim>
+struct ParentRefinementLevels : db::SimpleTag {
+ private:
+  using base = domain::Tags::InitialRefinementLevels<Dim>;
+
+ public:
+  using type = typename base::type;
+  static constexpr bool pass_metavariables = base::pass_metavariables;
+  using option_tags = typename base::option_tags;
+  static constexpr auto create_from_options = base::create_from_options;
+};
+
+/// Maximum number of multigrid levels that will be created. A value of '1'
+/// effectively disables the multigrid, and `std::nullopt` means the number
+/// of multigrid levels is not capped.
+template <typename OptionsGroup>
+struct MaxLevels : db::SimpleTag {
+  using type = std::optional<size_t>;
+  static constexpr bool pass_metavariables = false;
+  using option_tags = tmpl::list<OptionTags::MaxLevels<OptionsGroup>>;
+  static type create_from_options(const type value) noexcept { return value; };
+  static std::string name() noexcept {
+    return "MaxLevels(" + Options::name<OptionsGroup>() + ")";
+  }
+};
+
+/// Whether or not volume data should be recorded for debugging purposes
+template <typename OptionsGroup>
+struct OutputVolumeData : db::SimpleTag {
+  using type = bool;
+  static constexpr bool pass_metavariables = false;
+  using option_tags = tmpl::list<OptionTags::OutputVolumeData<OptionsGroup>>;
+  static type create_from_options(const type value) noexcept { return value; };
+  static std::string name() noexcept {
+    return "OutputVolumeData(" + Options::name<OptionsGroup>() + ")";
+  }
+};
+
+/// The multigrid level. The finest grid is always level 0 and the coarsest grid
+/// has the highest level.
+struct MultigridLevel : db::SimpleTag {
+  using type = size_t;
+};
+
+/// Indicates the root of the multigrid hierarchy, i.e. level 0.
+struct IsFinestGrid : db::SimpleTag {
+  using type = bool;
+};
+
+/// The ID of the element that covers the same region or more on the coarser
+/// (parent) grid
+template <size_t Dim>
+struct ParentId : db::SimpleTag {
+  using type = std::optional<ElementId<Dim>>;
+};
+
+/// The IDs of the elements that cover the same region on the finer (child) grid
+template <size_t Dim>
+struct ChildIds : db::SimpleTag {
+  using type = std::unordered_set<ElementId<Dim>>;
+};
+
+/// The mesh of the parent element. Needed for projections between grids.
+template <size_t Dim>
+struct ParentMesh : db::SimpleTag {
+  using type = std::optional<Mesh<Dim>>;
+};
+
+// The following tags are related to volume data output
+
+/// Continuously incrementing ID for volume observations
+template <typename OptionsGroup>
+struct ObservationId : db::SimpleTag {
+  using type = size_t;
+  static std::string name() noexcept {
+    return "ObservationId(" + Options::name<OptionsGroup>() + ")";
+  }
+};
+/// @{
+/// Prefix tag for recording volume data in
+/// `LinearSolver::multigrid::Tags::VolumeDataForOutput`
+template <typename Tag>
+struct PreSmoothingInitial : db::PrefixTag, db::SimpleTag {
+  using type = typename Tag::type;
+  using tag = Tag;
+};
+template <typename Tag>
+struct PreSmoothingSource : db::PrefixTag, db::SimpleTag {
+  using type = typename Tag::type;
+  using tag = Tag;
+};
+template <typename Tag>
+struct PreSmoothingResult : db::PrefixTag, db::SimpleTag {
+  using type = typename Tag::type;
+  using tag = Tag;
+};
+template <typename Tag>
+struct PreSmoothingResidual : db::PrefixTag, db::SimpleTag {
+  using type = typename Tag::type;
+  using tag = Tag;
+};
+template <typename Tag>
+struct PostSmoothingInitial : db::PrefixTag, db::SimpleTag {
+  using type = typename Tag::type;
+  using tag = Tag;
+};
+template <typename Tag>
+struct PostSmoothingSource : db::PrefixTag, db::SimpleTag {
+  using type = typename Tag::type;
+  using tag = Tag;
+};
+template <typename Tag>
+struct PostSmoothingResult : db::PrefixTag, db::SimpleTag {
+  using type = typename Tag::type;
+  using tag = Tag;
+};
+template <typename Tag>
+struct PostSmoothingResidual : db::PrefixTag, db::SimpleTag {
+  using type = typename Tag::type;
+  using tag = Tag;
+};
+/// @}
+/// Buffer for recording volume data
+template <typename OptionsGroup, typename FieldsTag>
+struct VolumeDataForOutput : db::SimpleTag {
+  using fields_tags = typename FieldsTag::type::tags_list;
+  using type = Variables<
+      tmpl::append<db::wrap_tags_in<PreSmoothingInitial, fields_tags>,
+                   db::wrap_tags_in<PreSmoothingSource, fields_tags>,
+                   db::wrap_tags_in<PreSmoothingResult, fields_tags>,
+                   db::wrap_tags_in<PreSmoothingResidual, fields_tags>,
+                   db::wrap_tags_in<PostSmoothingInitial, fields_tags>,
+                   db::wrap_tags_in<PostSmoothingSource, fields_tags>,
+                   db::wrap_tags_in<PostSmoothingResult, fields_tags>,
+                   db::wrap_tags_in<PostSmoothingResidual, fields_tags>>>;
+  static std::string name() noexcept {
+    return "VolumeDataForOutput(" + Options::name<OptionsGroup>() + ")";
+  }
+};
+
+}  // namespace Tags
+}  // namespace LinearSolver::multigrid

--- a/tests/Unit/Domain/Structure/CMakeLists.txt
+++ b/tests/Unit/Domain/Structure/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_DomainStructure")
 set(LIBRARY_SOURCES
   Test_BlockId.cpp
   Test_BlockNeighbor.cpp
+  Test_ChildSize.cpp
   Test_CreateInitialMesh.cpp
   Test_Direction.cpp
   Test_Element.cpp

--- a/tests/Unit/Domain/Structure/Test_ChildSize.cpp
+++ b/tests/Unit/Domain/Structure/Test_ChildSize.cpp
@@ -14,6 +14,15 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.ChildSize", "[Domain][Unit]") {
   CHECK(child_size({1, 0}, {0, 0}) == Spectral::ChildSize::LowerHalf);
   CHECK(child_size({1, 1}, {0, 0}) == Spectral::ChildSize::UpperHalf);
   CHECK(child_size({1, 1}, {1, 1}) == Spectral::ChildSize::Full);
+  CHECK(child_size<1>({{{2, 3}}}, {{{1, 1}}}) ==
+        std::array<Spectral::ChildSize, 1>{{Spectral::ChildSize::UpperHalf}});
+  CHECK(child_size<2>({{{0, 0}, {1, 0}}}, {{{0, 0}, {0, 0}}}) ==
+        std::array<Spectral::ChildSize, 2>{
+            {Spectral::ChildSize::Full, Spectral::ChildSize::LowerHalf}});
+  CHECK(child_size<3>({{{1, 1}, {1, 1}, {2, 2}}}, {{{0, 0}, {1, 1}, {1, 1}}}) ==
+        std::array<Spectral::ChildSize, 3>{{Spectral::ChildSize::UpperHalf,
+                                            Spectral::ChildSize::Full,
+                                            Spectral::ChildSize::LowerHalf}});
 }
 
 // [[OutputRegex, Segment id 'L1I0' is not the parent of 'L1I1'.]]

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
@@ -21,6 +21,7 @@
 #include "DataStructures/DenseVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
 #include "Domain/CreateInitialElement.hpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Structure/CreateInitialMesh.hpp"

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
@@ -343,6 +343,11 @@ struct CleanOutput {
       ERROR("Expected reductions file '" << reductions_file_name
                                          << "' does not exist");
     }
+    const auto& volume_file_name =
+        get<observers::Tags::VolumeFileName>(box) + "0.h5";
+    if (file_system::check_if_file_exists(volume_file_name)) {
+      file_system::rm(volume_file_name, true);
+    }
     return {std::move(box), true};
   }
 };

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/Multigrid/Helpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/Multigrid/Helpers.hpp
@@ -1,0 +1,261 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DenseMatrix.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Structure/CreateInitialMesh.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Parallel/Tags/Section.hpp"
+#include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
+#include "ParallelAlgorithms/LinearSolver/Multigrid/Tags.hpp"
+#include "ParallelAlgorithms/LinearSolver/Tags.hpp"
+#include "Utilities/Blas.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace helpers_distributed = DistributedLinearSolverAlgorithmTestHelpers;
+
+namespace TestHelpers::LinearSolver::multigrid {
+
+namespace OptionTags {
+struct LinearOperator {
+  static constexpr Options::String help =
+      "The linear operator A to invert. The outer list corresponds to "
+      "multigrid levels, ordered from finest to coarsest grid. The inner list "
+      "corresponds to the elements in the domain. The number of columns in "
+      "each matrix corresponds to the number of grid points in the element, "
+      "and the number of rows corresponds to the total number of grid points "
+      "in the domain.";
+  using type =
+      std::vector<std::vector<DenseMatrix<double, blaze::columnMajor>>>;
+};
+struct OperatorIsMassive {
+  static constexpr Options::String help =
+      "Whether or not the linear operator includes a mass matrix. This is "
+      "relevant for projection operations between grids.";
+  using type = bool;
+};
+}  // namespace OptionTags
+
+struct LinearOperator : db::SimpleTag {
+  using type =
+      std::vector<std::vector<DenseMatrix<double, blaze::columnMajor>>>;
+  using option_tags = tmpl::list<OptionTags::LinearOperator>;
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& linear_operator) noexcept {
+    return linear_operator;
+  }
+};
+
+struct OperatorIsMassive : db::SimpleTag {
+  using type = bool;
+  using option_tags = tmpl::list<OptionTags::OperatorIsMassive>;
+  static constexpr bool pass_metavariables = false;
+  static bool create_from_options(const bool value) noexcept { return value; }
+};
+
+using fields_tag = helpers_distributed::fields_tag;
+using sources_tag = helpers_distributed::sources_tag;
+
+struct InitializeElement {
+  using initialization_tags =
+      tmpl::list<::domain::Tags::InitialExtents<1>,
+                 ::domain::Tags::InitialRefinementLevels<1>>;
+  using const_global_cache_tags =
+      tmpl::list<helpers_distributed::Source, OperatorIsMassive>;
+  using simple_tags =
+      tmpl::list<::domain::Tags::Mesh<1>,
+                 ::domain::Tags::Coordinates<1, Frame::Inertial>, fields_tag,
+                 sources_tag>;
+  using compute_tags = tmpl::list<>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ActionList, typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ElementId<1>& element_id, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    // Initialize geometry
+    const auto& initial_extents =
+        db::get<::domain::Tags::InitialExtents<1>>(box);
+    const auto& domain = db::get<::domain::Tags::Domain<1>>(box);
+    auto mesh = ::domain::Initialization::create_initial_mesh(
+        initial_extents, element_id, Spectral::Quadrature::GaussLobatto);
+    const auto logical_coords = logical_coordinates(mesh);
+    const auto& block = domain.blocks()[element_id.block_id()];
+    const ElementMap<1, Frame::Inertial> element_map{
+        element_id, block.stationary_map().get_clone()};
+    auto inertial_coords = element_map(logical_coords);
+    // Initialize data
+    const size_t element_index = helpers_distributed::get_index(element_id);
+    const size_t multigrid_level = element_id.grid_index();
+    const auto& source =
+        multigrid_level == 0
+            ? typename sources_tag::type(
+                  gsl::at(get<helpers_distributed::Source>(box), element_index))
+            : typename sources_tag::type{};
+    const size_t num_points = mesh.number_of_grid_points();
+    auto initial_fields = typename fields_tag::type{num_points, 0.};
+    Initialization::mutate_assign<simple_tags>(
+        make_not_null(&box), std::move(mesh), std::move(inertial_coords),
+        std::move(initial_fields), std::move(source));
+    return {std::move(box)};
+  }
+};
+
+// The next two actions are responsible for applying the linear operator to the
+// operand data. They apply a chunk of the full matrix on each element and
+// perform a reduction to obtain the full matrix-vector product.
+
+template <typename OperandTag>
+struct CollectOperatorAction;
+
+template <typename OperandTag>
+struct ComputeOperatorAction {
+  using const_global_cache_tags = tmpl::list<LinearOperator>;
+  using local_operator_applied_to_operand_tag =
+      db::add_tag_prefix<::LinearSolver::Tags::OperatorAppliedTo, OperandTag>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ActionList, typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&, Parallel::AlgorithmExecution>
+  apply(db::DataBox<DbTagsList>& box,
+        const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+        const Parallel::GlobalCache<Metavariables>& /*cache*/,
+        const ElementId<1>& element_id, const ActionList /*meta*/,
+        const ParallelComponent* const /*meta*/) noexcept {
+    const size_t multigrid_level = element_id.grid_index();
+    const size_t element_index = helpers_distributed::get_index(element_id);
+    const auto& operator_matrices = get<LinearOperator>(box)[multigrid_level];
+    const size_t number_of_elements = operator_matrices.size();
+    const auto& linear_operator = gsl::at(operator_matrices, element_index);
+    const size_t number_of_grid_points = linear_operator.columns();
+    const auto& operand = get<OperandTag>(box);
+
+    typename OperandTag::type operator_applied_to_operand{
+        number_of_grid_points * number_of_elements};
+    // Could use apply_matrices here once it works with `DenseMatrix`, or
+    // `Matrix` is option-creatable
+    dgemv_('N', linear_operator.rows(), linear_operator.columns(), 1,
+           linear_operator.data(), linear_operator.spacing(), operand.data(), 1,
+           0, operator_applied_to_operand.data(), 1);
+
+    auto& section = *db::get_mutable_reference<Parallel::Tags::Section<
+        ParallelComponent, ::LinearSolver::multigrid::Tags::MultigridLevel>>(
+        make_not_null(&box));
+    Parallel::contribute_to_reduction<CollectOperatorAction<OperandTag>>(
+        Parallel::ReductionData<
+            Parallel::ReductionDatum<typename OperandTag::type, funcl::Plus<>>,
+            Parallel::ReductionDatum<size_t, funcl::AssertEqual<>>>{
+            operator_applied_to_operand, multigrid_level},
+        section.proxy()[element_id], section.proxy(), make_not_null(&section));
+
+    // Pause algorithm for now. The reduction will be broadcast to the next
+    // action which is responsible for restarting the algorithm.
+    return {std::move(box), Parallel::AlgorithmExecution::Pause};
+  }
+};
+
+template <typename OperandTag>
+struct CollectOperatorAction {
+  using local_operator_applied_to_operand_tag =
+      db::add_tag_prefix<::LinearSolver::Tags::OperatorAppliedTo, OperandTag>;
+
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables, typename ScalarFieldOperandTag,
+            Requires<tmpl::list_contains_v<
+                DbTagsList, local_operator_applied_to_operand_tag>> = nullptr>
+  static void apply(db::DataBox<DbTagsList>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ElementId<1>& element_id,
+                    const Variables<tmpl::list<ScalarFieldOperandTag>>&
+                        operator_applied_to_operand_global_data,
+                    const size_t broadcasting_multigrid_level) noexcept {
+    // We're receiving broadcasts also from reductions over other sections. See
+    // issue: https://github.com/sxs-collaboration/spectre/issues/3220
+    const size_t multigrid_level = element_id.grid_index();
+    if (multigrid_level != broadcasting_multigrid_level) {
+      return;
+    }
+    const size_t element_index = helpers_distributed::get_index(element_id);
+    // This could be generalized to work on the Variables instead of the
+    // Scalar, but it's only for the purpose of this test.
+    const size_t number_of_grid_points =
+        get<LinearOperator>(box)[multigrid_level][0].columns();
+    const auto& operator_applied_to_operand_global =
+        get<ScalarFieldOperandTag>(operator_applied_to_operand_global_data)
+            .get();
+    DataVector operator_applied_to_operand_local{number_of_grid_points};
+    std::copy(operator_applied_to_operand_global.begin() +
+                  static_cast<int>(element_index * number_of_grid_points),
+              operator_applied_to_operand_global.begin() +
+                  static_cast<int>((element_index + 1) * number_of_grid_points),
+              operator_applied_to_operand_local.begin());
+    db::mutate<local_operator_applied_to_operand_tag>(
+        make_not_null(&box),
+        [&operator_applied_to_operand_local,
+         &number_of_grid_points](auto operator_applied_to_operand) noexcept {
+          *operator_applied_to_operand =
+              typename local_operator_applied_to_operand_tag::type{
+                  number_of_grid_points};
+          get(get<
+              ::LinearSolver::Tags::OperatorAppliedTo<ScalarFieldOperandTag>>(
+              *operator_applied_to_operand)) =
+              operator_applied_to_operand_local;
+        });
+    // Proceed with algorithm
+    Parallel::get_parallel_component<ParallelComponent>(cache)[element_id]
+        .perform_algorithm(true);
+  }
+};
+
+template <typename OptionsGroup>
+struct TestResult {
+  using const_global_cache_tags =
+      tmpl::list<helpers_distributed::ExpectedResult>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ActionList, typename ParallelComponent>
+  static std::tuple<db::DataBox<DbTagsList>&&, bool> apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ElementId<1>& element_id, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    if (element_id.grid_index() > 0) {
+      return {std::move(box), true};
+    }
+    const size_t element_index = helpers_distributed::get_index(element_id);
+    const auto& expected_result =
+        gsl::at(get<helpers_distributed::ExpectedResult>(box), element_index);
+    const auto& result = get<helpers_distributed::ScalarFieldTag>(box).get();
+    for (size_t i = 0; i < expected_result.size(); i++) {
+      SPECTRE_PARALLEL_REQUIRE(result[i] == approx(expected_result[i]));
+    }
+    return {std::move(box), true};
+  }
+};
+
+}  // namespace TestHelpers::LinearSolver::multigrid

--- a/tests/Unit/IO/Observers/Test_Tags.cpp
+++ b/tests/Unit/IO/Observers/Test_Tags.cpp
@@ -10,6 +10,11 @@
 #include "Utilities/TypeTraits.hpp"
 
 namespace observers::Tags {
+namespace {
+struct TestTag {
+  using type = int;
+};
+}  // namespace
 SPECTRE_TEST_CASE("Unit.IO.Observers.Tags", "[Unit][Observers]") {
   TestHelpers::db::test_simple_tag<ExpectedContributorsForObservations>(
       "ExpectedContributorsForObservations");
@@ -28,6 +33,8 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.Tags", "[Unit][Observers]") {
   TestHelpers::db::test_simple_tag<ReductionDataNames<double>>(
       "ReductionDataNames");
   TestHelpers::db::test_simple_tag<H5FileLock>("H5FileLock");
+  TestHelpers::db::test_simple_tag<ObservationKey<TestTag>>(
+      "ObservationKey(TestTag)");
   TestHelpers::db::test_simple_tag<VolumeFileName>("VolumeFileName");
   TestHelpers::db::test_simple_tag<ReductionFileName>("ReductionFileName");
   static_assert(

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.cpp
@@ -69,8 +69,7 @@ struct Metavariables {
 
 static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &setup_memory_allocation_failure_reporting,
-    &domain::creators::register_derived_with_charm,
-    &TestHelpers::domain::BoundaryConditions::register_derived_with_charm};
+    &domain::creators::register_derived_with_charm};
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresPreconditionedAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Gmres/Test_DistributedGmresPreconditionedAlgorithm.cpp
@@ -77,8 +77,7 @@ struct Metavariables {
 
 static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &setup_memory_allocation_failure_reporting,
-    &domain::creators::register_derived_with_charm,
-    &TestHelpers::domain::BoundaryConditions::register_derived_with_charm};
+    &domain::creators::register_derived_with_charm};
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Actions/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Actions/CMakeLists.txt
@@ -1,16 +1,15 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-set(LIBRARY "Test_ParallelMultigrid")
+set(LIBRARY "Test_ParallelMultigridActions")
 
 set(LIBRARY_SOURCES
-  Test_Hierarchy.cpp
-  Test_Tags.cpp
+  Test_RestrictFields.cpp
   )
 
 add_test_library(
   ${LIBRARY}
-  "ParallelAlgorithms/LinearSolver/Multigrid"
+  "ParallelAlgorithms/LinearSolver/Multigrid/Actions"
   "${LIBRARY_SOURCES}"
   ""
   )
@@ -18,10 +17,13 @@ add_test_library(
 target_link_libraries(
   ${LIBRARY}
   PRIVATE
+  Convergence
   DataStructures
+  Domain
   DomainStructure
+  Logging
+  Parallel
   ParallelMultigrid
+  Spectral
   Utilities
   )
-
-add_subdirectory(Actions)

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Actions/Test_RestrictFields.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Actions/Test_RestrictFields.cpp
@@ -1,0 +1,211 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <optional>
+#include <type_traits>
+#include <unordered_set>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "IO/Logging/Tags.hpp"
+#include "IO/Logging/Verbosity.hpp"
+#include "NumericalAlgorithms/Convergence/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Parallel/Actions/TerminatePhase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "ParallelAlgorithms/LinearSolver/Multigrid/Actions/RestrictFields.hpp"
+#include "ParallelAlgorithms/LinearSolver/Multigrid/Tags.hpp"
+#include "ParallelAlgorithms/LinearSolver/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+
+struct DummyOptionsGroup {};
+
+template <size_t N>
+struct ScalarFieldTag : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+struct MassiveTag : db::SimpleTag {
+  using type = bool;
+};
+
+using fields_tag =
+    ::Tags::Variables<tmpl::list<ScalarFieldTag<0>, ScalarFieldTag<1>>>;
+
+template <size_t Dim, typename FieldsAreMassiveTag, typename Metavariables>
+struct ElementArray {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementId<Dim>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Initialization,
+          tmpl::list<ActionTesting::InitializeDataBox<tmpl::list<
+              LinearSolver::multigrid::Tags::ParentId<Dim>,
+              LinearSolver::multigrid::Tags::ChildIds<Dim>,
+              domain::Tags::Mesh<Dim>,
+              LinearSolver::multigrid::Tags::ParentMesh<Dim>,
+              Convergence::Tags::IterationId<DummyOptionsGroup>, fields_tag>>>>,
+      Parallel::PhaseActions<
+          typename Metavariables::Phase, Metavariables::Phase::Testing,
+          tmpl::list<
+              LinearSolver::multigrid::Actions::SendFieldsToCoarserGrid<
+                  tmpl::list<fields_tag>, DummyOptionsGroup,
+                  FieldsAreMassiveTag>,
+              LinearSolver::multigrid::Actions::ReceiveFieldsFromFinerGrid<
+                  Dim, tmpl::list<fields_tag>, DummyOptionsGroup>,
+              Parallel::Actions::TerminatePhase>>>;
+};
+
+template <size_t Dim, typename FieldsAreMassiveTag>
+struct Metavariables {
+  using element_array = ElementArray<Dim, FieldsAreMassiveTag, Metavariables>;
+  using component_list = tmpl::list<element_array>;
+  using const_global_cache_tags =
+      tmpl::conditional_t<std::is_same_v<FieldsAreMassiveTag, void>,
+                          tmpl::list<>, tmpl::list<FieldsAreMassiveTag>>;
+  enum class Phase { Initialization, Testing, Exit };
+};
+
+template <typename FieldsAreMassiveTag>
+void test_restrict_fields(const Mesh<1>& fine_mesh, const Mesh<1>& coarse_mesh,
+                          const DataVector& fine_data_left,
+                          const DataVector& fine_data_right,
+                          const DataVector& expected_coarse_data,
+                          const bool fields_are_massive = false) {
+  constexpr size_t Dim = 1;
+  using metavariables = Metavariables<Dim, FieldsAreMassiveTag>;
+  using element_array = typename metavariables::element_array;
+
+  const auto global_cache = [&fields_are_massive]() {
+    if constexpr (std::is_same_v<FieldsAreMassiveTag, void>) {
+      (void)fields_are_massive;
+      return tuples::TaggedTuple<logging::Tags::Verbosity<DummyOptionsGroup>>{
+          Verbosity::Verbose};
+    } else {
+      return tuples::TaggedTuple<logging::Tags::Verbosity<DummyOptionsGroup>,
+                                 FieldsAreMassiveTag>{Verbosity::Verbose,
+                                                      fields_are_massive};
+    }
+  }();
+
+  ActionTesting::MockRuntimeSystem<metavariables> runner{
+      std::move(global_cache)};
+
+  // Setup element array
+  const auto add_element =
+      [&runner](const ElementId<Dim>& element_id,
+                const std::optional<ElementId<Dim>>& parent_id,
+                const std::unordered_set<ElementId<Dim>>& child_ids,
+                const Mesh<Dim>& mesh,
+                const std::optional<Mesh<Dim>>& parent_mesh,
+                const std::optional<DataVector>& data) {
+        typename fields_tag::type fields{};
+        if (data.has_value()) {
+          fields.initialize(mesh.number_of_grid_points());
+          get(get<ScalarFieldTag<0>>(fields)) = *data;
+          get(get<ScalarFieldTag<1>>(fields)) = *data;
+        }
+        ActionTesting::emplace_component_and_initialize<element_array>(
+            make_not_null(&runner), element_id,
+            {parent_id, child_ids, mesh, parent_mesh, size_t{0},
+             std::move(fields)});
+      };
+  const ElementId<Dim> left_element_id{0, {{{1, 0}}}, 0};
+  const ElementId<Dim> right_element_id{0, {{{1, 1}}}, 0};
+  const ElementId<Dim> coarse_element_id{0, {{{0, 0}}}, 1};
+  add_element(left_element_id, coarse_element_id, {}, fine_mesh, coarse_mesh,
+              fine_data_left);
+  add_element(right_element_id, coarse_element_id, {}, fine_mesh, coarse_mesh,
+              fine_data_right);
+  add_element(coarse_element_id, std::nullopt,
+              {left_element_id, right_element_id}, coarse_mesh, std::nullopt,
+              std::nullopt);
+
+  ActionTesting::set_phase(make_not_null(&runner),
+                           metavariables::Phase::Testing);
+
+  // Skip over sending on coarse element
+  ActionTesting::next_action<element_array>(make_not_null(&runner),
+                                            coarse_element_id);
+  REQUIRE_FALSE(ActionTesting::next_action_if_ready<element_array>(
+      make_not_null(&runner), coarse_element_id));
+  // Send from left element
+  ActionTesting::next_action<element_array>(make_not_null(&runner),
+                                            left_element_id);
+  REQUIRE(ActionTesting::next_action_if_ready<element_array>(
+      make_not_null(&runner), left_element_id));
+  REQUIRE_FALSE(ActionTesting::next_action_if_ready<element_array>(
+      make_not_null(&runner), coarse_element_id));
+  // Send from right element
+  ActionTesting::next_action<element_array>(make_not_null(&runner),
+                                            right_element_id);
+  REQUIRE(ActionTesting::next_action_if_ready<element_array>(
+      make_not_null(&runner), right_element_id));
+  // Receive on coarse element
+  REQUIRE(ActionTesting::next_action_if_ready<element_array>(
+      make_not_null(&runner), coarse_element_id));
+  const auto& coarse_data =
+      ActionTesting::get_databox_tag<element_array, fields_tag>(
+          runner, coarse_element_id);
+  CHECK_ITERABLE_APPROX(get(get<ScalarFieldTag<0>>(coarse_data)),
+                        expected_coarse_data);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ParallelMultigrid.Action.RestrictFields",
+                  "[Unit][ParallelAlgorithms][LinearSolver][Actions]") {
+  const Mesh<1> fine_mesh{4, Spectral::Basis::Legendre,
+                          Spectral::Quadrature::GaussLobatto};
+  const Mesh<1> coarse_mesh{3, Spectral::Basis::Legendre,
+                            Spectral::Quadrature::GaussLobatto};
+  const DataVector fine_data_left{0., 1., 2., 3.};
+  const DataVector fine_data_right{4., 5., 6., 7.};
+  {
+    const DataVector coarse_data =
+        apply_matrices(
+            make_array<1>(Spectral::projection_matrix_child_to_parent(
+                fine_mesh, coarse_mesh, Spectral::ChildSize::LowerHalf)),
+            fine_data_left, Index<1>{4}) +
+        apply_matrices(
+            make_array<1>(Spectral::projection_matrix_child_to_parent(
+                fine_mesh, coarse_mesh, Spectral::ChildSize::UpperHalf)),
+            fine_data_right, Index<1>{4});
+    test_restrict_fields<void>(fine_mesh, coarse_mesh, fine_data_left,
+                               fine_data_right, coarse_data);
+    test_restrict_fields<MassiveTag>(fine_mesh, coarse_mesh, fine_data_left,
+                                     fine_data_right, coarse_data, false);
+  }
+  {
+    const DataVector coarse_data =
+        apply_matrices(
+            make_array<1>(Spectral::projection_matrix_child_to_parent(
+                fine_mesh, coarse_mesh, Spectral::ChildSize::LowerHalf, true)),
+            fine_data_left, Index<1>{4}) +
+        apply_matrices(
+            make_array<1>(Spectral::projection_matrix_child_to_parent(
+                fine_mesh, coarse_mesh, Spectral::ChildSize::UpperHalf, true)),
+            fine_data_right, Index<1>{4});
+    test_restrict_fields<MassiveTag>(fine_mesh, coarse_mesh, fine_data_left,
+                                     fine_data_right, coarse_data, true);
+  }
+}

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_ParallelMultigrid")
 
 set(LIBRARY_SOURCES
   Test_Hierarchy.cpp
+  Test_Tags.cpp
   )
 
 add_test_library(
@@ -17,6 +18,7 @@ add_test_library(
 target_link_libraries(
   ${LIBRARY}
   PRIVATE
+  DataStructures
   DomainStructure
   ParallelMultigrid
   Utilities

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/CMakeLists.txt
@@ -24,4 +24,31 @@ target_link_libraries(
   Utilities
   )
 
+add_distributed_linear_solver_algorithm_test("MultigridAlgorithm")
+target_link_libraries(
+  Test_MultigridAlgorithm
+  PRIVATE
+  ParallelMultigrid
+  )
+
+add_test(
+  NAME Integration.LinearSolver.MultigridAlgorithmMassive
+  COMMAND ${CMAKE_BINARY_DIR}/bin/Test_MultigridAlgorithm --input-file
+  ${CMAKE_CURRENT_SOURCE_DIR}/Test_MultigridAlgorithmMassive.yaml
+  )
+set_tests_properties(
+  Integration.LinearSolver.MultigridAlgorithmMassive
+  PROPERTIES
+  TIMEOUT 5
+  LABELS "integration"
+  ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
+
+add_distributed_linear_solver_algorithm_test(
+  "MultigridPreconditionedGmresAlgorithm")
+target_link_libraries(
+  Test_MultigridPreconditionedGmresAlgorithm
+  PRIVATE
+  ParallelMultigrid
+  )
+
 add_subdirectory(Actions)

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.cpp
@@ -1,0 +1,144 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#define CATCH_CONFIG_RUNNER
+
+#include <vector>
+
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Creators/Interval.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Elliptic/DiscontinuousGalerkin/DgElementArray.hpp"
+#include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp"
+#include "Helpers/ParallelAlgorithms/LinearSolver/Multigrid/Helpers.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/Actions/Goto.hpp"
+#include "Parallel/Actions/SetupDataBox.hpp"
+#include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/Main.hpp"
+#include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
+#include "ParallelAlgorithms/LinearSolver/Multigrid/ElementsAllocator.hpp"
+#include "ParallelAlgorithms/LinearSolver/Multigrid/Multigrid.hpp"
+#include "ParallelAlgorithms/LinearSolver/Multigrid/Tags.hpp"
+#include "ParallelAlgorithms/LinearSolver/Richardson/Richardson.hpp"
+#include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/MemoryHelpers.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+// \endcond
+
+namespace helpers = LinearSolverAlgorithmTestHelpers;
+namespace helpers_mg = TestHelpers::LinearSolver::multigrid;
+
+namespace {
+
+struct MultigridSolver {
+  static constexpr Options::String help =
+      "Options for the iterative linear solver";
+};
+
+struct RichardsonSmoother {
+  static constexpr Options::String help =
+      "Options for the iterative linear solver";
+};
+
+struct Metavariables {
+  static constexpr const char* const help{
+      "Test the Multigrid linear solver algorithm on multiple elements"};
+
+  static constexpr size_t volume_dim = 1;
+  using system =
+      TestHelpers::domain::BoundaryConditions::SystemWithoutBoundaryConditions<
+          volume_dim>;
+
+  // [setup_smoother]
+  using multigrid = LinearSolver::multigrid::Multigrid<
+      volume_dim, helpers_mg::fields_tag, MultigridSolver,
+      helpers_mg::OperatorIsMassive, helpers_mg::sources_tag>;
+
+  using smoother = LinearSolver::Richardson::Richardson<
+      typename multigrid::smooth_fields_tag, RichardsonSmoother,
+      typename multigrid::smooth_source_tag,
+      LinearSolver::multigrid::Tags::MultigridLevel>;
+  // [setup_smoother]
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<DomainCreator<1>, tmpl::list<domain::creators::Interval>>>;
+  };
+
+  using Phase = helpers::Phase;
+
+  using initialization_actions =
+      tmpl::list<::Actions::SetupDataBox, helpers_mg::InitializeElement,
+                 typename multigrid::initialize_element,
+                 typename smoother::initialize_element,
+                 ::Initialization::Actions::RemoveOptionsAndTerminatePhase>;
+
+  using register_actions = tmpl::list<typename multigrid::register_element,
+                                      typename smoother::register_element,
+                                      Parallel::Actions::TerminatePhase>;
+
+  // [action_list]
+  template <typename Label>
+  using smooth_actions = tmpl::list<
+      helpers_mg::ComputeOperatorAction<typename smoother::fields_tag>,
+      typename smoother::template solve<
+          helpers_mg::ComputeOperatorAction<typename smoother::operand_tag>,
+          Label>>;
+
+  using solve_actions =
+      tmpl::list<typename multigrid::template solve<
+                     smooth_actions<LinearSolver::multigrid::VcycleDownLabel>,
+                     smooth_actions<LinearSolver::multigrid::VcycleUpLabel>>,
+                 Parallel::Actions::TerminatePhase>;
+  // [action_list]
+
+  using test_actions =
+      tmpl::list<helpers_mg::TestResult<typename multigrid::options_group>>;
+
+  using component_list = tmpl::flatten<tmpl::list<
+      typename multigrid::component_list, typename smoother::component_list,
+      elliptic::DgElementArray<
+          Metavariables,
+          tmpl::list<
+              Parallel::PhaseActions<Phase, Phase::Initialization,
+                                     initialization_actions>,
+              Parallel::PhaseActions<Phase, Phase::RegisterWithObserver,
+                                     register_actions>,
+              Parallel::PhaseActions<Phase, Phase::PerformLinearSolve,
+                                     solve_actions>,
+              Parallel::PhaseActions<Phase, Phase::TestResult, test_actions>>,
+          LinearSolver::multigrid::ElementsAllocator<1, MultigridSolver>>,
+      observers::Observer<Metavariables>,
+      observers::ObserverWriter<Metavariables>,
+      helpers::OutputCleaner<Metavariables>>>;
+  using observed_reduction_data_tags =
+      observers::collect_reduction_data_tags<tmpl::list<multigrid, smoother>>;
+  static constexpr bool ignore_unrecognized_command_line_options = false;
+  static constexpr auto determine_next_phase =
+      helpers::determine_next_phase<Metavariables>;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
+};
+
+}  // namespace
+
+static const std::vector<void (*)()> charm_init_node_funcs{
+    &setup_error_handling, &setup_memory_allocation_failure_reporting,
+    &domain::creators::register_derived_with_charm};
+static const std::vector<void (*)()> charm_init_proc_funcs{
+    &enable_floating_point_exceptions};
+
+using charmxx_main_component = Parallel::Main<Metavariables>;
+
+#include "Parallel/CharmMain.tpp"  // IWYU pragma: keep

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.yaml
@@ -1,0 +1,66 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# The test problem being solved here is a DG-discretized 1D Poisson equation
+# -u''(x) = f(x) on the interval [0, pi] with source f(x)=sin(x) and homogeneous
+# Dirichlet boundary conditions such that the solution is u(x)=sin(x) as well.
+#
+# Details:
+# - Domain decomposition: 2 elements with 3 LGL grid-points each on the finest
+#   mesh
+# - DG scheme: Strong compact flux formulation (no auxiliary variables)
+# - "Massless": Multiplied by inverse mass matrix with mass-lumping. Note that
+#   whether or not the operator is DG-massive is relevant for the multigrid
+#   restriction operation.
+# - Internal penalty flux with sigma = 1.5 * N_points^2 / h
+
+DomainCreator:
+  Interval:
+    LowerBound: [0]
+    UpperBound: [3.141592653589793]
+    IsPeriodicIn: [false]
+    InitialRefinement: [1]
+    InitialGridPoints: [3]
+    TimeDependence: None
+
+LinearOperator:
+  - [[[17.133142186587385, 3.242277876554809, -2.8369931419854577],
+      [0.8105694691387026, 3.2422778765548097, -0.405284734569351],
+      [-2.8369931419854577, -1.6211389382774053, 11.403564235279148],
+      [1.2158542037080533, -4.863416814832214, -5.729577951308233],
+      [0.0, 0.0, -1.2158542037080537],
+      [0.0, 0.0, 1.2158542037080533]],
+     [[1.2158542037080533, 0.0, 0.0],
+      [-1.2158542037080537, 0.0, 0.0],
+      [-5.729577951308233, -4.863416814832214, 1.2158542037080533],
+      [11.403564235279148, -1.6211389382774053, -2.8369931419854577],
+      [-0.405284734569351, 3.2422778765548097, 0.8105694691387026],
+      [-2.836993141985458, 3.242277876554809, 17.133142186587385]]]
+  - [[[7.148074522300963, 0.8105694691387022, -1.0132118364233778],
+      [0.20264236728467566, 0.8105694691387024, 0.20264236728467566],
+      [-1.0132118364233778, 0.8105694691387022, 7.148074522300963]]]
+
+Source:
+  - [0.0, 0.7071067811865475, 1.0]
+  - [1.0, 0.7071067811865475, 0.0]
+
+ExpectedResult:
+  - [-0.04332079221988435, 0.7253224709680011, 0.9928055333486303]
+  - [0.9928055333486303, 0.7253224709680011, -0.04332079221988417]
+
+OperatorIsMassive: False
+
+Observers:
+  VolumeFileName: "Test_MultigridAlgorithm_Volume"
+  ReductionFileName: "Test_MultigridAlgorithm_Reductions"
+
+MultigridSolver:
+  Iterations: 5
+  Verbosity: Verbose
+  MaxLevels: Auto
+  OutputVolumeData: True
+
+RichardsonSmoother:
+  Iterations: 20
+  RelaxationParameter: 0.09020991440370969  # 2. / (max_eigval + min_eigval)
+  Verbosity: Silent

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithmMassive.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithmMassive.yaml
@@ -1,0 +1,57 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# This test problem is the same as detailed in `Test_MultigridAlgorithm.yaml`,
+# but the operator includes the mass matrix (with mass-lumping). This is
+# relevant for the multigrid restriction operation.
+
+DomainCreator:
+  Interval:
+    LowerBound: [0]
+    UpperBound: [3.141592653589793]
+    IsPeriodicIn: [false]
+    InitialRefinement: [1]
+    InitialGridPoints: [3]
+    TimeDependence: None
+
+LinearOperator:
+  - [[[4.485446135524357, 0.8488263631567751, -0.7427230677621782],
+      [0.8488263631567755, 3.395305452627101, -0.4244131815783874],
+      [-0.7427230677621782, -0.4244131815783877, 2.9854461355243567],
+      [0.31830988618379064, -1.2732395447351628, -1.5],
+      [0.0, 0.0, -1.273239544735163],
+      [0.0, 0.0, 0.31830988618379064]],
+     [[0.31830988618379064, 0.0, 0.0],
+      [-1.273239544735163, 0.0, 0.0],
+      [-1.5, -1.2732395447351628, 0.31830988618379064],
+      [2.9854461355243567, -0.4244131815783877, -0.7427230677621782],
+      [-0.4244131815783874, 3.395305452627101, 0.8488263631567755],
+      [-0.7427230677621783, 0.8488263631567751, 4.485446135524357]]]
+  - [[[3.7427230677621783, 0.42441318157838753, -0.5305164769729844],
+      [0.42441318157838775, 1.6976527263135506, 0.42441318157838775],
+      [-0.5305164769729844, 0.42441318157838753, 3.7427230677621783]]]
+
+Source:
+  - [0.0, 0.7404804896930609, 0.2617993877991494]
+  - [0.26179938779914935, 0.7404804896930614, 0.0]
+
+ExpectedResult:
+  - [-0.04332079221988435, 0.7253224709680011, 0.9928055333486303]
+  - [0.9928055333486303, 0.7253224709680011, -0.04332079221988417]
+
+OperatorIsMassive: True
+
+Observers:
+  VolumeFileName: "Test_MultigridAlgorithmMassive_Volume"
+  ReductionFileName: "Test_MultigridAlgorithmMassive_Reductions"
+
+MultigridSolver:
+  Iterations: 4
+  Verbosity: Verbose
+  MaxLevels: Auto
+  OutputVolumeData: True
+
+RichardsonSmoother:
+  Iterations: 20
+  RelaxationParameter: 0.33123384064827677  # 2. / (max_eigval + min_eigval)
+  Verbosity: Silent

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridPreconditionedGmresAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridPreconditionedGmresAlgorithm.cpp
@@ -1,0 +1,160 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#define CATCH_CONFIG_RUNNER
+
+#include <vector>
+
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Creators/Interval.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Elliptic/DiscontinuousGalerkin/DgElementArray.hpp"
+#include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Helpers/ParallelAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp"
+#include "Helpers/ParallelAlgorithms/LinearSolver/Multigrid/Helpers.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/Actions/Goto.hpp"
+#include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/Main.hpp"
+#include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
+#include "ParallelAlgorithms/LinearSolver/Actions/MakeIdentityIfSkipped.hpp"
+#include "ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp"
+#include "ParallelAlgorithms/LinearSolver/Multigrid/ElementsAllocator.hpp"
+#include "ParallelAlgorithms/LinearSolver/Multigrid/Multigrid.hpp"
+#include "ParallelAlgorithms/LinearSolver/Richardson/Richardson.hpp"
+#include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/MemoryHelpers.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+// \endcond
+
+namespace helpers = LinearSolverAlgorithmTestHelpers;
+namespace helpers_mg = TestHelpers::LinearSolver::multigrid;
+
+namespace {
+
+struct KrylovSolver {
+  static constexpr Options::String help =
+      "Options for the iterative linear solver";
+};
+
+struct MultigridSolver {
+  static constexpr Options::String help =
+      "Options for the iterative linear solver";
+};
+
+struct RichardsonSmoother {
+  static constexpr Options::String help =
+      "Options for the iterative linear solver";
+};
+
+struct Metavariables {
+  static constexpr const char* const help{
+      "Test the Multigrid solver used as a preconditioner for a "
+      "Krylov-subspace solver"};
+
+  static constexpr size_t volume_dim = 1;
+  using system =
+      TestHelpers::domain::BoundaryConditions::SystemWithoutBoundaryConditions<
+          volume_dim>;
+
+  using linear_solver =
+      LinearSolver::gmres::Gmres<Metavariables, helpers_mg::fields_tag,
+                                 KrylovSolver, true, helpers_mg::sources_tag,
+                                 LinearSolver::multigrid::Tags::IsFinestGrid>;
+  using multigrid = LinearSolver::multigrid::Multigrid<
+      volume_dim, typename linear_solver::operand_tag, MultigridSolver,
+      helpers_mg::OperatorIsMassive,
+      typename linear_solver::preconditioner_source_tag>;
+  using smoother = LinearSolver::Richardson::Richardson<
+      typename multigrid::smooth_fields_tag, RichardsonSmoother,
+      typename multigrid::smooth_source_tag,
+      LinearSolver::multigrid::Tags::MultigridLevel>;
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<DomainCreator<1>, tmpl::list<domain::creators::Interval>>>;
+  };
+
+  using Phase = helpers::Phase;
+
+  using initialization_actions = tmpl::list<
+      ::Actions::SetupDataBox, helpers_mg::InitializeElement,
+      typename linear_solver::initialize_element,
+      typename multigrid::initialize_element,
+      typename smoother::initialize_element,
+      helpers_mg::ComputeOperatorAction<typename linear_solver::fields_tag>,
+      ::Initialization::Actions::RemoveOptionsAndTerminatePhase>;
+
+  using register_actions = tmpl::list<typename linear_solver::register_element,
+                                      typename multigrid::register_element,
+                                      typename smoother::register_element,
+                                      Parallel::Actions::TerminatePhase>;
+
+  template <typename Label>
+  using smooth_actions = tmpl::list<
+      helpers_mg::ComputeOperatorAction<typename smoother::fields_tag>,
+      typename smoother::template solve<
+          helpers_mg::ComputeOperatorAction<typename smoother::operand_tag>,
+          Label>>;
+
+  using solve_actions = tmpl::list<
+      typename linear_solver::template solve<tmpl::list<
+          typename multigrid::template solve<
+              smooth_actions<LinearSolver::multigrid::VcycleDownLabel>,
+              smooth_actions<LinearSolver::multigrid::VcycleUpLabel>>,
+          LinearSolver::Actions::MakeIdentityIfSkipped<multigrid>,
+          // Only need to apply the operator here again in case the multigrid is
+          // skipped
+          helpers_mg::ComputeOperatorAction<
+              typename linear_solver::operand_tag>>>,
+      Parallel::Actions::TerminatePhase>;
+
+  using test_actions =
+      tmpl::list<helpers_mg::TestResult<typename multigrid::options_group>>;
+
+  using component_list = tmpl::flatten<tmpl::list<
+      typename linear_solver::component_list,
+      typename multigrid::component_list, typename smoother::component_list,
+      elliptic::DgElementArray<
+          Metavariables,
+          tmpl::list<
+              Parallel::PhaseActions<Phase, Phase::Initialization,
+                                     initialization_actions>,
+              Parallel::PhaseActions<Phase, Phase::RegisterWithObserver,
+                                     register_actions>,
+              Parallel::PhaseActions<Phase, Phase::PerformLinearSolve,
+                                     solve_actions>,
+              Parallel::PhaseActions<Phase, Phase::TestResult, test_actions>>,
+          LinearSolver::multigrid::ElementsAllocator<1, MultigridSolver>>,
+      observers::Observer<Metavariables>,
+      observers::ObserverWriter<Metavariables>,
+      helpers::OutputCleaner<Metavariables>>>;
+  using observed_reduction_data_tags = observers::collect_reduction_data_tags<
+      tmpl::list<linear_solver, multigrid, smoother>>;
+  static constexpr bool ignore_unrecognized_command_line_options = false;
+  static constexpr auto determine_next_phase =
+      helpers::determine_next_phase<Metavariables>;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) noexcept {}
+};
+
+}  // namespace
+
+static const std::vector<void (*)()> charm_init_node_funcs{
+    &setup_error_handling, &setup_memory_allocation_failure_reporting,
+    &domain::creators::register_derived_with_charm};
+static const std::vector<void (*)()> charm_init_proc_funcs{
+    &enable_floating_point_exceptions};
+
+using charmxx_main_component = Parallel::Main<Metavariables>;
+
+#include "Parallel/CharmMain.tpp"  // IWYU pragma: keep

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridPreconditionedGmresAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridPreconditionedGmresAlgorithm.yaml
@@ -1,0 +1,63 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# This test problem is the same as detailed in `Test_MultigridAlgorithmMassive.yaml`,
+# but the multigrid solver is used to precondition a GMRES solver.
+
+DomainCreator:
+  Interval:
+    LowerBound: [0]
+    UpperBound: [3.141592653589793]
+    IsPeriodicIn: [false]
+    InitialRefinement: [1]
+    InitialGridPoints: [3]
+    TimeDependence: None
+
+LinearOperator:
+  - [[[4.485446135524357, 0.8488263631567751, -0.7427230677621782],
+      [0.8488263631567755, 3.395305452627101, -0.4244131815783874],
+      [-0.7427230677621782, -0.4244131815783877, 2.9854461355243567],
+      [0.31830988618379064, -1.2732395447351628, -1.5],
+      [0.0, 0.0, -1.273239544735163],
+      [0.0, 0.0, 0.31830988618379064]],
+     [[0.31830988618379064, 0.0, 0.0],
+      [-1.273239544735163, 0.0, 0.0],
+      [-1.5, -1.2732395447351628, 0.31830988618379064],
+      [2.9854461355243567, -0.4244131815783877, -0.7427230677621782],
+      [-0.4244131815783874, 3.395305452627101, 0.8488263631567755],
+      [-0.7427230677621783, 0.8488263631567751, 4.485446135524357]]]
+  - [[[3.7427230677621783, 0.42441318157838753, -0.5305164769729844],
+      [0.42441318157838775, 1.6976527263135506, 0.42441318157838775],
+      [-0.5305164769729844, 0.42441318157838753, 3.7427230677621783]]]
+
+Source:
+  - [0.0, 0.7404804896930609, 0.2617993877991494]
+  - [0.26179938779914935, 0.7404804896930614, 0.0]
+
+ExpectedResult:
+  - [-0.04332079221988435, 0.7253224709680011, 0.9928055333486303]
+  - [0.9928055333486303, 0.7253224709680011, -0.04332079221988417]
+
+OperatorIsMassive: True
+
+Observers:
+  VolumeFileName: "Test_MultigridPreconditionedGmresAlgorithm_Volume"
+  ReductionFileName: "Test_MultigridPreconditionedGmresAlgorithm_Reductions"
+
+KrylovSolver:
+  ConvergenceCriteria:
+    MaxIterations: 2
+    AbsoluteResidual: 1e-14
+    RelativeResidual: 0
+  Verbosity: Verbose
+
+MultigridSolver:
+  Iterations: 2
+  Verbosity: Verbose
+  MaxLevels: Auto
+  OutputVolumeData: True
+
+RichardsonSmoother:
+  Iterations: 20
+  RelaxationParameter: 0.33123384064827677
+  Verbosity: Silent

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_Tags.cpp
@@ -1,0 +1,61 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "ParallelAlgorithms/LinearSolver/Multigrid/Tags.hpp"
+
+namespace LinearSolver::multigrid {
+
+namespace {
+struct Tag : db::SimpleTag {
+  using type = int;
+};
+struct TestSolver {};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.LinearSolver.Multigrid.Tags",
+                  "[Unit][ParallelAlgorithms][LinearSolver]") {
+  TestHelpers::db::test_simple_tag<Tags::ChildrenRefinementLevels<1>>(
+      "ChildrenRefinementLevels");
+  TestHelpers::db::test_simple_tag<Tags::ParentRefinementLevels<1>>(
+      "ParentRefinementLevels");
+  TestHelpers::db::test_simple_tag<Tags::MaxLevels<TestSolver>>(
+      "MaxLevels(TestSolver)");
+  TestHelpers::db::test_simple_tag<Tags::OutputVolumeData<TestSolver>>(
+      "OutputVolumeData(TestSolver)");
+  TestHelpers::db::test_simple_tag<Tags::MultigridLevel>("MultigridLevel");
+  TestHelpers::db::test_simple_tag<Tags::IsFinestGrid>("IsFinestGrid");
+  TestHelpers::db::test_simple_tag<Tags::ParentId<1>>("ParentId");
+  TestHelpers::db::test_simple_tag<Tags::ChildIds<1>>("ChildIds");
+  TestHelpers::db::test_simple_tag<Tags::ParentMesh<1>>("ParentMesh");
+  TestHelpers::db::test_simple_tag<Tags::ObservationId<TestSolver>>(
+      "ObservationId(TestSolver)");
+  TestHelpers::db::test_prefix_tag<Tags::PreSmoothingInitial<Tag>>(
+      "PreSmoothingInitial(Tag)");
+  TestHelpers::db::test_prefix_tag<Tags::PreSmoothingSource<Tag>>(
+      "PreSmoothingSource(Tag)");
+  TestHelpers::db::test_prefix_tag<Tags::PreSmoothingResult<Tag>>(
+      "PreSmoothingResult(Tag)");
+  TestHelpers::db::test_prefix_tag<Tags::PreSmoothingResidual<Tag>>(
+      "PreSmoothingResidual(Tag)");
+  TestHelpers::db::test_prefix_tag<Tags::PostSmoothingInitial<Tag>>(
+      "PostSmoothingInitial(Tag)");
+  TestHelpers::db::test_prefix_tag<Tags::PostSmoothingSource<Tag>>(
+      "PostSmoothingSource(Tag)");
+  TestHelpers::db::test_prefix_tag<Tags::PostSmoothingResult<Tag>>(
+      "PostSmoothingResult(Tag)");
+  TestHelpers::db::test_prefix_tag<Tags::PostSmoothingResidual<Tag>>(
+      "PostSmoothingResidual(Tag)");
+  TestHelpers::db::test_simple_tag<Tags::VolumeDataForOutput<
+      TestSolver, ::Tags::Variables<tmpl::list<::Tags::TempScalar<0>>>>>(
+      "VolumeDataForOutput(TestSolver)");
+}
+
+}  // namespace LinearSolver::multigrid

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -616,6 +616,8 @@ cmakelists_hardcoded_libraries() {
         whitelist "$1" \
                   "tests/Unit/Parallel/CMakeLists.txt$" \
                   "tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/\
+CMakeLists.txt$" \
+                  "tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/\
 CMakeLists.txt$" && \
         staged_grep -E -A1 "(${CHECKED_COMMANDS})\(\$" "$1" | \
             grep -Ev -- "--|${CHECKED_COMMANDS}" | \


### PR DESCRIPTION
## Proposed changes

Adds the multigrid solver, which is the last remaining component of the elliptic solver. It works by solving the equations on successively coarser grids.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
