### PR TITLE
Support generic spatial indices for spacetime indices in TensorExpressions except AddSub

### DIFF
--- a/src/DataStructures/Tensor/Expressions/CMakeLists.txt
+++ b/src/DataStructures/Tensor/Expressions/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_headers(
   LhsTensorSymmAndIndices.hpp
   Product.hpp
   NumberAsExpression.hpp
+  SpatialSpacetimeIndex.hpp
   SquareRoot.hpp
   TensorAsExpression.hpp
   TensorExpression.hpp

--- a/src/DataStructures/Tensor/Expressions/Evaluate.hpp
+++ b/src/DataStructures/Tensor/Expressions/Evaluate.hpp
@@ -7,10 +7,12 @@
 #pragma once
 
 #include <array>
+#include <cstddef>
 #include <type_traits>
 
 #include "DataStructures/Tensor/Expressions/LhsTensorSymmAndIndices.hpp"
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Structure.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/Gsl.hpp"
@@ -38,7 +40,156 @@ constexpr bool contains_indices_to_contract(
     return false;
   }
 }
+
+/// \brief Helper struct for checking that a RHS tensor's index can be evaluated
+/// to its corresponding index in the LHS tensor
+///
+/// \details
+/// A RHS index's corresponding LHS index uses the same generic index, such as
+/// `ti_a`. For it to be possible to evaluate a RHS index to its corresponding
+/// LHS index, this checks that the following is true for the index on both
+/// sides:
+/// - has the same valence (`UpLo`)
+/// - has the same `Frame` type
+/// - has the same number of spatial dimensions (allowing for expressions that
+///   use generic spatial indices for spacetime indices on either side)
+///
+/// \tparam LhsIndexList the LHS tensor's \ref SpacetimeIndex "TensorIndexType"
+/// list
+/// \tparam RhsIndexList the RHS tensor's \ref SpacetimeIndex "TensorIndexType"
+/// list
+/// \tparam LhsTensorIndexList the LHS tensor's generic index list
+/// \tparam RhsTensorIndexList the RHS tensor's generic index list
+/// \tparam CurrentLhsTensorIndex the current generic index of the LHS tensor
+/// that is being checked, e.g. the type of `ti_a`
+template <typename LhsIndexList, typename RhsIndexList,
+          typename LhsTensorIndexList, typename RhsTensorIndexList,
+          typename CurrentLhsTensorIndex>
+struct EvaluateIndexCheckHelper {
+  using lhs_index =
+      tmpl::at<LhsIndexList,
+               tmpl::index_of<LhsTensorIndexList, CurrentLhsTensorIndex>>;
+  using rhs_index =
+      tmpl::at<RhsIndexList,
+               tmpl::index_of<RhsTensorIndexList, CurrentLhsTensorIndex>>;
+
+  using type = std::bool_constant<
+      lhs_index::ul == rhs_index::ul and
+      std::is_same_v<typename lhs_index::Frame, typename rhs_index::Frame> and
+      ((lhs_index::index_type == rhs_index::index_type and
+        lhs_index::dim == rhs_index::dim) or
+       (lhs_index::index_type == IndexType::Spacetime and
+        lhs_index::dim == rhs_index::dim + 1) or
+       (rhs_index::index_type == IndexType::Spacetime and
+        lhs_index::dim + 1 == rhs_index::dim))>;
+};
+
+/// \brief Check that a RHS tensor's indices can be evaluated to their
+/// corresponding indices in the LHS tensor
+///
+/// \details
+/// For more details, see `EvaluateIndexCheckHelper`, which performs the check
+/// for each index one at a time.
+///
+/// \tparam LhsIndexList the LHS tensor's \ref SpacetimeIndex "TensorIndexType"
+/// list
+/// \tparam RhsIndexList the RHS tensor's \ref SpacetimeIndex "TensorIndexType"
+/// list
+/// \tparam LhsTensorIndexList the LHS tensor's generic index list
+/// \tparam RhsTensorIndexList the RHS tensor's generic index list
+template <typename LhsIndexList, typename RhsIndexList,
+          typename LhsTensorIndexList, typename RhsTensorIndexList>
+using EvaluateIndexCheck =
+    tmpl::fold<LhsTensorIndexList, tmpl::bool_<true>,
+               tmpl::and_<tmpl::_state,
+                          EvaluateIndexCheckHelper<
+                              tmpl::pin<LhsIndexList>, tmpl::pin<RhsIndexList>,
+                              tmpl::pin<LhsTensorIndexList>,
+                              tmpl::pin<RhsTensorIndexList>, tmpl::_element>>>;
 }  // namespace detail
