### PR TITLE
Add Schwarz smoothing to elliptic executables

### DIFF
--- a/src/Elliptic/Executables/Elasticity/CMakeLists.txt
+++ b/src/Elliptic/Executables/Elasticity/CMakeLists.txt
@@ -14,6 +14,7 @@ set(LIBS_TO_LINK
   ElasticitySolutions
   Elliptic
   EllipticDg
+  EllipticDgSubdomainOperator
   Events
   EventsAndTriggers
   Informer
@@ -22,6 +23,7 @@ set(LIBS_TO_LINK
   Options
   Parallel
   ParallelLinearSolver
+  ParallelSchwarz
   Utilities
   )
 

--- a/src/Elliptic/Executables/Poisson/CMakeLists.txt
+++ b/src/Elliptic/Executables/Poisson/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBS_TO_LINK
   DomainCreators
   Elliptic
   EllipticDg
+  EllipticDgSubdomainOperator
   Events
   EventsAndTriggers
   Informer
@@ -17,6 +18,7 @@ set(LIBS_TO_LINK
   Options
   Parallel
   ParallelLinearSolver
+  ParallelSchwarz
   Poisson
   PoissonBoundaryConditions
   PoissonSolutions

--- a/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
@@ -17,6 +17,8 @@
 #include "Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp"
 #include "Elliptic/DiscontinuousGalerkin/Actions/InitializeDomain.hpp"
 #include "Elliptic/DiscontinuousGalerkin/DgElementArray.hpp"
+#include "Elliptic/DiscontinuousGalerkin/SubdomainOperator/InitializeSubdomain.hpp"
+#include "Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp"
 #include "Elliptic/Systems/Poisson/FirstOrderSystem.hpp"
 #include "Elliptic/Tags.hpp"
 #include "Elliptic/Triggers/EveryNIterations.hpp"
@@ -42,6 +44,7 @@
 #include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
 #include "ParallelAlgorithms/Initialization/Actions/RemoveOptionsAndTerminatePhase.hpp"
 #include "ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp"
+#include "ParallelAlgorithms/LinearSolver/Schwarz/Schwarz.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 #include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Poisson/AnalyticSolution.hpp"
@@ -72,6 +75,11 @@ struct LinearSolverGroup {
 struct GmresGroup {
   static std::string name() noexcept { return "GMRES"; }
   static constexpr Options::String help = "Options for the GMRES linear solver";
+  using group = LinearSolverGroup;
+};
+struct SchwarzSmootherGroup {
+  static std::string name() noexcept { return "SchwarzSmoother"; }
+  static constexpr Options::String help = "Options for the Schwarz smoother";
   using group = LinearSolverGroup;
 };
 }  // namespace SolvePoisson::OptionTags
@@ -125,9 +133,18 @@ struct Metavariables {
   using linear_solver =
       LinearSolver::gmres::Gmres<Metavariables, fields_tag,
                                  SolvePoisson::OptionTags::LinearSolverGroup,
-                                 false>;
+                                 true>;
   using linear_solver_iteration_id =
       Convergence::Tags::IterationId<typename linear_solver::options_group>;
+  // Precondition each linear solver iteration with a number of Schwarz
+  // smoothing steps
+  using subdomain_operator =
+      elliptic::dg::subdomain_operator::SubdomainOperator<
+          system, SolvePoisson::OptionTags::SchwarzSmootherGroup>;
+  using schwarz_smoother = LinearSolver::Schwarz::Schwarz<
+      typename linear_solver::operand_tag,
+      SolvePoisson::OptionTags::SchwarzSmootherGroup, subdomain_operator,
+      typename linear_solver::preconditioner_source_tag>;
   // For the GMRES linear solver we need to apply the DG operator to its
   // internal "operand" in every iteration of the algorithm.
   using vars_tag = typename linear_solver::operand_tag;
@@ -166,7 +183,7 @@ struct Metavariables {
   using observed_reduction_data_tags =
       observers::collect_reduction_data_tags<tmpl::flatten<tmpl::list<
           tmpl::at<typename factory_creation::factory_classes, Event>,
-          linear_solver>>>;
+          linear_solver, schwarz_smoother>>>;
 
   // Specify all global synchronization points.
   enum class Phase { Initialization, RegisterWithObserver, Solve, Exit };
@@ -175,12 +192,16 @@ struct Metavariables {
       Actions::SetupDataBox,
       elliptic::dg::Actions::InitializeDomain<volume_dim>,
       typename linear_solver::initialize_element,
+      typename schwarz_smoother::initialize_element,
       elliptic::Actions::InitializeFields<system, initial_guess_tag>,
       elliptic::Actions::InitializeFixedSources<system, analytic_solution_tag>,
       elliptic::Actions::InitializeAnalyticSolution<
           analytic_solution_tag, tmpl::append<typename system::primal_fields,
                                               typename system::primal_fluxes>>,
       elliptic::dg::Actions::initialize_operator<system>,
+      elliptic::dg::subdomain_operator::Actions::InitializeSubdomain<
+          system, analytic_solution_tag,
+          typename schwarz_smoother::options_group>,
       elliptic::dg::Actions::ImposeInhomogeneousBoundaryConditionsOnSource<
           system, fixed_sources_tag>,
       // Apply the DG operator to the initial guess
@@ -195,12 +216,16 @@ struct Metavariables {
 
   using register_actions =
       tmpl::list<observers::Actions::RegisterEventsWithObservers,
+                 typename schwarz_smoother::register_element,
                  Parallel::Actions::TerminatePhase>;
 
-  using solve_actions = tmpl::list<
-      typename linear_solver::template solve<tmpl::list<
-          Actions::RunEventsAndTriggers, build_linear_operator_actions>>,
-      Actions::RunEventsAndTriggers, Parallel::Actions::TerminatePhase>;
+  using solve_actions =
+      tmpl::list<typename linear_solver::template solve<
+                     tmpl::list<Actions::RunEventsAndTriggers,
+                                typename schwarz_smoother::template solve<
+                                    build_linear_operator_actions>>>,
+                 Actions::RunEventsAndTriggers,
+                 Parallel::Actions::TerminatePhase>;
 
   using dg_element_array = elliptic::DgElementArray<
       Metavariables,
@@ -213,6 +238,7 @@ struct Metavariables {
   // Specify all parallel components that will execute actions at some point.
   using component_list = tmpl::flatten<
       tmpl::list<dg_element_array, typename linear_solver::component_list,
+                 typename schwarz_smoother::component_list,
                  observers::Observer<Metavariables>,
                  observers::ObserverWriter<Metavariables>>>;
 
@@ -256,6 +282,8 @@ static const std::vector<void (*)()> charm_init_node_funcs{
         metavariables::initial_guess_tag::type::element_type>,
     &Parallel::register_derived_classes_with_charm<
         metavariables::system::boundary_conditions_base>,
+    &Parallel::register_derived_classes_with_charm<
+        metavariables::schwarz_smoother::subdomain_solver>,
     &Parallel::register_factory_classes_with_charm<metavariables>};
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};

--- a/src/Elliptic/Executables/Xcts/CMakeLists.txt
+++ b/src/Elliptic/Executables/Xcts/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBS_TO_LINK
   DomainCreators
   Elliptic
   EllipticDg
+  EllipticDgSubdomainOperator
   ErrorHandling
   Events
   EventsAndTriggers
@@ -22,6 +23,7 @@ set(LIBS_TO_LINK
   Parallel
   ParallelLinearSolver
   ParallelNonlinearSolver
+  ParallelSchwarz
   Utilities
   Xcts
   XctsAnalyticData

--- a/src/ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Gmres/Gmres.hpp
@@ -42,7 +42,9 @@ namespace LinearSolver::gmres {
  * `db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, operand_tag>`
  * is updated with the preconditioned result in each step of the algorithm, i.e.
  * that it is \f$A(q)\f$ where \f$q\f$ is the preconditioner's approximate
- * solution to \f$A(q)=b\f$.
+ * solution to \f$A(q)=b\f$. The preconditioner always begins at an initial
+ * guess of zero. It does not need to compute the operator applied to the
+ * initial guess, since it's zero as well due to the linearity of the operator.
  *
  * Note that the operand \f$q\f$ for which \f$A(q)\f$ needs to be computed is
  * not the field \f$x\f$ we are solving for but

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/Actions/CommunicateOverlapFields.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/Actions/CommunicateOverlapFields.hpp
@@ -181,6 +181,8 @@ struct ReceiveOverlapFields<Dim, tmpl::list<OverlapFields...>, OptionsGroup> {
       detail::OverlapFieldsTag<Dim, tmpl::list<OverlapFields...>, OptionsGroup>;
 
  public:
+  using simple_tags =
+      tmpl::list<Tags::Overlaps<OverlapFields, Dim, OptionsGroup>...>;
   using const_global_cache_tags =
       tmpl::list<Tags::MaxOverlap<OptionsGroup>,
                  logging::Tags::Verbosity<OptionsGroup>>;

--- a/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ResidualMonitorActions.hpp
+++ b/src/ParallelAlgorithms/NonlinearSolver/NewtonRaphson/ResidualMonitorActions.hpp
@@ -78,7 +78,7 @@ struct CheckResidualMagnitude {
           make_not_null(&box),
           [residual_magnitude](const gsl::not_null<double*>
                                    initial_residual_magnitude) noexcept {
-            *initial_residual_magnitude = sqrt(residual_magnitude);
+            *initial_residual_magnitude = residual_magnitude;
           });
     } else {
       // Make sure we are converging. Far away from the solution the correction

--- a/tests/InputFiles/Elasticity/BentBeam.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam.yaml
@@ -49,15 +49,21 @@ Observers:
 LinearSolver:
   GMRES:
     ConvergenceCriteria:
-      MaxIterations: 9
+      MaxIterations: 2
       RelativeResidual: 1.e-8
       AbsoluteResidual: 1.e-14
     Verbosity: Verbose
 
+  SchwarzSmoother:
+    Iterations: 3
+    MaxOverlap: 2
+    Verbosity: Quiet
+    SubdomainSolver: ExplicitInverse
+
 EventsAndTriggers:
   ? EveryNIterations:
       N: 1
-      Offset: 9
+      Offset: 1
   : - ObserveErrorNorms:
         SubfileName: ErrorNorms
     - ObserveFields:

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -2,7 +2,8 @@
 # See LICENSE.txt for details.
 
 # Executable: SolveElasticity3D
-# Check: parse;execute
+# Check: parse;execute_check_output
+# Timeout: 10
 # ExpectedOutput:
 #   ElasticHalfSpaceMirrorReductions.h5
 #   ElasticHalfSpaceMirrorVolume0.h5
@@ -62,21 +63,35 @@ Observers:
 LinearSolver:
   GMRES:
     ConvergenceCriteria:
-      MaxIterations: 34
+      MaxIterations: 1
       RelativeResidual: 1.e-4
       AbsoluteResidual: 1.e-12
     Verbosity: Verbose
 
+  SchwarzSmoother:
+    Iterations: 3
+    MaxOverlap: 2
+    Verbosity: Verbose
+    SubdomainSolver:
+      Gmres:
+        ConvergenceCriteria:
+          MaxIterations: 50
+          RelativeResidual: 1.e-3
+          AbsoluteResidual: 1.e-12
+        Verbosity: Silent
+        Restart: None
+        Preconditioner: None
+
 EventsAndTriggers:
   ? EveryNIterations:
       N: 1
-      Offset: 27
+      Offset: 1
   : - ObserveErrorNorms:
         SubfileName: ErrorNorms
     - ObserveVolumeIntegrals:
         SubfileName: VolumeIntegrals
   ? EveryNIterations:
-      N: 2
+      N: 1
       Offset: 0
   : - ObserveFields:
         SubfileName: VolumeData

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -46,15 +46,21 @@ Observers:
 
 LinearSolver:
   ConvergenceCriteria:
-    MaxIterations: 8
+    MaxIterations: 4
     RelativeResidual: 1.e-10
     AbsoluteResidual: 1.e-10
   Verbosity: Verbose
 
+  SchwarzSmoother:
+    Iterations: 3
+    MaxOverlap: 2
+    Verbosity: Quiet
+    SubdomainSolver: ExplicitInverse
+
 EventsAndTriggers:
   ? EveryNIterations:
       N: 1
-      Offset: 8
+      Offset: 3
   : - ObserveErrorNorms:
         SubfileName: ErrorNorms
     - ObserveFields:

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -42,15 +42,21 @@ Observers:
 
 LinearSolver:
   ConvergenceCriteria:
-    MaxIterations: 21
+    MaxIterations: 2
     RelativeResidual: 1.e-10
     AbsoluteResidual: 1.e-10
   Verbosity: Verbose
 
+  SchwarzSmoother:
+    Iterations: 3
+    MaxOverlap: 2
+    Verbosity: Quiet
+    SubdomainSolver: ExplicitInverse
+
 EventsAndTriggers:
   ? EveryNIterations:
       N: 1
-      Offset: 8
+      Offset: 1
   : - ObserveErrorNorms:
         SubfileName: ErrorNorms
     - ObserveFields:

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -42,15 +42,21 @@ Observers:
 
 LinearSolver:
   ConvergenceCriteria:
-    MaxIterations: 22
+    MaxIterations: 1
     RelativeResidual: 1.e-6
     AbsoluteResidual: 1.e-6
   Verbosity: Verbose
 
+  SchwarzSmoother:
+    Iterations: 3
+    MaxOverlap: 2
+    Verbosity: Quiet
+    SubdomainSolver: ExplicitInverse
+
 EventsAndTriggers:
   ? EveryNIterations:
       N: 1
-      Offset: 9
+      Offset: 1
   : - ObserveErrorNorms:
         SubfileName: ErrorNorms
     - ObserveFields:

--- a/tests/InputFiles/Xcts/Schwarzschild.yaml
+++ b/tests/InputFiles/Xcts/Schwarzschild.yaml
@@ -3,7 +3,7 @@
 
 # Executable: SolveXcts
 # Check: parse;execute_check_output
-# Timeout: 20
+# Timeout: 40
 # ExpectedOutput:
 #   SchwarzschildReductions.h5
 #   SchwarzschildVolume0.h5
@@ -12,7 +12,7 @@
 #     Subfile: /ErrorNorms.dat
 #     FileGlob: SchwarzschildReductions.h5
 #     SkipColumns: [0, 1]
-#     AbsoluteTolerance: 0.09
+#     AbsoluteTolerance: 0.12
 
 Background:
   Schwarzschild:
@@ -26,7 +26,7 @@ DomainCreator:
     InnerRadius: 0.5
     OuterRadius: 10.
     InitialRefinement: 0
-    InitialGridPoints: [5, 5]
+    InitialGridPoints: [4, 4]
     UseEquiangularMap: True
     AspectRatio: 1.
     WhichWedges: All
@@ -57,7 +57,7 @@ Observers:
 NonlinearSolver:
   NewtonRaphson:
     ConvergenceCriteria:
-      MaxIterations: 2
+      MaxIterations: 1
       RelativeResidual: 1.e-4
       AbsoluteResidual: 1.e-12
     SufficientDecrease: 1.e-4
@@ -68,15 +68,30 @@ NonlinearSolver:
 LinearSolver:
   Gmres:
     ConvergenceCriteria:
-      MaxIterations: 65
+      MaxIterations: 2
       RelativeResidual: 1.e-3
       AbsoluteResidual: 1.e-12
     Verbosity: Quiet
 
+  SchwarzSmoother:
+    Iterations: 3
+    MaxOverlap: 2
+    Verbosity: Verbose
+    SubdomainSolver:
+      Gmres:
+        ConvergenceCriteria:
+          MaxIterations: 30
+          RelativeResidual: 1.e-2
+          AbsoluteResidual: 1.e-12
+        Verbosity: Silent
+        Restart: None
+        Preconditioner: None
+    SkipResets: True
+
 EventsAndTriggers:
   ? EveryNIterations:
       N: 1
-      Offset: 2
+      Offset: 1
   : - ObserveErrorNorms:
         SubfileName: ErrorNorms
     - ObserveFields:


### PR DESCRIPTION
## Proposed changes

Precondition the elliptic solves with a few Schwarz-smoothing
iterations. Drastically reduces the number of linear solver steps
at the cost of making each more expensive, but parallelizable.
Can be more expensive on a single core and for small problems,
but scales to multiple cores and large problems, which the
un-preconditioned solves did not (at all).

Upcoming work will add a multigrid solver, which runs the Schwarz
smoothing on a series of coarser grids (currently at #3249). I'll also add more
subdomain preconditioners to make the Schwarz iterations faster.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
