### PR TITLE
Convert TimeSequence to use factory map

### DIFF
--- a/src/Evolution/EventsAndDenseTriggers/DenseTriggers/Times.hpp
+++ b/src/Evolution/EventsAndDenseTriggers/DenseTriggers/Times.hpp
@@ -60,6 +60,7 @@ struct Options::create_from_yaml<DenseTriggers::Times> {
   template <typename Metavariables>
   static DenseTriggers::Times create(const Option& options) {
     return DenseTriggers::Times(
-        options.parse_as<std::unique_ptr<TimeSequence<double>>>());
+        options
+            .parse_as<std::unique_ptr<TimeSequence<double>>, Metavariables>());
   }
 };

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -142,6 +142,10 @@ struct EvolutionMetavars {
                    StepChoosers::standard_slab_choosers<system,
                                                         local_time_stepping>>,
         tmpl::pair<StepController, StepControllers::standard_step_controllers>,
+        tmpl::pair<TimeSequence<double>,
+                   TimeSequences::all_time_sequences<double>>,
+        tmpl::pair<TimeSequence<std::uint64_t>,
+                   TimeSequences::all_time_sequences<std::uint64_t>>,
         tmpl::pair<Trigger, tmpl::append<Triggers::logical_triggers,
                                          Triggers::time_triggers>>>;
   };
@@ -299,8 +303,6 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &domain::FunctionsOfTime::register_derived_with_charm,
     &Burgers::BoundaryConditions::register_derived_with_charm,
     &Burgers::BoundaryCorrections::register_derived_with_charm,
-    &Parallel::register_derived_classes_with_charm<TimeSequence<double>>,
-    &Parallel::register_derived_classes_with_charm<TimeSequence<std::uint64_t>>,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<
         PhaseChange<metavariables::phase_changes>>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGeneralizedHarmonic.hpp
@@ -59,8 +59,6 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &GeneralizedHarmonic::BoundaryCorrections::register_derived_with_charm,
     &domain::creators::register_derived_with_charm,
     &GeneralizedHarmonic::ConstraintDamping::register_derived_with_charm,
-    &Parallel::register_derived_classes_with_charm<TimeSequence<double>>,
-    &Parallel::register_derived_classes_with_charm<TimeSequence<std::uint64_t>>,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<
         PhaseChange<metavariables::phase_changes>>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -118,6 +118,7 @@
 #include "Time/StepControllers/Factory.hpp"
 #include "Time/StepControllers/StepController.hpp"
 #include "Time/Tags.hpp"
+#include "Time/TimeSequence.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Time/Triggers/TimeTriggers.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
@@ -234,6 +235,10 @@ struct GeneralizedHarmonicTemplateBase<
             StepChooser<StepChooserUse::Slab>,
             StepChoosers::standard_slab_choosers<system, local_time_stepping>>,
         tmpl::pair<StepController, StepControllers::standard_step_controllers>,
+        tmpl::pair<TimeSequence<double>,
+                   TimeSequences::all_time_sequences<double>>,
+        tmpl::pair<TimeSequence<std::uint64_t>,
+                   TimeSequences::all_time_sequences<std::uint64_t>>,
         tmpl::pair<Trigger, tmpl::append<Triggers::logical_triggers,
                                          Triggers::time_triggers>>>;
   };

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -207,6 +207,10 @@ struct EvolutionMetavars {
                    StepChoosers::standard_slab_choosers<system,
                                                         local_time_stepping>>,
         tmpl::pair<StepController, StepControllers::standard_step_controllers>,
+        tmpl::pair<TimeSequence<double>,
+                   TimeSequences::all_time_sequences<double>>,
+        tmpl::pair<TimeSequence<std::uint64_t>,
+                   TimeSequences::all_time_sequences<std::uint64_t>>,
         tmpl::pair<Trigger, tmpl::append<Triggers::logical_triggers,
                                          Triggers::time_triggers>>>;
   };
@@ -407,8 +411,6 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &domain::FunctionsOfTime::register_derived_with_charm,
     &grmhd::ValenciaDivClean::BoundaryConditions::register_derived_with_charm,
     &grmhd::ValenciaDivClean::BoundaryCorrections::register_derived_with_charm,