+
+/// \brief Computes a transformation from the LHS tensor's multi-indices to
+/// the equivalent RHS tensor's multi-indices, according to the differences in
+/// the orderings of their generic indices
+///
+/// \details
+/// The elements of the transformation are the positions of the RHS generic
+/// indices in the LHS generic indices. Put another way, for some `i`,
+/// `rhs_tensorindices[i] == lhs_tensorindices[index_transformation[i]]`.
+///
+/// Here is an example of what the algorithm does:
+///
+/// Tensor equation: \f$L_{cab} = R_{abc}\f$
+/// `lhs_tensorindices`:
+/// \code
+/// {2, 0, 1} // i.e. {c, a, b}
+/// \endcode
+/// `rhs_tensorindices`:
+/// \code
+/// {0, 1, 2} // i.e. {a, b, c}
+/// \endcode
+/// returned `index_transformation`:
+/// \code
+/// {1, 2, 0} // positions of RHS indices {a, b, c} in LHS indices {c, a, b}
+/// \endcode
+///
+/// \tparam NumIndices the number of indices in the tensors
+/// \param lhs_tensorindices the TensorIndexs of the LHS tensor
+/// \param rhs_tensorindices the TensorIndexs of the RHS tensor
+/// \return a transformation from the LHS tensor's multi-indices to the
+/// equivalent RHS tensor's multi-indices
+template <size_t NumIndices>
+SPECTRE_ALWAYS_INLINE constexpr std::array<size_t, NumIndices>
+compute_index_transformation(
+    const std::array<size_t, NumIndices>& lhs_tensorindices,
+    const std::array<size_t, NumIndices>& rhs_tensorindices) noexcept {
+  std::array<size_t, NumIndices> index_transformation{};
+  for (size_t i = 0; i < NumIndices; i++) {
+    gsl::at(index_transformation, i) = static_cast<size_t>(std::distance(
+        lhs_tensorindices.begin(),
+        alg::find(lhs_tensorindices, gsl::at(rhs_tensorindices, i))));
+  }
+  return index_transformation;
+}
+
+/// \brief Computes the RHS tensor multi-index that is equivalent to a given
+/// LHS tensor multi-index, according to the differences in the orderings of
+/// their generic indices
+///
+/// \details
+/// Here is an example of what the algorithm does:
+///
+/// Tensor equation: \f$L_{cab} = R_{abc}\f$
+/// `index_transformation`:
+/// \code
+/// {1, 2, 0} // positions of RHS indices {a, b, c} in LHS indices {c, a, b}
+/// \endcode
+/// `lhs_multi_index`:
+/// \code
+/// {3, 4, 5} // i.e. c = 3, a = 4, b = 5
+/// \endcode
+/// returned equivalent `rhs_multi_index`:
+/// \code
+/// {4, 5, 3} // i.e. a = 4, b = 5, c = 3
+/// \endcode
+///
+/// \tparam NumIndices the number of indices in the tensors
+/// \param lhs_multi_index the multi-index of the LHS tensor
+/// \param index_transformation the list of the positions of the RHS indices in
+/// the LHS indices
+/// \return the RHS tensor multi-index that is equivalent to `lhs_tensor_index`
+template <size_t NumIndices>
+SPECTRE_ALWAYS_INLINE constexpr std::array<size_t, NumIndices>
+compute_rhs_multi_index(
+    const std::array<size_t, NumIndices>& lhs_multi_index,
+    const std::array<size_t, NumIndices>& index_transformation) noexcept {
+  std::array<size_t, NumIndices> rhs_multi_index{};
+  for (size_t i = 0; i < NumIndices; i++) {
+    gsl::at(rhs_multi_index, i) =
+        gsl::at(lhs_multi_index, gsl::at(index_transformation, i));
+  }
+  return rhs_multi_index;
+}
 
 /*!
  * \ingroup TensorExpressionsGroup
@@ -78,14 +229,16 @@ constexpr bool contains_indices_to_contract(
  * @param rhs_tensorexpression the RHS TensorExpression to be evaluated
  */
 template <auto&... LhsTensorIndices, typename X, typename LhsSymmetry,
-          typename LhsIndexList, typename RhsTE,
-          Requires<std::is_base_of_v<Expression, RhsTE>> = nullptr>
+          typename LhsIndexList, typename Derived, typename RhsSymmetry,
+          typename RhsIndexList, typename... RhsTensorIndices>
 void evaluate(
     const gsl::not_null<Tensor<X, LhsSymmetry, LhsIndexList>*> lhs_tensor,
-    const RhsTE& rhs_tensorexpression) {
+    const TensorExpression<Derived, X, RhsSymmetry, RhsIndexList,
+                           tmpl::list<RhsTensorIndices...>>&
+        rhs_tensorexpression) {
   using lhs_tensorindex_list =
       tmpl::list<std::decay_t<decltype(LhsTensorIndices)>...>;
-  using rhs_tensorindex_list = typename RhsTE::args_list;
+  using rhs_tensorindex_list = tmpl::list<RhsTensorIndices...>;
   static_assert(
       tmpl::equal_members<lhs_tensorindex_list, rhs_tensorindex_list>::value,
       "The generic indices on the LHS of a tensor equation (that is, the "
@@ -103,37 +256,92 @@ void evaluate(
           {{std::decay_t<decltype(LhsTensorIndices)>::value...}}),
       "Cannot evaluate a tensor expression to a LHS tensor with generic "
       "indices that would be contracted, e.g. evaluate<ti_A, ti_a>.");
-  using rhs_symmetry = typename RhsTE::symmetry;
-  using rhs_tensorindextype_list = typename RhsTE::index_list;
-
-  // Stores (potentially reordered) symmetry and indices expected for the LHS
-  // tensor, with index order specified by LhsTensorIndices
-  using lhs_tensor_symm_and_indices =
-      LhsTensorSymmAndIndices<rhs_tensorindex_list, lhs_tensorindex_list,
-                              rhs_symmetry, rhs_tensorindextype_list>;
-  // Instead of simply checking that the LHS Tensor type is correct, individual
-  // checks for the data type and index list are carried out because it provides
-  // more fine-grained feedback and because the provided LHS symmetry may differ
-  // from the symmetry determined by the order of operations in the RHS
-  // expression.
+  // `EvaluateIndexCheck` does also check that valence (Up/Lo) of indices that
+  // correspond in the RHS and LHS tensors are equal, but the assertion message
+  // below does not mention this because a mismatch in valence should have been
+  // caught due to the combination of (i) the Tensor::operator() assertion
+  // checking that generic indices' valences match the tensor's indices'
+  // valences and (ii) the above assertion that RHS and LHS generic indices
+  // match
   static_assert(
-      std::is_same_v<X, typename RhsTE::type>,
-      "The data type stored by the LHS tensor does not match the data type "
-      "stored by the RHS expression.");
-  static_assert(
-      std::is_same_v<
-          LhsIndexList,
-          typename lhs_tensor_symm_and_indices::tensorindextype_list>,
-      "The index list of the LHS tensor does not match the index list of the "
-      "evaluated RHS expression.");
+      detail::EvaluateIndexCheck<LhsIndexList, RhsIndexList,
+                                 lhs_tensorindex_list,
+                                 rhs_tensorindex_list>::value,
+      "At least one index of the tensor evaluated from the RHS expression "
+      "cannot be evaluated to its corresponding index in the LHS tensor. This "
+      "is due to a difference in number of spatial dimensions or Frame type "
+      "between the index on the RHS and LHS. "
+      "e.g. evaluate<ti_a, ti_b>(L, R(ti_b, ti_a));, where R's first "
+      "index has 2 spatial dimensions but L's second index has 3 spatial "
+      "dimensions. Check RHS and LHS indices that use the same generic index.");
 
   using lhs_tensor_type = typename std::decay_t<decltype(*lhs_tensor)>;
 
