### PR TITLE
Add NewtonianEuler-specialized minmod limiter

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp
@@ -43,15 +43,10 @@ namespace PUP {
 class er;
 }  // namespace PUP
 
-namespace Limiters {
-template <size_t VolumeDim, typename TagsToLimit>
-class Minmod;
-
-namespace Minmod_detail {
+namespace Limiters::Minmod_detail {
 template <size_t VolumeDim>
 class BufferWrapper;
-}  // namespace Minmod_detail
-}  // namespace Limiters
+}  // namespace Limiters::Minmod_detail
 
 namespace domain::Tags {
 template <size_t Dim, typename Frame>
@@ -148,7 +143,10 @@ namespace Limiters {
 /// it to operate on h-refined grids.
 ///
 /// \tparam VolumeDim The number of spatial dimensions.
-/// \tparam Tags A typelist of tags specifying the tensors to limit.
+/// \tparam TagsToLimit A typelist of tags specifying the tensors to limit.
+template <size_t VolumeDim, typename TagsToLimit>
+class Minmod;
+
 template <size_t VolumeDim, typename... Tags>
 class Minmod<VolumeDim, tmpl::list<Tags...>> {
  public:

--- a/src/Evolution/Executables/NewtonianEuler/CMakeLists.txt
+++ b/src/Evolution/Executables/NewtonianEuler/CMakeLists.txt
@@ -48,6 +48,7 @@ set(LIBS_TO_LINK
   NewtonianEuler
   NewtonianEulerAnalyticData
   NewtonianEulerInstantiations
+  NewtonianEulerLimiters
   NewtonianEulerNumericalFluxes
   NewtonianEulerSolutions
   NewtonianEulerSources

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -20,7 +20,6 @@
 #include "Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp"
 #include "Evolution/DiscontinuousGalerkin/Initialization/QuadratureTag.hpp"
 #include "Evolution/DiscontinuousGalerkin/Limiters/LimiterActions.hpp"
-#include "Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp"
 #include "Evolution/DiscontinuousGalerkin/Limiters/Tags.hpp"
 #include "Evolution/EventsAndDenseTriggers/DenseTrigger.hpp"
 #include "Evolution/EventsAndDenseTriggers/DenseTriggers/Factory.hpp"
@@ -34,6 +33,7 @@
 #include "Evolution/Systems/NewtonianEuler/BoundaryConditions/RegisterDerivedWithCharm.hpp"
 #include "Evolution/Systems/NewtonianEuler/BoundaryCorrections/Factory.hpp"
 #include "Evolution/Systems/NewtonianEuler/BoundaryCorrections/RegisterDerived.hpp"
+#include "Evolution/Systems/NewtonianEuler/Limiters/Minmod.hpp"
 #include "Evolution/Systems/NewtonianEuler/SoundSpeedSquared.hpp"
 #include "Evolution/Systems/NewtonianEuler/Sources/NoSource.hpp"
 #include "Evolution/Systems/NewtonianEuler/System.hpp"
@@ -144,10 +144,7 @@ struct EvolutionMetavars {
   static constexpr bool has_source_terms =
       not std::is_same_v<source_term_type, NewtonianEuler::Sources::NoSource>;
 
-  using limiter = Tags::Limiter<Limiters::Minmod<
-      Dim, tmpl::list<NewtonianEuler::Tags::MassDensityCons,
-                      NewtonianEuler::Tags::MomentumDensity<Dim>,
-                      NewtonianEuler::Tags::EnergyDensity>>>;
+  using limiter = Tags::Limiter<NewtonianEuler::Limiters::Minmod<Dim>>;
 
   using time_stepper_tag = Tags::TimeStepper<
       tmpl::conditional_t<local_time_stepping, LtsTimeStepper, TimeStepper>>;

--- a/src/Evolution/Systems/NewtonianEuler/Limiters/CMakeLists.txt
+++ b/src/Evolution/Systems/NewtonianEuler/Limiters/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   CharacteristicHelpers.cpp
   Flattener.cpp
+  Minmod.cpp
   VariablesToLimit.cpp
   )
 
@@ -20,6 +21,7 @@ spectre_target_headers(
   CharacteristicHelpers.hpp
   Flattener.hpp
   KxrcfTci.hpp
+  Minmod.hpp
   VariablesToLimit.hpp
   )
 

--- a/src/Evolution/Systems/NewtonianEuler/Limiters/CMakeLists.txt
+++ b/src/Evolution/Systems/NewtonianEuler/Limiters/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   CharacteristicHelpers.cpp
   Flattener.cpp
+  VariablesToLimit.cpp
   )
 
 spectre_target_headers(
@@ -19,6 +20,7 @@ spectre_target_headers(
   CharacteristicHelpers.hpp
   Flattener.hpp
   KxrcfTci.hpp
+  VariablesToLimit.hpp
   )
 
 target_link_libraries(

--- a/src/Evolution/Systems/NewtonianEuler/Limiters/CharacteristicHelpers.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Limiters/CharacteristicHelpers.cpp
@@ -37,7 +37,7 @@ std::pair<Matrix, Matrix> right_and_left_eigenvectors(
     const Scalar<double>& mean_energy,
     const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
         equation_of_state,
-    const tnsr::i<double, VolumeDim>& unit_normal) noexcept {
+    const tnsr::i<double, VolumeDim>& unit_vector) noexcept {
   // Compute fluid primitives from mean conserved state
   const auto velocity = [&mean_density, &mean_momentum]() noexcept {
     auto result = mean_momentum;
@@ -81,10 +81,10 @@ std::pair<Matrix, Matrix> right_and_left_eigenvectors(
 
   return std::make_pair(right_eigenvectors<VolumeDim>(
                             velocity, sound_speed_squared, specific_enthalpy,
-                            kappa_over_density, unit_normal),
+                            kappa_over_density, unit_vector),
                         left_eigenvectors<VolumeDim>(
                             velocity, sound_speed_squared, specific_enthalpy,
-                            kappa_over_density, unit_normal));
+                            kappa_over_density, unit_vector));
 }
 
 template <size_t VolumeDim>

--- a/src/Evolution/Systems/NewtonianEuler/Limiters/CharacteristicHelpers.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Limiters/CharacteristicHelpers.hpp
@@ -12,11 +12,14 @@
 #include <utility>
 
 #include "DataStructures/Tags.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Evolution/Systems/NewtonianEuler/Characteristics.hpp"
 #include "Evolution/Systems/NewtonianEuler/SoundSpeedSquared.hpp"
 #include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/MeanValue.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -106,5 +109,151 @@ void conserved_fields_from_characteristic_fields(
     const Scalar<DataVector>& char_v_minus,
     const tnsr::I<DataVector, VolumeDim>& char_v_momentum,
     const Scalar<DataVector>& char_v_plus, const Matrix& right) noexcept;
+
+/// \brief Apply a limiter to the characteristic fields computed with respect
+/// to each direction in the volume, then take average of results
+///
+/// When computing the characteristic fields in the volume to pass as inputs to
+/// the limiter, it is not necessarily clear (in more than one dimension) which
+/// unit vector should be used in the characteristic decomposition. This is in
+/// contrast to uses of characteristic fields for, e.g., computing boundary
+/// conditions where the boundary normal provides a clear choice of unit vector.
+//
+/// The common solution to this challenge is to average the results of applying
+/// the limiter with different choices of characteristic decomposition:
+/// - For each direction (e.g. in 3D for each of
+///   \f$(\hat{x}, \hat{y}, \hat{z})\f$), compute the characteristic fields with
+///   respect to this direction. This gives `VolumeDim` sets of characteristic
+///   fields.
+/// - Apply the limiter to each set of characteristic fields, then convert back
+///   to conserved fields. This gives `VolumeDim` different sets of limited
+///   conserved fields.
+/// - Average the new conserved fields; this is the result of the limiting
+///   process.
+///
+/// This function handles the logic of computing the different characteristic
+/// fields, limiting them, converting back to conserved fields, and averaging.
+///
+/// The limiter to apply is passed in via a lambda which is responsible for
+/// converting any neighbor data to the characteristic representation, and then
+/// applying the limiter to all NewtonianEuler characteristic fields.
+template <size_t VolumeDim, size_t ThermodynamicDim, typename LimiterLambda>
+bool apply_limiter_to_characteristic_fields_in_all_directions(
+    const gsl::not_null<Scalar<DataVector>*> mass_density_cons,
+    const gsl::not_null<tnsr::I<DataVector, VolumeDim>*> momentum_density,
+    const gsl::not_null<Scalar<DataVector>*> energy_density,
+    const Mesh<VolumeDim>& mesh,
+    const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
+        equation_of_state,
+    const LimiterLambda& prepare_and_apply_limiter) noexcept {
+  // Temp variables for calculations
+  // There are quite a few tensors in this allocation because in general we need
+  // to preserve the input (cons field) tensors until they are overwritten at
+  // the very end of the computation... then we need additional buffers for the
+  // char fields, the limited cons fields, and the accumulated cons fields for
+  // averaging.
+  //
+  // Possible optimization: specialize the 1D case which doesn't do average so
+  // doesn't need as many buffers
+  Variables<tmpl::list<
+      NewtonianEuler::Tags::VMinus, NewtonianEuler::Tags::VMomentum<VolumeDim>,
+      NewtonianEuler::Tags::VPlus, ::Tags::TempScalar<0>,
+      ::Tags::TempI<0, VolumeDim>, ::Tags::TempScalar<1>, ::Tags::TempScalar<2>,
+      ::Tags::TempI<1, VolumeDim>, ::Tags::TempScalar<3>>>
+      temp_buffer(mesh.number_of_grid_points());
+  auto& char_v_minus = get<NewtonianEuler::Tags::VMinus>(temp_buffer);
+  auto& char_v_momentum =
+      get<NewtonianEuler::Tags::VMomentum<VolumeDim>>(temp_buffer);
+  auto& char_v_plus = get<NewtonianEuler::Tags::VPlus>(temp_buffer);
+  auto& temp_mass_density_cons = get<::Tags::TempScalar<0>>(temp_buffer);
+  auto& temp_momentum_density = get<::Tags::TempI<0, VolumeDim>>(temp_buffer);
+  auto& temp_energy_density = get<::Tags::TempScalar<1>>(temp_buffer);
+  auto& accumulate_mass_density_cons = get<::Tags::TempScalar<2>>(temp_buffer);
+  auto& accumulate_momentum_density =
+      get<::Tags::TempI<1, VolumeDim>>(temp_buffer);
+  auto& accumulate_energy_density = get<::Tags::TempScalar<3>>(temp_buffer);
+
+  // Initialize the accumulating tensors
+  get(accumulate_mass_density_cons) = 0.;
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    accumulate_momentum_density.get(i) = 0.;
+  }
+  get(accumulate_energy_density) = 0.;
+
+  // Cellwise means, used in computing the cons/char transformations
+  const auto mean_density =
+      Scalar<double>{mean_value(get(*mass_density_cons), mesh)};
+  const auto mean_momentum = [&momentum_density, &mesh]() noexcept {
+    tnsr::I<double, VolumeDim> result{};
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      result.get(i) = mean_value(momentum_density->get(i), mesh);
+    }
+    return result;
+  }();
+  const auto mean_energy =
+      Scalar<double>{mean_value(get(*energy_density), mesh)};
+
+  bool some_component_was_limited = false;
+
+  // Loop over directions, then compute chars w.r.t. this direction and limit
+  for (size_t d = 0; d < VolumeDim; ++d) {
+    const auto unit_vector = [&d]() noexcept {
+      auto components = make_array<VolumeDim>(0.);
+      components[d] = 1.;
+      return tnsr::i<double, VolumeDim>(components);
+    }();
+    const auto right_and_left =
+        NewtonianEuler::Limiters::right_and_left_eigenvectors(
+            mean_density, mean_momentum, mean_energy, equation_of_state,
+            unit_vector);
+    const auto& right = right_and_left.first;
+    const auto& left = right_and_left.second;
+
+    // Transform tensors to characteristics
+    NewtonianEuler::Limiters::characteristic_fields(
+        make_not_null(&char_v_minus), make_not_null(&char_v_momentum),
+        make_not_null(&char_v_plus), *mass_density_cons, *momentum_density,
+        *energy_density, left);
+
+    // Transform neighbor data and apply limiter
+    const bool some_component_was_limited_with_this_unit_vector =
+        prepare_and_apply_limiter(make_not_null(&char_v_minus),
+                                  make_not_null(&char_v_momentum),
+                                  make_not_null(&char_v_plus), left);
+
+    some_component_was_limited =
+        some_component_was_limited_with_this_unit_vector or
+        some_component_was_limited;
+
+    // Transform back to conserved variables. But skip the transformation if no
+    // limiting occured with this unit vector.
+    if (some_component_was_limited_with_this_unit_vector) {
+      NewtonianEuler::Limiters::conserved_fields_from_characteristic_fields(
+          make_not_null(&temp_mass_density_cons),
+          make_not_null(&temp_momentum_density),
+          make_not_null(&temp_energy_density), char_v_minus, char_v_momentum,
+          char_v_plus, right);
+    } else {
+      temp_mass_density_cons = *mass_density_cons;
+      temp_momentum_density = *momentum_density;
+      temp_energy_density = *energy_density;
+    }
+
+    // Add to running sum for averaging
+    const double one_over_dim = 1.0 / static_cast<double>(VolumeDim);
+    get(accumulate_mass_density_cons) +=
+        one_over_dim * get(temp_mass_density_cons);
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      accumulate_momentum_density.get(i) +=
+          one_over_dim * temp_momentum_density.get(i);
+    }
+    get(accumulate_energy_density) += one_over_dim * get(temp_energy_density);
+  }  // for loop over dimensions
+
+  *mass_density_cons = accumulate_mass_density_cons;
+  *momentum_density = accumulate_momentum_density;
+  *energy_density = accumulate_energy_density;
+  return some_component_was_limited;
+}
 
 }  // namespace NewtonianEuler::Limiters