-    &Parallel::register_derived_classes_with_charm<TimeSequence<double>>,
-    &Parallel::register_derived_classes_with_charm<TimeSequence<std::uint64_t>>,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<
         PhaseChange<metavariables::phase_changes>>,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -171,6 +171,10 @@ struct EvolutionMetavars {
                    StepChoosers::standard_slab_choosers<system,
                                                         local_time_stepping>>,
         tmpl::pair<StepController, StepControllers::standard_step_controllers>,
+        tmpl::pair<TimeSequence<double>,
+                   TimeSequences::all_time_sequences<double>>,
+        tmpl::pair<TimeSequence<std::uint64_t>,
+                   TimeSequences::all_time_sequences<std::uint64_t>>,
         tmpl::pair<Trigger, tmpl::append<Triggers::logical_triggers,
                                          Triggers::time_triggers>>>;
   };
@@ -336,8 +340,6 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &domain::FunctionsOfTime::register_derived_with_charm,
     &NewtonianEuler::BoundaryConditions::register_derived_with_charm,
     &NewtonianEuler::BoundaryCorrections::register_derived_with_charm,
-    &Parallel::register_derived_classes_with_charm<TimeSequence<double>>,
-    &Parallel::register_derived_classes_with_charm<TimeSequence<std::uint64_t>>,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<
         PhaseChange<metavariables::phase_changes>>,

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -156,6 +156,10 @@ struct EvolutionMetavars {
                    StepChoosers::standard_slab_choosers<
                        system, local_time_stepping, false>>,
         tmpl::pair<StepController, StepControllers::standard_step_controllers>,
+        tmpl::pair<TimeSequence<double>,
+                   TimeSequences::all_time_sequences<double>>,
+        tmpl::pair<TimeSequence<std::uint64_t>,
+                   TimeSequences::all_time_sequences<std::uint64_t>>,
         tmpl::pair<Trigger, tmpl::append<Triggers::logical_triggers,
                                          Triggers::time_triggers>>>;
   };
@@ -324,8 +328,6 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &Parallel::register_derived_classes_with_charm<
         RadiationTransport::M1Grey::BoundaryCorrections::BoundaryCorrection<
             metavariables::neutrino_species>>,
-    &Parallel::register_derived_classes_with_charm<TimeSequence<double>>,
-    &Parallel::register_derived_classes_with_charm<TimeSequence<std::uint64_t>>,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<
         PhaseChange<metavariables::phase_changes>>,

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -164,6 +164,10 @@ struct EvolutionMetavars {
                    StepChoosers::standard_slab_choosers<
                        system, local_time_stepping, false>>,
         tmpl::pair<StepController, StepControllers::standard_step_controllers>,
+        tmpl::pair<TimeSequence<double>,
+                   TimeSequences::all_time_sequences<double>>,
+        tmpl::pair<TimeSequence<std::uint64_t>,
+                   TimeSequences::all_time_sequences<std::uint64_t>>,
         tmpl::pair<Trigger, tmpl::append<Triggers::logical_triggers,
                                          Triggers::time_triggers>>>;
   };
