### PR TITLE
Add PhaseControl for checkpointing after wallclock; add checkpointing documentation

### DIFF
--- a/docs/Tutorials/CheckpointRestart.md
+++ b/docs/Tutorials/CheckpointRestart.md
@@ -1,0 +1,55 @@
+\cond NEVER
+Distributed under the MIT License.
+See LICENSE.txt for details.
+\endcond
+# %Setting up checkpoints and restarts {#tutorial_checkpoint_restart}
+
+SpECTRE executables can write checkpoints that save their instantaneous state to
+disc; the execution can be restarted later from a saved checkpoint. This feature
+is useful for expensive simulations that would run longer than the wallclock
+limits on a supercomputer system.
+
+Executables can checkpoint when:
+1. The `Phase` enumeration in the `Metavariables` has a `WriteCheckpoint` phase.
+2. The `WriteCheckpoint` phase is run by a `PhaseControl` specified in the
+   `Metavariables` and the input file. The two supported ways of running the
+   checkpoint phase are:
+   - with `CheckpointAndExitAfterWallclock`. This is the recommended phase
+     control for checkpointing, because it writes only one checkpoint before
+     cleanly terminating the code.
+     This reduces the disc space taken up by checkpoint files and stops using
+     up the allocation's CPU-hours on work that would be redone anyway after the
+     run is restarted.
+   - using `VisitAndReturn(WriteCheckpoint)`. This is useful for writing more
+     frequent checkpoint files, which could help when debugging a run by
+     restarting it from just before the failure.
+
+To restart an executable from a checkpoint file, run a command like this:
+```
+./MySpectreExecutable +restart SpectreCheckpoint000123
+```
+where the `000123` should be the number of the checkpoint to restart from.
+
+There are a number of caveats in the current implementation of checkpointing
+and restarting:
+
+1. The same binary must be used when writing the checkpoint and when restarting
+   from the checkpoint. If a different binary is used to restart the code,
+   there are no guarantees that the code will restart or that the continued
+   execution will be correct.
+2. The code must be restarted on the same hardware configuration used when
+   writing the checkpoint --- this means the same number of nodes with the same
+   number of processors per node.
+3. Currently, there is no support for modifying any parameters during a restart.
+   The restart only extends a simulation's runtime beyond wallclock limits.
+4. When using `CheckpointAndExitAfterWallclock` to trigger checkpoints, note
+   that the elapsed wallclock time is checked only when the `PhaseControl` is
+   run, i.e., at global synchronization points defined in the input file.
+   This means that to write a checkpoint in the 30 minutes before the end of a
+   job's queue time, the triggers in the input file must trigger global
+   synchronizations at least once every 30 minutes (and probably 2-3 times so
+   there is a margin for the time to write files to disc, etc). It is currently
+   up to the user to find the balance between too-frequent synchronizations
+   (that slow the code) and too-infrequent synchronizations (that won't allow
+   checkpoints to be written).
+

--- a/docs/Tutorials/Tutorials.md
+++ b/docs/Tutorials/Tutorials.md
@@ -12,3 +12,5 @@ See LICENSE.txt for details.
   and other Python modules provided by SpECTRE.
 - \ref tutorial_cce - How to get started running stand-alone CCE with
   externally produced data