--- a/src/Evolution/Systems/NewtonianEuler/Limiters/CharacteristicHelpers.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Limiters/CharacteristicHelpers.hpp
@@ -38,7 +38,7 @@ std::pair<Matrix, Matrix> right_and_left_eigenvectors(
     const Scalar<double>& mean_energy,
     const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
         equation_of_state,
-    const tnsr::i<double, VolumeDim>& unit_normal) noexcept;
+    const tnsr::i<double, VolumeDim>& unit_vector) noexcept;
 
 /// @{
 /// \brief Compute characteristic fields from conserved fields

--- a/src/Evolution/Systems/NewtonianEuler/Limiters/Minmod.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Limiters/Minmod.cpp
@@ -1,0 +1,283 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/NewtonianEuler/Limiters/Minmod.hpp"
+
+#include <array>
+#include <cstdlib>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Evolution/DiscontinuousGalerkin/Limiters/MinmodImpl.hpp"
+#include "Evolution/DiscontinuousGalerkin/Limiters/MinmodType.hpp"
+#include "Evolution/Systems/NewtonianEuler/Limiters/CharacteristicHelpers.hpp"
+#include "Evolution/Systems/NewtonianEuler/Limiters/Flattener.hpp"
+#include "NumericalAlgorithms/LinearOperators/MeanValue.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+
+template <size_t VolumeDim, size_t ThermodynamicDim>
+bool characteristic_minmod_impl(
+    const gsl::not_null<Scalar<DataVector>*> mass_density_cons,
+    const gsl::not_null<tnsr::I<DataVector, VolumeDim>*> momentum_density,
+    const gsl::not_null<Scalar<DataVector>*> energy_density,
+    const Limiters::MinmodType minmod_type, const double tvb_constant,
+    const Mesh<VolumeDim>& mesh, const Element<VolumeDim>& element,
+    const tnsr::I<DataVector, VolumeDim, Frame::Logical>& logical_coords,
+    const std::array<double, VolumeDim>& element_size,
+    const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
+        equation_of_state,
+    const std::unordered_map<
+        std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>,
+        typename NewtonianEuler::Limiters::Minmod<VolumeDim>::PackagedData,
+        boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
+        neighbor_data) noexcept {
+  // Storage for transforming neighbor_data into char variables
+  using CharacteristicVarsMinmod =
+      Limiters::Minmod<VolumeDim,
+                       tmpl::list<NewtonianEuler::Tags::VMinus,
+                                  NewtonianEuler::Tags::VMomentum<VolumeDim>,
+                                  NewtonianEuler::Tags::VPlus>>;
+  std::unordered_map<
+      std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>,
+      typename CharacteristicVarsMinmod::PackagedData,
+      boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>
+      neighbor_char_data{};
+  for (const auto& [key, data] : neighbor_data) {
+    neighbor_char_data[key].element_size = data.element_size;
+  }
+
+  // Buffers for minmod limiter and TCI
+  DataVector u_lin_buffer(mesh.number_of_grid_points());
+  Limiters::Minmod_detail::BufferWrapper<VolumeDim> tci_buffer(mesh);
+
+  // Outer lambda: wraps applying minmod to the NewtonianEuler characteristics
+  // for one particular choice of characteristic decomposition
+  const auto minmod_convert_neighbor_data_then_limit =
+      [&u_lin_buffer, &tci_buffer, &minmod_type, &tvb_constant, &mesh, &element,
+       &logical_coords, &element_size, &neighbor_data, &neighbor_char_data](
+          const gsl::not_null<Scalar<DataVector>*> char_v_minus,
+          const gsl::not_null<tnsr::I<DataVector, VolumeDim>*> char_v_momentum,
+          const gsl::not_null<Scalar<DataVector>*> char_v_plus,
+          const Matrix& left_eigenvectors) noexcept -> bool {
+    // Convert neighbor data to characteristics
+    for (const auto& [key, data] : neighbor_data) {
+      NewtonianEuler::Limiters::characteristic_fields(
+          make_not_null(&(neighbor_char_data[key].means)), data.means,
+          left_eigenvectors);
+    }
+
+    bool some_component_was_limited_with_this_normal = false;
+
+    // Inner lambda: apply minmod to one particular tensor
+    const auto wrap_minmod = [&some_component_was_limited_with_this_normal,
+                              &u_lin_buffer, &tci_buffer, &minmod_type,
+                              &tvb_constant, &mesh, &element, &logical_coords,
+                              &element_size, &neighbor_char_data](
+                                 auto tag, const auto tensor) noexcept {
+      const bool result =
+          Limiters::Minmod_detail::minmod_impl<VolumeDim, decltype(tag)>(
+              &u_lin_buffer, &tci_buffer, tensor, minmod_type, tvb_constant,
+              mesh, element, logical_coords, element_size, neighbor_char_data);
+      some_component_was_limited_with_this_normal =
+          result or some_component_was_limited_with_this_normal;
+    };
+    wrap_minmod(NewtonianEuler::Tags::VMinus{}, char_v_minus);
+    wrap_minmod(NewtonianEuler::Tags::VMomentum<VolumeDim>{}, char_v_momentum);
+    wrap_minmod(NewtonianEuler::Tags::VPlus{}, char_v_plus);
+    return some_component_was_limited_with_this_normal;
+  };
+
+  return NewtonianEuler::Limiters::
+      apply_limiter_to_characteristic_fields_in_all_directions(
+          mass_density_cons, momentum_density, energy_density, mesh,
+          equation_of_state, minmod_convert_neighbor_data_then_limit);
+}
+
+}  // namespace
+
+namespace NewtonianEuler::Limiters {
+
+template <size_t VolumeDim>
+Minmod<VolumeDim>::Minmod(
+    const ::Limiters::MinmodType minmod_type,
+    const NewtonianEuler::Limiters::VariablesToLimit vars_to_limit,
+    const double tvb_constant, const bool apply_flattener,
+    const bool disable_for_debugging) noexcept
+    : minmod_type_(minmod_type),
+      vars_to_limit_(vars_to_limit),
+      tvb_constant_(tvb_constant),
+      apply_flattener_(apply_flattener),
+      disable_for_debugging_(disable_for_debugging),
+      conservative_vars_minmod_(minmod_type_, tvb_constant_,
+                                disable_for_debugging_) {
+  ASSERT(tvb_constant >= 0.0, "The TVB constant must be non-negative.");
+}
+
+template <size_t VolumeDim>
+void Minmod<VolumeDim>::pup(PUP::er& p) noexcept {
+  p | minmod_type_;
+  p | vars_to_limit_;
+  p | tvb_constant_;
+  p | apply_flattener_;
+  p | disable_for_debugging_;
+  p | conservative_vars_minmod_;
+}
+
+template <size_t VolumeDim>
+void Minmod<VolumeDim>::package_data(
+    const gsl::not_null<PackagedData*> packaged_data,
+    const Scalar<DataVector>& mass_density_cons,
+    const tnsr::I<DataVector, VolumeDim>& momentum_density,
+    const Scalar<DataVector>& energy_density, const Mesh<VolumeDim>& mesh,
+    const std::array<double, VolumeDim>& element_size,
+    const OrientationMap<VolumeDim>& orientation_map) const noexcept {
+  conservative_vars_minmod_.package_data(packaged_data, mass_density_cons,
+                                         momentum_density, energy_density, mesh,
+                                         element_size, orientation_map);
+}
+
+template <size_t VolumeDim>
+template <size_t ThermodynamicDim>
+bool Minmod<VolumeDim>::operator()(
+    const gsl::not_null<Scalar<DataVector>*> mass_density_cons,
+    const gsl::not_null<tnsr::I<DataVector, VolumeDim>*> momentum_density,
+    const gsl::not_null<Scalar<DataVector>*> energy_density,
+    const Mesh<VolumeDim>& mesh, const Element<VolumeDim>& element,
+    const tnsr::I<DataVector, VolumeDim, Frame::Logical>& logical_coords,
+    const std::array<double, VolumeDim>& element_size,
+    const Scalar<DataVector>& det_inv_logical_to_inertial_jacobian,
+    const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
+        equation_of_state,
+    const std::unordered_map<
+        std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, PackagedData,
+        boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
+        neighbor_data) const noexcept {
+  if (UNLIKELY(disable_for_debugging_)) {
+    // Do not modify input tensors
+    return false;
+  }
+
+  // Checks for the post-timestep, pre-limiter NewtonianEuler state:
+#ifdef SPECTRE_DEBUG
+  const double mean_density = mean_value(get(*mass_density_cons), mesh);
+  ASSERT(mean_density > 0.0,
+         "Positivity was violated on a cell-average level.");
+  if constexpr (ThermodynamicDim == 2) {
+    const double mean_energy = mean_value(get(*energy_density), mesh);
+    ASSERT(mean_energy > 0.0,
+           "Positivity was violated on a cell-average level.");
+  }
+#endif  // SPECTRE_DEBUG
+
+  bool limiter_activated = false;
+
+  if (vars_to_limit_ == NewtonianEuler::Limiters::VariablesToLimit::Conserved) {
+    limiter_activated = conservative_vars_minmod_(
+        mass_density_cons, momentum_density, energy_density, mesh, element,
+        logical_coords, element_size, neighbor_data);
+  } else if (vars_to_limit_ ==
+             NewtonianEuler::Limiters::VariablesToLimit::Characteristic) {
+    limiter_activated = characteristic_minmod_impl(
+        mass_density_cons, momentum_density, energy_density, minmod_type_,
+        tvb_constant_, mesh, element, logical_coords, element_size,
+        equation_of_state, neighbor_data);
+  } else {
+    ERROR(
+        "No implementation of NewtonianEuler::Limiters::Minmod for variables: "
+        << vars_to_limit_);
+  }
+
+  if (apply_flattener_) {
+    const Scalar<DataVector> det_logical_to_inertial_jacobian{
+        1.0 / get(det_inv_logical_to_inertial_jacobian)};
+    const auto flattener_action = flatten_solution(
+        mass_density_cons, momentum_density, energy_density, mesh,
+        det_logical_to_inertial_jacobian, equation_of_state);
+    if (flattener_action != FlattenerAction::NoOp) {
+      limiter_activated = true;
+    }
+  }
+
+  // Checks for the post-limiter NewtonianEuler state:
+#ifdef SPECTRE_DEBUG
+  ASSERT(min(get(*mass_density_cons)) > 0.0, "Bad density after limiting.");
+  if constexpr (ThermodynamicDim == 2) {
+    const auto specific_internal_energy = Scalar<DataVector>{
+        get(*energy_density) / get(*mass_density_cons) -
+        0.5 * get(dot_product(*momentum_density, *momentum_density)) /
+            square(get(*mass_density_cons))};
+    const auto pressure = equation_of_state.pressure_from_density_and_energy(
+        *mass_density_cons, specific_internal_energy);
+    ASSERT(min(get(pressure)) > 0.0, "Bad pressure after limiting.");
+  }
+#endif  // SPECTRE_DEBUG
+
+  return limiter_activated;
+}
+
+template <size_t LocalDim>
+bool operator==(const Minmod<LocalDim>& lhs,
+                const Minmod<LocalDim>& rhs) noexcept {
+  // No need to compare the conservative_vars_minmod_ member variable because
+  // it is constructed from the other member variables.
+  return lhs.minmod_type_ == rhs.minmod_type_ and
+         lhs.vars_to_limit_ == rhs.vars_to_limit_ and
+         lhs.tvb_constant_ == rhs.tvb_constant_ and
+         lhs.apply_flattener_ == rhs.apply_flattener_ and
+         lhs.disable_for_debugging_ == rhs.disable_for_debugging_;
+}
+
+template <size_t VolumeDim>
+bool operator!=(const Minmod<VolumeDim>& lhs,
+                const Minmod<VolumeDim>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                          \
+  template class Minmod<DIM(data)>;                   \
+  template bool operator==(const Minmod<DIM(data)>&,  \
+                           const Minmod<DIM(data)>&); \
+  template bool operator!=(const Minmod<DIM(data)>&, const Minmod<DIM(data)>&);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+
+#define INSTANTIATE(_, data)                                                   \
+  template bool Minmod<DIM(data)>::operator()(                                 \
+      const gsl::not_null<Scalar<DataVector>*>,                                \
+      const gsl::not_null<tnsr::I<DataVector, DIM(data)>*>,                    \
+      const gsl::not_null<Scalar<DataVector>*>, const Mesh<DIM(data)>&,        \
+      const Element<DIM(data)>&,                                               \
+      const tnsr::I<DataVector, DIM(data), Frame::Logical>&,                   \
+      const std::array<double, DIM(data)>&, const Scalar<DataVector>&,         \
+      const EquationsOfState::EquationOfState<false, THERMO_DIM(data)>&,       \
+      const std::unordered_map<                                                \
+          std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>, PackagedData, \
+          boost::hash<                                                         \
+              std::pair<Direction<DIM(data)>, ElementId<DIM(data)>>>>&)        \
+      const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (1, 2))
+
+#undef INSTANTIATE
+#undef DIM
+#undef THERMO_DIM
+
+}  // namespace NewtonianEuler::Limiters

