### PR TITLE
Add ComputeHorizonVolumeQuantities.

### DIFF
--- a/src/ApparentHorizons/CMakeLists.txt
+++ b/src/ApparentHorizons/CMakeLists.txt
@@ -23,6 +23,8 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ChangeCenterOfStrahlkorper.hpp
+  ComputeHorizonVolumeQuantities.hpp
+  ComputeHorizonVolumeQuantities.tpp
   ComputeItems.hpp
   FastFlow.hpp
   SpherepackIterator.hpp

--- a/src/ApparentHorizons/ComputeHorizonVolumeQuantities.hpp
+++ b/src/ApparentHorizons/ComputeHorizonVolumeQuantities.hpp
@@ -1,0 +1,69 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+
+/// \cond
+class DataVector;
+template <size_t Dim>
+class Mesh;
+template <typename VariablesTags>
+class Variables;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace ah {
+
+/// Given the generalized harmonic variables in the volume, computes
+/// the quantities that will be interpolated onto an apparent horizon.
+///
+/// This is meant to be the primary `compute_vars_to_interpolate`
+/// for the horizon finder.
+///
+/// SrcTagList and DestTagList have limited flexibility, and their
+/// restrictions are static_asserted inside the apply functions.  The
+/// lack of complete flexibility is intentional, because most
+/// computations (e.g. for observers) should be done only on the
+/// horizon surface (i.e. after interpolation) as opposed to in the
+/// volume; only those computations that require data in the volume
+/// (e.g. volume numerical derivatives) should be done here.
+///
+/// For the dual-frame case, takes the Jacobians and does numerical
+/// derivatives in order to avoid Hessians.
+struct ComputeHorizonVolumeQuantities {
+  /// Single-frame case
+  template <typename SrcTagList, typename DestTagList>
+  static void apply(const gsl::not_null<Variables<DestTagList>*> target_vars,
+                    const Variables<SrcTagList>& src_vars,
+                    const Mesh<3>& mesh) noexcept;
+  /// Dual-frame case
+  template <typename SrcTagList, typename DestTagList, typename TargetFrame>
+  static void apply(
+      const gsl::not_null<Variables<DestTagList>*> target_vars,
+      const Variables<SrcTagList>& src_vars, const Mesh<3>& mesh,
+      const Jacobian<DataVector, 3, TargetFrame, Frame::Inertial>& jacobian,
+      const InverseJacobian<DataVector, 3, Frame::Logical, TargetFrame>&
+          inverse_jacobian) noexcept;
+
+  using allowed_src_tags =
+      tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                 Tags::deriv<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                             tmpl::size_t<3>, Frame::Inertial>>;
+  using required_src_tags =
+      tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>;
+};
+
+}  // namespace ah