+- \ref tutorial_checkpoint_restart - How to get set up a SpECTRE executable for
+  checkpointing and restarting

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -41,6 +41,7 @@
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp"
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/PhaseControl/PhaseControlTags.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
@@ -162,6 +163,7 @@ struct EvolutionMetavars {
   enum class Phase {
     Initialization,
     LoadBalancing,
+    WriteCheckpoint,
     RegisterWithObserver,
     InitializeTimeStepperHistory,
     Evolve,
@@ -178,8 +180,11 @@ struct EvolutionMetavars {
         << static_cast<int>(phase));
   }
 
-  using phase_changes = tmpl::list<PhaseControl::Registrars::VisitAndReturn<
-      EvolutionMetavars, Phase::LoadBalancing>>;
+  using phase_changes =
+      tmpl::list<PhaseControl::Registrars::VisitAndReturn<EvolutionMetavars,
+                                                          Phase::LoadBalancing>,
+                 PhaseControl::Registrars::CheckpointAndExitAfterWallclock<
+                     EvolutionMetavars>>;
 
   using initialize_phase_change_decision_data =
       PhaseControl::InitializePhaseChangeDecisionData<phase_changes>;

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -70,6 +70,7 @@
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/Algorithms/AlgorithmSingleton.hpp"
 #include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp"
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/PhaseControl/PhaseControlTags.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
@@ -169,6 +170,7 @@ struct GeneralizedHarmonicDefaults {
     InitializeTimeStepperHistory,
     Register,
     LoadBalancing,
+    WriteCheckpoint,
     Evolve,
     Exit
   };
@@ -243,8 +245,11 @@ struct GeneralizedHarmonicTemplateBase<
       observers::collect_reduction_data_tags<tmpl::push_back<
           tmpl::at<typename factory_creation::factory_classes, Event>>>;
 
-  using phase_changes = tmpl::list<PhaseControl::Registrars::VisitAndReturn<
-      GeneralizedHarmonicTemplateBase, Phase::LoadBalancing>>;
+  using phase_changes =
+      tmpl::list<PhaseControl::Registrars::VisitAndReturn<
+                     GeneralizedHarmonicTemplateBase, Phase::LoadBalancing>,
+                 PhaseControl::Registrars::CheckpointAndExitAfterWallclock<
+                     GeneralizedHarmonicTemplateBase>>;
 
   using initialize_phase_change_decision_data =
       PhaseControl::InitializePhaseChangeDecisionData<phase_changes>;

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -70,6 +70,7 @@
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/Algorithms/AlgorithmSingleton.hpp"
 #include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp"
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/PhaseControl/PhaseControlTags.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
@@ -234,6 +235,7 @@ struct EvolutionMetavars {
     InitializeTimeStepperHistory,
     Register,
     LoadBalancing,
+    WriteCheckpoint,
     Evolve,
     Exit
   };
@@ -248,8 +250,11 @@ struct EvolutionMetavars {
         << static_cast<int>(phase));
   }
 
-  using phase_changes = tmpl::list<PhaseControl::Registrars::VisitAndReturn<
-      EvolutionMetavars, Phase::LoadBalancing>>;
+  using phase_changes =
+      tmpl::list<PhaseControl::Registrars::VisitAndReturn<EvolutionMetavars,
+                                                          Phase::LoadBalancing>,
+                 PhaseControl::Registrars::CheckpointAndExitAfterWallclock<
+                     EvolutionMetavars>>;
 
   using initialize_phase_change_decision_data =
       PhaseControl::InitializePhaseChangeDecisionData<phase_changes>;
@@ -259,7 +264,7 @@ struct EvolutionMetavars {
 
   using dg_registration_list =
       tmpl::list<intrp::Actions::RegisterElementWithInterpolator,
-    observers::Actions::RegisterEventsWithObservers>;
+                 observers::Actions::RegisterEventsWithObservers>;
 
   using initialization_actions = tmpl::list<
       Actions::SetupDataBox,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -45,6 +45,7 @@
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp"
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/PhaseControl/PhaseControlTags.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
@@ -196,6 +197,7 @@ struct EvolutionMetavars {
     InitializeTimeStepperHistory,
     RegisterWithObserver,
     LoadBalancing,
+    WriteCheckpoint,
     Evolve,
     Exit
   };
@@ -210,8 +212,11 @@ struct EvolutionMetavars {
         << static_cast<int>(phase));
   }
 
-  using phase_changes = tmpl::list<PhaseControl::Registrars::VisitAndReturn<
-      EvolutionMetavars, Phase::LoadBalancing>>;
+  using phase_changes =
+      tmpl::list<PhaseControl::Registrars::VisitAndReturn<EvolutionMetavars,
+                                                          Phase::LoadBalancing>,
+                 PhaseControl::Registrars::CheckpointAndExitAfterWallclock<
+                     EvolutionMetavars>>;
 
   using initialize_phase_change_decision_data =
       PhaseControl::InitializePhaseChangeDecisionData<phase_changes>;

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -47,6 +47,7 @@
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp"
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/PhaseControl/PhaseControlTags.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
@@ -182,6 +183,7 @@ struct EvolutionMetavars {
     InitializeTimeStepperHistory,
     RegisterWithObserver,
     LoadBalancing,
+    WriteCheckpoint,
     Evolve,
     Exit
   };