--- a/src/Evolution/Systems/NewtonianEuler/Limiters/Minmod.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Limiters/Minmod.hpp
@@ -1,0 +1,190 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstdlib>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/Tags.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp"
+#include "Evolution/DiscontinuousGalerkin/Limiters/MinmodType.hpp"
+#include "Evolution/DiscontinuousGalerkin/Limiters/Tags.hpp"
+#include "Evolution/Systems/NewtonianEuler/Limiters/VariablesToLimit.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+template <size_t VolumeDim>
+class Direction;
+template <size_t VolumeDim>
+class Element;
+template <size_t VolumeDim>
+class ElementId;
+template <size_t VolumeDim>
+class Mesh;
+template <size_t VolumeDim>
+class OrientationMap;
+
+namespace boost {
+template <class T>
+struct hash;
+}  // namespace boost
+
+namespace PUP {
+class er;
+}  // namespace PUP
+
+namespace domain {
+namespace Tags {
+template <size_t Dim, typename Frame>
+struct Coordinates;
+template <size_t VolumeDim>
+struct Element;
+template <size_t VolumeDim>
+struct Mesh;
+template <size_t VolumeDim>
+struct SizeOfElement;
+}  // namespace Tags
+}  // namespace domain
+/// \endcond
+
+namespace NewtonianEuler {
+namespace Limiters {
+
+/// \ingroup LimitersGroup
+/// \brief A minmod-based generalized slope limiter for the NewtonianEuler
+/// system.
+///
+/// Implements the three minmod-based generalized slope limiters from
+/// \cite Cockburn1999 Sec. 2.4: \f$\Lambda\Pi^1\f$, \f$\Lambda\Pi^N\f$, and
+/// MUSCL. See the documentation of the system-agnostic ::Limiters::Minmod
+/// limiter for a general discussion of the algorithm and the various options
+/// that control the action of the limiter.
+///
+/// This implemention is specialized to the NewtonianEuler evolution system.
+/// By specializing the limiter to the system, we can add two features that
+/// improve its robustness:
+/// - the limiter can be applied to the system's characteristic variables. This
+///   is the recommendation of the reference, because it reduces spurious
+///   oscillations in the post-limiter solution.
+/// - after limiting, the solution can be processed to remove any remaining
+///   unphysical values like negative densities and pressures. We do this by
+///   scaling the solution around its mean (a "flattener" or "bounds-preserving"
+///   filter). Note: the flattener is applied to all elements, including those
+///   where the limiter did not act to reduce the solution's slopes.
+template <size_t VolumeDim>
+class Minmod {
+ public:
+  using ConservativeVarsMinmod = ::Limiters::Minmod<
+      VolumeDim, tmpl::list<NewtonianEuler::Tags::MassDensityCons,
+                            NewtonianEuler::Tags::MomentumDensity<VolumeDim>,
+                            NewtonianEuler::Tags::EnergyDensity>>;
+
+  struct VariablesToLimit {
+    using type = NewtonianEuler::Limiters::VariablesToLimit;
+    static type suggested_value() noexcept {
+      return NewtonianEuler::Limiters::VariablesToLimit::Characteristic;
+    }
+    static constexpr Options::String help = {
+        "Variable representation on which to apply the limiter"};
+  };
+  struct ApplyFlattener {
+    using type = bool;
+    static constexpr Options::String help = {
+        "Flatten after limiting to restore pointwise positivity"};
+  };
+  using options =
+      tmpl::list<typename ConservativeVarsMinmod::Type, VariablesToLimit,
+                 typename ConservativeVarsMinmod::TvbConstant, ApplyFlattener,
+                 typename ConservativeVarsMinmod::DisableForDebugging>;
+  static constexpr Options::String help = {
+      "A Minmod limiter specialized to the NewtonianEuler system"};
+  static std::string name() noexcept { return "NewtonianEulerMinmod"; };
+
+  explicit Minmod(::Limiters::MinmodType minmod_type,
+                  NewtonianEuler::Limiters::VariablesToLimit vars_to_limit,
+                  double tvb_constant, bool apply_flattener,
+                  bool disable_for_debugging = false) noexcept;
+
+  Minmod() noexcept = default;
+  Minmod(const Minmod& /*rhs*/) = default;
+  Minmod& operator=(const Minmod& /*rhs*/) = default;
+  Minmod(Minmod&& /*rhs*/) noexcept = default;
+  Minmod& operator=(Minmod&& /*rhs*/) noexcept = default;
+  ~Minmod() = default;
+
+  // clang-tidy: google-runtime-references
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+  using PackagedData = typename ConservativeVarsMinmod::PackagedData;
+  using package_argument_tags =
+      typename ConservativeVarsMinmod::package_argument_tags;
+
+  /// \brief Package data for sending to neighbor elements.
+  void package_data(
+      gsl::not_null<PackagedData*> packaged_data,
+      const Scalar<DataVector>& mass_density_cons,
+      const tnsr::I<DataVector, VolumeDim>& momentum_density,
+      const Scalar<DataVector>& energy_density, const Mesh<VolumeDim>& mesh,
+      const std::array<double, VolumeDim>& element_size,
+      const OrientationMap<VolumeDim>& orientation_map) const noexcept;
+
+  using limit_tags =
+      tmpl::list<NewtonianEuler::Tags::MassDensityCons,
+                 NewtonianEuler::Tags::MomentumDensity<VolumeDim>,
+                 NewtonianEuler::Tags::EnergyDensity>;
+  using limit_argument_tags =
+      tmpl::list<domain::Tags::Mesh<VolumeDim>,
+                 domain::Tags::Element<VolumeDim>,
+                 domain::Tags::Coordinates<VolumeDim, Frame::Logical>,
+                 domain::Tags::SizeOfElement<VolumeDim>,
+                 domain::Tags::DetInvJacobian<Frame::Logical, Frame::Inertial>,
+                 ::hydro::Tags::EquationOfStateBase>;
+
+  /// \brief Limits the solution on the element.
+  template <size_t ThermodynamicDim>
+  bool operator()(
+      gsl::not_null<Scalar<DataVector>*> mass_density_cons,
+      gsl::not_null<tnsr::I<DataVector, VolumeDim>*> momentum_density,
+      gsl::not_null<Scalar<DataVector>*> energy_density,
+      const Mesh<VolumeDim>& mesh, const Element<VolumeDim>& element,
+      const tnsr::I<DataVector, VolumeDim, Frame::Logical>& logical_coords,
+      const std::array<double, VolumeDim>& element_size,
+      const Scalar<DataVector>& det_inv_logical_to_inertial_jacobian,
+      const EquationsOfState::EquationOfState<false, ThermodynamicDim>&
+          equation_of_state,
+      const std::unordered_map<
+          std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, PackagedData,
+          boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
+          neighbor_data) const noexcept;
+
+ private:
+  template <size_t LocalDim>
+  // NOLINTNEXTLINE(readability-redundant-declaration) false positive
+  friend bool operator==(const Minmod<LocalDim>& lhs,
+                         const Minmod<LocalDim>& rhs) noexcept;
+
+  ::Limiters::MinmodType minmod_type_;
+  NewtonianEuler::Limiters::VariablesToLimit vars_to_limit_;
+  double tvb_constant_;
+  bool apply_flattener_;
+  bool disable_for_debugging_;
+  ConservativeVarsMinmod conservative_vars_minmod_;
+};
+
+template <size_t VolumeDim>
+bool operator!=(const Minmod<VolumeDim>& lhs,
+                const Minmod<VolumeDim>& rhs) noexcept;
+
+}  // namespace Limiters
+}  // namespace NewtonianEuler