@@ -335,8 +339,6 @@ static const std::vector<void (*)()> charm_init_node_funcs{
         register_derived_with_charm,
     &RelativisticEuler::Valencia::BoundaryCorrections::
         register_derived_with_charm,
-    &Parallel::register_derived_classes_with_charm<TimeSequence<double>>,
-    &Parallel::register_derived_classes_with_charm<TimeSequence<std::uint64_t>>,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<
         PhaseChange<metavariables::phase_changes>>,

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -140,6 +140,10 @@ struct EvolutionMetavars {
                                    StepChoosers::ByBlock<StepChooserUse::Slab,
                                                          volume_dim>>>,
         tmpl::pair<StepController, StepControllers::standard_step_controllers>,
+        tmpl::pair<TimeSequence<double>,
+                   TimeSequences::all_time_sequences<double>>,
+        tmpl::pair<TimeSequence<std::uint64_t>,
+                   TimeSequences::all_time_sequences<std::uint64_t>>,
         tmpl::pair<Trigger, tmpl::append<Triggers::logical_triggers,
                                          Triggers::time_triggers>>>;
   };
@@ -303,8 +307,6 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &ScalarWave::BoundaryCorrections::register_derived_with_charm,
     &Parallel::register_derived_classes_with_charm<
         MathFunction<1, Frame::Inertial>>,
-    &Parallel::register_derived_classes_with_charm<TimeSequence<double>>,
-    &Parallel::register_derived_classes_with_charm<TimeSequence<std::uint64_t>>,
     &Parallel::register_derived_classes_with_charm<TimeStepper>,
     &Parallel::register_derived_classes_with_charm<
         PhaseChange<metavariables::phase_changes>>,

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -48,7 +48,8 @@
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
-#include "Time/Triggers/TimeTriggers.hpp"
+#include "Time/Triggers/SlabCompares.hpp"
+#include "Time/Triggers/TimeCompares.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
 #include "Utilities/Functional.hpp"
@@ -205,8 +206,8 @@ struct Metavariables {
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes = tmpl::map<
         tmpl::pair<Event, tmpl::list<Events::Completion>>,
-        tmpl::pair<Trigger, tmpl::append<Triggers::logical_triggers,
-                                         Triggers::time_triggers>>>;
+        tmpl::pair<Trigger, tmpl::list<Triggers::SlabCompares,
+                                       Triggers::TimeCompares>>>;
   };
 
   enum class Phase { Initialization, RegisterWithObserver, Export, Exit };

--- a/src/Options/CMakeLists.txt
+++ b/src/Options/CMakeLists.txt
@@ -19,6 +19,7 @@ spectre_target_headers(
   Auto.hpp
   Comparator.hpp
   Factory.hpp
+  FactoryHelpers.hpp
   Options.hpp
   OptionsDetails.hpp
   ParseOptions.hpp

--- a/src/Options/FactoryHelpers.hpp
+++ b/src/Options/FactoryHelpers.hpp
@@ -1,0 +1,52 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Utilities/TMPL.hpp"
+
+namespace Options {
+namespace detail {
+template <typename FactoryClasses, typename... NewClasses>
+struct add_factory_classes;
+
+template <typename FactoryClasses, typename BaseClass, typename NewClasses,
+          typename... RestNewClasses>
+struct add_factory_classes<FactoryClasses, tmpl::pair<BaseClass, NewClasses>,
+                           RestNewClasses...>
+    : add_factory_classes<
+          tmpl::insert<
+              tmpl::erase<FactoryClasses, BaseClass>,
+              tmpl::pair<
+                  BaseClass,
+                  tmpl::append<
+                      tmpl::conditional_t<
+                          tmpl::has_key<FactoryClasses, BaseClass>::value,
+                          tmpl::at<FactoryClasses, BaseClass>, tmpl::list<>>,
+                      NewClasses>>>,
+          RestNewClasses...> {};
+
+template <typename FactoryClasses>
+struct add_factory_classes<FactoryClasses> {
+  using type = FactoryClasses;
+};
+}  // namespace detail
+
+/// Add new factory-creatable classes to the list in a
+/// `factory_creation` struct.
+///
+/// For each `tmpl::pair<Base, DerivedList>` in the `NewClasses`
+/// parameter pack, append the classes in `DerivedList` to the list
+/// for `Base` in `FactoryClasses`.  The `FactoryClasses` map need not
+/// have a preexisting entry for `Base`.
+///
+/// This example adds three new derived classes, two for one base
+/// class and one for another.
+///
+/// \snippet Test_FactoryHelpers.cpp add_factory_classes
+///
+/// \see Options::protocols::FactoryCreation
+template <typename FactoryClasses, typename... NewClasses>
+using add_factory_classes =
+    typename detail::add_factory_classes<FactoryClasses, NewClasses...>::type;
+}  // namespace Options

--- a/src/Time/TimeSequence.hpp
+++ b/src/Time/TimeSequence.hpp
@@ -12,16 +12,6 @@
 #include "Parallel/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
 
-/// \ingroup TimeSteppersGroup
-///
-/// Holds all the TimeSequences
-namespace TimeSequences {
-template <typename T>
-class EvenlySpaced;
-template <typename T>
-class Specified;
-}  // namespace TimeSequences
-
 /// Represents a sequence of times.
 ///
 /// The template parameter \p T can either be `double` for a sequence
@@ -43,9 +33,6 @@ class TimeSequence : public PUP::able {
 
   WRAPPED_PUPable_abstract(TimeSequence);  // NOLINT
 
-  using creatable_classes =
-      tmpl::list<TimeSequences::EvenlySpaced<T>, TimeSequences::Specified<T>>;
-
   /// Returns the time in the sequence nearest to \p time, the time
   /// before that, and the time after, in numerical order.  These
   /// values allow a consumer to find the times in the sequence
@@ -58,6 +45,9 @@ class TimeSequence : public PUP::able {
   virtual std::array<std::optional<T>, 3> times_near(T time) const noexcept = 0;
 };
 
+/// \ingroup TimeGroup
+///
+/// Holds all the TimeSequences
 namespace TimeSequences {
 /// A sequence of evenly spaced times.
 template <typename T>
@@ -138,4 +128,7 @@ class Specified : public TimeSequence<T> {
  private:
   std::vector<T> values_;
 };
+
+template <typename T>
+using all_time_sequences = tmpl::list<EvenlySpaced<T>, Specified<T>>;
 }  // namespace TimeSequences

--- a/src/Time/Triggers/Slabs.hpp
+++ b/src/Time/Triggers/Slabs.hpp
@@ -68,6 +68,7 @@ struct Options::create_from_yaml<Triggers::Slabs> {
   template <typename Metavariables>
   static Triggers::Slabs create(const Option& options) {
     return Triggers::Slabs(
-        options.parse_as<std::unique_ptr<TimeSequence<uint64_t>>>());
+        options.parse_as<std::unique_ptr<TimeSequence<uint64_t>>,
+                         Metavariables>());
   }
 };

--- a/src/Time/Triggers/Times.hpp
+++ b/src/Time/Triggers/Times.hpp
@@ -72,6 +72,7 @@ struct Options::create_from_yaml<Triggers::Times> {
   template <typename Metavariables>
   static Triggers::Times create(const Option& options) {
     return Triggers::Times(
-        options.parse_as<std::unique_ptr<TimeSequence<double>>>());
+        options
+            .parse_as<std::unique_ptr<TimeSequence<double>>, Metavariables>());
   }
 };

--- a/tests/Unit/Evolution/EventsAndDenseTriggers/DenseTriggers/Test_Filter.cpp
+++ b/tests/Unit/Evolution/EventsAndDenseTriggers/DenseTriggers/Test_Filter.cpp
@@ -20,6 +20,7 @@
 #include "Parallel/Tags/Metavariables.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
 #include "Time/Tags.hpp"
+#include "Time/TimeSequence.hpp"
 #include "Time/TimeStepId.hpp"
 #include "Time/Triggers/TimeCompares.hpp"
 #include "Utilities/TMPL.hpp"
@@ -67,6 +68,8 @@ struct Metavariables {
         tmpl::pair<DenseTrigger,
                    tmpl::list<DenseTriggers::Filter,
                               TestHelpers::DenseTriggers::TestTrigger>>,
+        tmpl::pair<TimeSequence<double>,
+                   TimeSequences::all_time_sequences<double>>,
         tmpl::pair<Trigger, tmpl::list<TestTrigger>>>;
   };
 };