@@ -196,8 +198,11 @@ struct EvolutionMetavars {
         << static_cast<int>(phase));
   }
 
-  using phase_changes = tmpl::list<PhaseControl::Registrars::VisitAndReturn<
-      EvolutionMetavars, Phase::LoadBalancing>>;
+  using phase_changes =
+      tmpl::list<PhaseControl::Registrars::VisitAndReturn<EvolutionMetavars,
+                                                          Phase::LoadBalancing>,
+                 PhaseControl::Registrars::CheckpointAndExitAfterWallclock<
+                     EvolutionMetavars>>;
 
   using initialize_phase_change_decision_data =
       PhaseControl::InitializePhaseChangeDecisionData<phase_changes>;

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -48,6 +48,7 @@
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp"
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/PhaseControl/PhaseControlTags.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
@@ -191,6 +192,7 @@ struct EvolutionMetavars {
     InitializeTimeStepperHistory,
     RegisterWithObserver,
     LoadBalancing,
+    WriteCheckpoint,
     Evolve,
     Exit
   };
@@ -205,8 +207,11 @@ struct EvolutionMetavars {
         << static_cast<int>(phase));
   }
 
-  using phase_changes = tmpl::list<PhaseControl::Registrars::VisitAndReturn<
-      EvolutionMetavars, Phase::LoadBalancing>>;
+  using phase_changes =
+      tmpl::list<PhaseControl::Registrars::VisitAndReturn<EvolutionMetavars,
+                                                          Phase::LoadBalancing>,
+                 PhaseControl::Registrars::CheckpointAndExitAfterWallclock<
+                     EvolutionMetavars>>;
 
   using initialize_phase_change_decision_data =
       PhaseControl::InitializePhaseChangeDecisionData<phase_changes>;

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -41,6 +41,7 @@
 #include "Parallel/Actions/SetupDataBox.hpp"
 #include "Parallel/Actions/TerminatePhase.hpp"
 #include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp"
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/PhaseControl/PhaseControlTags.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
@@ -172,6 +173,7 @@ struct EvolutionMetavars {
     RegisterWithObserver,
     InitializeTimeStepperHistory,
     LoadBalancing,
+    WriteCheckpoint,
     Evolve,
     Exit
   };
@@ -186,8 +188,11 @@ struct EvolutionMetavars {
         << static_cast<int>(phase));
   }
 
-  using phase_changes = tmpl::list<PhaseControl::Registrars::VisitAndReturn<
-      EvolutionMetavars, Phase::LoadBalancing>>;
+  using phase_changes =
+      tmpl::list<PhaseControl::Registrars::VisitAndReturn<EvolutionMetavars,
+                                                          Phase::LoadBalancing>,
+                 PhaseControl::Registrars::CheckpointAndExitAfterWallclock<
+                     EvolutionMetavars>>;
 
   using initialize_phase_change_decision_data =
       PhaseControl::InitializePhaseChangeDecisionData<phase_changes>;

--- a/src/Parallel/PhaseControl/CMakeLists.txt
+++ b/src/Parallel/PhaseControl/CMakeLists.txt
@@ -5,6 +5,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  CheckpointAndExitAfterWallclock.hpp
   ExecutePhaseChange.hpp
   PhaseChange.hpp
   PhaseControlTags.hpp

