### PR TITLE
Add explicit instantiation: Kastaun, NewmanHamlin, Palenzuela to PrimitiveFromConservative

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
@@ -190,6 +190,10 @@ bool PrimitiveFromConservative<OrderedListOfPrimitiveRecoverySchemes,
 using NewmanHamlinThenPalenzuelaEtAl = tmpl::list<
     grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin,
     grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::PalenzuelaEtAl>;
+using KastaunThenNewmanThenPalenzuela = tmpl::list<
+    grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl,
+    grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin,
+    grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::PalenzuelaEtAl>;
 
 GENERATE_INSTANTIATIONS(
     INSTANTIATION,
@@ -231,13 +235,12 @@ GENERATE_INSTANTIATIONS(
 
 GENERATE_INSTANTIATIONS(
     INSTANTIATION,
-    (tmpl::list<
-         grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl>,
+    (tmpl::list<grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl>,
      tmpl::list<
          grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin>,
      tmpl::list<
          grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::PalenzuelaEtAl>,
-     NewmanHamlinThenPalenzuelaEtAl),
+     NewmanHamlinThenPalenzuelaEtAl, KastaunThenNewmanThenPalenzuela),
     (true, false), (1, 2))
 
 #undef INSTANTIATION


### PR DESCRIPTION
## Proposed changes

Add explicit instantiations for using all 3 recovery schemes we currently have.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