--- a/src/Evolution/Systems/NewtonianEuler/Limiters/VariablesToLimit.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Limiters/VariablesToLimit.cpp
@@ -1,0 +1,43 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/NewtonianEuler/Limiters/VariablesToLimit.hpp"
+
+#include <ostream>
+#include <string>
+
+#include "Options/Options.hpp"
+#include "Options/ParseOptions.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+
+std::ostream& NewtonianEuler::Limiters::operator<<(
+    std::ostream& os,
+    const NewtonianEuler::Limiters::VariablesToLimit vars_to_limit) noexcept {
+  switch (vars_to_limit) {
+    case NewtonianEuler::Limiters::VariablesToLimit::Conserved:
+      return os << "Conserved";
+    case NewtonianEuler::Limiters::VariablesToLimit::Characteristic:
+      return os << "Characteristic";
+    default:  // LCOV_EXCL_LINE
+      // LCOV_EXCL_START
+      ERROR("Missing a case for operator<<(VariablesToLimit)");
+      // LCOV_EXCL_STOP
+  }
+}
+
+template <>
+NewtonianEuler::Limiters::VariablesToLimit
+Options::create_from_yaml<NewtonianEuler::Limiters::VariablesToLimit>::create<
+    void>(const Options::Option& options) {
+  const auto vars_to_limit_read_type = options.parse_as<std::string>();
+  if (vars_to_limit_read_type == "Conserved") {
+    return NewtonianEuler::Limiters::VariablesToLimit::Conserved;
+  } else if (vars_to_limit_read_type == "Characteristic") {
+    return NewtonianEuler::Limiters::VariablesToLimit::Characteristic;
+  }
+  PARSE_ERROR(options.context(),
+              "Failed to convert \""
+                  << vars_to_limit_read_type
+                  << "\" to VariablesToLimit. Expected one of: "
+                     "{Conserved, Characteristic}.");
+}

--- a/src/Evolution/Systems/NewtonianEuler/Limiters/VariablesToLimit.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Limiters/VariablesToLimit.hpp
@@ -1,0 +1,39 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <ostream>
+
+/// \cond
+namespace Options {
+class Option;
+template <typename T>
+struct create_from_yaml;
+}  // namespace Options
+/// \endcond
+
+namespace NewtonianEuler {
+namespace Limiters {
+/// \ingroup LimitersGroup
+/// \brief Type of NewtonianEuler variables to apply limiter to
+enum class VariablesToLimit { Conserved, Characteristic };
+
+std::ostream& operator<<(std::ostream& os,
+                         VariablesToLimit vars_to_limit) noexcept;
+}  // namespace Limiters
+}  // namespace NewtonianEuler
+
+template <>
+struct Options::create_from_yaml<NewtonianEuler::Limiters::VariablesToLimit> {
+  template <typename Metavariables>
+  static NewtonianEuler::Limiters::VariablesToLimit create(
+      const Options::Option& options) {
+    return create<void>(options);
+  }
+};
+
+template <>
+NewtonianEuler::Limiters::VariablesToLimit
+Options::create_from_yaml<NewtonianEuler::Limiters::VariablesToLimit>::create<
+    void>(const Options::Option& options);

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
@@ -43,11 +43,13 @@ AnalyticSolution:
     PressureStarTol: 1e-9
 
 Limiter:
-  Minmod:
+  NewtonianEulerMinmod:
     Type: LambdaPiN
+    VariablesToLimit: Characteristic
     # The optimal value of the TVB constant is problem-dependent.
     # This test uses 0 to favor robustness over accuracy.
     TvbConstant: 0.0
+    ApplyFlattener: true
     DisableForDebugging: false
 
 EventsAndTriggers:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
@@ -41,11 +41,13 @@ AnalyticSolution:
     PressureStarTol: 1e-9
 
 Limiter:
-  Minmod:
+  NewtonianEulerMinmod:
     Type: LambdaPiN
+    VariablesToLimit: Characteristic
     # The optimal value of the TVB constant is problem-dependent.
     # This test uses 0 to favor robustness over accuracy.
     TvbConstant: 0.0
+    ApplyFlattener: true
     DisableForDebugging: false
 
 EventsAndTriggers:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
@@ -41,11 +41,13 @@ AnalyticSolution:
     PressureStarTol: 1e-9
 
 Limiter:
-  Minmod:
+  NewtonianEulerMinmod:
     Type: LambdaPiN
+    VariablesToLimit: Characteristic
     # The optimal value of the TVB constant is problem-dependent.
     # This test uses 0 to favor robustness over accuracy.
     TvbConstant: 0.0
+    ApplyFlattener: true
     DisableForDebugging: false
 
 EventsAndTriggers:

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_CharacteristicHelpers.cpp
   Test_Flattener.cpp
   Test_KxrcfTci.cpp
+  Test_Minmod.cpp
   Test_VariablesToLimit.cpp
   )
 

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_CharacteristicHelpers.cpp
   Test_Flattener.cpp
   Test_KxrcfTci.cpp
