### PR TITLE
Eliminate rare asynchronization bug in interpolator.

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/Actions/InterpolationTargetVarsFromElement.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Actions/InterpolationTargetVarsFromElement.hpp
@@ -77,6 +77,44 @@ struct InterpolationTargetVarsFromElement {
         not InterpolationTargetTag::compute_target_points::is_sequential::value,
         "Use InterpolationTargetGetVarsFromElement only with non-sequential"
         " compute_target_points");
+    // Check if we already have completed interpolation at this
+    // temporal_id.
+    const auto& completed_ids =
+        db::get<Tags::CompletedTemporalIds<TemporalId>>(box);
+    // (Search from the end because temporal_id is more likely to be
+    // at the end of the list then at the beginning.)
+    if (UNLIKELY(std::find(completed_ids.rbegin(), completed_ids.rend(),
+                           temporal_id) != completed_ids.rend())) {
+      // The code will get into this 'if' statement in the following
+      // scenario:
+      // - There is at least one interpolation point exactly on the
+      //   boundary of two or more Elements, so that
+      //   InterpolationTargetVarsFromElement is called more than once
+      //   with data for the same interpolation point (this is ok,
+      //   and add_received_variables handles this).
+      // - The only Elements that have not yet called
+      //   InterpolationTargetVarsFromElement for this temporal_id are
+      //   those that have data only for duplicated interpolation
+      //   points, and the InterpolationTarget has already received
+      //   that data from other Elements.
+      // In this case, the InterpolationTarget proceeds to do its
+      // work because it has all the data it needs. There is now
+      // one more condition needed for the scenario that gets
+      // us inside this 'if':
+      // - The InterpolationTarget has already completed its work at
+      //   this temporal_id, and it has cleaned up its data structures
+      //   for this temporal_id before all of the remaining calls to
+      //   InterpolationTargetVarsFromElement have occurred at this
+      //   temporal_id, and now we are in one of those remaining
+      //   calls.
+      //
+      // If this scenario occurs, we just return. This is because the
+      // InterpolationTarget is done and there is nothing left to do
+      // at this temporal_id.  Note that if there were extra work to
+      // do at this temporal_id, then CompletedTemporalIds would not
+      // have an entry for this temporal_id.
+      return;
+    }
 
     // Call set_up_interpolation only if it has not been called for this
     // temporal_id.


### PR DESCRIPTION
## Proposed changes

See comments in code.  This fixes a rare bug uncovered by @moxcodes , where
an InterpolationTarget can be finished with its work and can have already cleaned up,
but yet there are still elements sending data to that InterpolationTarget (where the data is
for points that are duplicated because they are on exactly the boundary between two or more elements).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
