### PR TITLE
Add phase bookmarks to Algorithm

### DIFF
--- a/src/Parallel/PhaseControl/ExecutePhaseChange.hpp
+++ b/src/Parallel/PhaseControl/ExecutePhaseChange.hpp
@@ -36,17 +36,6 @@ namespace Actions {
  * - DataBox: As specified by the `PhaseChange` option-created objects.
  *   - `PhaseChange` objects are permitted to perform mutations on the
  *     \ref DataBoxGroup "DataBox" to store persistent state information.
- *
- * \warning This action should almost always be placed at the end of the action
- * list for a given phase, because the record of the index through the action
- * list will not be retained during a phase change. Therefore, to avoid
- * unexpected behavior, the phase changes should happen at the end of a phase,
- * so that if control returns to the same phase it may continue looping as
- * usual.
- * If this suggestion is ignored, the typical pathology is an infinite loop of
- * repeatedly triggering a phase change, because the trigger is examined too
- * early in the action list for any alteration to have occurred before being
- * interrupted again for a phase change.
  */
 template <typename PhaseChangeRegistrars>
 struct ExecutePhaseChange {

--- a/tests/Unit/Parallel/Test_AlgorithmPhaseControl.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmPhaseControl.cpp
@@ -187,11 +187,11 @@ struct ComponentBeta {
                                         Parallel::Actions::TerminatePhase>>,
       Parallel::PhaseActions<
           typename Metavariables::Phase, Metavariables::Phase::Evolve,
-          tmpl::list<
-              Actions::RecordPhaseIteration<3_st>,
-              Actions::TerminateAndRestart<ComponentAlpha<Metavariables>, 3_st>,
-              PhaseControl::Actions::ExecutePhaseChange<
-                  typename Metavariables::phase_changes>>>>;
+          tmpl::list<Actions::RecordPhaseIteration<3_st>,
+                     PhaseControl::Actions::ExecutePhaseChange<
+                         typename Metavariables::phase_changes>,
+                     Actions::TerminateAndRestart<ComponentAlpha<Metavariables>,
+                                                  3_st>>>>;
 
   using initialization_tags = Parallel::get_initialization_tags<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
@@ -285,7 +285,7 @@ struct TerminateAndRestart {
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
     if (db::get<Tags::Step>(box) % interval == 0) {
-      if(db::get<Tags::Step>(box) <= 15) {
+      if(db::get<Tags::Step>(box) < 15) {
         Parallel::simple_action<Actions::RestartMe<ParallelComponent>>(
             Parallel::get_parallel_component<OtherComponent>(cache));
 
@@ -451,26 +451,24 @@ struct TestMetavariables {
       tmpl::type_<ComponentBeta<TestMetavariables>> /*meta*/) noexcept {
     return "Running phase: Initialization\n" +
            repeat("Running phase: Evolve\n", 3_st) +  // steps 1-3 -> B
-           "Terminate and Restart\n"
-           "Running phase: TempPhaseB\n" +
+           "Running phase: TempPhaseB\n"
+           "Terminate and Restart\n" +
            repeat("Running phase: Evolve\n", 2_st) +  // steps 4-5 -> A
            "Running phase: TempPhaseA\n"
            "Running phase: Evolve\n"  // step 6 -> B
-           "Terminate and Restart\n"
-           "Running phase: TempPhaseB\n" +
-           repeat("Running phase: Evolve\n", 3_st) +  // steps 8-9 -> B
-           "Terminate and Restart\n"
            "Running phase: TempPhaseB\n"
+           "Terminate and Restart\n" +
+           repeat("Running phase: Evolve\n", 3_st) +  // steps 8-9 -> B
+           "Running phase: TempPhaseB\n"
+           "Terminate and Restart\n"
            "Running phase: Evolve\n"  // step 10 -> A
            "Running phase: TempPhaseA\n" +
            repeat("Running phase: Evolve\n", 2_st) +  // steps 11-12 -> B
-           "Terminate and Restart\n"
-           "Running phase: TempPhaseB\n" +
+           "Running phase: TempPhaseB\n"
+           "Terminate and Restart\n" +
            repeat("Running phase: Evolve\n", 3_st) +  // steps 13-15 -> A then B
-           "Terminate and Restart\n"
            "Running phase: TempPhaseA\n"
-           "Running phase: TempPhaseB\n" +
-           repeat("Running phase: Evolve\n", 3_st) +  // steps 16-18
+           "Running phase: TempPhaseB\n"
            "Terminate Completion\n";
   }
 


### PR DESCRIPTION
This records the step of the phase where the algorithm leaves off, so that if it
returns to the same phase (e.g. from checkpointing or load balancing), it will
start from the last visited action instead of starting from the beginning again.

This allows us to relax the restriction of `ExecutePhaseChange` needing to be
the last action in the list, and provides more flexibility for various
interoperability with phase changes.

### Upgrade instructions
<!-- UPGRADE INSTRUCTIONS -->
Conceivably, if you are designing a phase-control structure that involves returning to a previously visited phase, you may need to consider this change when designing the structure of the action list for the phase that is visited more than once. Most likely, it just relaxes the constraint of `ExecutePhaseChange` appearing last in the corresponding phase.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `major new feature` if appropriate.
