### PR TITLE
Fix RicciScalarScalar Argument Tag

### DIFF
--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -343,6 +343,52 @@ struct UnitNormalVectorCompute : UnitNormalVector<Frame>, db::ComputeTag {
   using return_type = tnsr::I<DataVector, 3, Frame>;
 };
 
+/// The 3-covariant gradient \f$D_i S_j\f$ of a Strahlkorper's normal
+template <typename Frame>
+struct GradUnitNormalOneForm : db::SimpleTag {
+  using type = tnsr::ii<DataVector, 3, Frame>;
+};
+/// Computes 3-covariant gradient \f$D_i S_j\f$ of a Strahlkorper's normal
+template <typename Frame>
+struct GradUnitNormalOneFormCompute : GradUnitNormalOneForm<Frame>,
+                                      db::ComputeTag {
+  using base = GradUnitNormalOneForm<Frame>;
+  static constexpr auto function = static_cast<void (*)(
+      const gsl::not_null<tnsr::ii<DataVector, 3, Frame>*>,
+      const tnsr::i<DataVector, 3, Frame>&, const Scalar<DataVector>&,
+      const tnsr::i<DataVector, 3, Frame>&,
+      const tnsr::ii<DataVector, 3, Frame>&, const DataVector&,
+      const tnsr::Ijj<DataVector, 3, Frame>&) noexcept>(
+      &StrahlkorperGr::grad_unit_normal_one_form<Frame>);
+  using argument_tags =
+      tmpl::list<Rhat<Frame>, Radius<Frame>, UnitNormalOneForm<Frame>,
+                 D2xRadius<Frame>, OneOverOneFormMagnitude,
+                 gr::Tags::SpatialChristoffelSecondKind<3, Frame, DataVector>>;
+  using return_type = tnsr::ii<DataVector, 3, Frame>;
+};
+
+/// Extrinsic curvature of a 2D Strahlkorper embedded in a 3D space.
+template <typename Frame>
+struct ExtrinsicCurvature : db::SimpleTag {
+  using type = tnsr::ii<DataVector, 3, Frame>;
+};
+/// Calculates the Extrinsic curvature of a 2D Strahlkorper embedded in a 3D
+/// space.
+template <typename Frame>
+struct ExtrinsicCurvatureCompute : ExtrinsicCurvature<Frame>, db::ComputeTag {
+  using base = ExtrinsicCurvature<Frame>;
+  static constexpr auto function =
+      static_cast<void (*)(const gsl::not_null<tnsr::ii<DataVector, 3, Frame>*>,
+                           const tnsr::ii<DataVector, 3, Frame>&,
+                           const tnsr::i<DataVector, 3, Frame>&,
+                           const tnsr::I<DataVector, 3, Frame>&) noexcept>(
+          &StrahlkorperGr::extrinsic_curvature<Frame>);
+  using argument_tags =
+      tmpl::list<GradUnitNormalOneForm<Frame>, UnitNormalOneForm<Frame>,
+                 UnitNormalVector<Frame>>;
+  using return_type = tnsr::ii<DataVector, 3, Frame>;
+};
+
 /// Ricci scalar is the two-dimensional intrinsic Ricci scalar curvature
 /// of a Strahlkorper
 struct RicciScalar : db::SimpleTag {
@@ -361,7 +407,7 @@ struct RicciScalarCompute : RicciScalar, db::ComputeTag {
       &StrahlkorperGr::ricci_scalar<Frame>);
   using argument_tags =
       tmpl::list<gr::Tags::SpatialRicci<3, Frame, DataVector>,
-                 UnitNormalVector<Frame>, gr::Tags::ExtrinsicCurvature<3>,
+                 UnitNormalVector<Frame>, ExtrinsicCurvature<Frame>,
                  gr::Tags::InverseSpatialMetric<3, Frame, DataVector>>;
   using return_type = Scalar<DataVector>;
 };

--- a/src/ApparentHorizons/TagsDeclarations.hpp
+++ b/src/ApparentHorizons/TagsDeclarations.hpp
@@ -46,6 +46,14 @@ template <typename Frame>
 struct UnitNormalVector;
 template <typename Frame>
 struct UnitNormalVectorCompute;
+template <typename Frame>
+struct GradUnitNormalOneForm;
+template <typename Frame>
+struct GradUnitNormalOneFormCompute;
+template <typename Frame>
+struct ExtrinsicCurvature;
+template <typename Frame>
+struct ExtrinsicCurvatureCompute;
 struct RicciScalar;
 template <typename Frame>
 struct RicciScalarCompute;

--- a/tests/Unit/ApparentHorizons/Test_Tags.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Tags.cpp
@@ -396,6 +396,12 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
       StrahlkorperTags::UnitNormalOneForm<Frame::Inertial>>(
       "UnitNormalOneForm");
   TestHelpers::db::test_simple_tag<
+      StrahlkorperTags::GradUnitNormalOneForm<Frame::Inertial>>(
+      "GradUnitNormalOneForm");
+  TestHelpers::db::test_simple_tag<
+      StrahlkorperTags::ExtrinsicCurvature<Frame::Inertial>>(
+      "ExtrinsicCurvature");
+  TestHelpers::db::test_simple_tag<
       StrahlkorperTags::UnitNormalVector<Frame::Inertial>>("UnitNormalVector");
   TestHelpers::db::test_simple_tag<
       StrahlkorperTags::Strahlkorper<Frame::Inertial>>("Strahlkorper");
@@ -503,6 +509,12 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
   TestHelpers::db::test_compute_tag<
       StrahlkorperTags::UnitNormalOneFormCompute<Frame::Inertial>>(
       "UnitNormalOneForm");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::GradUnitNormalOneFormCompute<Frame::Inertial>>(
+      "GradUnitNormalOneForm");
+  TestHelpers::db::test_compute_tag<
+      StrahlkorperTags::ExtrinsicCurvatureCompute<Frame::Inertial>>(
+      "ExtrinsicCurvature");
   TestHelpers::db::test_compute_tag<
       StrahlkorperTags::UnitNormalVectorCompute<Frame::Inertial>>(
       "UnitNormalVector");


### PR DESCRIPTION
## Proposed changes

Add the ExtrinsicCurvature and GradUnitNormalOneForm compute tags to fix a bug found in the arguments list for the Ricci Scalar compute tag in Tags.hpp.

Change the RicciScalar to take the argument tag ExtrinsicCurvature<Frame> (the extrinsic curvature of the 2D horizon embedded in 3D space) instead of gr::Tags::ExtrinsicCurvature<3> (the extrinsic curvature of the 3D space embedded in 3+1D spacetime).

The GradUnitNormalOneForm compute tag (computes the 3-covariant gradient of a Strahlkorper's normal) is required to pass through the ExtrinsicCurvature compute tag. 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