@@ -110,6 +113,8 @@ struct ExampleMetavariables {
     using factory_classes =
         tmpl::map<tmpl::pair<DenseTrigger, tmpl::list<DenseTriggers::Filter,
                                                       DenseTriggers::Times>>,
+                  tmpl::pair<TimeSequence<double>,
+                             TimeSequences::all_time_sequences<double>>,
                   tmpl::pair<Trigger, tmpl::list<Triggers::TimeCompares>>>;
   };
 };

--- a/tests/Unit/Evolution/EventsAndDenseTriggers/DenseTriggers/Test_Times.cpp
+++ b/tests/Unit/Evolution/EventsAndDenseTriggers/DenseTriggers/Test_Times.cpp
@@ -17,6 +17,7 @@
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
+#include "Time/TimeSequence.hpp"
 #include "Time/TimeStepId.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
@@ -27,7 +28,9 @@ struct Metavariables {
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes =
-        tmpl::map<tmpl::pair<DenseTrigger, tmpl::list<DenseTriggers::Times>>>;
+        tmpl::map<tmpl::pair<DenseTrigger, tmpl::list<DenseTriggers::Times>>,
+                  tmpl::pair<TimeSequence<double>,
+                             TimeSequences::all_time_sequences<double>>>;
   };
 };
 