+  Test_VariablesToLimit.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/Test_CharacteristicHelpers.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/Test_CharacteristicHelpers.cpp
@@ -31,21 +31,21 @@ void test_characteristic_helpers() noexcept {
   const auto nn_distribution = make_not_null(&distribution);
   const auto nn_distribution_positive = make_not_null(&distribution_positive);
 
-  // This computes a unit normal. It is NOT uniformly distributed in angle,
+  // This computes a unit vector. It is NOT uniformly distributed in angle,
   // but for this test the angular distribution is not important.
-  const auto unit_normal = [&nn_generator, &nn_distribution]() noexcept {
+  const auto unit_vector = [&nn_generator, &nn_distribution]() noexcept {
     const double double_used_for_size = 0.;
     auto result = make_with_random_values<tnsr::i<double, Dim>>(
         nn_generator, nn_distribution, double_used_for_size);
-    double normal_magnitude = get(magnitude(result));
-    // Though highly unlikely, the normal could have length nearly 0. If this
-    // happens, we edit the normal to make it non-zero.
-    if (normal_magnitude < 1e-3) {
+    double vector_magnitude = get(magnitude(result));
+    // Though highly unlikely, the vector could have length nearly 0. If this
+    // happens, we edit the vector to make it non-zero.
+    if (vector_magnitude < 1e-3) {
       get<0>(result) += 0.9;
-      normal_magnitude = get(magnitude(result));
+      vector_magnitude = get(magnitude(result));
     }
     for (auto& n_i : result) {
-      n_i /= normal_magnitude;
+      n_i /= vector_magnitude;
     }
     return result;
   }();
@@ -95,7 +95,7 @@ void test_characteristic_helpers() noexcept {
   const auto right_and_left =
       NewtonianEuler::Limiters::right_and_left_eigenvectors<Dim>(
           mean_mass_density, mean_momentum_density, mean_energy_density,
-          equation_of_state, unit_normal);
+          equation_of_state, unit_vector);
   const auto& right = right_and_left.first;
   const auto& left = right_and_left.second;
 

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/Test_Minmod.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/Test_Minmod.cpp
@@ -1,0 +1,629 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <boost/functional/hash.hpp>
+#include <cstddef>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tags.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/SizeOfElement.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Evolution/DiscontinuousGalerkin/Limiters/Minmod.hpp"
+#include "Evolution/DiscontinuousGalerkin/Limiters/MinmodImpl.hpp"
+#include "Evolution/DiscontinuousGalerkin/Limiters/MinmodType.hpp"
+#include "Evolution/Systems/NewtonianEuler/Limiters/CharacteristicHelpers.hpp"
+#include "Evolution/Systems/NewtonianEuler/Limiters/Minmod.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/Limiters/TestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+
+void test_neuler_minmod_option_parsing() noexcept {
+  INFO("Testing option parsing");
+  const auto lambda_pi1 =
+      TestHelpers::test_creation<NewtonianEuler::Limiters::Minmod<1>>(
+          "Type: LambdaPi1\n"
+          "VariablesToLimit: Characteristic\n"
+          "TvbConstant: 0.0\n"
+          "ApplyFlattener: True\n"
+          "DisableForDebugging: False");
+  const auto lambda_pi1_cons =
+      TestHelpers::test_creation<NewtonianEuler::Limiters::Minmod<1>>(
+          "Type: LambdaPi1\n"
+          "VariablesToLimit: Conserved\n"
+          "TvbConstant: 0.0\n"
+          "ApplyFlattener: True\n"
+          "DisableForDebugging: False");
+  const auto lambda_pi1_tvb =
+      TestHelpers::test_creation<NewtonianEuler::Limiters::Minmod<1>>(
+          "Type: LambdaPi1\n"
+          "VariablesToLimit: Characteristic\n"
+          "TvbConstant: 1.0\n"
+          "ApplyFlattener: True\n"
+          "DisableForDebugging: False");
+  const auto lambda_pi1_noflat =
+      TestHelpers::test_creation<NewtonianEuler::Limiters::Minmod<1>>(
+          "Type: LambdaPi1\n"
+          "VariablesToLimit: Characteristic\n"
+          "TvbConstant: 0.0\n"
+          "ApplyFlattener: False\n"
+          "DisableForDebugging: False");
+  const auto lambda_pi1_disabled =
+      TestHelpers::test_creation<NewtonianEuler::Limiters::Minmod<1>>(
+          "Type: LambdaPi1\n"
+          "VariablesToLimit: Characteristic\n"
+          "TvbConstant: 0.0\n"
+          "ApplyFlattener: True\n"
+          "DisableForDebugging: True");
+  const auto muscl =
+      TestHelpers::test_creation<NewtonianEuler::Limiters::Minmod<1>>(
+          "Type: Muscl\n"
+          "VariablesToLimit: Characteristic\n"
+          "TvbConstant: 0.0\n"
+          "ApplyFlattener: True\n"
+          "DisableForDebugging: False");
+
+  // Test operators == and !=
+  CHECK(lambda_pi1 == lambda_pi1);
+  CHECK(lambda_pi1 != lambda_pi1_cons);
+  CHECK(lambda_pi1 != lambda_pi1_tvb);
+  CHECK(lambda_pi1 != lambda_pi1_noflat);
+  CHECK(lambda_pi1 != lambda_pi1_disabled);
+  CHECK(lambda_pi1 != muscl);
+
+  const auto lambda_pin_2d =
+      TestHelpers::test_creation<NewtonianEuler::Limiters::Minmod<2>>(
+          "Type: LambdaPiN\n"
+          "VariablesToLimit: Characteristic\n"
+          "TvbConstant: 0.0\n"
+          "ApplyFlattener: True\n"
+          "DisableForDebugging: False");
+  const auto lambda_pin_3d =
+      TestHelpers::test_creation<NewtonianEuler::Limiters::Minmod<3>>(
+          "Type: LambdaPiN\n"
+          "VariablesToLimit: Characteristic\n"
+          "TvbConstant: 10.0\n"
+          "ApplyFlattener: True\n"
+          "DisableForDebugging: False");
+
+  // Test that creation from options gives correct object
+  const NewtonianEuler::Limiters::Minmod<1> expected_lambda_pi1(
+      Limiters::MinmodType::LambdaPi1,
+      NewtonianEuler::Limiters::VariablesToLimit::Characteristic, 0., true);
+  const NewtonianEuler::Limiters::Minmod<1> expected_lambda_pi1_cons(
+      Limiters::MinmodType::LambdaPi1,
+      NewtonianEuler::Limiters::VariablesToLimit::Conserved, 0., true);
+  const NewtonianEuler::Limiters::Minmod<1> expected_lambda_pi1_tvb(
+      Limiters::MinmodType::LambdaPi1,
+      NewtonianEuler::Limiters::VariablesToLimit::Characteristic, 1., true);
+  const NewtonianEuler::Limiters::Minmod<1> expected_lambda_pi1_noflat(
+      Limiters::MinmodType::LambdaPi1,
+      NewtonianEuler::Limiters::VariablesToLimit::Characteristic, 0., false);
+  const NewtonianEuler::Limiters::Minmod<1> expected_lambda_pi1_disabled(
+      Limiters::MinmodType::LambdaPi1,
+      NewtonianEuler::Limiters::VariablesToLimit::Characteristic, 0., true,
+      true);
+  const NewtonianEuler::Limiters::Minmod<1> expected_muscl(
+      Limiters::MinmodType::Muscl,
+      NewtonianEuler::Limiters::VariablesToLimit::Characteristic, 0., true);
+  const NewtonianEuler::Limiters::Minmod<2> expected_lambda_pin_2d(
+      Limiters::MinmodType::LambdaPiN,
+      NewtonianEuler::Limiters::VariablesToLimit::Characteristic, 0., true);
+  const NewtonianEuler::Limiters::Minmod<3> expected_lambda_pin_3d(
+      Limiters::MinmodType::LambdaPiN,
+      NewtonianEuler::Limiters::VariablesToLimit::Characteristic, 10., true);
+
+  CHECK(lambda_pi1 == expected_lambda_pi1);
+  CHECK(lambda_pi1_cons == expected_lambda_pi1_cons);
+  CHECK(lambda_pi1_tvb == expected_lambda_pi1_tvb);
+  CHECK(lambda_pi1_noflat == expected_lambda_pi1_noflat);
+  CHECK(lambda_pi1_disabled == expected_lambda_pi1_disabled);
+  CHECK(muscl == expected_muscl);
+  CHECK(lambda_pin_2d == expected_lambda_pin_2d);
+  CHECK(lambda_pin_3d == expected_lambda_pin_3d);
+}
+
+void test_neuler_minmod_serialization() noexcept {
+  INFO("Testing serialization");
+  const NewtonianEuler::Limiters::Minmod<1> minmod(
+      Limiters::MinmodType::LambdaPi1,
+      NewtonianEuler::Limiters::VariablesToLimit::Characteristic, 1., true);
+  test_serialization(minmod);
+}
+
+// Compare the specialized limiter to the generic limiter. The limiters are
+// compared for limiting conserved/evolved and limiting characteristic
+// variables.
+//
+// Note: comparing the specialized and generic limiters when limiting the
+// characteristic variables is tedious to do thoroughly, because we need to
+// call the generic limiter multiple times using characteristic fields w.r.t.
+// multiple different unit vectors. In essence, the test would need to fully
+// reimplement the specialized limiter. To avoid the test becoming so tedious,
+// we test a simpler restricted problem, where in 2D and 3D we require
+// input_momentum to be 0. With this simplification, the characteristic
+// decomposition becomes independent of the choice of unit vector, and therefore
+// the generic limiter can match the specialized limiter even when only one set
+// of characteristic (e.g., w.r.t. \hat{x}) is used.
+template <size_t VolumeDim>
+void test_neuler_vs_generic_minmod_work(
+    const Scalar<DataVector>& input_density,
+    const tnsr::I<DataVector, VolumeDim>& input_momentum,
+    const Scalar<DataVector>& input_energy, const Mesh<VolumeDim>& mesh,
+    const tnsr::I<DataVector, VolumeDim, Frame::Logical>& logical_coords,
+    const std::array<double, VolumeDim>& element_size,
+    const Scalar<DataVector>& det_inv_logical_to_inertial_jacobian,
+    const std::unordered_map<
+        std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>,
+        typename NewtonianEuler::Limiters::Minmod<VolumeDim>::PackagedData,
+        boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
+        neighbor_data) noexcept {
+  // Sanity check that input momentum satisfies simplifying assumptions
+  if constexpr (VolumeDim > 1) {
+    const auto zero_momentum = make_with_value<tnsr::I<DataVector, VolumeDim>>(
+        get<0>(input_momentum), 0.);
+    REQUIRE(input_momentum == zero_momentum);
+  }
+
+  const double tvb_constant = 0.;
+  const auto element = TestHelpers::Limiters::make_element<VolumeDim>();
+  const EquationsOfState::IdealFluid<false> equation_of_state{5. / 3.};
+
+  {
+    INFO("Compare specialized vs generic Minmod on conserved variables");
+    auto density_generic = input_density;
+    auto momentum_generic = input_momentum;
+    auto energy_generic = input_energy;
+    const Limiters::Minmod<
+        VolumeDim, tmpl::list<NewtonianEuler::Tags::MassDensityCons,
+                              NewtonianEuler::Tags::MomentumDensity<VolumeDim>,
+                              NewtonianEuler::Tags::EnergyDensity>>
+        minmod_generic(Limiters::MinmodType::LambdaPi1, tvb_constant);
+    const bool activated_generic = minmod_generic(
+        make_not_null(&density_generic), make_not_null(&momentum_generic),
+        make_not_null(&energy_generic), mesh, element, logical_coords,
+        element_size, neighbor_data);
+
+    auto density_specialized = input_density;
+    auto momentum_specialized = input_momentum;
+    auto energy_specialized = input_energy;
+    const auto vars_to_limit =
+        NewtonianEuler::Limiters::VariablesToLimit::Conserved;
+    const bool apply_flattener = false;
+    const NewtonianEuler::Limiters::Minmod<VolumeDim> minmod_specialized(
+        Limiters::MinmodType::LambdaPi1, vars_to_limit, tvb_constant,
+        apply_flattener);
+    const bool activated_specialized = minmod_specialized(
+        make_not_null(&density_specialized),
+        make_not_null(&momentum_specialized),
+        make_not_null(&energy_specialized), mesh, element, logical_coords,
+        element_size, det_inv_logical_to_inertial_jacobian, equation_of_state,
+        neighbor_data);
+
+    CHECK(activated_generic);
+    CHECK(activated_generic == activated_specialized);
+    CHECK_ITERABLE_APPROX(density_generic, density_specialized);
+    CHECK_ITERABLE_APPROX(momentum_generic, momentum_specialized);
+    CHECK_ITERABLE_APPROX(energy_generic, energy_specialized);
+  }
+
+  {
+    INFO("Compare specialized vs generic Minmod on characteristic variables");
+    // Cellwise means, for cons/char transforms
+    const auto mean_density =
+        Scalar<double>{mean_value(get(input_density), mesh)};
+    const auto mean_momentum = [&input_momentum, &mesh]() noexcept {
+      tnsr::I<double, VolumeDim> result{};
+      for (size_t i = 0; i < VolumeDim; ++i) {
+        result.get(i) = mean_value(input_momentum.get(i), mesh);
+      }
+      return result;
+    }();
+    const auto mean_energy =
+        Scalar<double>{mean_value(get(input_energy), mesh)};
+
+    // Compute characteristic transformation using x-direction...
+    // Note that in 2D and 3D we know the fluid velocity is 0, so this choice
+    // is arbitrary in these higher dimensions.
+    const auto unit_vector = []() noexcept {
+      auto components = make_array<VolumeDim>(0.);
+      components[0] = 1.;
+      return tnsr::i<double, VolumeDim>(components);
+    }();
+    const auto right_and_left =
+        NewtonianEuler::Limiters::right_and_left_eigenvectors(
+            mean_density, mean_momentum, mean_energy, equation_of_state,
+            unit_vector);
+    const auto& right = right_and_left.first;
+    const auto& left = right_and_left.second;
+
+    // Transform tensors to characteristics
+    auto char_v_minus = input_density;
+    auto char_v_momentum = input_momentum;
+    auto char_v_plus = input_energy;
+    NewtonianEuler::Limiters::characteristic_fields(
+        make_not_null(&char_v_minus), make_not_null(&char_v_momentum),
+        make_not_null(&char_v_plus), input_density, input_momentum,
+        input_energy, left);
+
+    using GenericMinmod =
+        Limiters::Minmod<VolumeDim,
+                         tmpl::list<NewtonianEuler::Tags::VMinus,
+                                    NewtonianEuler::Tags::VMomentum<VolumeDim>,
+                                    NewtonianEuler::Tags::VPlus>>;
+    std::unordered_map<
+        std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>,
+        typename GenericMinmod::PackagedData,
+        boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>
+        neighbor_char_data{};
+    for (const auto& [key, data] : neighbor_data) {
+      neighbor_char_data[key].element_size = data.element_size;
+      NewtonianEuler::Limiters::characteristic_fields(
+          make_not_null(&(neighbor_char_data[key].means)), data.means, left);
+    }
+
+    const GenericMinmod minmod_generic(Limiters::MinmodType::LambdaPi1,
+                                       tvb_constant);
+    const bool activated_generic = minmod_generic(
+        make_not_null(&char_v_minus), make_not_null(&char_v_momentum),
+        make_not_null(&char_v_plus), mesh, element, logical_coords,
+        element_size, neighbor_char_data);
+
+    // Transform back to evolved variables
+    // Note that because the fluid velocity is 0 and all sets of characteristics
+    // are identical, we can skip the step of combining different limiter
+    // results.
+    auto density_generic = input_density;
+    auto momentum_generic = input_momentum;
+    auto energy_generic = input_energy;
+    NewtonianEuler::Limiters::conserved_fields_from_characteristic_fields(
+        make_not_null(&density_generic), make_not_null(&momentum_generic),
+        make_not_null(&energy_generic), char_v_minus, char_v_momentum,
+        char_v_plus, right);
+
+    auto density_specialized = input_density;
+    auto momentum_specialized = input_momentum;
+    auto energy_specialized = input_energy;
+    const auto vars_to_limit =
+        NewtonianEuler::Limiters::VariablesToLimit::Characteristic;
+    const bool apply_flattener = false;
+    const NewtonianEuler::Limiters::Minmod<VolumeDim> minmod_specialized(
+        Limiters::MinmodType::LambdaPi1, vars_to_limit, tvb_constant,
+        apply_flattener);
+    const bool activated_specialized = minmod_specialized(
+        make_not_null(&density_specialized),
+        make_not_null(&momentum_specialized),
+        make_not_null(&energy_specialized), mesh, element, logical_coords,
+        element_size, det_inv_logical_to_inertial_jacobian, equation_of_state,
+        neighbor_data);
+
+    CHECK(activated_generic);
+    CHECK(activated_generic == activated_specialized);
+    CHECK_ITERABLE_APPROX(density_generic, density_specialized);
+    CHECK_ITERABLE_APPROX(momentum_generic, momentum_specialized);
+    CHECK_ITERABLE_APPROX(energy_generic, energy_specialized);
+  }
+}
+
+void test_neuler_vs_generic_minmod_1d() noexcept {
+  INFO("Testing NewtonianEuler::Limiters::Minmod limiter in 1D");
+  const auto mesh =
+      Mesh<1>(3, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto);
+  const auto element = TestHelpers::Limiters::make_element<1>();
+  const auto logical_coords = logical_coordinates(mesh);
+  using Affine = domain::CoordinateMaps::Affine;
+  const Affine xi_map{-1., 1., 3.7, 4.2};
+  const auto coordmap =
+      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(xi_map);
+  const ElementMap<1, Frame::Inertial> element_map(element.id(),
+                                                   coordmap->get_clone());
+  const auto element_size = size_of_element(element_map);
+  const auto det_inv_logical_to_inertial_jacobian =
+      determinant(element_map.inv_jacobian(logical_coords));
+
+  const auto& x = get<0>(logical_coords);
+  const auto mass_density_cons = [&x]() noexcept {
+    return Scalar<DataVector>{{{1. + 0.2 * x + 0.05 * square(x)}}};
+  }();
+  const auto momentum_density = [&x]() noexcept {
+    return tnsr::I<DataVector, 1>{{{0.2 - 0.3 * x}}};
+  }();
+  const auto energy_density = [&mesh]() noexcept {
+    return Scalar<DataVector>{DataVector(mesh.number_of_grid_points(), 1.)};
+  }();
+
+  std::unordered_map<std::pair<Direction<1>, ElementId<1>>,
+                     NewtonianEuler::Limiters::Minmod<1>::PackagedData,
+                     boost::hash<std::pair<Direction<1>, ElementId<1>>>>
+      neighbor_data{};
+  const std::array<std::pair<Direction<1>, ElementId<1>>, 2> dir_keys = {
+      {{Direction<1>::lower_xi(), ElementId<1>(1)},
+       {Direction<1>::upper_xi(), ElementId<1>(2)}}};
+  for (const auto& dir_key : dir_keys) {
+    neighbor_data[dir_key].element_size = element_size;
+  }
+
+  using mean_rho = Tags::Mean<NewtonianEuler::Tags::MassDensityCons>;
+  get(get<mean_rho>(neighbor_data[dir_keys[0]].means)) = 0.4;
+  get(get<mean_rho>(neighbor_data[dir_keys[1]].means)) = 1.1;
+
+  using mean_rhou = Tags::Mean<NewtonianEuler::Tags::MomentumDensity<1>>;
+  get<0>(get<mean_rhou>(neighbor_data[dir_keys[0]].means)) = 0.2;
+  get<0>(get<mean_rhou>(neighbor_data[dir_keys[1]].means)) = -0.1;
+
+  using mean_eps = Tags::Mean<NewtonianEuler::Tags::EnergyDensity>;
+  get(get<mean_eps>(neighbor_data[dir_keys[0]].means)) = 1.;
+  get(get<mean_eps>(neighbor_data[dir_keys[1]].means)) = 1.;
+
+  test_neuler_vs_generic_minmod_work(
+      mass_density_cons, momentum_density, energy_density, mesh, logical_coords,
+      element_size, det_inv_logical_to_inertial_jacobian, neighbor_data);
+}
+
+void test_neuler_vs_generic_minmod_2d() noexcept {
+  INFO("Testing NewtonianEuler::Limiters::Minmod limiter in 2D");
+  const auto mesh =
+      Mesh<2>(3, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto);
+  const auto element = TestHelpers::Limiters::make_element<2>();
+  const auto logical_coords = logical_coordinates(mesh);
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+  const Affine xi_map{-1., 1., 3.7, 4.2};
+  const Affine eta_map{-1., 1., 3.2, 4.2};
+  const Affine2D map2d{xi_map, eta_map};
+  const auto coordmap =
+      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(map2d);
+  const ElementMap<2, Frame::Inertial> element_map(element.id(),
+                                                   coordmap->get_clone());
+  const auto element_size = size_of_element(element_map);
+  const auto det_inv_logical_to_inertial_jacobian =
+      determinant(element_map.inv_jacobian(logical_coords));
+
+  const auto& x = get<0>(logical_coords);
+  const auto& y = get<1>(logical_coords);
+  const auto mass_density_cons = [&x, &y]() noexcept {
+    return Scalar<DataVector>{
+        {{1. + 0.2 * x - 0.1 * y + 0.05 * x * square(y)}}};
+  }();
+  const auto momentum_density = [&mesh]() noexcept {
+    return tnsr::I<DataVector, 2>{DataVector(mesh.number_of_grid_points(), 0.)};
+  }();
+  const auto energy_density = [&mesh]() noexcept {
+    return Scalar<DataVector>{DataVector(mesh.number_of_grid_points(), 1.)};
+  }();
+
+  std::unordered_map<std::pair<Direction<2>, ElementId<2>>,
+                     NewtonianEuler::Limiters::Minmod<2>::PackagedData,
+                     boost::hash<std::pair<Direction<2>, ElementId<2>>>>
+      neighbor_data{};
+  const std::array<std::pair<Direction<2>, ElementId<2>>, 4> dir_keys = {
+      {{Direction<2>::lower_xi(), ElementId<2>(1)},
+       {Direction<2>::upper_xi(), ElementId<2>(2)},
+       {Direction<2>::lower_eta(), ElementId<2>(3)},
+       {Direction<2>::upper_eta(), ElementId<2>(4)}}};
+  for (const auto& dir_key : dir_keys) {
+    neighbor_data[dir_key].element_size = element_size;
+  }
+
+  using mean_rho = Tags::Mean<NewtonianEuler::Tags::MassDensityCons>;
+  get(get<mean_rho>(neighbor_data[dir_keys[0]].means)) = 0.4;
+  get(get<mean_rho>(neighbor_data[dir_keys[1]].means)) = 1.1;
+  get(get<mean_rho>(neighbor_data[dir_keys[2]].means)) = 2.1;
+  get(get<mean_rho>(neighbor_data[dir_keys[3]].means)) = 0.9;
+
+  for (const auto& dir_key : dir_keys) {
+    using mean_rhou = Tags::Mean<NewtonianEuler::Tags::MomentumDensity<2>>;
+    get<0>(get<mean_rhou>(neighbor_data[dir_key].means)) = 0.;
+    get<1>(get<mean_rhou>(neighbor_data[dir_key].means)) = 0.;
+    using mean_eps = Tags::Mean<NewtonianEuler::Tags::EnergyDensity>;
+    get(get<mean_eps>(neighbor_data[dir_key].means)) = 1.;
+  }
+
+  test_neuler_vs_generic_minmod_work(
+      mass_density_cons, momentum_density, energy_density, mesh, logical_coords,
+      element_size, det_inv_logical_to_inertial_jacobian, neighbor_data);
+}
+
+void test_neuler_vs_generic_minmod_3d() noexcept {
+  INFO("Testing NewtonianEuler::Limiters::Minmod limiter in 3D");
+  const auto mesh =
+      Mesh<3>(std::array<size_t, 3>{{3, 3, 4}}, Spectral::Basis::Legendre,
+              Spectral::Quadrature::GaussLobatto);
+  const auto element = TestHelpers::Limiters::make_element<3>();
+  const auto logical_coords = logical_coordinates(mesh);
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine3D =
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  const Affine xi_map{-1., 1., 3.7, 4.2};
+  const Affine eta_map{-1., 1., 3.2, 4.2};
+  const Affine zeta_map{-1., 1., 1.3, 2.1};
+  const Affine3D map3d{xi_map, eta_map, zeta_map};
+  const auto coordmap =
+      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(map3d);
+  const ElementMap<3, Frame::Inertial> element_map(element.id(),
+                                                   coordmap->get_clone());
+  const auto element_size = size_of_element(element_map);
+  const auto det_inv_logical_to_inertial_jacobian =
+      determinant(element_map.inv_jacobian(logical_coords));
+
+  const auto& x = get<0>(logical_coords);
+  const auto& y = get<1>(logical_coords);
+  const auto& z = get<2>(logical_coords);
+  const auto mass_density_cons = [&x, &y, &z]() noexcept {
+    return Scalar<DataVector>{{{1. + 0.2 * x - 0.1 * y + 0.4 * z}}};
+  }();
+  const auto momentum_density = [&mesh]() noexcept {
+    return tnsr::I<DataVector, 3>{DataVector(mesh.number_of_grid_points(), 0.)};
+  }();
+  const auto energy_density = [&mesh]() noexcept {
+    return Scalar<DataVector>{DataVector(mesh.number_of_grid_points(), 1.)};
+  }();
+
+  std::unordered_map<std::pair<Direction<3>, ElementId<3>>,
+                     NewtonianEuler::Limiters::Minmod<3>::PackagedData,
+                     boost::hash<std::pair<Direction<3>, ElementId<3>>>>
+      neighbor_data{};
+  const std::array<std::pair<Direction<3>, ElementId<3>>, 6> dir_keys = {
+      {{Direction<3>::lower_xi(), ElementId<3>(1)},
+       {Direction<3>::upper_xi(), ElementId<3>(2)},
+       {Direction<3>::lower_eta(), ElementId<3>(3)},
+       {Direction<3>::upper_eta(), ElementId<3>(4)},
+       {Direction<3>::lower_zeta(), ElementId<3>(5)},
+       {Direction<3>::upper_zeta(), ElementId<3>(6)}}};
+  for (const auto& dir_key : dir_keys) {
+    neighbor_data[dir_key].element_size = element_size;
+  }
+
+  using mean_rho = Tags::Mean<NewtonianEuler::Tags::MassDensityCons>;
+  get(get<mean_rho>(neighbor_data[dir_keys[0]].means)) = 0.;
+  get(get<mean_rho>(neighbor_data[dir_keys[1]].means)) = 0.;
+  get(get<mean_rho>(neighbor_data[dir_keys[2]].means)) = 0.1;
+  get(get<mean_rho>(neighbor_data[dir_keys[3]].means)) = 1.2;
+  get(get<mean_rho>(neighbor_data[dir_keys[4]].means)) = 1.1;
+  get(get<mean_rho>(neighbor_data[dir_keys[5]].means)) = 0.9;
+
+  for (const auto& dir_key : dir_keys) {
+    using mean_rhou = Tags::Mean<NewtonianEuler::Tags::MomentumDensity<3>>;
+    get<0>(get<mean_rhou>(neighbor_data[dir_key].means)) = 0.;
+    get<1>(get<mean_rhou>(neighbor_data[dir_key].means)) = 0.;
+    get<2>(get<mean_rhou>(neighbor_data[dir_key].means)) = 0.;
+    using mean_eps = Tags::Mean<NewtonianEuler::Tags::EnergyDensity>;
+    get(get<mean_eps>(neighbor_data[dir_key].means)) = 1.;
+  }
+
+  test_neuler_vs_generic_minmod_work(
+      mass_density_cons, momentum_density, energy_density, mesh, logical_coords,
+      element_size, det_inv_logical_to_inertial_jacobian, neighbor_data);
+}
+
+template <size_t VolumeDim>
+void test_neuler_minmod_flattener() noexcept {
+  INFO("Testing flattener use in NewtonianEuler::Limiters::Minmod limiter");
+  CAPTURE(VolumeDim);
+
+  const auto mesh = Mesh<VolumeDim>(2, Spectral::Basis::Legendre,
+                                    Spectral::Quadrature::GaussLobatto);
+  // We use an element with no neighbors so the limiter does nothing
+  const auto element = Element<VolumeDim>{ElementId<VolumeDim>(0), {}};
+  const auto logical_coords = logical_coordinates(mesh);
+  const auto element_size = make_array<VolumeDim>(0.6);
+  // inv_jac = logical volume / inertial volume
+  const Scalar<DataVector> det_inv_logical_to_inertial_jacobian{DataVector(
+      mesh.number_of_grid_points(), pow<VolumeDim>(2.) / pow<VolumeDim>(0.6))};
+  const EquationsOfState::IdealFluid<false> equation_of_state{5. / 3.};
+
+  const size_t num_points = mesh.number_of_grid_points();
+  const auto input_density = [&num_points]() noexcept {
+    // One negative value to trigger flattener
+    Scalar<DataVector> density{DataVector(num_points, 0.8)};
+    get(density)[0] = -0.2;
+    return density;
+  }();
+  const auto input_momentum = [&num_points]() noexcept {
+    return tnsr::I<DataVector, VolumeDim>{DataVector(num_points, 0.1)};
+  }();
+  const auto input_energy = [&num_points]() noexcept {
+    return Scalar<DataVector>{DataVector(num_points, 1.4)};
+  }();
+
+  // Empty map because no neighbors
+  const std::unordered_map<
+      std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>,
+      typename NewtonianEuler::Limiters::Minmod<VolumeDim>::PackagedData,
+      boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>
+      neighbor_data{};
+
+  // First a sanity check: there should be a negative density for this test to
+  // make sense... otherwise we aren't testing anything useful
+  const bool has_negative_density = min(get(input_density)) < 0.;
+  REQUIRE(has_negative_density);
+  CHECK(true);
+
+  // With flattener off, check the limiter does nothing (because no neighbors).
+  //
+  // Note that the post-limiter result is unphysical: the density is still
+  // negative at one point. Because of this, we have to use the generic limiter
+  // when testing the limiter does nothing: the specialized limiter has an
+  // ASSERT that the post-limiting solution is valid which would fail here.
+  auto density = input_density;
+  auto momentum = input_momentum;
+  auto energy = input_energy;
+  const double tvb_constant = 0.;
+  const Limiters::Minmod<
+      VolumeDim, tmpl::list<NewtonianEuler::Tags::MassDensityCons,
+                            NewtonianEuler::Tags::MomentumDensity<VolumeDim>,
+                            NewtonianEuler::Tags::EnergyDensity>>
+      minmod_noflat(Limiters::MinmodType::LambdaPi1, tvb_constant);
+  const bool activated_noflat = minmod_noflat(
+      make_not_null(&density), make_not_null(&momentum), make_not_null(&energy),
+      mesh, element, logical_coords, element_size, neighbor_data);
+  CHECK_FALSE(activated_noflat);
+
+  // With flattener on, check limiter activates
+  density = input_density;
+  momentum = input_momentum;
+  energy = input_energy;
+  const auto vars_to_limit =
+      NewtonianEuler::Limiters::VariablesToLimit::Conserved;
+  const NewtonianEuler::Limiters::Minmod<VolumeDim> minmod(
+      Limiters::MinmodType::LambdaPi1, vars_to_limit, tvb_constant, true);
+  const bool activated = minmod(
+      make_not_null(&density), make_not_null(&momentum), make_not_null(&energy),
+      mesh, element, logical_coords, element_size,
+      det_inv_logical_to_inertial_jacobian, equation_of_state, neighbor_data);
+  CHECK(activated);
+
+  // Finally, check the negative density is brought back to positive
+  const bool density_is_positive_everywhere = min(get(density)) > 0.;
+  CHECK(density_is_positive_everywhere);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.NewtonianEuler.Limiters.Minmod",
+                  "[Limiters][Unit]") {
+  test_neuler_minmod_option_parsing();
+  test_neuler_minmod_serialization();
+
+  // The package_data function for NewtonianEuler::Limiters::Minmod is just a
+  // direct call to the generic Minmod package_data. We do not test it.
+
+  // We test the action of NewtonianEuler::Limiters::Minmod by comparing it to
+  // the action of the generic Minmod, for certain inputs where the comparison
+  // is not too difficult. To fully test the specialized limiter, would need to
+  // completely reimplement the logic within the test.
+  test_neuler_vs_generic_minmod_1d();
+  test_neuler_vs_generic_minmod_2d();
+  test_neuler_vs_generic_minmod_3d();
+
+  // Test the use of the post-processing flattener
+  test_neuler_minmod_flattener<1>();
+  test_neuler_minmod_flattener<2>();
+  test_neuler_minmod_flattener<3>();
+}

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/Test_VariablesToLimit.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Limiters/Test_VariablesToLimit.cpp
@@ -1,0 +1,36 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "Evolution/Systems/NewtonianEuler/Limiters/VariablesToLimit.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Utilities/GetOutput.hpp"
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.NewtonianEuler.Limiters.VariablesToLimit",
+    "[Limiters][Unit]") {
+  CHECK(NewtonianEuler::Limiters::VariablesToLimit::Conserved ==
+        TestHelpers::test_creation<NewtonianEuler::Limiters::VariablesToLimit>(
+            "Conserved"));
+  CHECK(NewtonianEuler::Limiters::VariablesToLimit::Characteristic ==
+        TestHelpers::test_creation<NewtonianEuler::Limiters::VariablesToLimit>(
+            "Characteristic"));
+
+  CHECK(get_output(NewtonianEuler::Limiters::VariablesToLimit::Conserved) ==
+        "Conserved");
+  CHECK(
+      get_output(NewtonianEuler::Limiters::VariablesToLimit::Characteristic) ==
+      "Characteristic");
+}
+
+// [[OutputRegex, Failed to convert "BadVars" to VariablesToLimit]]
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.NewtonianEuler.Limiters.VariablesToLimit.ParseErr",
+    "[Limiters][Unit]") {
+  ERROR_TEST();
+  TestHelpers::test_creation<NewtonianEuler::Limiters::VariablesToLimit>(
+      "BadVars");
+}


### PR DESCRIPTION
## Proposed changes

Adds a simple limiter specialized to the NewtonianEuler system. This means the limiter
- can act on the characteristic variables, as recommended
- can follow the limiting with an additional flattening step that helps avoid negative densities and pressures


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