--- a/src/Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp
+++ b/src/Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp
@@ -1,0 +1,281 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <optional>
+#include <pup.h>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#include "Options/Auto.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/AlgorithmMetafunctions.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Main.hpp"
+#include "Parallel/PhaseControl/PhaseChange.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/System/ParallelInfo.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace PhaseControl {
+template <typename Metavariables, typename PhaseChangeRegistrars>
+class CheckpointAndExitAfterWallclock;
+
+namespace Registrars {
+template <typename Metavariables>
+struct CheckpointAndExitAfterWallclock {
+  template <typename PhaseChangeRegistrars>
+  using f =
+      ::PhaseControl::CheckpointAndExitAfterWallclock<Metavariables,
+                                                      PhaseChangeRegistrars>;
+};
+}  // namespace Registrars
+/// \endcond
+
+namespace Tags {
+/// Storage in the phase change decision tuple so that the Main chare can record
+/// the phase to go to when restarting the run from a checkpoint file.
+///
+/// \note This tag is not intended to participate in any of the reduction
+/// procedures, so will error if the combine method is called.
+template <typename PhaseType>
+struct RestartPhase {
+  using type = std::optional<PhaseType>;
+
+  struct combine_method {
+    std::optional<PhaseType> operator()(
+        const std::optional<PhaseType> /*first_phase*/,
+        const std::optional<PhaseType>& /*second_phase*/) noexcept {
+      ERROR(
+          "The restart phase should only be altered by the phase change "
+          "arbitration in the Main chare, so no reduction data should be "
+          "provided.");
+    }
+  };
+
+  using main_combine_method = combine_method;
+};
+
+/// Storage in the phase change decision tuple so that the Main chare can record
+/// the elapsed wallclock time since the start of the run.
+///
+/// \note This tag is not intended to participate in any of the reduction
+/// procedures, so will error if the combine method is called.
+struct WallclockHoursAtCheckpoint {
+  using type = std::optional<double>;
+
+  struct combine_method {
+    std::optional<double> operator()(
+        const std::optional<double> /*first_time*/,
+        const std::optional<double>& /*second_time*/) noexcept {
+      ERROR(
+          "The wallclock time at which a checkpoint was requested should "
+          "only be altered by the phase change arbitration in the Main "
+          "chare, so no reduction data should be provided.");
+    }
+  };
+  using main_combine_method = combine_method;
+};
+
+/// Stores whether the checkpoint and exit has been requested.
+///
+/// Combinations are performed via `funcl::Or`, as the phase in question should
+/// be chosen if any component requests the jump.
+struct CheckpointAndExitRequested {
+  using type = bool;
+
+  using combine_method = funcl::Or<>;
+  using main_combine_method = funcl::Or<>;
+};
+
+}  // namespace Tags
+
+/*!
+ * \brief Phase control object that runs the WriteCheckpoint and Exit phases
+ * after a specified amount of wallclock time has elapsed.
+ *
+ * This phase control is useful for running SpECTRE executables performing
+ * lengthy computations that may exceed a supercomputer's wallclock limits.
+ * Writing a single checkpoint at the end of the job's allocated time allows
+ * the computation to be continued, while minimizing the disc space taken up by
+ * checkpoint files.
+ *
+ * Note that this phase control is not a trigger on wallclock time. Rather,
+ * it checks the elapsed wallclock time when called, likely from a global sync
+ * point triggered by some other mechanism, e.g., at some slab boundary.
+ * Therefore, the WriteCheckpoint and Exit phases will run the first time
+ * this phase control is called after the specified wallclock time has been
+ * reached.
+ *
+ * \warning the global sync points _must_ be triggered often enough to ensure
+ * there will be at least one sync point (i.e., one call to this phase control)
+ * in the window between the requested checkpoint-and-exit time and the time at
+ * which the batch system will kill the executable. To make this more concrete,
+ * consider this example: when running on a 12-hour queue with a
+ * checkpoint-and-exit requested after 11.5 hours, there is a 0.5-hour window
+ * for a global sync to occur, the checkpoint files to be written to disc, and
+ * the executable to clean up. In this case, triggering a global sync every
+ * 2-10 minutes might be desirable. Matching the global sync frequency with the
+ * time window for checkpoint and exit is the responsibility of the user!
+ */
+template <typename Metavariables,
+          typename PhaseChangeRegistrars = tmpl::list<
+              Registrars::CheckpointAndExitAfterWallclock<Metavariables>>>
+struct CheckpointAndExitAfterWallclock
+    : public PhaseChange<PhaseChangeRegistrars> {
+  // This PhaseChange only makes sense if Metavars has a WriteCheckpoint phase
+  static_assert(Parallel::Algorithm_detail::has_WriteCheckpoint_v<
+                    typename Metavariables::Phase>,
+                "Requested to write checkpoints but Metavariables::Phase "
+                "doesn't have a WriteCheckpoint phase");
+
+  CheckpointAndExitAfterWallclock(const std::optional<double> wallclock_hours,
+                                  const Options::Context& context = {})
+      : wallclock_hours_for_checkpoint_and_exit_(wallclock_hours) {
+    if (wallclock_hours.has_value() and wallclock_hours.value() < 0.0) {
+      PARSE_ERROR(context, "Must give a positive time in hours, but got "
+                               << wallclock_hours.value());
+    }
+  }
+  explicit CheckpointAndExitAfterWallclock(CkMigrateMessage* msg) noexcept
+      : PhaseChange<PhaseChangeRegistrars>(msg) {}
+
+  /// \cond
+  CheckpointAndExitAfterWallclock() = default;
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(CheckpointAndExitAfterWallclock);  // NOLINT
+  /// \endcond
+
+  struct WallclockHours {
+    using type = Options::Auto<double, Options::AutoLabel::None>;
+    static constexpr Options::String help = {
+        "Time in hours after which to write the checkpoint and exit. "
+        "If 'None' is specified, no action will be taken."};
+  };
+  using options = tmpl::list<WallclockHours>;
+  static constexpr Options::String help{
+      "Once the wallclock time has exceeded the specified amount, trigger "
+      "writing a checkpoint and then exit."};
+
+  using argument_tags = tmpl::list<>;
+  using return_tags = tmpl::list<>;
+
+  using phase_change_tags_and_combines =
+      tmpl::list<Tags::RestartPhase<typename Metavariables::Phase>,
+                 Tags::WallclockHoursAtCheckpoint,
+                 Tags::CheckpointAndExitRequested>;
+
+  template <typename LocalMetavariables>
+  using participating_components = typename LocalMetavariables::component_list;
+
+  template <typename... DecisionTags>
+  void initialize_phase_data_impl(
+      const gsl::not_null<tuples::TaggedTuple<DecisionTags...>*>
+          phase_change_decision_data) const noexcept {
+    tuples::get<Tags::RestartPhase<typename Metavariables::Phase>>(
+        *phase_change_decision_data) = std::nullopt;
+    tuples::get<Tags::WallclockHoursAtCheckpoint>(*phase_change_decision_data) =
+        std::nullopt;
+    tuples::get<Tags::CheckpointAndExitRequested>(*phase_change_decision_data) =
+        false;
+  }
+
+  template <typename ParallelComponent, typename ArrayIndex,
+            typename LocalMetavariables>
+  void contribute_phase_data_impl(
+      Parallel::GlobalCache<LocalMetavariables>& cache,
+      const ArrayIndex& array_index) const noexcept {
+    if constexpr (std::is_same_v<typename ParallelComponent::chare_type,
+                                 Parallel::Algorithms::Array>) {
+      Parallel::contribute_to_phase_change_reduction<ParallelComponent>(
+          tuples::TaggedTuple<Tags::CheckpointAndExitRequested>{true}, cache,
+          array_index);
+    } else {
+      Parallel::contribute_to_phase_change_reduction<ParallelComponent>(
+          tuples::TaggedTuple<Tags::CheckpointAndExitRequested>{true}, cache);
+    }
+  }
+
+  template <typename... DecisionTags, typename LocalMetavariables>
+  typename std::optional<
+      std::pair<typename Metavariables::Phase, ArbitrationStrategy>>
+  arbitrate_phase_change_impl(
+      const gsl::not_null<tuples::TaggedTuple<DecisionTags...>*>
+          phase_change_decision_data,
+      const typename LocalMetavariables::Phase current_phase,
+      const Parallel::GlobalCache<LocalMetavariables>& /*cache*/)
+      const noexcept {
+    // If no checkpoint-and-exit time given, then do nothing
+    if (not wallclock_hours_for_checkpoint_and_exit_.has_value()) {
+      return std::nullopt;
+    }
+
+    const double elapsed_hours = sys::wall_time() / 3600.0;
+
+    auto& restart_phase =
+        tuples::get<Tags::RestartPhase<typename Metavariables::Phase>>(
+            *phase_change_decision_data);
+    auto& wallclock_hours_at_checkpoint =
+        tuples::get<Tags::WallclockHoursAtCheckpoint>(
+            *phase_change_decision_data);
+    if (restart_phase.has_value()) {
+      ASSERT(wallclock_hours_at_checkpoint.has_value(),
+             "Consistency error: Should have recorded the Wallclock time "
+             "while recording a phase to restart from.");
+      // This `if` branch, where restart_phase has a value, is the
+      // post-checkpoint call to arbitrate_phase_change. Depending on the time
+      // elapsed so far in this run, next phase is...
+      // - Exit, if the time is large
+      // - restart_phase, if the time is small
+      if (elapsed_hours >= wallclock_hours_at_checkpoint.value()) {
+        // Preserve restart_phase for use after restarting from the checkpoint
+        return std::make_pair(Metavariables::Phase::Exit,
+                              ArbitrationStrategy::RunPhaseImmediately);
+      } else {
+        // Reset restart_phase until it is needed for the next checkpoint
+        const auto result = restart_phase;
+        restart_phase.reset();
+        wallclock_hours_at_checkpoint.reset();
+        return std::make_pair(result.value(),
+                              ArbitrationStrategy::PermitAdditionalJumps);
+      }
+    }
+
+    auto& checkpoint_and_exit_requested =
+        tuples::get<Tags::CheckpointAndExitRequested>(
+            *phase_change_decision_data);
+    if (checkpoint_and_exit_requested) {
+      checkpoint_and_exit_requested = false;
+      // We checked wallclock_hours_for_checkpoint_and_exit_ has value above
+      if (elapsed_hours >= wallclock_hours_for_checkpoint_and_exit_.value()) {
+        // Record phase and actual elapsed time for determining following phase
+        restart_phase = current_phase;
+        wallclock_hours_at_checkpoint = elapsed_hours;
+        return std::make_pair(Metavariables::Phase::WriteCheckpoint,
+                              ArbitrationStrategy::RunPhaseImmediately);
+      }
+    }
+    return std::nullopt;
+  }
+
+  void pup(PUP::er& p) noexcept override {
+    PhaseChange<PhaseChangeRegistrars>::pup(p);
+    p | wallclock_hours_for_checkpoint_and_exit_;
+  }
+
+ private:
+  std::optional<double> wallclock_hours_for_checkpoint_and_exit_ = std::nullopt;
+};
+}  // namespace PhaseControl
+
+/// \cond
+template <typename Metavariables, typename PhaseChangeRegistrars>
+PUP::able::PUP_ID PhaseControl::CheckpointAndExitAfterWallclock<
+    Metavariables, PhaseChangeRegistrars>::my_PUP_ID = 0;
+/// \endcond

