### PR TITLE
Make supporting 50th order DG easier

### DIFF
--- a/src/NumericalAlgorithms/Spectral/Spectral.hpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.hpp
@@ -131,17 +131,18 @@ constexpr size_t minimum_number_of_points =
 /*!
  * \brief Maximum number of allowed collocation points.
  *
- * \details We choose a limit of 23 FD grid points because for DG-subcell the
- * number of points in an element is `2 * (number_dg_points - 1)`. Because there
- * is no way of generically retrieving the maximum number of grid points for
- * a non-FD basis, we need to hard-code both values here. If the number of grid
- * points is increased for the non-FD bases, it should also be increased for the
- * FD basis. Note that for good task-based parallelization 23 grid points is
- * already a fairly large number.
+ * \details We choose a limit of 24 FD grid points because for DG-subcell the
+ * number of points in an element is `2 * number_dg_points - 1` for cell
+ * centered, and `2 * number_dg_points` for face-centered. Because there is no
+ * way of generically retrieving the maximum number of grid points for a non-FD
+ * basis, we need to hard-code both values here. If the number of grid points is
+ * increased for the non-FD bases, it should also be increased for the FD basis.
+ * Note that for good task-based parallelization 24 grid points is already a
+ * fairly large number.
  */
 template <Basis basis>
 constexpr size_t maximum_number_of_points =
-    basis == Basis::FiniteDifference ? 23 : 12;
+    basis == Basis::FiniteDifference ? 24 : 12;
 
 /*!
  * \brief Compute the function values of the basis function \f$\Phi_k(x)\f$


### PR DESCRIPTION
## Proposed changes

**Note: mostly whitespace, so I'd suggest using GitHub's "Hide Whitespace" mode**

Sometimes I want to test subcell with one giant element to make sure I don't have any communication-related bugs. For NS evolutions this means I need ~100 FD points per dimension in the cube (not absurd). There are some static caches that do tensor products of the number of grid points, which works fine for like 10-ish grid points, but not so much for 50 grid points. This factors out some `maximum_number_of_points` so I can easily locally override it in the file since that's in code the FD solver doesn't use anyway.

I also increase the number of FD points so we can support 12-th order DG-subcell (not that this is something we'll likely ever _actually_ use)

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