@@ -80,8 +83,7 @@ void check_both_directions(std::vector<double> trigger_times,
 
 SPECTRE_TEST_CASE("Unit.Evolution.EventsAndDenseTriggers.DenseTriggers.Times",
                   "[Unit][Evolution]") {
-  Parallel::register_classes_with_charm<DenseTriggers::Times>();
-  Parallel::register_derived_classes_with_charm<TimeSequence<double>>();
+  Parallel::register_factory_classes_with_charm<Metavariables>();
 
   const auto infinity = std::numeric_limits<double>::infinity();
 

--- a/tests/Unit/Options/CMakeLists.txt
+++ b/tests/Unit/Options/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_Comparator.cpp
   Test_CustomTypeConstruction.cpp
   Test_Factory.cpp
+  Test_FactoryHelpers.cpp
   Test_Options.cpp
   Test_StdComplex.cpp
   )

--- a/tests/Unit/Options/Test_FactoryHelpers.cpp
+++ b/tests/Unit/Options/Test_FactoryHelpers.cpp
@@ -1,0 +1,45 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <type_traits>
+
+#include "Options/FactoryHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+// Use a type for the label instead of an integer to catch any missing
+// tmpl::pins or such.
+template <typename Label>
+struct Base;
+template <typename Label>
+struct Derived;
+template <int>
+struct Label;
+
+using original_classes =
+    tmpl::map<tmpl::pair<Base<Label<0>>,
+                         tmpl::list<Derived<Label<0>>, Derived<Label<1>>>>,
+              tmpl::pair<Base<Label<1>>, tmpl::list<Derived<Label<2>>>>>;
+
+static_assert(std::is_same_v<original_classes,
+                             Options::add_factory_classes<original_classes>>);
+
+// [add_factory_classes]
+using new_classes = Options::add_factory_classes<
+    original_classes,
+    tmpl::pair<Base<Label<0>>,
+               tmpl::list<Derived<Label<3>>, Derived<Label<4>>>>,
+    tmpl::pair<Base<Label<2>>, tmpl::list<Derived<Label<5>>>>>;
+// [add_factory_classes]
+
+// tmpl::map doesn't guarantee an order for the keys, so we have to
+// check each entry separately.
+static_assert(tmpl::size<new_classes>::value == 3);
+static_assert(std::is_same_v<tmpl::at<new_classes, Base<Label<0>>>,
+                             tmpl::list<Derived<Label<0>>, Derived<Label<1>>,
+                                        Derived<Label<3>>, Derived<Label<4>>>>);
+static_assert(std::is_same_v<tmpl::at<new_classes, Base<Label<1>>>,
+                             tmpl::list<Derived<Label<2>>>>);
+static_assert(std::is_same_v<tmpl::at<new_classes, Base<Label<2>>>,
+                             tmpl::list<Derived<Label<5>>>>);
+}  // namespace

--- a/tests/Unit/Parallel/PhaseControl/Test_PhaseControlTags.cpp
+++ b/tests/Unit/Parallel/PhaseControl/Test_PhaseControlTags.cpp
@@ -4,6 +4,7 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <cstddef>
+#include <cstdint>
 #include <string>
 #include <type_traits>
 
@@ -16,6 +17,7 @@
 #include "Parallel/PhaseControl/PhaseChange.hpp"
 #include "Parallel/PhaseControl/PhaseControlTags.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "Time/TimeSequence.hpp"
 #include "Time/Triggers/Slabs.hpp"
 #include "Utilities/Functional.hpp"
 #include "Utilities/MakeString.hpp"