--- a/src/Parallel/PhaseControl/PhaseChange.hpp
+++ b/src/Parallel/PhaseControl/PhaseChange.hpp
@@ -149,6 +149,8 @@ struct PhaseChange : public PUP::able {
   /// \endcond
 
  public:
+  PhaseChange(CkMigrateMessage* msg) noexcept : PUP::able(msg) {};
+
   ~PhaseChange() override = default;
 
   WRAPPED_PUPable_abstract(PhaseChange);  // NOLINT

--- a/src/Utilities/System/ParallelInfo.hpp
+++ b/src/Utilities/System/ParallelInfo.hpp
@@ -89,7 +89,7 @@ inline int local_rank_of(const int proc_index) {
 
 /*!
  * \ingroup SystemUtilitiesGroup
- * \brief The current wall time in seconds
+ * \brief The elapsed wall time in seconds.
  */
-inline double wall_time() { return CmiWallTimer(); }
+inline double wall_time() { return CkWallTimer(); }
 }  // namespace sys

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave.yaml
@@ -16,6 +16,13 @@ Evolution:
       Order: 3
 
 PhaseChangeAndTriggers:
+  - - Slabs:
+       EvenlySpaced:
+         # Current implementation checks wallclock at these global syncs
+         Interval: 100
+         Offset: 0
+    - - CheckpointAndExitAfterWallclock:
+          WallclockHours: None
 
 DomainCreator:
   Brick:

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -16,6 +16,13 @@ Evolution:
       Order: 1
 
 PhaseChangeAndTriggers:
+  - - Slabs:
+       EvenlySpaced:
+         # Current implementation checks wallclock at these global syncs
+         Interval: 100
+         Offset: 0
+    - - CheckpointAndExitAfterWallclock:
+          WallclockHours: None
 
 DomainCreator:
   Shell:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/CylindricalBlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/CylindricalBlastWave.yaml
@@ -10,6 +10,13 @@ Evolution:
   TimeStepper: RungeKutta3
 
 PhaseChangeAndTriggers:
+  - - Slabs:
+       EvenlySpaced:
+         # Current implementation checks wallclock at these global syncs
+         Interval: 100
+         Offset: 0
+    - - CheckpointAndExitAfterWallclock:
+          WallclockHours: None
 
 DomainCreator:
   Brick:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -22,6 +22,13 @@ Evolution:
   # InitialSlabSize: 0.01
 
 PhaseChangeAndTriggers:
+  - - Slabs:
+       EvenlySpaced:
+         # Current implementation checks wallclock at these global syncs
+         Interval: 100
+         Offset: 0
+    - - CheckpointAndExitAfterWallclock:
+          WallclockHours: None
 
 DomainCreator:
   Brick:

--- a/tests/Unit/Parallel/PhaseControl/CMakeLists.txt
+++ b/tests/Unit/Parallel/PhaseControl/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_PhaseControl")
 
 set(LIBRARY_SOURCES
+  Test_CheckpointAndExitAfterWallclock.cpp
   Test_ExecutePhaseChange.cpp
   Test_PhaseChange.cpp
   Test_PhaseControlTags.cpp

--- a/tests/Unit/Parallel/PhaseControl/Test_CheckpointAndExitAfterWallclock.cpp
+++ b/tests/Unit/Parallel/PhaseControl/Test_CheckpointAndExitAfterWallclock.cpp
@@ -1,0 +1,144 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <optional>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp"
+#include "Parallel/PhaseControl/PhaseControlTags.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/LogicalTriggers.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+struct Metavariables {
+  using component_list = tmpl::list<>;
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes =
+        tmpl::map<tmpl::pair<Trigger, tmpl::list<Triggers::Always>>>;
+  };
+
+  enum class Phase { PhaseA, WriteCheckpoint, Exit };
+};
+
+SPECTRE_TEST_CASE("Unit.Parallel.PhaseControl.CheckpointAndExitAfterWallclock",
+                  "[Unit][Parallel]") {
+  // note that the `contribute_phase_data_impl` function is currently untested
+  // in this unit test, because we do not have good support for reductions in
+  // the action testing framework.
+  using phase_changes = tmpl::list<
+      PhaseControl::Registrars::CheckpointAndExitAfterWallclock<Metavariables>>;
+
+  const auto created_phase_changes = TestHelpers::test_option_tag<
+      PhaseControl::OptionTags::PhaseChangeAndTriggers<phase_changes>,
+      Metavariables>(
+      " - - Always:\n"
+      "   - - CheckpointAndExitAfterWallclock:\n"
+      "         WallclockHours: 0.0");
+
+  Parallel::GlobalCache<Metavariables> cache{};
+
+  using phase_change_decision_data_type = tuples::tagged_tuple_from_typelist<
+      PhaseControl::get_phase_change_tags<phase_changes>>;
+  phase_change_decision_data_type phase_change_decision_data{
+      Metavariables::Phase::PhaseA, true, 1.0, true};
+
+  const PhaseControl::CheckpointAndExitAfterWallclock<Metavariables>
+      phase_change0(0.0);
+  const PhaseControl::CheckpointAndExitAfterWallclock<Metavariables>
+      phase_change1(1.0);
+  {
+    INFO("Test initialize phase change decision data");
+    phase_change0.initialize_phase_data(
+        make_not_null(&phase_change_decision_data));
+    // extra parens in the check prevent Catch from trying to stream the tuple
+    CHECK((phase_change_decision_data ==
+           phase_change_decision_data_type{std::nullopt, std::nullopt, false,
+                                           true}));
+  }
+  {
+    INFO("Test arbitrate phase control");
+    // Check behavior when a checkpoint-and-exit has been requested
+    // First check case where wallclock time < trigger wallclock time, using
+    // the PhaseChange with a big trigger time.
+    // (this assumes the test doesn't take 1h to get here)
+    phase_change_decision_data =
+        phase_change_decision_data_type{std::nullopt, std::nullopt, true, true};
+    auto decision_result = phase_change1.arbitrate_phase_change(
+        make_not_null(&phase_change_decision_data),
+        Metavariables::Phase::PhaseA, cache);
+    CHECK((decision_result == std::nullopt));
+    CHECK((phase_change_decision_data ==
+           phase_change_decision_data_type{std::nullopt, std::nullopt, false,
+                                           true}));
+
+    // Now check case where wallclock time < trigger wallclock time, using
+    // the PhaseChange with a tiny trigger time.
+    // (this assumes the test takes at least a few cycles to get here)
+    phase_change_decision_data =
+        phase_change_decision_data_type{std::nullopt, std::nullopt, true, true};
+    decision_result = phase_change0.arbitrate_phase_change(
+        make_not_null(&phase_change_decision_data),
+        Metavariables::Phase::PhaseA, cache);
+    CHECK((decision_result ==
+           std::make_pair(
+               Metavariables::Phase::WriteCheckpoint,
+               PhaseControl::ArbitrationStrategy::RunPhaseImmediately)));
+    // It's impossible to know what the elapsed wallclock time will be, so we
+    // check the tags one by one...
+    CHECK((tuples::get<
+               PhaseControl::Tags::RestartPhase<typename Metavariables::Phase>>(
+               phase_change_decision_data) == Metavariables::Phase::PhaseA));
+    // Check recorded time in range: 0 second < time < 1 second
+    // (this assumes test run duration falls in this time window)
+    CHECK(tuples::get<PhaseControl::Tags::WallclockHoursAtCheckpoint>(
+              phase_change_decision_data) > 0.0);
+    const double one_second = 1.0 / 3600.0;
+    CHECK(tuples::get<PhaseControl::Tags::WallclockHoursAtCheckpoint>(
+              phase_change_decision_data) < one_second);
+    CHECK(tuples::get<PhaseControl::Tags::CheckpointAndExitRequested>(
+              phase_change_decision_data) == false);
+
+    // Check behavior following the checkpoint phase
+    // First check case where wallclock time < recorded time, which corresponds
+    // to restarting from a checkpoint.
+    // (this assumes the test doesn't take 1h to get here)
+    phase_change_decision_data = phase_change_decision_data_type{
+        Metavariables::Phase::PhaseA, 1.0, false, true};
+    decision_result = phase_change0.arbitrate_phase_change(
+        make_not_null(&phase_change_decision_data),
+        Metavariables::Phase::WriteCheckpoint, cache);
+    CHECK((decision_result ==
+           std::make_pair(
+               Metavariables::Phase::PhaseA,
+               PhaseControl::ArbitrationStrategy::PermitAdditionalJumps)));
+    CHECK((phase_change_decision_data ==
+           phase_change_decision_data_type{std::nullopt, std::nullopt, false,
+                                           true}));
+
+    // Now check case where wallclock time > recorded time, which corresponds to
+    // having just written a checkpoint. We want to exit now.
+    // (this assumes the test takes at least a few cycles to get here)
+    phase_change_decision_data = phase_change_decision_data_type{
+        Metavariables::Phase::PhaseA, 1e-15, false, true};
+    decision_result = phase_change0.arbitrate_phase_change(
+        make_not_null(&phase_change_decision_data),
+        Metavariables::Phase::WriteCheckpoint, cache);
+    CHECK((decision_result ==
+           std::make_pair(
+               Metavariables::Phase::Exit,
+               PhaseControl::ArbitrationStrategy::RunPhaseImmediately)));
+    CHECK((phase_change_decision_data ==
+           phase_change_decision_data_type{Metavariables::Phase::PhaseA, 1e-15,
+                                           false, true}));
+  }
+}


### PR DESCRIPTION
## Proposed changes

- Add a `CheckpointAndExitAfterWallclock` phase control. This is useful for writing a checkpoint and cleanly terminating a job before it runs out of wallclock time.
- Add this new phase control to all evolution executables. Give example usage in GH and GrMhd input files (but time is set to never write, so will not produce checkpoints in testing). Note: this is a mostly-arbitrary choice on my part, I'm happy to add the input-file triggers on more or fewer input files.
- Add a Tutorial that outlines how to set up checkpoint-restart

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