--- a/src/ApparentHorizons/ComputeHorizonVolumeQuantities.tpp
+++ b/src/ApparentHorizons/ComputeHorizonVolumeQuantities.tpp
@@ -1,0 +1,330 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ApparentHorizons/ComputeHorizonVolumeQuantities.hpp"
+
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/TempBuffer.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ExtrinsicCurvature.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Ricci.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Lapse.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Shift.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Transform.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace detail {
+
+template <typename Tag, typename DestTags, typename TempTags>
+typename Tag::type& get_from_target_or_temp(
+    const gsl::not_null<Variables<DestTags>*> target_vars,
+    const gsl::not_null<TempBuffer<TempTags>*> temp_vars) {
+  if constexpr (tmpl::list_contains<DestTags, Tag>::value) {
+    (void) temp_vars; // silence gcc 'unused variable' warning
+    return get<Tag>(*target_vars);
+  } else {
+    (void) target_vars; // silence gcc 'unused variable' warning
+    return get<Tag>(*temp_vars);
+  }
+}
+}  // namespace detail
+
+namespace ah {
+
+/// Single frame case
+template <typename SrcTagList, typename DestTagList>
+void ComputeHorizonVolumeQuantities::apply(
+    const gsl::not_null<Variables<DestTagList>*> target_vars,
+    const Variables<SrcTagList>& src_vars, const Mesh<3>& /*mesh*/) noexcept {
+  static_assert(
+      std::is_same_v<tmpl::list_difference<SrcTagList, allowed_src_tags>,
+                     tmpl::list<>>,
+      "Found a src tag that is not allowed");
+  static_assert(
+      std::is_same_v<tmpl::list_difference<required_src_tags, SrcTagList>,
+                     tmpl::list<>>,
+      "A required src tag is missing");
+
+  using allowed_dest_tags =
+      tmpl::list<gr::Tags::SpatialMetric<3, Frame::Inertial>,
+                 gr::Tags::InverseSpatialMetric<3, Frame::Inertial>,
+                 gr::Tags::ExtrinsicCurvature<3, Frame::Inertial>,
+                 gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial>,
+                 gr::Tags::SpatialRicci<3, Frame::Inertial>>;
+  static_assert(
+      std::is_same_v<tmpl::list_difference<DestTagList, allowed_dest_tags>,
+                     tmpl::list<>>,
+      "Found a dest tag that is not allowed");
+  using required_dest_tags =
+      tmpl::list<gr::Tags::ExtrinsicCurvature<3, Frame::Inertial>,
+                 gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial>>;
+  static_assert(
+      std::is_same_v<tmpl::list_difference<required_dest_tags, DestTagList>,
+                     tmpl::list<>>,
+      "A required dest tag is missing");
+
+  const auto& psi =
+      get<gr::Tags::SpacetimeMetric<3, Frame::Inertial>>(src_vars);
+  const auto& pi =
+      get<GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>>(src_vars);
+  const auto& phi =
+      get<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>(src_vars);
+
+  if (target_vars->number_of_grid_points() !=
+      src_vars.number_of_grid_points()) {
+    target_vars->initialize(src_vars.number_of_grid_points());
+  }
+
+  using metric_tag = gr::Tags::SpatialMetric<3, Frame::Inertial>;
+  using inv_metric_tag = gr::Tags::InverseSpatialMetric<3, Frame::Inertial>;
+  using lapse_tag = ::Tags::TempScalar<0, DataVector>;
+  using shift_tag = ::Tags::TempI<1, 3, Frame::Inertial, DataVector>;
+  using spacetime_normal_vector_tag =
+      ::Tags::TempA<2, 3, Frame::Inertial, DataVector>;
+
+  // All of the temporary tags, including some that may be repeated
+  // in the target_variables (for now).
+  using full_temp_tags_list =
+      tmpl::list<metric_tag, inv_metric_tag, lapse_tag, shift_tag,
+                 spacetime_normal_vector_tag>;
+
+  // temp tags without variables that are already in DestTagList.
+  using temp_tags_list =
+      tmpl::list_difference<full_temp_tags_list, tmpl::list<DestTagList>>;
+  TempBuffer<temp_tags_list> buffer(get<0, 0>(psi).size());
+
+  auto& extrinsic_curvature =
+      get<gr::Tags::ExtrinsicCurvature<3, Frame::Inertial>>(*target_vars);
+  auto& spatial_christoffel_second_kind =
+      get<gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial>>(
+          *target_vars);
+
+  // These are always temporaries.
+  auto& lapse = get<lapse_tag>(buffer);
+  auto& shift = get<shift_tag>(buffer);
+  auto& spacetime_normal_vector = get<spacetime_normal_vector_tag>(buffer);
+
+  // These may or may not be temporaries
+  auto& metric = detail::get_from_target_or_temp<metric_tag>(
+      target_vars, make_not_null(&buffer));
+  auto& inv_metric = detail::get_from_target_or_temp<inv_metric_tag>(
+      target_vars, make_not_null(&buffer));
+
+  // Actual computation starts here
+
+  gr::spatial_metric(make_not_null(&metric), psi);
+  // put determinant of 3-metric temporarily into lapse to save memory.
+  determinant_and_inverse(make_not_null(&lapse), make_not_null(&inv_metric),
+                          metric);
+  gr::shift(make_not_null(&shift), psi, inv_metric);
+  gr::lapse(make_not_null(&lapse), shift, psi);
+  gr::spacetime_normal_vector(make_not_null(&spacetime_normal_vector), lapse,
+                              shift);
+  GeneralizedHarmonic::extrinsic_curvature(make_not_null(&extrinsic_curvature),
+                                           spacetime_normal_vector, pi, phi);
+  GeneralizedHarmonic::christoffel_second_kind(
+      make_not_null(&spatial_christoffel_second_kind), phi, inv_metric);
+
+  if constexpr (tmpl::list_contains_v<
+                    DestTagList, gr::Tags::SpatialRicci<3, Frame::Inertial>>) {
+    static_assert(
+        tmpl::list_contains_v<
+            SrcTagList,
+            Tags::deriv<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                        tmpl::size_t<3>, Frame::Inertial>>,
+        "If Ricci is requested, SrcTags must include deriv of Phi");
+    auto& spatial_ricci =
+        get<gr::Tags::SpatialRicci<3, Frame::Inertial>>(*target_vars);
+    GeneralizedHarmonic::spatial_ricci_tensor(
+        make_not_null(&spatial_ricci), phi,
+        get<Tags::deriv<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                        tmpl::size_t<3>, Frame::Inertial>>(src_vars),
+        inv_metric);
+  }
+}
+
+/// Dual frame case
+template <typename SrcTagList, typename DestTagList, typename TargetFrame>
+void ComputeHorizonVolumeQuantities::apply(
+    const gsl::not_null<Variables<DestTagList>*> target_vars,
+    const Variables<SrcTagList>& src_vars, const Mesh<3>& mesh,
+    const Jacobian<DataVector, 3, TargetFrame, Frame::Inertial>& jacobian,
+    const InverseJacobian<DataVector, 3, Frame::Logical, TargetFrame>&
+        inverse_jacobian) noexcept {
+  static_assert(
+      std::is_same_v<tmpl::list_difference<SrcTagList, allowed_src_tags>,
+                     tmpl::list<>>,
+      "Found a src tag that is not allowed");
+  static_assert(
+      std::is_same_v<tmpl::list_difference<required_src_tags, SrcTagList>,
+                     tmpl::list<>>,
+      "A required src tag is missing");
+
+  using allowed_dest_tags =
+      tmpl::list<gr::Tags::SpatialMetric<3, TargetFrame>,
+                 gr::Tags::InverseSpatialMetric<3, TargetFrame>,
+                 gr::Tags::ExtrinsicCurvature<3, TargetFrame>,
+                 gr::Tags::SpatialChristoffelSecondKind<3, TargetFrame>,
+                 gr::Tags::SpatialRicci<3, TargetFrame>>;
+  static_assert(
+      std::is_same_v<tmpl::list_difference<DestTagList, allowed_dest_tags>,
+                     tmpl::list<>>,
+      "Found a dest tag that is not allowed");
+  using required_dest_tags =
+      tmpl::list<gr::Tags::ExtrinsicCurvature<3, TargetFrame>,
+                 gr::Tags::SpatialChristoffelSecondKind<3, TargetFrame>>;
+  static_assert(
+      std::is_same_v<tmpl::list_difference<required_dest_tags, DestTagList>,
+                     tmpl::list<>>,
+      "A required dest tag is missing");
+
+  const auto& psi =
+      get<gr::Tags::SpacetimeMetric<3, Frame::Inertial>>(src_vars);
+  const auto& pi =
+      get<GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>>(src_vars);
+  const auto& phi =
+      get<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>(src_vars);
+
+  if (target_vars->number_of_grid_points() !=
+      src_vars.number_of_grid_points()) {
+    target_vars->initialize(src_vars.number_of_grid_points());
+  }
+
+  using metric_tag = gr::Tags::SpatialMetric<3, TargetFrame>;
+  using inv_metric_tag = gr::Tags::InverseSpatialMetric<3, TargetFrame>;
+  using lapse_tag = ::Tags::TempScalar<0, DataVector>;
+  using shift_tag = ::Tags::TempI<1, 3, Frame::Inertial, DataVector>;
+  using spacetime_normal_vector_tag =
+      ::Tags::TempA<2, 3, Frame::Inertial, DataVector>;
+
+  // Additional temporary tags used for multiple frames
+  using inertial_metric_tag = ::Tags::Tempii<3, 3, Frame::Inertial, DataVector>;
+  using inertial_inv_metric_tag =
+      ::Tags::TempII<4, 3, Frame::Inertial, DataVector>;
+  using inertial_ex_curvature_tag =
+      ::Tags::Tempii<5, 3, Frame::Inertial, DataVector>;
+  using logical_deriv_metric_tag = ::Tags::TempTensor<
+      6, Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1, 1>,
+                index_list<SpatialIndex<3, UpLo::Lo, Frame::Logical>,
+                           SpatialIndex<3, UpLo::Lo, TargetFrame>,
+                           SpatialIndex<3, UpLo::Lo, TargetFrame>>>>;
+  using deriv_metric_tag = ::Tags::Tempijj<7, 3, TargetFrame, DataVector>;
+  using inertial_spatial_ricci_tag =
+      ::Tags::Tempii<8, 3, Frame::Inertial, DataVector>;
+
+  // All of the temporary tags, including some that may be repeated
+  // in the target_variables (for now).
+  using temp_tags_list_no_ricci =
+      tmpl::list<metric_tag, inv_metric_tag, lapse_tag, shift_tag,
+                 spacetime_normal_vector_tag, inertial_metric_tag,
+                 inertial_inv_metric_tag, inertial_ex_curvature_tag,
+                 logical_deriv_metric_tag, deriv_metric_tag>;
+  using full_temp_tags_list = std::conditional_t<
+      tmpl::list_contains_v<DestTagList,
+                            gr::Tags::SpatialRicci<3, TargetFrame>>,
+      tmpl::push_back<temp_tags_list_no_ricci, inertial_spatial_ricci_tag>,
+      temp_tags_list_no_ricci>;
+
+  auto& extrinsic_curvature =
+      get<gr::Tags::ExtrinsicCurvature<3, TargetFrame>>(*target_vars);
+  auto& spatial_christoffel_second_kind =
+      get<gr::Tags::SpatialChristoffelSecondKind<3, TargetFrame>>(*target_vars);
+
+  // temp tags without variables that are already in DestTagList.
+  using temp_tags_list =
+      tmpl::list_difference<full_temp_tags_list, tmpl::list<DestTagList>>;
+  TempBuffer<temp_tags_list> buffer(get<0, 0>(psi).size());
+
+  // These are always temporaries.
+  auto& lapse = get<lapse_tag>(buffer);
+  auto& shift = get<shift_tag>(buffer);
+  auto& spacetime_normal_vector = get<spacetime_normal_vector_tag>(buffer);
+  auto& inertial_metric = get<inertial_metric_tag>(buffer);
+  auto& inertial_inv_metric = get<inertial_inv_metric_tag>(buffer);
+  auto& inertial_ex_curvature = get<inertial_ex_curvature_tag>(buffer);
+  auto& logical_deriv_metric = get<logical_deriv_metric_tag>(buffer);
+  auto& deriv_metric = get<deriv_metric_tag>(buffer);
+
+  // These may or may not be temporaries
+  auto& metric = detail::get_from_target_or_temp<metric_tag>(
+      target_vars, make_not_null(&buffer));
+  auto& inv_metric = detail::get_from_target_or_temp<inv_metric_tag>(
+      target_vars, make_not_null(&buffer));
+
+  // Actual computation starts here
+
+  gr::spatial_metric(make_not_null(&inertial_metric), psi);
+  // put determinant of 3-metric temporarily into lapse to save memory.
+  determinant_and_inverse(make_not_null(&lapse),
+                          make_not_null(&inertial_inv_metric), inertial_metric);
+
+  // Compute inertial extrinsic curvature
+  gr::shift(make_not_null(&shift), psi, inertial_inv_metric);
+  gr::lapse(make_not_null(&lapse), shift, psi);
+  gr::spacetime_normal_vector(make_not_null(&spacetime_normal_vector), lapse,
+                              shift);
+  GeneralizedHarmonic::extrinsic_curvature(
+      make_not_null(&inertial_ex_curvature), spacetime_normal_vector, pi, phi);
+
+  // Transform spatial metric and extrinsic curvature
+  transform::to_different_frame(make_not_null(&metric), inertial_metric,
+                                jacobian);
+  transform::to_different_frame(make_not_null(&extrinsic_curvature),
+                                inertial_ex_curvature, jacobian);
+
+  // Invert transformed 3-metric.
+  // put determinant of 3-metric temporarily into lapse to save memory.
+  determinant_and_inverse(make_not_null(&lapse), make_not_null(&inv_metric),
+                          metric);
+
+  // Differentiate 3-metric.
+  logical_partial_derivative(make_not_null(&logical_deriv_metric), metric,
+                             mesh);
+  transform::first_index_to_different_frame(
+      make_not_null(&deriv_metric), logical_deriv_metric, inverse_jacobian);
+  gr::christoffel_second_kind(make_not_null(&spatial_christoffel_second_kind),
+                              deriv_metric, inv_metric);
+
+  if constexpr (tmpl::list_contains_v<DestTagList,
+                                      gr::Tags::SpatialRicci<3, TargetFrame>>) {
+    static_assert(
+        tmpl::list_contains_v<
+            SrcTagList,
+            Tags::deriv<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                        tmpl::size_t<3>, Frame::Inertial>>,
+        "If Ricci is requested, SrcTags must include deriv of Phi");
+
+    auto& inertial_spatial_ricci = get<inertial_spatial_ricci_tag>(buffer);
+    GeneralizedHarmonic::spatial_ricci_tensor(
+        make_not_null(&inertial_spatial_ricci), phi,
+        get<Tags::deriv<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                        tmpl::size_t<3>, Frame::Inertial>>(src_vars),
+        inertial_inv_metric);
+
+    auto& spatial_ricci =
+        get<gr::Tags::SpatialRicci<3, TargetFrame>>(*target_vars);
+    transform::to_different_frame(make_not_null(&spatial_ricci),
+                                  inertial_spatial_ricci, jacobian);
+  }
+}
+
+}  // namespace ah