+  // positions of indices in LHS tensor where generic spatial indices are used
+  // for spacetime indices
+  constexpr auto lhs_spatial_spacetime_index_positions =
+      detail::get_spatial_spacetime_index_positions<LhsIndexList,
+                                                    lhs_tensorindex_list>();
+  // positions of indices in RHS tensor where generic spatial indices are used
+  // for spacetime indices
+  constexpr auto rhs_spatial_spacetime_index_positions =
+      detail::get_spatial_spacetime_index_positions<RhsIndexList,
+                                                    rhs_tensorindex_list>();
+
   for (size_t i = 0; i < lhs_tensor_type::size(); i++) {
-    (*lhs_tensor)[i] =
-        rhs_tensorexpression
-            .template get<std::decay_t<decltype(LhsTensorIndices)>...>(
-                lhs_tensor_type::structure::get_canonical_tensor_index(i));
+    if constexpr (lhs_spatial_spacetime_index_positions.size() == 0) {
+      // either:
+      // (i) RHS nor LHS uses a generic spatial index for a spacetime index, or
+      // (ii) only RHS uses a generic spatial index for a spacetime index
+      auto rhs_multi_index = compute_rhs_multi_index(
+          lhs_tensor_type::structure::get_canonical_tensor_index(i),
+          compute_index_transformation<sizeof...(RhsTensorIndices)>(
+              {{std::decay_t<decltype(LhsTensorIndices)>::value...}},
+              {{RhsTensorIndices::value...}}));
+      for (size_t j = 0; j < rhs_spatial_spacetime_index_positions.size();
+           j++) {
+        gsl::at(rhs_multi_index,
+                gsl::at(rhs_spatial_spacetime_index_positions, j)) += 1;
+      }
+
+      (*lhs_tensor)[i] =
+          (~rhs_tensorexpression)
+              .template get<RhsTensorIndices...>(rhs_multi_index);
+
+    } else {
+      // either:
+      // (i) only LHS uses a generic spatial index for a spacetime index
+      // (ii) both RHS and LHS use a generic spatial index for a spacetime index
+      auto lhs_multi_index =
+          lhs_tensor_type::structure::get_canonical_tensor_index(i);
+      // Only evaluate the component at `lhs_multi_index` if it does not contain
+      // the time index (0) for any spacetime indices for which a generic
+      // spatial index is being used
+      if (alg::none_of(lhs_spatial_spacetime_index_positions,
+                       [lhs_multi_index](size_t j) {
+                         return gsl::at(lhs_multi_index, j) == 0;
+                       })) {
+        for (size_t j = 0; j < lhs_spatial_spacetime_index_positions.size();
+             j++) {
+          gsl::at(lhs_multi_index,
+                  gsl::at(lhs_spatial_spacetime_index_positions, j)) -= 1;
+        }
+        auto rhs_multi_index = compute_rhs_multi_index(
+            lhs_multi_index,
+            compute_index_transformation<sizeof...(RhsTensorIndices)>(
+                {{std::decay_t<decltype(LhsTensorIndices)>::value...}},
+                {{RhsTensorIndices::value...}}));
+        for (size_t j = 0; j < rhs_spatial_spacetime_index_positions.size();
+             j++) {
+          gsl::at(rhs_multi_index,
+                  gsl::at(rhs_spatial_spacetime_index_positions, j)) += 1;
+        }
+
+        (*lhs_tensor)[i] =
+            (~rhs_tensorexpression)
+                .template get<RhsTensorIndices...>(rhs_multi_index);
+      }
+    }
   }
 }
 
