### PR TITLE
Subcell resize dt(vars) and link IO lib

### DIFF
--- a/src/Evolution/DgSubcell/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/CMakeLists.txt
@@ -49,6 +49,7 @@ target_link_libraries(
   PUBLIC
   DataStructures
   Domain
+  IO
   Spectral
 
   INTERFACE

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
@@ -95,7 +95,8 @@ struct Component {
                  domain::Tags::ElementMap<Dim, Frame::Grid>,
                  domain::CoordinateMaps::Tags::CoordinateMap<Dim, Frame::Grid,
                                                              Frame::Inertial>,
-                 Tags::Variables<tmpl::list<Var1>>>;
+                 Tags::Variables<tmpl::list<Var1>>,
+                 Tags::Variables<tmpl::list<::Tags::dt<Var1>>>>;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       typename Metavariables::Phase, Metavariables::Phase::Initialization,
@@ -200,7 +201,9 @@ void test(const bool always_use_subcell, const bool interior_element) {
       &runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0}, 0,
       {initial_time, dg_mesh, element, clone_unique_ptrs(functions_of_time),
        logical_coords, std::move(logical_to_grid_map),
-       grid_to_inertial_map->get_clone(), var});
+       grid_to_inertial_map->get_clone(), var,
+       Variables<tmpl::list<::Tags::dt<Var1>>>{
+           dg_mesh.number_of_grid_points()}});
   // Invoke the SetupDataBox action on the runner
   ActionTesting::next_action<comp>(make_not_null(&runner), 0);
 


### PR DESCRIPTION
## Proposed changes

- When observing the dt(vars) currently the size is incorrect. This is a deeper bug with us not being able to observe the dt(vars) correctly, but resolving that is a pretty big change.
- DgSubcell has an observation event and so depends on IO

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