--- a/tests/Unit/ApparentHorizons/CMakeLists.txt
+++ b/tests/Unit/ApparentHorizons/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_ApparentHorizons")
 set(LIBRARY_SOURCES
   Test_ApparentHorizonFinder.cpp
   Test_ChangeCenterOfStrahlkorper.cpp
+  Test_ComputeHorizonVolumeQuantities.cpp
   Test_ComputeItems.cpp
   Test_FastFlow.cpp
   Test_SpherepackIterator.cpp

--- a/tests/Unit/ApparentHorizons/Test_ComputeHorizonVolumeQuantities.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ComputeHorizonVolumeQuantities.cpp
@@ -1,0 +1,483 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+
+#include "ApparentHorizons/ComputeHorizonVolumeQuantities.hpp"
+#include "ApparentHorizons/ComputeHorizonVolumeQuantities.tpp"
+#include "Domain/Block.hpp"
+#include "Domain/Creators/Brick.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/InitialElementIds.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ExtrinsicCurvature.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Phi.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Pi.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+template <typename IsTimeDependent, typename TargetFrame, typename SrcTags,
+          typename DestTags>
+void test_compute_horizon_volume_quantities() {
+  const size_t number_of_grid_points = 8;
+
+  // slab and temporal_id used only in the TimeDependent version.
+  Slab slab(0.0, 1.0);
+  TimeStepId temporal_id{true, 0, Time(slab, Rational(13, 15))};
+
+  // Create a brick offset from the origin, so a KerrSchild solution
+  // doesn't have a singularity or horizon in the domain.
+  std::unique_ptr<DomainCreator<3>> domain_creator;
+  if constexpr (IsTimeDependent::value) {
+    const double expiration_time = 1.0;
+    domain_creator = std::make_unique<domain::creators::Brick>(
+        std::array<double, 3>{3.1, 3.2, 3.3},
+        std::array<double, 3>{4.1, 4.2, 4.3}, std::array<size_t, 3>{0, 0, 0},
+        std::array<size_t, 3>{number_of_grid_points, number_of_grid_points,
+                              number_of_grid_points},
+        std::array<bool, 3>{false, false, false},
+        std::make_unique<
+            domain::creators::time_dependence::UniformTranslation<3>>(
+            0.0, expiration_time, std::array<double, 3>{0.01, 0.02, 0.03}));
+  } else {
+    domain_creator = std::make_unique<domain::creators::Brick>(
+        std::array<double, 3>{3.1, 3.2, 3.3},
+        std::array<double, 3>{4.1, 4.2, 4.3}, std::array<size_t, 3>{0, 0, 0},
+        std::array<size_t, 3>{number_of_grid_points, number_of_grid_points,
+                              number_of_grid_points});
+  }
+  const auto domain = domain_creator->create_domain();
+  ASSERT(domain.blocks().size() == 1, "Expected a Domain with one block");
+
+  const auto element_ids = initial_element_ids(
+      domain.blocks()[0].id(),
+      domain_creator->initial_refinement_levels()[domain.blocks()[0].id()]);
+  ASSERT(element_ids.size() == 1, "Expected a Domain with only one element");
+
+  // Set up target coordinates, and jacobians.
+  // We always compute our source quantities in the inertial frame.
+  // But we want our destination quantities in the target frame.
+  const Mesh mesh{domain_creator->initial_extents()[element_ids[0].block_id()],
+                  Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto};
+  tnsr::I<DataVector, 3, TargetFrame> target_frame_coords{};
+  InverseJacobian<DataVector, 3, Frame::Logical, Frame::Inertial>
+      inv_jacobian_logical_to_inertial{};
+  Jacobian<DataVector, 3, TargetFrame, Frame::Inertial>
+      jacobian_target_to_inertial{};
+  InverseJacobian<DataVector, 3, Frame::Logical, TargetFrame>
+      inv_jacobian_logical_to_target{};
+  if constexpr (IsTimeDependent::value) {
+    ElementMap<3, Frame::Grid> map_logical_to_grid{
+        element_ids[0],
+        domain.blocks()[0].moving_mesh_logical_to_grid_map().get_clone()};
+    const auto inv_jacobian_logical_to_grid =
+        map_logical_to_grid.inv_jacobian(logical_coordinates(mesh));
+    const auto inv_jacobian_grid_to_inertial =
+        domain.blocks()[0].moving_mesh_grid_to_inertial_map().inv_jacobian(
+            map_logical_to_grid(logical_coordinates(mesh)),
+            temporal_id.step_time().value(),
+            domain_creator->functions_of_time());
+    inv_jacobian_logical_to_inertial =
+        InverseJacobian<DataVector, 3, Frame::Logical, Frame::Inertial>(
+            mesh.number_of_grid_points(), 0.0);
+    for (size_t i = 0; i < 3; ++i) {
+      for (size_t j = 0; j < 3; ++j) {
+        for (size_t k = 0; k < 3; ++k) {
+          inv_jacobian_logical_to_inertial.get(i, j) +=
+              inv_jacobian_logical_to_grid.get(k, i) *
+              inv_jacobian_grid_to_inertial.get(j, k);
+        }
+      }
+    }
+    if constexpr (std::is_same_v<TargetFrame, Frame::Grid>) {
+      jacobian_target_to_inertial =
+          domain.blocks()[0].moving_mesh_grid_to_inertial_map().jacobian(
+              map_logical_to_grid(logical_coordinates(mesh)),
+              temporal_id.step_time().value(),
+              domain_creator->functions_of_time());
+      inv_jacobian_logical_to_target = inv_jacobian_logical_to_grid;
+      target_frame_coords = map_logical_to_grid(logical_coordinates(mesh));
+    } else {
+      static_assert(std::is_same_v<TargetFrame, Frame::Inertial>,
+                    "TargetFrame must be the Inertial frame");
+      inv_jacobian_logical_to_target = inv_jacobian_logical_to_inertial;
+      // jacobian_target_to_inertial is the identity in this case.
+      jacobian_target_to_inertial =
+          Jacobian<DataVector, 3, TargetFrame, Frame::Inertial>(
+              mesh.number_of_grid_points(), 0.0);
+      for (size_t i = 0; i < 3; ++i) {
+        jacobian_target_to_inertial.get(i, i) = 1.0;
+      }
+      target_frame_coords =
+          domain.blocks()[0].moving_mesh_grid_to_inertial_map()(
+              map_logical_to_grid(logical_coordinates(mesh)),
+              temporal_id.step_time().value(),
+              domain_creator->functions_of_time());
+    }
+  } else {
+    // time-independent.
+    static_assert(std::is_same_v<TargetFrame, Frame::Inertial>,
+                  "TargetFrame must be the Inertial frame");
+    // Don't need to define jacobian_target_to_inertial
+    ElementMap<3, Frame::Inertial> map_logical_to_inertial{
+        element_ids[0], domain.blocks()[0].stationary_map().get_clone()};
+    target_frame_coords = map_logical_to_inertial(logical_coordinates(mesh));
+    inv_jacobian_logical_to_inertial =
+        map_logical_to_inertial.inv_jacobian(logical_coordinates(mesh));
+    inv_jacobian_logical_to_target = inv_jacobian_logical_to_inertial;
+  }
+
+  // Set up analytic solution.
+  gr::Solutions::KerrSchild solution(1.0, {{0.1, 0.2, 0.3}},
+                                     {{0.03, 0.01, 0.02}});
+  const auto solution_vars_target_frame = solution.variables(
+      target_frame_coords, 0.0,
+      typename gr::Solutions::KerrSchild::tags<DataVector, TargetFrame>{});
+  const auto& lapse =
+      get<gr::Tags::Lapse<DataVector>>(solution_vars_target_frame);
+  const auto& dt_lapse =
+      get<Tags::dt<gr::Tags::Lapse<DataVector>>>(solution_vars_target_frame);
+  const auto& d_lapse = get<
+      typename gr::Solutions::KerrSchild::DerivLapse<DataVector, TargetFrame>>(
+      solution_vars_target_frame);
+  const auto& shift = get<gr::Tags::Shift<3, TargetFrame, DataVector>>(
+      solution_vars_target_frame);
+  const auto& d_shift = get<
+      typename gr::Solutions::KerrSchild::DerivShift<DataVector, TargetFrame>>(
+      solution_vars_target_frame);
+  const auto& dt_shift =
+      get<Tags::dt<gr::Tags::Shift<3, TargetFrame, DataVector>>>(
+          solution_vars_target_frame);
+  const auto& spatial_metric =
+      get<gr::Tags::SpatialMetric<3, TargetFrame, DataVector>>(
+          solution_vars_target_frame);
+  const auto& dt_spatial_metric =
+      get<Tags::dt<gr::Tags::SpatialMetric<3, TargetFrame, DataVector>>>(
+          solution_vars_target_frame);
+  const auto& d_spatial_metric =
+      get<typename gr::Solutions::KerrSchild::DerivSpatialMetric<DataVector,
+                                                                 TargetFrame>>(
+          solution_vars_target_frame);
+
+  // Fill src vars with analytic solution.
+  Variables<SrcTags> src_vars(mesh.number_of_grid_points());
+
+  if constexpr (std::is_same_v<TargetFrame, Frame::Inertial>) {
+    // Src vars are always in inertial frame. Here TargetFrame is inertial,
+    // so no frame transformation is needed.
+
+    get<::gr::Tags::SpacetimeMetric<3, TargetFrame>>(src_vars) =
+        gr::spacetime_metric(lapse, shift, spatial_metric);
+    get<::GeneralizedHarmonic::Tags::Phi<3, TargetFrame>>(src_vars) =
+        GeneralizedHarmonic::phi(lapse, d_lapse, shift, d_shift, spatial_metric,
+                                 d_spatial_metric);
+    get<::GeneralizedHarmonic::Tags::Pi<3, TargetFrame>>(src_vars) =
+        GeneralizedHarmonic::pi(
+            lapse, dt_lapse, shift, dt_shift, spatial_metric, dt_spatial_metric,
+            get<::GeneralizedHarmonic::Tags::Phi<3, TargetFrame>>(src_vars));
+  } else {
+    static_assert(std::is_same_v<TargetFrame, Frame::Grid>,
+                  "TargetFrame must be the Grid frame");
+    // Src vars are always in inertial frame. Here TargetFrame is not
+    // inertial, so we need to transform to the inertial frame.
+
+    // First figure out jacobians
+    const auto coords_frame_velocity_jacobians =
+        domain.blocks()[0]
+            .moving_mesh_grid_to_inertial_map()
+            .coords_frame_velocity_jacobians(
+                target_frame_coords, temporal_id.step_time().value(),
+                domain_creator->functions_of_time());
+    const auto& inv_jacobian_grid_to_inertial =
+        std::get<1>(coords_frame_velocity_jacobians);
+    const auto& jacobian_grid_to_inertial =
+        std::get<2>(coords_frame_velocity_jacobians);
+    const auto& frame_velocity_grid_to_inertial =
+        std::get<3>(coords_frame_velocity_jacobians);
+
+    // Now compute metric variables and transform them into the
+    // inertial frame.  We transform lapse, shift, 3-metric.  Then we
+    // will numerically differentiate transformed 3-metric because we
+    // don't have Hessians and therefore we cannot transform the GH
+    // Phi variable directly.
+    using inertial_metric_vars_tags = tmpl::list<
+        gr::Tags::Lapse<DataVector>,
+        gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+        gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+        gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>>;
+    Variables<inertial_metric_vars_tags> inertial_metric_vars(
+        mesh.number_of_grid_points());
+
+    // Just copy lapse, since it doesn't transform. Need it for derivs.
+    get<gr::Tags::Lapse<DataVector>>(inertial_metric_vars) = lapse;
+
+    // Transform shift
+    auto& shift_inertial =
+        get<::gr::Tags::Shift<3, Frame::Inertial>>(inertial_metric_vars);
+    for (size_t k = 0; k < 3; ++k) {
+      shift_inertial.get(k) = -frame_velocity_grid_to_inertial.get(k);
+      for (size_t j = 0; j < 3; ++j) {
+        shift_inertial.get(k) +=
+            jacobian_grid_to_inertial.get(k, j) * shift.get(j);
+      }
+    }
+
+    // Transform lower metric.
+    auto& lower_metric_inertial =
+        get<::gr::Tags::SpatialMetric<3, Frame::Inertial>>(
+            inertial_metric_vars);
+    transform::to_different_frame(make_not_null(&lower_metric_inertial),
+                                  spatial_metric,
+                                  inv_jacobian_grid_to_inertial);
+
+    // Transform extrinsic curvature.
+    auto& extrinsic_curvature_inertial =
+        get<gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>>(
+            inertial_metric_vars);
+    transform::to_different_frame(
+        make_not_null(&extrinsic_curvature_inertial),
+        get<gr::Tags::ExtrinsicCurvature<3, TargetFrame, DataVector>>(
+            solution_vars_target_frame),
+        inv_jacobian_grid_to_inertial);
+
+    // Now differentiate the inertial-frame lapse, shift, spatial metric
+    // to get inertial derivatives.
+    const auto deriv_inertial_metric_vars = partial_derivatives<
+        tmpl::list<gr::Tags::Lapse<DataVector>,
+                   gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+                   gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>>(
+        inertial_metric_vars, mesh, inv_jacobian_logical_to_inertial);
+    const auto& inertial_d_spatial_metric =
+        get<Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+                        tmpl::size_t<3>, Frame::Inertial>>(
+            deriv_inertial_metric_vars);
+    const auto& inertial_d_shift =
+        get<Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+                        tmpl::size_t<3>, Frame::Inertial>>(
+            deriv_inertial_metric_vars);
+    const auto& inertial_d_lapse =
+        get<Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,
+                        Frame::Inertial>>(deriv_inertial_metric_vars);
+
+    // Now fill src_vars
+    get<::gr::Tags::SpacetimeMetric<3, Frame::Inertial>>(src_vars) =
+        gr::spacetime_metric(lapse, shift_inertial, lower_metric_inertial);
+    get<::GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>(src_vars) =
+        GeneralizedHarmonic::phi(lapse, inertial_d_lapse, shift_inertial,
+                                 inertial_d_shift, lower_metric_inertial,
+                                 inertial_d_spatial_metric);
+
+    // Compute Pi from extrinsic curvature and Phi.  Fill in NaN
+    // for zero components of Pi, since they won't be used at all.
+    const auto spacetime_normal_vector =
+        gr::spacetime_normal_vector(lapse, shift_inertial);
+    auto& Pi =
+        get<::GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>>(src_vars);
+    const auto& Phi =
+        get<::GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>(src_vars);
+    for (size_t i = 0; i < 3; ++i) {
+      Pi.get(i + 1, 0) = std::numeric_limits<double>::signaling_NaN();
+      for (size_t j = i; j < 3; ++j) {  // symmetry
+        Pi.get(i + 1, j + 1) = 2.0 * extrinsic_curvature_inertial.get(i, j);
+        for (size_t c = 0; c < 4; ++c) {
+          Pi.get(i + 1, j + 1) -= spacetime_normal_vector.get(c) *
+                                  (Phi.get(i, j + 1, c) + Phi.get(j, i + 1, c));
+        }
+      }
+    }
+    Pi.get(0, 0) = std::numeric_limits<double>::signaling_NaN();
+  }
+
+  if constexpr (tmpl::list_contains_v<
+                    SrcTags, Tags::deriv<GeneralizedHarmonic::Tags::Phi<
+                                             3, Frame::Inertial>,
+                                         tmpl::size_t<3>, Frame::Inertial>>) {
+    // Need to compute numerical deriv of Phi.
+    // The partial_derivatives function allows differentiating only a
+    // subset of a Variables, but in that case, the resulting Variables
+    // cannot point into the original Variables, and also the subset must
+    // be the tags that occur at the beginning of the Variables.  Because
+    // this is only a test, we just create new Variables and copy.
+
+    // vars to be differentiated
+    using phi_tag_list =
+        tmpl::list<::GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>;
+    Variables<phi_tag_list> vars_before_differentiation(
+        mesh.number_of_grid_points());
+    get<::GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>(
+        vars_before_differentiation) =
+        get<::GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>(src_vars);
+
+    // differentiate
+    const auto vars_after_differentiation = partial_derivatives<phi_tag_list>(
+        vars_before_differentiation, mesh, inv_jacobian_logical_to_inertial);
+
+    // copy to src_vars.
+    get<Tags::deriv<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                    tmpl::size_t<3>, Frame::Inertial>>(src_vars) =
+        get<Tags::deriv<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                        tmpl::size_t<3>, Frame::Inertial>>(
+            vars_after_differentiation);
+  }
+
+  // Compute dest_vars
+  Variables<DestTags> dest_vars(mesh.number_of_grid_points());
+  if constexpr (IsTimeDependent::value) {
+    ah::ComputeHorizonVolumeQuantities::apply(
+        make_not_null(&dest_vars), src_vars, mesh, jacobian_target_to_inertial,
+        inv_jacobian_logical_to_target);
+  } else {
+    // time-independent.
+    ah::ComputeHorizonVolumeQuantities::apply(make_not_null(&dest_vars),
+                                              src_vars, mesh);
+  }
+
+  // Now make sure that dest vars are correct.
+
+  const auto expected_christoffel_second_kind = raise_or_lower_first_index(
+      gr::christoffel_first_kind(d_spatial_metric),
+      determinant_and_inverse(spatial_metric).second);
+  const auto& christoffel_second_kind =
+      get<gr::Tags::SpatialChristoffelSecondKind<3, TargetFrame>>(dest_vars);
+  if constexpr (not std::is_same_v<TargetFrame, Frame::Inertial>) {
+    // Use a more forgiving local_approx because for the multi-frame case,
+    // christoffel_second_kind is computed using numerical derivatives,
+    // therefore this test should agree to truncation error and not roundoff.
+    Approx local_approx = Approx::custom().epsilon(1.e-9).scale(1.);
+    CHECK_ITERABLE_CUSTOM_APPROX(expected_christoffel_second_kind,
+                                 christoffel_second_kind, local_approx);
+  } else {
+    // For a single frame there are no numerical derivatives
+    // involved in computing christoffel_second_kind.
+    CHECK_ITERABLE_APPROX(expected_christoffel_second_kind,
+                          christoffel_second_kind);
+  }
+
+  const auto expected_extrinsic_curvature =
+      gr::extrinsic_curvature(lapse, shift, d_shift, spatial_metric,
+                              dt_spatial_metric, d_spatial_metric);
+  const auto& extrinsic_curvature =
+      get<gr::Tags::ExtrinsicCurvature<3, TargetFrame>>(dest_vars);
+  CHECK_ITERABLE_APPROX(expected_extrinsic_curvature, extrinsic_curvature);
+
+  if constexpr (tmpl::list_contains_v<
+                    DestTags, gr::Tags::SpatialMetric<3, TargetFrame>>) {
+    const auto& numerical_spatial_metric =
+        get<gr::Tags::SpatialMetric<3, TargetFrame>>(dest_vars);
+    CHECK_ITERABLE_APPROX(spatial_metric, numerical_spatial_metric);
+  }
+
+  if constexpr (tmpl::list_contains_v<
+                    DestTags, gr::Tags::InverseSpatialMetric<3, TargetFrame>>) {
+    const auto& inv_spatial_metric =
+        get<gr::Tags::InverseSpatialMetric<3, TargetFrame>>(dest_vars);
+    CHECK_ITERABLE_APPROX(determinant_and_inverse(spatial_metric).second,
+                          inv_spatial_metric);
+  }
+
+  if constexpr (tmpl::list_contains_v<DestTags,
+                                      gr::Tags::SpatialRicci<3, TargetFrame>>) {
+    // Compute Ricci and check.
+    // Compute derivative of christoffel_2nd_kind, which is different
+    // from how Ricci is computed in ComputeHorizonVolumeQuantities, but
+    // which should give the same result to numerical truncation error.
+    using christoffel_tags =
+        tmpl::list<gr::Tags::SpatialChristoffelSecondKind<3, TargetFrame>>;
+    Variables<christoffel_tags> vars_before_deriv(mesh.number_of_grid_points());
+    get<gr::Tags::SpatialChristoffelSecondKind<3, TargetFrame>>(
+        vars_before_deriv) =
+        get<gr::Tags::SpatialChristoffelSecondKind<3, TargetFrame>>(dest_vars);
+
+    const auto vars_after_deriv = partial_derivatives<christoffel_tags>(
+        vars_before_deriv, mesh, inv_jacobian_logical_to_target);
+    const auto expected_ricci = gr::ricci_tensor(
+        get<gr::Tags::SpatialChristoffelSecondKind<3, TargetFrame>>(dest_vars),
+        get<::Tags::deriv<
+            gr::Tags::SpatialChristoffelSecondKind<3, TargetFrame>,
+            tmpl::size_t<3>, TargetFrame>>(vars_after_deriv));
+    const auto& ricci = get<gr::Tags::SpatialRicci<3, TargetFrame>>(dest_vars);
+    // Use a more forgiving local_approx because this test should agree
+    // to truncation error not roundoff, because it has numerical derivs.
+    Approx local_approx = Approx::custom().epsilon(1.e-9).scale(1.);
+    CHECK_ITERABLE_CUSTOM_APPROX(expected_ricci, ricci, local_approx);
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizons.ComputeHorizonVolumeQuantities",
+                  "[ApparentHorizons][Unit]") {
+  // time-independent.
+  // All possible tags.
+  test_compute_horizon_volume_quantities<
+      std::false_type, Frame::Inertial,
+      tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                 Tags::deriv<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                             tmpl::size_t<3>, Frame::Inertial>>,
+      tmpl::list<gr::Tags::SpatialMetric<3, Frame::Inertial>,
+                 gr::Tags::InverseSpatialMetric<3, Frame::Inertial>,
+                 gr::Tags::ExtrinsicCurvature<3, Frame::Inertial>,
+                 gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial>,
+                 gr::Tags::SpatialRicci<3, Frame::Inertial>>>();
+  // Leave out a few tags.
+  test_compute_horizon_volume_quantities<
+      std::false_type, Frame::Inertial,
+      tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>,
+      tmpl::list<gr::Tags::InverseSpatialMetric<3, Frame::Inertial>,
+                 gr::Tags::ExtrinsicCurvature<3, Frame::Inertial>,
+                 gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial>>>();
+  test_compute_horizon_volume_quantities<
+      std::false_type, Frame::Inertial,
+      tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>,
+      tmpl::list<gr::Tags::SpatialMetric<3, Frame::Inertial>,
+                 gr::Tags::ExtrinsicCurvature<3, Frame::Inertial>,
+                 gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial>>>();
+
+  // time-dependent.
+  // All possible tags.
+  test_compute_horizon_volume_quantities<
+      std::true_type, Frame::Grid,
+      tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                 Tags::deriv<GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>,
+                             tmpl::size_t<3>, Frame::Inertial>>,
+      tmpl::list<gr::Tags::SpatialMetric<3, Frame::Grid>,
+                 gr::Tags::InverseSpatialMetric<3, Frame::Grid>,
+                 gr::Tags::ExtrinsicCurvature<3, Frame::Grid>,
+                 gr::Tags::SpatialChristoffelSecondKind<3, Frame::Grid>,
+                 gr::Tags::SpatialRicci<3, Frame::Grid>>>();
+  // Leave out a few tags.
+  test_compute_horizon_volume_quantities<
+      std::true_type, Frame::Grid,
+      tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>,
+      tmpl::list<gr::Tags::InverseSpatialMetric<3, Frame::Grid>,
+                 gr::Tags::ExtrinsicCurvature<3, Frame::Grid>,
+                 gr::Tags::SpatialChristoffelSecondKind<3, Frame::Grid>>>();
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

Background:
For parallel interpolation, `compute_items_on_source` in the metavariables will eventually be replaced by `compute_vars_to_interpolate`.  The idea is that instead of specifying a long complicated chain of ComputeItems, the
metavariables will specify a single function `compute_vars_to_interpolate` that takes the source Variables
`Metavariables::interpolator_source_vars` (the quantities sent from Elements to the Interpolator parallel component) and computes the destination Variables `vars_to_interpolate_to_target` (the quantities that get interpolated in the volume). Because the user specifies one function instead of a chain of ComputeItems, that function can be better optimized (for instance, it can do a single memory allocation that includes all of its temporary variables).

This PR does not change `compute_items_on_source` to `compute_vars_to_interpolate`; that will be done in a subsequent PR, so as to avoid too large of a PR.
Instead, this PR adds a new `compute_vars_to_interpolate` called ComputeHorizonVolumeQuantities (and a test for it) that will be used for the apparent horizon finder.

ComputeHorizonVolumeQuantities offers functionality that the current horizon finder lacks:
 - It allows the output to be in a different frame than the input, and does all the required frame transformations.  This will allow finding the horizon in the grid frame for dual-frame evolutions.  Because we do not have Hessians, ComputeHorizonVolumeQuantities needs to take numerical derivatives to transform things like Christoffel symbols.
 - It optionally allows the Ricci tensor to be interpolated onto the horizon, for observers, and this will work for single and dual-frame setups.
 - It is tolerant to some variation in the specified  `vars_to_interpolate_to_target`, e.g. the user can request the SpatialMetric to be interpolated, or the InverseSpatialMetric, or both.
 - A future PR will add the ability to compute the covariant derivative of the extrinsic curvature on the horizon, which is another quantity needed for observers.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