@@ -165,6 +373,10 @@ void evaluate(
  * \metareturns Tensor
  *
  * This represents evaluating: \f$L_{ba} = R_{ab} + S_{ab}\f$
+ *
+ * Note: If a generic spatial index is used for a spacetime index in the RHS
+ * tensor, its corresponding index in the LHS tensor type will be a spatial
+ * index with the same valence, frame, and number of spatial dimensions.
  *
  * Note: `LhsTensorIndices` must be passed by reference because non-type
  * template parameters cannot be class types until C++20.

--- a/src/DataStructures/Tensor/Expressions/LhsTensorSymmAndIndices.hpp
+++ b/src/DataStructures/Tensor/Expressions/LhsTensorSymmAndIndices.hpp
@@ -8,6 +8,7 @@
 #include <iterator>
 #include <utility>
 
+#include "DataStructures/Tensor/Expressions/SpatialSpacetimeIndex.hpp"
 #include "DataStructures/Tensor/Structure.hpp"
 #include "DataStructures/Tensor/Symmetry.hpp"
 #include "Utilities/Algorithm.hpp"
@@ -24,6 +25,10 @@ namespace TensorExpressions {
  * the two that is used to determine the (potentially reordered) ordering of the
  * elements of the desired LHS Tensor`s ::Symmetry and typelist of
  * \ref SpacetimeIndex "TensorIndexType"s.
+ *
+ * Note: If a generic spatial index is used for a spacetime index in the RHS
+ * tensor, its corresponding index in the LHS tensor type will be a spatial
+ * index with the same valence, frame, and number of spatial dimensions.
  *
  * @tparam RhsTensorIndexList the typelist of TensorIndex of the RHS
  * TensorExpression
@@ -45,6 +50,7 @@ template <typename RhsTensorIndexList, typename... LhsTensorIndices,
 struct LhsTensorSymmAndIndices<
     RhsTensorIndexList, tmpl::list<LhsTensorIndices...>, RhsSymmetry,
     RhsTensorIndexTypeList, NumIndices, std::index_sequence<Ints...>> {
+  // LHS generic indices, RHS generic indices, and the mapping between them
   static constexpr std::array<size_t, NumIndices> lhs_tensorindex_values = {
       {LhsTensorIndices::value...}};
   static constexpr std::array<size_t, NumIndices> rhs_tensorindex_values = {
@@ -54,12 +60,37 @@ struct LhsTensorSymmAndIndices<
           rhs_tensorindex_values.begin(),
           alg::find(rhs_tensorindex_values, lhs_tensorindex_values[Ints]))...}};
 
+  // Compute symmetry of RHS after spacetime indices using generic spatial
+  // indices are swapped for spatial indices
+  static constexpr std::array<std::int32_t, NumIndices> rhs_symmetry = {
+      {tmpl::at_c<RhsSymmetry, Ints>::value...}};
+  using rhs_spatial_spacetime_index_positions_ =
+      detail::spatial_spacetime_index_positions<RhsTensorIndexTypeList,
+                                                RhsTensorIndexList>;
+  using make_list_type = std::conditional_t<
+      tmpl::size<rhs_spatial_spacetime_index_positions_>::value == 0, size_t,
+      rhs_spatial_spacetime_index_positions_>;
+  static constexpr auto rhs_spatial_spacetime_index_positions =
+      make_array_from_list<make_list_type>();
+  static constexpr std::array<std::int32_t, NumIndices>
+      rhs_spatial_spacetime_index_symmetry =
+          detail::get_spatial_spacetime_index_symmetry(
+              rhs_symmetry, rhs_spatial_spacetime_index_positions);
+
+  // Compute index list of RHS after spacetime indices using generic spatial
+  // indices are made nonsymmetric to other indices
+  using rhs_spatial_spacetime_tensorindextype_list =
+      detail::replace_spatial_spacetime_indices<
+          RhsTensorIndexTypeList, rhs_spatial_spacetime_index_positions_>;
+
   // Desired LHS Tensor's Symmetry, typelist of TensorIndexTypes, and Structure
   using symmetry =
-      Symmetry<tmpl::at_c<RhsSymmetry, lhs_to_rhs_map[Ints]>::value...>;
+      Symmetry<rhs_spatial_spacetime_index_symmetry[lhs_to_rhs_map[Ints]]...>;
   using tensorindextype_list =
-      tmpl::list<tmpl::at_c<RhsTensorIndexTypeList, lhs_to_rhs_map[Ints]>...>;
-  using structure = Tensor_detail::Structure<
-      symmetry, tmpl::at_c<RhsTensorIndexTypeList, lhs_to_rhs_map[Ints]>...>;
+      tmpl::list<tmpl::at_c<rhs_spatial_spacetime_tensorindextype_list,
+                            lhs_to_rhs_map[Ints]>...>;
+  using structure =
+      Tensor_detail::Structure<symmetry,
+                               tmpl::at_c<tensorindextype_list, Ints>...>;
 };
 }  // namespace TensorExpressions

--- a/src/DataStructures/Tensor/Expressions/SpatialSpacetimeIndex.hpp
+++ b/src/DataStructures/Tensor/Expressions/SpatialSpacetimeIndex.hpp
@@ -1,0 +1,118 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Symmetry.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \file
+/// Defines functions and metafunctions used for helping evaluate
+/// TensorExpression equations where generic spatial indices are used for
+/// spacetime indices
+
+namespace TensorExpressions {
+namespace detail {
+template <typename State, typename Element, typename Iteration,
+          typename TensorIndexList>
+struct spatial_spacetime_index_positions_impl {
+  using type = typename std::conditional_t<
+      Element::index_type == IndexType::Spacetime and
+          not tmpl::at<TensorIndexList, Iteration>::is_spacetime,
+      tmpl::push_back<State, Iteration>, State>;
+};
+
+/// \brief Given a generic index list and tensor index list, returns the list of
+/// positions where the generic index is spatial and the tensor index is
+/// spacetime
+///
+/// \tparam TensorIndexList the generic index list
+/// \tparam TensorIndexTypeList the list of
+/// \ref SpacetimeIndex "TensorIndexType"s
+template <typename TensorIndexTypeList, typename TensorIndexList>
+using spatial_spacetime_index_positions = tmpl::enumerated_fold<
+    TensorIndexTypeList, tmpl::list<>,
+    spatial_spacetime_index_positions_impl<
+        tmpl::_state, tmpl::_element, tmpl::_3, tmpl::pin<TensorIndexList>>,
+    tmpl::size_t<0>>;
+
+/// \brief Given a generic index list and tensor index list, returns the list of
+/// positions where the generic index is spatial and the tensor index is
+/// spacetime
+///
+/// \tparam TensorIndexList the generic index list
+/// \tparam TensorIndexTypeList the list of
+/// \ref SpacetimeIndex "TensorIndexType"s
+/// \return the list of positions where the generic index is spatial and the
+/// tensor index is spacetime
+template <typename TensorIndexTypeList, typename TensorIndexList>
+constexpr auto get_spatial_spacetime_index_positions() noexcept {
+  using spatial_spacetime_index_positions_ =
+      spatial_spacetime_index_positions<TensorIndexTypeList, TensorIndexList>;
+  using make_list_type = std::conditional_t<
+      tmpl::size<spatial_spacetime_index_positions_>::value == 0, size_t,
+      spatial_spacetime_index_positions_>;
+  return make_array_from_list<make_list_type>();
+}
+
+/// \brief Given a tensor symmetry and the positions of indices where a generic
+/// spatial index is used for a spacetime index, this returns the symmetry
+/// after making those indices nonsymmetric with others
+///
+/// \details
+/// Example: If `symmetry` is `[2, 1, 1, 1]` and
+/// `spatial_spacetime_index_positions` is `[1]`, then position 1 is the only
+/// position where a generic spatial index is used for a spacetime index. The
+/// resulting symmetry will make the index at position 1 no longer be symmetric
+/// with the indices at positions 2 and 3. Therefore, the resulting symmetry
+/// will be equivalent to the form of `[3, 2, 1, 1]`.
+///
+/// Note: the symmetry returned by this function is not in the canonical form
+/// specified by ::Symmetry. In reality, for the example above, this function
+/// would return `[2, 3, 1, 1]`.
+///
+/// \param symmetry the input tensor symmetry to transform
+/// \param spatial_spacetime_index_positions the positions of the indices of the
+/// tensor where a generic spatial index is used for a spacetime index
+/// \return the symmetry after making the `spatial_spacetime_index_positions` of
+/// `symmetry` nonsymmetric with other indices
+template <size_t NumIndices, size_t NumSpatialSpacetimeIndices>
+constexpr std::array<std::int32_t, NumIndices>
+get_spatial_spacetime_index_symmetry(
+    const std::array<std::int32_t, NumIndices>& symmetry,
+    const std::array<size_t, NumSpatialSpacetimeIndices>&
+        spatial_spacetime_index_positions) noexcept {
+  std::array<std::int32_t, NumIndices> spatial_spacetime_index_symmetry{};
+  const std::int32_t max_symm_value =
+      static_cast<std::int32_t>(*alg::max_element(symmetry));
+  for (size_t i = 0; i < NumIndices; i++) {
+    gsl::at(spatial_spacetime_index_symmetry, i) = gsl::at(symmetry, i);
+  }
+  for (size_t i = 0; i < NumSpatialSpacetimeIndices; i++) {
+    spatial_spacetime_index_symmetry[spatial_spacetime_index_positions[i]] +=
+        max_symm_value;
+    gsl::at(spatial_spacetime_index_symmetry,
+            gsl::at(spatial_spacetime_index_positions, i)) += max_symm_value;
+  }
+
+  return spatial_spacetime_index_symmetry;
+}
+
+template <typename S, typename E>
+struct replace_spatial_spacetime_indices_helper {
+  using type = tmpl::replace_at<S, E, change_index_type<tmpl::at<S, E>>>;
+};
+
+// The list of indices resulting from taking `TensorIndexTypeList` and
+// replacing the spacetime indices at positions `SpatialSpacetimeIndexPositions`
+// with spatial indices
+template <typename TensorIndexTypeList, typename SpatialSpacetimeIndexPositions>
+using replace_spatial_spacetime_indices = tmpl::fold<
+    SpatialSpacetimeIndexPositions, TensorIndexTypeList,
+    replace_spatial_spacetime_indices_helper<tmpl::_state, tmpl::_element>>;
+}  // namespace detail
+}  // namespace TensorExpressions

--- a/src/DataStructures/Tensor/Expressions/TensorAsExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorAsExpression.hpp
@@ -79,7 +79,7 @@ struct TensorAsExpression<Tensor<X, Symm, IndexList<Indices...>>,
   /// \endcode
   /// returned `index_transformation`:
   /// \code
-  /// {1, 2, 0} // positions of RHS indices {c, a, b} in LHS indices {a, b, c}
+  /// {1, 2, 0} // positions of RHS indices {a, b, c} in LHS indices {c, a, b}
   /// \endcode
   ///
   /// \param lhs_tensorindices the TensorIndexs of the LHS tensor
@@ -109,7 +109,7 @@ struct TensorAsExpression<Tensor<X, Symm, IndexList<Indices...>>,
   /// Tensor equation: \f$L_{cab} = R_{abc}\f$
   /// `index_transformation`:
   /// \code
-  /// {1, 2, 0} // positions of RHS indices {c, a, b} in LHS indices {a, b, c}
+  /// {1, 2, 0} // positions of RHS indices {a, b, c} in LHS indices {c, a, b}
   /// \endcode
   /// `lhs_multi_index`:
   /// \code

--- a/src/DataStructures/Tensor/IndexType.hpp
+++ b/src/DataStructures/Tensor/IndexType.hpp
@@ -236,3 +236,15 @@ using change_index_up_lo = Tensor_detail::TensorIndexType<
 
 template <typename... Ts>
 using index_list = tmpl::list<Ts...>;
+
+/// \ingroup TensorGroup
+/// Change the \ref SpacetimeIndex "TensorIndexType" to be spacetime
+/// if it's spatial and vice versa
+///
+/// \tparam Index the \ref SpacetimeIndex "TensorIndexType" to change
+template <typename Index>
+using change_index_type = Tensor_detail::TensorIndexType<
+    Index::index_type == IndexType::Spatial ? Index::dim : Index::dim - 1,
+    Index::ul, typename Index::Frame,
+    Index::index_type == IndexType::Spatial ? IndexType::Spacetime
+                                            : IndexType::Spatial>;

--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -264,11 +264,11 @@ class Tensor<X, Symm, IndexList<Indices...>> {
                        tmpl::integral_list<UpLo, Indices::ul...>>,
         "The valences of the generic indices in the expression do "
         "not match the valences of the indices in the Tensor.");
-    static_assert((... and (TensorIndices::is_spacetime ==
-                            (Indices::index_type == IndexType::Spacetime))),
-                  "The index types (SpatialIndex or SpacetimeIndex) of the "
-                  "generic indices in the expression do not match the index "
-                  "types of the indices in the Tensor.");
+    static_assert((... and (not(TensorIndices::is_spacetime and
+                                (Indices::index_type == IndexType::Spatial)))),
+                  "Cannot use a generic spacetime index for a spatial index. "
+                  "e.g. Cannot do R(ti_a), where R's index is spatial, because "
+                  "ti_a denotes a generic spacetime index.");
     return TensorExpressions::contract(TE<tmpl::list<TensorIndices...>>{*this});
   }
   /// @}

--- a/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
+++ b/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   Test_Evaluate.cpp
   Test_EvaluateRank3.cpp
   Test_EvaluateRank4.cpp
+  Test_EvaluateSpatialSpacetimeIndex.cpp
   Test_MixedOperations.cpp
   Test_Product.cpp
   Test_ProductHighRankIntermediate.cpp

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Contract.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Contract.cpp
@@ -632,10 +632,144 @@ void test_contractions_rank4(const DataType& used_for_size) noexcept {
 }
 
 template <typename DataType>
+void test_spatial_spacetime_index(const DataType& used_for_size) noexcept {
+  // Contract (spatial, spacetime) tensor
+  // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
+  // return type of `evaluate`
+  Tensor<DataType, Symmetry<2, 1>,
+         index_list<SpatialIndex<3, UpLo::Up, Frame::Inertial>,
+                    SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>
+
+      R(used_for_size);
+  create_tensor(make_not_null(&R));
+  const Tensor<DataType> R_contracted =
+      TensorExpressions::evaluate(R(ti_I, ti_i));
+
+  // Contract (spacetime, spatial) tensor
+  Tensor<DataType, Symmetry<2, 1>,
+         index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                    SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>
+      S(used_for_size);
+  create_tensor(make_not_null(&S));
+  const Tensor<DataType> S_contracted =
+      TensorExpressions::evaluate(S(ti_K, ti_k));
+
+  // Contract (spacetime, spacetime) tensor using generic spatial indices
+  Tensor<DataType, Symmetry<2, 1>,
+         index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>
+      T(used_for_size);
+  create_tensor(make_not_null(&T));
+  const Tensor<DataType> T_contracted =
+      TensorExpressions::evaluate(T(ti_j, ti_J));
+
+  DataType expected_R_sum = make_with_value<DataType>(used_for_size, 0.0);
+  DataType expected_S_sum = make_with_value<DataType>(used_for_size, 0.0);
+  DataType expected_T_sum = make_with_value<DataType>(used_for_size, 0.0);
+  for (size_t i = 0; i < 3; i++) {
+    expected_R_sum += R.get(i, i + 1);
+    expected_S_sum += S.get(i + 1, i);
+    expected_T_sum += T.get(i + 1, i + 1);
+  }
+  CHECK_ITERABLE_APPROX(R_contracted.get(), expected_R_sum);
+  CHECK_ITERABLE_APPROX(S_contracted.get(), expected_S_sum);
+  CHECK_ITERABLE_APPROX(T_contracted.get(), expected_T_sum);
+
+  Tensor<DataType, Symmetry<4, 3, 2, 1>,
+         index_list<SpatialIndex<3, UpLo::Up, Frame::Grid>,
+                    SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>
+      G(used_for_size);
+  create_tensor(make_not_null(&G));
+
+  // Contract one (spatial, spacetime) pair of indices of a tensor that also
+  // takes a generic spatial index for a single non-contracted spacetime index
+  // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
+  // return type of `evaluate`
+  const Tensor<DataType, Symmetry<2, 1>,
+               index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                          SpatialIndex<3, UpLo::Up, Frame::Grid>>>
+      G_contracted_1 =
+          TensorExpressions::evaluate<ti_i, ti_K>(G(ti_K, ti_j, ti_i, ti_J));
+
+  for (size_t i = 0; i < 3; i++) {
+    for (size_t k = 0; k < 3; k++) {
+      DataType expected_G_sum_1 = make_with_value<DataType>(used_for_size, 0.0);
+      for (size_t j = 0; j < 3; j++) {
+        expected_G_sum_1 += G.get(k, j, i + 1, j + 1);
+      }
+      CHECK_ITERABLE_APPROX(G_contracted_1.get(i, k), expected_G_sum_1);
+    }
+  }
+
+  // Contract one (spacetime, spacetime) pair of indices using generic spatial
+  // indices and then one (spatial, spatial) pair of indices
+  const Tensor<DataType> G_contracted_2 =
+      TensorExpressions::evaluate(G(ti_I, ti_i, ti_j, ti_J));
+
+  DataType expected_G_sum_2 = make_with_value<DataType>(used_for_size, 0.0);
+  for (size_t i = 0; i < 3; i++) {
+    for (size_t j = 0; j < 3; j++) {
+      expected_G_sum_2 += G.get(i, i, j + 1, j + 1);
+    }
+  }
+  CHECK_ITERABLE_APPROX(G_contracted_2.get(), expected_G_sum_2);
+
+  // Contract two (spatial, spacetime) pairs of indices
+  const Tensor<DataType> G_contracted_3 =
+      TensorExpressions::evaluate(G(ti_I, ti_j, ti_i, ti_J));
+
+  DataType expected_G_sum_3 = make_with_value<DataType>(used_for_size, 0.0);
+  for (size_t i = 0; i < 3; i++) {
+    for (size_t j = 0; j < 3; j++) {
+      expected_G_sum_3 += G.get(i, j, i + 1, j + 1);
+    }
+  }
+  CHECK_ITERABLE_APPROX(G_contracted_3.get(), expected_G_sum_3);
+
+  Tensor<DataType, Symmetry<4, 3, 2, 1>,
+         index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                    SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                    SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>
+      H(used_for_size);
+  create_tensor(make_not_null(&H));
+
+  // Contract one (spacetime, spacetime) pair of indices using generic spacetime
+  // indices and then one (spacetime, spacetime) pair of indices using generic
+  // spatial indices
+  const Tensor<DataType> H_contracted_1 =
+      TensorExpressions::evaluate(H(ti_i, ti_I, ti_a, ti_A));
+
+  DataType expected_H_sum_1 = make_with_value<DataType>(used_for_size, 0.0);
+  for (size_t i = 0; i < 3; i++) {
+    for (size_t a = 0; a < 4; a++) {
+      expected_H_sum_1 += H.get(i + 1, i + 1, a, a);
+    }
+  }
+  CHECK_ITERABLE_APPROX(H_contracted_1.get(), expected_H_sum_1);
+
+  // Contract two (spacetime, spacetime) pair of indices using generic spatial
+  // indices
+  const Tensor<DataType> H_contracted_2 =
+      TensorExpressions::evaluate(H(ti_j, ti_I, ti_i, ti_J));
+
+  DataType expected_H_sum_2 = make_with_value<DataType>(used_for_size, 0.0);
+  for (size_t j = 0; j < 3; j++) {
+    for (size_t i = 0; i < 3; i++) {
+      expected_H_sum_2 += H.get(j + 1, i + 1, i + 1, j + 1);
+    }
+  }
+  CHECK_ITERABLE_APPROX(H_contracted_2.get(), expected_H_sum_2);
+}
+
+template <typename DataType>
 void test_contractions(const DataType& used_for_size) noexcept {
   test_contractions_rank2(used_for_size);
   test_contractions_rank3(used_for_size);
   test_contractions_rank4(used_for_size);
+  test_spatial_spacetime_index(used_for_size);
 }
 }  // namespace
 

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateSpatialSpacetimeIndex.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateSpatialSpacetimeIndex.cpp
@@ -1,0 +1,259 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <random>
+
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Symmetry.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace {
+// \brief Test evaluation of tensors where generic spatial indices are used for
+// RHS spacetime indices
+//
+// \tparam DataType the type of data being stored in the expression operands
+template <typename DataType, typename Generator>
+void test_rhs(const DataType& used_for_size,
+              const gsl::not_null<Generator*> generator) noexcept {
+  std::uniform_real_distribution<> distribution(0.1, 1.0);
+  constexpr size_t dim = 3;
+
+  const auto R = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
+                        SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>>(
+      generator, distribution, used_for_size);
+
+  // \f$L_{ai} = R_{ai}\f$
+  // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
+  // return type of `evaluate`
+  const Tensor<DataType, Symmetry<2, 1>,
+               index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
+                          SpatialIndex<dim, UpLo::Lo, Frame::Inertial>>>
+      Lai_from_R_ai = TensorExpressions::evaluate<ti_a, ti_i>(R(ti_a, ti_i));
+
+  // \f$L_{ia} = R_{ai}\f$
+  const Tensor<DataType, Symmetry<2, 1>,
+               index_list<SpatialIndex<dim, UpLo::Lo, Frame::Inertial>,
+                          SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
+      Lia_from_R_ai = TensorExpressions::evaluate<ti_i, ti_a>(R(ti_a, ti_i));
+
+  // \f$L_{ai} = R_{ia}\f$
+  const Tensor<DataType, Symmetry<2, 1>,
+               index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
+                          SpatialIndex<dim, UpLo::Lo, Frame::Inertial>>>
+      Lai_from_R_ia = TensorExpressions::evaluate<ti_a, ti_i>(R(ti_i, ti_a));
+
+  // \f$L_{ia} = R_{ia}\f$
+  const Tensor<DataType, Symmetry<2, 1>,
+               index_list<SpatialIndex<dim, UpLo::Lo, Frame::Inertial>,
+                          SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
+      Lia_from_R_ia = TensorExpressions::evaluate<ti_i, ti_a>(R(ti_i, ti_a));
+
+  for (size_t a = 0; a < dim + 1; a++) {
+    for (size_t i = 0; i < dim; i++) {
+      CHECK(Lai_from_R_ai.get(a, i) == R.get(a, i + 1));
+      CHECK(Lia_from_R_ai.get(i, a) == R.get(a, i + 1));
+      CHECK(Lai_from_R_ia.get(a, i) == R.get(i + 1, a));
+      CHECK(Lia_from_R_ia.get(i, a) == R.get(i + 1, a));
+    }
+  }
+}
+
+// \brief Test evaluation of tensors where generic spatial indices are used for
+// LHS spacetime indices
+//
+// \tparam DataType the type of data being stored in the expression operands
+template <typename DataType, typename Generator>
+void test_lhs(const DataType& used_for_size,
+              const gsl::not_null<Generator*> generator) noexcept {
+  std::uniform_real_distribution<> distribution(0.1, 1.0);
+  constexpr size_t dim = 3;
+
+  const auto R = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
+                        SpatialIndex<dim, UpLo::Lo, Frame::Inertial>>>>(
+      generator, distribution, used_for_size);
+
+  // \f$L_{ai} = R_{ai}\f$
+  // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
+  // return type of `evaluate`
+  Tensor<DataType, Symmetry<2, 1>,
+         index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
+                    SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
+      Lai_from_R_ai(used_for_size);
+  TensorExpressions::evaluate<ti_a, ti_i>(make_not_null(&Lai_from_R_ai),
+                                          R(ti_a, ti_i));
+
+  // \f$L_{ia} = R_{ai}\f$
+  Tensor<DataType, Symmetry<2, 1>,
+         index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
+                    SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
+      Lia_from_R_ai(used_for_size);
+  TensorExpressions::evaluate<ti_i, ti_a>(make_not_null(&Lia_from_R_ai),
+                                          R(ti_a, ti_i));
+
+  const auto S = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<SpatialIndex<dim, UpLo::Lo, Frame::Inertial>,
+                        SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>>(
+      generator, distribution, used_for_size);
+
+  // \f$L_{ia} = S_{ia}\f$
+  Tensor<DataType, Symmetry<2, 1>,
+         index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
+                    SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
+      Lia_from_S_ia(used_for_size);
+  TensorExpressions::evaluate<ti_i, ti_a>(make_not_null(&Lia_from_S_ia),
+                                          S(ti_i, ti_a));
+
+  // \f$L_{ai} = S_{ia}\f$
+  Tensor<DataType, Symmetry<2, 1>,
+         index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
+                    SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
+      Lai_from_S_ia(used_for_size);
+  TensorExpressions::evaluate<ti_a, ti_i>(make_not_null(&Lai_from_S_ia),
+                                          S(ti_i, ti_a));
+
+  for (size_t a = 0; a < dim + 1; a++) {
+    for (size_t i = 0; i < dim; i++) {
+      CHECK(Lai_from_R_ai.get(a, i + 1) == R.get(a, i));
+      CHECK(Lia_from_R_ai.get(i + 1, a) == R.get(a, i));
+      CHECK(Lia_from_S_ia.get(i + 1, a) == S.get(i, a));
+      CHECK(Lai_from_S_ia.get(a, i + 1) == S.get(i, a));
+    }
+  }
+}
+
+// \brief Test evaluation of rank 2 tensors where generic spatial indices are
+// used for RHS and LHS spacetime indices
+//
+// \tparam DataType the type of data being stored in the expression operands
+template <typename DataType, typename Generator>
+void test_rhs_and_lhs_rank2(
+    const DataType& used_for_size,
+    const gsl::not_null<Generator*> generator) noexcept {
+  std::uniform_real_distribution<> distribution(0.1, 1.0);
+  constexpr size_t dim = 3;
+
+  const auto R = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
+                        SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>>(
+      generator, distribution, used_for_size);
+
+  // \f$L_{ai} = R_{ai}\f$
+  // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
+  // return type of `evaluate`
+  Tensor<DataType, Symmetry<2, 1>,
+         index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
+                    SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
+      Lai_from_R_ai(used_for_size);
+  TensorExpressions::evaluate<ti_a, ti_i>(make_not_null(&Lai_from_R_ai),
+                                          R(ti_a, ti_i));
+
+  // \f$L_{ia} = R_{ai}\f$
+  Tensor<DataType, Symmetry<2, 1>,
+         index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
+                    SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
+      Lia_from_R_ai(used_for_size);
+  TensorExpressions::evaluate<ti_i, ti_a>(make_not_null(&Lia_from_R_ai),
+                                          R(ti_a, ti_i));
+
+  // \f$L_{ai} = R_{ia}\f$
+  Tensor<DataType, Symmetry<2, 1>,
+         index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
+                    SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
+      Lai_from_R_ia(used_for_size);
+  TensorExpressions::evaluate<ti_a, ti_i>(make_not_null(&Lai_from_R_ia),
+                                          R(ti_i, ti_a));
+
+  // \f$L_{ia} = R_{ia}\f$
+  Tensor<DataType, Symmetry<2, 1>,
+         index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
+                    SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
+      Lia_from_R_ia(used_for_size);
+  TensorExpressions::evaluate<ti_i, ti_a>(make_not_null(&Lia_from_R_ia),
+                                          R(ti_i, ti_a));
+
+  for (size_t a = 0; a < dim + 1; a++) {
+    for (size_t i = 0; i < dim; i++) {
+      CHECK(Lai_from_R_ai.get(a, i + 1) == R.get(a, i + 1));
+      CHECK(Lia_from_R_ai.get(i + 1, a) == R.get(a, i + 1));
+      CHECK(Lai_from_R_ia.get(a, i + 1) == R.get(i + 1, a));
+      CHECK(Lia_from_R_ia.get(i + 1, a) == R.get(i + 1, a));
+    }
+  }
+}
+
+// \brief Test evaluation of rank 4 tensors where generic spatial indices are
+// used for RHS and LHS spacetime indices
+//
+// \tparam DataType the type of data being stored in the expression operands
+template <typename DataType, typename Generator>
+void test_rhs_and_lhs_rank4(
+    const DataType& used_for_size,
+    const gsl::not_null<Generator*> generator) noexcept {
+  std::uniform_real_distribution<> distribution(0.1, 1.0);
+  constexpr size_t dim = 3;
+
+  const auto R = make_with_random_values<
+      Tensor<DataType, Symmetry<3, 2, 1, 2>,
+             index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Grid>,
+                        SpacetimeIndex<dim, UpLo::Lo, Frame::Grid>,
+                        SpatialIndex<dim, UpLo::Lo, Frame::Grid>,
+                        SpacetimeIndex<dim, UpLo::Lo, Frame::Grid>>>>(
+      generator, distribution, used_for_size);
+
+  // \f$L_{ai} = R_{ai}\f$
+  // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
+  // return type of `evaluate`
+  Tensor<DataType, Symmetry<4, 3, 2, 1>,
+         index_list<SpatialIndex<dim, UpLo::Lo, Frame::Grid>,
+                    SpacetimeIndex<dim, UpLo::Lo, Frame::Grid>,
+                    SpacetimeIndex<dim, UpLo::Lo, Frame::Grid>,
+                    SpatialIndex<dim, UpLo::Lo, Frame::Grid>>>
+      Likaj_from_R_jaik(used_for_size);
+  TensorExpressions::evaluate<ti_i, ti_k, ti_a, ti_j>(
+      make_not_null(&Likaj_from_R_jaik), R(ti_j, ti_a, ti_i, ti_k));
+
+  for (size_t i = 0; i < dim; i++) {
+    for (size_t k = 0; k < dim; k++) {
+      for (size_t a = 0; a < dim + 1; a++) {
+        for (size_t j = 0; j < dim; j++) {
+          CHECK(Likaj_from_R_jaik.get(i, k + 1, a, j) ==
+                R.get(j + 1, a, i, k + 1));
+        }
+      }
+    }
+  }
+}
+
+template <typename DataType>
+void test_evaluate_spatial_spacetime_index(
+    const DataType& used_for_size) noexcept {
+  MAKE_GENERATOR(generator);
+
+  test_rhs(used_for_size, make_not_null(&generator));
+  test_lhs(used_for_size, make_not_null(&generator));
+  test_rhs_and_lhs_rank2(used_for_size, make_not_null(&generator));
+  test_rhs_and_lhs_rank4(used_for_size, make_not_null(&generator));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.DataStructures.Tensor.Expression.EvaluateSpatialSpacetimeIndex",
+    "[DataStructures][Unit]") {
+  test_evaluate_spatial_spacetime_index(
+      std::numeric_limits<double>::signaling_NaN());
+  test_evaluate_spatial_spacetime_index(
+      DataVector(5, std::numeric_limits<double>::signaling_NaN()));
+}

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_SquareRoot.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_SquareRoot.cpp
@@ -83,6 +83,27 @@ void test_sqrt(const DataType& used_for_size) noexcept {
       TensorExpressions::evaluate(sqrt(S(ti_k, ti_K) * 3.6));
   CHECK(sqrt_S.get() == sqrt(S_trace));
   CHECK(sqrt_S_T.get() == sqrt(S_trace * 3.6));
+
+  Tensor<DataType, Symmetry<1>,
+         index_list<SpatialIndex<4, UpLo::Up, Frame::Grid>>>
+      G(used_for_size);
+  assign_unique_values_to_tensor(make_not_null(&G));
+
+  Tensor<DataType, Symmetry<1>,
+         index_list<SpacetimeIndex<4, UpLo::Lo, Frame::Grid>>>
+      H(used_for_size);
+  assign_unique_values_to_tensor(make_not_null(&H));
+
+  DataType GH_product = make_with_value<DataType>(used_for_size, 0.0);
+  for (size_t i = 0; i < 4; i++) {
+    GH_product += G.get(i) * H.get(i + 1);
+  }
+
+  // Test expression that uses generic spatial index for a spacetime index
+  // \f$L = \sqrt{G^{j} H_{j}\f$
+  const Tensor<DataType> sqrt_GH_product =
+      TensorExpressions::evaluate(sqrt(G(ti_J) * H(ti_j)));
+  CHECK(sqrt_GH_product.get() == sqrt(GH_product));
 }
 }  // namespace
 


### PR DESCRIPTION
## Proposed changes

This PR adds support for providing generic spatial indices for spacetime indices of tensors used in `TensorExpression` equations that include any combination of the following operations:
- contractions
- inner products
- outer products
- square roots (of expressions that evaluate to rank 0 tensors)
- transpositions of indices

Note that this does not include addition and subtraction, for which support will be added in a future PR.

As a simple example, this enables equations like the following, where generic spatial indices `ti_i` and `ti_j` are provided for `spacetime_metric`'s spacetime indices:
```
const auto spatial_metric = TensorExpressions::evaluate<ti_i, ti_j>(spacetime_metric(ti_i, ti_j));
```

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
