### PR TITLE
Subcell GRMHD: swap gr tags between DG and subcell grids

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/CMakeLists.txt
@@ -5,6 +5,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   InitialDataTci.cpp
+  SwapGrTags.cpp
   TciOnDgGrid.cpp
   TciOnFdGrid.cpp
   TciOptions.cpp
@@ -16,6 +17,7 @@ spectre_target_headers(
   HEADERS
   InitialDataTci.hpp
   Subcell.hpp
+  SwapGrTags.hpp
   TciOnDgGrid.hpp
   TciOnFdGrid.hpp
   TciOptions.hpp

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/SwapGrTags.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/SwapGrTags.cpp
@@ -1,0 +1,55 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/SwapGrTags.hpp"
+
+#include <algorithm>
+#include <cstddef>
+
+#include "DataStructures/Variables.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace grmhd::ValenciaDivClean::subcell {
+void SwapGrTags::apply(
+    const gsl::not_null<
+        Variables<typename System::spacetime_variables_tag::tags_list>*>
+        active_gr_vars,
+    const gsl::not_null<typename evolution::dg::subcell::Tags::Inactive<
+        typename System::spacetime_variables_tag>::type*>
+        inactive_gr_vars,
+    const Mesh<3>& dg_mesh, const Mesh<3>& subcell_mesh,
+    const evolution::dg::subcell::ActiveGrid active_grid) noexcept {
+  if (active_grid == evolution::dg::subcell::ActiveGrid::Dg) {
+    // We might request a switch to the DG grid even if we are already on the DG
+    // grid, and in this case we do nothing. This can occur when applying
+    // SwapGrTags to a collection of elements that may have different TCI
+    // results.
+    if (active_gr_vars->number_of_grid_points() !=
+        dg_mesh.number_of_grid_points()) {
+      ASSERT(
+          active_gr_vars->number_of_grid_points() ==
+              subcell_mesh.number_of_grid_points(),
+          "When swapping the GR variables from subcell to DG, the active "
+          "GR variables should be holding the subcell variables and be of size "
+              << subcell_mesh.number_of_grid_points()
+              << " but they are of size "
+              << active_gr_vars->number_of_grid_points());
+      using std::swap;
+      swap(*active_gr_vars, *inactive_gr_vars);
+    }
+  } else {
+    if (active_gr_vars->number_of_grid_points() !=
+        subcell_mesh.number_of_grid_points()) {
+      ASSERT(active_gr_vars->number_of_grid_points() ==
+                 dg_mesh.number_of_grid_points(),
+             "When swapping the GR variables from DG to subcell, the active "
+             "GR variables should be holding the DG variables and be of size "
+                 << dg_mesh.number_of_grid_points() << " but they are of size "
+                 << active_gr_vars->number_of_grid_points());
+      using std::swap;
+      swap(*active_gr_vars, *inactive_gr_vars);
+    }
+  }
+}
+}  // namespace grmhd::ValenciaDivClean::subcell

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/SwapGrTags.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/SwapGrTags.hpp
@@ -1,0 +1,60 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+template <size_t Dim>
+class Mesh;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+template <typename TagsList>
+class Variables;
+/// \endcond
+
+namespace grmhd::ValenciaDivClean::subcell {
+/*!
+ * \brief Swaps the inactive and active GR variables.
+ *
+ * The values on the subcells are at the cell-centers.
+ *
+ * It should be possible to reduce memory usage by deallocating the GR variables
+ * on the DG grid when switching to subcell. However, the opposite case is not
+ * true since the GR variables are needed on the subcells if a neighbor is using
+ * subcell in order to compute the neighbor's fluxes.
+ *
+ * \note The `active_grid` is the grid we are swapping to, which may be the same
+ * as the current grid. On output the `active_gr_vars` will match the grid that
+ * `active_grid` is. This mutator is a no-op if they matched on input.
+ */
+struct SwapGrTags {
+  using return_tags = tmpl::list<typename System::spacetime_variables_tag,
+                                 evolution::dg::subcell::Tags::Inactive<
+                                     typename System::spacetime_variables_tag>>;
+  using argument_tags =
+      tmpl::list<::domain::Tags::Mesh<3>, evolution::dg::subcell::Tags::Mesh<3>,
+                 evolution::dg::subcell::Tags::ActiveGrid>;
+
+  static void apply(
+      gsl::not_null<
+          Variables<typename System::spacetime_variables_tag::tags_list>*>
+          active_gr_vars,
+      gsl::not_null<typename evolution::dg::subcell::Tags::Inactive<
+          typename System::spacetime_variables_tag>::type*>
+          inactive_gr_vars,
+      const Mesh<3>& dg_mesh, const Mesh<3>& subcell_mesh,
+      evolution::dg::subcell::ActiveGrid active_grid) noexcept;
+};
+}  // namespace grmhd::ValenciaDivClean::subcell

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp
@@ -55,6 +55,11 @@ struct System {
       ::Tags::Variables<hydro::grmhd_tags<DataVector>>;
   using spacetime_variables_tag =
       ::Tags::Variables<gr::tags_for_hydro<volume_dim, DataVector>>;
+  using flux_spacetime_variables_tag = ::Tags::Variables<tmpl::list<
+      gr::Tags::Lapse<DataVector>,
+      gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+      gr::Tags::SpatialMetric<3>, gr::Tags::SqrtDetSpatialMetric<DataVector>,
+      gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>>>;
 
   using compute_volume_time_derivative_terms = TimeDerivativeTerms;
   using volume_fluxes = ComputeFluxes;

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   BoundaryConditions/Test_Periodic.cpp
   BoundaryCorrections/Test_Rusanov.cpp
   Subcell/Test_InitialDataTci.cpp
+  Subcell/Test_SwapGrTags.cpp
   Subcell/Test_TciOnDgGrid.cpp
   Subcell/Test_TciOnFdGrid.cpp
   Subcell/Test_TciOptions.cpp

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_SwapGrTags.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_SwapGrTags.cpp
@@ -1,0 +1,77 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <memory>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Tags/Inactive.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/SwapGrTags.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.ValenciaDivClean.Subcell.SwapGrTags",
+                  "[Unit][Evolution]") {
+  const Mesh<3> dg_mesh{5, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+  const Mesh<3> subcell_mesh = evolution::dg::subcell::fd::mesh(dg_mesh);
+
+  const grmhd::ValenciaDivClean::System::spacetime_variables_tag::type
+      active_gr_vars(dg_mesh.number_of_grid_points());
+  const evolution::dg::subcell::Tags::Inactive<
+      typename grmhd::ValenciaDivClean::System::spacetime_variables_tag>::type
+      inactive_gr_vars(subcell_mesh.number_of_grid_points());
+
+  auto box = db::create<db::AddSimpleTags<
+      grmhd::ValenciaDivClean::System::spacetime_variables_tag,
+      evolution::dg::subcell::Tags::Inactive<
+          grmhd::ValenciaDivClean::System::spacetime_variables_tag>,
+      domain::Tags::Mesh<3>, evolution::dg::subcell::Tags::Mesh<3>,
+      evolution::dg::subcell::Tags::ActiveGrid>>(
+      active_gr_vars, inactive_gr_vars, dg_mesh, subcell_mesh,
+      evolution::dg::subcell::ActiveGrid::Dg);
+
+  for (const auto active_grid : {evolution::dg::subcell::ActiveGrid::Dg,
+                                 evolution::dg::subcell::ActiveGrid::Subcell,
+                                 evolution::dg::subcell::ActiveGrid::Dg}) {
+    db::mutate<evolution::dg::subcell::Tags::ActiveGrid>(
+        make_not_null(&box), [&active_grid](const auto active_grid_ptr) {
+          *active_grid_ptr = active_grid;
+        });
+
+    db::mutate_apply<grmhd::ValenciaDivClean::subcell::SwapGrTags>(
+        make_not_null(&box));
+
+    if (active_grid == evolution::dg::subcell::ActiveGrid::Dg) {
+      CHECK(
+          db::get<grmhd::ValenciaDivClean::System::spacetime_variables_tag>(box)
+              .number_of_grid_points() == dg_mesh.number_of_grid_points());
+      CHECK(db::get<evolution::dg::subcell::Tags::Inactive<
+                grmhd::ValenciaDivClean::System::spacetime_variables_tag>>(box)
+                .number_of_grid_points() ==
+            subcell_mesh.number_of_grid_points());
+    } else {
+      CHECK(
+          db::get<grmhd::ValenciaDivClean::System::spacetime_variables_tag>(box)
+              .number_of_grid_points() == subcell_mesh.number_of_grid_points());
+      CHECK(db::get<evolution::dg::subcell::Tags::Inactive<
+                grmhd::ValenciaDivClean::System::spacetime_variables_tag>>(box)
+                .number_of_grid_points() == dg_mesh.number_of_grid_points());
+    }
+  }
+}


### PR DESCRIPTION
## Proposed changes

I'm currently storing the background spacetime on both the DG and subcell grids (it turns out computing even the TOV solution [forget something like Kerr] is disappointingly expensive). This mutator swaps the active GR variables between subcell and DG

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