@@ -96,7 +98,9 @@ struct Metavariables {
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes =
-        tmpl::map<tmpl::pair<Trigger, tmpl::list<Triggers::Slabs>>>;
+        tmpl::map<tmpl::pair<TimeSequence<std::uint64_t>,
+                             TimeSequences::all_time_sequences<std::uint64_t>>,
+                  tmpl::pair<Trigger, tmpl::list<Triggers::Slabs>>>;
   };
 };
 
@@ -105,8 +109,7 @@ SPECTRE_TEST_CASE("Unit.Parallel.PhaseControl.PhaseControlTags",
   using phase_changes = tmpl::list<Registrars::TestCreatable<1_st>,
                                    Registrars::TestCreatable<2_st>>;
   Parallel::register_derived_classes_with_charm<PhaseChange<phase_changes>>();
-  Parallel::register_derived_classes_with_charm<TimeSequence<std::uint64_t>>();
-  Parallel::register_classes_with_charm<Triggers::Slabs>();
+  Parallel::register_factory_classes_with_charm<Metavariables>();
 
   TestHelpers::db::test_simple_tag<
       PhaseControl::Tags::PhaseChangeAndTriggers<phase_changes>>(

--- a/tests/Unit/Time/StepChoosers/Test_StepToTimes.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_StepToTimes.cpp
@@ -34,14 +34,15 @@ struct Metavariables {
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes =
         tmpl::map<tmpl::pair<StepChooser<StepChooserUse::Slab>,
-                             tmpl::list<StepChoosers::StepToTimes>>>;
+                             tmpl::list<StepChoosers::StepToTimes>>,
+                  tmpl::pair<TimeSequence<double>,
+                             TimeSequences::all_time_sequences<double>>>;
   };
   using component_list = tmpl::list<>;
 };
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Time.StepChoosers.StepToTimes", "[Unit][Time]") {
-  Parallel::register_derived_classes_with_charm<TimeSequence<double>>();
   Parallel::register_factory_classes_with_charm<Metavariables>();
 
   const auto requested = [](const double now, std::vector<double> times,

--- a/tests/Unit/Time/Test_TimeSequence.cpp
+++ b/tests/Unit/Time/Test_TimeSequence.cpp
@@ -19,8 +19,9 @@ namespace {
 void test_evenly_spaced() noexcept {
   {
     const TimeSequences::EvenlySpaced<std::uint64_t> constructed(3, 5);
-    const auto factory = TestHelpers::test_creation<
-        std::unique_ptr<TimeSequence<std::uint64_t>>>(
+    const auto factory = TestHelpers::test_factory_creation<
+        TimeSequence<std::uint64_t>,
+        TimeSequences::EvenlySpaced<std::uint64_t>>(
         "EvenlySpaced:\n"
         "  Interval: 3\n"
         "  Offset: 5\n");
@@ -49,7 +50,8 @@ void test_evenly_spaced() noexcept {
   {
     const TimeSequences::EvenlySpaced<double> constructed(3.75, 4.0625);
     const auto factory =
-        TestHelpers::test_creation<std::unique_ptr<TimeSequence<double>>>(
+        TestHelpers::test_factory_creation<TimeSequence<double>,
+                                           TimeSequences::EvenlySpaced<double>>(
             "EvenlySpaced:\n"
             "  Interval: 3.75\n"
             "  Offset: 4.0625\n");
@@ -73,8 +75,8 @@ void test_specified() noexcept {
     using Result = std::array<std::optional<std::uint64_t>, 3>;
     const TimeSequences::Specified<std::uint64_t> constructed(
         {4, 8, 0, 4, 4, 3, 4});
-    const auto factory = TestHelpers::test_creation<
-        std::unique_ptr<TimeSequence<std::uint64_t>>>(
+    const auto factory = TestHelpers::test_factory_creation<
+        TimeSequence<std::uint64_t>, TimeSequences::Specified<std::uint64_t>>(
         "Specified:\n"
         "  Values: [4, 8, 0, 4, 4, 3, 4]\n");
     const auto check = [&constructed, &factory](
@@ -113,7 +115,8 @@ void test_specified() noexcept {
     const TimeSequences::Specified<double> constructed(
         {-5.1, 7.2, -2.3, 0.0, -5.1, -5.1, 3.4, 4.5});
     const auto factory =
-        TestHelpers::test_creation<std::unique_ptr<TimeSequence<double>>>(
+        TestHelpers::test_factory_creation<TimeSequence<double>,
+                                           TimeSequences::Specified<double>>(
             "Specified:\n"
             "  Values: [-5.1, 7.2, -2.3, 0.0, -5.1, -5.1, 3.4, 4.5]\n");
     const auto check = [&constructed, &factory](
@@ -137,8 +140,10 @@ void test_specified() noexcept {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Time.TimeSequence", "[Unit][Time]") {
-  Parallel::register_derived_classes_with_charm<TimeSequence<std::uint64_t>>();
-  Parallel::register_derived_classes_with_charm<TimeSequence<double>>();
+  Parallel::register_classes_with_charm(
+      TimeSequences::all_time_sequences<double>{});
+  Parallel::register_classes_with_charm(
+      TimeSequences::all_time_sequences<std::uint64_t>{});
 
   test_evenly_spaced();
   test_specified();

--- a/tests/Unit/Time/Triggers/Test_NearTimes.cpp
+++ b/tests/Unit/Time/Triggers/Test_NearTimes.cpp
@@ -30,14 +30,15 @@ struct Metavariables {
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes =
-        tmpl::map<tmpl::pair<Trigger, tmpl::list<Triggers::NearTimes>>>;
+        tmpl::map<tmpl::pair<TimeSequence<double>,
+                             TimeSequences::all_time_sequences<double>>,
+                  tmpl::pair<Trigger, tmpl::list<Triggers::NearTimes>>>;
   };
 };
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Time.Triggers.NearTimes", "[Unit][Time]") {
   Parallel::register_factory_classes_with_charm<Metavariables>();
-  Parallel::register_derived_classes_with_charm<TimeSequence<double>>();
 
   using Direction = Triggers::NearTimes::Direction;
   using Unit = Triggers::NearTimes::Unit;

--- a/tests/Unit/Time/Triggers/Test_Slabs.cpp
+++ b/tests/Unit/Time/Triggers/Test_Slabs.cpp
@@ -18,6 +18,7 @@
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
+#include "Time/TimeSequence.hpp"
 #include "Time/TimeStepId.hpp"
 #include "Time/Triggers/Slabs.hpp"
 #include "Utilities/Gsl.hpp"
@@ -30,14 +31,15 @@ struct Metavariables {
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes =
-        tmpl::map<tmpl::pair<Trigger, tmpl::list<Triggers::Slabs>>>;
+        tmpl::map<tmpl::pair<TimeSequence<std::uint64_t>,
+                             TimeSequences::all_time_sequences<std::uint64_t>>,
+                  tmpl::pair<Trigger, tmpl::list<Triggers::Slabs>>>;
   };
 };
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Time.Triggers.Slabs", "[Unit][Time]") {
   Parallel::register_factory_classes_with_charm<Metavariables>();
-  Parallel::register_derived_classes_with_charm<TimeSequence<std::uint64_t>>();
 
   const auto trigger =
       TestHelpers::test_creation<std::unique_ptr<Trigger>, Metavariables>(

--- a/tests/Unit/Time/Triggers/Test_Times.cpp
+++ b/tests/Unit/Time/Triggers/Test_Times.cpp
@@ -33,14 +33,15 @@ struct Metavariables {
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes =
-        tmpl::map<tmpl::pair<Trigger, tmpl::list<Triggers::Times>>>;
+        tmpl::map<tmpl::pair<TimeSequence<double>,
+                             TimeSequences::all_time_sequences<double>>,
+                  tmpl::pair<Trigger, tmpl::list<Triggers::Times>>>;
   };
 };
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Time.Triggers.Times", "[Unit][Time]") {
   Parallel::register_factory_classes_with_charm<Metavariables>();
-  Parallel::register_derived_classes_with_charm<TimeSequence<double>>();
 
   const auto check = [](const double time, const double slab_size,
                         const std::vector<double>& trigger_times,


### PR DESCRIPTION
Also fixes the doxygen group of the TimeSequences namespace.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
